### PR TITLE
fix(form): use useDidUpdate for PrimitiveField focus handling

### DIFF
--- a/packages/sanity/src/core/form/members/object/fields/PrimitiveField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/PrimitiveField.tsx
@@ -1,6 +1,7 @@
 import {isBooleanSchemaType, isNumberSchemaType} from '@sanity/types'
-import {type ChangeEvent, useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {type ChangeEvent, useCallback, useMemo, useRef, useState} from 'react'
 
+import {useDidUpdate} from '../../../hooks/useDidUpdate'
 import {type FormPatch, PatchEvent, set, unset} from '../../../patch'
 import {type FieldMember, type PrimitiveFormNode} from '../../../store'
 import {useDocumentFieldActions} from '../../../studio/contexts/DocumentFieldActions'
@@ -35,11 +36,14 @@ export function PrimitiveField(props: {
 
   const {onPathBlur, onPathFocus, onChange} = useFormCallbacks()
 
-  useEffect(() => {
-    if (member.field.focused) {
+  // Use useDidUpdate to only focus when transitioning from unfocused to focused.
+  // This fixes Firefox focus issues when inline changes mode triggers re-renders,
+  // as it prevents redundant focus calls that can cause race conditions.
+  useDidUpdate(member.field.focused, (hadFocus, hasFocus) => {
+    if (!hadFocus && hasFocus) {
       focusRef.current?.focus()
     }
-  }, [member.field.focused])
+  })
 
   const handleBlur = useCallback(() => {
     onPathBlur(member.field.path)


### PR DESCRIPTION
## Summary
- Replace `useEffect` with `useDidUpdate` for focus handling in `PrimitiveField`
- Matches the pattern used by other field components (`ArrayOfObjectsField`, `ArrayOfPrimitivesField`, `ObjectField`)
- Fixes Firefox focus issues when inline changes mode triggers re-renders

## Problem
The previous implementation used `useEffect` which fires on every render when `focused=true`. This caused race conditions in Firefox when inline changes mode triggers re-renders - the focus call would happen at the wrong time relative to DOM updates.

## Solution
Use the `useDidUpdate` hook (already used by other field components) which only triggers focus when transitioning from unfocused to focused (`!hadFocus && hasFocus`). This prevents redundant focus calls and ensures proper timing.

## Test plan
- [ ] Test in Firefox with inline changes enabled
- [ ] Verify fields focus correctly when clicking/tabbing
- [ ] Verify no regressions in Chrome/Safari

Fixes SAPP-3446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)