### PR TITLE
fix(form): reset asset source state after upload completes

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileInput.tsx
@@ -234,6 +234,9 @@ export function BaseFileInput(props: BaseFileInputProps) {
                     handleAssetLimitUpsellDialog('field_action')
                   }
                   onChange(PatchEvent.from([unset([UPLOAD_STATUS_KEY])]))
+                  // Reset state to allow selecting again
+                  setSelectedAssetSource(null)
+                  setIsUploading(false)
                   break
                 }
                 default:

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -270,6 +270,9 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
                   }
                   onChange(PatchEvent.from([unset([UPLOAD_STATUS_KEY])]))
                   setMenuOpen(false)
+                  // Reset state to allow selecting again
+                  setSelectedAssetSource(null)
+                  setIsUploading(false)
                   break
                 }
                 default:


### PR DESCRIPTION
## Description

After uploading a file/image via the default asset source, the `selectedAssetSource` state was not being reset. This caused the "Select" functionality to break because clicking "Select" would try to set the same asset source that was already set, resulting in no state change and the dialog not opening.

## What changed

Added `setSelectedAssetSource(null)` and `setIsUploading(false)` to the `'all-complete'` case in both:
- `FileInput.tsx`
- `ImageInput.tsx`

This matches the behavior already present in:
- The error handling `catch` block (which correctly resets these states)
- The `handleSelectAssets` callback (which correctly resets when selecting an existing asset)

## Steps to reproduce (before fix)

1. Create a document type with a "file" field
2. Create a new document and upload a new file via the default asset source
3. Attempt to replace the file by selecting a replacement via the ellipsis menu
4. **Bug:** Nothing happens - the select dialog doesn't open

## Testing

After this fix, clicking "Select" after an upload will correctly open the asset source dialog.

Fixes SAPP-3483