### PR TITLE
test(e2e): require matcher in expectError to avoid suppressing unrelated errors

### DIFF
--- a/e2e/helpers/studioErrors.ts
+++ b/e2e/helpers/studioErrors.ts
@@ -8,6 +8,31 @@ import {type BrowserContext, type Locator, type Page} from '@playwright/test'
 export const STUDIO_ERROR_SELECTOR = '[data-testid="studio-error-screen"], #__sanityError'
 
 /**
+ * Source of a detected studio error.
+ * - `pageerror`: an uncaught exception propagated to `window.onerror`
+ * - `error-screen`: a rendered studio error screen (React boundary or pre-React overlay)
+ */
+export type StudioErrorSource = 'pageerror' | 'error-screen'
+
+export interface StudioErrorInfo {
+  source: StudioErrorSource
+  message: string
+}
+
+/**
+ * Predicate used by {@link expectError} to decide whether an observed error
+ * is the one the caller expected. Strings and regexps are matched against
+ * `message`; functions receive the full {@link StudioErrorInfo}.
+ */
+export type StudioErrorMatcher = string | RegExp | ((info: StudioErrorInfo) => boolean)
+
+function matches(matcher: StudioErrorMatcher, info: StudioErrorInfo): boolean {
+  if (typeof matcher === 'string') return info.message.includes(matcher)
+  if (matcher instanceof RegExp) return matcher.test(info.message)
+  return matcher(info)
+}
+
+/**
  * Returns a Playwright locator for the Studio error screen.
  * ```ts
  * await expect(studioErrorLocator(page)).toBeVisible()
@@ -18,17 +43,30 @@ export function studioErrorLocator(page: Page): Locator {
   return page.locator(STUDIO_ERROR_SELECTOR)
 }
 
-function attachErrorDetection(page: Page, state: {expecting: boolean}): void {
+interface WatcherState {
+  expected: StudioErrorMatcher | null
+}
+
+function handleError(state: WatcherState, info: StudioErrorInfo): void {
+  if (state.expected && matches(state.expected, info)) {
+    state.expected = null
+    return
+  }
+  throw new Error(`Studio threw an unexpected ${info.source}: ${info.message}`)
+}
+
+function attachErrorDetection(page: Page, state: WatcherState): void {
   page.on('pageerror', (error) => {
-    if (state.expecting) return
     if (error.message.includes('ResizeObserver')) return
-    throw new Error(`Studio threw an uncaught exception: ${error.message}`)
+    handleError(state, {source: 'pageerror', message: error.message})
   })
 
   page.on('console', (msg) => {
-    if (state.expecting) return
     if (msg.type() === 'error' && msg.text().startsWith('__STUDIO_ERROR__')) {
-      throw new Error(msg.text().slice('__STUDIO_ERROR__'.length))
+      handleError(state, {
+        source: 'error-screen',
+        message: msg.text().slice('__STUDIO_ERROR__'.length),
+      })
     }
   })
 
@@ -41,7 +79,7 @@ function attachErrorDetection(page: Page, state: {expecting: boolean}): void {
         fired = true
         const detail =
           el.getAttribute('data-error') || el.textContent?.trim().slice(0, 200) || 'Unknown error'
-        console.error(`__STUDIO_ERROR__Studio error screen detected: ${detail}`)
+        console.error(`__STUDIO_ERROR__${detail}`)
       }
     }).observe(document, {childList: true, subtree: true})
   }, STUDIO_ERROR_SELECTOR)
@@ -49,24 +87,42 @@ function attachErrorDetection(page: Page, state: {expecting: boolean}): void {
 
 /**
  * Attach Studio error detection to a browser context. Every page created
- * in the context will auto-fail on Studio error screens.
+ * in the context will auto-fail on Studio error screens and uncaught
+ * exceptions.
  *
- * Returns a handle to opt out when asserting errors:
+ * To assert that a specific error is expected, pass a matcher to
+ * `expectError`. Only errors matching that matcher are suppressed — any
+ * other error still fails the test, so unrelated regressions are not
+ * accidentally hidden.
+ *
  * ```ts
  * const {expectError} = watchForStudioErrors(context)
- * // later…
- * expectError()
+ * expectError(/Session not found/)
  * await expect(studioErrorLocator(page)).toBeVisible()
  * ```
+ *
+ * The matcher may be a substring, a regexp, or a predicate receiving
+ * `{source, message}`:
+ *
+ * ```ts
+ * expectError(({source, message}) => source === 'error-screen' && message.includes('CORS'))
+ * ```
+ *
+ * Each call expects a single matching error; the matcher is cleared once
+ * consumed. If the expected error never arrives, the caller's own
+ * assertion (e.g. `expect(studioErrorLocator(page)).toBeVisible()`) is
+ * what surfaces the failure.
  */
-export function watchForStudioErrors(context: BrowserContext) {
-  const state = {expecting: false}
+export function watchForStudioErrors(context: BrowserContext): {
+  expectError: (matcher: StudioErrorMatcher) => void
+} {
+  const state: WatcherState = {expected: null}
   context.on('page', (page) => {
     attachErrorDetection(page, state)
   })
   return {
-    expectError() {
-      state.expecting = true
+    expectError(matcher) {
+      state.expected = matcher
     },
   }
 }


### PR DESCRIPTION
### Description

Follow-up to #12619. The original `expectError()` silenced every error on the page until the end of the test, so an unrelated crash during an auth-error assertion would be swallowed rather than failing the test.

`expectError` now requires a matcher (string substring, RegExp, or `({source, message}) => boolean`). Only a matching error is suppressed — anything else still throws. The matcher is one-shot so each expected error needs an explicit opt-in.

Alternative considered: an allowlist of error substrings on the watcher itself. Rejected — same "set and forget" footgun as the original, just further from the assertion site.

### What to review

- `e2e/helpers/studioErrors.ts` — the behavior change is in `handleError` and the `expectError` signature.
- Console marker for studio error screens dropped the `Studio error screen detected:` prefix so matchers run against the raw `data-error` detail.
- No callers use `expectError` yet, so no downstream updates were needed.

### Testing

- `pnpm check:types` and `pnpm exec tsgo --project e2e/tsconfig.json` pass.
- No new unit tests — this is an e2e helper exercised by the auth specs that will adopt it.

### Notes for release

N/A – Internal only (e2e test tooling)
