### PR TITLE
fix(presentation): crash when switching to a perspective stack

### DIFF
--- a/packages/sanity/src/presentation/loader/LiveQueries.tsx
+++ b/packages/sanity/src/presentation/loader/LiveQueries.tsx
@@ -350,6 +350,6 @@ export function turboChargeResultIfSourceMap<T = unknown>(
       return null
     },
     mapChangedValue,
-    perspective,
+    Array.isArray(perspective) ? perspective.filter(Boolean) : perspective,
   )
 }


### PR DESCRIPTION
### Description

The root issue seems to be that our `perspective` state sometimes contains an empty `''` string when it's an array.
The root cause of the empty string perspective should be handled in a follow-up, for now it's enough to filter out empty strings before handing over `perspective` to `applySourceDocuments` which leads to the crash in its internal `findDocument` call [that calls `perspective.startsWith`](https://github.com/sanity-io/client/blob/567b2bb7e0e3aad820433f81494ecbc981420571/src/csm/createSourceDocumentResolver.ts#L24).

<img width="1474" height="609" alt="image" src="https://github.com/user-attachments/assets/cce56d99-982c-4846-b7ad-9d356b7bc1b7" />

```bash
{
  "error": {
    "stack": "TypeError: Cannot read properties of undefined (reading 'startsWith')\n    at findDocument (https://test-studio.sanity.dev/static/LiveQueries-DclBuRiA.js:1:1536)\n    at https://test-studio.sanity.dev/static/LiveQueries-DclBuRiA.js:1:1994\n    at Array.map (<anonymous>)\n    at applySourceDocuments (https://test-studio.sanity.dev/static/LiveQueries-DclBuRiA.js:1:2281)\n    at turboChargeResultIfSourceMap (https://test-studio.sanity.dev/static/LiveQueries-DclBuRiA.js:1:14017)\n    at useQuerySubscription (https://test-studio.sanity.dev/static/LiveQueries-DclBuRiA.js:1:13239)\n    at QuerySubscriptionComponent (https://test-studio.sanity.dev/static/LiveQueries-DclBuRiA.js:1:9783)\n    at renderWithHooks (https://test-studio.sanity.dev/static/profiling-Cd0QO0SW.js:1245:103805)\n    at updateFunctionComponent (https://test-studio.sanity.dev/static/profiling-Cd0QO0SW.js:1245:157870)\n    at updateSimpleMemoComponent (https://test-studio.sanity.dev/static/profiling-Cd0QO0SW.js:1245:151176)",
    "message": "Cannot read properties of undefined (reading 'startsWith')"
  }
}
```

### What to review

Should get to the bottom of this in a follow up.

### Testing

Here's a video that demonstrates how to repro on our test studio, and how it's fixed locally on this branch (no crash no matter what perspective is switched to):


https://github.com/user-attachments/assets/58fcb3da-203c-42b2-8c07-214d86e13fad



### Notes for release

Fixes a crash in Presentation Tool that could happen when switching perspectives. The error message `TypeError: Cannot read properties of undefined (reading 'startsWith')` wasn't very helpful, nor actionable. Good riddance! 🔪