### PR TITLE
fix(structure): allow text selection in validation panel error cards

### DIFF
--- a/packages/sanity/src/structure/panes/document/inspectors/validation/ValidationInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/validation/ValidationInspector.tsx
@@ -106,7 +106,12 @@ function ValidationCard(props: {
     (event: MouseEvent) => {
       // Allow text selection: if the user selected text, don't navigate
       const selection = window.getSelection()
-      if (selection && selection.toString().length > 0) {
+      if (
+        selection &&
+        selection.toString().length > 0 &&
+        // It's selecting inside the card, so don't navigate
+        event.currentTarget.contains(selection.anchorNode)
+      ) {
         return
       }
       onOpen(marker.path)

--- a/packages/sanity/src/structure/panes/document/inspectors/validation/ValidationInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/validation/ValidationInspector.tsx
@@ -12,7 +12,7 @@ import {
   type ValidationMarker,
 } from '@sanity/types'
 import {Box, Card, type CardTone, Flex, Stack, Text} from '@sanity/ui'
-import {type ErrorInfo, Fragment, useCallback, useMemo, useState} from 'react'
+import {type ErrorInfo, Fragment, type MouseEvent, useCallback, useMemo, useState} from 'react'
 import {type DocumentInspectorProps, isGoingToUnpublish, useTranslation} from 'sanity'
 
 import {ErrorBoundary} from '../../../../../ui-components'
@@ -102,7 +102,17 @@ function ValidationCard(props: {
   value: Partial<SanityDocument> | null
 }) {
   const {marker, onOpen, schemaType, value} = props
-  const handleOpen = useCallback(() => onOpen(marker.path), [marker, onOpen])
+  const handleClick = useCallback(
+    (event: MouseEvent) => {
+      // Allow text selection: if the user selected text, don't navigate
+      const selection = window.getSelection()
+      if (selection && selection.toString().length > 0) {
+        return
+      }
+      onOpen(marker.path)
+    },
+    [marker, onOpen],
+  )
   const [errorInfo, setErrorInfo] = useState<{error: Error; info: ErrorInfo} | null>(null)
   const Icon = MARKER_ICON[marker.level]
 
@@ -118,9 +128,10 @@ function ValidationCard(props: {
         <Card
           __unstable_focusRing
           as="button"
-          onClick={handleOpen}
+          onClick={handleClick}
           padding={3}
           radius={2}
+          style={{userSelect: 'text'}}
           tone={MARKER_TONE[marker.level]}
         >
           <Flex align="flex-start" gap={3}>


### PR DESCRIPTION
## Summary

The validation error cards in the document inspector side panel are rendered as `<button>` elements via `as="button"` on the Sanity UI `Card` component. By default, buttons suppress text selection, making it impossible for users to select specific parts of validation error messages — clicking and dragging would either fail to enter text-selection mode or highlight the entire panel.

## Changes

- **Add `userSelect: 'text'`** style to the validation card to explicitly allow text selection within the button element
- **Check `window.getSelection()`** on click — if the user has selected text, skip navigation so the selection is preserved

## How it works

When a user clicks on a validation card:
1. If they have drag-selected text, the click handler checks `window.getSelection()` and returns early — text selection is preserved
2. If they simply clicked (no selection), it navigates to the field as before

Keyboard navigation and accessibility are unaffected since the card remains a native `<button>` element.

Fixes https://linear.app/sanity/issue/SAPP-3708