### PR TITLE
chore: upgrade groq-js to 1.23.0

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -66,7 +66,7 @@
     "esbuild-register": "catalog:",
     "get-it": "^8.6.10",
     "get-latest-version": "^5.1.0",
-    "groq-js": "^1.22.0",
+    "groq-js": "^1.23.0",
     "pkg-dir": "^5.0.0",
     "prettier": "catalog:",
     "semver": "^7.7.2"

--- a/packages/@sanity/codegen/package.json
+++ b/packages/@sanity/codegen/package.json
@@ -57,7 +57,7 @@
     "debug": "^4.4.3",
     "globby": "^11.1.0",
     "groq": "workspace:*",
-    "groq-js": "^1.22.0",
+    "groq-js": "^1.23.0",
     "json5": "^2.2.3",
     "tsconfig-paths": "^4.2.0",
     "zod": "^3.25.76"

--- a/packages/@sanity/migrate/package.json
+++ b/packages/@sanity/migrate/package.json
@@ -53,7 +53,7 @@
     "arrify": "^2.0.1",
     "debug": "^4.4.3",
     "fast-fifo": "^1.3.2",
-    "groq-js": "^1.22.0",
+    "groq-js": "^1.23.0",
     "p-map": "^7.0.1"
   },
   "devDependencies": {

--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -61,7 +61,7 @@
     "@sanity/generate-help-url": "^3.0.1",
     "@sanity/types": "workspace:*",
     "arrify": "^2.0.1",
-    "groq-js": "^1.22.0",
+    "groq-js": "^1.23.0",
     "humanize-list": "^1.0.1",
     "leven": "^3.1.0",
     "lodash": "^4.17.21",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -201,7 +201,7 @@
     "fast-deep-equal": "3.1.3",
     "form-data": "^4.0.5",
     "get-it": "^8.6.10",
-    "groq-js": "^1.22.0",
+    "groq-js": "^1.23.0",
     "gunzip-maybe": "^1.4.2",
     "history": "^5.3.0",
     "i18next": "^23.16.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,13 +100,13 @@ importers:
     devDependencies:
       '@lerna-lite/cli':
         specifier: ^4.9.4
-        version: 4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@lerna-lite/version@4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@types/node@24.10.2)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0))(@types/node@24.10.2)(babel-plugin-macros@3.1.0)
+        version: 4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@lerna-lite/version@4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0))(@types/node@24.10.1)(babel-plugin-macros@3.1.0)
       '@lerna-lite/list':
         specifier: ^4.9.4
-        version: 4.9.4(@lerna-lite/publish@4.9.4)(@types/node@24.10.2)(babel-plugin-macros@3.1.0)
+        version: 4.9.4(@lerna-lite/publish@4.9.4)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)
       '@lerna-lite/publish':
         specifier: ^4.9.4
-        version: 4.9.4(@lerna-lite/list@4.9.4)(@types/node@24.10.2)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0)
+        version: 4.9.4(@lerna-lite/list@4.9.4)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0)
       '@repo/bundle-manager':
         specifier: workspace:*
         version: link:packages/@repo/bundle-manager
@@ -136,13 +136,13 @@ importers:
         version: 3.1.11(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.1(react@19.2.1))(react-is@19.2.1)(react@19.2.1)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@19.2.1(react@19.2.1))(react-is@19.2.1)(react@19.2.1))
       '@types/node':
         specifier: ^24.6.1
-        version: 24.10.2
+        version: 24.10.1
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20251128.1
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@24.10.2)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 3.2.4(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@24.10.1)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       conventional-changelog-conventionalcommits:
         specifier: ^9.1.0
         version: 9.1.0
@@ -202,7 +202,7 @@ importers:
         version: 48.12.1(encoding@0.1.13)(rollup@4.53.3)(typescript@5.9.3)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@24.10.2)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@24.10.1)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   dev/auto-updating-studio:
     dependencies:
@@ -520,7 +520,7 @@ importers:
         version: link:../../packages/@repo/utils
       '@sanity/color-input':
         specifier: ^5.0.1
-        version: 5.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react-is@19.2.1)(react@19.2.1)(sanity@packages+sanity)
+        version: 5.0.2(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react-is@19.2.1)(react@19.2.1)(sanity@packages+sanity)
       '@sanity/google-maps-input':
         specifier: ^4.2.0
         version: 4.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react-is@19.2.1)(react@19.2.1)(sanity@packages+sanity)
@@ -630,7 +630,7 @@ importers:
         version: 3.0.6
       '@sanity/color-input':
         specifier: ^5.0.1
