### PR TITLE
ci: skip CI for non-code changes using dorny/paths-filter

### DIFF
--- a/.github/actions/detect-code-changes/action.yml
+++ b/.github/actions/detect-code-changes/action.yml
@@ -1,0 +1,43 @@
+name: Detect code changes
+description: >
+  Returns whether the PR contains code changes, excluding docs,
+  config files, IDE settings, and other non-code files.
+outputs:
+  has_changes:
+    description: "'true' if code files changed, 'false' otherwise"
+    value: ${{ steps.filter.outputs.code }}
+runs:
+  using: composite
+  steps:
+    - uses: dorny/paths-filter@v4
+      id: filter
+      with:
+        filters: |
+          code:
+            - '**'
+            - '!**/*.md'
+            - '!LICENSE'
+            - '!.editorconfig'
+            - '!.prettierrc'
+            - '!.prettierignore'
+            - '!.oxfmtrc.json'
+            - '!.claude/**'
+            - '!.cursor/**'
+            - '!.agents/**'
+            - '!.vscode/**'
+            - '!.gitignore'
+            - '!.husky/**'
+            - '!.github/CODEOWNERS'
+            - '!.github/ISSUE_TEMPLATE/**'
+            - '!.github/PULL_REQUEST_TEMPLATE.md'
+            - '!.github/renovate.json'
+            - '!.github/skills/**'
+            - '!.github/workflows/**'
+            - '!.tsdoc/**'
+            - '!docs/**'
+            - '!examples/**'
+            - '!skills/**'
+            - '!catalog-info.yaml'
+            - '!knip.jsonc'
+            - '!lerna.json'
+            - '!.env.example'

--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -20,8 +20,14 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/detect-code-changes
+        id: changes
+
       - uses: ./.github/actions/setup
+        if: steps.changes.outputs.has_changes == 'true'
       - uses: rexxars/bundle-stats@8a203ebfe0d207cab6fa587dbf912815e11c7a7a # v1
+        if: steps.changes.outputs.has_changes == 'true'
         with:
           packages: packages/sanity
           build-command: pnpm build

--- a/.github/workflows/depCheck.yml
+++ b/.github/workflows/depCheck.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
       - uses: ./.github/actions/setup
 
       - name: Check for unused/missing dependencies

--- a/.github/workflows/e2e-ct.yml
+++ b/.github/workflows/e2e-ct.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-8core
     outputs:
-      examples_only: ${{ steps.check_examples.outputs.path_only }}
+      has_code_changes: ${{ steps.changes.outputs.has_changes }}
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -24,17 +24,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check if only examples files changed
-        id: check_examples
-        uses: ./.github/actions/check-path-only
-        with:
-          path: examples/
+      - uses: ./.github/actions/detect-code-changes
+        id: changes
 
       - uses: ./.github/actions/setup
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: steps.changes.outputs.has_changes == 'true'
 
       - name: Build packages
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: steps.changes.outputs.has_changes == 'true'
         # This warms up the turborepo remote cache
         run: pnpm build --output-logs=full --log-order=grouped
 
@@ -54,19 +51,19 @@ jobs:
         shardTotal: [2]
     steps:
       - uses: actions/checkout@v6
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
       - uses: ./.github/actions/setup
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
 
       - name: Store Playwright's Version
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
         id: playwright-version
         run: |
           PLAYWRIGHT_VERSION=$(npx playwright --version | sed 's/Version //')
           echo "Playwright's Version: $PLAYWRIGHT_VERSION"
           echo "version=${PLAYWRIGHT_VERSION}" >> "$GITHUB_OUTPUT"
       - name: Cache Playwright Browsers for Playwright's Version
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
         id: cache-playwright-browsers
         uses: actions/cache@v5
         with:
@@ -75,30 +72,30 @@ jobs:
       - name: Install Playwright Browsers
         # TODO: Fix webkit caching when downloading from cache
         # for some reason it doesn't work without installing again
-        if: needs.install.outputs.examples_only != 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+        if: needs.install.outputs.has_code_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
       - name: Build packages
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
         # This should take only a few seconds as it'll restore the remote cache that got primed in the `install` job
         run: pnpm build --output-logs=full --log-order=grouped
 
       - name: Run end-to-end tests
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
         env:
           PWTEST_BLOB_REPORT_NAME: ${{ matrix.project }}
           NODE_OPTIONS: --max_old_space_size=8192
         run: pnpm --filter sanity test:ct --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - uses: actions/upload-artifact@v6
