### PR TITLE
fix(presentation): render "Presentation" in page title when `options.title` is not passed

### DIFF
--- a/packages/sanity/src/presentation/plugin.tsx
+++ b/packages/sanity/src/presentation/plugin.tsx
@@ -8,7 +8,12 @@ import {
   isDocumentSchemaType,
 } from 'sanity'
 
-import {DEFAULT_TOOL_ICON, DEFAULT_TOOL_NAME, EDIT_INTENT_MODE} from './constants'
+import {
+  DEFAULT_TOOL_ICON,
+  DEFAULT_TOOL_NAME,
+  DEFAULT_TOOL_TITLE,
+  EDIT_INTENT_MODE,
+} from './constants'
 import {PresentationDocumentHeader} from './document/PresentationDocumentHeader'
 import {PresentationDocumentProvider} from './document/PresentationDocumentProvider'
 import {openInStructure} from './fieldActions/openInStructure'
@@ -133,7 +138,7 @@ export const presentationTool = definePlugin<PresentationPluginOptions>((options
       {
         icon: options.icon || DEFAULT_TOOL_ICON,
         name: toolName,
-        title: options.title,
+        title: options.title || DEFAULT_TOOL_TITLE,
         component: PresentationTool,
         options,
         canHandleIntent(intent, params) {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
This PR passes the `DEFAULT_TOOL_TITLE` as fallback to the `options.title` argument.
This is to change the page title (visually in the browser) from `presentation | *studioName*` to `Presentation | *studioName*` as the default title.

To make it consistent with the casing of other plugins, like the [Vision](https://github.com/sanity-io/sanity/blob/20caed10d7531f82167354623799371e580449be/packages/%40sanity/vision/src/visionTool.ts#L15-L16) tool.