### PR TITLE
chore(core): calendar component cleanup and tests

### DIFF
--- a/packages/sanity/src/core/components/inputs/DateInputs/DatePicker.tsx
+++ b/packages/sanity/src/core/components/inputs/DateInputs/DatePicker.tsx
@@ -1,13 +1,6 @@
-import {
-  type ComponentProps,
-  type ForwardedRef,
-  forwardRef,
-  useCallback,
-  useMemo,
-  useState,
-} from 'react'
+import {type ComponentProps, type ForwardedRef, forwardRef, useCallback, useMemo} from 'react'
 
-import {type TimeZoneScope, useTimeZone} from '../../../hooks/useTimeZone'
+import {type TimeZoneScope} from '../../../hooks/useTimeZone'
 import {Calendar, type CalendarProps} from './calendar/Calendar'
 import {type CalendarLabels} from './calendar/types'
 
@@ -44,13 +37,9 @@ export const DatePicker = forwardRef(function DatePicker(
     return now
   }, [_value])
 
-  const {utcToCurrentZoneDate} = useTimeZone(timeZoneScope)
-  const [focusedDate, setFocusedDay] = useState<Date>()
-
   const handleSelect = useCallback(
     (nextDate: Date) => {
       onChange(nextDate)
-      setFocusedDay(undefined)
     },
     [onChange],
   )
