### PR TITLE
fix: `traverse is not a function` error

### DIFF
--- a/packages/@sanity/codegen/src/typescript/expressionResolvers.ts
+++ b/packages/@sanity/codegen/src/typescript/expressionResolvers.ts
@@ -1,17 +1,12 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import {type TransformOptions} from '@babel/core'
+import {type TransformOptions, traverse} from '@babel/core'
 import {Scope} from '@babel/traverse'
 import * as babelTypes from '@babel/types'
 import createDebug from 'debug'
 
 import {parseSourceFile} from './parseSource'
-
-// @babel/traverse is a CJS module masquerading as an ESM module,
-// doing a `import traverse from '@babel/traverse'` causes problems,
-// and using await import('@babel/traverse') allows it to work consistently regardless of host env
-const {default: traverse} = await import('@babel/traverse')
 
 const debug = createDebug('sanity:codegen:findQueries:debug')
 


### PR DESCRIPTION
### Description

Fixes #11368, which is a regression caused by the removal of CJS and the fact that we've shipped dual CJS and ESM since Studio v3 were introduced, but all CLI paths only ever executed in CJS so bugs and issues in the ESM variants were never discovered.

In this case the problem is that `@babel/traverse` is shipping CJS in a way that attempts to be ESM compatible, but actually isn't.
There's detailed info on this on att and publint for this package:
- [Are the types wrong?](https://arethetypeswrong.github.io/?p=%40babel%2Ftraverse%407.28.5)
- [Publint](https://publint.dev/@babel/traverse@7.28.5)

~~The easiest way to solve this in a way that both works with the TypeScript checks, and also works consistently at runtime, regardless of wether `@sanity/codegen` is consumed from a ESM or CJS env, is to use a top-level `await import`, as it always exposes `export default xyz` and `module.exports.default = xyz` in the same way: `const {default: xyz} = await import()`.~~
The easiest way to solve this is to `import {traverse} from '@babel/core'` instead, which we already do here: https://github.com/sanity-io/sanity/blob/e37e861619a056aa09d34ebd0b0bd543c4d4fc65/packages/%40sanity/codegen/src/typescript/findQueriesInSource.ts#L4C47-L4C55

### What to review

Did I miss anything?

### Testing

If the CLI passes we're good. You can also test this with pkg.pr.new below, as well as a tagged release.

### Notes for release

Fixes a regression issue introduced in `sanity@4.20.0` that can cause `sanity schema extract` and `sanity typegen generate` commands to throw an `traverse is not a function"` errors.