### PR TITLE
fix: update function examples

### DIFF
--- a/examples/functions/algolia-document-sync/README.md
+++ b/examples/functions/algolia-document-sync/README.md
@@ -55,7 +55,6 @@ This function is built to be compatible with any of [the official "clean" templa
    }
 
    defineDocumentFunction({
-     type: 'sanity.function.document',
      name: 'algolia-document-sync',
      memory: 1,
      timeout: 10,

--- a/examples/functions/auto-changelog/README.md
+++ b/examples/functions/auto-changelog/README.md
@@ -118,7 +118,6 @@ npx sanity schema deploy
 
    ```ts
    defineDocumentFunction({
-     type: 'sanity.function.document',
      src: './functions/auto-changelog',
      memory: 2,
      timeout: 30,

--- a/examples/functions/auto-redirect/README.md
+++ b/examples/functions/auto-redirect/README.md
@@ -91,7 +91,6 @@ import {defineBlueprint, defineDocumentFunction} from '@sanity/blueprints'
 export default defineBlueprint({
   resources: [
     defineDocumentFunction({
-      type: 'sanity.function.document',
       name: 'auto-redirect',
       src: './functions/auto-redirect',
       memory: 2,

--- a/examples/functions/auto-summary/README.md
+++ b/examples/functions/auto-summary/README.md
@@ -71,7 +71,6 @@ npx sanity schema deploy
 
    ```ts
    defineDocumentFunction({
-     type: 'sanity.function.document',
      src: './functions/auto-summary',
      memory: 2,
      timeout: 30,

--- a/examples/functions/auto-tag/README.md
+++ b/examples/functions/auto-tag/README.md
@@ -75,7 +75,6 @@ npx sanity schema deploy
    export default defineBlueprint({
      resources: [
        defineDocumentFunction({
-         type: 'sanity.function.document',
          name: 'auto-tag',
          src: './functions/auto-tag',
          memory: 2,
@@ -164,7 +163,6 @@ Once you've tested your function locally and are satisfied with its behavior, yo
    export default defineBlueprint({
      resources: [
        defineDocumentFunction({
-         type: 'sanity.function.document',
          name: 'auto-tag',
          src: './functions/auto-tag',
          memory: 2,

--- a/examples/functions/bluesky-post/README.md
+++ b/examples/functions/bluesky-post/README.md
@@ -108,7 +108,6 @@ defineField({
    export default defineBlueprint({
      resources: [
        defineDocumentFunction({
-         type: 'sanity.function.document',
          name: 'bluesky-post',
          src: './functions/bluesky-post',
          memory: 1,

--- a/examples/functions/brand-voice-validator/README.md
+++ b/examples/functions/brand-voice-validator/README.md
@@ -75,7 +75,6 @@ npx sanity schema deploy
    export default defineBlueprint({
      resources: [
        defineDocumentFunction({
-         type: 'sanity.function.document',
          name: 'brand-voice-validator',
          src: './functions/brand-voice-validator',
          memory: 2,
@@ -166,7 +165,6 @@ import {defineBlueprint, defineDocumentFunction} from '@sanity/blueprints'
 export default defineBlueprint({
   resources: [
     defineDocumentFunction({
-      type: 'sanity.function.document',
       name: 'brand-voice-validator',
       src: './functions/brand-voice-validator',
       memory: 2,

--- a/examples/functions/capture-tone-of-voice/README.md
+++ b/examples/functions/capture-tone-of-voice/README.md
@@ -75,7 +75,6 @@ npx sanity schema deploy
    export default defineBlueprint({
      resources: [
        defineDocumentFunction({
-         type: 'sanity.function.document',
          name: 'capture-tone-of-voice',
          src: './functions/capture-tone-of-voice',
          memory: 2,
@@ -164,7 +163,6 @@ import {defineBlueprint, defineDocumentFunction} from '@sanity/blueprints'
 export default defineBlueprint({
   resources: [
     defineDocumentFunction({
-      type: 'sanity.function.document',
       name: 'capture-tone-of-voice',
       src: './functions/capture-tone-of-voice',
       memory: 2,

--- a/examples/functions/first-published/README.md
+++ b/examples/functions/first-published/README.md
@@ -122,7 +122,6 @@ Once you've tested your function locally and are satisfied with its behavior, yo
    export default defineBlueprint({
      resources: [
        defineDocumentFunction({
-         type: 'sanity.function.document',
          name: 'first-published',
          src: './functions/first-published',
          memory: 1,

--- a/examples/functions/klaviyo-campaign-create/README.md
+++ b/examples/functions/klaviyo-campaign-create/README.md
@@ -91,7 +91,6 @@ This function is built to be compatible with the [Sanity E-commerce template](ht
    export default defineBlueprint({
      resources: [
        defineDocumentFunction({
-         type: 'sanity.function.document',
          name: 'klaviyo-campaign-create',
          memory: 1,
          timeout: 30,

--- a/examples/functions/klaviyo-campaign-send/README.md
+++ b/examples/functions/klaviyo-campaign-send/README.md
@@ -91,7 +91,6 @@ This function is built to be compatible with the [Sanity E-commerce template](ht
    export default defineBlueprint({
      resources: [
        defineDocumentFunction({
-         type: 'sanity.function.document',
          name: 'klaviyo-campaign-send',
          memory: 1,
          timeout: 30,

--- a/examples/functions/mastodon-post/README.md
+++ b/examples/functions/mastodon-post/README.md
@@ -112,7 +112,6 @@ defineField({
    export default defineBlueprint({
      resources: [
        defineDocumentFunction({
-         type: 'sanity.function.document',
          name: 'mastodon-post',
          src: './functions/mastodon-post',
          memory: 1,

--- a/examples/functions/product-mapping/README.md
+++ b/examples/functions/product-mapping/README.md
@@ -209,7 +209,6 @@ defineField({
    export default defineBlueprint({
      resources: [
        defineDocumentFunction({
-         type: 'sanity.function.document',
          name: 'product-mapping',
          memory: 1,
          timeout: 10,

--- a/examples/functions/sentiment-analysis/README.md
+++ b/examples/functions/sentiment-analysis/README.md
@@ -110,7 +110,6 @@ npx sanity schema list
    export default defineBlueprint({
      resources: [
        defineDocumentFunction({
-         type: 'sanity.function.document',
          name: 'sentiment-analysis',
          src: './functions/sentiment-analysis',
          memory: 2,
@@ -225,7 +224,6 @@ import {defineBlueprint, defineDocumentFunction} from '@sanity/blueprints'
 export default defineBlueprint({
   resources: [
     defineDocumentFunction({
-      type: 'sanity.function.document',
       name: 'sentiment-analysis',
       src: './functions/sentiment-analysis',
       memory: 2,

--- a/examples/functions/slack-notify/README.md
+++ b/examples/functions/slack-notify/README.md
@@ -88,7 +88,6 @@ Most official templates already include these fields.
    export default defineBlueprint({
      resources: [
        defineDocumentFunction({
-         type: 'sanity.function.document',
          name: 'slack-notify',
          src: './functions/slack-notify',
          memory: 1,
@@ -234,7 +233,6 @@ import {defineBlueprint, defineDocumentFunction} from '@sanity/blueprints'
 export default defineBlueprint({
   resources: [
     defineDocumentFunction({
-      type: 'sanity.function.document',
       name: 'slack-notify',
       src: './functions/slack-notify',
       memory: 1,

--- a/examples/functions/social-media-crosspost/README.md
+++ b/examples/functions/social-media-crosspost/README.md
@@ -157,7 +157,6 @@ This function includes a `socialPost` document type schema with a custom charact
    export default defineBlueprint({
      resources: [
        defineDocumentFunction({
-         type: 'sanity.function.document',
          name: 'social-media-crosspost',
          src: './functions/social-media-crosspost',
          memory: 2,

--- a/examples/functions/stale-products-analysis/README.md
+++ b/examples/functions/stale-products-analysis/README.md
@@ -140,7 +140,6 @@ defineField({
    export default defineBlueprint({
      resources: [
        defineDocumentFunction({
-         type: 'sanity.function.document',
          name: 'stale-products-analysis',
          memory: 1,
          timeout: 30,


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

I'm updating the README.md for all the function examples. With later versions of `@sanity/blueprints` you should not pass `type` into `defineDocumentFunction`. if you do it will produce a TS error:

```
No overload matches this call.
  Overload 1 of 2, '(functionConfig: BlueprintDocumentFunctionConfig): BlueprintDocumentFunctionResource', gave the following error.
    Object literal may only specify known properties, and 'type' does not exist in type 'BlueprintDocumentFunctionConfig'.
  Overload 2 of 2, '(functionConfig: Omit<BlueprintDocumentFunctionResource, "type" | "src" | "event"> & { src?: string | undefined; event?: BlueprintDocumentFunctionResourceEvent | undefined; } & Partial<...>): BlueprintDocumentFunctionResource', gave the following error.
```

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Made the changes to the README.md files and made sure the new `sanity.blueprints.ts` parsed correctly.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

No new tests added.

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->

No notes.