### PR TITLE
fix(auth): make logout method return promise in auth store types

### DIFF
--- a/packages/sanity/src/core/store/_legacy/authStore/types.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/types.ts
@@ -41,7 +41,7 @@ export interface AuthStore {
    * out. The implementation is expected to remove all credentials both locally
    * and on the server.
    */
-  logout?: () => void
+  logout?: () => Promise<void>
   /**
    * Custom auth stores can implement a function that is designated to run when
    * the Studio loads (e.g. to trade a session ID for a token in cookie-less

--- a/packages/sanity/src/core/studio/screens/NotAuthenticatedScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/NotAuthenticatedScreen.tsx
@@ -16,7 +16,7 @@ export function NotAuthenticatedScreen() {
   const {activeWorkspace} = useActiveWorkspace()
 
   const handleLogout = useCallback(() => {
-    activeWorkspace.auth.logout?.()
+    void activeWorkspace.auth.logout?.()
   }, [activeWorkspace])
 
   useEffect(() => {

--- a/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
@@ -53,7 +53,7 @@ export function RequestAccessScreen() {
   const {activeWorkspace} = useActiveWorkspace()
 
   const handleLogout = useCallback(() => {
-    activeWorkspace.auth.logout?.()
+    void activeWorkspace.auth.logout?.()
   }, [activeWorkspace])
 
   // Get config info from active workspace


### PR DESCRIPTION
### Description
Just a small fix to make the type of authStore.logout() reflect the reality (making it possible to await authstore.logout() without incurring a type error)

### What to review
Makes sense?

### Testing
n/a

### Notes for release
n/a