### PR TITLE
fix(structure): truncate long document titles in pane header

### DIFF
--- a/packages/sanity/src/structure/components/pane/PaneHeader.styles.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneHeader.styles.tsx
@@ -38,6 +38,7 @@ export const TitleCard = styled(Card)(({theme}: {theme: Theme}) => {
   // Disable color updates on hover
   return css`
     background-color: ${bg};
+    min-width: 0;
 
     [data-ui='Text'] {
       color: ${fg};
@@ -53,4 +54,5 @@ export const TitleTextSkeleton = styled(TextSkeleton)`
 export const TitleText = styled(Text)`
   cursor: default;
   outline: none;
+  min-width: 0;
 `


### PR DESCRIPTION
### Description

When a document with a long title was open alongside the Comments pane, the title overflowed its pane and ran into the adjacent pane instead of truncating. `TitleText` already had `textOverflow="ellipsis"`, but the surrounding flex items defaulted to `min-width: auto`, which floors a flex item at its content's intrinsic width — so the box never got narrower than the text, and `text-overflow: ellipsis` had nothing to clip.

Closes SAPP-3765.

#### Before
https://test-studio.sanity.dev/test/structure/author;3b99d0a6-08ae-47cc-9fc3-31e9d8c642f7%2Cinspect%3Dsanity%252Fcomments

<img width="974" height="452" alt="image" src="https://github.com/user-attachments/assets/37754cb6-c9f7-4f37-b85c-5cba31ff9730" />

#### After
https://test-studio-git-sapp-3765.sanity.dev/test/structure/author;3b99d0a6-08ae-47cc-9fc3-31e9d8c642f7%2Cinspect%3Dsanity%252Fcomments

<img width="974" height="452" alt="image" src="https://github.com/user-attachments/assets/9a34375c-2922-4f13-bf17-41dd2e9fff71" />

### What to review
- Fix is sound?

### Testing
No automated test added, this is a pure CSS regression that's hard to assert in jsdom. Verified manually. 

### Notes for release

- Long document titles in the Studio pane header now truncate with an ellipsis instead of overflowing into adjacent panes (e.g. when the Comments pane is open).