### PR TITLE
chore: remove pnpm peer dependency rules

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,11 +53,6 @@ overrides:
   jsdom: 26.1.0
   vitest: $vitest
 
-peerDependencyRules:
-  allowAny:
-    - 'react'
-    - 'react-dom'
-
 catalogs:
   react18:
     react: ^18.3.1


### PR DESCRIPTION
### Description
Removes `peerDependencyRules` config from `pnpm-workspace.yaml` that (presumably) isn't needed anymore.

### What to review

Makes sense? According to @stipsan these rules where added in the early days of React 19 to avoid dragging in React 18 via dependencies.

### Testing
n/a

### Notes for release
n/a