### PR TITLE
feat(imagetool): display cropped image resolution in hotspot/crop modal

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/ImageToolInput/ImageToolInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageToolInput/ImageToolInput.tsx
@@ -1,5 +1,5 @@
 import {type HotspotPreview, type Image, type ImageSchemaType} from '@sanity/types'
-import {Box, Card, Flex, Grid, Heading, Stack, Text} from '@sanity/ui'
+import {Box, Card, Flex, Grid, Heading, Inline, Stack, Text} from '@sanity/ui'
 import {
   type ReactNode,
   useCallback,
@@ -130,6 +130,22 @@ export function ImageToolInput(props: ImageToolInputProps) {
 
   const isSvg = useMemo(() => value?.asset?._ref?.split('-').at(-1) === 'svg', [value?.asset?._ref])
 
+  // Calculate cropped dimensions
+  const croppedDimensions = useMemo(() => {
+    if (!image) return null
+
+    const crop = localValue.crop || DEFAULT_CROP
+    const croppedWidth = Math.round(image.width * (1 - crop.left - crop.right))
+    const croppedHeight = Math.round(image.height * (1 - crop.top - crop.bottom))
+
+    return {
+      originalWidth: image.width,
+      originalHeight: image.height,
+      croppedWidth,
+      croppedHeight,
+    }
+  }, [image, localValue.crop])
+
   const {t} = useTranslation()
   return (
     <FormField
@@ -213,6 +229,20 @@ export function ImageToolInput(props: ImageToolInputProps) {
             </RatioBox>
           </ChangeIndicator>
         </Card>
+
+        {/* Display cropped dimensions */}
+        {!isImageLoading && croppedDimensions && (
+          <Box marginTop={3}>
+            <Inline space={2}>
+              <Text size={1} muted>
+                {t('inputs.imagetool.crop-dimensions', {
+                  width: croppedDimensions.croppedWidth,
+                  height: croppedDimensions.croppedHeight,
+                })}
+              </Text>
+            </Inline>
+          </Box>
+        )}
 
         {hotspotPreviews.length > 0 ? (
           <Box marginTop={2}>

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -838,6 +838,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'inputs.image.upload-error.description': 'The upload could not be completed at this time.',
   /** Upload failed */
   'inputs.image.upload-error.title': 'Upload failed',
+  /** Cropped image dimensions: `{{width}}`×`{{height}}` */
+  'inputs.imagetool.crop-dimensions': 'Cropped image size: {{width}}×{{height}} px',
   /** Adjust the rectangle to crop image. Adjust the circle to specify the area that should always be visible. */
   'inputs.imagetool.description':
     'Adjust the rectangle to crop image. Adjust the circle to specify the area that should always be visible.',


### PR DESCRIPTION
Closes #4337

- Add cropped image dimensions display below the crop tool
- Calculate dimensions based on image size and crop values
- Add i18n key for the dimensions text

### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
