### PR TITLE
feat(typegen): add ArrayOf utility type for inline object array members

### DIFF
--- a/packages/@sanity/cli/src/actions/typegen/__tests__/generateAction.test.ts
+++ b/packages/@sanity/cli/src/actions/typegen/__tests__/generateAction.test.ts
@@ -243,9 +243,9 @@ test(generateAction.name, async () => {
 
     export declare const internalGroqTypeReferenceTo: unique symbol;
 
-    type ArrayMember<T> = T & {
+    type ArrayOf<T> = Array<T & {
       _key: string;
-    };
+    }>;
 
     // Source: src/queries.ts
     // Variable: postTitles
@@ -308,9 +308,11 @@ test(generateAction.name, async () => {
 
     export declare const internalGroqTypeReferenceTo: unique symbol;
 
-    type ArrayMember<T> = T & {
-      _key: string;
-    };
+    type ArrayOf<T> = Array<
+      T & {
+        _key: string;
+      }
+    >;
 
     // Source: src/queries.ts
     // Variable: postTitles
@@ -350,7 +352,7 @@ test(generateAction.name, async () => {
         "configOverloadClientMethods": true,
         "emptyUnionTypeNodesGenerated": 0,
         "filesWithErrors": 1,
-        "outputSize": 871,
+        "outputSize": 874,
         "queriesCount": 2,
         "queryFilesCount": 1,
         "schemaTypesCount": 2,

--- a/packages/@sanity/cli/test/__snapshots__/typegen.test.ts.snap
+++ b/packages/@sanity/cli/test/__snapshots__/typegen.test.ts.snap
@@ -36,9 +36,11 @@ export type AllSanitySchemaTypes = Person | Slug;
 
 export declare const internalGroqTypeReferenceTo: unique symbol;
 
-type ArrayMember<T> = T & {
-  _key: string;
-};
+type ArrayOf<T> = Array<
+  T & {
+    _key: string;
+  }
+>;
 
 // Source: src/queries.ts
 // Variable: PAGE_QUERY
@@ -83,9 +85,11 @@ export type AllSanitySchemaTypes = Person | Slug;
 
 export declare const internalGroqTypeReferenceTo: unique symbol;
 
-type ArrayMember<T> = T & {
-  _key: string;
-};
+type ArrayOf<T> = Array<
+  T & {
+    _key: string;
+  }
+>;
 
 // Source: src/queries.ts
 // Variable: PAGE_QUERY

--- a/packages/@sanity/codegen/src/typescript/__tests__/__snapshots__/typeGenerator.test.ts.snap
+++ b/packages/@sanity/codegen/src/typescript/__tests__/__snapshots__/typeGenerator.test.ts.snap
@@ -1,0 +1,49 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`TypeGenerator > ArrayOf should be handled for a complex query too 1`] = `
+"export type Post = {
+  _id: string;
+  _type: "post";
+  sections?: Array<{
+    _key: string;
+    _type: "section";
+    title?: string;
+  }>;
+  tags?: ArrayOf<Tag | Rag>;
+  strings: Array<string>;
+};
+
+export type Tag = {
+  _key: string;
+  _type: "tag";
+  label?: string;
+};
+
+export type Rag = {
+  _key: string;
+  _type: "rag";
+  color?: string;
+};
+
+export type AllSanitySchemaTypes = Post | Tag | Rag;
+
+export declare const internalGroqTypeReferenceTo: unique symbol;
+
+type ArrayOf<T> = Array<T & {
+  _key: string;
+}>;
+
+// Source: foo.ts
+// Variable: STRANGE_QUERY
+// Query: *[_type == "post"]{              sections[]{                ...,                "_key": 123              },              "surpriseField": coalesce(tags[_type == "rag"], *[_type == 'post'][0].strings, 123)            }
+export type STRANGE_QUERY_RESULT = Array<{
+  sections: Array<{
+    _key: 123;
+    _type: "section";
+    title?: string;
+  }> | null;
+  surpriseField: Array<string> | ArrayOf<Rag> | 123;
+}>;
+
+"
+`;

--- a/packages/@sanity/codegen/src/typescript/constants.ts
+++ b/packages/@sanity/codegen/src/typescript/constants.ts
@@ -3,10 +3,10 @@ import * as t from '@babel/types'
 export const INTERNAL_REFERENCE_SYMBOL = t.identifier('internalGroqTypeReferenceTo')
 export const ALL_SANITY_SCHEMA_TYPES = t.identifier('AllSanitySchemaTypes')
 export const SANITY_QUERIES = t.identifier('SanityQueries')
-export const ARRAY_MEMBER = t.identifier('ArrayMember')
+export const ARRAY_OF = t.identifier('ArrayOf')
 
 export const RESERVED_IDENTIFIERS = new Set<string>()
 RESERVED_IDENTIFIERS.add(SANITY_QUERIES.name)
 RESERVED_IDENTIFIERS.add(ALL_SANITY_SCHEMA_TYPES.name)
 RESERVED_IDENTIFIERS.add(INTERNAL_REFERENCE_SYMBOL.name)
-RESERVED_IDENTIFIERS.add(ARRAY_MEMBER.name)
+RESERVED_IDENTIFIERS.add(ARRAY_OF.name)

--- a/packages/@sanity/codegen/src/typescript/helpers.ts
+++ b/packages/@sanity/codegen/src/typescript/helpers.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 
 import {CodeGenerator} from '@babel/generator'
 import * as t from '@babel/types'
-import {type ObjectTypeNode} from 'groq-js'
+import {type ArrayTypeNode, type UnionTypeNode} from 'groq-js'
 
 import {RESERVED_IDENTIFIERS} from './constants'
 
@@ -59,7 +59,19 @@ export function generateCode(node: t.Node) {
   return `${new CodeGenerator(node).generate().code.trim()}\n\n`
 }
 
-export function isObjectArrayMember(typeNode: ObjectTypeNode): boolean {
-  const {attributes, rest} = typeNode
-  return '_key' in attributes || (rest?.type === 'object' && '_key' in rest.attributes)
+export function getFilterArrayUnionType(
+  typeNode: ArrayTypeNode,
+  predicate: (unionTypeNode: UnionTypeNode['of'][number]) => boolean,
+): ArrayTypeNode {
+  if (typeNode.of.type !== 'union') {
+    return typeNode
+  }
+
+  return {
+    ...typeNode,
+    of: {
+      ...typeNode.of,
+      of: typeNode.of.of.filter(predicate),
+    },
+  } satisfies ArrayTypeNode<UnionTypeNode>
 }


### PR DESCRIPTION
### Description

We're currently repeating the `{ _key: string } & T` throughout the schema. This PR aims to make the generated types a bit more readable and to reduce code duplication by wrapping array members created from inlined types in an `ArrayOf` type that looks like this:

```typescript
type ArrayOf<T> = Array<T & { _key: string}>
```

The `ArrayOf` type is **not** exported from the generated types file as we don't want it to be used outside the types file, and that it would make changes in the type generation harder going forward since people would probably start depending on it in their projects..

Type utils intended for external usage will be distributed through properly versioned packages on npm instead.

### What to review

The logic around identifying an array member, and the snapshot diffs.

### Testing

Snapshots has been updated to reflect the change, but for an end user this change should not have an impact on the exported types other than them being less repetetive.

I've also added tests for types generated for both schema and queries containing the `ArrayOf` type, asserting that it does not `_key` types that shouldn't be (string, numbers, null...) and that objects are wrapped in a simple `Array` as before.

### Notes for release

Reduce size of generated TS by using an `ArrayOf` util type for inline object array members.