-        if: always() && needs.install.outputs.examples_only != 'true'
+        if: always() && needs.install.outputs.has_code_changes == 'true'
         with:
           name: playwright-ct-report-${{ matrix.project }}-${{ matrix.shardIndex }}
           path: ${{ github.workspace }}/packages/sanity/blob-report
           retention-days: 30
 
   merge-reports:
-    if: always() && needs.install.outputs.examples_only != 'true'
+    if: always() && needs.install.outputs.has_code_changes == 'true'
     needs: [install, playwright-ct-test]
     runs-on: ubuntu-8core
     steps:

--- a/.github/workflows/e2e-embedded.yml
+++ b/.github/workflows/e2e-embedded.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     outputs:
-      examples_only: ${{ steps.check_examples.outputs.path_only }}
+      has_code_changes: ${{ steps.changes.outputs.has_changes }}
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -26,17 +26,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check if only examples files changed
-        id: check_examples
-        uses: ./.github/actions/check-path-only
-        with:
-          path: examples/
+      - uses: ./.github/actions/detect-code-changes
+        id: changes
 
       - uses: ./.github/actions/setup
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: steps.changes.outputs.has_changes == 'true'
 
       - name: Store Playwright's Version
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: steps.changes.outputs.has_changes == 'true'
         id: playwright-version
         run: |
           PLAYWRIGHT_VERSION=$(npx playwright --version | sed 's/Version //')
@@ -44,7 +41,7 @@ jobs:
           echo "version=${PLAYWRIGHT_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright Browsers for Playwright's Version
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: steps.changes.outputs.has_changes == 'true'
         id: cache-playwright-browsers
         uses: actions/cache@v5
         with:
@@ -52,11 +49,11 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
-        if: steps.check_examples.outputs.path_only != 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+        if: steps.changes.outputs.has_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
   test:
-    if: needs.install.outputs.examples_only != 'true'
+    if: needs.install.outputs.has_code_changes == 'true'
     timeout-minutes: 30
     needs: [install]
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-8core
     outputs:
-      examples_only: ${{ steps.check_examples.outputs.path_only }}
+      has_code_changes: ${{ steps.changes.outputs.has_changes }}
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -32,18 +32,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check if only examples files changed
-        id: check_examples
-        uses: ./.github/actions/check-path-only
-        with:
-          path: examples/
+      - uses: ./.github/actions/detect-code-changes
+        id: changes
 
       - uses: ./.github/actions/setup
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: steps.changes.outputs.has_changes == 'true'
 
       - name: Add PR Comment placeholder for e2e Preview Environment
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
-        if: ${{ github.event_name == 'pull_request' && steps.check_examples.outputs.path_only != 'true' }}
+        if: ${{ github.event_name == 'pull_request' && steps.changes.outputs.has_changes == 'true' }}
         with:
           comment-tag: "e2e-preview-url"
           message: |
@@ -53,7 +50,7 @@ jobs:
 
       - name: Add PR Comment placeholder for e2e report
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
-        if: ${{ github.event_name == 'pull_request' && steps.check_examples.outputs.path_only != 'true' }}
+        if: ${{ github.event_name == 'pull_request' && steps.changes.outputs.has_changes == 'true' }}
         with:
           comment-tag: "playwright-e2e-report"
           message: |
@@ -62,7 +59,7 @@ jobs:
             Waiting for E2E tests to finish…
 
       - name: Store Playwright's Version
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: steps.changes.outputs.has_changes == 'true'
         id: playwright-version
         run: |
           PLAYWRIGHT_VERSION=$(npx playwright --version | sed 's/Version //')
@@ -70,7 +67,7 @@ jobs:
           echo "version=${PLAYWRIGHT_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright Browsers for Playwright's Version
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: steps.changes.outputs.has_changes == 'true'
         id: cache-playwright-browsers
         uses: actions/cache@v5
         with:
@@ -78,7 +75,7 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
-        if: steps.check_examples.outputs.path_only != 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+        if: steps.changes.outputs.has_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
   dataset-setup:
@@ -90,16 +87,16 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v6
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
       - uses: ./.github/actions/setup
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
 
       - name: Echo Vercel preview URL
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
         run: echo ${{ github.event.deployment_status.target_url }}
 
       - name: dataset setup on PR (chromium)
-        if: needs.install.outputs.examples_only != 'true' && github.event_name == 'pull_request'
+        if: needs.install.outputs.has_code_changes == 'true' && github.event_name == 'pull_request'
         env:
           SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW_STAGING }}
@@ -110,7 +107,7 @@ jobs:
           pnpm e2e:setup
 
       - name: dataset setup on PR (firefox)
