### PR TITLE
fix(form): prevent erroneous upload warning when pasting plain text into PTE

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/common/uploadTarget/uploadTarget.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/uploadTarget/uploadTarget.tsx
@@ -158,7 +158,11 @@ export function uploadTarget<Props>(
         )
         const ready = filesAndAssetSources.filter((entry) => entry.assetSource !== null)
         if (ready.length === 0) {
-          alertRejectedFiles(filesAndAssetSources)
+          // Only show warning if there were actual files that couldn't be uploaded
+          // (avoid showing warning when pasting plain text which results in empty files array)
+          if (filesAndAssetSources.length > 0) {
+            alertRejectedFiles(filesAndAssetSources)
+          }
           return
         }
         const allAssetSources = types.flatMap(


### PR DESCRIPTION
## Summary

Fixes an issue where pasting plain text into a Portable Text Editor (PTE) field would incorrectly show a "cannot upload" warning toast.

## Problem

When pasting plain text into a PTE field:
1. The `fileTarget` component's paste handler extracts files from the clipboard data
2. For plain text, `extractPastedFiles` returns an empty array (no files to upload)
3. The empty array flows to `handleFiles` in `uploadTarget.tsx`
4. `getFilesAndAssetSources([]))` returns an empty array
5. The condition `ready.length === 0` evaluates to true
6. `alertRejectedFiles([])` is called, showing a warning toast with count: 0

## Solution

Add a check to ensure we only show the warning when there are actual files that were rejected:

```typescript
if (ready.length === 0) {
  // Only show warning if there were actual files that couldn't be uploaded
  if (filesAndAssetSources.length > 0) {
    alertRejectedFiles(filesAndAssetSources)
  }
  return
}
```

## Testing

1. Open a document with a Portable Text Editor field
2. Copy some plain text (e.g., from a text editor or website)
3. Paste into the PTE field
4. **Before:** Warning toast appears saying items cannot be uploaded
5. **After:** No warning toast, text pastes normally

## Linear Issue

Fixes [SAPP-3484](https://linear.app/sanity/issue/SAPP-3484)
