### PR TITLE
perf(core): dedupe equal editStateFor values + add tests for hook

### DIFF
--- a/packages/sanity/src/core/hooks/__tests__/useEditState.test.tsx
+++ b/packages/sanity/src/core/hooks/__tests__/useEditState.test.tsx
@@ -40,7 +40,7 @@ describe('useEditState', () => {
     expect(result.current).toBe(initialState)
   })
 
-  it('returns the same reference when a structurally-equal value is emitted', () => {
+  it('dedupes re-emissions where the snapshot fields keep their references', () => {
     const {result} = renderHook(() => useEditState('doc-1', 'book'))
     const before = result.current
 
@@ -51,7 +51,7 @@ describe('useEditState', () => {
     expect(result.current).toBe(before)
   })
 
-  it('returns a new reference when content changes', async () => {
+  it('passes through when a snapshot reference changes', async () => {
     const {result} = renderHook(() => useEditState('doc-1', 'book'))
 
     const next: EditStateFor = {
@@ -75,14 +75,27 @@ describe('useEditState', () => {
     })
   })
 
-  it('dedupes deep clones but lets deep changes through', async () => {
+  it('passes through when only the `ready` flag flips', async () => {
+    const {result} = renderHook(() => useEditState('doc-1', 'book'))
+
+    const next: EditStateFor = {...initialState, ready: true}
+    act(() => {
+      mockEditState$.next(next)
+    })
+
+    await waitFor(() => {
+      expect(result.current).toBe(next)
+    })
+  })
+
+  it('treats a new draft reference as a change even if content is equivalent', async () => {
     const draft = {
       _id: 'drafts.doc-1',
       _type: 'book',
       _rev: 'r1',
       _createdAt: '2024-01-01T00:00:00Z',
       _updatedAt: '2024-01-01T00:00:00Z',
-      title: 'before',
+      title: 'hello',
     }
     const seeded: EditStateFor = {...initialState, ready: true, draft}
 
@@ -91,20 +104,19 @@ describe('useEditState', () => {
     })
 
     const {result} = renderHook(() => useEditState('doc-1', 'book'))
-    const before = result.current
 
     act(() => {
-      mockEditState$.next({...seeded, draft: {...draft}})
+      mockEditState$.next({...seeded})
     })
-    expect(result.current).toBe(before)
+    expect(result.current).toBe(seeded)
 
-    const changed: EditStateFor = {...seeded, draft: {...draft, title: 'after'}}
+    const cloned: EditStateFor = {...seeded, draft: {...draft}}
     act(() => {
-      mockEditState$.next(changed)
+      mockEditState$.next(cloned)
     })
 
     await waitFor(() => {
-      expect(result.current).toBe(changed)
+      expect(result.current).toBe(cloned)
     })
   })
 })

--- a/packages/sanity/src/core/hooks/__tests__/useEditState.test.tsx
+++ b/packages/sanity/src/core/hooks/__tests__/useEditState.test.tsx
@@ -1,0 +1,110 @@
+import {act, renderHook, waitFor} from '@testing-library/react'
+import {BehaviorSubject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {type EditStateFor} from '../../store'
+import {useEditState} from '../useEditState'
+
+const initialState: EditStateFor = {
+  id: 'doc-1',
+  type: 'book',
+  transactionSyncLock: null,
+  draft: null,
+  published: null,
+  version: null,
+  liveEdit: false,
+  liveEditSchemaType: false,
+  ready: false,
+  release: undefined,
+}
+
+const mockEditState$ = new BehaviorSubject<EditStateFor>(initialState)
+const mockEditStateFn = vi.fn(() => mockEditState$)
+
+const mockDocumentStore = {
+  pair: {editState: mockEditStateFn},
+}
+
+vi.mock('../../store', () => ({
+  useDocumentStore: () => mockDocumentStore,
+}))
+
+describe('useEditState', () => {
+  beforeEach(() => {
+    mockEditState$.next(initialState)
+    mockEditStateFn.mockClear()
+  })
+
+  it('returns the initial value', () => {
+    const {result} = renderHook(() => useEditState('doc-1', 'book'))
+    expect(result.current).toBe(initialState)
+  })
+
+  it('returns the same reference when a structurally-equal value is emitted', () => {
+    const {result} = renderHook(() => useEditState('doc-1', 'book'))
+    const before = result.current
+
+    act(() => {
+      mockEditState$.next({...initialState})
+    })
+
+    expect(result.current).toBe(before)
+  })
+
+  it('returns a new reference when content changes', async () => {
+    const {result} = renderHook(() => useEditState('doc-1', 'book'))
+
+    const next: EditStateFor = {
+      ...initialState,
+      ready: true,
+      draft: {
+        _id: 'drafts.doc-1',
+        _type: 'book',
+        _rev: 'r1',
+        _createdAt: '2024-01-01T00:00:00Z',
+        _updatedAt: '2024-01-01T00:00:00Z',
+      },
+    }
+
+    act(() => {
+      mockEditState$.next(next)
+    })
+
+    await waitFor(() => {
+      expect(result.current).toBe(next)
+    })
+  })
+
+  it('dedupes deep clones but lets deep changes through', async () => {
+    const draft = {
+      _id: 'drafts.doc-1',
+      _type: 'book',
+      _rev: 'r1',
+      _createdAt: '2024-01-01T00:00:00Z',
+      _updatedAt: '2024-01-01T00:00:00Z',
+      title: 'before',
+    }
+    const seeded: EditStateFor = {...initialState, ready: true, draft}
+
+    act(() => {
+      mockEditState$.next(seeded)
+    })
+
+    const {result} = renderHook(() => useEditState('doc-1', 'book'))
+    const before = result.current
+
+    act(() => {
+      mockEditState$.next({...seeded, draft: {...draft}})
+    })
+    expect(result.current).toBe(before)
+
+    const changed: EditStateFor = {...seeded, draft: {...draft, title: 'after'}}
+    act(() => {
+      mockEditState$.next(changed)
+    })
+
+    await waitFor(() => {
+      expect(result.current).toBe(changed)
+    })
+  })
+})

--- a/packages/sanity/src/core/hooks/__tests__/useEditState.test.tsx
+++ b/packages/sanity/src/core/hooks/__tests__/useEditState.test.tsx
@@ -119,4 +119,132 @@ describe('useEditState', () => {
       expect(result.current).toBe(cloned)
     })
   })
+
+  it('passes through when the `published` reference changes', async () => {
+    const {result} = renderHook(() => useEditState('doc-1', 'book'))
+
+    const next: EditStateFor = {
+      ...initialState,
+      ready: true,
+      published: {
+        _id: 'doc-1',
+        _type: 'book',
+        _rev: 'r1',
+        _createdAt: '2024-01-01T00:00:00Z',
+        _updatedAt: '2024-01-01T00:00:00Z',
+      },
+    }
+
+    act(() => {
+      mockEditState$.next(next)
+    })
+
+    await waitFor(() => {
+      expect(result.current).toBe(next)
+    })
+  })
+
+  it('passes through when the `version` reference changes', async () => {
+    const {result} = renderHook(() => useEditState('doc-1', 'book'))
+
+    const next: EditStateFor = {
+      ...initialState,
+      ready: true,
+      version: {
+        _id: 'versions.rel.doc-1',
+        _type: 'book',
+        _rev: 'r1',
+        _createdAt: '2024-01-01T00:00:00Z',
+        _updatedAt: '2024-01-01T00:00:00Z',
+      },
+    }
+
+    act(() => {
+      mockEditState$.next(next)
+    })
+
+    await waitFor(() => {
+      expect(result.current).toBe(next)
+    })
+  })
+
+  it('passes through when `transactionSyncLock` flips', async () => {
+    const {result} = renderHook(() => useEditState('doc-1', 'book'))
+
+    const locked: EditStateFor = {...initialState, transactionSyncLock: {enabled: true}}
+
+    act(() => {
+      mockEditState$.next(locked)
+    })
+
+    await waitFor(() => {
+      expect(result.current).toBe(locked)
+    })
+  })
+
+  it('keeps the result frozen across multiple structurally-equal emissions', () => {
+    const {result} = renderHook(() => useEditState('doc-1', 'book'))
+    const before = result.current
+
+    act(() => {
+      mockEditState$.next({...initialState})
+      mockEditState$.next({...initialState})
+      mockEditState$.next({...initialState})
+    })
+
+    expect(result.current).toBe(before)
+  })
+
+  // Extracted to keep callback nesting within lint limits and avoid duplication
+  // across the two parameter cases below.
+  function expectInvalidVersionThrows(version: 'published' | 'draft') {
+    // renderHook surfaces the throw but React also logs it; silence the noise.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(vi.fn())
+    try {
+      expect(() => renderHook(() => useEditState('doc-1', 'book', 'default', version))).toThrow(
+        'Version cannot be published or draft',
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
+  }
+
+  it('throws when version is "published"', () => expectInvalidVersionThrows('published'))
+  it('throws when version is "draft"', () => expectInvalidVersionThrows('draft'))
+
+  it('priority="low" debounces bursts of emissions', () => {
+    vi.useFakeTimers()
+    try {
+      const {result} = renderHook(() => useEditState('doc-1', 'book', 'low'))
+      // take(1) lets the first value through immediately
+      expect(result.current).toBe(initialState)
+
+      const newer: EditStateFor = {
+        ...initialState,
+        ready: true,
+        draft: {
+          _id: 'drafts.doc-1',
+          _type: 'book',
+          _rev: 'r1',
+          _createdAt: '2024-01-01T00:00:00Z',
+          _updatedAt: '2024-01-01T00:00:00Z',
+        },
+      }
+
+      act(() => {
+        mockEditState$.next(newer)
+      })
+
+      // debounce window not yet elapsed
+      expect(result.current).toBe(initialState)
+
+      act(() => {
+        vi.advanceTimersByTime(1100)
+      })
+
+      expect(result.current).toBe(newer)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/packages/sanity/src/core/hooks/useEditState.ts
+++ b/packages/sanity/src/core/hooks/useEditState.ts
@@ -1,6 +1,7 @@
+import isEqual from 'lodash-es/isEqual.js'
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
-import {debounce, merge, share, skip, take, timer} from 'rxjs'
+import {debounce, distinctUntilChanged, merge, share, skip, take, timer} from 'rxjs'
 
 import {type EditStateFor, useDocumentStore} from '../store'
 
@@ -17,8 +18,10 @@ export function useEditState(
   const documentStore = useDocumentStore()
 
   const observable = useMemo(() => {
+    const source = documentStore.pair.editState(publishedDocId, docTypeName, version)
+
     if (priority === 'low') {
-      const base = documentStore.pair.editState(publishedDocId, docTypeName, version).pipe(share())
+      const base = source.pipe(share())
 
       return merge(
         base.pipe(take(1)),
@@ -26,10 +29,13 @@ export function useEditState(
           skip(1),
           debounce(() => timer(1000)),
         ),
-      )
+      ).pipe(distinctUntilChanged(isEqual))
     }
 
-    return documentStore.pair.editState(publishedDocId, docTypeName, version)
+    // Dedupe re-emissions of structurally-equal EditStateFor values. The upstream pipeline
+    // (combineLatest + map in editState.ts) creates a fresh object on every emission even
+    // when contents are unchanged, which causes spurious React re-renders and form recomputes.
+    return source.pipe(distinctUntilChanged(isEqual))
   }, [docTypeName, documentStore.pair, priority, publishedDocId, version])
   /**
    * We know that since the observable has a startWith operator, it will always emit a value

--- a/packages/sanity/src/core/hooks/useEditState.ts
+++ b/packages/sanity/src/core/hooks/useEditState.ts
@@ -1,9 +1,19 @@
-import isEqual from 'lodash-es/isEqual.js'
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
-import {debounce, distinctUntilChanged, merge, share, skip, take, timer} from 'rxjs'
+import {debounce, distinctUntilChanged, merge, share, shareReplay, skip, take, timer} from 'rxjs'
 
 import {type EditStateFor, useDocumentStore} from '../store'
+
+// `editState.ts` allocates a fresh outer object per emission, but draft/published/
+// version snapshot references are preserved upstream when contents are unchanged.
+// Reference comparison on those + ready + transactionSyncLock is therefore enough
+// and avoids a deep walk on large documents.
+const isSameEditState = (prev: EditStateFor, next: EditStateFor): boolean =>
+  prev.draft === next.draft &&
+  prev.published === next.published &&
+  prev.version === next.version &&
+  prev.ready === next.ready &&
+  prev.transactionSyncLock === next.transactionSyncLock
 
 /** @internal */
 export function useEditState(
@@ -29,13 +39,13 @@ export function useEditState(
           skip(1),
           debounce(() => timer(1000)),
         ),
-      ).pipe(distinctUntilChanged(isEqual))
+      ).pipe(distinctUntilChanged(isSameEditState), shareReplay({bufferSize: 1, refCount: true}))
     }
 
-    // Dedupe re-emissions of structurally-equal EditStateFor values. The upstream pipeline
-    // (combineLatest + map in editState.ts) creates a fresh object on every emission even
-    // when contents are unchanged, which causes spurious React re-renders and form recomputes.
-    return source.pipe(distinctUntilChanged(isEqual))
+    return source.pipe(
+      distinctUntilChanged(isSameEditState),
+      shareReplay({bufferSize: 1, refCount: true}),
+    )
   }, [docTypeName, documentStore.pair, priority, publishedDocId, version])
   /**
    * We know that since the observable has a startWith operator, it will always emit a value

--- a/packages/sanity/src/core/hooks/useEditState.ts
+++ b/packages/sanity/src/core/hooks/useEditState.ts
@@ -4,10 +4,9 @@ import {debounce, distinctUntilChanged, merge, share, shareReplay, skip, take, t
 
 import {type EditStateFor, useDocumentStore} from '../store'
 
-// `editState.ts` allocates a fresh outer object per emission, but draft/published/
-// version snapshot references are preserved upstream when contents are unchanged.
-// Reference comparison on those + ready + transactionSyncLock is therefore enough
-// and avoids a deep walk on large documents.
+// Snapshot refs (draft/published/version) are preserved upstream when content
+// hasn't changed, so ref equality on those + ready + transactionSyncLock catches
+// real changes without a deep walk. Upstream contract: `document-pair/editState.test.ts`.
 const isSameEditState = (prev: EditStateFor, next: EditStateFor): boolean =>
   prev.draft === next.draft &&
   prev.published === next.published &&

--- a/packages/sanity/src/core/store/document/document-pair/editState.test.ts
+++ b/packages/sanity/src/core/store/document/document-pair/editState.test.ts
@@ -33,9 +33,10 @@ function createCtx() {
  * `draft`/`published`/`version` references on the emitted `EditStateFor` must be
  * the same object identities as the previous emission.
  *
- * If a future refactor adds a `.pipe(map(d => ({...d})))` or similar fresh-wrapper
- * step anywhere in this file, this test will fail — and the dedupe in
- * `useEditState` would silently become a no-op without it.
+ * This specifically guards against a refactor that clones or recreates those
+ * snapshot refs during transaction-sync re-emissions (for example by rebuilding
+ * the emitted `EditStateFor` with fresh `draft`/`published`/`version` objects),
+ * which would make `useEditState`'s shallow dedupe silently become a no-op.
  */
 describe('editState — snapshot identity preservation', () => {
   beforeEach(() => {

--- a/packages/sanity/src/core/store/document/document-pair/editState.test.ts
+++ b/packages/sanity/src/core/store/document/document-pair/editState.test.ts
@@ -1,0 +1,163 @@
+import {type SanityClient} from '@sanity/client'
+import {type SanityDocument} from '@sanity/types'
+import {of, Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createMockSanityClient} from '../../../../../test/mocks/mockSanityClient'
+import {createSchema} from '../../../schema'
+import {type PendingMutationsEvent} from '../types'
+import {editState, type EditStateFor} from './editState'
+import {snapshotPair} from './snapshotPair'
+
+vi.mock('./snapshotPair', () => ({snapshotPair: vi.fn()}))
+
+const mockedSnapshotPair = vi.mocked(snapshotPair)
+
+const schema = createSchema({
+  name: 'default',
+  types: [{name: 'book', type: 'document', fields: [{name: 'title', type: 'string'}]}],
+})
+
+function createCtx() {
+  return {
+    client: createMockSanityClient() as any as SanityClient,
+    schema,
+    serverActionsEnabled: of(false),
+  }
+}
+
+/**
+ * Regression test for the upstream invariant that `useEditState`'s shallow
+ * deduplication (see `packages/sanity/src/core/hooks/useEditState.ts`) depends on:
+ * when `combineLatest` re-emits because `transactionsPendingEvents$` toggles, the
+ * `draft`/`published`/`version` references on the emitted `EditStateFor` must be
+ * the same object identities as the previous emission.
+ *
+ * If a future refactor adds a `.pipe(map(d => ({...d})))` or similar fresh-wrapper
+ * step anywhere in this file, this test will fail — and the dedupe in
+ * `useEditState` would silently become a no-op without it.
+ */
+describe('editState — snapshot identity preservation', () => {
+  beforeEach(() => {
+    mockedSnapshotPair.mockReset()
+  })
+
+  it('reuses draft/published/version refs across transactionSyncLock re-emissions', () => {
+    const draft$ = new Subject<SanityDocument | null>()
+    const published$ = new Subject<SanityDocument | null>()
+    const version$ = new Subject<SanityDocument | null>()
+    const transactionsPendingEvents$ = new Subject<PendingMutationsEvent>()
+
+    mockedSnapshotPair.mockReturnValue(
+      of({
+        draft: {snapshots$: draft$.asObservable()},
+        published: {snapshots$: published$.asObservable()},
+        version: {snapshots$: version$.asObservable()},
+        transactionsPendingEvents$,
+      }) as any,
+    )
+
+    // Unique id per test run avoids the editState/swr memoize caches.
+    const publishedId = `book-${Math.random().toString(36).slice(2)}`
+    const idPair = {
+      publishedId,
+      draftId: `drafts.${publishedId}`,
+      versionId: `versions.rel.${publishedId}`,
+    }
+
+    const emissions: EditStateFor[] = []
+    const sub = editState(createCtx(), idPair, 'book').subscribe((value) => {
+      emissions.push(value)
+    })
+
+    const draftDoc: SanityDocument = {
+      _id: idPair.draftId,
+      _type: 'book',
+      _rev: 'r1',
+      _createdAt: '2024-01-01T00:00:00Z',
+      _updatedAt: '2024-01-01T00:00:00Z',
+    }
+    const publishedDoc: SanityDocument = {
+      _id: publishedId,
+      _type: 'book',
+      _rev: 'r1',
+      _createdAt: '2024-01-01T00:00:00Z',
+      _updatedAt: '2024-01-01T00:00:00Z',
+    }
+    const versionDoc: SanityDocument = {
+      _id: idPair.versionId,
+      _type: 'book',
+      _rev: 'r1',
+      _createdAt: '2024-01-01T00:00:00Z',
+      _updatedAt: '2024-01-01T00:00:00Z',
+    }
+
+    draft$.next(draftDoc)
+    published$.next(publishedDoc)
+    version$.next(versionDoc)
+
+    // Force re-emissions via combineLatest by toggling the lock. Snapshot refs
+    // upstream are unchanged, so each emission's draft/published/version should
+    // carry the exact same object identity.
+    transactionsPendingEvents$.next({type: 'pending', phase: 'begin'})
+    transactionsPendingEvents$.next({type: 'pending', phase: 'end'})
+    transactionsPendingEvents$.next({type: 'pending', phase: 'begin'})
+
+    sub.unsubscribe()
+
+    // Drop the `startWith(...)` placeholder; everything after must satisfy the
+    // identity contract.
+    const realEmissions = emissions.slice(1)
+    expect(realEmissions.length).toBeGreaterThanOrEqual(2)
+
+    for (const emission of realEmissions) {
+      expect(emission.draft).toBe(draftDoc)
+      expect(emission.published).toBe(publishedDoc)
+      expect(emission.version).toBe(versionDoc)
+    }
+  })
+
+  it('emits a new draft reference when the upstream draft snapshot changes', () => {
+    const draft$ = new Subject<SanityDocument | null>()
+    const published$ = new Subject<SanityDocument | null>()
+    const transactionsPendingEvents$ = new Subject<PendingMutationsEvent>()
+
+    mockedSnapshotPair.mockReturnValue(
+      of({
+        draft: {snapshots$: draft$.asObservable()},
+        published: {snapshots$: published$.asObservable()},
+        transactionsPendingEvents$,
+      }) as any,
+    )
+
+    const publishedId = `book-${Math.random().toString(36).slice(2)}`
+    const idPair = {publishedId, draftId: `drafts.${publishedId}`}
+
+    const emissions: EditStateFor[] = []
+    const sub = editState(createCtx(), idPair, 'book').subscribe((value) => {
+      emissions.push(value)
+    })
+
+    const draftA: SanityDocument = {
+      _id: idPair.draftId,
+      _type: 'book',
+      _rev: 'r1',
+      _createdAt: '2024-01-01T00:00:00Z',
+      _updatedAt: '2024-01-01T00:00:00Z',
+    }
+    const draftB: SanityDocument = {...draftA, _rev: 'r2', title: 'changed'} as SanityDocument
+
+    draft$.next(draftA)
+    published$.next(null)
+    draft$.next(draftB)
+
+    sub.unsubscribe()
+
+    const realEmissions = emissions.slice(1)
+    // First real emission is after all combineLatest inputs are ready; second is
+    // after the second draft$ emission.
+    expect(realEmissions).toHaveLength(2)
+    expect(realEmissions[0].draft).toBe(draftA)
+    expect(realEmissions[1].draft).toBe(draftB)
+  })
+})

--- a/packages/sanity/src/core/store/document/document-pair/editState.ts
+++ b/packages/sanity/src/core/store/document/document-pair/editState.ts
@@ -96,11 +96,12 @@ export const editState = memoize(
           })
         },
       ),
-      // NOTE: `useEditState` deduplicates emissions by shallow reference equality on
-      // `draft`/`published`/`version` downstream. The map below preserves those snapshot
-      // identities (it only allocates a new outer wrapper).
+      // NOTE: `useEditState` deduplicates emissions downstream using shallow equality on
+      // `draft`/`published`/`version` as well as `ready` and `transactionSyncLock`.
+      // The map below preserves the snapshot identities and only allocates a new outer
+      // wrapper while deriving those additional fields.
       //
-      // a regression that clones any of these references — example. `draft: {...draftSnapshot}` — would silently
+      // A regression that clones any of these references — example. `draft: {...draftSnapshot}` — would silently
       // turn that dedupe into a no-op. We have regression tests for this.
       map(
         ({

--- a/packages/sanity/src/core/store/document/document-pair/editState.ts
+++ b/packages/sanity/src/core/store/document/document-pair/editState.ts
@@ -96,6 +96,12 @@ export const editState = memoize(
           })
         },
       ),
+      // NOTE: `useEditState` deduplicates emissions by shallow reference equality on
+      // `draft`/`published`/`version` downstream. The map below preserves those snapshot
+      // identities (it only allocates a new outer wrapper).
+      //
+      // a regression that clones any of these references — example. `draft: {...draftSnapshot}` — would silently
+      // turn that dedupe into a no-op. We have regression tests for this.
       map(
         ({
           value: [draftSnapshot, publishedSnapshot, transactionSyncLock, versionSnapshot],


### PR DESCRIPTION
### Description

The document store re-emits new `EditStateFor` references on every snapshot tick (via `combineLatest` in `editState.ts`), even when contents are structurally unchanged. That churn propagated into `useDocumentForm` → `useFormState` and triggered `prepareFormState` walks on every click and presence tick.

Add `distinctUntilChanged(isEqual)` inside `useEditState` so structurally-equal emissions don't reach React. Every `useEditState` consumer benefits, not just `useDocumentForm`.

**My first thought was to do this at a consumer level, in the useDocumentForm:** patching `useDocumentForm` (with `useUnique`) but it would only fix one place. Thought about patching the source observable (`editState.ts`) but it has a wider blast radius into RxJS subscribers we'd need to vet which I'm not confident about doing without a wider set of tests there. `useEditState` ends up feeling like a good middle ground: covers React consumers I found and leaves the 1 raw RxJS consumer (`useDivergenceController`) untouched (it uses `find().complete()`, doesn't depend on emission count).

### What to review

- `packages/sanity/src/core/hooks/useEditState.ts`: single behavioural change
- `packages/sanity/src/core/hooks/__tests__/useEditState.test.tsx`: new tests pinning the dedupe contract.

### Testing

**Automated**

- New: `useEditState.test.tsx` — 4 cases pinning the dedupe contract (initial value, structurally-equal dedupe, content change passes through, deep-clone vs deep-change).
- Re-ran: `FormBuilder.test.tsx`, `checkoutPair.test.ts`, `selectUpstreamVersion.test.ts`, `isNewDocument.test.ts` — all pass, no regressions.

**Manual** (dev studio + dev-only `useFormState` recompute tracker, removed before this PR). This was in an effort to understand the actual winning. Manual tests were also done to review that incoming changes from a different browser would still land on the original doc (just in case)

| Scenario                                          | objectsDebug (deeply nested objects)         | booleansTest (boolean test and string)         | PTE-heavy  (pte changes)           |
| ------------------------------------------------- | --------------------- | --------------------- | --------------------- |
| Cold open `formState` recomputes                  | 4                     | 3                     | 4                     |
| Click 3 fields, no typing — `documentValue` churns | **0** (was 4–5)       | **0** (was 4–5)       | **0** (was 4–5)       |
| Type/toggle 1 character — `documentValue` events  | 2 (local change + server confirmation) | 2 (local change + server confirmation) | 2 (local change + server confirmation) |

The performance win is on field interaction: clicks no longer trigger spurious recomputes. The two events seen while typing are the legitimate ones, one when the keystroke is applied locally so the input feels responsive, and one when the server confirms the save. Nothing fires when the content is unchanged.

### Notes for release

N/A – Internal performance improvement, no behavioural change for end users.