### PR TITLE
chore(ci): improve in-flight release check workflow names

### DIFF
--- a/.github/workflows/check-inflight-release.yml
+++ b/.github/workflows/check-inflight-release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   update-release-status:
-    name: "Update in-flight release status checks for open PRs"
+    name: "Update status checks for open PRs"
     runs-on: ubuntu-latest
 
     if: |
@@ -38,7 +38,7 @@ jobs:
 
   check-pr-release-status:
     runs-on: ubuntu-latest
-    name: "Update in-flight release status check for PR"
+    name: "Update status check for PR"
 
     if: github.event_name == 'pull_request'
 


### PR DESCRIPTION
### Description
Updates the name of the workflow for checking in-flight release status to make it clearer that it updates *separate status checks*, and isn't a status check on its own.

### What to review
makes sense? is it clearer?

### Notes for release
n/a