### PR TITLE
docs(cli): update auto-updates documentation URL

### DIFF
--- a/dev/auto-updating-studio/sanity.cli.ts
+++ b/dev/auto-updating-studio/sanity.cli.ts
@@ -9,7 +9,7 @@ export default defineCliConfig({
 
     /**
      * Enable auto-updates for studios.
-     * Learn more at https://www.sanity.io/docs/cli#auto-updates
+     * Learn more at https://www.sanity.io/docs/studio/latest-version-of-sanity#k47faf43faf56
      */
     autoUpdates: true,
   },

--- a/packages/@sanity/cli/src/actions/init-project/createCliConfig.ts
+++ b/packages/@sanity/cli/src/actions/init-project/createCliConfig.ts
@@ -11,7 +11,7 @@ export default defineCliConfig({
   deployment: {
     /**
      * Enable auto-updates for studios.
-     * Learn more at https://www.sanity.io/docs/cli#auto-updates
+     * Learn more at https://www.sanity.io/docs/studio/latest-version-of-sanity#k47faf43faf56
      */
     autoUpdates: __BOOL__autoUpdates__,
   }

--- a/packages/@sanity/cli/src/types.ts
+++ b/packages/@sanity/cli/src/types.ts
@@ -357,7 +357,7 @@ export interface CliConfig {
 
     /**
      * Enable auto-updates for studios.
-     * {@link https://www.sanity.io/docs/cli#auto-updates}
+     * {@link https://www.sanity.io/docs/studio/latest-version-of-sanity#k47faf43faf56}
      */
     autoUpdates?: boolean
   }


### PR DESCRIPTION
### Description

Updates the documentation URL for the autoUpdates configuration option in the CLI config. The old URL (https://www.sanity.io/docs/cli#auto-updates) has been replaced with the current documentation page. The replaced url is returning a 404 page.

This change ensures developers are directed to the correct documentation when configuring auto-updates for Sanity Studio.

### What to review

Verify that the new documentation URL is correct and accessible.

### Testing

Not applicable. This is a documentation URL update only. No functional changes to the codebase. 

