### PR TITLE
fix: allow custom object types as portable text annotations

### DIFF
--- a/dev/test-studio/schema/debug/annotationCustomTypeTest.ts
+++ b/dev/test-studio/schema/debug/annotationCustomTypeTest.ts
@@ -1,0 +1,211 @@
+/**
+ * Test case for GitHub issue #3782:
+ * https://github.com/sanity-io/sanity/issues/3782
+ *
+ * This tests whether custom object types can be used directly as annotations
+ * in portable text fields without wrapping them in another object.
+ *
+ * The issue reported that using a custom type directly in annotations array
+ * caused errors, while inline object definitions or wrapped objects worked fine.
+ *
+ * FIX APPLIED:
+ * Modified `isJSONTypeOf` in packages/\@sanity/schema/src/sanity/validation/utils/isJSONTypeOf.ts
+ * to handle the case where custom types are referenced but not yet fully resolved during
+ * schema validation traversal.
+ */
+
+import {defineArrayMember, defineField, defineType} from 'sanity'
+
+/**
+ * A custom CTA (Call to Action) type defined at the schema level.
+ * This type will be used directly as an annotation to test issue #3782.
+ */
+export const ctaType = defineType({
+  name: 'ctaAnnotation',
+  title: 'CTA',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'url',
+      title: 'URL',
+      type: 'url',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'label',
+      title: 'Button Label',
+      type: 'string',
+    }),
+    defineField({
+      name: 'openInNewTab',
+      title: 'Open in new tab',
+      type: 'boolean',
+      initialValue: false,
+    }),
+  ],
+})
+
+/**
+ * Another custom annotation type to test with more fields.
+ */
+export const tooltipAnnotationType = defineType({
+  name: 'tooltipAnnotation',
+  title: 'Tooltip',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'text',
+      title: 'Tooltip Text',
+      type: 'text',
+      rows: 2,
+      validation: (Rule) => Rule.required(),
+    }),
+  ],
+})
+
+/**
+ * Test document that uses custom types directly as annotations.
+ * This is the core test for issue #3782.
+ */
+export const annotationCustomTypeTest = defineType({
+  name: 'annotationCustomTypeTest',
+  title: 'Annotation Custom Type Test (Issue #3782)',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+    }),
+
+    /**
+     * TEST CASE 1: Using custom type directly as annotation
+     *
+     * This is what users want to do - reference a custom type directly in annotations.
+     * It should work now.
+     */
+    defineField({
+      name: 'bodyWithCustomAnnotation',
+      title: 'Body with Custom Annotation Type (Issue #3782 Test)',
+      description:
+        'This field uses a custom type (ctaAnnotation) directly in the annotations array. ' +
+        'This did not use to work. It should now work with the fix applied.',
+      type: 'array',
+      of: [
+        defineArrayMember({
+          type: 'block',
+          marks: {
+            decorators: [
+              {title: 'Strong', value: 'strong'},
+              {title: 'Emphasis', value: 'em'},
+            ],
+            annotations: [
+              // Using a custom type directly by name - should now work!
+              {
+                type: 'ctaAnnotation',
+                name: 'cta',
+                title: 'CTA Link',
+              },
+              // Using a custom type directly by name - should now work!
+              {
+                type: 'tooltipAnnotation',
+                name: 'tooltip',
+                title: 'Tooltip',
+              },
+            ],
+          },
+        }),
+      ],
+    }),
+
+    // TEST CASE 2: Using inline object definition
+    // This approach also works (always did)
+    defineField({
+      name: 'bodyWithInlineAnnotation',
+      title: 'Body with Inline Annotation',
+      description:
+        'This field uses an inline object definition for annotation. ' +
+        'This approach has always worked.',
+      type: 'array',
+      of: [
+        defineArrayMember({
+          type: 'block',
+          marks: {
+            decorators: [
+              {title: 'Strong', value: 'strong'},
+              {title: 'Emphasis', value: 'em'},
+            ],
+            annotations: [
+              // Inline definition
+              {
+                name: 'ctaInline',
+                type: 'object',
+                title: 'CTA Link (Inline)',
+                fields: [
+                  {
+                    name: 'url',
+                    title: 'URL',
+                    type: 'url',
+                  },
+                  {
+                    name: 'label',
+                    title: 'Button Label',
+                    type: 'string',
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      ],
+    }),
+
+    // TEST CASE 3: Wrapped in another object
+    // Another approach - custom type as a field inside an object
+    defineField({
+      name: 'bodyWithWrappedAnnotation',
+      title: 'Body with Wrapped Annotation',
+      description:
+        'This field wraps the custom type reference as a field inside an object. ' +
+        'This approach has always worked.',
+      type: 'array',
+      of: [
+        defineArrayMember({
+          type: 'block',
+          marks: {
+            decorators: [
+              {title: 'Strong', value: 'strong'},
+              {title: 'Emphasis', value: 'em'},
+            ],
+            annotations: [
+              // Wrapped in an object with the custom type as a field
+              {
+                name: 'ctaWrapper',
+                type: 'object',
+                title: 'CTA Link (Wrapped)',
+                fields: [
+                  {
+                    name: 'cta',
+                    title: 'CTA Details',
+                    type: 'ctaAnnotation',
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      ],
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+    },
+    prepare({title}) {
+      return {
+        title: title || 'Annotation Custom Type Test',
+        subtitle: 'Issue #3782 Test Case',
+      }
+    },
+  },
+})

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -7,6 +7,11 @@ import validationTest from './ci/validationCI'
 import actions from './debug/actions'
 import {allFieldsGroupHidden} from './debug/allFieldsGroupHidden'
 import {allNativeInputComponents} from './debug/allNativeInputComponents'
+import {
+  annotationCustomTypeTest,
+  ctaType,
+  tooltipAnnotationType,
+} from './debug/annotationCustomTypeTest'
 import {arrayCapabilities} from './debug/arrayCapabilities'
 import button from './debug/button'
 import {circularCrossDatasetReferenceTest} from './debug/circularCrossDatasetReference'
@@ -200,6 +205,9 @@ export function createSchemaTypes(projectId: string) {
 
     // Test documents for debugging
     actions,
+    annotationCustomTypeTest,
+    ctaType,
+    tooltipAnnotationType,
     button,
     collapsibleObjects,
     commentsDebug,

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -96,6 +96,7 @@ export const DEBUG_INPUT_TYPES = [
   'validationTest',
   'virtualizationDebug',
   'virtualizationInObject',
+  'annotationCustomTypeTest',
 ]
 
 export const CI_INPUT_TYPES = ['conditionalFieldset', 'validationCI', 'textsTest', 'commentsCI']

--- a/packages/@sanity/schema/src/sanity/validation/types/block.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/block.ts
@@ -281,7 +281,13 @@ function validateAnnotations(annotations: any, visitorContext: any, problems: an
 
     const {_problems} = visitorContext.visit(annotation, visitorContext)
     const targetType = annotation.type && visitorContext.getType(annotation.type)
-    if (targetType && !isJSONTypeOf(targetType, 'object', visitorContext)) {
+
+    // Only validate if targetType is actually resolved (not just a placeholder).
+    // During schema traversal, custom types start as empty placeholder objects {}
+    // that get filled in later. We can identify a resolved type by the presence
+    // of 'jsonType' or 'type' properties.
+    const isResolvedType = targetType && ('jsonType' in targetType || 'type' in targetType)
+    if (isResolvedType && !isJSONTypeOf(targetType, 'object', visitorContext)) {
       _problems.push(
         error(
           `Annotation cannot have type "${annotation.type}" - annotation types must inherit from object`,

--- a/packages/@sanity/schema/test/validation/validation.test.ts
+++ b/packages/@sanity/schema/test/validation/validation.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-nested-callbacks */
 import {SquareIcon} from '@sanity/icons'
 import {flatten} from 'lodash-es'
 import {describe, expect, test} from 'vitest'
@@ -202,5 +203,241 @@ describe('Validation test', () => {
       (problem: any) => problem.severity === 'error',
     )
     expect(validationErrors).toHaveLength(0)
+  })
+
+  describe('block annotations with custom types', () => {
+    test('accepts custom object type used directly as annotation', () => {
+      // This is the pattern that was broken in issue #3782
+      // https://github.com/sanity-io/sanity/issues/3782
+      const schemaDef = [
+        {
+          name: 'ctaAnnotation',
+          type: 'object',
+          title: 'CTA',
+          fields: [
+            {name: 'url', type: 'url'},
+            {name: 'label', type: 'string'},
+          ],
+        },
+        {
+          name: 'testDocument',
+          type: 'document',
+          fields: [
+            {
+              name: 'body',
+              type: 'array',
+              of: [
+                {
+                  type: 'block',
+                  marks: {
+                    annotations: [
+                      {
+                        type: 'ctaAnnotation',
+                        name: 'cta',
+                        title: 'CTA Link',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      const validation = validateSchema(schemaDef)
+      const testDocument = validation.get('testDocument')
+
+      // Check document has no errors
+      expect(testDocument._problems).toHaveLength(0)
+
+      // Check the block field has no errors
+      const bodyField = testDocument.fields.find((f: any) => f.name === 'body')
+      expect(bodyField._problems).toHaveLength(0)
+
+      // Check the block type has no errors
+      const blockType = bodyField.of[0]
+      expect(blockType._problems).toHaveLength(0)
+
+      // Check the annotation has no errors
+      const annotation = blockType.marks.annotations[0]
+      expect(annotation._problems).toHaveLength(0)
+    })
+
+    test('accepts multiple custom object types as annotations', () => {
+      const schemaDef = [
+        {
+          name: 'linkAnnotation',
+          type: 'object',
+          fields: [{name: 'href', type: 'url'}],
+        },
+        {
+          name: 'tooltipAnnotation',
+          type: 'object',
+          fields: [{name: 'text', type: 'string'}],
+        },
+        {
+          name: 'testDocument',
+          type: 'document',
+          fields: [
+            {
+              name: 'body',
+              type: 'array',
+              of: [
+                {
+                  type: 'block',
+                  marks: {
+                    annotations: [
+                      {type: 'linkAnnotation', name: 'link', title: 'Link'},
+                      {type: 'tooltipAnnotation', name: 'tooltip', title: 'Tooltip'},
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      const validation = validateSchema(schemaDef)
+      const testDocument = validation.get('testDocument')
+      const bodyField = testDocument.fields.find((f: any) => f.name === 'body')
+      const blockType = bodyField.of[0]
+
+      // Both annotations should have no errors
+      expect(blockType.marks.annotations[0]._problems).toHaveLength(0)
+      expect(blockType.marks.annotations[1]._problems).toHaveLength(0)
+    })
+
+    test('still accepts inline object annotations', () => {
+      const schemaDef = [
+        {
+          name: 'testDocument',
+          type: 'document',
+          fields: [
+            {
+              name: 'body',
+              type: 'array',
+              of: [
+                {
+                  type: 'block',
+                  marks: {
+                    annotations: [
+                      {
+                        type: 'object',
+                        name: 'inlineLink',
+                        title: 'Inline Link',
+                        fields: [
+                          {name: 'href', type: 'url'},
+                          {name: 'blank', type: 'boolean'},
+                        ],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      const validation = validateSchema(schemaDef)
+      const testDocument = validation.get('testDocument')
+      const bodyField = testDocument.fields.find((f: any) => f.name === 'body')
+      const blockType = bodyField.of[0]
+
+      expect(blockType.marks.annotations[0]._problems).toHaveLength(0)
+    })
+
+    test('still rejects non-object types as annotations', () => {
+      const schemaDef = [
+        {
+          name: 'stringType',
+          type: 'string',
+        },
+        {
+          name: 'testDocument',
+          type: 'document',
+          fields: [
+            {
+              name: 'body',
+              type: 'array',
+              of: [
+                {
+                  type: 'block',
+                  marks: {
+                    annotations: [
+                      {
+                        type: 'stringType',
+                        name: 'invalidAnnotation',
+                        title: 'Invalid',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      const validation = validateSchema(schemaDef)
+      const testDocument = validation.get('testDocument')
+      const bodyField = testDocument.fields.find((f: any) => f.name === 'body')
+      const blockType = bodyField.of[0]
+      const annotation = blockType.marks.annotations[0]
+
+      // Should have an error because annotations must inherit from object
+      const errors = annotation._problems.filter((p: any) => p.severity === 'error')
+      expect(errors.length).toBeGreaterThan(0)
+      expect(errors[0].message).toContain('annotation types must inherit from object')
+    })
+
+    test('accepts mixed custom and inline annotations', () => {
+      const schemaDef = [
+        {
+          name: 'customLink',
+          type: 'object',
+          fields: [{name: 'url', type: 'url'}],
+        },
+        {
+          name: 'testDocument',
+          type: 'document',
+          fields: [
+            {
+              name: 'body',
+              type: 'array',
+              of: [
+                {
+                  type: 'block',
+                  marks: {
+                    annotations: [
+                      // Custom type reference
+                      {type: 'customLink', name: 'customLink', title: 'Custom Link'},
+                      // Inline object definition
+                      {
+                        type: 'object',
+                        name: 'inlineNote',
+                        title: 'Note',
+                        fields: [{name: 'text', type: 'text'}],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      const validation = validateSchema(schemaDef)
+      const testDocument = validation.get('testDocument')
+      const bodyField = testDocument.fields.find((f: any) => f.name === 'body')
+      const blockType = bodyField.of[0]
+
+      // Both should work without errors
+      expect(blockType.marks.annotations[0]._problems).toHaveLength(0)
+      expect(blockType.marks.annotations[1]._problems).toHaveLength(0)
+    })
   })
 })


### PR DESCRIPTION
### Description

Fixes #3782, where the validation was being too trigger happy about using custom types

The fix detects that custom types like ctaAnnotation are still placeholders ({}) during the initial validation pass and stops it from going into the isJSONTypeOf too early triggering an error before it should.

Let me know if this feels still too broad.

Schema that would break: https://github.com/sanity-io/sanity/pull/11893/changes#diff-246ea298ea0dd7e3a0922756908f7af2bdfe6cc1a4c0ce6bf3bf3fb00a8cbbf1R81-R161

Before
<img width="1239" height="942" alt="image" src="https://github.com/user-attachments/assets/0d07ebf8-0667-49de-81b3-7362b63b57a1" />

After

https://github.com/user-attachments/assets/7d8ddc17-137a-4d44-8c8e-57b91dfd08ec


### What to review

Let me know if this feels still too broad. 
Tagging @rexxars  specifically since the git blame throws it your way and I would just feel safer if other folks that have been in this area in recent times (if 7 years can be considered "recent" see something that I did not)

### Testing

Added unit tests.

You can manually test by going to the specific doc type created and either use one of the existing docs or creating an ew one [here](https://test-studio-git-fixes-3782.sanity.dev/test/structure/input-debug;annotationCustomTypeTest)

### Notes for release

Fixes bug where using custom types directly in annotations within a portable text editor would cause the studio to crash