### PR TITLE
fix(cli): telemetry in MCP commands

### DIFF
--- a/packages/@sanity/cli/src/__telemetry__/init.telemetry.ts
+++ b/packages/@sanity/cli/src/__telemetry__/init.telemetry.ts
@@ -1,5 +1,7 @@
 import {defineTrace} from '@sanity/telemetry'
 
+import {type EditorName} from '../actions/init-project/setupMCP'
+
 interface StartStep {
   step: 'start'
   flags: Record<string, string | number | undefined | boolean>
@@ -73,6 +75,13 @@ interface SelectPackageManagerStep {
   selectedOption: string
 }
 
+interface MCPSetupStep {
+  step: 'mcpSetup'
+  detectedEditors: EditorName[]
+  configuredEditors: EditorName[]
+  skipped: boolean
+}
+
 type InitStepResult =
   | StartStep
   | LoginStep
@@ -87,6 +96,7 @@ type InitStepResult =
   | SelectTemplateStep
   | UseDefaultPlanCoupon
   | UseDefaultPlanId
+  | MCPSetupStep
 
 export const CLIInitStepCompleted = defineTrace<InitStepResult>({
   name: 'CLI Init Step Completed',

--- a/packages/@sanity/cli/src/commands/mcp/configureMcpCommand.ts
+++ b/packages/@sanity/cli/src/commands/mcp/configureMcpCommand.ts
@@ -1,5 +1,6 @@
 import {detectAvailableEditors, setupMCP} from '../../actions/init-project/setupMCP'
 import {type CliCommandDefinition} from '../../types'
+import {MCPConfigureTrace} from './mcp.telemetry'
 
 const helpText = `
 Examples
@@ -14,18 +15,32 @@ const configureMcpCommand: CliCommandDefinition = {
   signature: '',
   description: 'Configure Sanity MCP server for AI editors (Cursor, VS Code, Claude Code)',
   async action(args, context) {
-    const {output} = context
+    const {output, telemetry} = context
+    const trace = telemetry.trace(MCPConfigureTrace)
 
     // Check for editors first so we can give helpful feedback
     const detected = await detectAvailableEditors()
     if (detected.length === 0) {
       output.print('No supported AI editors detected (Cursor, VS Code, Claude Code).')
       output.print('Visit https://mcp.sanity.io for manual setup instructions.')
+      trace.log({
+        detectedEditors: [],
+        configuredEditors: [],
+      })
+      trace.complete()
       return
     }
 
     // Run the MCP setup flow (reuses init logic)
-    await setupMCP(context, {mcp: true})
+    const mcpResult = await setupMCP(context, {mcp: true})
+    trace.log({
+      detectedEditors: mcpResult.detectedEditors,
+      configuredEditors: mcpResult.configuredEditors,
+    })
+    if (mcpResult.error) {
+      trace.error(mcpResult.error)
+    }
+    trace.complete()
   },
 }
 

--- a/packages/@sanity/cli/src/commands/mcp/mcp.telemetry.ts
+++ b/packages/@sanity/cli/src/commands/mcp/mcp.telemetry.ts
@@ -1,0 +1,14 @@
+import {defineTrace} from '@sanity/telemetry'
+
+import {type EditorName} from '../../actions/init-project/setupMCP'
+
+interface MCPConfigureTraceData {
+  detectedEditors: EditorName[]
+  configuredEditors: EditorName[]
+}
+
+export const MCPConfigureTrace = defineTrace<MCPConfigureTraceData>({
+  name: 'CLI MCP Configure Completed',
+  version: 1,
+  description: 'User completed MCP configuration via CLI',
+})


### PR DESCRIPTION
### Description

Adds telemetry tracking for MCP setup to help debug reported configuration failures and understand adoption.

Tracks:
- detectedEditors / configuredEditors - which AI editors were found and configured
- skipped - whether user opted out (init flow only)
- Errors via trace.error() with full details

Follows existing CLI telemetry patterns (LoginTrace, TypesGeneratedTrace).

### What to review

- Telemetry data structure in init.telemetry.ts and mcp.telemetry.ts
- Changed MCPSetupResult return type in setupMCP.ts to clean up code

### Testing
Manual testing of sanity init and sanity mcp configure flows ✅