### PR TITLE
fix(auth): return stats from handleCallbackResult

### DIFF
--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -248,7 +248,7 @@ export function _createAuthStore({
       broadcast(loginMethod === 'cookie' ? null : getToken(projectId))
       return {
         loginMethod,
-        flow: 'no-session',
+        flow: 'already-authenticated',
         success: true,
         durationMs: Math.round(performance.now() - startTime),
       }

--- a/packages/sanity/src/core/store/_legacy/authStore/types.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/types.ts
@@ -105,11 +105,11 @@ export interface HandleCallbackResult {
   loginMethod: LoginMethod
   /**
    * Which auth flow was taken:
-   * - `'no-session'`: No session ID was present; no auth exchange was attempted.
+   * - `'already-authenticated'`: User was already authenticated; no exchange needed.
    * - `'cookie-auth'`: Attempted cookie-based authentication via `/users/me`.
    * - `'token-exchange'`: Traded a session ID for a persistent token.
    */
-  flow: 'no-session' | 'cookie-auth' | 'token-exchange'
+  flow: 'already-authenticated' | 'cookie-auth' | 'token-exchange'
   /** Whether the auth flow completed successfully. */
   success: boolean
   /** Total wall-clock time for the callback handling, in milliseconds. */


### PR DESCRIPTION
### Description

Changes `handleCallbackUrl` in the auth store to return a `HandleCallbackResult` object instead of `void`. The result includes timing info (`durationMs`, `tokenExchangeDurationMs`), which auth flow was taken (`no-session`, `cookie-auth`, `token-exchange`), success/failure status, and the login method used.

This gives callers (e.g. `AuthBoundary`) the information needed to report telemetry on the auth callback flow (opening a follow-up PR for this).

### What to review

- `createAuthStore.ts` — the three return paths in `handleCallbackUrl` and the error handling around `tradeSessionForToken`
- `types.ts` — the new `HandleCallbackResult` interface. Are the names/properties self-explanatory and sensible?

### Testing

No new tests. The function's observable side effects (what gets broadcast) are unchanged; only the return value is new.

### Notes for release

N/A – Internal only