### PR TITLE
feat(toggles): fail open schema and manifest toggles

### DIFF
--- a/packages/sanity/src/core/config/uploadSchema.ts
+++ b/packages/sanity/src/core/config/uploadSchema.ts
@@ -14,21 +14,17 @@ import {DESCRIPTOR_CONVERTER} from '../schema'
 
 const debug = debugit('sanity:config')
 
-const TOGGLE = 'toggle.schema.upload-pause'
+const DISABLE_TOGGLE = 'toggle.schema.upload-pause.disable'
 
 async function isEnabled(client: SanityClient): Promise<boolean> {
-  if (typeof process !== 'undefined' && process?.env?.SANITY_STUDIO_SCHEMA_DESCRIPTOR) {
-    return true
-  }
-
   const {projectId} = client.config()
   if (!projectId) return false
 
   return firstValueFrom(getFeatures({projectId, versionedClient: client}))
-    .then((features) => features.includes(TOGGLE))
+    .then((features) => !features.includes(DISABLE_TOGGLE))
     .catch((err) => {
-      debug('Fetching features failed. NOT sending schema to server.', {err})
-      return false
+      debug('Fetching features failed. Sending schema to server.', {err})
+      return true
     })
 }
 

--- a/packages/sanity/src/core/store/userApplications/__tests__/userApplicationCache.test.ts
+++ b/packages/sanity/src/core/store/userApplications/__tests__/userApplicationCache.test.ts
@@ -5,11 +5,11 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../studioClient'
 import {createUserApplicationCache, type UserApplication} from '../userApplicationCache'
 
-const TOGGLE = 'toggle.user-application.upload-live-manifest'
+const DISABLE_TOGGLE = 'toggle.user-application.upload-live-manifest.disable'
 
-// Mock getFeatures to return the toggle by default
+// Mock getFeatures to return empty array by default (feature enabled when disable toggle is absent)
 vi.mock('../../../hooks/useFeatureEnabled', () => ({
-  getFeatures: vi.fn(() => of([TOGGLE])),
+  getFeatures: vi.fn(() => of([])),
 }))
 
 describe('userApplicationCache', () => {
@@ -178,9 +178,9 @@ describe('userApplicationCache', () => {
   })
 
   describe('feature toggle', () => {
-    it('should return empty array when feature toggle is disabled', async () => {
+    it('should return empty array when feature is disabled (disable toggle present)', async () => {
       const {getFeatures} = await import('../../../hooks/useFeatureEnabled')
-      vi.mocked(getFeatures).mockReturnValueOnce(of([]))
+      vi.mocked(getFeatures).mockReturnValueOnce(of([DISABLE_TOGGLE]))
 
       const cache = createUserApplicationCache()
       const result = await cache.get(mockClient)
@@ -189,9 +189,9 @@ describe('userApplicationCache', () => {
       expect(mockRequest).not.toHaveBeenCalled()
     })
 
-    it('should fetch apps when feature toggle is enabled', async () => {
+    it('should fetch apps when feature is enabled (disable toggle absent)', async () => {
       const {getFeatures} = await import('../../../hooks/useFeatureEnabled')
-      vi.mocked(getFeatures).mockReturnValueOnce(of([TOGGLE]))
+      vi.mocked(getFeatures).mockReturnValueOnce(of([]))
 
       const mockApps = [{id: 'app-1', type: 'studio', urlType: 'internal', appHost: 'studio-1'}]
       mockRequest.mockResolvedValueOnce(mockApps)

--- a/packages/sanity/src/core/store/userApplications/userApplicationCache.ts
+++ b/packages/sanity/src/core/store/userApplications/userApplicationCache.ts
@@ -7,24 +7,19 @@ import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
 
 const debug = debugit('sanity:store')
 
-const TOGGLE = 'toggle.user-application.upload-live-manifest'
+const DISABLE_TOGGLE = 'toggle.user-application.upload-live-manifest.disable'
 
 async function isEnabled(client: SanityClient): Promise<boolean> {
-  if (typeof process !== 'undefined' && process?.env?.SANITY_STUDIO_USER_APPLICATION_CACHE) {
-    return true
-  }
-
   const {projectId} = client.config()
   if (!projectId) return false
 
   return firstValueFrom(getFeatures({projectId, versionedClient: client}))
-    .then((features) => features.includes(TOGGLE))
+    .then((features) => !features.includes(DISABLE_TOGGLE))
     .catch((err) => {
-      debug(
-        `Fetching features failed. User applications cache not enabled for project ${projectId}.`,
-        {err},
-      )
-      return false
+      debug(`Fetching features failed. User applications cache enabled for project ${projectId}.`, {
+        err,
+      })
+      return true
     })
 }
 


### PR DESCRIPTION
### Description

The toggles have been forced on for some time, flipping the logic so we can decommission the toggles.

### What to review

- Toggle checking logic makes sense.
- Tests pass

### Testing

We shouldn't see any change in existing behavior.

### Notes for release

This is relate to an internal feature. No notes needed.