### PR TITLE
chore: enable hmr for design-studio

### DIFF
--- a/dev/design-studio/package.json
+++ b/dev/design-studio/package.json
@@ -37,7 +37,8 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "sanity": "workspace:*",
-    "styled-components": "catalog:"
+    "styled-components": "catalog:",
+    "vite": "catalog:"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/dev/design-studio/sanity.cli.ts
+++ b/dev/design-studio/sanity.cli.ts
@@ -1,0 +1,67 @@
+import {defineCliConfig} from 'sanity/cli'
+import {defaultClientConditions, mergeConfig, type UserConfig} from 'vite'
+
+const reactCompilerAllowList = /\/(?:sanity|@sanity\/vision)\/src\/.*\.tsx?$/
+
+export default defineCliConfig({
+  api: {
+    projectId: 'ppsg7ml5',
+    dataset: 'design-studio',
+  },
+  reactCompiler: {
+    target: '19',
+    // By default the compiler is loaded up on all workspace files, even sanity/lib/structure.js which is pre-compiled with `@sanity/pkg-utils`,
+    // and so we filter by just studio files
+    sources: (filename) => {
+      // The default behavior is to always skip node_modules: https://github.com/facebook/react/blob/d6cae440e34c6250928e18bed4a16480f83ae18a/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts#L326
+      if (filename.indexOf('node_modules') !== -1) {
+        return false
+      }
+      // If the file is `.ts` or `.tsx` then we should run the compiler (it's resolved with the `monorepo` condition during `sanity dev`)
+      // otherwise it's likely resolving a built file that had react compiler already applied during its build process
+      return reactCompilerAllowList.test(filename)
+    },
+  },
+  vite(viteConfig: UserConfig, {command, mode}): UserConfig {
+    const nextConfig = mergeConfig(viteConfig, {
+      server: {
+        warmup: {
+          clientFiles: [
+            /**
+             * Since the test studio on the monorepo is using src files for `sanity`, `sanity/structure`, `@sanity/vision`, etc,
+             * it's not enough with the default `./.sanity/runtime/app.js` warmup file,
+             * we have to add a few more to avoid the initial "waterfall of reload doom" scenario.
+             * The ones we add here are from lazy loaded import() calls that are discovered late due to our file structure.
+             * They're not a problem in production, as our npm bundling hoists the dynamic imports to the top level entrypoint so vite discovers them early.
+             */
+            // https://github.com/sanity-io/sanity/blob/f6357dbe1e19076286c06de8d2c272058c0dc01e/packages/sanity/src/structure/structureTool.ts#L108
+            './node_modules/sanity/src/structure/components/structureTool/StructureToolBoundary.tsx',
+            // https://github.com/sanity-io/sanity/blob/f6357dbe1e19076286c06de8d2c272058c0dc01e/packages/sanity/src/presentation/plugin.tsx#L26
+            './node_modules/sanity/src/presentation/PresentationToolGrantsCheck.tsx',
+            // https://github.com/sanity-io/sanity/blob/f6357dbe1e19076286c06de8d2c272058c0dc01e/packages/sanity/src/presentation/plugin.tsx#L27
+            './node_modules/sanity/src/presentation/loader/BroadcastDisplayedDocument.tsx',
+            // https://github.com/sanity-io/sanity/blob/f6357dbe1e19076286c06de8d2c272058c0dc01e/packages/sanity/src/structure/panes/StructureToolPane.tsx#L26
+            './node_modules/sanity/src/structure/panes/userComponent/UserComponentPane.tsx',
+            // https://github.com/sanity-io/sanity/blob/f6357dbe1e19076286c06de8d2c272058c0dc01e/packages/sanity/src/structure/panes/StructureToolPane.tsx#L27
+            './node_modules/sanity/src/structure/panes/document/DocumentPane.tsx',
+            // https://github.com/sanity-io/sanity/blob/f6357dbe1e19076286c06de8d2c272058c0dc01e/packages/sanity/src/structure/panes/StructureToolPane.tsx#L28
+            './node_modules/sanity/src/structure/panes/documentList/PaneContainer.tsx',
+            // https://github.com/sanity-io/sanity/blob/f6357dbe1e19076286c06de8d2c272058c0dc01e/packages/sanity/src/structure/panes/StructureToolPane.tsx#L29
+            './node_modules/sanity/src/structure/panes/list/ListPane.tsx',
+          ],
+        },
+      },
+      // Needed due to the monorepo setup, optimizeDeps will cause duplication of context providers when it chunks lazy imports so we have to disable optimization
+      optimizeDeps: {exclude: ['sanity']},
+    } satisfies UserConfig)
+
+    // Support hot reloading of files from monorepo workspaces during development
+    if (mode !== 'production' && command === 'serve') {
+      return mergeConfig(nextConfig, {
+        resolve: {conditions: ['monorepo', ...defaultClientConditions]},
+      } satisfies UserConfig)
+    }
+
+    return nextConfig
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,9 @@ importers:
       styled-components:
         specifier: 'catalog:'
         version: '@sanity/styled-components@6.1.24(react-dom@19.2.4(react@19.2.4))(react@19.2.4)'
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.1(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
     devDependencies:
       eslint:
         specifier: 'catalog:'


### PR DESCRIPTION
### Description
Enables hot reloading for design studio, e.g. when running `pnpm dev:design-studio`

### What to review
- Copied over the vite config from `test-studio`

### Testing

- run `pnpm dev:design-studio`
- make a change to any of the studio components `/packages/sanity/src`
- verify that the design studio reloads and reflects the changes

### Notes for release

n/a – internal