### PR TITLE
refactor: remove editObject telemetry event

### DIFF
--- a/packages/sanity/src/core/form/members/array/items/ArrayOfObjectsItem.tsx
+++ b/packages/sanity/src/core/form/members/array/items/ArrayOfObjectsItem.tsx
@@ -17,7 +17,6 @@ import {FormCallbacksProvider, useFormCallbacks} from '../../../studio/contexts/
 import {
   CreateAppendedObject,
   CreatePrependedObject,
-  EditedObject,
   NavigatedToViaArrayList,
   RemovedObject,
 } from '../../../studio/tree-editing/__telemetry__/nestedObjects.telemetry'
@@ -225,25 +224,13 @@ export function ArrayOfObjectsItem(props: MemberItemProps) {
 
   const handleChange = useCallback(
     (event: PatchEvent | PatchArg) => {
-      telemetry.log(EditedObject, {
-        path: pathToString(member.item.path),
-        origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
-      })
-
       onChange(
         PatchEvent.from(event)
           .prepend(setIfMissing(createProtoValue(member.item.schemaType)))
           .prefixAll({_key: member.key}),
       )
     },
-    [
-      enhancedObjectDialogEnabled,
-      onChange,
-      member.item.schemaType,
-      member.item.path,
-      member.key,
-      telemetry,
-    ],
+    [onChange, member.item.schemaType, member.key],
   )
   const handleCollapse = useCallback(() => {
     onSetPathCollapsed(member.item.path, true)

--- a/packages/sanity/src/core/form/studio/tree-editing/__telemetry__/nestedObjects.telemetry.ts
+++ b/packages/sanity/src/core/form/studio/tree-editing/__telemetry__/nestedObjects.telemetry.ts
@@ -58,12 +58,6 @@ export const CreateAppendedObject = defineEvent<NestedDialogOpenedInfo & NestedO
   description: 'User created an appended object in an array list',
 })
 
-export const EditedObject = defineEvent<NestedDialogOpenedInfo & NestedObjectInfoOrigin>({
-  name: 'Edited Object in Array List',
-  version: 1,
-  description: 'User edited a object in an array list',
-})
-
 export const RemovedObject = defineEvent<NestedDialogOpenedInfo & NestedObjectInfoOrigin>({
   name: 'Removed Object in Array List',
   version: 1,


### PR DESCRIPTION
### Description

Remove the "Edited Object in Array List" telemetry event as it's causing a spike of activity for little worth of data

Adding a filter on the telemetry repo as well

### What to review

Anything that I missed?

### Testing

All test should pass

### Notes for release

N/A