### PR TITLE
refactor(core): rename releaseId => selectedPerspectiveName

### DIFF
--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -51,6 +51,7 @@ import {
   getPublishedId,
   getVersionFromId,
   getVersionId,
+  isSystemBundle,
   useUnique,
 } from '../util'
 import {
@@ -178,6 +179,9 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
       : undefined
 
   const activeDocumentReleaseId = useMemo(() => {
+    if (isSystemBundle(selectedPerspectiveName)) {
+      return undefined
+    }
     // if a document version exists with the selected release id, then it should use that
     if (documentVersions.some((id) => getVersionFromId(id) === selectedPerspectiveName)) {
       return selectedPerspectiveName


### PR DESCRIPTION
### Description
Small naming refactor: We've previously had the assumption that the selected perspective would always be a release. However, this isn't the case as it could be a non-release bundle ID.

### What to review
Makes sense? This should be a mere naming change, and just impact the local scope where the rename was made.

### Testing
- If CI is happy we're good.

### Notes for release
n/a
