### PR TITLE
feat(core): variants plugin setup - default disabled

### DIFF
--- a/.agents/skills/sanity-config-reducers/SKILL.md
+++ b/.agents/skills/sanity-config-reducers/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: sanity-config-reducers
+description: Add and review Sanity config properties that are reduced across root config and plugins. Use when adding beta flags, feature config, workspace/source options, default plugin gates, or resolved Source fields in packages/sanity/src/core/config.
+---
+
+# Sanity Config Reducers
+
+## Start Here
+
+Use this skill when a config value can be supplied by root config or plugins and needs deterministic merge behavior.
+
+Inspect these files first:
+
+- `packages/sanity/src/core/config/types.ts`
+- `packages/sanity/src/core/config/configPropertyReducers.ts`
+- `packages/sanity/src/core/config/prepareConfig.tsx`
+- `packages/sanity/src/core/config/flattenConfig.ts`
+- `packages/sanity/src/core/config/resolveDefaultPlugins.ts` if the config gates default plugin injection.
+
+## Reducer Pattern
+
+Reducers usually:
+
+1. Call `flattenConfig(config, [])`.
+2. Reduce from an explicit `initialValue`.
+3. Read the property from each `innerConfig`.
+4. Ignore `undefined`.
+5. Accept only the documented type.
+6. Throw with `getPrintableType(value)` for invalid values.
+
+Config namespaces should usually be objects, even when they initially only contain one flag. This keeps room for future options without changing the public shape. For booleans, prefer `feature.enabled` and follow this shape:
+
+```ts
+export const featureEnabledReducer = (opts: {
+  config: PluginOptions
+  initialValue: boolean
+}): boolean => {
+  const {config, initialValue} = opts
+  const flattenedConfig = flattenConfig(config, [])
+
+  return flattenedConfig.reduce((acc, {config: innerConfig}) => {
+    const enabled = innerConfig.feature?.enabled
+
+    if (typeof enabled === 'undefined') return acc
+    if (typeof enabled === 'boolean') return enabled
+
+    throw new Error(
+      `Expected \`feature.enabled\` to be a boolean, but received ${getPrintableType(enabled)}`,
+    )
+  }, initialValue)
+}
+```
+
+Root config is flattened after plugin config, so root values usually win when a reducer overwrites with the latest defined value.
+
+## Types And Exposure
+
+When adding a config property:
+
+- Declare the public or internal input type in `PluginOptions`, `WorkspaceOptions`, or the relevant nested type in `types.ts`.
+- Prefer extensible object namespaces such as `beta.feature.enabled` over direct booleans such as `beta.feature`.
+- If runtime code needs the resolved value, expose it on `Source`, `Workspace`, or the relevant prepared object in `prepareConfig.tsx`.
+- Keep raw config access through `source.__internal.options` as an implementation detail, not the primary runtime API.
+
+## Default Plugin Gates
+
+Default plugin lists are computed before full source resolution. If a config value controls default plugin injection:
+
+- Compute the reduced value early enough in `prepareConfig.tsx`, before calling `getDefaultPlugins`.
+- Thread that reduced value into `getDefaultPluginsOptions` or the options passed to `getDefaultPlugins`.
+- Use the same reducer later when exposing the resolved runtime value, so gating and runtime context agree.
+- Add tests for default false/true behavior and invalid values.
+
+## Beta Flags
+
+Beta flags live under `BetaFeatures` in `types.ts` and resolved runtime values under `source.beta`.
+
+Prefer a dedicated reducer when:
+
+- Plugins can set or override the flag.
+- Invalid values should produce helpful errors.
+- The flag gates default plugin injection.
+
+Do not special-case beta flags in components by reading raw config if a resolved value can be exposed instead.
+
+## Verification
+
+Add focused config tests for:
+
+- Default value.
+- Root config value.
+- Plugin-provided value.
+- Root-over-plugin precedence when relevant.
+- Invalid namespace object error message when the top-level config is malformed.
+- Invalid nested property error message, for example when `enabled` is not the documented type.

--- a/.agents/skills/sanity-default-plugins/SKILL.md
+++ b/.agents/skills/sanity-default-plugins/SKILL.md
@@ -34,10 +34,62 @@ export const feature = definePlugin({
       layout: FeatureStudioLayout,
     },
   },
+  i18n: {
+    bundles: [featureUsEnglishLocaleBundle],
+  },
 })
 ```
 
 Use `../../config/definePlugin` when matching existing internal plugin files. `../../config` is also available in some folders.
