### PR TITLE
fix(form): load crop image via authed blob URL for private assets

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInput.tsx
@@ -397,6 +397,7 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
     (inputProps: Omit<InputProps, 'renderDefault'>) => {
       return (
         <ImageInputHotspotInput
+          accessPolicy={accessPolicy}
           isImageToolEnabled={isImageToolEnabled()}
           handleCloseDialog={handleCloseDialog}
           imageInputProps={props}
@@ -404,7 +405,7 @@ function BaseImageInputComponent(props: BaseImageInputProps): React.JSX.Element 
         />
       )
     },
-    [handleCloseDialog, isImageToolEnabled, props],
+    [accessPolicy, handleCloseDialog, isImageToolEnabled, props],
   )
   const renderAssetSource = useCallback(() => {
     if (!selectedAssetSource) return null

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputHotspotInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputHotspotInput.tsx
@@ -1,25 +1,34 @@
 import {Stack} from '@sanity/ui'
 
 import {Dialog} from '../../../../../ui-components'
+import {LoadingBlock} from '../../../../components/loadingBlock'
 import {type FIXME} from '../../../../FIXME'
 import {useTranslation} from '../../../../i18n'
 import {PresenceOverlay} from '../../../../presence'
 import {type InputProps} from '../../../types'
 import {ImageToolInput} from '../ImageToolInput'
+import {type AssetAccessPolicy} from '../types'
 import {type BaseImageInputProps} from './types'
+import {useImageUrl} from './useImageUrl'
 
 export function ImageInputHotspotInput(props: {
+  accessPolicy: AssetAccessPolicy
   handleCloseDialog: () => void
   inputProps: Omit<InputProps, 'renderDefault'>
   imageInputProps: BaseImageInputProps
   isImageToolEnabled: boolean
 }) {
-  const {handleCloseDialog, inputProps, imageInputProps, isImageToolEnabled} = props
+  const {accessPolicy, handleCloseDialog, inputProps, imageInputProps, isImageToolEnabled} = props
   const {t} = useTranslation()
   const {changed, id, imageUrlBuilder, value} = imageInputProps
 
+  const {isLoading, url: imageUrl} = useImageUrl({
+    accessPolicy,
+    imageSource: value?.asset ? value : undefined,
+    imageUrlBuilder,
+  })
+
   const withImageTool = isImageToolEnabled && value && value.asset
-  const imageUrl = value?.asset ? imageUrlBuilder.image(value.asset).url() : ''
 
   return (
     <Dialog
@@ -33,13 +42,19 @@ export function ImageInputHotspotInput(props: {
       <PresenceOverlay>
         <Stack space={5}>
           {withImageTool && value?.asset && (
-            <ImageToolInput
-              {...imageInputProps}
-              imageUrl={imageUrl}
-              value={value as FIXME}
-              presence={inputProps.presence}
-              changed={changed}
-            />
+            <>
+              {isLoading || !imageUrl ? (
+                <LoadingBlock showText />
+              ) : (
+                <ImageToolInput
+                  {...imageInputProps}
+                  imageUrl={imageUrl}
+                  value={value as FIXME}
+                  presence={inputProps.presence}
+                  changed={changed}
+                />
+              )}
+            </>
           )}
         </Stack>
       </PresenceOverlay>

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputHotspotInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputHotspotInput.tsx
@@ -22,13 +22,14 @@ export function ImageInputHotspotInput(props: {
   const {t} = useTranslation()
   const {changed, id, imageUrlBuilder, value} = imageInputProps
 
+  const withImageTool = isImageToolEnabled && value && value.asset
+
+  // Use the asset ref so the URL builder doesn't re-apply existing crop/hotspot.
   const {isLoading, url: imageUrl} = useImageUrl({
     accessPolicy,
-    imageSource: value?.asset ? value : undefined,
+    imageSource: withImageTool ? value.asset : undefined,
     imageUrlBuilder,
   })
-
-  const withImageTool = isImageToolEnabled && value && value.asset
 
   return (
     <Dialog

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/__tests__/ImageInputHotspotInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/__tests__/ImageInputHotspotInput.test.tsx
@@ -7,29 +7,7 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {ImageInputHotspotInput} from '../ImageInputHotspotInput'
 import {useImageUrl} from '../useImageUrl'
 
-function renderWithTheme(ui: ReactElement): RenderResult {
-  return render(<ThemeProvider theme={studioTheme}>{ui}</ThemeProvider>)
-}
-
 vi.mock('../useImageUrl')
-
-vi.mock('../../../../../../ui-components', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>()
-  return {
-    ...actual,
-    Dialog: ({children}: {children: React.ReactNode}) => (
-      <div data-testid="hotspot-dialog">{children}</div>
-    ),
-  }
-})
-
-vi.mock('../../../../../presence', () => ({
-  PresenceOverlay: ({children}: {children: React.ReactNode}) => <>{children}</>,
-}))
-
-vi.mock('../../../../../i18n', () => ({
-  useTranslation: () => ({t: (key: string) => key}),
-}))
 
 vi.mock('../../ImageToolInput', () => ({
   ImageToolInput: (props: {imageUrl: string}) => (
@@ -37,36 +15,24 @@ vi.mock('../../ImageToolInput', () => ({
   ),
 }))
 
-vi.mock('../../../../../components/loadingBlock', () => ({
-  LoadingBlock: () => <div data-testid="loading-block" />,
-}))
+const assetRef = {_ref: 'image-abc-100x100-jpg', _type: 'reference'}
 
-const assetRef = {_ref: 'image-abc-100x100-jpg', _type: 'reference' as const}
-
-const baseValue = {
-  _type: 'image',
-  asset: assetRef,
-}
-
-const imageUrlBuilder = {
-  image: vi.fn().mockReturnThis(),
-  url: vi.fn().mockReturnValue('https://cdn.sanity.io/asset.jpg'),
-} as unknown as ImageUrlBuilder
-
-const baseImageInputProps = {
-  id: 'mainImage',
-  imageUrlBuilder,
-  value: baseValue,
-  changed: false,
-} as any
-
-const baseInputProps = {presence: []} as any
+const imageUrlBuilder = {} as ImageUrlBuilder
 
 const baseProps = {
   handleCloseDialog: vi.fn(),
-  imageInputProps: baseImageInputProps,
-  inputProps: baseInputProps,
+  inputProps: {presence: []} as any,
+  imageInputProps: {
+    id: 'mainImage',
+    imageUrlBuilder,
+    value: {_type: 'image', asset: assetRef},
+    changed: false,
+  } as any,
   isImageToolEnabled: true,
+}
+
+function renderWithTheme(ui: ReactElement): RenderResult {
+  return render(<ThemeProvider theme={studioTheme}>{ui}</ThemeProvider>)
 }
 
 describe('ImageInputHotspotInput', () => {
@@ -74,32 +40,38 @@ describe('ImageInputHotspotInput', () => {
     vi.clearAllMocks()
   })
 
-  it('passes accessPolicy, image value, and url builder to useImageUrl', () => {
-    vi.mocked(useImageUrl).mockReturnValue({
-      url: 'https://cdn.sanity.io/asset.jpg',
-      isLoading: false,
-    })
+  it('passes the asset reference (not the full image value) to useImageUrl', () => {
+    vi.mocked(useImageUrl).mockReturnValue({url: 'https://cdn/x.jpg', isLoading: false})
 
     renderWithTheme(<ImageInputHotspotInput {...baseProps} accessPolicy="public" />)
 
     expect(useImageUrl).toHaveBeenCalledWith({
       accessPolicy: 'public',
-      imageSource: baseValue,
+      imageSource: assetRef,
       imageUrlBuilder,
     })
   })
 
-  it('renders a LoadingBlock while the image url is resolving', () => {
-    vi.mocked(useImageUrl).mockReturnValue({url: undefined, isLoading: true})
+  it('skips the fetch when image tool is disabled', () => {
+    vi.mocked(useImageUrl).mockReturnValue({url: 'https://cdn/x.jpg', isLoading: false})
 
-    renderWithTheme(<ImageInputHotspotInput {...baseProps} accessPolicy="checking" />)
+    renderWithTheme(
+      <ImageInputHotspotInput {...baseProps} accessPolicy="private" isImageToolEnabled={false} />,
+    )
 
-    expect(screen.getByTestId('loading-block')).toBeInTheDocument()
+    expect(useImageUrl).toHaveBeenCalledWith({
+      accessPolicy: 'private',
+      imageSource: undefined,
+      imageUrlBuilder,
+    })
     expect(screen.queryByTestId('image-tool-input')).not.toBeInTheDocument()
   })
 
-  it('renders a LoadingBlock when there is no url even if not loading', () => {
-    vi.mocked(useImageUrl).mockReturnValue({url: undefined, isLoading: false})
+  it.each([
+    ['loading', {url: undefined, isLoading: true}],
+    ['no url available', {url: undefined, isLoading: false}],
+  ])('renders LoadingBlock when %s', (_label, hookResult) => {
+    vi.mocked(useImageUrl).mockReturnValue(hookResult)
 
     renderWithTheme(<ImageInputHotspotInput {...baseProps} accessPolicy="private" />)
 
@@ -108,28 +80,12 @@ describe('ImageInputHotspotInput', () => {
   })
 
   it('renders ImageToolInput with the resolved url once available', () => {
-    const url = 'blob:https://studio.sanity.io/private-asset'
+    const url = 'blob:https://studio/private-asset'
     vi.mocked(useImageUrl).mockReturnValue({url, isLoading: false})
 
     renderWithTheme(<ImageInputHotspotInput {...baseProps} accessPolicy="private" />)
 
-    const tool = screen.getByTestId('image-tool-input')
-    expect(tool).toBeInTheDocument()
-    expect(tool).toHaveAttribute('data-image-url', url)
-    expect(screen.queryByTestId('loading-block')).not.toBeInTheDocument()
-  })
-
-  it('does not render the ImageToolInput when image tool is disabled', () => {
-    vi.mocked(useImageUrl).mockReturnValue({
-      url: 'https://cdn.sanity.io/asset.jpg',
-      isLoading: false,
-    })
-
-    renderWithTheme(
-      <ImageInputHotspotInput {...baseProps} accessPolicy="public" isImageToolEnabled={false} />,
-    )
-
-    expect(screen.queryByTestId('image-tool-input')).not.toBeInTheDocument()
+    expect(screen.getByTestId('image-tool-input')).toHaveAttribute('data-image-url', url)
     expect(screen.queryByTestId('loading-block')).not.toBeInTheDocument()
   })
 })

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/__tests__/ImageInputHotspotInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/__tests__/ImageInputHotspotInput.test.tsx
@@ -1,0 +1,135 @@
+import {type ImageUrlBuilder} from '@sanity/image-url'
+import {studioTheme, ThemeProvider} from '@sanity/ui'
+import {render, type RenderResult, screen} from '@testing-library/react'
+import {type ReactElement} from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {ImageInputHotspotInput} from '../ImageInputHotspotInput'
+import {useImageUrl} from '../useImageUrl'
+
+function renderWithTheme(ui: ReactElement): RenderResult {
+  return render(<ThemeProvider theme={studioTheme}>{ui}</ThemeProvider>)
+}
+
+vi.mock('../useImageUrl')
+
+vi.mock('../../../../../../ui-components', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    Dialog: ({children}: {children: React.ReactNode}) => (
+      <div data-testid="hotspot-dialog">{children}</div>
+    ),
+  }
+})
+
+vi.mock('../../../../../presence', () => ({
+  PresenceOverlay: ({children}: {children: React.ReactNode}) => <>{children}</>,
+}))
+
+vi.mock('../../../../../i18n', () => ({
+  useTranslation: () => ({t: (key: string) => key}),
+}))
+
+vi.mock('../../ImageToolInput', () => ({
+  ImageToolInput: (props: {imageUrl: string}) => (
+    <div data-testid="image-tool-input" data-image-url={props.imageUrl} />
+  ),
+}))
+
+vi.mock('../../../../../components/loadingBlock', () => ({
+  LoadingBlock: () => <div data-testid="loading-block" />,
+}))
+
+const assetRef = {_ref: 'image-abc-100x100-jpg', _type: 'reference' as const}
+
+const baseValue = {
+  _type: 'image',
+  asset: assetRef,
+}
+
+const imageUrlBuilder = {
+  image: vi.fn().mockReturnThis(),
+  url: vi.fn().mockReturnValue('https://cdn.sanity.io/asset.jpg'),
+} as unknown as ImageUrlBuilder
+
+const baseImageInputProps = {
+  id: 'mainImage',
+  imageUrlBuilder,
+  value: baseValue,
+  changed: false,
+} as any
+
+const baseInputProps = {presence: []} as any
+
+const baseProps = {
+  handleCloseDialog: vi.fn(),
+  imageInputProps: baseImageInputProps,
+  inputProps: baseInputProps,
+  isImageToolEnabled: true,
+}
+
+describe('ImageInputHotspotInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('passes accessPolicy, image value, and url builder to useImageUrl', () => {
+    vi.mocked(useImageUrl).mockReturnValue({
+      url: 'https://cdn.sanity.io/asset.jpg',
+      isLoading: false,
+    })
+
+    renderWithTheme(<ImageInputHotspotInput {...baseProps} accessPolicy="public" />)
+
+    expect(useImageUrl).toHaveBeenCalledWith({
+      accessPolicy: 'public',
+      imageSource: baseValue,
+      imageUrlBuilder,
+    })
+  })
+
+  it('renders a LoadingBlock while the image url is resolving', () => {
+    vi.mocked(useImageUrl).mockReturnValue({url: undefined, isLoading: true})
+
+    renderWithTheme(<ImageInputHotspotInput {...baseProps} accessPolicy="checking" />)
+
+    expect(screen.getByTestId('loading-block')).toBeInTheDocument()
+    expect(screen.queryByTestId('image-tool-input')).not.toBeInTheDocument()
+  })
+
+  it('renders a LoadingBlock when there is no url even if not loading', () => {
+    vi.mocked(useImageUrl).mockReturnValue({url: undefined, isLoading: false})
+
+    renderWithTheme(<ImageInputHotspotInput {...baseProps} accessPolicy="private" />)
+
+    expect(screen.getByTestId('loading-block')).toBeInTheDocument()
+    expect(screen.queryByTestId('image-tool-input')).not.toBeInTheDocument()
+  })
+
+  it('renders ImageToolInput with the resolved url once available', () => {
+    const url = 'blob:https://studio.sanity.io/private-asset'
+    vi.mocked(useImageUrl).mockReturnValue({url, isLoading: false})
+
+    renderWithTheme(<ImageInputHotspotInput {...baseProps} accessPolicy="private" />)
+
+    const tool = screen.getByTestId('image-tool-input')
+    expect(tool).toBeInTheDocument()
+    expect(tool).toHaveAttribute('data-image-url', url)
+    expect(screen.queryByTestId('loading-block')).not.toBeInTheDocument()
+  })
+
+  it('does not render the ImageToolInput when image tool is disabled', () => {
+    vi.mocked(useImageUrl).mockReturnValue({
+      url: 'https://cdn.sanity.io/asset.jpg',
+      isLoading: false,
+    })
+
+    renderWithTheme(
+      <ImageInputHotspotInput {...baseProps} accessPolicy="public" isImageToolEnabled={false} />,
+    )
+
+    expect(screen.queryByTestId('image-tool-input')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('loading-block')).not.toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/__tests__/useAccessPolicy.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/__tests__/useAccessPolicy.test.tsx
@@ -1,0 +1,154 @@
+import {type SanityClient} from '@sanity/client'
+import {renderHook, waitFor} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {enqueueAssetAccessPolicyFetch} from '../../../../../store/accessPolicy/fetch'
+import {makeMediaLibraryRef} from '../../../../../store/accessPolicy/refs'
+import {useProjectDatasets} from '../../../../../store/project/useProjectDatasets'
+import {useAccessPolicy} from '../useAccessPolicy'
+
+vi.mock('../../../../../store/project/useProjectDatasets')
+vi.mock('../../../../../store/accessPolicy/fetch')
+
+function makeClient(config: {dataset?: string; token?: string}): SanityClient {
+  return {
+    config: () => ({dataset: config.dataset, token: config.token}),
+  } as unknown as SanityClient
+}
+
+const privateDatasetEntry = {
+  name: 'production',
+  aclMode: 'private' as const,
+  createdAt: '2024-01-01',
+  createdByUserId: 'user',
+  tags: [],
+}
+
+const publicDatasetEntry = {
+  name: 'production',
+  aclMode: 'public' as const,
+  createdAt: '2024-01-01',
+  createdByUserId: 'user',
+  tags: [],
+}
+
+describe('useAccessPolicy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('plain (non-Media-Library) sources', () => {
+    const plainImageSource = {
+      _type: 'image',
+      asset: {_ref: 'image-abc-100x100-jpg', _type: 'reference'},
+    }
+
+    it('returns "private" when the workspace dataset has aclMode: private', () => {
+      vi.mocked(useProjectDatasets).mockReturnValue({value: [privateDatasetEntry]})
+
+      const {result} = renderHook(() =>
+        useAccessPolicy({
+          client: makeClient({dataset: 'production'}),
+          source: plainImageSource,
+        }),
+      )
+
+      expect(result.current).toBe('private')
+    })
+
+    it('returns "public" when the workspace dataset has aclMode: public', () => {
+      vi.mocked(useProjectDatasets).mockReturnValue({value: [publicDatasetEntry]})
+
+      const {result} = renderHook(() =>
+        useAccessPolicy({
+          client: makeClient({dataset: 'production'}),
+          source: plainImageSource,
+        }),
+      )
+
+      expect(result.current).toBe('public')
+    })
+
+    it('returns "checking" while the dataset list is still loading', () => {
+      vi.mocked(useProjectDatasets).mockReturnValue({value: null})
+
+      const {result} = renderHook(() =>
+        useAccessPolicy({
+          client: makeClient({dataset: 'production'}),
+          source: plainImageSource,
+        }),
+      )
+
+      expect(result.current).toBe('checking')
+    })
+
+    it('falls back to "public" when the dataset is not in the project list', () => {
+      vi.mocked(useProjectDatasets).mockReturnValue({value: [privateDatasetEntry]})
+
+      const {result} = renderHook(() =>
+        useAccessPolicy({
+          client: makeClient({dataset: 'staging'}),
+          source: plainImageSource,
+        }),
+      )
+
+      expect(result.current).toBe('public')
+    })
+
+    it('falls back to "public" when the client has no dataset configured', () => {
+      vi.mocked(useProjectDatasets).mockReturnValue({value: [privateDatasetEntry]})
+
+      const {result} = renderHook(() =>
+        useAccessPolicy({
+          client: makeClient({}),
+          source: plainImageSource,
+        }),
+      )
+
+      expect(result.current).toBe('public')
+    })
+  })
+
+  describe('Media Library sources', () => {
+    const libraryId = 'lib123'
+    const assetId = 'image-xyz-200x200-png'
+    const mediaLibrarySource = {
+      media: {
+        _ref: makeMediaLibraryRef(libraryId, assetId),
+        _type: 'globalDocumentReference' as const,
+      },
+    }
+
+    it('returns "unknown" for cookie-auth clients (no token)', () => {
+      vi.mocked(useProjectDatasets).mockReturnValue({value: [privateDatasetEntry]})
+
+      const {result} = renderHook(() =>
+        useAccessPolicy({
+          client: makeClient({dataset: 'production'}),
+          source: mediaLibrarySource,
+        }),
+      )
+
+      expect(result.current).toBe('unknown')
+      expect(enqueueAssetAccessPolicyFetch).not.toHaveBeenCalled()
+    })
+
+    it('resolves the per-asset cdnAccessPolicy when the client has a token', async () => {
+      vi.mocked(useProjectDatasets).mockReturnValue({value: [privateDatasetEntry]})
+      vi.mocked(enqueueAssetAccessPolicyFetch).mockResolvedValue('private')
+
+      const {result} = renderHook(() =>
+        useAccessPolicy({
+          client: makeClient({dataset: 'production', token: 'tok'}),
+          source: mediaLibrarySource,
+        }),
+      )
+
+      await waitFor(() => expect(result.current).toBe('private'))
+      expect(enqueueAssetAccessPolicyFetch).toHaveBeenCalledWith(
+        makeMediaLibraryRef(libraryId, assetId),
+        expect.anything(),
+      )
+    })
+  })
+})

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/__tests__/useAccessPolicy.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/__tests__/useAccessPolicy.test.tsx
@@ -4,149 +4,78 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {enqueueAssetAccessPolicyFetch} from '../../../../../store/accessPolicy/fetch'
 import {makeMediaLibraryRef} from '../../../../../store/accessPolicy/refs'
+import {type ProjectDatasetData} from '../../../../../store/project/types'
 import {useProjectDatasets} from '../../../../../store/project/useProjectDatasets'
 import {useAccessPolicy} from '../useAccessPolicy'
 
 vi.mock('../../../../../store/project/useProjectDatasets')
 vi.mock('../../../../../store/accessPolicy/fetch')
 
-function makeClient(config: {dataset?: string; token?: string}): SanityClient {
-  return {
-    config: () => ({dataset: config.dataset, token: config.token}),
-  } as unknown as SanityClient
+const PLAIN_SOURCE = {_type: 'image', asset: {_ref: 'image-abc-100x100-jpg', _type: 'reference'}}
+const LIB_ID = 'lib123'
+const ASSET_ID = 'image-xyz-200x200-png'
+const ML_SOURCE = {
+  media: {_ref: makeMediaLibraryRef(LIB_ID, ASSET_ID), _type: 'globalDocumentReference'},
 }
 
-const privateDatasetEntry = {
-  name: 'production',
-  aclMode: 'private' as const,
-  createdAt: '2024-01-01',
-  createdByUserId: 'user',
-  tags: [],
+function makeClient(datasetName?: string, token?: string): SanityClient {
+  return {config: () => ({dataset: datasetName, token})} as unknown as SanityClient
 }
 
-const publicDatasetEntry = {
-  name: 'production',
-  aclMode: 'public' as const,
-  createdAt: '2024-01-01',
-  createdByUserId: 'user',
-  tags: [],
+function makeDataset(name: string, aclMode: 'public' | 'private'): ProjectDatasetData {
+  return {name, aclMode, createdAt: '', createdByUserId: '', tags: []}
+}
+
+function renderPolicy(client: SanityClient, source: unknown) {
+  return renderHook(() => useAccessPolicy({client, source: source as never})).result
 }
 
 describe('useAccessPolicy', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
+  beforeEach(() => vi.clearAllMocks())
 
   describe('plain (non-Media-Library) sources', () => {
-    const plainImageSource = {
-      _type: 'image',
-      asset: {_ref: 'image-abc-100x100-jpg', _type: 'reference'},
-    }
-
     it('returns "private" when the workspace dataset has aclMode: private', () => {
-      vi.mocked(useProjectDatasets).mockReturnValue({value: [privateDatasetEntry]})
-
-      const {result} = renderHook(() =>
-        useAccessPolicy({
-          client: makeClient({dataset: 'production'}),
-          source: plainImageSource,
-        }),
-      )
-
-      expect(result.current).toBe('private')
+      vi.mocked(useProjectDatasets).mockReturnValue({value: [makeDataset('production', 'private')]})
+      expect(renderPolicy(makeClient('production'), PLAIN_SOURCE).current).toBe('private')
     })
 
     it('returns "public" when the workspace dataset has aclMode: public', () => {
-      vi.mocked(useProjectDatasets).mockReturnValue({value: [publicDatasetEntry]})
-
-      const {result} = renderHook(() =>
-        useAccessPolicy({
-          client: makeClient({dataset: 'production'}),
-          source: plainImageSource,
-        }),
-      )
-
-      expect(result.current).toBe('public')
+      vi.mocked(useProjectDatasets).mockReturnValue({value: [makeDataset('production', 'public')]})
+      expect(renderPolicy(makeClient('production'), PLAIN_SOURCE).current).toBe('public')
     })
 
     it('returns "checking" while the dataset list is still loading', () => {
       vi.mocked(useProjectDatasets).mockReturnValue({value: null})
-
-      const {result} = renderHook(() =>
-        useAccessPolicy({
-          client: makeClient({dataset: 'production'}),
-          source: plainImageSource,
-        }),
-      )
-
-      expect(result.current).toBe('checking')
+      expect(renderPolicy(makeClient('production'), PLAIN_SOURCE).current).toBe('checking')
     })
 
     it('falls back to "public" when the dataset is not in the project list', () => {
-      vi.mocked(useProjectDatasets).mockReturnValue({value: [privateDatasetEntry]})
-
-      const {result} = renderHook(() =>
-        useAccessPolicy({
-          client: makeClient({dataset: 'staging'}),
-          source: plainImageSource,
-        }),
-      )
-
-      expect(result.current).toBe('public')
+      vi.mocked(useProjectDatasets).mockReturnValue({value: [makeDataset('production', 'private')]})
+      expect(renderPolicy(makeClient('staging'), PLAIN_SOURCE).current).toBe('public')
     })
 
     it('falls back to "public" when the client has no dataset configured', () => {
-      vi.mocked(useProjectDatasets).mockReturnValue({value: [privateDatasetEntry]})
-
-      const {result} = renderHook(() =>
-        useAccessPolicy({
-          client: makeClient({}),
-          source: plainImageSource,
-        }),
-      )
-
-      expect(result.current).toBe('public')
+      vi.mocked(useProjectDatasets).mockReturnValue({value: [makeDataset('production', 'private')]})
+      expect(renderPolicy(makeClient(), PLAIN_SOURCE).current).toBe('public')
     })
   })
 
   describe('Media Library sources', () => {
-    const libraryId = 'lib123'
-    const assetId = 'image-xyz-200x200-png'
-    const mediaLibrarySource = {
-      media: {
-        _ref: makeMediaLibraryRef(libraryId, assetId),
-        _type: 'globalDocumentReference' as const,
-      },
-    }
-
     it('returns "unknown" for cookie-auth clients (no token)', () => {
-      vi.mocked(useProjectDatasets).mockReturnValue({value: [privateDatasetEntry]})
-
-      const {result} = renderHook(() =>
-        useAccessPolicy({
-          client: makeClient({dataset: 'production'}),
-          source: mediaLibrarySource,
-        }),
-      )
-
-      expect(result.current).toBe('unknown')
+      vi.mocked(useProjectDatasets).mockReturnValue({value: [makeDataset('production', 'private')]})
+      expect(renderPolicy(makeClient('production'), ML_SOURCE).current).toBe('unknown')
       expect(enqueueAssetAccessPolicyFetch).not.toHaveBeenCalled()
     })
 
     it('resolves the per-asset cdnAccessPolicy when the client has a token', async () => {
-      vi.mocked(useProjectDatasets).mockReturnValue({value: [privateDatasetEntry]})
+      vi.mocked(useProjectDatasets).mockReturnValue({value: [makeDataset('production', 'private')]})
       vi.mocked(enqueueAssetAccessPolicyFetch).mockResolvedValue('private')
 
-      const {result} = renderHook(() =>
-        useAccessPolicy({
-          client: makeClient({dataset: 'production', token: 'tok'}),
-          source: mediaLibrarySource,
-        }),
-      )
+      const result = renderPolicy(makeClient('production', 'tok'), ML_SOURCE)
 
       await waitFor(() => expect(result.current).toBe('private'))
       expect(enqueueAssetAccessPolicyFetch).toHaveBeenCalledWith(
-        makeMediaLibraryRef(libraryId, assetId),
+        makeMediaLibraryRef(LIB_ID, ASSET_ID),
         expect.anything(),
       )
     })

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/useAccessPolicy.ts
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/useAccessPolicy.ts
@@ -9,9 +9,8 @@ import {useProjectDatasets} from '../../../../store/project/useProjectDatasets'
 import {type AssetAccessPolicy} from '../types'
 
 /**
- * Resolve the effective access policy for a given image source, including
- * Media Library specific checks when possible, and dataset-level visibility
- * for plain image assets.
+ * Resolves the access policy for an image source: per-asset for Media Library,
+ * dataset aclMode for plain assets.
  *
  * @internal
  */
@@ -49,8 +48,7 @@ export function useAccessPolicy(params: {
     return cdnAccessPolicy ?? 'unknown'
   }
 
-  // Plain asset: derive policy from the workspace dataset's aclMode so private
-  // datasets route through the authed blob-fetch path in `useImageUrl`.
+  // Plain asset: dataset aclMode drives the authed blob-fetch in `useImageUrl`.
   const datasetName = client.config().dataset
   if (!datasetName) return 'public'
   if (datasets === null) return 'checking'

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/useAccessPolicy.ts
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/useAccessPolicy.ts
@@ -5,11 +5,13 @@ import useSWR from 'swr'
 
 import {enqueueAssetAccessPolicyFetch} from '../../../../store/accessPolicy/fetch'
 import {getMediaLibraryRef, type MediaLibraryRef} from '../../../../store/accessPolicy/refs'
+import {useProjectDatasets} from '../../../../store/project/useProjectDatasets'
 import {type AssetAccessPolicy} from '../types'
 
 /**
  * Resolve the effective access policy for a given image source, including
- * Media Library specific checks when possible.
+ * Media Library specific checks when possible, and dataset-level visibility
+ * for plain image assets.
  *
  * @internal
  */
@@ -38,12 +40,21 @@ export function useAccessPolicy(params: {
   }
   const {data: cdnAccessPolicy, isLoading} = useSWR(requestKey, fetcher, options)
 
-  // Non-Media Library assets are always 'public'
-  if (!ref) return 'public'
-  // If we can't check for an access policy (no token)
-  if (!canCheck) return 'unknown'
-  // If we can check AND a check is in progress
-  if (isLoading) return 'checking'
-  // The actual fetched policy, default to 'unknown' if undefined
-  return cdnAccessPolicy ?? 'unknown'
+  const {value: datasets} = useProjectDatasets()
+
+  // Media Library asset: defer to the per-asset cdnAccessPolicy lookup
+  if (ref) {
+    if (!canCheck) return 'unknown'
+    if (isLoading) return 'checking'
+    return cdnAccessPolicy ?? 'unknown'
+  }
+
+  // Plain asset: derive policy from the workspace dataset's aclMode so private
+  // datasets route through the authed blob-fetch path in `useImageUrl`.
+  const datasetName = client.config().dataset
+  if (!datasetName) return 'public'
+  if (datasets === null) return 'checking'
+  const datasetEntry = datasets.find((entry) => entry.name === datasetName)
+  if (!datasetEntry) return 'public'
+  return datasetEntry.aclMode
 }


### PR DESCRIPTION
## Description

Fixes #12720. Clicking **Crop image** on a private-dataset image showed `Could not load image from <cdn-url>` (403 from `cdn.sanity.io`), most visible in Firefox on deployed studios.

Root cause: the crop dialog passed a plain CDN URL straight to `<img src>`. The CDN authenticates that request via the browser's `.sanity.io` session cookie, but the browser only sends that cookie when the studio is hosted under `*.sanity.io`. Studios deployed on any other domain - and especially in Firefox, which drops cross-site cookies aggressively - never see the cookie, so the CDN returns 403. The preview tile already loads private assets through an authed `fetch` + `blob:` URL (via `useImageUrl` / `useImageObjectUrl`); the crop dialog was the only `<img>` path that hadn't been wired up.

This PR does two things:

1. **Wires the crop dialog through `useImageUrl`** so it uses the same authed-blob path as the preview tile. While the fetch is in flight the dialog shows a `LoadingBlock`.
2. **Teaches `useAccessPolicy` about plain private datasets.** It previously only returned `'private'` for Media Library assets; plain image assets always came back `'public'`, so step 1 alone wouldn't fix #12720. It now reads the workspace dataset's `aclMode` via `useProjectDatasets()`.

Cookie-only clients (no `client.config().token`) fall back to today's behavior - plain CDN URL, browser handles auth - so they're no worse off.

## What to review

- `ImageInputHotspotInput.tsx` - the `useImageUrl` call and `LoadingBlock` fallback.
- `useAccessPolicy.ts` - the new branch mapping dataset `aclMode` to `AssetAccessPolicy`. This widens behavior for every consumer (preview tile, asset menu, `SanityDefaultPreview` thumbnails, `FileInput`) - intentional.

## Testing

- Unit tests for `ImageInputHotspotInput` (loading/ready states, URL plumbing) and `useAccessPolicy` (plain + Media Library paths).
- Manual: open **Crop image** on a private dataset in Firefox - bitmap loads, no 403.

## Notes for release

Crop dialog now authenticates private-dataset image requests directly, fixing a 403 that surfaced in Firefox and on deployed studios.
