### PR TITLE
fix(core): getDocumentAtRevision prefer revision match

### DIFF
--- a/packages/sanity/src/core/store/_legacy/history/createHistoryStore.ts
+++ b/packages/sanity/src/core/store/_legacy/history/createHistoryStore.ts
@@ -122,6 +122,12 @@ const getDocumentAtRevision = (
       const draft = documents.find((res) => res._id === draftId)
       const version = versionId ? documents.find((res) => res._id === versionId) : undefined
 
+      if (revision !== 'lastRevision') {
+        if (version?._rev === revision) return version
+        if (draft?._rev === revision) return draft
+        if (published?._rev === revision) return published
+        return undefined
+      }
       return version || draft || published
     })
 


### PR DESCRIPTION
### Description
There is a strange behavior in the history endpoint when querying documents using revision and multiple documents entries.
For example; using this query  `https://ppsg7ml5.api.sanity.io/v2025-02-19/data/history/test/documents/a7a480fd-0fcb-4ebd-84dd-f9f3c735610e,drafts.a7a480fd-0fcb-4ebd-84dd-f9f3c735610e?revision=RLq6k8oF20GXGuS7SHHxTV&tag=sanity.studio.history-revision` we get two documents with different revision from it. A published and a draft.
The draft document should not be returned by CL and I opened a request to get that fixed.

In the meantime, we can fix this behavior in the studio by checking which documents we are getting back from the history endpoint and instead of just checking the existence of it, we check if the document revision matches with what we specified.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
fixes an issue restoring published documents from the history endpoint created by publishing releases.
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
