### PR TITLE
fix(structure): guard against null formState in DivergencesProvider

### DIFF
--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -480,7 +480,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
     changesOpen,
     hasUpstreamVersion,
     displayInlineChanges,
-  })!
+  })
 
   const formStateRef = useRef(formState)
   useEffect(() => {
@@ -490,6 +490,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
   useComlinkViewHistory({editState})
 
   const handleSetOpenPath = (path: Path) => {
+    if (!formStateRef.current) return
     const ops = getExpandOperations(formStateRef.current, path)
     ops.forEach((op) => {
       if (op.type === 'expandPath') {

--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -106,7 +106,7 @@ interface DocumentFormValue extends Pick<NodeChronologyProps, 'hasUpstreamVersio
 
   ready: boolean
   value: SanityDocumentLike
-  formState: FormState
+  formState: FormState | null
   focusPath: Path
   validation: ValidationMarker[]
   permissions: PermissionCheckResult | undefined
@@ -119,7 +119,7 @@ interface DocumentFormValue extends Pick<NodeChronologyProps, 'hasUpstreamVersio
   onChange: (event: PatchEvent) => void
   onPathOpen: (path: Path) => void
   onProgrammaticFocus: (nextPath: Path) => void
-  formStateRef: RefObject<FormState>
+  formStateRef: RefObject<FormState | null>
   schemaType: ObjectSchemaType
 }
 

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -7,6 +7,7 @@ import {
 } from '@sanity/types'
 import {fromString as pathFromString, resolveKeyedPath} from '@sanity/util/paths'
 import {
+  type ComponentProps,
   type ComponentType,
   useCallback,
   useContext,
@@ -719,25 +720,27 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
 
   const divergencesContext = useContext(DocumentDivergencesContext)
 
+  // If `DocumentPaneProvider` is rendered as a descendant of another
+  // instance of `DivergencesProvider`, inherit its enabled state,
+  // rather than overriding it.
+  //
+  // This allows `DocumentPaneProvider` to appear as a descendant of
+  // `DivergencesProvider` with `enabled` explicitly set to `false`,
+  // without that explicit opt-out being overridden by the workspace's
+  // `advancedVersionControl.enabled` configuration.
+  const divergencesContextEnabled = divergencesContext?.enabled ?? advancedVersionControlEnabled
+
+  // Disable when `formState` or `schemaType` is transiently absent
+  // (e.g. a `hidden` callback returns true, or the schema is still loading).
+  const divergencesEnabled = divergencesContextEnabled && formState && schemaType
+  const divergencesProps: ComponentProps<typeof DivergencesProvider> = divergencesEnabled
+    ? {enabled: true, upstreamEditState, editState, subjectId: value._id, schemaType, formState}
+    : {enabled: false}
+
   return (
     <DocumentPaneInfoContext.Provider value={documentPaneInfo}>
       <DocumentPaneContext.Provider value={documentPane}>
-        <DivergencesProvider
-          // If `DocumentPaneProvider` is rendered as a descendant of another
-          // instance of `DivergencesProvider`, inherit its enabled state,
-          // rather than overriding it.
-          //
-          // This allows `DocumentPaneProvider` to appear as a descendant of
-          // `DivergencesProvider` with `enabled` explicitly set to `false`,
-          // without that explicit opt-out being overriden by the workspace's
-          // `advancedVersionControl.enabled` configuration.
-          enabled={divergencesContext?.enabled ?? advancedVersionControlEnabled}
-          upstreamEditState={upstreamEditState}
-          editState={editState}
-          subjectId={value._id}
-          schemaType={formState.schemaType}
-          formState={formState}
-        >
+        <DivergencesProvider {...divergencesProps}>
           <DivergenceAutofocus onProgrammaticFocus={onProgrammaticFocus} />
           <DocumentTitle
             isDeleted={isDeleted}

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -732,10 +732,12 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
 
   // Disable when `formState` or `schemaType` is transiently absent
   // (e.g. a `hidden` callback returns true, or the schema is still loading).
-  const divergencesEnabled = divergencesContextEnabled && formState && schemaType
-  const divergencesProps: ComponentProps<typeof DivergencesProvider> = divergencesEnabled
-    ? {enabled: true, upstreamEditState, editState, subjectId: value._id, schemaType, formState}
-    : {enabled: false}
+  const isDivergencesEnabled = Boolean(divergencesContextEnabled && formState && schemaType)
+
+  const divergencesProps: ComponentProps<typeof DivergencesProvider> =
+    isDivergencesEnabled && formState && schemaType
+      ? {enabled: true, upstreamEditState, editState, subjectId: value._id, schemaType, formState}
+      : {enabled: false}
 
   return (
     <DocumentPaneInfoContext.Provider value={documentPaneInfo}>


### PR DESCRIPTION
### Description

DocumentPaneProvider read `formState.schemaType` unguarded when wrapping the `DivergencesProvider` introduced in v5.17.0. `formState` can be null on initial render (for example, when a document type's `hidden` callback returns true), which crashes the document pane with `Cannot read properties of null (reading 'schemaType')`.

This change disables divergences when `formState` or `schemaType` is absent, and tightens `useDocumentForm`'s return type to `FormState | null` so future unguarded reads fail at compile time.

### What to review

### Testing

### Notes for release

Fixes a crash on the document pane (`Cannot read properties of null (reading 'schemaType')`) that could occur when opening documents whose schema relies on `hidden` callbacks. Divergences are now disabled until form state is fully resolved.