### PR TITLE
fix: update fileAsset and imageAsset required fields

### DIFF
--- a/packages/@sanity/schema/src/sanity/builtinTypes/fileAsset.ts
+++ b/packages/@sanity/schema/src/sanity/builtinTypes/fileAsset.ts
@@ -1,3 +1,5 @@
+import {type Rule} from '@sanity/types'
+
 export default {
   name: 'sanity.fileAsset',
   title: 'File',
@@ -42,6 +44,7 @@ export default {
       title: 'SHA1 hash',
       readOnly: true,
       fieldset: 'system',
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'extension',
@@ -49,6 +52,7 @@ export default {
       title: 'File extension',
       readOnly: true,
       fieldset: 'system',
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'mimeType',
@@ -56,6 +60,7 @@ export default {
       title: 'Mime type',
       readOnly: true,
       fieldset: 'system',
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'size',
@@ -63,6 +68,7 @@ export default {
       title: 'File size in bytes',
       readOnly: true,
       fieldset: 'system',
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'assetId',
@@ -70,6 +76,7 @@ export default {
       title: 'Asset ID',
       readOnly: true,
       fieldset: 'system',
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'uploadId',
@@ -84,6 +91,7 @@ export default {
       title: 'Path',
       readOnly: true,
       fieldset: 'system',
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'url',
@@ -91,6 +99,7 @@ export default {
       title: 'Url',
       readOnly: true,
       fieldset: 'system',
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'source',

--- a/packages/@sanity/schema/src/sanity/builtinTypes/imageAsset.ts
+++ b/packages/@sanity/schema/src/sanity/builtinTypes/imageAsset.ts
@@ -1,4 +1,4 @@
-import {type SanityDocument} from '@sanity/types'
+import {type SanityDocument, type Rule} from '@sanity/types'
 
 export default {
   name: 'sanity.imageAsset',
@@ -44,6 +44,7 @@ export default {
       title: 'SHA1 hash',
       readOnly: true,
       fieldset: 'system',
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'extension',
@@ -51,6 +52,7 @@ export default {
       readOnly: true,
       title: 'File extension',
       fieldset: 'system',
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'mimeType',
@@ -58,6 +60,7 @@ export default {
       readOnly: true,
       title: 'Mime type',
       fieldset: 'system',
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'size',
@@ -65,6 +68,7 @@ export default {
       title: 'File size in bytes',
       readOnly: true,
       fieldset: 'system',
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'assetId',
@@ -72,6 +76,7 @@ export default {
       title: 'Asset ID',
       readOnly: true,
       fieldset: 'system',
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'uploadId',
@@ -86,6 +91,7 @@ export default {
       title: 'Path',
       readOnly: true,
       fieldset: 'system',
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'url',
@@ -93,6 +99,7 @@ export default {
       title: 'Url',
       readOnly: true,
       fieldset: 'system',
+      validation: (Rule: Rule) => Rule.required(),
     },
     {
       name: 'metadata',


### PR DESCRIPTION
### Description
This PR updates `sanity.fileAsset` and `sanity.imageAsset` schemas to indicate the required fields as defined in the [client types ](https://github.com/sanity-io/client/blob/main/src/types.ts#L346-L352)

```ts
export interface SanityAssetDocument extends SanityDocument {
  url: string
  path: string
  size: number
  assetId: string
  mimeType: string
  sha1hash: string
  extension: string
  uploadId?: string
  originalFilename?: string
}
```

Marking them required will change them to required when running typegen, which is what we want to affect with this change.

This files are generated in the client and this fields are disabled for edit in the studio.
The transaction that creates the file creates it with all of this fields, so it feels safe to do this change.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
update fileAsset and imageAsset required fields

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