-        version: 5.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react-is@19.2.1)(react@19.2.1)(sanity@packages+sanity)
+        version: 5.0.2(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react-is@19.2.1)(react@19.2.1)(sanity@packages+sanity)
       '@sanity/google-maps-input':
         specifier: ^4.2.0
         version: 4.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react-is@19.2.1)(react@19.2.1)(sanity@packages+sanity)
@@ -648,7 +648,7 @@ importers:
         version: link:../../packages/@sanity/migrate
       '@sanity/preview-url-secret':
         specifier: ^3.0.0
-        version: 3.0.0(@sanity/client@7.13.1(debug@4.4.3))(@sanity/icons@3.7.4(react@19.2.1))(sanity@packages+sanity)
+        version: 3.0.0(@sanity/client@7.13.1)(@sanity/icons@3.7.4(react@19.2.1))(sanity@packages+sanity)
       '@sanity/react-loader':
         specifier: ^2.0.0
         version: 2.0.0(@sanity/types@packages+@sanity+types)(react@19.2.1)(typescript@5.9.3)
@@ -1112,8 +1112,8 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0(debug@4.4.3)
       groq-js:
-        specifier: ^1.22.0
-        version: 1.22.0
+        specifier: ^1.23.0
+        version: 1.23.0
       pkg-dir:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1326,8 +1326,8 @@ importers:
         specifier: workspace:*
         version: link:../../groq
       groq-js:
-        specifier: ^1.22.0
-        version: 1.22.0
+        specifier: ^1.23.0
+        version: 1.23.0
       json5:
         specifier: ^2.2.3
         version: 2.2.3
@@ -1401,7 +1401,7 @@ importers:
         version: link:../../@repo/tsconfig
       '@sanity/pkg-utils':
         specifier: 'catalog:'
