### PR TITLE
fix(core): add version into documentEvents observable

### DIFF
--- a/packages/sanity/src/core/store/document/document-pair/documentEvents.ts
+++ b/packages/sanity/src/core/store/document/document-pair/documentEvents.ts
@@ -1,5 +1,5 @@
 import {type SanityClient} from '@sanity/client'
-import {merge, type Observable} from 'rxjs'
+import {EMPTY, merge, type Observable} from 'rxjs'
 import {switchMap} from 'rxjs/operators'
 
 import {type DocumentStoreExtraOptions} from '../getPairListener'
@@ -20,7 +20,9 @@ export const documentEvents = memoize(
     pairListenerOptions?: DocumentStoreExtraOptions,
   ): Observable<DocumentVersionEvent> => {
     return memoizedPair(client, idPair, typeName, serverActionsEnabled, pairListenerOptions).pipe(
-      switchMap(({draft, published}) => merge(draft.events, published.events)),
+      switchMap(({draft, published, version}) =>
+        merge(draft.events, published.events, version?.events ?? EMPTY),
+      ),
     )
   },
   memoizeKeyGen,


### PR DESCRIPTION
### Description
Includes versions in the document events observable.
Without the version stream, editing in a release perspective could miss mutation/rebase events for the release document, so the form patch channel would not be notified correctly for remote changes or rebases on that version.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
include version in document events observable. 
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
