### PR TITLE
fix: hide register studio option from local dev mode studios

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesMenuItems.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesMenuItems.tsx
@@ -16,6 +16,7 @@ import {type SemVer} from 'semver'
 
 import {MenuItem} from '../../../../../ui-components'
 import {LoadingBlock} from '../../../../components/loadingBlock'
+import {isDev} from '../../../../environment'
 import {useTranslation} from '../../../../i18n'
 import {useEnvAwareSanityWebsiteUrl} from '../../../hooks/useEnvAwareSanityWebsiteUrl'
 import {useLiveUserApplication} from '../../../liveUserApplication/useLiveUserApplication'
@@ -178,7 +179,7 @@ function StudioRegistration() {
     window.open(url, '_blank', 'noopener,noreferrer')
   }, [projectId, sanityWebsiteUrl, canDeployStudio])
 
-  if (userApplication) {
+  if (userApplication || isDev) {
     return null
   }
 

--- a/packages/sanity/src/core/studio/components/navbar/resources/ResourcesMenuItems.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/ResourcesMenuItems.tsx
@@ -169,7 +169,7 @@ function StudioRegistration() {
   const sanityWebsiteUrl = useEnvAwareSanityWebsiteUrl()
   const workspaces = useWorkspaces()
   const projectId = workspaces[0]?.projectId
-  const canDeployStudio = useCanDeployStudio(!userApplication)
+  const canDeployStudio = useCanDeployStudio(!userApplication && !isDev)
 
   const handleRegisterStudio = useCallback(() => {
     if (!projectId || !canDeployStudio) return


### PR DESCRIPTION
### Description
Before PR:
<img width="221" height="226" alt="Screenshot 2026-05-07 at 18 15 43" src="https://github.com/user-attachments/assets/ff38bdd9-1734-4617-9962-e2c4e9712be0" />
'Register Studio' shows even when running in dev mode locally. Registering a localhost studio should not be something we recommend.

After PR:
<img width="225" height="229" alt="Screenshot 2026-05-07 at 18 14 52" src="https://github.com/user-attachments/assets/1bc99839-0ee3-4908-ae7d-72ef3badd12f" />
Hiding this menu item when in dev mode

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixing an issue where localhost running studios would suggest registering with Sanity
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
