### PR TITLE
chore(e2e): show pass/fail status in PR comment and report link

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -358,12 +358,7 @@ jobs:
 
             ${{ steps.linked-summary.outputs.text }} • [view run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
-            <details>
-            <summary>Studio</summary>
-
             **Studio:** ${{ needs.deploy-preview.outputs.preview_url }}
-
-            </details>
 
       - name: Update PR Comment (tests failed)
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,7 +46,7 @@ jobs:
           message: |
             ### 🧪 E2E Tests
 
-            Setting up preview environment and running tests…
+            ⏳ Setting up preview environment and running tests… • [view progress](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
       - name: Store Playwright's Version
         if: steps.changes.outputs.has_changes == 'true'
@@ -153,21 +153,7 @@ jobs:
           message: |
             ### 🧪 E2E Tests
 
-            **Report:** Tests are running, report will appear here when done.
-            **Preview:** ${{ steps.deploy.outputs.DEPLOY_URL }}
-
-            <details>
-            <summary>Environment variables for local testing</summary>
-
-            ```
-            SANITY_E2E_PROJECT_ID=${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
-            SANITY_E2E_BASE_URL=${{ steps.deploy.outputs.DEPLOY_URL }}
-            SANITY_E2E_DATASET=${{ env.CHROMIUM_DATASET }}
-            SANITY_E2E_DATASET_CHROMIUM=${{ env.CHROMIUM_DATASET }}
-            SANITY_E2E_DATASET_FIREFOX=${{ env.FIREFOX_DATASET }}
-            ```
-
-            </details>
+            ⏳ Running tests… • [view progress](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
   playwright-test:
     timeout-minutes: 30
@@ -228,12 +214,20 @@ jobs:
   e2e-status:
     name: "E2E Status"
     runs-on: ubuntu-latest
-    needs: [playwright-test]
+    needs: [playwright-test, deploy-report]
     if: ${{ !cancelled() }}
     steps:
       - name: Check E2E test matrix status
         run: |
           result="${{ needs.playwright-test.result }}"
+          report_url="${{ needs.deploy-report.outputs.report_url }}"
+
+          if [ -n "$report_url" ]; then
+            echo "## E2E Test Report" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**[View Full Report]($report_url)**" >> $GITHUB_STEP_SUMMARY
+          fi
+
           if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
             echo "E2E test matrix failed with status: $result"
             exit 1
@@ -243,6 +237,14 @@ jobs:
     needs: [install, playwright-test]
     if: always() && needs.install.outputs.has_code_changes == 'true'
     runs-on: ubuntu-latest
+    outputs:
+      test_summary: ${{ steps.summary.outputs.summary }}
+      passed: ${{ steps.summary.outputs.passed }}
+      failed: ${{ steps.summary.outputs.failed }}
+      flaky: ${{ steps.summary.outputs.flaky }}
+      skipped: ${{ steps.summary.outputs.skipped }}
+      failed_files: ${{ steps.summary.outputs.failed_files }}
+      failed_files_formatted: ${{ steps.summary.outputs.failed_files_formatted }}
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
@@ -255,7 +257,31 @@ jobs:
           path: all-blob-reports
 
       - name: Merge into HTML Report
-        run: npx playwright merge-reports --reporter html all-blob-reports/blob-report
+        run: npx playwright merge-reports --reporter html,./e2e/reporters/summary.ts all-blob-reports/blob-report
+
+      - name: Extract test summary
+        id: summary
+        run: |
+          node -e "
+            const s = JSON.parse(require('fs').readFileSync('test-summary.json', 'utf8'));
+            const parts = [];
+            if (s.passed) parts.push('🟢 ' + s.passed + ' passed');
+            if (s.failed) parts.push('🔴 ' + s.failed + ' failed');
+            if (s.flaky) parts.push('🟡 ' + s.flaky + ' flaky');
+            if (s.skipped) parts.push('⚪ ' + s.skipped + ' skipped');
+            console.log('summary=' + parts.join(' • '));
+            console.log('passed=' + s.passed);
+            console.log('failed=' + s.failed);
+            console.log('flaky=' + s.flaky);
+            console.log('skipped=' + s.skipped);
+            if (s.failedFiles.length) console.log('failed_files=' + s.failedFiles.join(' '));
+            if (s.failedFilesFormatted) {
+              // Use heredoc for multiline output
+              process.stdout.write('failed_files_formatted<<ENDOFFILES\n');
+              process.stdout.write(s.failedFilesFormatted + '\n');
+              process.stdout.write('ENDOFFILES\n');
+            }
+          " >> $GITHUB_OUTPUT
 
       - name: Upload HTML report
         id: upload-playwright-report
@@ -292,7 +318,6 @@ jobs:
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_E2E_STUDIO_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_E2E_STUDIO_PROJECT_ID }}
-          COMMIT_MESSAGE: ${{ github.event.head_commit.message || github.event.pull_request.title }}
         run: |
           echo "REPORT_URL=$(vercel deploy --prebuilt \
             --token=${{ secrets.VERCEL_E2E_STUDIO_TOKEN }} \
@@ -303,38 +328,69 @@ jobs:
             -m githubRunId="${{ github.run_id }}" \
             | tail -n 1)" >> $GITHUB_OUTPUT
 
