### PR TITLE
ci(e2e): optimize Playwright CI workflows

### DIFF
--- a/.github/workflows/e2e-ct.yml
+++ b/.github/workflows/e2e-ct.yml
@@ -69,7 +69,7 @@ jobs:
         # TODO: Fix webkit caching when downloading from cache
         # for some reason it doesn't work without installing again
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps ${{ matrix.project }}
 
       - name: Build packages
         # This should take only a few seconds as it'll restore the remote cache that got primed in the `install` job
@@ -105,7 +105,7 @@ jobs:
   merge-reports:
     if: always() && needs.install.outputs.has_code_changes == 'true'
     needs: [install, playwright-ct-test]
-    runs-on: ubuntu-8core
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup

--- a/.github/workflows/e2e-embedded.yml
+++ b/.github/workflows/e2e-embedded.yml
@@ -17,10 +17,6 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-    strategy:
-      fail-fast: false
-      matrix:
-        project: [chromium, firefox]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -50,7 +46,7 @@ jobs:
 
       - name: Install Playwright Browsers
         if: steps.changes.outputs.has_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps chromium firefox
 
   test:
     if: needs.install.outputs.has_code_changes == 'true'
@@ -87,7 +83,7 @@ jobs:
 
       - name: Install Playwright Browsers
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps ${{ matrix.project }}
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Install Playwright Browsers
         if: steps.changes.outputs.has_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps chromium firefox
 
   dataset-setup:
     timeout-minutes: 10
@@ -90,25 +90,16 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - name: Create dataset (chromium)
+      - name: Create datasets (chromium + firefox in parallel)
         env:
           SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
           SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_WRITE_TOKEN }}
-          SANITY_E2E_DATASET: ${{ env.CHROMIUM_DATASET }}
           SANITY_CLI_API_RATE_LIMIT_BYPASS: ${{ secrets.SANITY_CLI_API_RATE_LIMIT_BYPASS }}
         run: |
-          echo "Creating dataset: ${{ env.CHROMIUM_DATASET }}"
-          pnpm e2e:setup
-
-      - name: Create dataset (firefox)
-        env:
-          SANITY_E2E_PROJECT_ID: ${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
-          SANITY_E2E_SESSION_TOKEN: ${{ secrets.SANITY_E2E_WRITE_TOKEN }}
-          SANITY_E2E_DATASET: ${{ env.FIREFOX_DATASET }}
-          SANITY_CLI_API_RATE_LIMIT_BYPASS: ${{ secrets.SANITY_CLI_API_RATE_LIMIT_BYPASS }}
-        run: |
-          echo "Creating dataset: ${{ env.FIREFOX_DATASET }}"
-          pnpm e2e:setup
+          echo "Creating datasets: ${{ env.CHROMIUM_DATASET }} and ${{ env.FIREFOX_DATASET }}"
+          SANITY_E2E_DATASET=${{ env.CHROMIUM_DATASET }} pnpm e2e:setup &
+          SANITY_E2E_DATASET=${{ env.FIREFOX_DATASET }} pnpm e2e:setup &
+          wait
 
   deploy-preview:
     runs-on: ubuntu-8core
@@ -228,7 +219,8 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps ${{ matrix.project }}
 
       - name: Run E2E tests
         env:
@@ -263,7 +255,7 @@ jobs:
   merge-reports:
     needs: [install, playwright-test]
     if: always() && needs.install.outputs.has_code_changes == 'true'
-    runs-on: ubuntu-8core
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup


### PR DESCRIPTION
### Description

The E2E Playwright workflows have several sources of wasted time that compound across the 8+ parallel shards:

- **Browser install runs unconditionally in test shards** — the `e2e.yml` test jobs always ran `npx playwright install --with-deps` even when the cache was already restored. With `--with-deps` also installing apt packages, this adds ~1-2 min per shard for no reason.
- **Every shard downloads all browsers** — a chromium shard doesn't need firefox binaries and vice versa. Passing the specific browser name to `playwright install` cuts download time roughly in half.
- **Dataset creation is sequential** — the chromium and firefox datasets are independent but were created one after the other. Running them in parallel with background processes cuts this step's wall-clock time in half.
- **`merge-reports` uses 8-core runners** — this job just downloads artifacts and merges HTML/JSON reports. `ubuntu-latest` is sufficient and frees up expensive runners.
- **Embedded install job has a pointless matrix** — it ran the identical checkout/setup/cache
steps twice (once per browser) when a single run caching both browsers is enough. 

Total duration of two e2e.yml runs in this branch:
1. [8m 54s](https://github.com/sanity-io/sanity/actions/runs/23587372963/attempts/1?pr=12519)
2. [5m 53s](https://github.com/sanity-io/sanity/actions/runs/23587372963?pr=12519) – likely faster because of cached vercel deployment(?)

For comparison, we've been floating at around ~10-11 mins lately: https://github.com/sanity-io/sanity/actions/workflows/e2e.yml

### What to review
Verify the `wait` in the parallel dataset creation won't mask failures (it propagates exit codes from backgrounded processes in bash).

### Notes for release

 N/A