### PR TITLE
fix(form): keep dialog open when focusing reference link in grid item

### DIFF
--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInputPreview.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInputPreview.tsx
@@ -17,7 +17,6 @@ import {IntentLink} from 'sanity/router'
 import {MenuButton, MenuItem, TooltipDelayGroupProvider} from '../../../../ui-components'
 import {ContextMenuButton} from '../../../components/contextMenuButton'
 import {useTranslation} from '../../../i18n'
-import {EMPTY_ARRAY} from '../../../util/empty'
 import {withFocusRing} from '../../components/withFocusRing/withFocusRing'
 import {useDidUpdate} from '../../hooks/useDidUpdate'
 import {set, unset} from '../../patch'
@@ -218,10 +217,10 @@ export function ReferenceInputPreview(props: ReferenceInputProps & {children: Re
   const handleFocus = useCallback(
     (event: FocusEvent) => {
       if (event.target === elementRef.current) {
-        onPathFocus(EMPTY_ARRAY)
+        onPathFocus(path)
       }
     },
-    [onPathFocus],
+    [onPathFocus, path],
   )
 
   const [cardRef, setCardRef] = useState<HTMLDivElement | null>(null)


### PR DESCRIPTION
### Description

Fixes [SAPP-3687](https://linear.app/sanity/issue/SAPP-3687).

When clicking a reference link inside an open array-item modal (e.g. an array-of-references with `options.layout: "grid"`), focus moves to the link and `ReferenceInputPreview`'s `handleFocus` called `onPathFocus([])`. That cleared the focus path of the open item, and the dialog closed instead of navigating to the referenced document. Mirrors the same fix applied to `CrossDatasetReferenceInput` in #12304 - pass the input's `path` to `onPathFocus` instead of `[]`, so the open item stays focused.

### What to review

### Testing

- Open https://test-studio-git-fix-sapp-3687-reference-in-grid-closing.sanity.dev/test/structure/input-standard;arraysTest;b94bef73-09cb-4ac3-b0c7-3bdd439bbca0%2Cpath%3DpolymorphicGridArray%255B_key%253D%253D%2522133bc88c0f50%2522%255D
- Scroll down to **Polymorphic grid array**, click the first item, then click the reference - the dialog should stay open and the referenced document should open.

<img width="1494" height="710" alt="beforeAfterGridArrayPR" src="https://github.com/user-attachments/assets/e67a2d57-c164-4944-9cbc-43d96bdd46e8" />

### Notes for release

Fixed an issue where clicking a reference inside an open array-item modal would close the modal instead of opening the referenced document.