### PR TITLE
fix(cli): pass releasesOperation to @sanity/import when using --replace or --missing

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/dataset/importDatasetCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/dataset/importDatasetCommand.ts
@@ -125,6 +125,7 @@ const importDatasetCommand: CliCommandDefinition = {
     } = flags
 
     const operation = getMutationOperation(args.extOptions)
+    const releasesOperation = getReleasesOperation(flags)
     const client = apiClient()
 
     const [file, target] = args.argsWithoutOptions
@@ -258,6 +259,7 @@ const importDatasetCommand: CliCommandDefinition = {
         client: importClient,
         assetsBase,
         operation,
+        releasesOperation,
         onProgress,
         allowFailingAssets,
         allowAssetsInDifferentDataset,
@@ -359,6 +361,17 @@ function getMutationOperation(flags: ParsedImportFlags) {
   }
 
   return 'create'
+}
+
+function getReleasesOperation(flags: ParsedImportFlags): 'fail' | 'ignore' | 'replace' {
+  const {replace, missing} = flags
+  if (replace) {
+    return 'replace'
+  }
+  if (missing) {
+    return 'ignore'
+  }
+  return 'fail'
 }
 
 function getPercentage(opts: ProgressEvent) {


### PR DESCRIPTION
### Description

The `--replace` and `--missing` flags were not working for release system documents because `releasesOperation` was never passed to `sanityImport()`. This caused release imports to always use the default 'fail' behavior, resulting in errors like "there is already a release with that ID" even when `--replace` was specified.

### What to review

That import passes down `--replace` options to `@sanity/import` for content releases.

### Testing

The import command is mostly tested in `@sanity/import`, not sure we need to add tests here.

### Notes for release

**What changed**

Fixed the `--replace` and `--missing` flags for `sanity dataset import` to correctly handle release system documents. Previously, these flags only affected regular documents but not releases, causing errors like "there is already a release with that ID" even when `--replace` was specified.

**How to use**

No change in usage - the existing flags now work as expected.

**Does this affect the docs team?**

No - this is a bug fix for existing documented behavior.