### PR TITLE
fix(form): restore drag-drop upload for asset sources without Uploader

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileInput.tsx
@@ -242,9 +242,48 @@ export function BaseFileInput(props: BaseFileInputProps) {
           })
           console.error(err)
         }
+      } else {
+        // Fallback for asset sources without an Uploader (e.g., sanity-plugin-media)
+        // Use the standard uploader mechanism to handle the file upload
+        const file = files[0]
+        const uploader = resolveUploader(schemaType, file)
+        if (uploader) {
+          setIsUploading(true)
+          onChange(PatchEvent.from(createInitialUploadPatches(file)))
+          const uploadOptions: UploadOptions = {
+            metadata: get(schemaType, 'options.metadata'),
+            storeOriginalFilename: get(schemaType, 'options.storeOriginalFilename'),
+          }
+          const subscription = uploader.upload(client, file, schemaType, uploadOptions).subscribe({
+            next: (uploadEvent) => {
+              if (uploadEvent.patches) {
+                onChange(PatchEvent.from(uploadEvent.patches))
+              }
+            },
+            error: (err) => {
+              console.error(err)
+              push({
+                status: 'error',
+                description: t('asset-sources.common.uploader.upload-failed.description'),
+                title: t('asset-sources.common.uploader.upload-failed.title'),
+              })
+              onChange(PatchEvent.from([unset([UPLOAD_STATUS_KEY])]))
+              setIsUploading(false)
+            },
+            complete: () => {
+              onChange(PatchEvent.from([unset([UPLOAD_STATUS_KEY])]))
+              setIsUploading(false)
+            },
+          })
+          // Store subscription for cleanup
+          setAssetSourceUploader({
+            unsubscribe: () => subscription.unsubscribe(),
+            uploader: {abort: () => subscription.unsubscribe()} as AssetSourceUploader,
+          })
+        }
       }
     },
-    [assetSourceUploader, handleAssetLimitUpsellDialog, onChange, push, schemaType, t],
+    [assetSourceUploader, handleAssetLimitUpsellDialog, onChange, push, schemaType, t, client],
   )
 
   // Abort asset source uploads and unsubscribe from the uploader is the component unmounts

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -286,9 +286,56 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
           })
           console.error(err)
         }
+      } else {
+        // Fallback for asset sources without an Uploader (e.g., sanity-plugin-media)
+        // Use the standard uploader mechanism to handle the file upload
+        const uploader = resolveUploader(schemaType, file)
+        if (uploader) {
+          setIsUploading(true)
+          onChange(PatchEvent.from(createInitialUploadPatches(file)))
+          const uploadOptions: UploadOptions = {
+            metadata: get(schemaType, 'options.metadata'),
+            storeOriginalFilename: get(schemaType, 'options.storeOriginalFilename'),
+          }
+          const subscription = uploader.upload(client, file, schemaType, uploadOptions).subscribe({
+            next: (uploadEvent) => {
+              if (uploadEvent.patches) {
+                onChange(PatchEvent.from(uploadEvent.patches))
+              }
+            },
+            error: (err) => {
+              console.error(err)
+              push({
+                status: 'error',
+                description: t('asset-sources.common.uploader.upload-failed.description'),
+                title: t('asset-sources.common.uploader.upload-failed.title'),
+              })
+              onChange(PatchEvent.from([unset([UPLOAD_STATUS_KEY])]))
+              setIsUploading(false)
+            },
+            complete: () => {
+              onChange(PatchEvent.from([unset([UPLOAD_STATUS_KEY])]))
+              setIsUploading(false)
+            },
+          })
+          // Store subscription for cleanup
+          setAssetSourceUploader({
+            unsubscribe: () => subscription.unsubscribe(),
+            uploader: {abort: () => subscription.unsubscribe()} as AssetSourceUploader,
+          })
+        }
       }
     },
-    [handleAssetLimitUpsellDialog, assetSourceUploader, onChange, push, schemaType, t],
+    [
+      handleAssetLimitUpsellDialog,
+      assetSourceUploader,
+      onChange,
+      push,
+      schemaType,
+      t,
+      resolveUploader,
+      client,
+    ],
   )
 
   // Abort asset source uploads and unsubscribe from the uploader is the component unmounts

--- a/packages/sanity/src/core/form/studio/uploads/resolveUploadAssetSources.ts
+++ b/packages/sanity/src/core/form/studio/uploads/resolveUploadAssetSources.ts
@@ -19,7 +19,11 @@ export function resolveUploadAssetSources(
     if (file && !accepts(file, type.options?.accept || 'image/*')) {
       return []
     }
-    return formBuilder.__internal.image.assetSources.filter((source) => Boolean(source.Uploader))
+    const assetSources = formBuilder.__internal.image.assetSources
+    const sourcesWithUploader = assetSources.filter((source) => Boolean(source.Uploader))
+    // If no asset sources have an Uploader, return all sources to allow drag-and-drop
+    // to proceed. The upload step will handle missing Uploaders by finding a fallback.
+    return sourcesWithUploader.length > 0 ? sourcesWithUploader : assetSources
   }
   if (is.type('file', type)) {
     if (!supportsDirectFileUploads) {
@@ -28,7 +32,11 @@ export function resolveUploadAssetSources(
     if (file && !accepts(file, type.options?.accept || '')) {
       return []
     }
-    return formBuilder.__internal.file.assetSources.filter((source) => Boolean(source.Uploader))
+    const assetSources = formBuilder.__internal.file.assetSources
+    const sourcesWithUploader = assetSources.filter((source) => Boolean(source.Uploader))
+    // If no asset sources have an Uploader, return all sources to allow drag-and-drop
+    // to proceed. The upload step will handle missing Uploaders by finding a fallback.
+    return sourcesWithUploader.length > 0 ? sourcesWithUploader : assetSources
   }
   return []
 }


### PR DESCRIPTION
## Summary

- Fixes drag-and-drop upload regression introduced in v4.21.0 (PR #11204)
- Custom asset source plugins like `sanity-plugin-media` stopped working because the refactored code required asset sources to have an `Uploader` property
- This restores backward compatibility without requiring plugins to implement their own Uploader

## Changes

1. **resolveUploadAssetSources.ts**: If no configured asset sources have an Uploader, return all sources anyway to allow drag-and-drop to proceed
2. **ImageInput.tsx / FileInput.tsx**: When an asset source lacks an Uploader, fall back to the standard `resolveUploader` mechanism

## Test plan

- [ ] Install `sanity-plugin-media` in a studio
- [ ] Configure asset sources to only use the plugin:
  ```ts
  form: {
    image: {
      assetSources: previousAssetSources => {
        return previousAssetSources.filter(assetSource => assetSource === mediaAssetSource)
      }
    }
  }
  ```
- [ ] Verify drag-and-drop upload works for image fields
- [ ] Verify standard asset sources (without custom plugin) still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)