### PR TITLE
fix: warn on doc type used as field type in array member too

### DIFF
--- a/packages/@sanity/schema/src/sanity/validation/types/array.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/array.ts
@@ -254,7 +254,28 @@ export default (typeDef: any, visitorContext: any) => {
 
   return {
     ...typeDef,
-    of: of.map(visitorContext.visit),
+    of: of.map((ofMember: any, index: number) => {
+      const visited = visitorContext.visit(ofMember, index)
+
+      if (
+        ofMember.type &&
+        typeof ofMember.type === 'string' &&
+        visitorContext.getType(ofMember.type)?.type === 'document'
+      ) {
+        return {
+          ...visited,
+          _problems: [
+            ...(visited._problems || []),
+            warning(
+              `The type "${ofMember.type}" is a document type and should not be used as a field type directly. Use a "reference" if you want to create a link to the document, or use "object" if you want to embed fields inline.`,
+              HELP_IDS.FIELD_TYPE_IS_DOCUMENT,
+            ),
+          ],
+        }
+      }
+
+      return visited
+    }),
     _problems: problems,
   }
 }

--- a/packages/@sanity/schema/test/validation/validation.test.ts
+++ b/packages/@sanity/schema/test/validation/validation.test.ts
@@ -345,6 +345,88 @@ describe('Validation test', () => {
       expect(warnings[0].message).toContain('person')
     })
 
+    test('warns when a nested field type references a document type', () => {
+      const schemaDef = [
+        {
+          name: 'person',
+          type: 'document',
+          fields: [{name: 'name', type: 'string'}],
+        },
+        {
+          name: 'otherType',
+          type: 'document',
+          fields: [
+            {
+              name: 'author',
+              type: 'person',
+            },
+            {
+              name: 'hero',
+              type: 'object',
+              fields: [
+                {
+                  name: 'legend',
+                  type: 'person',
+                },
+              ],
+            },
+            {
+              name: 'people',
+              type: 'array',
+              of: [
+                {
+                  name: 'person',
+                  type: 'person',
+                },
+                {
+                  name: 'objectPerson',
+                  type: 'object',
+                  fields: [
+                    {
+                      name: 'person',
+                      type: 'person',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      const validation = validateSchema(schemaDef)
+      const otherTypeValidation = validation.get('otherType')
+
+      expect(otherTypeValidation._problems).toHaveLength(0)
+
+      const authorField = otherTypeValidation.fields[0]
+      expect(authorField._problems).toHaveLength(1)
+      expect(authorField._problems[0]).toHaveProperty('helpId', 'schema-field-type-is-document')
+
+      const objectField = otherTypeValidation.fields.find((f: any) => f.name === 'hero')
+      expect(objectField._problems).toHaveLength(0)
+      expect(objectField.fields[0]._problems).toHaveLength(1)
+      expect(objectField.fields[0]._problems[0]).toHaveProperty(
+        'helpId',
+        'schema-field-type-is-document',
+      )
+
+      const arrayField = otherTypeValidation.fields.find((f: any) => f.name === 'people')
+      expect(arrayField._problems).toHaveLength(0)
+      expect(arrayField.of[0]._problems).toHaveLength(1)
+      expect(arrayField.of[0]._problems[0]).toHaveProperty(
+        'helpId',
+        'schema-field-type-is-document',
+      )
+
+      const arrayObjectField = arrayField.of[1].fields[0]
+      expect(arrayObjectField._problems).toHaveLength(1)
+      expect(arrayObjectField._problems[0]).toHaveProperty(
+        'helpId',
+        'schema-field-type-is-document',
+      )
+    })
+
     test('does not warn for object field types', () => {
       const schemaDef = [
         {


### PR DESCRIPTION
### Description

#12151 added warning for doc type used as field type in doc/object, but did not catch when an array member was of the document type. This PR adds that.

### What to review

The logic and the test.

### Notes for release

No note needed for this.