### PR TITLE
fix(sanity): `FormRow` exports snapshots

### DIFF
--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -115,7 +115,7 @@ exports[`exports snapshot 1`] = `
     "FormFieldValidationStatus": "function",
     "FormInput": "object",
     "FormProvider": "function",
-    "FormRow": "object",
+    "FormRow": "function",
     "FormValueProvider": "function",
     "FromTo": "object",
     "FromToArrow": "function",


### PR DESCRIPTION
### Description

Not quite sure how this slipped through CI checks when we changed the export itself in an earlier PR. Fixed export snapshot.

### What to review

Exports snapshot.

### Testing

Tests pass.