### PR TITLE
fix: issue with Calendar on typing

### DIFF
--- a/packages/sanity/src/core/components/inputs/DateInputs/calendar/Calendar.tsx
+++ b/packages/sanity/src/core/components/inputs/DateInputs/calendar/Calendar.tsx
@@ -4,6 +4,7 @@ import {Box, Flex, Grid, Select, Text} from '@sanity/ui'
 import {format} from '@sanity/util/legacyDateFormat'
 import {addDays} from 'date-fns/addDays'
 import {addMonths} from 'date-fns/addMonths'
+import {isValid} from 'date-fns/isValid'
 import {parse} from 'date-fns/parse'
 import {setDate} from 'date-fns/setDate'
 import {setHours} from 'date-fns/setHours'
@@ -181,7 +182,12 @@ export const Calendar = forwardRef(function Calendar(
     (event: FormEvent<HTMLInputElement>) => {
       const nextValue = event.currentTarget.value
       if (nextValue) {
+        // avoids native time input segment navigation resetting while typing.
+        setTimeValue(nextValue)
         const date = parse(nextValue, 'HH:mm', new Date())
+        if (!isValid(date)) {
+          return
+        }
         handleTimeChange(date.getHours(), date.getMinutes())
       } else {
         // Setting the timeValue to undefined will let the input behave correctly as a time input while the user types.

--- a/packages/sanity/src/core/components/inputs/DateInputs/calendar/__tests__/Calendar.test.tsx
+++ b/packages/sanity/src/core/components/inputs/DateInputs/calendar/__tests__/Calendar.test.tsx
@@ -160,6 +160,7 @@ describe('Calendar with stored timezone tokyo', () => {
     // Change the time to 22:30 Tokyo time
     await userEvent.clear(timeInput)
     await userEvent.type(timeInput, '22:30')
+    expect(timeInput).toHaveValue('22:30')
 
     // 22:30 Tokyo = 13:30 UTC (Tokyo is UTC+9)
     expect(mockOnSelect).toHaveBeenCalledWith(new Date('2024-01-15T13:30:00Z'))


### PR DESCRIPTION
### Description

before

https://github.com/user-attachments/assets/365068e5-d738-4c61-8e88-66c5b8d42ffe

after

https://github.com/user-attachments/assets/ee74a46b-7ed7-4eff-a9b7-ec14e0bbe2e0

### What to review

- Does this make sense? Am I missing some use case that might trip this logic?

### Testing

Updated tests

### Notes for release

Fixes issue where writing on the hour time in the datetimeinput would require double pressing of numbers to get double digit numbers (1 - 1 - 2 to get 12, for example)