### PR TITLE
fix(cli): add early validation for missing dataset in migration command

### DIFF
--- a/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
+++ b/packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts
@@ -179,14 +179,18 @@ const runMigrationCommand: CliCommandDefinition<CreateFlags> = {
       )
     }
 
-    if (!dataset && !projectConfig.dataset) {
+    const actualDataset =
+      dataset ||
+      (projectConfig.dataset === '~dummy-placeholder-dataset-' ? undefined : projectConfig.dataset)
+
+    if (!actualDataset) {
       throw new Error(
         'sanity.cli.js does not contain a dataset name ("api.dataset") and no --dataset option was provided.',
       )
     }
 
     const apiConfig = {
-      dataset: dataset ?? projectConfig.dataset!,
+      dataset: actualDataset,
       projectId: project ?? projectConfig.projectId!,
       apiHost: projectConfig.apiHost,
       token: projectConfig.token!,


### PR DESCRIPTION
### Description

This PR adds early validation for missing dataset configuration in the `sanity migration run` command.
If you forget to add the dataset into sanity.cli when running a migration you get an unhelpful error:

```
HTTPError: Dataset alias not found: Dataset alias "dummy-placeholder-dataset-" not found for project ID "r2y6wevh"
```
This adds an early validation to return a proper error:
```
    'sanity.cli.js does not contain a dataset name ("api.dataset") and no --dataset option was provided.
```

**What changed:** Added a validation check that throws a clear error when no dataset is configured in `sanity.cli.ts` and no `--dataset` flag is provided.

**Issue:** Fixes #7528

### What to review

- The validation logic in `packages/sanity/src/_internal/cli/commands/migration/runMigrationCommand.ts` (lines 182-186)
- The new test file at `packages/sanity/src/_internal/cli/commands/migration/__tests__/runMigrationCommand.test.ts`
- Verify the error message is clear and follows the same pattern as the existing `projectId` validation

### Testing

Added a new test file with 3 test cases:
1. Throws error when dataset is not configured
2. Throws error when projectId is not configured (existing validation)
3. Does not throw when dataset is properly configured

All tests passing locally.

### Notes for release
n/a improvement