### PR TITLE
fix(sanity): add `_strengthenOnPublish` to reference schema type

### DIFF
--- a/packages/@sanity/schema/src/legacy/types/reference.ts
+++ b/packages/@sanity/schema/src/legacy/types/reference.ts
@@ -17,7 +17,20 @@ const WEAK_FIELD = {
   type: 'boolean',
 }
 
-const REFERENCE_FIELDS = [REF_FIELD, WEAK_FIELD]
+const STRENGTHEN_ON_PUBLISH_FIELD = {
+  name: '_strengthenOnPublish',
+  title: 'Strengthen on publish',
+  type: 'object',
+  fields: [
+    {
+      name: 'type',
+      title: 'Type',
+      type: 'string',
+    },
+  ],
+}
+
+const REFERENCE_FIELDS = [REF_FIELD, WEAK_FIELD, STRENGTHEN_ON_PUBLISH_FIELD]
 
 const OVERRIDABLE_FIELDS = [...DEFAULT_OVERRIDEABLE_FIELDS]
 

--- a/packages/sanity/src/core/form/studio/inputResolver/helpers.ts
+++ b/packages/sanity/src/core/form/studio/inputResolver/helpers.ts
@@ -6,7 +6,7 @@ export function getOption(type: SchemaType, optionName: string) {
 }
 
 const PSEUDO_OBJECTS = ['array', 'file', 'image', 'reference', 'slug']
-const HIDDEN_FIELDS = ['asset', 'crop', 'hotspot', '_ref', '_weak', 'media']
+const HIDDEN_FIELDS = ['asset', 'crop', 'hotspot', '_ref', '_weak', '_strengthenOnPublish', 'media']
 const NO_LEVEL_LAYOUTS = ['tags']
 const NO_LEVEL_TYPES = ['slug']
 


### PR DESCRIPTION
### Description

This branch adds the `_strengthenOnPublish` field to the core reference schema type. It's currently absent, despite being a field routinely added by the system.

~This branch also fixes a gap in the `extractManifestRestore` test, in which fields in the tested schema type weren't sanitised before being used in assertions.~
Edit: those tests were removed when the CLI was ejected from this repository.

#### Why add it now?

The process that displays divergences to the user is informed by the schema. If a divergence affects a field that doesn't exist in the schema, it's excluded.

This means that if a user copies the upstream value of a reference field that has `_strengthenOnPublish` defined, the `_strengthenOnPublish` value is not currently copied. **This can create a reference strength mismatch**. Including `_strengthenOnPublish` in the reference schema type definition fixes this.

https://github.com/user-attachments/assets/537cbe1a-4a7e-49e9-8207-097696a57f7e

https://github.com/user-attachments/assets/3ba60262-1c9b-4b7c-81e1-5c7d0917d78d


### What to review

The updated reference schema type definition.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->