### PR TITLE
feat(typegen)!: return same case when generating types

### DIFF
--- a/packages/@sanity/cli/test/__snapshots__/typegen.test.ts.snap
+++ b/packages/@sanity/cli/test/__snapshots__/typegen.test.ts.snap
@@ -39,7 +39,7 @@ export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: src/queries.ts
 // Variable: PAGE_QUERY
 // Query: *[_type == "page" && slug.current == $slug][0]
-export type PAGE_QUERYResult = null;
+export type PAGE_QUERY_RESULT = null;
 "
 `;
 
@@ -82,6 +82,6 @@ export declare const internalGroqTypeReferenceTo: unique symbol;
 // Source: src/queries.ts
 // Variable: PAGE_QUERY
 // Query: *[_type == "page" && slug.current == $slug][0]
-export type PAGE_QUERYResult = null;
+export type PAGE_QUERY_RESULT = null;
 "
 `;

--- a/packages/@sanity/cli/test/typegen.test.ts
+++ b/packages/@sanity/cli/test/typegen.test.ts
@@ -303,7 +303,7 @@ describeCliTest('CLI: `sanity typegen`', () => {
 
             const types = await readFile(`${studiosPath}/cli-test-studio/out/types.ts`)
             expect(types.toString()).toContain(
-              `'*[_type == "page" && slug.current == $slug][0]': PAGE_QUERYResult;`,
+              `'*[_type == "page" && slug.current == $slug][0]': PAGE_QUERY_RESULT;`,
             )
           },
         ),

--- a/packages/@sanity/codegen/src/__tests__/casing.test.ts
+++ b/packages/@sanity/codegen/src/__tests__/casing.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it} from 'vitest'
+
+import {resultSuffix} from '../casing'
+
+describe('resultSuffix', () => {
+  it('appends Result for camelCase', () => {
+    expect(resultSuffix('userName')).toBe('userNameResult')
+    expect(resultSuffix('value')).toBe('valueResult')
+  })
+
+  it('appends Result for PascalCase', () => {
+    expect(resultSuffix('UserName')).toBe('UserNameResult')
+    expect(resultSuffix('Value')).toBe('ValueResult')
+  })
+
+  it('appends _result for snake_case', () => {
+    expect(resultSuffix('user_name')).toBe('user_name_result')
+    expect(resultSuffix('value')).toBe('valueResult') // still valid camel case, covered above
+  })
+
+  it('appends _RESULT for UPPER_SNAKE', () => {
+    expect(resultSuffix('USER_NAME')).toBe('USER_NAME_RESULT')
+    expect(resultSuffix('VALUE')).toBe('VALUE_RESULT')
+  })
+
+  it("returns 'result' for empty string", () => {
+    expect(resultSuffix('')).toBe('result')
+  })
+
+  it('falls back to camelCase style when casing is unknown', () => {
+    expect(resultSuffix('user name')).toBe('usernameResult')
+    expect(resultSuffix('weird$value!')).toBe('weirdvalueResult')
+    expect(resultSuffix('123abc')).toBe('123abcResult')
+  })
+})

--- a/packages/@sanity/codegen/src/casing.ts
+++ b/packages/@sanity/codegen/src/casing.ts
@@ -1,0 +1,29 @@
+/*
+ * resultSuffix takes a variable name and appends "result" in the same casing style.
+ * Supported: camelCase, PascalCase, snake_case, UPPER_SNAKE.
+ * Falls back to camelCase-style suffix when casing is unknown.
+ */
+export function resultSuffix(variableName: string): string {
+  if (!variableName) return 'result'
+
+  const isUpperSnake = /^[A-Z0-9_]+$/.test(variableName) // VALUE, USER_NAME
+  const isSnake = /^[a-z0-9_]+$/.test(variableName) && variableName.includes('_') // user_name
+  const isCamel = /^[a-z][A-Za-z0-9]*$/.test(variableName) // userName
+
+  if (isCamel) {
+    return `${variableName}Result`
+  }
+
+  if (isUpperSnake) {
+    return `${variableName}_RESULT`
+  }
+
+  if (isSnake) {
+    return `${variableName}_result`
+  }
+
+  // Fallback: clean weird chars and use camel-style suffix
+  const cleaned = variableName.replace(/[^A-Za-z0-9]/g, '')
+
+  return `${cleaned}Result`
+}

--- a/packages/@sanity/codegen/src/typescript/typeGenerator.ts
+++ b/packages/@sanity/codegen/src/typescript/typeGenerator.ts
@@ -5,6 +5,7 @@ import {type WorkerChannel, type WorkerChannelReporter} from '@sanity/worker-cha
 import {type SchemaType} from 'groq-js'
 import {createSelector} from 'reselect'
 
+import {resultSuffix} from '../casing'
 import {ALL_SANITY_SCHEMA_TYPES, INTERNAL_REFERENCE_SYMBOL, SANITY_QUERIES} from './constants'
 import {computeOnce, generateCode, getUniqueIdentifierForName, normalizePath} from './helpers'
 import {SchemaTypeGenerator} from './schemaTypeGenerator'
@@ -145,7 +146,7 @@ export class TypeGenerator {
         const {variable} = extractedQuery
         try {
           const {tsType, stats} = schemaTypeGenerator.evaluateQuery(extractedQuery)
-          const id = getUniqueIdentifierForName(`${variable.id.name}Result`, currentIdentifiers)
+          const id = getUniqueIdentifierForName(resultSuffix(variable.id.name), currentIdentifiers)
           const typeAlias = t.tsTypeAliasDeclaration(id, null, tsType)
           const trimmedQuery = extractedQuery.query.replace(/(\r\n|\n|\r)/gm, '').trim()
           const ast = t.addComments(t.exportNamedDeclaration(typeAlias), 'leading', [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20667,7 +20667,7 @@ snapshots:
 
   groq-js@1.21.0:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Detect casing and return the generated type name with the same casing. If we can't detect it we fall back to camelCase

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

yes

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

TypeGen(Breaking!): Return generated type names in same case as the query name case.
