### PR TITLE
fix(form): prevent scroll jump when opening field overflow menu

### DIFF
--- a/packages/sanity/src/core/form/field/actions/FieldActionMenu.tsx
+++ b/packages/sanity/src/core/form/field/actions/FieldActionMenu.tsx
@@ -1,6 +1,6 @@
 import {EllipsisHorizontalIcon} from '@sanity/icons'
 import {Card, Menu} from '@sanity/ui'
-import {memo, useCallback, useId, useMemo, useState} from 'react'
+import {memo, type PointerEvent, useCallback, useId, useMemo, useState} from 'react'
 
 import {Button, type ButtonProps, MenuButton, type MenuButtonProps} from '../../../../ui-components'
 import {type DocumentFieldActionGroup, type DocumentFieldActionNode} from '../../../config'
@@ -131,6 +131,14 @@ function RootFieldActionMenuGroup(props: {
   const {node, onOpen, onClose, open} = props
   const {title} = useI18nText(node)
 
+  // Prevent the browser's default focus-and-scroll behaviour on pointer down.
+  // Without this, clicking the overflow menu button while another field (possibly
+  // far away) holds focus causes the browser to scroll the document as it shifts
+  // focus, resulting in an unexpected jump to the top of the form.
+  const handlePointerDown = useCallback((event: PointerEvent) => {
+    event.preventDefault()
+  }, [])
+
   return (
     <MenuButton
       button={
@@ -139,6 +147,7 @@ function RootFieldActionMenuGroup(props: {
           data-testid="field-actions-trigger"
           icon={node.icon}
           mode="bleed"
+          onPointerDown={handlePointerDown}
           tabIndex={0}
           tooltipProps={{
             ...STATUS_BUTTON_TOOLTIP_PROPS,

--- a/packages/sanity/src/core/form/field/actions/__tests__/FieldActionMenu.test.tsx
+++ b/packages/sanity/src/core/form/field/actions/__tests__/FieldActionMenu.test.tsx
@@ -1,0 +1,70 @@
+import {EllipsisHorizontalIcon} from '@sanity/icons'
+import {fireEvent, render, screen} from '@testing-library/react'
+import {type ComponentType, type PropsWithChildren} from 'react'
+import {beforeAll, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {type DocumentFieldActionNode} from '../../../../config'
+import {FieldActionMenu} from '../FieldActionMenu'
+
+const mockNodes: DocumentFieldActionNode[] = [
+  {
+    type: 'group',
+    children: [
+      {
+        type: 'action',
+        icon: EllipsisHorizontalIcon,
+        title: 'Copy',
+        onAction: vi.fn(),
+      },
+    ],
+    icon: EllipsisHorizontalIcon,
+    title: 'Field actions',
+  },
+]
+
+describe('FieldActionMenu', () => {
+  let TestWrapper: ComponentType<PropsWithChildren>
+
+  beforeAll(async () => {
+    TestWrapper = await createTestProvider()
+  })
+
+  it('should prevent default on pointerdown to avoid scroll jump', () => {
+    const onMenuOpenChange = vi.fn()
+
+    render(
+      <TestWrapper>
+        <FieldActionMenu nodes={mockNodes} onMenuOpenChange={onMenuOpenChange} />
+      </TestWrapper>,
+    )
+
+    const trigger = screen.getByTestId('field-actions-trigger')
+
+    // Verify that pointerdown's default is prevented, which stops the browser
+    // from performing focus-and-scroll behaviour when clicking the menu trigger.
+    // eslint-disable-next-line testing-library/prefer-user-event -- fireEvent is needed to check preventDefault return value
+    const defaultPrevented = !fireEvent.pointerDown(trigger)
+    expect(defaultPrevented).toBe(true)
+  })
+
+  it('should still open the menu on click despite pointerdown prevention', () => {
+    const onMenuOpenChange = vi.fn()
+
+    render(
+      <TestWrapper>
+        <FieldActionMenu nodes={mockNodes} onMenuOpenChange={onMenuOpenChange} />
+      </TestWrapper>,
+    )
+
+    const trigger = screen.getByTestId('field-actions-trigger')
+
+    // Click the trigger button — the click event should still work even though
+    // pointerdown default is prevented.
+    // eslint-disable-next-line testing-library/prefer-user-event -- fireEvent used for consistency with pointerDown test
+    fireEvent.click(trigger)
+
+    // The menu should open
+    expect(onMenuOpenChange).toHaveBeenCalledWith(true)
+  })
+})


### PR DESCRIPTION
### Description

Fixes [SAPP-3605](https://linear.app/sanity/issue/SAPP-3605).

Clicking a field overflow menu (ellipsis) while scrolled down in a long document caused the document to jump to the top. Root cause: the browser's native focus behavior on `mousedown` shifts focus from the top-of-document auto-focused field to the menu button, triggering an implicit scroll. Added `onPointerDown` with `preventDefault()` to the menu trigger — `pointerdown` fires before `mousedown`, cancelling it suppresses the implicit focus-and-scroll. `MenuButton` still manages focus internally so keyboard accessibility is preserved.

### What to review

- `FieldActionMenu.tsx` — `onPointerDown` handler added to `RootFieldActionMenuGroup`'s trigger button.
- New `FieldActionMenu.test.tsx` with 2 tests.

### Testing

- 2 new tests verifying the `preventDefault` behavior on pointerdown.
- All 609 form tests pass.
- Manual verification: opening the overflow menu on a scrolled-down field no longer jumps to the top.

### Notes for release

Fixed a bug where clicking the overflow menu (⋯) on a field scrolled the document to the top. Opening a field's overflow menu now keeps the page in place.
