### PR TITLE
fix: use the same peer dependency range for vision as regular plugins

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -79,7 +79,7 @@ jobs:
           done
 
       - name: Re-install after version bump
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped

--- a/.github/workflows/release-next-major.yml
+++ b/.github/workflows/release-next-major.yml
@@ -81,7 +81,7 @@ jobs:
           done
 
       - name: Re-install after version bump
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -83,7 +83,7 @@ jobs:
           done
 
       - name: Re-install after version bump
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -102,7 +102,7 @@
   },
   "peerDependencies": {
     "react": "^18 || ^19.0.0",
-    "sanity": "workspace:^",
+    "sanity": "^4.0.0-0 || ^5.0.0-0",
     "styled-components": "^6.1.15"
   }
 }


### PR DESCRIPTION
### Description

Should solve the build issues on `release-next` without introducing new issues. Still preserves the intended fix in #11480.

### What to review

Makes sense?

### Testing

We have to merge to trigger the build that tells if we've recovered.

### Notes for release

N/A