### PR TITLE
fix(core): prepare for PTE v6 render component types

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -23,7 +23,6 @@ import {css, styled} from 'styled-components'
 import {TooltipDelayGroupProvider} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
 import {useFormBuilder} from '../../useFormBuilder'
-import {usePortableTextMemberSchemaTypes} from './contexts/PortableTextMemberSchemaTypes'
 import {EditableCard, EditableWrapper, Root, Scroller, ToolbarCard} from './Editor.styles'
 import {useScrollSelectionIntoView} from './hooks/useScrollSelectionIntoView'
 import {useSpellCheck} from './hooks/useSpellCheck'
@@ -126,45 +125,17 @@ export function Editor(props: EditorProps): ReactNode {
     [t],
   )
   const spellCheck = useSpellCheck()
-  const schemaTypes = usePortableTextMemberSchemaTypes()
+  const renderDecorator = useCallback((decoratorProps: BlockDecoratorRenderProps) => {
+    return <Decorator {...decoratorProps} />
+  }, [])
 
-  const renderDecorator = useCallback(
-    (decoratorProps: BlockDecoratorRenderProps) => {
-      const sanitySchemaType = schemaTypes.decorators.find(
-        (type) => type.value === decoratorProps.value,
-      )
-      if (!sanitySchemaType) {
-        // This should never happen
-        throw new Error(`Could not find Sanity schema type for decorator: ${decoratorProps.value}`)
-      }
-      return <Decorator {...decoratorProps} schemaType={sanitySchemaType} />
-    },
-    [schemaTypes.decorators],
-  )
+  const renderStyle = useCallback((styleProps: BlockStyleRenderProps) => {
+    return <Style {...styleProps} />
+  }, [])
 
-  const renderStyle = useCallback(
-    (styleProps: BlockStyleRenderProps) => {
-      const sanitySchemaType = schemaTypes.styles.find((type) => type.value === styleProps.value)
-      if (!sanitySchemaType) {
-        // This should never happen
-        throw new Error(`Could not find Sanity schema type for style: ${styleProps.value}`)
-      }
-      return <Style {...styleProps} schemaType={sanitySchemaType} />
-    },
-    [schemaTypes.styles],
-  )
-
-  const renderListItem = useCallback(
-    (listItemProps: BlockListItemRenderProps) => {
-      const sanitySchemaType = schemaTypes.lists.find((type) => type.value === listItemProps.value)
-      if (!sanitySchemaType) {
-        // This should never happen
-        throw new Error(`Could not find Sanity schema type for list item: ${listItemProps.value}`)
-      }
-      return <ListItem {...listItemProps} schemaType={sanitySchemaType} />
-    },
-    [schemaTypes.lists],
-  )
+  const renderListItem = useCallback((listItemProps: BlockListItemRenderProps) => {
+    return <ListItem {...listItemProps} />
+  }, [])
 
   const scrollSelectionIntoView = useScrollSelectionIntoView(scrollElement)
 

--- a/packages/sanity/src/core/form/inputs/PortableText/text/Decorator.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/Decorator.tsx
@@ -4,6 +4,7 @@ import {useCallback, useMemo} from 'react'
 import {css, styled} from 'styled-components'
 
 import {type BlockDecoratorProps} from '../../../types'