-        version: 10.1.2(@types/babel__core@7.20.5)(@types/node@24.10.2)(@typescript/native-preview@7.0.0-dev.20251128.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(debug@4.4.3)(typescript@5.9.3)
+        version: 10.1.2(@types/babel__core@7.20.5)(@types/node@24.10.1)(@typescript/native-preview@7.0.0-dev.20251128.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(typescript@5.9.3)
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20251128.1
@@ -1436,8 +1436,8 @@ importers:
         specifier: ^1.3.2
         version: 1.3.2
       groq-js:
-        specifier: ^1.22.0
-        version: 1.22.0
+        specifier: ^1.23.0
+        version: 1.23.0
       p-map:
         specifier: ^7.0.1
         version: 7.0.4
@@ -1543,8 +1543,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       groq-js:
-        specifier: ^1.22.0
-        version: 1.22.0
+        specifier: ^1.23.0
+        version: 1.23.0
       humanize-list:
         specifier: ^1.0.1
         version: 1.0.1
@@ -2008,10 +2008,10 @@ importers:
         version: link:../@sanity/mutator
       '@sanity/presentation-comlink':
         specifier: ^2.0.1
-        version: 2.0.1(@sanity/client@7.13.1(debug@4.4.3))(@sanity/types@packages+@sanity+types)
+        version: 2.0.1(@sanity/client@7.13.1)(@sanity/types@packages+@sanity+types)
       '@sanity/preview-url-secret':
         specifier: ^3.0.0
-        version: 3.0.0(@sanity/client@7.13.1(debug@4.4.3))(@sanity/icons@3.7.4(react@19.2.1))(sanity@packages+sanity)
+        version: 3.0.0(@sanity/client@7.13.1)(@sanity/icons@3.7.4(react@19.2.1))(sanity@packages+sanity)
       '@sanity/schema':
         specifier: workspace:*
         version: link:../@sanity/schema
@@ -2124,8 +2124,8 @@ importers:
         specifier: ^8.6.10
         version: 8.7.0(debug@4.4.3)
       groq-js:
-        specifier: ^1.22.0
-        version: 1.22.0
+        specifier: ^1.23.0
+        version: 1.23.0
       gunzip-maybe:
         specifier: ^1.4.2
         version: 1.4.2
@@ -2372,7 +2372,7 @@ importers:
         version: 3.4.0(@sanity/ui@3.1.11(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react-is@19.2.1)(react@19.2.1))(@types/node@24.10.2)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       '@sanity/visual-editing-csm':
         specifier: ^2.0.26
-        version: 2.0.26(@sanity/client@7.13.1(debug@4.4.3))(@sanity/types@packages+@sanity+types)(typescript@5.9.3)
+        version: 2.0.26(@sanity/client@7.13.1)(@sanity/types@packages+@sanity+types)(typescript@5.9.3)
       '@sentry/types':
         specifier: ^8.55.0
         version: 8.55.0
@@ -5560,12 +5560,12 @@ packages:
       sanity: ^3 || ^4.0.0-0
       styled-components: ^5.2 || ^6
 
-  '@sanity/color-input@5.0.3':
-    resolution: {integrity: sha512-F5snxreLoCeMvvfMSRCmHdjT7dZ4PRHtq1nD4d5mhy/XDL0NRAivqwRxz0PWUPKUA83jq7MCqHwh00VwznqnIg==}
+  '@sanity/color-input@5.0.2':
+    resolution: {integrity: sha512-sBtSZtk8weLkl5u+69X4HpvgItBzRP2Pumwb7C6I1s7sMcW0g8kiLJWebKVPaUjoDohchYdrcu20t8QjAlmXmQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       react: ^18.3 || ^19
-      sanity: ^4.0.0-0 || ^5.0.0-0
+      sanity: ^4
       styled-components: ^6.1
 
   '@sanity/color@3.0.6':
@@ -6178,6 +6178,9 @@ packages:
 
   '@types/node@22.19.2':
     resolution: {integrity: sha512-LPM2G3Syo1GLzXLGJAKdqoU35XvrWzGJ21/7sgZTUpbkBaOasTj8tjwn6w+hCkqaa1TfJ/w67rJSwYItlJ2mYw==}
+
+  '@types/node@24.10.1':
+    resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
 
   '@types/node@24.10.2':
     resolution: {integrity: sha512-WOhQTZ4G8xZ1tjJTvKOpyEVSGgOTvJAfDK3FNFgELyaTpzhdgHVHeqW8V+UJvzF5BT+/B54T/1S2K6gd9c7bbA==}
@@ -9150,8 +9153,8 @@ packages:
   graphmatch@1.1.0:
     resolution: {integrity: sha512-0E62MaTW5rPZVRLyIJZG/YejmdA/Xr1QydHEw3Vt+qOKkMIOE8WDLc9ZX2bmAjtJFZcId4lEdrdmASsEy7D1QA==}
 
-  groq-js@1.22.0:
-    resolution: {integrity: sha512-AKdkUorjSJ0nwCrGP/CMsGnzXgmz+UweL02BUS4skYTI5WHk5hxwUJV1elV97NczsLlV8+euCeQFkzwaWmIhMA==}
+  groq-js@1.23.0:
+    resolution: {integrity: sha512-5NAIMuK8BYLbgvBPimnh+KZOSqp+09gSrtn0kYtstOFNF6lN77bPKHezdJDRRLQvfbR/RWJ7B0ygtG/KbMX90g==}
     engines: {node: '>= 14'}
 
   groq@3.88.1-typegen-experimental.0:
@@ -15190,6 +15193,19 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.2
 
+  '@inquirer/core@10.3.2(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.10.1)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.10.1
+
   '@inquirer/core@10.3.2(@types/node@24.10.2)':
     dependencies:
       '@inquirer/ansi': 1.0.2
@@ -15231,6 +15247,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.2
 
+  '@inquirer/expand@4.0.23(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.10.1)
+      '@inquirer/type': 3.0.10(@types/node@24.10.1)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.10.1
+
   '@inquirer/expand@4.0.23(@types/node@24.10.2)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@24.10.2)
@@ -15263,6 +15287,13 @@ snapshots:
   '@inquirer/figures@1.0.15': {}
 
   '@inquirer/figures@2.0.2': {}
+
+  '@inquirer/input@4.3.1(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.10.1)
+      '@inquirer/type': 3.0.10(@types/node@24.10.1)
+    optionalDependencies:
+      '@types/node': 24.10.1
 
   '@inquirer/input@4.3.1(@types/node@24.10.2)':
     dependencies:
@@ -15370,6 +15401,16 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.2
 
+  '@inquirer/select@4.4.2(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.10.1)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.10.1)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.10.1
+
   '@inquirer/select@4.4.2(@types/node@24.10.2)':
     dependencies:
       '@inquirer/ansi': 1.0.2
@@ -15388,6 +15429,10 @@ snapshots:
       '@inquirer/type': 4.0.2(@types/node@24.10.2)
     optionalDependencies:
       '@types/node': 24.10.2
+
+  '@inquirer/type@3.0.10(@types/node@24.10.1)':
+    optionalDependencies:
+      '@types/node': 24.10.1
 
   '@inquirer/type@3.0.10(@types/node@24.10.2)':
     optionalDependencies:
@@ -15453,10 +15498,10 @@ snapshots:
 
   '@juggle/resize-observer@3.4.0': {}
 
-  '@lerna-lite/cli@4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@lerna-lite/version@4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@types/node@24.10.2)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0))(@types/node@24.10.2)(babel-plugin-macros@3.1.0)':
+  '@lerna-lite/cli@4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@lerna-lite/version@4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0))(@types/node@24.10.1)(babel-plugin-macros@3.1.0)':
     dependencies:
-      '@lerna-lite/core': 4.9.4(@types/node@24.10.2)(babel-plugin-macros@3.1.0)
-      '@lerna-lite/init': 4.9.4(@types/node@24.10.2)(babel-plugin-macros@3.1.0)
+      '@lerna-lite/core': 4.9.4(@types/node@24.10.1)(babel-plugin-macros@3.1.0)
+      '@lerna-lite/init': 4.9.4(@types/node@24.10.1)(babel-plugin-macros@3.1.0)
       '@lerna-lite/npmlog': 4.9.4
       dedent: 1.7.0(babel-plugin-macros@3.1.0)
       dotenv: 17.2.3
@@ -15464,19 +15509,19 @@ snapshots:
       load-json-file: 7.0.1
       yargs: 18.0.0
     optionalDependencies:
-      '@lerna-lite/list': 4.9.4(@lerna-lite/publish@4.9.4)(@types/node@24.10.2)(babel-plugin-macros@3.1.0)
-      '@lerna-lite/publish': 4.9.4(@lerna-lite/list@4.9.4)(@types/node@24.10.2)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0)
-      '@lerna-lite/version': 4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@types/node@24.10.2)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0)
+      '@lerna-lite/list': 4.9.4(@lerna-lite/publish@4.9.4)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)
+      '@lerna-lite/publish': 4.9.4(@lerna-lite/list@4.9.4)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0)
+      '@lerna-lite/version': 4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
       - supports-color
 
