### PR TITLE
test: temporarily use fake timers for test

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
@@ -4,6 +4,7 @@ import {usePerspective} from 'sanity'
 import {
   type Mock,
   type MockedFunction,
+  afterEach,
   beforeAll,
   beforeEach,
   describe,
@@ -89,6 +90,7 @@ beforeAll(async () => {
 
 describe('CopyDocumentActions', () => {
   beforeEach(() => {
+    vi.useFakeTimers({shouldAdvanceTime: true})
     vi.clearAllMocks()
     Object.assign(navigator, {
       clipboard: {writeText: mockClipboardWriteText},
@@ -100,6 +102,10 @@ describe('CopyDocumentActions', () => {
       documentType: 'article',
       documentId: 'doc-123',
     })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   async function clickMenuItem(testId: string) {


### PR DESCRIPTION
### Description

> [!NOTE]
> Turns out this needs a wider fix. Working on it.

I believe the real fix for this is https://github.com/sanity-io/ui/pull/2181 but until that lands and we update, this _might_ silence the issues we're seeing on some unit tests:

```
ReferenceError: window is not defined
 ❯ resolveUpdatePriority node_modules/.pnpm/react-dom@19.2.4_react@19.2.4/node_modules/react-dom/cjs/react-dom-client.development.js:1308:7
 ❯ requestUpdateLane node_modules/.pnpm/react-dom@19.2.4_react@19.2.4/node_modules/react-dom/cjs/react-dom-client.development.js:16345:11
 ❯ dispatchSetState node_modules/.pnpm/react-dom@19.2.4_react@19.2.4/node_modules/react-dom/cjs/react-dom-client.development.js:9126:14
 ❯ Timeout.action [as _onTimeout] node_modules/.pnpm/@sanity+ui@3.1.13_@emotion+is-prop-valid@1.4.0_@sanity+styled-components@6.1.24_react-d_5a06a13ba0fc77dadcaacef74351e620/node_modules/@sanity/ui/dist/_chunks-es/_visual-editing.mjs:4716:7
 ❯ listOnTimeout node:internal/timers:605:17
 ❯ processTimers node:internal/timers:541:7

This error originated in "packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
```

### Notes for release

N/A