### PR TITLE
test(sanity): mock fromEvent modules in ReleaseSummary test

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
@@ -14,6 +14,7 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {getByDataUi} from '../../../../../../test/setup/customQueries'
 import {setupVirtualListEnv} from '../../../../../../test/testUtils/setupVirtualListEnv'
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import type * as ConnectionStatusStoreMod from '../../../../store/_legacy/connection-status/connection-status-store'
 import {
   activeASAPRelease,
   archivedScheduledRelease,
@@ -89,6 +90,22 @@ vi.mock('../../../../preview/streams/visibilityChange', async () => {
   const {EMPTY} = await import('rxjs')
   return {visibilityChange$: EMPTY}
 })
+vi.mock('../../../../store/_legacy/debugParams/debugParams', async () => {
+  const {of} = await import('rxjs')
+  return {debugParams$: of([]), debugRolesParam$: of([])}
+})
+
+vi.mock(
+  '../../../../store/_legacy/connection-status/connection-status-store',
+  async (importOriginal) => {
+    const mod = await importOriginal<typeof ConnectionStatusStoreMod>()
+    const {of} = await import('rxjs')
+    return {
+      ...mod,
+      createConnectionStatusStore: () => ({connectionStatus$: of(mod.CONNECTING)}),
+    }
+  },
+)
 
 const releaseDocuments = [
   {


### PR DESCRIPTION
### Description
Fixes a recurring test failure due to a race condition between refCountDelay and jsdom teardown, made visible in Node 24.

Based on claude's assesment, the root cause is this:
1. ReleaseSummary renders components that use useDocumentPairPermissions → useGrantsStore →
  createGrantsStore
2. The grants store subscribes to debugParams$ which uses fromEvent(window, 'hashchange') (in
  packages/sanity/src/core/store/_legacy/debugParams/debugParams.ts)
3. The grants store wraps this with refCountDelay(1000) — meaning after the last subscriber unsubscribes, it waits 1000ms before actually unsubscribing from the upstream fromEvent
4. When the test ends, React unmounts and unsubscribes from the grants store  5. refCountDelay starts a 1000ms timer before unsubscribing from fromEvent(window, 'hashchange')
6. Meanwhile, vitest's jsdom teardown runs and deletes removeEventListener from the global window
7. After 1000ms, refCountDelay fires and tries to call window.removeEventListener('hashchange', handler)
  — but removeEventListener no longer exists → boom

### Why Node 24 only?
The error was always latent. Node 24's newer V8 engine likely processes pending timers during teardown more aggressively or surfaces unhandled errors from async callbacks that were previously swallowed. 

### What to review

If tests pass now, we're good

### Testing
This is fixing a failing test

### Notes for release
n/a – internal only