### PR TITLE
feat: make enhancedObjectDialog opt out

### DIFF
--- a/dev/studio-e2e-testing/sanity.config.ts
+++ b/dev/studio-e2e-testing/sanity.config.ts
@@ -130,13 +130,6 @@ const defaultConfig = defineConfig({
       fieldTypes: ['string'],
     }),
   ],
-  beta: {
-    form: {
-      enhancedObjectDialog: {
-        enabled: true,
-      },
-    },
-  },
   announcements: {
     enabled: false,
   },

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -84,14 +84,6 @@ const sharedSettings = ({projectId}: {projectId: string}) => {
       bundles: testStudioLocaleBundles,
     },
 
-    beta: {
-      form: {
-        enhancedObjectDialog: {
-          enabled: true,
-        },
-      },
-    },
-
     mediaLibrary: {
       enabled: true,
     },

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -750,7 +750,7 @@ function resolveSource({
       },
       form: {
         enhancedObjectDialog: {
-          enabled: enhancedObjectDialogEnabledReducer({config, initialValue: false}),
+          enabled: enhancedObjectDialogEnabledReducer({config, initialValue: true}),
         },
       },
       create: {


### PR DESCRIPTION
### Description

Part of the release plan makes this feature be optout for the next 3 weeks.

### Testing

Existing tests should pass (we have smoke tests for different configs in e2e tests)

### Notes for release

Enhanced object dialog (beta) improvements: the enhancedObjectdialog beta is now opt out by default.

In order to opt out, you will need to go to your `sanity.config.ts` and change / add a property `enhancedObjectDialog` and set it to `false`

```export default defineConfig({
// ...
  beta: {
    form: {
      enhancedObjectDialog: {
        enabled: false,
      },
    },
  },
})
```