### PR TITLE
chore: log telemetry events to devtools console

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,7 @@
 export PATH="`pwd`/node_modules/.bin:$PATH"
 
 # Log telemetry events to console
+# Can be overridden in .env if needed
 export SANITY_STUDIO_DEBUG_TELEMETRY=true
 
 # /---


### PR DESCRIPTION
### Description
Tiny dev QOL improvement:  Log telemetry events to console to make it more visible to what will be submitted when developing events.

### What to review
Enabled in .envrc so it can be disabled in local .env files, which will be applied later.


### Testing
- Checkout branch
- run `direnv allow`
- run `pnpm dev`
- Verify that telemetry events are logged to console

### Notes for release
n/a – internal