### PR TITLE
fix(core): show json diffs for missing fields, skip _system field

### DIFF
--- a/packages/sanity/src/core/field/diff/changes/buildChangeList.ts
+++ b/packages/sanity/src/core/field/diff/changes/buildChangeList.ts
@@ -21,8 +21,11 @@ import {
 } from '../../types'
 import {hasPTMemberType} from '../../types/portableText/diff/helpers'
 import {getValueError} from '../../validation'
+import {JsonFieldDiff} from '../components/JsonFieldDiff'
 import {isFieldChange} from '../helpers'
 import {resolveDiffComponent} from '../resolve/resolveDiffComponent'
+import {UNKNOWN_DOCUMENT_FIELD_SCHEMA_TYPE} from './unknownDocumentFieldSchema'
+import {getSortedUnknownChangedObjectFieldNames} from './unknownObjectDiffFields'
 
 interface DiffContext {
   itemDiff?: ItemDiff
@@ -53,6 +56,36 @@ function buildChangeList(
   return getFieldChange(schemaType, diff, path, titlePath, context)
 }
 
+function buildUnknownFieldChangeNodes(
+  fieldDiff: Diff,
+  fieldPath: Path,
+  fieldTitlePath: ChangeTitlePath,
+  {itemDiff, parentDiff, parentSchema}: DiffContext,
+): FieldChangeNode[] {
+  const {fromValue, toValue, type} = fieldDiff
+
+  if (type === 'array' && isEmpty(fromValue) && isEmpty(toValue)) {
+    return []
+  }
+
+  return [
+    {
+      type: 'field',
+      diff: fieldDiff,
+      path: fieldPath,
+      itemDiff,
+      parentDiff,
+      titlePath: fieldTitlePath,
+      schemaType: UNKNOWN_DOCUMENT_FIELD_SCHEMA_TYPE,
+      showHeader: true,
+      showIndex: true,
+      key: pathToString(fieldPath) || 'root',
+      diffComponent: JsonFieldDiff,
+      parentSchema,
+    },
+  ]
+}
+
 export function buildObjectChangeList(
   schemaType: ObjectSchemaType,
   diff: ObjectDiff,
@@ -61,6 +94,7 @@ export function buildObjectChangeList(
   diffContext: DiffContext = {},
 ): ChangeNode[] {
   const changes: ChangeNode[] = []
+  const {fieldFilter} = diffContext
 
   const childContext: DiffContext = {...diffContext, parentSchema: schemaType}
   const fieldSets =
@@ -71,6 +105,15 @@ export function buildObjectChangeList(
     } else {
       changes.push(...buildFieldsetChangeList(fieldSet, diff, path, titlePath, childContext))
     }
+  }
+
+  for (const fieldName of getSortedUnknownChangedObjectFieldNames(schemaType, diff, fieldFilter)) {
+    const fieldDiff = diff.fields[fieldName]
+    const fieldPath = path.concat([fieldName])
+    const fieldTitlePath = titlePath.concat([fieldName])
+    changes.push(
+      ...buildUnknownFieldChangeNodes(fieldDiff, fieldPath, fieldTitlePath, childContext),
+    )
   }
 
   if (changes.length < 2) {

--- a/packages/sanity/src/core/field/diff/changes/buildChangeList.ts
+++ b/packages/sanity/src/core/field/diff/changes/buildChangeList.ts
@@ -107,7 +107,8 @@ export function buildObjectChangeList(
     }
   }
 
-  for (const fieldName of getSortedUnknownChangedObjectFieldNames(schemaType, diff, fieldFilter)) {
+  const unknownFieldNames = getSortedUnknownChangedObjectFieldNames(schemaType, diff, fieldFilter)
+  for (const fieldName of unknownFieldNames) {
     const fieldDiff = diff.fields[fieldName]
     const fieldPath = path.concat([fieldName])
     const fieldTitlePath = titlePath.concat([fieldName])

--- a/packages/sanity/src/core/field/diff/changes/unknownDocumentFieldSchema.ts
+++ b/packages/sanity/src/core/field/diff/changes/unknownDocumentFieldSchema.ts
@@ -1,0 +1,10 @@
+import {type ObjectSchemaType} from '@sanity/types'
+
+import {JsonFieldDiff} from '../components/JsonFieldDiff'
+
+export const UNKNOWN_DOCUMENT_FIELD_SCHEMA_TYPE: ObjectSchemaType = {
+  name: '__sanity.unknownDocumentField',
+  fields: [],
+  jsonType: 'object',
+  components: {diff: JsonFieldDiff},
+}

--- a/packages/sanity/src/core/field/diff/changes/unknownObjectDiffFields.test.ts
+++ b/packages/sanity/src/core/field/diff/changes/unknownObjectDiffFields.test.ts
@@ -71,11 +71,13 @@ describe('getSortedUnknownChangedObjectFieldNames', () => {
     expect(getSortedUnknownChangedObjectFieldNames(schema, diff, ['b'])).toEqual(['b'])
   })
 
-  it('omits `_system` even when not on schema (internal / noisy)', () => {
+  it('omits `_system`, `_type`, and `_key` when not on schema (internal / noisy)', () => {
     const diff = {
       type: 'object',
       fields: {
         _system: {isChanged: true},
+        _type: {isChanged: true},
+        _key: {isChanged: true},
         orphan: {isChanged: true},
       },
     } as unknown as ObjectDiff

--- a/packages/sanity/src/core/field/diff/changes/unknownObjectDiffFields.test.ts
+++ b/packages/sanity/src/core/field/diff/changes/unknownObjectDiffFields.test.ts
@@ -1,0 +1,85 @@
+import {type ObjectSchemaType} from '@sanity/types'
+import {describe, expect, it} from 'vitest'
+
+import {type ObjectDiff} from '../../types'
+import {
+  collectObjectSchemaFieldNames,
+  getSortedUnknownChangedObjectFieldNames,
+} from './unknownObjectDiffFields'
+
+function docSchema(fields: ObjectSchemaType['fields']): ObjectSchemaType {
+  return {
+    name: 'article',
+    jsonType: 'object',
+    fields,
+  } as ObjectSchemaType
+}
+
+describe('collectObjectSchemaFieldNames', () => {
+  it('collects names from fields when there are no fieldsets', () => {
+    const schema = docSchema([
+      {name: 'title', type: {name: 'string', jsonType: 'string'} as any},
+      {name: 'body', type: {name: 'text', jsonType: 'string'} as any},
+    ])
+    expect(collectObjectSchemaFieldNames(schema)).toEqual(new Set(['title', 'body']))
+  })
+
+  it('collects names from multi-fieldsets', () => {
+    const schema = {
+      ...docSchema([{name: 'unused', type: {name: 'string', jsonType: 'string'} as any}]),
+      fieldsets: [
+        {
+          single: false as const,
+          name: 'meta',
+          fields: [
+            {name: 'seo', type: {name: 'string', jsonType: 'string'} as any},
+            {name: 'slug', type: {name: 'slug', jsonType: 'object'} as any},
+          ],
+        },
+      ],
+    } as ObjectSchemaType
+    expect(collectObjectSchemaFieldNames(schema)).toEqual(new Set(['seo', 'slug']))
+  })
+})
+
+describe('getSortedUnknownChangedObjectFieldNames', () => {
+  const schema = docSchema([{name: 'title', type: {name: 'string', jsonType: 'string'} as any}])
+
+  it('returns lexicographically sorted unknown keys that changed', () => {
+    const diff = {
+      type: 'object',
+      fields: {
+        zebra: {isChanged: true},
+        title: {isChanged: true},
+        orphan: {isChanged: true},
+        unchanged: {isChanged: false},
+      },
+    } as unknown as ObjectDiff
+
+    expect(getSortedUnknownChangedObjectFieldNames(schema, diff)).toEqual(['orphan', 'zebra'])
+  })
+
+  it('respects fieldFilter when provided', () => {
+    const diff = {
+      type: 'object',
+      fields: {
+        a: {isChanged: true},
+        b: {isChanged: true},
+      },
+    } as unknown as ObjectDiff
+
+    expect(getSortedUnknownChangedObjectFieldNames(schema, diff, ['b'])).toEqual(['b'])
+  })
+
+  it('omits `_system` even when not on schema (internal / noisy)', () => {
+    const diff = {
+      type: 'object',
+      fields: {
+        _system: {isChanged: true},
+        orphan: {isChanged: true},
+      },
+    } as unknown as ObjectDiff
+
+    expect(getSortedUnknownChangedObjectFieldNames(schema, diff)).toEqual(['orphan'])
+  })
+})

--- a/packages/sanity/src/core/field/diff/changes/unknownObjectDiffFields.test.ts
+++ b/packages/sanity/src/core/field/diff/changes/unknownObjectDiffFields.test.ts
@@ -71,13 +71,16 @@ describe('getSortedUnknownChangedObjectFieldNames', () => {
     expect(getSortedUnknownChangedObjectFieldNames(schema, diff, ['b'])).toEqual(['b'])
   })
 
-  it('omits `_system`, `_type`, and `_key` when not on schema (internal / noisy)', () => {
+  it('omits document metadata and internal keys when not on schema', () => {
     const diff = {
       type: 'object',
       fields: {
+        _createdAt: {isChanged: true},
+        _key: {isChanged: true},
+        _rev: {isChanged: true},
         _system: {isChanged: true},
         _type: {isChanged: true},
-        _key: {isChanged: true},
+        _updatedAt: {isChanged: true},
         orphan: {isChanged: true},
       },
     } as unknown as ObjectDiff

--- a/packages/sanity/src/core/field/diff/changes/unknownObjectDiffFields.ts
+++ b/packages/sanity/src/core/field/diff/changes/unknownObjectDiffFields.ts
@@ -3,12 +3,20 @@ import {type ObjectSchemaType} from '@sanity/types'
 import {type ObjectDiff} from '../../types'
 
 /**
- * Keys we never surface as “unknown schema” JSON diffs — they are internal /
- * system-managed and would only add noise (or churn) to Review changes.
+ * Keys we never surface as “unknown schema” JSON diffs — Sanity document /
+ * object conventions (`_type`, `_key`) and internal blobs (`_system`) that
+ * would only add noise or churn to Review changes.
  *
  * @internal
  */
-const SKIP_UNKNOWN_JSON_DIFF_FIELD_NAMES = new Set<string>(['_system'])
+const SKIP_UNKNOWN_JSON_DIFF_FIELD_NAMES = new Set<string>([
+  '_key',
+  '_system',
+  '_type',
+  '_createdAt',
+  '_updatedAt',
+  '_rev',
+])
 
 /**
  * Field names declared on an object schema type (including multi-fieldsets).
@@ -34,8 +42,8 @@ export function collectObjectSchemaFieldNames(schemaType: ObjectSchemaType): Set
 /**
  * Keys present in `diff.fields` that are not declared on `schemaType`, have
  * `isChanged`, and pass optional `fieldFilter` (when set, the name must be
- * included). Skips internal keys such as `_system` (see
- * `SKIP_UNKNOWN_JSON_DIFF_FIELD_NAMES`).
+ * included). Skips `_type`, `_key`, `_system`, and any future entries in
+ * `SKIP_UNKNOWN_JSON_DIFF_FIELD_NAMES`.
  * Sorted lexicographically for stable UI ordering.
  *
  * @internal

--- a/packages/sanity/src/core/field/diff/changes/unknownObjectDiffFields.ts
+++ b/packages/sanity/src/core/field/diff/changes/unknownObjectDiffFields.ts
@@ -3,19 +3,20 @@ import {type ObjectSchemaType} from '@sanity/types'
 import {type ObjectDiff} from '../../types'
 
 /**
- * Keys we never surface as “unknown schema” JSON diffs — Sanity document /
- * object conventions (`_type`, `_key`) and internal blobs (`_system`) that
- * would only add noise or churn to Review changes.
+ * Keys we never surface as “unknown schema” JSON diffs — standard document
+ * metadata (`_createdAt`, `_updatedAt`, `_rev`, `_type`), portable object
+ * identity (`_key`), and internal blobs (`_system`) that would only add noise
+ * or churn to Review changes.
  *
  * @internal
  */
 const SKIP_UNKNOWN_JSON_DIFF_FIELD_NAMES = new Set<string>([
+  '_createdAt',
   '_key',
+  '_rev',
   '_system',
   '_type',
-  '_createdAt',
   '_updatedAt',
-  '_rev',
 ])
 
 /**
@@ -42,8 +43,8 @@ export function collectObjectSchemaFieldNames(schemaType: ObjectSchemaType): Set
 /**
  * Keys present in `diff.fields` that are not declared on `schemaType`, have
  * `isChanged`, and pass optional `fieldFilter` (when set, the name must be
- * included). Skips `_type`, `_key`, `_system`, and any future entries in
- * `SKIP_UNKNOWN_JSON_DIFF_FIELD_NAMES`.
+ * included). Skips standard metadata / internal keys in
+ * `SKIP_UNKNOWN_JSON_DIFF_FIELD_NAMES` (see set above).
  * Sorted lexicographically for stable UI ordering.
  *
  * @internal

--- a/packages/sanity/src/core/field/diff/changes/unknownObjectDiffFields.ts
+++ b/packages/sanity/src/core/field/diff/changes/unknownObjectDiffFields.ts
@@ -1,0 +1,63 @@
+import {type ObjectSchemaType} from '@sanity/types'
+
+import {type ObjectDiff} from '../../types'
+
+/**
+ * Keys we never surface as “unknown schema” JSON diffs — they are internal /
+ * system-managed and would only add noise (or churn) to Review changes.
+ *
+ * @internal
+ */
+const SKIP_UNKNOWN_JSON_DIFF_FIELD_NAMES = new Set<string>(['_system'])
+
+/**
+ * Field names declared on an object schema type (including multi-fieldsets).
+ *
+ * @internal
+ */
+export function collectObjectSchemaFieldNames(schemaType: ObjectSchemaType): Set<string> {
+  const names = new Set<string>()
+  const fieldSets =
+    schemaType.fieldsets || schemaType.fields.map((field) => ({single: true, field}))
+  for (const fieldSet of fieldSets) {
+    if (fieldSet.single) {
+      names.add(fieldSet.field.name)
+    } else {
+      for (const field of fieldSet.fields) {
+        names.add(field.name)
+      }
+    }
+  }
+  return names
+}
+
+/**
+ * Keys present in `diff.fields` that are not declared on `schemaType`, have
+ * `isChanged`, and pass optional `fieldFilter` (when set, the name must be
+ * included). Skips internal keys such as `_system` (see
+ * `SKIP_UNKNOWN_JSON_DIFF_FIELD_NAMES`).
+ * Sorted lexicographically for stable UI ordering.
+ *
+ * @internal
+ */
+export function getSortedUnknownChangedObjectFieldNames(
+  schemaType: ObjectSchemaType,
+  diff: ObjectDiff,
+  fieldFilter?: string[],
+): string[] {
+  const schemaFieldNames = collectObjectSchemaFieldNames(schemaType)
+  const unknown = Object.keys(diff.fields).filter(
+    (name) => !schemaFieldNames.has(name) && !SKIP_UNKNOWN_JSON_DIFF_FIELD_NAMES.has(name),
+  )
+  unknown.sort()
+  return unknown.filter((fieldName) => {
+    const fieldDiff = diff.fields[fieldName]
+    if (!fieldDiff?.isChanged) {
+      return false
+    }
+    if (fieldFilter && !fieldFilter.includes(fieldName)) {
+      return false
+    }
+    return true
+  })
+}

--- a/packages/sanity/src/core/field/diff/components/JsonFieldDiff.tsx
+++ b/packages/sanity/src/core/field/diff/components/JsonFieldDiff.tsx
@@ -1,4 +1,4 @@
-import {Code, Stack, Text} from '@sanity/ui'
+import {Card, Code, Stack, Text} from '@sanity/ui'
 import {type CSSProperties} from 'react'
 import {styled} from 'styled-components'
 
@@ -79,10 +79,10 @@ export const JsonFieldDiff: DiffComponent = ({diff}) => {
     ) : null
 
   return (
-    <Stack space={3} paddingY={1}>
-      <Text muted size={1}>
-        {t('changes.unknown-schema-field.description')}
-      </Text>
+    <Stack space={4} paddingY={1}>
+      <Card border padding={3} radius={2} tone="caution">
+        <Text size={1}>{t('changes.unknown-schema-field.description')}</Text>
+      </Card>
       {content}
     </Stack>
   )

--- a/packages/sanity/src/core/field/diff/components/JsonFieldDiff.tsx
+++ b/packages/sanity/src/core/field/diff/components/JsonFieldDiff.tsx
@@ -1,0 +1,89 @@
+import {Code, Stack, Text} from '@sanity/ui'
+import {type CSSProperties} from 'react'
+import {styled} from 'styled-components'
+
+import {useTranslation} from '../../../i18n'
+import {type DiffComponent} from '../../types'
+import {useChangeVerb} from '../hooks/useChangeVerb'
+import {DiffCard} from './DiffCard'
+import {DiffTooltip} from './DiffTooltip'
+import {FromToArrow} from './FromToArrow'
+
+/**
+ * Horizontal scroll only. Avoid `overflow-x: auto` on `pre`: CSS pairs it with
+ * `overflow-y: auto`, which spuriously shows a vertical scrollbar in flex layouts.
+ */
+const CodeWrapper = styled.div`
+  max-width: 100%;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+`
+
+const cardStyles: CSSProperties = {
+  flex: 1,
+  minWidth: 0,
+  display: 'block',
+  whiteSpace: 'break-spaces',
+}
+
+function jsonify(value: unknown): string {
+  if (typeof value === 'undefined') {
+    return 'undefined'
+  }
+  return JSON.stringify(value, null, 2)
+}
+
+/** @internal */
+export const JsonFieldDiff: DiffComponent = ({diff}) => {
+  const {t} = useTranslation()
+  const changeVerb = useChangeVerb(diff)
+
+  const from = diff.fromValue !== undefined && diff.fromValue !== null && (
+    <DiffCard as="del" diff={diff} style={cardStyles}>
+      <CodeWrapper>
+        <Code language="json" size={1}>
+          {jsonify(diff.fromValue)}
+        </Code>
+      </CodeWrapper>
+    </DiffCard>
+  )
+
+  const to = diff.toValue !== undefined && diff.toValue !== null && (
+    <DiffCard as="ins" diff={diff} style={cardStyles}>
+      <CodeWrapper>
+        <Code language="json" size={1}>
+          {jsonify(diff.toValue)}
+        </Code>
+      </CodeWrapper>
+    </DiffCard>
+  )
+
+  const content =
+    from && to ? (
+      <DiffTooltip description={changeVerb} diff={diff}>
+        <Stack space={3}>
+          {from}
+          <FromToArrow direction="down" align="center" />
+          {to}
+        </Stack>
+      </DiffTooltip>
+    ) : from ? (
+      <DiffTooltip description={changeVerb} diff={diff}>
+        {from}
+      </DiffTooltip>
+    ) : to ? (
+      <DiffTooltip description={changeVerb} diff={diff}>
+        {to}
+      </DiffTooltip>
+    ) : null
+
+  return (
+    <Stack space={3} paddingY={1}>
+      <Text muted size={1}>
+        {t('changes.unknown-schema-field.description')}
+      </Text>
+      {content}
+    </Stack>
+  )
+}

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -438,6 +438,9 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'changes.same-revision-selected-title': 'Same revision selected',
   /** Title for the Review Changes pane */
   'changes.title': 'History',
+  /** Shown above raw JSON diff for document fields that are not defined in the schema */
+  'changes.unknown-schema-field.description':
+    'This field is not defined in the schema. Values are shown as JSON.',
   /**The title that will be shown in the badge inside the events when the item is a draft */
   'changes.versions.draft': 'Draft',
 


### PR DESCRIPTION
### Description

Review changes only listed schema-declared fields, so keys that exist in `ObjectDiff` but not on the document type were dropped even though `@sanity/diff` already computes them, legacy or API-only properties were invisible in Studio.

This surfaces those keys as a JSON before/after, using a synthetic type to attach `JsonFieldDiff` without running normal schema validation. Unknown keys are resolved in `unknownObjectDiffFields` (testable). `_system` is skipped so it does not appear as an “unknown” JSON row. Wide JSON uses a horizontal scroll wrapper so `overflow-x: auto` on `pre` does not pair with a spurious vertical scrollbar.

Example of a tag added through media library in a `sanity.mediaAsset` document, this tag is not part of the schema given tags are added by the media plugin
https://test-studio-git-json-diffs.sanity.dev/test/structure/sanity.imageAsset;image-cd1f5a0bf2fefaebb6ddf954eca18fab81b6d8b8-2847x2847-png%2Cinspect%3Dsanity%252Fstructure%252Fhistory%2CchangesInspectorTab%3Dreview?perspective=published

<img width="399" height="730" alt="Screenshot 2026-04-24 at 13 21 27" src="https://github.com/user-attachments/assets/6a45228b-b237-4878-aa71-9314412cfcc1" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

Update **Review changes** ,  properties that are not defined on the schema now show as a raw JSON before/after

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
