### PR TITLE
fix(schema): use `Symbol.for` in validation field reference

### DIFF
--- a/packages/@sanity/schema/src/legacy/Rule.ts
+++ b/packages/@sanity/schema/src/legacy/Rule.ts
@@ -16,7 +16,7 @@ import {
 } from '@sanity/types'
 import {cloneDeep} from 'lodash-es'
 
-const FIELD_REF = Symbol('FIELD_REF')
+const FIELD_REF = Symbol.for('@sanity/schema/field-ref')
 const ruleConstraintTypes: RuleTypeConstraint[] = [
   'Array',
   'Boolean',


### PR DESCRIPTION
### Description

The `FIELD_REF` symbol is used in the validation system to signal "a reference to a field". The CLI tool has some extraction logic for manifests and schemas that traverse rules and excludes this validation type if found. This check relies on importing the symbol from either the `sanity` or `@sanity/schema` package, which we try to avoid as it can lead to mismatches in different versions etc. To make this type of check easier, this PR changes to use `Symbol.for()` so that the same identity will be returned regardless of which version we use.

For backwards compatibility, we still need to also check for the old `FIELD_REF` description, but that's an implementation detail and not necessary for consideration here.

### What to review

Change doesn't have side effects we haven't accounted for
 
### Testing

Relying on existing tests - this shouldn't have any runtime behavior differences.

### Notes for release

None
