### PR TITLE
fix(sanity): `getDocumentAtRevision` error when no document found

### DIFF
--- a/packages/sanity/src/core/store/events/getDocumentAtRevision.ts
+++ b/packages/sanity/src/core/store/events/getDocumentAtRevision.ts
@@ -56,7 +56,7 @@ export function getDocumentAtRevision<InputContext extends Context>({
       .pipe(
         map((response) => {
           const document = response.documents[0]
-          return {document: document, loading: false, revisionId: document._rev}
+          return {document: document, loading: false, revisionId: document?._rev}
         }),
 
         catchError((error: Error) => {


### PR DESCRIPTION
### Description

Tiny 🤏 fix to prevent error occurring if no document found by `getDocumentAtRevision`.

### Testing

- Ensured `_rev` is set correctly when document found.
- Ensured no error occurs when no document found.