### PR TITLE
fix(preview): reduce redundant fetches in document preview observers

### DIFF
--- a/packages/sanity/src/core/preview/__test__/createPathObserver.test.ts
+++ b/packages/sanity/src/core/preview/__test__/createPathObserver.test.ts
@@ -1,0 +1,322 @@
+import {BehaviorSubject, type Observable, of, Subject} from 'rxjs'
+import {describe, expect, it, vi} from 'vitest'
+
+import {type SanityClient} from '../../form/studio/assetSourceDataset/uploader'
+import {createPathObserver} from '../createPathObserver'
+import {type ClientLike, createObserveFields} from '../observeFields'
+import {type InvalidationChannelEvent} from '../types'
+
+function collectEmissions<T>(observable: Observable<T>): {
+  values: T[]
+  unsubscribe: () => void
+} {
+  const values: T[] = []
+  const subscription = observable.subscribe((value) => values.push(value))
+  return {values, unsubscribe: () => subscription.unsubscribe()}
+}
+
+describe('createPathObserver', () => {
+  describe('_rev-based deduplication', () => {
+    it('should not rebuild subscription tree when _rev has not changed', () => {
+      let observeFieldsCalls = 0
+      const subject = new BehaviorSubject<Record<string, unknown> | null>({
+        _id: 'doc1',
+        _rev: 'rev1',
+        _type: 'test',
+        title: 'Hello',
+      })
+
+      const observeFields = vi.fn(
+        (_id: string, _fields: string[]): Observable<Record<string, unknown> | null> => {
+          observeFieldsCalls++
+          return subject
+        },
+      )
+
+      const observePaths = createPathObserver({observeFields})
+      const {values, unsubscribe} = collectEmissions(
+        observePaths({_type: 'reference', _ref: 'doc1'}, ['title']),
+      )
+
+      expect(observeFieldsCalls).toBe(1)
+      expect(values).toHaveLength(1)
+
+      // Re-emit the same _rev with a fresh object (simulates JSON parse from refetch)
+      subject.next({
+        _id: 'doc1',
+        _rev: 'rev1',
+        _type: 'test',
+        title: 'Hello',
+      })
+
+      // switchMap should NOT have fired again since _rev is the same
+      expect(values).toHaveLength(1)
+
+      unsubscribe()
+    })
+
+    it('should rebuild subscription tree when _rev changes', () => {
+      const subject = new BehaviorSubject<Record<string, unknown> | null>({
+        _id: 'doc1',
+        _rev: 'rev1',
+        _type: 'test',
+        title: 'Hello',
+      })
+
+      const observeFields = vi.fn(
+        (_id: string, _fields: string[]): Observable<Record<string, unknown> | null> => {
+          return subject
+        },
+      )
+
+      const observePaths = createPathObserver({observeFields})
+      const {values, unsubscribe} = collectEmissions(
+        observePaths({_type: 'reference', _ref: 'doc1'}, ['title']),
+      )
+
+      expect(values).toHaveLength(1)
+
+      subject.next({
+        _id: 'doc1',
+        _rev: 'rev2',
+        _type: 'test',
+        title: 'Updated',
+      })
+
+      expect(values).toHaveLength(2)
+      expect(values[1]).toMatchObject({title: 'Updated'})
+
+      unsubscribe()
+    })
+
+    it('should pass through null snapshots (deleted documents) regardless of _rev', () => {
+      const subject = new BehaviorSubject<Record<string, unknown> | null>({
+        _id: 'doc1',
+        _rev: 'rev1',
+        _type: 'test',
+        title: 'Hello',
+      })
+
+      const observeFields = vi.fn(
+        (_id: string, _fields: string[]): Observable<Record<string, unknown> | null> => {
+          return subject
+        },
+      )
+
+      const observePaths = createPathObserver({observeFields})
+      const {values, unsubscribe} = collectEmissions(
+        observePaths({_type: 'reference', _ref: 'doc1'}, ['title']),
+      )
+
+      expect(values).toHaveLength(1)
+
+      // Document deleted: null has no _rev, which differs from 'rev1'
+      subject.next(null)
+
+      expect(values).toHaveLength(2)
+      expect(values[1]).toBeNull()
+
+      unsubscribe()
+    })
+
+    it('should not re-emit when object fields are identical but references are fresh objects', () => {
+      const subject = new BehaviorSubject<Record<string, unknown> | null>({
+        _id: 'doc1',
+        _rev: 'rev1',
+        _type: 'test',
+        image: {_ref: 'image-abc', _type: 'reference'},
+      })
+
+      const observeFields = vi.fn(
+        (_id: string, _fields: string[]): Observable<Record<string, unknown> | null> => {
+          return subject
+        },
+      )
+
+      const observePaths = createPathObserver({observeFields})
+      const {values, unsubscribe} = collectEmissions(
+        observePaths({_type: 'reference', _ref: 'doc1'}, ['image']),
+      )
+
+      expect(values).toHaveLength(1)
+
+      // Fresh object, same _rev: simulates what happens on every refetch from JSON parse
+      subject.next({
+        _id: 'doc1',
+        _rev: 'rev1',
+        _type: 'test',
+        image: {_ref: 'image-abc', _type: 'reference'},
+      })
+
+      expect(values).toHaveLength(1)
+
+      unsubscribe()
+    })
+
+    it('should handle multiple rapid emissions with same _rev', () => {
+      const subject = new BehaviorSubject<Record<string, unknown> | null>({
+        _id: 'doc1',
+        _rev: 'rev1',
+        _type: 'test',
+        title: 'Hello',
+      })
+
+      const observeFields = vi.fn(
+        (_id: string, _fields: string[]): Observable<Record<string, unknown> | null> => {
+          return subject
+        },
+      )
+
+      const observePaths = createPathObserver({observeFields})
+      const {values, unsubscribe} = collectEmissions(
+        observePaths({_type: 'reference', _ref: 'doc1'}, ['title']),
+      )
+
+      // Simulate the polling storm: 10 rapid re-emissions with same _rev
+      for (let i = 0; i < 10; i++) {
+        subject.next({
+          _id: 'doc1',
+          _rev: 'rev1',
+          _type: 'test',
+          title: 'Hello',
+        })
+      }
+
+      // Only the initial emission should have passed through
+      expect(values).toHaveLength(1)
+
+      unsubscribe()
+    })
+  })
+
+  describe('integration: query count with real observeFields pipeline', () => {
+    it('should not re-fetch when invalidation events arrive but document has not changed', async () => {
+      let fetchCallCount = 0
+
+      const client: ClientLike = {
+        observable: {
+          fetch: (_query: string) => {
+            fetchCallCount++
+            return of([
+              [
+                {
+                  _id: 'mainContentList',
+                  _rev: 'rev1',
+                  _type: 'contentList',
+                  name: 'Main Content',
+                  _createdAt: '2025-01-01T00:00:00Z',
+                  _updatedAt: '2025-01-01T00:00:00Z',
+                },
+              ],
+            ])
+          },
+        },
+        withConfig: () => client,
+      }
+
+      const invalidationChannel = new Subject<InvalidationChannelEvent>()
+      const observeFields = createObserveFields({
+        invalidationChannel,
+        client: client as unknown as SanityClient,
+      })
+      const observePaths = createPathObserver({observeFields})
+
+      const {values, unsubscribe} = collectEmissions(
+        observePaths({_type: 'reference', _ref: 'mainContentList'}, ['name']),
+      )
+
+      // Initial connect triggers the first fetch
+      invalidationChannel.next({type: 'connected'})
+      await new Promise((resolve) => setTimeout(resolve, 200))
+
+      const fetchCountAfterConnect = fetchCallCount
+      expect(fetchCountAfterConnect).toBeGreaterThanOrEqual(1)
+      expect(values.length).toBeGreaterThanOrEqual(1)
+
+      // Simulate 10 mutation events for the same document (same _rev comes back each time).
+      // This reproduces the HAR scenario: global listener fires repeatedly,
+      // observeFields re-fetches, but the document hasn't actually changed.
+      for (let i = 0; i < 10; i++) {
+        invalidationChannel.next({
+          type: 'mutation',
+          documentId: 'mainContentList',
+          visibility: 'query',
+        })
+        await new Promise((resolve) => setTimeout(resolve, 150))
+      }
+
+      // Without the fix: switchMap would rebuild the subscription tree on each
+      // re-emission, causing recursive observePaths calls and additional fetches.
+      // With the fix: distinctUntilChanged(_rev) suppresses identical emissions,
+      // so no subscription tree rebuild occurs.
+      //
+      // We allow some fetches from the invalidation channel (observeFields still
+      // re-fetches on mutation events), but the key assertion is that the total
+      // number of fetches is bounded, not proportional to mutation count * tree depth.
+      const totalFetches = fetchCallCount
+      // In the HAR, the unfixed version produced 28+ fetches for the same document.
+      // With the fix, observeFields may still refetch per invalidation, but
+      // the recursive observePaths won't amplify each refetch into additional queries.
+      expect(totalFetches).toBeLessThan(20)
+
+      unsubscribe()
+    })
+  })
+
+  describe('basic path resolution', () => {
+    it('should resolve simple paths from a document', () => {
+      const observeFields = vi.fn(
+        (_id: string, _fields: string[]): Observable<Record<string, unknown> | null> => {
+          return of({
+            _id: 'doc1',
+            _rev: 'rev1',
+            _type: 'test',
+            title: 'Hello',
+            subtitle: 'World',
+          })
+        },
+      )
+
+      const observePaths = createPathObserver({observeFields})
+      const {values, unsubscribe} = collectEmissions(
+        observePaths({_type: 'reference', _ref: 'doc1'}, ['title', 'subtitle']),
+      )
+
+      expect(values).toHaveLength(1)
+      expect(values[0]).toMatchObject({title: 'Hello', subtitle: 'World'})
+
+      unsubscribe()
+    })
+
+    it('should return null for deleted documents', () => {
+      const observeFields = vi.fn(
+        (_id: string, _fields: string[]): Observable<Record<string, unknown> | null> => {
+          return of(null)
+        },
+      )
+
+      const observePaths = createPathObserver({observeFields})
+      const {values, unsubscribe} = collectEmissions(
+        observePaths({_type: 'reference', _ref: 'doc1'}, ['title']),
+      )
+
+      expect(values).toHaveLength(1)
+      expect(values[0]).toBeNull()
+
+      unsubscribe()
+    })
+
+    it('should return leaf values as-is', () => {
+      const observeFields = vi.fn()
+      const observePaths = createPathObserver({observeFields})
+
+      const {values, unsubscribe} = collectEmissions(observePaths(null as any, ['title']))
+
+      expect(values).toHaveLength(1)
+      expect(values[0]).toBeNull()
+      expect(observeFields).not.toHaveBeenCalled()
+
+      unsubscribe()
+    })
+  })
+})

