### PR TITLE
chore(ci): upload next-major bundle to staging bucket

### DIFF
--- a/.github/workflows/release-next-major.yml
+++ b/.github/workflows/release-next-major.yml
@@ -105,3 +105,17 @@ jobs:
         run: pnpm -r publish --tag next-major --no-git-checks
         env:
           NPM_CONFIG_PROVENANCE: true
+
+      - name: Build bundles for staging
+        env:
+          SANITY_INTERNAL_ENV: "staging" # sets the __SANITY_STAGING__ global variable to true in built bundles
+        run: pnpm run build:bundle
+
+      # Note: we need to run this after publish so we get the updated version numbers from npx lerna publish
+      # ideally, the flow should be 1) bump packages using lerna version, 2) upload to module cdn, 3) lerna publish to npm from packages
+      - name: Upload bundles to staging bucket
+        env:
+          GOOGLE_PROJECT_ID: ${{ secrets.GCS_STAGING_PROJECT_ID }}
+          GCLOUD_SERVICE_KEY: ${{ secrets.GCS_STAGING_SERVICE_KEY }}
+          GCLOUD_BUCKET: ${{ secrets.GCS_STAGING_BUCKET }}
+        run: pnpm bundle-manager publish --tag=next-major

--- a/packages/@repo/bundle-manager/src/constants.ts
+++ b/packages/@repo/bundle-manager/src/constants.ts
@@ -1,7 +1,7 @@
 export const corePkgs = ['sanity', '@sanity/vision'] as const
 export const appVersion = 'v1'
 
-export const VALID_TAGS = ['latest', 'stable', 'next'] as const
+export const VALID_TAGS = ['latest', 'stable', 'next', 'next-major'] as const
 
 /**
  * How long to keep previous tags around (in seconds) to account for potential delays in manifest propagation.


### PR DESCRIPTION
### Description
Builds and uploads bundles to staging on push to the `next-major`-branch. This allows us to verify that building + uploading bundles works before releasing a new major. The `next-major` tag isn't exposed as something you can select in via /manage, so actually testing auto-updating studios against this tag will likely require some manual edits of the import map in studio build outputs.

### What to review
- Makes sense

### Testing
I've tested locally that bundling works – need to merge to verify that uploading with configured credentials works.

### Notes for release
n/a