### PR TITLE
fix(core): allows setting timezone to dates arrays

### DIFF
--- a/dev/test-studio/schema/standard/datetime.ts
+++ b/dev/test-studio/schema/standard/datetime.ts
@@ -118,8 +118,28 @@ export default defineType({
               name: 'date',
               type: 'datetime',
               title: 'A datetime field with custom date format',
+              options: {
+                allowTimeZoneSwitch: true,
+                displayTimeZone: 'Europe/Oslo',
+              },
             },
           ],
+        },
+      ],
+    },
+    {
+      name: 'datetimesDirectlyInArray',
+      type: 'array',
+      title: 'Datetimes directly in array (for SAPP-3018 testing)',
+      description:
+        'Tests timezone persistence for datetime fields directly in arrays without wrapper objects',
+      of: [
+        {
+          type: 'datetime',
+          options: {
+            displayTimeZone: 'Europe/Oslo',
+            allowTimeZoneSwitch: true,
+          },
         },
       ],
     },

--- a/packages/sanity/src/core/form/inputs/DateInputs/DateTimeInput.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/DateTimeInput.tsx
@@ -46,7 +46,7 @@ export function sanitizeTimeZoneKeyId(id: string): string {
           return `key-${segment._key}`
         }
         if (typeof segment === 'number') {
-          return `idx-${segment}`
+          return `idx_${segment}`
         }
         return segment
       })


### PR DESCRIPTION
### Description
Fixes an issue in where setting timezone to an array of dates will fail, this was failing because `cellar` doesn't allow a hyphen (-) in the field id. 
Changing the field id to use an underscore instead fixes it.


https://github.com/user-attachments/assets/9e4c6439-a118-4937-9695-38a2a02dbd48



**Caveat**:
Given we are using an index based key, moving the items within the array will not move the timezone, in order for it to properly work we recommend using an object in the array instead of plain dates.


https://github.com/user-attachments/assets/b86152f1-d854-42d7-98c0-0732a14560e8



Defining a field like this:
``` ts
defineField({
      name: 'datetimesDirectlyInArray',
      type: 'array',
      title: 'Datetimes directly in array',
      of: [
        {
          type: 'datetime',
          options: {
            displayTimeZone: 'Europe/Oslo',
            allowTimeZoneSwitch: true,
          },
        },
      ],
    })
```
Will create the following data structure, in where we don't have a `key` to persist the value to.
```
  "datetimesDirectlyInArray": [
    "2026-01-14T08:37:00.000Z",
    "2026-01-15T09:01:00.000Z"
  ],
```

While creating it with an object, like this:
```ts
defineField(   {
      name: 'inArray',
      type: 'array',
      of: [
        {
          type: 'object',
          fields: [
            {
              name: 'date',
              type: 'datetime',
              title: 'A datetime field with custom date format',
              options: {
                allowTimeZoneSwitch: true,
                displayTimeZone: 'Europe/Oslo',
              },
            },
          ],
        },
      ],
   })
```

Will create the following data structure, in where we have a `key` to persist the value to.
```
  "inArrayWithTimezoneSwitch": [
    {
      "_key": "6738365b9728",
      "_type": "dateObject",
      "date": "2026-01-21T22:07:00.000Z"
    },
    {
      "_key": "e76a8e15c7f0",
      "_type": "dateObject",
      "date": "2026-01-16T22:07:00.000Z"
    }
  ]
```

So the recommendation is to use the object based array.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open https://test-studio-git-sapp-3018-datetime-array-timezone-persistence.sanity.dev/test/structure/input-standard;datetimeTest, scroll to the dates array and add a timezone to a date, it should be persisted.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue to allow setting timezone to dates arrays. 

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
