### PR TITLE
fix: concat `previewUrl` and `targetOrigin` correctly

### DIFF
--- a/packages/sanity/src/presentation/preview/PreviewHeader.tsx
+++ b/packages/sanity/src/presentation/preview/PreviewHeader.tsx
@@ -62,7 +62,7 @@ const PreviewHeaderDefault = (props: Omit<PreviewHeaderProps, 'renderDefault'>) 
       presentationRef.send({type: 'iframe reload'})
       // Funky way to reload an iframe without CORS issues
       // ref.current.src = ref.current.src
-      Object.assign(iframeRef.current, {src: `${targetOrigin}${previewUrl || '/'}`})
+      Object.assign(iframeRef.current, {src: new URL(previewUrl || '/', targetOrigin).toString()})
     })
   }
 


### PR DESCRIPTION
### Description

Fixes https://linear.app/sanity/issue/SAPP-3334/refreshing-presentation-preview-navigates-to-double-url by using `new URL()` to concat the `targetOrigin` with `previewUrl`.

### What to review

Makes sense?

### Testing

The vid shows how to repro, it can be done by going to https://test-studio.sanity.dev/presentation-preview-kit/presentation///?preview=https%3A//preview-kit-next-app-router.sanity.dev/api/draft-mode/enable and hitting the refresh button.

### Notes for release

Fixes an issue where Presentation Tool when hitting the refresh button would construct an invalid URL if the URL bar used an absolute URL.