### PR TITLE
fix(sanity): scope popover modal focus trapping to owner pane

### DIFF
--- a/packages/sanity/src/core/components/popoverDialog/PopoverDialog.tsx
+++ b/packages/sanity/src/core/components/popoverDialog/PopoverDialog.tsx
@@ -1,7 +1,16 @@
 import {CloseIcon} from '@sanity/icons'
-import {Box, Flex, Layer, type ResponsiveWidthProps, Stack, Text, type Theme} from '@sanity/ui'
+import {
+  Box,
+  Flex,
+  Layer,
+  type ResponsiveWidthProps,
+  Stack,
+  Text,
+  type Theme,
+  usePortal,
+} from '@sanity/ui'
 import {type Dispatch, type ReactNode, type SetStateAction, useCallback} from 'react'
-import TrapFocus from 'react-focus-lock'
+import TrapFocus, {type ReactFocusLockProps} from 'react-focus-lock'
 import {css, styled} from 'styled-components'
 
 import {Button, Popover, type PopoverProps} from '../../../ui-components'
@@ -43,6 +52,7 @@ interface PopoverDialogProps {
 /** @internal */
 export function PopoverDialog(props: PopoverDialogProps) {
   const {children, header, onClose, referenceElement, containerRef, width} = props
+  const portal = usePortal()
 
   const handleClose = useCallback(() => {
     onClose()
@@ -51,10 +61,23 @@ export function PopoverDialog(props: PopoverDialogProps) {
     referenceElement?.focus()
   }, [onClose, referenceElement])
 
+  // If the popover is opened inside a portal, trap focus only in that portal.
+  // This allows focus interactions in panes outside of the portal scope, which
+  // is especially important if the popover contains links to content that opens
+  // in a separate pane (such as a reference).
+  //
+  // Note that providing an allow list to `TrapFocus` in this way does not enable
+  // keyboard navigation outside of the `TrapFocus` component. This can be
+  // enabled using groups or shards.
+  //
+  // https://github.com/theKashey/react-focus-lock/issues/97#issuecomment-594844115
+  const trapPaneFocus: ReactFocusLockProps['whiteList'] = (interactionElement) =>
+    !portal.element || portal.element.contains(interactionElement)
+
   // @todo: these use the same styles as dialogs, can this be shared?
   const content = (
     <PopoverContainer width={width} data-testid="popover-dialog">
-      <TrapFocus autoFocus>
+      <TrapFocus autoFocus whiteList={trapPaneFocus}>
         <Stack ref={containerRef}>
           <StickyLayer>
             <Box padding={2} paddingLeft={4}>


### PR DESCRIPTION
### Description

If a dialog popover is opened inside a pane, focus will now only be trapped inside the scope of the containing portal element (if there is one).

This allows focus interactions in panes outside of the popover scope, which is especially important if the popover contains links to content that opens in a separate pane (such as a reference).

### What to review

Focus trapping inside an object set to popover mode. For example, "Array of multiple types (modal.type=popover)" found at `http://localhost:3333/test/structure/input-standard;arraysTest`.

Prior to this fix, when opening a reference inside an object in a pane, the editor was unable to focus any fields in the reference pane. There is a video of this behaviour in SAPP-3688.

### Testing

- Verified popover focus trapping still works correctly.
- Verified focus is now possible in other panes while popover dialog is open.

### Notes for release

Fixes an issue preventing referenced document from being edited when opened from an object in popover mode.