### PR TITLE
fix(tasks): remove task specific params when closing sidebar

### DIFF
--- a/packages/sanity/src/core/tasks/components/activity/TasksActivityLog.tsx
+++ b/packages/sanity/src/core/tasks/components/activity/TasksActivityLog.tsx
@@ -20,6 +20,11 @@ import {type FormPatch, type PatchEvent, set} from '../../../form'
 import {useTranslation} from '../../../i18n'
 import {useCurrentUser} from '../../../store'
 import {useWorkspace} from '../../../studio'
+import {
+  TASKS_SELECTED_TASK_SEARCH_PARAM,
+  TASKS_SIDEBAR_SEARCH_PARAM,
+  TASKS_VIEW_MODE_SEARCH_PARAM,
+} from '../../context/navigation/types'
 import {tasksLocaleNamespace} from '../../i18n'
 import {type TaskDocument} from '../../types'
 import {getMentionedUsers} from '../form/utils'
@@ -73,9 +78,9 @@ export function TasksActivityLog(props: TasksActivityLogProps) {
   const handleGetNotificationValue = (message: CommentInputProps['value'], commentId: string) => {
     const studioUrl = new URL(`${window.location.origin}${basePath ? `${basePath}/` : ''}`)
 
-    studioUrl.searchParams.set('sidebar', 'tasks')
-    studioUrl.searchParams.set('selectedTask', value?._id)
-    studioUrl.searchParams.set('viewMode', 'edit')
+    studioUrl.searchParams.set(TASKS_SIDEBAR_SEARCH_PARAM, 'tasks')
+    studioUrl.searchParams.set(TASKS_SELECTED_TASK_SEARCH_PARAM, value?._id)
+    studioUrl.searchParams.set(TASKS_VIEW_MODE_SEARCH_PARAM, 'edit')
     studioUrl.searchParams.set('commentId', commentId)
 
     const mentionedUsers = getMentionedUsers(message)

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksNotificationTarget.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksNotificationTarget.tsx
@@ -10,6 +10,11 @@ import {useClient} from '../../../../hooks'
 import {usePerspective} from '../../../../perspective/usePerspective'
 import {useWorkspace} from '../../../../studio'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../../studioClient'
+import {
+  TASKS_SELECTED_TASK_SEARCH_PARAM,
+  TASKS_SIDEBAR_SEARCH_PARAM,
+  TASKS_VIEW_MODE_SEARCH_PARAM,
+} from '../../../context/navigation/types'
 import {useDocumentPreviewValues} from '../../../hooks'
 import {type TaskContext, type TaskDocument} from '../../../types'
 import {CurrentWorkspaceProvider} from '../CurrentWorkspaceProvider'
@@ -21,9 +26,9 @@ export function getTaskURL(taskId: string, basePath?: string, toolName: string =
 
   const currentUrl = new URL(`${path}/`)
 
-  currentUrl.searchParams.set('sidebar', 'tasks')
-  currentUrl.searchParams.set('selectedTask', taskId)
-  currentUrl.searchParams.set('viewMode', 'edit')
+  currentUrl.searchParams.set(TASKS_SIDEBAR_SEARCH_PARAM, 'tasks')
+  currentUrl.searchParams.set(TASKS_SELECTED_TASK_SEARCH_PARAM, taskId)
+  currentUrl.searchParams.set(TASKS_VIEW_MODE_SEARCH_PARAM, 'edit')
   return currentUrl.toString()
 }
 

--- a/packages/sanity/src/core/tasks/context/navigation/TasksNavigationProvider.tsx
+++ b/packages/sanity/src/core/tasks/context/navigation/TasksNavigationProvider.tsx
@@ -6,7 +6,16 @@ import {TasksNavigationContext} from 'sanity/_singletons'
 import {useRouter} from 'sanity/router'
 
 import {TaskLinkCopied, TaskLinkOpened} from '../../__telemetry__/tasks.telemetry'
-import {type Action, type SidebarTabsIds, type State, type ViewModeOptions} from './types'
+import {
+  type Action,
+  type SidebarTabsIds,
+  type State,
+  TASKS_SEARCH_PARAMS,
+  TASKS_SELECTED_TASK_SEARCH_PARAM,
+  TASKS_SIDEBAR_SEARCH_PARAM,
+  TASKS_VIEW_MODE_SEARCH_PARAM,
+  type ViewModeOptions,
+} from './types'
 
 const initialState: State = {
   viewMode: 'list',
@@ -108,7 +117,15 @@ export const TasksNavigationProvider = ({children}: {children: ReactNode}) => {
 
   const handleCloseTasks = useCallback(() => {
     dispatch({type: 'TOGGLE_TASKS_VIEW', payload: false})
-  }, [])
+
+    // Remove task-related query parameters from the URL
+    router.navigate({
+      ...router.state,
+      _searchParams: (router.state._searchParams ?? []).filter(
+        ([key]) => !TASKS_SEARCH_PARAMS.includes(key as (typeof TASKS_SEARCH_PARAMS)[number]),
+      ),
+    })
+  }, [router])
 
   const handleOpenTasks = useCallback(() => {
     dispatch({type: 'TOGGLE_TASKS_VIEW', payload: true})
@@ -116,10 +133,10 @@ export const TasksNavigationProvider = ({children}: {children: ReactNode}) => {
 
   const handleCopyLinkToTask = useCallback(() => {
     const url = new URL(window.location.href)
-    url.searchParams.set('sidebar', 'tasks')
-    url.searchParams.set('viewMode', state.viewMode)
+    url.searchParams.set(TASKS_SIDEBAR_SEARCH_PARAM, 'tasks')
+    url.searchParams.set(TASKS_VIEW_MODE_SEARCH_PARAM, state.viewMode)
     if (state.selectedTask) {
-      url.searchParams.set('selectedTask', state.selectedTask)
+      url.searchParams.set(TASKS_SELECTED_TASK_SEARCH_PARAM, state.selectedTask)
     }
     navigator.clipboard
       .writeText(url.toString())
@@ -136,9 +153,9 @@ export const TasksNavigationProvider = ({children}: {children: ReactNode}) => {
   }, [state.selectedTask, state.viewMode, telemetry, toast])
 
   const searchParams = new URLSearchParams(router.state._searchParams)
-  const sidebar = searchParams.get('sidebar')
-  const viewMode = searchParams.get('viewMode')
-  const selectedTask = searchParams.get('selectedTask')
+  const sidebar = searchParams.get(TASKS_SIDEBAR_SEARCH_PARAM)
+  const viewMode = searchParams.get(TASKS_VIEW_MODE_SEARCH_PARAM)
+  const selectedTask = searchParams.get(TASKS_SELECTED_TASK_SEARCH_PARAM)
 
   useEffect(() => {
     // listen to the URL to open the tasks view if the sidebar is set to task.

--- a/packages/sanity/src/core/tasks/context/navigation/types.ts
+++ b/packages/sanity/src/core/tasks/context/navigation/types.ts
@@ -1,5 +1,15 @@
 import {type TaskDocument} from '../../types'
 
+/** Query parameter keys used for tasks sidebar deep-linking */
+export const TASKS_SIDEBAR_SEARCH_PARAM = 'sidebar'
+export const TASKS_SELECTED_TASK_SEARCH_PARAM = 'selectedTask'
+export const TASKS_VIEW_MODE_SEARCH_PARAM = 'viewMode'
+export const TASKS_SEARCH_PARAMS = [
+  TASKS_SIDEBAR_SEARCH_PARAM,
+  TASKS_SELECTED_TASK_SEARCH_PARAM,
+  TASKS_VIEW_MODE_SEARCH_PARAM,
+] as const
+
 export type SidebarTabsIds = 'assigned' | 'subscribed' | 'document'
 
 export type ViewMode = 'create' | 'edit' | 'list' | 'draft' | 'duplicate'


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->
   
 - Fix tasks sidebar not cleaning up URL query parameters (`sidebar`, `selectedTask`, `viewMode`) on close                                                                                                                 
 - Extract task search param names into constants to eliminate scattered string literals across 3 files

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

There weren't any tests for the provider, but if there are any integration/e2e lmk and i can work it in there?

### Related issues

* resolves SDK-1003

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->

* When closing the tasks sidebar, params are correctly removed from the URL to accurately reflect the application state