### PR TITLE
fix: restore fonts for schema icon extract

### DIFF
--- a/packages/sanity/src/core/config/createDefaultIcon.tsx
+++ b/packages/sanity/src/core/config/createDefaultIcon.tsx
@@ -1,6 +1,7 @@
 import {COLOR_HUES, hues} from '@sanity/color'
 import {darken, hasBadContrast, lighten, readableColor} from 'color2k'
-import {styled} from 'styled-components'
+import {useState} from 'react'
+import {useTheme} from 'styled-components'
 
 function pseudoRandomNumber(seed: string) {
   const hashCode = seed
@@ -10,24 +11,19 @@ function pseudoRandomNumber(seed: string) {
   return Math.abs((hashCode * 16807) % 2147483647) / 2147483647
 }
 
-const SvgText = styled.text`
-  font-family: ${({theme}) => theme.sanity.fonts.text.family};
-  font-weight: ${({theme}) => theme.sanity.fonts.text.weights.medium};
-  font-size: ${({theme}) => theme.sanity.fonts.text.sizes[1].fontSize}px;
-  transform: translateY(1px);
-`
+const possibleTints = ['300', '400', '500', '600', '700'] as const
 
-/**
- * Creates an icon element based on the input title
- * @internal
- */
-export function createDefaultIcon(title: string, subtitle: string) {
-  const rng1 = pseudoRandomNumber(`${title} ${subtitle}`)
+function DefaultIcon({title, subtitle}: {title: string; subtitle: string}): React.JSX.Element {
+  const theme = useTheme()
+  const fontFamily = theme.sanity.fonts.text.family
+  const fontWeight = theme.sanity.fonts.text.weights.medium
+  const fontSize = `${theme.sanity.fonts.text.sizes[1].fontSize}px`
+
+  const [rng1] = useState(() => pseudoRandomNumber(`${title} ${subtitle}`))
 
   const huesWithoutGray = COLOR_HUES.filter((hue) => hue !== 'gray')
   const colorHue = huesWithoutGray[Math.floor(rng1 * huesWithoutGray.length)]
-  const possibleTints = ['300', '400', '500', '600', '700'] as const
-  const rng2 = pseudoRandomNumber(rng1.toString())
+  const [rng2] = useState(() => pseudoRandomNumber(rng1.toString()))
   const tint = possibleTints[Math.floor(rng2 * possibleTints.length)]
   const color = hues[colorHue][tint].hex
 
@@ -57,16 +53,30 @@ export function createDefaultIcon(title: string, subtitle: string) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
       <rect width={32} height={32} rx={2} fill={color} />
-      <SvgText
+      <text
         x="50%"
         y="50%"
         textAnchor="middle"
         alignmentBaseline="middle"
         dominantBaseline="middle"
         fill={textColor}
+        style={{
+          fontFamily,
+          fontWeight,
+          fontSize,
+          transform: 'translateY(1px)',
+        }}
       >
         {letters}
-      </SvgText>
+      </text>
     </svg>
   )
+}
+
+/**
+ * Creates an icon element based on the input title
+ * @internal
+ */
+export function createDefaultIcon(title: string, subtitle: string) {
+  return <DefaultIcon title={title} subtitle={subtitle} />
 }


### PR DESCRIPTION
### Description

Fixes a regression introduced by #10757 that lead to workspace icons missing their font in dashboard:
<img width="702" height="330" alt="image" src="https://github.com/user-attachments/assets/4066ba3f-1bed-40df-944c-7d4276b2cc2f" />

The cause were that the basic fallback icons needed some styles to set the font:
```html
<style data-styled="true" data-styled-version="6.1.19">
  .legFOJ {
    font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
      "Helvetica Neue", "Liberation Sans", Helvetica, Arial, system-ui,
      sans-serif;
    font-weight: 500;
    font-size: 13px;
    transform: translateY(1px);
  }
  /*!sc*/
  data-styled.g404[id="sc-erobCP"] {
    content: "legFOJ,";
  }
  /*!sc*/
</style>
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
  <rect width="32" height="32" rx="2" fill="#721fe5"></rect>
  <text
    x="50%"
    y="50%"
    text-anchor="middle"
    alignment-baseline="middle"
    fill="hsla(265, 79%, 91%, 1)"
    class="sc-erobCP legFOJ"
  >
    PC
  </text>
</svg>
```

After #10757 it changed to:
```html
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
  <rect width="32" height="32" rx="2" fill="#18e2e2"></rect>
  <text
    x="50%"
    y="50%"
    text-anchor="middle"
    alignment-baseline="middle"
    fill="hsla(180, 81%, 9%, 1)"
    class="sc-gzpDuk hfXNsv"
  >
    OS
  </text>
</svg>
```

With this PR it changes to:
```html
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
  <rect width="32" height="32" rx="2" fill="#ef4434"></rect>
  <text 
    x="50%" 
    y="50%" 
    text-anchor="middle" 
    alignment-baseline="middle" 
    dominant-baseline="middle" 
    fill="hsla(5, 85%, 17%, 1)" 
    style="font-family: Inter, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, &quot;Liberation Sans&quot;, Helvetica, Arial, system-ui, sans-serif; font-weight: 500; font-size: 13px; transform: translateY(1px);"
  >
    PW
  </text>
</svg>
```


### What to review

Missed anything?

### Testing

If tests pass we're good, in order to truly know the issue has resolved we have to test after release.

### Notes for release

Fixes a regression in `v4.20.0` that caused icons in dashboard to miss text styling.
