### PR TITLE
fix(comments): enable click-outside handler when comment popover is open

### DIFF
--- a/packages/sanity/src/core/comments/plugin/field/CommentsFieldButton.tsx
+++ b/packages/sanity/src/core/comments/plugin/field/CommentsFieldButton.tsx
@@ -121,7 +121,7 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
     [startDiscard],
   )
 
-  useClickOutsideEvent(!open && startDiscard, () => [popoverRef.current])
+  useClickOutsideEvent(open && startDiscard, () => [popoverRef.current])
 
   if (!hasComments) {
     const placeholder = (

--- a/packages/sanity/src/core/comments/plugin/field/CommentsFieldButton.tsx
+++ b/packages/sanity/src/core/comments/plugin/field/CommentsFieldButton.tsx
@@ -131,7 +131,7 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
     [startDiscard],
   )
 
-  useClickOutsideEvent(!open && startDiscard, () => [popoverRef.current])
+  useClickOutsideEvent(open && startDiscard, () => [popoverRef.current])
 
   if (!hasComments) {
     const placeholder = (


### PR DESCRIPTION
### Description

Fixes [SAPP-3409](https://linear.app/sanity/issue/SAPP-3409).

The click-outside handler for the comments popover had an inverted boolean: `useClickOutsideEvent` was active when the popover was closed and disabled when it was open, so clicking outside while composing a comment did nothing. Flipped `!open` to `open` — a one-character fix.

### What to review

- `CommentsFieldButton.tsx` — the `useClickOutsideEvent` condition.

### Testing

- Manual: opening a comment popover and clicking outside now dismisses it as expected.

### Notes for release

Clicking outside an open comment popover now correctly dismisses it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-boolean correction in comments UI with no auth, data, or API impact.
> 
> **Overview**
> Fixes inverted logic on the field **add-comment** popover so outside clicks are handled only while the popover is **open**.
> 
> In `CommentsFieldButton`, the first argument to `useClickOutsideEvent` was `!open`, which registered the outside-click listener when the popover was closed and skipped it while composing. It is now `open`, matching other comment UI (e.g. edit mode uses a truthy “enabled” condition). Outside clicks while open still flow through `startDiscard`, which closes immediately or opens the discard dialog when there is draft content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97bb5c35a187fac5297f98c3cc61b2bced5adf79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->