### PR TITLE
fix(releases): improve activity panel UX consistency

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -64,27 +64,27 @@ const releasesLocaleStrings = {
   /** Label for unarchiving a release */
   'action.unarchive': 'Unarchive release',
   /* The text for the activity event when a document is added to a release */
-  'activity.event.add-document': 'added a document version',
+  'activity.event.add-document': 'Added a document version',
   /* The text for the activity event when the release is archived */
-  'activity.event.archive': 'archived the <strong>{{releaseTitle}}</strong> release',
+  'activity.event.archive': 'Archived the <strong>{{releaseTitle}}</strong> release',
   /* The text for the activity event when the release is created */
   'activity.event.create':
-    'created the <strong>{{releaseTitle}}</strong> release <ScheduleTarget>targeting </ScheduleTarget>',
+    'Created the <strong>{{releaseTitle}}</strong> release <ScheduleTarget>targeting </ScheduleTarget>',
   /* The text for the activity event when a document is removed from a release */
-  'activity.event.discard-document': 'discarded a document version',
-  'activity.event.edit': 'set release time to <ScheduleTarget></ScheduleTarget>',
+  'activity.event.discard-document': 'Discarded a document version',
+  'activity.event.edit': 'Set release time to <ScheduleTarget></ScheduleTarget>',
   /**The text to display in the changes when the release type changes to asap */
-  'activity.event.edit-time-asap': 'immediately',
+  'activity.event.edit-time-asap': 'As soon as possible',
   /**The text to display in the changes when the release type changes to undecided */
-  'activity.event.edit-time-undecided': 'never',
+  'activity.event.edit-time-undecided': 'Undecided',
   /* The text for the activity event when the release is published */
-  'activity.event.publish': 'published the <strong>{{releaseTitle}}</strong> release',
+  'activity.event.publish': 'Published the <strong>{{releaseTitle}}</strong> release',
   /* The text for the activity event when the release is scheduled */
-  'activity.event.schedule': 'marked as scheduled',
+  'activity.event.schedule': 'Marked as scheduled',
   /** The text for the activity event when the release is unarchived */
-  'activity.event.unarchive': 'unarchived the <strong>{{releaseTitle}}</strong> release',
+  'activity.event.unarchive': 'Unarchived the <strong>{{releaseTitle}}</strong> release',
   /** The text for the activity event when the release is unscheduled */
-  'activity.event.unschedule': 'marked as unscheduled',
+  'activity.event.unschedule': 'Marked as unscheduled',
   /** The loading text for when releases are loading */
   'activity.panel.loading': 'Loading release activity',
   /** The loading text for when releases are loading */

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseActivityListItem.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseActivityListItem.tsx
@@ -3,9 +3,9 @@ import {motion} from 'motion/react'
 import {memo, type ReactNode, useMemo} from 'react'
 import {styled} from 'styled-components'
 
-import {RelativeTime} from '../../../components/RelativeTime'
 import {UserAvatar} from '../../../components/userAvatar/UserAvatar'
 import {useDateTimeFormat} from '../../../hooks/useDateTimeFormat'
+import {useRelativeTime} from '../../../hooks/useRelativeTime'
 import {Translate, useTranslation} from '../../../i18n'
 import {releasesLocaleNamespace} from '../../i18n'
 import {ReleaseDocumentPreview} from '../components/ReleaseDocumentPreview'
@@ -92,6 +92,23 @@ const ScheduleTarget = ({children, event}: {children: ReactNode; event: ReleaseE
 }
 
 const FadeInCard = motion.create(Card)
+
+function ActivityTimestamp({timestamp}: {timestamp: string}) {
+  const dateTimeFormat = useDateTimeFormat({
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+  const date = useMemo(() => new Date(timestamp), [timestamp])
+  const formattedDate = useMemo(() => dateTimeFormat.format(date), [dateTimeFormat, date])
+  const relativeTime = useRelativeTime(date, {useTemporalPhrase: true, minimal: true})
+
+  return (
+    <time dateTime={date.toISOString()} title={relativeTime}>
+      {formattedDate}
+    </time>
+  )
+}
+
 export const ReleaseActivityListItem = memo(
   ({
     event,
@@ -116,10 +133,10 @@ export const ReleaseActivityListItem = memo(
         animate={{opacity: 1}}
         transition={{type: 'spring', bounce: 0, duration: 0.4}}
       >
-        <Flex align="flex-start" gap={2}>
+        <Flex align="center" gap={2}>
           <UserAvatar user={event.author} />
           <Stack flex={1}>
-            <Flex gap={2} paddingY={2}>
+            <Flex gap={2} align="center">
               <StatusText muted size={1}>
                 <Translate
                   t={t}
@@ -131,7 +148,7 @@ export const ReleaseActivityListItem = memo(
                   values={{releaseTitle}}
                   i18nKey={ACTIVITY_TEXT_118N[event.type]}
                 />{' '}
-                &middot; <RelativeTime time={event.timestamp} useTemporalPhrase minimal />
+                &middot; <ActivityTimestamp timestamp={event.timestamp} />
               </StatusText>
             </Flex>
             {isAddDocumentToReleaseEvent(event) || isDiscardDocumentFromReleaseEvent(event) ? (


### PR DESCRIPTION
### Description

Fixes [SAPP-2691](https://linear.app/sanity/issue/SAPP-2691).

Several UX issues in the Content Releases activity panel:
1. Avatar/text misalignment.
2. Activity copy was lowercase instead of sentence case.
3. "immediately" label didn't match "ASAP" used elsewhere.
4. Relative timestamps were less useful than absolute ones for audit/troubleshooting.

Fixed alignment to vertically center, updated all 11 activity strings to sentence case, changed `activity.event.edit-time-asap` to "As soon as possible" (matching the release type picker), and switched the displayed timestamp to absolute with the relative time accessible via tooltip.

### What to review

- `ReleaseActivityListItem.tsx` — Flex alignment + new `ActivityTimestamp` helper with absolute date + relative-time tooltip.
- `resources.ts` — sentence-case and label consistency updates.

### Testing

- All 159 release detail tests pass.
- No snapshot updates needed.

### Notes for release

Polished the Content Releases activity panel: avatars align with text, activity entries use sentence case, the "immediately" label is now "As soon as possible" to match the release type picker, and each entry now shows an absolute timestamp with relative time on hover.
