### PR TITLE
chore(ci): bump renovate nodeMaxMemory to 2GB

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -140,7 +140,7 @@
     }
   ],
   "toolSettings": {
-    "nodeMaxMemory": 1536
+    "nodeMaxMemory": 2048
   },
   "ignorePaths": ["packages/sanity/fixtures/examples/prj-with-react-19/package.json"]
 }


### PR DESCRIPTION
Unfortunately bumping `toolSettings.nodeMaxMemory` to 1.5GB in #12550 didn't help and we're still getting  [kernel-out-of-memory](https://developer.mend.io/github/sanity-io/sanity/-/job/af64d4f2-66ec-4b89-a768-107553611f4d) falures from renovate

Trying 2GB.

