### PR TITLE
fix(codegen): don't warn on `import.meta.hot`

### DIFF
--- a/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts
+++ b/packages/sanity/src/_internal/cli/util/mockBrowserEnvironment.ts
@@ -62,6 +62,8 @@ export function mockBrowserEnvironment(basePath: string): () => void {
       ...getStudioEnvironmentVariables({prefix: 'process.env.', jsonEncode: true}),
       // define the `import.meta.env` global
       ...getStudioEnvironmentVariables({prefix: 'import.meta.env.', jsonEncode: true}),
+      // define the `import.meta.hot` global, so we don't get `"import.meta" is not available with the "cjs" output format and will be empty` warnings
+      'import.meta.hot': 'false',
     },
   })
 


### PR DESCRIPTION
### Description

Running commands like `sanity schema extract` should not log warnings like:
```bash
"import.meta" is not available with the "cjs" output format and will be empty
```

### What to review

Missed anything?

### Testing

It's covered by the CLI suite, you can manually test by `cd dev/test-studio && pnpm sanity schema extract --workspace default` and verify that the warning no longer shows up.

### Notes for release

See above
