### PR TITLE
chore(ci): re-use typedoc comment

### DIFF
--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -86,28 +86,19 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && steps.generate.outputs.success == 'true'
-        uses: actions/github-script@v7
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
         with:
-          script: |
-            const fileSize = '${{ steps.generate.outputs.file_size }}';
-            const exportCount = '${{ steps.generate.outputs.export_count }}';
-
-            const body = `## 📚 TypeDoc Generation Result
+          comment-tag: "typedoc-result"
+          message: |
+            ## 📚 TypeDoc Generation Result
 
             ✅ **TypeDoc generated successfully!**
 
-            - **File size:** ${fileSize}
-            - **Total exports:** ${exportCount}
-            - **Artifact:** \`sanity-typedoc-${{ github.sha }}\`
+            - **File size:** ${{ steps.generate.outputs.file_size }}
+            - **Total exports:** ${{ steps.generate.outputs.export_count }}
+            - **Artifact:** `sanity-typedoc-${{ github.sha }}`
 
-            The TypeDoc JSON file has been generated and validated. All documentation scripts completed successfully.`;
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            });
+            The TypeDoc JSON file has been generated and validated. All documentation scripts completed successfully.
 
       - name: Extract version from tag
         if: (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.upload == 'true') && steps.generate.outputs.success == 'true'


### PR DESCRIPTION
### Description
Currently, every time a pull request is updated, a new typedoc comment will be posted on the PR, adding a bit of noise (See for example https://github.com/sanity-io/sanity/pull/12050).

This replaced the rest api call with using https://github.com/thollander/actions-comment-pull-request, which supports providing a comment tag, which updates any previous comment with the given tag instead of creating a new one.

### What to review

Makes sense?

### Testing

This PR should demonstrate that it works ([2 workflow runs](https://github.com/sanity-io/sanity/actions/runs/21598164625), [one comment](https://github.com/sanity-io/sanity/pull/12058#issuecomment-3836243741)).

### Notes for release
n/a