### PR TITLE
fix: positioning of reference input lists in documents (and modals / dialogs / popovers)

### DIFF
--- a/packages/sanity/src/core/form/components/EditPortal.tsx
+++ b/packages/sanity/src/core/form/components/EditPortal.tsx
@@ -56,22 +56,22 @@ export function EditPortal(props: PopoverProps | DialogProps): React.JSX.Element
         scrollElement={documentScrollElement}
         containerElement={containerElement}
       >
-        <BoundaryElementProvider element={documentScrollElement}>
-          <Dialog
-            __unstable_autoFocus={props.autofocus}
-            contentRef={setDocumentScrollElement}
-            data-testid="edit-portal-dialog"
-            header={header}
-            id={props.id || ''}
-            onClickOutside={onClose}
-            onClose={onClose}
-            onDragEnter={onDragEnter}
-            onDrop={onDrop}
-            width={width}
-          >
+        <Dialog
+          __unstable_autoFocus={props.autofocus}
+          contentRef={setDocumentScrollElement}
+          data-testid="edit-portal-dialog"
+          header={header}
+          id={props.id || ''}
+          onClickOutside={onClose}
+          onClose={onClose}
+          onDragEnter={onDragEnter}
+          onDrop={onDrop}
+          width={width}
+        >
+          <BoundaryElementProvider element={documentScrollElement}>
             {contents}
-          </Dialog>
-        </BoundaryElementProvider>
+          </BoundaryElementProvider>
+        </Dialog>
       </VirtualizerScrollInstanceProvider>
     )
   }

--- a/packages/sanity/src/core/form/components/EditPortal.tsx
+++ b/packages/sanity/src/core/form/components/EditPortal.tsx
@@ -1,4 +1,4 @@
-import {Box, type ResponsiveWidthProps} from '@sanity/ui'
+import {BoundaryElementProvider, Box, type ResponsiveWidthProps} from '@sanity/ui'
 import {type DragEvent, type ReactNode, useRef, useState} from 'react'
 
 import {Dialog} from '../../../ui-components'
@@ -56,20 +56,22 @@ export function EditPortal(props: PopoverProps | DialogProps): React.JSX.Element
         scrollElement={documentScrollElement}
         containerElement={containerElement}
       >
-        <Dialog
-          __unstable_autoFocus={props.autofocus}
-          contentRef={setDocumentScrollElement}
-          data-testid="edit-portal-dialog"
-          header={header}
-          id={props.id || ''}
-          onClickOutside={onClose}
-          onClose={onClose}
-          onDragEnter={onDragEnter}
-          onDrop={onDrop}
-          width={width}
-        >
-          {contents}
-        </Dialog>
+        <BoundaryElementProvider element={documentScrollElement}>
+          <Dialog
+            __unstable_autoFocus={props.autofocus}
+            contentRef={setDocumentScrollElement}
+            data-testid="edit-portal-dialog"
+            header={header}
+            id={props.id || ''}
+            onClickOutside={onClose}
+            onClose={onClose}
+            onDragEnter={onDragEnter}
+            onDrop={onDrop}
+            width={width}
+          >
+            {contents}
+          </Dialog>
+        </BoundaryElementProvider>
       </VirtualizerScrollInstanceProvider>
     )
   }
@@ -86,7 +88,9 @@ export function EditPortal(props: PopoverProps | DialogProps): React.JSX.Element
         scrollElement={documentScrollElement}
         containerElement={containerElement}
       >
-        {contents}
+        <BoundaryElementProvider element={documentScrollElement}>
+          {contents}
+        </BoundaryElementProvider>
       </VirtualizerScrollInstanceProvider>
     </PopoverDialog>
   )

--- a/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
+++ b/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
@@ -1,6 +1,6 @@
 import {useTelemetry} from '@sanity/telemetry/react'
 import {type Path} from '@sanity/types'
-import {Box, type ResponsiveWidthProps, useGlobalKeyDown} from '@sanity/ui'
+import {BoundaryElementProvider, Box, type ResponsiveWidthProps, useGlobalKeyDown} from '@sanity/ui'
 import {type DragEvent, type ReactNode, useCallback, useEffect, useRef, useState} from 'react'
 import {styled} from 'styled-components'
 
@@ -180,28 +180,30 @@ export function EnhancedObjectDialog(props: PopoverProps | DialogProps): React.J
         scrollElement={documentScrollElement}
         containerElement={containerElement}
       >
