### PR TITLE
refactor(studio): migrate global styles to vanilla extract

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -187,6 +187,7 @@
     "@sanity/workbench": "0.1.0-alpha.42",
     "@sentry/react": "^10.69.0",
     "@tanstack/react-virtual": "^3.14.9",
+    "@vanilla-extract/dynamic": "catalog:",
     "@xstate/react": "^6.1.0",
     "clsx": "^2.1.1",
     "color2k": "^2.0.4",

--- a/packages/sanity/src/core/studio/GlobalStyle.test.tsx
+++ b/packages/sanity/src/core/studio/GlobalStyle.test.tsx
@@ -1,0 +1,88 @@
+import {studioTheme, ThemeProvider} from '@sanity/ui'
+import {render} from '@testing-library/react'
+import {afterEach, describe, expect, it} from 'vitest'
+
+import {GlobalStyle} from './GlobalStyle'
+import {GLOBAL_STYLES_ATTRIBUTE} from './globalStyleConstants'
+import {uiColorBg} from './styles.css'
+
+const uiColorBgName = uiColorBg.slice(4, -1)
+
+function ThemedGlobalStyle({scheme}: {scheme: 'dark' | 'light'}) {
+  return (
+    // oxlint-disable-next-line no-deprecated -- ThemeProvider is required to exercise useTheme_v2
+    <ThemeProvider scheme={scheme} theme={studioTheme}>
+      <GlobalStyle />
+    </ThemeProvider>
+  )
+}
+
+afterEach(() => {
+  document.documentElement.removeAttribute(GLOBAL_STYLES_ATTRIBUTE)
+  document.documentElement.style.removeProperty(uiColorBgName)
+})
+
+describe('GlobalStyle', () => {
+  it('restores the document root after unmounting', () => {
+    document.documentElement.style.setProperty(uiColorBgName, 'hotpink')
+
+    const {unmount} = render(<ThemedGlobalStyle scheme="dark" />)
+
+    expect(document.documentElement).toHaveAttribute(GLOBAL_STYLES_ATTRIBUTE)
+    expect(document.documentElement.style.getPropertyValue(uiColorBgName)).not.toBe('hotpink')
+
+    unmount()
+
+    expect(document.documentElement).not.toHaveAttribute(GLOBAL_STYLES_ATTRIBUTE)
+    expect(document.documentElement.style.getPropertyValue(uiColorBgName)).toBe('hotpink')
+  })
+
+  it('restores the surviving instance when another instance unmounts', () => {
+    const light = render(<ThemedGlobalStyle scheme="light" />)
+    const lightBackground = document.documentElement.style.getPropertyValue(uiColorBgName)
+    const dark = render(<ThemedGlobalStyle scheme="dark" />)
+    const darkBackground = document.documentElement.style.getPropertyValue(uiColorBgName)
+
+    expect(darkBackground).not.toBe(lightBackground)
+
+    dark.unmount()
+
+    expect(document.documentElement).toHaveAttribute(GLOBAL_STYLES_ATTRIBUTE)
+    expect(document.documentElement.style.getPropertyValue(uiColorBgName)).toBe(lightBackground)
+
+    light.unmount()
+
+    expect(document.documentElement).not.toHaveAttribute(GLOBAL_STYLES_ATTRIBUTE)
+    expect(document.documentElement.style.getPropertyValue(uiColorBgName)).toBe('')
+  })
+
+  it('keeps the latest instance active when an earlier instance unmounts', () => {
+    const light = render(<ThemedGlobalStyle scheme="light" />)
+    const dark = render(<ThemedGlobalStyle scheme="dark" />)
+    const darkBackground = document.documentElement.style.getPropertyValue(uiColorBgName)
+
+    light.unmount()
+
+    expect(document.documentElement).toHaveAttribute(GLOBAL_STYLES_ATTRIBUTE)
+    expect(document.documentElement.style.getPropertyValue(uiColorBgName)).toBe(darkBackground)
+
+    dark.unmount()
+
+    expect(document.documentElement).not.toHaveAttribute(GLOBAL_STYLES_ATTRIBUTE)
+    expect(document.documentElement.style.getPropertyValue(uiColorBgName)).toBe('')
+  })
+
+  it('keeps mount precedence when an earlier instance changes theme', () => {
+    const earlier = render(<ThemedGlobalStyle scheme="light" />)
+    const latest = render(<ThemedGlobalStyle scheme="dark" />)
+    const latestBackground = document.documentElement.style.getPropertyValue(uiColorBgName)
+
+    earlier.rerender(<ThemedGlobalStyle scheme="dark" />)
+    earlier.rerender(<ThemedGlobalStyle scheme="light" />)
+
+    expect(document.documentElement.style.getPropertyValue(uiColorBgName)).toBe(latestBackground)
+
+    latest.unmount()
+    earlier.unmount()
+  })
+})

