### PR TITLE
fix: prevent bare imports from appearing in random chunks

### DIFF
--- a/packages/sanity/package.config.ts
+++ b/packages/sanity/package.config.ts
@@ -15,4 +15,10 @@ export default defineConfig({
 
   babel: {reactCompiler: true, styledComponents: true},
   reactCompilerOptions: {target: '19'},
+
+  // Workaround for a long-standing rollup bug: when `moduleSideEffects` marks externals as
+  // side-effect-free (e.g. 'no-external') in a multi-entry build, bare imports from other entries
+  // leak into the first entry. The default `true` avoids this. Since the output is a library, the
+  // consumer's bundler handles external tree-shaking anyway.
+  rollup: {treeshake: {moduleSideEffects: true}},
 })


### PR DESCRIPTION
## Summary

- Work around a long-standing rollup bug that causes bare side-effect imports to leak across entry points in multi-entry builds
- The build output for `sanity/cli` incorrectly contained `import "@sanity/migrate"` despite the source having no such import

## The problem

When `@sanity/pkg-utils` builds a package with multiple exports (like `./cli`, `./migrate`, `./index`), it feeds them all into a single `rollup()` call. Rollup has a bug where, when `treeshake.moduleSideEffects` is set to anything that marks externals as side-effect-free (`'no-external'`, `false`, or an equivalent function), **every external import from other entries leaks into the first entry as a bare side-effect import**.

For the `sanity` package, this meant `lib/cli.js` (the first entry alphabetically) gained `import "@sanity/migrate"`, `import "@sanity/types"`, and other imports from sibling entries - none of which exist in `src/_exports/cli.ts`.

This caused runtime failures when `@sanity/migrate` was not installed or had an incompatible version, since importing `sanity/cli` would attempt to load it.

## The fix

Override `moduleSideEffects` back to `true` (rollup's default) in `package.config.ts`. This prevents the bug from triggering. Since the output is a library, the consuming bundler handles external tree-shaking anyway - the `'no-external'` optimization was unnecessary here.

## Reproduction

Minimal rollup config that triggers the bug (tested across rollup 3.x and all of 4.x):

```js
// Two entry points, completely independent
// src/cli.ts:    export { foo } from 'pkg-a'
// src/migrate.ts: export * from 'pkg-b'

export default {
  input: { cli: 'src/cli.ts', migrate: 'src/migrate.ts' },
  external: (id) => !id.startsWith('.') && !id.startsWith('/'),
  output: { dir: 'lib', format: 'esm' },
  treeshake: { moduleSideEffects: 'no-external' }, // triggers the bug
}
// Result: cli.js contains `import 'pkg-b'` - leaked from migrate entry
```

Upstream fix should go into `@sanity/pkg-utils` (removing `moduleSideEffects` from `resolveRollupConfig.ts`), but this unblocks the studio repo now.

## Test plan

- Build the `sanity` package and verify `lib/cli.js` no longer contains `import "@sanity/migrate"`
- Verify `lib/migrate.js` still correctly contains `export * from "@sanity/migrate"`

### Notes for release

N/A