### PR TITLE
fix(studio): stop eagerly fetching auth for all workspaces at the start

### DIFF
--- a/packages/sanity/src/core/studio/activeWorkspaceMatcher/ActiveWorkspaceMatcher.tsx
+++ b/packages/sanity/src/core/studio/activeWorkspaceMatcher/ActiveWorkspaceMatcher.tsx
@@ -25,7 +25,7 @@ export function ActiveWorkspaceMatcher({
   unstable_history: historyProp,
 }: ActiveWorkspaceMatcherProps) {
   const allWorkspaces = useWorkspaces()
-  const {visibleWorkspaces, authStates} = useVisibleWorkspaces()
+  const {visibleWorkspaces, isResolvingHiddenWorkspaces} = useVisibleWorkspaces()
   const history = useMemo(() => historyProp || createHistory(), [historyProp])
 
   const setActiveWorkspaceName = useCallback(
@@ -61,7 +61,7 @@ export function ActiveWorkspaceMatcher({
     case 'match': {
       const matchedWorkspace = result.workspace
 
-      if (typeof matchedWorkspace.hidden === 'function' && authStates === undefined) {
+      if (typeof matchedWorkspace.hidden === 'function' && isResolvingHiddenWorkspaces) {
         return <LoadingComponent />
       }
 

--- a/packages/sanity/src/core/studio/activeWorkspaceMatcher/__tests__/ActiveWorkspaceMatcher.test.tsx
+++ b/packages/sanity/src/core/studio/activeWorkspaceMatcher/__tests__/ActiveWorkspaceMatcher.test.tsx
@@ -75,7 +75,9 @@ function createContextValue(
     visibleWorkspaces: workspaces.filter(
       (workspace) => !evaluateWorkspaceHidden(workspace, authStates?.[workspace.name]),
     ),
-    authStates,
+    isResolvingHiddenWorkspaces:
+      authStates === undefined &&
+      workspaces.some((workspace) => typeof workspace.hidden === 'function'),
   }
 }
 

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
@@ -8,11 +8,13 @@ import {useTranslation} from '../../../../../i18n'
 import {useActiveWorkspace} from '../../../../activeWorkspaceMatcher'
 import {useVisibleWorkspaces} from '../../../../workspaces'
 import {WORKSPACES_DOCS_URL} from '../constants'
+import {useWorkspaceAuthStates} from '../hooks'
 import {WorkspacePreview} from '../WorkspacePreview'
 import {Layout} from './Layout'
 
 export function WorkspaceAuth() {
-  const {visibleWorkspaces, authStates} = useVisibleWorkspaces()
+  const {visibleWorkspaces} = useVisibleWorkspaces()
+  const [authStates] = useWorkspaceAuthStates(visibleWorkspaces)
   const {activeWorkspace, setActiveWorkspace} = useActiveWorkspace()
   const [selectedWorkspaceName, setSelectedWorkspaceName] = useState<string | null>(
     activeWorkspace?.name || null,

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -15,6 +15,7 @@ import {MenuButton, type MenuButtonProps, MenuItem, Tooltip} from '../../../../.
 import {useTranslation} from '../../../../i18n'
 import {useActiveWorkspace} from '../../../activeWorkspaceMatcher'
 import {useVisibleWorkspaces} from '../../../workspaces'
+import {useWorkspaceAuthStates} from './hooks'
 import {ManageMenu} from './ManageMenu'
 import {STATE_TITLES, WorkspacePreviewIcon} from './WorkspacePreview'
 
@@ -26,7 +27,8 @@ const POPOVER_PROPS: MenuButtonProps['popover'] = {
 }
 
 export function WorkspaceMenuButton() {
-  const {visibleWorkspaces, authStates} = useVisibleWorkspaces()
+  const {visibleWorkspaces} = useVisibleWorkspaces()
+  const [authStates] = useWorkspaceAuthStates(visibleWorkspaces)
   const {activeWorkspace} = useActiveWorkspace()
   const {t} = useTranslation()
   const [scrollbarWidth, setScrollbarWidth] = useState(0)

--- a/packages/sanity/src/core/studio/workspaces/VisibleWorkspacesProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaces/VisibleWorkspacesProvider.tsx
@@ -2,7 +2,6 @@ import {type ReactNode, useMemo} from 'react'
 import {VisibleWorkspacesContext} from 'sanity/_singletons'
 
 import {type WorkspaceSummary} from '../../config/types'
-import {type AuthState} from '../../store/_legacy/authStore/types'
 import {useWorkspaceAuthStates} from '../components/navbar/workspace/hooks'
 import {evaluateWorkspaceHidden} from './useVisibleWorkspaces'
 import {useWorkspaces} from './useWorkspaces'
@@ -10,7 +9,15 @@ import {useWorkspaces} from './useWorkspaces'
 /** @internal */
 export interface VisibleWorkspacesContextValue {
   visibleWorkspaces: WorkspaceSummary[]
-  authStates: Record<string, AuthState> | undefined
+  /**
+   * `true` while auth state is still resolving for one or more workspaces
+   * whose visibility depends on a function-based `hidden` property.
+   * `visibleWorkspaces` includes these workspaces optimistically in the
+   * meantime.
+   *
+   * Follows the same fail-open pattern as `evaluateWorkspaceHidden`.
+   */
+  isResolvingHiddenWorkspaces: boolean
 }
 
 /** @internal */
@@ -20,10 +27,7 @@ export function VisibleWorkspacesProvider({children}: {children: ReactNode}) {
   // Only subscribe to auth state for workspaces whose visibility depends on
   // the current user. Workspaces with boolean or undefined `hidden` are
   // evaluated synchronously, so we don't need a per-workspace `/users/me`
-  // request to decide whether to render them. This avoids a thundering herd
-  // of auth requests at studio boot (which was measurably increasing p99
-  // `load`-event times in Firefox and causing `page.goto` to time out in
-  // e2e tests).
+  // request to decide whether to render them.
   const workspacesNeedingAuth = useMemo(
     () => allWorkspaces.filter((workspace) => typeof workspace.hidden === 'function'),
     [allWorkspaces],
@@ -31,14 +35,16 @@ export function VisibleWorkspacesProvider({children}: {children: ReactNode}) {
 
   const [authStates] = useWorkspaceAuthStates(workspacesNeedingAuth)
 
+  const isResolvingHiddenWorkspaces = workspacesNeedingAuth.length > 0 && authStates === undefined
+
   const value = useMemo<VisibleWorkspacesContextValue>(
     () => ({
       visibleWorkspaces: allWorkspaces.filter(
         (workspace) => !evaluateWorkspaceHidden(workspace, authStates?.[workspace.name]),
       ),
-      authStates,
+      isResolvingHiddenWorkspaces,
     }),
-    [allWorkspaces, authStates],
+    [allWorkspaces, authStates, isResolvingHiddenWorkspaces],
   )
 
   return (

--- a/packages/sanity/src/core/studio/workspaces/VisibleWorkspacesProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaces/VisibleWorkspacesProvider.tsx
@@ -35,16 +35,14 @@ export function VisibleWorkspacesProvider({children}: {children: ReactNode}) {
 
   const [authStates] = useWorkspaceAuthStates(workspacesNeedingAuth)
 
-  const isResolvingHiddenWorkspaces = workspacesNeedingAuth.length > 0 && authStates === undefined
-
   const value = useMemo<VisibleWorkspacesContextValue>(
     () => ({
       visibleWorkspaces: allWorkspaces.filter(
         (workspace) => !evaluateWorkspaceHidden(workspace, authStates?.[workspace.name]),
       ),
-      isResolvingHiddenWorkspaces,
+      isResolvingHiddenWorkspaces: workspacesNeedingAuth.length > 0 && authStates === undefined,
     }),
-    [allWorkspaces, authStates, isResolvingHiddenWorkspaces],
+    [allWorkspaces, workspacesNeedingAuth, authStates],
   )
 
   return (

--- a/packages/sanity/src/core/studio/workspaces/VisibleWorkspacesProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaces/VisibleWorkspacesProvider.tsx
@@ -16,9 +16,22 @@ export interface VisibleWorkspacesContextValue {
 /** @internal */
 export function VisibleWorkspacesProvider({children}: {children: ReactNode}) {
   const allWorkspaces = useWorkspaces()
-  const [authStates] = useWorkspaceAuthStates(allWorkspaces)
 
-  const value = useMemo(
+  // Only subscribe to auth state for workspaces whose visibility depends on
+  // the current user. Workspaces with boolean or undefined `hidden` are
+  // evaluated synchronously, so we don't need a per-workspace `/users/me`
+  // request to decide whether to render them. This avoids a thundering herd
+  // of auth requests at studio boot (which was measurably increasing p99
+  // `load`-event times in Firefox and causing `page.goto` to time out in
+  // e2e tests).
+  const workspacesNeedingAuth = useMemo(
+    () => allWorkspaces.filter((workspace) => typeof workspace.hidden === 'function'),
+    [allWorkspaces],
+  )
+
+  const [authStates] = useWorkspaceAuthStates(workspacesNeedingAuth)
+
+  const value = useMemo<VisibleWorkspacesContextValue>(
     () => ({
       visibleWorkspaces: allWorkspaces.filter(
         (workspace) => !evaluateWorkspaceHidden(workspace, authStates?.[workspace.name]),

--- a/packages/sanity/src/core/studio/workspaces/__tests__/VisibleWorkspacesProvider.test.tsx
+++ b/packages/sanity/src/core/studio/workspaces/__tests__/VisibleWorkspacesProvider.test.tsx
@@ -1,0 +1,147 @@
+import {act, renderHook} from '@testing-library/react'
+import {type ReactNode} from 'react'
+import {BehaviorSubject, Subject} from 'rxjs'
+import {WorkspacesContext} from 'sanity/_singletons'
+import {describe, expect, it} from 'vitest'
+
+import {type WorkspaceSummary} from '../../../config/types'
+import {type AuthState} from '../../../store/_legacy/authStore/types'
+import {useVisibleWorkspaces} from '../useVisibleWorkspaces'
+import {VisibleWorkspacesProvider} from '../VisibleWorkspacesProvider'
+
+function createAuthState(overrides: Partial<AuthState> = {}): AuthState {
+  return {
+    authenticated: true,
+    currentUser: {
+      id: 'u1',
+      name: 'User',
+      email: 'u@example.com',
+      role: '',
+      roles: [],
+      profileImage: '',
+    },
+    client: {} as AuthState['client'],
+    ...overrides,
+  }
+}
+
+interface TestWorkspace extends WorkspaceSummary {
+  authSubscriptionCount: () => number
+}
+
+function createWorkspace(options: {
+  name: string
+  hidden?: WorkspaceSummary['hidden']
+  state$?: Subject<AuthState>
+}): TestWorkspace {
+  const subject = options.state$ ?? new BehaviorSubject<AuthState>(createAuthState())
+
+  // Count every subscription, including those created transitively by
+  // `.pipe(...)` / `combineLatest`. These all end up calling `_subscribe`
+  // on the source Subject, so spying there gives us an accurate count.
+  let count = 0
+  const withSpy = subject as unknown as {
+    _subscribe: (...args: unknown[]) => unknown
+  }
+  const original = withSpy._subscribe.bind(subject)
+  withSpy._subscribe = (...args: unknown[]) => {
+    count++
+    return original(...args)
+  }
+
+  const workspace = {
+    type: 'workspace-summary',
+    name: options.name,
+    title: options.name,
+    basePath: `/${options.name}`,
+    hidden: options.hidden,
+    projectId: 'p',
+    dataset: 'd',
+    schema: {} as WorkspaceSummary['schema'],
+    i18n: {} as WorkspaceSummary['i18n'],
+    theme: {} as WorkspaceSummary['theme'],
+    icon: null,
+    customIcon: false,
+    auth: {state: subject.asObservable()} as unknown as WorkspaceSummary['auth'],
+    __internal: {sources: []},
+  } as unknown as WorkspaceSummary
+
+  return Object.assign(workspace, {authSubscriptionCount: () => count})
+}
+
+function renderProvider(workspaces: WorkspaceSummary[]) {
+  const wrapper = ({children}: {children: ReactNode}) => (
+    <WorkspacesContext.Provider value={workspaces}>
+      <VisibleWorkspacesProvider>{children}</VisibleWorkspacesProvider>
+    </WorkspacesContext.Provider>
+  )
+  return renderHook(() => useVisibleWorkspaces(), {wrapper})
+}
+
+describe('VisibleWorkspacesProvider', () => {
+  it('does not subscribe to workspace auth for workspaces without a callback-based hidden', () => {
+    // Regression guard: before this fix the provider subscribed to
+    // `workspace.auth.state` for every configured workspace at studio
+    // boot, producing a thundering herd of `/users/me` requests that
+    // caused Firefox e2e `page.goto` timeouts.
+    const plain = createWorkspace({name: 'default'})
+    const staticallyHidden = createWorkspace({name: 'admin', hidden: true})
+    const staticallyVisible = createWorkspace({name: 'guest', hidden: false})
+
+    const view = renderProvider([plain, staticallyHidden, staticallyVisible])
+
+    expect(plain.authSubscriptionCount()).toBe(0)
+    expect(staticallyHidden.authSubscriptionCount()).toBe(0)
+    expect(staticallyVisible.authSubscriptionCount()).toBe(0)
+
+    expect(view.result.current.isResolvingHiddenWorkspaces).toBe(false)
+    expect(view.result.current.visibleWorkspaces.map((w) => w.name)).toEqual(['default', 'guest'])
+  })
+
+  it('subscribes only to workspaces with a callback-based hidden', () => {
+    const plain = createWorkspace({name: 'default'})
+    const callback = createWorkspace({name: 'admin', hidden: () => false})
+
+    const view = renderProvider([plain, callback])
+
+    expect(plain.authSubscriptionCount()).toBe(0)
+    expect(callback.authSubscriptionCount()).toBeGreaterThan(0)
+    expect(view.result.current.visibleWorkspaces.map((w) => w.name)).toEqual(['default', 'admin'])
+  })
+
+  it('flips isResolvingHiddenWorkspaces from true to false once callback auth resolves', () => {
+    const state$ = new Subject<AuthState>()
+    const plain = createWorkspace({name: 'default'})
+    const callback = createWorkspace({
+      name: 'admin',
+      hidden: ({currentUser}) =>
+        currentUser !== null && !currentUser.roles.some((role) => role.name === 'administrator'),
+      state$,
+    })
+
+    const view = renderProvider([plain, callback])
+
+    expect(view.result.current.isResolvingHiddenWorkspaces).toBe(true)
+    // Fail-open: callback-hidden workspaces are included optimistically
+    // while auth is still resolving.
+    expect(view.result.current.visibleWorkspaces.map((w) => w.name)).toEqual(['default', 'admin'])
+
+    act(() => {
+      state$.next(
+        createAuthState({
+          currentUser: {
+            id: 'editor',
+            name: 'Editor',
+            email: 'editor@example.com',
+            role: 'editor',
+            roles: [{name: 'editor', title: 'Editor'}],
+            profileImage: '',
+          },
+        }),
+      )
+    })
+
+    expect(view.result.current.isResolvingHiddenWorkspaces).toBe(false)
+    expect(view.result.current.visibleWorkspaces.map((w) => w.name)).toEqual(['default'])
+  })
+})


### PR DESCRIPTION
### Description

`VisibleWorkspacesProvider` was eagerly calling `/users/me` for every configured workspace at studio boot, even when `hidden` was a boolean or undefined. This measurably delayed Firefox's `load` event and was the root cause of the Firefox e2e `page.goto` timeout flake. 

Only workspaces with a function-based `hidden` actually need auth state to decide visibility, so restrict the subscription to those.

The provider's context previously exposed a generic `authStates` map that was easy for a future consumer to reach for and misuse once the data is scoped; it's replaced with a narrower `isResolvingHiddenWorkspaces` flag. Consumers that genuinely need auth for all visible workspaces (`WorkspaceMenuButton`, `WorkspaceAuth`) self-subscribe via `useWorkspaceAuthStates`.

**Alternatives considered:** a scoped `authStates` map with docs: rejected; ux wise would introduce the same level of concerns in usage and would crash the current consumers which dereference `authStates[name].authenticated` without null-checks.

### What to review

Did I miss anything?

### Testing

- Existing tests should pass
- Added new tests for the Provider
- Firefox e2e flake to be verified on re-run.

### Notes for release

N/A: Internal only