### PR TITLE
fix(structure): void documentActionProps.release for non-release versions

### DIFF
--- a/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
@@ -57,7 +57,7 @@ export const useUnpublishVersionAction: DocumentActionComponent = (
     }
   }, [isAlreadyUnpublished, version, revertUnpublishVersion, toast, coreT])
 
-  if (!version) return null
+  if (!release || !version) return null
 
   const insufficientPermissions = !isPermissionsLoading && !permissions?.granted
 

--- a/packages/sanity/src/structure/DocumentActionsProvider.tsx
+++ b/packages/sanity/src/structure/DocumentActionsProvider.tsx
@@ -6,6 +6,8 @@ import {
   EMPTY_ARRAY,
   getDocumentIdForCanvasLink,
   GetHookCollectionState,
+  getReleaseIdFromReleaseDocumentId,
+  useActiveReleases,
   useCanvasCompanionDoc,
   useTranslation,
 } from 'sanity'
@@ -22,21 +24,28 @@ interface ResolvedAction extends DocumentActionDescription {
 export function DocumentActionsProvider(props: {children: React.ReactNode}) {
   const {children} = props
 
+  const {data: activeReleases} = useActiveReleases()
+
   const {actions, editState, isInitialValueLoading, revisionId} = useDocumentPane()
 
   const onCompleteRef = useRef<() => void>(null)
 
-  const actionProps: Omit<DocumentActionProps, 'onComplete'> | null = useMemo(
-    () =>
-      editState
-        ? {
-            ...editState,
-            revision: revisionId || undefined,
-            initialValueResolved: !isInitialValueLoading,
-          }
-        : null,
-    [editState, isInitialValueLoading, revisionId],
-  )
+  const actionProps: Omit<DocumentActionProps, 'onComplete'> | null = useMemo(() => {
+    // note: this is actually the bundle id of the current document
+
+    const matchingReleaseName = activeReleases
+      .map((r) => getReleaseIdFromReleaseDocumentId(r._id))
+      .find((candidate) => candidate === editState?.release)
+
+    return editState
+      ? {
+          ...editState,
+          release: matchingReleaseName,
+          revision: revisionId || undefined,
+          initialValueResolved: !isInitialValueLoading,
+        }
+      : null
+  }, [editState, isInitialValueLoading, revisionId, activeReleases])
 
   if (!actionProps) {
     return null


### PR DESCRIPTION
### Description
Currently, document actions receive a `release`-prop which is the _bundle-id_ part of the version id. This is misleading, because the bundle-id might not have a corresponding release.

This PR changes it so that we pass `release: undefined`  if there is no release associated with the document version

### What to review
Makes sense?

### Testing
Shouldn't affect existing code, CI should pass

### Notes for release

n/a