### PR TITLE
fix(form): maintain select button position with disableNew on image fields

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/FileInput/FileAsset.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FileAsset.tsx
@@ -1,6 +1,6 @@
 import {isFileSource} from '@sanity/asset-utils'
 import {type AssetSource} from '@sanity/types'
-import {Box, Card} from '@sanity/ui'
+import {Box, Card, Flex} from '@sanity/ui'
 import {useCallback, useMemo} from 'react'
 
 import {ChangeIndicator} from '../../../../changeIndicators'
@@ -149,7 +149,9 @@ function FileUploadPlaceHolder(props: FileAssetProps & {disableNew?: boolean}) {
   return (
     <Card tone={readOnly ? 'transparent' : 'inherit'} border paddingX={3} paddingY={2} radius={2}>
       {disableNew ? (
-        browseElement
+        <Flex align="center" justify="flex-end">
+          {browseElement}
+        </Flex>
       ) : (
         <UploadPlaceholder
           assetSources={assetSources}

--- a/packages/sanity/src/core/form/inputs/files/FileInput/__tests__/fileInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/__tests__/fileInput.test.tsx
@@ -37,6 +37,28 @@ describe('FileInput with empty state', () => {
 
   it.todo('renders new file when a new file in uploaded')
 
+  it('renders browse button right-aligned when disableNew is true', async () => {
+    await renderFileInput({
+      fieldDefinition: {
+        name: 'someFile',
+        title: 'A simple file',
+        type: 'file',
+        options: {disableNew: true},
+      },
+      observeAsset: observeAssetStub,
+      render: (inputProps) => <BaseFileInput {...inputProps} />,
+    })
+    // Browse button should still be present
+    expect(screen.getByTestId(fileBrowseTestId('test-source'))).toBeInTheDocument()
+    // Upload button should NOT be present
+    expect(screen.queryByTestId('file-input-upload-button-test-source')).not.toBeInTheDocument()
+    // The browse button's parent flex container should have justify-content: flex-end
+    const browseButton = screen.getByTestId(fileBrowseTestId('test-source'))
+    const flexContainer = browseButton.closest('[data-ui="Flex"]')
+    expect(flexContainer).toBeInTheDocument()
+    expect(flexContainer).toHaveStyle('justify-content: flex-end')
+  })
+
   it('shows invalid file warning when asset ref is not a valid file source', async () => {
     // Value with asset ref that doesn't match file asset id format (e.g. deleted/broken ref)
     const invalidValue = {

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputUploadPlaceholder.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputUploadPlaceholder.tsx
@@ -1,5 +1,5 @@
 import {type AssetSource} from '@sanity/types'
-import {Card} from '@sanity/ui'
+import {Card, Flex} from '@sanity/ui'
 import {memo, useCallback} from 'react'
 
 import {UploadPlaceholder} from '../common/UploadPlaceholder'
@@ -41,7 +41,9 @@ function ImageInputUploadPlaceholderComponent(props: {
     <div style={{padding: 1}}>
       <Card tone={readOnly ? 'transparent' : 'inherit'} border paddingX={3} paddingY={2} radius={2}>
         {disableNew ? (
-          renderBrowser()
+          <Flex align="center" justify="flex-end">
+            {renderBrowser()}
+          </Flex>
         ) : (
           <UploadPlaceholder
             assetSources={assetSources}

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/__tests__/imageInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/__tests__/imageInput.test.tsx
@@ -27,6 +27,30 @@ describe('ImageInput with empty state', () => {
     expect(screen.getByTestId(imageBrowseTestId('test-source'))).toBeInTheDocument()
   })
 
+  it('renders browse button right-aligned when disableNew is true', async () => {
+    await renderImageInput({
+      assetSources: [{Uploader: {}, name: 'test-source'} as any],
+      configOverrides: {mediaLibrary: {enabled: false}},
+      fieldDefinition: {
+        name: 'mainImage',
+        title: 'Main image',
+        type: 'image',
+        options: {disableNew: true},
+      },
+      observeAsset: observeImageAssetStub,
+      render: (inputProps) => <BaseImageInput {...inputProps} />,
+    })
+    // Browse button should still be present
+    expect(screen.getByTestId(imageBrowseTestId('test-source'))).toBeInTheDocument()
+    // Upload button should NOT be present
+    expect(screen.queryByTestId('file-input-upload-button-test-source')).not.toBeInTheDocument()
+    // The browse button's parent flex container should have justify-content: flex-end
+    const browseButton = screen.getByTestId(imageBrowseTestId('test-source'))
+    const flexContainer = browseButton.closest('[data-ui="Flex"]')
+    expect(flexContainer).toBeInTheDocument()
+    expect(flexContainer).toHaveStyle('justify-content: flex-end')
+  })
+
   it('shows invalid image warning when asset ref is not a valid image source', async () => {
     const invalidValue = {
       _type: 'image',


### PR DESCRIPTION
### Description

Fixes [SAPP-3720](https://linear.app/sanity/issue/SAPP-3720).

Adding `options: { disableNew: true }` to an image or file field caused the "Select" button to shift from the right of the field to the left. Root cause: when `disableNew` is true, the browse button was rendered without the `UploadPlaceholder` wrapper that provides `Flex justify="space-between"`. Wrapped the browse button in `<Flex justify="flex-end">` when `disableNew` is true, preserving right-alignment.

### What to review

- `ImageInputUploadPlaceholder.tsx` and `FileAsset.tsx` — the `disableNew` branch now wraps the browse button in a right-aligned Flex.

### Testing

- New tests in `imageInput.test.tsx` and `fileInput.test.tsx` verifying right-aligned position.
- All 3 image input + 12 file input tests pass.

### Notes for release

Fixed a UI glitch where setting `disableNew: true` on an image or file field moved the "Select" button from the right side to the left. The button now stays on the right consistently.
