### PR TITLE
fix(releases): resolving issues with navigation between scheduled drafts and releases

### DIFF
--- a/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesList.tsx
@@ -162,15 +162,17 @@ export function ReleasesList({
           ))}
         </Stack>
       )}
-      {areReleasesEnabled && (
-        <StickyBottomCard borderTop paddingY={1} paddingX={2}>
-          <Stack space={1}>
-            <ScheduledDraftsMenuItem />
-            <ViewContentReleasesMenuItem />
-            <CreateReleaseMenuItem onCreateRelease={handleOpenBundleDialog} />
-          </Stack>
-        </StickyBottomCard>
-      )}
+      <StickyBottomCard borderTop paddingY={1} paddingX={2}>
+        <Stack space={1}>
+          <ScheduledDraftsMenuItem />
+          {areReleasesEnabled && (
+            <>
+              <ViewContentReleasesMenuItem />
+              <CreateReleaseMenuItem onCreateRelease={handleOpenBundleDialog} />
+            </>
+          )}
+        </Stack>
+      </StickyBottomCard>
     </Card>
   )
 }

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -102,21 +102,10 @@ export function ReleasesOverview() {
   const navigateRef = useRef(router.navigate)
   const [releaseGroupMode, setReleaseGroupMode] = useState<Mode>(getInitialReleaseGroupMode(router))
 
-  const [cardinalityView, setCardinalityView] = useState<CardinalityView>(
-    getInitialCardinalityView({router, isScheduledDraftsEnabled, isReleasesEnabled}),
+  const cardinalityView = useMemo(
+    () => getInitialCardinalityView({router, isScheduledDraftsEnabled, isReleasesEnabled})(),
+    [router, isScheduledDraftsEnabled, isReleasesEnabled],
   )
-
-  const viewFromUrl = useMemo(
-    (): CardinalityView =>
-      new URLSearchParams(router.state._searchParams).get('view') === 'drafts'
-        ? 'drafts'
-        : 'releases',
-    [router.state._searchParams],
-  )
-
-  if (viewFromUrl !== cardinalityView) {
-    setCardinalityView(viewFromUrl)
-  }
 
   const [releaseFilterDate, setReleaseFilterDate] = useState<Date | undefined>(
     getInitialFilterDate(router),
@@ -249,8 +238,12 @@ export function ReleasesOverview() {
   )
 
   const handleCardinalityViewChange = useCallback(
-    (view: CardinalityView) => () => setCardinalityView(view),
-    [],
+    (view: CardinalityView) => () => {
+      router.navigate({
+        _searchParams: buildReleasesSearchParams(releaseFilterDate, releaseGroupMode, view),
+      })
+    },
+    [router, releaseFilterDate, releaseGroupMode],
   )
 
   const handleSelectFilterDate = useCallback(
@@ -277,7 +270,7 @@ export function ReleasesOverview() {
     navigateRef.current = router.navigate
   })
 
-  // Sync local state to URL when user interacts with filters
+  // Sync filter/group state to URL, preserving the current cardinality view
   useEffect(() => {
     navigateRef.current({
       _searchParams: buildReleasesSearchParams(


### PR DESCRIPTION
### Description
Addresses https://github.com/sanity-io/sanity/issues/12573

When `releases.enabled: false` and `scheduledDrafts.enabled: true`, the Scheduled Drafts view was inaccessible due to two issues:

1. **`ReleasesOverview.tsx`** - PR #12354 correctly identified that `cardinalityView` needed to react to URL changes (not just on mount), but the render-time override it added (`viewFromUrl`) always defaulted to `'releases'` when the URL didn't yet contain `view=drafts`. Since this ran before the sync effect could write the correct param, the view was stuck on "Releases" and clicking "Scheduled Drafts" was immediately undone. The fix retains the reactive URL behaviour by deriving `cardinalityView` directly from the URL and config via `useMemo` - same intent, no race condition.

2. **`ReleasesList.tsx`** - The `ScheduledDraftsMenuItem` was gated behind `areReleasesEnabled`, hiding the navbar link when releases were disabled. Since the component already self-gates internally, it's now rendered independently.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Have verified this both in the studio directly and via the dashboard. Have also tested navigating around via the cardinality picker and also from the global perspective nav and all navigation now works as expected
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
