### PR TITLE
style: updates to the workspace switcher

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -71,7 +71,7 @@ export function WorkspaceMenuButton() {
               <>
                 <MenuDivider style={{padding: 0}} />
                 <Box paddingTop={2} paddingBottom={1}>
-                  <Box paddingRight={5} paddingLeft={4} paddingBottom={2}>
+                  <Box paddingRight={5} paddingLeft={4} paddingBottom={3}>
                     <Text size={0} weight="medium">
                       {t('workspaces.action.switch-workspace')}
                     </Text>


### PR DESCRIPTION
### Description

>[!CAUTION]
> @kaylasanity and @joneidejohnsen need to approve before merging

- Updated padding for menu items in the workspace menu items to match with and without scroll

| with guideline | without |
|-------------------------|---------|
|       <img width="726" height="549" alt="image" src="https://github.com/user-attachments/assets/3c0e065d-091f-4c68-a7bb-6a4d1613908b" />                  |      <img width="726" height="549" alt="image" src="https://github.com/user-attachments/assets/2129ccd4-be68-45a4-9e5e-2e0c905887ce" />  |

- Align preview icon of the menu item alongside the items and text of the rest of the workspace

<img width="806" height="554" alt="image" src="https://github.com/user-attachments/assets/64150349-32d9-4245-a874-3e8753761708" />

- Add padding to bottom of "switch workspace" text
<img width="363" height="598" alt="image" src="https://github.com/user-attachments/assets/34e579f3-5c23-4231-87b5-766a900f8129" />

### What to review

@joneidejohnsen and @kaylasanity asked for these changes so they should double check that the changes that have been made are as they want it. I have left comments for them in the linear story as well but if they prefer to comment here that works as well for me.

### Notes for release

N/A
