### PR TITLE
feat: built-in PTE `pasteLink` plugin enabled by default

### DIFF
--- a/dev/test-studio/schema/standard/portableText/customPlugins.tsx
+++ b/dev/test-studio/schema/standard/portableText/customPlugins.tsx
@@ -306,6 +306,96 @@ export const customPlugins = defineType({
     },
 
     /**
+     * Paste Link Disabled
+     *
+     * Disables the default behavior of converting selected text into a link
+     * when a URL is pasted.
+     */
+    {
+      type: 'array',
+      name: 'pasteLinkDisabled',
+      title: 'Paste Link Disabled',
+      description:
+        'The paste link behavior is disabled - pasting a URL on selected text will replace the text',
+      of: [
+        {
+          type: 'block',
+        },
+      ],
+      components: {
+        portableText: {
+          plugins: (props) => {
+            return props.renderDefault({
+              ...props,
+              plugins: {
+                ...props.plugins,
+                pasteLink: {
+                  enabled: false,
+                },
+              },
+            })
+          },
+        },
+      },
+    },
+
+    /**
+     * Custom Paste Link Annotation
+     *
+     * Uses a custom link matcher to support a different annotation type
+     * for links (e.g., 'customLink' instead of 'link').
+     */
+    {
+      type: 'array',
+      name: 'customPasteLinkAnnotation',
+      title: 'Custom Paste Link Annotation',
+      description:
+        'The paste link behavior uses a custom annotation called "customLink" with a "url" field instead of the default "link" with "href"',
+      of: [
+        {
+          type: 'block',
+          marks: {
+            annotations: [
+              {
+                name: 'customLink',
+                title: 'Custom Link',
+                type: 'object',
+                fields: [
+                  {
+                    name: 'url',
+                    title: 'URL',
+                    type: 'url',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+      components: {
+        portableText: {
+          plugins: (props) => {
+            return props.renderDefault({
+              ...props,
+              plugins: {
+                ...props.plugins,
+                pasteLink: {
+                  link: ({context, value}) => {
+                    const customLink = context.schema.annotations.find(
+                      (a) => a.name === 'customLink',
+                    )
+                    if (!customLink) return undefined
+                    return {_type: 'customLink', url: value.href}
+                  },
+                },
+              },
+            })
+          },
+        },
+      },
+    },
+
+    /**
      * No Plugins
      *
      * Removes all plugins from the editor.

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -150,6 +150,7 @@
     "@portabletext/patches": "^2.0.4",
     "@portabletext/plugin-markdown-shortcuts": "^5.0.21",
     "@portabletext/plugin-one-line": "^4.0.21",
+    "@portabletext/plugin-paste-link": "^1.0.0",
     "@portabletext/plugin-typography": "^5.0.21",
     "@portabletext/react": "^6.0.2",
     "@portabletext/sanity-bridge": "^2.0.0",

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -2,6 +2,7 @@ import {defineBehavior} from '@portabletext/editor/behaviors'
 import {BehaviorPlugin} from '@portabletext/editor/plugins'
 import {MarkdownShortcutsPlugin} from '@portabletext/plugin-markdown-shortcuts'
 import {OneLinePlugin} from '@portabletext/plugin-one-line'
+import {PasteLinkPlugin} from '@portabletext/plugin-paste-link'
 import {createDecoratorGuard, TypographyPlugin} from '@portabletext/plugin-typography'
 import {type ArraySchemaType, type PortableTextBlock} from '@sanity/types'
 import {type ComponentType, useMemo} from 'react'
@@ -40,6 +41,7 @@ export const PortableTextEditorPlugins = (props: {
         markdown: {
           config: markdownConfig,
         },
+        pasteLink: {},
         typography: {
           guard: createDecoratorGuard({
             decorators: ({context}) =>
@@ -86,6 +88,7 @@ function DefaultPortableTextEditorPlugins(props: Omit<PortableTextPluginsProps, 
   return (
     <>
       <DefaultMarkdownShortcutsPlugin {...props.plugins.markdown} />
+      <DefaultPasteLinkPlugin {...props.plugins.pasteLink} />
       <DefaultTypographyPlugin {...props.plugins.typography} />
     </>
   )
@@ -116,6 +119,16 @@ function DefaultMarkdownShortcutsPlugin(
       {...restMarkdownConfig}
     />
   )
+}
+
+function DefaultPasteLinkPlugin(props: PortableTextPluginsProps['plugins']['pasteLink']) {
+  const {enabled, ...pasteLinkPluginProps} = props ?? {}
+
+  if (enabled === false) {
+    return null
+  }
+
+  return <PasteLinkPlugin {...pasteLinkPluginProps} />
 }
 
 function DefaultTypographyPlugin(props: PortableTextPluginsProps['plugins']['typography']) {

--- a/packages/sanity/src/core/form/types/blockProps.ts
+++ b/packages/sanity/src/core/form/types/blockProps.ts
@@ -1,4 +1,5 @@
 import {type MarkdownShortcutsPluginProps} from '@portabletext/plugin-markdown-shortcuts'
+import {type PasteLinkPluginProps} from '@portabletext/plugin-paste-link'
 import {type TypographyPluginProps} from '@portabletext/plugin-typography'
 import {
   type ArraySchemaType,
@@ -460,6 +461,12 @@ export interface PortableTextPluginsProps {
            */
           enabled?: boolean
         })
+    pasteLink?: {
+      /**
+       * @defaultValue true
+       */
+      enabled?: boolean
+    } & PasteLinkPluginProps
     typography?: {
       /**
        * @defaultValue true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1783,6 +1783,9 @@ importers:
       '@portabletext/plugin-one-line':
         specifier: ^4.0.21
         version: 4.0.21(@portabletext/editor@4.3.6(@portabletext/sanity-bridge@2.0.0)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rxjs@7.8.2))(react@19.2.3)
+      '@portabletext/plugin-paste-link':
+        specifier: ^1.0.0
+        version: 1.0.0(@portabletext/editor@4.3.6(@portabletext/sanity-bridge@2.0.0)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rxjs@7.8.2))(react@19.2.3)
       '@portabletext/plugin-typography':
         specifier: ^5.0.21
         version: 5.0.21(@portabletext/editor@4.3.6(@portabletext/sanity-bridge@2.0.0)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rxjs@7.8.2))(@types/react@19.2.7)(react@19.2.3)
@@ -4667,6 +4670,13 @@ packages:
 
   '@portabletext/plugin-one-line@4.0.21':
     resolution: {integrity: sha512-dJJJ1oymoRH3aUQEUse2MvAmAGXhq5T7Rq7PfdGj6zhAGXxSQY0J5iEPgqBfbAWtWzHocM5e7dUXfAigsjqGMA==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      '@portabletext/editor': ^4.3.6
+      react: ^19.2
+
+  '@portabletext/plugin-paste-link@1.0.0':
+    resolution: {integrity: sha512-EpPoHkqu9ao5GWXd07TjrGo4QRtrYlzsJS60KIvbvV9b97Qhz3pXdLrqRkDmAn6OA6bwrLNp1bCaENN0tjqt0Q==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       '@portabletext/editor': ^4.3.6
@@ -15739,6 +15749,11 @@ snapshots:
       - '@types/react'
 
   '@portabletext/plugin-one-line@4.0.21(@portabletext/editor@4.3.6(@portabletext/sanity-bridge@2.0.0)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rxjs@7.8.2))(react@19.2.3)':
+    dependencies:
+      '@portabletext/editor': 4.3.6(@portabletext/sanity-bridge@2.0.0)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rxjs@7.8.2)
+      react: 19.2.3
+
+  '@portabletext/plugin-paste-link@1.0.0(@portabletext/editor@4.3.6(@portabletext/sanity-bridge@2.0.0)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rxjs@7.8.2))(react@19.2.3)':
     dependencies:
       '@portabletext/editor': 4.3.6(@portabletext/sanity-bridge@2.0.0)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rxjs@7.8.2)
       react: 19.2.3


### PR DESCRIPTION
### Description

The official `@portabletext/plugin-paste-link` plugin has been added to all Portable Text Inputs in Studio and enabled by default. If there's a URL on `text/plain` on the clipboard, the plugin will take care of properly pasting that as an annotation rather than as plain text.

By default, the plugin looks for an annotation of name `'link'` with an `'href'` string field, and if that is present, it uses that to create the link. This behavior can be configured by providing a custom link matcher function (a function that has access to the current editor schema and returns either a typed object or undefined):

```ts
pasteLink: {
  link: ({context, value}) => {
    const customLink = context.schema.annotations.find((a) => a.name
=== 'customLink')
    if (!customLink) return undefined
    return {_type: 'customLink', url: value.href}
  },
}
```

A `guard` can also be used to prohibit the plugin from running in certain scenarios:

```ts
pasteLink: {
  guard: ({snapshot}) => getActiveStyle(snapshot) !== 'h1',
}
```

To disable the link, simply set `enabled: false`:

```ts
pasteLink: {
  enabled: false,
}
```



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Try to paste a link in an editor that has a `'link'` annotation with an `'href'` field and verify that it works. Verify that a link can be created both with an expanded and collapsed selection. Try the same in an editor that is not configured with such an annotation. Pasting should happen as normal.

Beware that the link must be on `text/plain` on the clipboard.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

The official PTE plugin has a test suite: https://github.com/portabletext/editor/blob/main/packages/plugin-paste-link/src/paste-link.feature

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

Pasting a URL in a Portable Text Input now automatically creates a link

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
