### PR TITLE
fix(form): pass current document to reference filter function

### DIFF
--- a/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
+++ b/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
@@ -142,6 +142,9 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
         }).pipe(
           map(({hits}) => hits.map(({hit}) => hit)),
           switchMap((docs) => {
+            // if no hits, return empty array immediately
+            // note that combineLatest([]) will never emit (effectively the same as NEVER), so without this,
+            // the subscriber will never receive any result
             if (docs.length === 0) {
               return of([])
             }


### PR DESCRIPTION
### Description
Currently, when resolving custom reference filters, the document value passed isn't always up-to-date, and e.g. won't reflect the initial value set on the document type.

This fixes the issue by moving to `useEffectEvent()` for the handleSearch callback, resulting in the search callback always seeing the latest document value.

### What to review
- Recommend turning on the "No whitespace" option when reviewing
- Also noticed that in case of no hits, we'd keep showing the spinner. This happens because `combineLatest([])` never emits any value, so I've also added an explicit check for an empty search result and in that case we return an empty array instead of invoking combineLatest

### Testing
- Create a document type with an initial value, and a reference field that uses this value in a custom reference filter.

### Notes for release
- Fixes issue causing custom reference filters to receive a stale document value
- Fixes issue causing reference search to keep showing a spinner when there are no hits