### PR TITLE
fix(portable-text): show annotation popover on first click

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/CombinedAnnotationPopover.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/CombinedAnnotationPopover.tsx
@@ -96,6 +96,16 @@ export function CombinedAnnotationPopover(props: CombinedAnnotationPopoverProps)
     }
   }, [handleSelectionChange])
 
+  // Re-check selection when annotations register or unregister.
+  // Annotation components register with the context after React processes
+  // the editor's selection change, which happens after the DOM
+  // selectionchange event has already fired. Without this, the popover
+  // misses the first click because annotations.length is still 0 when
+  // selectionchange runs.
+  useEffect(() => {
+    handleSelectionChange()
+  }, [handleSelectionChange])
+
   // Handle scroll to keep popover positioned correctly
   const handleScroll = useCallback(() => {
     if (rangeRef.current) {


### PR DESCRIPTION
### Description

Fixes a regression from #11923 where clicking inside an annotation requires two clicks before the toolbar popover appears.

The root cause is a race condition between the DOM `selectionchange` event and React's render cycle. When the user clicks inside an annotation:

1. The browser fires `selectionchange`
2. `CombinedAnnotationPopover` handles it and checks `annotations.length` - but it's still 0
3. The editor processes the selection change and re-renders annotation components
4. `DefaultAnnotationComponent` registers with the context (`annotations.length` becomes 1)
5. No new `selectionchange` fires, so the popover never opens

On the second click, the annotation is already registered from step 4, so the popover opens immediately.

The fix adds a `useEffect` that re-runs the selection check whenever annotations are registered or unregistered. Since `handleSelectionChange` is recreated when `annotations` changes (it's in the `useCallback` dependency array), the effect fires after annotation registration and picks up the current selection.

### What to review

The added `useEffect` and its comment explaining the timing issue.

### Testing

- Click inside an annotation - popover should appear on the first click (previously required two clicks)
- Click away from annotation - popover should close
- Click from one annotation to another - popover should update
- Multiple overlapping annotations should still show combined popover

### Notes for release

The annotation toolbar popover now appears on the first click instead of requiring two clicks. This was a regression introduced in the combined annotation popover feature.