### PR TITLE
chore(deps): bump GitHub Actions dependencies to latest versions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v5
 
     - uses: actions/setup-node@v6
       with:

--- a/.github/actions/vercel-env/action.yml
+++ b/.github/actions/vercel-env/action.yml
@@ -32,7 +32,7 @@ runs:
       run: pnpm vercel env pull .env.tmp --yes --environment=${{ inputs.environment }} --token=${{ inputs.token }}
 
     - name: Load Vercel environment variables into GITHUB_ENV
-      uses: actions/github-script@v6
+      uses: actions/github-script@v8
       with:
         script: |
           const dotenv = require('dotenv')

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -101,7 +101,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Create or update PR
-        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         id: create-pull-request
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/e2e-ct.yml
+++ b/.github/workflows/e2e-ct.yml
@@ -81,7 +81,7 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=8192
         run: pnpm --filter sanity test:ct --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-ct-report-${{ matrix.project }}-${{ matrix.shardIndex }}
@@ -111,7 +111,7 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Download blob reports from Github Actions Artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: playwright-ct-report-*
           merge-multiple: true
@@ -120,7 +120,7 @@ jobs:
       - name: Merge into HTML Report
         run: npx playwright merge-reports --reporter json ${{ github.workspace }}/packages/sanity/playwright-ct/playwright-ct-report >> ${{ github.workspace }}/packages/sanity/playwright-ct/playwright-ct-report/playwright-ct-test-results.json
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: full-playwright-ct-report

--- a/.github/workflows/e2e-embedded.yml
+++ b/.github/workflows/e2e-embedded.yml
@@ -92,7 +92,7 @@ jobs:
         run: pnpm embedded-studio-vite:test --project ${{ matrix.project }}
 
       - name: Upload Playwright Report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report-${{ matrix.project }}

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -17,7 +17,7 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
@@ -31,7 +31,7 @@ jobs:
       - name: Namespace version with build run id
         run: npm version --no-git-commit-hooks --no-git-tag-version "${{ steps.npm-version.outputs.NPM_VERSION }}-gh.${{ github.run_id }}"
       - run: pnpm pack --pack-destination ./artifacts
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: pack-sanity-ui
           path: artifacts
@@ -52,7 +52,7 @@ jobs:
           repository: sanity-io/sanity
       - uses: ./.github/actions/setup
 
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: pack-sanity-ui
           path: artifacts
@@ -84,7 +84,7 @@ jobs:
         with:
           repository: sanity-io/sanity
       - uses: ./.github/actions/setup
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: pack-sanity-ui
           path: artifacts
@@ -147,7 +147,7 @@ jobs:
         with:
           repository: sanity-io/sanity
       - uses: ./.github/actions/setup
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: pack-sanity-ui
           path: artifacts
@@ -186,7 +186,7 @@ jobs:
         # As e2e:build ran in the `install` job, turbopack restores it from cache here
         run: pnpm e2e:build && pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report-${{ matrix.project }}-${{ matrix.shardIndex }}
@@ -204,7 +204,7 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Download blob reports from Github Actions Artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: playwright-report-*
           merge-multiple: true
