### PR TITLE
fix(core): remove noisy hotkeys stability warning

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useHotKeys.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useHotKeys.tsx
@@ -3,18 +3,11 @@ import {useMemo, useState} from 'react'
 
 import {usePortableTextMemberSchemaTypes} from '../contexts/PortableTextMemberSchemaTypes'
 
-// This hook will create final hotkeys for the editor from on those from props.
+// This hook will create final hotkeys for the editor based on those from props.
 export function useHotkeys(hotkeys: HotkeyOptions): HotkeyOptions {
   const schemaTypes = usePortableTextMemberSchemaTypes()
-
-  // Guard that hotkeys from props will be a stable object.
-  // If this props is defined inline and is always a new object, there will be issues with key handling and cursor!
   const [initialHotkeys] = useState(() => hotkeys)
-  if (initialHotkeys !== hotkeys) {
-    console.warn(
-      'Make sure that hotkeys are a stable object across renders, or there will be issues with key handling in the Portable Text Editor.',
-    )
-  }
+
   return useMemo(() => {
     const defaultHotkeys: {marks: Record<string, string>} = {marks: {}}
     schemaTypes.decorators.forEach((dec) => {


### PR DESCRIPTION
### Description

The console is currently littered with hotkey warnings:

<img width="1199" height="328" alt="Screenshot 2026-03-06 at 10 18 05" src="https://github.com/user-attachments/assets/0bffc12f-273f-4757-a35c-e40fcd136d0f" />

This commit removes the `console.warn` in `useHotkeys` that fires when the `hotkeys` prop changes reference across renders.

The warning fires frequently because `handleToggleFullscreen` in `PortableTextInput.tsx` depends on `path` (an array prop that gets a new reference on re-renders), which causes `hotkeysWithFullscreenToggle` in `Compositor.tsx` to recompute, giving `useHotkeys` a new object on every render.

The warning is unnecessary because the hook already captures the initial hotkeys in `useState` and uses that stable reference in the `useMemo` - the actual hotkey behavior is unaffected by prop reference changes.

### What to review

The only change is removing the `console.warn` and its guard condition. The `useState` capture and `useMemo` are preserved.

### Testing

No behavioral change - the hotkeys work exactly as before, just without the console noise.

### Notes for release

Removed a noisy `console.warn` about hotkeys stability that fired on every render in the Portable Text input.