### PR TITLE
test(typegen): rewrite assertions to remove flake

### DIFF
--- a/packages/@sanity/cli/test/shared/environment.ts
+++ b/packages/@sanity/cli/test/shared/environment.ts
@@ -157,7 +157,7 @@ export function runSanityLongRunningCommand(
   expectedOutput: (result: {stdout: string; stderr: string}) => Promise<void> | void,
 ) {
   const cwd = options.cwd ?? ((currentCwd) => currentCwd)
-  const timeout = options.timeout || 25_000
+  const timeout = options.timeout || 10_000
   const startedAt = Date.now()
 
   const proc = spawn(process.argv[0], [cliBinPath, ...args], {


### PR DESCRIPTION
### Description

Adjust assertions to not assert for things that could be affected by left-overs from other test runs.

The test introduced flake since it asserted on `unlink` events and on number of files in the tmp studio dir, and that dir is used in several tests without being completely reset.