### PR TITLE
fix(deps): add `sanity` to peerDependencies in @sanity/vision

### DIFF
--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -102,6 +102,7 @@
   },
   "peerDependencies": {
     "react": "^18 || ^19.0.0",
+    "sanity": "workspace:^",
     "styled-components": "^6.1.15"
   }
 }


### PR DESCRIPTION
### Description

fixes #11479 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->
this specifically fixes @sanity/vision when [global virtual store](https://pnpm.io/settings#enableglobalvirtualstore) is enabled

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

if you wanted to find similar issues, you could try enabling global virtual store for this repository to potentially surface other resolution issues. I'm not sure if local packages would be linked in the same way though, you may also need to enable [link workspace packages](https://pnpm.io/settings#linkworkspacepackages).

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->


fixes resolution of `@sanity/vision` when used in pnpm with `enableGlobalVirtualStore` set to `true`

