### PR TITLE
fix: fix position for telemetry requests which were wrong + make sure that the requests don't have miltiple calls accidentally

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -199,18 +199,16 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
   const toast = useToast()
 
   const handleToggleFullscreen = useCallback(() => {
-    setIsFullscreen((v) => {
-      const next = !v
-      if (next) {
-        telemetry.log(PortableTextInputExpanded)
-      } else {
-        telemetry.log(PortableTextInputCollapsed)
-      }
-      setFullscreenPath(path, next)
-      onFullScreenChange?.(next)
-      return next
-    })
-  }, [onFullScreenChange, setFullscreenPath, path, telemetry])
+    const next = !isFullscreen
+    if (next) {
+      telemetry.log(PortableTextInputExpanded)
+    } else {
+      telemetry.log(PortableTextInputCollapsed)
+    }
+    setFullscreenPath(path, next)
+    onFullScreenChange?.(next)
+    setIsFullscreen(next)
+  }, [telemetry, path, setFullscreenPath, onFullScreenChange, isFullscreen])
 
   // Reset invalidValue if new value is coming in from props
   useEffect(() => {

--- a/packages/sanity/src/core/form/inputs/PortableText/contexts/fullscreen/FullscreenPTEProvider.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/contexts/fullscreen/FullscreenPTEProvider.tsx
@@ -26,24 +26,24 @@ export function FullscreenPTEProvider({children}: FullscreenPTEProviderProps): R
 
   const getFullscreenPath = useCallback(
     (path: Path): string | undefined => {
-      telemetry.log(ClosedPortableTextEditorFullScreen, {
-        path: pathToString(path),
-        origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
-      })
       return fullscreenPaths.find((savedPath) => savedPath === pathToString(path)) ?? undefined
     },
-    [fullscreenPaths, enhancedObjectDialogEnabled, telemetry],
+    [fullscreenPaths],
   )
 
   const setFullscreenPath = useCallback(
     (path: Path, isFullscreen: boolean): void => {
-      telemetry.log(OpenedPortableTextEditorFullScreen, {
-        path: pathToString(path),
-        origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
-      })
       if (isFullscreen) {
+        telemetry.log(OpenedPortableTextEditorFullScreen, {
+          path: pathToString(path),
+          origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
+        })
         setFullscreenPaths([...fullscreenPaths, pathToString(path)])
       } else {
+        telemetry.log(ClosedPortableTextEditorFullScreen, {
+          path: pathToString(path),
+          origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
+        })
         setFullscreenPaths(fullscreenPaths.filter((savedPath) => savedPath !== pathToString(path)))
       }
     },


### PR DESCRIPTION
### Description

The close fullscreen was causing too many requests as it was on the wrong method 
Also noticed that we were making double calls to close the fullscreen when it wasn't needed 

### What to review

What's on the tin

### Testing

All tests should pass,
Manual tests were also done as well as when the full screen is set true as default for ptes

### Notes for release

N/A internal
