### PR TITLE
fix(deps): pin `isomorphic-dompurify` to solve `jsdom` errors on next.js

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -208,7 +208,7 @@
     "import-fresh": "^3.3.1",
     "is-hotkey-esm": "^1.0.0",
     "is-tar": "^1.0.0",
-    "isomorphic-dompurify": "^2.26.0",
+    "isomorphic-dompurify": "2.26.0",
     "jsdom": "catalog:",
     "jsdom-global": "^3.0.2",
     "json-lexer": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2121,8 +2121,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       isomorphic-dompurify:
-        specifier: ^2.26.0
-        version: 2.33.0
+        specifier: 2.26.0
+        version: 2.26.0
       jsdom:
         specifier: 26.1.0
         version: 26.1.0
@@ -9797,9 +9797,9 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
-  isomorphic-dompurify@2.33.0:
-    resolution: {integrity: sha512-pXGR3rAHAXb5Bvr56pc5aV0Lh8laubLo7/60F+soOzDFmwks6MtgDhL7p46VoxLnwgIsjgmVhQpUt4mUlL/XEw==}
-    engines: {node: '>=20.19.5'}
+  isomorphic-dompurify@2.26.0:
+    resolution: {integrity: sha512-nZmoK4wKdzPs5USq4JHBiimjdKSVAOm2T1KyDoadtMPNXYHxiENd19ou4iU/V4juFM6LVgYQnpxCYmxqNP4Obw==}
+    engines: {node: '>=18'}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -21926,7 +21926,7 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  isomorphic-dompurify@2.33.0:
+  isomorphic-dompurify@2.26.0:
     dependencies:
       dompurify: 3.3.0
       jsdom: 26.1.0


### PR DESCRIPTION
### Description

The latest `isomorphic-dompurify` [v2.27.0](https://github.com/kkomelin/isomorphic-dompurify/releases/tag/2.27.0) bumps `jsom` to v27, while `sanity` still uses v26.
This leads to issues when embedding a studio on next.js:
```bash
 ⚠ ./node_modules/isomorphic-dompurify
Package jsdom can't be external
The request jsdom matches serverExternalPackages (or the default list).
The package resolves to a different version when requested from the project directory (26.1.0) compared to the package requested from the importing module (27.1.0).
Make sure to install the same version of the package in both locations.


 ⨯ TypeError: chunk.reason.enqueueModel is not a function
    at ignore-listed frames {
  digest: '3762743190'
```

Fixes #11462, more context on that issues.

### What to review

All good?

### Testing

A pkg.pr.new comment will be posted below that shows testing instructions, you can use https://github.com/sanity-io/template-nextjs-personal-website/issues/39 which currently reproduces the issue when:
1. `npm install && npm run dev`.
2. Open `http://localhost:3000/studio`.
3. The warning shows in the console, if attempting to deploy to vercel the build will either fail, or you'll get a 500 error when visiting `/studio`.

### Notes for release

Fixes an issue affecting studios embedded on next.js with errors like:
```bash
Package jsdom can't be external
The request jsdom matches serverExternalPackages (or the default list).
The package resolves to a different version when requested from the project directory (26.1.0) compared to the package requested from the importing module (27.1.0).
Make sure to install the same version of the package in both locations.
```