### PR TITLE
feat(build): expose build id

### DIFF
--- a/packages/sanity/src/_internal/cli/server/getViteConfig.ts
+++ b/packages/sanity/src/_internal/cli/server/getViteConfig.ts
@@ -148,6 +148,7 @@ export async function getViteConfig(options: ViteOptions): Promise<InlineConfig>
     },
     define: {
       '__SANITY_STAGING__': process.env.SANITY_INTERNAL_ENV === 'staging',
+      '__SANITY_BUILD_TIMESTAMP__': JSON.stringify(Date.now()),
       'process.env.PKG_BUILD_VERSION': JSON.stringify(process.env.PKG_BUILD_VERSION),
       'process.env.MODE': JSON.stringify(mode),
       /**

--- a/packages/sanity/src/core/studio/manifest/registerLiveStudioManifest.tsx
+++ b/packages/sanity/src/core/studio/manifest/registerLiveStudioManifest.tsx
@@ -6,6 +6,10 @@ import {type Source, type WorkspaceSummary} from '../../config/types'
 import {type UserApplication} from '../../store/userApplications'
 import {resolveIcon} from './icon'
 
+const buildId: string | undefined =
+  // @ts-expect-error: __SANITY_BUILD_TIMESTAMP__ is a global env variable set by the vite config
+  typeof __SANITY_BUILD_TIMESTAMP__ === 'undefined' ? undefined : `${__SANITY_BUILD_TIMESTAMP__}`
+
 /**
  * Workspace configuration for the Studio manifest.
  * @internal
@@ -98,6 +102,7 @@ async function generateStudioManifest(
   )
 
   return {
+    buildId,
     // Filter out null entries (workspaces without schemaDescriptorId)
     workspaces: workspaceManifests.filter((config): config is WorkspaceManifest => config !== null),
   }


### PR DESCRIPTION
### Description

Added a build timestamp to the Studio manifest to help identify when a specific build was created. This timestamp is injected at build time via a new `__SANITY_BUILD_TIMESTAMP__` global variable defined in the Vite configuration.

### What to review

- The addition of `__SANITY_BUILD_TIMESTAMP__` in the Vite config
- How the timestamp is accessed and included in the Studio manifest as `buildId`
- The TypeScript handling for the global variable

### Testing

The changes have been tested by verifying that the build timestamp is correctly included in the Studio manifest when building the application.

### Notes for release

Added a build timestamp to the Studio manifest, which can help with debugging and identifying when a specific build was created. This is an internal change that doesn't affect user-facing functionality.