-        if: needs.install.outputs.examples_only != 'true' && github.event_name == 'pull_request'
+        if: needs.install.outputs.has_code_changes == 'true' && github.event_name == 'pull_request'
         env:
           SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_SESSION_TOKEN_NEW_STAGING }}
@@ -130,19 +127,19 @@ jobs:
       preview_url: ${{ steps.deploy.outputs.DEPLOY_URL }}
     steps:
       - uses: actions/checkout@v6
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
       - uses: ./.github/actions/setup
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
 
       - name: Pull Vercel Environment Information
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_E2E_STUDIO_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_E2E_STUDIO_PROJECT_ID }}
         run: pnpm vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_E2E_STUDIO_TOKEN }}
 
       - name: Build Project Artifacts on PR
-        if: needs.install.outputs.examples_only != 'true' && github.event_name == 'pull_request'
+        if: needs.install.outputs.has_code_changes == 'true' && github.event_name == 'pull_request'
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_E2E_STUDIO_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_E2E_STUDIO_PROJECT_ID }}
@@ -154,7 +151,7 @@ jobs:
         run: pnpm vercel build --token=${{ secrets.VERCEL_E2E_STUDIO_TOKEN }}
 
       - name: Build Project Artifacts on main
-        if: needs.install.outputs.examples_only != 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: needs.install.outputs.has_code_changes == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_E2E_STUDIO_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_E2E_STUDIO_PROJECT_ID }}
@@ -167,7 +164,7 @@ jobs:
         run: pnpm vercel build --token=${{ secrets.VERCEL_E2E_STUDIO_TOKEN }}
 
       - name: Deploy Project Artifacts to Vercel
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
         id: deploy
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message || github.event.pull_request.title }}
@@ -185,7 +182,7 @@ jobs:
           -m githubCommitAuthorLogin="${{ github.event.sender.login || github.actor }}" | tail -n 1)" >> $GITHUB_OUTPUT
 
       - name: Echo the preview URL
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
         run: |
           if [ -z "${{ steps.deploy.outputs.DEPLOY_URL }}" ]; then
            echo "::error::Preview URL was not found. Deployment may have failed."
@@ -195,7 +192,7 @@ jobs:
 
       - name: Add PR Comment with preview URL
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
-        if: needs.install.outputs.examples_only != 'true' && github.event_name == 'pull_request'
+        if: needs.install.outputs.has_code_changes == 'true' && github.event_name == 'pull_request'
         with:
           comment-tag: "e2e-preview-url"
           message: |
@@ -239,15 +236,15 @@ jobs:
         shardTotal: [4]
     steps:
       - uses: actions/checkout@v6
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
       - name: Echo the base URL
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
         run: echo "$SANITY_E2E_BASE_URL"
       - uses: ./.github/actions/setup
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
 
       - name: Store Playwright's Version
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
         id: playwright-version
         run: |
           PLAYWRIGHT_VERSION=$(npx playwright --version | sed 's/Version //')
@@ -255,7 +252,7 @@ jobs:
           echo "version=${PLAYWRIGHT_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright Browsers for Playwright's Version
-        if: needs.install.outputs.examples_only != 'true'
+        if: needs.install.outputs.has_code_changes == 'true'
         id: cache-playwright-browsers
         uses: actions/cache/restore@v5
         with:
@@ -263,11 +260,11 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
-        if: needs.install.outputs.examples_only != 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+        if: needs.install.outputs.has_code_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
       - name: Run E2E tests on main
-        if: needs.install.outputs.examples_only != 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: needs.install.outputs.has_code_changes == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           # Missing in docs but in use
           # here https://github.com/microsoft/playwright/blob/main/packages/playwright/src/reporters/blob.ts#L108
@@ -282,7 +279,7 @@ jobs:
         run: pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - name: Run E2E tests on PR
-        if: needs.install.outputs.examples_only != 'true' && github.event_name == 'pull_request'
+        if: needs.install.outputs.has_code_changes == 'true' && github.event_name == 'pull_request'
         env:
           # Missing in docs but in use
           # here https://github.com/microsoft/playwright/blob/main/packages/playwright/src/reporters/blob.ts#L108
@@ -296,7 +293,7 @@ jobs:
         run: pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - uses: actions/upload-artifact@v6
-        if: always() && needs.install.outputs.examples_only != 'true'
+        if: always() && needs.install.outputs.has_code_changes == 'true'
         with:
           name: playwright-report-${{ matrix.project }}-${{ matrix.shardIndex }}
           path: |
@@ -305,7 +302,7 @@ jobs:
           retention-days: 30
 
   merge-reports:
