### PR TITLE
fix(schema): warn when field names collide with DOM property names

### DIFF
--- a/packages/@sanity/schema/src/sanity/validation/createValidationResult.ts
+++ b/packages/@sanity/schema/src/sanity/validation/createValidationResult.ts
@@ -30,7 +30,7 @@ export const HELP_IDS = {
   GLOBAL_DOCUMENT_REFERENCE_INVALID: 'global-document-reference-invalid',
   DEPRECATED_BLOCKEDITOR_KEY: 'schema-deprecated-blockeditor-key',
   STANDALONE_BLOCK_TYPE: 'schema-standalone-block-type',
-  OBJECT_FIELD_NAME_RESERVED_DOM_PROPERTY: 'schema-field-name-reserved-dom-property',
+  OBJECT_FIELD_NAME_PROBLEMATIC: 'schema-field-name-problematic',
 }
 
 function createValidationResult(

--- a/packages/@sanity/schema/src/sanity/validation/types/object.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/object.ts
@@ -8,13 +8,13 @@ const VALID_FIELD_RE = /^[A-Za-z]+[0-9A-Za-z_]*$/
 const CONVENTIONAL_FIELD_RE = /^[A-Za-z_]+[0-9A-Za-z_]*$/
 
 /**
- * DOM Node/Element property names that can cause issues when used as field names.
- * Using these as field names may cause Studio crashes due to name collisions
- * with DOM APIs when document values are accidentally treated as DOM elements.
+ * Field names that can cause issues due to collisions with DOM API properties
+ * or React naming conventions. Using these as field names may cause Studio
+ * crashes when document values are accidentally treated as DOM elements.
  *
  * See: https://github.com/sanity-io/sanity/issues/4435
  */
-const RESERVED_DOM_PROPERTY_NAMES = new Set([
+const PROBLEMATIC_FIELD_NAMES = new Set([
   // Node properties
   'parentNode',
   'childNodes',
@@ -107,13 +107,13 @@ function validateFieldName(name: any): Array<any> {
       HELP_IDS.OBJECT_FIELD_NAME_INVALID,
     ]
   }
-  if (RESERVED_DOM_PROPERTY_NAMES.has(name)) {
+  if (PROBLEMATIC_FIELD_NAMES.has(name)) {
     return [
       warning(
-        `Field name "${name}" may cause issues. This name collides with a DOM API property, ` +
+        `Field name "${name}" may cause issues. This name collides with a DOM API property or a React naming convention, ` +
           `which can cause the Studio to crash in certain scenarios. ` +
           `Consider renaming this field to avoid potential issues.`,
-        HELP_IDS.OBJECT_FIELD_NAME_RESERVED_DOM_PROPERTY,
+        HELP_IDS.OBJECT_FIELD_NAME_PROBLEMATIC,
       ),
     ]
   }

--- a/packages/@sanity/schema/test/validation/validation.test.ts
+++ b/packages/@sanity/schema/test/validation/validation.test.ts
@@ -446,8 +446,8 @@ describe('Validation test', () => {
     })
   })
 
-  describe('DOM property name validation', () => {
-    test('warns when field name is a reserved DOM property (parentNode)', () => {
+  describe('Problematic field name validation', () => {
+    test('warns when field name is a problematic DOM property (parentNode)', () => {
       const schemaDef = [
         {
           type: 'document',
@@ -467,13 +467,13 @@ describe('Validation test', () => {
       expect(parentNodeField._problems).toHaveLength(1)
       expect(parentNodeField._problems[0]).toMatchObject({
         severity: 'warning',
-        helpId: 'schema-field-name-reserved-dom-property',
+        helpId: 'schema-field-name-problematic',
       })
       expect(parentNodeField._problems[0].message).toContain('parentNode')
       expect(parentNodeField._problems[0].message).toContain('DOM API property')
     })
 
-    test('warns when field name is a reserved DOM property (children)', () => {
+    test('warns when field name is a problematic DOM property (children)', () => {
       const schemaDef = [
         {
           type: 'object',
@@ -490,11 +490,11 @@ describe('Validation test', () => {
       expect(childrenField._problems).toHaveLength(1)
       expect(childrenField._problems[0]).toMatchObject({
         severity: 'warning',
-        helpId: 'schema-field-name-reserved-dom-property',
+        helpId: 'schema-field-name-problematic',
       })
     })
 
-    test('warns for various reserved DOM property names', () => {
+    test('warns for various problematic field names', () => {
       const schemaDef = [
         {
           type: 'object',
@@ -521,12 +521,12 @@ describe('Validation test', () => {
         expect(field._problems).toHaveLength(1)
         expect(field._problems[0]).toMatchObject({
           severity: 'warning',
-          helpId: 'schema-field-name-reserved-dom-property',
+          helpId: 'schema-field-name-problematic',
         })
       }
     })
 
-    test('does not warn for non-reserved field names', () => {
+    test('does not warn for non-problematic field names', () => {
       const schemaDef = [
         {
           type: 'object',


### PR DESCRIPTION
## Summary

Adds schema validation warning when field names match reserved DOM Node/Element property names (e.g., `parentNode`, `children`, `innerHTML`).

These field names can cause the Studio to crash when document data is accidentally treated as DOM elements in certain scenarios. The warning helps developers identify and rename problematic fields early.

**Changes:**
- Added `OBJECT_FIELD_NAME_RESERVED_DOM_PROPERTY` help ID for documentation linking
- Added `RESERVED_DOM_PROPERTY_NAMES` Set with 42 DOM property names that can cause collisions
- Added validation check in `validateFieldName()` to emit a warning when a field name matches
- Added 4 test cases covering the validation behavior

**Why a warning (not error):**
- Doesn't break existing schemas
- Gives developers visibility into potential crash scenarios
- Follows existing patterns for schema validation warnings

Fixes #4435

## Test plan

- [x] Unit tests pass (`pnpm --filter @sanity/schema test`)
- [ ] Manual test: Create schema with `parentNode` field, verify warning appears in Studio console

🤖 Generated with [Claude Code](https://claude.com/claude-code)