### PR TITLE
feat(sanity): warn on divergent auth configs for same project id

### DIFF
--- a/packages/sanity/src/core/config/__tests__/prepareConfig.test.ts
+++ b/packages/sanity/src/core/config/__tests__/prepareConfig.test.ts
@@ -1,0 +1,171 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getCollectedConfigWarnings} from '../configWarnings'
+import {prepareConfig} from '../prepareConfig'
+import {type WorkspaceOptions} from '../types'
+
+// Minimum viable workspace for prepareConfig — avoids pulling in real
+// schema/client resolution. projectId is randomized per test so the
+// module-level warning dedupe doesn't bleed across cases.
+function createWorkspace(overrides: Partial<WorkspaceOptions>): WorkspaceOptions {
+  return {
+    name: 'test',
+    basePath: '/',
+    projectId: `test-${Math.random().toString(36).slice(2)}`,
+    dataset: 'test',
+    ...overrides,
+  }
+}
+
+describe('prepareConfig — divergent auth warning', () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore()
+  })
+
+  it('warns when two workspaces for the same project declare different auth configs', () => {
+    const projectId = `divergent-${Math.random().toString(36).slice(2)}`
+    const warningsBefore = getCollectedConfigWarnings().length
+
+    prepareConfig([
+      createWorkspace({
+        name: 'cookie-workspace',
+        projectId,
+        basePath: '/cookie',
+        auth: {loginMethod: 'cookie'},
+      }),
+      createWorkspace({
+        name: 'token-workspace',
+        projectId,
+        basePath: '/token',
+        auth: {loginMethod: 'token'},
+      }),
+    ])
+
+    const newWarnings = getCollectedConfigWarnings().slice(warningsBefore)
+    const authWarning = newWarnings.find(
+      (w) => w.type === 'project-auth-divergence' && w.projectId === projectId,
+    )
+    expect(authWarning).toBeDefined()
+    expect(authWarning?.groups).toEqual(
+      expect.arrayContaining([['cookie-workspace'], ['token-workspace']]),
+    )
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`Workspaces for project "${projectId}" declare different`),
+    )
+  })
+
+  it('does not warn when two workspaces for the same project declare identical auth configs', () => {
+    const projectId = `identical-${Math.random().toString(36).slice(2)}`
+    const warningsBefore = getCollectedConfigWarnings().length
+
+    prepareConfig([
+      createWorkspace({
+        name: 'w1',
+        projectId,
+        basePath: '/w1',
+        auth: {loginMethod: 'cookie'},
+      }),
+      createWorkspace({
+        name: 'w2',
+        projectId,
+        basePath: '/w2',
+        auth: {loginMethod: 'cookie'},
+      }),
+    ])
+
+    const newWarnings = getCollectedConfigWarnings().slice(warningsBefore)
+    const authWarning = newWarnings.find(
+      (w) => w.type === 'project-auth-divergence' && w.projectId === projectId,
+    )
+    expect(authWarning).toBeUndefined()
+    expect(consoleWarnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining(`Workspaces for project "${projectId}" declare different`),
+    )
+  })
+
+  it('does not warn when workspaces for different projects each have their own auth config', () => {
+    const projectA = `projA-${Math.random().toString(36).slice(2)}`
+    const projectB = `projB-${Math.random().toString(36).slice(2)}`
+    const warningsBefore = getCollectedConfigWarnings().length
+
+    prepareConfig([
+      createWorkspace({
+        name: 'a',
+        projectId: projectA,
+        basePath: '/a',
+        auth: {loginMethod: 'cookie'},
+      }),
+      createWorkspace({
+        name: 'b',
+        projectId: projectB,
+        basePath: '/b',
+        auth: {loginMethod: 'token'},
+      }),
+    ])
+
+    const newWarnings = getCollectedConfigWarnings().slice(warningsBefore)
+    const authWarning = newWarnings.find(
+      (w) =>
+        w.type === 'project-auth-divergence' &&
+        (w.projectId === projectA || w.projectId === projectB),
+    )
+    expect(authWarning).toBeUndefined()
+  })
+
+  it('does not warn when only one workspace is configured for a project', () => {
+    const projectId = `single-${Math.random().toString(36).slice(2)}`
+    const warningsBefore = getCollectedConfigWarnings().length
+
+    prepareConfig([
+      createWorkspace({
+        name: 'solo',
+        projectId,
+        basePath: '/',
+        auth: {loginMethod: 'cookie'},
+      }),
+    ])
+
+    const newWarnings = getCollectedConfigWarnings().slice(warningsBefore)
+    const authWarning = newWarnings.find(
+      (w) => w.type === 'project-auth-divergence' && w.projectId === projectId,
+    )
+    expect(authWarning).toBeUndefined()
+  })
+
+  it('does not warn when two workspaces declare the same auth config with different property order', () => {
+    // AuthConfig is fingerprinted via a canonical (key-sorted) hash so that
+    // `{loginMethod: 'cookie', mode: 'replace'}` and
+    // `{mode: 'replace', loginMethod: 'cookie'}` compare equal — property
+    // declaration order and autoformatter reordering must not produce false
+    // positives.
+    const projectId = `order-${Math.random().toString(36).slice(2)}`
+    const warningsBefore = getCollectedConfigWarnings().length
+
+    prepareConfig([
+      createWorkspace({
+        name: 'w1',
+        projectId,
+        basePath: '/w1',
+        auth: {loginMethod: 'cookie', mode: 'replace', redirectOnSingle: true},
+      }),
+      createWorkspace({
+        name: 'w2',
+        projectId,
+        basePath: '/w2',
+        auth: {redirectOnSingle: true, mode: 'replace', loginMethod: 'cookie'},
+      }),
+    ])
+
+    const newWarnings = getCollectedConfigWarnings().slice(warningsBefore)
+    const authWarning = newWarnings.find(
+      (w) => w.type === 'project-auth-divergence' && w.projectId === projectId,
+    )
+    expect(authWarning).toBeUndefined()
+  })
+})

