### PR TITLE
fix: defer import of `isomorphic-dompurify`

### DIFF
--- a/packages/sanity/src/core/studio/manifest/generateStudioManifest.ts
+++ b/packages/sanity/src/core/studio/manifest/generateStudioManifest.ts
@@ -20,7 +20,7 @@ export interface GenerateStudioManifestOptions<W extends ManifestWorkspaceInput>
    * Function to resolve the icon HTML string for a workspace.
    * Return undefined if the icon cannot be resolved.
    */
-  resolveIcon: (workspace: W) => string | undefined
+  resolveIcon: (workspace: W) => string | undefined | Promise<string | undefined>
   /** The Sanity version string */
   bundleVersion: string
   /** Optional build ID */
@@ -30,11 +30,11 @@ export interface GenerateStudioManifestOptions<W extends ManifestWorkspaceInput>
 /**
  * Generates a workspace manifest entry from a workspace and its schema descriptor ID.
  */
-function generateWorkspaceManifest<W extends ManifestWorkspaceInput>(
+async function generateWorkspaceManifest<W extends ManifestWorkspaceInput>(
   workspace: W,
   schemaDescriptorId: string,
-  resolveIcon: (workspace: W) => string | undefined,
-): StudioWorkspaceManifest {
+  resolveIcon: (workspace: W) => string | undefined | Promise<string | undefined>,
+): Promise<StudioWorkspaceManifest> {
   return {
     name: workspace.name,
     projectId: workspace.projectId,
@@ -43,7 +43,7 @@ function generateWorkspaceManifest<W extends ManifestWorkspaceInput>(
     basePath: workspace.basePath || undefined,
     title: workspace.title || undefined,
     subtitle: workspace.subtitle || undefined,
-    icon: resolveIcon(workspace),
+    icon: await resolveIcon(workspace),
     mediaLibraryId: workspace.mediaLibrary?.enabled ? workspace.mediaLibrary.libraryId : undefined,
   }
 }

--- a/packages/sanity/src/core/studio/manifest/icon.tsx
+++ b/packages/sanity/src/core/studio/manifest/icon.tsx
@@ -1,6 +1,5 @@
 import {ThemeProvider} from '@sanity/ui'
 import {type RootTheme} from '@sanity/ui/theme'
-import DOMPurify from 'isomorphic-dompurify'
 import {type ComponentType, isValidElement, type ReactNode} from 'react'
 import {renderToStaticMarkup} from 'react-dom/server'
 import {isValidElementType} from 'react-is'
@@ -312,7 +311,7 @@ function normalizeIcon(
  * Uses ServerStyleSheet to capture styled-components styles without
  * interfering with the main application's style sheet.
  */
-export const resolveIcon = (props: IconProps): string | undefined => {
+export const resolveIcon = async (props: IconProps): Promise<string | undefined> => {
   try {
     // Create the icon element wrapped with theme provider
     const iconElement = normalizeIcon(props.icon, props.title, props.subtitle)
@@ -324,6 +323,7 @@ export const resolveIcon = (props: IconProps): string | undefined => {
     // Combine styles and element
     const html = elementHtml.trim()
 
+    const {default: DOMPurify} = await import('isomorphic-dompurify')
     return DOMPurify.sanitize(html, purifyConfig)
   } catch {
     return undefined


### PR DESCRIPTION
### Description

By making `resolveIcon` async and dynamically loading `isomorphic-dompurify`, we shed ~100ms at import time when loading the `sanity` module (measured on an M4 Pro). This accounts for ~15% of the total load time, and drops 600+ commonjs modules from being imported at load time.

### What to review

Stuff still works.

### Testing

Same tests as before - `generateStudioManifest` was already async so no big changes were needed.

### Notes for release

N/A