--- a/packages/sanity/src/core/preview/__test__/createPathObserver.test.ts
+++ b/packages/sanity/src/core/preview/__test__/createPathObserver.test.ts
@@ -1,5 +1,5 @@
 import {BehaviorSubject, type Observable, of, Subject} from 'rxjs'
-import {describe, expect, it, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {type SanityClient} from '../../form/studio/assetSourceDataset/uploader'
 import {createPathObserver} from '../createPathObserver'
@@ -190,12 +190,20 @@ describe('createPathObserver', () => {
   })
 
   describe('integration: query count with real observeFields pipeline', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
     it('should not amplify fetches through subscription tree rebuilds when document has not changed', async () => {
       let fetchCallCount = 0
 
       const client: ClientLike = {
         observable: {
-          fetch: (_query: string) => {
+          fetch: () => {
             fetchCallCount++
             return of([
               [
@@ -204,8 +212,6 @@ describe('createPathObserver', () => {
                   _rev: 'rev1',
                   _type: 'contentList',
                   name: 'Main Content',
-                  _createdAt: '2025-01-01T00:00:00Z',
-                  _updatedAt: '2025-01-01T00:00:00Z',
                 },
               ],
             ])
@@ -225,39 +231,76 @@ describe('createPathObserver', () => {
         observePaths({_type: 'reference', _ref: 'mainContentList'}, ['name']),
       )
 
-      // Initial connect triggers the first fetch
       invalidationChannel.next({type: 'connected'})
-      await new Promise((resolve) => setTimeout(resolve, 200))
+      await vi.advanceTimersByTimeAsync(200)
 
       const fetchCountAfterConnect = fetchCallCount
       expect(fetchCountAfterConnect).toBeGreaterThanOrEqual(1)
       expect(values.length).toBeGreaterThanOrEqual(1)
 
-      // Simulate 10 mutation events for the same document (same _rev comes back each time).
-      // This reproduces the HAR scenario: global listener fires repeatedly,
-      // observeFields re-fetches, but the document hasn't actually changed.
       for (let i = 0; i < 10; i++) {
         invalidationChannel.next({
           type: 'mutation',
           documentId: 'mainContentList',
           visibility: 'query',
         })
-        await new Promise((resolve) => setTimeout(resolve, 150))
+        await vi.advanceTimersByTimeAsync(200)
       }
 
-      // Without the fix: switchMap would rebuild the subscription tree on each
-      // re-emission, causing recursive observePaths calls and additional fetches.
-      // With the fix: distinctUntilChanged(_rev) suppresses identical emissions,
-      // so no subscription tree rebuild occurs.
-      //
-      // We allow some fetches from the invalidation channel (observeFields still
-      // re-fetches on mutation events), but the key assertion is that the total
-      // number of fetches is bounded, not proportional to mutation count * tree depth.
-      const totalFetches = fetchCallCount
-      // In a HAR where we have identified the issue, the unfixed version produced too many unneded fetches for the same document.
-      // With the fix, observeFields may still refetch per invalidation, but
-      // the recursive observePaths won't amplify each refetch into additional queries.
-      expect(totalFetches).toBeLessThan(20)
+      // Each mutation triggers at most one fetch via observeFields (no amplification
+      // from the recursive subscription tree thanks to distinctUntilChanged on _rev).
+      expect(fetchCallCount).toBeLessThanOrEqual(fetchCountAfterConnect + 10)
+
+      unsubscribe()
+    })
+
+    it('should propagate new emissions downstream when _rev changes between fetches', async () => {
+      let fetchCallCount = 0
+
+      const client: ClientLike = {
+        observable: {
+          fetch: () => {
+            fetchCallCount++
+            return of([
+              [
+                {
+                  _id: 'mainContentList',
+                  _rev: `rev${fetchCallCount}`,
+                  _type: 'contentList',
+                  name: `Content v${fetchCallCount}`,
+                },
+              ],
+            ])
+          },
+        },
+        withConfig: () => client,
+      }
+
+      const invalidationChannel = new Subject<InvalidationChannelEvent>()
+      const observeFields = createObserveFields({
+        invalidationChannel,
+        client: client as unknown as SanityClient,
+      })
+      const observePaths = createPathObserver({observeFields})
+
+      const {values, unsubscribe} = collectEmissions(
+        observePaths({_type: 'reference', _ref: 'mainContentList'}, ['name']),
+      )
+
+      invalidationChannel.next({type: 'connected'})
+      await vi.advanceTimersByTimeAsync(200)
+
+      expect(values.length).toBeGreaterThanOrEqual(1)
+      const valuesAfterConnect = values.length
+
+      invalidationChannel.next({
+        type: 'mutation',
+        documentId: 'mainContentList',
+        visibility: 'query',
+      })
+      await vi.advanceTimersByTimeAsync(200)
+
+      expect(values.length).toBeGreaterThan(valuesAfterConnect)
 
       unsubscribe()
     })

--- a/packages/sanity/src/core/preview/__test__/createPathObserver.test.ts
+++ b/packages/sanity/src/core/preview/__test__/createPathObserver.test.ts
@@ -254,7 +254,7 @@ describe('createPathObserver', () => {
       // re-fetches on mutation events), but the key assertion is that the total
       // number of fetches is bounded, not proportional to mutation count * tree depth.
       const totalFetches = fetchCallCount
-      // In the HAR, the unfixed version produced 28+ fetches for the same document.
+      // In a HAR where we have identified the issue, the unfixed version produced too many unneded fetches for the same document.
       // With the fix, observeFields may still refetch per invalidation, but
       // the recursive observePaths won't amplify each refetch into additional queries.
       expect(totalFetches).toBeLessThan(20)

--- a/packages/sanity/src/core/preview/__test__/createPathObserver.test.ts
+++ b/packages/sanity/src/core/preview/__test__/createPathObserver.test.ts
@@ -361,5 +361,64 @@ describe('createPathObserver', () => {
 
       unsubscribe()
     })
+
+    it('should resolve nested paths through references', () => {
+      const observeFields = vi.fn(
+        (id: string, fields: string[]): Observable<Record<string, unknown> | null> => {
+          if (id === 'book1') {
+            return of({
+              _id: 'book1',
+              _rev: 'rev1',
+              _type: 'book',
+              author: {_ref: 'author1', _type: 'reference'},
+            })
+          }
+          if (id === 'author1') {
+            return of({
+              _id: 'author1',
+              _rev: 'rev1',
+              _type: 'author',
+              name: 'Alice',
+            })
+          }
+          return of(null)
+        },
+      )
+
+      const observePaths = createPathObserver({observeFields})
+      const {values, unsubscribe} = collectEmissions(
+        observePaths({_type: 'reference', _ref: 'book1'}, [['author', 'name']]),
+      )
+
+      expect(values.length).toBeGreaterThanOrEqual(1)
+      const last = values[values.length - 1]
+      expect(last).toMatchObject({author: {name: 'Alice'}})
+      expect(observeFields).toHaveBeenCalledWith('author1', ['name'], undefined, undefined)
+
+      unsubscribe()
+    })
+
+    it('should resolve paths on documents passed by _id (not _ref)', () => {
+      const observeFields = vi.fn(
+        (_id: string, _fields: string[]): Observable<Record<string, unknown> | null> => {
+          return of({
+            _id: 'doc1',
+            _rev: 'rev1',
+            _type: 'test',
+            title: 'Direct',
+          })
+        },
+      )
+
+      const observePaths = createPathObserver({observeFields})
+      const {values, unsubscribe} = collectEmissions(
+        observePaths({_id: 'doc1', _type: 'test'}, ['title']),
+      )
+
+      expect(values).toHaveLength(1)
+      expect(values[0]).toMatchObject({title: 'Direct'})
+
+      unsubscribe()
+    })
   })
 })

--- a/packages/sanity/src/core/preview/__test__/createPathObserver.test.ts
+++ b/packages/sanity/src/core/preview/__test__/createPathObserver.test.ts
@@ -190,7 +190,7 @@ describe('createPathObserver', () => {
   })
 
   describe('integration: query count with real observeFields pipeline', () => {
-    it('should not re-fetch when invalidation events arrive but document has not changed', async () => {
+    it('should not amplify fetches through subscription tree rebuilds when document has not changed', async () => {
       let fetchCallCount = 0
 
       const client: ClientLike = {

--- a/packages/sanity/src/core/preview/__test__/observeFields.test.ts
+++ b/packages/sanity/src/core/preview/__test__/observeFields.test.ts
@@ -385,40 +385,6 @@ describe('observeFields', () => {
       sub.unsubscribe()
     })
 
-    it('should NOT re-fetch for a version outside the active perspective stack', async () => {
-      let fetchCount = 0
-      const client: ClientLike = {
-        observable: {
-          fetch: () => {
-            fetchCount++
-            return of([[{_id: 'foo', _rev: `rev${fetchCount}`, _type: 'testDoc', title: 'Test'}]])
-          },
-        },
-        withConfig: () => client,
-      }
-      const channel = new Subject<InvalidationChannelEvent>()
-      const observe = createObserveFields({
-        invalidationChannel: channel,
-        client: client as unknown as SanityClient,
-      })
-
-      const sub = observe('foo', ['title'], undefined, ['drafts', 'summer']).subscribe(() => {})
-
-      channel.next({type: 'connected'})
-      await new Promise((r) => setTimeout(r, 200))
-      const afterConnect = fetchCount
-
-      channel.next({
-        type: 'mutation',
-        documentId: 'versions.winter.foo',
-        visibility: 'query',
-      })
-      await new Promise((r) => setTimeout(r, 200))
-
-      expect(fetchCount).toBe(afterConnect)
-      sub.unsubscribe()
-    })
-
     it('should always re-fetch on connected event regardless of perspective', async () => {
       let fetchCount = 0
       const client: ClientLike = {

--- a/packages/sanity/src/core/preview/__test__/observeFields.test.ts
+++ b/packages/sanity/src/core/preview/__test__/observeFields.test.ts
@@ -385,6 +385,40 @@ describe('observeFields', () => {
       sub.unsubscribe()
     })
 
+    it('should NOT re-fetch for a version outside the active perspective stack', async () => {
+      let fetchCount = 0
+      const client: ClientLike = {
+        observable: {
+          fetch: () => {
+            fetchCount++
+            return of([[{_id: 'foo', _rev: `rev${fetchCount}`, _type: 'testDoc', title: 'Test'}]])
+          },
+        },
+        withConfig: () => client,
+      }
+      const channel = new Subject<InvalidationChannelEvent>()
+      const observe = createObserveFields({
+        invalidationChannel: channel,
+        client: client as unknown as SanityClient,
+      })
+
+      const sub = observe('foo', ['title'], undefined, ['drafts', 'summer']).subscribe(() => {})
+
+      channel.next({type: 'connected'})
+      await new Promise((r) => setTimeout(r, 200))
+      const afterConnect = fetchCount
+
+      channel.next({
+        type: 'mutation',
+        documentId: 'versions.winter.foo',
+        visibility: 'query',
+      })
+      await new Promise((r) => setTimeout(r, 200))
+
+      expect(fetchCount).toBe(afterConnect)
+      sub.unsubscribe()
+    })
+
     it('should always re-fetch on connected event regardless of perspective', async () => {
       let fetchCount = 0
       const client: ClientLike = {

--- a/packages/sanity/src/core/preview/__test__/observeFields.test.ts
+++ b/packages/sanity/src/core/preview/__test__/observeFields.test.ts
@@ -419,6 +419,74 @@ describe('observeFields', () => {
       sub.unsubscribe()
     })
 
+    it('should NOT re-fetch when the same base document is mutated in an out-of-stack version while observing drafts', async () => {
+      let fetchCount = 0
+      const client: ClientLike = {
+        observable: {
+          fetch: () => {
+            fetchCount++
+            return of([[{_id: 'foo', _rev: `rev${fetchCount}`, _type: 'testDoc', title: 'Test'}]])
+          },
+        },
+        withConfig: () => client,
+      }
+      const channel = new Subject<InvalidationChannelEvent>()
+      const observe = createObserveFields({
+        invalidationChannel: channel,
+        client: client as unknown as SanityClient,
+      })
+
+      const sub = observe('foo', ['title'], undefined, ['drafts']).subscribe(() => {})
+
+      channel.next({type: 'connected'})
+      await new Promise((r) => setTimeout(r, 200))
+      const afterConnect = fetchCount
+
+      channel.next({
+        type: 'mutation',
+        documentId: 'versions.summer.foo',
+        visibility: 'query',
+      })
+      await new Promise((r) => setTimeout(r, 200))
+
+      expect(fetchCount).toBe(afterConnect)
+      sub.unsubscribe()
+    })
+
+    it('should NOT re-fetch when the same base document is mutated in drafts while observing a version perspective', async () => {
+      let fetchCount = 0
+      const client: ClientLike = {
+        observable: {
+          fetch: () => {
+            fetchCount++
+            return of([[{_id: 'foo', _rev: `rev${fetchCount}`, _type: 'testDoc', title: 'Test'}]])
+          },
+        },
+        withConfig: () => client,
+      }
+      const channel = new Subject<InvalidationChannelEvent>()
+      const observe = createObserveFields({
+        invalidationChannel: channel,
+        client: client as unknown as SanityClient,
+      })
+
+      const sub = observe('foo', ['title'], undefined, ['summer']).subscribe(() => {})
+
+      channel.next({type: 'connected'})
+      await new Promise((r) => setTimeout(r, 200))
+      const afterConnect = fetchCount
+
+      channel.next({
+        type: 'mutation',
+        documentId: 'drafts.foo',
+        visibility: 'query',
+      })
+      await new Promise((r) => setTimeout(r, 200))
+
+      expect(fetchCount).toBe(afterConnect)
+      sub.unsubscribe()
+    })
+
     it('should always re-fetch on connected event regardless of perspective', async () => {
       let fetchCount = 0
       const client: ClientLike = {

--- a/packages/sanity/src/core/preview/__test__/observeFields.test.ts
+++ b/packages/sanity/src/core/preview/__test__/observeFields.test.ts
@@ -1,6 +1,6 @@
 import {firstValueFrom, of, Subject} from 'rxjs'
 import {take, tap} from 'rxjs/operators'
-import {describe, expect, it} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {type SanityClient} from '../../form/studio/assetSourceDataset/uploader'
 import {MAX_DOCUMENT_ID_CHUNK_SIZE} from '../../util/const'
@@ -267,6 +267,14 @@ describe('observeFields', () => {
   describe('invalidation filter with perspective', () => {
     const SETTLE_TIME = 200
 
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
     function setupPerspectiveTest() {
       let fetchCount = 0
       const client: ClientLike = {
@@ -295,7 +303,7 @@ describe('observeFields', () => {
 
     async function connectAndSettle(channel: Subject<InvalidationChannelEvent>) {
       channel.next({type: 'connected'})
-      await new Promise((r) => setTimeout(r, SETTLE_TIME))
+      await vi.advanceTimersByTimeAsync(SETTLE_TIME)
     }
 
     it('should re-fetch when the observed document itself is mutated (with perspective)', async () => {
@@ -306,7 +314,7 @@ describe('observeFields', () => {
       const afterConnect = harness.fetchCount
 
       sendMutations(harness.channel, 'foo')
-      await new Promise((r) => setTimeout(r, SETTLE_TIME))
+      await vi.advanceTimersByTimeAsync(SETTLE_TIME)
 
       expect(harness.fetchCount).toBeGreaterThan(afterConnect)
       sub.unsubscribe()
@@ -320,7 +328,7 @@ describe('observeFields', () => {
       const afterConnect = harness.fetchCount
 
       sendMutations(harness.channel, 'drafts.foo')
-      await new Promise((r) => setTimeout(r, SETTLE_TIME))
+      await vi.advanceTimersByTimeAsync(SETTLE_TIME)
 
       expect(harness.fetchCount).toBeGreaterThan(afterConnect)
       sub.unsubscribe()
@@ -336,7 +344,7 @@ describe('observeFields', () => {
       const afterConnect = harness.fetchCount
 
       sendMutations(harness.channel, 'versions.summer.foo')
-      await new Promise((r) => setTimeout(r, SETTLE_TIME))
+      await vi.advanceTimersByTimeAsync(SETTLE_TIME)
 
       expect(harness.fetchCount).toBeGreaterThan(afterConnect)
       sub.unsubscribe()
@@ -350,7 +358,7 @@ describe('observeFields', () => {
       const afterConnect = harness.fetchCount
 
       sendMutations(harness.channel, ['trigger-doc', 'drafts.other-doc', 'versions.summer.bar'])
-      await new Promise((r) => setTimeout(r, SETTLE_TIME))
+      await vi.advanceTimersByTimeAsync(SETTLE_TIME)
 
       expect(harness.fetchCount).toBe(afterConnect)
       sub.unsubscribe()
@@ -366,7 +374,7 @@ describe('observeFields', () => {
       const afterConnect = harness.fetchCount
 
       sendMutations(harness.channel, 'versions.winter.foo')
-      await new Promise((r) => setTimeout(r, SETTLE_TIME))
+      await vi.advanceTimersByTimeAsync(SETTLE_TIME)
 
       expect(harness.fetchCount).toBe(afterConnect)
       sub.unsubscribe()
@@ -380,7 +388,7 @@ describe('observeFields', () => {
       const afterConnect = harness.fetchCount
 
       sendMutations(harness.channel, 'versions.summer.foo')
-      await new Promise((r) => setTimeout(r, SETTLE_TIME))
+      await vi.advanceTimersByTimeAsync(SETTLE_TIME)
 
       expect(harness.fetchCount).toBe(afterConnect)
       sub.unsubscribe()
@@ -394,7 +402,7 @@ describe('observeFields', () => {
       const afterConnect = harness.fetchCount
 
       sendMutations(harness.channel, 'drafts.foo')
-      await new Promise((r) => setTimeout(r, SETTLE_TIME))
+      await vi.advanceTimersByTimeAsync(SETTLE_TIME)
 
       expect(harness.fetchCount).toBe(afterConnect)
       sub.unsubscribe()

--- a/packages/sanity/src/core/preview/__test__/observeFields.test.ts
+++ b/packages/sanity/src/core/preview/__test__/observeFields.test.ts
@@ -256,4 +256,193 @@ describe('observeFields', () => {
       .unsubscribe()
     expect(syncValue).toBe(null)
   })
+
+  describe('invalidation filter with perspective', () => {
+    it('should re-fetch when the observed document itself is mutated (with perspective)', async () => {
+      let fetchCount = 0
+      const client: ClientLike = {
+        observable: {
+          fetch: () => {
+            fetchCount++
+            return of([[{_id: 'foo', _rev: `rev${fetchCount}`, _type: 'testDoc', title: 'Test'}]])
+          },
+        },
+        withConfig: () => client,
+      }
+      const channel = new Subject<InvalidationChannelEvent>()
+      const observe = createObserveFields({
+        invalidationChannel: channel,
+        client: client as unknown as SanityClient,
+      })
+
+      const values: any[] = []
+      const sub = observe('foo', ['title'], undefined, ['drafts']).subscribe((v) => values.push(v))
+
+      channel.next({type: 'connected'})
+      await new Promise((r) => setTimeout(r, 200))
+      const afterConnect = fetchCount
+
+      channel.next({type: 'mutation', documentId: 'foo', visibility: 'query'})
+      await new Promise((r) => setTimeout(r, 200))
+
+      expect(fetchCount).toBeGreaterThan(afterConnect)
+      sub.unsubscribe()
+    })
+
+    it('should re-fetch when the draft version of observed document is mutated', async () => {
+      let fetchCount = 0
+      const client: ClientLike = {
+        observable: {
+          fetch: () => {
+            fetchCount++
+            return of([[{_id: 'foo', _rev: `rev${fetchCount}`, _type: 'testDoc', title: 'Test'}]])
+          },
+        },
+        withConfig: () => client,
+      }
+      const channel = new Subject<InvalidationChannelEvent>()
+      const observe = createObserveFields({
+        invalidationChannel: channel,
+        client: client as unknown as SanityClient,
+      })
+
+      const sub = observe('foo', ['title'], undefined, ['drafts']).subscribe(() => {})
+
+      channel.next({type: 'connected'})
+      await new Promise((r) => setTimeout(r, 200))
+      const afterConnect = fetchCount
+
+      channel.next({type: 'mutation', documentId: 'drafts.foo', visibility: 'query'})
+      await new Promise((r) => setTimeout(r, 200))
+
+      expect(fetchCount).toBeGreaterThan(afterConnect)
+      sub.unsubscribe()
+    })
+
+    it('should re-fetch when a versioned document matching the observed doc is mutated', async () => {
+      let fetchCount = 0
+      const client: ClientLike = {
+        observable: {
+          fetch: () => {
+            fetchCount++
+            return of([[{_id: 'foo', _rev: `rev${fetchCount}`, _type: 'testDoc', title: 'Test'}]])
+          },
+        },
+        withConfig: () => client,
+      }
+      const channel = new Subject<InvalidationChannelEvent>()
+      const observe = createObserveFields({
+        invalidationChannel: channel,
+        client: client as unknown as SanityClient,
+      })
+
+      const sub = observe('foo', ['title'], undefined, ['drafts', 'summer']).subscribe(() => {})
+
+      channel.next({type: 'connected'})
+      await new Promise((r) => setTimeout(r, 200))
+      const afterConnect = fetchCount
+
+      channel.next({
+        type: 'mutation',
+        documentId: 'versions.summer.foo',
+        visibility: 'query',
+      })
+      await new Promise((r) => setTimeout(r, 200))
+
+      expect(fetchCount).toBeGreaterThan(afterConnect)
+      sub.unsubscribe()
+    })
+
+    it('should NOT re-fetch when an unrelated document is mutated (with perspective)', async () => {
+      let fetchCount = 0
+      const client: ClientLike = {
+        observable: {
+          fetch: () => {
+            fetchCount++
+            return of([[{_id: 'foo', _rev: `rev${fetchCount}`, _type: 'testDoc', title: 'Test'}]])
+          },
+        },
+        withConfig: () => client,
+      }
+      const channel = new Subject<InvalidationChannelEvent>()
+      const observe = createObserveFields({
+        invalidationChannel: channel,
+        client: client as unknown as SanityClient,
+      })
+
+      const sub = observe('foo', ['title'], undefined, ['drafts']).subscribe(() => {})
+
+      channel.next({type: 'connected'})
+      await new Promise((r) => setTimeout(r, 200))
+      const afterConnect = fetchCount
+
+      channel.next({type: 'mutation', documentId: 'trigger-doc', visibility: 'query'})
+      channel.next({type: 'mutation', documentId: 'drafts.other-doc', visibility: 'query'})
+      channel.next({type: 'mutation', documentId: 'versions.summer.bar', visibility: 'query'})
+      await new Promise((r) => setTimeout(r, 200))
+
+      expect(fetchCount).toBe(afterConnect)
+      sub.unsubscribe()
+    })
+
+    it('should NOT re-fetch for a version outside the active perspective stack', async () => {
+      let fetchCount = 0
+      const client: ClientLike = {
+        observable: {
+          fetch: () => {
+            fetchCount++
+            return of([[{_id: 'foo', _rev: `rev${fetchCount}`, _type: 'testDoc', title: 'Test'}]])
+          },
+        },
+        withConfig: () => client,
+      }
+      const channel = new Subject<InvalidationChannelEvent>()
+      const observe = createObserveFields({
+        invalidationChannel: channel,
+        client: client as unknown as SanityClient,
+      })
+
+      const sub = observe('foo', ['title'], undefined, ['drafts', 'summer']).subscribe(() => {})
+
+      channel.next({type: 'connected'})
+      await new Promise((r) => setTimeout(r, 200))
+      const afterConnect = fetchCount
+
+      channel.next({
+        type: 'mutation',
+        documentId: 'versions.winter.foo',
+        visibility: 'query',
+      })
+      await new Promise((r) => setTimeout(r, 200))
+
+      expect(fetchCount).toBe(afterConnect)
+      sub.unsubscribe()
+    })
+
+    it('should always re-fetch on connected event regardless of perspective', async () => {
+      let fetchCount = 0
+      const client: ClientLike = {
+        observable: {
+          fetch: () => {
+            fetchCount++
+            return of([[{_id: 'foo', _rev: `rev${fetchCount}`, _type: 'testDoc', title: 'Test'}]])
+          },
+        },
+        withConfig: () => client,
+      }
+      const channel = new Subject<InvalidationChannelEvent>()
+      const observe = createObserveFields({
+        invalidationChannel: channel,
+        client: client as unknown as SanityClient,
+      })
+
+      const sub = observe('foo', ['title'], undefined, ['drafts']).subscribe(() => {})
+
+      channel.next({type: 'connected'})
+      await new Promise((r) => setTimeout(r, 200))
+
+      expect(fetchCount).toBeGreaterThan(0)
+      sub.unsubscribe()
+    })
+  })
 })

--- a/packages/sanity/src/core/preview/__test__/observeFields.test.ts
+++ b/packages/sanity/src/core/preview/__test__/observeFields.test.ts
@@ -8,6 +8,13 @@ import {chunkCombinedSelections, type ClientLike, createObserveFields} from '../
 import {type InvalidationChannelEvent} from '../types'
 import {type CombinedSelection} from '../utils/optimizeQuery'
 
+function sendMutations(channel: Subject<InvalidationChannelEvent>, documentIds: string | string[]) {
+  const ids = Array.isArray(documentIds) ? documentIds : [documentIds]
+  for (const documentId of ids) {
+    channel.next({type: 'mutation', documentId, visibility: 'query'})
+  }
+}
+
 describe('chunkCombinedSelections', () => {
   it('should return a single chunk when IDs fit within the size limit', () => {
     const selections: CombinedSelection[] = [
@@ -258,7 +265,9 @@ describe('observeFields', () => {
   })
 
   describe('invalidation filter with perspective', () => {
-    it('should re-fetch when the observed document itself is mutated (with perspective)', async () => {
+    const SETTLE_TIME = 200
+
+    function setupPerspectiveTest() {
       let fetchCount = 0
       const client: ClientLike = {
         observable: {
@@ -275,241 +284,129 @@ describe('observeFields', () => {
         client: client as unknown as SanityClient,
       })
 
-      const values: any[] = []
-      const sub = observe('foo', ['title'], undefined, ['drafts']).subscribe((v) => values.push(v))
+      return {
+        get fetchCount() {
+          return fetchCount
+        },
+        channel,
+        observe,
+      }
+    }
 
+    async function connectAndSettle(channel: Subject<InvalidationChannelEvent>) {
       channel.next({type: 'connected'})
-      await new Promise((r) => setTimeout(r, 200))
-      const afterConnect = fetchCount
+      await new Promise((r) => setTimeout(r, SETTLE_TIME))
+    }
 
-      channel.next({type: 'mutation', documentId: 'foo', visibility: 'query'})
-      await new Promise((r) => setTimeout(r, 200))
+    it('should re-fetch when the observed document itself is mutated (with perspective)', async () => {
+      const harness = setupPerspectiveTest()
+      const sub = harness.observe('foo', ['title'], undefined, ['drafts']).subscribe(() => {})
 
-      expect(fetchCount).toBeGreaterThan(afterConnect)
+      await connectAndSettle(harness.channel)
+      const afterConnect = harness.fetchCount
+
+      sendMutations(harness.channel, 'foo')
+      await new Promise((r) => setTimeout(r, SETTLE_TIME))
+
+      expect(harness.fetchCount).toBeGreaterThan(afterConnect)
       sub.unsubscribe()
     })
 
     it('should re-fetch when the draft version of observed document is mutated', async () => {
-      let fetchCount = 0
-      const client: ClientLike = {
-        observable: {
-          fetch: () => {
-            fetchCount++
-            return of([[{_id: 'foo', _rev: `rev${fetchCount}`, _type: 'testDoc', title: 'Test'}]])
-          },
-        },
-        withConfig: () => client,
-      }
-      const channel = new Subject<InvalidationChannelEvent>()
-      const observe = createObserveFields({
-        invalidationChannel: channel,
-        client: client as unknown as SanityClient,
-      })
+      const harness = setupPerspectiveTest()
+      const sub = harness.observe('foo', ['title'], undefined, ['drafts']).subscribe(() => {})
 
-      const sub = observe('foo', ['title'], undefined, ['drafts']).subscribe(() => {})
+      await connectAndSettle(harness.channel)
+      const afterConnect = harness.fetchCount
 
-      channel.next({type: 'connected'})
-      await new Promise((r) => setTimeout(r, 200))
-      const afterConnect = fetchCount
+      sendMutations(harness.channel, 'drafts.foo')
+      await new Promise((r) => setTimeout(r, SETTLE_TIME))
 
-      channel.next({type: 'mutation', documentId: 'drafts.foo', visibility: 'query'})
-      await new Promise((r) => setTimeout(r, 200))
-
-      expect(fetchCount).toBeGreaterThan(afterConnect)
+      expect(harness.fetchCount).toBeGreaterThan(afterConnect)
       sub.unsubscribe()
     })
 
     it('should re-fetch when a versioned document matching the observed doc is mutated', async () => {
-      let fetchCount = 0
-      const client: ClientLike = {
-        observable: {
-          fetch: () => {
-            fetchCount++
-            return of([[{_id: 'foo', _rev: `rev${fetchCount}`, _type: 'testDoc', title: 'Test'}]])
-          },
-        },
-        withConfig: () => client,
-      }
-      const channel = new Subject<InvalidationChannelEvent>()
-      const observe = createObserveFields({
-        invalidationChannel: channel,
-        client: client as unknown as SanityClient,
-      })
+      const harness = setupPerspectiveTest()
+      const sub = harness
+        .observe('foo', ['title'], undefined, ['drafts', 'summer'])
+        .subscribe(() => {})
 
-      const sub = observe('foo', ['title'], undefined, ['drafts', 'summer']).subscribe(() => {})
+      await connectAndSettle(harness.channel)
+      const afterConnect = harness.fetchCount
 
-      channel.next({type: 'connected'})
-      await new Promise((r) => setTimeout(r, 200))
-      const afterConnect = fetchCount
+      sendMutations(harness.channel, 'versions.summer.foo')
+      await new Promise((r) => setTimeout(r, SETTLE_TIME))
 
-      channel.next({
-        type: 'mutation',
-        documentId: 'versions.summer.foo',
-        visibility: 'query',
-      })
-      await new Promise((r) => setTimeout(r, 200))
-
-      expect(fetchCount).toBeGreaterThan(afterConnect)
+      expect(harness.fetchCount).toBeGreaterThan(afterConnect)
       sub.unsubscribe()
     })
 
     it('should NOT re-fetch when an unrelated document is mutated (with perspective)', async () => {
-      let fetchCount = 0
-      const client: ClientLike = {
-        observable: {
-          fetch: () => {
-            fetchCount++
-            return of([[{_id: 'foo', _rev: `rev${fetchCount}`, _type: 'testDoc', title: 'Test'}]])
-          },
-        },
-        withConfig: () => client,
-      }
-      const channel = new Subject<InvalidationChannelEvent>()
-      const observe = createObserveFields({
-        invalidationChannel: channel,
-        client: client as unknown as SanityClient,
-      })
+      const harness = setupPerspectiveTest()
+      const sub = harness.observe('foo', ['title'], undefined, ['drafts']).subscribe(() => {})
 
-      const sub = observe('foo', ['title'], undefined, ['drafts']).subscribe(() => {})
+      await connectAndSettle(harness.channel)
+      const afterConnect = harness.fetchCount
 
-      channel.next({type: 'connected'})
-      await new Promise((r) => setTimeout(r, 200))
-      const afterConnect = fetchCount
+      sendMutations(harness.channel, ['trigger-doc', 'drafts.other-doc', 'versions.summer.bar'])
+      await new Promise((r) => setTimeout(r, SETTLE_TIME))
 
-      channel.next({type: 'mutation', documentId: 'trigger-doc', visibility: 'query'})
-      channel.next({type: 'mutation', documentId: 'drafts.other-doc', visibility: 'query'})
-      channel.next({type: 'mutation', documentId: 'versions.summer.bar', visibility: 'query'})
-      await new Promise((r) => setTimeout(r, 200))
-
-      expect(fetchCount).toBe(afterConnect)
+      expect(harness.fetchCount).toBe(afterConnect)
       sub.unsubscribe()
     })
 
     it('should NOT re-fetch for a version outside the active perspective stack', async () => {
-      let fetchCount = 0
-      const client: ClientLike = {
-        observable: {
-          fetch: () => {
-            fetchCount++
-            return of([[{_id: 'foo', _rev: `rev${fetchCount}`, _type: 'testDoc', title: 'Test'}]])
-          },
-        },
-        withConfig: () => client,
-      }
-      const channel = new Subject<InvalidationChannelEvent>()
-      const observe = createObserveFields({
-        invalidationChannel: channel,
-        client: client as unknown as SanityClient,
-      })
+      const harness = setupPerspectiveTest()
+      const sub = harness
+        .observe('foo', ['title'], undefined, ['drafts', 'summer'])
+        .subscribe(() => {})
 
-      const sub = observe('foo', ['title'], undefined, ['drafts', 'summer']).subscribe(() => {})
+      await connectAndSettle(harness.channel)
+      const afterConnect = harness.fetchCount
 
-      channel.next({type: 'connected'})
-      await new Promise((r) => setTimeout(r, 200))
-      const afterConnect = fetchCount
+      sendMutations(harness.channel, 'versions.winter.foo')
+      await new Promise((r) => setTimeout(r, SETTLE_TIME))
 
-      channel.next({
-        type: 'mutation',
-        documentId: 'versions.winter.foo',
-        visibility: 'query',
-      })
-      await new Promise((r) => setTimeout(r, 200))
-
-      expect(fetchCount).toBe(afterConnect)
+      expect(harness.fetchCount).toBe(afterConnect)
       sub.unsubscribe()
     })
 
     it('should NOT re-fetch when the same base document is mutated in an out-of-stack version while observing drafts', async () => {
-      let fetchCount = 0
-      const client: ClientLike = {
-        observable: {
-          fetch: () => {
-            fetchCount++
-            return of([[{_id: 'foo', _rev: `rev${fetchCount}`, _type: 'testDoc', title: 'Test'}]])
-          },
-        },
-        withConfig: () => client,
-      }
-      const channel = new Subject<InvalidationChannelEvent>()
-      const observe = createObserveFields({
-        invalidationChannel: channel,
-        client: client as unknown as SanityClient,
-      })
+      const harness = setupPerspectiveTest()
+      const sub = harness.observe('foo', ['title'], undefined, ['drafts']).subscribe(() => {})
 
-      const sub = observe('foo', ['title'], undefined, ['drafts']).subscribe(() => {})
+      await connectAndSettle(harness.channel)
+      const afterConnect = harness.fetchCount
 
-      channel.next({type: 'connected'})
-      await new Promise((r) => setTimeout(r, 200))
-      const afterConnect = fetchCount
+      sendMutations(harness.channel, 'versions.summer.foo')
+      await new Promise((r) => setTimeout(r, SETTLE_TIME))
 
-      channel.next({
-        type: 'mutation',
-        documentId: 'versions.summer.foo',
-        visibility: 'query',
-      })
-      await new Promise((r) => setTimeout(r, 200))
-
-      expect(fetchCount).toBe(afterConnect)
+      expect(harness.fetchCount).toBe(afterConnect)
       sub.unsubscribe()
     })
 
     it('should NOT re-fetch when the same base document is mutated in drafts while observing a version perspective', async () => {
-      let fetchCount = 0
-      const client: ClientLike = {
-        observable: {
-          fetch: () => {
-            fetchCount++
-            return of([[{_id: 'foo', _rev: `rev${fetchCount}`, _type: 'testDoc', title: 'Test'}]])
-          },
-        },
-        withConfig: () => client,
-      }
-      const channel = new Subject<InvalidationChannelEvent>()
-      const observe = createObserveFields({
-        invalidationChannel: channel,
-        client: client as unknown as SanityClient,
-      })
+      const harness = setupPerspectiveTest()
+      const sub = harness.observe('foo', ['title'], undefined, ['summer']).subscribe(() => {})
 
-      const sub = observe('foo', ['title'], undefined, ['summer']).subscribe(() => {})
+      await connectAndSettle(harness.channel)
+      const afterConnect = harness.fetchCount
 
-      channel.next({type: 'connected'})
-      await new Promise((r) => setTimeout(r, 200))
-      const afterConnect = fetchCount
+      sendMutations(harness.channel, 'drafts.foo')
+      await new Promise((r) => setTimeout(r, SETTLE_TIME))
 
-      channel.next({
-        type: 'mutation',
-        documentId: 'drafts.foo',
-        visibility: 'query',
-      })
-      await new Promise((r) => setTimeout(r, 200))
-
-      expect(fetchCount).toBe(afterConnect)
+      expect(harness.fetchCount).toBe(afterConnect)
       sub.unsubscribe()
     })
 
     it('should always re-fetch on connected event regardless of perspective', async () => {
-      let fetchCount = 0
-      const client: ClientLike = {
-        observable: {
-          fetch: () => {
-            fetchCount++
-            return of([[{_id: 'foo', _rev: `rev${fetchCount}`, _type: 'testDoc', title: 'Test'}]])
-          },
-        },
-        withConfig: () => client,
-      }
-      const channel = new Subject<InvalidationChannelEvent>()
-      const observe = createObserveFields({
-        invalidationChannel: channel,
-        client: client as unknown as SanityClient,
-      })
+      const harness = setupPerspectiveTest()
+      const sub = harness.observe('foo', ['title'], undefined, ['drafts']).subscribe(() => {})
 
-      const sub = observe('foo', ['title'], undefined, ['drafts']).subscribe(() => {})
+      await connectAndSettle(harness.channel)
 
-      channel.next({type: 'connected'})
-      await new Promise((r) => setTimeout(r, 200))
-
-      expect(fetchCount).toBeGreaterThan(0)
+      expect(harness.fetchCount).toBeGreaterThan(0)
       sub.unsubscribe()
     })
   })

--- a/packages/sanity/src/core/preview/createPathObserver.ts
+++ b/packages/sanity/src/core/preview/createPathObserver.ts
@@ -2,7 +2,7 @@ import {type StackablePerspective} from '@sanity/client'
 import {isCrossDatasetReference, isReference} from '@sanity/types'
 import uniq from 'lodash-es/uniq.js'
 import {type Observable, of as observableOf} from 'rxjs'
-import {switchMap} from 'rxjs/operators'
+import {distinctUntilChanged, switchMap} from 'rxjs/operators'
 
 import {isRecord} from '../util'
 import {type ApiConfig, type FieldName, type Previewable, type PreviewPath} from './types'
@@ -71,6 +71,7 @@ function observePaths(
       : apiConfig
 
     return observeFields(id, nextHeads, refApiConfig, perspective).pipe(
+      distinctUntilChanged((prev, curr) => prev?._rev === curr?._rev),
       switchMap((snapshot) => {
         if (snapshot === null) {
           return observableOf(null)

--- a/packages/sanity/src/core/preview/observeFields.ts
+++ b/packages/sanity/src/core/preview/observeFields.ts
@@ -229,7 +229,7 @@ export function createObserveFields(options: {
           // or versions outside the active perspective.
           return (
             getPublishedId(event.documentId) === getPublishedId(documentId) &&
-            idMatchesPerspective(perspective, documentId)
+            idMatchesPerspective(perspective, event.documentId)
           )
         }
         // if not using perspective, refetch previews for the document that was actually changed

--- a/packages/sanity/src/core/preview/observeFields.ts
+++ b/packages/sanity/src/core/preview/observeFields.ts
@@ -222,11 +222,15 @@ export function createObserveFields(options: {
           return true
         }
         if (hasPerspective) {
-          // if a perspective stack was provided, we need to refetch if we receive a mutation
-          // for a document whose _id matches either:
-          // - the published _id (since it's always implied)
-          // - any version id matching the provided perspectives
-          return idMatchesPerspective(perspective, documentId)
+          // With perspectives, refetch only when the mutated document is a
+          // version of the observed document (same base/published id) AND that
+          // version is relevant to the current perspective stack (e.g. drafts,
+          // a specific release). This avoids refetching for unrelated documents
+          // or versions outside the active perspective.
+          return (
+            getPublishedId(event.documentId) === getPublishedId(documentId) &&
+            idMatchesPerspective(perspective, documentId)
+          )
         }
         // if not using perspective, refetch previews for the document that was actually changed
         return event.documentId === documentId


### PR DESCRIPTION
### Description

Fixes preview document-path observers flooding the network with redundant queries whenever any document in the dataset is mutated, causing document lists to fail to load on slower connections.

- The invalidation filter in `observeFields` was checking whether the *observer's own* document ID matched the perspective stack: a static check that always passed for published IDs. Every mutation to any document triggered a re-fetch for every active observer. Fixed by comparing the `event.documentId`'s published ID against the observer's published ID, so only mutations to versions of the observed document trigger re-fetches.
- The recursive `observePaths` in `createPathObserver` was tearing down and rebuilding its entire subscription tree on every emission from `observeFields`, even when the document hadn't actually changed. Added `distinctUntilChanged` on `_rev` before the `switchMap` so identical snapshots don't cascade unneeded.

> [!NOTE]
> One thing you will be able to see is that the document list in the after, even with a network that is throttled by 3G will still load as it's not trying to render previews that don't need the refetches (the three documents are constantly being changed by the mutation call happening in the background)

Before (main)

https://github.com/user-attachments/assets/0a3dcda0-e0b7-4b6c-b9c5-1e02a8873fe2

After (this branch)

https://github.com/user-attachments/assets/90fbba34-7f88-45db-a6f4-379b565b30d5


### What to review

- The filter condition change in `observeFields.ts` (~line 225) — this is the higher-impact fix. Make sure the combination of `getPublishedId` equality + `idMatchesPerspective` covers all perspective-relevant mutations without missing legitimate re-fetches.
- The `distinctUntilChanged(_rev)` in `createPathObserver.ts` (~line 74) — straightforward but worth confirming `_rev` is always present on non-null snapshots flowing through this pipe.

### Testing

- Added tests in `createPathObserver.test.ts` covering `_rev`-based deduplication: identical snapshots are suppressed, changed `_rev` passes through, null snapshots pass through, rapid identical emissions are deduplicated. Also an integration test using the real `createObserveFields` pipeline that fires 10 mutation events and asserts fetch count stays bounded.
- Added tests in `observeFields.test.ts` for the invalidation filter with perspectives: mutations to the observed document (published, draft, matching version) trigger re-fetches; mutations to unrelated documents and versions outside the active perspective stack do not; connected events always trigger re-fetches.

> [!Note]
> These two automated tests are a bit harder to nail down the incident aspect, which is where the next section comes in. They are still useful to have but it is not the use case that lead to the incident a while back but it does help

- Verified with HAR captures on the test-studio document list under simulated 3G: requests dropped from 283 to 133 (-53%), data transferred from ~1.30 MiB to ~44.5 KiB (-97%), and the document list actually loads now.

### HAR comparison (test-studio document list, simulated 3G + 10 mutations via curl)
| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Requests | 283 | 133 | **-53%** |
| Data transferred | 1.30 MiB | 44.5 KiB | **-97%** |
| Document list loads | No | Yes (except the 3 documents that keep getting pelted with mutations as references, this is expected | |

#### To reproduce locally
1. Check out `main`, build, and start the dev studio: `pnpm build && pnpm dev`
2. Open `http://localhost:3333`, navigate to a document list (e.g. Book).
3. In Chrome DevTools → Network, enable **Slow 3G** throttling and filter by `preview.document-paths`.
4. In a terminal, fire mutations to generate invalidation events:
   - Get your token from the debug
   - Run mutations: `for i in $(seq 1 10); do curl -s -X POST "https://api.sanity.io/v2021-06-07/data/mutate/test" -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"mutations":[{"createOrReplace":{"_id":"trigger-doc","_type":"something","title":"trigger '$i'"}}]}'; sleep 1; done`
6. Export the HAR. Then check out this branch, rebuild (`pnpm build`), restart dev, and repeat.

### Notes for release

Fixed an issue where document list previews could fail to load on slower connections due to redundant network requests triggered by unrelated document mutations.