-        <StyledDialog
-          $isHidden={!isTop}
-          __unstable_autoFocus={isTop ? props.autofocus : false}
-          contentRef={setDocumentScrollElement}
-          data-testid="nested-object-dialog"
-          header={
-            <DialogBreadcrumbs
-              currentPath={currentPath}
-              onNavigate={navigateTo}
-              onClose={handleStackedDialogClose}
-            />
-          }
-          id={dialogId}
-          onClose={handleStackedDialogClose}
-          onDragEnter={onDragEnter}
-          onDrop={onDrop}
-          width={width}
-          animate={!shouldDisableAnimation}
-          onClickOutside={handleCompleteDialogClose}
-        >
-          {contents}
-        </StyledDialog>
+        <BoundaryElementProvider element={documentScrollElement}>
+          <StyledDialog
+            $isHidden={!isTop}
+            __unstable_autoFocus={isTop ? props.autofocus : false}
+            contentRef={setDocumentScrollElement}
+            data-testid="nested-object-dialog"
+            header={
+              <DialogBreadcrumbs
+                currentPath={currentPath}
+                onNavigate={navigateTo}
+                onClose={handleStackedDialogClose}
+              />
+            }
+            id={dialogId}
+            onClose={handleStackedDialogClose}
+            onDragEnter={onDragEnter}
+            onDrop={onDrop}
+            width={width}
+            animate={!shouldDisableAnimation}
+            onClickOutside={handleCompleteDialogClose}
+          >
+            {contents}
+          </StyledDialog>
+        </BoundaryElementProvider>
       </VirtualizerScrollInstanceProvider>
     )
   }
@@ -211,15 +213,17 @@ export function EnhancedObjectDialog(props: PopoverProps | DialogProps): React.J
       scrollElement={documentScrollElement}
       containerElement={containerElement}
     >
-      <PopoverDialog
-        header={header}
-        onClose={handleStackedDialogClose}
-        width={width}
-        containerRef={setDocumentScrollElement}
-        referenceElement={props.legacy_referenceElement}
-      >
-        {contents}
-      </PopoverDialog>
+      <BoundaryElementProvider element={documentScrollElement}>
+        <PopoverDialog
+          header={header}
+          onClose={handleStackedDialogClose}
+          width={width}
+          containerRef={setDocumentScrollElement}
+          referenceElement={props.legacy_referenceElement}
+        >
+          {contents}
+        </PopoverDialog>
+      </BoundaryElementProvider>
     </VirtualizerScrollInstanceProvider>
   )
 }

--- a/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
+++ b/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
@@ -213,17 +213,17 @@ export function EnhancedObjectDialog(props: PopoverProps | DialogProps): React.J
       scrollElement={documentScrollElement}
       containerElement={containerElement}
     >
-      <BoundaryElementProvider element={documentScrollElement}>
-        <PopoverDialog
-          header={header}
-          onClose={handleStackedDialogClose}
-          width={width}
-          containerRef={setDocumentScrollElement}
-          referenceElement={props.legacy_referenceElement}
-        >
+      <PopoverDialog
+        header={header}
+        onClose={handleStackedDialogClose}
+        width={width}
+        containerRef={setDocumentScrollElement}
+        referenceElement={props.legacy_referenceElement}
+      >
+        <BoundaryElementProvider element={documentScrollElement}>
           {contents}
-        </PopoverDialog>
-      </BoundaryElementProvider>
+        </BoundaryElementProvider>
+      </PopoverDialog>
     </VirtualizerScrollInstanceProvider>
   )
 }

--- a/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
+++ b/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
@@ -180,30 +180,30 @@ export function EnhancedObjectDialog(props: PopoverProps | DialogProps): React.J
         scrollElement={documentScrollElement}
         containerElement={containerElement}
       >
-        <BoundaryElementProvider element={documentScrollElement}>
-          <StyledDialog
-            $isHidden={!isTop}
-            __unstable_autoFocus={isTop ? props.autofocus : false}
-            contentRef={setDocumentScrollElement}
-            data-testid="nested-object-dialog"
-            header={
-              <DialogBreadcrumbs
-                currentPath={currentPath}
-                onNavigate={navigateTo}
-                onClose={handleStackedDialogClose}
-              />
-            }
-            id={dialogId}
-            onClose={handleStackedDialogClose}
-            onDragEnter={onDragEnter}
-            onDrop={onDrop}
-            width={width}
-            animate={!shouldDisableAnimation}
-            onClickOutside={handleCompleteDialogClose}
-          >
+        <StyledDialog
+          $isHidden={!isTop}
+          __unstable_autoFocus={isTop ? props.autofocus : false}
+          contentRef={setDocumentScrollElement}
+          data-testid="nested-object-dialog"
+          header={
+            <DialogBreadcrumbs
+              currentPath={currentPath}
+              onNavigate={navigateTo}
+              onClose={handleStackedDialogClose}
+            />
+          }
+          id={dialogId}
+          onClose={handleStackedDialogClose}
+          onDragEnter={onDragEnter}
+          onDrop={onDrop}
+          width={width}
+          animate={!shouldDisableAnimation}
+          onClickOutside={handleCompleteDialogClose}
+        >
+          <BoundaryElementProvider element={documentScrollElement}>
             {contents}
