### PR TITLE
fix(cli): update @sanity/template-validator to ^3.0.0 to fix undici vulnerability

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -66,7 +66,7 @@
     "@sanity/codegen": "catalog:",
     "@sanity/runtime-cli": "^13.1.0",
     "@sanity/telemetry": "catalog:",
-    "@sanity/template-validator": "^2.4.5",
+    "@sanity/template-validator": "^3.0.0",
     "@sanity/worker-channels": "^1.1.0",
     "chalk": "^4.1.2",
     "debug": "^4.4.3",


### PR DESCRIPTION
## Summary

Bumps `@sanity/template-validator` from `^2.4.5` to `^3.0.0` to resolve a security vulnerability in the transitive dependency `undici`.

## Vulnerability Details

- **Package:** undici
- **Vulnerable versions:** < 6.23.0
- **Fixed version:** >= 6.23.0
- **Issue:** Unbounded decompression chain in HTTP responses on Node.js Fetch API via Content-Encoding leads to resource exhaustion
- **Advisory:** https://github.com/advisories/GHSA-7v5v-9h63-cj86

## Dependency Chain (before)

```
@sanity/cli → @sanity/template-validator@^2.x → @actions/github@^6.0.0 → undici@^5.28.5 (vulnerable)
```

## Dependency Chain (after)

```
@sanity/cli → @sanity/template-validator@^3.0.0 → @actions/github@^9.0.0 → undici@^6.23.0 (fixed)
```

## Related

- Upstream fix: https://github.com/sanity-io/template-validator/pull/15 (merged)
- `@sanity/template-validator@3.0.0` released: 2026-02-04
- Issue: #12049

## Test plan

- [ ] Verify CI passes
- [ ] Verify template validation still works with the updated dependency