### PR TITLE
chore: add workflow to auto tag example only PRs

### DIFF
--- a/.github/workflows/label-examples-pr.yml
+++ b/.github/workflows/label-examples-pr.yml
@@ -1,0 +1,35 @@
+name: Label Examples-Only PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label-examples:
+    runs-on: ubuntu-latest
+    name: Label PR based on file changes
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check if only examples files changed
+        id: check
+        uses: ./.github/actions/check-examples-only
+
+      - name: Add examples label
+        if: steps.check.outputs.examples_only == 'true'
+        run: gh pr edit ${{ github.event.pull_request.number }} --add-label "examples"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Remove examples label
+        if: steps.check.outputs.examples_only != 'true'
+        run: gh pr edit ${{ github.event.pull_request.number }} --remove-label "examples" || true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
### Description
Many PRs are made that only include changes for the `examples` directory.

To make it easier to flag when a PR is not relevant for Studio team, this PR adds in a new auto-added `examples` github tag to the PR.

This also adds in `paths-ignore` so that branches that only have changes in `example` dir do not run any of our tests.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
This needs to be merged to `main` in order to be tested. I'll monitor and react with any fixes once that's done.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