-      - name: Update PR Comment with report link
+      - name: Build linked summary
+        id: linked-summary
+        env:
+          REPORT_URL: ${{ steps.deploy.outputs.REPORT_URL }}
+          PASSED: ${{ needs.merge-reports.outputs.passed }}
+          FAILED: ${{ needs.merge-reports.outputs.failed }}
+          FLAKY: ${{ needs.merge-reports.outputs.flaky }}
+          SKIPPED: ${{ needs.merge-reports.outputs.skipped }}
+        run: |
+          node -e "
+            const u = process.env.REPORT_URL;
+            const s = {passed: +process.env.PASSED, failed: +process.env.FAILED, flaky: +process.env.FLAKY, skipped: +process.env.SKIPPED};
+            const parts = [];
+            if (s.passed) parts.push('[🟢 ' + s.passed + ' passed](' + u + '#?q=s%3Apassed)');
+            if (s.failed) parts.push('[🔴 ' + s.failed + ' failed](' + u + '#?q=s%3Afailed)');
+            if (s.flaky) parts.push('[🟡 ' + s.flaky + ' flaky](' + u + '#?q=s%3Aflaky)');
+            if (s.skipped) parts.push('([⚪ ' + s.skipped + ' skipped](' + u + '#?q=s%3Askipped))');
+            console.log('text=' + parts.join(' • ') + ' • [view full report](' + u + ')');
+          " >> $GITHUB_OUTPUT
+
+      - name: Update PR Comment (tests passed)
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && needs.playwright-test.result == 'success'
         with:
           comment-tag: "e2e-status"
           message: |
-            ### 🧪 E2E Tests
+            ### ✅ E2E Tests
 
