### PR TITLE
fix(cli): remove missing appId warning from sanity dev

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/dev/devAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/dev/devAction.ts
@@ -27,7 +27,6 @@ import {upgradePackages} from '../../util/packageManager/upgradePackages'
 import {getSharedServerConfig, gracefulServerDeath} from '../../util/servers'
 import {shouldAutoUpdate} from '../../util/shouldAutoUpdate'
 import {getTimer} from '../../util/timing'
-import {warnAboutMissingAppId} from '../../util/warnAboutMissingAppId'
 
 export interface StartDevServerCommandFlags {
   'host'?: string
@@ -169,14 +168,7 @@ export default async function startSanityDevServer(
     const appId = getAppId({cliConfig, output})
 
     output.print(`${logSymbols.info} Running with auto-updates enabled`)
-    if (!appId) {
-      warnAboutMissingAppId({
-        appType: 'studio',
-        cliConfigPath,
-        output,
-        projectId: cliConfig?.api?.projectId,
-      })
-    }
+
     // Check local versions against deployed versions
     let result: Awaited<ReturnType<typeof compareDependencyVersions>> | undefined
     try {


### PR DESCRIPTION
### Description
when runnint `sanity dev` after initializing a new studio, we currently show a warning saying:

```
⚠ No appId configured. This studio will auto-update to the latest channel.
To enable fine grained version selection, head over to 
https://www.sanity.io/manage/project/:projectId/studios and add the appId 
to the deployment section in sanity.cli.ts.
```

This warning is not really relevant until you have deployed your studio for the first time (and maybe hardly even then), and is likely more confusing to new users than it is helpful.


### Testing


### Notes for release
- Don't show missing appId warning when running sanity dev
