### PR TITLE
chore(pnpm): add `trustPolicy: no-downgrade`

### DIFF
--- a/packages/@sanity/cli/test/init.test.ts
+++ b/packages/@sanity/cli/test/init.test.ts
@@ -314,6 +314,9 @@ describeCliTest('CLI: `sanity init`', () => {
               // minimumReleaseAge, so this should not make a big difference
               // eslint-disable-next-line camelcase
               npm_config_minimum_release_age: '0',
+              // the same is true for `trustPolicy`, it doesn't pick up `trustPolicyExclude`
+              // eslint-disable-next-line camelcase
+              npm_config_trust_policy: 'off',
             },
           },
         )

--- a/packages/@sanity/cli/test/shared/globalSetup.ts
+++ b/packages/@sanity/cli/test/shared/globalSetup.ts
@@ -91,7 +91,10 @@ function prepareStudios() {
       // We'll want to test the actual integration with the monorepo packages,
       // instead of the versions that is available on npm, so we'll symlink them before running npm install
       await exec(nodePath, [SYMLINK_SCRIPT, destinationPath], {cwd: destinationPath})
-      await exec(pnpmPath, ['install', '--ignore-workspace'], {cwd: destinationPath})
+      // --trust-policy off is used because of an issue where pnpm still inherits `trustPolicy` form `pnpm-workspace.yaml` but not `trustPolicyExclude`
+      await exec(pnpmPath, ['install', '--ignore-workspace', '--trust-policy', 'off'], {
+        cwd: destinationPath,
+      })
 
       // Make a copy of the studio and include a custom document component, in order to see
       // that it resolves. We "cannot" use the same studio as it would _always_ use the
@@ -104,7 +107,8 @@ function prepareStudios() {
       // We'll want to test the actual integration with the monorepo packages,
       // instead of the versions that is available on npm, so we'll symlink them before running npm install
       await exec(nodePath, [SYMLINK_SCRIPT, customDocStudioPath], {cwd: customDocStudioPath})
-      await exec(pnpmPath, ['install', '--ignore-workspace'], {
+      // --trust-policy off is used because of an issue where pnpm still inherits `trustPolicy` form `pnpm-workspace.yaml` but not `trustPolicyExclude`
+      await exec(pnpmPath, ['install', '--ignore-workspace', '--trust-policy', 'off'], {
         cwd: customDocStudioPath,
       })
     }),

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,9 +67,31 @@ minimumReleaseAgeExclude:
   - '@oxlint-tsgolint/*'
   - '@portabletext/*'
   - '@sanity/*'
+  - '@types/*'
+  - '@typescript/*'
+  - csstype
   - 'groq-js'
   - 'oxlint'
   - 'oxlint-tsgolint'
   - 'eslint-plugin-oxlint'
   - 'react-rx'
   - 'use-effect-event'
+
+trustPolicy: no-downgrade
+
+trustPolicyExclude:
+  - '@octokit/endpoint@9.0.6'
+  - '@octokit/plugin-paginate-rest@9.2.2'
+  - '@reduxjs/toolkit@2.9.0'
+  - '@sanity/mutate@0.11.0-canary.4'
+  - '@sanity/sdk@2.1.2'
+  - '@swc/core@1.13.5'
+  - chokidar@4.0.3
+  - groq@3.88.1-typegen-experimental.0
+  - react-redux@9.2.0
+  - reselect@5.1.1
+  - rxjs@7.8.2
+  - semver@5.7.2 || 6.3.1
+  - undici@5.29.0
+  - undici-types@6.21.0
+  - vite@6.4.1


### PR DESCRIPTION
### Description

[Read the Mitigating supply chain attacks guide](https://pnpm.io/next/supply-chain-security), and [the trust policy section](https://pnpm.io/next/supply-chain-security#enforce-trust-with-trustpolicy). 
We have been using provenance publishing for most of our libraries for a while, and we're currently moving libraries to [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers).
We are not alone in this, the wider npm ecosystem is undergoing the same migration.
When a supply chain attack happens they tend to publish malicious versions of a package directly, which means the new version will no longer have provenance and pnpm's `trustPolicy: no-downgrade` will refuse to install it, unless it's explicitly defined in `trustPolicyExclude`.
The `trustPolicyExclude` exceptions require explicit versions, you cannot specify trusted major versions or a `*`.

It's important to note that supply chain attacks can still happen with trusted publishing, an attacker can gain trust and maintainer rights and sneak in malicious code that is merged and published through a PR, thus the new malicious version can still have provenance and pass the `trustPolicy: no-downgrade` check. Thus the `minimumReleaseAge` setting still has merit here.

### What to review

Any questions?

### Testing

If it installs it's all good.

### Notes for release

N/A
