### PR TITLE
fix(releases): add character limit to release names

### DIFF
--- a/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
@@ -9,6 +9,7 @@ import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {useReleaseFormOptimisticUpdating} from '../../hooks/useReleaseFormOptimisticUpdating'
 
 const MAX_DESCRIPTION_HEIGHT = 200
+const MAX_TITLE_LENGTH = 100
 
 const TitleInput = styled.input((props) => {
   const {color, font} = getTheme_v2(props.theme)
@@ -170,6 +171,7 @@ export function TitleDescriptionForm({
         data-testid="release-form-title"
         readOnly={!isReleaseOpen}
         disabled={disabled}
+        maxLength={MAX_TITLE_LENGTH}
       />
       {shouldShowDescription && (
         <DescriptionTextArea


### PR DESCRIPTION
## Description

Adds a 100 character limit to release names to prevent UI issues when release titles are excessively long.

## What changed

Added a `maxLength={100}` attribute to the release title input field in `TitleDescriptionForm.tsx`.

## Why

Release names currently have no character limit, which can cause UI problems when titles are very long (as noted in the issue - "anytime these release titles are displayed they seem to show the full text").

A 100 character limit is a reasonable constraint that:
- Allows descriptive release names
- Prevents UI overflow issues
- Aligns with common title length limits in other content management systems

## Testing

1. Create a new release
2. Try to type more than 100 characters in the title field
3. Verify the input stops accepting characters at 100

Fixes SAPP-2796