### PR TITLE
chore(ci): switch to package build for lefthook

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "perf:studio": "cd perf/studio && pnpm preview",
     "perf:studio:build": "pnpm build --filter=perf-studio",
     "perf:studio:dev": "cd perf/studio && pnpm dev",
-    "postinstall": "lefthook install --reset-hooks-path",
     "predev:embedded-studio": "turbo run build --filter=embedded-studio^...",
     "preembedded-studio-vite:dev": "turbo run build --filter=e2e-embedded-studio-vite^...",
     "prepublishOnly": "pnpm build",
@@ -118,15 +117,6 @@
     "typedoc": "^0.28.16",
     "vercel": "^48.12.1",
     "vitest": "catalog:"
-  },
-  "lint-staged": {
-    "*.{js,jsx,ts,tsx,mjs,cjs}": [
-      "oxfmt --no-error-on-unmatched-pattern",
-      "oxlint --disable-nested-config --type-aware --fix --quiet"
-    ],
-    "*.{md,yml,yaml,css,json}": [
-      "oxfmt --no-error-on-unmatched-pattern"
-    ]
   },
   "packageManager": "pnpm@11.0.0",
   "//": "pnpm settings moved to pnpm-workspace.yaml"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,8 +12,7 @@ packages:
 
 allowBuilds:
   esbuild: false
-  # we run lefthook install as a postinstall in our own workspace package.json
-  lefthook: false
+  lefthook: true
   unrs-resolver: false
 
 catalog:


### PR DESCRIPTION
### Description
Turns out I was wrong here: https://github.com/sanity-io/sanity/pull/12766#discussion_r3167502691 – Lefthook's own postinstall script also checks if CI var is set, and then skips installing the hook. Instead of doing env checking in our poistinstall in our workspace package.json, we might as well use the lefthook postinstall instead. So this PR enables it and removes the postinstall script from our own package.json.

### What to review
- Also saw that the lint-staged config was still floating around, so removed that as well.

### Testing
CI should be enough

### Notes for release

n/a