### PR TITLE
chore(ci): checkout main if needed when comparing staged changes

### DIFF
--- a/.github/workflows/lintPr.yml
+++ b/.github/workflows/lintPr.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0 # needed for the --affected flag in turbo to work correctly
       - name: Ensure local main ref exists for turbo --affected
-        run: git fetch origin main:main
+        run: git checkout -B main origin/main && git switch -
       - uses: ./.github/actions/setup
 
       - name: Oxlint files


### PR DESCRIPTION
### Descriptions

Small follow-up fix from #12209

git refuses to run `git fetch origin main:main` when `main` is the checked out branch, currently causing the lintPR workflow to fail in `main`:
```
fatal: refusing to fetch into branch 'refs/heads/main' checked out at '/home/runner/work/sanity/sanity'
```

This switches to using the same technique we use when creating the Release PR:

https://github.com/sanity-io/sanity/blob/5855068d96277575ea72a0b08a18c4fdbfd87aad/.github/workflows/create-release-pr.yml#L32-L33

### What to review

- I'm not even sure if we need to run this in workflow in `main` at all, but focusing on making CI pass for now.

### Testing
I guess merging to main and see if it works?

### Notes for release

n/a – internal