### PR TITLE
ci: fix e2e ui workflow

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -17,7 +17,12 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: pnpm
+      - run: pnpm install
       - name: Patch increment version in package.json
         id: npm-version
         shell: bash


### PR DESCRIPTION
### Description

The `prepare` job checks out the calling UI repo (no `repository:` specified), then tries to use `./.github/actions/setup` which only exists in the `sanity` repo. This fails when using it from the `sanity-io/ui` repo.

The fix replaces the composite action reference (`./.github/actions/setup`) with inline setup steps in the prepare job:

1. pnpm/action-setup@v4 - installs pnpm
2. actions/setup-node@v6 - installs Node with pnpm cache
3. pnpm install - installs dependencies (using full install, not `--ignore-scripts`, since this is the UI repo's own package)

The other jobs (`build-cli`, `install`, `playwright-test`, `merge-reports`) are fine as-is - they explicitly check out `sanity-io/sanity` first, so `./.github/actions/setup` resolves correctly.

### What to review

Workflow looks good?

### Testing

Not quite sure how to test this one without merging, but seems pretty safe.

### Notes for release

N/A