### PR TITLE
fix(sanity): inline comment input re-animate on every value change

### DIFF
--- a/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
+++ b/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
@@ -551,20 +551,19 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
   return (
     <>
       <BoundaryElementProvider element={boundaryElement}>
+        {showFloatingInput && currentUser && (
+          <InlineCommentInputPopover
+            currentUser={currentUser}
+            mentionOptions={mentionOptions}
+            onChange={setNextCommentValue}
+            onClickOutside={resetStates}
+            onDiscardConfirm={handleCommentDiscardConfirm}
+            onSubmit={handleSubmit}
+            referenceElement={popoverAuthoringReferenceElement}
+            value={nextCommentValue}
+          />
+        )}
         <AnimatePresence>
-          {showFloatingInput && currentUser && (
-            <InlineCommentInputPopover
-              currentUser={currentUser}
-              mentionOptions={mentionOptions}
-              onChange={setNextCommentValue}
-              onClickOutside={resetStates}
-              onDiscardConfirm={handleCommentDiscardConfirm}
-              onSubmit={handleSubmit}
-              referenceElement={popoverAuthoringReferenceElement}
-              value={nextCommentValue}
-            />
-          )}
-
           {showFloatingButton && !showFloatingInput && (
             <FloatingButtonPopover
               disabled={currentSelectionIsOverlapping || Boolean(addonDatasetError)}

--- a/packages/sanity/src/core/comments/plugin/input/components/InlineCommentInputPopover.tsx
+++ b/packages/sanity/src/core/comments/plugin/input/components/InlineCommentInputPopover.tsx
@@ -1,6 +1,5 @@
 import {type CurrentUser} from '@sanity/types'
 import {Stack, useClickOutsideEvent} from '@sanity/ui'
-import {motion, type Variants} from 'motion/react'
 import {useCallback, useRef} from 'react'
 import {styled} from 'styled-components'
 
@@ -10,16 +9,9 @@ import {hasCommentMessageValue} from '../../../helpers'
 
 const POPOVER_FALLBACK_PLACEMENTS: PopoverProps['fallbackPlacements'] = ['bottom', 'top']
 
-const MotionPopover = motion.create(Popover)
-
 const RootStack = styled(Stack)`
   width: 250px;
 `
-
-const VARIANTS: Variants = {
-  hidden: {opacity: 0},
-  visible: {opacity: 1},
-}
 
 interface InlineCommentInputPopoverProps {
   currentUser: CurrentUser
@@ -88,17 +80,14 @@ export function InlineCommentInputPopover(props: InlineCommentInputPopoverProps)
   )
 
   return (
-    <MotionPopover
-      animate="visible"
+    <Popover
       content={content}
       data-ui="InlineCommentInputPopover"
       fallbackPlacements={POPOVER_FALLBACK_PLACEMENTS}
-      initial="hidden"
       open
       placement="bottom"
       portal
       referenceElement={referenceElement}
-      variants={VARIANTS}
     />
   )
 }


### PR DESCRIPTION
### Description

This branch refactors the inline comment popover to use the animations provided by Sanity UI's `Popover`, rather than implementing its own on top.

This fixes the inline comment popover re-animating every time the comment value changes, as reported in #12557.

#### Before

https://github.com/user-attachments/assets/434d69ba-b824-4a4c-9544-64c4c6d0aa50

#### After

https://github.com/user-attachments/assets/abf4b83a-b816-4d29-80c8-6723209efa7d

### What to review

The PTE inline comments popover does not re-animate on value change.

### Testing

Verified in Test Studio.

### Notes for release

Fixes an issue causing the comment input to flash when authoring a comment inside a Portable Text field.