### PR TITLE
feat: add warning when a document type is used for a field

### DIFF
--- a/packages/@sanity/schema/src/sanity/validation/createValidationResult.ts
+++ b/packages/@sanity/schema/src/sanity/validation/createValidationResult.ts
@@ -31,6 +31,7 @@ export const HELP_IDS = {
   GLOBAL_DOCUMENT_REFERENCE_INVALID: 'global-document-reference-invalid',
   DEPRECATED_BLOCKEDITOR_KEY: 'schema-deprecated-blockeditor-key',
   STANDALONE_BLOCK_TYPE: 'schema-standalone-block-type',
+  FIELD_TYPE_IS_DOCUMENT: 'schema-field-type-is-document',
 }
 
 function createValidationResult(

--- a/packages/@sanity/schema/src/sanity/validation/types/object.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/object.ts
@@ -58,7 +58,7 @@ function validateFieldName(name: any): Array<any> {
   return []
 }
 
-export function validateField(field: any, _visitorContext: any) {
+export function validateField(field: any, visitorContext: any) {
   if (!isPlainObject(field)) {
     return [
       error(
@@ -75,6 +75,20 @@ export function validateField(field: any, _visitorContext: any) {
       : [error('Missing field name', HELP_IDS.OBJECT_FIELD_NAME_INVALID)]),
   )
   problems.push(...validateComponent(field))
+
+  if (
+    field.type &&
+    typeof field.type === 'string' &&
+    visitorContext.getType(field.type)?.type === 'document'
+  ) {
+    problems.push(
+      warning(
+        `The type "${field.type}" is a document type and should not be used as a field type directly. Use a "reference" if you want to create a link to the document, or use "object" if you want to embed fields inline.`,
+        HELP_IDS.FIELD_TYPE_IS_DOCUMENT,
+      ),
+    )
+  }
+
   return problems
 }
 


### PR DESCRIPTION
### Description

We currently support using document types as the type of fields. It is an anti pattern that is often used in places where doc references or object types should have been used instead.

### Notes for release

Now prints a warning if a document type is used as the type of a field.