### PR TITLE
chore: upgrade pnpm to 11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "postinstall": "husky",
     "predev:embedded-studio": "turbo run build --filter=embedded-studio^...",
     "preembedded-studio-vite:dev": "turbo run build --filter=e2e-embedded-studio-vite^...",
-    "preinstall": "npx --loglevel=silent -y only-allow pnpm",
     "prepublishOnly": "pnpm build",
     "publish:tarball": "node -r esbuild-register scripts/publish/tarball",
     "start": "pnpm dev",
@@ -130,6 +129,6 @@
       "oxfmt --no-error-on-unmatched-pattern"
     ]
   },
-  "packageManager": "pnpm@10.33.1",
+  "packageManager": "pnpm@11.0.0",
   "//": "pnpm settings moved to pnpm-workspace.yaml"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,14 +10,18 @@ packages:
   - packages/sanity
   - packages/sanity/fixtures/examples/*
 
+allowBuilds:
+  esbuild: false
+  unrs-resolver: false
+
 catalog:
   '@playwright/experimental-ct-react': 1.59.1
   '@playwright/test': 1.59.1
   '@sanity/client': ^7.21.0
-  '@sanity/migrate': ^6.1.1
-  '@sanity/telemetry': ^1.1.0
   '@sanity/eslint-config-i18n': ^2.0.0
+  '@sanity/migrate': ^6.1.1
   '@sanity/pkg-utils': ^10.4.15
+  '@sanity/telemetry': ^1.1.0
   '@sanity/ui': ^3.1.14
   '@types/node': ^24.3.0
   '@types/react': ^19.2.11
@@ -31,11 +35,6 @@ catalog:
   esbuild-register: ^3.6.0
   eslint: ^9.39.2
   globals: ^16.2.0
-  playwright: 1.59.1
-  react: ^19.2.4
-  react-dom: ^19.2.4
-  react-is: ^19.2.4
-  rimraf: ^6.1.3
   # Note: there is currently a test failure in src/core/form/inputs/files/FileInput/__tests__/fileInput.test.tsx
   # that blocks us from upgrading to jsdom@27 – once that test is passing, the jsdom override can be removed from
   # the workspace package.json.
@@ -43,19 +42,14 @@ catalog:
   # × FileInput with empty state > renders the browse button with a tooltip when it has at least one element in assetSources
   #     → Cannot create property 'border-width' on string '1px solid var(--card-border-color)'
   jsdom: ^26.1.0
+  playwright: 1.59.1
+  react: ^19.2.4
+  react-dom: ^19.2.4
+  react-is: ^19.2.4
+  rimraf: ^6.1.3
+  styled-components: npm:@sanity/styled-components@^6.1.24
   vite: ^7.3.1
   vitest: ^4.1.4
-  styled-components: npm:@sanity/styled-components@^6.1.24
-
-overrides:
-  # The e2e-ui.yml workflow needs a @sanity/ui related override in the root package.json in order for it's pnpm add -w ./artifacts/sanity-ui-*.tgz to work its magic.
-  '@sanity/ui@3': '$@sanity/ui'
-  # We are currently blocked from upgrading to jsdom 27 because of a strange build error related to the new version of
-  # cssstyle required by jsdom 27. If this error is no longer present, it's safe to remove the following override.
-  jsdom: 26.1.0
-  vitest: $vitest
-
-preferWorkspacePackages: true
 linkWorkspacePackages: deep
 
 minimumReleaseAge: 4320
@@ -82,6 +76,16 @@ minimumReleaseAgeExclude:
   - 'react-is'
   - 'react-rx'
   - 'sanity-plugin-internationalized-array'
+
+overrides:
+  # The e2e-ui.yml workflow needs a @sanity/ui related override in the root package.json in order for it's pnpm add -w ./artifacts/sanity-ui-*.tgz to work its magic.
+  '@sanity/ui@3': '$@sanity/ui'
+  # We are currently blocked from upgrading to jsdom 27 because of a strange build error related to the new version of
+  # cssstyle required by jsdom 27. If this error is no longer present, it's safe to remove the following override.
+  jsdom: 26.1.0
+  vitest: $vitest
+
+preferWorkspacePackages: true
 
 trustPolicy: no-downgrade
 


### PR DESCRIPTION
> [!IMPORTANT]
> Requires #12760


### Description

Upgrades to [pnpm@11](https://github.com/pnpm/pnpm/releases/tag/v11.0.0)

Note: the latest dist-tag still points at 10.x, so upgrades has to be done manually, see https://bsky.app/profile/pnpm.io/post/3mkkgxmxcuk2s

Also explicitly disables postinstall scripts from esbuild and unrs-resolver. Not because they are not to be trusted, but, but because I'm pretty sure we don't  _need_ them.

### What to review
Also did some housekeeping:
- `npx only-allow pnpm` is no longer needed, removed.
- pnpm-workspace.yaml got reorganized as part of pnpm writing to it, most of the diff is either just whitespace or sort order changes.

### Testing
If it runs on CI we should be good, can also be tested by checking out the branch and running pnpm install

### Notes for release

n/a