-    if: always() && needs.install.outputs.examples_only != 'true'
+    if: always() && needs.install.outputs.has_code_changes == 'true'
     needs: [install, playwright-test]
     runs-on: ubuntu-8core
     steps:

--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -31,23 +31,20 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     outputs:
       preview_url: ${{ steps.deploy-preview.outputs.DEPLOY_URL }}
-      examples_only: ${{ steps.check_examples.outputs.path_only }}
+      has_code_changes: ${{ steps.changes.outputs.has_changes }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Check if only examples files changed
-        id: check_examples
-        uses: ./.github/actions/check-path-only
-        with:
-          path: examples/
+      - uses: ./.github/actions/detect-code-changes
+        id: changes
 
       - uses: ./.github/actions/setup
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: steps.changes.outputs.has_changes == 'true'
 
       - name: Pull Vercel Environment Information
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: steps.changes.outputs.has_changes == 'true'
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_EFPS_STUDIO_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_EFPS_STUDIO_PROJECT_ID }}
@@ -58,7 +55,7 @@ jobs:
             --token=${{ secrets.VERCEL_EFPS_STUDIO_TOKEN }}
 
       - name: Load Vercel Env Vars into GITHUB_ENV
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: steps.changes.outputs.has_changes == 'true'
         uses: ./.github/actions/vercel-env
         with:
           org-id: ${{ secrets.VERCEL_EFPS_STUDIO_ORG_ID }}
@@ -72,7 +69,7 @@ jobs:
 
       - name: Build Experiment Studio from PR
         # We prebuild in the GH action if in a branch to make it faster
-        if: ${{github.ref_name != 'main' && steps.check_examples.outputs.path_only != 'true'}}
+        if: ${{github.ref_name != 'main' && steps.changes.outputs.has_changes == 'true'}}
         env:
           SANITY_STUDIO_EFPS_EXPERIMENT_PROJECT_ID: ${{ env.SANITY_STUDIO_EFPS_EXPERIMENT_PROJECT_ID }}
           SANITY_STUDIO_EFPS_EXPERIMENT_DATASET: ${{ env.SANITY_STUDIO_EFPS_EXPERIMENT_DATASET }}
@@ -85,7 +82,7 @@ jobs:
 
       - name: Deploy Experiment Studio from PR
         id: deploy-preview
-        if: ${{github.ref_name != 'main' && steps.check_examples.outputs.path_only != 'true'}}
+        if: ${{github.ref_name != 'main' && steps.changes.outputs.has_changes == 'true'}}
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message || github.event.pull_request.title }}
         run: |
@@ -105,7 +102,7 @@ jobs:
 
       - name: Deploy new reference Studio from main
         id: deploy-main
-        if: ${{github.ref_name == 'main' && steps.check_examples.outputs.path_only != 'true'}}
+        if: ${{github.ref_name == 'main' && steps.changes.outputs.has_changes == 'true'}}
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message || github.event.pull_request.title }}
         run: |
@@ -124,7 +121,7 @@ jobs:
   efps-test:
     # We do not currently run in main, but we could do that if we want to compare main
     # against e.g. previous release
-    if: ${{github.ref_name != 'main' && needs.deploy.outputs.examples_only != 'true'}}
+    if: ${{github.ref_name != 'main' && needs.deploy.outputs.has_code_changes == 'true'}}
     timeout-minutes: 30
     runs-on: ubuntu-8core
     needs: [deploy]
@@ -212,7 +209,7 @@ jobs:
           retention-days: 30
 
   merge-reports:
