### PR TITLE
chore(ci): fix release PR merged condition

### DIFF
--- a/.github/workflows/check-inflight-release.yml
+++ b/.github/workflows/check-inflight-release.yml
@@ -14,8 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     if: |
-      github.head_ref == 'ci/release-main' &&
-      (github.event.action == 'ready_for_review' || github.event.action == 'converted_to_draft' || github.event.action == 'closed')
+      (github.head_ref == 'ci/release-main' &&
+        (github.event.action == 'ready_for_review' || github.event.action == 'converted_to_draft'))
+      || (github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'ci/release-main')
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup


### PR DESCRIPTION
### Description
The "check for inflight release" workflow should run when the Release PR is merged. The previous condition for detecting a release PR wasn't working as expected, since `github.head_ref` will always be `main`. This PR changes the condition to instead check that the PR was merged and that the source branch matches the branch from which the release PR was opened (`ci/release-main`).

### What to review
Makes sense?

### Testing


### Notes for release
n/a