### PR TITLE
fix: issue when reverting to revisions in live edits

### DIFF
--- a/packages/sanity/src/core/store/history/createHistoryStore.ts
+++ b/packages/sanity/src/core/store/history/createHistoryStore.ts
@@ -1,5 +1,5 @@
 import {type Action, type SanityClient} from '@sanity/client'
-import {type DocumentId, isVersionId} from '@sanity/id-utils'
+import {type DocumentId, isDraftId, isVersionId} from '@sanity/id-utils'
 import {
   isReference,
   type Reference,
@@ -253,14 +253,14 @@ function restore(
       return {...document, _id: targetDocumentId}
     }),
     mergeMap((restoredDraft) => {
-      // When the restore targets the published document itself (i.e. live edit
-      // is enabled for the document type), the `sanity.action.document.replaceDraft`
-      // action cannot be used because it requires `attributes._id` to be prefixed
-      // with either `drafts.` or `versions.{bundleId}`. Fall back to the mutation
-      // API for these cases, matching the behavior of the non-server-actions path.
-      const isLiveEditRestore = targetDocumentId === documentId
+      // `sanity.action.document.replaceDraft` requires `attributes._id` to be
+      // prefixed with either `drafts.` or `versions.<bundleId>`. When it isn't
+      // (e.g. restoring a live-edit document directly onto the published id),
+      // fall back to the mutation API, matching the non-server-actions path.
+      const canUseServerAction =
+        isDraftId(targetDocumentId as DocumentId) || isVersionId(targetDocumentId as DocumentId)
 
-      if (options?.useServerDocumentActions && !isLiveEditRestore) {
+      if (options?.useServerDocumentActions && canUseServerAction) {
         const replaceDraftAction: Action = {
           actionType: 'sanity.action.document.replaceDraft',
           publishedId: documentId,

--- a/packages/sanity/src/core/store/history/createHistoryStore.ts
+++ b/packages/sanity/src/core/store/history/createHistoryStore.ts
@@ -253,7 +253,14 @@ function restore(
       return {...document, _id: targetDocumentId}
     }),
     mergeMap((restoredDraft) => {
-      if (options?.useServerDocumentActions) {
+      // When the restore targets the published document itself (i.e. live edit
+      // is enabled for the document type), the `sanity.action.document.replaceDraft`
+      // action cannot be used because it requires `attributes._id` to be prefixed
+      // with either `drafts.` or `versions.{bundleId}`. Fall back to the mutation
+      // API for these cases, matching the behavior of the non-server-actions path.
+      const isLiveEditRestore = targetDocumentId === documentId
+
+      if (options?.useServerDocumentActions && !isLiveEditRestore) {
         const replaceDraftAction: Action = {
           actionType: 'sanity.action.document.replaceDraft',
           publishedId: documentId,

--- a/packages/sanity/src/core/store/history/history.test.ts
+++ b/packages/sanity/src/core/store/history/history.test.ts
@@ -139,7 +139,7 @@ describe('createHistoryStore', () => {
       mockRequest.mockReset().mockResolvedValue({documents: [revisionDoc]})
     })
 
-    test('uses replaceDraft action for non-live-edit documents', async () => {
+    test('uses replaceDraft action when target id is drafts-prefixed', async () => {
       const client = buildClient()
       const historyStore = createHistoryStore({client})
 
@@ -162,12 +162,7 @@ describe('createHistoryStore', () => {
       })
     })
 
-    test('falls back to createOrReplace when restoring a live-edit document', async () => {
-      // For live-edit documents, targetDocumentId equals the publishedId. The
-      // `sanity.action.document.replaceDraft` action requires attributes._id to
-      // be prefixed with either "drafts." or "versions.{bundleId}", which would
-      // cause the server to reject the request. Ensure we fall back to the
-      // mutation API instead.
+    test('falls back to createOrReplace when target id is unprefixed', async () => {
       const client = buildClient()
       const historyStore = createHistoryStore({client})
 
@@ -188,7 +183,7 @@ describe('createHistoryStore', () => {
       )
     })
 
-    test('falls back to createOrReplace when restoring a deleted live-edit document', async () => {
+    test('falls back to createOrReplace for a deleted document with unprefixed target id', async () => {
       const client = buildClient()
       const historyStore = createHistoryStore({client})
 
@@ -198,6 +193,50 @@ describe('createHistoryStore', () => {
             fromDeleted: true,
             useServerDocumentActions: true,
           })
+          .subscribe({complete: resolve, error: reject})
+      })
+
+      expect(mockAction).not.toHaveBeenCalled()
+      expect(mockCreateOrReplace).toHaveBeenCalledTimes(1)
+    })
+
+    test('uses create + replaceDraft actions for a deleted document with a drafts-prefixed target', async () => {
+      const client = buildClient()
+      const historyStore = createHistoryStore({client})
+
+      await new Promise<void>((resolve, reject) => {
+        historyStore
+          .restore('doc-id', 'drafts.doc-id', 'rev-1', {
+            fromDeleted: true,
+            useServerDocumentActions: true,
+          })
+          .subscribe({complete: resolve, error: reject})
+      })
+
+      expect(mockCreateOrReplace).not.toHaveBeenCalled()
+      expect(mockAction).toHaveBeenCalledTimes(1)
+      const [actions] = mockAction.mock.calls[0]
+      expect(actions).toHaveLength(2)
+      expect(actions[0]).toMatchObject({
+        actionType: 'sanity.action.document.create',
+        publishedId: 'doc-id',
+        ifExists: 'fail',
+        attributes: expect.objectContaining({_id: 'drafts.doc-id'}),
+      })
+      expect(actions[1]).toMatchObject({
+        actionType: 'sanity.action.document.replaceDraft',
+        publishedId: 'doc-id',
+        attributes: expect.objectContaining({_id: 'drafts.doc-id'}),
+      })
+    })
+
+    test('falls back to createOrReplace when useServerDocumentActions is not set', async () => {
+      const client = buildClient()
+      const historyStore = createHistoryStore({client})
+
+      await new Promise<void>((resolve, reject) => {
+        historyStore
+          .restore('doc-id', 'drafts.doc-id', 'rev-1', {fromDeleted: false})
           .subscribe({complete: resolve, error: reject})
       })
 

--- a/packages/sanity/src/core/store/history/history.test.ts
+++ b/packages/sanity/src/core/store/history/history.test.ts
@@ -1,4 +1,5 @@
 import {type SanityClient} from '@sanity/client'
+import {of} from 'rxjs'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {createHistoryStore, removeMissingReferences} from './createHistoryStore'
@@ -101,6 +102,107 @@ describe('createHistoryStore', () => {
       const result = await historyStore.getDocumentAtRevision('test-doc', 'lastRevision')
 
       expect(result).toBeUndefined()
+    })
+  })
+
+  describe('restore', () => {
+    const revisionDoc = {
+      _id: 'doc-id',
+      _rev: 'rev-1',
+      _type: 'testType',
+      _createdAt: '2024-01-01T00:00:00Z',
+      _updatedAt: '2024-01-02T00:00:00Z',
+      title: 'Restored',
+    }
+
+    const mockAction = vi.fn()
+    const mockCreateOrReplace = vi.fn()
+    const mockFetch = vi.fn()
+    const mockRequest = vi.fn()
+
+    const buildClient = () =>
+      ({
+        config: () => ({dataset: 'test-dataset'}),
+        request: mockRequest,
+        withConfig: vi.fn().mockReturnThis(),
+        observable: {
+          fetch: mockFetch,
+          createOrReplace: mockCreateOrReplace,
+          action: mockAction,
+        },
+      }) as unknown as SanityClient
+
+    beforeEach(() => {
+      mockAction.mockReset().mockReturnValue(of({transactionId: 'tx'}))
+      mockCreateOrReplace.mockReset().mockReturnValue(of({transactionId: 'tx'}))
+      mockFetch.mockReset().mockReturnValue(of({}))
+      mockRequest.mockReset().mockResolvedValue({documents: [revisionDoc]})
+    })
+
+    test('uses replaceDraft action for non-live-edit documents', async () => {
+      const client = buildClient()
+      const historyStore = createHistoryStore({client})
+
+      await new Promise<void>((resolve, reject) => {
+        historyStore
+          .restore('doc-id', 'drafts.doc-id', 'rev-1', {
+            fromDeleted: false,
+            useServerDocumentActions: true,
+          })
+          .subscribe({complete: resolve, error: reject})
+      })
+
+      expect(mockAction).toHaveBeenCalledTimes(1)
+      expect(mockCreateOrReplace).not.toHaveBeenCalled()
+      const [actions] = mockAction.mock.calls[0]
+      expect(actions).toMatchObject({
+        actionType: 'sanity.action.document.replaceDraft',
+        publishedId: 'doc-id',
+        attributes: expect.objectContaining({_id: 'drafts.doc-id'}),
+      })
+    })
+
+    test('falls back to createOrReplace when restoring a live-edit document', async () => {
+      // For live-edit documents, targetDocumentId equals the publishedId. The
+      // `sanity.action.document.replaceDraft` action requires attributes._id to
+      // be prefixed with either "drafts." or "versions.{bundleId}", which would
+      // cause the server to reject the request. Ensure we fall back to the
+      // mutation API instead.
+      const client = buildClient()
+      const historyStore = createHistoryStore({client})
+
+      await new Promise<void>((resolve, reject) => {
+        historyStore
+          .restore('doc-id', 'doc-id', 'rev-1', {
+            fromDeleted: false,
+            useServerDocumentActions: true,
+          })
+          .subscribe({complete: resolve, error: reject})
+      })
+
+      expect(mockAction).not.toHaveBeenCalled()
+      expect(mockCreateOrReplace).toHaveBeenCalledTimes(1)
+      expect(mockCreateOrReplace).toHaveBeenCalledWith(
+        expect.objectContaining({_id: 'doc-id', title: 'Restored'}),
+        {visibility: 'async'},
+      )
+    })
+
+    test('falls back to createOrReplace when restoring a deleted live-edit document', async () => {
+      const client = buildClient()
+      const historyStore = createHistoryStore({client})
+
+      await new Promise<void>((resolve, reject) => {
+        historyStore
+          .restore('doc-id', 'doc-id', 'rev-1', {
+            fromDeleted: true,
+            useServerDocumentActions: true,
+          })
+          .subscribe({complete: resolve, error: reject})
+      })
+
+      expect(mockAction).not.toHaveBeenCalled()
+      expect(mockCreateOrReplace).toHaveBeenCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
### Description

Before:
We were getting a cryptic error when trying to revert to a revision on a live-edit document:

> action index 0: `attributes._id` must be prefixed with either "drafts." or "versions."(bundleId)

https://github.com/user-attachments/assets/ec0dce78-43ce-4c7e-b7b8-34e65ed14302

After:

https://github.com/user-attachments/assets/c8567855-c584-4eaa-961e-db92cdd312ef

Live-edit docs have no draft, so `restore` targets the published id directly. The server-actions path for restore (`sanity.action.document.replaceDraft`) rejects that because it requires `attributes._id` to be prefixed with `drafts.` or `versions.<bundleId>`. Non-live-edit docs are unaffected because their target is always `drafts.<id>`, and version restores go through `versions.<bundleId>.<id>`.

**Fix:** route on the rule the server actually enforces — the prefix of `targetDocumentId`. When it isn't a draft or version id, fall back to `client.observable.createOrReplace`, matching the non-server-actions path.
**Alternatives considered:**
- `targetDocumentId === documentId` as a proxy for "live edit" — caller-convention coincidence, drifts from the server rule.
- Prefixing the id before sending — the action semantically creates/replaces a _draft_, which doesn't apply here.
- New server action for live-edit restore — out of scope; the mutation API already handles this.

### What to review

Did I miss anything? 

### Testing
- Unit tests in `history.test.ts` cover each branch of `restore`.
- Manually verified against the `thesis` type (`liveEdit: true`) in test-studio: revert now succeeds.

### Notes for release
Fixes an error that prevented reverting a live-edit document to an earlier revision.
