### PR TITLE
chore(deps): replace globby with tinyglobby

### DIFF
--- a/dev/efps/helpers/remapCpuProfile.ts
+++ b/dev/efps/helpers/remapCpuProfile.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import globby from 'globby'
 import {type CDPSession} from 'playwright'
 import SourceMap from 'source-map'
+import {glob} from 'tinyglobby'
 
 type CpuProfile = Extract<
   Awaited<ReturnType<CDPSession['send']>>,
@@ -15,7 +15,7 @@ export async function remapCpuProfile(
   sourceMapsDir: string,
 ): Promise<CpuProfile> {
   const sourceMaps = new Map()
-  const sourceMapFiles = await globby(path.join(sourceMapsDir, '**/*.map'))
+  const sourceMapFiles = await glob(path.join(sourceMapsDir, '**/*.map'))
 
   for (const sourceMapFile of sourceMapFiles) {
     const mapContent = await fs.promises.readFile(sourceMapFile, 'utf8')

--- a/dev/efps/package.json
+++ b/dev/efps/package.json
@@ -35,13 +35,13 @@
     "cli-table3": "^0.6.5",
     "dotenv": "^16.6.1",
     "eslint": "catalog:",
-    "globby": "^11.1.0",
     "ora": "^8.2.0",
     "playwright": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "sanity": "workspace:*",
     "source-map": "^0.7.6",
+    "tinyglobby": "^0.2.15",
     "yargs": "^17.7.2"
   }
 }

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -45,7 +45,6 @@
     "@turf/points-within-polygon": "^5.1.5",
     "@vercel/stega": "1.0.0",
     "chokidar": "^3.6.0",
-    "globby": "^11.1.0",
     "history": "^5.3.0",
     "lodash-es": "^4.17.22",
     "qs": "^6.14.1",

--- a/perf/tests/cli.ts
+++ b/perf/tests/cli.ts
@@ -4,7 +4,7 @@ import {parseArgs} from 'node:util'
 
 import {createClient} from '@sanity/client'
 import {config} from 'dotenv'
-import globby from 'globby'
+import {glob} from 'tinyglobby'
 
 import {STUDIO_DATASET, STUDIO_PROJECT_ID} from './config/constants'
 import {findEnv, readEnv} from './config/envVars'
@@ -32,7 +32,7 @@ async function main(args: {
   label?: string
 }) {
   const currentBranch = getCurrentBranchSync()
-  const testFiles = await globby(`${__dirname}/tests/**/${args.pattern || '*'}.test.ts`)
+  const testFiles = await glob(`${__dirname}/tests/**/${args.pattern || '*'}.test.ts`)
   const branch = args.branch || findEnv('PERF_TEST_BRANCH') || currentBranch
   const headless = args.headless ?? findEnv('PERF_TEST_HEADLESS') !== 'false'
 

--- a/perf/tests/package.json
+++ b/perf/tests/package.json
@@ -20,9 +20,9 @@
     "@sanity/uuid": "^3.0.2",
     "dotenv": "^16.6.1",
     "execa": "^2.1.0",
-    "globby": "^11.1.0",
     "lodash-es": "^4.18.1",
-    "rxjs": "^7.8.2"
+    "rxjs": "^7.8.2",
+    "tinyglobby": "^0.2.15"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,9 +310,6 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.1)
-      globby:
-        specifier: ^11.1.0
-        version: 11.1.0
       ora:
         specifier: ^8.2.0
         version: 8.2.0
@@ -331,6 +328,9 @@ importers:
       source-map:
         specifier: ^0.7.6
         version: 0.7.6
+      tinyglobby:
+        specifier: ^0.2.15
+        version: 0.2.15
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -637,9 +637,6 @@ importers:
       chokidar:
         specifier: ^3.6.0
         version: 3.6.0
-      globby:
-        specifier: ^11.1.0
-        version: 11.1.0
       history:
         specifier: ^5.3.0
         version: 5.3.0
@@ -2024,15 +2021,15 @@ importers:
       execa:
         specifier: ^2.1.0
         version: 2.1.0
-      globby:
-        specifier: ^11.1.0
-        version: 11.1.0
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
+      tinyglobby:
+        specifier: ^0.2.15
+        version: 0.2.15
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -2085,9 +2082,6 @@ importers:
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
-      globby:
-        specifier: ^11.1.0
-        version: 11.1.0
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
@@ -2103,6 +2097,9 @@ importers:
       semver:
         specifier: ^7.7.3
         version: 7.7.4
+      tinyglobby:
+        specifier: ^0.2.15
+        version: 0.2.15
 
 packages:
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -17,12 +17,12 @@
     "@types/lodash-es": "^4.17.12",
     "@types/semver": "^7.7.1",
     "chalk": "^4.1.2",
-    "globby": "^11.1.0",
     "lodash-es": "^4.18.1",
     "minimist": "^1.2.8",
     "rimraf": "catalog:",
     "rxjs": "^7.8.2",
-    "semver": "^7.7.3"
+    "semver": "^7.7.3",
+    "tinyglobby": "^0.2.15"
   },
   "engines": {
     "node": ">=20.19 <22 || >=22.12"

--- a/scripts/publish/tarball.ts
+++ b/scripts/publish/tarball.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import {fileURLToPath} from 'node:url'
 
 import chalk from 'chalk'
-import globby from 'globby'
+import {glob} from 'tinyglobby'
 
 main().catch((err) => {
   console.error(chalk.red(err))
@@ -21,7 +21,7 @@ async function main() {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const root = require('../../package.json')
   const workspaces = root.workspaces as string[]
-  const pkgJsonPaths = await globby(workspaces.map((p) => `${p}/package.json`))
+  const pkgJsonPaths = await glob(workspaces.map((p) => `${p}/package.json`))
 
   const versions: Record<string, string> = {}
 


### PR DESCRIPTION
## Description

Replaces `globby@^11.1.0` (legacy CJS-compat version from 2021) with `tinyglobby@^0.2.15` across internal tooling scripts. Also removes an unused `globby` dependency from `dev/test-studio`.

## What to review

- Import changes from `import globby from 'globby'` → `import {glob} from 'tinyglobby'` in 3 files
- `package.json` dependency swaps in `scripts/`, `perf/tests/`, `dev/efps/`
- Removal of unused `globby` from `dev/test-studio/package.json`

## Testing

No published packages are affected — all changes are in internal dev/perf/build tooling.

## Notes for release

N/A — internal tooling only, no user-facing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)