### PR TITLE
fix(media-library): support groups and fieldset in `defineVideoField`

### DIFF
--- a/dev/test-studio/schema/standard/videos.ts
+++ b/dev/test-studio/schema/standard/videos.ts
@@ -7,6 +7,8 @@ export default defineType({
   type: 'document',
   title: 'Videos test',
   icon: VideoIcon,
+  groups: [{name: 'content', title: 'Content'}],
+  fieldsets: [{name: 'coolVideos', title: 'Cool Videos'}],
   fields: [
     {
       name: 'title',
@@ -16,6 +18,16 @@ export default defineType({
     defineVideoField({
       title: 'A simple video',
       name: 'someVideo',
+    }),
+    defineVideoField({
+      title: 'A simple video in content group',
+      name: 'someVideoInContentGroup',
+      group: 'content',
+    }),
+    defineVideoField({
+      title: 'A simple video in a fieldset',
+      name: 'someVideoInFieldset',
+      fieldset: 'coolVideos',
     }),
     defineField({
       name: 'arrayOfVideos',

--- a/packages/sanity/src/media-library/plugin/schemas/defineVideoField.ts
+++ b/packages/sanity/src/media-library/plugin/schemas/defineVideoField.ts
@@ -1,4 +1,4 @@
-import {defineField} from '@sanity/types'
+import {defineField, type FieldDefinitionBase} from '@sanity/types'
 
 import {type VideoDefinition} from './types'
 
@@ -24,7 +24,7 @@ import {type VideoDefinition} from './types'
  *
  * @beta
  */
-export function defineVideoField(definition: Omit<VideoDefinition, 'type'>) {
+export function defineVideoField(definition: Omit<VideoDefinition, 'type'> & FieldDefinitionBase) {
   // @ts-expect-error FIXME
   return defineField({
     ...definition,


### PR DESCRIPTION
### Description
`defineVideoField` is missing `FieldDefinitionBase` which adds support to group and fieldsets in the definition helper.
Before, this was showing an error.
```ts
  fields: [
    defineVideoField({
      name: "authorVideo",
      description: "Author profile video",
      group: "content'", // errors with Object literal may only specify known properties, and 'group' does not exist in type 'Omit<VideoDefinition, "type">'
    }),

```
Now it works.

<img width="586" height="204" alt="Screenshot 2025-12-02 at 10 10 25" src="https://github.com/user-attachments/assets/95df3ec8-5c01-49fd-8694-23147bd01cc7" />
<img width="574" height="136" alt="Screenshot 2025-12-02 at 10 10 31" src="https://github.com/user-attachments/assets/d55976c6-928b-4b13-be2b-d70dd5a910b9" />


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
fix(media-library): support groups and fieldset in `defineVideoField`
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
