### PR TITLE
fix(core): arrays previews to include the first item 

### DIFF
--- a/dev/test-studio/schema/standard/arrays.tsx
+++ b/dev/test-studio/schema/standard/arrays.tsx
@@ -763,12 +763,14 @@ export default defineType({
       title: 'title',
       strings: 'arrayOfStrings',
       firstItem: 'arrayOfStrings.0',
+      length: 'arrayOfStrings.length',
     },
-    prepare({title, strings, firstItem}) {
+    prepare({title, strings, firstItem, length}) {
       // oxlint-disable-next-line no-console
       console.log('arraysTest preview.prepare', {
         strings,
         firstItem,
+        length,
       })
       return {title}
     },

--- a/dev/test-studio/schema/standard/arrays.tsx
+++ b/dev/test-studio/schema/standard/arrays.tsx
@@ -758,4 +758,19 @@ export default defineType({
       type: 'deepNested.body',
     }),
   ],
+  preview: {
+    select: {
+      title: 'title',
+      strings: 'arrayOfStrings',
+      firstItem: 'arrayOfStrings.0',
+    },
+    prepare({title, strings, firstItem}) {
+      // oxlint-disable-next-line no-console
+      console.log('arraysTest preview.prepare', {
+        strings,
+        firstItem,
+      })
+      return {title}
+    },
+  },
 })

--- a/packages/sanity/src/core/preview/__test__/createPathObserver.test.ts
+++ b/packages/sanity/src/core/preview/__test__/createPathObserver.test.ts
@@ -189,6 +189,37 @@ describe('createPathObserver', () => {
     })
   })
 
+  describe('primitive arrays in preview paths', () => {
+    it('resolves numeric segments and length on string arrays without wiping index 0', () => {
+      const observeFields = vi.fn()
+      const observePaths = createPathObserver({observeFields})
+
+      const {values, unsubscribe} = collectEmissions(
+        observePaths(
+          {
+            _id: 'drafts.issue5378',
+            _type: 'issue5378PreviewStringArray',
+            // @ts-expect-error -  type of Previewable is incorrect.
+            names: ['first', 'second'],
+          },
+          ['names', 'names.0', 'names.length'],
+        ),
+      )
+
+      expect(observeFields).not.toHaveBeenCalled()
+      expect(values).toHaveLength(1)
+      expect(values[0]).toMatchObject({
+        names: {
+          '0': 'first',
+          '1': 'second',
+          'length': 2,
+        },
+      })
+
+      unsubscribe()
+    })
+  })
+
   describe('integration: query count with real observeFields pipeline', () => {
     beforeEach(() => {
       vi.useFakeTimers()

--- a/packages/sanity/src/core/preview/createPathObserver.ts
+++ b/packages/sanity/src/core/preview/createPathObserver.ts
@@ -105,7 +105,10 @@ function observePaths(
   const next = Object.keys(leads).reduce((res: Record<string, unknown>, head) => {
     const tails = leads[head].filter((tail) => tail.length > 0)
     if (tails.length === 0) {
-      res[head] = isRecord(value) ? (value as Record<string, unknown>)[head] : undefined
+      res[head] =
+        isRecord(value) || Array.isArray(value)
+          ? (value as Record<string, unknown>)[head]
+          : undefined
     } else {
       res[head] = observePaths((value as any)[head], tails, observeFields, apiConfig, perspective)
     }


### PR DESCRIPTION
### Description
Fixes https://github.com/sanity-io/sanity/issues/5378
To repro see [this deploy preview](https://test-studio-ireqotavz.sanity.dev/test/structure/input-standard;arraysTest;9131a5ba-ffc7-4551-a045-a61e9388ba26), open the console and see the values printed. 

We are trying to access the first value of the array, but it's returning undefined due to the incorrect spreading .
<img width="569" height="217" alt="Screenshot 2026-05-18 at 14 44 02" src="https://github.com/user-attachments/assets/c123ee6f-2137-4fe9-a574-d5a8530f0ea9" />

<img width="420" height="118" alt="Screenshot 2026-05-18 at 14 44 05" src="https://github.com/user-attachments/assets/22870c49-174e-4934-b25b-d74b1b2fa591" />


After the changes, the value is correctly returned.
<img width="467" height="117" alt="Screenshot 2026-05-18 at 14 44 52" src="https://github.com/user-attachments/assets/fc3f293b-3013-4cdd-89a7-787ecc459d20" />

This PR fixes preview observation for `preview.select` paths that traverse primitive arrays (for example `tags.0`, `tags.length`) together with the parent field (`tags`).

`observePaths` rebuilt array subtrees by spreading the array into a plain object, then re-read leaf segments with `isRecord(value)`. Arrays are not “records” in that helper, so indices like `'0'` and `'length'` became `undefined` and overwrote the spread values. The observable snapshot could end up shaped like `{ "1": "second" }` with the first element missing, matching [Issue #5378](https://github.com/sanity-io/sanity/issues/5378).

Leaf reads now treat arrays like plain objects for indexed access (`isRecord(value) || Array.isArray(value)`), so numeric segments and `length` resolve correctly.

**Test studio:** `arraysTest` includes a small preview on the existing `arrayOfStrings` field that logs `strings` and `firstItem` (`arrayOfStrings.0`) so this regression can be checked manually in `pnpm dev`.



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review



<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
- Manual: [visit preview](https://test-studio-git-fix-gh-5378.sanity.dev/test/structure/input-standard;arraysTest;9131a5ba-ffc7-4551-a045-a61e9388ba26)  → **Arrays test** → add entries under **array of strings** → confirm document list / pane preview and console: **`strings`** retains index `0` and **`firstItem`** matches the first string.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Document / list previews that use preview.select with arrays of primitives and dotted paths (e.g. names.0, names.length) now receive the correct values instead of dropping the first element or mis-shaping the array.

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
