### PR TITLE
fix(vision): allow custom domains for saved query recall

### DIFF
--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -70,8 +70,8 @@ function nodeContains(node: Node, other: EventTarget | Node | null): boolean {
   return node === other || !!(node.compareDocumentPosition(other as Node) & 16)
 }
 
-const sanityUrl =
-  /\.(?:api|apicdn)\.sanity\.(?:io|work)\/(vX|v1|v\d{4}-\d\d-\d\d)\/.*?(?:query|listen)\/(.*?)\?(.*)/
+// Match Sanity API URLs with any domain (supports custom CDN domains like foolcdn.com)
+const sanityUrl = /\/(vX|v1|v\d{4}-\d\d-\d\d)\/.*?(?:query|listen)\/(.*?)\?(.*)/
 
 const isRunHotkey = (event: KeyboardEvent) =>
   isHotkey('ctrl+enter', event) || isHotkey('mod+enter', event)


### PR DESCRIPTION
## Summary
- Fix saved query recall for customers using custom CDN domains
- The `sanityUrl` regex in VisionGui.tsx was too restrictive, only matching `sanity.io` and `sanity.work` domains
- Customers using custom domains (like `foolcdn.com`) could save queries but not recall them

## Test plan
- [ ] Save a query in Vision with default domain - verify it can be recalled
- [ ] Modify a saved query URL in localStorage to use a custom domain (e.g., `foolcdn.com`)
- [ ] Verify the query with custom domain can now be recalled and loaded into the editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)