### PR TITLE
fix(cli): use yarn up for Yarn 2+ (Berry) when auto-upgrading

### DIFF
--- a/packages/sanity/src/_internal/cli/util/packageManager/packageManagerChoice.ts
+++ b/packages/sanity/src/_internal/cli/util/packageManager/packageManagerChoice.ts
@@ -198,3 +198,9 @@ function getRunningPackageManager(): PackageManager | undefined {
 
   return undefined
 }
+
+export function getPackageManagerVersion(): number | undefined {
+  const agent = process.env.npm_config_user_agent || ''
+  const match = agent.match(/(?:yarn|npm|pnpm|bun)\/(\d+)/)
+  return match ? parseInt(match[1], 10) : undefined
+}

--- a/packages/sanity/src/_internal/cli/util/packageManager/upgradePackages.ts
+++ b/packages/sanity/src/_internal/cli/util/packageManager/upgradePackages.ts
@@ -1,6 +1,10 @@
 import execa, {type CommonOptions, type ExecaReturnValue} from 'execa'
 
-import {getPartialEnvWithNpmPath, type PackageManager} from './packageManagerChoice'
+import {
+  getPackageManagerVersion,
+  getPartialEnvWithNpmPath,
+  type PackageManager,
+} from './packageManagerChoice'
 
 export interface InstallOptions {
   packageManager: PackageManager
@@ -26,7 +30,8 @@ export async function upgradePackages(
     output.print(`Running 'npm ${npmArgs.join(' ')}'`)
     result = await execa('npm', npmArgs, execOptions)
   } else if (packageManager === 'yarn') {
-    const yarnArgs = ['upgrade ', ...upgradePackageArgs]
+    const upgradeCmd = (getPackageManagerVersion() ?? 0) >= 2 ? 'up' : 'upgrade'
+    const yarnArgs = [upgradeCmd, ...upgradePackageArgs]
     output.print(`Running 'yarn ${yarnArgs.join(' ')}'`)
     result = await execa('yarn', yarnArgs, execOptions)
   } else if (packageManager === 'pnpm') {


### PR DESCRIPTION
## Summary
- Detects Yarn 2+ (Berry) at runtime and uses `yarn up` instead of `yarn upgrade`
- `yarn upgrade` was replaced with `yarn up` starting in Yarn 2

## The problem
When running `sanity dev` with Yarn Berry, the auto-upgrade prompt runs `yarn upgrade <pkg>@<version>` which doesn't exist. This results in:
```
Usage Error: Couldn't find a script named "upgrade".
```

## The fix
Parses the yarn version from `npm_config_user_agent` (e.g. `yarn/4.9.4`) and uses `up` for v2+ or `upgrade` for Classic (v1).

## Test plan
- Run `sanity dev` in a Yarn Berry workspace with outdated Sanity deps
- Accept the auto-upgrade prompt
- Verify `yarn up <pkg>@<version>` runs successfully
- Verify Yarn Classic (v1) workspaces still use `yarn upgrade`