### PR TITLE
fix(sanity): displayed divergence indicators

### DIFF
--- a/packages/sanity/src/core/divergence/divergenceNavigator.ts
+++ b/packages/sanity/src/core/divergence/divergenceNavigator.ts
@@ -6,9 +6,9 @@ import {useObservable} from 'react-rx'
 import {
   BehaviorSubject,
   combineLatest,
+  distinctUntilChanged,
   EMPTY,
   filter,
-  first,
   map,
   merge,
   type Observable,
@@ -136,7 +136,7 @@ type Action =
 interface DivergenceNavigatorContext {
   divergences: Observable<CollatedDocumentDivergencesState>
   schemaType: ObjectSchemaType
-  formState: Pick<FormState, 'groups' | '_allMembers'>
+  formState: Pick<FormState, 'groups' | '_allMembers' | 'value'>
 }
 
 interface StateContext {
@@ -169,7 +169,10 @@ export function useDivergenceNavigator({
   useEffect(() => schemaTypeContext.next(schemaType), [schemaTypeContext, schemaType])
 
   const formStateContext = useMemo(
-    () => new BehaviorSubject<Pick<FormState, 'groups' | '_allMembers'> | undefined>(undefined),
+    () =>
+      new BehaviorSubject<Pick<FormState, 'groups' | '_allMembers' | 'value'> | undefined>(
+        undefined,
+      ),
     [],
   )
   useEffect(() => formStateContext.next(formState), [formStateContext, formState])
@@ -193,9 +196,11 @@ export function useDivergenceNavigator({
         // and interaction with the document editor.
         //
         // It's unnecessary to remap divergences every time the displayed
-        // document or state, like the focus path, changes. Therefore, this
-        // code takes only the first form state value emitted.
-        first(),
+        // document or state, like the focus path, changes. Therefore, the
+        // form state is only emitted when the displayed document id changes
+        // (e.g. when an editor first opens a document, or when they switch to
+        // a different version of a document).
+        distinctUntilChanged((previous, current) => previous.value?._id === current.value?._id),
         map((state) => (state ? pick(state, ['groups', '_allMembers']) : state)),
       ),
     })

--- a/packages/sanity/src/core/form/contexts/DivergencesProvider.tsx
+++ b/packages/sanity/src/core/form/contexts/DivergencesProvider.tsx
@@ -33,7 +33,6 @@ interface PropsEnabled extends PropsWithChildren {
   upstreamEditState: EditStateFor
   editState: EditStateFor
   subjectId: string
-  displayedId: string
   schemaType: ObjectSchemaType
 }
 
@@ -60,7 +59,6 @@ const DivergencesProviderEnabled: ComponentType<PropsEnabled> = ({
   editState,
   subjectId,
   schemaType,
-  displayedId,
   children,
 }) => {
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
@@ -69,7 +67,7 @@ const DivergencesProviderEnabled: ComponentType<PropsEnabled> = ({
   const upstreamId = upstreamHead?._id
   const hasUpstreamVersion = typeof upstreamId !== 'undefined'
 
-  const subject = isPublishedId(displayedId)
+  const subject = isPublishedId(subjectId)
     ? editState.published
     : (editState.version ?? editState.draft)
 

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -724,9 +724,8 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
           enabled={divergencesContext?.enabled ?? advancedVersionControlEnabled}
           upstreamEditState={upstreamEditState}
           editState={editState}
-          subjectId={documentId}
+          subjectId={value._id}
           schemaType={formState.schemaType}
-          displayedId={value._id}
           formState={formState}
         >
           <DivergenceAutofocus onProgrammaticFocus={onProgrammaticFocus} />

--- a/packages/sanity/test/testUtils/DivergencesTestProvider.tsx
+++ b/packages/sanity/test/testUtils/DivergencesTestProvider.tsx
@@ -1,76 +1,7 @@
-import {Schema} from '@sanity/schema'
-import {type ObjectSchemaType, defineType} from '@sanity/types'
 import {type ComponentType, type PropsWithChildren} from 'react'
 
 import {DivergencesProvider} from '../../src/core/form/contexts/DivergencesProvider'
-import {useFormState} from '../../src/core/form/store/useFormState'
 
 export const DivergencesTestProvider: ComponentType<PropsWithChildren> = ({children}) => {
-  const bookSchemaType = Schema.compile({
-    types: [
-      defineType({
-        name: 'store',
-        type: 'document',
-        fields: [
-          {
-            name: 'address',
-            title: 'Address',
-            type: 'string',
-          },
-        ],
-      }),
-    ],
-  })
-
-  const schemaType = bookSchemaType.get('store') as ObjectSchemaType
-
-  const formState = useFormState({
-    schemaType,
-    documentValue: {},
-    comparisonValue: {},
-    focusPath: [],
-    collapsedPaths: undefined,
-    collapsedFieldSets: undefined,
-    fieldGroupState: undefined,
-    openPath: [],
-    presence: [],
-    validation: [],
-    perspective: 'published',
-    hasUpstreamVersion: false,
-  })!
-
-  return (
-    <DivergencesProvider
-      formState={formState}
-      subjectId="y"
-      displayedId="y"
-      schemaType={schemaType}
-      upstreamEditState={{
-        id: 'x',
-        type: 'store',
-        transactionSyncLock: null,
-        draft: null,
-        published: null,
-        version: null,
-        liveEdit: false,
-        liveEditSchemaType: false,
-        ready: true,
-        release: undefined,
-      }}
-      editState={{
-        id: 'x',
-        type: 'store',
-        transactionSyncLock: null,
-        draft: null,
-        published: null,
-        version: null,
-        liveEdit: false,
-        liveEditSchemaType: false,
-        ready: true,
-        release: undefined,
-      }}
-    >
-      {children}
-    </DivergencesProvider>
-  )
+  return <DivergencesProvider enabled={false}>{children}</DivergencesProvider>
 }


### PR DESCRIPTION
### Description

This branch fixes a couple of subtle issues that would sometimes cause divergence indicators to appear incorrectly.

1. The published document id was inadvertently being used as the subject document id, causing divergences for the previously viewed version to remain visible after navigating to a different document version until recomputing. The published id is no longer conflated here, and the redundant `displayedId` prop has been removed.
2. Only the first emitted form state context value was being taken when calculating divergences. This change was made in #12440 to prevent excessive recomputes, but did not cater to the scenario that the entire displayed document changes (e.g. when navigating to a different version of the document). This caused divergences in array nodes to be hidden after navigating to a document version from a different version *in which the divergent array path is absent*. The process now takes the displayed id into account, which prevents excessive recomputes, while correctly emitting a value when the displayed document id changes.

### What to review

Presence of expected divergence indicators, especially after navigating between different versions of a document.

### Testing

Verified the rendering issues (divergence indicators lingering for a few moments after switching versions, divergence indicators inconsistently appearing after switching version—detailed in SAPP-3664 and SAPP-3665) are no longer present.
