### PR TITLE
fix: resolve lint warnings (batch approach)

### DIFF
--- a/packages/sanity/src/_singletons/context/FullscreenPTEContext.ts
+++ b/packages/sanity/src/_singletons/context/FullscreenPTEContext.ts
@@ -9,7 +9,9 @@ export const FullscreenPTEContext = createContext<FullscreenPTEContextValue>(
   'sanity/_singletons/context/fullscreen-pte',
   {
     getFullscreenPath: () => undefined,
-    setFullscreenPath: () => { /* intentionally empty */ },
+    setFullscreenPath: () => {
+      /* intentionally empty */
+    },
     hasAnyFullscreen: () => false,
     allFullscreenPaths: [],
   },

--- a/packages/sanity/src/_singletons/context/FullscreenPTEContext.ts
+++ b/packages/sanity/src/_singletons/context/FullscreenPTEContext.ts
@@ -9,7 +9,7 @@ export const FullscreenPTEContext = createContext<FullscreenPTEContextValue>(
   'sanity/_singletons/context/fullscreen-pte',
   {
     getFullscreenPath: () => undefined,
-    setFullscreenPath: () => {},
+    setFullscreenPath: () => { /* intentionally empty */ },
     hasAnyFullscreen: () => false,
     allFullscreenPaths: [],
   },

--- a/packages/sanity/src/_singletons/context/FullscreenPTEContext.ts
+++ b/packages/sanity/src/_singletons/context/FullscreenPTEContext.ts
@@ -9,9 +9,8 @@ export const FullscreenPTEContext = createContext<FullscreenPTEContextValue>(
   'sanity/_singletons/context/fullscreen-pte',
   {
     getFullscreenPath: () => undefined,
-    setFullscreenPath: () => {
-      /* intentionally empty */
-    },
+    // eslint-disable-next-line no-empty-function
+    setFullscreenPath: () => {},
     hasAnyFullscreen: () => false,
     allFullscreenPaths: [],
   },

--- a/packages/sanity/src/_singletons/context/PackageVersionInfoContext.tsx
+++ b/packages/sanity/src/_singletons/context/PackageVersionInfoContext.tsx
@@ -51,7 +51,7 @@ export const PackageVersionInfoContext = createContext<PackageVersionInfoContext
   'sanity/_singletons/context/package-version-info',
   {
     isAutoUpdating: false,
-    checkForUpdates: () => {},
+    checkForUpdates: () => { /* intentionally empty */ },
     get currentVersion(): never {
       throw new Error('PackageVersionInfoContext not provided')
     },

--- a/packages/sanity/src/_singletons/context/PackageVersionInfoContext.tsx
+++ b/packages/sanity/src/_singletons/context/PackageVersionInfoContext.tsx
@@ -51,9 +51,8 @@ export const PackageVersionInfoContext = createContext<PackageVersionInfoContext
   'sanity/_singletons/context/package-version-info',
   {
     isAutoUpdating: false,
-    checkForUpdates: () => {
-      /* intentionally empty */
-    },
+    // eslint-disable-next-line no-empty-function
+    checkForUpdates: () => {},
     get currentVersion(): never {
       throw new Error('PackageVersionInfoContext not provided')
     },

--- a/packages/sanity/src/_singletons/context/PackageVersionInfoContext.tsx
+++ b/packages/sanity/src/_singletons/context/PackageVersionInfoContext.tsx
@@ -51,7 +51,9 @@ export const PackageVersionInfoContext = createContext<PackageVersionInfoContext
   'sanity/_singletons/context/package-version-info',
   {
     isAutoUpdating: false,
-    checkForUpdates: () => { /* intentionally empty */ },
+    checkForUpdates: () => {
+      /* intentionally empty */
+    },
     get currentVersion(): never {
       throw new Error('PackageVersionInfoContext not provided')
     },

--- a/packages/sanity/src/core/canvas/actions/LinkToCanvas/useLinkToCanvas.ts
+++ b/packages/sanity/src/core/canvas/actions/LinkToCanvas/useLinkToCanvas.ts
@@ -145,7 +145,7 @@ export function useLinkToCanvas({document}: {document: SanityDocument | undefine
         map((organizationId) => {
           if (!organizationId) {
             // Users should not land at this stage, it is caught first in the action by disabling it
-            return () => {}
+            return () => { /* intentionally empty */ }
           }
           const isStaging = client.config().apiHost === 'https://api.sanity.work'
 

--- a/packages/sanity/src/core/canvas/actions/LinkToCanvas/useLinkToCanvas.ts
+++ b/packages/sanity/src/core/canvas/actions/LinkToCanvas/useLinkToCanvas.ts
@@ -145,9 +145,8 @@ export function useLinkToCanvas({document}: {document: SanityDocument | undefine
         map((organizationId) => {
           if (!organizationId) {
             // Users should not land at this stage, it is caught first in the action by disabling it
-            return () => {
-              /* intentionally empty */
-            }
+            // eslint-disable-next-line no-empty-function
+            return () => {}
           }
           const isStaging = client.config().apiHost === 'https://api.sanity.work'
 

--- a/packages/sanity/src/core/canvas/actions/LinkToCanvas/useLinkToCanvas.ts
+++ b/packages/sanity/src/core/canvas/actions/LinkToCanvas/useLinkToCanvas.ts
@@ -145,7 +145,9 @@ export function useLinkToCanvas({document}: {document: SanityDocument | undefine
         map((organizationId) => {
           if (!organizationId) {
             // Users should not land at this stage, it is caught first in the action by disabling it
-            return () => { /* intentionally empty */ }
+            return () => {
+              /* intentionally empty */
+            }
           }
           const isStaging = client.config().apiHost === 'https://api.sanity.work'
 

--- a/packages/sanity/src/core/components/rovingFocus/__tests__/useRovingFocus.test.tsx
+++ b/packages/sanity/src/core/components/rovingFocus/__tests__/useRovingFocus.test.tsx
@@ -46,37 +46,37 @@ describe('base/useRovingFocus:', () => {
 
     // Focus button #0 on tab
     await userEvent.tab()
-    expect(buttons[0]).toBe(document.activeElement)
+    expect(buttons[0]).toHaveFocus()
 
     // Focus button #1 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
-    expect(buttons[1]).toBe(document.activeElement)
+    expect(buttons[1]).toHaveFocus()
 
     // Focus button #2 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
-    expect(buttons[2]).toBe(document.activeElement)
+    expect(buttons[2]).toHaveFocus()
 
     // Focus button #3 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
-    expect(buttons[3]).toBe(document.activeElement)
+    expect(buttons[3]).toHaveFocus()
 
     // Focus button #0 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
-    expect(buttons[0]).toBe(document.activeElement)
+    expect(buttons[0]).toHaveFocus()
 
     // Focus button #3 on arrow left
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowLeft'})
-    expect(buttons[3]).toBe(document.activeElement)
+    expect(buttons[3]).toHaveFocus()
 
     // Focus button #2 on arrow left
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowLeft'})
-    expect(buttons[2]).toBe(document.activeElement)
+    expect(buttons[2]).toHaveFocus()
   })
 
   /**
@@ -89,37 +89,37 @@ describe('base/useRovingFocus:', () => {
 
     // Focus button #0 on tab
     await userEvent.tab()
-    expect(buttons[0]).toBe(document.activeElement)
+    expect(buttons[0]).toHaveFocus()
 
     // Focus button #1 on arrow down
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowDown'})
-    expect(buttons[1]).toBe(document.activeElement)
+    expect(buttons[1]).toHaveFocus()
 
     // Focus button #2 on arrow down
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowDown'})
-    expect(buttons[2]).toBe(document.activeElement)
+    expect(buttons[2]).toHaveFocus()
 
     // Focus button #3 on arrow down
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowDown'})
-    expect(buttons[3]).toBe(document.activeElement)
+    expect(buttons[3]).toHaveFocus()
 
     // Focus button #0 on arrow down
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowDown'})
-    expect(buttons[0]).toBe(document.activeElement)
+    expect(buttons[0]).toHaveFocus()
 
     // Focus button #3 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowUp'})
-    expect(buttons[3]).toBe(document.activeElement)
+    expect(buttons[3]).toHaveFocus()
 
     // Focus button #2 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowUp'})
-    expect(buttons[2]).toBe(document.activeElement)
+    expect(buttons[2]).toHaveFocus()
   })
 
   /**
@@ -132,17 +132,17 @@ describe('base/useRovingFocus:', () => {
 
     // Focus button #1 on tab
     await userEvent.tab()
-    expect(buttons[1]).toBe(document.activeElement)
+    expect(buttons[1]).toHaveFocus()
 
     // Focus button #3 on arrow right (skips #2 because it is disabled)
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
-    expect(buttons[3]).toBe(document.activeElement)
+    expect(buttons[3]).toHaveFocus()
 
     // Focus button #1 on arrow right (skips #0 because it is disabled)
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
-    expect(buttons[1]).toBe(document.activeElement)
+    expect(buttons[1]).toHaveFocus()
   })
 
   /**
@@ -155,27 +155,27 @@ describe('base/useRovingFocus:', () => {
 
     // Focus button #0 on tab
     await userEvent.tab()
-    expect(buttons[0]).toBe(document.activeElement)
+    expect(buttons[0]).toHaveFocus()
 
     // Focus button #1 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
-    expect(buttons[1]).toBe(document.activeElement)
+    expect(buttons[1]).toHaveFocus()
 
     // Focus button #2 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
-    expect(buttons[2]).toBe(document.activeElement)
+    expect(buttons[2]).toHaveFocus()
 
     // Focus button #3 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
-    expect(buttons[3]).toBe(document.activeElement)
+    expect(buttons[3]).toHaveFocus()
 
     // Focus button #3 on arrow right (because loop is disabled, the focus stays on #3)
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
-    expect(buttons[3]).toBe(document.activeElement)
+    expect(buttons[3]).toHaveFocus()
   })
 
   /**
@@ -188,11 +188,11 @@ describe('base/useRovingFocus:', () => {
 
     // Focus button #3 on tab (the last button)
     await userEvent.tab()
-    expect(buttons[3]).toBe(document.activeElement)
+    expect(buttons[3]).toHaveFocus()
 
     // Focus button #0 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
-    expect(buttons[0]).toBe(document.activeElement)
+    expect(buttons[0]).toHaveFocus()
   })
 })

--- a/packages/sanity/src/core/components/rovingFocus/__tests__/useRovingFocus.test.tsx
+++ b/packages/sanity/src/core/components/rovingFocus/__tests__/useRovingFocus.test.tsx
@@ -1,5 +1,5 @@
 import {Card, studioTheme, ThemeProvider} from '@sanity/ui'
-import {fireEvent, render} from '@testing-library/react'
+import {fireEvent, render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {useState} from 'react'
 import {describe, expect, it} from 'vitest'
@@ -25,7 +25,7 @@ function RenderTestComponent(props: TestProps) {
 
   return (
     <ThemeProvider theme={studioTheme}>
-      <Card ref={setRootElement} id="rootElement">
+      <Card ref={setRootElement} id="rootElement" data-testid="rootElement">
         <Button text="Test" disabled={withDisabledButtons} />
         <Button text="Test" />
         <Button text="Test" disabled={withDisabledButtons} />
@@ -40,9 +40,9 @@ describe('base/useRovingFocus:', () => {
    * Horizontal direction
    */
   it('horizontal direction', async () => {
-    const {container} = render(<RenderTestComponent />)
-    const rootElement = container.querySelector('#rootElement')
-    const buttons = rootElement!.querySelectorAll('button')
+    render(<RenderTestComponent />)
+    const rootElement = screen.getByTestId('rootElement')
+    const buttons = screen.getAllByRole('button')
 
     // Focus button #0 on tab
     await userEvent.tab()
@@ -50,32 +50,32 @@ describe('base/useRovingFocus:', () => {
 
     // Focus button #1 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowRight'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
     expect(buttons[1]).toBe(document.activeElement)
 
     // Focus button #2 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowRight'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
     expect(buttons[2]).toBe(document.activeElement)
 
     // Focus button #3 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowRight'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
     expect(buttons[3]).toBe(document.activeElement)
 
     // Focus button #0 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowRight'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
     expect(buttons[0]).toBe(document.activeElement)
 
     // Focus button #3 on arrow left
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowLeft'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowLeft'})
     expect(buttons[3]).toBe(document.activeElement)
 
     // Focus button #2 on arrow left
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowLeft'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowLeft'})
     expect(buttons[2]).toBe(document.activeElement)
   })
 
@@ -83,9 +83,9 @@ describe('base/useRovingFocus:', () => {
    * Vertical direction
    */
   it('vertical direction', async () => {
-    const {container} = render(<RenderTestComponent direction="vertical" />)
-    const rootElement = container.querySelector('#rootElement')
-    const buttons = rootElement!.querySelectorAll('button')
+    render(<RenderTestComponent direction="vertical" />)
+    const rootElement = screen.getByTestId('rootElement')
+    const buttons = screen.getAllByRole('button')
 
     // Focus button #0 on tab
     await userEvent.tab()
@@ -93,32 +93,32 @@ describe('base/useRovingFocus:', () => {
 
     // Focus button #1 on arrow down
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowDown'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowDown'})
     expect(buttons[1]).toBe(document.activeElement)
 
     // Focus button #2 on arrow down
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowDown'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowDown'})
     expect(buttons[2]).toBe(document.activeElement)
 
     // Focus button #3 on arrow down
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowDown'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowDown'})
     expect(buttons[3]).toBe(document.activeElement)
 
     // Focus button #0 on arrow down
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowDown'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowDown'})
     expect(buttons[0]).toBe(document.activeElement)
 
     // Focus button #3 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowUp'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowUp'})
     expect(buttons[3]).toBe(document.activeElement)
 
     // Focus button #2 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowUp'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowUp'})
     expect(buttons[2]).toBe(document.activeElement)
   })
 
@@ -126,9 +126,9 @@ describe('base/useRovingFocus:', () => {
    * With disabled buttons
    */
   it('with disabled buttons', async () => {
-    const {container} = render(<RenderTestComponent withDisabledButtons />)
-    const rootElement = container.querySelector('#rootElement')
-    const buttons = rootElement!.querySelectorAll('button')
+    render(<RenderTestComponent withDisabledButtons />)
+    const rootElement = screen.getByTestId('rootElement')
+    const buttons = screen.getAllByRole('button')
 
     // Focus button #1 on tab
     await userEvent.tab()
@@ -136,12 +136,12 @@ describe('base/useRovingFocus:', () => {
 
     // Focus button #3 on arrow right (skips #2 because it is disabled)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowRight'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
     expect(buttons[3]).toBe(document.activeElement)
 
     // Focus button #1 on arrow right (skips #0 because it is disabled)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowRight'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
     expect(buttons[1]).toBe(document.activeElement)
   })
 
@@ -149,9 +149,9 @@ describe('base/useRovingFocus:', () => {
    * Without loop
    */
   it('without loop', async () => {
-    const {container} = render(<RenderTestComponent loop={false} />)
-    const rootElement = container.querySelector('#rootElement')
-    const buttons = rootElement!.querySelectorAll('button')
+    render(<RenderTestComponent loop={false} />)
+    const rootElement = screen.getByTestId('rootElement')
+    const buttons = screen.getAllByRole('button')
 
     // Focus button #0 on tab
     await userEvent.tab()
@@ -159,22 +159,22 @@ describe('base/useRovingFocus:', () => {
 
     // Focus button #1 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowRight'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
     expect(buttons[1]).toBe(document.activeElement)
 
     // Focus button #2 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowRight'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
     expect(buttons[2]).toBe(document.activeElement)
 
     // Focus button #3 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowRight'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
     expect(buttons[3]).toBe(document.activeElement)
 
     // Focus button #3 on arrow right (because loop is disabled, the focus stays on #3)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowRight'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
     expect(buttons[3]).toBe(document.activeElement)
   })
 
@@ -182,9 +182,9 @@ describe('base/useRovingFocus:', () => {
    * Initial focus last
    */
   it('initial focus last', async () => {
-    const {container} = render(<RenderTestComponent initialFocus="last" />)
-    const rootElement = container.querySelector('#rootElement')
-    const buttons = rootElement!.querySelectorAll('button')
+    render(<RenderTestComponent initialFocus="last" />)
+    const rootElement = screen.getByTestId('rootElement')
+    const buttons = screen.getAllByRole('button')
 
     // Focus button #3 on tab (the last button)
     await userEvent.tab()
@@ -192,7 +192,7 @@ describe('base/useRovingFocus:', () => {
 
     // Focus button #0 on arrow right
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.keyDown(rootElement!, {key: 'ArrowRight'})
+    fireEvent.keyDown(rootElement, {key: 'ArrowRight'})
     expect(buttons[0]).toBe(document.activeElement)
   })
 })

--- a/packages/sanity/src/core/components/timeZone/DialogTimeZone.test.tsx
+++ b/packages/sanity/src/core/components/timeZone/DialogTimeZone.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen, waitFor, within} from '@testing-library/react'
+import {render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
@@ -120,9 +120,8 @@ describe('DialogTimeZone', () => {
       wrapper,
     })
 
-    // Find the autocomplete input container
-    const autocomplete = screen.getByRole('combobox')
-    const clearButton = within(autocomplete.parentElement!).getByRole('button', {name: /clear/i})
+    // Find the clear button near the autocomplete input
+    const clearButton = screen.getByRole('button', {name: /clear/i})
 
     await user.click(clearButton)
 

--- a/packages/sanity/src/core/config/__tests__/createDefaultIcon.test.tsx
+++ b/packages/sanity/src/core/config/__tests__/createDefaultIcon.test.tsx
@@ -36,6 +36,7 @@ describe('createDefaultIcon', () => {
     const {container} = renderIcon('🟢')
     // When the title is only emojis, after filtering there should be no letters
     // The component should handle this gracefully (empty text)
+    // eslint-disable-next-line testing-library/no-node-access -- SVG has no accessible role to query by
     const svg = container.querySelector('svg')
     expect(svg).toBeInTheDocument()
   })

--- a/packages/sanity/src/core/config/__tests__/createDefaultIcon.test.tsx
+++ b/packages/sanity/src/core/config/__tests__/createDefaultIcon.test.tsx
@@ -36,7 +36,7 @@ describe('createDefaultIcon', () => {
     const {container} = renderIcon('🟢')
     // When the title is only emojis, after filtering there should be no letters
     // The component should handle this gracefully (empty text)
-    // eslint-disable-next-line testing-library/no-node-access -- SVG has no accessible role to query by
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- SVG has no accessible role to query by
     const svg = container.querySelector('svg')
     expect(svg).toBeInTheDocument()
   })

--- a/packages/sanity/src/core/config/__tests__/createDefaultIcon.test.tsx
+++ b/packages/sanity/src/core/config/__tests__/createDefaultIcon.test.tsx
@@ -33,10 +33,10 @@ describe('createDefaultIcon', () => {
   })
 
   it('should handle titles that are only emojis', () => {
-    renderIcon('🟢')
+    const {container} = renderIcon('🟢')
     // When the title is only emojis, after filtering there should be no letters
     // The component should handle this gracefully (empty text)
-    const svg = document.querySelector('svg')
+    const svg = container.querySelector('svg')
     expect(svg).toBeInTheDocument()
   })
 

--- a/packages/sanity/src/core/form/inputs/BooleanInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/BooleanInput.test.tsx
@@ -57,12 +57,12 @@ const defs = {
 }
 
 it('renders the boolean input field', async () => {
-  const {result} = await renderBooleanInput({
+  await renderBooleanInput({
     fieldDefinition: defs.booleanTest,
     render: (inputProps) => <BooleanInput {...inputProps} />,
   })
 
-  const input = result.container.querySelector('input[id="booleanTest"]')
+  const input = screen.getByRole('checkbox')
   expect(input).toBeDefined()
   expect(input).toHaveAttribute('type', 'checkbox')
   expect(input).toBePartiallyChecked()
@@ -70,60 +70,60 @@ it('renders the boolean input field', async () => {
 
 describe('Mouse accessibility', () => {
   it('emits onFocus when clicked', async () => {
-    const {onFocus, result} = await renderBooleanInput({
+    const {onFocus} = await renderBooleanInput({
       fieldDefinition: defs.booleanTest,
       render: (inputProps) => <BooleanInput {...inputProps} />,
     })
-    const input = result.container.querySelector('input[id="booleanTest"]')
-    await userEvent.click(input!)
+    const input = screen.getByRole('checkbox')
+    await userEvent.click(input)
     expect(onFocus).toBeCalled()
   })
 
   it('emits onChange when clicked', async () => {
-    const {onChange, result} = await renderBooleanInput({
+    const {onChange} = await renderBooleanInput({
       fieldDefinition: defs.booleanTest,
       render: (inputProps) => <BooleanInput {...inputProps} />,
     })
 
-    const input = result.container.querySelector('input[id="booleanTest"]')
-    await userEvent.click(input!)
+    const input = screen.getByRole('checkbox')
+    await userEvent.click(input)
     expect(onChange).toBeCalled()
   })
 })
 
 describe('Keyboard accessibility', () => {
   it('emits onFocus when tabbing to input', async () => {
-    const {onFocus, result} = await renderBooleanInput({
+    const {onFocus} = await renderBooleanInput({
       fieldDefinition: defs.booleanTest,
       render: (inputProps) => <BooleanInput {...inputProps} />,
     })
 
-    const input = result.container.querySelector('input[id="booleanTest"]')
+    const input = screen.getByRole('checkbox')
     await userEvent.tab()
     expect(input).toHaveFocus()
     expect(onFocus).toBeCalled()
   })
 
   it('emits onChange when pressing enter', async () => {
-    const {onChange, result} = await renderBooleanInput({
+    const {onChange} = await renderBooleanInput({
       fieldDefinition: defs.booleanTest,
       render: (inputProps) => <BooleanInput {...inputProps} />,
     })
 
-    const input = result.container.querySelector('input[id="booleanTest"]')
-    await userEvent.click(input!)
+    const input = screen.getByRole('checkbox')
+    await userEvent.click(input)
     await waitFor(() => {
       expect(onChange).toBeCalled()
     })
   })
 
   it('emits onBlur when navigating away from field', async () => {
-    const {onBlur, result} = await renderBooleanInput({
+    const {onBlur} = await renderBooleanInput({
       fieldDefinition: defs.booleanTest,
       render: (inputProps) => <BooleanInput {...inputProps} />,
     })
 
-    const input = result.container.querySelector('input[id="booleanTest"]')
+    const input = screen.getByRole('checkbox')
     await userEvent.tab()
     await userEvent.tab()
     expect(input).not.toHaveFocus()
@@ -134,38 +134,38 @@ describe('Keyboard accessibility', () => {
 
 describe('Layout options', () => {
   it('renders a switch (default)', async () => {
-    const {result} = await renderBooleanInput({
+    await renderBooleanInput({
       fieldDefinition: defs.booleanTest,
       render: (inputProps) => <BooleanInput {...inputProps} />,
     })
 
-    const input = result.container.querySelector('input[id="booleanTest"][data-ui="Switch"]')
-    expect(input).toBeDefined()
+    const input = screen.getByRole('checkbox')
+    expect(input).toHaveAttribute('data-ui', 'Switch')
   })
 
   it('renders a checkbox', async () => {
-    const {result} = await renderBooleanInput({
+    await renderBooleanInput({
       fieldDefinition: defs.booleanTest,
       render: (inputProps) => <BooleanInput {...inputProps} />,
     })
 
-    const input = result.container.querySelector('input[id="booleanTest"][data-ui="Checkbox"]')
-    expect(input).toBeDefined()
+    const input = screen.getByRole('checkbox')
+    expect(input).toHaveAttribute('data-ui', 'Checkbox')
   })
 })
 
 describe('readOnly property', () => {
   it('makes field read-only', async () => {
-    const {onChange, result} = await renderBooleanInput({
+    const {onChange} = await renderBooleanInput({
       fieldDefinition: defs.booleanReadOnly,
       render: (inputProps) => <BooleanInput {...inputProps} readOnly />,
     })
 
-    const input = result.container.querySelector('input[id="booleanReadOnly"]')
+    const input = screen.getByRole('checkbox')
     expect(input).toBeDisabled()
 
     // Mouse event
-    await userEvent.click(input!)
+    await userEvent.click(input)
     // expect(input).toHaveFocus()
     expect(onChange).not.toBeCalled()
 
@@ -175,28 +175,28 @@ describe('readOnly property', () => {
   })
 
   it('renders a tooltip on the switch', async () => {
-    const {container} = await renderBooleanInput({
+    await renderBooleanInput({
       fieldDefinition: defs.booleanReadOnly,
       render: (inputProps) => <BooleanInput {...inputProps} readOnly />,
     })
 
-    const input = container.querySelector('input[id="booleanReadOnly"]')
-    await userEvent.hover(input!)
+    const input = screen.getByRole('checkbox')
+    await userEvent.hover(input)
 
     await screen.findByText('Disabled')
   })
 
   it('does not make field read-only with callback', async () => {
-    const {onChange, result} = await renderBooleanInput({
+    const {onChange} = await renderBooleanInput({
       fieldDefinition: defs.readOnlyCallback,
       render: (inputProps) => <BooleanInput {...inputProps} />,
     })
 
-    const input = result.container.querySelector('input[id="readOnlyCallback"]')
+    const input = screen.getByRole('checkbox')
     expect(input).not.toBeDisabled()
 
     // Mouse event
-    await userEvent.click(input!)
+    await userEvent.click(input)
     expect(onChange).toBeCalled()
 
     // Keyboard event
@@ -207,17 +207,17 @@ describe('readOnly property', () => {
   })
 
   it.skip('makes field read-only based on value in document', async () => {
-    const {onChange, result} = await renderBooleanInput({
+    const {onChange} = await renderBooleanInput({
       fieldDefinition: defs.readOnlyWithDocument,
       props: {documentValue: {title: 'Hello, world'}},
       render: (inputProps) => <BooleanInput {...inputProps} />,
     })
 
-    const input = result.container.querySelector('input[id="readOnlyWithDocument"]')
+    const input = screen.getByRole('checkbox')
     expect(input).toBeDisabled()
 
     // Mouse event
-    await userEvent.click(input!)
+    await userEvent.click(input)
     expect(onChange).not.toBeCalled()
 
     // Keyboard event

--- a/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/__tests__/CrossDatasetReferenceInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/__tests__/CrossDatasetReferenceInput.test.tsx
@@ -296,7 +296,7 @@ describe('user interaction happy paths', () => {
     // (https://github.com/sanity-io/design/blob/b956686c2c663c4f21910f7d3d0be0a27663f5f4/packages/%40sanity/ui/src/components/autocomplete/autocompleteOption.tsx#L16-L20)
     // if this tests suddenly fails this expectation, it can be removed along with the waiting
     expect(onChange).toHaveBeenCalledTimes(0)
-    await waitForElementToBeRemoved(() => screen.getByTestId('autocomplete-popover'))
+    await waitForElementToBeRemoved(() => screen.queryByTestId('autocomplete-popover'))
     //----
 
     expect(onChange).toHaveBeenCalledTimes(1)
@@ -409,7 +409,7 @@ describe('user interaction happy paths', () => {
     // if this tests suddenly fails this expectation, it can be removed along with the waiting
     expect(onChange).toHaveBeenCalledTimes(0)
     // await wait(1)
-    await waitForElementToBeRemoved(() => screen.getByTestId('autocomplete-popover'))
+    await waitForElementToBeRemoved(() => screen.queryByTestId('autocomplete-popover'))
     //----
 
     expect(onChange).toHaveBeenCalledTimes(1)

--- a/packages/sanity/src/core/form/inputs/DateInputs/__tests__/CommonDateTimeInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/__tests__/CommonDateTimeInput.test.tsx
@@ -5,7 +5,7 @@ import {
   format,
   parse,
 } from '@sanity/util/legacyDateFormat'
-import {fireEvent} from '@testing-library/react'
+import {fireEvent, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {expect, test, vi} from 'vitest'
 
@@ -103,8 +103,8 @@ test('time zone for the test environment should be set to America/Los_Angeles', 
 })
 
 test('does not emit onChange after invalid value has been typed', async () => {
-  const {result, onChange} = await renderInput()
-  const input = result.container.querySelector('input')!
+  const {onChange} = await renderInput()
+  const input = screen.getByRole('textbox') as HTMLInputElement
 
   await userEvent.type(input, 'this is invalid')
   expect(input.value).toBe('this is invalid')
@@ -116,8 +116,8 @@ test('does not emit onChange after invalid value has been typed', async () => {
 })
 
 test('emits onChange on correct format if a valid value has been typed', async () => {
-  const {result, onChange} = await renderInput()
-  const input = result.container.querySelector('input')!
+  const {onChange} = await renderInput()
+  const input = screen.getByRole('textbox') as HTMLInputElement
 
   // NOTE: the date is entered and displayed in local time zone (which is hardcoded to America/Los_Angeles)
   await userEvent.type(input, '2021-03-28 10:23')

--- a/packages/sanity/src/core/form/inputs/DateInputs/__tests__/CommonDateTimeInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/__tests__/CommonDateTimeInput.test.tsx
@@ -68,7 +68,7 @@ const CALENDAR_LABELS: CalendarLabels = {
 async function renderInput() {
   const onChange = vi.fn()
 
-  const ret = await renderStringInput({
+  const view = await renderStringInput({
     fieldDefinition: defineField({
       type: 'datetime',
       name: 'test',
@@ -93,7 +93,7 @@ async function renderInput() {
     },
   })
 
-  return {...ret, onChange}
+  return {...view, onChange}
 }
 
 // NOTE: for the tests to be deterministic we need this to ensure tests are run in a predefined time zone

--- a/packages/sanity/src/core/form/inputs/DateInputs/__tests__/DateInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/__tests__/DateInput.test.tsx
@@ -1,5 +1,5 @@
 import {defineField} from '@sanity/types'
-import {fireEvent} from '@testing-library/react'
+import {fireEvent, screen} from '@testing-library/react'
 import {expect, test} from 'vitest'
 
 import {renderStringInput} from '../../../../../../test/form'
@@ -12,7 +12,7 @@ test('time zone for the test environment should be set to America/Los_Angeles', 
 })
 
 test('does not emit onChange after invalid value has been typed', async () => {
-  const {onChange, result} = await renderStringInput({
+  const {onChange} = await renderStringInput({
     fieldDefinition: defineField({
       type: 'date',
       name: 'test',
@@ -20,7 +20,7 @@ test('does not emit onChange after invalid value has been typed', async () => {
     render: (inputProps) => <DateInput {...inputProps} />,
   })
 
-  const input = result.container.querySelector('input')!
+  const input = screen.getByRole('textbox') as HTMLInputElement
 
   // eslint-disable-next-line testing-library/prefer-user-event
   fireEvent.change(input, {target: {value: 'this is invalid'}})
@@ -33,7 +33,7 @@ test('does not emit onChange after invalid value has been typed', async () => {
 })
 
 test('emits onChange on correct format if a valid value has been typed', async () => {
-  const {onChange, result} = await renderStringInput({
+  const {onChange} = await renderStringInput({
     fieldDefinition: defineField({
       type: 'date',
       name: 'test',
@@ -41,7 +41,7 @@ test('emits onChange on correct format if a valid value has been typed', async (
     render: (inputProps) => <DateInput {...inputProps} />,
   })
 
-  const input = result.container.querySelector('input')!
+  const input = screen.getByRole('textbox') as HTMLInputElement
 
   // NOTE: the date is entered and displayed in local time zone
   // eslint-disable-next-line testing-library/prefer-user-event
@@ -55,7 +55,7 @@ test('emits onChange on correct format if a valid value has been typed', async (
 })
 
 test('formatting of deserialized value', async () => {
-  const {result} = await renderStringInput({
+  await renderStringInput({
     fieldDefinition: defineField({
       type: 'date',
       name: 'test',
@@ -64,14 +64,14 @@ test('formatting of deserialized value', async () => {
     render: (inputProps) => <DateInput {...inputProps} />,
   })
 
-  const input = result.container.querySelector('input')!
+  const input = screen.getByRole('textbox') as HTMLInputElement
 
   // const {textInput} = renderInput({value: '2021-03-28'} as any)
   expect(input.value).toBe('2021-03-28')
 })
 
 test('change the date should show the correct date in the input (save on enter)', async () => {
-  const {onChange, result} = await renderStringInput({
+  const {onChange} = await renderStringInput({
     fieldDefinition: defineField({
       type: 'date',
       name: 'test',
@@ -80,7 +80,7 @@ test('change the date should show the correct date in the input (save on enter)'
     render: (inputProps) => <DateInput {...inputProps} />,
   })
 
-  const input = result.container.querySelector('input')!
+  const input = screen.getByRole('textbox') as HTMLInputElement
   // eslint-disable-next-line testing-library/prefer-user-event
   fireEvent.change(input, {target: {value: '2021-03-30'}})
   fireEvent.blur(input)

--- a/packages/sanity/src/core/form/inputs/DateInputs/__tests__/DateTimeInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/__tests__/DateTimeInput.test.tsx
@@ -35,7 +35,7 @@ test('time zone for the test environment should be set to America/Los_Angeles', 
 })
 
 test('does not emit onChange after invalid value has been typed', async () => {
-  const {onChange, result} = await renderStringInput({
+  const {onChange} = await renderStringInput({
     fieldDefinition: defineField({
       type: 'datetime',
       name: 'test',
@@ -43,7 +43,7 @@ test('does not emit onChange after invalid value has been typed', async () => {
     render: (inputProps) => <DateTimeInputWithFormValue {...inputProps} />,
   })
 
-  const input = result.container.querySelector('input')!
+  const input = screen.getByRole('textbox') as HTMLInputElement
 
   await userEvent.type(input, 'this is invalid')
   expect(input.value).toBe('this is invalid')
@@ -55,7 +55,7 @@ test('does not emit onChange after invalid value has been typed', async () => {
 })
 
 test('emits onChange on correct format if a valid value has been typed', async () => {
-  const {onChange, result} = await renderStringInput({
+  const {onChange} = await renderStringInput({
     fieldDefinition: defineField({
       type: 'datetime',
       name: 'test',
@@ -63,7 +63,7 @@ test('emits onChange on correct format if a valid value has been typed', async (
     render: (inputProps) => <DateTimeInputWithFormValue {...inputProps} />,
   })
 
-  const input = result.container.querySelector('input')!
+  const input = screen.getByRole('textbox') as HTMLInputElement
 
   // NOTE: the date is entered and displayed in local time zone
   // (which is hardcoded to America/Los_Angeles)
@@ -77,7 +77,7 @@ test('emits onChange on correct format if a valid value has been typed', async (
 })
 
 test('formatting of deserialized value', async () => {
-  const {result} = await renderStringInput({
+  await renderStringInput({
     fieldDefinition: defineField({
       type: 'datetime',
       name: 'test',
@@ -86,7 +86,7 @@ test('formatting of deserialized value', async () => {
     render: (inputProps) => <DateTimeInputWithFormValue {...inputProps} />,
   })
 
-  const input = result.container.querySelector('input')!
+  const input = screen.getByRole('textbox') as HTMLInputElement
 
   // const {textInput} = renderInput({value: '2021-03-28T17:23:00.000Z'} as any)
   expect(input.value).toBe('2021-03-28 10:23')
@@ -95,7 +95,7 @@ test('formatting of deserialized value', async () => {
 test('time is shown in the display time zone if specified (utc+1 winter)', async () => {
   const spy = vi.spyOn(useTimeZoneModule, 'useTimeZone').mockReturnValue(mockUseTimeZoneWithOslo)
 
-  const {result} = await renderStringInput({
+  await renderStringInput({
     fieldDefinition: defineField({
       type: 'datetime',
       name: 'test',
@@ -105,7 +105,7 @@ test('time is shown in the display time zone if specified (utc+1 winter)', async
     render: (inputProps) => <DateTimeInputWithFormValue {...inputProps} />,
   })
 
-  const input = result.container.querySelector('input')!
+  const input = screen.getByRole('textbox') as HTMLInputElement
 
   expect(input.value).toBe('2021-01-15 13:00')
 
@@ -115,7 +115,7 @@ test('time is shown in the display time zone if specified (utc+1 winter)', async
 test('time is shown in the display time zone if specified (utc+2 summer)', async () => {
   const spy = vi.spyOn(useTimeZoneModule, 'useTimeZone').mockReturnValue(mockUseTimeZoneWithOslo)
 
-  const {result} = await renderStringInput({
+  await renderStringInput({
     fieldDefinition: defineField({
       type: 'datetime',
       name: 'test',
@@ -125,7 +125,7 @@ test('time is shown in the display time zone if specified (utc+2 summer)', async
     render: (inputProps) => <DateTimeInputWithFormValue {...inputProps} />,
   })
 
-  const input = result.container.querySelector('input')!
+  const input = screen.getByRole('textbox') as HTMLInputElement
 
   expect(input.value).toBe('2021-06-15 14:00')
 
@@ -133,7 +133,7 @@ test('time is shown in the display time zone if specified (utc+2 summer)', async
 })
 
 test('Make sure time is displaying in wall time when displayTimeZone is not set', async () => {
-  const {result} = await renderStringInput({
+  await renderStringInput({
     fieldDefinition: defineField({
       type: 'datetime',
       name: 'test',
@@ -142,7 +142,7 @@ test('Make sure time is displaying in wall time when displayTimeZone is not set'
     render: (inputProps) => <DateTimeInputWithFormValue {...inputProps} />,
   })
 
-  const input = result.container.querySelector('input')!
+  const input = screen.getByRole('textbox') as HTMLInputElement
 
   expect(input.value).toBe('2021-06-15 05:00')
 })
@@ -155,7 +155,7 @@ test('Make sure we are respecting the saved timezone in hook when displayTimeZon
     const fieldName = 'test'
     const initialUtcValue = '2021-06-15T12:00:00.000Z'
 
-    const {result} = await renderStringInput({
+    await renderStringInput({
       fieldDefinition: defineField({
         type: 'datetime',
         name: fieldName,
@@ -174,7 +174,7 @@ test('Make sure we are respecting the saved timezone in hook when displayTimeZon
       ),
     })
 
-    const input = result.container.querySelector('input')!
+    const input = screen.getByRole('textbox') as HTMLInputElement
 
     expect(input.value).toBe('2021-06-15 21:00')
 
@@ -188,7 +188,7 @@ test('Make sure we are respecting the saved timezone in hook when displayTimeZon
 test('Make sure that if the hook timezone is set but the allowTimeZoneSwitch is false, that we respect the displayTimeZone', async () => {
   const spy = vi.spyOn(useTimeZoneModule, 'useTimeZone').mockReturnValue(mockUseTimeZoneWithOslo)
 
-  const {result} = await renderStringInput({
+  await renderStringInput({
     fieldDefinition: defineField({
       type: 'datetime',
       name: 'test',
@@ -198,7 +198,7 @@ test('Make sure that if the hook timezone is set but the allowTimeZoneSwitch is 
     render: (inputProps) => <DateTimeInputWithFormValue {...inputProps} />,
   })
 
-  const input = result.container.querySelector('input')!
+  const input = screen.getByRole('textbox') as HTMLInputElement
   // should be 2 hours ahead for Oslo in Summer
   expect(input.value).toBe('2021-06-15 14:00')
 
@@ -208,7 +208,7 @@ test('Make sure that if the hook timezone is set but the allowTimeZoneSwitch is 
 test('the time zone can not be changed by the user if not allowed', async () => {
   const spy = vi.spyOn(useTimeZoneModule, 'useTimeZone').mockReturnValue(mockUseTimeZoneWithOslo)
 
-  const {result} = await renderStringInput({
+  await renderStringInput({
     fieldDefinition: defineField({
       type: 'datetime',
       name: 'test',
@@ -304,7 +304,7 @@ const expected = {
 
 Object.entries(expected).forEach(([format, expectedValue]) => {
   test(`renders date in format token "${format}"`, async () => {
-    const {result} = await renderStringInput({
+    await renderStringInput({
       fieldDefinition: defineField({
         type: 'datetime',
         name: 'test',
@@ -313,7 +313,7 @@ Object.entries(expected).forEach(([format, expectedValue]) => {
       props: {documentValue: {test: TEST_DATE_ISO}},
       render: (inputProps) => <DateTimeInputWithFormValue {...inputProps} />,
     })
-    const input = result.container.querySelector('input')!
+    const input = screen.getByRole('textbox') as HTMLInputElement
     // added to enforce type safety and linting from screaming
     const isRegExp = (value: unknown): value is RegExp => value instanceof RegExp
     if (isRegExp(expectedValue)) {

--- a/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/__tests__/GlobalDocumentReferenceInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/__tests__/GlobalDocumentReferenceInput.test.tsx
@@ -230,7 +230,7 @@ describe('user interaction happy paths', () => {
     // (https://github.com/sanity-io/design/blob/b956686c2c663c4f21910f7d3d0be0a27663f5f4/packages/%40sanity/ui/src/components/autocomplete/autocompleteOption.tsx#L16-L20)
     // if this tests suddenly fails this expectation, it can be removed along with the waiting
     expect(onChange).toHaveBeenCalledTimes(0)
-    await waitForElementToBeRemoved(() => screen.getByTestId('autocomplete-popover'), {
+    await waitForElementToBeRemoved(() => screen.queryByTestId('autocomplete-popover'), {
       timeout: 1000,
     })
 
@@ -333,7 +333,7 @@ describe('user interaction happy paths', () => {
     // if this tests suddenly fails this expectation, it can be removed along with the waiting
     expect(onChange).toHaveBeenCalledTimes(0)
     // await wait(1)
-    await waitForElementToBeRemoved(() => screen.getByTestId('autocomplete-popover'))
+    await waitForElementToBeRemoved(() => screen.queryByTestId('autocomplete-popover'))
     //----
 
     expect(onChange).toHaveBeenCalledTimes(1)

--- a/packages/sanity/src/core/form/inputs/ObjectInput/__tests__/ObjectFieldset.test.tsx
+++ b/packages/sanity/src/core/form/inputs/ObjectInput/__tests__/ObjectFieldset.test.tsx
@@ -1,5 +1,5 @@
 import {defineField} from '@sanity/types'
-import {screen} from '@testing-library/react'
+import {screen, within} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {describe, expect, it} from 'vitest'
 
@@ -49,12 +49,11 @@ describe('fieldset with default options', () => {
         )
       },
     })
-    const fieldset = screen.queryByTestId('fieldset-withDefaults')
+    const fieldset = screen.getByRole('group', {name: 'Fieldset with defaults'})
     expect(fieldset).toBeVisible()
-    expect(fieldset!.tagName).toBe('FIELDSET')
-    const legend = fieldset!.querySelector('legend')
+    expect(fieldset.tagName).toBe('FIELDSET')
+    const legend = within(fieldset).getByText('Fieldset with defaults')
     expect(legend).toBeVisible()
-    expect(legend).toContainHTML('Fieldset with defaults')
     const field1 = screen.queryByTestId('input-withDefaults1')
     expect(field1).toBeVisible()
     expect(fieldset).toContainElement(field1)
@@ -66,11 +65,9 @@ describe('fieldset with default options', () => {
       render: (inputProps) => <ObjectInput {...inputProps} />,
     })
 
-    const fieldset = result.container.querySelector('fieldset')
+    const fieldset = screen.getByRole('group', {name: 'Fieldset with defaults'})
     expect(fieldset).toBeVisible()
-    const legend = fieldset!.querySelector('legend')
-    expect(legend).toBeVisible()
-    expect(legend!.querySelector('button')).toBeNull()
+    expect(within(fieldset).queryByRole('button')).toBeNull()
   })
 })
 
@@ -81,12 +78,11 @@ describe('collapsible fieldset with default options', () => {
       render: (inputProps) => <ObjectInput {...inputProps} />,
     })
 
-    const fieldset = screen.queryByTestId('fieldset-collapsibleWithDefaults')
+    const fieldset = screen.getByRole('group', {name: 'Collapsible fieldset with defaults'})
     expect(fieldset).toBeVisible()
-    expect(fieldset!.tagName).toBe('FIELDSET')
-    const legend = fieldset!.querySelector('legend')
+    expect(fieldset.tagName).toBe('FIELDSET')
+    const legend = within(fieldset).getByText('Collapsible fieldset with defaults')
     expect(legend).toBeVisible()
-    expect(legend).toContainHTML('Collapsible fieldset with defaults')
   })
 
   it('renders a button for the fieldset legend ', async () => {
@@ -95,9 +91,9 @@ describe('collapsible fieldset with default options', () => {
       render: (inputProps) => <ObjectInput {...inputProps} />,
     })
 
-    const fieldset = screen.queryByTestId('fieldset-collapsibleWithDefaults')
+    const fieldset = screen.getByRole('group', {name: 'Collapsible fieldset with defaults'})
     expect(fieldset).toBeVisible()
-    const toggleButton = fieldset!.querySelector('legend button')
+    const toggleButton = within(fieldset).getByRole('button')
     expect(toggleButton).toBeVisible()
   })
 
@@ -119,14 +115,13 @@ describe('collapsible fieldset with default options', () => {
       render: (inputProps) => <ObjectInput {...inputProps} />,
     })
 
-    const fieldset = screen.queryByTestId('fieldset-collapsibleWithDefaults')
+    const fieldset = screen.getByRole('group', {name: 'Collapsible fieldset with defaults'})
     expect(fieldset).toBeVisible()
-    const toggleButton = fieldset!.querySelector('legend button')
+    const toggleButton = within(fieldset).getByRole('button')
 
     expect(screen.queryByTestId('input-collapsibleWithDefaults1')).toBeNull()
 
-    expect(toggleButton).toBeDefined()
-    await userEvent.click(toggleButton!)
+    await userEvent.click(toggleButton)
     expect(onSetFieldSetCollapsed).toHaveBeenCalledTimes(1)
   })
 
@@ -142,11 +137,10 @@ describe('collapsible fieldset with default options', () => {
       ),
     })
 
-    const fieldset = screen.queryByTestId('fieldset-collapsibleWithDefaults')
+    const fieldset = screen.getByRole('group', {name: 'Collapsible fieldset with defaults'})
 
-    const toggleButton = fieldset!.querySelector('legend button')
-    expect(toggleButton).toBeDefined()
-    await userEvent.click(toggleButton!)
+    const toggleButton = within(fieldset).getByRole('button')
+    await userEvent.click(toggleButton)
     expect(onFocus).not.toHaveBeenCalled()
   })
 })

--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputBasic/StringInputBasic.test.tsx
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputBasic/StringInputBasic.test.tsx
@@ -1,3 +1,4 @@
+import {screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {describe, expect, it} from 'vitest'
 
@@ -21,9 +22,9 @@ describe('StringInputBasic', () => {
       },
     })
 
-    const input = result.container.querySelector('input')
+    const input = screen.getByRole('textbox')
 
-    expect(input?.value).toBe('test')
+    expect(input).toHaveValue('test')
   })
 
   it('emits onFocus', async () => {
@@ -42,9 +43,9 @@ describe('StringInputBasic', () => {
       },
     })
 
-    const input = result.container.querySelector('input')
+    const input = screen.getByRole('textbox')
 
-    input?.focus()
+    input.focus()
 
     expect(onFocus.mock.calls).toHaveLength(1)
   })
@@ -65,9 +66,9 @@ describe('StringInputBasic', () => {
       },
     })
 
-    const input = result.container.querySelector('input')
+    const input = screen.getByRole('textbox')
 
-    await userEvent.type(input!, 't')
+    await userEvent.type(input, 't')
 
     expect(onNativeChange).toHaveBeenCalledTimes(1)
   })
@@ -88,10 +89,10 @@ describe('StringInputBasic', () => {
       },
     })
 
-    const input = result.container.querySelector('input')
-    expect(input!.value).toBe('t')
+    const input = screen.getByRole('textbox')
+    expect(input).toHaveValue('t')
 
-    await userEvent.click(input!)
+    await userEvent.click(input)
     await userEvent.keyboard('[Backspace]')
 
     expect(onNativeChange).toHaveBeenCalledTimes(1)

--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/StringInputPortableText.test.tsx
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/StringInputPortableText.test.tsx
@@ -1,17 +1,15 @@
-import {waitFor} from '@testing-library/react'
+import {screen, waitFor} from '@testing-library/react'
 import {describe, expect, it} from 'vitest'
 
 import {renderStringInput} from '../../../../../../test/form/renderStringInput'
 import {StringInputPortableText} from './StringInputPortableText'
-
-const INPUT_SELECTOR = '[data-testid="string-input-portable-text"]'
 
 // This is only partially tested at the moment, because jsdom does not support contenteditable. This
 // is a good candidate to adopt Vitest Browser Mode, which would allow the test suite to reach
 // parity with `StringInputBasic.test.tsx`.
 describe('StringInputPortableText', () => {
   it('renders input value', async () => {
-    const {result} = await renderStringInput({
+    await renderStringInput({
       render: (inputProps) => <StringInputPortableText {...inputProps} value="test" />,
       fieldDefinition: {
         type: 'string',
@@ -20,7 +18,7 @@ describe('StringInputPortableText', () => {
       },
     })
 
-    const input = result.container.querySelector(INPUT_SELECTOR)
+    const input = screen.getByTestId('string-input-portable-text')
 
     await waitFor(() => {
       expect(input).toHaveTextContent('test')

--- a/packages/sanity/src/core/form/inputs/files/__tests__/assetSourceIntegration.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/__tests__/assetSourceIntegration.test.tsx
@@ -50,7 +50,9 @@ vi.mock('../../../../../media-library/plugin/VideoInput/useVideoPlaybackInfo', (
       aspectRatio: 16 / 9,
     },
     error: undefined,
-    retry: () => { /* intentionally empty */ },
+    retry: () => {
+      /* intentionally empty */
+    },
   }),
 }))
 

--- a/packages/sanity/src/core/form/inputs/files/__tests__/assetSourceIntegration.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/__tests__/assetSourceIntegration.test.tsx
@@ -50,7 +50,7 @@ vi.mock('../../../../../media-library/plugin/VideoInput/useVideoPlaybackInfo', (
       aspectRatio: 16 / 9,
     },
     error: undefined,
-    retry: () => {},
+    retry: () => { /* intentionally empty */ },
   }),
 }))
 

--- a/packages/sanity/src/core/form/inputs/files/__tests__/assetSourceIntegration.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/__tests__/assetSourceIntegration.test.tsx
@@ -144,6 +144,7 @@ describe.each(INPUT_CONFIGS)(
           ? new File(['content'], 'test.mp4', {type: 'video/mp4'})
           : new File(['content'], 'test.pdf', {type: 'application/pdf'})
       const uploadButton = screen.getByTestId(uploadTestId)
+      // eslint-disable-next-line testing-library/no-node-access -- hidden file input has no accessible role
       let fileInput = uploadButton.querySelector('input[type="file"]') as HTMLInputElement | null
       // Single source: FileInputButton has embedded input. Multiple sources: UploadDropDownMenu uses
       // imperative openFilePicker - click button to open menu, then click menu item to create input.
@@ -187,6 +188,7 @@ describe.each(INPUT_CONFIGS)(
           ? new File(['more content'], 'test2.mp4', {type: 'video/mp4'})
           : new File(['more content'], 'test2.pdf', {type: 'application/pdf'})
       // Input may have been removed after first upload (imperative flow); click again to create new one
+      // eslint-disable-next-line testing-library/no-node-access -- hidden file input has no accessible role
       let fileInput2 = uploadButton.querySelector('input[type="file"]') as HTMLInputElement | null
       if (!fileInput2) {
         await userEvent.click(uploadButton)
@@ -304,6 +306,7 @@ describe.each(INPUT_CONFIGS)(
 
       const uploadButton = screen.getByTestId('file-input-upload-button-component-source')
       expect(uploadButton).toBeInTheDocument()
+      // eslint-disable-next-line testing-library/no-node-access -- hidden file input has no accessible role
       expect(uploadButton.querySelector('input[type="file"]')).not.toBeInTheDocument()
       await userEvent.click(uploadButton)
 

--- a/packages/sanity/src/core/form/inputs/files/__tests__/assetSourceIntegration.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/__tests__/assetSourceIntegration.test.tsx
@@ -50,9 +50,8 @@ vi.mock('../../../../../media-library/plugin/VideoInput/useVideoPlaybackInfo', (
       aspectRatio: 16 / 9,
     },
     error: undefined,
-    retry: () => {
-      /* intentionally empty */
-    },
+    // eslint-disable-next-line no-empty-function
+    retry: () => {},
   }),
 }))
 

--- a/packages/sanity/src/core/form/inputs/files/common/__tests__/uploadTarget.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/__tests__/uploadTarget.test.tsx
@@ -99,13 +99,13 @@ describe('uploadTarget - drag and drop', () => {
       render: (inputProps) => <BaseFileInput {...inputProps} />,
     })
 
-    const fileTarget = document.querySelector('[data-test-id="file-target"]')
+    const fileTarget = screen.getByTestId('file-target')
     expect(fileTarget).toBeInTheDocument()
 
     const file = new File(['content'], 'test.pdf', {type: 'application/pdf'})
     const dataTransfer = createMockDataTransfer([file])
 
-    fireEvent.drop(fileTarget!, {dataTransfer})
+    fireEvent.drop(fileTarget, {dataTransfer})
 
     await waitFor(
       () => {
@@ -137,7 +137,7 @@ describe('uploadTarget - drag and drop', () => {
       render: (inputProps) => <BaseFileInput {...inputProps} />,
     })
 
-    const fileTarget = document.querySelector('[data-test-id="file-target"]')
+    const fileTarget = screen.getByTestId('file-target')
     expect(fileTarget).toBeInTheDocument()
 
     const fileTypes = [{kind: 'file' as const, type: 'application/pdf'}]
@@ -146,7 +146,7 @@ describe('uploadTarget - drag and drop', () => {
       files: [] as File[],
     }
 
-    fireEvent.dragEnter(fileTarget!, {dataTransfer})
+    fireEvent.dragEnter(fileTarget, {dataTransfer})
 
     await waitFor(() => {
       expect(screen.getByTestId('upload-target-drop-message')).toBeInTheDocument()
@@ -165,13 +165,13 @@ describe('uploadTarget - drag and drop', () => {
       render: (inputProps) => <BaseFileInput {...inputProps} />,
     })
 
-    const fileTarget = document.querySelector('[data-test-id="file-target"]')
+    const fileTarget = screen.getByTestId('file-target')
     expect(fileTarget).toBeInTheDocument()
 
     const file = new File(['content'], 'test.pdf', {type: 'application/pdf'})
     const dataTransfer = createMockDataTransfer([file])
 
-    fireEvent.drop(fileTarget!, {dataTransfer})
+    fireEvent.drop(fileTarget, {dataTransfer})
 
     await waitFor(() => {
       expect(screen.getByTestId('upload-destination-source-a')).toBeInTheDocument()
@@ -215,7 +215,7 @@ describe('uploadTarget - drag and drop', () => {
       render: (inputProps) => <BaseFileInput {...inputProps} />,
     })
 
-    const fileTarget = document.querySelector('[data-test-id="file-target"]')
+    const fileTarget = screen.getByTestId('file-target')
     expect(fileTarget).toBeInTheDocument()
 
     const rejectedFile = new File(['content'], 'rejected.txt', {type: 'text/plain'})
@@ -225,7 +225,7 @@ describe('uploadTarget - drag and drop', () => {
       items: [{kind: 'file' as const, type: 'text/plain'}],
       files: [] as File[],
     }
-    fireEvent.dragEnter(fileTarget!, {dataTransfer: dragDataTransfer})
+    fireEvent.dragEnter(fileTarget, {dataTransfer: dragDataTransfer})
 
     await waitFor(() => {
       expect(screen.getByTestId('upload-target-drop-message-not-allowed')).toBeInTheDocument()
@@ -233,7 +233,7 @@ describe('uploadTarget - drag and drop', () => {
 
     // Dropping does not trigger upload
     const dropDataTransfer = createMockDataTransfer([rejectedFile])
-    fireEvent.drop(fileTarget!, {dataTransfer: dropDataTransfer})
+    fireEvent.drop(fileTarget, {dataTransfer: dropDataTransfer})
 
     await waitFor(() => {
       expect(onChange).not.toHaveBeenCalled()
@@ -255,7 +255,7 @@ describe('uploadTarget - drag and drop', () => {
       render: (inputProps) => <BaseVideoInput {...inputProps} />,
     })
 
-    const fileTarget = document.querySelector('[data-test-id="file-target"]')
+    const fileTarget = screen.getByTestId('file-target')
     expect(fileTarget).toBeInTheDocument()
 
     const rejectedFile = new File(['content'], 'rejected.webm', {type: 'video/webm'})
@@ -265,7 +265,7 @@ describe('uploadTarget - drag and drop', () => {
       items: [{kind: 'file' as const, type: 'video/webm'}],
       files: [] as File[],
     }
-    fireEvent.dragEnter(fileTarget!, {dataTransfer: dragDataTransfer})
+    fireEvent.dragEnter(fileTarget, {dataTransfer: dragDataTransfer})
 
     await waitFor(() => {
       expect(screen.getByTestId('upload-target-drop-message-not-allowed')).toBeInTheDocument()
@@ -273,7 +273,7 @@ describe('uploadTarget - drag and drop', () => {
 
     // Dropping does not trigger upload
     const dropDataTransfer = createMockDataTransfer([rejectedFile])
-    fireEvent.drop(fileTarget!, {dataTransfer: dropDataTransfer})
+    fireEvent.drop(fileTarget, {dataTransfer: dropDataTransfer})
 
     await waitFor(() => {
       expect(onChange).not.toHaveBeenCalled()
@@ -298,13 +298,13 @@ describe('uploadTarget - drag and drop', () => {
       render: (inputProps) => <BaseFileInput {...inputProps} />,
     })
 
-    const fileTarget = document.querySelector('[data-test-id="file-target"]')
+    const fileTarget = screen.getByTestId('file-target')
     expect(fileTarget).toBeInTheDocument()
 
     const file = new File(['content'], 'test.pdf', {type: 'application/pdf'})
     const dataTransfer = createMockDataTransfer([file])
 
-    fireEvent.drop(fileTarget!, {dataTransfer})
+    fireEvent.drop(fileTarget, {dataTransfer})
 
     // Picker should show only upload-capable sources, not browse-only
     await waitFor(() => {
@@ -331,13 +331,13 @@ describe('uploadTarget - drag and drop', () => {
       render: (inputProps) => <BaseImageInput {...inputProps} />,
     })
 
-    const fileTarget = document.querySelector('[data-test-id="file-target"]')
+    const fileTarget = screen.getByTestId('file-target')
     expect(fileTarget).toBeInTheDocument()
 
     const file = new File(['content'], 'test.jpg', {type: 'image/jpeg'})
     const dataTransfer = createMockDataTransfer([file])
 
-    fireEvent.drop(fileTarget!, {dataTransfer})
+    fireEvent.drop(fileTarget, {dataTransfer})
 
     await waitFor(() => {
       expect(screen.getByTestId('upload-destination-source-a')).toBeInTheDocument()
@@ -357,7 +357,7 @@ describe('uploadTarget - drag and drop', () => {
       render: (inputProps) => <BaseFileInput {...inputProps} readOnly />,
     })
 
-    const fileTarget = document.querySelector('[data-test-id="file-target"]')
+    const fileTarget = screen.getByTestId('file-target')
     expect(fileTarget).toBeInTheDocument()
 
     const fileTypes = [{kind: 'file' as const, type: 'application/pdf'}]
@@ -366,7 +366,7 @@ describe('uploadTarget - drag and drop', () => {
       files: [] as File[],
     }
 
-    fireEvent.dragEnter(fileTarget!, {dataTransfer})
+    fireEvent.dragEnter(fileTarget, {dataTransfer})
 
     await waitFor(() => {
       expect(screen.queryByTestId('upload-target-drop-message')).not.toBeInTheDocument()

--- a/packages/sanity/src/core/form/inputs/files/common/__tests__/uploadTarget.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/__tests__/uploadTarget.test.tsx
@@ -32,7 +32,7 @@ vi.mock('../../../../../../media-library/plugin/VideoInput/useVideoPlaybackInfo'
       aspectRatio: 16 / 9,
     },
     error: undefined,
-    retry: () => {},
+    retry: () => { /* intentionally empty */ },
   }),
 }))
 vi.mock('../../../../../../media-library/plugin/VideoInput/VideoPlayer', () => ({
@@ -58,17 +58,17 @@ function createMockDataTransfer(files: File[]): DataTransfer {
     files: fileList,
     items: {
       length: files.length,
-      add: () => {},
-      clear: () => {},
+      add: () => { /* intentionally empty */ },
+      clear: () => { /* intentionally empty */ },
       get: () => null,
-      remove: () => {},
+      remove: () => { /* intentionally empty */ },
       *[Symbol.iterator]() {
         for (const f of files) {
           yield {
             kind: 'file' as const,
             type: f.type,
             getAsFile: () => f,
-            getAsString: () => {},
+            getAsString: () => { /* intentionally empty */ },
             webkitGetAsEntry: () => null,
           } as DataTransferItem
         }

--- a/packages/sanity/src/core/form/inputs/files/common/__tests__/uploadTarget.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/__tests__/uploadTarget.test.tsx
@@ -32,7 +32,9 @@ vi.mock('../../../../../../media-library/plugin/VideoInput/useVideoPlaybackInfo'
       aspectRatio: 16 / 9,
     },
     error: undefined,
-    retry: () => { /* intentionally empty */ },
+    retry: () => {
+      /* intentionally empty */
+    },
   }),
 }))
 vi.mock('../../../../../../media-library/plugin/VideoInput/VideoPlayer', () => ({
@@ -58,17 +60,25 @@ function createMockDataTransfer(files: File[]): DataTransfer {
     files: fileList,
     items: {
       length: files.length,
-      add: () => { /* intentionally empty */ },
-      clear: () => { /* intentionally empty */ },
+      add: () => {
+        /* intentionally empty */
+      },
+      clear: () => {
+        /* intentionally empty */
+      },
       get: () => null,
-      remove: () => { /* intentionally empty */ },
+      remove: () => {
+        /* intentionally empty */
+      },
       *[Symbol.iterator]() {
         for (const f of files) {
           yield {
             kind: 'file' as const,
             type: f.type,
             getAsFile: () => f,
-            getAsString: () => { /* intentionally empty */ },
+            getAsString: () => {
+              /* intentionally empty */
+            },
             webkitGetAsEntry: () => null,
           } as DataTransferItem
         }

--- a/packages/sanity/src/core/form/inputs/files/common/__tests__/uploadTarget.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/__tests__/uploadTarget.test.tsx
@@ -32,9 +32,8 @@ vi.mock('../../../../../../media-library/plugin/VideoInput/useVideoPlaybackInfo'
       aspectRatio: 16 / 9,
     },
     error: undefined,
-    retry: () => {
-      /* intentionally empty */
-    },
+    // eslint-disable-next-line no-empty-function
+    retry: () => {},
   }),
 }))
 vi.mock('../../../../../../media-library/plugin/VideoInput/VideoPlayer', () => ({
@@ -60,25 +59,21 @@ function createMockDataTransfer(files: File[]): DataTransfer {
     files: fileList,
     items: {
       length: files.length,
-      add: () => {
-        /* intentionally empty */
-      },
-      clear: () => {
-        /* intentionally empty */
-      },
+      // eslint-disable-next-line no-empty-function
+      add: () => {},
+      // eslint-disable-next-line no-empty-function
+      clear: () => {},
       get: () => null,
-      remove: () => {
-        /* intentionally empty */
-      },
+      // eslint-disable-next-line no-empty-function
+      remove: () => {},
       *[Symbol.iterator]() {
         for (const f of files) {
           yield {
             kind: 'file' as const,
             type: f.type,
             getAsFile: () => f,
-            getAsString: () => {
-              /* intentionally empty */
-            },
+            // eslint-disable-next-line no-empty-function
+            getAsString: () => {},
             webkitGetAsEntry: () => null,
           } as DataTransferItem
         }

--- a/packages/sanity/src/core/form/inputs/files/common/fileTarget/fileTarget.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/fileTarget/fileTarget.tsx
@@ -305,7 +305,7 @@ export function fileTarget<ComponentProps>(
           onDragEnter={disabled ? undefined : handleDragEnter}
           onDragLeave={disabled ? undefined : handleDragLeave}
           onDrop={disabled ? undefined : handleDrop}
-          data-test-id="file-target"
+          data-testid="file-target"
           {...fileTargetDataAttribute}
         />
         {!disabled && showPasteInput && (

--- a/packages/sanity/src/core/form/studio/FormBuilder.test.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilder.test.tsx
@@ -125,7 +125,7 @@ describe('FormBuilder', () => {
       return <FormBuilder {...formBuilderProps} />
     }
 
-    const result = render(
+    const view = render(
       <TestProvider>
         <TestForm />
       </TestProvider>,
@@ -222,7 +222,7 @@ describe('FormBuilder', () => {
       return <FormBuilder {...formBuilderProps} />
     }
 
-    const result = render(
+    const view = render(
       <TestProvider>
         <TestForm />
       </TestProvider>,

--- a/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.test.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.test.tsx
@@ -27,7 +27,9 @@ describe('FormBuilderInputErrorBoundary', () => {
 
   it('calls onUncaughtError when an error is caught', async () => {
     // React logs caught errors from error boundaries to console.error
-    vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
+    vi.spyOn(console, 'error').mockImplementation(() => {
+      /* intentionally empty */
+    })
     const onUncaughtError = vi.fn()
 
     const ThrowErrorComponent = () => {

--- a/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.test.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.test.tsx
@@ -27,7 +27,7 @@ describe('FormBuilderInputErrorBoundary', () => {
 
   it('calls onUncaughtError when an error is caught', async () => {
     // React logs caught errors from error boundaries to console.error
-    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
     const onUncaughtError = vi.fn()
 
     const ThrowErrorComponent = () => {

--- a/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.test.tsx
+++ b/packages/sanity/src/core/form/studio/FormBuilderInputErrorBoundary.test.tsx
@@ -27,9 +27,8 @@ describe('FormBuilderInputErrorBoundary', () => {
 
   it('calls onUncaughtError when an error is caught', async () => {
     // React logs caught errors from error boundaries to console.error
-    vi.spyOn(console, 'error').mockImplementation(() => {
-      /* intentionally empty */
-    })
+    // eslint-disable-next-line no-empty-function
+    vi.spyOn(console, 'error').mockImplementation(() => {})
     const onUncaughtError = vi.fn()
 
     const ThrowErrorComponent = () => {

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/__tests__/MediaLibrary.test.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/__tests__/MediaLibrary.test.tsx
@@ -82,7 +82,7 @@ describe('provisioning', () => {
 
   test('renders error catch by the ErrorBoundary if something unexpected happens', async () => {
     // React logs caught errors from error boundaries to console.error
-    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
     const client = createMockSanityClient({
       requestCallback: (request) => {
         switch (request.uri) {

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/__tests__/MediaLibrary.test.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/__tests__/MediaLibrary.test.tsx
@@ -82,7 +82,9 @@ describe('provisioning', () => {
 
   test('renders error catch by the ErrorBoundary if something unexpected happens', async () => {
     // React logs caught errors from error boundaries to console.error
-    vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
+    vi.spyOn(console, 'error').mockImplementation(() => {
+      /* intentionally empty */
+    })
     const client = createMockSanityClient({
       requestCallback: (request) => {
         switch (request.uri) {

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/__tests__/MediaLibrary.test.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/__tests__/MediaLibrary.test.tsx
@@ -82,9 +82,8 @@ describe('provisioning', () => {
 
   test('renders error catch by the ErrorBoundary if something unexpected happens', async () => {
     // React logs caught errors from error boundaries to console.error
-    vi.spyOn(console, 'error').mockImplementation(() => {
-      /* intentionally empty */
-    })
+    // eslint-disable-next-line no-empty-function
+    vi.spyOn(console, 'error').mockImplementation(() => {})
     const client = createMockSanityClient({
       requestCallback: (request) => {
         switch (request.uri) {

--- a/packages/sanity/src/core/form/studio/inputs/reference/__tests__/resolveCreateTypeFilter.test.ts
+++ b/packages/sanity/src/core/form/studio/inputs/reference/__tests__/resolveCreateTypeFilter.test.ts
@@ -168,9 +168,8 @@ describe('resolveCreateTypeFilter', () => {
 
   describe('error handling and fallbacks', () => {
     test('returns all types when filter throws error', () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {
-        /* intentionally empty */
-      })
+      // eslint-disable-next-line no-empty-function
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       const result = resolveCreateTypeFilter({
         schemaType: createSchemaType(['book', 'author'], () => {
@@ -200,9 +199,8 @@ describe('resolveCreateTypeFilter', () => {
     })
 
     test('returns all types when filter returns non-array', () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {
-        /* intentionally empty */
-      })
+      // eslint-disable-next-line no-empty-function
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       const result = resolveCreateTypeFilter({
         schemaType: createSchemaType(['book', 'author'], () => 'book' as any),
@@ -246,9 +244,8 @@ describe('resolveCreateTypeFilter', () => {
     })
 
     test('returns all types when filter returns objects without type property', () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {
-        /* intentionally empty */
-      })
+      // eslint-disable-next-line no-empty-function
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       const result = resolveCreateTypeFilter({
         schemaType: createSchemaType(

--- a/packages/sanity/src/core/form/studio/inputs/reference/__tests__/resolveCreateTypeFilter.test.ts
+++ b/packages/sanity/src/core/form/studio/inputs/reference/__tests__/resolveCreateTypeFilter.test.ts
@@ -168,7 +168,9 @@ describe('resolveCreateTypeFilter', () => {
 
   describe('error handling and fallbacks', () => {
     test('returns all types when filter throws error', () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+        /* intentionally empty */
+      })
 
       const result = resolveCreateTypeFilter({
         schemaType: createSchemaType(['book', 'author'], () => {
@@ -198,7 +200,9 @@ describe('resolveCreateTypeFilter', () => {
     })
 
     test('returns all types when filter returns non-array', () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+        /* intentionally empty */
+      })
 
       const result = resolveCreateTypeFilter({
         schemaType: createSchemaType(['book', 'author'], () => 'book' as any),
@@ -242,7 +246,9 @@ describe('resolveCreateTypeFilter', () => {
     })
 
     test('returns all types when filter returns objects without type property', () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+        /* intentionally empty */
+      })
 
       const result = resolveCreateTypeFilter({
         schemaType: createSchemaType(

--- a/packages/sanity/src/core/form/studio/inputs/reference/__tests__/resolveCreateTypeFilter.test.ts
+++ b/packages/sanity/src/core/form/studio/inputs/reference/__tests__/resolveCreateTypeFilter.test.ts
@@ -168,7 +168,7 @@ describe('resolveCreateTypeFilter', () => {
 
   describe('error handling and fallbacks', () => {
     test('returns all types when filter throws error', () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
 
       const result = resolveCreateTypeFilter({
         schemaType: createSchemaType(['book', 'author'], () => {
@@ -198,7 +198,7 @@ describe('resolveCreateTypeFilter', () => {
     })
 
     test('returns all types when filter returns non-array', () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
 
       const result = resolveCreateTypeFilter({
         schemaType: createSchemaType(['book', 'author'], () => 'book' as any),
@@ -242,7 +242,7 @@ describe('resolveCreateTypeFilter', () => {
     })
 
     test('returns all types when filter returns objects without type property', () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
 
       const result = resolveCreateTypeFilter({
         schemaType: createSchemaType(

--- a/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesNav.test.tsx
+++ b/packages/sanity/src/core/perspective/navbar/__tests__/ReleasesNav.test.tsx
@@ -169,18 +169,19 @@ describe('ReleasesNav', () => {
       })
 
       it('should show the intended release date for intended schedule releases', async () => {
-        const scheduledMenuItem = within(screen.getByTestId('release-menu'))
-          .getByText('active Scheduled 2')
-          .closest('button')!
+        const scheduledMenuItem = within(screen.getByTestId('release-menu')).getByRole('button', {
+          name: /active Scheduled 2/,
+        })
 
         within(scheduledMenuItem).getByText(/\b\d{1,2}\/\d{1,2}\/\d{4}\b/)
         within(scheduledMenuItem).getByTestId('release-avatar-suggest')
       })
 
       it('should show the actual release date for a scheduled release', async () => {
-        const scheduledMenuItem = within(screen.getByTestId('release-menu'))
-          .getByText('scheduled Release')
-          .closest('button')!
+        const releaseMenu = screen.getByTestId('release-menu')
+        const scheduledMenuItem = within(releaseMenu).getByRole('button', {
+          name: /scheduled Release/,
+        })
 
         within(scheduledMenuItem).getByText(/\b\d{1,2}\/\d{1,2}\/\d{4}\b/)
         within(scheduledMenuItem).getByTestId('release-lock-icon')
@@ -189,11 +190,12 @@ describe('ReleasesNav', () => {
 
       it('should show the error icon if the release is active and has an error', () => {
         const releaseMenu = screen.getByTestId('release-menu')
-        const releaseTitle = within(releaseMenu).getByText('active asap Error Release')
-        const releaseButton = releaseTitle?.closest('button')
+        const releaseButton = within(releaseMenu).getByRole('button', {
+          name: /active asap Error Release/,
+        })
 
         expect(releaseButton).toBeTruthy()
-        within(releaseButton!).getByTestId('release-error-icon')
+        within(releaseButton).getByTestId('release-error-icon')
       })
 
       it('allows for new release to be created', async () => {
@@ -245,9 +247,9 @@ describe('ReleasesNav', () => {
         it('should allow for hiding of any deeper layered releases', async () => {
           await prerenderTest()
 
-          const deepLayerRelease = within(screen.getByTestId('release-menu'))
-            .getByText('active Release')
-            .closest('button')!
+          const deepLayerRelease = within(screen.getByTestId('release-menu')).getByRole('button', {
+            name: /^active Release/,
+          })
 
           // toggle to hide
           await userEvent.click(within(deepLayerRelease).getByTestId('release-toggle-visibility'))
@@ -265,9 +267,9 @@ describe('ReleasesNav', () => {
         it('should not allow for hiding of published perspective', async () => {
           await prerenderTest()
 
-          const publishedRelease = within(screen.getByTestId('release-menu'))
-            .getByText('Published')
-            .closest('button')!
+          const publishedRelease = within(screen.getByTestId('release-menu')).getByRole('button', {
+            name: /Published/,
+          })
 
           expect(
             within(publishedRelease).queryByTestId('release-toggle-visibility'),
@@ -277,9 +279,9 @@ describe('ReleasesNav', () => {
         it('should allow for hiding of draft perspective', async () => {
           await prerenderTest()
 
-          const drafts = within(screen.getByTestId('release-menu'))
-            .getByText('Drafts')
-            .closest('button')!
+          const drafts = within(screen.getByTestId('release-menu')).getByRole('button', {
+            name: /Drafts/,
+          })
 
           expect(within(drafts).getByTestId('release-toggle-visibility')).toBeInTheDocument()
           // toggle to hide
@@ -297,9 +299,9 @@ describe('ReleasesNav', () => {
         it('should not allow hiding of the current perspective', async () => {
           await prerenderTest()
 
-          const currentRelease = within(screen.getByTestId('release-menu'))
-            .getByText('active Scheduled 2')
-            .closest('button')!
+          const currentRelease = within(screen.getByTestId('release-menu')).getByRole('button', {
+            name: /active Scheduled 2/,
+          })
 
           expect(
             within(currentRelease).queryByTestId('release-toggle-visibility'),
@@ -309,9 +311,9 @@ describe('ReleasesNav', () => {
         it('should not allow hiding of un-nested releases', async () => {
           await prerenderTest()
 
-          const unNestedRelease = within(screen.getByTestId('release-menu'))
-            .getByText('undecided Release')
-            .closest('button')!
+          const unNestedRelease = within(screen.getByTestId('release-menu')).getByRole('button', {
+            name: /undecided Release/,
+          })
 
           expect(
             within(unNestedRelease).queryByTestId('release-toggle-visibility'),
@@ -321,9 +323,10 @@ describe('ReleasesNav', () => {
         it('should not allow hiding of locked in scheduled releases', async () => {
           await prerenderTest()
 
-          const scheduledReleaseMenuItem = within(screen.getByTestId('release-menu'))
-            .getByText('scheduled Release')
-            .closest('button')!
+          const scheduledReleaseMenuItem = within(screen.getByTestId('release-menu')).getByRole(
+            'button',
+            {name: /scheduled Release/},
+          )
 
           expect(
             within(scheduledReleaseMenuItem).queryByTestId('release-toggle-visibility'),
@@ -338,9 +341,10 @@ describe('ReleasesNav', () => {
 
         await renderAndWaitForStableMenu()
 
-        const activeReleaseMenuItem = within(screen.getByTestId('release-menu'))
-          .getByText('active Release')
-          .closest('button')!
+        const activeReleaseMenuItem = within(screen.getByTestId('release-menu')).getByRole(
+          'button',
+          {name: /^active Release/},
+        )
 
         const indicatorIcon = within(activeReleaseMenuItem).getByTestId('release-indicator-icon')
         expect(indicatorIcon).toHaveStyle({opacity: 0})

--- a/packages/sanity/src/core/preview/utils/getPreviewStateObservable.test.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewStateObservable.test.ts
@@ -29,7 +29,7 @@ function createMockDocumentPreviewStore() {
         // Return a minimal observable that emits once
         return {
           pipe: () => ({
-            subscribe: () => ({unsubscribe: () => {}}),
+            subscribe: () => ({unsubscribe: () => { /* intentionally empty */ }}),
           }),
         }
       },

--- a/packages/sanity/src/core/preview/utils/getPreviewStateObservable.test.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewStateObservable.test.ts
@@ -30,9 +30,8 @@ function createMockDocumentPreviewStore() {
         return {
           pipe: () => ({
             subscribe: () => ({
-              unsubscribe: () => {
-                /* intentionally empty */
-              },
+              // eslint-disable-next-line no-empty-function
+              unsubscribe: () => {},
             }),
           }),
         }

--- a/packages/sanity/src/core/preview/utils/getPreviewStateObservable.test.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewStateObservable.test.ts
@@ -29,7 +29,11 @@ function createMockDocumentPreviewStore() {
         // Return a minimal observable that emits once
         return {
           pipe: () => ({
-            subscribe: () => ({unsubscribe: () => { /* intentionally empty */ }}),
+            subscribe: () => ({
+              unsubscribe: () => {
+                /* intentionally empty */
+              },
+            }),
           }),
         }
       },

--- a/packages/sanity/src/core/releases/components/dialog/__tests__/CreateReleaseDialog.test.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/__tests__/CreateReleaseDialog.test.tsx
@@ -66,7 +66,7 @@ describe('CreateReleaseDialog', () => {
 
       // Wait for the button to be enabled after typing
       await waitFor(() => {
-        expect(submitButton.closest('button')).not.toBeDisabled()
+        expect(submitButton).not.toBeDisabled()
       })
 
       await userEvent.click(submitButton)

--- a/packages/sanity/src/core/releases/store/__tests__/createReleaseMetadataAggregator.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/createReleaseMetadataAggregator.test.ts
@@ -64,9 +64,8 @@ describe('createReleaseMetadataAggregator', () => {
   })
 
   it('should handle fetch errors with loading states', async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => {
-      /* intentionally empty */
-    })
+    // eslint-disable-next-line no-empty-function
+    vi.spyOn(console, 'error').mockImplementation(() => {})
     const error = new Error('Fetch failed')
     mockClient.observable.fetch.mockReturnValue(
       new Observable((subscriber) => subscriber.error(error)),

--- a/packages/sanity/src/core/releases/store/__tests__/createReleaseMetadataAggregator.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/createReleaseMetadataAggregator.test.ts
@@ -64,7 +64,9 @@ describe('createReleaseMetadataAggregator', () => {
   })
 
   it('should handle fetch errors with loading states', async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
+    vi.spyOn(console, 'error').mockImplementation(() => {
+      /* intentionally empty */
+    })
     const error = new Error('Fetch failed')
     mockClient.observable.fetch.mockReturnValue(
       new Observable((subscriber) => subscriber.error(error)),

--- a/packages/sanity/src/core/releases/store/__tests__/createReleaseMetadataAggregator.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/createReleaseMetadataAggregator.test.ts
@@ -64,7 +64,7 @@ describe('createReleaseMetadataAggregator', () => {
   })
 
   it('should handle fetch errors with loading states', async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
     const error = new Error('Fetch failed')
     mockClient.observable.fetch.mockReturnValue(
       new Observable((subscriber) => subscriber.error(error)),

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/__tests__/ReleaseMenuButton.test.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/__tests__/ReleaseMenuButton.test.tsx
@@ -180,9 +180,8 @@ describe('ReleaseMenuButton', () => {
 
       describe('when archiving fails', () => {
         beforeEach(async () => {
-          vi.spyOn(console, 'error').mockImplementation(() => {
-            /* intentionally empty */
-          })
+          // eslint-disable-next-line no-empty-function
+          vi.spyOn(console, 'error').mockImplementation(() => {})
           mockUseReleaseOperations.mockReturnValue({
             ...useReleaseOperationsMockReturn,
             archive: vi.fn().mockRejectedValue(new Error('some rejection reason')),
@@ -284,9 +283,8 @@ describe('ReleaseMenuButton', () => {
 
       describe('when deleting fails', () => {
         beforeEach(async () => {
-          vi.spyOn(console, 'error').mockImplementation(() => {
-            /* intentionally empty */
-          })
+          // eslint-disable-next-line no-empty-function
+          vi.spyOn(console, 'error').mockImplementation(() => {})
           mockUseReleaseOperations.mockReturnValue({
             ...useReleaseOperationsMockReturn,
             deleteRelease: vi.fn().mockRejectedValue(new Error('some rejection reason')),
@@ -554,9 +552,8 @@ describe('ReleaseMenuButton', () => {
 
       describe('when duplication fails', () => {
         beforeEach(() => {
-          vi.spyOn(console, 'error').mockImplementation(() => {
-            /* intentionally empty */
-          })
+          // eslint-disable-next-line no-empty-function
+          vi.spyOn(console, 'error').mockImplementation(() => {})
           duplicateReleaseMock.mockRejectedValue(new Error('some duplication error'))
         })
 

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/__tests__/ReleaseMenuButton.test.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/__tests__/ReleaseMenuButton.test.tsx
@@ -180,7 +180,7 @@ describe('ReleaseMenuButton', () => {
 
       describe('when archiving fails', () => {
         beforeEach(async () => {
-          vi.spyOn(console, 'error').mockImplementation(() => {})
+          vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
           mockUseReleaseOperations.mockReturnValue({
             ...useReleaseOperationsMockReturn,
             archive: vi.fn().mockRejectedValue(new Error('some rejection reason')),
@@ -282,7 +282,7 @@ describe('ReleaseMenuButton', () => {
 
       describe('when deleting fails', () => {
         beforeEach(async () => {
-          vi.spyOn(console, 'error').mockImplementation(() => {})
+          vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
           mockUseReleaseOperations.mockReturnValue({
             ...useReleaseOperationsMockReturn,
             deleteRelease: vi.fn().mockRejectedValue(new Error('some rejection reason')),
@@ -550,7 +550,7 @@ describe('ReleaseMenuButton', () => {
 
       describe('when duplication fails', () => {
         beforeEach(() => {
-          vi.spyOn(console, 'error').mockImplementation(() => {})
+          vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
           duplicateReleaseMock.mockRejectedValue(new Error('some duplication error'))
         })
 

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/__tests__/ReleaseMenuButton.test.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/__tests__/ReleaseMenuButton.test.tsx
@@ -180,7 +180,9 @@ describe('ReleaseMenuButton', () => {
 
       describe('when archiving fails', () => {
         beforeEach(async () => {
-          vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
+          vi.spyOn(console, 'error').mockImplementation(() => {
+            /* intentionally empty */
+          })
           mockUseReleaseOperations.mockReturnValue({
             ...useReleaseOperationsMockReturn,
             archive: vi.fn().mockRejectedValue(new Error('some rejection reason')),
@@ -282,7 +284,9 @@ describe('ReleaseMenuButton', () => {
 
       describe('when deleting fails', () => {
         beforeEach(async () => {
-          vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
+          vi.spyOn(console, 'error').mockImplementation(() => {
+            /* intentionally empty */
+          })
           mockUseReleaseOperations.mockReturnValue({
             ...useReleaseOperationsMockReturn,
             deleteRelease: vi.fn().mockRejectedValue(new Error('some rejection reason')),
@@ -550,7 +554,9 @@ describe('ReleaseMenuButton', () => {
 
       describe('when duplication fails', () => {
         beforeEach(() => {
-          vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
+          vi.spyOn(console, 'error').mockImplementation(() => {
+            /* intentionally empty */
+          })
           duplicateReleaseMock.mockRejectedValue(new Error('some duplication error'))
         })
 

--- a/packages/sanity/src/core/releases/tool/components/__tests__/ReleaseDocumentPreview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/components/__tests__/ReleaseDocumentPreview.test.tsx
@@ -23,7 +23,10 @@ const mockPreviewValues = {
 
 vi.mock('../../../../preview/components/SanityDefaultPreview', () => ({
   SanityDefaultPreview: vi.fn(({isPlaceholder, title, subtitle, status}) => (
-    <div data-ui={isPlaceholder ? 'Placeholder' : 'Preview'}>
+    <div
+      data-ui={isPlaceholder ? 'Placeholder' : 'Preview'}
+      data-testid={isPlaceholder ? 'preview-placeholder' : 'preview-content'}
+    >
       {!isPlaceholder && title && <div>{title}</div>}
       {!isPlaceholder && subtitle && <div>{subtitle}</div>}
       {status}
@@ -96,51 +99,51 @@ describe('ReleaseDocumentPreview', () => {
       value: null,
     })
 
-    const {container} = await renderTest({
+    await renderTest({
       documentId: 'doc123',
       documentTypeName: 'post',
       releaseId: activeASAPRelease._id,
     })
 
-    expect(container.querySelector('[data-ui="Placeholder"]')).toBeInTheDocument()
+    expect(screen.getByTestId('preview-placeholder')).toBeInTheDocument()
   })
 
   it('creates link with published perspective when release state is published', async () => {
-    const {container} = await renderTest({
+    await renderTest({
       documentId: 'doc123',
       documentTypeName: 'post',
       releaseId: activeASAPRelease._id,
       releaseState: 'published',
     })
 
-    const link = container.querySelector('a')
-    const searchParams = JSON.parse(link.getAttribute('data-search-params'))
+    const link = screen.getByRole('link')
+    const searchParams = JSON.parse(link.getAttribute('data-search-params') ?? 'null')
     expect(searchParams).toContainEqual(['perspective', 'published'])
   })
 
   it('creates link with release ID perspective when release state is not published', async () => {
-    const {container} = await renderTest({
+    await renderTest({
       documentId: 'doc123',
       documentTypeName: 'post',
       releaseId: activeScheduledRelease._id,
       releaseState: 'active',
     })
 
-    const link = container.querySelector('a')
-    const searchParams = JSON.parse(link.getAttribute('data-search-params'))
+    const link = screen.getByRole('link')
+    const searchParams = JSON.parse(link.getAttribute('data-search-params') ?? 'null')
     expect(searchParams).toContainEqual(['perspective', 'rActive'])
   })
 
   it('creates link with release ID perspective when release state is not published', async () => {
-    const {container} = await renderTest({
+    await renderTest({
       documentId: 'doc123',
       documentTypeName: 'post',
       releaseId: activeScheduledRelease._id,
       releaseState: 'archived',
     })
 
-    const link = container.querySelector('a')
-    const searchParams = JSON.parse(link.getAttribute('data-search-params'))
+    const link = screen.getByRole('link')
+    const searchParams = JSON.parse(link.getAttribute('data-search-params') ?? 'null')
     expect(searchParams).toBeNull()
   })
 })

--- a/packages/sanity/src/core/releases/tool/components/__tests__/ReleaseDocumentPreview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/components/__tests__/ReleaseDocumentPreview.test.tsx
@@ -66,13 +66,13 @@ const renderTest = async (props: ComponentProps<typeof ReleaseDocumentPreview>) 
     resources: [releasesUsEnglishLocaleBundle],
   })
 
-  const rendered = render(<ReleaseDocumentPreview {...props} />, {wrapper})
+  const view = render(<ReleaseDocumentPreview {...props} />, {wrapper})
 
   await waitFor(() => {
     expect(screen.queryByTestId('loading-block')).not.toBeInTheDocument()
   })
 
-  return rendered
+  return view
 }
 
 describe('ReleaseDocumentPreview', () => {

--- a/packages/sanity/src/core/releases/tool/components/__tests__/ReleaseTime.test.tsx
+++ b/packages/sanity/src/core/releases/tool/components/__tests__/ReleaseTime.test.tsx
@@ -26,13 +26,13 @@ const renderTest = async (props: ComponentProps<typeof ReleaseTime>) => {
     resources: [releasesUsEnglishLocaleBundle],
   })
 
-  const rendered = render(<ReleaseTime {...props} />, {wrapper})
+  const view = render(<ReleaseTime {...props} />, {wrapper})
 
   await waitFor(() => {
     expect(screen.queryByTestId('loading-block')).not.toBeInTheDocument()
   })
 
-  return rendered
+  return view
 }
 
 describe('ReleaseTime', () => {

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/__tests__/useDocumentRevertStates.test.ts
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/__tests__/useDocumentRevertStates.test.ts
@@ -43,9 +43,8 @@ describe('useDocumentRevertStates', () => {
     vi.clearAllMocks()
     // Suppress expected console.error from the revert states pipeline
     // (async fetch errors during test teardown and intentional error tests)
-    vi.spyOn(console, 'error').mockImplementation(() => {
-      /* intentionally empty */
-    })
+    // eslint-disable-next-line no-empty-function
+    vi.spyOn(console, 'error').mockImplementation(() => {})
 
     mockUseClient.mockReturnValue(mockClient)
 

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/__tests__/useDocumentRevertStates.test.ts
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/__tests__/useDocumentRevertStates.test.ts
@@ -43,7 +43,9 @@ describe('useDocumentRevertStates', () => {
     vi.clearAllMocks()
     // Suppress expected console.error from the revert states pipeline
     // (async fetch errors during test teardown and intentional error tests)
-    vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
+    vi.spyOn(console, 'error').mockImplementation(() => {
+      /* intentionally empty */
+    })
 
     mockUseClient.mockReturnValue(mockClient)
 

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/__tests__/useDocumentRevertStates.test.ts
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/__tests__/useDocumentRevertStates.test.ts
@@ -43,7 +43,7 @@ describe('useDocumentRevertStates', () => {
     vi.clearAllMocks()
     // Suppress expected console.error from the revert states pipeline
     // (async fetch errors during test teardown and intentional error tests)
-    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
 
     mockUseClient.mockReturnValue(mockClient)
 

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDashboardFooter.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDashboardFooter.test.tsx
@@ -17,7 +17,7 @@ const renderTest = async (props?: Partial<React.ComponentProps<typeof ReleaseDas
     resources: [releasesUsEnglishLocaleBundle],
   })
 
-  const rendered = render(
+  const view = render(
     <ReleaseDashboardFooter
       release={activeASAPRelease}
       events={[]}
@@ -36,7 +36,7 @@ const renderTest = async (props?: Partial<React.ComponentProps<typeof ReleaseDas
     {timeout: 5000, interval: 1000},
   )
 
-  return rendered
+  return view
 }
 
 describe('ReleaseDashboardFooter', () => {

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDashboardFooter.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDashboardFooter.test.tsx
@@ -88,6 +88,7 @@ describe('ReleaseDashboardFooter', () => {
       await renderTest({release: archivedScheduledRelease})
 
       const footerActions = screen.getByTestId('release-dashboard-footer-actions')
+      // eslint-disable-next-line testing-library/no-node-access -- checking child count, no accessible query available
       expect(footerActions.children.length).toEqual(1)
     })
   })

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDashboardFooter.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDashboardFooter.test.tsx
@@ -87,7 +87,8 @@ describe('ReleaseDashboardFooter', () => {
     test('shows the unarchive button', async () => {
       await renderTest({release: archivedScheduledRelease})
 
-      expect(screen.getByTestId('release-dashboard-footer-actions').children.length).toEqual(1)
+      const footerActions = screen.getByTestId('release-dashboard-footer-actions')
+      expect(footerActions.children.length).toEqual(1)
     })
   })
 })

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
@@ -184,7 +184,7 @@ describe('ReleaseDetail', () => {
         await screen.findAllByText(activeASAPRelease.metadata.title, {exact: false}),
       ).not.toHaveLength(0)
       expect(await screen.findByTestId('release-menu-button')).toBeInTheDocument()
-      expect((await screen.findByTestId('publish-all-button')).closest('button')).toBeDisabled()
+      expect(await screen.findByTestId('publish-all-button')).toBeDisabled()
     })
   })
 })
@@ -230,7 +230,7 @@ describe('after releases have loaded', () => {
       it('should disable publish all button', async () => {
         await renderTest()
         await waitFor(() => {
-          expect(screen.getByTestId('publish-all-button').closest('button')).toBeDisabled()
+          expect(screen.getByTestId('publish-all-button')).toBeDisabled()
         })
       })
     })
@@ -258,7 +258,7 @@ describe('after releases have loaded', () => {
         await renderTest()
 
         await waitFor(() => {
-          expect(screen.getByTestId('publish-all-button').closest('button')).not.toBeDisabled()
+          expect(screen.getByTestId('publish-all-button')).not.toBeDisabled()
         })
       })
 
@@ -270,8 +270,7 @@ describe('after releases have loaded', () => {
         await waitFor(
           () => {
             const publishButton = screen.getByTestId('publish-all-button')
-            const button = publishButton.closest('button')
-            expect(button).toBeInTheDocument()
+            expect(publishButton).toBeInTheDocument()
           },
           {timeout: 1000},
         )
@@ -285,8 +284,7 @@ describe('after releases have loaded', () => {
         await waitFor(
           () => {
             const publishButton = screen.getByTestId('publish-all-button')
-            const button = publishButton.closest('button')
-            expect(button).toBeInTheDocument()
+            expect(publishButton).toBeInTheDocument()
           },
           {timeout: 1000},
         )

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
@@ -98,7 +98,7 @@ const renderTest = async () => {
   const wrapper = await createTestProvider({
     resources: [releasesUsEnglishLocaleBundle],
   })
-  const result = render(
+  const view = render(
     <RouterProvider
       state={{
         releaseId: activeASAPRelease._id,
@@ -113,7 +113,7 @@ const renderTest = async () => {
 
   await flushMicrotasksThisIsACodeSmell()
 
-  return result
+  return view
 }
 
 const publishAgnosticTests = (title: string) => {

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseTypePicker.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseTypePicker.test.tsx
@@ -279,9 +279,8 @@ describe('ReleaseTypePicker', () => {
       mockUseReleaseOperations.mockReturnValue({
         ...useReleaseOperationsMockReturn,
         updateRelease: vi.fn().mockImplementation(() => {
-          return new Promise(() => {
-            /* intentionally empty */
-          })
+          // eslint-disable-next-line no-empty-function
+          return new Promise(() => {})
         }),
       })
       await renderComponent()

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseTypePicker.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseTypePicker.test.tsx
@@ -289,7 +289,7 @@ describe('ReleaseTypePicker', () => {
       mockUseReleaseOperations.mockReturnValue({
         ...useReleaseOperationsMockReturn,
         updateRelease: vi.fn().mockImplementation(() => {
-          return new Promise(() => {})
+          return new Promise(() => { /* intentionally empty */ })
         }),
       })
       await renderComponent()

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseTypePicker.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseTypePicker.test.tsx
@@ -289,7 +289,9 @@ describe('ReleaseTypePicker', () => {
       mockUseReleaseOperations.mockReturnValue({
         ...useReleaseOperationsMockReturn,
         updateRelease: vi.fn().mockImplementation(() => {
-          return new Promise(() => { /* intentionally empty */ })
+          return new Promise(() => {
+            /* intentionally empty */
+          })
         }),
       })
       await renderComponent()

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseTypePicker.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseTypePicker.test.tsx
@@ -41,17 +41,7 @@ const renderComponent = async (release = activeASAPRelease) => {
 }
 
 const findTabByName = async (name: string) => {
-  const labels = await screen.findAllByText(name)
-
-  for (const label of labels) {
-    const tab = label.closest('[role="tab"]') as HTMLButtonElement | null
-
-    if (tab) {
-      return tab
-    }
-  }
-
-  throw new Error(`Could not find tab with name "${name}"`)
+  return screen.getByRole('tab', {name})
 }
 
 const mockUpdateRelease = vi.fn()

--- a/packages/sanity/src/core/releases/tool/detail/events/getReleaseEvents.ts
+++ b/packages/sanity/src/core/releases/tool/detail/events/getReleaseEvents.ts
@@ -42,8 +42,12 @@ const notEnabledActivityEvents: ReturnType<typeof getReleaseActivityEvents> = {
     loading: false,
     error: null,
   }),
-  reloadEvents: () => { /* intentionally empty */ },
-  loadMore: () => { /* intentionally empty */ },
+  reloadEvents: () => {
+    /* intentionally empty */
+  },
+  loadMore: () => {
+    /* intentionally empty */
+  },
 }
 
 /**

--- a/packages/sanity/src/core/releases/tool/detail/events/getReleaseEvents.ts
+++ b/packages/sanity/src/core/releases/tool/detail/events/getReleaseEvents.ts
@@ -42,8 +42,8 @@ const notEnabledActivityEvents: ReturnType<typeof getReleaseActivityEvents> = {
     loading: false,
     error: null,
   }),
-  reloadEvents: () => {},
-  loadMore: () => {},
+  reloadEvents: () => { /* intentionally empty */ },
+  loadMore: () => { /* intentionally empty */ },
 }
 
 /**

--- a/packages/sanity/src/core/releases/tool/detail/events/getReleaseEvents.ts
+++ b/packages/sanity/src/core/releases/tool/detail/events/getReleaseEvents.ts
@@ -42,12 +42,10 @@ const notEnabledActivityEvents: ReturnType<typeof getReleaseActivityEvents> = {
     loading: false,
     error: null,
   }),
-  reloadEvents: () => {
-    /* intentionally empty */
-  },
-  loadMore: () => {
-    /* intentionally empty */
-  },
+  // eslint-disable-next-line no-empty-function
+  reloadEvents: () => {},
+  // eslint-disable-next-line no-empty-function
+  loadMore: () => {},
 }
 
 /**

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
@@ -678,9 +678,8 @@ describe('ReleasesOverview', () => {
     })
 
     describe('narrow viewport layout', () => {
-      beforeEach(async () => {
+      beforeEach(() => {
         vi.mocked(useMediaIndex).mockReturnValue(1)
-        await rerender()
       })
 
       afterEach(() => {
@@ -688,6 +687,7 @@ describe('ReleasesOverview', () => {
       })
 
       it('opens the calendar filter as a dialog instead of a sidebar', async () => {
+        await rerender()
         const filterButton = screen.getByRole('button', {name: 'calendar'})
         expect(filterButton).toBeInTheDocument()
         await userEvent.click(filterButton)
@@ -696,7 +696,8 @@ describe('ReleasesOverview', () => {
         expect(dialog).toBeInTheDocument()
       })
 
-      it('hides the timezone text and shows only the icon', () => {
+      it('hides the timezone text and shows only the icon', async () => {
+        await rerender()
         expect(screen.queryByText('SCT (Sanity/Oslo)')).not.toBeInTheDocument()
       })
     })

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
@@ -303,8 +303,8 @@ describe('ReleasesOverview', () => {
         },
         {timeout: 4000},
       )
-      expect(screen.getByText('Active').closest('button')).toBeDisabled()
-      expect(screen.getByText('Archived').closest('button')).toBeDisabled()
+      expect(screen.getByRole('button', {name: 'Active'})).toBeDisabled()
+      expect(screen.getByRole('button', {name: 'Archived'})).toBeDisabled()
     })
 
     it('does show the page heading', () => {
@@ -527,8 +527,8 @@ describe('ReleasesOverview', () => {
     })
 
     it('allows for switching between history modes', () => {
-      expect(screen.getByText('Active').closest('button')).not.toBeDisabled()
-      expect(screen.getByText('Archived').closest('button')).not.toBeDisabled()
+      expect(screen.getByRole('button', {name: 'Active'})).not.toBeDisabled()
+      expect(screen.getByRole('button', {name: 'Archived'})).not.toBeDisabled()
     })
 
     it('allows for pinning perspectives', async () => {
@@ -539,11 +539,9 @@ describe('ReleasesOverview', () => {
       const pinButton = within(firstRow).getByTestId('pin-release-button')
 
       expect(pinButton).toBeInTheDocument()
-      const buttonElement = pinButton.closest('button')
-      expect(buttonElement).not.toBeNull()
-      expect(buttonElement).not.toBeDisabled()
+      expect(pinButton).not.toBeDisabled()
 
-      await userEvent.click(buttonElement!)
+      await userEvent.click(pinButton)
 
       await waitFor(() => {
         expect(mockedSetPerspective).toHaveBeenCalledOnce()
@@ -576,7 +574,7 @@ describe('ReleasesOverview', () => {
         const todayTile = within(getByDataUi(document.body, 'Calendar')).getByTestId(
           'day-tile-today',
         )
-        expect(todayTile.firstChild).toHaveStyle('font-weight: 700')
+        expect(within(todayTile).getByText(/\d+/)).toHaveStyle('font-weight: 700')
       })
 
       describe('selecting a release date', () => {
@@ -600,9 +598,9 @@ describe('ReleasesOverview', () => {
         })
 
         it('clears the filter by clicking the selected date', async () => {
-          // not ideal, but the easiest way of finding the now selected date
-          const todayTile = getCalendar().querySelector('[data-selected]')
-          await userEvent.click(todayTile!)
+          // The today tile was clicked in beforeEach, so it should now be selected
+          const selectedTile = within(getCalendar()).getByTestId('day-tile-today')
+          await userEvent.click(selectedTile)
 
           await waitFor(() => {
             expect(screen.getAllByTestId('table-row')).toHaveLength(5)
@@ -665,7 +663,7 @@ describe('ReleasesOverview', () => {
           const todayTile = within(getByDataUi(document.body, 'Calendar')).getByTestId(
             'day-tile-today',
           )
-          expect(todayTile.parentNode).not.toHaveStyle('font-weight: 700')
+          expect(within(todayTile).getByText(/\d+/)).not.toHaveStyle('font-weight: 700')
         })
 
         it('shows no releases when filtered by today', async () => {
@@ -690,7 +688,7 @@ describe('ReleasesOverview', () => {
       })
 
       it('opens the calendar filter as a dialog instead of a sidebar', async () => {
-        const filterButton = document.querySelector('button[name="calendar"]') as HTMLButtonElement
+        const filterButton = screen.getByRole('button', {name: 'calendar'})
         expect(filterButton).toBeInTheDocument()
         await userEvent.click(filterButton)
 
@@ -721,7 +719,7 @@ describe('ReleasesOverview', () => {
 
       it('does not allow for perspective pinning', () => {
         screen.getAllByTestId('table-row').forEach((row) => {
-          expect(within(row).getByTestId('pin-release-button').closest('button')).toBeDisabled()
+          expect(within(row).getByTestId('pin-release-button')).toBeDisabled()
         })
       })
     })
@@ -825,8 +823,8 @@ describe('ReleasesOverview', () => {
           const dropdownButton = screen.queryByTestId('cardinality-view-menu')
           expect(dropdownButton).not.toBeInTheDocument()
 
-          const releasesText = screen.getByText('Releases')
-          expect(releasesText.closest('button')).toBeNull()
+          expect(screen.getByText('Releases')).toBeInTheDocument()
+          expect(screen.queryByRole('button', {name: 'Releases'})).not.toBeInTheDocument()
         })
 
         it('should show the create release button', () => {
@@ -894,7 +892,7 @@ describe('ReleasesOverview', () => {
           expect(releasesButton).toBeInTheDocument()
 
           // Should find the dropdown menu button by id
-          const dropdownButton = document.getElementById('cardinality-view-menu')
+          const dropdownButton = screen.getByTestId('cardinality-view-menu')
           expect(dropdownButton).toBeInTheDocument()
         })
 
@@ -1065,7 +1063,7 @@ describe('ReleasesOverview', () => {
         expect(releasesButton).toBeInTheDocument()
 
         // Should find the dropdown menu button by id
-        const dropdownButton = document.getElementById('cardinality-view-menu')
+        const dropdownButton = screen.getByTestId('cardinality-view-menu')
         expect(dropdownButton).toBeInTheDocument()
       })
 

--- a/packages/sanity/src/core/scheduledPublishing/contexts/ScheduledPublishingEnabledProvider.test.tsx
+++ b/packages/sanity/src/core/scheduledPublishing/contexts/ScheduledPublishingEnabledProvider.test.tsx
@@ -62,11 +62,11 @@ describe('ScheduledPublishingEnabledProvider - previously used', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: false, isLoading: false})
     useWorkspaceMock.mockReturnValue({scheduledPublishing: {enabled: false}})
 
-    const value = renderHook(useScheduledPublishingEnabled, {
+    const view = renderHook(useScheduledPublishingEnabled, {
       wrapper: ScheduledPublishingEnabledProvider,
     })
 
-    expect(value.result.current).toEqual({
+    expect(view.result.current).toEqual({
       enabled: false,
       mode: null,
       // Workspace is not enabled, so we won't do a request to check if they have used it or not.
@@ -77,11 +77,11 @@ describe('ScheduledPublishingEnabledProvider - previously used', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: true, isLoading: false})
     useWorkspaceMock.mockReturnValue({scheduledPublishing: {enabled: false}})
 
-    const value = renderHook(useScheduledPublishingEnabled, {
+    const view = renderHook(useScheduledPublishingEnabled, {
       wrapper: ScheduledPublishingEnabledProvider,
     })
 
-    expect(value.result.current).toEqual({
+    expect(view.result.current).toEqual({
       enabled: false,
       mode: null,
       // Workspace is not enabled, so we won't do a request to check if they have used it or not.
@@ -93,11 +93,11 @@ describe('ScheduledPublishingEnabledProvider - previously used', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: true, isLoading: false})
     useWorkspaceMock.mockReturnValue({scheduledPublishing: {enabled: true}})
 
-    const value = renderHook(useScheduledPublishingEnabled, {
+    const view = renderHook(useScheduledPublishingEnabled, {
       wrapper: ScheduledPublishingEnabledProvider,
     })
 
-    expect(value.result.current).toEqual({
+    expect(view.result.current).toEqual({
       enabled: true,
       mode: 'default',
       hasUsedScheduledPublishing: {used: true, loading: false},
@@ -108,11 +108,11 @@ describe('ScheduledPublishingEnabledProvider - previously used', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: false, isLoading: false})
     useWorkspaceMock.mockReturnValue({scheduledPublishing: {enabled: true}})
 
-    const value = renderHook(useScheduledPublishingEnabled, {
+    const view = renderHook(useScheduledPublishingEnabled, {
       wrapper: ScheduledPublishingEnabledProvider,
     })
 
-    expect(value.result.current).toEqual({
+    expect(view.result.current).toEqual({
       enabled: true,
       mode: 'upsell',
       hasUsedScheduledPublishing: {used: true, loading: false},
@@ -123,11 +123,11 @@ describe('ScheduledPublishingEnabledProvider - previously used', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: false, isLoading: true})
     useWorkspaceMock.mockReturnValue({scheduledPublishing: {enabled: true}})
 
-    const value = renderHook(useScheduledPublishingEnabled, {
+    const view = renderHook(useScheduledPublishingEnabled, {
       wrapper: ScheduledPublishingEnabledProvider,
     })
 
-    expect(value.result.current).toEqual({
+    expect(view.result.current).toEqual({
       enabled: false,
       mode: null,
       hasUsedScheduledPublishing: {used: true, loading: false},
@@ -142,11 +142,11 @@ describe('ScheduledPublishingEnabledProvider - previously used', () => {
     })
     useWorkspaceMock.mockReturnValue({scheduledPublishing: {enabled: true}})
 
-    const value = renderHook(useScheduledPublishingEnabled, {
+    const view = renderHook(useScheduledPublishingEnabled, {
       wrapper: ScheduledPublishingEnabledProvider,
     })
 
-    expect(value.result.current).toEqual({
+    expect(view.result.current).toEqual({
       enabled: false,
       mode: null,
       hasUsedScheduledPublishing: {used: true, loading: false},
@@ -182,11 +182,11 @@ describe('ScheduledPublishingEnabledProvider - not previously used', () => {
       },
     })
 
-    const value = renderHook(useScheduledPublishingEnabled, {
+    const view = renderHook(useScheduledPublishingEnabled, {
       wrapper: ScheduledPublishingEnabledProvider,
     })
 
-    expect(value.result.current).toEqual({
+    expect(view.result.current).toEqual({
       enabled: false,
       mode: null,
       hasUsedScheduledPublishing: {used: false, loading: false},
@@ -200,11 +200,11 @@ describe('ScheduledPublishingEnabledProvider - not previously used', () => {
       scheduledPublishing: {enabled: true, __internal__workspaceEnabled: false},
     })
 
-    const value = renderHook(useScheduledPublishingEnabled, {
+    const view = renderHook(useScheduledPublishingEnabled, {
       wrapper: ScheduledPublishingEnabledProvider,
     })
 
-    expect(value.result.current).toEqual({
+    expect(view.result.current).toEqual({
       enabled: false,
       mode: null,
       hasUsedScheduledPublishing: {used: false, loading: false},
@@ -218,11 +218,11 @@ describe('ScheduledPublishingEnabledProvider - not previously used', () => {
       scheduledPublishing: {enabled: true, __internal__workspaceEnabled: true},
     })
 
-    const value = renderHook(useScheduledPublishingEnabled, {
+    const view = renderHook(useScheduledPublishingEnabled, {
       wrapper: ScheduledPublishingEnabledProvider,
     })
 
-    expect(value.result.current).toEqual({
+    expect(view.result.current).toEqual({
       enabled: true,
       mode: 'default',
       // Users have opted in, so we are not checking if they used it, we are just returning a default true value
@@ -236,11 +236,11 @@ describe('ScheduledPublishingEnabledProvider - not previously used', () => {
       scheduledPublishing: {enabled: true, __internal__workspaceEnabled: true},
     })
 
-    const value = renderHook(useScheduledPublishingEnabled, {
+    const view = renderHook(useScheduledPublishingEnabled, {
       wrapper: ScheduledPublishingEnabledProvider,
     })
 
-    expect(value.result.current).toEqual({
+    expect(view.result.current).toEqual({
       enabled: true,
       mode: 'upsell',
       // Users have opted in, so we are not checking if they used it, we are just returning a default true value

--- a/packages/sanity/src/core/singleDocRelease/context/SingleDocReleaseEnabledProvider.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/context/SingleDocReleaseEnabledProvider.test.tsx
@@ -27,49 +27,49 @@ describe('SingleDocReleaseEnabledProvider', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: false, isLoading: false})
     useSourceMock.mockReturnValue({scheduledDrafts: {enabled: false}})
 
-    const value = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
+    const view = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
 
     expect(useFeatureEnabled).toHaveBeenCalledWith(featureFlagName)
-    expect(value.result.current).toEqual({enabled: false, mode: null})
+    expect(view.result.current).toEqual({enabled: false, mode: null})
   })
   it('should not show single doc releases if user opt out and the feature is enabled (any plan)', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: true, isLoading: false})
     useSourceMock.mockReturnValue({scheduledDrafts: {enabled: false}})
 
-    const value = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
+    const view = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
 
     expect(useFeatureEnabled).toHaveBeenCalledWith(featureFlagName)
-    expect(value.result.current).toEqual({enabled: false, mode: null})
+    expect(view.result.current).toEqual({enabled: false, mode: null})
   })
 
   it('should show default mode if user hasnt opted out and the feature flag is enabled (growth or above)', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: true, isLoading: false})
     useSourceMock.mockReturnValue({scheduledDrafts: {enabled: true}})
 
-    const value = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
+    const view = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
 
     expect(useFeatureEnabled).toHaveBeenCalledWith(featureFlagName)
-    expect(value.result.current).toEqual({enabled: true, mode: 'default'})
+    expect(view.result.current).toEqual({enabled: true, mode: 'default'})
   })
 
   it('should show upsell mode if user has not opt out and the feature is not enabled (free plans)', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: false, isLoading: false})
     useSourceMock.mockReturnValue({scheduledDrafts: {enabled: true}})
 
-    const value = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
+    const view = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
 
     expect(useFeatureEnabled).toHaveBeenCalledWith(featureFlagName)
-    expect(value.result.current).toEqual({enabled: true, mode: 'upsell'})
+    expect(view.result.current).toEqual({enabled: true, mode: 'upsell'})
   })
 
   it('should not show single doc releases if it is loading the feature', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: false, isLoading: true})
     useSourceMock.mockReturnValue({scheduledDrafts: {enabled: true}})
 
-    const value = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
+    const view = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
 
     expect(useFeatureEnabled).toHaveBeenCalledWith(featureFlagName)
-    expect(value.result.current).toEqual({enabled: false, mode: null})
+    expect(view.result.current).toEqual({enabled: false, mode: null})
   })
 
   it('should not show the plugin if useFeatureEnabled has an error', () => {
@@ -80,9 +80,9 @@ describe('SingleDocReleaseEnabledProvider', () => {
     })
     useSourceMock.mockReturnValue({scheduledDrafts: {enabled: true}})
 
-    const value = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
+    const view = renderHook(useSingleDocReleaseEnabled, {wrapper: SingleDocReleaseEnabledProvider})
 
     expect(useFeatureEnabled).toHaveBeenCalledWith(featureFlagName)
-    expect(value.result.current).toEqual({enabled: false, mode: null})
+    expect(view.result.current).toEqual({enabled: false, mode: null})
   })
 })

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.test.tsx
@@ -276,9 +276,8 @@ describe('useScheduledDraftMenuActions', () => {
     })
 
     it('should show error toast when operation fails', async () => {
-      vi.spyOn(console, 'error').mockImplementation(() => {
-        /* intentionally empty */
-      })
+      // eslint-disable-next-line no-empty-function
+      vi.spyOn(console, 'error').mockImplementation(() => {})
       const error = new Error('Pause failed')
       mockOperations.pauseScheduledDraft.mockRejectedValueOnce(error)
 

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.test.tsx
@@ -276,7 +276,7 @@ describe('useScheduledDraftMenuActions', () => {
     })
 
     it('should show error toast when operation fails', async () => {
-      vi.spyOn(console, 'error').mockImplementation(() => {})
+      vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
       const error = new Error('Pause failed')
       mockOperations.pauseScheduledDraft.mockRejectedValueOnce(error)
 

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.test.tsx
@@ -276,7 +276,9 @@ describe('useScheduledDraftMenuActions', () => {
     })
 
     it('should show error toast when operation fails', async () => {
-      vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
+      vi.spyOn(console, 'error').mockImplementation(() => {
+        /* intentionally empty */
+      })
       const error = new Error('Pause failed')
       mockOperations.pauseScheduledDraft.mockRejectedValueOnce(error)
 

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.test.tsx
@@ -1,5 +1,5 @@
 import {Menu} from '@sanity/ui'
-import {render, screen, waitFor} from '@testing-library/react'
+import {render, screen, waitFor, within} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
 import {beforeEach, describe, expect, it, type MockedFunction, vi} from 'vitest'
 
@@ -187,7 +187,7 @@ describe('useScheduledDraftMenuActions', () => {
     )
 
     const menuContainer = screen.getByTestId('menu-items')
-    const menuItems = menuContainer.children
+    const menuItems = within(menuContainer).getAllByRole('menuitem')
 
     // Should have exactly 3 menu items
     expect(menuItems).toHaveLength(3)

--- a/packages/sanity/src/core/store/events/utils.test.ts
+++ b/packages/sanity/src/core/store/events/utils.test.ts
@@ -8,9 +8,8 @@ import {
 import {addParentToEvents, sortEvents} from './utils'
 
 describe('addParentToEvents', () => {
-  it('should add the correct parentId to the events', () => {
-    /* intentionally empty */
-  })
+  // eslint-disable-next-line no-empty-function
+  it('should add the correct parentId to the events', () => {})
 })
 
 describe('sortEvents', () => {

--- a/packages/sanity/src/core/store/events/utils.test.ts
+++ b/packages/sanity/src/core/store/events/utils.test.ts
@@ -8,7 +8,9 @@ import {
 import {addParentToEvents, sortEvents} from './utils'
 
 describe('addParentToEvents', () => {
-  it('should add the correct parentId to the events', () => { /* intentionally empty */ })
+  it('should add the correct parentId to the events', () => {
+    /* intentionally empty */
+  })
 })
 
 describe('sortEvents', () => {

--- a/packages/sanity/src/core/store/events/utils.test.ts
+++ b/packages/sanity/src/core/store/events/utils.test.ts
@@ -8,7 +8,7 @@ import {
 import {addParentToEvents, sortEvents} from './utils'
 
 describe('addParentToEvents', () => {
-  it('should add the correct parentId to the events', () => {})
+  it('should add the correct parentId to the events', () => { /* intentionally empty */ })
 })
 
 describe('sortEvents', () => {

--- a/packages/sanity/src/core/store/renderingContext/coreUiRenderingContext.test.ts
+++ b/packages/sanity/src/core/store/renderingContext/coreUiRenderingContext.test.ts
@@ -50,9 +50,8 @@ it('parses the `_context` URL search parameter', async () => {
 })
 
 it('fails gracefully if the `_context` URL search parameter cannot be parsed', async () => {
-  vi.spyOn(console, 'warn').mockImplementation(() => {
-    /* intentionally empty */
-  })
+  // eslint-disable-next-line no-empty-function
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
   const invalidCoreUiContextString = urlSearch(coreUiProductionContext).slice(0, -10)
 
   await expect(() => coreUiRenderingContext(invalidCoreUiContextString)).toMatchEmissions([

--- a/packages/sanity/src/core/store/renderingContext/coreUiRenderingContext.test.ts
+++ b/packages/sanity/src/core/store/renderingContext/coreUiRenderingContext.test.ts
@@ -50,7 +50,9 @@ it('parses the `_context` URL search parameter', async () => {
 })
 
 it('fails gracefully if the `_context` URL search parameter cannot be parsed', async () => {
-  vi.spyOn(console, 'warn').mockImplementation(() => { /* intentionally empty */ })
+  vi.spyOn(console, 'warn').mockImplementation(() => {
+    /* intentionally empty */
+  })
   const invalidCoreUiContextString = urlSearch(coreUiProductionContext).slice(0, -10)
 
   await expect(() => coreUiRenderingContext(invalidCoreUiContextString)).toMatchEmissions([

--- a/packages/sanity/src/core/store/renderingContext/coreUiRenderingContext.test.ts
+++ b/packages/sanity/src/core/store/renderingContext/coreUiRenderingContext.test.ts
@@ -50,7 +50,7 @@ it('parses the `_context` URL search parameter', async () => {
 })
 
 it('fails gracefully if the `_context` URL search parameter cannot be parsed', async () => {
-  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => { /* intentionally empty */ })
   const invalidCoreUiContextString = urlSearch(coreUiProductionContext).slice(0, -10)
 
   await expect(() => coreUiRenderingContext(invalidCoreUiContextString)).toMatchEmissions([

--- a/packages/sanity/src/core/store/studio-app/__tests__/appIdCache.test.ts
+++ b/packages/sanity/src/core/store/studio-app/__tests__/appIdCache.test.ts
@@ -17,7 +17,9 @@ describe('appIdCache', () => {
   })
 
   it(`should suppress error and return undefined`, async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
+    vi.spyOn(console, 'error').mockImplementation(() => {
+      /* intentionally empty */
+    })
     const cache = createAppIdCache()
     const appIdFetcher = vi.fn(async () => {
       throw new Error('simulated-error')

--- a/packages/sanity/src/core/store/studio-app/__tests__/appIdCache.test.ts
+++ b/packages/sanity/src/core/store/studio-app/__tests__/appIdCache.test.ts
@@ -17,9 +17,8 @@ describe('appIdCache', () => {
   })
 
   it(`should suppress error and return undefined`, async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => {
-      /* intentionally empty */
-    })
+    // eslint-disable-next-line no-empty-function
+    vi.spyOn(console, 'error').mockImplementation(() => {})
     const cache = createAppIdCache()
     const appIdFetcher = vi.fn(async () => {
       throw new Error('simulated-error')

--- a/packages/sanity/src/core/store/studio-app/__tests__/appIdCache.test.ts
+++ b/packages/sanity/src/core/store/studio-app/__tests__/appIdCache.test.ts
@@ -17,7 +17,7 @@ describe('appIdCache', () => {
   })
 
   it(`should suppress error and return undefined`, async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
     const cache = createAppIdCache()
     const appIdFetcher = vi.fn(async () => {
       throw new Error('simulated-error')

--- a/packages/sanity/src/core/studio/Studio.test.tsx
+++ b/packages/sanity/src/core/studio/Studio.test.tsx
@@ -50,8 +50,8 @@ describe('Studio', () => {
     const node = document.createElement('div')
     document.body.appendChild(node)
 
-    const html = renderToString(<Studio config={config} />)
-    node.innerHTML = html
+    const view = renderToString(<Studio config={config} />)
+    node.innerHTML = view
 
     const root = await act(() => hydrateRoot(node, <Studio config={config} />))
     act(() => root.unmount())

--- a/packages/sanity/src/core/studio/__tests__/colorSchemeStore.test.ts
+++ b/packages/sanity/src/core/studio/__tests__/colorSchemeStore.test.ts
@@ -25,9 +25,8 @@ describe('colorSchemeStore', () => {
 
   test('default color scheme is system', () => {
     mockLocalStorage.getItem.mockReturnValue(null)
-    const unsubscribe = subscribe(() => {
-      /* intentionally empty */
-    })
+    // eslint-disable-next-line no-empty-function
+    const unsubscribe = subscribe(() => {})
     expect(getSnapshot()).toBe('system')
     unsubscribe()
   })

--- a/packages/sanity/src/core/studio/__tests__/colorSchemeStore.test.ts
+++ b/packages/sanity/src/core/studio/__tests__/colorSchemeStore.test.ts
@@ -25,7 +25,7 @@ describe('colorSchemeStore', () => {
 
   test('default color scheme is system', () => {
     mockLocalStorage.getItem.mockReturnValue(null)
-    const unsubscribe = subscribe(() => {})
+    const unsubscribe = subscribe(() => { /* intentionally empty */ })
     expect(getSnapshot()).toBe('system')
     unsubscribe()
   })

--- a/packages/sanity/src/core/studio/__tests__/colorSchemeStore.test.ts
+++ b/packages/sanity/src/core/studio/__tests__/colorSchemeStore.test.ts
@@ -25,7 +25,9 @@ describe('colorSchemeStore', () => {
 
   test('default color scheme is system', () => {
     mockLocalStorage.getItem.mockReturnValue(null)
-    const unsubscribe = subscribe(() => { /* intentionally empty */ })
+    const unsubscribe = subscribe(() => {
+      /* intentionally empty */
+    })
     expect(getSnapshot()).toBe('system')
     unsubscribe()
   })

--- a/packages/sanity/src/core/studio/components/navbar/search/components/common/__tests__/FilterLabel.test.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/common/__tests__/FilterLabel.test.tsx
@@ -80,7 +80,7 @@ describe('FilterLabel', () => {
   })
 
   test('handles missing operator descriptionKey', async () => {
-    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => { /* intentionally empty */ })
     const filterWithoutDescription: SearchFilter = {
       ...mockFilter,
       operatorType: 'unknown',

--- a/packages/sanity/src/core/studio/components/navbar/search/components/common/__tests__/FilterLabel.test.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/common/__tests__/FilterLabel.test.tsx
@@ -80,9 +80,8 @@ describe('FilterLabel', () => {
   })
 
   test('handles missing operator descriptionKey', async () => {
-    vi.spyOn(console, 'warn').mockImplementation(() => {
-      /* intentionally empty */
-    })
+    // eslint-disable-next-line no-empty-function
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
     const filterWithoutDescription: SearchFilter = {
       ...mockFilter,
       operatorType: 'unknown',

--- a/packages/sanity/src/core/studio/components/navbar/search/components/common/__tests__/FilterLabel.test.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/common/__tests__/FilterLabel.test.tsx
@@ -80,7 +80,9 @@ describe('FilterLabel', () => {
   })
 
   test('handles missing operator descriptionKey', async () => {
-    vi.spyOn(console, 'warn').mockImplementation(() => { /* intentionally empty */ })
+    vi.spyOn(console, 'warn').mockImplementation(() => {
+      /* intentionally empty */
+    })
     const filterWithoutDescription: SearchFilter = {
       ...mockFilter,
       operatorType: 'unknown',

--- a/packages/sanity/src/core/studio/components/navbar/search/definitions/fields.test.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/definitions/fields.test.tsx
@@ -245,7 +245,9 @@ describe('createFieldDefinitions', () => {
   })
 
   it('should return empty string when title contains a custom React component that cannot render', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { /* intentionally empty */ })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {
+      /* intentionally empty */
+    })
 
     function ThrowsOnRender(props: {children: React.ReactNode}) {
       throw new Error('should not render')

--- a/packages/sanity/src/core/studio/components/navbar/search/definitions/fields.test.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/definitions/fields.test.tsx
@@ -245,7 +245,7 @@ describe('createFieldDefinitions', () => {
   })
 
   it('should return empty string when title contains a custom React component that cannot render', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { /* intentionally empty */ })
 
     function ThrowsOnRender(props: {children: React.ReactNode}) {
       throw new Error('should not render')

--- a/packages/sanity/src/core/studio/components/navbar/search/definitions/fields.test.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/definitions/fields.test.tsx
@@ -245,9 +245,8 @@ describe('createFieldDefinitions', () => {
   })
 
   it('should return empty string when title contains a custom React component that cannot render', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {
-      /* intentionally empty */
-    })
+    // eslint-disable-next-line no-empty-function
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     function ThrowsOnRender(props: {children: React.ReactNode}) {
       throw new Error('should not render')

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -15,7 +15,7 @@ import {parseImportMapModuleCdnUrl} from './utils'
 const POLL_INTERVAL_MS = 1000 * 60 * 15 // check every 15 minutes
 const CHECK_THROTTLE_TIME_MS = 1000 * 10 // prevent checking more often than every 10s
 
-const noop = () => {}
+const noop = () => { /* intentionally empty */ }
 
 type VersionCheckState = {
   lastCheckedAt: Date | null

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -15,7 +15,9 @@ import {parseImportMapModuleCdnUrl} from './utils'
 const POLL_INTERVAL_MS = 1000 * 60 * 15 // check every 15 minutes
 const CHECK_THROTTLE_TIME_MS = 1000 * 10 // prevent checking more often than every 10s
 
-const noop = () => { /* intentionally empty */ }
+const noop = () => {
+  /* intentionally empty */
+}
 
 type VersionCheckState = {
   lastCheckedAt: Date | null

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -15,9 +15,8 @@ import {parseImportMapModuleCdnUrl} from './utils'
 const POLL_INTERVAL_MS = 1000 * 60 * 15 // check every 15 minutes
 const CHECK_THROTTLE_TIME_MS = 1000 * 10 // prevent checking more often than every 10s
 
-const noop = () => {
-  /* intentionally empty */
-}
+// eslint-disable-next-line no-empty-function
+const noop = () => {}
 
 type VersionCheckState = {
   lastCheckedAt: Date | null

--- a/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
@@ -76,7 +76,10 @@ export function RequestAccessScreen() {
 
   // Check if user has a pending access request for this project
   useEffect(() => {
-    if (!client || !projectId) return () => { /* intentionally empty */ }
+    if (!client || !projectId)
+      return () => {
+        /* intentionally empty */
+      }
     const request$ = client.observable
       .request<AccessRequest[] | null>({
         url: '/access/requests/me',

--- a/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
@@ -77,9 +77,8 @@ export function RequestAccessScreen() {
   // Check if user has a pending access request for this project
   useEffect(() => {
     if (!client || !projectId)
-      return () => {
-        /* intentionally empty */
-      }
+      // eslint-disable-next-line no-empty-function
+      return () => {}
     const request$ = client.observable
       .request<AccessRequest[] | null>({
         url: '/access/requests/me',

--- a/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
@@ -76,7 +76,7 @@ export function RequestAccessScreen() {
 
   // Check if user has a pending access request for this project
   useEffect(() => {
-    if (!client || !projectId) return () => {}
+    if (!client || !projectId) return () => { /* intentionally empty */ }
     const request$ = client.observable
       .request<AccessRequest[] | null>({
         url: '/access/requests/me',

--- a/packages/sanity/src/core/studio/studioAnnouncements/useStudioAnnouncements.tsx
+++ b/packages/sanity/src/core/studio/studioAnnouncements/useStudioAnnouncements.tsx
@@ -10,7 +10,9 @@ export function useStudioAnnouncements(): StudioAnnouncementsContextValue {
     return {
       studioAnnouncements: [],
       unseenAnnouncements: [],
-      onDialogOpen: () => { /* intentionally empty */ },
+      onDialogOpen: () => {
+        /* intentionally empty */
+      },
     }
   }
 

--- a/packages/sanity/src/core/studio/studioAnnouncements/useStudioAnnouncements.tsx
+++ b/packages/sanity/src/core/studio/studioAnnouncements/useStudioAnnouncements.tsx
@@ -10,9 +10,8 @@ export function useStudioAnnouncements(): StudioAnnouncementsContextValue {
     return {
       studioAnnouncements: [],
       unseenAnnouncements: [],
-      onDialogOpen: () => {
-        /* intentionally empty */
-      },
+      // eslint-disable-next-line no-empty-function
+      onDialogOpen: () => {},
     }
   }
 

--- a/packages/sanity/src/core/studio/studioAnnouncements/useStudioAnnouncements.tsx
+++ b/packages/sanity/src/core/studio/studioAnnouncements/useStudioAnnouncements.tsx
@@ -10,7 +10,7 @@ export function useStudioAnnouncements(): StudioAnnouncementsContextValue {
     return {
       studioAnnouncements: [],
       unseenAnnouncements: [],
-      onDialogOpen: () => {},
+      onDialogOpen: () => { /* intentionally empty */ },
     }
   }
 

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.test.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.test.tsx
@@ -75,7 +75,9 @@ describe('WorkspaceRouterProvider', () => {
   // TODO: This test has been broken by the addition of `ActiveWorkspaceMatcherProvider` to `TestProvider`.
   it('calls onUncaughtError when an error is caught', async () => {
     // React logs caught errors from error boundaries to console.error
-    vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
+    vi.spyOn(console, 'error').mockImplementation(() => {
+      /* intentionally empty */
+    })
     const onUncaughtError = vi.fn()
 
     const ThrowErrorComponent = () => {

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.test.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.test.tsx
@@ -75,7 +75,7 @@ describe('WorkspaceRouterProvider', () => {
   // TODO: This test has been broken by the addition of `ActiveWorkspaceMatcherProvider` to `TestProvider`.
   it('calls onUncaughtError when an error is caught', async () => {
     // React logs caught errors from error boundaries to console.error
-    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
     const onUncaughtError = vi.fn()
 
     const ThrowErrorComponent = () => {

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.test.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceRouterProvider.test.tsx
@@ -75,9 +75,8 @@ describe('WorkspaceRouterProvider', () => {
   // TODO: This test has been broken by the addition of `ActiveWorkspaceMatcherProvider` to `TestProvider`.
   it('calls onUncaughtError when an error is caught', async () => {
     // React logs caught errors from error boundaries to console.error
-    vi.spyOn(console, 'error').mockImplementation(() => {
-      /* intentionally empty */
-    })
+    // eslint-disable-next-line no-empty-function
+    vi.spyOn(console, 'error').mockImplementation(() => {})
     const onUncaughtError = vi.fn()
 
     const ThrowErrorComponent = () => {

--- a/packages/sanity/src/core/tasks/context/enabled/TasksEnabledProvider.test.tsx
+++ b/packages/sanity/src/core/tasks/context/enabled/TasksEnabledProvider.test.tsx
@@ -24,44 +24,44 @@ describe('TasksEnabledProvider', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: false, isLoading: false})
     useWorkspaceMock.mockReturnValue({tasks: {enabled: false}})
 
-    const value = renderHook(useTasksEnabled, {wrapper: TasksEnabledProvider})
+    const view = renderHook(useTasksEnabled, {wrapper: TasksEnabledProvider})
 
-    expect(value.result.current).toEqual({enabled: false, mode: null})
+    expect(view.result.current).toEqual({enabled: false, mode: null})
   })
   it('should not show tasks if user opt out and the feature is enabled (any plan)', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: true, isLoading: false})
     useWorkspaceMock.mockReturnValue({tasks: {enabled: false}})
 
-    const value = renderHook(useTasksEnabled, {wrapper: TasksEnabledProvider})
+    const view = renderHook(useTasksEnabled, {wrapper: TasksEnabledProvider})
 
-    expect(value.result.current).toEqual({enabled: false, mode: null})
+    expect(view.result.current).toEqual({enabled: false, mode: null})
   })
 
   it('should show default mode if user hasnt opted out and the feature is enabled (growth or above)', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: true, isLoading: false})
     useWorkspaceMock.mockReturnValue({tasks: {enabled: true}})
 
-    const value = renderHook(useTasksEnabled, {wrapper: TasksEnabledProvider})
+    const view = renderHook(useTasksEnabled, {wrapper: TasksEnabledProvider})
 
-    expect(value.result.current).toEqual({enabled: true, mode: 'default'})
+    expect(view.result.current).toEqual({enabled: true, mode: 'default'})
   })
 
   it('should show upsell mode if user has not opt out and the feature is not enabled (free plans)', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: false, isLoading: false})
     useWorkspaceMock.mockReturnValue({tasks: {enabled: true}})
 
-    const value = renderHook(useTasksEnabled, {wrapper: TasksEnabledProvider})
+    const view = renderHook(useTasksEnabled, {wrapper: TasksEnabledProvider})
 
-    expect(value.result.current).toEqual({enabled: true, mode: 'upsell'})
+    expect(view.result.current).toEqual({enabled: true, mode: 'upsell'})
   })
 
   it('should not show tasks if it is loading the feature', () => {
     useFeatureEnabledMock.mockReturnValue({enabled: false, isLoading: true})
     useWorkspaceMock.mockReturnValue({tasks: {enabled: true}})
 
-    const value = renderHook(useTasksEnabled, {wrapper: TasksEnabledProvider})
+    const view = renderHook(useTasksEnabled, {wrapper: TasksEnabledProvider})
 
-    expect(value.result.current).toEqual({enabled: false, mode: null})
+    expect(view.result.current).toEqual({enabled: false, mode: null})
   })
 
   it('should not show the plugin if useFeatureEnabled has an error', () => {
@@ -72,9 +72,9 @@ describe('TasksEnabledProvider', () => {
     })
     useWorkspaceMock.mockReturnValue({tasks: {enabled: true}})
 
-    const value = renderHook(useTasksEnabled, {wrapper: TasksEnabledProvider})
+    const view = renderHook(useTasksEnabled, {wrapper: TasksEnabledProvider})
 
-    expect(value.result.current).toEqual({enabled: false, mode: null})
+    expect(view.result.current).toEqual({enabled: false, mode: null})
   })
 
   it('should call "useFeatureEnabled" with "sanityTasks"', () => {

--- a/packages/sanity/src/core/templates/__tests__/resolveDeep.test.ts
+++ b/packages/sanity/src/core/templates/__tests__/resolveDeep.test.ts
@@ -11,13 +11,13 @@ function generateNestedObjectTest(
   maxDepth: number,
   depth?: number,
 ): Record<string, any> {
-  depth = depth || 1
-  if (depth >= maxDepth) return obj
+  let currentDepth = depth || 1
+  if (currentDepth >= maxDepth) return obj
 
-  depth++
+  currentDepth++
   return {
     ...obj,
-    child: generateNestedObjectTest(obj, maxDepth, depth),
+    child: generateNestedObjectTest(obj, maxDepth, currentDepth),
   }
 }
 

--- a/packages/sanity/src/core/util/__tests__/createHookFromObservableFactory.test.tsx
+++ b/packages/sanity/src/core/util/__tests__/createHookFromObservableFactory.test.tsx
@@ -195,7 +195,9 @@ describe('createHookFromObservableFactory', () => {
     renderHook(useHook, {
       // Error is hoisted. To prevent it from being printed as uncaught in terminal,
       // we explicitly catch it and suppress it
-      onCaughtError: () => { /* intentionally empty */ },
+      onCaughtError: () => {
+        /* intentionally empty */
+      },
       wrapper: class Wrapper extends Component<PropsWithChildren> {
         static getDerivedStateFromError(err: Error) {
           error = err

--- a/packages/sanity/src/core/util/__tests__/createHookFromObservableFactory.test.tsx
+++ b/packages/sanity/src/core/util/__tests__/createHookFromObservableFactory.test.tsx
@@ -195,7 +195,7 @@ describe('createHookFromObservableFactory', () => {
     renderHook(useHook, {
       // Error is hoisted. To prevent it from being printed as uncaught in terminal,
       // we explicitly catch it and suppress it
-      onCaughtError: () => {},
+      onCaughtError: () => { /* intentionally empty */ },
       wrapper: class Wrapper extends Component<PropsWithChildren> {
         static getDerivedStateFromError(err: Error) {
           error = err

--- a/packages/sanity/src/core/util/__tests__/createHookFromObservableFactory.test.tsx
+++ b/packages/sanity/src/core/util/__tests__/createHookFromObservableFactory.test.tsx
@@ -204,6 +204,7 @@ describe('createHookFromObservableFactory', () => {
           return {hasError: true}
         }
         override render() {
+          // eslint-disable-next-line testing-library/no-node-access -- React class component render, not DOM access
           return this.props.children
         }
       },

--- a/packages/sanity/src/core/util/__tests__/createHookFromObservableFactory.test.tsx
+++ b/packages/sanity/src/core/util/__tests__/createHookFromObservableFactory.test.tsx
@@ -195,9 +195,8 @@ describe('createHookFromObservableFactory', () => {
     renderHook(useHook, {
       // Error is hoisted. To prevent it from being printed as uncaught in terminal,
       // we explicitly catch it and suppress it
-      onCaughtError: () => {
-        /* intentionally empty */
-      },
+      // eslint-disable-next-line no-empty-function
+      onCaughtError: () => {},
       wrapper: class Wrapper extends Component<PropsWithChildren> {
         static getDerivedStateFromError(err: Error) {
           error = err

--- a/packages/sanity/src/media-library/plugin/VideoInput/__tests__/videoInput.test.tsx
+++ b/packages/sanity/src/media-library/plugin/VideoInput/__tests__/videoInput.test.tsx
@@ -28,7 +28,9 @@ vi.mock('../useVideoPlaybackInfo', () => ({
       aspectRatio: 16 / 9,
     },
     error: undefined,
-    retry: () => { /* intentionally empty */ },
+    retry: () => {
+      /* intentionally empty */
+    },
   }),
 }))
 

--- a/packages/sanity/src/media-library/plugin/VideoInput/__tests__/videoInput.test.tsx
+++ b/packages/sanity/src/media-library/plugin/VideoInput/__tests__/videoInput.test.tsx
@@ -28,9 +28,8 @@ vi.mock('../useVideoPlaybackInfo', () => ({
       aspectRatio: 16 / 9,
     },
     error: undefined,
-    retry: () => {
-      /* intentionally empty */
-    },
+    // eslint-disable-next-line no-empty-function
+    retry: () => {},
   }),
 }))
 

--- a/packages/sanity/src/media-library/plugin/VideoInput/__tests__/videoInput.test.tsx
+++ b/packages/sanity/src/media-library/plugin/VideoInput/__tests__/videoInput.test.tsx
@@ -28,7 +28,7 @@ vi.mock('../useVideoPlaybackInfo', () => ({
       aspectRatio: 16 / 9,
     },
     error: undefined,
-    retry: () => {},
+    retry: () => { /* intentionally empty */ },
   }),
 }))
 

--- a/packages/sanity/src/presentation/panels/util.ts
+++ b/packages/sanity/src/presentation/panels/util.ts
@@ -58,9 +58,11 @@ export function getNextWidths(
       nextWidths[index] = nextWidth
 
       if (
-        deltaApplied.toPrecision(10).localeCompare(Math.abs(effectiveDelta).toPrecision(10), undefined, {
-          numeric: true,
-        }) >= 0
+        deltaApplied
+          .toPrecision(10)
+          .localeCompare(Math.abs(effectiveDelta).toPrecision(10), undefined, {
+            numeric: true,
+          }) >= 0
       ) {
         break
       }

--- a/packages/sanity/src/presentation/panels/util.ts
+++ b/packages/sanity/src/presentation/panels/util.ts
@@ -29,26 +29,27 @@ export function getNextWidths(
   const widths = initialWidths || prevWidths
   const nextWidths = [...widths]
 
+  let effectiveDelta = delta
   {
-    const pivotPanel = delta < 0 ? panelAfter : panelBefore
+    const pivotPanel = effectiveDelta < 0 ? panelAfter : panelBefore
     const index = panels.findIndex((panel) => panel.id === pivotPanel.id)
     const width = widths[index]
-    const nextWidth = getNextWidth(pivotPanel, width + Math.abs(delta), containerWidth)
+    const nextWidth = getNextWidth(pivotPanel, width + Math.abs(effectiveDelta), containerWidth)
     if (width === nextWidth) {
       return widths
     }
-    delta = delta < 0 ? width - nextWidth : nextWidth - width
+    effectiveDelta = effectiveDelta < 0 ? width - nextWidth : nextWidth - width
   }
 
   let deltaApplied = 0
-  let pivotPanel = delta < 0 ? panelBefore : panelAfter
+  let pivotPanel = effectiveDelta < 0 ? panelBefore : panelAfter
   let index = panels.findIndex((panel) => panel.id === pivotPanel.id)
 
   while (true) {
     const panel = panels[index]
     const width = widths[index]
 
-    const deltaRemaining = Math.abs(delta) - Math.abs(deltaApplied)
+    const deltaRemaining = Math.abs(effectiveDelta) - Math.abs(deltaApplied)
 
     const nextWidth = getNextWidth(panel, width - deltaRemaining, containerWidth)
 
@@ -57,7 +58,7 @@ export function getNextWidths(
       nextWidths[index] = nextWidth
 
       if (
-        deltaApplied.toPrecision(10).localeCompare(Math.abs(delta).toPrecision(10), undefined, {
+        deltaApplied.toPrecision(10).localeCompare(Math.abs(effectiveDelta).toPrecision(10), undefined, {
           numeric: true,
         }) >= 0
       ) {
@@ -65,7 +66,7 @@ export function getNextWidths(
       }
     }
 
-    if (delta < 0) {
+    if (effectiveDelta < 0) {
       if (--index < 0) {
         break
       }
@@ -78,7 +79,7 @@ export function getNextWidths(
     return widths
   }
 
-  pivotPanel = delta < 0 ? panelAfter : panelBefore
+  pivotPanel = effectiveDelta < 0 ? panelAfter : panelBefore
   index = panels.findIndex((panel) => panel.id === pivotPanel.id)
   nextWidths[index] = widths[index] + deltaApplied
 

--- a/packages/sanity/src/presentation/useMainDocument.ts
+++ b/packages/sanity/src/presentation/useMainDocument.ts
@@ -59,14 +59,14 @@ function getParamsFromResult(
 export function getRouteContext(route: Path, url: URL): DocumentResolverContext | undefined {
   const routes = Array.isArray(route) ? route : [route]
 
-  for (route of routes) {
+  for (const currentRoute of routes) {
     let {origin} = url
-    let path = route
+    let path = currentRoute
 
     // Handle absolute URLs
-    if (typeof route === 'string') {
+    if (typeof currentRoute === 'string') {
       try {
-        const absolute = new URL(route)
+        const absolute = new URL(currentRoute)
 
         // If we are dealing with an absolute URL, ensure the origins match
         if (absolute.origin !== origin) continue
@@ -87,7 +87,7 @@ export function getRouteContext(route: Path, url: URL): DocumentResolverContext 
         return {origin, params, path}
       }
     } catch (e) {
-      throw new Error(`"${route}" is not a valid route pattern`, {cause: e})
+      throw new Error(`"${currentRoute}" is not a valid route pattern`, {cause: e})
     }
   }
   return undefined

--- a/packages/sanity/src/router/IntentLink.test.tsx
+++ b/packages/sanity/src/router/IntentLink.test.tsx
@@ -13,7 +13,7 @@ vi.mock('./stickyParams', () => ({
 describe('IntentLink', () => {
   it('should resolve intent link with query params', () => {
     const router = route.create('/test', [route.intents('/intent')])
-    const component = render(
+    const view = render(
       <IntentLink
         intent="edit"
         params={{
@@ -31,14 +31,14 @@ describe('IntentLink', () => {
       },
     )
     // Component should render the query param in the href
-    expect(component.container.querySelector('a')?.href).toContain(
+    expect(view.container.querySelector('a')?.href).toContain(
       '/test/intent/edit/id=document-id-123;type=document-type/?aTestStickyParam=aStickyParam.value',
     )
   })
 
   it('should preserve sticky parameters when resolving intent link', () => {
     const router = route.create('/test', [route.intents('/intent')])
-    const component = render(
+    const view = render(
       <IntentLink
         intent="edit"
         params={{
@@ -61,14 +61,14 @@ describe('IntentLink', () => {
       },
     )
     // Component should render the query param in the href
-    expect(component.container.querySelector('a')?.href).toContain(
+    expect(view.container.querySelector('a')?.href).toContain(
       '/test/intent/edit/id=document-id-123;type=document-type/?aTestStickyParam=aStickyParam.value',
     )
   })
 
   it('should allow sticky parameters to be overridden when resolving intent link', () => {
     const router = route.create('/test', [route.intents('/intent')])
-    const component = render(
+    const view = render(
       <IntentLink
         intent="edit"
         params={{
@@ -92,10 +92,10 @@ describe('IntentLink', () => {
       },
     )
     // Component should render the query param in the href
-    expect(component.container.querySelector('a')?.href).toContain(
+    expect(view.container.querySelector('a')?.href).toContain(
       '/test/intent/edit/id=document-id-123;type=document-type/?aTestStickyParam=aStickyParam.value.to-be-defined',
     )
-    expect(component.container.querySelector('a')?.href).not.toContain(
+    expect(view.container.querySelector('a')?.href).not.toContain(
       'aTestStickyParam=aStickyParam.value.to-be-overridden',
     )
   })

--- a/packages/sanity/src/router/IntentLink.test.tsx
+++ b/packages/sanity/src/router/IntentLink.test.tsx
@@ -1,4 +1,4 @@
-import {render} from '@testing-library/react'
+import {render, screen} from '@testing-library/react'
 import noop from 'lodash-es/noop.js'
 import {describe, expect, it, vi} from 'vitest'
 
@@ -31,8 +31,11 @@ describe('IntentLink', () => {
       },
     )
     // Component should render the query param in the href
-    expect(view.container.querySelector('a')?.href).toContain(
-      '/test/intent/edit/id=document-id-123;type=document-type/?aTestStickyParam=aStickyParam.value',
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      expect.stringContaining(
+        '/test/intent/edit/id=document-id-123;type=document-type/?aTestStickyParam=aStickyParam.value',
+      ),
     )
   })
 
@@ -61,8 +64,11 @@ describe('IntentLink', () => {
       },
     )
     // Component should render the query param in the href
-    expect(view.container.querySelector('a')?.href).toContain(
-      '/test/intent/edit/id=document-id-123;type=document-type/?aTestStickyParam=aStickyParam.value',
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      expect.stringContaining(
+        '/test/intent/edit/id=document-id-123;type=document-type/?aTestStickyParam=aStickyParam.value',
+      ),
     )
   })
 
@@ -92,10 +98,14 @@ describe('IntentLink', () => {
       },
     )
     // Component should render the query param in the href
-    expect(view.container.querySelector('a')?.href).toContain(
-      '/test/intent/edit/id=document-id-123;type=document-type/?aTestStickyParam=aStickyParam.value.to-be-defined',
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute(
+      'href',
+      expect.stringContaining(
+        '/test/intent/edit/id=document-id-123;type=document-type/?aTestStickyParam=aStickyParam.value.to-be-defined',
+      ),
     )
-    expect(view.container.querySelector('a')?.href).not.toContain(
+    expect(link.getAttribute('href')).not.toContain(
       'aTestStickyParam=aStickyParam.value.to-be-overridden',
     )
   })

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -384,7 +384,9 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
                 )
               }
               selected
-              onClick={() => { /* intentionally empty */ }}
+              onClick={() => {
+                /* intentionally empty */
+              }}
               locked={false}
               tone={getReleaseTone(filteredReleases.inCreation!)}
               text={displayTitle}

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -384,9 +384,8 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
                 )
               }
               selected
-              onClick={() => {
-                /* intentionally empty */
-              }}
+              // eslint-disable-next-line no-empty-function
+              onClick={() => {}}
               locked={false}
               tone={getReleaseTone(filteredReleases.inCreation!)}
               text={displayTitle}

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -384,7 +384,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
                 )
               }
               selected
-              onClick={() => {}}
+              onClick={() => { /* intentionally empty */ }}
               locked={false}
               tone={getReleaseTone(filteredReleases.inCreation!)}
               text={displayTitle}

--- a/packages/sanity/src/structure/structureBuilder/util/__tests__/getExtendedProjection.test.ts
+++ b/packages/sanity/src/structure/structureBuilder/util/__tests__/getExtendedProjection.test.ts
@@ -175,9 +175,8 @@ describe('getExtendedProjection', () => {
   })
 
   test('ignores missing fields in non-strict mode while keeping valid paths', () => {
-    vi.spyOn(console, 'warn').mockImplementation(() => {
-      /* intentionally empty */
-    })
+    // eslint-disable-next-line no-empty-function
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
     const orderBy: SortOrderingItem[] = [
       {field: 'title', direction: 'asc'},
       {field: 'missingField', direction: 'asc'},

--- a/packages/sanity/src/structure/structureBuilder/util/__tests__/getExtendedProjection.test.ts
+++ b/packages/sanity/src/structure/structureBuilder/util/__tests__/getExtendedProjection.test.ts
@@ -175,7 +175,7 @@ describe('getExtendedProjection', () => {
   })
 
   test('ignores missing fields in non-strict mode while keeping valid paths', () => {
-    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => { /* intentionally empty */ })
     const orderBy: SortOrderingItem[] = [
       {field: 'title', direction: 'asc'},
       {field: 'missingField', direction: 'asc'},

--- a/packages/sanity/src/structure/structureBuilder/util/__tests__/getExtendedProjection.test.ts
+++ b/packages/sanity/src/structure/structureBuilder/util/__tests__/getExtendedProjection.test.ts
@@ -175,7 +175,9 @@ describe('getExtendedProjection', () => {
   })
 
   test('ignores missing fields in non-strict mode while keeping valid paths', () => {
-    vi.spyOn(console, 'warn').mockImplementation(() => { /* intentionally empty */ })
+    vi.spyOn(console, 'warn').mockImplementation(() => {
+      /* intentionally empty */
+    })
     const orderBy: SortOrderingItem[] = [
       {field: 'title', direction: 'asc'},
       {field: 'missingField', direction: 'asc'},

--- a/packages/sanity/src/ui-components/errorBoundary/__test__/ErrorBoundary.test.tsx
+++ b/packages/sanity/src/ui-components/errorBoundary/__test__/ErrorBoundary.test.tsx
@@ -16,9 +16,8 @@ describe('ErrorBoundary', () => {
 
   it('calls onUncaughtError when an error is caught', async () => {
     // React logs caught errors from error boundaries to console.error
-    vi.spyOn(console, 'error').mockImplementation(() => {
-      /* intentionally empty */
-    })
+    // eslint-disable-next-line no-empty-function
+    vi.spyOn(console, 'error').mockImplementation(() => {})
     const onUncaughtError = vi.fn()
     const onCatch = vi.fn()
 
@@ -51,9 +50,8 @@ describe('ErrorBoundary', () => {
 
   it('calls onCatch prop when an error is caught when no onUncaughtError exists', () => {
     // React logs caught errors from error boundaries to console.error
-    vi.spyOn(console, 'error').mockImplementation(() => {
-      /* intentionally empty */
-    })
+    // eslint-disable-next-line no-empty-function
+    vi.spyOn(console, 'error').mockImplementation(() => {})
     const onCatch = vi.fn()
 
     const WrapperWithoutError = ({children}: {children: React.ReactNode}) => {

--- a/packages/sanity/src/ui-components/errorBoundary/__test__/ErrorBoundary.test.tsx
+++ b/packages/sanity/src/ui-components/errorBoundary/__test__/ErrorBoundary.test.tsx
@@ -16,7 +16,9 @@ describe('ErrorBoundary', () => {
 
   it('calls onUncaughtError when an error is caught', async () => {
     // React logs caught errors from error boundaries to console.error
-    vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
+    vi.spyOn(console, 'error').mockImplementation(() => {
+      /* intentionally empty */
+    })
     const onUncaughtError = vi.fn()
     const onCatch = vi.fn()
 
@@ -49,7 +51,9 @@ describe('ErrorBoundary', () => {
 
   it('calls onCatch prop when an error is caught when no onUncaughtError exists', () => {
     // React logs caught errors from error boundaries to console.error
-    vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
+    vi.spyOn(console, 'error').mockImplementation(() => {
+      /* intentionally empty */
+    })
     const onCatch = vi.fn()
 
     const WrapperWithoutError = ({children}: {children: React.ReactNode}) => {

--- a/packages/sanity/src/ui-components/errorBoundary/__test__/ErrorBoundary.test.tsx
+++ b/packages/sanity/src/ui-components/errorBoundary/__test__/ErrorBoundary.test.tsx
@@ -16,7 +16,7 @@ describe('ErrorBoundary', () => {
 
   it('calls onUncaughtError when an error is caught', async () => {
     // React logs caught errors from error boundaries to console.error
-    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
     const onUncaughtError = vi.fn()
     const onCatch = vi.fn()
 
@@ -49,7 +49,7 @@ describe('ErrorBoundary', () => {
 
   it('calls onCatch prop when an error is caught when no onUncaughtError exists', () => {
     // React logs caught errors from error boundaries to console.error
-    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => { /* intentionally empty */ })
     const onCatch = vi.fn()
 
     const WrapperWithoutError = ({children}: {children: React.ReactNode}) => {

--- a/packages/sanity/test/descriptors/extractManifestToSchema.test.ts
+++ b/packages/sanity/test/descriptors/extractManifestToSchema.test.ts
@@ -539,19 +539,16 @@ describe('ManifestSchemaTypes[] converts to Schema', () => {
     const customization: any = {
       recursiveObject, // this one will be cut off at max-depth
       serializableProp: 'dummy',
-      nonSerializableProp: () => {
-        /* intentionally empty */
-      },
+      // eslint-disable-next-line no-empty-function
+      nonSerializableProp: () => {},
       options: {
         serializableOption: true,
-        nonSerializableOption: () => {
-          /* intentionally empty */
-        },
+        // eslint-disable-next-line no-empty-function
+        nonSerializableOption: () => {},
         nested: {
           serializableOption: 1,
-          nonSerializableOption: () => {
-            /* intentionally empty */
-          },
+          // eslint-disable-next-line no-empty-function
+          nonSerializableOption: () => {},
         },
       },
     }

--- a/packages/sanity/test/descriptors/extractManifestToSchema.test.ts
+++ b/packages/sanity/test/descriptors/extractManifestToSchema.test.ts
@@ -539,13 +539,13 @@ describe('ManifestSchemaTypes[] converts to Schema', () => {
     const customization: any = {
       recursiveObject, // this one will be cut off at max-depth
       serializableProp: 'dummy',
-      nonSerializableProp: () => {},
+      nonSerializableProp: () => { /* intentionally empty */ },
       options: {
         serializableOption: true,
-        nonSerializableOption: () => {},
+        nonSerializableOption: () => { /* intentionally empty */ },
         nested: {
           serializableOption: 1,
-          nonSerializableOption: () => {},
+          nonSerializableOption: () => { /* intentionally empty */ },
         },
       },
     }

--- a/packages/sanity/test/descriptors/extractManifestToSchema.test.ts
+++ b/packages/sanity/test/descriptors/extractManifestToSchema.test.ts
@@ -539,13 +539,19 @@ describe('ManifestSchemaTypes[] converts to Schema', () => {
     const customization: any = {
       recursiveObject, // this one will be cut off at max-depth
       serializableProp: 'dummy',
-      nonSerializableProp: () => { /* intentionally empty */ },
+      nonSerializableProp: () => {
+        /* intentionally empty */
+      },
       options: {
         serializableOption: true,
-        nonSerializableOption: () => { /* intentionally empty */ },
+        nonSerializableOption: () => {
+          /* intentionally empty */
+        },
         nested: {
           serializableOption: 1,
-          nonSerializableOption: () => { /* intentionally empty */ },
+          nonSerializableOption: () => {
+            /* intentionally empty */
+          },
         },
       },
     }

--- a/packages/sanity/test/descriptors/schema.test.tsx
+++ b/packages/sanity/test/descriptors/schema.test.tsx
@@ -351,7 +351,9 @@ describe('Base features', () => {
             name: 'foo',
             type: 'string',
             options: {
-              a: () => { /* intentionally empty */ },
+              a: () => {
+                /* intentionally empty */
+              },
             } as object,
           })
         ).typeDef,

--- a/packages/sanity/test/descriptors/schema.test.tsx
+++ b/packages/sanity/test/descriptors/schema.test.tsx
@@ -351,7 +351,7 @@ describe('Base features', () => {
             name: 'foo',
             type: 'string',
             options: {
-              a: () => {},
+              a: () => { /* intentionally empty */ },
             } as object,
           })
         ).typeDef,

--- a/packages/sanity/test/descriptors/schema.test.tsx
+++ b/packages/sanity/test/descriptors/schema.test.tsx
@@ -351,9 +351,8 @@ describe('Base features', () => {
             name: 'foo',
             type: 'string',
             options: {
-              a: () => {
-                /* intentionally empty */
-              },
+              // eslint-disable-next-line no-empty-function
+              a: () => {},
             } as object,
           })
         ).typeDef,

--- a/packages/sanity/test/validation/infer.test.ts
+++ b/packages/sanity/test/validation/infer.test.ts
@@ -150,7 +150,7 @@ describe('schema validation inference', () => {
     })
 
     test("gives error if media can't be found", async () => {
-      vi.spyOn(console, 'warn').mockImplementation(() => {})
+      vi.spyOn(console, 'warn').mockImplementation(() => { /* intentionally empty */ })
       client.fetch.mockImplementation(() => Promise.resolve(false))
 
       await expect(

--- a/packages/sanity/test/validation/infer.test.ts
+++ b/packages/sanity/test/validation/infer.test.ts
@@ -150,9 +150,8 @@ describe('schema validation inference', () => {
     })
 
     test("gives error if media can't be found", async () => {
-      vi.spyOn(console, 'warn').mockImplementation(() => {
-        /* intentionally empty */
-      })
+      // eslint-disable-next-line no-empty-function
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
       client.fetch.mockImplementation(() => Promise.resolve(false))
 
       await expect(

--- a/packages/sanity/test/validation/infer.test.ts
+++ b/packages/sanity/test/validation/infer.test.ts
@@ -150,7 +150,9 @@ describe('schema validation inference', () => {
     })
 
     test("gives error if media can't be found", async () => {
-      vi.spyOn(console, 'warn').mockImplementation(() => { /* intentionally empty */ })
+      vi.spyOn(console, 'warn').mockImplementation(() => {
+        /* intentionally empty */
+      })
       client.fetch.mockImplementation(() => Promise.resolve(false))
 
       await expect(


### PR DESCRIPTION
## Summary

This PR systematically fixes ESLint lint warnings across the monorepo.

**Result: 330 → 18 warnings (312 fixed, 95% reduction, 0 errors)**

---

### Batch 1: `no-empty-function` (45 warnings → 0) ✅
- Added `// eslint-disable-next-line no-empty-function` to suppress warnings on intentionally empty function bodies across 33 files
- No functional changes

### Batch 2: `render-result-naming-convention` + `no-param-reassign` (37 warnings → 0) ✅
- Renamed render result variables to `view` per testing-library convention across 12 files
  - `result`, `rendered`, `value`, `html`, `component`, `ret` → `view`
- Replaced parameter reassignment with local variables in 3 files
  - `resolveDeep.test.ts`: `depth` param → `currentDepth` local
  - `panels/util.ts`: `delta` param → `effectiveDelta` local
  - `useMainDocument.ts`: `route` param → `currentRoute` local
- No functional changes

### Batch 3: `testing-library/no-node-access` (211 warnings → 0) ✅
- Replaced direct DOM access with testing-library queries across 23+ test files
  - `container.querySelector()` → `screen.getByRole/getByTestId/getByText`
  - `.closest("button")` → `screen.getByRole("button", { name })`
  - `document.querySelector()` → `screen.getByTestId/getByRole`
  - `document.activeElement` checks → `toHaveFocus()` matcher
  - `.firstChild/.children/.parentNode` → `within().getBy*` queries
- Added eslint-disable for legitimate cases (hidden file inputs, SVGs, false positives)
- No functional changes

### Batch 4: Remaining testing-library rules (6 warnings → 0) ✅
- `prefer-query-by-disappearance`: use `queryBy*` instead of `getBy*` in `waitForElementToBeRemoved()` (4 warnings)
- `no-render-in-lifecycle`: move `render()` from `beforeEach` into individual tests (1 warning)
- `no-container`: eslint-disable for SVG with no accessible role (1 warning)
- No functional changes

---

## Remaining 18 warnings (not fixable in this PR)

### `complexity` — 9 warnings
Functions exceeding max cyclomatic complexity of 30. Would require significant logic refactoring with risk of introducing bugs.

| File | Function | Complexity |
|------|----------|------------|
| `src/core/field/types/image/diff/ImageFieldDiff.tsx` | arrow function (L23) | 34 |
| `src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx` | arrow function (L29) | 35 |
| `src/core/form/inputs/ReferenceInput/ReferenceInputPreview.tsx` | `ReferenceInputPreview` | 36 |
| `src/core/form/inputs/ReferenceInput/ReferenceItem.tsx` | `ReferenceItem` | 66 |
| `src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx` | `GridItem` | 33 |
| `src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx` | `PreviewItem` | 34 |
| `src/core/releases/tool/overview/ReleasesOverview.tsx` | `ReleasesOverview` | 41 |
| `src/core/studio/components/navbar/search/contexts/search/reducer.ts` | `searchReducer` | 33 |
| `src/structure/documentActions/PublishAction.tsx` | arrow function (L211) | 35 |

### `react-hooks/incompatible-library` — 7 warnings
TanStack Table / virtualization libraries return functions that can't be memoized safely by React Compiler. Not fixable in userland.

| File | Line |
|------|------|
| `src/core/components/commandList/CommandList.tsx` | 154 |
| `src/core/form/inputs/arrays/.../VirtualizedArrayList.tsx` | 191 |
| `src/core/releases/tool/components/Table/Table.tsx` | 107 |
| `src/core/releases/tool/detail/ReleaseActivityList.tsx` | 80 |
| `src/core/scheduled-publishing/tool/schedules/VirtualList.tsx` | 95 |
| `src/structure/panes/documentList/sheetList/DocumentSheetListPane.tsx` | 66 |
| `src/structure/panes/documentList/sheetList/__tests__/ColumnsControl.test.tsx` | 25 |

### `react-hooks/todo` — 2 warnings
React compiler doesn't yet support `UpdateExpression` on globals (`syncRenders++`). Awaiting compiler support.

| File | Lines |
|------|-------|
| `src/core/util/__tests__/createHookFromObservableFactory.test.tsx` | 106, 111 |

### `class-methods-use-this` — 1 warning
Base class `validate()` method that throws "must be implemented by extending class". Using `this` would be incorrect here — it's an intentional design pattern.

| File | Line |
|------|------|
| `packages/@sanity/schema/src/legacy/Rule.ts` | 355 |