### PR TITLE
fix: fixes issue with loading esm cli bin

### DIFF
--- a/packages/sanity/bin/sanity
+++ b/packages/sanity/bin/sanity
@@ -19,6 +19,7 @@
 import {readFile, open} from 'node:fs/promises'
 import {createRequire} from 'node:module'
 import {dirname, resolve} from 'node:path'
+import {pathToFileURL} from 'node:url'
 import execa from 'execa'
 
 const require = createRequire(import.meta.url)
@@ -54,7 +55,7 @@ async function runSanityCli() {
   // prevent needing to spawn a new process
   if (await isNodeScript(bin)) {
     if (type === 'module') {
-      await import(bin)
+      await import(pathToFileURL(bin).href)
     } else {
       require(bin)
     }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This is not currently an issue but a future facing fix, absolute paths are not supported in windows and need to be converted to file urls. Ref: https://github.com/nodejs/node/issues/31710 Please let me know if I misunderstood anything 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Changes makes sense

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Nothing yet, there is tests in other repo and have manually tested.

### Notes for release

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->

N/A (internal for now, codepath is unused)