### PR TITLE
chore(ci): fix `lint:fix if needed` workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "chore:lint:fix": "turbo run lint --ui tui -- --quiet --fix",
     "chore:lint:inspect": "eslint --inspect-config",
     "chore:normalize-versions": "node -r esbuild-register scripts/normalizeDependencyVersions.ts",
-    "chore:oxlint:fix": "oxlint --type-aware --fix --quiet",
+    "chore:oxlint:fix": "oxlint --type-aware --fix --fix-suggestions --quiet",
     "clean": "npm-run-all build:clean clean:deps",
     "clean:deps": "pnpm --r --parallel exec rm -Rf node_modules && rm -Rf node_modules",
     "depcheck": "pnpm check:deps",

--- a/packages/sanity/src/core/create/studio-app/fetchCreateCompatibleAppId.ts
+++ b/packages/sanity/src/core/create/studio-app/fetchCreateCompatibleAppId.ts
@@ -35,10 +35,10 @@ async function fetchStudiosWithUrl(
   projectId: string,
   internalSuffix: string,
 ) {
-  const apps = (await client.request({
+  const apps = await client.request<StudioAppResponse[]>({
     method: 'GET',
     url: `/projects/${projectId}/user-applications`,
-  })) as StudioAppResponse[]
+  })
 
   return apps.map((app) => ({
     ...app,


### PR DESCRIPTION
### Description

Trying to unblock #11725 once again. This time it turns out the issue was the `as StudioAppResponse[]` type casting in `fetchCreateCompatibleAppId`. Luckily `client.request` supports passing it as a generic `client.request<StudioAppResponse[]>` which is preserved when `oxlint --type-aware --fix`.

Also adding back `--fix-suggestions` as it didn't cause any problems after all, and is handy in creating opportunities for the CI to fix things we can't safely add to `precommit`, but is fine to do in a PR format. 

### What to review

Missed anything?

### Testing

Have to merge the PR to see if #11725 recovers.

### Notes for release

N/A