### PR TITLE
fix(structure): consider selected bundle in "reference changed" check

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ReferenceChangedBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ReferenceChangedBanner.tsx
@@ -33,7 +33,7 @@ interface ParentReferenceInfo {
 
 export const ReferenceChangedBanner = memo(() => {
   const documentPreviewStore = useDocumentPreviewStore()
-  const {selectedReleaseId} = usePerspective()
+  const {selectedPerspectiveName} = usePerspective()
   const {params, groupIndex, routerPanesState, replaceCurrent, BackLink} = usePaneRouter()
   const routerReferenceId = routerPanesState[groupIndex]?.[0].id
   const parentGroup = routerPanesState[groupIndex - 1] as RouterPaneGroup | undefined
@@ -79,7 +79,7 @@ export const ReferenceChangedBanner = memo(() => {
           publishedId,
           (keyedSegmentIndex === -1 ? path : path.slice(0, keyedSegmentIndex)) as string[][],
           {
-            version: selectedReleaseId,
+            version: selectedPerspectiveName,
           },
         )
         .pipe(
@@ -110,7 +110,7 @@ export const ReferenceChangedBanner = memo(() => {
           ),
         ),
     )
-  }, [selectedReleaseId, documentPreviewStore, parentId, parentRefPath])
+  }, [selectedPerspectiveName, documentPreviewStore, parentId, parentRefPath])
   const referenceInfo = useObservable(referenceInfoObservable, {loading: true})
 
   const handleReloadReference = useCallback(() => {


### PR DESCRIPTION
### Description
Small fix for non-release version documents.

Currently, when navigating to a reference of a non-release version, we wrongly display the "This reference has been removed since you opened it"-banner. Repro: https://test-studio.sanity.dev/test/structure/book;1765976089835-autogenerated-9;126c9982-8d39-4a30-a121-3c3578858019%2Ctype%3Dauthor%2CparentRefPath%3Dauthor%2Ctemplate%3Dauthor?perspective=foo

### What to review
- This fixes the issue by making the banner check against `selectedPerspectiveName` instead of `selectedReleaseId`

### Testing
Try the repro url above on the branch build, and verify that the banner doesn't appear: https://test-studio-git-fix-reference-banner-non-release-bundle.sanity.dev/test/structure/book;1765976089835-autogenerated-9;126c9982-8d39-4a30-a121-3c3578858019%2Ctype%3Dauthor%2CparentRefPath%3Dauthor%2Ctemplate%3Dauthor?perspective=foo

### Notes for release
n/a