### PR TITLE
chore: npm badges for our tagged versions

### DIFF
--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -11,7 +11,10 @@
 </div>
 
 <div align="center">
-  <img alt="" src="https://img.shields.io/npm/v/sanity?style=flat">
+  <img alt="" src="https://img.shields.io/npm/v/sanity/latest?style=flat">
+  <img alt="" src="https://img.shields.io/npm/v/sanity/next?style=flat">
+  <img alt="" src="https://img.shields.io/npm/v/sanity/stable?style=flat">
+  <br />
   <img alt="" src="https://img.shields.io/npm/dm/@sanity/client?style=flat">
   <img alt="" src="https://img.shields.io/npm/l/sanity.svg?style=flat">
   <a aria-label="Join the Sanity community" href="https://www.sanity.io/community/join?utm_source=readme">


### PR DESCRIPTION
Add NPM badges for each tagged version so users can see the version that Autoupdate settings will use.

<img width="685" height="180" alt="image" src="https://github.com/user-attachments/assets/0c7e1bfe-03ff-4898-a3d6-220fc360bca0" />
