### PR TITLE
feat(core): widen the form when using focus mode

### DIFF
--- a/e2e/tests/expanded-document/expanded.spec.ts
+++ b/e2e/tests/expanded-document/expanded.spec.ts
@@ -165,3 +165,39 @@ test.describe('maximized document - with enhanced object dialog', () => {
     ).not.toBeVisible()
   })
 })
+
+test.describe('maximized document - form width', () => {
+  test('form width increases in focus mode', async ({page, createDraftDocument}) => {
+    await createDraftDocument('/content/input-standard;portable-text;pt_allTheBellsAndWhistles')
+
+    await expect(page.getByTestId('focus-pane-button-focus')).toBeVisible()
+    await expect(page.getByTestId('field-text')).toBeVisible()
+    await expect(page.locator('.pt-editable .pt-block').first()).toBeVisible()
+
+    const formContainer = page.getByTestId('form-container')
+    const normalMaxWidthFC = await formContainer.evaluate((el) =>
+      Number.parseFloat(window.getComputedStyle(el).maxWidth),
+    )
+
+    const firstBlock = page.locator('.pt-editable .pt-block').first()
+    const normalMaxWidthPTE = await firstBlock.evaluate((el) =>
+      Number.parseFloat(window.getComputedStyle(el).maxWidth),
+    )
+
+    await page.getByTestId('focus-pane-button-focus').click()
+
+    await expect(page.getByTestId('focus-pane-button-collapse')).toBeVisible()
+
+    const focusedMaxWidthFC = await formContainer.evaluate((el) =>
+      Number.parseFloat(window.getComputedStyle(el).maxWidth),
+    )
+    const focusedMaxWidthPTE = await firstBlock.evaluate((el) =>
+      Number.parseFloat(window.getComputedStyle(el).maxWidth),
+    )
+
+    expect(normalMaxWidthPTE).toBe(640)
+    expect(normalMaxWidthFC).toBe(640)
+    expect(focusedMaxWidthPTE).toBe(960)
+    expect(focusedMaxWidthFC).toBe(960)
+  })
+})

--- a/packages/sanity/src/core/form/FormBuilderContext.ts
+++ b/packages/sanity/src/core/form/FormBuilderContext.ts
@@ -14,6 +14,7 @@ import {
   type RenderPreviewCallback,
 } from './types'
 
+export type FormWidth = 1 | 2
 /**
  *
  * @hidden
@@ -48,6 +49,7 @@ export interface FormBuilderContextValue {
   collapsedPaths: StateTree<boolean> | undefined
   focusPath: Path
   focused?: boolean
+  formWidth: FormWidth
   groups: FormFieldGroup[]
   id: string
   readOnly?: boolean

--- a/packages/sanity/src/core/form/FormBuilderProvider.tsx
+++ b/packages/sanity/src/core/form/FormBuilderProvider.tsx
@@ -7,7 +7,7 @@ import {type FormNodePresence} from '../presence'
 import {EMPTY_ARRAY} from '../util'
 import {DocumentIdProvider} from './contexts/DocumentIdProvider'
 import {HoveredFieldProvider} from './field'
-import {type FormBuilderContextValue} from './FormBuilderContext'
+import {type FormBuilderContextValue, type FormWidth} from './FormBuilderContext'
 import {ArrayOfObjectsFunctions} from './inputs/arrays/ArrayOfObjectsInput/ArrayOfObjectsFunctions'
 import {DefaultCustomMarkers} from './inputs/PortableText/_legacyDefaultParts/CustomMarkers'
 import {DefaultMarkers} from './inputs/PortableText/_legacyDefaultParts/Markers'
@@ -43,6 +43,7 @@ export interface FormBuilderProviderProps {
   filterField?: FormBuilderFilterFieldFn
   focusPath: Path
   focused?: boolean
+  formWidth?: FormWidth
   groups: FormFieldGroup[]
   id: string
   image: Source['form']['image']
@@ -92,6 +93,7 @@ export function FormBuilderProvider(props: FormBuilderProviderProps) {
     filterField,
     focusPath,
     focused,
+    formWidth = 1,
     groups,
     id,
     image,
@@ -174,6 +176,7 @@ export function FormBuilderProvider(props: FormBuilderProviderProps) {
       renderItem,
       renderPreview,
       schemaType,
+      formWidth,
     }),
     [
       __internal,
@@ -194,6 +197,7 @@ export function FormBuilderProvider(props: FormBuilderProviderProps) {
       renderItem,
       renderPreview,
       schemaType,
+      formWidth,
     ],
   )
 

--- a/packages/sanity/src/core/form/components/layout/FormContainer.tsx
+++ b/packages/sanity/src/core/form/components/layout/FormContainer.tsx
@@ -2,10 +2,12 @@
 import {getTheme_v2} from '@sanity/ui/theme'
 import {css, styled} from 'styled-components'
 
+import {type FormWidth} from '../../FormBuilderContext'
+
 /**
  * @internal
  */
