### PR TITLE
chore(ci): enable publishing & module-server uploads for v4

### DIFF
--- a/.github/workflows/release-v4.yml
+++ b/.github/workflows/release-v4.yml
@@ -111,8 +111,6 @@ jobs:
           echo "✅ npm authentication validated - using $EXPECTED_NPM_USER account"
 
       - name: Publish packages to npm
-        # todo: remove
-        if: false
         run: pnpm -r publish --tag maintenance-v4
         env:
           NPM_CONFIG_PROVENANCE: true
@@ -141,8 +139,6 @@ jobs:
         run: pnpm run build:bundle
 
       - name: Upload bundles to staging bucket
-        # todo remove
-        if: false
         env:
           GOOGLE_PROJECT_ID: ${{ secrets.GCS_STAGING_PROJECT_ID }}
           GCLOUD_SERVICE_KEY: ${{ secrets.GCS_STAGING_SERVICE_KEY }}
@@ -153,8 +149,6 @@ jobs:
         run: pnpm run build:bundle
 
       - name: Upload bundles to production bucket
-        # todo remove
-        if: false
         env:
           GOOGLE_PROJECT_ID: ${{ secrets.GCS_PRODUCTION_PROJECT_ID }}
           GCLOUD_SERVICE_KEY: ${{ secrets.GCS_PRODUCTION_SERVICE_KEY }}


### PR DESCRIPTION
### Description
Verified that the publish workflow for v4 succeeded in all steps except for:
- publish to npm
- upload to module server (staging)
- upload to module server (production)

See commit in d22c67da9dc8f711441662cd50272861c6484eef (now removed from `v4`) and the workflow run https://github.com/sanity-io/sanity/actions/runs/22142985702/job/64012193953

We should be good to enable these now.