### PR TITLE
fix(preview): return default paths when select is undefined

### DIFF
--- a/packages/sanity/src/core/preview/utils/getPreviewPaths.test.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewPaths.test.ts
@@ -15,11 +15,13 @@ const preview: SchemaType['preview'] = {
 }
 
 describe('getPreviewPaths', () => {
-  it('Should return undefined if no selection is provided', () => {
+  it('Should return default paths if no selection is provided', () => {
     const paths = getPreviewPaths({
       select: undefined,
     })
-    expect(paths).toBeUndefined()
+    // Even without a select, we need to return default paths to ensure
+    // proper document observation for draft status detection
+    expect(paths).toEqual([['_createdAt'], ['_updatedAt']])
   })
   it('should return the default preview paths', () => {
     const paths = getPreviewPaths(preview)

--- a/packages/sanity/src/core/preview/utils/getPreviewPaths.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewPaths.ts
@@ -3,14 +3,15 @@ import {type PreviewableType, type PreviewPath} from '../types'
 const DEFAULT_PREVIEW_PATHS: PreviewPath[] = [['_createdAt'], ['_updatedAt']]
 
 /** @internal */
-export function getPreviewPaths(preview: PreviewableType['preview']): PreviewPath[] | undefined {
+export function getPreviewPaths(preview: PreviewableType['preview']): PreviewPath[] {
   const selection = preview?.select
-
-  if (!selection) return undefined
 
   // Transform the selection dot-notation paths into array paths.
   // Example: ['object.title', 'name'] => [['object', 'title'], ['name']]
-  const paths = Object.values(selection).map((value) => String(value).split('.')) || []
+  // When no selection is provided, we still need to return the default paths
+  // to ensure proper document observation (fixes draft icon showing incorrectly
+  // when using prepare() without select in preview config).
+  const paths = selection ? Object.values(selection).map((value) => String(value).split('.')) : []
 
   // Return the paths with the default preview paths appended.
   return paths.concat(DEFAULT_PREVIEW_PATHS)


### PR DESCRIPTION
## Summary
- Ensures `getPreviewPaths` always returns default paths (`_createdAt`, `_updatedAt`) even when `select` is undefined
- Fixes draft icon showing incorrectly in desk structure when using `prepare()` without `select` in preview config

## Problem
When a schema has a preview config with only `prepare()` and no `select`:
```js
preview: {
  prepare() {
    return { title: 'Website' }
  }
}
```

The desk structure shows the draft icon even when the document is published. This happens because:
1. `getPreviewPaths` returned `undefined` when `select` was missing
2. The preview observer took a fallback path that didn't properly observe document fields
3. Draft status detection was broken due to missing document observation

## Solution
Changed `getPreviewPaths` to always return at least the default paths, ensuring proper document observation regardless of whether `select` is specified.

## Test plan
- [x] Updated existing test to reflect new behavior
- [x] Create a document schema with `preview: { prepare() { return { title: 'Test' } } }`
- [x] Add it to desk structure via `S.documentListItem()` or `S.documentTypeListItem()`
- [x] Create and publish a document
- [x] Verify the draft icon no longer shows for published documents

Fixes #4349

🤖 Generated with [Claude Code](https://claude.com/claude-code)