### PR TITLE
fix: hiding publish action always on the published document

### DIFF
--- a/packages/sanity/src/structure/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/PublishAction.tsx
@@ -7,11 +7,13 @@ import {
   type DocumentActionComponent,
   getVersionFromId,
   InsufficientPermissionsMessage,
+  isPublishedPerspective,
   type TFunction,
   useCurrentUser,
   useDocumentOperation,
   useDocumentPairPermissions,
   useEditState,
+  usePerspective,
   useRelativeTime,
   useSyncState,
   useTranslation,
@@ -52,6 +54,7 @@ function AlreadyPublished({publishedAt}: {publishedAt: string}) {
 /** @internal */
 export const usePublishAction: DocumentActionComponent = (props) => {
   const {id, type, liveEdit, draft, published, release, version} = props
+  const {selectedPerspective} = usePerspective()
   const [publishState, setPublishState] = useState<
     {status: 'publishing'; publishRevision: string | undefined} | {status: 'published'} | null
   >(null)
@@ -171,6 +174,11 @@ export const usePublishAction: DocumentActionComponent = (props) => {
   ])
 
   return useMemo(() => {
+    if (isPublishedPerspective(selectedPerspective)) {
+      // never show publish action on a published document
+      return null
+    }
+
     if (release && version) {
       // release versions are not publishable by this action, they should be published as part of a release
       return null
@@ -242,6 +250,7 @@ export const usePublishAction: DocumentActionComponent = (props) => {
       onHandle: handle,
     }
   }, [
+    selectedPerspective,
     release,
     liveEdit,
     version,


### PR DESCRIPTION
### Description
There was a regressions (unable to track exactly down) that has caused the publish document action to show almost always on a published document.

There was a regression introduced in (https://github.com/sanity-io/sanity/pull/11598). That PR replaced the `isPublishedId(value._id)` check with `published && !draft && !version` to support version documents, but inadvertently removed the logic that hid the Publish button when viewing the Published perspective. 

This PR resolves this issue by returning `null` from the publish action when the document is already published.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue where published documents would show a publish action
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
