### PR TITLE
chore(ci): add renovate concurrency limits

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,8 @@
     "github>sanity-io/renovate-config:workarounds-esm",
     "github>sanity-io/renovate-config:dedupe"
   ],
+  "branchConcurrentLimit": 3,
+  "prConcurrentLimit": 5,
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {


### PR DESCRIPTION
## Summary
- Adds `branchConcurrentLimit: 3` and `prConcurrentLimit: 5` to cap peak memory usage per Renovate run

Reduces memory consumption to help Renovate stay within the free tier limits on this large pnpm monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)