### PR TITLE
chore: test v24.0.0, and v24.x, not v24.x twice

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,22 @@
+name: "Setup Environment"
+description: "Sets up Node.js, pnpm, and installs dependencies"
+
+inputs:
+  node-version:
+    description: "Node.js version to use"
+    required: true
+    default: lts/*
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v4
+
+    - uses: actions/setup-node@v6
+      with:
+        cache: pnpm
+        node-version: ${{ inputs.node-version }}
+
+    - name: Install project dependencies
+      run: pnpm install --ignore-scripts
+      shell: bash

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -82,16 +82,11 @@ jobs:
         run: |
           echo "Only examples files changed, skipping CLI tests"
           exit 0
-      - uses: pnpm/action-setup@v4
-        if: steps.check_release.outputs.skip != 'true' && steps.check_examples_only.outputs.examples_only != 'true'
-      - uses: actions/setup-node@v5
+
+      - uses: ./.github/actions/setup
         if: steps.check_release.outputs.skip != 'true' && steps.check_examples_only.outputs.examples_only != 'true'
         with:
           node-version: ${{ matrix.node }}
-
-      - name: Install project dependencies
-        if: steps.check_release.outputs.skip != 'true' && steps.check_examples_only.outputs.examples_only != 'true'
-        run: pnpm install
 
       - name: Build CLI
         if: steps.check_release.outputs.skip != 'true' && steps.check_examples_only.outputs.examples_only != 'true'

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -28,19 +28,14 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
+
+      - uses: ./.github/actions/setup
 
       - uses: actions/create-github-app-token@v2
         id: app-token
         with:
           app-id: ${{ secrets.ECOSPARK_APP_ID }}
           private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
-
-      - name: Install deps & build
-        run: pnpm install --ignore-scripts
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped

--- a/.github/workflows/depCheck.yml
+++ b/.github/workflows/depCheck.yml
@@ -8,13 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - name: Check for unused/missing dependencies
         id: depcheck

--- a/.github/workflows/e2e-ct.yml
+++ b/.github/workflows/e2e-ct.yml
@@ -19,13 +19,7 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - name: Build packages
         # This warms up the turborepo remote cache
@@ -47,13 +41,7 @@ jobs:
         shardTotal: [2]
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - name: Store Playwright's Version
         id: playwright-version
@@ -96,13 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - name: Download blob reports from Github Actions Artifacts
         uses: actions/download-artifact@v5

--- a/.github/workflows/e2e-embedded.yml
+++ b/.github/workflows/e2e-embedded.yml
@@ -21,13 +21,7 @@ jobs:
         project: [chromium, firefox]
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - name: Store Playwright's Version
         id: playwright-version
@@ -63,13 +57,7 @@ jobs:
         project: [chromium, firefox]
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - name: Store Playwright's Version
         id: playwright-version

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -17,12 +17,7 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - run: pnpm install
+      - uses: ./.github/actions/setup
       - name: Patch increment version in package.json
         id: npm-version
         shell: bash
@@ -50,17 +45,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           repository: sanity-io/sanity
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
+      - uses: ./.github/actions/setup
 
       - uses: actions/download-artifact@v5
         with:
           name: pack-sanity-ui
           path: artifacts
-      - name: Install project dependencies
-        run: pnpm install
+
       # For this trick to work there needs to be a `"@sanity/ui@3": "$@sanity/ui"` override in the root package.json, with a `@sanity/ui` entry in `devDependencies`
       - run: pnpm add -w ./artifacts/sanity-ui-*.tgz
 
@@ -84,17 +75,12 @@ jobs:
       - uses: actions/checkout@v5
         with:
           repository: sanity-io/sanity
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
+      - uses: ./.github/actions/setup
       - uses: actions/download-artifact@v5
         with:
           name: pack-sanity-ui
           path: artifacts
 
-      - name: Install project dependencies
-        run: pnpm install
       - run: pnpm add -w ./artifacts/sanity-ui-*.tgz
 
       - name: Store Playwright's Version
@@ -152,10 +138,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           repository: sanity-io/sanity
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
+      - uses: ./.github/actions/setup
       - uses: actions/download-artifact@v5
         with:
           name: pack-sanity-ui
@@ -215,13 +198,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           repository: sanity-io/sanity
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - name: Download blob reports from Github Actions Artifacts
         uses: actions/download-artifact@v5

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,10 +32,7 @@ jobs:
         project: [chromium, firefox]
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
+      - uses: ./.github/actions/setup
 
       - name: Add PR Comment placeholder for e2e Preview Environment
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
@@ -56,9 +53,6 @@ jobs:
             ### 📊 Playwright Test Report
 
             Waiting for E2E tests to finish…
-
-      - name: Install project dependencies
-        run: pnpm install
 
       - name: Store Playwright's Version
         id: playwright-version
@@ -87,16 +81,10 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
+      - uses: ./.github/actions/setup
 
       - name: Echo Vercel preview URL
         run: echo ${{ github.event.deployment_status.target_url }}
-
-      - name: Install project dependencies
-        run: pnpm install
 
       - name: Build CLI
         if: ${{ github.event_name == 'pull_request' }}
@@ -133,13 +121,7 @@ jobs:
       preview_url: ${{ steps.deploy.outputs.DEPLOY_URL }}
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - name: Pull Vercel Environment Information
         env:
@@ -243,14 +225,9 @@ jobs:
         shardTotal: [4]
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
       - name: Echo the base URL
         run: echo "$SANITY_E2E_BASE_URL"
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - name: Store Playwright's Version
         id: playwright-version
@@ -314,13 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - name: Download blob reports from Github Actions Artifacts
         uses: actions/download-artifact@v5

--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -33,13 +33,7 @@ jobs:
       preview_url: ${{ steps.deploy-preview.outputs.DEPLOY_URL }}
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - name: Pull Vercel Environment Information
         env:
@@ -133,10 +127,7 @@ jobs:
         shardTotal: [3]
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
+      - uses: ./.github/actions/setup
 
       - name: Add PR comment placeholder
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
@@ -147,9 +138,6 @@ jobs:
             ### ⚡️ Editor Performance Report
 
             Deploying studio and running performance tests…
-
-      - name: Install project dependencies
-        run: pnpm install
 
       - name: Store Playwright's Version
         id: playwright-version
@@ -216,16 +204,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
 
       - name: remove node_modules in folder efps
         run: rm -rf ./dev/efps/node_modules && rm -rf pnpm-lock.yaml
 
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - name: Download blob reports from Github Actions Artifacts
         uses: actions/download-artifact@v5

--- a/.github/workflows/formatCheck.yml
+++ b/.github/workflows/formatCheck.yml
@@ -17,13 +17,7 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - name: Cache Prettier
         uses: actions/cache@v4

--- a/.github/workflows/generate-dts-tests-if-needed.yml
+++ b/.github/workflows/generate-dts-tests-if-needed.yml
@@ -21,13 +21,7 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - name: Generate DTS exports
         run: pnpm generate:dts-exports

--- a/.github/workflows/lint-fix-if-needed.yml
+++ b/.github/workflows/lint-fix-if-needed.yml
@@ -21,13 +21,7 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - name: Cache Prettier
         uses: actions/cache@v4

--- a/.github/workflows/lintPr.yml
+++ b/.github/workflows/lintPr.yml
@@ -22,13 +22,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # needed for the --affected flag in turbo to work correctly
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - name: Oxlint files
         run: pnpm turbo run check:oxlint -- --format github

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -11,13 +11,7 @@ jobs:
     if: github.event_name == 'deployment_status' && github.event.deployment.environment == 'production' && github.event.deployment_status.state == 'success' && startsWith(github.event.deployment_status.target_url, 'https://performance-studio')
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - name: Store Playwright's Version
         id: playwright-version

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -20,13 +20,7 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - id: pre-flight
         run: |

--- a/.github/workflows/pnpm-if-needed.yml
+++ b/.github/workflows/pnpm-if-needed.yml
@@ -22,13 +22,7 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install --config.ignore-scripts=true
+      - uses: ./.github/actions/setup
 
       - run: pnpm dedupe --config.ignore-scripts=true
       - uses: actions/create-github-app-token@v2

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -14,13 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
+      - uses: ./.github/actions/setup
 
       - name: Remove E2E datasets for closed PRs
         env:

--- a/.github/workflows/react-compiler.yml
+++ b/.github/workflows/react-compiler.yml
@@ -18,10 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
+      - uses: ./.github/actions/setup
       - run: pnpm -r up --ignore-scripts react-compiler-runtime@latest babel-plugin-react-compiler@latest eslint-plugin-react-hooks@latest
       - uses: actions/create-github-app-token@v2
         id: generate-token

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -32,13 +32,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install deps
-        run: pnpm install --ignore-scripts
+      - uses: ./.github/actions/setup
 
       - name: Bump canary versions
         # Note: ubuntu-latest ships with lerna installed on the system

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -32,13 +32,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
 
-      - name: Install deps
-        run: pnpm install --ignore-scripts
+      - uses: ./.github/actions/setup
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped
@@ -103,13 +98,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install deps
-        run: pnpm install --ignore-scripts
+      - uses: ./.github/actions/setup
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped
@@ -146,13 +135,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install deps
-        run: pnpm install --ignore-scripts
+      - uses: ./.github/actions/setup
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped

--- a/.github/workflows/release-next-major.yml
+++ b/.github/workflows/release-next-major.yml
@@ -32,13 +32,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install deps
-        run: pnpm install --ignore-scripts
+      - uses: ./.github/actions/setup
 
       - name: Bump with conventional commits
         # Note: ubuntu-latest ships with lerna installed on the system

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -36,13 +36,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install deps
-        run: pnpm install --ignore-scripts
+      - uses: ./.github/actions/setup
 
       - name: Bump canary versions
         # Note: ubuntu-latest ships with lerna installed on the system

--- a/.github/workflows/tag-latest.yml
+++ b/.github/workflows/tag-latest.yml
@@ -51,13 +51,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install deps
-        run: pnpm install --ignore-scripts
+      - uses: ./.github/actions/setup
 
       - name: Set publishing config
         run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_PUBLISH_TOKEN}"
@@ -102,13 +96,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install deps
-        run: pnpm install --ignore-scripts
+      - uses: ./.github/actions/setup
 
       - name: Update manifest with latest tag (staging)
         env:

--- a/.github/workflows/tag-stable.yml
+++ b/.github/workflows/tag-stable.yml
@@ -51,13 +51,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install deps
-        run: pnpm install --ignore-scripts
+      - uses: ./.github/actions/setup
 
       - name: Set publishing config
         run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_PUBLISH_TOKEN}"
@@ -102,13 +96,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install deps
-        run: pnpm install --ignore-scripts
+      - uses: ./.github/actions/setup
 
       - name: Update manifest with stable tag (staging)
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,16 +70,11 @@ jobs:
         run: |
           echo "Only examples files changed, skipping unit tests"
           exit 0
-      - uses: pnpm/action-setup@v4
-        if: steps.check_examples_only.outputs.examples_only != 'true'
-      - uses: actions/setup-node@v5
+
+      - uses: ./.github/actions/setup
         if: steps.check_examples_only.outputs.examples_only != 'true'
         with:
           node-version: ${{ matrix.node }}
-
-      - name: Install project dependencies
-        if: steps.check_examples_only.outputs.examples_only != 'true'
-        run: pnpm install
 
       - name: Build packages
         if: steps.check_examples_only.outputs.examples_only != 'true'
@@ -152,16 +147,8 @@ jobs:
           echo "Only examples files changed, skipping coverage report"
           exit 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: ./.github/actions/setup
         if: steps.check_examples_only.outputs.examples_only != 'true'
-      - uses: actions/setup-node@v5
-        if: steps.check_examples_only.outputs.examples_only != 'true'
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        if: steps.check_examples_only.outputs.examples_only != 'true'
-        run: pnpm install
 
       - name: "Download coverage artifacts"
         if: steps.check_examples_only.outputs.examples_only != 'true'

--- a/.github/workflows/testExports.yml
+++ b/.github/workflows/testExports.yml
@@ -43,16 +43,9 @@ jobs:
         run: |
           echo "Only examples files changed, skipping export tests"
           exit 0
-      - uses: pnpm/action-setup@v4
-        if: steps.check_examples_only.outputs.examples_only != 'true'
-      - uses: actions/setup-node@v5
-        if: steps.check_examples_only.outputs.examples_only != 'true'
-        with:
-          node-version: lts/*
 
-      - name: Install project dependencies
+      - uses: ./.github/actions/setup
         if: steps.check_examples_only.outputs.examples_only != 'true'
-        run: pnpm install
 
       - name: Check export conditions in native node ESM and CJS, and TypeScript DTS
         if: steps.check_examples_only.outputs.examples_only != 'true'

--- a/.github/workflows/typeCheck.yml
+++ b/.github/workflows/typeCheck.yml
@@ -11,14 +11,7 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: lts/*
-
-      - name: Install project dependencies
-        run: pnpm install
-
+      - uses: ./.github/actions/setup
       - name: Check type system
         # Turbo will run type checks on all files in the project
         # and ensure that dependencies are built with @sanity/pkg-utils to output dts


### PR DESCRIPTION
### Description

We're currently running the same v24 cli test **twice**, since `24.0` as `node-version` is resolved to `24` by the GH worker. While `24.0.0` stays `24.0.0`.
By having them separate, as per the original intention, it'll hopefully reduce flake that we've seen since we doubled the matrix size for the CLI suite.
While at it I reduced some boilerplate by adopting the `setup/action.yml` convention we've started using on other monorepos to keep the way we setup `node` and `pnpm`, and then run `pnpm install` to a single file.

We should probably do the same with the playwright boilerplate.

### What to review

All good?

### Testing

If the CI is happy we're good to merge.

### Notes for release

N/A
