### PR TITLE
feat(auth): use partitioned cookies with fallback for dual mode

### DIFF
--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -3,6 +3,7 @@ import {
   createClient as createSanityClient,
   type SanityClient,
 } from '@sanity/client'
+import {type CurrentUser} from '@sanity/types'
 import isEqual from 'lodash-es/isEqual.js'
 import memoize from 'lodash-es/memoize.js'
 import {defer} from 'rxjs'
@@ -164,6 +165,40 @@ const getCurrentUser = async (
 }
 
 /**
+ * Probe whether a given auth method works by calling /users/me.
+ * Returns the user if authenticated, null otherwise. Unlike `getCurrentUser`,
+ * this function has no side effects (no token clearing, no CORS checks) -
+ * it's only used during the post-login probe phase.
+ */
+async function probeCurrentUser(client: SanityClient): Promise<CurrentUser | null> {
+  try {
+    const user = await client.request({uri: '/users/me', tag: 'users.probe'})
+    // /users/me returns an empty object (not a 401) when unauthenticated,
+    // so we check for a string `id` field to confirm a real user
+    return typeof user?.id === 'string' ? user : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Exchange a session ID for both a cookie and a token via /auth/exchange.
+ * The endpoint sets a Set-Cookie header (stored under the Studio's partition key
+ * because this is a fetch with credentials from the Studio's origin) and returns
+ * the token in the response body.
+ */
+async function exchangeSessionForToken(client: SanityClient, sessionId: string): Promise<string> {
+  const {token} = await client.request<{success: boolean; token: string}>({
+    method: 'GET',
+    uri: '/auth/exchange',
+    query: {sid: sessionId},
+    tag: 'auth.exchange',
+  })
+
+  return token
+}
+
+/**
  * @internal
  */
 export function _createAuthStore({
@@ -181,12 +216,6 @@ export function _createAuthStore({
 
   const clientFactory = clientFactoryOption ?? createSanityClient
 
-  // // TODO: there is currently a bug where the AuthBoundary flashes the
-  // // `NotAuthenticatedComponent` on the first load after a login with
-  // // cookieless mode. A potential solution to fix this bug is to delay
-  // // emitting `state$` until the session ID has been converted to a token
-  // const firstMessage = messages.pipe(first())
-
   const token$ = messages.pipe(
     startWith(isCookielessCompatibleLoginMethod(loginMethod) ? getToken(projectId) : null),
   )
@@ -202,8 +231,6 @@ export function _createAuthStore({
   }
 
   const state$ = token$.pipe(
-    // // see above
-    // debounce(() => firstMessage),
     map((token) =>
       clientFactory({
         projectId,
@@ -244,6 +271,8 @@ export function _createAuthStore({
     // workaround for https://github.com/vercel/next.js/issues/91819
     clearSessionId()
 
+    // No session ID means this is a normal cold load, not a post-login redirect.
+    // Broadcast the existing token (if any) so state$ can check /users/me.
     if (!sessionId) {
       broadcast(loginMethod === 'cookie' ? null : getToken(projectId))
       return {
@@ -254,10 +283,15 @@ export function _createAuthStore({
       }
     }
 
-    const requestClient = clientFactory({
+    // --- Post-login redirect: we have a session ID from the auth provider ---
+
+    // Step 1: Exchange the session ID for a token (and a cookie as a side effect).
+    // The fetch uses credentials: include so the browser stores the Set-Cookie
+    // under the correct partition key (the Studio's origin).
+    const exchangeClient = clientFactory({
       projectId,
       dataset,
-      useCdn: true,
+      useCdn: false,
       withCredentials: true,
       apiVersion: '2021-06-07',
       requestTagPrefix: 'sanity.studio',
@@ -265,63 +299,132 @@ export function _createAuthStore({
       ...hostOptions,
     })
 
-    let currentUser
-    if (loginMethod === 'dual' || loginMethod === 'cookie') {
-      // try to get the current user by using the cookie credentials
-      currentUser = await getCurrentUser(requestClient, broadcast)
-    }
-
-    // If we have a user, or token authentication is explicitly disallowed (`cookie` mode),
-    // then we don't need/want to fetch a token
-    if (currentUser || loginMethod === 'cookie') {
-      // if that worked, then we don't need to fetch a token
-      broadcast(null)
-      return {
-        loginMethod,
-        flow: 'cookie-auth',
-        success: !!currentUser,
-        durationMs: Math.round(performance.now() - startTime),
-        failureReason: currentUser ? undefined : 'cookie auth failed, login method is cookie-only',
-      }
-    }
-
-    // If we allow using token authentication, we should try to trade the session ID
-    // for a token and store it locally for subsequent use
-    const tokenExchangeStart = performance.now()
+    let token: string
+    const exchangeStart = performance.now()
     try {
-      const token = await tradeSessionForToken(requestClient, sessionId)
-      broadcast(token ?? null)
-      return {
-        loginMethod,
-        flow: 'token-exchange',
-        success: !!token,
-        durationMs: Math.round(performance.now() - startTime),
-        tokenExchangeDurationMs: Math.round(performance.now() - tokenExchangeStart),
-        failureReason: token ? undefined : 'token exchange returned empty token',
-      }
+      token = await exchangeSessionForToken(exchangeClient, sessionId)
     } catch (err) {
       broadcast(null)
       return {
         loginMethod,
-        flow: 'token-exchange',
+        flow: 'exchange',
         success: false,
         durationMs: Math.round(performance.now() - startTime),
-        tokenExchangeDurationMs: Math.round(performance.now() - tokenExchangeStart),
-        failureReason: err instanceof Error ? err.message : 'token exchange failed',
+        exchangeDurationMs: Math.round(performance.now() - exchangeStart),
+        failureReason: err instanceof Error ? err.message : 'exchange failed',
+        error: {
+          type: 'auth-failed',
+          message: 'Failed to exchange session for credentials. Please try logging in again.',
+        },
       }
     }
-  }
+    const exchangeDurationMs = Math.round(performance.now() - exchangeStart)
 
-  async function tradeSessionForToken(client: SanityClient, sessionId: string): Promise<string> {
-    const {token} = await client.request<{token: string}>({
-      method: 'GET',
-      uri: `/auth/fetch`,
-      query: {sid: sessionId},
-      tag: 'auth.fetch-token',
-    })
+    // Step 2: Probe which auth methods work by calling /users/me.
+    // We create separate clients for each probe to isolate the auth mechanisms.
+    // Only create the clients we actually need for the configured login method.
+    const probeStart = performance.now()
 
-    saveToken({token, projectId})
-    return token
+    const probeClientOptions = {
+      projectId,
+      dataset,
+      useCdn: false,
+      apiVersion: '2021-06-07',
+      requestTagPrefix: 'sanity.studio',
+      headers: DEFAULT_STUDIO_CLIENT_HEADERS,
+      ...hostOptions,
+    } as const
+
+    let cookieUser: CurrentUser | null = null
+    let tokenUser: CurrentUser | null = null
+
+    if (loginMethod === 'dual') {
+      // Dual mode: probe both methods in parallel
+      const [cookieResult, tokenResult] = await Promise.allSettled([
+        probeCurrentUser(clientFactory({...probeClientOptions, withCredentials: true})),
+        probeCurrentUser(clientFactory({...probeClientOptions, token})),
+      ])
+      cookieUser = cookieResult.status === 'fulfilled' ? cookieResult.value : null
+      tokenUser = tokenResult.status === 'fulfilled' ? tokenResult.value : null
+    } else if (loginMethod === 'cookie') {
+      // Cookie-only mode: only probe cookies
+      cookieUser = await probeCurrentUser(
+        clientFactory({...probeClientOptions, withCredentials: true}),
+      )
+    } else {
+      // Token-only mode: only probe token
+      tokenUser = await probeCurrentUser(clientFactory({...probeClientOptions, token}))
+    }
+
+    const probeDurationMs = Math.round(performance.now() - probeStart)
+    const durationMs = Math.round(performance.now() - startTime)
+
+    // Step 3: Determine the outcome based on which probes succeeded.
+
+    // Prefer cookie auth when available (avoids storing tokens in localStorage)
+    if (cookieUser) {
+      broadcast(null)
+      return {
+        loginMethod,
+        flow: 'exchange',
+        success: true,
+        durationMs,
+        exchangeDurationMs,
+        probeDurationMs,
+        authMethod: 'cookie',
+      }
+    }
+
+    if (tokenUser) {
+      saveToken({token, projectId})
+      broadcast(token)
+      return {
+        loginMethod,
+        flow: 'exchange',
+        success: true,
+        durationMs,
+        exchangeDurationMs,
+        probeDurationMs,
+        authMethod: 'token',
+      }
+    }
+
+    // Neither probe succeeded
+    broadcast(null)
+
+    if (loginMethod === 'cookie') {
+      return {
+        loginMethod,
+        flow: 'exchange',
+        success: false,
+        durationMs,
+        exchangeDurationMs,
+        probeDurationMs,
+        failureReason: 'cookie probe failed in cookie-only mode',
+        error: {
+          type: 'cookie-blocked',
+          message:
+            'Authentication could not be completed because this browser appears to block ' +
+            'third-party cookies. This studio is configured to use cookie-based authentication ' +
+            'only. Try using a different browser, disabling strict cookie blocking, or ask the ' +
+            'studio administrator to enable token-based authentication.',
+        },
+      }
+    }
+
+    return {
+      loginMethod,
+      flow: 'exchange',
+      success: false,
+      durationMs,
+      exchangeDurationMs,
+      probeDurationMs,
+      failureReason: 'all auth probes failed',
+      error: {
+        type: 'auth-failed',
+        message: 'Authentication failed. Please try logging in again.',
+      },
+    }
   }
 
   async function logout() {

--- a/packages/sanity/src/core/store/_legacy/authStore/createLoginComponent.tsx
+++ b/packages/sanity/src/core/store/_legacy/authStore/createLoginComponent.tsx
@@ -77,16 +77,18 @@ function createHrefForProvider({
   params.set('origin', `${window.location.origin}${redirectPath}`)
   params.set('projectId', projectId)
 
-  // Setting `type=token` will return the sid as part of the _query_, which may end up in
-  // server access logs and similar. Instead, use `withSid=true` to return the sid as part
-  // of the _hash_ instead, which is only accessible to the client. Other auth types will
-  // use the `type` parameter - `dual` will automatically use the hash, so do not need the
-  // additional parameter.
   if (loginMethod === 'token') {
+    // Token-only mode: don't set a type (avoids cookie being set server-side).
+    // withSid=true returns the sid in the URL hash instead of the query string,
+    // keeping it out of server access logs.
     params.set('withSid', 'true')
   } else {
-    params.set('type', loginMethod)
+    // Both 'dual' and 'cookie' modes use type=dual so the backend returns both
+    // a cookie (via /transfer redirect) and a sid in the hash. The Studio then
+    // probes which auth method actually works after calling /auth/exchange.
+    params.set('type', 'dual')
   }
+
   return `${url}?${params}`
 }
 

--- a/packages/sanity/src/core/store/_legacy/authStore/types.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/types.ts
@@ -96,7 +96,8 @@ export type LoginComponentProps =
 
 /**
  * Result returned from `handleCallbackUrl` describing what happened during
- * the auth callback flow. Used for telemetry and diagnostics.
+ * the auth callback flow. Used for telemetry, diagnostics, and error handling
+ * in the AuthBoundary.
  *
  * @internal
  */
@@ -105,17 +106,32 @@ export interface HandleCallbackResult {
   loginMethod: LoginMethod
   /**
    * Which auth flow was taken:
-   * - `'already-authenticated'`: User was already authenticated; no exchange needed.
-   * - `'cookie-auth'`: Attempted cookie-based authentication via `/users/me`.
-   * - `'token-exchange'`: Traded a session ID for a persistent token.
+   * - `'already-authenticated'`: No sid in hash - user was already authenticated or not.
+   * - `'exchange'`: sid was present, went through /auth/exchange + probe flow.
    */
-  flow: 'already-authenticated' | 'cookie-auth' | 'token-exchange'
+  flow: 'already-authenticated' | 'exchange'
   /** Whether the auth flow completed successfully. */
   success: boolean
   /** Total wall-clock time for the callback handling, in milliseconds. */
   durationMs: number
-  /** Time spent on the session-to-token exchange specifically. Only set for `'token-exchange'` flow. */
-  tokenExchangeDurationMs?: number
+  /** Time spent on the /auth/exchange call specifically. Only set for `'exchange'` flow. */
+  exchangeDurationMs?: number
+  /** Time spent on the /users/me probe calls. Only set for `'exchange'` flow. */
+  probeDurationMs?: number
+  /** Which auth method was selected by the probes. Only set when `success` is `true` and flow is `'exchange'`. */
+  authMethod?: 'cookie' | 'token'
   /** Human-readable reason for failure. Only set when `success` is `false`. */
   failureReason?: string
+  /**
+   * Structured error for the AuthBoundary to render appropriate UI.
+   * Only set when `success` is `false` and flow is `'exchange'`.
+   *
+   * - `'cookie-blocked'`: cookie-only mode and the cookie probe failed.
+   *   The browser likely has strict cookie policies.
+   * - `'auth-failed'`: all probe methods failed. The user should retry.
+   */
+  error?: {
+    type: 'cookie-blocked' | 'auth-failed'
+    message: string
+  }
 }

--- a/packages/sanity/src/core/studio/AuthBoundary.tsx
+++ b/packages/sanity/src/core/studio/AuthBoundary.tsx
@@ -1,7 +1,11 @@
+/* eslint-disable @sanity/i18n/no-attribute-string-literals */
 import {useTelemetry} from '@sanity/telemetry/react'
-import {type ComponentType, type ReactNode, useEffect, useState} from 'react'
+import {Card, Flex, Heading, Stack, Text} from '@sanity/ui'
+import {type ComponentType, type ReactNode, useCallback, useEffect, useState} from 'react'
 
+import {Button} from '../../ui-components'
 import {LoadingBlock} from '../components/loadingBlock'
+import {type HandleCallbackResult} from '../store/_legacy/authStore/types'
 import {
   AuthBoundaryResolved,
   SessionTokenExchangeCompleted,
@@ -25,27 +29,32 @@ export function AuthBoundary({
   const [error, handleError] = useState<unknown>(null)
   if (error) throw error
 
-  const [loggedIn, setLoggedIn] = useState<'logged-in' | 'logged-out' | 'loading' | 'unauthorized'>(
-    'loading',
-  )
+  const [status, setStatus] = useState<
+    'logged-in' | 'logged-out' | 'loading' | 'unauthorized' | 'error'
+  >('loading')
+  const [authError, setAuthError] = useState<HandleCallbackResult['error']>()
   const [loginProvider, setLoginProvider] = useState<string | undefined>()
   const {activeWorkspace} = useActiveWorkspace()
   const telemetry = useTelemetry()
   const [mountTime] = useState(() => performance.now())
   useEffect(() => {
-    if (loggedIn !== 'loading') {
+    if (status !== 'loading') {
       telemetry.log(AuthBoundaryResolved, {
         durationMs: Math.round(performance.now() - mountTime),
-        result: loggedIn,
+        result: status,
       })
     }
-  }, [loggedIn, telemetry, mountTime])
+  }, [status, telemetry, mountTime])
 
   useEffect(() => {
     activeWorkspace.auth
       .handleCallbackUrl?.()
       .then((result) => {
         telemetry.log(SessionTokenExchangeCompleted, result)
+        if (!result.success && result.error) {
+          setAuthError(result.error)
+          setStatus('error')
+        }
       })
       .catch(handleError)
   }, [activeWorkspace.auth, telemetry])
@@ -53,23 +62,22 @@ export function AuthBoundary({
   useEffect(() => {
     const subscription = activeWorkspace.auth.state.subscribe({
       next: ({authenticated, currentUser}) => {
-        /**
-         * If a user has never had any roles on for the given workspace project
-         * e.g. because they've only ever been an organization member thereby
-         * giving them implicit access to the studio then they will have no roles
-         * array on their user so to account for this case or the case that they have
-         * had roles removed then we need to set the logged in state to unauthorized.
-         */
-        if (
-          authenticated &&
-          (!Array.isArray(currentUser?.roles) || currentUser.roles.length === 0)
-        ) {
-          setLoggedIn('unauthorized')
-          if (currentUser?.provider) setLoginProvider(currentUser.provider)
-          return
-        }
+        setStatus((prev) => {
+          // Don't let a state$ emission override the error state - the
+          // handleCallbackUrl result takes precedence when auth exchange fails,
+          // as state$ may emit 'logged-out' from the broadcast(null) on failure.
+          if (prev === 'error') return prev
 
-        setLoggedIn(authenticated ? 'logged-in' : 'logged-out')
+          if (
+            authenticated &&
+            (!Array.isArray(currentUser?.roles) || currentUser.roles.length === 0)
+          ) {
+            if (currentUser?.provider) setLoginProvider(currentUser.provider)
+            return 'unauthorized'
+          }
+
+          return authenticated ? 'logged-in' : 'logged-out'
+        })
       },
       error: handleError,
     })
@@ -79,20 +87,51 @@ export function AuthBoundary({
     }
   }, [activeWorkspace])
 
-  if (loggedIn === 'loading') return <LoadingComponent />
+  const handleRetry = useCallback(() => {
+    setAuthError(undefined)
+    setStatus('logged-out')
+  }, [])
 
-  if (loggedIn === 'unauthorized') {
-    // If using unverified `sanity` login provider, send them
-    // to basic NotAuthorized component.
+  if (status === 'loading') return <LoadingComponent />
+
+  if (status === 'error' && authError) {
+    return <AuthErrorScreen error={authError} onRetry={handleRetry} />
+  }
+
+  if (status === 'unauthorized') {
     if (!loginProvider || loginProvider === 'sanity') return <NotAuthenticatedComponent />
-    // Otherwise, send user to request access screen
     return <RequestAccessScreen />
   }
 
-  // NOTE: there is currently a bug where the `AuthenticateComponent` will
-  // flash after the first login with cookieless mode. See `createAuthStore`
-  // for details
-  if (loggedIn === 'logged-out') return <AuthenticateComponent />
+  if (status === 'logged-out') return <AuthenticateComponent />
 
   return <>{children}</>
+}
+
+function AuthErrorScreen({
+  error,
+  onRetry,
+}: {
+  error: NonNullable<HandleCallbackResult['error']>
+  onRetry: () => void
+}) {
+  const heading = error.type === 'cookie-blocked' ? 'Cookies blocked' : 'Authentication failed'
+
+  return (
+    <Card height="fill">
+      <Flex align="center" justify="center" height="fill" padding={4}>
+        <Stack space={4} style={{maxWidth: 400}}>
+          <Heading as="h1" size={1}>
+            {heading}
+          </Heading>
+          <Text muted size={1}>
+            {error.message}
+          </Text>
+          {error.type === 'auth-failed' && (
+            <Button text="Try again" tone="default" onClick={onRetry} size="large" />
+          )}
+        </Stack>
+      </Flex>
+    </Card>
+  )
 }

--- a/packages/sanity/src/core/studio/__telemetry__/authBoundary.telemetry.ts
+++ b/packages/sanity/src/core/studio/__telemetry__/authBoundary.telemetry.ts
@@ -3,23 +3,25 @@ import {defineEvent} from '@sanity/telemetry'
 /** Fired when the AuthBoundary resolves from 'loading' to a final auth state. */
 export const AuthBoundaryResolved = defineEvent<{
   durationMs: number
-  result: 'logged-in' | 'logged-out' | 'unauthorized'
+  result: 'logged-in' | 'logged-out' | 'unauthorized' | 'error'
 }>({
   name: 'Auth Boundary Resolved',
-  version: 1,
+  version: 2,
   description: 'Time from AuthBoundary mount until auth state is resolved',
 })
 
 /** Fired when handleCallbackUrl completes in the auth store. */
 export const SessionTokenExchangeCompleted = defineEvent<{
   loginMethod: 'dual' | 'cookie' | 'token'
-  flow: 'already-authenticated' | 'cookie-auth' | 'token-exchange'
+  flow: 'already-authenticated' | 'exchange'
   success: boolean
   durationMs: number
-  tokenExchangeDurationMs?: number
+  exchangeDurationMs?: number
+  probeDurationMs?: number
+  authMethod?: 'cookie' | 'token'
   failureReason?: string
 }>({
   name: 'Session Token Exchange Completed',
-  version: 1,
-  description: 'Result of the session token exchange flow in handleCallbackUrl',
+  version: 2,
+  description: 'Result of the auth exchange flow in handleCallbackUrl',
 })


### PR DESCRIPTION
### Description

Replaces the Studio's post-login auth flow with a new `/auth/exchange` endpoint to fix partitioned cookie issues.

- The old flow tried cookie-based `/users/me` first, then fell back to exchanging the session ID for a token via `/auth/fetch`. This broke because the `Partitioned` cookie set during the transfer redirect is stored under the API host's partition key, not the Studio's - so the cookie is never sent on subsequent cross-site fetches.
- The new flow calls `/auth/exchange?sid=...` with `credentials: include`, which both sets a cookie under the correct partition key and returns the token in the response body. It then probes `/users/me` with each auth method (cookie and/or token, depending on `loginMethod`) in parallel to determine which one actually works.
- Cookie mode now sends `type=dual` to the auth provider instead of `type=cookie`, so a session ID is always returned in the hash.
- The AuthBoundary now has an `error` state that prevents flashing login providers when auth fails after a redirect. Instead it shows an appropriate error message ("Cookies blocked" for cookie-only mode, "Authentication failed" with retry for other modes).

### What to review

- `createAuthStore.ts` has the core flow rewrite - the three-step exchange/probe/decide logic in `handleCallbackUrl`, plus two new helpers (`probeCurrentUser`, `exchangeSessionForToken`)
- The race condition guard in `AuthBoundary.tsx` (the `setStatus` callback form that prevents `state$` from overriding the error state)
- The `createHrefForProvider` change is small but important - cookie mode now sends `type=dual`

All changes are in the `sanity` package.

### Testing

No automated tests added. The auth flow depends on real browser cookie behavior, cross-origin fetch, and server-side session management that can't be meaningfully mocked in jsdom. The existing test suite passes with no regressions.

Manual testing needed:
- Login with dual mode (default) - should prefer cookie auth when available, fall back to token
- Login with cookie-only mode in a browser that blocks third-party cookies - should show "Cookies blocked" error
- Login with token-only mode - should store token and use bearer auth
- Cold load when already authenticated - should work as before

### Notes for release

N/A - Part of auth infrastructure improvements. No user-facing API changes.