### PR TITLE
fix(core): use `<Link>` for workspace switching

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -10,6 +10,7 @@ import {
   Text,
 } from '@sanity/ui'
 import {useCallback, useState} from 'react'
+import {Link} from 'sanity/router'
 
 import {MenuButton, type MenuButtonProps, MenuItem, Tooltip} from '../../../../../ui-components'
 import {useTranslation} from '../../../../i18n'
@@ -28,7 +29,7 @@ const POPOVER_PROPS: MenuButtonProps['popover'] = {
 
 export function WorkspaceMenuButton() {
   const workspaces = useWorkspaces()
-  const {activeWorkspace, setActiveWorkspace} = useActiveWorkspace()
+  const {activeWorkspace} = useActiveWorkspace()
   const [authStates] = useWorkspaceAuthStates(workspaces)
   const {t} = useTranslation()
   const [scrollbarWidth, setScrollbarWidth] = useState(0)
@@ -92,7 +93,8 @@ export function WorkspaceMenuButton() {
                       return (
                         <MenuItem
                           key={workspace.name}
-                          onClick={() => setActiveWorkspace(workspace.name)}
+                          as={Link}
+                          href={workspace.basePath}
                           badgeText={STATE_TITLES[state]}
                           iconRight={isSelected ? CheckmarkIcon : undefined}
                           pressed={isSelected}
@@ -103,6 +105,7 @@ export function WorkspaceMenuButton() {
                           style={{
                             marginLeft: '1rem',
                             marginRight: `calc(1.25rem - ${scrollbarWidth}px)`,
+                            textDecoration: 'none',
                           }}
                           __unstable_space={0}
                         />


### PR DESCRIPTION
### Description

Replaces hard navigation with soft navigation in the workspace switcher menu to fix X-Frame-Options errors when the studio is embedded in iframes.

Fixes #10995

### What to review


### Testing

Manual testing recommended:
1. Open studio with multiple workspaces configured
2. Click workspace dropdown and switch between workspaces
3. Verify navigation works without page reload
4. Test in embedded iframe context (should no longer trigger X-Frame-Options error)

### Notes for release
**Do not add, it was reverted**
> Fix for workspace switcher causing X-Frame-Options errors when studio is embedded. 

