### PR TITLE
fix(sanity): cancel fetch response bodies to prevent connection blocking

### DIFF
--- a/packages/sanity/src/core/feedback/__tests__/useFeedbackAvailable.test.ts
+++ b/packages/sanity/src/core/feedback/__tests__/useFeedbackAvailable.test.ts
@@ -116,4 +116,43 @@ describe('useFeedbackAvailable', () => {
     })
     expect(fetch).toHaveBeenCalledTimes(1)
   })
+
+  it('should consume or cancel the response body to avoid holding the HTTP stream open', async () => {
+    // An unconsumed fetch() body keeps the underlying HTTP stream alive,
+    // which can cause head-of-line blocking on multiplexed connections (H2/H3).
+    const bodyCancel = vi.fn(() => Promise.resolve())
+    const bodyText = vi.fn(() => Promise.resolve(''))
+    const bodyJson = vi.fn(() => Promise.resolve({}))
+    const bodyArrayBuffer = vi.fn(() => Promise.resolve(new ArrayBuffer(0)))
+
+    const mockBody = {
+      cancel: bodyCancel,
+      getReader: vi.fn(),
+      locked: false,
+      pipeTo: vi.fn(),
+      pipeThrough: vi.fn(),
+      tee: vi.fn(),
+    } as unknown as ReadableStream
+
+    const mockResponse = new Response(null, {status: 200})
+    Object.defineProperty(mockResponse, 'body', {value: mockBody})
+    Object.defineProperty(mockResponse, 'text', {value: bodyText})
+    Object.defineProperty(mockResponse, 'json', {value: bodyJson})
+    Object.defineProperty(mockResponse, 'arrayBuffer', {value: bodyArrayBuffer})
+
+    vi.mocked(fetch).mockResolvedValue(mockResponse)
+
+    renderHook(() => useFeedbackAvailable({dsn}))
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(1)
+    })
+
+    const bodyWasConsumed =
+      bodyCancel.mock.calls.length > 0 ||
+      bodyText.mock.calls.length > 0 ||
+      bodyJson.mock.calls.length > 0 ||
+      bodyArrayBuffer.mock.calls.length > 0
+
+    expect(bodyWasConsumed).toBe(true)
+  })
 })

--- a/packages/sanity/src/core/feedback/hooks/useFeedbackAvailable.ts
+++ b/packages/sanity/src/core/feedback/hooks/useFeedbackAvailable.ts
@@ -35,7 +35,13 @@ export function useFeedbackAvailable(options: UseFeedbackAvailableOptions): bool
       // 502 → error: Sentry unreachable
       // catch → error: tunnel itself unreachable (ad blocker, network error)
 
-      .then((response) => setAvailable(response.ok))
+      .then((response) => {
+        // Cancel the body stream to free the underlying HTTP connection.
+        // Without this, the unconsumed body keeps the H2/H3 stream open,
+        // which can cause head-of-line blocking on multiplexed connections.
+        void response.body?.cancel()
+        setAvailable(response.ok)
+      })
       .catch(() => setAvailable(false))
   }, [dsn, skip])
 

