### PR TITLE
fix(gdr): use resource-config param to resolve GDRs+ML

### DIFF
--- a/packages/sanity/src/_internal/cli/actions/media/importAssetsAction.ts
+++ b/packages/sanity/src/_internal/cli/actions/media/importAssetsAction.ts
@@ -131,13 +131,13 @@ const importAssetsAction: CliCommandAction<ImportAssetsFlags> = async (args, con
     args.extOptions['media-library-id'] ?? (await determineTargetMediaLibrary(context))
 
   const client = apiClient().withConfig({
-    'apiVersion': MINIMUM_API_VERSION,
-    'requestTagPrefix': 'sanity.mediaLibraryCli.import',
-    '~experimental_resource': {
+    apiVersion: MINIMUM_API_VERSION,
+    requestTagPrefix: 'sanity.mediaLibraryCli.import',
+    resource: {
       type: 'media-library',
       id: mediaLibraryId,
     },
-    'perspective': 'drafts',
+    perspective: 'drafts',
   })
 
   output.print()

--- a/packages/sanity/src/core/form/studio/inputs/globalDocumentReference/datastores/getReferenceClient.ts
+++ b/packages/sanity/src/core/form/studio/inputs/globalDocumentReference/datastores/getReferenceClient.ts
@@ -8,8 +8,8 @@ export function getReferenceClient(
   if (schemaType.resourceType === 'dataset') {
     const [projectId, datasetName] = schemaType.resourceId.split('.', 2)
     return client.withConfig({
-      'apiVersion': 'X',
-      '~experimental_resource': {
+      apiVersion: 'X',
+      resource: {
         type: 'dataset',
         id: `${projectId}.${datasetName}`,
       },
@@ -17,8 +17,8 @@ export function getReferenceClient(
   }
   if (schemaType.resourceType === 'media-library' || schemaType.resourceType === 'canvas') {
     return client.withConfig({
-      'apiVersion': '2025-02-19',
-      '~experimental_resource': {
+      apiVersion: '2025-02-19',
+      resource: {
         type: schemaType.resourceType,
         id: schemaType.resourceId,
       },

--- a/packages/sanity/src/core/validation/validators/objectValidator.ts
+++ b/packages/sanity/src/core/validation/validators/objectValidator.ts
@@ -107,7 +107,7 @@ export const objectValidators: Validators = {
     try {
       const [type, libraryId, documentId] = value.media._ref.split(':', 3)
       // TODO: replace this with stable resource config when available
-      const resourceConfig = {'~experimental_resource': {type, id: libraryId}}
+      const resourceConfig = {resource: {type, id: libraryId}}
       const asset = await context
         .getClient({apiVersion: '2025-02-19'})
         .withConfig(resourceConfig)


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR broke chaining config with `~experimental_resource` as it will always prefer the first set `~experimental_resource` and write it to `resource`, so later `~experimental_resource` will just be ignored. 

Also updated `'~experimental_resource'` in other places... 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

The code

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Everything should just work as before...

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->

Fix references between media libraries and datasets.