### PR TITLE
feat(codegen): type utilities for generated types

### DIFF
--- a/packages/@sanity/codegen/src/__tests__/typeUtils.test.ts
+++ b/packages/@sanity/codegen/src/__tests__/typeUtils.test.ts
@@ -1,0 +1,99 @@
+import {describe, expectTypeOf, it} from 'vitest'
+
+import {type FilterByType, type Get} from '../typeUtils'
+
+// Test types that mimic generated Sanity types
+type Tag = {
+  _key: string
+  _type: 'tag'
+  label?: string
+}
+
+type Category = {
+  _key: string
+  _type: 'category'
+  name?: string
+  priority?: number
+}
+
+type Section = {
+  _key: string
+  _type: 'section'
+  title?: string
+  nestedProp?: {
+    somethingInHere?: Array<string> | null
+  } | null
+}
+
+type Post = {
+  _id: string
+  _type: 'post'
+  sections?: Array<Section> | null
+  tags?: Array<Tag | Category> | null
+  tuple?: [string, number, {nested: boolean}] | null
+  indexed?: {
+    0: string
+    1: number
+    named: boolean
+  } | null
+}
+
+describe('FilterByType', () => {
+  it('filters union type by _type discriminator', () => {
+    expectTypeOf<FilterByType<Tag | Category, 'tag'>>().toEqualTypeOf<Tag>()
+    expectTypeOf<FilterByType<Tag | Category, 'category'>>().toEqualTypeOf<Category>()
+  })
+
+  it('works with array element unions', () => {
+    type TagOrCategory = NonNullable<Post['tags']>[number]
+    expectTypeOf<FilterByType<TagOrCategory, 'tag'>>().toEqualTypeOf<Tag>()
+  })
+
+  it('returns never for non-matching type', () => {
+    // @ts-expect-error - 'invalid' is not a valid _type
+    type Invalid = FilterByType<Tag | Category, 'invalid'>
+  })
+})
+
+describe('Get', () => {
+  it('accesses single-level properties preserving their type', () => {
+    expectTypeOf<Get<Post, '_id'>>().toEqualTypeOf<string>()
+  })
+
+  it('accesses nested properties preserving null/undefined', () => {
+    // Section.title is optional (string | undefined)
+    expectTypeOf<Get<Post, 'sections', number, 'title'>>().toEqualTypeOf<string | undefined>()
+  })
+
+  it('accesses deeply nested properties preserving null unions', () => {
+    // nestedProp.somethingInHere is Array<string> | null | undefined
+    expectTypeOf<Get<Post, 'sections', number, 'nestedProp', 'somethingInHere'>>().toEqualTypeOf<
+      Array<string> | null | undefined
+    >()
+  })
+
+  it('accesses tuple elements with number keys', () => {
+    expectTypeOf<Get<Post, 'tuple', 0>>().toEqualTypeOf<string>()
+    expectTypeOf<Get<Post, 'tuple', 1>>().toEqualTypeOf<number>()
+    expectTypeOf<Get<Post, 'tuple', 2>>().toEqualTypeOf<{nested: boolean}>()
+  })
+
+  it('accesses all tuple elements with number type', () => {
+    expectTypeOf<Get<Post, 'tuple', number>>().toEqualTypeOf<string | number | {nested: boolean}>()
+  })
+
+  it('accesses nested properties within tuple elements', () => {
+    expectTypeOf<Get<Post, 'tuple', 2, 'nested'>>().toEqualTypeOf<boolean>()
+  })
+
+  it('accesses objects with numeric keys', () => {
+    expectTypeOf<Get<Post, 'indexed', 0>>().toEqualTypeOf<string>()
+    expectTypeOf<Get<Post, 'indexed', 1>>().toEqualTypeOf<number>()
+    expectTypeOf<Get<Post, 'indexed', 'named'>>().toEqualTypeOf<boolean>()
+  })
+
+  it('preserves null union at top level', () => {
+    // sections is Array<Section> | null | undefined
+    expectTypeOf<Get<Post, 'sections'>>().toEqualTypeOf<Array<Section> | null | undefined>()
+  })
+})

