### PR TITLE
feat: add support for thumbhash 

### DIFF
--- a/dev/efps/tests/article/sanity.types.ts
+++ b/dev/efps/tests/article/sanity.types.ts
@@ -463,6 +463,7 @@ export type SanityImageMetadata = {
   palette?: SanityImagePalette
   lqip?: string
   blurHash?: string
+  thumbHash?: string
   hasAlpha?: boolean
   isOpaque?: boolean
 }

--- a/dev/efps/tests/recipe/sanity.types.ts
+++ b/dev/efps/tests/recipe/sanity.types.ts
@@ -193,6 +193,7 @@ export type SanityImageMetadata = {
   palette?: SanityImagePalette
   lqip?: string
   blurHash?: string
+  thumbHash?: string
   hasAlpha?: boolean
   isOpaque?: boolean
 }

--- a/dev/efps/tests/synthetic/sanity.types.ts
+++ b/dev/efps/tests/synthetic/sanity.types.ts
@@ -202,6 +202,7 @@ export type SanityImageMetadata = {
   palette?: SanityImagePalette
   lqip?: string
   blurHash?: string
+  thumbHash?: string
   hasAlpha?: boolean
   isOpaque?: boolean
 }

--- a/packages/@sanity/schema/src/sanity/builtinTypes/imageMetadata.ts
+++ b/packages/@sanity/schema/src/sanity/builtinTypes/imageMetadata.ts
@@ -41,6 +41,12 @@ export default {
       readOnly: true,
     },
     {
+      name: 'thumbHash',
+      title: 'ThumbHash',
+      type: 'string',
+      readOnly: true,
+    },
+    {
       name: 'hasAlpha',
       title: 'Has alpha channel',
       type: 'boolean',

--- a/packages/@sanity/schema/test/extractSchema/__snapshots__/extractSchema.test.ts.snap
+++ b/packages/@sanity/schema/test/extractSchema/__snapshots__/extractSchema.test.ts.snap
@@ -395,6 +395,13 @@ exports[`Extract schema test > Can hoist types > Hoist repeated objects 1`] = `
             "type": "inline",
           },
         },
+        "thumbHash": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+          },
+        },
       },
       "type": "object",
     },
@@ -1420,6 +1427,13 @@ exports[`Extract schema test > Can hoist types > hoisted inline types should not
           "value": {
             "name": "sanity.imagePalette",
             "type": "inline",
+          },
+        },
+        "thumbHash": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
           },
         },
       },
@@ -3203,6 +3217,13 @@ exports[`Extract schema test > Extracts schema general 1`] = `
           "value": {
             "name": "sanity.imagePalette",
             "type": "inline",
+          },
+        },
+        "thumbHash": {
+          "optional": true,
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
           },
         },
       },

--- a/packages/@sanity/types/src/assets/types.ts
+++ b/packages/@sanity/types/src/assets/types.ts
@@ -62,6 +62,7 @@ export interface ImageMetadata {
   palette?: ImagePalette
   lqip?: string
   blurHash?: string
+  thumbHash?: string
   hasAlpha: boolean
   isOpaque: boolean
 }
@@ -166,6 +167,7 @@ export type AssetMetadataType =
   | 'palette'
   | 'lqip'
   | 'blurhash'
+  | 'thumbhash'
   | 'none'
 
 /** @beta */
@@ -179,7 +181,7 @@ export interface AssetSource {
 
   i18nKey?: string
   component: ComponentType<AssetSourceComponentProps>
-  icon?: ComponentType<EmptyProps>
+  icon?: ComponentType
   /** @beta */
   Uploader?: AssetSourceUploaderClass
 }

--- a/packages/@sanity/types/src/schema/definition/type/image.ts
+++ b/packages/@sanity/types/src/schema/definition/type/image.ts
@@ -6,7 +6,14 @@ import {type FileOptions, type FileValue} from './file'
 import {type ObjectDefinition} from './object'
 
 /** @public */
-export type ImageMetadataType = 'blurhash' | 'lqip' | 'palette' | 'exif' | 'image' | 'location'
+export type ImageMetadataType =
+  | 'blurhash'
+  | 'thumbhash'
+  | 'lqip'
+  | 'palette'
+  | 'exif'
+  | 'image'
+  | 'location'
 
 /** @public */
 export interface HotspotPreview {

--- a/packages/@sanity/types/test/image.test.ts
+++ b/packages/@sanity/types/test/image.test.ts
@@ -38,7 +38,7 @@ describe('image types', () => {
         collapsed: true,
         collapsible: true,
         columns: 2,
-        metadata: ['blurhash', 'lqip', 'palette', 'exif', 'location'],
+        metadata: ['blurhash', 'thumbhash', 'lqip', 'palette', 'exif', 'location'],
         hotspot: true,
         storeOriginalFilename: true,
         accept: 'yolo/files',

--- a/packages/sanity/src/core/form/studio/utils/tests/index.ts
+++ b/packages/sanity/src/core/form/studio/utils/tests/index.ts
@@ -114,6 +114,12 @@ export const requiredImageTypes = [
         readOnly: true,
       },
       {
+        name: 'thumbHash',
+        title: 'ThumbHash',
+        type: 'string',
+        readOnly: true,
+      },
+      {
         name: 'hasAlpha',
         title: 'Has alpha channel',
         type: 'boolean',

--- a/packages/sanity/test/cli/graphql/__snapshots__/extract.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/extract.test.ts.snap
@@ -1531,6 +1531,11 @@ exports[`GraphQL - Schema extraction > Should be able to extract a simple schema
           "fieldName": "palette",
           "type": "SanityImagePalette",
         },
