### PR TITLE
fix(auth): guard access to browser-only globals in SSR environments

### DIFF
--- a/packages/sanity/src/core/store/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/authStore/createAuthStore.ts
@@ -282,15 +282,20 @@ export function _createAuthStore({
   // The tap triggers tokenStorage.update() which pushes to the BehaviorSubject
   // backing tokenStorage.value — so the actual emission comes from that stream.
   // switchMap to EMPTY so this branch produces no direct values.
-  const hashTokenChange = fromEvent(window, 'hashchange').pipe(
-    tap(() => {
-      const hashToken = consumeHashToken()
-      if (hashToken) {
-        tokenStorage.update({token: hashToken})
-      }
-    }),
-    switchMap(() => EMPTY),
-  )
+  // Guarded for SSR: `window` is undefined on the server, where we can't
+  // listen for hash changes anyway.
+  const hashTokenChange =
+    typeof window === 'undefined'
+      ? EMPTY
+      : fromEvent(window, 'hashchange').pipe(
+          tap(() => {
+            const hashToken = consumeHashToken()
+            if (hashToken) {
+              tokenStorage.update({token: hashToken})
+            }
+          }),
+          switchMap(() => EMPTY),
+        )
 
   const tokenClient$ = concat(
     of(initialTokenClient),

--- a/packages/sanity/src/core/store/authStore/createBroadcastState.ts
+++ b/packages/sanity/src/core/store/authStore/createBroadcastState.ts
@@ -57,6 +57,17 @@ export function createMemoryStorage<T>(): BroadcastedStateStorage<T> {
   return {load, store}
 }
 
+// `BroadcastChannel` is browser-only. In SSR (Next.js App Router, etc.) the
+// auth store is constructed during workspace evaluation on the server, where
+// the global is undefined. Fall back to a no-op channel so construction is
+// safe; cross-tab sync is meaningless on the server anyway.
+function createChannel(key: string): Pick<BroadcastChannel, 'postMessage' | 'close' | 'onmessage'> {
+  if (typeof BroadcastChannel === 'undefined') {
+    return {postMessage: () => {}, close: () => {}, onmessage: null}
+  }
+  return new BroadcastChannel(key)
+}
+
 export function createBroadcastState(key: string): BroadcastedState<void>
 export function createBroadcastState<T>(
   key: string,
@@ -72,7 +83,7 @@ export function createBroadcastState<T>(
   initial?: (current: T | undefined) => T | undefined,
   storage: BroadcastedStateStorage<T> = createMemoryStorage(),
 ): BroadcastedState<T> {
-  const channel = new BroadcastChannel(key)
+  const channel = createChannel(key)
   const subject = new BehaviorSubject<T | undefined>(initial?.(storage.load()))
 
   storage.store(subject.getValue())

--- a/packages/sanity/test/node-environment.test.ts
+++ b/packages/sanity/test/node-environment.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment node
+import {describe, expect, it} from 'vitest'
+
+import {defineConfig} from '../src/core/config/defineConfig'
+import {prepareConfig} from '../src/core/config/prepareConfig'
+
+// Runs it the Node environment to catch issues with accessing browser-only globals
+// during e.g. Next.js server rendering, CLI scripts, scheduled jobs, etc.
+describe('prepareConfig (Node environment)', () => {
+  it('runs without `window` or `localStorage` defined', () => {
+    expect(typeof window).toBe('undefined')
+    expect(typeof localStorage).toBe('undefined')
+  })
+
+  it('does not throw when called from Node', () => {
+    const config = defineConfig({
+      name: 'default',
+      projectId: 'node-test',
+      dataset: 'node',
+      schema: {types: []},
+    })
+
+    expect(() => prepareConfig(config)).not.toThrow()
+  })
+})


### PR DESCRIPTION
### Description

The auth store refactor in #12679 made `_createAuthStore` access browser-only globals (`window`, `BroadcastChannel`) on the synchronous path. This broke SSR, see #12788.

### What to review
- Guards make sense?
- Note: BroadCastChannel is [defined in Node](https://nodejs.org/api/worker_threads.html#class-broadcastchannel-extends-eventtarget), but seems reasonable to include a guard regardless.

### Testing
- Included a regression test that calls prepareConfig in node using `// @vitest-environment node`, for catching similar future issues

### Notes for release
- Fixes a regression introduced in 5.23.0 that could cause the studio to crash during server-side rendering.
