### PR TITLE
fix(schema): regression when inline type reference another inline type

### DIFF
--- a/packages/@sanity/schema/src/sanity/extractSchema.ts
+++ b/packages/@sanity/schema/src/sanity/extractSchema.ts
@@ -158,7 +158,7 @@ export function extractSchema(
     // If we have a type that is point to a type, that is pointing to a type, we assume this is a circular reference
     // and we return an inline type referencing it instead
     if (schemaType.type?.name && sortedSchemaTypeNames.indexOf(schemaType.type?.name) > -1) {
-      return {type: 'inline', name: schemaType.name} satisfies InlineTypeNode
+      return {type: 'inline', name: schemaType.type?.name} satisfies InlineTypeNode
     }
 
     if (isStringType(schemaType)) {

--- a/packages/@sanity/schema/test/extractSchema/__snapshots__/extractSchema.test.ts.snap
+++ b/packages/@sanity/schema/test/extractSchema/__snapshots__/extractSchema.test.ts.snap
@@ -5107,3 +5107,39 @@ exports[`Extract schema test > will ignore global document reference types at th
   },
 ]
 `;
+
+exports[`inline regression: inline type that references other inline type 1`] = `
+[
+  {
+    "name": "sanityIcon",
+    "type": "type",
+    "value": {
+      "name": "iconPicker",
+      "type": "inline",
+    },
+  },
+  {
+    "name": "iconPicker",
+    "type": "type",
+    "value": {
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "iconPicker",
+          },
+        },
+        "title": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+          },
+        },
+      },
+      "type": "object",
+    },
+  },
+]
+`;

--- a/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
+++ b/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
@@ -793,3 +793,40 @@ describe('Extract schema test', () => {
     expect(inlineRef.value.dereferencesTo).toBe('thing')
   })
 })
+
+test('inline regression: inline type that references other inline type', () => {
+  const schema = createSchema(
+    {
+      name: 'test',
+      types: [
+        defineType({
+          type: 'iconPicker',
+          title: 'sanityIcon',
+          name: 'sanityIcon',
+        }),
+        defineType({
+          type: 'object',
+          title: 'iconPicker',
+          name: 'iconPicker',
+          fields: [
+            {
+              type: 'string',
+              name: 'title',
+            },
+          ],
+        }),
+      ],
+    },
+    true,
+  )
+
+  const extracted = extractSchema(schema)
+  expect(extracted.map((v) => v.name)).toStrictEqual(['sanityIcon', 'iconPicker'])
+  expect(extracted).toMatchSnapshot()
+  const inlineRef = extracted.find((type) => type.name === 'sanityIcon')
+  expect(inlineRef).toBeDefined()
+  assert(inlineRef !== undefined) // this is a workaround for TS, but leave the expect above for clarity in case of failure
+  assert(inlineRef.type === 'type')
+  assert(inlineRef.value.type === 'inline')
+  expect(inlineRef.value.name).toBe('iconPicker')
+})


### PR DESCRIPTION
### Description

Was using the wrong type name, so it ended up referencing itself 🙃 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Added

Added

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

Fix(schema): Regression when extracting schema with inline type that inlines another type
