### PR TITLE
fix(core): set correct focus path for assets inputs in images

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -8,7 +8,6 @@ import {
 import {Stack, useToast} from '@sanity/ui'
 import {get} from 'lodash'
 import {
-  type FocusEvent,
   Fragment,
   memo,
   type ReactNode,
@@ -236,21 +235,6 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
     },
     [onChange, resolveUploader, schemaType, uploadWith],
   )
-  const handleFileTargetFocus = useCallback(
-    (event: FocusEvent) => {
-      // We want to handle focus when the file target element *itself* receives
-      // focus, not when an interactive child element receives focus. Since React has decided
-      // to let focus bubble, so this workaround is needed
-      // Background: https://github.com/facebook/react/issues/6410#issuecomment-671915381
-      if (
-        event.currentTarget === event.target &&
-        event.currentTarget === elementProps.ref?.current
-      ) {
-        elementProps.onFocus(event)
-      }
-    },
-    [elementProps],
-  )
 
   const handleCancelUpload = useCallback(() => {
     cancelUpload()
@@ -473,14 +457,12 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
       if (value && typeof value.asset !== 'undefined' && !value?._upload && !isImageSource(value)) {
         return <InvalidImageWarning onClearValue={handleClearField} />
       }
-
       return (
         <ImageInputAsset
           assetSources={assetSources}
           directUploads={directUploads !== false}
           elementProps={elementProps}
           handleClearUploadState={handleClearUploadState}
-          handleFileTargetFocus={handleFileTargetFocus}
           hoveringFiles={hoveringFiles}
           imageUrlBuilder={imageUrlBuilder}
           inputProps={inputProps}
@@ -506,7 +488,6 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
       getFileTone,
       handleClearField,
       handleClearUploadState,
-      handleFileTargetFocus,
       handleSelectFilesToUpload,
       hoveringFiles,
       imageUrlBuilder,

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAsset.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAsset.tsx
@@ -20,7 +20,6 @@ function ImageInputAssetComponent(props: {
   directUploads: boolean
   elementProps: BaseImageInputProps['elementProps']
   handleClearUploadState: () => void
-  handleFileTargetFocus: (event: FocusEvent<Element, Element>) => void
   onSelectFiles: (assetSource: AssetSource, files: File[]) => void
   hoveringFiles: FileInfo[]
   imageUrlBuilder: ImageUrlBuilder
@@ -42,7 +41,6 @@ function ImageInputAssetComponent(props: {
     directUploads,
     elementProps,
     handleClearUploadState,
-    handleFileTargetFocus,
     onSelectFiles,
     hoveringFiles,
     inputProps,
@@ -161,6 +159,22 @@ function ImageInputAssetComponent(props: {
     setShowDestinationSourcePicker(false)
     setAssetSourceDestination(null)
   }, [])
+
+  const handleFileTargetFocus = useCallback(
+    (event: FocusEvent) => {
+      // We want to handle focus when the file target element *itself* receives
+      // focus, not when an interactive child element receives focus. Since React has decided
+      // to let focus bubble, so this workaround is needed
+      // Background: https://github.com/facebook/react/issues/6410#issuecomment-671915381
+      if (
+        event.currentTarget === event.target &&
+        event.currentTarget === elementProps.ref?.current
+      ) {
+        inputProps.elementProps.onFocus(event)
+      }
+    },
+    [inputProps, elementProps.ref?.current],
+  )
 
   return (
     <div style={customProperties}>

--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -536,13 +536,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
           handleSetOpenPath(pathFor(newOpenPath))
         }
       } else {
-        const lastSegment = nextFocusPath[nextFocusPath.length - 1]
-        if (isKeySegment(lastSegment)) {
-          // For fields inside array items, preserve the key segment, or the focus path will be lost
-          handleSetOpenPath(pathFor(nextFocusPath))
-        } else {
-          handleSetOpenPath(pathFor(nextFocusPath.slice(0, -1)))
-        }
+        handleSetOpenPath(pathFor(nextFocusPath.slice(0, -1)))
       }
 
       focusPathRef.current = nextFocusPath


### PR DESCRIPTION
### Description
Fixes https://github.com/sanity-io/sanity/issues/8146 and https://github.com/sanity-io/sanity/issues/7547

**Updated**:

Slept on it and figure out the error was not how we are doing the focus check, the error is the path in where we are setting the focus when focusing in the asset input.
Before this changes, when trying to focus on the asset input the path was set to the object root, instead of to the object + `asset`
So clicking in an asset input was setting a path like: `["imageArrayInGrid2",{"_key": "5f030c6ba2ef"}]` this has the cascade effect of what is explained cross out at the bottom of this description, what I considered the initial issue.

**How we can fix this properly?**
Well, we can set the **correct** path for it, if we are focusing on the `asset` input, we should set the path focus to include that `asset` input.
So the new focus path we set looks like this: `["imageArrayInGrid2",{"_key": "5f030c6ba2ef"},"asset"]`, this fixes the same issue while setting the correct path.

[See last commit for it](https://github.com/sanity-io/sanity/pull/11317/commits/8888309e9bdf4ae2405856de13136751d84df28e)

~~When clicking an image in an input it sets the focus path to the path of the object + the{ key} ,
for example: `["myImagesArray", {key: "foo}]` 
Then, we are slicing that key part of the path away from the focus path so we are setting the path to `["myImagesArray"]`, this will have the side effect of closing the dialog, we don't want that.
Image inputs in dialogs are quite useless in Safari, and they are also unexepctedly closed in chrome if you focus on it, focus on something else and then focus back on it.
By doing this change, image inputs are usable again inside dialogs.~~

Errors in Safari and chrome, after the fix it works nicely

https://github.com/user-attachments/assets/1188b83d-0f87-4e0b-9cc6-55197725a0de


https://github.com/user-attachments/assets/6569e348-0ab3-4bdb-aba8-d6e5457bd13e


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
How can we check for side effects of this change?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
You will need to run this locally or trust in the video that the fix works, because with the new enhanced dialog editing this issue is fixed, I applied a very similar fix than what that dialog does.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an error in where focusing on image inputs inside dialogs will unexpectedly close it. 
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
