### PR TITLE
fix(preview): cap concurrent preview fetches to prevent connection saturation

### DIFF
--- a/packages/sanity/src/core/preview/__test__/previewConcurrency.test.ts
+++ b/packages/sanity/src/core/preview/__test__/previewConcurrency.test.ts
@@ -1,0 +1,59 @@
+import {type SanityClient} from '@sanity/client'
+import {Subject} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createDocumentPreviewStore, MAX_PREVIEW_FETCH_CONCURRENCY} from '../documentPreviewStore'
+
+describe('preview fetch concurrency cap', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should export a reasonable concurrency limit', () => {
+    expect(MAX_PREVIEW_FETCH_CONCURRENCY).toBeGreaterThan(0)
+    expect(MAX_PREVIEW_FETCH_CONCURRENCY).toBeLessThanOrEqual(10)
+  })
+
+  it('should cap concurrent preview fetches through createDocumentPreviewStore', async () => {
+    let inFlight = 0
+    let maxInFlight = 0
+    const listenSubject = new Subject()
+
+    const mockClient = {
+      withConfig: vi.fn(),
+      listen: vi.fn(() => listenSubject.asObservable()),
+      observable: {
+        fetch: vi.fn(() => {
+          inFlight++
+          maxInFlight = Math.max(maxInFlight, inFlight)
+          // Never resolve — simulates slow responses to keep slots occupied
+          return new Subject().asObservable()
+        }),
+      },
+    } as unknown as SanityClient
+    ;(mockClient.withConfig as ReturnType<typeof vi.fn>).mockReturnValue(mockClient)
+
+    const store = createDocumentPreviewStore({client: mockClient})
+
+    // Each document gets a unique field so combineSelections produces separate
+    // selections → separate chunks → separate fetchChunk calls → separate
+    // client.observable.fetch calls gated by the concurrency limiter.
+    const docCount = MAX_PREVIEW_FETCH_CONCURRENCY * 3
+    const subs = Array.from({length: docCount}, (_, i) =>
+      store.observePaths({_type: 'reference', _ref: `doc-${i}`}, [`unique_field_${i}`]).subscribe(),
+    )
+
+    // Emit welcome to trigger initial fetch for all observers
+    listenSubject.next({type: 'welcome'})
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(maxInFlight).toBeGreaterThan(0)
+    expect(maxInFlight).toBeLessThanOrEqual(MAX_PREVIEW_FETCH_CONCURRENCY)
+
+    subs.forEach((sub) => sub.unsubscribe())
+  })
+})

--- a/packages/sanity/src/core/preview/__test__/previewConcurrency.test.ts
+++ b/packages/sanity/src/core/preview/__test__/previewConcurrency.test.ts
@@ -13,11 +13,6 @@ describe('preview fetch concurrency cap', () => {
     vi.useRealTimers()
   })
 
