### PR TITLE
fix(sanity): excessive recomputing based on `formState`

### DIFF
--- a/packages/sanity/src/core/divergence/divergenceNavigator.ts
+++ b/packages/sanity/src/core/divergence/divergenceNavigator.ts
@@ -6,6 +6,7 @@ import {useObservable} from 'react-rx'
 import {
   BehaviorSubject,
   combineLatest,
+  EMPTY,
   filter,
   first,
   map,
@@ -19,6 +20,7 @@ import {
 
 import {type DiffComponent, type DiffComponentOptions} from '../field'
 import {type FormState} from '../form/store'
+import {useWorkspace} from '../studio/workspace'
 import {type CollatedDocumentDivergencesState} from './collateDocumentDivergences'
 import {type Divergence, type DivergenceAtPath} from './readDocumentDivergences'
 import {transposeSchema} from './transposeSchema'
@@ -154,6 +156,10 @@ export function useDivergenceNavigator({
   schemaType,
   formState,
 }: DivergenceNavigatorContext): DivergenceNavigator {
+  const {
+    advancedVersionControl: {enabled: advancedVersionControlEnabled},
+  } = useWorkspace()
+
   const dispatch = useMemo(() => new Subject<Action>(), [])
 
   const schemaTypeContext = useMemo(
@@ -168,30 +174,32 @@ export function useDivergenceNavigator({
   )
   useEffect(() => formStateContext.next(formState), [formStateContext, formState])
 
-  const context = useMemo<Observable<StateContext>>(
-    () =>
-      combineLatest({
-        divergences: divergences,
-        schemaType: schemaTypeContext.pipe(filter((value) => typeof value !== 'undefined')),
-        formState: formStateContext.pipe(
-          filter((value) => typeof value !== 'undefined'),
-          // Form state is used to map divergences to fields, and order them to
-          // match the order fields and groups are rendered in the document
-          // editor.
-          //
-          // However, form state also encapsulates current value, the focused
-          // path, etc. and changes with every change to the displayed document
-          // and interaction with the document editor.
-          //
-          // It's unnecessary to remap divergences every time the displayed
-          // document or state, like the focus path, changes. Therefore, this
-          // code takes only the first form state value emitted.
-          first(),
-          map((state) => (state ? pick(state, ['groups', '_allMembers']) : state)),
-        ),
-      }),
-    [divergences, schemaTypeContext, formStateContext],
-  )
+  const context = useMemo<Observable<StateContext>>(() => {
+    if (!advancedVersionControlEnabled) {
+      return EMPTY
+    }
+
+    return combineLatest({
+      divergences: divergences,
+      schemaType: schemaTypeContext.pipe(filter((value) => typeof value !== 'undefined')),
+      formState: formStateContext.pipe(
+        filter((value) => typeof value !== 'undefined'),
+        // Form state is used to map divergences to fields, and order them to
+        // match the order fields and groups are rendered in the document
+        // editor.
+        //
+        // However, form state also encapsulates current value, the focused
+        // path, etc. and changes with every change to the displayed document
+        // and interaction with the document editor.
+        //
+        // It's unnecessary to remap divergences every time the displayed
+        // document or state, like the focus path, changes. Therefore, this
+        // code takes only the first form state value emitted.
+        first(),
+        map((state) => (state ? pick(state, ['groups', '_allMembers']) : state)),
+      ),
+    })
+  }, [advancedVersionControlEnabled, divergences, schemaTypeContext, formStateContext])
 
   const readState = useMemo(() => createStateReducer({dispatch, context}), [dispatch, context])
 


### PR DESCRIPTION
### Description

After divergences are computed, they are mapped to schema nodes and ordered to match the schema definition. This process relies on form state, but form state changes much more frequently than matters for this process—it does not need to know about the current document value or document editor state such as the focus path.

To reduce unnecessary computation, this branch updates this process to only consider the first form state value emitted. This eliminates unnecessary computation that was previously occurring on every input.

The code has also been refined to reflect that only the `groups` and  `_allMembers` form state properties are required.

This branch also adds a new check to better isolate divergence related code based on whether Advanced Version Control is switched on. Note that the measurements below were taken without this change, to ensure the core fix is effective.

#### CPU usage _before_ problem introduced - keypress inside text field, inside PTE block

<img width="220" height="146" alt="Screenshot 2026-03-17 at 14 37 25" src="https://github.com/user-attachments/assets/14745241-8e29-454b-ae1f-51d6d08d2001" />

<img width="913" height="318" alt="Screenshot 2026-03-17 at 14 37 46" src="https://github.com/user-attachments/assets/095bddb6-a4b0-4559-8e52-916299b5460a" />

Keypress event handlers taking approximately 70ms–100ms.

#### CPU usage _after_ problem introduced - keypress inside text field, inside PTE block

<img width="210" height="123" alt="Screenshot 2026-03-17 at 14 40 27" src="https://github.com/user-attachments/assets/b2a634a5-2060-4d3f-b409-fc24c01868ca" />

<img width="820" height="305" alt="Screenshot 2026-03-17 at 14 41 03" src="https://github.com/user-attachments/assets/d14ca955-7cd8-4373-8b65-2ff822c74edf" />

Keypress event handlers taking approximately 100ms–220ms.

#### CPU usage _after this fix_ - keypress inside text field, inside PTE block

<img width="180" height="145" alt="Screenshot 2026-03-17 at 14 47 41" src="https://github.com/user-attachments/assets/d7739b6f-8889-4beb-90c1-9e92c76153f9" />

<img width="842" height="242" alt="Screenshot 2026-03-17 at 14 48 16" src="https://github.com/user-attachments/assets/bfb4d02d-a9e4-46ce-aa74-61da761b2092" />

Keypress event handlers taking approximately 70ms–100ms.

### What to review

Changes to take only first form state value.

### Testing

Tested divergence management in Test Studio, tested keypress responsiveness, and compared CPU profiles.