### PR TITLE
fix(core): when redirecting to workspace preserve search & hash

### DIFF
--- a/dev/test-studio/plugins/router-debug/RouterDebug.tsx
+++ b/dev/test-studio/plugins/router-debug/RouterDebug.tsx
@@ -4,7 +4,7 @@ import {useClient} from 'sanity'
 import {IntentLink, RouteScope, StateLink, useRouter, useStateLink} from 'sanity/router'
 
 export function RouterDebug() {
-  const {navigate} = useRouter()
+  const {navigate, navigateUrl} = useRouter()
 
   const link = useStateLink({
     state: {
@@ -56,6 +56,17 @@ export function RouterDebug() {
           >
             Open in focus mode
           </IntentLink>
+
+          <Button
+            onClick={() =>
+              navigateUrl({
+                path: '/?sidebar=tasks&selectedTask=a763cdc1-d517-45b2-b3b9-19bf7507f4e5&viewMode=edit',
+                replace: false,
+              })
+            }
+          >
+            Open Task
+          </Button>
           <Button
             onClick={() => {
               navigate({

--- a/packages/sanity/src/core/studio/activeWorkspaceMatcher/ActiveWorkspaceMatcher.tsx
+++ b/packages/sanity/src/core/studio/activeWorkspaceMatcher/ActiveWorkspaceMatcher.tsx
@@ -44,7 +44,11 @@ export function ActiveWorkspaceMatcher({
 
   useEffect(() => {
     if (result.type === 'redirect') {
-      history.replace(result.pathname)
+      history.replace({
+        pathname: result.pathname,
+        search: history.location.search,
+        hash: history.location.hash,
+      })
     }
   }, [history, result])
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

With tasks, Dashboard gets the URL like `/?sidebar=tasks&selectedTask=a763cdc1-d517-45b2-b3b9-19bf7507f4e5&viewMode=edit`. If the studio is already open then it doesn't navigate. This is because we see it as a redirect to a workspace & do not preserve the 

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