--- a/packages/@sanity/codegen/src/_exports/index.ts
+++ b/packages/@sanity/codegen/src/_exports/index.ts
@@ -17,3 +17,4 @@ export {
   type ExtractedQuery,
   QueryExtractionError,
 } from '../typescript/types'
+export {type FilterByType, type Get} from '../typeUtils'

--- a/packages/@sanity/codegen/src/typeUtils.ts
+++ b/packages/@sanity/codegen/src/typeUtils.ts
@@ -1,0 +1,151 @@
+/** Excludes `null` and `undefined` from a type. */
+type NonNullish<T> = T extends null | undefined ? never : T
+
+/** Builds a tuple from elements, stopping at the first `never`. */
+type TakeUntilNever<T extends unknown[]> = T extends [infer H, ...infer Rest]
+  ? [H] extends [never]
+    ? []
+    : [H, ...TakeUntilNever<Rest>]
+  : []
+
+/** Recursively navigates through a path, stripping nullability for key lookup. */
+type NavigatePath<T, Path extends unknown[]> = Path extends []
+  ? NonNullish<T>
+  : Path extends [infer K, ...infer Rest]
+    ? K extends keyof NonNullish<T>
+      ? NavigatePath<NonNullish<T>[K], Rest>
+      : never
+    : never
+
+/** Recursively gets value at path, preserving nullability at final access. */
+type GetAtPath<T, Path extends unknown[]> = Path extends []
+  ? T
+  : Path extends [infer K]
+    ? K extends keyof NonNullish<T>
+      ? NonNullish<T>[K]
+      : never
+    : Path extends [infer K, ...infer Rest]
+      ? K extends keyof NonNullish<T>
+        ? GetAtPath<NonNullish<T>[K], Rest>
+        : never
+      : never
+
+/**
+ * Get a deeply nested property type from a complex type structure. Safely navigates
+ * through nullable types (`T | null | undefined`) at each level, preserving the
+ * nullability of the final accessed property.
+ *
+ * Supports up to 20 levels of nesting.
+ *
+ * @example
+ * ```ts
+ * type POST_QUERY_RESULT = {
+ *   _id: string
+ *   author: {
+ *     profile: {
+ *       name: string;
+ *     } | null;
+ *   } | null;
+ *   links: Array<{
+ *     _key: string
+ *     type: 'link'
+ *     label: string
+ *     url: string
+ *   }> | null
+ * } | null
+ *
+ * // Basic property access:
+ * type Id = Get<POST_QUERY_RESULT, '_id'>;
+ * // → string
+ *
+ * // Nested property access:
+ * type Profile = Get<POST_QUERY_RESULT, 'author', 'profile';
+ * // → { name: string } | null
+ *
+ * // Array element access using `number`:
+ * type Link = Get<POST_QUERY_RESULT, 'links', number, 'label'>;
+ * // → string
+ * ```
+ */
+export type Get<
+  T,
+  K1 extends keyof NonNullish<T>,
+  K2 extends keyof NavigatePath<T, [K1]> = never,
+  K3 extends keyof NavigatePath<T, [K1, K2]> = never,
+  K4 extends keyof NavigatePath<T, [K1, K2, K3]> = never,
+  K5 extends keyof NavigatePath<T, [K1, K2, K3, K4]> = never,
+  K6 extends keyof NavigatePath<T, [K1, K2, K3, K4, K5]> = never,
+  K7 extends keyof NavigatePath<T, [K1, K2, K3, K4, K5, K6]> = never,
+  K8 extends keyof NavigatePath<T, [K1, K2, K3, K4, K5, K6, K7]> = never,
+  K9 extends keyof NavigatePath<T, [K1, K2, K3, K4, K5, K6, K7, K8]> = never,
+  K10 extends keyof NavigatePath<T, [K1, K2, K3, K4, K5, K6, K7, K8, K9]> = never,
+  K11 extends keyof NavigatePath<T, [K1, K2, K3, K4, K5, K6, K7, K8, K9, K10]> = never,
+  K12 extends keyof NavigatePath<T, [K1, K2, K3, K4, K5, K6, K7, K8, K9, K10, K11]> = never,
+  K13 extends keyof NavigatePath<T, [K1, K2, K3, K4, K5, K6, K7, K8, K9, K10, K11, K12]> = never,
+  K14 extends keyof NavigatePath<T, [K1, K2, K3, K4, K5, K6, K7, K8, K9, K10, K11, K12, K13]> =
+    never,
+  K15 extends keyof NavigatePath<T, [K1, K2, K3, K4, K5, K6, K7, K8, K9, K10, K11, K12, K13, K14]> =
+    never,
+  K16 extends keyof NavigatePath<
+    T,
+    [K1, K2, K3, K4, K5, K6, K7, K8, K9, K10, K11, K12, K13, K14, K15]
+  > = never,
+  K17 extends keyof NavigatePath<
+    T,
+    [K1, K2, K3, K4, K5, K6, K7, K8, K9, K10, K11, K12, K13, K14, K15, K16]
+  > = never,
+  K18 extends keyof NavigatePath<
+    T,
+    [K1, K2, K3, K4, K5, K6, K7, K8, K9, K10, K11, K12, K13, K14, K15, K16, K17]
+  > = never,
+  K19 extends keyof NavigatePath<
+    T,
+    [K1, K2, K3, K4, K5, K6, K7, K8, K9, K10, K11, K12, K13, K14, K15, K16, K17, K18]
+  > = never,
+  K20 extends keyof NavigatePath<
+    T,
+    [K1, K2, K3, K4, K5, K6, K7, K8, K9, K10, K11, K12, K13, K14, K15, K16, K17, K18, K19]
+  > = never,
+> = GetAtPath<
+  T,
+  TakeUntilNever<
+    [K1, K2, K3, K4, K5, K6, K7, K8, K9, K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K20]
+  >
+>
+
+/**
+ * Filter a union of object types by the _type property. This is handy when working with page builder
+ * setups where the returned type is an array containing multiple types.
+ *
+ * @example
+ * ```ts
+ *
+ * export type Callout = {
+ *   _type: 'callout'
+ *   title?: string
+ *   content?: string
+ * }
+ *
+ * export type Video = {
+ *   _type: 'video'
+ *   url?: string
+ *   caption?: string
+ * }
+ * type FORM_QUERY_RESULT = {
+ *   _id: string
+ *   title?: string
+ *   content?: Array<
+ *     | ({ _key: string } & Callout)
+ *     | ({ _key: string } & Video)
+ *   >
+ * } | null
+ *
+ * // Get the type of the content with the Get helper
+ * type Content = Get<FORM_QUERY_RESULT, 'content', number>
+ *
+ * // Get the type for a callout module from the page builder type
+ * type CalloutModule = FilterByType<Content, 'callout'>
+ * // → { _key: string } & Callout
+ * ```
+ */
+export type FilterByType<U extends {_type: string}, T extends U['_type']> = Extract<U, {_type: T}>


