### PR TITLE
fix: coreUi intent links need to use exact full path

### DIFF
--- a/packages/sanity/src/core/hooks/__tests__/useStudioUrl.test.tsx
+++ b/packages/sanity/src/core/hooks/__tests__/useStudioUrl.test.tsx
@@ -40,18 +40,18 @@ const mockUseProjectOrganizationId = useProjectOrganizationId as Mock
 const mockUseEnvAwareSanityWebsiteUrl = useEnvAwareSanityWebsiteUrl as Mock
 const mockGetDashboardPath = getDashboardPath as Mock
 
-function setupStudioContext() {
+function setupStudioContext(basePath = '/') {
   mockUseRenderingContext.mockReturnValue(null)
   mockUseStudioAppIdStore.mockReturnValue({studioApp: null, loading: false})
-  mockUseActiveWorkspace.mockReturnValue({activeWorkspace: {name: 'default'}})
+  mockUseActiveWorkspace.mockReturnValue({activeWorkspace: {name: 'default', basePath}})
   mockUseProjectOrganizationId.mockReturnValue({value: null, loading: false})
   mockUseEnvAwareSanityWebsiteUrl.mockReturnValue('https://www.sanity.io')
 }
 
-function setupCoreUiContext() {
+function setupCoreUiContext(basePath = '/') {
   mockUseRenderingContext.mockReturnValue({name: 'coreUi'})
   mockUseStudioAppIdStore.mockReturnValue({studioApp: {appId: 'my-app'}, loading: false})
-  mockUseActiveWorkspace.mockReturnValue({activeWorkspace: {name: 'default'}})
+  mockUseActiveWorkspace.mockReturnValue({activeWorkspace: {name: 'default', basePath}})
   mockUseProjectOrganizationId.mockReturnValue({value: 'org-123', loading: false})
   mockUseEnvAwareSanityWebsiteUrl.mockReturnValue('https://www.sanity.io')
   mockGetDashboardPath.mockReturnValue(
@@ -137,6 +137,48 @@ describe('useStudioUrl', () => {
       })
 
       expect(built).toBe(window.location.origin)
+    })
+  })
+
+  describe('buildIntentUrl', () => {
+    it('returns origin + full intent link in studio context (default basePath /)', () => {
+      setupStudioContext()
+      const {result} = renderHook(() => useStudioUrl())
+      expect(result.current.buildIntentUrl('/intent/edit/id=doc1;type=article')).toBe(
+        `${window.location.origin}/intent/edit/id=doc1;type=article`,
+      )
+    })
+
+    it('preserves basePath in intent link in studio context', () => {
+      setupStudioContext('/test')
+      const {result} = renderHook(() => useStudioUrl())
+      expect(result.current.buildIntentUrl('/test/intent/edit/id=doc1;type=article')).toBe(
+        `${window.location.origin}/test/intent/edit/id=doc1;type=article`,
+      )
+    })
+
+    it('appends intent link without stripping in coreUi context when basePath is /', () => {
+      setupCoreUiContext('/')
+      const {result} = renderHook(() => useStudioUrl())
+      expect(result.current.buildIntentUrl('/intent/edit/id=doc1;type=article')).toBe(
+        'https://www.sanity.io/organizations/org-123/apps/my-app/workspaces/default/intent/edit/id=doc1;type=article',
+      )
+    })
+
+    it('strips basePath from intent link in coreUi context', () => {
+      setupCoreUiContext('/test')
+      const {result} = renderHook(() => useStudioUrl())
+      expect(result.current.buildIntentUrl('/test/intent/edit/id=doc1;type=article')).toBe(
+        'https://www.sanity.io/organizations/org-123/apps/my-app/workspaces/default/intent/edit/id=doc1;type=article',
+      )
+    })
+
+    it('strips multi-segment basePath from intent link in coreUi context', () => {
+      setupCoreUiContext('/admin/studio')
+      const {result} = renderHook(() => useStudioUrl())
+      expect(result.current.buildIntentUrl('/admin/studio/intent/edit/id=doc1;type=article')).toBe(
+        'https://www.sanity.io/organizations/org-123/apps/my-app/workspaces/default/intent/edit/id=doc1;type=article',
+      )
     })
   })
 })

