### PR TITLE
fix: restore workspace hidden property

### DIFF
--- a/packages/sanity/src/core/config/__tests__/prepareConfig.test.ts
+++ b/packages/sanity/src/core/config/__tests__/prepareConfig.test.ts
@@ -169,3 +169,25 @@ describe('prepareConfig — divergent auth warning', () => {
     expect(authWarning).toBeUndefined()
   })
 })
+
+describe('prepareConfig — workspace hidden property', () => {
+  it('preserves a boolean `hidden` value on the workspace summary', () => {
+    const {workspaces} = prepareConfig([
+      createWorkspace({name: 'visible', basePath: '/visible', hidden: false}),
+      createWorkspace({name: 'hidden-bool', basePath: '/hidden-bool', hidden: true}),
+    ])
+
+    expect(workspaces.find((w) => w.name === 'visible')?.hidden).toBe(false)
+    expect(workspaces.find((w) => w.name === 'hidden-bool')?.hidden).toBe(true)
+  })
+
+  it('preserves a function-based `hidden` callback on the workspace summary', () => {
+    const hidden = vi.fn(() => true)
+
+    const {workspaces} = prepareConfig([
+      createWorkspace({name: 'callback', basePath: '/callback', hidden}),
+    ])
+
+    expect(workspaces.find((w) => w.name === 'callback')?.hidden).toBe(hidden)
+  })
+})

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -401,6 +401,7 @@ export function prepareConfig(
       theme: rootSource.theme || studioTheme,
       title,
       subtitle: rootSource.subtitle,
+      hidden: rootSource.hidden,
       __internal: {
         sources: resolvedSources,
       },


### PR DESCRIPTION
### Description
Brings back hidden property on workspace which was introduced in https://github.com/sanity-io/sanity/pull/12599 (released in v5.22.0), but broke in https://github.com/sanity-io/sanity/pull/12692 (released in v5.23.0). This was almost certain an accidental regression.

### What to review
Makes sense?

### Testing
Included regression test
- Failing before fix in 4e366be
- Passing after fix in ddddedf

### Notes for release

Fixes a regression where workspace hidden config was ignored, causing hidden workspaces to appear.