-  '@lerna-lite/core@4.9.4(@types/node@24.10.2)(babel-plugin-macros@3.1.0)':
+  '@lerna-lite/core@4.9.4(@types/node@24.10.1)(babel-plugin-macros@3.1.0)':
     dependencies:
-      '@inquirer/expand': 4.0.23(@types/node@24.10.2)
-      '@inquirer/input': 4.3.1(@types/node@24.10.2)
-      '@inquirer/select': 4.4.2(@types/node@24.10.2)
+      '@inquirer/expand': 4.0.23(@types/node@24.10.1)
+      '@inquirer/input': 4.3.1(@types/node@24.10.1)
+      '@inquirer/select': 4.4.2(@types/node@24.10.1)
       '@lerna-lite/npmlog': 4.9.4
       '@npmcli/run-script': 10.0.3
       ci-info: 4.3.1
@@ -15505,9 +15550,9 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  '@lerna-lite/init@4.9.4(@types/node@24.10.2)(babel-plugin-macros@3.1.0)':
+  '@lerna-lite/init@4.9.4(@types/node@24.10.1)(babel-plugin-macros@3.1.0)':
     dependencies:
-      '@lerna-lite/core': 4.9.4(@types/node@24.10.2)(babel-plugin-macros@3.1.0)
+      '@lerna-lite/core': 4.9.4(@types/node@24.10.1)(babel-plugin-macros@3.1.0)
       fs-extra: 11.3.2
       p-map: 7.0.4
       write-json-file: 7.0.0
@@ -15516,11 +15561,11 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  '@lerna-lite/list@4.9.4(@lerna-lite/publish@4.9.4)(@types/node@24.10.2)(babel-plugin-macros@3.1.0)':
+  '@lerna-lite/list@4.9.4(@lerna-lite/publish@4.9.4)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)':
     dependencies:
-      '@lerna-lite/cli': 4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@lerna-lite/version@4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@types/node@24.10.2)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0))(@types/node@24.10.2)(babel-plugin-macros@3.1.0)
-      '@lerna-lite/core': 4.9.4(@types/node@24.10.2)(babel-plugin-macros@3.1.0)
-      '@lerna-lite/listable': 4.9.4(@types/node@24.10.2)(babel-plugin-macros@3.1.0)
+      '@lerna-lite/cli': 4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@lerna-lite/version@4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0))(@types/node@24.10.1)(babel-plugin-macros@3.1.0)
+      '@lerna-lite/core': 4.9.4(@types/node@24.10.1)(babel-plugin-macros@3.1.0)
+      '@lerna-lite/listable': 4.9.4(@types/node@24.10.1)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - '@lerna-lite/exec'
       - '@lerna-lite/publish'
