### PR TITLE
chore(deps): updates rimraf to v6

### DIFF
--- a/dev/design-studio/package.json
+++ b/dev/design-studio/package.json
@@ -43,6 +43,6 @@
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "eslint": "catalog:",
-    "rimraf": "^5.0.10"
+    "rimraf": "catalog:"
   }
 }

--- a/dev/page-building-studio/package.json
+++ b/dev/page-building-studio/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "eslint": "catalog:",
-    "rimraf": "^5.0.10",
+    "rimraf": "catalog:",
     "vite": "catalog:"
   }
 }

--- a/dev/sdk-app/package.json
+++ b/dev/sdk-app/package.json
@@ -22,7 +22,7 @@
     "styled-components": "catalog:"
   },
   "devDependencies": {
-    "rimraf": "^5.0.10",
+    "rimraf": "catalog:",
     "sanity": "workspace:"
   }
 }

--- a/dev/starter-studio/package.json
+++ b/dev/starter-studio/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "eslint": "catalog:",
-    "rimraf": "^5.0.10"
+    "rimraf": "catalog:"
   }
 }

--- a/dev/test-create-integration-studio/package.json
+++ b/dev/test-create-integration-studio/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "eslint": "catalog:",
-    "rimraf": "^5.0.10"
+    "rimraf": "catalog:"
   }
 }

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -71,7 +71,7 @@
     "babel-plugin-react-compiler": "1.0.0",
     "chokidar": "^3.6.0",
     "eslint": "catalog:",
-    "rimraf": "^5.0.10",
+    "rimraf": "catalog:",
     "tsx": "^4.21.0",
     "vite": "catalog:"
   }

--- a/examples/studios/ecommerce-studio/package.json
+++ b/examples/studios/ecommerce-studio/package.json
@@ -34,5 +34,8 @@
     "react-dom": "catalog:",
     "sanity": "workspace:*",
     "styled-components": "catalog:"
+  },
+  "devDependencies": {
+    "rimraf": "catalog:"
   }
 }

--- a/examples/studios/movies-studio/package.json
+++ b/examples/studios/movies-studio/package.json
@@ -33,5 +33,8 @@
     "react-dom": "catalog:",
     "sanity": "workspace:*",
     "styled-components": "catalog:"
+  },
+  "devDependencies": {
+    "rimraf": "catalog:"
   }
 }

--- a/packages/@sanity/diff/package.json
+++ b/packages/@sanity/diff/package.json
@@ -60,7 +60,7 @@
     "@sanity/pkg-utils": "catalog:",
     "@typescript/native-preview": "catalog:",
     "eslint": "catalog:",
-    "rimraf": "^5.0.10"
+    "rimraf": "catalog:"
   },
   "browserslist": [
     "node >=20.19",

--- a/packages/@sanity/mutator/package.json
+++ b/packages/@sanity/mutator/package.json
@@ -70,7 +70,7 @@
     "@types/node": "catalog:",
     "@typescript/native-preview": "catalog:",
     "eslint": "catalog:",
-    "rimraf": "^5.0.10",
+    "rimraf": "catalog:",
     "vitest": "catalog:"
   },
   "browserslist": [

--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -88,7 +88,7 @@
     "@types/react": "catalog:",
     "@typescript/native-preview": "catalog:",
     "eslint": "catalog:",
-    "rimraf": "^5.0.10",
+    "rimraf": "catalog:",
     "vitest": "catalog:"
   },
   "browserslist": [

--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -69,7 +69,7 @@
     "@vitejs/plugin-react": "catalog:",
     "eslint": "catalog:",
     "react": "catalog:",
-    "rimraf": "^5.0.10",
+    "rimraf": "catalog:",
     "vitest": "catalog:"
   },
   "peerDependencies": {

--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -139,7 +139,7 @@
     "@types/node": "catalog:",
     "@typescript/native-preview": "catalog:",
     "eslint": "catalog:",
-    "rimraf": "^5.0.10",
+    "rimraf": "catalog:",
     "vitest": "catalog:"
   },
   "browserslist": [

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -99,7 +99,7 @@
     "jsdom": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "rimraf": "^5.0.10",
+    "rimraf": "catalog:",
     "sanity": "^5.14.1",
     "styled-components": "catalog:",
     "vite": "catalog:",

--- a/packages/groq/package.json
+++ b/packages/groq/package.json
@@ -58,7 +58,7 @@
     "@types/node": "catalog:",
     "@typescript/native-preview": "catalog:",
     "eslint": "catalog:",
-    "rimraf": "^5.0.10"
+    "rimraf": "catalog:"
   },
   "browserslist": [
     "node >=20.19",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -297,7 +297,7 @@
     "jsdom": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "rimraf": "^5.0.10",
+    "rimraf": "catalog:",
     "rxjs-etc": "^10.6.2",
     "styled-components": "catalog:",
     "swr": "2.2.5",

--- a/perf/studio/package.json
+++ b/perf/studio/package.json
@@ -17,13 +17,13 @@
     "babel-plugin-react-compiler": "1.0.0",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "rimraf": "^5.0.10",
     "sanity": "workspace:*",
     "styled-components": "catalog:"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "@repo/tsconfig": "workspace:*",
-    "eslint": "catalog:"
+    "eslint": "catalog:",
+    "rimraf": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ catalogs:
     react-is:
       specifier: ^19.2.4
       version: 19.2.4
+    rimraf:
+      specifier: ^6.1.3
+      version: 6.1.3
     styled-components:
       specifier: npm:@sanity/styled-components@^6.1.24
       version: 6.1.24
@@ -238,8 +241,8 @@ importers:
         specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.1)
       rimraf:
