### PR TITLE
fix(sanity): add missing perspective when calling `observeDocumentTypeFromId` for references

### DIFF
--- a/packages/sanity/src/core/preview/createPreviewObserver.ts
+++ b/packages/sanity/src/core/preview/createPreviewObserver.ts
@@ -83,7 +83,7 @@ export function createPreviewObserver(context: {
       // Previewing references actually means getting the referenced value,
       // and preview using the preview config of its type
       // We do this since there's no way of knowing the type of the referenced value by looking at the reference value alone
-      return observeDocumentTypeFromId(value._ref).pipe(
+      return observeDocumentTypeFromId(value._ref, undefined, perspective).pipe(
         switchMap((typeName) => {
           if (typeName) {
             const refType = type.to.find((toType) => toType.name === typeName)


### PR DESCRIPTION
### Description

When calling `observeDocumentTypeFromId` for reference fields, the perspective was not being included. This could result in the type not being found when referencing a document with no published version, and a fallback preview being displayed.

#### Before

<img width="645" height="326" alt="before" src="https://github.com/user-attachments/assets/223b5445-1772-43a8-9771-6b42e61b6c30" />

#### After

<img width="645" height="326" alt="after" src="https://github.com/user-attachments/assets/c48216b7-7687-43d7-b682-90a594419c0a" />

### What to review

The `observeDocumentTypeFromId` call.

You can see the example in the "Polymorphic grid array" field at `http://localhost:3333/test/structure/input-standard;arraysTest;67c992bd-bdf8-47f2-9484-15ec688ef000`.

### Testing

Verified correct previews are displayed in Test Studio.

### Notes for release

Fixes issue causing fallback media to be display when a field references a document with no published version.