### PR TITLE
fix(sanity): use project hostname for agent bundles SSE endpoint

### DIFF
--- a/packages/sanity/src/core/store/agent/createAgentBundlesStore.ts
+++ b/packages/sanity/src/core/store/agent/createAgentBundlesStore.ts
@@ -98,9 +98,8 @@ function listenToBundles(
   client: SanityClient,
   organizationId: string,
 ): Observable<AgentBundlesState> {
-  const globalClient = client.withConfig({useProjectHostname: false})
-  const {token, withCredentials} = globalClient.config()
-  const url = globalClient.getUrl(`/agent/${organizationId}/bundles/mine/listen`)
+  const {token, withCredentials} = client.config()
+  const url = client.getUrl(`/agent/${organizationId}/bundles/mine/listen`)
 
   const esOptions: PolyfillEventSourceInit = {}
   if (token || withCredentials) esOptions.withCredentials = true


### PR DESCRIPTION
Removes the `useProjectHostname: false` override in `listenToBundles`, so the agent bundles SSE endpoint uses the project-scoped hostname instead of the global API host. This fixes CORS issues when connecting to the SSE endpoint.

- Removed the intermediate `globalClient` created via `client.withConfig({useProjectHostname: false})`
- The `client` is now used directly for both config and URL generation