### PR TITLE
fix(form): reset datepicker calendar view when setting current time

### DIFF
--- a/packages/sanity/src/core/components/inputs/DateInputs/calendar/Calendar.tsx
+++ b/packages/sanity/src/core/components/inputs/DateInputs/calendar/Calendar.tsx
@@ -101,6 +101,11 @@ export const Calendar = forwardRef(function Calendar(
   const {timeZone, zoneDateToUtc, utcToCurrentZoneDate} = useTimeZone(timeZoneScope)
   const currentTzDate = useMemo(() => utcToCurrentZoneDate(value), [utcToCurrentZoneDate, value])
   const [focusedDate, setFocusedDate] = useState<Date>(value)
+  const [prevValue, setPrevValue] = useState<Date>(value)
+  if (prevValue !== value) {
+    setPrevValue(value)
+    setFocusedDate(value)
+  }
 
   const [displayMonth, displayYear] = useMemo(() => {
     return [

--- a/packages/sanity/src/core/components/inputs/DateInputs/calendar/__tests__/Calendar.test.tsx
+++ b/packages/sanity/src/core/components/inputs/DateInputs/calendar/__tests__/Calendar.test.tsx
@@ -194,3 +194,39 @@ describe('Calendar with stored timezone tokyo', () => {
     expect(mockOnSelect).toHaveBeenCalledWith(new Date('2024-01-19T18:30:00Z'))
   })
 })
+
+describe('Calendar resets displayed month when value changes', () => {
+  beforeEach(() => {
+    const getKeyMock = vi.fn().mockReturnValue(of(null))
+    const setKeyMock = vi.fn().mockResolvedValue(null)
+    useKeyValueStoreMock.mockReturnValue({getKey: getKeyMock, setKey: setKeyMock})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('updates displayed month when value prop changes', async () => {
+    const TestProvider = await createTestProvider()
+
+    const {rerender} = render(
+      <TestProvider>
+        <Calendar {...defaultProps} value={new Date('2029-04-20T10:00:00Z')} />
+      </TestProvider>,
+    )
+
+    // Calendar should show April 2029
+    const monthSelect = screen.getByRole('combobox') as HTMLSelectElement
+    expect(monthSelect).toHaveValue('3') // 0-indexed: April = 3
+
+    // Re-render with a new value (current-ish date)
+    rerender(
+      <TestProvider>
+        <Calendar {...defaultProps} value={new Date('2024-01-15T10:00:00Z')} />
+      </TestProvider>,
+    )
+
+    // Calendar should now show January 2024
+    expect(monthSelect).toHaveValue('0') // 0-indexed: January = 0
+  })
+})


### PR DESCRIPTION
### Description

Fixes [SAPP-3506](https://linear.app/sanity/issue/SAPP-3506).

When navigating the datepicker to a future date (e.g. April 2029) and clicking "Set to current time", the field value updated correctly but the calendar modal continued displaying the future month/year. The fix syncs the calendar's internal `focusedDate` state with the `value` prop when `value` changes externally.

### What to review

- Single `useEffect` addition in `Calendar.tsx` to sync `focusedDate` with the `value` prop.
- New test in `Calendar.test.tsx` that re-renders with a different value and asserts the displayed month updates.

### Testing

- Added a test that renders with April 2029 then re-renders with January 2024 and asserts the month select updates.
- All existing Calendar, DateTimeInput, and CommonDateTimeInput tests still pass.

### Notes for release

Fixed the datetime picker so the calendar view follows the field value when it changes from outside the calendar (for example after clicking "Set to current time"). Previously the calendar could stay on a past or future month while the field itself held the current time.
