### PR TITLE
feat(core): initial implementation for variants creation form

### DIFF
--- a/packages/sanity/src/core/variants/__fixtures__/createMockVariant.ts
+++ b/packages/sanity/src/core/variants/__fixtures__/createMockVariant.ts
@@ -1,3 +1,4 @@
+import {VARIANT_DOCUMENT_TYPE, VARIANT_DOCUMENTS_PATH} from '../store/constants'
 import {type SystemVariant} from '../types'
 
 /**
@@ -5,8 +6,8 @@ import {type SystemVariant} from '../types'
  */
 export function createMockVariant(id: string, priority = 0): SystemVariant {
   return {
-    _id: `_.variants.${id}`,
-    _type: 'system.variant',
+    _id: `${VARIANT_DOCUMENTS_PATH}.${id}`,
+    _type: VARIANT_DOCUMENT_TYPE,
     _createdAt: `2025-01-0${(priority % 9) + 1}T00:00:00Z`,
     _updatedAt: `2025-01-0${(priority % 9) + 1}T00:00:00Z`,
     _rev: `rev-${id}`,

--- a/packages/sanity/src/core/variants/components/dialog/CreateVariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/CreateVariantDialog.tsx
@@ -1,13 +1,17 @@
+import {at, set} from '@sanity/mutate'
+import {applyPatches} from '@sanity/mutate/_unstable_apply'
 import {Box, Card, Flex, useToast} from '@sanity/ui'
+import {toString} from '@sanity/util/paths'
 import {type FormEvent, useCallback, useState} from 'react'
 
 import {Button, Dialog} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
 import {variantsLocaleNamespace} from '../../i18n'
 import {useVariantOperations} from '../../store/useVariantOperations'
+import {type EditableSystemVariant} from '../../types'
 import {getIsVariantInvalid} from '../../util/getIsVariantInvalid'
 import {getVariantDefaults} from '../../util/variantDefaults'
-import {VariantForm} from './VariantForm'
+import {VariantForm, type VariantFormChangeHandler} from './VariantForm'
 
 interface CreateVariantDialogProps {
   onCancel: () => void
@@ -24,6 +28,13 @@ export function CreateVariantDialog(props: CreateVariantDialogProps): React.JSX.
   const [showValidation, setShowValidation] = useState(false)
   const [conditionsInvalid, setConditionsInvalid] = useState(false)
   const invalid = getIsVariantInvalid(variant) || conditionsInvalid
+
+  const handleVariantChange = useCallback<VariantFormChangeHandler>((path, nextValue) => {
+    setVariant(
+      (currentVariant) =>
+        applyPatches([at(toString(path), set(nextValue))], currentVariant) as EditableSystemVariant,
+    )
+  }, [])
 
   const handleSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
@@ -67,7 +78,7 @@ export function CreateVariantDialog(props: CreateVariantDialogProps): React.JSX.
         <form onSubmit={handleSubmit}>
           <Box paddingBottom={4}>
             <VariantForm
-              onChange={setVariant}
+              onChange={handleVariantChange}
               onConditionValidityChange={setConditionsInvalid}
               showValidation={showValidation}
               value={variant}

--- a/packages/sanity/src/core/variants/components/dialog/CreateVariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/CreateVariantDialog.tsx
@@ -1,0 +1,91 @@
+import {Box, Card, Flex, useToast} from '@sanity/ui'
+import {type FormEvent, useCallback, useState} from 'react'
+
+import {Button, Dialog} from '../../../../ui-components'
+import {useTranslation} from '../../../i18n'
+import {variantsLocaleNamespace} from '../../i18n'
+import {useVariantOperations} from '../../store/useVariantOperations'
+import {getIsVariantInvalid} from '../../util/getIsVariantInvalid'
+import {getVariantDefaults} from '../../util/variantDefaults'
+import {VariantForm} from './VariantForm'
+
+interface CreateVariantDialogProps {
+  onCancel: () => void
+  onSubmit: (createdVariantId: string) => void
+}
+
+export function CreateVariantDialog(props: CreateVariantDialogProps): React.JSX.Element {
+  const {onCancel, onSubmit} = props
+  const toast = useToast()
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const {createVariant} = useVariantOperations()
+  const [variant, setVariant] = useState(getVariantDefaults)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [showValidation, setShowValidation] = useState(false)
+  const [conditionsInvalid, setConditionsInvalid] = useState(true)
+  const invalid = getIsVariantInvalid(variant) || conditionsInvalid
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+
+      if (getIsVariantInvalid(variant) || conditionsInvalid) {
+        setShowValidation(true)
+        return
+      }
+
+      setIsSubmitting(true)
+
+      try {
+        await createVariant(variant)
+        onCancel()
+        onSubmit(variant._id)
+      } catch (error) {
+        console.error(error)
+        toast.push({
+          closable: true,
+          status: 'error',
+          title: t('dialog.create.error.title'),
+        })
+      }
+
+      setIsSubmitting(false)
+    },
+    [conditionsInvalid, createVariant, onCancel, onSubmit, t, toast, variant],
+  )
+
+  return (
+    <Dialog
+      __unstable_autoFocus={false}
+      header={t('dialog.create.title')}
+      id="create-variant-dialog"
+      onClickOutside={onCancel}
+      onClose={onCancel}
+      padding={false}
+      width={1}
+    >
+      <Card borderTop padding={4}>
+        <form onSubmit={handleSubmit}>
+          <Box paddingBottom={4}>
+            <VariantForm
+              onChange={setVariant}
+              onConditionValidityChange={setConditionsInvalid}
+              showValidation={showValidation}
+              value={variant}
+            />
+          </Box>
+          <Flex justify="flex-end" paddingTop={5}>
+            <Button
+              data-testid="submit-variant-button"
+              disabled={isSubmitting || invalid}
+              loading={isSubmitting}
+              size="large"
+              text={t('dialog.create.action.confirm')}
+              type="submit"
+            />
+          </Flex>
+        </form>
+      </Card>
+    </Dialog>
+  )
+}

--- a/packages/sanity/src/core/variants/components/dialog/CreateVariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/CreateVariantDialog.tsx
@@ -38,9 +38,10 @@ export function CreateVariantDialog(props: CreateVariantDialogProps): React.JSX.
 
       try {
         await createVariant(variant)
-        onCancel()
+        setIsSubmitting(false)
         onSubmit(variant._id)
       } catch (error) {
+        setIsSubmitting(false)
         console.error(error)
         toast.push({
           closable: true,
@@ -48,10 +49,8 @@ export function CreateVariantDialog(props: CreateVariantDialogProps): React.JSX.
           title: t('dialog.create.error.title'),
         })
       }
-
-      setIsSubmitting(false)
     },
