### PR TITLE
fix: show initial value template icons in new document pickers

### DIFF
--- a/dev/test-studio/initialValueTemplates/index.ts
+++ b/dev/test-studio/initialValueTemplates/index.ts
@@ -1,3 +1,4 @@
+import {CogIcon, RocketIcon} from '@sanity/icons'
 import {type Template} from 'sanity'
 
 export const resolveInitialValueTemplates: Template[] = [
@@ -6,6 +7,7 @@ export const resolveInitialValueTemplates: Template[] = [
     title: 'Developer',
     description: `Selects the role "Developer" for you, so you don't have to`,
     schemaType: 'author',
+    icon: CogIcon,
     value: () => ({role: 'developer'}),
   },
   {
@@ -13,6 +15,7 @@ export const resolveInitialValueTemplates: Template[] = [
     title: 'Author unlocked',
     description: 'An unlocked author',
     schemaType: 'author',
+    icon: RocketIcon,
     value: {locked: false},
   },
   {

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentListOption.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentListOption.tsx
@@ -1,6 +1,7 @@
 import {type CurrentUser} from '@sanity/types'
-import {Card, Text} from '@sanity/ui'
-import {type MouseEvent, useCallback, useMemo} from 'react'
+import {Box, Card, Flex, Text} from '@sanity/ui'
+import {isValidElement, type MouseEvent, useCallback, useMemo} from 'react'
+import {isValidElementType} from 'react-is'
 import {useIntentLink} from 'sanity/router'
 
 import {Tooltip} from '../../../../../ui-components'
@@ -43,6 +44,7 @@ export function NewDocumentListOption(props: NewDocumentListOptionProps) {
   )
 
   const {title} = useI18nText(option)
+  const {icon: Icon} = option
 
   return (
     <Tooltip
@@ -64,7 +66,17 @@ export function NewDocumentListOption(props: NewDocumentListOptionProps) {
           padding={preview === 'inline' ? 3 : 4}
           radius={2}
         >
-          <Text size={preview === 'inline' ? 1 : undefined}>{title}</Text>
+          <Flex align="center" gap={3}>
+            {Icon && (
+              <Box>
+                <Text size={preview === 'inline' ? 1 : undefined}>
+                  {isValidElement(Icon) && Icon}
+                  {isValidElementType(Icon) && <Icon />}
+                </Text>
+              </Box>
+            )}
+            <Text size={preview === 'inline' ? 1 : undefined}>{title}</Text>
+          </Flex>
         </Card>
       </div>
     </Tooltip>

--- a/packages/sanity/src/core/studio/components/navbar/new-document/__tests__/NewDocumentListOption.test.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/__tests__/NewDocumentListOption.test.tsx
@@ -1,0 +1,69 @@
+import {render, screen} from '@testing-library/react'
+import {describe, expect, test, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {NewDocumentListOption} from '../NewDocumentListOption'
+import {type NewDocumentOption, type PreviewLayout} from '../types'
+
+vi.mock('sanity/router', async (importOriginal) => {
+  const actual: Record<string, unknown> = await importOriginal()
+  return {
+    ...actual,
+    useIntentLink: () => ({onClick: vi.fn(), href: '/test'}),
+  }
+})
+
+function TestIcon() {
+  return <svg data-testid="template-icon" />
+}
+
+function createOption(overrides: Partial<NewDocumentOption> = {}): NewDocumentOption {
+  return {
+    id: 'test-option',
+    type: 'initialValueTemplateItem',
+    templateId: 'test-template',
+    schemaType: 'author',
+    title: 'Test Option',
+    hasPermission: true,
+    ...overrides,
+  }
+}
+
+const defaultProps = {
+  currentUser: {id: 'user1', name: 'Test User', email: 'test@test.com', role: '', roles: []},
+  onClick: vi.fn(),
+  preview: 'inline' as PreviewLayout,
+}
+
+describe('NewDocumentListOption', () => {
+  test('renders icon when option has an icon component', async () => {
+    const wrapper = await createTestProvider()
+    const option = createOption({icon: TestIcon})
+
+    render(<NewDocumentListOption {...defaultProps} option={option} />, {wrapper})
+
+    expect(screen.getByTestId('template-icon')).toBeInTheDocument()
+    expect(screen.getByText('Test Option')).toBeInTheDocument()
+  })
+
+  test('renders icon when option has a JSX element icon', async () => {
+    const wrapper = await createTestProvider()
+    const iconElement = <svg data-testid="jsx-icon" />
+    const option = createOption({icon: iconElement})
+
+    render(<NewDocumentListOption {...defaultProps} option={option} />, {wrapper})
+
+    expect(screen.getByTestId('jsx-icon')).toBeInTheDocument()
+    expect(screen.getByText('Test Option')).toBeInTheDocument()
+  })
+
+  test('renders without icon when option has no icon', async () => {
+    const wrapper = await createTestProvider()
+    const option = createOption()
+
+    render(<NewDocumentListOption {...defaultProps} option={option} />, {wrapper})
+
+    expect(screen.getByText('Test Option')).toBeInTheDocument()
+    expect(screen.queryByTestId('template-icon')).toBeNull()
+  })
+})

--- a/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx
+++ b/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx
@@ -183,6 +183,7 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
                 <MenuItem
                   as={Link}
                   data-as={disabled ? 'button' : 'a'}
+                  icon={item.icon}
                   text={title}
                   aria-label={
                     disabled ? t('pane-header.disabled-created-button.aria-label') : title

--- a/packages/sanity/src/structure/structureBuilder/DocumentList.ts
+++ b/packages/sanity/src/structure/structureBuilder/DocumentList.ts
@@ -306,7 +306,7 @@ function inferInitialValueTemplates(
         schemaType,
       }),
     )
-    .map((option) => ({...option, icon: AddIcon}))
+    .map((option) => ({...option, icon: option.icon || AddIcon}))
 }
 
 function inferTypeName(spec: PartialDocumentList): string | undefined {


### PR DESCRIPTION
### Description
Passing icons through to initial value templates was supported from a type perspective but were never being rendering in any of the template pickers.

This PR conditionally renders the icons when they are provided

| Before | After |
|--------|--------|
| <img width="328" height="205" alt="Screenshot 2026-03-25 at 18 44 42" src="https://github.com/user-attachments/assets/4c255731-1b80-4296-b6c1-9a56e8e99a6e" /> | <img width="322" height="209" alt="Screenshot 2026-03-25 at 18 43 17" src="https://github.com/user-attachments/assets/dfe340f4-8cf4-43fa-bced-5813d635490b" /> |
| <img width="147" height="160" alt="Screenshot 2026-03-25 at 18 45 04" src="https://github.com/user-attachments/assets/85aa3450-4bc3-4414-b5aa-f3e6d7646752" /> | <img width="175" height="165" alt="Screenshot 2026-03-25 at 18 43 47" src="https://github.com/user-attachments/assets/d984b20a-a237-4a56-8da1-db84895bee01" /> |

Closes https://github.com/sanity-io/sanity/issues/4707
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue where icons that were provided with initial value templates were not being shown in template pickers in the Studio ([github issue 4707](https://github.com/sanity-io/sanity/issues/4707))
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
