### PR TITLE
feat(core): add variant definition delete action

### DIFF
--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -12,6 +12,8 @@ const variantsLocaleStrings = {
   'overview.action.create-variant': 'Create variant',
   /** Label for the Variants overview delete action. */
   'overview.action.delete-variant': 'Delete variant',
+  /** Error toast title when variant deletion fails. */
+  'overview.action.delete-variant.error.title': 'Unable to delete variant',
   /** Link label for Variants overview documentation (empty state). */
   'overview.action.documentation': 'Documentation',
   /** Description for the Variants overview empty state. */

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantMenuButton.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantMenuButton.test.tsx
@@ -1,0 +1,82 @@
+import {render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {flushMicrotasksThisIsACodeSmell} from '../../../../../test/testUtils/flushMicrotasks'
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {variantAlphaAudience} from '../../__fixtures__/variants.fixture'
+import {variantsUsEnglishLocaleBundle} from '../../i18n'
+import {VariantMenuButton} from '../overview/VariantMenuButton'
+
+const variantOperationsMock = vi.hoisted(() => ({
+  createVariant: vi.fn(),
+  updateVariant: vi.fn(),
+  deleteVariant: vi.fn(),
+}))
+
+vi.mock('../../store/useVariantOperations', () => ({
+  useVariantOperations: vi.fn(() => variantOperationsMock),
+}))
+
+function createDeferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+
+  return {promise, resolve, reject}
+}
+
+describe('VariantMenuButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    variantOperationsMock.deleteVariant.mockResolvedValue(undefined)
+  })
+
+  const renderMenuButton = async () => {
+    const wrapper = await createTestProvider({
+      resources: [variantsUsEnglishLocaleBundle],
+    })
+    const result = render(<VariantMenuButton variant={variantAlphaAudience} />, {wrapper})
+    await flushMicrotasksThisIsACodeSmell()
+    return result
+  }
+
+  it('deletes the variant when delete is selected', async () => {
+    const user = userEvent.setup()
+
+    await renderMenuButton()
+
+    await user.click(screen.getByRole('button'))
+    await user.click(await screen.findByText('Delete variant'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
+    })
+  })
+
+  it('shows a loading state on the menu button while deleting', async () => {
+    const user = userEvent.setup()
+    const deleteDeferred = createDeferred()
+    variantOperationsMock.deleteVariant.mockReturnValue(deleteDeferred.promise)
+
+    await renderMenuButton()
+
+    const menuButton = screen.getByRole('button')
+
+    await user.click(menuButton)
+    await user.click(await screen.findByText('Delete variant'))
+
+    await waitFor(() => {
+      expect(menuButton).toBeDisabled()
+    })
+
+    deleteDeferred.resolve()
+
+    await waitFor(() => {
+      expect(menuButton).toBeEnabled()
+    })
+  })
+})

--- a/packages/sanity/src/core/variants/tool/overview/VariantMenuButton.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantMenuButton.tsx
@@ -1,24 +1,48 @@
-import {Menu} from '@sanity/ui'
-import {useCallback} from 'react'
+import {Menu, useToast} from '@sanity/ui'
+import {useCallback, useState} from 'react'
 
 import {MenuButton, MenuItem} from '../../../../ui-components'
 import {ContextMenuButton} from '../../../components/contextMenuButton'
 import {useTranslation} from '../../../i18n'
 import {variantsLocaleNamespace} from '../../i18n'
+import {useVariantOperations} from '../../store/useVariantOperations'
 import {type SystemVariant} from '../../types'
 import {getVariantId} from '../util'
 
 export function VariantMenuButton({variant}: {variant: SystemVariant}) {
   const {t} = useTranslation(variantsLocaleNamespace)
-  const handleDelete = useCallback(() => undefined, [])
+  const toast = useToast()
+  const {deleteVariant} = useVariantOperations()
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const handleDelete = useCallback(async () => {
+    setIsDeleting(true)
+
+    try {
+      await deleteVariant(variant._id)
+      setIsDeleting(false)
+    } catch (error) {
+      console.error(error)
+      toast.push({
+        closable: true,
+        status: 'error',
+        title: t('overview.action.delete-variant.error.title'),
+      })
+      setIsDeleting(false)
+    }
+  }, [deleteVariant, t, toast, variant._id])
 
   return (
     <MenuButton
-      button={<ContextMenuButton />}
+      button={<ContextMenuButton disabled={isDeleting} loading={isDeleting} />}
       id={`variant-actions-${getVariantId(variant._id)}`}
       menu={
         <Menu>
           <MenuItem
+            // TODO: This action now doesn't validate the documents count in a variant, once we can
+            // start adding documents to a variant we should revisit this to validate the documents count.
+            // If it has documents we should probably disable the delete action or at least handle it differently.
+            disabled={isDeleting}
             onClick={handleDelete}
             text={t('overview.action.delete-variant')}
             tone="critical"


### PR DESCRIPTION
### Description
Adds action to delete variant documents.
Includes a new component test to validate the action.


https://github.com/user-attachments/assets/95a1d8c3-247d-448d-bf61-1c8e0a948a36



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open the variants tool, select an existing variant and delete it.
Added component coverage for selecting the delete action and for the loading state while deletion is in progress.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a internal only

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes for this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->