### PR TITLE
ci: simplify job names to be runner-agnostic

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -14,8 +14,8 @@ concurrency:
 jobs:
   cli-test:
     timeout-minutes: 60
-    name: CLI Tests (${{ matrix.os }} / node ${{ matrix.node }})
-    runs-on: ${{ matrix.os }}
+    name: CLI Tests (node ${{ matrix.node }})
+    runs-on: ubuntu-8core
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -27,7 +27,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-8core]
         node: [20.19.0, 20, 22.14.0, 22, 24.0.0, 24]
         experimental: [false]
         # include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ concurrency:
 jobs:
   test:
     timeout-minutes: 60
-    name: Test (${{ matrix.os }} / node ${{ matrix.node }})
-    runs-on: ${{ matrix.os }}
+    name: Test (node ${{ matrix.node }})
+    runs-on: ubuntu-8core
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -25,7 +25,6 @@ jobs:
       # we want to know if a test fails on a specific node version
       fail-fast: false
       matrix:
-        os: [ubuntu-8core]
         node: [20, 22, 24]
         experimental: [false]
         shardIndex: [1, 2, 3, 4]


### PR DESCRIPTION
## Summary

Remove runner type from job names so branch protection rules don't break when changing runners.

**Before:** `Test (ubuntu-8core / node 20)`
**After:** `Test (node 20)`

## Why

The previous PR (#11820) changed runners from `ubuntu-latest` to `ubuntu-8core`, which changed job names and broke branch protection rules. This decouples job names from runner type.

## Required action

After merge, update branch protection ruleset to use new names:
- `Test (node 20)`, `Test (node 22)`
- `CLI Tests (node 20)`, `CLI Tests (node 22)`

🤖 Generated with [Claude Code](https://claude.ai/code)