@@ -60,10 +49,8 @@ export const DatePicker = forwardRef(function DatePicker(
       {...rest}
       labels={calendarLabels}
       ref={ref}
-      selectedDate={utcToCurrentZoneDate(value)}
+      value={value}
       onSelect={handleSelect}
-      focusedDate={utcToCurrentZoneDate(focusedDate || value)}
-      onFocusedDateChange={setFocusedDay}
       padding={padding}
       showTimeZone={showTimeZone}
       timeZoneScope={timeZoneScope}

--- a/packages/sanity/src/core/components/inputs/DateInputs/calendar/Calendar.tsx
+++ b/packages/sanity/src/core/components/inputs/DateInputs/calendar/Calendar.tsx
@@ -37,13 +37,11 @@ export const MONTH_PICKER_VARIANT = {
 export type CalendarProps = Omit<ComponentProps<'div'>, 'onSelect'> & {
   selectTime?: boolean
   /**
-   * Provide timezone aware date.
+   * Use UTC date for the value, the calendar will display it in the timezone scope.
    */
-  selectedDate: Date
+  value: Date
   timeStep?: number
   onSelect: (date: Date) => void
-  focusedDate: Date
-  onFocusedDateChange: (index: Date) => void
   labels: CalendarLabels
   monthPickerVariant?: (typeof MONTH_PICKER_VARIANT)[keyof typeof MONTH_PICKER_VARIANT]
   padding?: number
@@ -78,9 +76,7 @@ export const Calendar = forwardRef(function Calendar(
 ) {
   const {
     selectTime,
-    onFocusedDateChange,
-    selectedDate: savedSelectedDate,
-    focusedDate: _focusedDate,
+    value,
     timeStep = 1,
     onSelect,
     labels,
@@ -92,9 +88,9 @@ export const Calendar = forwardRef(function Calendar(
     ...restProps
   } = props
 
-  const focusedDate = _focusedDate ?? savedSelectedDate
-
-  const {timeZone, zoneDateToUtc} = useTimeZone(timeZoneScope)
+  const {timeZone, zoneDateToUtc, utcToCurrentZoneDate} = useTimeZone(timeZoneScope)
+  const currentTzDate = useMemo(() => utcToCurrentZoneDate(value), [utcToCurrentZoneDate, value])
+  const [focusedDate, setFocusedDate] = useState<Date>(value)
 
   const [displayMonth, displayYear] = useMemo(() => {
     return [
@@ -105,11 +101,6 @@ export const Calendar = forwardRef(function Calendar(
   }, [focusedDate, timeZone?.name])
 
   const {DialogTimeZone, dialogProps, dialogTimeZoneShow} = useDialogTimeZone(timeZoneScope)
-
-  const setFocusedDate = useCallback(
-    (date: Date) => onFocusedDateChange(date),
-    [onFocusedDateChange],
-  )
 
   const setFocusedDateMonth = useCallback(
     (month: number) => setFocusedDate(setDate(setMonth(focusedDate, month), 1)),
@@ -134,8 +125,8 @@ export const Calendar = forwardRef(function Calendar(
   const handleDateChange = useCallback(
     (date: Date) => {
       const newDate = setMinutes(
-        setHours(date, savedSelectedDate.getHours()),
-        savedSelectedDate.getMinutes(),
+        setHours(date, currentTzDate.getHours()),
+        currentTzDate.getMinutes(),
       )
       if (!timeZone) {
         onSelect(newDate)
@@ -145,28 +136,28 @@ export const Calendar = forwardRef(function Calendar(
       const utcDate = zoneDateToUtc(newDate)
       onSelect(utcDate)
     },
-    [onSelect, savedSelectedDate, timeZone, zoneDateToUtc],
+    [onSelect, currentTzDate, timeZone, zoneDateToUtc],
   )
 
   const handleTimeChange = useCallback(
     (hours: number, mins: number) => {
       if (!timeZone) {
-        onSelect(setHours(setMinutes(savedSelectedDate, mins), hours))
+        onSelect(setHours(setMinutes(currentTzDate, mins), hours))
         return
       }
       // Get the date in the timezone
-      const zonedDate = new TZDate(savedSelectedDate, timeZone.name)
+      const zonedDate = new TZDate(currentTzDate, timeZone.name)
       const newZonedDate = setHours(setMinutes(zonedDate, mins), hours)
       // Convert to regular Date to save as UTC instead of preserving timezone offset
       const utcDate = zoneDateToUtc(newZonedDate)
       onSelect(utcDate)
     },
-    [onSelect, savedSelectedDate, timeZone, zoneDateToUtc],
+    [onSelect, currentTzDate, timeZone, zoneDateToUtc],
   )
 
   const timeFromDate = useMemo(
-    () => format(savedSelectedDate, 'HH:mm', {timeZone: timeZone?.name}),
-    [savedSelectedDate, timeZone?.name],
+    () => format(currentTzDate, 'HH:mm', {timeZone: timeZone?.name}),
+    [currentTzDate, timeZone?.name],
   )
   const [timeValue, setTimeValue] = useState<string | undefined>(timeFromDate)
 
@@ -178,9 +169,9 @@ export const Calendar = forwardRef(function Calendar(
 
   const handleTimeChangeInputChange = useCallback(
     (event: FormEvent<HTMLInputElement>) => {
-      const value = event.currentTarget.value
-      if (value) {
-        const date = parse(value, 'HH:mm', new Date())
+      const nextValue = event.currentTarget.value
+      if (nextValue) {
+        const date = parse(nextValue, 'HH:mm', new Date())
         handleTimeChange(date.getHours(), date.getMinutes())
       } else {
         // Setting the timeValue to undefined will let the input behave correctly as a time input while the user types.
@@ -212,21 +203,21 @@ export const Calendar = forwardRef(function Calendar(
         return
       }
       if (event.key === 'ArrowUp') {
-        onFocusedDateChange(addDays(focusedDate, -7))
+        setFocusedDate(addDays(focusedDate, -7))
       }
       if (event.key === 'ArrowDown') {
-        onFocusedDateChange(addDays(focusedDate, 7))
+        setFocusedDate(addDays(focusedDate, 7))
       }
       if (event.key === 'ArrowLeft') {
-        onFocusedDateChange(addDays(focusedDate, -1))
+        setFocusedDate(addDays(focusedDate, -1))
       }
       if (event.key === 'ArrowRight') {
-        onFocusedDateChange(addDays(focusedDate, 1))
+        setFocusedDate(addDays(focusedDate, 1))
       }
       // set focus temporarily on this element to make sure focus is still inside the calendar-grid after re-render
       ref.current?.querySelector<HTMLElement>('[data-preserve-focus]')?.focus()
     },
-    [ref, focusCurrentWeekDay, onFocusedDateChange, focusedDate],
+    [ref, focusCurrentWeekDay, focusedDate],
   )
 
   useEffect(() => {
@@ -366,7 +357,7 @@ export const Calendar = forwardRef(function Calendar(
             date={focusedDate}
             focused={focusedDate}
             onSelect={handleDateChange}
-            selected={savedSelectedDate}
+            selected={currentTzDate}
             isPastDisabled={isPastDisabled}
           />
           {PRESERVE_FOCUS_ELEMENT}
@@ -417,7 +408,7 @@ export const Calendar = forwardRef(function Calendar(
                         minutes={minutes}
                         onTimeChange={handleTimeChange}
                         text={text}
-                        aria-label={labels.setToTimePreset(text, savedSelectedDate)}
+                        aria-label={labels.setToTimePreset(text, currentTzDate)}
                       />
                     )
                   })}

--- a/packages/sanity/src/core/hooks/useTimeZone.tsx
+++ b/packages/sanity/src/core/hooks/useTimeZone.tsx
@@ -7,7 +7,7 @@ import {useCallback, useEffect, useMemo, useState} from 'react'
 import {useObservable} from 'react-rx'
 import {startWith} from 'rxjs/operators'
 
-import {useKeyValueStore} from '../store'
+import {useKeyValueStore} from '../store/_legacy/datastores'
 import {DATE_FORMAT} from '../studio/timezones/constants'
 import ToastDescription from '../studio/timezones/toastDescription/ToastDescription'
 import {type NormalizedTimeZone} from '../studio/timezones/types'


### PR DESCRIPTION
### Description
Removes duplicated date conversion in the calendar component, which is unnecessary because it's already handled by the `useTimeZone` hook.
Updates some states the calendar receives and simplifies them.
Adds new tests and removes the mock for the `useTimezone` hook, and instead it mocks the `useKeyValueStore` to provide a way to update the selected timezone.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
New tests were added.
Manual tests in the date time input are appreciated.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
