### PR TITLE
feat(cli): add --extract-schema flag to dev command

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/dev/devCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/dev/devCommand.ts
@@ -21,10 +21,14 @@ Notes
 Options
   --port <port> TCP port to start server on. [default: 3333]
   --host <host> The local network interface at which to listen. [default: "127.0.0.1"]
+  --extract-schema Enable schema extraction in watch mode alongside the dev server
+  --schema-path <path> Path for extracted schema file [default: "schema.json"]
 
 Examples
   sanity dev --host=0.0.0.0
   sanity dev --port=1942
+  sanity dev --extract-schema
+  sanity dev --extract-schema --schema-path=./schemas/studio.json
 `
 
 const devCommand: CliCommandDefinition = {


### PR DESCRIPTION
### Description

Added schema extraction capabilities to the `sanity dev` command. This allows developers to automatically extract and save the Sanity schema to a JSON file while running the development server.

### What to review

- New CLI flags added to the dev command:
    - `--extract-schema`: Enables schema extraction in watch mode
    - `--schema-path`: Specifies the output path for the extracted schema (defaults to `schema.json`)
- Schema watcher initialization and cleanup in the dev action
- Command documentation updates with examples

### Testing

Tested by running the dev server with the new flags and verifying that:

- Schema extraction works when enabled with `--extract-schema`
- Custom output paths work with `--schema-path`
- Schema watcher properly cleans up on process exit

### Notes for release

Added schema extraction capabilities to the `sanity dev` command. You can now automatically extract your Sanity schema to a JSON file while running the development server. The schema JSON is used for type generation with the `sanity typegen generate` command.

Usage examples:

```
sanity dev --extract-schema
sanity dev --extract-schema --schema-path=./location/schema.json
```