### PR TITLE
chore(ci): remove vitest --changed in CI for now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # Full history required for vitest --changed to diff against base branch
           fetch-depth: 0
 
       - name: Check if only examples files changed
@@ -64,12 +63,6 @@ jobs:
         run: |
           # Base arguments for all test runs
           ARGS="--test-timeout=60000 --retry 4 --shard=${{ matrix.shardIndex}}/${{ matrix.shardTotal }} --passWithNoTests"
-
-          # Add --changed for PRs (unless 'full-test-suite' label is present)
-          if [ "${{ github.event_name }}" == "pull_request" ] && [ "${{ contains(github.event.pull_request.labels.*.name, 'full-test-suite') }}" != "true" ]; then
-            ARGS="$ARGS --changed origin/${{ github.base_ref }}"
-          fi
-
           if [ "${{ matrix.node }}" == "20" ]; then
             # We only gather coverage from a single Node version.
             # We pass in `--reporter=blob` so that we can combine the results from all shards.


### PR DESCRIPTION
### Description
Removes the --changed flag from unit test workflow for now since it caused the exports test to not run on PRs

Not sure how much savings it provides, but we can look into adding it back later.

### What to review
Makes sense?

### Testing
If CI is happy we're good

### Notes for release
n/a