### PR TITLE
fix(auth): workaround Next.js replaceState bug

### DIFF
--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -13,7 +13,7 @@ import {DEFAULT_STUDIO_CLIENT_HEADERS} from '../../../studioClient'
 import {CorsOriginError} from '../cors'
 import {createBroadcastChannel} from './createBroadcastChannel'
 import {createLoginComponent} from './createLoginComponent'
-import {getSessionId} from './sessionId'
+import {clearSessionId, getSessionId} from './sessionId'
 import * as storage from './storage'
 import {type AuthState, type AuthStore} from './types'
 import {isCookielessCompatibleLoginMethod} from './utils/asserters'
@@ -240,6 +240,8 @@ export function _createAuthStore({
 
   async function handleCallbackUrl() {
     const sessionId = getSessionId()
+    // workaround for https://github.com/vercel/next.js/issues/91819
+    clearSessionId()
 
     if (!sessionId) {
       broadcast(loginMethod === 'cookie' ? null : getToken(projectId))

--- a/packages/sanity/src/core/store/_legacy/authStore/sessionId.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/sessionId.ts
@@ -26,6 +26,14 @@ function consumeSessionId(): string | null {
   return sidParam
 }
 
+/**
+ * Provides a workaround for https://github.com/vercel/next.js/issues/91819
+ * Can be removed once that's fixed
+ */
+export function clearSessionId(): void {
+  consumeSessionId()
+}
+
 // this module consumes the session ID as a side-effect as soon as its loaded
 // to remove the session ID from the history (vs waiting to remove the sid hash
 // until react mounts). Once it is consumed and loaded once, we don't want to


### PR DESCRIPTION
### Description
Adds a workaround for https://github.com/vercel/next.js/issues/91819

Closes #12431

### What to review
The workaround simply (re)consumes the sid hash parameter in the auth callback url, re-issues the replaceState call which removes the sid again. Instead of exporting `consumeSessionId()` I'm calling it from a dedicated export that we can delete if/when the upstream issue is fixed.

### Testing
- I've tested and verified that it works for an embedded Studios in Next.js 16.2 with `auth.loginMethod: 'token'`

### Notes for release
Adds a workaround for a bug in Next.js that could in some cases result in an error saying `Session with sid (…) not found`