### PR TITLE
feat(sanity): add `introspectSchema`

### DIFF
--- a/packages/sanity/src/core/divergence/utils/flatten.ts
+++ b/packages/sanity/src/core/divergence/utils/flatten.ts
@@ -1,4 +1,10 @@
-import {isKeyedObject, type KeyedObject, type KeyedSegment, type Path} from '@sanity/types'
+import {
+  isKeyedObject,
+  type KeyedObject,
+  type KeyedSegment,
+  type Path,
+  type PathSegment,
+} from '@sanity/types'
 import {toString} from '@sanity/util/paths'
 
 import {isRecord} from '../../util/isRecord'
@@ -239,4 +245,19 @@ function readType(value: unknown): string {
   }
 
   return typeof value
+}
+
+/**
+ * @internal
+ */
+export function normalizePathSegment(
+  segment: PathSegment | PathSegmentWithType,
+): PathSegmentWithType | {segment: PathSegment; type?: never} {
+  if (typeof segment === 'object' && 'type' in segment) {
+    return segment
+  }
+
+  return {
+    segment,
+  }
 }

--- a/packages/sanity/src/core/divergence/utils/introspectSchema.test.ts
+++ b/packages/sanity/src/core/divergence/utils/introspectSchema.test.ts
@@ -1,0 +1,221 @@
+import {Schema} from '@sanity/schema'
+import {defineType, type ObjectSchemaType} from '@sanity/types'
+import {expect, it} from 'vitest'
+
+import {introspectSchema} from './introspectSchema'
+
+const bookSchemaType = Schema.compile({
+  types: [
+    defineType({
+      name: 'store',
+      type: 'object',
+      fields: [
+        {
+          name: 'address',
+          title: 'Address',
+          type: 'string',
+        },
+      ],
+    }),
+    defineType({
+      name: 'book',
+      type: 'document',
+      fields: [
+        {
+          name: 'title',
+          title: 'Title',
+          type: 'string',
+        },
+        {
+          name: 'translations',
+          title: 'Translations',
+          type: 'object',
+          fields: [
+            {name: 'no', type: 'string', title: 'Norwegian (Bokmål)'},
+            {name: 'nn', type: 'string', title: 'Norwegian (Nynorsk)'},
+            {name: 'se', type: 'string', title: 'Swedish'},
+          ],
+        },
+        {
+          name: 'author',
+          title: 'Author',
+          type: 'reference',
+          to: {type: 'author', title: 'Author'},
+        },
+        {
+          name: 'favoriteColors',
+          title: 'Favourite Colours',
+          type: 'array',
+          of: [{type: 'string'}],
+        },
+        {
+          name: 'luckyNumbers',
+          title: 'Lucky Numbers',
+          type: 'array',
+          of: [{type: 'string'}, {type: 'number'}],
+        },
+        {
+          name: 'retailers',
+          title: 'Retailers',
+          type: 'array',
+          of: [
+            {
+              name: 'website',
+              type: 'object',
+              fields: [
+                {
+                  name: 'websiteName',
+                  title: 'Website Name',
+                  type: 'string',
+                },
+              ],
+            },
+            {
+              type: 'store',
+            },
+          ],
+        },
+        {
+          name: 'coverImage',
+          title: 'Cover Image',
+          type: 'image',
+          options: {hotspot: true},
+        },
+        {
+          name: 'publicationYear',
+          title: 'Year of publication',
+          type: 'number',
+        },
+        {
+          name: 'isbn',
+          title: 'ISBN number',
+          description: 'ISBN-number of the book. Not shown in studio.',
+          type: 'number',
+          hidden: true,
+        },
+        {
+          name: 'reviewsInline',
+          type: 'array',
+          of: [
+            {
+              type: 'object',
+              name: 'review',
+              fields: [
+                {
+                  name: 'title',
+                  title: 'Title',
+                  type: 'string',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: 'genre',
+          title: 'Genre',
+          type: 'string',
+          options: {
+            list: [
+              {title: 'Fiction', value: 'fiction'},
+              {title: 'Non Fiction', value: 'nonfiction'},
+              {title: 'Poetry', value: 'poetry'},
+            ],
+          },
+        },
+      ],
+    }),
+  ],
+}).get('book') as ObjectSchemaType
+
+it('can introspect root fields', () => {
+  const path = ['title']
+  const segments = [...introspectSchema(bookSchemaType, path)]
+
+  expect(segments.length).toBe(1)
+  expect(segments[0].title).toBe('Title')
+})
+
+it('can introspect object fields', () => {
+  const path = ['translations', 'nn']
+  const segments = [...introspectSchema(bookSchemaType, path)]
+
+  expect(segments.length).toBe(2)
+  expect(segments[0].title).toBe('Translations')
+  expect(segments[1].title).toBe('Norwegian (Nynorsk)')
+})
+
+it('can introspect monomorphic primitive arrays without type hint', () => {
+  const segments = [...introspectSchema(bookSchemaType, ['favoriteColors', 0])]
+
+  expect(segments.length).toBe(2)
+  expect(segments[0].title).toBe('Favourite Colours')
+  expect(segments[1].title).toBe('String')
+})
+
+it('can introspect monomorphic object arrays without type hint', () => {
+  const segments = [...introspectSchema(bookSchemaType, ['reviewsInline', {_key: 'x'}])]
+
+  expect(segments.length).toBe(2)
+  expect(segments[0].title).toBe('Reviews Inline')
+  expect(segments[1].title).toBe('Review')
+})
+
+it('can introspect polymorphic primitive arrays with type hint', () => {
+  const segmentsString = [
+    ...introspectSchema(bookSchemaType, [
+      'luckyNumbers',
+      {
+        segment: 0,
+        type: 'string',
+      },
+    ]),
+  ]
+
+  const segmentsNumber = [
+    ...introspectSchema(bookSchemaType, [
+      'luckyNumbers',
+      {
+        segment: 0,
+        type: 'number',
+      },
+    ]),
+  ]
+
+  expect(segmentsString.length).toBe(2)
+  expect(segmentsString[0].title).toBe('Lucky Numbers')
+  expect(segmentsString[1].title).toBe('String')
+
+  expect(segmentsNumber.length).toBe(2)
+  expect(segmentsNumber[0].title).toBe('Lucky Numbers')
+  expect(segmentsNumber[1].title).toBe('Number')
+})
+
+it('can introspect polymorphic object arrays with type hint', () => {
+  const segmentsWebsite = [
+    ...introspectSchema(bookSchemaType, [
+      'retailers',
+      {
+        segment: {_key: 'x'},
+        type: 'website',
+      },
+    ]),
+  ]
+
+  const segmentsStore = [
+    ...introspectSchema(bookSchemaType, [
+      'retailers',
+      {
+        segment: {_key: 'x'},
+        type: 'store',
+      },
+    ]),
+  ]
+
+  expect(segmentsWebsite.length).toBe(2)
+  expect(segmentsWebsite[0].title).toBe('Retailers')
+  expect(segmentsWebsite[1].title).toBe('Website')
+
+  expect(segmentsStore.length).toBe(2)
+  expect(segmentsStore[0].title).toBe('Retailers')
+  expect(segmentsStore[1].title).toBe('Store')
+})

--- a/packages/sanity/src/core/divergence/utils/introspectSchema.ts
+++ b/packages/sanity/src/core/divergence/utils/introspectSchema.ts
@@ -1,0 +1,91 @@
+import {
+  isArraySchemaType,
+  isObjectSchemaType,
+  type PathSegment,
+  type SchemaType,
+} from '@sanity/types'
+
+import {getTypeChain} from '../../form/studio/inputResolver/helpers'
+import {normalizePathSegment, type PathSegmentWithType} from './flatten'
+
+/**
+ * Extract the schema types that lead to the provided path.
+ *
+ * For each segment of the provided path, the corresponding schema type is yielded.
+ *
+ * If any path segment is ambiguous (e.g. part of a polymorphic array), a `PathSegmentWithType`
+ * segment must be provided instead. The introspection process will select the schema type that
+ * matches the specified type.
+ *
+ * @internal
+ */
+export function* introspectSchema(
+  schemaType: SchemaType | undefined,
+  path: (PathSegment | PathSegmentWithType)[],
+  cache: WeakMap<SchemaType, Record<string, SchemaType>> = new WeakMap(),
+  fullyQualifiedPath: (PathSegment | PathSegmentWithType)[] = [],
+): Generator<SchemaType> {
+  const [head, ...tail] = path
+
+  if (typeof schemaType === 'undefined') {
+    return
+  }
+
+  if (typeof head === 'undefined') {
+    return
+  }
+
+  const nextFullyQualifiedPath = fullyQualifiedPath.concat(head)
+  const cacheKey = JSON.stringify(nextFullyQualifiedPath)
+  let cachedSchemaType = cache.get(schemaType)
+
+  if (typeof cachedSchemaType === 'undefined') {
+    cachedSchemaType = {}
+    cache.set(schemaType, cachedSchemaType)
+  }
+
+  const cachedPath = cachedSchemaType?.[cacheKey]
+  const {segment: headSegment, type: headType} = normalizePathSegment(head)
+
+  let headSchemaType: SchemaType | undefined
+
+  if (typeof cachedPath !== 'undefined') {
+    headSchemaType = cachedPath
+  } else {
+    if (isObjectSchemaType(schemaType)) {
+      headSchemaType = schemaType.fields.find((field) => field.name === headSegment)?.type
+    }
+
+    if (isArraySchemaType(schemaType)) {
+      if (schemaType.of.length === 0) {
+        throw new Error(
+          `Array schema at segment \`${JSON.stringify(headSegment)}\` has no constituent types`,
+        )
+      }
+
+      if (schemaType.of.length === 1) {
+        headSchemaType = schemaType.of[0]
+      } else {
+        if (typeof headType === 'undefined') {
+          throw new Error(
+            `No type hint provided for polymorphic array segment: \`${JSON.stringify(headSegment)}\``,
+          )
+        }
+
+        headSchemaType = schemaType.of.find((type) => {
+          const typeChain = getTypeChain(type, new Set())
+          return typeChain.some(({name}) => name === headType)
+        })
+      }
+    }
+
+    if (typeof headSchemaType === 'undefined') {
+      throw new Error(`Could not resolve schema segment: \`${JSON.stringify(headSegment)}\``)
+    }
+
+    cachedSchemaType[cacheKey] = headSchemaType
+  }
+
+  yield headSchemaType
+  yield* introspectSchema(headSchemaType, tail, cache, nextFullyQualifiedPath)
+}


### PR DESCRIPTION
### Description

This branch adds an `introspectSchema` utility. Given a schema and a path, it will iterate every path segment, yielding the corresponding schema type.

If there is a polymorphic array found anywhere in the path, the type of content must be provided for that segment in order to narrow which path to follow.

To reduce repeated work, the result of each path lookup is cached in a WeakMap keyed by the schema type object.

This utility is used when deciding how a divergence should be displayed. Divergences are reported for every divergent leaf node in a document. When rendering a divergence, `introspectSchema` is used to read the corresponding schema type. This helps us understand how the divergence can be mapped to the rendered document editor.

For example, given the path:

```
someObject.someKey.someArray[4]
```

The `introspectSchema` utility will yield the following:

1. The `someObject` schema type.
2. The `someObject.someKey` schema type.
3. The `someObject.someKey.someArray` schema type.
4. The `someObject.someKey.someArray[4]` schema type (assuming the `someArray` array is monomorphic—otherwise, the segment `[4]` would require a type hint.)

### What to review

Does this approach and implementation seem reasonable?

### Testing

Added unit tests.