### PR TITLE
test(e2e): remove unnecessary Firefox skips from PTE fullscreen tests

### DIFF
--- a/e2e/tests/pte/FullScreenEscape.spec.ts
+++ b/e2e/tests/pte/FullScreenEscape.spec.ts
@@ -38,7 +38,9 @@ test.describe('Portable Text Input - FullScreen Escape', () => {
     page,
     browserName,
   }) => {
-    test.skip(browserName === 'firefox')
+    // In Firefox the annotation <span> layout isn't ready by the time PopoverEditDialog
+    // reads its position, so @sanity/ui's Popover keeps the hidden attribute.
+    test.skip(browserName === 'firefox', 'PopoverEditDialog stays hidden in Firefox (timing issue)')
 
     await page.getByTestId('document-panel-portal').getByRole('textbox').click()
     await page.getByTestId('document-panel-portal').getByRole('textbox').fill('test')

--- a/e2e/tests/pte/InitialFullScreen.spec.ts
+++ b/e2e/tests/pte/InitialFullScreen.spec.ts
@@ -5,12 +5,10 @@ import {test} from '../../studio-test'
 test.describe('Initial full screen', () => {
   test('if initial full screen is on for a PTE, you should be able to close it by clicking the collapse button', async ({
     page,
-    browserName,
     createDraftDocument,
   }) => {
     await createDraftDocument('/content/input-standard;portable-text;initialFullScreenPTE')
 
-    test.skip(browserName === 'firefox')
     await expect(page.getByTestId('fullscreen-button-collapse')).toBeVisible()
     await page.getByTestId('fullscreen-button-collapse').click()
     await expect(


### PR DESCRIPTION
## Description

Two PTE fullscreen tests (`InitialFullScreen.spec.ts` and `FullScreenEscape.spec.ts`) were skipped on Firefox without explanation. Investigating slow e2e CI runs revealed that these skips were placed *after* `createDraftDocument()`, meaning the test would navigate to the page, wait for the full 60s timeout to expire, fail, retry up to 2 times — and only then hit `test.skip()`. This wasted up to 3 minutes per test on every Firefox shard.

I considered simply moving the `test.skip()` before the navigation to avoid the wasted time, but since the underlying PTE fullscreen functionality works fine in Firefox (confirmed by other tests in the same file passing on retry), I figured its better to remove the skips entirely and run these tests on Firefox.

CI confirmed that `InitialFullScreen` passes on Firefox, so that skip is removed. The popover test in `FullScreenEscape` genuinely fails — the annotation `<span>` layout isn't ready by the time `PopoverEditDialog` reads its position, so `@sanity/ui`'s Popover keeps the `hidden` attribute. That skip is kept with a documented reason.

## What to review

- `InitialFullScreen.spec.ts`: Firefox skip removed — test passed on Firefox in CI.
- `FullScreenEscape.spec.ts`: Popover test skip kept with documented reason. The first test (escape to close fullscreen) now runs on Firefox.

## Notes for release
N/A
