### PR TITLE
perf: defer per-workspace auth checks via /auth/id probe

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -335,6 +335,14 @@ export default defineConfig([
   },
   {
     ...defaultWorkspace,
+    name: 'secondary',
+    title: 'Secondary test project',
+    projectId: 'q5caobza',
+    dataset: 'production',
+    basePath: '/secondary',
+  },
+  {
+    ...defaultWorkspace,
     name: 'unsplash',
     title: 'Only Unsplash Asset Source',
     basePath: '/unsplash',

--- a/packages/sanity/src/core/store/authStore/__tests__/probeWorkspaceAuth.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/probeWorkspaceAuth.test.ts
@@ -2,6 +2,7 @@ import {type ClientConfig as SanityClientConfig, type SanityClient} from '@sanit
 import {firstValueFrom} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
+import {getAuthTokenStorageKey} from '../constants'
 import {_probeWorkspaceAuthForTest, _resetProbeWorkspaceAuthCache} from '../probeWorkspaceAuth'
 
 // Match the convention from createAuthStore.test.ts: ensure localStorage is
@@ -163,7 +164,7 @@ describe('probeWorkspaceAuth', () => {
   })
 
   it('uses token auth when a token is present in localStorage', async () => {
-    localStorage.setItem('__studio_auth_token_p1', JSON.stringify({token: 'mock-token-abc'}))
+    localStorage.setItem(getAuthTokenStorageKey('p1'), JSON.stringify({token: 'mock-token-abc'}))
 
     const mock = createMockFactory({authenticated: true})
     const probe$ = _probeWorkspaceAuthForTest(

--- a/packages/sanity/src/core/store/authStore/__tests__/probeWorkspaceAuth.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/probeWorkspaceAuth.test.ts
@@ -1,8 +1,8 @@
 import {type ClientConfig as SanityClientConfig, type SanityClient} from '@sanity/client'
-import {firstValueFrom} from 'rxjs'
+import {firstValueFrom, lastValueFrom, take, toArray} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {getAuthTokenStorageKey} from '../constants'
+import {getAuthTokenStorageKey, getCookieAuthStateKey} from '../constants'
 import {_probeWorkspaceAuthForTest, _resetProbeWorkspaceAuthCache} from '../probeWorkspaceAuth'
 
 // Match the convention from createAuthStore.test.ts: ensure localStorage is
@@ -204,7 +204,7 @@ describe('probeWorkspaceAuth', () => {
     )
     await firstValueFrom(cookieProbe$)
 
-    localStorage.setItem('__studio_auth_token_p1', JSON.stringify({token: 'tok'}))
+    localStorage.setItem(getAuthTokenStorageKey('p1'), JSON.stringify({token: 'tok'}))
 
     const tokenProbe$ = _probeWorkspaceAuthForTest(
       {projectId: 'p1', dataset: 'd1'},
@@ -212,5 +212,67 @@ describe('probeWorkspaceAuth', () => {
     )
 
     expect(cookieProbe$).not.toBe(tokenProbe$)
+  })
+
+  it('re-probes a cookie probe when the cookie auth broadcast emits', async () => {
+    // Simulates another tab logging in (or out): the active workspace's
+    // AuthStore broadcasts on the cookie auth state channel after its
+    // /users/me probe. The probe should react with a fresh /auth/id call.
+    let authed = true
+    const mock = createMockFactory({
+      authIdImpl: () =>
+        authed ? Promise.resolve({id: 'mock-id', expiry: 0}) : Promise.reject(create401Error()),
+    })
+
+    const probe$ = _probeWorkspaceAuthForTest(
+      {projectId: 'p-cookie', dataset: 'd1'},
+      {clientFactory: mock.factory},
+    )
+    // Collect the first emission and one more after the broadcast.
+    const collected = lastValueFrom(probe$.pipe(take(2), toArray()))
+
+    // Wait for the initial probe to land before broadcasting.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mock.callCount()).toBe(1)
+
+    // Flip the mock so the next probe yields a different result that passes
+    // distinctUntilChanged downstream.
+    authed = false
+
+    // A sibling tab broadcasts on the per-project channel.
+    const channel = new BroadcastChannel(getCookieAuthStateKey('p-cookie'))
+    channel.postMessage(JSON.stringify({authenticated: false}))
+    channel.close()
+
+    const emissions = await collected
+    // One initial probe + one re-probe triggered by the broadcast.
+    expect(mock.callCount()).toBe(2)
+    expect(emissions).toEqual([{authenticated: true}, {authenticated: false}])
+  })
+
+  it('does not re-probe a token probe when the cookie auth broadcast emits', async () => {
+    // Token-only probes are independent of cookie state. A cookie-state
+    // broadcast for the same project must not trigger a re-probe.
+    localStorage.setItem(getAuthTokenStorageKey('p-token'), JSON.stringify({token: 'tok'}))
+
+    const mock = createMockFactory({authenticated: true})
+    const probe$ = _probeWorkspaceAuthForTest(
+      {projectId: 'p-token', dataset: 'd1'},
+      {clientFactory: mock.factory},
+    )
+
+    // Subscribe so the probe is active and listening.
+    const sub = probe$.subscribe()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mock.callCount()).toBe(1)
+
+    const channel = new BroadcastChannel(getCookieAuthStateKey('p-token'))
+    channel.postMessage(JSON.stringify({authenticated: true}))
+    channel.close()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // Still 1: the broadcast was ignored.
+    expect(mock.callCount()).toBe(1)
+    sub.unsubscribe()
   })
 })

--- a/packages/sanity/src/core/store/authStore/__tests__/probeWorkspaceAuth.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/probeWorkspaceAuth.test.ts
@@ -1,0 +1,215 @@
+import {type ClientConfig as SanityClientConfig, type SanityClient} from '@sanity/client'
+import {firstValueFrom} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {_probeWorkspaceAuthForTest, _resetProbeWorkspaceAuthCache} from '../probeWorkspaceAuth'
+
+// Match the convention from createAuthStore.test.ts: ensure localStorage is
+// considered supported in the test environment so the token-attribution code
+// path is exercised.
+vi.mock('../../../util/supportsLocalStorage', () => ({
+  supportsLocalStorage: true,
+}))
+
+interface MockFactoryOptions {
+  authenticated?: boolean
+  // Override per-call behaviour for /auth/id, e.g. simulate transient errors
+  authIdImpl?: (config: SanityClientConfig) => Promise<unknown>
+}
+
+interface MockFactory {
+  factory: (options: SanityClientConfig) => SanityClient
+  callCount: () => number
+  configs: () => SanityClientConfig[]
+}
+
+function create401Error(): Error & {statusCode: number} {
+  const err = new Error('Unauthorized') as Error & {statusCode: number}
+  err.statusCode = 401
+  return err
+}
+
+function createMockFactory({
+  authenticated = true,
+  authIdImpl,
+}: MockFactoryOptions = {}): MockFactory {
+  let calls = 0
+  const configs: SanityClientConfig[] = []
+
+  const factory = (config: SanityClientConfig): SanityClient => {
+    configs.push(config)
+    return {
+      request: vi.fn(({uri}: {uri: string}) => {
+        if (uri === '/auth/id') {
+          calls++
+          if (authIdImpl) return authIdImpl(config)
+          if (authenticated) {
+            return Promise.resolve({id: 'mock-id', expiry: 0})
+          }
+          return Promise.reject(create401Error())
+        }
+        return Promise.resolve({})
+      }),
+    } as unknown as SanityClient
+  }
+
+  return {
+    factory,
+    callCount: () => calls,
+    configs: () => configs,
+  }
+}
+
+describe('probeWorkspaceAuth', () => {
+  beforeEach(() => {
+    _resetProbeWorkspaceAuthCache()
+    if (typeof localStorage !== 'undefined') localStorage.clear()
+  })
+
+  afterEach(() => {
+    _resetProbeWorkspaceAuthCache()
+  })
+
+  it('emits {authenticated: true} on a 200 response', async () => {
+    const mock = createMockFactory({authenticated: true})
+    const result = await firstValueFrom(
+      _probeWorkspaceAuthForTest({projectId: 'p1', dataset: 'd1'}, {clientFactory: mock.factory}),
+    )
+    expect(result).toEqual({authenticated: true})
+  })
+
+  it('emits {authenticated: false} on a 401 response', async () => {
+    const mock = createMockFactory({authenticated: false})
+    const result = await firstValueFrom(
+      _probeWorkspaceAuthForTest({projectId: 'p1', dataset: 'd1'}, {clientFactory: mock.factory}),
+    )
+    expect(result).toEqual({authenticated: false})
+  })
+
+  it('treats non-401 errors as unauthenticated (fails open)', async () => {
+    // A transient failure (network blip, 5xx, CORS misconfig) should not
+    // tear down the studio via React's error boundary. The probe degrades
+    // to `{authenticated: false}` and logs a warning.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const mock = createMockFactory({
+      authIdImpl: () => Promise.reject(new Error('boom')),
+    })
+
+    const result = await firstValueFrom(
+      _probeWorkspaceAuthForTest({projectId: 'p1', dataset: 'd1'}, {clientFactory: mock.factory}),
+    )
+
+    expect(result).toEqual({authenticated: false})
+    expect(warnSpy).toHaveBeenCalledOnce()
+    warnSpy.mockRestore()
+  })
+
+  it('dedups probes for the same project/apiHost/token tuple', async () => {
+    const mock = createMockFactory({authenticated: true})
+    const a = _probeWorkspaceAuthForTest(
+      {projectId: 'p1', dataset: 'd1'},
+      {clientFactory: mock.factory},
+    )
+    const b = _probeWorkspaceAuthForTest(
+      {projectId: 'p1', dataset: 'd2'}, // different dataset, same project
+      {clientFactory: mock.factory},
+    )
+    expect(a).toBe(b)
+
+    await firstValueFrom(a)
+    expect(mock.callCount()).toBe(1)
+  })
+
+  it('does not dedup probes for different projects', async () => {
+    const mock = createMockFactory({authenticated: true})
+    const a = _probeWorkspaceAuthForTest(
+      {projectId: 'p1', dataset: 'd1'},
+      {clientFactory: mock.factory},
+    )
+    const b = _probeWorkspaceAuthForTest(
+      {projectId: 'p2', dataset: 'd1'},
+      {clientFactory: mock.factory},
+    )
+    expect(a).not.toBe(b)
+
+    await Promise.all([firstValueFrom(a), firstValueFrom(b)])
+    expect(mock.callCount()).toBe(2)
+  })
+
+  it('does not dedup probes for different apiHosts', async () => {
+    const mock = createMockFactory({authenticated: true})
+    const a = _probeWorkspaceAuthForTest(
+      {projectId: 'p1', dataset: 'd1', apiHost: 'https://api.sanity.io'},
+      {clientFactory: mock.factory},
+    )
+    const b = _probeWorkspaceAuthForTest(
+      {projectId: 'p1', dataset: 'd1', apiHost: 'https://api.sanity.work'},
+      {clientFactory: mock.factory},
+    )
+    expect(a).not.toBe(b)
+  })
+
+  it('uses cookie auth (withCredentials) when no token is in localStorage', async () => {
+    const mock = createMockFactory({authenticated: true})
+    const probe$ = _probeWorkspaceAuthForTest(
+      {projectId: 'p1', dataset: 'd1'},
+      {clientFactory: mock.factory},
+    )
+    await firstValueFrom(probe$)
+
+    const config = mock.configs()[0]
+    expect(config.withCredentials).toBe(true)
+    expect(config.token).toBeUndefined()
+  })
+
+  it('uses token auth when a token is present in localStorage', async () => {
+    localStorage.setItem('__studio_auth_token_p1', JSON.stringify({token: 'mock-token-abc'}))
+
+    const mock = createMockFactory({authenticated: true})
+    const probe$ = _probeWorkspaceAuthForTest(
+      {projectId: 'p1', dataset: 'd1'},
+      {clientFactory: mock.factory},
+    )
+    await firstValueFrom(probe$)
+
+    const config = mock.configs()[0]
+    expect(config.token).toBe('mock-token-abc')
+    expect(config.withCredentials).toBeUndefined()
+  })
+
+  it('does not write to localStorage when probing', async () => {
+    const writeSpy = vi.spyOn(Storage.prototype, 'setItem')
+    const mock = createMockFactory({authenticated: true})
+
+    await firstValueFrom(
+      _probeWorkspaceAuthForTest({projectId: 'p1', dataset: 'd1'}, {clientFactory: mock.factory}),
+    )
+
+    // The probe is independent of the full AuthStore: it only reads
+    // localStorage to detect a token, and never writes auth state.
+    expect(writeSpy).not.toHaveBeenCalled()
+    writeSpy.mockRestore()
+  })
+
+  it('keys differently per token so concurrent token + cookie probes for the same project resolve independently', async () => {
+    // Project A: no token (cookie probe).
+    // Project A again: token in localStorage (token probe).
+    // These should be two different cache entries.
+    const mock = createMockFactory({authenticated: true})
+
+    const cookieProbe$ = _probeWorkspaceAuthForTest(
+      {projectId: 'p1', dataset: 'd1'},
+      {clientFactory: mock.factory},
+    )
+    await firstValueFrom(cookieProbe$)
+
+    localStorage.setItem('__studio_auth_token_p1', JSON.stringify({token: 'tok'}))
+
+    const tokenProbe$ = _probeWorkspaceAuthForTest(
+      {projectId: 'p1', dataset: 'd1'},
+      {clientFactory: mock.factory},
+    )
+
+    expect(cookieProbe$).not.toBe(tokenProbe$)
+  })
+})

--- a/packages/sanity/src/core/store/authStore/constants.ts
+++ b/packages/sanity/src/core/store/authStore/constants.ts
@@ -1,0 +1,45 @@
+import {DEFAULT_STUDIO_CLIENT_HEADERS} from '../../studioClient'
+
+// Shared constants and key construction for the auth store.
+//
+// Both `createAuthStore` and `probeWorkspaceAuth` read or coordinate on the
+// values defined here, so they live in one place to keep the two in sync.
+
+// API version used by all auth-related client requests.
+const AUTH_API_VERSION = 'v2026-05-04'
+
+// Prefix for the localStorage key holding a per-project auth token.
+const AUTH_TOKEN_STORAGE_PREFIX = '__studio_auth_token_'
+
+// Prefix for the BroadcastChannel / localStorage key for cross-tab cookie auth state.
+const COOKIE_AUTH_STATE_PREFIX = '__studio_auth_cookie_state_'
+
+/** @internal Stable reference for the "not authenticated" auth result. */
+export const UNAUTHENTICATED = {authenticated: false} as const
+
+/** @internal Stable reference for the "authenticated" auth result (without user details). */
+export const AUTHENTICATED = {authenticated: true} as const
+
+/**
+ * @internal
+ * Baseline `ClientConfig` used by every auth-related Sanity client.
+ * Callers add `projectId`, `dataset`, and credentials (`token` / `withCredentials`).
+ */
+export const AUTH_CLIENT_OPTIONS = {
+  apiVersion: AUTH_API_VERSION,
+  useCdn: false,
+  perspective: 'raw',
+  requestTagPrefix: 'sanity.studio',
+  allowReconfigure: false,
+  headers: DEFAULT_STUDIO_CLIENT_HEADERS,
+} as const
+
+/** @internal localStorage key holding the per-project auth token. Value shape: `{token?: string}`. */
+export function getAuthTokenStorageKey(projectId: string): string {
+  return `${AUTH_TOKEN_STORAGE_PREFIX}${projectId}`
+}
+
+/** @internal BroadcastChannel / localStorage key for cross-tab cookie auth state. */
+export function getCookieAuthStateKey(projectId: string): string {
+  return `${COOKIE_AUTH_STATE_PREFIX}${projectId}`
+}

--- a/packages/sanity/src/core/store/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/authStore/createAuthStore.ts
@@ -21,9 +21,14 @@ import {
 
 import {type AuthConfig} from '../../config/auth/types'
 import {isStaging} from '../../environment/isStaging'
-import {DEFAULT_STUDIO_CLIENT_HEADERS} from '../../studioClient'
 import {canonicalHash} from '../../util/canonicalHash'
 import {CorsOriginError} from '../cors'
+import {
+  AUTH_CLIENT_OPTIONS,
+  getAuthTokenStorageKey,
+  getCookieAuthStateKey,
+  UNAUTHENTICATED,
+} from './constants'
 import {createBroadcastState} from './createBroadcastState'
 import {createBroadcastStorage} from './createBroadcastStorage'
 import {createLoginComponent} from './createLoginComponent'
@@ -95,17 +100,13 @@ const getCurrentUser = async (
   }
 }
 
-const UNAUTHENTICATED = {authenticated: false} as const
-
-const API_VERSION = 'v2026-04-09'
-
 /**
  * Probe whether a given auth method works by calling /auth/id.
  */
 const probeCurrentUser = (client: SanityClient): Promise<AuthProbeResult> => {
   return client
     .request<{id: string; expiry: number}>({
-      uri: '/users/me',
+      uri: '/auth/id',
       tag: 'auth.check-id',
     })
     .then(
@@ -144,15 +145,6 @@ async function exchangeSessionForToken(client: SanityClient, sessionId: string):
   return token
 }
 
-const COMMON_CLIENT_OPTIONS = {
-  apiVersion: API_VERSION,
-  useCdn: false,
-  perspective: 'raw',
-  requestTagPrefix: 'sanity.studio',
-  allowReconfigure: false,
-  headers: DEFAULT_STUDIO_CLIENT_HEADERS,
-} as const
-
 /**
  * @internal
  */
@@ -178,7 +170,7 @@ export function _createAuthStore({
   //    1. HTTP cookie
 
   const tokenStorage = createBroadcastStorage<{token?: string}>(
-    `__studio_auth_token_${projectId}`,
+    getAuthTokenStorageKey(projectId),
     // sets the initial value
     (currentTokenValue) => {
       if (!isCookielessCompatibleLoginMethod(loginMethod)) {
@@ -199,7 +191,7 @@ export function _createAuthStore({
   // has a different status that what it received from another tab, it fetches. This ensures all
   // tabs converge on the same auth state
   const cookieAuthState = createBroadcastState<{authenticated: boolean | 'pending'}>(
-    `__studio_auth_cookie_state_${projectId}`,
+    getCookieAuthStateKey(projectId),
     () => ({authenticated: 'pending'}),
   )
 
@@ -219,7 +211,7 @@ export function _createAuthStore({
   }
 
   const cookieClient = clientFactory({
-    ...COMMON_CLIENT_OPTIONS,
+    ...AUTH_CLIENT_OPTIONS,
     ...hostOptions,
     projectId,
     dataset,
@@ -229,7 +221,7 @@ export function _createAuthStore({
   const currentTokenState = tokenStorage.get()
 
   const initialTokenClient = clientFactory({
-    ...COMMON_CLIENT_OPTIONS,
+    ...AUTH_CLIENT_OPTIONS,
     ...hostOptions,
     projectId,
     dataset,
@@ -239,7 +231,7 @@ export function _createAuthStore({
   })
 
   const initialDualClient = clientFactory({
-    ...COMMON_CLIENT_OPTIONS,
+    ...AUTH_CLIENT_OPTIONS,
     ...hostOptions,
     projectId,
     dataset,
@@ -298,7 +290,7 @@ export function _createAuthStore({
       .pipe(
         map((nextTokenState) => {
           return clientFactory({
-            ...COMMON_CLIENT_OPTIONS,
+            ...AUTH_CLIENT_OPTIONS,
             ...hostOptions,
             projectId,
             dataset,
@@ -316,7 +308,7 @@ export function _createAuthStore({
     merge(hashTokenChange, tokenStorage.value.pipe(skip(1))).pipe(
       map((nextTokenState) => {
         return clientFactory({
-          ...COMMON_CLIENT_OPTIONS,
+          ...AUTH_CLIENT_OPTIONS,
           ...hostOptions,
           projectId,
           dataset,
@@ -402,7 +394,7 @@ export function _createAuthStore({
 
     // Client used to exchange SID (Session ID) for a token (and a cookie as a side effect)
     const exchangeClient = clientFactory({
-      ...COMMON_CLIENT_OPTIONS,
+      ...AUTH_CLIENT_OPTIONS,
       ...hostOptions,
       projectId,
       dataset,

--- a/packages/sanity/src/core/store/authStore/probeWorkspaceAuth.ts
+++ b/packages/sanity/src/core/store/authStore/probeWorkspaceAuth.ts
@@ -3,8 +3,8 @@ import {
   createClient as createSanityClient,
   type SanityClient,
 } from '@sanity/client'
-import {defer, EMPTY, fromEvent, type Observable} from 'rxjs'
-import {distinctUntilChanged, filter, shareReplay, startWith, switchMap} from 'rxjs/operators'
+import {defer, EMPTY, fromEvent, merge, type Observable, using} from 'rxjs'
+import {distinctUntilChanged, filter, shareReplay, skip, startWith, switchMap} from 'rxjs/operators'
 
 import {isStaging} from '../../environment/isStaging'
 import {supportsLocalStorage} from '../../util/supportsLocalStorage'
@@ -12,8 +12,10 @@ import {
   AUTH_CLIENT_OPTIONS,
   AUTHENTICATED,
   getAuthTokenStorageKey,
+  getCookieAuthStateKey,
   UNAUTHENTICATED,
 } from './constants'
+import {createBroadcastState} from './createBroadcastState'
 
 /** @internal */
 export interface WorkspaceAuthProbeInput {
@@ -68,9 +70,13 @@ async function callAuthId(client: SanityClient): Promise<WorkspaceAuthProbeResul
   }
 }
 
-// Module-level cache. Lives for the lifetime of the page; bounded by the
-// number of distinct (apiHost, projectId, token) tuples in the studio
-// config, which is small in practice.
+// Module-level cache for observable identity. Keeps two simultaneous probes
+// for the same tuple sharing one underlying request via `shareReplay`.
+// The cache holds observable references only; the inner BroadcastChannel
+// and DOM listeners are created on first subscribe and disposed on last
+// unsubscribe (see `using` below). Bounded by the number of distinct
+// (apiHost, projectId, token) tuples in the studio config — typically a
+// handful, so a plain `Map` (no LRU eviction) is sufficient.
 const cache = new Map<string, Observable<WorkspaceAuthProbeResult>>()
 
 function cacheKey(input: {
@@ -111,22 +117,53 @@ function buildProbe(
 
   const client = factory(clientConfig)
 
-  // Re-probe when this project's token key changes in another tab.
-  // We don't write to storage from here — only listen.
   const tokenKey = getAuthTokenStorageKey(input.projectId)
-  const storageEvents$: Observable<unknown> =
-    typeof window === 'undefined'
-      ? EMPTY
-      : fromEvent<StorageEvent>(window, 'storage').pipe(filter((e) => e.key === tokenKey))
+  const cookieKey = getCookieAuthStateKey(input.projectId)
 
-  const observable$ = storageEvents$.pipe(
-    startWith(undefined),
-    switchMap(() => defer(() => callAuthId(client))),
-    // `callAuthId` always returns one of two stable references
-    // (`AUTHENTICATED` / `UNAUTHENTICATED`), so default `===` is enough.
-    distinctUntilChanged(),
-    shareReplay({bufferSize: 1, refCount: true}),
-  )
+  // Re-probe when an external signal indicates auth state may have changed.
+  //
+  // Token workspaces: `localStorage` writes from another tab fire a `storage`
+  // event natively. Always subscribe.
+  //
+  // Cookie/dual workspaces: cookies don't generate browser events, so the
+  // active workspace's `AuthStore` broadcasts on a per-project channel after
+  // login/logout. We listen but never write — token-only probes ignore this
+  // signal because their credential (the token) is independent of cookie
+  // state. We treat any emit as a tick: re-run `callAuthId` rather than
+  // trusting the broadcast value.
+  type ProbeResource = {
+    cookieState: ReturnType<typeof createBroadcastState> | null
+    unsubscribe: () => void
+  }
+  const observable$ = using(
+    (): ProbeResource => {
+      // Resource factory: opens the BroadcastChannel on first subscribe and
+      // closes it on last unsubscribe. Token-only probes have no use for
+      // the cookie broadcast, so they skip the channel entirely. The
+      // resource is owned by `using` per subscription, so simultaneous
+      // teardown/resubscribe cycles can't cross-dispose each other.
+      const cookieState = token ? null : createBroadcastState(cookieKey)
+      return {cookieState, unsubscribe: () => cookieState?.dispose()}
+    },
+    (resource) => {
+      const {cookieState} = resource as ProbeResource
+      // `createBroadcastState` is a `BehaviorSubject`-backed value
+      // observable; skip its initial replay so we only fire on subsequent
+      // (i.e., genuinely new) emits.
+      const cookieTicks$ = cookieState?.value.pipe(skip(1)) ?? EMPTY
+      const storageEvents$: Observable<unknown> =
+        typeof window === 'undefined'
+          ? EMPTY
+          : fromEvent<StorageEvent>(window, 'storage').pipe(filter((e) => e.key === tokenKey))
+      return merge(storageEvents$, cookieTicks$).pipe(
+        startWith(undefined),
+        switchMap(() => defer(() => callAuthId(client))),
+        // `callAuthId` always returns one of two stable references
+        // (`AUTHENTICATED` / `UNAUTHENTICATED`), so default `===` is enough.
+        distinctUntilChanged(),
+      )
+    },
+  ).pipe(shareReplay({bufferSize: 1, refCount: true}))
 
   cache.set(key, observable$)
   return observable$
@@ -140,11 +177,15 @@ function buildProbe(
  *
  * Independent of the full `AuthStore`: does not write to localStorage or
  * BroadcastChannels, so probing many workspaces never poisons the active
- * workspace's auth state.
+ * workspace's auth state. The probe does *listen* to the cookie auth
+ * broadcast (cookie/dual probes only) and to `storage` events (all probes)
+ * to re-probe when another tab logs in or out.
  *
  * Probes are deduped by `(apiHost, projectId, token)`. Workspaces in the same
  * project that share a token (or both rely on the cookie) share a single
- * underlying request via `shareReplay`.
+ * underlying request via `shareReplay`. The BroadcastChannel and DOM
+ * listeners are created on first subscribe and disposed when the last
+ * subscriber unsubscribes.
  *
  * @internal
  */

--- a/packages/sanity/src/core/store/authStore/probeWorkspaceAuth.ts
+++ b/packages/sanity/src/core/store/authStore/probeWorkspaceAuth.ts
@@ -1,0 +1,184 @@
+import {
+  type ClientConfig as SanityClientConfig,
+  createClient as createSanityClient,
+  type SanityClient,
+} from '@sanity/client'
+import {defer, EMPTY, fromEvent, type Observable} from 'rxjs'
+import {distinctUntilChanged, filter, shareReplay, startWith, switchMap} from 'rxjs/operators'
+
+import {isStaging} from '../../environment/isStaging'
+import {DEFAULT_STUDIO_CLIENT_HEADERS} from '../../studioClient'
+import {supportsLocalStorage} from '../../util/supportsLocalStorage'
+
+/** @internal */
+export interface WorkspaceAuthProbeInput {
+  projectId: string
+  dataset: string
+  apiHost?: string
+}
+
+/** @internal */
+export interface WorkspaceAuthProbeResult {
+  authenticated: boolean
+}
+
+const API_VERSION = 'v2026-05-04'
+const TOKEN_STORAGE_PREFIX = '__studio_auth_token_'
+
+const PROBE_CLIENT_OPTIONS = {
+  apiVersion: API_VERSION,
+  useCdn: false,
+  perspective: 'raw',
+  requestTagPrefix: 'sanity.studio',
+  allowReconfigure: false,
+  headers: DEFAULT_STUDIO_CLIENT_HEADERS,
+} as const
+
+const UNAUTHENTICATED: WorkspaceAuthProbeResult = {authenticated: false}
+const AUTHENTICATED: WorkspaceAuthProbeResult = {authenticated: true}
+
+function getStoredToken(projectId: string): string | undefined {
+  if (!supportsLocalStorage) return undefined
+  try {
+    const raw = localStorage.getItem(`${TOKEN_STORAGE_PREFIX}${projectId}`)
+    if (!raw) return undefined
+    const parsed = JSON.parse(raw) as {token?: string} | null
+    return parsed?.token
+  } catch {
+    return undefined
+  }
+}
+
+function resolveApiHost(apiHost?: string): string | undefined {
+  if (apiHost) return apiHost
+  if (isStaging) return 'https://api.sanity.work'
+  return undefined
+}
+
+async function callAuthId(client: SanityClient): Promise<WorkspaceAuthProbeResult> {
+  try {
+    const response = await client.request<{id?: string}>({
+      uri: '/auth/id',
+      tag: 'auth.probe',
+    })
+    return typeof response?.id === 'string' ? AUTHENTICATED : UNAUTHENTICATED
+  } catch (err) {
+    // 401 is the canonical "not authenticated" signal.
+    if ((err as {statusCode?: number})?.statusCode === 401) {
+      return UNAUTHENTICATED
+    }
+    // For any other failure (network blip, 5xx, CORS misconfig) we fail
+    // open as `unauthenticated` rather than throw. Throwing here would
+    // propagate to React's error boundary and tear down the studio for
+    // a transient probe failure. The user can still attempt to log in
+    // from the workspace menu / login screen, and the next probe attempt
+    // (e.g. on remount) will pick up the truth.
+    console.warn('Workspace auth probe failed; treating as unauthenticated:', err)
+    return UNAUTHENTICATED
+  }
+}
+
+// Module-level cache. Lives for the lifetime of the page; bounded by the
+// number of distinct (apiHost, projectId, token) tuples in the studio
+// config, which is small in practice.
+const cache = new Map<string, Observable<WorkspaceAuthProbeResult>>()
+
+function cacheKey(input: {
+  apiHost: string | undefined
+  projectId: string
+  token: string | undefined
+}): string {
+  // Cookie probes (no token) collapse across workspaces of the same project
+  // on the same apiHost. Token probes are keyed per-token so different tokens
+  // resolve independently.
+  const auth = input.token ? `tok:${input.token}` : 'cookie'
+  return `${input.apiHost ?? 'default'}|${input.projectId}|${auth}`
+}
+
+interface CreateProbeOptions {
+  clientFactory?: (options: SanityClientConfig) => SanityClient
+}
+
+function buildProbe(
+  input: WorkspaceAuthProbeInput,
+  options: CreateProbeOptions = {},
+): Observable<WorkspaceAuthProbeResult> {
+  const apiHost = resolveApiHost(input.apiHost)
+  const token = getStoredToken(input.projectId)
+  const factory = options.clientFactory ?? createSanityClient
+
+  const key = cacheKey({apiHost, projectId: input.projectId, token})
+  const existing = cache.get(key)
+  if (existing) return existing
+
+  const clientConfig: SanityClientConfig = {
+    ...PROBE_CLIENT_OPTIONS,
+    projectId: input.projectId,
+    dataset: input.dataset,
+    ...(apiHost ? {apiHost} : {}),
+    ...(token ? {token, ignoreBrowserTokenWarning: true} : {withCredentials: true}),
+  }
+
+  const client = factory(clientConfig)
+
+  // Re-probe when this project's token key changes in another tab.
+  // We don't write to storage from here — only listen.
+  const tokenKey = `${TOKEN_STORAGE_PREFIX}${input.projectId}`
+  const storageEvents$: Observable<unknown> =
+    typeof window === 'undefined'
+      ? EMPTY
+      : fromEvent<StorageEvent>(window, 'storage').pipe(filter((e) => e.key === tokenKey))
+
+  const observable$ = storageEvents$.pipe(
+    startWith(undefined),
+    switchMap(() => defer(() => callAuthId(client))),
+    // `callAuthId` always returns one of two stable references
+    // (`AUTHENTICATED` / `UNAUTHENTICATED`), so default `===` is enough.
+    distinctUntilChanged(),
+    shareReplay({bufferSize: 1, refCount: true}),
+  )
+
+  cache.set(key, observable$)
+  return observable$
+}
+
+/**
+ * Probe whether the current user is authenticated against a workspace's project.
+ *
+ * Hits the project-scoped `/auth/id` endpoint, which only returns whether the
+ * caller has a valid session — no user object, no current-user PII.
+ *
+ * Independent of the full `AuthStore`: does not write to localStorage or
+ * BroadcastChannels, so probing many workspaces never poisons the active
+ * workspace's auth state.
+ *
+ * Probes are deduped by `(apiHost, projectId, token)`. Workspaces in the same
+ * project that share a token (or both rely on the cookie) share a single
+ * underlying request via `shareReplay`.
+ *
+ * @internal
+ */
+export function probeWorkspaceAuth(
+  input: WorkspaceAuthProbeInput,
+): Observable<WorkspaceAuthProbeResult> {
+  return buildProbe(input)
+}
+
+/**
+ * @internal
+ * Test-only: clear the dedup cache.
+ */
+export function _resetProbeWorkspaceAuthCache(): void {
+  cache.clear()
+}
+
+/**
+ * @internal
+ * Test-only: build a probe with an injected client factory.
+ */
+export function _probeWorkspaceAuthForTest(
+  input: WorkspaceAuthProbeInput,
+  options: CreateProbeOptions,
+): Observable<WorkspaceAuthProbeResult> {
+  return buildProbe(input, options)
+}

--- a/packages/sanity/src/core/store/authStore/probeWorkspaceAuth.ts
+++ b/packages/sanity/src/core/store/authStore/probeWorkspaceAuth.ts
@@ -7,8 +7,13 @@ import {defer, EMPTY, fromEvent, type Observable} from 'rxjs'
 import {distinctUntilChanged, filter, shareReplay, startWith, switchMap} from 'rxjs/operators'
 
 import {isStaging} from '../../environment/isStaging'
-import {DEFAULT_STUDIO_CLIENT_HEADERS} from '../../studioClient'
 import {supportsLocalStorage} from '../../util/supportsLocalStorage'
+import {
+  AUTH_CLIENT_OPTIONS,
+  AUTHENTICATED,
+  getAuthTokenStorageKey,
+  UNAUTHENTICATED,
+} from './constants'
 
 /** @internal */
 export interface WorkspaceAuthProbeInput {
@@ -22,25 +27,10 @@ export interface WorkspaceAuthProbeResult {
   authenticated: boolean
 }
 
-const API_VERSION = 'v2026-05-04'
-const TOKEN_STORAGE_PREFIX = '__studio_auth_token_'
-
-const PROBE_CLIENT_OPTIONS = {
-  apiVersion: API_VERSION,
-  useCdn: false,
-  perspective: 'raw',
-  requestTagPrefix: 'sanity.studio',
-  allowReconfigure: false,
-  headers: DEFAULT_STUDIO_CLIENT_HEADERS,
-} as const
-
-const UNAUTHENTICATED: WorkspaceAuthProbeResult = {authenticated: false}
-const AUTHENTICATED: WorkspaceAuthProbeResult = {authenticated: true}
-
 function getStoredToken(projectId: string): string | undefined {
   if (!supportsLocalStorage) return undefined
   try {
-    const raw = localStorage.getItem(`${TOKEN_STORAGE_PREFIX}${projectId}`)
+    const raw = localStorage.getItem(getAuthTokenStorageKey(projectId))
     if (!raw) return undefined
     const parsed = JSON.parse(raw) as {token?: string} | null
     return parsed?.token
@@ -112,7 +102,7 @@ function buildProbe(
   if (existing) return existing
 
   const clientConfig: SanityClientConfig = {
-    ...PROBE_CLIENT_OPTIONS,
+    ...AUTH_CLIENT_OPTIONS,
     projectId: input.projectId,
     dataset: input.dataset,
     ...(apiHost ? {apiHost} : {}),
@@ -123,7 +113,7 @@ function buildProbe(
 
   // Re-probe when this project's token key changes in another tab.
   // We don't write to storage from here — only listen.
-  const tokenKey = `${TOKEN_STORAGE_PREFIX}${input.projectId}`
+  const tokenKey = getAuthTokenStorageKey(input.projectId)
   const storageEvents$: Observable<unknown> =
     typeof window === 'undefined'
       ? EMPTY

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
@@ -8,13 +8,13 @@ import {useTranslation} from '../../../../../i18n'
 import {useActiveWorkspace} from '../../../../activeWorkspaceMatcher'
 import {useVisibleWorkspaces} from '../../../../workspaces'
 import {WORKSPACES_DOCS_URL} from '../constants'
-import {useWorkspaceAuthStates} from '../hooks'
+import {useWorkspaceAuthProbes} from '../hooks'
 import {WorkspacePreview} from '../WorkspacePreview'
 import {Layout} from './Layout'
 
 export function WorkspaceAuth() {
   const {visibleWorkspaces} = useVisibleWorkspaces()
-  const [authStates] = useWorkspaceAuthStates(visibleWorkspaces)
+  const [authStates] = useWorkspaceAuthProbes({workspaces: visibleWorkspaces})
   const {activeWorkspace, setActiveWorkspace} = useActiveWorkspace()
   const [selectedWorkspaceName, setSelectedWorkspaceName] = useState<string | null>(
     activeWorkspace?.name || null,

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -12,10 +12,11 @@ import {
 import {useCallback, useState} from 'react'
 
 import {MenuButton, type MenuButtonProps, MenuItem, Tooltip} from '../../../../../ui-components'
+import {LoadingBlock} from '../../../../components/loadingBlock'
 import {useTranslation} from '../../../../i18n'
 import {useActiveWorkspace} from '../../../activeWorkspaceMatcher'
 import {useVisibleWorkspaces} from '../../../workspaces'
-import {useWorkspaceAuthStates} from './hooks'
+import {useWorkspaceAuthProbes} from './hooks'
 import {ManageMenu} from './ManageMenu'
 import {STATE_TITLES, WorkspacePreviewIcon} from './WorkspacePreview'
 
@@ -28,10 +29,22 @@ const POPOVER_PROPS: MenuButtonProps['popover'] = {
 
 export function WorkspaceMenuButton() {
   const {visibleWorkspaces} = useVisibleWorkspaces()
-  const [authStates] = useWorkspaceAuthStates(visibleWorkspaces)
   const {activeWorkspace} = useActiveWorkspace()
   const {t} = useTranslation()
   const [scrollbarWidth, setScrollbarWidth] = useState(0)
+
+  // Defer the per-workspace auth probe until the menu is first opened.
+  // The menu is hidden behind a popover; probing on mount fans out
+  // /auth/id requests for every visible workspace before the user has
+  // even asked to switch. Latch to `true` on first open so the data
+  // stays warm if the user reopens the menu.
+  const [hasOpened, setHasOpened] = useState(false)
+  const handleOpen = useCallback(() => setHasOpened(true), [])
+
+  const [authStates, isLoadingAuth] = useWorkspaceAuthProbes({
+    workspaces: visibleWorkspaces,
+    enabled: hasOpened,
+  })
 
   const stackRef = useCallback((node: HTMLDivElement | null) => {
     if (node) {
@@ -40,14 +53,14 @@ export function WorkspaceMenuButton() {
     }
   }, [])
 
-  const disabled = !authStates
+  const isProbing = hasOpened && (isLoadingAuth || !authStates)
 
   return (
     <MenuButton
       button={
         <Flex>
-          <Tooltip content={t('workspaces.select-workspace-tooltip')} disabled={disabled} portal>
-            <UIButton disabled={disabled} mode="bleed" padding={2} width="fill">
+          <Tooltip content={t('workspaces.select-workspace-tooltip')} portal>
+            <UIButton mode="bleed" padding={2} width="fill">
               <Flex align="center" gap={2}>
                 <Box>
                   <Text size={1} textOverflow="ellipsis" weight="medium">
@@ -63,8 +76,13 @@ export function WorkspaceMenuButton() {
         </Flex>
       }
       id="workspace-menu"
+      onOpen={handleOpen}
       menu={
-        !disabled && authStates ? (
+        isProbing ? (
+          <Menu padding={0} style={{maxWidth: '350px', minWidth: '250px', overflowY: 'hidden'}}>
+            <LoadingBlock showText />
+          </Menu>
+        ) : authStates ? (
           <Menu padding={0} style={{maxWidth: '350px', minWidth: '250px', overflowY: 'hidden'}}>
             <ManageMenu multipleWorkspaces={visibleWorkspaces.length > 1} />
             {visibleWorkspaces.length > 1 && (

--- a/packages/sanity/src/core/studio/components/navbar/workspace/hooks/index.ts
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from './useWorkspaceAuthProbes'
 export * from './useWorkspaceAuthStates'

--- a/packages/sanity/src/core/studio/components/navbar/workspace/hooks/useWorkspaceAuthProbes.ts
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/hooks/useWorkspaceAuthProbes.ts
@@ -1,0 +1,50 @@
+import {combineLatest, NEVER, of} from 'rxjs'
+import {map} from 'rxjs/operators'
+
+import {type WorkspaceSummary} from '../../../../../config'
+import {
+  probeWorkspaceAuth,
+  type WorkspaceAuthProbeResult,
+} from '../../../../../store/authStore/probeWorkspaceAuth'
+import {createHookFromObservableFactory} from '../../../../../util'
+
+interface UseWorkspaceAuthProbesArg {
+  workspaces: WorkspaceSummary[]
+  /**
+   * When `false`, the hook stays in its loading state and never subscribes
+   * to any probe. Use this to defer the per-workspace `/auth/id` fan-out
+   * until a UI surface (e.g. a popover menu) actually mounts or opens.
+   * Defaults to `true`.
+   */
+  enabled?: boolean
+}
+
+/**
+ * Returns `{[workspaceName]: {authenticated}}` for the given workspaces, using
+ * the lightweight `/auth/id` probe ({@link probeWorkspaceAuth}) instead of the
+ * full per-workspace `AuthStore`.
+ *
+ * Use this when a callsite only needs to know whether the user is logged in
+ * to a workspace's project — not who they are. Probes are deduped by
+ * `(apiHost, projectId, token)`, so workspaces in the same project share a
+ * single underlying request.
+ *
+ * @internal
+ */
+export const useWorkspaceAuthProbes = createHookFromObservableFactory(
+  ({workspaces, enabled = true}: UseWorkspaceAuthProbesArg) => {
+    if (!enabled) return NEVER
+    if (workspaces.length === 0) {
+      return of({} as Record<string, WorkspaceAuthProbeResult>)
+    }
+    return combineLatest(
+      workspaces.map((workspace) =>
+        probeWorkspaceAuth({
+          projectId: workspace.projectId,
+          dataset: workspace.dataset,
+          apiHost: workspace.apiHost,
+        }).pipe(map((result) => [workspace.name, result] as const)),
+      ),
+    ).pipe(map((entries) => Object.fromEntries(entries)))
+  },
+)


### PR DESCRIPTION
### Description

The workspace menu and login screen previously subscribed to `workspace.auth.state` for every visible workspace, forcing a full per-workspace `AuthStore` (with `/users/me`) at studio boot. With many workspaces this fans out a lot of requests for surfaces the user may never open.

This PR replaces those subscriptions with a lightweight `/auth/id` probe deduped by `(apiHost, projectId, token)`. The menu defers probing until first open. Cross-tab login/logout is picked up via the cookie auth `BroadcastChannel` (cookie/dual probes) and `storage` events (token probes); the probe only listens, never writes.

- Why not reuse `auth.state`? it would still create the full `AuthStore` per workspace.

- Why not return `currentUser` too? Only `VisibleWorkspacesProvider` needs it, and only for function-form `hidden` callbacks. It still uses `auth.state`; everything else uses the probe.

- Why fail-open on non-401? The previous behavior would have torn down the studio via React's error boundary on any transient `/auth/id` failure.

- A separate refactor commit extracts shared keys, baseline client config, API version, and the two stable auth-state constants into `constants.ts` and bumps the auth store apiVersion to `v2026-05-04` to match the probe.

### What to review

- `probeWorkspaceAuth.ts`: dedup key, fail-open behavior, the `using` resource lifecycle, and the cookie-vs-token listener split.
- `WorkspaceMenuButton.tsx`: the `enabled: hasOpened` gating.
- The new `useWorkspaceAuthProbes` is kept alongside the existing `useWorkspaceAuthStates` because the latter still serves `VisibleWorkspacesProvider`.
- The apiVersion bump in `constants.ts`.

### Testing

- Unit tests for `probeWorkspaceAuth` covering 200/401/non-401 fail-open, dedup, cookie vs token wiring, no localStorage writes, and the two cross-tab cases.
- Existing `createAuthStore` and `VisibleWorkspacesProvider` suites still pass.
- Manually verified in test-studio: no auth requests fire until the workspace menu is opened.

### Notes for release

- Improved initial load times for studios with many workspaces
