### PR TITLE
fix(sanity): switch off divergences for entire inspector subtree

### DIFF
--- a/packages/sanity/src/core/form/components/FormGutterCustomProperties.ts
+++ b/packages/sanity/src/core/form/components/FormGutterCustomProperties.ts
@@ -1,0 +1,15 @@
+import {styled, css} from 'styled-components'
+
+interface Props {
+  $enabled: boolean
+}
+
+/**
+ * @internal
+ */
+export const FormGutterCustomProperties = styled.div<Props>(({$enabled}) => {
+  return css`
+    display: contents;
+    --formGutterEnabled: ${$enabled ? 1 : 0};
+  `
+})

--- a/packages/sanity/src/core/form/components/layout/FormContainer.tsx
+++ b/packages/sanity/src/core/form/components/layout/FormContainer.tsx
@@ -9,6 +9,8 @@ export const FormContainer = styled.div((props) => {
   const {space, container} = getTheme_v2(props.theme)
 
   return css`
+    --formGutterSize: calc(${space[4]}px * var(--formGutterEnabled));
+    --formGutterGap: calc(${space[3]}px * var(--formGutterEnabled));
     box-sizing: border-box;
     margin-inline: auto;
     padding-inline: ${space[4]}px;

--- a/packages/sanity/src/core/form/contexts/DivergencesProvider.tsx
+++ b/packages/sanity/src/core/form/contexts/DivergencesProvider.tsx
@@ -24,6 +24,7 @@ import {selectUpstreamVersion} from '../../store/_legacy/document/selectUpstream
 import {getDocumentAtRevision} from '../../store/events/getDocumentAtRevision'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
 import {isPublishedId} from '../../util/draftUtils'
+import {FormGutterCustomProperties} from '../components/FormGutterCustomProperties'
 import {type FormState} from '../store'
 
 interface PropsEnabled extends PropsWithChildren {
@@ -50,7 +51,7 @@ export const DivergencesProvider: ComponentType<Props> = (props) => {
     return <DivergencesProviderEnabled {...props} />
   }
 
-  return <DocumentDivergencesContext.Provider value={{enabled: false}} {...props} />
+  return <DivergencesProviderDisabled {...props} />
 }
 
 const DivergencesProviderEnabled: ComponentType<PropsEnabled> = ({
@@ -108,7 +109,15 @@ const DivergencesProviderEnabled: ComponentType<PropsEnabled> = ({
 
   return (
     <DocumentDivergencesContext.Provider value={{enabled: true, ...divergenceNavigator}}>
-      {children}
+      <FormGutterCustomProperties $enabled>{children}</FormGutterCustomProperties>
+    </DocumentDivergencesContext.Provider>
+  )
+}
+
+const DivergencesProviderDisabled: ComponentType<PropsWithChildren> = ({children}) => {
+  return (
+    <DocumentDivergencesContext.Provider value={{enabled: false}}>
+      <FormGutterCustomProperties $enabled={false}>{children}</FormGutterCustomProperties>
     </DocumentDivergencesContext.Provider>
   )
 }

--- a/packages/sanity/src/core/studio/GlobalStyle.tsx
+++ b/packages/sanity/src/core/studio/GlobalStyle.tsx
@@ -29,7 +29,7 @@ interface Props {
 }
 
 const GlobalStyleSheet = createGlobalStyle<Props>(({theme, $documentEditorGutterEnabled}) => {
-  const {color, font, space} = getTheme_v2(theme)
+  const {color, font} = getTheme_v2(theme)
 
   return css`
     ::-webkit-resizer {
@@ -63,11 +63,6 @@ const GlobalStyleSheet = createGlobalStyle<Props>(({theme, $documentEditorGutter
 
     *::selection {
       background-color: ${rgba(color.focusRing, 0.3)};
-    }
-
-    :root {
-      --formGutterSize: ${$documentEditorGutterEnabled ? space[4] : 0}px;
-      --formGutterGap: ${$documentEditorGutterEnabled ? space[3] : 0}px;
     }
 
     html {

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -9,6 +9,7 @@ import {fromString as pathFromString, resolveKeyedPath} from '@sanity/util/paths
 import {
   type ComponentType,
   useCallback,
+  useContext,
   useEffect,
   useEffectEvent,
   useMemo,
@@ -44,7 +45,11 @@ import {
   useUnique,
   useWorkspace,
 } from 'sanity'
-import {DocumentPaneContext, DocumentPaneInfoContext} from 'sanity/_singletons'
+import {
+  DocumentDivergencesContext,
+  DocumentPaneContext,
+  DocumentPaneInfoContext,
+} from 'sanity/_singletons'
 import {useRouter} from 'sanity/router'
 
 import {usePaneRouter} from '../../components'
@@ -702,11 +707,21 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
     return undefined
   }, [paramPath, ready])
 
+  const divergencesContext = useContext(DocumentDivergencesContext)
+
   return (
     <DocumentPaneInfoContext.Provider value={documentPaneInfo}>
       <DocumentPaneContext.Provider value={documentPane}>
         <DivergencesProvider
-          enabled={advancedVersionControlEnabled}
+          // If `DocumentPaneProvider` is rendered as a descendant of another
+          // instance of `DivergencesProvider`, inherit its enabled state,
+          // rather than overriding it.
+          //
+          // This allows `DocumentPaneProvider` to appear as a descendant of
+          // `DivergencesProvider` with `enabled` explicitly set to `false`,
+          // without that explicit opt-out being overriden by the workspace's
+          // `advancedVersionControl.enabled` configuration.
+          enabled={divergencesContext?.enabled ?? advancedVersionControlEnabled}
           upstreamEditState={upstreamEditState}
           editState={editState}
           subjectId={documentId}

--- a/packages/sanity/src/structure/panes/document/documentInspector/DocumentInspectorPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentInspector/DocumentInspectorPanel.tsx
@@ -1,6 +1,6 @@
 import {Box} from '@sanity/ui'
 import {useCallback} from 'react'
-import {Resizable} from 'sanity'
+import {DivergencesProvider, Resizable} from 'sanity'
 
 import {usePane} from '../../../components'
 import {useStructureTool} from '../../../useStructureTool'
@@ -28,8 +28,18 @@ export function DocumentInspectorPanel(
   if (collapsed || !inspector) return null
 
   const Component = inspector.component
+
+  // No document/form shown in an inspector (e.g. a task, or AI assist
+  // instruction) is expected to support divergences itself. Therefore,
+  // divergences are switched off for the entire inspector subtree, regardless
+  // of whether the workspace has switched them on.
+  //
+  // This prevents redundant form gutters being rendered in the already
+  // limited space available to inspectors.
   const element = (
-    <Component onClose={handleClose} documentId={documentId} documentType={documentType} />
+    <DivergencesProvider enabled={false}>
+      <Component onClose={handleClose} documentId={documentId} documentType={documentType} />
+    </DivergencesProvider>
   )
 
   if (features.resizablePanes) {


### PR DESCRIPTION
### Description

This branch allows individual subtrees to switch divergences on or off, fixing the issue of errant gutters appearing outside of the main document editor (e.g. in the inspector when editing an AI Assist instruction document, which we do not ever expect to be divergent).

To achieve this, the form gutter properties have been moved from `:root` to individual DOM elements that the React app can render as needed to control the layout of the subtree.

### What to review

The layout of document editors inside inspectors in a workspace that has advanced version control switched on (`advancedVersionControl.enabled`).

#### Before
<img width="507" height="710" alt="before" src="https://github.com/user-attachments/assets/585290a4-4487-4f50-b2cb-099dc0d18457" />

#### After

<img width="507" height="710" alt="after" src="https://github.com/user-attachments/assets/74b55a4f-3889-4b52-bc30-8153db4436b2" />

### Testing

Verified layouts of main document editor and document editor inside inspectors in workspaces with and without advanced version control switched on.