### PR TITLE
fix(structure): omit system bundles from versions in reference banner

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ReferenceChangedBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ReferenceChangedBanner.tsx
@@ -9,6 +9,7 @@ import {debounceTime, map} from 'rxjs/operators'
 import {
   type DocumentAvailability,
   getPublishedId,
+  isSystemBundle,
   useDocumentPreviewStore,
   usePerspective,
   useTranslation,
@@ -79,7 +80,7 @@ export const ReferenceChangedBanner = memo(() => {
           publishedId,
           (keyedSegmentIndex === -1 ? path : path.slice(0, keyedSegmentIndex)) as string[][],
           {
-            version: selectedPerspectiveName,
+            version: isSystemBundle(selectedPerspectiveName) ? undefined : selectedPerspectiveName,
           },
         )
         .pipe(


### PR DESCRIPTION
### Description
When opening a the reference of a document in a new pane in the studio, the studio crashes due to how it is receiving the `selectedPerspectiveName = "published"`, which then passes to `observePathsDocumentPair`.
`observePathsDocumentPair` should only receive releases ids as versions, neither `published` or `draft`.

```
Error: Version can not be "published" or "drafts"
    at getIdPair (draftUtils.ts:84:11)
    at Object.observePathsDocumentPair [as unstable_observePathsDocumentPair] (documentPair.ts:29:47)
    at Memo(:3333/test/structure/ReferenceChangedBanner) (http://localhost:3333/@fs/Users/pedrobonamin/code/sanity/packages/sanity/src/structure/panes/document/documentPanel/banners/ReferenceChangedBanner.tsx?t=1768984376424:72:64)

```


**Issue**
https://github.com/user-attachments/assets/8cc889c3-0476-46f4-8169-bd3e63bfa0aa

**Fixed**
https://github.com/user-attachments/assets/bbb4f8c6-b84b-43db-aeaf-15c54c93ea3b

 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in where opening referenced documents could crash the studio if the perspective is published.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
