### PR TITLE
fix(form): position reference autocomplete popovers in portaled dialogs

### DIFF
--- a/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/ReferenceAutocomplete.tsx
+++ b/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/ReferenceAutocomplete.tsx
@@ -11,6 +11,7 @@ import {styled} from 'styled-components'
 
 import {Popover} from '../../../../ui-components'
 import {Translate, useTranslation} from '../../../i18n'
+import {AUTOCOMPLETE_POPOVER_BOUNDARY} from '../referenceAutocompletePopoverBoundary'
 
 const StyledPopover = styled(Popover)`
   & > div {
@@ -59,6 +60,8 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
         fallbackPlacements={FALLBACK_PLACEMENTS}
         arrow={false}
         constrainSize
+        floatingBoundary={AUTOCOMPLETE_POPOVER_BOUNDARY}
+        referenceBoundary={AUTOCOMPLETE_POPOVER_BOUNDARY}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         content={

--- a/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/ReferenceAutocomplete.test.tsx
+++ b/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/ReferenceAutocomplete.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Ensures reference autocomplete popovers pass explicit floating/reference boundaries so
+ * portaled dialogs (and embeds without DocumentPanel) get correct Floating UI behavior.
+ *
+ * `ReferenceInput/ReferenceAutocomplete` (same-dataset), GDR, and Cross-dataset
+ * `CrossDatasetReferenceInput/ReferenceAutocomplete` share this Popover wiring. Same-dataset needs
+ * `useFormBuilder` mocked with a `focusPath` that matches the `path` passed in props so the
+ * component can mount.
+ */
+import {type Autocomplete, type AutocompleteProps} from '@sanity/ui'
+import {render, waitFor} from '@testing-library/react'
+import {
+  type ForwardedRef,
+  forwardRef,
+  type ReactNode,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
+import {describe, expect, test, vi, beforeEach} from 'vitest'
+
+import type * as UIComponentsModule from '../../../../ui-components'
+import {ReferenceAutocomplete as CrossDatasetReferenceAutocomplete} from '../CrossDatasetReferenceInput/ReferenceAutocomplete'
+import {ReferenceAutocomplete as SameDatasetReferenceAutocomplete} from '../ReferenceInput/ReferenceAutocomplete'
+import {ReferenceAutocomplete} from './ReferenceAutocomplete'
+
+type PopoverBoundaryCapture = Pick<
+  UIComponentsModule.PopoverProps,
+  'floatingBoundary' | 'referenceBoundary'
+>
+
+/** Last props passed from ReferenceAutocomplete to Popover (via styled wrapper). */
+let lastPopoverProps: PopoverBoundaryCapture | null = null
+
+function assignForwardedRef<T>(ref: ForwardedRef<T>, value: T | null): void {
+  if (typeof ref === 'function') {
+    ref(value)
+  } else if (ref) {
+    ref.current = value
+  }
+}
+
+const {sameDatasetFieldPath} = vi.hoisted(() => ({
+  sameDatasetFieldPath: ['sameDatasetRefField'] as const,
+}))
+
+vi.mock('../../useFormBuilder', () => ({
+  useFormBuilder: () => ({
+    focusPath: [...sameDatasetFieldPath],
+  }),
+}))
+
+vi.mock('@sanity/ui', async (importOriginal) => {
+  const mod = (await importOriginal()) as Record<string, unknown>
+
+  /**
+   * Minimal Autocomplete that always invokes `renderPopover` so StyledPopover mounts (mirrors open search UI).
+   */
+  const AutocompleteStub = forwardRef(function AutocompleteStub(
+    props: AutocompleteProps,
+    ref: ForwardedRef<HTMLInputElement>,
+  ) {
+    const {renderPopover} = props
+    const contentRef = useRef<HTMLDivElement>(null)
+    const [popover, setPopover] = useState<ReactNode>(null)
+
+    useLayoutEffect(() => {
+      if (typeof renderPopover !== 'function') {
+        setPopover(null)
+        return
+      }
+      const input = document.createElement('input')
+      setPopover(
+        renderPopover(
+          {
+            content: null,
+            hidden: false,
+            inputElement: input,
+            onMouseEnter: () => undefined,
+            onMouseLeave: () => undefined,
+          },
+          contentRef,
+        ),
+      )
+    }, [renderPopover])
+
+    return (
+      <div data-testid="autocomplete-stub">
+        <input
+          data-testid="autocomplete-input"
+          ref={(node) => {
+            assignForwardedRef(ref, node)
+          }}
+        />
+        {popover}
+      </div>
+    )
+  })
+
+  return {...mod, Autocomplete: AutocompleteStub as Autocomplete}
+})
+
+vi.mock('../../../i18n', () => ({
+  useTranslation: () => ({t: (key: string) => key}),
+  Translate: ({children}: {children?: ReactNode}) => <>{children}</>,
+}))
+
+vi.mock('../../../../ui-components', async (importOriginal) => {
+  const mod = (await importOriginal()) as UIComponentsModule
+  const Forward = forwardRef<HTMLDivElement, UIComponentsModule.PopoverProps>(
+    function PopoverCapture(props, ref) {
+      useLayoutEffect(() => {
+        lastPopoverProps = {
+          floatingBoundary: props.floatingBoundary,
+          referenceBoundary: props.referenceBoundary,
+        }
+      }, [props.floatingBoundary, props.referenceBoundary])
+      return <div ref={ref} data-testid="popover-capture" data-floating-ui-role="popover" />
+    },
+  )
+  return {...mod, Popover: Forward as UIComponentsModule.Popover}
+})
+
+describe('ReferenceAutocomplete popover boundaries (portaled dialogs / embeds)', () => {
+  beforeEach(() => {
+    lastPopoverProps = null
+  })
+
+  test('global document reference: passes documentElement as floatingBoundary and referenceBoundary to Popover', async () => {
+    render(
+      <ReferenceAutocomplete
+        loading={false}
+        options={[]}
+        onQueryChange={() => undefined}
+        referenceElement={null}
+        searchString=""
+        id="ref-ac-test"
+      />,
+    )
+
+    await waitFor(() => {
+      expect(lastPopoverProps).not.toBeNull()
+    })
+
+    expect(lastPopoverProps?.floatingBoundary).toBe(document.documentElement)
+    expect(lastPopoverProps?.referenceBoundary).toBe(document.documentElement)
+  })
+
+  test('cross-dataset reference: passes documentElement as floatingBoundary and referenceBoundary to Popover', async () => {
+    render(
+      <CrossDatasetReferenceAutocomplete
+        loading={false}
+        options={[]}
+        onQueryChange={() => undefined}
+        referenceElement={null}
+        searchString=""
+        id="cross-ref-ac-test"
+      />,
+    )
+
+    await waitFor(() => {
+      expect(lastPopoverProps).not.toBeNull()
+    })
+
+    expect(lastPopoverProps?.floatingBoundary).toBe(document.documentElement)
+    expect(lastPopoverProps?.referenceBoundary).toBe(document.documentElement)
+  })
+
+  test('same-dataset reference: passes documentElement as floatingBoundary and referenceBoundary to Popover', async () => {
+    render(
+      <SameDatasetReferenceAutocomplete
+        path={[...sameDatasetFieldPath]}
+        loading={false}
+        options={[]}
+        onQueryChange={() => undefined}
+        referenceElement={null}
+        searchString=""
+        id="same-dataset-ref-ac-test"
+      />,
+    )
+
+    await waitFor(() => {
+      expect(lastPopoverProps).not.toBeNull()
+    })
+
+    expect(lastPopoverProps?.floatingBoundary).toBe(document.documentElement)
+    expect(lastPopoverProps?.referenceBoundary).toBe(document.documentElement)
+  })
+})

--- a/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/ReferenceAutocomplete.tsx
+++ b/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/ReferenceAutocomplete.tsx
@@ -12,6 +12,7 @@ import {styled} from 'styled-components'
 
 import {Popover} from '../../../../ui-components'
 import {Translate, useTranslation} from '../../../i18n'
+import {AUTOCOMPLETE_POPOVER_BOUNDARY} from '../referenceAutocompletePopoverBoundary'
 
 const StyledPopover = styled(Popover)`
   & > div {
@@ -60,6 +61,8 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
         fallbackPlacements={FALLBACK_PLACEMENTS}
         arrow={false}
         constrainSize
+        floatingBoundary={AUTOCOMPLETE_POPOVER_BOUNDARY}
+        referenceBoundary={AUTOCOMPLETE_POPOVER_BOUNDARY}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         content={

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceAutocomplete.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceAutocomplete.tsx
@@ -15,6 +15,7 @@ import {styled} from 'styled-components'
 import {useFormBuilder} from '../..'
 import {Popover} from '../../../../ui-components'
 import {Translate, useTranslation} from '../../../i18n'
+import {AUTOCOMPLETE_POPOVER_BOUNDARY} from '../referenceAutocompletePopoverBoundary'
 
 const StyledPopover = styled(Popover)`
   & > div {
@@ -77,6 +78,8 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
         fallbackPlacements={FALLBACK_PLACEMENTS}
         arrow={false}
         constrainSize
+        floatingBoundary={AUTOCOMPLETE_POPOVER_BOUNDARY}
+        referenceBoundary={AUTOCOMPLETE_POPOVER_BOUNDARY}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         content={

--- a/packages/sanity/src/core/form/inputs/referenceAutocompletePopoverBoundary.ts
+++ b/packages/sanity/src/core/form/inputs/referenceAutocompletePopoverBoundary.ts
@@ -1,0 +1,10 @@
+/**
+ * Document pane uses BoundaryElementProvider on the scroll container. Portaled dialogs sit outside
+ * that subtree, so the default boundaries break in two ways: `hide` sets referenceHidden (popover
+ * hidden), and flip/shift/constrainSize use the wrong rect (popover misplaced). Use the document
+ * root for both floating and reference boundaries so placement matches the viewport everywhere.
+ *
+ * Shared by same-dataset, cross-dataset, and global-document reference autocompletes.
+ */
+export const AUTOCOMPLETE_POPOVER_BOUNDARY: HTMLElement | undefined =
+  typeof document === 'undefined' ? undefined : document.documentElement


### PR DESCRIPTION
### Description

There was a bug where the autocomplete would not render properly sometimes (for example when used inside an array and modal in the Media Library). It just became invisible.

#### Problem / fix

Document pane BoundaryElementProvider uses the scroll container; portaled array/nested-object dialogs render outside it. Default floating and reference boundaries then hid the popover (referenceHidden) or misaligned it (flip/shift/constrainSize). Set both boundaries to documentElement so visibility and placement use the viewport for global, same-dataset, and cross-dataset reference autocompletes.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Are the changes safe? Could they cause problems elsewhere?
<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Not easy to reproduce as it seems to work fine inside the Studio itself. The same schema in the Media Library caused problems.

Added test.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
* Fixed a issue where autocompletion for reference picker wouldn't render correctly in some sitations.
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