--- a/packages/sanity/src/core/config/configWarnings.ts
+++ b/packages/sanity/src/core/config/configWarnings.ts
@@ -1,0 +1,30 @@
+/**
+ * A warning about divergent `auth` configs across workspaces for the same
+ * project. Collected at prepareConfig time and surfaced by the studio UI in
+ * dev mode via `ConfigIssuesButton`.
+ *
+ * @internal
+ */
+export interface ProjectAuthDivergenceWarning {
+  type: 'project-auth-divergence'
+  projectId: string
+  /** Grouped workspace names, one array per distinct auth config shape. */
+  groups: string[][]
+  /** Human-readable message suitable for console output or a UI surface. */
+  message: string
+}
+
+/** @internal */
+export type ConfigWarning = ProjectAuthDivergenceWarning
+
+const collected: ConfigWarning[] = []
+
+/** @internal */
+export function recordConfigWarning(warning: ConfigWarning): void {
+  collected.push(warning)
+}
+
+/** @internal */
+export function getCollectedConfigWarnings(): ReadonlyArray<ConfigWarning> {
+  return collected
+}

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -29,6 +29,7 @@ import {uploadSchema} from '../studio/manifest/uploadSchema'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../studioClient'
 import {type InitialValueTemplateItem, type Template, type TemplateItem} from '../templates'
 import {EMPTY_ARRAY, isNonNullable} from '../util'
