### PR TITLE
fix: make sure `require` calls comes from `createRequire`

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/media/deployAspectAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/media/deployAspectAction.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises'
+import {createRequire} from 'node:module'
 import {EOL} from 'node:os'
 import path from 'node:path'
 
@@ -37,6 +38,8 @@ import {
 import {ASPECT_FILE_EXTENSIONS, MINIMUM_API_VERSION} from './constants'
 import {determineTargetMediaLibrary} from './lib/determineTargetMediaLibrary'
 import {withMediaLibraryConfig} from './lib/withMediaLibraryConfig'
+
+const require = createRequire(import.meta.url)
 
 interface DeployAspectFlags {
   'media-library-id'?: string

--- a/packages/sanity/src/_internal/cli/commands/build/buildCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/build/buildCommand.ts
@@ -2,6 +2,10 @@ import type {CliCommandArguments, CliCommandContext, CliCommandDefinition} from 
 import {BuildSanityStudioCommandFlags} from '../../actions/build/buildAction'
 import {determineIsApp} from '../../util/determineIsApp'
 
+import {createRequire} from 'node:module'
+
+const require = createRequire(import.meta.url)
+
 const helpText = `
 Options
   --source-maps Enable source maps for built bundles (increases size of bundle)

--- a/packages/sanity/src/_internal/cli/commands/dev/devCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/dev/devCommand.ts
@@ -1,3 +1,5 @@
+import {createRequire} from 'node:module'
+
 import {
   type CliCommandArguments,
   type CliCommandContext,
@@ -6,6 +8,8 @@ import {
 
 import {type StartDevServerCommandFlags} from '../../actions/dev/devAction'
 import {determineIsApp} from '../../util/determineIsApp'
+
+const require = createRequire(import.meta.url)
 
 // TODO: Add this once we are ready to release it.
 // --load-in-dashboard <boolean> Load the dev server in the Sanity dashboard. [default: false]

--- a/packages/sanity/src/_internal/cli/commands/migration/utils/resolveMigrationScript.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/utils/resolveMigrationScript.ts
@@ -1,9 +1,12 @@
+import {createRequire} from 'node:module'
 import path from 'node:path'
 
 import {type Migration} from '@sanity/migrate'
 import {isPlainObject} from 'lodash'
 
 import {MIGRATION_SCRIPT_EXTENSIONS, MIGRATIONS_DIRECTORY} from '../constants'
+
+const require = createRequire(import.meta.url)
 
 interface ResolvedMigrationScript {
   /**

--- a/packages/sanity/src/_internal/cli/commands/preview/previewCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/preview/previewCommand.ts
@@ -1,3 +1,5 @@
+import {createRequire} from 'node:module'
+
 import {
   type CliCommandArguments,
   type CliCommandContext,
@@ -5,6 +7,8 @@ import {
 } from '@sanity/cli'
 
 import {type StartPreviewServerCommandFlags} from '../../actions/preview/previewAction'
+
+const require = createRequire(import.meta.url)
 
 const helpText = `
 Notes

--- a/packages/sanity/src/_internal/cli/commands/start/startCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/start/startCommand.ts
@@ -1,3 +1,5 @@
+import {createRequire} from 'node:module'
+
 import {
   type CliCommandArguments,
   type CliCommandContext,
@@ -7,6 +9,8 @@ import {
 import {type StartPreviewServerCommandFlags} from '../../actions/preview/previewAction'
 import {isInteractive} from '../../util/isInteractive'
 import {getDevAction} from '../dev/devCommand'
+
+const require = createRequire(import.meta.url)
 
 const helpText = `
 Notes

--- a/packages/sanity/src/_internal/cli/server/getBrowserAliases.ts
+++ b/packages/sanity/src/_internal/cli/server/getBrowserAliases.ts
@@ -1,8 +1,11 @@
+import {createRequire} from 'node:module'
 import path from 'node:path'
 
 import {escapeRegExp} from 'lodash'
 import * as resolve from 'resolve.exports'
 import {type Alias} from 'vite'
+
+const require = createRequire(import.meta.url)
 
 /**
  * The following are the specifiers that are expected/allowed to be used within

--- a/packages/sanity/src/_internal/cli/util/getStudioWorkspaces.ts
+++ b/packages/sanity/src/_internal/cli/util/getStudioWorkspaces.ts
@@ -1,10 +1,13 @@
 import fs from 'node:fs'
+import {createRequire} from 'node:module'
 import path from 'node:path'
 
 import {firstValueFrom} from 'rxjs'
 import {type Config, resolveConfig, type Workspace, type WorkspaceOptions} from 'sanity'
 
 import {mockBrowserEnvironment} from './mockBrowserEnvironment'
+
+const require = createRequire(import.meta.url)
 
 const candidates = [
   'sanity.config.js',

--- a/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts
+++ b/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts
@@ -1,3 +1,5 @@
+import {createRequire} from 'node:module'
+
 import {ResizeObserver} from '@juggle/resize-observer'
 import {register as registerESBuild} from 'esbuild-register/dist/node'
 import jsdomGlobal from 'jsdom-global'
@@ -5,6 +7,8 @@ import {addHook} from 'pirates'
 import resolveFrom from 'resolve-from'
 
 import {getStudioEnvironmentVariables} from '../server/getStudioEnvironmentVariables'
+
+const require = createRequire(import.meta.url)
 
 const jsdomDefaultHtml = `<!doctype html>
 <html>


### PR DESCRIPTION
### Description

Fixes regressions introduced in #11021

### What to review

Missed anywhere?

### Testing

If CI works it's good, but we need to test on `sanity@next` in a vanilla next.js studio to know for sure that we're all good.

### Notes for release

N/A - regression is only on `next`, not on `stable`