### PR TITLE
chore(deps): update `@sanity/export` to v6

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -151,7 +151,7 @@
     "@sanity/diff-match-patch": "^3.2.0",
     "@sanity/diff-patch": "^5.0.0",
     "@sanity/eventsource": "^5.0.2",
-    "@sanity/export": "^5.0.1",
+    "@sanity/export": "^6.0.1",
     "@sanity/icons": "^3.7.4",
     "@sanity/id-utils": "^1.0.0",
     "@sanity/image-url": "^2.0.1",

--- a/packages/sanity/src/_internal/cli/actions/media/exportAssetsAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/media/exportAssetsAction.ts
@@ -1,9 +1,8 @@
 import path from 'node:path'
 
 import {type CliCommandAction} from '@sanity/cli'
-import {exportDataset} from '@sanity/export'
+import {exportDataset, type ExportProgress} from '@sanity/export'
 
-import {type ProgressEvent} from '../../commands/dataset/exportDatasetCommand'
 import {MINIMUM_API_VERSION} from './constants'
 import {determineTargetMediaLibrary} from './lib/determineTargetMediaLibrary'
 
@@ -46,7 +45,7 @@ const exportAssetsAction: CliCommandAction<ExportAssetsFlags> = async (args, con
       types: ['sanity.asset'],
       assetConcurrency: DEFAULT_CONCURRENCY,
       mode: 'stream',
-      onProgress: (progress: ProgressEvent) => {
+      onProgress: (progress: ExportProgress) => {
         if (progress.step !== currentStep) {
           spinner.succeed()
           spinner = output.spinner(progress.step).start()
@@ -78,7 +77,7 @@ const exportAssetsAction: CliCommandAction<ExportAssetsFlags> = async (args, con
       },
       // Media Library archives only record asset aspect data. All other data can be safely
       // ommitted.
-      transformDocument: (doc: unknown) => {
+      transformDocument: (doc) => {
         if (
           typeof doc !== 'object' ||
           doc === null ||

--- a/packages/sanity/src/_internal/cli/commands/dataset/exportDatasetCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/dataset/exportDatasetCommand.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 
 import {type CliCommandDefinition, type CliPrompter} from '@sanity/cli'
-import {exportDataset} from '@sanity/export'
+import {exportDataset, type ExportMode, type ExportProgress} from '@sanity/export'
 import {absolutify} from '@sanity/util/fs'
 import prettyMs from 'pretty-ms'
 
@@ -48,7 +48,7 @@ interface ParsedExportFlags {
   overwrite?: boolean
   types?: string[]
   assetConcurrency?: number
-  mode?: string
+  mode?: ExportMode
 }
 
 function parseFlags(rawFlags: ExportFlags): ParsedExportFlags {
@@ -81,21 +81,11 @@ function parseFlags(rawFlags: ExportFlags): ParsedExportFlags {
     flags.overwrite = Boolean(rawFlags.overwrite)
   }
 
-  if (typeof rawFlags.mode !== 'undefined') {
+  if (rawFlags.mode === 'stream' || rawFlags.mode === 'cursor') {
     flags.mode = rawFlags.mode
   }
 
   return flags
-}
-
-/**
- * @internal
- */
-export interface ProgressEvent {
-  step: string
-  update?: boolean
-  current: number
-  total: number
 }
 
 const exportDatasetCommand: CliCommandDefinition<ExportFlags> = {
@@ -162,7 +152,7 @@ const exportDatasetCommand: CliCommandDefinition<ExportFlags> = {
 
     let currentStep = 'Exporting documents...'
     let spinner = output.spinner(currentStep).start()
-    const onProgress = (progress: ProgressEvent) => {
+    const onProgress = (progress: ExportProgress) => {
       if (progress.step !== currentStep) {
         spinner.succeed()
         spinner = output.spinner(progress.step).start()
@@ -178,7 +168,7 @@ const exportDatasetCommand: CliCommandDefinition<ExportFlags> = {
       await exportDataset({
         client,
         dataset,
-        outputPath,
+        outputPath: outputPath === '-' ? process.stdout : outputPath,
         onProgress,
         ...flags,
       })

--- a/packages/sanity/typings/export.d.ts
+++ b/packages/sanity/typings/export.d.ts
@@ -1,3 +1,0 @@
-declare module '@sanity/export' {
-  export function exportDataset(options: any): Promise<void>
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1974,8 +1974,8 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       '@sanity/export':
-        specifier: ^5.0.1
-        version: 5.0.1
+        specifier: ^6.0.1
+        version: 6.0.1
       '@sanity/icons':
         specifier: ^3.7.4
         version: 3.7.4(react@19.2.1)
@@ -5616,8 +5616,8 @@ packages:
   '@sanity/eventsource@5.0.2':
     resolution: {integrity: sha512-/B9PMkUvAlUrpRq0y+NzXgRv5lYCLxZNsBJD2WXVnqZYOfByL9oQBV7KiTaARuObp5hcQYuPfOAVjgXe3hrixA==}
 
-  '@sanity/export@5.0.1':
-    resolution: {integrity: sha512-ATHXvRNup6mTYYxlGXvJpzAodx1GuXfNcIdxy027LmAKPRoUExwp7rg2yfU/Nxu0gvpfeDbUPneJ2H5gPQmNWg==}
+  '@sanity/export@6.0.1':
+    resolution: {integrity: sha512-n9RgFZpGN45Nsx6AvvXLQMKqoDmt9vVPJmRzejR6gMv60YYciaY1Ldm8aw8SelwqFtX2S93lwC/ZGsFY7tybOQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
   '@sanity/generate-help-url@3.0.1':
@@ -16767,14 +16767,13 @@ snapshots:
       event-source-polyfill: 1.0.31
       eventsource: 2.0.2
 
-  '@sanity/export@5.0.1':
+  '@sanity/export@6.0.1':
     dependencies:
       archiver: 7.0.1
       debug: 4.4.3(supports-color@8.1.1)
       get-it: 8.7.0(debug@4.4.3)
       json-stream-stringify: 3.1.6
       p-queue: 9.0.1
-      rimraf: 6.1.2
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a


### PR DESCRIPTION
### Description

Upgrades `@sanity/export` to v6, which now ships types. Also fixed the one breaking change: passing `-` as output path no longer works, instead we manually pass `process.stdout`.

### What to review

Export still works

### Testing

Relying on existing tests.

### Notes for release

None
