### PR TITLE
fix(releases): clean up draft after scheduled release publish

### DIFF
--- a/packages/sanity/src/core/releases/store/__tests__/createReleaseOperationsStore.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/createReleaseOperationsStore.test.ts
@@ -16,8 +16,13 @@ import {
 
 describe('createReleaseOperationsStore', () => {
   let mockClient: any
+  let mockTransaction: any
 
   beforeEach(() => {
+    mockTransaction = {
+      delete: vi.fn().mockReturnThis(),
+      commit: vi.fn().mockResolvedValue(undefined),
+    }
     mockClient = {
       config: vi.fn().mockReturnValue({dataset: 'test-dataset'}),
       action: vi.fn().mockResolvedValue(undefined),
@@ -31,7 +36,9 @@ describe('createReleaseOperationsStore', () => {
         unarchive: vi.fn().mockResolvedValue(undefined),
         delete: vi.fn().mockResolvedValue(undefined),
       },
-      getDocument: vi.fn(),
+      fetch: vi.fn().mockResolvedValue([]),
+      getDocument: vi.fn().mockResolvedValue(null),
+      transaction: vi.fn().mockReturnValue(mockTransaction),
       createVersion: vi.fn().mockResolvedValue(undefined),
       discardVersion: vi.fn().mockResolvedValue(undefined),
       unpublishVersion: vi.fn().mockResolvedValue(undefined),
@@ -82,6 +89,85 @@ describe('createReleaseOperationsStore', () => {
       },
       undefined,
     )
+  })
+
+  describe('publishRelease draft cleanup', () => {
+    it('should discard matching drafts after publishing a release', async () => {
+      const store = createStore()
+
+      // Set up: release has one document
+      mockClient.fetch.mockResolvedValueOnce(['versions.rASAP.doc1'])
+
+      // Draft and published match
+      const sharedContent = {_type: 'article', title: 'Hello'}
+      mockClient.getDocument
+        .mockResolvedValueOnce({_id: 'drafts.doc1', _rev: 'rev-1', ...sharedContent})
+        .mockResolvedValueOnce({_id: 'doc1', _rev: 'rev-2', ...sharedContent})
+
+      await store.publishRelease(activeASAPRelease._id)
+
+      expect(mockClient.releases.publish).toHaveBeenCalled()
+      expect(mockClient.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('partOfRelease'),
+        {releaseId: 'rASAP'},
+        expect.objectContaining({tag: 'release.pre-publish-query'}),
+      )
+      expect(mockTransaction.delete).toHaveBeenCalledWith('drafts.doc1')
+      expect(mockTransaction.commit).toHaveBeenCalledWith(
+        expect.objectContaining({tag: 'release.post-publish-draft-cleanup'}),
+      )
+    })
+
+    it('should not discard drafts that differ from published after release publish', async () => {
+      const store = createStore()
+
+      mockClient.fetch.mockResolvedValueOnce(['versions.rASAP.doc1'])
+
+      // Draft and published differ
+      mockClient.getDocument
+        .mockResolvedValueOnce({
+          _id: 'drafts.doc1',
+          _rev: 'rev-1',
+          _type: 'article',
+          title: 'Draft',
+        })
+        .mockResolvedValueOnce({
+          _id: 'doc1',
+          _rev: 'rev-2',
+          _type: 'article',
+          title: 'Published',
+        })
+
+      await store.publishRelease(activeASAPRelease._id)
+
+      expect(mockClient.releases.publish).toHaveBeenCalled()
+      expect(mockTransaction.delete).not.toHaveBeenCalled()
+    })
+
+    it('should skip draft cleanup for dry run publishes', async () => {
+      const store = createStore()
+      const opts = {dryRun: true}
+
+      await store.publishRelease(activeASAPRelease._id, opts)
+
+      expect(mockClient.releases.publish).toHaveBeenCalled()
+      expect(mockClient.fetch).not.toHaveBeenCalled()
+    })
+
+    it('should not fail publish if draft cleanup fails', async () => {
+      const store = createStore()
+
+      mockClient.fetch.mockResolvedValueOnce(['versions.rASAP.doc1'])
+
+      // Make getDocument throw to simulate cleanup failure
+      mockClient.getDocument.mockRejectedValue(new Error('Network error'))
+
+      // Should not throw despite cleanup failure
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      await expect(store.publishRelease(activeASAPRelease._id)).resolves.not.toThrow()
+      expect(warnSpy).toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
   })
 
   it('should schedule a release', async () => {

--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -11,6 +11,7 @@ import {
 import {getPublishedId, getVersionFromId, getVersionId} from '../../util'
 import {type ReleasesUpsellContextValue} from '../contexts/upsell/types'
 import {type RevertDocument} from '../tool/components/releaseCTAButtons/ReleaseRevertButton/useDocumentRevertStates'
+import {discardMatchingDrafts} from '../util/discardMatchingDrafts'
 import {getReleaseIdFromReleaseDocumentId} from '../util/getReleaseIdFromReleaseDocumentId'
 import {isReleaseLimitError} from './isReleaseLimitError'
 
@@ -112,11 +113,45 @@ export function createReleaseOperationsStore(options: {
     )
   }
 
-  const handlePublishRelease = (releaseId: string, opts?: BaseActionOptions) =>
-    handleReleaseLimitError(
-      client.releases.publish({releaseId: getReleaseIdFromReleaseDocumentId(releaseId)}, opts),
+  const handlePublishRelease = async (
+    releaseId: string,
+    opts?: BaseActionOptions,
+  ): Promise<SingleActionResult> => {
+    const resolvedReleaseId = getReleaseIdFromReleaseDocumentId(releaseId)
+
+    // Collect the published IDs of documents in the release BEFORE publishing,
+    // because after publish the version documents may no longer exist.
+    let publishedIdsForCleanup: string[] = []
+    if (!opts?.dryRun) {
+      try {
+        const versionIds = await client.fetch<string[]>(
+          `*[sanity::partOfRelease($releaseId)]._id`,
+          {releaseId: resolvedReleaseId},
+          {tag: 'release.pre-publish-query'},
+        )
+        publishedIdsForCleanup = [...new Set((versionIds || []).map((id) => getPublishedId(id)))]
+      } catch {
+        // If the pre-publish query fails, proceed with publish but skip cleanup
+      }
+    }
+
+    const result = await handleReleaseLimitError(
+      client.releases.publish({releaseId: resolvedReleaseId}, opts),
       opts,
     )
+
+    // After successful publish, clean up matching drafts
+    if (!opts?.dryRun && publishedIdsForCleanup.length > 0) {
+      try {
+        await discardMatchingDrafts(client, publishedIdsForCleanup)
+      } catch (error) {
+        // Draft cleanup is best-effort; don't fail the publish if cleanup fails
+        console.warn('Failed to clean up drafts after release publish:', error)
+      }
+    }
+
+    return result
+  }
 
   const handleScheduleRelease = (releaseId: string, publishAt: Date, opts?: BaseActionOptions) =>
     handleReleaseLimitError(

--- a/packages/sanity/src/core/releases/store/createReleaseStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseStore.ts
@@ -5,12 +5,14 @@ import {
   concat,
   concatWith,
   count,
+  EMPTY,
   filter,
   from,
   merge,
   type Observable,
   of,
   type OperatorFunction,
+  pairwise,
   pipe,
   scan,
   shareReplay,
@@ -18,10 +20,11 @@ import {
   switchMap,
   tap,
 } from 'rxjs'
-import {distinctUntilChanged, map, startWith} from 'rxjs/operators'
+import {distinctUntilChanged, map, mergeMap, startWith} from 'rxjs/operators'
 
 import {type DocumentPreviewStore} from '../../preview'
 import {listenQuery} from '../../store/_legacy'
+import {discardMatchingDraftsForRelease} from '../util/discardMatchingDrafts'
 import {RELEASE_DOCUMENT_TYPE, RELEASE_DOCUMENTS_PATH} from './constants'
 import {createReleaseMetadataAggregator} from './createReleaseMetadataAggregator'
 import {releasesReducer, type ReleasesReducerAction, type ReleasesReducerState} from './reducer'
@@ -145,6 +148,41 @@ export function createReleaseStore(context: {
     startWith(INITIAL_STATE),
     shareReplay(1),
   )
+
+  // Side-effect: when a release transitions to 'published' (e.g., via scheduled publish),
+  // clean up any drafts that now match their published counterparts.
+  const draftCleanup$ = state$.pipe(
+    pairwise(),
+    mergeMap(([prevState, nextState]) => {
+      const newlyPublishedReleases: ReleaseDocument[] = []
+      for (const [id, release] of nextState.releases) {
+        if (release.state === 'published') {
+          const prevRelease = prevState.releases.get(id)
+          // Only trigger for releases that just transitioned to 'published'
+          if (prevRelease && prevRelease.state !== 'published') {
+            newlyPublishedReleases.push(release)
+          }
+        }
+      }
+
+      if (newlyPublishedReleases.length === 0) return EMPTY
+
+      return from(
+        Promise.all(
+          newlyPublishedReleases.map((release) =>
+            discardMatchingDraftsForRelease(client, release).catch((err) => {
+              console.warn('Failed to clean up drafts after release publish:', err)
+            }),
+          ),
+        ),
+      )
+    }),
+    catchError(() => EMPTY),
+  )
+
+  // Subscribe to the cleanup observable to activate the side-effect.
+  // This is a fire-and-forget subscription that lives for the app lifecycle.
+  draftCleanup$.subscribe()
 
   const errorCount$ = state$.pipe(releaseStoreErrorCount(), shareReplay(1))
 

--- a/packages/sanity/src/core/releases/util/__tests__/discardMatchingDrafts.test.ts
+++ b/packages/sanity/src/core/releases/util/__tests__/discardMatchingDrafts.test.ts
@@ -1,0 +1,227 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {describe, expect, it, vi} from 'vitest'
+
+import {
+  discardMatchingDrafts,
+  discardMatchingDraftsForRelease,
+  documentsContentMatch,
+} from '../discardMatchingDrafts'
+
+describe('documentsContentMatch', () => {
+  it('returns true when documents have matching content (ignoring system fields)', () => {
+    const draft = {_id: 'drafts.doc1', _rev: 'rev-a', _type: 'article', title: 'Hello'}
+    const published = {_id: 'doc1', _rev: 'rev-b', _type: 'article', title: 'Hello'}
+    expect(documentsContentMatch(draft, published)).toBe(true)
+  })
+
+  it('returns false when documents have different content', () => {
+    const draft = {_id: 'drafts.doc1', _rev: 'rev-a', _type: 'article', title: 'Draft'}
+    const published = {_id: 'doc1', _rev: 'rev-b', _type: 'article', title: 'Published'}
+    expect(documentsContentMatch(draft, published)).toBe(false)
+  })
+
+  it('returns false when documents have different number of fields', () => {
+    const draft = {_id: 'drafts.doc1', _rev: 'rev-a', _type: 'article', title: 'Hello', extra: 1}
+    const published = {_id: 'doc1', _rev: 'rev-b', _type: 'article', title: 'Hello'}
+    expect(documentsContentMatch(draft, published)).toBe(false)
+  })
+
+  it('ignores _updatedAt and _createdAt differences', () => {
+    const draft = {
+      _id: 'drafts.doc1',
+      _rev: 'rev-a',
+      _createdAt: '2024-01-01',
+      _updatedAt: '2024-01-02',
+      _type: 'article',
+      title: 'Hello',
+    }
+    const published = {
+      _id: 'doc1',
+      _rev: 'rev-b',
+      _createdAt: '2024-01-03',
+      _updatedAt: '2024-01-04',
+      _type: 'article',
+      title: 'Hello',
+    }
+    expect(documentsContentMatch(draft, published)).toBe(true)
+  })
+
+  it('handles nested objects and arrays', () => {
+    const draft = {
+      _id: 'drafts.doc1',
+      _rev: 'rev-a',
+      _type: 'article',
+      body: [{_type: 'block', children: [{text: 'Hello'}]}],
+    }
+    const published = {
+      _id: 'doc1',
+      _rev: 'rev-b',
+      _type: 'article',
+      body: [{_type: 'block', children: [{text: 'Hello'}]}],
+    }
+    expect(documentsContentMatch(draft, published)).toBe(true)
+  })
+
+  it('matches regardless of key order', () => {
+    const draft = {_id: 'drafts.doc1', _rev: 'rev-a', title: 'Hello', _type: 'article'}
+    const published = {_id: 'doc1', _rev: 'rev-b', _type: 'article', title: 'Hello'}
+    expect(documentsContentMatch(draft, published)).toBe(true)
+  })
+})
+
+describe('discardMatchingDrafts', () => {
+  const createMockClient = () => {
+    const mockTx = {
+      delete: vi.fn().mockReturnThis(),
+      commit: vi.fn().mockResolvedValue(undefined),
+    }
+    return {
+      client: {
+        getDocument: vi.fn().mockResolvedValue(null),
+        transaction: vi.fn().mockReturnValue(mockTx),
+      } as any,
+      mockTx,
+    }
+  }
+
+  it('does nothing for empty published IDs', async () => {
+    const {client} = createMockClient()
+    await discardMatchingDrafts(client, [])
+    expect(client.getDocument).not.toHaveBeenCalled()
+  })
+
+  it('deletes drafts that match published versions', async () => {
+    const {client, mockTx} = createMockClient()
+    const sharedContent = {_type: 'article', title: 'Hello'}
+
+    client.getDocument
+      .mockResolvedValueOnce({_id: 'drafts.doc1', _rev: 'rev-1', ...sharedContent})
+      .mockResolvedValueOnce({_id: 'doc1', _rev: 'rev-2', ...sharedContent})
+
+    await discardMatchingDrafts(client, ['doc1'])
+
+    expect(mockTx.delete).toHaveBeenCalledWith('drafts.doc1')
+    expect(mockTx.commit).toHaveBeenCalledWith({tag: 'release.post-publish-draft-cleanup'})
+  })
+
+  it('does not delete drafts that differ from published', async () => {
+    const {client, mockTx} = createMockClient()
+
+    client.getDocument
+      .mockResolvedValueOnce({_id: 'drafts.doc1', _rev: 'rev-1', _type: 'article', title: 'Draft'})
+      .mockResolvedValueOnce({
+        _id: 'doc1',
+        _rev: 'rev-2',
+        _type: 'article',
+        title: 'Published',
+      })
+
+    await discardMatchingDrafts(client, ['doc1'])
+
+    expect(mockTx.delete).not.toHaveBeenCalled()
+    expect(mockTx.commit).not.toHaveBeenCalled()
+  })
+
+  it('does not delete when draft does not exist', async () => {
+    const {client, mockTx} = createMockClient()
+
+    client.getDocument
+      .mockResolvedValueOnce(null) // no draft
+      .mockResolvedValueOnce({_id: 'doc1', _rev: 'rev-2', _type: 'article', title: 'Published'})
+
+    await discardMatchingDrafts(client, ['doc1'])
+
+    expect(mockTx.delete).not.toHaveBeenCalled()
+  })
+
+  it('handles multiple documents, only deleting matching drafts', async () => {
+    const {client, mockTx} = createMockClient()
+
+    // doc1: draft matches published
+    client.getDocument
+      .mockResolvedValueOnce({_id: 'drafts.doc1', _rev: 'rev-1', _type: 'article', title: 'Same'})
+      .mockResolvedValueOnce({_id: 'doc1', _rev: 'rev-2', _type: 'article', title: 'Same'})
+      // doc2: draft differs from published
+      .mockResolvedValueOnce({
+        _id: 'drafts.doc2',
+        _rev: 'rev-3',
+        _type: 'article',
+        title: 'Different',
+      })
+      .mockResolvedValueOnce({
+        _id: 'doc2',
+        _rev: 'rev-4',
+        _type: 'article',
+        title: 'Published',
+      })
+
+    await discardMatchingDrafts(client, ['doc1', 'doc2'])
+
+    expect(mockTx.delete).toHaveBeenCalledWith('drafts.doc1')
+    expect(mockTx.delete).not.toHaveBeenCalledWith('drafts.doc2')
+    expect(mockTx.delete).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('discardMatchingDraftsForRelease', () => {
+  const createMockClient = () => {
+    const mockTx = {
+      delete: vi.fn().mockReturnThis(),
+      commit: vi.fn().mockResolvedValue(undefined),
+    }
+    return {
+      client: {
+        fetch: vi.fn().mockResolvedValue([]),
+        getDocument: vi.fn().mockResolvedValue(null),
+        transaction: vi.fn().mockReturnValue(mockTx),
+      } as any,
+      mockTx,
+    }
+  }
+
+  it('uses finalDocumentStates when available', async () => {
+    const {client, mockTx} = createMockClient()
+    const sharedContent = {_type: 'article', title: 'Hello'}
+
+    client.getDocument
+      .mockResolvedValueOnce({_id: 'drafts.doc1', _rev: 'rev-1', ...sharedContent})
+      .mockResolvedValueOnce({_id: 'doc1', _rev: 'rev-2', ...sharedContent})
+
+    const release = {
+      _id: '_.releases.rTest',
+      state: 'published',
+      finalDocumentStates: [{id: 'doc1'}],
+    } as unknown as ReleaseDocument
+
+    await discardMatchingDraftsForRelease(client, release)
+
+    // Should NOT call fetch because finalDocumentStates is available
+    expect(client.fetch).not.toHaveBeenCalled()
+    expect(mockTx.delete).toHaveBeenCalledWith('drafts.doc1')
+  })
+
+  it('queries for documents when finalDocumentStates is not available', async () => {
+    const {client, mockTx} = createMockClient()
+    const sharedContent = {_type: 'article', title: 'Hello'}
+
+    client.fetch.mockResolvedValueOnce(['versions.rTest.doc1'])
+    client.getDocument
+      .mockResolvedValueOnce({_id: 'drafts.doc1', _rev: 'rev-1', ...sharedContent})
+      .mockResolvedValueOnce({_id: 'doc1', _rev: 'rev-2', ...sharedContent})
+
+    const release = {
+      _id: '_.releases.rTest',
+      state: 'published',
+      finalDocumentStates: null,
+    } as unknown as ReleaseDocument
+
+    await discardMatchingDraftsForRelease(client, release)
+
+    expect(client.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('partOfRelease'),
+      {releaseId: 'rTest'},
+      expect.objectContaining({tag: 'release.post-publish-draft-cleanup'}),
+    )
+    expect(mockTx.delete).toHaveBeenCalledWith('drafts.doc1')
+  })
+})

--- a/packages/sanity/src/core/releases/util/discardMatchingDrafts.ts
+++ b/packages/sanity/src/core/releases/util/discardMatchingDrafts.ts
@@ -1,0 +1,96 @@
+import {type ReleaseDocument, type SanityClient} from '@sanity/client'
+
+import {getDraftId, getPublishedId} from '../../util'
+import {getReleaseIdFromReleaseDocumentId} from './getReleaseIdFromReleaseDocumentId'
+
+const SYSTEM_FIELDS = ['_id', '_rev', '_updatedAt', '_createdAt']
+
+/**
+ * Compares two documents for content equality, ignoring system fields
+ * that are expected to differ between draft and published versions.
+ *
+ * @internal
+ */
+export function documentsContentMatch(
+  draftDoc: Record<string, unknown>,
+  publishedDoc: Record<string, unknown>,
+): boolean {
+  const draftEntries = Object.entries(draftDoc).filter(([key]) => !SYSTEM_FIELDS.includes(key))
+  const publishedEntries = Object.entries(publishedDoc).filter(
+    ([key]) => !SYSTEM_FIELDS.includes(key),
+  )
+
+  if (draftEntries.length !== publishedEntries.length) return false
+
+  try {
+    const normalize = (entries: [string, unknown][]) =>
+      JSON.stringify(entries.sort(([a], [b]) => a.localeCompare(b)))
+    return normalize(draftEntries) === normalize(publishedEntries)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Discards drafts that match their published counterparts for a given set of published IDs.
+ * This prevents stale drafts from persisting after a release publish.
+ *
+ * @internal
+ */
+export async function discardMatchingDrafts(
+  client: SanityClient,
+  publishedIds: string[],
+): Promise<void> {
+  if (!publishedIds.length) return
+
+  const draftIdsToDelete: string[] = []
+  await Promise.all(
+    publishedIds.map(async (publishedId) => {
+      const draftId = getDraftId(publishedId)
+      const [draftDoc, publishedDoc] = await Promise.all([
+        client.getDocument(draftId),
+        client.getDocument(publishedId),
+      ])
+
+      if (draftDoc && publishedDoc && documentsContentMatch(draftDoc, publishedDoc)) {
+        draftIdsToDelete.push(draftId)
+      }
+    }),
+  )
+
+  if (draftIdsToDelete.length > 0) {
+    const tx = client.transaction()
+    for (const draftId of draftIdsToDelete) {
+      tx.delete(draftId)
+    }
+    await tx.commit({tag: 'release.post-publish-draft-cleanup'})
+  }
+}
+
+/**
+ * After a release is published, discard any drafts that match the published version.
+ * Uses `finalDocumentStates` if available (for already-published releases),
+ * otherwise queries for documents still in the release.
+ *
+ * @internal
+ */
+export async function discardMatchingDraftsForRelease(
+  client: SanityClient,
+  release: ReleaseDocument,
+): Promise<void> {
+  const releaseId = getReleaseIdFromReleaseDocumentId(release._id)
+
+  let publishedIds: string[]
+  if (release.finalDocumentStates?.length) {
+    publishedIds = release.finalDocumentStates.map((doc) => doc.id)
+  } else {
+    const versionIds = await client.fetch<string[]>(
+      `*[sanity::partOfRelease($releaseId)]._id`,
+      {releaseId},
+      {tag: 'release.post-publish-draft-cleanup'},
+    )
+    publishedIds = [...new Set((versionIds || []).map((id) => getPublishedId(id)))]
+  }
+
+  await discardMatchingDrafts(client, publishedIds)
+}


### PR DESCRIPTION
### Description

Fixes [SAPP-3645](https://linear.app/sanity/issue/SAPP-3645).

After a content release published, draft documents were not cleaned up — the Publish button stayed active and a `drafts.<id>` record remained that matched the published version. Root cause: `client.releases.publish()` publishes version docs to their published IDs but does not discard pre-existing drafts, unlike the single-document publish path which deletes the draft in the same transaction.

Added a `discardMatchingDrafts` utility that compares draft and published content and deletes matching drafts. It runs after both manual release publishes (via `handlePublishRelease` in the operation store) and scheduled release publishes (via a reactive side-effect on the release state transition). Best-effort — cleanup failures are logged but don't break publish.

### What to review

- New `discardMatchingDrafts.ts` — content comparison + delete helpers.
- `createReleaseOperationStore.ts` — cleanup after `client.releases.publish()`.
- `createReleaseStore.ts` — reactive side-effect on scheduled publish state transition.

### Testing

- 13 new tests for the utility (content matching, dry-run handling, failure behavior).
- 4 new tests for draft cleanup in the operations store.
- All 48 release store tests pass.

### Notes for release

Fixed a bug where a draft could linger after a content release published, leaving the Publish button active despite identical published content. Drafts that match the published version are now discarded after a release publishes.
