### PR TITLE
test(e2e): add data-testid to error screens and auto-detect in e2e tests

### DIFF
--- a/e2e/helpers/studioErrors.ts
+++ b/e2e/helpers/studioErrors.ts
@@ -1,0 +1,72 @@
+import {type BrowserContext, type Locator, type Page} from '@playwright/test'
+
+/**
+ * Selector that matches any Studio error screen — both the React error
+ * boundary screens (`data-testid="studio-error-screen"`) and the pre-React
+ * `window.onerror` overlay (`#__sanityError`).
+ */
+export const STUDIO_ERROR_SELECTOR = '[data-testid="studio-error-screen"], #__sanityError'
+
+/**
+ * Returns a Playwright locator for the Studio error screen.
+ * ```ts
+ * await expect(studioErrorLocator(page)).toBeVisible()
+ * await expect(studioErrorLocator(page)).toHaveAttribute('data-error', /Session not found/)
+ * ```
+ */
+export function studioErrorLocator(page: Page): Locator {
+  return page.locator(STUDIO_ERROR_SELECTOR)
+}
+
+function attachErrorDetection(page: Page, state: {expecting: boolean}): void {
+  page.on('pageerror', (error) => {
+    if (state.expecting) return
+    if (error.message.includes('ResizeObserver')) return
+    throw new Error(`Studio threw an uncaught exception: ${error.message}`)
+  })
+
+  page.on('console', (msg) => {
+    if (state.expecting) return
+    if (msg.type() === 'error' && msg.text().startsWith('__STUDIO_ERROR__')) {
+      throw new Error(msg.text().slice('__STUDIO_ERROR__'.length))
+    }
+  })
+
+  void page.addInitScript((selector) => {
+    let fired = false
+    new MutationObserver(() => {
+      if (fired) return
+      const el = document.querySelector(selector)
+      if (el) {
+        fired = true
+        const detail =
+          el.getAttribute('data-error') || el.textContent?.trim().slice(0, 200) || 'Unknown error'
+        console.error(`__STUDIO_ERROR__Studio error screen detected: ${detail}`)
+      }
+    }).observe(document, {childList: true, subtree: true})
+  }, STUDIO_ERROR_SELECTOR)
+}
+
+/**
+ * Attach Studio error detection to a browser context. Every page created
+ * in the context will auto-fail on Studio error screens.
+ *
+ * Returns a handle to opt out when asserting errors:
+ * ```ts
+ * const {expectError} = watchForStudioErrors(context)
+ * // later…
+ * expectError()
+ * await expect(studioErrorLocator(page)).toBeVisible()
+ * ```
+ */
+export function watchForStudioErrors(context: BrowserContext) {
+  const state = {expecting: false}
+  context.on('page', (page) => {
+    attachErrorDetection(page, state)
+  })
+  return {
+    expectError() {
+      state.expecting = true
+    },
+  }
+}

--- a/e2e/studio-test.ts
+++ b/e2e/studio-test.ts
@@ -4,6 +4,8 @@ import {test as baseTest} from '@playwright/test'
 import {createClient, type SanityClient, type SanityDocument} from '@sanity/client'
 import {uuid} from '@sanity/uuid'
 
