### PR TITLE
fix(core): move EditorChange type ownership from PTE to Studio

### DIFF
--- a/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
+++ b/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable max-statements */
 /* eslint-disable max-nested-callbacks */
 import {
-  type EditorChange,
   type EditorSelection,
   type PortableTextBlock,
   PortableTextEditor,
@@ -16,7 +15,7 @@ import {debounce, isEqual} from 'lodash-es'
 import {AnimatePresence} from 'motion/react'
 import {memo, startTransition, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 
-import {type PortableTextInputProps, useFieldActions} from '../../../../form'
+import {type EditorChange, type PortableTextInputProps, useFieldActions} from '../../../../form'
 import {useCurrentUser} from '../../../../store'
 import {useAddonDataset} from '../../../../studio/addonDataset/useAddonDataset'
 import {CommentInlineHighlightSpan} from '../../../components'

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -1,9 +1,7 @@
 import {
-  type EditorChange,
   type EditorEmittedEvent,
   EditorProvider,
   type EditorSelection,
-  type InvalidValue,
   type Patch,
   PortableTextEditor,
   type RangeDecoration,
@@ -38,7 +36,7 @@ import {
 import {SANITY_PATCH_TYPE} from '../../patch'
 import {type ArrayOfObjectsItemMember, type ObjectFormNode} from '../../store'
 import {immutableReconcile} from '../../store/utils/immutableReconcile'
-import {type PortableTextInputProps} from '../../types'
+import {type EditorChange, type PortableTextInputProps} from '../../types'
 import {Compositor} from './Compositor'
 import {useFullscreenPTE} from './contexts/fullscreen'
 import {PortableTextMarkersProvider} from './contexts/PortableTextMarkers'
@@ -147,7 +145,10 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
     })
 
   const [ignoreValidationError, setIgnoreValidationError] = useState(false)
-  const [invalidValue, setInvalidValue] = useState<InvalidValue | null>(null)
+  const [invalidValue, setInvalidValue] = useState<Extract<
+    EditorChange,
+    {type: 'invalidValue'}
+  > | null>(null)
   const [isActive, setIsActive] = useState(initialActive ?? true)
   const [hasFocusWithin, setHasFocusWithin] = useState(false)
   const [ready, setReady] = useState(false)

--- a/packages/sanity/src/core/form/types/inputProps.ts
+++ b/packages/sanity/src/core/form/types/inputProps.ts
@@ -1,9 +1,10 @@
 import {
-  type EditorChange,
   type EditorSelection,
   type HotkeyOptions,
+  type InvalidValueResolution,
   type OnCopyFn,
   type OnPasteResultOrPromise,
+  type Patch,
   type PasteData as EditorPasteData,
   type PortableTextEditor,
   type RangeDecoration,
@@ -28,6 +29,7 @@ import {
 } from '@sanity/types'
 import {
   type ComponentType,
+  type FocusEvent as ReactFocusEvent,
   type FocusEventHandler,
   type FormEventHandler,
   type MutableRefObject,
@@ -629,3 +631,33 @@ export type PasteData = Omit<EditorPasteData, 'schemaTypes'> & {
  * all cases. Always return plain `undefined` if possible.
  */
 export type OnPasteFn = (data: PasteData) => OnPasteResultOrPromise
+
+/**
+ * Studio-owned change types emitted by the Portable Text editor.
+ *
+ * These types mirror the editor's internal event types but are owned by Studio
+ * to decouple Studio's public callback interface from the editor's internals.
+ * The `EditorChangePlugin` in `PortableTextInput.tsx` translates
+ * `EditorEmittedEvent`s into these change types.
+ *
+ * @beta
+ */
+export type EditorChange =
+  | {type: 'blur'; event: ReactFocusEvent<HTMLDivElement, Element>}
+  | {type: 'error'; name: string; level: 'warning' | 'error'; description: string; data?: unknown}
+  | {type: 'focus'; event: ReactFocusEvent<HTMLDivElement, Element>}
+  | {
+      type: 'invalidValue'
+      resolution: InvalidValueResolution | null
+      value: PortableTextBlock[] | undefined
+    }
+  | {type: 'loading'; isLoading: boolean}
+  | {type: 'mutation'; patches: Patch[]; snapshot: PortableTextBlock[] | undefined}
+  | {type: 'patch'; patch: Patch}
+  | {type: 'ready'}
+  | {type: 'connection'; value: 'online' | 'offline'}
+  | {type: 'redo'; patches: Patch[]; snapshot: PortableTextBlock[] | undefined}
+  | {type: 'selection'; selection: EditorSelection}
+  | {type: 'undo'; patches: Patch[]; snapshot: PortableTextBlock[] | undefined}
+  | {type: 'unset'; previousValue: PortableTextBlock[]}
+  | {type: 'value'; value: PortableTextBlock[] | undefined}


### PR DESCRIPTION
### Description

Move the `EditorChange` type from `@portabletext/editor` to a Studio-local definition in `inputProps.ts`. Same pattern as `OnPasteFn` in #12181.

The Portable Text editor is removing the old `PortableTextEditor` component and its `change$` observable in v6. `EditorChange` was the type produced by that observable. Studio already translates `EditorEmittedEvent` into `EditorChange` via `EditorChangePlugin`, so Studio should own the type.

No behavioral changes. Not all variants (like `'undo'`) are actively produced by the `EditorChangePlugin` though.  But the full set is kept because removing variants could break Studio users who pattern-match on them.

### What to review

- `EditorChange` type at the bottom of `inputProps.ts` matches the original PTE type exactly (all 14 variants)
- `Extract<EditorChange, {type: 'invalidValue'}>` pattern for the `invalidValue` state type
- Import paths resolve across the three files

### Testing

Type-only change. No runtime behavior changes.