### PR TITLE
fix: resolving z indexes issue with popovers inside document form

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -13,7 +13,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import {type DocumentActionDescription, useFieldActions, useTranslation} from 'sanity'
+import {type DocumentActionDescription, useFieldActions, useTranslation, useZIndex} from 'sanity'
 import {css, styled} from 'styled-components'
 
 import {Button, TooltipDelayGroupProvider} from '../../../../../ui-components'
@@ -105,6 +105,10 @@ export const DocumentPanelHeader = memo(
     const scrollContainerRef = useRef<HTMLDivElement>(null)
     const showGradient = useChipScrollPosition(scrollContainerRef)
     const telemetry = useTelemetry()
+    const zIndex = useZIndex()
+    const paneHeaderZIndex = Array.isArray(zIndex.paneHeader)
+      ? zIndex.paneHeader[1]
+      : zIndex.paneHeader
 
     const menuNodes = useMemo(
       () =>
@@ -192,7 +196,11 @@ export const DocumentPanelHeader = memo(
             backButton={backButton}
           />
         ) : (
-          <Card hidden={collapsed} style={{lineHeight: 0}} borderBottom>
+          <Card
+            hidden={collapsed}
+            style={{lineHeight: 0, position: 'relative', zIndex: paneHeaderZIndex}}
+            borderBottom
+          >
             <Flex gap={3} paddingY={3}>
               <HorizontalScroller $showGradient={showGradient}>
                 <Flex


### PR DESCRIPTION
### Description

Fixes [SAPP-3726](https://linear.app/sanity/issue/SAPP-3726/popovers-layer-over-version-chips-and-actions-bar) — popovers (e.g. the Portable Text "Edit Link" annotation editor) were rendering over the document panel's version chips bar and actions row.

The cause was `DocumentPanelHeader`'s outer `<Card>` was `position: static` (the default), so any `z-index` applied to it - directly or via the existing `LayerProvider` chain - was silently a no-op. The chips bar lost to body popovers (which paint at `z-index: 500`) on every screen.

This PR adds `position: relative` to the chips bar `<Card>` and consumes `zIndex.paneHeader` via `useZIndex()`.

Initially explored several other approaches that didn't pan out - moving `DocumentPanelSubHeader` to a higher level in `DocumentLayout`, wrapping containers in `LayerProvider` with bumped `zOffset`s, and adding `isolation: isolate` to `FormColumn` / `DocumentBox` - all of which were defeated by the same underlying problem: the chips bar wasn't a stacking context, so no amount of z-index plumbing around it had any effect.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Go to [this document](https://test-studio-git-fix-sapp-3726-doc-nav-z-index-issue.sanity.dev/test/structure/input-standard;portable-text;pt_allTheBellsAndWhistles;2f64fa65-beb5-4dc9-ac5d-c8151a14b512%2Cpath%3DwhitespacePreserve%255B_key%253D%253D%25223216dba87a9f%2522%255D.markDefs%255B_key%253D%253D%2522d1ff16f37cb6%2522%255D), open up the edit popover on the first portable text link and see that as you scroll the popover stays correctly behind all the headers and nav bars.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

Fixes bug where popovers (e.g. the Portable Text Edit Link editor) could render over the document pane's version chips and actions bar.