### PR TITLE
fix(core): void selectedReleaseId if bundle is outside a release

### DIFF
--- a/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
+++ b/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
@@ -1,6 +1,7 @@
 import {useMemo} from 'react'
 import {PerspectiveContext} from 'sanity/_singletons'
 
+import {getReleaseIdFromReleaseDocumentId} from '../releases'
 import {getReleasesPerspectiveStack} from '../releases/hooks/utils'
 import {useActiveReleases} from '../releases/store/useActiveReleases'
 import {useWorkspace} from '../studio/workspace'
@@ -52,11 +53,19 @@ export function PerspectiveProvider({
       selectedPerspectiveName,
       selectedReleaseId: isSystemBundleName(selectedPerspectiveName)
         ? undefined
-        : selectedPerspectiveName,
+        : releases
+            .map((release) => getReleaseIdFromReleaseDocumentId(release._id))
+            .find((releaseName) => releaseName === selectedPerspectiveName),
       perspectiveStack,
       excludedPerspectives,
     }
-  }, [selectedPerspectiveName, selectedPerspective, perspectiveStack, excludedPerspectives])
+  }, [
+    selectedPerspectiveName,
+    releases,
+    selectedPerspective,
+    perspectiveStack,
+    excludedPerspectives,
+  ])
 
   return <PerspectiveContext.Provider value={value}>{children}</PerspectiveContext.Provider>
 }


### PR DESCRIPTION
### Description
This sets `selectedReleaseId` to undefined if the current selected perspective does not have a matching release

### What to review
Makes sense?

### Testing
Existing tests should be enough

### Notes for release

n/a