### PR TITLE
fix(e2e): stabilize validation and vision test race conditions

### DIFF
--- a/e2e/tests/validation-test/validation.spec.ts
+++ b/e2e/tests/validation-test/validation.spec.ts
@@ -44,11 +44,24 @@ test.describe('Validation test', () => {
       await page.keyboard.press('Escape')
 
       await expect(page.getByTestId('nested-object-dialog')).not.toBeVisible()
-      await expect(page.getByRole('button', {name: 'Validation'})).toBeVisible()
-      await expect(page.getByRole('button', {name: 'Validation'})).toBeEnabled()
-      await page.getByRole('button', {name: 'Validation'}).click()
 
+      // Wait for the form to reflect the newly-added array row before opening the
+      // Validation panel. Without this, the click-through to `array-item-menu-button`
+      // races against the array re-render that follows the Escape/close-dialog
+      // mutation and can target a stale (about-to-unmount) node.
       const arrayItemMenuButton = page.getByTestId('array-item-menu-button')
+      await expect(arrayItemMenuButton).toHaveCount(1)
+
+      const validationButton = page.getByRole('button', {name: 'Validation'})
+      await expect(validationButton).toBeVisible()
+      await expect(validationButton).toBeEnabled()
+      await validationButton.click()
+
+      // The Validation inspector mounts async and reflows the pane; wait for at
+      // least one validation marker to land (the nested furniture list error)
+      // before interacting with the array row menu.
+      await expect(page.getByRole('button', {name: 'House / Room / List furniture'})).toBeVisible()
+
       await expect(arrayItemMenuButton).toBeVisible()
       await expect(arrayItemMenuButton).toBeEnabled()
       await retryingClickUntilVisible(
@@ -56,8 +69,9 @@ test.describe('Validation test', () => {
         arrayItemMenuButton,
         page.getByRole('menuitem', {name: 'Remove'}),
       )
-      await expect(page.getByRole('menuitem', {name: 'Remove'})).toBeEnabled()
-      await page.getByRole('menuitem', {name: 'Remove'}).click()
+      const removeMenuItem = page.getByRole('menuitem', {name: 'Remove'})
+      await expect(removeMenuItem).toBeEnabled()
+      await removeMenuItem.click()
 
       await expect(
         page.getByRole('button', {name: 'Room cant be unfurnished!', exact: true}),
@@ -102,6 +116,12 @@ test.describe('Validation test', () => {
 
       await expect(page.getByTestId('nested-object-dialog')).not.toBeVisible()
 
+      // Wait for the first row to be committed to the form before adding the
+      // second. This guards against the flake where clicking `add` again while
+      // the first row is still mid-mount silently no-ops.
+      const arrayItemMenuButton = page.getByTestId('array-item-menu-button')
+      await expect(arrayItemMenuButton).toHaveCount(1)
+
       // Wait for the add button to be ready again after closing the dialog
       await expect(addButton).toBeVisible()
       await expect(addButton).toBeEnabled()
@@ -117,11 +137,18 @@ test.describe('Validation test', () => {
 
       await expect(page.getByTestId('nested-object-dialog')).not.toBeVisible()
 
-      await expect(page.getByRole('button', {name: 'Validation'})).toBeVisible()
-      await expect(page.getByRole('button', {name: 'Validation'})).toBeEnabled()
+      // Wait for BOTH array rows to appear in the form before opening validation.
+      // Previously the test jumped straight to clicking the Validation button;
+      // if the second row hadn't finished mounting, the validation inspector
+      // would render only one marker and the `toHaveCount(2)` below would flake.
+      await expect(arrayItemMenuButton).toHaveCount(2)
+
+      const validationButton = page.getByRole('button', {name: 'Validation'})
+      await expect(validationButton).toBeVisible()
+      await expect(validationButton).toBeEnabled()
 
       // Click and wait for validation panel to open by waiting for validation items
-      await page.getByRole('button', {name: 'Validation'}).click()
+      await validationButton.click()
 
       // Wait for validation items to appear - checking count first ensures they're all rendered
       await expect(page.getByRole('button', {name: 'House / Room / List furniture'})).toHaveCount(
@@ -129,7 +156,7 @@ test.describe('Validation test', () => {
         {timeout: 10000},
       )
 
-      const firstMenuButton = page.getByTestId('array-item-menu-button').first()
+      const firstMenuButton = arrayItemMenuButton.first()
       await expect(firstMenuButton).toBeVisible()
       await expect(firstMenuButton).toBeEnabled()
       await retryingClickUntilVisible(
@@ -137,8 +164,9 @@ test.describe('Validation test', () => {
         firstMenuButton,
         page.getByRole('menuitem', {name: 'Remove'}),
       )
-      await expect(page.getByRole('menuitem', {name: 'Remove'})).toBeEnabled()
-      await page.getByRole('menuitem', {name: 'Remove'}).click()
+      const removeMenuItem = page.getByRole('menuitem', {name: 'Remove'})
+      await expect(removeMenuItem).toBeEnabled()
+      await removeMenuItem.click()
       await expect(page.getByRole('button', {name: 'House / Room / List furniture'})).toHaveCount(1)
 
       expect(errors).toHaveLength(0)
@@ -183,14 +211,25 @@ test.describe('Validation test', () => {
       await page.keyboard.press('Escape')
 
       await expect(page.getByTestId('nested-object-dialog')).not.toBeVisible()
-      await expect(page.getByRole('button', {name: 'Validation'})).toBeVisible()
-      await expect(page.getByRole('button', {name: 'Validation'})).toBeEnabled()
-      await page.getByRole('button', {name: 'Validation'}).click()
 
+      // Ensure the newly-added array row is present in the form before opening
+      // the validation inspector; prevents a race with the post-dialog re-render.
+      const arrayItemMenuButtons = page.getByTestId('array-item-menu-button')
+      await expect(arrayItemMenuButtons).toHaveCount(1)
+
+      const validationButton = page.getByRole('button', {name: 'Validation'})
+      await expect(validationButton).toBeVisible()
+      await expect(validationButton).toBeEnabled()
+      await validationButton.click()
+
+      // Both validation markers must be present before removing the array row,
+      // otherwise the subsequent assertions fail intermittently because the
+      // marker list is populated by an async validation run that can trail the
+      // mutation.
       await expect(page.getByRole('button', {name: 'Name Required'})).toBeVisible()
       await expect(page.getByRole('button', {name: 'House / Room / List furniture'})).toBeVisible()
 
-      const arrayItemMenuButton = page.getByTestId('array-item-menu-button').first()
+      const arrayItemMenuButton = arrayItemMenuButtons.first()
       await expect(arrayItemMenuButton).toBeVisible()
       await expect(arrayItemMenuButton).toBeEnabled()
       await retryingClickUntilVisible(
@@ -198,8 +237,9 @@ test.describe('Validation test', () => {
         arrayItemMenuButton,
         page.getByRole('menuitem', {name: 'Remove'}),
       )
-      await expect(page.getByRole('menuitem', {name: 'Remove'})).toBeEnabled()
-      await page.getByRole('menuitem', {name: 'Remove'}).click()
+      const removeMenuItem = page.getByRole('menuitem', {name: 'Remove'})
+      await expect(removeMenuItem).toBeEnabled()
+      await removeMenuItem.click()
 
       await expect(page.getByRole('button', {name: 'Name Required'})).toBeVisible()
       await expect(

--- a/e2e/tests/vision/utils.ts
+++ b/e2e/tests/vision/utils.ts
@@ -23,6 +23,19 @@ export const openVisionTool = async (page: Page) => {
   await page.goto('/vision')
   // Wait for vision to be visible
   await expect(page.getByTestId('vision-root')).toBeVisible()
+
+  // Vision is a code-split tool: the React tree renders `vision-root` before
+  // the CodeMirror editors have finished lazy-loading. Tests that immediately
+  // click or type into the query/params editors race against this async mount.
+  // Wait for both CodeMirror content nodes to be attached and marked editable
+  // (CodeMirror sets `contenteditable="true"` once the view is ready for input).
+  const queryEditor = page.getByTestId('vision-query-editor').locator('.cm-content')
+  const paramsEditor = page.getByTestId('params-editor').locator('.cm-content')
+
+  await expect(queryEditor).toBeVisible()
+  await expect(paramsEditor).toBeVisible()
+  await expect(queryEditor).toHaveAttribute('contenteditable', 'true')
+  await expect(paramsEditor).toHaveAttribute('contenteditable', 'true')
 }
 
 export const getVisionRegions = async (page: Page) => {

--- a/e2e/tests/vision/vision.spec.ts
+++ b/e2e/tests/vision/vision.spec.ts
@@ -120,17 +120,27 @@ test.describe('Vision', () => {
     const inputText = `*[_type == "book" && _id == "${bookDocumentId}"]`
     await expect(queryEditor).toBeEnabled()
     await queryEditor.fill(inputText)
-    // Assert that the text was correctly inserted
+    // Assert that the text was correctly inserted. The `toHaveText` poll is the
+    // real readiness signal that CodeMirror has committed the value to its
+    // internal state; no arbitrary sleep is needed here.
     await expect(queryEditor).toHaveText(inputText)
 
-    // sleep for a bit so the text is part of the query, there is nothing in the ui to show that the text has been inserted
-    await new Promise((resolve) => setTimeout(resolve, 1000))
+    // The Listen button is disabled until Vision has parsed the current query,
+    // so waiting for `enabled` is the reliable readiness signal (replaces an
+    // earlier arbitrary 1s sleep used to "let the text become part of the query").
+    const listenButton = page.locator('button').filter({hasText: 'Listen'})
+    await expect(listenButton).toBeVisible()
+    await expect(listenButton).toBeEnabled()
+    await listenButton.click()
 
-    // Find the button with the text "Fetch" and click it.
-    await page.locator('button').filter({hasText: 'Listen'}).click()
-
-    // Wait until the listener is active
-    await new Promise((resolve) => setTimeout(resolve, 1000))
+    // Clicking Listen swaps the UI to a Stop button once the listener
+    // subscription is established on the backend. Creating the document before
+    // the Stop button appears races the listener setup and can cause the
+    // document event to be missed entirely. Waiting for `Stop` is the
+    // definitive "listener is active" readiness signal (replaces an earlier
+    // arbitrary 1s sleep).
+    const stopButton = page.locator('button').filter({hasText: 'Stop'})
+    await expect(stopButton).toBeVisible()
 
     await sanityClient.create({
       _type: 'book',
@@ -143,7 +153,7 @@ test.describe('Vision', () => {
     await expect(resultRegion.getByText(`documentId:${bookDocumentId}`)).toBeVisible()
 
     // Stop the listener
-    await page.locator('button').filter({hasText: 'Stop'}).click()
-    await expect(page.locator('button').filter({hasText: 'Listen'})).toBeVisible()
+    await stopButton.click()
+    await expect(listenButton).toBeVisible()
   })
 })


### PR DESCRIPTION
### Description

Fixes the top chromium E2E flakes in the validation and Vision suites by replacing implicit auto-waits and hardcoded sleeps with deterministic readiness signals.

**Validation (`validation.spec.ts:8, :69, :147`)** — three distinct races:
- Escape→click-Validation race after a nested-object dialog close: the mutation committing a new array row triggered a re-render, and Playwright's auto-wait on `array-item-menu-button` could latch onto a stale node about to unmount. Added `expect(arrayItemMenuButton).toHaveCount(N)` as the commit-complete signal.
- Validation-inspector populates asynchronously; added an explicit `toBeVisible` on the marker button after opening the inspector.
- Double add-single-object-button click could fire before the first row was committed (the array input silently dropped the second click).

**Vision (`vision.spec.ts:7, :105`)** — two races:
- `openVisionTool` returned as soon as `vision-root` appeared, but CodeMirror editors are code-split and lazy-loaded; `.cm-content` is in the DOM before `contenteditable` is set. Added `toHaveAttribute('contenteditable', 'true')` poll on both editors (CodeMirror sets this only when ready for input).
- Replaced two hardcoded `setTimeout(1000)` sleeps with `expect(listenButton).toBeEnabled()` and `expect(stopButton).toBeVisible()` — the Listen→Stop swap is the definitive "listener active" signal.

### What to review

- `validation.spec.ts` — count/visibility asserts around the Escape and Validation-inspector flows.
- `vision/utils.ts` + `vision/vision.spec.ts` — `openVisionTool` readiness check and the replacement of `setTimeout` sleeps with deterministic signals.

### Testing

- No test intent changed, no arbitrary sleeps introduced.
- Each new wait is a readiness signal specific to the code under test.
- CI will validate on the chromium + firefox matrix.

### Notes for release

Not user-facing — E2E test stability fix.
