### PR TITLE
fix(config): cache prepared configs

### DIFF
--- a/packages/sanity/src/core/config/__tests__/prepareConfig.test.ts
+++ b/packages/sanity/src/core/config/__tests__/prepareConfig.test.ts
@@ -1,0 +1,174 @@
+import {describe, beforeEach, expect, it} from 'vitest'
+
+import {getSchemaContentKey, _clearSchemaCache, prepareConfig} from '../prepareConfig'
+import {SchemaError} from '../SchemaError'
+
+describe('getSchemaContentKey', () => {
+  it('returns the same key for identical type arrays', () => {
+    const types = [{type: 'document', name: 'post', fields: [{name: 'title', type: 'string'}]}]
+    const typesClone = [{type: 'document', name: 'post', fields: [{name: 'title', type: 'string'}]}]
+
+    expect(getSchemaContentKey(types)).toBe(getSchemaContentKey(typesClone))
+  })
+
+  it('returns different keys for different type arrays', () => {
+    const typesA = [{type: 'document', name: 'post', fields: [{name: 'title', type: 'string'}]}]
+    const typesB = [{type: 'document', name: 'author', fields: [{name: 'name', type: 'string'}]}]
+
+    expect(getSchemaContentKey(typesA)).not.toBe(getSchemaContentKey(typesB))
+  })
+
+  it('handles functions by serializing their body', () => {
+    const typesA = [{name: 'post', prepare: (data: unknown) => ({title: String(data)})}]
+    const typesACopy = [{name: 'post', prepare: (data: unknown) => ({title: String(data)})}]
+
+    // Same function body produces same key
+    expect(getSchemaContentKey(typesA)).toBe(getSchemaContentKey(typesACopy))
+
+    // Different function body produces different key
+    const typesB = [{name: 'post', prepare: (data: unknown) => ({title: `prefix: ${data}`})}]
+    expect(getSchemaContentKey(typesA)).not.toBe(getSchemaContentKey(typesB))
+  })
+
+  it('returns null for types with circular references', () => {
+    const typeA: any = {name: 'post'}
+    typeA.self = typeA // circular reference
+    expect(getSchemaContentKey([typeA])).toBeNull()
+  })
+
+  it('treats undefined fields as equivalent to missing fields', () => {
+    const typesA = [{name: 'post', description: undefined}]
+    const typesB = [{name: 'post'}]
+    // JSON.stringify drops undefined — these produce the same key
+    expect(getSchemaContentKey(typesA)).toBe(getSchemaContentKey(typesB))
+  })
+})
+
+describe('prepareConfig schema caching', () => {
+  beforeEach(() => {
+    _clearSchemaCache()
+  })
+
+  it('workspaces with different names get different Schema objects even with identical types', () => {
+    const config = [
+      {
+        name: 'workspace-a',
+        basePath: '/a',
+        projectId: 'ppsg7ml5',
+        dataset: 'production',
+        schema: {
+          types: [
+            {type: 'document' as const, name: 'post', fields: [{name: 'title', type: 'string'}]},
+          ],
+        },
+      },
+      {
+        name: 'workspace-b',
+        basePath: '/b',
+        projectId: 'ppsg7ml5',
+        dataset: 'staging',
+        schema: {
+          types: [
+            {type: 'document' as const, name: 'post', fields: [{name: 'title', type: 'string'}]},
+          ],
+        },
+      },
+    ]
+
+    const {workspaces} = prepareConfig(config)
+
+    expect(workspaces).toHaveLength(2)
+    // Different source.name means different cache key — Schema objects should differ
+    expect(workspaces[0].schema).not.toBe(workspaces[1].schema)
+  })
+
+  it('workspaces with different schema types get different Schema objects', () => {
+    const config = [
+      {
+        name: 'workspace-a',
+        basePath: '/a',
+        projectId: 'ppsg7ml5',
+        dataset: 'production',
+        schema: {
+          types: [
+            {type: 'document' as const, name: 'post', fields: [{name: 'title', type: 'string'}]},
+          ],
+        },
+      },
+      {
+        name: 'workspace-b',
+        basePath: '/b',
+        projectId: 'ppsg7ml5',
+        dataset: 'staging',
+        schema: {
+          types: [
+            {
+              type: 'document' as const,
+              name: 'author',
+              fields: [{name: 'name', type: 'string'}],
+            },
+          ],
+        },
+      },
+    ]
+
+    const {workspaces} = prepareConfig(config)
+
+    expect(workspaces).toHaveLength(2)
+    expect(workspaces[0].schema).not.toBe(workspaces[1].schema)
+  })
+
+  it('reuses schema across separate prepareConfig calls with same name and types', () => {
+    const config1 = {
+      name: 'default',
+      projectId: 'ppsg7ml5',
+      dataset: 'production',
+      schema: {
+        types: [
+          {type: 'document' as const, name: 'post', fields: [{name: 'title', type: 'string'}]},
+        ],
+      },
+    }
+    const config2 = {
+      name: 'default',
+      projectId: 'ppsg7ml5',
+      dataset: 'staging',
+      schema: {
+        types: [
+          {type: 'document' as const, name: 'post', fields: [{name: 'title', type: 'string'}]},
+        ],
+      },
+    }
+
+    const result1 = prepareConfig(config1)
+    const result2 = prepareConfig(config2)
+    // Different config object references bypass the WeakMap,
+    // but the schema cache should still share the Schema object
+    expect(result1.workspaces[0].schema).toBe(result2.workspaces[0].schema)
+  })
+
+  it('schema with validation errors throws SchemaError', () => {
+    // A schema type with an invalid field configuration should throw SchemaError
+    const config = {
+      name: 'default',
+      projectId: 'ppsg7ml5',
+      dataset: 'production',
+      schema: {
+        types: [
+          {
+            type: 'document' as const,
+            name: 'post',
+            fields: [
+              {
+                name: 'title',
+                type: 'nonExistentType',
+              },
+            ],
+          },
+        ],
+      },
+    }
+
+    expect(() => prepareConfig(config)).toThrow(SchemaError)
+  })
+})

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -102,6 +102,55 @@ function normalizeIcon(
 
 const preparedWorkspaces = new WeakMap<SingleWorkspace | WorkspaceOptions, WorkspaceSummary>()
 
+/**
+ * Cache for deduplicating Schema objects across workspaces with identical schema types.
+ * Keyed by a content hash of the resolved schema type definitions.
+ */
+const schemaCache = new Map<string, Schema>()
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    schemaCache.clear()
+  })
+}
+
+/**
+ * Clear the schema cache. Intended for use in tests only.
+ * @internal
+ */
+export function _clearSchemaCache(): void {
+  schemaCache.clear()
+}
+
+/**
+ * Compute a content key for a set of schema type definitions.
+ * Uses JSON.stringify with a replacer that handles functions,
+ * so two identical type sets produce the same key.
+ *
+ * Note: Function serialization uses .toString() which captures source text but NOT
+ * closed-over variable values. Two closures with identical source code but different
+ * captured values will produce the same key. This is acceptable because schema type
+ * definitions rarely use closures in this way — they are typically static definitions.
+ *
+ * Returns `null` if serialization fails (e.g. circular references), in which case
+ * the caller should skip caching and create a new Schema every time.
+ *
+ * @internal
+ */
+export function getSchemaContentKey(schemaTypes: unknown[]): string | null {
+  try {
+    return JSON.stringify(schemaTypes, (_key, value) => {
+      if (typeof value === 'function') {
+        return `__fn:${value.toString()}`
+      }
+      return value
+    })
+  } catch {
+    // Circular references or other serialization failures — skip caching
+    return null
+  }
+}
+
 // Create media library sources with configuration
 const createMediaLibraryAssetSources = (config: PluginOptions) => {
   const libraryId = mediaLibraryLibraryIdReducer({config, initialValue: undefined})
@@ -225,10 +274,20 @@ export function prepareConfig(
         })
       }
 
