### PR TITLE
chore(release-notes): strip version and section headers from Renovate changelog output

### DIFF
--- a/packages/@repo/release-notes/src/utils/__test__/parseRenovateReleaseNotes.test.ts
+++ b/packages/@repo/release-notes/src/utils/__test__/parseRenovateReleaseNotes.test.ts
@@ -158,7 +158,7 @@ Some normal release notes here.`
     expect(blocks).toEqual([])
   })
 
-  it('preserves version headers that have visible sections', () => {
+  it('strips version headers and merges sections across versions', () => {
     const body = `### Release Notes
 
 <details>
@@ -181,13 +181,15 @@ Some normal release notes here.`
     const blocks = parseRenovateReleaseNotes(body)
     const markdown = portableTextToMarkdown(blocks)
 
-    expect(markdown).toContain('v2.0.0')
+    // Version headers should NOT appear in output
+    expect(markdown).not.toContain('v2.0.0')
+    expect(markdown).not.toContain('v1.0.0')
+    // Content from both versions should be present
     expect(markdown).toContain('new feature A')
-    expect(markdown).toContain('v1.0.0')
     expect(markdown).toContain('fix B')
   })
 
-  it('removes version headers with only hidden sections', () => {
+  it('strips all version headers and excludes hidden sections', () => {
     const body = `### Release Notes
 
 <details>
@@ -210,11 +212,61 @@ Some normal release notes here.`
     const blocks = parseRenovateReleaseNotes(body)
     const markdown = portableTextToMarkdown(blocks)
 
-    expect(markdown).toContain('v2.0.0')
-    expect(markdown).toContain('visible feature')
-    // v1.0.0 header should be removed since it only has Dependencies
+    // No version headers in output
+    expect(markdown).not.toContain('v2.0.0')
     expect(markdown).not.toContain('v1.0.0')
+    // Visible content preserved, hidden content excluded
+    expect(markdown).toContain('visible feature')
     expect(markdown).not.toContain('hidden deps content')
+  })
+
+  it('merges same-type sections across multiple versions', () => {
+    const body = `### Release Notes
+
+<details>
+<summary>sanity-io/cli (@sanity/cli)</summary>
+
+### [\`v6.1.3\`](https://example.com)
+
+##### Bug Fixes
+
+- fix the project-id flag
+
+### [\`v6.1.2\`](https://example.com)
+
+##### Bug Fixes
+
+- bump react to latest
+
+### [\`v6.1.1\`](https://example.com)
+
+##### Bug Fixes
+
+- lazy-load icon resolver
+
+##### Features
+
+- add new template flag
+
+</details>`
+
+    const blocks = parseRenovateReleaseNotes(body)
+    const markdown = portableTextToMarkdown(blocks)
+
+    // All bug fixes should appear together under one Bug Fixes header
+    expect(markdown).toContain('fix the project-id flag')
+    expect(markdown).toContain('bump react to latest')
+    expect(markdown).toContain('lazy-load icon resolver')
+    expect(markdown).toContain('add new template flag')
+
+    // No version headers in output
+    expect(markdown).not.toMatch(/###.*v6\.1\.3/)
+    expect(markdown).not.toMatch(/###.*v6\.1\.2/)
+    expect(markdown).not.toMatch(/###.*v6\.1\.1/)
+
+    // No section headers in output — just the list items
+    expect(markdown).not.toContain('Bug Fixes')
+    expect(markdown).not.toContain('Features')
   })
 
   it('strips renovate-debug HTML comments', () => {

--- a/packages/@repo/release-notes/src/utils/parseRenovateReleaseNotes.ts
+++ b/packages/@repo/release-notes/src/utils/parseRenovateReleaseNotes.ts
@@ -72,35 +72,25 @@ function extractDetailsBlocks(body: string): DetailsBlock[] {
 
 /**
  * Splits markdown by section headers (h5: `##### Section Name`) and keeps only
- * visible sections. Removes version headers (h3) that end up with no visible sections.
+ * visible sections. Strips version headers (h3) and merges sections of the same
+ * type across versions so multi-version PRs produce a single grouped output.
  */
 function filterVisibleSections(markdown: string): string {
   const lines = markdown.split('\n')
-  const output: string[] = []
 
-  let currentVersionHeader: string | null = null
-  let currentVersionLines: string[] = []
+  // Map from lowercase section name → list of content lines (excluding the header itself)
+  const sectionItems = new Map<string, string[]>()
+  // Track insertion order for deterministic output
+  const sectionOrder: string[] = []
+
+  let currentSection: string | null = null
   let inVisibleSection = false
-  let hasVisibleContent = false
-
-  function flushVersion() {
-    if (hasVisibleContent) {
-      if (currentVersionHeader !== null) {
-        output.push(currentVersionHeader)
-      }
-      output.push(...currentVersionLines)
-    }
-    currentVersionHeader = null
-    currentVersionLines = []
-    inVisibleSection = false
-    hasVisibleContent = false
-  }
 
   for (const line of lines) {
-    // Version header (h3): ### [`v6.1.3`](...)
+    // Version header (h3): ### [`v6.1.3`](...) — skip entirely
     if (/^###\s+\[/.test(line)) {
-      flushVersion()
-      currentVersionHeader = line
+      currentSection = null
+      inVisibleSection = false
       continue
     }
 
@@ -110,18 +100,28 @@ function filterVisibleSections(markdown: string): string {
       const sectionName = sectionMatch[1].trim().toLowerCase()
       inVisibleSection = VISIBLE_CHANGELOG_SECTIONS.has(sectionName)
       if (inVisibleSection) {
-        currentVersionLines.push(line)
-        hasVisibleContent = true
+        currentSection = sectionName
+        if (!sectionItems.has(sectionName)) {
+          sectionItems.set(sectionName, [])
+          sectionOrder.push(sectionName)
+        }
+      } else {
+        currentSection = null
       }
       continue
     }
 
-    if (inVisibleSection) {
-      currentVersionLines.push(line)
+    if (inVisibleSection && currentSection) {
+      sectionItems.get(currentSection)!.push(line)
     }
   }
 
-  flushVersion()
+  // Collect all items without section headers
+  const output: string[] = []
+  for (const section of sectionOrder) {
+    output.push(...sectionItems.get(section)!)
+  }
+
   return output.join('\n')
 }
 


### PR DESCRIPTION
## Summary
- Multi-version Renovate PRs were including version headers (e.g. `v6.1.3`) and section headers (e.g. `Bug Fixes`) as line items in the suggested release note contents
- `filterVisibleSections` now merges items from the same section type across versions into a flat list without any headers
- Added test coverage for multi-version merging behavior

## Test plan
- [x] All 13 existing and new tests pass
- [ ] Verify that Renovate PRs spanning multiple versions produce clean flat list output in release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)