### PR DESCRIPTION
### Description

This PR adds two type utilities: `Get` and `FilterByUnion`.

#### `Get`
A typed property extractor that eases use of generated types by removing the need for doing `NonNullable` when getting deep props, while still giving TS powered autocomplete for prop names ~all the way down~ twenty levels deep.

https://github.com/user-attachments/assets/7580599f-20d7-4d0e-bc26-a810b748258e

#### `FilterByType`
A utility for extracting a single type from a union of objects, using the `_type` as the descriminator. This is a typical use case when implementing modules for blocks originating from a "page builder" fields in the schema, represented as an array of different types.

With this utility in combination with `Get` is easier to get hold of the type for a specific module type.

https://github.com/user-attachments/assets/c70cf91f-a135-45f4-9ac9-eb18a9a1372b

### What to review

The code and the tests.

I would have liked to make the definition of `Get` less repetetive, but could not find a way to do that that gives proper types and a the path to get as faked variadric positional type arg (instead of a path array).

A path array also works and can be implemented in a more recursive fashion - I’ve experimented with it.. you can get it typed just fine, but the DX and autocomplete is bob-bob when the type arg is defined as a union of tuples. At least in vscode you get type errors with a list of allowed types, but no autocomplete.

### Testing

Have tested manually and added automated type tests.

### Notes for release

- adds `Get` and `FilterByType` for getting deep properties from generated types and making getting the type for a module in a typical page builder setup easier.