### PR TITLE
chore(tsconfig): exclude __tests__ pattern

### DIFF
--- a/packages/sanity/tsconfig.lib.json
+++ b/packages/sanity/tsconfig.lib.json
@@ -6,6 +6,7 @@
     "./src/**/__mocks__",
     "./src/**/__workshop__",
     "./src/**/__test__",
+    "./src/**/__tests__",
     "./src/**/*.test.ts",
     "./src/**/*.test.tsx",
     "./src/**/*.test-d.ts",


### PR DESCRIPTION
### Description
#11059 is currently blocked by a type error in `packages/sanity/src/core/releases/store/__tests__`. We have tsconfig excludes for `./src/**/__test__`, but not `./src/**/__tests__` (notice plural), but we seem to be using a mix of `__test__` and `__tests__` as name for test directories. This PR adds adding `./src/**/__tests__` to the exlcude list as well.

### Notes for release
n/a