### PR TITLE
fix(core): reverts use `<Link>` for workspace switching (#11844)

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -89,9 +89,6 @@ export function WorkspaceMenuButton() {
 
                       const isSelected = workspace.name === activeWorkspace.name
 
-                      // we have a temporary need to make a hard direct link to the workspace
-                      // because of possibly shared context between workspaces. When this is resolved,
-                      // we can remove this and use setActiveWorkspace instead
                       return (
                         <MenuItem
                           key={workspace.name}


### PR DESCRIPTION
This reverts commit c89364ca06fe84eba1134043cf27bbcfc410ec16.

### Description
Reverting as styling is not passed correctly to the `Link` component through the menu item. 

**No selected or pressed styled applied**

<img width="322" height="542" alt="Screenshot 2026-01-16 at 13 03 52" src="https://github.com/user-attachments/assets/f72d5af2-335a-4df0-aef5-0fde7674d385" />


**How it should be:**
<img width="359" height="573" alt="Screenshot 2026-01-16 at 13 06 21" src="https://github.com/user-attachments/assets/90574d55-b1dd-4932-85a5-0acf0a10cb4e" />


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
