### PR TITLE
fix(typegen): preserve non-identifier keys in generated types

### DIFF
--- a/packages/@sanity/codegen/src/typescript/helpers.ts
+++ b/packages/@sanity/codegen/src/typescript/helpers.ts
@@ -15,6 +15,15 @@ export function sanitizeIdentifier(input: string): string {
   return `${input.replace(/^\d/, '_').replace(/[^$\w]+(.)/g, (_, char) => char.toUpperCase())}`
 }
 
+/**
+ * Checks if a string is a valid ECMAScript IdentifierName.
+ * IdentifierNames start with a letter, underscore, or $, and contain only
+ * alphanumeric characters, underscores, or $.
+ */
+export function isIdentifierName(input: string): boolean {
+  return /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(input)
+}
+
 export function normalizeIdentifier(input: string): string {
   const sanitized = sanitizeIdentifier(input)
   return `${sanitized.charAt(0).toUpperCase()}${sanitized.slice(1)}`

--- a/packages/@sanity/codegen/src/typescript/schemaTypeGenerator.ts
+++ b/packages/@sanity/codegen/src/typescript/schemaTypeGenerator.ts
@@ -17,7 +17,7 @@ import {ARRAY_OF, INTERNAL_REFERENCE_SYMBOL} from './constants'
 import {
   getFilterArrayUnionType,
   getUniqueIdentifierForName,
-  sanitizeIdentifier,
+  isIdentifierName,
   weakMapMemo,
 } from './helpers'
 import {type ExtractedQuery, type TypeEvaluationStats} from './types'
@@ -157,10 +157,8 @@ export class SchemaTypeGenerator {
   // Helper function used to generate TS types for object properties.
   private generateTsObjectProperty(key: string, attribute: ObjectAttribute): t.TSPropertySignature {
     const type = this.generateTsType(attribute.value)
-    const propertySignature = t.tsPropertySignature(
-      t.identifier(sanitizeIdentifier(key)),
-      t.tsTypeAnnotation(type),
-    )
+    const keyNode = isIdentifierName(key) ? t.identifier(key) : t.stringLiteral(key)
+    const propertySignature = t.tsPropertySignature(keyNode, t.tsTypeAnnotation(type))
     propertySignature.optional = attribute.optional
 
     return propertySignature


### PR DESCRIPTION
## Summary

TypeGen now preserves non-identifier property keys by quoting them instead of transforming them to camelCase.

**Before:** `"my-field"` in GROQ → `myField` in generated types (didn't match runtime)  
**After:** `"my-field"` in GROQ → `"my-field"` in generated types (matches runtime)

Valid JavaScript identifiers remain unquoted:
```typescript
{
  _id: string;           // valid identifier - unquoted
  "my-field": string;    // invalid identifier - quoted
}
```

Property keys that aren't valid JS identifiers (kebab-case, spaces, leading digits, etc.) are now quoted instead of transformed to camelCase. Generated types now match runtime data.

Users accessing kebab-cased keys via camelCase will get type errors:
```typescript
// Before: types didn't match runtime
result.myField  // TS valid, undefined at runtime

// After: types match runtime  
result["my-field"]  // both TS and runtime agree
```

## Test plan

- [x] Added comprehensive test covering valid identifiers (unquoted) and invalid identifiers (quoted)
- [x] Updated existing test snapshots
- [x] All 100 tests pass