### PR TITLE
fix(releases): preserve search input focus when filtering yields no results

### DIFF
--- a/packages/sanity/src/core/releases/tool/components/Table/TableLayout.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/TableLayout.tsx
@@ -1,5 +1,4 @@
-import {Box, Stack} from '@sanity/ui'
-import {type ReactNode} from 'react'
+import {type CSSProperties, type ReactNode, useMemo} from 'react'
 
 interface TableLayoutProps {
   isEmptyState: boolean
@@ -8,50 +7,35 @@ interface TableLayoutProps {
   contentHeight?: string
 }
 
+const emptyTableStyle: CSSProperties = {
+  width: '100%',
+  height: '100%',
+  display: 'grid',
+  gridTemplateRows: 'auto 1fr',
+}
+
+const defaultTableStyle: CSSProperties = {
+  width: '100%',
+}
+
 /**
  * @internal
  */
 export const TableLayout = ({isEmptyState, header, content, contentHeight}: TableLayoutProps) => {
-  if (isEmptyState) {
-    // Empty state layout - use CSS Grid to fill height
-    return (
-      <div style={{height: '100%'}}>
-        <table
-          style={{
-            width: '100%',
-            height: '100%',
-            display: 'grid',
-            gridTemplateRows: 'auto 1fr',
-          }}
-        >
-          {header}
-          <tbody
-            style={{
-              height: '100%',
-              position: 'relative',
-              overflow: 'hidden',
-            }}
-          >
-            {content}
-          </tbody>
-        </table>
-      </div>
-    )
-  }
+  const tbodyStyle = useMemo<CSSProperties>(
+    () =>
+      isEmptyState
+        ? {height: '100%', position: 'relative', overflow: 'hidden'}
+        : {height: contentHeight, position: 'relative'},
+    [isEmptyState, contentHeight],
+  )
 
-  // Normal content layout - use original scrollable structure
   return (
-    <Stack as="table">
-      {header}
-      <Box
-        style={{
-          height: contentHeight,
-          position: 'relative',
-        }}
-        as="tbody"
-      >
-        {content}
-      </Box>
-    </Stack>
+    <div style={{height: '100%'}}>
+      <table style={isEmptyState ? emptyTableStyle : defaultTableStyle}>
+        {header}
+        <tbody style={tbodyStyle}>{content}</tbody>
+      </table>
+    </div>
   )
 }

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
@@ -242,6 +242,16 @@ describe('ReleaseSummary', () => {
       within(searchedFirstDocument).getByText('Second document')
     })
 
+    it('retains search input focus when search yields no results', async () => {
+      await prerenderTest()
+
+      const searchInput = screen.getByPlaceholderText('Search documents')
+      await userEvent.type(searchInput, 'nonexistent query')
+
+      expect(screen.queryAllByTestId('table-row')).toHaveLength(0)
+      expect(searchInput).toHaveFocus()
+    })
+
     it('Allows for adding a document to an active release', async () => {
       await prerenderTest()
 


### PR DESCRIPTION
### Description

Fixes an issue where the search input on the releases summary page loses focus when the search query returns no matching documents. This made the search feel unresponsive, requiring users to click the input again to continue typing.

The root cause was in `TableLayout` - it rendered two entirely different DOM trees depending on whether the table had results or not (`Stack` vs `div > table`). When the search filter produced zero results, React unmounted and remounted the entire subtree (including the search input), causing the browser to drop focus.

Resolves https://linear.app/sanity/issue/PS-1195

### What to review

- `packages/sanity/src/core/releases/tool/components/Table/TableLayout.tsx` - the core fix. Now uses a single DOM structure (`div > table > tbody`) for both empty and non-empty states, toggling only CSS styles rather than switching element types.
- `packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx` - new regression test that verifies the search input retains focus when search yields no results.

To manually verify:
1. Open a release with documents on the summary page
2. Click the search input and type a query that matches no documents
3. Confirm the input retains focus and you can continue typing or clear without re-clicking

### Testing

Added a regression test in `ReleaseSummary.test.tsx` that types a non-matching search query and asserts the input still has focus after the table transitions to the empty state.

### Notes for release

Fixes an issue where typing in the release document search would cause the input to lose focus when no results matched.