### PR TITLE
ci: make bundle stats check non-blocking to CI

### DIFF
--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   bundle-stats:
+    continue-on-error: true
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
### Description
The bundle stats check shouldn't be a required gate to pass through to merge branches. It should be treated much like EFPS steps
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
