### PR TITLE
fix(releases): don't validate references in releases

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -79,7 +79,7 @@ const getActiveReleaseDocumentsObservable = ({
     // scheduledYield is used to provide some control over the main thread
     return from(schedulerYield(() => Promise.resolve())).pipe(
       switchMap(() =>
-        validateDocumentWithReferences(ctx, of(document), true).pipe(
+        validateDocumentWithReferences(ctx, of(document), false).pipe(
           map((validationStatus) => ({
             ...validationStatus,
             hasError: validationStatus.validation.some((marker) => isValidationErrorMarker(marker)),


### PR DESCRIPTION
### Description
Looks like a regression snuck in to `next`, causing reference existence to be validated for documents in a release on the releases page. This should fix it by passing `requirePublishedReferences=false` when validating documents here.

### What to review
Makes sense?

### Notes for release
n/a – this affected next