### PR TITLE
chore(ci): skip lintPr workflow in main

### DIFF
--- a/.github/workflows/lintPr.yml
+++ b/.github/workflows/lintPr.yml
@@ -3,9 +3,6 @@ name: Lint PR
 on:
   # Build on pushes branches that have a PR (including drafts)
   pull_request:
-  # Build on commits pushed to branches without a PR if it's in the allowlist
-  push:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}


### PR DESCRIPTION
### Description
We don't allow direct push to main, so don't think there's any good reason for running the lintPr workflow in `main`

### What to review
- Makes sense?

### Testing
Merge and see that it's skipped in main

### Notes for release
n/a – internal