-          </StyledDialog>
-        </BoundaryElementProvider>
+          </BoundaryElementProvider>
+        </StyledDialog>
       </VirtualizerScrollInstanceProvider>
     )
   }

--- a/packages/sanity/src/core/form/hooks/useReferenceAutocompletePopoverBoundary.ts
+++ b/packages/sanity/src/core/form/hooks/useReferenceAutocompletePopoverBoundary.ts
@@ -1,6 +1,6 @@
 import {useBoundaryElement} from '@sanity/ui'
 
-import {AUTOCOMPLETE_POPOVER_BOUNDARY} from './referenceAutocompletePopoverBoundary'
+import {AUTOCOMPLETE_POPOVER_BOUNDARY} from '../inputs/referenceAutocompletePopoverBoundary'
 
 /**
  * Pick the right Floating UI boundary for a reference autocomplete popover.

--- a/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/ReferenceAutocomplete.tsx
+++ b/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/ReferenceAutocomplete.tsx
@@ -11,7 +11,7 @@ import {styled} from 'styled-components'
 
 import {Popover} from '../../../../ui-components'
 import {Translate, useTranslation} from '../../../i18n'
-import {useReferenceAutocompletePopoverBoundary} from '../useReferenceAutocompletePopoverBoundary'
+import {useReferenceAutocompletePopoverBoundary} from '../../hooks/useReferenceAutocompletePopoverBoundary'
 
 const StyledPopover = styled(Popover)`
   & > div {

--- a/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/ReferenceAutocomplete.tsx
+++ b/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/ReferenceAutocomplete.tsx
@@ -11,7 +11,7 @@ import {styled} from 'styled-components'
 
 import {Popover} from '../../../../ui-components'
 import {Translate, useTranslation} from '../../../i18n'
-import {AUTOCOMPLETE_POPOVER_BOUNDARY} from '../referenceAutocompletePopoverBoundary'
+import {useReferenceAutocompletePopoverBoundary} from '../useReferenceAutocompletePopoverBoundary'
 
 const StyledPopover = styled(Popover)`
   & > div {
@@ -37,6 +37,7 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
   const {searchString, loading, portalRef, referenceElement, ...restProps} = props
   const {t} = useTranslation()
   const hasResults = props.options && props.options.length > 0
+  const popoverBoundary = useReferenceAutocompletePopoverBoundary(referenceElement)
   const renderPopover = useCallback(
     (
       {
@@ -60,8 +61,8 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
         fallbackPlacements={FALLBACK_PLACEMENTS}
         arrow={false}
         constrainSize
-        floatingBoundary={AUTOCOMPLETE_POPOVER_BOUNDARY}
-        referenceBoundary={AUTOCOMPLETE_POPOVER_BOUNDARY}
+        floatingBoundary={popoverBoundary}
+        referenceBoundary={popoverBoundary}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         content={
@@ -90,7 +91,7 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
         matchReferenceWidth
       />
     ),
-    [hasResults, t, searchString, loading, portalRef, referenceElement],
+    [hasResults, t, searchString, loading, portalRef, referenceElement, popoverBoundary],
   )
   return <Autocomplete {...restProps} ref={ref} renderPopover={renderPopover} />
 })

--- a/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/ReferenceAutocomplete.test.tsx
+++ b/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/ReferenceAutocomplete.test.tsx
@@ -1,6 +1,13 @@
 /**
- * Ensures reference autocomplete popovers pass explicit floating/reference boundaries so
- * portaled dialogs (and embeds without DocumentPanel) get correct Floating UI behavior.
+ * Ensures reference autocomplete popovers pick the correct Floating UI boundary so that:
+ *
+ *  - In the document pane (where `BoundaryElementProvider` wraps the scroll container) the
+ *    popover is constrained to that scroll container. This prevents the popover from overlapping
+ *    the sticky pane header, the version chips / document actions bar, or clipping into the pane
+ *    top when flipped upward (SAPP-3726, SAPP-3728, SGH-588).
+ *  - In portaled dialogs (e.g. the Media Library) where the reference element is not inside the
+ *    inherited boundary element, we fall back to `document.documentElement` so the popover is
+ *    positioned against the viewport (avoids `referenceHidden` / misalignment).
  *
  * `ReferenceInput/ReferenceAutocomplete` (same-dataset), GDR, and Cross-dataset
  * `CrossDatasetReferenceInput/ReferenceAutocomplete` share this Popover wiring. Same-dataset needs
@@ -31,6 +38,9 @@ type PopoverBoundaryCapture = Pick<
 
 /** Last props passed from ReferenceAutocomplete to Popover (via styled wrapper). */
 let lastPopoverProps: PopoverBoundaryCapture | null = null
