### PR TITLE
fix(core): infinite redirects when trying to log in via SSO

### DIFF
--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -158,10 +158,14 @@ export function _createAuthStore({
   loginMethod = 'dual',
   ...providerOptions
 }: AuthStoreOptions): AuthStore {
-  // this broadcast channel receives either a token as a `string` or `null`.
-  // a new client will be created from it, otherwise, it'll only trigger a retry
-  // for cookie-based auth
-  const {broadcast, messages} = createBroadcastChannel<string | null>(`dual_mode_auth_${projectId}`)
+  // This broadcast channel receives token and callbackHandled state.
+  // A new client will be created when the token changes. The callbackHandled flag
+  // tracks whether handleCallbackUrl has completed, preventing redirects before
+  // session ID exchange is complete (preventing Safari ITP infinite loop issue).
+  const {broadcast, messages} = createBroadcastChannel<{
+    token: string | null
+    callbackHandled: boolean
+  }>(`dual_mode_auth_${projectId}`)
 
   const clientFactory = clientFactoryOption ?? createSanityClient
 
@@ -172,7 +176,11 @@ export function _createAuthStore({
   // const firstMessage = messages.pipe(first())
 
   const token$ = messages.pipe(
-    startWith(isCookielessCompatibleLoginMethod(loginMethod) ? getToken(projectId) : null),
+    startWith(
+      isCookielessCompatibleLoginMethod(loginMethod)
+        ? {token: getToken(projectId), callbackHandled: false}
+        : {token: null, callbackHandled: false},
+    ),
   )
 
   // Allow configuration of `apiHost` through source configuration
@@ -188,29 +196,34 @@ export function _createAuthStore({
   const state$ = token$.pipe(
     // // see above
     // debounce(() => firstMessage),
-    map((token) =>
-      clientFactory({
-        projectId,
-        dataset,
-        apiVersion: '2021-06-07',
-        useCdn: false,
-        ...(token ? {token} : {withCredentials: true}),
-        perspective: 'raw',
-        requestTagPrefix: 'sanity.studio',
-        ignoreBrowserTokenWarning: true,
-        allowReconfigure: false,
-        headers: DEFAULT_STUDIO_CLIENT_HEADERS,
-        ...hostOptions,
-      }),
-    ),
-    switchMap((client) =>
+    map(({token, callbackHandled}) => {
+      return {
+        client: clientFactory({
+          projectId,
+          dataset,
+          apiVersion: '2021-06-07',
+          useCdn: false,
+          ...(token ? {token} : {withCredentials: true}),
+          perspective: 'raw',
+          requestTagPrefix: 'sanity.studio',
+          ignoreBrowserTokenWarning: true,
+          allowReconfigure: false,
+          headers: DEFAULT_STUDIO_CLIENT_HEADERS,
+          ...hostOptions,
+        }),
+        callbackHandled,
+      }
+    }),
+    switchMap(({client, callbackHandled}) =>
       defer(async (): Promise<AuthState> => {
-        const currentUser = await getCurrentUser(client, broadcast)
-
+        const currentUser = await getCurrentUser(client, (message) =>
+          broadcast({token: message, callbackHandled: false}),
+        )
         return {
           currentUser,
           client,
           authenticated: !!currentUser,
+          callbackHandled,
         }
       }),
     ),
@@ -222,13 +235,23 @@ export function _createAuthStore({
     shareReplay(1),
   )
 
+  let sessionIdFound = false
   async function handleCallbackUrl() {
     const sessionId = getSessionId()
 
+    const handleCallbackUrlBroadcast = (token: string | null) =>
+      broadcast({token, callbackHandled: true})
+
     if (!sessionId) {
-      broadcast(loginMethod === 'cookie' ? null : getToken(projectId))
+      // Only broadcast the token if we haven't found the session ID yet
+      // in some cases this will be called multiple times before the session ID has time to be validated
+      // we don't want to broadcast while the session ID is being validated
+      if (!sessionIdFound) {
+        handleCallbackUrlBroadcast(loginMethod === 'cookie' ? null : getToken(projectId))
+      }
       return
     }
+    sessionIdFound = true
 
     const requestClient = clientFactory({
       projectId,
@@ -244,21 +267,21 @@ export function _createAuthStore({
     let currentUser
     if (loginMethod === 'dual' || loginMethod === 'cookie') {
       // try to get the current user by using the cookie credentials
-      currentUser = await getCurrentUser(requestClient, broadcast)
+      currentUser = await getCurrentUser(requestClient, handleCallbackUrlBroadcast)
     }
 
     // If we have a user, or token authentication is explicitly disallowed (`cookie` mode),
     // then we don't need/want to fetch a token
     if (currentUser || loginMethod === 'cookie') {
       // if that worked, then we don't need to fetch a token
-      broadcast(null)
+      handleCallbackUrlBroadcast(null)
       return
     }
 
     // If we allow using token authentication, we should try to trade the session ID
     // for a token and store it locally for subsequent use
     const token = await tradeSessionForToken(requestClient, sessionId)
-    broadcast(token ?? null)
+    handleCallbackUrlBroadcast(token ?? null)
   }
 
   async function tradeSessionForToken(client: SanityClient, sessionId: string): Promise<string> {
@@ -288,18 +311,20 @@ export function _createAuthStore({
 
     clearToken(projectId)
     await requestClient.request<void>({uri: '/auth/logout', method: 'POST'})
-    broadcast(null)
+    broadcast({token: null, callbackHandled: true})
+    sessionIdFound = false
   }
 
   const LoginComponent = createLoginComponent({
     ...providerOptions,
+    state$,
     getClient: () => state$.pipe(map((state) => state.client)),
     loginMethod,
   })
 
   return {
     handleCallbackUrl,
-    token: token$,
+    token: token$.pipe(map(({token}) => token)),
     state: state$,
     LoginComponent,
     logout,

--- a/packages/sanity/src/core/store/_legacy/authStore/createMockAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createMockAuthStore.ts
@@ -18,6 +18,6 @@ export interface MockAuthStoreOptions {
  */
 export function createMockAuthStore({client, currentUser = null}: MockAuthStoreOptions): AuthStore {
   return {
-    state: of({authenticated: true, client, currentUser}),
+    state: of({authenticated: true, client, currentUser, callbackHandled: false}),
   }
 }

--- a/packages/sanity/src/core/store/_legacy/authStore/types.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/types.ts
@@ -72,6 +72,10 @@ export interface AuthState {
    * requests in the Studio
    */
   client: SanityClient
+  /**
+   * Tracks whether handleCallbackUrl has completed processing, useful for preventing redirects before the session ID has been validated for a token
+   */
+  callbackHandled: boolean
 }
 
 /**


### PR DESCRIPTION
### Description
- Fixes an infinite redirect loop that occurs in Safari when `redirectOnSingle` is enabled in the auth configuration
- Adds `callbackHandled` state to `AuthState` to track when `handleCallbackUrl` has completed processing, to prevent the `LoginComponent` from redirecting until the session ID has been resolved.


When using `redirectOnSingle: true` in the auth configuration, Safari users experience an infinite redirect loop during login, while Chrome users do not.

**Cause: Safari's Intelligent Tracking Prevention (ITP)**

Safari's ITP blocks third-party cookies more aggressively than Chrome. This creates a race condition in the authentication flow:

### Chrome Flow (works correctly):
1. User visits the app → `state$` emits initial auth state
2. Client is created with `withCredentials: true` (cookie-based auth)
3. First `/users/me` request is sent with cookies
4. **Chrome sends cookies successfully** → user is authenticated
5. No redirect needed

### Safari Flow (broken before this fix):
1. User visits the app → `state$` emits initial auth state  
2. Client is created with `withCredentials: true` (cookie-based auth)
3. First `/users/me` request is sent with cookies
4. **Safari blocks cookies due to ITP** → user appears unauthenticated
5. `AuthBoundary` renders `LoginComponent` with `authenticated: false`
6. `redirectOnSingle: true` triggers redirect to login provider **immediately**
7. User logs in → redirected back with session ID in URL hash
8. But `handleCallbackUrl()` hasn't processed the session ID yet
9. User still appears unauthenticated → redirect triggers again
10. **Infinite loop!**

The core issue is that the `LoginComponent` was redirecting before `handleCallbackUrl()` had a chance to exchange the session ID for a token.

https://github.com/user-attachments/assets/b01bae4a-c270-477d-abed-b0e9e7ead019


## Solution

Added a `callbackHandled` flag to the auth state that tracks whether `handleCallbackUrl()` has completed:

1. **Initial state**: `callbackHandled: false`
2. **After `handleCallbackUrl()` completes**: broadcasts `callbackHandled: true`
3. **`LoginComponent`**: only redirects when `callbackHandled: true`

This ensures the redirect only happens after:
- The session ID (if present) has been exchanged for a token
- The auth state has been properly updated

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Login with SSO works as always.
Redirect loop doesn't happen anymore in safari.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue when using `redirectOnSingle: true` in the auth configuration, Safari users experience an infinite redirect loop during login.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

