### PR TITLE
fix: resolving issue where multiple scrollable containers show in the releases global nav menu

### DIFF
--- a/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenu.tsx
+++ b/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenu.tsx
@@ -38,7 +38,7 @@ export function GlobalPerspectiveMenu({
     useReleasesUpsell()
   const styledMenuRef = useRef<HTMLDivElement>(null)
 
-  const {isRangeVisible, onScroll, resetRangeVisibility, setScrollContainer, scrollElementRef} =
+  const {isRangeVisible, resetRangeVisibility, setScrollContainer, scrollElementRef} =
     useScrollIndicatorVisibility()
   const handleOpenBundleDialog = useCallback(() => {
     if (releasesUpsellMode === 'upsell') {
@@ -71,7 +71,6 @@ export function GlobalPerspectiveMenu({
             <ReleasesList
               areReleasesEnabled={areReleasesEnabled}
               setScrollContainer={setScrollContainer}
-              onScroll={onScroll}
               isRangeVisible={isRangeVisible}
               scrollElementRef={scrollElementRef}
               selectedPerspectiveName={selectedPerspectiveName}
@@ -81,10 +80,13 @@ export function GlobalPerspectiveMenu({
           </StyledMenu>
         }
         popover={{
+          __unstable_margins: [0, 0, 32, 0],
           constrainSize: true,
           fallbackPlacements: ['bottom-end'],
           placement: 'bottom-end',
           portal: true,
+          // @ts-expect-error PopoverProps doesn't include `style`, but the Popover implementation accepts it via React.HTMLProps<HTMLDivElement>
+          style: {overflow: 'hidden'} as React.CSSProperties,
           tone: 'default',
           zOffset: 3000,
         }}

--- a/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
@@ -22,15 +22,23 @@ import {ViewContentReleasesMenuItem} from './ViewContentReleasesMenuItem'
 
 const orderedReleaseTypes: ReleaseType[] = ['asap', 'scheduled', 'undecided']
 
-const ScrollWrapper = styled(Stack)`
-  overflow: auto;
-  max-height: 75vh;
+const StickyCard = styled(Card)`
+  position: sticky;
+  z-index: 2;
+  background: var(--card-bg-color);
+`
+
+const StickyTopCard = styled(StickyCard)`
+  top: 0;
+`
+
+const StickyBottomCard = styled(StickyCard)`
+  bottom: 0;
 `
 
 export function ReleasesList({
   areReleasesEnabled,
   setScrollContainer,
-  onScroll,
   isRangeVisible,
   selectedPerspectiveName,
   handleOpenBundleDialog,
@@ -38,8 +46,7 @@ export function ReleasesList({
   menuItemProps,
 }: {
   areReleasesEnabled: boolean
-  setScrollContainer: (el: HTMLDivElement) => void
-  onScroll: (event: React.UIEvent<HTMLDivElement>) => void
+  setScrollContainer: (el: HTMLElement | null) => void
   isRangeVisible: boolean
   selectedPerspectiveName: string | undefined
   handleOpenBundleDialog: () => void
@@ -114,8 +121,8 @@ export function ReleasesList({
   }
 
   return (
-    <Card radius={3} overflow="hidden">
-      <Card borderBottom padding={1}>
+    <Card radius={3}>
+      <StickyTopCard borderBottom padding={1}>
         <Stack space={1}>
           <GlobalPerspectiveMenuItem
             rangePosition={isRangeVisible ? getRangePosition(range, 0) : undefined}
@@ -130,9 +137,9 @@ export function ReleasesList({
             />
           )}
         </Stack>
-      </Card>
+      </StickyTopCard>
       {areReleasesEnabled && (
-        <ScrollWrapper ref={setScrollContainer} onScroll={onScroll} data-ui="scroll-wrapper">
+        <Stack ref={setScrollContainer} data-ui="scroll-wrapper">
           {orderedReleaseTypes.map((releaseType) => (
             <ReleaseTypeMenuSection
               key={releaseType}
@@ -143,16 +150,16 @@ export function ReleasesList({
               menuItemProps={menuItemProps}
             />
           ))}
-        </ScrollWrapper>
+        </Stack>
       )}
       {areReleasesEnabled && (
-        <Card borderTop paddingY={1} paddingX={2}>
+        <StickyBottomCard borderTop paddingY={1} paddingX={2}>
           <Stack space={1}>
             <ScheduledDraftsMenuItem />
             <ViewContentReleasesMenuItem />
             <CreateReleaseMenuItem onCreateRelease={handleOpenBundleDialog} />
           </Stack>
-        </Card>
+        </StickyBottomCard>
       )}
     </Card>
   )

--- a/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesList.test.tsx
+++ b/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesList.test.tsx
@@ -61,7 +61,6 @@ describe('ReleasesList', () => {
         <Menu>
           <ReleasesList
             setScrollContainer={vi.fn()}
-            onScroll={vi.fn()}
             isRangeVisible={false}
             selectedPerspectiveName={undefined}
             handleOpenBundleDialog={handleOpenBundleDialog}
@@ -83,7 +82,6 @@ describe('ReleasesList', () => {
         <Menu>
           <ReleasesList
             setScrollContainer={vi.fn()}
-            onScroll={vi.fn()}
             isRangeVisible={false}
             selectedPerspectiveName={undefined}
             handleOpenBundleDialog={handleOpenBundleDialog}
@@ -134,7 +132,6 @@ describe('ReleasesList', () => {
         <Menu>
           <ReleasesList
             setScrollContainer={vi.fn()}
-            onScroll={vi.fn()}
             isRangeVisible={false}
             selectedPerspectiveName={undefined}
             handleOpenBundleDialog={handleOpenBundleDialog}
@@ -167,7 +164,6 @@ describe('ReleasesList', () => {
         <Menu>
           <ReleasesList
             setScrollContainer={vi.fn()}
-            onScroll={vi.fn()}
             isRangeVisible={false}
             selectedPerspectiveName={undefined}
             handleOpenBundleDialog={handleOpenBundleDialog}
@@ -193,7 +189,6 @@ describe('ReleasesList', () => {
         <Menu>
           <ReleasesList
             setScrollContainer={vi.fn()}
-            onScroll={vi.fn()}
             isRangeVisible={false}
             selectedPerspectiveName={undefined}
             handleOpenBundleDialog={handleOpenBundleDialog}
@@ -223,7 +218,6 @@ describe('ReleasesList', () => {
         <Menu>
           <ReleasesList
             setScrollContainer={vi.fn()}
-            onScroll={vi.fn()}
             isRangeVisible={false}
             selectedPerspectiveName={undefined}
             handleOpenBundleDialog={handleOpenBundleDialog}

--- a/packages/sanity/src/core/perspective/navbar/useScrollIndicatorVisibility.ts
+++ b/packages/sanity/src/core/perspective/navbar/useScrollIndicatorVisibility.ts
@@ -1,8 +1,20 @@
-import {useCallback, useMemo, useRef, useState} from 'react'
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 
-export type ScrollElement = HTMLDivElement | null
+export type ScrollElement = HTMLElement | null
 
-function isElementVisibleInContainer(container: ScrollElement, element: ScrollElement) {
+function findScrollableAncestor(element: HTMLElement): HTMLElement | null {
+  let current: HTMLElement | null = element.parentElement
+  while (current) {
+    const {overflowY} = getComputedStyle(current)
+    if (overflowY === 'auto' || overflowY === 'scroll') {
+      return current
+    }
+    current = current.parentElement
+  }
+  return null
+}
+
+function isElementVisibleInContainer(container: ScrollElement, element: ScrollElement): boolean {
   if (!container || !element) return true
 
   const containerRect = container.getBoundingClientRect()
@@ -15,33 +27,57 @@ function isElementVisibleInContainer(container: ScrollElement, element: ScrollEl
 }
 
 export const useScrollIndicatorVisibility = () => {
-  const scrollContainerRef = useRef<ScrollElement>(null)
   const scrollElementRef = useRef<ScrollElement>(null)
+  const scrollAncestorRef = useRef<HTMLElement | null>(null)
 
   const [isRangeVisible, setIsRangeVisible] = useState(true)
 
   const handleScroll = useCallback(
     () =>
       setIsRangeVisible(
-        isElementVisibleInContainer(scrollContainerRef.current, scrollElementRef.current),
+        isElementVisibleInContainer(scrollAncestorRef.current, scrollElementRef.current),
       ),
     [],
   )
 
-  const setScrollContainer = useCallback((container: HTMLDivElement) => {
-    scrollContainerRef.current = container
-  }, [])
+  const setScrollContainer = useCallback(
+    (container: HTMLElement | null) => {
+      const previousAncestor = scrollAncestorRef.current
+      if (previousAncestor) {
+        previousAncestor.removeEventListener('scroll', handleScroll)
+        scrollAncestorRef.current = null
+      }
+
+      if (container) {
+        const scrollableAncestor = findScrollableAncestor(container)
+        scrollAncestorRef.current = scrollableAncestor
+
+        if (scrollableAncestor) {
+          scrollableAncestor.addEventListener('scroll', handleScroll, {passive: true})
+        }
+      }
+    },
+    [handleScroll],
+  )
+
+  useEffect(() => {
+    return () => {
+      const ancestor = scrollAncestorRef.current
+      if (ancestor) {
+        ancestor.removeEventListener('scroll', handleScroll)
+      }
+    }
+  }, [handleScroll])
 
   const resetRangeVisibility = useCallback(() => setIsRangeVisible(true), [])
 
   return useMemo(
     () => ({
       resetRangeVisibility,
-      onScroll: handleScroll,
       isRangeVisible,
       setScrollContainer,
       scrollElementRef,
     }),
-    [handleScroll, isRangeVisible, resetRangeVisibility, setScrollContainer],
+    [isRangeVisible, resetRangeVisibility, setScrollContainer],
   )
 }


### PR DESCRIPTION
### Description
The perspective menu's header and footer items would scroll away with the list content. 

This fix makes them sticky by moving scroll responsibility to the popover's constrained container and using sticky positioning for the top (Published/Drafts) and bottom (Scheduled Drafts/View Releases/Create Release) sections.

Before:
![releasesMenuScrollBEFORE](https://github.com/user-attachments/assets/7ef25534-b2f1-404a-beda-765e817ad78e)

After:
![releasesMenuScrollAFTER](https://github.com/user-attachments/assets/cd63a217-aeff-4389-b6e4-21047f54e772)

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
The `style` prop on the popover is suppressed with `@ts-expect-error` because `PopoverProps` in `@sanity/ui` doesn't include `style` in its type definition, even though the underlying `Popover` component accepts it at runtime via `React.HTMLProps<HTMLDivElement>`. I am going to make a change to the `@sanity/ui` types so that this can be resolved, but for now keeping the TS error suppression seems the smoothest way of getting this fix in
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue where on narrower screens the list of releases would have multiple scrollbars
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->

