### PR TITLE
fix(form): re-enable editing liveEdit documents in published perspective

### DIFF
--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -205,7 +205,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
 
   const value: SanityDocumentLike = useMemo(() => {
     const baseValue = initialValue?.value || {_id: documentId, _type: documentType}
-    if (selectedPerspectiveName) {
+    if (releaseId) {
       // in cases where the current version is going to be unpublished, we need to show the published document
       // this way, instead of showing the version that will stop existing, we show instead the published document with a fall back
       if (editState.version && isGoingToUnpublish(editState.version)) {
@@ -223,8 +223,10 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
             {_id: documentId, _type: documentType})
       )
     }
-    // if no version is selected, but there is only version, it should default to the version it finds
-    if (!selectedPerspectiveName && onlyHasVersions) {
+    // we have either a selected perspective that's not a release,
+    // or no version is selected, but there are only versions,
+    // so it should default to the version it finds
+    if (selectedPerspectiveName || onlyHasVersions) {
       return editState.version || editState.draft || editState.published || baseValue
     }
     return editState?.draft || editState?.published || baseValue
@@ -235,6 +237,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
     editState.published,
     editState.version,
     initialValue,
+    releaseId,
     liveEdit,
     selectedPerspectiveName,
     onlyHasVersions,


### PR DESCRIPTION
### Description
Noticed two small regressions from #11594 that caused 
1. liveEdit documents to become readOnly if if perspective=published
2. the wrong document value to be selected based on the perspective param


### What to review
Is the logic sound?

### Testing

for 1:
- Repro here: https://test-studio.sanity.dev/test/structure/input-debug;thesis;1766180391525-autogenerated-0?perspective=published
- Notice that the form is readonly
- Test the same document from the preview build of this PR: https://test-studio-git-allow-live-edit-published.sanity.dev/test/structure/input-debug;thesis;1766180391525-autogenerated-0?perspective=published
- The form is no longer readOnly

for 2:
- Repro: https://test-studio.sanity.dev/test/structure/book;1765976089835-autogenerated-9?perspective=published
- Notice that the the form shows the draft value (despite the header being correct)
- Test the same document from the preview build of this PR: https://test-studio-git-allow-live-edit-published.sanity.dev/test/structure/book;1765976089835-autogenerated-9?perspective=published
- notice that it loads the correct version into the form


### Notes for release
n/a