### PR TITLE
refactor: the menu items in viewContentReleases and ScheduledDraftsMenuItem show proper hovering 

### DIFF
--- a/packages/sanity/src/core/perspective/navbar/ScheduledDraftsMenuItem.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ScheduledDraftsMenuItem.tsx
@@ -1,15 +1,7 @@
 import {CalendarIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
-import {
-  type ComponentProps,
-  type ComponentType,
-  type ForwardedRef,
-  forwardRef,
-  useCallback,
-  useMemo,
-} from 'react'
-import {IntentLink, useRouter} from 'sanity/router'
-import {styled} from 'styled-components'
+import {type ComponentType, useCallback} from 'react'
+import {useIntentLink} from 'sanity/router'
 
 import {MenuItem} from '../../../ui-components/menuItem/MenuItem'
 import {FEATURES, useFeatureEnabled} from '../../hooks/useFeatureEnabled'
@@ -19,12 +11,7 @@ import {useScheduledDraftsEnabled} from '../../singleDocRelease/hooks/useSchedul
 import {RELEASES_SCHEDULED_DRAFTS_INTENT} from '../../singleDocRelease/plugin'
 import {useWorkspace} from '../../studio/workspace'
 
-const StyledLinkComponent = styled(IntentLink)`
-  text-decoration: none;
-`
-
 export const ScheduledDraftsMenuItem: ComponentType = () => {
-  const router = useRouter()
   const {t} = useTranslation()
   const telemetry = useTelemetry()
   const isScheduledDraftsEnabled = useScheduledDraftsEnabled()
@@ -35,40 +22,23 @@ export const ScheduledDraftsMenuItem: ComponentType = () => {
     },
   } = useWorkspace()
 
-  const scheduledDraftsUrl = router.resolveIntentLink(RELEASES_SCHEDULED_DRAFTS_INTENT, {
-    view: 'drafts',
-  })
-
-  const handleClick = useCallback(() => {
+  const logNavigationTelemetry = useCallback(() => {
     telemetry.log(NavigatedToScheduledDrafts, {source: 'menu'})
   }, [telemetry])
 
-  const LinkComponent = useMemo(
-    () =>
-      // eslint-disable-next-line @typescript-eslint/no-shadow
-      forwardRef(function LinkComponent(
-        restProps: ComponentProps<typeof IntentLink>,
-        ref: ForwardedRef<HTMLAnchorElement>,
-      ) {
-        return (
-          <StyledLinkComponent
-            {...restProps}
-            intent={RELEASES_SCHEDULED_DRAFTS_INTENT}
-            params={{view: 'drafts'}}
-            ref={ref}
-          />
-        )
-      }),
-    [],
-  )
+  const {href, onClick} = useIntentLink({
+    intent: RELEASES_SCHEDULED_DRAFTS_INTENT,
+    params: {view: 'drafts'},
+    onClick: logNavigationTelemetry,
+  })
 
   if (!isScheduledDraftsEnabled || !isSingleDocReleaseEnabled || !isDraftModelEnabled) return null
 
   return (
     <MenuItem
-      as={LinkComponent}
-      href={scheduledDraftsUrl}
-      onClick={handleClick}
+      as="a"
+      href={href}
+      onClick={onClick}
       icon={CalendarIcon}
       text={t('release.menu.scheduled-drafts')}
       data-testid="scheduled-drafts-menu-item"

--- a/packages/sanity/src/core/perspective/navbar/ViewContentReleasesMenuItem.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ViewContentReleasesMenuItem.tsx
@@ -1,62 +1,32 @@
 import {CalendarIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
-import {
-  type ComponentProps,
-  type ComponentType,
-  type ForwardedRef,
-  forwardRef,
-  useCallback,
-  useMemo,
-} from 'react'
-import {IntentLink, useRouter} from 'sanity/router'
-import {styled} from 'styled-components'
+import {type ComponentType, useCallback} from 'react'
+import {useIntentLink} from 'sanity/router'
 
 import {MenuItem} from '../../../ui-components/menuItem/MenuItem'
 import {useTranslation} from '../../i18n'
 import {NavigatedToReleasesOverview} from '../../releases/__telemetry__/navigation.telemetry'
 import {RELEASES_INTENT} from '../../releases/plugin'
-import {SCHEDULES_TOOL_NAME} from '../../schedules/plugin'
 
-const StyledLinkComponent = styled(IntentLink)`
-  text-decoration: none;
-`
 export const ViewContentReleasesMenuItem: ComponentType = () => {
-  const router = useRouter()
   const {t} = useTranslation()
   const telemetry = useTelemetry()
 
-  const releasesUrl = router.resolvePathFromState({
-    tool: SCHEDULES_TOOL_NAME,
-  })
-
-  const handleClick = useCallback(() => {
+  const logNavigationTelemetry = useCallback(() => {
     telemetry.log(NavigatedToReleasesOverview, {source: 'menu'})
   }, [telemetry])
 
-  const LinkComponent = useMemo(
-    () =>
-      // eslint-disable-next-line @typescript-eslint/no-shadow
-      forwardRef(function LinkComponent(
-        restProps: ComponentProps<typeof IntentLink>,
-        ref: ForwardedRef<HTMLAnchorElement>,
-      ) {
-        return (
-          <StyledLinkComponent
-            {...restProps}
-            intent={RELEASES_INTENT}
-            params={{source: 'menu'}}
-            ref={ref}
-          />
-        )
-      }),
-    [],
-  )
+  const {href, onClick} = useIntentLink({
+    intent: RELEASES_INTENT,
+    params: {source: 'menu'},
+    onClick: logNavigationTelemetry,
+  })
 
   return (
     <MenuItem
-      as={LinkComponent}
-      href={releasesUrl}
-      onClick={handleClick}
+      as="a"
+      href={href}
+      onClick={onClick}
       icon={CalendarIcon}
       text={t('release.menu.view-releases')}
       data-testid="view-content-releases-menu-item"


### PR DESCRIPTION
### Description

Before

https://github.com/user-attachments/assets/d00c68cf-a0a5-4cb8-baef-65eff5f6e8b4

After

https://github.com/user-attachments/assets/8d3f5049-06e5-4850-807e-c909b4748b56

### What to review

Just altered the way that we were rendering the MenuItem -> it was a IntentLink before and now instead we are using a hook which will send the same props but not change the HTML.

### Testing

- Navigation works as expected,
- Existing tests pass,
- The hovering now works

### Notes for release

In the releases drop down menu the View Scheduled Drafts and View Content Releases Not highlighted menu items now correctly show hovering.