+import {canonicalHash} from '../util/canonicalHash'
 import {
   advancedVersionControlEnabledReducer,
   announcementsEnabledReducer,
@@ -63,6 +64,7 @@ import {
   toolsReducer,
 } from './configPropertyReducers'
 import {ConfigResolutionError} from './ConfigResolutionError'
+import {recordConfigWarning} from './configWarnings'
 import {createDefaultIcon} from './createDefaultIcon'
 import {documentFieldActionsReducer, initialDocumentFieldActions} from './document'
 import {resolveConfigProperty} from './resolveConfigProperty'
@@ -109,6 +111,109 @@ function warnDeprecatedConfigContextClientOnce() {
   console.warn(
     '`configContext.client` is deprecated and will be removed in the next release! Use `context.getClient({apiVersion: "2021-06-07"})` instead',
   )
+}
+
+const warnedProjectAuthDivergence = new Set<string>()
+
+/**
+ * Detects when multiple workspaces declare different `auth` configurations
+ * for the same projectId. Auth is project-scoped at runtime (cookies are
+ * scoped to the API domain; tokens are stored by projectId in localStorage),
+ * so per-workspace auth configs for the same project don't actually isolate
+ * auth between workspaces — whichever workspace initializes first wins at
+ * the storage level, and other configs become silent no-ops.
+ *
+ * Logs to the console and records the finding on the module-level warnings
+ * list (see `configWarnings.ts`) so the studio UI can surface it in dev
+ * mode via `ConfigIssuesButton`.
+ *
+ * @internal
+ */
+function warnOnDivergentProjectAuth(
+  workspaces: ReadonlyArray<WorkspaceOptions | SingleWorkspace>,
+): void {
+  const byProject = new Map<string, Array<{name: string; auth: unknown}>>()
+  for (const workspace of workspaces) {
+    const {projectId, auth, name} = workspace as WorkspaceOptions & {auth?: unknown}
+    if (!projectId || auth === undefined) continue
+    const list = byProject.get(projectId) ?? []
+    list.push({name: name ?? 'default', auth})
+    byProject.set(projectId, list)
+  }
+
+  for (const [projectId, entries] of byProject) {
+    if (entries.length < 2) continue
+
+    // Fingerprint each auth config so we can tell whether they diverge.
+    // AuthStore instances (already-constructed) are compared by reference
+    // identity; plain AuthConfig objects are compared by JSON shape.
+    // `providers` can be a function — different function identities will
+    // show as divergent, which may produce false positives but is acceptable
+    // for a deprecation warning.
+    const fingerprints = new Map<string, string[]>()
+    for (const {name, auth} of entries) {
+      const fingerprint = fingerprintAuth(auth)
+      const names = fingerprints.get(fingerprint) ?? []
+      names.push(name)
+      fingerprints.set(fingerprint, names)
+    }
+
+    if (fingerprints.size < 2) continue
+
+    // De-dupe across multiple prepareConfig runs in the same session
+    // (HMR, tests, multiple studio instances).
+    const warnKey = `${projectId}:${[...fingerprints.keys()].sort().join('|')}`
+    if (warnedProjectAuthDivergence.has(warnKey)) continue
+    warnedProjectAuthDivergence.add(warnKey)
+
+    const groups = [...fingerprints.values()]
+    const formattedGroups = groups.map((names) => `  • ${names.map((n) => `"${n}"`).join(', ')}`)
+    const message =
+      `Workspaces for project "${projectId}" declare different \`auth\` ` +
+      `configurations. Auth is project-scoped — workspaces for the same project ` +
+      `share cookies and tokens regardless of their individual \`auth\` config, so ` +
+      `only the first-initialized workspace's config actually takes effect. ` +
+      `Consolidate these to a single shared config:\n${formattedGroups.join('\n')}`
+
+    console.warn(`[sanity] ${message}`)
+    recordConfigWarning({
+      type: 'project-auth-divergence',
+      projectId,
+      groups,
+      message,
+    })
+  }
+}
+
+function fingerprintAuth(auth: unknown): string {
+  if (auth === null || typeof auth !== 'object') return String(auth)
+
+  // Pre-built `AuthStore` instances are compared by reference identity.
+  // `createAuthStore` is memoized by a canonical hash of its options, so two
+  // `createAuthStore(equivalentOptions)` calls return the same instance —
+  // meaning reference identity is sufficient to detect "same auth" even when
+  // the calls were made separately per workspace.
+  if (isAuthStore(auth)) return `AuthStore@${getObjectId(auth)}`
+
+  // Plain `AuthConfig` objects are compared by canonical shape (keys sorted
+  // recursively) so property declaration order doesn't produce false
+  // positives.
+  try {
+    return `AuthConfig:${canonicalHash(auth)}`
+  } catch {
+    return `unserializable@${getObjectId(auth)}`
+  }
+}
+
+const objectIds = new WeakMap<object, number>()
+let nextObjectId = 1
+function getObjectId(value: object): number {
+  let id = objectIds.get(value)
+  if (id === undefined) {
+    id = nextObjectId++
+    objectIds.set(value, id)
+  }
+  return id
 }
 
 // Create media library sources with configuration
@@ -183,6 +288,8 @@ export function prepareConfig(
       causes: [e.message],
     })
   }
