### PR TITLE
feat(asset-sources): add persistence key for Media Library plugin

### DIFF
--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@sanity/client": "catalog:",
-    "@sanity/media-library-types": "^1.2.0"
+    "@sanity/media-library-types": "^1.3.0"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@sanity/client": "catalog:",
-    "@sanity/media-library-types": "^1.3.0"
+    "@sanity/media-library-types": "^1.4.0"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -189,7 +189,7 @@
     "@sanity/image-url": "^2.0.3",
     "@sanity/insert-menu": "^3.0.5",
     "@sanity/logos": "^2.2.2",
-    "@sanity/media-library-types": "^1.3.0",
+    "@sanity/media-library-types": "^1.4.0",
     "@sanity/message-protocol": "^0.23.0",
     "@sanity/migrate": "catalog:",
     "@sanity/mutate": "^0.16.1",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -189,7 +189,7 @@
     "@sanity/image-url": "^2.0.3",
     "@sanity/insert-menu": "^3.0.5",
     "@sanity/logos": "^2.2.2",
-    "@sanity/media-library-types": "^1.2.0",
+    "@sanity/media-library-types": "^1.3.0",
     "@sanity/message-protocol": "^0.23.0",
     "@sanity/migrate": "catalog:",
     "@sanity/mutate": "^0.16.1",

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/__tests__/MediaLibraryPluginDialogs.test.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/__tests__/MediaLibraryPluginDialogs.test.tsx
@@ -1,0 +1,107 @@
+import {type SanityClient} from '@sanity/client'
+import {render} from '@testing-library/react'
+import noop from 'lodash-es/noop.js'
+import {type ReactNode, useRef} from 'react'
+import {describe, expect, test, vi} from 'vitest'
+
+import {createMockSanityClient} from '../../../../../../test/mocks/mockSanityClient'
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {MediaLibraryIdsContext} from '../../../../../_singletons/context/MediaLibraryIdsContext'
+import {decodeJsonParams, encodeJsonParams} from '../../../../../router/utils/jsonParamsEncoding'
+
+// SelectAssetsDialog calls useFormValue for validation; stub so we need not wrap FormValueProvider
+// (embedding FormValueProvider alongside other imports in this file breaks RouterProvider resolution).
+vi.mock('../../../contexts/FormValue', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../../../contexts/FormValue')>()
+  return {
+    ...mod,
+    useFormValue: () => undefined,
+  }
+})
+
+async function renderWithStudioTree(
+  client: SanityClient,
+  config: {projectId: string; dataset: string; name: string},
+  children: ReactNode,
+) {
+  const TestProvider = await createTestProvider({
+    client,
+    config: {
+      projectId: config.projectId,
+      dataset: config.dataset,
+      name: config.name,
+    },
+  })
+  return render(
+    <TestProvider>
+      <MediaLibraryIdsContext.Provider
+        value={{organizationId: 'test-org-id', libraryId: 'test-library-id'}}
+      >
+        {children}
+      </MediaLibraryIdsContext.Provider>
+    </TestProvider>,
+  )
+}
+
+describe('Media Library plugin iframe payloads', () => {
+  test('SelectAssetsDialog iframe src contains pickerPersistenceKey in createPluginView', async () => {
+    const {SelectAssetsDialog} = await import('../shared/SelectAssetsDialog')
+    const client = createMockSanityClient() as any as SanityClient
+    function Harness() {
+      const ref = useRef<HTMLDivElement>(null)
+      return <SelectAssetsDialog open onClose={noop} onSelect={noop} ref={ref} selection={[]} />
+    }
+    await renderWithStudioTree(client, {projectId: 'p1', dataset: 'd1', name: 'ws1'}, <Harness />)
+
+    const iframe = document.querySelector<HTMLIFrameElement>('iframe[src*="createPluginView"]')
+    expect(iframe).toBeTruthy()
+    const src = iframe!.getAttribute('src')!
+    const url = new URL(src)
+    const raw = url.searchParams.get('createPluginView')
+    expect(raw).toBeTruthy()
+    const parsed = decodeJsonParams(raw!) as {pickerPersistenceKey?: string}
+    const expectedKey =
+      encodeJsonParams({
+        projectId: 'p1',
+        dataset: 'd1',
+        workspaceName: 'ws1',
+      }) || undefined
+    expect(parsed.pickerPersistenceKey).toBe(expectedKey)
+  })
+
+  test('OpenInSourceDialog iframe payload omits pickerPersistenceKey', async () => {
+    const {OpenInSourceDialog} = await import('../shared/OpenInSourceDialog')
+    const client = createMockSanityClient() as any as SanityClient
+    await renderWithStudioTree(
+      client,
+      {projectId: 'p1', dataset: 'd1', name: 'ws1'},
+      <OpenInSourceDialog
+        asset={
+          {
+            _id: 'asset-1',
+            _type: 'sanity.imageAsset',
+            source: {name: 'mux', id: 'mux-asset-99'},
+          } as any
+        }
+        dialogHeaderTitle="Open"
+        selectNewAssetButtonLabel="Select"
+        onClose={noop}
+        onSelectNewAsset={noop}
+      />,
+    )
+
+    const iframe = document.querySelector<HTMLIFrameElement>('iframe[src*="createPluginView"]')
+    expect(iframe).toBeTruthy()
+    const src = iframe!.getAttribute('src')!
+    const url = new URL(src)
+    expect(url.pathname).toContain('/assets/mux-asset-99')
+    const raw = url.searchParams.get('createPluginView')
+    expect(raw).toBeTruthy()
+    const parsed = decodeJsonParams(raw!) as {
+      pickerPersistenceKey?: string
+      disableNavigation?: boolean
+    }
+    expect(parsed.pickerPersistenceKey).toBeUndefined()
+    expect(parsed.disableNavigation).toBe(true)
+  })
+})

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/__tests__/MediaLibraryPluginDialogs.test.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/__tests__/MediaLibraryPluginDialogs.test.tsx
@@ -2,17 +2,18 @@ import {type SanityClient} from '@sanity/client'
 import {render} from '@testing-library/react'
 import noop from 'lodash-es/noop.js'
 import {type ReactNode, useRef} from 'react'
