### PR TITLE
fix(sanity): allow `FormBuilder` to render without parent `DocumentDivergencesContext`

### DIFF
--- a/dev/test-studio/plugins/form-builder-repro/FormBuilderRepro.tsx
+++ b/dev/test-studio/plugins/form-builder-repro/FormBuilderRepro.tsx
@@ -1,0 +1,107 @@
+import {Card, Heading, Stack, Text} from '@sanity/ui'
+import {useMemo, useState} from 'react'
+import {ChangeIndicatorsTracker, createPatchChannel, FormBuilder, useDocumentForm} from 'sanity'
+
+import {FORM_BUILDER_REPRO_TYPE} from './plugin'
+
+/**
+ * Reproduction for the `useDocumentDivergences` crash reported by plugin authors
+ * (e.g. the Vercel Deploy plugin's "Add Project" dialog).
+ *
+ * This tool mounts `<FormBuilder>` outside any `DocumentPaneProvider`, mirroring
+ * the shape of a plugin that opens a dialog containing form fields for creating
+ * a "hidden" document. Before the FormBuilder fix this throws:
+ *
+ *   Error: useDocumentDivergences must be used within a DocumentDivergencesContext
+ *
+ * After the fix it renders cleanly.
+ *
+ * The schema type used here (`formBuilderReproDoc`) is intentionally minimal:
+ * no incoming reference decorations, no document actions, no inspectors — so any
+ * error that surfaces is attributable to the `FormBuilder` itself, not to schema
+ * features that also depend on a `DocumentPaneProvider`.
+ */
+export function FormBuilderRepro() {
+  const [patchChannel] = useState(() => createPatchChannel())
+  const [documentId] = useState(() => `repro-${Date.now()}`)
+
+  const initialValue = useMemo(
+    () => ({
+      loading: false,
+      value: {
+        _id: documentId,
+        _type: FORM_BUILDER_REPRO_TYPE,
+      },
+      error: null,
+    }),
+    [documentId],
+  )
+
+  const {
+    formState,
+    onChange,
+    onPathOpen,
+    onFocus,
+    onBlur,
+    onSetActiveFieldGroup,
+    onSetCollapsedFieldSet,
+    onSetCollapsedPath,
+    collapsedFieldSets,
+    ready,
+    collapsedPaths,
+    schemaType,
+    value,
+  } = useDocumentForm({
+    documentId,
+    documentType: FORM_BUILDER_REPRO_TYPE,
+    initialValue,
+  })
+
+  if (formState === null || !ready) {
+    return (
+      <Card padding={5}>
+        <Text muted>Loading form...</Text>
+      </Card>
+    )
+  }
+
+  return (
+    <Card padding={5}>
+      <Stack space={4}>
+        <Heading>FormBuilder repro</Heading>
+        <Text muted size={1}>
+          Renders `&lt;FormBuilder&gt;` outside `DocumentPaneProvider`. Without the FormBuilder
+          DivergencesProvider fix, this throws `useDocumentDivergences must be used within a
+          DocumentDivergencesContext`.
+        </Text>
+        <Card border padding={4} radius={2}>
+          <ChangeIndicatorsTracker>
+            <FormBuilder
+              __internal_patchChannel={patchChannel}
+              id="root"
+              onChange={onChange}
+              onPathFocus={onFocus}
+              onPathOpen={onPathOpen}
+              onPathBlur={onBlur}
+              onFieldGroupSelect={onSetActiveFieldGroup}
+              onSetFieldSetCollapsed={onSetCollapsedFieldSet}
+              onSetPathCollapsed={onSetCollapsedPath}
+              collapsedPaths={collapsedPaths}
+              collapsedFieldSets={collapsedFieldSets}
+              focusPath={formState.focusPath}
+              changed={formState.changed}
+              focused={formState.focused}
+              groups={formState.groups}
+              validation={formState.validation}
+              members={formState.members}
+              presence={formState.presence}
+              schemaType={schemaType}
+              value={value}
+              hasUpstreamVersion={false}
+            />
+          </ChangeIndicatorsTracker>
+        </Card>
+      </Stack>
+    </Card>
+  )
+}

