### PR TITLE
fix(validation): allow relative URLs when scheme excludes http

### DIFF
--- a/dev/test-studio/schema/standard/urls.ts
+++ b/dev/test-studio/schema/standard/urls.ts
@@ -26,5 +26,19 @@ export default defineType({
       description: 'A relative URL field',
       validation: (Rule) => Rule.uri({allowRelative: true}),
     },
+    {
+      name: 'httpsOnlyRelative',
+      type: 'url',
+      title: 'HTTPS-only, relative allowed',
+      description: 'Accepts https URLs and relative paths like /example',
+      validation: (Rule) => Rule.uri({scheme: ['https'], allowRelative: true}),
+    },
+    {
+      name: 'httpAndHttpsRelative',
+      type: 'url',
+      title: 'HTTP/HTTPS, relative allowed',
+      description: 'Accepts http and https URLs and relative paths',
+      validation: (Rule) => Rule.uri({scheme: ['http', 'https'], allowRelative: true}),
+    },
   ],
 })

--- a/packages/sanity/src/core/validation/validators/stringValidator.ts
+++ b/packages/sanity/src/core/validation/validators/stringValidator.ts
@@ -67,7 +67,9 @@ export const stringValidators: Validators = {
     }
 
     const urlScheme = url.protocol.replace(/:$/, '')
-    const matchesAllowedScheme = options.scheme.some((scheme) => scheme.test(urlScheme))
+    const isRelative = isRelativeUrl(strValue)
+    const matchesAllowedScheme =
+      isRelative || options.scheme.some((scheme) => scheme.test(urlScheme))
     if (!matchesAllowedScheme) {
       return message || i18n.t('validation:string.url.disallowed-scheme', {scheme: urlScheme})
     }

--- a/packages/sanity/test/validation/__snapshots__/strings.test.ts.snap
+++ b/packages/sanity/test/validation/__snapshots__/strings.test.ts.snap
@@ -309,6 +309,20 @@ exports[`string > uppercase constraint > uppercase: some lowercase 2`] = `
 
 exports[`string > uppercase constraint > uppercase: valid 1`] = `[]`;
 
+exports[`string > uri constraint (allowRelative with restrictive scheme) > uri: absolute URL still rejects disallowed scheme 1`] = `
+[
+  {
+    "__internal_metadata": undefined,
+    "item": {
+      "message": "Does not match allowed protocols/schemes",
+    },
+    "level": "error",
+    "message": "Does not match allowed protocols/schemes",
+    "path": [],
+  },
+]
+`;
+
 exports[`string > uri constraint (credentials) > uri: credentials specified but not allowed 1`] = `
 [
   {

--- a/packages/sanity/test/validation/strings.test.ts
+++ b/packages/sanity/test/validation/strings.test.ts
@@ -146,6 +146,15 @@ describe('string', () => {
     )
   })
 
+  test('uri constraint (allowRelative with restrictive scheme)', async () => {
+    const rule = Rule.string().uri({scheme: ['https'], allowRelative: true})
+    await expect(rule.validate('/example', context)).resolves.toHaveLength(0)
+    await expect(rule.validate('https://example.com', context)).resolves.toHaveLength(0)
+    await expect(rule.validate('http://example.com', context)).resolves.toMatchSnapshot(
+      'uri: absolute URL still rejects disallowed scheme',
+    )
+  })
+
   test('custom rule with string', async () => {
     const rule = Rule.string().custom<string>((val) =>
       val.split('').reverse().join('') === val ? true : 'Must be a palindrome!',


### PR DESCRIPTION
### Description
Relative URLs like `/example` were rejected when `allowRelative: true` was combined with a scheme list that excluded `http`, because the validator checked the scheme of an internal dummy origin used to parse relative paths. The fix skips the scheme check for relative URLs, which have no scheme of their own.

Closes https://github.com/sanity-io/sanity/issues/7559
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Added new field to the test-studio inside URL fields schema
Updated existing unit tests
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixed `allowRelative: true` being ignored when the scheme list excludes `http` ([github issue 7559](https://github.com/sanity-io/sanity/issues/7559))
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
