### PR TITLE
fix(studio): handle emoji characters in workspace icon generation

### DIFF
--- a/packages/sanity/src/core/config/__tests__/createDefaultIcon.test.tsx
+++ b/packages/sanity/src/core/config/__tests__/createDefaultIcon.test.tsx
@@ -1,0 +1,72 @@
+import {studioTheme, ThemeProvider} from '@sanity/ui'
+import {render, screen} from '@testing-library/react'
+import {describe, expect, it} from 'vitest'
+
+import {createDefaultIcon} from '../createDefaultIcon'
+
+function renderIcon(title: string, subtitle = '') {
+  return render(
+    <ThemeProvider theme={studioTheme}>{createDefaultIcon(title, subtitle)}</ThemeProvider>,
+  )
+}
+
+describe('createDefaultIcon', () => {
+  it('should render the first letter of a single word title', () => {
+    renderIcon('Studio')
+    expect(screen.getByText('S')).toBeInTheDocument()
+  })
+
+  it('should render the first two letters of a multi-word title', () => {
+    renderIcon('My Studio')
+    expect(screen.getByText('MS')).toBeInTheDocument()
+  })
+
+  it('should handle titles with emojis by ignoring them', () => {
+    // This tests the fix for the Sentry error where emojis caused lone surrogates
+    renderIcon('Staging 🟠')
+    expect(screen.getByText('S')).toBeInTheDocument()
+  })
+
+  it('should handle titles with multiple emojis', () => {
+    renderIcon('🎉 Party Time 🎊')
+    expect(screen.getByText('PT')).toBeInTheDocument()
+  })
+
+  it('should handle titles that are only emojis', () => {
+    renderIcon('🟢')
+    // When the title is only emojis, after filtering there should be no letters
+    // The component should handle this gracefully (empty text)
+    const svg = document.querySelector('svg')
+    expect(svg).toBeInTheDocument()
+  })
+
+  it('should handle titles with special unicode characters', () => {
+    renderIcon('Producción 🟢')
+    expect(screen.getByText('P')).toBeInTheDocument()
+  })
+
+  it('should handle titles with accented characters', () => {
+    renderIcon('Café Résumé')
+    expect(screen.getByText('CR')).toBeInTheDocument()
+  })
+
+  it('should not produce lone surrogates in the output', () => {
+    // Render a title with emojis
+    const {container} = renderIcon('Test 🟠 Title')
+
+    // Get all text content and check for lone surrogates
+    const textContent = container.textContent || ''
+
+    // Regex to detect lone surrogates
+    const loneSurrogateRegex =
+      /[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/
+
+    expect(textContent).not.toMatch(loneSurrogateRegex)
+  })
+
+  it('should handle complex emoji like flags', () => {
+    // Flag emojis are composed of multiple code points
+    renderIcon('🇺🇸 USA')
+    expect(screen.getByText('U')).toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/core/config/createDefaultIcon.tsx
+++ b/packages/sanity/src/core/config/createDefaultIcon.tsx
@@ -30,14 +30,14 @@ function DefaultIcon({title, subtitle}: {title: string; subtitle: string}): Reac
   const letters = title
     // split by whitespace
     .split(/\s/g)
-    // replace all non-word characters with empty string
-    .map((word) => word.replace(/\\W/g, ''))
+    // replace all non-word characters with empty string (Unicode-aware)
+    .map((word) => word.replace(/[^\p{L}\p{N}]/gu, ''))
     // remove empty strings
     .filter(Boolean)
     // take the first two words
     .slice(0, 2)
-    // grab the first letter and make it upper case
-    .map((i) => i.charAt(0).toUpperCase())
+    // grab the first character (Unicode-aware to handle emojis/surrogate pairs correctly)
+    .map((i) => [...i][0]?.toUpperCase() ?? '')
 
   const darkened = darken(color, 0.4)
   const lightened = lighten(color, 0.4)


### PR DESCRIPTION
### Description

Fixes a bug where workspace titles containing emoji characters (e.g., "Staging 🟠") would cause the default icon generation to produce invalid Unicode strings.

Two issues were present in `createDefaultIcon.tsx`:

1. The regex `/\\W/g` was incorrectly matching the literal string `\W` instead of non-word characters, allowing emojis to pass through the filter
2. Using `charAt(0)` on strings containing emojis returns only the high surrogate of the surrogate pair, producing invalid lone surrogates

The fix uses a Unicode-aware regex (`/[^\p{L}\p{N}]/gu`) and spreads the string to properly handle multi-code-unit characters (`[...str][0]`).

### What to review

- The regex and string handling changes in `createDefaultIcon.tsx`
- The new test cases covering emoji handling

### Testing

Added 9 test cases in `createDefaultIcon.test.tsx` covering:
- Single and multi-word titles
- Titles with emojis (the bug case)
- Titles that are only emojis
- Titles with accented characters (e.g., "Producción")
- Verification that no lone surrogates are produced in output
- Complex emojis like country flags

### Notes for release

Not required - this is a bug fix for an edge case that most users won't encounter.
