### PR TITLE
chore(ci): publish next-major with timestamp based prerelease increment

### DIFF
--- a/.github/workflows/release-next-major.yml
+++ b/.github/workflows/release-next-major.yml
@@ -54,27 +54,29 @@ jobs:
         # A:
         # lerna version does not support --canary (for some reason, it's only supported for lerna publish)
         # When publishing tagged canary releases, we want the version to be:
-        # <conventional-commit-bump>.<commits-ahead>+<commit-hash>
+        # <conventional-commit-bump>.<timestamp>+<commit-hash>
         # However, the lerna version command we run above does not append the commit hash, and it
-        # always sets the <commits-ahead> part to "0"
+        # always sets the <timestamp> part to "0" (because its based on commits ahead.
         # So, in order to get the desired target version, we need to post-process package versions
         # by manually getting the number of commits in the branch since last release, and replace the "0"
-        # with the correct number of commits ahead, and finally append the commit hash.
+        # with the timestamp, and finally append the commit hash.
+        # Its important to use timestamp for next-major, because this branch is regularily rebased on next, which
+        # means the "commits-ahead" number will be repeating
+        # e.g. consider the following timeline:
+        # - v4.10.0 is released from main, next major is 2 commits ahead, v5.0.0-next-major.2 gets released from `next-major`
+        # - v4.11.0 is released from main, next major is rebased against `main`, but still 2 commits ahead
+        # Now, we'll attempt to release v5.0.0-next-major.2, which has already been published, causing conflict during publish.
+        # Using timestamp instead, fixes the issue, as in the above example we'd
+        # get e.g. v5.0.0-next-major.20251210114512 and v5.0.0-next-major.20251210120356
+        # so you might have a release
         run: |
-          COMMIT_COUNT="0" # fallback refcount value
+          INCREMENT=$(date +%Y%m%d%H%M%S)
           COMMIT_HASH=$(git rev-parse --short HEAD)
 
-          TAG_INFO=$(git describe --tags --long --first-parent)
-
-          if [[ $TAG_INFO =~ ^(.+)-([0-9]+)-g([0-9a-f]+)$ ]]; then
-            COMMIT_COUNT="${BASH_REMATCH[2]}"
-          fi
-
-          echo "COMMITS AHEAD: $COMMIT_COUNT"
           echo "COMMIT HASH: $COMMIT_HASH"
 
           for pkg in $(lerna list --all --json | jq -r '.[].location'); do
-            jq --arg commit_count "$COMMIT_COUNT" --arg commit_hash "$COMMIT_HASH" '.version |= sub("\\.0$"; "." + $commit_count + "+"+$commit_hash)' "$pkg/package.json" > "$pkg/package.tmp.json"
+            jq --arg increment "$INCREMENT" --arg commit_hash "$COMMIT_HASH" '.version |= sub("\\.0$"; "." + $increment + "+"+$commit_hash)' "$pkg/package.json" > "$pkg/package.tmp.json"
             mv "$pkg/package.tmp.json" "$pkg/package.json"
           done
 


### PR DESCRIPTION
### Description
Currently, the `next-major` publish workflow uses "commits ahead" as the prerelease increment. Because `next-major` is regularily rebased against `main`, commits ahead is not reliable because as its likely to be repeated after rebasing against `main`, causing the workflow to attempt to publish the same version twice. I've elaborated a bit more in comments in the actual worflow.

Note: in theory we have this issue with our `release-canary` workflow as well, e.g. if the `canary`-branch includes a feat (mandating a minor bump), and is rebased against main after a patch release.

For the `release-next` workflow we should be good, as its released from main which is never rebased.

### Notes for release

n/a