### PR TITLE
fix(linter): enforce no unnecessary boolean literal comparisons

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -117,7 +117,6 @@
     "jest/valid-describe-callback": "off",
     "vitest/no-disabled-tests": "off",
     "vitest/no-test-prefixes": "off",
-    "jest/no-disabled-tests": "off",
     "jsx_a11y/no-autofocus": "off",
     "jsx_a11y/no-static-element-interactions": "off", // Allow event handlers on static elements
     "unicorn/require-post-message-target-origin": "off", // disabled since it can't distinguish between `window.postMessage` and node `Worker#postMessage`
@@ -171,6 +170,8 @@
     "eslint/no-unsafe-optional-chaining": "warn",
     "promise/always-return": ["error", {"ignoreLastCallback": true}],
     "require-module-specifiers": "warn",
+    // handy type-aware rules
+    "no-unnecessary-boolean-literal-compare": "error",
     // Powerful type-aware rules that should be enabled in the future, but have too many violations to be handled in a single PR
     "no-base-to-string": "warn",
     "no-duplicate-type-constituents": "warn",
@@ -178,7 +179,6 @@
     "no-misused-spread": "warn",
     "no-multiple-resolved": "warn",
     "no-redundant-type-constituents": "warn",
-    "no-unnecessary-boolean-literal-compare": "warn",
     "no-unnecessary-template-expression": "warn",
     "no-unnecessary-type-arguments": "warn",
     "no-unnecessary-type-assertion": "warn",

--- a/packages/@sanity/cli/src/actions/init-project/bootstrapRemoteTemplate.ts
+++ b/packages/@sanity/cli/src/actions/init-project/bootstrapRemoteTemplate.ts
@@ -88,7 +88,7 @@ export async function bootstrapRemoteTemplate(
     })
 
     const port = getDefaultPortForFramework(packageFramework?.slug)
