### PR TITLE
fix(studio): hide user menu on mobile in dashboard mode

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/navDrawer/NavDrawer.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/navDrawer/NavDrawer.tsx
@@ -217,24 +217,28 @@ export const NavDrawer = memo(function NavDrawer(props: NavDrawerProps) {
 
                   {setScheme && <AppearanceMenu setScheme={setScheme} />}
                   <LocaleMenu />
-                  <ManageMenu />
+                  <CapabilityGate capability="globalUserMenu">
+                    <ManageMenu />
+                  </CapabilityGate>
                 </Flex>
               </Flex>
 
-              {auth.logout && (
-                <Card flex="none" padding={2} borderTop>
-                  <Stack>
-                    <Button
-                      iconRight={LeaveIcon}
-                      justify="flex-start"
-                      mode="bleed"
-                      onClick={auth.logout}
-                      size="large"
-                      text={t('user-menu.action.sign-out')}
-                    />
-                  </Stack>
-                </Card>
-              )}
+              <CapabilityGate capability="globalUserMenu">
+                {auth.logout && (
+                  <Card flex="none" padding={2} borderTop>
+                    <Stack>
+                      <Button
+                        iconRight={LeaveIcon}
+                        justify="flex-start"
+                        mode="bleed"
+                        onClick={auth.logout}
+                        size="large"
+                        text={t('user-menu.action.sign-out')}
+                      />
+                    </Stack>
+                  </Card>
+                )}
+              </CapabilityGate>
             </InnerCardMotion>
           </Root>
         </TrapFocus>


### PR DESCRIPTION
### Description

Fixes [SAPP-3113](https://linear.app/sanity/issue/SAPP-3113).

When Studio runs within the Dashboard (embedded/`coreUi` rendering context), the user dropdown menu was correctly hidden on desktop but remained accessible on mobile — users could open Manage project menu and sign-out button via the mobile `NavDrawer`. Wrapped `ManageMenu` and the sign-out button in `<CapabilityGate capability="globalUserMenu">`, matching the existing desktop pattern. `AppearanceMenu` and `LocaleMenu` remain visible (those are Studio-local preferences, not account actions).

### What to review

- `NavDrawer.tsx` — two new `CapabilityGate` wrappers around `ManageMenu` and the sign-out button.

### Testing

- All 4 existing `CapabilityGate` tests pass.
- Lint clean.

### Notes for release

Fixed a bug in Dashboard-embedded Studio where the user menu (Manage project, sign out) was still accessible on mobile even though it was hidden on desktop. Mobile now matches desktop behavior.
