### PR TITLE
fix(sanity): publishing versions using `PublishAction`

### DIFF
--- a/e2e/tests/releases/utils/__fixtures__/documents.ts
+++ b/e2e/tests/releases/utils/__fixtures__/documents.ts
@@ -16,3 +16,8 @@ export const speciesDocumentNameUndecided = {
   _type: 'species',
   name: 'Undecided A',
 }
+
+export const speciesDocumentNameAnonymousVersion = {
+  _type: 'species',
+  name: 'Anonymous version',
+}

--- a/packages/sanity/src/structure/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/PublishAction.tsx
@@ -65,10 +65,10 @@ export const usePublishAction: DocumentActionComponent = (props) => {
   const {changesOpen, documentId, documentType, value} = useDocumentPane()
   const validationStatus = useValidationStatus(value._id, type, !release)
   const syncState = useSyncState(id, type)
-  const editState = useEditState(documentId, documentType)
+  const editState = useEditState(documentId, documentType, 'default', bundleId)
   const {t} = useTranslation(structureLocaleNamespace)
 
-  const revision = (editState?.draft || editState?.published || {})._rev
+  const revision = (editState?.version || editState?.draft || editState?.published || {})._rev
   const toast = useToast()
 
   const hasValidationErrors = validationStatus.validation.some(isValidationErrorMarker)


### PR DESCRIPTION
### Description

This branch fixes a bug caused by `useEditState` in `PublishAction` not acknowledging version documents. This caused the action to get stuck in the validation state, because the revision id—which comes from `useEditState`—always reflected the published or draft version, and not the version being published.

### What to review

Changes to `PublishAction`.

### Testing

- Added E2E test to ensure publish document action can publish anonymous versions.
- It's possible to use the publish action to publish draft version _and_ anonymous versions (e.g. those created by Content Agent).

### Notes for release

Fixes an issue causing document action to hang in "Validating document…" state when attempting to publish versions created by Content Agent.