### PR TITLE
fix(ci): restore provenance after pnpm 11 upgrade

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -35,7 +35,8 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Bump canary versions
-        run: pnpm --silent release-notes bump --preid=canary
+        # `--no-build-metadata` works around https://github.com/pnpm/pnpm/issues/11518
+        run: pnpm --silent release-notes bump --preid=canary --no-build-metadata
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped
@@ -56,6 +57,4 @@ jobs:
           echo "✅ npm authentication validated - using $EXPECTED_NPM_USER account"
 
       - name: Publish packages to npm
-        run: pnpm -r publish --tag canary --no-git-checks
-        env:
-          NPM_CONFIG_PROVENANCE: true
+        run: pnpm -r publish --tag canary --no-git-checks --provenance

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -123,9 +123,7 @@ jobs:
           echo "✅ npm authentication validated - using $EXPECTED_NPM_USER account"
 
       - name: Publish packages to npm
-        run: pnpm -r publish
-        env:
-          NPM_CONFIG_PROVENANCE: true
+        run: pnpm -r publish --provenance
 
   publish-releases:
     # Publish sanity.io Changelog & github release

--- a/.github/workflows/release-next-major.yml
+++ b/.github/workflows/release-next-major.yml
@@ -35,7 +35,8 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Bump next-major versions
-        run: pnpm --silent release-notes bump --preid=next-major
+        # `--no-build-metadata` works around https://github.com/pnpm/pnpm/issues/11518
+        run: pnpm --silent release-notes bump --preid=next-major --no-build-metadata
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped
@@ -56,9 +57,7 @@ jobs:
           echo "✅ npm authentication validated - using $EXPECTED_NPM_USER account"
 
       - name: Publish packages to npm
-        run: pnpm -r publish --tag next-major --no-git-checks
-        env:
-          NPM_CONFIG_PROVENANCE: true
+        run: pnpm -r publish --tag next-major --no-git-checks --provenance
 
       - name: Build bundles for staging
         env:

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -38,7 +38,8 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Bump next versions
-        run: pnpm --silent release-notes bump --preid=next --suffixType=commits-ahead
+        # `--no-build-metadata` works around https://github.com/pnpm/pnpm/issues/11518
+        run: pnpm --silent release-notes bump --preid=next --suffixType=commits-ahead --no-build-metadata
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped
@@ -59,9 +60,7 @@ jobs:
           echo "✅ npm authentication validated - using $EXPECTED_NPM_USER account"
 
       - name: Publish packages to npm
-        run: pnpm -r publish --tag next --no-git-checks
-        env:
-          NPM_CONFIG_PROVENANCE: true
+        run: pnpm -r publish --tag next --no-git-checks --provenance
 
       - name: Build bundles for staging
         env:

--- a/packages/@repo/release-notes/bin/release-notes.ts
+++ b/packages/@repo/release-notes/bin/release-notes.ts
@@ -39,6 +39,11 @@ await yargs(process.argv.slice(2))
           choices: ['timestamp', 'commits-ahead'] as const,
           default: 'timestamp' as const,
         },
+        buildMetadata: {
+          description: 'Append +<commitHash> build metadata to the version (default: true)',
+          type: 'boolean',
+          default: true,
+        },
         dryRun: {
           description: 'Print the new version without writing files',
           type: 'boolean',
@@ -49,6 +54,7 @@ await yargs(process.argv.slice(2))
         await bump({
           preid: args.preid,
           suffixType: args.suffixType,
+          buildMetadata: args.buildMetadata,
           dryRun: args.dryRun,
         })
       } catch (error) {

--- a/packages/@repo/release-notes/src/commands/bump.ts
+++ b/packages/@repo/release-notes/src/commands/bump.ts
@@ -13,6 +13,7 @@ export type SuffixType = 'timestamp' | 'commits-ahead'
 interface BumpOptions {
   preid?: string
   suffixType?: SuffixType
+  buildMetadata?: boolean
   dryRun?: boolean
 }
 
@@ -103,7 +104,7 @@ function writeVersion(packagePath: string, newVersion: string): void {
 }
 
 export async function bump(options: BumpOptions = {}): Promise<void> {
-  const {preid, suffixType = 'timestamp', dryRun} = options
+  const {preid, suffixType = 'timestamp', buildMetadata = true, dryRun} = options
 
   const currentVersion = readRootVersion()
   const git = readGitInfo()
@@ -114,11 +115,8 @@ export async function bump(options: BumpOptions = {}): Promise<void> {
   console.error(`Semver increment: ${semverIncrement}`)
 
   // Compute new version
-  const suffix = preid
-    ? suffixType === 'commits-ahead'
-      ? `${git.commitCount}+${git.commitHash}`
-      : `${formatTimestamp(now)}+${git.commitHash}`
-    : undefined
+  const base = suffixType === 'commits-ahead' ? git.commitCount : formatTimestamp(now)
+  const suffix = preid ? (buildMetadata ? `${base}+${git.commitHash}` : base) : undefined
 
   const newVersion = computeVersion({currentVersion, semverIncrement, preid, suffix})
 


### PR DESCRIPTION
### Description

After the pnpm 11 upgrade in #12759, published packages stopped carrying npm provenance.

This happened because pnpm 11 [no longer reads `npm_config_*` environment variables](https://github.com/pnpm/pnpm/releases/tag/v11.0.0) (must be `pnpm_config_*`), so the workflows'  `NPM_CONFIG_PROVENANCE: true` became a silent no-op.

This was fixed by instead explicitly passing `--provenance` to pnpm publish, however, this uncovered a regression in pnpm@11, causing `+buildmetadata` in versions to break publishing with provenance. See [pnpm/pnpm#11518](https://github.com/pnpm/pnpm/issues/11518). As a workaround for this, I've added a `--no-build-metadata` flag to the `release-notes bump`, dropping the `+build metadata` from published versions for now.

I considered changing to `5.25.0-canary.20260507102941.<sha>`, but afaik the only thing we need `+buildmetadata` for is to show a commit backlink from studio version dialog, which is very much non-critical.

### What to review

Version output, before/after:

| Workflow | Before | After |
| --- | --- | --- |
| `release-canary` | `5.25.0-canary.20260507102941+f2a94758bf` | `5.25.0-canary.20260507102941` |
| `release-next` | `5.25.0-next.42+f2a94758bf` | `5.25.0-next.42` |
| `release-latest` | `5.25.0` | `5.25.0` *(unchanged)* |

### Testing
Pushed this to the `canary`-branch and verified that it worked: https://github.com/sanity-io/sanity/actions/runs/25496706766/job/74818292735

### Notes for release

- restores npm provenance attestations on published packages
