### PR TITLE
fix(structure): hide "release archived"-banner for non-release bundles

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/DeletedDocumentBanners.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/DeletedDocumentBanners.tsx
@@ -4,6 +4,7 @@ import {useCallback} from 'react'
 import {
   isDraftPerspective,
   isPublishedPerspective,
+  isReleaseDocument,
   type ReleaseDocument,
   Translate,
   useDocumentOperation,
@@ -23,6 +24,7 @@ export function DeletedDocumentBanners() {
   if (
     !isPublishedPerspective(selectedPerspective) &&
     !isDraftPerspective(selectedPerspective) &&
+    isReleaseDocument(selectedPerspective) &&
     selectedPerspective.state === 'archived'
   ) {
     return <ArchivedReleaseBanner release={selectedPerspective as ReleaseDocument} />

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/DeletedDocumentBanners.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/__tests__/DeletedDocumentBanners.test.tsx
@@ -64,7 +64,11 @@ describe('DeletedDocumentBanners', () => {
   })
 
   it('prefers to show release deleted banner when document was in a release', async () => {
-    const mockReleaseDocument = {_id: 'test', state: 'archived'} as ReleaseDocument
+    const mockReleaseDocument = {
+      _id: '_.releases.rtest',
+      _type: 'system.release',
+      state: 'archived',
+    } as ReleaseDocument
     mockUsePerspective.mockReturnValue({selectedPerspective: mockReleaseDocument} as ReturnType<
       typeof usePerspective
     >)
@@ -77,6 +81,7 @@ describe('DeletedDocumentBanners', () => {
       releasesIds: [mockReleaseDocument._id],
     })
     mockUseDocumentPane.mockReturnValue({
+      documentId: 'foo',
       isDeleted: true,
       isDeleting: false,
       ready: true,


### PR DESCRIPTION
### Description
Currently, when visiting a deleted document while a non-release perspective is selected, the document pane will show a banner saying that the release has been archived. This PR fixes that by not showing this banner unless the selected perspective is actually an archived release.

### What to review
- makes sense

### Testing
tests updated

### Notes for release
n/a