### PR TITLE
fix(sanity): handle groq2024 searches that sort on child paths and complex GROQ expressions

### DIFF
--- a/dev/test-studio/schema/standard/slugs.ts
+++ b/dev/test-studio/schema/standard/slugs.ts
@@ -10,6 +10,28 @@ export default defineType({
   name: 'slugsTest',
   type: 'document',
   title: 'Slugs test',
+  orderings: [
+    {
+      title: 'Slug (asc)',
+      name: 'slugAsc',
+      by: [
+        {
+          field: 'slug.current',
+          direction: 'asc',
+        },
+      ],
+    },
+    {
+      title: 'Slug (desc)',
+      name: 'slugDesc',
+      by: [
+        {
+          field: 'slug.current',
+          direction: 'desc',
+        },
+      ],
+    },
+  ],
   preview: {
     select: {
       title: 'title',

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
@@ -44,6 +44,16 @@ const schemaTypes = [
           },
         ],
       }),
+      defineField({
+        name: 'location',
+        type: 'object',
+        fields: [
+          defineField({
+            name: 'city',
+            type: 'string',
+          }),
+        ],
+      }),
     ],
   }),
 ]
@@ -187,6 +197,64 @@ describe('createSearchQuery', () => {
       `)
 
       expect(query).toContain('| order(exampleField desc)')
+    })
+
+    it('should sort on nested fields', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
+      const {query} = createSearchQuery(
+        {
+          query: 'test',
+          types: [testType],
+        },
+        '',
+        {
+          sort: [
+            {
+              direction: 'desc',
+              field: 'location.city',
+            },
+          ],
+        },
+      )
+
+      expect(query).toMatchInlineSnapshot(`
+        "// findability-mvi:5
+        *[_type in $__types && ([@, _id] match text::query($__query) || references($__rawQuery))] | order(location.city desc) [0...$__limit] {"location.city": location.city, _type, _id, _originalId}"
+      `)
+
+      expect(query).toContain('| order(location.city desc)')
+    })
+
+    it('should sort on complex GROQ expressions', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
+      const {query} = createSearchQuery(
+        {
+          query: 'test',
+          types: [testType],
+        },
+        '',
+        {
+          sort: [
+            {
+              direction: 'desc',
+              field: 'string::length(title)',
+            },
+          ],
+        },
+      )
+
+      expect(query).toMatchInlineSnapshot(`
+        "// findability-mvi:5
+        *[_type in $__types && ([@, _id] match text::query($__query) || references($__rawQuery))] | order(string::length(title) desc) [0...$__limit] {"string::length(title)": string::length(title), _type, _id, _originalId}"
+      `)
+
+      expect(query).toContain('| order(string::length(title) desc)')
     })
 
     it('should use multiple sort fields and directions', () => {

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
@@ -6,6 +6,7 @@ import {
 } from '@sanity/types'
 import groupBy from 'lodash-es/groupBy.js'
 
+import {fieldNeedsEscape} from '../../util/searchUtils'
 import {deriveSearchWeightsFromType2024} from '../common/deriveSearchWeightsFromType2024'
 import {prefixLast} from '../common/token'
 import {toOrderClause} from '../common/toOrderClause'
@@ -101,7 +102,15 @@ export function createSearchQuery(
   ].flat()
 
   const projectionFields = sortOrder.map(({field}) => field).concat('_type', '_id', '_originalId')
-  const projection = projectionFields.join(', ')
+
+  const projection = projectionFields
+    .map((field) => {
+      if (fieldNeedsEscape(field)) {
+        return `"${field}": ${field}`
+      }
+      return field
+    })
+    .join(', ')
 
   const query = [
     `*[${filters.join(' && ')}]`,


### PR DESCRIPTION
### Description

If a document list sorts on a sub path, or the result of a complex GROQ expression, the `groq2024` search strategy currently produces an invalid GROQ query. This causes the document list to crash.

Here's what the generated GROQ expression currently looks like when sorting on the sub path `translations.se`:

```ts
{
  translations.se, // this is invalid
  title,
  _type,
  _id
}
```

This branch fixes the problem by creating a named projection field when sub paths or complex GROQ expressions are used in sort orders:

```ts
{
  "translations.se": translations.se, // this is valid
  title,
  _type,
  _id
}
```

This is a simple way to ensure the generated query is valid, while still allowing code consuming the result data to easily address projected fields.

| Before | After |
| --- | --- |
| <img width="336" height="565" alt="before" src="https://github.com/user-attachments/assets/348adcd7-8673-4c62-8056-88dccae327f8" /> | <img width="336" height="565" alt="after" src="https://github.com/user-attachments/assets/56d78142-2b67-4da5-aecc-1dd49f6196d9" /> |

### What to review

Document lists can successfully sort on sub paths. There is a new example to demonstrate this in Test Studio; access it in the playground workspace, where `groq2024` search is used: `http://localhost:3333/playground/structure/input-standard;slugsTest;e22cd77d-369f-40f2-af7f-7cef1f59f632`.

### Testing

Added tests, existing tests pass, and verified correct behaviour in Test Studio.

### Notes for release

Fixes a bug causing document lists to fail with a GROQ error when using the `groq2024` search strategy and sorting on a sub path (such as `slug.current`).