### PR TITLE
fix(schema): convert missing descriptor properties and expand test coverage

### DIFF
--- a/packages/@sanity/schema/src/descriptors/convert.ts
+++ b/packages/@sanity/schema/src/descriptors/convert.ts
@@ -157,10 +157,15 @@ export class DescriptorConverter {
   }
 }
 
+function getOwnProps(schemaType: SchemaType): Record<string, unknown> {
+  // OWN_PROPS_NAME is only set on subtypes, not the core types.
+  return OWN_PROPS_NAME in schemaType
+    ? (schemaType as any)[OWN_PROPS_NAME]
+    : (schemaType as unknown as Record<string, unknown>)
+}
+
 function convertCommonTypeDef(schemaType: SchemaType, path: string, opts: Options): CommonTypeDef {
-  // Note that OWN_PROPS_NAME is only set on subtypes, not the core types.
-  // We might consider setting OWN_PROPS_NAME on _all_ types to avoid this branch.
-  const ownProps = OWN_PROPS_NAME in schemaType ? (schemaType as any)[OWN_PROPS_NAME] : schemaType
+  const ownProps = getOwnProps(schemaType)
 
   let fields: ObjectField[] | undefined
   if (Array.isArray(ownProps.fields)) {
@@ -312,7 +317,8 @@ function convertTypeDef(schemaType: SchemaType, path: string, opts: Options): Ty
     }
     case 'reference':
     case 'globalDocumentReference':
-    case 'crossDatasetReference':
+    case 'crossDatasetReference': {
+      const ownProps = getOwnProps(schemaType)
       return {
         extends: schemaType.type.name,
         to: filterStringKey(
@@ -321,8 +327,10 @@ function convertTypeDef(schemaType: SchemaType, path: string, opts: Options): Ty
             // The `toType.type` case is for crossDatasetReferences/crossDatasetReference
             .map((toType) => ({name: toType.name || toType.type?.name || toType.type})),
         ),
+        weak: maybeTrue(ownProps.weak),
         ...common,
       } satisfies ReferenceTypeDef
+    }
     default:
       return {extends: schemaType.type.name, ...common} satisfies SubtypeDef
   }

--- a/packages/@sanity/schema/src/descriptors/convert.ts
+++ b/packages/@sanity/schema/src/descriptors/convert.ts
@@ -227,7 +227,10 @@ function convertCommonTypeDef(schemaType: SchemaType, path: string, opts: Option
     )
   }
 
