### PR TITLE
chore(sanity): add telemetry to diff view

### DIFF
--- a/packages/sanity/src/structure/diffView/__telemetry__/diffView.telemetry.ts
+++ b/packages/sanity/src/structure/diffView/__telemetry__/diffView.telemetry.ts
@@ -1,0 +1,44 @@
+import {defineEvent} from '@sanity/telemetry'
+import {type DocumentVariantType} from 'sanity'
+
+interface DiffViewDocumentSelectionInfo {
+  /**
+   * The document variants being viewed, in the order that they are displayed.
+   */
+  documentVariantTypes: DocumentVariantType[]
+}
+
+interface DiffViewDocumentSelectionChangedInfo extends DiffViewDocumentSelectionInfo {
+  /**
+   * The document variants that were being viewed, in the order that they were
+   * displayed, before the user changed them.
+   */
+  previousDocumentVariantTypes: DocumentVariantType[]
+}
+
+/**
+ * @internal
+ */
+export const DiffViewEntered = defineEvent<DiffViewDocumentSelectionInfo>({
+  name: 'DiffViewEntered',
+  version: 1,
+  description: 'User entered document comparison view',
+})
+
+/**
+ * @internal
+ */
+export const DiffViewExited = defineEvent<DiffViewDocumentSelectionInfo>({
+  name: 'DiffViewExited',
+  version: 1,
+  description: 'User exited document comparison view',
+})
+
+/**
+ * @internal
+ */
+export const DiffViewDocumentSelectionChanged = defineEvent<DiffViewDocumentSelectionChangedInfo>({
+  name: 'DiffViewDocumentSelectionChanged',
+  version: 1,
+  description: 'User set one of the documents being compared',
+})

--- a/packages/sanity/src/structure/diffView/hooks/useDiffViewState.test.ts
+++ b/packages/sanity/src/structure/diffView/hooks/useDiffViewState.test.ts
@@ -2,7 +2,7 @@ import {renderHook} from '@testing-library/react'
 import {type RouterContextValue, useRouter} from 'sanity/router'
 import {it as baseIt, describe, expect, vi} from 'vitest'
 
-import {useDiffViewState} from './useDiffViewState'
+import {selectActiveTransition, useDiffViewState} from './useDiffViewState'
 
 vi.mock('sanity/router', () => ({
   useRouter: vi.fn(),
@@ -360,5 +360,31 @@ describe('useDiffViewState', () => {
         },
       })
     })
+  })
+})
+
+describe('selectActiveTransition', () => {
+  it('returns "entered" when transitioning from inactive to active', () => {
+    expect(selectActiveTransition({isActive: false}, {isActive: true})).toBe('entered')
+  })
+
+  it('returns "entered" when transitioning from undefined to active', () => {
+    expect(selectActiveTransition(undefined, {isActive: true})).toBe('entered')
+  })
+
+  it('returns "exited" when transitioning from active to inactive', () => {
+    expect(selectActiveTransition({isActive: true}, {isActive: false})).toBe('exited')
+  })
+
+  it('returns undefined when isActive remains false', () => {
+    expect(selectActiveTransition({isActive: false}, {isActive: false})).toBeUndefined()
+  })
+
+  it('returns undefined when isActive remains true', () => {
+    expect(selectActiveTransition({isActive: true}, {isActive: true})).toBeUndefined()
+  })
+
+  it('returns undefined when previous state is undefined and state is inactive', () => {
+    expect(selectActiveTransition(undefined, {isActive: false})).toBeUndefined()
   })
 })

--- a/packages/sanity/src/structure/diffView/hooks/useDiffViewState.ts
+++ b/packages/sanity/src/structure/diffView/hooks/useDiffViewState.ts
@@ -195,3 +195,24 @@ function parseParams({
     },
   } as ParamsSuccess
 }
+
+/**
+ * Given the previous and current states, determine whether the view became
+ * active (entered) or became inactive (exited).
+ *
+ * @internal
+ */
+export function selectActiveTransition(
+  previousState: Pick<DiffViewState, 'isActive'> | undefined,
+  state: Pick<DiffViewState, 'isActive'>,
+): 'entered' | 'exited' | undefined {
+  if (!previousState?.isActive && state.isActive) {
+    return 'entered'
+  }
+
+  if (previousState?.isActive && !state.isActive) {
+    return 'exited'
+  }
+
+  return undefined
+}

