### PR TITLE
fix(mutator): include more details with error message

### DIFF
--- a/packages/@sanity/mutator/src/patch/ImmutableAccessor.ts
+++ b/packages/@sanity/mutator/src/patch/ImmutableAccessor.ts
@@ -23,6 +23,16 @@ export class ImmutableAccessor implements Probe {
     return 'primitive'
   }
 
+  valueType() {
+    if (this._value === null) {
+      return 'null'
+    }
+    if (Array.isArray(this._value)) {
+      return 'array'
+    }
+    return typeof this._value
+  }
+
   // Common reader, supported by all containers
   get(): unknown {
     return this._value

--- a/packages/@sanity/mutator/src/patch/InsertPatch.ts
+++ b/packages/@sanity/mutator/src/patch/InsertPatch.ts
@@ -20,7 +20,10 @@ export class InsertPatch {
   apply(targets: Expression[], accessor: ImmutableAccessor): ImmutableAccessor {
     let result = accessor
     if (accessor.containerType() !== 'array') {
-      throw new Error('Attempt to apply insert patch to non-array value')
+      const valueType = accessor.valueType()
+      throw new Error(
+        `Attempt to apply insert patch to value of type "${valueType}" at path "${accessor.path.join(' → ')}"`,
+      )
     }
 
     switch (this.location) {


### PR DESCRIPTION
### Description
Occasionally, we receive reports of the error: _Attempt to apply insert patch to non-array value._ This issue is particularly difficult to reproduce, and the current error message doesn’t provide much actionable context.

This PR adds additional details to the error output, giving us a little more insight into when and why it occurs.

### Before
<img width="894" height="372" alt="image" src="https://github.com/user-attachments/assets/1c4735e5-81f9-43a7-a01a-724b6a3ff2ed" />

### After
<img width="888" height="363" alt="image" src="https://github.com/user-attachments/assets/4c4a6142-126a-4222-87d3-3bc07880391d" />

### What to review
Makes sense?

### Testing
Hard to test given that its hard to repro in the first place, but one way to force-trigger this error is to change the `setIfMissing()`-call here so it sets the field to an non-array value, e.g. `setIfMissing(0)`, and then try to insert a new item into an empty array of objects:

https://github.com/sanity-io/sanity/blob/d67c58fe99daf30c8af44b4299986357b70e7008/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx#L158

### Notes for release
n/a