### PR TITLE
feat(cli): add Gemini, Codex and Copilot CLIs to MCP configure

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -77,7 +77,8 @@
     "jsonc-parser": "^3.3.1",
     "pkg-dir": "^5.0.0",
     "prettier": "^3.8.1",
-    "semver": "^7.7.2"
+    "semver": "^7.7.2",
+    "smol-toml": "^1.6.0"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1158,6 +1158,9 @@ importers:
       semver:
         specifier: ^7.7.2
         version: 7.7.3
+      smol-toml:
+        specifier: ^1.6.0
+        version: 1.6.0
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -11848,6 +11851,10 @@ packages:
 
   smob@1.5.0:
     resolution: {integrity: sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==}
+
+  smol-toml@1.6.0:
+    resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
+    engines: {node: '>= 18'}
 
   snapdragon-node@2.1.1:
     resolution: {integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==}
@@ -24149,6 +24156,8 @@ snapshots:
   smart-buffer@4.2.0: {}
 
   smob@1.5.0: {}
+
+  smol-toml@1.6.0: {}
 
   snapdragon-node@2.1.1:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -40,6 +40,7 @@
     "BROWSER_ARGS",
     "BROWSER",
     "BUILD_NUMBER",
+    "CODEX_HOME",
     "EDITOR",
     // These should be passed through but not be used as cache keys since they are tokens
     "EFPS_SANITY_TOKEN_STAGING",


### PR DESCRIPTION
### Description
Adds Gemini CLI, GitHub Copilot CLI, and Codex CLI as supported editors in `sanity mcp configure` (and the MCP step in `sanity init`). Gemini and Copilot are detected via their global config directories and use the existing HTTP transport pattern.
Codex CLI is different — it stores config in TOML (`~/.codex/config.toml`) with a distinct server shape (`mcp_servers`, `http_headers` instead of `headers`). This required making the MCP config pipeline format-aware: a `format` discriminator on `EditorConfig` routes detection and writing through either the existing JSONC path or a new TOML path powered by `smol-toml` (parse, merge, stringify — no hand-rolled serialization). The JSONC path is completely unchanged.
GitHub Copilot CLI additionally includes `tools: ["*"]` in its server config, which is required for global MCP installs in that client.
### What to review
- `editorConfigs.ts` — three new entries plus a `format` field on the interface. Codex uses `http_headers.Authorization` (not `headers`) and respects `CODEX_HOME`.
- `editors.ts` — `parseConfig` now accepts a format parameter; TOML branch uses `smol-toml`, JSONC branch is untouched.
- `mcp.ts` — `writeMCPConfig` branches on format for the write path. TOML does parse/merge/stringify; JSONC keeps existing `jsonc-parser` modify/applyEdits flow.
- `turbo.json` — `CODEX_HOME` added to `globalPassThroughEnv`.
- New dep: `smol-toml` in `@sanity/cli`.
### Testing
No unit tests in this package for MCP editor configs. All three editors were manually verified on macOS — detection and config file writing work as expected. The equivalent change in the new CLI repo includes full unit tests (Codex TOML write, `CODEX_HOME` override, unparseable TOML skip behavior).
### Notes for release
Users with Gemini CLI, GitHub Copilot CLI, or Codex CLI installed will now see them offered during `sanity mcp configure` and `sanity init`.