+
+  warnOnDivergentProjectAuth(workspaceOptions)
 
   const workspaces = workspaceOptions.map((rawWorkspace): WorkspaceSummary => {
     if (preparedWorkspaces.has(rawWorkspace)) {

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -170,10 +170,10 @@ function warnOnDivergentProjectAuth(
     const formattedGroups = groups.map((names) => `  • ${names.map((n) => `"${n}"`).join(', ')}`)
     const message =
       `Workspaces for project "${projectId}" declare different \`auth\` ` +
-      `configurations. Auth is project-scoped — workspaces for the same project ` +
-      `share cookies and tokens regardless of their individual \`auth\` config, so ` +
-      `only the first-initialized workspace's config actually takes effect. ` +
-      `Consolidate these to a single shared config:\n${formattedGroups.join('\n')}`
+      `configurations. Auth is project-scoped: workspaces for the same project ` +
+      `share cookies and tokens. Only the first-initialized workspace's \`auth\` ` +
+      `config takes effect; others are silent no-ops. Consolidate these to a ` +
+      `single shared config:\n${formattedGroups.join('\n')}`
 
     console.warn(`[sanity] ${message}`)
     recordConfigWarning({

--- a/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/_legacy/authStore/createAuthStore.ts
@@ -22,6 +22,7 @@ import {
 import {type AuthConfig} from '../../../config'
 import {isStaging} from '../../../environment/isStaging'
 import {DEFAULT_STUDIO_CLIENT_HEADERS} from '../../../studioClient'
+import {canonicalHash} from '../../../util/canonicalHash'
 import {CorsOriginError} from '../cors'
 import {createBroadcastState} from './createBroadcastState'
 import {createBroadcastStorage} from './createBroadcastStorage'
@@ -531,19 +532,6 @@ export function _createAuthStore({
   }
 }
 
-function hash(value: unknown): string {
-  if (typeof value !== 'object' || value === null) return `${value}`
-
-  // note: this code path works for arrays as well as objects
-  return JSON.stringify(
-    Object.fromEntries(
-      Object.entries(value)
-        .sort(([a], [b]) => a.localeCompare(b, 'en'))
-        .map(([k, v]) => [k, hash(v)]),
-    ),
-  )
-}
-
 /**
  * Public options for `createAuthStore`. The `getSessionId` and `consumeHashToken`
  * dependencies are wired automatically using the default implementations.
@@ -561,5 +549,5 @@ export const createAuthStore = memoize(
       getSessionId: defaultGetSessionId,
       consumeHashToken: defaultConsumeHashToken,
     }),
-  hash,
+  canonicalHash,
 )

--- a/packages/sanity/src/core/studio/components/navbar/configIssues/ConfigIssuesButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/configIssues/ConfigIssuesButton.tsx
@@ -89,7 +89,7 @@ export function ConfigIssuesButton() {
                   >
                     <Stack space={2}>
                       <Text size={1} weight="medium">
-                        Divergent auth config for project "{warning.projectId}"
+                        Divergent auth config
                       </Text>
                       <Text size={1} style={{whiteSpace: 'pre-wrap'}}>
                         {warning.message}

--- a/packages/sanity/src/core/studio/components/navbar/configIssues/ConfigIssuesButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/configIssues/ConfigIssuesButton.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable i18next/no-literal-string */
 import {WarningOutlineIcon} from '@sanity/icons'
-import {Stack, Text} from '@sanity/ui'
+import {Card, Stack, Text} from '@sanity/ui'
 import {useCallback, useId, useState} from 'react'
 
 import {Dialog} from '../../../../../ui-components'
 import {StatusButton} from '../../../../components'
+import {getCollectedConfigWarnings} from '../../../../config/configWarnings'
 import {useSchema} from '../../../../hooks'
 import {useTranslation} from '../../../../i18n'
 import {useColorSchemeValue} from '../../../colorScheme'
@@ -16,6 +17,9 @@ export function ConfigIssuesButton() {
     schema._validation?.filter((group) =>
       group.problems.some((problem) => problem.severity === 'warning'),
     ) || []
+
+  const configWarnings = getCollectedConfigWarnings()
+  const totalWarnings = groupsWithWarnings.length + configWarnings.length
 
   // get root scheme
   const scheme = useColorSchemeValue()
@@ -35,7 +39,7 @@ export function ConfigIssuesButton() {
     }
   }, [buttonElement])
 
-  if (groupsWithWarnings.length === 0) {
+  if (totalWarnings === 0) {
     return null
   }
 
@@ -65,14 +69,40 @@ export function ConfigIssuesButton() {
           <Stack space={4}>
             <Stack space={3}>
               <Text as="h2" size={1} weight="medium">
-                Found {groupsWithWarnings.length} schema warnings
+                Found {totalWarnings} configuration warning{totalWarnings === 1 ? '' : 's'}
               </Text>{' '}
               <Text muted size={1}>
                 Configuration checks are only performed during development and will not be visible
                 in production builds
               </Text>
             </Stack>
-            <SchemaProblemGroups problemGroups={groupsWithWarnings} />
+
+            {configWarnings.length > 0 && (
+              <Stack space={3}>
+                {configWarnings.map((warning, index) => (
+                  <Card
+                    key={`${warning.type}-${warning.projectId}-${index}`}
+                    padding={3}
+                    radius={2}
+                    shadow={1}
+                    tone="caution"
+                  >
+                    <Stack space={2}>
+                      <Text size={1} weight="medium">
+                        Divergent auth config for project "{warning.projectId}"
+                      </Text>
+                      <Text size={1} style={{whiteSpace: 'pre-wrap'}}>
+                        {warning.message}
+                      </Text>
+                    </Stack>
+                  </Card>
+                ))}
+              </Stack>
+            )}
+
+            {groupsWithWarnings.length > 0 && (
+              <SchemaProblemGroups problemGroups={groupsWithWarnings} />
+            )}
           </Stack>
         </Dialog>
       )}

--- a/packages/sanity/src/core/util/canonicalHash.ts
+++ b/packages/sanity/src/core/util/canonicalHash.ts
@@ -1,0 +1,27 @@
+/**
+ * Produces a stable string hash of a value where object property order does
+ * not affect the result. Recurses into nested objects/arrays and sorts keys
+ * before stringifying.
+ *
+ * Used to compare configuration shapes (e.g. two `AuthConfig` objects) for
+ * structural equality without being sensitive to the author's declaration
+ * order.
+ *
+ * Functions are stringified via their source (via the default coercion of
+ * `typeof value !== 'object'`), so two arrow functions with identical
+ * source compare equal.
+ *
+ * @internal
+ */
+export function canonicalHash(value: unknown): string {
+  if (typeof value !== 'object' || value === null) return `${value}`
+
+  // Works for arrays as well as objects; arrays' numeric keys sort correctly.
+  return JSON.stringify(
+    Object.fromEntries(
+      Object.entries(value)
+        .sort(([a], [b]) => a.localeCompare(b, 'en'))
+        .map(([k, v]) => [k, canonicalHash(v)]),
+    ),
+  )
+}


### PR DESCRIPTION
### Description

When a studio has multiple workspaces configured for the same project, the `auth` config on each workspace can only really take effect on one of them: Auth is project-scoped, so workspaces for the same project end up sharing a session regardless of what their individual configs say. Today this happens silently, and whichever workspace initializes first wins.

This PR adds detection for workspaces for the same project declaring different auth configs, and when detected, a warning will appear in the dev-mode config-issues panel in the navbar. Additionally, a console.warning will be issued once per project.

Example from the (rather contrived) auth testing studio:
<img width="2074" height="1638" alt="image" src="https://github.com/user-attachments/assets/49c51111-9ff7-4241-a077-05a17a10d2a3" />

### What to review
Makes sense? Is the warning clear and actionable?

### Testing

Unit tests included

### Notes for release

Studios now warns you when multiple workspaces sharing the same project ID have conflicting auth configurations.