### PR TITLE
feat(sanity): collator for all divergences in a subject-upstream pair

### DIFF
--- a/packages/sanity/src/core/divergence/collateDocumentDivergences.test.ts
+++ b/packages/sanity/src/core/divergence/collateDocumentDivergences.test.ts
@@ -1,0 +1,113 @@
+import {type SanityDocument} from '@sanity/types'
+import {describe, expect, it} from 'vitest'
+
+import {
+  type CollatedDocumentDivergencesState,
+  collateDocumentDivergences,
+  peekCollatedDocumentDivergences,
+} from './collateDocumentDivergences'
+
+describe('collateDocumentDivergences', () => {
+  it('collates document divergences when context is written', async () => {
+    const upstreamAtFork: SanityDocument = {
+      _id: 'a',
+      _type: 'article',
+      _rev: 'revA',
+      _createdAt: '2025-10-29T09:00:00Z',
+      _updatedAt: '2025-10-29T09:10:00Z',
+      alpha: 'alpha',
+    }
+
+    const upstreamHead: SanityDocument = {
+      _id: 'a',
+      _type: 'article',
+      _rev: 'revB',
+      _createdAt: '2025-10-29T09:00:00Z',
+      _updatedAt: '2025-10-29T09:10:00Z',
+      alpha: 'beta',
+    }
+
+    const subjectHead: SanityDocument = {
+      _id: 'drafts.a',
+      _type: 'article',
+      _rev: 'revC',
+      _createdAt: '2025-10-29T09:00:00Z',
+      _updatedAt: '2025-10-29T09:10:00Z',
+      alpha: 'alpha',
+    }
+
+    const {context, observable} = collateDocumentDivergences({
+      upstreamId: upstreamHead._id,
+      subjectId: subjectHead._id,
+    })
+
+    const emissions: CollatedDocumentDivergencesState[] = []
+    observable.subscribe((emission) => emissions.push(emission))
+
+    context.next({
+      upstreamAtFork,
+      upstreamHead,
+      subjectHead,
+    })
+
+    await expect.poll(() => emissions.at(-1)?.state).toBe('ready')
+
+    expect(emissions.at(0)?.state).toBe('pending')
+    expect(emissions.at(-1)?.state).toBe('ready')
+  })
+})
+
+describe('peekCollatedDocumentDivergences', () => {
+  it('emits collated divergences once available', async () => {
+    const upstreamAtFork: SanityDocument = {
+      _id: 'b',
+      _type: 'article',
+      _rev: 'revA',
+      _createdAt: '2025-10-29T09:00:00Z',
+      _updatedAt: '2025-10-29T09:10:00Z',
+      alpha: 'alpha',
+    }
+
+    const upstreamHead: SanityDocument = {
+      _id: 'b',
+      _type: 'article',
+      _rev: 'revB',
+      _createdAt: '2025-10-29T09:00:00Z',
+      _updatedAt: '2025-10-29T09:10:00Z',
+      alpha: 'beta',
+    }
+
+    const subjectHead: SanityDocument = {
+      _id: 'drafts.b',
+      _type: 'article',
+      _rev: 'revC',
+      _createdAt: '2025-10-29T09:00:00Z',
+      _updatedAt: '2025-10-29T09:10:00Z',
+      alpha: 'alpha',
+    }
+
+    const {context} = collateDocumentDivergences({
+      upstreamId: upstreamHead._id,
+      subjectId: subjectHead._id,
+    })
+
+    const peek = peekCollatedDocumentDivergences({
+      upstreamId: 'b',
+      subjectId: 'drafts.b',
+    })
+
+    const emissions: CollatedDocumentDivergencesState[] = []
+    peek.subscribe((emission) => emissions.push(emission))
+
+    context.next({
+      upstreamAtFork,
+      upstreamHead,
+      subjectHead,
+    })
+
+    await expect.poll(() => emissions.at(-1)?.state).toBe('ready')
+
+    expect(emissions.at(0)?.state).toBe('pending')
+    expect(emissions.at(-1)?.state).toBe('ready')
+  })
+})