-    if (corsAdded.includes(port) === false) {
+    if (corsAdded.includes(port)) {
       debug('Setting CORS origin to http://localhost:%d', port)
       await setCorsOrigin(`http://localhost:${port}`, variables.projectId, apiClient)
       corsAdded.push(port)

--- a/packages/@sanity/cli/src/util/remoteTemplate.ts
+++ b/packages/@sanity/cli/src/util/remoteTemplate.ts
@@ -60,7 +60,7 @@ function isGithubRepoShorthand(value: string): boolean {
 }
 
 function isGithubRepoUrl(value: string | URL): value is URL | GithubUrlString {
-  if (URL.canParse(value) === false) {
+  if (!URL.canParse(value)) {
     return false
   }
   const url = new URL(value)

--- a/packages/@sanity/schema/src/sanity/extractSchema.ts
+++ b/packages/@sanity/schema/src/sanity/extractSchema.ts
@@ -313,7 +313,7 @@ export function extractSchema(
 
       // if we extract with enforceRequiredFields, we will mark the field as optional only if it is not a required field,
       // else we will always mark it as optional
-      const optional = extractOptions.enforceRequiredFields ? fieldIsRequired === false : true
+      const optional = extractOptions.enforceRequiredFields ? !fieldIsRequired : true
 
       attributes[field.name] = {
         type: 'objectAttribute',

--- a/packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx
+++ b/packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx
@@ -339,7 +339,7 @@ function CommentsInspectorInner(
     // We can't solely rely on the comment id from the url since the comment might not be loaded yet.
     const commentToScrollTo = getComment(commentIdParamRef.current || '')
 
-    if (!loading && commentToScrollTo && didScrollToCommentFromParam.current === false) {
+    if (!loading && commentToScrollTo && !didScrollToCommentFromParam.current) {
       // Make sure we have the correct status set before we scroll to the comment
       setStatus(commentToScrollTo.status || 'open')
 

--- a/packages/sanity/src/core/components/collapseMenu/CollapseMenu.tsx
+++ b/packages/sanity/src/core/components/collapseMenu/CollapseMenu.tsx
@@ -249,7 +249,7 @@ export const AutoCollapseMenu = forwardRef(function AutoCollapseMenu(
     () =>
       menuOptions.filter((optionElement) => {
         const intersection = collapsedIntersections[optionElement.key as string]
-        return intersection?.intersects === false
+        return !intersection?.intersects
       }),
     [menuOptions, collapsedIntersections],
   )
@@ -258,7 +258,7 @@ export const AutoCollapseMenu = forwardRef(function AutoCollapseMenu(
   const visibleMenuOptions = shouldCollapse
     ? collapsedElements.filter((optionElement) => {
         const intersection = collapsedIntersections[optionElement.key as string]
-        return intersection?.intersects === true
+        return intersection?.intersects
       })
     : menuOptions
 

--- a/packages/sanity/src/core/create/components/CreateLinkedDocumentBannerContent.tsx
+++ b/packages/sanity/src/core/create/components/CreateLinkedDocumentBannerContent.tsx
@@ -45,7 +45,7 @@ export function CreateLinkedDocumentBannerContent(props: CreateLinkedDocumentBan
     ),
   )
 
-  if (metadata?.ejected !== false) {
+  if (metadata?.ejected) {
     return null
   }
 

--- a/packages/sanity/src/core/form/FormBuilderProvider.tsx
+++ b/packages/sanity/src/core/form/FormBuilderProvider.tsx
@@ -126,12 +126,12 @@ export function FormBuilderProvider(props: FormBuilderProviderProps) {
       },
       file: {
         assetSources: file.assetSources,
-        directUploads: file?.directUploads !== false,
+        directUploads: file?.directUploads ?? true,
       },
       filterField: filterField || (() => true),
       image: {
         assetSources: image.assetSources,
-        directUploads: image?.directUploads !== false,
+        directUploads: image?.directUploads ?? true,
       },
       onChange,
     }),

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useSpellCheck.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useSpellCheck.tsx
@@ -10,6 +10,6 @@ export function useSpellCheck(): boolean {
     const spellCheckOption = editor.schemaTypes.block.options?.spellCheck
     const isChrome96 =
       typeof navigator === 'undefined' ? false : /Chrome\/96/.test(navigator.userAgent)
-    return spellCheckOption === undefined && isChrome96 === true ? false : spellCheckOption
+    return spellCheckOption === undefined && isChrome96 ? false : spellCheckOption
   }, [editor])
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/InsertMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/InsertMenu.tsx
@@ -48,9 +48,7 @@ export const InsertMenu = memo(function InsertMenu(props: InsertMenuProps) {
             {typeName: title},
           )}
           mode="bleed"
-          disabled={
-            disabled || (isVoidFocus && item.inline === true) || Boolean(item.type.deprecated)
-          }
+          disabled={disabled || (isVoidFocus && item.inline) || Boolean(item.type.deprecated)}
           data-testid={`${item.type.name}-insert-menu-button`}
           icon={item.icon}
           onClick={item.handle}

--- a/packages/sanity/src/core/form/store/conditional-property/resolveConditionalProperty.ts
+++ b/packages/sanity/src/core/form/store/conditional-property/resolveConditionalProperty.ts
@@ -24,6 +24,7 @@ export function resolveConditionalProperty(
   }
 
   return (
+    // oxlint-disable-next-line no-unnecessary-boolean-literal-compare - we can't trust the return value here is actually a boolean at runtime
     property({
       document: document as any,
       parent,

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CanonicalReleaseContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CanonicalReleaseContextMenu.tsx
@@ -104,7 +104,7 @@ export const CanonicalReleaseContextMenu = memo(function CanonicalReleaseContext
           tone="critical"
           disabled={disabled || locked || !hasDiscardPermission}
           tooltipProps={{
-            disabled: hasDiscardPermission === true,
+            disabled: hasDiscardPermission,
             content: t('release.action.permission.error'),
           }}
         />

--- a/packages/sanity/src/core/releases/store/useOrgActiveReleaseCount.ts
+++ b/packages/sanity/src/core/releases/store/useOrgActiveReleaseCount.ts
@@ -26,6 +26,7 @@ function createOrgActiveReleaseCountStore(
     switchMap((state) => {
       if (
         state === null ||
+        // oxlint-disable-next-line no-unnecessary-boolean-literal-compare
         staleFlag$.getValue() === true ||
         activeReleaseCountAtFetch.getValue() !== activeReleasesCount
       ) {

--- a/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
+++ b/packages/sanity/src/core/store/_legacy/history/useTimelineStore.ts
@@ -34,7 +34,7 @@ interface UseTimelineControllerOpts {
 /** @internal */
 export interface TimelineState {
   chunks: Chunk[]
-  diff: ObjectDiff<Annotation, Record<string, any>> | null
+  diff: ObjectDiff<Annotation> | null
   /** null is used here when the chunks hasn't loaded / is not known */
   hasMoreChunks: boolean | null
   isLoading: boolean
@@ -215,7 +215,7 @@ export function useTimelineStore({
                 chunks,
                 diff: innerController.sinceTime ? innerController.currentObjectDiff() : null,
                 isLoading: innerController.isLoading,
-                isPristine: timelineReady ? chunks.length === 0 && hasMoreChunks === false : null,
+                isPristine: timelineReady ? chunks.length === 0 && !hasMoreChunks : null,
                 hasMoreChunks: !innerController.timeline.reachedEarliestEntry,
                 lastNonDeletedRevId: lastNonDeletedChunk?.[0]?.id,
                 onOlderRevision: innerController.onOlderRevision(),

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentList.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentList.tsx
@@ -35,7 +35,7 @@ export function NewDocumentList(props: NewDocumentListProps) {
   }, [onDocumentClick])
 
   const getItemDisabled = useCallback(
-    (index: number) => options[index]?.hasPermission === false,
+    (index: number) => options[index]?.hasPermission ?? true,
     [options],
   )
 

--- a/packages/sanity/src/core/studio/router/helpers.ts
+++ b/packages/sanity/src/core/studio/router/helpers.ts
@@ -84,7 +84,7 @@ export function resolveIntentState(
   // Rank tools by how well they can handle the intent, based on the params they support.
   // Only the ones defined in `WEIGHTED_*_INTENT_PARAMS` are considered, and on ties in score,
   // the first tool wins. Any active tool is considered first, then the rest.
-  const initialMatch: {score: number; tool: Tool<any> | null} = {score: -1, tool: null}
+  const initialMatch: {score: number; tool: Tool | null} = {score: -1, tool: null}
   const {tool: matchingTool} = (currentTool ? [currentTool, ...otherTools] : orderedTools).reduce(
     (prev, tool) => {
       if (!tool || typeof tool.canHandleIntent !== 'function') {
@@ -104,9 +104,7 @@ export function resolveIntentState(
 
       // Rank by number of supported, weighted values
       const score = weightedParams.reduce((prevScore, weightedParam) => {
-        return weightedParam in params && canHandle[weightedParam] === true
-          ? prevScore + 1
-          : prevScore
+        return weightedParam in params && canHandle[weightedParam] ? prevScore + 1 : prevScore
       }, 0)
 
       return score > prev.score ? {score, tool} : prev

--- a/packages/sanity/src/core/tasks/context/navigation/TasksNavigationProvider.tsx
+++ b/packages/sanity/src/core/tasks/context/navigation/TasksNavigationProvider.tsx
@@ -19,7 +19,7 @@ const initialState: State = {
 function reducer(state: State, action: Action): State {
   switch (action.type) {
     case 'TOGGLE_TASKS_VIEW': {
-      if (action.payload === false) {
+      if (!action.payload) {
         return {
           ...initialState,
           isOpen: action.payload,

--- a/packages/sanity/src/presentation/PresentationToolGrantsCheck.tsx
+++ b/packages/sanity/src/presentation/PresentationToolGrantsCheck.tsx
@@ -57,10 +57,10 @@ export default function PresentationToolGrantsCheck({
       initialPreviewUrl={url}
       vercelProtectionBypass={vercelProtectionBypass}
       canToggleSharePreviewAccess={
-        previewAccessSharingCreatePermission?.granted === true &&
-        previewAccessSharingUpdatePermission?.granted === true
+        Boolean(previewAccessSharingCreatePermission?.granted) &&
+        Boolean(previewAccessSharingUpdatePermission?.granted)
       }
-      canUseSharedPreviewAccess={previewAccessSharingReadPermission?.granted === true}
+      canUseSharedPreviewAccess={Boolean(previewAccessSharingReadPermission?.granted)}
       previewUrlRef={previewUrlRef}
     />
   )

--- a/packages/sanity/src/presentation/overlays/schema/extract.tsx
+++ b/packages/sanity/src/presentation/overlays/schema/extract.tsx
@@ -308,7 +308,7 @@ export function extractSchema(workspace: Workspace): SchemaType[] {
         name: field.name,
         title: typeof field.type.title === 'string' ? field.type.title : undefined,
         value,
-        optional: isFieldRequired(field) === false,
+        optional: !isFieldRequired(field),
       }
     }
 
@@ -370,7 +370,7 @@ export function extractSchema(workspace: Workspace): SchemaType[] {
 
   function createUnionNodeOptions(
     schemaType: ArraySchemaType,
-    of: SchemaUnionOption<SchemaNode>[],
+    of: SchemaUnionOption[],
   ): SchemaUnionNodeOptions | undefined {
     const {options} = schemaType
     if (!options) return undefined

--- a/packages/sanity/src/structure/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/PublishAction.tsx
@@ -96,7 +96,7 @@ export const usePublishAction: DocumentActionComponent = (props) => {
   useEffect(() => {
     // make sure the validation status is about the current revision and not an earlier one
     const validationComplete =
-      validationStatus.isValidating === false && validationStatus.revision !== revision
+      !validationStatus.isValidating && validationStatus.revision !== revision
 
     if (!publishScheduled || isSyncing || !validationComplete) {
       return

--- a/packages/sanity/src/structure/hasObsoleteDraft.ts
+++ b/packages/sanity/src/structure/hasObsoleteDraft.ts
@@ -38,7 +38,7 @@ export function hasObsoleteDraft({editState, workspace, schemaType}: Context):
     },
   } = workspace
 
-  if (draftExists === false) {
+  if (!draftExists) {
     return {
       result: false,
     }

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPaneContent.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPaneContent.tsx
@@ -140,7 +140,7 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
       return (
         <>
           <PaneItem
-            icon={showIcons === false ? false : undefined}
+            icon={showIcons ? undefined : false}
             id={publishedId}
             layout={layout}
             marginBottom={1}

--- a/packages/sanity/src/structure/panes/list/ListPaneContent.tsx
+++ b/packages/sanity/src/structure/panes/list/ListPaneContent.tsx
@@ -15,7 +15,7 @@ import {type PaneListItem, type PaneListItemDivider} from '../../types'
 interface ListPaneContentProps {
   childItemId?: string
   isActive?: boolean
-  items: (PaneListItem<unknown> | PaneListItemDivider)[] | undefined
+  items: (PaneListItem | PaneListItemDivider)[] | undefined
   layout?: GeneralPreviewLayoutKey
   showIcons: boolean
   title: string
@@ -80,21 +80,15 @@ export function ListPaneContent(props: ListPaneContentProps) {
 
   const shouldShowIconForItem = useCallback(
     (item: PaneListItem): boolean => {
-      const itemShowIcon = item.displayOptions?.showIcon
-
       // Specific true/false on item should have precedence over list setting
-      if (typeof itemShowIcon !== 'undefined') {
-        return itemShowIcon !== false // Boolean(item.icon)
-      }
-
       // If no item setting is defined, defer to the pane settings
-      return showIcons !== false // Boolean(item.icon)
+      return item.displayOptions?.showIcon ?? showIcons ?? false
     },
     [showIcons],
   )
 
   const renderItem = useCallback(
-    (item: PaneListItem<unknown> | PaneListItemDivider, ctx: CommandListItemContext) => {
+    (item: PaneListItem | PaneListItemDivider, ctx: CommandListItemContext) => {
       const {virtualIndex: itemIndex} = ctx
 
       if (item.type === 'divider') {


### PR DESCRIPTION
### Description

I didn't like some of the auto fixes in #11725 so I've decided to handle them manually here. Since the `no-unnecessary-boolean-literal-compare)` rule now supports `--fix` it doesn't make sense to have it stay a `warn`, it should be `error` so it's explicit or visible. Otherwise someone might PR a change that spawns a follow up PR like #11725 that risks changing program behavior since we sometimes lie in our type-system 😅 

### What to review

Everything makes sense? I've tried to balance letting the rule work its magic, except for in specific places where it risks changing runtime behavior where we should be using `unknown` and parsing untrusted input where custom code can choose to suppress contracts with `// @ts-expect-error` and `// @ts-ignore`.

### Testing

If the CI is happy we good.

### Notes for release

N/A
