### PR TITLE
chore(core): display comments error if present

### DIFF
--- a/packages/sanity/src/core/comments/i18n/resources.ts
+++ b/packages/sanity/src/core/comments/i18n/resources.ts
@@ -81,6 +81,9 @@ const commentsLocaleStrings = defineLocalesResources('comments', {
   /** The text shown in the inline comment button */
   'inline-add-comment-button.title': 'Add comment',
 
+  /** The title of the error card shown in the comments inspector */
+  'inspector-error.title': 'Something went wrong while loading comments',
+
   /** Aria label for the breadcrumb button showing the field path. `{{field}}` is the last (most specific) field. */
   'list-item.breadcrumb-button-go-to-field-aria-label': 'Go to {{field}} field',
   /** The button tooltip content for the add reaction button */

--- a/packages/sanity/src/core/comments/plugin/field/CommentsFieldButton.tsx
+++ b/packages/sanity/src/core/comments/plugin/field/CommentsFieldButton.tsx
@@ -14,6 +14,7 @@ import {styled} from 'styled-components'
 import {Button, Popover, Tooltip} from '../../../../ui-components'
 import {type UserListWithPermissionsHookValue} from '../../../hooks'
 import {Translate, useTranslation} from '../../../i18n'
+import {useAddonDataset} from '../../../studio/addonDataset/useAddonDataset'
 import {CommentInput, type CommentInputHandle} from '../../components'
 import {hasCommentMessageValue} from '../../helpers'
 import {commentsLocaleNamespace} from '../../i18n'
@@ -56,6 +57,7 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
     value,
   } = props
   const {t} = useTranslation(commentsLocaleNamespace)
+  const {error: addonDatasetError} = useAddonDataset()
   const popoverRef = useRef<HTMLDivElement | null>(null)
   const [addCommentButtonElement, setAddCommentButtonElement] = useState<HTMLButtonElement | null>(
     null,
@@ -164,7 +166,7 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
         <div>
           <Button
             aria-label={t('field-button.aria-label-add')}
-            disabled={isCreatingDataset}
+            disabled={isCreatingDataset || Boolean(addonDatasetError)}
             icon={AddCommentIcon}
             mode="bleed"
             onClick={onClick}

--- a/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
+++ b/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-statements */
 /* eslint-disable max-nested-callbacks */
 import {
   type EditorChange,
@@ -16,6 +17,7 @@ import {memo, startTransition, useCallback, useEffect, useMemo, useRef, useState
 
 import {type PortableTextInputProps} from '../../../../form'
 import {useCurrentUser} from '../../../../store'
+import {useAddonDataset} from '../../../../studio/addonDataset/useAddonDataset'
 import {CommentInlineHighlightSpan} from '../../../components'
 import {isTextSelectionComment} from '../../../helpers'
 import {
@@ -71,6 +73,7 @@ export const CommentsPortableTextInputInner = memo(function CommentsPortableText
 
   const {comments, getComment, mentionOptions, onCommentsOpen, operation, setStatus, status} =
     useComments()
+  const {error: addonDatasetError} = useAddonDataset()
   const {setSelectedPath, selectedPath} = useCommentsSelectedPath()
   const {scrollToComment, scrollToGroup} = useCommentsScroll()
   const {handleOpenDialog} = useCommentsUpsell()
@@ -555,7 +558,7 @@ export const CommentsPortableTextInputInner = memo(function CommentsPortableText
 
           {showFloatingButton && !showFloatingInput && (
             <FloatingButtonPopover
-              disabled={currentSelectionIsOverlapping}
+              disabled={currentSelectionIsOverlapping || Boolean(addonDatasetError)}
               onClick={handleSelectCurrentSelection}
               onClickOutside={resetStates}
               referenceElement={selectionReferenceElement}

--- a/packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx
+++ b/packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx
@@ -6,6 +6,7 @@ import {styled} from 'styled-components'
 import {type DocumentInspectorProps} from '../../../config'
 import {useTranslation} from '../../../i18n'
 import {useCurrentUser} from '../../../store'
+import {useAddonDataset} from '../../../studio/addonDataset'
 import {
   CommentDeleteDialog,
   CommentsList,
@@ -31,6 +32,7 @@ import {
   type CommentsUIMode,
   type CommentUpdatePayload,
 } from '../../types'
+import {CommentsInspectorError} from './CommentsInspectorError'
 import {CommentsInspectorFeedbackFooter} from './CommentsInspectorFeedbackFooter'
 import {CommentsInspectorHeader} from './CommentsInspectorHeader'
 
@@ -90,7 +92,7 @@ function CommentsInspectorInner(
     onPathOpen,
   } = useComments()
   const commentIdParamRef = useRef<string | undefined>(selectedCommentId)
-
+  const {error: addonDatasetError} = useAddonDataset()
   const didScrollToCommentFromParam = useRef<boolean>(false)
 
   const pushToast = useToast().push
@@ -417,7 +419,7 @@ function CommentsInspectorInner(
             mode={mode}
           />
         </CommentsOnboardingPopover>
-
+        {addonDatasetError && <CommentsInspectorError error={addonDatasetError} />}
         {currentUser && (
           <CommentsList
             beforeListNode={beforeListNode}

--- a/packages/sanity/src/core/comments/plugin/inspector/CommentsInspectorError.tsx
+++ b/packages/sanity/src/core/comments/plugin/inspector/CommentsInspectorError.tsx
@@ -1,0 +1,23 @@
+import {Box, Card, Stack, Text} from '@sanity/ui'
+
+import {useTranslation} from '../../../i18n'
+import {commentsLocaleNamespace} from '../../i18n'
+
+export function CommentsInspectorError({error}: {error: Error}) {
+  const {t} = useTranslation(commentsLocaleNamespace)
+
+  return (
+    <Box padding={2}>
+      <Card paddingX={2} paddingY={3} tone="critical" border radius={3}>
+        <Stack space={3}>
+          <Text size={1} weight="medium">
+            {t('inspector-error.title')}
+          </Text>
+          <Text size={1} muted>
+            {error.message}
+          </Text>
+        </Stack>
+      </Card>
+    </Box>
+  )
+}

--- a/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx
+++ b/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx
@@ -18,6 +18,7 @@ function AddonDatasetProviderInner(props: AddonDatasetSetupProviderProps) {
   const [addonDatasetClient, setAddonDatasetClient] = useState<SanityClient | null>(null)
   const [isCreatingDataset, setIsCreatingDataset] = useState<boolean>(false)
   const [ready, setReady] = useState<boolean>(false)
+  const [error, setError] = useState<Error | null>(null)
 
   const getAddonDatasetName = useCallback(async (): Promise<string | undefined> => {
     const res = await originalClient.request({
@@ -107,10 +108,10 @@ function AddonDatasetProviderInner(props: AddonDatasetSetupProviderProps) {
         const client = handleCreateClient(addonDatasetName)
         setAddonDatasetClient(client)
       })
-      .catch(() => {
+      .catch((err) => {
         // If the addon dataset does not exist or we don't have permission to access it,
         // We can ignore this error.
-        // TODO: Surface error to the user when they try to use the comments feature.
+        setError(err)
       })
       .finally(() => {
         setReady(true)
@@ -123,8 +124,9 @@ function AddonDatasetProviderInner(props: AddonDatasetSetupProviderProps) {
       createAddonDataset: handleCreateAddonDataset,
       isCreatingDataset,
       ready,
+      error,
     }),
-    [addonDatasetClient, handleCreateAddonDataset, isCreatingDataset, ready],
+    [addonDatasetClient, error, handleCreateAddonDataset, isCreatingDataset, ready],
   )
 
   return <AddonDatasetContext.Provider value={ctxValue}>{children}</AddonDatasetContext.Provider>

--- a/packages/sanity/src/core/studio/addonDataset/types.ts
+++ b/packages/sanity/src/core/studio/addonDataset/types.ts
@@ -15,4 +15,5 @@ export interface AddonDatasetContextValue {
    */
   createAddonDataset: () => Promise<SanityClient | null>
   ready: boolean
+  error: Error | null
 }


### PR DESCRIPTION
### Description
Comments requires dataset read permissions to verify that the add-on dataset is available.
We have seen reports from users in where comments doesn't work and they don't understand the reason behind it, this PR tries to bring clarity to it and surface the error if there is an error when trying to load the addon dataset.

This changes also disables the comment button when there is an error, so users don't try to create a comment which will later not be possible to post, but it doesn't block the inspector, so if they click on the inspector they will be able to see the details of the error.

<img width="1039" height="949" alt="Screenshot 2025-12-01 at 15 15 00" src="https://github.com/user-attachments/assets/7126b0f6-b7c2-4abf-bb90-7fc8c7715290" />


If no Add-on dataset is present, then the api will return an empty array, it won't error out as it did before, so the normal flow for creating the dataset on first use of comments will continue working.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
