### PR TITLE
fix(core): `revisionNotFound` wait until document is ready

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -508,7 +508,7 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
   )
 
   const isDeleted = useMemo(() => getIsDeleted(editState), [editState, getIsDeleted])
-  const revisionNotFound = onOlderRevision && !revisionDocument
+  const revisionNotFound = onOlderRevision && !revisionDocument && ready
 
   const currentDisplayed = useMemo(() => {
     if (editState.version && isGoingToUnpublish(editState.version)) {


### PR DESCRIPTION
### Description
Fixes an issue in where the document will "flash" a banner indicating that the revision was not found before finally loading the full document. 
The flash can be seen in the following video at 00:05 

https://github.com/user-attachments/assets/936aa435-5703-4f80-a82f-eff2ecd9fd0c

By waiting for the document pane to be ready before setting the `revisionNotFound` boolean we can fix this, by consistently waiting until everything is loaded.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Repeat the steps in the video, the banner should not flash
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
