### PR TITLE
fix(sanity): restore ability for `prepare()` to fallback to schema icon

### DIFF
--- a/packages/sanity/src/core/preview/components/PreviewLoader.tsx
+++ b/packages/sanity/src/core/preview/components/PreviewLoader.tsx
@@ -74,13 +74,14 @@ export function PreviewLoader(
       )
     }
 
+    // media: null or false explicitly suppresses the icon.
+    // All other falsy cases (undefined, missing key) fall back to the schema icon.
+    if (preview?.value?.media === null || preview?.value?.media === false) {
+      return undefined
+    }
+
     if (!preview?.value?.media) {
-      // Only fall back to schema icon if there's no custom prepare function.
-      // When a prepare function is defined and doesn't return media,
-      // the user intentionally omitted it - don't show the schema icon.
-      // See: https://github.com/sanity-io/sanity/issues/1200
-      const hasCustomPrepare = typeof schemaType.preview?.prepare === 'function'
-      return hasCustomPrepare ? undefined : schemaType.icon
+      return schemaType.icon
     }
 
     // @todo: fix `TS2769: No overload matches this call.`

--- a/packages/sanity/src/core/preview/components/__tests__/PreviewLoader.test.tsx
+++ b/packages/sanity/src/core/preview/components/__tests__/PreviewLoader.test.tsx
@@ -62,8 +62,8 @@ describe('PreviewLoader', () => {
       expect(capturedMedia).toBe(DocumentIcon)
     })
 
-    it('should NOT show schema icon when prepare function exists but returns no media', () => {
-      // Schema WITH custom prepare function
+    it('should show schema icon when prepare function exists but returns no media key', () => {
+      // Schema WITH custom prepare function that omits media key entirely
       const schemaType = {
         name: 'testDoc',
         icon: DocumentIcon,
@@ -75,7 +75,7 @@ describe('PreviewLoader', () => {
 
       vi.mocked(useValuePreview).mockReturnValue({
         isLoading: false,
-        value: {title: 'Test Title'}, // No media in return value
+        value: {title: 'Test Title'}, // No media key in return value
       })
 
       render(
@@ -87,8 +87,8 @@ describe('PreviewLoader', () => {
         />,
       )
 
-      // Verify the component was called with undefined media (no icon fallback)
-      expect(capturedMedia).toBeUndefined()
+      // media key is absent, so fall back to schema icon
+      expect(capturedMedia).toBe(DocumentIcon)
     })
 
     it('should show returned media when prepare function returns media', () => {
@@ -147,12 +147,39 @@ describe('PreviewLoader', () => {
         />,
       )
 
-      // media: null is falsy, so the condition !preview?.value?.media is true
-      // Since there's a custom prepare, it should return undefined (no fallback)
+      // media key is present and falsy (null), so no icon is shown
       expect(capturedMedia).toBeUndefined()
     })
 
-    it('should NOT show schema icon when prepare function returns media: undefined explicitly', () => {
+    it('should NOT show schema icon when prepare function returns media: false', () => {
+      const schemaType = {
+        name: 'testDoc',
+        icon: DocumentIcon,
+        preview: {
+          select: {title: 'title'},
+          prepare: ({title}: {title: string}) => ({title, media: false}),
+        },
+      } as unknown as SchemaType
+
+      vi.mocked(useValuePreview).mockReturnValue({
+        isLoading: false,
+        value: {title: 'Test Title', media: false},
+      })
+
+      render(
+        <PreviewLoader
+          component={MockPreviewComponent}
+          schemaType={schemaType}
+          value={{_id: 'test', _type: 'testDoc'}}
+          skipVisibilityCheck
+        />,
+      )
+
+      // media: false is an explicit opt-out, no icon shown
+      expect(capturedMedia).toBeUndefined()
+    })
+
+    it('should show schema icon when prepare function returns media: undefined', () => {
       // Schema WITH custom prepare function that explicitly returns undefined media
       const schemaType = {
         name: 'testDoc',
@@ -177,9 +204,8 @@ describe('PreviewLoader', () => {
         />,
       )
 
-      // media: undefined is falsy, so the condition !preview?.value?.media is true
-      // Since there's a custom prepare, it should return undefined (no fallback)
-      expect(capturedMedia).toBeUndefined()
+      // media: undefined is not an explicit opt-out, fall back to schema icon
+      expect(capturedMedia).toBe(DocumentIcon)
     })
 
     it('should show schema icon when no preview config at all', () => {


### PR DESCRIPTION
### Description

#11623 changed preview.prepare() so that omitting a media property would opt out of the schema icon. While opting out is a valid use case, opting in (i.e. falling back to the schema icon) is equally valid, so both should be supported.

This PR restores the balance: returning `media: null` or `media: false` explicitly opts out of the schema icon, while omitting media or setting it to undefined falls back to it. This works with patterns like:

```js
prepare(value) {
  return {
		//...
		media: icons[value.type] // falls back to schema icon if no value.type key is present in icons
	}
}
```

```js
prepare(value) {
  return {
		//...
		media: icons[value.type] || null // no icon
	}
}
```

### What to review
This may affect the output of existing `preview.prepare()` functions after upgrading, which is technically a visual breaking change. However, since #11623 was itself an unintended visual breaking change, this can reasonably be treated as a bugfix.

### Testing
Tests updated to assert the wanted behavior

### Notes for release
Restores fallback to schema icon when `media` is omitted from `preview.prepare()`. To opt out of the schema icon, return `media: null` or `media: false`.