### PR TITLE
fix(docs): export IncomingReferenceOptions

### DIFF
--- a/packages/sanity/src/structure/index.ts
+++ b/packages/sanity/src/structure/index.ts
@@ -10,7 +10,10 @@ export type {
 export {ConfirmDeleteDialog, Pane, PaneContent, PaneLayout, usePaneRouter} from './components'
 export {defineIncomingReferenceDecoration} from './components/incomingReferencesDecoration/defineIncomingReferenceDecoration'
 export {isIncomingReferenceCreation} from './components/incomingReferencesDecoration/isIncomingReferenceCreation'
-export {type IncomingReferenceAction} from './components/incomingReferencesDecoration/types'
+export {
+  type IncomingReferenceAction,
+  type IncomingReferencesOptions,
+} from './components/incomingReferencesDecoration/types'
 export {structureLocaleNamespace, type StructureLocaleResourceKeys} from './i18n'
 export * from './panes/document'
 export {DocumentInspectorHeader} from './panes/document/documentInspector'


### PR DESCRIPTION
### Description

Exports `IncomingReferenceOptions` from the structure entrypoint.

The typedoc reference wasn't picking up the options for the new `defineIncomingReferenceDecoration`. Typedoc can only see types that are explicitly defined, and as we don't want to include everything (including internal types), we need to add it.

### What to review

### Testing

Confirm no conflict w/ existing build and type configs.

### Notes for release

N/A
