### PR TITLE
chore(ci): do not set title when updating changelog document

### DIFF
--- a/packages/@repo/release-notes/src/commands/createOrUpdateChangelogDocs.ts
+++ b/packages/@repo/release-notes/src/commands/createOrUpdateChangelogDocs.ts
@@ -87,7 +87,6 @@ export async function createOrUpdateChangelogDocs(args: {
     ]),
     patch(apiVersionDocId.version, [at('date', set(format(new Date(), 'yyyy-MM-dd')))]),
     patch(changelogDocumentId.version, [
-      at('title', setIfMissing(tentativeVersion)),
       at('releaseAutomation', setIfMissing({})),
       at('releaseAutomation.tentativeVersion', set(tentativeVersion)),
       at('releaseAutomation.source', set('studio')),


### PR DESCRIPTION
### Description
Currently, the release automation script sets the default title on the release notes document to the version number. We usually want the title to reflect the changes included in the release. Setting the version number as the default makes it easy to overlook that the title hasn’t been intentionally set.

### Testing
- Clear the title field on the current release notes document and make sure it doesn't re-appear after a new change has been merged to main
 
### Notes for release
n/a