### PR TITLE
feat(core): route studio root to first visible workspace

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -296,6 +296,14 @@ const defaultWorkspace = defineConfig({
 })
 
 export default defineConfig([
+  {
+    ...defaultWorkspace,
+    name: 'default-hidden',
+    title: 'Default Hidden',
+    subtitle: 'Statically hidden and configured as the first (default) workspace',
+    basePath: '/default-hidden',
+    hidden: true,
+  },
   defaultWorkspace,
   {
     ...defaultWorkspace,

--- a/packages/sanity/src/core/studio/activeWorkspaceMatcher/ActiveWorkspaceMatcher.tsx
+++ b/packages/sanity/src/core/studio/activeWorkspaceMatcher/ActiveWorkspaceMatcher.tsx
@@ -25,7 +25,7 @@ export function ActiveWorkspaceMatcher({
   unstable_history: historyProp,
 }: ActiveWorkspaceMatcherProps) {
   const allWorkspaces = useWorkspaces()
-  const {visibleWorkspaces, isResolvingHiddenWorkspaces} = useVisibleWorkspaces()
+  const {visibleWorkspaces, workspaceAuthStates} = useVisibleWorkspaces()
   const history = useMemo(() => historyProp || createHistory(), [historyProp])
 
   const setActiveWorkspaceName = useCallback(
@@ -39,13 +39,10 @@ export function ActiveWorkspaceMatcher({
   )
 
   const handleNavigateToDefaultWorkspace = useCallback(() => {
-    const firstVisibleWorkspace = visibleWorkspaces[0]
-    if (firstVisibleWorkspace) {
-      setActiveWorkspaceName(firstVisibleWorkspace.name)
-    }
-  }, [setActiveWorkspaceName, visibleWorkspaces])
+    history.push('/')
+  }, [history])
 
-  const result = useSyncPathnameWithWorkspace(history, allWorkspaces)
+  const result = useSyncPathnameWithWorkspace(history, allWorkspaces, workspaceAuthStates)
 
   useEffect(() => {
     if (result.type === 'redirect') {
@@ -61,7 +58,10 @@ export function ActiveWorkspaceMatcher({
     case 'match': {
       const matchedWorkspace = result.workspace
 
-      if (typeof matchedWorkspace.hidden === 'function' && isResolvingHiddenWorkspaces) {
+      if (
+        typeof matchedWorkspace.hidden === 'function' &&
+        workspaceAuthStates[matchedWorkspace.name] === undefined
+      ) {
         return <LoadingComponent />
       }
 
@@ -84,6 +84,7 @@ export function ActiveWorkspaceMatcher({
       )
     }
     case 'redirect':
+    case 'loading':
       return <LoadingComponent />
     case 'not-found':
       return <NotFoundComponent onNavigateToDefaultWorkspace={handleNavigateToDefaultWorkspace} />

--- a/packages/sanity/src/core/studio/activeWorkspaceMatcher/__tests__/ActiveWorkspaceMatcher.test.tsx
+++ b/packages/sanity/src/core/studio/activeWorkspaceMatcher/__tests__/ActiveWorkspaceMatcher.test.tsx
@@ -1,4 +1,5 @@
-import {render, screen} from '@testing-library/react'
+import {render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
 import {createMemoryHistory} from 'history'
 import {type ReactNode} from 'react'
 import {VisibleWorkspacesContext, WorkspacesContext} from 'sanity/_singletons'
@@ -71,13 +72,12 @@ function createContextValue(
   workspaces: WorkspaceSummary[],
   authStates: Record<string, AuthState> | undefined,
 ): VisibleWorkspacesContextValue {
+  const workspaceAuthStates: Record<string, AuthState | undefined> = authStates ?? {}
   return {
     visibleWorkspaces: workspaces.filter(
-      (workspace) => !evaluateWorkspaceHidden(workspace, authStates?.[workspace.name]),
+      (workspace) => !evaluateWorkspaceHidden(workspace, workspaceAuthStates[workspace.name]),
     ),
-    isResolvingHiddenWorkspaces:
-      authStates === undefined &&
-      workspaces.some((workspace) => typeof workspace.hidden === 'function'),
+    workspaceAuthStates,
   }
 }
 
@@ -255,6 +255,105 @@ describe('ActiveWorkspaceMatcher hidden workspace behaviour', () => {
     expect(screen.queryByTestId('not-found')).toBeNull()
   })
 
+  it('redirects from root to first visible workspace when first workspace is statically hidden', async () => {
+    const hiddenWorkspace = createWorkspace({
+      name: 'hidden',
+      basePath: '/hidden',
+      hidden: true,
+    })
+    const visibleWorkspace = createWorkspace({name: 'visible', basePath: '/visible'})
+
+    const workspaces = [hiddenWorkspace, visibleWorkspace]
+    const contextValue = createContextValue(workspaces, {
+      hidden: createAuthState(),
+      visible: createAuthState(),
+    })
+
+    const history = createMemoryHistory({initialEntries: ['/']})
+
+    render(
+      <TestWrapper contextValue={contextValue} allWorkspaces={workspaces}>
+        <ActiveWorkspaceMatcher
+          unstable_history={history}
+          LoadingComponent={LoadingComponent}
+          NotFoundComponent={NotFoundComponent}
+        >
+          <div data-testid="children">Visible workspace content</div>
+        </ActiveWorkspaceMatcher>
+      </TestWrapper>,
+    )
+
+    await waitFor(() => {
+      expect(history.location.pathname).toBe('/visible')
+    })
+
+    expect(screen.getByTestId('children')).toBeDefined()
+    expect(screen.queryByTestId('not-found')).toBeNull()
+  })
+
+  it('redirects from root to first workspace when all workspaces are visible', async () => {
+    const workspaceA = createWorkspace({name: 'a', basePath: '/a'})
+    const workspaceB = createWorkspace({name: 'b', basePath: '/b'})
+
+    const workspaces = [workspaceA, workspaceB]
+    const contextValue = createContextValue(workspaces, {
+      a: createAuthState(),
+      b: createAuthState(),
+    })
+
+    const history = createMemoryHistory({initialEntries: ['/']})
+
+    render(
+      <TestWrapper contextValue={contextValue} allWorkspaces={workspaces}>
+        <ActiveWorkspaceMatcher
+          unstable_history={history}
+          LoadingComponent={LoadingComponent}
+          NotFoundComponent={NotFoundComponent}
+        >
+          <div data-testid="children">First workspace content</div>
+        </ActiveWorkspaceMatcher>
+      </TestWrapper>,
+    )
+
+    await waitFor(() => {
+      expect(history.location.pathname).toBe('/a')
+    })
+
+    expect(screen.getByTestId('children')).toBeDefined()
+    expect(screen.queryByTestId('not-found')).toBeNull()
+  })
+
+  it('renders LoadingComponent at root while hidden workspaces are still resolving', () => {
+    const functionHiddenWorkspace = createWorkspace({
+      name: 'function-hidden',
+      basePath: '/function-hidden',
+      hidden: () => true,
+    })
+    const visibleWorkspace = createWorkspace({name: 'visible', basePath: '/visible'})
+
+    const workspaces = [functionHiddenWorkspace, visibleWorkspace]
+    const contextValue = createContextValue(workspaces, undefined)
+
+    const history = createMemoryHistory({initialEntries: ['/']})
+
+    render(
+      <TestWrapper contextValue={contextValue} allWorkspaces={workspaces}>
+        <ActiveWorkspaceMatcher
+          unstable_history={history}
+          LoadingComponent={LoadingComponent}
+          NotFoundComponent={NotFoundComponent}
+        >
+          <div data-testid="children">Should not render</div>
+        </ActiveWorkspaceMatcher>
+      </TestWrapper>,
+    )
+
+    expect(screen.getByTestId('loading')).toBeDefined()
+    expect(screen.queryByTestId('children')).toBeNull()
+    expect(screen.queryByTestId('not-found')).toBeNull()
+    expect(history.location.pathname).toBe('/')
+  })
+
   it('renders NotFoundComponent without crashing when all workspaces are statically hidden', () => {
     const hiddenOne = createWorkspace({name: 'hidden-one', basePath: '/hidden-one', hidden: true})
     const hiddenTwo = createWorkspace({name: 'hidden-two', basePath: '/hidden-two', hidden: true})
@@ -283,5 +382,172 @@ describe('ActiveWorkspaceMatcher hidden workspace behaviour', () => {
 
     expect(screen.getByTestId('not-found')).toBeDefined()
     expect(screen.queryByTestId('children')).toBeNull()
+  })
+
+  it('renders LoadingComponent on match while matched workspace auth is still resolving', () => {
+    const fnHidden = createWorkspace({
+      name: 'fn-hidden',
+      basePath: '/fn-hidden',
+      hidden: () => false,
+    })
+
+    const workspaces = [fnHidden]
+    const contextValue = createContextValue(workspaces, {})
+
+    const history = createMemoryHistory({initialEntries: ['/fn-hidden']})
+
+    render(
+      <TestWrapper contextValue={contextValue} allWorkspaces={workspaces}>
+        <ActiveWorkspaceMatcher
+          unstable_history={history}
+          LoadingComponent={LoadingComponent}
+          NotFoundComponent={NotFoundComponent}
+        >
+          <div data-testid="children">Should not render yet</div>
+        </ActiveWorkspaceMatcher>
+      </TestWrapper>,
+    )
+
+    expect(screen.getByTestId('loading')).toBeDefined()
+    expect(screen.queryByTestId('children')).toBeNull()
+    expect(screen.queryByTestId('not-found')).toBeNull()
+  })
+
+  it('renders matched workspace once its auth resolves and hidden() returns false', () => {
+    const fnHidden = createWorkspace({
+      name: 'fn-hidden',
+      basePath: '/fn-hidden',
+      hidden: () => false,
+    })
+
+    const workspaces = [fnHidden]
+    const contextValue = createContextValue(workspaces, {'fn-hidden': createAuthState()})
+
+    const history = createMemoryHistory({initialEntries: ['/fn-hidden']})
+
+    render(
+      <TestWrapper contextValue={contextValue} allWorkspaces={workspaces}>
+        <ActiveWorkspaceMatcher
+          unstable_history={history}
+          LoadingComponent={LoadingComponent}
+          NotFoundComponent={NotFoundComponent}
+        >
+          <div data-testid="children">Workspace content</div>
+        </ActiveWorkspaceMatcher>
+      </TestWrapper>,
+    )
+
+    expect(screen.getByTestId('children')).toBeDefined()
+    expect(screen.queryByTestId('loading')).toBeNull()
+    expect(screen.queryByTestId('not-found')).toBeNull()
+  })
+
+  it('does not wait on other workspaces auth when matching a statically-visible workspace', () => {
+    const fnHiddenOther = createWorkspace({
+      name: 'fn-hidden-other',
+      basePath: '/fn-hidden-other',
+      hidden: () => true,
+    })
+    const staticVisible = createWorkspace({name: 'static-visible', basePath: '/static-visible'})
+
+    const workspaces = [fnHiddenOther, staticVisible]
+    const contextValue = createContextValue(workspaces, {})
+
+    const history = createMemoryHistory({initialEntries: ['/static-visible']})
+
+    render(
+      <TestWrapper contextValue={contextValue} allWorkspaces={workspaces}>
+        <ActiveWorkspaceMatcher
+          unstable_history={history}
+          LoadingComponent={LoadingComponent}
+          NotFoundComponent={NotFoundComponent}
+        >
+          <div data-testid="children">Visible workspace content</div>
+        </ActiveWorkspaceMatcher>
+      </TestWrapper>,
+    )
+
+    expect(screen.getByTestId('children')).toBeDefined()
+    expect(screen.queryByTestId('loading')).toBeNull()
+    expect(screen.queryByTestId('not-found')).toBeNull()
+  })
+
+  it('redirects from root past statically-hidden workspace to next visible without waiting on later function-hidden workspaces', async () => {
+    const staticHidden = createWorkspace({
+      name: 'static-hidden',
+      basePath: '/static-hidden',
+      hidden: true,
+    })
+    const staticVisible = createWorkspace({name: 'static-visible', basePath: '/static-visible'})
+    const fnHidden = createWorkspace({
+      name: 'fn-hidden',
+      basePath: '/fn-hidden',
+      hidden: () => true,
+    })
+
+    const workspaces = [staticHidden, staticVisible, fnHidden]
+    const contextValue = createContextValue(workspaces, {})
+
+    const history = createMemoryHistory({initialEntries: ['/']})
+
+    render(
+      <TestWrapper contextValue={contextValue} allWorkspaces={workspaces}>
+        <ActiveWorkspaceMatcher
+          unstable_history={history}
+          LoadingComponent={LoadingComponent}
+          NotFoundComponent={NotFoundComponent}
+        >
+          <div data-testid="children">Visible workspace content</div>
+        </ActiveWorkspaceMatcher>
+      </TestWrapper>,
+    )
+
+    await waitFor(() => {
+      expect(history.location.pathname).toBe('/static-visible')
+    })
+
+    expect(screen.getByTestId('children')).toBeDefined()
+    expect(screen.queryByTestId('loading')).toBeNull()
+    expect(screen.queryByTestId('not-found')).toBeNull()
+  })
+
+  it('navigates to first visible workspace when go-to-default is clicked from NotFoundComponent', async () => {
+    const staticHidden = createWorkspace({
+      name: 'static-hidden',
+      basePath: '/static-hidden',
+      hidden: true,
+    })
+    const staticVisible = createWorkspace({name: 'static-visible', basePath: '/static-visible'})
+
+    const workspaces = [staticHidden, staticVisible]
+    const contextValue = createContextValue(workspaces, {
+      'static-hidden': createAuthState(),
+      'static-visible': createAuthState(),
+    })
+
+    const history = createMemoryHistory({initialEntries: ['/static-hidden']})
+
+    render(
+      <TestWrapper contextValue={contextValue} allWorkspaces={workspaces}>
+        <ActiveWorkspaceMatcher
+          unstable_history={history}
+          LoadingComponent={LoadingComponent}
+          NotFoundComponent={NotFoundComponent}
+        >
+          <div data-testid="children">Visible workspace content</div>
+        </ActiveWorkspaceMatcher>
+      </TestWrapper>,
+    )
+
+    expect(screen.getByTestId('not-found')).toBeDefined()
+
+    await userEvent.click(screen.getByTestId('not-found'))
+
+    await waitFor(() => {
+      expect(history.location.pathname).toBe('/static-visible')
+    })
+
+    expect(screen.getByTestId('children')).toBeDefined()
+    expect(screen.queryByTestId('not-found')).toBeNull()
   })
 })

--- a/packages/sanity/src/core/studio/activeWorkspaceMatcher/__tests__/matchWorkspace.test.ts
+++ b/packages/sanity/src/core/studio/activeWorkspaceMatcher/__tests__/matchWorkspace.test.ts
@@ -3,22 +3,46 @@ import assert from 'node:assert'
 
 import {describe, expect, it} from 'vitest'
 
+import {type AuthState} from '../../../store/authStore/types'
 import {type WorkspaceLike} from '../../workspaces'
 import {createCommonBasePathRegex} from '../createCommonBasePathRegex'
 import {matchWorkspace as actualMatchWorkspace} from '../matchWorkspace'
 import {normalizedWorkspaces} from '../useNormalizedWorkspaces'
 
+function createAuthState(overrides: Partial<AuthState> = {}): AuthState {
+  return {
+    authenticated: true,
+    currentUser: {
+      id: 'user1',
+      name: 'Test User',
+      email: 'test@test.com',
+      role: 'administrator',
+      roles: [{name: 'administrator', title: 'Administrator'}],
+      profileImage: '',
+    },
+    client: {} as AuthState['client'],
+    ...overrides,
+  }
+}
+
 describe('matchWorkspace', () => {
   const matchWorkspace = ({
     pathname,
     workspaces,
+    workspaceAuthStates = {},
   }: {
     pathname: string
     workspaces: WorkspaceLike[]
+    workspaceAuthStates?: Record<string, AuthState>
   }) => {
     const normalized = normalizedWorkspaces(workspaces as any)
     const basePathRegex = createCommonBasePathRegex(normalized)
-    return actualMatchWorkspace({basePathRegex, pathname, workspaces: normalized})
+    return actualMatchWorkspace({
+      basePathRegex,
+      pathname,
+      workspaces: normalized,
+      workspaceAuthStates,
+    })
   }
   it('returns a match if the incoming `pathname` matches a workspace `basePath`', () => {
     const foo = {name: 'foo', basePath: '/common/foo'}
@@ -46,6 +70,111 @@ describe('matchWorkspace', () => {
 
     assert(resultOne.type === 'redirect')
     expect(resultOne.pathname).toBe(foo.basePath) // the first workspace in the array
+  })
+
+  it('skips a statically hidden workspace and redirects to the next visible one', () => {
+    const commonBasePath = `/x/common`
+    const hidden = {name: 'hidden', basePath: `${commonBasePath}/hidden`, hidden: true}
+    const visible = {name: 'visible', basePath: `${commonBasePath}/visible`}
+
+    const result = matchWorkspace({
+      workspaces: [hidden, visible],
+      pathname: '/',
+      workspaceAuthStates: {},
+    })
+
+    assert(result.type === 'redirect')
+    expect(result.pathname).toBe(visible.basePath)
+  })
+
+  it('returns loading when the first function-hidden workspace has no auth state yet', () => {
+    const commonBasePath = `/x/common`
+    const fnHidden = {
+      name: 'fnHidden',
+      basePath: `${commonBasePath}/fn-hidden`,
+      hidden: () => false,
+    }
+    const fallback = {name: 'fallback', basePath: `${commonBasePath}/fallback`}
+
+    const result = matchWorkspace({
+      workspaces: [fnHidden, fallback],
+      pathname: '/',
+      workspaceAuthStates: {},
+    })
+
+    expect(result.type).toBe('loading')
+  })
+
+  it('redirects to a function-hidden workspace once its callback resolves to visible', () => {
+    const commonBasePath = `/x/common`
+    const fnHidden = {
+      name: 'fnHidden',
+      basePath: `${commonBasePath}/fn-hidden`,
+      hidden: () => false,
+    }
+    const other = {name: 'other', basePath: `${commonBasePath}/other`}
+
+    const result = matchWorkspace({
+      workspaces: [fnHidden, other],
+      pathname: '/',
+      workspaceAuthStates: {fnHidden: createAuthState()},
+    })
+
+    assert(result.type === 'redirect')
+    expect(result.pathname).toBe(fnHidden.basePath)
+  })
+
+  it('skips a function-hidden workspace whose callback resolves to hidden', () => {
+    const commonBasePath = `/x/common`
+    const fnHidden = {
+      name: 'fnHidden',
+      basePath: `${commonBasePath}/fn-hidden`,
+      hidden: () => true,
+    }
+    const other = {name: 'other', basePath: `${commonBasePath}/other`}
+
+    const result = matchWorkspace({
+      workspaces: [fnHidden, other],
+      pathname: '/',
+      workspaceAuthStates: {fnHidden: createAuthState()},
+    })
+
+    assert(result.type === 'redirect')
+    expect(result.pathname).toBe(other.basePath)
+  })
+
+  it('falls back to the first configured workspace when all workspaces are hidden', () => {
+    const commonBasePath = `/x/common`
+    const hiddenA = {name: 'hiddenA', basePath: `${commonBasePath}/hidden-a`, hidden: true}
+    const hiddenB = {name: 'hiddenB', basePath: `${commonBasePath}/hidden-b`, hidden: true}
+
+    const result = matchWorkspace({
+      workspaces: [hiddenA, hiddenB],
+      pathname: '/',
+      workspaceAuthStates: {},
+    })
+
+    assert(result.type === 'redirect')
+    expect(result.pathname).toBe(hiddenA.basePath)
+  })
+
+  it('does not wait for a later function-hidden workspace when an earlier one is statically visible', () => {
+    const commonBasePath = `/x/common`
+    const visible = {name: 'visible', basePath: `${commonBasePath}/visible`}
+    const fnHidden = {
+      name: 'fnHidden',
+      basePath: `${commonBasePath}/fn-hidden`,
+      hidden: () => false,
+    }
+
+    const result = matchWorkspace({
+      workspaces: [visible, fnHidden],
+      pathname: '/',
+      workspaceAuthStates: {},
+    })
+
+    assert(result.type === 'redirect')
+    expect(result.pathname).toBe(visible.basePath)
   })
 
   it('results in a redirect to the first workspace if the incoming `pathname` partially matches the common base path', () => {
@@ -121,6 +250,15 @@ describe('matchWorkspace', () => {
       workspaces: [foo, bar, baz],
       // this should not match anything
       pathname: '/common/ba',
+    })
+
+    expect(result.type).toBe('not-found')
+  })
+
+  it('returns not-found when workspaces is empty', () => {
+    const result = matchWorkspace({
+      workspaces: [],
+      pathname: '/',
     })
 
     expect(result.type).toBe('not-found')

--- a/packages/sanity/src/core/studio/activeWorkspaceMatcher/createCommonBasePathRegex.ts
+++ b/packages/sanity/src/core/studio/activeWorkspaceMatcher/createCommonBasePathRegex.ts
@@ -16,6 +16,9 @@ import {type NormalizedWorkspace} from './types'
  * @internal
  */
 export function createCommonBasePathRegex(workspaces: NormalizedWorkspace[]): RegExp {
+  // No workspaces means no common base path; return a regex that never matches.
+  if (workspaces.length === 0) return /^$/
+
   const workspaceSegments = workspaces.map((workspace) =>
     // gets the segments from the basePath
     workspace.basePath

--- a/packages/sanity/src/core/studio/activeWorkspaceMatcher/matchWorkspace.ts
+++ b/packages/sanity/src/core/studio/activeWorkspaceMatcher/matchWorkspace.ts
@@ -1,4 +1,6 @@
+import {type WorkspaceAuthStates} from '../components/navbar/workspace/hooks'
 import {type WorkspacesContextValue} from '../workspaces'
+import {evaluateWorkspaceHidden} from '../workspaces/useVisibleWorkspaces'
 import {type NormalizedWorkspace} from './types'
 
 /** @internal */
@@ -6,6 +8,7 @@ export interface MatchWorkspaceOptions {
   workspaces: NormalizedWorkspace[]
   pathname: string
   basePathRegex: RegExp
+  workspaceAuthStates: WorkspaceAuthStates
 }
 
 /** @internal */
@@ -13,10 +16,18 @@ export type MatchWorkspaceResult =
   | {type: 'match'; workspace: WorkspacesContextValue[number]}
   | {type: 'redirect'; pathname: string}
   | {type: 'not-found'}
+  | {type: 'loading'}
 
 /**
- * Given a pathname and a list of workspaces, returns either a workspace match,
- * a redirect, or not-found.
+ * Resolves a pathname against the configured workspaces. Returns a match for a
+ * known workspace path, a redirect to the first visible workspace when the
+ * pathname is the common base path, or not-found otherwise.
+ *
+ * The default redirect walks workspaces in config order, skipping any with
+ * `hidden: true` or with a `hidden()` callback that returns `true`. It returns
+ * `loading` only when a function-hidden workspace is reached whose auth state
+ * has not yet resolved. If every workspace is hidden, it falls back to the
+ * first configured workspace.
  *
  * @internal
  */
@@ -24,8 +35,9 @@ export function matchWorkspace({
   pathname,
   workspaces,
   basePathRegex,
+  workspaceAuthStates,
 }: MatchWorkspaceOptions): MatchWorkspaceResult {
-  const [firstWorkspace] = workspaces
+  if (workspaces.length === 0) return {type: 'not-found'}
   // eslint-disable-next-line @typescript-eslint/no-shadow
   for (const {workspace, basePath, basePathRegex} of workspaces) {
     // this regex ends with a `(\\/|$)` (forward slash or end) to prevent false
@@ -37,14 +49,19 @@ export function matchWorkspace({
     }
   }
 
-  // if the pathname is only a leading slash, then return a redirect
-  if (pathname === '/') {
-    return {type: 'redirect', pathname: firstWorkspace.basePath}
-  }
-
-  if (basePathRegex.test(pathname)) {
-    // redirect to the first workspace configured
-    return {type: 'redirect', pathname: firstWorkspace.basePath}
+  if (pathname === '/' || basePathRegex.test(pathname)) {
+    for (const {workspace, basePath} of workspaces) {
+      const {hidden} = workspace
+      if (hidden === true) continue
+      if (typeof hidden === 'function') {
+        const authState = workspaceAuthStates[workspace.name]
+        if (authState === undefined) return {type: 'loading'}
+        if (evaluateWorkspaceHidden(workspace, authState)) continue
+      }
+      return {type: 'redirect', pathname: basePath}
+    }
+    // Every workspace is hidden; fall back to the first configured one.
+    return {type: 'redirect', pathname: workspaces[0].basePath}
   }
 
   // if the pathname was not a subset of the common base path, then the route

--- a/packages/sanity/src/core/studio/activeWorkspaceMatcher/useSyncPathnameWithWorkspace.ts
+++ b/packages/sanity/src/core/studio/activeWorkspaceMatcher/useSyncPathnameWithWorkspace.ts
@@ -1,6 +1,7 @@
 import {useMemo, useState} from 'react'
 import {useSyncExternalStoreWithSelector} from 'use-sync-external-store/with-selector'
 
+import {type WorkspaceAuthStates} from '../components/navbar/workspace/hooks'
 import {type RouterHistory} from '../router'
 import {type WorkspacesContextValue} from '../workspaces'
 import {createCommonBasePathRegex} from './createCommonBasePathRegex'
@@ -14,6 +15,7 @@ import {useNormalizedWorkspaces} from './useNormalizedWorkspaces'
 export function useSyncPathnameWithWorkspace(
   history: RouterHistory,
   _workspaces: WorkspacesContextValue,
+  workspaceAuthStates: WorkspaceAuthStates,
 ): MatchWorkspaceResult {
   // Workspaces changes infrequently, but router matching can fire a lot. And so there's value in memoizing the normalized
   // to avoid creating new arrays on every render.
@@ -31,7 +33,13 @@ export function useSyncPathnameWithWorkspace(
       subscribe: (onStoreChange: () => void) => history.listen(onStoreChange),
       getSnapshot: () => history.location.pathname,
       getServerSnapshot: () => serverSnapshot,
-      selector: (pathname: string) => matchWorkspace({basePathRegex, pathname, workspaces}),
+      selector: (pathname: string) =>
+        matchWorkspace({
+          basePathRegex,
+          pathname,
+          workspaces,
+          workspaceAuthStates,
+        }),
       isEqual: (a: MatchWorkspaceResult, b: MatchWorkspaceResult) => {
         if (a.type !== b.type) return false
         switch (a.type) {
@@ -40,6 +48,7 @@ export function useSyncPathnameWithWorkspace(
           case 'redirect':
             return a.pathname === (b as typeof a).pathname
           case 'not-found':
+          case 'loading':
             return true
           default:
             // oxlint-disable-next-line no-explicit-any
@@ -47,7 +56,7 @@ export function useSyncPathnameWithWorkspace(
         }
       },
     }
-  }, [basePathRegex, history, serverSnapshot, workspaces])
+  }, [basePathRegex, history, serverSnapshot, workspaces, workspaceAuthStates])
 
   return useSyncExternalStoreWithSelector<string, MatchWorkspaceResult>(
     store.subscribe,

--- a/packages/sanity/src/core/studio/components/navbar/workspace/hooks/useWorkspaceAuthStates.ts
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/hooks/useWorkspaceAuthStates.ts
@@ -1,14 +1,28 @@
-import {combineLatest} from 'rxjs'
-import {map} from 'rxjs/operators'
+import {merge, of} from 'rxjs'
+import {map, scan, startWith} from 'rxjs/operators'
 
 import {type WorkspaceSummary} from '../../../../../config'
+import {type AuthState} from '../../../../../store/authStore/types'
 import {createHookFromObservableFactory} from '../../../../../util'
 
+export type WorkspaceAuthStates = Record<string, AuthState | undefined>
+
+const EMPTY_AUTH_STATES: WorkspaceAuthStates = {}
+
 export const useWorkspaceAuthStates = createHookFromObservableFactory(
-  (workspaces: WorkspaceSummary[]) =>
-    combineLatest(
-      workspaces.map((workspace) =>
+  (workspaces: WorkspaceSummary[]) => {
+    if (workspaces.length === 0) return of(EMPTY_AUTH_STATES)
+    return merge(
+      ...workspaces.map((workspace) =>
         workspace.auth.state.pipe(map((state) => [workspace.name, state] as const)),
       ),
-    ).pipe(map((entries) => Object.fromEntries(entries))),
+    ).pipe(
+      scan<readonly [string, AuthState], WorkspaceAuthStates>(
+        (acc, [name, state]) => ({...acc, [name]: state}),
+        {},
+      ),
+      startWith(EMPTY_AUTH_STATES),
+    )
+  },
+  EMPTY_AUTH_STATES,
 )

--- a/packages/sanity/src/core/studio/workspaces/VisibleWorkspacesProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaces/VisibleWorkspacesProvider.tsx
@@ -2,22 +2,17 @@ import {type ReactNode, useMemo} from 'react'
 import {VisibleWorkspacesContext} from 'sanity/_singletons'
 
 import {type WorkspaceSummary} from '../../config/types'
-import {useWorkspaceAuthStates} from '../components/navbar/workspace/hooks'
+import {
+  useWorkspaceAuthStates,
+  type WorkspaceAuthStates,
+} from '../components/navbar/workspace/hooks'
 import {evaluateWorkspaceHidden} from './useVisibleWorkspaces'
 import {useWorkspaces} from './useWorkspaces'
 
 /** @internal */
 export interface VisibleWorkspacesContextValue {
   visibleWorkspaces: WorkspaceSummary[]
-  /**
-   * `true` while auth state is still resolving for one or more workspaces
-   * whose visibility depends on a function-based `hidden` property.
-   * `visibleWorkspaces` includes these workspaces optimistically in the
-   * meantime.
-   *
-   * Follows the same fail-open pattern as `evaluateWorkspaceHidden`.
-   */
-  isResolvingHiddenWorkspaces: boolean
+  workspaceAuthStates: WorkspaceAuthStates
 }
 
 /** @internal */
@@ -33,16 +28,16 @@ export function VisibleWorkspacesProvider({children}: {children: ReactNode}) {
     [allWorkspaces],
   )
 
-  const [authStates] = useWorkspaceAuthStates(workspacesNeedingAuth)
+  const [workspaceAuthStates] = useWorkspaceAuthStates(workspacesNeedingAuth)
 
   const value = useMemo<VisibleWorkspacesContextValue>(
     () => ({
       visibleWorkspaces: allWorkspaces.filter(
-        (workspace) => !evaluateWorkspaceHidden(workspace, authStates?.[workspace.name]),
+        (workspace) => !evaluateWorkspaceHidden(workspace, workspaceAuthStates[workspace.name]),
       ),
-      isResolvingHiddenWorkspaces: workspacesNeedingAuth.length > 0 && authStates === undefined,
+      workspaceAuthStates,
     }),
-    [allWorkspaces, workspacesNeedingAuth, authStates],
+    [allWorkspaces, workspaceAuthStates],
   )
 
   return (

--- a/packages/sanity/src/core/studio/workspaces/__tests__/VisibleWorkspacesProvider.test.tsx
+++ b/packages/sanity/src/core/studio/workspaces/__tests__/VisibleWorkspacesProvider.test.tsx
@@ -94,7 +94,7 @@ describe('VisibleWorkspacesProvider', () => {
     expect(staticallyHidden.authSubscriptionCount()).toBe(0)
     expect(staticallyVisible.authSubscriptionCount()).toBe(0)
 
-    expect(view.result.current.isResolvingHiddenWorkspaces).toBe(false)
+    expect(view.result.current.workspaceAuthStates).toEqual({})
     expect(view.result.current.visibleWorkspaces.map((w) => w.name)).toEqual(['default', 'guest'])
   })
 
@@ -109,7 +109,7 @@ describe('VisibleWorkspacesProvider', () => {
     expect(view.result.current.visibleWorkspaces.map((w) => w.name)).toEqual(['default', 'admin'])
   })
 
-  it('flips isResolvingHiddenWorkspaces from true to false once callback auth resolves', () => {
+  it('resolves workspaceAuthStates for a callback-hidden workspace once auth emits', () => {
     const state$ = new Subject<AuthState>()
     const plain = createWorkspace({name: 'default'})
     const callback = createWorkspace({
@@ -121,7 +121,7 @@ describe('VisibleWorkspacesProvider', () => {
 
     const view = renderProvider([plain, callback])
 
-    expect(view.result.current.isResolvingHiddenWorkspaces).toBe(true)
+    expect(view.result.current.workspaceAuthStates.admin).toBeUndefined()
     // Fail-open: callback-hidden workspaces are included optimistically
     // while auth is still resolving.
     expect(view.result.current.visibleWorkspaces.map((w) => w.name)).toEqual(['default', 'admin'])
@@ -141,7 +141,42 @@ describe('VisibleWorkspacesProvider', () => {
       )
     })
 
-    expect(view.result.current.isResolvingHiddenWorkspaces).toBe(false)
+    expect(view.result.current.workspaceAuthStates.admin).toBeDefined()
     expect(view.result.current.visibleWorkspaces.map((w) => w.name)).toEqual(['default'])
+  })
+
+  it('progressively resolves workspaceAuthStates as each workspace auth emits', () => {
+    const firstState$ = new Subject<AuthState>()
+    const secondState$ = new Subject<AuthState>()
+    const firstWorkspace = createWorkspace({
+      name: 'first',
+      hidden: () => false,
+      state$: firstState$,
+    })
+    const secondWorkspace = createWorkspace({
+      name: 'second',
+      hidden: () => false,
+      state$: secondState$,
+    })
+
+    const view = renderProvider([firstWorkspace, secondWorkspace])
+
+    expect(view.result.current.workspaceAuthStates).toEqual({})
+
+    const firstAuthState = createAuthState()
+    act(() => {
+      firstState$.next(firstAuthState)
+    })
+
+    expect(view.result.current.workspaceAuthStates.first).toBe(firstAuthState)
+    expect(view.result.current.workspaceAuthStates.second).toBeUndefined()
+
+    const secondAuthState = createAuthState()
+    act(() => {
+      secondState$.next(secondAuthState)
+    })
+
+    expect(view.result.current.workspaceAuthStates.first).toBe(firstAuthState)
+    expect(view.result.current.workspaceAuthStates.second).toBe(secondAuthState)
   })
 })


### PR DESCRIPTION
### Description

[SAPP-3825](https://linear.app/sanity/issue/SAPP-3825/route-studio-root-to-first-visible-workspace) 

Studio routed `/` to the first configured workspace even when the user could not see it, dumping them on "Workspace not found." This PR walks workspaces in config order and routes to the first one the user can see. The not-found screen's recovery button uses the same walk.

Workspace auth resolution moves from a global `combineLatest` gate to per-workspace progressive emission, so routing waits only on the specific workspace whose visibility it needs.

### What to review

- `matchWorkspace.ts` walks workspaces in config order with a per-workspace auth check, returning `{type: 'loading'}` only for the workspace under evaluation.
- `useWorkspaceAuthStates.ts` swaps `combineLatest` for `merge` + `scan` + `startWith`. The `workspacesNeedingAuth` filter still prevents thundering-herd `/users/me` requests.
- `VisibleWorkspacesContextValue` drops `isResolvingHiddenWorkspaces` and exposes `workspaceAuthStates`. `visibleWorkspaces` keeps its fail-open semantics, so the workspace switcher is unchanged.
- The not-found "go to default workspace" button now pushes `/` and delegates the choice to the matcher's walk.

### Testing

`dev/test-studio/sanity.config.ts` prepends a statically-hidden workspace, so `pnpm dev` at `/` exercises the walk and `/default-hidden` shows the not-found screen with a working recovery button. 
Unit tests added across the workspace matcher logic

### Notes for release

Studio root now routes to the first workspace the user can see, fixing the case where the configured default is hidden from them.