### PR TITLE
fix(core): remove static css import from `sanity` and `vision`

### DIFF
--- a/packages/@sanity/vision/package.config.ts
+++ b/packages/@sanity/vision/package.config.ts
@@ -10,9 +10,14 @@ export default defineConfig({
     treeshake: {moduleSideEffects: true},
     output: {
       intro: (chunkInfo) => {
-        if (chunkInfo.isEntry && chunkInfo.name === 'index') {
-          return `import './bundle.css'`
-        }
+        /**
+         * TODO: we are avoiding importing the bundle.css file here because it's producing
+         * errors when using `sanity` with node or for server rendering
+         * `Error: Unknown file extension ".css"`
+         */
+        // if (chunkInfo.isEntry && chunkInfo.name === 'index') {
+        //   return `import './bundle.css'`
+        // }
 
         return ''
       },

--- a/packages/sanity/package.config.ts
+++ b/packages/sanity/package.config.ts
@@ -24,9 +24,14 @@ export default defineConfig({
     treeshake: {moduleSideEffects: true},
     output: {
       intro: (chunkInfo) => {
-        if (chunkInfo.isEntry && chunkInfo.name === 'index') {
-          return `import './bundle.css'`
-        }
+        /**
+         * TODO: we are avoiding importing the bundle.css file here because it's producing
+         * errors when using `sanity` with node or for server rendering:
+         * `Error: Unknown file extension ".css"`
+         */
+        // if (chunkInfo.isEntry && chunkInfo.name === 'index') {
+        //   return `import './bundle.css'`
+        // }
         return ''
       },
     },


### PR DESCRIPTION
### Description

As part of `v5.22.0` we started shipping static css files with sanity and vision. This is to prepare us to move this packages away from `styled-components`.
We shipped this files which were "empty", only included a variable which we used for internal testing.

However, this presented a variety of edge cases that we didn't find in our initial testing.  This affects users using sanity in node, which could be for cases like server rendering or for other cases like running typegen, etc.

This produced the following error:
```
  Error: Unknown file extension ".css"
```

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
`import "./bundle.css"` is not added anymore as part of the dist package.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes ` Error: Unknown file extension ".css"` 
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