@@ -15531,9 +15576,9 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  '@lerna-lite/listable@4.9.4(@types/node@24.10.2)(babel-plugin-macros@3.1.0)':
+  '@lerna-lite/listable@4.9.4(@types/node@24.10.1)(babel-plugin-macros@3.1.0)':
     dependencies:
-      '@lerna-lite/core': 4.9.4(@types/node@24.10.2)(babel-plugin-macros@3.1.0)
+      '@lerna-lite/core': 4.9.4(@types/node@24.10.1)(babel-plugin-macros@3.1.0)
       columnify: 1.6.0
       tinyrainbow: 3.0.3
     transitivePeerDependencies:
@@ -15551,12 +15596,12 @@ snapshots:
       tinyrainbow: 3.0.3
       wide-align: 1.1.5
 
-  '@lerna-lite/publish@4.9.4(@lerna-lite/list@4.9.4)(@types/node@24.10.2)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0)':
+  '@lerna-lite/publish@4.9.4(@lerna-lite/list@4.9.4)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0)':
     dependencies:
-      '@lerna-lite/cli': 4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@lerna-lite/version@4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@types/node@24.10.2)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0))(@types/node@24.10.2)(babel-plugin-macros@3.1.0)
-      '@lerna-lite/core': 4.9.4(@types/node@24.10.2)(babel-plugin-macros@3.1.0)
+      '@lerna-lite/cli': 4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@lerna-lite/version@4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0))(@types/node@24.10.1)(babel-plugin-macros@3.1.0)
+      '@lerna-lite/core': 4.9.4(@types/node@24.10.1)(babel-plugin-macros@3.1.0)
       '@lerna-lite/npmlog': 4.9.4
-      '@lerna-lite/version': 4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@types/node@24.10.2)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0)
+      '@lerna-lite/version': 4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0)
       '@npmcli/arborist': 9.1.8
       '@npmcli/package-json': 7.0.4
       byte-size: 9.0.1
@@ -15589,11 +15634,11 @@ snapshots:
       - conventional-commits-filter
       - supports-color
 
-  '@lerna-lite/version@4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@types/node@24.10.2)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0)':
+  '@lerna-lite/version@4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0)':
     dependencies:
       '@conventional-changelog/git-client': 2.5.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.2.1)
-      '@lerna-lite/cli': 4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@lerna-lite/version@4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@types/node@24.10.2)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0))(@types/node@24.10.2)(babel-plugin-macros@3.1.0)
-      '@lerna-lite/core': 4.9.4(@types/node@24.10.2)(babel-plugin-macros@3.1.0)
+      '@lerna-lite/cli': 4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@lerna-lite/version@4.9.4(@lerna-lite/list@4.9.4)(@lerna-lite/publish@4.9.4)(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(conventional-commits-filter@5.0.0))(@types/node@24.10.1)(babel-plugin-macros@3.1.0)
+      '@lerna-lite/core': 4.9.4(@types/node@24.10.1)(babel-plugin-macros@3.1.0)
       '@lerna-lite/npmlog': 4.9.4
       '@octokit/plugin-enterprise-rest': 6.0.1
       '@octokit/rest': 22.0.1
@@ -15697,11 +15742,38 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
+  '@microsoft/api-extractor-model@7.32.1(@types/node@24.10.1)':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.0
+      '@rushstack/node-core-library': 5.19.0(@types/node@24.10.1)
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@microsoft/api-extractor-model@7.32.1(@types/node@24.10.2)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.0
       '@rushstack/node-core-library': 5.19.0(@types/node@24.10.2)
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@microsoft/api-extractor@7.55.1(@types/node@24.10.1)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.32.1(@types/node@24.10.1)
+      '@microsoft/tsdoc': 0.16.0
+      '@microsoft/tsdoc-config': 0.18.0
+      '@rushstack/node-core-library': 5.19.0(@types/node@24.10.1)
+      '@rushstack/rig-package': 0.6.0
+      '@rushstack/terminal': 0.19.4(@types/node@24.10.1)
+      '@rushstack/ts-command-line': 5.1.4(@types/node@24.10.1)
+      diff: 8.0.2
+      lodash: 4.17.21
+      minimatch: 10.0.3
+      resolve: 1.22.11
+      semver: 7.5.4
+      source-map: 0.6.1
+      typescript: 5.8.2
     transitivePeerDependencies:
       - '@types/node'
 
