### PR TITLE
chore(ci): drop node 20 from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       # we want to know if a test fails on a specific node version
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
+        node: [22, 24]
         experimental: [false]
         shardIndex: [1, 2, 3, 4]
         shardTotal: [4]
@@ -64,7 +64,7 @@ jobs:
         run: |
           # Base arguments for all test runs
           ARGS="--test-timeout=60000 --retry 4 --shard=${{ matrix.shardIndex}}/${{ matrix.shardTotal }} --passWithNoTests"
-          if [ "${{ matrix.node }}" == "20" ]; then
+          if [ "${{ matrix.node }}" == "24" ]; then
             # We only gather coverage from a single Node version.
             # We pass in `--reporter=blob` so that we can combine the results from all shards.
             ARGS="$ARGS --coverage --reporter=default --reporter=blob"
@@ -74,7 +74,7 @@ jobs:
           GITHUB_SHARD_IDENTIFIER: ${{ matrix.shardIndex }}-${{ matrix.shardTotal }}
 
       - name: Upload blob report to GitHub Actions Artifacts
-        if: ${{ !cancelled() && matrix.node == '20' }}
+        if: ${{ !cancelled() && matrix.node == '24' }}
         uses: actions/upload-artifact@v7
         with:
           name: blob-report-${{ github.run_id }}-${{ matrix.shardIndex }}


### PR DESCRIPTION
### Description

[Node 20 will be EOL tomorrow](https://github.com/nodejs/release#release-schedule), and running unit tests against it blocks us from [upgrading to pnpm@11](https://github.com/sanity-io/sanity/pull/12759), so lets drop it from our test matrix

Note: I originally added node 25 to the test matrix, but looks like we got a job to do to update our tests: https://github.com/sanity-io/sanity/actions/runs/25109325564?pr=12760

Note: this does not mean that we are dropping node 20 support. We're just leaving it untested, but will still fix bugs reported for the engines we support. That said, think its unlikely that we'll accidentally break node 20 without also breaking 24.

### What to review
Makes sense?

### Testing
CI should be enough

### Notes for release
n/a