### PR TITLE
chore(ci): don't cancel-in-progress jobs that open/rebase PRs

### DIFF
--- a/.github/workflows/generate-dts-tests-if-needed.yml
+++ b/.github/workflows/generate-dts-tests-if-needed.yml
@@ -7,7 +7,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
-  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/lint-fix-if-needed.yml
+++ b/.github/workflows/lint-fix-if-needed.yml
@@ -7,7 +7,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
-  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/pnpm-if-needed.yml
+++ b/.github/workflows/pnpm-if-needed.yml
@@ -9,7 +9,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
-  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
### Description

Cancelling jobs that open PRs have a bit of undefined behavior, for example the `lint-fix-if-needed.yaml` have been spotted opening and rebasing a PR when cancelled, but not running all the job steps prior. It's best to let them run to completion and simply run one at most at any given time as its concurrency model.

### What to review

All good?

### Testing

Must merge to test

### Notes for release

N/A
