### PR TITLE
feat(core): enable typographic behaviors in Portable Text Inputs by default

### DIFF
--- a/dev/test-studio/schema/standard/portableText/customPlugins.tsx
+++ b/dev/test-studio/schema/standard/portableText/customPlugins.tsx
@@ -266,8 +266,37 @@ export const customPlugins = defineType({
                 ...props.plugins,
                 typography: {
                   ...props.plugins.typography,
-                  enabled: true,
                   preset: 'all',
+                },
+              },
+            })
+          },
+        },
+      },
+    },
+
+    /**
+     * No Typographic rules enabled
+     */
+    {
+      type: 'array',
+      name: 'noTypographicRulesEnabled',
+      title: 'No Typographic Rules Enabled',
+      description: 'No typographic rules are enabled',
+      of: [
+        {
+          type: 'block',
+        },
+      ],
+      components: {
+        portableText: {
+          plugins: (props) => {
+            return props.renderDefault({
+              ...props,
+              plugins: {
+                ...props.plugins,
+                typography: {
+                  enabled: false,
                 },
               },
             })

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -41,7 +41,6 @@ export const PortableTextEditorPlugins = (props: {
           config: markdownConfig,
         },
         typography: {
-          enabled: false,
           guard: createDecoratorGuard({
             decorators: ({context}) =>
               context.schema.decorators.flatMap((decorator) =>


### PR DESCRIPTION
### Description

This means that all Portable Text Inputs automatically get typographic
behaviors like smart quotes and turning two dashes into an em dash.

The `typography` plugin is already thoroughly documented here, and if there is
a need to configure or disable it globally or per field, that is possible as well:

https://www.sanity.io/docs/studio/portable-text-editor-configuration#abdaf9097fd4

(This reverts commit https://github.com/sanity-io/sanity/commit/f7660dd7b11bb5142173aff297b26a01462507ef.)

> [!NOTE]
> To be as helpful as possible, we explicitly want this change as part of v5 of Studio, not v4

### What to review

For reference, here is the original PR that added and enabled this plugin: https://github.com/sanity-io/sanity/pull/11061

### Testing

Quick smoke test. Does it work as expected? Is it turned on by default and properly disabled/configured in the "custom plugins" example document?

### Notes for release

The typography plugin has been enabled by default in all Portable Text Input. It is completely configurable, but out of the box it provides useful typographic behaviors like smart quotes and turning "->" in "→"