+        {
+          "description": undefined,
+          "fieldName": "thumbHash",
+          "type": "String",
+        },
       ],
       "kind": "Type",
       "name": "SanityImageMetadata",
@@ -2498,6 +2503,11 @@ exports[`GraphQL - Schema extraction > Should be able to extract schema with uni
         {
           "fieldName": "palette",
           "type": "SanityImagePalette",
+        },
+        {
+          "description": undefined,
+          "fieldName": "thumbHash",
+          "type": "String",
         },
       ],
       "kind": "Type",

--- a/packages/sanity/test/cli/graphql/__snapshots__/gen2.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/gen2.test.ts.snap
@@ -4223,6 +4223,11 @@ exports[`GraphQL - Generation 2 > Should be able to generate graphql schema 1`] 
           "fieldName": "palette",
           "type": "SanityImagePalette",
         },
+        {
+          "description": undefined,
+          "fieldName": "thumbHash",
+          "type": "String",
+        },
       ],
       "kind": "Type",
       "name": "SanityImageMetadata",
@@ -4277,6 +4282,11 @@ exports[`GraphQL - Generation 2 > Should be able to generate graphql schema 1`] 
           "isReference": undefined,
           "type": "SanityImagePaletteFilter",
         },
+        {
+          "fieldName": "thumbHash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
       ],
       "kind": "InputObject",
       "name": "SanityImageMetadataFilter",
@@ -4318,6 +4328,10 @@ exports[`GraphQL - Generation 2 > Should be able to generate graphql schema 1`] 
         {
           "fieldName": "palette",
           "type": "SanityImagePaletteSorting",
+        },
+        {
+          "fieldName": "thumbHash",
+          "type": "SortOrder",
         },
       ],
       "kind": "InputObject",

--- a/packages/sanity/test/cli/graphql/__snapshots__/gen3.test.ts.snap
+++ b/packages/sanity/test/cli/graphql/__snapshots__/gen3.test.ts.snap
@@ -4312,6 +4312,11 @@ exports[`GraphQL - Generation 3 > Should be able to generate graphql schema 1`] 
           "fieldName": "palette",
           "type": "SanityImagePalette",
         },
+        {
+          "description": undefined,
+          "fieldName": "thumbHash",
+          "type": "String",
+        },
       ],
       "kind": "Type",
       "name": "SanityImageMetadata",
@@ -4366,6 +4371,11 @@ exports[`GraphQL - Generation 3 > Should be able to generate graphql schema 1`] 
           "isReference": undefined,
           "type": "SanityImagePaletteFilter",
         },
+        {
+          "fieldName": "thumbHash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
       ],
       "kind": "InputObject",
       "name": "SanityImageMetadataFilter",
@@ -4407,6 +4417,10 @@ exports[`GraphQL - Generation 3 > Should be able to generate graphql schema 1`] 
         {
           "fieldName": "palette",
           "type": "SanityImagePaletteSorting",
+        },
+        {
+          "fieldName": "thumbHash",
+          "type": "SortOrder",
         },
       ],
       "kind": "InputObject",
@@ -9151,6 +9165,11 @@ exports[`GraphQL - Generation 3 > Should be able to generate graphql schema with
           "fieldName": "palette",
           "type": "SanityImagePalette",
         },
