### PR TITLE
test: skip popover while staging is unstable

### DIFF
--- a/e2e/tests/pte/referencesInPopover.spec.ts
+++ b/e2e/tests/pte/referencesInPopover.spec.ts
@@ -2,7 +2,7 @@ import {expect} from '@playwright/test'
 
 import {test} from '../../studio-test'
 
-test.describe('In PTE - references in popover', () => {
+test.skip('In PTE - references in popover', () => {
   test.beforeEach(async ({page, createDraftDocument}, testInfo) => {
     testInfo.setTimeout(testInfo.timeout + 60_000)
     await createDraftDocument('/content/input-standard;portable-text;pt_allTheBellsAndWhistles')


### PR DESCRIPTION
### Description

Staging is unstable but these tests need to have some more time while staging is unstable

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
