### PR TITLE
fix: issue where padding bottom was too close to dialog, fixes #11849

### DIFF
--- a/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
+++ b/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
@@ -105,7 +105,7 @@ export function EnhancedObjectDialog(props: PopoverProps | DialogProps): React.J
 
   const contents = (
     <PresenceOverlay margins={PRESENCE_MARGINS}>
-      <Box ref={containerElement} style={{height: 'min(calc(100vh - 200px), 500px)'}}>
+      <Box ref={containerElement} style={{minHeight: 'min(calc(100vh - 200px), 500px)'}}>
         {children}
       </Box>
     </PresenceOverlay>


### PR DESCRIPTION
### Description

Fixes #11849

before
<img width="819" height="704" alt="image" src="https://github.com/user-attachments/assets/fc5c03cd-cc44-4497-bbdc-8e16accf8726" />

after
<img width="819" height="861" alt="image" src="https://github.com/user-attachments/assets/0a0fdfbd-fdb9-4c91-b3ec-6e81f422208e" />

Also made sure to check that dialogs for objects that have few fields look as they should ✅ 

<img width="819" height="861" alt="image" src="https://github.com/user-attachments/assets/19a86757-d186-49f1-9026-a1134d952738" />

### What to review

Small css change

### Testing

Not needed

### Notes for release

Fixes issue where an object's input inside of modals were too close to the edge at the bottom