### PR TITLE
fix(core): include versions in consistency status validation

### DIFF
--- a/packages/sanity/src/core/store/document/document-pair/consistencyStatus.ts
+++ b/packages/sanity/src/core/store/document/document-pair/consistencyStatus.ts
@@ -1,5 +1,5 @@
 import {type SanityClient} from '@sanity/client'
-import {combineLatest, type Observable} from 'rxjs'
+import {combineLatest, of, type Observable} from 'rxjs'
 import {distinctUntilChanged, map, publishReplay, refCount, switchMap} from 'rxjs/operators'
 
 import {type DocumentStoreExtraOptions} from '../getPairListener'
@@ -25,11 +25,16 @@ export const consistencyStatus: (
     extraOptions?: DocumentStoreExtraOptions,
   ) => {
     return memoizedPair(client, idPair, typeName, serverActionsEnabled, extraOptions).pipe(
-      switchMap(({draft, published}) =>
-        combineLatest([draft.consistency$, published.consistency$]),
+      switchMap(({draft, published, version}) =>
+        combineLatest([
+          draft.consistency$,
+          published.consistency$,
+          version?.consistency$ ?? of(true),
+        ]),
       ),
       map(
-        ([draftIsConsistent, publishedIsConsistent]) => draftIsConsistent && publishedIsConsistent,
+        ([draftIsConsistent, publishedIsConsistent, versionIsConsistent]) =>
+          draftIsConsistent && publishedIsConsistent && versionIsConsistent,
       ),
       distinctUntilChanged(),
       publishReplay(1),

--- a/packages/sanity/src/core/store/document/document-pair/operationEvents.ts
+++ b/packages/sanity/src/core/store/document/document-pair/operationEvents.ts
@@ -168,6 +168,7 @@ export const operationEvents = memoize(
                 if (requiresConsistency) {
                   operationArguments.published.commit()
                   operationArguments.draft.commit()
+                  operationArguments.version?.commit()
                 }
                 const isConsistent$ = consistencyStatus(
                   ctx.client,


### PR DESCRIPTION
### Description

Versions haven't been included in the `consistency` check, this has the side effect of the syncing and saved status line not showing in the version documents.
See this example in `next` , editing the document doesn't show the `saving` status

https://github.com/user-attachments/assets/5c0204ab-aa13-436d-8688-052f503c784a


With this fix, now the versions work the same as drafts or published, in were after doing changes you see a `saving` status and then a `saved` when it finished.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open a version document, editing the document should trigger the syncing status. 

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Version documents now show the **saving**  and **saved** when editing them.
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
