### PR TITLE
test(e2e): replace waitForSelector and waitForTimeout with locator APIs

### DIFF
--- a/e2e/tests/desk/deprecatedDocument.spec.ts
+++ b/e2e/tests/desk/deprecatedDocument.spec.ts
@@ -5,9 +5,5 @@ import {test} from '../../studio-test'
 test(`deprecated document type shows deprecated message`, async ({page, createDraftDocument}) => {
   await createDraftDocument('/content/input-debug;deprecatedDocument')
 
-  await page.waitForSelector(`data-testid=deprecated-document-type-banner`)
-
-  const deprecatedBadge = page.getByTestId(`deprecated-document-type-banner`)
-
-  await expect(deprecatedBadge).toBeVisible()
+  await expect(page.getByTestId('deprecated-document-type-banner')).toBeVisible()
 })

--- a/e2e/tests/desk/documentList.spec.ts
+++ b/e2e/tests/desk/documentList.spec.ts
@@ -50,7 +50,7 @@ test(`navigating document creates only one listener connection`, async ({page, b
     }
   })
 
-  await page.waitForSelector('[data-testid="structure-tool-list-pane"]')
+  await expect(page.getByTestId('structure-tool-list-pane')).toBeVisible()
 
   // Scroll the items to click into view.
   await page.evaluate(() => {

--- a/e2e/tests/desk/inspectDialog.spec.ts
+++ b/e2e/tests/desk/inspectDialog.spec.ts
@@ -46,10 +46,7 @@ test('clicking inspect mode sets value in storage', async ({
     value: 'raw',
   })
 
-  // Wait for the UI to stabilize
-  await page.waitForTimeout(500)
-
-  // Set up listener for the second network request
+  // Set up listener for the second network request before clicking
   const keyValueRequest2 = page.waitForResponse(async (response) => {
     return response.url().includes('/users/me/keyvalue') && response.request().method() === 'PUT'
   })

--- a/e2e/tests/document-actions/publish.spec.ts
+++ b/e2e/tests/document-actions/publish.spec.ts
@@ -22,9 +22,6 @@ test(`document panel displays correct title for published document`, async ({
   // Focus the publish button to trigger the tooltip showing the keyboard shortcut
   await page.getByTestId('action-publish').focus()
 
-  // There is a delay before the tooltip opens, let's explicitly wait for it
-  await page.waitForTimeout(300)
-
   // Now look for the tooltip to appear, with platform-aware keyboard shortcuts
   // It'll have a data-testid of 'document-status-bar-hotkeys'
   await expect(page.getByTestId('document-status-bar-hotkeys')).toBeVisible()

--- a/e2e/tests/document-actions/restore.spec.ts
+++ b/e2e/tests/document-actions/restore.spec.ts
@@ -2,6 +2,7 @@ import {expect} from '@playwright/test'
 
 import {
   expectCreatedOrEditedStatus,
+  expectEditedStatus,
   expectPublishedStatus,
 } from '../../helpers/documentStatusAssertions'
 import {test} from '../../studio-test'
@@ -38,8 +39,8 @@ test(`documents can be restored to an earlier revision`, async ({page, createDra
   await titleInput.fill(titleB)
   await expect(titleInput).toHaveValue(titleB)
 
-  // Wait for the document to be published.
-  await page.waitForTimeout(2_000)
+  // Wait for the document to be saved before publishing.
+  await expectEditedStatus(documentStatus)
   await publishButton.click()
   await expectPublishedStatus(documentStatus)
 
@@ -83,9 +84,7 @@ test(`respects overridden restore action`, async ({page, createDraftDocument}) =
   await createDraftDocument('/content/input-debug;documentActionsTest')
 
   // waits for the top most form layer to finish loading
-  await page.waitForSelector('[data-testid="document-panel-scroller"]', {
-    state: 'visible',
-  })
+  await expect(page.getByTestId('document-panel-scroller')).toBeVisible()
 
   await titleInput.fill(titleA)
   // Wait for the document to finish saving
@@ -103,8 +102,8 @@ test(`respects overridden restore action`, async ({page, createDraftDocument}) =
   await titleInput.fill(titleB)
   await expect(titleInput).toHaveValue(titleB)
 
-  // Wait for the document to be published.
-  await page.waitForTimeout(2_000)
+  // Wait for the document to be saved before publishing.
+  await expectEditedStatus(documentStatus)
   await publishKeypress()
   await expectPublishedStatus(documentStatus)
 
@@ -167,8 +166,8 @@ test(`respects removed restore action`, async ({page, createDraftDocument}) => {
   await titleInput.fill(titleB)
   await expect(titleInput).toHaveValue(titleB)
 
-  // Wait for the document to be published.
-  await page.waitForTimeout(2_000)
+  // Wait for the document to be saved before publishing.
+  await expectEditedStatus(documentStatus)
   await publishButton.click()
   await expectPublishedStatus(documentStatus)
 

--- a/e2e/tests/enhanced-object-dialog/breadcrumbNavigation.spec.ts
+++ b/e2e/tests/enhanced-object-dialog/breadcrumbNavigation.spec.ts
@@ -62,9 +62,7 @@ test.describe('Enhanced Object Dialog - breadcrumb navigation', () => {
     await expect(friendNameField).toBeVisible()
     await expect(friendNameField).toHaveValue('Dolphin')
 
-    // Verify it stays stable after a short wait (catches flicker regressions)
-    await page.waitForTimeout(500)
-    await expect(friendNameField).toBeVisible()
+    // Verify it stays stable (catches flicker regressions)
     await expect(friendNameField).toHaveValue('Dolphin')
   })
 })

--- a/e2e/tests/enhanced-object-dialog/closeAndReopen.spec.ts
+++ b/e2e/tests/enhanced-object-dialog/closeAndReopen.spec.ts
@@ -36,7 +36,6 @@ test.describe('Enhanced Object Dialog - close and reopen', () => {
     await expect(modal).toBeVisible()
 
     // Ensure the dialog stays open (doesn't flicker closed)
-    await page.waitForTimeout(500)
     await expect(modal).toBeVisible()
   })
 
@@ -57,7 +56,6 @@ test.describe('Enhanced Object Dialog - close and reopen', () => {
     await expect(modal).toBeVisible()
 
     // Ensure the dialog stays open (doesn't flicker closed)
-    await page.waitForTimeout(500)
     await expect(modal).toBeVisible()
   })
 
@@ -76,7 +74,6 @@ test.describe('Enhanced Object Dialog - close and reopen', () => {
     await page.mouse.click(cardBox!.x - 30, cardBox!.y + cardBox!.height / 2)
 
     // Ensure that it closes
-    await page.waitForTimeout(500)
     await expect(modal).not.toBeVisible()
 
     // Click the item to reopen

--- a/e2e/tests/inputs/date.spec.ts
+++ b/e2e/tests/inputs/date.spec.ts
@@ -29,7 +29,7 @@ test.skip(`date input shows validation on entering date in the text field`, asyn
 }) => {
   await createDraftDocument('/content/input-debug;dateValidation')
 
-  await page.waitForSelector(`data-testid=field-requiredDate`)
+  await expect(page.getByTestId('field-requiredDate')).toBeVisible()
 
   await page.getByTestId('field-requiredDate').getByTestId('date-input').fill('2023-01-01')
 
@@ -61,7 +61,7 @@ test(`date input shows validation on entering date in the textfield and onBlur`,
 }) => {
   await createDraftDocument('/content/input-debug;dateValidation')
 
-  await page.waitForSelector(`data-testid=field-requiredDate`)
+  await expect(page.getByTestId('field-requiredDate')).toBeVisible()
 
   await page.getByTestId('field-requiredDate').getByTestId('date-input').fill('2023-01-01')
   await page.getByTestId('field-requiredDate').getByTestId('date-input').blur()

--- a/e2e/tests/inputs/datetime.spec.ts
+++ b/e2e/tests/inputs/datetime.spec.ts
@@ -8,7 +8,7 @@ test(`datetime input shows validation on selecting date from datepicker`, async 
 }) => {
   await createDraftDocument('/content/input-debug;dateTimeValidation')
 
-  await page.waitForSelector(`data-testid=field-requiredDatetime`)
+  await expect(page.getByTestId('field-requiredDatetime')).toBeVisible()
 
   await page.getByTestId('field-requiredDatetime').getByTestId('select-date-button').click()
   await page.getByTestId('date-input-dialog').getByTestId('date-input').fill('2023')
@@ -28,7 +28,7 @@ test.skip(`datetime input shows validation on entering date in the textfield`, a
 }) => {
   await createDraftDocument('/content/input-debug;dateTimeValidation')
 
-  await page.waitForSelector(`data-testid=field-requiredDatetime`)
+  await expect(page.getByTestId('field-requiredDatetime')).toBeVisible()
 
   await page
     .getByTestId('field-requiredDatetime')

--- a/e2e/tests/navbar/createNewDocumentNav.spec.ts
+++ b/e2e/tests/navbar/createNewDocumentNav.spec.ts
@@ -16,7 +16,7 @@ test('create new document from menu button', async ({page, baseURL}) => {
   // https://github.com/sanity-io/sanity/blob/6d5b4e88c4cb0fbd41fcebbaebabd88e9fac16b5/packages/sanity/src/core/components/commandList/CommandList.tsx#L596
   await page.getByTestId('create-new-author').click({force: true})
 
-  await page.waitForSelector('data-testid=document-pane')
+  await expect(page.getByTestId('document-pane')).toBeVisible()
 
   expect(page.url()).toMatch(/(chromium|firefox)\/content\/author;[0-9a-fA-F-]/)
 })


### PR DESCRIPTION
### Description

Removes deprecated/anti-pattern Playwright APIs from E2E tests:
- **`waitForSelector()`** (8 instances, 6 files) → `expect(locator).toBeVisible()` using modern locator-based API
- **`waitForTimeout()`** (10 instances, 5 files) → event-driven waits: `expectEditedStatus()` for autosave confirmation, and relying on Playwright's auto-retrying assertions

Intentionally kept `waitForTimeout` in `retryingClick.ts` (retry backoff), `reference.spec.ts` (search-index delay), and `customReleaseActions.spec.ts` (console message wait) where no DOM condition exists to wait on.

### What to review
- Makes sense?
- I've ran E2E tests multiple times in this branch without issues.


### Notes for release

N/A – Internal only
