### PR TITLE
fix(releases): add empty state for cardinality-one releases with no documents

### DIFF
--- a/packages/sanity/src/core/releases/__fixtures__/release.fixture.ts
+++ b/packages/sanity/src/core/releases/__fixtures__/release.fixture.ts
@@ -126,6 +126,23 @@ export const activeUndecidedRelease: ReleaseDocumentWithTitle = {
   },
 }
 
+export const activeCardinalityOneRelease: ReleaseDocumentWithTitle = {
+  _rev: 'cardinalityOneRev',
+  _id: '_.releases.rCardinalityOne',
+  name: 'rCardinalityOne',
+  _type: 'system.release',
+  _createdAt: '2023-10-10T08:00:00Z',
+  _updatedAt: '2023-10-10T09:00:00Z',
+  state: 'active',
+  metadata: {
+    title: 'Scheduled Draft',
+    releaseType: 'scheduled',
+    intendedPublishAt: '2023-10-10T10:00:00.000Z',
+    description: 'A single document scheduled draft',
+    cardinality: 'one',
+  },
+}
+
 export const activeUndecidedErrorRelease: ReleaseDocumentWithTitle = {
   _rev: 'undecidedErrorRev',
   _id: '_.releases.rUndecidedError',

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -377,6 +377,11 @@ const releasesLocaleStrings = {
   'summary.not-published': 'Not published',
   /** Text for when the release has no documents */
   'summary.no-documents': 'No documents',
+  /** Title for the empty state when a cardinality-one release has no documents */
+  'summary.no-documents-cardinality-one.title': 'No document in this release',
+  /** Description for the empty state when a cardinality-one release has no documents */
+  'summary.no-documents-cardinality-one.description':
+    'This scheduled draft does not contain a document. It may have been removed.',
   /** Text for when the release is composed of one document */
   'summary.document-count_one': '{{count}} document',
   /** Text for when the release is composed of multiple documents */

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -1,13 +1,14 @@
 import {type ReleaseDocument, type SanityDocument} from '@sanity/client'
 import {AddIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
-import {Card, Container, Flex, useToast} from '@sanity/ui'
+import {Card, Container, Flex, Stack, Text, useToast} from '@sanity/ui'
 import {type CSSProperties, useCallback, useEffect, useMemo, useState} from 'react'
 
 import {Button} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
 import {getVersionId} from '../../../util/draftUtils'
 import {getDocumentVariantType} from '../../../util/getDocumentVariantType'
+import {isCardinalityOneRelease} from '../../../util/releaseUtils'
 import {AddedVersion} from '../../__telemetry__/releases.telemetry'
 import {releasesLocaleNamespace} from '../../i18n'
 import {useReleaseOperations} from '../../store/useReleaseOperations'
@@ -169,6 +170,31 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
     () => (pendingAddedDocument.length ? [...documents, ...pendingAddedDocument] : documents),
     [documents, pendingAddedDocument],
   )
+
+  const isCardinalityOne = isCardinalityOneRelease(release)
+  const hasNoDocuments = !isLoading && documents.length === 0
+
+  if (isCardinalityOne && hasNoDocuments) {
+    return (
+      <Flex
+        direction="column"
+        align="center"
+        justify="center"
+        padding={5}
+        style={FULL_HEIGHT_STYLE}
+        data-testid="cardinality-one-empty-state"
+      >
+        <Stack space={3} style={{textAlign: 'center', maxWidth: '300px'}}>
+          <Text size={1} weight="semibold">
+            {t('summary.no-documents-cardinality-one.title')}
+          </Text>
+          <Text size={1} muted>
+            {t('summary.no-documents-cardinality-one.description')}
+          </Text>
+        </Stack>
+      </Flex>
+    )
+  }
 
   return (
     <Flex direction="column" style={FULL_HEIGHT_STYLE}>

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
@@ -17,6 +17,7 @@ import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
 import type * as ConnectionStatusStoreMod from '../../../../store/_legacy/connection-status/connection-status-store'
 import {
   activeASAPRelease,
+  activeCardinalityOneRelease,
   archivedScheduledRelease,
   scheduledRelease,
 } from '../../../__fixtures__/release.fixture'
@@ -280,6 +281,49 @@ describe('ReleaseSummary', () => {
     it('does not allow for adding documents', async () => {
       await prerenderTest()
       expect(screen.queryByText('Add document')).toBeNull()
+    })
+  })
+
+  describe('for a cardinality-one release with no documents', () => {
+    it('shows the empty state message', async () => {
+      await renderTest({release: activeCardinalityOneRelease, documents: []})
+
+      expect(await screen.findByTestId('cardinality-one-empty-state')).toBeInTheDocument()
+      expect(screen.getByText('No document in this release')).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          'This scheduled draft does not contain a document. It may have been removed.',
+        ),
+      ).toBeInTheDocument()
+    })
+
+    it('does not show the document table', async () => {
+      await renderTest({release: activeCardinalityOneRelease, documents: []})
+
+      expect(await screen.findByTestId('cardinality-one-empty-state')).toBeInTheDocument()
+      expect(screen.queryByTestId('document-table-card')).not.toBeInTheDocument()
+    })
+
+    it('does not show the add document button', async () => {
+      await renderTest({release: activeCardinalityOneRelease, documents: []})
+
+      expect(await screen.findByTestId('cardinality-one-empty-state')).toBeInTheDocument()
+      expect(screen.queryByText('Add document')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('for a cardinality-one release with documents', () => {
+    it('shows the document table normally', async () => {
+      await renderTest({release: activeCardinalityOneRelease, documents: releaseDocuments})
+
+      // eslint-disable-next-line testing-library/prefer-find-by
+      await waitFor(() => screen.getByTestId('document-table-card'), {
+        timeout: 5000,
+        interval: 500,
+      })
+
+      expect(screen.queryByTestId('cardinality-one-empty-state')).not.toBeInTheDocument()
+      expect(screen.getAllByTestId('table-row')).toHaveLength(2)
     })
   })
 


### PR DESCRIPTION
### Description

Fixes [SAPP-3083](https://linear.app/sanity/issue/SAPP-3083).

A cardinality-one release (scheduled draft) with zero documents showed the full document-table UI with an empty list, which was confusing. Added a dedicated empty state in `ReleaseSummary` with a title and description, rendered instead of the table + filter tabs + add-document button when the release has no documents.

### What to review

- `ReleaseSummary.tsx` — early-return for the empty-state branch.
- `resources.ts` — new i18n strings.
- `release.fixture.ts` — added `activeCardinalityOneRelease` fixture for testing.

### Testing

- 4 new tests covering the empty state render and the regression case (cardinality-one with documents still renders the table).
- All 52 release detail tests pass.

### Notes for release

Scheduled drafts with no document now show a clean empty state instead of a mostly-empty table.