@@ -16564,6 +16636,19 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
+  '@rushstack/node-core-library@5.19.0(@types/node@24.10.1)':
+    dependencies:
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1(ajv@8.13.0)
+      fs-extra: 11.3.2
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.11
+      semver: 7.5.4
+    optionalDependencies:
+      '@types/node': 24.10.1
+
   '@rushstack/node-core-library@5.19.0(@types/node@24.10.2)':
     dependencies:
       ajv: 8.13.0
@@ -16577,6 +16662,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.2
 
+  '@rushstack/problem-matcher@0.1.1(@types/node@24.10.1)':
+    optionalDependencies:
+      '@types/node': 24.10.1
+
   '@rushstack/problem-matcher@0.1.1(@types/node@24.10.2)':
     optionalDependencies:
       '@types/node': 24.10.2
@@ -16586,6 +16675,14 @@ snapshots:
       resolve: 1.22.11
       strip-json-comments: 3.1.1
 
+  '@rushstack/terminal@0.19.4(@types/node@24.10.1)':
+    dependencies:
+      '@rushstack/node-core-library': 5.19.0(@types/node@24.10.1)
+      '@rushstack/problem-matcher': 0.1.1(@types/node@24.10.1)
+      supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 24.10.1
+
   '@rushstack/terminal@0.19.4(@types/node@24.10.2)':
     dependencies:
       '@rushstack/node-core-library': 5.19.0(@types/node@24.10.2)
@@ -16593,6 +16690,15 @@ snapshots:
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 24.10.2
+
+  '@rushstack/ts-command-line@5.1.4(@types/node@24.10.1)':
+    dependencies:
+      '@rushstack/terminal': 0.19.4(@types/node@24.10.1)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
 
   '@rushstack/ts-command-line@5.1.4(@types/node@24.10.2)':
     dependencies:
@@ -16686,7 +16792,7 @@ snapshots:
       - codemirror
       - react-is
 
-  '@sanity/color-input@5.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react-is@19.2.1)(react@19.2.1)(sanity@packages+sanity)':
+  '@sanity/color-input@5.0.2(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react-is@19.2.1)(react@19.2.1)(sanity@packages+sanity)':
     dependencies:
       '@sanity/icons': 3.7.4(react@19.2.1)
       '@sanity/ui': 3.1.11(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react-is@19.2.1)(react@19.2.1)
@@ -16726,8 +16832,8 @@ snapshots:
     dependencies:
       '@sanity/client': 7.13.1(debug@4.4.3)
       '@sanity/comlink': 4.0.1
-      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.13.1(debug@4.4.3))(@sanity/types@packages+@sanity+types)
-      '@sanity/visual-editing-csm': 2.0.26(@sanity/client@7.13.1(debug@4.4.3))(@sanity/types@packages+@sanity+types)(typescript@5.9.3)
+      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.13.1)(@sanity/types@packages+@sanity+types)
+      '@sanity/visual-editing-csm': 2.0.26(@sanity/client@7.13.1)(@sanity/types@packages+@sanity+types)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@sanity/types'
       - debug
@@ -16961,6 +17067,68 @@ snapshots:
     dependencies:
       zod: 4.1.13
 
