### PR TITLE
chore(core): updates PTE annotation styles

### DIFF
--- a/dev/test-studio/schema/standard/portableText/allTheBellsAndWhistles.ts
+++ b/dev/test-studio/schema/standard/portableText/allTheBellsAndWhistles.ts
@@ -1,4 +1,11 @@
-import {BellIcon, ColorWheelIcon, DocumentPdfIcon, ImageIcon, InfoOutlineIcon} from '@sanity/icons'
+import {
+  BellIcon,
+  ColorWheelIcon,
+  DocumentPdfIcon,
+  ImageIcon,
+  InfoOutlineIcon,
+  LinkIcon,
+} from '@sanity/icons'
 import {type Rule} from '@sanity/types'
 import {defineArrayMember, defineField, defineType} from 'sanity'
 
@@ -143,6 +150,23 @@ export const ptAllTheBellsAndWhistlesType = defineType({
               name: 'inlineReference',
               title: 'Inline reference',
               to: [{type: 'book'}],
+            }),
+            defineField({
+              type: 'object',
+              name: 'inlineIcon',
+              icon: LinkIcon,
+              fields: [
+                defineField({
+                  type: 'string',
+                  name: 'iconName',
+                  title: 'Icon',
+                }),
+                defineField({
+                  type: 'string',
+                  name: 'iconColor',
+                  title: 'Icon Color',
+                }),
+              ],
             }),
           ],
         }),

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.styles.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.styles.ts
@@ -23,13 +23,13 @@ export function rootStyle({theme}: {theme: Theme}) {
     padding: 2px;
     box-shadow: inset 0 0 0 1px var(--card-border-color);
     height: calc(1em - 1px);
-    margin-top: 0.0625em;
     cursor: default;
 
     &:not([hidden]) {
       display: inline-flex;
       align-items: center;
-      vertical-align: top;
+      vertical-align: text-bottom;
+      margin-inline: 2px;
     }
 
     &[data-ready-only] {


### PR DESCRIPTION
### Description
Fixes https://github.com/sanity-io/sanity/issues/7331
Updates PTE annotation styles to look better aligned with the text and includes some extra spacing so caret is not under the annotation.
| Before | After |
|--------|--------|
|<img width="700" height="405" alt="Screenshot 2026-01-23 at 12 34 21" src="https://github.com/user-attachments/assets/b813261e-18bc-4531-a8fa-280335c7bc1f" />| <img width="706" height="411" alt="Screenshot 2026-01-23 at 12 33 38" src="https://github.com/user-attachments/assets/0e36cbbe-5b1b-45b2-b5eb-e21e1ddef0f7" />| 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Annotations look good?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Slight touches to portable text annotation styles.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
