### PR TITLE
feat: enable private asset selection from media library

### DIFF
--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@sanity/client": "catalog:",
-    "@sanity/media-library-types": "^1.0.2"
+    "@sanity/media-library-types": "^1.1.0"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -159,7 +159,7 @@
     "@sanity/import": "^4.0.3",
     "@sanity/insert-menu": "^3.0.3",
     "@sanity/logos": "^2.2.2",
-    "@sanity/media-library-types": "^1.0.2",
+    "@sanity/media-library-types": "^1.1.0",
     "@sanity/message-protocol": "^0.18.0",
     "@sanity/migrate": "catalog:",
     "@sanity/mutator": "workspace:*",

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/hooks/usePluginFrameUrl.ts
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/hooks/usePluginFrameUrl.ts
@@ -1,10 +1,11 @@
+import {type PluginPayload} from '@sanity/media-library-types'
 import {useMemo} from 'react'
 import {encodeJsonParams} from 'sanity/router'
 
 import {useMediaLibraryIds} from './useMediaLibraryIds'
 import {useSanityMediaLibraryConfig} from './useSanityMediaLibraryConfig'
 
-export function usePluginFrameUrl(path: string, params: Record<string, any>) {
+export function usePluginFrameUrl(path: string, params: PluginPayload) {
   const pluginConfig = useSanityMediaLibraryConfig()
   const mediaLibraryIds = useMediaLibraryIds()
   const appHost = pluginConfig.__internal.hosts.app

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/MediaLibraryAssetSource.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/MediaLibraryAssetSource.tsx
@@ -36,6 +36,8 @@ const MediaLibraryAssetSourceComponent = function MediaLibraryAssetSourceCompone
     throw new Error('No projectId found')
   }
 
+  const selectAssetType = assetType === 'sanity.video' ? 'video' : assetType
+
   return (
     <MediaLibraryProvider projectId={projectId} libraryId={libraryIdProp}>
       <UploadAssetsDialog
@@ -50,7 +52,7 @@ const MediaLibraryAssetSourceComponent = function MediaLibraryAssetSourceCompone
           dialogHeaderTitle={
             dialogHeaderTitle ||
             t('asset-sources.media-library.select-dialog.title', {
-              context: assetType === 'sanity.video' ? 'video' : assetType,
+              context: selectAssetType,
               targetTitle: schemaType?.title,
             })
           }
@@ -60,7 +62,7 @@ const MediaLibraryAssetSourceComponent = function MediaLibraryAssetSourceCompone
           onSelect={onSelect}
           selection={[]}
           schemaType={schemaType}
-          selectAssetType={assetType}
+          selectAssetType={selectAssetType}
         />
       </PortalProvider>
     </MediaLibraryProvider>

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
@@ -1,4 +1,9 @@
 import {
+  type PluginFilter,
+  type PluginPayload,
+  type PluginSelectAssetType,
+} from '@sanity/media-library-types'
+import {
   type AssetFromSource,
   type FileSchemaType,
   type ImageSchemaType,
@@ -22,7 +27,7 @@ import {useMediaLibraryIds} from '../hooks/useMediaLibraryIds'
 import {usePluginFrameUrl} from '../hooks/usePluginFrameUrl'
 import {usePluginPostMessage} from '../hooks/usePluginPostMessage'
 import {useSanityMediaLibraryConfig} from '../hooks/useSanityMediaLibraryConfig'
-import {type AssetSelectionItem, type AssetType, type PluginPostMessage} from '../types'
+import {type AssetSelectionItem, type PluginPostMessage} from '../types'
 import {AppDialog} from './Dialog'
 import {Iframe} from './Iframe'
 import {filterMediaValidationMarkers} from './validation'
@@ -34,7 +39,7 @@ export interface SelectAssetsDialogProps {
   onSelect: (assetFromSource: AssetFromSource[]) => void
   ref: React.Ref<HTMLDivElement>
   schemaType?: ImageSchemaType | FileSchemaType
-  selectAssetType?: AssetType
+  selectAssetType?: PluginSelectAssetType
   selection: AssetSelectionItem[]
   selectionType?: 'single' | 'multiple'
 }
@@ -105,20 +110,22 @@ export function SelectAssetsDialog(props: SelectAssetsDialogProps): ReactNode {
     [client, document, mediaLibraryIds?.libraryId, schema, schemaType, workspace.i18n],
   )
 
-  const pluginFilters = (schemaType?.options?.mediaLibrary?.filters || []).map((filter) => ({
-    type: 'groq',
-    name: filter.name,
-    query: filter.query,
-    active: true,
-  }))
+  const pluginFilters: PluginFilter[] = (schemaType?.options?.mediaLibrary?.filters || []).map(
+    (filter) => ({
+      type: 'groq' as const,
+      name: filter.name,
+      query: filter.query,
+    }),
+  )
 
-  const params = useMemo(
+  const params = useMemo<PluginPayload>(
     () => ({
-      selectionType,
-      selectAssetTypes: [selectAssetType === 'sanity.video' ? 'video' : selectAssetType],
-      scheme: dark ? 'dark' : 'light',
       auth: authType,
+      capabilities: {privateAssets: true},
       pluginFilters,
+      scheme: dark ? 'dark' : 'light',
+      selectAssetTypes: selectAssetType ? [selectAssetType] : [],
+      selectionType,
     }),
     [selectionType, selectAssetType, dark, authType, pluginFilters],
   )

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/types.ts
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/types.ts
@@ -69,8 +69,6 @@ export interface AssetMenuAction {
   type: 'delete' | 'showUsage'
 }
 
-export type AssetType = 'image' | 'file' | 'sanity.video'
-
 /**
  * The type that is returned from the Media Library for an selected asset item
  * @internal

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1522,8 +1522,8 @@ importers:
         specifier: 'catalog:'
         version: 7.14.0(debug@4.4.3)
       '@sanity/media-library-types':
-        specifier: ^1.0.2
-        version: 1.0.2
+        specifier: ^1.1.0
+        version: 1.1.0
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -1891,8 +1891,8 @@ importers:
         specifier: ^2.2.2
         version: 2.2.2(react@19.2.3)
       '@sanity/media-library-types':
-        specifier: ^1.0.2
-        version: 1.0.2
+        specifier: ^1.1.0
+        version: 1.1.0
       '@sanity/message-protocol':
         specifier: ^0.18.0
         version: 0.18.0
@@ -5413,8 +5413,8 @@ packages:
     peerDependencies:
       react: ^18.3 || ^19.0.0-0
 
-  '@sanity/media-library-types@1.0.2':
-    resolution: {integrity: sha512-OrAZ7mLDn3nd8fsRKPU6b4kNYMPLCFEXM1ghwC5xvcdD6k97b1sGR15USyG7e0exWIdH3S6Gm9xG/Jcfw+8l5A==}
+  '@sanity/media-library-types@1.1.0':
+    resolution: {integrity: sha512-awoxTyK6jS57FILEFA18FFXcajQnl+tzTX/oqPZ9NIxVpFgzYEAbr+kw6iFlSjyRdTcm/g2gFzgzk2OOOzQkRQ==}
 
   '@sanity/message-protocol@0.12.0':
     resolution: {integrity: sha512-RMRWQG5yVkCZnnBHW3qxVbZGUOeXPBzFPdD9+pynQCTVZI7zYBEzjnY8lcSYjty+0unDHqeoqMPfBXhqs0rg2g==}
@@ -16456,7 +16456,7 @@ snapshots:
       '@sanity/color': 3.0.6
       react: 19.2.3
 
-  '@sanity/media-library-types@1.0.2': {}
+  '@sanity/media-library-types@1.1.0': {}
 
   '@sanity/message-protocol@0.12.0':
     dependencies:


### PR DESCRIPTION
### Description

This PR exposes support for private assets to the Media Library via a new `capabilities` property in the plugin payload. This allows the plugin to enable private asset selection in studios that support it.

Key changes:
- Updates the plugin parameters to include the `capabilities` field to report support for private assets.
- Imports and uses new types from the `@sanity/media-library-types` package.
- Refactors asset type normalization to align types with the Media Library plugin format.

### What to review

Check that private asset selection works end-to-end in the plugin UI.

### Testing

1. Open the Media Library test studio.
2. Create an `Images test` document under `Standard inputs`.
3. Select a `Main Image` from the Media Library.
4. Verify that an asset with Private visibility can be selected.

### Notes for release

Private assets are now selectable when using the Media Library plugin.