--- a/dev/test-studio/plugins/form-builder-repro/index.ts
+++ b/dev/test-studio/plugins/form-builder-repro/index.ts
@@ -1,0 +1,1 @@
+export * from './plugin'

--- a/dev/test-studio/plugins/form-builder-repro/plugin.tsx
+++ b/dev/test-studio/plugins/form-builder-repro/plugin.tsx
@@ -1,0 +1,37 @@
+import {DocumentIcon} from '@sanity/icons'
+import {defineField, defineType, definePlugin} from 'sanity'
+
+import {FormBuilderRepro} from './FormBuilderRepro'
+
+export const FORM_BUILDER_REPRO_TYPE = 'formBuilderReproDoc'
+
+const formBuilderReproSchema = defineType({
+  name: FORM_BUILDER_REPRO_TYPE,
+  type: 'document',
+  title: 'FormBuilder repro doc',
+  fields: [
+    defineField({name: 'title', type: 'string', title: 'Title'}),
+    defineField({name: 'description', type: 'text', title: 'Description'}),
+    defineField({
+      name: 'tags',
+      type: 'array',
+      title: 'Tags',
+      of: [{type: 'string'}],
+    }),
+  ],
+})
+
+export const formBuilderReproTool = definePlugin(() => ({
+  name: 'form-builder-repro',
+  schema: {
+    types: [formBuilderReproSchema],
+  },
+  tools: [
+    {
+      name: 'form-builder-repro',
+      title: 'FormBuilder repro',
+      icon: DocumentIcon,
+      component: FormBuilderRepro,
+    },
+  ],
+}))

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -42,6 +42,7 @@ import {resolveInitialValueTemplates} from './initialValueTemplates'
 import {customInspector} from './inspectors/custom'
 import {testStudioLocaleBundles} from './locales'
 import {errorReportingTestPlugin} from './plugins/error-reporting-test'
+import {formBuilderReproTool} from './plugins/form-builder-repro'
 import {autoCloseBrackets} from './plugins/input/auto-close-brackets-plugin'
 import {wave} from './plugins/input/wave-plugin'
 import {languageFilter} from './plugins/language-filter'
