### PR TITLE
feat(cli): upgrade blueprints doctor and plan

### DIFF
--- a/packages/@sanity/cli/package.json
+++ b/packages/@sanity/cli/package.json
@@ -64,7 +64,7 @@
     "@babel/traverse": "^7.28.6",
     "@sanity/client": "catalog:",
     "@sanity/codegen": "catalog:",
-    "@sanity/runtime-cli": "^14.0.1",
+    "@sanity/runtime-cli": "^14.1.2",
     "@sanity/telemetry": "catalog:",
     "@sanity/template-validator": "^3.0.0",
     "@sanity/worker-channels": "^1.1.0",

--- a/packages/@sanity/cli/src/commands/blueprints/deployBlueprintsCommand.ts
+++ b/packages/@sanity/cli/src/commands/blueprints/deployBlueprintsCommand.ts
@@ -7,6 +7,7 @@ import {transformHelpText} from '../../util/runtimeCommandHelp'
 export interface BlueprintsDeployFlags {
   'no-wait'?: boolean
   'stack'?: string
+  'verbose'?: boolean
 }
 
 const defaultFlags: BlueprintsDeployFlags = {
@@ -34,7 +35,7 @@ const deployBlueprintsCommand: CliCommandDefinition<BlueprintsDeployFlags> = {
 
     const cmdConfig = await initDeployedBlueprintConfig({
       bin: 'sanity',
-      log: logger.Logger(output.print),
+      log: logger.Logger(output.print, {verbose: flags.verbose}),
       stackOverride: flags.stack,
       token,
     })
@@ -45,6 +46,7 @@ const deployBlueprintsCommand: CliCommandDefinition<BlueprintsDeployFlags> = {
       ...cmdConfig.value,
       flags: {
         'no-wait': flags['no-wait'],
+        'verbose': flags.verbose,
       },
     })
 

--- a/packages/@sanity/cli/src/commands/blueprints/destroyBlueprintsCommand.ts
+++ b/packages/@sanity/cli/src/commands/blueprints/destroyBlueprintsCommand.ts
@@ -14,6 +14,7 @@ export interface BlueprintsDestroyFlags {
   'stackId'?: string
   'stack'?: string
   'no-wait'?: boolean
+  'verbose'?: boolean
 }
 
 const defaultFlags: BlueprintsDestroyFlags = {
@@ -41,7 +42,7 @@ const destroyBlueprintsCommand: CliCommandDefinition<BlueprintsDestroyFlags> = {
 
     const cmdConfig = await initBlueprintConfig({
       bin: 'sanity',
-      log: logger.Logger(output.print),
+      log: logger.Logger(output.print, {verbose: flags.verbose}),
       token,
     })
 
@@ -54,6 +55,7 @@ const destroyBlueprintsCommand: CliCommandDefinition<BlueprintsDestroyFlags> = {
         'force': flags.force ?? flags.f,
         'project-id': flags['project-id'] ?? flags.projectId ?? flags.project,
         'stack': flags['stack-id'] ?? flags.stackId ?? flags.stack,
+        'verbose': flags.verbose,
       },
     })
 

--- a/packages/@sanity/cli/src/commands/blueprints/infoBlueprintsCommand.ts
+++ b/packages/@sanity/cli/src/commands/blueprints/infoBlueprintsCommand.ts
@@ -7,6 +7,7 @@ import {transformHelpText} from '../../util/runtimeCommandHelp'
 export interface BlueprintsInfoFlags {
   stack?: string
   id?: string
+  verbose?: boolean
 }
 
 const defaultFlags: BlueprintsInfoFlags = {
@@ -34,7 +35,7 @@ const infoBlueprintsCommand: CliCommandDefinition<BlueprintsInfoFlags> = {
 
     const cmdConfig = await initDeployedBlueprintConfig({
       bin: 'sanity',
-      log: logger.Logger(output.print),
+      log: logger.Logger(output.print, {verbose: flags.verbose}),
       stackOverride: flags.stack ?? flags.id,
       token,
     })
@@ -43,7 +44,9 @@ const infoBlueprintsCommand: CliCommandDefinition<BlueprintsInfoFlags> = {
 
     const {success, error} = await blueprintInfoCore({
       ...cmdConfig.value,
-      flags: {},
+      flags: {
+        verbose: flags.verbose,
+      },
     })
 
     if (!success) throw new Error(error)

--- a/packages/@sanity/cli/src/commands/blueprints/logsBlueprintsCommand.ts
+++ b/packages/@sanity/cli/src/commands/blueprints/logsBlueprintsCommand.ts
@@ -8,6 +8,7 @@ export interface BlueprintsLogsFlags {
   watch?: boolean
   w?: boolean
   stack?: string
+  verbose?: boolean
 }
 
 const defaultFlags: BlueprintsLogsFlags = {
@@ -35,7 +36,7 @@ const logsBlueprintsCommand: CliCommandDefinition<BlueprintsLogsFlags> = {
 
     const cmdConfig = await initDeployedBlueprintConfig({
       bin: 'sanity',
-      log: logger.Logger(output.print),
+      log: logger.Logger(output.print, {verbose: flags.verbose}),
       stackOverride: flags.stack,
       token,
     })
@@ -46,6 +47,7 @@ const logsBlueprintsCommand: CliCommandDefinition<BlueprintsLogsFlags> = {
       ...cmdConfig.value,
       flags: {
         watch: flags.watch ?? flags.w,
+        verbose: flags.verbose,
       },
     })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1109,8 +1109,8 @@ importers:
         specifier: 'catalog:'
         version: 5.9.4(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(yaml@2.8.2)
       '@sanity/runtime-cli':
-        specifier: ^14.0.1
-        version: 14.0.1(@types/node@24.10.4)(debug@4.4.3)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        specifier: ^14.1.2
+        version: 14.1.2(@types/node@24.10.4)(debug@4.4.3)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       '@sanity/telemetry':
         specifier: 'catalog:'
         version: 0.8.1(react@19.2.4)
@@ -5551,8 +5551,8 @@ packages:
     peerDependencies:
       react: ^18.3 || ^19
 
-  '@sanity/runtime-cli@14.0.1':
-    resolution: {integrity: sha512-CY8hIWPvq4qJ+h+dQ/Pz40K7M8AGOpRnBKyAAFHzCZJE10hUnMpyBtwafUTj3RyYNbAhDDv2XyFdgXpNM53IAQ==}
+  '@sanity/runtime-cli@14.1.2':
+    resolution: {integrity: sha512-raTVvpEl56d+EoB0JqsUiq7MkMlz+dXmPy73rTJ5zbcilxvCcC3SrH39T2nQRxJR6Jjuw3Heyl8tsMGOq+objA==}
     engines: {node: '>=20.19'}
     hasBin: true
 
@@ -16594,7 +16594,7 @@ snapshots:
       - debug
       - typescript
 
-  '@sanity/runtime-cli@14.0.1(@types/node@24.10.4)(debug@4.4.3)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)':
+  '@sanity/runtime-cli@14.1.2(@types/node@24.10.4)(debug@4.4.3)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)':
     dependencies:
       '@architect/hydrate': 5.0.1
       '@architect/inventory': 5.0.0


### PR DESCRIPTION
### Description

- upgrade `blueprints` + `functions` command internals
- improved `blueprints doctor` output
- new `blueprints plan` functionality
- allow `--verbose` flag passthrough. 
  - this flag does not always generate extra output, but it's helpful to have in place before it does

### What to review

### Testing

these features are well tested in the runtime-cli where these internals live

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->

1. New `blueprints plan` feature: the command outputs a summarized plan generated by the Blueprints API detailing what will happen during a deploy utilizing the same server-side logic used during a real Stack update.

<img width="1262" height="464" alt="image" src="https://github.com/user-attachments/assets/411957a6-89bc-4cfe-a1eb-46c6d431ffe8" />

2. Updated `blueprints doctor` output is better organized and more specific to help diagnose issues locally and in the Stack deployment configuration.
3. Misc `blueprints` and `functions` improvements/fixes