-export const FormContainer = styled.div((props) => {
+export const FormContainer = styled.div<{$formWidth: FormWidth}>((props) => {
   const {space, container} = getTheme_v2(props.theme)
 
   return css`
@@ -14,6 +16,6 @@ export const FormContainer = styled.div((props) => {
     padding-inline: ${space[4]}px;
     padding-block-start: ${space[5]}px;
     padding-block-end: ${space[9]}px;
-    max-width: calc(${container[1]}px + (var(--formGutterSize, 0px) * 2) + (var(--formGutterGap, 0px) * 2));
+    max-width: calc(${container[props.$formWidth]}px + (var(--formGutterSize, 0px) * 2) + (var(--formGutterGap, 0px) * 2));
   `
 })

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
@@ -5,6 +5,7 @@ import {getTheme_v2} from '@sanity/ui/theme'
 import {css, styled} from 'styled-components'
 
 import {ScrollContainer} from '../../../components/scroll'
+import {type FormWidth} from '../../FormBuilderContext'
 import {createListName, TEXT_LEVELS} from './text'
 
 export const Root = styled(Card)<{$isOneLine: boolean}>`
@@ -67,8 +68,13 @@ export const Scroller = styled(ScrollContainer)`
     min-height: auto;
   }
 `
+interface EditableWrapperProps {
+  $isFullscreen: boolean
+  $isOneLine: boolean
+  $formWidth: FormWidth
+}
 
-export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $isOneLine: boolean}>`
+export const EditableWrapper = styled(Card)<EditableWrapperProps>`
   height: 100%;
   width: 100%;
   counter-reset: ${TEXT_LEVELS.map((l) => createListName(l)).join(' ')};
@@ -121,7 +127,7 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $isOneLine:
 
     & > .pt-block {
       margin: 0 auto;
-      max-width: ${(props) => getTheme_v2(props.theme).container[1]}px;
+      max-width: ${(props) => getTheme_v2(props.theme).container[props.$formWidth]}px;
     }
 
     /* & > .pt-block {

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -95,7 +95,7 @@ export function Editor(props: EditorProps): ReactNode {
     setScrollElement,
     ariaDescribedBy,
   } = props
-  const {id} = useFormBuilder()
+  const {id, formWidth} = useFormBuilder()
   const {t} = useTranslation()
   const {isTopLayer} = useLayer()
 
@@ -212,6 +212,7 @@ export function Editor(props: EditorProps): ReactNode {
           <div>
             <EditableWrapper
               $isFullscreen={isFullscreen}
+              $formWidth={formWidth}
               $isOneLine={isOneLine}
               tone={readOnly ? 'transparent' : 'default'}
             >

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
@@ -3,6 +3,7 @@ import {type ReactNode, useCallback, useMemo} from 'react'
 
 import {EnhancedObjectDialog, useEnhancedObjectDialog} from '../../../..'
 import {useTranslation} from '../../../../../i18n'
+import {useFormBuilder} from '../../../../useFormBuilder'
 import {_getModalOption} from '../helpers'
 import {DefaultEditDialog} from './DialogModal'
 import {PopoverEditDialog} from './PopoverModal'
@@ -32,7 +33,7 @@ export function ObjectEditModal(props: {
   const modalType = schemaModalOption?.type || defaultType
 
   const {enabled: nestedObjectNavigationEnabled} = useEnhancedObjectDialog()
-
+  const {formWidth} = useFormBuilder()
   const schemaTypeTitle = schemaType.i18nTitleKey
     ? t(schemaType.i18nTitleKey)
     : schemaType.title || schemaType.name
@@ -69,7 +70,7 @@ export function ObjectEditModal(props: {
       type="dialog"
       onClose={onClose}
       header={modalTitle}
-      width={1}
+      width={formWidth}
       autofocus={autoFocus}
     >
       {props.children}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../../../studio/tree-editing'
 import {UPLOAD_STATUS_KEY} from '../../../../studio/uploads/constants'
 import {type ObjectItem, type ObjectItemProps} from '../../../../types'
+import {useFormBuilder} from '../../../../useFormBuilder'
 import {regenerateKeys} from '../../../../utils/regenerateKeys'
 import {useArrayValidation} from '../../common/ArrayValidationContext'
 import {CellLayout} from '../../layouts/CellLayout'
@@ -89,6 +90,7 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
   } = props
   const {t} = useTranslation()
   const arrayValidation = useArrayValidation()
+  const {formWidth} = useFormBuilder()
   const maxReached = arrayValidation?.maxReached
   const maxReachedReason = arrayValidation?.maxReachedReason
 
@@ -344,7 +346,7 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
               : t('inputs.array.action.edit', {itemTypeTitle})
           }
           type={parentSchemaType?.options?.modal?.type || 'dialog'}
-          width={parentSchemaType?.options?.modal?.width ?? 1}
+          width={parentSchemaType?.options?.modal?.width ?? formWidth}
           id={value._key}
           onClose={onClose}
           autofocus={focused}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
@@ -22,6 +22,7 @@ import {
 } from '../../../../studio/tree-editing'
 import {UPLOAD_STATUS_KEY} from '../../../../studio/uploads/constants'
 import {type ObjectItem, type ObjectItemProps} from '../../../../types'
+import {useFormBuilder} from '../../../../useFormBuilder'
 import {regenerateKeys} from '../../../../utils/regenerateKeys'
 import {useArrayValidation} from '../../common/ArrayValidationContext'
 import {RowLayout} from '../../layouts/RowLayout'
@@ -74,7 +75,7 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
   const arrayValidation = useArrayValidation()
   const maxReached = arrayValidation?.maxReached
   const maxReachedReason = arrayValidation?.maxReachedReason
-
+  const {formWidth} = useFormBuilder()
   const {enabled: enhancedObjectDialogEnabled} = useEnhancedObjectDialog()
 
   // The edit portal should open if the item is open and:
@@ -334,7 +335,7 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
               : t('inputs.array.action.edit', {itemTypeTitle})
           }
           type={parentSchemaType?.options?.modal?.type || 'dialog'}
-          width={parentSchemaType?.options?.modal?.width ?? 1}
+          width={parentSchemaType?.options?.modal?.width ?? formWidth}
           id={value._key}
           onClose={onClose}
           autofocus={focused}

--- a/packages/sanity/src/core/form/studio/FormBuilder.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilder.tsx
@@ -22,6 +22,7 @@ import {
   useItemComponent,
   usePreviewComponent,
 } from '../form-components-hooks'
+import {type FormWidth} from '../FormBuilderContext'
 import {FullscreenPTEProvider} from '../inputs/PortableText/contexts/fullscreen'
 import {type FormPatch, type PatchChannel, PatchEvent} from '../patch'
 import {type StateTree} from '../store'
@@ -85,6 +86,7 @@ export interface FormBuilderProps extends Omit<
   validation: ValidationMarker[]
   value: FormDocumentValue | undefined
   compareValue?: SanityDocument
+  formWidth?: FormWidth
 }
 
 /**
@@ -120,6 +122,7 @@ export function FormBuilder(props: FormBuilderProps) {
     validation,
     value,
     compareValue,
+    formWidth,
   } = props
 
   const handleCollapseField = useCallback(
@@ -316,6 +319,7 @@ export function FormBuilder(props: FormBuilderProps) {
       validation={validation}
       readOnly={readOnly}
       schemaType={schemaType}
+      formWidth={formWidth}
     >
       <GetFormValueProvider value={value}>
         <FormValueProvider value={value}>

--- a/packages/sanity/src/core/form/studio/FormProvider.tsx
+++ b/packages/sanity/src/core/form/studio/FormProvider.tsx
@@ -14,6 +14,7 @@ import {
   useItemComponent,
   usePreviewComponent,
 } from '../form-components-hooks'
+import {type FormWidth} from '../FormBuilderContext'
 import {FormBuilderProvider} from '../FormBuilderProvider'
 import {type PatchChannel, type PatchEvent} from '../patch'
 import {type FormFieldGroup, type StateTree} from '../store'
@@ -57,6 +58,7 @@ export interface FormProviderProps {
   readOnly?: boolean
   schemaType: ObjectSchemaType
   validation: ValidationMarker[]
+  formWidth?: FormWidth
 }
 
 /**
@@ -89,6 +91,7 @@ export function FormProvider(props: FormProviderProps) {
     readOnly,
     schemaType,
     validation,
+    formWidth,
   } = props
 
   const {file, image} = useSource().form
@@ -169,6 +172,7 @@ export function FormProvider(props: FormProviderProps) {
       renderItem={renderItem}
       renderPreview={renderPreview}
       schemaType={schemaType}
+      formWidth={formWidth}
       validation={validation}
     >
       {children}

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -165,7 +165,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
   const formWidth = maximizedPane ? 2 : 1
 
   return (
-    <FormContainer hidden={hidden} $formWidth={formWidth}>
+    <FormContainer hidden={hidden} $formWidth={formWidth} data-testid="form-container">
       <PresenceOverlay margins={margins}>
         <Box
           as="form"

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -29,6 +29,7 @@ import {
 
 import {Delay} from '../../../../components'
 import {structureLocaleNamespace} from '../../../../i18n'
+import {useResolvedPanesList} from '../../../../structureResolvers/useResolvedPanesList'
 import {useDocumentPane} from '../../useDocumentPane'
 import {useDocumentTitle} from '../../useDocumentTitle'
 import {FormHeader} from './FormHeader'
@@ -71,6 +72,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
   const documentStore = useDocumentStore()
   const presence = useDocumentPresence(documentId)
   const {title} = useDocumentTitle()
+  const {maximizedPane} = useResolvedPanesList()
   // The `patchChannel` is an INTERNAL publish/subscribe channel that we use to notify form-builder
   // nodes about both remote and local patches.
   // - Used by the Portable Text input to modify selections.
@@ -160,9 +162,10 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
   )
 
   const isReadOnly = connectionState === 'reconnecting' || formState?.readOnly || !editState?.ready
+  const formWidth = maximizedPane ? 2 : 1
 
   return (
-    <FormContainer hidden={hidden}>
+    <FormContainer hidden={hidden} $formWidth={formWidth}>
       <PresenceOverlay margins={margins}>
         <Box
           as="form"
@@ -223,6 +226,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
                 readOnly={isReadOnly}
                 schemaType={formState.schemaType}
                 validation={validation}
+                formWidth={formWidth}
                 value={
                   // note: the form state doesn't have a typed concept of a "document" value
                   // but these should be compatible

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderTitle.tsx
@@ -1,4 +1,3 @@
-import {useMemo} from 'react'
 import {useTranslation} from 'sanity'
 
 import {structureLocaleNamespace} from '../../../../i18n'
@@ -9,16 +8,11 @@ import {DocumentHeaderBreadcrumb} from './DocumentHeaderBreadcrumb'
 
 export function DocumentHeaderTitle(): React.JSX.Element {
   const {connectionState, schemaType, title, value: documentValue, index} = useDocumentPane()
-  const {paneDataItems} = useResolvedPanesList()
+  const {paneDataItems, maximizedPane} = useResolvedPanesList()
   const {title: documentTitle, error} = useDocumentTitle()
   const subscribed = Boolean(documentValue)
 
   const {t} = useTranslation(structureLocaleNamespace)
-
-  const hasMaximizedPane = useMemo(
-    () => paneDataItems.some((paneData) => paneData.maximized),
-    [paneDataItems],
-  )
 
   if (connectionState === 'connecting' && !subscribed) {
     return <></>
@@ -44,7 +38,7 @@ export function DocumentHeaderTitle(): React.JSX.Element {
 
   return (
     <>
-      {hasMaximizedPane ? (
+      {maximizedPane ? (
         <DocumentHeaderBreadcrumb paneDataItems={paneDataItems} currentPaneIndex={index} />
       ) : (
         documentTitle || (


### PR DESCRIPTION
### Description
Fix: https://github.com/sanity-io/sanity/issues/5496
Fix: https://github.com/sanity-io/sanity/issues/4989

When entering focus mode we have more width available, we can use some of that width to make the form wider.
It takes the form max width from `640px` to `960px` when entering focus mode, we have an inline padding of 20px per side, so it leaves space for a form of `600x` and `920px`.

  

https://github.com/user-attachments/assets/a63675b3-f41c-4f70-88b6-993e6f74ccfe




<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
What do you think about `FormWidth` prop in the form builder?

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open a studio, enter focus mode, max width should change.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Widen form when entering focus mode.

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
