### PR TITLE
fix(form): prevent modal close on first reference click in grid layout

### DIFF
--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/Grid/GridItem.tsx
@@ -116,8 +116,10 @@ export function GridItem<Item extends ObjectItem = ObjectItem>(props: GridItemPr
   useScrollIntoViewOnFocusWithin(previewCardRef, open)
 
   useDidUpdate(focused, (hadFocus, hasFocus) => {
-    if (!hadFocus && hasFocus && previewCardRef.current) {
+    if (!hadFocus && hasFocus && previewCardRef.current && !open) {
       // Note: if editing an inline item, focus is handled by the item input itself and no ref is being set
+      // Skip when the dialog is open to prevent stealing focus from elements inside the dialog
+      // (e.g. reference links), which would interrupt the user's interaction on the first click.
       previewCardRef.current?.focus()
     }
   })

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
@@ -105,8 +105,10 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
   useScrollIntoViewOnFocusWithin(previewCardRef, canScrollIntoView)
 
   useDidUpdate(focused, (hadFocus, hasFocus) => {
-    if (!hadFocus && hasFocus && previewCardRef.current) {
+    if (!hadFocus && hasFocus && previewCardRef.current && !open) {
       // Note: if editing an inline item, focus is handled by the item input itself and no ref is being set
+      // Skip when the dialog is open to prevent stealing focus from elements inside the dialog
+      // (e.g. reference links), which would interrupt the user's interaction on the first click.
       previewCardRef.current?.focus()
     }
   })


### PR DESCRIPTION
### Description

Fixes [SAPP-3687](https://linear.app/sanity/issue/SAPP-3687).

In an array of references rendered with `options.layout: "grid"`, the first click on a reference inside an open grid-item modal closed the modal instead of navigating. Root cause: `useDidUpdate` was restoring focus to the preview card whenever the `focused` prop transitioned `false → true`, which stole focus from the reference click and caused `onClickOutside` to dismiss the modal. Added an `!open` guard so focus is not stolen while the item dialog is open.

### What to review

- `GridItem.tsx` and `PreviewItem.tsx` — the `useDidUpdate` callback now skips focus restoration when the dialog is open.

### Testing

- All 608 form tests pass.
- Manual verification: clicking a reference in the grid modal now consistently opens the referenced document on first click.

### Notes for release

Fixed a bug where the first click on a reference link inside a grid array-item modal would close the modal instead of opening the referenced document. Subsequent clicks always worked; now the first click works too.
