### PR TITLE
feat(schema)!: add schema inline hoisting

### DIFF
--- a/packages/@sanity/schema/src/sanity/extractSchema.ts
+++ b/packages/@sanity/schema/src/sanity/extractSchema.ts
@@ -107,6 +107,12 @@ export function extractSchema(
       repeated.delete(objectField)
       return
     }
+    // Skip creating hoisted types for unknown types - there's no point hoisting types we don't understand.
+    // Remove from `repeated` so the field falls through to convertSchemaType in createObject.
+    if (base.type === 'unknown') {
+      repeated.delete(objectField)
+      return
+    }
     schema.push({
       type: 'type',
       name: getGeneratedTypeName(key),

--- a/packages/@sanity/schema/test/extractSchema/__snapshots__/extractSchema.test.ts.snap
+++ b/packages/@sanity/schema/test/extractSchema/__snapshots__/extractSchema.test.ts.snap
@@ -2550,13 +2550,6 @@ exports[`Extract schema test > Can not extract global document references at the
 exports[`Extract schema test > Extracts schema general 1`] = `
 [
   {
-    "name": "media",
-    "type": "type",
-    "value": {
-      "type": "unknown",
-    },
-  },
-  {
     "name": "sanity.imageAsset.reference",
     "type": "type",
     "value": {
@@ -6133,8 +6126,7 @@ exports[`Extract schema test > Extracts schema general 1`] = `
               "optional": true,
               "type": "objectAttribute",
               "value": {
-                "name": "media",
-                "type": "inline",
+                "type": "unknown",
               },
             },
           },

--- a/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
+++ b/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
@@ -227,9 +227,8 @@ describe('Extract schema test', () => {
 
     const extracted = extractSchema(schema)
 
-    expect(extracted.length).toBe(30)
+    expect(extracted.length).toBe(29)
     expect(extracted.map((v) => v.name)).toStrictEqual([
-      'media',
       'sanity.imageAsset.reference',
       'author.reference',
       'deep',


### PR DESCRIPTION
### Description

The PR improves the schema generation by hoisting types used in the schema to avoid code duplication and to improve the resulting schema JSON and TS types.

When testing in `sanity-io/www-sanity-io` there was a reduction in both the `schema.json` (103k→92k) and the generated TS types (19k→17k lines) of ≈9%.

> ⚠️ The order of the output types changes with these changes as the repeated types are pushed to the schema before we iterate over the main schema types, changing the order of the output when later used in type generation.
>
> Also the names of hoisted types _may_ change, depending on during which parent traversal the type is references the second time – this is what determines the name in `pickRepeatedName`.

<details>
As an example here is the schema for `manage.getStarted` in the `www-sanity-io`, looking like this:

```typescript
export const getStarted = defineType({
  name: "manage.getStarted",
  title: "Get Started",
  type: "document",
  fields: [
    defineField({
      name: "systemPrompt",
      type: "learnBlockContent",
      title: "System Prompt",
      description:
        "A preamble or system prompt that will be used to guide the LLM when copying the getting started course as an LLM prompt. This should provide instructions on how the LLM should guide users through the course.",
    }),
    ...
  ]
})
```

**<summary>Before/after example 📉</summary>**

### Before hoising
...the `learnBlockContent` type would be inlined for the `systemPrompt` property.

```typescript
export type ManageGetStarted = {
  _id: string
  _type: "manage.getStarted"
  _createdAt: string
  _updatedAt: string
  _rev: string
  systemPrompt?: Array<
    | {
        children?: Array<
          | {
              marks?: Array<string>
              text?: string
              _type: "span"
              _key: string
            }
          | {
              _ref: string
              _type: "reference"
              _weak?: boolean
              [internalGroqTypeReferenceTo]?: "article"
            }
          | {
              _ref: string
              _type: "reference"
              _weak?: boolean
              [internalGroqTypeReferenceTo]?: "docsOverview"
            }
          | {
              _ref: string
              _type: "reference"
              _weak?: boolean
              _key: string
              [internalGroqTypeReferenceTo]?: "lesson"
            }
          | {
              _ref: string
              _type: "reference"
              _weak?: boolean
              _key: string
              [internalGroqTypeReferenceTo]?: "course"
            }
          | {
              _ref: string
              _type: "reference"
              _weak?: boolean
              _key: string
              [internalGroqTypeReferenceTo]?: "track"
            }
        >
        style?: "normal" | "lead" | "h2" | "h3" | "h4" | "blockquote"
        listItem?: "bullet" | "number" | "task" | "action" | "caution" | "note"
        markDefs?: Array<
          | {
              href?: string
              openInNewWindow?: boolean
              _type: "link"
              _key: string
            }
          | {
              _ref: string
              _type: "reference"
              _weak?: boolean
              [internalGroqTypeReferenceTo]?: "article"
            }
          | {
              _ref: string
              _type: "reference"
              _weak?: boolean
              [internalGroqTypeReferenceTo]?: "docsOverview"
            }
          | {
              _ref: string
              _type: "reference"
              _weak?: boolean
              [internalGroqTypeReferenceTo]?: "lesson"
            }
          | {
              _ref: string
              _type: "reference"
              _weak?: boolean
              [internalGroqTypeReferenceTo]?: "course"
            }
          | {
              asset?: {
                _ref: string
                _type: "reference"
                _weak?: boolean
                [internalGroqTypeReferenceTo]?: "sanity.fileAsset"
              }
              media?: unknown
              _type: "file"
              _key: string
            }
        >
        level?: number
        _type: "block"
        _key: string
      }
    | ({
        _key: string
      } & Code)
    | ({
        _key: string
      } & QuizQuestion)
    | {
        _ref: string
        _type: "reference"
        _weak?: boolean
        _key: string
        [internalGroqTypeReferenceTo]?: "blockquote"
      }
    | {
        asset?: {
          _ref: string
          _type: "reference"
          _weak?: boolean
          [internalGroqTypeReferenceTo]?: "sanity.imageAsset"
        }
        media?: unknown
        hotspot?: SanityImageHotspot
        crop?: SanityImageCrop
        _type: "image"
        _key: string
      }
  >
  tabs?: Array<{
    title?: string
    icon?: {
      asset?: {
        _ref: string
        _type: "reference"
        _weak?: boolean
        [internalGroqTypeReferenceTo]?: "sanity.imageAsset"
      }
      media?: unknown
      hotspot?: SanityImageHotspot
      crop?: SanityImageCrop
      darkModeImage?: {
        asset?: {
          _ref: string
          _type: "reference"
          _weak?: boolean
          [internalGroqTypeReferenceTo]?: "sanity.imageAsset"
        }
        media?: unknown
        hotspot?: SanityImageHotspot
        crop?: SanityImageCrop
        _type: "image"
      }
      _type: "image"
    }
    slug?: Slug
    course?: {
      _ref: string
      _type: "reference"
      _weak?: boolean
      [internalGroqTypeReferenceTo]?: "course"
    }
    _type: "tab"
    _key: string
  }>
  displayTabSwitcherInLessons?: Array<{
    _ref: string
    _type: "reference"
    _weak?: boolean
    _key: string
    [internalGroqTypeReferenceTo]?: "lesson"
  }>
  related?: Array<{
    label?: string
    title?: string
    description?: string
    url?: string
    _type: "relatedResource"
    _key: string
  }>
}
``` 

### After hoisting
...it's instead referencing the `LearnBlockContent` type.

```typescript
export type ManageGetStarted = {
  _id: string
  _type: "manage.getStarted"
  _createdAt: string
  _updatedAt: string
  _rev: string
  systemPrompt?: LearnBlockContent
  tabs?: Array<{
    title?: string
    icon?: {
      asset?: {
        _ref: string
        _type: "reference"
        _weak?: boolean
        [internalGroqTypeReferenceTo]?: "sanity.imageAsset"
      }
      media?: unknown
      hotspot?: SanityImageHotspot
      crop?: SanityImageCrop
      darkModeImage?: {
        asset?: {
          _ref: string
          _type: "reference"
          _weak?: boolean
          [internalGroqTypeReferenceTo]?: "sanity.imageAsset"
        }
        media?: unknown
        hotspot?: SanityImageHotspot
        crop?: SanityImageCrop
        _type: "image"
      }
      _type: "image"
    }
    slug?: Slug
    course?: {
      _ref: string
      _type: "reference"
      _weak?: boolean
      [internalGroqTypeReferenceTo]?: "course"
    }
    _type: "tab"
    _key: string
  }>
  displayTabSwitcherInLessons?: Array<{
    _ref: string
    _type: "reference"
    _weak?: boolean
    _key: string
    [internalGroqTypeReferenceTo]?: "lesson"
  }>
  related?: Array<{
    label?: string
    title?: string
    description?: string
    url?: string
    _type: "relatedResource"
    _key: string
  }>
}
```

</details>

### What to review

The hoisting logic. Especially the bits around which types are hoisted and not.

### Testing

I've manually gone through the types generated from `sanity-io/www-sanity-io` and compared the types. Due to the type hoisting the order of the output types has changed, but it's still deterministic (same input → same output every time).

An automated test for hoisted types has been added.

### Notes for release

Reduced code duplication in schema and generated types by hoisting types that were inlined in the types before.

❗️Marked as a breaking change since the user types will change after generating **and** _possibly_ change references if types get a new name due to where the reference that triggered the hoisting was located. For most project the naming will be the same after this updgrade.