### PR TITLE
fix(e2e): stabilize page.goto wrapper for Firefox CI load

### DIFF
--- a/e2e/studio-test.ts
+++ b/e2e/studio-test.ts
@@ -79,7 +79,22 @@ export const test = baseTest.extend<SanityFixtures>({
       if (typeof url === 'string' && url.startsWith('/')) {
         url = `${baseUrl.origin}${basePath}${url}`
       }
-      return await originalGoto(url, options)
+      // Default to `domcontentloaded` rather than Playwright's default of `load`.
+      //
+      // The studio loads many subresources after the initial HTML is parsed
+      // (code-split chunks, workspace/auth/config fetches against the staging
+      // API, fonts, etc). On Firefox under CI load, the full `load` event
+      // frequently takes longer than the 60s test timeout, producing
+      // `page.originalGoto: Test timeout of 60000ms exceeded` flakes.
+      //
+      // Every caller already blocks on an explicit readiness signal after
+      // navigating (e.g. `[data-testid="form-view"]` via `createDraftDocument`,
+      // or an `expect(...).toBeVisible()` assertion), so waiting for `load`
+      // here adds latency without making the tests any more correct.
+      //
+      // Callers that genuinely need `load` / `networkidle` can still opt in
+      // by passing `{waitUntil: 'load'}` explicitly.
+      return await originalGoto(url, {waitUntil: 'domcontentloaded', ...options})
     }
 
     // Block the free trial dialog API to prevent overlay from intercepting clicks


### PR DESCRIPTION
### Description

Fixes the #1 Firefox E2E flake on `main`: `page.originalGoto: Test timeout of 60000ms exceeded` (seen 10-16 times per failing Firefox run).

`studio-test.ts` wraps `page.goto` (the wrapper is named `originalGoto` internally, which is the string that appears in the error). It called the underlying `goto` without a `waitUntil`, so Playwright defaulted to `waitUntil: 'load'` — waiting for the browser `load` event (all subresources + scripts). Studio startup is heavy (code-split chunks, workspace/auth/config fetches against `api.sanity.work`, fonts) and Firefox under CI load frequently can't fire `load` within the per-test 60s timeout.

Defaulted the wrapper to `waitUntil: 'domcontentloaded'`. Every affected caller already asserts its own readiness after navigating (`form-view` visible, `expect(...).toBeVisible()`, etc.), and callers who genuinely need `load`/`networkidle` can still override via `options`.

### What to review

- `e2e/studio-test.ts` — one-line default change.

### Testing

- Swept `e2e/` for existing `waitUntil` usages; the two callers that set one explicitly are unaffected.
- CI will validate on the full Firefox shard set.

### Notes for release

Not user-facing — CI infrastructure fix for Firefox E2E stability.
