### PR TITLE
fix(types): preserve type autocomplete for defineField inside defineType

### DIFF
--- a/packages/@sanity/types/src/schema/definition/schemaDefinition.ts
+++ b/packages/@sanity/types/src/schema/definition/schemaDefinition.ts
@@ -1,7 +1,11 @@
 import {type ComponentType, type ReactNode} from 'react'
 
 import {type PreviewConfig} from '../preview'
-import {type InitialValueProperty, type SchemaValidationValue} from '../types'
+import {
+  type AutocompleteString,
+  type InitialValueProperty,
+  type SchemaValidationValue,
+} from '../types'
 import {
   type ArrayDefinition,
   type BlockDefinition,
@@ -83,7 +87,7 @@ export type IntrinsicTypeName = IntrinsicDefinitions[keyof IntrinsicDefinitions]
  */
 export type SchemaTypeDefinition<TType extends IntrinsicTypeName = IntrinsicTypeName> =
   | IntrinsicDefinitions[IntrinsicTypeName]
-  | TypeAliasDefinition<string, TType>
+  | TypeAliasDefinition<AutocompleteString, TType>
 
 /**
  * Represents a reference to another type registered top-level in your schema.
@@ -161,4 +165,5 @@ export type InlineFieldDefinition = {
 export type FieldDefinition<
   TType extends IntrinsicTypeName = IntrinsicTypeName,
   TAlias extends IntrinsicTypeName | undefined = undefined,
-> = (InlineFieldDefinition[TType] | TypeAliasDefinition<string, TAlias>) & FieldDefinitionBase
+> = (InlineFieldDefinition[TType] | TypeAliasDefinition<AutocompleteString, TAlias>) &
+  FieldDefinitionBase

--- a/packages/@sanity/types/src/schema/definition/type/array.ts
+++ b/packages/@sanity/types/src/schema/definition/type/array.ts
@@ -2,7 +2,11 @@ import {type InsertMenuOptions} from '@sanity/insert-menu'
 
 import {type FieldReference} from '../../../validation'
 import {type RuleDef, type ValidationBuilder} from '../../ruleBuilder'
-import {type InitialValueProperty, type SchemaValidationValue} from '../../types'
+import {
+  type AutocompleteString,
+  type InitialValueProperty,
+  type SchemaValidationValue,
+} from '../../types'
 import {
   type IntrinsicDefinitions,
   type IntrinsicTypeName,
@@ -100,7 +104,9 @@ export type IntrinsicArrayOfDefinition = {
 export type ArrayOfType<
   TType extends IntrinsicTypeName = IntrinsicTypeName,
   TAlias extends IntrinsicTypeName | undefined = undefined,
-> = IntrinsicArrayOfDefinition[TType] | ArrayOfEntry<TypeAliasDefinition<string, TAlias>>
+> =
+  | IntrinsicArrayOfDefinition[TType]
+  | ArrayOfEntry<TypeAliasDefinition<AutocompleteString, TAlias>>
 
 /** @public */
 export interface ArrayDefinition extends BaseSchemaDefinition {


### PR DESCRIPTION
# fix(types): preserve type autocomplete for defineField inside defineType

Fixes sanity-io/sanity#4816

### Description

`defineField`'s `type` property loses IDE autocomplete when nested inside `defineType`'s `fields: []`, while working correctly standalone.

`FieldDefinition`, `ArrayOfType`, and `SchemaTypeDefinition` all include `TypeAliasDefinition<string, TAlias>` in their union types. The `string` type parameter collapses `IntrinsicTypeName | string` to just `string`, destroying the literal union that IDEs use for autocomplete. When `defineField` is called inside `defineType`'s `fields: FieldDefinition[]`, the contextual type flows in with `type: string`, overriding `defineField`'s own generic constraint.

Replaces `TypeAliasDefinition<string, TAlias>` with `TypeAliasDefinition<AutocompleteString, TAlias>` in all three types. `AutocompleteString` (`string & {}`) is structurally equivalent to `string` for assignment but prevents TypeScript from collapsing the literal union, preserving IDE autocomplete.

<img width="598" height="391" alt="image" src="https://github.com/user-attachments/assets/77ce440f-daa4-4dbb-a497-66f0cfb8d9bf" />


### What to review

- `packages/@sanity/types/src/schema/definition/schemaDefinition.ts` — `FieldDefinition` and `SchemaTypeDefinition` changes
- `packages/@sanity/types/src/schema/definition/type/array.ts` — `ArrayOfType` change

### Testing

All 55 existing type tests in `packages/@sanity/types/test/` pass (including `document.test.ts`, `object.test.ts`, `array.test.ts` which exercise `defineField` inside `defineType`). Verified in IDE that `defineType({ type: 'document', name: 'x', fields: [defineField({ type: '' })] })` now shows autocomplete for `type`.

### Notes for release

Fixes IDE autocomplete for the `type` property in `defineField` when used inside `defineType`'s `fields` array. Previously, autocomplete suggestions were only available when `defineField` was used standalone.
