### PR TITLE
feat(releases): add tooltip to release badge for truncated titles

### DIFF
--- a/packages/sanity/src/core/releases/components/documentHeader/dialog/CopyToNewReleaseDialog.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/dialog/CopyToNewReleaseDialog.tsx
@@ -5,6 +5,7 @@ import {useState} from 'react'
 
 import {Button} from '../../../../../ui-components/button/Button'
 import {Dialog} from '../../../../../ui-components/dialog/Dialog'
+import {Tooltip} from '../../../../../ui-components/tooltip/Tooltip'
 import {LoadingBlock} from '../../../../components/loadingBlock/LoadingBlock'
 import {useSchema} from '../../../../hooks/useSchema'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
@@ -145,24 +146,24 @@ export function CopyToNewReleaseDialog(props: {
             <LoadingBlock />
           )}
 
-          <Flex
-            align="center"
-            gap={2}
-            padding={1}
-            paddingRight={2}
-            style={{
-              borderRadius: 999,
-              border: '1px solid var(--card-border-color)',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-            }}
-          >
-            <ReleaseAvatar padding={1} tone={tone} />
-            <Text size={1} title={displayTitle}>
-              {displayTitle}
-            </Text>
-          </Flex>
+          <Tooltip content={displayTitle}>
+            <Flex
+              align="center"
+              gap={2}
+              padding={1}
+              paddingRight={2}
+              style={{
+                borderRadius: 999,
+                border: '1px solid var(--card-border-color)',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              <ReleaseAvatar padding={1} tone={tone} />
+              <Text size={1}>{displayTitle}</Text>
+            </Flex>
+          </Tooltip>
         </Flex>
       </Box>
 


### PR DESCRIPTION
## Summary
- Add Tooltip component to release badge in CopyToNewReleaseDialog
- Shows full release title on hover when title is truncated

## Problem
Release badges truncate long titles with ellipsis. Users couldn't see the full title without clicking through to another view.

## Solution
Wrap the release badge Flex container with Sanity's Tooltip component. This replaces the native `title` attribute with a styled tooltip that matches the rest of the UI.

## Test plan
- [ ] Open CopyToNewReleaseDialog with a long release title
- [ ] Verify tooltip appears on hover showing full title
- [ ] Verify tooltip styling matches other tooltips in the app

Fixes SAPP-3451.

🤖 Generated with [Claude Code](https://claude.com/claude-code)