### PR TITLE
fix: show login screen instead of error when session expires

### DIFF
--- a/dev/auth-test-studio/package.json
+++ b/dev/auth-test-studio/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
+    "@vanilla-extract/vite-plugin": "catalog:",
     "eslint": "catalog:",
     "rimraf": "catalog:",
     "vite": "catalog:"

--- a/dev/auth-test-studio/sanity.cli.ts
+++ b/dev/auth-test-studio/sanity.cli.ts
@@ -1,3 +1,4 @@
+import {vanillaExtractPlugin} from '@vanilla-extract/vite-plugin'
 import {defineCliConfig} from 'sanity/cli'
 import {defaultClientConditions, mergeConfig, type UserConfig} from 'vite'
 
@@ -34,6 +35,7 @@ export default defineCliConfig({
     const reactProductionProfiling = process.env.REACT_PRODUCTION_PROFILING === 'true'
 
     const nextConfig = mergeConfig(viteConfig, {
+      plugins: [vanillaExtractPlugin()],
       server: {
         warmup: {
           clientFiles: [

--- a/packages/sanity/src/core/store/authStore/__tests__/createLoginComponent.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/createLoginComponent.test.ts
@@ -1,0 +1,71 @@
+import {type SanityClient} from '@sanity/client'
+import {describe, expect, it, vi} from 'vitest'
+
+import {getProviders} from '../createLoginComponent'
+
+interface MockClient {
+  config: Record<string, unknown>
+  request: ReturnType<typeof vi.fn>
+  withConfig: (next: Record<string, unknown>) => MockClient
+}
+
+interface MockClientFactory {
+  client: MockClient
+  /** Configs captured at the moment each request was made. */
+  requestConfigs: Array<Record<string, unknown>>
+}
+
+function createMockClient(initialConfig: Record<string, unknown>): MockClientFactory {
+  const requestConfigs: Array<Record<string, unknown>> = []
+  const make = (config: Record<string, unknown>): MockClient => {
+    const client: MockClient = {
+      config,
+      request: vi.fn(() => {
+        requestConfigs.push(client.config)
+        return Promise.resolve({providers: [], thirdPartyLogin: true})
+      }),
+      withConfig: (next) => make({...client.config, ...next}),
+    }
+    return client
+  }
+  return {client: make(initialConfig), requestConfigs}
+}
+
+describe('getProviders', () => {
+  it('requests /auth/providers without sending the auth credential', async () => {
+    // Regression: when a Studio session expires, sending the now-stale token
+    // (or session cookie) with /auth/providers causes the server to reject
+    // the request, which surfaces as a generic "An error occurred" screen via
+    // StudioErrorBoundary instead of routing the user back through the login
+    // flow. /auth/providers is public, so the fix is to strip credentials —
+    // an anonymous request can't trip the rejection path.
+    const {client, requestConfigs} = createMockClient({
+      token: 'expired-token',
+      withCredentials: true,
+    })
+
+    await getProviders({
+      client: client as unknown as SanityClient,
+      mode: 'append',
+      providers: [],
+    })
+
+    expect(requestConfigs).toHaveLength(1)
+    expect(requestConfigs[0]?.token).toBeUndefined()
+    expect(requestConfigs[0]?.withCredentials).toBe(false)
+  })
+
+  it('skips /auth/providers entirely in replace mode with a provider array', async () => {
+    const {client, requestConfigs} = createMockClient({token: 'expired-token'})
+    const customProviders = [{name: 'github', title: 'GitHub', url: 'https://example.com/login'}]
+
+    const result = await getProviders({
+      client: client as unknown as SanityClient,
+      mode: 'replace',
+      providers: customProviders,
+    })
+
+    expect(result).toEqual(customProviders)
+    expect(requestConfigs).toHaveLength(0)
+  })
+})

--- a/packages/sanity/src/core/store/authStore/createLoginComponent.tsx
+++ b/packages/sanity/src/core/store/authStore/createLoginComponent.tsx
@@ -28,7 +28,13 @@ export async function getProviders({
     return customProviders
   }
 
-  const {providers} = await client.request<AuthProviderResponse>({
+  // Fetch providers without credentials. `/auth/providers` doesn't require
+  // auth, and including a now-expired credential here causes the server to
+  // 401 the request, which would surface as a generic error boundary to a
+  // user who simply needs to log in again. Stripping the token + cookie
+  // sidesteps that — anonymous callers get the public provider list.
+  const credentiallessClient = client.withConfig({token: undefined, withCredentials: false})
+  const {providers} = await credentiallessClient.request<AuthProviderResponse>({
     uri: '/auth/providers',
   })
 

--- a/packages/sanity/src/core/store/authStore/createLoginComponent.tsx
+++ b/packages/sanity/src/core/store/authStore/createLoginComponent.tsx
@@ -17,7 +17,8 @@ interface GetProvidersOptions extends AuthConfig {
   client: SanityClient
 }
 
-async function getProviders({
+/** @internal */
+export async function getProviders({
   client,
   mode,
   providers: customProviders = [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../../packages/@repo/eslint-config
+      '@vanilla-extract/vite-plugin':
+        specifier: 'catalog:'
+        version: 5.2.2(@types/node@24.10.13)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(vite@7.3.2(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       eslint:
         specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.1)


### PR DESCRIPTION
### Description

When a Studio session expires, `LoginComponent`'s call to `/auth/providers` includes the now-stale credential. This leads to an error being thrown in the Studio and doesn't go away after a reload.

### What to review
- The regression test + fix
- Also snuck in a small fix for our dev/auth testing Studio.

### Testing

Unit test in `createLoginComponent.test.ts`: fails without the change: https://github.com/sanity-io/sanity/actions/runs/25812000294/job/75830536128?pr=12827
Passes with the fix: https://github.com/sanity-io/sanity/actions/runs/25812291246/job/75831590873?pr=12827

### Notes for release

Fixes a regression where the Studio would show a generic "An error occurred" screen instead of the login screen when a session expired. Expired sessions now route through the normal login flow.
