### PR TITLE
fix(docs): code of conduct path in contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Contributions are always welcome, no matter how large or small.
 
 ## Getting started
 
-Before contributing, please read our [code of conduct](https://github.com/sanity-io/sanity/blob/current/CODE_OF_CONDUCT.md).
+Before contributing, please read our [code of conduct](CODE_OF_CONDUCT.md).
 
 Then make sure you have _Node.js version 18 or newer_. We currently use [pnpm](https://pnpm.io/installation) as our package manager, so make sure you have that installed as well.
 


### PR DESCRIPTION
### Description

If you click on code of conduct from contributing it wil get you to an error page

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

Is the path correct? 

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
