### PR TITLE
ci: set up bundle stats workflow

### DIFF
--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -19,11 +19,10 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
       - uses: ./.github/actions/setup
       - uses: rexxars/bundle-stats@v1
         with:
           packages: packages/sanity
           build-command: pnpm build
           only: "."
+          compare-npm: latest


### PR DESCRIPTION
### Description

Adds a bundle stats reporter, see report below: https://github.com/sanity-io/sanity/pull/12285#issuecomment-3986070283

This (can) help to keep an eye on unexpected bundle size changes and potential impact of _import time_, which is not something that is often measured but we actively want to keep track of.

Note that the import time might be noisy. I haven't ran enough runs on GH actions to know _how_ noisy, but if it becomes a problem we can look into dropping it or moving it to dedicated hardware.

### What to review

Workflow is helpful?

### Testing

See result on this PR.

### Notes for release

N/A