### PR TITLE
fix(structure): ensure close button is rightmost in split pane toolbar

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -248,16 +248,6 @@ export const DocumentPanelHeader = memo(
                     />
                   )}
 
-                  {showSplitPaneCloseButton && (
-                    <Button
-                      key="close-view-button"
-                      icon={CloseIcon}
-                      mode="bleed"
-                      onClick={onPaneClose}
-                      tooltipProps={{content: t('buttons.split-pane-close-button.title')}}
-                    />
-                  )}
-
                   {onSetMaximizedPane && (
                     <Button
                       key="focus-pane-button"
@@ -277,6 +267,16 @@ export const DocumentPanelHeader = memo(
                       data-testid={
                         isMaximizedPane ? 'focus-pane-button-collapse' : 'focus-pane-button-focus'
                       }
+                    />
+                  )}
+
+                  {showSplitPaneCloseButton && (
+                    <Button
+                      key="close-view-button"
+                      icon={CloseIcon}
+                      mode="bleed"
+                      onClick={onPaneClose}
+                      tooltipProps={{content: t('buttons.split-pane-close-button.title')}}
                     />
                   )}
 


### PR DESCRIPTION
## Summary

Fixes toolbar button ordering in split document panes when in focus mode. The close button was appearing as second-from-right instead of rightmost after splitting a pane.

**Root cause:** The button rendering order placed the focus button (expand/collapse) after the split pane close button, instead of before it.

**Fix:** Reorder button rendering so close buttons (split close or group close) are always rendered last, keeping them rightmost in the toolbar.

**New order:**
1. Split pane button (create split)
2. Focus pane button (expand/collapse)
3. Close button (split close OR group close) - always rightmost

Closes SAPP-3423

## Test plan

- [ ] Open a document in Studio
- [ ] Enter focus mode (expand icon)
- [ ] Verify close button is rightmost in toolbar
- [ ] Click "split right" to create a split pane
- [ ] Verify close button remains rightmost in both panes
- [ ] Collapse focus mode and verify button order is still correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)