### PR TITLE
fix(manifest): better handling of user application clients

### DIFF
--- a/packages/sanity/src/core/store/userApplications/UserApplicationCacheProvider.tsx
+++ b/packages/sanity/src/core/store/userApplications/UserApplicationCacheProvider.tsx
@@ -1,8 +1,6 @@
 import {type ReactNode, useContext, useMemo} from 'react'
 import {UserApplicationCacheContext} from 'sanity/_singletons'
 
-import {useClient} from '../../hooks/useClient'
-import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
 import {createUserApplicationCache, type UserApplicationCache} from './userApplicationCache'
 
 interface UserApplicationCacheProviderProps {
@@ -15,13 +13,9 @@ interface UserApplicationCacheProviderProps {
  * @internal
  */
 export function UserApplicationCacheProvider({children}: UserApplicationCacheProviderProps) {
-  const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const parentCache = useContext(UserApplicationCacheContext)
 
-  const cache = useMemo(
-    () => parentCache || createUserApplicationCache(client),
-    [parentCache, client],
-  )
+  const cache = useMemo(() => parentCache || createUserApplicationCache(), [parentCache])
 
   return (
     <UserApplicationCacheContext.Provider value={cache}>

--- a/packages/sanity/src/core/store/userApplications/__tests__/userApplicationCache.test.ts
+++ b/packages/sanity/src/core/store/userApplications/__tests__/userApplicationCache.test.ts
@@ -2,6 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {of} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
+import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../studioClient'
 import {createUserApplicationCache, type UserApplication} from '../userApplicationCache'
 
 const TOGGLE = 'toggle.user-application.upload-live-manifest'
@@ -16,25 +17,33 @@ describe('userApplicationCache', () => {
   const mockWithConfig = vi.fn()
   const mockConfig = vi.fn()
 
-  const mockClient = {
-    withConfig: mockWithConfig,
-  } as unknown as SanityClient
-
   const mockConfiguredClient = {
     request: mockRequest,
     config: mockConfig,
   }
+
+  // Helper to create a mock client with a specific projectId
+  const createMockClient = (projectId: string) =>
+    ({
+      withConfig: mockWithConfig,
+      config: vi.fn().mockReturnValue({projectId}),
+    }) as unknown as SanityClient
+
+  // Default mock client for most tests
+  let mockClient: SanityClient
 
   beforeEach(() => {
     vi.clearAllMocks()
     mockWithConfig.mockReturnValue(mockConfiguredClient)
     // Default config returns the projectId that was configured
     mockConfig.mockReturnValue({projectId: 'proj-123'})
+    // Create default client with proj-123
+    mockClient = createMockClient('proj-123')
   })
 
   describe('createUserApplicationCache', () => {
     it('should return an object with get method', () => {
-      const cache = createUserApplicationCache(mockClient)
+      const cache = createUserApplicationCache()
 
       expect(cache).toHaveProperty('get')
       expect(typeof cache.get).toBe('function')
@@ -42,10 +51,7 @@ describe('userApplicationCache', () => {
   })
 
   describe('get', () => {
-    // API response type (without apiHost, which is added by the cache)
-    type ApiUserApplication = Omit<UserApplication, 'apiHost'>
-
-    const mockApps: ApiUserApplication[] = [
+    const mockApps: UserApplication[] = [
       {
         id: 'app-1',
         type: 'studio',
@@ -62,50 +68,34 @@ describe('userApplicationCache', () => {
       },
     ]
 
-    it('should configure client with projectId and fetch apps from API', async () => {
+    it('should configure client with DEFAULT_STUDIO_CLIENT_OPTIONS and fetch apps from API', async () => {
       mockRequest.mockResolvedValueOnce(mockApps)
 
-      const cache = createUserApplicationCache(mockClient)
-      const result = await cache.get('proj-123')
+      const cache = createUserApplicationCache()
+      const result = await cache.get(mockClient)
 
-      expect(mockWithConfig).toHaveBeenCalledWith({
-        projectId: 'proj-123',
-        apiHost: 'https://api.sanity.io',
-      })
+      expect(mockWithConfig).toHaveBeenCalledWith(DEFAULT_STUDIO_CLIENT_OPTIONS)
       expect(mockRequest).toHaveBeenCalledWith({
         method: 'GET',
         url: '/projects/proj-123/user-applications',
         tag: 'user-application-cache.fetch-user-applications',
       })
-      expect(result).toEqual(mockApps.map((app) => ({...app, apiHost: 'https://api.sanity.io'})))
-    })
-
-    it('should configure client with projectId and apiHost when provided', async () => {
-      mockRequest.mockResolvedValueOnce(mockApps)
-
-      const cache = createUserApplicationCache(mockClient)
-      await cache.get('proj-123', 'https://api.example.com')
-
-      expect(mockWithConfig).toHaveBeenCalledWith({
-        projectId: 'proj-123',
-        apiHost: 'https://api.example.com',
-      })
+      expect(result).toEqual(mockApps)
     })
 
     it('should cache results and return cached on subsequent calls', async () => {
       mockRequest.mockResolvedValueOnce(mockApps)
 
-      const cache = createUserApplicationCache(mockClient)
-      const expectedApps = mockApps.map((app) => ({...app, apiHost: 'https://api.sanity.io'}))
+      const cache = createUserApplicationCache()
 
       // First call - should fetch from API
-      const result1 = await cache.get('proj-123')
-      expect(result1).toEqual(expectedApps)
+      const result1 = await cache.get(mockClient)
+      expect(result1).toEqual(mockApps)
       expect(mockRequest).toHaveBeenCalledTimes(1)
 
       // Second call - should return cached result
-      const result2 = await cache.get('proj-123')
-      expect(result2).toEqual(expectedApps)
+      const result2 = await cache.get(mockClient)
+      expect(result2).toEqual(mockApps)
       expect(mockRequest).toHaveBeenCalledTimes(1)
     })
 
@@ -118,95 +108,72 @@ describe('userApplicationCache', () => {
           }),
       )
 
-      const cache = createUserApplicationCache(mockClient)
+      const cache = createUserApplicationCache()
 
-      const [result1, result2] = await Promise.all([cache.get('proj-123'), cache.get('proj-123')])
+      const [result1, result2] = await Promise.all([cache.get(mockClient), cache.get(mockClient)])
 
-      // Both concurrent requests return apps with apiHost
-      const expectedApps = mockApps.map((app) => ({...app, apiHost: 'https://api.sanity.io'}))
-      expect(result1).toEqual(expectedApps)
-      expect(result2).toEqual(expectedApps)
+      expect(result1).toEqual(mockApps)
+      expect(result2).toEqual(mockApps)
     })
 
     it('should return empty array and clear cache on API failure', async () => {
       mockRequest.mockRejectedValueOnce(new Error('Network error'))
 
-      const cache = createUserApplicationCache(mockClient)
-      const result = await cache.get('proj-123')
+      const cache = createUserApplicationCache()
+      const result = await cache.get(mockClient)
 
       expect(result).toEqual([])
 
       // Cache should be cleared, so next call should retry
       mockRequest.mockResolvedValueOnce(mockApps)
-      const result2 = await cache.get('proj-123')
-      expect(result2).toEqual(mockApps.map((app) => ({...app, apiHost: 'https://api.sanity.io'})))
+      const result2 = await cache.get(mockClient)
+      expect(result2).toEqual(mockApps)
       expect(mockRequest).toHaveBeenCalledTimes(2)
     })
 
     it('should handle empty project (no apps)', async () => {
       mockRequest.mockResolvedValueOnce([])
 
-      const cache = createUserApplicationCache(mockClient)
-      const result = await cache.get('proj-empty')
+      const emptyClient = createMockClient('proj-empty')
+      const cache = createUserApplicationCache()
+      const result = await cache.get(emptyClient)
 
       expect(result).toEqual([])
 
       // Second call should also return empty array from cache
-      const result2 = await cache.get('proj-empty')
+      const result2 = await cache.get(emptyClient)
       expect(result2).toEqual([])
       expect(mockRequest).toHaveBeenCalledTimes(1)
     })
 
     it('should cache different projects independently', async () => {
-      const appsProject1: ApiUserApplication[] = [
+      const appsProject1: UserApplication[] = [
         {id: 'app-p1', type: 'studio', projectId: 'proj-1', urlType: 'internal', appHost: 'p1'},
       ]
-      const appsProject2: ApiUserApplication[] = [
+      const appsProject2: UserApplication[] = [
         {id: 'app-p2', type: 'studio', projectId: 'proj-2', urlType: 'internal', appHost: 'p2'},
       ]
 
       mockRequest.mockResolvedValueOnce(appsProject1).mockResolvedValueOnce(appsProject2)
 
-      const cache = createUserApplicationCache(mockClient)
-
-      const expectedApps1 = appsProject1.map((app) => ({...app, apiHost: 'https://api.sanity.io'}))
-      const expectedApps2 = appsProject2.map((app) => ({...app, apiHost: 'https://api.sanity.io'}))
+      const cache = createUserApplicationCache()
+      const client1 = createMockClient('proj-1')
+      const client2 = createMockClient('proj-2')
 
       // First calls - each project fetches from API
-      const result1 = await cache.get('proj-1')
-      const result2 = await cache.get('proj-2')
+      const result1 = await cache.get(client1)
+      const result2 = await cache.get(client2)
 
-      expect(result1).toEqual(expectedApps1)
-      expect(result2).toEqual(expectedApps2)
+      expect(result1).toEqual(appsProject1)
+      expect(result2).toEqual(appsProject2)
       expect(mockRequest).toHaveBeenCalledTimes(2)
 
       // Both projects should be cached
-      const result1Again = await cache.get('proj-1')
-      const result2Again = await cache.get('proj-2')
-      expect(result1Again).toEqual(expectedApps1)
-      expect(result2Again).toEqual(expectedApps2)
+      const result1Again = await cache.get(client1)
+      const result2Again = await cache.get(client2)
+      expect(result1Again).toEqual(appsProject1)
+      expect(result2Again).toEqual(appsProject2)
       expect(mockRequest).toHaveBeenCalledTimes(2) // No additional calls
-    })
-
-    it('should store apiHost on cached apps for subsequent calls', async () => {
-      const appsFromApi: ApiUserApplication[] = [
-        {id: 'app-1', type: 'studio', urlType: 'internal', appHost: 'studio-1'},
-      ]
-      mockRequest.mockResolvedValueOnce(appsFromApi)
-
-      const cache = createUserApplicationCache(mockClient)
-
-      // First call returns original apps from API
-      await cache.get('proj-123', 'https://api.example.com')
-
-      // Second call returns cached apps with apiHost added
-      const result = await cache.get('proj-123')
-
-      expect(result[0]).toEqual({
-        ...appsFromApi[0],
-        apiHost: 'https://api.example.com',
-      })
-      expect(mockRequest).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -215,8 +182,8 @@ describe('userApplicationCache', () => {
       const {getFeatures} = await import('../../../hooks/useFeatureEnabled')
       vi.mocked(getFeatures).mockReturnValueOnce(of([]))
 
-      const cache = createUserApplicationCache(mockClient)
-      const result = await cache.get('proj-123')
+      const cache = createUserApplicationCache()
+      const result = await cache.get(mockClient)
 
       expect(result).toEqual([])
       expect(mockRequest).not.toHaveBeenCalled()
@@ -229,10 +196,10 @@ describe('userApplicationCache', () => {
       const mockApps = [{id: 'app-1', type: 'studio', urlType: 'internal', appHost: 'studio-1'}]
       mockRequest.mockResolvedValueOnce(mockApps)
 
-      const cache = createUserApplicationCache(mockClient)
-      const result = await cache.get('proj-123')
+      const cache = createUserApplicationCache()
+      const result = await cache.get(mockClient)
 
-      expect(result).toEqual(mockApps.map((app) => ({...app, apiHost: 'https://api.sanity.io'})))
+      expect(result).toEqual(mockApps)
       expect(mockRequest).toHaveBeenCalled()
     })
   })

--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -73,16 +73,19 @@ export function StudioProvider({
 
   const _children = useMemo(
     () => (
-      <WorkspaceLoader LoadingComponent={LoadingBlock} ConfigErrorsComponent={ConfigErrorsScreen}>
-        <StudioTelemetryProvider config={config}>
-          <LocaleProvider>
-            <PackageVersionStatusProvider>
-              <MaybeEnableErrorReporting errorReporter={errorReporter} />
-              <ResourceCacheProvider>
-                <UserApplicationCacheProvider>
-                  <AppIdCacheProvider>
-                    <LiveUserApplicationProvider>
-                      <LiveManifestRegisterProvider />
+      <UserApplicationCacheProvider>
+        <LiveUserApplicationProvider>
+          <LiveManifestRegisterProvider />
+          <WorkspaceLoader
+            LoadingComponent={LoadingBlock}
+            ConfigErrorsComponent={ConfigErrorsScreen}
+          >
+            <StudioTelemetryProvider config={config}>
+              <LocaleProvider>
+                <PackageVersionStatusProvider>
+                  <MaybeEnableErrorReporting errorReporter={errorReporter} />
+                  <ResourceCacheProvider>
+                    <AppIdCacheProvider>
                       <ComlinkRouteHandler />
                       <StudioAnnouncementsProvider>
                         <GlobalPerspectiveProvider>
@@ -91,14 +94,14 @@ export function StudioProvider({
                           </DocumentLimitUpsellProvider>
                         </GlobalPerspectiveProvider>
                       </StudioAnnouncementsProvider>
-                    </LiveUserApplicationProvider>
-                  </AppIdCacheProvider>
-                </UserApplicationCacheProvider>
-              </ResourceCacheProvider>
-            </PackageVersionStatusProvider>
-          </LocaleProvider>
-        </StudioTelemetryProvider>
-      </WorkspaceLoader>
+                    </AppIdCacheProvider>
+                  </ResourceCacheProvider>
+                </PackageVersionStatusProvider>
+              </LocaleProvider>
+            </StudioTelemetryProvider>
+          </WorkspaceLoader>
+        </LiveUserApplicationProvider>
+      </UserApplicationCacheProvider>
     ),
     [children, config],
   )

--- a/packages/sanity/src/core/studio/liveUserApplication/LiveUserApplicationProvider.tsx
+++ b/packages/sanity/src/core/studio/liveUserApplication/LiveUserApplicationProvider.tsx
@@ -1,9 +1,12 @@
+import debugit from 'debug'
 import {type ReactNode, useEffect, useMemo, useState} from 'react'
 import {LiveUserApplicationContext} from 'sanity/_singletons'
 
 import {type UserApplication, useUserApplicationCache} from '../../store/userApplications'
 import {useWorkspaces} from '../workspaces'
 import {findUserApplication} from './liveUserApplication'
+
+const debug = debugit('studio:live-user-application')
 
 /** @internal */
 interface LiveUserApplicationProviderProps {
@@ -31,7 +34,7 @@ export function LiveUserApplicationProvider({children}: LiveUserApplicationProvi
         }
       })
       .catch((error) => {
-        console.error('Error when determining live user application id:', error)
+        debug('Error when determining live user application id:', error)
         if (hasSubscriber) {
           setUserApplication(undefined)
         }

--- a/packages/sanity/src/core/studio/liveUserApplication/liveUserApplication.ts
+++ b/packages/sanity/src/core/studio/liveUserApplication/liveUserApplication.ts
@@ -1,11 +1,14 @@
+import {firstValueFrom} from 'rxjs'
+
 import {type WorkspaceSummary} from '../../config/types'
 import {type UserApplication, type UserApplicationCache} from '../../store/userApplications'
 
-function getAppUrl(app: UserApplication): string {
-  const isStaging = app.apiHost !== undefined && app.apiHost.includes('sanity.work')
-  const internalUrlSuffix = isStaging ? 'studio.sanity.work' : 'sanity.studio'
+function getAppUrl(app: UserApplication, internalHost: string): string {
+  if (app.urlType === 'internal') {
+    return `https://${app.appHost}.${internalHost}`
+  }
 
-  return app.urlType === 'internal' ? `https://${app.appHost}.${internalUrlSuffix}` : app.appHost
+  return app.appHost
 }
 
 /**
@@ -28,32 +31,45 @@ export async function findUserApplication(
   cache: UserApplicationCache,
   workspaces: WorkspaceSummary[],
 ): Promise<UserApplication | undefined> {
-  // If configuredAppId is set, fetch it. If the appHost matches the current window location, return the id
-  // Else, for each unique project in the workspaces, fetch the user application by appHost
-
   // Ensure we are running in a browser context
   if (typeof window === 'undefined' || !window.location) {
     return undefined
   }
 
-  // Get unique project IDs from workspaces
-  const entities = Array.from(
-    new Map(
-      workspaces.map((ws) => [ws.projectId, {projectId: ws.projectId, apiHost: ws.apiHost}]),
-    ).values(),
+  if (workspaces.length === 0) {
+    return undefined
+  }
+
+  // If we are guessing the user application, we only check the first workspace. This makes
+  // it easier to explain to end users and provides motivation for users to adopt using `sanity deploy`
+  // In the future we will refactor this to prefer using the user application configured in the CLI.
+  // Note: we don't do this today since we don't know the project id the user application is associated with and CORS.
+  const workspace = workspaces[0]
+  const state = await firstValueFrom(workspace.auth.state)
+  if (!state.authenticated) {
+    return undefined
+  }
+
+  let internalHost = 'sanity.studio'
+  if (workspace.apiHost !== undefined && workspace.apiHost.includes('sanity.work')) {
+    internalHost = 'studio.sanity.work'
+  }
+
+  const userApplications = await cache.get(state.client)
+  const bestMatch = userApplications.reduce<[UserApplication | undefined, string]>(
+    (best, app) => {
+      const appUrl = getAppUrl(app, internalHost)
+      if (
+        appUrl &&
+        currentUrlMatchesApp(window.location, appUrl) &&
+        appUrl.length > best[1].length
+      ) {
+        return [app, appUrl]
+      }
+      return best
+    },
+    [undefined, ''],
   )
 
-  // Fetch all project apps in parallel using the cache and find the best match (longest URL)
-  const allAppsArrays = await Promise.all(entities.map((e) => cache.get(e.projectId, e.apiHost)))
-
-  const bestMatch = allAppsArrays.flat().reduce<UserApplication | undefined>((best, app) => {
-    const appUrl = getAppUrl(app)
-    if (appUrl && currentUrlMatchesApp(window.location, appUrl)) {
-      const bestUrl = best ? getAppUrl(best) : ''
-      return appUrl.length > bestUrl.length ? app : best
-    }
-    return best
-  }, undefined)
-
-  return bestMatch
+  return bestMatch[0]
 }

--- a/packages/sanity/src/core/studio/manifest/LiveManifestRegisterProvider.tsx
+++ b/packages/sanity/src/core/studio/manifest/LiveManifestRegisterProvider.tsx
@@ -1,11 +1,12 @@
 import {useRootTheme} from '@sanity/ui'
+import debugit from 'debug'
 import {useEffect} from 'react'
 
-import {useClient} from '../../hooks/useClient'
-import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
 import {useLiveUserApplication} from '../liveUserApplication/useLiveUserApplication'
 import {useWorkspaces} from '../workspaces'
 import {registerStudioManifest} from './registerLiveStudioManifest'
+
+const debug = debugit('sanity:manifest')
 
 /**
  * Provider that automatically uploads the studio manifest when the Studio loads.
@@ -14,7 +15,6 @@ import {registerStudioManifest} from './registerLiveStudioManifest'
  * @internal
  */
 export function LiveManifestRegisterProvider() {
-  const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const workspaces = useWorkspaces()
   const {userApplication} = useLiveUserApplication()
   const {theme} = useRootTheme()
@@ -25,10 +25,10 @@ export function LiveManifestRegisterProvider() {
       return
     }
     // Upload once when workspaces are available
-    registerStudioManifest(client, userApplication, workspaces, theme).catch((err) => {
-      console.error('Failed to upload studio manifest', err)
+    registerStudioManifest(userApplication, workspaces, theme).catch((err) => {
+      debug('Failed to upload studio manifest', err)
     })
-  }, [client, userApplication, workspaces, theme])
+  }, [userApplication, workspaces, theme])
 
   return null
 }


### PR DESCRIPTION
### Description

- Refactor the live user application and live manifest code to use the workspace clients.
- Moved the UserApplicationCacheProvider, LiveUserApplicationProvider, LiveManifestRegisterProvider to reduce refetching (looking at the test Studio, this may not have any effect since we seem to be reloading the entire Studio when the workspace changes)

### What to review

- Code make sense
- Reduced 401 errors related to `/user-applications` requests

### Testing

- Unit tests pass
- For manual testing, run in dev mode and filter requests for `user-applications`

### Notes for release

This is an internal change related to uploading live manifests.