--- a/packages/sanity/src/core/divergence/collateDocumentDivergences.ts
+++ b/packages/sanity/src/core/divergence/collateDocumentDivergences.ts
@@ -1,0 +1,179 @@
+import {isEqual} from 'lodash-es'
+import QuickLRU from 'quick-lru'
+import {
+  debounceTime,
+  distinctUntilChanged,
+  filter,
+  map,
+  mergeMap,
+  type Observable,
+  of,
+  shareReplay,
+  startWith,
+  Subject,
+  switchMap,
+  switchScan,
+  tap,
+  toArray,
+} from 'rxjs'
+
+import {
+  type Divergence,
+  type DivergenceAtPath,
+  type FindDivergencesContext,
+  readDocumentDivergences,
+} from './readDocumentDivergences'
+import {delayTask} from './utils/delayTask'
+
+export interface CollatedDocumentDivergencesState {
+  state: 'pending' | 'ready'
+  divergences: Record<string, Divergence>
+}
+
+interface Instance {
+  observable: Observable<CollatedDocumentDivergencesState>
+  context: Subject<FindDivergencesContext>
+}
+
+interface CollatedDocumentDivergencesContext {
+  upstreamId: string
+  subjectId: string
+}
+
+const DEBOUNCE_DURATION = 1_000
+const CACHE_MAX_SIZE = 10
+
+let cacheWriteChannel: Subject<string>
+let cache: QuickLRU<string, Instance>
+
+/**
+ * @internal
+ */
+export const collateDocumentDivergencesInitialState: CollatedDocumentDivergencesState = {
+  state: 'pending',
+  divergences: {},
+}
+
+/**
+ * Collate all divergences in a single document.
+ *
+ * For each upstream id and subject id pair, the instance is cached globally in a LRU store.
+ * Computation is throttled, and yields to the main thread to minimise blocking of the UI.
+ *
+ * The consumer is responsible for providing the data this computation depends on
+ * (`FindDivergencesContext`). If any of the underlying context changes, recomputation can be
+ * triggered by writing the updated context to the returned `context` subject.
+ *
+ * @internal
+ */
+export function collateDocumentDivergences({
+  upstreamId,
+  subjectId,
+}: CollatedDocumentDivergencesContext): Instance {
+  initialiseCache()
+
+  const cacheKey = getCacheKey({upstreamId, subjectId})
+  const cachedInstance = cache.get(cacheKey)
+
+  if (typeof cachedInstance !== 'undefined') {
+    return cachedInstance
+  }
+
+  const context = new Subject<FindDivergencesContext>()
+  const markName = ['collateDocumentDivergences', cacheKey].join('.')
+
+  const observable: Observable<CollatedDocumentDivergencesState> = context.pipe(
+    debounceTime(DEBOUNCE_DURATION),
+    tap(() => performance.mark(cacheKey)),
+    distinctUntilChanged(isContextEqual),
+    switchScan((state, nextContext) => {
+      return of(nextContext).pipe(
+        delayTask(),
+        tap(() => performance.mark(markName)),
+        switchMap(readDocumentDivergences),
+        toArray(),
+        tap(() =>
+          performance.measure(cacheKey, {
+            start: markName,
+            detail: {
+              devtools: {
+                dataType: 'track-entry',
+                track: 'Find all divergences',
+                trackGroup: 'Aggregate Divergences',
+                color: 'tertiary-dark',
+              },
+            },
+          }),
+        ),
+        map<DivergenceAtPath[], Record<string, Divergence>>(Object.fromEntries),
+        map<Record<string, Divergence>, CollatedDocumentDivergencesState>((divergences) => ({
+          ...state,
+          state: 'ready',
+          divergences,
+        })),
+        startWith<CollatedDocumentDivergencesState>({
+          ...state,
+          state: 'pending',
+        }),
+      )
+    }, collateDocumentDivergencesInitialState),
+    startWith(collateDocumentDivergencesInitialState),
+    shareReplay(1),
+  )
+
+  const instance: Instance = {context, observable}
+
+  cache.set(cacheKey, instance)
+  cacheWriteChannel.next(cacheKey)
+
+  return instance
+}
+
+/**
+ * Subscribe to collated document divergences without initiating computation.
+ *
+ * @internal
+ */
+export function peekCollatedDocumentDivergences({
+  upstreamId,
+  subjectId,
+}: CollatedDocumentDivergencesContext): Observable<CollatedDocumentDivergencesState> {
+  initialiseCache()
+
+  const cacheKey = getCacheKey({upstreamId, subjectId})
+  const instance = cache.get(cacheKey)
+
+  if (typeof instance !== 'undefined') {
+    return instance.observable
+  }
+
+  return cacheWriteChannel.pipe(
+    filter((writtenCacheKey) => writtenCacheKey === cacheKey),
+    map((writtenCacheKey) => cache.get(writtenCacheKey)),
+    filter((cachedInstance) => typeof cachedInstance !== 'undefined'),
+    mergeMap(({observable}) => observable),
+    startWith(collateDocumentDivergencesInitialState),
+    shareReplay(1),
+  )
+}
+
+function isContextEqual(a: FindDivergencesContext, b: FindDivergencesContext): boolean {
+  return (
+    a.upstreamHead._rev === b.upstreamHead._rev &&
+    a.subjectHead._rev === b.subjectHead._rev &&
+    a.upstreamAtFork._rev === b.upstreamAtFork._rev &&
+    isEqual(a.resolutions, b.resolutions)
+  )
+}
+
+function initialiseCache() {
+  cache ??= new QuickLRU({maxSize: CACHE_MAX_SIZE})
+  cacheWriteChannel ??= new Subject()
+}
+
+function getCacheKey({
+  subjectId,
+  upstreamId,
+}: Pick<CollatedDocumentDivergencesContext, 'subjectId' | 'upstreamId'>): string {
+  return [upstreamId, subjectId].join('.')
+}


### PR DESCRIPTION
### Description

This branch adds the `collateDocumentDivergences` function, which can be used to subscribe to all of an upstream-subject pair's divergences in the UI. When the context changes (any of the version snapshots, or the resolutions), the observable debounces and yields to the main thread before recomputing. This is to reduce the impact on the performance of the UI.

When divergences are being recomputed, the previous set remains available, but the state switches from `"ready"` to `"pending"` (stale-while-revalidate). This allows the rendering of divergences to remain stable in the UI while recomputing. The `"pending`" state can be used to reflect this is occurring.

Instances are cached in a LRU store, which is addressable by the upstream-subject id pair.

If parts of the UI need to subscribe to the status of divergences affecting an upstream-subject pair *without themselves initiating computation*, the `peekCollatedDocumentDivergences` function can be used to subscribe to the state of a given upstream-subject pair.

### What to review

The new `collateDocumentDivergences` and `peekCollatedDocumentDivergences` functions.

### Testing

Added unit tests.