### PR TITLE
chore: remove webkit from running in e2e ct

### DIFF
--- a/.github/workflows/e2e-ct.yml
+++ b/.github/workflows/e2e-ct.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install Playwright Browsers
         # TODO: Fix webkit caching when downloading from cache
         # for some reason it doesn't work without installing again
-        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true' || matrix.project == 'webkit'
+        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
       - name: Build packages


### PR DESCRIPTION
### Description

Unblocks #11335 
My suggestion would be to skip the webkit tests since we don't even run them for the e2e and the e2e are the significantly more important ones from an overall overview studio usage standpoint (imo)
If we do want to turn on the webkit then we need to look at it separately since it's going to be its own can of worms

### What to review

It doesn't make sense to me that we are running webkit on the ct but not on the e2e. Especially now that it blocks an upgrade to playwright

### Testing

All tests should pass

### Notes for release

N/A