### PR TITLE
fix(ci): use default lint output format for reliable error visibility

### DIFF
--- a/.github/workflows/lintPr.yml
+++ b/.github/workflows/lintPr.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
       - name: Oxlint files
-        run: pnpm turbo run check:oxlint -- --format github
+        run: pnpm turbo run check:oxlint
 
   eslint:
     runs-on: ubuntu-latest
@@ -33,7 +33,7 @@ jobs:
         run: git fetch origin main:main
       - uses: ./.github/actions/setup
       - name: ESLint files
-        run: pnpm turbo run lint --affected --output-logs=full --continue -- -f gha
+        run: pnpm turbo run lint --affected --output-logs=full --continue
 
   knip:
     runs-on: ubuntu-latest

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -25,8 +25,6 @@
         "dotenv",
         // keeping it a dev dependency speeds up 'npx only-allow pnpm' in package.json's preinstall script
         "only-allow",
-        // Knip does not bind extra args (`-f gha`) behind e.g. `pnpm turbo run lint` to the target binary
-        "eslint-formatter-gha",
         // See .github/workflows/e2e-ui.yml
         "@sanity/ui",
       ],

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "dotenv-flow": "^4.1.0",
     "esbuild-register": "catalog:",
     "eslint": "catalog:",
-    "eslint-formatter-gha": "^2.0.1",
     "husky": "^9.1.7",
     "knip": "^5.88.1",
     "lint-staged": "^16.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,9 +130,6 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.1)
-      eslint-formatter-gha:
-        specifier: ^2.0.1
-        version: 2.0.1
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -7549,17 +7546,6 @@ packages:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
 
-  eslint-formatter-gha@2.0.1:
-    resolution: {integrity: sha512-HbiPXXjIley/JRcQ9zRZ4HJhhU8ZIf0wVLbfyQKm/7HIcbvOsA2xwl/Lblyd8fhYalUWxKcodJOwsOwxw7O0Cw==}
-
-  eslint-formatter-json@9.0.1:
-    resolution: {integrity: sha512-EQ/X+bPjiOUDo4frNbkY+5R6emaHTL7t2jHsJw5s8p8w1BTJ6ao6S7g/PaRyx/CqqaYcjJkWAPHH/onNyFlJBQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  eslint-formatter-stylish@9.0.1:
-    resolution: {integrity: sha512-FlhMRUiDUHztGj+bhm3pYo5DJ6Gbjh/FGPClcDENme7f9+Sc3+HZg6wMq80KJmRD8/oj/Ib6gy4D/ppjmHfGVA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   eslint-import-context@0.1.9:
     resolution: {integrity: sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -10659,9 +10645,6 @@ packages:
 
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
-
-  text-table@0.2.0:
-    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
   throttleit@2.1.0:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
@@ -17606,19 +17589,6 @@ snapshots:
       eslint-plugin-turbo: 2.8.4(eslint@9.39.2(jiti@2.6.1))(turbo@2.8.4)
       turbo: 2.8.4
 
-  eslint-formatter-gha@2.0.1:
-    dependencies:
-      eslint-formatter-json: 9.0.1
-      eslint-formatter-stylish: 9.0.1
-
-  eslint-formatter-json@9.0.1: {}
-
-  eslint-formatter-stylish@9.0.1:
-    dependencies:
-      chalk: 4.1.2
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
-
   eslint-import-context@0.1.9(unrs-resolver@1.11.1):
     dependencies:
       get-tsconfig: 4.13.7
@@ -21067,8 +21037,6 @@ snapshots:
       b4a: 1.7.3
     transitivePeerDependencies:
       - react-native-b4a
-
-  text-table@0.2.0: {}
 
   throttleit@2.1.0: {}
 


### PR DESCRIPTION
### Description

The GHA reporter only surfaces annotations on lines in the PR diff. Lint errors in unchanged files (triggered by changes elsewhere) are silently swallowed, with no file path or line number anywhere to look at. Not worth keeping the inline-annotation UX for.

Considered running the linter twice (default format + GHA format on failure), but that doubles lint time on red builds for a UX win the reviewer will ignore in favor of the log anyway.

### What to review

- Inline PR annotations are gone; errors now appear only in the Lint PR job log.

### Testing

Validated by the Lint PR workflow on this PR itself.

### Notes for release

N/A
