### PR TITLE
fix: safari was requiring two clicks to be done on an array item before dialog would open

### DIFF
--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
@@ -268,7 +268,7 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
         tabIndex={0}
         disabled={resolvingInitialValue}
         // Use mousedown instead of click to trigger open before focus events cause re-renders.
-        // This fixes a Chrome-specific issue where the array container receives focus first,
+        // This fixes a Safari-specific issue where the array container receives focus first,
         // triggering a state update that causes a re-render before the click event completes.
         onMouseDown={onOpen}
         onClick={onOpen}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
@@ -254,7 +254,7 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
         radius={1}
         disabled={resolvingInitialValue}
         // Use mousedown instead of click to trigger open before focus events cause re-renders.
-        // This fixes a Chrome-specific issue where the array container receives focus first,
+        // This fixes a Safari-specific issue where the array container receives focus first,
         // triggering a state update that causes a re-render before the click event completes.
         onMouseDown={onOpen}
         onClick={onOpen}


### PR DESCRIPTION
### Description

Safari was requiring two clicks to be done on an array item before dialog would open.

Before:
(safari) requires two clicks on the item object to open

https://github.com/user-attachments/assets/cadc03e6-87a1-48af-9220-b7b6ec3d7905

(chromium) working as normal

https://github.com/user-attachments/assets/29fd0abf-760d-4f44-8ddd-134bcd0da3c7

After: 
(safari) working as normal

https://github.com/user-attachments/assets/b162e514-06a4-47ab-9325-455670b0eb4e

(chromium) working as normal

https://github.com/user-attachments/assets/59ba9747-de1f-4cea-83db-a9d8c7a2ec83

### What to review

Does everything look as it should?
Trying it out manually is the best approach

> [!Note]
> This is a bit of an odd one, 
> Added onMouseDown to the items for opening array items in both PreviewItem.tsx (list layout) and GridItem.tsx (grid layout). onMouseDown fires synchronously before any focus events, so the correct path (with the item _key) is set before Chrome's focus behavior can interfere.

### Testing

If you go to debug objects (or search for realistic names) you can find a document that has deeply nested objects.
Clicking the item on safari should open and the url should be correct and update correct as you go deeply and when you paste it to other pages

Tried to add e2e tests for this but ended up realising they don't work too well so e2e doesn't feel like the right approach but trying to add tests for the actual paneProvider and useDocumentForm feels more complex than this scope.

Existing tests should pass

### Notes for release

Fixes issue on safari where an object array item wasn't opening on first click