### PR TITLE
test: increase watch mode test timeout

### DIFF
--- a/packages/@sanity/cli/test/typegen.test.ts
+++ b/packages/@sanity/cli/test/typegen.test.ts
@@ -275,7 +275,10 @@ describeCliTest('CLI: `sanity typegen`', () => {
               await runSanityLongRunningCommand(
                 studioName,
                 ['typegen', 'generate', '--watch', ...cmdArgs],
-                cmdOptions,
+                {
+                  ...cmdOptions,
+                  timeout: 25_000,
+                },
                 async (output) => {
                   // assert that it's doing the initial generation
                   expect(output.stderr).toContain('Successfully generated types')


### PR DESCRIPTION
### Description

Typegen watch mode test some times take too long to complete and is shut down after the default 10s timeout of the `runSanityLongRunningCommand` function. 

This PR explictly increases the timeout of the watch mode test to 25s – still within the default timeout of 30s in the suite.