### PR TITLE
ci: fix missing `main` when comparing staged changes

### DIFF
--- a/.github/workflows/lintPr.yml
+++ b/.github/workflows/lintPr.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # needed for the --affected flag in turbo to work correctly
+      - name: Ensure local main ref exists for turbo --affected
+        run: git fetch origin main:main
       - uses: ./.github/actions/setup
 
       - name: Oxlint files


### PR DESCRIPTION
### Description

The lint workflow tries to use turbo's "affected" flag, but is missing `main`, which means it fails with something like:

```
Run pnpm turbo run lint --affected --output-logs=full --continue -- -f gha
Failed to resolve base ref 'main' from GitHub Actions event: Git error: fatal: ambiguous argument 'main': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

This slows down executions and creates log noise.

### What to review

Lint workflow no longer shows described error

### Testing

Let workflow run and see if it fixes the issue

### Notes for release

N/A: Internal only