+        {
+          "description": undefined,
+          "fieldName": "thumbHash",
+          "type": "String",
+        },
       ],
       "kind": "Type",
       "name": "SanityImageMetadata",
@@ -9205,6 +9224,11 @@ exports[`GraphQL - Generation 3 > Should be able to generate graphql schema with
           "isReference": undefined,
           "type": "SanityImagePaletteCustomFilterSuffix",
         },
+        {
+          "fieldName": "thumbHash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
       ],
       "kind": "InputObject",
       "name": "SanityImageMetadataCustomFilterSuffix",
@@ -9246,6 +9270,10 @@ exports[`GraphQL - Generation 3 > Should be able to generate graphql schema with
         {
           "fieldName": "palette",
           "type": "SanityImagePaletteSorting",
+        },
+        {
+          "fieldName": "thumbHash",
+          "type": "SortOrder",
         },
       ],
       "kind": "InputObject",
@@ -14328,6 +14356,11 @@ exports[`GraphQL - Generation 3 > Union cache: sanitySchema: 'manySelfRefsSchema
           "fieldName": "palette",
           "type": "SanityImagePalette",
         },
+        {
+          "description": undefined,
+          "fieldName": "thumbHash",
+          "type": "String",
+        },
       ],
       "kind": "Type",
       "name": "SanityImageMetadata",
@@ -14382,6 +14415,11 @@ exports[`GraphQL - Generation 3 > Union cache: sanitySchema: 'manySelfRefsSchema
           "isReference": undefined,
           "type": "SanityImagePaletteFilter",
         },
+        {
+          "fieldName": "thumbHash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
       ],
       "kind": "InputObject",
       "name": "SanityImageMetadataFilter",
@@ -14423,6 +14461,10 @@ exports[`GraphQL - Generation 3 > Union cache: sanitySchema: 'manySelfRefsSchema
         {
           "fieldName": "palette",
           "type": "SanityImagePaletteSorting",
+        },
+        {
+          "fieldName": "thumbHash",
+          "type": "SortOrder",
         },
       ],
       "kind": "InputObject",
@@ -24728,6 +24770,11 @@ exports[`GraphQL - Generation 3 > Union cache: sanitySchema: 'manySelfRefsSchema
           "fieldName": "palette",
           "type": "SanityImagePalette",
         },
+        {
+          "description": undefined,
+          "fieldName": "thumbHash",
+          "type": "String",
+        },
       ],
       "kind": "Type",
       "name": "SanityImageMetadata",
@@ -24782,6 +24829,11 @@ exports[`GraphQL - Generation 3 > Union cache: sanitySchema: 'manySelfRefsSchema
           "isReference": undefined,
           "type": "SanityImagePaletteFilter",
         },
+        {
+          "fieldName": "thumbHash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
       ],
       "kind": "InputObject",
       "name": "SanityImageMetadataFilter",
@@ -24823,6 +24875,10 @@ exports[`GraphQL - Generation 3 > Union cache: sanitySchema: 'manySelfRefsSchema
         {
           "fieldName": "palette",
           "type": "SanityImagePaletteSorting",
+        },
+        {
+          "fieldName": "thumbHash",
+          "type": "SortOrder",
         },
       ],
       "kind": "InputObject",
@@ -34790,6 +34846,11 @@ exports[`GraphQL - Generation 3 > Union cache: sanitySchema: 'testStudioSchema' 
           "fieldName": "palette",
           "type": "SanityImagePalette",
         },
+        {
+          "description": undefined,
+          "fieldName": "thumbHash",
+          "type": "String",
+        },
       ],
       "kind": "Type",
       "name": "SanityImageMetadata",
@@ -34844,6 +34905,11 @@ exports[`GraphQL - Generation 3 > Union cache: sanitySchema: 'testStudioSchema' 
           "isReference": undefined,
           "type": "SanityImagePaletteFilter",
         },
+        {
+          "fieldName": "thumbHash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
       ],
       "kind": "InputObject",
       "name": "SanityImageMetadataFilter",
