### PR TITLE
fix(cli): remove trailing space in yarn upgrade command

### DIFF
--- a/packages/sanity/src/_internal/cli/util/packageManager/upgradePackages.ts
+++ b/packages/sanity/src/_internal/cli/util/packageManager/upgradePackages.ts
@@ -26,7 +26,7 @@ export async function upgradePackages(
     output.print(`Running 'npm ${npmArgs.join(' ')}'`)
     result = await execa('npm', npmArgs, execOptions)
   } else if (packageManager === 'yarn') {
-    const yarnArgs = ['upgrade ', ...upgradePackageArgs]
+    const yarnArgs = ['upgrade', ...upgradePackageArgs]
     output.print(`Running 'yarn ${yarnArgs.join(' ')}'`)
     result = await execa('yarn', yarnArgs, execOptions)
   } else if (packageManager === 'pnpm') {


### PR DESCRIPTION
## Summary
- Fixes a trailing space in the yarn upgrade args: `'upgrade '` → `'upgrade'`
- This caused Yarn to fail with `Couldn't find a script named "upgrade "` when auto-upgrading studio dependencies

## The bug
In `upgradePackages.ts`, the yarn args array was `['upgrade ', ...packages]` instead of `['upgrade', ...packages]`. The trailing space meant Yarn tried to find a script literally named `"upgrade "` (with space), which never matches. That space isn't needed anyways since it's joined by spaces in https://github.com/sanity-io/sanity/pull/12300/changes#diff-5d5e02a715658a3cf96341b94b26c3b97da7c75c890900eadc370726d1efae65L30

## Test plan
- Run `sanity dev` with a Yarn workspace that has outdated Sanity dependencies
- Accept the auto-upgrade prompt
- Verify `yarn upgrade` runs without the "Couldn't find a script" error