### PR TITLE
fix: adding names to currently nameless telemetry events

### DIFF
--- a/packages/sanity/src/core/studio/__telemetry__/studioLoaded.telemetry.ts
+++ b/packages/sanity/src/core/studio/__telemetry__/studioLoaded.telemetry.ts
@@ -1,0 +1,19 @@
+import {defineEvent} from '@sanity/telemetry'
+
+export interface StudioLoadedInfo {
+  studioVersion: string
+  reactVersion: string
+  environment: 'production' | 'development'
+  userAgent: string
+  screenDensity: number
+  screenHeight: number
+  screenWidth: number
+  screenInnerHeight: number
+  screenInnerWidth: number
+}
+
+export const StudioLoaded = defineEvent<StudioLoadedInfo>({
+  name: 'Studio Loaded',
+  version: 1,
+  description: 'Fired once per studio mount with studio version and environment metadata',
+})

--- a/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
+++ b/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
@@ -19,6 +19,7 @@ import {useClient} from '../../hooks'
 import {useProjectOrganizationId} from '../../store/project/useProjectOrganizationId'
 import {SANITY_VERSION} from '../../version'
 import {WorkspaceFeaturesObserved} from '../__telemetry__/featureAvailability.telemetry'
+import {StudioLoaded} from '../__telemetry__/studioLoaded.telemetry'
 import {useWorkspace} from '../workspace'
 import {PerformanceTelemetryTracker} from './PerformanceTelemetry'
 import {type TelemetryContext} from './types'
@@ -124,15 +125,19 @@ export function StudioTelemetryProvider(props: {children: ReactNode}) {
   // eslint-disable-next-line react-hooks/refs
   const store = useMemo(() => createBatchedStore(sessionId, storeOptions), [storeOptions])
 
-  // Also update user properties on the store (for backwards compatibility)
   useEffect(() => {
     if (!isClient || !contextRef.current) return
-    store.logger.updateUserProperties({
-      userAgent: contextRef.current.userAgent,
-      screen: contextRef.current.screen,
-      reactVersion,
+    const ctx = contextRef.current
+    store.logger.log(StudioLoaded, {
       studioVersion: SANITY_VERSION,
-      environment: contextRef.current.environment,
+      reactVersion,
+      environment: ctx.environment,
+      userAgent: ctx.userAgent,
+      screenDensity: ctx.screen.density,
+      screenHeight: ctx.screen.height,
+      screenWidth: ctx.screen.width,
+      screenInnerHeight: ctx.screen.innerHeight,
+      screenInnerWidth: ctx.screen.innerWidth,
     })
   }, [store.logger])
 

--- a/packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx
+++ b/packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx
@@ -4,11 +4,20 @@ import {render} from '@testing-library/react'
 import {type ReactNode} from 'react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
+import type * as SanityTelemetry from '@sanity/telemetry'
+
 // Disable console.logging of telemetry events in tests
 import.meta.env.SANITY_STUDIO_DEBUG_TELEMETRY = ''
 
 // Mocks (these get hoisted automatically by vitest)
-vi.mock('@sanity/telemetry')
+vi.mock('@sanity/telemetry', async () => {
+  const actual = await vi.importActual<typeof SanityTelemetry>('@sanity/telemetry')
+  return {
+    ...actual,
+    createBatchedStore: vi.fn(),
+    createSessionId: vi.fn(),
+  }
+})
 vi.mock('@sanity/telemetry/react', () => ({
   TelemetryProvider: ({children}: {children: ReactNode}) => children,
   DeferredTelemetryProvider: ({children}: {children: ReactNode}) => children,
@@ -37,6 +46,7 @@ import {useRouterState} from 'sanity/router'
 import {useClient} from '../../../hooks'
 import {useProjectOrganizationId} from '../../../store/project/useProjectOrganizationId'
 import {WorkspaceFeaturesObserved} from '../../__telemetry__/featureAvailability.telemetry'
+import {StudioLoaded} from '../../__telemetry__/studioLoaded.telemetry'
 import {useWorkspace} from '../../workspace'
 import {StudioTelemetryProvider} from '../StudioTelemetryProvider'
 /* eslint-enable import/first */
@@ -81,7 +91,6 @@ describe('StudioTelemetryProvider', () => {
       return {
         logger: {
           log: mockLog,
-          updateUserProperties: vi.fn(),
         },
       } as never
     })
@@ -381,5 +390,33 @@ describe('StudioTelemetryProvider', () => {
     expect(mockLog).toHaveBeenCalledWith(WorkspaceFeaturesObserved, {
       advancedVersionControlEnabled: false,
     })
+  })
+
+  it('emits StudioLoaded once on mount with studio version and environment metadata', () => {
+    render(
+      <DeferredTelemetryProvider>
+        <StudioTelemetryProvider>
+          <div>Test Child</div>
+        </StudioTelemetryProvider>
+      </DeferredTelemetryProvider>,
+    )
+
+    const studioLoadedCalls = mockLog.mock.calls.filter(([event]) => event === StudioLoaded)
+    expect(studioLoadedCalls).toHaveLength(1)
+
+    expect(mockLog).toHaveBeenCalledWith(
+      StudioLoaded,
+      expect.objectContaining({
+        studioVersion: '3.0.0-test',
+        environment: 'development',
+        reactVersion: expect.any(String),
+        userAgent: expect.any(String),
+        screenDensity: expect.any(Number),
+        screenHeight: expect.any(Number),
+        screenWidth: expect.any(Number),
+        screenInnerHeight: expect.any(Number),
+        screenInnerWidth: expect.any(Number),
+      }),
+    )
   })
 })

--- a/packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx
+++ b/packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx
@@ -1,10 +1,9 @@
+import type * as SanityTelemetry from '@sanity/telemetry'
 /* eslint-disable import/first */
 // Regular imports first
 import {render} from '@testing-library/react'
 import {type ReactNode} from 'react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-
-import type * as SanityTelemetry from '@sanity/telemetry'
 
 // Disable console.logging of telemetry events in tests
 import.meta.env.SANITY_STUDIO_DEBUG_TELEMETRY = ''


### PR DESCRIPTION
### Description

The studio was calling `store.logger.updateUserProperties(...)` once per mount, which the `@sanity/telemetry` SDK emits as a `type: 'userProperties'` entry with no `name` field — these flow through the same `/intake/batch` transport as named events and land in the `telemetry` table as nameless rows. Replaced that call with a properly-named `Studio Loaded` event defined via `defineEvent` so the studio-version, environment, and screen metadata can now be filtered and grouped on `event_name`.

### What to review

- The new event definition in `packages/sanity/src/core/studio/__telemetry__/studioLoaded.telemetry.ts`
- The replaced effect in `packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx`
- The test changes in `packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx` — note the `vi.mock('@sanity/telemetry')` was switched to a partial mock so `defineEvent` stays real and event references compare correctly in assertions

### Testing

Added a dedicated test case `emits StudioLoaded once on mount with studio version and environment metadata` which asserts that `StudioLoaded` is logged exactly once per provider mount and that the payload carries the expected `studioVersion`, `environment`, `reactVersion`, `userAgent`, and the five screen dimension fields.

### Notes for release

N/A