### PR TITLE
fix(comments): hide empty field wrapper when field component is hidden

### DIFF
--- a/packages/sanity/src/core/comments/plugin/field/CommentsField.tsx
+++ b/packages/sanity/src/core/comments/plugin/field/CommentsField.tsx
@@ -76,6 +76,13 @@ const HighlightDiv = styled(motion.div)(({theme}) => {
 
 const FieldStack = styled(Stack)`
   position: relative;
+
+  // Hide when the field component renders nothing (e.g. a custom
+  // field component that returns null) to avoid an empty wrapper
+  // taking up space in the form.
+  &:empty:not([hidden]) {
+    display: none;
+  }
 `
 
 function CommentFieldInner(


### PR DESCRIPTION
### Description

This pull request fixes a small issue where the comments field wrapper is still visible even when the original field component is hidden, causing unwanted space in the form.

How to reproduce:

1. Hide a field using `components.field` by returning `null`.
2. Notice how the field is hidden, but the comments field wrapper is still in the DOM, taking up unwanted space in the form.

See image below where two fields have been hidden in the middle of the form. To the left shows the comments field wrappers taking up space, right shows the fix from this PR.

<img width="1598" height="476" alt="image" src="https://github.com/user-attachments/assets/d2123504-fc99-4505-90b7-6c373ec30627" />

### What to review

- Ensure that, when hiding a field, the comments field wrapper does not take up any space in the form.

### Notes for release

Fixed comments field wrapper displaying an empty element when the field component is hidden.