### PR TITLE
refactor: add privacy policy link

### DIFF
--- a/packages/sanity/src/core/feedback/__tests__/feedbackClient.test.ts
+++ b/packages/sanity/src/core/feedback/__tests__/feedbackClient.test.ts
@@ -162,7 +162,7 @@ describe('sendFeedbackToSentry', () => {
       expect(event.tags.contactName).toBe('Test User')
     })
 
-    it('still strips userId from tags', async () => {
+    it('preserves userId in tags', async () => {
       await sendFeedbackToSentry(
         makePayload({
           telemetryConsent: 'denied',
@@ -176,7 +176,7 @@ describe('sendFeedbackToSentry', () => {
       )
 
       const [event] = mockCaptureEvent.mock.calls[0]
-      expect(event.tags).not.toHaveProperty('userId')
+      expect(event.tags.userId).toBe('user-123')
     })
   })
 

--- a/packages/sanity/src/core/feedback/components/FeedbackDialog.tsx
+++ b/packages/sanity/src/core/feedback/components/FeedbackDialog.tsx
@@ -3,7 +3,7 @@ import {Card, Flex, Stack, Switch, Text, TextArea, useToast} from '@sanity/ui'
 import {type ChangeEvent, type ClipboardEvent, useCallback, useId, useState} from 'react'
 
 import {Button, Dialog} from '../../../ui-components'
-import {useTranslation} from '../../i18n'
+import {Translate, useTranslation} from '../../i18n'
 import {useInStudioFeedback} from '../hooks/useInStudioFeedback'
 import {type Sentiment} from '../types'
 import {ImageAttachment} from './ImageAttachment'
@@ -241,6 +241,23 @@ export function FeedbackDialog(props: FeedbackDialogProps) {
 
                 <Text size={1} muted>
                   {t('feedback.consent.disclaimer')}
+                </Text>
+                <Text size={1} muted>
+                  <Translate
+                    t={t}
+                    i18nKey="feedback.consent.disclaimer.privacy"
+                    components={{
+                      PrivacyLink: ({children}) => (
+                        <a
+                          href="https://www.sanity.io/legal/privacy"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {children}
+                        </a>
+                      ),
+                    }}
+                  />
                 </Text>
               </Stack>
               <Flex align="center" gap={2}>

--- a/packages/sanity/src/core/feedback/feedbackClient.ts
+++ b/packages/sanity/src/core/feedback/feedbackClient.ts
@@ -57,17 +57,16 @@ export async function sendFeedbackToSentry(payload: FeedbackPayload): Promise<st
   const hasContactConsent = String(tags.contactConsent) === 'true'
   // Keep in mind that users should be made aware that their name and email are shared with the Sanity team
   // In the UI, even if they have given us consent
-  const shareName = hasTelemetryConsent || hasContactConsent
-  const shareEmail = hasTelemetryConsent || hasContactConsent
+  const sharePii = hasTelemetryConsent || hasContactConsent
 
   const {userId: _userId, ...safeTags} = tags
-  const eventTags = hasTelemetryConsent ? tags : safeTags
+  const eventTags = sharePii ? tags : safeTags
 
   const feedbackEvent = {
     contexts: {
       feedback: {
-        contactEmail: shareEmail ? email : undefined,
-        name: shareName ? name : undefined,
+        contactEmail: sharePii ? email : undefined,
+        name: sharePii ? name : undefined,
         message,
         url: tags.url,
         source,
@@ -78,8 +77,8 @@ export async function sendFeedbackToSentry(payload: FeedbackPayload): Promise<st
     tags: {
       ...eventTags,
       feedbackVersion,
-      ...(shareName ? {contactName: name ?? ''} : {}),
-      ...(shareEmail ? {contactEmail: email ?? ''} : {}),
+      ...(sharePii ? {contactName: name ?? ''} : {}),
+      ...(sharePii ? {contactEmail: email ?? ''} : {}),
       telemetryConsent,
       type: 'feedback',
       source,

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -549,7 +549,10 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Cancel button text */
   'feedback.cancel': 'Cancel',
   /** Consent disclaimer shown when the user agrees to follow up */
-  'feedback.consent.disclaimer': `We'd love to learn more. Selecting yes shares your name and email with the Sanity team.`,
+  'feedback.consent.disclaimer':
+    'By selecting yes, you agree to share your name and email with the Sanity team.',
+  /** Consent disclaimer privacy policy link */
+  'feedback.consent.disclaimer.privacy': 'See our <PrivacyLink>Privacy Policy</PrivacyLink>.',
   /** Label for the contact consent toggle */
   'feedback.consent.label': 'Can we follow up with you about this feedback?',
   /** Consent toggle: no */


### PR DESCRIPTION
### Description

<img width="676" height="573" alt="image" src="https://github.com/user-attachments/assets/64b0d40f-0ceb-487c-bb18-abb0d0267c56" />

This PR updates the feedback dialog's contact consent flow and PII handling:

- Added a disclaimer when toggled to "Yes" explaining name and email will be shared, with a link to the Privacy Policy (https://www.sanity.io/legal/privacy)
- PII stripping updated: if the user gives contact consent, all PII (name, email, userId) is preserved regardless of telemetry status. PII is only stripped when both telemetry and contact consent are denied. This has been verified with Francis and Andrej.

### What to review

Does it make sense and anything jumping at you?

### Notes for release

N/A: Internal feedback system changes only. No public API changes.