### PR TITLE
chore(docs): fix typedoc upload step from skipping

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -80,6 +80,14 @@ jobs:
         env:
           RELEASE_AS: ${{ needs.build-and-validate.outputs.version}}
 
+  typedoc:
+    needs: [build-and-validate, git-operations]
+    uses: ./.github/workflows/typedoc.yml
+    with:
+      upload: true
+      version: ${{ needs.build-and-validate.outputs.version }}
+    secrets: inherit
+
   npm-publish:
     needs: [build-and-validate, git-operations]
     if: always() && needs.build-and-validate.result == 'success' && (needs.git-operations.result == 'success' || needs.git-operations.result == 'skipped')

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -21,6 +21,17 @@ on:
         required: false
         default: false
         type: boolean
+  workflow_call:
+    inputs:
+      upload:
+        description: Upload generated TypeDoc file
+        required: false
+        default: false
+        type: boolean
+      version:
+        description: Version to upload as
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -101,10 +112,14 @@ jobs:
             The TypeDoc JSON file has been generated and validated. All documentation scripts completed successfully.
 
       - name: Extract version from tag
-        if: (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.upload == 'true') && steps.generate.outputs.success == 'true'
+        if: (startsWith(github.ref, 'refs/tags/v') || inputs.upload) && steps.generate.outputs.success == 'true'
         id: version
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+          if [[ -n "${{ inputs.version }}" ]]; then
+            VERSION="${{ inputs.version }}"
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "📋 Using provided version: $VERSION"
+          elif [[ "${{ github.ref }}" == refs/tags/v* ]]; then
             # Extract version from git tag (e.g., refs/tags/v1.2.3 -> 1.2.3)
             VERSION=${GITHUB_REF#refs/tags/v}
             echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -117,7 +132,7 @@ jobs:
           fi
 
       - name: Upload TypeDoc to Sanity Docs API
-        if: (startsWith(github.ref, 'refs/tags/v') || github.event.inputs.upload == 'true') && steps.generate.outputs.success == 'true'
+        if: (startsWith(github.ref, 'refs/tags/v') || inputs.upload) && steps.generate.outputs.success == 'true'
         uses: sanity-io/reference-api-typedoc/.github/actions/typedoc-upload@main
         with:
           packageName: "sanity"


### PR DESCRIPTION
### Description                                                                                                                                 
                                                                                                                                                  
The TypeDoc workflow (`typedoc.yml`) was never triggered during releases because `release-latest.yml` pushes tags using the default `GITHUB_TOKEN`, and GitHub Actions suppresses downstream workflow triggers from `GITHUB_TOKEN` generated events to prevent recursive loops.

This fixes the issue by making `typedoc.yml` a reusable workflow (via `workflow_call`) and calling it directly from `release-latest.yml` after the tag is created, bypassing the event trigger limitation entirely.

### What to review
- `typedoc.yml`: Added `workflow_call` trigger with `upload` and `version` inputs. Updated `if` conditions from `github.event.inputs.upload == 'true'` to `inputs.upload` (works for both `workflow_dispatch` and `workflow_call`). Added `inputs.version` handling in the version extraction step.
- `release-latest.yml`: Added a `typedoc` job that calls the typedoc workflow after `git-operations` completes. Runs in parallel with `npm-publish`.
- Existing trigger paths (tag push, PR validation, manual dispatch) are unchanged.

### Testing

N/A — CI workflow change. Can be verified by running the typedoc workflow manually via `workflow_dispatch` with `upload: false`, or by observing the next release run.

### Notes for release

N/A: Internal CI only