### PR TITLE
fix(releases): use selected timezone in perspective menu dates

### DIFF
--- a/packages/@repo/test-dts-exports/test/fixtures/sanity.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/sanity.test-d.ts
@@ -1565,6 +1565,7 @@ import type {
   useFilteredReleases,
   useFormattedDuration,
   UseFormattedDurationOptions,
+  useFormatRelativeLocalePublishDate,
   useFormBuilder,
   useFormCallbacks,
   useFormState,
@@ -6447,6 +6448,9 @@ describe('sanity', () => {
   })
   test('UseFormattedDurationOptions', () => {
     expectTypeOf<UseFormattedDurationOptions>().toBeObject()
+  })
+  test('useFormatRelativeLocalePublishDate', () => {
+    expectTypeOf<typeof useFormatRelativeLocalePublishDate>().toBeFunction()
   })
   test('useFormBuilder', () => {
     expectTypeOf<typeof useFormBuilder>().toBeFunction()

--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -56,6 +56,7 @@ export {
   useDocumentVersionInfo,
   useDocumentVersions,
   useDocumentVersionTypeSortedList,
+  useFormatRelativeLocalePublishDate,
   useIsReleaseActive,
   useOnlyHasVersions,
   useReleasesIds,

--- a/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenuItem.tsx
+++ b/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenuItem.tsx
@@ -13,14 +13,11 @@ import {usePerspective} from '../../perspective/usePerspective'
 import {useSetPerspective} from '../../perspective/useSetPerspective'
 import {ReleaseAvatarIcon} from '../../releases/components/ReleaseAvatar'
 import {ReleaseTitle} from '../../releases/components/ReleaseTitle'
+import {useFormatRelativeLocalePublishDate} from '../../releases/hooks/useFormatRelativeLocalePublishDate'
 import {isReleaseDocument} from '../../releases/store/types'
 import {LATEST, PUBLISHED} from '../../releases/util/const'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
-import {
-  formatRelativeLocalePublishDate,
-  isDraftPerspective,
-  isReleaseScheduledOrScheduling,
-} from '../../releases/util/util'
+import {isDraftPerspective, isReleaseScheduledOrScheduling} from '../../releases/util/util'
 import {useWorkspace} from '../../studio/workspace'
 import {type ReleasesNavMenuItemPropsGetter} from '../types'
 import {GlobalPerspectiveMenuItemIndicator} from './PerspectiveLayerIndicator'
@@ -101,6 +98,7 @@ export const GlobalPerspectiveMenuItem = forwardRef<
   const {selectedPerspective, selectedPerspectiveName} = usePerspective()
   const setPerspective = useSetPerspective()
   const {toggleExcludedPerspective, isPerspectiveExcluded} = useExcludedPerspective()
+  const formatPublishDate = useFormatRelativeLocalePublishDate()
   const releaseId = isReleaseDocument(release)
     ? getReleaseIdFromReleaseDocumentId(release._id)
     : release
@@ -200,7 +198,7 @@ export const GlobalPerspectiveMenuItem = forwardRef<
               release.metadata.releaseType === 'scheduled' &&
               (release.publishAt || release.metadata.intendedPublishAt) && (
                 <Text muted size={1}>
-                  {formatRelativeLocalePublishDate(release)}
+                  {formatPublishDate(release)}
                 </Text>
               )}
           </Stack>

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuItem.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuItem.tsx
@@ -4,7 +4,8 @@ import {Flex, Stack, Text} from '@sanity/ui'
 import {memo} from 'react'
 
 import {useTranslation} from '../../../../i18n'
-import {formatRelativeLocalePublishDate, isReleaseScheduledOrScheduling} from '../../../util/util'
+import {useFormatRelativeLocalePublishDate} from '../../../hooks/useFormatRelativeLocalePublishDate'
+import {isReleaseScheduledOrScheduling} from '../../../util/util'
 import {ReleaseAvatar} from '../../ReleaseAvatar'
 import {ReleaseTitle} from '../../ReleaseTitle'
 
@@ -13,6 +14,7 @@ export const VersionContextMenuItem = memo(function VersionContextMenuItem(props
 }) {
   const {release} = props
   const {t} = useTranslation()
+  const formatPublishDate = useFormatRelativeLocalePublishDate()
   const isScheduled = isReleaseScheduledOrScheduling(release)
 
   return (
@@ -28,7 +30,7 @@ export const VersionContextMenuItem = memo(function VersionContextMenuItem(props
           {release.metadata.releaseType === 'asap' && <>{t('release.type.asap')}</>}
           {release.metadata.releaseType === 'scheduled' &&
             (release.metadata.intendedPublishAt ? (
-              <>{formatRelativeLocalePublishDate(release)}</>
+              <>{formatPublishDate(release)}</>
             ) : (
               /** should not be allowed to do, but a fall back in case if somehow no date is added */
               <>{t('release.chip.tooltip.unknown-date')}</>

--- a/packages/sanity/src/core/releases/hooks/index.ts
+++ b/packages/sanity/src/core/releases/hooks/index.ts
@@ -1,6 +1,7 @@
 export * from './useCopyToDrafts'
 export * from './useDocumentVersions'
 export * from './useDocumentVersionTypeSortedList'
+export * from './useFormatRelativeLocalePublishDate'
 export * from './useIsReleaseActive'
 export * from './useOnlyHasVersions'
 export * from './useVersionOperations'

--- a/packages/sanity/src/core/releases/hooks/useFormatRelativeLocalePublishDate.ts
+++ b/packages/sanity/src/core/releases/hooks/useFormatRelativeLocalePublishDate.ts
@@ -1,0 +1,25 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {useCallback} from 'react'
+
+import {useTimeZone} from '../../hooks/useTimeZone'
+import {CONTENT_RELEASES_TIME_ZONE_SCOPE} from '../../studio/constants'
+import {formatRelativeLocalePublishDate} from '../util/util'
+
+/**
+ * Returns a formatter that renders a release's publish date as a locale-aware
+ * relative string ("today at 10:20 AM", "tomorrow at 09:00 AM", etc.) interpreted
+ * in the user's selected content-releases timezone.
+ *
+ * Factory shape: the hook itself is called unconditionally at the top of a
+ * component (Rules of Hooks compliant); the returned function may be invoked
+ * conditionally inside JSX.
+ *
+ * @internal
+ */
+export function useFormatRelativeLocalePublishDate(): (release: ReleaseDocument) => string {
+  const {timeZone} = useTimeZone(CONTENT_RELEASES_TIME_ZONE_SCOPE)
+  return useCallback(
+    (release: ReleaseDocument) => formatRelativeLocalePublishDate(release, timeZone.name),
+    [timeZone.name],
+  )
+}

--- a/packages/sanity/src/core/releases/hooks/useFormatRelativeLocalePublishDate.ts
+++ b/packages/sanity/src/core/releases/hooks/useFormatRelativeLocalePublishDate.ts
@@ -6,13 +6,9 @@ import {CONTENT_RELEASES_TIME_ZONE_SCOPE} from '../../studio/constants'
 import {formatRelativeLocalePublishDate} from '../util/util'
 
 /**
- * Returns a formatter that renders a release's publish date as a locale-aware
- * relative string ("today at 10:20 AM", "tomorrow at 09:00 AM", etc.) interpreted
- * in the user's selected content-releases timezone.
- *
- * Factory shape: the hook itself is called unconditionally at the top of a
- * component (Rules of Hooks compliant); the returned function may be invoked
- * conditionally inside JSX.
+ * Returns a function that formats a release's publish date in the studio's
+ * selected content-releases timezone (e.g. "today at 10:20 AM"). The returned
+ * function is safe to call inside conditional JSX.
  *
  * @internal
  */

--- a/packages/sanity/src/core/releases/util/util.ts
+++ b/packages/sanity/src/core/releases/util/util.ts
@@ -47,12 +47,25 @@ export function getPublishDateFromRelease(release: ReleaseDocument): Date | null
   return new Date(dateString)
 }
 
-/** @internal */
-export function formatRelativeLocalePublishDate(release: ReleaseDocument): string {
+/**
+ * Formats a release's publish date as a locale-aware relative string.
+ *
+ * When `timeZone` is omitted, the host runtime's timezone is used (the user's
+ * system TZ in browsers; the host machine's TZ in Node/SSR — pass an explicit
+ * IANA zone in non-browser environments). Inside React components, prefer
+ * `useFormatRelativeLocalePublishDate` — it binds the user's selected studio
+ * timezone automatically.
+ *
+ * @internal
+ */
+export function formatRelativeLocalePublishDate(
+  release: ReleaseDocument,
+  timeZone?: string,
+): string {
   const publishDate = getPublishDateFromRelease(release)
 
   if (!publishDate) return ''
-  return formatRelativeLocale(publishDate, new Date())
+  return formatRelativeLocale(publishDate, new Date(), timeZone)
 }
 
 /** @internal */

--- a/packages/sanity/src/core/releases/util/util.ts
+++ b/packages/sanity/src/core/releases/util/util.ts
@@ -48,13 +48,9 @@ export function getPublishDateFromRelease(release: ReleaseDocument): Date | null
 }
 
 /**
- * Formats a release's publish date as a locale-aware relative string.
- *
- * When `timeZone` is omitted, the host runtime's timezone is used (the user's
- * system TZ in browsers; the host machine's TZ in Node/SSR — pass an explicit
- * IANA zone in non-browser environments). Inside React components, prefer
- * `useFormatRelativeLocalePublishDate` — it binds the user's selected studio
- * timezone automatically.
+ * Formats a release's publish date as a locale-aware relative string. `timeZone`
+ * defaults to the host runtime's TZ; inside React components, prefer
+ * `useFormatRelativeLocalePublishDate` to bind the studio's selected timezone.
  *
  * @internal
  */

--- a/packages/sanity/src/core/util/__tests__/formatRelativeLocale.test.ts
+++ b/packages/sanity/src/core/util/__tests__/formatRelativeLocale.test.ts
@@ -1,3 +1,4 @@
+import {tz} from '@date-fns/tz'
 import {formatRelative} from 'date-fns/formatRelative'
 import {describe, expect, it} from 'vitest'
 
@@ -9,23 +10,55 @@ describe('formatRelativeLocale', () => {
   it('should return relative format for dates within a week', () => {
     const dateWithinWeek = new Date(currentDate.getTime() + 2 * 24 * 60 * 60 * 1000) // 2 days later
 
-    const result = formatRelativeLocale(dateWithinWeek, currentDate)
-    expect(result).toBe(formatRelative(dateWithinWeek, currentDate)) // Should match formatRelative directly
+    const result = formatRelativeLocale(dateWithinWeek, currentDate, 'UTC')
+    // Should match formatRelative when both interpret the dates in UTC
+    expect(result).toBe(formatRelative(dateWithinWeek, currentDate, {in: tz('UTC')}))
   })
 
   it('should return a locale date string for dates more than a week away', () => {
     const dateMoreThanAWeek = new Date(currentDate.getTime() + 10 * 24 * 60 * 60 * 1000) // 10 days later
 
-    const result = formatRelativeLocale(dateMoreThanAWeek, currentDate)
-    // expect locale string (MM/dd/yyyy format)
-    expect(result).toBe(dateMoreThanAWeek.toLocaleDateString())
+    const result = formatRelativeLocale(dateMoreThanAWeek, currentDate, 'UTC')
+    // expect locale string in UTC zone
+    expect(result).toBe(dateMoreThanAWeek.toLocaleDateString(undefined, {timeZone: 'UTC'}))
   })
 
   it('should return locale date string for past dates more than a week ago', () => {
     const dateMoreThanAWeekAgo = new Date(currentDate.getTime() - 10 * 24 * 60 * 60 * 1000) // 10 days ago
 
-    const result = formatRelativeLocale(dateMoreThanAWeekAgo, currentDate)
-    // Expected to be in locale format
-    expect(result).toBe(dateMoreThanAWeekAgo.toLocaleDateString())
+    const result = formatRelativeLocale(dateMoreThanAWeekAgo, currentDate, 'UTC')
+    expect(result).toBe(dateMoreThanAWeekAgo.toLocaleDateString(undefined, {timeZone: 'UTC'}))
+  })
+
+  it('renders the time portion in the provided timeZone', () => {
+    // Same UTC instants, different wall-clock time per zone:
+    //   target = 2023-10-02T01:00:00Z  -> 10:00 in Asia/Tokyo, 21:00 in America/New_York
+    //   base   = 2023-10-01T22:00:00Z  -> 07:00 (Oct 2) in Tokyo, 18:00 (Oct 1) in New_York
+    // In each zone, target and base fall on the same calendar day, so both render as "today at <time>".
+    const baseDate = new Date('2023-10-01T22:00:00Z')
+    const target = new Date('2023-10-02T01:00:00Z')
+
+    const tokyo = formatRelativeLocale(target, baseDate, 'Asia/Tokyo')
+    const newYork = formatRelativeLocale(target, baseDate, 'America/New_York')
+
+    expect(tokyo).toMatch(/today at/i)
+    expect(newYork).toMatch(/today at/i)
+    expect(tokyo).not.toEqual(newYork)
+    expect(tokyo).toContain('10:00')
+    expect(newYork).toContain('9:00 PM')
+  })
+
+  it('crosses the relative-day boundary based on the provided timeZone', () => {
+    // 2023-10-01T15:00:00Z is:
+    //   - Oct 1 23:00 in Asia/Singapore (+08:00)  -> "today" relative to Oct 1 16:00 SGT (08:00:00Z)
+    //   - Oct 2 04:00 in Pacific/Auckland (+13:00) -> "tomorrow" relative to Oct 1 21:00 NZDT (08:00:00Z)
+    const baseDate = new Date('2023-10-01T08:00:00Z') // Oct 1 in both zones
+    const target = new Date('2023-10-01T15:00:00Z')
+
+    const singapore = formatRelativeLocale(target, baseDate, 'Asia/Singapore')
+    const auckland = formatRelativeLocale(target, baseDate, 'Pacific/Auckland')
+
+    expect(singapore).toMatch(/today at/i)
+    expect(auckland).toMatch(/tomorrow at/i)
   })
 })

--- a/packages/sanity/src/core/util/__tests__/formatRelativeLocale.test.ts
+++ b/packages/sanity/src/core/util/__tests__/formatRelativeLocale.test.ts
@@ -31,34 +31,29 @@ describe('formatRelativeLocale', () => {
   })
 
   it('renders the time portion in the provided timeZone', () => {
-    // Same UTC instants, different wall-clock time per zone:
-    //   target = 2023-10-02T01:00:00Z  -> 10:00 in Asia/Tokyo, 21:00 in America/New_York
-    //   base   = 2023-10-01T22:00:00Z  -> 07:00 (Oct 2) in Tokyo, 18:00 (Oct 1) in New_York
-    // In each zone, target and base fall on the same calendar day, so both render as "today at <time>".
+    // Both zones never observe DST, so the offsets stay constant year-round.
     const baseDate = new Date('2023-10-01T22:00:00Z')
     const target = new Date('2023-10-02T01:00:00Z')
 
     const tokyo = formatRelativeLocale(target, baseDate, 'Asia/Tokyo')
-    const newYork = formatRelativeLocale(target, baseDate, 'America/New_York')
+    const honolulu = formatRelativeLocale(target, baseDate, 'Pacific/Honolulu')
 
     expect(tokyo).toMatch(/today at/i)
-    expect(newYork).toMatch(/today at/i)
-    expect(tokyo).not.toEqual(newYork)
-    expect(tokyo).toContain('10:00')
-    expect(newYork).toContain('9:00 PM')
+    expect(honolulu).toMatch(/today at/i)
+    expect(tokyo).not.toEqual(honolulu)
+    expect(tokyo).toContain('10:00') // 01:00 UTC = 10:00 in Tokyo (+09)
+    expect(honolulu).toContain('3:00 PM') // 01:00 UTC = 15:00 in Honolulu (-10)
   })
 
   it('crosses the relative-day boundary based on the provided timeZone', () => {
-    // 2023-10-01T15:00:00Z is:
-    //   - Oct 1 23:00 in Asia/Singapore (+08:00)  -> "today" relative to Oct 1 16:00 SGT (08:00:00Z)
-    //   - Oct 2 04:00 in Pacific/Auckland (+13:00) -> "tomorrow" relative to Oct 1 21:00 NZDT (08:00:00Z)
-    const baseDate = new Date('2023-10-01T08:00:00Z') // Oct 1 in both zones
+    // Both zones never observe DST, so the offsets stay constant year-round.
+    const baseDate = new Date('2023-10-01T08:00:00Z')
     const target = new Date('2023-10-01T15:00:00Z')
 
     const singapore = formatRelativeLocale(target, baseDate, 'Asia/Singapore')
-    const auckland = formatRelativeLocale(target, baseDate, 'Pacific/Auckland')
+    const brisbane = formatRelativeLocale(target, baseDate, 'Australia/Brisbane')
 
-    expect(singapore).toMatch(/today at/i)
-    expect(auckland).toMatch(/tomorrow at/i)
+    expect(singapore).toMatch(/today at/i) // Oct 1 23:00 in Singapore (+08), same day as base
+    expect(brisbane).toMatch(/tomorrow at/i) // Oct 2 01:00 in Brisbane (+10), next day from base
   })
 })

--- a/packages/sanity/src/core/util/formatRelativeLocale.ts
+++ b/packages/sanity/src/core/util/formatRelativeLocale.ts
@@ -8,16 +8,13 @@ type DateInput = Date | number | string
 const RUNTIME_TIME_ZONE = Intl.DateTimeFormat().resolvedOptions().timeZone
 
 /**
- * date-fns `formatRelative` defaults to formatting as `MM/dd/yyyy` (en-US) when the date is more
- * than ~6 days from `baseDate`. `formatRelativeLocale` substitutes that fallback with the
- * browser's locale date format so non-en-US users don't see American-style dates.
+ * Renders `date` relative to `baseDate` in `timeZone`. Replaces date-fns's en-US
+ * `MM/dd/yyyy` fallback (used for dates more than ~6 days out) with the browser's
+ * locale date format, so non-en-US users don't see American-style dates.
  *
- * Relative-day boundaries, time portions, and the locale fallback are all interpreted in
- * `timeZone`. When omitted, the host runtime's timezone is used (matching native JS date
- * formatting defaults). In browsers this is the user's system TZ; in Node/SSR it is the host
- * machine's TZ — pass an explicit IANA zone in non-browser environments. To render in the
- * user's selected studio timezone, callers should pass the appropriate zone — typically
- * from a hook that binds the current studio timezone (e.g., one that wraps `useTimeZone`).
+ * `timeZone` defaults to the host runtime's TZ. Pass an explicit IANA zone for
+ * non-browser contexts or to render in the user's selected studio timezone (e.g.
+ * via a hook that wraps `useTimeZone`).
  *
  * @internal
  */
@@ -27,10 +24,7 @@ export const formatRelativeLocale = (
   timeZone: string = RUNTIME_TIME_ZONE,
 ): string => {
   const relative = formatRelative(date, baseDate, {in: tzHelper(timeZone)})
-  // Heuristic: date-fns's en-US "Other" bucket renders as MM/dd/yyyy. Detecting it lets us
-  // swap in a browser-locale calendar string so non-en-US users don't see American dates.
-  // If date-fns ever changes that fallback shape (or a locale option is threaded through),
-  // this branch silently stops triggering.
+  // Detect date-fns's en-US `MM/dd/yyyy` fallback and swap in a browser-locale string.
   if (isValid(parse(relative, 'MM/dd/yyyy', new Date()))) {
     return new Date(date).toLocaleDateString(undefined, {timeZone})
   }

--- a/packages/sanity/src/core/util/formatRelativeLocale.ts
+++ b/packages/sanity/src/core/util/formatRelativeLocale.ts
@@ -1,20 +1,38 @@
+import {tz as tzHelper} from '@date-fns/tz'
 import {formatRelative} from 'date-fns/formatRelative'
 import {isValid} from 'date-fns/isValid'
 import {parse} from 'date-fns/parse'
 
+type DateInput = Date | number | string
+
+const RUNTIME_TIME_ZONE = Intl.DateTimeFormat().resolvedOptions().timeZone
+
 /**
- * date-fns `formatRelative` defaults to formatting as `mm/dd/yyyy` if the date is more/less than
- * a week away. `formatRelativeLocale` will adjust formatting in these cases to match the correct
- * locale format.
+ * date-fns `formatRelative` defaults to formatting as `MM/dd/yyyy` (en-US) when the date is more
+ * than ~6 days from `baseDate`. `formatRelativeLocale` substitutes that fallback with the
+ * browser's locale date format so non-en-US users don't see American-style dates.
+ *
+ * Relative-day boundaries, time portions, and the locale fallback are all interpreted in
+ * `timeZone`. When omitted, the host runtime's timezone is used (matching native JS date
+ * formatting defaults). In browsers this is the user's system TZ; in Node/SSR it is the host
+ * machine's TZ — pass an explicit IANA zone in non-browser environments. To render in the
+ * user's selected studio timezone, callers should pass the appropriate zone — typically
+ * from a hook that binds the current studio timezone (e.g., one that wraps `useTimeZone`).
+ *
  * @internal
  */
-export const formatRelativeLocale = (...args: Parameters<typeof formatRelative>) => {
-  const dateFnsRelative = formatRelative(...args)
-
-  // if date is of format mm/dd/yyyy, format as a locale string instead
-  if (isValid(parse(dateFnsRelative, 'MM/dd/yyyy', new Date()))) {
-    const [dateTime] = args
-    return new Date(dateTime).toLocaleDateString()
+export const formatRelativeLocale = (
+  date: DateInput,
+  baseDate: DateInput,
+  timeZone: string = RUNTIME_TIME_ZONE,
+): string => {
+  const relative = formatRelative(date, baseDate, {in: tzHelper(timeZone)})
+  // Heuristic: date-fns's en-US "Other" bucket renders as MM/dd/yyyy. Detecting it lets us
+  // swap in a browser-locale calendar string so non-en-US users don't see American dates.
+  // If date-fns ever changes that fallback shape (or a locale option is threaded through),
+  // this branch silently stops triggering.
+  if (isValid(parse(relative, 'MM/dd/yyyy', new Date()))) {
+    return new Date(date).toLocaleDateString(undefined, {timeZone})
   }
-  return dateFnsRelative
+  return relative
 }

--- a/packages/sanity/src/structure/diffView/versionMode/components/VersionModeHeader.tsx
+++ b/packages/sanity/src/structure/diffView/versionMode/components/VersionModeHeader.tsx
@@ -17,7 +17,6 @@ import {type TFunction} from 'i18next'
 import {type ComponentProps, type ComponentType, useMemo} from 'react'
 import {
   type DocumentLayoutProps,
-  formatRelativeLocalePublishDate,
   getDraftId,
   getPublishedId,
   getReleaseIdFromReleaseDocumentId,
@@ -36,6 +35,7 @@ import {
   useActiveReleases,
   useDocumentVersions,
   useEditState,
+  useFormatRelativeLocalePublishDate,
   useTranslation,
   useWorkspace,
 } from 'sanity'
@@ -270,6 +270,7 @@ const VersionMenuItem: ComponentType<VersionMenuItemProps> = ({
 }) => {
   const {t: tCore} = useTranslation()
   const {t: tStructure} = useTranslation(structureLocaleNamespace)
+  const formatPublishDate = useFormatRelativeLocalePublishDate()
 
   const onClick = () => {
     if (type === 'draft') {
@@ -321,7 +322,7 @@ const VersionMenuItem: ComponentType<VersionMenuItemProps> = ({
           )}
           {release.metadata.releaseType === 'scheduled' && (
             <Text muted size={1}>
-              {formatRelativeLocalePublishDate(release)}
+              {formatPublishDate(release)}
             </Text>
           )}
         </Stack>

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ScheduledReleaseBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ScheduledReleaseBanner.tsx
@@ -1,11 +1,11 @@
 import {LockIcon} from '@sanity/icons'
 import {Text} from '@sanity/ui'
 import {
-  formatRelativeLocalePublishDate,
   getReleaseTone,
   LATEST,
   type ReleaseDocument,
   Translate,
+  useFormatRelativeLocalePublishDate,
   useTranslation,
 } from 'sanity'
 
@@ -19,6 +19,7 @@ export function ScheduledReleaseBanner({
   const tone = getReleaseTone(currentRelease ?? LATEST)
 
   const {t: tCore} = useTranslation()
+  const formatPublishDate = useFormatRelativeLocalePublishDate()
 
   return (
     <Banner
@@ -30,7 +31,7 @@ export function ScheduledReleaseBanner({
             t={tCore}
             i18nKey="release.banner.scheduled-for-publishing-on"
             values={{
-              date: formatRelativeLocalePublishDate(currentRelease),
+              date: formatPublishDate(currentRelease),
             }}
           />
         </Text>

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -1,7 +1,6 @@
 import {Stack, Text} from '@sanity/ui'
 import {memo, useCallback, useMemo} from 'react'
 import {
-  formatRelativeLocalePublishDate,
   getReleaseIdFromReleaseDocumentId,
   getReleaseTone,
   getVersionFromId,
@@ -23,6 +22,7 @@ import {
   type UseDateTimeFormatOptions,
   useDocumentVersions,
   useFilteredReleases,
+  useFormatRelativeLocalePublishDate,
   useGetDefaultPerspective,
   useAgentVersionDisplay,
   usePerspective,
@@ -42,6 +42,7 @@ import {NonReleaseVersionsSelect} from '../NonReleaseVersionsSelect'
 
 const TooltipContent = ({release}: {release: ReleaseDocument}) => {
   const {t} = useTranslation()
+  const formatPublishDate = useFormatRelativeLocalePublishDate()
 
   if (release.state === 'archived') {
     return <Text size={1}>{t('release.chip.tooltip.archived')}</Text>
@@ -60,7 +61,7 @@ const TooltipContent = ({release}: {release: ReleaseDocument}) => {
               t={t}
               i18nKey="release.chip.tooltip.intended-for-date"
               values={{
-                date: formatRelativeLocalePublishDate(release),
+                date: formatPublishDate(release),
               }}
             />
           ) : (
@@ -68,7 +69,7 @@ const TooltipContent = ({release}: {release: ReleaseDocument}) => {
               t={t}
               i18nKey="release.chip.tooltip.scheduled-for-date"
               values={{
-                date: formatRelativeLocalePublishDate(release),
+                date: formatPublishDate(release),
               }}
             />
           )}

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -598,6 +598,7 @@ exports[`exports snapshot 1`] = `
     "useFormCallbacks": "function",
     "useFormState": "function",
     "useFormValue": "function",
+    "useFormatRelativeLocalePublishDate": "function",
     "useFormattedDuration": "function",
     "useGetDefaultPerspective": "function",
     "useGetFormValue": "function",


### PR DESCRIPTION
### Description

Release publish dates were rendered in browser-local time instead of the user's selected content-releases timezone, affecting five surfaces (perspective navbar, version context menu, document chip tooltip, scheduled release banner, version-mode diff header). Fixed via a new `useFormatRelativeLocalePublishDate` factory hook.

Closes [SAPP-2385](https://linear.app/sanity/issue/SAPP-2385)

Before:
Regardless of the TZ selection the date is always following the local:
<img width="320" height="249" alt="Screenshot 2026-05-08 at 19 05 26" src="https://github.com/user-attachments/assets/77ce0618-2715-4016-8e4b-6edad22fc1b6" />

<img width="293" height="249" alt="Screenshot 2026-05-08 at 19 05 49" src="https://github.com/user-attachments/assets/fe41eb94-5456-4d1e-8d0e-fd43c58abdb7" />

After:
Correctly adjusts the dateTime presentation based on the TZ selection:
<img width="297" height="246" alt="Screenshot 2026-05-08 at 19 06 00" src="https://github.com/user-attachments/assets/1a7667c5-d3cd-44a7-88a9-45b57a61d695" />

<img width="291" height="247" alt="Screenshot 2026-05-08 at 19 06 23" src="https://github.com/user-attachments/assets/6dc8c226-95e1-47a0-9ba0-e62856128cd8" />


### What to review

- Factory shape on the new hook (returns a function so it works in conditional JSX).
- `formatRelativeLocale` gained an optional `timeZone` arg - backward-compatible.

Affected package: `sanity`.

### Testing

5 unit tests on `formatRelativeLocale` (2 new TZ-aware). Fixtures + exports snapshot updated.

### Notes for release

Release publish dates now follow the user's selected Content Releases timezone.