### PR TITLE
chore(release-notes): use nbsp for edit link text

### DIFF
--- a/packages/@repo/release-notes/bin/release-notes.ts
+++ b/packages/@repo/release-notes/bin/release-notes.ts
@@ -158,6 +158,6 @@ function formatEntry({
   const changelogEntryUrl = `${ADMIN_STUDIO_URL}/intent/edit/id=${changelogDocumentId.published};path=${entryPath}/?perspective=${releaseId}`
 
   const byline = pr.user?.login ? `[${pr.user?.login}](${pr.user.html_url})` : ''
-  const releaseNoteLink = `[:pencil: Edit](${changelogEntryUrl})`
+  const releaseNoteLink = `[:pencil:&nbsp;Edit](${changelogEntryUrl})`
   return `${byline} | ${originalCommitMessage} | [#${pr.number}](${pr.html_url}) | ${conventionalCommit.hash} | ${releaseNoteLink}`
 }


### PR DESCRIPTION
### Description
**Before**
<img width="908" height="299" alt="image" src="https://github.com/user-attachments/assets/9befa10f-bd1e-4b9e-8bdc-c975877385e1" />


**After**
<img width="895" height="254" alt="image" src="https://github.com/user-attachments/assets/6c9e14a9-e428-47f8-a3eb-4c9348ef8609" />

That's all 💆‍♂️
