### PR TITLE
fix: prevent published from being treated as a release

### DIFF
--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -203,7 +203,9 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
 
   const value: SanityDocumentLike = useMemo(() => {
     const baseValue = initialValue?.value || {_id: documentId, _type: documentType}
-    if (releaseId) {
+    // Only treat releaseId as an actual release/anonymous bundle if it's not a system bundle ('published' or 'drafts')
+    // System bundles are handled by subsequent conditions below
+    if (releaseId && !isSystemBundle(releaseId)) {
       // in cases where the current version is going to be unpublished, we need to show the published document
       // this way, instead of showing the version that will stop existing, we show instead the published document with a fall back
       if (editState.version && isGoingToUnpublish(editState.version)) {


### PR DESCRIPTION
### Description
There was a bug introduced in the changes that facilitated anonymous bundles. [The change there was that we moved from passing the releaseId through the document pane provider, to passing the perspective name](https://github.com/sanity-io/sanity/pull/11745/changes#diff-7d4931380ae88cfbe9b089e1b3ff44dd33c5a1ce0d737817076e3ef6be17a494L281). This meant that system bundles like 'published' were now being passed as the releaseId parameter to useDocumentForm, causing the document form to incorrectly treat them as releases and attempt to load version documents instead of published documents. The fix adds an `!isSystemBundle` check to ensure that system bundles skip the release-specific logic and fall through to their dedicated handling conditions, while still allowing actual releases and anonymous bundles to be processed correctly.

| Before | After |
|--------|--------|
| ![beforePerspectivePubPR](https://github.com/user-attachments/assets/e55d5266-5a67-4d33-a63f-2a08cce774af) | ![fixPerspectivePubPR](https://github.com/user-attachments/assets/fe5c01ce-d62e-4b35-b98f-59919c9aaa60) | 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Test it here - https://test-studio.sanity.dev/test/structure/author;701c9c29-2d55-4f9e-9c4f-7db73cebdd15?perspective=published
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue where the published version of the document would not show when it was selected in the document form.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