-        specifier: ^5.0.10
-        version: 5.0.10
+        specifier: 'catalog:'
+        version: 6.1.3
 
   dev/e2e-embedded-studio-vite:
     dependencies:
@@ -416,8 +419,8 @@ importers:
         specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.1)
       rimraf:
-        specifier: ^5.0.10
-        version: 5.0.10
+        specifier: 'catalog:'
+        version: 6.1.3
       vite:
         specifier: 'catalog:'
         version: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -444,8 +447,8 @@ importers:
         version: '@sanity/styled-components@6.1.24(react-dom@19.2.4(react@19.2.4))(react@19.2.4)'
     devDependencies:
       rimraf:
-        specifier: ^5.0.10
-        version: 5.0.10
+        specifier: 'catalog:'
+        version: 6.1.3
 
   dev/starter-studio:
     dependencies:
@@ -472,8 +475,8 @@ importers:
         specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.1)
       rimraf:
-        specifier: ^5.0.10
-        version: 5.0.10
+        specifier: 'catalog:'
+        version: 6.1.3
 
   dev/studio-e2e-testing:
     dependencies:
@@ -558,8 +561,8 @@ importers:
         specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.1)
       rimraf:
-        specifier: ^5.0.10
-        version: 5.0.10
+        specifier: 'catalog:'
+        version: 6.1.3
 
   dev/test-studio:
     dependencies:
@@ -718,8 +721,8 @@ importers:
         specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.1)
       rimraf:
-        specifier: ^5.0.10
-        version: 5.0.10
+        specifier: 'catalog:'
+        version: 6.1.3
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -1113,8 +1116,8 @@ importers:
         specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.1)
       rimraf:
-        specifier: ^5.0.10
-        version: 5.0.10
+        specifier: 'catalog:'
+        version: 6.1.3
 
   packages/@sanity/mutator:
     dependencies:
@@ -1165,8 +1168,8 @@ importers:
         specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.1)
       rimraf:
-        specifier: ^5.0.10
-        version: 5.0.10
+        specifier: 'catalog:'
+        version: 6.1.3
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@edge-runtime/vm@3.2.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -1235,8 +1238,8 @@ importers:
         specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.1)
       rimraf:
-        specifier: ^5.0.10
-        version: 5.0.10
+        specifier: 'catalog:'
+        version: 6.1.3
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@edge-runtime/vm@3.2.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -1284,8 +1287,8 @@ importers:
         specifier: 'catalog:'
         version: 19.2.4
       rimraf:
-        specifier: ^5.0.10
-        version: 5.0.10
+        specifier: 'catalog:'
+        version: 6.1.3
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@edge-runtime/vm@3.2.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -1336,8 +1339,8 @@ importers:
         specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.1)
       rimraf:
-        specifier: ^5.0.10
-        version: 5.0.10
+        specifier: 'catalog:'
+        version: 6.1.3
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@edge-runtime/vm@3.2.0)(@types/node@24.10.13)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -1469,8 +1472,8 @@ importers:
         specifier: 'catalog:'
         version: 19.2.4(react@19.2.4)
       rimraf:
-        specifier: ^5.0.10
-        version: 5.0.10
+        specifier: 'catalog:'
+        version: 6.1.3
       sanity:
         specifier: ^5.14.1
         version: link:../../sanity
@@ -1508,8 +1511,8 @@ importers:
         specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.1)
       rimraf:
-        specifier: ^5.0.10
-        version: 5.0.10
+        specifier: 'catalog:'
+        version: 6.1.3
 
   packages/sanity:
     dependencies:
@@ -1938,8 +1941,8 @@ importers:
         specifier: 'catalog:'
         version: 19.2.4(react@19.2.4)
       rimraf:
-        specifier: ^5.0.10
-        version: 5.0.10
+        specifier: 'catalog:'
+        version: 6.1.3
       rxjs-etc:
         specifier: ^10.6.2
         version: 10.6.2(rxjs@7.8.2)
