### PR TITLE
chore(workflows): update mark issues as done action

### DIFF
--- a/.github/workflows/mark_issues_done_on_release.yml
+++ b/.github/workflows/mark_issues_done_on_release.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Mark Growth Linear issues Done
         id: mark-growth-issues-done
-        uses: sanity-io/mark-issues-done-action@main
+        uses: sanity-labs/mark-issues-done-action@main
         with:
           linear_api_key: ${{secrets.LINEAR_API_TOKEN}}
           repository_name: ${{github.event.repository.name}}


### PR DESCRIPTION
The mark-issues-done-action has moved from the sanity-io org to sanity-labs. This updates the workflow to reference the new location.