### PR TITLE
feat(releases): add filter for documents with validation errors

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -479,6 +479,13 @@ const releasesLocaleStrings = {
   /** Text for when no scheduled drafts are found */
   'no-scheduled-drafts': 'No Scheduled Drafts',
 
+  /** Label for the filter showing documents with validation errors */
+  'filter.validation-errors': 'Errors: {{count}}',
+  /** Aria label for the validation errors filter button */
+  'filter.validation-errors.aria-label': 'Show only documents with validation errors',
+  /** Aria label for clearing the validation errors filter */
+  'filter.validation-errors.clear-aria-label': 'Show all documents',
+
   /** Banner text showing count of active scheduled drafts requiring confirmation with one draft */
   'banner.confirm-active-scheduled-drafts_one':
     'There is {{count}} Scheduled Draft that requires scheduling confirmation',

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -50,6 +50,7 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
 
   const [openAddDocumentDialog, setAddDocumentDialog] = useState(false)
   const [pendingAddedDocument, setPendingAddedDocument] = useState<BundleDocumentRow[]>([])
+  const [showErrorsOnly, setShowErrorsOnly] = useState(false)
 
   const {t} = useTranslation(releasesLocaleNamespace)
 
@@ -72,6 +73,10 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
   )
 
   const handleAddDocumentClick = useCallback(() => setAddDocumentDialog(true), [])
+
+  const handleToggleErrorsFilter = useCallback(() => {
+    setShowErrorsOnly((prev) => !prev)
+  }, [])
 
   const filterRows = useCallback(
     (data: DocumentInRelease[], searchTerm: string) =>
@@ -151,10 +156,17 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
       )
   }, [documents, pendingAddedDocument, t, toast])
 
-  const tableData = useMemo(
-    () => (pendingAddedDocument.length ? [...documents, ...pendingAddedDocument] : documents),
-    [documents, pendingAddedDocument],
-  )
+  const tableData = useMemo(() => {
+    const allDocuments = pendingAddedDocument.length
+      ? [...documents, ...pendingAddedDocument]
+      : documents
+
+    if (showErrorsOnly) {
+      return allDocuments.filter((doc) => doc.validation?.hasError)
+    }
+
+    return allDocuments
+  }, [documents, pendingAddedDocument, showErrorsOnly])
 
   return (
     <Card
@@ -170,9 +182,13 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
     >
       <Stack>
         <ReleaseActionBadges
-          documents={tableData}
+          documents={
+            pendingAddedDocument.length ? [...documents, ...pendingAddedDocument] : documents
+          }
           releaseState={release.state}
           isLoading={isLoading}
+          showErrorsOnly={showErrorsOnly}
+          onToggleErrorsFilter={handleToggleErrorsFilter}
         />
         <Card borderTop>
           <Table<DocumentInReleaseDetail>


### PR DESCRIPTION
## Summary

- Adds a clickable "Errors: N" button to the release detail view that filters the document list to show only documents with validation errors
- Helps users quickly find and fix invalid documents in large releases instead of scrolling through the entire list
- The button only appears when there are documents with validation errors

## Changes

- `ReleaseActionBadges`: Added error count calculation and filter toggle button with critical tone
- `ReleaseSummary`: Added `showErrorsOnly` state and filter logic for table data
- `resources.ts`: Added i18n translation keys for the filter button labels

## Test plan

- [ ] Open a release with some documents that have validation errors
- [ ] Verify the "Errors: N" button appears showing the count of invalid documents
- [ ] Click the button to filter - only documents with errors should be visible
- [ ] Click again to clear the filter and show all documents
- [ ] Verify the button doesn't appear if there are no validation errors

Closes SAPP-3443

🤖 Generated with [Claude Code](https://claude.com/claude-code)