### PR TITLE
fix: normalize Windows paths in runtime.ts for ES module imports

### DIFF
--- a/packages/sanity/src/_internal/cli/server/runtime.ts
+++ b/packages/sanity/src/_internal/cli/server/runtime.ts
@@ -55,7 +55,8 @@ export async function writeSanityRuntime({
           studioRootPath: cwd,
           monorepo,
           props: {
-            entryPath: `/${path.relative(cwd, path.join(runtimeDir, 'app.js'))}`,
+            // Convert to forward slashes for URL paths (path.relative returns backslashes on Windows)
+            entryPath: `/${path.relative(cwd, path.join(runtimeDir, 'app.js')).split(path.sep).join('/')}`,
             basePath: basePath || '/',
           },
           isApp,
@@ -79,7 +80,10 @@ export async function writeSanityRuntime({
   let relativeConfigLocation: string | null = null
   if (!isApp) {
     const studioConfigPath = await getSanityStudioConfigPath(cwd)
-    relativeConfigLocation = studioConfigPath ? path.relative(runtimeDir, studioConfigPath) : null
+    // Convert to forward slashes for ES module imports (path.relative returns backslashes on Windows)
+    relativeConfigLocation = studioConfigPath
+      ? path.relative(runtimeDir, studioConfigPath).split(path.sep).join('/')
+      : null
   }
 
   const relativeEntry = cwd ? path.resolve(cwd, entry || './src/App') : entry


### PR DESCRIPTION
## Summary
Fixes #10803

On Windows, `path.relative()` returns backslashes which get double-escaped when passed to `JSON.stringify()`, resulting in invalid import paths like `..\\\\..\\\\sanity.config.ts` in `.sanity/runtime/app.js`.

## Solution
Normalize paths to forward slashes using `.split(path.sep).join('/')` in two locations:
1. `entryPath` for HTML script src (line 59)
2. `relativeConfigLocation` for ES module imports (line 84-85)

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Manual verification on Windows (need Windows environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)