-    if: ${{github.ref_name != 'main' && needs.deploy.outputs.examples_only != 'true' && needs.efps-test.result == 'success'}}
+    if: ${{ github.ref_name != 'main' && needs.deploy.outputs.has_code_changes == 'true' && needs.efps-test.result == 'success' }}
     needs: [deploy, efps-test]
     runs-on: ubuntu-8core
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      has_code_changes: ${{ steps.changes.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/detect-code-changes
+        id: changes
+
   test:
     timeout-minutes: 60
     name: Test (node ${{ matrix.node }}) - ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
     runs-on: ubuntu-8core
+    needs: [check]
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -39,26 +50,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        if: needs.check.outputs.has_code_changes == 'true'
         with:
           fetch-depth: 0
 
-      - name: Check if only examples files changed
-        id: check_examples
-        uses: ./.github/actions/check-path-only
-        with:
-          path: examples/
-
       - uses: ./.github/actions/setup
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: needs.check.outputs.has_code_changes == 'true'
         with:
           node-version: ${{ matrix.node }}
 
       - name: Build packages
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: needs.check.outputs.has_code_changes == 'true'
         run: pnpm build --output-logs=full --log-order=grouped
 
       - name: Test
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: needs.check.outputs.has_code_changes == 'true'
         id: test
         run: |
           # Base arguments for all test runs
@@ -73,7 +79,7 @@ jobs:
           GITHUB_SHARD_IDENTIFIER: ${{ matrix.shardIndex }}-${{ matrix.shardTotal }}
 
       - name: Upload blob report to GitHub Actions Artifacts
-        if: ${{ !cancelled() && matrix.node == '20' && steps.check_examples.outputs.path_only != 'true' }}
+        if: ${{ !cancelled() && matrix.node == '20' && needs.check.outputs.has_code_changes == 'true' }}
         uses: actions/upload-artifact@v6
         with:
           name: blob-report-${{ github.run_id }}-${{ matrix.shardIndex }}
@@ -83,7 +89,7 @@ jobs:
 
   report-coverage:
     if: ${{ !cancelled() }}
-    needs: test
+    needs: [check, test]
     runs-on: ubuntu-8core
     permissions:
       # Required to put a comment into the pull-request
@@ -91,20 +97,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        if: needs.check.outputs.has_code_changes == 'true'
         with:
           fetch-depth: 0
 
-      - name: Check if only examples files changed
-        id: check_examples
-        uses: ./.github/actions/check-path-only
-        with:
-          path: examples/
-
       - uses: ./.github/actions/setup
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: needs.check.outputs.has_code_changes == 'true'
 
       - name: "Download coverage artifacts"
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: needs.check.outputs.has_code_changes == 'true'
         uses: actions/download-artifact@v7
         with:
           path: .vitest-reports
@@ -112,12 +113,12 @@ jobs:
           merge-multiple: true
 
       - name: Merged report
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: needs.check.outputs.has_code_changes == 'true'
         id: merge_reports
         continue-on-error: true
         run: |
           pnpm vitest run --merge-reports --coverage
 
       - name: Report coverage
-        if: steps.check_examples.outputs.path_only != 'true' && steps.merge_reports.outcome == 'success'
+        if: needs.check.outputs.has_code_changes == 'true' && steps.merge_reports.outcome == 'success'
         uses: davelosert/vitest-coverage-report-action@5b6122e3a819a3be7b27fc961b7faafb3bf00e4d # v2

--- a/.github/workflows/testExports.yml
+++ b/.github/workflows/testExports.yml
@@ -13,15 +13,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check if only examples files changed
-        id: check_examples
-        uses: ./.github/actions/check-path-only
-        with:
-          path: examples/
+      - uses: ./.github/actions/detect-code-changes
+        id: changes
 
       - uses: ./.github/actions/setup
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: steps.changes.outputs.has_changes == 'true'
 
       - name: Check export conditions in native node ESM and CJS, and TypeScript DTS
-        if: steps.check_examples.outputs.path_only != 'true'
+        if: steps.changes.outputs.has_changes == 'true'
         run: pnpm test:exports


### PR DESCRIPTION
## Summary

This should make CI faster and waste less time on renovate PR and some docs changes. Please review the list maybe replace the check path only? cc @jordanl17 

- Uses `dorny/paths-filter@v4` across 7 CI workflows to skip expensive jobs for non-code changes
- Non-code changes (markdown, docs, editor configs, CI workflows, examples, etc.) now skip expensive test/build jobs instead of only skipping for `examples/` changes
- Uses step-level `if:` guards for required status checks (test, e2e, e2e-ct) so jobs always "pass" with skipped steps, avoiding branch protection issues
- **The shared filter configuration lives in a single composite action at `.github/actions/detect-code-changes/action.yml`** to avoid duplicating the exclusion list across all workflows

### Workflows updated

| Workflow | Change |
|----------|--------|
| `test.yml` | New `check` job with paths-filter; `test` + `report-coverage` reference it |
| `e2e-ct.yml` | Replaced `check-path-only` in `install` job |
| `e2e.yml` | Replaced `check-path-only` in `install` job |
| `e2e-embedded.yml` | Replaced `check-path-only` in `install` job |
| `efps.yml` | Replaced `check-path-only` in `deploy` job |
| `testExports.yml` | Replaced inline `check-path-only` |
| `bundle-stats.yml` | Added new paths-filter (had no skip logic before) |

### Not changed
- `check-path-only` action — still used by `label-path-only` for PR labeling
- `depCheck.yml` — should always run
- `formatCheck.yml`, `lintPr.yml`, `typeCheck.yml` — fast enough to always run
- Release, tag, issue management, and scheduled workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)