### PR TITLE
fix(presentation): sync perspective cookie for content agent documents

### DIFF
--- a/packages/sanity/src/presentation/preview/Preview.tsx
+++ b/packages/sanity/src/presentation/preview/Preview.tsx
@@ -105,10 +105,11 @@ export const Preview = memo(
     )
     const previewUrl = useMemo(() => {
       const url = new URL(initialUrl)
-      // Always set the perspective that's being used, even if preview mode isn't configured
-      if (!url.searchParams.get(urlSearchParamPreviewPerspective)) {
-        url.searchParams.set(urlSearchParamPreviewPerspective, urlPerspective)
-      }
+      // Always set the current perspective, overwriting any stale value that may
+      // have been baked into the resolved preview-mode URL at mount time (e.g.
+      // when a Content Agent document lives in a release but the initial
+      // perspective was "drafts").
+      url.searchParams.set(urlSearchParamPreviewPerspective, urlPerspective)
 
       if (vercelProtectionBypass || url.searchParams.get(urlSearchParamVercelProtectionBypass)) {
         // samesitenone is required since the request is from an iframe

--- a/packages/sanity/src/presentation/util/__tests__/encodeStudioPerspective.test.ts
+++ b/packages/sanity/src/presentation/util/__tests__/encodeStudioPerspective.test.ts
@@ -1,0 +1,27 @@
+import {describe, expect, it} from 'vitest'
+
+import {encodeStudioPerspective} from '../encodeStudioPerspective'
+
+describe('encodeStudioPerspective', () => {
+  it('returns "drafts" for the drafts perspective', () => {
+    expect(encodeStudioPerspective('drafts')).toBe('drafts')
+  })
+
+  it('returns "published" for the published perspective', () => {
+    expect(encodeStudioPerspective('published')).toBe('published')
+  })
+
+  it('joins an array perspective with commas (release perspective stack)', () => {
+    expect(encodeStudioPerspective(['rABC123', 'drafts'])).toBe('rABC123,drafts')
+  })
+
+  it('handles a single-element array perspective', () => {
+    expect(encodeStudioPerspective(['published'])).toBe('published')
+  })
+
+  it('handles a full release perspective stack', () => {
+    expect(encodeStudioPerspective(['rRelease1', 'rRelease2', 'drafts'])).toBe(
+      'rRelease1,rRelease2,drafts',
+    )
+  })
+})


### PR DESCRIPTION
### Description

Fixes [SAPP-3672](https://linear.app/sanity/issue/SAPP-3672).

Presentation Mode couldn't sync the perspective for Content Agent documents — the `sanity-preview-perspective` cookie stayed as `"drafts"` and the frontend returned 404. Root cause: the resolve-preview-mode-url xstate actor captured a stale perspective value in a closure at mount time (typically `"drafts"`), and `Preview.tsx` only set the perspective search param when it was absent. Removed the conditional guard so the perspective is always set to the current value.

### What to review

- `Preview.tsx` — `url.searchParams.set(...)` is now unconditional.
- New tests for `encodeStudioPerspective` helper.

### Testing

- 5 new tests for `encodeStudioPerspective`.
- All 75 presentation tests pass.
- Existing state machine snapshots unchanged.

### Notes for release

Fixed Presentation Mode so documents created by Content Agent are now viewable. The preview perspective cookie now always updates to match the current workspace perspective, not a stale value from when the preview loaded.
