### PR TITLE
fix(ci): add auth store e2e tests

### DIFF
--- a/.github/workflows/e2e-auth.yml
+++ b/.github/workflows/e2e-auth.yml
@@ -1,0 +1,57 @@
+name: Auth E2E Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  auth-e2e:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/detect-code-changes
+        id: changes
+
+      - uses: ./.github/actions/setup
+        if: steps.changes.outputs.has_changes == 'true'
+
+      - name: Store Playwright's Version
+        if: steps.changes.outputs.has_changes == 'true'
+        id: playwright-version
+        run: |
+          PLAYWRIGHT_VERSION=$(npx playwright --version | sed 's/Version //')
+          echo "version=${PLAYWRIGHT_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright Browsers
+        if: steps.changes.outputs.has_changes == 'true'
+        id: cache-playwright-browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
+
+      - name: Install Playwright Browsers
+        if: steps.changes.outputs.has_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Build packages and auth-test-studio
+        if: steps.changes.outputs.has_changes == 'true'
+        run: pnpm build --filter=auth-test-studio...
+
+      - name: Run auth E2E tests
+        if: steps.changes.outputs.has_changes == 'true'
+        run: pnpm --filter e2e test:auth
+        env:
+          CI: "true"

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,4 +1,5 @@
 # Automated testing files
 /report
 /results
+/results-auth
 /blob-report

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -13,7 +13,8 @@
     "preview": "pnpm e2e:build && pnpm --filter studio-e2e-testing preview",
     "setup": "tsx -r dotenv-flow/config scripts/setup",
     "start": "pnpm --filter studio-e2e-testing preview",
