### PR TITLE
chore(deps): replace execa with node:child_process in perf tests

### DIFF
--- a/perf/tests/package.json
+++ b/perf/tests/package.json
@@ -19,7 +19,6 @@
     "@sanity/client": "catalog:",
     "@sanity/uuid": "^3.0.2",
     "dotenv": "^16.6.1",
-    "execa": "^2.1.0",
     "lodash-es": "^4.18.1",
     "rxjs": "^7.8.2",
     "tinyglobby": "^0.2.15"

--- a/perf/tests/runner/utils/gitUtils.ts
+++ b/perf/tests/runner/utils/gitUtils.ts
@@ -1,6 +1,10 @@
-import execa from 'execa'
+import {execFile, execFileSync} from 'node:child_process'
+import {promisify} from 'node:util'
+
 import partition from 'lodash-es/partition.js'
 import uniq from 'lodash-es/uniq.js'
+
+const execFileAsync = promisify(execFile)
 
 const placeholders = {
   commit: '%H',
@@ -82,21 +86,21 @@ function getGitArgs(format: string) {
 export async function getGitInfo<Field extends GitField>(
   fields: Field[],
 ): Promise<{[K in Field]: string}> {
-  const output = execa('git', getGitArgs(createFormat(fields)))
-  return parseOutput(fields, (await output).stdout)
+  const output = await execFileAsync('git', getGitArgs(createFormat(fields)))
+  return parseOutput(fields, output.stdout)
 }
 
 export function getGitInfoSync(fields: GitField[]) {
-  const res = execa.sync('git', getGitArgs(createFormat(fields)))
-  return parseOutput(fields, res.stdout)
+  const stdout = execFileSync('git', getGitArgs(createFormat(fields)), {encoding: 'utf-8'})
+  return parseOutput(fields, stdout)
 }
 
 const CURRENT_BRANCH_ARGS = ['rev-parse', '--abbrev-ref', 'HEAD']
 
 export function getCurrentBranch() {
-  return execa('git', CURRENT_BRANCH_ARGS).then((res) => res.stdout)
+  return execFileAsync('git', CURRENT_BRANCH_ARGS).then((res) => res.stdout)
 }
 
 export function getCurrentBranchSync() {
-  return execa.sync('git', CURRENT_BRANCH_ARGS).stdout
+  return execFileSync('git', CURRENT_BRANCH_ARGS, {encoding: 'utf-8'})
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2018,9 +2018,6 @@ importers:
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1
-      execa:
-        specifier: ^2.1.0
-        version: 2.1.0
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
@@ -7589,10 +7586,6 @@ packages:
     resolution: {integrity: sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==}
     engines: {node: '>=20.0.0'}
 
-  execa@2.1.0:
-    resolution: {integrity: sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==}
-    engines: {node: ^8.12.0 || >=9.7.0}
-
   execa@3.2.0:
     resolution: {integrity: sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==}
     engines: {node: ^8.12.0 || >=9.7.0}
@@ -9129,10 +9122,6 @@ packages:
     resolution: {integrity: sha512-tkyb4pc0Zb0oOswCb5tORPk9MvVL6gcDq1cMItQHmsbVk1skk7YF6cH+UU2GxeNLHMuk6wFEOSmEmJ2cnAK1jg==}
     engines: {node: ^14.18.0 || ^16.13.0 || >=18.0.0, npm: '>= 8'}
     hasBin: true
-
-  npm-run-path@3.1.0:
-    resolution: {integrity: sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==}
-    engines: {node: '>=8'}
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -17648,18 +17637,6 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.6
 
-  execa@2.1.0:
-    dependencies:
-      cross-spawn: 7.0.6
-      get-stream: 5.2.0
-      is-stream: 2.0.1
-      merge-stream: 2.0.0
-      npm-run-path: 3.1.0
-      onetime: 5.1.2
-      p-finally: 2.0.1
-      signal-exit: 3.0.7
-      strip-final-newline: 2.0.0
-
   execa@3.2.0:
     dependencies:
       cross-spawn: 7.0.6
@@ -19187,10 +19164,6 @@ snapshots:
       read-package-json-fast: 3.0.2
       shell-quote: 1.8.3
       which: 3.0.1
-
-  npm-run-path@3.1.0:
-    dependencies:
-      path-key: 3.1.1
 
   npm-run-path@4.0.1:
     dependencies:


### PR DESCRIPTION
## Description

Replaces the `execa` dependency with Node's built-in `node:child_process` module in the perf test utilities. `execa@^2.1.0` was only used for simple synchronous and async git command execution, which `execFile`/`execFileSync` handle natively.

## What to review

- `perf/tests/runner/utils/gitUtils.ts` — all `execa` calls replaced with `execFile`/`execFileSync` from `node:child_process`
- `perf/tests/package.json` — `execa` removed from dependencies
- `pnpm-lock.yaml` — lockfile updated, `pnpm dedupe` verified

## Testing

- [ ] Perf tests still run correctly

## Notes for release

No user-facing changes. Internal dependency cleanup only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)