+  '@sanity/pkg-utils@10.1.2(@types/babel__core@7.20.5)(@types/node@24.10.1)(@typescript/native-preview@7.0.0-dev.20251128.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(typescript@5.9.3)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/parser': 7.28.5
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.5)
+      '@babel/types': 7.28.5
+      '@microsoft/api-extractor': 7.55.1(@types/node@24.10.1)
+      '@microsoft/tsdoc-config': 0.18.0
+      '@optimize-lodash/rollup-plugin': 6.0.0(rollup@4.53.3)
+      '@rollup/plugin-alias': 6.0.0(rollup@4.53.3)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.28.5)(@types/babel__core@7.20.5)(rollup@4.53.3)
+      '@rollup/plugin-commonjs': 29.0.0(rollup@4.53.3)
+      '@rollup/plugin-json': 6.1.0(rollup@4.53.3)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.53.3)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.53.3)
+      '@rollup/plugin-terser': 0.4.4(rollup@4.53.3)
+      '@sanity/browserslist-config': 1.0.5
+      '@sanity/parse-package-json': 1.0.1
+      '@vanilla-extract/rollup-plugin': 1.5.0(babel-plugin-macros@3.1.0)(rollup@4.53.3)
+      browserslist: 4.28.1
+      cac: 6.7.14
+      chalk: 5.6.2
+      chokidar: 5.0.0
+      empathic: 2.0.0
+      esbuild: 0.27.1
+      find-config: 1.0.0
+      get-latest-version: 5.1.0(debug@4.4.3)
+      git-url-parse: 16.1.0
+      globby: 16.0.0
+      jsonc-parser: 3.3.1
+      lightningcss: 1.30.2
+      mkdirp: 3.0.1
+      outdent: 0.8.0
+      prettier: 3.7.4
+      pretty-bytes: 7.1.0
+      prompts: 2.4.2
+      recast: 0.23.11
+      rimraf: 6.1.2
+      rolldown: 1.0.0-beta.53
+      rolldown-plugin-dts: 0.18.3(@typescript/native-preview@7.0.0-dev.20251128.1)(rolldown@1.0.0-beta.53)(typescript@5.9.3)
+      rollup: 4.53.3
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.27.1)(rollup@4.53.3)
+      rxjs: 7.8.2
+      treeify: 1.1.0
+      tsx: 4.21.0
+      typescript: 5.9.3
+      uuid: 13.0.0
+      zod: 4.1.13
+      zod-validation-error: 5.0.0(zod@4.1.13)
+    optionalDependencies:
+      babel-plugin-react-compiler: 1.0.0
+    transitivePeerDependencies:
+      - '@ts-macro/tsc'
+      - '@types/babel__core'
+      - '@types/node'
+      - '@typescript/native-preview'
+      - babel-plugin-macros
+      - debug
+      - oxc-resolver
+      - supports-color
+      - vue-tsc
+
   '@sanity/pkg-utils@10.1.2(@types/babel__core@7.20.5)(@types/node@24.10.2)(@typescript/native-preview@7.0.0-dev.20251128.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(debug@4.4.3)(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.28.5
@@ -17023,10 +17191,10 @@ snapshots:
       - supports-color
       - vue-tsc
 
-  '@sanity/presentation-comlink@2.0.1(@sanity/client@7.13.1(debug@4.4.3))(@sanity/types@packages+@sanity+types)':
+  '@sanity/presentation-comlink@2.0.1(@sanity/client@7.13.1)(@sanity/types@packages+@sanity+types)':
     dependencies:
       '@sanity/comlink': 4.0.1
-      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.13.1(debug@4.4.3))(@sanity/types@packages+@sanity+types)
+      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.13.1)(@sanity/types@packages+@sanity+types)
     transitivePeerDependencies:
       - '@sanity/client'
       - '@sanity/types'
@@ -17036,7 +17204,7 @@ snapshots:
       prettier: 3.7.4
       prettier-plugin-packagejson: 2.5.20(prettier@3.7.4)
 
-  '@sanity/preview-url-secret@3.0.0(@sanity/client@7.13.1(debug@4.4.3))(@sanity/icons@3.7.4(react@19.2.1))(sanity@packages+sanity)':
+  '@sanity/preview-url-secret@3.0.0(@sanity/client@7.13.1)(@sanity/icons@3.7.4(react@19.2.1))(sanity@packages+sanity)':
     dependencies:
       '@sanity/client': 7.13.1(debug@4.4.3)
       '@sanity/uuid': 3.0.2
@@ -17048,7 +17216,7 @@ snapshots:
     dependencies:
       '@sanity/client': 7.13.1(debug@4.4.3)
       '@sanity/core-loader': 2.0.0(@sanity/types@packages+@sanity+types)(typescript@5.9.3)
-      '@sanity/visual-editing-csm': 2.0.26(@sanity/client@7.13.1(debug@4.4.3))(@sanity/types@packages+@sanity+types)(typescript@5.9.3)
+      '@sanity/visual-editing-csm': 2.0.26(@sanity/client@7.13.1)(@sanity/types@packages+@sanity+types)(typescript@5.9.3)
       react: 19.2.1
     transitivePeerDependencies:
       - '@sanity/types'
@@ -17071,7 +17239,7 @@ snapshots:
       eventsource: 4.1.0
       find-up: 8.0.0
       get-folder-size: 5.0.0
-      groq-js: 1.22.0
+      groq-js: 1.23.0
       inquirer: 12.11.1(@types/node@24.10.2)
       jiti: 2.6.1
       mime-types: 3.0.2
@@ -17156,7 +17324,7 @@ snapshots:
       '@sanity/mutate': 0.12.6(debug@4.4.3)
       '@sanity/types': 3.99.0(@types/react@19.2.7)(debug@4.4.3)
       groq: 3.88.1-typegen-experimental.0
