### PR TITLE
chore(ci): use pnpm whoami instead of npm whoami

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -47,10 +47,10 @@ jobs:
 
       - name: Check valid token
         run: |
-          WHOAMI_RESULT=$(npm whoami)
-          echo "npm whoami result: $WHOAMI_RESULT"
+          WHOAMI_RESULT=$(pnpm whoami)
+          echo "pnpm whoami result: $WHOAMI_RESULT"
           if [ "$WHOAMI_RESULT" != "$EXPECTED_NPM_USER" ]; then
-            echo "Error: npm whoami returned '$WHOAMI_RESULT', expected '$EXPECTED_NPM_USER'"
+            echo "Error: pnpm whoami returned '$WHOAMI_RESULT', expected '$EXPECTED_NPM_USER'"
             exit 1
           fi
           echo "✅ npm authentication validated - using $EXPECTED_NPM_USER account"

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -114,10 +114,10 @@ jobs:
 
       - name: Check valid token
         run: |
-          WHOAMI_RESULT=$(npm whoami)
-          echo "npm whoami result: $WHOAMI_RESULT"
+          WHOAMI_RESULT=$(pnpm whoami)
+          echo "pnpm whoami result: $WHOAMI_RESULT"
           if [ "$WHOAMI_RESULT" != "$EXPECTED_NPM_USER" ]; then
-            echo "Error: npm whoami returned '$WHOAMI_RESULT', expected '$EXPECTED_NPM_USER'"
+            echo "Error: pnpm whoami returned '$WHOAMI_RESULT', expected '$EXPECTED_NPM_USER'"
             exit 1
           fi
           echo "✅ npm authentication validated - using $EXPECTED_NPM_USER account"

--- a/.github/workflows/release-next-major.yml
+++ b/.github/workflows/release-next-major.yml
@@ -47,10 +47,10 @@ jobs:
 
       - name: Check valid token
         run: |
-          WHOAMI_RESULT=$(npm whoami)
-          echo "npm whoami result: $WHOAMI_RESULT"
+          WHOAMI_RESULT=$(pnpm whoami)
+          echo "pnpm whoami result: $WHOAMI_RESULT"
           if [ "$WHOAMI_RESULT" != "$EXPECTED_NPM_USER" ]; then
-            echo "Error: npm whoami returned '$WHOAMI_RESULT', expected '$EXPECTED_NPM_USER'"
+            echo "Error: pnpm whoami returned '$WHOAMI_RESULT', expected '$EXPECTED_NPM_USER'"
             exit 1
           fi
           echo "✅ npm authentication validated - using $EXPECTED_NPM_USER account"

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -50,10 +50,10 @@ jobs:
 
       - name: Check valid token
         run: |
-          WHOAMI_RESULT=$(npm whoami)
-          echo "npm whoami result: $WHOAMI_RESULT"
+          WHOAMI_RESULT=$(pnpm whoami)
+          echo "pnpm whoami result: $WHOAMI_RESULT"
           if [ "$WHOAMI_RESULT" != "$EXPECTED_NPM_USER" ]; then
-            echo "Error: npm whoami returned '$WHOAMI_RESULT', expected '$EXPECTED_NPM_USER'"
+            echo "Error: pnpm whoami returned '$WHOAMI_RESULT', expected '$EXPECTED_NPM_USER'"
             exit 1
           fi
           echo "✅ npm authentication validated - using $EXPECTED_NPM_USER account"

--- a/.github/workflows/tag-latest.yml
+++ b/.github/workflows/tag-latest.yml
@@ -60,10 +60,10 @@ jobs:
 
       - name: Check valid token
         run: |
-          WHOAMI_RESULT=$(npm whoami)
-          echo "npm whoami result: $WHOAMI_RESULT"
+          WHOAMI_RESULT=$(pnpm whoami)
+          echo "pnpm whoami result: $WHOAMI_RESULT"
           if [ "$WHOAMI_RESULT" != "$EXPECTED_NPM_USER" ]; then
-            echo "Error: npm whoami returned '$WHOAMI_RESULT', expected '$EXPECTED_NPM_USER'"
+            echo "Error: pnpm whoami returned '$WHOAMI_RESULT', expected '$EXPECTED_NPM_USER'"
             exit 1
           fi
           echo "✅ npm authentication validated - using $EXPECTED_NPM_USER account"
@@ -81,7 +81,7 @@ jobs:
           for pkg_dir in $packages; do
             pkg_name=$(jq -r '.name' "$pkg_dir/package.json")
             echo "Tagging $pkg_name@$version as latest"
-            npm dist-tag add "$pkg_name@$version" latest
+            pnpm dist-tag add "$pkg_name@$version" latest
           done
 
           echo "✅ All packages tagged as latest"

--- a/.github/workflows/tag-stable.yml
+++ b/.github/workflows/tag-stable.yml
@@ -60,10 +60,10 @@ jobs:
 
       - name: Check valid token
         run: |
-          WHOAMI_RESULT=$(npm whoami)
-          echo "npm whoami result: $WHOAMI_RESULT"
+          WHOAMI_RESULT=$(pnpm whoami)
+          echo "pnpm whoami result: $WHOAMI_RESULT"
           if [ "$WHOAMI_RESULT" != "$EXPECTED_NPM_USER" ]; then
-            echo "Error: npm whoami returned '$WHOAMI_RESULT', expected '$EXPECTED_NPM_USER'"
+            echo "Error: pnpm whoami returned '$WHOAMI_RESULT', expected '$EXPECTED_NPM_USER'"
             exit 1
           fi
           echo "✅ npm authentication validated - using $EXPECTED_NPM_USER account"
@@ -81,7 +81,7 @@ jobs:
           for pkg_dir in $packages; do
             pkg_name=$(jq -r '.name' "$pkg_dir/package.json")
             echo "Tagging $pkg_name@$version as stable"
-            npm dist-tag add "$pkg_name@$version" stable
+            pnpm dist-tag add "$pkg_name@$version" stable
           done
 
           echo "✅ All packages tagged as stable"

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -35,6 +35,8 @@
         "sanity-tsdoc",
         // Knip doesn't understand `cd perf/studio && pnpm preview`
         "preview",
+        // `pnpm dist-tag` invocations in tag-latest.yml / tag-stable.yml
+        "dist-tag",
       ],
     },
     "packages/sanity": {


### PR DESCRIPTION
### Description

pnpm v11 changed `pnpm config set` to write to a pnpm-only config file instead of `~/.npmrc`, so subsequent `npm whoami` / `npm dist-tag` calls fail with `ENEEDAUTH`, causing our release workflows to fail.

This update workflows to use `pnpm whoami` and `pnpm dist-tag`, which will read from the pnpm-only config location.

### What to review
- Looks correct?
- Added `dist-tag` to `ignoreBinaries` since knip doesn't seem to pick up `pnpm dist-tag`.

### Testing
I pushed this fix to the canary branch and verified that check passed there: https://github.com/sanity-io/sanity/actions/runs/25365627522/job/74375619117

### Notes for release

N/A
