### PR TITLE
fix: ensure module server uploads `.mjs` files

### DIFF
--- a/packages/@repo/bundle-manager/src/commands/uploadBundles.ts
+++ b/packages/@repo/bundle-manager/src/commands/uploadBundles.ts
@@ -23,7 +23,6 @@ const storage = new Storage({
 const bucket = storage.bucket(readEnv<KnownEnvVar>('GCLOUD_BUCKET'))
 
 const mimeTypes: Record<string, string | undefined> = {
-  '.js': 'application/javascript',
   '.mjs': 'application/javascript',
   '.map': 'application/json',
 }

--- a/packages/@repo/package.bundle/src/package.bundle.ts
+++ b/packages/@repo/package.bundle/src/package.bundle.ts
@@ -41,6 +41,10 @@ export const defaultConfig: UserConfig = {
         exports: 'named',
         dir: 'dist',
         format: 'es',
+        // Due to module server expecting `.mjs`, and packages/sanity/package.json#type now being `module`, it's necessary to configure vite to continue using `.mjs`
+        // Otherwise it'll start using `.js` instead: https://github.com/vitejs/vite/blob/a3cd262f37228967e455617e982b35fccc49ffe9/packages/vite/src/node/build.ts#L664-L679
+        entryFileNames: '[name].mjs',
+        chunkFileNames: '[name]-[hash].mjs',
       },
       treeshake: {
         preset: 'recommended',


### PR DESCRIPTION
### Description

Removing CJS in #11021 broke the `release-next` github workflow, it was fixed in #11278.
Unfortunately the "fix" was fixing the symptom, not the issue: the module server expects `.mjs` file endings on the js assets.
#11278 changed the uploader to also allow `.js` ones, but in production for studios on the `next` channel this resulted in 404's:
<img width="2902" height="1022" alt="image" src="https://github.com/user-attachments/assets/d49a84bf-d0e9-4adb-9303-73c08724da75" />

In this PR the bundler used for uploading these assets instead explicitly sets `.mjs` file endings, and reverts the bucket uploader allowance for `.js` files.

### What to review

Everything makes sense?

### Testing

If it builds we good, though I'll need to merge to know for a fact that it works.

### Notes for release

N/A - this regression did not affect any stable release channels.