### PR TITLE
chore(ci): add permissions for typedoc workflow job

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -81,6 +81,9 @@ jobs:
 
   typedoc:
     needs: [build-and-validate, git-operations]
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/typedoc.yml
     with:
       upload: true


### PR DESCRIPTION
### Description
Grants `contents: read` and `pull-requests: write` to the typedoc job in release-latest.yml so the reusable workflow call no longer fails validation against the workflow's permissions: {} default.

### What to review

### Testing

### Notes for release
n/a