### PR TITLE
fix(core): deprecated label and validation icons overlap

### DIFF
--- a/dev/test-studio/schema/debug/deprecatedFields.ts
+++ b/dev/test-studio/schema/debug/deprecatedFields.ts
@@ -24,6 +24,7 @@ export const deprecatedFields = defineType({
         reason: 'This string field is deprecated',
       },
       type: 'namedDeprecatedObject',
+      validation: (Rule) => Rule.required(),
     }),
     defineField({
       name: 'namedDeprecatedArray',
@@ -32,6 +33,18 @@ export const deprecatedFields = defineType({
         reason: 'This string field is deprecated',
       },
       type: 'namedDeprecatedArray',
+      validation: (Rule) => Rule.required(),
+    }),
+
+    defineField({
+      deprecated: {
+        reason: 'This string list is deprecated',
+      },
+      name: 'type',
+      type: 'string',
+      title: 'list',
+      initialValue: 'foo',
+      options: {list: ['Frukt', 'Dyr', 'Fjell']},
     }),
     defineField({
       deprecated: {
@@ -46,21 +59,12 @@ export const deprecatedFields = defineType({
     }),
     defineField({
       deprecated: {
-        reason: 'This string list is deprecated',
-      },
-      name: 'type',
-      type: 'string',
-      title: 'list',
-      initialValue: 'foo',
-      options: {list: ['Frukt', 'Dyr', 'Fjell']},
-    }),
-    defineField({
-      deprecated: {
         reason: 'This number field is deprecated',
       },
       name: 'number',
       title: 'number',
       type: 'number',
+      validation: (Rule) => Rule.required(),
     }),
     defineField({
       deprecated: {
@@ -69,6 +73,7 @@ export const deprecatedFields = defineType({
       name: 'boolean',
       title: 'boolean',
       type: 'boolean',
+      validation: (Rule) => Rule.required(),
     }),
     defineField({
       deprecated: {

--- a/packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldHeaderText.tsx
@@ -11,9 +11,11 @@ import {FormFieldValidationStatus} from './FormFieldValidationStatus'
 const LabelSuffix = styled(Flex)`
   /*
    * Prevent the block size of appended elements (such as the deprecated field badge) affecting
-   * the intrinsic block size of the label.
+   * the intrinsic block size of the label, while still allowing the inline size (width) to
+   * expand naturally to fit its content.
    */
-  contain: size;
+  height: 0;
+  overflow: visible;
 `
 
 /** @internal */


### PR DESCRIPTION
### Description
Fixes https://github.com/sanity-io/sanity/issues/10723

Fixes an issue where the deprecated badge and validation icon would overlap each other in form field headers.
The `LabelSuffix` component was using `contain: size` to prevent appended elements from affecting the label's block size. However, this also constrained the inline size (width), causing the badge and icon to overlap instead of being laid out side-by-side.
Replaced contain: size with height: 0; overflow: visible which:
Still prevents the block size from being affected (height contribution is zero)
Allows the inline size (width) to expand naturally to fit the content

**Before**
<img width="614" height="414" alt="Screenshot 2026-01-19 at 17 26 36" src="https://github.com/user-attachments/assets/ebc66750-ccd6-4f4b-a2a1-a00b16e1326a" />

**Now** 
https://test-studio-git-fix-gh-10723.sanity.dev/test/structure/input-debug;deprecatedFields;f36672bd-a313-4794-a68e-de283e5f3adb

<img width="587" height="417" alt="Screenshot 2026-01-20 at 08 32 09" src="https://github.com/user-attachments/assets/aad12be4-36ab-49c4-a141-f808d57c641b" />



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open a document with a deprecated field that also has validation errors , [for example this one](https://test-studio-git-fix-gh-10723.sanity.dev/test/structure/input-debug;deprecatedFields;f36672bd-a313-4794-a68e-de283e5f3adb)

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes overlap of deprecated label with validation status icons in fields labels
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
