### PR TITLE
fix: explicitly set .mjs file extensions in bundle output

### DIFF
--- a/packages/@repo/package.bundle/src/package.bundle.ts
+++ b/packages/@repo/package.bundle/src/package.bundle.ts
@@ -41,6 +41,8 @@ export const defaultConfig: UserConfig = {
         exports: 'named',
         dir: 'dist',
         format: 'es',
+        entryFileNames: '[name].mjs',
+        chunkFileNames: '[name]-[hash].mjs',
       },
       treeshake: {
         preset: 'recommended',


### PR DESCRIPTION
### Description
Bundled files pushed to auto updating studios is broken.

The issue occurred because Rollup defaults to .js extensions regardless of format setting. With "type": "module" and CJS removed, there's no automatic .mjs conversion, so we must explicitly configure entryFileNames and chunkFileNames to use .mjs extensions.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
