### PR TITLE
fix(types): correct BlockRule value type from any[] to PortableTextBlock

### DIFF
--- a/packages/@sanity/types/src/portableText/types.ts
+++ b/packages/@sanity/types/src/portableText/types.ts
@@ -1,8 +1,8 @@
-/** @alpha */
+/** @public */
 
 export type PortableTextBlock = PortableTextTextBlock | PortableTextObject
 
-/** @alpha */
+/** @public */
 export interface PortableTextTextBlock<TChild = PortableTextSpan | PortableTextObject> {
   _type: string
   _key: string
@@ -13,14 +13,14 @@ export interface PortableTextTextBlock<TChild = PortableTextSpan | PortableTextO
   level?: number
 }
 
-/** @alpha */
+/** @public */
 export interface PortableTextObject {
   _type: string
   _key: string
   [other: string]: unknown
 }
 
-/** @alpha */
+/** @public */
 export interface PortableTextSpan {
   _key: string
   _type: 'span'
@@ -28,10 +28,10 @@ export interface PortableTextSpan {
   marks?: string[]
 }
 
-/** @alpha */
+/** @public */
 export type PortableTextChild = PortableTextObject | PortableTextSpan
 
-/** @alpha */
+/** @public */
 export interface PortableTextListBlock extends PortableTextTextBlock {
   listItem: string
   level: number

--- a/packages/@sanity/types/src/schema/definition/type/block.ts
+++ b/packages/@sanity/types/src/schema/definition/type/block.ts
@@ -1,5 +1,6 @@
 import {type ComponentType, type ReactNode} from 'react'
 
+import {type PortableTextBlock} from '../../../portableText'
 import {type RuleDef, type ValidationBuilder} from '../../ruleBuilder'
 import {type InitialValueProperty} from '../../types'
 import {type ArrayOfType} from './array'
@@ -29,7 +30,7 @@ export interface BlockOptions extends BaseSchemaTypeOptions {
 }
 
 /** @public */
-export interface BlockRule extends RuleDef<BlockRule, any[]> {}
+export interface BlockRule extends RuleDef<BlockRule, PortableTextBlock> {}
 
 /**
  * Schema definition for text block decorators.
@@ -259,7 +260,7 @@ export interface BlockDefinition extends BaseSchemaDefinition {
   lists?: BlockListDefinition[]
   marks?: BlockMarksDefinition
   of?: ArrayOfType<'object' | 'reference'>[]
-  initialValue?: InitialValueProperty<any, any[]>
+  initialValue?: InitialValueProperty<any, PortableTextBlock>
   options?: BlockOptions
-  validation?: ValidationBuilder<BlockRule, any[]>
+  validation?: ValidationBuilder<BlockRule, PortableTextBlock>
 }

--- a/packages/@sanity/types/src/schema/definition/type/block.ts
+++ b/packages/@sanity/types/src/schema/definition/type/block.ts
@@ -2,7 +2,6 @@ import {type ComponentType, type ReactNode} from 'react'
 
 import {type PortableTextBlock} from '../../../portableText'
 import {type RuleDef, type ValidationBuilder} from '../../ruleBuilder'
-import {type InitialValueProperty} from '../../types'
 import {type ArrayOfType} from './array'
 import {type BaseSchemaDefinition, type BaseSchemaTypeOptions} from './common'
 import {type ObjectDefinition} from './object'
@@ -260,7 +259,8 @@ export interface BlockDefinition extends BaseSchemaDefinition {
   lists?: BlockListDefinition[]
   marks?: BlockMarksDefinition
   of?: ArrayOfType<'object' | 'reference'>[]
-  initialValue?: InitialValueProperty<any, PortableTextBlock>
+  /** Block types do not support initialValue - the runtime schema validation rejects it. */
+  initialValue?: never
   options?: BlockOptions
   validation?: ValidationBuilder<BlockRule, PortableTextBlock>
 }

--- a/packages/@sanity/types/test/block.test.ts
+++ b/packages/@sanity/types/test/block.test.ts
@@ -16,11 +16,16 @@ describe('block types', () => {
         title: 'Custom PTE',
         icon: () => null,
         description: 'Description',
-        initialValue: () => Promise.resolve([]),
+        initialValue: () =>
+          Promise.resolve({
+            _type: 'block',
+            _key: 'initial',
+            children: [{_type: 'span' as const, _key: 'span1', text: '', marks: []}],
+          }),
         validation: (Rule) => [
           Rule.required()
             .required()
-            .custom((value) => (value?.filter((t) => !t).length === 1 ? 'Error' : true))
+            .custom((value) => (value?._type !== 'block' ? 'Error' : true))
             .warning(),
           // @ts-expect-error greaterThan does not exist on BlockRule
           Rule.greaterThan(5).error(),

--- a/packages/@sanity/types/test/block.test.ts
+++ b/packages/@sanity/types/test/block.test.ts
@@ -16,12 +16,8 @@ describe('block types', () => {
         title: 'Custom PTE',
         icon: () => null,
         description: 'Description',
-        initialValue: () =>
-          Promise.resolve({
-            _type: 'block',
-            _key: 'initial',
-            children: [{_type: 'span' as const, _key: 'span1', text: '', marks: []}],
-          }),
+        // @ts-expect-error initialValue is not supported on block types
+        initialValue: {_type: 'block'},
         validation: (Rule) => [
           Rule.required()
             .required()


### PR DESCRIPTION
### Description
Fixes #4464. 

`BlockRule` and `BlockDefinition` used `any[]` as their value type, but a block's runtime value is a single `PortableTextBlock` object - not an array. Every other schema type (`StringRule`, `NumberRule`, `ObjectRule`) uses its correct singular value type. This change makes block consistent.

### Backwards compatibility

This is a type-level breaking change by strict semver standards: `custom()` validators on block types will now receive `PortableTextBlock` instead of `any[]`. In practice, the risk is low:

- The `any[]` type was wrong - it never matched the runtime value. Anyone calling array methods based on this type already had a latent runtime bug.
- any is maximally permissive, so most real-world validators access object properties on value rather than treating it as an array. That code continues to work.
- The test that accompanied the original typing used `value?.filter(...)` as if it were an array - confirming the type was incorrect, not that array usage was intended.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
- `BlockRule` now `extends RuleDef<BlockRule, PortableTextBlock>` instead of `RuleDef<BlockRule, any[]>`
- `BlockDefinition.initialValue` and `BlockDefinition.validation` use `PortableTextBlock` instead of `any[]`
- Promoted `PortableTextBlock` and its constituent types (`PortableTextTextBlock`, `PortableTextObject`, `PortableTextSpan`, `PortableTextChild`, `PortableTextListBlock`) from `@alpha` to `@public` - these types have been stable since September 2020 and are already widely used by consumers
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
`BlockRule` now uses `PortableTextBlock` instead of `any[]`, matching the actual runtime value passed to custom validators.
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
