### PR TITLE
fix: discard dialog show the correct document preview

### DIFF
--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -22,8 +22,9 @@ export function DiscardVersionDialog(props: {
   documentId: string
   documentType: string
   fromPerspective: string | TargetPerspective
+  isGoingToUnpublish: boolean
 }): React.JSX.Element {
-  const {onClose, documentId, documentType, fromPerspective} = props
+  const {onClose, documentId, documentType, fromPerspective, isGoingToUnpublish} = props
   const {t} = useTranslation(releasesLocaleNamespace)
   const {t: coreT} = useTranslation()
   const {discardChanges} = useDocumentOperation(getPublishedId(documentId), documentType)
@@ -99,9 +100,9 @@ export function DiscardVersionDialog(props: {
       <Stack space={3} paddingX={3} marginBottom={2}>
         {schemaType ? (
           <Preview
-            value={{_id: documentId}}
+            value={{_id: isGoingToUnpublish ? getPublishedId(documentId) : documentId}}
             schemaType={schemaType}
-            perspectiveStack={[currentRelease]}
+            perspectiveStack={isGoingToUnpublish ? [] : [currentRelease]}
           />
         ) : (
           <LoadingBlock />

--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -268,6 +268,7 @@ export const VersionChip = memo(function VersionChip(props: {
           documentId={isVersion ? getVersionId(documentId, bundleId) : documentId}
           fromPerspective={text}
           documentType={documentType}
+          isGoingToUnpublish={isGoingToUnpublish}
         />
       )}
 

--- a/packages/sanity/src/core/releases/plugin/documentActions/DiscardVersionAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/DiscardVersionAction.tsx
@@ -12,6 +12,7 @@ import {usePerspective} from '../../../perspective/usePerspective'
 import {useDocumentPairPermissions} from '../../../store/_legacy/grants/documentPairPermissions'
 import {useCurrentUser} from '../../../store/user/hooks'
 import {DiscardVersionDialog} from '../../components/dialog/DiscardVersionDialog'
+import {isGoingToUnpublish} from '../../util/isGoingToUnpublish'
 
 // React Compiler needs functions that are hooks to have the `use` prefix, pascal case are treated as a component, these are hooks even though they're confusingly named `DocumentActionComponent`
 /** @internal */
@@ -22,6 +23,7 @@ export const useDiscardVersionAction: DocumentActionComponent = (
   const currentUser = useCurrentUser()
   const {t} = useTranslation()
   const {selectedPerspective} = usePerspective()
+  const willUnpublish = version ? isGoingToUnpublish(version) : false
 
   const [permissions, isPermissionsLoading] = useDocumentPairPermissions({
     id,
@@ -55,6 +57,7 @@ export const useDiscardVersionAction: DocumentActionComponent = (
       type: 'custom',
       component: (
         <DiscardVersionDialog
+          isGoingToUnpublish={willUnpublish}
           documentId={version._id}
           documentType={type}
           onClose={() => setDialogOpen(false)}

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -110,6 +110,7 @@ const DocumentActionsInner = memo(
         </Card>
         {showDiscardDialog && (
           <DiscardVersionDialog
+            isGoingToUnpublish={isGoingToUnpublish(document.document)}
             onClose={() => setShowDiscardDialog(false)}
             documentId={document.document._id}
             documentType={document.document._type}


### PR DESCRIPTION
### Description

There was an issue where the discarding an unpublishing version was showing the wrong preview in the confirm dialog

before
<img width="342" height="544" alt="image" src="https://github.com/user-attachments/assets/e634ec3f-df39-4ad4-bdb9-57643d560f80" />

after
<img width="342" height="298" alt="image" src="https://github.com/user-attachments/assets/91b810fe-ea5c-4247-82bc-d1279e61e40d" />

### What to review

This matches what already exists in the preview for the documents in the document table for the releases details (in the ReleaseDocumentPreview.ts)

### Testing

Existing tests should suffice.
You can manually check by going to a release with an unpublished doc (such as Reverting "Rita Undecided Test - don't touch please!) and checking yourself!
However, setting any document to unpublish and trying it on the version chip or on the menu document from within the release detail should show that it works

### Notes for release

Fixes issue where the confirm dialog before discarding a version that was going to be unpublished was showing the wrong preview
