### PR TITLE
fix(i18n): graceful fallback for invalid locale component tags in Translate

### DIFF
--- a/dev/test-studio/components/TranslateExample.tsx
+++ b/dev/test-studio/components/TranslateExample.tsx
@@ -58,6 +58,27 @@ export const TranslateExample = forwardRef(function TranslateExample() {
             }}
           />
         </Text>
+
+        <Text weight="bold">Broken translations (should fall back gracefully, not crash):</Text>
+
+        <Text>
+          Missing self-closing:{' '}
+          <Translate t={t} i18nKey="translate.missing-self-closing" components={{}} />
+        </Text>
+        <Text>
+          Missing wrapping: <Translate t={t} i18nKey="translate.missing-wrapping" components={{}} />
+        </Text>
+        <Text>
+          Mismatched component (issue #12617):{' '}
+          <Translate
+            t={t}
+            i18nKey="translate.mismatched-component"
+            components={{
+              VersionBadge: ({children}) => <span style={{fontWeight: 'bold'}}>{children}</span>,
+            }}
+            values={{title: 'My Release'}}
+          />
+        </Text>
       </Stack>
     </Card>
   )

--- a/dev/test-studio/locales/index.ts
+++ b/dev/test-studio/locales/index.ts
@@ -15,6 +15,11 @@ const enUSStrings = {
   // Used by `fieldGroupsWithI18n` debug schema type
   'field-groups.group-1': '🇺🇸 Group 1',
   'field-groups.group-2': '🇺🇸 Group 2',
+
+  // Used by `TranslateExample` to test graceful fallback for broken translations (#12617)
+  'translate.missing-self-closing': 'Before <Missing/> after',
+  'translate.missing-wrapping': 'Click <Label>here</Label> to continue',
+  'translate.mismatched-component': 'Not in the <Label>{{title}}</Label> release.',
 }
 
 const enUS = defineLocaleResourceBundle({

--- a/packages/sanity/src/core/i18n/Translate.tsx
+++ b/packages/sanity/src/core/i18n/Translate.tsx
@@ -114,7 +114,21 @@ export function Translate(props: TranslationProps) {
   const formatters: FormatterFns = {
     list: (listValues) => listFormat.format(listValues),
   }
-  return <>{render(tokens, props.values, props.components || {}, formatters)}</>
+  const componentMap = props.components || {}
+  let content: ReactNode
+  try {
+    content = render(tokens, props.values, componentMap, formatters)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.warn(`Translate: Failed to render translation for key "${props.i18nKey}": ${message}`)
+    // Fall back to the interpolated translation as plain text so the user
+    // sees readable content instead of a raw i18n key
+    content = props.t(props.i18nKey, {
+      context: props.context,
+      replace: props.values,
+    })
+  }
+  return <>{content}</>
 }
 
 function render(

--- a/packages/sanity/src/core/i18n/__tests__/Translate.test.tsx
+++ b/packages/sanity/src/core/i18n/__tests__/Translate.test.tsx
@@ -1,7 +1,7 @@
 import {studioTheme, ThemeProvider} from '@sanity/ui'
 import {render, screen} from '@testing-library/react'
 import {type ComponentProps, type ReactNode} from 'react'
-import {describe, expect, it} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 
 import {LocaleProviderBase} from '../components/LocaleProvider'
 import {useTranslation} from '../hooks/useTranslation'
@@ -149,5 +149,94 @@ describe('Translate component', () => {
     expect(await screen.findByTestId('output')).toHaveTextContent(
       '3 people signed up: Bjørge, Rita, and Espen',
     )
+  })
+
+  describe('fallback for invalid translations', () => {
+    it('falls back to interpolated text for a missing self-closing component', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const wrapper = await getWrapper([createBundle({message: 'Before <Missing/> after'})])
+      render(<TestComponent i18nKey="message" components={{}} />, {wrapper})
+      expect(await screen.findByTestId('output')).toHaveTextContent('Before <Missing/> after')
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Component not found: Missing'))
+      warnSpy.mockRestore()
+    })
+
+    it('falls back to interpolated text for a missing wrapping component', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const wrapper = await getWrapper([
+        createBundle({message: 'Click <Label>here</Label> to continue'}),
+      ])
+      render(<TestComponent i18nKey="message" components={{}} />, {wrapper})
+      expect(await screen.findByTestId('output')).toHaveTextContent(
+        'Click <Label>here</Label> to continue',
+      )
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Component not defined: Label'))
+      warnSpy.mockRestore()
+    })
+
+    it('falls back to interpolated text for an unrecognized HTML tag', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const wrapper = await getWrapper([createBundle({message: 'Some <blink>text</blink> here'})])
+      render(<TestComponent i18nKey="message" components={{}} />, {wrapper})
+      expect(await screen.findByTestId('output')).toHaveTextContent('Some <blink>text</blink> here')
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('HTML tag "blink" is not allowed'),
+      )
+      warnSpy.mockRestore()
+    })
+
+    it('falls back to interpolated text for mismatched component tags from stale locales', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const wrapper = await getWrapper([
+        createBundle({message: 'The <Label>{{title}}</Label> release'}),
+      ])
+      render(
+        <TestComponent
+          i18nKey="message"
+          components={{
+            VersionBadge: ({children}) => <span>{children}</span>,
+          }}
+          values={{title: 'My Release'}}
+        />,
+        {wrapper},
+      )
+      expect(await screen.findByTestId('output')).toHaveTextContent(
+        'The <Label>My Release</Label> release',
+      )
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Component not defined: Label'))
+      warnSpy.mockRestore()
+    })
+
+    it('does not warn when all components are provided correctly', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const wrapper = await getWrapper([
+        createBundle({
+          message: 'Your search for "<Red>{{keyword}}</Red>" took <Bold>{{duration}}ms</Bold>',
+        }),
+      ])
+      render(
+        <TestComponent
+          i18nKey="message"
+          components={{
+            Red: ({children}) => <span style={{color: 'red'}}>{children}</span>,
+            Bold: ({children}) => <b>{children}</b>,
+          }}
+          values={{keyword: 'something', duration: '123'}}
+        />,
+        {wrapper},
+      )
+      await screen.findByTestId('output')
+      expect(warnSpy).not.toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+
+    it('does not warn when recognized HTML tags are used', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const wrapper = await getWrapper([createBundle({title: 'An <code>embedded</code> thing'})])
+      render(<TestComponent i18nKey="title" components={{}} />, {wrapper})
+      expect(await screen.findByTestId('output')).toHaveTextContent('An embedded thing')
+      expect(warnSpy).not.toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
   })
 })