--- a/packages/sanity/src/core/studio/GlobalStyle.tsx
+++ b/packages/sanity/src/core/studio/GlobalStyle.tsx
@@ -1,11 +1,43 @@
-import {getTheme_v2, rgba} from '@sanity/ui/theme'
-import {type ComponentType} from 'react'
-import {createGlobalStyle, css} from 'styled-components'
+import {useTheme_v2 as useThemeV2} from '@sanity/ui'
+import {rgba} from '@sanity/ui/theme'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {useInsertionEffect, useState} from 'react'
 
-import {useWorkspace} from './workspace'
+import {GLOBAL_STYLES_ATTRIBUTE} from './globalStyleConstants'
+import {
+  selectionBackgroundColor,
+  uiColorBg,
+  uiColorBorder,
+  uiColorMutedFg,
+  uiFontTextFamily,
+  uiFontTextWeightMedium,
+  webkitResizerBackgroundImage,
+} from './styles.css'
 
-const SCROLLBAR_SIZE = 12 // px
-const SCROLLBAR_BORDER_SIZE = 4 // px
+interface InitialVariable {
+  priority: string
+  value: string
+}
+
+interface GlobalStyleRegistry {
+  initialAttributePresent: boolean
+  initialVariables: Map<string, InitialVariable>
+  instances: Map<symbol, Record<string, string> | undefined>
+  root: HTMLElement
+}
+
+const registries = new WeakMap<Document, GlobalStyleRegistry>()
+const globalStyleVariableNames = Object.keys(
+  assignInlineVars({
+    [selectionBackgroundColor]: '',
+    [uiColorBg]: '',
+    [uiColorBorder]: '',
+    [uiColorMutedFg]: '',
+    [uiFontTextFamily]: '',
+    [uiFontTextWeightMedium]: '',
+    [webkitResizerBackgroundImage]: '',
+  }),
+)
 
 // Construct a resize handle icon as a data URI, to be displayed in browsers that support the `::-webkit-resizer` selector.
 function buildResizeHandleDataUri(hexColor: string) {
@@ -14,73 +46,126 @@ function buildResizeHandleDataUri(hexColor: string) {
   return `url("data:image/svg+xml,${encodedSvg}")`
 }
 
-export const GlobalStyle: ComponentType = () => {
-  const {
-    advancedVersionControl: {enabled: advancedVersionControlEnabled},
-  } = useWorkspace()
-
-  return <GlobalStyleSheet $documentEditorGutterEnabled={advancedVersionControlEnabled} />
+function applyVariables(root: HTMLElement, variables: Record<string, string>) {
+  for (const [name, value] of Object.entries(variables)) {
+    root.style.setProperty(name, value)
+  }
 }
 
-interface Props {
-  $documentEditorGutterEnabled: boolean
+function getLatestVariables(instances: Map<symbol, Record<string, string> | undefined>) {
+  let latest: Record<string, string> | undefined
+
+  for (const variables of instances.values()) {
+    if (variables) latest = variables
+  }
+
+  return latest
 }
 
-const GlobalStyleSheet = createGlobalStyle<Props>(({theme, $documentEditorGutterEnabled}) => {
-  const {color, font} = getTheme_v2(theme)
+function registerGlobalStyles(ownerDocument: Document, instanceId: symbol) {
+  const root = ownerDocument.documentElement
+  let registry = registries.get(ownerDocument)
 
-  return css`
-    ::-webkit-resizer {
-      background-image: ${buildResizeHandleDataUri(color.icon)};
-      background-repeat: no-repeat;
-      background-position: bottom right;
+  if (!registry) {
+    registry = {
+      initialAttributePresent: root.hasAttribute(GLOBAL_STYLES_ATTRIBUTE),
+      initialVariables: new Map(
+        globalStyleVariableNames.map((name) => [
+          name,
+          {
+            priority: root.style.getPropertyPriority(name),
+            value: root.style.getPropertyValue(name),
+          },
+        ]),
+      ),
+      instances: new Map(),
+      root,
+    }
+    registries.set(ownerDocument, registry)
+  }
+
+  registry.instances.set(instanceId, undefined)
+  registry.root.setAttribute(GLOBAL_STYLES_ATTRIBUTE, '')
+
+  return () => {
+    const currentRegistry = registries.get(ownerDocument)
+
+    if (!currentRegistry?.instances.delete(instanceId)) return
+
+    const latestVariables = getLatestVariables(currentRegistry.instances)
+    if (latestVariables) {
+      applyVariables(currentRegistry.root, latestVariables)
+      return
     }
 
-    ::-webkit-scrollbar {
-      width: ${SCROLLBAR_SIZE}px;
-      height: ${SCROLLBAR_SIZE}px;
+    for (const [name, initial] of currentRegistry.initialVariables) {
+      if (initial.value) {
+        currentRegistry.root.style.setProperty(name, initial.value, initial.priority)
+      } else {
+        currentRegistry.root.style.removeProperty(name)
+      }
     }
 
-    ::-webkit-scrollbar-corner {
-      background-color: transparent;
+    if (!currentRegistry.initialAttributePresent) {
+      currentRegistry.root.removeAttribute(GLOBAL_STYLES_ATTRIBUTE)
     }
 
-    ::-webkit-scrollbar-thumb {
-      background-clip: content-box;
-      background-color: var(--card-border-color, ${color.border});
-      border: ${SCROLLBAR_BORDER_SIZE}px solid transparent;
-    }
+    registries.delete(ownerDocument)
+  }
+}
 
-    ::-webkit-scrollbar-thumb:hover {
-      background-color: var(--card-muted-fg-color, ${color.muted.fg});
-    }
+function updateGlobalStyles(
+  ownerDocument: Document,
+  instanceId: symbol,
+  variables: Record<string, string>,
+) {
+  const registry = registries.get(ownerDocument)
+  if (!registry?.instances.has(instanceId)) return
 
-    ::-webkit-scrollbar-track {
-      background: transparent;
-    }
+  registry.instances.set(instanceId, variables)
 
-    *::selection {
-      background-color: ${rgba(color.focusRing, 0.3)};
-    }
+  let latestInstanceId: symbol | undefined
+  for (const id of registry.instances.keys()) {
+    latestInstanceId = id
+  }
 
-    html {
-      background-color: ${color.bg};
-    }
+  if (latestInstanceId === instanceId) {
+    applyVariables(registry.root, variables)
+  }
+}
 
-    body {
-      scrollbar-gutter: stable;
-    }
+export function GlobalStyle(): null {
+  const [instanceId] = useState(Symbol)
+  const {color, font} = useThemeV2()
+  const webkitResizerBackgroundImageValue = buildResizeHandleDataUri(color.icon)
+  const selectionBackgroundColorValue = rgba(color.focusRing, 0.3)
 
-    #sanity {
-      font-family: ${font.text.family};
-    }
+  useInsertionEffect(() => registerGlobalStyles(document, instanceId), [instanceId])
 
-    b {
-      font-weight: ${font.text.weights.medium};
-    }
+  useInsertionEffect(() => {
+    updateGlobalStyles(
+      document,
+      instanceId,
+      assignInlineVars({
+        [selectionBackgroundColor]: selectionBackgroundColorValue,
+        [uiColorBg]: color.bg,
+        [uiColorBorder]: color.border,
+        [uiColorMutedFg]: color.muted.fg,
+        [uiFontTextFamily]: font.text.family,
+        [uiFontTextWeightMedium]: font.text.weights.medium.toString(),
+        [webkitResizerBackgroundImage]: webkitResizerBackgroundImageValue,
+      }),
+    )
+  }, [
+    color.bg,
+    color.border,
+    color.muted.fg,
+    font.text.family,
+    font.text.weights.medium,
+    instanceId,
+    selectionBackgroundColorValue,
+    webkitResizerBackgroundImageValue,
+  ])
 
-    strong {
-      font-weight: ${font.text.weights.medium};
-    }
-  `
-})
+  return null
+}

--- a/packages/sanity/src/core/studio/globalStyleConstants.ts
+++ b/packages/sanity/src/core/studio/globalStyleConstants.ts
@@ -1,0 +1,1 @@
+export const GLOBAL_STYLES_ATTRIBUTE = 'data-sanity-global-styles'

--- a/packages/sanity/src/core/studio/styles.css.ts
+++ b/packages/sanity/src/core/studio/styles.css.ts
@@ -56,7 +56,7 @@ globalStyle(`${globalStylesRoot} *::selection`, {
   backgroundColor: selectionBackgroundColor,
 })
 
-globalStyle(globalStylesRoot, {
+globalStyle(`html:where([${GLOBAL_STYLES_ATTRIBUTE}])`, {
   backgroundColor: uiColorBg,
 })
 

--- a/packages/sanity/src/core/studio/styles.css.ts
+++ b/packages/sanity/src/core/studio/styles.css.ts
@@ -1,7 +1,83 @@
-import {globalStyle} from '@vanilla-extract/css'
+import {createGlobalVar, createVar, fallbackVar, globalStyle} from '@vanilla-extract/css'
+
+import {GLOBAL_STYLES_ATTRIBUTE} from './globalStyleConstants'
+
+const SCROLLBAR_SIZE = 12 // px
+const SCROLLBAR_BORDER_SIZE = 4 // px
+const globalStylesRoot = `:where(html[${GLOBAL_STYLES_ATTRIBUTE}])`
+
+export const selectionBackgroundColor = createVar()
+export const uiColorBg = createVar()
+export const uiColorBorder = createVar()
+export const uiColorMutedFg = createVar()
+export const uiFontTextFamily = createVar()
+export const uiFontTextWeightMedium = createVar()
+export const webkitResizerBackgroundImage = createVar()
+
+const uiCardBorderColor = createGlobalVar('card-border-color')
+const uiCardMutedFgColor = createGlobalVar('card-muted-fg-color')
+
+function globalElementStyle(selector: string, rule: Parameters<typeof globalStyle>[1]) {
+  globalStyle(`${globalStylesRoot}${selector}, ${globalStylesRoot} ${selector}`, rule)
+}
+
+globalElementStyle('::-webkit-resizer', {
+  backgroundImage: webkitResizerBackgroundImage,
+  backgroundRepeat: 'no-repeat',
+  backgroundPosition: 'bottom right',
+})
+
+globalElementStyle('::-webkit-scrollbar', {
+  width: SCROLLBAR_SIZE,
+  height: SCROLLBAR_SIZE,
+})
+
+globalElementStyle('::-webkit-scrollbar-corner', {
+  backgroundColor: 'transparent',
+})
+
+globalElementStyle('::-webkit-scrollbar-thumb', {
+  backgroundClip: 'content-box',
+  backgroundColor: fallbackVar(uiCardBorderColor, uiColorBorder),
+  borderWidth: SCROLLBAR_BORDER_SIZE,
+  borderStyle: 'solid',
+  borderColor: 'transparent',
+})
+
+globalElementStyle('::-webkit-scrollbar-thumb:hover', {
+  backgroundColor: fallbackVar(uiCardMutedFgColor, uiColorMutedFg),
+})
+
+globalElementStyle('::-webkit-scrollbar-track', {
+  background: 'transparent',
+})
+
+globalStyle(`${globalStylesRoot} *::selection`, {
+  backgroundColor: selectionBackgroundColor,
+})
+
+globalStyle(globalStylesRoot, {
+  backgroundColor: uiColorBg,
+})
+
+globalStyle(`${globalStylesRoot} body`, {
+  scrollbarGutter: 'stable',
+})
 
 globalStyle('#sanity', {
   vars: {
     '--static-css-file-loaded-studio': 'true',
   },
+})
+
+globalStyle(`${globalStylesRoot} #sanity`, {
+  fontFamily: uiFontTextFamily,
+})
+
+globalStyle(`${globalStylesRoot} b`, {
+  fontWeight: uiFontTextWeightMedium,
+})
+
+globalStyle(`${globalStylesRoot} strong`, {
+  fontWeight: uiFontTextWeightMedium,
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1922,6 +1922,9 @@ importers:
       '@tanstack/react-virtual':
         specifier: ^3.14.9
         version: 3.14.9(react-dom@19.2.8)(react@19.2.8)
+      '@vanilla-extract/dynamic':
+        specifier: 'catalog:'
+        version: 2.1.5
       '@xstate/react':
         specifier: ^6.1.0
         version: 6.1.0(@types/react@19.2.18)(react@19.2.8)(xstate@5.32.5)


### PR DESCRIPTION
### Description

- Migrates the Studio’s runtime `styled-components` global stylesheet to statically extracted vanilla-extract rules.
- Keeps theme-dependent scrollbar, selection, background, font, and resize-handle values dynamic through CSS custom properties.
- Updates the original work for current `main`; build wiring and the Vision migration that landed separately are no longer duplicated here.

### What to review

- Theme variable setup and cleanup in `packages/sanity/src/core/studio/GlobalStyle.tsx`.
- Style parity and extracted selectors in `packages/sanity/src/core/studio/styles.css.ts`.
- The generated `sanity/bundle.css` output and behavior when switching between light and dark themes.

### Testing

- `pnpm build`
- `pnpm check:format`
- `pnpm check:oxlint`
- `pnpm test:exports`
- `pnpm --filter @repo/package.bundle test`
- Verified the built CSS contains the global selectors.
- Manually verified light/dark theme switching and scrollbar styling.
- `pnpm test`: 609 test files passed; two unrelated request-error test files failed locally. Neither is touched by this PR.

### Notes for release

N/A – Internal styling implementation change with no intended user-facing behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches document-root CSS and multi-instance lifecycle for every Studio mount; regressions could show up in light/dark theming, scrollbars, or embedded/multi-studio pages, though new tests cover registry behavior.
> 
> **Overview**
> Replaces Studio **runtime `styled-components` global CSS** with **static vanilla-extract rules** in `styles.css.ts`, scoped under `html[data-sanity-global-styles]`. Theme-driven values (background, selection, scrollbars, resize handle, fonts) are still applied at runtime via **`@vanilla-extract/dynamic`** inline vars on `document.documentElement`.
> 
> `GlobalStyle` is now a null-render component that registers instances in a per-document registry: it snapshots pre-existing root styles, applies the latest mounted instance’s variables, and restores the DOM when the last instance unmounts. **`GlobalStyle.test.tsx`** covers multi-instance mount order and cleanup.
> 
> Adds **`@vanilla-extract/dynamic`** to `@sanity/sanity` and drops **`useWorkspace`** from global styling (workspace-specific gutter wiring is no longer part of this component).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cb3a77fc29e868d54ad84e77c83d614dfc815d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->