### PR TITLE
feat(core): make document action keys extensible via declaration merging

### DIFF
--- a/packages/sanity/src/core/config/document/actions.ts
+++ b/packages/sanity/src/core/config/document/actions.ts
@@ -22,21 +22,7 @@ export interface DocumentActionProps extends EditStateFor {
   initialValueResolved: boolean
 }
 
-type SanityDefinedAction =
-  | 'delete'
-  | 'discardChanges'
-  | 'discardVersion'
-  | 'duplicate'
-  | 'restore'
-  | 'publish'
-  | 'unpublish'
-  | 'unpublishVersion'
-  | 'linkToCanvas'
-  | 'editInCanvas'
-  | 'unlinkFromCanvas'
-  | 'schedule'
-
-const SANITY_DEFINED_ACTIONS: Record<SanityDefinedAction, SanityDefinedAction> = {
+const SANITY_DEFINED_ACTIONS = {
   delete: 'delete',
   discardChanges: 'discardChanges',
   discardVersion: 'discardVersion',
@@ -52,17 +38,53 @@ const SANITY_DEFINED_ACTIONS: Record<SanityDefinedAction, SanityDefinedAction> =
 }
 
 /**
- * @beta
- * Indicates whether the action is a Sanity defined action or a custom action.
+ * Union of action identifiers built into Sanity. Use for exhaustive matching
+ * over built-in actions.
+ *
+ * @public
+ */
+export type SanityDefinedAction = keyof typeof SANITY_DEFINED_ACTIONS
+
+/**
+ * Registry of document action keys. Extend via declaration merging to
+ * register a custom action key. Use `never` as the value type; the values
+ * are unused, and indexed access (`DocumentActionKeys[K]`) is not part of
+ * the public contract.
+ *
+ * ```ts
+ * declare module 'sanity' {
+ *   interface DocumentActionKeys {
+ *     myPlugin: never
+ *   }
+ * }
+ * ```
+ *
+ * Once registered, `MyAction.action = 'myPlugin'` type-checks, and other
+ * plugins can target the action for replacement.
+ *
+ * To match only Sanity-defined actions exhaustively, narrow with
+ * `isSanityDefinedAction`.
+ *
+ * @public
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- empty by design; extended via declaration merging
+export interface DocumentActionKeys extends Record<SanityDefinedAction, never> {}
+
+/**
+ * Narrow an action's identifier to {@link SanityDefinedAction}. Use to
+ * exhaustively match built-in actions in projects where plugins have
+ * registered additional keys.
  *
  * @param action - The action to check.
- * @returns `true` if the action is a Sanity defined action, `false` otherwise.
+ * @returns `true` if the action identifier is Sanity-defined.
+ *
+ * @public
  */
 export const isSanityDefinedAction = (
-  action: DocumentActionDescription & {action?: DocumentActionComponent['action']},
-): boolean => {
+  action: DocumentActionDescription & {action?: keyof DocumentActionKeys},
+): action is DocumentActionDescription & {action: SanityDefinedAction} => {
   if (!action.action) return false
-  return SANITY_DEFINED_ACTIONS[action.action] !== undefined
+  return action.action in SANITY_DEFINED_ACTIONS
 }
 
 /**
@@ -73,10 +95,12 @@ export interface DocumentActionComponent extends ActionComponent<
   DocumentActionDescription
 > {
   /**
-   * An optional meta property that can used to replace this document action
-   * with another. E.g.:
+   * Stable identifier for this action. Set to a {@link SanityDefinedAction}
+   * to replace a built-in, or to a key registered on
+   * {@link DocumentActionKeys} via declaration merging so other plugins can
+   * target the action for replacement.
    *
-   * ```js
+   * ```ts
    * import {defineConfig} from 'sanity'
    * import {MyPublishAction} from '...'
    *
@@ -84,13 +108,13 @@ export interface DocumentActionComponent extends ActionComponent<
    *   document: {
    *     actions: (prev) =>
    *       prev.map((previousAction) =>
-   *         previousAction.action === 'publish' ? MyPublishAction : previousAction
+   *         previousAction.action === 'publish' ? MyPublishAction : previousAction,
    *       ),
    *   },
    * })
    * ```
    */
-  action?: SanityDefinedAction
+  action?: keyof DocumentActionKeys
   /**
    * For debugging purposes
    */


### PR DESCRIPTION
### Description

Plugin authors who set `MyAction.action = 'myPlugin'` got a TypeScript error because the field was a closed union of Sanity built-ins. This PR converts the field into an extensible registry. Plugins extend `DocumentActionKeys` via declaration merging to register their own keys.

Closes [#4863](https://github.com/sanity-io/sanity/issues/4863).

### What to review

One file: `packages/sanity/src/core/config/document/actions.ts`. Verify:

- `SANITY_DEFINED_ACTIONS` runtime const is unchanged
- `SanityDefinedAction` is now derived via `keyof typeof SANITY_DEFINED_ACTIONS` and exported `@public`
- `DocumentActionKeys` is a new `@public` interface seeded with built-ins; plugin authors merge into it
- `isSanityDefinedAction` is now a type predicate, narrows to `SanityDefinedAction`
- `DocumentActionComponent.action` accepts `keyof DocumentActionKeys`

No other source files need changes. Internal arrays typed as `DocumentActionComponent['action'][]` (in `canvasIntegrationPlugin.ts`, `structureTool.ts`, `DocumentActionsProvider.tsx`) keep working because the widened element type matches their `.includes()` inputs.

### Testing

- `pnpm check:types` passes
- `pnpm test:exports` passes (2,844 type-level tests)
- Verified the issue reporter's exact code type-checks after declaration merging
- Verified that without the merge, the assignment still errors as before
- No new unit tests: change is a type-system refactor with zero runtime change

### Notes for release

Three new `@public` exports:

- `SanityDefinedAction` - union of Sanity-defined action identifiers
- `DocumentActionKeys` - extend via declaration merging to register custom keys
- `isSanityDefinedAction` - now a type predicate, narrows to `SanityDefinedAction`

Register a custom action key:

```ts
declare module 'sanity' {
  interface DocumentActionKeys {
    myPlugin: never
  }
}

const MyAction: DocumentActionComponent = (props) => null
MyAction.action = 'myPlugin' // type-checks
```

Recover exhaustive matching over built-ins:

```ts
if (isSanityDefinedAction(action)) {
  switch (action.action) {
    case 'publish': /* ... */ break
    // exhaustive over SanityDefinedAction
  }
}
```

A docs page on extending action keys would help plugin authors discover this. Flagging for the docs team as a follow-up.