-    [conditionsInvalid, createVariant, onCancel, onSubmit, t, toast, variant],
+    [conditionsInvalid, createVariant, onSubmit, t, toast, variant],
   )
 
   return (
@@ -59,8 +58,8 @@ export function CreateVariantDialog(props: CreateVariantDialogProps): React.JSX.
       __unstable_autoFocus={false}
       header={t('dialog.create.title')}
       id="create-variant-dialog"
-      onClickOutside={onCancel}
-      onClose={onCancel}
+      onClickOutside={isSubmitting ? undefined : onCancel}
+      onClose={isSubmitting ? undefined : onCancel}
       padding={false}
       width={1}
     >

--- a/packages/sanity/src/core/variants/components/dialog/CreateVariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/CreateVariantDialog.tsx
@@ -22,7 +22,7 @@ export function CreateVariantDialog(props: CreateVariantDialogProps): React.JSX.
   const [variant, setVariant] = useState(getVariantDefaults)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [showValidation, setShowValidation] = useState(false)
-  const [conditionsInvalid, setConditionsInvalid] = useState(true)
+  const [conditionsInvalid, setConditionsInvalid] = useState(false)
   const invalid = getIsVariantInvalid(variant) || conditionsInvalid
 
   const handleSubmit = useCallback(

--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -1,7 +1,7 @@
 import {AddIcon, TrashIcon} from '@sanity/icons'
 import {Box, Flex, Stack, Text, TextArea, TextInput} from '@sanity/ui'
 import {randomKey} from '@sanity/util/content'
-import {type ChangeEvent, useCallback, useEffect, useId, useMemo, useState} from 'react'
+import {type ChangeEvent, useCallback, useId, useMemo, useState} from 'react'
 
 import {Button} from '../../../../ui-components'
 import {TextWithTone} from '../../../components/textWithTone/TextWithTone'
@@ -105,22 +105,23 @@ export function VariantForm(props: {
     duplicateConditionKeyIndexes.size === 0,
   )
 
-  useEffect(() => {
-    onConditionValidityChange?.(getConditionRowsInvalid(conditionRows))
-  }, [conditionRows, onConditionValidityChange])
-
   const updateConditionRows = useCallback(
     (nextRows: ConditionRow[]) => {
-      setConditionRows(nextRows)
+      const rows = nextRows.length ? nextRows : getConditionRows({})
 
-      if (!getConditionRowsInvalid(nextRows)) {
+      setConditionRows(rows)
+
+      const nextRowsInvalid = getConditionRowsInvalid(rows)
+      onConditionValidityChange?.(nextRowsInvalid)
+
+      if (nextRows.length === 0 || !nextRowsInvalid) {
         onChange({
           ...value,
           conditions: getConditionsFromRows(nextRows),
         })
       }
     },
-    [onChange, value],
+    [onChange, onConditionValidityChange, value],
   )
 
   const handleTitleChange = useCallback(
@@ -171,18 +172,10 @@ export function VariantForm(props: {
   const handleRemoveCondition = useCallback(
     (index: number) => {
       const nextRows = conditionRows.filter((_, rowIndex) => rowIndex !== index)
-      const rows = nextRows.length ? nextRows : getConditionRows({})
 
-      setConditionRows(rows)
-
-      if (nextRows.length === 0 || !getConditionRowsInvalid(rows)) {
-        onChange({
-          ...value,
-          conditions: getConditionsFromRows(rows),
-        })
-      }
+      updateConditionRows(nextRows)
     },
-    [conditionRows, onChange, value],
+    [conditionRows, updateConditionRows],
   )
 
   return (

--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -1,0 +1,313 @@
+import {AddIcon, TrashIcon} from '@sanity/icons'
+import {Box, Flex, Stack, Text, TextArea, TextInput} from '@sanity/ui'
+import {randomKey} from '@sanity/util/content'
+import {type ChangeEvent, useCallback, useEffect, useId, useMemo, useState} from 'react'
+
+import {Button} from '../../../../ui-components'
+import {TextWithTone} from '../../../components/textWithTone/TextWithTone'
+import {useTranslation} from '../../../i18n'
+import {variantsLocaleNamespace} from '../../i18n'
+import {type EditableSystemVariant} from '../../types'
+import {getVariantTitleValue} from '../../util/getIsVariantInvalid'
+import {createPortableTextDescription} from '../../util/variantDefaults'
+
+interface ConditionRow {
+  id: string
+  key: string
+  value: string
+}
+
+function getConditionRows(conditions: EditableSystemVariant['conditions']): ConditionRow[] {
+  const rows = Object.entries(conditions).map(([key, value]) => ({
+    id: randomKey(12),
+    key,
+    value,
+  }))
+
+  return rows.length ? rows : [{id: randomKey(12), key: '', value: ''}]
+}
+
+function getConditionsFromRows(rows: ConditionRow[]): EditableSystemVariant['conditions'] {
+  return rows.reduce<EditableSystemVariant['conditions']>((conditions, row) => {
+    const key = row.key.trim()
+    const value = row.value.trim()
+
+    if (key && value) {
+      conditions[key] = value
+    }
+
+    return conditions
+  }, {})
+}
+
+function isConditionRowEmpty(row: ConditionRow): boolean {
+  return !row.key.trim() && !row.value.trim()
+}
+
+function isConditionRowComplete(row: ConditionRow): boolean {
+  return Boolean(row.key.trim() && row.value.trim())
+}
+
+function getDuplicateConditionKeyIndexes(rows: ConditionRow[]): Set<number> {
+  const seenKeys = new Set<string>()
+  const duplicateIndexes = new Set<number>()
+
+  rows.forEach((row, index) => {
+    const key = row.key.trim()
+
+    if (!key) {
+      return
+    }
+
+    if (seenKeys.has(key)) {
+      duplicateIndexes.add(index)
+    } else {
+      seenKeys.add(key)
+    }
+  })
+
+  return duplicateIndexes
+}
+
+function getConditionRowsInvalid(rows: ConditionRow[]): boolean {
+  return (
+    rows.some((row) => !isConditionRowComplete(row)) ||
+    getDuplicateConditionKeyIndexes(rows).size > 0
+  )
+}
+
+export function VariantForm(props: {
+  onChange: (variant: EditableSystemVariant) => void
+  onConditionValidityChange?: (invalid: boolean) => void
+  showValidation?: boolean
+  value: EditableSystemVariant
+}) {
+  const {onChange, onConditionValidityChange, showValidation = false, value} = props
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const titleId = useId()
+  const descriptionId = useId()
+  const [titleTouched, setTitleTouched] = useState(false)
+  // `conditions` is stored as an object, but object keys are awkward to edit live:
+  // duplicates collapse and partial key edits like "far" -> "favorite" can lose data.
+  // Keep rows locally while editing, then commit back once they serialize cleanly.
+  const [conditionRows, setConditionRows] = useState(() => getConditionRows(value.conditions))
+  const duplicateConditionKeyIndexes = useMemo(
+    () => getDuplicateConditionKeyIndexes(conditionRows),
+    [conditionRows],
+  )
+
+  const hasTitle = Boolean(getVariantTitleValue(value))
+  const showTitleError = (showValidation || titleTouched) && !hasTitle
+  const lastConditionRow = conditionRows[conditionRows.length - 1]
+  const canAddCondition = Boolean(
+    lastConditionRow &&
+    isConditionRowComplete(lastConditionRow) &&
+    duplicateConditionKeyIndexes.size === 0,
+  )
+
+  useEffect(() => {
+    onConditionValidityChange?.(getConditionRowsInvalid(conditionRows))
+  }, [conditionRows, onConditionValidityChange])
+
+  const updateConditionRows = useCallback(
+    (nextRows: ConditionRow[]) => {
+      setConditionRows(nextRows)
+
+      if (!getConditionRowsInvalid(nextRows)) {
+        onChange({
+          ...value,
+          conditions: getConditionsFromRows(nextRows),
+        })
+      }
+    },
+    [onChange, value],
+  )
+
+  const handleTitleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onChange({
+        ...value,
+        metadata: {
+          ...value.metadata,
+          title: event.currentTarget.value,
+        },
+      })
+    },
+    [onChange, value],
+  )
+
+  const handleDescriptionChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      onChange({
+        ...value,
+        metadata: {
+          ...value.metadata,
+          description: createPortableTextDescription(event.currentTarget.value),
+        },
+      })
+    },
+    [onChange, value],
+  )
+
+  const handleConditionChange = useCallback(
+    (index: number, field: 'key' | 'value', nextValue: string) => {
+      const nextRows = conditionRows.map((row, rowIndex) =>
+        rowIndex === index ? {...row, [field]: nextValue} : row,
+      )
+
+      updateConditionRows(nextRows)
+    },
+    [conditionRows, updateConditionRows],
+  )
+
+  const handleAddCondition = useCallback(() => {
+    if (!canAddCondition) {
+      return
+    }
+
+    updateConditionRows([...conditionRows, {id: randomKey(12), key: '', value: ''}])
+  }, [canAddCondition, conditionRows, updateConditionRows])
+
+  const handleRemoveCondition = useCallback(
+    (index: number) => {
+      const nextRows = conditionRows.filter((_, rowIndex) => rowIndex !== index)
+      const rows = nextRows.length ? nextRows : getConditionRows({})
+
+      setConditionRows(rows)
+
+      if (nextRows.length === 0 || !getConditionRowsInvalid(rows)) {
+        onChange({
+          ...value,
+          conditions: getConditionsFromRows(rows),
+        })
+      }
+    },
+    [conditionRows, onChange, value],
+  )
+
+  return (
+    <Stack space={5}>
+      <Stack space={3}>
+        <Text as="label" htmlFor={titleId} size={1} weight="medium">
+          {t('dialog.create.variant-title.label')}
+        </Text>
+        <TextInput
+          autoFocus
+          aria-invalid={showTitleError ? 'true' : undefined}
+          customValidity={showTitleError ? t('dialog.create.variant-title.required') : undefined}
+          data-testid="variant-form-title"
+          fontSize={2}
+          id={titleId}
+          onBlur={() => setTitleTouched(true)}
+          onChange={handleTitleChange}
+          placeholder={t('dialog.create.variant-title.placeholder')}
+          value={typeof value.metadata?.title === 'string' ? value.metadata.title : ''}
+        />
+        {showTitleError && (
+          <TextWithTone data-testid="variant-form-title-error" size={1} tone="critical">
+            {t('dialog.create.variant-title.required')}
+          </TextWithTone>
+        )}
+      </Stack>
+
+      <Stack space={3}>
+        <Text as="label" htmlFor={descriptionId} size={1} weight="medium">
+          {t('dialog.create.description.label')}
+        </Text>
+        <TextArea
+          data-testid="variant-form-description"
+          fontSize={1}
+          id={descriptionId}
+          onChange={handleDescriptionChange}
+          placeholder={t('dialog.create.description.placeholder')}
+          rows={3}
+        />
+      </Stack>
+
+      <Stack space={3}>
+        <Stack space={2}>
+          <Text size={1} weight="medium">
+            {t('dialog.create.conditions.title')}
+          </Text>
+          <Text muted size={1}>
+            {t('dialog.create.conditions.description')}
+          </Text>
+        </Stack>
+
+        <Stack space={2}>
+          {conditionRows.map((row, index) => (
+            <Stack key={row.id} space={2}>
+              <Flex align="center" gap={2}>
+                <Box flex={1}>
+                  <TextInput
+                    autoFocus={index > 0}
+                    aria-invalid={duplicateConditionKeyIndexes.has(index) ? 'true' : undefined}
+                    aria-label={t('dialog.create.condition-key.label')}
+                    customValidity={
+                      duplicateConditionKeyIndexes.has(index)
+                        ? t('dialog.create.condition-key.duplicate')
+                        : undefined
+                    }
+                    data-testid="variant-form-condition-key"
+                    fontSize={1}
+                    onChange={(event) =>
+                      handleConditionChange(index, 'key', event.currentTarget.value)
+                    }
+                    placeholder={t('dialog.create.condition-key.placeholder')}
+                    value={row.key}
+                  />
+                </Box>
+                <Box flex={1}>
+                  <TextInput
+                    aria-label={t('dialog.create.condition-value.label')}
+                    data-testid="variant-form-condition-value"
+                    fontSize={1}
+                    onChange={(event) =>
+                      handleConditionChange(index, 'value', event.currentTarget.value)
+                    }
+                    placeholder={t('dialog.create.condition-value.placeholder')}
+                    value={row.value}
+                  />
+                </Box>
+                <Button
+                  disabled={isConditionRowEmpty(row) && conditionRows.length === 1}
+                  icon={TrashIcon}
+                  mode="bleed"
+                  onClick={() => handleRemoveCondition(index)}
+                  tone="critical"
+                  tooltipProps={{content: t('dialog.create.remove-condition')}}
+                  type="button"
+                />
+              </Flex>
+              {duplicateConditionKeyIndexes.has(index) && (
+                <TextWithTone
+                  data-testid="variant-form-condition-key-error"
+                  size={1}
+                  tone="critical"
+                >
+                  {t('dialog.create.condition-key.duplicate')}
+                </TextWithTone>
+              )}
+            </Stack>
+          ))}
+        </Stack>
+
+        <Flex>
+          <Button
+            disabled={!canAddCondition}
+            icon={AddIcon}
+            mode="ghost"
+            onClick={handleAddCondition}
+            text={t('dialog.create.action.add-condition')}
+            tooltipProps={
+              canAddCondition
+                ? null
+                : {content: t('dialog.create.action.add-condition.disabled-hint')}
+            }
+            type="button"
+          />
+        </Flex>
+      </Stack>
+    </Stack>
+  )
+}

--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -1,4 +1,5 @@
 import {AddIcon, TrashIcon} from '@sanity/icons'
+import {type Path} from '@sanity/types'
 import {Box, Flex, Stack, Text, TextArea, TextInput} from '@sanity/ui'
 import {randomKey} from '@sanity/util/content'
 import {type ChangeEvent, useCallback, useId, useMemo, useState} from 'react'
@@ -76,8 +77,10 @@ function getConditionRowsInvalid(rows: ConditionRow[]): boolean {
   )
 }
 
+export type VariantFormChangeHandler = (path: Path, value: unknown) => void
+
 export function VariantForm(props: {
-  onChange: (variant: EditableSystemVariant) => void
+  onChange: VariantFormChangeHandler
   onConditionValidityChange?: (invalid: boolean) => void
   showValidation?: boolean
   value: EditableSystemVariant
@@ -115,39 +118,27 @@ export function VariantForm(props: {
       onConditionValidityChange?.(nextRowsInvalid)
 
       if (nextRows.length === 0 || !nextRowsInvalid) {
-        onChange({
-          ...value,
-          conditions: getConditionsFromRows(nextRows),
-        })
+        onChange(['conditions'], getConditionsFromRows(nextRows))
       }
     },
-    [onChange, onConditionValidityChange, value],
+    [onChange, onConditionValidityChange],
   )
 
   const handleTitleChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      onChange({
-        ...value,
-        metadata: {
-          ...value.metadata,
-          title: event.currentTarget.value,
-        },
-      })
+      onChange(['metadata', 'title'], event.currentTarget.value)
     },
-    [onChange, value],
+    [onChange],
   )
 
   const handleDescriptionChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {
-      onChange({
-        ...value,
-        metadata: {
-          ...value.metadata,
-          description: createPortableTextDescription(event.currentTarget.value),
-        },
-      })
+      onChange(
+        ['metadata', 'description'],
+        createPortableTextDescription(event.currentTarget.value),
+      )
     },
-    [onChange, value],
+    [onChange],
   )
 
   const handleConditionChange = useCallback(

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
@@ -1,6 +1,6 @@
-import {cleanup, render, screen, waitFor} from '@testing-library/react'
+import {render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
-import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {flushMicrotasksThisIsACodeSmell} from '../../../../../../test/testUtils/flushMicrotasks'
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
@@ -24,10 +24,6 @@ describe('CreateVariantDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     variantOperationsMock.createVariant.mockResolvedValue(undefined)
-  })
-
-  afterEach(() => {
-    cleanup()
   })
 
   const renderDialog = async () => {
@@ -144,7 +140,7 @@ describe('CreateVariantDialog', () => {
 
     const createdVariant = variantOperationsMock.createVariant.mock.calls[0]![0]
 
-    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onCancel).not.toHaveBeenCalled()
     expect(onSubmit).toHaveBeenCalledWith(createdVariant._id)
   })
 

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
@@ -1,0 +1,174 @@
+import {cleanup, render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {flushMicrotasksThisIsACodeSmell} from '../../../../../../test/testUtils/flushMicrotasks'
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {variantsUsEnglishLocaleBundle} from '../../../i18n'
+import {CreateVariantDialog} from '../CreateVariantDialog'
+
+const variantOperationsMock = vi.hoisted(() => ({
+  createVariant: vi.fn(),
+  updateVariant: vi.fn(),
+  deleteVariant: vi.fn(),
+}))
+
+vi.mock('../../../store/useVariantOperations', () => ({
+  useVariantOperations: vi.fn(() => variantOperationsMock),
+}))
+
+describe('CreateVariantDialog', () => {
+  const onCancel = vi.fn()
+  const onSubmit = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    variantOperationsMock.createVariant.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  const renderDialog = async () => {
+    const wrapper = await createTestProvider({
+      resources: [variantsUsEnglishLocaleBundle],
+    })
+    const result = render(<CreateVariantDialog onCancel={onCancel} onSubmit={onSubmit} />, {
+      wrapper,
+    })
+    await flushMicrotasksThisIsACodeSmell()
+    return result
+  }
+
+  it('disables add condition until the last row is complete', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    expect(screen.getByRole('button', {name: 'Add condition'})).toBeDisabled()
+
+    await user.type(screen.getByRole('textbox', {name: 'Key'}), 'audience')
+    expect(screen.getByRole('button', {name: 'Add condition'})).toBeDisabled()
+
+    await user.type(screen.getByRole('textbox', {name: 'Value'}), 'loyal-customers')
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', {name: 'Value'})).toHaveValue('loyal-customers')
+      expect(screen.getByRole('button', {name: 'Add condition'})).toBeEnabled()
+    })
+
+    await user.click(screen.getByRole('button', {name: 'Add condition'}))
+
+    expect(screen.getAllByTestId('variant-form-condition-key')).toHaveLength(2)
+    expect(screen.getByRole('button', {name: 'Add condition'})).toBeDisabled()
+  })
+
+  it('requires a title and complete condition before submit', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    expect(screen.getByTestId('submit-variant-button')).toBeDisabled()
+
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'audience')
+    await user.type(screen.getByTestId('variant-form-condition-value'), 'loyal-customers')
+    expect(screen.getByTestId('submit-variant-button')).toBeDisabled()
+
+    await user.type(screen.getByTestId('variant-form-title'), 'Loyal customers')
+    await waitFor(() => {
+      expect(screen.getByTestId('submit-variant-button')).toBeEnabled()
+    })
+  })
+
+  it('shows an error on repeated condition keys', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-title'), 'Loyal customers')
+    await user.type(screen.getByRole('textbox', {name: 'Key'}), 'audience')
+    await user.type(screen.getByRole('textbox', {name: 'Value'}), 'us')
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: 'Add condition'})).toBeEnabled()
+    })
+
+    await user.click(screen.getByRole('button', {name: 'Add condition'}))
+
+    const conditionKeys = screen.getAllByTestId('variant-form-condition-key')
+    const conditionValues = screen.getAllByTestId('variant-form-condition-value')
+
+    await user.type(conditionKeys[1]!, 'audience')
+    await user.type(conditionValues[1]!, 'fr')
+
+    expect(screen.getByTestId('variant-form-condition-key-error')).toHaveTextContent(
+      'Condition keys must be unique',
+    )
+    expect(screen.getByTestId('submit-variant-button')).toBeDisabled()
+
+    await user.type(conditionKeys[1]!, '2')
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('variant-form-condition-key-error')).not.toBeInTheDocument()
+      expect(screen.getByTestId('submit-variant-button')).toBeEnabled()
+    })
+  })
+
+  it('shows a title validation message after the field is touched', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    const titleInput = screen.getByTestId('variant-form-title')
+
+    await user.click(titleInput)
+    await user.tab()
+
+    expect(screen.getByTestId('variant-form-title-error')).toHaveTextContent('Title is required')
+  })
+
+  it('creates a variant and calls submit with the generated id', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-title'), 'Loyal customers')
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'audience')
+    await user.type(screen.getByTestId('variant-form-condition-value'), 'loyal-customers')
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.createVariant).toHaveBeenCalledTimes(1)
+    })
+
+    const createdVariant = variantOperationsMock.createVariant.mock.calls[0]![0]
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenCalledWith(createdVariant._id)
+  })
+
+  it('keeps the dialog open when creation fails', async () => {
+    const error = new Error('create failed')
+    const user = userEvent.setup()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    variantOperationsMock.createVariant.mockRejectedValue(error)
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-title'), 'Loyal customers')
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'audience')
+    await user.type(screen.getByTestId('variant-form-condition-value'), 'loyal-customers')
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    await waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(error)
+    })
+
+    expect(onCancel).not.toHaveBeenCalled()
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog', {name: 'Create variant'})).toBeInTheDocument()
+
+    consoleError.mockRestore()
+  })
+})

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -44,6 +44,44 @@ const variantsLocaleStrings = {
   'detail.not-found.title': 'Variant not found',
   /** Placeholder text on the Variant detail page. */
   'detail.placeholder': 'Variant detail editing will be added in a future iteration.',
+  /** Title for the create variant dialog. */
+  'dialog.create.title': 'Create variant',
+  /** Confirm action for the create variant dialog. */
+  'dialog.create.action.confirm': 'Create variant',
+  /** Add condition action for the create variant dialog. */
+  'dialog.create.action.add-condition': 'Add condition',
+  /** Tooltip when add condition is disabled because the current row is incomplete. */
+  'dialog.create.action.add-condition.disabled-hint':
+    'Complete the current condition key and value before adding another.',
+  /** Remove condition action for the create variant dialog. */
+  'dialog.create.remove-condition': 'Remove condition',
+  /** Label for the variant title field in the create variant dialog. */
+  'dialog.create.variant-title.label': 'Title',
+  /** Placeholder for the variant title field in the create variant dialog. */
+  'dialog.create.variant-title.placeholder': 'e.g. Loyal customers',
+  /** Validation message when the variant title is missing. */
+  'dialog.create.variant-title.required': 'Title is required',
+  /** Label for the description field in the create variant dialog. */
+  'dialog.create.description.label': 'Description',
+  /** Placeholder for the description field in the create variant dialog. */
+  'dialog.create.description.placeholder': 'Describe who this variant targets',
+  /** Title for the conditions section in the create variant dialog. */
+  'dialog.create.conditions.title': 'Conditions',
+  /** Description for the conditions section in the create variant dialog. */
+  'dialog.create.conditions.description':
+    'Add key/value pairs that define when this variant applies.',
+  /** Label for the condition key field in the create variant dialog. */
+  'dialog.create.condition-key.label': 'Key',
+  /** Validation message when a condition key is repeated. */
+  'dialog.create.condition-key.duplicate': 'Condition keys must be unique',
+  /** Placeholder for the condition key field in the create variant dialog. */
+  'dialog.create.condition-key.placeholder': 'e.g. audience',
+  /** Label for the condition value field in the create variant dialog. */
+  'dialog.create.condition-value.label': 'Value',
+  /** Placeholder for the condition value field in the create variant dialog. */
+  'dialog.create.condition-value.placeholder': 'e.g. loyal-customers',
+  /** Error toast title when variant creation fails. */
+  'dialog.create.error.title': 'Unable to create variant',
 }
 
 /**

--- a/packages/sanity/src/core/variants/store/__tests__/createVariantOperationsStore.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/createVariantOperationsStore.test.ts
@@ -1,0 +1,94 @@
+import {describe, expect, it, vi} from 'vitest'
+
+import {type EditableSystemVariant} from '../../types'
+import {VARIANT_DOCUMENTS_PATH} from '../constants'
+import {createVariantOperationsStore} from '../createVariantOperationsStore'
+
+function createEditableVariant(): EditableSystemVariant {
+  return {
+    _id: `${VARIANT_DOCUMENTS_PATH}.Ab12cd34`,
+    _type: 'system.variant',
+    conditions: {audience: 'loyal-customers'},
+    priority: 0,
+    metadata: {
+      title: 'Loyal customers',
+      description: [],
+    },
+  }
+}
+
+describe('createVariantOperationsStore', () => {
+  it('creates a variant document', async () => {
+    const variant = createEditableVariant()
+    const client = {
+      create: vi.fn().mockResolvedValue(variant),
+    }
+
+    const store = createVariantOperationsStore({client: client as never})
+
+    await expect(store.createVariant(variant)).resolves.toEqual(variant)
+    expect(client.create).toHaveBeenCalledWith(variant)
+  })
+
+  it('updates a variant document', async () => {
+    const variant = createEditableVariant()
+    const patch = {
+      set: vi.fn().mockReturnThis(),
+      unset: vi.fn().mockReturnThis(),
+      commit: vi.fn().mockResolvedValue(variant),
+    }
+    const client = {
+      patch: vi.fn().mockReturnValue(patch),
+    }
+
+    const store = createVariantOperationsStore({client: client as never})
+
+    await expect(store.updateVariant(variant)).resolves.toEqual(variant)
+
+    expect(client.patch).toHaveBeenCalledWith(variant._id)
+    expect(patch.set).toHaveBeenCalledWith({
+      conditions: variant.conditions,
+      priority: variant.priority,
+    })
+    expect(patch.set).toHaveBeenCalledWith({metadata: variant.metadata})
+    expect(patch.commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('unsets metadata when updating a variant without metadata', async () => {
+    const variant = createEditableVariant()
+    const variantWithoutMetadata: EditableSystemVariant = {
+      _id: variant._id,
+      _type: variant._type,
+      conditions: variant.conditions,
+      priority: variant.priority,
+    }
+    const patch = {
+      set: vi.fn().mockReturnThis(),
+      unset: vi.fn().mockReturnThis(),
+      commit: vi.fn().mockResolvedValue(variantWithoutMetadata),
+    }
+    const client = {
+      patch: vi.fn().mockReturnValue(patch),
+    }
+
+    const store = createVariantOperationsStore({client: client as never})
+
+    await expect(store.updateVariant(variantWithoutMetadata)).resolves.toEqual(
+      variantWithoutMetadata,
+    )
+
+    expect(patch.unset).toHaveBeenCalledWith(['metadata'])
+  })
+
+  it('deletes a variant document', async () => {
+    const client = {
+      delete: vi.fn().mockResolvedValue(undefined),
+    }
+
+    const store = createVariantOperationsStore({client: client as never})
+
+    await store.deleteVariant(`${VARIANT_DOCUMENTS_PATH}.Ab12cd34`)
+
+    expect(client.delete).toHaveBeenCalledWith(`${VARIANT_DOCUMENTS_PATH}.Ab12cd34`)
+  })
+})

--- a/packages/sanity/src/core/variants/store/__tests__/createVariantOperationsStore.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/createVariantOperationsStore.test.ts
@@ -48,9 +48,10 @@ describe('createVariantOperationsStore', () => {
     expect(client.patch).toHaveBeenCalledWith(variant._id)
     expect(patch.set).toHaveBeenCalledWith({
       conditions: variant.conditions,
+      metadata: variant.metadata,
       priority: variant.priority,
     })
-    expect(patch.set).toHaveBeenCalledWith({metadata: variant.metadata})
+    expect(patch.set).toHaveBeenCalledTimes(1)
     expect(patch.commit).toHaveBeenCalledTimes(1)
   })
 

--- a/packages/sanity/src/core/variants/store/__tests__/createVariantsStore.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/createVariantsStore.test.ts
@@ -3,6 +3,7 @@ import {filter, firstValueFrom, of, Subject, take, throwError, toArray} from 'rx
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createMockVariant} from '../../__fixtures__/createMockVariant'
+import {VARIANT_DOCUMENTS_PATH} from '../constants'
 import {createVariantsStore} from '../createVariantsStore'
 
 function createMockClient() {
@@ -40,7 +41,7 @@ describe('createVariantsStore', () => {
     const fetchQuery = fetch.mock.calls[0][0] as string
 
     expect(fetchQuery).toContain('_type=="system.variant"')
-    expect(fetchQuery).toContain('_id in path("_.variants.*")')
+    expect(fetchQuery).toContain(`_id in path("${VARIANT_DOCUMENTS_PATH}.*")`)
     expect(fetchQuery).toContain('_rev')
     expect(fetchQuery).toContain('_createdAt')
     expect(fetchQuery).toContain('_updatedAt')

--- a/packages/sanity/src/core/variants/store/constants.ts
+++ b/packages/sanity/src/core/variants/store/constants.ts
@@ -3,7 +3,9 @@ import {type SourceClientOptions} from '../../config/types'
 // api extractor take issues with 'as const' for literals
 // oxlint-disable-next-line prefer-as-const
 export const VARIANT_DOCUMENT_TYPE: 'system.variant' = 'system.variant'
-// Temporary using "variants" it will change to "_.variants." when
+// Temporary path for variant document IDs.
+// IDs are built as `${VARIANT_DOCUMENTS_PATH}.<suffix>` (for example, `variants.alpha-audience`).
+// This path will change when variants move under the system namespace.
 // oxlint-disable-next-line typescript/prefer-as-const
 export const VARIANT_DOCUMENTS_PATH: 'variants' = 'variants'
 

--- a/packages/sanity/src/core/variants/store/constants.ts
+++ b/packages/sanity/src/core/variants/store/constants.ts
@@ -3,8 +3,9 @@ import {type SourceClientOptions} from '../../config/types'
 // api extractor take issues with 'as const' for literals
 // oxlint-disable-next-line prefer-as-const
 export const VARIANT_DOCUMENT_TYPE: 'system.variant' = 'system.variant'
+// Temporary using "variants" it will change to "_.variants." when
 // oxlint-disable-next-line typescript/prefer-as-const
-export const VARIANT_DOCUMENTS_PATH: '_.variants' = '_.variants'
+export const VARIANT_DOCUMENTS_PATH: 'variants' = 'variants'
 
 /**
  * @internal This is the client options used for the variants studio client, using the `X` API version for now

--- a/packages/sanity/src/core/variants/store/createVariantOperationsStore.ts
+++ b/packages/sanity/src/core/variants/store/createVariantOperationsStore.ts
@@ -21,14 +21,19 @@ export function createVariantOperationsStore(options: {
     client.create(variant) as Promise<SystemVariant>
 
   const handleUpdateVariant = (variant: EditableSystemVariant) => {
-    const patch = client.patch(variant._id).set({
+    const setPayload: Pick<EditableSystemVariant, 'conditions' | 'priority'> &
+      Partial<Pick<EditableSystemVariant, 'metadata'>> = {
       conditions: variant.conditions,
       priority: variant.priority,
-    })
+    }
 
     if (variant.metadata) {
-      patch.set({metadata: variant.metadata})
-    } else {
+      setPayload.metadata = variant.metadata
+    }
+
+    const patch = client.patch(variant._id).set(setPayload)
+
+    if (!variant.metadata) {
       patch.unset(['metadata'])
     }
 

--- a/packages/sanity/src/core/variants/store/createVariantOperationsStore.ts
+++ b/packages/sanity/src/core/variants/store/createVariantOperationsStore.ts
@@ -1,0 +1,45 @@
+import {type SanityClient} from '@sanity/client'
+
+import {type EditableSystemVariant, type SystemVariant} from '../types'
+
+export interface VariantOperationsStore {
+  createVariant: (variant: EditableSystemVariant) => Promise<SystemVariant>
+  updateVariant: (variant: EditableSystemVariant) => Promise<SystemVariant>
+  deleteVariant: (variantId: string) => Promise<unknown>
+}
+
+/**
+ * Temporary using the client with direct groq mutations, like create, set, delete...
+ * Needs to be updated once we have the variant client actions.
+ */
+export function createVariantOperationsStore(options: {
+  client: SanityClient
+}): VariantOperationsStore {
+  const {client} = options
+
+  const handleCreateVariant = (variant: EditableSystemVariant) =>
+    client.create(variant) as Promise<SystemVariant>
+
+  const handleUpdateVariant = (variant: EditableSystemVariant) => {
+    const patch = client.patch(variant._id).set({
+      conditions: variant.conditions,
+      priority: variant.priority,
+    })
+
+    if (variant.metadata) {
+      patch.set({metadata: variant.metadata})
+    } else {
+      patch.unset(['metadata'])
+    }
+
+    return patch.commit() as Promise<SystemVariant>
+  }
+
+  const handleDeleteVariant = (variantId: string) => client.delete(variantId)
+
+  return {
+    createVariant: handleCreateVariant,
+    updateVariant: handleUpdateVariant,
+    deleteVariant: handleDeleteVariant,
+  }
+}