@@ -215,6 +216,7 @@ const sharedSettings = ({projectId}: {projectId: string}) => {
       muxInput({mp4_support: 'standard'}),
       imageHotspotArrayPlugin(),
       routerDebugTool(),
+      formBuilderReproTool(),
       errorReportingTestPlugin(),
       media(),
       markdownSchema(),

--- a/packages/sanity/playwright-ct/tests/formBuilder/utils/TestWrapper.tsx
+++ b/packages/sanity/playwright-ct/tests/formBuilder/utils/TestWrapper.tsx
@@ -25,7 +25,6 @@ import {route} from '../../../../src/router'
 import {RouterProvider} from '../../../../src/router/RouterProvider'
 import {Pane, PaneContent, PaneLayout} from '../../../../src/structure/components/pane'
 import {createMockSanityClient} from '../../../../test/mocks/mockSanityClient'
-import {DivergencesTestProvider} from '../../../../test/testUtils/DivergencesTestProvider'
 import {getMockWorkspace} from '../../../../test/testUtils/getMockWorkspaceFromConfig'
 
 interface TestWrapperProps {
@@ -125,9 +124,7 @@ const TestWrapperContents = (
                               <PaneLayout height="fill">
                                 <Pane id="test-pane">
                                   <PaneContent>
-                                    <DivergencesTestProvider>
-                                      <Card padding={3}>{children}</Card>
-                                    </DivergencesTestProvider>
+                                    <Card padding={3}>{children}</Card>
                                   </PaneContent>
                                 </Pane>
                               </PaneLayout>

--- a/packages/sanity/src/_singletons/context/DocumentDivergencesContext.ts
+++ b/packages/sanity/src/_singletons/context/DocumentDivergencesContext.ts
@@ -12,7 +12,10 @@ export type DocumentDivergencesContextValue =
 /**
  * @internal
  */
-export const DocumentDivergencesContext = createContext<DocumentDivergencesContextValue | null>(
+export const DocumentDivergencesContext = createContext<DocumentDivergencesContextValue>(
   'sanity/_singletons/context/document-divergences',
-  null,
+  {
+    enabled: false,
+    sessionId: null,
+  },
 )

--- a/packages/sanity/src/core/form/contexts/DivergencesProvider.tsx
+++ b/packages/sanity/src/core/form/contexts/DivergencesProvider.tsx
@@ -144,13 +144,7 @@ const DivergencesProviderDisabled: ComponentType<PropsWithChildren> = ({children
  * @internal
  */
 export function useDocumentDivergences(): DocumentDivergencesContextValue {
-  const context = useContext(DocumentDivergencesContext)
-
-  if (!context) {
-    throw new Error('useDocumentDivergences must be used within a DocumentDivergencesContext')
-  }
-
-  return context
+  return useContext(DocumentDivergencesContext)
 }
 
 /**

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.tsx
@@ -7,12 +7,7 @@ import {useEffect, useMemo, useState} from 'react'
 import {styled} from 'styled-components'
 
 import {LoadingBlock} from '../../../../components'
-import {
-  createPatchChannel,
-  DivergencesProvider,
-  FormBuilder,
-  useDocumentForm,
-} from '../../../../form'
+import {createPatchChannel, FormBuilder, useDocumentForm} from '../../../../form'
 import {useCurrentUser} from '../../../../store'
 import {useWorkspace} from '../../../../studio'
 import {MentionUserProvider, useMentionUser, useTasks, useTasksNavigation} from '../../../context'
@@ -183,9 +178,7 @@ export function TasksFormBuilder() {
     // This provider needs to be mounted before the TasksAddonWorkspaceProvider.
     <MentionUserProvider>
       <TasksAddonWorkspaceProvider mode={viewMode === 'edit' ? 'edit' : 'create'}>
-        <DivergencesProvider enabled={false}>
-          <TasksFormBuilderInner documentId={selectedTask} initialValue={initialValue} />
-        </DivergencesProvider>
+        <TasksFormBuilderInner documentId={selectedTask} initialValue={initialValue} />
       </TasksAddonWorkspaceProvider>
     </MentionUserProvider>
   )

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -10,7 +10,6 @@ import {
   type ComponentProps,
   type ComponentType,
   useCallback,
-  useContext,
   useEffect,
   useEffectEvent,
   useMemo,
@@ -46,11 +45,7 @@ import {
   useUnique,
   useWorkspace,
 } from 'sanity'
-import {
-  DocumentDivergencesContext,
-  DocumentPaneContext,
-  DocumentPaneInfoContext,
-} from 'sanity/_singletons'
+import {DocumentPaneContext, DocumentPaneInfoContext} from 'sanity/_singletons'
 import {useRouter} from 'sanity/router'
 
 import {usePaneRouter} from '../../components'
@@ -718,21 +713,9 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
     return undefined
   }, [paramPath, ready])
 
-  const divergencesContext = useContext(DocumentDivergencesContext)
-
-  // If `DocumentPaneProvider` is rendered as a descendant of another
-  // instance of `DivergencesProvider`, inherit its enabled state,
-  // rather than overriding it.
-  //
-  // This allows `DocumentPaneProvider` to appear as a descendant of
-  // `DivergencesProvider` with `enabled` explicitly set to `false`,
-  // without that explicit opt-out being overridden by the workspace's
-  // `advancedVersionControl.enabled` configuration.
-  const divergencesContextEnabled = divergencesContext?.enabled ?? advancedVersionControlEnabled
-
   // Disable when `formState` or `schemaType` is transiently absent
   // (e.g. a `hidden` callback returns true, or the schema is still loading).
-  const isDivergencesEnabled = Boolean(divergencesContextEnabled && formState && schemaType)
+  const isDivergencesEnabled = advancedVersionControlEnabled && Boolean(formState && schemaType)
 
   const divergencesProps: ComponentProps<typeof DivergencesProvider> =
     isDivergencesEnabled && formState && schemaType

--- a/packages/sanity/src/structure/panes/document/documentInspector/DocumentInspectorPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentInspector/DocumentInspectorPanel.tsx
@@ -1,6 +1,6 @@
 import {Box} from '@sanity/ui'
 import {useCallback} from 'react'
-import {DivergencesProvider, Resizable} from 'sanity'
+import {Resizable} from 'sanity'
 
 import {usePane} from '../../../components'
 import {useStructureTool} from '../../../useStructureTool'
@@ -28,18 +28,8 @@ export function DocumentInspectorPanel(
   if (collapsed || !inspector) return null
 
   const Component = inspector.component
-
-  // No document/form shown in an inspector (e.g. a task, or AI assist
-  // instruction) is expected to support divergences itself. Therefore,
-  // divergences are switched off for the entire inspector subtree, regardless
-  // of whether the workspace has switched them on.
-  //
-  // This prevents redundant form gutters being rendered in the already
-  // limited space available to inspectors.
   const element = (
-    <DivergencesProvider enabled={false}>
-      <Component onClose={handleClose} documentId={documentId} documentType={documentType} />
-    </DivergencesProvider>
+    <Component onClose={handleClose} documentId={documentId} documentType={documentType} />
   )
 
   if (features.resizablePanes) {

--- a/packages/sanity/test/testUtils/DivergencesTestProvider.tsx
+++ b/packages/sanity/test/testUtils/DivergencesTestProvider.tsx
@@ -1,7 +1,0 @@
-import {type ComponentType, type PropsWithChildren} from 'react'
-
-import {DivergencesProvider} from '../../src/core/form/contexts/DivergencesProvider'
-
-export const DivergencesTestProvider: ComponentType<PropsWithChildren> = ({children}) => {
-  return <DivergencesProvider enabled={false}>{children}</DivergencesProvider>
-}

--- a/packages/sanity/test/testUtils/TestProvider.tsx
+++ b/packages/sanity/test/testUtils/TestProvider.tsx
@@ -26,7 +26,6 @@ import {SourceProvider} from '../../src/core/studio/source'
 import {WorkspaceProvider} from '../../src/core/studio/workspace'
 import {route, RouterProvider} from '../../src/router'
 import {type Panes} from '../../src/structure/structureResolvers'
-import {DivergencesTestProvider} from './DivergencesTestProvider'
 import {getMockWorkspace} from './getMockWorkspaceFromConfig'
 
 // Mock the useUpsellData hook to prevent API calls in tests
@@ -109,9 +108,7 @@ export async function createTestProvider({
                             <AddonDatasetContext.Provider value={addonDatasetContextValue}>
                               <PerspectiveContext.Provider value={perspectiveContextValueMock}>
                                 <DocumentLimitUpsellProvider>
-                                  <AssetLimitUpsellProvider>
-                                    <DivergencesTestProvider>{children}</DivergencesTestProvider>
-                                  </AssetLimitUpsellProvider>
+                                  <AssetLimitUpsellProvider>{children}</AssetLimitUpsellProvider>
                                 </DocumentLimitUpsellProvider>
                               </PerspectiveContext.Provider>
                             </AddonDatasetContext.Provider>


### PR DESCRIPTION
### Description

`DocumentDivergencesContext` consumers no longer throw an error if the context is absent. This prevents errors occurring when a `FormBuilder` is rendered outside the document pane component tree (e.g. in a plugin). In this scenario, forms are now gracefully rendered with divergences switched off.

This change allows us to simplify our previous implementation. Instead of needing to explicitly switch off divergences in places like the task editor, these components are implicitly opted out, because they render their own `FormBuilder` *outside of the document pane's context*.

### What to review

The context changes.

### Testing

- Divergences can be switched on and off in the main document editor as expected.
- Divergences are never switched on in the inspector pane, or for forms it renders, such as the task editor.
- Plugins that render `FormBuilder` no longer fail. [You can test it here](https://test-studio-dgwqe37v7.sanity.dev/test/form-builder-repro).

### Notes for release

- Fixes "useDocumentDivergences must be used within a DocumentDivergencesContext" error in third-party code that renders the `FormBuilder` component.