### PR TITLE
fix(sanity): loosen `@sanity/types` workspace version constraint

### DIFF
--- a/packages/@repo/release-notes/package.json
+++ b/packages/@repo/release-notes/package.json
@@ -34,7 +34,7 @@
     "@sanity/client": "catalog:",
     "@sanity/id-utils": "^1.0.0",
     "@sanity/mutate": "^0.16.1",
-    "@sanity/types": "workspace:^",
+    "@sanity/types": "workspace:*",
     "conventional-commits-parser": "^6.2.1",
     "date-fns": "^4.1.0",
     "description-to-co-authors": "^0.3.0",


### PR DESCRIPTION
### Description

`next` release is failing due to outdated `@sanity/types` dependency. It should be referring to the latest version in the monorepo.

I'm unable to replicate this outside of CI, but this is one potential issue I noticed.

### What to review

The dep change.

### Testing

Monorepo can still build (`pnpm build:bundle`).