### PR TITLE
fix(structure): apply dateTime() ordering to date fields

### DIFF
--- a/packages/sanity/src/structure/panes/documentList/__tests__/helpers.test.ts
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/helpers.test.ts
@@ -33,6 +33,10 @@ const mockSchema = Schema.compile({
       type: 'datetime',
     },
     {
+      name: 'aliasedDate',
+      type: 'date',
+    },
+    {
       name: 'article',
       title: 'Article',
       type: 'document',
@@ -61,6 +65,14 @@ const mockSchema = Schema.compile({
           name: 'relevantUntil',
           type: 'aliasedDateTime',
         },
+        {
+          name: 'releaseDate',
+          type: 'date',
+        },
+        {
+          name: 'expiryDate',
+          type: 'aliasedDate',
+        },
       ],
     },
   ],
@@ -81,6 +93,18 @@ describe('applyOrderingFunctions()', () => {
 
   test('applies `dateTime()` to shallow datetime field orderings', () => {
     const ordering = {by: [{field: 'publishDate', direction: 'desc' as const}]}
+    const withFn = applyOrderingFunctions(ordering, mockSchema.get('article'))
+    expect(withFn).toEqual({by: [{...ordering.by[0], mapWith: 'dateTime'}]})
+  })
+
+  test('applies `dateTime()` to shallow date field orderings', () => {
+    const ordering = {by: [{field: 'releaseDate', direction: 'desc' as const}]}
+    const withFn = applyOrderingFunctions(ordering, mockSchema.get('article'))
+    expect(withFn).toEqual({by: [{...ordering.by[0], mapWith: 'dateTime'}]})
+  })
+
+  test('applies `dateTime()` to aliased date field orderings', () => {
+    const ordering = {by: [{field: 'expiryDate', direction: 'desc' as const}]}
     const withFn = applyOrderingFunctions(ordering, mockSchema.get('article'))
     expect(withFn).toEqual({by: [{...ordering.by[0], mapWith: 'dateTime'}]})
   })
@@ -165,6 +189,22 @@ describe('fieldExtendsType()', () => {
     )!
 
     expect(fieldExtendsType(field, 'number')).toBe(false)
+  })
+
+  test('correctly identifies date fields', () => {
+    const field = (mockSchema.get('article') as ObjectSchemaType).fields.find(
+      (current) => current.name === 'releaseDate',
+    )!
+
+    expect(fieldExtendsType(field, 'date')).toBe(true)
+  })
+
+  test('correctly identifies aliased date fields as date', () => {
+    const field = (mockSchema.get('article') as ObjectSchemaType).fields.find(
+      (current) => current.name === 'expiryDate',
+    )!
+
+    expect(fieldExtendsType(field, 'date')).toBe(true)
   })
 })
 

--- a/packages/sanity/src/structure/panes/documentList/helpers.ts
+++ b/packages/sanity/src/structure/panes/documentList/helpers.ts
@@ -44,8 +44,10 @@ export function applyOrderingFunctions(order: SortOrder, schemaType: ObjectSchem
     }
 
     // Note: order matters here, since the jsonType of a date field is `string`,
-    // but we want to apply `datetime()`, not `lower()`
-    if (fieldExtendsType(fieldType, 'datetime')) {
+    // but we want to apply `dateTime()`, not `lower()`.
+    // Both 'datetime' and 'date' types need the dateTime() GROQ function for proper sorting.
+    // See: https://github.com/sanity-io/sanity/issues/6355
+    if (fieldExtendsType(fieldType, 'datetime') || fieldExtendsType(fieldType, 'date')) {
       return {...by, mapWith: 'dateTime'}
     }
 


### PR DESCRIPTION
## Summary
- Fixes #6355 - Date sort order not working in document lists
- The `applyOrderingFunctions()` helper only applied the `dateTime()` GROQ function to `datetime` fields, not `date` fields
- This caused `date` type fields to be sorted as strings instead of chronologically
- String sorting produces incorrect order (e.g., "2021-11-01" > "2022-03-01" as strings)

## Changes
- Modified `applyOrderingFunctions()` in `helpers.ts` to also check for `date` type fields
- Both `datetime` and `date` fields now get the `dateTime()` GROQ function applied for proper chronological sorting

## Test plan
- [x] Added 2 new tests for `date` field sorting (`releaseDate` direct, `expiryDate` aliased)
- [x] Added 2 new tests for `fieldExtendsType()` with date types
- [x] All 24 tests passing in `helpers.test.ts`
- [x] Existing datetime tests still pass (no regression)

## Technical Details
The GROQ `dateTime()` function works for both `date` and `datetime` types, converting them to comparable values for proper sorting. The fix adds a simple `|| fieldExtendsType(fieldType, 'date')` check alongside the existing `datetime` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)