### PR TITLE
fix(structure): add clickOutside workaround for nested modals

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/NonReleaseVersionsSelect.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/NonReleaseVersionsSelect.tsx
@@ -41,7 +41,8 @@ export function NonReleaseVersionsSelect(props: {
       if (event.target && 'matches' in event.target && typeof event.target.matches === 'function') {
         // note: this is an (ugly) workaround for useClickOutside not working through portals (as its based on elements.contains())
         // do not close dropdown if click happens in a portal
-        // note: this *can* cause false positives if the user clicks outside
+        // note: this *can* cause false positives if the user clicks outside any other portal
+        // element on the page and expects the dropdown to close
         const isPortal = (event.target as {matches: HTMLElement['matches']}).matches(
           '[data-portal] *',
         )


### PR DESCRIPTION
### Description

This [useClickOutside callback](https://github.com/sanity-io/sanity/blob/main/packages/sanity/src/structure/panes/document/documentPanel/header/NonReleaseVersionsSelect.tsx#L37) is triggered by portals rendered by the VersionChip. The useClickOutsideEvent hook is fundamentally broken with portals as it's based on element.contains(), and thus follows the DOM hierarchy, not the React component hierarchy. 

This PR provides a (rather hacky) workaround that adds a check to the "click outside"-callback checking whether the event was triggered inside an element with the `data-portal` attribute, and in that case, ignores it.

### Testing

- Reproduce by opening the non-release version selector, right click to trigger the context menu and select an option that triggers a modal, e.g. "discard version", or "create release". In `main` any click inside the dialog will make it close.
- Doing the same in the preview build should prevent the dialog from closing.


### Notes for release
n/a