### PR TITLE
fix(structure): add empty state to incoming refs inspector

### DIFF
--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -485,6 +485,8 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'incoming-references-input.types-not-defined':
     'No incoming references defined for this type, see the docs for more information.',
 
+  /** The text shown if there are no incoming references in the inspector */
+  'incoming-references-pane.no-references': 'No incoming references found.',
   /** The text shown if there are no incoming references for a type */
   'incoming-references-pane.no-references-found': 'No references of this type found.',
   /** The text shown if there is no schema type found for a document in the incoming references pane */

--- a/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/IncomingReferencesList.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/IncomingReferencesList.tsx
@@ -160,8 +160,23 @@ export function IncomingReferencesList() {
 
   const emptyMessage = t('incoming-references-pane.no-references-found')
 
+  const showEmptyState =
+    !references?.loading &&
+    references?.list.length === 0 &&
+    !crossDatasetRefs?.loading &&
+    crossDatasetRefs?.list.length === 0
+
   return (
     <>
+      {showEmptyState && (
+        <Card border radius={3} padding={1} tone="default">
+          <Box paddingY={3} paddingX={2}>
+            <Text size={1} muted>
+              {t('incoming-references-pane.no-references')}
+            </Text>
+          </Box>
+        </Card>
+      )}
       {references?.loading ? (
         <LoadingBlock showText title={t('incoming-references-input.types-loading')} />
       ) : (


### PR DESCRIPTION
### Description
Adds empty state to incoming refs inspector
I missed this in the initial implementation.

<img width="1118" height="946" alt="Screenshot 2026-03-26 at 16 26 03" src="https://github.com/user-attachments/assets/0273d4c3-cb27-41a3-90cc-97c661146a1f" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
