### PR TITLE
fix: update rendering logic to exclude "Estimated" for archived releases and improve readability

### DIFF
--- a/packages/sanity/src/core/releases/tool/components/ReleaseTime.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseTime.tsx
@@ -4,6 +4,7 @@ import {Box, Flex, Text} from '@sanity/ui'
 import {useTranslation} from '../../../i18n'
 import {useReleaseTime} from '../../hooks/useReleaseTime'
 import {releasesLocaleNamespace} from '../../i18n'
+import {ARCHIVED_RELEASE_STATES} from '../../util/const'
 import {isReleaseScheduledOrScheduling} from '../../util/util'
 import {type TableRelease} from '../overview/ReleasesOverview'
 
@@ -32,7 +33,7 @@ export const ReleaseTime: React.FC<{release: TableRelease}> = ({release}) => {
   // For scheduled releases:
 
   const isScheduledOrScheduling = isReleaseScheduledOrScheduling(release)
-  const isArchived = release.state === 'archived'
+  const isInArchivedView = ARCHIVED_RELEASE_STATES.includes(release.state)
 
   return (
     <Flex gap={1} align="center" wrap="wrap">
@@ -43,7 +44,7 @@ export const ReleaseTime: React.FC<{release: TableRelease}> = ({release}) => {
           </Text>
         </Box>
       )}
-      {!isArchived && (
+      {!isInArchivedView && (
         <>
           <Box paddingY={1}>
             <Text size={1} muted>

--- a/packages/sanity/src/core/releases/tool/components/__tests__/ReleaseTime.test.tsx
+++ b/packages/sanity/src/core/releases/tool/components/__tests__/ReleaseTime.test.tsx
@@ -75,6 +75,16 @@ describe('ReleaseTime', () => {
     expect(screen.getByText('Oct 10, 2023', {exact: false})).toBeInTheDocument()
   })
 
+  it('renders the date without "Estimated" prefix for published releases', async () => {
+    await renderTest({
+      release: {...archivedScheduledRelease, state: 'published' as const},
+    })
+
+    expect(screen.queryByText('Estimated')).not.toBeInTheDocument()
+    expect(screen.queryByText('Scheduled')).not.toBeInTheDocument()
+    expect(screen.getByText('Oct 10, 2023', {exact: false})).toBeInTheDocument()
+  })
+
   it('renders nothing when releaseType is "scheduled" and publishDate is not available', async () => {
     await renderTest({
       release: {


### PR DESCRIPTION
### Description
Before:
<img width="619" height="555" alt="Screenshot 2026-03-10 at 13 06 56" src="https://github.com/user-attachments/assets/650c1b01-aa97-4c9b-bd24-8acdb2491443" />

After:
<img width="619" height="548" alt="Screenshot 2026-03-10 at 13 06 21" src="https://github.com/user-attachments/assets/47a6780c-d201-4bfc-8efb-2c21a623de01" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes a bug where archived scheduled drafts always showed their published date as 'estimated'
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
