### PR TITLE
fix: reduce LISTENER_RESET_DELAY from 10s to 5s

### DIFF
--- a/packages/sanity/src/core/preview/constants.tsx
+++ b/packages/sanity/src/core/preview/constants.tsx
@@ -5,10 +5,11 @@ export const INCLUDE_FIELDS_QUERY = ['_id', '_rev', '_type']
 export const INCLUDE_FIELDS = [...INCLUDE_FIELDS_QUERY, '_key']
 
 /**
- * How long to wait after the last subscriber has unsubscribed before resetting the observable and disconnecting the listener
- * We want to keep the listener alive for a short while after the last subscriber has unsubscribed to avoid unnecessary reconnects
+ * How long to wait after the last subscriber has unsubscribed before resetting the observable and disconnecting the listener.
+ * We want to keep the listener alive for a short while after the last subscriber has unsubscribed to avoid unnecessary reconnects.
+ * Reduced from 10s to 5s to limit concurrent SSE connections during navigation-heavy sessions.
  */
-export const LISTENER_RESET_DELAY = 10_000
+export const LISTENER_RESET_DELAY = 5_000
 
 export const AVAILABILITY_READABLE = {
   available: true,

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/memoizedPair.ts
@@ -8,8 +8,11 @@ import {memoize} from '../utils/createMemoizer'
 import {checkoutPair, type Pair} from './checkoutPair'
 import {memoizeKeyGen} from './memoizeKeyGen'
 
-// How long to keep listener connected for after last unsubscribe
-const LISTENER_RESET_DELAY = 10_000
+// How long to keep listener connected for after last unsubscribe.
+// Reduced from 10s to 5s to limit concurrent SSE connections during
+// navigation-heavy sessions. 5s still covers most "navigate away and back"
+// patterns while cutting the stale connection window in half.
+const LISTENER_RESET_DELAY = 5_000
 
 export const memoizedPair: (
   client: SanityClient,


### PR DESCRIPTION
### Description

Reduces the SSE listener grace period after last unsubscribe from 10 seconds to 5 seconds in both document pair listeners (memoizedPair.ts) and the global preview listener (constants.tsx).

This cuts the window where stale SSE connections persist during navigation-heavy sessions, reducing peak concurrent connection count by an estimated 5-8 connections. 5 seconds still covers most 'navigate away and back' patterns.

> [!Note]
> Part of the Sanity Studio save performance investigation, addresses listener accumulation that contributes to server-side fan-out during commits. 12 in the studio, 1 is in separate plugins that we know we need to tackle. This is on the lower side of impact side of things but was identified as something that could of benefit

### What to review

Any meaninful danger in reducing the time?
It didn't look like to be the case to me and during tests however we have little to not surface here. There shouldn't be any outright danger
Trying it out manually feels like everything works as expected

### Testing
Harder to test locally / on the deployed version as it will usually require a large batch of changes to happen in between and checking the network tab with normal level of interaction didn't seem to present issues. 

### Notes for release

Reduced SSE listener grace period from 10s to 5s to lower concurrent connection count during document navigation, reducing server-side fan-out on commits.