### PR TITLE
fix(releases): pass through publish action in version context

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.test.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.test.ts
@@ -189,7 +189,7 @@ describe('publish', () => {
             },
           },
         } as unknown as OperationArgs)
-      }).toThrow('cannot execute "publish" when draft is missing')
+      }).toThrow('cannot execute "publish" when draft or version is missing')
 
       expect(client.$log).toMatchSnapshot()
     })

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/publish.ts
@@ -9,21 +9,21 @@ export const publish: OperationImpl<[], DisabledReason> = {
     if (isLiveEditEnabled(schema, typeName)) {
       return 'LIVE_EDIT_ENABLED'
     }
-    if (!snapshots.draft) {
+    if (!snapshots.draft && !snapshots.version) {
       return snapshots.published ? 'ALREADY_PUBLISHED' : 'NO_CHANGES'
     }
     return false
   },
   execute: ({client, idPair, snapshots}) => {
     // The editor must be able to see the draft they are choosing to publish.
-    if (!snapshots.draft) {
-      throw new Error('cannot execute "publish" when draft is missing')
+    if (!snapshots.draft && !snapshots.version) {
+      throw new Error('cannot execute "publish" when draft or version is missing')
     }
 
     return actionsApiClient(client, idPair).observable.action(
       {
         actionType: 'sanity.action.document.publish',
-        draftId: idPair.draftId,
+        draftId: (snapshots.draft?._id || snapshots.version?._id)!,
         publishedId: idPair.publishedId,
         // Optimistic locking using `ifPublishedRevisionId` ensures that concurrent publish action
         // invocations do not override each other.

--- a/packages/sanity/src/structure/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/PublishAction.tsx
@@ -5,8 +5,8 @@ import {Text} from '@sanity/ui'
 import {useCallback, useEffect, useMemo, useState} from 'react'
 import {
   type DocumentActionComponent,
+  getVersionFromId,
   InsufficientPermissionsMessage,
-  isPublishedId,
   type TFunction,
   useCurrentUser,
   useDocumentOperation,
@@ -51,11 +51,14 @@ function AlreadyPublished({publishedAt}: {publishedAt: string}) {
 // React Compiler needs functions that are hooks to have the `use` prefix, pascal case are treated as a component, these are hooks even though they're confusingly named `DocumentActionComponent`
 /** @internal */
 export const usePublishAction: DocumentActionComponent = (props) => {
-  const {id, type, liveEdit, draft, published, release} = props
+  const {id, type, liveEdit, draft, published, release, version} = props
   const [publishState, setPublishState] = useState<
     {status: 'publishing'; publishRevision: string | undefined} | {status: 'published'} | null
   >(null)
-  const {publish} = useDocumentOperation(id, type)
+
+  const bundleId = version?._id && getVersionFromId(version._id)
+
+  const {publish} = useDocumentOperation(id, type, bundleId)
   const {changesOpen, documentId, documentType, value} = useDocumentPane()
   const validationStatus = useValidationStatus(value._id, type, !release)
   const syncState = useSyncState(id, type)
@@ -158,12 +161,15 @@ export const usePublishAction: DocumentActionComponent = (props) => {
   ])
 
   return useMemo(() => {
-    if (release) {
-      // Version documents are not publishable by this action, they should be published as part of a release
+    if (release && version) {
+      // release versions are not publishable by this action, they should be published as part of a release
       return null
     }
-    if (liveEdit) {
-      // Live edit documents are not publishable by this action, they are published automatically
+
+    if (liveEdit && !version) {
+      // disable publish if liveEdit is true and we're not on a version
+      // e.g. if liveEdit is true and we have a version, we want to allow publish
+      // note that liveEdit is "forced" on version documents as a hack of sorts
       return null
     }
 
@@ -172,7 +178,7 @@ export const usePublishAction: DocumentActionComponent = (props) => {
      * then it means the draft is yet to be saved - in this case don't disabled
      * the publish button due to ALREADY_PUBLISHED reason
      */
-    if (isPublishedId(value._id) && draft !== null) {
+    if (published && !draft && !version) {
       return {
         tone: 'default',
         icon: PublishIcon,
@@ -226,8 +232,9 @@ export const usePublishAction: DocumentActionComponent = (props) => {
   }, [
     release,
     liveEdit,
-    value._id,
+    version,
     draft,
+    published,
     isPermissionsLoading,
     permissions?.granted,
     publishScheduled,
@@ -238,7 +245,6 @@ export const usePublishAction: DocumentActionComponent = (props) => {
     t,
     title,
     handle,
-    published?._updatedAt,
     currentUser,
   ])
 }


### PR DESCRIPTION
### Description
Realized too late that this ideally should have been merged before #11602, since it actually includes the publish action for versions, since "Schedule publish" has become the primary action for non-release versions now :)

This PR enables the Publish action for version documents not in a release

### What to review

### Testing
(same as for #11602 – but now they are actually accurate 😆)
- Open documents in the "foo"-perspective here, observe that the publish button becomes the primary one: https://test-studio-git-sapp-3343-alow-publish-non-release-versions.sanity.dev/test/structure/book;1766050895135-autogenerated-6?perspective=foo
- Also verify that its not shown for documents in a release

### Notes for release
n/a