+
+## Locale Resources
+
+Default core plugins that render UI text should add a locale resource bundle. Follow the pattern from `packages/sanity/src/core/singleDocRelease`:
+
+- `packages/sanity/src/core/<feature>/i18n/index.ts`: exports the locale namespace, US English bundle, and resource key type.
+- `packages/sanity/src/core/<feature>/i18n/resources.ts`: exports default locale strings and `keyof` resource type.
+- `packages/sanity/src/core/<feature>/plugin/index.ts`: imports the bundle and registers it under `i18n.bundles`.
+
+Example `i18n/index.ts`:
+
+```ts
+import {type LocaleResourceBundle} from '../../i18n'
+
+export const featureNamespace: 'feature' = 'feature'
+
+export const featureUsEnglishLocaleBundle: LocaleResourceBundle = {
+  locale: 'en-US',
+  namespace: featureNamespace,
+  resources: () => import('./resources'),
+}
+
+export type {FeatureLocaleResourceKeys} from './resources'
+```
+
+Example `i18n/resources.ts`:
+
+```ts
+const featureLocaleStrings = {
+  'action.example': 'Example',
+}
+
+export type FeatureLocaleResourceKeys = keyof typeof featureLocaleStrings
+
+export default featureLocaleStrings
+```
+
+Example plugin registration:
+
+```ts
+import {featureUsEnglishLocaleBundle} from '../i18n'
+
+export const feature = definePlugin({
+  name: FEATURE_NAME,
+  i18n: {
+    bundles: [featureUsEnglishLocaleBundle],
+  },
+})
+```
 
 ## Default Plugin Wiring
 

--- a/.agents/skills/sanity-default-plugins/SKILL.md
+++ b/.agents/skills/sanity-default-plugins/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: sanity-default-plugins
+description: Create and wire Sanity core plugins using the monorepo's default plugin conventions. Use when adding, modifying, or reviewing plugins under packages/sanity/src/core, especially plugins added through resolveDefaultPlugins or studio.components middleware.
+---
+
+# Sanity Core Plugin
+
+## Start Here
+
+Before adding a core plugin, read the `sanity-plugin-authoring` skill at `../sanity-plugin-authoring/SKILL.md` to understand the general Sanity plugin API and what plugins can provide. Then inspect nearby plugins and these files:
+
+- `packages/sanity/src/core/config/resolveDefaultPlugins.ts`
+- `packages/sanity/src/core/config/types.ts`
+- `packages/sanity/src/core/config/studio/types.ts`
+- A similar plugin under `packages/sanity/src/core/*/plugin/`
+
+The new plugin should be added inside `core` so it can be imported into the default plugins.
+
+Prefer local patterns over new abstractions.
+
+## Plugin Shape
+
+Use `definePlugin` and export a stable internal name constant:
+
+```ts
+import {definePlugin} from '../../config/definePlugin'
+
+export const FEATURE_NAME = 'sanity/feature'
+
+export const feature = definePlugin({
+  name: FEATURE_NAME,
+  studio: {
+    components: {
+      layout: FeatureStudioLayout,
+    },
+  },
+})
+```
+
+Use `../../config/definePlugin` when matching existing internal plugin files. `../../config` is also available in some folders.
+
+## Default Plugin Wiring
+
+Default core plugins are listed in `resolveDefaultPlugins.ts`.
+
+1. Import the plugin and its name constant.
+2. Add the plugin to `defaultPlugins(options)` in the desired composition order.
+3. If gated, add a `plugin.name === FEATURE_NAME` branch in `getDefaultPlugins`.
+4. Add any required options to `DefaultPluginsWorkspaceOptions` in `types.ts`.
+5. In `getDefaultPluginsOptions`, build default plugin options directly from workspace config defaults and spreads. Do not call config property reducers here; reducers belong to resolved source/workspace config, while default plugin options are a lightweight workspace-level input for plugin insertion.
+6. Update `packages/sanity/src/core/config/__tests__/resolveConfig.test.ts` with focused default plugin tests:
+   - The plugin is not added by default.
+   - The plugin is added when the proper config flag is enabled.
+7. Add ordering coverage when plugin order affects UI composition.
+
+Example default option shape:
+
+```ts
+variants: {
+  enabled: false,
+  ...workspace.beta?.variants,
+}
+```
+
+Remember: user plugins are appended before default plugins in `prepareConfig.tsx`, then the component middleware chain reverses flattened config order. Check the existing chain before relying on wrapper order.
+
+## Verification
+
+For default plugin changes, run:
+
+```sh
+pnpm vitest run --project=sanity packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
+```
+
+Also run lint/read diagnostics for edited files. Add component-level tests only when the plugin changes runtime rendering beyond insertion.

