### PR TITLE
fix: update response handling to return latest package version

### DIFF
--- a/packages/sanity/src/core/studio/packageVersionStatus/fetchLatestVersions.ts
+++ b/packages/sanity/src/core/studio/packageVersionStatus/fetchLatestVersions.ts
@@ -76,7 +76,7 @@ export const fetchLatestAvailableVersionForPackage = async (options: {
         accept: 'application/json',
       },
     })
-    return res.json().then((data): string => data.packageVersion)
+    return res.json().then((data): string => data.latest)
   } catch (err) {
     console.error(
       `Failed to fetch version for package (using tag=${tag})`,


### PR DESCRIPTION
### Description
There is a new field in the response from the module-server. Previously only the `packageVersion` was exposed. This would follow major upgrade rules, which would have the impact that if your studio was not auto-updating and on v4.x say, but the latest version was v5.x, the 'upgrade available' menu item would only show the highest v4.x.

Now, the module-server response includes a response key that surfaces the very highest semver, regardless of major upgrade rules. This means that v4.x will see v5.x correctly going forward.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
This is difficult to test because it requires being on a major version one behind the latest, whilst also including this particular pkg-pr-new. However, the module-server changes have been fully tested and verified, and the change to studio is trivially pointing to this new field
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
For self-updating studios, Studio now flags the correct highest latest version that is available to upgrade to.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
