### PR TITLE
fix(portable-text): handle empty width array in annotation modal

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
@@ -45,7 +45,12 @@ export function ObjectEditModal(props: {
     onClose()
   }, [onClose])
 
-  const modalWidth = schemaModalOption?.width
+  // If width is an empty array (user set modal options but didn't specify width),
+  // pass undefined to let the modal component use its default width.
+  const modalWidth =
+    schemaModalOption?.width && schemaModalOption.width.length > 0
+      ? schemaModalOption.width
+      : undefined
 
   if (modalType === 'popover') {
     return (


### PR DESCRIPTION
## Summary
Fixes #4219 - Annotation popover width ignored in v3

## Problem
When a user sets `modal: {}` or `modal: {type: 'popover'}` on an annotation type without specifying a width, the popover defaults to `min-content` width instead of respecting the default width.

**Root cause:** `_getModalOption` returns `width: []` (empty array) when no width is specified. This empty array bypasses the default value in `PopoverEditDialog`:

```tsx
const {width = 1} = props  // Default only triggers for undefined, not []
```

An empty array `[]` is truthy, so the default `1` is never used. The popover receives an empty array and falls back to `min-content`.

## Solution
Check if the width array is empty and pass `undefined` instead, allowing the modal component to use its default width:

```tsx
const modalWidth =
  schemaModalOption?.width && schemaModalOption.width.length > 0
    ? schemaModalOption.width
    : undefined
```

## Changes
- `packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx`
  - Added check for empty width array before passing to modal components

## Testing
- Build passes
- When `modal: {width: 1}` is set → uses width 1 ✓
- When `modal: {}` is set (no width) → uses default width 1 ✓
- When `modal: undefined` → uses default width 1 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>