### PR TITLE
chore(ci): block merge when release in progress

### DIFF
--- a/.github/workflows/check-inflight-release.yml
+++ b/.github/workflows/check-inflight-release.yml
@@ -1,0 +1,64 @@
+name: Check for in-flight release
+
+on:
+  pull_request:
+    # synchronize is needed for check-pr-release-status
+    types: [opened, reopened, ready_for_review, converted_to_draft, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update-release-status:
+    name: "Update in-flight release status checks"
+    runs-on: ubuntu-latest
+
+    if: |
+      github.head_ref == 'ci/release-main' &&
+      (github.event.action == 'ready_for_review' || github.event.action == 'converted_to_draft' || github.event.action == 'closed')
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+
+      - name: Update in-flight release status check for open PRs
+        run: |
+          pnpm --silent release-notes status-check-prs
+        env:
+          RELEASE_NOTES_SANITY_PROJECT_ID: ${{ vars.RELEASE_NOTES_SANITY_PROJECT_ID }}
+          RELEASE_NOTES_SANITY_DATASET: ${{ vars.RELEASE_NOTES_SANITY_DATASET }}
+          RELEASE_NOTES_ADMIN_STUDIO_URL: ${{ vars.RELEASE_NOTES_ADMIN_STUDIO_URL }}
+          RELEASE_NOTES_SANITY_TOKEN: ${{ secrets.RELEASE_NOTES_SANITY_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  check-pr-release-status:
+    runs-on: ubuntu-latest
+    name: "Run in-flight release status check on PR"
+
+    if: github.event_name == 'pull_request' && github.head_ref != 'ci/release-main' # run for all PRs *except* for Release PR
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+
+      - name: Check if there is an in-flight release
+        run: |
+          pnpm --silent release-notes status-check-commit \
+            --commit=${{ github.event.pull_request.head.sha }}
+        env:
+          RELEASE_NOTES_SANITY_PROJECT_ID: ${{ vars.RELEASE_NOTES_SANITY_PROJECT_ID }}
+          RELEASE_NOTES_SANITY_DATASET: ${{ vars.RELEASE_NOTES_SANITY_DATASET }}
+          RELEASE_NOTES_ADMIN_STUDIO_URL: ${{ vars.RELEASE_NOTES_ADMIN_STUDIO_URL }}
+          RELEASE_NOTES_SANITY_TOKEN: ${{ secrets.RELEASE_NOTES_SANITY_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/packages/@repo/release-notes/bin/release-notes.ts
+++ b/packages/@repo/release-notes/bin/release-notes.ts
@@ -8,6 +8,8 @@ import yargs from 'yargs'
 import {commentPrAfterMerge} from '../src/commands/commentPrAfterMerge'
 import {createOrUpdateChangelogDocs} from '../src/commands/createOrUpdateChangelogDocs'
 import {publishReleases} from '../src/commands/publishReleases'
+import {writeCommitCheck} from '../src/commands/writeCommitCheck'
+import {writePrChecks} from '../src/commands/writePrChecks'
 import {type KnownEnvVar, type PullRequest} from '../src/types'
 import {stripPr} from '../src/utils/stripPrNumber'
 
@@ -116,6 +118,24 @@ await yargs(process.argv.slice(2))
         process.exit(1)
       }
     },
+  })
+  .command({
+    command: 'status-check-prs',
+    describe: 'Update in-flight release status checks for all open PRs',
+    handler: () => writePrChecks().then(() => void 0),
+  })
+  .command({
+    command: 'status-check-commit',
+    describe: 'Update in-flight release status checks for a single commit',
+    builder: (cmd) =>
+      cmd.options({
+        commit: {
+          description: 'Head commit to run check on',
+          type: 'string',
+          demandOption: true,
+        },
+      }),
+    handler: (args) => writeCommitCheck({commit: args.commit}).then(() => void 0),
   })
   .demandCommand(1, 'must provide a valid command')
   .help('h')

--- a/packages/@repo/release-notes/src/commands/commentPrAfterMerge.ts
+++ b/packages/@repo/release-notes/src/commands/commentPrAfterMerge.ts
@@ -1,14 +1,10 @@
 /* oxlint-disable no-console */
 import {type RestEndpointMethodTypes} from '@octokit/rest'
 
+import {REPO} from '../constants'
 import {octokit} from '../octokit'
 import {getMergedPRForCommit} from '../utils/github'
 import {createId} from '../utils/ids'
-
-const REPO = {
-  owner: 'sanity-io',
-  repo: 'sanity',
-}
 
 const INTERNAL_ASSOCIATIONS = ['MEMBER', 'OWNER']
 

--- a/packages/@repo/release-notes/src/commands/writeCommitCheck.ts
+++ b/packages/@repo/release-notes/src/commands/writeCommitCheck.ts
@@ -1,0 +1,6 @@
+import {getReleasePr} from '../utils/getReleasePR'
+import {writeCheck} from '../utils/writeCheck'
+
+export async function writeCommitCheck(options: {commit: string}) {
+  return writeCheck({releasePr: await getReleasePr(), headSha: options.commit})
+}

--- a/packages/@repo/release-notes/src/commands/writePrChecks.ts
+++ b/packages/@repo/release-notes/src/commands/writePrChecks.ts
@@ -1,0 +1,23 @@
+import pMap from 'p-map'
+
+import {REPO} from '../constants'
+import {octokit} from '../octokit'
+import {getReleasePr} from '../utils/getReleasePR'
+import {writeCheck} from '../utils/writeCheck'
+
+export async function writePrChecks() {
+  const releasePr = await getReleasePr()
+
+  // get the 100 most recently updated PRs
+  const {data: prs} = await octokit.pulls.list({
+    ...REPO,
+    // eslint-disable-next-line camelcase
+    per_page: 100,
+    state: 'open',
+    sort: 'updated',
+    directory: 'desc',
+    base: 'main',
+  })
+
+  return pMap(prs, (pr) => writeCheck({releasePr, headSha: pr.head.sha}), {concurrency: 10})
+}

--- a/packages/@repo/release-notes/src/constants.ts
+++ b/packages/@repo/release-notes/src/constants.ts
@@ -1,1 +1,6 @@
 export const STUDIO_PLATFORM_DOCUMENT_ID = 'c91b88aa-f3eb-481f-879a-8a1cebc1297c'
+
+export const REPO = {
+  owner: 'sanity-io',
+  repo: 'sanity',
+}

--- a/packages/@repo/release-notes/src/utils/getReleasePR.ts
+++ b/packages/@repo/release-notes/src/utils/getReleasePR.ts
@@ -1,0 +1,17 @@
+import {REPO} from '../constants'
+import {octokit} from '../octokit'
+
+export async function getReleasePr() {
+  const {data: releasePrs} = await octokit.pulls.list({
+    ...REPO,
+    state: 'open',
+    head: `${REPO.owner}:ci/release-main`,
+    base: 'main',
+  })
+
+  if (releasePrs.length > 1) {
+    throw new Error('Multiple open release PRs found, something is wrong!')
+  }
+
+  return releasePrs[0]
+}

--- a/packages/@repo/release-notes/src/utils/writeCheck.ts
+++ b/packages/@repo/release-notes/src/utils/writeCheck.ts
@@ -1,0 +1,26 @@
+import {REPO} from '../constants'
+import {octokit} from '../octokit'
+import {type PullRequest} from '../types'
+
+export function writeCheck({headSha, releasePr}: {releasePr: PullRequest; headSha: string}) {
+  const canMerge = !releasePr || releasePr.draft
+
+  return octokit.checks.create({
+    ...REPO,
+    // eslint-disable-next-line camelcase
+    external_id: 'release-pr-status-check',
+    name: 'Check for in-flight release',
+    // eslint-disable-next-line camelcase
+    head_sha: headSha,
+    status: canMerge ? 'completed' : 'in_progress',
+    ...(canMerge ? {conclusion: 'success'} : {}),
+    output: {
+      title: canMerge
+        ? '✅ There is no in-flight release, merging is OK.'
+        : '‼️ Release in progress, merging is blocked.',
+      summary: canMerge
+        ? `✅ The [release PR](${releasePr.html_url}) is still a draft, merging is OK.`
+        : `⚠️️ The [release PR](${releasePr.html_url}) is marked as ready for review. Please wait for the release to complete before merging.`,
+    },
+  })
+}


### PR DESCRIPTION
### Description

Adds a workflow that creates status checks on  head commits in all open PRs. This status check is marked as pending if the release PR is marked as **ready for review**. If there is no release PR yet, or the release PR is a draft, the status check will pass as `completed`.

We can make this status check required and by that effectively ensure we block merges to main when we're in the process of running a release.

If release PR is a draft, or doesn't exist yet:
<img width="1284" height="71" alt="image" src="https://github.com/user-attachments/assets/653ebc86-1c93-4e79-8ec4-dcd128d56c65" />

If there is a Release PR, and its marked as ready for review:
<img width="1372" height="79" alt="image" src="https://github.com/user-attachments/assets/53e8502d-fd1c-4909-8687-2fdfa7fd45d7" />


### What to review

This adds two jobs in a single workflow:
- One runs for an individual PRs, reporting status check based on what the status of the release PR (if any) currently is. This writes the status check on the HEAD commit in the PR based on the status of the Release PR.
- The other one is triggered by changes in the release PR (e.g. when it is closed, or change status from draft to ready for review). This fetches the current PRs opened against main and creates or updates the status check for the HEAD commit in each PR.

### Testing
- Have tested manually that everything works as expected, will do an additional round of testing once this PR is merged.

### Notes for release

n/a