### PR TITLE
fix: do not use _strengthenOnPublish if reference is in the same release

### DIFF
--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
@@ -9,7 +9,7 @@ import {Button} from '../../../../ui-components'
 import {ReferenceInputPreviewCard} from '../../../components'
 import {Translate, useTranslation} from '../../../i18n'
 import {usePerspective} from '../../../perspective/usePerspective'
-import {getPublishedId, isNonNullable} from '../../../util'
+import {getPublishedId, getVersionFromId, isNonNullable} from '../../../util'
 import {Alert} from '../../components/Alert'
 import {useDidUpdate} from '../../hooks/useDidUpdate'
 import {set, setIfMissing, unset} from '../../patch'
@@ -43,6 +43,7 @@ interface AutocompleteOption {
   hit: ReferenceSearchHit
   value: string
 }
+
 export function ReferenceInput(props: ReferenceInputProps) {
   const {
     createOptions,
@@ -144,12 +145,16 @@ export function ReferenceInput(props: ReferenceInputProps) {
       }
       // if there's no published version of this document, set the reference to weak
 
+      const isSameReleaseRef = selectedReleaseId == getVersionFromId(hit.originalId)
+
       const patches = [
         setIfMissing({}),
         set(schemaType.name, ['_type']),
         set(getPublishedId(nextId), ['_ref']),
-        hit.published && !schemaType.weak ? unset(['_weak']) : set(true, ['_weak']),
-        hit.published
+        (hit.published || isSameReleaseRef) && !schemaType.weak
+          ? unset(['_weak'])
+          : set(true, ['_weak']),
+        hit.published || isSameReleaseRef
           ? unset(['_strengthenOnPublish'])
           : set({type: hit?.type, weak: schemaType.weak}, ['_strengthenOnPublish']),
       ].filter(isNonNullable)
@@ -158,7 +163,15 @@ export function ReferenceInput(props: ReferenceInputProps) {
       // Move focus away from _ref and one level up
       onPathFocus(path)
     },
-    [onChange, onPathFocus, schemaType.name, schemaType.weak, searchState.hits, path],
+    [
+      onChange,
+      onPathFocus,
+      schemaType.name,
+      schemaType.weak,
+      searchState.hits,
+      selectedReleaseId,
+      path,
+    ],
   )
 
   const handleClear = useCallback(() => {

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx
@@ -145,7 +145,8 @@ export function ReferenceInput(props: ReferenceInputProps) {
       }
       // if there's no published version of this document, set the reference to weak
 
-      const isSameReleaseRef = selectedReleaseId == getVersionFromId(hit.originalId)
+      const isSameReleaseRef =
+        selectedReleaseId && selectedReleaseId == getVersionFromId(hit.originalId)
 
       const patches = [
         setIfMissing({}),

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/types.ts
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/types.ts
@@ -67,6 +67,7 @@ export interface ReferenceSearchHit {
   id: string
   type: string
   published: boolean
+  originalId: string
 }
 
 export interface ReferenceInputProps<Value = Reference> extends ObjectInputProps<

--- a/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
+++ b/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-nested-callbacks */
 import {type SanityDocument, type StackablePerspective} from '@sanity/client'
-import {getPublishedId} from '@sanity/client/csm'
+import {getPublishedId, getVersionFromId} from '@sanity/client/csm'
 import {DEFAULT_MAX_FIELD_DEPTH} from '@sanity/schema/_internal'
 import {
   type Reference,
@@ -159,6 +159,7 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
                     id: doc._id,
                     type: doc._type,
                     published: Boolean(published),
+                    originalId: doc._originalId,
                   })),
                 ),
               ),

--- a/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
+++ b/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-nested-callbacks */
 import {type SanityDocument, type StackablePerspective} from '@sanity/client'
-import {getPublishedId, getVersionFromId} from '@sanity/client/csm'
+import {getPublishedId} from '@sanity/client/csm'
 import {DEFAULT_MAX_FIELD_DEPTH} from '@sanity/schema/_internal'
 import {
   type Reference,

--- a/packages/sanity/src/core/search/common/types.ts
+++ b/packages/sanity/src/core/search/common/types.ts
@@ -47,7 +47,7 @@ export interface SearchStory {
  * @internal
  */
 export interface SearchHit {
-  hit: SanityDocumentLike
+  hit: SanityDocumentLike & {_originalId: string}
 }
 
 /**


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
