### PR TITLE
fix(sanity): disable delete action for agent bundle versions

### DIFF
--- a/packages/sanity/src/core/store/index.ts
+++ b/packages/sanity/src/core/store/index.ts
@@ -1,4 +1,5 @@
 export * from './_legacy'
+export {isAgentBundleName} from './agent/createAgentBundlesStore'
 export {type AgentVersionDisplay, useAgentVersionDisplay} from './agent/useAgentVersionDisplay'
 export * from './events'
 export * from './user'

--- a/packages/sanity/src/structure/documentActions/DeleteAction.tsx
+++ b/packages/sanity/src/structure/documentActions/DeleteAction.tsx
@@ -4,6 +4,7 @@ import {
   type DocumentActionComponent,
   getVersionFromId,
   InsufficientPermissionsMessage,
+  isAgentBundleName,
   isReleaseScheduledOrScheduling,
   useCurrentUser,
   useDocumentOperation,
@@ -24,6 +25,7 @@ const DISABLED_REASON_TITLE_KEY = {
 /** @internal */
 export const useDeleteAction: DocumentActionComponent = ({id, type, draft, version}) => {
   const bundleId = version?._id && getVersionFromId(version._id)
+  const isAgentBundle = isAgentBundleName(bundleId)
   const {delete: deleteOp} = useDocumentOperation(id, type, bundleId)
   const [isDeleting, setIsDeleting] = useState(false)
   const [isConfirmDialogOpen, setConfirmDialogOpen] = useState(false)
@@ -61,6 +63,8 @@ export const useDeleteAction: DocumentActionComponent = ({id, type, draft, versi
   const currentUser = useCurrentUser()
 
   return useMemo(() => {
+    if (isAgentBundle) return null
+
     if (!isPermissionsLoading && !permissions?.granted) {
       return {
         tone: 'critical',
@@ -113,6 +117,7 @@ export const useDeleteAction: DocumentActionComponent = ({id, type, draft, versi
     handleCancel,
     handleConfirm,
     hasScheduledRelease,
+    isAgentBundle,
     id,
     isConfirmDialogOpen,
     isDeleting,


### PR DESCRIPTION
Stacked on #12329.

Disables the delete action when viewing an agent bundle version. Agent bundles are managed by the agent system — the studio shouldn't offer to delete them, especially since the cascade delete dialog would nuke all versions including other users' bundles.

### Changes

- Export `isAgentBundleName` from `core/store` so it's available via `'sanity'`
- Disable the delete action in `DeleteAction.tsx` when the current version is an agent bundle

Fixes SAPP-3592