### PR TITLE
fix(core): ensure `_type` is set on initial value templates

### DIFF
--- a/packages/sanity/src/core/store/_legacy/grants/templatePermissions.ts
+++ b/packages/sanity/src/core/store/_legacy/grants/templatePermissions.ts
@@ -102,6 +102,7 @@ export function getTemplatePermissions({
           permission: 'create',
           document: {
             _id: documentId,
+            _type: schemaType.name,
             ...resolvedInitialValue,
           },
         }).pipe(


### PR DESCRIPTION
### Description
Currently,  the document type is not passed on from the initial value to the permission check, so e.g. if defining a template like this:
```
S.documentTypeList('sometype')
	.title('SomeType template')
	.initialValueTemplates(
		S.initialValueTemplateItem('some-template', {
			title: 'Some template',
		}),
	)
```
… the resolved initial value will not include `_type: 'sometype'`. This breaks custom access roles with resource filters like `_type == "sometype"`, giving false negatives saying the user doesn't have create access.

Even setting _type explicitly results in _type getting removed before the document value is passed on to the permission check:
```
S.documentTypeList('sometype')
	.title('SomeType template')
	.initialValueTemplates(
		S.initialValueTemplateItem('some-template', {
			_type: 'sometype',
			title: 'Some template',
		}),
	)
```

### What to review
Does it make sense? I'm a bit surprised its been this way for so long.

### Testing
See repro steps in linear issue, and verify that it works after this PR

### Notes for release
- Fixes an issue causing custom access roles with `_type`-based resource filters to disallow creating new documents where it should be allowed.
