### PR TITLE
fix(cli): add clear error message when dataset is missing for migrations

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -179,6 +179,12 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
       )
     }
 
+    if (!dataset && !projectConfig.dataset) {
+      throw new Error(
+        'sanity.cli.js does not contain a dataset ("api.dataset") and no --dataset option was provided.',
+      )
+    }
+
     const apiConfig = {
       dataset: dataset ?? projectConfig.dataset!,
       projectId: project ?? projectConfig.projectId!,


### PR DESCRIPTION
### Description

Fixes #7528

When running `sanity migration run` without a configured dataset in `sanity.cli.ts`, the CLI would previously fall back to a placeholder dataset name (`~dummy-placeholder-dataset-`) resulting in a confusing HTTP 404 error.

This adds a guard clause to validate the dataset configuration before making API calls, providing a clear error message upfront:
```
sanity.cli.js does not contain a dataset ("api.dataset") and no --dataset option was provided.
```

This matches the existing behavior for missing `projectId` validation.

### What to review

- The change is in `packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts`
- Added a check for missing dataset that mirrors the existing projectId check (lines 176-180)
- The new check (lines 182-186) throws a clear error message before any API calls are made

### Testing

Manually tested by:
1. Commenting out `dataset` in `sanity.cli.ts`
2. Running `npx sanity migration run <migration-name>`
3. Verified the new clear error message appears instead of the confusing HTTP 404

No automated test was added as there are no existing unit tests for the migration command validation logic.

### Notes for release

**What changed:** The `sanity migration run` command now shows a clear error message when the dataset is not configured in `sanity.cli.ts` and no `--dataset` flag is provided.

**Before:** Users would see a confusing HTTP 404 error referencing `~dummy-placeholder-dataset-`

**After:** Users see: `sanity.cli.js does not contain a dataset ("api.dataset") and no --dataset option was provided.`

This is a UX improvement with no breaking changes.