### PR TITLE
chore(deps): exclude groq@5.24.0 from trust policy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -90,7 +90,7 @@ trustPolicyExclude:
   - '@sanity/sdk@2.1.2'
   - '@swc/core@1.13.5'
   - chokidar@4.0.3
-  - groq@3.88.1-typegen-experimental.0
+  - groq@5.24.0
   - react-redux@9.2.0
   - reselect@5.1.1
   - rxjs@7.8.2


### PR DESCRIPTION
### Description

groq@5.24.0 got published without provenance. This causes pnpm install to flag it as a trust downgrade. Provenance is restored on publish now, but the cli / codegen still takes in groq@5.24.0 as a transitive dependency. This fixes the issue by marking it as trusted.

### What to review
- Removed the previous version, as I strongly doubt its needed

### Testing


### Notes for release

n/a – monorepo local only