### PR TITLE
chore(docs): remove migrate from typedoc

### DIFF
--- a/packages/sanity/typedoc.config.json
+++ b/packages/sanity/typedoc.config.json
@@ -6,7 +6,6 @@
     "./src/_exports/structure.ts",
     "./src/_exports/presentation.ts",
     "./src/_exports/router.ts",
-    "./src/_exports/migrate.ts",
     "./src/_exports/media-library.ts"
   ],
   "entryPointStrategy": "expand",


### PR DESCRIPTION
### Description

Removes the migrate exports from the typedoc references. 

I missed that migrate rolled out into it's own repo at the tail end of last year. We'll generate it there instead. 🙇 

### What to review

### Testing

If the PR generates without error.

### Notes for release

N/A
