### PR TITLE
ci(workflows): drop fetch-depth: 0 from jobs that don't need history

### DIFF
--- a/.github/workflows/e2e-auth.yml
+++ b/.github/workflows/e2e-auth.yml
@@ -18,8 +18,6 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - uses: ./.github/actions/detect-code-changes
         id: changes

--- a/.github/workflows/e2e-ct.yml
+++ b/.github/workflows/e2e-ct.yml
@@ -21,8 +21,6 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - uses: ./.github/actions/detect-code-changes
         id: changes

--- a/.github/workflows/e2e-embedded.yml
+++ b/.github/workflows/e2e-embedded.yml
@@ -19,8 +19,6 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - uses: ./.github/actions/detect-code-changes
         id: changes

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,8 +29,6 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - uses: ./.github/actions/detect-code-changes
         id: changes
@@ -75,8 +73,6 @@ jobs:
     if: needs.install.outputs.has_code_changes == 'true'
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - uses: ./.github/actions/setup
 

--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -34,8 +34,6 @@ jobs:
       has_code_changes: ${{ steps.changes.outputs.has_changes }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - uses: ./.github/actions/detect-code-changes
         id: changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,8 +51,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - uses: ./.github/actions/setup
         with:
@@ -108,8 +106,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - uses: ./.github/actions/setup
 

--- a/.github/workflows/testExports.yml
+++ b/.github/workflows/testExports.yml
@@ -10,8 +10,6 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - uses: ./.github/actions/detect-code-changes
         id: changes

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -50,8 +50,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - uses: pnpm/action-setup@v5
 


### PR DESCRIPTION
### Description

`actions/checkout` defaults to a shallow, single-commit clone. Passing `fetch-depth: 0` opts into unshallow, which also pulls every branch and every tag — slower and adds pages of `* [new branch] …` / `* [new tag] …` lines to the log.

The removed jobs don't run any git-history-aware tooling.

### What to review
Left untouched:
- release workflows (`release-*`, `create-release-pr`): `release-notes bump` uses `conventional-recommended-bump` against `v`-prefixed tags; `lintPr.yml`
- eslint job: comment says `turbo --affected` needed it
- `auto-label-pr.yml`: does `git diff origin/<base>...HEAD` and would need tuning, not just removal.

### Testing
CI running on this PR exercises every touched workflow. If checkout silently relied on history somewhere I missed, those jobs will fail here before merge.

### Notes for release

N/A – Internal only
