### PR TITLE
feat: warning on releases overview when release has missed intended publish date

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -186,6 +186,8 @@ const releasesLocaleStrings = {
   'failed-publish-title': 'Failed to publish',
   /** Title text displayed for releases that failed to schedule  */
   'failed-schedule-title': 'Failed to schedule',
+  /** Tooltip text for releases that have passed their intended publish date */
+  'passed-intended-publish-date': 'This release has passed its intended publish date',
 
   /**The text that will be shown in the footer to indicate the time the release was archived */
   'footer.status.archived': 'Archived',

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -28,6 +28,7 @@ import {useArchivedReleases} from '../../store/useArchivedReleases'
 import {useReleaseOperations} from '../../store/useReleaseOperations'
 import {useReleasePermissions} from '../../store/useReleasePermissions'
 import {type ReleasesMetadata, useReleasesMetadata} from '../../store/useReleasesMetadata'
+import {getIsScheduledDateInPast} from '../../util/getIsScheduledDateInPast'
 import {getReleaseTone} from '../../util/getReleaseTone'
 import {getReleaseDefaults, shouldShowReleaseInView} from '../../util/util'
 import {Table, type TableRowProps} from '../components/Table/Table'
@@ -122,15 +123,21 @@ export function ReleasesOverview() {
   const mediaIndex = useMediaIndex()
 
   const getRowProps = useCallback(
-    (datum: TableRelease): Partial<TableRowProps> =>
-      datum.isDeleted
-        ? {tone: 'transparent'}
-        : {
-            tone:
-              isReleaseDocument(selectedPerspective) && selectedPerspective._id === datum._id
-                ? getReleaseTone(datum)
-                : 'default',
-          },
+    (datum: TableRelease): Partial<TableRowProps> => {
+      if (datum.isDeleted) {
+        return {tone: 'transparent'}
+      }
+
+      if (isReleaseDocument(selectedPerspective) && selectedPerspective._id === datum._id) {
+        return {tone: getReleaseTone(datum)}
+      }
+
+      if (datum.state === 'active' && getIsScheduledDateInPast(datum)) {
+        return {tone: 'caution'}
+      }
+
+      return {tone: 'default'}
+    },
     [selectedPerspective],
   )
 

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverviewColumnDefs.tsx
@@ -1,12 +1,12 @@
-import {CheckmarkCircleIcon, ErrorOutlineIcon, LockIcon} from '@sanity/icons'
+import {CheckmarkCircleIcon, ErrorOutlineIcon, LockIcon, WarningOutlineIcon} from '@sanity/icons'
 import {Card, Flex, Text} from '@sanity/ui'
 // eslint-disable-next-line @sanity/i18n/no-i18next-import -- figure out how to have the linter be fine with importing types-only
 import {type TFunction} from 'i18next'
-import {Fragment} from 'react'
 
 import {ToneIcon} from '../../../../ui-components/toneIcon/ToneIcon'
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
 import {RelativeTime} from '../../../components'
+import {getIsScheduledDateInPast} from '../../util/getIsScheduledDateInPast'
 import {getPublishDateFromRelease, isReleaseScheduledOrScheduling} from '../../util/util'
 import {ReleaseTime} from '../components/ReleaseTime'
 import {Headers} from '../components/Table/TableHeader'
@@ -211,25 +211,39 @@ export const releasesOverviewColumnDefs: (
         id: 'error',
         sorting: false,
         width: 40,
-        header: () => <Fragment />,
-        cell: ({datum: {error, state}, cellProps}) => (
-          <Flex
-            {...cellProps}
-            align="center"
-            paddingX={2}
-            paddingY={3}
-            sizing="border"
-            data-testid="error-indicator"
-          >
-            {typeof error !== 'undefined' && state === 'active' && (
-              <Tooltip content={<Text size={1}>{t('failed-publish-title')}</Text>} portal>
-                <Text size={1}>
-                  <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
-                </Text>
-              </Tooltip>
-            )}
-          </Flex>
-        ),
+        header: ({headerProps}) => <Flex {...headerProps} paddingY={3} sizing="border" />,
+        cell: ({datum, cellProps}) => {
+          const {error, state} = datum
+          const hasError = typeof error !== 'undefined' && state === 'active'
+          const hasWarning = state === 'active' && getIsScheduledDateInPast(datum)
+
+          return (
+            <Flex
+              {...cellProps}
+              align="center"
+              gap={2}
+              paddingX={2}
+              paddingY={3}
+              sizing="border"
+              data-testid="error-indicator"
+            >
+              {hasError && (
+                <Tooltip content={<Text size={1}>{t('failed-publish-title')}</Text>} portal>
+                  <Text size={1}>
+                    <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
+                  </Text>
+                </Tooltip>
+              )}
+              {hasWarning && (
+                <Tooltip content={<Text size={1}>{t('passed-intended-publish-date')}</Text>} portal>
+                  <Text size={1}>
+                    <ToneIcon icon={WarningOutlineIcon} tone="caution" />
+                  </Text>
+                </Tooltip>
+              )}
+            </Flex>
+          )
+        },
       },
       'all',
     ),


### PR DESCRIPTION
### Description
> [!NOTE]
> This change, including copy, has already received design approval
 
<img width="1216" height="549" alt="Screenshot 2025-12-30 at 12 29 02" src="https://github.com/user-attachments/assets/f5d8e90c-e37e-454c-bc9f-63d9ed6cd579" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
A warning will now appear to flag Content Releases that have missed their intended publish date
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