--- a/packages/sanity/src/structure/diffView/plugin/DiffViewDocumentLayout.tsx
+++ b/packages/sanity/src/structure/diffView/plugin/DiffViewDocumentLayout.tsx
@@ -1,17 +1,29 @@
+import {useTelemetry} from '@sanity/telemetry/react'
 import {useToast} from '@sanity/ui'
 import {type ComponentType, type PropsWithChildren} from 'react'
-import {type DocumentLayoutProps, useTranslation} from 'sanity'
+import {
+  type DocumentVariantType,
+  type DocumentLayoutProps,
+  getDocumentVariantType,
+  useTranslation,
+} from 'sanity'
 
 import {structureLocaleNamespace} from '../../i18n'
+import {
+  DiffViewEntered,
+  DiffViewExited,
+  DiffViewDocumentSelectionChanged,
+} from '../__telemetry__/diffView.telemetry'
 import {DiffView} from '../components/DiffView'
-import {useDiffViewState} from '../hooks/useDiffViewState'
+import {selectActiveTransition, useDiffViewState} from '../hooks/useDiffViewState'
 
 export const DiffViewDocumentLayout: ComponentType<
   PropsWithChildren<Pick<DocumentLayoutProps, 'documentId' | 'documentType'>>
 > = ({children, documentId}) => {
   const toast = useToast()
   const {t} = useTranslation(structureLocaleNamespace)
-  const {isActive} = useDiffViewState({
+  const {log} = useTelemetry()
+  const {isActive, documents} = useDiffViewState({
     onParamsError: (errors) => {
       toast.push({
         id: 'diffViewParamsParsingError',
@@ -30,6 +42,45 @@ export const DiffViewDocumentLayout: ComponentType<
         ),
       })
     },
+    onActiveChanged: (previousState, state) => {
+      if (selectActiveTransition(previousState, state) === 'entered') {
+        log(DiffViewEntered, {
+          documentVariantTypes: documentIdsToVariantTypes([
+            state.documents?.previous.id,
+            state.documents?.next.id,
+          ]),
+        })
+        return
+      }
+
+      if (
+        selectActiveTransition(previousState, state) === 'exited' &&
+        typeof previousState !== 'undefined'
+      ) {
+        log(DiffViewExited, {
+          documentVariantTypes: documentIdsToVariantTypes([
+            previousState.documents?.previous.id,
+            previousState.documents?.next.id,
+          ]),
+        })
+      }
+    },
+    onTargetDocumentsChanged: (previousState, state) => {
+      if (typeof previousState === 'undefined') {
+        return
+      }
+
+      log(DiffViewDocumentSelectionChanged, {
+        previousDocumentVariantTypes: documentIdsToVariantTypes([
+          previousState.documents?.previous.id,
+          previousState.documents?.next.id,
+        ]),
+        documentVariantTypes: documentIdsToVariantTypes([
+          state.documents?.previous.id,
+          state.documents?.next.id,
+        ]),
+      })
+    },
   })
 
   return (
@@ -38,4 +89,8 @@ export const DiffViewDocumentLayout: ComponentType<
       {isActive && <DiffView documentId={documentId} />}
     </>
   )
+}
+
+function documentIdsToVariantTypes(ids: (string | undefined)[]): DocumentVariantType[] {
+  return ids.filter((id) => typeof id === 'string').map(getDocumentVariantType)
 }


### PR DESCRIPTION
### Description

This branch adds telemetry to the diff view ("Compare versions"), and the necessary event hooks to support it.

The set of displayed documents are logged as an array of document variant types ("published", "draft", or "version") in the order they are displayed, rather than the "previous" and "next" documents literally. This is to allow flexibility to support displaying more than two documents in the future.

#### Events

##### `DiffViewEntered`
- Logged when entering the diff view, including when navigating to it by URL directly.
- Logs the current set of displayed document variant types as `documentVariantTypes`.

##### `DiffViewExited`
- Logged when exiting the diff view.
- Logs the documents variant types that were previously displayed as `documentVariantTypes`.

##### `DiffViewDocumentSelectionChanged`
- Logged when changing either of the displayed documents.
- Logs the document variant types that were previously displayed as `previousDocumentVariantTypes`.
- Logs the current set of displayed documents as `documentVariantTypes`

### What to review

- The new `onActiveChanged` and `onTargetDocumentsChanged` diff view event hooks.
- The new diff view telemetry.

### Testing

Added unit tests and verified logged events and data.