### PR TITLE
fix(test): disable console intercept to prevent worker teardown races

### DIFF
--- a/packages/@repo/test-config/vitest/index.mjs
+++ b/packages/@repo/test-config/vitest/index.mjs
@@ -14,6 +14,11 @@ export function defineConfig(config) {
     ...config,
     test: {
       ...config?.test,
+      // Disable console interception to prevent `EnvironmentTeardownError: Closing rpc while
+      // "onUserConsoleLog" was pending` when async emissions (e.g. RxJS catchError logs) fire
+      // after a test's body resolves but before the worker finishes teardown. Tradeoff:
+      // console output goes directly to stdout/stderr instead of through the vitest reporter.
+      disableConsoleIntercept: config?.test?.disableConsoleIntercept ?? true,
       // oxlint-disable-next-line no-misused-spread
       alias: {...config?.test?.alias, ...getViteAliases()},
       typecheck: {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -5,12 +5,6 @@ import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
   test: {
-    // Disable console interception to prevent `EnvironmentTeardownError: Closing rpc while
-    // "onUserConsoleLog" was pending` when async emissions (e.g. RxJS catchError logs) fire
-    // after a test's body resolves but before the worker finishes teardown.
-    // Tradeoff: console.log output from tests goes directly to stdout/stderr instead of
-    // through the vitest reporter, but reliability beats tidy output here.
-    disableConsoleIntercept: true,
     forceRerunTriggers: [
       '**/package.json/**',
       '**/vitest.config.*/**',

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -5,6 +5,12 @@ import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
   test: {
+    // Disable console interception to prevent `EnvironmentTeardownError: Closing rpc while
+    // "onUserConsoleLog" was pending` when async emissions (e.g. RxJS catchError logs) fire
+    // after a test's body resolves but before the worker finishes teardown.
+    // Tradeoff: console.log output from tests goes directly to stdout/stderr instead of
+    // through the vitest reporter, but reliability beats tidy output here.
+    disableConsoleIntercept: true,
     forceRerunTriggers: [
       '**/package.json/**',
       '**/vitest.config.*/**',


### PR DESCRIPTION
### Description

Global fix for the `EnvironmentTeardownError` that has been failing `Test (node 20) - 3/4` (and occasionally other shards) consistently on `main`:

```
EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending
```

Components that use RxJS observables emit `console.error` from `catchError` operators. When they unmount during `@testing-library` cleanup, those observables can still be mid-emission. The `console` call fires after the test body resolves but before the worker finishes teardown, and vitest's `onUserConsoleLog` RPC races the shutdown.

Confirmed in `CrossDatasetReferenceInput.test.tsx` and `DocumentPerspectiveList.test.tsx`; likely affects any test that unmounts an RxJS-using component.

Set `disableConsoleIntercept: true` at both the root vitest config and the shared `@repo/test-config/vitest` used by `packages/sanity`. This is the vitest-recommended fix — console output goes directly to stdout/stderr instead of through the reporter's RPC channel. Tradeoff: less tidy reporter output, but reliability matters more, and Node 22 / 24 shards aren't affected today.

### What to review

- `packages/@repo/test-config/vitest/index.mjs` — shared base used by `packages/sanity`.
- `vitest.config.mts` — root config, covers the rest of the workspace.
- Both include a comment explaining the rationale and the tradeoff.

### Testing

- Ran both failing test files locally with the fix: 27 tests pass, 4 skipped, exit code 0.
- CI will validate across the full Node matrix.

### Notes for release

Not user-facing — CI infrastructure fix for vitest worker teardown races.
