### PR TITLE
fix(pte): widen annotation popover default width

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -41,7 +41,7 @@ const NoopContainer = ({children, ...props}: PropsWithChildren) => (
 const POPOVER_FALLBACK_PLACEMENTS: PopoverProps['fallbackPlacements'] = ['top', 'bottom']
 
 export function PopoverEditDialog(props: PopoverEditDialogProps): ReactNode {
-  const {floatingBoundary, referenceBoundary, referenceElement, width = 1} = props
+  const {floatingBoundary, referenceBoundary, referenceElement, width = 2} = props
   return (
     <RootPopover
       content={<Content {...props} />}


### PR DESCRIPTION
## Summary
Increases the default width of the annotation popover from `1` to `2` to make reference fields usable within annotations.

## Behavior

**Before:**
- Open a document with a PTE field containing an annotation with a reference field
- Click on the annotation to open the edit popover
- **Bug:** The popover is too narrow - reference fields are cramped and nearly unusable

**After:**
- Open a document with a PTE field containing an annotation with a reference field
- Click on the annotation to open the edit popover
- **Fixed:** The popover is wider, making reference fields properly usable

## Technical Details

The fix changes the default `width` prop in `ObjectEditModal.tsx` from `1` to `2`:

```typescript
// Before
width = 1,

// After
width = 2,
```

This affects the `Popover` component's width, giving annotation edit modals more horizontal space for complex field types like references.

## Test plan
- [ ] Open a document with a PTE field containing annotations with reference fields
- [ ] Click on an annotation to open the edit popover
- [ ] Verify the popover is now wider and reference fields are usable
- [ ] Verify the change doesn't negatively affect simple annotations (e.g., links with just a URL field)

Fixes SAPP-3444

🤖 Generated with [Claude Code](https://claude.com/claude-code)