@@ -34885,6 +34951,10 @@ exports[`GraphQL - Generation 3 > Union cache: sanitySchema: 'testStudioSchema' 
         {
           "fieldName": "palette",
           "type": "SanityImagePaletteSorting",
+        },
+        {
+          "fieldName": "thumbHash",
+          "type": "SortOrder",
         },
       ],
       "kind": "InputObject",
@@ -39629,6 +39699,11 @@ exports[`GraphQL - Generation 3 > Union cache: sanitySchema: 'testStudioSchema' 
           "fieldName": "palette",
           "type": "SanityImagePalette",
         },
+        {
+          "description": undefined,
+          "fieldName": "thumbHash",
+          "type": "String",
+        },
       ],
       "kind": "Type",
       "name": "SanityImageMetadata",
@@ -39683,6 +39758,11 @@ exports[`GraphQL - Generation 3 > Union cache: sanitySchema: 'testStudioSchema' 
           "isReference": undefined,
           "type": "SanityImagePaletteFilter",
         },
+        {
+          "fieldName": "thumbHash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
       ],
       "kind": "InputObject",
       "name": "SanityImageMetadataFilter",
@@ -39724,6 +39804,10 @@ exports[`GraphQL - Generation 3 > Union cache: sanitySchema: 'testStudioSchema' 
         {
           "fieldName": "palette",
           "type": "SanityImagePaletteSorting",
+        },
+        {
+          "fieldName": "thumbHash",
+          "type": "SortOrder",
         },
       ],
       "kind": "InputObject",
@@ -42723,6 +42807,11 @@ exports[`GraphQL - Generation 3 > Union cache: sanitySchema: 'unionRefsSchema' >
           "fieldName": "palette",
           "type": "SanityImagePalette",
         },
+        {
+          "description": undefined,
+          "fieldName": "thumbHash",
+          "type": "String",
+        },
       ],
       "kind": "Type",
       "name": "SanityImageMetadata",
@@ -42777,6 +42866,11 @@ exports[`GraphQL - Generation 3 > Union cache: sanitySchema: 'unionRefsSchema' >
           "isReference": undefined,
           "type": "SanityImagePaletteFilter",
         },
+        {
+          "fieldName": "thumbHash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
       ],
       "kind": "InputObject",
       "name": "SanityImageMetadataFilter",
@@ -42818,6 +42912,10 @@ exports[`GraphQL - Generation 3 > Union cache: sanitySchema: 'unionRefsSchema' >
         {
           "fieldName": "palette",
           "type": "SanityImagePaletteSorting",
+        },
+        {
+          "fieldName": "thumbHash",
+          "type": "SortOrder",
         },
       ],
       "kind": "InputObject",
@@ -45898,6 +45996,11 @@ exports[`GraphQL - Generation 3 > Union cache: sanitySchema: 'unionRefsSchema' >
           "fieldName": "palette",
           "type": "SanityImagePalette",
         },
+        {
+          "description": undefined,
+          "fieldName": "thumbHash",
+          "type": "String",
+        },
       ],
       "kind": "Type",
       "name": "SanityImageMetadata",
@@ -45952,6 +46055,11 @@ exports[`GraphQL - Generation 3 > Union cache: sanitySchema: 'unionRefsSchema' >
           "isReference": undefined,
           "type": "SanityImagePaletteFilter",
         },
+        {
+          "fieldName": "thumbHash",
+          "isReference": undefined,
+          "type": "StringFilter",
+        },
       ],
       "kind": "InputObject",
       "name": "SanityImageMetadataFilter",
@@ -45993,6 +46101,10 @@ exports[`GraphQL - Generation 3 > Union cache: sanitySchema: 'unionRefsSchema' >
         {
           "fieldName": "palette",
           "type": "SanityImagePaletteSorting",
+        },
+        {
+          "fieldName": "thumbHash",
+          "type": "SortOrder",
         },
       ],
       "kind": "InputObject",

