### PR TITLE
ci: fixing issue with older issues not being detected on auto-close stale issue workflow

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -27,9 +27,6 @@ jobs:
           enable-statistics: true
           only-issue-labels: "needs-more-info"
 
-          # Prevents backlog processing
-          start-date: "2026-01-29T00:00:00Z"
-
           # 10 days inactive → warning, then 4 more days → closure (14 days total)
           days-before-stale: 10
           days-before-close: 4


### PR DESCRIPTION
### Description
The `start-date` parameter in the stale issues workflow was filtering by issue creation date, which permanently excluded any issue created before January 29, 2026 from stale processing. This meant older `needs-more-info` issues were never warned or closed, regardless of how long they'd been inactive. Removing `start-date` allows the workflow to evaluate all `needs-more-info` issues based on their last activity date.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Have simulated and verified that this has resolved the problem.
Have also manually replicated the steps of this workflow on the stale issues that currently existed and were missed.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
