### PR TITLE
feat(sanity): add `time` param support to `getDocumentAtRevision`

### DIFF
--- a/packages/sanity/src/core/store/events/getDocumentAtRevision.ts
+++ b/packages/sanity/src/core/store/events/getDocumentAtRevision.ts
@@ -7,38 +7,74 @@ import {type EventsStoreRevision} from './types'
 
 const documentRevisionCache: Record<string, Observable<EventsStoreRevision>> = Object.create(null)
 
-export function getDocumentAtRevision({
+/**
+ * - When fetching by `revisionId`, `revisionId` will always be present in the result.
+ * - When fetching by `time`, `revisionId` will only be present after fetching.
+ */
+type Result<InputContext> = InputContext extends {revisionId: string}
+  ? EventsStoreRevision
+  : Omit<EventsStoreRevision, 'revisionId'> & Partial<Pick<EventsStoreRevision, 'revisionId'>>
+
+type Context = {client: SanityClient; documentId: string} & (
+  | {
+      /**
+       * Fetch the document revision by revision id.
+       */
+      revisionId: string
+      time?: never
+    }
+  | {
+      revisionId?: never
+      /**
+       * Fetch the document revision by time, formatted as a Content Lake compatible
+       * date-time string.
+       */
+      time: string
+    }
+)
+
+export function getDocumentAtRevision<InputContext extends Context>({
   client,
   documentId,
   revisionId,
-}: {
-  client: SanityClient
-  documentId: string
-  revisionId: string
-}): Observable<EventsStoreRevision | null> {
+  time,
+}: InputContext): Observable<Result<InputContext> | null> {
   if (revisionId === HISTORY_CLEARED_EVENT_ID) {
     return of({document: null, loading: false, revisionId: revisionId})
   }
-  const cacheKey = `${documentId}@${revisionId}`
+  const cacheKey = `${documentId}@${revisionId ? ['revisionId', revisionId].join('.') : ['time', time].join('.')}`
   const dataset = client.config().dataset
   if (!documentRevisionCache[cacheKey]) {
+    const searchParams = new URLSearchParams(
+      typeof revisionId === 'string' ? {revision: revisionId} : {time},
+    )
     documentRevisionCache[cacheKey] = client.observable
       .request<{documents: SanityDocument[]}>({
-        url: `/data/history/${dataset}/documents/${documentId}?revision=${revisionId}`,
+        url: `/data/history/${dataset}/documents/${documentId}?${searchParams}`,
         tag: 'get-document-revision',
       })
       .pipe(
         map((response) => {
           const document = response.documents[0]
-          return {document: document, loading: false, revisionId: revisionId}
+          return {document: document, loading: false, revisionId: document._rev}
         }),
 
         catchError((error: Error) => {
           // TODO: Handle error
           console.error('Error fetching document at revision', error)
-          return [{document: null, loading: false, revisionId: revisionId}]
+          return [
+            {
+              document: null,
+              loading: false,
+              revisionId: revisionId,
+            } satisfies Result<Context> as any,
+          ]
         }),
-        startWith({document: null, loading: true, revisionId: revisionId}),
+        startWith({
+          document: null,
+          loading: true,
+          revisionId: revisionId,
+        } satisfies Result<Context> as any),
         shareReplay(1),
       )
   }


### PR DESCRIPTION
### Description

This branch adds support for fetching a document revision at a given time, as supported by [the Content Lake History API](https://www.sanity.io/docs/http-reference/history#getrevision). It updates the cache key format to ensure there's no overlap in the instance a document has a date-time-like revision id.

### What to review

Changes to `getDocumentAtRevision`.

### Testing

This function isn't directly tested, but other tests pass that rely on it working correctly.