### PR TITLE
chore: adding telemetry to track when feedback dialog is opened and closed

### DIFF
--- a/packages/sanity/src/core/feedback/__telemetry__/feedback.telemetry.ts
+++ b/packages/sanity/src/core/feedback/__telemetry__/feedback.telemetry.ts
@@ -1,0 +1,13 @@
+import {defineEvent} from '@sanity/telemetry'
+
+export const FeedbackDialogOpened = defineEvent({
+  name: 'Feedback Dialog Opened',
+  version: 1,
+  description: 'User opened the in-studio feedback dialog',
+})
+
+export const FeedbackDialogDismissed = defineEvent({
+  name: 'Feedback Dialog Dismissed',
+  version: 1,
+  description: 'User closed the in-studio feedback dialog without sending feedback.',
+})

--- a/packages/sanity/src/core/feedback/__tests__/FeedbackDialog.telemetry.test.tsx
+++ b/packages/sanity/src/core/feedback/__tests__/FeedbackDialog.telemetry.test.tsx
@@ -1,0 +1,62 @@
+import {render, screen} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {type ReactNode} from 'react'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../test/testUtils/TestProvider'
+import {defineConfig} from '../../config/defineConfig'
+import {FeedbackDialogDismissed} from '../__telemetry__/feedback.telemetry'
+import {FeedbackDialog} from '../components/FeedbackDialog'
+
+const mockLog = vi.fn()
+vi.mock('@sanity/telemetry/react', () => ({
+  useTelemetry: vi.fn(() => ({log: mockLog})),
+}))
+
+vi.mock('../feedbackClient', () => ({
+  sendFeedbackToSentry: vi.fn(() => Promise.resolve()),
+  FEEDBACK_TUNNEL_URL: 'https://api.sanity.io/intake/feedback',
+}))
+
+const config = defineConfig({projectId: 'test', dataset: 'test'})
+
+async function createWrapper() {
+  const wrapper = await createTestProvider({config, resources: []})
+  return ({children}: {children: ReactNode}) => wrapper({children: <>{children}</>})
+}
+
+const defaultProps = {
+  onClose: vi.fn(),
+  dsn: 'https://key@sentry.sanity.io/123',
+  feedbackVersion: '1',
+  source: 'test',
+}
+
+describe('FeedbackDialog dismiss telemetry', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('logs `Feedback Dialog Dismissed` when the Cancel button is clicked', async () => {
+    const wrapper = await createWrapper()
+    render(<FeedbackDialog {...defaultProps} />, {wrapper})
+
+    await userEvent.click(screen.getByRole('button', {name: /^cancel$/i}))
+
+    expect(mockLog).toHaveBeenCalledWith(FeedbackDialogDismissed)
+  })
+
+  it('does not log `Feedback Dialog Dismissed` when feedback was successfully submitted', async () => {
+    const wrapper = await createWrapper()
+    render(<FeedbackDialog {...defaultProps} />, {wrapper})
+
+    await userEvent.click(screen.getByRole('button', {name: /^easy$/i}))
+    await userEvent.type(
+      screen.getByLabelText('What is working? What could be better?'),
+      'Looks great',
+    )
+    await userEvent.click(screen.getByRole('button', {name: /send feedback/i}))
+
+    expect(mockLog).not.toHaveBeenCalledWith(FeedbackDialogDismissed)
+  })
+})

--- a/packages/sanity/src/core/feedback/components/FeedbackDialog.tsx
+++ b/packages/sanity/src/core/feedback/components/FeedbackDialog.tsx
@@ -12,6 +12,7 @@ import {FeedbackContext} from 'sanity/_singletons'
 
 import {Button, Dialog} from '../../../ui-components'
 import {sendFeedbackToSentry} from '../feedbackClient'
+import {useFeedbackTelemetry} from '../hooks/useFeedbackTelemetry'
 import {useFeedbackTranslation} from '../i18n/useFeedbackTranslation'
 import {type Sentiment} from '../types'
 import {ImageAttachment} from './ImageAttachment'