--- a/packages/sanity/src/core/network/isUsingLegacyHttp.test.ts
+++ b/packages/sanity/src/core/network/isUsingLegacyHttp.test.ts
@@ -1,0 +1,107 @@
+import {type SanityClient} from '@sanity/client'
+import {firstValueFrom} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {isUsingLegacyHttp} from './isUsingLegacyHttp'
+
+describe('isUsingLegacyHttp', () => {
+  let originalPerformanceObserver: typeof PerformanceObserver
+  let originalPerformanceResourceTiming: typeof PerformanceResourceTiming
+
+  beforeEach(() => {
+    originalPerformanceObserver = globalThis.PerformanceObserver
+    originalPerformanceResourceTiming = globalThis.PerformanceResourceTiming
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    globalThis.PerformanceObserver = originalPerformanceObserver
+    globalThis.PerformanceResourceTiming = originalPerformanceResourceTiming
+    vi.restoreAllMocks()
+  })
+
+  describe('response body consumption', () => {
+    it('should consume or cancel the response body to avoid holding the HTTP stream open', async () => {
+      // Track whether the response body was consumed or cancelled.
+      // An unconsumed fetch() body keeps the underlying HTTP stream alive,
+      // which can cause head-of-line blocking on multiplexed connections (H2/H3).
+      const bodyCancel = vi.fn(() => Promise.resolve())
+      const bodyText = vi.fn(() => Promise.resolve(''))
+      const bodyJson = vi.fn(() => Promise.resolve({}))
+      const bodyArrayBuffer = vi.fn(() => Promise.resolve(new ArrayBuffer(0)))
+
+      const mockBody = {
+        cancel: bodyCancel,
+        getReader: vi.fn(),
+        locked: false,
+        pipeTo: vi.fn(),
+        pipeThrough: vi.fn(),
+        tee: vi.fn(),
+      } as unknown as ReadableStream
+
+      const mockResponse = new Response('pong', {status: 200})
+      // Replace the body with our spy-able version
+      Object.defineProperty(mockResponse, 'body', {value: mockBody})
+      Object.defineProperty(mockResponse, 'text', {value: bodyText})
+      Object.defineProperty(mockResponse, 'json', {value: bodyJson})
+      Object.defineProperty(mockResponse, 'arrayBuffer', {
+        value: bodyArrayBuffer,
+      })
+
+      vi.mocked(fetch).mockResolvedValue(mockResponse)
+
+      // Mock PerformanceObserver to emit a timing entry so the observable completes
+      const mockEntry = {
+        name: 'https://test.api.sanity.io/v2025-02-19/ping?tag=sanity.studio.protocol-check',
+        nextHopProtocol: 'h3',
+      }
+      const mockObserve = vi.fn()
+      const mockDisconnect = vi.fn()
+
+      vi.stubGlobal(
+        'PerformanceObserver',
+        class {
+          callback: (list: {getEntries: () => unknown[]}) => void
+          constructor(callback: (list: {getEntries: () => unknown[]}) => void) {
+            this.callback = callback
+          }
+          observe() {
+            mockObserve()
+            // Emit the entry async so the fetch can resolve first
+            setTimeout(() => {
+              this.callback({getEntries: () => [mockEntry]})
+            }, 0)
+          }
+          disconnect() {
+            mockDisconnect()
+          }
+        },
+      )
+      // oxlint-disable-next-line typescript/no-extraneous-class
+      const FakePerformanceResourceTiming = class FakePerformanceResourceTiming {}
+      vi.stubGlobal('PerformanceResourceTiming', FakePerformanceResourceTiming)
+
+      // Make mockEntry pass the instanceof check
+      Object.setPrototypeOf(mockEntry, FakePerformanceResourceTiming.prototype)
+
+      const client = {
+        getUrl: (path: string) => `https://test.api.sanity.io/v2025-02-19${path}`,
+      } as unknown as SanityClient
+
+      const result = await firstValueFrom(isUsingLegacyHttp(client))
+
+      // The protocol was detected
+      expect(result).toBe(false) // h3 is not legacy
+
+      // The critical assertion: the response body must have been consumed or cancelled.
+      // Any one of these methods being called is sufficient — it means the stream was freed.
+      const bodyWasConsumed =
+        bodyCancel.mock.calls.length > 0 ||
+        bodyText.mock.calls.length > 0 ||
+        bodyJson.mock.calls.length > 0 ||
+        bodyArrayBuffer.mock.calls.length > 0
+
+      expect(bodyWasConsumed).toBe(true)
+    })
+  })
+})

--- a/packages/sanity/src/core/network/isUsingLegacyHttp.ts
+++ b/packages/sanity/src/core/network/isUsingLegacyHttp.ts
@@ -83,7 +83,15 @@ function detectProtocol(checkUrl: string): Observable<string | undefined> {
     ),
   )
 
