### PR TITLE
fix: respect options.disableNew for asset menus

### DIFF
--- a/dev/test-studio/schema/standard/videos.ts
+++ b/dev/test-studio/schema/standard/videos.ts
@@ -67,5 +67,12 @@ export default defineType({
         }),
       ],
     }),
+    defineVideoField({
+      name: 'video',
+      title: 'Video with disabled upload',
+      options: {
+        disableNew: true,
+      },
+    }),
   ],
 })

--- a/packages/sanity/src/core/form/inputs/files/FileInput/FilePreview.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/FilePreview.tsx
@@ -136,10 +136,13 @@ export function FilePreview(props: FileAssetProps) {
     t,
   ])
 
+  const disableNew = schemaType.options?.disableNew === true
+
   const uploadMenuItem = useUploadMenuItem({
     accept,
     assetSourcesWithUpload,
     directUploads,
+    disableNew,
     readOnly,
     onSelectFiles: handleSelectFilesFromAssetSource,
     onOpenSourceForUpload: handleOpenSourceForUpload,

--- a/packages/sanity/src/core/form/inputs/files/FileInput/__tests__/fileInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/FileInput/__tests__/fileInput.test.tsx
@@ -169,6 +169,25 @@ describe('FileInput with asset', () => {
     expect(screen.getByText('31 Bytes')).toBeInTheDocument()
   })
 
+  it('does not show upload in context menu when disableNew is true', async () => {
+    await renderFileInput({
+      fieldDefinition: {
+        name: 'someFile',
+        title: 'A simple file',
+        type: 'file',
+        options: {disableNew: true},
+      },
+      observeAsset: observeAssetStub,
+      render: (inputProps) => <BaseFileInput {...inputProps} value={value} />,
+    })
+
+    await userEvent.click(screen.getByTestId('options-menu-button'))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('file-input-upload-button-test-source')).not.toBeInTheDocument()
+    })
+  })
+
   it.todo('renders new file when a new file in uploaded')
 
   /* readOnly - the files input is read only or not */

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetMenu.tsx
@@ -177,6 +177,7 @@ function ImageInputAssetMenuWithReferenceAssetComponent(
     observeAsset,
     readOnly,
     reference,
+    schemaType,
     setHotspotButtonElement,
     menuButtonRef,
     setMenuOpen,
@@ -241,10 +242,13 @@ function ImageInputAssetMenuWithReferenceAssetComponent(
     }
   }, [asset, onOpenInSource, openInSourceResult, setMenuOpen])
 
+  const disableNew = schemaType.options?.disableNew === true
+
   const uploadMenuItem = useUploadMenuItem({
     accept,
     assetSourcesWithUpload,
     directUploads,
+    disableNew,
     readOnly,
     onSelectFiles: handleSelectFilesFromAssetSource,
     onOpenSourceForUpload: handleOpenSourceForUpload,

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/__tests__/imageInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/__tests__/imageInput.test.tsx
@@ -3,7 +3,9 @@
  * Asset source behavior is covered in assetSourceIntegration.test.tsx.
  * Drag-to-upload is covered in common/__tests__/uploadTarget.test.tsx.
  */
-import {screen} from '@testing-library/react'
+import {createImageUrlBuilder} from '@sanity/image-url'
+import {screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
 import {describe, expect, it} from 'vitest'
 
 import {observeImageAssetStub} from '../../../../../../../test/fixtures/assetSourceMocks'
@@ -64,5 +66,37 @@ describe('ImageInput with empty state', () => {
       render: (inputProps) => <BaseImageInput {...inputProps} value={invalidValue} />,
     })
     expect(screen.getByTestId('invalid-image-warning')).toBeInTheDocument()
+  })
+})
+
+describe('ImageInput with asset', () => {
+  const value = {
+    asset: {
+      _ref: 'image-26db46ec62059d6cd491b4343afaecc92ff1b4d5-100x100-jpg',
+      _type: 'reference',
+    },
+    _type: 'image',
+  }
+
+  it('does not show upload in context menu when disableNew is true', async () => {
+    await renderImageInput({
+      assetSources: [{Uploader: {}, name: 'test-source'} as any],
+      configOverrides: {mediaLibrary: {enabled: false}},
+      fieldDefinition: {
+        name: 'mainImage',
+        title: 'Main image',
+        type: 'image',
+        options: {disableNew: true},
+      },
+      imageUrlBuilder: createImageUrlBuilder({projectId: 'test', dataset: 'test'}),
+      observeAsset: observeImageAssetStub,
+      render: (inputProps) => <BaseImageInput {...inputProps} value={value} />,
+    })
+
+    await userEvent.click(screen.getByTestId('options-menu-button'))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('file-input-upload-button')).not.toBeInTheDocument()
+    })
   })
 })

