### PR TITLE
fix(core): only validate .media validation markers

### DIFF
--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
@@ -25,7 +25,7 @@ import {useSanityMediaLibraryConfig} from '../hooks/useSanityMediaLibraryConfig'
 import {type AssetSelectionItem, type AssetType, type PluginPostMessage} from '../types'
 import {AppDialog} from './Dialog'
 import {Iframe} from './Iframe'
-import {ignoreAssetRequiredValidation} from './validation'
+import {filterMediaValidationMarkers} from './validation'
 
 export interface SelectAssetsDialogProps {
   dialogHeaderTitle?: ReactNode
@@ -100,7 +100,7 @@ export function SelectAssetsDialog(props: SelectAssetsDialogProps): ReactNode {
           return true
         },
       })
-      return ignoreAssetRequiredValidation(result)
+      return filterMediaValidationMarkers(result)
     },
     [client, document, mediaLibraryIds?.libraryId, schema, schemaType, workspace.i18n],
   )

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/validation.ts
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/validation.ts
@@ -1,25 +1,24 @@
 import {type ValidationMarker} from '@sanity/types'
 
 /**
- * Ignore asset required validation markers.
+ * Ignore anything but the 'media' validation markers
  *
- * This is used to still allow asset selection when validating
- * asset source media library assets.
+ * This is used to still allow an asset selection even if there are other validation errors on the field,
  *
  * @param validationMarkers - The validation markers to filter.
  * @returns The filtered validation markers.
  */
-export function ignoreAssetRequiredValidation(validationMarkers: ValidationMarker[]) {
+export function filterMediaValidationMarkers(validationMarkers: ValidationMarker[]) {
   return validationMarkers.filter((marker) => {
     if (
       '__internal_metadata' in marker &&
       typeof marker.__internal_metadata === 'object' &&
       marker.__internal_metadata !== null &&
       'name' in marker.__internal_metadata &&
-      marker.__internal_metadata.name === 'assetRequired'
+      marker.__internal_metadata?.name === 'media'
     ) {
-      return false
+      return true
     }
-    return true
+    return false
   })
 }

--- a/packages/sanity/src/core/validation/validators/objectValidator.ts
+++ b/packages/sanity/src/core/validation/validators/objectValidator.ts
@@ -144,14 +144,32 @@ export const objectValidators: Validators = {
       clearTimeout(slowTimer)
     }
 
-    if (isLocalizedMessages(result)) {
-      return localizeMessage(result, context.i18n)
+    const validationErrorMetadata = {
+      // eslint-disable-next-line camelcase
+      __internal_metadata: {
+        name: 'media',
+      },
     }
 
-    if (typeof result === 'string') {
-      return message || result
+    // Valid, no errors
+    if (result === true) {
+      return result
     }
 
-    return result
+    // Ensure we always return ValidationMarker with metadata
+    return Array.isArray(result)
+      ? result
+      : [result].map((res) => {
+          if (typeof res === 'string') {
+            return {...validationErrorMetadata, message: message || res}
+          }
+          if (isLocalizedMessages(res)) {
+            return {
+              ...validationErrorMetadata,
+              message: message || localizeMessage(res, context.i18n),
+            }
+          }
+          return {...validationErrorMetadata, ...res, message: message || res.message}
+        })
   },
 }

--- a/packages/sanity/test/validation/infer.test.ts
+++ b/packages/sanity/test/validation/infer.test.ts
@@ -1,6 +1,7 @@
 import {type SanityClient} from '@sanity/client'
 import {Schema as SchemaBuilder} from '@sanity/schema'
 import {type ObjectSchemaType, type Rule, type SanityDocument} from '@sanity/types'
+import {has} from 'lodash'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {type Workspace} from '../../src/core/config'
@@ -109,7 +110,7 @@ describe('schema validation inference', () => {
               // Validate that the image is a summer image when the document topic is summer
               if (media.asset.assetType === 'sanity.imageAsset') {
                 const aspects = media.asset.aspects
-                if (aspects?.season === 'summer') {
+                if (has(aspects, 'season') && aspects.season === 'summer') {
                   return true
                 }
                 return 'Image must be a summer image'
@@ -187,6 +188,10 @@ describe('schema validation inference', () => {
         }),
       ).resolves.toEqual([
         {
+          // eslint-disable-next-line camelcase
+          __internal_metadata: {
+            name: 'media',
+          },
           item: {
             message: 'Image must be a summer image',
           },


### PR DESCRIPTION
### Description

Only `.media` validation rules should be considered when validating a selection for the Media Library plugin.

Other validation rules on the field (such as required alt text on images) should not render the selection invalid.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That this makes sense.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Try adding this:

```
    {
      name: 'imageWithAdditionalFields',
      title: 'Image with additional fields',
      type: 'image',
      validation: (Rule) => Rule.media<'sanity.imageAsset'>(({media}) => {
        return media.asset.currentVersion.metadata?.dimensions?.width > 1000 || 'Image must be wider than 1000px'
      }),
      fields: [
        {
          title: 'Alt text,
          name: 'altText',
          type: 'string',
          validation: (rule) =>
            rule.required()
              .error('Alt required')
        },
      ],
    },
```

Missing alt text should not prohibit selecting an image from the ML. But selecting images less than 1000 px wide should be.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
* Fixed a bug where nested validation rules could prohibit selecting an asset from the Media Library.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
