### PR TITLE
fix: mcp cli wording

### DIFF
--- a/packages/@sanity/cli/src/actions/init-project/setupMCP.ts
+++ b/packages/@sanity/cli/src/actions/init-project/setupMCP.ts
@@ -110,7 +110,7 @@ async function promptForMCPSetup(
     {
       type: 'checkbox',
       name: 'selectedEditors',
-      message: 'Configure Sanity MCP server',
+      message: 'Configure Sanity MCP server?',
       choices: editorChoices,
     },
   ])
@@ -263,8 +263,8 @@ export async function setupMCP(
     // 6. Write configs for each selected editor
     for (const editor of selected) {
       await writeMCPConfig(editor, token)
-      output.success(`MCP configured for ${editor.name}`)
     }
+    output.success(`MCP configured for ${selected.map((e) => e.name).join(', ')}`)
 
     return selected
   } catch (error) {


### PR DESCRIPTION
### Description

Minor CLI wording fixes for MCP question.
- Add `?` To Configure Sanity MCP server? question. 
    - Fixes GRO-4159
- Displays all configured clients in 1 line e.g. MCP configured for Cursor, Claude Code, VS Code. 
    - Fixes GRO-4160

### Testing
Tested locally

### Notes for release