-      groq-js: 1.22.0
+      groq-js: 1.23.0
       lodash-es: 4.17.21
       reselect: 5.1.1
       rxjs: 7.8.2
@@ -17330,16 +17498,16 @@ snapshots:
       '@types/uuid': 8.3.4
       uuid: 8.3.2
 
-  '@sanity/visual-editing-csm@2.0.26(@sanity/client@7.13.1(debug@4.4.3))(@sanity/types@packages+@sanity+types)(typescript@5.9.3)':
+  '@sanity/visual-editing-csm@2.0.26(@sanity/client@7.13.1)(@sanity/types@packages+@sanity+types)(typescript@5.9.3)':
     dependencies:
       '@sanity/client': 7.13.1(debug@4.4.3)
-      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.13.1(debug@4.4.3))(@sanity/types@packages+@sanity+types)
+      '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.13.1)(@sanity/types@packages+@sanity+types)
       valibot: 1.2.0(typescript@5.9.3)
     transitivePeerDependencies:
       - '@sanity/types'
       - typescript
 
-  '@sanity/visual-editing-types@1.1.8(@sanity/client@7.13.1(debug@4.4.3))(@sanity/types@packages+@sanity+types)':
+  '@sanity/visual-editing-types@1.1.8(@sanity/client@7.13.1)(@sanity/types@packages+@sanity+types)':
     dependencies:
       '@sanity/client': 7.13.1(debug@4.4.3)
     optionalDependencies:
@@ -17351,10 +17519,10 @@ snapshots:
       '@sanity/icons': 3.7.4(react@19.2.1)
       '@sanity/insert-menu': 2.1.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@sanity/types@packages+@sanity+types)(react-dom@19.2.1(react@19.2.1))(react-is@19.2.1)(react@19.2.1)
       '@sanity/mutate': 0.11.0-canary.4(xstate@5.24.0)
-      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.13.1(debug@4.4.3))(@sanity/types@packages+@sanity+types)
-      '@sanity/preview-url-secret': 3.0.0(@sanity/client@7.13.1(debug@4.4.3))(@sanity/icons@3.7.4(react@19.2.1))(sanity@packages+sanity)
+      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.13.1)(@sanity/types@packages+@sanity+types)
+      '@sanity/preview-url-secret': 3.0.0(@sanity/client@7.13.1)(@sanity/icons@3.7.4(react@19.2.1))(sanity@packages+sanity)
       '@sanity/ui': 3.1.11(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react-is@19.2.1)(react@19.2.1)
-      '@sanity/visual-editing-csm': 2.0.26(@sanity/client@7.13.1(debug@4.4.3))(@sanity/types@packages+@sanity+types)(typescript@5.9.3)
+      '@sanity/visual-editing-csm': 2.0.26(@sanity/client@7.13.1)(@sanity/types@packages+@sanity+types)(typescript@5.9.3)
       '@vercel/stega': 0.1.2
       get-random-values-esm: 1.0.2
       react: 19.2.1
@@ -17696,6 +17864,10 @@ snapshots:
   '@types/node@22.19.2':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/node@24.10.1':
+    dependencies:
+      undici-types: 7.16.0
 
   '@types/node@24.10.2':
     dependencies:
@@ -18488,7 +18660,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@24.10.2)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@24.10.1)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -18503,7 +18675,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@24.10.2)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@24.10.1)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -18514,6 +18686,14 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.2.6(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.2.6(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/mocker@3.2.4(vite@7.2.6(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -21348,7 +21528,7 @@ snapshots:
 
   graphmatch@1.1.0: {}
 
-  groq-js@1.22.0:
+  groq-js@1.23.0:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -25599,6 +25779,27 @@ snapshots:
       - supports-color
       - typescript
 
+  vite-node@3.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@8.1.1)
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.2.6(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
@@ -25648,6 +25849,23 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
+  vite@7.2.6(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.53.3
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.10.1
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.30.2
+      terser: 5.44.1
+      tsx: 4.21.0
+      yaml: 2.8.2
+
   vite@7.2.6(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
@@ -25669,6 +25887,50 @@ snapshots:
     dependencies:
       find-up-simple: 1.0.1
       pathe: 2.0.3
+
+  vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@24.10.1)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.2.6(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@8.1.1)
+      expect-type: 1.2.2
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.2.6(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@edge-runtime/vm': 3.2.0
+      '@types/debug': 4.1.12
+      '@types/node': 24.10.1
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@24.10.2)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:


### PR DESCRIPTION
### Description

Upgrade `groq-js` to latest version.

### Notes for release

- upgrade `groq-js` to version `1.23.0`