--- a/packages/sanity/src/core/form/inputs/files/common/UploadPlaceholder.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/UploadPlaceholder.tsx
@@ -56,6 +56,7 @@ function UploadPlaceholderComponent(props: UploadPlaceholderProps) {
   const {t} = useTranslation()
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const source = useSource()
+  const disableNew = schemaType.options?.disableNew === true
 
   const assetSourcesWithUpload = useMemo(() => {
     const result = getAssetSourcesWithUpload(assetSources)
@@ -89,6 +90,10 @@ function UploadPlaceholderComponent(props: UploadPlaceholderProps) {
   )
 
   const uploadButton = useMemo(() => {
+    if (disableNew) {
+      return null
+    }
+
     switch (assetSourcesWithUpload.length) {
       case 0:
         return null
@@ -144,12 +149,21 @@ function UploadPlaceholderComponent(props: UploadPlaceholderProps) {
     accept,
     assetSourcesWithUpload,
     directUploads,
+    disableNew,
     handleSelectFiles,
     onOpenSourceForUpload,
     onUpload,
     readOnly,
     t,
   ])
+
+  if (disableNew) {
+    return browse ? (
+      <Flex align="center" justify="flex-end" ref={setRootElement}>
+        {browse}
+      </Flex>
+    ) : null
+  }
 
   return assetSourcesWithUpload.length === 0 ? null : (
     <Flex

--- a/packages/sanity/src/core/form/inputs/files/common/useUploadMenuItem.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/useUploadMenuItem.tsx
@@ -12,6 +12,8 @@ export interface UseUploadMenuItemOptions {
   accept: string
   assetSourcesWithUpload: AssetSource[]
   directUploads?: boolean
+  /** When true, upload menu items are hidden (schema option disableNew). */
+  disableNew?: boolean
   readOnly?: boolean
   onSelectFiles: (assetSource: AssetSource, files: File[]) => void
   onOpenSourceForUpload?: (assetSource: AssetSource) => void
@@ -43,6 +45,7 @@ export function useUploadMenuItem(options: UseUploadMenuItemOptions): ReactNode 
     accept,
     assetSourcesWithUpload,
     directUploads,
+    disableNew,
     readOnly,
     onSelectFiles,
     onOpenSourceForUpload,
@@ -57,6 +60,10 @@ export function useUploadMenuItem(options: UseUploadMenuItemOptions): ReactNode 
   const {t} = useTranslation()
 
   return useMemo(() => {
+    if (disableNew) {
+      return null
+    }
+
     switch (assetSourcesWithUpload.length) {
       case 0:
         return null
@@ -110,6 +117,7 @@ export function useUploadMenuItem(options: UseUploadMenuItemOptions): ReactNode 
     accept,
     assetSourcesWithUpload,
     directUploads,
+    disableNew,
     dropdownMenuTestId,
     getSingleButtonTestId,
     onCloseParentMenu,

--- a/packages/sanity/src/media-library/plugin/VideoInput/VideoPreview.tsx
+++ b/packages/sanity/src/media-library/plugin/VideoInput/VideoPreview.tsx
@@ -255,10 +255,13 @@ export function VideoPreview(props: VideoAssetInputProps) {
     t,
   ])
 
+  const disableNew = schemaType.options?.disableNew === true
+
   const uploadMenuItem = useUploadMenuItem({
     accept,
     assetSourcesWithUpload,
     directUploads,
+    disableNew,
     readOnly,
     onSelectFiles: handleSelectVideosFromAssetSource,
     onOpenSourceForUpload: handleOpenSourceForUpload,

--- a/packages/sanity/src/media-library/plugin/VideoInput/__tests__/videoInput.test.tsx
+++ b/packages/sanity/src/media-library/plugin/VideoInput/__tests__/videoInput.test.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../../../../test/fixtures/assetSourceMocks'
 import {renderVideoInput} from '../../../../../test/form'
 import {getDataTestIdPrefix} from '../../../../core/form/inputs/files/common/AssetSourceBrowser'
+import {StudioVideoInput} from '../StudioVideoInput'
 import {BaseVideoInput} from '../VideoInput'
 
 // Mock useVideoPlaybackInfo so VideoPreview shows the options menu instead of waiting for API
@@ -54,6 +55,64 @@ describe('VideoInput - local tests', () => {
         `${getDataTestIdPrefix({name: 'sanity.video', jsonType: 'object'})}-browse-button-media-library-mock`,
       ),
     ).toBeInTheDocument()
+  })
+
+  it('renders browse button right-aligned when disableNew is true', async () => {
+    const assetSource = createMockAssetSourceWithMediaLibraryUploader()
+    const videoBrowseTestId = `${getDataTestIdPrefix({name: 'sanity.video', jsonType: 'object'})}-browse-button-media-library-mock`
+
+    await renderVideoInput({
+      assetSources: [assetSource],
+      fieldDefinition: {
+        name: 'someVideo',
+        title: 'A video',
+        type: 'sanity.video',
+        options: {disableNew: true},
+      },
+      observeAsset: observeVideoAssetStub,
+      render: (inputProps) => <BaseVideoInput {...inputProps} />,
+    })
+
+    expect(screen.getByTestId(videoBrowseTestId)).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('file-input-upload-button-media-library-mock'),
+    ).not.toBeInTheDocument()
+
+    const browseButton = screen.getByTestId(videoBrowseTestId)
+    const flexContainer = browseButton.closest('[data-ui="Flex"]')
+    expect(flexContainer).toBeInTheDocument()
+    expect(flexContainer).toHaveStyle('justify-content: flex-end')
+  })
+
+  it('StudioVideoInput hides upload when disableNew is true', async () => {
+    const videoBrowseTestId = `${getDataTestIdPrefix({name: 'sanity.video', jsonType: 'object'})}-browse-button-sanity-media-library`
+
+    await renderVideoInput({
+      fieldDefinition: {
+        name: 'someVideo',
+        title: 'A video',
+        type: 'sanity.video',
+        options: {disableNew: true},
+      },
+      observeAsset: observeVideoAssetStub,
+      render: (inputProps) => {
+        const {
+          assetSources: _assetSources,
+          client: _client,
+          directUploads: _directUploads,
+          observeAsset: _observeAsset,
+          resolveUploader: _resolveUploader,
+          t: _t,
+          ...studioProps
+        } = inputProps
+        return <StudioVideoInput {...studioProps} />
+      },
+    })
+
+    expect(screen.getByTestId(videoBrowseTestId)).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('file-input-upload-button-sanity-media-library'),
+    ).not.toBeInTheDocument()
   })
 
   it('shows invalid video warning when asset ref is not a media-library ref', async () => {

--- a/packages/sanity/src/media-library/plugin/VideoInput/__tests__/videoSchemaOptions.test.ts
+++ b/packages/sanity/src/media-library/plugin/VideoInput/__tests__/videoSchemaOptions.test.ts
@@ -1,0 +1,29 @@
+import {Schema} from '@sanity/schema'
+import {describe, expect, it} from 'vitest'
+
+import {mediaLibrarySchemas} from '../../schemas'
+
+describe('sanity.video schema options', () => {
+  it('preserves disableNew on field-level options', () => {
+    const schema = Schema.compile({
+      name: 'test',
+      types: [
+        ...mediaLibrarySchemas,
+        {
+          name: 'testDoc',
+          type: 'document',
+          fields: [
+            {
+              name: 'video',
+              type: 'sanity.video',
+              options: {disableNew: true},
+            },
+          ],
+        },
+      ],
+    })
+
+    const field = schema.get('testDoc').fields.find((f) => f.name === 'video')
+    expect(field?.type.options?.disableNew).toBe(true)
+  })
+})

--- a/packages/sanity/src/media-library/plugin/schemas/types.ts
+++ b/packages/sanity/src/media-library/plugin/schemas/types.ts
@@ -16,6 +16,11 @@ import {isRecord} from '../../../core/util'
 export interface VideoOptions extends ObjectOptions {
   accept?: string
   sources?: AssetSource[]
+  /**
+   * When set to `true`, hides the upload UI, only allowing selection of existing assets from the media library.
+   * Useful for centralized asset management workflows where ad-hoc uploads should be prevented.
+   */
+  disableNew?: boolean
 }
 
 /** @public */


### PR DESCRIPTION
### Description

I noticed that asset fields didn't respect the `options.disableNew` when showing the asset context menu. Drag/Drop respected this, but didn't remove the "Upload" menu in the asset context menu.

The video type didn't have this option, so I added it there as well.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review
Looking into the two last fields in the Image and File tests in the Test Studio, the array with this option enabled should respect this option in any circumstance where you can upload.

I have also added a new field in the bottom of the Video documents in the Test Studio for this as well.

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Added unit tests. Manual testing can be done in the Test Studio for Image, File and Video.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
* Fixed a issue where you could still upload to fields where the schema type has had upload disabled (options.disableNew)

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
