### PR TITLE
chore(ci): handle missing release PR, update check on release PR closed

### DIFF
--- a/.github/workflows/check-inflight-release.yml
+++ b/.github/workflows/check-inflight-release.yml
@@ -3,7 +3,7 @@ name: Check for in-flight release
 on:
   pull_request:
     # synchronize is needed for check-pr-release-status
-    types: [opened, reopened, ready_for_review, converted_to_draft, synchronize]
+    types: [opened, closed, reopened, ready_for_review, converted_to_draft, synchronize]
 
 permissions:
   contents: read

--- a/packages/@repo/release-notes/src/utils/writeCheck.ts
+++ b/packages/@repo/release-notes/src/utils/writeCheck.ts
@@ -8,7 +8,7 @@ export function writeCheck({
   releasePr,
 }: {
   currentPrNumber: number
-  releasePr: PullRequest
+  releasePr?: PullRequest
   headSha: string
 }) {
   const canMerge =
@@ -31,7 +31,9 @@ export function writeCheck({
         ? '✅ There is no in-flight release, merging is OK.'
         : '‼️ Release in progress, merging is blocked.',
       summary: canMerge
-        ? `✅ The [release PR](${releasePr.html_url}) is still a draft, merging is OK.`
+        ? releasePr
+          ? `✅ The [release PR](${releasePr.html_url}) is still a draft, merging is OK.`
+          : `✅ There is no release PR, merging is OK`
         : `⚠️️ The [release PR](${releasePr.html_url}) is marked as ready for review. Please wait for the release to complete before merging.`,
     },
   })


### PR DESCRIPTION

### Description
Fixes two smaller issues with release automation:
- when Release PR was merged, the workflow updating status checks on PRs didn't run. Fixed by adding the `closed` type to workflow events
- Running the `check-pr-release-status` job currently fails if there is no release PR

### Notes for release
n/a