### PR TITLE
refactor: fix release scripts

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -79,7 +79,7 @@ jobs:
           done
 
       - name: Re-install after version bump
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped

--- a/.github/workflows/release-next-major.yml
+++ b/.github/workflows/release-next-major.yml
@@ -81,7 +81,7 @@ jobs:
           done
 
       - name: Re-install after version bump
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -83,7 +83,7 @@ jobs:
           done
 
       - name: Re-install after version bump
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped


### PR DESCRIPTION
### Description

Since merging #11480 the `release-next` workflow has been failing with this error:
```bash
 ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with <ROOT>/packages/@sanity/vision/package.json

Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"

  Failure reason:
  specifiers in the lockfile don't match specifiers in package.json:
* 1 dependencies are mismatched:
  - sanity (lockfile: workspace:*, manifest: workspace:^)
```

This PR fixes that by letting the `Re-install after version bump` steps ignore outdated lockfiles.

### What to review

Makes sense?

### Testing

To the best of my knowledge we have to merge this PR to trigger the workflow and know if it works.

### Notes for release

N/A
