### PR TITLE
fix: resolving re-render loop when collapsing comments

### DIFF
--- a/packages/sanity/src/core/comments/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/core/comments/components/list/CommentsListItem.tsx
@@ -144,7 +144,6 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
   const {t} = useTranslation(commentsLocaleNamespace)
   const [value, setValue] = useState<CommentMessage>(EMPTY_ARRAY)
   const [collapsed, setCollapsed] = useState<boolean>(true)
-  const [didExpand, setDidExpand] = useState(false)
   const replyInputRef = useRef<CommentInputHandle>(null)
 
   const {isTopLayer} = useLayer()
@@ -230,7 +229,6 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
   const handleExpand = useCallback((e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
     setCollapsed(false)
-    setDidExpand(true)
   }, [])
 
   const splicedReplies = useMemo(() => {
@@ -246,10 +244,6 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
   const expandButtonText = `${replies?.length - MAX_COLLAPSED_REPLIES} more ${
     replies?.length - MAX_COLLAPSED_REPLIES === 1 ? 'comment' : 'comments'
   }`
-
-  if (replies.length > MAX_COLLAPSED_REPLIES && !didExpand) {
-    setCollapsed(true)
-  }
 
   return (
     <StyledThreadCard
@@ -300,7 +294,7 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
           />
         </Stack>
 
-        {showCollapseButton && !didExpand && (
+        {showCollapseButton && collapsed && (
           <Flex gap={1} paddingY={1} sizing="border">
             <SpacerAvatar />
 


### PR DESCRIPTION
### Description

`CommentsListItem` was calling `setCollapsed(true)` directly in its render body (not in an effect or handler). When rapid comment creation was triggered, it caused many re-renders in quick succession (optimistic update + server response for each comment), which caused a crash with "Too many re-renders."

The fix removes the call entirely since the state it was setting was already the correct value by default.

#### Before
![lotsOfCommentsBEFORE](https://github.com/user-attachments/assets/e88c811e-5bdd-4034-8f73-b76a3af0f1c8)

#### After
![lotsOfCommentsAFTER](https://github.com/user-attachments/assets/6785c3d8-cb6e-40f4-b6f1-25c9c3bc9477)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue where sometimes when posting multiple comments the Structure tool would crash and prevent viewing comments in the document.
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
