### PR TITLE
fix(vision): do not fetch if query is empty

### DIFF
--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -270,7 +270,9 @@ export function VisionGui(props: VisionGuiProps) {
 
       cancelListenerSubscription()
 
-      setQueryInProgress(!context.params.error && Boolean(context.query))
+      const hasQuery = context.query.trim().length > 0
+
+      setQueryInProgress(!context.params.error && hasQuery)
       setListenInProgress(false)
       setListenMutations([])
       setError(context.params.error ? new Error(context.params.error) : undefined)
@@ -278,7 +280,7 @@ export function VisionGui(props: VisionGuiProps) {
       setQueryTime(undefined)
       setE2eTime(undefined)
 
-      if (context.params.error) {
+      if (context.params.error || !hasQuery) {
         return
       }
 


### PR DESCRIPTION
### Description
I noticed that now when opening vision with an empty query the user is received with an error:
<img width="1696" height="1037" alt="Screenshot 2026-05-11 at 12 31 49" src="https://github.com/user-attachments/assets/855ca178-29cb-4c26-be2d-d4f01050d800" />


https://github.com/user-attachments/assets/0d3f3a89-f22c-423c-ab9d-6c823c0f5789


Avoid this error by not fetching when the query is empty.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open vision.
Clear your query.
Reload vision, no error should be presented.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
