### PR TITLE
ci: include shard number in workflow name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   test:
     timeout-minutes: 60
-    name: Test (node ${{ matrix.node }})
+    name: Test (node ${{ matrix.node }}) - ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
     runs-on: ubuntu-8core
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
### Description

I find this confusing:

<img width="394" height="157" alt="image" src="https://github.com/user-attachments/assets/2cb52b56-83c9-4125-9996-e9eac9ac3a0e" />

This adds the shard number to the test name so its easier to understand :)

### Notes for release

N/A