### PR TITLE
chore(ci): run oxfmt instead of prettier

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Fix lerna.json EOF formatting
         # lerna version formats lerna.json removing EOF line
         # this is needed to pass linter
-        run: pnpm oxfmt --write lerna.json
+        run: pnpm oxfmt lerna.json
 
       - name: Sync workspace lockfile
         run: pnpm install --lockfile-only


### PR DESCRIPTION
### Description
Prettier is no longer a dependency after #12067, so replacing the call to prettier CLI with oxfmt

### Notes for release

n/a