### PR TITLE
chore(e2e): fix test timeouts and remove unnecessary test.slow() calls

### DIFF
--- a/e2e/helpers/documentStatusAssertions.ts
+++ b/e2e/helpers/documentStatusAssertions.ts
@@ -22,7 +22,7 @@ interface DocumentStatusOptions {
 }
 
 const DEFAULT_OPTIONS: DocumentStatusOptions = {
-  timeout: 60_000,
+  timeout: 30_000,
   useInnerText: true,
 }
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -82,7 +82,7 @@ const playwrightConfig: PlaywrightTestConfig = {
   testDir: TESTS_PATH,
 
   /* Maximum time one test can run for. */
-  timeout: 30 * 1000,
+  timeout: 60_000,
 
   fullyParallel: true,
 
@@ -91,12 +91,12 @@ const playwrightConfig: PlaywrightTestConfig = {
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 1000 * 60 * 5,
+    timeout: 30_000,
   },
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */
   outputDir: ARTIFACT_OUTPUT_PATH,
 
-  retries: 1,
+  retries: 2,
   reporter: excludeGithub([['list'], ['blob']]),
   use: {
     actionTimeout: 10000,

--- a/e2e/tests/default-layout/versionStatus.spec.ts
+++ b/e2e/tests/default-layout/versionStatus.spec.ts
@@ -15,7 +15,6 @@ test.describe('auto-updating studio behavior', () => {
       browserName === 'firefox',
       'Firefox has timing issues with dynamically injected import maps',
     )
-    test.slow()
 
     // Set up route interception BEFORE navigating so all requests are caught
     await page.route('https://sanity-cdn.**/v1/modules/sanity/latest/**', (route) => {

--- a/e2e/tests/desk/documentList.spec.ts
+++ b/e2e/tests/desk/documentList.spec.ts
@@ -15,7 +15,6 @@ test(`navigating document creates only one listener connection`, async ({page, b
   // For now, only test in other browsers except firefox due to flakiness in Firefox with the requests
   test.skip(browserName === 'firefox')
 
-  test.slow()
   await page.goto('/content')
 
   let authorListenersCount = 0

--- a/e2e/tests/desk/documentTypeListContextMenu.spec.ts
+++ b/e2e/tests/desk/documentTypeListContextMenu.spec.ts
@@ -116,7 +116,6 @@ test('clicking custom sort order and direction sets value in storage', async ({
 test('clicking list view sets value in storage', async ({page, sanityClient, browserName}) => {
   // For now, only test in Chromium due to flakiness in Firefox and WebKit
   test.skip(browserName !== 'chromium')
-  test.slow()
 
   await page.goto('/content/author')
 

--- a/e2e/tests/document-actions/delete.spec.ts
+++ b/e2e/tests/document-actions/delete.spec.ts
@@ -44,7 +44,6 @@ test(`deleted document shows the right name from last revision`, async ({
   page,
   createDraftDocument,
 }) => {
-  test.slow()
   const documentName = 'John Doe'
   const publishButton = page.getByTestId('action-publish')
   const paneFooter = page.getByTestId('pane-footer-document-status')

--- a/e2e/tests/document-actions/publish.spec.ts
+++ b/e2e/tests/document-actions/publish.spec.ts
@@ -9,7 +9,6 @@ test(`document panel displays correct title for published document`, async ({
   page,
   createDraftDocument,
 }) => {
-  test.slow()
   const title = 'Test Title'
 
   await createDraftDocument('/content/book')

--- a/e2e/tests/enhanced-object-dialog/breadcrumbNavigation.spec.ts
+++ b/e2e/tests/enhanced-object-dialog/breadcrumbNavigation.spec.ts
@@ -5,7 +5,6 @@ import {test} from '../../studio-test'
 test.describe('Enhanced Object Dialog - breadcrumb navigation', () => {
   test.beforeEach(async ({createDraftDocument, page, browserName}) => {
     test.skip(browserName === 'firefox')
-    test.slow()
 
     await createDraftDocument('/content/input-debug;objectsDebug')
 

--- a/e2e/tests/enhanced-object-dialog/closeAndReopen.spec.ts
+++ b/e2e/tests/enhanced-object-dialog/closeAndReopen.spec.ts
@@ -5,7 +5,6 @@ import {test} from '../../studio-test'
 test.describe('Enhanced Object Dialog - close and reopen', () => {
   test.beforeEach(async ({createDraftDocument, page, browserName}) => {
     test.skip(browserName === 'firefox')
-    test.slow()
 
     await createDraftDocument('/content/input-debug;objectsDebug')
 

--- a/e2e/tests/enhanced-object-dialog/componentItemSmoke.spec.ts
+++ b/e2e/tests/enhanced-object-dialog/componentItemSmoke.spec.ts
@@ -6,7 +6,6 @@ test.describe('Enhanced Object Dialog - schema with component item and input smo
   test.beforeEach(async ({createDraftDocument}) => {
     // wait for form to be attached
     await createDraftDocument('/content/input-debug;objectsDebug')
-    test.slow()
   })
 
   test(`opening - when creating new item with custom components.item, the modal should open`, async ({

--- a/e2e/tests/enhanced-object-dialog/smoke.spec.ts
+++ b/e2e/tests/enhanced-object-dialog/smoke.spec.ts
@@ -40,7 +40,6 @@ test.describe('Enhanced Object Dialog - open and close', () => {
 test.describe('Enhanced Object Dialog - nested open and close via breadcrumb root', () => {
   test.beforeEach(async ({createDraftDocument, page, browserName}) => {
     test.skip(browserName === 'firefox')
-    test.slow()
 
     await createDraftDocument('/content/input-debug;objectsDebug')
 
@@ -84,7 +83,6 @@ test.describe('Enhanced Object Dialog - when tab focusing on an array item', () 
   test.beforeEach(async ({createDraftDocument, page, browserName}) => {
     // Skip Firefox due to flakiness with click/fill interactions
     test.skip(browserName === 'firefox')
-    test.slow()
 
     // wait for form to be attached
     await createDraftDocument('/content/input-debug;objectsDebug')
@@ -122,7 +120,6 @@ test.describe('Enhanced Object Dialog - when tab focusing on an array item', () 
   test(`When pressing enter on an array item, the tree editing modal should open`, async ({
     page,
   }) => {
-    test.slow()
     // Focus the array item directly rather than relying on Tab order
     await page
       .getByTestId('field-animals')

--- a/e2e/tests/expanded-document/expanded.spec.ts
+++ b/e2e/tests/expanded-document/expanded.spec.ts
@@ -4,7 +4,6 @@ import {test} from '../../studio-test'
 
 test.describe('maximized document', () => {
   test.beforeEach(async ({page, createDraftDocument}) => {
-    test.slow()
     await createDraftDocument('/content/input-standard;referenceTest')
 
     await expect(page.getByTestId('focus-pane-button-focus')).toBeVisible()
@@ -38,8 +37,6 @@ test.describe('maximized document', () => {
   })
 
   test('navigation to referenced document works when document is maximized', async ({page}) => {
-    test.slow()
-
     await page.getByTestId('focus-pane-button-focus').click()
 
     await expect(page.locator('#selfOrEmpty-selectTypeMenuButton')).toBeVisible()
@@ -73,8 +70,6 @@ test.describe('maximized document', () => {
   })
 
   test('pane focuses on the middle pane, will close references to the right', async ({page}) => {
-    test.slow()
-
     // set first reference
     await expect(page.locator('#selfOrEmpty-selectTypeMenuButton')).toBeVisible()
     await page.locator('#selfOrEmpty-selectTypeMenuButton').click()

--- a/e2e/tests/inputs/array.spec.ts
+++ b/e2e/tests/inputs/array.spec.ts
@@ -16,8 +16,6 @@ test(`file drop event should not propagate to dialog parent`, async ({
   page,
   createDraftDocument,
 }) => {
-  test.slow()
-
   await createDraftDocument('/content/input-standard;arraysTest')
 
   await expect(page.getByTestId('document-panel-scroller')).toBeAttached({
@@ -70,7 +68,6 @@ test(`file drop event should not propagate to dialog parent`, async ({
 })
 
 test(`Scenario: Adding a new type from multiple options`, async ({page, createDraftDocument}) => {
-  test.slow()
   await createDraftDocument('/content/input-standard;arraysTest')
 
   await expect(page.getByTestId('document-panel-scroller')).toBeAttached({
@@ -120,8 +117,6 @@ test(`Scenario: Adding new array item before using the context menu`, async ({
   page,
   createDraftDocument,
 }) => {
-  test.slow()
-
   const {popoverMenu, popoverMenuItem, insertDialog, input, closeDialogButton, items} =
     createArrayFieldLocators(page)
 
@@ -176,7 +171,6 @@ test(`Scenario: Adding new array item after using the context menu`, async ({
   page,
   createDraftDocument,
 }) => {
-  test.slow()
   const {popoverMenu, popoverMenuItem, insertDialog, input, closeDialogButton, items} =
     createArrayFieldLocators(page)
 

--- a/e2e/tests/inputs/revertArrayChanges.spec.ts
+++ b/e2e/tests/inputs/revertArrayChanges.spec.ts
@@ -8,7 +8,6 @@ test.describe('Array revert changes', () => {
     page,
     createDraftDocument,
   }) => {
-    test.slow()
     // Create a draft document
     await createDraftDocument('/content/input-standard;arraysTest')
 

--- a/e2e/tests/navbar/search.spec.ts
+++ b/e2e/tests/navbar/search.spec.ts
@@ -8,8 +8,6 @@ test('searching creates unique saved searches', async ({
   createDraftDocument,
   sanityClient,
 }) => {
-  test.slow()
-
   const dataset = sanityClient.config().dataset
   await createDraftDocument('/content/book')
 

--- a/e2e/tests/plugins/media.spec.ts
+++ b/e2e/tests/plugins/media.spec.ts
@@ -4,7 +4,6 @@ import {retryingClickUntilVisible} from '../../helpers/retryingClick'
 import {test} from '../../studio-test'
 
 test('media plugin should open from input', async ({page, createDraftDocument}) => {
-  test.slow()
   await createDraftDocument('/content/input-standard;imagesTest')
 
   // wait for input to be visible (nth(1) = mainImage, first image field in imagesTest schema)
@@ -27,7 +26,6 @@ test('media plugin should open from input', async ({page, createDraftDocument}) 
 })
 
 test('open media plugin from navbar', async ({page}) => {
-  test.slow()
   await page.goto('/')
   await expect(page.getByTestId('parent-config-studio-tool-menu')).toBeVisible()
 

--- a/e2e/tests/presentation/presentation.spec.ts
+++ b/e2e/tests/presentation/presentation.spec.ts
@@ -4,15 +4,12 @@ import {test} from '../../studio-test'
 
 test.describe('Presentation', () => {
   test.beforeEach(async ({page}) => {
-    test.slow()
-
     await page.goto('/presentation')
     // Wait for presentation to be visible
     await expect(page.getByTestId('presentation-root')).toBeVisible()
   })
 
   test('should be able to load a simple preview', async ({page}) => {
-    test.slow()
     const root = page.getByTestId('presentation-root')
     await expect(root).toBeVisible()
     const previewIframe = root.locator('iframe')
@@ -30,7 +27,6 @@ test.describe('Presentation', () => {
   test('should be able to toggle preview viewport', async ({page, browserName}) => {
     // For now, only test in other browsers except firefox due to flakiness in Firefox with the requests
     test.skip(browserName === 'firefox')
-    test.slow()
 
     const root = page.getByTestId('presentation-root')
     const previewIframe = root.locator('iframe')

--- a/e2e/tests/pte/FullScreenBackwardsSelect.spec.ts
+++ b/e2e/tests/pte/FullScreenBackwardsSelect.spec.ts
@@ -7,7 +7,6 @@ import {test} from '../../studio-test'
 test.skip('Portable Text Input - Fullscreen Backwards Select', () => {
   test.beforeEach(async ({page, createDraftDocument, browserName}) => {
     test.skip(browserName === 'firefox')
-    test.slow()
     await createDraftDocument('/content/input-standard;portable-text;pt_allTheBellsAndWhistles')
 
     const pteEditor = page.getByTestId('field-text')
@@ -55,7 +54,6 @@ test.skip('Portable Text Input - Fullscreen Backwards Select', () => {
     browserName,
   }) => {
     test.skip(browserName === 'firefox')
-    test.slow()
 
     const portal = page.getByTestId('document-panel-portal')
 

--- a/e2e/tests/pte/FullScreenEscape.spec.ts
+++ b/e2e/tests/pte/FullScreenEscape.spec.ts
@@ -4,7 +4,6 @@ import {test} from '../../studio-test'
 
 test.describe('Portable Text Input - FullScreen Escape', () => {
   test.beforeEach(async ({page, createDraftDocument}) => {
-    test.slow()
     await createDraftDocument('/content/input-standard;portable-text;pt_allTheBellsAndWhistles')
 
     const pteEditor = page.getByTestId('field-text')
@@ -28,8 +27,6 @@ test.describe('Portable Text Input - FullScreen Escape', () => {
   })
 
   test('you should be able to use scape to close full screen mode', async ({page}) => {
-    test.slow()
-
     // Escape should close the fullscreen mode
     await page.keyboard.press('Escape')
     await expect(
@@ -41,7 +38,6 @@ test.describe('Portable Text Input - FullScreen Escape', () => {
     page,
     browserName,
   }) => {
-    test.slow()
     test.skip(browserName === 'firefox')
 
     await page.getByTestId('document-panel-portal').getByRole('textbox').click()

--- a/e2e/tests/pte/InitialFullScreen.spec.ts
+++ b/e2e/tests/pte/InitialFullScreen.spec.ts
@@ -11,7 +11,6 @@ test.describe('Initial full screen', () => {
     await createDraftDocument('/content/input-standard;portable-text;initialFullScreenPTE')
 
     test.skip(browserName === 'firefox')
-    test.slow()
     await expect(page.getByTestId('fullscreen-button-collapse')).toBeVisible()
     await page.getByTestId('fullscreen-button-collapse').click()
     await expect(

--- a/e2e/tests/pte/referencesInPopover.spec.ts
+++ b/e2e/tests/pte/referencesInPopover.spec.ts
@@ -5,7 +5,6 @@ import {test} from '../../studio-test'
 test.describe('In PTE - references in popover', () => {
   test.beforeEach(async ({page, createDraftDocument, browserName}, testInfo) => {
     test.skip(browserName === 'firefox', 'Firefox has timing issues with PTE editor interaction')
-    test.slow()
     await createDraftDocument('/content/input-standard;portable-text;pt_allTheBellsAndWhistles')
 
     // Important since the having two documents side by side is vital to the test
@@ -46,8 +45,6 @@ test.describe('In PTE - references in popover', () => {
   test('you should be able to create a new reference document and change the fields while the popover is open', async ({
     page,
   }) => {
-    test.slow()
-
     // Create a new reference document
     await expect(page.locator('[data-testid^="create-new-document-select-text"]')).toBeVisible()
     await page.locator('[data-testid^="create-new-document-select-text"]').click()
@@ -68,7 +65,6 @@ test.describe('In PTE - references in popover', () => {
   test('you should be able to add an existing document as reference and keep the link if picking a document that goes outside of the modal viewport', async ({
     page,
   }) => {
-    test.slow()
     // Press arrow for existing references
     await expect(
       page.getByTestId('reference-input').getByRole('button', {name: 'Open'}),

--- a/e2e/tests/releases/customActions/customReleaseActions.spec.ts
+++ b/e2e/tests/releases/customActions/customReleaseActions.spec.ts
@@ -86,8 +86,6 @@ test.describe('Custom Release Actions', () => {
   const createCustomActionTests = (contextName: string, setupPath: string, isOverview: boolean) => {
     test.describe(contextName, () => {
       test.beforeEach(async ({page}) => {
-        test.slow()
-
         // Navigate and wait for the releases API response to complete
         // This ensures the release data is fully loaded before interacting with the page
         await Promise.all([
@@ -125,7 +123,6 @@ test.describe('Custom Release Actions', () => {
       })
 
       test('should verify context data', async ({page}) => {
-        test.slow()
         const consoleMessages: string[] = []
         page.on('console', (msg) => {
           consoleMessages.push(msg.text())

--- a/e2e/tests/releases/displayDocument/DisplayedDocument.spec.ts
+++ b/e2e/tests/releases/displayDocument/DisplayedDocument.spec.ts
@@ -160,7 +160,6 @@ test.describe('displayedDocument', () => {
     }) => {
       skipIfBrowser(browserName)
 
-      test.slow()
       // specific document set up for this test in mind
       await page.goto(`/content/species;${publishedDocument._id}`)
 
@@ -180,7 +179,6 @@ test.describe('displayedDocument', () => {
   test.describe('draft pinned - No draft, no publish, with version', () => {
     test(`single version - shows version displayed`, async ({page, browserName}) => {
       skipIfBrowser(browserName)
-      test.slow()
 
       // specific document set up for this test in mind
       await page.goto(`/content/species;${singleASAPVersionDocument._id}`)
@@ -203,7 +201,6 @@ test.describe('displayedDocument', () => {
     test('multiple version - shows first version displayed', async ({page, browserName}) => {
       skipIfBrowser(browserName)
 
-      test.slow()
       // specific document set up for this test in mind
       await page.goto(`/content/species;${multipleVersionsDocId}`)
       const asapChip = page.getByTestId('document-header-ASAP-Release-A-chip')
@@ -225,7 +222,6 @@ test.describe('displayedDocument', () => {
     })
 
     test(`displayed document is read only`, async ({page, browserName}) => {
-      test.slow()
       skipIfBrowser(browserName)
       // specific document set up for this test in mind
       await page.goto(`/content/species;${singleASAPVersionDocument._id}`)
@@ -243,7 +239,6 @@ test.describe('displayedDocument', () => {
 
   test.describe('published pinned', () => {
     test('draft, publish, no version - shows draft displayed', async ({page, browserName}) => {
-      test.slow()
       skipIfBrowser(browserName)
 
       // specific document set up for this test in mind
@@ -268,7 +263,6 @@ test.describe('displayedDocument', () => {
       page,
       browserName,
     }) => {
-      test.slow()
       skipIfBrowser(browserName)
 
       // specific document set up for this test in mind
@@ -297,7 +291,6 @@ test.describe('displayedDocument', () => {
       _testContext,
       browserName,
     }) => {
-      test.slow()
       skipIfBrowser(browserName)
 
       const customDraft = await createDocument(sanityClient, {
@@ -327,7 +320,6 @@ test.describe('displayedDocument', () => {
       page,
       browserName,
     }) => {
-      test.slow()
       skipIfBrowser(browserName)
 
       // specific document set up for this test in mind
@@ -356,7 +348,6 @@ test.describe('displayedDocument', () => {
       page,
       browserName,
     }) => {
-      test.slow()
       skipIfBrowser(browserName)
 
       // specific document set up for this test in mind
@@ -384,7 +375,6 @@ test.describe('displayedDocument', () => {
       page,
       browserName,
     }) => {
-      test.slow()
       skipIfBrowser(browserName)
 
       // specific document set up for this test in mind
@@ -413,7 +403,6 @@ test.describe('displayedDocument', () => {
       sanityClient,
       browserName,
     }) => {
-      test.slow()
       skipIfBrowser(browserName)
 
       const dataset = sanityClient.config().dataset
@@ -454,7 +443,6 @@ test.describe('displayedDocument', () => {
       _testContext,
       browserName,
     }) => {
-      test.slow()
       skipIfBrowser(browserName)
 
       const documentId = _testContext.getUniqueDocumentId()

--- a/e2e/tests/releases/revert/revertASAP.spec.ts
+++ b/e2e/tests/releases/revert/revertASAP.spec.ts
@@ -25,7 +25,6 @@ test.describe('Revert ASAP', () => {
 
   test.beforeEach(async ({sanityClient, browserName, page, _testContext}) => {
     skipIfBrowser(browserName)
-    test.slow()
 
     const dataset = sanityClient.config().dataset
 

--- a/e2e/tests/releases/revert/revertSchedule.spec.ts
+++ b/e2e/tests/releases/revert/revertSchedule.spec.ts
@@ -24,7 +24,6 @@ test.describe('Revert Scheduled', () => {
 
   test.beforeEach(async ({sanityClient, browserName, page, _testContext}) => {
     skipIfBrowser(browserName)
-    test.slow()
     const dataset = sanityClient.config().dataset
 
     await createRelease({

--- a/e2e/tests/releases/revert/revertUndecided.spec.ts
+++ b/e2e/tests/releases/revert/revertUndecided.spec.ts
@@ -24,7 +24,6 @@ test.describe('Revert Undecided', () => {
 
   test.beforeEach(async ({sanityClient, browserName, page, _testContext}) => {
     skipIfBrowser(browserName)
-    test.slow()
     const dataset = sanityClient.config().dataset
 
     await createRelease({

--- a/e2e/tests/releases/unarchive/unarchiveASAP.spec.ts
+++ b/e2e/tests/releases/unarchive/unarchiveASAP.spec.ts
@@ -24,7 +24,6 @@ test.describe('Unarchive ASAP', () => {
 
   test.beforeEach(async ({sanityClient, browserName, page, _testContext}) => {
     skipIfBrowser(browserName)
-    test.slow()
     const dataset = sanityClient.config().dataset
 
     await createRelease({

--- a/e2e/tests/releases/unarchive/unarchiveUndecided.spec.ts
+++ b/e2e/tests/releases/unarchive/unarchiveUndecided.spec.ts
@@ -24,7 +24,6 @@ test.describe('Unarchive Undecided', () => {
 
   test.beforeEach(async ({sanityClient, browserName, page, _testContext}) => {
     skipIfBrowser(browserName)
-    test.slow()
     const dataset = sanityClient.config().dataset
 
     await createRelease({

--- a/e2e/tests/validation-test/validation.spec.ts
+++ b/e2e/tests/validation-test/validation.spec.ts
@@ -6,7 +6,6 @@ import {test} from '../../studio-test'
 test.describe('Validation test', () => {
   test.describe('should not throw error when a validation error is present', () => {
     test('and the one array item has been deleted', async ({page, createDraftDocument}) => {
-      test.slow()
       const errors: string[] = []
 
       // eslint-disable-next-line max-nested-callbacks
@@ -71,8 +70,6 @@ test.describe('Validation test', () => {
       page,
       createDraftDocument,
     }) => {
-      test.slow()
-
       const errors: string[] = []
 
       // eslint-disable-next-line max-nested-callbacks
@@ -151,8 +148,6 @@ test.describe('Validation test', () => {
       page,
       createDraftDocument,
     }) => {
-      test.slow()
-
       const errors: string[] = []
 
       // eslint-disable-next-line max-nested-callbacks

--- a/e2e/tests/vision/vision.spec.ts
+++ b/e2e/tests/vision/vision.spec.ts
@@ -5,8 +5,6 @@ import {encodeQueryString, getVisionRegions, openVisionTool} from './utils'
 
 test.describe('Vision', () => {
   test('should be possible to type an execute a query', async ({page, sanityClient}) => {
-    test.slow()
-
     const bookTitle = 'Test Book'
     const bookDocument = await sanityClient.create({
       _type: 'book',


### PR DESCRIPTION
### Description
Had claude do an evaluation of our test suite and look for ways to speed it up, and this is what it came up with:

- raises base test timeout to 60s (from 30s)
- drop expect timeout from 5min to 30s
- bump retries to 2
- remove test.slow() from ~55 tests that no longer need it.
- Still keeping test.slow() for some tests which chain multiple long-running operations, like text, reference, and restore specs.

I think these are good improvements, we want failing tests to fail fast. Failing fast + an additional retry is likely improving reliability of tests and also reducing wait time in case of legit test failures.

### What to review
Makes sense? No actual test changes here, just tweaking timeouts and parameters.

FWIW, the e2e tests successfully completed 3 times without requiring re-runs in this branch.

### Testing

### Notes for release
n/a