--- a/packages/sanity/test/cli/graphql/fixtures/many-self-refs.ts
+++ b/packages/sanity/test/cli/graphql/fixtures/many-self-refs.ts
@@ -228,6 +228,12 @@ export default Schema.compile({
           readOnly: true,
         },
         {
+          name: 'thumbHash',
+          title: 'ThumbHash',
+          type: 'string',
+          readOnly: true,
+        },
+        {
           name: 'hasAlpha',
           title: 'Has alpha channel',
           type: 'boolean',

--- a/packages/sanity/test/cli/graphql/fixtures/test-studio.ts
+++ b/packages/sanity/test/cli/graphql/fixtures/test-studio.ts
@@ -401,6 +401,12 @@ export default Schema.compile({
           readOnly: true,
         },
         {
+          name: 'thumbHash',
+          title: 'ThumbHash',
+          type: 'string',
+          readOnly: true,
+        },
+        {
           name: 'hasAlpha',
           title: 'Has alpha channel',
           type: 'boolean',

--- a/packages/sanity/test/cli/graphql/fixtures/union-refs.ts
+++ b/packages/sanity/test/cli/graphql/fixtures/union-refs.ts
@@ -252,6 +252,12 @@ export default Schema.compile({
           readOnly: true,
         },
         {
+          name: 'thumbHash',
+          title: 'ThumbHash',
+          type: 'string',
+          readOnly: true,
+        },
+        {
           name: 'hasAlpha',
           title: 'Has alpha channel',
           type: 'boolean',


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This adds support for the new Thumbhash field in the media library. Thumbhash provides an efficent way to embed placeholder images: https://evanw.github.io/thumbhash/

I had to add this field to the sanity client too (see [#1178](https://github.com/sanity-io/client/pull/1178)), hence the package update. 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

We've added thumbhash suppoort to the media-library. This is currently on staging, but I intend to promote this to production this afternoon. This is implemented on a best-effort basis for all image formats, however should it fail the feild will not be populated. Users get their Thumbhash but querying the api for their current image asset version. 

**Example**

POST `api.sanity.work/vX/media-libraries/mlJw3CVBf0dh/query/`
Body: `{"query": "*[assetType==\"sanity.imageAsset\" && currentVersion->_id==\"image-cb1d7680628b0bfce42af5df8e1f419219dd5d5b-600x500-jpg\"]{ currentVersion-> }"}`

This returns a result like:
```json
{
    "query": "*[assetType==\"sanity.imageAsset\" && currentVersion->_id==\"image-cb1d7680628b0bfce42af5df8e1f419219dd5d5b-600x500-jpg\"]{ currentVersion-> }",
    "result": [
        {
            "currentVersion": {
                "_createdAt": "2026-01-05T11:48:56Z",
                "_id": "image-cb1d7680628b0bfce42af5df8e1f419219dd5d5b-600x500-jpg",
                "_rev": "dIGib8TfVFCdgqcbI81F7E",
                "_system": {
                    "createdBy": "gNahGPv88"
                },
                "_type": "sanity.imageAsset",
                "_updatedAt": "2026-01-05T11:48:59Z",
                "cdnAccessPolicy": "public",
                "extension": "jpg",
                "metadata": {
                    "_type": "sanity.imageMetadata",
                    "blurHash": "eKIP0#+W0CE4?E00Sj^%xunz5xWrIaI_-LTNjEIXNLNgm$a#-;$_9g",
                    "dimensions": {
                        "_type": "sanity.imageDimensions",
                        "aspectRatio": 1.2,
                        "height": 500,
                        "width": 600
                    },
                    "exif": {
                        "PixelXDimension": 600,
                        "PixelYDimension": 500,
                        "_type": "sanity.imageExifMetadata"
                    },
                    "hasAlpha": false,
                    "image": {
                        "ExifOffset": 90,
                        "Orientation": 1,
                        "ResolutionUnit": 2,
                        "XResolution": 96,
                        "YResolution": 96,
                        "_type": "sanity.imageExifTags"
                    },
                    "isOpaque": true,
                    "lqip": "data:image/jpeg;base64,/9j/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAARABQDASIAAhEBAxEB/8QAGQABAQEAAwAAAAAAAAAAAAAAAAYDBAUH/8QAKhAAAQMDAQYGAwAAAAAAAAAAAQACBAMFETEGBxIUIlETFSE0NUNyc7H/xAAWAQEBAQAAAAAAAAAAAAAAAAAGBAX/xAAhEQABAwMFAQEAAAAAAAAAAAABAAIRAwQhMTVBYXESgf/aAAwDAQACEQMRAD8A43lzoroT5DeKNWcOpuhGVSbQ26HTm0GWumeF7QA0DUrTdswXG4MtE2jzEA9Yz9R757K+2wtcSyReYg0Q6o/DBV4s+GqC6/bdCYLwCBmGmdCRx35hZ4ZbOt3Oz84PYjULymtBdSqOY8Yc30KLsqmC8knJOpRMqVJwYBUMnk9o2+qC4logLXdr76b+tv8AVXbQ/FSPyCIhV3vVL8Sijtz/AAqJdqiIniJr/9k=",
                    "palette": {
                        "_type": "sanity.imagePalette",
                        "darkMuted": {
                            "_type": "sanity.imagePaletteSwatch",
                            "background": "#706034",
                            "foreground": "#fff",
                            "population": 1.67,
                            "title": "#fff"
                        },
                        "darkVibrant": {
                            "_type": "sanity.imagePaletteSwatch",
                            "background": "#1a69b0",
                            "foreground": "#fff",
                            "population": 0.81,
                            "title": "#fff"
                        },
                        "dominant": {
                            "_type": "sanity.imagePaletteSwatch",
                            "background": "#4ca4fc",
                            "foreground": "#fff",
                            "population": 9.05,
                            "title": "#fff"
                        },
                        "lightMuted": {
                            "_type": "sanity.imagePaletteSwatch",
                            "background": "#ecebe6",
                            "foreground": "#000",
                            "population": 7.08,
                            "title": "#000"
                        },
                        "lightVibrant": {
                            "_type": "sanity.imagePaletteSwatch",
                            "background": "#4ca4fc",
                            "foreground": "#fff",
                            "population": 9.05,
                            "title": "#fff"
                        },
                        "muted": {
                            "_type": "sanity.imagePaletteSwatch",
                            "background": "#425c7a",
                            "foreground": "#fff",
                            "population": 0.94,
                            "title": "#fff"
                        },
                        "vibrant": {
                            "_type": "sanity.imagePaletteSwatch",
                            "background": "#f9d820",
                            "foreground": "#000",
                            "population": 8.32,
                            "title": "#000"
                        }
                    },
                    "thumbHash": "57YJPogEpniAm3eId5h3V6eHDHjBcDc="
                },
                "mimeType": "image/jpeg",
                "originalFilename": "homer_simpson_feature.jpg",
                "path": "media-libraries/mlJw3CVBf0dh/images/cb1d7680628b0bfce42af5df8e1f419219dd5d5b-600x500.jpg",
                "sha1hash": "cb1d7680628b0bfce42af5df8e1f419219dd5d5b",
                "size": 36093,
                "source": {
                    "id": "image-cb1d7680628b0bfce42af5df8e1f419219dd5d5b-600x500-jpg",
                    "name": "sanity-image",
                    "url": "https://cdn.sanity.work/media-libraries/mlJw3CVBf0dh/images/cb1d7680628b0bfce42af5df8e1f419219dd5d5b-600x500.jpg"
                },
                "state": "ready",
                "url": "https://cdn.sanity.work/media-libraries/mlJw3CVBf0dh/images/cb1d7680628b0bfce42af5df8e1f419219dd5d5b-600x500.jpg"
            }
        }
    ],
    "syncTags": [
        "s1:YE3oEw",
        "s1:0oGyMg",
        "s1:IhJm/g",
        "s1:8ZIbdg",
        "s1:Y+jSrA",
        "s1:u006Aw",
        "s1:OkT9dQ",
        "s1:Vu/OBQ",
        "s1:/iW8eQ",
        "s1:un5PBQ",
        "s1:MmU9gg",
        "s1:gYG9fQ",
        "s1:MS0ZGg"
    ],
    "ms": 24
}
```

(new field at bottom of metadata)

Example. Thumbhash left, original image on the right. 

<img width="232" height="132" alt="Screenshot 2026-01-06 at 14 46 37" src="https://github.com/user-attachments/assets/37d9838a-ff31-46d1-8fe1-cd0ac0f89b9b" />

I asked chatgpt to generate a test file to render the thumbhash for me, however there's other ways to use them too. 

```html
<script type="module">
  import * as th from "https://esm.sh/thumbhash@0.1.1";

  const b64 = "57YJPogEpniAm3eId5h3V6eHDHjBcDc";
  const bytes = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
  document.getElementById("img").src = th.thumbHashToDataURL(bytes);
</script>```
