### PR TITLE
feat(liveManifest): include bundleVersion in manifest

### DIFF
--- a/packages/sanity/src/core/studio/manifest/__tests__/registerLiveStudioManifest.test.tsx
+++ b/packages/sanity/src/core/studio/manifest/__tests__/registerLiveStudioManifest.test.tsx
@@ -151,7 +151,8 @@ describe('registerStudioManifest', () => {
       expect(mockRequest).toHaveBeenCalledWith(
         expect.objectContaining({
           body: {
-            value: {
+            value: expect.objectContaining({
+              bundleVersion: expect.any(String),
               workspaces: [
                 {
                   name: 'my-workspace',
@@ -165,7 +166,7 @@ describe('registerStudioManifest', () => {
                   mediaLibraryId: undefined,
                 },
               ],
-            },
+            }),
           },
         }),
       )

--- a/packages/sanity/src/core/studio/manifest/registerLiveStudioManifest.tsx
+++ b/packages/sanity/src/core/studio/manifest/registerLiveStudioManifest.tsx
@@ -4,6 +4,7 @@ import {firstValueFrom} from 'rxjs'
 import {type Source, type WorkspaceSummary} from '../../config/types'
 import {type UserApplication} from '../../store/userApplications'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
+import {SANITY_VERSION} from '../../version'
 import {resolveIcon} from './icon'
 
 const buildId: string | undefined =
@@ -34,6 +35,7 @@ interface WorkspaceManifest {
 interface StudioManifest {
   version?: string
   buildId?: string
+  bundleVersion?: string
   workspaces: WorkspaceManifest[]
 }
 
@@ -103,6 +105,7 @@ async function generateStudioManifest(
 
   return {
     buildId,
+    bundleVersion: SANITY_VERSION,
     // Filter out null entries (workspaces without schemaDescriptorId)
     workspaces: workspaceManifests.filter((config): config is WorkspaceManifest => config !== null),
   }


### PR DESCRIPTION
### Description

Adds the studio version of the bundle in the manigest

### What to review

The version is in the manifest

### Testing

The version is well tested, the existing unit tests should be enough

### Notes for release

This is related to an internal change, no release. notes need.