### PR TITLE
fix(core): show timezone button when `allowTimeZoneSwitch` is true

### DIFF
--- a/dev/test-studio/schema/standard/datetime.ts
+++ b/dev/test-studio/schema/standard/datetime.ts
@@ -35,6 +35,15 @@ export default defineType({
       },
     },
     {
+      name: 'aDateTimeWithTimezoneSwitchNoDefault',
+      type: 'datetime',
+      title: 'A datetime field with timezone switch but no displayTimeZone',
+      description: 'The timezone switch button should be visible',
+      options: {
+        allowTimeZoneSwitch: true,
+      },
+    },
+    {
       name: 'aDateTimeWithDisplayTimezoneInAmericaLosAngeles',
       type: 'datetime',
       title: 'A datetime field in America/Los_Angeles',

--- a/packages/sanity/src/core/form/inputs/DateInputs/DateTimeInput.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/DateTimeInput.tsx
@@ -235,7 +235,9 @@ export function DateTimeInput(props: DateTimeInputProps) {
                   validation={validation}
                   title={schemaType.title}
                   suffix={
-                    displayTimeZone && (
+                    // Check raw schema options for allowTimeZoneSwitch since the parsed value
+                    // defaults to true - we only want to show the button when explicitly configured
+                    (displayTimeZone || schemaType.options?.allowTimeZoneSwitch === true) && (
                       <TimeZoneButtonElementQuery>
                         <TimeZoneButton
                           tooltipContent={


### PR DESCRIPTION
### Description

Show timezone button when `allowTimeZoneSwitch: true` is set without `displayTimeZone`.

The condition now checks `schemaType.options?.allowTimeZoneSwitch === true` (raw schema options) since the parsed value defaults to true.

Fixes [SAPP-3018](https://linear.app/sanity/issue/SAPP-3018)

### What to review


### Testing

Added test field `aDateTimeWithTimezoneSwitchNoDefault` in test studio. Manual verification: confirm timezone button appears with only `allowTimeZoneSwitch: true`.

### Notes for release

Timezone switch button now displays when `allowTimeZoneSwitch: true` is configured without `displayTimeZone`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)