### PR TITLE
fix(ci): exclude markdown files from v8 coverage

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -35,6 +35,8 @@ export default defineConfig({
         '**/__telemetry__/**',
         // exclude internal
         'packages/@repo/**',
+        // exclude non-source files that the v8 coverage provider can't parse
+        '**/*.md',
       ],
       reportOnFailure: true,
       clean: true,


### PR DESCRIPTION
### Description

- The coverage `include` pattern `packages/**/src/**` matched `.md` files inside `src/` directories (e.g. `packages/sanity/src/router/README.md`)
- The V8 coverage provider tried to parse these via Rollup, producing `RollupError: Expected ident` failures
- The resulting `console.error` output during coverage processing raced with vitest 4.1.4's worker teardown, causing flaky `EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending`
- Started occurring after the vitest upgrade from 4.0.18 to 4.1.4

### Testing

Fixes a CI-only flake that can't be reproduced locally (requires coverage + sharded workers). Unit tests should no longer randomly fail.

### Notes for release
