### PR TITLE
chore(scripts): improve args parsing for generate documents script

### DIFF
--- a/scripts/generate-documents/cli.ts
+++ b/scripts/generate-documents/cli.ts
@@ -13,6 +13,7 @@ import {validation} from './templates/validation'
 
 const {values: args} = parseArgs({
   args: process.argv.slice(2),
+  allowNegative: true,
   options: {
     number: {
       type: 'string',
@@ -27,6 +28,7 @@ const {values: args} = parseArgs({
     },
     draft: {
       type: 'boolean',
+      default: true,
     },
     published: {
       type: 'boolean',
@@ -103,7 +105,7 @@ const client = createClient({
 
 run({
   bundle: args.bundle,
-  draft: args.draft || true,
+  draft: args.draft,
   published: args.published,
   concurrency: args.concurrency ? Number(args.concurrency) : undefined,
   number: args.number ? Number(args.number) : undefined,


### PR DESCRIPTION
### Description
Small improvemnet to internal dev script for generating documents

fixes it so that it's possible to generate documents without drafts, e.g.:
```
pnpm tsx scripts/generate-documents/cli.ts --no-draft --bundle foo -n 10 -t book
```
^-- will create 10 documents in bundle `foo` using the `book`-template, without creating drafts

### What to review
makes sense?

### Testing


### Notes for release
n/a