### PR TITLE
fix: put back missing support for file extension type file accept

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/common/uploadTarget/uploadTarget.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/uploadTarget/uploadTarget.tsx
@@ -81,6 +81,30 @@ export function uploadTarget<Props>(
 
     const assetSourceDestinationName = useRef<string | null>(null)
 
+    const alertRejectedFiles = useCallback(
+      (rejected: FileEntry[]) => {
+        pushToast({
+          closable: true,
+          status: 'warning',
+          title: t('inputs.array.error.cannot-upload-unable-to-convert', {
+            count: rejected.length,
+          }),
+          description: rejected.map((task, i) => (
+            // oxlint-disable-next-line no-array-index-key
+            <Flex key={i} gap={2} padding={2}>
+              <Box>
+                <Text weight="medium">{task.file.name}</Text>
+              </Box>
+              <Box>
+                <Text size={1}>({task.file.type})</Text>
+              </Box>
+            </Flex>
+          )),
+        })
+      },
+      [pushToast, t],
+    )
+
     // This is called after the user has dropped or pasted files and selected an asset source destination (if applicable)
     const handleUploadFiles = useCallback(
       (files: File[]) => {
@@ -95,24 +119,7 @@ export function uploadTarget<Props>(
         const rejected = filesAndAssetSources.filter((entry) => entry.assetSource === null)
 
         if (rejected.length > 0) {
-          pushToast({
-            closable: true,
-            status: 'warning',
-            title: t('inputs.array.error.cannot-upload-unable-to-convert', {
-              count: rejected.length,
-            }),
-            description: rejected.map((task, i) => (
-              // oxlint-disable-next-line no-array-index-key
-              <Flex key={i} gap={2} padding={2}>
-                <Box>
-                  <Text weight="medium">{task.file.name}</Text>
-                </Box>
-                <Box>
-                  <Text size={1}>({task.file.type})</Text>
-                </Box>
-              </Flex>
-            )),
-          })
+          alertRejectedFiles(rejected)
         }
         if (onSelectFile) {
           ready.forEach((entry) => {
@@ -124,7 +131,7 @@ export function uploadTarget<Props>(
           })
         }
       },
-      [types, formBuilder, assetSourceDestinationName, pushToast, t, onSelectFile],
+      [alertRejectedFiles, formBuilder, onSelectFile, types],
     )
 
     // This is called when files are dropped or pasted onto the upload target. It may show the asset source destination picker if needed.
@@ -141,6 +148,7 @@ export function uploadTarget<Props>(
         )
         const ready = filesAndAssetSources.filter((entry) => entry.assetSource !== null)
         if (ready.length === 0) {
+          alertRejectedFiles(filesAndAssetSources)
           return
         }
         const allAssetSources = types.flatMap(
@@ -156,7 +164,7 @@ export function uploadTarget<Props>(
         setFilesToUpload([])
         handleUploadFiles(ready.map((entry) => entry.file))
       },
-      [isReadOnly, types, formBuilder, handleUploadFiles],
+      [alertRejectedFiles, isReadOnly, types, formBuilder, handleUploadFiles],
     )
 
     const [hoveringFiles, setHoveringFiles] = useState<FileInfo[]>([])
@@ -270,35 +278,31 @@ function getFilesAndAssetSources(
   formBuilder: FIXME,
 ): FileEntry[] {
   const imageType = types.find((type) => type.name === 'image')
-  const imageAssetSource =
-    (imageType &&
-      resolveUploadAssetSources(imageType, formBuilder).find(
-        (source) => !assetSourceDestinationName || source.name === assetSourceDestinationName,
-      )) ||
-    null
   const fileType = types.find((type) => type.name === 'file')
-  const fileAssetSource =
-    (fileType &&
-      resolveUploadAssetSources(fileType, formBuilder).find(
-        (source) => !assetSourceDestinationName || source.name === assetSourceDestinationName,
-      )) ||
-    null
 
   return files.map((file) => {
+    const imageAssetSource =
+      (imageType &&
+        resolveUploadAssetSources(imageType, formBuilder, file).find(
+          (source) => !assetSourceDestinationName || source.name === assetSourceDestinationName,
+        )) ||
+      null
     const isImage = imageType && file.type.startsWith('image/') && imageAssetSource
-    const acceptedImage =
-      imageType && (!imageType.options.accept || imageType.options.accept?.includes(file.type))
-    if (isImage && acceptedImage) {
+    if (isImage) {
       return {
         file,
         schemaType: imageType,
         assetSource: imageAssetSource,
       }
     }
+    const fileAssetSource =
+      (fileType &&
+        resolveUploadAssetSources(fileType, formBuilder, file).find(
+          (source) => !assetSourceDestinationName || source.name === assetSourceDestinationName,
+        )) ||
+      null
     const isFile = fileType && fileAssetSource
-    const acceptedFile =
-      fileType && (!fileType.options.accept || fileType.options.accept?.includes(file.type))
-    if (isFile && acceptedFile) {
+    if (isFile) {
       return {
         file,
         schemaType: fileType,


### PR DESCRIPTION
### Description

With the recent refactor of drag and drop uploads, support for file extension accept for schema type's `options.accept` broke.

This will re-introduce that support again.

It needs access to the file names when collecting available asset sources for upload.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fix bug where support for file and image schema type `accept` option did not support file extension type of list (only mime types).
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
