### PR TITLE
fix(structure): published perspective incorrectly showing draft version

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -39,6 +39,7 @@ import {
 import {DocumentPaneContext} from 'sanity/_singletons'
 import {useRouter} from 'sanity/router'
 
+import {isDraftOrPublished} from '../../../core/releases/util/util'
 import {usePaneRouter} from '../../components'
 import {useDiffViewRouter} from '../../diffView/hooks/useDiffViewRouter'
 import {useDocumentLastRev} from '../../hooks/useDocumentLastRev'
@@ -278,7 +279,11 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
     documentId,
     initialValue: initialValue,
     comparisonValue: getComparisonValue,
-    releaseId: selectedPerspectiveName,
+    // Only pass releaseId for actual releases, not for system perspectives like 'published' or 'drafts'
+    releaseId:
+      selectedPerspectiveName && !isDraftOrPublished(selectedPerspectiveName)
+        ? selectedPerspectiveName
+        : undefined,
     selectedPerspectiveName,
     initialFocusPath: params.path ? pathFromString(params.path) : EMPTY_ARRAY,
     readOnly: getIsReadOnly,


### PR DESCRIPTION
## Summary

- Fixes a regression where the published perspective incorrectly displays draft content instead of the actual published document
- Root cause: `selectedPerspectiveName` was passed as `releaseId` to `useDocumentForm` even when viewing 'published' or 'drafts' perspectives
- The fix filters out system perspectives from `releaseId`, allowing the correct `isPublishedPerspective` logic to handle them

## Test plan

- [ ] Open a document that has both draft and published versions
- [ ] Switch to "Published" perspective
- [ ] Verify the published content is displayed (not draft content)
- [ ] Verify draft perspective still shows draft content correctly
- [ ] Verify release perspectives still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)