### PR TITLE
feat(studioManifest): register live manifest with content operating system

### DIFF
--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -23,6 +23,7 @@ import {ColorSchemeProvider} from './colorScheme'
 import {ComlinkRouteHandler} from './components/ComlinkRouteHandler'
 import {Z_OFFSET} from './constants'
 import {LiveUserApplicationProvider} from './liveUserApplication/LiveUserApplicationProvider'
+import {LiveManifestRegisterProvider} from './manifest'
 import {MaybeEnableErrorReporting} from './MaybeEnableErrorReporting'
 import {PackageVersionStatusProvider} from './packageVersionStatus/PackageVersionStatusProvider'
 import {
@@ -81,6 +82,7 @@ export function StudioProvider({
                 <UserApplicationCacheProvider>
                   <AppIdCacheProvider>
                     <LiveUserApplicationProvider>
+                      <LiveManifestRegisterProvider />
                       <ComlinkRouteHandler />
                       <StudioAnnouncementsProvider>
                         <GlobalPerspectiveProvider>

--- a/packages/sanity/src/core/studio/manifest/LiveManifestRegisterProvider.tsx
+++ b/packages/sanity/src/core/studio/manifest/LiveManifestRegisterProvider.tsx
@@ -1,0 +1,34 @@
+import {useRootTheme} from '@sanity/ui'
+import {useEffect} from 'react'
+
+import {useClient} from '../../hooks/useClient'
+import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
+import {useLiveUserApplication} from '../liveUserApplication/useLiveUserApplication'
+import {useWorkspaces} from '../workspaces'
+import {registerStudioManifest} from './registerLiveStudioManifest'
+
+/**
+ * Provider that automatically uploads the studio manifest when the Studio loads.
+ * This runs once when all workspaces are available and includes all workspace information.
+ *
+ * @internal
+ */
+export function LiveManifestRegisterProvider() {
+  const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+  const workspaces = useWorkspaces()
+  const {userApplication} = useLiveUserApplication()
+  const {theme} = useRootTheme()
+
+  useEffect(() => {
+    if (!userApplication || workspaces.length === 0) {
+      // Nothing to register
+      return
+    }
+    // Upload once when workspaces are available
+    registerStudioManifest(client, userApplication, workspaces, theme).catch((err) => {
+      console.error('Failed to upload studio manifest', err)
+    })
+  }, [client, userApplication, workspaces, theme])
+
+  return null
+}

--- a/packages/sanity/src/core/studio/manifest/__tests__/registerLiveStudioManifest.test.tsx
+++ b/packages/sanity/src/core/studio/manifest/__tests__/registerLiveStudioManifest.test.tsx
@@ -1,0 +1,303 @@
+import {type SanityClient} from '@sanity/client'
+import {buildTheme, type RootTheme} from '@sanity/ui/theme'
+import {of} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {type Source, type WorkspaceSummary} from '../../../config/types'
+import {type UserApplication} from '../../../store/userApplications'
+import {registerStudioManifest} from '../registerLiveStudioManifest'
+
+// Mock the icon module to avoid styled-components complexity in tests
+vi.mock('../icon', () => ({
+  resolveIcon: vi.fn(() => '<svg>mock-icon</svg>'),
+}))
+
+const mockTheme: RootTheme = buildTheme()
+
+describe('registerStudioManifest', () => {
+  const mockRequest = vi.fn()
+  const mockWithConfig = vi.fn()
+
+  const mockClient = {
+    withConfig: mockWithConfig,
+  } as unknown as SanityClient
+
+  const mockConfiguredClient = {
+    request: mockRequest,
+  }
+
+  const mockUserApplication: UserApplication = {
+    id: 'app-123',
+    type: 'studio',
+    projectId: 'app-project',
+    urlType: 'internal',
+    appHost: 'test-studio',
+    apiHost: 'https://api.sanity.io',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockWithConfig.mockReturnValue(mockConfiguredClient)
+    mockRequest.mockResolvedValue(undefined)
+  })
+
+  /**
+   * Helper to create a mock WorkspaceSummary with the required structure.
+   */
+  function createMockWorkspace(
+    overrides: Partial<{
+      name: string
+      projectId: string
+      dataset: string
+      title: string
+      subtitle: string
+      basePath: string
+      schemaDescriptorId: string | undefined
+      mediaLibrary: {enabled: boolean; libraryId?: string} | undefined
+    }> = {},
+  ): WorkspaceSummary {
+    const name = overrides.name ?? 'default'
+    const projectId = overrides.projectId ?? 'test-project'
+    const dataset = overrides.dataset ?? 'production'
+    const title = overrides.title ?? 'Test Workspace'
+    const subtitle = overrides.subtitle
+    const basePath = overrides.basePath ?? '/'
+    // Use 'schemaDescriptorId' in overrides to check if explicitly set (including undefined)
+    const schemaDescriptorId =
+      'schemaDescriptorId' in overrides ? overrides.schemaDescriptorId : 'schema-123'
+    const mediaLibrary = overrides.mediaLibrary
+
+    const mockSource = {
+      __internal: {
+        schemaDescriptorId: Promise.resolve(schemaDescriptorId),
+      },
+    } as unknown as Source
+
+    return {
+      type: 'workspace-summary',
+      name,
+      projectId,
+      dataset,
+      title,
+      subtitle,
+      basePath,
+      icon: null,
+      customIcon: false,
+      mediaLibrary,
+      __internal: {
+        sources: [
+          {
+            name,
+            projectId,
+            dataset,
+            title,
+            source: of(mockSource),
+          },
+        ],
+      },
+    } as unknown as WorkspaceSummary
+  }
+
+  describe('client configuration', () => {
+    it('should configure client with projectId and apiHost from userApplication', async () => {
+      const workspace = createMockWorkspace()
+
+      await registerStudioManifest(mockClient, mockUserApplication, [workspace], mockTheme)
+
+      expect(mockWithConfig).toHaveBeenCalledWith({
+        projectId: 'app-project',
+        apiHost: 'https://api.sanity.io',
+      })
+    })
+  })
+
+  describe('successful registration', () => {
+    it('should post manifest to the correct endpoint', async () => {
+      const workspace = createMockWorkspace()
+
+      await registerStudioManifest(mockClient, mockUserApplication, [workspace], mockTheme)
+
+      expect(mockRequest).toHaveBeenCalledWith({
+        method: 'POST',
+        uri: '/projects/app-project/user-applications/app-123/config/live-manifest',
+        body: {
+          value: expect.objectContaining({
+            workspaces: expect.any(Array),
+          }),
+        },
+        tag: 'live-manifest-register',
+      })
+    })
+
+    it('should include all workspace properties in manifest', async () => {
+      const workspace = createMockWorkspace({
+        name: 'my-workspace',
+        projectId: 'proj-456',
+        dataset: 'staging',
+        title: 'My Workspace',
+        subtitle: 'Development',
+        basePath: '/studio',
+        schemaDescriptorId: 'schema-abc',
+      })
+
+      await registerStudioManifest(mockClient, mockUserApplication, [workspace], mockTheme)
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: {
+            value: {
+              workspaces: [
+                {
+                  name: 'my-workspace',
+                  projectId: 'proj-456',
+                  dataset: 'staging',
+                  schemaDescriptorId: 'schema-abc',
+                  basePath: '/studio',
+                  title: 'My Workspace',
+                  subtitle: 'Development',
+                  icon: '<svg>mock-icon</svg>',
+                  mediaLibraryId: undefined,
+                },
+              ],
+            },
+          },
+        }),
+      )
+    })
+
+    it('should handle multiple workspaces', async () => {
+      const workspace1 = createMockWorkspace({
+        name: 'workspace-1',
+        projectId: 'proj-1',
+        schemaDescriptorId: 'schema-1',
+      })
+      const workspace2 = createMockWorkspace({
+        name: 'workspace-2',
+        projectId: 'proj-2',
+        schemaDescriptorId: 'schema-2',
+      })
+
+      await registerStudioManifest(
+        mockClient,
+        mockUserApplication,
+        [workspace1, workspace2],
+        mockTheme,
+      )
+
+      const callArgs = mockRequest.mock.calls[0][0]
+      expect(callArgs.body.value.workspaces).toHaveLength(2)
+      expect(callArgs.body.value.workspaces[0].name).toBe('workspace-1')
+      expect(callArgs.body.value.workspaces[1].name).toBe('workspace-2')
+    })
+
+    it('should include mediaLibraryId when mediaLibrary is enabled', async () => {
+      const workspace = createMockWorkspace({
+        mediaLibrary: {enabled: true, libraryId: 'lib-123'},
+      })
+
+      await registerStudioManifest(mockClient, mockUserApplication, [workspace], mockTheme)
+
+      const callArgs = mockRequest.mock.calls[0][0]
+      expect(callArgs.body.value.workspaces[0].mediaLibraryId).toBe('lib-123')
+    })
+
+    it('should not include mediaLibraryId when mediaLibrary is disabled', async () => {
+      const workspace = createMockWorkspace({
+        mediaLibrary: {enabled: false, libraryId: 'lib-123'},
+      })
+
+      await registerStudioManifest(mockClient, mockUserApplication, [workspace], mockTheme)
+
+      const callArgs = mockRequest.mock.calls[0][0]
+      expect(callArgs.body.value.workspaces[0].mediaLibraryId).toBeUndefined()
+    })
+  })
+
+  describe('skipping registration', () => {
+    it('should skip registration when no workspaces have schemaDescriptorId', async () => {
+      const workspace = createMockWorkspace({
+        schemaDescriptorId: undefined,
+      })
+
+      await registerStudioManifest(mockClient, mockUserApplication, [workspace], mockTheme)
+
+      expect(mockRequest).not.toHaveBeenCalled()
+    })
+
+    it('should skip registration when workspaces array is empty', async () => {
+      await registerStudioManifest(mockClient, mockUserApplication, [], mockTheme)
+
+      expect(mockRequest).not.toHaveBeenCalled()
+    })
+
+    it('should filter out workspaces without schemaDescriptorId', async () => {
+      const validWorkspace = createMockWorkspace({
+        name: 'valid',
+        schemaDescriptorId: 'schema-valid',
+      })
+      const invalidWorkspace = createMockWorkspace({
+        name: 'invalid',
+        schemaDescriptorId: undefined,
+      })
+
+      await registerStudioManifest(
+        mockClient,
+        mockUserApplication,
+        [validWorkspace, invalidWorkspace],
+        mockTheme,
+      )
+
+      const callArgs = mockRequest.mock.calls[0][0]
+      expect(callArgs.body.value.workspaces).toHaveLength(1)
+      expect(callArgs.body.value.workspaces[0].name).toBe('valid')
+    })
+  })
+
+  describe('workspace source resolution', () => {
+    it('should handle workspace with no sources', async () => {
+      const workspace = createMockWorkspace()
+      // Override to have empty sources
+      workspace.__internal.sources = []
+
+      await registerStudioManifest(mockClient, mockUserApplication, [workspace], mockTheme)
+
+      // Should skip since no source means no schemaDescriptorId
+      expect(mockRequest).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('optional fields', () => {
+    it('should omit basePath when it is empty string', async () => {
+      const workspace = createMockWorkspace({
+        basePath: '',
+      })
+
+      await registerStudioManifest(mockClient, mockUserApplication, [workspace], mockTheme)
+
+      const callArgs = mockRequest.mock.calls[0][0]
+      expect(callArgs.body.value.workspaces[0].basePath).toBeUndefined()
+    })
+
+    it('should omit title when not provided', async () => {
+      const workspace = createMockWorkspace({
+        title: '',
+      })
+
+      await registerStudioManifest(mockClient, mockUserApplication, [workspace], mockTheme)
+
+      const callArgs = mockRequest.mock.calls[0][0]
+      expect(callArgs.body.value.workspaces[0].title).toBeUndefined()
+    })
+
+    it('should omit subtitle when not provided', async () => {
+      const workspace = createMockWorkspace({
+        subtitle: undefined,
+      })
+
+      await registerStudioManifest(mockClient, mockUserApplication, [workspace], mockTheme)
+
+      const callArgs = mockRequest.mock.calls[0][0]
+      expect(callArgs.body.value.workspaces[0].subtitle).toBeUndefined()
+    })
+  })
+})

--- a/packages/sanity/src/core/studio/manifest/icon.tsx
+++ b/packages/sanity/src/core/studio/manifest/icon.tsx
@@ -1,0 +1,343 @@
+import {ThemeProvider} from '@sanity/ui'
+import {type RootTheme} from '@sanity/ui/theme'
+import DOMPurify from 'isomorphic-dompurify'
+import {type ComponentType, isValidElement, type ReactNode} from 'react'
+import {renderToStaticMarkup} from 'react-dom/server'
+import {isValidElementType} from 'react-is'
+import {ServerStyleSheet} from 'styled-components'
+
+import {createDefaultIcon} from '../../config/createDefaultIcon'
+
+interface IconProps {
+  icon?: ComponentType | ReactNode
+  title: string
+  subtitle?: string
+  theme: RootTheme
+}
+
+/**
+ * DOMPurify configuration for sanitizing rendered icon HTML.
+ * Uses an allowlist for tags and attributes to ensure safety.
+ */
+const purifyConfig = {
+  ALLOWED_ATTR: [
+    // SVG attributes
+    'accent-height',
+    'accumulate',
+    'additive',
+    'alignment-baseline',
+    'amplitude',
+    'ascent',
+    'attributename',
+    'attributetype',
+    'azimuth',
+    'basefrequency',
+    'baseline-shift',
+    'begin',
+    'bias',
+    'by',
+    'class',
+    'clip',
+    'clippathunits',
+    'clip-path',
+    'clip-rule',
+    'color',
+    'color-interpolation',
+    'color-interpolation-filters',
+    'color-profile',
+    'color-rendering',
+    'cx',
+    'cy',
+    'd',
+    'dx',
+    'dy',
+    'diffuseconstant',
+    'direction',
+    'display',
+    'divisor',
+    'dur',
+    'edgemode',
+    'elevation',
+    'end',
+    'exponent',
+    'fill',
+    'fill-opacity',
+    'fill-rule',
+    'filter',
+    'filterunits',
+    'flood-color',
+    'flood-opacity',
+    'font-family',
+    'font-size',
+    'font-size-adjust',
+    'font-stretch',
+    'font-style',
+    'font-variant',
+    'font-weight',
+    'fx',
+    'fy',
+    'g1',
+    'g2',
+    'glyph-name',
+    'glyphref',
+    'gradientunits',
+    'gradienttransform',
+    'height',
+    'href',
+    'id',
+    'image-rendering',
+    'in',
+    'in2',
+    'intercept',
+    'k',
+    'k1',
+    'k2',
+    'k3',
+    'k4',
+    'kerning',
+    'keypoints',
+    'keysplines',
+    'keytimes',
+    'lang',
+    'lengthadjust',
+    'letter-spacing',
+    'kernelmatrix',
+    'kernelunitlength',
+    'lighting-color',
+    'local',
+    'marker-end',
+    'marker-mid',
+    'marker-start',
+    'markerheight',
+    'markerunits',
+    'markerwidth',
+    'maskcontentunits',
+    'maskunits',
+    'max',
+    'mask',
+    'media',
+    'method',
+    'mode',
+    'min',
+    'name',
+    'numoctaves',
+    'offset',
+    'operator',
+    'opacity',
+    'order',
+    'orient',
+    'orientation',
+    'origin',
+    'overflow',
+    'paint-order',
+    'path',
+    'pathlength',
+    'patterncontentunits',
+    'patterntransform',
+    'patternunits',
+    'points',
+    'preservealpha',
+    'preserveaspectratio',
+    'primitiveunits',
+    'r',
+    'rx',
+    'ry',
+    'radius',
+    'refx',
+    'refy',
+    'repeatcount',
+    'repeatdur',
+    'restart',
+    'result',
+    'rotate',
+    'scale',
+    'seed',
+    'shape-rendering',
+    'slope',
+    'specularconstant',
+    'specularexponent',
+    'spreadmethod',
+    'startoffset',
+    'stddeviation',
+    'stitchtiles',
+    'stop-color',
+    'stop-opacity',
+    'stroke-dasharray',
+    'stroke-dashoffset',
+    'stroke-linecap',
+    'stroke-linejoin',
+    'stroke-miterlimit',
+    'stroke-opacity',
+    'stroke',
+    'stroke-width',
+    'style',
+    'surfacescale',
+    'systemlanguage',
+    'tabindex',
+    'tablevalues',
+    'targetx',
+    'targety',
+    'transform',
+    'transform-origin',
+    'text-anchor',
+    'text-decoration',
+    'text-rendering',
+    'textlength',
+    'type',
+    'u1',
+    'u2',
+    'unicode',
+    'values',
+    'viewbox',
+    'visibility',
+    'version',
+    'vert-adv-y',
+    'vert-origin-x',
+    'vert-origin-y',
+    'width',
+    'word-spacing',
+    'wrap',
+    'writing-mode',
+    'xchannelselector',
+    'ychannelselector',
+    'x',
+    'x1',
+    'x2',
+    'xmlns',
+    'y',
+    'y1',
+    'y2',
+    'z',
+    'zoomandpan',
+    // HTML attributes
+    'alt',
+    'crossorigin',
+    'decoding',
+    'elementtiming',
+    'fetchpriority',
+    'loading',
+    'src',
+    'srcset',
+  ],
+  ALLOWED_TAGS: [
+    // HTML tags
+    'img',
+    'style',
+    // SVG tags
+    'svg',
+    'a',
+    'altglyph',
+    'altglyphdef',
+    'altglyphitem',
+    'animatecolor',
+    'animatemotion',
+    'animatetransform',
+    'circle',
+    'clippath',
+    'defs',
+    'desc',
+    'ellipse',
+    'filter',
+    'font',
+    'g',
+    'glyph',
+    'glyphref',
+    'hkern',
+    'image',
+    'line',
+    'lineargradient',
+    'marker',
+    'mask',
+    'metadata',
+    'mpath',
+    'path',
+    'pattern',
+    'polygon',
+    'polyline',
+    'radialgradient',
+    'rect',
+    'stop',
+    'switch',
+    'symbol',
+    'text',
+    'textpath',
+    'title',
+    'tref',
+    'tspan',
+    'view',
+    'vkern',
+    // SVG filter tags
+    'feBlend',
+    'feColorMatrix',
+    'feComponentTransfer',
+    'feComposite',
+    'feConvolveMatrix',
+    'feDiffuseLighting',
+    'feDisplacementMap',
+    'feDistantLight',
+    'feDropShadow',
+    'feFlood',
+    'feFuncA',
+    'feFuncB',
+    'feFuncG',
+    'feFuncR',
+    'feGaussianBlur',
+    'feImage',
+    'feMerge',
+    'feMergeNode',
+    'feMorphology',
+    'feOffset',
+    'fePointLight',
+    'feSpecularLighting',
+    'feSpotLight',
+    'feTile',
+    'feTurbulence',
+  ],
+  /**
+   * Required to allow for the use of `style` tags,
+   * namely rendering the style tags from `styled-components`
+   */
+  FORCE_BODY: true,
+}
+
+/**
+ * Normalizes icon input to a React element.
+ */
+function normalizeIcon(
+  Icon: ComponentType | ReactNode | undefined,
+  title: string,
+  subtitle = '',
+): React.JSX.Element {
+  if (isValidElementType(Icon)) return <Icon />
+  if (isValidElement(Icon)) return Icon
+  return createDefaultIcon(title, subtitle)
+}
+
+/**
+ * Renders a workspace icon to an HTML string.
+ * Uses ServerStyleSheet to capture styled-components styles without
+ * interfering with the main application's style sheet.
+ */
+export const resolveIcon = (props: IconProps): string | undefined => {
+  const sheet = new ServerStyleSheet()
+
+  try {
+    // Create the icon element wrapped with theme provider
+    const iconElement = normalizeIcon(props.icon, props.title, props.subtitle)
+    const wrappedElement = <ThemeProvider theme={props.theme}>{iconElement}</ThemeProvider>
+
+    // Render to static markup while collecting styles
+    const elementHtml = renderToStaticMarkup(sheet.collectStyles(wrappedElement))
+    const styleHtml = sheet.getStyleTags()
+
+    // Combine styles and element
+    const html = `${styleHtml}${elementHtml}`.trim()
+
+    return DOMPurify.sanitize(html, purifyConfig)
+  } catch {
+    return undefined
+  } finally {
+    // Always seal the sheet to prevent memory leaks
+    sheet.seal()
+  }
+}

--- a/packages/sanity/src/core/studio/manifest/index.ts
+++ b/packages/sanity/src/core/studio/manifest/index.ts
@@ -1,0 +1,4 @@
+/**
+ * @internal
+ */
+export {LiveManifestRegisterProvider} from './LiveManifestRegisterProvider'


### PR DESCRIPTION
### Description

Added a new feature to automatically register Studio manifest information with the Content Operating System. This manifest includes workspace configurations, schema descriptor IDs, and other Studio metadata that enables better integration with other Sanity services.

The implementation adds a new `LiveManifestRegisterProvider` component that runs once when the Studio loads, collecting information about all workspaces and uploading it to the backend.

### What to review

- The new `LiveManifestRegisterProvider` component and its integration in the Studio provider tree
- The manifest registration logic in `registerStudioManifest.tsx`
- Icon rendering and sanitization in `icon.tsx`
- Test coverage for the manifest registration functionality

### Testing

Added comprehensive unit tests for the `registerStudioManifest` function, covering:
- Client configuration
- Successful registration scenarios
- Skipping registration when appropriate
- Workspace source resolution
- Handling of optional fields

### Notes for release

This is an internal change as it requires the schema descriptor upload toggle to be enabled. When the toggle is enabled, this change enables automatic registration of Studio configuration with the Content Operating System. The Studio now uploads workspace information including project IDs, datasets, schema descriptor IDs, and media library configurations. This enables better integration with other Sanity services and lays groundwork for future features that need to understand Studio structure.