### PR TITLE
fix(ci): handle commits without an associated PR

### DIFF
--- a/packages/@repo/release-notes/bin/release-notes.ts
+++ b/packages/@repo/release-notes/bin/release-notes.ts
@@ -319,16 +319,25 @@ function formatEntry({
   releaseId,
 }: {
   conventionalCommit: Commit
-  pr: PullRequest
+  pr: PullRequest | undefined
   changelogDocumentId: GenerateChangeLogResult['changelogDocumentId']
   releaseId: GenerateChangeLogResult['releaseId']
 }) {
   const entryKey = conventionalCommit.hash!.slice(0, 8)
-  const originalCommitMessage = stripPr(conventionalCommit.header || '', pr.number)
+  const originalCommitMessage = stripPr(conventionalCommit.header || '', pr?.number)
   const entryPath = encodeURIComponent(`changelog[_key=="${entryKey}"]`)
   const changelogEntryUrl = `${getAdminStudioUrl()}/intent/edit/id=${changelogDocumentId.published};path=${entryPath}/?perspective=${releaseId}`
 
-  const byline = pr.user?.login ? `[${pr.user?.login}](${pr.user.html_url})` : ''
+  if (!pr) {
+    // oxlint-disable-next-line no-console
+    console.warn(
+      `⚠️  WARNING: GitHub returned no PR association for commit ${conventionalCommit.hash}. ` +
+        `Rendering changelog row without a PR link.`,
+    )
+  }
+
+  const byline = pr?.user?.login ? `[${pr.user.login}](${pr.user.html_url})` : ''
+  const prCell = pr ? `[#${pr.number}](${pr.html_url})` : '—'
   const releaseNoteLink = `[:pencil:&nbsp;Edit](${changelogEntryUrl})`
-  return `${byline} | ${originalCommitMessage} | [#${pr.number}](${pr.html_url}) | ${conventionalCommit.hash} | ${releaseNoteLink}`
+  return `${byline} | ${originalCommitMessage} | ${prCell} | ${conventionalCommit.hash} | ${releaseNoteLink}`
 }

--- a/packages/@repo/release-notes/src/commands/commentPrAfterMerge.ts
+++ b/packages/@repo/release-notes/src/commands/commentPrAfterMerge.ts
@@ -18,7 +18,14 @@ export async function commentPrAfterMerge(options: {
   const octokit = getOctokit()
   const pr = await getMergedPRForCommit('sanity-io', 'sanity', options.commit)
   if (!pr) {
-    throw new Error('No PR found for this commit')
+    // GitHub's commit→PR association index is best-effort and occasionally
+    // misses associations. Skip posting the reminder rather than failing the
+    // workflow.
+    console.warn(
+      `⚠️  WARNING: GitHub returned no PR association for commit ${options.commit}. ` +
+        `Skipping release-notes reminder comment.`,
+    )
+    return
   }
 
   console.log(`Found PR #${pr.number}`)


### PR DESCRIPTION
### Description

The `Create Release PR` workflow crashed with `TypeError: Cannot read properties of undefined (reading 'number')` when generating the changelog summary. Two recent commits on `main` (#12742, #12734) had no PR returned by GitHub's `listPullRequestsAssociatedWithCommit` API even though both PRs exist and are merged, `gh pr view` resolves them. All commits on `main` go through PRs (branch protection enforces it).

This fixes the issue by gracefully handling missing PRs.

### Notes for release

N/A