@@ -1982,9 +1985,6 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.4(react@19.2.4)
-      rimraf:
-        specifier: ^5.0.10
-        version: 5.0.10
       sanity:
         specifier: workspace:*
         version: link:../../packages/sanity
@@ -2001,6 +2001,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.1)
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.1.3
 
   perf/tests:
     dependencies:
@@ -2099,8 +2102,8 @@ importers:
         specifier: ^1.2.8
         version: 1.2.8
       rimraf:
-        specifier: ^5.0.10
-        version: 5.0.10
+        specifier: 'catalog:'
+        version: 6.1.3
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
@@ -3832,10 +3835,6 @@ packages:
       '@types/node':
         optional: true
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
@@ -4487,10 +4486,6 @@ packages:
     resolution: {integrity: sha512-bSuItSU8mTSDsvmmLTepTdCL2FkJI6dwt9tot/k0EmiYF+ArRzmsl4lXVLssJNRV5lJEc5IViyTrh7oiwrjUqA==}
     cpu: [x64]
     os: [win32]
-
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
 
   '@playwright/experimental-ct-core@1.57.0':
     resolution: {integrity: sha512-Z5Uh+61vR5FDRE+YJIMrnD8m6i2wJmYK525AHCJNcAcGcEC+i7xuMnZmZkg+booi3YHIwql/ApAlm03+jsCIzQ==}
@@ -7303,9 +7298,6 @@ packages:
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
   easymde@2.20.0:
     resolution: {integrity: sha512-V1Z5f92TfR42Na852OWnIZMbM7zotWQYTddNaLYZFVKj7APBbyZ3FYJ27gBw2grMW3R6Qdv9J8n5Ij7XRSIgXQ==}
 
@@ -7330,9 +7322,6 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
@@ -8177,11 +8166,6 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  glob@10.5.0:
-    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
-
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
@@ -8802,9 +8786,6 @@ packages:
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
-
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jackspeak@4.2.3:
     resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
@@ -9843,10 +9824,6 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
-
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
@@ -10449,10 +10426,6 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rimraf@5.0.10:
-    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
-    hasBin: true
-
   rimraf@6.1.3:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
@@ -10887,10 +10860,6 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
-
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
 
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -11813,10 +11782,6 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
-
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
 
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
@@ -13786,15 +13751,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.13
 
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.1.2
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
-
   '@isaacs/cliui@9.0.0': {}
 
   '@isaacs/fs-minipass@4.0.1':
@@ -14590,9 +14546,6 @@ snapshots:
     optional: true
 
   '@oxlint/win32-x64@1.43.0':
-    optional: true
-
-  '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@playwright/experimental-ct-core@1.57.0(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)':
@@ -18089,8 +18042,6 @@ snapshots:
       readable-stream: 3.6.2
       stream-shift: 1.0.3
 
-  eastasianwidth@0.2.0: {}
-
   easymde@2.20.0:
     dependencies:
       '@types/codemirror': 5.60.17
@@ -18124,8 +18075,6 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
-
-  emoji-regex@9.2.2: {}
 
   empathic@2.0.0: {}
 
@@ -19186,15 +19135,6 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@10.5.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.5
-      minipass: 7.1.3
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
-
   glob@11.1.0:
     dependencies:
       foreground-child: 3.3.1
@@ -19800,12 +19740,6 @@ snapshots:
       get-proto: 1.0.1
       has-symbols: 1.1.0
       set-function-name: 2.0.2
-
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
 
   jackspeak@4.2.3:
     dependencies:
@@ -20924,11 +20858,6 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.3
-
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.2.6
@@ -21536,10 +21465,6 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rimraf@5.0.10:
-    dependencies:
-      glob: 10.5.0
-
   rimraf@6.1.3:
     dependencies:
       glob: 13.0.6
@@ -22115,12 +22040,6 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.1.2
 
   string-width@7.2.0:
     dependencies:
@@ -23083,12 +23002,6 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 5.1.2
-      strip-ansi: 7.1.2
 
   wrap-ansi@9.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,7 @@ catalog:
   react: ^19.2.4
   react-dom: ^19.2.4
   react-is: ^19.2.4
+  rimraf: ^6.1.3
   # Note: there is currently a test failure in src/core/form/inputs/files/FileInput/__tests__/fileInput.test.tsx
   # that blocks us from upgrading to jsdom@27 – once that test is passing, the jsdom override can be removed from
   # the workspace package.json.

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -23,7 +23,7 @@
     "globby": "^11.1.0",
     "lodash-es": "^4.17.22",
     "minimist": "^1.2.8",
-    "rimraf": "^5.0.10",
+    "rimraf": "catalog:",
     "rxjs": "^7.8.2",
     "semver": "^7.7.3",
     "yargs": "^17.7.2"


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Removes a vulnerable version of glob to fix downstream security reports

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Existing things work. v6 is mostly dropping support under node 20

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Existing tests should work

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->

N/A