### PR TITLE
chore(ci): set up changelog reminder comment for merged PRs

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -116,3 +116,15 @@ jobs:
           base: main
           team-reviewers: "@sanity-io/studio"
           draft: true
+
+      - name: Post release notes reminder to the associated PR
+        run: |
+          pnpm --silent release-notes comment-pr-after-merge \
+          --baseVersion=${{ steps.get-base-version.outputs.base-version }} \
+          --commit=${{ github.sha }}
+        env:
+          RELEASE_NOTES_SANITY_PROJECT_ID: ${{ vars.RELEASE_NOTES_SANITY_PROJECT_ID }}
+          RELEASE_NOTES_SANITY_DATASET: ${{ vars.RELEASE_NOTES_SANITY_DATASET }}
+          RELEASE_NOTES_ADMIN_STUDIO_URL: ${{ vars.RELEASE_NOTES_ADMIN_STUDIO_URL }}
+          RELEASE_NOTES_SANITY_TOKEN: ${{ secrets.RELEASE_NOTES_SANITY_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/packages/@repo/release-notes/bin/release-notes.ts
+++ b/packages/@repo/release-notes/bin/release-notes.ts
@@ -5,6 +5,7 @@ import {type Commit, type CommitBase, type CommitMeta} from 'conventional-commit
 import {type pMapSkip} from 'p-map'
 import yargs from 'yargs'
 
+import {commentPrAfterMerge} from '../src/commands/commentPrAfterMerge'
 import {createOrUpdateChangelogDocs} from '../src/commands/createOrUpdateChangelogDocs'
 import {publishReleases} from '../src/commands/publishReleases'
 import {type KnownEnvVar, type PullRequest} from '../src/types'
@@ -77,6 +78,37 @@ await yargs(process.argv.slice(2))
       try {
         await publishReleases({
           targetVersion: args.targetVersion,
+        })
+      } catch (error) {
+        // oxlint-disable-next-line no-console
+        console.error(error)
+        process.exit(1)
+      }
+    },
+  })
+  .command({
+    command: 'comment-pr-after-merge',
+    describe: 'Create a comment on the PR(s) associated with a commit',
+    builder: (cmd) =>
+      cmd.options({
+        commit: {
+          description: 'Version',
+          type: 'string',
+          demandOption: true,
+        },
+        baseVersion: {
+          description:
+            'Current base version. E.g. the current version in package.json / lerna.json',
+          type: 'string',
+          demandOption: true,
+        },
+      }),
+    handler: async (args) => {
+      try {
+        await commentPrAfterMerge({
+          baseVersion: args.baseVersion,
+          commit: args.commit,
+          adminStudioBaseUrl: ADMIN_STUDIO_URL,
         })
       } catch (error) {
         // oxlint-disable-next-line no-console

--- a/packages/@repo/release-notes/src/commands/createOrUpdateChangelogDocs.ts
+++ b/packages/@repo/release-notes/src/commands/createOrUpdateChangelogDocs.ts
@@ -1,7 +1,6 @@
 import {ConventionalGitClient} from '@conventional-changelog/git-client'
 import {MONOREPO_ROOT} from '@repo/utils'
 import {ClientError} from '@sanity/client'
-import {createPublishedId, getDraftId, getVersionId} from '@sanity/id-utils'
 import {
   at,
   createIfNotExists,
@@ -19,18 +18,14 @@ import pMap from 'p-map'
 
 import {client} from '../client'
 import {STUDIO_PLATFORM_DOCUMENT_ID} from '../constants'
-import {octokit} from '../octokit'
 import {type PullRequestInfo} from '../types'
 import {extractReleaseNotes} from '../utils/extractReleaseNotes'
 import {getCommits, getSemverTags} from '../utils/getCommits'
+import {getMergedPRForCommit} from '../utils/github'
+import {createId} from '../utils/ids'
 import {markdownToPortableText} from '../utils/portabletext-markdown/markdownToPortableText'
 import {stripPr} from '../utils/stripPrNumber'
 import {uploadImages} from '../utils/uploadImages'
-
-const createId = (releaseId: string, input: string) => {
-  const published = createPublishedId(input)
-  return {published, version: getVersionId(published, releaseId), draft: getDraftId(published)}
-}
 
 export async function createOrUpdateChangelogDocs(args: {
   tentativeVersion?: string
@@ -220,18 +215,4 @@ async function fetchCommitPrs(commits: Commit[]) {
     },
     {concurrency: 4},
   )
-}
-
-async function getMergedPRForCommit(owner: string, repo: string, commitSha: string) {
-  // Get PRs associated with the commit
-  // see https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests
-  const {data: prs} = await octokit.repos.listPullRequestsAssociatedWithCommit({
-    owner,
-    repo,
-    // eslint-disable-next-line camelcase
-    commit_sha: commitSha,
-  })
-
-  // Find the merged PR (if any)
-  return prs.find((pr) => pr.merged_at !== null)
 }

--- a/packages/@repo/release-notes/src/commands/publishReleases.ts
+++ b/packages/@repo/release-notes/src/commands/publishReleases.ts
@@ -47,7 +47,7 @@ export async function publishReleases(options: {targetVersion: string}) {
   const formattedChangelog = `
 Author | Message | Commit
 ------------ | ------------- | -------------
-${changelogDocument.changelog.map((entry) => `${atAuthor(entry.author)} | ${entry.subject} (#${entry.pr}) | ${entry.hash}`).join('\n')}
+${changelogDocument.changelog.map((entry) => `${mention(entry.author)} | ${entry.subject} (#${entry.pr}) | ${entry.hash}`).join('\n')}
   `
   const response = await octokit.request('POST /repos/{owner}/{repo}/releases', {
     owner: 'sanity-io',
@@ -65,12 +65,13 @@ ${changelogDocument.changelog.map((entry) => `${atAuthor(entry.author)} | ${entr
   console.log('Created GitHub Release:', response.data.html_url)
 }
 
-function atAuthor(author: StudioChangelogEntry['author']) {
+function mention(author: StudioChangelogEntry['author']) {
   if (author.type !== 'bot') {
     return `@${author.username}`
   }
   return author.username
 }
+
 function ghReleaseTemplate(vars: {
   changelogDocumentId: string
   targetVersion: string

--- a/packages/@repo/release-notes/src/utils/github.ts
+++ b/packages/@repo/release-notes/src/utils/github.ts
@@ -1,0 +1,15 @@
+import {octokit} from '../octokit'
+
+export async function getMergedPRForCommit(owner: string, repo: string, commitSha: string) {
+  // Get PRs associated with the commit
+  // see https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests
+  const {data: prs} = await octokit.repos.listPullRequestsAssociatedWithCommit({
+    owner,
+    repo,
+    // eslint-disable-next-line camelcase
+    commit_sha: commitSha,
+  })
+
+  // Find the merged PR (if any)
+  return prs.find((pr) => pr.merged_at !== null)
+}

--- a/packages/@repo/release-notes/src/utils/ids.ts
+++ b/packages/@repo/release-notes/src/utils/ids.ts
@@ -1,0 +1,6 @@
+import {createPublishedId, getDraftId, getVersionId} from '@sanity/id-utils'
+
+export const createId = (releaseId: string, input: string) => {
+  const published = createPublishedId(input)
+  return {published, version: getVersionId(published, releaseId), draft: getDraftId(published)}
+}


### PR DESCRIPTION
### Description
This adds a command to the internal `@repo/release-notes` cli for posting a release notes reminder comment to a PR associated with a commit, and calls this after gathering of release notes in the create-release-pr workflow.

- Once a PR is merged, a comment will be posted with a link to edit release notes. 
- If the author of the PR is a community contributor, the approver of the PR will be mentioned and asked to review and verify release notes.
- If the PR author is a project member, they will be asked to review the release notes.

### Example comments
**PR author is a project member**
<img width="1024" height="213" alt="image" src="https://github.com/user-attachments/assets/06ccea20-ccab-40aa-9c8b-16a3442719b4" />


**PR author is an external contributor**

(here @bjoerge is the external contributor, and @jordanl17 is the approver of the PR with project owner/membership)
<img width="1036" height="221" alt="image" src="https://github.com/user-attachments/assets/4d9cb4cf-7a69-4d46-a877-e4b3ef2d04ac" />