-    "test": "playwright test"
+    "test": "playwright test",
+    "test:auth": "playwright test --config=playwright.auth.config.ts"
   },
   "devDependencies": {
     "@playwright/test": "catalog:",

--- a/e2e/playwright.auth.config.ts
+++ b/e2e/playwright.auth.config.ts
@@ -12,13 +12,19 @@ const PORT = 3340
  *   pnpm --filter auth-test-studio dev --port 3340
  *
  * CI: the webServer block auto-starts the preview server.
+ *
+ * NOTE: If running locally against the Vite dev server, page loads are much
+ * slower (~20s vs ~1s with the preview server). You may need to increase the
+ * timeouts below, or build and run the preview server instead:
+ *   pnpm build --filter=auth-test-studio...
+ *   pnpm --filter auth-test-studio start --port 3340
  */
 export default defineConfig({
   testDir: './tests/auth',
   timeout: 60_000,
   fullyParallel: true,
   expect: {
-    timeout: 30_000,
+    timeout: 10_000,
   },
   outputDir: './results-auth',
   retries: 1,

--- a/e2e/playwright.auth.config.ts
+++ b/e2e/playwright.auth.config.ts
@@ -1,0 +1,54 @@
+import {defineConfig, devices} from '@playwright/test'
+
+const CI = process.env.CI === 'true'
+const PORT = 3340
+
+/**
+ * Playwright config for auth-related e2e tests.
+ * Uses dev/auth-test-studio on port 3340 with cookie and token workspaces.
+ * Tests mock all auth APIs — no real credentials needed.
+ *
+ * Local dev: start the studio yourself first:
+ *   pnpm --filter auth-test-studio dev --port 3340
+ *
+ * CI: the webServer block auto-starts the preview server.
+ */
+export default defineConfig({
+  testDir: './tests/auth',
+  timeout: 60_000,
+  fullyParallel: true,
+  expect: {
+    timeout: 30_000,
+  },
+  outputDir: './results-auth',
+  retries: 1,
+  reporter: [['list']],
+  use: {
+    actionTimeout: 10_000,
+    trace: 'on-first-retry',
+    viewport: {width: 1728, height: 1000},
+    video: 'retain-on-failure',
+    baseURL: `http://localhost:${PORT}`,
+    headless: true,
+    contextOptions: {reducedMotion: 'reduce'},
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {...devices['Desktop Chrome']},
+    },
+  ],
+  // In local dev, the studio must already be running on the port.
+  // In CI, Playwright starts the preview server automatically.
+  ...(CI
+    ? {
+        webServer: {
+          command: `pnpm sanity preview --port ${PORT}`,
+          port: PORT,
+          cwd: '../dev/auth-test-studio',
+          reuseExistingServer: false,
+          stdout: 'pipe',
+        },
+      }
+    : {}),
+})

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -80,6 +80,9 @@ const FIREFOX_PROJECT: PlaywrightTestProject = {
 const playwrightConfig: PlaywrightTestConfig = {
   globalSetup: './globalSetup',
   testDir: TESTS_PATH,
+  // Auth tests use a separate config (playwright.auth.config.ts) with their own
+  // dev server on port 3340. Exclude them from the default config.
+  testIgnore: ['**/tests/auth/**'],
 
   /* Maximum time one test can run for. */
   timeout: 60_000,

--- a/e2e/tests/auth/README.md
+++ b/e2e/tests/auth/README.md
@@ -1,0 +1,123 @@
+# Auth cross-tab sync e2e tests
+
+These tests verify that authentication state (login/logout) syncs across browser tabs via BroadcastChannel, for both cookie and token auth modes.
+
+## Running the tests
+
+Start the auth test studio (keep it running):
+
+```bash
+pnpm --filter auth-test-studio dev --port 3340
+```
+
+Run all auth tests:
+
+```bash
+pnpm --filter e2e exec playwright test --config=playwright.auth.config.ts
+```
+
+Run a single test:
+
+```bash
+pnpm --filter e2e exec playwright test --config=playwright.auth.config.ts -g "Token auth.*login after logout" --retries=0 tests/auth/tokenAuth.spec.ts
+```
+
+Add `--headed` to watch the browser.
+
+## How the tests work
+
+All API responses are mocked via Playwright `page.route()` — no real credentials are needed. The mocks control when `/users/me` returns a user (authenticated) or 401 (unauthenticated).
+
+The token auth tests include a catch-all route that returns empty 200 responses for any unmocked Sanity API endpoint. This prevents the fake broadcast token from hitting real servers and triggering 401 errors on studio infrastructure endpoints (`/acl`, `/features`, `/projects`, etc.).
+
+## Manual verification
+
+To verify cross-tab auth sync manually with a real Sanity account:
+
+### Prerequisites
+
+1. Start the studio: `pnpm --filter auth-test-studio dev --port 3340`
+2. Open Chrome (or any browser)
+
+### Cookie auth (http://localhost:3340/cookie)
+
+#### Logout broadcasts to other tab
+
+1. Open `http://localhost:3340/cookie` in **Tab A** and log in
+2. Wait for the studio navbar to appear
+3. Open `http://localhost:3340/cookie` in **Tab B**
+4. Wait for the studio navbar to appear
+5. In **Tab A**: click the user menu (bottom-left avatar) then "Sign out"
+6. **Tab A** shows the login screen
+7. **Verify**: switch to **Tab B** — it should also show the login screen without refreshing
+
+#### Login broadcasts to other tab
+
+1. Continue from above (both tabs showing login screen)
+2. In **Tab A**: click a login provider and complete the OAuth flow
+3. **Tab A** shows the studio navbar
+4. **Verify**: switch to **Tab B** — it should also show the studio navbar without refreshing
+
+#### Single tab logout
+
+1. Open `http://localhost:3340/cookie` in one tab and log in
+2. Click user menu then "Sign out"
+3. **Verify**: the login screen appears
+
+### Token auth (http://localhost:3340/token)
+
+#### Logout broadcasts to other tab
+
+1. Open `http://localhost:3340/token` in **Tab A** and log in
+2. Wait for the studio navbar to appear
+3. Open `http://localhost:3340/token` in **Tab B**
+4. Wait for the studio navbar to appear
+5. In **Tab A**: click user menu then "Sign out"
+6. **Tab A** shows the login screen
+7. **Verify**: switch to **Tab B** — it should also show the login screen
+8. **Bonus**: DevTools > Application > Local Storage — `__studio_auth_token_*` should be cleared
+
+#### Login broadcasts to other tab
+
+1. Continue from above (both tabs showing login screen)
+2. In **Tab A**: click a login provider and complete the OAuth flow
+3. **Tab A** shows the studio navbar
+4. **Verify**: switch to **Tab B** — it should also show the studio navbar
+5. **Bonus**: check Local Storage — `__studio_auth_token_*` should have a token value
+
+#### Single tab logout
+
+1. Open `http://localhost:3340/token` in one tab and log in
+2. Click user menu then "Sign out"
+3. **Verify**: the login screen appears
+
+### SSO (http://localhost:3340/sso/cookie, /sso/token, /sso/redirect)
+
+The auth-test-studio includes SSO workspaces that replace the default providers with a single SAML provider. These require a real SSO provider URL configured in `dev/auth-test-studio/sanity.config.ts`.
+
+- `/sso-cookie` — SSO with cookie auth
+- `/sso-token` — SSO with token auth
+- `/sso-dual-redirectOnSingle` — SSO with `redirectOnSingle` (skips provider chooser, redirects straight to SSO)
+
+### Available workspaces
+
+| Path                           | Login method   | Notes                      |
+| ------------------------------ | -------------- | -------------------------- |
+| `/cookie`                      | cookie         | Used by e2e tests          |
+| `/token`                       | token          | Used by e2e tests          |
+| `/dual`                        | dual (default) | Cookie with token fallback |
+| `/cookie-redirectOnSingle`     | cookie         | Skips provider chooser     |
+| `/token-redirectOnSingle`      | token          | Skips provider chooser     |
+| `/dual-redirectOnSingle`       | dual           | Skips provider chooser     |
+| `/sso-cookie`                  | cookie         | Single SSO provider        |
+| `/sso-token`                   | token          | Single SSO provider        |
+| `/sso-dual`                    | dual           | Single SSO provider        |
+| `/sso-cookie-redirectOnSingle` | cookie         | SSO + redirectOnSingle     |
+| `/sso-token-redirectOnSingle`  | token          | SSO + redirectOnSingle     |
+| `/sso-dual-redirectOnSingle`   | dual           | SSO + redirectOnSingle     |
+
+### What to watch for
+
+- Cross-tab sync should happen within a few seconds with no refresh
+- If a tab doesn't update, check the browser console for errors
+- Token auth stores the token in localStorage; cookie auth relies on HTTP cookies. Both use BroadcastChannel for cross-tab notification

--- a/e2e/tests/auth/cookieAuth.spec.ts
+++ b/e2e/tests/auth/cookieAuth.spec.ts
@@ -21,14 +21,10 @@ test.describe('Cookie auth: cross-tab sync', () => {
 
     // Load tabs sequentially to avoid broadcast races during init
     await page1.goto(STUDIO_URL)
-    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible({
-      timeout: 30_000,
-    })
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
     await page2.goto(STUDIO_URL)
-    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible({
-      timeout: 30_000,
-    })
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
     // Switch both mocks to unauthenticated before triggering logout.
     // Both pages may re-check /users/me after receiving the BroadcastChannel
@@ -45,16 +41,12 @@ test.describe('Cookie auth: cross-tab sync', () => {
     // so we use a data-ui selector + text match instead of getByRole("heading")
     await expect(
       page1.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
-    ).toBeVisible({
-      timeout: 15_000,
-    })
+    ).toBeVisible()
 
     // Page2 should also show login screen via BroadcastChannel sync
     await expect(
       page2.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
-    ).toBeVisible({
-      timeout: 15_000,
-    })
+    ).toBeVisible()
   })
 
   test('login after logout syncs across tabs via BroadcastChannel', async ({context}) => {
@@ -63,17 +55,13 @@ test.describe('Cookie auth: cross-tab sync', () => {
 
     // 1. Load page1 first and wait for it to be fully authenticated
     await page1.goto(STUDIO_URL)
-    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible({
-      timeout: 30_000,
-    })
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
     // 2. Then load page2 — sequential to avoid broadcast race during init
     const page2 = await context.newPage()
     const page2Auth = await setupMockAuth(page2, {catchAll: true})
     await page2.goto(STUDIO_URL)
-    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible({
-      timeout: 30_000,
-    })
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
     // 3. Logout from page2
     page1Auth.logOut()
@@ -84,10 +72,10 @@ test.describe('Cookie auth: cross-tab sync', () => {
     // Both tabs should show the login screen
     await expect(
       page2.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
-    ).toBeVisible({timeout: 15_000})
+    ).toBeVisible()
     await expect(
       page1.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
-    ).toBeVisible({timeout: 15_000})
+    ).toBeVisible()
 
     // 4. Simulate login in page1 by navigating back to the studio.
     //    With cookie auth, the server sets the cookie during the provider redirect,
@@ -97,14 +85,10 @@ test.describe('Cookie auth: cross-tab sync', () => {
     await page1.goto(STUDIO_URL)
 
     // Page1 should be authenticated again (navbar visible)
-    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible({
-      timeout: 30_000,
-    })
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
     // Page2 should also become authenticated via BroadcastChannel sync
-    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible({
-      timeout: 30_000,
-    })
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible()
   })
 
   test('single tab logout shows login screen', async ({context}) => {
@@ -112,19 +96,15 @@ test.describe('Cookie auth: cross-tab sync', () => {
     await setupMockAuth(page, {catchAll: true})
 
     await page.goto(STUDIO_URL)
-    await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible({
-      timeout: 30_000,
-    })
+    await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
     // Open user menu and click "Sign out"
     await page.locator('[id="user-menu"]').click()
     await page.getByText('Sign out').click()
 
     // Should show the login screen
-    await expect(page.locator('[data-ui="Heading"]:has-text("Choose login provider")')).toBeVisible(
-      {
-        timeout: 15_000,
-      },
-    )
+    await expect(
+      page.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible()
   })
 })

--- a/e2e/tests/auth/cookieAuth.spec.ts
+++ b/e2e/tests/auth/cookieAuth.spec.ts
@@ -1,0 +1,130 @@
+// eslint-disable-next-line no-restricted-imports -- auth tests use raw Playwright (no studio-test fixtures)
+import {expect, test} from '@playwright/test'
+
+import {watchForStudioErrors} from '../../helpers/studioErrors'
+import {BASE_URL, setupMockAuth} from './helpers'
+
+const STUDIO_URL = `${BASE_URL}/cookie`
+
+test.describe('Cookie auth: cross-tab sync', () => {
+  test.beforeEach(async ({context}) => {
+    watchForStudioErrors(context)
+  })
+
+  test('logout in one tab reflects in another tab via BroadcastChannel', async ({context}) => {
+    const page1 = await context.newPage()
+    const page2 = await context.newPage()
+
+    // Set up authenticated mocks for both pages
+    const page1Auth = await setupMockAuth(page1, {catchAll: true})
+    const page2Auth = await setupMockAuth(page2, {catchAll: true})
+
+    // Load tabs sequentially to avoid broadcast races during init
+    await page1.goto(STUDIO_URL)
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    await page2.goto(STUDIO_URL)
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    // Switch both mocks to unauthenticated before triggering logout.
+    // Both pages may re-check /users/me after receiving the BroadcastChannel
+    // message, so both mocks must return 401.
+    page1Auth.logOut()
+    page2Auth.logOut()
+
+    // In page1: open user menu and click "Sign out"
+    await page1.locator('[id="user-menu"]').click()
+    await page1.getByText('Sign out').click()
+
+    // Page1 should show the login screen
+    // Note: Sanity UI's <Heading> renders as a <div>, not an <h1>–<h6>,
+    // so we use a data-ui selector + text match instead of getByRole("heading")
+    await expect(
+      page1.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible({
+      timeout: 15_000,
+    })
+
+    // Page2 should also show login screen via BroadcastChannel sync
+    await expect(
+      page2.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible({
+      timeout: 15_000,
+    })
+  })
+
+  test('login after logout syncs across tabs via BroadcastChannel', async ({context}) => {
+    const page1 = await context.newPage()
+    const page1Auth = await setupMockAuth(page1, {catchAll: true})
+
+    // 1. Load page1 first and wait for it to be fully authenticated
+    await page1.goto(STUDIO_URL)
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    // 2. Then load page2 — sequential to avoid broadcast race during init
+    const page2 = await context.newPage()
+    const page2Auth = await setupMockAuth(page2, {catchAll: true})
+    await page2.goto(STUDIO_URL)
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    // 3. Logout from page2
+    page1Auth.logOut()
+    page2Auth.logOut()
+    await page2.locator('[id="user-menu"]').click()
+    await page2.getByText('Sign out').click()
+
+    // Both tabs should show the login screen
+    await expect(
+      page2.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible({timeout: 15_000})
+    await expect(
+      page1.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible({timeout: 15_000})
+
+    // 4. Simulate login in page1 by navigating back to the studio.
+    //    With cookie auth, the server sets the cookie during the provider redirect,
+    //    so the studio loads fresh and /users/me returns the authenticated user.
+    page1Auth.logIn()
+    page2Auth.logIn()
+    await page1.goto(STUDIO_URL)
+
+    // Page1 should be authenticated again (navbar visible)
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    // Page2 should also become authenticated via BroadcastChannel sync
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible({
+      timeout: 30_000,
+    })
+  })
+
+  test('single tab logout shows login screen', async ({context}) => {
+    const page = await context.newPage()
+    await setupMockAuth(page, {catchAll: true})
+
+    await page.goto(STUDIO_URL)
+    await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    // Open user menu and click "Sign out"
+    await page.locator('[id="user-menu"]').click()
+    await page.getByText('Sign out').click()
+
+    // Should show the login screen
+    await expect(page.locator('[data-ui="Heading"]:has-text("Choose login provider")')).toBeVisible(
+      {
+        timeout: 15_000,
+      },
+    )
+  })
+})

--- a/e2e/tests/auth/dualAuth.spec.ts
+++ b/e2e/tests/auth/dualAuth.spec.ts
@@ -1,0 +1,93 @@
+// eslint-disable-next-line no-restricted-imports -- auth tests use raw Playwright (no studio-test fixtures)
+import {expect, test} from '@playwright/test'
+
+import {watchForStudioErrors} from '../../helpers/studioErrors'
+import {BASE_URL, setupMockAuth} from './helpers'
+
+// Dual auth (loginMethod: 'dual') tries cookie first, falls back to token.
+// The auth store uses withCredentials (cookies) when available, and stores
+// a token in localStorage as fallback.
+const STUDIO_URL = `${BASE_URL}/dual`
+
+test.describe('Dual auth: cross-tab sync', () => {
+  test.beforeEach(async ({context}) => {
+    watchForStudioErrors(context)
+  })
+
+  test('logout in one tab reflects in another tab via BroadcastChannel', async ({context}) => {
+    const page1 = await context.newPage()
+    const page2 = await context.newPage()
+
+    const page1Auth = await setupMockAuth(page1, {catchAll: true})
+    const page2Auth = await setupMockAuth(page2, {catchAll: true})
+
+    await page1.goto(STUDIO_URL)
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+
+    await page2.goto(STUDIO_URL)
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+
+    page1Auth.logOut()
+    page2Auth.logOut()
+
+    await page1.locator('[id="user-menu"]').click()
+    await page1.getByText('Sign out').click()
+
+    await expect(
+      page1.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible({timeout: 15_000})
+
+    await expect(
+      page2.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible({timeout: 15_000})
+  })
+
+  test('login after logout syncs across tabs via BroadcastChannel', async ({context}) => {
+    const page1 = await context.newPage()
+    const page1Auth = await setupMockAuth(page1, {catchAll: true})
+
+    await page1.goto(STUDIO_URL)
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+
+    const page2 = await context.newPage()
+    const page2Auth = await setupMockAuth(page2, {catchAll: true})
+    await page2.goto(STUDIO_URL)
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+
+    // Logout from page2
+    page1Auth.logOut()
+    page2Auth.logOut()
+    await page2.locator('[id="user-menu"]').click()
+    await page2.getByText('Sign out').click()
+
+    await expect(
+      page2.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible({timeout: 15_000})
+    await expect(
+      page1.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible({timeout: 15_000})
+
+    // Simulate login by navigating back (cookie auth flow)
+    page1Auth.logIn()
+    page2Auth.logIn()
+    await page1.goto(STUDIO_URL)
+
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+  })
+
+  test('single tab logout shows login screen', async ({context}) => {
+    const page = await context.newPage()
+    await setupMockAuth(page, {catchAll: true})
+
+    await page.goto(STUDIO_URL)
+    await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+
+    await page.locator('[id="user-menu"]').click()
+    await page.getByText('Sign out').click()
+
+    await expect(page.locator('[data-ui="Heading"]:has-text("Choose login provider")')).toBeVisible(
+      {timeout: 15_000},
+    )
+  })
+})

--- a/e2e/tests/auth/dualAuth.spec.ts
+++ b/e2e/tests/auth/dualAuth.spec.ts
@@ -22,10 +22,10 @@ test.describe('Dual auth: cross-tab sync', () => {
     const page2Auth = await setupMockAuth(page2, {catchAll: true})
 
     await page1.goto(STUDIO_URL)
-    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
     await page2.goto(STUDIO_URL)
-    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
     page1Auth.logOut()
     page2Auth.logOut()
@@ -35,11 +35,11 @@ test.describe('Dual auth: cross-tab sync', () => {
 
     await expect(
       page1.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
-    ).toBeVisible({timeout: 15_000})
+    ).toBeVisible()
 
     await expect(
       page2.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
-    ).toBeVisible({timeout: 15_000})
+    ).toBeVisible()
   })
 
   test('login after logout syncs across tabs via BroadcastChannel', async ({context}) => {
@@ -47,12 +47,12 @@ test.describe('Dual auth: cross-tab sync', () => {
     const page1Auth = await setupMockAuth(page1, {catchAll: true})
 
     await page1.goto(STUDIO_URL)
-    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
     const page2 = await context.newPage()
     const page2Auth = await setupMockAuth(page2, {catchAll: true})
     await page2.goto(STUDIO_URL)
-    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
     // Logout from page2
     page1Auth.logOut()
@@ -62,18 +62,18 @@ test.describe('Dual auth: cross-tab sync', () => {
 
     await expect(
       page2.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
-    ).toBeVisible({timeout: 15_000})
+    ).toBeVisible()
     await expect(
       page1.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
-    ).toBeVisible({timeout: 15_000})
+    ).toBeVisible()
 
     // Simulate login by navigating back (cookie auth flow)
     page1Auth.logIn()
     page2Auth.logIn()
     await page1.goto(STUDIO_URL)
 
-    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
-    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible()
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible()
   })
 
   test('single tab logout shows login screen', async ({context}) => {
@@ -81,13 +81,13 @@ test.describe('Dual auth: cross-tab sync', () => {
     await setupMockAuth(page, {catchAll: true})
 
     await page.goto(STUDIO_URL)
-    await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+    await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
     await page.locator('[id="user-menu"]').click()
     await page.getByText('Sign out').click()
 
-    await expect(page.locator('[data-ui="Heading"]:has-text("Choose login provider")')).toBeVisible(
-      {timeout: 15_000},
-    )
+    await expect(
+      page.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible()
   })
 })

--- a/e2e/tests/auth/dualAuth.spec.ts
+++ b/e2e/tests/auth/dualAuth.spec.ts
@@ -2,14 +2,32 @@
 import {expect, test} from '@playwright/test'
 
 import {watchForStudioErrors} from '../../helpers/studioErrors'
-import {BASE_URL, setupMockAuth} from './helpers'
+import {BASE_URL, MOCK_TOKEN, PROJECT_ID, setupMockAuth} from './helpers'
 
 // Dual auth (loginMethod: 'dual') tries cookie first, falls back to token.
 // The auth store uses withCredentials (cookies) when available, and stores
 // a token in localStorage as fallback.
 const STUDIO_URL = `${BASE_URL}/dual`
+const TOKEN_STORAGE_KEY = `__studio_auth_token_${PROJECT_ID}`
 
-test.describe('Dual auth: cross-tab sync', () => {
+/**
+ * Seed localStorage with a mock token before navigation.
+ * Used for the token-fallback tests where cookie auth fails.
+ */
+async function seedToken(page: import('@playwright/test').Page) {
+  await page.addInitScript(
+    ({key, token}) => {
+      localStorage.setItem(key, JSON.stringify({token}))
+    },
+    {key: TOKEN_STORAGE_KEY, token: MOCK_TOKEN},
+  )
+}
+
+// ── Cookie-first path (default dual behavior) ──────────────────────────────
+// cookieProbeSucceeds defaults to true, so these exercise the same path as
+// cookie auth — the auth store uses withCredentials and never touches tokens.
+
+test.describe('Dual auth (cookie path): cross-tab sync', () => {
   test.beforeEach(async ({context}) => {
     watchForStudioErrors(context)
   })
@@ -79,6 +97,103 @@ test.describe('Dual auth: cross-tab sync', () => {
   test('single tab logout shows login screen', async ({context}) => {
     const page = await context.newPage()
     await setupMockAuth(page, {catchAll: true})
+
+    await page.goto(STUDIO_URL)
+    await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible()
+
+    await page.locator('[id="user-menu"]').click()
+    await page.getByText('Sign out').click()
+
+    await expect(
+      page.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible()
+  })
+})
+
+// ── Token-fallback path ─────────────────────────────────────────────────────
+// When cookie auth fails (cookieProbeSucceeds: false), dual mode falls back to
+// token-based auth. The auth store reads the token from localStorage and uses
+// it in the Authorization header instead of withCredentials.
+
+test.describe('Dual auth (token fallback): cross-tab sync', () => {
+  test.beforeEach(async ({context}) => {
+    watchForStudioErrors(context)
+  })
+
+  test('logout in one tab reflects in another tab via BroadcastChannel', async ({context}) => {
+    const page1 = await context.newPage()
+    const page2 = await context.newPage()
+
+    const page1Auth = await setupMockAuth(page1, {cookieProbeSucceeds: false, catchAll: true})
+    const page2Auth = await setupMockAuth(page2, {cookieProbeSucceeds: false, catchAll: true})
+
+    await seedToken(page1)
+    await seedToken(page2)
+
+    await page1.goto(STUDIO_URL)
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible()
+
+    await page2.goto(STUDIO_URL)
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible()
+
+    page1Auth.logOut()
+    page2Auth.logOut()
+
+    await page1.locator('[id="user-menu"]').click()
+    await page1.getByText('Sign out').click()
+
+    await expect(
+      page1.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible()
+
+    await expect(
+      page2.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible()
+  })
+
+  test('login after logout syncs across tabs via BroadcastChannel', async ({context}) => {
+    const page1 = await context.newPage()
+    const page1Auth = await setupMockAuth(page1, {cookieProbeSucceeds: false, catchAll: true})
+    await seedToken(page1)
+
+    await page1.goto(STUDIO_URL)
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible()
+
+    const page2 = await context.newPage()
+    const page2Auth = await setupMockAuth(page2, {cookieProbeSucceeds: false, catchAll: true})
+    await seedToken(page2)
+    await page2.goto(STUDIO_URL)
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible()
+
+    // Logout from page2
+    page1Auth.logOut()
+    page2Auth.logOut()
+    await page2.locator('[id="user-menu"]').click()
+    await page2.getByText('Sign out').click()
+
+    await expect(
+      page2.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible()
+    await expect(
+      page1.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible()
+
+    // Simulate login via token exchange: navigate with #sid=<session-id>.
+    // The auth store exchanges the SID for a token via GET /auth/fetch?sid=...,
+    // stores the token in localStorage, and broadcasts it to other tabs.
+    page1Auth.logIn()
+    page2Auth.logIn()
+
+    await page1.goto(`${STUDIO_URL}#sid=mock-session-id-12345678`)
+
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible()
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible()
+  })
+
+  test('single tab logout shows login screen', async ({context}) => {
+    const page = await context.newPage()
+    await setupMockAuth(page, {cookieProbeSucceeds: false, catchAll: true})
+    await seedToken(page)
 
     await page.goto(STUDIO_URL)
     await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible()

--- a/e2e/tests/auth/helpers.ts
+++ b/e2e/tests/auth/helpers.ts
@@ -1,0 +1,144 @@
+import {type Page, type Route} from '@playwright/test'
+
+export const PROJECT_ID = 'ppsg7ml5'
+
+// Base URL for the auth-test-studio workspaces.
+// With multiple envs, paths are prefixed with the project ID.
+export const BASE_URL = `http://localhost:3340/${PROJECT_ID}`
+
+export const MOCK_USER = {
+  id: 'mock-user-123',
+  name: 'Test User',
+  email: 'test@example.com',
+  profileImage: '',
+  provider: 'google',
+  role: '',
+  roles: [{name: 'administrator', title: 'Administrator'}],
+}
+
+export const MOCK_PROVIDERS = {
+  providers: [
+    {
+      name: 'google',
+      title: 'Google',
+      url: 'https://api.sanity.io/v1/auth/login/google',
+      logo: null,
+    },
+  ],
+  thirdPartyLogin: true,
+}
+
+export const MOCK_TOKEN = 'mock-token-abc123'
+
+export const MOCK_AUTH_PROBE = {
+  id: 'mock-user-123',
+  expiry: Math.floor(Date.now() / 1000) + 3600,
+}
+
+export interface MockAuth {
+  logOut(): void
+  logIn(): void
+}
+
+/**
+ * Set up route mocks for all Sanity API endpoints.
+ *
+ * Options:
+ * - `cookieProbeSucceeds`: if true, /auth/id returns 200 (cookie auth works).
+ *   If false, returns 401 (forces token fallback). Default: true.
+ * - `catchAll`: if true, register a catch-all route returning empty 200 for
+ *   any unmocked Sanity API request. Needed for token/dual auth where a fake
+ *   token would otherwise hit real servers and trigger 401s. Default: false.
+ */
+export async function setupMockAuth(
+  page: Page,
+  options: {cookieProbeSucceeds?: boolean; catchAll?: boolean} = {},
+): Promise<MockAuth> {
+  const {cookieProbeSucceeds = true, catchAll = false} = options
+  let authenticated = true
+
+  if (catchAll) {
+    const emptyOk = (route: Route) =>
+      route.fulfill({status: 200, contentType: 'application/json', body: '[]'})
+    await page.route('**/*.api.sanity.io/**', emptyOk)
+    await page.route('**/api.sanity.io/**', emptyOk)
+  }
+
+  await page.route('**/users/me*', (route) => {
+    if (authenticated) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_USER),
+      })
+    }
+    // Return 200 with an empty object (no `id` field) instead of 401.
+    // A 401 triggers getCurrentUser's error handler which calls broadcast(null),
+    // re-triggering the state$ pipeline and causing an infinite loop
+    // (401 → broadcast → new client → getCurrentUser → 401 → …).
+    // Returning an empty object makes getCurrentUser return null (unauthenticated)
+    // without triggering the broadcast loop.
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    })
+  })
+
+  await page.route('**/auth/providers*', (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_PROVIDERS),
+    })
+  })
+
+  await page.route('**/auth/id*', (route) => {
+    if (cookieProbeSucceeds && authenticated) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_AUTH_PROBE),
+      })
+    }
+    return route.fulfill({
+      status: 401,
+      contentType: 'application/json',
+      body: JSON.stringify({statusCode: 401, error: 'Unauthorized', message: 'Not authenticated'}),
+    })
+  })
+
+  await page.route('**/auth/fetch*', (route) => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({token: MOCK_TOKEN}),
+    })
+  })
+
+  await page.route('**/auth/logout*', (route) => {
+    authenticated = false
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ok: true}),
+    })
+  })
+
+  await page.route('**/journey/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: 'null',
+    }),
+  )
+
+  return {
+    logOut() {
+      authenticated = false
+    },
+    logIn() {
+      authenticated = true
+    },
+  }
+}

--- a/e2e/tests/auth/redirectOnSingle.spec.ts
+++ b/e2e/tests/auth/redirectOnSingle.spec.ts
@@ -1,0 +1,86 @@
+// eslint-disable-next-line no-restricted-imports -- auth tests use raw Playwright (no studio-test fixtures)
+import {expect, test} from '@playwright/test'
+
+import {watchForStudioErrors} from '../../helpers/studioErrors'
+import {BASE_URL, setupMockAuth} from './helpers'
+
+// These workspaces have redirectOnSingle: true with a single provider (GitHub).
+// When unauthenticated, the studio should redirect directly to the provider URL
+// instead of showing the "Choose login provider" screen.
+//
+// The redirect uses window.location.href, which triggers a full page navigation
+// to the auth provider. We detect this by waiting for the URL to change.
+
+test.describe('redirectOnSingle', () => {
+  test.beforeEach(async ({context}) => {
+    watchForStudioErrors(context)
+  })
+
+  for (const {name, path} of [
+    {name: 'cookie', path: 'cookie-redirectOnSingle'},
+    {name: 'token', path: 'token-redirectOnSingle'},
+    {name: 'dual', path: 'dual-redirectOnSingle'},
+  ]) {
+    test(`${name} auth: skips provider chooser and redirects to provider`, async ({context}) => {
+      const page = await context.newPage()
+      const mock = await setupMockAuth(page, {catchAll: true})
+      mock.logOut()
+
+      await page.goto(`${BASE_URL}/${path}`)
+
+      // The studio should redirect to the GitHub auth URL (the only provider).
+      await page.waitForURL('**/auth/login/github*', {timeout: 15_000})
+    })
+  }
+
+  for (const {name, path} of [
+    {name: 'cookie', path: 'cookie'},
+    {name: 'token', path: 'token'},
+    {name: 'dual', path: 'dual'},
+  ]) {
+    test(`${name} auth: without redirectOnSingle shows provider chooser`, async ({context}) => {
+      const page = await context.newPage()
+      const mock = await setupMockAuth(page, {catchAll: true})
+      mock.logOut()
+
+      await page.goto(`${BASE_URL}/${path}`)
+
+      await expect(
+        page.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+      ).toBeVisible({timeout: 15_000})
+    })
+  }
+
+  // FIXME: after logout, redirectOnSingle should NOT redirect to the auth provider.
+  // Redirecting after logout effectively logs the user back in, which defeats the
+  // purpose of logging out (e.g. to switch accounts). The login screen should be
+  // shown instead. Currently the LoginComponent always redirects when
+  // redirectOnSingle is true and there's only one provider.
+  for (const {name, path} of [
+    {name: 'cookie', path: 'cookie-redirectOnSingle'},
+    {name: 'token', path: 'token-redirectOnSingle'},
+    {name: 'dual', path: 'dual-redirectOnSingle'},
+  ]) {
+    test.fixme(`${name} auth: logout with redirectOnSingle shows login screen instead of redirecting`, async ({
+      context,
+    }) => {
+      const page = await context.newPage()
+      const mock = await setupMockAuth(page, {catchAll: true})
+
+      await page.goto(`${BASE_URL}/${path}`)
+      await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+
+      mock.logOut()
+      await page.locator('[id="user-menu"]').click()
+      await page.getByText('Sign out').click()
+
+      // After logout, the login screen should appear — NOT a redirect to the provider.
+      await expect(
+        page.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+      ).toBeVisible({timeout: 15_000})
+
+      // Verify the URL stayed on localhost (no redirect to auth provider)
+      expect(page.url()).toContain('localhost:3340')
+    })
+  }
+})

--- a/e2e/tests/auth/redirectOnSingle.spec.ts
+++ b/e2e/tests/auth/redirectOnSingle.spec.ts
@@ -29,7 +29,7 @@ test.describe('redirectOnSingle', () => {
       await page.goto(`${BASE_URL}/${path}`)
 
       // The studio should redirect to the GitHub auth URL (the only provider).
-      await page.waitForURL('**/auth/login/github*', {timeout: 15_000})
+      await page.waitForURL('**/auth/login/github*')
     })
   }
 
@@ -47,7 +47,7 @@ test.describe('redirectOnSingle', () => {
 
       await expect(
         page.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
-      ).toBeVisible({timeout: 15_000})
+      ).toBeVisible()
     })
   }
 
@@ -68,7 +68,7 @@ test.describe('redirectOnSingle', () => {
       const mock = await setupMockAuth(page, {catchAll: true})
 
       await page.goto(`${BASE_URL}/${path}`)
-      await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+      await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
       mock.logOut()
       await page.locator('[id="user-menu"]').click()
@@ -77,7 +77,7 @@ test.describe('redirectOnSingle', () => {
       // After logout, the login screen should appear — NOT a redirect to the provider.
       await expect(
         page.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
-      ).toBeVisible({timeout: 15_000})
+      ).toBeVisible()
 
       // Verify the URL stayed on localhost (no redirect to auth provider)
       expect(page.url()).toContain('localhost:3340')

--- a/e2e/tests/auth/smoke.spec.ts
+++ b/e2e/tests/auth/smoke.spec.ts
@@ -13,7 +13,7 @@ test.describe('Auth smoke test', () => {
     const page = await context.newPage()
     await setupMockAuth(page, {catchAll: true})
     await page.goto(`${BASE_URL}/cookie`)
-    await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+    await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible()
   })
 
   test('single tab logout shows login screen', async ({context}) => {
@@ -21,14 +21,14 @@ test.describe('Auth smoke test', () => {
     const mock = await setupMockAuth(page, {catchAll: true})
 
     await page.goto(`${BASE_URL}/cookie`)
-    await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+    await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
     mock.logOut()
     await page.locator('[id="user-menu"]').click()
     await page.getByText('Sign out').click()
 
-    await expect(page.locator('[data-ui="Heading"]:has-text("Choose login provider")')).toBeVisible(
-      {timeout: 15_000},
-    )
+    await expect(
+      page.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible()
   })
 })

--- a/e2e/tests/auth/smoke.spec.ts
+++ b/e2e/tests/auth/smoke.spec.ts
@@ -1,0 +1,34 @@
+// eslint-disable-next-line no-restricted-imports -- auth tests use raw Playwright (no studio-test fixtures)
+import {expect, test} from '@playwright/test'
+
+import {watchForStudioErrors} from '../../helpers/studioErrors'
+import {BASE_URL, setupMockAuth} from './helpers'
+
+test.describe('Auth smoke test', () => {
+  test.beforeEach(async ({context}) => {
+    watchForStudioErrors(context)
+  })
+
+  test('studio loads with mocked auth', async ({context}) => {
+    const page = await context.newPage()
+    await setupMockAuth(page, {catchAll: true})
+    await page.goto(`${BASE_URL}/cookie`)
+    await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+  })
+
+  test('single tab logout shows login screen', async ({context}) => {
+    const page = await context.newPage()
+    const mock = await setupMockAuth(page, {catchAll: true})
+
+    await page.goto(`${BASE_URL}/cookie`)
+    await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible({timeout: 30_000})
+
+    mock.logOut()
+    await page.locator('[id="user-menu"]').click()
+    await page.getByText('Sign out').click()
+
+    await expect(page.locator('[data-ui="Heading"]:has-text("Choose login provider")')).toBeVisible(
+      {timeout: 15_000},
+    )
+  })
+})

--- a/e2e/tests/auth/sso.spec.ts
+++ b/e2e/tests/auth/sso.spec.ts
@@ -26,7 +26,7 @@ test.describe('SSO', () => {
       await page.goto(`${BASE_URL}/${path}`)
 
       // The login screen should show the SAML provider button
-      await expect(page.locator('text=saml')).toBeVisible({timeout: 15_000})
+      await expect(page.locator('text=saml')).toBeVisible()
     })
   }
 
@@ -43,7 +43,7 @@ test.describe('SSO', () => {
       await page.goto(`${BASE_URL}/${path}`)
 
       // Should redirect directly to the SAML SSO login URL
-      await page.waitForURL('**/auth/saml/login/**', {timeout: 15_000})
+      await page.waitForURL('**/auth/saml/login/**')
     })
   }
 })

--- a/e2e/tests/auth/sso.spec.ts
+++ b/e2e/tests/auth/sso.spec.ts
@@ -1,0 +1,49 @@
+// eslint-disable-next-line no-restricted-imports -- auth tests use raw Playwright (no studio-test fixtures)
+import {expect, test} from '@playwright/test'
+
+import {watchForStudioErrors} from '../../helpers/studioErrors'
+import {BASE_URL, setupMockAuth} from './helpers'
+
+// SSO workspaces use createAuthStore with a single SAML provider replacing
+// the default providers. When unauthenticated, the login screen should show
+// the SAML provider button. With redirectOnSingle, it should redirect directly.
+
+test.describe('SSO', () => {
+  test.beforeEach(async ({context}) => {
+    watchForStudioErrors(context)
+  })
+
+  for (const {name, path} of [
+    {name: 'cookie', path: 'sso-cookie'},
+    {name: 'token', path: 'sso-token'},
+    {name: 'dual', path: 'sso-dual'},
+  ]) {
+    test(`${name} auth: shows SSO provider in login screen`, async ({context}) => {
+      const page = await context.newPage()
+      const mock = await setupMockAuth(page, {catchAll: true})
+      mock.logOut()
+
+      await page.goto(`${BASE_URL}/${path}`)
+
+      // The login screen should show the SAML provider button
+      await expect(page.locator('text=saml')).toBeVisible({timeout: 15_000})
+    })
+  }
+
+  for (const {name, path} of [
+    {name: 'cookie', path: 'sso-cookie-redirectOnSingle'},
+    {name: 'token', path: 'sso-token-redirectOnSingle'},
+    {name: 'dual', path: 'sso-dual-redirectOnSingle'},
+  ]) {
+    test(`${name} auth: SSO + redirectOnSingle redirects to SAML provider`, async ({context}) => {
+      const page = await context.newPage()
+      const mock = await setupMockAuth(page, {catchAll: true})
+      mock.logOut()
+
+      await page.goto(`${BASE_URL}/${path}`)
+
+      // Should redirect directly to the SAML SSO login URL
+      await page.waitForURL('**/auth/saml/login/**', {timeout: 15_000})
+    })
+  }
+})

--- a/e2e/tests/auth/tokenAuth.spec.ts
+++ b/e2e/tests/auth/tokenAuth.spec.ts
@@ -1,0 +1,152 @@
+// eslint-disable-next-line no-restricted-imports -- auth tests use raw Playwright (no studio-test fixtures)
+import {expect, test} from '@playwright/test'
+
+import {watchForStudioErrors} from '../../helpers/studioErrors'
+import {BASE_URL, MOCK_TOKEN, PROJECT_ID, setupMockAuth} from './helpers'
+
+const STUDIO_URL = `${BASE_URL}/token`
+const TOKEN_STORAGE_KEY = `__studio_auth_token_${PROJECT_ID}`
+
+/**
+ * Seed localStorage with a mock token before navigation.
+ * The auth store reads from localStorage on init when loginMethod is 'token'.
+ */
+async function seedToken(page: import('@playwright/test').Page) {
+  await page.addInitScript(
+    ({key, token}) => {
+      localStorage.setItem(key, JSON.stringify({token}))
+    },
+    {key: TOKEN_STORAGE_KEY, token: MOCK_TOKEN},
+  )
+}
+
+test.describe('Token auth: cross-tab sync', () => {
+  test.beforeEach(async ({context}) => {
+    watchForStudioErrors(context)
+  })
+
+  test('logout in one tab reflects in another tab via BroadcastChannel', async ({context}) => {
+    const page1 = await context.newPage()
+    const page2 = await context.newPage()
+
+    // Set up authenticated mocks for both pages
+    const page1Auth = await setupMockAuth(page1, {cookieProbeSucceeds: false, catchAll: true})
+    const page2Auth = await setupMockAuth(page2, {cookieProbeSucceeds: false, catchAll: true})
+
+    // Seed token in localStorage so both pages start authenticated
+    await seedToken(page1)
+    await seedToken(page2)
+
+    // Load tabs sequentially to avoid broadcast races during init
+    await page1.goto(STUDIO_URL)
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    await page2.goto(STUDIO_URL)
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    // Switch both mocks to unauthenticated before triggering logout.
+    // Both pages may re-check /users/me after receiving the BroadcastChannel
+    // message, so both mocks must return 401.
+    page1Auth.logOut()
+    page2Auth.logOut()
+
+    // In page1: open user menu and click "Sign out"
+    await page1.locator('[id="user-menu"]').click()
+    await page1.getByText('Sign out').click()
+
+    // Page1 should show the login screen
+    await expect(
+      page1.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible({
+      timeout: 15_000,
+    })
+
+    // Page2 should also show login screen via BroadcastChannel sync
+    await expect(
+      page2.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible({
+      timeout: 15_000,
+    })
+  })
+
+  test('login after logout syncs across tabs via BroadcastChannel', async ({context}) => {
+    const page1 = await context.newPage()
+    const page1Auth = await setupMockAuth(page1, {cookieProbeSucceeds: false, catchAll: true})
+    await seedToken(page1)
+
+    // 1. Load page1 first and wait for it to be fully authenticated
+    await page1.goto(STUDIO_URL)
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    // 2. Then load page2 — sequential to avoid broadcast race during init
+    const page2 = await context.newPage()
+    const page2Auth = await setupMockAuth(page2, {cookieProbeSucceeds: false, catchAll: true})
+    await seedToken(page2)
+    await page2.goto(STUDIO_URL)
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    // 3. Logout from page2
+    page1Auth.logOut()
+    page2Auth.logOut()
+    await page2.locator('[id="user-menu"]').click()
+    await page2.getByText('Sign out').click()
+
+    // Both tabs should show the login screen
+    await expect(
+      page2.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible({timeout: 15_000})
+    await expect(
+      page1.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible({timeout: 15_000})
+
+    // 4. Simulate login in page1 by navigating with #sid=<session-id>.
+    //    For token auth, the auth store:
+    //    a) Exchanges the SID for a token via GET /auth/fetch?sid=...
+    //    b) Stores the token in localStorage via tokenStorage.update({token})
+    //    c) Broadcasts the new token to other tabs via BroadcastChannel
+    page1Auth.logIn()
+    page2Auth.logIn()
+
+    await page1.goto(`${STUDIO_URL}#sid=mock-session-id-12345678`)
+
+    // Page1 should be authenticated again (navbar visible)
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    // Page2 should also become authenticated via BroadcastChannel sync
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible({
+      timeout: 30_000,
+    })
+  })
+
+  test('single tab logout shows login screen', async ({context}) => {
+    const page = await context.newPage()
+    await setupMockAuth(page, {cookieProbeSucceeds: false, catchAll: true})
+    await seedToken(page)
+
+    await page.goto(STUDIO_URL)
+    await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible({
+      timeout: 30_000,
+    })
+
+    // Open user menu and click "Sign out"
+    await page.locator('[id="user-menu"]').click()
+    await page.getByText('Sign out').click()
+
+    // Should show the login screen
+    await expect(page.locator('[data-ui="Heading"]:has-text("Choose login provider")')).toBeVisible(
+      {
+        timeout: 15_000,
+      },
+    )
+  })
+})

--- a/e2e/tests/auth/tokenAuth.spec.ts
+++ b/e2e/tests/auth/tokenAuth.spec.ts
@@ -39,14 +39,10 @@ test.describe('Token auth: cross-tab sync', () => {
 
     // Load tabs sequentially to avoid broadcast races during init
     await page1.goto(STUDIO_URL)
-    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible({
-      timeout: 30_000,
-    })
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
     await page2.goto(STUDIO_URL)
-    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible({
-      timeout: 30_000,
-    })
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
     // Switch both mocks to unauthenticated before triggering logout.
     // Both pages may re-check /users/me after receiving the BroadcastChannel
@@ -61,16 +57,12 @@ test.describe('Token auth: cross-tab sync', () => {
     // Page1 should show the login screen
     await expect(
       page1.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
-    ).toBeVisible({
-      timeout: 15_000,
-    })
+    ).toBeVisible()
 
     // Page2 should also show login screen via BroadcastChannel sync
     await expect(
       page2.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
-    ).toBeVisible({
-      timeout: 15_000,
-    })
+    ).toBeVisible()
   })
 
   test('login after logout syncs across tabs via BroadcastChannel', async ({context}) => {
@@ -80,18 +72,14 @@ test.describe('Token auth: cross-tab sync', () => {
 
     // 1. Load page1 first and wait for it to be fully authenticated
     await page1.goto(STUDIO_URL)
-    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible({
-      timeout: 30_000,
-    })
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
     // 2. Then load page2 — sequential to avoid broadcast race during init
     const page2 = await context.newPage()
     const page2Auth = await setupMockAuth(page2, {cookieProbeSucceeds: false, catchAll: true})
     await seedToken(page2)
     await page2.goto(STUDIO_URL)
-    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible({
-      timeout: 30_000,
-    })
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
     // 3. Logout from page2
     page1Auth.logOut()
@@ -102,10 +90,10 @@ test.describe('Token auth: cross-tab sync', () => {
     // Both tabs should show the login screen
     await expect(
       page2.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
-    ).toBeVisible({timeout: 15_000})
+    ).toBeVisible()
     await expect(
       page1.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
-    ).toBeVisible({timeout: 15_000})
+    ).toBeVisible()
 
     // 4. Simulate login in page1 by navigating with #sid=<session-id>.
     //    For token auth, the auth store:
@@ -118,14 +106,10 @@ test.describe('Token auth: cross-tab sync', () => {
     await page1.goto(`${STUDIO_URL}#sid=mock-session-id-12345678`)
 
     // Page1 should be authenticated again (navbar visible)
-    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible({
-      timeout: 30_000,
-    })
+    await expect(page1.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
     // Page2 should also become authenticated via BroadcastChannel sync
-    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible({
-      timeout: 30_000,
-    })
+    await expect(page2.locator('[data-testid="studio-navbar"]')).toBeVisible()
   })
 
   test('single tab logout shows login screen', async ({context}) => {
@@ -134,19 +118,15 @@ test.describe('Token auth: cross-tab sync', () => {
     await seedToken(page)
 
     await page.goto(STUDIO_URL)
-    await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible({
-      timeout: 30_000,
-    })
+    await expect(page.locator('[data-testid="studio-navbar"]')).toBeVisible()
 
     // Open user menu and click "Sign out"
     await page.locator('[id="user-menu"]').click()
     await page.getByText('Sign out').click()
 
     // Should show the login screen
-    await expect(page.locator('[data-ui="Heading"]:has-text("Choose login provider")')).toBeVisible(
-      {
-        timeout: 15_000,
-      },
-    )
+    await expect(
+      page.locator('[data-ui="Heading"]:has-text("Choose login provider")'),
+    ).toBeVisible()
   })
 })

--- a/e2e/tests/desk/inspectDialog.spec.ts
+++ b/e2e/tests/desk/inspectDialog.spec.ts
@@ -46,9 +46,18 @@ test('clicking inspect mode sets value in storage', async ({
     value: 'raw',
   })
 
-  // Set up listener for the second network request before clicking
+  // Set up listener for the second network request before clicking.
+  // Match on the response body to avoid catching a late duplicate of the first PUT.
   const keyValueRequest2 = page.waitForResponse(async (response) => {
-    return response.url().includes('/users/me/keyvalue') && response.request().method() === 'PUT'
+    if (!response.url().includes('/users/me/keyvalue') || response.request().method() !== 'PUT') {
+      return false
+    }
+    try {
+      const body = await response.json()
+      return body[0]?.value === 'parsed'
+    } catch {
+      return false
+    }
   })
 
   // Click Parsed tab

--- a/e2e/tests/document-actions/restore.spec.ts
+++ b/e2e/tests/document-actions/restore.spec.ts
@@ -39,8 +39,8 @@ test(`documents can be restored to an earlier revision`, async ({page, createDra
   await titleInput.fill(titleB)
   await expect(titleInput).toHaveValue(titleB)
 
-  // Wait for the document to be saved before publishing.
-  await expectEditedStatus(documentStatus)
+  // Wait for the publish button to become enabled (indicates changes are ready to publish).
+  await expect(publishButton).toBeEnabled()
   await publishButton.click()
   await expectPublishedStatus(documentStatus)
 
@@ -102,7 +102,7 @@ test(`respects overridden restore action`, async ({page, createDraftDocument}) =
   await titleInput.fill(titleB)
   await expect(titleInput).toHaveValue(titleB)
 
-  // Wait for the document to be saved before publishing.
+  // Wait for the document to have unsaved changes before publishing.
   await expectEditedStatus(documentStatus)
   await publishKeypress()
   await expectPublishedStatus(documentStatus)
@@ -166,8 +166,8 @@ test(`respects removed restore action`, async ({page, createDraftDocument}) => {
   await titleInput.fill(titleB)
   await expect(titleInput).toHaveValue(titleB)
 
-  // Wait for the document to be saved before publishing.
-  await expectEditedStatus(documentStatus)
+  // Wait for the publish button to become enabled (indicates changes are ready to publish).
+  await expect(publishButton).toBeEnabled()
   await publishButton.click()
   await expectPublishedStatus(documentStatus)
 


### PR DESCRIPTION
## Description

Adds e2e tests for the auth store's cross-tab sync, login/logout flows, SSO, and `redirectOnSingle` behavior. These tests mock all Sanity API responses so they run without real credentials.

Also discovered and documented two bugs:
- **401 infinite loop**: `getCurrentUser`'s 401 handler calls `broadcast(null)`, which re-triggers `state$`, causing an infinite loop. The e2e mocks work around this by returning 200 with an empty object instead of 401.
- **`redirectOnSingle` redirects after logout**: After signing out, the `LoginComponent` immediately redirects to the auth provider instead of showing the login screen, effectively logging the user back in. Marked as `test.fixme`.

> [!NOTE]
> These tests do **not** run as part of the regular e2e workflow. They use a dedicated auth-test-studio on port 3340 with mocked APIs, so they have their own Playwright config (`playwright.auth.config.ts`), their own CI workflow (`e2e-auth.yml`), and are excluded from the default config via `testIgnore`.

## What to review

- `e2e/tests/auth/` — all new test files and shared helpers
- `e2e/playwright.auth.config.ts` — separate Playwright config for auth tests
- `.github/workflows/e2e-auth.yml` — CI workflow that builds the auth-test-studio and runs auth e2e tests
- `e2e/playwright.config.ts` — `testIgnore` added to exclude auth tests from the main e2e run

## Testing

```bash
pnpm --filter auth-test-studio dev --port 3340
pnpm --filter e2e exec playwright test --config=playwright.auth.config.ts --retries=0
```

## Notes for release
N/A