### PR TITLE
chore: replace deprecated placement in menuButton for popover.placement

### DIFF
--- a/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/CrossDatasetReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/CrossDatasetReferenceInput.tsx
@@ -405,8 +405,7 @@ export function CrossDatasetReferenceInput(props: CrossDatasetReferenceInputProp
                           )}
                         </Menu>
                       }
-                      placement="right"
-                      popover={{portal: true, tone: 'default'}}
+                      popover={{placement: 'right', portal: true, tone: 'default'}}
                     />
                   </Inline>
                 </Flex>

--- a/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/GlobalDocumentReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/GlobalDocumentReferenceInput.tsx
@@ -417,8 +417,7 @@ export function GlobalDocumentReferenceInput(props: GlobalDocumentReferenceInput
                       )}
                     </Menu>
                   }
-                  placement="right"
-                  popover={{portal: true, tone: 'default'}}
+                  popover={{placement: 'right', portal: true, tone: 'default'}}
                 />
               </Inline>
             </Flex>

--- a/packages/sanity/src/core/scheduled-publishing/components/scheduleContextMenu/FallbackContextMenu.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/scheduleContextMenu/FallbackContextMenu.tsx
@@ -38,8 +38,7 @@ export const FallbackContextMenu = (props: Props) => {
           />
         </Menu>
       }
-      placement="left"
-      popover={{portal: true, tone: 'default'}}
+      popover={{placement: 'left', portal: true, tone: 'default'}}
     />
   )
 }

--- a/packages/sanity/src/core/scheduled-publishing/components/scheduleContextMenu/ScheduleContextMenu.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/scheduleContextMenu/ScheduleContextMenu.tsx
@@ -37,8 +37,7 @@ export const ScheduleContextMenu = (props: Props) => {
           />
         </Menu>
       }
-      placement="left"
-      popover={{portal: true, tone: 'default'}}
+      popover={{placement: 'left', portal: true, tone: 'default'}}
     />
   )
 }

--- a/packages/sanity/src/core/scheduled-publishing/tool/scheduleFilters/ScheduleFilters.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/tool/scheduleFilters/ScheduleFilters.tsx
@@ -65,7 +65,7 @@ export const ScheduleFilters = (props: ScheduleFiltersProps) => {
                 ))}
               </Menu>
             }
-            placement="bottom"
+            popover={{placement: 'bottom'}}
           />
         )}
       </Box>

--- a/packages/sanity/src/core/studio/components/navbar/search/components/SortMenu.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/SortMenu.tsx
@@ -99,8 +99,7 @@ export function SortMenu() {
               })}
             </Menu>
           }
-          placement="bottom-start"
-          popover={{portal: true, radius: 2}}
+          popover={{placement: 'bottom-start', portal: true, radius: 2}}
         />
       </SortMenuContentFlex>
     </Card>

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/OperatorsMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/OperatorsMenuButton.tsx
@@ -91,8 +91,8 @@ export function OperatorsMenuButton({filter, operator}: OperatorsMenuButtonProps
             })}
           </Menu>
         }
-        placement="bottom-start"
         popover={{
+          placement: 'bottom-start',
           constrainSize: true,
           portal: false,
           radius: 2,


### PR DESCRIPTION
### Description
Replaces deprecated `placement` prop from menu button for popover.placement.
Functionality remains the same.
Brings us a tiny step closer to sanity ui v4/v5

Deprecation warning here:
https://github.com/sanity-io/ui/blob/main/src/core/components/menu/menuButton.tsx#L35-L37

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
