### PR TITLE
refactor: add hasAttachment tag to sentry feedback

### DIFF
--- a/packages/sanity/src/core/feedback/__tests__/feedbackClient.test.ts
+++ b/packages/sanity/src/core/feedback/__tests__/feedbackClient.test.ts
@@ -228,15 +228,17 @@ describe('sendFeedbackToSentry', () => {
     const attachment = {filename: 'screenshot.png', data: new Uint8Array([1, 2, 3])}
     await sendFeedbackToSentry(makePayload({attachments: [attachment]}))
 
-    const [, hint] = mockCaptureEvent.mock.calls[0]
+    const [event, hint] = mockCaptureEvent.mock.calls[0]
     expect(hint.attachments).toEqual([attachment])
+    expect(event.tags.hasAttachment).toBe('true')
   })
 
   it('passes empty hint when no attachments', async () => {
     await sendFeedbackToSentry(makePayload({attachments: undefined}))
 
-    const [, hint] = mockCaptureEvent.mock.calls[0]
+    const [event, hint] = mockCaptureEvent.mock.calls[0]
     expect(hint).toEqual({})
+    expect(event.tags.hasAttachment).toBe('false')
   })
 
   it('handles missing name and email gracefully with consent', async () => {

--- a/packages/sanity/src/core/feedback/__tests__/feedbackClient.test.ts
+++ b/packages/sanity/src/core/feedback/__tests__/feedbackClient.test.ts
@@ -230,7 +230,7 @@ describe('sendFeedbackToSentry', () => {
 
     const [event, hint] = mockCaptureEvent.mock.calls[0]
     expect(hint.attachments).toEqual([attachment])
-    expect(event.tags.hasAttachment).toBe('true')
+    expect(event.tags.hasAttachments).toBe(true)
   })
 
   it('passes empty hint when no attachments', async () => {
@@ -238,7 +238,7 @@ describe('sendFeedbackToSentry', () => {
 
     const [event, hint] = mockCaptureEvent.mock.calls[0]
     expect(hint).toEqual({})
-    expect(event.tags.hasAttachment).toBe('false')
+    expect(event.tags.hasAttachments).toBe(false)
   })
 
   it('handles missing name and email gracefully with consent', async () => {

--- a/packages/sanity/src/core/feedback/feedbackClient.ts
+++ b/packages/sanity/src/core/feedback/feedbackClient.ts
@@ -62,7 +62,7 @@ export async function sendFeedbackToSentry(payload: FeedbackPayload): Promise<st
 
   const {userId: _userId, ...safeTags} = tags
   const eventTags = hasTelemetryConsent ? tags : safeTags
-  const hasAttachments = attachments?.length
+  const hasAttachments = !!attachments?.length
 
   const feedbackEvent = {
     contexts: {

--- a/packages/sanity/src/core/feedback/feedbackClient.ts
+++ b/packages/sanity/src/core/feedback/feedbackClient.ts
@@ -62,6 +62,7 @@ export async function sendFeedbackToSentry(payload: FeedbackPayload): Promise<st
 
   const {userId: _userId, ...safeTags} = tags
   const eventTags = hasTelemetryConsent ? tags : safeTags
+  const hasAttachments = attachments?.length
 
   const feedbackEvent = {
     contexts: {
@@ -81,12 +82,13 @@ export async function sendFeedbackToSentry(payload: FeedbackPayload): Promise<st
       ...(shareName ? {contactName: name ?? ''} : {}),
       ...(shareEmail ? {contactEmail: email ?? ''} : {}),
       telemetryConsent,
+      hasAttachments,
       type: 'feedback',
       source,
     },
   }
 
-  const hint = attachments?.length ? {attachments} : {}
+  const hint = hasAttachments ? {attachments} : {}
 
   const eventId = scope.captureEvent(feedbackEvent, hint)
 


### PR DESCRIPTION
### Description

Asked as part of Andrej's request to update slack notifications, attachments (images) in feedback are handled separately from the tags which makes it impossible to show hints that you have an attachment. Adding an extra tag makes that easier in the sentry interface.

### What to review

On the tin

### Testing

Added extra tests for these for completeness sake.
You can view my tests on this slack channel #rita-feedback-test-channel (you can do it on the deployed / locally but trying to keep the internal noise to a minimum)

### Notes for release

N/A
