### PR TITLE
fix(releases): handle title overflow when side-tray is open

### DIFF
--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseName.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseName.tsx
@@ -99,14 +99,14 @@ export const ReleaseNameCell: VisibleColumn<TableRelease>['cell'] = ({
             }
             aria-live="assertive"
           />
-          <Card {...cardProps} padding={2} radius={2} flex={1}>
+          <Card {...cardProps} padding={2} radius={2} flex={1} style={{minWidth: 0}}>
             <Flex align="center" gap={2}>
               <Box flex="none">
                 <ReleaseAvatar tone={getReleaseTone(release)} />
               </Box>
-              <Stack flex={1} space={2}>
-                <Flex align="center" gap={2}>
-                  <Text size={1} weight="medium">
+              <Stack flex={1} space={2} style={{minWidth: 0}}>
+                <Flex align="center" gap={2} style={{minWidth: 0}}>
+                  <Text size={1} weight="medium" textOverflow="ellipsis">
                     {displayTitle}
                   </Text>
                 </Flex>


### PR DESCRIPTION
## Description

Fixes title overflow in the releases table when the side-tray is open. Long release titles now properly truncate with ellipsis instead of overflowing.

## What changed

Updated `ReleaseName.tsx` to properly handle text overflow:
- Added `minWidth: 0` to flex containers (Card, Stack, Flex) to allow them to shrink below their content size
- Added `textOverflow="ellipsis"` to the Text component to truncate long titles

## Why

When the side-tray is open, the available width for the releases table is reduced. Without proper overflow handling, long release titles would overflow their container and break the layout.

The `minWidth: 0` fix is a common CSS pattern for flex children - by default, flex items have `min-width: auto` which prevents them from shrinking smaller than their content. Setting `minWidth: 0` allows the flex items to shrink and enables the text truncation to work.

## Testing

1. Create a release with a very long title
2. Open the releases overview
3. Open the side-tray (e.g., by clicking on a document)
4. Verify the long title is truncated with ellipsis instead of overflowing

Fixes SAPP-3020