### PR TITLE
test: fixing failing autoupdating mock

### DIFF
--- a/e2e/tests/default-layout/versionStatus.spec.ts
+++ b/e2e/tests/default-layout/versionStatus.spec.ts
@@ -18,12 +18,13 @@ test.describe('auto-updating studio behavior', () => {
     test.slow()
 
     // Set up route interception BEFORE navigating so all requests are caught
-    await page.route('https://sanity-cdn.**/v1/modules/sanity/default/**', (route) => {
+    await page.route('https://sanity-cdn.**/v1/modules/sanity/latest/**', (route) => {
       return route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
           packageVersion: '4.2.0',
+          latest: '4.2.0',
         }),
       })
     })
@@ -53,5 +54,9 @@ test.describe('auto-updating studio behavior', () => {
 
     // Wait for menu to be visible before checking for the update item
     await expect(page.getByTestId('menu-item-update-studio-now')).toBeVisible({timeout: 10000})
+
+    // Verify the mock version is actually being displayed in the UI
+    // This proves the mock is working and not falling back to real API
+    await expect(page.getByTestId('menu-item-update-studio-now')).toContainText('4.2.0')
   })
 })


### PR DESCRIPTION
### Description
In moving the `fetchLatestVersions` to use a new `latest` response key, this broke this E2E test (although, rather weirdly it didn't break on the PR E2E..). 

On investigating more it actually seems like this mock was not being used at all, since auto-updating studios would typically fallback to using the `latest` channel, not default. I hypothesis this was still passing since we were giving back an actual response that included a `packageVersion` in the 4.x range. But now that we've move to using the `latest` field, which always returns the very highest available semver, since the mock wasn't intercepting, this was returning `5.x` (because we are currently on v5) and so the remainder of the test was failing.

The changes here:
1. update the mock so that it properly intercept
2. Verify that the interception is happening as expected by asserting that the correct latest version is being displayed
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
