### PR TITLE
feat(telemetry): track auth store timings

### DIFF
--- a/packages/sanity/src/core/studio/AuthBoundary.tsx
+++ b/packages/sanity/src/core/studio/AuthBoundary.tsx
@@ -1,6 +1,11 @@
+import {useTelemetry} from '@sanity/telemetry/react'
 import {type ComponentType, type ReactNode, useEffect, useState} from 'react'
 
 import {LoadingBlock} from '../components/loadingBlock'
+import {
+  AuthBoundaryResolved,
+  SessionTokenExchangeCompleted,
+} from './__telemetry__/authBoundary.telemetry'
 import {useActiveWorkspace} from './activeWorkspaceMatcher'
 import {AuthenticateScreen, NotAuthenticatedScreen, RequestAccessScreen} from './screens'
 
@@ -25,10 +30,25 @@ export function AuthBoundary({
   )
   const [loginProvider, setLoginProvider] = useState<string | undefined>()
   const {activeWorkspace} = useActiveWorkspace()
+  const telemetry = useTelemetry()
+  const [mountTime] = useState(() => performance.now())
+  useEffect(() => {
+    if (loggedIn !== 'loading') {
+      telemetry.log(AuthBoundaryResolved, {
+        durationMs: Math.round(performance.now() - mountTime),
+        result: loggedIn,
+      })
+    }
+  }, [loggedIn, telemetry, mountTime])
 
   useEffect(() => {
-    activeWorkspace.auth.handleCallbackUrl?.().catch(handleError)
-  }, [activeWorkspace.auth])
+    activeWorkspace.auth
+      .handleCallbackUrl?.()
+      .then((result) => {
+        telemetry.log(SessionTokenExchangeCompleted, result)
+      })
+      .catch(handleError)
+  }, [activeWorkspace.auth, telemetry])
 
   useEffect(() => {
     const subscription = activeWorkspace.auth.state.subscribe({

--- a/packages/sanity/src/core/studio/__telemetry__/authBoundary.telemetry.ts
+++ b/packages/sanity/src/core/studio/__telemetry__/authBoundary.telemetry.ts
@@ -1,0 +1,25 @@
+import {defineEvent} from '@sanity/telemetry'
+
+/** Fired when the AuthBoundary resolves from 'loading' to a final auth state. */
+export const AuthBoundaryResolved = defineEvent<{
+  durationMs: number
+  result: 'logged-in' | 'logged-out' | 'unauthorized'
+}>({
+  name: 'Auth Boundary Resolved',
+  version: 1,
+  description: 'Time from AuthBoundary mount until auth state is resolved',
+})
+
+/** Fired when handleCallbackUrl completes in the auth store. */
+export const SessionTokenExchangeCompleted = defineEvent<{
+  loginMethod: 'dual' | 'cookie' | 'token'
+  flow: 'already-authenticated' | 'cookie-auth' | 'token-exchange'
+  success: boolean
+  durationMs: number
+  tokenExchangeDurationMs?: number
+  failureReason?: string
+}>({
+  name: 'Session Token Exchange Completed',
+  version: 1,
+  description: 'Result of the session token exchange flow in handleCallbackUrl',
+})


### PR DESCRIPTION
### Description
Adds telemetry timing for two parts of our auth flow:

1. How long time do we spend on resolving auth state before we can go on with rendering the rest of the Studio (AuthBoundaryResolved)
2. How long time do we spend on exhanging session token (for the cases where we need to)

### What to review
- Does the events make sense?

### Testing
- Best tested via preview build, look for telemetry events in the console: https://test-studio-git-sapp-3615-log-telemetry.sanity.dev/

### Notes for release
n/a