### PR TITLE
fix(router): non-sticky params stick around

### DIFF
--- a/packages/sanity/src/router/RouteScope.tsx
+++ b/packages/sanity/src/router/RouteScope.tsx
@@ -85,7 +85,8 @@ export const RouteScope = function RouteScope(props: RouteScopeProps): React.JSX
       if (_nextState === null) return null
 
       const {_searchParams, ...nextState} = _nextState || {}
-      const nextParentState = addScope(parentStateRef.current, scope, nextState)
+      const {_searchParams: _parentSearchParams, ...parentState} = parentStateRef.current
+      const nextParentState = addScope(parentState, scope, nextState)
       if (__unsafe_disableScopedSearchParams) {
         // Move search params to parent scope
         nextParentState._searchParams = _searchParams

--- a/packages/sanity/src/router/__test__/RouterScope.test.tsx
+++ b/packages/sanity/src/router/__test__/RouterScope.test.tsx
@@ -32,13 +32,22 @@ const initialState: RouterState = {
   tool: 'desk',
 }
 
+const initialStateWithNonStickyParams: RouterState = {
+  _searchParams: [
+    ['stickyParam', 'stickyValue'],
+    ['sidebar', 'tasks'],
+    ['selectedTask', 'abc123'],
+  ],
+  tool: 'desk',
+}
+
 interface WrapperProps {
   children: React.ReactNode
 }
 
-const createWrapper = (disableScopedSearchParams = false) => {
+const createWrapper = (disableScopedSearchParams = false, state = initialState) => {
   const Wrapper = ({children}: WrapperProps) => (
-    <RouterProvider onNavigate={mockOnNavigate} router={mockRouter} state={initialState}>
+    <RouterProvider onNavigate={mockOnNavigate} router={mockRouter} state={state}>
       <RouteScope scope="testScope" __unsafe_disableScopedSearchParams={disableScopedSearchParams}>
         {children}
       </RouteScope>
@@ -425,6 +434,62 @@ describe('RouteScope', () => {
         tool: 'desk',
         testScope: {},
       },
+    })
+  })
+
+  describe('non-sticky params should not leak into child links', () => {
+    it('resolvePathFromState should not include non-sticky parent params', () => {
+      const wrapper = createWrapper(false, initialStateWithNonStickyParams)
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      vi.mocked(mockRouter.encode).mockClear()
+
+      result.current.resolvePathFromState({scopedValue: 'test'})
+
+      expect(mockRouter.encode).toHaveBeenCalledWith({
+        _searchParams: [['stickyParam', 'stickyValue']],
+        tool: 'desk',
+        testScope: {
+          scopedValue: 'test',
+          _searchParams: undefined,
+        },
+      })
+    })
+
+    it('navigate should not include non-sticky parent params', () => {
+      const wrapper = createWrapper(false, initialStateWithNonStickyParams)
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      act(() => {
+        result.current.navigate({scopedKey: 'scopedValue'})
+      })
+
+      expect(mockOnNavigate).toHaveBeenCalledWith({
+        path: {
+          _searchParams: [['stickyParam', 'stickyValue']],
+          tool: 'desk',
+          testScope: {
+            scopedKey: 'scopedValue',
+          },
+        },
+      })
+    })
+
+    it('should not leak non-sticky params with __unsafe_disableScopedSearchParams', () => {
+      const wrapper = createWrapper(true, initialStateWithNonStickyParams)
+      const {result} = renderHook(() => useRouter(), {wrapper})
+
+      vi.mocked(mockRouter.encode).mockClear()
+
+      result.current.resolvePathFromState({scopedValue: 'test'})
+
+      expect(mockRouter.encode).toHaveBeenCalledWith({
+        _searchParams: [['stickyParam', 'stickyValue']],
+        tool: 'desk',
+        testScope: {
+          scopedValue: 'test',
+        },
+      })
     })
   })
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

I merged #12351 and in testing the `next` release found that even though the search params were removed from the URL they would leak to the structure tool so whenever you clicked a navigation item the pane would re-open – this most likely isn't the right behaviour?

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

* Is this the correct behaviour? I would assume so, but would be nice to be validated here lol

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->

* Fixes issue where some search params would stick around even though they were removed from the URL 