### PR TITLE
feat(telemetry): enrich studio event context

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -154,13 +154,17 @@ Every event in a batch is enriched with a `TelemetryContext` object before sendi
         studioVersion: "5.18.0",
         reactVersion: "19.2.3",
         environment: "production",
+        connection: { effectiveType: "4g", downlink: 10, rtt: 50, saveData: false },
 
         // Dynamic (updated on navigation)
         orgId: "org_xyz",
         activeTool: "desk",
+        workspaceCount: 2,
         activeWorkspace: "default",
         activeProjectId: "abc123",
         activeDataset: "production",
+        pluginCount: 12,
+        schemaTypeCount: 84,
       }
     }
   ]
@@ -168,6 +172,7 @@ Every event in a batch is enriched with a `TelemetryContext` object before sendi
 ```
 
 The context is stored in a `useRef` so that dynamic values (workspace, tool, org) can update without re-creating the batched store.
+Workspace, plugin, and schema type counts are derived from the already-resolved Studio configuration. Connection quality uses the browser Network Information API when available. None of these fields add Sanity API requests.
 
 ## Consent
 

--- a/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
+++ b/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
@@ -20,6 +20,7 @@ import {useProjectOrganizationId} from '../../store/project/useProjectOrganizati
 import {SANITY_VERSION} from '../../version'
 import {WorkspaceFeaturesObserved} from '../__telemetry__/featureAvailability.telemetry'
 import {useWorkspace} from '../workspace'
+import {useWorkspaces} from '../workspaces'
 import {PerformanceTelemetryTracker} from './PerformanceTelemetry'
 import {type TelemetryContext} from './types'
 import {debugLoggingStore} from './utils/debugLoggingStore'
@@ -29,12 +30,54 @@ const sessionId = createSessionId()
 /** Telemetry only runs on client */
 const isClient = typeof window !== 'undefined'
 
+interface PluginWithNestedPlugins {
+  plugins?: PluginWithNestedPlugins[]
+}
+
+interface BrowserConnection {
+  effectiveType?: string
+  downlink?: number
+  rtt?: number
+  saveData?: boolean
+}
+
+type NavigatorWithConnection = Navigator & {
+  connection?: BrowserConnection
+  mozConnection?: BrowserConnection
+  webkitConnection?: BrowserConnection
+}
+
+function countPlugins(plugins: PluginWithNestedPlugins[] | undefined): number {
+  if (!plugins) return 0
+  return plugins.reduce((count, plugin) => count + 1 + countPlugins(plugin.plugins), 0)
+}
+
+function getConnection(): TelemetryContext['connection'] {
+  if (!isClient) return null
+
+  const nav = navigator as NavigatorWithConnection
+  const connection = nav.connection || nav.mozConnection || nav.webkitConnection
+
+  if (!connection) return null
+
+  return {
+    effectiveType: connection.effectiveType ?? null,
+    downlink: typeof connection.downlink === 'number' ? connection.downlink : null,
+    rtt: typeof connection.rtt === 'number' ? connection.rtt : null,
+    saveData: typeof connection.saveData === 'boolean' ? connection.saveData : null,
+  }
+}
+
 export function StudioTelemetryProvider(props: {children: ReactNode}) {
   const client = useClient({apiVersion: 'v2023-12-18'})
   const projectId = client.config().projectId
 
   // Get workspace context
   const workspace = useWorkspace()
+  const workspaces = useWorkspaces()
+  const workspaceCount = workspaces.length
+  const workspacePlugins = workspace.__internal.options.plugins
+  const workspaceSchema = workspace.schema
 
   // Get organization ID (async, may be null initially)
   const {value: orgId} = useProjectOrganizationId()
@@ -55,6 +98,9 @@ export function StudioTelemetryProvider(props: {children: ReactNode}) {
   // Telemetry only runs on client - no SSR fallbacks needed
   useEffect(() => {
     if (!isClient) return
+    const pluginCount = countPlugins(workspacePlugins)
+    const schemaTypeCount = workspaceSchema.getTypeNames().length
+
     contextRef.current = {
       // Static values
       userAgent: navigator.userAgent,
@@ -68,15 +114,28 @@ export function StudioTelemetryProvider(props: {children: ReactNode}) {
       studioVersion: SANITY_VERSION,
       reactVersion,
       environment: isProd ? 'production' : 'development',
+      connection: getConnection(),
 
       // Dynamic values
       orgId: orgId || null,
       activeTool,
+      workspaceCount,
       activeWorkspace: workspace.name,
       activeProjectId: workspace.projectId,
       activeDataset: workspace.dataset,
+      pluginCount,
+      schemaTypeCount,
     }
-  }, [orgId, activeTool, workspace.name, workspace.projectId, workspace.dataset])
+  }, [
+    orgId,
+    activeTool,
+    workspaceCount,
+    workspace.name,
+    workspace.projectId,
+    workspace.dataset,
+    workspacePlugins,
+    workspaceSchema,
+  ])
 
   const storeOptions = useMemo((): CreateBatchedStoreOptions => {
     const debugTelemetry = import.meta && import.meta.env?.SANITY_STUDIO_DEBUG_TELEMETRY === 'true'

--- a/packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx
+++ b/packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx
@@ -15,6 +15,7 @@ vi.mock('@sanity/telemetry/react', () => ({
 }))
 vi.mock('../../../hooks')
 vi.mock('../../workspace')
+vi.mock('../../workspaces')
 vi.mock('../../../store/project/useProjectOrganizationId')
 vi.mock('sanity/router')
 vi.mock('../../../environment', () => ({
@@ -38,8 +39,14 @@ import {useClient} from '../../../hooks'
 import {useProjectOrganizationId} from '../../../store/project/useProjectOrganizationId'
 import {WorkspaceFeaturesObserved} from '../../__telemetry__/featureAvailability.telemetry'
 import {useWorkspace} from '../../workspace'
+import {useWorkspaces} from '../../workspaces'
 import {StudioTelemetryProvider} from '../StudioTelemetryProvider'
 /* eslint-enable import/first */
+
+function mockRouterTool(tool: string) {
+  vi.mocked(useRouterState).mockImplementation(((selector: (state: {tool?: string}) => unknown) =>
+    selector({tool})) as never)
+}
 
 describe('StudioTelemetryProvider', () => {
   let capturedStoreOptions: {
@@ -59,8 +66,32 @@ describe('StudioTelemetryProvider', () => {
     name: 'test-workspace',
     projectId: 'test-project',
     dataset: 'test-dataset',
+    schema: {
+      getTypeNames: () => ['author', 'post', 'sanity.imageAsset'],
+    },
+    __internal: {
+      options: {
+        plugins: [
+          {name: 'root-plugin'},
+          {name: 'plugin-with-child', plugins: [{name: 'child-plugin'}]},
+        ],
+      },
+    },
     advancedVersionControl: {enabled: true},
   }
+
+  const mockWorkspaces = [
+    {
+      name: 'test-workspace',
+      projectId: 'test-project',
+      dataset: 'test-dataset',
+    },
+    {
+      name: 'secondary-workspace',
+      projectId: 'secondary-project',
+      dataset: 'production',
+    },
+  ]
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -69,11 +100,11 @@ describe('StudioTelemetryProvider', () => {
     vi.mocked(createSessionId).mockReturnValue('test-session-id' as SessionId)
     vi.mocked(useClient).mockReturnValue(mockClient as never)
     vi.mocked(useWorkspace).mockReturnValue(mockWorkspace as never)
+    vi.mocked(useWorkspaces).mockReturnValue(mockWorkspaces as never)
     vi.mocked(useProjectOrganizationId).mockReturnValue({
       value: 'org-123',
     } as never)
-    vi.mocked(useRouterState).mockImplementation(((selector: (state: {tool?: string}) => unknown) =>
-      selector({tool: 'desk'})) as any)
+    mockRouterTool('desk')
 
     // Capture store options when createBatchedStore is called
     vi.mocked(createBatchedStore).mockImplementation((_sessionId, options) => {
@@ -134,6 +165,9 @@ describe('StudioTelemetryProvider', () => {
                 activeProjectId: 'test-project',
                 activeDataset: 'test-dataset',
                 activeTool: 'desk',
+                workspaceCount: 2,
+                pluginCount: 3,
+                schemaTypeCount: 3,
               }),
             }),
           ]),
@@ -181,6 +215,9 @@ describe('StudioTelemetryProvider', () => {
       orgId: 'org-123',
       activeWorkspace: 'test-workspace',
       activeTool: 'desk',
+      workspaceCount: 2,
+      pluginCount: 3,
+      schemaTypeCount: 3,
     })
 
     vi.unstubAllGlobals()
@@ -197,6 +234,7 @@ describe('StudioTelemetryProvider', () => {
 
     // Change workspace
     vi.mocked(useWorkspace).mockReturnValue({
+      ...mockWorkspace,
       name: 'new-workspace',
       projectId: 'new-project',
       dataset: 'new-dataset',
@@ -242,8 +280,7 @@ describe('StudioTelemetryProvider', () => {
     )
 
     // Change active tool
-    vi.mocked(useRouterState).mockImplementation(((selector: (state: {tool?: string}) => unknown) =>
-      selector({tool: 'vision'})) as any)
+    mockRouterTool('vision')
 
     rerender(
       <DeferredTelemetryProvider>
@@ -349,6 +386,51 @@ describe('StudioTelemetryProvider', () => {
     vi.unstubAllGlobals()
   })
 
+  it('includes browser connection quality when the Network Information API is available', async () => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      connection: {
+        effectiveType: '4g',
+        downlink: 8.4,
+        rtt: 50,
+        saveData: false,
+      },
+      userAgent: 'test-user-agent',
+    })
+
+    render(
+      <DeferredTelemetryProvider>
+        <StudioTelemetryProvider>
+          <div>Test Child</div>
+        </StudioTelemetryProvider>
+      </DeferredTelemetryProvider>,
+    )
+
+    const testBatch = [{name: 'Test Event'}]
+    await capturedStoreOptions.sendEvents!(testBatch)
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          batch: expect.arrayContaining([
+            expect.objectContaining({
+              context: expect.objectContaining({
+                connection: {
+                  effectiveType: '4g',
+                  downlink: 8.4,
+                  rtt: 50,
+                  saveData: false,
+                },
+              }),
+            }),
+          ]),
+        }),
+      }),
+    )
+
+    vi.unstubAllGlobals()
+  })
+
   it('emits WorkspaceFeaturesObserved with the advancedVersionControl flag enabled', () => {
     render(
       <DeferredTelemetryProvider>
@@ -365,9 +447,11 @@ describe('StudioTelemetryProvider', () => {
 
   it('emits WorkspaceFeaturesObserved with the flag disabled when advancedVersionControl is undefined', () => {
     vi.mocked(useWorkspace).mockReturnValue({
+      ...mockWorkspace,
       name: 'test-workspace',
       projectId: 'test-project',
       dataset: 'test-dataset',
+      advancedVersionControl: undefined,
     } as never)
 
     render(

--- a/packages/sanity/src/core/studio/telemetry/types.ts
+++ b/packages/sanity/src/core/studio/telemetry/types.ts
@@ -20,16 +20,29 @@ export interface TelemetryContext {
   reactVersion: string
   /** Environment: production or development */
   environment: 'production' | 'development'
+  /** Browser network quality, when available */
+  connection: {
+    effectiveType: string | null
+    downlink: number | null
+    rtt: number | null
+    saveData: boolean | null
+  } | null
 
   // Dynamic (updated on navigation/context changes)
   /** Organization ID (null if not yet loaded) */
   orgId: string | null
   /** Currently active tool name */
   activeTool: string | undefined
+  /** Total number of configured workspaces */
+  workspaceCount: number
   /** Current workspace name */
   activeWorkspace: string
   /** Current project ID */
   activeProjectId: string
   /** Current dataset name */
   activeDataset: string
+  /** Total number of configured plugins in the active workspace, including nested plugins */
+  pluginCount: number
+  /** Total number of compiled schema types in the active workspace */
+  schemaTypeCount: number
 }

--- a/packages/sanity/src/core/validation/util/__tests__/requestIdleCallback.test.ts
+++ b/packages/sanity/src/core/validation/util/__tests__/requestIdleCallback.test.ts
@@ -1,0 +1,19 @@
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+describe('requestIdleCallback polyfill', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  it('can cancel a shimmed idle callback after window becomes unavailable', async () => {
+    vi.resetModules()
+
+    const {cancelIdleCallback, requestIdleCallback} = await import('../requestIdleCallback')
+    const handle = requestIdleCallback(() => undefined)
+
+    vi.stubGlobal('window', undefined)
+
+    expect(() => cancelIdleCallback(handle)).not.toThrow()
+  })
+})

--- a/packages/sanity/src/core/validation/util/requestIdleCallback.ts
+++ b/packages/sanity/src/core/validation/util/requestIdleCallback.ts
@@ -6,23 +6,23 @@
  */
 const requestIdleCallbackShim: typeof window.requestIdleCallback = function requestIdleCallbackShim(
   callback,
-  options?,
+  _options?,
 ): number {
   const start = Date.now()
-  return window.setTimeout(() => {
+  return globalThis.setTimeout(() => {
     callback({
       didTimeout: false,
       timeRemaining() {
         return Math.max(0, Date.now() - start)
       },
     })
-  }, 0)
+  }, 0) as unknown as number
 }
 
 const cancelIdleCallbackShim: typeof window.cancelIdleCallback = function cancelIdleCallbackShim(
   handle: number,
 ): void {
-  return window.clearTimeout(handle)
+  return globalThis.clearTimeout(handle)
 }
 
 const win = typeof window === 'undefined' ? undefined : window


### PR DESCRIPTION
### Description

Telemetry analysis for load-health events needs workspace, plugin, schema, project, and network context directly on the event wrapper so queries do not have to join against session-level metadata. This keeps the enrichment in StudioTelemetryProvider because the needed Studio config and browser data are already available there, avoiding extra fetches on the loading path.

While verifying CI feedback, this also guards the validation idle-callback shim against jsdom/Node teardown where window is no longer available during RxJS cleanup.

### What to review

- The event wrapper context enrichment in packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
- The TelemetryContext shape in packages/sanity/src/core/studio/telemetry/types.ts
- The provider tests covering HTTP, beacon, counts, and browser connection data
- The validation requestIdleCallback shim cleanup path and regression test

### Testing

- env CI=true /Users/david.annez/Library/pnpm/.tools/@pnpm+macos-arm64/10.30.3/bin/pnpm vitest run --project=sanity packages/sanity/src/core/validation/util/__tests__/requestIdleCallback.test.ts packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx
- ./node_modules/.bin/oxfmt --check packages/sanity/src/core/validation/util/requestIdleCallback.ts packages/sanity/src/core/validation/util/__tests__/requestIdleCallback.test.ts packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx packages/sanity/src/core/studio/telemetry/types.ts packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx docs/TELEMETRY.md
- ./node_modules/.bin/oxlint packages/sanity/src/core/validation/util/requestIdleCallback.ts packages/sanity/src/core/validation/util/__tests__/requestIdleCallback.test.ts packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx packages/sanity/src/core/studio/telemetry/types.ts packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx
- git diff --check

### Notes for release

N/A – Internal only