### PR TITLE
fix: allow `createGlobalStyle` to work with auto updating studios

### DIFF
--- a/packages/sanity/src/_internal/cli/server/buildVendorDependencies.ts
+++ b/packages/sanity/src/_internal/cli/server/buildVendorDependencies.ts
@@ -96,7 +96,7 @@ const VENDOR_IMPORTS: VendorImports = {
   },
   'styled-components': {
     '^6.1.0': {
-      '.': './dist/styled-components.esm.js',
+      '.': './dist/styled-components.browser.esm.js',
       './package.json': './package.json',
     },
   },


### PR DESCRIPTION
### Description

#### On auto updating studios `createGlobalStyle` is broken and no global styles are rendered!

When we publish auto updating studios we vendor `react`, `react-dom` and `styled-components`.
Unfortunately we vendored `styled-components` to `styled-components/dist/styled-components.esm.js` while we should've aliased to `styled-components/dist/styled-components.browser.esm.js`.
`styled-components.esm.js` is for `node` environments, and using it instead of `styled-components.browser.esm.js` breaks `createGlobalStyle`.

When `styled-components` builds for `npm` it sets the `__SERVER__` constant to `true` for `styled-components.esm.js` and `false` for `styled-components.browser.esm.js`.
This constant branches important logic in `createGlobalStyle`: https://github.com/styled-components/styled-components/blob/a21089e1cde9d2492349088787c59dd85358a337/packages/styled-components/src/constructors/createGlobalStyle.ts#L51-L62

Because `__SERVER__` is false the `useLayoutEffect` that calls `renderStyles` isn't there: https://github.com/styled-components/styled-components/blob/a21089e1cde9d2492349088787c59dd85358a337/packages/styled-components/src/constructors/createGlobalStyle.ts#L58C11-L58C76

And since `ssc.styleSheet.server` is always false it also doesn't insert styles during render: https://github.com/styled-components/styled-components/blob/a21089e1cde9d2492349088787c59dd85358a337/packages/styled-components/src/constructors/createGlobalStyle.ts#L51-L53

<details>
  <summary>

Why is `ssc.styleSheet.server` false?

  </summary>

The value of `ssc.styleSheet.server` [is set during the construction of the default `StyleSheet`, the `options.isServer`](https://github.com/styled-components/styled-components/blob/a21089e1cde9d2492349088787c59dd85358a337/packages/styled-components/src/sheet/Sheet.ts#L54).

[The `isServer` option is by default set to `!IS_BROWSER`](https://github.com/styled-components/styled-components/blob/a21089e1cde9d2492349088787c59dd85358a337/packages/styled-components/src/sheet/Sheet.ts#L25C14-L25C24). `IS_BROWSER` is [basically](https://github.com/styled-components/styled-components/blob/a21089e1cde9d2492349088787c59dd85358a337/packages/styled-components/src/constants.ts#L15) defined as `typeof window !== 'undefined'`


</details>

We have two cases of `createGlobalStyle` in our own code:
- https://github.com/sanity-io/sanity/blob/8d6c11d817aeda8aac8aeb4cd1028304372b4353/packages/sanity/src/core/studio/GlobalStyle.tsx#L16-L73
- https://github.com/sanity-io/sanity/blob/8d6c11d817aeda8aac8aeb4cd1028304372b4353/packages/sanity/src/presentation/preview/IFrame.tsx#L88-L101

I've sometimes noticed that auto updating studios have cases of text that lack our `Inter` font-family, and never understood why, [but today I learned it's because we set the default `body` `font-family` in a `createGlobalStyle`](https://github.com/sanity-io/sanity/blob/8d6c11d817aeda8aac8aeb4cd1028304372b4353/packages/sanity/src/core/studio/GlobalStyle.tsx#L62).


I've made a repro showing the issue, during `sanity dev` it renders the font (it's missing later because I'm intentionally rendering the `@sanity/ui` button as `<Button>Zoom In</Button>` when it's supposed to be `<Button text="Zoom In" />`):


https://github.com/user-attachments/assets/1f155d91-3d0b-4817-a55e-95e168ec337a

Once deployed with `autoUpdates: true` all global styling is missing and clicking the Zoom In/Out button does nothing:


https://github.com/user-attachments/assets/d3a0eaa8-c797-406b-a02a-b6f31515719b



### What to review

Missed anything?

### Testing

You can try the pkg.pr.new build on a studio that has auto-updating studio, and once deployed you can verify styles are there by inspecting `body` and seeing it has `scrollbar-gutter: stable;`:

<img width="1510" height="756" alt="image" src="https://github.com/user-attachments/assets/48782fee-f482-4ba8-8659-c40fc9fdabbf" />


### Notes for release

Fixes an issue where `createGlobalStyle` from `styled-components` doesn't work if the Studio is [deployed with `autoUpdates: true`](https://www.sanity.io/docs/studio/latest-version-of-sanity). Styles declared with it were simply not there once deployed, while they work just fine if `autoUpdates: false` or when working locally with `sanity dev`.
Usually this issue would manifest itself in some UI text using Times New Roman instead of Inter, and missing browser scrollbar styling.
If you're affected by this issue you'll need to run a new `sanity deploy` after updating to `sanity@latest`, [you might as well use our `styled-components` fork while at it and give your studio a nice performance boost](https://github.com/sanity-io/styled-components-last-resort#readme).
If you're already using `@sanity/styled-components` instead of `styled-components` then you're not affected by this issue.