--- a/.agents/skills/sanity-plugin-authoring/SKILL.md
+++ b/.agents/skills/sanity-plugin-authoring/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: sanity-plugin-authoring
+description: Explain and create Sanity Studio plugins using the public plugin and tool APIs. Use when creating user-facing plugins, adding tools through plugins, or when an agent needs to understand what a Sanity plugin can configure before applying monorepo-specific default plugin wiring.
+---
+
+# Sanity Plugin Authoring
+
+## What A Plugin Is
+
+A Sanity Studio plugin is a named configuration bundle that can be added to a Studio through the `plugins` array. Plugin configuration accepts most workspace config properties, except workspace-owned settings such as `dataset`, `projectId`, `auth`, and `theme`.
+
+Always give plugins a stable unique `name`. Prefer `definePlugin()` so editors expose useful types and autocomplete.
+
+```ts
+import {definePlugin} from 'sanity'
+
+export const previewUrlPlugin = definePlugin({
+  name: 'preview-url-plugin',
+  document: {
+    productionUrl: async (prev, {document}) => {
+      const slug = document.slug?.current
+      return slug ? `https://example.com/${slug}` : prev
+    },
+  },
+})
+```
+
+## Configurable Plugins
+
+Use `definePlugin((options) => ({...}))` when callers need to configure behavior.
+
+```ts
+export const myPlugin = definePlugin<{enabled?: boolean}>((options) => ({
+  name: 'my-plugin',
+  tools: options.enabled === false ? [] : [myTool],
+}))
+```
+
+Keep option namespaces extensible. Prefer object shapes such as `{feature: {enabled: true}}` instead of direct booleans when future settings are likely.
+
+## What Plugins Can Provide
+
+Common plugin properties:
+
+- `document`: Document actions, badges, production URL resolvers, and new document defaults.
+- `form`: Form customizations, asset sources, and custom input rendering.
+- `plugins`: Nested plugins.
+- `tools`: Studio tools contributed by the plugin.
+- `schema`: Schema types and initial value templates.
+- `studio`: Studio component overrides and middleware.
+- `title`: Human-readable plugin name.
+- `onUncaughtError`: Custom error handling, logging, or telemetry.
+
+Use the smallest surface that solves the feature.
+
+## Tools In Plugins
+
+A tool is a top-level Studio view with routing and predictable URLs. Tools commonly represent full-screen workflows such as Structure, Vision, Dashboard, or Presentation.
+
+When adding a tool through a plugin:
+
+- Add it through the plugin `tools` property.
+- Give it a stable `name`, `title`, `component`, and router when needed.
+- Remember tool visual order is affected by the order tools are added, followed by tools added through plugins.
+- Use `studio.components.toolMenu` when the visual menu order needs custom rendering.
+- Use the top-level `tools` reducer pattern when changing the default opened tool, because visual menu order alone does not choose the default route.
+
+## Studio Components
+
+`studio.components` can customize parts of the Studio UI. Components that receive `renderDefault` are middleware: call `props.renderDefault(props)` unless intentionally replacing the default UI.
+
+Use this for UI wrappers, navigation changes, or tool menu ordering. Be careful not to change scroll containers or layout ownership accidentally.
+
+## Before Coding
+
+1. Identify whether the feature is a plugin, a tool, a schema extension, a form extension, or a document extension.
+2. Check existing plugin examples in the repo.
+3. Choose a stable plugin name.
+4. Decide whether the plugin needs options.
+5. Add focused tests for the configured behavior.
+
+For Sanity monorepo default plugin wiring, read `sanity-core-plugin` after this skill.
+
+## References
+
+- [Sanity Studio Plugins](https://www.sanity.io/docs/studio/studio-plugins)
+- [Sanity Plugins API](https://www.sanity.io/docs/studio/plugins-api-reference)
+- [Sanity Studio Tools](https://www.sanity.io/docs/studio/studio-tools)
+- [Sanity Tools Cheat Sheet](https://www.sanity.io/docs/studio/tools-cheat-sheet)

--- a/.agents/skills/sanity-plugin-authoring/SKILL.md
+++ b/.agents/skills/sanity-plugin-authoring/SKILL.md
@@ -48,6 +48,7 @@ Common plugin properties:
 - `tools`: Studio tools contributed by the plugin.
 - `schema`: Schema types and initial value templates.
 - `studio`: Studio component overrides and middleware.
+- `i18n`: Locale resource bundles used by plugin UI.
 - `title`: Human-readable plugin name.
 - `onUncaughtError`: Custom error handling, logging, or telemetry.
 
@@ -70,6 +71,60 @@ When adding a tool through a plugin:
 `studio.components` can customize parts of the Studio UI. Components that receive `renderDefault` are middleware: call `props.renderDefault(props)` unless intentionally replacing the default UI.
 
 Use this for UI wrappers, navigation changes, or tool menu ordering. Be careful not to change scroll containers or layout ownership accidentally.
+
+## Locale Resources
+
+If a plugin renders UI text, add an `i18n` bundle instead of hard-coding user-facing strings. The usual file shape is:
+
+```txt
+feature/
+├── i18n/
+│   ├── index.ts
+│   └── resources.ts
+└── plugin/
+    └── index.ts
+```
+
+In `i18n/index.ts`, define a namespace and default US English bundle:
+
+```ts
+import {type LocaleResourceBundle} from '../../i18n'
+
+export const featureNamespace: 'feature' = 'feature'
+
+export const featureUsEnglishLocaleBundle: LocaleResourceBundle = {
+  locale: 'en-US',
+  namespace: featureNamespace,
+  resources: () => import('./resources'),
+}
+
+export type {FeatureLocaleResourceKeys} from './resources'
+```
+
+In `i18n/resources.ts`, export the default strings and key type:
+
+```ts
+const featureLocaleStrings = {
+  'action.example': 'Example',
+}
+
+export type FeatureLocaleResourceKeys = keyof typeof featureLocaleStrings
+
+export default featureLocaleStrings
+```
+
+Then register the bundle from the plugin:
+
+```ts
+import {featureUsEnglishLocaleBundle} from '../i18n'
+
+export const feature = definePlugin({
+  name: 'sanity/feature',
+  i18n: {
+    bundles: [featureUsEnglishLocaleBundle],
+  },
+})
+```
 
 ## Before Coding
 

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -292,6 +292,11 @@ const defaultWorkspace = defineConfig({
       return prev
     },
   },
+  beta: {
+    variants: {
+      enabled: true,
+    },
+  },
 })
 
 export default defineConfig([

--- a/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
+++ b/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
@@ -4,6 +4,7 @@ import {bufferTime} from 'rxjs/operators'
 import {describe, expect, it} from 'vitest'
 
 import {createMockAuthStore} from '../../store'
+import {VARIANTS_NAME} from '../../variants/plugin'
 import {definePlugin} from '../definePlugin'
 import {createSourceFromConfig, createWorkspaceFromConfig, resolveConfig} from '../resolveConfig'
 import {type PluginOptions} from '../types'
@@ -169,6 +170,53 @@ describe('resolveConfig', () => {
       {name: 'sanity/schedules'},
       {name: 'sanity/singleDocRelease'},
     ])
+  })
+  it('wont include variants default plugin by default', async () => {
+    const projectId = 'ppsg7ml5'
+    const dataset = 'production'
+    const client = createClient({
+      projectId,
+      apiVersion: '2021-06-07',
+      dataset,
+      useCdn: false,
+    })
+    const [workspace] = await firstValueFrom(
+      resolveConfig({
+        name: 'default',
+        dataset,
+        projectId,
+        auth: createMockAuthStore({client, currentUser: null}),
+        plugins: [], // No plugins
+      }),
+    )
+    const pluginNames = workspace.__internal.options.plugins?.map((p) => p.name) ?? []
+    expect(pluginNames).not.toContain(VARIANTS_NAME)
+  })
+  it('includes variants default plugin when the feature is enabled', async () => {
+    const projectId = 'ppsg7ml5'
+    const dataset = 'production'
+    const client = createClient({
+      projectId,
+      apiVersion: '2021-06-07',
+      dataset,
+      useCdn: false,
+    })
+    const [workspace] = await firstValueFrom(
+      resolveConfig({
+        name: 'default',
+        dataset,
+        projectId,
+        auth: createMockAuthStore({client, currentUser: null}),
+        plugins: [], // No plugins
+        beta: {
+          variants: {
+            enabled: true,
+          },
+        },
+      }),
+    )
+    const pluginNames = workspace.__internal.options.plugins?.map((p) => p.name) ?? []
+    expect(pluginNames).toContain(VARIANTS_NAME)
   })
   it('wont include releases plugin if the feature is disabled', async () => {
     const projectId = 'ppsg7ml5'

--- a/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
+++ b/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
@@ -378,6 +378,86 @@ describe('createSourceFromConfig', () => {
   })
 })
 
+describe('beta variants config', () => {
+  const projectId = 'ppsg7ml5'
+  const dataset = 'production'
+
+  it('defaults variants to false', async () => {
+    const source = await createSourceFromConfig({projectId, dataset})
+
+    expect(source.beta?.variants?.enabled).toBe(false)
+  })
+
+  it('resolves variants from root config', async () => {
+    const source = await createSourceFromConfig({
+      projectId,
+      dataset,
+      beta: {variants: {enabled: true}},
+    })
+
+    expect(source.beta?.variants?.enabled).toBe(true)
+  })
+
+  it('resolves variants from plugin config', async () => {
+    const source = await createSourceFromConfig({
+      projectId,
+      dataset,
+      plugins: [
+        definePlugin({
+          name: 'sanity/beta-variants',
+          beta: {variants: {enabled: true}},
+        })(),
+      ],
+    })
+
+    expect(source.beta?.variants?.enabled).toBe(true)
+  })
+
+  it('lets root config override plugin variants config', async () => {
+    const source = await createSourceFromConfig({
+      projectId,
+      dataset,
+      plugins: [
+        definePlugin({
+          name: 'sanity/beta-variants',
+          beta: {variants: {enabled: false}},
+        })(),
+      ],
+      beta: {variants: {enabled: true}},
+    })
+
+    expect(source.beta?.variants?.enabled).toBe(true)
+  })
+
+  it('throws when variants is not an object', async () => {
+    await expect(
+      createSourceFromConfig({
+        projectId,
+        dataset,
+        beta: {
+          // @ts-expect-error should be an object
+          variants: 'enabled',
+        },
+      }),
+    ).rejects.toThrow('Expected `beta.variants` to be an object, but received string')
+  })
+
+  it('throws when variants enabled is not a boolean', async () => {
+    await expect(
+      createSourceFromConfig({
+        projectId,
+        dataset,
+        beta: {
+          variants: {
+            // @ts-expect-error should be a boolean
+            enabled: 'enabled',
+          },
+        },
+      }),
+    ).rejects.toThrow('Expected `beta.variants.enabled` to be a boolean, but received string')
+  })
+})
+
 describe('search strategy selection', () => {
   const projectId = 'ppsg7ml5'
   const dataset = 'production'

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -10,6 +10,7 @@ import {type ErrorInfo, type ReactNode} from 'react'
 import {type LocaleConfigContext, type LocaleDefinition, type LocaleResourceBundle} from '../i18n'
 import {type Template, type TemplateItem} from '../templates'
 import {getPrintableType} from '../util/getPrintableType'
+import {isRecord} from '../util/isRecord'
 import {
   type DocumentActionComponent,
   type DocumentBadgeComponent,
@@ -453,6 +454,38 @@ export const eventsAPIReducer = (opts: {
 
     throw new Error(
       `Expected \`beta.eventsAPI.${opts.key}\` to be a boolean, but received ${getPrintableType(
+        enabled,
+      )}`,
+    )
+  }, initialValue)
+
+  return result
+}
+
+export const variantsEnabledReducer = (opts: {
+  config: PluginOptions
+  initialValue: boolean
+}): boolean => {
+  const {config, initialValue} = opts
+  const flattenedConfig = flattenConfig(config, [])
+
+  const result = flattenedConfig.reduce((acc: boolean, {config: innerConfig}) => {
+    const variants: unknown = innerConfig.beta?.variants
+
+    if (typeof variants === 'undefined') return acc
+    if (!isRecord(variants)) {
+      throw new Error(
+        `Expected \`beta.variants\` to be an object, but received ${getPrintableType(variants)}`,
+      )
+    }
+
+    const enabled = variants.enabled
+
+    if (typeof enabled === 'undefined') return acc
+    if (typeof enabled === 'boolean') return enabled
+
+    throw new Error(
+      `Expected \`beta.variants.enabled\` to be a boolean, but received ${getPrintableType(
         enabled,
       )}`,
     )

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -62,6 +62,7 @@ import {
   searchStrategyReducer,
   serverDocumentActionsReducer,
   toolsReducer,
+  variantsEnabledReducer,
 } from './configPropertyReducers'
 import {ConfigResolutionError} from './ConfigResolutionError'
 import {recordConfigWarning} from './configWarnings'
@@ -865,6 +866,9 @@ function resolveSource({
       eventsAPI: {
         documents: eventsAPIReducer({config, initialValue: true, key: 'documents'}),
         releases: eventsAPIReducer({config, initialValue: false, key: 'releases'}),
+      },
+      variants: {
+        enabled: variantsEnabledReducer({config, initialValue: false}),
       },
     },
     // eslint-disable-next-line camelcase

--- a/packages/sanity/src/core/config/resolveDefaultPlugins.ts
+++ b/packages/sanity/src/core/config/resolveDefaultPlugins.ts
@@ -7,6 +7,7 @@ import {SCHEDULED_PUBLISHING_NAME, scheduledPublishing} from '../scheduled-publi
 import {schedules, SCHEDULES_NAME} from '../schedules/plugin'
 import {SINGLE_DOC_RELEASE_NAME, singleDocRelease} from '../singleDocRelease/plugin'
 import {tasks, TASKS_NAME} from '../tasks/plugin'
+import {variants, VARIANTS_NAME} from '../variants/plugin'
 import {
   type AppsOptions,
   type DefaultPluginsWorkspaceOptions,
@@ -16,6 +17,7 @@ import {
 } from './types'
 
 const defaultPlugins = (options: DefaultPluginsOptions) => [
+  variants(),
   comments(),
   tasks(),
   scheduledPublishing(),
@@ -32,6 +34,9 @@ type DefaultPluginsOptions = DefaultPluginsWorkspaceOptions & {
 
 export function getDefaultPlugins(options: DefaultPluginsOptions, plugins?: PluginOptions[]) {
   return defaultPlugins(options).filter((plugin) => {
+    if (plugin.name === VARIANTS_NAME) {
+      return options.variants.enabled
+    }
     if (plugin.name === SCHEDULED_PUBLISHING_NAME) {
       // The scheduled publishing plugin is only included if other plugin is included by the user.
       return options.scheduledPublishing.enabled && !!plugins?.length
@@ -91,5 +96,9 @@ export function getDefaultPluginsOptions(
     },
     mediaLibrary: workspace?.mediaLibrary,
     scheduledDrafts: workspace.scheduledDrafts ?? {enabled: true},
+    variants: {
+      enabled: false,
+      ...workspace.beta?.variants,
+    },
   }
 }

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -1255,6 +1255,7 @@ export type {
 export type DefaultPluginsWorkspaceOptions = {
   tasks: {enabled: boolean}
   scheduledDrafts: {enabled: boolean}
+  variants: {enabled: boolean}
   scheduledPublishing: ScheduledPublishingPluginOptions
   releases: {
     enabled?: boolean

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -1358,4 +1358,10 @@ export interface BetaFeatures {
     documents?: boolean
     releases?: boolean
   }
+  /**
+   * Config for variants beta features in Studio.
+   */
+  variants?: {
+    enabled?: boolean
+  }
 }

--- a/packages/sanity/src/core/perspective/navbar/ReleasesNav.tsx
+++ b/packages/sanity/src/core/perspective/navbar/ReleasesNav.tsx
@@ -39,17 +39,28 @@ const ReleasesNavContainer = styled(Card)`
 interface Props {
   withReleasesToolButton?: boolean
   menuItemProps?: ReleasesNavMenuItemPropsGetter
+  border?: boolean
 }
 
 /**
  * @internal
  */
-export const ReleasesNav: ComponentType<Props> = ({withReleasesToolButton, menuItemProps}) => {
+export const ReleasesNav: ComponentType<Props> = ({
+  withReleasesToolButton,
+  menuItemProps,
+  border = true,
+}) => {
   const releasesToolAvailable = useReleasesToolAvailable()
   const isReleasesEnabled = !!useWorkspace().releases?.enabled
   const {selectedPerspective, selectedPerspectiveName} = usePerspective()
   return (
-    <ReleasesNavContainer flex="none" tone="inherit" radius="full" data-ui="ReleasesNav" border>
+    <ReleasesNavContainer
+      flex="none"
+      tone="inherit"
+      radius="full"
+      data-ui="ReleasesNav"
+      border={border}
+    >
       {withReleasesToolButton && releasesToolAvailable && <ReleasesToolLink />}
       <CurrentGlobalPerspectiveLabel selectedPerspective={selectedPerspective} />
       <GlobalPerspectiveMenu

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -68,7 +68,7 @@ const NavGrid = styled(Grid)`
 export function StudioNavbar(props: Omit<NavbarProps, 'renderDefault'>) {
   const {__internal_actions: actions = EMPTY_ARRAY} = props
 
-  const {name, tools} = useWorkspace()
+  const {beta, name, tools} = useWorkspace()
   const routerState = useRouterState()
   const mediaIndex = useMediaIndex()
   const activeToolName = typeof routerState.tool === 'string' ? routerState.tool : undefined
@@ -270,7 +270,7 @@ export function StudioNavbar(props: Omit<NavbarProps, 'renderDefault'>) {
                   </SearchProvider>
                 </LayerProvider>
 
-                <ReleasesNav withReleasesToolButton />
+                {!beta?.variants?.enabled && <ReleasesNav withReleasesToolButton />}
                 {actionNodes}
                 {shouldRender.tools && <FreeTrial type="topbar" />}
                 <PresenceMenu />

--- a/packages/sanity/src/core/variants/i18n/index.ts
+++ b/packages/sanity/src/core/variants/i18n/index.ts
@@ -1,0 +1,28 @@
+import {type LocaleResourceBundle} from '../../i18n'
+
+/**
+ * The locale namespace for variants.
+ *
+ * @internal
+ */
+// oxlint-disable-next-line prefer-as-const
+export const variantsLocaleNamespace: 'variants' = 'variants'
+
+/**
+ * The default locale resource for variants, which is US English.
+ *
+ * @internal
+ */
+export const variantsUsEnglishLocaleBundle: LocaleResourceBundle = {
+  locale: 'en-US',
+  namespace: variantsLocaleNamespace,
+  resources: () => import('./resources'),
+}
+
+/**
+ * The locale resource keys for variants.
+ *
+ * @alpha
+ * @hidden
+ */
+export type {VariantsLocaleResourceKeys} from './resources'

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -1,0 +1,18 @@
+/**
+ * Defined locale strings for variants, in US English.
+ *
+ * @internal
+ */
+const variantsLocaleStrings = {
+  /** Label for the variants navigation row. */
+  'navbar.view-as': 'View as',
+  /** Label for the version selector in the variants navigation row. */
+  'navbar.version': 'Version',
+}
+
+/**
+ * @alpha
+ */
+export type VariantsLocaleResourceKeys = keyof typeof variantsLocaleStrings
+
+export default variantsLocaleStrings

--- a/packages/sanity/src/core/variants/plugin/components/VariantsStudioNavbar.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/VariantsStudioNavbar.tsx
@@ -1,0 +1,50 @@
+import {Card, Flex, Text} from '@sanity/ui'
+import {styled} from 'styled-components'
+
+import {type NavbarProps} from '../../../config/studio/types'
+import {useTranslation} from '../../../i18n'
+import {ReleasesNav} from '../../../perspective/navbar/ReleasesNav'
+import {usePerspective} from '../../../perspective/usePerspective'
+import {getReleaseTone} from '../../../releases/util/getReleaseTone'
+import {variantsLocaleNamespace} from '../../i18n'
+
+const ReleaseNavContainer = styled(Card)`
+  /* overflow: hidden; */
+
+  // Reset the margin for the releases nav
+  [data-ui='ReleasesNav'] {
+    margin: 0;
+  }
+`
+export function VariantsStudioNavbar(props: NavbarProps) {
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const {selectedPerspective} = usePerspective()
+
+  return (
+    <Flex direction="column">
+      {props.renderDefault(props)}
+      <Card tone="neutral" paddingY={2} paddingX={3} borderBottom>
+        <Flex justify="center" align="center" gap={2}>
+          <Text weight="medium" size={1}>
+            {t('navbar.view-as')}
+          </Text>
+          <ReleaseNavContainer
+            tone={getReleaseTone(selectedPerspective)}
+            border
+            radius={4}
+            paddingLeft={1}
+          >
+            <Flex marginLeft={1}>
+              <Card borderRight tone="inherit">
+                <Flex align="center" paddingX={2} height={'fill'}>
+                  <Text size={1}>{t('navbar.version')}</Text>
+                </Flex>
+              </Card>
+              <ReleasesNav withReleasesToolButton border={false} />
+            </Flex>
+          </ReleaseNavContainer>
+        </Flex>
+      </Card>
+    </Flex>
+  )
+}

--- a/packages/sanity/src/core/variants/plugin/index.tsx
+++ b/packages/sanity/src/core/variants/plugin/index.tsx
@@ -1,0 +1,13 @@
+import {definePlugin} from '../../config/definePlugin'
+
+/**
+ * @internal
+ */
+export const VARIANTS_NAME = 'sanity/variants'
+
+/**
+ * @internal
+ */
+export const variants = definePlugin({
+  name: VARIANTS_NAME,
+})

--- a/packages/sanity/src/core/variants/plugin/index.tsx
+++ b/packages/sanity/src/core/variants/plugin/index.tsx
@@ -1,5 +1,6 @@
 import {definePlugin} from '../../config/definePlugin'
-
+import {variantsUsEnglishLocaleBundle} from '../i18n'
+import {VariantsStudioNavbar} from './components/VariantsStudioNavbar'
 /**
  * @internal
  */
@@ -10,4 +11,12 @@ export const VARIANTS_NAME = 'sanity/variants'
  */
 export const variants = definePlugin({
   name: VARIANTS_NAME,
+  studio: {
+    components: {
+      navbar: VariantsStudioNavbar,
+    },
+  },
+  i18n: {
+    bundles: [variantsUsEnglishLocaleBundle],
+  },
 })


### PR DESCRIPTION
### Description

This sets up the initial scaffolding for the new default `variants` plugin behind `beta.variants.enabled`. The flag is off by default, so the new navbar and variants plugin path should not be visible unless a Studio explicitly opts in.

If enabled, the users will see the new navbar, this will allow us to start testing the navbar with the opt in users.
<img width="1340" height="996" alt="Screenshot 2026-04-29 at 18 54 34" src="https://github.com/user-attachments/assets/77aad0e5-82c9-4e05-ba57-93d7158259d9" />

This also adds a few repo-local agent skills that document plugin authoring, default plugin wiring, and config reducer patterns so future agents have the relevant Sanity conventions in-context before making similar changes.


### What to review

- The `beta.variants.enabled` config shape and default plugin gating.
- The `variants` plugin navbar behavior and `ReleasesNav` integration.
- The resolver tests proving the plugin is absent by default and present only when enabled.

### Testing

- Added/updated config resolution coverage in `packages/sanity/src/core/config/__tests__/resolveConfig.test.ts`.
- Verified with:
  - `pnpm vitest run --project=sanity packages/sanity/src/core/config/__tests__/resolveConfig.test.ts`

### Notes for release

N/A – Initial scaffolding behind a disabled feature flag.