### PR TITLE
chore(test-studio): allow external contributors to configure project via env vars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,8 @@ pnpm dev  # Starts at http://localhost:3333
 - Uses staging API by default (`api.sanity.work`)
 - Session persists in browser, so subsequent visits won't require re-authentication
 
+**External contributors:** The dev studio uses internal Sanity projects by default. To use your own project, copy `dev/test-studio/.env.example` to `dev/test-studio/.env` and fill in your project ID and dataset. Only the default workspace reads these overrides.
+
 Use the dev studio when you need to:
 
 - Visually verify UI changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,20 @@ pnpm build
 pnpm dev
 ```
 
+## Using the dev studio (external contributors)
+
+The dev studio (`pnpm dev`) uses internal Sanity projects by default. To use your own project instead:
+
+1. Create a free Sanity project at https://www.sanity.io/get-started
+2. Copy the example env file and fill in your values:
+   ```sh
+   cp dev/test-studio/.env.example dev/test-studio/.env
+   ```
+   Edit `dev/test-studio/.env` with your project ID and dataset name.
+3. Run `pnpm dev` - the studio starts at http://localhost:3333
+
+Only the default workspace (at `/test`) reads these values. Other workspaces in the picker use internal projects and can be ignored.
+
 # Release/workflow guidelines
 
 - `current` always points to the last released version

--- a/dev/test-studio/.env.example
+++ b/dev/test-studio/.env.example
@@ -1,4 +1,14 @@
-# To disable strict mode on your local checkout:
-# `cp .env.example .env.development`
-# Then restart your `sanity dev` or `pnpm dev` command
-SANITY_STUDIO_REACT_STRICT_MODE=false
+  # Optional: Override the default Sanity project used by the test studio's default workspace.
+  # External contributors who don't have access to the internal Sanity project should set these
+  # to point to their own Sanity project.
+  #
+  # 1. Create a free project at https://www.sanity.io/get-started
+  # 2. Copy this file to .env and fill in your project's values
+  #
+  # SANITY_STUDIO_PROJECT_ID=your-project-id
+  # SANITY_STUDIO_DATASET=production
+
+  # To disable strict mode on your local checkout:
+  # `cp .env.example .env.development`
+  # Then restart your `sanity dev` or `pnpm dev` command
+  SANITY_STUDIO_REACT_STRICT_MODE=false

--- a/dev/test-studio/.gitignore
+++ b/dev/test-studio/.gitignore
@@ -1,4 +1,5 @@
 /dist
 
+.env
 .env.*
 !.env.example

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
+    "@repo/utils": "workspace:*",
     "@types/lodash-es": "^4.17.12",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",

--- a/dev/test-studio/sanity.cli.ts
+++ b/dev/test-studio/sanity.cli.ts
@@ -45,15 +45,21 @@ export default defineCliConfig({
   vite(viteConfig: UserConfig, {command, mode}): UserConfig {
     const reactProductionProfiling = process.env.REACT_PRODUCTION_PROFILING === 'true'
 
+    // Only inject custom project overrides during local dev, not CI builds
+    const localDevDefines =
+      command === 'serve'
+        ? {
+            'import.meta.env.SANITY_STUDIO_PROJECT_ID': JSON.stringify(
+              process.env.SANITY_STUDIO_PROJECT_ID || '',
+            ),
+            'import.meta.env.SANITY_STUDIO_DATASET': JSON.stringify(
+              process.env.SANITY_STUDIO_DATASET || '',
+            ),
+          }
+        : {}
+
     const nextConfig = mergeConfig(viteConfig, {
-      define: {
-        'process.env.SANITY_STUDIO_PROJECT_ID': JSON.stringify(
-          process.env.SANITY_STUDIO_PROJECT_ID || '',
-        ),
-        'process.env.SANITY_STUDIO_DATASET': JSON.stringify(
-          process.env.SANITY_STUDIO_DATASET || '',
-        ),
-      },
+      define: localDevDefines,
       server: {
         warmup: {
           clientFiles: [

--- a/dev/test-studio/sanity.cli.ts
+++ b/dev/test-studio/sanity.cli.ts
@@ -1,21 +1,22 @@
 import path from 'node:path'
 
+import {loadEnvFiles} from '@repo/utils'
 import {defineCliConfig} from 'sanity/cli'
 import {defaultClientConditions, mergeConfig, type UserConfig} from 'vite'
 
+loadEnvFiles()
+
 const isStaging = process.env.SANITY_INTERNAL_ENV == 'staging'
+
+const projectId = process.env.SANITY_STUDIO_PROJECT_ID || (isStaging ? 'exx11uqh' : 'ppsg7ml5')
+const dataset = process.env.SANITY_STUDIO_DATASET || (isStaging ? 'playground' : 'test')
 const reactCompilerAllowList = /\/(?:sanity|@sanity\/vision)\/src\/.*\.tsx?$/
 
 export default defineCliConfig({
-  api: isStaging
-    ? {
-        projectId: 'exx11uqh',
-        dataset: 'playground',
-      }
-    : {
-        projectId: 'ppsg7ml5',
-        dataset: 'test',
-      },
+  api: {
+    projectId,
+    dataset,
+  },
   // Can be overriden by:
   // A) `SANITY_STUDIO_REACT_STRICT_MODE=false pnpm dev`
   // B) creating a `.env` file locally that sets the same env variable as above
@@ -42,6 +43,14 @@ export default defineCliConfig({
     const reactProductionProfiling = process.env.REACT_PRODUCTION_PROFILING === 'true'
 
     const nextConfig = mergeConfig(viteConfig, {
+      define: {
+        'process.env.SANITY_STUDIO_PROJECT_ID': JSON.stringify(
+          process.env.SANITY_STUDIO_PROJECT_ID || '',
+        ),
+        'process.env.SANITY_STUDIO_DATASET': JSON.stringify(
+          process.env.SANITY_STUDIO_DATASET || '',
+        ),
+      },
       server: {
         warmup: {
           clientFiles: [

--- a/dev/test-studio/sanity.cli.ts
+++ b/dev/test-studio/sanity.cli.ts
@@ -8,15 +8,18 @@ loadEnvFiles()
 
 const isStaging = process.env.SANITY_INTERNAL_ENV == 'staging'
 
-const projectId = process.env.SANITY_STUDIO_PROJECT_ID || (isStaging ? 'exx11uqh' : 'ppsg7ml5')
-const dataset = process.env.SANITY_STUDIO_DATASET || (isStaging ? 'playground' : 'test')
 const reactCompilerAllowList = /\/(?:sanity|@sanity\/vision)\/src\/.*\.tsx?$/
 
 export default defineCliConfig({
-  api: {
-    projectId,
-    dataset,
-  },
+  api: isStaging
+    ? {
+        projectId: 'exx11uqh',
+        dataset: 'playground',
+      }
+    : {
+        projectId: 'ppsg7ml5',
+        dataset: 'test',
+      },
   // Can be overriden by:
   // A) `SANITY_STUDIO_REACT_STRICT_MODE=false pnpm dev`
   // B) creating a `.env` file locally that sets the same env variable as above

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -57,8 +57,8 @@ import {defaultDocumentNode, newDocumentOptions, structure} from './structure'
 // @ts-expect-error - defined by vite
 const isStaging = globalThis.__SANITY_STAGING__ === true
 
-const customProjectId = process.env.SANITY_STUDIO_PROJECT_ID
-const customDataset = process.env.SANITY_STUDIO_DATASET
+const customProjectId = import.meta.env?.SANITY_STUDIO_PROJECT_ID || ''
+const customDataset = import.meta.env?.SANITY_STUDIO_DATASET || ''
 
 const envConfig = {
   // use this for production workspaces

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -57,6 +57,9 @@ import {defaultDocumentNode, newDocumentOptions, structure} from './structure'
 // @ts-expect-error - defined by vite
 const isStaging = globalThis.__SANITY_STAGING__ === true
 
+const customProjectId = process.env.SANITY_STUDIO_PROJECT_ID
+const customDataset = process.env.SANITY_STUDIO_DATASET
+
 const envConfig = {
   // use this for production workspaces
   production: isStaging ? {apiHost: 'https://api.sanity.io'} : {},
@@ -241,13 +244,16 @@ const sharedSettings = ({projectId}: {projectId: string}) => {
   })()
 }
 
+const defaultProjectId = customProjectId || 'ppsg7ml5'
+const defaultDataset = customDataset || 'test'
+
 const defaultWorkspace = defineConfig({
   name: 'default',
   title: 'Test Studio',
-  projectId: 'ppsg7ml5',
-  dataset: 'test',
+  projectId: defaultProjectId,
+  dataset: defaultDataset,
   ...envConfig.production,
-  plugins: [sharedSettings({projectId: 'ppsg7ml5'})],
+  plugins: [sharedSettings({projectId: defaultProjectId})],
 
   onUncaughtError: (error, errorInfo) => {
     console.log(error)
@@ -299,8 +305,9 @@ const defaultWorkspace = defineConfig({
   },
 })
 
-export default defineConfig([
-  defaultWorkspace,
+// Workspaces that depend on Sanity-owned projects and datasets.
+// Omitted when a custom project is set via env vars.
+const internalWorkspaces: WorkspaceOptions[] = [
   {
     ...defaultWorkspace,
     name: 'us',
@@ -634,4 +641,9 @@ export default defineConfig([
       enabled: true,
     },
   },
+]
+
+export default defineConfig([
+  defaultWorkspace,
+  ...(customProjectId ? [] : internalWorkspaces),
 ]) as WorkspaceOptions[]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -689,6 +689,9 @@ importers:
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../../packages/@repo/eslint-config
+      '@repo/utils':
+        specifier: workspace:*
+        version: link:../../packages/@repo/utils
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12


### PR DESCRIPTION


### Description

Closes #4021. External contributors can now configure the test studio to use their own Sanity project via env vars (`SANITY_STUDIO_PROJECT_ID`, `SANITY_STUDIO_DATASET`) instead of editing tracked files.

### What to review

- `sanity.cli.ts`: `loadEnvFiles()` integration and Vite `define` block - raw env values passed to browser context so the fallback detection works correctly
- `sanity.config.ts`: conditional exclusion of internal workspaces when a custom project is set
- `CONTRIBUTING.md` / `AGENTS.md`: clarity and accuracy of the new contributor setup instructions

### Testing

No automated tests - this is a dev-time configuration change. Verified manually:
- With `.env` set: only the default workspace appears, connected to the custom project
- Without `.env`: all workspaces appear with existing internal project IDs (no regression)
- Lint, format, and type checks pass

### Notes for release

Improved the external contributor experience for the dev studio. Contributors can now configure `dev/test-studio` to use their own Sanity project via a `.env` file, removing the need to edit tracked config files.