### PR TITLE
fix(codegen,cli): handle CSS imports when require(esm) happens

### DIFF
--- a/dev/studio-e2e-testing/package.json
+++ b/dev/studio-e2e-testing/package.json
@@ -26,7 +26,7 @@
     "react-dom": "catalog:",
     "sanity": "workspace:*",
     "sanity-plugin-internationalized-array": "^3.2.2",
-    "sanity-plugin-markdown": "^6.0.0",
+    "sanity-plugin-markdown": "8.0.2",
     "sanity-plugin-media": "^4.1.1",
     "sanity-plugin-mux-input": "^2.12.1",
     "sanity-test-studio": "workspace:*",

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -61,7 +61,7 @@
     "sanity-plugin-asset-source-unsplash": "^7.0.1",
     "sanity-plugin-hotspot-array": "^3.0.2",
     "sanity-plugin-internationalized-array": "^3.2.2",
-    "sanity-plugin-markdown": "^6.0.0",
+    "sanity-plugin-markdown": "8.0.2",
     "sanity-plugin-media": "^4.1.1",
     "sanity-plugin-mux-input": "^2.12.1",
     "styled-components": "catalog:"

--- a/packages/sanity/mock-browser-env-stub-loader.mjs
+++ b/packages/sanity/mock-browser-env-stub-loader.mjs
@@ -1,0 +1,27 @@
+const fileExtensions = [
+  '.css',
+  '.eot',
+  '.gif',
+  '.jpeg',
+  '.jpg',
+  '.otf',
+  '.png',
+  '.sass',
+  '.scss',
+  '.svg',
+  '.ttf',
+  '.webp',
+  '.woff',
+  '.woff2',
+]
+
+export async function load(url, context, nextLoad) {
+  if (fileExtensions.some((extension) => url.endsWith(extension))) {
+    return {
+      format: 'module',
+      source: `export default ${JSON.stringify(url)}`,
+      shortCircuit: true,
+    }
+  }
+  return nextLoad(url, context)
+}

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -109,7 +109,8 @@
     "bin",
     "lib",
     "dist",
