### PR TITLE
refactor: replace `use-effect-event` with `react`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,13 +14,7 @@
   "packageRules": [
     {
       "description": "Exclude @sanity/* packages from minimumReleaseAge (no delay for internal packages)",
-      "matchPackageNames": [
-        "/^@sanity\\//",
-        "/^@portabletext\\//",
-        "/^react-rx$/",
-        "/^use-effect-event$/",
-        "/^groq-js$/"
-      ],
+      "matchPackageNames": ["/^@sanity\\//", "/^@portabletext\\//", "/^react-rx$/", "/^groq-js$/"],
       "minimumReleaseAge": "0 days"
     },
     {

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -72,8 +72,7 @@
     "quick-lru": "^5.1.1",
     "react-fast-compare": "^3.2.2",
     "react-rx": "^4.2.2",
-    "rxjs": "^7.8.2",
-    "use-effect-event": "^2.0.3"
+    "rxjs": "^7.8.2"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -10,7 +10,15 @@ import {
 import {ChevronLeftIcon, ChevronRightIcon} from '@sanity/icons'
 import {Box, Button, Flex, useToast} from '@sanity/ui'
 import {isHotkey} from 'is-hotkey-esm'
-import {type ChangeEvent, useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {
+  type ChangeEvent,
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import {
   getReleaseIdFromReleaseDocumentId,
   isCardinalityOneRelease,
@@ -23,7 +31,6 @@ import {
   useTranslation,
   useWorkspace,
 } from 'sanity'
-import {useEffectEvent} from 'use-effect-event'
 
 import {API_VERSIONS, DEFAULT_API_VERSION} from '../apiVersions'
 import {VisionCodeMirror, type VisionCodeMirrorHandle} from '../codemirror/VisionCodeMirror'

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -260,7 +260,6 @@
     "tinyglobby": "^0.2.14",
     "urlpattern-polyfill": "10.1.0",
     "use-device-pixel-ratio": "^1.1.2",
-    "use-effect-event": "^2.0.3",
     "use-hot-module-reload": "^2.0.0",
     "use-sync-external-store": "^1.6.0",
     "uuid": "^11.1.0",

--- a/packages/sanity/src/core/comments/__workshop__/CommentInlineHighlightDebugStory.tsx
+++ b/packages/sanity/src/core/comments/__workshop__/CommentInlineHighlightDebugStory.tsx
@@ -10,8 +10,7 @@ import {defineArrayMember, defineField, isKeySegment, type PortableTextBlock} fr
 import {Box, Button, Card, Code, Container, Flex, Label, Stack, Text} from '@sanity/ui'
 import {uuid} from '@sanity/uuid'
 import {isEqual} from 'lodash'
-import {startTransition, useEffect, useMemo, useRef, useState} from 'react'
-import {useEffectEvent} from 'use-effect-event'
+import {startTransition, useEffect, useEffectEvent, useMemo, useRef, useState} from 'react'
 
 import {useCurrentUser} from '../../store'
 import {type CommentDocument} from '../types'

--- a/packages/sanity/src/core/hooks/useGlobalCopyPasteElementHandler.ts
+++ b/packages/sanity/src/core/hooks/useGlobalCopyPasteElementHandler.ts
@@ -1,7 +1,6 @@
 import {type Path} from '@sanity/types'
 import {isHotkey} from 'is-hotkey-esm'
-import {useEffect} from 'react'
-import {useEffectEvent} from 'use-effect-event'
+import {useEffect, useEffectEvent} from 'react'
 
 import {isFileTargetElement} from '../form/inputs/files/common/fileTarget/fileTarget'
 import {type FormDocumentValue} from '../form/types/formDocumentValue'

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/FormCreate.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/FormCreate.tsx
@@ -1,8 +1,7 @@
 import {TrashIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {Box, Flex, Switch, Text, useToast} from '@sanity/ui'
-import {useCallback, useEffect, useState} from 'react'
-import {useEffectEvent} from 'use-effect-event'
+import {useCallback, useEffect, useEffectEvent, useState} from 'react'
 
 import {Button} from '../../../../../ui-components'
 import {type ObjectInputProps, set} from '../../../../form'

--- a/packages/sanity/src/core/tasks/hooks/useActivityLog.ts
+++ b/packages/sanity/src/core/tasks/hooks/useActivityLog.ts
@@ -1,5 +1,4 @@
-import {useCallback, useEffect, useState} from 'react'
-import {useEffectEvent} from 'use-effect-event'
+import {useCallback, useEffect, useEffectEvent, useState} from 'react'
 
 import {useClient} from '../../hooks'
 import {getTransactionsLogs} from '../../store/translog/getTransactionsLogs'

--- a/packages/sanity/src/presentation/PresentationTool.tsx
+++ b/packages/sanity/src/presentation/PresentationTool.tsx
@@ -17,7 +17,16 @@ import {
 } from '@sanity/preview-url-secret/constants'
 import {BoundaryElementProvider, Flex} from '@sanity/ui'
 import {useActorRef, useSelector} from '@xstate/react'
-import {lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import {
   type CommentIntentGetter,
   COMMENTS_INSPECTOR_NAME,
@@ -30,7 +39,6 @@ import {
 } from 'sanity'
 import {type RouterContextValue, useRouter} from 'sanity/router'
 import {styled} from 'styled-components'
-import {useEffectEvent} from 'use-effect-event'
 
 import {DEFAULT_TOOL_NAME, EDIT_INTENT_MODE} from './constants'
 import PostMessageFeatures from './features/PostMessageFeatures'

--- a/packages/sanity/src/presentation/document/PresentationDocumentProvider.tsx
+++ b/packages/sanity/src/presentation/document/PresentationDocumentProvider.tsx
@@ -1,6 +1,13 @@
-import {type ReactNode, useCallback, useContext, useLayoutEffect, useMemo, useState} from 'react'
+import {
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffectEvent,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from 'react'
 import {PresentationDocumentContext} from 'sanity/_singletons'
-import {useEffectEvent} from 'use-effect-event'
 
 import {type PresentationPluginOptions} from '../types'
 import {type PresentationDocumentContextValue} from './types'

--- a/packages/sanity/src/presentation/loader/LiveQueries.tsx
+++ b/packages/sanity/src/presentation/loader/LiveQueries.tsx
@@ -18,7 +18,15 @@ import {
   type LoaderNodeMsg,
 } from '@sanity/presentation-comlink'
 import isEqual from 'fast-deep-equal'
-import {memo, startTransition, useDeferredValue, useEffect, useMemo, useState} from 'react'
+import {
+  memo,
+  startTransition,
+  useDeferredValue,
+  useEffect,
+  useEffectEvent,
+  useMemo,
+  useState,
+} from 'react'
 import {
   isReleasePerspective,
   RELEASES_STUDIO_CLIENT_OPTIONS,
@@ -28,7 +36,6 @@ import {
   useDataset,
   useProjectId,
 } from 'sanity'
-import {useEffectEvent} from 'use-effect-event'
 
 import {API_VERSION, MIN_LOADER_QUERY_LISTEN_HEARTBEAT_INTERVAL} from '../constants'
 import {type LoaderConnection, type PresentationPerspective} from '../types'

--- a/packages/sanity/src/presentation/preview/Preview.tsx
+++ b/packages/sanity/src/presentation/preview/Preview.tsx
@@ -29,6 +29,7 @@ import {
   memo,
   useCallback,
   useEffect,
+  useEffectEvent,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -37,7 +38,6 @@ import {
 } from 'react'
 import {flushSync} from 'react-dom'
 import {Translate, useTranslation} from 'sanity'
-import {useEffectEvent} from 'use-effect-event'
 
 import {Button, TooltipDelayGroupProvider} from '../../ui-components'
 import {ErrorCard} from '../components/ErrorCard'

--- a/packages/sanity/src/presentation/useMainDocument.ts
+++ b/packages/sanity/src/presentation/useMainDocument.ts
@@ -1,9 +1,8 @@
 import {type ResponseQueryOptions} from '@sanity/client'
 import {match, type Path} from 'path-to-regexp'
-import {useEffect, useRef, useState} from 'react'
+import {useEffect, useEffectEvent, useRef, useState} from 'react'
 import {useClient} from 'sanity'
 import {type RouterState, useRouter} from 'sanity/router'
-import {useEffectEvent} from 'use-effect-event'
 
 import {API_VERSION} from './constants'
 import {

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -1,5 +1,13 @@
 import {Box, Container, Flex, focusFirstDescendant, Spinner, Text} from '@sanity/ui'
-import {type FormEvent, forwardRef, useCallback, useEffect, useMemo, useState} from 'react'
+import {
+  type FormEvent,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useMemo,
+  useState,
+} from 'react'
 import {tap} from 'rxjs/operators'
 import {
   createPatchChannel,
@@ -16,7 +24,6 @@ import {
   usePerspective,
   useTranslation,
 } from 'sanity'
-import {useEffectEvent} from 'use-effect-event'
 
 import {Delay} from '../../../../components'
 import {structureLocaleNamespace} from '../../../../i18n'

--- a/packages/sanity/src/structure/panes/document/useResetHistoryParams.ts
+++ b/packages/sanity/src/structure/panes/document/useResetHistoryParams.ts
@@ -1,6 +1,5 @@
-import {useEffect, useRef} from 'react'
+import {useEffect, useEffectEvent, useRef} from 'react'
 import {usePerspective} from 'sanity'
-import {useEffectEvent} from 'use-effect-event'
 
 import {usePaneRouter} from '../../components'
 import {EMPTY_PARAMS} from './constants'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1749,9 +1749,6 @@ importers:
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
-      use-effect-event:
-        specifier: ^2.0.3
-        version: 2.0.3(react@19.2.3)
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -2273,9 +2270,6 @@ importers:
       use-device-pixel-ratio:
         specifier: ^1.1.2
         version: 1.1.2(react@19.2.3)
-      use-effect-event:
-        specifier: ^2.0.3
-        version: 2.0.3(react@19.2.3)
       use-hot-module-reload:
         specifier: ^2.0.0
         version: 2.0.0(react@19.2.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -78,7 +78,6 @@ minimumReleaseAgeExclude:
   - 'react-dom'
   - 'react-is'
   - 'react-rx'
-  - 'use-effect-event'
 
 trustPolicy: no-downgrade
 


### PR DESCRIPTION
### Description

Since `useEffectEvent` is a native React 19.2 API we no longer need the `use-effect-event` package 🎉 

### What to review

Missed a spot? 

### Testing

If the CI is happy then we're happy! ☺️ 

### Notes for release

The Studio codebase is now using the native `React.useEffectEvent` API, instead of the polyfill from `use-effect-event`. This improves performance and slightly reduces the bundlesize so studio can load faster ✨ 