### PR TITLE
fix(core): use intent links for content releases navigation

### DIFF
--- a/packages/sanity/src/core/perspective/navbar/ScheduledDraftsMenuItem.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ScheduledDraftsMenuItem.tsx
@@ -1,7 +1,15 @@
 import {CalendarIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
-import {type ComponentType, useCallback} from 'react'
-import {useRouter} from 'sanity/router'
+import {
+  type ComponentProps,
+  type ComponentType,
+  type ForwardedRef,
+  forwardRef,
+  useCallback,
+  useMemo,
+} from 'react'
+import {IntentLink, useRouter} from 'sanity/router'
+import {styled} from 'styled-components'
 
 import {MenuItem} from '../../../ui-components/menuItem/MenuItem'
 import {FEATURES, useFeatureEnabled} from '../../hooks/useFeatureEnabled'
@@ -10,6 +18,10 @@ import {NavigatedToScheduledDrafts} from '../../releases/__telemetry__/navigatio
 import {useScheduledDraftsEnabled} from '../../singleDocRelease/hooks/useScheduledDraftsEnabled'
 import {RELEASES_SCHEDULED_DRAFTS_INTENT} from '../../singleDocRelease/plugin'
 import {useWorkspace} from '../../studio/workspace'
+
+const StyledLinkComponent = styled(IntentLink)`
+  text-decoration: none;
+`
 
 export const ScheduledDraftsMenuItem: ComponentType = () => {
   const router = useRouter()
@@ -31,11 +43,30 @@ export const ScheduledDraftsMenuItem: ComponentType = () => {
     telemetry.log(NavigatedToScheduledDrafts, {source: 'menu'})
   }, [telemetry])
 
+  const LinkComponent = useMemo(
+    () =>
+      // eslint-disable-next-line @typescript-eslint/no-shadow
+      forwardRef(function LinkComponent(
+        restProps: ComponentProps<typeof IntentLink>,
+        ref: ForwardedRef<HTMLAnchorElement>,
+      ) {
+        return (
+          <StyledLinkComponent
+            {...restProps}
+            intent={RELEASES_SCHEDULED_DRAFTS_INTENT}
+            params={{view: 'drafts'}}
+            ref={ref}
+          />
+        )
+      }),
+    [],
+  )
+
   if (!isScheduledDraftsEnabled || !isSingleDocReleaseEnabled || !isDraftModelEnabled) return null
 
   return (
     <MenuItem
-      as="a"
+      as={LinkComponent}
       href={scheduledDraftsUrl}
       onClick={handleClick}
       icon={CalendarIcon}

--- a/packages/sanity/src/core/perspective/navbar/ViewContentReleasesMenuItem.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ViewContentReleasesMenuItem.tsx
@@ -1,13 +1,25 @@
 import {CalendarIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
-import {type ComponentType, useCallback} from 'react'
-import {useRouter} from 'sanity/router'
+import {
+  type ComponentProps,
+  type ComponentType,
+  type ForwardedRef,
+  forwardRef,
+  useCallback,
+  useMemo,
+} from 'react'
+import {IntentLink, useRouter} from 'sanity/router'
+import {styled} from 'styled-components'
 
 import {MenuItem} from '../../../ui-components/menuItem/MenuItem'
 import {useTranslation} from '../../i18n'
 import {NavigatedToReleasesOverview} from '../../releases/__telemetry__/navigation.telemetry'
+import {RELEASES_INTENT} from '../../releases/plugin'
 import {SCHEDULES_TOOL_NAME} from '../../schedules/plugin'
 
+const StyledLinkComponent = styled(IntentLink)`
+  text-decoration: none;
+`
 export const ViewContentReleasesMenuItem: ComponentType = () => {
   const router = useRouter()
   const {t} = useTranslation()
@@ -21,9 +33,28 @@ export const ViewContentReleasesMenuItem: ComponentType = () => {
     telemetry.log(NavigatedToReleasesOverview, {source: 'menu'})
   }, [telemetry])
 
+  const LinkComponent = useMemo(
+    () =>
+      // eslint-disable-next-line @typescript-eslint/no-shadow
+      forwardRef(function LinkComponent(
+        restProps: ComponentProps<typeof IntentLink>,
+        ref: ForwardedRef<HTMLAnchorElement>,
+      ) {
+        return (
+          <StyledLinkComponent
+            {...restProps}
+            intent={RELEASES_INTENT}
+            params={{source: 'menu'}}
+            ref={ref}
+          />
+        )
+      }),
+    [],
+  )
+
   return (
     <MenuItem
-      as="a"
+      as={LinkComponent}
       href={releasesUrl}
       onClick={handleClick}
       icon={CalendarIcon}


### PR DESCRIPTION
### Description
Using intent links instead of plain html links to navigate to releases views from within the studio, this has the benefits of not doing a hard navigation when clicking the link and to resolve the issue `Refused to display '<studio-url>e-Options' to 'sameorigin` 

When using normal links, the studio will do a hard navigation within the studio causing it to crash inside dashboard.

Uploading Screen Recording 2026-01-14 at 07.54.20.mov…


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
