### PR TITLE
fix(structure): validate persisted sort order against schema before applying

### DIFF
--- a/dev/test-studio/schema/book.ts
+++ b/dev/test-studio/schema/book.ts
@@ -154,6 +154,11 @@ export default defineType({
       name: 'publicationYearAscNullsLast',
       by: [{field: 'publicationYear', direction: 'asc', nulls: 'last'}],
     },
+    {
+      title: 'By non-existent field',
+      name: 'nonExistentField',
+      by: [{field: 'nonExistentField', direction: 'desc'}],
+    },
   ],
   preview: {
     select: {

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -577,6 +577,9 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'panes.document-list-pane.search-input.aria-label': 'Search list',
   /** The search input for the search input on the document list pane */
   'panes.document-list-pane.search-input.placeholder': 'Search list',
+  /** The tooltip text shown when a sort menu item references fields not present in the current schema */
+  'panes.document-list-pane.sort-order.disabled-reason':
+    'This sorting option uses fields that are not part of this document type',
   /** The summary title when displaying an error for a document operation result */
   'panes.document-operation-results.error.summary.title': 'Details',
   /** The text when a generic operation failed (fallback, generally not shown)  */

--- a/packages/sanity/src/structure/panes/documentList/PaneContainer.tsx
+++ b/packages/sanity/src/structure/panes/documentList/PaneContainer.tsx
@@ -1,11 +1,13 @@
 import {Card, Code} from '@sanity/ui'
 import isEqual from 'lodash-es/isEqual.js'
-import {memo, useMemo, useState} from 'react'
+import {memo, useCallback, useMemo, useState} from 'react'
 import {
   EMPTY_ARRAY,
   type GeneralDocumentListLayoutKey,
+  type ObjectSchemaType,
   SourceProvider,
   useI18nText,
+  useSchema,
   useSource,
 } from 'sanity'
 import shallowEquals from 'shallow-equals'
@@ -18,7 +20,7 @@ import {useStructureToolSetting} from '../../useStructureToolSetting'
 import {type BaseStructureToolPaneProps} from '../types'
 import {DEFAULT_ORDERING, EMPTY_RECORD} from './constants'
 import {DocumentListPane} from './DocumentListPane'
-import {findStaticTypesInFilter} from './helpers'
+import {findStaticTypesInFilter, validateSortOrder} from './helpers'
 import {PaneHeader} from './PaneHeader'
 import {type SortOrder} from './types'
 
@@ -129,22 +131,37 @@ export const PaneContainer = memo(function PaneContainer(
     defaultSortOrder,
   )
 
-  // Custom menu item state for tracking selected state of custom menu items
-  // Uses local state (doesn't persist across refreshes) to avoid keyValueStore allowlist issues
+  const schema = useSchema()
+  const validatedSortOrder = useMemo(() => {
+    if (!sortOrderRaw) return sortOrderRaw
+    const schemaType = typeName ? (schema.get(typeName) as ObjectSchemaType | undefined) : undefined
+    return validateSortOrder(sortOrderRaw, schemaType, defaultSortOrder)
+  }, [sortOrderRaw, typeName, schema, defaultSortOrder])
+
+  const handleSetSortOrder = useCallback(
+    async (newSortOrder: SortOrder) => {
+      const schemaType = typeName
+        ? (schema.get(typeName) as ObjectSchemaType | undefined)
+        : undefined
+      const validated = validateSortOrder(newSortOrder, schemaType, defaultSortOrder)
+      await setSortOrder(validated)
+    },
+    [setSortOrder, typeName, schema, defaultSortOrder],
+  )
+
   const [customMenuItemState, setCustomMenuItemState] = useState<CustomMenuItemState>({})
 
-  // Add auto-generated IDs to menu items that don't have one
   const menuItemsWithIds = useMemo(() => addIdsToMenuItems(menuItems), [menuItems])
 
   const menuItemsWithSelectedState = useMemo(
     () =>
       addSelectedStateToMenuItems({
         menuItems: menuItemsWithIds,
-        sortOrderRaw,
+        sortOrderRaw: validatedSortOrder,
         layout,
         customMenuItemState,
       }),
-    [customMenuItemState, layout, menuItemsWithIds, sortOrderRaw],
+    [customMenuItemState, layout, menuItemsWithIds, validatedSortOrder],
   )
 
   return (
@@ -170,11 +187,11 @@ export const PaneContainer = memo(function PaneContainer(
           menuItemGroups={menuItemGroups}
           menuItems={menuItemsWithSelectedState}
           setLayout={setLayout}
-          setSortOrder={setSortOrder}
+          setSortOrder={handleSetSortOrder}
           setCustomMenuItemState={setCustomMenuItemState}
           title={title}
         />
-        <DocumentListPane {...props} sortOrder={sortOrderRaw} layout={layout} />
+        <DocumentListPane {...props} sortOrder={validatedSortOrder} layout={layout} />
       </Pane>
     </SourceProvider>
   )

--- a/packages/sanity/src/structure/panes/documentList/PaneContainer.tsx
+++ b/packages/sanity/src/structure/panes/documentList/PaneContainer.tsx
@@ -9,11 +9,13 @@ import {
   useI18nText,
   useSchema,
   useSource,
+  useTranslation,
 } from 'sanity'
 import shallowEquals from 'shallow-equals'
 
 import {Pane} from '../../components/pane'
 import {_DEBUG} from '../../constants'
+import {structureLocaleNamespace} from '../../i18n'
 import {assignId} from '../../structureResolvers/assignId'
 import {type PaneMenuItem} from '../../types'
 import {useStructureToolSetting} from '../../useStructureToolSetting'
@@ -40,13 +42,25 @@ const addIdsToMenuItems = (menuItems?: PaneMenuItem[]): PaneMenuItem[] | undefin
   })
 }
 
-const addSelectedStateToMenuItems = (options: {
+/**
+ * @internal exported for testing
+ */
+export const addSelectedStateToMenuItems = (options: {
   menuItems?: PaneMenuItem[]
   sortOrderRaw?: SortOrder
   layout?: GeneralDocumentListLayoutKey
   customMenuItemState?: CustomMenuItemState
+  schemaType?: ObjectSchemaType
+  disabledSortReason?: string
 }) => {
-  const {menuItems, sortOrderRaw, layout, customMenuItemState = {}} = options
+  const {
+    menuItems,
+    sortOrderRaw,
+    layout,
+    customMenuItemState = {},
+    schemaType,
+    disabledSortReason,
+  } = options
 
   return menuItems?.map((item) => {
     if (item.params?.layout) {
@@ -57,9 +71,16 @@ const addSelectedStateToMenuItems = (options: {
     }
 
     if (item?.params?.by) {
+      const itemSortOrder: SortOrder = {by: item.params.by}
+      const isInvalidSortOrder =
+        validateSortOrder(itemSortOrder, schemaType, DEFAULT_ORDERING) !== itemSortOrder
+
       return {
         ...item,
         selected: isEqual(sortOrderRaw?.by, item?.params?.by || EMPTY_ARRAY),
+        ...(isInvalidSortOrder && {
+          disabled: {reason: disabledSortReason},
+        }),
       }
     }
 
@@ -132,26 +153,30 @@ export const PaneContainer = memo(function PaneContainer(
   )
 
   const schema = useSchema()
+  const schemaType = useMemo(
+    () => (typeName ? (schema.get(typeName) as ObjectSchemaType | undefined) : undefined),
+    [typeName, schema],
+  )
+  const {t} = useTranslation(structureLocaleNamespace)
+
   const validatedSortOrder = useMemo(() => {
     if (!sortOrderRaw) return sortOrderRaw
-    const schemaType = typeName ? (schema.get(typeName) as ObjectSchemaType | undefined) : undefined
     return validateSortOrder(sortOrderRaw, schemaType, defaultSortOrder)
-  }, [sortOrderRaw, typeName, schema, defaultSortOrder])
+  }, [sortOrderRaw, schemaType, defaultSortOrder])
 
   const handleSetSortOrder = useCallback(
     async (newSortOrder: SortOrder) => {
-      const schemaType = typeName
-        ? (schema.get(typeName) as ObjectSchemaType | undefined)
-        : undefined
       const validated = validateSortOrder(newSortOrder, schemaType, defaultSortOrder)
       await setSortOrder(validated)
     },
-    [setSortOrder, typeName, schema, defaultSortOrder],
+    [setSortOrder, schemaType, defaultSortOrder],
   )
 
   const [customMenuItemState, setCustomMenuItemState] = useState<CustomMenuItemState>({})
 
   const menuItemsWithIds = useMemo(() => addIdsToMenuItems(menuItems), [menuItems])
+
+  const disabledSortReason = t('panes.document-list-pane.sort-order.disabled-reason')
 
   const menuItemsWithSelectedState = useMemo(
     () =>
@@ -160,8 +185,17 @@ export const PaneContainer = memo(function PaneContainer(
         sortOrderRaw: validatedSortOrder,
         layout,
         customMenuItemState,
+        schemaType,
+        disabledSortReason,
       }),
-    [customMenuItemState, layout, menuItemsWithIds, validatedSortOrder],
+    [
+      customMenuItemState,
+      disabledSortReason,
+      layout,
+      menuItemsWithIds,
+      schemaType,
+      validatedSortOrder,
+    ],
   )
 
   return (

--- a/packages/sanity/src/structure/panes/documentList/__tests__/addSelectedStateToMenuItems.test.ts
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/addSelectedStateToMenuItems.test.ts
@@ -1,0 +1,163 @@
+import {Schema} from '@sanity/schema'
+import {type ObjectSchemaType} from '@sanity/types'
+import {describe, expect, test} from 'vitest'
+
+import {type PaneMenuItem} from '../../../types'
+import {addSelectedStateToMenuItems} from '../PaneContainer'
+
+const mockSchema = Schema.compile({
+  name: 'default',
+  types: [
+    {
+      name: 'category',
+      title: 'Category',
+      type: 'document',
+      fields: [{name: 'title', type: 'string'}],
+    },
+  ],
+})
+
+const categorySchemaType = mockSchema.get('category') as ObjectSchemaType
+
+describe('addSelectedStateToMenuItems', () => {
+  describe('sort order disabled state', () => {
+    test('does not disable menu items when sort fields exist in schema', () => {
+      const menuItems: PaneMenuItem[] = [
+        {
+          title: 'Sort by title',
+          params: {by: [{field: 'title', direction: 'asc' as const}]},
+        },
+      ]
+
+      const result = addSelectedStateToMenuItems({
+        menuItems,
+        schemaType: categorySchemaType,
+        disabledSortReason: 'Sort order invalid',
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result![0].disabled).toBeUndefined()
+    })
+
+    test('disables menu items when sort fields do not exist in schema', () => {
+      const menuItems: PaneMenuItem[] = [
+        {
+          title: 'Sort by nonExistent',
+          params: {by: [{field: 'nonExistentField', direction: 'asc' as const}]},
+        },
+      ]
+
+      const result = addSelectedStateToMenuItems({
+        menuItems,
+        schemaType: categorySchemaType,
+        disabledSortReason: 'Sort order invalid',
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result![0].disabled).toEqual({reason: 'Sort order invalid'})
+    })
+
+    test('does not disable menu items that sort by built-in fields', () => {
+      const menuItems: PaneMenuItem[] = [
+        {
+          title: 'Sort by updated',
+          params: {by: [{field: '_updatedAt', direction: 'desc' as const}]},
+        },
+      ]
+
+      const result = addSelectedStateToMenuItems({
+        menuItems,
+        schemaType: categorySchemaType,
+        disabledSortReason: 'Sort order invalid',
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result![0].disabled).toBeUndefined()
+    })
+
+    test('does not disable sort items when schemaType is undefined', () => {
+      const menuItems: PaneMenuItem[] = [
+        {
+          title: 'Sort by anything',
+          params: {by: [{field: 'anyField', direction: 'asc' as const}]},
+        },
+      ]
+
+      const result = addSelectedStateToMenuItems({
+        menuItems,
+        schemaType: undefined,
+        disabledSortReason: 'Sort order invalid',
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result![0].disabled).toBeUndefined()
+    })
+
+    test('disables only invalid sort items in a mixed list', () => {
+      const menuItems: PaneMenuItem[] = [
+        {
+          title: 'Sort by title',
+          params: {by: [{field: 'title', direction: 'asc' as const}]},
+        },
+        {
+          title: 'Sort by nonExistent',
+          params: {by: [{field: 'nonExistentField', direction: 'asc' as const}]},
+        },
+        {
+          title: 'Sort by updated',
+          params: {by: [{field: '_updatedAt', direction: 'desc' as const}]},
+        },
+      ]
+
+      const result = addSelectedStateToMenuItems({
+        menuItems,
+        schemaType: categorySchemaType,
+        disabledSortReason: 'Sort order invalid',
+      })
+
+      expect(result).toHaveLength(3)
+      expect(result![0].disabled).toBeUndefined()
+      expect(result![1].disabled).toEqual({reason: 'Sort order invalid'})
+      expect(result![2].disabled).toBeUndefined()
+    })
+
+    test('does not affect layout menu items', () => {
+      const menuItems: PaneMenuItem[] = [
+        {
+          title: 'Compact view',
+          params: {layout: 'compact'},
+        },
+      ]
+
+      const result = addSelectedStateToMenuItems({
+        menuItems,
+        layout: 'default',
+        schemaType: categorySchemaType,
+        disabledSortReason: 'Sort order invalid',
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result![0].disabled).toBeUndefined()
+    })
+
+    test('preserves selected state alongside disabled state', () => {
+      const menuItems: PaneMenuItem[] = [
+        {
+          title: 'Sort by nonExistent',
+          params: {by: [{field: 'nonExistentField', direction: 'asc' as const}]},
+        },
+      ]
+
+      const result = addSelectedStateToMenuItems({
+        menuItems,
+        sortOrderRaw: {by: [{field: 'nonExistentField', direction: 'asc' as const}]},
+        schemaType: categorySchemaType,
+        disabledSortReason: 'Sort order invalid',
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result![0].selected).toBe(true)
+      expect(result![0].disabled).toEqual({reason: 'Sort order invalid'})
+    })
+  })
+})

--- a/packages/sanity/src/structure/panes/documentList/__tests__/helpers.test.ts
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/helpers.test.ts
@@ -2,7 +2,12 @@ import {Schema} from '@sanity/schema'
 import {type ObjectSchemaType} from '@sanity/types'
 import {describe, expect, test} from 'vitest'
 
-import {applyOrderingFunctions, fieldExtendsType, findStaticTypesInFilter} from '../helpers'
+import {
+  applyOrderingFunctions,
+  fieldExtendsType,
+  findStaticTypesInFilter,
+  validateSortOrder,
+} from '../helpers'
 
 const mockSchema = Schema.compile({
   name: 'default',
@@ -165,6 +170,98 @@ describe('fieldExtendsType()', () => {
     )!
 
     expect(fieldExtendsType(field, 'number')).toBe(false)
+  })
+})
+
+describe('validateSortOrder()', () => {
+  const fallback = {by: [{field: '_updatedAt', direction: 'desc' as const}]}
+
+  test('returns sort order unchanged when all fields are built-in', () => {
+    const sortOrder = {by: [{field: '_updatedAt', direction: 'desc' as const}]}
+    const result = validateSortOrder(sortOrder, mockSchema.get('category'), fallback)
+    expect(result).toBe(sortOrder)
+  })
+
+  test('returns sort order unchanged when custom field exists in schema', () => {
+    const sortOrder = {by: [{field: 'title', direction: 'asc' as const}]}
+    const result = validateSortOrder(sortOrder, mockSchema.get('category'), fallback)
+    expect(result).toBe(sortOrder)
+  })
+
+  test('returns fallback when custom field does not exist in schema', () => {
+    const sortOrder = {by: [{field: 'displayTitle', direction: 'asc' as const}]}
+    const result = validateSortOrder(sortOrder, mockSchema.get('category'), fallback)
+    expect(result).toBe(fallback)
+  })
+
+  test('returns fallback when any field in a multi-field sort is invalid', () => {
+    const sortOrder = {
+      by: [
+        {field: '_updatedAt', direction: 'desc' as const},
+        {field: 'nonExistentField', direction: 'asc' as const},
+      ],
+    }
+    const result = validateSortOrder(sortOrder, mockSchema.get('category'), fallback)
+    expect(result).toBe(fallback)
+  })
+
+  test('returns sort order as-is when schemaType is undefined', () => {
+    const sortOrder = {by: [{field: 'anyField', direction: 'asc' as const}]}
+    const result = validateSortOrder(sortOrder, undefined, fallback)
+    expect(result).toBe(sortOrder)
+  })
+
+  test.each(['_id', '_type', '_rev', '_createdAt', '_updatedAt'])(
+    'accepts built-in field %s',
+    (field) => {
+      const sortOrder = {by: [{field, direction: 'asc' as const}]}
+      const result = validateSortOrder(sortOrder, mockSchema.get('category'), fallback)
+      expect(result).toBe(sortOrder)
+    },
+  )
+
+  test('validates nested field paths correctly', () => {
+    const validNested = {by: [{field: 'title.en', direction: 'asc' as const}]}
+    expect(validateSortOrder(validNested, mockSchema.get('article'), fallback)).toBe(validNested)
+
+    const invalidNested = {by: [{field: 'title.fr', direction: 'asc' as const}]}
+    expect(validateSortOrder(invalidNested, mockSchema.get('article'), fallback)).toBe(fallback)
+  })
+
+  test('cross-workspace scenario: sort order valid in one schema but not another', () => {
+    const workspaceBSchema = Schema.compile({
+      name: 'workspaceB',
+      types: [
+        {
+          name: 'page',
+          type: 'document',
+          fields: [{name: 'title', type: 'string'}],
+        },
+      ],
+    })
+
+    const sortByDisplayTitle = {
+      by: [{field: 'displayTitle', direction: 'asc' as const}],
+      extendedProjection: 'displayTitle',
+    }
+
+    const result = validateSortOrder(sortByDisplayTitle, workspaceBSchema.get('page'), fallback)
+    expect(result).toBe(fallback)
+  })
+
+  test('passes through sort order with empty by array', () => {
+    const sortOrder = {by: []}
+    const result = validateSortOrder(sortOrder, mockSchema.get('category'), fallback)
+    expect(result).toBe(sortOrder)
+  })
+
+  test('preserves extendedProjection on valid sort order', () => {
+    const sortOrder = {
+      by: [{field: 'title', direction: 'asc' as const}],
+      extendedProjection: 'title',
+    }
+    const result = validateSortOrder(sortOrder, mockSchema.get('category'), fallback)
+    expect(result).toBe(sortOrder)
   })
 })
 

--- a/packages/sanity/src/structure/panes/documentList/__tests__/helpers.test.ts
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/helpers.test.ts
@@ -38,6 +38,24 @@ const mockSchema = Schema.compile({
       type: 'datetime',
     },
     {
+      name: 'author',
+      title: 'Author',
+      type: 'document',
+      fields: [
+        {name: 'name', type: 'string'},
+        {name: 'bestFriend', type: 'reference', to: [{type: 'author'}]},
+      ],
+    },
+    {
+      name: 'book',
+      title: 'Book',
+      type: 'document',
+      fields: [
+        {name: 'title', type: 'string'},
+        {name: 'author', type: 'reference', to: [{type: 'author'}]},
+      ],
+    },
+    {
       name: 'article',
       title: 'Article',
       type: 'document',
@@ -176,12 +194,6 @@ describe('fieldExtendsType()', () => {
 describe('validateSortOrder()', () => {
   const fallback = {by: [{field: '_updatedAt', direction: 'desc' as const}]}
 
-  test('returns sort order unchanged when all fields are built-in', () => {
-    const sortOrder = {by: [{field: '_updatedAt', direction: 'desc' as const}]}
-    const result = validateSortOrder(sortOrder, mockSchema.get('category'), fallback)
-    expect(result).toBe(sortOrder)
-  })
-
   test('returns sort order unchanged when custom field exists in schema', () => {
     const sortOrder = {by: [{field: 'title', direction: 'asc' as const}]}
     const result = validateSortOrder(sortOrder, mockSchema.get('category'), fallback)
@@ -220,12 +232,14 @@ describe('validateSortOrder()', () => {
     },
   )
 
-  test('validates nested field paths correctly', () => {
-    const validNested = {by: [{field: 'title.en', direction: 'asc' as const}]}
-    expect(validateSortOrder(validNested, mockSchema.get('article'), fallback)).toBe(validNested)
+  test('accepts valid nested field path', () => {
+    const sortOrder = {by: [{field: 'title.en', direction: 'asc' as const}]}
+    expect(validateSortOrder(sortOrder, mockSchema.get('article'), fallback)).toBe(sortOrder)
+  })
 
-    const invalidNested = {by: [{field: 'title.fr', direction: 'asc' as const}]}
-    expect(validateSortOrder(invalidNested, mockSchema.get('article'), fallback)).toBe(fallback)
+  test('returns fallback for invalid nested field path', () => {
+    const sortOrder = {by: [{field: 'title.fr', direction: 'asc' as const}]}
+    expect(validateSortOrder(sortOrder, mockSchema.get('article'), fallback)).toBe(fallback)
   })
 
   test('cross-workspace scenario: sort order valid in one schema but not another', () => {
@@ -246,6 +260,24 @@ describe('validateSortOrder()', () => {
     }
 
     const result = validateSortOrder(sortByDisplayTitle, workspaceBSchema.get('page'), fallback)
+    expect(result).toBe(fallback)
+  })
+
+  test('accepts sort order with single-target reference path', () => {
+    const sortOrder = {by: [{field: 'author.name', direction: 'asc' as const}]}
+    const result = validateSortOrder(sortOrder, mockSchema.get('book'), fallback)
+    expect(result).toBe(sortOrder)
+  })
+
+  test('accepts sort order with deeply nested reference path', () => {
+    const sortOrder = {by: [{field: 'author.bestFriend.name', direction: 'asc' as const}]}
+    const result = validateSortOrder(sortOrder, mockSchema.get('book'), fallback)
+    expect(result).toBe(sortOrder)
+  })
+
+  test('returns fallback when referenced field does not exist on target type', () => {
+    const sortOrder = {by: [{field: 'author.nonExistent', direction: 'asc' as const}]}
+    const result = validateSortOrder(sortOrder, mockSchema.get('book'), fallback)
     expect(result).toBe(fallback)
   })
 

--- a/packages/sanity/src/structure/panes/documentList/helpers.ts
+++ b/packages/sanity/src/structure/panes/documentList/helpers.ts
@@ -58,10 +58,10 @@ export function applyOrderingFunctions(order: SortOrder, schemaType: ObjectSchem
 const BUILT_IN_SORT_FIELDS = new Set(['_id', '_type', '_rev', '_createdAt', '_updatedAt'])
 
 /**
- * Validates that all fields referenced in a sort order exist in the given schema type.
- * Built-in document fields are always considered valid. Returns the fallback when any
- * custom field is missing, which prevents crashes when a persisted sort order from one
- * workspace references fields absent in another workspace's schema.
+ * Checks that every field in a sort order resolves against the schema type.
+ * Built-in document fields (_id, _createdAt, etc.) always pass. Returns
+ * the fallback when any field is missing - typically when a persisted sort
+ * order from one workspace references fields absent in another.
  */
 export function validateSortOrder(
   sortOrder: SortOrder,

--- a/packages/sanity/src/structure/panes/documentList/helpers.ts
+++ b/packages/sanity/src/structure/panes/documentList/helpers.ts
@@ -1,4 +1,5 @@
 import {
+  isArraySchemaType,
   isIndexSegment,
   isKeySegment,
   isReferenceSchemaType,
@@ -105,28 +106,29 @@ function tryResolveSchemaTypeForPath(baseType: SchemaType, path: string): Schema
     }
 
     const isArrayAccessor = isKeySegment(segment) || isIndexSegment(segment)
-    if (!isArrayAccessor || current.jsonType !== 'array') {
+    if (!isArrayAccessor || !isArraySchemaType(current)) {
       return undefined
     }
 
-    const [memberType, otherType] = current.of || []
-    if (otherType || !memberType) {
+    if (current.of.length !== 1) {
       // Can't figure out the type without knowing the value
       return undefined
     }
+
+    const memberType: SchemaType = current.of[0]
 
     if (!isReferenceSchemaType(memberType)) {
       current = memberType
       continue
     }
 
-    const [refType, otherRefType] = memberType.to || []
-    if (otherRefType || !refType) {
+    const refTargets: SchemaType[] = memberType.to || []
+    if (refTargets.length !== 1) {
       // Can't figure out the type without knowing the value
       return undefined
     }
 
-    current = refType
+    current = refTargets[0]
   }
 
   return current

--- a/packages/sanity/src/structure/panes/documentList/helpers.ts
+++ b/packages/sanity/src/structure/panes/documentList/helpers.ts
@@ -55,6 +55,32 @@ export function applyOrderingFunctions(order: SortOrder, schemaType: ObjectSchem
   return orderBy.every((item, index) => item === order.by[index]) ? order : {...order, by: orderBy}
 }
 
+const BUILT_IN_SORT_FIELDS = new Set(['_id', '_type', '_rev', '_createdAt', '_updatedAt'])
+
+/**
+ * Validates that all fields referenced in a sort order exist in the given schema type.
+ * Built-in document fields are always considered valid. Returns the fallback when any
+ * custom field is missing, which prevents crashes when a persisted sort order from one
+ * workspace references fields absent in another workspace's schema.
+ */
+export function validateSortOrder(
+  sortOrder: SortOrder,
+  schemaType: ObjectSchemaType | undefined,
+  fallback: SortOrder,
+): SortOrder {
+  if (!schemaType) {
+    return sortOrder
+  }
+
+  const allFieldsValid = sortOrder.by.every(
+    (entry) =>
+      BUILT_IN_SORT_FIELDS.has(entry.field) ||
+      Boolean(tryResolveSchemaTypeForPath(schemaType, entry.field)),
+  )
+
+  return allFieldsValid ? sortOrder : fallback
+}
+
 function tryResolveSchemaTypeForPath(baseType: SchemaType, path: string): SchemaType | undefined {
   const pathSegments = PathUtils.fromString(path)
 

--- a/packages/sanity/src/structure/panes/documentList/helpers.ts
+++ b/packages/sanity/src/structure/panes/documentList/helpers.ts
@@ -92,6 +92,15 @@ function tryResolveSchemaTypeForPath(baseType: SchemaType, path: string): Schema
 
     if (typeof segment === 'string') {
       current = getFieldTypeByName(current, segment)
+
+      if (current && isReferenceSchemaType(current)) {
+        const [refType, otherRefType] = current.to || []
+        if (otherRefType || !refType) {
+          return undefined
+        }
+        current = refType
+      }
+
       continue
     }
 

--- a/packages/sanity/src/structure/structureBuilder/MenuItem.ts
+++ b/packages/sanity/src/structure/structureBuilder/MenuItem.ts
@@ -391,6 +391,10 @@ export function getOrderingMenuItemsForSchemaType(
   return (
     type.orderings ? type.orderings.concat(DEFAULT_ORDERING_OPTIONS) : DEFAULT_ORDERING_OPTIONS
   ).map((ordering: SortOrdering) =>
-    getOrderingMenuItem(context, ordering, getExtendedProjection(type, ordering.by)),
+    getOrderingMenuItem(
+      context,
+      ordering,
+      getExtendedProjection(type, ordering.by, false, ordering.title),
+    ),
   )
 }

--- a/packages/sanity/src/structure/structureBuilder/util/__tests__/getExtendedProjection.test.ts
+++ b/packages/sanity/src/structure/structureBuilder/util/__tests__/getExtendedProjection.test.ts
@@ -1,8 +1,8 @@
 import {Schema} from '@sanity/schema'
 import {type SchemaType, type SortOrderingItem} from '@sanity/types'
-import {describe, expect, test, vi} from 'vitest'
+import {afterEach, describe, expect, test, vi} from 'vitest'
 
-import {getExtendedProjection} from '../getExtendedProjection'
+import {_resetWarningCache, getExtendedProjection} from '../getExtendedProjection'
 
 const mockSchema = Schema.compile({
   name: 'default',
@@ -121,6 +121,11 @@ const withObjectFieldsOrder = mockSchema.get('withObjectFieldsOrder') as SchemaT
 const withArrayFields = mockSchema.get('withArrayFields') as SchemaType
 
 describe('getExtendedProjection', () => {
+  afterEach(() => {
+    _resetWarningCache()
+    vi.restoreAllMocks()
+  })
+
   test('keeps simple field ordering projection', () => {
     const orderBy: SortOrderingItem[] = [{field: 'publicationYear', direction: 'asc'}]
 
@@ -221,11 +226,29 @@ describe('getExtendedProjection', () => {
     )
   })
 
+  test('includes ordering name in warning when provided', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const orderBy: SortOrderingItem[] = [{field: 'missingField', direction: 'asc'}]
+
+    getExtendedProjection(withObjectFieldsOrder, orderBy, false, 'By missing field')
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('The sort ordering "By missing field" references'),
+    )
+  })
+
+  test('uses generic label when ordering name is not provided', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const orderBy: SortOrderingItem[] = [{field: 'missingField', direction: 'asc'}]
+
+    getExtendedProjection(withObjectFieldsOrder, orderBy)
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('A sort ordering references'))
+  })
+
   test('throws in strict mode when ordering targets missing top-level field', () => {
     const orderBy: SortOrderingItem[] = [{field: 'missingField', direction: 'asc'}]
 
     expect(() => getExtendedProjection(withObjectFieldsOrder, orderBy, true)).toThrow(
-      'The current ordering config targeted the nonexistent field "missingField"',
+      'A sort ordering references the nonexistent field "missingField"',
     )
   })
 
@@ -233,7 +256,7 @@ describe('getExtendedProjection', () => {
     const orderBy: SortOrderingItem[] = [{field: 'translations.fi', direction: 'asc'}]
 
     expect(() => getExtendedProjection(withObjectFieldsOrder, orderBy, true)).toThrow(
-      'The current ordering config targeted the nonexistent field "fi"',
+      'A sort ordering references the nonexistent field "fi"',
     )
   })
 
@@ -241,7 +264,7 @@ describe('getExtendedProjection', () => {
     const orderBy: SortOrderingItem[] = [{field: 'title.foo', direction: 'asc'}]
 
     expect(() => getExtendedProjection(withObjectFieldsOrder, orderBy, true)).toThrow(
-      'attempted to traverse into field "foo" on non-object schema type',
+      'the field "foo" on non-object schema type',
     )
   })
 
@@ -276,7 +299,7 @@ describe('getExtendedProjection', () => {
     const orderBy: SortOrderingItem[] = [{field: 'title[0]', direction: 'asc'}]
 
     expect(() => getExtendedProjection(withArrayFields, orderBy, true)).toThrow(
-      'used array access on non-array field "title"',
+      'array access on non-array field "title"',
     )
   })
 

--- a/packages/sanity/src/structure/structureBuilder/util/getExtendedProjection.ts
+++ b/packages/sanity/src/structure/structureBuilder/util/getExtendedProjection.ts
@@ -22,6 +22,11 @@ type ProjectionNode = {
   children: Map<string, ProjectionNode>
 }
 
+type ProjectionOptions = {
+  strict: boolean
+  orderingName?: string
+}
+
 /**
  * Returns an existing child projection node or creates a new one.
  * We use this while walking order paths so repeated paths like
@@ -68,8 +73,7 @@ function recurseIntoField(
   nodeKey: string,
   fieldType: SchemaType,
   tail: PathSegment[],
-  strict: boolean,
-  orderingName?: string,
+  options: ProjectionOptions,
 ): void {
   if (tail.length === 0) {
     getOrCreateChildNode(nodes, nodeKey, false)
@@ -78,14 +82,12 @@ function recurseIntoField(
 
   if (isReferenceSchemaType(fieldType) && 'to' in fieldType) {
     const refNode = getOrCreateChildNode(nodes, nodeKey, true)
-    fieldType.to.forEach((refType) =>
-      joinReferences(refNode.children, refType, tail, strict, orderingName),
-    )
+    fieldType.to.forEach((refType) => joinReferences(refNode.children, refType, tail, options))
     return
   }
 
   const node = getOrCreateChildNode(nodes, nodeKey, false)
-  joinReferences(node.children, fieldType, tail, strict, orderingName)
+  joinReferences(node.children, fieldType, tail, options)
 }
 
 /**
@@ -113,13 +115,14 @@ function joinReferences(
   nodes: Map<string, ProjectionNode>,
   schemaType: SchemaType,
   path: PathSegment[],
-  strict: boolean,
-  orderingName?: string,
+  options: ProjectionOptions,
 ) {
   const [head, ...rest] = path
   if (!head || typeof head !== 'string') {
     return
   }
+
+  const {strict, orderingName} = options
 
   if (!('fields' in schemaType)) {
     reportError(
@@ -147,7 +150,7 @@ function joinReferences(
     (isIndexSegment(nextSegment) || isKeySegment(nextSegment) || isIndexTuple(nextSegment))
 
   if (!hasArrayAccessor) {
-    recurseIntoField(nodes, head, schemaField.type, rest, strict, orderingName)
+    recurseIntoField(nodes, head, schemaField.type, rest, options)
     return
   }
 
@@ -184,7 +187,7 @@ function joinReferences(
   const tail = rest.slice(1)
   const memberType = members[0]
 
-  recurseIntoField(nodes, nodeKey, memberType, tail, strict, orderingName)
+  recurseIntoField(nodes, nodeKey, memberType, tail, options)
 }
 
 /**
@@ -241,10 +244,11 @@ export function getExtendedProjection(
   orderingName?: string,
 ): string {
   const nodes = new Map<string, ProjectionNode>()
+  const options: ProjectionOptions = {strict, orderingName}
 
   orderBy.forEach((ordering) => {
     if (!ordering.field) return
-    joinReferences(nodes, schemaType, pathFromString(ordering.field), strict, orderingName)
+    joinReferences(nodes, schemaType, pathFromString(ordering.field), options)
   })
 
   return createProjection(nodes)

--- a/packages/sanity/src/structure/structureBuilder/util/getExtendedProjection.ts
+++ b/packages/sanity/src/structure/structureBuilder/util/getExtendedProjection.ts
@@ -10,6 +10,12 @@ import {
 import {fromString as pathFromString} from '@sanity/util/paths'
 
 const IMPLICIT_SCHEMA_TYPE_FIELDS = ['_id', '_type', '_createdAt', '_updatedAt', '_rev']
+const warnedMessages = new Set<string>()
+
+/** @internal */
+export function _resetWarningCache(): void {
+  warnedMessages.clear()
+}
 
 type ProjectionNode = {
   reference: boolean
@@ -38,7 +44,19 @@ function getOrCreateChildNode(
 
 function reportError(message: string, strict: boolean): void {
   if (strict) throw new Error(message)
-  console.warn(message)
+  if (!warnedMessages.has(message)) {
+    warnedMessages.add(message)
+    console.warn(message)
+  }
+}
+
+/**
+ * Builds an error message prefix that includes the ordering name when available.
+ */
+function formatOrderingLabel(orderingName: string | undefined): string {
+  return orderingName
+    ? `The sort ordering "${orderingName}" references`
+    : 'A sort ordering references'
 }
 
 /**
@@ -51,6 +69,7 @@ function recurseIntoField(
   fieldType: SchemaType,
   tail: PathSegment[],
   strict: boolean,
+  orderingName?: string,
 ): void {
   if (tail.length === 0) {
     getOrCreateChildNode(nodes, nodeKey, false)
@@ -59,12 +78,14 @@ function recurseIntoField(
 
   if (isReferenceSchemaType(fieldType) && 'to' in fieldType) {
     const refNode = getOrCreateChildNode(nodes, nodeKey, true)
-    fieldType.to.forEach((refType) => joinReferences(refNode.children, refType, tail, strict))
+    fieldType.to.forEach((refType) =>
+      joinReferences(refNode.children, refType, tail, strict, orderingName),
+    )
     return
   }
 
   const node = getOrCreateChildNode(nodes, nodeKey, false)
-  joinReferences(node.children, fieldType, tail, strict)
+  joinReferences(node.children, fieldType, tail, strict, orderingName)
 }
 
 /**
@@ -93,6 +114,7 @@ function joinReferences(
   schemaType: SchemaType,
   path: PathSegment[],
   strict: boolean,
+  orderingName?: string,
 ) {
   const [head, ...rest] = path
   if (!head || typeof head !== 'string') {
@@ -101,7 +123,7 @@ function joinReferences(
 
   if (!('fields' in schemaType)) {
     reportError(
-      `The current ordering config attempted to traverse into field "${head}" on non-object schema type "${schemaType.name}"`,
+      `${formatOrderingLabel(orderingName)} the field "${head}" on non-object schema type "${schemaType.name}"`,
       strict,
     )
     return
@@ -110,8 +132,9 @@ function joinReferences(
   const schemaField = schemaType.fields.find((field) => field.name === head)
   if (!schemaField) {
     if (!IMPLICIT_SCHEMA_TYPE_FIELDS.includes(head)) {
+      const validFields = schemaType.fields.map((field) => field.name).join(', ')
       reportError(
-        `The current ordering config targeted the nonexistent field "${head}" on schema type "${schemaType.name}". It should be one of ${schemaType.fields.map((field) => field.name).join(', ')}`,
+        `${formatOrderingLabel(orderingName)} the nonexistent field "${head}" on schema type "${schemaType.name}". Valid fields are: ${validFields}`,
         strict,
       )
     }
@@ -124,14 +147,14 @@ function joinReferences(
     (isIndexSegment(nextSegment) || isKeySegment(nextSegment) || isIndexTuple(nextSegment))
 
   if (!hasArrayAccessor) {
-    recurseIntoField(nodes, head, schemaField.type, rest, strict)
+    recurseIntoField(nodes, head, schemaField.type, rest, strict, orderingName)
     return
   }
 
   // Range slices are not meaningful for ordering projections.
   if (isIndexTuple(nextSegment)) {
     reportError(
-      `The current ordering config used a range slice on "${head}" on schema type "${schemaType.name}". Range slices are not supported for ordering.`,
+      `${formatOrderingLabel(orderingName)} a range slice on "${head}" on schema type "${schemaType.name}". Range slices are not supported for ordering.`,
       strict,
     )
     return
@@ -139,7 +162,7 @@ function joinReferences(
 
   if (schemaField.type.jsonType !== 'array') {
     reportError(
-      `The current ordering config used array access on non-array field "${head}" on schema type "${schemaType.name}"`,
+      `${formatOrderingLabel(orderingName)} array access on non-array field "${head}" on schema type "${schemaType.name}"`,
       strict,
     )
     return
@@ -150,7 +173,7 @@ function joinReferences(
   ) as SchemaType[]
   if (members.length !== 1) {
     reportError(
-      `The current ordering config used array access on multi-type array field "${head}" on schema type "${schemaType.name}". Array ordering requires a single member type.`,
+      `${formatOrderingLabel(orderingName)} array access on multi-type array field "${head}" on schema type "${schemaType.name}". Array ordering requires a single member type.`,
       strict,
     )
     return
@@ -161,7 +184,7 @@ function joinReferences(
   const tail = rest.slice(1)
   const memberType = members[0]
 
-  recurseIntoField(nodes, nodeKey, memberType, tail, strict)
+  recurseIntoField(nodes, nodeKey, memberType, tail, strict, orderingName)
 }
 
 /**
@@ -215,12 +238,13 @@ export function getExtendedProjection(
   schemaType: SchemaType,
   orderBy: SortOrderingItem[],
   strict: boolean = false,
+  orderingName?: string,
 ): string {
   const nodes = new Map<string, ProjectionNode>()
 
   orderBy.forEach((ordering) => {
     if (!ordering.field) return
-    joinReferences(nodes, schemaType, pathFromString(ordering.field), strict)
+    joinReferences(nodes, schemaType, pathFromString(ordering.field), strict, orderingName)
   })
 
   return createProjection(nodes)


### PR DESCRIPTION
### Description
Validates persisted document list sort orders against the current workspace's schema before applying them. Fixes a crash in multi-workspace studios where sorting by a field in Workspace A (e.g. `displayTitle`) persists to a shared key, then breaks Workspace B's document list when that field doesn't exist in its schema.

Sort orderings that reference fields not present in the current document type now appear disabled in the document list menu with a tooltip explanation.

Resolves [SAPP-3636](https://linear.app/sanity/issue/SAPP-3636)

### What to review

- `validateSortOrder()` in `helpers.ts` - pure function that checks sort order fields against the schema type, falling back to default for missing fields
- Validation wiring in `PaneContainer.tsx` - validates on both read (before rendering) and write (before persisting via `handleSetSortOrder`)
- Disabled state for invalid sort menu items in `addSelectedStateToMenuItems` - uses `validateSortOrder` to check each menu item's sort fields and stamps `disabled: {reason}` on invalid ones
- Unit tests in `helpers.test.ts` - 13 new test cases covering built-in fields, missing fields, nested paths, empty arrays, extended projections, and the exact cross-workspace scenario

<img width="365" height="240" alt="Screenshot 2026-04-08 at 11 30 43" src="https://github.com/user-attachments/assets/2c54bdb7-ec5b-428c-8d17-20a80349ef71" />

### Testing

13 unit tests added to `helpers.test.ts`, verified that these are failing on the current `main` but passing with these changes.

### Notes for release

In multi-workspace studios, changing the document list sort order in one workspace no longer crashes another workspace whose schema lacks the sorted field. The studio falls back to sorting by last edited. Invalid sort orderings appear disabled in the menu and log a console warning.
