### PR TITLE
chore(ci): add summary status jobs to simplify required checks

### DIFF
--- a/.github/workflows/e2e-ct.yml
+++ b/.github/workflows/e2e-ct.yml
@@ -49,7 +49,6 @@ jobs:
       fail-fast: false
       matrix:
         project: [chromium, firefox]
-        # Add more shards here if needed, but remember that the github required checks will have to be updated as well
         shardIndex: [1, 2]
         shardTotal: [2]
     steps:
@@ -96,6 +95,19 @@ jobs:
           name: playwright-ct-report-${{ matrix.project }}-${{ matrix.shardIndex }}
           path: ${{ github.workspace }}/packages/sanity/blob-report
           retention-days: 30
+
+  e2e-ct-status:
+    name: "E2E CT Status"
+    runs-on: ubuntu-latest
+    needs: [playwright-ct-test]
+    if: always()
+    steps:
+      - name: Check E2E CT test matrix status
+        run: |
+          if [ "${{ needs.playwright-ct-test.result }}" != "success" ]; then
+            echo "E2E CT test matrix failed with status: ${{ needs.playwright-ct-test.result }}"
+            exit 1
+          fi
 
   merge-reports:
     if: always() && needs.install.outputs.examples_only != 'true'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -218,9 +218,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Be sure to update all instances in this file if updated, as well as github required checks
         project: [chromium, firefox]
-        # Add more shards here if needed, but remember that the github required checks will have to be updated as well
         shardIndex: [1, 2, 3, 4]
         shardTotal: [4]
     steps:
@@ -268,6 +266,19 @@ jobs:
             e2e/blob-report
             e2e/results
           retention-days: 30
+
+  e2e-status:
+    name: "E2E Status"
+    runs-on: ubuntu-latest
+    needs: [playwright-test]
+    if: always()
+    steps:
+      - name: Check E2E test matrix status
+        run: |
+          if [ "${{ needs.playwright-test.result }}" != "success" ]; then
+            echo "E2E test matrix failed with status: ${{ needs.playwright-test.result }}"
+            exit 1
+          fi
 
   merge-reports:
     if: always() && needs.install.outputs.examples_only != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,19 @@ jobs:
           include-hidden-files: true
           retention-days: 1
 
+  test-status:
+    name: "Test Status"
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: always()
+    steps:
+      - name: Check test matrix status
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "Test matrix failed with status: ${{ needs.test.result }}"
+            exit 1
+          fi
+
   report-coverage:
     if: ${{ !cancelled() }}
     needs: test


### PR DESCRIPTION
### Description
Add test-status, e2e-status, and e2e-ct-status jobs that aggregate matrix results into a single pass/fail check, so branch protection doesn't need updating when shards or node versions change.

### What to review
Makes sense?

### Testing

Will update required checks after merge.

### Notes for release
n/a