### PR TITLE
fix: add dialog for content releases misconfiguration with support contact option

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1486,6 +1486,14 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Tooltip for the dropdown to show all versions of document */
   'release.version-list.tooltip': 'See all document versions',
 
+  /** Button text for contacting support in the releases misconfiguration dialog */
+  'releases.upsell.misconfiguration.contact-support': 'Contact Support',
+  /** Header for the releases misconfiguration dialog */
+  'releases.upsell.misconfiguration.header': 'Content releases configuration issue',
+  /** Message shown in the releases misconfiguration dialog */
+  'releases.upsell.misconfiguration.message':
+    'Content releases are enabled for your project, but there appears to be a configuration issue with your release limits. Please contact support to have your content releases properly configured.',
+
   /** Confirm button text for the schedule publish dialog */
   'schedule-publish-dialog.confirm': 'Schedule',
   /** Description for the schedule publish dialog */

--- a/packages/sanity/src/core/releases/components/dialog/ReleaseLimitsMisconfigurationDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/ReleaseLimitsMisconfigurationDialog.tsx
@@ -1,0 +1,41 @@
+import {Stack, Text} from '@sanity/ui'
+import {useCallback} from 'react'
+
+import {Dialog} from '../../../../ui-components'
+import {useTranslation} from '../../../i18n'
+
+interface ReleaseLimitsMisconfigurationDialogProps {
+  onClose: () => void
+}
+
+export function ReleaseLimitsMisconfigurationDialog(
+  props: ReleaseLimitsMisconfigurationDialogProps,
+) {
+  const {onClose} = props
+  const {t} = useTranslation()
+
+  const handleContactSupport = useCallback(() => {
+    window.open('https://www.sanity.io/contact/support', '_blank', 'noopener,noreferrer')
+    onClose()
+  }, [onClose])
+
+  return (
+    <Dialog
+      id="releases-misconfiguration-dialog"
+      header={t('releases.upsell.misconfiguration.header')}
+      width={1}
+      onClose={onClose}
+      footer={{
+        confirmButton: {
+          text: t('releases.upsell.misconfiguration.contact-support'),
+          onClick: handleContactSupport,
+          tone: 'primary',
+        },
+      }}
+    >
+      <Stack space={4}>
+        <Text>{t('releases.upsell.misconfiguration.message')}</Text>
+      </Stack>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
### Description
In cases where the `orgActiveReleaseLimit` was `0`, we were wrongly setting state to `null` which means the interpolation wasn't being passed correctly.

This resulted in the following:
<img width="536" height="619" alt="Screenshot 2025-11-25 at 17 20 08" src="https://github.com/user-attachments/assets/42f62cc2-e902-40eb-ae9d-242e95b40c71" />

Now there is a particular condition that will catch when there is misconfiguration - that is that the org has content releases enabled, but the release quota is 0. In this case, now, the following will show:

<img width="674" height="397" alt="Screenshot 2025-11-26 at 15 43 35" src="https://github.com/user-attachments/assets/ffd4cb6e-6f92-4db4-9b61-b29417166d0f" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Verified by testing with a org where content release was enabled but no quota was allowed
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
