### PR TITLE
fix(playwright): allow vercel.app base urls

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -129,18 +129,19 @@ const playwrightConfig: PlaywrightTestConfig = {
   projects: E2E_DEBUG ? [CHROMIUM_PROJECT] : [CHROMIUM_PROJECT, FIREFOX_PROJECT, ...OS_BROWSERS],
 
   /* Run your local dev server before starting the tests */
-  webServer: BASE_URL.includes('.sanity.dev')
-    ? undefined
-    : {
-        /**
-         * If it is running in CI just start the production build assuming that studio is already build
-         * Locally run the dev server
-         */
-        command: CI ? 'pnpm start' : 'pnpm dev',
-        port: 3339,
-        reuseExistingServer: !CI,
-        stdout: 'pipe',
-      },
+  webServer:
+    BASE_URL.includes('.sanity.dev') || BASE_URL.includes('.vercel.app')
+      ? undefined
+      : {
+          /**
+           * If it is running in CI just start the production build assuming that studio is already build
+           * Locally run the dev server
+           */
+          command: CI ? 'pnpm start' : 'pnpm dev',
+          port: 3339,
+          reuseExistingServer: !CI,
+          stdout: 'pipe',
+        },
 }
 
 export default defineConfig(playwrightConfig)


### PR DESCRIPTION
We are seeing build errors (ref: https://github.com/sanity-io/sanity/actions/runs/20025908662/job/57429497155?pr=11382)

Looking at the logs, the `SANITY_E2E_BASE_URL` is being set to `https://e2e-studio-gs8nuyxv5-sanity-sandbox.vercel.app/`