### PR TITLE
chore(ci): set renovate nodeMaxMemory to 1GB

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -139,5 +139,8 @@
       "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{configDescription}}}{{{controls}}}{{{footer}}}\n### Notes for release\n{{{changelogs}}}"
     }
   ],
+  "toolSettings": {
+    "nodeMaxMemory": "1024"
+  },
   "ignorePaths": ["packages/sanity/fixtures/examples/prj-with-react-19/package.json"]
 }


### PR DESCRIPTION
Renovate is [currently failing](https://developer.mend.io/github/sanity-io/sanity/-/job/73fb0b90-dbf8-4ccf-9136-d9342c25613c) with `kernel-out-of-memory`.

Lets see if setting `toolSettings.nodeMaxMemory` helps, re: https://github.com/renovatebot/renovate/discussions/41982#discussioncomment-16273010

I chose 1024MB based on this comment: https://github.com/renovatebot/renovate/discussions/40942#discussioncomment-16011497

From the comments it looks like we might need to tweak it further, but lets see.