### PR TITLE
fix(cli): mark react < 19.2.2 as deprecated

### DIFF
--- a/packages/sanity/src/_internal/cli/util/checkStudioDependencyVersions.ts
+++ b/packages/sanity/src/_internal/cli/util/checkStudioDependencyVersions.ts
@@ -128,12 +128,12 @@ function listPackages(pkgs: PackageInfo[]) {
 function getUpgradeInstructions(pkgs: PackageInfo[]) {
   const inst = pkgs
     .map((pkg) => {
-      const [highestSupported] = pkg.supported
+      const [recommendedVersion] = pkg.supported
         .concat(pkg.deprecatedBelow || [])
         .map((version) => (semver.coerce(version) || {version: ''}).version)
         .sort(semver.rcompare)
 
-      return `"${pkg.name}@^${highestSupported}"`
+      return `"${pkg.name}@^${recommendedVersion}"`
     })
     .join(' ')
 


### PR DESCRIPTION
### Description
Marks everything below `react` + `react-dom` versions below 19.2.2 as deprecated.

Also noticed that I mistakenly marked < 19.2.1 as _unsupported_ earlier, which it isn't (sanity v4.x still supports react 18.x and 19.x). This PR also reverts that change.

### What to review
Makes sense?

### Testing


### Notes for release
- Marks versions of `react` + `react-dom` below 19.2.2 as deprecated.