### PR TITLE
chore(core): update invalid fields styles

### DIFF
--- a/dev/test-studio/schema/debug/validation.tsx
+++ b/dev/test-studio/schema/debug/validation.tsx
@@ -297,7 +297,8 @@ export default defineType({
       description: 'Reference to a book with custom rule that ensures referenced book has a cover',
       type: 'reference',
       to: [{type: 'book'}],
-      validation: (Rule) =>
+      validation: (Rule) => [
+        Rule.required().error('Book is required'),
         Rule.custom(
           (value) =>
             new Promise((resolve) => {
@@ -312,6 +313,7 @@ export default defineType({
               // })
             }),
         ),
+      ],
     },
     {
       name: 'titleCase',
@@ -374,6 +376,7 @@ export default defineType({
         layout: 'radio',
         list: ['one', 'two', 'three'],
       },
+      validation: (Rule) => Rule.required().error('Radio is required'),
     },
     {
       name: 'readonlyField',

--- a/packages/sanity/src/core/components/inputs/DateInputs/DateTimeInput.tsx
+++ b/packages/sanity/src/core/components/inputs/DateInputs/DateTimeInput.tsx
@@ -77,6 +77,7 @@ export const DateTimeInput = forwardRef(function DateTimeInput(
     readOnly,
     constrainSize = true,
     monthPickerVariant,
+    customValidity,
     padding,
     disableInput,
     isPastDisabled,
@@ -170,6 +171,7 @@ export const DateTimeInput = forwardRef(function DateTimeInput(
         readOnly={disableInput || readOnly}
         value={inputValue}
         onChange={onInputChange}
+        customValidity={customValidity}
         suffix={
           isPickerOpen ? (
             // Note: we're conditionally inserting the popover here due to an

--- a/packages/sanity/src/core/form/inputs/BooleanInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/BooleanInput.test.tsx
@@ -1,4 +1,4 @@
-import {defineField} from '@sanity/types'
+import {defineField, type FormNodeValidation} from '@sanity/types'
 import {screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
 import {describe, expect, it} from 'vitest'
@@ -223,5 +223,31 @@ describe('readOnly property', () => {
     // Keyboard event
     await userEvent.tab()
     expect(input).not.toHaveFocus()
+  })
+})
+
+describe('Validation', () => {
+  it('applies critical tone when there are validation errors', async () => {
+    const errorValidation: FormNodeValidation[] = [
+      {level: 'error', message: 'This field is required', path: []},
+    ]
+
+    const {result} = await renderBooleanInput({
+      fieldDefinition: defs.booleanTest,
+      render: (inputProps) => <BooleanInput {...inputProps} validation={errorValidation} />,
+    })
+
+    const card = result.container.querySelector('[data-testid="boolean-input"]')
+    expect(card).toHaveAttribute('data-tone', 'critical')
+  })
+
+  it('does not apply critical tone when there are no validation errors', async () => {
+    const {result} = await renderBooleanInput({
+      fieldDefinition: defs.booleanTest,
+      render: (inputProps) => <BooleanInput {...inputProps} />,
+    })
+
+    const card = result.container.querySelector('[data-testid="boolean-input"]')
+    expect(card).not.toHaveAttribute('data-tone', 'critical')
   })
 })

--- a/packages/sanity/src/core/form/inputs/BooleanInput.tsx
+++ b/packages/sanity/src/core/form/inputs/BooleanInput.tsx
@@ -37,7 +37,8 @@ export function BooleanInput(props: BooleanInputProps) {
 
   const LayoutSpecificInput = layout === 'checkbox' ? Checkbox : Switch
 
-  const tone: CardTone | undefined = readOnly ? 'transparent' : undefined
+  const hasErrors = readOnly ? false : validation?.some((v) => v.level === 'error')
+  const tone: CardTone | undefined = hasErrors ? 'critical' : readOnly ? 'transparent' : undefined
 
   const input = (
     <Box padding={3} style={{paddingTop: '0.85rem'}}>

--- a/packages/sanity/src/core/form/inputs/DateInputs/CommonDateTimeInput.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/CommonDateTimeInput.tsx
@@ -29,6 +29,7 @@ export interface CommonDateTimeInputProps {
   value: string | undefined
   calendarLabels: CalendarLabels
   timeZoneScope: TimeZoneScope
+  validationError?: string
 }
 
 const DEFAULT_PLACEHOLDER_TIME = new Date()
@@ -50,6 +51,7 @@ export const CommonDateTimeInput = forwardRef(function CommonDateTimeInput(
     timeStep,
     timeZoneScope,
     value,
+    validationError,
     ...restProps
   } = props
 
@@ -124,7 +126,7 @@ export const CommonDateTimeInput = forwardRef(function CommonDateTimeInput(
       readOnly={Boolean(readOnly)}
       onInputChange={handleDatePickerInputChange}
       onChange={handleDatePickerChange}
-      customValidity={parseResult?.error}
+      customValidity={parseResult?.error || validationError}
     />
   )
 })

--- a/packages/sanity/src/core/form/inputs/DateInputs/DateInput.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/DateInput.tsx
@@ -21,7 +21,7 @@ const serialize = (date: Date) => format(date, DEFAULT_DATE_FORMAT)
  * @hidden
  * @beta */
 export function DateInput(props: DateInputProps) {
-  const {readOnly, onChange, schemaType, elementProps, value, id} = props
+  const {readOnly, onChange, schemaType, elementProps, value, id, validationError} = props
   const dateFormat = schemaType.options?.dateFormat || DEFAULT_DATE_FORMAT
   const {t} = useTranslation()
   const timeZoneScope: TimeZoneScope = {type: 'input', id}
@@ -55,6 +55,7 @@ export function DateInput(props: DateInputProps) {
       serialize={serialize}
       value={value}
       timeZoneScope={timeZoneScope}
+      validationError={validationError}
     />
   )
 }

--- a/packages/sanity/src/core/form/inputs/DateInputs/DateTimeInput.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/DateTimeInput.tsx
@@ -147,6 +147,7 @@ export function DateTimeInput(props: DateTimeInputProps) {
     elementProps,
     id,
     validation,
+    validationError,
     changed,
     path,
     presence = EMPTY_ARRAY,
@@ -282,6 +283,7 @@ export function DateTimeInput(props: DateTimeInputProps) {
                 selectTime
                 value={value}
                 timeZoneScope={timeZoneScope}
+                validationError={validationError}
               />
             </div>
           </div>

--- a/packages/sanity/src/core/form/inputs/DateInputs/__tests__/CommonDateTimeInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/__tests__/CommonDateTimeInput.test.tsx
@@ -128,3 +128,40 @@ test('emits onChange on correct format if a valid value has been typed', async (
   // NOTE: the date is entered and displayed in local time zone but stored in utc
   expect(onChange.mock.calls).toEqual([['2021-03-28T17:23:00.000Z']])
 })
+
+test('passes validationError as native validity message when there is no parse error', async () => {
+  const validationErrorMessage = 'Date must be in the past'
+  const onChange = vi.fn()
+
+  const ret = await renderStringInput({
+    fieldDefinition: defineField({
+      type: 'datetime',
+      name: 'test',
+    }),
+    // Use a valid stored value so there is no parse error
+    props: {documentValue: {test: '2021-03-28T17:23:00.000Z'}},
+    render: (props) => {
+      const {id, readOnly = false, value} = props
+
+      return (
+        <CommonDateTimeInput
+          deserialize={deserialize}
+          calendarLabels={CALENDAR_LABELS}
+          id={id}
+          formatInputValue={formatInputValue}
+          onChange={onChange}
+          parseInputValue={parseInputValue}
+          readOnly={readOnly}
+          serialize={serialize}
+          value={value}
+          timeZoneScope={{type: 'input' as TimeZoneScopeType, id}}
+          validationError={validationErrorMessage}
+        />
+      )
+    },
+  })
+
+  const input = ret.result.container.querySelector('input')!
+  // When customValidity is set, the native input's validationMessage should reflect it
+  expect(input.validationMessage).toBe(validationErrorMessage)
+})

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
@@ -58,7 +58,10 @@ export function ReferenceInput(props: ReferenceInputProps) {
     path,
     elementProps,
     focusPath,
+    validation,
   } = props
+
+  const validationError = validation?.find((v) => v.level === 'error')?.message
   const {selectedReleaseId} = usePerspective()
 
   const {getReferenceInfo} = useReferenceInput({
@@ -363,6 +366,7 @@ export function ReferenceInput(props: ReferenceInputProps) {
                 renderValue={renderValue}
                 openButton={{onClick: handleAutocompleteOpenButtonClick}}
                 portalRef={autoCompletePortalRef}
+                customValidity={validationError}
                 value={value?._ref}
               />
 

--- a/packages/sanity/src/core/form/inputs/SelectInput.tsx
+++ b/packages/sanity/src/core/form/inputs/SelectInput.tsx
@@ -1,6 +1,6 @@
 import {ResetIcon} from '@sanity/icons'
 import {isTitledListValue, type TitledListValue} from '@sanity/types'
-import {Box, Card, Flex, Inline, Radio, Select, Stack, Text} from '@sanity/ui'
+import {Box, Card, type CardTone, Flex, Inline, Radio, Select, Stack, Text} from '@sanity/ui'
 import capitalize from 'lodash-es/capitalize.js'
 import {
   type ChangeEvent,
@@ -35,6 +35,7 @@ export function SelectInput(props: StringInputProps) {
   const {
     value,
     readOnly,
+    validation,
     validationError,
     schemaType,
     onChange,
@@ -43,6 +44,9 @@ export function SelectInput(props: StringInputProps) {
     focused,
     elementProps,
   } = props
+
+  const hasErrors = validation?.some((v) => v.level === 'error')
+  const tone: CardTone | undefined = hasErrors ? 'critical' : undefined
   const items = useMemo(
     () => (schemaType.options?.list || []).map(toSelectItem),
     [schemaType.options],
@@ -98,24 +102,26 @@ export function SelectInput(props: StringInputProps) {
       inputId={inputId}
       items={items}
       direction={schemaType.options?.direction || 'vertical'}
-      customValidity={validationError}
       onChange={handleChange}
       readOnly={readOnly}
+      tone={tone}
     />
   ) : (
-    <Select
-      {...elementProps}
-      customValidity={validationError}
-      value={optionValueFromItem(currentItem)}
-      readOnly={readOnly}
-      onChange={handleSelectChange}
-    >
-      {[EMPTY_ITEM, ...items].map((item, i) => (
-        <option key={`${i - 1}`} value={i - 1}>
-          {item.title}
-        </option>
-      ))}
-    </Select>
+    <Card tone={tone} radius={2}>
+      <Select
+        {...elementProps}
+        customValidity={validationError}
+        value={optionValueFromItem(currentItem)}
+        readOnly={readOnly}
+        onChange={handleSelectChange}
+      >
+        {[EMPTY_ITEM, ...items].map((item, i) => (
+          <option key={`${i - 1}`} value={i - 1}>
+            {item.title}
+          </option>
+        ))}
+      </Select>
+    </Card>
   )
   return (
     <ChangeIndicator path={path} isChanged={changed} hasFocus={!!focused}>
@@ -134,11 +140,13 @@ const RadioSelect = forwardRef(function RadioSelect(
     onFocus: (event: FocusEvent<HTMLElement>) => void
     customValidity?: string
     inputId?: string
+    tone?: CardTone
   },
 
   ref: ForwardedRef<HTMLInputElement>,
 ) {
-  const {items, value, onChange, onFocus, readOnly, customValidity, direction, inputId} = props
+  const {items, value, onChange, onFocus, readOnly, customValidity, direction, inputId, tone} =
+    props
   const {t} = useTranslation()
 
   const handleClear = useCallback(() => {
@@ -150,7 +158,7 @@ const RadioSelect = forwardRef(function RadioSelect(
   const showClearButton = !readOnly && value
 
   return (
-    <Card border paddingY={2} paddingX={3} radius={2}>
+    <Card border paddingY={2} paddingX={3} radius={2} tone={tone}>
       <Flex align={isHorizontal ? 'center' : 'flex-end'} gap={3} justify="space-between">
         <Layout space={3} role="group" paddingY={1}>
           {items.map((item, index) => (

--- a/packages/sanity/src/core/form/inputs/SelectInput.tsx
+++ b/packages/sanity/src/core/form/inputs/SelectInput.tsx
@@ -105,6 +105,7 @@ export function SelectInput(props: StringInputProps) {
       onChange={handleChange}
       readOnly={readOnly}
       tone={tone}
+      customValidity={validationError}
     />
   ) : (
     <Card tone={tone} radius={2}>

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridArrayInput.tsx
@@ -1,4 +1,4 @@
-import {Card, Stack, Text} from '@sanity/ui'
+import {Card, type CardTone, Stack, Text} from '@sanity/ui'
 import {useCallback, useMemo} from 'react'
 
 import {useTranslation} from '../../../../../i18n'
@@ -37,9 +37,13 @@ export function GridArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
     renderInput,
     renderPreview,
     schemaType,
+    validation,
     value = EMPTY,
   } = props
   const {t} = useTranslation()
+
+  const hasErrors = validation?.some((v) => v.level === 'error')
+  const errorTone: CardTone | undefined = hasErrors ? 'critical' : undefined
 
   const sortable = schemaType.options?.sortable !== false
 
@@ -63,14 +67,14 @@ export function GridArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
         >
           <Stack data-ui="ArrayInput__content" space={2}>
             {members?.length === 0 && (
-              <Card padding={3} border radius={2}>
+              <Card padding={3} border radius={2} tone={errorTone}>
                 <Text align="center" muted size={1}>
                   {schemaType.placeholder || <>{t('inputs.array.no-items-label')}</>}
                 </Text>
               </Card>
             )}
             {members?.length > 0 && (
-              <Card border radius={1}>
+              <Card border radius={1} tone={errorTone}>
                 <List
                   columns={[2, 3, 4]}
                   gap={3}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.test.tsx
@@ -1,4 +1,4 @@
-import {type ArraySchemaType} from '@sanity/types'
+import {type ArraySchemaType, type FormNodeValidation} from '@sanity/types'
 import {studioTheme, ThemeProvider} from '@sanity/ui'
 import {render, screen} from '@testing-library/react'
 import {type ReactNode} from 'react'
@@ -52,7 +52,11 @@ function createSchemaType(max?: number): ArraySchemaType {
   } as ArraySchemaType
 }
 
-function renderListArrayInput(options: {max?: number; memberCount: number}) {
+function renderListArrayInput(options: {
+  max?: number
+  memberCount: number
+  validation?: FormNodeValidation[]
+}) {
   const members = Array.from({length: options.memberCount}, (_, idx) => ({key: `key-${idx}`}))
   const props = {
     arrayFunctions: ValidationProbe,
@@ -60,6 +64,7 @@ function renderListArrayInput(options: {max?: number; memberCount: number}) {
     members,
     schemaType: createSchemaType(options.max),
     focusPath: [],
+    validation: options.validation,
   } as unknown as ArrayOfObjectsInputProps<ObjectItem>
 
   return render(<ListArrayInput {...props} />, {
@@ -109,5 +114,24 @@ describe('ListArrayInput', () => {
 
     expect(element.type).toBe(MockItemComponent)
     expect(element.props).toEqual(expect.objectContaining({schemaType: itemSchemaType}))
+  })
+  it('applies critical tone to empty state card when there are validation errors', () => {
+    const errorValidation: FormNodeValidation[] = [
+      {level: 'error', message: 'Array is required', path: []},
+    ]
+    const {container} = renderListArrayInput({
+      memberCount: 0,
+      validation: errorValidation,
+    })
+
+    const emptyCard = container.querySelector('[data-ui="Card"]')
+    expect(emptyCard).toHaveAttribute('data-tone', 'critical')
+  })
+
+  it('does not apply critical tone to empty state card when there are no errors', () => {
+    const {container} = renderListArrayInput({memberCount: 0})
+
+    const emptyCard = container.querySelector('[data-ui="Card"]')
+    expect(emptyCard).not.toHaveAttribute('data-tone', 'critical')
   })
 })

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/ListArrayInput.tsx
@@ -1,6 +1,6 @@
 import {type DragStartEvent} from '@dnd-kit/core'
 import {isKeySegment} from '@sanity/types'
-import {Card, Stack, Text} from '@sanity/ui'
+import {Card, type CardTone, Stack, Text} from '@sanity/ui'
 import {useCallback, useMemo, useRef, useState} from 'react'
 import shallowEquals from 'shallow-equals'
 
@@ -41,6 +41,7 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
     renderInput,
     renderPreview,
     schemaType,
+    validation,
     value = EMPTY,
   } = props
   const {t} = useTranslation()
@@ -52,6 +53,8 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
     (itemProps: Omit<ObjectItemProps, 'renderDefault'>) => <ItemComponent {...itemProps} />,
     [ItemComponent],
   )
+  const hasErrors = validation?.some((v) => v.level === 'error')
+  const errorTone: CardTone | undefined = hasErrors ? 'critical' : undefined
 
   // Stores the index of the item being dragged
   const [activeDragItemIndex, setActiveDragItemIndex] = useState<number | null>(null)
@@ -105,7 +108,7 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
         >
           <Stack data-ui="ArrayInput__content" space={2}>
             {members.length === 0 ? (
-              <Card padding={3} border radius={2}>
+              <Card padding={3} border radius={2} tone={errorTone}>
                 <Text align="center" muted size={1}>
                   {schemaType.placeholder || <>{t('inputs.array.no-items-label')}</>}
                 </Text>
@@ -114,6 +117,7 @@ export function ListArrayInput<Item extends ObjectItem>(props: ArrayOfObjectsInp
               <VirtualizedArrayList
                 key={mountKey}
                 members={members}
+                tone={errorTone}
                 memberKeys={memberKeys}
                 activeDragItemIndex={activeDragItemIndex}
                 focusPathKey={focusPathKey}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/VirtualizedArrayList.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/VirtualizedArrayList.tsx
@@ -1,5 +1,5 @@
 import {type DragStartEvent} from '@dnd-kit/core'
-import {Card, useTheme} from '@sanity/ui'
+import {Card, type CardTone, useTheme} from '@sanity/ui'
 import {
   defaultRangeExtractor,
   elementScroll,
@@ -36,6 +36,7 @@ interface VirtualizedArrayListProps<Item extends ObjectItem> {
   listGridGap: number
   paddingY: number
   radius: number
+  tone?: CardTone
 }
 
 /**
@@ -66,6 +67,7 @@ export function VirtualizedArrayList<Item extends ObjectItem>(
     listGridGap,
     paddingY,
     radius,
+    tone,
   } = props
 
   const {space} = useTheme().sanity
@@ -212,6 +214,7 @@ export function VirtualizedArrayList<Item extends ObjectItem>(
     <Card
       ref={parentRef}
       border
+      tone={tone}
       radius={radius}
       style={{
         // This is not memoized since it changes on scroll so it will change anyways making memo useless

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/ArrayOfPrimitivesInput.tsx
@@ -1,4 +1,4 @@
-import {Card, Stack} from '@sanity/ui'
+import {Card, type CardTone, Stack} from '@sanity/ui'
 import get from 'lodash-es/get.js'
 import {PureComponent} from 'react'
 
@@ -157,10 +157,15 @@ export class ArrayOfPrimitivesInput extends PureComponent<ArrayOfPrimitivesInput
       elementProps,
       arrayFunctions: ArrayFunctions = ArrayOfPrimitivesFunctions,
       changed,
+      validation,
     } = this.props
 
     const isSortable = !readOnly && get(schemaType, 'options.sortable') !== false
     const isGrid = schemaType.options?.layout === 'grid'
+
+    // Compute tone for array container based on validation errors
+    const hasErrors = validation?.some((v) => v.level === 'error')
+    const errorTone: CardTone | undefined = hasErrors ? 'critical' : undefined
 
     // Note: we need this in order to generate new id's when items are moved around in the list
     // without it, dndkit will restore focus on the original index of the dragged item
@@ -181,9 +186,9 @@ export class ArrayOfPrimitivesInput extends PureComponent<ArrayOfPrimitivesInput
           >
             <Stack space={1}>
               {membersWithSortIds.length === 0 ? (
-                <NoItemsPlaceholder schemaType={schemaType} />
+                <NoItemsPlaceholder schemaType={schemaType} validation={validation} />
               ) : (
-                <Card padding={1} border>
+                <Card padding={1} border tone={errorTone}>
                   <List
                     onItemMove={this.handleSortEnd}
                     onItemMoveStart={this.handleItemMoveStart}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/NoItemsPlaceholder.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfPrimitivesInput/NoItemsPlaceholder.tsx
@@ -1,5 +1,5 @@
-import {type ArraySchemaType} from '@sanity/types'
-import {Card, Text} from '@sanity/ui'
+import {type ArraySchemaType, type FormNodeValidation} from '@sanity/types'
+import {Card, type CardTone, Text} from '@sanity/ui'
 
 import {useTranslation} from '../../../../i18n'
 
@@ -8,10 +8,20 @@ import {useTranslation} from '../../../../i18n'
  *
  * @internal
  */
-export function NoItemsPlaceholder({schemaType}: {schemaType: ArraySchemaType}) {
+export function NoItemsPlaceholder({
+  schemaType,
+  validation,
+}: {
+  schemaType: ArraySchemaType
+  validation?: FormNodeValidation[]
+}) {
   const {t} = useTranslation()
+
+  const hasErrors = validation?.some((v) => v.level === 'error')
+  const tone: CardTone | undefined = hasErrors ? 'critical' : undefined
+
   return (
-    <Card padding={3} border radius={2}>
+    <Card padding={3} border radius={2} tone={tone}>
       <Text align="center" muted size={1}>
         {schemaType.placeholder || t('inputs.array.no-items-label')}
       </Text>


### PR DESCRIPTION
### Description

Adds visual error styling (critical tone) to form inputs when they have validation errors. Inputs now display a red border/background when invalid.

Closes https://github.com/sanity-io/sanity/issues/11915

**Updated inputs:**
#### `BooleanInput` - Card gets critical tone on error
**Before**
<img width="651" height="132" alt="Screenshot 2026-03-27 at 10 04 17" src="https://github.com/user-attachments/assets/c315bbb3-2847-48be-a2d0-981c1b2f4568" />

**After**
<img width="621" height="127" alt="Screenshot 2026-03-27 at 10 09 49" src="https://github.com/user-attachments/assets/39659d68-df22-42e7-93ca-92851c7a9544" />


####  `SelectInput` - Card/Radio gets critical tone on error
**Before**
<img width="647" height="349" alt="Screenshot 2026-03-27 at 10 05 12" src="https://github.com/user-attachments/assets/7566629f-41fb-4099-952c-0021fd6eb516" />


**After**
<img width="650" height="339" alt="Screenshot 2026-03-27 at 10 11 06" src="https://github.com/user-attachments/assets/3e74cc64-a7f2-4402-b71d-5f6533fe5510" />


#### `DateInput` / `DateTimeInput` - Passes `validationError` to show native input validation
**Before**
<img width="644" height="147" alt="Screenshot 2026-03-27 at 10 06 25" src="https://github.com/user-attachments/assets/7b3d8b79-6206-4e4b-8182-7b99aff9edb8" />


**After**
<img width="622" height="115" alt="Screenshot 2026-03-27 at 10 11 42" src="https://github.com/user-attachments/assets/088ebc10-3521-45f5-be7c-c14272227b60" />


#### `ReferenceInput` - Passes `customValidity` for native input validation
**Before**
<img width="640" height="124" alt="Screenshot 2026-03-27 at 10 07 14" src="https://github.com/user-attachments/assets/8dce5ed3-04b0-4f88-912b-1172280b64a4" />


**After**
<img width="620" height="113" alt="Screenshot 2026-03-27 at 10 12 22" src="https://github.com/user-attachments/assets/f7c978a4-cb01-4f60-8bcd-9bcf76b79e6d" />


#### `ListArrayInput` / `GridArrayInput` / `ArrayOfPrimitivesInput` - Container card gets critical tone on error
**Before**

<img width="654" height="180" alt="Screenshot 2026-03-27 at 10 08 10" src="https://github.com/user-attachments/assets/48b58531-835a-4135-aecf-0655adba910a" />

<img width="643" height="190" alt="Screenshot 2026-03-27 at 10 08 58" src="https://github.com/user-attachments/assets/eb9e9746-84e9-49a1-b247-5094239e1667" />


**After**
<img width="643" height="148" alt="Screenshot 2026-03-27 at 10 14 50" src="https://github.com/user-attachments/assets/86f7661c-cae0-47ce-8a6d-03450be6d958" />

<img width="640" height="163" alt="Screenshot 2026-03-27 at 10 14 54" src="https://github.com/user-attachments/assets/c8dda12a-1cde-4bf6-af08-1828f24567e7" />



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

1. Trigger validation errors on different input types and verify the red styling appears
2. Test with the validation test schema in the test studio


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Manual testing with the test studio , through the validation document https://test-studio-git-gh-11915.sanity.dev/test/structure/input-debug;validationTest;86ca4c51-e3e1-4f7b-a78c-159096105523

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Inputs now consistently display critical tones when they have validation errors.

<!--
Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this is PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "Part of feature X" or "Not required" in this section.
-->
