### PR TITLE
fix: add back groq prerelease to trustPolicyExclude

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -90,7 +90,10 @@ trustPolicyExclude:
   - '@sanity/sdk@2.1.2'
   - '@swc/core@1.13.5'
   - chokidar@4.0.3
-  - groq@5.24.0
+  # 5.24.0 got accidental trust-downgrade
+  # 3.88.1-typegen-experimental.0 is a dependency of @sanity/sdk
+  - groq@5.24.0 || 3.88.1-typegen-experimental.0
+  - sanity-plugin-internationalized-array@4.0.8
   - react-redux@9.2.0
   - reselect@5.1.1
   - rxjs@7.8.2


### PR DESCRIPTION
### Description
Partially reverts #12832. Turns out we still exclusion for 3.88.1-typegen-experimental.0, it's a dependency of @sanity/sdk

### What to review
- Also added exclusion for `sanity-plugin-internationalized-array@4.0.8`

### Testing
- Once merged, CI checks on #12804 should pass after a rebase

### Notes for release

n/a – monorepo only