### PR TITLE
chore(ci): publish github release instead of creating draft

### DIFF
--- a/packages/@repo/release-notes/src/commands/publishReleases.ts
+++ b/packages/@repo/release-notes/src/commands/publishReleases.ts
@@ -60,7 +60,7 @@ ${changelogDocument.changelog.map((entry) => `${mention(entry.author)} | ${entry
       targetVersion: options.targetVersion,
       changelog: formattedChangelog,
     }),
-    draft: true,
+    draft: false,
   })
   console.log('Created GitHub Release:', response.data.html_url)
 }


### PR DESCRIPTION
### Description
Currently, after merging a release PR, we're creating the GitHub release as a draft, which then must be manually published. This PR changes it so the release instead gets published right away.

### Notes for release
n/a