@@ -219,7 +219,7 @@ jobs:
           fi
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: always() && hashFiles('playwright-report/**') != ''
         with:
           name: full-html-report--attempt-${{ github.run_attempt }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -229,7 +229,7 @@ jobs:
           SANITY_E2E_DATASET: ${{ (matrix.project == 'chromium') && env.CHROMIUM_DATASET || env.FIREFOX_DATASET }}
         run: pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report-${{ matrix.project }}-${{ matrix.shardIndex }}
@@ -261,7 +261,7 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Download blob reports from Github Actions Artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: playwright-report-*
           merge-multiple: true
@@ -272,7 +272,7 @@ jobs:
 
       - name: Upload HTML report
         id: upload-playwright-report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: full-html-report--attempt-${{ github.run_attempt }}
           path: playwright-report

--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -201,7 +201,7 @@ jobs:
           STUDIO_URL: ${{ needs.deploy.outputs.preview_url }}
         run: pnpm efps:test -- -- --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: efps-report-${{ matrix.shardIndex }}-attempt-${{ github.run_attempt }}
@@ -217,7 +217,7 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Download blob reports from Github Actions Artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: efps-report-*
           merge-multiple: true

--- a/.github/workflows/generate-dts-tests-if-needed.yml
+++ b/.github/workflows/generate-dts-tests-if-needed.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           app-id: ${{ secrets.ECOSPARK_APP_ID }}
           private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
-      - uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8
+      - uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         id: create-pull-request
         with:
           body: "I ran `pnpm generate:dts-exports` 🧑‍💻. If you need to investigate where new imports are coming from run `TEST_DTS_EXPORTS_DIAGNOSTICS=full pnpm generate:dts-exports` 💡"

--- a/.github/workflows/lint-fix-if-needed.yml
+++ b/.github/workflows/lint-fix-if-needed.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           app-id: ${{ secrets.ECOSPARK_APP_ID }}
           private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
-      - uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8
+      - uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         # Run even if `lint:fix` fails
         if: always()
         id: create-pull-request

--- a/.github/workflows/mark_issues_done_on_release.yml
+++ b/.github/workflows/mark_issues_done_on_release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Mark Growth Linear issues Done
         id: mark-growth-issues-done

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -42,7 +42,7 @@ jobs:
           pnpx pkg-pr-new publish --pnpm --no-template --json output.json --comment=off --compact ${{ steps.pre-flight.outputs.packages }}
 
       - name: Post or update comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pnpm-if-needed.yml
+++ b/.github/workflows/pnpm-if-needed.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           app-id: ${{ secrets.ECOSPARK_APP_ID }}
           private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
-      - uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8
+      - uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         id: create-pull-request
         with:
           body: I ran `pnpm dedupe` 🧑‍💻

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -205,7 +205,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_CI_ALERTS }}
           webhook-type: incoming-webhook

--- a/.github/workflows/release-next-major.yml
+++ b/.github/workflows/release-next-major.yml
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_CI_ALERTS }}
           webhook-type: incoming-webhook

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_CI_ALERTS }}
           webhook-type: incoming-webhook

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload blob report to GitHub Actions Artifacts
         if: ${{ !cancelled() && matrix.node == '20' }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: blob-report-${{ github.run_id }}-${{ matrix.shardIndex }}
           path: ".vitest-reports/*"
@@ -114,7 +114,7 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: "Download coverage artifacts"
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: .vitest-reports
           pattern: blob-report-${{ github.run_id }}-*
@@ -128,4 +128,4 @@ jobs:
 
       - name: Report coverage
         if: steps.merge_reports.outcome == 'success'
-        uses: davelosert/vitest-coverage-report-action@bd52af59d9cd548ea7cd405044d2458042e6d888 # v2
+        uses: davelosert/vitest-coverage-report-action@c0c9b09c93750ee1d8335d14e94ce3d6fc61df50 # v2.11.0

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -49,13 +49,13 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
 
@@ -89,7 +89,7 @@ jobs:
 
       - name: Upload TypeDoc artifact
         if: steps.generate.outputs.success == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sanity-typedoc-${{ github.sha }}
           path: packages/sanity/docs/sanity-typedoc-output.json

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -16,6 +16,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Bumps all outdated GitHub Actions dependencies to their latest versions across 19 workflow files.

### Tag version bumps
| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | v4, v5 | v6 |
| `actions/setup-node` | v5 | v6 |
| `actions/upload-artifact` | v4, v6 | v7 |
| `actions/download-artifact` | v7 | v8 |
| `actions/github-script` | v6 | v8 |
| `pnpm/action-setup` | v4 | v5 |

### Hash-pinned version bumps
| Action | Old | New |
|--------|-----|-----|
| `peter-evans/create-pull-request` | v8.0.0 | v8.1.0 |
| `slackapi/slack-github-action` | v2.1.1 | v3.0.1 |
| `amannn/action-semantic-pull-request` | v5 | v6.1.1 |
| `davelosert/vitest-coverage-report-action` | v2 | v2.11.0 |

All major version bumps are Node.js runtime updates (20 to 24) with no input/output API changes. One thing to note: `actions/download-artifact` v8 now errors on hash digest mismatches by default (previously warned).

## What to review

- Verify CI workflows pass with the updated action versions
- Pay attention to any download-artifact digest mismatch errors

## Testing

- CI pipeline should validate all workflows

## Notes for release

N/A