### PR TITLE
test(sanity): update exports snapshot

### DIFF
--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -480,6 +480,8 @@ exports[`exports snapshot 1`] = `
     "joinPath": "function",
     "listenQuery": "function",
     "matchWorkspace": "function",
+    "measureFirstEmission": "function",
+    "measureFirstMatch": "function",
     "newDraftFrom": "function",
     "noop": "function",
     "normalizeIndexSegment": "function",


### PR DESCRIPTION
### Description
Updates snapshot test for sanity's package exports that started failing after merge of #12373 

Looks like the use of `vitest --changed` added in #11909 doesn't trigger the exports tests on PRs, which is why this made its way into main in the first place. Will make a separate PR to ensure we always run the exports snapshot test on PRs.

### Notes for release
n/a