### PR TITLE
feat(core): initial setup for variants store

### DIFF
--- a/packages/sanity/src/core/variants/store/__tests__/createVariantsStore.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/createVariantsStore.test.ts
@@ -1,0 +1,134 @@
+import {type SanityClient} from '@sanity/client'
+import {filter, firstValueFrom, of, Subject, take, throwError, toArray} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createVariantsStore} from '../createVariantsStore'
+import {createVariant} from './testUtils'
+
+function createMockClient() {
+  const listener$ = new Subject<{
+    type: 'welcome' | 'mutation'
+    transition?: 'update'
+    visibility?: 'query'
+  }>()
+  const fetch = vi.fn()
+  const listen = vi.fn(() => listener$)
+  const client = {
+    listen,
+    observable: {fetch},
+  } as unknown as SanityClient
+
+  return {client, fetch, listen, listener$}
+}
+
+describe('createVariantsStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('loads variants from the variants system document path', async () => {
+    const variant = createVariant('a')
+    const {client, fetch, listen, listener$} = createMockClient()
+    fetch.mockReturnValue(of([variant]))
+
+    const store = createVariantsStore({client})
+    const valuesPromise = firstValueFrom(store.state$.pipe(take(4), toArray()))
+
+    listener$.next({type: 'welcome'})
+
+    const values = await valuesPromise
+    const fetchQuery = fetch.mock.calls[0][0] as string
+
+    expect(fetchQuery).toContain('_type=="system.variant"')
+    expect(fetchQuery).toContain('_id in path("_.variants.*")')
+    expect(fetchQuery).toContain('_createdAt')
+    expect(fetchQuery).toContain('"priority": coalesce(priority, 0)')
+    expect(fetchQuery).toContain('| order(_createdAt desc)')
+    expect(fetch).toHaveBeenCalledWith(
+      fetchQuery,
+      {},
+      expect.objectContaining({filterResponse: true, tag: 'variants.listen'}),
+    )
+    expect(listen).toHaveBeenCalledWith(
+      fetchQuery,
+      {},
+      expect.objectContaining({
+        events: ['welcome', 'mutation', 'reconnect'],
+        includeAllVersions: true,
+        tag: 'variants.listen',
+        visibility: 'query',
+      }),
+    )
+    expect(values[0]).toMatchObject({state: 'initialising'})
+    expect(values[1]).toMatchObject({state: 'loading'})
+    expect(values[3]).toMatchObject({state: 'loaded', error: undefined})
+    expect(Array.from(values[3].variants.values())).toEqual([variant])
+  })
+
+  it('keeps variants updated when the listener refetches', async () => {
+    const firstVariant = createVariant('a')
+    const updatedVariant = createVariant('b', 1)
+    const {client, fetch, listener$} = createMockClient()
+    fetch.mockReturnValueOnce(of([firstVariant])).mockReturnValueOnce(of([updatedVariant]))
+
+    const store = createVariantsStore({client})
+    const valuesPromise = firstValueFrom(store.state$.pipe(take(6), toArray()))
+
+    listener$.next({type: 'welcome'})
+    listener$.next({type: 'mutation', transition: 'update', visibility: 'query'})
+
+    const values = await valuesPromise
+    const lastValue = values.at(-1)!
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(lastValue.state).toBe('loaded')
+    expect(Array.from(lastValue.variants.values())).toEqual([updatedVariant])
+  })
+
+  it('supports removing a variant through dispatch', async () => {
+    const variantA = createVariant('a')
+    const variantB = createVariant('b', 1)
+    const {client, fetch, listener$} = createMockClient()
+    fetch.mockReturnValue(of([variantA, variantB]))
+
+    const store = createVariantsStore({client})
+    const loadedPromise = firstValueFrom(
+      store.state$.pipe(
+        filter(({state, variants}) => state === 'loaded' && variants.size === 2),
+        take(1),
+      ),
+    )
+
+    listener$.next({type: 'welcome'})
+    await loadedPromise
+
+    const deletedPromise = firstValueFrom(
+      store.state$.pipe(
+        filter(({variants}) => variants.size === 1 && variants.has(variantB._id)),
+        take(1),
+      ),
+    )
+
+    store.dispatch({type: 'VARIANT_DELETED', payload: {id: variantA._id}})
+
+    const deletedState = await deletedPromise
+
+    expect(Array.from(deletedState.variants.values())).toEqual([variantB])
+  })
+
+  it('exposes listener errors in the store state', async () => {
+    const error = new Error('Failed to fetch variants')
+    const {client, fetch, listener$} = createMockClient()
+    fetch.mockReturnValue(throwError(() => error))
+
+    const store = createVariantsStore({client})
+    const valuesPromise = firstValueFrom(store.state$.pipe(take(3), toArray()))
+
+    listener$.next({type: 'welcome'})
+
+    const values = await valuesPromise
+    const lastValue = values.at(-1)!
+
+    expect(lastValue).toMatchObject({state: 'error', error})
+  })
+})

