### PR TITLE
test: add tests for createCallbackResolver

### DIFF
--- a/packages/sanity/src/core/form/store/conditional-property/__tests__/createCallbackResolver.test.ts
+++ b/packages/sanity/src/core/form/store/conditional-property/__tests__/createCallbackResolver.test.ts
@@ -1,0 +1,350 @@
+import {Schema} from '@sanity/schema'
+import {type ObjectSchemaType, type Schema as SchemaInstance, type SchemaType} from '@sanity/types'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {createCallbackResolver} from '../createCallbackResolver'
+
+const MOCK_USER = {id: 'u', name: 'u', email: 'u@u', roles: []}
+
+function compile(types: unknown[]): SchemaInstance {
+  return Schema.compile({name: 'test', types: types as never})
+}
+
+function getType(schema: SchemaInstance, name: string): ObjectSchemaType {
+  const type = schema.get(name) as SchemaType | undefined
+  if (!type) throw new Error(`Type ${name} not found`)
+  return type as ObjectSchemaType
+}
+
+describe('createCallbackResolver', () => {
+  let resolveHidden: ReturnType<typeof createCallbackResolver<'hidden'>>
+  let resolveReadOnly: ReturnType<typeof createCallbackResolver<'readOnly'>>
+
+  beforeEach(() => {
+    resolveHidden = createCallbackResolver({property: 'hidden'})
+    resolveReadOnly = createCallbackResolver({property: 'readOnly'})
+  })
+
+  describe('no-callback short-circuit', () => {
+    test('returns undefined for a flat object with no callbacks', () => {
+      const schema = compile([
+        {
+          name: 'book',
+          type: 'document',
+          fields: [
+            {name: 'title', type: 'string'},
+            {name: 'subtitle', type: 'string'},
+          ],
+        },
+      ])
+      const schemaType = getType(schema, 'book')
+      const documentValue = {_id: 'a', _type: 'book', title: 'hello', subtitle: 'world'}
+
+      expect(resolveHidden({currentUser: MOCK_USER, documentValue, schemaType})).toBeUndefined()
+      expect(resolveReadOnly({currentUser: MOCK_USER, documentValue, schemaType})).toBeUndefined()
+    })
+
+    test('returns undefined for nested objects/arrays when no callbacks exist anywhere', () => {
+      const schema = compile([
+        {
+          name: 'book',
+          type: 'document',
+          fields: [
+            {name: 'title', type: 'string'},
+            {
+              name: 'author',
+              type: 'object',
+              fields: [
+                {name: 'firstName', type: 'string'},
+                {name: 'lastName', type: 'string'},
+              ],
+            },
+            {
+              name: 'quotes',
+              type: 'array',
+              of: [
+                {
+                  type: 'object',
+                  name: 'quote',
+                  fields: [
+                    {name: 'text', type: 'string'},
+                    {name: 'page', type: 'number'},
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+      const schemaType = getType(schema, 'book')
+      const documentValue = {
+        _id: 'a',
+        _type: 'book',
+        author: {firstName: 'A', lastName: 'B'},
+        quotes: [{_key: 'k1', _type: 'quote', text: 'hi', page: 1}],
+      }
+
+      expect(resolveHidden({currentUser: MOCK_USER, documentValue, schemaType})).toBeUndefined()
+      expect(resolveReadOnly({currentUser: MOCK_USER, documentValue, schemaType})).toBeUndefined()
+    })
+  })
+
+  describe('walks when callbacks exist', () => {
+    test('detects a `hidden` callback at the root', () => {
+      const schema = compile([
+        {
+          name: 'book',
+          type: 'document',
+          hidden: () => true,
+          fields: [{name: 'title', type: 'string'}],
+        },
+      ])
+      const schemaType = getType(schema, 'book')
+      const documentValue = {_id: 'a', _type: 'book'}
+
+      const result = resolveHidden({currentUser: MOCK_USER, documentValue, schemaType})
+      expect(result).toEqual({value: true})
+    })
+
+    test('detects a `hidden` callback on a nested field', () => {
+      const schema = compile([
+        {
+          name: 'book',
+          type: 'document',
+          fields: [
+            {name: 'title', type: 'string'},
+            {name: 'subtitle', type: 'string', hidden: () => true},
+          ],
+        },
+      ])
+      const schemaType = getType(schema, 'book')
+      const documentValue = {_id: 'a', _type: 'book'}
+
+      const result = resolveHidden({currentUser: MOCK_USER, documentValue, schemaType})
+      expect(result).toEqual({children: {subtitle: {value: true}}})
+    })
+
+    test('detects a `hidden` callback inside an array item type', () => {
+      const schema = compile([
+        {
+          name: 'book',
+          type: 'document',
+          fields: [
+            {
+              name: 'quotes',
+              type: 'array',
+              of: [
+                {
+                  type: 'object',
+                  name: 'quote',
+                  fields: [{name: 'text', type: 'string', hidden: () => true}],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+      const schemaType = getType(schema, 'book')
+      const documentValue = {
+        _id: 'a',
+        _type: 'book',
+        quotes: [{_key: 'k1', _type: 'quote', text: 'hi'}],
+      }
+
+      const result = resolveHidden({currentUser: MOCK_USER, documentValue, schemaType})
+      expect(result).toEqual({
+        children: {quotes: {children: {k1: {children: {text: {value: true}}}}}},
+      })
+    })
+
+    test('detects constant `hidden: true` on a field (does not require a callback)', () => {
+      const schema = compile([
+        {
+          name: 'book',
+          type: 'document',
+          fields: [
+            {name: 'title', type: 'string'},
+            {name: 'subtitle', type: 'string', hidden: true},
+          ],
+        },
+      ])
+      const schemaType = getType(schema, 'book')
+      const documentValue = {_id: 'a', _type: 'book'}
+
+      const result = resolveHidden({currentUser: MOCK_USER, documentValue, schemaType})
+      expect(result).toEqual({children: {subtitle: {value: true}}})
+    })
+
+    test('passes the document value to the callback', () => {
+      const callback = vi.fn(() => false)
+      const schema = compile([
+        {
+          name: 'book',
+          type: 'document',
+          fields: [{name: 'title', type: 'string', hidden: callback}],
+        },
+      ])
+      const schemaType = getType(schema, 'book')
+      const documentValue = {_id: 'a', _type: 'book', title: 'hello'}
+
+      resolveHidden({currentUser: MOCK_USER, documentValue, schemaType})
+
+      expect(callback).toHaveBeenCalledTimes(1)
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({document: documentValue, currentUser: MOCK_USER}),
+      )
+    })
+  })
+
+  describe('cyclic schemas', () => {
+    test('does not blow the stack on a self-referential schema with no callbacks', () => {
+      const schema = compile([
+        {
+          name: 'tree',
+          type: 'document',
+          fields: [
+            {name: 'label', type: 'string'},
+            {name: 'children', type: 'array', of: [{type: 'tree'}]},
+          ],
+        },
+      ])
+      const schemaType = getType(schema, 'tree')
+      const documentValue = {_id: 'a', _type: 'tree', label: 'root'}
+
+      expect(() => resolveHidden({currentUser: MOCK_USER, documentValue, schemaType})).not.toThrow()
+      expect(resolveHidden({currentUser: MOCK_USER, documentValue, schemaType})).toBeUndefined()
+    })
+
+    test('finds a callback inside a self-referential schema', () => {
+      const schema = compile([
+        {
+          name: 'tree',
+          type: 'document',
+          fields: [
+            {name: 'label', type: 'string', hidden: () => true},
+            {name: 'children', type: 'array', of: [{type: 'tree'}]},
+          ],
+        },
+      ])
+      const schemaType = getType(schema, 'tree')
+      const documentValue = {_id: 'a', _type: 'tree'}
+
+      const result = resolveHidden({currentUser: MOCK_USER, documentValue, schemaType})
+      expect(result).toEqual({children: {label: {value: true}}})
+    })
+  })
+
+  describe('inputOverride', () => {
+    test('returns `{value: true}` when the property override is `true`', () => {
+      const schema = compile([
+        {
+          name: 'book',
+          type: 'document',
+          fields: [{name: 'title', type: 'string'}],
+        },
+      ])
+      const schemaType = getType(schema, 'book')
+      const documentValue = {_id: 'a', _type: 'book'}
+
+      expect(
+        resolveReadOnly({currentUser: MOCK_USER, documentValue, schemaType, readOnly: true}),
+      ).toEqual({value: true})
+    })
+  })
+
+  describe('caching', () => {
+    test('returns the same reference for the same inputs called twice', () => {
+      const callback = vi.fn(() => false)
+      const schema = compile([
+        {
+          name: 'book',
+          type: 'document',
+          fields: [{name: 'title', type: 'string', hidden: callback}],
+        },
+      ])
+      const schemaType = getType(schema, 'book')
+      const documentValue = {_id: 'a', _type: 'book'}
+
+      const first = resolveHidden({currentUser: MOCK_USER, documentValue, schemaType})
+      const second = resolveHidden({currentUser: MOCK_USER, documentValue, schemaType})
+
+      expect(second).toBe(first)
+      // The callback was only invoked once because the second call hit the
+      // reference-equality cache.
+      expect(callback).toHaveBeenCalledTimes(1)
+    })
+
+    test('schemas that reach MAX_FIELD_DEPTH still emit the original marker tree', () => {
+      // Behaviour preservation: the original `resolveCallbackState` walk
+      // emits `{value: false}` markers at depth 20 and propagates `{children:
+      // …}` upward. The structural cache is depth-aware so it does NOT
+      // short-circuit deep schemas — they fall through to the original walk
+      // and produce the same shape they did before this optimization.
+      // Regression alarm: if this test starts returning `undefined`, the
+      // depth check has been bypassed and behaviour has silently changed.
+      let typeDef: Record<string, unknown> = {name: 'leaf', type: 'string'}
+      for (let i = 0; i < 22; i++) {
+        typeDef = {
+          name: `level${i}`,
+          type: 'object',
+          fields: [typeDef as never],
+        }
+      }
+      const schema = compile([{name: 'root', type: 'document', fields: [typeDef as never]}])
+      const schemaType = getType(schema, 'root')
+      const documentValue = {_id: 'a', _type: 'root'}
+
+      const result = resolveHidden({currentUser: MOCK_USER, documentValue, schemaType})
+      expect(result).toBeDefined()
+      expect(result).toHaveProperty('children')
+    })
+
+    test('shallow no-callback schemas still short-circuit to `undefined`', () => {
+      // Companion to the depth-aware preservation test above: schemas that
+      // do NOT reach MAX_FIELD_DEPTH should hit the structural-cache short
+      // circuit and skip the recursive walk entirely.
+      const schema = compile([
+        {
+          name: 'shallow',
+          type: 'document',
+          fields: [
+            {name: 'a', type: 'string'},
+            {
+              name: 'nested',
+              type: 'object',
+              fields: [{name: 'inner', type: 'string'}],
+            },
+          ],
+        },
+      ])
+      const schemaType = getType(schema, 'shallow')
+      const documentValue = {_id: 'a', _type: 'shallow'}
+
+      expect(resolveHidden({currentUser: MOCK_USER, documentValue, schemaType})).toBeUndefined()
+    })
+
+    test('the structural cache is shared across resolver instances', () => {
+      // Schema with no callbacks anywhere — the structural cache classifies it
+      // once and any subsequent resolver for the same `schemaType` short-circuits.
+      const schema = compile([
+        {
+          name: 'flat',
+          type: 'document',
+          fields: [
+            {name: 'a', type: 'string'},
+            {name: 'b', type: 'string'},
+            {name: 'c', type: 'string'},
+          ],
+        },
+      ])
+      const schemaType = getType(schema, 'flat')
+      const documentValue = {_id: 'd', _type: 'flat'}
+
+      const resolverA = createCallbackResolver({property: 'hidden'})
+      const resolverB = createCallbackResolver({property: 'hidden'})
+
+      expect(resolverA({currentUser: MOCK_USER, documentValue, schemaType})).toBeUndefined()
+      expect(resolverB({currentUser: MOCK_USER, documentValue, schemaType})).toBeUndefined()
+    })
+  })
+})

--- a/packages/sanity/src/core/form/store/conditional-property/__tests__/createCallbackResolver.test.ts
+++ b/packages/sanity/src/core/form/store/conditional-property/__tests__/createCallbackResolver.test.ts
@@ -25,7 +25,7 @@ describe('createCallbackResolver', () => {
     resolveReadOnly = createCallbackResolver({property: 'readOnly'})
   })
 
-  describe('no-callback short-circuit', () => {
+  describe('schemas without callbacks', () => {
     test('returns undefined for a flat object with no callbacks', () => {
       const schema = compile([
         {
@@ -252,7 +252,7 @@ describe('createCallbackResolver', () => {
     })
   })
 
-  describe('caching', () => {
+  describe('per-instance cache', () => {
     test('returns the same reference for the same inputs called twice', () => {
       const callback = vi.fn(() => false)
       const schema = compile([
@@ -273,15 +273,14 @@ describe('createCallbackResolver', () => {
       // reference-equality cache.
       expect(callback).toHaveBeenCalledTimes(1)
     })
+  })
 
-    test('schemas that reach MAX_FIELD_DEPTH still emit the original marker tree', () => {
-      // Behaviour preservation: the original `resolveCallbackState` walk
-      // emits `{value: false}` markers at depth 20 and propagates `{children:
-      // …}` upward. The structural cache is depth-aware so it does NOT
-      // short-circuit deep schemas — they fall through to the original walk
-      // and produce the same shape they did before this optimization.
-      // Regression alarm: if this test starts returning `undefined`, the
-      // depth check has been bypassed and behaviour has silently changed.
+  describe('depth limit', () => {
+    test('emits a marker tree at MAX_FIELD_DEPTH (does not recurse beyond the limit)', () => {
+      // Characterizes the existing depth-bounded walk: at `level === MAX_FIELD_DEPTH`
+      // the resolver returns `{value: false}` instead of recursing further, and the
+      // markers propagate up as a `{children: …}` tree. This protects against a
+      // future change that silently bypasses the depth gate.
       let typeDef: Record<string, unknown> = {name: 'leaf', type: 'string'}
       for (let i = 0; i < 22; i++) {
         typeDef = {
@@ -297,54 +296,6 @@ describe('createCallbackResolver', () => {
       const result = resolveHidden({currentUser: MOCK_USER, documentValue, schemaType})
       expect(result).toBeDefined()
       expect(result).toHaveProperty('children')
-    })
-
-    test('shallow no-callback schemas still short-circuit to `undefined`', () => {
-      // Companion to the depth-aware preservation test above: schemas that
-      // do NOT reach MAX_FIELD_DEPTH should hit the structural-cache short
-      // circuit and skip the recursive walk entirely.
-      const schema = compile([
-        {
-          name: 'shallow',
-          type: 'document',
-          fields: [
-            {name: 'a', type: 'string'},
-            {
-              name: 'nested',
-              type: 'object',
-              fields: [{name: 'inner', type: 'string'}],
-            },
-          ],
-        },
-      ])
-      const schemaType = getType(schema, 'shallow')
-      const documentValue = {_id: 'a', _type: 'shallow'}
-
-      expect(resolveHidden({currentUser: MOCK_USER, documentValue, schemaType})).toBeUndefined()
-    })
-
-    test('the structural cache is shared across resolver instances', () => {
-      // Schema with no callbacks anywhere — the structural cache classifies it
-      // once and any subsequent resolver for the same `schemaType` short-circuits.
-      const schema = compile([
-        {
-          name: 'flat',
-          type: 'document',
-          fields: [
-            {name: 'a', type: 'string'},
-            {name: 'b', type: 'string'},
-            {name: 'c', type: 'string'},
-          ],
-        },
-      ])
-      const schemaType = getType(schema, 'flat')
-      const documentValue = {_id: 'd', _type: 'flat'}
-
-      const resolverA = createCallbackResolver({property: 'hidden'})
-      const resolverB = createCallbackResolver({property: 'hidden'})
-
-      expect(resolverA({currentUser: MOCK_USER, documentValue, schemaType})).toBeUndefined()
-      expect(resolverB({currentUser: MOCK_USER, documentValue, schemaType})).toBeUndefined()
     })
   })
 })

--- a/packages/sanity/src/core/form/store/conditional-property/createCallbackResolver.ts
+++ b/packages/sanity/src/core/form/store/conditional-property/createCallbackResolver.ts
@@ -11,6 +11,116 @@ import {
   resolveConditionalProperty,
 } from './resolveConditionalProperty'
 
+/**
+ * Per-`(schemaType, property)` summary used to decide whether the recursive
+ * walk in `resolveCallbackState` can be skipped. The walk is skipped only
+ * when `!hasCallback && nestingDepth < MAX_FIELD_DEPTH`; any other case falls
+ * through to the original walk so observable behaviour is preserved.
+ */
+interface SchemaSummary {
+  hasCallback: boolean
+  /** Capped at `MAX_FIELD_DEPTH`. Cyclic types always reach the cap. */
+  nestingDepth: number
+}
+
+const SCHEMA_SUMMARY_CACHE: WeakMap<
+  SchemaType,
+  {hidden?: SchemaSummary; readOnly?: SchemaSummary}
+> = new WeakMap()
+
+const CYCLIC_SUMMARY: SchemaSummary = {hasCallback: false, nestingDepth: MAX_FIELD_DEPTH}
+
+function isPossiblyTruthy(value: unknown): boolean {
+  return typeof value === 'function' || value === true
+}
+
+function summarizeSchema(
+  schemaType: SchemaType,
+  property: 'hidden' | 'readOnly',
+  seen: WeakSet<SchemaType> = new WeakSet(),
+): SchemaSummary {
+  // Cycle break: re-entering a type up the call stack means any direct
+  // callback on it has already been checked in the original visit. We report
+  // `nestingDepth: MAX_FIELD_DEPTH` so cyclic schemas always run the original
+  // walk (which is itself bounded by `MAX_FIELD_DEPTH`).
+  if (seen.has(schemaType)) return CYCLIC_SUMMARY
+
+  let entry = SCHEMA_SUMMARY_CACHE.get(schemaType)
+  const cached = entry?.[property]
+  if (cached) return cached
+
+  if (isPossiblyTruthy(schemaType[property])) {
+    const summary: SchemaSummary = {hasCallback: true, nestingDepth: 0}
+    if (!entry) {
+      entry = {}
+      SCHEMA_SUMMARY_CACHE.set(schemaType, entry)
+    }
+    entry[property] = summary
+    return summary
+  }
+
+  seen.add(schemaType)
+  const summary = computeSummary(schemaType, property, seen)
+
+  if (!entry) {
+    entry = {}
+    SCHEMA_SUMMARY_CACHE.set(schemaType, entry)
+  }
+  entry[property] = summary
+  return summary
+}
+
+function computeSummary(
+  schemaType: SchemaType,
+  property: 'hidden' | 'readOnly',
+  seen: WeakSet<SchemaType>,
+): SchemaSummary {
+  let hasCallback = false
+  let maxChildNestingDepth = -1
+
+  const visit = (child: SchemaSummary) => {
+    if (child.hasCallback) hasCallback = true
+    if (child.nestingDepth > maxChildNestingDepth) maxChildNestingDepth = child.nestingDepth
+  }
+
+  if (schemaType.jsonType === 'object') {
+    const fieldsets = schemaType.fieldsets
+      ? schemaType.fieldsets
+      : schemaType.fields.map((field) => ({single: true as const, field}))
+
+    for (const fieldset of fieldsets) {
+      if (fieldset.single) {
+        visit(summarizeSchema(fieldset.field.type, property, seen))
+        continue
+      }
+      if (isPossiblyTruthy(fieldset.hidden)) hasCallback = true
+      for (const field of fieldset.fields) {
+        visit(summarizeSchema(field.type, property, seen))
+      }
+    }
+
+    for (const group of schemaType.groups ?? EMPTY_ARRAY) {
+      // Mirrors the original `resolveCallbackState`: groups today only declare
+      // `hidden`, never `readOnly`, but we defer to the runtime shape so that
+      // a future schema-API extension is picked up automatically.
+      if (property in group && isPossiblyTruthy(group[property as 'hidden'])) {
+        hasCallback = true
+      }
+    }
+  } else if (schemaType.jsonType === 'array') {
+    for (const item of schemaType.of ?? EMPTY_ARRAY) {
+      visit(summarizeSchema(item, property, seen))
+    }
+  }
+  // Leaf types contribute no recursion: `maxChildNestingDepth` stays at -1
+  // and the resulting summary has `nestingDepth: 0`.
+
+  return {
+    hasCallback,
+    nestingDepth: Math.min(maxChildNestingDepth + 1, MAX_FIELD_DEPTH),
+  }
+}
+
 interface ResolveCallbackStateOptions {
   property: 'readOnly' | 'hidden'
   value: unknown
@@ -177,6 +287,17 @@ export function createCallbackResolver<TProperty extends 'hidden' | 'readOnly'>(
     }
 
     if (last?.serializedHash === serializedHash) return last.result
+
+    // Module-scoped short-circuit: when the schema has no `hidden`/`readOnly`
+    // callbacks anywhere AND doesn't reach `MAX_FIELD_DEPTH`, the recursive
+    // walk below would always produce `undefined`, so skip it. Schemas that
+    // do reach the depth limit fall through to the original walk so the
+    // depth-boundary marker tree is preserved verbatim.
+    const summary = summarizeSchema(schemaType, property)
+    if (!summary.hasCallback && summary.nestingDepth < MAX_FIELD_DEPTH) {
+      last = {serializedHash, result: undefined}
+      return undefined
+    }
 
     const result = immutableReconcile(
       last?.result ?? null,

--- a/packages/sanity/src/core/form/store/conditional-property/createCallbackResolver.ts
+++ b/packages/sanity/src/core/form/store/conditional-property/createCallbackResolver.ts
@@ -11,116 +11,6 @@ import {
   resolveConditionalProperty,
 } from './resolveConditionalProperty'
 
-/**
- * Per-`(schemaType, property)` summary used to decide whether the recursive
- * walk in `resolveCallbackState` can be skipped. The walk is skipped only
- * when `!hasCallback && nestingDepth < MAX_FIELD_DEPTH`; any other case falls
- * through to the original walk so observable behaviour is preserved.
- */
-interface SchemaSummary {
-  hasCallback: boolean
-  /** Capped at `MAX_FIELD_DEPTH`. Cyclic types always reach the cap. */
-  nestingDepth: number
-}
-
-const SCHEMA_SUMMARY_CACHE: WeakMap<
-  SchemaType,
-  {hidden?: SchemaSummary; readOnly?: SchemaSummary}
-> = new WeakMap()
-
-const CYCLIC_SUMMARY: SchemaSummary = {hasCallback: false, nestingDepth: MAX_FIELD_DEPTH}
-
-function isPossiblyTruthy(value: unknown): boolean {
-  return typeof value === 'function' || value === true
-}
-
-function summarizeSchema(
-  schemaType: SchemaType,
-  property: 'hidden' | 'readOnly',
-  seen: WeakSet<SchemaType> = new WeakSet(),
-): SchemaSummary {
-  // Cycle break: re-entering a type up the call stack means any direct
-  // callback on it has already been checked in the original visit. We report
-  // `nestingDepth: MAX_FIELD_DEPTH` so cyclic schemas always run the original
-  // walk (which is itself bounded by `MAX_FIELD_DEPTH`).
-  if (seen.has(schemaType)) return CYCLIC_SUMMARY
-
-  let entry = SCHEMA_SUMMARY_CACHE.get(schemaType)
-  const cached = entry?.[property]
-  if (cached) return cached
-
-  if (isPossiblyTruthy(schemaType[property])) {
-    const summary: SchemaSummary = {hasCallback: true, nestingDepth: 0}
-    if (!entry) {
-      entry = {}
-      SCHEMA_SUMMARY_CACHE.set(schemaType, entry)
-    }
-    entry[property] = summary
-    return summary
-  }
-
-  seen.add(schemaType)
-  const summary = computeSummary(schemaType, property, seen)
-
-  if (!entry) {
-    entry = {}
-    SCHEMA_SUMMARY_CACHE.set(schemaType, entry)
-  }
-  entry[property] = summary
-  return summary
-}
-
-function computeSummary(
-  schemaType: SchemaType,
-  property: 'hidden' | 'readOnly',
-  seen: WeakSet<SchemaType>,
-): SchemaSummary {
-  let hasCallback = false
-  let maxChildNestingDepth = -1
-
-  const visit = (child: SchemaSummary) => {
-    if (child.hasCallback) hasCallback = true
-    if (child.nestingDepth > maxChildNestingDepth) maxChildNestingDepth = child.nestingDepth
-  }
-
-  if (schemaType.jsonType === 'object') {
-    const fieldsets = schemaType.fieldsets
-      ? schemaType.fieldsets
-      : schemaType.fields.map((field) => ({single: true as const, field}))
-
-    for (const fieldset of fieldsets) {
-      if (fieldset.single) {
-        visit(summarizeSchema(fieldset.field.type, property, seen))
-        continue
-      }
-      if (isPossiblyTruthy(fieldset.hidden)) hasCallback = true
-      for (const field of fieldset.fields) {
-        visit(summarizeSchema(field.type, property, seen))
-      }
-    }
-
-    for (const group of schemaType.groups ?? EMPTY_ARRAY) {
-      // Mirrors the original `resolveCallbackState`: groups today only declare
-      // `hidden`, never `readOnly`, but we defer to the runtime shape so that
-      // a future schema-API extension is picked up automatically.
-      if (property in group && isPossiblyTruthy(group[property as 'hidden'])) {
-        hasCallback = true
-      }
-    }
-  } else if (schemaType.jsonType === 'array') {
-    for (const item of schemaType.of ?? EMPTY_ARRAY) {
-      visit(summarizeSchema(item, property, seen))
-    }
-  }
-  // Leaf types contribute no recursion: `maxChildNestingDepth` stays at -1
-  // and the resulting summary has `nestingDepth: 0`.
-
-  return {
-    hasCallback,
-    nestingDepth: Math.min(maxChildNestingDepth + 1, MAX_FIELD_DEPTH),
-  }
-}
-
 interface ResolveCallbackStateOptions {
   property: 'readOnly' | 'hidden'
   value: unknown
@@ -287,17 +177,6 @@ export function createCallbackResolver<TProperty extends 'hidden' | 'readOnly'>(
     }
 
     if (last?.serializedHash === serializedHash) return last.result
-
-    // Module-scoped short-circuit: when the schema has no `hidden`/`readOnly`
-    // callbacks anywhere AND doesn't reach `MAX_FIELD_DEPTH`, the recursive
-    // walk below would always produce `undefined`, so skip it. Schemas that
-    // do reach the depth limit fall through to the original walk so the
-    // depth-boundary marker tree is preserved verbatim.
-    const summary = summarizeSchema(schemaType, property)
-    if (!summary.hasCallback && summary.nestingDepth < MAX_FIELD_DEPTH) {
-      last = {serializedHash, result: undefined}
-      return undefined
-    }
 
     const result = immutableReconcile(
       last?.result ?? null,


### PR DESCRIPTION
### Description

Originally scoped as a perf optimisation but after running some performance tooling came to the conclusion it wasn't worth shipping the actual fix. 

What's left is the test suite written during the investigation. `createCallbackResolver` had zero direct unit-test coverage before, only transitive coverage via the form integration suite, which was slow to surface a regression I introduced mid-investigation. These tests pin observable behaviour of the existing walk and are worth keeping on their own merits, regardless of whether we pursue the optimisation later.

### What to review

- The tests / what's on the tin, if there is anything you feel it should be added to the tests

### Testing

12 tests, all passing against the unmodified resolver.

### Notes for release

N/A – Internal only.