### PR TITLE
fix(structure): copy document URL respects content releases

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -435,13 +435,22 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
 
       if (item.action === 'copy-document-url' && navigator) {
         telemetry.log(DocumentURLCopied)
-        // Chose to copy the user's current URL instead of
-        // the document's edit intent link because
-        // of bugs when resolving a document that has
-        // multiple access paths within Structure
+
+        // Get scheduledDraft from pane params if present
+        const scheduledDraft = params.scheduledDraft
+
+        // Build the intent path with release context
+        // - For content releases: add perspective as search param
+        // - For scheduled drafts: add scheduledDraft as intent param
+        const perspectiveParam =
+          selectedReleaseId && !scheduledDraft ? `?perspective=${selectedReleaseId}` : ''
+        const scheduledDraftParam = scheduledDraft ? `;scheduledDraft=${scheduledDraft}` : ''
+
         const copyUrl = buildStudioUrl({
-          coreUi: (url) => `${url}/intent/edit/id=${documentId};type=${documentType}`,
+          coreUi: (url) =>
+            `${url}/intent/edit/id=${documentId};type=${documentType}${scheduledDraftParam}${perspectiveParam}`,
         })
+
         await navigator.clipboard.writeText(copyUrl)
         pushToast({
           id: 'copy-document-url',
@@ -499,6 +508,8 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
       diffViewRouter,
       value._id,
       toggleInlineChanges,
+      params,
+      selectedReleaseId,
     ],
   )
 


### PR DESCRIPTION
### Description

When copying a document URL via the "Copy document URL" menu action, the URL now includes the current perspective/release context. Previously, the copied URL always opened the document in the default perspective, even when the user was viewing a content release or scheduled draft.

Related issue: https://linear.app/sanity/issue/SAPP-3550

**Changes:**
- Content releases: URL now includes `?perspective=rReleaseId` search param
- Scheduled drafts: URL now includes `scheduledDraft=rId` as intent param
- Regular drafts: No change (default behavior preserved)

### What to review

1. Review the changes in `DocumentPaneProvider.tsx` - specifically the `handleMenuAction` function's `copy-document-url` case
2. The pattern matches the existing implementation in `CommentsWrapper.tsx` for comment links
3. Verify the dependency array update is correct

### Testing

Manual testing steps:
1. Open a document in a content release
2. Click the "Copy document URL" action
3. Verify the copied URL includes the perspective parameter
4. Open the URL in a new tab and verify it opens in the same release

For scheduled drafts:
1. Open a document as a scheduled draft
2. Copy the URL
3. Verify it includes the scheduledDraft intent param

No automated tests added - this follows the same pattern as the existing `CommentsWrapper.tsx` implementation which has comprehensive tests in `CommentsWrapper.test.tsx`.

### Notes for release

Copy document URL now preserves the current content release context, allowing users to share links that open documents in the same release they were viewing.