### PR TITLE
perf: lazily build ui theme

### DIFF
--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -79,7 +79,14 @@ export * from './studio'
 export {DEFAULT_STUDIO_CLIENT_OPTIONS} from './studioClient'
 export {IsLastPaneProvider, useDocumentPreviewValues} from './tasks'
 export * from './templates'
-export * from './theme'
+export {
+  buildLegacyTheme,
+  defaultTheme,
+  type LegacyThemeProps,
+  type LegacyThemeTints,
+  type StudioTheme,
+  type StudioThemeColorSchemeKey,
+} from './theme'
 export * from './user-color'
 export * from './util'
 export {

--- a/packages/sanity/src/core/studio/StudioThemeProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioThemeProvider.tsx
@@ -3,7 +3,7 @@ import {type RootTheme} from '@sanity/ui/theme'
 import {type ReactNode} from 'react'
 import {ColorSchemeSetValueContext, ColorSchemeValueContext} from 'sanity/_singletons'
 
-import {defaultTheme, type StudioTheme} from '../theme'
+import {getDefaultTheme, type StudioTheme} from '../theme'
 import {useActiveWorkspace} from './activeWorkspaceMatcher'
 
 interface StudioThemeProviderProps {
@@ -17,6 +17,7 @@ interface StudioThemeProviderProps {
 const isThemerTheme = (theme: StudioTheme): boolean => theme.__themer === true
 
 function getThemeValues(theme: StudioTheme): RootTheme {
+  const defaultTheme = getDefaultTheme()
   return {
     ...defaultTheme,
     v2: theme.v2,

--- a/packages/sanity/src/core/theme/__tests__/defaultTheme.test.ts
+++ b/packages/sanity/src/core/theme/__tests__/defaultTheme.test.ts
@@ -1,0 +1,48 @@
+import {describe, expect, it} from 'vitest'
+
+import {defaultTheme, getDefaultTheme} from '../index'
+
+describe('defaultTheme', () => {
+  it('has expected top-level properties', () => {
+    expect(defaultTheme).toHaveProperty('color')
+    expect(defaultTheme).toHaveProperty('fonts')
+    expect(defaultTheme).toHaveProperty('color')
+    expect(defaultTheme).toHaveProperty('container')
+    expect(defaultTheme).toHaveProperty('media')
+    expect(defaultTheme).toHaveProperty('v2')
+  })
+
+  it('supports property enumeration', () => {
+    const keys = Object.keys(defaultTheme)
+    expect(keys).toContain('color')
+    expect(keys).toContain('fonts')
+    expect(keys).toContain('v2')
+  })
+
+  it('supports the "in" operator', () => {
+    expect('color' in defaultTheme).toBe(true)
+    expect('fonts' in defaultTheme).toBe(true)
+    expect('nonExistentProp' in defaultTheme).toBe(false)
+  })
+
+  it('supports Object.getOwnPropertyDescriptor', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(defaultTheme, 'color')
+    expect(descriptor).toBeDefined()
+    expect(descriptor?.value).toBeDefined()
+  })
+
+  it('returns the same value as getDefaultTheme()', () => {
+    const direct = getDefaultTheme()
+    expect(defaultTheme.color).toBe(direct.color)
+    expect(defaultTheme.fonts).toBe(direct.fonts)
+    expect(defaultTheme.v2).toBe(direct.v2)
+  })
+})
+
+describe('getDefaultTheme', () => {
+  it('caches the theme instance', () => {
+    const first = getDefaultTheme()
+    const second = getDefaultTheme()
+    expect(first).toBe(second)
+  })
+})

--- a/packages/sanity/src/core/theme/index.ts
+++ b/packages/sanity/src/core/theme/index.ts
@@ -4,8 +4,37 @@ export {buildLegacyTheme} from './_legacy/theme'
 export {type LegacyThemeProps, type LegacyThemeTints} from './_legacy/types'
 export {type StudioTheme, type StudioThemeColorSchemeKey} from './types'
 
+let _defaultTheme: RootTheme | undefined
+
 /**
  * @internal
  * @deprecated Will be removed in upcoming major version
  * */
-export const defaultTheme: RootTheme = buildTheme()
+export function getDefaultTheme(): RootTheme {
+  if (!_defaultTheme) {
+    _defaultTheme = buildTheme()
+  }
+  return _defaultTheme
+}
+
+/**
+ * The default theme. This is a proxy to the default theme, in order to lazily initialize it
+ * on use and not pay the cost of building the theme on module load.
+ *
+ * @internal
+ * @deprecated Will be removed in upcoming major version.
+ * */
+export const defaultTheme: RootTheme = /* @__PURE__ */ new Proxy({} as RootTheme, {
+  get(_target, prop, receiver) {
+    return Reflect.get(getDefaultTheme(), prop, receiver)
+  },
+  ownKeys() {
+    return Reflect.ownKeys(getDefaultTheme())
+  },
+  getOwnPropertyDescriptor(_target, prop) {
+    return Object.getOwnPropertyDescriptor(getDefaultTheme(), prop)
+  },
+  has(_target, prop) {
+    return prop in getDefaultTheme()
+  },
+})


### PR DESCRIPTION
### Description

`buildTheme()` takes ~250ms on my M4 Pro MacBook. There's work in progress to address this, both by [lazily computing more things](https://github.com/sanity-io/ui/pull/2177), as well as a larger architectural change.

Regardless of that work, I feel like it makes sense for us to not do this computation at _module load time_, but rather when accessed/needed. This PR changes the (deprecated) `defaultTheme` to be lazy (through a proxy, because it's a const export), and also adds a `getDefaultTheme()` method which is used and should be preferred internally.

In order to not export this new method, I also changes the theme exports to be more specific - only exporting what was already exported instead of blindly exporting everything.

### What to review

Studio still works as expected, theme can still be imported/accessed through `defaultTheme`.

### Testing

Added new tests for the constant (because it's a proxy), as well as the `getDefaultTheme()` (even though its internal)

### Notes for release

N/A
