### PR TITLE
fix(release-notes): unset releaseAutomation before publishing content release

### DIFF
--- a/packages/@repo/release-notes/src/commands/publishReleases.ts
+++ b/packages/@repo/release-notes/src/commands/publishReleases.ts
@@ -36,10 +36,15 @@ export async function publishReleases(options: {dryRun: boolean; targetVersion: 
   if (isVersionId(changelogDocumentId)) {
     const releaseId = getVersionNameFromId(changelogDocumentId)
     if (options.dryRun) {
+      console.log(`[DRY RUN] Unsetting releaseAutomation on document ${changelogDocumentId}`)
       console.log(
         `[DRY RUN] Publishing content release ${releaseId} for version ${options.targetVersion}`,
       )
     } else {
+      // Unset releaseAutomation before publishing to avoid validation issues post-release
+      console.log(`Unsetting releaseAutomation on document ${changelogDocumentId}`)
+      await client.patch(changelogDocumentId).unset(['releaseAutomation']).commit()
+
       console.log(`Publishing content release ${releaseId} for version ${options.targetVersion}`)
       await client.releases.publish({releaseId})
       console.log(


### PR DESCRIPTION
### Description

Unsets the `releaseAutomation` field on the changelog document before calling `releases.publish()`. Without this, the field persists on the published document and can cause validation errors.

### What to review

- `packages/@repo/release-notes/src/commands/publishReleases.ts` — the patch + unset is added inside the `isVersionId` branch, just before the release publish call. Dry-run mode logs the intent without mutating.

### Testing

No automated tests — this is release tooling that runs against live Sanity APIs. Verified the patch call structure matches existing `@sanity/client` usage in the codebase.

### Notes for release

N/A – Internal tooling only