-            **Report:** ${{ steps.deploy.outputs.REPORT_URL }}
-            **Preview:** ${{ needs.deploy-preview.outputs.preview_url }}
-
-            Includes test results, traces and videos of any failures.
+            ${{ steps.linked-summary.outputs.text }} • [view run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
             <details>
-            <summary>Environment variables for local testing</summary>
+            <summary>Studio</summary>
 
-            ```
-            SANITY_E2E_PROJECT_ID=${{ vars.SANITY_E2E_PROJECT_ID_STAGING }}
-            SANITY_E2E_BASE_URL=${{ needs.deploy-preview.outputs.preview_url }}
-            SANITY_E2E_DATASET=${{ env.CHROMIUM_DATASET }}
-            SANITY_E2E_DATASET_CHROMIUM=${{ env.CHROMIUM_DATASET }}
-            SANITY_E2E_DATASET_FIREFOX=${{ env.FIREFOX_DATASET }}
-            ```
+            **Studio:** ${{ needs.deploy-preview.outputs.preview_url }}
 
             </details>
 
-      - name: Write Job Summary
-        if: always() && steps.deploy.outputs.REPORT_URL != ''
-        run: |
-          echo "## E2E Test Report" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**[View Full Report](${{ steps.deploy.outputs.REPORT_URL }})**" >> $GITHUB_STEP_SUMMARY
+      - name: Update PR Comment (tests failed)
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
+        if: github.event_name == 'pull_request' && needs.playwright-test.result != 'success'
+        with:
+          comment-tag: "e2e-status"
+          message: |
+            ### ❌ E2E Tests
+
+            ${{ steps.linked-summary.outputs.text }} • [view run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+            <details>
+            <summary>Debug failing tests locally</summary>
+
+            ```sh
+            SANITY_E2E_PROJECT_ID=${{ vars.SANITY_E2E_PROJECT_ID_STAGING }} \
+            SANITY_E2E_BASE_URL=${{ needs.deploy-preview.outputs.preview_url }} \
+            SANITY_E2E_DATASET=${{ env.CHROMIUM_DATASET }} \
+            SANITY_E2E_DATASET_CHROMIUM=${{ env.CHROMIUM_DATASET }} \
+            SANITY_E2E_DATASET_FIREFOX=${{ env.FIREFOX_DATASET }} \
+            pnpm test:e2e --headed \
+              ${{ needs.merge-reports.outputs.failed_files_formatted }}
+            ```
+
+            **Studio:** ${{ needs.deploy-preview.outputs.preview_url }}
+
+            </details>
 
       - name: Add commit comment with report link
         if: github.event_name == 'push' && steps.deploy.outputs.REPORT_URL != '' && needs.playwright-test.result == 'failure'
@@ -342,10 +398,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh api repos/${{ github.repository }}/commits/${{ github.sha }}/comments \
-            -f body="**[E2E Test Report](${{ steps.deploy.outputs.REPORT_URL }})**"
+            -f body="**[E2E Test Report](${{ steps.deploy.outputs.REPORT_URL }}#?q=s%3Afailed)**"
 
   update-comment-on-failure:
-    needs: [install, deploy-preview, playwright-test, deploy-report]
+    needs: [install, deploy-preview, playwright-test, merge-reports, deploy-report]
     if: |
       always()
       && github.event_name == 'pull_request'
@@ -353,12 +409,31 @@ jobs:
       && needs.deploy-report.result != 'success'
     runs-on: ubuntu-latest
     steps:
-      - name: Update PR Comment with final status
+      - name: Update PR Comment (cancelled)
+        if: needs.playwright-test.result == 'cancelled'
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
         with:
           comment-tag: "e2e-status"
           message: |
-            ### 🧪 E2E Tests
+            ### ⚪ E2E Tests
 
-            **Report:** ${{ needs.playwright-test.result == 'cancelled' && 'Tests were cancelled.' || format('Download from [Actions artifacts]({0}/{1}/actions/runs/{2}).', github.server_url, github.repository, github.run_id) }}
-            **Preview:** ${{ needs.deploy-preview.outputs.preview_url || 'Not available.' }}
+            Cancelled • [view run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+      - name: Update PR Comment (report deploy failed)
+        if: needs.playwright-test.result != 'cancelled'
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
+        with:
+          comment-tag: "e2e-status"
+          message: |
+            ### ${{ needs.playwright-test.result == 'success' && '✅' || '❌' }} E2E Tests
+
+            ${{ needs.merge-reports.outputs.test_summary || 'Report deploy failed' }} • [view run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+            **Report:** [Download from Actions artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+            <details>
+            <summary>Studio</summary>
+
+            **Studio:** ${{ needs.deploy-preview.outputs.preview_url || 'Not available.' }}
+
+            </details>

--- a/e2e/reporters/summary.ts
+++ b/e2e/reporters/summary.ts
@@ -13,38 +13,45 @@ import type {FullResult, Reporter, TestCase} from '@playwright/test/reporter'
  *   npx playwright merge-reports --reporter html,./e2e/reporters/summary.ts blob-reports
  */
 export default class SummaryReporter implements Reporter {
-  private passed = 0
-  private failed = 0
-  private flaky = 0
-  private skipped = 0
-  private failedFiles = new Set<string>()
+  private tests: TestCase[] = []
 
   onTestEnd(test: TestCase) {
-    switch (test.outcome()) {
-      case 'expected':
-        this.passed++
-        break
-      case 'unexpected':
-        this.failed++
-        if (test.location.file) this.failedFiles.add(test.location.file)
-        break
-      case 'flaky':
-        this.flaky++
-        break
-      case 'skipped':
-        this.skipped++
-        break
-    }
+    this.tests.push(test)
   }
 
   onEnd(_result: FullResult) {
     const cwd = process.cwd()
-    const failedFiles = [...this.failedFiles].map((f) => path.relative(cwd, f))
+    const counts = {passed: 0, failed: 0, flaky: 0, skipped: 0}
+    const failedFileSet = new Set<string>()
+
+    // Deduplicate by test ID — onTestEnd is called per attempt (including retries),
+    // so we only want the last attempt for each test.
+    const lastByTestId = new Map<string, TestCase>()
+    for (const test of this.tests) {
+      lastByTestId.set(test.id, test)
+    }
+
+    for (const test of lastByTestId.values()) {
+      switch (test.outcome()) {
+        case 'expected':
+          counts.passed++
+          break
+        case 'unexpected':
+          counts.failed++
+          if (test.location.file) failedFileSet.add(test.location.file)
+          break
+        case 'flaky':
+          counts.flaky++
+          break
+        case 'skipped':
+          counts.skipped++
+          break
+      }
+    }
+
+    const failedFiles = [...failedFileSet].map((f) => path.relative(cwd, f))
     const summary = {
-      passed: this.passed,
-      failed: this.failed,
-      flaky: this.flaky,
-      skipped: this.skipped,
+      ...counts,
       failedFiles,
       // Pre-formatted for use in shell code blocks: each file on its own line with \
       failedFilesFormatted: failedFiles.join(' \\\n  '),

--- a/e2e/reporters/summary.ts
+++ b/e2e/reporters/summary.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import type {FullResult, Reporter, TestCase} from '@playwright/test/reporter'
+
+/**
+ * Custom Playwright reporter that outputs a JSON summary of test results.
+ *
+ * Writes `test-summary.json` with counts and failed file paths.
+ * Used by the CI workflow to build PR comments with test summaries.
+ *
+ * Usage with merge-reports:
+ *   npx playwright merge-reports --reporter html,./e2e/reporters/summary.ts blob-reports
+ */
+export default class SummaryReporter implements Reporter {
+  private passed = 0
+  private failed = 0
+  private flaky = 0
+  private skipped = 0
+  private failedFiles = new Set<string>()
+
+  onTestEnd(test: TestCase) {
+    switch (test.outcome()) {
+      case 'expected':
+        this.passed++
+        break
+      case 'unexpected':
+        this.failed++
+        if (test.location.file) this.failedFiles.add(test.location.file)
+        break
+      case 'flaky':
+        this.flaky++
+        break
+      case 'skipped':
+        this.skipped++
+        break
+    }
+  }
+
+  onEnd(_result: FullResult) {
+    const cwd = process.cwd()
+    const failedFiles = [...this.failedFiles].map((f) => path.relative(cwd, f))
+    const summary = {
+      passed: this.passed,
+      failed: this.failed,
+      flaky: this.flaky,
+      skipped: this.skipped,
+      failedFiles,
+      // Pre-formatted for use in shell code blocks: each file on its own line with \
+      failedFilesFormatted: failedFiles.join(' \\\n  '),
+    }
+    fs.writeFileSync('test-summary.json', JSON.stringify(summary))
+  }
+}


### PR DESCRIPTION
### Description

Makes E2E test results easier to find and act on:
- One PR comment instead of two, updated as the workflow progresses.
- Click any test count to jump to a filtered view in the report (e.g. just failures)
- On failure: copy-pasteable command to reproduce locally with `--headed` and the exact failing files
- On `main`: failing commits get a comment linking directly to the report

### What to review
- `e2e/reporters/summary.ts` — custom Playwright reporter
- `.github/workflows/e2e.yml` — new jobs and comment logic
- The `if` conditions on jobs for correctness across all scenarios

PS: Sorry about the js-in-yaml 🙈 

### Testing

Triggered E2E runs on this PR to verify all comment states.

### Notes for release
n/a