### PR TITLE
fix(core): remove redundant tooltips from workspace menu buttons

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/workspace/ManageMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/ManageMenu.tsx
@@ -39,7 +39,6 @@ export function ManageMenu({multipleWorkspaces}: {multipleWorkspaces: boolean}) 
           href={`${envAwareWebsiteUrl}/manage/project/${projectId}`}
           target="_blank"
           icon={CogIcon}
-          tooltipProps={{content: t('user-menu.action.manage-project-aria-label')}}
           text={t('user-menu.action.manage-project-aria-label')}
           // @ts-expect-error -- Custom CSS property for Button component, needs to be unset so the border works as default
           style={{'--card-border-color': 'unset'}}
@@ -51,7 +50,6 @@ export function ManageMenu({multipleWorkspaces}: {multipleWorkspaces: boolean}) 
             href={`${envAwareWebsiteUrl}/manage/project/${projectId}/members?invite=true`}
             target="_blank"
             icon={AddUserIcon}
-            tooltipProps={{content: t('user-menu.action.invite-members')}}
             text={t('user-menu.action.invite-members')}
             // @ts-expect-error -- Custom CSS property for Button component, needs to be unset so the border works as default
             style={{'--card-border-color': 'unset'}}


### PR DESCRIPTION
  ## Summary
  - Removed redundant tooltips from "Manage project" and "Invite members" buttons in the workspace menu
  - These buttons had tooltips showing the exact same text as the visible button labels, which is unnecessary

  Closes [SAPP-3136](https://linear.app/sanity/issue/SAPP-3136/improvement-remove-redundant-tooltip)

## Notes for Release
N/A