+import {watchForStudioErrors} from './helpers/studioErrors'
+
 class _TestSanityContext {
   documentIds: Set<string>
 
@@ -66,7 +68,9 @@ interface SanityFixtures {
 export const test = baseTest.extend<SanityFixtures>({
   // Extends the goto function to preserve the base pathname if it exists in the baseURL
   // This is used to ensure the navigation goes to the correct workspace.
-  async page({page, baseURL}, use) {
+  async page({page, context, baseURL}, use) {
+    watchForStudioErrors(context)
+
     const originalGoto = page.goto.bind(page)
     const baseUrl = new URL(baseURL || '')
     const basePath = baseUrl.pathname

--- a/packages/sanity/src/core/studio/ViteDevServerStopped.tsx
+++ b/packages/sanity/src/core/studio/ViteDevServerStopped.tsx
@@ -46,6 +46,8 @@ export const DetectViteDevServerStopped = (): ReactNode =>
 
 export const DevServerStoppedErrorScreen = (): ReactNode => (
   <Card
+    data-testid="studio-error-screen"
+    data-error="Dev server stopped"
     height="fill"
     overflow="auto"
     paddingY={[4, 5, 6, 7]}

--- a/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/CorsOriginErrorScreen.tsx
@@ -77,7 +77,7 @@ export function CorsOriginErrorScreen(props: CorsOriginErrorScreenProps) {
   }, [])
 
   return (
-    <Card height="fill">
+    <Card data-testid="studio-error-screen" data-error="CORS origin error" height="fill">
       <CenteredContainer align="center" justify="center" padding={4}>
         <ContentWrapper paddingBottom={5}>
           <Stack space={5}>

--- a/packages/sanity/src/core/studio/screens/FallbackErrorScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/FallbackErrorScreen.tsx
@@ -20,7 +20,15 @@ export function FallbackErrorScreen(props: {
   const stack = typeof error?.stack === 'string' && error?.stack
 
   return (
-    <Card height="fill" overflow="auto" paddingY={[4, 5, 6, 7]} paddingX={4} sizing="border">
+    <Card
+      data-testid="studio-error-screen"
+      data-error={message || heading}
+      height="fill"
+      overflow="auto"
+      paddingY={[4, 5, 6, 7]}
+      paddingX={4}
+      sizing="border"
+    >
       <View display="flex" height="fill">
         <Container width={3}>
           <Stack space={6}>

--- a/packages/sanity/src/core/studio/screens/ImportErrorScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/ImportErrorScreen.tsx
@@ -40,7 +40,15 @@ export function ImportErrorScreen(props: {error: Error; eventId?: string; autoRe
   }, [autoReload, countdownSeconds])
 
   return (
-    <Card height="fill" overflow="auto" paddingY={[4, 5, 6, 7]} paddingX={4} sizing="border">
+    <Card
+      data-testid="studio-error-screen"
+      data-error={error.message || 'Import error'}
+      height="fill"
+      overflow="auto"
+      paddingY={[4, 5, 6, 7]}
+      paddingX={4}
+      sizing="border"
+    >
       <View display="flex" height="fill">
         <Container width={3}>
           <Stack space={6}>

--- a/packages/sanity/src/core/studio/screens/schemaErrors/SchemaErrorsScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/schemaErrors/SchemaErrorsScreen.tsx
@@ -59,7 +59,15 @@ export function SchemaErrorsScreen({schema}: SchemaErrorsScreenProps) {
   }
 
   return (
-    <Card height="fill" overflow="auto" paddingY={[4, 5, 6, 7]} paddingX={4} sizing="border">
+    <Card
+      data-testid="studio-error-screen"
+      data-error="Schema errors"
+      height="fill"
+      overflow="auto"
+      paddingY={[4, 5, 6, 7]}
+      paddingX={4}
+      sizing="border"
+    >
       <Container width={1}>
         <Stack space={5}>
           <Flex justify="space-between" align="center" gap={2}>


### PR DESCRIPTION
### Description
Adds detection for error screens in our e2e tests. This should make tests fail fast instead of waiting for element selectors to time out if the studio crashes because of e.g. network error, misconfiguration or backend issues.

### What to review
- Adds `data-testid="studio-error-screen"` and `data-error` attributes to all Studio error screens 
- Adds `e2e/helpers/studioErrors.ts` with `watchForStudioErrors(context)` that auto-fails tests when an error screen appears (via MutationObserver)+ console marker + page.on('console') listener) – note that this is injected by playwright when running tests, so adds no overhead outside of e2e tests.

### Testing
e2e tests should still pass. 

### Notes for release
n/a