### PR TITLE
feat(typegen): use array member generic for object in array

### DIFF
--- a/packages/@sanity/codegen/src/typescript/__tests__/typeGenerator.test.ts
+++ b/packages/@sanity/codegen/src/typescript/__tests__/typeGenerator.test.ts
@@ -190,6 +190,10 @@ describe(TypeGenerator.name, () => {
 
       export declare const internalGroqTypeReferenceTo: unique symbol;
 
+      export type ArrayMember<T> = T & {
+        _key: string;
+      };
+
       // Source: foo.ts
       // Variable: queryFoo
       // Query: *[_type == "foo"]
@@ -294,6 +298,10 @@ describe(TypeGenerator.name, () => {
 
       export declare const internalGroqTypeReferenceTo: unique symbol;
 
+      export type ArrayMember<T> = T & {
+        _key: string;
+      };
+
       // Source: foo.ts
       // Variable: queryFoo
       // Query: *[_type == "foo"]
@@ -361,6 +369,10 @@ describe(TypeGenerator.name, () => {
       export type AllSanitySchemaTypes = Foo | Bar;
 
       export declare const internalGroqTypeReferenceTo: unique symbol;
+
+      export type ArrayMember<T> = T & {
+        _key: string;
+      };
 
       "
     `)
@@ -595,21 +607,25 @@ describe(TypeGenerator.name, () => {
     const result = await typeGenerator.generateTypes({schema})
 
     expect(result.code).toMatchInlineSnapshot(`
-"export type Author = {
-  images: Array<{
-    asset: {
-      _ref: string;
-      _type: "reference";
-      [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
-    };
-  }>;
-};
+      "export type Author = {
+        images: Array<{
+          asset: {
+            _ref: string;
+            _type: "reference";
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+          };
+        }>;
+      };
 
-export type AllSanitySchemaTypes = Author;
+      export type AllSanitySchemaTypes = Author;
 
-export declare const internalGroqTypeReferenceTo: unique symbol;
+      export declare const internalGroqTypeReferenceTo: unique symbol;
 
-"
-`)
+      export type ArrayMember<T> = T & {
+        _key: string;
+      };
+
+      "
+    `)
   })
 })

--- a/packages/@sanity/codegen/src/typescript/constants.ts
+++ b/packages/@sanity/codegen/src/typescript/constants.ts
@@ -3,8 +3,10 @@ import * as t from '@babel/types'
 export const INTERNAL_REFERENCE_SYMBOL = t.identifier('internalGroqTypeReferenceTo')
 export const ALL_SANITY_SCHEMA_TYPES = t.identifier('AllSanitySchemaTypes')
 export const SANITY_QUERIES = t.identifier('SanityQueries')
+export const ARRAY_MEMBER = t.identifier('ArrayMember')
 
 export const RESERVED_IDENTIFIERS = new Set<string>()
 RESERVED_IDENTIFIERS.add(SANITY_QUERIES.name)
 RESERVED_IDENTIFIERS.add(ALL_SANITY_SCHEMA_TYPES.name)
 RESERVED_IDENTIFIERS.add(INTERNAL_REFERENCE_SYMBOL.name)
+RESERVED_IDENTIFIERS.add(ARRAY_MEMBER.name)

--- a/packages/@sanity/codegen/src/typescript/helpers.ts
+++ b/packages/@sanity/codegen/src/typescript/helpers.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 
 import {CodeGenerator} from '@babel/generator'
 import * as t from '@babel/types'
+import {type ObjectTypeNode} from 'groq-js'
 
 import {RESERVED_IDENTIFIERS} from './constants'
 
@@ -56,4 +57,9 @@ export function weakMapMemo<TParam extends object, TReturn>(fn: (arg: TParam) =>
 
 export function generateCode(node: t.Node) {
   return `${new CodeGenerator(node).generate().code.trim()}\n\n`
+}
+
+export function isObjectArrayMember(typeNode: ObjectTypeNode): boolean {
+  const {attributes, rest} = typeNode
+  return '_key' in attributes || (rest?.type === 'object' && '_key' in rest.attributes)
 }


### PR DESCRIPTION
### Description

We're currently repeating the `{ _key: string } & T` pattern over and over again. This PR aims to make the generated types a bit more readable and to reduce code duplication by wrapping the object types in an `ArrayMember` generic that looks like this

```typescript
type ArrayMember<T> = T & { _key: string}
```

For a large schema (70k lines of schema.json) I saw a reduction in the size of the generated types from 12.5k lines to 11k (-12%), while the byte size was reduces less: 252kb to 243 (4%).

<details>
  <summary>Before/after change</summary>

### Before
```typescript
export type Assessment = {
  _id: string
  _type: "assessment"
  _createdAt: string
  _updatedAt: string
  _rev: string
  title?: string
  slug?: Slug
  eyebrow?: string
  description?: string
  sections?: Array<
    {
      _key: string
    } & AssessmentSection
  >
  summary?: AssessmentSummary
  forms?: Array<
    {
      _key: string
    } & FormReference
  >
  summaryText?: BlockContent
  completionCtas?: Array<
    {
      _key: string
    } & Button
  >
  shareTitle?: string
  shareDescription?: string
  seoTitle?: string
}
```

### After
```typescript
export type Assessment = {
  _id: string
  _type: "assessment"
  _createdAt: string
  _updatedAt: string
  _rev: string
  title?: string
  slug?: Slug
  eyebrow?: string
  description?: string
  sections?: Array<ArrayMember<AssessmentSection>>
  summary?: AssessmentSummary
  forms?: Array<ArrayMember<FormReference>>
  summaryText?: BlockContent
  completionCtas?: Array<ArrayMember<Button>>
  shareTitle?: string
  shareDescription?: string
  seoTitle?: string
}

/* ... */

// and at the end of the sanity.types.ts file
export type ArrayMember<T> = T & {
  _key: string
}
```

### What to review

The logic around identifying an array member, and the snapshot diffs.

### Testing

Snapshots has been updated to reflect the change, but for an end user this change does not have an impact on the exported types other than them being less repetetive.

### Notes for release

Reduce size of generated TS by using an `ArrayMember` generic for object array members