### PR TITLE
fix(releases): hide publish option for already-published scheduled drafts

### DIFF
--- a/packages/sanity/src/core/releases/tool/overview/ScheduledDraftMenuButtonWrapper.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ScheduledDraftMenuButtonWrapper.tsx
@@ -40,7 +40,7 @@ export const ScheduledDraftMenuButtonWrapper = ({release}: {release: ReleaseDocu
   })
 
   const displayedMenuItems = useMemo(() => {
-    if (release.state === 'archived') {
+    if (release.state === 'archived' || release.state === 'published') {
       return [<MenuItem key={'delete-schedule'} {...actions.deleteSchedule} />]
     }
 
@@ -52,7 +52,6 @@ export const ScheduledDraftMenuButtonWrapper = ({release}: {release: ReleaseDocu
       ]
     }
 
-    // Active mode
     return [
       <MenuItem key={'publish-now'} {...actions.publishNow} />,
       <MenuItem key={'edit-schedule'} {...actions.editSchedule} />,


### PR DESCRIPTION
## Summary

When viewing archived scheduled drafts in the Releases overview, releases with state `'published'` were still showing the 'Publish Now' menu option. Clicking this would fail since the draft has already been published.

## The Fix

Added a check for `'published'` state alongside the existing `'archived'` check in `ScheduledDraftMenuButtonWrapper.tsx`. This is consistent with how other places in the codebase handle archived/published releases (e.g., `ReleaseMenu.tsx` uses `release.state === 'published' || release.state === 'archived'`).

## Changes

- `ScheduledDraftMenuButtonWrapper.tsx`: Updated the condition to check for both `'archived'` and `'published'` states when determining which menu items to display

## Testing

1. Create a scheduled draft
2. Let it publish (or publish it manually)
3. Navigate to Releases overview > Drafts tab > Archived
4. Open the context menu for the published draft
5. Verify only 'Delete schedule' option is shown (not 'Publish Now')

Fixes SAPP-3500

Notes for Release
N/A