### PR TITLE
ci(e2e): skip merge-reports when tests never ran

### DIFF
--- a/.github/workflows/e2e-ct.yml
+++ b/.github/workflows/e2e-ct.yml
@@ -103,8 +103,8 @@ jobs:
           fi
 
   merge-reports:
-    if: always() && needs.install.outputs.has_code_changes == 'true'
-    needs: [install, playwright-ct-test]
+    needs: [playwright-ct-test]
+    if: "!cancelled() && needs.playwright-ct-test.result != 'skipped'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -253,8 +253,8 @@ jobs:
           fi
 
   merge-reports:
-    needs: [install, playwright-test]
-    if: always() && needs.install.outputs.has_code_changes == 'true'
+    needs: [playwright-test]
+    if: "!cancelled() && needs.playwright-test.result != 'skipped'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
### Description
Replace `always()` with `!cancelled()` and check that the test job wasn't skipped. This prevents merge-reports from failing when an earlier job (e.g. install) fails due to an outdated lockfile or similar infrastructure issue.

### What to review
Makes sense?

### Testing

If CI passes we're good

### Notes for release

N/A