### PR TITLE
fix(core): make tags input wider, fixes firefox crop issue

### DIFF
--- a/packages/sanity/src/core/form/components/tagInput/tagInput.tsx
+++ b/packages/sanity/src/core/form/components/tagInput/tagInput.tsx
@@ -235,7 +235,7 @@ export const TagInput = forwardRef(
 
       if (inputElement) {
         inputElement.style.width = '0'
-        inputElement.style.width = `${inputElement.scrollWidth}px`
+        inputElement.style.width = `calc(${inputElement.scrollWidth}px + 1rem)`
       }
     }, [inputValue])
 


### PR DESCRIPTION
### Description
Fixes https://github.com/sanity-io/sanity/issues/12436
Makes the tag input 1rem wider, 1 rem is the padding we are adding to the input.
When measuring the `scrollWidth` in firefox the padding is not considered into that width and the measurement we do returns a smaller than needed value. 
See video 

https://github.com/user-attachments/assets/c5d8c638-29b4-4def-942a-e10edac0ab5a

With this, the issue is fixed by making the input wider, by 1rem which is the value we are using for the padding, yes, it also makes it wider in safari and chrome, where we don't need to, but I think it's an ok tradeoff because the width is added at the end of the input and is not noticeable.

**Firefox**:

<img width="592" height="135" alt="Screenshot 2026-03-17 at 09 59 57" src="https://github.com/user-attachments/assets/7bd86465-248b-498b-85a4-c78784cf4d36" />

**Chrome**

<img width="632" height="144" alt="Screenshot 2026-03-17 at 10 00 26" src="https://github.com/user-attachments/assets/e81cecef-cf98-4ab7-9729-2f834c531d8c" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
