### PR TITLE
chore: return single stack if outside of a release bundle

### DIFF
--- a/packages/sanity/src/core/releases/hooks/utils.ts
+++ b/packages/sanity/src/core/releases/hooks/utils.ts
@@ -79,7 +79,8 @@ export function getReleasesPerspectiveStack({
   )
   const selectedIndex = sorted.indexOf(selectedPerspectiveName)
   if (selectedIndex === -1) {
-    return EMPTY
+    // we're in a non-release stack
+    return [selectedPerspectiveName, ...defaultPerspective]
   }
   return sorted
     .slice(selectedIndex)


### PR DESCRIPTION
### Description
Currently, if opening the studio with a perspective that is not a release, previews will fallback to an empty array as the perspective stack. This causes documents to be rendered either with preview values from published version, or as "Untitled"

### What to review
- Makes sense?
- Any unintended side effects of this change?

### Testing
- Compare base of this PR: https://test-studio-git-sapp-3342-allow-editing-doc-outside-release.sanity.dev/test/structure/house;testing-release-less-bundle-6?perspective=bundle-foo

- with branch build: https://test-studio-git-sapp-3345.sanity.dev/test/structure/house;testing-release-less-bundle-6?perspective=bundle-foo

And see that the referenced document (which is also in the non-release perspective) is being previewed correctly in the latter


### Notes for release
n/a
