### PR TITLE
fix(form): support programmatic focus with inline changes enabled

### DIFF
--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/StringInputPortableText.test.tsx
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/StringInputPortableText.test.tsx
@@ -26,4 +26,22 @@ describe('StringInputPortableText', () => {
       expect(input).toHaveTextContent('test')
     })
   })
+
+  it('wires up focusRef so programmatic focus works', async () => {
+    const {focusRef} = await renderStringInput({
+      render: (inputProps) => <StringInputPortableText {...inputProps} value="test" />,
+      fieldDefinition: {
+        type: 'string',
+        name: 'string',
+        title: 'String',
+      },
+    })
+
+    // The FocusBridgePlugin should have assigned an object with a focus method
+    // to the ref, allowing PrimitiveField to call focusRef.current.focus()
+    await waitFor(() => {
+      expect(focusRef.current).toBeDefined()
+      expect(typeof focusRef.current?.focus).toBe('function')
+    })
+  })
 })

--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/StringInputPortableText.tsx
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/StringInputPortableText.tsx
@@ -11,7 +11,7 @@ import {BehaviorPlugin, EventListenerPlugin} from '@portabletext/editor/plugins'
 import {OneLinePlugin} from '@portabletext/plugin-one-line'
 import {type Path} from '@sanity/types'
 import {Card, useArrayProp, useRootTheme} from '@sanity/ui'
-import {useCallback, useEffect, useState} from 'react'
+import {type MutableRefObject, useCallback, useEffect, useState} from 'react'
 import {styled} from 'styled-components'
 
 import {set, unset} from '../../../patch/patch'
@@ -76,7 +76,7 @@ export function StringInputPortableText(props: StringInputProps) {
     value: definitiveValue,
     __unstable_computeDiff: computeDiff,
   } = props
-  const {onFocus, onBlur, style} = elementProps
+  const {onFocus, onBlur, style, ref: focusRef} = elementProps
 
   const {diff, rangeDecorations, onOptimisticChange} = useOptimisticDiff({
     definitiveValue,
@@ -173,6 +173,7 @@ export function StringInputPortableText(props: StringInputProps) {
       <EditorProvider initialConfig={initialConfig}>
         <OneLinePlugin />
         <EventListenerPlugin on={handleEditorEvent} />
+        <FocusBridgePlugin focusRef={focusRef} />
         <UpdateValuePlugin value={props.value} />
         <UpdateReadOnlyPlugin readOnly={props.readOnly ?? false} />
         <BehaviorPlugin behaviors={[plainTextPasteBehaviour, plainTextOneLineBehaviour]} />
@@ -217,6 +218,27 @@ function UpdateValuePlugin(props: {value: string | undefined}) {
       value: packageValue(props.value),
     })
   }, [editor, props.value])
+
+  return null
+}
+
+/**
+ * Bridges the `focusRef` from `PrimitiveField` to the PTE editor's `focus()` method.
+ *
+ * `PrimitiveField` calls `focusRef.current?.focus()` when `member.field.focused` becomes true
+ * (e.g. during programmatic focus). Without this bridge, the ref remains unset and the
+ * PTE-backed string input never receives focus.
+ */
+function FocusBridgePlugin(props: {focusRef: MutableRefObject<{focus: () => void} | undefined>}) {
+  const editor = useEditor()
+  const {focusRef} = props
+
+  useEffect(() => {
+    focusRef.current = {focus: () => editor.send({type: 'focus'})}
+    return () => {
+      focusRef.current = undefined
+    }
+  }, [editor, focusRef])
 
   return null
 }


### PR DESCRIPTION
### Description

Fixes [SAPP-3492](https://linear.app/sanity/issue/SAPP-3492).

Programmatic focus (e.g. from clicking a divergence to inspect) didn't work on string fields when inline changes mode was on. Root cause: `StringInputPortableText` (used when `displayInlineChanges` is true) didn't consume the `ref` from `elementProps`, so `focusRef.current` stayed `undefined` and `PrimitiveField`'s `.focus()` call was a no-op. Added a `FocusBridgePlugin` that wires the `focusRef` to the PTE editor via `editor.send({type: 'focus'})`.

### What to review

- `StringInputPortableText.tsx` — extracts `ref: focusRef` from `elementProps`, renders a new `FocusBridgePlugin` inside `EditorProvider`.
- New test verifying `focusRef.current` is set up with a working `focus()` method.

### Testing

- 1 new test for the FocusBridgePlugin.
- All 6 StringInput tests pass (both Basic and PortableText variants).

### Notes for release

Fixed programmatic focus (e.g. jumping to a divergence from the overview) when inline changes mode is on. Previously the focus was silently dropped for string fields in this mode.