+import {usePortableTextMemberSchemaTypes} from '../contexts/PortableTextMemberSchemaTypes'
 import {TEXT_DECORATOR_TAGS} from './constants'
 
 const Root = styled.span(({theme}: {theme: Theme}) => {
@@ -20,8 +21,14 @@ const Root = styled.span(({theme}: {theme: Theme}) => {
 
 export function Decorator(props: BlockDecoratorRenderProps) {
   const {value, focused, selected, children, schemaType} = props
+  const schemaTypes = usePortableTextMemberSchemaTypes()
+  const sanitySchemaType = schemaTypes.decorators.find((type) => type.value === schemaType.value)
+  if (!sanitySchemaType) {
+    // This should never happen
+    throw new Error(`Could not find Sanity schema type for decorator: ${schemaType.value}`)
+  }
   const tag = TEXT_DECORATOR_TAGS[value]
-  const CustomComponent = schemaType.component
+  const CustomComponent = sanitySchemaType.component
   const DefaultComponent = useCallback(
     (defaultComponentProps: BlockDecoratorProps) => {
       return (
@@ -36,9 +43,9 @@ export function Decorator(props: BlockDecoratorRenderProps) {
     const componentProps = {
       focused,
       renderDefault: DefaultComponent,
-      schemaType,
+      schemaType: sanitySchemaType,
       selected,
-      title: schemaType.title,
+      title: sanitySchemaType.title,
       value,
     }
     return CustomComponent ? (
@@ -47,5 +54,5 @@ export function Decorator(props: BlockDecoratorRenderProps) {
       // eslint-disable-next-line react-hooks/static-components -- this is intentional and how the middleware components has to work
       <DefaultComponent {...componentProps}>{children}</DefaultComponent>
     )
-  }, [CustomComponent, DefaultComponent, children, focused, schemaType, selected, value])
+  }, [CustomComponent, DefaultComponent, children, focused, sanitySchemaType, selected, value])
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/text/ListItem.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/ListItem.tsx
@@ -2,6 +2,7 @@ import {type BlockListItemRenderProps} from '@portabletext/editor'
 import {useMemo} from 'react'
 
 import {type BlockListItemProps} from '../../../types'
+import {usePortableTextMemberSchemaTypes} from '../contexts/PortableTextMemberSchemaTypes'
 
 const DefaultComponent = (dProps: BlockListItemProps) => {
   return <>{dProps.children}</>
@@ -9,14 +10,20 @@ const DefaultComponent = (dProps: BlockListItemProps) => {
 
 export const ListItem = (props: BlockListItemRenderProps) => {
   const {block, children, schemaType, selected, focused, level, value} = props
-  const {title, component: CustomComponent} = schemaType
+  const schemaTypes = usePortableTextMemberSchemaTypes()
+  const sanitySchemaType = schemaTypes.lists.find((type) => type.value === schemaType.value)
+  if (!sanitySchemaType) {
+    // This should never happen
+    throw new Error(`Could not find Sanity schema type for list item: ${schemaType.value}`)
+  }
+  const {title, component: CustomComponent} = sanitySchemaType
   return useMemo(() => {
     const componentProps = {
       block,
       focused,
       level,
       renderDefault: DefaultComponent,
-      schemaType,
+      schemaType: sanitySchemaType,
       selected,
       title,
       value,
@@ -26,5 +33,5 @@ export const ListItem = (props: BlockListItemRenderProps) => {
     ) : (
       <DefaultComponent {...componentProps}>{children}</DefaultComponent>
     )
-  }, [CustomComponent, block, children, focused, level, schemaType, selected, title, value])
+  }, [CustomComponent, block, children, focused, level, sanitySchemaType, selected, title, value])
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/text/Style.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/Style.tsx
@@ -2,10 +2,17 @@ import {type BlockStyleRenderProps} from '@portabletext/editor'
 import {useCallback, useMemo} from 'react'
 
 import {type BlockStyleProps} from '../../../types'
+import {usePortableTextMemberSchemaTypes} from '../contexts/PortableTextMemberSchemaTypes'
 import {Normal as FallbackComponent, TEXT_STYLES, TextContainer} from './textStyles'
 
 export const Style = (props: BlockStyleRenderProps) => {
   const {block, focused, children, selected, schemaType} = props
+  const schemaTypes = usePortableTextMemberSchemaTypes()
+  const sanitySchemaType = schemaTypes.styles.find((type) => type.value === schemaType.value)
+  if (!sanitySchemaType) {
+    // This should never happen
+    throw new Error(`Could not find Sanity schema type for style: ${schemaType.value}`)
+  }
   const DefaultComponentWithFallback = useMemo(
     () =>
       (block.style && TEXT_STYLES[block.style] ? TEXT_STYLES[block.style] : TEXT_STYLES[0]) ||
@@ -27,13 +34,13 @@ export const Style = (props: BlockStyleRenderProps) => {
   )
 
   return useMemo(() => {
-    const CustomComponent = schemaType.component
-    const {title, value} = schemaType
+    const CustomComponent = sanitySchemaType.component
+    const {title, value} = sanitySchemaType
     const componentProps = {
       block,
       focused,
       renderDefault: DefaultComponent,
-      schemaType,
+      schemaType: sanitySchemaType,
       selected,
       title,
       value,
@@ -44,5 +51,5 @@ export const Style = (props: BlockStyleRenderProps) => {
       // eslint-disable-next-line react-hooks/static-components -- this is intentional and how the middleware components has to work
       <DefaultComponent {...componentProps}>{children}</DefaultComponent>
     )
-  }, [DefaultComponent, block, children, focused, schemaType, selected])
+  }, [DefaultComponent, block, children, focused, sanitySchemaType, selected])
 }


### PR DESCRIPTION
Third in a series of PRs preparing Studio for [portabletext/editor#2136](https://github.com/portabletext/editor/pull/2136), which removes `@sanity/schema` and `@sanity/types` dependencies from `@portabletext/editor`.

- **PR #11920**: introduced `usePortableTextMemberSchemaTypes()` and applied the internal lookup pattern to Annotation, BlockObject, InlineObject, and TextBlock
- **PR #12181**: switched to `schemaDefinition` API, Studio-owned paste types, HTML paste behavior
- **This PR**: completes the pattern for Decorator, Style, and ListItem

PR #11920 placed the Sanity type lookup for Decorator, Style, and ListItem in the wrong spot: Editor.tsx render callbacks resolved the Sanity type and passed it down as a prop override. The components should own their own lookup, same as Annotation and the other components do. This PR moves the lookup into the components themselves.

**Move Sanity type lookup into render components**

Each component now calls `usePortableTextMemberSchemaTypes()` internally and finds the Sanity type by `props.schemaType.value`, using the editor's schema type as the bridge to the full Sanity type:

- `Decorator.tsx`: looks up decorator by `schemaType.value`, reads `component` and `title` from the resolved Sanity type
- `Style.tsx`: same pattern
- `ListItem.tsx`: same pattern
- `Editor.tsx`: render callbacks simplified to pass props through unchanged, `usePortableTextMemberSchemaTypes()` import removed

No behavioral change with PTE v5.

See #12214 for the version bump that tests these changes against PTE 6.0.0-canary.0.

### What to review

The pattern should match Annotation, BlockObject, InlineObject, and TextBlock from PR #11920. Are there other render components that still depend on Sanity-specific properties from the editor's render props?

### Testing

Types check clean against PTE v5. No functional change.

### Notes for release

N/A: Internal preparation for upcoming `@portabletext/editor` v6.