### PR TITLE
chore: remove pre-commit husky hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-pnpm lint-staged

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,8 @@ packages:
 
 allowBuilds:
   esbuild: false
+  # we run lefthook install as a postinstall in our own workspace package.json
+  lefthook: false
   unrs-resolver: false
 
 catalog:


### PR DESCRIPTION
### Description
Two cleanups after #12755:

- Removes `.husky` folder
- Denies lefthook's postinstall script (we don't need it as we install it via postinstall in our own package.json)

### What to review
Makes sense?

### Testing
n/a

### Notes for release
n/a