-  return defer(() => fetch(checkUrl)).pipe(
+  return defer(() =>
+    fetch(checkUrl).then((res) => {
+      // Cancel the body stream to free the underlying HTTP connection.
+      // Without this, the unconsumed body keeps the H2/H3 stream open,
+      // which can cause head-of-line blocking on multiplexed connections.
+      void res.body?.cancel()
+      return res
+    }),
+  ).pipe(
     // when the request is over, we map it to the corresponding timing entry
     mergeMap(() => timingEntry),
     // Race the actual timing detection against a 2.5s timer.

--- a/packages/sanity/src/core/network/unconsumedBodyBlocking.test.ts
+++ b/packages/sanity/src/core/network/unconsumedBodyBlocking.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+import {createServer, type Server} from 'node:http'
+import {type AddressInfo} from 'node:net'
+
+import {afterAll, beforeAll, describe, expect, it} from 'vitest'
+
+/**
+ * Demonstrates that not consuming a fetch() response body holds the underlying
+ * TCP connection open, preventing reuse by later requests.
+ *
+ * Uses a server that streams its response body slowly so the body is still
+ * in-flight when the test issues the next request. This makes the blocking
+ * unambiguous: undici cannot reuse a connection whose response body hasn't
+ * been fully received, so every unconsumed request forces a new TCP connection.
+ *
+ * In the browser the same principle applies at the HTTP/2 and HTTP/3 stream
+ * level — an unconsumed body keeps the stream alive, consumes connection-level
+ * flow-control window, and under load causes head-of-line blocking of unrelated
+ * requests sharing the same multiplexed connection.
+ */
+describe('unconsumed fetch body prevents connection reuse', () => {
+  const REQUEST_COUNT = 5
+  const BODY_STREAM_DURATION_MS = 300
+
+  function createStreamingServer(): Promise<{
+    url: string
+    connections: () => number
+    close: () => Promise<void>
+  }> {
+    let connectionCount = 0
+    const server: Server = createServer((_req, res) => {
+      res.writeHead(200, {'content-type': 'text/plain'})
+      res.write('start\n')
+      const interval = setInterval(() => res.write('.\n'), 50)
+      setTimeout(() => {
+        clearInterval(interval)
+        res.end('done\n')
+      }, BODY_STREAM_DURATION_MS)
+    })
+    server.on('connection', () => {
+      connectionCount++
+    })
+    return new Promise((resolve) =>
+      server.listen(0, '127.0.0.1', () => {
+        const {port} = server.address() as AddressInfo
+        resolve({
+          url: `http://127.0.0.1:${port}/ping`,
+          connections: () => connectionCount,
+          close: () => new Promise<void>((r) => server.close(() => r())),
+        })
+      }),
+    )
+  }
+
+  let unconsumed: Awaited<ReturnType<typeof createStreamingServer>>
+  let consumed: Awaited<ReturnType<typeof createStreamingServer>>
+
+  beforeAll(async () => {
+    // Each scenario gets its own server (and therefore its own origin + pool).
+    ;[unconsumed, consumed] = await Promise.all([createStreamingServer(), createStreamingServer()])
+
+    // --- unconsumed: only read headers, ignore body ---
+    for (let i = 0; i < REQUEST_COUNT; i++) {
+      const res = await fetch(unconsumed.url)
+      res.headers.get('content-type')
+    }
+
+    // --- consumed: fully read body with text() ---
+    for (let i = 0; i < REQUEST_COUNT; i++) {
+      const res = await fetch(consumed.url)
+      await res.text()
+    }
+  })
+
+  afterAll(async () => {
+    await Promise.all([unconsumed.close(), consumed.close()])
+  })
+
+  it('opens one TCP connection per request when body is not consumed', () => {
+    // Each sequential fetch() must open a new TCP connection because the
+    // previous connection is still occupied by its unfinished response body.
+    expect(unconsumed.connections()).toBe(REQUEST_COUNT)
+  })
+
+  it('reuses connections when body is fully consumed', () => {
+    // text() waits for the complete body, then returns the connection to
+    // the pool. The next request reuses the existing connection.
+    expect(consumed.connections()).toBeLessThan(unconsumed.connections())
+  })
+})

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.test.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.test.ts
@@ -1759,6 +1759,81 @@ describe('checkoutPair -- latency and mutation performance reporting', () => {
 
     sub.unsubscribe()
   })
+
+  test('shard info fetch should consume or cancel the response body to avoid holding the HTTP stream open', async () => {
+    // An unconsumed fetch() body keeps the underlying HTTP/2 or HTTP/3 stream alive,
+    // which can cause head-of-line blocking on multiplexed connections.
+    // The shard info fetch only reads a header — it must also drain or cancel the body.
+    const bodyCancel = vi.fn(() => Promise.resolve())
+    const bodyText = vi.fn(() => Promise.resolve(''))
+    const bodyJson = vi.fn(() => Promise.resolve({}))
+    const bodyArrayBuffer = vi.fn(() => Promise.resolve(new ArrayBuffer(0)))
+
+    const mockBody = {
+      cancel: bodyCancel,
+      getReader: vi.fn(),
+      locked: false,
+      pipeTo: vi.fn(),
+      pipeThrough: vi.fn(),
+      tee: vi.fn(),
+    } as unknown as ReadableStream
+
+    const mockResponse = new Response('pong', {
+      status: 200,
+      headers: {'X-Sanity-Shard': 'test-shard'},
+    })
+    Object.defineProperty(mockResponse, 'body', {value: mockBody})
+    Object.defineProperty(mockResponse, 'text', {value: bodyText})
+    Object.defineProperty(mockResponse, 'json', {value: bodyJson})
+    Object.defineProperty(mockResponse, 'arrayBuffer', {value: bodyArrayBuffer})
+
+    vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse)
+
+    const listenerSubject = new Subject()
+    const commitSubject = new Subject()
+    const onReportLatency = vi.fn()
+
+    const testClient = {
+      ...client,
+      dataRequest: vi.fn(() => commitSubject),
+      observable: {
+        ...client.observable,
+        listen: () => merge(of({type: 'welcome'}).pipe(delay(0)), listenerSubject),
+      },
+      getUrl: (url: string) => url,
+      getDataUrl: (path: string) => `/data/${path}`,
+    }
+
+    const {draft, published} = checkoutPair(testClient as any as SanityClient, idPair, of(false), {
+      onReportLatency,
+    })
+    const combined = merge(draft.events, published.events)
+    const sub = combined.subscribe()
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Trigger a mutation so reportLatency resolves the shard info
+    draft.mutate(draft.patch([{set: {title: 'test'}}]))
+    draft.commit()
+    commitSubject.next({transactionId: 'tx-body', results: []})
+    commitSubject.complete()
+    await vi.advanceTimersByTimeAsync(0)
+
+    listenerSubject.next(createMutationEvent('tx-body', 'draftId', 'any', 'rev2'))
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(0)
+
+    // The response body must have been consumed or cancelled.
+    const bodyWasConsumed =
+      bodyCancel.mock.calls.length > 0 ||
+      bodyText.mock.calls.length > 0 ||
+      bodyJson.mock.calls.length > 0 ||
+      bodyArrayBuffer.mock.calls.length > 0
+
+    expect(bodyWasConsumed).toBe(true)
+
+    sub.unsubscribe()
+  })
 })
 
 describe('checkoutPair -- slow commit warning', () => {

--- a/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/_legacy/document/document-pair/checkoutPair.ts
@@ -442,7 +442,14 @@ function reportLatency(options: {
     shardInfo = fetch(client.getUrl(client.getDataUrl('ping')), {
       signal: AbortSignal.timeout(FETCH_SHARD_TIMEOUT),
     })
-      .then((response) => response.headers.get('X-Sanity-Shard') || undefined)
+      .then((response) => {
+        const shard = response.headers.get('X-Sanity-Shard') || undefined
+        // Cancel the body stream to free the underlying HTTP connection.
+        // Without this, the unconsumed body keeps the H2/H3 stream open,
+        // which can cause head-of-line blocking on multiplexed connections.
+        void response.body?.cancel()
+        return shard
+      })
       .catch(() => undefined)
   } catch {
     shardInfo = Promise.resolve(undefined)


### PR DESCRIPTION
## Summary

Three places in the studio use raw `fetch()` and only read headers or status without consuming the response body. This leaves the underlying HTTP stream open, preventing connection reuse and causing head-of-line blocking on multiplexed H2/H3 connections.

## What changed

Added `response.body?.cancel()` after reading headers in:

- `checkoutPair.ts` — shard info fetch (reads `X-Sanity-Shard` header, ignores body)
- `isUsingLegacyHttp.ts` — protocol detection fetch (only needs PerformanceResourceTiming, ignores response entirely)
- `useFeedbackAvailable.ts` — feedback tunnel check (only checks `response.ok`)

## Why

A HAR file showed a 41-byte `/data/ping/production` response taking **156 seconds** in the "receive" phase while all other requests to the same origin were stalled. The server responded in 465ms — the remaining 155s was the browser waiting on the unconsumed body stream.

All 97 requests to the API shared a single HTTP/3 connection. The unconsumed ping response body held the stream open, blocking connection-level flow control and stalling subsequent requests.

## Testing

- Unit tests verify `body.cancel()` is called in all three code paths
- Integration test (`unconsumedBodyBlocking.test.ts`) spins up a real HTTP server and proves unconsumed bodies prevent connection reuse (5 connections for 5 requests vs 1 with consumption)
- Standalone local repro script for manual verification of the behavior showed the same around calling `text() / `cancel()`