### PR TITLE
fix(ci): keep release-notes consistent for PR-less commits

### DIFF
--- a/packages/@repo/release-notes/bin/release-notes.ts
+++ b/packages/@repo/release-notes/bin/release-notes.ts
@@ -332,11 +332,11 @@ function formatEntry({
     // oxlint-disable-next-line no-console
     console.warn(
       `⚠️  WARNING: GitHub returned no PR association for commit ${conventionalCommit.hash}. ` +
-        `Rendering changelog row without a PR link.`,
+        `Rendering changelog row without author info.`,
     )
   }
 
-  const byline = pr?.user?.login ? `[${pr.user.login}](${pr.user.html_url})` : ''
+  const byline = pr?.user?.login ? `[${pr.user.login}](${pr.user.html_url})` : '—'
   const prCell = pr ? `[#${pr.number}](${pr.html_url})` : '—'
   const releaseNoteLink = `[:pencil:&nbsp;Edit](${changelogEntryUrl})`
   return `${byline} | ${originalCommitMessage} | ${prCell} | ${conventionalCommit.hash} | ${releaseNoteLink}`

--- a/packages/@repo/release-notes/src/commands/createOrUpdateChangelogDocs.ts
+++ b/packages/@repo/release-notes/src/commands/createOrUpdateChangelogDocs.ts
@@ -144,7 +144,10 @@ async function mergeChangelogBody(
 }
 
 function createEntry(client: SanityClient, info: PullRequestInfo, {dryRun}: {dryRun?: boolean}) {
-  return info.pr && info.pr.body ? getReleaseNotesMutations(client, info, {dryRun}) : []
+  // Always emit an entry, even when GitHub didn't return a PR association or
+  // the PR has no body. This keeps the changelog document consistent with the
+  // release-PR description table (both should reflect every commit that shipped).
+  return getReleaseNotesMutations(client, info, {dryRun})
 }
 
 async function getReleaseNotesMutations(

--- a/packages/@repo/release-notes/src/commands/publishReleases.ts
+++ b/packages/@repo/release-notes/src/commands/publishReleases.ts
@@ -63,11 +63,8 @@ Author | Message | Commit
 ------------ | ------------- | -------------
 ${changelogDocument.changelog
   .map((entry) => {
-    return [
-      mention(entry.author),
-      `${stripPr(entry.header, entry.pr)} (#${entry.pr})`,
-      entry.hash,
-    ].join(' | ')
+    const message = entry.pr ? `${stripPr(entry.header, entry.pr)} (#${entry.pr})` : entry.header
+    return [mention(entry.author), message, entry.hash].join(' | ')
   })
   .join('\n')}
   `
@@ -101,10 +98,9 @@ ${changelogDocument.changelog
 }
 
 function mention(author: StudioChangelogEntry['author']) {
-  if (author?.type !== 'bot') {
-    return `@${author?.username}`
-  }
-  return author.username
+  if (!author?.username) return '—'
+  if (author.type === 'bot') return author.username
+  return `@${author.username}`
 }
 
 function ghReleaseTemplate(vars: {


### PR DESCRIPTION
### Description

The fix in #12750 messed up the changelist in the release [PR](https://github.com/sanity-io/sanity/pull/ci/release-main), example:

<img width="834" height="181" alt="image" src="https://github.com/user-attachments/assets/cb0fdd38-e500-4c69-aac3-7cef72a24cfe" />


This PR should fix it by always making sure we render a consistent amount of cells for each row,

### Notes for release

N/A – Internal CI tooling.
