### PR TITLE
fix(core): always save UTC timezone in date input

### DIFF
--- a/packages/sanity/src/core/hooks/useTimeZone.tsx
+++ b/packages/sanity/src/core/hooks/useTimeZone.tsx
@@ -369,7 +369,10 @@ export const useTimeZone = (scope: TimeZoneScope) => {
     (date: Date) => {
       if (!timeZone) return date
       // Create a TZDate by interpreting the date components as being in the timezone
-      return createTZDateFromComponents(date, timeZone.name)
+      const tzDate = createTZDateFromComponents(date, timeZone.name)
+      // Convert to regular Date to save as UTC instead of preserving timezone offset
+      const utcDate = new Date(tzDate)
+      return utcDate
     },
     [timeZone],
   )


### PR DESCRIPTION
### Description
[When we updated data-fns to v4 we also migrated to `@date-fns/tz`](https://github.com/sanity-io/sanity/pull/11295/) which introduced some issues in the timezone selection, instead of saving the UTC time it was saving the time with the timezone applied to it.
So for example, it was storing values like: `2025-12-09T09:45:15.219-03:00` instead of `2025-12-09T12:45:00.000Z` which is incorrect.
This PR fixes that by restoring the initial intention of the calendar input by saving the utc dates, not the timezone dates.



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in where date time was saved using the selected timezone if the user selected the date from the calendar
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
