### PR TITLE
feat(core): Setting up variants tool

### DIFF
--- a/packages/sanity/src/core/variants/__fixtures__/createMockVariant.ts
+++ b/packages/sanity/src/core/variants/__fixtures__/createMockVariant.ts
@@ -1,0 +1,16 @@
+import {type SystemVariant} from '../types'
+
+/**
+ * @internal
+ */
+export function createMockVariant(id: string, priority = 0): SystemVariant {
+  return {
+    _id: `_.variants.${id}`,
+    _type: 'system.variant',
+    _createdAt: `2025-01-0${(priority % 9) + 1}T00:00:00Z`,
+    _updatedAt: `2025-01-0${(priority % 9) + 1}T00:00:00Z`,
+    _rev: `rev-${id}`,
+    conditions: {audience: id},
+    priority,
+  }
+}

--- a/packages/sanity/src/core/variants/__fixtures__/variants.fixture.ts
+++ b/packages/sanity/src/core/variants/__fixtures__/variants.fixture.ts
@@ -1,8 +1,22 @@
-import {createVariant} from '../store/__tests__/testUtils'
+import {type PortableTextBlock} from '@sanity/types'
+
 import {type SystemVariant} from '../types'
+import {createMockVariant} from './createMockVariant'
+
+function createDescription(text: string): PortableTextBlock[] {
+  return [
+    {
+      _key: 'description',
+      _type: 'block',
+      children: [{_key: 'span', _type: 'span', marks: [], text}],
+      markDefs: [],
+      style: 'normal',
+    },
+  ]
+}
 
 export const variantAlphaAudience: SystemVariant = {
-  ...createVariant('alpha-audience', 2),
+  ...createMockVariant('alpha-audience', 2),
   conditions: {audience: 'alpha', locale: 'en-US'},
   metadata: {
     title: 'Alpha audience',
@@ -11,7 +25,7 @@ export const variantAlphaAudience: SystemVariant = {
 }
 
 export const variantNorwegianMarket: SystemVariant = {
-  ...createVariant('norwegian-market', 1),
+  ...createMockVariant('norwegian-market', 1),
   conditions: {locale: 'nb-NO', market: 'nordics'},
   metadata: {
     title: 'Norwegian market',

--- a/packages/sanity/src/core/variants/__fixtures__/variants.fixture.ts
+++ b/packages/sanity/src/core/variants/__fixtures__/variants.fixture.ts
@@ -1,0 +1,20 @@
+import {createVariant} from '../store/__tests__/testUtils'
+import {type SystemVariant} from '../types'
+
+export const variantAlphaAudience: SystemVariant = {
+  ...createVariant('alpha-audience', 2),
+  conditions: {audience: 'alpha', locale: 'en-US'},
+  metadata: {
+    title: 'Alpha audience',
+    description: [],
+  },
+}
+
+export const variantNorwegianMarket: SystemVariant = {
+  ...createVariant('norwegian-market', 1),
+  conditions: {locale: 'nb-NO', market: 'nordics'},
+  metadata: {
+    title: 'Norwegian market',
+    description: [],
+  },
+}

--- a/packages/sanity/src/core/variants/__fixtures__/variants.fixture.ts
+++ b/packages/sanity/src/core/variants/__fixtures__/variants.fixture.ts
@@ -1,19 +1,5 @@
-import {type PortableTextBlock} from '@sanity/types'
-
 import {type SystemVariant} from '../types'
 import {createMockVariant} from './createMockVariant'
-
-function createDescription(text: string): PortableTextBlock[] {
-  return [
-    {
-      _key: 'description',
-      _type: 'block',
-      children: [{_key: 'span', _type: 'span', marks: [], text}],
-      markDefs: [],
-      style: 'normal',
-    },
-  ]
-}
 
 export const variantAlphaAudience: SystemVariant = {
   ...createMockVariant('alpha-audience', 2),

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -8,6 +8,42 @@ const variantsLocaleStrings = {
   'navbar.view-as': 'View as',
   /** Label for the version selector in the variants navigation row. */
   'navbar.version': 'Version',
+  /** Label for the Variants overview create action. */
+  'overview.action.create-variant': 'Create variant',
+  /** Label for the Variants overview delete action. */
+  'overview.action.delete-variant': 'Delete variant',
+  /** Link label for Variants overview documentation (empty state). */
+  'overview.action.documentation': 'Documentation',
+  /** Description for the Variants overview empty state. */
+  'overview.empty-state.description':
+    'Variant definitions describe how content is personalized for audiences, locales, segments, and more.',
+  /** Description for the Variants overview. */
+  'overview.description':
+    'Manage variant definitions that control how content is personalized for different audiences, locales, and segments.',
+  /** Error message for the Variants overview. */
+  'overview.error': 'Unable to load variants',
+  /** Placeholder for the Variants overview search field. */
+  'overview.search.placeholder': 'Search variant definitions…',
+  /** Column header for the variant title column in the overview table. */
+  'overview.table.variant': 'Variant',
+  /** Column header for document count in the overview table. */
+  'overview.table.documents': 'Documents',
+  /** Fallback text when a variant has no conditions. */
+  'overview.table.no-conditions': 'No conditions',
+  /** Title for the Variants overview. */
+  'overview.title': 'Variants',
+  /** Back action on the Variant detail page. */
+  'detail.back': 'Back to variants',
+  /** Loading message on the Variant detail page. */
+  'detail.loading': 'Loading variant',
+  /** Fallback text when a variant has no description. */
+  'detail.no-description': 'No description yet.',
+  /** Description for the missing Variant detail page. */
+  'detail.not-found.description': 'The requested variant could not be found.',
+  /** Title for the missing Variant detail page. */
+  'detail.not-found.title': 'Variant not found',
+  /** Placeholder text on the Variant detail page. */
+  'detail.placeholder': 'Variant detail editing will be added in a future iteration.',
 }
 
 /**

--- a/packages/sanity/src/core/variants/plugin/index.tsx
+++ b/packages/sanity/src/core/variants/plugin/index.tsx
@@ -1,10 +1,19 @@
+import {route} from 'sanity/router'
+
 import {definePlugin} from '../../config/definePlugin'
 import {variantsUsEnglishLocaleBundle} from '../i18n'
+import {VariantsTool} from '../tool/VariantsTool'
 import {VariantsStudioNavbar} from './components/VariantsStudioNavbar'
+
 /**
  * @internal
  */
 export const VARIANTS_NAME = 'sanity/variants'
+
+/**
+ * @internal
+ */
+export const VARIANTS_TOOL_NAME = 'variants'
 
 /**
  * @internal
@@ -16,6 +25,15 @@ export const variants = definePlugin({
       navbar: VariantsStudioNavbar,
     },
   },
+  tools: [
+    {
+      name: VARIANTS_TOOL_NAME,
+      title: 'Variants',
+      component: VariantsTool,
+      router: route.create('/', [route.create('/:variantId')]),
+      __internalApplicationType: VARIANTS_NAME,
+    },
+  ],
   i18n: {
     bundles: [variantsUsEnglishLocaleBundle],
   },

--- a/packages/sanity/src/core/variants/plugin/index.tsx
+++ b/packages/sanity/src/core/variants/plugin/index.tsx
@@ -10,10 +10,7 @@ import {VariantsStudioNavbar} from './components/VariantsStudioNavbar'
  */
 export const VARIANTS_NAME = 'sanity/variants'
 
-/**
- * @internal
- */
-export const VARIANTS_TOOL_NAME = 'variants'
+const VARIANTS_TOOL_NAME = 'variants'
 
 /**
  * @internal

--- a/packages/sanity/src/core/variants/store/__tests__/createVariantsStore.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/createVariantsStore.test.ts
@@ -2,8 +2,8 @@ import {type SanityClient} from '@sanity/client'
 import {filter, firstValueFrom, of, Subject, take, throwError, toArray} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
+import {createMockVariant} from '../../__fixtures__/createMockVariant'
 import {createVariantsStore} from '../createVariantsStore'
-import {createVariant} from './testUtils'
 
 function createMockClient() {
   const listener$ = new Subject<{
@@ -27,7 +27,7 @@ describe('createVariantsStore', () => {
   })
 
   it('loads variants from the variants system document path', async () => {
-    const variant = createVariant('a')
+    const variant = createMockVariant('a')
     const {client, fetch, listen, listener$} = createMockClient()
     fetch.mockReturnValue(of([variant]))
 
@@ -68,8 +68,8 @@ describe('createVariantsStore', () => {
   })
 
   it('keeps variants updated when the listener refetches', async () => {
-    const firstVariant = createVariant('a')
-    const updatedVariant = createVariant('b', 1)
+    const firstVariant = createMockVariant('a')
+    const updatedVariant = createMockVariant('b', 1)
     const {client, fetch, listener$} = createMockClient()
     fetch.mockReturnValueOnce(of([firstVariant])).mockReturnValueOnce(of([updatedVariant]))
 
@@ -88,8 +88,8 @@ describe('createVariantsStore', () => {
   })
 
   it('supports removing a variant through dispatch', async () => {
-    const variantA = createVariant('a')
-    const variantB = createVariant('b', 1)
+    const variantA = createMockVariant('a')
+    const variantB = createMockVariant('b', 1)
     const {client, fetch, listener$} = createMockClient()
     fetch.mockReturnValue(of([variantA, variantB]))
 

--- a/packages/sanity/src/core/variants/store/__tests__/reducer.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/reducer.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, it} from 'vitest'
 
+import {createMockVariant} from '../../__fixtures__/createMockVariant'
 import {variantStoreReducer, type VariantStoreState} from '../reducer'
-import {createVariant} from './testUtils'
 
 describe('variantStoreReducer', () => {
   const initialState: VariantStoreState = {
@@ -10,7 +10,7 @@ describe('variantStoreReducer', () => {
   }
 
   it('sets variants by id', () => {
-    const variants = [createVariant('a'), createVariant('b', 1)]
+    const variants = [createMockVariant('a'), createMockVariant('b', 1)]
     const state: VariantStoreState = {
       variants: new Map(),
       state: 'loading',
@@ -32,7 +32,7 @@ describe('variantStoreReducer', () => {
   })
 
   it('sets variants and marks the fetch as loaded when fetch succeeds', () => {
-    const variants = [createVariant('a'), createVariant('b', 1)]
+    const variants = [createMockVariant('a'), createMockVariant('b', 1)]
     const error = new Error('Previous failure')
     const state: VariantStoreState = {
       variants: new Map(),
@@ -55,7 +55,7 @@ describe('variantStoreReducer', () => {
   })
 
   it('clears variants when the payload is null', () => {
-    const variant = createVariant('a')
+    const variant = createMockVariant('a')
     const state: VariantStoreState = {
       variants: new Map([[variant._id, variant]]),
       state: 'loaded',
@@ -71,8 +71,8 @@ describe('variantStoreReducer', () => {
   })
 
   it('removes a deleted variant without mutating the previous state', () => {
-    const variantA = createVariant('a')
-    const variantB = createVariant('b', 1)
+    const variantA = createMockVariant('a')
+    const variantB = createMockVariant('b', 1)
     const state: VariantStoreState = {
       variants: new Map([
         [variantA._id, variantA],

--- a/packages/sanity/src/core/variants/store/__tests__/testUtils.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/testUtils.ts
@@ -1,13 +1,1 @@
-import {type SystemVariant} from '../../types'
-
-export function createVariant(id: string, priority = 0): SystemVariant {
-  return {
-    _id: `_.variants.${id}`,
-    _type: 'system.variant',
-    _createdAt: `2025-01-0${priority + 1}T00:00:00Z`,
-    _updatedAt: `2025-01-0${priority + 1}T00:00:00Z`,
-    _rev: `rev-${id}`,
-    conditions: {audience: id},
-    priority,
-  }
-}
+export {createMockVariant as createVariant} from '../../__fixtures__/createMockVariant'

--- a/packages/sanity/src/core/variants/store/__tests__/testUtils.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/testUtils.ts
@@ -1,1 +1,0 @@
-export {createMockVariant as createVariant} from '../../__fixtures__/createMockVariant'

--- a/packages/sanity/src/core/variants/store/__tests__/useAllVariants.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/useAllVariants.test.ts
@@ -2,9 +2,9 @@ import {act, renderHook, waitFor} from '@testing-library/react'
 import {BehaviorSubject} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
+import {createMockVariant} from '../../__fixtures__/createMockVariant'
 import {type VariantStoreState} from '../reducer'
 import {useAllVariants} from '../useAllVariants'
-import {createVariant} from './testUtils'
 
 const initialState: VariantStoreState = {
   variants: new Map(),
@@ -39,8 +39,8 @@ describe('useAllVariants', () => {
   })
 
   it('returns variants from the store state', async () => {
-    const variantA = createVariant('a')
-    const variantB = createVariant('b', 1)
+    const variantA = createMockVariant('a')
+    const variantB = createMockVariant('b', 1)
 
     const {result} = renderHook(() => useAllVariants())
 

--- a/packages/sanity/src/core/variants/store/__tests__/useAllVariants.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/useAllVariants.test.ts
@@ -33,6 +33,7 @@ describe('useAllVariants', () => {
     expect(result.current).toEqual({
       loading: true,
       data: [],
+      byId: new Map(),
       error: undefined,
     })
   })
@@ -57,6 +58,10 @@ describe('useAllVariants', () => {
       expect(result.current).toEqual({
         loading: false,
         data: [variantA, variantB],
+        byId: new Map([
+          [variantA._id, variantA],
+          [variantB._id, variantB],
+        ]),
         error: undefined,
       })
     })
@@ -79,6 +84,7 @@ describe('useAllVariants', () => {
       expect(result.current).toEqual({
         loading: false,
         data: [],
+        byId: new Map(),
         error,
       })
     })

--- a/packages/sanity/src/core/variants/store/useAllVariants.ts
+++ b/packages/sanity/src/core/variants/store/useAllVariants.ts
@@ -10,6 +10,7 @@ import {useVariantsStore} from './useVariantsStore'
  */
 export function useAllVariants(): {
   data: SystemVariant[]
+  byId: Map<string, SystemVariant>
   error?: Error
   loading: boolean
 } {
@@ -19,6 +20,7 @@ export function useAllVariants(): {
   return useMemo(
     () => ({
       data: Array.from(variants.values()),
+      byId: variants,
       error: error,
       loading: ['loading', 'initialising'].includes(state),
     }),

--- a/packages/sanity/src/core/variants/tool/VariantsTool.tsx
+++ b/packages/sanity/src/core/variants/tool/VariantsTool.tsx
@@ -1,0 +1,15 @@
+import {useRouter} from 'sanity/router'
+
+import {VariantDetail} from './detail/VariantDetail'
+import {VariantsOverview} from './overview/VariantsOverview'
+
+export function VariantsTool() {
+  const router = useRouter()
+  const variantId = typeof router.state.variantId === 'string' ? router.state.variantId : undefined
+
+  if (variantId) {
+    return <VariantDetail key={variantId} />
+  }
+
+  return <VariantsOverview />
+}

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -1,0 +1,113 @@
+import {render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {flushMicrotasksThisIsACodeSmell} from '../../../../../test/testUtils/flushMicrotasks'
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {variantAlphaAudience} from '../../__fixtures__/variants.fixture'
+import {variantsUsEnglishLocaleBundle} from '../../i18n'
+import {type SystemVariant} from '../../types'
+import {VariantDetail} from '../detail/VariantDetail'
+
+const mockNavigate = vi.fn()
+
+const routerState = vi.hoisted(() => ({
+  variantId: undefined as string | undefined,
+}))
+
+const variantsMock = vi.hoisted(() => ({
+  data: [] as SystemVariant[],
+  loading: false,
+  error: undefined as Error | undefined,
+}))
+
+vi.mock('sanity/router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRouter: vi.fn(() => ({
+    state: routerState,
+    navigate: mockNavigate,
+    resolveIntentLink: vi.fn(),
+  })),
+}))
+
+vi.mock('../../store/useAllVariants', () => ({
+  useAllVariants: vi.fn(() => ({
+    data: variantsMock.data,
+    loading: variantsMock.loading,
+    error: variantsMock.error,
+  })),
+}))
+
+describe('VariantDetail', () => {
+  beforeEach(() => {
+    variantsMock.data = []
+    variantsMock.loading = false
+    variantsMock.error = undefined
+    routerState.variantId = undefined
+    mockNavigate.mockClear()
+  })
+
+  const renderDetail = async () => {
+    const wrapper = await createTestProvider({
+      resources: [variantsUsEnglishLocaleBundle],
+    })
+    const result = render(<VariantDetail />, {wrapper})
+    await flushMicrotasksThisIsACodeSmell()
+    return result
+  }
+
+  it('shows loading state while variants are loading', async () => {
+    routerState.variantId = encodeURIComponent(variantAlphaAudience._id)
+    variantsMock.loading = true
+
+    await renderDetail()
+
+    expect(screen.getByTestId('loading-block')).toBeInTheDocument()
+  })
+
+  it('renders title, description fallback, and placeholder when variant exists', async () => {
+    routerState.variantId = encodeURIComponent(variantAlphaAudience._id)
+    variantsMock.data = [variantAlphaAudience]
+
+    await renderDetail()
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', {level: 1, name: 'Alpha audience'})).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('No description yet.')).toBeInTheDocument()
+    expect(
+      screen.getByText('Variant detail editing will be added in a future iteration.'),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', {name: 'Back to variants'})).toBeInTheDocument()
+  })
+
+  it('shows not found when variant id does not match any document', async () => {
+    routerState.variantId = encodeURIComponent('_.variants.missing')
+    variantsMock.data = [variantAlphaAudience]
+
+    await renderDetail()
+
+    await waitFor(() => {
+      expect(screen.getByText('Variant not found')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('The requested variant could not be found.')).toBeInTheDocument()
+  })
+
+  it('navigates back to overview when Back is pressed', async () => {
+    routerState.variantId = encodeURIComponent('_.variants.missing')
+    variantsMock.data = []
+    const user = userEvent.setup()
+
+    await renderDetail()
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', {name: 'Back to variants'})).toBeEnabled(),
+    )
+
+    await user.click(screen.getByRole('button', {name: 'Back to variants'}))
+
+    expect(mockNavigate).toHaveBeenCalledWith({})
+  })
+})

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -8,6 +8,7 @@ import {variantAlphaAudience} from '../../__fixtures__/variants.fixture'
 import {variantsUsEnglishLocaleBundle} from '../../i18n'
 import {type SystemVariant} from '../../types'
 import {VariantDetail} from '../detail/VariantDetail'
+import {getVariantId} from '../util'
 
 const mockNavigate = vi.fn()
 
@@ -17,6 +18,7 @@ const routerState = vi.hoisted(() => ({
 
 const variantsMock = vi.hoisted(() => ({
   data: [] as SystemVariant[],
+  byId: new Map<string, SystemVariant>(),
   loading: false,
   error: undefined as Error | undefined,
 }))
@@ -33,6 +35,7 @@ vi.mock('sanity/router', async (importOriginal) => ({
 vi.mock('../../store/useAllVariants', () => ({
   useAllVariants: vi.fn(() => ({
     data: variantsMock.data,
+    byId: variantsMock.byId,
     loading: variantsMock.loading,
     error: variantsMock.error,
   })),
@@ -41,11 +44,17 @@ vi.mock('../../store/useAllVariants', () => ({
 describe('VariantDetail', () => {
   beforeEach(() => {
     variantsMock.data = []
+    variantsMock.byId = new Map()
     variantsMock.loading = false
     variantsMock.error = undefined
     routerState.variantId = undefined
     mockNavigate.mockClear()
   })
+
+  const setVariants = (variants: SystemVariant[]) => {
+    variantsMock.data = variants
+    variantsMock.byId = new Map(variants.map((variant) => [variant._id, variant]))
+  }
 
   const renderDetail = async () => {
     const wrapper = await createTestProvider({
@@ -57,7 +66,7 @@ describe('VariantDetail', () => {
   }
 
   it('shows loading state while variants are loading', async () => {
-    routerState.variantId = encodeURIComponent(variantAlphaAudience._id)
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
     variantsMock.loading = true
 
     await renderDetail()
@@ -66,8 +75,8 @@ describe('VariantDetail', () => {
   })
 
   it('renders title, description fallback, and placeholder when variant exists', async () => {
-    routerState.variantId = encodeURIComponent(variantAlphaAudience._id)
-    variantsMock.data = [variantAlphaAudience]
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
+    setVariants([variantAlphaAudience])
 
     await renderDetail()
 
@@ -83,8 +92,8 @@ describe('VariantDetail', () => {
   })
 
   it('shows not found when variant id does not match any document', async () => {
-    routerState.variantId = encodeURIComponent('_.variants.missing')
-    variantsMock.data = [variantAlphaAudience]
+    routerState.variantId = getVariantId('_.variants.missing')
+    setVariants([variantAlphaAudience])
 
     await renderDetail()
 
@@ -96,8 +105,8 @@ describe('VariantDetail', () => {
   })
 
   it('navigates back to overview when Back is pressed', async () => {
-    routerState.variantId = encodeURIComponent('_.variants.missing')
-    variantsMock.data = []
+    routerState.variantId = getVariantId('_.variants.missing')
+    setVariants([])
     const user = userEvent.setup()
 
     await renderDetail()

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -1,5 +1,6 @@
 import {render, screen, waitFor, within} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
+import {type Ref, forwardRef, type HTMLProps} from 'react'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {flushMicrotasksThisIsACodeSmell} from '../../../../../test/testUtils/flushMicrotasks'
@@ -9,6 +10,7 @@ import {variantAlphaAudience, variantNorwegianMarket} from '../../__fixtures__/v
 import {variantsUsEnglishLocaleBundle} from '../../i18n'
 import {type SystemVariant} from '../../types'
 import {VariantsOverview} from '../overview/VariantsOverview'
+import {getVariantId} from '../util'
 
 const mockNavigate = vi.fn()
 
@@ -18,6 +20,7 @@ const routerState = vi.hoisted(() => ({
 
 const variantsMock = vi.hoisted(() => ({
   data: [] as SystemVariant[],
+  byId: new Map<string, SystemVariant>(),
   loading: false,
   error: undefined as Error | undefined,
 }))
@@ -28,12 +31,33 @@ vi.mock('sanity/router', async (importOriginal) => ({
     state: routerState,
     navigate: mockNavigate,
     resolveIntentLink: vi.fn(),
+    resolvePathFromState: vi.fn(({variantId}: {variantId?: string}) =>
+      variantId ? `/variants/${variantId}` : '/variants',
+    ),
   })),
+  StateLink: forwardRef(function MockStateLink(
+    {state, ...rest}: {state?: {variantId?: string}} & HTMLProps<HTMLAnchorElement>,
+    ref,
+  ) {
+    return (
+      // oxlint-disable-next-line jsx_a11y/anchor-has-content
+      <a
+        {...rest}
+        ref={ref as Ref<HTMLAnchorElement>}
+        href={state?.variantId ? `/variants/${state.variantId}` : '/variants'}
+        onClick={(event) => {
+          event.preventDefault()
+          mockNavigate(state)
+        }}
+      />
+    )
+  }),
 }))
 
 vi.mock('../../store/useAllVariants', () => ({
   useAllVariants: vi.fn(() => ({
     data: variantsMock.data,
+    byId: variantsMock.byId,
     loading: variantsMock.loading,
     error: variantsMock.error,
   })),
@@ -44,6 +68,7 @@ setupVirtualListEnv()
 describe('VariantsOverview', () => {
   beforeEach(() => {
     variantsMock.data = []
+    variantsMock.byId = new Map()
     variantsMock.loading = false
     variantsMock.error = undefined
     routerState.variantId = undefined
@@ -63,8 +88,13 @@ describe('VariantsOverview', () => {
     return result
   }
 
+  const setVariants = (variants: SystemVariant[]) => {
+    variantsMock.data = variants
+    variantsMock.byId = new Map(variants.map((variant) => [variant._id, variant]))
+  }
+
   it('renders title, description, create action, and search', async () => {
-    variantsMock.data = [variantAlphaAudience]
+    setVariants([variantAlphaAudience])
 
     await renderOverview()
 
@@ -79,7 +109,7 @@ describe('VariantsOverview', () => {
   })
 
   it('lists variants in the virtualized table', async () => {
-    variantsMock.data = [variantAlphaAudience, variantNorwegianMarket]
+    setVariants([variantAlphaAudience, variantNorwegianMarket])
 
     await renderOverview()
 
@@ -93,7 +123,7 @@ describe('VariantsOverview', () => {
   })
 
   it('filters variants when searching by title or condition', async () => {
-    variantsMock.data = [variantAlphaAudience, variantNorwegianMarket]
+    setVariants([variantAlphaAudience, variantNorwegianMarket])
     const user = userEvent.setup()
 
     await renderOverview()
@@ -121,7 +151,7 @@ describe('VariantsOverview', () => {
   })
 
   it('navigates to variant detail when a row title is activated', async () => {
-    variantsMock.data = [variantAlphaAudience]
+    setVariants([variantAlphaAudience])
     const user = userEvent.setup()
 
     await renderOverview()
@@ -131,7 +161,7 @@ describe('VariantsOverview', () => {
     await user.click(screen.getByText('Alpha audience'))
 
     expect(mockNavigate).toHaveBeenCalledWith({
-      variantId: encodeURIComponent(variantAlphaAudience._id),
+      variantId: getVariantId(variantAlphaAudience._id),
     })
   })
 

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -1,0 +1,179 @@
+import {render, screen, waitFor, within} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {flushMicrotasksThisIsACodeSmell} from '../../../../../test/testUtils/flushMicrotasks'
+import {setupVirtualListEnv} from '../../../../../test/testUtils/setupVirtualListEnv'
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {variantAlphaAudience, variantNorwegianMarket} from '../../__fixtures__/variants.fixture'
+import {variantsUsEnglishLocaleBundle} from '../../i18n'
+import {type SystemVariant} from '../../types'
+import {VariantsOverview} from '../overview/VariantsOverview'
+
+const mockNavigate = vi.fn()
+
+const routerState = vi.hoisted(() => ({
+  variantId: undefined as string | undefined,
+}))
+
+const variantsMock = vi.hoisted(() => ({
+  data: [] as SystemVariant[],
+  loading: false,
+  error: undefined as Error | undefined,
+}))
+
+vi.mock('sanity/router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRouter: vi.fn(() => ({
+    state: routerState,
+    navigate: mockNavigate,
+    resolveIntentLink: vi.fn(),
+  })),
+}))
+
+vi.mock('../../store/useAllVariants', () => ({
+  useAllVariants: vi.fn(() => ({
+    data: variantsMock.data,
+    loading: variantsMock.loading,
+    error: variantsMock.error,
+  })),
+}))
+
+setupVirtualListEnv()
+
+describe('VariantsOverview', () => {
+  beforeEach(() => {
+    variantsMock.data = []
+    variantsMock.loading = false
+    variantsMock.error = undefined
+    routerState.variantId = undefined
+    mockNavigate.mockClear()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const renderOverview = async () => {
+    const wrapper = await createTestProvider({
+      resources: [variantsUsEnglishLocaleBundle],
+    })
+    const result = render(<VariantsOverview />, {wrapper})
+    await flushMicrotasksThisIsACodeSmell()
+    return result
+  }
+
+  it('renders title, description, create action, and search', async () => {
+    variantsMock.data = [variantAlphaAudience]
+
+    await renderOverview()
+
+    expect(screen.getByRole('heading', {level: 1, name: 'Variants'})).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Manage variant definitions that control how content is personalized for different audiences, locales, and segments.',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', {name: 'Create variant'})).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Search variant definitions…')).toBeInTheDocument()
+  })
+
+  it('lists variants in the virtualized table', async () => {
+    variantsMock.data = [variantAlphaAudience, variantNorwegianMarket]
+
+    await renderOverview()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(2)
+    })
+
+    expect(screen.getByText('Alpha audience')).toBeInTheDocument()
+    expect(screen.getByText('Norwegian market')).toBeInTheDocument()
+    expect(screen.getAllByText('0')).toHaveLength(2)
+  })
+
+  it('filters variants when searching by title or condition', async () => {
+    variantsMock.data = [variantAlphaAudience, variantNorwegianMarket]
+    const user = userEvent.setup()
+
+    await renderOverview()
+
+    await waitFor(() => expect(screen.getAllByTestId('table-row')).toHaveLength(2))
+
+    const search = screen.getByPlaceholderText('Search variant definitions…')
+    await user.type(search, 'Norwegian')
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(1)
+    })
+
+    expect(screen.getByText('Norwegian market')).toBeInTheDocument()
+    expect(screen.queryByText('Alpha audience')).not.toBeInTheDocument()
+
+    await user.clear(search)
+    await user.type(search, 'nb-no')
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(1)
+    })
+
+    within(screen.getAllByTestId('table-row')[0]!).getByText('Norwegian market')
+  })
+
+  it('navigates to variant detail when a row title is activated', async () => {
+    variantsMock.data = [variantAlphaAudience]
+    const user = userEvent.setup()
+
+    await renderOverview()
+
+    await waitFor(() => expect(screen.getAllByTestId('table-row')).toHaveLength(1))
+
+    await user.click(screen.getByText('Alpha audience'))
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      variantId: encodeURIComponent(variantAlphaAudience._id),
+    })
+  })
+
+  it('shows empty state when there are no variants', async () => {
+    variantsMock.data = []
+
+    await renderOverview()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variants-empty-state')).toBeInTheDocument()
+    })
+
+    expect(screen.getByTestId('variant-illustration')).toBeInTheDocument()
+    expect(screen.getByTestId('no-variants-info-text')).toHaveTextContent('Variants')
+    const emptyState = screen.getByTestId('variants-empty-state')
+    expect(within(emptyState).getByRole('button', {name: 'Create variant'})).toBeInTheDocument()
+    expect(within(emptyState).getByRole('link', {name: 'Documentation'})).toHaveAttribute(
+      'href',
+      'https://www.sanity.io/docs/content-variants',
+    )
+  })
+
+  it('shows loading skeleton rows while variants are loading', async () => {
+    variantsMock.data = []
+    variantsMock.loading = true
+
+    await renderOverview()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row-skeleton')).toHaveLength(3)
+    })
+  })
+
+  it('shows error copy in the table empty state when load fails with no data', async () => {
+    variantsMock.data = []
+    variantsMock.loading = false
+    variantsMock.error = new Error('network')
+
+    await renderOverview()
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Unable to load variants').length).toBeGreaterThanOrEqual(1)
+    })
+  })
+})

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsTool.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsTool.test.tsx
@@ -1,4 +1,5 @@
 import {render, screen, waitFor} from '@testing-library/react'
+import {forwardRef, type HTMLProps} from 'react'
 import {describe, expect, it, vi} from 'vitest'
 
 import {flushMicrotasksThisIsACodeSmell} from '../../../../../test/testUtils/flushMicrotasks'
@@ -7,6 +8,7 @@ import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
 import {variantAlphaAudience} from '../../__fixtures__/variants.fixture'
 import {variantsUsEnglishLocaleBundle} from '../../i18n'
 import {type SystemVariant} from '../../types'
+import {getVariantId} from '../util'
 import {VariantsTool} from '../VariantsTool'
 
 const routerState = vi.hoisted(() => ({
@@ -15,6 +17,7 @@ const routerState = vi.hoisted(() => ({
 
 const variantsMock = vi.hoisted(() => ({
   data: [] as SystemVariant[],
+  byId: new Map<string, SystemVariant>(),
   loading: false,
   error: undefined as Error | undefined,
 }))
@@ -25,12 +28,28 @@ vi.mock('sanity/router', async (importOriginal) => ({
     state: routerState,
     navigate: vi.fn(),
     resolveIntentLink: vi.fn(),
+    resolvePathFromState: vi.fn(({variantId}: {variantId?: string}) =>
+      variantId ? `/variants/${variantId}` : '/variants',
+    ),
   })),
+  StateLink: forwardRef(function MockStateLink(
+    {state, ...rest}: {state?: {variantId?: string}} & HTMLProps<HTMLAnchorElement>,
+    ref,
+  ) {
+    return (
+      <a
+        {...rest}
+        ref={ref}
+        href={state?.variantId ? `/variants/${state.variantId}` : '/variants'}
+      />
+    )
+  }),
 }))
 
 vi.mock('../../store/useAllVariants', () => ({
   useAllVariants: vi.fn(() => ({
     data: variantsMock.data,
+    byId: variantsMock.byId,
     loading: variantsMock.loading,
     error: variantsMock.error,
   })),
@@ -51,6 +70,7 @@ describe('VariantsTool', () => {
   it('renders overview when router has no variantId', async () => {
     routerState.variantId = undefined
     variantsMock.data = [variantAlphaAudience]
+    variantsMock.byId = new Map([[variantAlphaAudience._id, variantAlphaAudience]])
     variantsMock.loading = false
 
     await renderTool()
@@ -61,8 +81,9 @@ describe('VariantsTool', () => {
   })
 
   it('renders detail when router state includes variantId', async () => {
-    routerState.variantId = encodeURIComponent(variantAlphaAudience._id)
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
     variantsMock.data = [variantAlphaAudience]
+    variantsMock.byId = new Map([[variantAlphaAudience._id, variantAlphaAudience]])
     variantsMock.loading = false
 
     await renderTool()

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsTool.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsTool.test.tsx
@@ -1,0 +1,76 @@
+import {render, screen, waitFor} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+
+import {flushMicrotasksThisIsACodeSmell} from '../../../../../test/testUtils/flushMicrotasks'
+import {setupVirtualListEnv} from '../../../../../test/testUtils/setupVirtualListEnv'
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {variantAlphaAudience} from '../../__fixtures__/variants.fixture'
+import {variantsUsEnglishLocaleBundle} from '../../i18n'
+import {type SystemVariant} from '../../types'
+import {VariantsTool} from '../VariantsTool'
+
+const routerState = vi.hoisted(() => ({
+  variantId: undefined as string | undefined,
+}))
+
+const variantsMock = vi.hoisted(() => ({
+  data: [] as SystemVariant[],
+  loading: false,
+  error: undefined as Error | undefined,
+}))
+
+vi.mock('sanity/router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRouter: vi.fn(() => ({
+    state: routerState,
+    navigate: vi.fn(),
+    resolveIntentLink: vi.fn(),
+  })),
+}))
+
+vi.mock('../../store/useAllVariants', () => ({
+  useAllVariants: vi.fn(() => ({
+    data: variantsMock.data,
+    loading: variantsMock.loading,
+    error: variantsMock.error,
+  })),
+}))
+
+setupVirtualListEnv()
+
+describe('VariantsTool', () => {
+  const renderTool = async () => {
+    const wrapper = await createTestProvider({
+      resources: [variantsUsEnglishLocaleBundle],
+    })
+    const result = render(<VariantsTool />, {wrapper})
+    await flushMicrotasksThisIsACodeSmell()
+    return result
+  }
+
+  it('renders overview when router has no variantId', async () => {
+    routerState.variantId = undefined
+    variantsMock.data = [variantAlphaAudience]
+    variantsMock.loading = false
+
+    await renderTool()
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', {level: 1, name: 'Variants'})).toBeInTheDocument()
+    })
+  })
+
+  it('renders detail when router state includes variantId', async () => {
+    routerState.variantId = encodeURIComponent(variantAlphaAudience._id)
+    variantsMock.data = [variantAlphaAudience]
+    variantsMock.loading = false
+
+    await renderTool()
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', {level: 1, name: 'Alpha audience'})).toBeInTheDocument()
+    })
+
+    expect(screen.queryByPlaceholderText('Search variant definitions…')).not.toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/core/variants/tool/__tests__/util.test.ts
+++ b/packages/sanity/src/core/variants/tool/__tests__/util.test.ts
@@ -1,0 +1,74 @@
+import {describe, expect, it} from 'vitest'
+
+import {createVariant} from '../../store/__tests__/testUtils'
+import {
+  filterVariantsForSearch,
+  getVariantConditionsText,
+  getVariantDescription,
+  getVariantId,
+  getVariantTitle,
+} from '../util'
+
+describe('variants tool utilities', () => {
+  it('derives a display id from a variant document id', () => {
+    expect(getVariantId('_.variants.audience-a')).toBe('audience-a')
+    expect(getVariantId('audience-a')).toBe('audience-a')
+  })
+
+  it('uses metadata title before falling back to the id suffix', () => {
+    const variant = createVariant('audience-a')
+
+    expect(getVariantTitle(variant)).toBe('audience-a')
+    expect(getVariantTitle({...variant, metadata: {title: 'Audience A', description: []}})).toBe(
+      'Audience A',
+    )
+  })
+
+  it('formats conditions as key value pairs', () => {
+    expect(getVariantConditionsText({audience: 'developer', locale: 'en'})).toBe(
+      'audience: developer, locale: en',
+    )
+  })
+
+  it('extracts plain text descriptions from portable text', () => {
+    const variant = createVariant('audience-a')
+
+    expect(
+      getVariantDescription({
+        ...variant,
+        metadata: {
+          description: [
+            {
+              _key: 'block-1',
+              _type: 'block',
+              children: [{_key: 'span-1', _type: 'span', marks: [], text: 'Developer audience'}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      }),
+    ).toBe('Developer audience')
+  })
+
+  it('filters variants by title and condition keys or values', () => {
+    const developerVariant = {
+      ...createVariant('developer'),
+      metadata: {title: 'Developer audience', description: []},
+    }
+    const localeVariant = {
+      ...createVariant('norwegian', 1),
+      conditions: {locale: 'nb-NO'},
+    }
+
+    expect(filterVariantsForSearch([developerVariant, localeVariant], 'developer')).toEqual([
+      developerVariant,
+    ])
+    expect(filterVariantsForSearch([developerVariant, localeVariant], 'locale')).toEqual([
+      localeVariant,
+    ])
+    expect(filterVariantsForSearch([developerVariant, localeVariant], 'nb-no')).toEqual([
+      localeVariant,
+    ])
+  })
+})

--- a/packages/sanity/src/core/variants/tool/__tests__/util.test.ts
+++ b/packages/sanity/src/core/variants/tool/__tests__/util.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest'
 
-import {createVariant} from '../../store/__tests__/testUtils'
+import {createMockVariant} from '../../__fixtures__/createMockVariant'
 import {
   decodeVariantIdFromRoute,
   filterVariantsForSearch,
@@ -17,7 +17,7 @@ describe('variants tool utilities', () => {
   })
 
   it('uses metadata title before falling back to the id suffix', () => {
-    const variant = createVariant('audience-a')
+    const variant = createMockVariant('audience-a')
 
     expect(getVariantTitle(variant)).toBe('audience-a')
     expect(getVariantTitle({...variant, metadata: {title: 'Audience A', description: []}})).toBe(
@@ -43,7 +43,7 @@ describe('variants tool utilities', () => {
   })
 
   it('extracts plain text descriptions from portable text', () => {
-    const variant = createVariant('audience-a')
+    const variant = createMockVariant('audience-a')
 
     expect(
       getVariantDescription({
@@ -65,11 +65,11 @@ describe('variants tool utilities', () => {
 
   it('filters variants by title and condition keys or values', () => {
     const developerVariant = {
-      ...createVariant('developer'),
+      ...createMockVariant('developer'),
       metadata: {title: 'Developer audience', description: []},
     }
     const localeVariant = {
-      ...createVariant('norwegian', 1),
+      ...createMockVariant('norwegian', 1),
       conditions: {locale: 'nb-NO'},
     }
 

--- a/packages/sanity/src/core/variants/tool/__tests__/util.test.ts
+++ b/packages/sanity/src/core/variants/tool/__tests__/util.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, it} from 'vitest'
 
 import {createVariant} from '../../store/__tests__/testUtils'
 import {
+  decodeVariantIdFromRoute,
   filterVariantsForSearch,
   getVariantConditionsText,
   getVariantDescription,
@@ -24,10 +25,21 @@ describe('variants tool utilities', () => {
     )
   })
 
-  it('formats conditions as key value pairs', () => {
+  it('formats conditions as quoted key value pairs', () => {
     expect(getVariantConditionsText({audience: 'developer', locale: 'en'})).toBe(
-      'audience: developer, locale: en',
+      'audience: "developer", locale: "en"',
     )
+    expect(getVariantConditionsText({locale: 'en,nb'})).toBe('locale: "en,nb"')
+  })
+
+  it('decodes route slugs back to variant document ids', () => {
+    expect(decodeVariantIdFromRoute('alpha-audience')).toBe('_.variants.alpha-audience')
+    expect(decodeVariantIdFromRoute(encodeURIComponent('loyal-customers'))).toBe(
+      '_.variants.loyal-customers',
+    )
+    expect(decodeVariantIdFromRoute(encodeURIComponent('_.variants.a'))).toBe('_.variants.a')
+    expect(decodeVariantIdFromRoute('%E0%A4%A')).toBe('_.variants.%E0%A4%A')
+    expect(decodeVariantIdFromRoute(undefined)).toBeUndefined()
   })
 
   it('extracts plain text descriptions from portable text', () => {

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
@@ -1,5 +1,4 @@
 import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
-import {useMemo} from 'react'
 import {useRouter} from 'sanity/router'
 
 import {Button} from '../../../../ui-components/button/Button'
@@ -7,20 +6,17 @@ import {LoadingBlock} from '../../../components'
 import {useTranslation} from '../../../i18n'
 import {variantsLocaleNamespace} from '../../i18n'
 import {useAllVariants} from '../../store/useAllVariants'
-import {getVariantDescription, getVariantTitle} from '../util'
+import {decodeVariantIdFromRoute, getVariantDescription, getVariantTitle} from '../util'
 
 export function VariantDetail() {
   const router = useRouter()
   const {t} = useTranslation(variantsLocaleNamespace)
   const variantIdRaw =
     typeof router.state.variantId === 'string' ? router.state.variantId : undefined
-  const variantId = decodeURIComponent(variantIdRaw || '')
-  const {data: variants, loading} = useAllVariants()
+  const variantId = decodeVariantIdFromRoute(variantIdRaw)
+  const {byId, loading} = useAllVariants()
 
-  const variant = useMemo(
-    () => variants.find((candidate) => candidate._id === variantId),
-    [variantId, variants],
-  )
+  const variant = variantId ? byId.get(variantId) : undefined
 
   if (loading) {
     return <LoadingBlock fill title={t('detail.loading')} />

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
@@ -1,0 +1,77 @@
+import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
+import {useMemo} from 'react'
+import {useRouter} from 'sanity/router'
+
+import {Button} from '../../../../ui-components/button/Button'
+import {LoadingBlock} from '../../../components'
+import {useTranslation} from '../../../i18n'
+import {variantsLocaleNamespace} from '../../i18n'
+import {useAllVariants} from '../../store/useAllVariants'
+import {getVariantDescription, getVariantTitle} from '../util'
+
+export function VariantDetail() {
+  const router = useRouter()
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const variantIdRaw =
+    typeof router.state.variantId === 'string' ? router.state.variantId : undefined
+  const variantId = decodeURIComponent(variantIdRaw || '')
+  const {data: variants, loading} = useAllVariants()
+
+  const variant = useMemo(
+    () => variants.find((candidate) => candidate._id === variantId),
+    [variantId, variants],
+  )
+
+  if (loading) {
+    return <LoadingBlock fill title={t('detail.loading')} />
+  }
+
+  if (!variant) {
+    return (
+      <Flex direction="column" flex={1} height="fill">
+        <Card borderBottom flex="none" padding={3}>
+          <Button mode="bleed" onClick={() => router.navigate({})} text={t('detail.back')} />
+        </Card>
+        <Box padding={4}>
+          <Card border padding={4} radius={3}>
+            <Stack space={3}>
+              <Text size={2} weight="semibold">
+                {t('detail.not-found.title')}
+              </Text>
+              <Text muted size={1}>
+                {t('detail.not-found.description')}
+              </Text>
+            </Stack>
+          </Card>
+        </Box>
+      </Flex>
+    )
+  }
+
+  const description = getVariantDescription(variant)
+
+  return (
+    <Flex direction="column" flex={1} height="fill">
+      <Card borderBottom flex="none" padding={3}>
+        <Button mode="bleed" onClick={() => router.navigate({})} text={t('detail.back')} />
+      </Card>
+      <Box padding={4}>
+        <Card border padding={4} radius={3}>
+          <Stack space={4}>
+            <Stack space={3}>
+              <Text as="h1" size={4} weight="bold">
+                {getVariantTitle(variant)}
+              </Text>
+              <Text muted size={1}>
+                {description || t('detail.no-description')}
+              </Text>
+            </Stack>
+            <Text muted size={1}>
+              {t('detail.placeholder')}
+            </Text>
+          </Stack>
+        </Card>
+      </Box>
+    </Flex>
+  )
+}

--- a/packages/sanity/src/core/variants/tool/overview/VariantMenuButton.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantMenuButton.tsx
@@ -1,0 +1,30 @@
+import {Menu} from '@sanity/ui'
+import {useCallback} from 'react'
+
+import {MenuButton, MenuItem} from '../../../../ui-components'
+import {ContextMenuButton} from '../../../components/contextMenuButton'
+import {useTranslation} from '../../../i18n'
+import {variantsLocaleNamespace} from '../../i18n'
+import {type SystemVariant} from '../../types'
+
+export function VariantMenuButton({variant}: {variant: SystemVariant}) {
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const handleDelete = useCallback(() => undefined, [])
+
+  return (
+    <MenuButton
+      button={<ContextMenuButton />}
+      id={`variant-actions-${variant._id}`}
+      menu={
+        <Menu>
+          <MenuItem
+            onClick={handleDelete}
+            text={t('overview.action.delete-variant')}
+            tone="critical"
+          />
+        </Menu>
+      }
+      popover={{placement: 'bottom-end', portal: true}}
+    />
+  )
+}

--- a/packages/sanity/src/core/variants/tool/overview/VariantMenuButton.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantMenuButton.tsx
@@ -6,6 +6,7 @@ import {ContextMenuButton} from '../../../components/contextMenuButton'
 import {useTranslation} from '../../../i18n'
 import {variantsLocaleNamespace} from '../../i18n'
 import {type SystemVariant} from '../../types'
+import {getVariantId} from '../util'
 
 export function VariantMenuButton({variant}: {variant: SystemVariant}) {
   const {t} = useTranslation(variantsLocaleNamespace)
@@ -14,7 +15,7 @@ export function VariantMenuButton({variant}: {variant: SystemVariant}) {
   return (
     <MenuButton
       button={<ContextMenuButton />}
-      id={`variant-actions-${variant._id}`}
+      id={`variant-actions-${getVariantId(variant._id)}`}
       menu={
         <Menu>
           <MenuItem

--- a/packages/sanity/src/core/variants/tool/overview/VariantsEmptyState.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsEmptyState.tsx
@@ -1,4 +1,4 @@
-import {Flex, Inline, rem, Text} from '@sanity/ui'
+import {Flex, rem, Text} from '@sanity/ui'
 
 import {Button} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'

--- a/packages/sanity/src/core/variants/tool/overview/VariantsEmptyState.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsEmptyState.tsx
@@ -1,0 +1,46 @@
+import {Flex, Inline, rem, Text} from '@sanity/ui'
+
+import {Button} from '../../../../ui-components'
+import {useTranslation} from '../../../i18n'
+import {variantsLocaleNamespace} from '../../i18n'
+import {VariantIllustration} from '../resources/VariantIllustration'
+
+interface VariantsEmptyStateProps {
+  createVariantButton?: React.ReactNode
+}
+
+const VARIANTS_DOCUMENTATION_URL = 'https://www.sanity.io/docs/content-variants'
+
+export const VariantsEmptyState = ({createVariantButton}: VariantsEmptyStateProps) => {
+  const {t} = useTranslation(variantsLocaleNamespace)
+
+  return (
+    <Flex
+      align="center"
+      data-testid="variants-empty-state"
+      flex={1}
+      direction="column"
+      gap={3}
+      style={{maxWidth: rem(300)}}
+      paddingBottom={5}
+    >
+      <VariantIllustration />
+      <Text as="h1" size={1} weight="semibold" data-testid="no-variants-info-text">
+        {t('overview.title')}
+      </Text>
+      <Text size={1} muted style={{textAlign: 'center'}}>
+        {t('overview.empty-state.description')}
+      </Text>
+      <Flex gap={2}>
+        {createVariantButton}
+        <Button
+          as="a"
+          href={VARIANTS_DOCUMENTATION_URL}
+          target="_blank"
+          mode="ghost"
+          text={t('overview.action.documentation')}
+        />
+      </Flex>
+    </Flex>
+  )
+}

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
@@ -1,0 +1,118 @@
+import {AddIcon, SearchIcon} from '@sanity/icons'
+import {Box, Card, Container, Flex, Stack, Text, TextInput} from '@sanity/ui'
+import {useCallback, useMemo, useState} from 'react'
+
+import {Button} from '../../../../ui-components/button/Button'
+import {useTranslation} from '../../../i18n'
+import {Table, type TableProps} from '../../../releases/tool/components/Table/Table'
+import {variantsLocaleNamespace} from '../../i18n'
+import {useAllVariants} from '../../store/useAllVariants'
+import {type SystemVariant} from '../../types'
+import {filterVariantsForSearch} from '../util'
+import {VariantMenuButton} from './VariantMenuButton'
+import {VariantsEmptyState} from './VariantsEmptyState'
+import {variantsOverviewColumnDefs} from './VariantsOverviewColumnDefs'
+
+const VARIANT_TABLE_ROW_ID = '_id'
+
+export function VariantsOverview() {
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const {data: variants, error, loading} = useAllVariants()
+  const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const handleCreateVariant = useCallback(() => undefined, [])
+  const columnDefs = useMemo(() => variantsOverviewColumnDefs(t), [t])
+  const renderRowActions = useCallback<
+    NonNullable<TableProps<SystemVariant, undefined>['rowActions']>
+  >(({datum}) => <VariantMenuButton variant={datum as SystemVariant} />, [])
+
+  const variantsList = useMemo(() => variants ?? [], [variants])
+
+  const filteredVariants = useMemo(
+    () => filterVariantsForSearch(variantsList, searchQuery),
+    [variantsList, searchQuery],
+  )
+
+  const hasVariants = variantsList.length > 0
+
+  const createVariantButton = useMemo(
+    () => (
+      <Button
+        icon={AddIcon}
+        onClick={handleCreateVariant}
+        text={t('overview.action.create-variant')}
+      />
+    ),
+    [handleCreateVariant, t],
+  )
+
+  const tableEmptyState = useCallback(() => {
+    if (error && !hasVariants) {
+      return (
+        <Flex align="center" direction="column" gap={3} justify="center" padding={4}>
+          <Text muted size={1}>
+            {t('overview.error')}
+          </Text>
+        </Flex>
+      )
+    }
+
+    return <VariantsEmptyState createVariantButton={createVariantButton} />
+  }, [createVariantButton, error, hasVariants, t])
+
+  return (
+    <Flex direction="column" flex={1} height="fill">
+      {/* Same container width as releases document table (`container[3]` in Table), so chrome aligns with row content */}
+      <Container flex="none" width={3}>
+        <Flex direction="column" paddingX={3}>
+          <Card flex="none" paddingY={5}>
+            <Flex align="flex-start" gap={4} justify="space-between">
+              <Stack space={3}>
+                <Text as="h1" size={4} weight="bold">
+                  {t('overview.title')}
+                </Text>
+                <Text muted size={1}>
+                  {t('overview.description')}
+                </Text>
+              </Stack>
+              {createVariantButton}
+            </Flex>
+          </Card>
+
+          <Box flex="none" paddingBottom={4} paddingTop={2}>
+            <TextInput
+              clearButton={!!searchQuery}
+              fontSize={1}
+              icon={SearchIcon}
+              onChange={(event) => setSearchQuery(event.currentTarget.value)}
+              onClear={() => setSearchQuery('')}
+              placeholder={t('overview.search.placeholder')}
+              radius={3}
+              value={searchQuery}
+            />
+          </Box>
+
+          {error && (
+            <Card flex="none" padding={3} tone="critical">
+              <Text size={1}>{t('overview.error')}</Text>
+            </Card>
+          )}
+        </Flex>
+      </Container>
+
+      {/* Full-width scroll region so table borders span the tool pane (same pattern as release detail summary). */}
+      <Box flex={1} overflow="auto" ref={setScrollContainerRef}>
+        <Table<SystemVariant>
+          columnDefs={columnDefs}
+          data={filteredVariants}
+          emptyState={tableEmptyState}
+          loading={loading}
+          rowId={VARIANT_TABLE_ROW_ID}
+          rowActions={renderRowActions}
+          scrollContainerRef={scrollContainerRef}
+        />
+      </Box>
+    </Flex>
+  )
+}

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
@@ -1,0 +1,111 @@
+import {Box, Card, Flex, Skeleton, Stack, Text} from '@sanity/ui'
+import {useCallback} from 'react'
+import {useRouter} from 'sanity/router'
+
+import {type UseTranslationResponse, useTranslation} from '../../../i18n'
+import {Headers} from '../../../releases/tool/components/Table/TableHeader'
+import {type Column, type VisibleColumn} from '../../../releases/tool/components/Table/types'
+import {variantsLocaleNamespace} from '../../i18n'
+import {type SystemVariant} from '../../types'
+import {getVariantConditionsText, getVariantTitle} from '../util'
+
+const VariantDocumentsCell: VisibleColumn<SystemVariant>['cell'] = ({cellProps, datum}) => {
+  if (datum.isLoading) {
+    return (
+      <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border">
+        <Text size={1}>
+          <Skeleton animated radius={1} style={{width: '4ch'}} />
+        </Text>
+      </Flex>
+    )
+  }
+
+  return (
+    <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border">
+      <Text muted size={1}>
+        0
+      </Text>
+    </Flex>
+  )
+}
+
+const VariantTitleCell: VisibleColumn<SystemVariant>['cell'] = ({cellProps, datum: variant}) => {
+  const router = useRouter()
+  const {t} = useTranslation(variantsLocaleNamespace)
+
+  const handleNavigate = useCallback(() => {
+    router.navigate({variantId: encodeURIComponent(variant._id)})
+  }, [router, variant._id])
+
+  if (variant.isLoading) {
+    return (
+      <Box {...cellProps} flex={1} paddingLeft={3} paddingRight={2} paddingY={2} sizing="border">
+        <Stack space={2}>
+          <Text size={1} weight="medium">
+            <Skeleton animated radius={1} style={{width: '16ch'}} />
+          </Text>
+          <Text muted size={1}>
+            <Skeleton animated radius={1} style={{width: '32ch'}} />
+          </Text>
+        </Stack>
+      </Box>
+    )
+  }
+
+  const conditionsText = getVariantConditionsText(variant.conditions)
+
+  return (
+    <Box {...cellProps} flex={1} paddingLeft={3} paddingRight={2} paddingY={1} sizing="border">
+      <Card as="a" flex={1} onClick={handleNavigate} padding={2} radius={2} tone="inherit">
+        <Flex align="center" gap={3}>
+          <Stack flex={1} space={2}>
+            <Text size={1} weight="medium">
+              {getVariantTitle(variant)}
+            </Text>
+            <Text muted size={1}>
+              {conditionsText || t('overview.table.no-conditions')}
+            </Text>
+          </Stack>
+        </Flex>
+      </Card>
+    </Box>
+  )
+}
+
+export function variantsOverviewColumnDefs(
+  t: UseTranslationResponse<'variants', undefined>['t'],
+): Column<SystemVariant>[] {
+  return [
+    {
+      id: 'metadata.title',
+      sorting: true,
+      width: null,
+      style: {minWidth: 'min(50%, calc(100vw - 80px))'},
+      header: (props) => (
+        <Flex
+          {...props.headerProps}
+          flex={1}
+          paddingLeft={3}
+          paddingRight={2}
+          paddingY={3}
+          sizing="border"
+        >
+          <Headers.SortHeaderButton {...props} text={t('overview.table.variant')} />
+        </Flex>
+      ),
+      cell: VariantTitleCell,
+      sortTransform: (variant) => getVariantTitle(variant),
+    },
+    {
+      id: 'documentCount',
+      sorting: false,
+      width: 120,
+      header: ({headerProps}) => (
+        <Flex {...headerProps} paddingY={3} sizing="border">
+          <Headers.BasicHeader text={t('overview.table.documents')} />
+        </Flex>
+      ),
+      cell: VariantDocumentsCell,
+    },
+  ]
+}

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
@@ -1,13 +1,13 @@
 import {Box, Card, Flex, Skeleton, Stack, Text} from '@sanity/ui'
-import {useCallback} from 'react'
-import {useRouter} from 'sanity/router'
+import {type ForwardedRef, forwardRef, type HTMLProps, useMemo} from 'react'
+import {StateLink} from 'sanity/router'
 
 import {type UseTranslationResponse, useTranslation} from '../../../i18n'
 import {Headers} from '../../../releases/tool/components/Table/TableHeader'
 import {type Column, type VisibleColumn} from '../../../releases/tool/components/Table/types'
 import {variantsLocaleNamespace} from '../../i18n'
 import {type SystemVariant} from '../../types'
-import {getVariantConditionsText, getVariantTitle} from '../util'
+import {getVariantId, getVariantConditionsText, getVariantTitle} from '../util'
 
 const VariantDocumentsCell: VisibleColumn<SystemVariant>['cell'] = ({cellProps, datum}) => {
   if (datum.isLoading) {
@@ -30,12 +30,20 @@ const VariantDocumentsCell: VisibleColumn<SystemVariant>['cell'] = ({cellProps, 
 }
 
 const VariantTitleCell: VisibleColumn<SystemVariant>['cell'] = ({cellProps, datum: variant}) => {
-  const router = useRouter()
   const {t} = useTranslation(variantsLocaleNamespace)
 
-  const handleNavigate = useCallback(() => {
-    router.navigate({variantId: encodeURIComponent(variant._id)})
-  }, [router, variant._id])
+  const encodedVariantId = getVariantId(variant._id)
+
+  const VariantLink = useMemo(
+    () =>
+      forwardRef(function VariantLinkComponent(
+        linkProps: HTMLProps<HTMLAnchorElement>,
+        ref: ForwardedRef<HTMLAnchorElement>,
+      ) {
+        return <StateLink {...linkProps} ref={ref} state={{variantId: encodedVariantId}} />
+      }),
+    [encodedVariantId],
+  )
 
   if (variant.isLoading) {
     return (
@@ -56,7 +64,7 @@ const VariantTitleCell: VisibleColumn<SystemVariant>['cell'] = ({cellProps, datu
 
   return (
     <Box {...cellProps} flex={1} paddingLeft={3} paddingRight={2} paddingY={1} sizing="border">
-      <Card as="a" flex={1} onClick={handleNavigate} padding={2} radius={2} tone="inherit">
+      <Card as={VariantLink} data-as="a" flex={1} padding={2} radius={2} tone="inherit">
         <Flex align="center" gap={3}>
           <Stack flex={1} space={2}>
             <Text size={1} weight="medium">

--- a/packages/sanity/src/core/variants/tool/resources/VariantIllustration.tsx
+++ b/packages/sanity/src/core/variants/tool/resources/VariantIllustration.tsx
@@ -1,0 +1,134 @@
+/**
+ * Isometric illustration: one primary document with smaller derived copies,
+ * echoing the layered panels used in {@link ReleaseIllustration}.
+ */
+const BASE_PANEL =
+  'M64 150.174V81.8262C64 79.1748 65.498 76.751 67.8695 75.5653L103.87 57.5652C108.524 55.2381 114 58.6226 114 63.8262V132.174C114 134.825 112.502 137.249 110.131 138.435L74.1305 156.435C69.4762 158.762 64 155.377 64 150.174Z'
+
+/** Horizontal “body copy” lines in panel local coordinates */
+const LINES_FULL = ['M72 86 L106 86', 'M72 96 L102 96', 'M72 106 L104 106', 'M72 116 L98 116']
+
+const LINES_MEDIUM = ['M72 88 L100 88', 'M72 98 L96 98', 'M72 108 L102 108']
+
+const LINES_SHORT = ['M72 90 L94 90', 'M72 100 L92 100']
+
+export const VariantIllustration = () => (
+  <svg
+    data-testid="variant-illustration"
+    width="248"
+    height="201"
+    viewBox="0 0 248 201"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    {/* faint depth behind hub */}
+    <g opacity={0.12}>
+      <path
+        d={BASE_PANEL}
+        fill="var(--card-muted-bg-color)"
+        stroke="var(--card-muted-fg-color)"
+        strokeWidth={1.2}
+        transform="translate(12 10)"
+      />
+      <path
+        d={BASE_PANEL}
+        fill="var(--card-muted-bg-color)"
+        stroke="var(--card-muted-fg-color)"
+        strokeWidth={1.2}
+        transform="translate(6 6)"
+      />
+    </g>
+
+    {/* derived copies — same silhouette, different inner lines */}
+    <g opacity={0.28}>
+      <g transform="translate(118 6) scale(0.5)">
+        <path
+          d={BASE_PANEL}
+          fill="var(--card-muted-bg-color)"
+          stroke="var(--card-muted-fg-color)"
+          strokeWidth={1.2}
+        />
+        {LINES_MEDIUM.map((d, i) => (
+          <path
+            key={`sat-a-${i}`}
+            d={d}
+            stroke="var(--card-muted-fg-color)"
+            strokeWidth={1.2}
+            strokeLinecap="round"
+            opacity={0.55}
+          />
+        ))}
+      </g>
+    </g>
+
+    <g opacity={0.34}>
+      <g transform="translate(126 52) scale(0.52)">
+        <path
+          d={BASE_PANEL}
+          fill="var(--card-muted-bg-color)"
+          stroke="var(--card-muted-fg-color)"
+          strokeWidth={1.2}
+        />
+        {LINES_FULL.slice(0, 3).map((d, i) => (
+          <path
+            key={`sat-b-${i}`}
+            d={d}
+            stroke="var(--card-muted-fg-color)"
+            strokeWidth={1.2}
+            strokeLinecap="round"
+            opacity={0.5}
+          />
+        ))}
+      </g>
+    </g>
+
+    <g opacity={0.26}>
+      <g transform="translate(106 102) scale(0.48)">
+        <path
+          d={BASE_PANEL}
+          fill="var(--card-muted-bg-color)"
+          stroke="var(--card-muted-fg-color)"
+          strokeWidth={1.2}
+        />
+        {LINES_SHORT.map((d, i) => (
+          <path
+            key={`sat-c-${i}`}
+            d={d}
+            stroke="var(--card-muted-fg-color)"
+            strokeWidth={1.2}
+            strokeLinecap="round"
+            opacity={0.55}
+          />
+        ))}
+      </g>
+    </g>
+
+    {/* soft connectors — hub to satellites */}
+    <g opacity={0.14} stroke="var(--card-muted-fg-color)" strokeWidth={1.2} strokeLinecap="round">
+      <path d="M118 112 Q 152 72 168 58" fill="none" />
+      <path d="M124 124 Q 168 108 188 92" fill="none" />
+      <path d="M118 138 Q 150 152 162 168" fill="none" />
+    </g>
+
+    {/* primary document */}
+    <g transform="translate(26 20) scale(1.06)">
+      <path
+        d={BASE_PANEL}
+        fill="var(--card-muted-bg-color)"
+        stroke="var(--card-muted-fg-color)"
+        strokeWidth={1.2}
+        opacity={0.92}
+      />
+      {LINES_FULL.map((d, i) => (
+        <path
+          key={`hub-${i}`}
+          d={d}
+          stroke="var(--card-muted-fg-color)"
+          strokeWidth={1.2}
+          strokeLinecap="round"
+          opacity={0.42 + i * 0.06}
+        />
+      ))}
+    </g>
+  </svg>
+)

--- a/packages/sanity/src/core/variants/tool/resources/VariantIllustration.tsx
+++ b/packages/sanity/src/core/variants/tool/resources/VariantIllustration.tsx
@@ -14,6 +14,7 @@ const LINES_SHORT = ['M72 90 L94 90', 'M72 100 L92 100']
 
 export const VariantIllustration = () => (
   <svg
+    aria-hidden="true"
     data-testid="variant-illustration"
     width="248"
     height="201"
@@ -48,9 +49,9 @@ export const VariantIllustration = () => (
           stroke="var(--card-muted-fg-color)"
           strokeWidth={1.2}
         />
-        {LINES_MEDIUM.map((d, i) => (
+        {LINES_MEDIUM.map((d) => (
           <path
-            key={`sat-a-${i}`}
+            key={d}
             d={d}
             stroke="var(--card-muted-fg-color)"
             strokeWidth={1.2}
@@ -69,9 +70,9 @@ export const VariantIllustration = () => (
           stroke="var(--card-muted-fg-color)"
           strokeWidth={1.2}
         />
-        {LINES_FULL.slice(0, 3).map((d, i) => (
+        {LINES_FULL.slice(0, 3).map((d) => (
           <path
-            key={`sat-b-${i}`}
+            key={d}
             d={d}
             stroke="var(--card-muted-fg-color)"
             strokeWidth={1.2}
@@ -90,9 +91,9 @@ export const VariantIllustration = () => (
           stroke="var(--card-muted-fg-color)"
           strokeWidth={1.2}
         />
-        {LINES_SHORT.map((d, i) => (
+        {LINES_SHORT.map((d) => (
           <path
-            key={`sat-c-${i}`}
+            key={d}
             d={d}
             stroke="var(--card-muted-fg-color)"
             strokeWidth={1.2}
@@ -119,14 +120,14 @@ export const VariantIllustration = () => (
         strokeWidth={1.2}
         opacity={0.92}
       />
-      {LINES_FULL.map((d, i) => (
+      {LINES_FULL.map((d, index) => (
         <path
-          key={`hub-${i}`}
+          key={d}
           d={d}
           stroke="var(--card-muted-fg-color)"
           strokeWidth={1.2}
           strokeLinecap="round"
-          opacity={0.42 + i * 0.06}
+          opacity={0.42 + index * 0.06}
         />
       ))}
     </g>

--- a/packages/sanity/src/core/variants/tool/util.ts
+++ b/packages/sanity/src/core/variants/tool/util.ts
@@ -32,8 +32,33 @@ export function getVariantTitle(variant: SystemVariant): string {
  */
 export function getVariantConditionsText(conditions: SystemVariant['conditions']): string {
   return Object.entries(conditions)
-    .map(([key, value]) => `${key}: ${value}`)
+    .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
     .join(', ')
+}
+
+/**
+ * Decodes router state / URL path segments back to a variant document id.
+ *
+ * @internal
+ */
+export function decodeVariantIdFromRoute(variantIdRaw: string | undefined): string | undefined {
+  if (!variantIdRaw) {
+    return undefined
+  }
+
+  let decoded: string
+
+  try {
+    decoded = decodeURIComponent(variantIdRaw)
+  } catch {
+    decoded = variantIdRaw
+  }
+
+  if (decoded.startsWith(`${VARIANT_ID_PREFIX}`)) {
+    return decoded
+  }
+
+  return `${VARIANT_ID_PREFIX}${decoded}`
 }
 
 /**

--- a/packages/sanity/src/core/variants/tool/util.ts
+++ b/packages/sanity/src/core/variants/tool/util.ts
@@ -1,0 +1,74 @@
+import {isPortableTextBlock, toPlainText} from '@portabletext/toolkit'
+
+import {VARIANT_DOCUMENTS_PATH} from '../store/constants'
+import {type SystemVariant} from '../types'
+
+const VARIANT_ID_PREFIX = `${VARIANT_DOCUMENTS_PATH}.`
+
+/**
+ * @internal
+ */
+export function getVariantId(variantDocumentId: string): string {
+  return variantDocumentId.startsWith(VARIANT_ID_PREFIX)
+    ? variantDocumentId.slice(VARIANT_ID_PREFIX.length)
+    : variantDocumentId
+}
+
+/**
+ * @internal
+ */
+export function getVariantTitle(variant: SystemVariant): string {
+  const title = variant.metadata?.title
+
+  if (typeof title === 'string' && title.trim()) {
+    return title
+  }
+
+  return getVariantId(variant._id)
+}
+
+/**
+ * @internal
+ */
+export function getVariantConditionsText(conditions: SystemVariant['conditions']): string {
+  return Object.entries(conditions)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join(', ')
+}
+
+/**
+ * @internal
+ */
+export function getVariantDescription(variant: SystemVariant): string {
+  const description = variant.metadata?.description
+
+  if (!Array.isArray(description) || !description.every(isPortableTextBlock)) {
+    return ''
+  }
+
+  return toPlainText(description).trim()
+}
+
+/**
+ * @internal
+ */
+export function filterVariantsForSearch(
+  variants: SystemVariant[],
+  searchTerm: string,
+): SystemVariant[] {
+  const normalizedSearchTerm = searchTerm.trim().toLowerCase()
+
+  if (!normalizedSearchTerm) {
+    return variants
+  }
+
+  return variants.filter((variant) => {
+    const searchableValues = [
+      getVariantTitle(variant),
+      getVariantId(variant._id),
+      ...Object.entries(variant.conditions).flat(),
+    ]
+
+    return searchableValues.some((value) => value.toLowerCase().includes(normalizedSearchTerm))
+  })
+}

--- a/packages/sanity/src/core/variants/types.ts
+++ b/packages/sanity/src/core/variants/types.ts
@@ -8,7 +8,8 @@ export interface SystemVariant extends SanityDocument {
   conditions: Record<string, string>
   priority: number // defaults to 0.
   metadata?: {
-    description: PortableTextBlock[]
+    title?: string
+    description?: PortableTextBlock[]
     [key: string]: unknown // <-- Here we can store anything useful for the UI
   }
 }


### PR DESCRIPTION
### Description

Introduces an early **Variants** Studio tool scaffold so we can iterate on listing and navigating variant definitions without blocking on full product behavior. This is intentionally incomplete (placeholder actions, no real create flow).

<img width="800"  alt="image" src="https://github.com/user-attachments/assets/2df70bd7-703d-4588-b83e-e18c500490e6" />


<img width="800" alt="image" src="https://github.com/user-attachments/assets/4ae35e8b-663f-4c1f-80a2-d4840b91bea6" />

<img width="800" alt="image" src="https://github.com/user-attachments/assets/4e0d20c9-f58a-46b7-a8ed-b5a443b6a710" />


### What to review
- `packages/sanity/src/core/variants/**` — plugin wiring, overview table plus empty/detail placeholders, layout alignment with the releases `Table` pattern.

### Testing
- Vitest integration-style tests under `packages/sanity/src/core/variants/tool/__tests__/`.
- Optional: `pnpm vitest run --project=sanity packages/sanity/src/core/variants/tool/__tests__/`.
### Notes for release
N/A – Part of Variants scaffolding; not yet a complete user-facing feature.