### PR TITLE
fix(core): use `toolTitle` for `document.title` if present

### DIFF
--- a/packages/sanity/src/core/studio/StudioLayout.tsx
+++ b/packages/sanity/src/core/studio/StudioLayout.tsx
@@ -108,14 +108,14 @@ export function StudioLayoutComponent() {
   const [searchOpen, setSearchOpen] = useState<boolean>(false)
 
   const documentTitle = useMemo(() => {
-    const mainTitle = title || startCase(name)
-
-    if (activeToolName) {
-      return `${startCase(activeToolName)} | ${mainTitle}`
+    const workspaceTitle = title || startCase(name)
+    const toolTitle = activeTool ? activeTool.title || activeTool.name : undefined
+    if (toolTitle) {
+      return `${toolTitle} | ${workspaceTitle}`
     }
+    return workspaceTitle
+  }, [activeTool, name, title])
 
-    return mainTitle
-  }, [activeToolName, name, title])
   const toolControlsDocumentTitle = !!activeTool?.controlsDocumentTitle
 
   useEffect(() => {


### PR DESCRIPTION
### Description
The browser `<title>` tag should use the tool's title field (if provided) rather than name

Sanity Studio is using the name field instead of the title field for the browser's <title> tag when working with tools. Additionally, the Studio is automatically transforming camelCase names into separate words, which produces incorrect results in Norwegian and probably other languages.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
use the tool title for `document.title` if present, instead of defaulting to tool name
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
