### PR TITLE
fix(sanity): fix crash when calling `operation.delete.execute()` without versions argument

### DIFF
--- a/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/delete.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/serverOperations/delete.ts
@@ -3,10 +3,10 @@ import {isPublishedId} from '@sanity/client/csm'
 import {type OperationImpl} from '../operations/types'
 import {actionsApiClient} from '../utils/actionsApiClient'
 
-export const del: OperationImpl<[versions: string[]], 'NOTHING_TO_DELETE'> = {
+export const del: OperationImpl<[versions?: string[]], 'NOTHING_TO_DELETE'> = {
   disabled: ({snapshots}) =>
     snapshots.draft || snapshots.published || snapshots.version ? false : 'NOTHING_TO_DELETE',
-  execute: ({client, idPair, snapshots}, versions) => {
+  execute: ({client, idPair, snapshots}, versions = []) => {
     //the delete action requires a published doc -- discard versions if not present
     if (!snapshots.published) {
       return actionsApiClient(client, idPair).observable.action(


### PR DESCRIPTION
### Description
Fixes a regression in Studio [v4.22.0](https://github.com/sanity-io/sanity/compare/v4.21.1...v4.22.0) causing a crash when a custom component calls operations.delete.execute() without arguments (error: Cannot read properties of undefined (reading 'map')).


### Notes for release
Fixes regression from v4.22.0 where `operations.delete.execute()` called without arguments caused a crash in custom components or document actions.