### PR TITLE
fix: deleting a document will always discard all versions of the document too

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/delete.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/delete.ts
@@ -1,3 +1,7 @@
+import {from} from 'rxjs'
+import {switchMap} from 'rxjs/operators'
+
+import {getPublishedId} from '../../../../../util/draftUtils'
 import {type OperationImpl} from '../operations/types'
 import {actionsApiClient} from '../utils/actionsApiClient'
 import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
@@ -10,30 +14,43 @@ export const del: OperationImpl<[], 'NOTHING_TO_DELETE'> = {
       return tx.commit({tag: 'document.delete'})
     }
 
-    //the delete action requires a published doc -- discard if not present
-    if (!snapshots.published) {
-      return actionsApiClient(client, idPair).observable.action(
-        {
-          actionType: 'sanity.action.document.discard',
-          draftId: idPair.draftId,
-        },
-        {tag: 'document.delete'},
-      )
-    }
+    const publishedId = getPublishedId(idPair.publishedId)
 
-    return actionsApiClient(client, idPair).observable.action(
-      {
-        actionType: 'sanity.action.document.delete',
-        includeDrafts: snapshots.draft ? [idPair.draftId] : [],
-        publishedId: idPair.publishedId,
-      },
-      {
-        tag: 'document.delete',
-        // this disables referential integrity for cross-dataset references. we
-        // have this set because we warn against deletes in the `ConfirmDeleteDialog`
-        // UI. This operation is run when "delete anyway" is clicked
-        skipCrossDatasetReferenceValidation: true,
-      },
+    return from(
+      client.fetch<string[]>(
+        `*[sanity::versionOf($publishedId)]._id`,
+        {publishedId},
+        {tag: 'document.delete'},
+      ),
+    ).pipe(
+      switchMap((allVersionIds) => {
+        if (snapshots.published) {
+          return actionsApiClient(client, idPair).observable.action(
+            {
+              actionType: 'sanity.action.document.delete',
+              includeDrafts: allVersionIds.filter((id) => id !== publishedId),
+              publishedId,
+            },
+            {
+              tag: 'document.delete',
+              skipCrossDatasetReferenceValidation: true,
+            },
+          )
+        }
+
+        return from(
+          actionsApiClient(client, idPair).action(
+            allVersionIds.map((versionId) => ({
+              actionType: 'sanity.action.document.version.discard' as const,
+              versionId,
+            })),
+            {
+              tag: 'document.delete',
+              skipCrossDatasetReferenceValidation: true,
+            },
+          ),
+        )
+      }),
     )
   },
 }


### PR DESCRIPTION
### Description
We are currently only using the `document.delete` action when a published document exists. `document.delete` requires a published ID that exists. There are a couple of issues
1. We are not passing `includedDrafts` array through to `document.delete` which means that we are not also deleting the other versions of the document that exist
2. When a published document doesn't exist, we are using `document.discard` which is firstly a deprecated action, and secondly only discard a single document version, rather than all versions.

This PR makes the changes so that:
1. `includedDrafts` passes the document Ids of all versions to delete the published and all other versions of the document
2. `version.discard` is used instead of `document.discard` and the actions are chained together to delete all the versions of that document

Before:
Release version document is not deleted
![123deleteProperlyBeforePR](https://github.com/user-attachments/assets/3fda8c82-22db-4e66-84fa-9410f1367f31)

After:
All versions of the document are deleted
![DeleteProperlyAfterPR](https://github.com/user-attachments/assets/b88d12d0-2381-458f-bed2-75e40750774e)
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue where deleting a document would in some cases not delete all versions of that document.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
