### PR TITLE
chore(ci): bump renovate nodeMaxMemory to 2.5GB

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -140,7 +140,7 @@
     }
   ],
   "toolSettings": {
-    "nodeMaxMemory": 2048
+    "nodeMaxMemory": 2560
   },
   "ignorePaths": ["packages/sanity/fixtures/examples/prj-with-react-19/package.json"]
 }


### PR DESCRIPTION
Bumping `toolSettings.nodeMaxMemory` to 2GB in #12553 didn't [take](https://developer.mend.io/github/sanity-io/sanity/-/job/6a13c2a9-e3e8-4ec7-adbe-5c1f4f872677) either. This PR bumps to 2.5GB in a last attempt before reporting back to renovate