### PR TITLE
fix(core): fix false positive Node.js runtime detection in Next.js

### DIFF
--- a/packages/sanity/src/core/util/supportsLocalStorage.ts
+++ b/packages/sanity/src/core/util/supportsLocalStorage.ts
@@ -11,7 +11,13 @@ export const supportsLocalStorage = (() => {
   // bail out in non-browser environments — even if browser globals have been
   // mocked (e.g., jsdom in CLI commands/tests). `process.versions` is set by
   // all major server-side runtimes and is not faked by jsdom.
-  if (typeof process !== 'undefined' && typeof process.versions !== 'undefined') {
+  // Note that `process.versions` may also be defined by frameworks.
+  // E.g. Next.js/Turbopack polyfills it and sets it to an empty object
+  if (
+    typeof process !== 'undefined' &&
+    typeof process.versions !== 'undefined' &&
+    typeof process.versions.node !== 'undefined'
+  ) {
     return false
   }
 


### PR DESCRIPTION
### Description

Turns out the Node.js runtime detection added in #12350 give false positive in Next.js, which polyfills `process.versions` to an empty object. This caused us to return `supportsLocalStorage: false` in Next.js, which again caused token to be persisted in memory instead of localStorage.

Fixes #12431

### Testing
- Upgrade to preview release in a Next.js app that embeds the studio, verify that logging in persists the token in localstorage.

### Notes for release
- Fixes issue causing authentication to not persist between page reloads in Next.js
