### PR TITLE
chore(ci): change nodeMaxMemory from string to number

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -140,7 +140,7 @@
     }
   ],
   "toolSettings": {
-    "nodeMaxMemory": "1024"
+    "nodeMaxMemory": 1536
   },
   "ignorePaths": ["packages/sanity/fixtures/examples/prj-with-react-19/package.json"]
 }


### PR DESCRIPTION
### Description

Should have had an additional cup of coffee this morning. The `toolSettings.nodeMaxMemory` setting from https://github.com/sanity-io/sanity/pull/12548 must be a number, not a string 🤦🏼 

### What to review
- Also upped it to 1,5GB since I have a strong suspicion 1GB won't be enough for this repo.

### Testing
Need to merge to main and re-run renovate scan to verify.