### PR TITLE
test(sanity): don't use debug logging telemetry store when running tests

### DIFF
--- a/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
+++ b/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
@@ -24,8 +24,6 @@ import {type TelemetryContext} from './types'
 
 const sessionId = createSessionId()
 
-const DEBUG_TELEMETRY = import.meta && import.meta.env?.SANITY_STUDIO_DEBUG_TELEMETRY === 'true'
-
 /** Telemetry only runs on client */
 const isClient = typeof window !== 'undefined'
 
@@ -93,7 +91,9 @@ export function StudioTelemetryProvider(props: {children: ReactNode}) {
   }, [orgId, activeTool, workspace.name, workspace.projectId, workspace.dataset])
 
   const storeOptions = useMemo((): CreateBatchedStoreOptions => {
-    if (DEBUG_TELEMETRY) {
+    const debugTelemetry = import.meta && import.meta.env?.SANITY_STUDIO_DEBUG_TELEMETRY === 'true'
+
+    if (debugTelemetry) {
       return debugLoggingStore
     }
     return {

--- a/packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx
+++ b/packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx
@@ -4,6 +4,9 @@ import {render} from '@testing-library/react'
 import {type ReactNode} from 'react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
+// Disable console.logging of telemetry events in tests
+import.meta.env.SANITY_STUDIO_DEBUG_TELEMETRY = ''
+
 // Mocks (these get hoisted automatically by vitest)
 vi.mock('@sanity/telemetry')
 vi.mock('@sanity/telemetry/react', () => ({


### PR DESCRIPTION
### Description
We currently set `SANITY_STUDIO_DEBUG_TELEMETRY=true` in .envrc. This var is then read when running tests, causing telemetry test assertions to fail when running locally because we end up using the logging store. This fixes the issue by simply clearing `SANITY_STUDIO_DEBUG_TELEMETRY` in telemetry tests.

Also deferring the `SANITY_STUDIO_DEBUG_TELEMETRY` check to when we instantiate the store.

### What to review
Makes sense? I considered adding a check for import.meta.VITEST to StudioTelemetryProvider, but this seemed like a cleaner fix.

### Testing
CI should pass

### Notes for release
n/a