### PR TITLE
fix(ci): stop deleting pnpm-lock.yaml in efps merge-reports job

### DIFF
--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -206,7 +206,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: remove node_modules in folder efps
-        run: rm -rf ./dev/efps/node_modules && rm -rf pnpm-lock.yaml
+        run: rm -rf ./dev/efps/node_modules
 
       - uses: ./.github/actions/setup
 


### PR DESCRIPTION
## Summary
- Fixes the `merge-reports` job in the efps workflow which was failing with: `Dependencies lock file is not found`

The job was incorrectly deleting `pnpm-lock.yaml` before running the setup action:
```yaml
run: rm -rf ./dev/efps/node_modules && rm -rf pnpm-lock.yaml
```

Removed the erroneous `rm -rf pnpm-lock.yaml` from the command.

## Test plan
- [x] Verify the efps workflow `merge-reports` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)