### PR TITLE
fix(form): add min-width to reference autocomplete popover

### DIFF
--- a/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/ReferenceAutocomplete.tsx
+++ b/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/ReferenceAutocomplete.tsx
@@ -17,6 +17,12 @@ const StyledPopover = styled(Popover)`
     overflow: auto;
     -webkit-overflow-scrolling: touch;
   }
+
+  /* Ensure the popover has a minimum width even when rendered inside narrow containers
+   * such as block editor annotation popovers. Fixes squeezed/unreadable search results. */
+  [data-ui='Popover__wrapper'] {
+    min-width: 250px;
+  }
 `
 
 const StyledText = styled(Text)`

--- a/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/ReferenceAutocomplete.tsx
+++ b/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/ReferenceAutocomplete.tsx
@@ -18,6 +18,12 @@ const StyledPopover = styled(Popover)`
     overflow: auto;
     -webkit-overflow-scrolling: touch;
   }
+
+  /* Ensure the popover has a minimum width even when rendered inside narrow containers
+   * such as block editor annotation popovers. Fixes squeezed/unreadable search results. */
+  [data-ui='Popover__wrapper'] {
+    min-width: 250px;
+  }
 `
 
 const StyledText = styled(Text)`

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceAutocomplete.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceAutocomplete.tsx
@@ -17,6 +17,12 @@ const StyledPopover = styled(Popover)`
     overflow: auto;
     -webkit-overflow-scrolling: touch;
   }
+
+  /* Ensure the popover has a minimum width even when rendered inside narrow containers
+   * such as block editor annotation popovers. Fixes squeezed/unreadable search results. */
+  [data-ui='Popover__wrapper'] {
+    min-width: 250px;
+  }
 `
 
 const StyledText = styled(Text)`


### PR DESCRIPTION
## Summary
- Adds a minimum width (250px) to the reference autocomplete popover wrapper
- Prevents the dropdown from becoming squeezed and unreadable when rendered inside narrow containers
- Applied to all three ReferenceAutocomplete components (ReferenceInput, GlobalDocumentReferenceInput, CrossDatasetReferenceInput)

## Problem
When adding a reference field to a block editor mark/annotation (like an internal link), the reference autocomplete dropdown would be squeezed to match the width of the narrow annotation popover, making search results unreadable.

See issue screenshots showing the squeezed UI:
- Original: horizontally squeezed document previews
- After fix: readable dropdown with minimum width

## Test plan
- [ ] Add a reference field to a block editor annotation (e.g., internal link mark)
- [ ] Open the annotation popover and trigger the reference search
- [ ] Verify the autocomplete dropdown is at least 250px wide and readable
- [ ] Verify normal reference fields outside of annotations still work as expected

Fixes #3990

🤖 Generated with [Claude Code](https://claude.com/claude-code)