### PR TITLE
fix(core): reset calendar focused date when setting to current time

### DIFF
--- a/packages/sanity/src/core/components/inputs/DateInputs/calendar/Calendar.tsx
+++ b/packages/sanity/src/core/components/inputs/DateInputs/calendar/Calendar.tsx
@@ -101,6 +101,11 @@ export const Calendar = forwardRef(function Calendar(
   const {timeZone, zoneDateToUtc, utcToCurrentZoneDate} = useTimeZone(timeZoneScope)
   const currentTzDate = useMemo(() => utcToCurrentZoneDate(value), [utcToCurrentZoneDate, value])
   const [focusedDate, setFocusedDate] = useState<Date>(value)
+  const [prevValue, setPrevValue] = useState<Date>(value)
+  if (prevValue !== value) {
+    setPrevValue(value)
+    setFocusedDate(value)
+  }
 
   const [displayMonth, displayYear] = useMemo(() => {
     return [

--- a/packages/sanity/src/core/components/inputs/DateInputs/calendar/Calendar.tsx
+++ b/packages/sanity/src/core/components/inputs/DateInputs/calendar/Calendar.tsx
@@ -101,11 +101,6 @@ export const Calendar = forwardRef(function Calendar(
   const {timeZone, zoneDateToUtc, utcToCurrentZoneDate} = useTimeZone(timeZoneScope)
   const currentTzDate = useMemo(() => utcToCurrentZoneDate(value), [utcToCurrentZoneDate, value])
   const [focusedDate, setFocusedDate] = useState<Date>(value)
-  const [prevValue, setPrevValue] = useState<Date>(value)
-  if (prevValue !== value) {
-    setPrevValue(value)
-    setFocusedDate(value)
-  }
 
   const [displayMonth, displayYear] = useMemo(() => {
     return [
@@ -348,7 +343,12 @@ export const Calendar = forwardRef(function Calendar(
     setFocusedDateYear,
   ])
 
-  const handleNowClick = useCallback(() => onSelect(new Date()), [onSelect])
+  const handleNowClick = useCallback(() => {
+    const now = new Date()
+    onSelect(now)
+    setFocusedDate(now)
+  }, [onSelect])
+
   return (
     <Box data-testid="calendar" data-ui="Calendar" {...restProps} ref={ref}>
       {/* Select date */}

--- a/packages/sanity/src/core/components/inputs/DateInputs/calendar/__tests__/Calendar.test.tsx
+++ b/packages/sanity/src/core/components/inputs/DateInputs/calendar/__tests__/Calendar.test.tsx
@@ -195,7 +195,7 @@ describe('Calendar with stored timezone tokyo', () => {
   })
 })
 
-describe('Calendar resets displayed month when value changes', () => {
+describe('Calendar updates displayed month when user sets current time', () => {
   beforeEach(() => {
     const getKeyMock = vi.fn().mockReturnValue(of(null))
     const setKeyMock = vi.fn().mockResolvedValue(null)
@@ -203,30 +203,53 @@ describe('Calendar resets displayed month when value changes', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
-  it('updates displayed month when value prop changes', async () => {
+  it('updates displayed month when set to current time is clicked', async () => {
     const TestProvider = await createTestProvider()
+    const mockOnSelect = vi.fn()
 
     const {rerender} = render(
       <TestProvider>
-        <Calendar {...defaultProps} value={new Date('2029-04-20T10:00:00Z')} />
+        <Calendar
+          {...defaultProps}
+          selectTime
+          onSelect={mockOnSelect}
+          value={new Date('2029-04-20T10:00:00Z')}
+          timeZoneScope={{type: 'input', id: 'test'}}
+        />
       </TestProvider>,
     )
 
     // Calendar should show April 2029
     const monthSelect = screen.getByRole('combobox') as HTMLSelectElement
     expect(monthSelect).toHaveValue('3') // 0-indexed: April = 3
+    expect(screen.getByTestId('date-input')).toHaveValue('2029')
 
-    // Re-render with a new value (current-ish date)
+    // Re-rendering with a new value should not change the displayed month/year.
     rerender(
       <TestProvider>
-        <Calendar {...defaultProps} value={new Date('2024-01-15T10:00:00Z')} />
+        <Calendar
+          {...defaultProps}
+          selectTime
+          onSelect={mockOnSelect}
+          value={new Date('2024-01-15T12:34:00Z')}
+          timeZoneScope={{type: 'input', id: 'test'}}
+        />
       </TestProvider>,
     )
+    expect(monthSelect).toHaveValue('3') // 0-indexed: April = 3
+    expect(screen.getByTestId('date-input')).toHaveValue('2029')
 
-    // Calendar should now show January 2024
+    vi.useFakeTimers({toFake: ['Date']})
+    vi.setSystemTime(new Date('2024-01-15T12:34:00Z'))
+
+    await userEvent.click(screen.getByRole('button', {name: 'Set to current time'}))
+
+    expect(mockOnSelect).toHaveBeenCalledWith(new Date('2024-01-15T12:34:00Z'))
     expect(monthSelect).toHaveValue('0') // 0-indexed: January = 0
+    expect(screen.getByTestId('date-input')).toHaveValue('2024')
   })
 })

--- a/packages/sanity/src/core/components/inputs/DateInputs/calendar/__tests__/Calendar.test.tsx
+++ b/packages/sanity/src/core/components/inputs/DateInputs/calendar/__tests__/Calendar.test.tsx
@@ -194,3 +194,39 @@ describe('Calendar with stored timezone tokyo', () => {
     expect(mockOnSelect).toHaveBeenCalledWith(new Date('2024-01-19T18:30:00Z'))
   })
 })
+
+describe('Calendar resets displayed month when value changes', () => {
+  beforeEach(() => {
+    const getKeyMock = vi.fn().mockReturnValue(of(null))
+    const setKeyMock = vi.fn().mockResolvedValue(null)
+    useKeyValueStoreMock.mockReturnValue({getKey: getKeyMock, setKey: setKeyMock})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('updates displayed month when value prop changes', async () => {
+    const TestProvider = await createTestProvider()
+
+    const {rerender} = render(
+      <TestProvider>
+        <Calendar {...defaultProps} value={new Date('2029-04-20T10:00:00Z')} />
+      </TestProvider>,
+    )
+
+    // Calendar should show April 2029
+    const monthSelect = screen.getByRole('combobox') as HTMLSelectElement
+    expect(monthSelect).toHaveValue('3') // 0-indexed: April = 3
+
+    // Re-render with a new value (current-ish date)
+    rerender(
+      <TestProvider>
+        <Calendar {...defaultProps} value={new Date('2024-01-15T10:00:00Z')} />
+      </TestProvider>,
+    )
+
+    // Calendar should now show January 2024
+    expect(monthSelect).toHaveValue('0') // 0-indexed: January = 0
+  })
+})


### PR DESCRIPTION
### Description

Clicking “Set to current time” now also updates the calendar’s focused date. This keeps the displayed calendar month/year aligned with the date selected by that user action.



https://github.com/user-attachments/assets/12dfdbd3-e296-4fee-a47c-70dbc71af14b



### What to review

- The current-time button handler in `Calendar`
- The regression test covering the focused date update after clicking “Set to current time”

### Testing



### Notes for release

Fixed the date picker calendar display after using “Set to current time”.