### PR TITLE
fix(core): live editable document creation issue

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/patch.ts
@@ -44,6 +44,7 @@ export const patch: OperationImpl<[patches: any[], initialDocument?: Record<stri
               _type: typeName,
               ...initialDocument,
             }),
+            ...patchMutation,
           ]
       // No drafting, so patch and commit the published document
       published.mutate(mutations)


### PR DESCRIPTION
### Description
There is an issue when creating live edit documents, on the first patch the document is created but the patch is not persisted.
So if you open a document and type something into it, the first letter typed will be lost, because it is only creating the document and not respecting the initial patch.
This change fixes that by respecting both the creation and the patch.

**Error**
 when first selecting the image the document is created but the image is not persisted into it.

https://github.com/user-attachments/assets/37a97ddc-5977-458c-9da1-39e70db96f7d

**Fixed 🎉** 

https://github.com/user-attachments/assets/e1dc8fee-cad8-41d6-8725-48f55ac1f379


This happens with any type of transaction, not only the ones coming from images

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in live edit documents losing the first transaction when created. Users needed to do the first action twice.
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
