### PR TITLE
fix(core): support copy pasting anonymous objects

### DIFF
--- a/dev/test-studio/schema/standard/arrays.tsx
+++ b/dev/test-studio/schema/standard/arrays.tsx
@@ -170,6 +170,36 @@ export default defineType({
       ],
     },
     {
+      name: 'arrayOfDescriptionObjects',
+      description:
+        'This array contains objects with a `description` field, to test copying between unnamed arrays',
+      type: 'array',
+      of: [
+        {
+          title: 'Has description',
+          type: 'object',
+          fields: [{name: 'description', title: 'Description', type: 'string'}],
+        },
+      ],
+    },
+    {
+      name: 'namedAndAnonymousObjects',
+      type: 'array',
+      of: [
+        {
+          title: 'Named object',
+          type: 'object',
+          name: 'namedObject',
+          fields: [{name: 'title', type: 'string'}],
+        },
+        {
+          title: 'Anonymous object',
+          type: 'object',
+          fields: [{name: 'title', type: 'string'}],
+        },
+      ],
+    },
+    {
       name: 'arrayWithNoTitle',
       title: 'Array with no title',
       type: 'array',

--- a/packages/sanity/src/core/studio/copyPaste/__test__/schema/editor.tsx
+++ b/packages/sanity/src/core/studio/copyPaste/__test__/schema/editor.tsx
@@ -109,6 +109,28 @@ export const editorDocument = defineType({
       ],
     }),
     defineField({
+      name: 'arrayWithAnonymousAndNamedObject',
+      title: 'Array with anonymous and named objects',
+      description: 'This array contains objects of type as defined inline',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          title: 'Something',
+          fields: [
+            {name: 'first', type: 'string', title: 'First string'},
+            {name: 'second', type: 'string', title: 'Second string'},
+          ],
+        },
+        {
+          type: 'object',
+          name: 'item2',
+          title: 'Item 2',
+          fields: [{name: 'title', type: 'string', title: 'Title'}],
+        },
+      ],
+    }),
+    defineField({
       type: 'object',
       name: 'color',
       title: 'Color with a long title',

--- a/packages/sanity/src/core/studio/copyPaste/__test__/transferValue.test.ts
+++ b/packages/sanity/src/core/studio/copyPaste/__test__/transferValue.test.ts
@@ -1171,6 +1171,110 @@ describe('transferValue', () => {
       expect(transferValueResult?.errors).toEqual([])
       expect(transferValueResult?.targetValue).toEqual(expectedOutput)
     })
+
+    test('can copy array of anonymous objects (objects without _type)', async () => {
+      // Anonymous objects don't have a _type property - this is the case when
+      // array members are defined inline without a name
+      const sourceValue = [
+        {
+          _key: 'f37ded611b8c',
+          first: 'Hello',
+          second: 'World',
+        },
+      ]
+      const expectedOutput = [
+        {
+          _key: expect.any(String),
+          first: 'Hello',
+          second: 'World',
+        },
+      ]
+      const sourceRootSchemaType = resolveSchemaTypeForPath(schema.get('editor')!, [
+        'arrayWithAnonymousObject',
+      ])!
+      const transferValueResult = await transferValue({
+        sourceRootSchemaType,
+        sourcePath: [],
+        sourceValue,
+        targetDocumentSchemaType: schema.get('editor')!,
+        targetRootSchemaType: resolveSchemaTypeForPath(schema.get('editor')!, [
+          'arrayWithAnonymousObject',
+        ])!,
+        targetPath: [],
+        targetRootValue: {},
+        targetRootPath: [],
+        currentUser,
+      })
+      expect(transferValueResult?.errors).toEqual([])
+      expect(transferValueResult?.targetValue).toEqual(expectedOutput)
+    })
+    test('can copy array of anonymous and named objects mixed (objects without _type)', async () => {
+      // Anonymous objects don't have a _type property - this is the case when
+      // array members are defined inline without a name
+      const sourceValue = [
+        {
+          _key: 'f37ded611b8c',
+          first: 'Hello',
+          second: 'World',
+        },
+      ]
+      const expectedOutput = [
+        {
+          _key: expect.any(String),
+          first: 'Hello',
+          second: 'World',
+        },
+      ]
+      const sourceRootSchemaType = resolveSchemaTypeForPath(schema.get('editor')!, [
+        'arrayWithAnonymousAndNamedObject',
+      ])!
+      const transferValueResult = await transferValue({
+        sourceRootSchemaType,
+        sourcePath: [],
+        sourceValue,
+        targetDocumentSchemaType: schema.get('editor')!,
+        targetRootSchemaType: resolveSchemaTypeForPath(schema.get('editor')!, [
+          'arrayWithAnonymousAndNamedObject',
+        ])!,
+        targetPath: [],
+        targetRootValue: {},
+        targetRootPath: [],
+        currentUser,
+      })
+      expect(transferValueResult?.errors).toEqual([])
+      expect(transferValueResult?.targetValue).toEqual(expectedOutput)
+    })
+    test('filters out empty objects when no properties match between anonymous objects', async () => {
+      // When copying between arrays with different anonymous object structures,
+      // if no properties match, the resulting object would only have _key.
+      // We should filter these out as they are effectively empty.
+      const sourceValue = [
+        {
+          _key: 'f37ded611b8c',
+          title: 'Hello', // 'title' doesn't exist in target schema
+        },
+      ]
+      const sourceRootSchemaType = resolveSchemaTypeForPath(schema.get('editor')!, [
+        // arrayWithAnonymousObject has 'first' and 'second' fields, no 'title' field, so it shouldn't be possible to copy anything
+        'arrayWithAnonymousObject',
+      ])!
+      const transferValueResult = await transferValue({
+        sourceRootSchemaType,
+        sourcePath: [],
+        sourceValue,
+        targetDocumentSchemaType: schema.get('editor')!,
+        targetRootSchemaType: resolveSchemaTypeForPath(schema.get('editor')!, [
+          'arrayWithAnonymousObject',
+        ])!,
+        targetPath: [],
+        targetRootValue: {},
+        targetRootPath: [],
+        currentUser,
+      })
+      expect(transferValueResult?.errors).toEqual([])
+      // Empty objects (with only _key) should be filtered out, resulting in empty array
+      expect(transferValueResult?.targetValue).toEqual([])
+    })
   })
 
   describe('numbers', () => {

--- a/packages/sanity/src/core/studio/copyPaste/utils.ts
+++ b/packages/sanity/src/core/studio/copyPaste/utils.ts
@@ -161,6 +161,13 @@ export function transformValueToText(value: unknown): string {
 
 export function isEmptyValue(value: unknown): boolean {
   if (value === null || value === undefined) return true
+  if (typeof value === 'object') {
+    const keys = Object.keys(value)
+    // An object is effectively empty if it only has `_key` (no content at all)
+    if (keys.length === 1 && keys[0] === '_key') {
+      return true
+    }
+  }
   if (Array.isArray(value) && value.length === 0) return true
   return false
 }


### PR DESCRIPTION
### Description

Closes #7607

Fixes copy-paste for anonymous objects in arrays (objects defined inline without a `name` property). Previously, these objects would fail to paste because the system couldn't match the type.

**Changes:**
- Use `resolveTypeName` to resolve types for anonymous objects (returns `'object'` when no `_type` exists)
- Added `findMatchingArrayMemberType` helper to match array items by resolved type name
- Only set `_type` on pasted objects if the source had one (preserves anonymous objects)
- Extended `isEmptyValue` to filter out objects with only `_key` (no actual content)


https://github.com/user-attachments/assets/5f5e796c-480f-4f48-9e6f-f1af01c8dcd9


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
- `findMatchingArrayMemberType` function in `transferValue.ts`
- Conditional `_type` assignment in `collateObjectValue`
- Extended `isEmptyValue` check in `utils.ts`
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Added 3 unit tests:
- `can copy array of anonymous objects (objects without _type)`
- `can copy array of anonymous and named objects mixed`
- `filters out empty objects when no properties match between anonymous objects`
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Copy-paste now works correctly for arrays with anonymous objects (inline object definitions without a `name`). Previously these would fail with a type mismatch error.
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