--- a/packages/sanity/src/core/hooks/useStudioUrl.ts
+++ b/packages/sanity/src/core/hooks/useStudioUrl.ts
@@ -16,6 +16,7 @@ type StudioUrlModifier = {coreUi?: StudioUrlBuilder; studio?: StudioUrlBuilder} 
 interface UseStudioUrlReturnType {
   studioUrl: string
   buildStudioUrl: (modifiers: StudioUrlModifier) => string
+  buildIntentUrl: (intentLink: string) => string
 }
 
 /**
@@ -54,6 +55,8 @@ export const useStudioUrl = (defaultUrl?: string): UseStudioUrlReturnType => {
     sanityWebsiteUrl,
   ])
 
+  const basePath = activeWorkspace.basePath
+
   const buildStudioUrl = useCallback(
     ({coreUi, studio}: StudioUrlModifier) => {
       const urlModifier = isCoreUi ? coreUi : studio
@@ -63,7 +66,18 @@ export const useStudioUrl = (defaultUrl?: string): UseStudioUrlReturnType => {
     [isCoreUi, studioUrl],
   )
 
+  const buildIntentUrl = useCallback(
+    (intentLink: string) => {
+      if (isCoreUi && basePath !== '/') {
+        return `${studioUrl}${intentLink.slice(basePath.length)}`
+      }
+      return `${studioUrl}${intentLink}`
+    },
+    [basePath, isCoreUi, studioUrl],
+  )
+
   return {
+    buildIntentUrl,
     buildStudioUrl,
     studioUrl,
   }

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/CopyDocumentActions.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/CopyDocumentActions.tsx
@@ -23,7 +23,7 @@ export function CopyDocumentActions() {
   const {selectedReleaseId, selectedPerspectiveName} = usePerspective()
   const {params} = usePaneRouter()
   const {resolveIntentLink} = useRouter()
-  const {buildStudioUrl} = useStudioUrl()
+  const {buildIntentUrl} = useStudioUrl()
   const {t} = useTranslation(structureLocaleNamespace)
   const telemetry = useTelemetry()
   const {push: pushToast} = useToast()
@@ -56,12 +56,7 @@ export function CopyDocumentActions() {
     }
 
     const intentLink = resolveIntentLink('edit', intentParams, searchParams)
-    const appendIntentLink = (url: string) => `${url}${intentLink}`
-
-    const copyUrl = buildStudioUrl({
-      coreUi: appendIntentLink,
-      studio: appendIntentLink,
-    })
+    const copyUrl = buildIntentUrl(intentLink)
 
     await navigator.clipboard.writeText(copyUrl)
     pushToast({
@@ -70,7 +65,7 @@ export function CopyDocumentActions() {
       title: t('panes.document-operation-results.operation-success_copy-url'),
     })
   }, [
-    buildStudioUrl,
+    buildIntentUrl,
     documentId,
     documentType,
     pushToast,

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
@@ -9,8 +9,8 @@ import {structureUsEnglishLocaleBundle} from '../../../../../i18n'
 import {CopyDocumentActions} from '../CopyDocumentActions'
 
 const mockResolveIntentLink = vi.hoisted(() => vi.fn(() => '/mock-intent-link'))
-const mockBuildStudioUrl = vi.hoisted(() =>
-  vi.fn(({studio}: {studio?: (url: string) => string}) => studio?.('http://localhost:3333') ?? ''),
+const mockBuildIntentUrl = vi.hoisted(() =>
+  vi.fn((intentLink: string) => `http://localhost:3333${intentLink}`),
 )
 const mockTelemetryLog = vi.hoisted(() => vi.fn())
 const mockClipboardWriteText = vi.hoisted(() => vi.fn(() => Promise.resolve()))
@@ -28,7 +28,7 @@ vi.mock('sanity', async (importOriginal) => ({
   usePerspective: vi.fn(() => DEFAULT_PERSPECTIVE),
   useStudioUrl: vi.fn(() => ({
     studioUrl: 'http://localhost:3333',
-    buildStudioUrl: mockBuildStudioUrl,
+    buildIntentUrl: mockBuildIntentUrl,
   })),
   useTranslation: vi.fn(() => ({
     t: (key: string) => key,
@@ -147,6 +147,7 @@ describe('CopyDocumentActions', () => {
       render(<CopyDocumentActions />, {wrapper})
       await clickMenuItem('copy-link-to-document')
 
+      expect(mockBuildIntentUrl).toHaveBeenCalledWith('/intent/edit/id=doc-123;type=article')
       expect(mockClipboardWriteText).toHaveBeenCalledWith(
         'http://localhost:3333/intent/edit/id=doc-123;type=article',
       )


### PR DESCRIPTION
### Description

When copying a document URL in CoreUI, the workspace `basePath` leaks into the URL - producing paths like `.../default/test/intent/edit/...` instead of `.../default/intent/edit/...`. CoreUI can't resolve this and redirects to `/structure`.

This happens because `resolveIntentLink` always includes the workspace `basePath` in the path it returns. In standalone studios this is correct - the basePath is needed for client-side routing. In CoreUI, the dashboard URL already identifies the workspace by name (`/workspaces/default`), making the basePath redundant.

This PR adds `buildIntentUrl` to `useStudioUrl` which strips the basePath prefix from intent links when in CoreUI. When there's no custom basePath (the default `/`), nothing is stripped.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Have verified no regression when running a standalone studio. I think the easiest way of confirming this works for Core is to merge this and then test on a studio running in core.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
