### PR TITLE
fix(structure): hide add to release banner for non-release versions

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -233,6 +233,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
       editState?.version && isGoingToUnpublish(editState?.version)
 
     if (
+      isReleaseDocument(selectedPerspective) &&
       displayed?._id &&
       getVersionFromId(displayed._id) !== selectedReleaseId &&
       ready &&
@@ -243,7 +244,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
       return (
         <DocumentNotInReleaseBanner
           documentId={value._id}
-          currentRelease={selectedPerspective as ReleaseDocument}
+          currentRelease={selectedPerspective}
           isScheduledRelease={isScheduledRelease}
         />
       )


### PR DESCRIPTION
### Description
This makes sure we show the "Add to release"-banner only if the current perspective is a release

### What to review
Makes sense?

### Testing

### Notes for release
n/a