### PR DESCRIPTION
## Description

Closes #12617

The `Translate` component throws hard errors when a translation string contains component tags (e.g. `<Label>`) that aren't provided in the `components` prop. This was caused by the English source for `banners.release.not-in-release` being renamed from `<Label>` to `<VersionBadge>`, but several locale packages (`sv-SE`, `ja-JP`, `zh-Hans`, `ko-KR`) had already synced the original `<Label>` tag before the rename. The translation key stayed the same but the expected component changed, causing a mismatch that crashes the page.

This is unlikely to be a common occurrence but PRs to fix the affected locale bundles in `sanity-io/locales` will follow shortly. This change addresses the issue directly in the studio to ensure graceful handling regardless of locale bundle state.

## What to review

The fix wraps the `render()` call inside the `Translate` component in a try-catch. Since `render()` is a plain recursive function (not a React component), its throws happen synchronously during the function call, making a try-catch sufficient without needing an ErrorBoundary or extra component wrappers.

On failure, the catch block logs a `console.warn` with the key and error message, then falls back to the interpolated translation string as plain text - so users see readable content (with literal tags visible) instead of a crash.

## Testing

- 6 new unit tests covering all error paths, the exact #12617 scenario, and no-false-positive checks
- Run: `pnpm vitest run --project=sanity packages/sanity/src/core/i18n/__tests__/Translate.test.tsx`
- A "Translate Test" page in the test-studio structure view includes three broken translation examples to verify the fallback visually via `pnpm dev`

## Notes for release

Fixes an issue where some localised bundles would cause the studio to crash.