### PR TITLE
chore(ci): use timestamp instead of commit count in prerelease id

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -54,27 +54,19 @@ jobs:
         # A:
         # lerna version does not support --canary (for some reason, it's only supported for lerna publish)
         # When publishing tagged canary releases, we want the version to be:
-        # <conventional-commit-bump>.<commits-ahead>+<commit-hash>
+        # <conventional-commit-bump>.<timestamp>+<commit-hash>
         # However, the lerna version command we run above does not append the commit hash, and it
-        # always sets the <commits-ahead> part to "0"
+        # always sets the <timestamp> part to "0"
         # So, in order to get the desired target version, we need to post-process package versions
-        # by manually getting the number of commits in the branch since last release, and replace the "0"
-        # with the correct number of commits ahead, and finally append the commit hash.
+        # by getting the current timestamp and replace the "0" with it, and finally append the commit hash.
         run: |
-          COMMIT_COUNT="0" # fallback refcount value
           COMMIT_HASH=$(git rev-parse --short HEAD)
-
-          TAG_INFO=$(git describe --tags --long --first-parent)
-
-          if [[ $TAG_INFO =~ ^(.+)-([0-9]+)-g([0-9a-f]+)$ ]]; then
-            COMMIT_COUNT="${BASH_REMATCH[2]}"
-          fi
-
-          echo "COMMITS AHEAD: $COMMIT_COUNT"
+          TIMESTAMP=$(date +"%Y%m%d%H%M%S")
+          echo "TIMESTAMP: $TIMESTAMP"
           echo "COMMIT HASH: $COMMIT_HASH"
 
           for pkg in $(lerna list --all --json | jq -r '.[].location'); do
-            jq --arg commit_count "$COMMIT_COUNT" --arg commit_hash "$COMMIT_HASH" '.version |= sub("\\.0$"; "." + $commit_count + "+"+$commit_hash)' "$pkg/package.json" > "$pkg/package.tmp.json"
+            jq --arg timestamp "$TIMESTAMP" --arg commit_hash "$COMMIT_HASH" '.version |= sub("\\.0$"; "." + $timestamp + "+"+$commit_hash)' "$pkg/package.json" > "$pkg/package.tmp.json"
             mv "$pkg/package.tmp.json" "$pkg/package.json"
           done
 


### PR DESCRIPTION
### Description
Our release workflow for the canary branch uses "number of commits ahead" in prerelease identifiers when publishing to npm. Since the `canary` branch is often rebased, and commits in it are squashed etc. its likely for the "commits ahead" number to repeat across workflow runs. This fixes the issue by using a timestamp instead of commits ahead count in the prerelease id.

Example
- Before: `5.12.1-canary.2+85bb5335cc` (note that the`+<sha>` part is not considered part of the version)
- After: `5.12.1-canary.20260302090738+85bb5335cc`

### What to review
Makes sense?

### Testing
Already ran this in the `canary` branch without any issue. See https://github.com/sanity-io/sanity/actions/runs/22568908322/job/65371425565

### Notes for release
n/a