### PR TITLE
fix(sanity): use "added" and "removed" diffs in divergence inspector

### DIFF
--- a/packages/sanity/src/core/divergence/components/DivergenceDetail.tsx
+++ b/packages/sanity/src/core/divergence/components/DivergenceDetail.tsx
@@ -6,7 +6,7 @@ import {type RefObject, type ComponentType, Fragment} from 'react'
 import {DocumentChangeContext} from 'sanity/_singletons'
 
 import {Button} from '../../../ui-components/button/Button'
-import {emptyValuesByType, type DiffComponent, type DiffComponentOptions} from '../../field'
+import {type DiffComponent, type DiffComponentOptions} from '../../field'
 import {useTranslation} from '../../i18n'
 import {type DivergenceNavigator, type ReachableDivergence} from '../divergenceNavigator'
 import {useDivergenceController} from '../hooks/useDivergenceController'
@@ -56,9 +56,8 @@ export const DivergenceDetail: ComponentType<DivergenceDetailProps> = ({
   const diff = isLoading
     ? undefined
     : diffInput<any>(
-        wrap(upstreamBase?.value?.value ?? emptyValuesByType[divergence.schemaType.jsonType], {}),
-        wrap(upstreamHead?.value?.value ?? emptyValuesByType[divergence.schemaType.jsonType], {}),
-        {},
+        wrap(upstreamBase?.value?.value ?? null, {}),
+        wrap(upstreamHead?.value?.value ?? null, {}),
       )
 
   const DiffComponent = normalizeDiffComponent(divergence.diffComponent)


### PR DESCRIPTION
### Description

If either of the diff values are `null` or `undefined`, the divergence inspector currently attempts to resolve an empty value based on the field's `jsonType` property. e.g. for a "string" type, the inspector will resolve an empty value of `""`.

This is unnecessary, because the `diffInput` function already produces an "added" diff if the value transitioned from `null`, and a "removed" diff if the value transitioned to `null`.

Additionally, it causes a bug in which the UI renders `NaN` if a `datetime` value was added or removed. This is because `datetime` fields have a JSON type of "string", but the empty value for a string type (`""`) cannot be parsed as a date.

This branch removes the empty value resolution, instead relying on the "added" and "removed" diff support that already exists in the system, and in doing so, fixes the `NaN` datetime bug.

#### Before

<img width="667" height="290" alt="before" src="https://github.com/user-attachments/assets/96f6e93e-0cd6-4b40-9ee0-d41540ce3128" />

#### After

<img width="667" height="290" alt="after" src="https://github.com/user-attachments/assets/a777ac63-abcd-4305-b002-0d01c621314a" />

### What to review

Divergence inspector where a `datetime` value has been added or removed.

### Testing

Verified correct behaviour in Test Studio when a divergence is caused by adding or removing a `datetime` value.