### PR TITLE
chore(deps): add get-it to minimumReleaseAgeExclude

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,6 +71,7 @@ minimumReleaseAgeExclude:
   - '@types/*'
   - '@typescript/*'
   - csstype
+  - 'get-it'
   - 'groq-js'
   - 'oxlint'
   - 'oxlint-tsgolint'


### PR DESCRIPTION
### Description
Excludes [`sanity-io/get-it`](https://github.com/sanity-io/get-it) from minimum release age policy.

### What to review
- Should make this mergeable: https://github.com/sanity-io/sanity/pull/11395

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a