### PR TITLE
fix: handling case that zero releases in quota - still showing 0 rather than interpolation brackets

### DIFF
--- a/packages/sanity/src/core/releases/contexts/upsell/ReleasesUpsellProvider.tsx
+++ b/packages/sanity/src/core/releases/contexts/upsell/ReleasesUpsellProvider.tsx
@@ -119,7 +119,7 @@ export function ReleasesUpsellProvider(props: {children: React.ReactNode}) {
             firstValueFrom(orgActiveReleaseCount$),
             firstValueFrom(
               releaseLimits$.pipe(
-                tap((limit) => setReleaseLimit(limit?.orgActiveReleaseLimit || null)),
+                tap((limit) => setReleaseLimit(limit?.orgActiveReleaseLimit || 0)),
               ),
             ),
           ])


### PR DESCRIPTION
### Description
In cases where the `orgActiveReleaseLimit` was `0`, we were wrongly setting state to `null` which means the interpolation wasn't being passed correctly.

This resulted in the following:
<img width="536" height="619" alt="Screenshot 2025-11-25 at 17 20 08" src="https://github.com/user-attachments/assets/42f62cc2-e902-40eb-ae9d-242e95b40c71" />

Now this will show instead.
<img width="340" height="401" alt="Screenshot 2025-11-25 at 17 21 05" src="https://github.com/user-attachments/assets/f478f17e-15ee-4265-8fc9-8d8b5a95d819" />

NOTE: this is a rare edge case - it is unlikely that zero quota will be assigned to an org that has content releases enabled. However given that it is a possibility it is perhaps better than we still show `0` rather than `{{releaseLimit}}`.

Ideally we would show a custom upsell modal in this instance

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
