### PR TITLE
fix(ci): report inflight-release-check as passed on release PR

### DIFF
--- a/.github/workflows/check-inflight-release.yml
+++ b/.github/workflows/check-inflight-release.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Run in-flight release status check on PR"
 
-    if: github.event_name == 'pull_request' && github.head_ref != 'ci/release-main' # run for all PRs *except* for Release PR
+    if: github.event_name == 'pull_request'
 
     steps:
       - uses: actions/checkout@v6
@@ -55,7 +55,8 @@ jobs:
       - name: Check if there is an in-flight release
         run: |
           pnpm --silent release-notes status-check-commit \
-            --commit=${{ github.event.pull_request.head.sha }}
+            --commit=${{ github.event.pull_request.head.sha }} \
+            --pr=${{ github.event.pull_request.number }}
         env:
           RELEASE_NOTES_SANITY_PROJECT_ID: ${{ vars.RELEASE_NOTES_SANITY_PROJECT_ID }}
           RELEASE_NOTES_SANITY_DATASET: ${{ vars.RELEASE_NOTES_SANITY_DATASET }}

--- a/packages/@repo/release-notes/bin/release-notes.ts
+++ b/packages/@repo/release-notes/bin/release-notes.ts
@@ -134,8 +134,14 @@ await yargs(process.argv.slice(2))
           type: 'string',
           demandOption: true,
         },
+        pr: {
+          description: 'Current pull request',
+          type: 'number',
+          demandOption: true,
+        },
       }),
-    handler: (args) => writeCommitCheck({commit: args.commit}).then(() => void 0),
+    handler: (args) =>
+      writeCommitCheck({commit: args.commit, currentPrNumber: args.pr}).then(() => void 0),
   })
   .demandCommand(1, 'must provide a valid command')
   .help('h')

--- a/packages/@repo/release-notes/src/commands/writeCommitCheck.ts
+++ b/packages/@repo/release-notes/src/commands/writeCommitCheck.ts
@@ -1,6 +1,10 @@
 import {getReleasePr} from '../utils/getReleasePR'
 import {writeCheck} from '../utils/writeCheck'
 
-export async function writeCommitCheck(options: {commit: string}) {
-  return writeCheck({releasePr: await getReleasePr(), headSha: options.commit})
+export async function writeCommitCheck(options: {commit: string; currentPrNumber: number}) {
+  return writeCheck({
+    currentPrNumber: options.currentPrNumber,
+    releasePr: await getReleasePr(),
+    headSha: options.commit,
+  })
 }

--- a/packages/@repo/release-notes/src/commands/writePrChecks.ts
+++ b/packages/@repo/release-notes/src/commands/writePrChecks.ts
@@ -19,5 +19,9 @@ export async function writePrChecks() {
     base: 'main',
   })
 
-  return pMap(prs, (pr) => writeCheck({releasePr, headSha: pr.head.sha}), {concurrency: 10})
+  return pMap(
+    prs.filter((pr) => pr.number !== releasePr.number),
+    (pr) => writeCheck({releasePr, headSha: pr.head.sha, currentPrNumber: pr.number}),
+    {concurrency: 10},
+  )
 }

--- a/packages/@repo/release-notes/src/utils/writeCheck.ts
+++ b/packages/@repo/release-notes/src/utils/writeCheck.ts
@@ -2,8 +2,20 @@ import {REPO} from '../constants'
 import {octokit} from '../octokit'
 import {type PullRequest} from '../types'
 
-export function writeCheck({headSha, releasePr}: {releasePr: PullRequest; headSha: string}) {
-  const canMerge = !releasePr || releasePr.draft
+export function writeCheck({
+  currentPrNumber,
+  headSha,
+  releasePr,
+}: {
+  currentPrNumber: number
+  releasePr: PullRequest
+  headSha: string
+}) {
+  const canMerge =
+    !releasePr ||
+    releasePr.draft ||
+    // Release PR should always be mergeable
+    releasePr.number === currentPrNumber
 
   return octokit.checks.create({
     ...REPO,


### PR DESCRIPTION
### Description
Since we now require the "Check for in-flight release"-check to pass for PRs, we also need to run it for the release PR. Currently the release PR itself is stuck waiting for it to report: https://github.com/sanity-io/sanity/pull/11982

This fixes the issue by enabling the workflow for the release PR and passing the current PR to the cli command, and then, if we're running on the release PR, we just report the status check as passed.

### What to review
Code makes sense?

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a