@@ -90,6 +91,13 @@ export function FeedbackDialog(props: FeedbackDialogProps) {
   const [showAttachment, setShowAttachment] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [dragOver, setDragOver] = useState(false)
+
+  const {feedbackDialogDismissed} = useFeedbackTelemetry()
+
+  const handleDismiss = useCallback(() => {
+    feedbackDialogDismissed()
+    onClose()
+  }, [feedbackDialogDismissed, onClose])
 
   const handleMessageChange = useCallback((event: ChangeEvent<HTMLTextAreaElement>) => {
     setMessage(event.currentTarget.value)
@@ -197,8 +205,8 @@ export function FeedbackDialog(props: FeedbackDialogProps) {
     <Dialog
       id={dialogId}
       header={dialogTitle ?? t('feedback.dialog.title')}
-      onClose={onClose}
-      onClickOutside={onClose}
+      onClose={handleDismiss}
+      onClickOutside={handleDismiss}
       width={1}
       padding={false}
     >
@@ -283,7 +291,7 @@ export function FeedbackDialog(props: FeedbackDialogProps) {
 
       <Card padding={3} borderTop>
         <Flex gap={2} justify="flex-end">
-          <Button mode="ghost" text={t('feedback.cancel')} onClick={onClose} />
+          <Button mode="ghost" text={t('feedback.cancel')} onClick={handleDismiss} />
           <Button
             tone="primary"
             text={t('feedback.submit')}

--- a/packages/sanity/src/core/feedback/hooks/useFeedbackTelemetry.ts
+++ b/packages/sanity/src/core/feedback/hooks/useFeedbackTelemetry.ts
@@ -1,0 +1,27 @@
+import {useTelemetry} from '@sanity/telemetry/react'
+import {useCallback, useMemo} from 'react'
+
+import {FeedbackDialogDismissed, FeedbackDialogOpened} from '../__telemetry__/feedback.telemetry'
+
+interface FeedbackTelemetryHookValue {
+  feedbackDialogOpened: () => void
+  feedbackDialogDismissed: () => void
+}
+
+/** @internal */
+export function useFeedbackTelemetry(): FeedbackTelemetryHookValue {
+  const telemetry = useTelemetry()
+
+  const feedbackDialogOpened = useCallback(() => {
+    telemetry.log(FeedbackDialogOpened)
+  }, [telemetry])
+
+  const feedbackDialogDismissed = useCallback(() => {
+    telemetry.log(FeedbackDialogDismissed)
+  }, [telemetry])
+
+  return useMemo(
+    () => ({feedbackDialogOpened, feedbackDialogDismissed}),
+    [feedbackDialogOpened, feedbackDialogDismissed],
+  )
+}

--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesButton.tsx
@@ -9,6 +9,7 @@ import {StatusButton} from '../../../../components'
 import {STUDIO_DSN} from '../../../../error/sentry/sentryErrorReporter'
 import {StudioFeedbackDialog} from '../../../../feedback/components/StudioFeedbackDialog'
 import {useFeedbackAvailable} from '../../../../feedback/hooks/useFeedbackAvailable'
+import {useFeedbackTelemetry} from '../../../../feedback/hooks/useFeedbackTelemetry'
 import {useTranslation} from '../../../../i18n'
 import {useRenderingContext} from '../../../../store/renderingContext/useRenderingContext'
 import {useLiveUserApplication} from '../../../liveUserApplication/useLiveUserApplication'
@@ -61,7 +62,11 @@ export function ResourcesButton() {
   }, [])
 
   const [feedbackDialogOpen, setFeedbackDialogOpen] = useState(false)
-  const handleOpenFeedback = useCallback(() => setFeedbackDialogOpen(true), [])
+  const {feedbackDialogOpened} = useFeedbackTelemetry()
+  const handleOpenFeedback = useCallback(() => {
+    feedbackDialogOpened()
+    setFeedbackDialogOpen(true)
+  }, [feedbackDialogOpened])
   const handleCloseFeedback = useCallback(() => setFeedbackDialogOpen(false), [])
 
   return (


### PR DESCRIPTION
### Description
It might be useful for us to instrument across the opening of the feedback dialogs that don't result in feedback submissions.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
N/A
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
