### PR TITLE
fix(core): ensure PTE custom toolbar icons use correct color token

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/helpers.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/helpers.tsx
@@ -19,6 +19,7 @@ import {
 import {type ObjectSchemaType} from '@sanity/types'
 import {capitalize, get} from 'lodash-es'
 import {type ComponentType, isValidElement} from 'react'
+import {isValidElementType} from 'react-is'
 
 import {CustomIcon} from './CustomIcon'
 import {
@@ -203,16 +204,11 @@ const listStyleIcons: Record<string, ComponentType> = {
 }
 
 const ActionIcon = ({action}: {action: PTEToolbarAction}) => {
-  const icon = action.icon
-  if (isValidElement(icon)) {
-    return icon
-  }
-  // At this point, icon could be a ComponentType or other ReactNode types
-  // (strings, numbers, etc.)
-  if (typeof icon === 'function') {
-    const Icon = icon
-    return <Icon />
-  }
+  const Icon = action.icon
+
+  if (isValidElementType(Icon)) return <Icon />
+  if (isValidElement(Icon)) return Icon
+
   // Fallback for any other ReactNode types
   return null
 }
@@ -224,7 +220,7 @@ export function getActionIcon(action: PTEToolbarAction, active: boolean) {
     }
 
     return (
-      <span data-sanity-icon="custom-icon">
+      <span data-sanity-icon style={{display: 'contents'}}>
         <ActionIcon action={action} />
       </span>
     )


### PR DESCRIPTION
### Description
fixes https://github.com/sanity-io/sanity/issues/10082
Custom icons provided to Portable Text toolbar actions were rendering with incorrect colors. 
This happened because:
- Icons from @sanity/icons include a data-sanity-icon attribute that triggers CSS rules applying --card-icon-color
- Custom icons (either as ComponentType or ReactNode) lacked this attribute, causing them to fall back to --card-fg-color

With this fix, custom icons will be wrapped in a `span`  with `data-sanity-icon` attribute, which will change the default color to use and will apply the `--card-icon-color` variable 
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Ensure PTE custom toolbar icons use correct color token
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
