### PR TITLE
fix(form): remove excessive minHeight from EnhancedObjectDialog

### DIFF
--- a/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
+++ b/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
@@ -107,7 +107,7 @@ export function EnhancedObjectDialog(props: PopoverProps | DialogProps): React.J
 
   const contents = (
     <PresenceOverlay margins={PRESENCE_MARGINS}>
-      <Box ref={containerElement} style={{minHeight: 'min(calc(100vh - 200px), 500px)'}}>
+      <Box ref={containerElement}>
         {children}
       </Box>
     </PresenceOverlay>


### PR DESCRIPTION
## Description

Fixes an issue where the Enhanced Object Dialog modal displays excessive whitespace when editing small objects.

## What changed

Removed the  constraint from the content Box in EnhancedObjectDialog. The  was introduced in #11852 to fix padding issues, but it caused a regression where the dialog always takes up at least 500px of height regardless of content size.

## Why

The tree-editing version of EnhancedObjectDialog doesn't have any height constraints on the content Box and works correctly. This change aligns the behavior.

## Testing

1. Create a document with an array of objects containing only 1-2 fields
2. Click to edit an object in the array
3. Verify the dialog sizes appropriately to the content without excessive whitespace

Fixes SAPP-3504