### PR TITLE
chore(ci): improve release note PR comment

### DIFF
--- a/packages/@repo/release-notes/src/commands/commentPrAfterMerge.ts
+++ b/packages/@repo/release-notes/src/commands/commentPrAfterMerge.ts
@@ -47,11 +47,11 @@ export async function commentPrAfterMerge(options: {
   const authorIsBot = collaborators.author.type === 'Bot'
 
   // Create comment
-  const commentBody = `A :scroll: [Release note](${changelogEntryUrl}) has been created for this PR.
+  const commentBody = `A **[:scroll: Release note](${changelogEntryUrl})** has been created for this PR.
 
 ${
   collaborators.isExternalContribution || authorIsBot
-    ? `${collaborators.approvers.map((approver) => mention(approver)).join(', ')} as approver${collaborators.approvers.length > 1 ? 's' : ''} of this PR, please take a look at the [release note](${changelogEntryUrl}) note and make sure it includes all the relevant details.`
+    ? `${collaborators.approvers.map((approver) => mention(approver)).join(', ')} as reviewer${collaborators.approvers.length > 1 ? 's' : ''} of this PR, please take a look and make sure it includes all the relevant details.`
     : `Please take a look and make sure it includes all the relevant details.`
 }
 
@@ -62,7 +62,7 @@ ${authorIsBot ? '`*beep boop*`' : `Thanks for your contribution, ${mention(colla
 }
 
 async function createOrUpdateComment(options: {commit: string; pr: number; body: string}) {
-  const idempotenceMarker = `[idempotence-key]:#release-notes-reminder\n`
+  const idempotencyMarker = `[idempotency-key]:#release-notes-reminder\n`
 
   const {data: existingComments} = await octokit.rest.issues.listComments({
     ...REPO,
@@ -75,12 +75,12 @@ async function createOrUpdateComment(options: {commit: string; pr: number; body:
   })
 
   const existingComment = existingComments.find(
-    (comment) => comment.body && comment.body?.includes(idempotenceMarker),
+    (comment) => comment.body && comment.body?.includes(idempotencyMarker),
   )
 
   if (existingComment && existingComment.body) {
     // check if there are any changes
-    const withoutMarker = existingComment.body.replace(idempotenceMarker, '')
+    const withoutMarker = existingComment.body.replace(idempotencyMarker, '')
     if (withoutMarker === options.body) {
       console.log('Comment is unchanged. Nothing to do')
       return Promise.resolve()
@@ -89,7 +89,7 @@ async function createOrUpdateComment(options: {commit: string; pr: number; body:
       ...REPO,
       // eslint-disable-next-line camelcase
       comment_id: existingComment.id,
-      body: idempotenceMarker + options.body,
+      body: idempotencyMarker + options.body,
     })
   }
 
@@ -97,7 +97,7 @@ async function createOrUpdateComment(options: {commit: string; pr: number; body:
     ...REPO,
     // eslint-disable-next-line camelcase
     issue_number: options.pr,
-    body: idempotenceMarker + options.body,
+    body: idempotencyMarker + options.body,
   })
 }
 


### PR DESCRIPTION
### Description
A couple of smaller enhancements after #12011 
- If the author of the PR is bot, will skip the mention
- Reformats the message a bit, so the link may appear in integration previews (alas, the gh <> slack integration doesn't handle link previews well)
- Fixes a typo

### What to review

Makes sense?


### Notes for release

n/a