### PR TITLE
fix(sanity): use `@sanity/uuid` to produce feedback session id

### DIFF
--- a/packages/sanity/src/core/feedback/hooks/useStudioFeedbackTags.ts
+++ b/packages/sanity/src/core/feedback/hooks/useStudioFeedbackTags.ts
@@ -1,3 +1,4 @@
+import {uuid} from '@sanity/uuid'
 import {useCallback, useMemo, version as reactVersion} from 'react'
 import {useRouterState} from 'sanity/router'
 
@@ -11,7 +12,7 @@ import {useWorkspace} from '../../studio/workspace'
 import {SANITY_VERSION} from '../../version'
 import {type BaseFeedbackTags, type DynamicFeedbackTags} from '../types'
 
-const sessionId = typeof crypto !== 'undefined' ? crypto.randomUUID() : Math.random().toString(36)
+const sessionId = uuid()
 
 interface PluginEntry {
   name: string


### PR DESCRIPTION
### Description

The implementation currently attempts to use `crypto.randomUUID`, and falls back to `Math.random` if it's unavailable.

The check fails in non-secure environments where `crypto` is defined, but `crypto.randomUUID` is not.

`@sanity/uuid` is already loaded and conventionally used across the codebase for UUID generation, so this change simply switches to that to avoid additional work in the feedback module.

### What to review

The feedback session id.

### Testing

Existing tests pass.