### PR TITLE
chore: changes to catalog should bust turbo cache

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -71,7 +71,7 @@
     "SANITY_AUTH_TOKEN"
   ],
   "globalDependencies": [
-    ".npmrc",
+    "pnpm-workspace.yaml",
     ".oxlintrc.json",
     "lerna.json"
   ],


### PR DESCRIPTION

### Description
Found the root cause for why sometimes lint and build didn't fail until after a PR is merged.
When we adopted pnpm catalogs, and later moved pnpm settings from .npmrc to pnpm-workspace.yaml, we forgot to add the workspace config to turbo global dependencies. This PR fixes that.

### What to review

Any other global dependencies we forgot?

### Testing

CI tests should be enough, though they might fail now since we might have cache that should have expired on other PRs and not make it to main.

### Notes for release

N/A