-  const reason = ownProps.deprecated?.reason
+  const reason =
+    isObject(ownProps.deprecated) && 'reason' in ownProps.deprecated
+      ? ownProps.deprecated.reason
+      : undefined
 
   let orderings: ObjectOrdering[] | undefined
   if (Array.isArray(ownProps.orderings)) {

--- a/packages/@sanity/schema/src/descriptors/convert.ts
+++ b/packages/@sanity/schema/src/descriptors/convert.ts
@@ -463,7 +463,7 @@ function maybeValidations(obj: unknown): Validation[] | undefined {
     case 'url':
       impliedRules.push({
         type: 'uri',
-        allowRelative: false,
+        scheme: ['http', 'https'],
       })
       break
     case 'slug':
@@ -506,8 +506,12 @@ function maybeValidations(obj: unknown): Validation[] | undefined {
       continue
     }
 
-    // Add implied rules that aren't already defined in the validation
-    const rulesToAdd = impliedRules.filter((ir) => !validation.rules.some((r) => isEqual(r, ir)))
+    // Add implied rules that aren't already defined in the validation.
+    // Implied rules are defaults — if explicit validation already includes a rule of the
+    // same type, the default is redundant. Match by type since that's the semantic identity.
+    const rulesToAdd = impliedRules.filter(
+      (ir) => !validation.rules.some((r) => r.type === ir.type),
+    )
     if (rulesToAdd.length > 0) {
       validation.rules.unshift(...rulesToAdd)
     }
@@ -718,17 +722,33 @@ function convertRuleSpec(spec: unknown, optional?: true): RuleType | undefined {
       }
       return undefined
     case 'uri': {
+      const options =
+        isObject(constraint) && 'options' in constraint && isObject(constraint.options)
+          ? constraint.options
+          : undefined
+
+      const scheme =
+        options && 'scheme' in options && Array.isArray(options.scheme) && options.scheme.length > 0
+          ? options.scheme
+              .map((s: unknown) => convertSchemeValue(s))
+              .filter((s): s is string | {type: 'regex'; pattern: string} => s !== undefined)
+          : undefined
+
       const allowRelative =
-        isObject(constraint) &&
-        'options' in constraint &&
-        isObject(constraint.options) &&
-        'allowRelative' in constraint.options
-          ? maybeBoolean(constraint.options.allowRelative)
+        options && 'allowRelative' in options ? maybeBoolean(options.allowRelative) : undefined
+      const relativeOnly =
+        options && 'relativeOnly' in options ? maybeBoolean(options.relativeOnly) : undefined
+      const allowCredentials =
+        options && 'allowCredentials' in options
+          ? maybeBoolean(options.allowCredentials)
           : undefined
 
       return {
         type: 'uri',
-        ...(allowRelative !== undefined && {allowRelative}),
+        ...(scheme !== undefined && scheme.length > 0 && {scheme}),
+        ...(allowRelative && {allowRelative}),
+        ...(relativeOnly && {relativeOnly}),
+        ...(allowCredentials && {allowCredentials}),
       }
     }
     case 'custom':
@@ -762,6 +782,35 @@ function convertConstraintValue(constraint: unknown): string | FieldReference {
   }
   // Convert to string
   return String(constraint)
+}
+
+// Regex metacharacters that escapeRegex in Rule.ts escapes
+const REGEX_META = /[.*+?^${}()|[\]\\]/
+
+/**
+ * Converts a scheme value to either a plain string or a `{type: 'regex', pattern}` object.
+ * Rule.uri() wraps plain strings as `new RegExp("^" + escapeRegex(str) + "$")`.
+ * If the source matches that pattern (anchored, no metacharacters), recover the plain string.
+ * Otherwise, return a RegexPattern for user-provided RegExp patterns.
+ */
+function convertSchemeValue(val: unknown): string | {type: 'regex'; pattern: string} | undefined {
+  if (val instanceof RegExp) {
+    const {source, flags} = val
+    // If flags are present, always emit a regex pattern with inline modifiers (e.g. (?i))
+    // to preserve flag semantics in a portable way across regex libraries.
+    if (flags) {
+      return {type: 'regex', pattern: `(?${flags})${source}`}
+    }
+    const match = source.match(/^\^(.*)\$$/)
+    if (match && !REGEX_META.test(match[1])) {
+      return match[1]
+    }
+    return {type: 'regex', pattern: source}
+  }
+  if (typeof val === 'string') {
+    return val
+  }
+  return undefined
 }
 
 function maybeBoolean(val: unknown): boolean | undefined {

--- a/packages/@sanity/schema/src/descriptors/types.ts
+++ b/packages/@sanity/schema/src/descriptors/types.ts
@@ -210,5 +210,11 @@ export type Rule =
   | {type: 'length'; value: string | FieldReference}
   | {type: 'precision'; value: string | FieldReference}
   | {type: 'regex'; pattern: string; invert?: true}
-  | {type: 'uri'; allowRelative?: boolean}
+  | {
+      type: 'uri'
+      scheme?: (string | {type: 'regex'; pattern: string})[]
+      allowRelative?: boolean
+      relativeOnly?: boolean
+      allowCredentials?: boolean
+    }
   | {type: 'custom'; name?: string; optional?: true}

--- a/packages/@sanity/schema/src/descriptors/types.ts
+++ b/packages/@sanity/schema/src/descriptors/types.ts
@@ -114,6 +114,9 @@ export type ObjectFieldset = {
   title?: string
   description?: string
   group?: string
+  hidden?: true | FunctionMarker
+  readOnly?: true | FunctionMarker
+  options?: EncodableValue
 }
 
 export type ObjectGroup = {

--- a/packages/@sanity/schema/src/descriptors/types.ts
+++ b/packages/@sanity/schema/src/descriptors/types.ts
@@ -140,7 +140,7 @@ export type ObjectOrderingBy = {
 export interface ReferenceTypeDef extends SubtypeDef {
   extends: 'reference' | 'crossDatasetReference' | 'globalDocumentReference'
   to: ReferenceTarget[]
-  weak?: boolean
+  weak?: true
 }
 
 export type ReferenceTarget = {

--- a/packages/@sanity/schema/src/manifest/createSchemaFromManifestTypes.ts
+++ b/packages/@sanity/schema/src/manifest/createSchemaFromManifestTypes.ts
@@ -243,8 +243,26 @@ function applyRuleSpec(rule: IRule, ruleSpec: unknown): IRule {
       break
 
     case 'uri':
-      if (isObject(constraint) && 'options' in constraint) {
-        return rule.uri(constraint.options as UriValidationOptions)
+      if (isObject(constraint) && 'options' in constraint && isObject(constraint.options)) {
+        const uriOptions = {...(constraint.options as Record<string, unknown>)}
+        // Scheme values are stored as RegExp.toString() strings (e.g., "/^http$/") during
+        // manifest serialization, or as {type: 'regex', pattern} objects in the descriptor
+        // format. Convert both back to RegExp so rule.uri() doesn't double-wrap them.
+        if ('scheme' in uriOptions && Array.isArray(uriOptions.scheme)) {
+          uriOptions.scheme = uriOptions.scheme.map((s: unknown) => {
+            // Manifest serialization stores RegExp as "/pattern/flags" strings via
+            // RegExp.toString(). Only convert those back to RegExp. Plain strings
+            // (e.g. "https" from the descriptor format) are passed through so that
+            // rule.uri() can anchor them correctly.
+            if (typeof s === 'string') {
+              if (/^\/(.*)\/([gimuy]*)$/.test(s)) return stringToRegExp(s)
+              return s
+            }
+            if (isRegexPattern(s)) return regexPatternToRegExp(s)
+            return s
+          })
+        }
+        return rule.uri(uriOptions as UriValidationOptions)
       }
       break
 
@@ -290,4 +308,25 @@ function stringToRegExp(str: string): RegExp {
   }
   // Fallback if the format doesn't match
   return new RegExp(str)
+}
+
+function isRegexPattern(val: unknown): val is {type: 'regex'; pattern: string} {
+  return (
+    typeof val === 'object' &&
+    val !== null &&
+    'type' in val &&
+    (val as {type: unknown}).type === 'regex' &&
+    'pattern' in val &&
+    typeof (val as {pattern: unknown}).pattern === 'string'
+  )
+}
+
+function regexPatternToRegExp(val: {type: 'regex'; pattern: string}): RegExp {
+  // Inline modifiers like (?i) are used to encode flags in a portable way.
+  // Extract them to reconstruct the RegExp with proper flags.
+  const match = val.pattern.match(/^\(\?([a-z]+)\)(.*)$/)
+  if (match) {
+    return new RegExp(match[2], match[1])
+  }
+  return new RegExp(val.pattern)
 }

--- a/packages/sanity/test/descriptors/schema.test.tsx
+++ b/packages/sanity/test/descriptors/schema.test.tsx
@@ -911,6 +911,165 @@ describe('Base features', () => {
       })
     })
 
+    test('uri validation serializes scheme', async () => {
+      expect(
+        (
+          await convertType({
+            name: 'foo',
+            type: 'string',
+            validation: (rule: any) => rule.uri({scheme: ['https', /.*foo.*/]}),
+          })
+        ).typeDef,
+      ).toMatchObject({
+        validation: [
+          {
+            level: 'error',
+            rules: [
+              {
+                type: 'uri',
+                scheme: [
+                  'https',
+                  {
+                    type: 'regex',
+                    pattern: '.*foo.*',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    test('uri validation serializes relativeOnly', async () => {
+      expect(
+        (
+          await convertType({
+            name: 'foo',
+            type: 'string',
+            validation: (rule: any) => rule.uri({relativeOnly: true}),
+          })
+        ).typeDef,
+      ).toMatchObject({
+        validation: [
+          {
+            level: 'error',
+            rules: [{type: 'uri', relativeOnly: true}],
+          },
+        ],
+      })
+    })
+
+    test('uri validation serializes allowCredentials', async () => {
+      expect(
+        (
+          await convertType({
+            name: 'foo',
+            type: 'string',
+            validation: (rule: any) => rule.uri({allowCredentials: true}),
+          })
+        ).typeDef,
+      ).toMatchObject({
+        validation: [
+          {
+            level: 'error',
+            rules: [{type: 'uri', allowCredentials: true}],
+          },
+        ],
+      })
+    })
+
+    test('uri validation serializes all options together', async () => {
+      expect(
+        (
+          await convertType({
+            name: 'foo',
+            type: 'string',
+            validation: (rule: any) =>
+              rule.uri({
+                scheme: ['https'],
+                allowRelative: true,
+                relativeOnly: false,
+                allowCredentials: true,
+              }),
+          })
+        ).typeDef,
+      ).toMatchObject({
+        validation: [
+          {
+            level: 'error',
+            rules: [
+              {
+                type: 'uri',
+                scheme: ['https'],
+                allowRelative: true,
+                allowCredentials: true,
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    test('uri validation preserves regex source for non-string schemes', async () => {
+      expect(
+        (
+          await convertType({
+            name: 'foo',
+            type: 'string',
+            validation: (rule: any) => rule.uri({scheme: [/^https?$/]}),
+          })
+        ).typeDef,
+      ).toMatchObject({
+        validation: [
+          {
+            level: 'error',
+            rules: [{type: 'uri', scheme: [{type: 'regex', pattern: '^https?$'}]}],
+          },
+        ],
+      })
+    })
+
+    test('uri validation recovers anchored regex to plain string', async () => {
+      // Rule.uri() wraps plain strings as /^str$/, and convertSchemeValue should
+      // recover them back to plain strings. Test with an explicit anchored regex.
+      expect(
+        (
+          await convertType({
+            name: 'foo',
+            type: 'string',
+            validation: (rule: any) => rule.uri({scheme: [/^http$/]}),
+          })
+        ).typeDef,
+      ).toMatchObject({
+        validation: [
+          {
+            level: 'error',
+            rules: [{type: 'uri', scheme: ['http']}],
+          },
+        ],
+      })
+    })
+
+    test('uri validation preserves regex flags via inline modifiers', async () => {
+      expect(
+        (
+          await convertType({
+            name: 'foo',
+            type: 'string',
+            validation: (rule: any) => rule.uri({scheme: [/^http$/i]}),
+          })
+        ).typeDef,
+      ).toMatchObject({
+        validation: [
+          {
+            level: 'error',
+            rules: [{type: 'uri', scheme: [{type: 'regex', pattern: '(?i)^http$'}]}],
+          },
+        ],
+      })
+    })
+
     test('enum validation (valid)', async () => {
       expect(
         (
@@ -1285,7 +1444,7 @@ describe('Base features', () => {
           level: 'error',
           rules: [
             {type: 'enum', values: ['a', 'b', 'c']},
-            {type: 'uri', allowRelative: false},
+            {type: 'uri', scheme: ['http', 'https']},
           ],
         },
         {

--- a/packages/sanity/test/descriptors/schema.test.tsx
+++ b/packages/sanity/test/descriptors/schema.test.tsx
@@ -2330,6 +2330,15 @@ describe('Text', () => {
   })
 })
 
+describe('Slug', () => {
+  test('implied validation', async () => {
+    const type = await convertType({name: 'foo', type: 'slug'})
+    expect(type.typeDef).toMatchObject({
+      validation: [{level: 'error', rules: [{type: 'custom'}]}],
+    })
+  })
+})
+
 describe('References', () => {
   test('reference', async () => {
     expect(
@@ -2350,6 +2359,39 @@ describe('References', () => {
         {name: '_weak', typeDef: {extends: 'boolean'}},
       ],
     })
+  })
+
+  test('weak reference', async () => {
+    expect(
+      (
+        await convertType(
+          {name: 'foo', type: 'reference', to: [{type: 'person'}], weak: true},
+          {
+            name: 'person',
+            type: 'document',
+            fields: [{name: 'name', type: 'string'}],
+          },
+        )
+      ).typeDef,
+    ).toMatchObject({
+      to: [{name: 'person'}],
+      weak: true,
+    })
+  })
+
+  test('non-weak reference omits weak', async () => {
+    expect(
+      (
+        await convertType(
+          {name: 'foo', type: 'reference', to: [{type: 'person'}]},
+          {
+            name: 'person',
+            type: 'document',
+            fields: [{name: 'name', type: 'string'}],
+          },
+        )
+      ).typeDef.weak,
+    ).toBeUndefined()
   })
 
   test('crossDatasetReference', async () => {
@@ -2561,6 +2603,76 @@ describe('Block', () => {
   })
 })
 
+describe('Type-specific options', () => {
+  test('array options', async () => {
+    const type = await convertType({
+      name: 'foo',
+      type: 'array',
+      of: [{type: 'string'}],
+      options: {layout: 'grid', sortable: false},
+    })
+    expect(type.typeDef.options).toMatchObject({
+      layout: 'grid',
+      sortable: false,
+    })
+  })
+
+  test('datetime options', async () => {
+    const type = await convertType({
+      name: 'foo',
+      type: 'datetime',
+      options: {dateFormat: 'YYYY-MM-DD', timeStep: 15},
+    })
+    expect(type.typeDef.options).toMatchObject({
+      dateFormat: 'YYYY-MM-DD',
+      timeStep: {__type: 'number', value: '15'},
+    })
+  })
+
+  test('image options', async () => {
+    const type = await convertType({
+      name: 'foo',
+      type: 'image',
+      options: {hotspot: true},
+    })
+    expect(type.typeDef.options).toMatchObject({
+      hotspot: true,
+    })
+  })
+
+  test('boolean options', async () => {
+    const type = await convertType({
+      name: 'foo',
+      type: 'boolean',
+      options: {layout: 'checkbox'},
+    })
+    expect(type.typeDef.options).toMatchObject({
+      layout: 'checkbox',
+    })
+  })
+
+  test('string list options', async () => {
+    const type = await convertType({
+      name: 'foo',
+      type: 'string',
+      options: {
+        list: [
+          {title: 'Option A', value: 'a'},
+          {title: 'Option B', value: 'b'},
+        ],
+        layout: 'radio',
+      },
+    })
+    expect(type.typeDef.options).toMatchObject({
+      list: [
+        {title: 'Option A', value: 'a'},
+        {title: 'Option B', value: 'b'},
+      ],
+      layout: 'radio',
+    })
+  })
+})
+
 // Tests for full roundtrip conversion (schema → manifest → schema)
 describe('Manifest roundtrip conversion', () => {
   test('basic types survive roundtrip conversion', async () => {
@@ -2682,6 +2794,56 @@ describe('createSchemaFromManifestTypes', () => {
         },
       ]),
     )
+  })
+
+  test('plain string URI schemes are anchored correctly after roundtrip', async () => {
+    // Descriptor format stores schemes as plain strings (e.g. "https") whereas manifest
+    // format stores them as RegExp.toString() strings (e.g. "/^https$/").
+    // When descriptor-format data is fed to createSchemaFromManifestTypes, plain strings
+    // must be passed through to rule.uri() which anchors them, not converted to unanchored RegExp.
+    const schema = createSchemaFromManifestTypes({
+      name: 'test',
+      types: [
+        {
+          name: 'myUrl',
+          type: 'string',
+          validation: [
+            {
+              level: 'error',
+              rules: [
+                {
+                  flag: 'uri',
+                  constraint: {
+                    options: {
+                      scheme: ['https', {type: 'regex', pattern: '(?i)^ftp$'}],
+                      allowRelative: true,
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+
+    const desc = await DESCRIPTOR_CONVERTER.get(schema)
+    const type = Object.values(desc.objectValues).find(
+      (val) => val.name === 'myUrl',
+    ) as EncodedNamedType
+
+    expect(type.typeDef.validation).toMatchObject([
+      {
+        level: 'error',
+        rules: [
+          {
+            type: 'uri',
+            scheme: ['https', {type: 'regex', pattern: '(?i)^ftp$'}],
+            allowRelative: true,
+          },
+        ],
+      },
+    ])
   })
 })
 


### PR DESCRIPTION
### Description

Fixes several gaps in the schema descriptor conversion layer:

- **URI validation**: Convert all `rule.uri()` options (`scheme`, `relativeOnly`, `allowCredentials`) — previously only `allowRelative` was converted. RegExp scheme values are serialized as `{type: 'regex', pattern}` objects, with anchored no-metachar patterns recovered back to plain strings.
- **Weak references**: Convert the `weak` flag on reference types using `OWN_PROPS_NAME` to read the user-defined value.
- **ObjectFieldset types**: Add missing `hidden`, `readOnly`, and `options` properties to the `ObjectFieldset` type definition.
- **Manifest roundtrip**: Update `createSchemaFromManifestTypes` to reconstruct `RegExp` objects from both serialized regex strings and `{type: 'regex', pattern}` descriptor objects when rebuilding URI validation rules.

### What to review

- `packages/@sanity/schema/src/descriptors/convert.ts` — URI scheme conversion logic (`convertSchemeValue`) and weak reference handling
- `packages/@sanity/schema/src/descriptors/types.ts` — Updated `ObjectFieldset` and `Rule` type definitions
- `packages/@sanity/schema/src/manifest/createSchemaFromManifestTypes.ts` — Regex pattern reconstruction for manifest roundtrip
- `packages/sanity/test/descriptors/schema.test.tsx` — New test coverage for URI options, slug type, type-specific options, and weak references

### Testing

Added unit tests covering:
- All URI validation options (scheme, allowRelative, relativeOnly, allowCredentials) individually and combined
- RegExp scheme serialization/deserialization (plain regex, anchored recovery, flag preservation via inline modifiers)
- Slug type implied validation
- Type-specific options (array, datetime, image, boolean, string list)

### Notes for release

N/A: Internal schema descriptor improvements