-  it('should export a reasonable concurrency limit', () => {
-    expect(MAX_PREVIEW_FETCH_CONCURRENCY).toBeGreaterThan(0)
-    expect(MAX_PREVIEW_FETCH_CONCURRENCY).toBeLessThanOrEqual(10)
-  })
-
   it('should cap concurrent preview fetches through createDocumentPreviewStore', async () => {
     let inFlight = 0
     let maxInFlight = 0

--- a/packages/sanity/src/core/preview/documentPreviewStore.ts
+++ b/packages/sanity/src/core/preview/documentPreviewStore.ts
@@ -6,6 +6,7 @@ import {
   type WelcomeEvent,
 } from '@sanity/client'
 import {type PrepareViewOptions, type SanityDocument} from '@sanity/types'
+import {createClientConcurrencyLimiter} from '@sanity/util/client'
 import {combineLatest, type Observable} from 'rxjs'
 import {distinctUntilChanged, filter, map} from 'rxjs/operators'
 
@@ -140,6 +141,13 @@ export interface DocumentPreviewStoreOptions {
   client: SanityClient
 }
 
+/** Caps concurrent preview fetches to leave connection headroom for SSE and other API calls.
+ *
+ * @internal */
+export const MAX_PREVIEW_FETCH_CONCURRENCY = 4
+
+const limitPreviewConcurrency = createClientConcurrencyLimiter(MAX_PREVIEW_FETCH_CONCURRENCY)
+
 /** @internal */
 export function createDocumentPreviewStore({
   client,
@@ -156,8 +164,9 @@ export function createDocumentPreviewStore({
     map((event) => (event.type === 'welcome' ? {type: 'connected' as const} : event)),
   )
 
+  const previewClient = limitPreviewConcurrency(versionedClient)
   const observeDocument = createObserveDocument({client, mutationChannel: globalListener})
-  const observeFields = createObserveFields({client: versionedClient, invalidationChannel})
+  const observeFields = createObserveFields({client: previewClient, invalidationChannel})
   const observePaths = createPathObserver({observeFields})
 
   function observeDocumentTypeFromId(

--- a/packages/sanity/src/core/preview/index.ts
+++ b/packages/sanity/src/core/preview/index.ts
@@ -1,7 +1,12 @@
 export * from './components/Preview'
 export * from './components/PreviewLoader'
 export * from './components/SanityDefaultPreview'
-export * from './documentPreviewStore'
+export type {
+  DocumentPreviewStore,
+  DocumentPreviewStoreOptions,
+  ObserveForPreviewFn,
+} from './documentPreviewStore'
+export {createDocumentPreviewStore} from './documentPreviewStore'
 export * from './types'
 export {unstable_useObserveDocument, useUnstableObserveDocument} from './useObserveDocument'
 export * from './useValuePreview'


### PR DESCRIPTION
### Description

Caps concurrent `preview.document-paths` fetches to prevent connection saturation, ensuring SSE listeners and other critical requests always have connection headroom.

When the preview system fires many GROQ fetches simultaneously (SSE reconnect triggers all observers at once, or a large document list loads), requests queue in the browser's `blocked` phase for 1–2.4s, starving the SSE listener and document-pair listener of connections. This was observed during an incident alongside the polling bug fixed in [#12624](https://github.com/sanity-io/sanity/pull/12624).

This PR wraps the preview-dedicated client with `createClientConcurrencyLimiter(4)` from `@sanity/util/client`: the same Proxy-based semaphore used by the validation system. **Only gates `fetch` / `observable.fetch`, not `listen`, so SSE connections are unaffected.** 

The cap of 4 matches `DEFAULT_CONCURRENCY` in `withMaxConcurrency` and leaves headroom within the browser's ~6 per-origin HTTP/1.1 connection limit for SSE and other API calls.

>[!Note]
> https://github.com/sanity-io/sanity/pull/12624 does not need to be merged before this, but it is the higher-priority fix. Without it, polling amplification will dominate and obscure the concurrency cap's effect.

### What to review

- The wiring in `documentPreviewStore.ts`: `previewClient` is wrapped with the limiter, while `globalListener` stays on the unwrapped `versionedClient` so SSE is never blocked.
- The cap value (4): chosen to match existing internal precedent and leave connection headroom.

### Testing

- Integration test in `previewConcurrency.test.ts` 
- Verified with HAR captures on the test-studio Book list under simulated 3G (hard load → throttle → navigate → 1 minute capture):

| Metric | Before (main) | After (this branch) |
|---|---|---|
| Max concurrent heavy requests | 5 | **4** (at cap) |
| Avg latency | 976ms | 825ms (-15%) |
| Heavy request count | 11 | 11 (unchanged) |

#### To reproduce locally

1. `git checkout main && pnpm install && pnpm build && pnpm dev`
2. Open `http://localhost:3333`, navigate to Species, enable **Slow 3G** in DevTools Network tab, then navigate to Book
3. Filter by `document-paths`, wait ~30s (I waited around a minute), capture HAR
4. `git checkout <this-branch> && pnpm install && pnpm build && pnpm dev`
5. Repeat steps 2–3 and compare Waterfall columns

You can also do this with the deployed vercel.

### Notes for release

Improved document list loading performance by capping concurrent preview fetch requests, reducing connection saturation on slower networks.