### PR TITLE
chore: add deprecated tag for enhnacedObjectdialog Beta Property

### DIFF
--- a/packages/sanity/src/_singletons/context/EnhancedObjectDialogContext.ts
+++ b/packages/sanity/src/_singletons/context/EnhancedObjectDialogContext.ts
@@ -4,6 +4,7 @@ import type {EnhancedObjectDialogContextValue} from '../../core/form/studio/tree
 
 /**
  * @internal
+ * @deprecated This context is no longer used and will be removed in a future release as we make the enhanced object dialog the default.
  */
 export const EnhancedObjectDialogContext = createContext<EnhancedObjectDialogContextValue>(
   'sanity/_singletons/context/enhanced-object-dialog-enabled',

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -437,6 +437,9 @@ export const eventsAPIReducer = (opts: {
   return result
 }
 
+/**
+ * @deprecated This reducer is no longer used and will be removed in a future release as we make the enhanced object dialog the default.
+ */
 export const enhancedObjectDialogEnabledReducer = (opts: {
   config: PluginOptions
   initialValue: boolean
@@ -674,7 +677,9 @@ export const searchStrategyReducer = ({
       // The strategy has been explicitly defined.
       if (typeof strategy !== 'undefined') {
         if (!isSearchStrategy(strategy)) {
-          const listFormatter = new Intl.ListFormat('en-US', {type: 'disjunction'})
+          const listFormatter = new Intl.ListFormat('en-US', {
+            type: 'disjunction',
+          })
           const options = listFormatter.format(searchStrategies.map((value) => `"${value}"`))
           const received =
             typeof strategy === 'string' ? `"${strategy}"` : getPrintableType(strategy)

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -384,7 +384,9 @@ export interface DocumentLanguageFilterContext extends ConfigContext {
  * @hidden
  * @beta
  */
-export type DocumentLanguageFilterComponent = ComponentType<{schemaType: ObjectSchemaType}>
+export type DocumentLanguageFilterComponent = ComponentType<{
+  schemaType: ObjectSchemaType
+}>
 
 /**
  *
@@ -1259,7 +1261,7 @@ export interface BetaFeatures {
   form?: {
     /**
      * Enhanced Object Dialog is a new dialog for editing objects in the studio.
-     * @beta
+     * @deprecated This property will be removed in a future release as we make the enhanced object dialog the default.
      */
     enhancedObjectDialog?: {
       enabled: boolean

--- a/packages/sanity/src/core/form/studio/tree-editing/context/enabled/EnhancedObjectDialogProvider.tsx
+++ b/packages/sanity/src/core/form/studio/tree-editing/context/enabled/EnhancedObjectDialogProvider.tsx
@@ -12,6 +12,9 @@ interface EnhancedObjectDialogProviderProps {
   legacyEditing?: boolean
 }
 
+/**
+ * @deprecated This provider is no longer used and will be removed in a future release as we make the enhanced object dialog the default.
+ */
 export function EnhancedObjectDialogProvider(
   props: EnhancedObjectDialogProviderProps,
 ): React.JSX.Element {

--- a/packages/sanity/src/core/form/studio/tree-editing/context/enabled/useEnhancedObjectDialog.ts
+++ b/packages/sanity/src/core/form/studio/tree-editing/context/enabled/useEnhancedObjectDialog.ts
@@ -17,6 +17,7 @@ export interface EnhancedObjectDialogContextValue {
 
 /**
  * @internal
+ * @deprecated This hook is no longer used and will be removed in a future release as we make the enhanced object dialog the default.
  */
 export function useEnhancedObjectDialog(): EnhancedObjectDialogContextValue {
   return useContext(EnhancedObjectDialogContext)


### PR DESCRIPTION
### Description

Deprecated will stay for a week (upon discussion) and then logic will be cleaned up and properties will be removed.
(this is part of the original plan, dates and timelines can be adjusted upon discussion)

https://github.com/user-attachments/assets/3facc899-cba0-4527-b2eb-931b207b46de

### What to review

Should I add a deprecate somewhere else? Different warning?

### Testing

Nothing necessary right now.

### Notes for release

Enhanced Object Dialog beta: Add `@deprecated` tags to the `beta.form.enhancedObjectDialog` studio config as we prepare to make the enhanced object dialog the default.