### PR TITLE
fix: show publish as primary action for non-release versions

### DIFF
--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -53,9 +53,9 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
   const showFirstActionButton = showingRevision
     ? Boolean(firstActionState)
     : selectedReleaseId
-      ? // If the first action is a custom action and we are in a version document show it.
-        firstActionState && !isSanityDefinedAction(firstActionState)
-      : firstActionState && !editState?.liveEdit
+      ? // If the first action is a custom action and we are in a release document show it.
+        firstActionState && selectedReleaseId && !isSanityDefinedAction(firstActionState)
+      : firstActionState && (!editState?.liveEdit || editState?.version)
 
   const sideMenuItems = useMemo(() => {
     return showFirstActionButton


### PR DESCRIPTION
### Description
It should be possible to publish a version that's not in a release. This PR makes Publish the primary action for any version that is not part of a release.

### What to review
Makes sense?

### Testing
- Open documents in the "foo"-perspective here, observe that the publish button becomes the primary one: https://test-studio-git-sapp-3343-publish-as-primary-action-non-93d747.sanity.dev/test/structure/book;1766050895135-autogenerated-6?perspective=foo
- Also verify that its not shown for documents in a release

### Notes for release
n/a