+
+/** Element returned from the mocked `useBoundaryElement` hook (null = no provider). */
+let mockBoundaryElement: HTMLElement | null = null
 
 function assignForwardedRef<T>(ref: ForwardedRef<T>, value: T | null): void {
   if (typeof ref === 'function') {
@@ -97,7 +107,12 @@ vi.mock('@sanity/ui', async (importOriginal) => {
     )
   })
 
-  return {...mod, Autocomplete: AutocompleteStub as Autocomplete}
+  // Mock `useBoundaryElement` so we can drive the hook under test without rendering a real
+  // `BoundaryElementProvider` (which would require importing from the mocked module and trips
+  // hoisting inside `importOriginal`).
+  const useBoundaryElement = () => ({version: 0.0, element: mockBoundaryElement})
+
+  return {...mod, Autocomplete: AutocompleteStub as Autocomplete, useBoundaryElement}
 })
 
 vi.mock('../../../i18n', () => ({
@@ -121,69 +136,184 @@ vi.mock('../../../../ui-components', async (importOriginal) => {
   return {...mod, Popover: Forward as UIComponentsModule.Popover}
 })
 
-describe('ReferenceAutocomplete popover boundaries (portaled dialogs / embeds)', () => {
+/**
+ * Build a scroll-container stand-in, attach it to the DOM, and register it as the boundary
+ * element that the mocked `useBoundaryElement` will return. Also builds a reference element that
+ * is a descendant of that container so `boundary.contains(reference)` is `true`.
+ */
+function setupContainedBoundary(): {
+  boundary: HTMLDivElement
+  referenceElement: HTMLDivElement
+} {
+  const boundary = document.createElement('div')
+  boundary.dataset.testid = 'scroll-boundary'
+  const referenceElement = document.createElement('div')
+  referenceElement.dataset.testid = 'reference-anchor'
+  boundary.append(referenceElement)
+  document.body.append(boundary)
+  mockBoundaryElement = boundary
+  return {boundary, referenceElement}
+}
+
+describe('ReferenceAutocomplete popover boundaries', () => {
   beforeEach(() => {
     lastPopoverProps = null
+    mockBoundaryElement = null
   })
 
-  test('global document reference: passes documentElement as floatingBoundary and referenceBoundary to Popover', async () => {
-    render(
-      <ReferenceAutocomplete
-        loading={false}
-        options={[]}
-        onQueryChange={() => undefined}
-        referenceElement={null}
-        searchString=""
-        id="ref-ac-test"
-      />,
-    )
+  describe('falls back to documentElement in portaled dialogs / embeds (no scroll-container ancestor)', () => {
+    test('global document reference', async () => {
+      render(
+        <ReferenceAutocomplete
+          loading={false}
+          options={[]}
+          onQueryChange={() => undefined}
+          referenceElement={null}
+          searchString=""
+          id="ref-ac-test"
+        />,
+      )
 
-    await waitFor(() => {
-      expect(lastPopoverProps).not.toBeNull()
+      await waitFor(() => {
+        expect(lastPopoverProps).not.toBeNull()
+      })
+
+      expect(lastPopoverProps?.floatingBoundary).toBe(document.documentElement)
+      expect(lastPopoverProps?.referenceBoundary).toBe(document.documentElement)
     })
 
-    expect(lastPopoverProps?.floatingBoundary).toBe(document.documentElement)
-    expect(lastPopoverProps?.referenceBoundary).toBe(document.documentElement)
+    test('cross-dataset reference', async () => {
+      render(
+        <CrossDatasetReferenceAutocomplete
+          loading={false}
+          options={[]}
+          onQueryChange={() => undefined}
+          referenceElement={null}
+          searchString=""
+          id="cross-ref-ac-test"
+        />,
+      )
+
+      await waitFor(() => {
+        expect(lastPopoverProps).not.toBeNull()
+      })
+
+      expect(lastPopoverProps?.floatingBoundary).toBe(document.documentElement)
+      expect(lastPopoverProps?.referenceBoundary).toBe(document.documentElement)
+    })
+
+    test('same-dataset reference', async () => {
+      render(
+        <SameDatasetReferenceAutocomplete
+          path={[...sameDatasetFieldPath]}
+          loading={false}
+          options={[]}
+          onQueryChange={() => undefined}
+          referenceElement={null}
+          searchString=""
+          id="same-dataset-ref-ac-test"
+        />,
+      )
+
+      await waitFor(() => {
+        expect(lastPopoverProps).not.toBeNull()
+      })
+
+      expect(lastPopoverProps?.floatingBoundary).toBe(document.documentElement)
+      expect(lastPopoverProps?.referenceBoundary).toBe(document.documentElement)
+    })
   })
 
-  test('cross-dataset reference: passes documentElement as floatingBoundary and referenceBoundary to Popover', async () => {
-    render(
-      <CrossDatasetReferenceAutocomplete
-        loading={false}
-        options={[]}
-        onQueryChange={() => undefined}
-        referenceElement={null}
-        searchString=""
-        id="cross-ref-ac-test"
-      />,
-    )
+  describe('uses the boundary element from context when it contains the reference (document pane scroll container)', () => {
+    test('global document reference', async () => {
+      const {boundary, referenceElement} = setupContainedBoundary()
 
-    await waitFor(() => {
-      expect(lastPopoverProps).not.toBeNull()
+      render(
+        <ReferenceAutocomplete
+          loading={false}
+          options={[]}
+          onQueryChange={() => undefined}
+          referenceElement={referenceElement}
+          searchString=""
+          id="ref-ac-test-with-boundary"
+        />,
+      )
+
+      await waitFor(() => {
+        expect(lastPopoverProps?.floatingBoundary).toBe(boundary)
+      })
+      expect(lastPopoverProps?.referenceBoundary).toBe(boundary)
     })
 
-    expect(lastPopoverProps?.floatingBoundary).toBe(document.documentElement)
-    expect(lastPopoverProps?.referenceBoundary).toBe(document.documentElement)
+    test('cross-dataset reference', async () => {
+      const {boundary, referenceElement} = setupContainedBoundary()
+
+      render(
+        <CrossDatasetReferenceAutocomplete
+          loading={false}
+          options={[]}
+          onQueryChange={() => undefined}
+          referenceElement={referenceElement}
+          searchString=""
+          id="cross-ref-ac-test-with-boundary"
+        />,
+      )
+
+      await waitFor(() => {
+        expect(lastPopoverProps?.floatingBoundary).toBe(boundary)
+      })
+      expect(lastPopoverProps?.referenceBoundary).toBe(boundary)
+    })
+
+    test('same-dataset reference', async () => {
+      const {boundary, referenceElement} = setupContainedBoundary()
+
+      render(
+        <SameDatasetReferenceAutocomplete
+          path={[...sameDatasetFieldPath]}
+          loading={false}
+          options={[]}
+          onQueryChange={() => undefined}
+          referenceElement={referenceElement}
+          searchString=""
+          id="same-dataset-ref-ac-test-with-boundary"
+        />,
+      )
+
+      await waitFor(() => {
+        expect(lastPopoverProps?.floatingBoundary).toBe(boundary)
+      })
+      expect(lastPopoverProps?.referenceBoundary).toBe(boundary)
+    })
   })
 
-  test('same-dataset reference: passes documentElement as floatingBoundary and referenceBoundary to Popover', async () => {
-    render(
-      <SameDatasetReferenceAutocomplete
-        path={[...sameDatasetFieldPath]}
-        loading={false}
-        options={[]}
-        onQueryChange={() => undefined}
-        referenceElement={null}
-        searchString=""
-        id="same-dataset-ref-ac-test"
-      />,
-    )
+  describe('falls back to documentElement when context element does not contain the reference', () => {
+    test('global document reference with boundary element but reference element outside it', async () => {
+      // Attach a boundary to the mock, but leave the reference element elsewhere in the DOM.
+      const boundary = document.createElement('div')
+      document.body.append(boundary)
+      mockBoundaryElement = boundary
 
-    await waitFor(() => {
-      expect(lastPopoverProps).not.toBeNull()
+      const detachedReference = document.createElement('div')
+      document.body.append(detachedReference)
+
+      render(
+        <ReferenceAutocomplete
+          loading={false}
+          options={[]}
+          onQueryChange={() => undefined}
+          referenceElement={detachedReference}
+          searchString=""
+          id="ref-ac-test-detached"
+        />,
+      )
+
+      await waitFor(() => {
+        expect(lastPopoverProps).not.toBeNull()
+      })
+
+      expect(lastPopoverProps?.floatingBoundary).toBe(document.documentElement)
+      expect(lastPopoverProps?.referenceBoundary).toBe(document.documentElement)
     })
-
-    expect(lastPopoverProps?.floatingBoundary).toBe(document.documentElement)
-    expect(lastPopoverProps?.referenceBoundary).toBe(document.documentElement)
   })
 })

--- a/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/ReferenceAutocomplete.tsx
+++ b/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/ReferenceAutocomplete.tsx
@@ -12,7 +12,7 @@ import {styled} from 'styled-components'
 
 import {Popover} from '../../../../ui-components'
 import {Translate, useTranslation} from '../../../i18n'
-import {useReferenceAutocompletePopoverBoundary} from '../useReferenceAutocompletePopoverBoundary'
+import {useReferenceAutocompletePopoverBoundary} from '../../hooks/useReferenceAutocompletePopoverBoundary'
 
 const StyledPopover = styled(Popover)`
   & > div {

--- a/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/ReferenceAutocomplete.tsx
+++ b/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/ReferenceAutocomplete.tsx
@@ -12,7 +12,7 @@ import {styled} from 'styled-components'
 
 import {Popover} from '../../../../ui-components'
 import {Translate, useTranslation} from '../../../i18n'
-import {AUTOCOMPLETE_POPOVER_BOUNDARY} from '../referenceAutocompletePopoverBoundary'
+import {useReferenceAutocompletePopoverBoundary} from '../useReferenceAutocompletePopoverBoundary'
 
 const StyledPopover = styled(Popover)`
   & > div {
@@ -38,6 +38,7 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
   const {searchString, loading, portalRef, referenceElement, ...restProps} = props
   const {t} = useTranslation()
   const hasResults = props.options && props.options.length > 0
+  const popoverBoundary = useReferenceAutocompletePopoverBoundary(referenceElement)
   const renderPopover = useCallback(
     (
       {
@@ -61,8 +62,8 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
         fallbackPlacements={FALLBACK_PLACEMENTS}
         arrow={false}
         constrainSize
-        floatingBoundary={AUTOCOMPLETE_POPOVER_BOUNDARY}
-        referenceBoundary={AUTOCOMPLETE_POPOVER_BOUNDARY}
+        floatingBoundary={popoverBoundary}
+        referenceBoundary={popoverBoundary}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         content={
@@ -91,7 +92,7 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
         matchReferenceWidth
       />
     ),
-    [hasResults, t, searchString, loading, portalRef, referenceElement],
+    [hasResults, t, searchString, loading, portalRef, referenceElement, popoverBoundary],
   )
   return <Autocomplete {...restProps} ref={ref} renderPopover={renderPopover} />
 })

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/DialogModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/DialogModal.tsx
@@ -1,4 +1,4 @@
-import {Box} from '@sanity/ui'
+import {BoundaryElementProvider, Box} from '@sanity/ui'
 import {type ReactNode, useId, useRef, useState} from 'react'
 
 import {Dialog} from '../../../../../../ui-components'
@@ -38,7 +38,9 @@ export function DefaultEditDialog(props: DefaultEditDialogProps) {
           scrollElement={contentElement}
           containerElement={containerElement}
         >
-          <Box ref={containerElement}>{children}</Box>
+          <BoundaryElementProvider element={contentElement}>
+            <Box ref={containerElement}>{children}</Box>
+          </BoundaryElementProvider>
         </VirtualizerScrollInstanceProvider>
       </PresenceOverlay>
     </Dialog>

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -1,8 +1,22 @@
 /* eslint-disable react/no-unused-prop-types */
 
 import {CloseIcon} from '@sanity/icons'
-import {Box, Flex, Text, useClickOutsideEvent, useGlobalKeyDown} from '@sanity/ui'
-import {type PropsWithChildren, type ReactNode, useCallback, useRef, useState} from 'react'
+import {
+  BoundaryElementProvider,
+  Box,
+  Flex,
+  Text,
+  useClickOutsideEvent,
+  useGlobalKeyDown,
+} from '@sanity/ui'
+import {
+  type PropsWithChildren,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import FocusLock from 'react-focus-lock'
 import {type PortableTextEditorElement} from 'sanity/_singletons'
 
@@ -102,7 +116,16 @@ function Content(props: PopoverEditDialogProps) {
 
   // This seems to work with regular refs as well, but it might be safer to use state.
   const [contentElement, setContentElement] = useState<HTMLDivElement | null>(null)
+  const [boundaryElement, setBoundaryElement] = useState<HTMLElement | null>(null)
   const containerElement = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!contentElement) {
+      setBoundaryElement(null)
+      return
+    }
+    setBoundaryElement(contentElement.closest<HTMLElement>('[data-ui="Popover__wrapper"]'))
+  }, [contentElement])
 
   const handleFocusLockWhiteList = useCallback((element: HTMLElement) => {
     // This is needed in order for focusLock not to trap focus in the
@@ -127,33 +150,35 @@ function Content(props: PopoverEditDialogProps) {
       scrollElement={contentElement}
       containerElement={containerElement}
     >
-      <FocusLock autoFocus whiteList={handleFocusLockWhiteList}>
-        <Flex as={NoopContainer} ref={containerElement} direction="column" height="fill">
-          <ContentHeaderBox flex="none" padding={1}>
-            <Flex align="center">
-              <Box flex={1} padding={2}>
-                <Text weight="medium">{title}</Text>
-              </Box>
+      <BoundaryElementProvider element={boundaryElement}>
+        <FocusLock autoFocus whiteList={handleFocusLockWhiteList}>
+          <Flex as={NoopContainer} ref={containerElement} direction="column" height="fill">
+            <ContentHeaderBox flex="none" padding={1}>
+              <Flex align="center">
+                <Box flex={1} padding={2}>
+                  <Text weight="medium">{title}</Text>
+                </Box>
 
-              <Button
-                autoFocus
-                icon={CloseIcon}
-                mode="bleed"
-                onClick={handleClose}
-                tooltipProps={{content: 'Close'}}
-                data-testid="close-popover-edit-dialog-button"
-              />
-            </Flex>
-          </ContentHeaderBox>
-          <ContentScrollerBox flex={1}>
-            <PresenceOverlay margins={[0, 0, 1, 0]}>
-              <Box padding={3} ref={setContentElement}>
-                {props.children}
-              </Box>
-            </PresenceOverlay>
-          </ContentScrollerBox>
-        </Flex>
-      </FocusLock>
+                <Button
+                  autoFocus
+                  icon={CloseIcon}
+                  mode="bleed"
+                  onClick={handleClose}
+                  tooltipProps={{content: 'Close'}}
+                  data-testid="close-popover-edit-dialog-button"
+                />
+              </Flex>
+            </ContentHeaderBox>
+            <ContentScrollerBox flex={1}>
+              <PresenceOverlay margins={[0, 0, 1, 0]}>
+                <Box padding={3} ref={setContentElement}>
+                  {props.children}
+                </Box>
+              </PresenceOverlay>
+            </ContentScrollerBox>
+          </Flex>
+        </FocusLock>
+      </BoundaryElementProvider>
     </VirtualizerScrollInstanceProvider>
   )
 }

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceAutocomplete.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceAutocomplete.tsx
@@ -15,7 +15,7 @@ import {styled} from 'styled-components'
 import {useFormBuilder} from '../..'
 import {Popover} from '../../../../ui-components'
 import {Translate, useTranslation} from '../../../i18n'
-import {useReferenceAutocompletePopoverBoundary} from '../useReferenceAutocompletePopoverBoundary'
+import {useReferenceAutocompletePopoverBoundary} from '../../hooks/useReferenceAutocompletePopoverBoundary'
 
 const StyledPopover = styled(Popover)`
   & > div {

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceAutocomplete.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceAutocomplete.tsx
@@ -15,7 +15,7 @@ import {styled} from 'styled-components'
 import {useFormBuilder} from '../..'
 import {Popover} from '../../../../ui-components'
 import {Translate, useTranslation} from '../../../i18n'
-import {AUTOCOMPLETE_POPOVER_BOUNDARY} from '../referenceAutocompletePopoverBoundary'
+import {useReferenceAutocompletePopoverBoundary} from '../useReferenceAutocompletePopoverBoundary'
 
 const StyledPopover = styled(Popover)`
   & > div {
@@ -55,6 +55,7 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
 
   const {t} = useTranslation()
   const hasResults = props.options && props.options.length > 0
+  const popoverBoundary = useReferenceAutocompletePopoverBoundary(referenceElement)
   const renderPopover = useCallback(
     (
       {
@@ -78,8 +79,8 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
         fallbackPlacements={FALLBACK_PLACEMENTS}
         arrow={false}
         constrainSize
-        floatingBoundary={AUTOCOMPLETE_POPOVER_BOUNDARY}
-        referenceBoundary={AUTOCOMPLETE_POPOVER_BOUNDARY}
+        floatingBoundary={popoverBoundary}
+        referenceBoundary={popoverBoundary}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         content={
@@ -108,7 +109,7 @@ export const ReferenceAutocomplete = forwardRef(function ReferenceAutocomplete(
         matchReferenceWidth
       />
     ),
-    [hasResults, t, searchString, loading, portalRef, referenceElement],
+    [hasResults, t, searchString, loading, portalRef, referenceElement, popoverBoundary],
   )
   return (
     <Autocomplete

--- a/packages/sanity/src/core/form/inputs/referenceAutocompletePopoverBoundary.ts
+++ b/packages/sanity/src/core/form/inputs/referenceAutocompletePopoverBoundary.ts
@@ -2,7 +2,9 @@
  * Document pane uses BoundaryElementProvider on the scroll container. Portaled dialogs sit outside
  * that subtree, so the default boundaries break in two ways: `hide` sets referenceHidden (popover
  * hidden), and flip/shift/constrainSize use the wrong rect (popover misplaced). Use the document
- * root for both floating and reference boundaries so placement matches the viewport everywhere.
+ * root as a fallback boundary so placement matches the viewport when the reference element isn't
+ * inside the nearest `BoundaryElementProvider`. For the in-studio case (where the reference _is_
+ * inside the scroll container boundary), see {@link useReferenceAutocompletePopoverBoundary}.
  *
  * Shared by same-dataset, cross-dataset, and global-document reference autocompletes.
  */

--- a/packages/sanity/src/core/form/inputs/referenceAutocompletePopoverBoundary.ts
+++ b/packages/sanity/src/core/form/inputs/referenceAutocompletePopoverBoundary.ts
@@ -2,9 +2,8 @@
  * Document pane uses BoundaryElementProvider on the scroll container. Portaled dialogs sit outside
  * that subtree, so the default boundaries break in two ways: `hide` sets referenceHidden (popover
  * hidden), and flip/shift/constrainSize use the wrong rect (popover misplaced). Use the document
- * root as a fallback boundary so placement matches the viewport when the reference element isn't
- * inside the nearest `BoundaryElementProvider`. For the in-studio case (where the reference _is_
- * inside the scroll container boundary), see {@link useReferenceAutocompletePopoverBoundary}.
+ * root as a fallback boundary when the reference element isn't inside a `BoundaryElementProvider`.
+ * For the in-pane case, see {@link useReferenceAutocompletePopoverBoundary}.
  *
  * Shared by same-dataset, cross-dataset, and global-document reference autocompletes.
  */

--- a/packages/sanity/src/core/form/inputs/useReferenceAutocompletePopoverBoundary.ts
+++ b/packages/sanity/src/core/form/inputs/useReferenceAutocompletePopoverBoundary.ts
@@ -1,0 +1,34 @@
+import {useBoundaryElement} from '@sanity/ui'
+
+import {AUTOCOMPLETE_POPOVER_BOUNDARY} from './referenceAutocompletePopoverBoundary'
+
+/**
+ * Pick the right Floating UI boundary for a reference autocomplete popover.
+ *
+ * Document pane installs a `BoundaryElementProvider` on the scroll container. When the reference
+ * input is rendered inside that subtree we want to reuse that boundary so the popover is
+ * constrained by the scroll container (respects the sticky pane header, version chips /
+ * document actions, and the bottom footer).
+ *
+ * Portaled dialogs (e.g. the Media Library, Create-new document) render outside the document
+ * pane's scroll container, so the inherited context element no longer contains the reference
+ * input. In that case fall back to {@link AUTOCOMPLETE_POPOVER_BOUNDARY} (the document root) so
+ * the popover is anchored against the viewport.
+ *
+ * Shared by same-dataset, cross-dataset, and global-document reference autocompletes.
+ *
+ * @internal
+ */
+export function useReferenceAutocompletePopoverBoundary(
+  referenceElement: HTMLElement | null,
+): HTMLElement | null {
+  const {element: contextElement} = useBoundaryElement()
+
+  // Prefer the nearest `BoundaryElementProvider` element when it actually contains the reference
+  // element in the DOM (typically the document pane scroll container).
+  if (contextElement && referenceElement && contextElement.contains(referenceElement)) {
+    return contextElement
+  }
+
+  return AUTOCOMPLETE_POPOVER_BOUNDARY ?? null
+}


### PR DESCRIPTION
### Description

Fixes #12689 and a couple of other issues that have been reported.
The problem is always this: the reference input ends up beneath areas of the studio where it shouldn't. With this boundary, that won't be the problem anymore. The reference list will occupy whatever space it has available.

I didn't merge the schema changes, some of these are already available on the test studio as is though :) 

Before:
<img width="2190" height="1544" alt="image" src="https://github.com/user-attachments/assets/fb24d87e-53ef-4e85-84ca-69b3f41e530d" />
<img width="1462" height="1556" alt="image" src="https://github.com/user-attachments/assets/4a4f9d7a-1301-4c68-baf7-59ebd512d8ba" />
<img width="681" height="294" alt="image" src="https://github.com/user-attachments/assets/a7f15ac1-2b69-40dc-a6ce-0634258cf9cb" />

After:
<img width="1010" height="882" alt="image" src="https://github.com/user-attachments/assets/6b7f1901-8916-42af-b9a0-54178291d946" />
<img width="1010" height="882" alt="image" src="https://github.com/user-attachments/assets/3b23da6a-3564-451b-b819-4adf0f24ea86" />

https://github.com/user-attachments/assets/1a1340d1-d1aa-4875-9839-7139dca11715

https://github.com/user-attachments/assets/84eb89c5-0c09-491d-94d5-6c32a0fe5369

### What to review

Tested manually to make sure that both reference list shown from the bottom and top wouldn't be negatively impacted by this change. Example (document without a scroll)
<img width="1010" height="882" alt="image" src="https://github.com/user-attachments/assets/1e8c54b7-373e-4426-9461-ba103236f13f" />

Did I miss anything?

### Testing

Updated tests, manually tested

### Notes for release

References in dialogs and popovers will be visible with the available space and not hide under different sections of the UI