### PR TITLE
chore(ci): use correct template variable for renovate CLI release notes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -135,7 +135,7 @@
     {
       "description": "Include release notes in PR description for @sanity/cli updates",
       "matchPackageNames": ["@sanity/cli"],
-      "prBodyTemplate": "Notes for release\n{{{releaseNotes}}}"
+      "prBodyTemplate": "### Notes for release\n{{{changelogs}}}"
     }
   ],
   "ignorePaths": ["packages/sanity/fixtures/examples/prj-with-react-19/package.json"]


### PR DESCRIPTION
## Summary

Claude hallucinated before and made up things. Not validates with the docs hopefully this is it

- Fixes the `prBodyTemplate` for `@sanity/cli` Renovate PRs to use `{{{changelogs}}}` instead of `{{{releaseNotes}}}`
- `{{{releaseNotes}}}` is not a valid PR body template variable, which is why #12405 had an empty body

## Test plan
- [ ] Wait for next `@sanity/cli` release and verify the Renovate PR includes release notes in the description

🤖 Generated with [Claude Code](https://claude.com/claude-code)