### PR TITLE
chore(ci): add release notes to renovate PRs for @sanity/cli

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -129,6 +129,11 @@
       "description": "Always upgrade oxlint together",
       "groupName": "oxlint",
       "matchPackageNames": ["oxlint", "eslint-plugin-oxlint", "oxlint-tsgolint"]
+    },
+    {
+      "description": "Include release notes in PR description for @sanity/cli updates",
+      "matchPackageNames": ["@sanity/cli"],
+      "prBodyTemplate": "Notes for release\n{{{releaseNotes}}}"
     }
   ],
   "ignorePaths": ["packages/sanity/fixtures/examples/prj-with-react-19/package.json"]


### PR DESCRIPTION
## Summary
- Adds a Renovate package rule for `@sanity/cli` that includes GitHub release notes in the PR description
- When a new CLI version is published, the Renovate PR will show "Notes for release" followed by the release notes

## Test plan
- [ ] Publish a new CLI release with notes in flat format (no bullets, no headers)
- [ ] Confirm Renovate opens a PR with the release notes embedded in the description
- [ ] Adjust `prBodyTemplate` if formatting needs tweaking

🤖 Generated with [Claude Code](https://claude.com/claude-code)