--- a/packages/sanity/src/core/variants/store/__tests__/createVariantsStore.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/createVariantsStore.test.ts
@@ -41,7 +41,9 @@ describe('createVariantsStore', () => {
 
     expect(fetchQuery).toContain('_type=="system.variant"')
     expect(fetchQuery).toContain('_id in path("_.variants.*")')
+    expect(fetchQuery).toContain('_rev')
     expect(fetchQuery).toContain('_createdAt')
+    expect(fetchQuery).toContain('_updatedAt')
     expect(fetchQuery).toContain('"priority": coalesce(priority, 0)')
     expect(fetchQuery).toContain('| order(_createdAt desc)')
     expect(fetch).toHaveBeenCalledWith(

--- a/packages/sanity/src/core/variants/store/__tests__/createVariantsStore.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/createVariantsStore.test.ts
@@ -32,7 +32,7 @@ describe('createVariantsStore', () => {
     fetch.mockReturnValue(of([variant]))
 
     const store = createVariantsStore({client})
-    const valuesPromise = firstValueFrom(store.state$.pipe(take(4), toArray()))
+    const valuesPromise = firstValueFrom(store.state$.pipe(take(3), toArray()))
 
     listener$.next({type: 'welcome'})
 
@@ -61,8 +61,8 @@ describe('createVariantsStore', () => {
     )
     expect(values[0]).toMatchObject({state: 'initialising'})
     expect(values[1]).toMatchObject({state: 'loading'})
-    expect(values[3]).toMatchObject({state: 'loaded', error: undefined})
-    expect(Array.from(values[3].variants.values())).toEqual([variant])
+    expect(values[2]).toMatchObject({state: 'loaded', error: undefined})
+    expect(Array.from(values[2].variants.values())).toEqual([variant])
   })
 
   it('keeps variants updated when the listener refetches', async () => {
@@ -72,7 +72,7 @@ describe('createVariantsStore', () => {
     fetch.mockReturnValueOnce(of([firstVariant])).mockReturnValueOnce(of([updatedVariant]))
 
     const store = createVariantsStore({client})
-    const valuesPromise = firstValueFrom(store.state$.pipe(take(6), toArray()))
+    const valuesPromise = firstValueFrom(store.state$.pipe(take(4), toArray()))
 
     listener$.next({type: 'welcome'})
     listener$.next({type: 'mutation', transition: 'update', visibility: 'query'})

--- a/packages/sanity/src/core/variants/store/__tests__/reducer.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/reducer.test.ts
@@ -1,0 +1,92 @@
+import {describe, expect, it} from 'vitest'
+
+import {variantStoreReducer, type VariantStoreState} from '../reducer'
+import {createVariant} from './testUtils'
+
+describe('variantStoreReducer', () => {
+  const initialState: VariantStoreState = {
+    variants: new Map(),
+    state: 'initialising',
+  }
+
+  it('sets variants by id', () => {
+    const variants = [createVariant('a'), createVariant('b', 1)]
+
+    const result = variantStoreReducer(initialState, {
+      type: 'VARIANTS_SET',
+      payload: variants,
+    })
+
+    expect(result.variants).toEqual(
+      new Map([
+        [variants[0]._id, variants[0]],
+        [variants[1]._id, variants[1]],
+      ]),
+    )
+  })
+
+  it('clears variants when the payload is null', () => {
+    const variant = createVariant('a')
+    const state: VariantStoreState = {
+      variants: new Map([[variant._id, variant]]),
+      state: 'loaded',
+    }
+
+    const result = variantStoreReducer(state, {
+      type: 'VARIANTS_SET',
+      payload: null,
+    })
+
+    expect(result.variants.size).toBe(0)
+  })
+
+  it('removes a deleted variant without mutating the previous state', () => {
+    const variantA = createVariant('a')
+    const variantB = createVariant('b', 1)
+    const state: VariantStoreState = {
+      variants: new Map([
+        [variantA._id, variantA],
+        [variantB._id, variantB],
+      ]),
+      state: 'loaded',
+    }
+
+    const result = variantStoreReducer(state, {
+      type: 'VARIANT_DELETED',
+      payload: {id: variantA._id},
+    })
+
+    expect(result.variants).toEqual(new Map([[variantB._id, variantB]]))
+    expect(state.variants).toEqual(
+      new Map([
+        [variantA._id, variantA],
+        [variantB._id, variantB],
+      ]),
+    )
+  })
+
+  it('moves between loading, loaded, and error states', () => {
+    const error = new Error('Failed to load variants')
+
+    expect(
+      variantStoreReducer(initialState, {
+        type: 'LOADING_STATE_CHANGED',
+        payload: {loading: true, error: undefined},
+      }),
+    ).toMatchObject({state: 'loading', error: undefined})
+
+    expect(
+      variantStoreReducer(initialState, {
+        type: 'LOADING_STATE_CHANGED',
+        payload: {loading: false, error: undefined},
+      }),
+    ).toMatchObject({state: 'loaded', error: undefined})
+
+    expect(
+      variantStoreReducer(initialState, {
+        type: 'LOADING_STATE_CHANGED',
+        payload: {loading: false, error},
+      }),
+    ).toMatchObject({state: 'error', error})
+  })
+})

--- a/packages/sanity/src/core/variants/store/__tests__/reducer.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/reducer.test.ts
@@ -11,8 +11,12 @@ describe('variantStoreReducer', () => {
 
   it('sets variants by id', () => {
     const variants = [createVariant('a'), createVariant('b', 1)]
+    const state: VariantStoreState = {
+      variants: new Map(),
+      state: 'loading',
+    }
 
-    const result = variantStoreReducer(initialState, {
+    const result = variantStoreReducer(state, {
       type: 'VARIANTS_SET',
       payload: variants,
     })
@@ -23,6 +27,31 @@ describe('variantStoreReducer', () => {
         [variants[1]._id, variants[1]],
       ]),
     )
+    expect(result.state).toBe('loading')
+    expect(result.error).toBeUndefined()
+  })
+
+  it('sets variants and marks the fetch as loaded when fetch succeeds', () => {
+    const variants = [createVariant('a'), createVariant('b', 1)]
+    const error = new Error('Previous failure')
+    const state: VariantStoreState = {
+      variants: new Map(),
+      state: 'error',
+      error,
+    }
+
+    const result = variantStoreReducer(state, {
+      type: 'FETCH_SUCCEEDED',
+      payload: variants,
+    })
+
+    expect(result.variants).toEqual(
+      new Map([
+        [variants[0]._id, variants[0]],
+        [variants[1]._id, variants[1]],
+      ]),
+    )
+    expect(result).toMatchObject({state: 'loaded', error: undefined})
   })
 
   it('clears variants when the payload is null', () => {
@@ -38,6 +67,7 @@ describe('variantStoreReducer', () => {
     })
 
     expect(result.variants.size).toBe(0)
+    expect(result).toMatchObject({state: 'loaded'})
   })
 
   it('removes a deleted variant without mutating the previous state', () => {

--- a/packages/sanity/src/core/variants/store/__tests__/testUtils.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/testUtils.ts
@@ -1,0 +1,13 @@
+import {type SystemVariant} from '../../types'
+
+export function createVariant(id: string, priority = 0): SystemVariant {
+  return {
+    _id: `_.variants.${id}`,
+    _type: 'system.variant',
+    _createdAt: `2025-01-0${priority + 1}T00:00:00Z`,
+    _updatedAt: `2025-01-0${priority + 1}T00:00:00Z`,
+    _rev: `rev-${id}`,
+    conditions: {audience: id},
+    priority,
+  }
+}

--- a/packages/sanity/src/core/variants/store/__tests__/useAllVariants.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/useAllVariants.test.ts
@@ -1,0 +1,86 @@
+import {act, renderHook, waitFor} from '@testing-library/react'
+import {BehaviorSubject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {type VariantStoreState} from '../reducer'
+import {useAllVariants} from '../useAllVariants'
+import {createVariant} from './testUtils'
+
+const initialState: VariantStoreState = {
+  variants: new Map(),
+  state: 'initialising',
+}
+
+const mockState$ = new BehaviorSubject<VariantStoreState>(initialState)
+const mockDispatch = vi.fn()
+
+vi.mock('../useVariantsStore', () => ({
+  useVariantsStore: () => ({
+    state$: mockState$,
+    dispatch: mockDispatch,
+  }),
+}))
+
+describe('useAllVariants', () => {
+  beforeEach(() => {
+    mockState$.next(initialState)
+    vi.clearAllMocks()
+  })
+
+  it('returns the initial loading state', async () => {
+    const {result} = renderHook(() => useAllVariants())
+
+    expect(result.current).toEqual({
+      loading: true,
+      data: [],
+      error: undefined,
+    })
+  })
+
+  it('returns variants from the store state', async () => {
+    const variantA = createVariant('a')
+    const variantB = createVariant('b', 1)
+
+    const {result} = renderHook(() => useAllVariants())
+
+    act(() => {
+      mockState$.next({
+        variants: new Map([
+          [variantA._id, variantA],
+          [variantB._id, variantB],
+        ]),
+        state: 'loaded',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        loading: false,
+        data: [variantA, variantB],
+        error: undefined,
+      })
+    })
+  })
+
+  it('returns errors from the store state', async () => {
+    const error = new Error('Failed to load variants')
+
+    const {result} = renderHook(() => useAllVariants())
+
+    act(() => {
+      mockState$.next({
+        variants: new Map(),
+        state: 'error',
+        error,
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        loading: false,
+        data: [],
+        error,
+      })
+    })
+  })
+})

--- a/packages/sanity/src/core/variants/store/constants.ts
+++ b/packages/sanity/src/core/variants/store/constants.ts
@@ -1,0 +1,16 @@
+import {type SourceClientOptions} from '../../config/types'
+
+// api extractor take issues with 'as const' for literals
+// oxlint-disable-next-line prefer-as-const
+export const VARIANT_DOCUMENT_TYPE: 'system.variant' = 'system.variant'
+export const VARIANT_DOCUMENTS_PATH = '_.variants'
+
+/**
+ * @internal This is the client options used for the variants studio client, using the `X` API version for now
+ * Will change to a specific version soon.
+ * TODO: Remove after API version is stable and support variants
+ */
+export const VARIANTS_STUDIO_CLIENT_OPTIONS: SourceClientOptions = {
+  // TBD; using today for now
+  apiVersion: 'X',
+}

--- a/packages/sanity/src/core/variants/store/constants.ts
+++ b/packages/sanity/src/core/variants/store/constants.ts
@@ -3,7 +3,8 @@ import {type SourceClientOptions} from '../../config/types'
 // api extractor take issues with 'as const' for literals
 // oxlint-disable-next-line prefer-as-const
 export const VARIANT_DOCUMENT_TYPE: 'system.variant' = 'system.variant'
-export const VARIANT_DOCUMENTS_PATH = '_.variants'
+// oxlint-disable-next-line typescript/prefer-as-const
+export const VARIANT_DOCUMENTS_PATH: '_.variants' = '_.variants'
 
 /**
  * @internal This is the client options used for the variants studio client, using the `X` API version for now

--- a/packages/sanity/src/core/variants/store/createVariantsStore.ts
+++ b/packages/sanity/src/core/variants/store/createVariantsStore.ts
@@ -1,0 +1,133 @@
+import {type SanityClient} from '@sanity/client'
+import {type Dispatch} from 'react'
+import {
+  BehaviorSubject,
+  catchError,
+  concat,
+  concatWith,
+  filter,
+  merge,
+  type Observable,
+  of,
+  scan,
+  shareReplay,
+  Subject,
+  switchMap,
+  tap,
+} from 'rxjs'
+import {map, startWith} from 'rxjs/operators'
+
+import {listenQuery} from '../../store'
+import {type SystemVariant} from '../types'
+import {VARIANT_DOCUMENTS_PATH, VARIANT_DOCUMENT_TYPE} from './constants'
+import {variantStoreReducer, type VariantStoreAction, type VariantStoreState} from './reducer'
+
+type ActionWrapper = {action: VariantStoreAction}
+type ResponseWrapper = {response: SystemVariant[]}
+
+const SORT_FIELD = '_createdAt'
+const SORT_ORDER = 'desc'
+// Newest variants first
+const QUERY_SORT_ORDER = `order(${SORT_FIELD} ${SORT_ORDER})`
+const QUERY_FILTER = `_type=="${VARIANT_DOCUMENT_TYPE}" && _id in path("${VARIANT_DOCUMENTS_PATH}.*")`
+const QUERY_PROJECTION = `{
+  _id,
+  _type,
+  _createdAt,
+  conditions,
+  "priority": coalesce(priority, 0),
+  metadata,
+}`
+
+const QUERY = `*[${QUERY_FILTER}] ${QUERY_PROJECTION} | ${QUERY_SORT_ORDER}`
+
+const INITIAL_STATE: VariantStoreState = {
+  variants: new Map(),
+  state: 'initialising' as const,
+}
+
+export interface VariantStore {
+  state$: Observable<VariantStoreState>
+  dispatch: Dispatch<VariantStoreAction>
+}
+
+/**
+ * The variants store is initialised lazily when first subscribed to. Upon subscription, it will
+ * fetch a list of variants and create a listener to keep the locally held state fresh.
+ *
+ * The store is not disposed of when all subscriptions are closed. After it has been initialised,
+ * it will keep listening for the duration of the app's lifecycle. Subsequent subscriptions will be
+ * given the latest state upon subscription.
+ */
+export function createVariantsStore(context: {client: SanityClient}): VariantStore {
+  const {client} = context
+
+  const dispatch$ = new Subject<VariantStoreAction>()
+  const fetchPending$ = new BehaviorSubject<boolean>(false)
+
+  function dispatch(action: VariantStoreAction): void {
+    dispatch$.next(action)
+  }
+
+  const listFetch$ = of<ActionWrapper>({
+    action: {
+      type: 'LOADING_STATE_CHANGED',
+      payload: {
+        loading: true,
+        error: undefined,
+      },
+    },
+  }).pipe(
+    // Ignore invocations while the list fetch is pending.
+    filter(() => !fetchPending$.value),
+    tap(() => fetchPending$.next(true)),
+    concatWith(
+      listenQuery(client, QUERY, {}, {tag: 'variants.listen'}).pipe(
+        tap(() => fetchPending$.next(false)),
+        map((variants) => ({response: variants})),
+      ),
+    ),
+
+    catchError((error) =>
+      of<ActionWrapper>({
+        action: {
+          type: 'LOADING_STATE_CHANGED',
+          payload: {
+            loading: false,
+            error,
+          },
+        },
+      }),
+    ),
+    switchMap<ActionWrapper | ResponseWrapper, Observable<VariantStoreAction | undefined>>(
+      (entry) => {
+        if ('action' in entry) {
+          return of<VariantStoreAction>(entry.action)
+        }
+
+        return of<VariantStoreAction[]>(
+          {type: 'VARIANTS_SET', payload: entry.response},
+          {
+            type: 'LOADING_STATE_CHANGED',
+            payload: {
+              loading: false,
+              error: undefined,
+            },
+          },
+        )
+      },
+    ),
+  )
+
+  const state$ = concat(merge(listFetch$, dispatch$)).pipe(
+    filter((action): action is VariantStoreAction => typeof action !== 'undefined'),
+    scan((state, action) => variantStoreReducer(state, action), INITIAL_STATE),
+    startWith(INITIAL_STATE),
+    shareReplay(1),
+  )
+
+  return {
+    state$,
+    dispatch,
+  }
+}

--- a/packages/sanity/src/core/variants/store/createVariantsStore.ts
+++ b/packages/sanity/src/core/variants/store/createVariantsStore.ts
@@ -15,7 +15,9 @@ const QUERY_FILTER = `_type=="${VARIANT_DOCUMENT_TYPE}" && _id in path("${VARIAN
 const QUERY_PROJECTION = `{
   _id,
   _type,
+  _rev,
   _createdAt,
+  _updatedAt,
   conditions,
   "priority": coalesce(priority, 0),
   metadata,

--- a/packages/sanity/src/core/variants/store/createVariantsStore.ts
+++ b/packages/sanity/src/core/variants/store/createVariantsStore.ts
@@ -1,29 +1,11 @@
 import {type SanityClient} from '@sanity/client'
 import {type Dispatch} from 'react'
-import {
-  BehaviorSubject,
-  catchError,
-  concat,
-  concatWith,
-  filter,
-  merge,
-  type Observable,
-  of,
-  scan,
-  shareReplay,
-  Subject,
-  switchMap,
-  tap,
-} from 'rxjs'
+import {catchError, concatWith, merge, type Observable, of, scan, shareReplay, Subject} from 'rxjs'
 import {map, startWith} from 'rxjs/operators'
 
 import {listenQuery} from '../../store'
-import {type SystemVariant} from '../types'
 import {VARIANT_DOCUMENTS_PATH, VARIANT_DOCUMENT_TYPE} from './constants'
 import {variantStoreReducer, type VariantStoreAction, type VariantStoreState} from './reducer'
-
-type ActionWrapper = {action: VariantStoreAction}
-type ResponseWrapper = {response: SystemVariant[]}
 
 const SORT_FIELD = '_createdAt'
 const SORT_ORDER = 'desc'
@@ -63,64 +45,36 @@ export function createVariantsStore(context: {client: SanityClient}): VariantSto
   const {client} = context
 
   const dispatch$ = new Subject<VariantStoreAction>()
-  const fetchPending$ = new BehaviorSubject<boolean>(false)
 
   function dispatch(action: VariantStoreAction): void {
     dispatch$.next(action)
   }
 
-  const listFetch$ = of<ActionWrapper>({
-    action: {
-      type: 'LOADING_STATE_CHANGED',
-      payload: {
-        loading: true,
-        error: undefined,
-      },
+  const listFetch$ = of<VariantStoreAction>({
+    type: 'LOADING_STATE_CHANGED',
+    payload: {
+      loading: true,
+      error: undefined,
     },
   }).pipe(
-    // Ignore invocations while the list fetch is pending.
-    filter(() => !fetchPending$.value),
-    tap(() => fetchPending$.next(true)),
     concatWith(
       listenQuery(client, QUERY, {}, {tag: 'variants.listen'}).pipe(
-        tap(() => fetchPending$.next(false)),
-        map((variants) => ({response: variants})),
+        map((variants): VariantStoreAction => ({type: 'FETCH_SUCCEEDED', payload: variants})),
       ),
     ),
 
     catchError((error) =>
-      of<ActionWrapper>({
-        action: {
-          type: 'LOADING_STATE_CHANGED',
-          payload: {
-            loading: false,
-            error,
-          },
+      of<VariantStoreAction>({
+        type: 'LOADING_STATE_CHANGED',
+        payload: {
+          loading: false,
+          error,
         },
       }),
     ),
-    switchMap<ActionWrapper | ResponseWrapper, Observable<VariantStoreAction | undefined>>(
-      (entry) => {
-        if ('action' in entry) {
-          return of<VariantStoreAction>(entry.action)
-        }
-
-        return of<VariantStoreAction[]>(
-          {type: 'VARIANTS_SET', payload: entry.response},
-          {
-            type: 'LOADING_STATE_CHANGED',
-            payload: {
-              loading: false,
-              error: undefined,
-            },
-          },
-        )
-      },
-    ),
   )
 
-  const state$ = concat(merge(listFetch$, dispatch$)).pipe(
-    filter((action): action is VariantStoreAction => typeof action !== 'undefined'),
+  const state$ = merge(listFetch$, dispatch$).pipe(
     scan((state, action) => variantStoreReducer(state, action), INITIAL_STATE),
     startWith(INITIAL_STATE),
     shareReplay(1),

--- a/packages/sanity/src/core/variants/store/reducer.ts
+++ b/packages/sanity/src/core/variants/store/reducer.ts
@@ -1,0 +1,76 @@
+import {type SystemVariant} from '../types'
+
+interface VariantDeletedAction {
+  type: 'VARIANT_DELETED'
+  payload: {
+    id: string
+  }
+}
+
+interface VariantsSetAction {
+  type: 'VARIANTS_SET'
+  payload: SystemVariant[] | null
+}
+
+interface LoadingStateChangedAction {
+  type: 'LOADING_STATE_CHANGED'
+  payload: {
+    loading: boolean
+    error: Error | undefined
+  }
+}
+
+export type VariantStoreAction =
+  | VariantsSetAction
+  | LoadingStateChangedAction
+  | VariantDeletedAction
+
+export interface VariantStoreState {
+  variants: Map<string, SystemVariant>
+  state: 'initialising' | 'loading' | 'loaded' | 'error'
+  error?: Error
+}
+
+function createVariantsSet(variants: SystemVariant[] | null) {
+  return (variants ?? []).reduce((acc, variant) => {
+    acc.set(variant._id, variant)
+    return acc
+  }, new Map<string, SystemVariant>())
+}
+
+export function variantStoreReducer(
+  state: VariantStoreState,
+  action: VariantStoreAction,
+): VariantStoreState {
+  switch (action.type) {
+    case 'LOADING_STATE_CHANGED': {
+      return {
+        ...state,
+        state: action.payload.error ? 'error' : action.payload.loading ? 'loading' : 'loaded',
+        error: action.payload.error,
+      }
+    }
+
+    case 'VARIANTS_SET': {
+      const variantsById = createVariantsSet(action.payload)
+
+      return {
+        ...state,
+        variants: variantsById,
+      }
+    }
+    case 'VARIANT_DELETED': {
+      const {id} = action.payload
+      const restVariants = new Map(
+        Array.from(state.variants.entries()).filter(([key]) => key !== id),
+      )
+      return {
+        ...state,
+        variants: restVariants,
+      }
+    }
+
+    default:
+      return state
+  }
+}

--- a/packages/sanity/src/core/variants/store/reducer.ts
+++ b/packages/sanity/src/core/variants/store/reducer.ts
@@ -7,6 +7,10 @@ interface VariantDeletedAction {
   }
 }
 
+interface FetchSucceededAction {
+  type: 'FETCH_SUCCEEDED'
+  payload: SystemVariant[] | null
+}
 interface VariantsSetAction {
   type: 'VARIANTS_SET'
   payload: SystemVariant[] | null
@@ -24,6 +28,7 @@ export type VariantStoreAction =
   | VariantsSetAction
   | LoadingStateChangedAction
   | VariantDeletedAction
+  | FetchSucceededAction
 
 export interface VariantStoreState {
   variants: Map<string, SystemVariant>
@@ -59,6 +64,16 @@ export function variantStoreReducer(
         variants: variantsById,
       }
     }
+    case 'FETCH_SUCCEEDED': {
+      const variantsById = createVariantsSet(action.payload)
+      return {
+        ...state,
+        variants: variantsById,
+        state: 'loaded',
+        error: undefined,
+      }
+    }
+
     case 'VARIANT_DELETED': {
       const {id} = action.payload
       const restVariants = new Map(

--- a/packages/sanity/src/core/variants/store/reducer.ts
+++ b/packages/sanity/src/core/variants/store/reducer.ts
@@ -76,9 +76,9 @@ export function variantStoreReducer(
 
     case 'VARIANT_DELETED': {
       const {id} = action.payload
-      const restVariants = new Map(
-        Array.from(state.variants.entries()).filter(([key]) => key !== id),
-      )
+      const restVariants = new Map(state.variants)
+      restVariants.delete(id)
+
       return {
         ...state,
         variants: restVariants,

--- a/packages/sanity/src/core/variants/store/useAllVariants.ts
+++ b/packages/sanity/src/core/variants/store/useAllVariants.ts
@@ -1,0 +1,27 @@
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+
+import {type SystemVariant} from '../types'
+import {useVariantsStore} from './useVariantsStore'
+
+/**
+ * Gets all variants.
+ * @internal
+ */
+export function useAllVariants(): {
+  data: SystemVariant[]
+  error?: Error
+  loading: boolean
+} {
+  const {state$} = useVariantsStore()
+  const {variants, error, state} = useObservable(state$)!
+
+  return useMemo(
+    () => ({
+      data: Array.from(variants.values()),
+      error: error,
+      loading: ['loading', 'initialising'].includes(state),
+    }),
+    [error, variants, state],
+  )
+}

--- a/packages/sanity/src/core/variants/store/useVariantsStore.ts
+++ b/packages/sanity/src/core/variants/store/useVariantsStore.ts
@@ -1,0 +1,33 @@
+import {useMemo} from 'react'
+
+import {useClient} from '../../hooks'
+import {useResourceCache} from '../../store'
+import {useWorkspace} from '../../studio'
+import {VARIANTS_STUDIO_CLIENT_OPTIONS} from './constants'
+import {createVariantsStore, type VariantStore} from './createVariantsStore'
+
+/** @internal */
+export function useVariantsStore(): VariantStore {
+  const resourceCache = useResourceCache()
+  const workspace = useWorkspace()
+  const studioClient = useClient(VARIANTS_STUDIO_CLIENT_OPTIONS)
+
+  return useMemo(() => {
+    const variantStore =
+      resourceCache.get<VariantStore>({
+        dependencies: [workspace],
+        namespace: 'VariantsStore',
+      }) ||
+      createVariantsStore({
+        client: studioClient,
+      })
+
+    resourceCache.set({
+      dependencies: [workspace],
+      namespace: 'VariantsStore',
+      value: variantStore,
+    })
+
+    return variantStore
+  }, [resourceCache, workspace, studioClient])
+}

--- a/packages/sanity/src/core/variants/types.ts
+++ b/packages/sanity/src/core/variants/types.ts
@@ -1,0 +1,14 @@
+import {type SanityDocument, type PortableTextBlock} from '@sanity/types'
+
+import {type VARIANT_DOCUMENTS_PATH} from './store/constants'
+
+export interface SystemVariant extends SanityDocument {
+  _type: 'system.variant'
+  _id: `${typeof VARIANT_DOCUMENTS_PATH}.${string}`
+  conditions: Record<string, string>
+  priority: number // defaults to 0.
+  metadata?: {
+    description: PortableTextBlock[]
+    [key: string]: unknown // <-- Here we can store anything useful for the UI
+  }
+}


### PR DESCRIPTION
### Description

Sets up the initial variants store, following the existing releases store implementation so variants can be loaded once, kept fresh through listener updates, and exposed through store hooks.

### What to review

Focus on the variants store behavior in `packages/sanity/src/core/variants/store`, especially the GROQ query, reducer actions, and parity with the releases store pattern.

### Testing

Added unit/integration coverage for the variants reducer, store listener flow, delete dispatch, error state, and `useAllVariants`.

### Notes for release

N/A – Internal only