### PR TITLE
fix(core): prevent PointerOverlayDiv from blocking clicks on initial render in CommandList

### DIFF
--- a/packages/sanity/src/core/components/commandList/CommandList.tsx
+++ b/packages/sanity/src/core/components/commandList/CommandList.tsx
@@ -573,7 +573,7 @@ const CommandListComponent = forwardRef<CommandListHandle, CommandListProps>(fun
       {...responsivePaddingProps}
     >
       {canReceiveFocus && <FocusOverlayDiv offset={focusRingOffset} />}
-      <PointerOverlayDiv aria-hidden="true" data-enabled ref={setPointerOverlayElement} />
+      <PointerOverlayDiv aria-hidden="true" data-enabled="false" ref={setPointerOverlayElement} />
       {virtualizer && (
         <VirtualListChildBox
           forwardedAs="ul"


### PR DESCRIPTION
### Description

This PR fixes an issue where the `PointerOverlayDiv` in `CommandList` could block clicks on document list items when the component first renders.

Previously, the overlay was initialized with `data-enabled="true"`, causing it to cover the entire list and intercept pointer events. If the user's cursor was already positioned over the list during render, the `mouseenter` event would not fire, leaving the overlay active and preventing interaction.

This change initializes the overlay with `data-enabled="false"` so that it does not block pointer events by default. The existing logic continues to toggle the overlay as needed during keyboard navigation.

Fixes: #12323

---

### What to review

* Verify that list items are clickable immediately after render
* Ensure that the overlay no longer blocks pointer events on initial load
* Confirm that keyboard navigation still correctly toggles the overlay behavior

---

### Testing

No automated tests were added.

This change was verified logically:

* The overlay is now disabled by default, preventing it from intercepting pointer events on mount
* Existing event handlers (`enableChildContainerPointerEvents`) continue to manage overlay state during interaction

---

### Notes for release

Fixes an issue where document list items in `CommandList` were not clickable on initial render if the mouse was already positioned over the list.
