### PR TITLE
fix(core): use PT schema for htmlToBlocks instead of Sanity ArraySchemaType

### DIFF
--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -21,6 +21,7 @@
     "@portabletext/editor": "^5.0.4",
     "@portabletext/plugin-character-pair-decorator": "^6.0.4",
     "@portabletext/react": "^6.0.2",
+    "@portabletext/sanity-bridge": "^2.0.2",
     "@portabletext/toolkit": "^5.0.1",
     "@sanity/assist": "^5.0.3",
     "@sanity/cli": "workspace:*",

--- a/dev/test-studio/schema/standard/portableText/customMarkers/CustomContentInput.tsx
+++ b/dev/test-studio/schema/standard/portableText/customMarkers/CustomContentInput.tsx
@@ -1,5 +1,6 @@
 import {htmlToBlocks} from '@portabletext/block-tools'
 import {type OnPasteFn, type PortableTextBlock} from '@portabletext/editor'
+import {sanitySchemaToPortableTextSchema} from '@portabletext/sanity-bridge'
 import {useCallback, useMemo} from 'react'
 import {PortableTextInput, type PortableTextInputProps, type PortableTextMarker} from 'sanity'
 
@@ -18,7 +19,7 @@ export function CustomContentInput(inputProps: PortableTextInputProps) {
       console.log('Run `sanity install @sanity/code-input, and add `type: "code"` to your schema.')
     }
     if (html && hasCodeType) {
-      const blocks = htmlToBlocks(html, type, {
+      const blocks = htmlToBlocks(html, sanitySchemaToPortableTextSchema(type), {
         rules: [
           {
             deserialize(el, next, block) {

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -49,7 +49,7 @@ export const PortableTextEditorPlugins = (props: {
             return false
           }
 
-          const blocks = htmlToBlocks(event.data, schemaTypes.portableText, {
+          const blocks = htmlToBlocks(event.data, snapshot.context.schema, {
             keyGenerator: snapshot.context.keyGenerator,
             unstable_whitespaceOnPasteMode:
               schemaTypes.block.options?.unstable_whitespaceOnPasteMode,
@@ -79,7 +79,7 @@ export const PortableTextEditorPlugins = (props: {
         ],
       }),
     ],
-    [schemaTypes.block.options?.unstable_whitespaceOnPasteMode, schemaTypes.portableText],
+    [schemaTypes.block.options?.unstable_whitespaceOnPasteMode],
   )
 
   const componentProps = useMemo(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -578,6 +578,9 @@ importers:
       '@portabletext/react':
         specifier: ^6.0.2
         version: 6.0.2(react@19.2.4)
+      '@portabletext/sanity-bridge':
+        specifier: ^2.0.2
+        version: 2.0.2
       '@portabletext/toolkit':
         specifier: ^5.0.1
         version: 5.0.1


### PR DESCRIPTION
### Description

`@portabletext/block-tools` is dropping its `@sanity/types` and `@portabletext/sanity-bridge` dependencies in the next major version. Today, those dependencies pull the entire `@sanity/types` and `@sanity/schema` transitive dependency chain into `node_modules` for anyone who installs `@portabletext/editor` (which depends on block-tools). That is a lot of weight for a library that should be framework-agnostic.

After the block-tools update, `htmlToBlocks` will only accept a Portable Text `Schema` from `@portabletext/schema`, not a Sanity `ArraySchemaType`. This PR updates Studio to pass the right schema type ahead of that change.

### What to review

- **`Plugins.tsx`**: Uses `snapshot.context.schema` (already a PT `Schema`) instead of `schemaTypes.portableText` (a Sanity `ArraySchemaType`). The behavior snapshot already carries the compiled schema, so no conversion needed.
- **`CustomContentInput.tsx` (test-studio)**: Wraps `type` with `sanitySchemaToPortableTextSchema()` since this `onPaste` callback only has the Sanity type available.
- **`dev/test-studio/package.json`**: Adds `@portabletext/sanity-bridge` as a dependency so the test studio can import from it.

### Testing

Type-check passes. No runtime behavior change: `snapshot.context.schema` is the same PT schema that `htmlToBlocks` already extracted internally from the Sanity type.

### Notes for release

N/A: Internal preparation for upcoming `@portabletext/block-tools` major version.