### PR TITLE
fix(form): pass selectedAssets to asset sources

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/__tests__/assetSourceIntegration.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/__tests__/assetSourceIntegration.test.tsx
@@ -3,6 +3,7 @@
  * Tests the shared asset source behavior: upload flow, browse flow, empty state, no sources fallback.
  */
 import {createImageUrlBuilder} from '@sanity/image-url'
+import {type AssetSource} from '@sanity/types'
 import {screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
 import {describe, expect, it, vi} from 'vitest'
@@ -15,6 +16,7 @@ import {
 } from '../../../../../../test/fixtures/assetSourceMocks'
 import {renderFileInput, renderImageInput, renderVideoInput} from '../../../../../../test/form'
 import {BaseVideoInput} from '../../../../../media-library/plugin/VideoInput/VideoInput'
+import {MediaLibraryUploader} from '../../../studio/assetSourceMediaLibrary/uploader'
 import {getDataTestIdPrefix} from '../common/AssetSourceBrowser'
 import {BaseFileInput} from '../FileInput'
 import {BaseImageInput} from '../ImageInput'
@@ -538,6 +540,49 @@ describe.each(BROWSE_AFTER_UPLOAD_CONFIGS)(
         {timeout: 5000},
       )
       expect(screen.getByTestId('mock-upload-component')).toHaveTextContent('Open in Source')
+    }, 15000)
+
+    it('passes selectedAssets when opened via browse with existing value', async () => {
+      const SelectedAssetsTestSource: AssetSource = {
+        name: 'media-library-mock',
+        title: 'Test',
+        component: (props) => (
+          <div
+            data-testid="selected-assets-test"
+            data-selected-assets-count={props.selectedAssets.length}
+          />
+        ),
+        Uploader: MediaLibraryUploader,
+      }
+
+      const baseOptions = {
+        assetSources: [SelectedAssetsTestSource],
+        fieldDefinition,
+        observeAsset: observeAsset as any,
+        props: {documentValue},
+        render: (inputProps: any) => <BaseInput {...(inputProps as any)} />,
+      }
+      const renderOptions =
+        imageUrlBuilder !== undefined ? {...baseOptions, imageUrlBuilder} : baseOptions
+
+      await renderFn(renderOptions as any)
+
+      const optionsButton = await screen.findByTestId('options-menu-button', {}, {timeout: 5000})
+      await userEvent.click(optionsButton)
+      const browseButton = await screen.findByTestId(
+        getBrowseTestIdForConfig(),
+        {},
+        {timeout: 5000},
+      )
+      await userEvent.click(browseButton)
+
+      await waitFor(
+        () => {
+          const el = screen.getByTestId('selected-assets-test')
+          expect(el).toHaveAttribute('data-selected-assets-count', '1')
+        },
+        {timeout: 5000},
+      )
     }, 15000)
 
     it('disables browse and clear when readOnly', async () => {

--- a/packages/sanity/src/core/form/inputs/files/common/AssetSourceDialog.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/AssetSourceDialog.tsx
@@ -139,10 +139,10 @@ export function AssetSourceDialog<
     [Component, commonProps],
   )
 
-  // When action is 'select', we're opening the picker to choose a new asset. Skip loading the
-  // current asset—many asset sources (e.g. Media Library) don't need it, and media-library refs
-  // can't be observed via documentPreviewStore, so loading would hang on the skeleton.
-  if (value?.asset && observeAsset && action !== 'select') {
+  // Load the current asset when the field has a value, so asset sources receive it in
+  // selectedAssets. Note: media-library refs may not resolve via documentPreviewStore
+  // (observeVideoAsset handles them; observeImageAsset/observeFileAsset use the dataset).
+  if (value?.asset && observeAsset) {
     return (
       <WithReferencedAsset
         observeAsset={observeAsset}


### PR DESCRIPTION
### Description

Restores the behavior where asset sources receive the current asset in `selectedAssets` when opened via the browse flow, even when the field already has a value. This fixes a regression introduced in a previous refactor that broke plugins, such as image annotation tools.

#### Problem

After upgrading from Sanity 5.10 to 5.17.1, custom asset sources (e.g., image annotation plugins) stopped receiving the selected asset in `selectedAssets` when opened via the default browse/select flow. The array was always `[]` even when the image field had an existing asset.

A refactor had added logic to skip loading the current asset when `action === 'select'`, passing `selectedAssets={[]}` instead. This was intended to avoid loading media-library refs that cannot be observed via `documentPreviewStore`, but it broke asset sources that need the current asset in select mode.

#### Solution

Revert to always loading the asset when the field has a value (`value?.asset`), regardless of action. This matches the pre-refactor behavior and ensures asset sources receive the current asset in `selectedAssets` when opened via browse.

#### Changes

- **`AssetSourceDialog.tsx`**: Remove the `action !== 'select'` condition so the asset is loaded whenever `value?.asset` and `observeAsset` are present.
- **`assetSourceIntegration.test.tsx`**: Add a test that verifies `selectedAssets` is passed when opening via browse with an existing field value (file, image, and video inputs).

#### Note

For image and file, the asset ref is always a dataset document ID (sanity.imageAsset / sanity.fileAsset), so observeImageAsset and observeFileAsset work as expected. Only video uses media-library refs for asset, and observeVideoAsset already handles those (compatibility was added as part of a later step in the mentioned refactor).

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That the changes look right and will fix the reported problem.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
I have added an integration test for this.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
* Restores the behavior where asset sources receive the current asset in `selectedAssets` when opened via the browse flow, even when the field already has a value.

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
