### PR TITLE
fix(document): resolving copying document id on live edit schema type

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/CopyDocumentActions.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/CopyDocumentActions.tsx
@@ -14,12 +14,12 @@ import {useDocumentPaneInfo} from '../../useDocumentPaneInfo'
 /**
  * Renders a dropdown button in the document panel header with two actions:
  * - Copy link to document (perspective-aware URL)
- * - Copy document ID (context-aware, including version/draft prefix)
+ * - Copy document ID (prefixed for versions/drafts, plain for published and live edit types)
  *
  * @internal
  */
 export function CopyDocumentActions() {
-  const {documentId, documentType} = useDocumentPaneInfo()
+  const {documentId, documentType, schemaType} = useDocumentPaneInfo()
   const {selectedReleaseId, selectedPerspectiveName} = usePerspective()
   const {params} = usePaneRouter()
   const {resolveIntentLink} = useRouter()
@@ -36,12 +36,12 @@ export function CopyDocumentActions() {
       return getVersionId(documentId, versionReleaseId)
     }
 
-    if (selectedPerspectiveName === 'published') {
+    if (selectedPerspectiveName === 'published' || schemaType?.liveEdit) {
       return documentId
     }
 
     return getDraftId(documentId)
-  }, [documentId, scheduledDraft, selectedPerspectiveName, selectedReleaseId])
+  }, [documentId, scheduledDraft, schemaType?.liveEdit, selectedPerspectiveName, selectedReleaseId])
 
   const handleCopyLink = useCallback(async () => {
     telemetry.log(DocumentURLCopied)

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
@@ -1,21 +1,11 @@
 import {render, screen} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
 import {usePerspective} from 'sanity'
-import {
-  type Mock,
-  type MockedFunction,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest'
+import {type Mock, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
 import {usePaneRouter} from '../../../../../components'
 import {structureUsEnglishLocaleBundle} from '../../../../../i18n'
-import {type DocumentPaneInfoContextValue} from '../../../DocumentPaneContext'
 import {useDocumentPaneInfo} from '../../../useDocumentPaneInfo'
 import {CopyDocumentActions} from '../CopyDocumentActions'
 
@@ -76,9 +66,7 @@ vi.mock('@sanity/telemetry/react', () => ({
 
 const mockUsePerspective = usePerspective as Mock
 const mockUsePaneRouter = usePaneRouter as Mock
-const mockUseDocumentPaneInfo = useDocumentPaneInfo as MockedFunction<
-  () => Partial<DocumentPaneInfoContextValue>
->
+const mockUseDocumentPaneInfo = useDocumentPaneInfo as Mock
 let wrapper: React.ComponentType<{children: React.ReactNode}>
 
 beforeAll(async () => {
@@ -99,6 +87,7 @@ describe('CopyDocumentActions', () => {
     mockUseDocumentPaneInfo.mockReturnValue({
       documentType: 'article',
       documentId: 'doc-123',
+      schemaType: {liveEdit: false},
     })
   })
 
@@ -197,6 +186,19 @@ describe('CopyDocumentActions', () => {
       await clickMenuItem('copy-document-id')
 
       expect(mockClipboardWriteText).toHaveBeenCalledWith('drafts.doc-123')
+    })
+
+    it('copies {docId} for live edit document types', async () => {
+      mockUseDocumentPaneInfo.mockReturnValue({
+        documentType: 'settings',
+        documentId: 'doc-123',
+        schemaType: {liveEdit: true},
+      })
+
+      render(<CopyDocumentActions />, {wrapper})
+      await clickMenuItem('copy-document-id')
+
+      expect(mockClipboardWriteText).toHaveBeenCalledWith('doc-123')
     })
 
     it('copies {docId} for published perspective', async () => {


### PR DESCRIPTION
### Description
"Copy document ID" on live edit schema types copied the draft-prefixed ID (`drafts.xyz`) instead of the published document ID (`xyz`). The `contextAwareDocumentId` memo in `CopyDocumentActions` fell through to `getDraftId()` because the default perspective is `drafts`, with no check for live edit types.

This adds a `schemaType.liveEdit` check so live edit documents return the plain document ID - matching how `DocumentEventsPane` and `useDocumentForm` already handle this case.

Closes [SAPP-3701](https://linear.app/sanity/issue/SAPP-3701/copy-document-id-uses-draft-id-with-live-edit)

### What to review
- The condition ordering in the `contextAwareDocumentId` memo - version IDs still take priority, live edit sits alongside the published perspective check
- The new test case for live edit document types

### Testing
- New unit test: "copies {docId} for live edit document types"
- All existing `CopyDocumentActions` tests pass (13/13)

### Notes for release
Fixed an issue where "Copy document ID" on live edit document types copied the draft ID instead of the published ID.