-      const schema = createSchema({
-        name: source.name,
-        types: schemaTypes,
-      })
+      const contentKey = getSchemaContentKey(schemaTypes)
+      const schemaKey = contentKey !== null ? `${source.name}:${contentKey}` : null
+      let schema: Schema
+      if (schemaKey !== null && schemaCache.has(schemaKey)) {
+        schema = schemaCache.get(schemaKey)!
+      } else {
+        schema = createSchema({
+          name: source.name,
+          types: schemaTypes,
+        })
+        if (schemaKey !== null) {
+          schemaCache.set(schemaKey, schema)
+        }
+      }
 
       const schemaValidationProblemGroups = schema._validation
       const schemaErrors = schemaValidationProblemGroups?.filter((msg) =>


### PR DESCRIPTION
### Description

When multiple workspaces share the same schema types (a common pattern for multi-dataset setups like production/staging), prepareConfig redundantly compiles the schema for each workspace. Schema compilation via `createSchema` is expensive, so this adds a content-based cache that deduplicates identical schemas across workspaces.

The cache uses a JSON content key derived from the resolved schema type definitions (with a replacer to handle functions), so workspaces with structurally identical types share the same Schema object.

### What to review

- packages/sanity/src/core/config/prepareConfig.tsx — the schemaCache Map, getSchemaContentKey helper, and the cache lookup in the workspace preparation loop
- Whether the content-key approach (JSON.stringify with function serialization) is robust enough, or if edge cases could produce false cache hits
- The cache uses a module-level Map — consider whether this could cause issues with stale schemas across HMR cycles or dynamic config changes

### Testing

Added unit tests in packages/sanity/src/core/config/__tests__/prepareConfig.test.ts:
- getSchemaContentKey returns the same key for identical types and different keys for different types
- Function values are serialized by their .toString() body
- Workspaces with identical schema types share the same Schema reference
- Workspaces with different schema types get distinct Schema objects
- Schemas with validation errors still throw as expected

### Notes for release

N/A: Internal performance optimization.