### PR TITLE
fix(comments): move contentEditable to popover content

### DIFF
--- a/packages/sanity/src/core/comments/plugin/input/components/FloatingButtonPopover.tsx
+++ b/packages/sanity/src/core/comments/plugin/input/components/FloatingButtonPopover.tsx
@@ -1,5 +1,5 @@
 import {AddCommentIcon} from '@sanity/icons'
-import {useClickOutsideEvent} from '@sanity/ui'
+import {Box, useClickOutsideEvent} from '@sanity/ui'
 import {motion, type Variants} from 'motion/react'
 import {useRef} from 'react'
 import {styled} from 'styled-components'
@@ -38,23 +38,28 @@ export function FloatingButtonPopover(props: FloatingButtonPopoverProps) {
   const enabledText = t('inline-add-comment-button.title')
   const text = disabled ? disabledText : enabledText
 
+  // Wrap the button in a non-editable container to prevent it from being
+  // treated as editable content when rendered near Portable Text editors.
+  // Note: contentEditable={false} must be on the content, not the Popover itself,
+  // as applying it to the portal container can interfere with click event propagation.
   const content = (
-    <Button
-      data-testid="inline-comment-button"
-      disabled={disabled}
-      icon={disabled ? CommentDisabledIcon : AddCommentIcon}
-      mode="bleed"
-      onClick={onClick}
-      ref={buttonRef}
-      text={text}
-    />
+    <Box contentEditable={false}>
+      <Button
+        data-testid="inline-comment-button"
+        disabled={disabled}
+        icon={disabled ? CommentDisabledIcon : AddCommentIcon}
+        mode="bleed"
+        onClick={onClick}
+        ref={buttonRef}
+        text={text}
+      />
+    </Box>
   )
 
   return (
     <MotionPopover
       animate="visible"
       content={content}
-      contentEditable={false}
       fallbackPlacements={POPOVER_FALLBACK_PLACEMENTS}
       initial="hidden"
       open


### PR DESCRIPTION
## Summary
- Move `contentEditable={false}` from the Popover component to an inner Box wrapper
- Fixes comments button popover not responding to clicks in certain editor states

## Background
When `contentEditable={false}` was applied to the Popover component itself, it ended up on the portal container element. In certain browser states (particularly when focus is involved), this can interfere with click event propagation to children.

By moving `contentEditable={false}` to the inner content wrapper (a Box containing the Button), we preserve the intended behavior of marking this content as non-editable near Portable Text editors while ensuring clicks propagate correctly.

## Test plan
- [ ] Open a document with Portable Text field
- [ ] Select text and verify the inline comment button appears
- [ ] Click the button and verify it responds to clicks
- [ ] Test in both Chrome and Firefox

Fixes SAPP-3409

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>