### PR TITLE
fix: missing types in `sanity/structure` and `sanity/presentation`

### DIFF
--- a/packages/@repo/package.config/src/package.config.ts
+++ b/packages/@repo/package.config/src/package.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
   },
   dist: 'lib',
   extract: {
+    // TODO: disabled for now as it's not compatible with `dts: 'rolldown'`, we should replace `@microsoft/api-extractor` with a better tool for validating tsdoc tags`
+    enabled: false,
     // We already check types with `check:types` scripts
     checkTypes: false,
 
@@ -34,4 +36,6 @@ export default defineConfig({
     noImplicitSideEffects: 'error',
     noPublishConfigExports: 'error',
   },
+  // `dts: 'api-extractor'` is not compatible with `customConditions: ['monorepo']` for typegen, it leads to invalid syntax in `.d.ts` files
+  dts: 'rolldown',
 })

--- a/packages/sanity/src/core/schema/createSchema.ts
+++ b/packages/sanity/src/core/schema/createSchema.ts
@@ -6,7 +6,7 @@ import {inferFromSchema as inferValidation} from '../validation'
 
 const isError = (problem: SchemaValidationResult) => problem.severity === 'error'
 
-export const builtinSchema = SchemaBuilder.compile({
+export const builtinSchema: Schema = SchemaBuilder.compile({
   name: 'studio',
   types: builtinTypes,
 })

--- a/packages/sanity/tsconfig.lib.json
+++ b/packages/sanity/tsconfig.lib.json
@@ -12,5 +12,8 @@
     "./src/**/*.test-d.ts",
     "./src/**/*.test-d.tsx",
     "./src/**/vitest.config.mts"
-  ]
+  ],
+  "compilerOptions": {
+    "customConditions": ["monorepo"]
+  }
 }


### PR DESCRIPTION
### Description

Fixes #12079

The regression happened in #11746, released in 5.3.0.

[Checking the diff shows these entry points that got types replaced with `any`](https://npmdiff.dev/sanity/5.2.0/5.3.0/):

[lib/structure.d.ts](https://npmdiff.dev/sanity/5.2.0/5.3.0/package/lib/structure.d.ts)
<img width="1326" height="210" alt="image" src="https://github.com/user-attachments/assets/312fe8d4-84a4-4021-b5bb-c30b94659db6" />

<img width="1020" height="520" alt="image" src="https://github.com/user-attachments/assets/af0a7021-673e-403f-b709-989e96e7302e" />
<img width="1290" height="426" alt="image" src="https://github.com/user-attachments/assets/083b70a7-a9cc-48ff-8ade-059b9939939a" />

[lib/router.d.ts](https://npmdiff.dev/sanity/5.2.0/5.3.0/package/lib/router.d.ts/)
<img width="1274" height="294" alt="image" src="https://github.com/user-attachments/assets/74cb34f9-e90a-4166-9c74-a2e5c21e33d0" />

[lib/presentation.d.ts](https://npmdiff.dev/sanity/5.2.0/5.3.0/package/lib/presentation.d.ts/)


<img width="1238" height="172" alt="image" src="https://github.com/user-attachments/assets/0e2f8bca-daac-4ded-ae48-71eb8aa9fa95" />

[lib/index.d.ts](https://npmdiff.dev/sanity/5.2.0/5.3.0/package/lib/index.d.ts/)

<img width="1066" height="1054" alt="image" src="https://github.com/user-attachments/assets/d747cf4d-0e68-4feb-8aec-53dca283d38a" />

[lib/desk.d.ts](https://npmdiff.dev/sanity/5.2.0/5.3.0/package/lib/desk.d.ts/)

<img width="1250" height="172" alt="image" src="https://github.com/user-attachments/assets/b89292d3-6f16-43bb-a109-3876ae8308bc" />
<img width="990" height="298" alt="image" src="https://github.com/user-attachments/assets/a84dd773-a9f6-46e7-af83-1f9f789ac3d8" />

[lib/_singletons.d.ts](https://npmdiff.dev/sanity/5.2.0/5.3.0/package/lib/_singletons.d.ts/)

<img width="1706" height="154" alt="image" src="https://github.com/user-attachments/assets/777c9855-d5c9-4efc-b260-dbd946d61630" />
<img width="1458" height="148" alt="image" src="https://github.com/user-attachments/assets/2891d3e3-cef0-432f-bc24-92f07058febe" />
There are 100 other cases that I've omitted here.

### What to review

Did I miss anything?

### Testing

There is a pkg.pr.new link on the PR you can use to test and make sure that `import {presentationTool} from 'sanity/presentation'`, `import {structureTool} from 'sanity/structure'` and such has types instead of `any`.

### Notes for release

`sanity@5.3.0` had a regression where `structureTool()`, `presentationTool()` and a few other APIs ended up with `any` as their type, instead of the rich typescript typings that they're supposed to have. In this release the types are back 😮‍💨
