### PR TITLE
fix: schedules tool title

### DIFF
--- a/packages/sanity/src/core/config/resolveDefaultPlugins.ts
+++ b/packages/sanity/src/core/config/resolveDefaultPlugins.ts
@@ -16,7 +16,7 @@ import {
   type WorkspaceOptions,
 } from './types'
 
-const defaultPlugins = [
+const defaultPlugins = (options: DefaultPluginsOptions) => [
   comments(),
   tasks(),
   scheduledPublishing(),
@@ -24,7 +24,7 @@ const defaultPlugins = [
   releases(),
   canvasIntegration(),
   mediaLibrary(),
-  schedules(),
+  schedules(options),
   singleDocRelease(),
 ]
 
@@ -33,7 +33,7 @@ type DefaultPluginsOptions = DefaultPluginsWorkspaceOptions & {
 }
 
 export function getDefaultPlugins(options: DefaultPluginsOptions, plugins?: PluginOptions[]) {
-  return defaultPlugins.filter((plugin) => {
+  return defaultPlugins(options).filter((plugin) => {
     if (plugin.name === SCHEDULED_PUBLISHING_NAME) {
       // The scheduled publishing plugin is only included if other plugin is included by the user.
       return options.scheduledPublishing.enabled && !!plugins?.length

--- a/packages/sanity/src/core/schedules/plugin/index.ts
+++ b/packages/sanity/src/core/schedules/plugin/index.ts
@@ -1,12 +1,12 @@
 import {route} from 'sanity/router'
 
+import {type DefaultPluginsWorkspaceOptions} from '../../config'
 import {definePlugin} from '../../config/definePlugin'
 import {releasesUsEnglishLocaleBundle} from '../../releases/i18n'
 import {RELEASES_INTENT} from '../../releases/plugin'
 import {ReleasesStudioLayout} from '../../releases/plugin/ReleasesStudioLayout'
 import {ReleasesTool} from '../../releases/tool/ReleasesTool'
 import {RELEASES_SCHEDULED_DRAFTS_INTENT} from '../../singleDocRelease/plugin'
-import {useWorkspace} from '../../studio'
 
 /**
  * @internal
@@ -18,15 +18,10 @@ export const SCHEDULES_NAME = 'sanity/schedules'
  */
 export const SCHEDULES_TOOL_NAME = 'releases'
 
-const ToolTitle = () => {
-  const isReleasesEnabled = useWorkspace().releases?.enabled
-  return <div>{isReleasesEnabled ? 'Releases' : 'Scheduled Drafts'}</div>
-}
-
 /**
  * @internal
  */
-export const schedules = definePlugin({
+export const schedules = definePlugin((options: DefaultPluginsWorkspaceOptions) => ({
   name: SCHEDULES_NAME,
   studio: {
     components: {
@@ -36,8 +31,7 @@ export const schedules = definePlugin({
   tools: [
     {
       name: SCHEDULES_TOOL_NAME,
-      // @ts-expect-error - title expects a string, but it will render the Component.
-      title: <ToolTitle />,
+      title: options.releases.enabled ? 'Releases' : 'Scheduled Drafts',
       component: ReleasesTool,
       router: route.create('/', [route.create('/:releaseId')]),
       __internalApplicationType: 'sanity/schedules',
@@ -64,4 +58,4 @@ export const schedules = definePlugin({
   i18n: {
     bundles: [releasesUsEnglishLocaleBundle],
   },
-})
+}))


### PR DESCRIPTION
### Description
Little hack to update the schedules tool title depending if releases is enabled or not.
When releases is not enabled we render the title to say "scheduled drafts", if enabled, it will say "Releases".

This expects a string, but it takes the string all the way to the render moment so it will also render a component, I don't think we should open the API to accept components because in a future we could need to update this and force the string, if we open it, then users will also be able to pass components which will make it a breaking change to refactor it.
<img width="1391" height="629" alt="Screenshot 2026-03-02 at 12 06 22" src="https://github.com/user-attachments/assets/130da0a9-5c0b-4c5f-ac45-22a378cc6151" />
<img width="1400" height="387" alt="Screenshot 2026-03-02 at 12 07 46" src="https://github.com/user-attachments/assets/461028aa-8c68-479b-841c-bf7e8609282b" />


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
