### PR TITLE
fix(schema): support extracting object type without fields

### DIFF
--- a/packages/@sanity/schema/src/sanity/extractSchema.ts
+++ b/packages/@sanity/schema/src/sanity/extractSchema.ts
@@ -174,11 +174,7 @@ export function extractSchema(
 
     if (typeName === 'document' && isObjectType(schemaType)) {
       const defaultAttributes = documentDefaultFields(schemaType.name)
-
       const object = createObject(schemaType)
-      if (object.type === 'unknown') {
-        return null
-      }
 
       return {
         name: schemaType.name,
@@ -284,9 +280,7 @@ export function extractSchema(
 
     throw new Error(`Type "${schemaType.name}" not found`)
   }
-  function createObject(
-    schemaType: ObjectSchemaType | SanitySchemaType,
-  ): ObjectTypeNode | UnknownTypeNode {
+  function createObject(schemaType: ObjectSchemaType | SanitySchemaType): ObjectTypeNode {
     const attributes: Record<string, ObjectAttribute> = {}
 
     const fields = gatherFields(schemaType)
@@ -338,11 +332,6 @@ export function extractSchema(
       attributes.asset
     ) {
       attributes.asset.optional = false
-    }
-
-    // Ignore empty objects
-    if (Object.keys(attributes).length === 0) {
-      return {type: 'unknown'} satisfies UnknownTypeNode
     }
 
     if (schemaType.type?.name !== 'document' && schemaType.name !== 'object') {

--- a/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
+++ b/packages/@sanity/schema/test/extractSchema/extractSchema.test.ts
@@ -553,6 +553,50 @@ describe('Extract schema test', () => {
     })
   })
 
+  test('object type without fields returns empty object type', () => {
+    const types = [
+      defineType({
+        title: 'Empty Object',
+        name: 'emptyObject',
+        type: 'object',
+        fields: [],
+      }),
+      defineType({
+        title: 'Test Document',
+        name: 'testDocument',
+        type: 'document',
+        fields: [
+          {
+            title: 'Empty',
+            name: 'empty',
+            type: 'emptyObject',
+          },
+        ],
+      }),
+    ]
+
+    // Compile directly to bypass validation that rejects objects with no fields
+    const schema = Schema.compile({
+      name: 'test',
+      types: [...types, ...builtinTypes],
+    })
+
+    const extracted = extractSchema(schema)
+    const emptyObjectType = extracted.find((type) => type.name === 'emptyObject')
+    expect(emptyObjectType).toBeDefined()
+    assert(emptyObjectType !== undefined)
+    assert(emptyObjectType.type === 'type')
+    expect(emptyObjectType.name).toBe('emptyObject')
+    expect(emptyObjectType.value.type).toBe('object')
+    assert(emptyObjectType.value.type === 'object')
+    expect(emptyObjectType.value.attributes).toStrictEqual({
+      _type: {
+        type: 'objectAttribute',
+        value: {type: 'string', value: 'emptyObject'},
+      },
+    })
+  })
+
   test('order of types does not matter', () => {
     const schema1 = createSchema({
       name: 'test',


### PR DESCRIPTION
### Description

`extractSchema` returned `{type: 'unknown'}` for object types with no fields, which caused unknowns to be generated for known object types. Since we allow defining object types with no fields we need to support it.

This PR changes it to return `{type: 'object', attributes: {}}` instead, preserving the correct type structure.

### What to review

My primary question is why we decided to return unknown for objects without fields in the first place.. If we just thought that it was a thing that wouldn't happen, or that it was something we planned on disallowing but never did I think changing it is fine. If we did it for some other reason we need to think this through..

- `packages/@sanity/schema/src/sanity/extractSchema.ts` — the behavior change and return type narrowing (`ObjectTypeNode | UnknownTypeNode` → `ObjectTypeNode`)
- `packages/@sanity/schema/test/extractSchema/extractSchema.test.ts` — new test for the empty object case

### Testing

Added a unit test that defines an object type with no fields, extracts the schema, and verifies it produces a proper object type node with only the `_type` attribute.

### Notes for release

`extractSchema` now returns a proper object type for object types without fields, instead of returning an unknown type. This affects consumers of the `@sanity/schema` extract API.