### PR TITLE
feat(release-notes): import images from release notes section

### DIFF
--- a/packages/@repo/release-notes/package.json
+++ b/packages/@repo/release-notes/package.json
@@ -32,11 +32,11 @@
     "@sanity/client": "catalog:",
     "@sanity/id-utils": "^1.0.0",
     "@sanity/mutate": "^0.16.1",
-    "@sanity/types": "workspace:^",
     "conventional-commits-parser": "^6.2.1",
     "date-fns": "^4.1.0",
     "description-to-co-authors": "^0.3.0",
     "p-map": "^7.0.3",
+    "turndown": "^7.2.2",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
@@ -45,6 +45,7 @@
     "@repo/test-config": "workspace:*",
     "@repo/tsconfig": "workspace:*",
     "@repo/utils": "workspace:*",
+    "@types/turndown": "^5.0.6",
     "@types/yargs": "^17.0.33",
     "vitest": "catalog:"
   },

--- a/packages/@repo/release-notes/src/utils/__test__/__fixtures__/pr-with-images.md
+++ b/packages/@repo/release-notes/src/utils/__test__/__fixtures__/pr-with-images.md
@@ -1,0 +1,19 @@
+### Description
+
+Test
+
+### Notes for release
+
+In markdown’s gentle, ticking time,
+I shape my thoughts in simple rhyme—
+With hashes bold and asterisks bright,
+I carve out headings in the night.
+
+![](https://github.com/user-attachments/assets/ba950690-8b08-4b56-b6e0-efc1fb348251)[pr-with-images.md](pr-with-images.md)
+
+<img width="559" height="376" alt="Screenshot 2026-01-28 at 12 55 05" src="https://github.com/user-attachments/assets/d9940c9c-a14e-46ab-9145-ec87a78d0d95" />
+
+Some gifs:
+![filterReleaseDocumentsSimplePR](https://github.com/user-attachments/assets/a1670ec5-b5fa-488d-9e3a-4ec288805784)
+
+<img width="398" height="256" alt="Image" src="https://github.com/user-attachments/assets/a1670ec5-b5fa-488d-9e3a-4ec288805784" />

--- a/packages/@repo/release-notes/src/utils/__test__/extractReleaseNotes.test.ts
+++ b/packages/@repo/release-notes/src/utils/__test__/extractReleaseNotes.test.ts
@@ -1,21 +1,11 @@
-import {readFile} from 'node:fs/promises'
-
-import {markdownToPortableText, portableTextToMarkdown} from '@portabletext/markdown'
+import {portableTextToMarkdown} from '@portabletext/markdown'
 import {describe, expect, it} from 'vitest'
 
 import {extractReleaseNotes} from '../extractReleaseNotes'
-
-function readFixture(name: string) {
-  return readFile(new URL(`./__fixtures__/${name}`, import.meta.url), 'utf8')
-}
+import {markdownToPortableText} from '../portabletext-markdown/markdownToPortableText'
+import {keyGenerator, readFixture} from './helpers'
 
 describe('extractReleaseNotesFromPRDescription', () => {
-  it('extracts release notes from PR description', async () => {
-    const notes = extractReleaseNotes(markdownToPortableText(await readFixture('pr-1.md')))
-    expect(portableTextToMarkdown(notes)).toEqual(
-      `Schema errors screen now contains a button to copy schema type errors as Markdown.`,
-    )
-  })
   it('extracts release notes when there is just a single release notes header', () => {
     const notes = extractReleaseNotes(
       markdownToPortableText(`### Notes for release
@@ -29,9 +19,115 @@ These are the release notes
     const notes = extractReleaseNotes(markdownToPortableText(await readFixture('template.md')))
     expect(notes).toEqual([])
   })
+  it('extracts images and html ', async () => {
+    const notes = extractReleaseNotes(
+      markdownToPortableText(await readFixture('pr-with-images.md'), {
+        keyGenerator: keyGenerator(),
+      }),
+    )
+    expect(notes).toMatchInlineSnapshot(`
+      [
+        {
+          "_key": "key-6",
+          "_type": "block",
+          "children": [
+            {
+              "_key": "key-7",
+              "_type": "span",
+              "marks": [],
+              "text": "In markdown’s gentle, ticking time,
+      I shape my thoughts in simple rhyme—
+      With hashes bold and asterisks bright,
+      I carve out headings in the night.",
+            },
+          ],
+          "markDefs": [],
+          "style": "normal",
+        },
+        {
+          "_key": "key-8",
+          "_type": "block",
+          "children": [
+            {
+              "_key": "key-9",
+              "_type": "image",
+              "alt": "",
+              "src": "https://github.com/user-attachments/assets/ba950690-8b08-4b56-b6e0-efc1fb348251",
+            },
+            {
+              "_key": "key-11",
+              "_type": "span",
+              "marks": [
+                "key-10",
+              ],
+              "text": "pr-with-images.md",
+            },
+          ],
+          "markDefs": [
+            {
+              "_key": "key-10",
+              "_type": "link",
+              "href": "pr-with-images.md",
+            },
+          ],
+          "style": "normal",
+        },
+        {
+          "_key": "key-18",
+          "_type": "image",
+          "alt": "Screenshot 2026-01-28 at 12 55 05",
+          "src": "https://github.com/user-attachments/assets/d9940c9c-a14e-46ab-9145-ec87a78d0d95",
+        },
+        {
+          "_key": "key-13",
+          "_type": "block",
+          "children": [
+            {
+              "_key": "key-14",
+              "_type": "span",
+              "marks": [],
+              "text": "Some gifs:
+      ",
+            },
+            {
+              "_key": "key-15",
+              "_type": "image",
+              "alt": "filterReleaseDocumentsSimplePR",
+              "src": "https://github.com/user-attachments/assets/a1670ec5-b5fa-488d-9e3a-4ec288805784",
+            },
+          ],
+          "markDefs": [],
+          "style": "normal",
+        },
+        {
+          "_key": "key-20",
+          "_type": "image",
+          "alt": "Image",
+          "src": "https://github.com/user-attachments/assets/a1670ec5-b5fa-488d-9e3a-4ec288805784",
+        },
+      ]
+    `)
+  })
+  it('extracts code examples', () => {
+    const notes = extractReleaseNotes(
+      markdownToPortableText(`### Notes for release
+\`\`\`js
+console.log('code!')
+\`\`\`
+`),
+    )
+    expect(notes).toEqual([
+      expect.objectContaining({
+        _key: expect.any(String),
+        _type: 'code',
+        language: 'js',
+        code: "console.log('code!')",
+      }),
+    ])
+  })
   it.each(['n/a', 'N/A', 'n/a – internal only', '\n n/a'])(
     'ignores if text starts with %s ',
-    async (a) => {
+    (a) => {
       const notes = extractReleaseNotes(
         markdownToPortableText(`### Notes for release
 ${a}

--- a/packages/@repo/release-notes/src/utils/__test__/helpers.ts
+++ b/packages/@repo/release-notes/src/utils/__test__/helpers.ts
@@ -1,0 +1,13 @@
+import {readFile} from 'node:fs/promises'
+
+export function readFixture(name: string) {
+  return readFile(new URL(`./__fixtures__/${name}`, import.meta.url), 'utf8')
+}
+
+export function keyGenerator() {
+  let currentKey = 0
+  return () => {
+    // deterministic keygenerator for tests
+    return `key-${currentKey++}`
+  }
+}

--- a/packages/@repo/release-notes/src/utils/__test__/uploadImages.test.ts
+++ b/packages/@repo/release-notes/src/utils/__test__/uploadImages.test.ts
@@ -1,0 +1,142 @@
+import {type SanityImageAssetDocument} from '@sanity/client'
+import {describe, expect, it, vi} from 'vitest'
+
+import {extractReleaseNotes} from '../extractReleaseNotes'
+import {markdownToPortableText} from '../portabletext-markdown/markdownToPortableText'
+import {uploadImages} from '../uploadImages'
+import {keyGenerator, readFixture} from './helpers'
+
+const assetDocument = ({id}: {id: string}): SanityImageAssetDocument => ({
+  _id: id,
+  _createdAt: '',
+  _originalId: '',
+  _rev: '',
+  _updatedAt: '',
+  extension: '',
+  metadata: {
+    _type: 'sanity.imageMetadata',
+    dimensions: {_type: 'sanity.imageDimensions', aspectRatio: 0, height: 0, width: 0},
+    hasAlpha: false,
+    isOpaque: false,
+  },
+  mimeType: '',
+  originalFilename: '',
+  path: '',
+  sha1hash: '',
+  size: 0,
+  uploadId: '',
+  url: '',
+  _type: 'sanity.imageAsset',
+  assetId: 'mocked_asset_id',
+})
+
+describe('uploadImages()', () => {
+  it('uploads images from markdown', async () => {
+    const notes = extractReleaseNotes(
+      markdownToPortableText(await readFixture('pr-with-images.md'), {
+        keyGenerator: keyGenerator(),
+      }),
+    )
+
+    const imageNumber = 0
+    const mockClient = {
+      assets: {
+        upload: vi.fn(async () => {
+          return assetDocument({id: `mocked_image_id_${imageNumber}`})
+        }),
+      },
+    }
+    const notesWithAssets = await uploadImages(mockClient, notes)
+
+    expect(notesWithAssets).toMatchInlineSnapshot(`
+      [
+        {
+          "_key": "key-6",
+          "_type": "block",
+          "children": [
+            {
+              "_key": "key-7",
+              "_type": "span",
+              "marks": [],
+              "text": "In markdown’s gentle, ticking time,
+      I shape my thoughts in simple rhyme—
+      With hashes bold and asterisks bright,
+      I carve out headings in the night.",
+            },
+          ],
+          "markDefs": [],
+          "style": "normal",
+        },
+        {
+          "_key": "key-8",
+          "_type": "block",
+          "children": [
+            {
+              "_key": "key-9",
+              "_type": "image",
+              "asset": {
+                "_ref": "mocked_image_id_0",
+                "_type": "reference",
+              },
+            },
+            {
+              "_key": "key-11",
+              "_type": "span",
+              "marks": [
+                "key-10",
+              ],
+              "text": "pr-with-images.md",
+            },
+          ],
+          "markDefs": [
+            {
+              "_key": "key-10",
+              "_type": "link",
+              "href": "pr-with-images.md",
+            },
+          ],
+          "style": "normal",
+        },
+        {
+          "_key": "key-18",
+          "_type": "image",
+          "asset": {
+            "_ref": "mocked_image_id_0",
+            "_type": "reference",
+          },
+        },
+        {
+          "_key": "key-13",
+          "_type": "block",
+          "children": [
+            {
+              "_key": "key-14",
+              "_type": "span",
+              "marks": [],
+              "text": "Some gifs:
+      ",
+            },
+            {
+              "_key": "key-15",
+              "_type": "image",
+              "asset": {
+                "_ref": "mocked_image_id_0",
+                "_type": "reference",
+              },
+            },
+          ],
+          "markDefs": [],
+          "style": "normal",
+        },
+        {
+          "_key": "key-20",
+          "_type": "image",
+          "asset": {
+            "_ref": "mocked_image_id_0",
+            "_type": "reference",
+          },
+        },
+      ]
+    `)
+  })
+})

--- a/packages/@repo/release-notes/src/utils/portabletext-markdown/markdownToPortableText.ts
+++ b/packages/@repo/release-notes/src/utils/portabletext-markdown/markdownToPortableText.ts
@@ -1,0 +1,34 @@
+import {markdownToPortableText as originalMarkdownToPortableText} from '@portabletext/markdown'
+import TurndownService from 'turndown'
+
+import {type PortableTextHtml, type PortableTextMarkdownBlock} from './types'
+
+type Options = {
+  keyGenerator?: () => string
+}
+export type NormalizedMarkdownBlock = Exclude<PortableTextMarkdownBlock, PortableTextHtml>
+
+const turndownService = new TurndownService()
+
+// small shim to narrow typing of markdownToPortableText to what it actually returns
+export function markdownToPortableText(
+  markdown: string,
+  // note: original markdownToPortableText takes more options, but we don't use them here
+  options?: Options,
+) {
+  return normalize(
+    originalMarkdownToPortableText(markdown, options) as PortableTextMarkdownBlock[],
+    options,
+  )
+}
+// Normalizes markdown to portable text by converting html blocks to markdown
+export function normalize(
+  blocks: PortableTextMarkdownBlock[],
+  options?: Options,
+): NormalizedMarkdownBlock[] {
+  return blocks.flatMap((block) =>
+    block._type === 'html'
+      ? markdownToPortableText(turndownService.turndown(block.html), options)
+      : block,
+  )
+}

--- a/packages/@repo/release-notes/src/utils/portabletext-markdown/types.ts
+++ b/packages/@repo/release-notes/src/utils/portabletext-markdown/types.ts
@@ -1,0 +1,66 @@
+type PortableTextStyle = 'normal' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'blockquote'
+type PortableTextListItem = 'number' | 'bullet'
+type PortableTextDecorator = 'strong' | 'em' | 'code' | 'strike-through'
+
+type PortableTextSpan = {
+  _type: 'span'
+  _key: string
+  text: string
+  marks?: PortableTextDecorator[]
+}
+
+export type PortableTextLink = {
+  _type: 'link'
+  _key: string
+  href: string
+  title?: string
+}
+
+export type PortableTextBlock = {
+  _type: 'block'
+  _key: string
+  style?: PortableTextStyle
+  listItem?: PortableTextListItem
+  children: (PortableTextSpan | PortableTextImage | PortableTextCode | PortableTextLink)[]
+}
+
+export type PortableTextCode = {
+  _type: 'code'
+  _key: string
+  language?: string
+  code: string
+}
+
+export type PortableTextImage = {
+  _type: 'image'
+  _key: string
+  src: string
+  alt?: string
+  title?: string
+}
+
+export type PortableTextHorizontalRule = {
+  _type: 'horizontal-rule'
+  _key: string
+}
+
+export type PortableTextHtml = {
+  _type: 'html'
+  _key: string
+  html: string
+}
+
+export type PortableTextTable = {
+  _type: 'table'
+  _key: string
+  headerRows?: number
+  rows: unknown[]
+}
+
+export type PortableTextMarkdownBlock =
+  | PortableTextBlock
+  | PortableTextCode
+  | PortableTextImage
+  | PortableTextHorizontalRule
+  | PortableTextHtml
+  | PortableTextTable

--- a/packages/@repo/release-notes/src/utils/uploadImages.ts
+++ b/packages/@repo/release-notes/src/utils/uploadImages.ts
@@ -1,0 +1,79 @@
+import {Readable} from 'node:stream'
+
+import {
+  type SanityClient,
+  type SanityImageAssetDocument,
+  type UploadClientConfig,
+} from '@sanity/client'
+import pMap from 'p-map'
+
+import {type PortableTextBlock, type PortableTextMarkdownBlock} from './portabletext-markdown/types'
+
+export type ClientLike = {assets: {upload: SanityClient['assets']['upload']}}
+
+export async function uploadImages(client: ClientLike, blocks: PortableTextMarkdownBlock[]) {
+  return pMap(blocks, async (block) => {
+    if (block._type === 'block') {
+      return uploadInlineImages(client, block)
+    }
+    if (block._type !== 'image') {
+      return block
+    }
+    const asset = await uploadImage(client, block.src, {
+      preserveFilename: false,
+      tag: 'release-note-image',
+      source: {
+        id: block._key,
+        name: 'studio-release-automation',
+        url: block.src,
+      },
+    })
+    return {
+      _type: 'image',
+      alt: block.alt,
+      asset: {_ref: asset._id, _type: 'reference'},
+      _key: block._key,
+    }
+  })
+}
+
+async function uploadInlineImages(client: ClientLike, block: PortableTextBlock) {
+  const children = await pMap(block.children, async (span) => {
+    if (span._type === 'image') {
+      const asset = await uploadImage(client, span.src, {
+        preserveFilename: false,
+        tag: 'release-note-image',
+        source: {
+          id: span._key,
+          name: 'studio-release-automation',
+          url: span.src,
+        },
+      })
+      return {
+        _type: 'image' as const,
+        asset: {_ref: asset._id, _type: 'reference'},
+        _key: span._key,
+      }
+    }
+    return span
+  })
+  return {
+    ...block,
+    children,
+  }
+}
+
+export async function uploadImage(
+  client: ClientLike,
+  url: string,
+  metadata: UploadClientConfig,
+): Promise<SanityImageAssetDocument> {
+  const {body, status} = await fetch(url)
+  if (status < 200 || status > 299) {
+    throw new Error(`HTTP Error ${status} while fetching image from: ${url}`)
+  }
+  if (!body) {
+    throw new Error(`No response while fetching image from: ${url}`)
+  }
+  return client.assets.upload('image', Readable.fromWeb(body), metadata)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -918,9 +918,6 @@ importers:
       '@sanity/mutate':
         specifier: ^0.16.1
         version: 0.16.1(debug@4.4.3)(xstate@5.25.1)
-      '@sanity/types':
-        specifier: ^5.0.0
-        version: link:../../@sanity/types
       conventional-commits-parser:
         specifier: ^6.2.1
         version: 6.2.1
@@ -933,6 +930,9 @@ importers:
       p-map:
         specifier: ^7.0.3
         version: 7.0.4
+      turndown:
+        specifier: ^7.2.2
+        version: 7.2.2
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -952,6 +952,9 @@ importers:
       '@repo/utils':
         specifier: workspace:*
         version: link:../utils
+      '@types/turndown':
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/yargs':
         specifier: ^17.0.33
         version: 17.0.35
@@ -4251,6 +4254,9 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
+  '@mixmark-io/domino@2.2.0':
+    resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
+
   '@mswjs/interceptors@0.39.8':
     resolution: {integrity: sha512-2+BzZbjRO7Ct61k8fMNHEtoKjeWI9pIlHFTqBwZ5icHpqszIgEZbjb1MW5Z0+bITTCTl3gk4PDBxs9tA/csXvA==}
     engines: {node: '>=18'}
@@ -6017,6 +6023,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/turndown@5.0.6':
+    resolution: {integrity: sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -12396,6 +12405,9 @@ packages:
     resolution: {integrity: sha512-7Imdmg37joOloTnj+DPrab9hIaQcDdJ5RwSzcauo/wMOSAgO+A/I/8b3hsGGs6PWQz70m/jkPgdqWsfNKtwwDQ==}
     hasBin: true
 
+  turndown@7.2.2:
+    resolution: {integrity: sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -15184,6 +15196,8 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
+  '@mixmark-io/domino@2.2.0': {}
+
   '@mswjs/interceptors@0.39.8':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -17454,6 +17468,8 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/turndown@5.0.6': {}
 
   '@types/unist@2.0.11': {}
 
@@ -24690,6 +24706,10 @@ snapshots:
       turbo-linux-arm64: 2.7.5
       turbo-windows-64: 2.7.5
       turbo-windows-arm64: 2.7.5
+
+  turndown@7.2.2:
+    dependencies:
+      '@mixmark-io/domino': 2.2.0
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
### Description
This makes our release automation upload images from the "Notes from release" section on PRs.

### What to review
Code makes sense? Markdown is quite the leaky abstraction, so I'm using [turndown](https://npmx.dev/turndown) to convert from markdown to portable text in two separate passes:
1. Convert PR description to markdown, this will return portable text with `{_type: 'html'}`-blocks/spans
2. Convert any of these `html` blocks/spans to markdown using turndown and then pass it through markdownToPortableText again

This approach seems to work quite well.

### Testing
- Includes basic unit tests

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
