### PR TITLE
fix: remove underline from openInNewTabIcon menu item for refs

### DIFF
--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceItem.tsx
@@ -303,6 +303,7 @@ export function ReferenceItem<Item extends ReferenceItemValue = ReferenceItemVal
             {!isEditing && hasRef && (
               <MenuItem
                 as={IntentLink}
+                data-as="a"
                 icon={OpenInNewTabIcon}
                 // @ts-expect-error - these are valid types but there's an issue in `@sanity/ui@3` where type inference is not working on `as` props
                 intent="edit"


### PR DESCRIPTION
### Description

Before:
<img width="879" height="456" alt="image" src="https://github.com/user-attachments/assets/373159e4-18f1-4c54-bd7c-fde1bbbfceb5" />

After:
<img width="717" height="434" alt="image" src="https://github.com/user-attachments/assets/e69f93f9-6a8a-4ec1-847a-56c049d77463" />

### What to review

Any caveats that might come from this?

### Testing

Manually tested it!

### Notes for release

Updated styling for Open in New Tab from the reference input menu actions