### PR TITLE
fix: dont use localStorage in node.js

### DIFF
--- a/packages/sanity/src/core/util/supportsLocalStorage.ts
+++ b/packages/sanity/src/core/util/supportsLocalStorage.ts
@@ -5,6 +5,16 @@
  * @internal
  */
 export const supportsLocalStorage = (() => {
+  // Non-browser runtimes (Node.js 22+, Bun, Deno) may expose a built-in
+  // `localStorage` global that either warns or behaves differently from the
+  // browser implementation. Since this utility is only useful in real browsers,
+  // bail out in non-browser environments — even if browser globals have been
+  // mocked (e.g., jsdom in CLI commands/tests). `process.versions` is set by
+  // all major server-side runtimes and is not faked by jsdom.
+  if (typeof process !== 'undefined' && typeof process.versions !== 'undefined') {
+    return false
+  }
+
   const key = '__tmp_supports_local_storage'
 
   try {


### PR DESCRIPTION
### Description

Node.js now exposes `localStorage` and warns (in 25+) if trying to access it without providing a file path:

```
(node:23423) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)
```

When running commands such as `sanity schema extract` or `sanity documents validate`, this path with be triggered.   Because we mock browser globals while trying to read the schema, we can't just do a simple `window` check - this attempts to solve it by checking the presence of `process.versions`.

Note: This might impact any tests that used JSDOM/happy-dom and previously relied on localStorage somehow, lets see what the tests say.

Fixes #12183

### Notes for release

Fixes an issue where localStorage deprecation warnings would be printed when running certain CLI commands using Node.js v25.
