### PR TITLE
fix: ensure schema errors are caught

### DIFF
--- a/packages/sanity/src/core/studio/workspaces/WorkspacesProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaces/WorkspacesProvider.tsx
@@ -1,4 +1,4 @@
-import {type ComponentType, type ReactNode, startTransition, useEffect, useState} from 'react'
+import {type ComponentType, type ReactNode, useDeferredValue} from 'react'
 import {WorkspacesContext} from 'sanity/_singletons'
 
 import {type Config, prepareConfig} from '../../config'
@@ -19,11 +19,10 @@ export function WorkspacesProvider({
   basePath,
   LoadingComponent,
 }: WorkspacesProviderProps) {
-  const [workspaces, setWorkspaces] = useState<WorkspacesContextValue | null>(null)
-
-  useEffect(() => {
-    startTransition(() => setWorkspaces(prepareConfig(config, {basePath}).workspaces))
-  }, [basePath, config])
+  const workspaces = useDeferredValue(
+    prepareConfig(config, {basePath}).workspaces satisfies WorkspacesContextValue,
+    null,
+  )
 
   if (workspaces === null) {
     return <LoadingComponent />


### PR DESCRIPTION
### Description

Fixes a regression introduced in #10834 that caused schema errors to not be caught properly and formatted. @judofyr discovered it's due to the global `startTransition` [always throwing](https://github.com/facebook/react/blob/1721e73e149d482a4421d4ea9f76d36a2c79ad02/packages/react/src/ReactStartTransition.js#L94) to global error handlers.

### What to review

Missed a spot?

### Testing

If tests pass we should be good, I'm also triggering a preview release so it can be tested ASAP.

### Notes for release

Fixes a regression in v4.19 where schema errors are not formatted properly and difficult to understand. 