-    "static"
+    "static",
+    "mock-browser-env-stub-loader.mjs"
   ],
   "scripts": {
     "build": "pnpm clean && pkg-utils build --strict --check --clean",

--- a/packages/sanity/src/_internal/cli/server/sanityMonorepo.ts
+++ b/packages/sanity/src/_internal/cli/server/sanityMonorepo.ts
@@ -11,11 +11,14 @@ export interface SanityMonorepo {
 
 export async function getMonorepoAliases(monorepoPath: string) {
   const {default: aliases} = await import('@repo/dev-aliases')
-  return Object.fromEntries(
-    Object.entries(aliases).map(([pkgName, pkgPath]) => {
-      return [pkgName, path.resolve(monorepoPath, path.join('packages', pkgPath))]
-    }),
-  )
+  const entries = Object.entries(aliases).map(([pkgName, pkgPath]) => {
+    return [pkgName, path.resolve(monorepoPath, path.join('packages', pkgPath))]
+  })
+  return Object.fromEntries([
+    // Ensure package.json imports are mapped correctly
+    ...entries.map(([pkgName]) => [`${pkgName}/package.json`, `${pkgName}/package.json`]),
+    ...entries,
+  ])
 }
 
 /**

--- a/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts
+++ b/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts
@@ -1,4 +1,5 @@
-import {createRequire} from 'node:module'
+import {createRequire, register} from 'node:module'
+import {pathToFileURL} from 'node:url'
 
 import {ResizeObserver} from '@juggle/resize-observer'
 import {register as registerESBuild} from 'esbuild-register/dist/node'
@@ -10,6 +11,12 @@ import {getStudioEnvironmentVariables} from '../server/getStudioEnvironmentVaria
 import {setupImportErrorHandler} from './importErrorHandler'
 
 const require = createRequire(import.meta.url)
+
+// Handle require(esm) cases that breaks free from esbuild-register+pirates
+register(
+  './mock-browser-env-stub-loader.mjs',
+  pathToFileURL(require.resolve('sanity/package.json')),
+)
 
 const jsdomDefaultHtml = `<!doctype html>
 <html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -522,8 +522,8 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(sanity@packages+sanity)
       sanity-plugin-markdown:
-        specifier: ^6.0.0
-        version: 6.0.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(easymde@2.20.0)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(sanity@packages+sanity)
+        specifier: 8.0.2
+        version: 8.0.2(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(easymde@2.20.0)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(sanity@packages+sanity)
       sanity-plugin-media:
         specifier: ^4.1.1
         version: 4.1.1(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(sanity@packages+sanity)
@@ -701,8 +701,8 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(sanity@packages+sanity)
       sanity-plugin-markdown:
-        specifier: ^6.0.0
-        version: 6.0.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(easymde@2.20.0)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(sanity@packages+sanity)
+        specifier: 8.0.2
+        version: 8.0.2(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(easymde@2.20.0)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(sanity@packages+sanity)
       sanity-plugin-media:
         specifier: ^4.1.1
         version: 4.1.1(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(sanity@packages+sanity)
@@ -11606,13 +11606,13 @@ packages:
       sanity: ^3.52.4 || ^4.0.0-0 || ^5
       styled-components: ^6.1
 
-  sanity-plugin-markdown@6.0.0:
-    resolution: {integrity: sha512-HrfQMuEuAZOAgU5JdUWrbxAwUPbPnYPOzSvOwk65wYe2bHpC6rtkZQ1rCe9uTUsuRiFDh7KeG0NjaeD6vf/MHg==}
-    engines: {node: '>=18'}
+  sanity-plugin-markdown@8.0.2:
+    resolution: {integrity: sha512-hud+zlLtThSxLC8Cx7LjPsfETc7NlyZmKTZWGpZGqCQswmWlWwKbemkyfGAPh6wpzWYV49jVqHHpJIn31XFRZQ==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       easymde: ^2.18
-      react: ^18.3 || ^19
-      sanity: ^4
+      react: ^19.2
+      sanity: ^5
       styled-components: ^6.1
 
   sanity-plugin-media@4.1.1:
@@ -23766,9 +23766,8 @@ snapshots:
       - react-dom
       - react-is
 
-  sanity-plugin-markdown@6.0.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(easymde@2.20.0)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(sanity@packages+sanity):
+  sanity-plugin-markdown@8.0.2(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(easymde@2.20.0)(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)(sanity@packages+sanity):
     dependencies:
-      '@sanity/incompatible-plugin': 1.0.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@sanity/ui': 3.1.11(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react-is@19.2.3)(react@19.2.3)
       easymde: 2.20.0
       react: 19.2.3


### PR DESCRIPTION
### Description

Whenever our CLI needs to process `sanity.config.ts` it has to setup a lot of mocks and loader tricks. It uses [esbuild-register](https://www.npmjs.com/package/esbuild-register) + [pirates](https://www.npmjs.com/package/pirates) to hook into `require(cjs)`, treating everything as CJS so that it can use require hooks, and until now this has been an airtight way to ensure that if a `sanity.config.ts` file, or any of its dependencies that end up being imported, if they contain any imports that only work in bundlers (like `import 'foo/bar/styles.css'`) it doesn't throw any exceptions.

Until node shipped support for `require(esm)` that is. We now have a scenario, like described in https://github.com/sanity-io/sanity/issues/11653, where `sanity-plugin-markdown` [has stopped shipping CJS](https://github.com/sanity-io/plugins/releases/tag/sanity-plugin-markdown%407.0.0) and [it contains an import of a CSS file](https://github.com/sanity-io/plugins/blob/03760cc23b9356268fb6c52b1d0954a9861ea415/plugins/sanity-plugin-markdown/src/index.ts#L2).

It would cause an error like:
```bash
> sanity schema extract

✗ Failed to extract schema

Error: Failed to load configuration file "~/Developer/are-we-vX-yet/studio/sanity.config.ts"
    at getStudioConfig (~/Developer/are-we-vX-yet/node_modules/.pnpm/sanity@5.1.0_@emotion+is-prop-valid@1.2.2_@portabletext+sanity-bridge@2.0.0_@types+reac_26e35efa7f189a65ccddab958bc64ea8/node_modules/sanity/lib/_chunks-cjs/getStudioWorkspaces.cjs:25:13)
    at Object.getStudioWorkspaces (~/Developer/are-we-vX-yet/node_modules/.pnpm/sanity@5.1.0_@emotion+is-prop-valid@1.2.2_@portabletext+sanity-bridge@2.0.0_@types+reac_26e35efa7f189a65ccddab958bc64ea8/node_modules/sanity/lib/_chunks-cjs/getStudioWorkspaces.cjs:43:20)
    at main (~/Developer/are-we-vX-yet/node_modules/.pnpm/sanity@5.1.0_@emotion+is-prop-valid@1.2.2_@portabletext+sanity-bridge@2.0.0_@types+reac_26e35efa7f189a65ccddab958bc64ea8/node_modules/sanity/lib/_internal/cli/threads/extractSchema.cjs:10:50)
    at Object.<anonymous> (~/Developer/are-we-vX-yet/node_modules/.pnpm/sanity@5.1.0_@emotion+is-prop-valid@1.2.2_@portabletext+sanity-bridge@2.0.0_@types+reac_26e35efa7f189a65ccddab958bc64ea8/node_modules/sanity/lib/_internal/cli/threads/extractSchema.cjs:25:1)
    at TracingChannel.traceSync (node:diagnostics_channel:328:14)

Caused by:

TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".css" for ~/Developer/are-we-vX-yet/node_modules/.pnpm/easymde@2.20.0/node_modules/easymde/dist/easymde.min.css
 ELIFECYCLE  Command failed with exit code 1.
```

The reason why this happens is because what starts out as:
```js
// sanity.config.ts
import {markdownSchema} from 'sanity-plugin-markdown'
```
is transformed to this by `esbuild-register`:
```js
const {markdownSchema} = require('sanity-plugin-markdown')
```
In `sanity-plugin-markdown` versions 6 and older this is fine, as it ships CJS that contains:
```js
require("easymde/dist/easymde.min.css")
```
and our `pirates` setup ensures it is stubbed out.

In `sanity-plugin-markdown@7` or later it no longer has CJS, so `require('sanity-plugin-markdown')` is a `require(esm)`, which means the ESM module graph is loaded and not altered by `esbuild-register` nor `pirates`:

```js
import "easymde/dist/easymde.min.css"
```

[By setting up an ESM loader we solve this. Typically, an ESM loader has to run _first_ for it to have an effect.](https://nodejs.org/api/module.html#moduleregisterspecifier-parenturl-options) In our case we are using `esbuild-register` and then we `require('sanity.config.ts')`, so we can `import {register} from 'node:module'` and call `register` simply before the `require('sanity.config.ts')` happens, and it will only affect the cases where `require(esm)` happens, from workers that call `mockBrowserEnvironment`.


### What to review

Miss anything?

### Testing

Existing tests are enough for now, with `sanity-plugin-markdown` being pinned. Once this PR is merged and in a stable release I'll remove the CJS format from `sanity-plugin-markdown` again and bump it here, as it'll serve as an integration test that CSS imports inside `node_modules` from a library that doesn't ship CJS is fully supported.

### Notes for release

Fixes an issue where newer plugins that no longer ship CJS formats and contain CSS imports would cause an `ERR_UNKNOWN_FILE_EXTENSION` error when running commands like `sanity schema extract`.
`sanity-plugin-markdown` stopped shipping CJS and has been ESM only since v7 and was impacted by this.