### PR TITLE
fix(form): unsubscribe dataset uploader streams on abort

### DIFF
--- a/packages/sanity/src/core/form/studio/assetSourceDataset/__tests__/datasetUploader.test.ts
+++ b/packages/sanity/src/core/form/studio/assetSourceDataset/__tests__/datasetUploader.test.ts
@@ -1,0 +1,57 @@
+import {type SanityClient} from '@sanity/client'
+import {type SchemaType} from '@sanity/types'
+import {Observable} from 'rxjs'
+import {describe, expect, it, vi, beforeEach, afterEach} from 'vitest'
+
+import {set} from '../../../patch'
+import {UPLOAD_STATUS_KEY} from '../../uploads/constants'
+import {resolveUploader} from '../../uploads/resolveUploader'
+import {createDatasetUploader} from '../uploader'
+
+vi.mock('../../uploads/resolveUploader')
+
+const mockSchemaType = {name: 'file', type: 'file', options: {}} as unknown as SchemaType
+
+describe('DatasetUploader', () => {
+  beforeEach(() => {
+    vi.mocked(resolveUploader).mockReturnValue({
+      type: 'file',
+      accepts: '*',
+      priority: 1,
+      upload: () =>
+        new Observable((subscriber) => {
+          const intervalId = globalThis.setInterval(() => {
+            subscriber.next({
+              type: 'uploadProgress',
+              patches: [set(50, [UPLOAD_STATUS_KEY, 'progress'])],
+            })
+          }, 5)
+          return () => globalThis.clearInterval(intervalId)
+        }),
+    } as NonNullable<ReturnType<typeof resolveUploader>>)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('abort() unsubscribes underlying uploads so onChange stops receiving patches', async () => {
+    const onChange = vi.fn()
+    const UploaderClass = createDatasetUploader({client: {} as SanityClient})
+    const uploader = new UploaderClass()
+
+    uploader.upload([new File(['x'], 'doc.pdf', {type: 'application/pdf'})], {
+      schemaType: mockSchemaType,
+      onChange,
+    })
+
+    await new Promise((r) => setTimeout(r, 25))
+    expect(onChange.mock.calls.length).toBeGreaterThan(0)
+
+    uploader.abort()
+
+    const callsAfterAbort = onChange.mock.calls.length
+    await new Promise((r) => setTimeout(r, 35))
+    expect(onChange.mock.calls.length).toBe(callsAfterAbort)
+  })
+})

--- a/packages/sanity/src/core/form/studio/assetSourceDataset/uploader.ts
+++ b/packages/sanity/src/core/form/studio/assetSourceDataset/uploader.ts
@@ -40,6 +40,11 @@ class DatasetUploader implements AssetSourceUploader {
     this.subscribers.forEach((fn) => fn(event))
   }
 
+  private teardownFileSubscription(fileId: string): void {
+    this.subscriptions.get(fileId)?.unsubscribe()
+    this.subscriptions.delete(fileId)
+  }
+
   upload(
     files: globalThis.File[],
     options?: {
@@ -91,11 +96,11 @@ class DatasetUploader implements AssetSourceUploader {
                 type: 'error',
                 files: this.files.filter((erroredFile) => erroredFile.status === 'error'),
               })
-              this.subscriptions.get(fileId)?.unsubscribe()
+              this.teardownFileSubscription(fileId)
             },
             complete: () => {
               this.updateFile(uploadFile.id, {status: 'complete'})
-              this.subscriptions.get(fileId)?.unsubscribe()
+              this.teardownFileSubscription(fileId)
             },
           }),
         )
@@ -105,18 +110,30 @@ class DatasetUploader implements AssetSourceUploader {
   }
 
   abort(file?: AssetSourceUploadFile): void {
+    const targets: AssetSourceUploadFile[] = []
     if (file) {
       const target = this.files.find((f) => f.id === file.id)
       if (target && ['pending', 'uploading'].includes(target.status)) {
-        this.updateFile(target.id, {status: 'aborted'})
+        targets.push(target)
       }
     } else {
       for (const target of this.files) {
         if (['pending', 'uploading'].includes(target.status)) {
-          this.updateFile(target.id, {status: 'aborted'})
+          targets.push(target)
         }
       }
     }
+
+    // Stop dataset upload streams first; otherwise progress patches can arrive after
+    // all-complete has unset `_upload`, which breaks the patch applier.
+    for (const target of targets) {
+      this.teardownFileSubscription(target.id)
+    }
+
+    for (const target of targets) {
+      this.updateFile(target.id, {status: 'aborted'})
+    }
+
     this.emit({
       type: 'abort',
       files: this.files.filter((abortedFile) => abortedFile.status === 'aborted'),
@@ -161,6 +178,10 @@ class DatasetUploader implements AssetSourceUploader {
   }
 
   reset(): void {
+    for (const subscription of this.subscriptions.values()) {
+      subscription.unsubscribe()
+    }
+    this.subscriptions.clear()
     this.files = []
   }
 }


### PR DESCRIPTION
### Description

Aborting a dataset asset upload cleared _upload via all-complete while the inner uploadFile/uploadImage subscription kept emitting progress patches, causing patch applier errors. Teardown subscriptions in abort and reset; add regression test.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
That the changes looks correct

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Added a unit test for this.

Can be tested manually by uploading a large file to the dataset, and canceling it.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
* Fixed a bug where canceling dataset uploads gave an error message.
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
