### PR TITLE
fix(sanity): ensure dedicated `ReferenceFieldDiff` is used when diffing cross dataset references

### DIFF
--- a/packages/sanity/src/core/field/diff/resolve/defaultComponents.ts
+++ b/packages/sanity/src/core/field/diff/resolve/defaultComponents.ts
@@ -21,6 +21,7 @@ export const defaultComponents: Record<
   image: ImageFieldDiff,
   number: NumberFieldDiff,
   reference: ReferenceFieldDiff,
+  crossDatasetReference: ReferenceFieldDiff,
   slug: SlugFieldDiff,
   string: StringFieldDiff,
 }


### PR DESCRIPTION
### Description

This branch updates the diff component resolver so that cross dataset references use the existing reference diff component (which it's compatible with).

Not only does this provide better UX, but it's vital for showing divergences affecting cross dataset references.

#### Before

<img width="1191" height="459" alt="before" src="https://github.com/user-attachments/assets/ea33bd43-82d5-4b04-8d1f-49f4aa37e20c" />

#### After

<img width="1191" height="459" alt="after" src="https://github.com/user-attachments/assets/8bd2de08-a257-40a3-beed-d11a9bbb481f" />

### What to review

Diff component resolver.

### Testing

Previewed a cross dataset reference in Test Studio to verify correct diff component rendered.

### Notes for release

Adds rich diff previews when inspecting changes in cross dataset reference fields.