### PR TITLE
fix(core): handle null token in auth store

### DIFF
--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -176,6 +176,10 @@ export function _createAuthStore({
   // const firstMessage = messages.pipe(first())
 
   const token$ = messages.pipe(
+    map((message) => ({
+      token: message?.token || null,
+      callbackHandled: message?.callbackHandled ?? false,
+    })),
     startWith(
       isCookielessCompatibleLoginMethod(loginMethod)
         ? {token: getToken(projectId), callbackHandled: false}

--- a/packages/sanity/src/core/store/_legacy/authStore/createBroadcastChannel.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createBroadcastChannel.ts
@@ -5,7 +5,7 @@ import {isNonNullable} from '../../../util'
 import * as storage from './storage'
 
 export interface BroadcastChannel<T> {
-  messages: Observable<T>
+  messages: Observable<T | null>
   broadcast: (message: T) => void
 }
 


### PR DESCRIPTION
### Description
Fixes an error in `authStore` which was not backwards compatible after the change introduced in https://github.com/sanity-io/sanity/pull/11825 
The token was returning a `null` value which was not possible to destructure. This `null` value was coming from the localStorage and emitted by the `messages` broadcast channel here https://github.com/sanity-io/sanity/compare/fix-auth-store?expand=1#diff-242a994553cd0ad0ea851a053557d8ec18759133997b222384e537879b838684R31

```
Cannot destructure property 'token' of 'object null' as it is null.
```

With this change, it will map the `null` value and convert it to an object, and it also fixes the types on messages, to indicate that it can return a `null` value and force consumers to handle it.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open the studio, it should load.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
