### PR TITLE
fix: update revert dialog position

### DIFF
--- a/packages/sanity/src/core/field/diff/components/RevertChangesConfirmDialog.tsx
+++ b/packages/sanity/src/core/field/diff/components/RevertChangesConfirmDialog.tsx
@@ -39,8 +39,8 @@ export function RevertChangesConfirmDialog({
       open={open}
       referenceElement={referenceElement}
       tone="critical"
-      placement="left"
-      fallbackPlacements={['left', 'left-start', 'left-end']}
+      placement="bottom"
+      fallbackPlacements={['bottom', 'bottom-start', 'bottom-end']}
     />
   )
 }


### PR DESCRIPTION
### Description
Fixes https://github.com/sanity-io/sanity/issues/4677

Changes the dialog position from `left` which could be offscreen to `bottom`
| Before | Now |
|--------|--------|
| <img width="302" height="746" alt="Screenshot 2026-02-26 at 15 51 55" src="https://github.com/user-attachments/assets/be604c8a-8c8b-4a88-8819-ffc5d5edd842" />| <img width="303" height="751" alt="Screenshot 2026-02-26 at 15 51 24" src="https://github.com/user-attachments/assets/414530c2-3cc7-471b-b1a8-2d0f13766c89" /> | 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
