### PR TITLE
feat(studio): accept temporary token prop for workbench-provided auth

### DIFF
--- a/packages/sanity/src/core/config/auth/types.ts
+++ b/packages/sanity/src/core/config/auth/types.ts
@@ -63,12 +63,6 @@ export interface AuthConfig {
    * but can be set if using custom cname for API domain.
    */
   apiHost?: string
-
-  /**
-   * @hidden
-   * @beta
-   */
-  __internal_token?: string
 }
 
 /**

--- a/packages/sanity/src/core/config/auth/types.ts
+++ b/packages/sanity/src/core/config/auth/types.ts
@@ -63,6 +63,12 @@ export interface AuthConfig {
    * but can be set if using custom cname for API domain.
    */
   apiHost?: string
+
+  /**
+   * @hidden
+   * @beta
+   */
+  __internal_token?: string
 }
 
 /**

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -159,7 +159,7 @@ const createDatasetAssetSources = (config: SourceOptions, client: SanityClient) 
  */
 export function prepareConfig(
   config: Config | MissingConfigFile,
-  options?: {basePath?: string},
+  options?: {basePath?: string; token?: string},
 ): PreparedConfig {
   if (!Array.isArray(config) && 'missingConfigFile' in config) {
     throw new ConfigResolutionError({
@@ -249,7 +249,7 @@ export function prepareConfig(
         throw new SchemaError(schema)
       }
 
-      const auth = getAuthStore(source)
+      const auth = getAuthStore(source, {token: options?.token})
       const i18n = prepareI18n(source)
       const source$ = auth.state.pipe(
         map(({client, authenticated, currentUser}) => {
@@ -308,14 +308,14 @@ export function prepareConfig(
   return {type: 'prepared-config', workspaces}
 }
 
-function getAuthStore(source: SourceOptions): AuthStore {
+function getAuthStore(source: SourceOptions, {token}: {token?: string}): AuthStore {
   if (isAuthStore(source.auth)) {
     return source.auth
   }
 
   const clientFactory = source.unstable_clientFactory || createClient
   const {projectId, dataset, apiHost} = source
-  return createAuthStore({apiHost, ...source.auth, clientFactory, dataset, projectId})
+  return createAuthStore({apiHost, ...source.auth, clientFactory, dataset, projectId, token})
 }
 
 interface ResolveSourceOptions {

--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -24,6 +24,7 @@ export interface AuthStoreOptions extends AuthConfig {
   clientFactory?: (options: SanityClientConfig) => SanityClient
   projectId: string
   dataset: string
+  token?: string
 }
 
 const getStorageKey = (projectId: string): string => {
@@ -173,6 +174,7 @@ export function _createAuthStore({
   dataset,
   apiHost,
   loginMethod = 'dual',
+  token: providedToken,
   ...providerOptions
 }: AuthStoreOptions): AuthStore {
   // this broadcast channel receives either a token as a `string` or `null`.
@@ -189,7 +191,13 @@ export function _createAuthStore({
   // const firstMessage = messages.pipe(first())
 
   const token$ = messages.pipe(
-    startWith(isCookielessCompatibleLoginMethod(loginMethod) ? getToken(projectId) : null),
+    startWith(
+      providedToken
+        ? providedToken
+        : isCookielessCompatibleLoginMethod(loginMethod)
+          ? getToken(projectId)
+          : null,
+    ),
   )
 
   // Allow configuration of `apiHost` through source configuration

--- a/packages/sanity/src/core/studio/Studio.tsx
+++ b/packages/sanity/src/core/studio/Studio.tsx
@@ -86,6 +86,15 @@ export interface StudioProps {
    * @hidden
    * @beta */
   unstable_noAuthBoundary?: boolean
+
+  /**
+   * Used as a temporary measure to forward the token from workbench to the studio for instant
+   * authentication.
+   * @internal
+   * @hidden
+   * @experimental
+   */
+  unstable_temporaryToken?: string
 }
 
 /**
@@ -100,6 +109,7 @@ export function Studio(props: StudioProps): React.JSX.Element {
     unstable_globalStyles: globalStyles,
     unstable_history,
     unstable_noAuthBoundary,
+    unstable_temporaryToken,
   } = props
 
   return (
@@ -110,6 +120,7 @@ export function Studio(props: StudioProps): React.JSX.Element {
       scheme={scheme}
       unstable_history={unstable_history}
       unstable_noAuthBoundary={unstable_noAuthBoundary}
+      unstable_temporaryToken={unstable_temporaryToken}
     >
       {globalStyles && <GlobalStyle />}
       <StudioLayout />

--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -53,6 +53,7 @@ export function StudioProvider({
   scheme,
   unstable_history: history,
   unstable_noAuthBoundary: noAuthBoundary,
+  unstable_temporaryToken: token,
 }: StudioProviderProps) {
   // We initialize the error reporter as early as possible in order to catch anything that could
   // occur during configuration loading, React rendering etc. StudioProvider is often the highest
@@ -112,6 +113,7 @@ export function StudioProvider({
                 config={config}
                 basePath={basePath}
                 LoadingComponent={LoadingBlock}
+                token={token}
               >
                 <VisibleWorkspacesProvider>
                   <ActiveWorkspaceMatcher

--- a/packages/sanity/src/core/studio/renderStudio.tsx
+++ b/packages/sanity/src/core/studio/renderStudio.tsx
@@ -2,10 +2,9 @@ import {StrictMode} from 'react'
 import {createRoot} from 'react-dom/client'
 
 import {type Config} from '../config'
-import {Studio} from './Studio'
+import {Studio, type StudioProps} from './Studio'
 
-interface RenderStudioOptions {
-  basePath?: string
+interface RenderStudioOptions extends Pick<StudioProps, 'basePath' | 'unstable_temporaryToken'> {
   reactStrictMode?: boolean
 }
 
@@ -40,14 +39,19 @@ export function renderStudio(
   }
 
   const opts = typeof options === 'boolean' ? {reactStrictMode: options} : options
-  const {reactStrictMode = false, basePath} = opts
+  const {reactStrictMode = false, basePath, unstable_temporaryToken} = opts
 
   const root = createRoot(rootElement)
 
   root.render(
     reactStrictMode ? (
       <StrictMode>
-        <Studio config={config} basePath={basePath} unstable_globalStyles />
+        <Studio
+          config={config}
+          basePath={basePath}
+          unstable_globalStyles
+          unstable_temporaryToken={unstable_temporaryToken}
+        />
       </StrictMode>
     ) : (
       <Studio config={config} basePath={basePath} unstable_globalStyles />

--- a/packages/sanity/src/core/studio/workspaces/WorkspacesProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaces/WorkspacesProvider.tsx
@@ -10,6 +10,7 @@ export interface WorkspacesProviderProps {
   children: ReactNode
   basePath?: string
   LoadingComponent: ComponentType
+  token?: string
 }
 
 /** @internal */
@@ -18,9 +19,10 @@ export function WorkspacesProvider({
   children,
   basePath,
   LoadingComponent,
+  token,
 }: WorkspacesProviderProps) {
   const workspaces = useDeferredValue(
-    prepareConfig(config, {basePath}).workspaces satisfies WorkspacesContextValue,
+    prepareConfig(config, {basePath, token}).workspaces satisfies WorkspacesContextValue,
     null,
   )
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4144,17 +4144,34 @@ packages:
   '@module-federation/error-codes@2.3.1':
     resolution: {integrity: sha512-s3IjT2OYrSBNNmxdTmmrWBpsFfeNszdL6BSqjXLHb1CgXWUYLNXpb05IopnzMhRLcur6MTGuKR0ZSjJbmvQBbg==}
 
+  '@module-federation/error-codes@2.3.3':
+    resolution: {integrity: sha512-UVtKBoKnRDcHgByIDvPRZSxQqjqbNH7NvJm1KHLoce33+EDiIdZYs0HvvUQv43RgESpB9s7HjrqFlq3bEcAgfQ==}
+
   '@module-federation/managers@2.3.1':
     resolution: {integrity: sha512-kK/4FkoaIxbJbN+R6+cq+igv095hPox8oheZOKkrYA9P6Xv5FiHza+gHlCntiWTMrU8bzqJHH4VYm6gq1RB+dQ==}
 
   '@module-federation/runtime-core@2.3.1':
     resolution: {integrity: sha512-E0WgaCn32AWzD0n6SCH7VQ+kxk46XyX432PQWARgyQzCX/wyLkaT+We3A18RVNUevRT85YHLrrVIhMKJJVHgjA==}
 
+  '@module-federation/runtime-core@2.3.3':
+    resolution: {integrity: sha512-B07LDH9KxhBO3GbULGW64mQFVQBtrEd3PoaCBm7XR1IbU8rMQUJQjDNVZgXYcyhRPBVP+3KWZuiaKFRiNb6PQw==}
+
   '@module-federation/runtime@2.3.1':
     resolution: {integrity: sha512-NiKelHKzOf1Vz8oqcxC/XRUAW224O6lKj9xD0cfp5Bp343iu6s58RlLvX1ypF+UpCl3jA4JM8npGax/3jjyifw==}
 
+  '@module-federation/runtime@2.3.3':
+    resolution: {integrity: sha512-JYJ3qv9V85DtBtT/ppDuJNwBTUrYqqZDYcyiTzwY5+44dC5QPvgJ//F+BOhAhZ02WkZV0b4jsKTyLOC3vXKGqQ==}
+
   '@module-federation/sdk@2.3.1':
     resolution: {integrity: sha512-lgWxFZyLRKDXWRGlV6ROjFJ6MRaJTxs0bBnS6hS9ONfr/0TkeW4JzDbsfzrB8g4p6IgSKB+wQ9XfibJCGBI5OQ==}
+    peerDependencies:
+      node-fetch: ^3.3.2
+    peerDependenciesMeta:
+      node-fetch:
+        optional: true
+
+  '@module-federation/sdk@2.3.3':
+    resolution: {integrity: sha512-mwCS+LQdqiSc6fM5iz/S60ibaFNSH6kNqlZkCRIuS4yjdZ+jgnihz+6xp1QzppvfFgKLhEHBiXOmcYOdk3Ckew==}
     peerDependencies:
       node-fetch: ^3.3.2
     peerDependenciesMeta:
@@ -7437,8 +7454,8 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -14086,6 +14103,8 @@ snapshots:
 
   '@module-federation/error-codes@2.3.1': {}
 
+  '@module-federation/error-codes@2.3.3': {}
+
   '@module-federation/managers@2.3.1':
     dependencies:
       '@module-federation/sdk': 2.3.1
@@ -14101,6 +14120,13 @@ snapshots:
     transitivePeerDependencies:
       - node-fetch
 
+  '@module-federation/runtime-core@2.3.3':
+    dependencies:
+      '@module-federation/error-codes': 2.3.3
+      '@module-federation/sdk': 2.3.3
+    transitivePeerDependencies:
+      - node-fetch
+
   '@module-federation/runtime@2.3.1':
     dependencies:
       '@module-federation/error-codes': 2.3.1
@@ -14109,7 +14135,17 @@ snapshots:
     transitivePeerDependencies:
       - node-fetch
 
+  '@module-federation/runtime@2.3.3':
+    dependencies:
+      '@module-federation/error-codes': 2.3.3
+      '@module-federation/runtime-core': 2.3.3
+      '@module-federation/sdk': 2.3.3
+    transitivePeerDependencies:
+      - node-fetch
+
   '@module-federation/sdk@2.3.1': {}
+
+  '@module-federation/sdk@2.3.3': {}
 
   '@module-federation/third-party-dts-extractor@2.3.1':
     dependencies:
@@ -14123,7 +14159,7 @@ snapshots:
       '@module-federation/runtime': 2.3.1
       '@module-federation/sdk': 2.3.1
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      defu: 6.1.4
+      defu: 6.1.7
       es-module-lexer: 2.0.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
@@ -14144,7 +14180,7 @@ snapshots:
       '@module-federation/runtime': 2.3.1
       '@module-federation/sdk': 2.3.1
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      defu: 6.1.4
+      defu: 6.1.7
       es-module-lexer: 2.0.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
@@ -15457,7 +15493,7 @@ snapshots:
 
   '@sanity/federation@0.1.0-alpha.4(debug@4.4.3)(rollup@4.60.1)(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@module-federation/runtime': 2.3.1
+      '@module-federation/runtime': 2.3.3
       '@module-federation/vite': 1.14.0(debug@4.4.3)(rollup@4.60.1)(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       vite: 7.3.2(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
@@ -15471,7 +15507,7 @@ snapshots:
 
   '@sanity/federation@0.1.0-alpha.6(debug@4.4.3)(rollup@4.60.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@module-federation/runtime': 2.3.1
+      '@module-federation/runtime': 2.3.3
       '@module-federation/vite': 1.14.0(debug@4.4.3)(rollup@4.60.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
@@ -17995,7 +18031,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
-  defu@6.1.4: {}
+  defu@6.1.7: {}
 
   delayed-stream@1.0.0: {}
 


### PR DESCRIPTION
### Description

Workbench needs to inject an auth token into Studio at boot so embedded sessions skip the browser login flow. Adds `unstable_temporaryToken` on `Studio`/`renderStudio` that seeds `createAuthStore`'s token stream, bypassing the usual cookie/localStorage lookup. Marked `unstable_` and `@experimental` — stopgap until workbench gets a proper custom auth store integration.

### Related issues

* resolves SDK-1299