### PR TITLE
fix(sanity): fix false positive reference validation for release docs

### DIFF
--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -243,7 +243,12 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
     onlyHasVersions,
   ])
 
-  const {validation: validationRaw} = useValidationStatus(value._id, documentType, !releaseId)
+  const {validation: validationRaw} = useValidationStatus(
+    value._id,
+    documentType,
+    // require referenced documents to be published unless the document is in a release
+    !releaseId,
+  )
 
   const validation = useUnique(validationRaw)
 

--- a/packages/sanity/src/core/hooks/useValidationStatus.ts
+++ b/packages/sanity/src/core/hooks/useValidationStatus.ts
@@ -10,13 +10,14 @@ const INITIAL: ValidationStatus = {validation: [], isValidating: false}
 export function useValidationStatus(
   validationTargetId: string,
   docTypeName: string,
-  requireReferenceExistence: boolean,
+  requirePublishedReferences: boolean,
 ): ValidationStatus {
   const documentStore = useDocumentStore()
 
   const observable = useMemo(
-    () => documentStore.pair.validation(validationTargetId, docTypeName, requireReferenceExistence),
-    [docTypeName, documentStore.pair, validationTargetId, requireReferenceExistence],
+    () =>
+      documentStore.pair.validation(validationTargetId, docTypeName, requirePublishedReferences),
+    [docTypeName, documentStore.pair, validationTargetId, requirePublishedReferences],
   )
 
   return useObservable(observable, INITIAL)

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/validation.ts
@@ -38,7 +38,7 @@ export const validation = memoize(
     {draftId, publishedId, versionId}: IdPair,
     typeName: string,
     validationTarget: DocumentVariantType,
-    requireReferenceExistence: boolean,
+    validatePublishedReferences: boolean,
   ): Observable<ValidationStatus> => {
     const document$ = editState(ctx, {draftId, publishedId, versionId}, typeName).pipe(
       map((state) => {
@@ -60,9 +60,9 @@ export const validation = memoize(
       shareLatestWithRefCount(),
     )
 
-    return validateDocumentWithReferences(ctx, document$, requireReferenceExistence)
+    return validateDocumentWithReferences(ctx, document$, validatePublishedReferences)
   },
-  (ctx, idPair, typeName, validationTarget, allowVersionReferences) => {
+  (ctx, idPair, typeName, validationTarget, validatePublishedReferences) => {
     // Use the actual document ID being validated in the cache key for explicitness
     const documentId =
       validationTarget === 'draft'
@@ -70,6 +70,6 @@ export const validation = memoize(
         : validationTarget === 'version'
           ? idPair.versionId
           : idPair.publishedId
-    return `${memoizeKeyGen(ctx.client, idPair, typeName)}-${documentId}-${allowVersionReferences}`
+    return `${memoizeKeyGen(ctx.client, idPair, typeName)}-${documentId}-${validatePublishedReferences}`
   },
 )

--- a/packages/sanity/src/core/store/_legacy/document/document-store.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-store.ts
@@ -100,7 +100,11 @@ export interface DocumentStore {
     validation: (
       validationTargetId: string,
       type: string,
-      requireReferenceExistence: boolean,
+      // Whether to require referenced documents to be published
+      // if `true`, any reference to a document that's not published will yield a validation error
+      // if `false`, any reference to a non-published document is ok as long as it's in the same bundle
+      // as the document we're validating
+      validatePublishedReferences: boolean,
     ) => Observable<ValidationStatus>
   }
 }
@@ -219,11 +223,11 @@ export function createDocumentStore({
           }),
         )
       },
-      validation(validationTargetId, type, requireReferenceExistence) {
+      validation(validationTargetId, type, requirePublishedReferences) {
         const publishedId = getPublishedId(validationTargetId)
         const idPair = getIdPair(publishedId, {version: getVersionFromId(validationTargetId)})
         const validationTarget = getDocumentVariantType(validationTargetId)
-        return validation(ctx, idPair, type, validationTarget, requireReferenceExistence)
+        return validation(ctx, idPair, type, validationTarget, requirePublishedReferences)
       },
     },
   }


### PR DESCRIPTION
### Description
Fixes a false positive that would yield a validation error on a document in a release referencing another document in the same release. This is explicitly allowed, since we can guarantee that both documents will be released in the same transaction.

This was a regression in #11599 which never made it into an official release.

### What to review
Also took the liberty to rename variables/arguments for clarity, and added some comments to clarify how the flag changes behavior.


### Testing
- See repro of the issue here: https://test-studio.sanity.dev/test/structure/book;b369f971-12c7-4a2b-bd5f-0db4dcf55df5%2Ctemplate%3Dbook%2Cversion%3DrjOthGRpu;0b362ac2-2670-4fa5-9910-31164b5b25dd%2Ctemplate%3Dauthor%2CparentRefPath%3Dauthor%2Ctype%3Dauthor%2Cversion%3DrjOthGRpu?perspective=rjOthGRpu
- Verify that this branch build is correct: https://test-studio-git-fix-release-reference-validation.sanity.dev/test/structure/book;b369f971-12c7-4a2b-bd5f-0db4dcf55df5%2Ctemplate%3Dbook%2Cversion%3DrjOthGRpu;0b362ac2-2670-4fa5-9910-31164b5b25dd%2Ctemplate%3Dauthor%2CparentRefPath%3Dauthor%2Ctype%3Dauthor%2Cversion%3DrjOthGRpu?perspective=rjOthGRpu

- Also verify that we still have the "reference must be published" versions outside of releases: https://test-studio-git-fix-release-reference-validation.sanity.dev/test/structure/book;ded327a3-ce35-43f4-aaad-46ba28bdb5c9%2Ctemplate%3Dbook;485de2ce-c71a-49f7-8d93-45aabffb466a%2Ctemplate%3Dauthor%2CparentRefPath%3Dauthor%2Ctype%3Dauthor?perspective=foo
- And for drafts: https://test-studio-git-fix-release-reference-validation.sanity.dev/test/structure/book;346a28dd-8bae-4963-b288-dedbb9bcbddf%2Ctemplate%3Dbook;1f0846e7-be40-4064-9ae3-da518227e535%2Ctemplate%3Dauthor%2CparentRefPath%3Dauthor%2Ctype%3Dauthor

### Notes for release
n/a