### PR TITLE
refactor(sanity): pass only document id when duplicating release

### DIFF
--- a/packages/sanity/src/core/releases/store/__tests__/createReleaseOperationsStore.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/createReleaseOperationsStore.test.ts
@@ -527,24 +527,25 @@ describe('createReleaseOperationsStore', () => {
       )
 
       expect(mockClient.releases.create).toHaveBeenCalled()
-      expect(mockClient.action).toHaveBeenCalledWith([
-        {
-          actionType: 'sanity.action.document.version.create',
-          document: {
-            ...releaseDocuments[0],
-            _id: 'versions.rPublished-copy.doc1',
+      expect(mockClient.action).toHaveBeenCalledWith(
+        [
+          {
+            actionType: 'sanity.action.document.version.create',
+            baseId: 'doc1',
+            publishedId: 'doc1',
+            versionId: 'versions.rPublished-copy.doc1',
           },
-          publishedId: 'doc1',
-        },
-        {
-          actionType: 'sanity.action.document.version.create',
-          document: {
-            ...releaseDocuments[1],
-            _id: 'versions.rPublished-copy.doc2',
+          {
+            actionType: 'sanity.action.document.version.create',
+            baseId: 'doc2',
+            publishedId: 'doc2',
+            versionId: 'versions.rPublished-copy.doc2',
           },
-          publishedId: 'doc2',
+        ],
+        {
+          tag: 'duplicate-release.create-members',
         },
-      ])
+      )
     })
 
     it('should handle errors when creating the release', async () => {

--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -231,8 +231,9 @@ export function createReleaseOperationsStore(options: {
       const duplicateVersionDocumentActions: CreateVersionAction[] = releaseDocuments.map(
         (releaseDocument) => ({
           actionType: 'sanity.action.document.version.create',
-          document: {...releaseDocument, _id: getVersionId(releaseDocument._id, versionId)},
+          baseId: releaseDocument._id,
           publishedId: getPublishedId(releaseDocument._id),
+          versionId: getVersionId(releaseDocument._id, versionId),
         }),
       )
       await client.action(duplicateVersionDocumentActions, {


### PR DESCRIPTION
### Description

Since implementing the duplicate release action, Content Lake has added the ability to execute the `sanity.action.document.version.create` action simply by providing a base document id. When operating in this mode, the client does not need to provide a JSON payload of the entire document.

In some cases, duplicating large releases was failing due to the request payload size being too large. This should no longer occur.

### What to review

Duplicating a release. You can identify the HTTP request that creates release members by filtering on request tag `duplicate-release.create-members` (added by this branch).

### Testing

Existing tests pass, manually verified by copying a large release multiple times to ensure performance is as expected.

### Notes for release

Fixes issue that could cause duplicating large content releases to time out.
