### PR TITLE
fix(core): pte inline comments respect __internal_comments disabled

### DIFF
--- a/dev/test-studio/schema/standard/portableText/allTheBellsAndWhistles.ts
+++ b/dev/test-studio/schema/standard/portableText/allTheBellsAndWhistles.ts
@@ -421,6 +421,13 @@ export const ptAllTheBellsAndWhistlesType = defineType({
     defineField({
       name: 'content',
       type: 'array',
+      title: 'Content, comments disabled',
+      components: {
+        field: (props) => {
+          // eslint-disable-next-line camelcase
+          return props.renderDefault({...props, __internal_comments: undefined})
+        },
+      },
       of: [
         defineArrayMember({
           name: 'something',

--- a/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
+++ b/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
@@ -14,7 +14,7 @@ import {debounce, isEqual} from 'lodash'
 import {AnimatePresence} from 'motion/react'
 import {memo, startTransition, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 
-import {type PortableTextInputProps} from '../../../../form'
+import {type PortableTextInputProps, useFieldActions} from '../../../../form'
 import {useCurrentUser} from '../../../../store'
 import {CommentInlineHighlightSpan} from '../../../components'
 import {isTextSelectionComment} from '../../../helpers'
@@ -47,6 +47,7 @@ const AI_ASSIST_TYPE = 'sanity.assist.instruction.prompt'
 
 export function CommentsPortableTextInput(props: PortableTextInputProps) {
   const {enabled, mode} = useCommentsEnabled()
+  const fieldActions = useFieldActions()
 
   // This is a workaround solution to disable comments for the AI assist type.
   // The AI assist uses the official PTE input which is composed from the
@@ -54,8 +55,13 @@ export function CommentsPortableTextInput(props: PortableTextInputProps) {
   // will get the comments functionality as well, which  we don't want.
   // Therefore we disable the comments for the AI assist type.
   const isAiAssist = props.schemaType.name === AI_ASSIST_TYPE
-
-  if (!enabled || isAiAssist) {
+  /**
+   * Comments can be disabled at field level by passing the `__internal_comments: undefined` prop to the field.
+   * Even though is not recommended and tagged as internal, it works for all type of fields.
+   * This adds the same ability to disable inline comments in the Portable Text editor.
+   */
+  const isCommentsEnabledInField = Boolean(fieldActions.__internal_comments)
+  if (!enabled || isAiAssist || !isCommentsEnabledInField) {
     return props.renderDefault(props)
   }
 


### PR DESCRIPTION
### Description
Comments can be disabled at field level by passing the `__internal_comments: undefined` prop to the field.
Even though is not recommended and tagged as internal, it works for all type of fields.
This adds the same ability to disable inline comments in the Portable Text editor.

So now, defining a portable text input field like this, will also disable inline comments.

```ts
    defineField({
      name: 'content',
      type: 'array',
      title: 'Content, comments disabled',
      components: {
        field: (props) => {
          return props.renderDefault({...props, __internal_comments: undefined})
        },
      },
    fields: []...
   })
```

<img width="551" height="387" alt="Screenshot 2025-12-01 at 10 15 25" src="https://github.com/user-attachments/assets/ea8b3925-0c7d-46a6-9eef-3a79515dba6e" />
<img width="549" height="352" alt="Screenshot 2025-12-01 at 10 15 34" src="https://github.com/user-attachments/assets/ae32af15-ca6d-4554-8acc-9132040e6156" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
