### PR TITLE
ci(renovate): add self-hosted renovate bot workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,18 @@
+name: Renovate
+on:
+  schedule:
+    - cron: "0 */2 * * *" # Every 2 hours
+  pull_request:
+    types: [closed]
+    branches: [main]
+  issues:
+    types: [edited]
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    uses: sanity-io/sanity-actions/.github/workflows/renovate.yml@jw/selfhosted-renovate
+    with:
+      log-level: debug
+      autodiscover: false
+    secrets: inherit


### PR DESCRIPTION
### Description

Adds a GitHub Actions workflow to run Renovate as a self-hosted bot instead of relying on the hosted Renovate GitHub App. Uses the reusable workflow from sanity-io/sanity-actions#473 (not yet merged to main).

Runs every 2 hours, on PR close to main, on dependency dashboard issue edits, and via manual dispatch.

### What to review

- `.github/workflows/renovate.yml` — the only file added
- The action ref points to `@jw/selfhosted-renovate` branch — needs updating to `@main` once sanity-io/sanity-actions#473 is merged

### Testing

N/A — CI workflow, will be validated by GitHub Actions on merge.

### Notes for release

N/A – Internal only