### PR TITLE
chore(deps): add @sanity/cli to renovate auto-approve list

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -54,6 +54,7 @@
       "matchPackageNames": [
         "@portabletext/*",
         "@sanity/bifur-client",
+        "@sanity/cli",
         "@sanity/client",
         "@sanity/import",
         "@sanity/export",
@@ -85,6 +86,7 @@
         "@portabletext/editor",
         "@portabletext/html",
         "@sanity/bifur-client",
+        "@sanity/cli",
         "@sanity/client",
         "@sanity/comlink",
         "@sanity/eslint-config-i18n",


### PR DESCRIPTION
## Summary

- Adds `@sanity/cli` to the Renovate auto-approve list so PRs are opened automatically on weekdays without requiring Dependency Dashboard approval
- Also adds it to the `rangeStrategy: "bump"` rule alongside other internal `@sanity/*` production dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)