### PR TITLE
fix(cli): use caret for upgrade command, mark react < 19.2.1 as deprecated

### DIFF
--- a/packages/sanity/src/_internal/cli/util/checkStudioDependencyVersions.ts
+++ b/packages/sanity/src/_internal/cli/util/checkStudioDependencyVersions.ts
@@ -132,7 +132,7 @@ function getUpgradeInstructions(pkgs: PackageInfo[]) {
         .map((version) => (semver.coerce(version) || {version: ''}).version)
         .sort(semver.rcompare)
 
-      return `"${pkg.name}@${highestSupported}"`
+      return `"${pkg.name}@^${highestSupported}"`
     })
     .join(' ')
 


### PR DESCRIPTION
### Description
We didn't include a caret in our update instructions which is unfortunate since after #11238 got released we ended up suggesting upgrading to vulnerable React versions.


Before
```
[WARN] The following package versions have been deprecated and should be upgraded:

  react (installed: 18.3.1, want: ^19.2)
  react-dom (installed: 18.3.1, want: ^19.2)

Support for these will be removed in a future release!

  To upgrade, run either:

  npm install "react@19.2.0" "react-dom@19.2.0"

  or

  yarn add "react@19.2.0" "react-dom@19.2.0"

  or

  pnpm add "react@19.2.0" "react-dom@19.2.0"

```

After
```
[WARN] The following package versions have been deprecated and should be upgraded:

  react (installed: 18.3.1, want: ^19.2.1)
  react-dom (installed: 18.3.1, want: ^19.2.1)

Support for these will be removed in a future release!

  To upgrade, run either:

  npm install "react@^19.2.1" "react-dom@^19.2.1"

  or

  yarn add "react@^19.2.1" "react-dom@^19.2.1"

  or

  pnpm add "react@^19.2.1" "react-dom@^19.2.1"
```

### What to review
Makes sense?


### Testing
Install the preview release in a project using react 18, verify that npm run dev (or equivalent) prints the above message

### Notes for release
- Fixes suggested upgrade command for deprecated packages to use caret version range
- Marks React < 19.2.1 as deprecated