### PR TITLE
chore: hiding types from reference docs

### DIFF
--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -70,12 +70,14 @@ export interface GroupableActionDescription<GroupType = unknown> extends BaseAct
 
 /**
  * Symbol for configuring decision parameters schema
+ * @hidden
  * @beta
  */
 export const DECISION_PARAMETERS_SCHEMA = Symbol('__decisionParametersSchema')
 
 /**
  * Configuration for decision parameters
+ * @hidden
  * @beta
  */
 export interface DecisionParametersConfig {
@@ -267,7 +269,10 @@ export interface ConfigContext {
    * Localization resources
    */
   i18n: LocaleSource
-  /** @beta */
+  /**
+   * @hidden
+   * @beta
+   */
   [DECISION_PARAMETERS_SCHEMA]?: DecisionParametersConfig
 }
 
@@ -518,7 +523,10 @@ export interface PluginOptions {
   /** Configuration for Scheduled drafts */
   scheduledDrafts?: DefaultPluginsWorkspaceOptions['scheduledDrafts']
 
-  /** @beta */
+  /**
+   * @hidden
+   * @beta
+   */
   [DECISION_PARAMETERS_SCHEMA]?: DecisionParametersConfig
 
   /** Configuration for Content Releases */
@@ -687,6 +695,7 @@ export interface WorkspaceOptions extends SourceOptions {
   scheduledDrafts?: DefaultPluginsWorkspaceOptions['scheduledDrafts']
 
   /**
+   * @hidden
    * @beta
    */
   [DECISION_PARAMETERS_SCHEMA]?: DecisionParametersConfig


### PR DESCRIPTION
### Description
Wrongly the experimental personalization config options were being exposed to the reference docs - https://reference.sanity.io/sanity/index/WorkspaceOptions/#decision_parameters_schema

This PR hides them and their type defs.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