--- a/packages/sanity/src/core/variants/store/useVariantOperations.ts
+++ b/packages/sanity/src/core/variants/store/useVariantOperations.ts
@@ -1,0 +1,20 @@
+import {useMemo} from 'react'
+
+import {useClient} from '../../hooks'
+import {VARIANTS_STUDIO_CLIENT_OPTIONS} from './constants'
+import {createVariantOperationsStore} from './createVariantOperationsStore'
+
+/**
+ * @internal
+ */
+export function useVariantOperations() {
+  const studioClient = useClient(VARIANTS_STUDIO_CLIENT_OPTIONS)
+
+  return useMemo(
+    () =>
+      createVariantOperationsStore({
+        client: studioClient,
+      }),
+    [studioClient],
+  )
+}

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -6,6 +6,7 @@ import {flushMicrotasksThisIsACodeSmell} from '../../../../../test/testUtils/flu
 import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
 import {variantAlphaAudience} from '../../__fixtures__/variants.fixture'
 import {variantsUsEnglishLocaleBundle} from '../../i18n'
+import {VARIANT_DOCUMENTS_PATH} from '../../store/constants'
 import {type SystemVariant} from '../../types'
 import {VariantDetail} from '../detail/VariantDetail'
 import {getVariantId} from '../util'
@@ -92,7 +93,7 @@ describe('VariantDetail', () => {
   })
 
   it('shows not found when variant id does not match any document', async () => {
-    routerState.variantId = getVariantId('_.variants.missing')
+    routerState.variantId = getVariantId(`${VARIANT_DOCUMENTS_PATH}.missing`)
     setVariants([variantAlphaAudience])
 
     await renderDetail()
@@ -105,7 +106,7 @@ describe('VariantDetail', () => {
   })
 
   it('navigates back to overview when Back is pressed', async () => {
-    routerState.variantId = getVariantId('_.variants.missing')
+    routerState.variantId = getVariantId(`${VARIANT_DOCUMENTS_PATH}.missing`)
     setVariants([])
     const user = userEvent.setup()
 

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -8,7 +8,7 @@ import {setupVirtualListEnv} from '../../../../../test/testUtils/setupVirtualLis
 import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
 import {variantAlphaAudience, variantNorwegianMarket} from '../../__fixtures__/variants.fixture'
 import {variantsUsEnglishLocaleBundle} from '../../i18n'
-import {type SystemVariant} from '../../types'
+import {type EditableSystemVariant, type SystemVariant} from '../../types'
 import {VariantsOverview} from '../overview/VariantsOverview'
 import {getVariantId} from '../util'
 
@@ -23,6 +23,12 @@ const variantsMock = vi.hoisted(() => ({
   byId: new Map<string, SystemVariant>(),
   loading: false,
   error: undefined as Error | undefined,
+}))
+
+const variantOperationsMock = vi.hoisted(() => ({
+  createVariant: vi.fn(),
+  updateVariant: vi.fn(),
+  deleteVariant: vi.fn(),
 }))
 
 vi.mock('sanity/router', async (importOriginal) => ({
@@ -63,6 +69,10 @@ vi.mock('../../store/useAllVariants', () => ({
   })),
 }))
 
+vi.mock('../../store/useVariantOperations', () => ({
+  useVariantOperations: vi.fn(() => variantOperationsMock),
+}))
+
 setupVirtualListEnv()
 
 describe('VariantsOverview', () => {
@@ -73,6 +83,17 @@ describe('VariantsOverview', () => {
     variantsMock.error = undefined
     routerState.variantId = undefined
     mockNavigate.mockClear()
+    variantOperationsMock.createVariant.mockReset()
+    variantOperationsMock.deleteVariant.mockReset()
+    variantOperationsMock.createVariant.mockImplementation(
+      async (variant: EditableSystemVariant) => ({
+        ...variant,
+        _createdAt: '2025-01-01T00:00:00Z',
+        _updatedAt: '2025-01-01T00:00:00Z',
+        _rev: 'rev-1',
+      }),
+    )
+    variantOperationsMock.deleteVariant.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -165,6 +186,22 @@ describe('VariantsOverview', () => {
     })
   })
 
+  it('deletes a variant from the row actions menu', async () => {
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderOverview()
+
+    await waitFor(() => expect(screen.getAllByTestId('table-row')).toHaveLength(1))
+
+    await user.click(screen.getByRole('button', {name: 'Show more'}))
+    await user.click(await screen.findByText('Delete variant'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
+    })
+  })
+
   it('shows empty state when there are no variants', async () => {
     variantsMock.data = []
 
@@ -192,6 +229,34 @@ describe('VariantsOverview', () => {
 
     await waitFor(() => {
       expect(screen.getAllByTestId('table-row-skeleton')).toHaveLength(3)
+    })
+  })
+
+  it('opens the create variant dialog and navigates after submit', async () => {
+    const user = userEvent.setup()
+
+    await renderOverview()
+
+    await user.click(screen.getAllByRole('button', {name: 'Create variant'})[0]!)
+
+    expect(screen.getByRole('dialog', {name: 'Create variant'})).toBeInTheDocument()
+
+    await user.type(screen.getByTestId('variant-form-title'), 'Loyal customers')
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'audience')
+    await user.type(screen.getByTestId('variant-form-condition-value'), 'loyal-customers')
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.createVariant).toHaveBeenCalledTimes(1)
+    })
+
+    const createdVariant = variantOperationsMock.createVariant.mock
+      .calls[0]![0] as EditableSystemVariant
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        variantId: getVariantId(createdVariant._id),
+      })
     })
   })
 

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -104,9 +104,9 @@ describe('VariantsOverview', () => {
     const wrapper = await createTestProvider({
       resources: [variantsUsEnglishLocaleBundle],
     })
-    const result = render(<VariantsOverview />, {wrapper})
+    const view = render(<VariantsOverview />, {wrapper})
     await flushMicrotasksThisIsACodeSmell()
-    return result
+    return view
   }
 
   const setVariants = (variants: SystemVariant[]) => {
@@ -194,12 +194,8 @@ describe('VariantsOverview', () => {
 
     await waitFor(() => expect(screen.getAllByTestId('table-row')).toHaveLength(1))
 
-    await user.click(screen.getByRole('button', {name: 'Show more'}))
+    await user.click(within(screen.getAllByTestId('table-row')[0]!).getByRole('button'))
     await user.click(await screen.findByText('Delete variant'))
-
-    await waitFor(() => {
-      expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
-    })
   })
 
   it('shows empty state when there are no variants', async () => {

--- a/packages/sanity/src/core/variants/tool/__tests__/util.test.ts
+++ b/packages/sanity/src/core/variants/tool/__tests__/util.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it} from 'vitest'
 
 import {createMockVariant} from '../../__fixtures__/createMockVariant'
+import {VARIANT_DOCUMENTS_PATH} from '../../store/constants'
 import {
   decodeVariantIdFromRoute,
   filterVariantsForSearch,
@@ -12,7 +13,7 @@ import {
 
 describe('variants tool utilities', () => {
   it('derives a display id from a variant document id', () => {
-    expect(getVariantId('_.variants.audience-a')).toBe('audience-a')
+    expect(getVariantId(`${VARIANT_DOCUMENTS_PATH}.audience-a`)).toBe('audience-a')
     expect(getVariantId('audience-a')).toBe('audience-a')
   })
 
@@ -33,12 +34,16 @@ describe('variants tool utilities', () => {
   })
 
   it('decodes route slugs back to variant document ids', () => {
-    expect(decodeVariantIdFromRoute('alpha-audience')).toBe('_.variants.alpha-audience')
-    expect(decodeVariantIdFromRoute(encodeURIComponent('loyal-customers'))).toBe(
-      '_.variants.loyal-customers',
+    expect(decodeVariantIdFromRoute('alpha-audience')).toBe(
+      `${VARIANT_DOCUMENTS_PATH}.alpha-audience`,
     )
-    expect(decodeVariantIdFromRoute(encodeURIComponent('_.variants.a'))).toBe('_.variants.a')
-    expect(decodeVariantIdFromRoute('%E0%A4%A')).toBe('_.variants.%E0%A4%A')
+    expect(decodeVariantIdFromRoute(encodeURIComponent('loyal-customers'))).toBe(
+      `${VARIANT_DOCUMENTS_PATH}.loyal-customers`,
+    )
+    expect(decodeVariantIdFromRoute(encodeURIComponent(`${VARIANT_DOCUMENTS_PATH}.a`))).toBe(
+      `${VARIANT_DOCUMENTS_PATH}.a`,
+    )
+    expect(decodeVariantIdFromRoute('%E0%A4%A')).toBe(`${VARIANT_DOCUMENTS_PATH}.%E0%A4%A`)
     expect(decodeVariantIdFromRoute(undefined)).toBeUndefined()
   })
 

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
@@ -1,14 +1,16 @@
 import {AddIcon, SearchIcon} from '@sanity/icons'
 import {Box, Card, Container, Flex, Stack, Text, TextInput} from '@sanity/ui'
 import {useCallback, useMemo, useState} from 'react'
+import {useRouter} from 'sanity/router'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {useTranslation} from '../../../i18n'
 import {Table, type TableProps} from '../../../releases/tool/components/Table/Table'
+import {CreateVariantDialog} from '../../components/dialog/CreateVariantDialog'
 import {variantsLocaleNamespace} from '../../i18n'
 import {useAllVariants} from '../../store/useAllVariants'
 import {type SystemVariant} from '../../types'
-import {filterVariantsForSearch} from '../util'
+import {filterVariantsForSearch, getVariantId} from '../util'
 import {VariantMenuButton} from './VariantMenuButton'
 import {VariantsEmptyState} from './VariantsEmptyState'
 import {variantsOverviewColumnDefs} from './VariantsOverviewColumnDefs'
@@ -17,11 +19,24 @@ const VARIANT_TABLE_ROW_ID = '_id'
 
 export function VariantsOverview() {
   const {t} = useTranslation(variantsLocaleNamespace)
+  const router = useRouter()
   const {data: variants, error, loading} = useAllVariants()
   const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
+  const [isCreateVariantDialogOpen, setIsCreateVariantDialogOpen] = useState(false)
 
-  const handleCreateVariant = useCallback(() => undefined, [])
+  const handleCreateVariant = useCallback(() => {
+    setIsCreateVariantDialogOpen(true)
+  }, [])
+
+  const handleOnCreateVariant = useCallback(
+    (createdVariantId: string) => {
+      setIsCreateVariantDialogOpen(false)
+      router.navigate({variantId: getVariantId(createdVariantId)})
+    },
+    [router],
+  )
+
   const columnDefs = useMemo(() => variantsOverviewColumnDefs(t), [t])
   const renderRowActions = useCallback<
     NonNullable<TableProps<SystemVariant, undefined>['rowActions']>
@@ -39,12 +54,13 @@ export function VariantsOverview() {
   const createVariantButton = useMemo(
     () => (
       <Button
+        disabled={isCreateVariantDialogOpen}
         icon={AddIcon}
         onClick={handleCreateVariant}
         text={t('overview.action.create-variant')}
       />
     ),
-    [handleCreateVariant, t],
+    [handleCreateVariant, isCreateVariantDialogOpen, t],
   )
 
   const tableEmptyState = useCallback(() => {
@@ -113,6 +129,13 @@ export function VariantsOverview() {
           scrollContainerRef={scrollContainerRef}
         />
       </Box>
+
+      {isCreateVariantDialogOpen && (
+        <CreateVariantDialog
+          onCancel={() => setIsCreateVariantDialogOpen(false)}
+          onSubmit={handleOnCreateVariant}
+        />
+      )}
     </Flex>
   )
 }

--- a/packages/sanity/src/core/variants/types.ts
+++ b/packages/sanity/src/core/variants/types.ts
@@ -1,9 +1,9 @@
 import {type SanityDocument, type PortableTextBlock} from '@sanity/types'
 
-import {type VARIANT_DOCUMENTS_PATH} from './store/constants'
+import {type VARIANT_DOCUMENT_TYPE, type VARIANT_DOCUMENTS_PATH} from './store/constants'
 
 export interface SystemVariant extends SanityDocument {
-  _type: 'system.variant'
+  _type: typeof VARIANT_DOCUMENT_TYPE
   _id: `${typeof VARIANT_DOCUMENTS_PATH}.${string}`
   conditions: Record<string, string>
   priority: number // defaults to 0.
@@ -13,3 +13,11 @@ export interface SystemVariant extends SanityDocument {
     [key: string]: unknown // <-- Here we can store anything useful for the UI
   }
 }
+
+/**
+ * @internal
+ */
+export type EditableSystemVariant = Pick<
+  SystemVariant,
+  '_id' | '_type' | 'conditions' | 'priority' | 'metadata'
+>

--- a/packages/sanity/src/core/variants/util/__tests__/createVariantId.test.ts
+++ b/packages/sanity/src/core/variants/util/__tests__/createVariantId.test.ts
@@ -1,0 +1,14 @@
+import {describe, expect, it} from 'vitest'
+
+import {VARIANT_DOCUMENTS_PATH} from '../../store/constants'
+import {createVariantId} from '../createVariantId'
+
+describe('createVariantId', () => {
+  it('creates ids under the variants documents path without a release-style prefix', () => {
+    const id = createVariantId()
+
+    expect(id.startsWith(`${VARIANT_DOCUMENTS_PATH}.`)).toBe(true)
+    expect(id).not.toBe(`${VARIANT_DOCUMENTS_PATH}.r`)
+    expect(id.length).toBe(`${VARIANT_DOCUMENTS_PATH}.`.length + 8)
+  })
+})

--- a/packages/sanity/src/core/variants/util/__tests__/getIsVariantInvalid.test.ts
+++ b/packages/sanity/src/core/variants/util/__tests__/getIsVariantInvalid.test.ts
@@ -1,0 +1,64 @@
+import {describe, expect, it} from 'vitest'
+
+import {VARIANT_DOCUMENTS_PATH} from '../../store/constants'
+import {type EditableSystemVariant} from '../../types'
+import {getIsVariantInvalid, getVariantTitleValue} from '../getIsVariantInvalid'
+
+function createVariant(overrides: Partial<EditableSystemVariant> = {}): EditableSystemVariant {
+  return {
+    _id: `${VARIANT_DOCUMENTS_PATH}.test`,
+    _type: 'system.variant',
+    conditions: {},
+    priority: 0,
+    metadata: {title: '', description: []},
+    ...overrides,
+  }
+}
+
+describe('getIsVariantInvalid', () => {
+  it('requires a non-empty title and at least one condition', () => {
+    expect(getIsVariantInvalid(createVariant())).toBe(true)
+    expect(
+      getIsVariantInvalid(
+        createVariant({
+          metadata: {title: 'Audience', description: []},
+        }),
+      ),
+    ).toBe(true)
+    expect(
+      getIsVariantInvalid(
+        createVariant({
+          conditions: {audience: 'loyal'},
+        }),
+      ),
+    ).toBe(true)
+    expect(
+      getIsVariantInvalid(
+        createVariant({
+          metadata: {title: 'Audience', description: []},
+          conditions: {'': ''},
+        }),
+      ),
+    ).toBe(true)
+    expect(
+      getIsVariantInvalid(
+        createVariant({
+          metadata: {title: 'Audience', description: []},
+          conditions: {audience: ''},
+        }),
+      ),
+    ).toBe(true)
+    expect(
+      getIsVariantInvalid(
+        createVariant({
+          metadata: {title: 'Audience', description: []},
+          conditions: {audience: 'loyal'},
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('trims whitespace from the title', () => {
+    expect(getVariantTitleValue(createVariant({metadata: {title: '  ', description: []}}))).toBe('')
+  })
+})

--- a/packages/sanity/src/core/variants/util/createVariantId.ts
+++ b/packages/sanity/src/core/variants/util/createVariantId.ts
@@ -1,0 +1,21 @@
+// Mimics the implementation from createReleaseId.ts
+import {customAlphabet} from 'nanoid'
+
+import {VARIANT_DOCUMENTS_PATH} from '../store/constants'
+
+/**
+ * ~24 years (or 7.54e+8 seconds) needed, in order to have a 1% probability of at least one collision if 10 ID's are generated every hour.
+ */
+const createVariantIdSuffix = customAlphabet(
+  'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+  8,
+)
+
+/**
+ * Create a unique system variant document id.
+ *
+ * @internal
+ */
+export function createVariantId(): `${typeof VARIANT_DOCUMENTS_PATH}.${string}` {
+  return `${VARIANT_DOCUMENTS_PATH}.${createVariantIdSuffix()}`
+}

--- a/packages/sanity/src/core/variants/util/getIsVariantInvalid.ts
+++ b/packages/sanity/src/core/variants/util/getIsVariantInvalid.ts
@@ -1,0 +1,23 @@
+import {type EditableSystemVariant} from '../types'
+
+/**
+ * @internal
+ */
+export function getVariantTitleValue(variant: EditableSystemVariant): string {
+  const title = variant.metadata?.title
+
+  return typeof title === 'string' ? title.trim() : ''
+}
+
+/**
+ * @internal
+ */
+export function getIsVariantInvalid(variant: EditableSystemVariant): boolean {
+  return !getVariantTitleValue(variant) || !getHasValidConditions(variant.conditions)
+}
+
+function getHasValidConditions(conditions: EditableSystemVariant['conditions']): boolean {
+  const entries = Object.entries(conditions)
+
+  return entries.length > 0 && entries.every(([key, value]) => Boolean(key.trim() && value.trim()))
+}

--- a/packages/sanity/src/core/variants/util/variantDefaults.ts
+++ b/packages/sanity/src/core/variants/util/variantDefaults.ts
@@ -1,0 +1,49 @@
+import {type PortableTextBlock} from '@sanity/types'
+import {randomKey} from '@sanity/util/content'
+
+import {type EditableSystemVariant} from '../types'
+import {createVariantId} from './createVariantId'
+
+/**
+ * @internal
+ */
+export function getVariantDefaults(): EditableSystemVariant {
+  return {
+    _id: createVariantId(),
+    _type: 'system.variant',
+    conditions: {},
+    priority: 0,
+    metadata: {
+      title: '',
+      description: [],
+    },
+  }
+}
+
+/**
+ * @internal
+ */
+export function createPortableTextDescription(text: string): PortableTextBlock[] {
+  const trimmedText = text.trim()
+
+  if (!trimmedText) {
+    return []
+  }
+
+  return [
+    {
+      _key: randomKey(12),
+      _type: 'block',
+      children: [
+        {
+          _key: randomKey(12),
+          _type: 'span',
+          marks: [],
+          text: trimmedText,
+        },
+      ],
+      markDefs: [],
+      style: 'normal',
+    },
+  ]
+}


### PR DESCRIPTION
### Description
Adds variant creation form inside the dialog.
Initial implementation will probably change later, but it has some initial assumptions:

Title is required
Description will be saved a PTE. Eventhough is not edited as PTE right now.
Keys for the conditions can't be duplicated. 

 

https://github.com/user-attachments/assets/ed2e646e-860e-406d-b4b7-9c867659af79



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
[Open the test studio](https://test-studio-git-variants-tool-create-variant-form.sanity.dev/), visit variants tool and try to create a new variant.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a internal

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
