### PR TITLE
feat: add telemetry around the publish button state and time

### DIFF
--- a/packages/sanity/src/structure/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/PublishAction.tsx
@@ -166,11 +166,17 @@ export const usePublishAction: DocumentActionComponent = (props) => {
 
   useEffect(() => {
     if (!isWaitingToPublish) return undefined
-    telemetry.log(PublishButtonDisabledStart, {documentId: id})
+    telemetry.log(PublishButtonDisabledStart, {
+      documentId: id,
+      isRemoteEvent: editState?.transactionSyncLock?.enabled,
+    })
     return () => {
-      telemetry.log(PublishButtonDisabledComplete, {documentId: id})
+      telemetry.log(PublishButtonDisabledComplete, {
+        documentId: id,
+        isRemoteEvent: editState?.transactionSyncLock?.enabled,
+      })
     }
-  }, [isWaitingToPublish, telemetry, id])
+  }, [isWaitingToPublish, telemetry, id, editState?.transactionSyncLock?.enabled])
 
   const handle = useCallback(() => {
     telemetry.log(DocumentPublished, {

--- a/packages/sanity/src/structure/documentActions/__telemetry__/documentActions.telemetry.ts
+++ b/packages/sanity/src/structure/documentActions/__telemetry__/documentActions.telemetry.ts
@@ -11,6 +11,16 @@ interface DocumentPublishedInfo {
    */
   previouslyPublished: boolean
 }
+
+interface PublishButtonDisabledInfo {
+  /**
+   * Associated with a remote event
+   * Specifically with the condition editState?.transactionSyncLock?.enabled for publishing a document
+   * Which can be triggered by a remote event
+   */
+  isRemoteEvent: boolean
+}
+
 export const DocumentPublished = defineEvent<DocumentPublishedInfo>({
   name: 'Document Published',
   version: 1,
@@ -33,13 +43,15 @@ export const TimeToPublishComplete = defineEvent<DocumentIdInfo>({
   description: 'Logs when a publish operation completes (revision change confirmed)',
 })
 
-export const PublishButtonDisabledStart = defineEvent<DocumentIdInfo>({
+export const PublishButtonDisabledStart = defineEvent<DocumentIdInfo & PublishButtonDisabledInfo>({
   name: 'Publish Button Becomes Disabled - Started',
   version: 1,
   description: 'Logs when the publish button becomes disabled',
 })
 
-export const PublishButtonDisabledComplete = defineEvent<DocumentIdInfo>({
+export const PublishButtonDisabledComplete = defineEvent<
+  DocumentIdInfo & PublishButtonDisabledInfo
+>({
   name: 'Publish Button Becomes Disabled - Completed',
   version: 1,
   description: 'Logs when the publish button becomes enabled again',


### PR DESCRIPTION
### Description

Used log events instead of track specifically after asking about it from the telemetry folks!
The timing calculations will be done in the backend based on the documentId (another thing I asked about and double checked)

Just waiting on confirmation on naming conventions

Add telemetry for two use cases:
- How long it takes for the button to go from disabled to enabled
  - has a few exceptions: only tracking it when it makes sense based on if changes have been made (so it won't start tracking as soon as you open a document that as a disabled button for example) 
  - Identifies slow connections or longer periods of requests
- The time it takes to click of the publish until it successfully publishes

### What to review

Does this make sense? Am I missing something?

### Testing

N/A

### Notes for release

N/A