### PR TITLE
fix(core): update server delete operation to include versions list

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/operations/types.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/operations/types.ts
@@ -30,8 +30,8 @@ type Patch = any
 // Note: Changing this interface in a backwards incompatible manner will be a breaking change
 export interface OperationsAPI {
   commit: Operation | GuardedOperation
-  delete: Operation<[], 'NOTHING_TO_DELETE' | 'NOT_READY'>
-  del: Operation<[], 'NOTHING_TO_DELETE'> | GuardedOperation
+  delete: Operation<[versions?: string[]], 'NOTHING_TO_DELETE' | 'NOT_READY'>
+  del: Operation<[versions?: string[]], 'NOTHING_TO_DELETE'> | GuardedOperation
   publish:
     | Operation<[], 'LIVE_EDIT_ENABLED' | 'ALREADY_PUBLISHED' | 'NO_CHANGES'>
     | GuardedOperation

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/delete.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/delete.ts
@@ -1,15 +1,11 @@
+import {isPublishedId} from '@sanity/client/csm'
+
 import {type OperationImpl} from '../operations/types'
 import {actionsApiClient} from '../utils/actionsApiClient'
-import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
 
-export const del: OperationImpl<[], 'NOTHING_TO_DELETE'> = {
+export const del: OperationImpl<[versions: string[]], 'NOTHING_TO_DELETE'> = {
   disabled: ({snapshots}) => (snapshots.draft || snapshots.published ? false : 'NOTHING_TO_DELETE'),
-  execute: ({client, schema, idPair, typeName, snapshots}) => {
-    if (isLiveEditEnabled(schema, typeName)) {
-      const tx = client.observable.transaction().delete(idPair.publishedId)
-      return tx.commit({tag: 'document.delete'})
-    }
-
+  execute: ({client, idPair, snapshots}, versions) => {
     //the delete action requires a published doc -- discard if not present
     if (!snapshots.published) {
       return actionsApiClient(client, idPair).observable.action(
@@ -24,7 +20,12 @@ export const del: OperationImpl<[], 'NOTHING_TO_DELETE'> = {
     return actionsApiClient(client, idPair).observable.action(
       {
         actionType: 'sanity.action.document.delete',
-        includeDrafts: snapshots.draft ? [idPair.draftId] : [],
+        includeDrafts: versions
+          ? // if versions are provided, remove the published id from the list, all versions need to be included in order for the delete to work.
+            versions.filter((v) => !isPublishedId(v))
+          : snapshots.draft
+            ? [idPair.draftId]
+            : [],
         publishedId: idPair.publishedId,
       },
       {

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx
@@ -1,6 +1,6 @@
 import {Box, Flex} from '@sanity/ui'
-import {useId, useMemo} from 'react'
-import {LoadingBlock, useTranslation} from 'sanity'
+import {useCallback, useId, useMemo} from 'react'
+import {getPublishedId, LoadingBlock, useDocumentVersions, useTranslation} from 'sanity'
 import {styled} from 'styled-components'
 
 import {Dialog} from '../../../ui-components'
@@ -41,7 +41,7 @@ export interface ConfirmDeleteDialogProps {
    */
   action?: 'delete' | 'unpublish'
   onCancel: () => void
-  onConfirm: () => void
+  onConfirm: (versions: string[]) => void
 }
 
 /**
@@ -71,6 +71,13 @@ export function ConfirmDeleteDialog({
   } = useReferringDocuments(id)
   const documentTitle = <DocTitle document={useMemo(() => ({_id: id, _type: type}), [id, type])} />
   const showConfirmButton = !isLoading
+  const {data: documentVersions, loading: versionsLoading} = useDocumentVersions({
+    documentId: getPublishedId(id),
+  })
+
+  const handleConfirm = useCallback(() => {
+    onConfirm(documentVersions)
+  }, [onConfirm, documentVersions])
 
   return (
     <Dialog
@@ -88,7 +95,7 @@ export function ConfirmDeleteDialog({
                 totalCount > 0
                   ? t('confirm-delete-dialog.confirm-anyway-button.text', {context: action})
                   : t('confirm-delete-dialog.confirm-button.text', {context: action}),
-              onClick: onConfirm,
+              onClick: handleConfirm,
             }
           : undefined,
       }}
@@ -96,7 +103,7 @@ export function ConfirmDeleteDialog({
       onClickOutside={onCancel}
     >
       <DialogBody>
-        {crossDatasetReferences && internalReferences && !isLoading ? (
+        {crossDatasetReferences && internalReferences && !isLoading && !versionsLoading ? (
           <ConfirmDeleteDialogBody
             crossDatasetReferences={crossDatasetReferences}
             internalReferences={internalReferences}
@@ -110,6 +117,7 @@ export function ConfirmDeleteDialog({
             onReferenceLinkClick={onCancel}
             documentId={id}
             documentType={type}
+            documentVersions={documentVersions}
           />
         ) : (
           <LoadingContainer data-testid="loading-container">

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
@@ -29,6 +29,7 @@ type DeletionConfirmationDialogBodyProps = Required<ReferringDocuments> & {
   onReferenceLinkClick?: () => void
   documentId: string
   documentType: string
+  documentVersions: string[]
 }
 
 /**
@@ -46,6 +47,7 @@ export function ConfirmDeleteDialogBody({
   documentId,
   documentType,
   onReferenceLinkClick,
+  documentVersions,
 }: DeletionConfirmationDialogBodyProps) {
   const schema = useSchema()
   const toast = useToast()
@@ -86,11 +88,11 @@ export function ConfirmDeleteDialogBody({
           />
         </Text>
         {action === 'delete' && (
-          <VersionsPreviewList documentId={documentId} documentType={documentType} />
+          <VersionsPreviewList documentType={documentType} documentVersions={documentVersions} />
         )}
       </Stack>
     ),
-    [t, action, documentTitle, documentId, documentType],
+    [t, action, documentTitle, documentType, documentVersions],
   )
 
   if (internalReferences?.totalCount === 0 && crossDatasetReferences?.totalCount === 0) {

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/VersionsPreviewList.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/VersionsPreviewList.tsx
@@ -14,7 +14,6 @@ import {
   type SchemaType,
   useActiveReleases,
   useDocumentPreviewStore,
-  useDocumentVersions,
   useSchema,
   useTranslation,
 } from 'sanity'
@@ -123,13 +122,12 @@ const VersionItemPreview = ({
  *
  */
 export const VersionsPreviewList = ({
-  documentId,
   documentType,
+  documentVersions,
 }: {
-  documentId: string
   documentType: string
+  documentVersions: string[]
 }) => {
-  const {data: documentVersions} = useDocumentVersions({documentId: getPublishedId(documentId)})
   const schema = useSchema()
 
   const schemaType = schema.get(documentType)

--- a/packages/sanity/src/structure/documentActions/DeleteAction.tsx
+++ b/packages/sanity/src/structure/documentActions/DeleteAction.tsx
@@ -32,13 +32,15 @@ export const useDeleteAction: DocumentActionComponent = ({id, type, draft, relea
     setConfirmDialogOpen(false)
   }, [])
 
-  const handleConfirm = useCallback(() => {
-    setIsDeleting(true)
-    setConfirmDialogOpen(false)
-    paneSetIsDeleting(true)
-    deleteOp.execute()
-    setIsDeleting(false)
-  }, [deleteOp, paneSetIsDeleting])
+  const handleConfirm = useCallback(
+    (versions: string[]) => {
+      setConfirmDialogOpen(false)
+      setIsDeleting(true)
+      deleteOp.execute(versions)
+      setIsDeleting(false)
+    },
+    [deleteOp, setIsDeleting],
+  )
 
   const handle = useCallback(() => {
     setConfirmDialogOpen(true)


### PR DESCRIPTION
### Description
When executing the server delete operation we need to include the version documents as part of the `includeDrafts` array. If that is not included, then the server action will fail with this error:

<img width="480" height="208" alt="image" src="https://github.com/user-attachments/assets/3098f317-47fc-451e-b603-7359cf92a8d1" />

This is to prevent deleting unverified documents.
Now that we are displaying the list of the documents before running the delete action, we can pass that list to the server action and confirm the removal of all the documents.


https://github.com/user-attachments/assets/0b6e1009-fe97-404c-b0b1-c9202689e7d7


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Try to delete a document with versions, it should work.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes delete operation to support deletion of version documents

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
