### PR TITLE
fix(studio): show toast when clipboard access is denied on copy

### DIFF
--- a/packages/sanity/src/core/studio/copyPaste/CopyPasteProvider.tsx
+++ b/packages/sanity/src/core/studio/copyPaste/CopyPasteProvider.tsx
@@ -132,14 +132,26 @@ export const CopyPasteProvider: React.FC<{
         schemaTypes: [schemaTypeAtPath.jsonType],
       })
 
-      const isWrittenToClipboard = await writeClipboardItem(payloadValue)
+      try {
+        const isWrittenToClipboard = await writeClipboardItem(payloadValue)
 
-      if (!isWrittenToClipboard) {
-        toast.push({
-          status: 'error',
-          title: t('copy-paste.on-copy.validation.clipboard-not-supported.title'),
-          description: t('copy-paste.on-copy.validation.clipboard-not-supported.description'),
-        })
+        if (!isWrittenToClipboard) {
+          toast.push({
+            status: 'error',
+            title: t('copy-paste.on-copy.validation.clipboard-not-supported.title'),
+            description: t('copy-paste.on-copy.validation.clipboard-not-supported.description'),
+          })
+        }
+      } catch (error) {
+        if (error.name === 'NotAllowedError') {
+          toast.push({
+            status: 'error',
+            title: t('copy-paste.on-copy.validation.clipboard-not-supported.title'),
+            description: t('copy-paste.on-copy.validation.clipboard-not-supported.description'),
+          })
+        } else {
+          throw error
+        }
       }
     },
     [documentMeta, telemetry, toast, t],

--- a/packages/sanity/src/core/studio/copyPaste/utils.ts
+++ b/packages/sanity/src/core/studio/copyPaste/utils.ts
@@ -113,6 +113,10 @@ export async function writeClipboardItem(copyActionResult: SanityClipboardItem):
     await navigator.clipboard.write([clipboardItem])
     return true
   } catch (error) {
+    // Re-throw permission errors so they can be handled specifically
+    if (error.name === 'NotAllowedError') {
+      throw error
+    }
     console.error(`Failed to write to clipboard: ${error.message}`, error)
     return false
   }


### PR DESCRIPTION
## Summary

When users attempt to copy content but have denied clipboard permissions, the Studio now shows a clear error toast explaining the issue and how to resolve it.

## Problem

Studio currently silently fails when attempting to use programmatic copy functions after declining or ignoring a prior request for clipboard access. The paste operation already handled this case with a toast message, but copy did not.

## Solution

- Update `writeClipboardItem` to re-throw `NotAllowedError` so it can be handled specifically
- Add try/catch in `onCopy` to catch permission errors and show the appropriate toast with:
  - Title: "Clipboard access blocked"
  - Description: "Clipboard access required to copy this content. Allow clipboard permissions in your browser settings, then try copying again."

## Test plan

- [ ] Open Studio and navigate to a document with content
- [ ] Open browser settings and deny clipboard permissions for the Studio origin
- [ ] Attempt to copy a field using the field action menu
- [ ] Verify a toast appears with "Clipboard access blocked" message
- [ ] Allow clipboard permissions and verify copy works again

Fixes SAPP-3188

🤖 Generated with [Goose](https://github.com/block/goose)