+import {MediaLibraryIdsContext} from 'sanity/_singletons'
+import {decodeJsonParams, encodeJsonParams} from 'sanity/router'
 import {describe, expect, test, vi} from 'vitest'
 
 import {createMockSanityClient} from '../../../../../../test/mocks/mockSanityClient'
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
-import {MediaLibraryIdsContext} from '../../../../../_singletons/context/MediaLibraryIdsContext'
-import {decodeJsonParams, encodeJsonParams} from '../../../../../router/utils/jsonParamsEncoding'
+import type * as FormValueMod from '../../../contexts/FormValue'
 
 // SelectAssetsDialog calls useFormValue for validation; stub so we need not wrap FormValueProvider
 // (embedding FormValueProvider alongside other imports in this file breaks RouterProvider resolution).
 vi.mock('../../../contexts/FormValue', async (importOriginal) => {
-  const mod = await importOriginal<typeof import('../../../contexts/FormValue')>()
+  const mod = await importOriginal<typeof FormValueMod>()
   return {
     ...mod,
     useFormValue: () => undefined,
@@ -44,12 +45,28 @@ async function renderWithStudioTree(
 }
 
 describe('Media Library plugin iframe payloads', () => {
+  const expectedPickerKey =
+    encodeJsonParams({
+      projectId: 'p1',
+      dataset: 'd1',
+      workspaceName: 'ws1',
+    }) || undefined
+
   test('SelectAssetsDialog iframe src contains pickerPersistenceKey in createPluginView', async () => {
     const {SelectAssetsDialog} = await import('../shared/SelectAssetsDialog')
     const client = createMockSanityClient() as any as SanityClient
     function Harness() {
       const ref = useRef<HTMLDivElement>(null)
-      return <SelectAssetsDialog open onClose={noop} onSelect={noop} ref={ref} selection={[]} />
+      return (
+        <SelectAssetsDialog
+          open
+          onClose={noop}
+          onSelect={noop}
+          ref={ref}
+          selection={[]}
+          pickerPersistenceKey={expectedPickerKey}
+        />
+      )
     }
     await renderWithStudioTree(client, {projectId: 'p1', dataset: 'd1', name: 'ws1'}, <Harness />)
 
@@ -60,22 +77,17 @@ describe('Media Library plugin iframe payloads', () => {
     const raw = url.searchParams.get('createPluginView')
     expect(raw).toBeTruthy()
     const parsed = decodeJsonParams(raw!) as {pickerPersistenceKey?: string}
-    const expectedKey =
-      encodeJsonParams({
-        projectId: 'p1',
-        dataset: 'd1',
-        workspaceName: 'ws1',
-      }) || undefined
-    expect(parsed.pickerPersistenceKey).toBe(expectedKey)
+    expect(parsed.pickerPersistenceKey).toBe(expectedPickerKey)
   })
 
-  test('OpenInSourceDialog iframe payload omits pickerPersistenceKey', async () => {
+  test('OpenInSourceDialog iframe src includes pickerPersistenceKey and disableNavigation', async () => {
     const {OpenInSourceDialog} = await import('../shared/OpenInSourceDialog')
     const client = createMockSanityClient() as any as SanityClient
     await renderWithStudioTree(
       client,
       {projectId: 'p1', dataset: 'd1', name: 'ws1'},
       <OpenInSourceDialog
+        pickerPersistenceKey={expectedPickerKey}
         asset={
           {
             _id: 'asset-1',
@@ -101,7 +113,7 @@ describe('Media Library plugin iframe payloads', () => {
       pickerPersistenceKey?: string
       disableNavigation?: boolean
     }
-    expect(parsed.pickerPersistenceKey).toBeUndefined()
+    expect(parsed.pickerPersistenceKey).toBe(expectedPickerKey)
     expect(parsed.disableNavigation).toBe(true)
   })
 })

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/MediaLibraryAssetSource.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/MediaLibraryAssetSource.tsx
@@ -1,9 +1,11 @@
 import {type AssetSourceComponentProps} from '@sanity/types'
 import {PortalProvider} from '@sanity/ui'
-import {type ForwardedRef, forwardRef, memo, useCallback, useEffect, useState} from 'react'
+import {type ForwardedRef, forwardRef, memo, useCallback, useEffect, useMemo, useState} from 'react'
+import {encodeJsonParams} from 'sanity/router'
 
 import {useClient} from '../../../../hooks'
 import {useTranslation} from '../../../../i18n'
+import {useWorkspace} from '../../../../studio'
 import {DEFAULT_API_VERSION} from '../constants'
 import {MediaLibraryProvider} from './MediaLibraryProvider'
 import {OpenInSourceDialog} from './OpenInSourceDialog'
@@ -33,6 +35,16 @@ const MediaLibraryAssetSourceComponent = function MediaLibraryAssetSourceCompone
   const {t} = useTranslation()
   const client = useClient({apiVersion: DEFAULT_API_VERSION})
   const projectId = client.config().projectId
+  const workspace = useWorkspace()
+  const pickerPersistenceKey = useMemo(
+    () =>
+      encodeJsonParams({
+        projectId: workspace.projectId,
+        dataset: workspace.dataset,
+        workspaceName: workspace.name,
+      }) || undefined,
+    [workspace.projectId, workspace.dataset, workspace.name],
+  )
   const portalElement = useRootPortalElement()
   const handleSelectNewAsset = useCallback(() => {
     if (onChangeAction) {
@@ -57,6 +69,7 @@ const MediaLibraryAssetSourceComponent = function MediaLibraryAssetSourceCompone
       />
       <PortalProvider element={portalElement}>
         <SelectAssetsDialog
+          pickerPersistenceKey={pickerPersistenceKey}
           dialogHeaderTitle={
             dialogHeaderTitle ||
             t('asset-sources.media-library.select-dialog.title', {
@@ -74,6 +87,7 @@ const MediaLibraryAssetSourceComponent = function MediaLibraryAssetSourceCompone
         />
         {action === 'openInSource' && assetToOpen && (
           <OpenInSourceDialog
+            pickerPersistenceKey={pickerPersistenceKey}
             asset={assetToOpen}
             dialogHeaderTitle={t('asset-sources.media-library.open-in-source-dialog.title')}
             selectNewAssetButtonLabel={

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/OpenInSourceDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/OpenInSourceDialog.tsx
@@ -2,11 +2,9 @@ import {type PluginPayload} from '@sanity/media-library-types'
 import {type Asset} from '@sanity/types'
 import {Box, Card, Flex, useTheme} from '@sanity/ui'
 import {type ReactNode, useCallback, useMemo} from 'react'
-import {encodeJsonParams} from 'sanity/router'
 
 import {Button} from '../../../../../ui-components'
 import {useTranslation} from '../../../../i18n'
-import {useWorkspace} from '../../../../studio'
 import {useAuthType} from '../hooks/useAuthType'
 import {usePluginFrameUrl} from '../hooks/usePluginFrameUrl'
 import {usePluginPostMessage} from '../hooks/usePluginPostMessage'
@@ -31,7 +29,6 @@ export function OpenInSourceDialog(props: OpenInSourceDialogProps): ReactNode {
   const theme = useTheme()
   const {t} = useTranslation()
   const {dark} = theme.sanity.color
-  const workspace = useWorkspace()
   const mediaLibraryConfig = useSanityMediaLibraryConfig()
   const appHost = mediaLibraryConfig.__internal.hosts.app
   const authType = useAuthType()
@@ -39,6 +36,7 @@ export function OpenInSourceDialog(props: OpenInSourceDialogProps): ReactNode {
   // Get the asset ID from the source property
   const sourceAssetId = asset.source?.id
 
+  /** No `pickerPersistenceKey`: avoid sharing the asset picker's Huey localStorage partition. */
   const params = useMemo<PluginPayload>(
     () => ({
       scheme: dark ? 'dark' : 'light',
@@ -46,14 +44,8 @@ export function OpenInSourceDialog(props: OpenInSourceDialogProps): ReactNode {
       disableNavigation: true,
       selectAssetTypes: [],
       selectionType: 'single',
-      pickerPersistenceKey:
-        encodeJsonParams({
-          projectId: workspace.projectId,
-          dataset: workspace.dataset,
-          workspaceName: workspace.name,
-        }) || undefined,
     }),
-    [dark, authType, workspace.projectId, workspace.dataset, workspace.name],
+    [dark, authType],
   )
 
   const iframeUrl = usePluginFrameUrl(`/assets/${sourceAssetId}`, params)

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/OpenInSourceDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/OpenInSourceDialog.tsx
@@ -2,9 +2,11 @@ import {type PluginPayload} from '@sanity/media-library-types'
 import {type Asset} from '@sanity/types'
 import {Box, Card, Flex, useTheme} from '@sanity/ui'
 import {type ReactNode, useCallback, useMemo} from 'react'
+import {encodeJsonParams} from 'sanity/router'
 
 import {Button} from '../../../../../ui-components'
 import {useTranslation} from '../../../../i18n'
+import {useWorkspace} from '../../../../studio'
 import {useAuthType} from '../hooks/useAuthType'
 import {usePluginFrameUrl} from '../hooks/usePluginFrameUrl'
 import {usePluginPostMessage} from '../hooks/usePluginPostMessage'
@@ -29,6 +31,7 @@ export function OpenInSourceDialog(props: OpenInSourceDialogProps): ReactNode {
   const theme = useTheme()
   const {t} = useTranslation()
   const {dark} = theme.sanity.color
+  const workspace = useWorkspace()
   const mediaLibraryConfig = useSanityMediaLibraryConfig()
   const appHost = mediaLibraryConfig.__internal.hosts.app
   const authType = useAuthType()
@@ -43,8 +46,14 @@ export function OpenInSourceDialog(props: OpenInSourceDialogProps): ReactNode {
       disableNavigation: true,
       selectAssetTypes: [],
       selectionType: 'single',
+      pickerPersistenceKey:
+        encodeJsonParams({
+          projectId: workspace.projectId,
+          dataset: workspace.dataset,
+          workspaceName: workspace.name,
+        }) || undefined,
     }),
-    [dark, authType],
+    [dark, authType, workspace.projectId, workspace.dataset, workspace.name],
   )
 
   const iframeUrl = usePluginFrameUrl(`/assets/${sourceAssetId}`, params)

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/OpenInSourceDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/OpenInSourceDialog.tsx
@@ -14,6 +14,8 @@ import {AppDialog} from './Dialog'
 import {Iframe} from './Iframe'
 
 export interface OpenInSourceDialogProps {
+  /** Opaque key for Media Library iframe picker state partitioning; usually precomputed in the asset source. */
+  pickerPersistenceKey?: string
   asset: Asset
   dialogHeaderTitle: ReactNode
   selectNewAssetButtonLabel: string
@@ -25,7 +27,14 @@ export interface OpenInSourceDialogProps {
  * Dialog that opens an asset in the Media Library for viewing/editing
  */
 export function OpenInSourceDialog(props: OpenInSourceDialogProps): ReactNode {
-  const {asset, dialogHeaderTitle, onClose, onSelectNewAsset, selectNewAssetButtonLabel} = props
+  const {
+    asset,
+    dialogHeaderTitle,
+    onClose,
+    onSelectNewAsset,
+    selectNewAssetButtonLabel,
+    pickerPersistenceKey,
+  } = props
   const theme = useTheme()
   const {t} = useTranslation()
   const {dark} = theme.sanity.color
@@ -36,7 +45,6 @@ export function OpenInSourceDialog(props: OpenInSourceDialogProps): ReactNode {
   // Get the asset ID from the source property
   const sourceAssetId = asset.source?.id
 
-  /** No `pickerPersistenceKey`: avoid sharing the asset picker's Huey localStorage partition. */
   const params = useMemo<PluginPayload>(
     () => ({
       scheme: dark ? 'dark' : 'light',
@@ -44,8 +52,9 @@ export function OpenInSourceDialog(props: OpenInSourceDialogProps): ReactNode {
       disableNavigation: true,
       selectAssetTypes: [],
       selectionType: 'single',
+      pickerPersistenceKey,
     }),
-    [dark, authType],
+    [dark, authType, pickerPersistenceKey],
   )
 
   const iframeUrl = usePluginFrameUrl(`/assets/${sourceAssetId}`, params)

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
@@ -12,6 +12,7 @@ import {
 } from '@sanity/types'
 import {Box, Card, Flex, useTheme, useToast} from '@sanity/ui'
 import {type ReactNode, useCallback, useMemo, useState} from 'react'
+import {encodeJsonParams} from 'sanity/router'
 
 import {Button} from '../../../../../ui-components'
 import {useFormValue} from '../../../../form'
@@ -126,8 +127,23 @@ export function SelectAssetsDialog(props: SelectAssetsDialogProps): ReactNode {
       scheme: dark ? 'dark' : 'light',
       selectAssetTypes: selectAssetType ? [selectAssetType] : [],
       selectionType,
+      pickerPersistenceKey:
+        encodeJsonParams({
+          projectId: workspace.projectId,
+          dataset: workspace.dataset,
+          workspaceName: workspace.name,
+        }) || undefined,
     }),
-    [selectionType, selectAssetType, dark, authType, pluginFilters],
+    [
+      selectionType,
+      selectAssetType,
+      dark,
+      authType,
+      pluginFilters,
+      workspace.projectId,
+      workspace.dataset,
+      workspace.name,
+    ],
   )
   const iframeUrl = usePluginFrameUrl('/assets', params)
 

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
@@ -12,7 +12,6 @@ import {
 } from '@sanity/types'
 import {Box, Card, Flex, useTheme, useToast} from '@sanity/ui'
 import {type ReactNode, useCallback, useMemo, useState} from 'react'
-import {encodeJsonParams} from 'sanity/router'
 
 import {Button} from '../../../../../ui-components'
 import {useFormValue} from '../../../../form'
@@ -34,6 +33,8 @@ import {Iframe} from './Iframe'
 import {filterMediaValidationMarkers} from './validation'
 
 export interface SelectAssetsDialogProps {
+  /** Opaque key for Media Library iframe picker state partitioning; usually precomputed in the asset source. */
+  pickerPersistenceKey?: string
   dialogHeaderTitle?: ReactNode
   open: boolean
   onClose: () => void
@@ -58,6 +59,7 @@ export function SelectAssetsDialog(props: SelectAssetsDialogProps): ReactNode {
   const authType = useAuthType()
 
   const {
+    pickerPersistenceKey,
     dialogHeaderTitle,
     onClose,
     open,
@@ -127,23 +129,9 @@ export function SelectAssetsDialog(props: SelectAssetsDialogProps): ReactNode {
       scheme: dark ? 'dark' : 'light',
       selectAssetTypes: selectAssetType ? [selectAssetType] : [],
       selectionType,
-      pickerPersistenceKey:
-        encodeJsonParams({
-          projectId: workspace.projectId,
-          dataset: workspace.dataset,
-          workspaceName: workspace.name,
-        }) || undefined,
+      pickerPersistenceKey,
     }),
-    [
-      selectionType,
-      selectAssetType,
-      dark,
-      authType,
-      pluginFilters,
-      workspace.projectId,
-      workspace.dataset,
-      workspace.name,
-    ],
+    [selectionType, selectAssetType, dark, authType, pluginFilters, pickerPersistenceKey],
   )
   const iframeUrl = usePluginFrameUrl('/assets', params)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1277,8 +1277,8 @@ importers:
         specifier: 'catalog:'
         version: 7.21.0
       '@sanity/media-library-types':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.4.0
+        version: 1.4.0
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -1652,8 +1652,8 @@ importers:
         specifier: ^2.2.2
         version: 2.2.2(react@19.2.4)
       '@sanity/media-library-types':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.4.0
+        version: 1.4.0
       '@sanity/message-protocol':
         specifier: ^0.23.0
         version: 0.23.0
@@ -5322,8 +5322,8 @@ packages:
     peerDependencies:
       react: ^18.3 || ^19.0.0-0
 
-  '@sanity/media-library-types@1.2.0':
-    resolution: {integrity: sha512-p+Bw96I63SwBcMNA/L5dnMdEcS88EEDUDZ65LGuwOCMXrESRGMFCSxgc+0HnL0JXDIzgYgfrPuf1I3bO9QneAw==}
+  '@sanity/media-library-types@1.4.0':
+    resolution: {integrity: sha512-DZwNT+dDSc1JPW4e7U5C+IJELq5IAeU2A1UcY1079gl+Hakx2USvu5LyY1hrjb1eifRPAhL8uwOVcMNBUmSmzg==}
 
   '@sanity/message-protocol@0.18.2':
     resolution: {integrity: sha512-sxPpM0q6ozvoWCQMFwPfL0KR8nkNl5gOhzkEH0EE8RHWfxH7jqHtxnXC/AEk5f4o/PuGChcHDWUof97JZ6LInw==}
@@ -14836,7 +14836,7 @@ snapshots:
       '@sanity/color': 3.0.6
       react: 19.2.4
 
-  '@sanity/media-library-types@1.2.0': {}
+  '@sanity/media-library-types@1.4.0': {}
 
   '@sanity/message-protocol@0.18.2':
     dependencies:
@@ -15120,7 +15120,7 @@ snapshots:
   '@sanity/types@4.22.0(@types/react@19.2.14)':
     dependencies:
       '@sanity/client': 7.21.0
-      '@sanity/media-library-types': 1.2.0
+      '@sanity/media-library-types': 1.4.0
       '@types/react': 19.2.14
 
   '@sanity/ui@2.16.22(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)':


### PR DESCRIPTION
### Description

This will add support for the Media Library Plugin to remember the users working folder and other things we want to persist, when interacting with the Media Library in a certain dataset & workspace combo.

It will send a unique persistence key to the Media Library which it will store settings on for that workspace.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

That the changes looks allright.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Added unit tests.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

N/A - should not be mentioned (yet)

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
