### PR TITLE
fix(studio): position toasts flush with bottom of screen

### DIFF
--- a/packages/sanity/src/core/studio/GlobalStyle.tsx
+++ b/packages/sanity/src/core/studio/GlobalStyle.tsx
@@ -62,6 +62,11 @@ export const GlobalStyle = createGlobalStyle((props) => {
       font-family: ${font.text.family};
     }
 
+    /* Fix toast positioning - remove bottom padding so toasts appear flush with screen edge */
+    [data-ui='ToastProvider'] {
+      padding-bottom: 0 !important;
+    }
+
     b {
       font-weight: ${font.text.weights.medium};
     }


### PR DESCRIPTION
## Summary

Fixes toast notifications appearing offset from the bottom of the screen by removing the bottom padding on the ToastProvider container.

**Root cause:** The `ToastProvider` from `@sanity/ui` was configured with `paddingY={7}`, which adds padding to both top and bottom. Since the container is positioned with `position: fixed; bottom: 0;`, this bottom padding caused toasts to appear ~28px above the screen edge.

**Fix:** Override the bottom padding to 0 via CSS global styles, keeping top padding for navbar clearance.

Closes SAPP-3433

## Test plan

- [ ] Open any Studio document
- [ ] Trigger a toast (e.g., save a document, perform an action that shows a notification)
- [ ] Verify the toast appears flush with the bottom of the screen
- [ ] Verify there's still proper spacing from the navbar at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)