### PR TITLE
chore(release-notes): preserve PR/issue reference links in Renovate changelog items

### DIFF
--- a/packages/@repo/release-notes/src/utils/__test__/parseRenovateReleaseNotes.test.ts
+++ b/packages/@repo/release-notes/src/utils/__test__/parseRenovateReleaseNotes.test.ts
@@ -31,8 +31,11 @@ describe('parseRenovateReleaseNotes', () => {
     // Should NOT contain deps-scoped items even when under Bug Fixes
     expect(markdown).not.toContain('update oclif-tooling')
 
-    // Should NOT contain commit hashes or PR refs
+    // Should preserve PR/issue refs as links (without outer parens)
+    expect(markdown).toMatch(/\[#\d+]\(/)
     expect(markdown).not.toMatch(/\(\[#\d+]\(/)
+
+    // Should NOT contain commit hashes
     expect(markdown).not.toMatch(/\(\[[0-9a-f]{7}]\(/)
 
     // Should NOT contain content from non-allowlisted packages
@@ -87,6 +90,10 @@ describe('parseRenovateReleaseNotes', () => {
     const markdown = portableTextToMarkdown(blocks)
 
     expect(markdown).toContain('a visible fix')
+    // PR ref link should be preserved
+    expect(markdown).toContain('[#1](https://example.com)')
+    // Commit hash should be stripped
+    expect(markdown).not.toContain('abc1234')
     expect(markdown).not.toContain('dep bumped')
     expect(markdown).not.toContain('reformatted code')
     expect(markdown).not.toContain('updated config')
@@ -115,7 +122,7 @@ describe('parseRenovateReleaseNotes', () => {
     expect(markdown).not.toContain('deps')
   })
 
-  it('strips commit hashes and PR refs from list items', () => {
+  it('strips commit hashes but preserves PR refs as links', () => {
     const body = `### Release Notes
 
 <details>
@@ -133,8 +140,12 @@ describe('parseRenovateReleaseNotes', () => {
     const markdown = portableTextToMarkdown(blocks)
 
     expect(markdown).toContain('fix something important')
-    expect(markdown).not.toContain('#123')
+    // PR ref should be preserved as a link
+    expect(markdown).toContain('[#123](https://example.com/issues/123)')
+    // Commit hash should be stripped
     expect(markdown).not.toContain('deadbeef')
+    // Outer parens around PR ref should be removed
+    expect(markdown).not.toContain('([#123]')
   })
 
   it('returns empty for non-Renovate PR bodies', () => {

--- a/packages/@repo/release-notes/src/utils/parseRenovateReleaseNotes.ts
+++ b/packages/@repo/release-notes/src/utils/parseRenovateReleaseNotes.ts
@@ -126,7 +126,9 @@ function filterVisibleSections(markdown: string): string {
 }
 
 /**
- * Strip trailing commit hashes like `(0b660b9)` and PR refs like `(#661)` from list items,
+ * Strip trailing commit hashes like `([0b660b9](url))` from list items,
+ * unwrap PR/issue refs from outer parentheses so the link is preserved
+ * (e.g. `([#661](url))` → `[#661](url)`),
  * and remove dependency-scoped items (e.g. `- **deps:** ...`) that aren't meaningful for release notes.
  */
 function cleanChangelogItems(markdown: string): string {
@@ -134,10 +136,9 @@ function cleanChangelogItems(markdown: string): string {
     markdown
       // Remove dependency-scoped list items
       .replace(/^\s*-\s+\*\*deps:\*\*.*$/gm, '')
-      // Strip PR refs and commit hashes from remaining items
-      .replace(
-        /^(\s*-\s+.+?)\s*(?:\(\[#\d+]\([^)]*\)\)\s*)?(?:\(\[[0-9a-f]+]\([^)]*\)\)\s*)?$/gm,
-        '$1',
-      )
+      // Strip trailing commit hash links like ([0b660b9](url))
+      .replace(/\s*\(\[[0-9a-f]+]\([^)]*\)\)/gm, '')
+      // Unwrap PR/issue refs: ([#123](url)) → [#123](url) so the link is preserved
+      .replace(/\(\[#(\d+)]\(([^)]*)\)\)/gm, '[#$1]($2)')
   )
 }


### PR DESCRIPTION
## Summary
- The `cleanChangelogItems` function in `parseRenovateReleaseNotes.ts` was stripping **all** trailing references (both PR/issue links and commit hash links) from changelog list items before converting to portable text, resulting in studio documents with no links in `markDefs`
- Changed to only strip commit hash links (`([0b660b9](url))`) while preserving PR/issue reference links by unwrapping them from outer parentheses (`([#691](url))` → `[#691](url)`)
- This produces proper `link` annotations in the portable text `markDefs`, so links render correctly in the studio

## Test plan
- [x] All 26 existing release-notes tests pass with updated assertions
- [ ] Verify that Renovate PR changelog items in the studio now show clickable PR/issue links
- [ ] Confirm commit hash links are still stripped from the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)