### PR TITLE
fix(sanity): document panel header layered behind document panel popovers

### DIFF
--- a/packages/sanity/src/structure/panes/document/document-layout/DocumentLayout.tsx
+++ b/packages/sanity/src/structure/panes/document/document-layout/DocumentLayout.tsx
@@ -8,6 +8,7 @@ import {
   FieldActionsProvider,
   FieldActionsResolver,
   GetFormValueProvider,
+  LegacyLayerProvider,
   type Path,
   useDocumentIdStack,
   useGlobalCopyPasteElementHandler,
@@ -217,7 +218,9 @@ export function DocumentLayout() {
             onKeyUp={handleKeyUp}
             rootRef={setRootElement}
           >
-            <DocumentPanelHeader ref={setHeaderElement} menuItems={menuItems} />
+            <LegacyLayerProvider zOffset="paneHeader">
+              <DocumentPanelHeader ref={setHeaderElement} menuItems={menuItems} />
+            </LegacyLayerProvider>
             <DialogProvider position={DIALOG_PROVIDER_POSITION} zOffset={zOffsets.paneDialog}>
               <Flex direction="column" flex={1} height={layoutCollapsed ? undefined : 'fill'}>
                 <StyledChangeConnectorRoot

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -1,6 +1,6 @@
 import {ArrowLeftIcon, CloseIcon, CollapseIcon, ExpandIcon, SplitVerticalIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
-import {Box, Card, Flex} from '@sanity/ui'
+import {Box, Card, Flex, useLayer} from '@sanity/ui'
 // eslint-disable-next-line camelcase
 import {getTheme_v2, rgba} from '@sanity/ui/theme'
 import {
@@ -105,6 +105,7 @@ export const DocumentPanelHeader = memo(
     const scrollContainerRef = useRef<HTMLDivElement>(null)
     const showGradient = useChipScrollPosition(scrollContainerRef)
     const telemetry = useTelemetry()
+    const {zIndex} = useLayer()
 
     const menuNodes = useMemo(
       () =>
@@ -192,7 +193,7 @@ export const DocumentPanelHeader = memo(
             backButton={backButton}
           />
         ) : (
-          <Card hidden={collapsed} style={{lineHeight: 0}} borderBottom>
+          <Card hidden={collapsed} style={{lineHeight: 0, zIndex}} borderBottom>
             <Flex gap={3} paddingY={3}>
               <HorizontalScroller $showGradient={showGradient}>
                 <Flex


### PR DESCRIPTION
### Description

This branch fixes a layering issue causing popovers inside the document panel to be layered above the document panel header (the UI containing version chips).

The problem is solved by wrapping this component in a layer provider set to the same depth as the pane header (the UI containing the document panel subheader and banners), and applying the provided `z-index` to the rendered element.

It's a little tricky to see, but these screenshots demonstrate:

#### Reference input - before

<img width="902" height="436" alt="reference-before" src="https://github.com/user-attachments/assets/05d05baa-12af-4c4b-86a2-62fae19e5d21" />

#### Reference input - after

<img width="902" height="436" alt="reference-after" src="https://github.com/user-attachments/assets/7a83f0fd-a290-4b63-8677-2ab49db3057b" />

#### PTE popover - before

<img width="677" height="447" alt="pte-overlay-before" src="https://github.com/user-attachments/assets/21d2204e-0e91-476b-8604-7e1b283ade16" />

#### PTE popover - after

<img width="677" height="447" alt="pte-overlay-after" src="https://github.com/user-attachments/assets/314a7a48-6537-420b-a1b0-92c5fd99b4d2" />

### What to review

Document panel popovers do not appear above the document panel header (the UI containing version chips).

### Testing

- Manually verified various scenarios in Test Studio in Safari, Firefox, and Chromium.
- Manually verified popovers *inside the document panel header* such as the version chip context menu, copy menu, and document context menu render correctly.

### Notes for release

Fixes a bug causing popovers to sometimes render above the document panel header and version chips.