### PR TITLE
fix(sanity): migrate deprecated `motion` call to `motion.create`

### DIFF
--- a/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/IncomingReferenceDocument.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/IncomingReferenceDocument.tsx
@@ -15,7 +15,7 @@ import {IncomingReferencePreview} from '../../../../components/incomingReference
 import {usePaneRouter} from '../../../../components/paneRouter/usePaneRouter'
 import {structureLocaleNamespace} from '../../../../i18n'
 
-const FadeInFlex = motion(Flex)
+const FadeInFlex = motion.create(Flex)
 
 export const IncomingReferenceDocument = (props: {
   document: SanityDocument


### PR DESCRIPTION
### Description

Migrate deprecated `motion` call to `motion.create`. This prevents the warning `motion() is deprecated. Use motion.create() instead` being logged when the app runs.

### What to review

The changed function call.

### Testing

Verified that `FadeInFlex` still fades in.

Verified warning is no longer logged when running app in browser or CLI context.