### PR TITLE
feat(core): add variant definition edit form

### DIFF
--- a/packages/sanity/src/core/variants/components/dialog/CreateVariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/CreateVariantDialog.tsx
@@ -1,17 +1,10 @@
-import {at, set} from '@sanity/mutate'
-import {applyPatches} from '@sanity/mutate/_unstable_apply'
-import {Box, Card, Flex, useToast} from '@sanity/ui'
-import {toString} from '@sanity/util/paths'
-import {type FormEvent, useCallback, useState} from 'react'
+import {useCallback, useMemo} from 'react'
 
-import {Button, Dialog} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
 import {variantsLocaleNamespace} from '../../i18n'
 import {useVariantOperations} from '../../store/useVariantOperations'
-import {type EditableSystemVariant} from '../../types'
-import {getIsVariantInvalid} from '../../util/getIsVariantInvalid'
 import {getVariantDefaults} from '../../util/variantDefaults'
-import {VariantForm, type VariantFormChangeHandler} from './VariantForm'
+import {VariantDialog} from './VariantDialog'
 
 interface CreateVariantDialogProps {
   onCancel: () => void
@@ -20,82 +13,28 @@ interface CreateVariantDialogProps {
 
 export function CreateVariantDialog(props: CreateVariantDialogProps): React.JSX.Element {
   const {onCancel, onSubmit} = props
-  const toast = useToast()
   const {t} = useTranslation(variantsLocaleNamespace)
   const {createVariant} = useVariantOperations()
-  const [variant, setVariant] = useState(getVariantDefaults)
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [showValidation, setShowValidation] = useState(false)
-  const [conditionsInvalid, setConditionsInvalid] = useState(false)
-  const invalid = getIsVariantInvalid(variant) || conditionsInvalid
-
-  const handleVariantChange = useCallback<VariantFormChangeHandler>((path, nextValue) => {
-    setVariant(
-      (currentVariant) =>
-        applyPatches([at(toString(path), set(nextValue))], currentVariant) as EditableSystemVariant,
-    )
-  }, [])
+  const initialValue = useMemo(() => getVariantDefaults(), [])
 
   const handleSubmit = useCallback(
-    async (event: FormEvent<HTMLFormElement>) => {
-      event.preventDefault()
-
-      if (getIsVariantInvalid(variant) || conditionsInvalid) {
-        setShowValidation(true)
-        return
-      }
-
-      setIsSubmitting(true)
-
-      try {
-        await createVariant(variant)
-        setIsSubmitting(false)
-        onSubmit(variant._id)
-      } catch (error) {
-        setIsSubmitting(false)
-        console.error(error)
-        toast.push({
-          closable: true,
-          status: 'error',
-          title: t('dialog.create.error.title'),
-        })
-      }
+    async (variant: typeof initialValue) => {
+      await createVariant(variant)
+      onSubmit(variant._id)
     },
-    [conditionsInvalid, createVariant, onSubmit, t, toast, variant],
+    [createVariant, onSubmit],
   )
 
   return (
-    <Dialog
-      __unstable_autoFocus={false}
+    <VariantDialog
+      confirmDataTestId="submit-variant-button"
+      confirmText={t('dialog.create.action.confirm')}
+      errorTitle={t('dialog.create.error.title')}
       header={t('dialog.create.title')}
       id="create-variant-dialog"
-      onClickOutside={isSubmitting ? undefined : onCancel}
-      onClose={isSubmitting ? undefined : onCancel}
-      padding={false}
-      width={1}
-    >
-      <Card borderTop padding={4}>
-        <form onSubmit={handleSubmit}>
-          <Box paddingBottom={4}>
-            <VariantForm
-              onChange={handleVariantChange}
-              onConditionValidityChange={setConditionsInvalid}
-              showValidation={showValidation}
-              value={variant}
-            />
-          </Box>
-          <Flex justify="flex-end" paddingTop={5}>
-            <Button
-              data-testid="submit-variant-button"
-              disabled={isSubmitting || invalid}
-              loading={isSubmitting}
-              size="large"
-              text={t('dialog.create.action.confirm')}
-              type="submit"
-            />
-          </Flex>
-        </form>
-      </Card>
-    </Dialog>
+      initialValue={initialValue}
+      onCancel={onCancel}
+      onSubmit={handleSubmit}
+    />
   )
 }

--- a/packages/sanity/src/core/variants/components/dialog/EditVariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/EditVariantDialog.tsx
@@ -1,0 +1,52 @@
+import {useCallback, useMemo} from 'react'
+
+import {useTranslation} from '../../../i18n'
+import {variantsLocaleNamespace} from '../../i18n'
+import {useVariantOperations} from '../../store/useVariantOperations'
+import {type EditableSystemVariant, type SystemVariant} from '../../types'
+import {VariantDialog} from './VariantDialog'
+
+interface EditVariantDialogProps {
+  onCancel: () => void
+  onSubmit: () => void
+  variant: SystemVariant
+}
+
+function toEditableVariant(variant: SystemVariant): EditableSystemVariant {
+  return {
+    _id: variant._id,
+    _type: variant._type,
+    conditions: variant.conditions,
+    priority: variant.priority,
+    metadata: variant.metadata,
+  }
+}
+
+export function EditVariantDialog(props: EditVariantDialogProps): React.JSX.Element {
+  const {onCancel, onSubmit, variant: initialVariant} = props
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const {updateVariant} = useVariantOperations()
+  const initialValue = useMemo(() => toEditableVariant(initialVariant), [initialVariant])
+
+  const handleSubmit = useCallback(
+    async (variant: EditableSystemVariant) => {
+      await updateVariant(variant)
+      onSubmit()
+    },
+    [onSubmit, updateVariant],
+  )
+
+  return (
+    <VariantDialog
+      confirmDataTestId="save-variant-button"
+      confirmText={t('dialog.edit.action.confirm')}
+      errorTitle={t('dialog.edit.error.title')}
+      header={t('dialog.edit.title')}
+      id="edit-variant-dialog"
+      initialValue={initialValue}
+      onCancel={onCancel}
+      onSubmit={handleSubmit}
+      renderCancelButton
+    />
+  )
+}

--- a/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
@@ -109,7 +109,7 @@ export function VariantDialog(props: VariantDialogProps): React.JSX.Element {
             )}
             <Button
               data-testid={confirmDataTestId}
-              disabled={isSubmitting || invalid}
+              disabled={isSubmitting}
               loading={isSubmitting}
               size="large"
               text={confirmText}

--- a/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
@@ -1,0 +1,123 @@
+import {at, set} from '@sanity/mutate'
+import {applyPatches} from '@sanity/mutate/_unstable_apply'
+import {Box, Card, Flex, useToast} from '@sanity/ui'
+import {toString} from '@sanity/util/paths'
+import {type FormEvent, useCallback, useState} from 'react'
+
+import {Button, Dialog} from '../../../../ui-components'
+import {useTranslation} from '../../../i18n'
+import {variantsLocaleNamespace} from '../../i18n'
+import {type EditableSystemVariant} from '../../types'
+import {getIsVariantInvalid} from '../../util/getIsVariantInvalid'
+import {VariantForm, type VariantFormChangeHandler} from './VariantForm'
+
+interface VariantDialogProps {
+  confirmDataTestId: string
+  confirmText: string
+  errorTitle: string
+  header: string
+  id: string
+  initialValue: EditableSystemVariant
+  onCancel: () => void
+  onSubmit: (variant: EditableSystemVariant) => Promise<void>
+  renderCancelButton?: boolean
+}
+
+export function VariantDialog(props: VariantDialogProps): React.JSX.Element {
+  const {
+    confirmDataTestId,
+    confirmText,
+    errorTitle,
+    header,
+    id,
+    initialValue,
+    onCancel,
+    onSubmit,
+    renderCancelButton = false,
+  } = props
+  const toast = useToast()
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const [variant, setVariant] = useState(initialValue)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [showValidation, setShowValidation] = useState(false)
+  const [conditionsInvalid, setConditionsInvalid] = useState(false)
+  const invalid = getIsVariantInvalid(variant) || conditionsInvalid
+
+  const handleVariantChange = useCallback<VariantFormChangeHandler>((path, nextValue) => {
+    setVariant(
+      (currentVariant) =>
+        applyPatches([at(toString(path), set(nextValue))], currentVariant) as EditableSystemVariant,
+    )
+  }, [])
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+
+      if (invalid) {
+        setShowValidation(true)
+        return
+      }
+
+      setIsSubmitting(true)
+
+      try {
+        await onSubmit(variant)
+        setIsSubmitting(false)
+      } catch (error) {
+        setIsSubmitting(false)
+        console.error(error)
+        toast.push({
+          closable: true,
+          status: 'error',
+          title: errorTitle,
+        })
+      }
+    },
+    [errorTitle, invalid, onSubmit, toast, variant],
+  )
+
+  return (
+    <Dialog
+      __unstable_autoFocus={false}
+      header={header}
+      id={id}
+      onClickOutside={isSubmitting ? undefined : onCancel}
+      onClose={isSubmitting ? undefined : onCancel}
+      padding={false}
+      width={1}
+    >
+      <Card borderTop padding={4}>
+        <form onSubmit={handleSubmit}>
+          <Box paddingBottom={4}>
+            <VariantForm
+              onChange={handleVariantChange}
+              onConditionValidityChange={setConditionsInvalid}
+              showValidation={showValidation}
+              value={variant}
+            />
+          </Box>
+          <Flex gap={2} justify="flex-end" paddingTop={5}>
+            {renderCancelButton && (
+              <Button
+                disabled={isSubmitting}
+                mode="ghost"
+                onClick={onCancel}
+                text={t('dialog.edit.action.cancel')}
+                type="button"
+              />
+            )}
+            <Button
+              data-testid={confirmDataTestId}
+              disabled={isSubmitting || invalid}
+              loading={isSubmitting}
+              size="large"
+              text={confirmText}
+              type="submit"
+            />
+          </Flex>
+        </form>
+      </Card>
+    </Dialog>
+  )
+}

--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -8,8 +8,12 @@ import {type ChangeEvent, useCallback, useId, useMemo, useState} from 'react'
 import {Button} from '../../../../ui-components'
 import {TextWithTone} from '../../../components/textWithTone/TextWithTone'
 import {useTranslation} from '../../../i18n'
-import {variantsLocaleNamespace} from '../../i18n'
+import {type VariantsLocaleResourceKeys, variantsLocaleNamespace} from '../../i18n'
 import {type EditableSystemVariant} from '../../types'
+import {
+  getConditionKeyValidationError,
+  getConditionValueValidationError,
+} from '../../util/conditionValidation'
 import {getVariantTitleValue} from '../../util/getIsVariantInvalid'
 import {createPortableTextDescription} from '../../util/variantDefaults'
 
@@ -17,6 +21,11 @@ interface ConditionRow {
   id: string
   key: string
   value: string
+}
+
+interface ConditionRowValidation {
+  key: VariantsLocaleResourceKeys | null
+  value: VariantsLocaleResourceKeys | null
 }
 
 function getConditionRows(conditions: EditableSystemVariant['conditions']): ConditionRow[] {
@@ -46,36 +55,55 @@ function isConditionRowEmpty(row: ConditionRow): boolean {
   return !row.key.trim() && !row.value.trim()
 }
 
-function isConditionRowComplete(row: ConditionRow): boolean {
-  return Boolean(row.key.trim() && row.value.trim())
+function getEmptyConditionRowValidation(): ConditionRowValidation {
+  return {key: null, value: null}
 }
 
-function getDuplicateConditionKeyIndexes(rows: ConditionRow[]): Set<number> {
+function getConditionRowsValidation(rows: ConditionRow[]): Map<number, ConditionRowValidation> {
+  const conditionRowsValidation = new Map<number, ConditionRowValidation>()
   const seenKeys = new Set<string>()
-  const duplicateIndexes = new Set<number>()
 
   rows.forEach((row, index) => {
+    const validation: ConditionRowValidation = {key: null, value: null}
     const key = row.key.trim()
+    const value = row.value.trim()
 
-    if (!key) {
-      return
+    if (key) {
+      if (seenKeys.has(key)) {
+        validation.key = 'dialog.create.condition-key.duplicate'
+      } else {
+        seenKeys.add(key)
+      }
+
+      const keyError = getConditionKeyValidationError(row.key)
+
+      if (!validation.key && keyError === 'reserved') {
+        validation.key = 'dialog.create.condition-key.reserved'
+      } else if (!validation.key && keyError === 'invalid') {
+        validation.key = 'dialog.create.condition-key.invalid'
+      }
+    } else if (value) {
+      validation.key = 'dialog.create.condition-key.required'
     }
 
-    if (seenKeys.has(key)) {
-      duplicateIndexes.add(index)
-    } else {
-      seenKeys.add(key)
+    const valueError = getConditionValueValidationError(row.value)
+
+    if ((key || isConditionRowEmpty(row)) && valueError === 'empty') {
+      validation.value = 'dialog.create.condition-value.required'
+    } else if (valueError === 'invalid') {
+      validation.value = 'dialog.create.condition-value.invalid'
     }
+
+    conditionRowsValidation.set(index, validation)
   })
 
-  return duplicateIndexes
+  return conditionRowsValidation
 }
 
-function getConditionRowsInvalid(rows: ConditionRow[]): boolean {
-  return (
-    rows.some((row) => !isConditionRowComplete(row)) ||
-    getDuplicateConditionKeyIndexes(rows).size > 0
-  )
+function hasConditionRowsValidationErrors(
+  validation: Map<number, ConditionRowValidation>,
+): boolean {
+  return Array.from(validation.values()).some(({key, value}) => key || value)
 }
 
 function getPortableTextDescriptionValue(description?: PortableTextBlock[]): string {
@@ -98,23 +126,20 @@ export function VariantForm(props: {
   const {t} = useTranslation(variantsLocaleNamespace)
   const titleId = useId()
   const descriptionId = useId()
-  const [titleTouched, setTitleTouched] = useState(false)
   // `conditions` is stored as an object, but object keys are awkward to edit live:
   // duplicates collapse and partial key edits like "far" -> "favorite" can lose data.
   // Keep rows locally while editing, then commit back once they serialize cleanly.
   const [conditionRows, setConditionRows] = useState(() => getConditionRows(value.conditions))
-  const duplicateConditionKeyIndexes = useMemo(
-    () => getDuplicateConditionKeyIndexes(conditionRows),
+  const conditionsValidation = useMemo(
+    () => getConditionRowsValidation(conditionRows),
     [conditionRows],
   )
 
   const hasTitle = Boolean(getVariantTitleValue(value))
-  const showTitleError = (showValidation || titleTouched) && !hasTitle
+  const showTitleError = showValidation && !hasTitle
   const lastConditionRow = conditionRows[conditionRows.length - 1]
   const canAddCondition = Boolean(
-    lastConditionRow &&
-    isConditionRowComplete(lastConditionRow) &&
-    duplicateConditionKeyIndexes.size === 0,
+    lastConditionRow && !hasConditionRowsValidationErrors(conditionsValidation),
   )
 
   const updateConditionRows = useCallback(
@@ -123,7 +148,8 @@ export function VariantForm(props: {
 
       setConditionRows(rows)
 
-      const nextRowsInvalid = getConditionRowsInvalid(rows)
+      const nextRowsValidation = getConditionRowsValidation(rows)
+      const nextRowsInvalid = hasConditionRowsValidationErrors(nextRowsValidation)
       onConditionValidityChange?.(nextRowsInvalid)
 
       if (nextRows.length === 0 || !nextRowsInvalid) {
@@ -191,7 +217,6 @@ export function VariantForm(props: {
           data-testid="variant-form-title"
           fontSize={2}
           id={titleId}
-          onBlur={() => setTitleTouched(true)}
           onChange={handleTitleChange}
           placeholder={t('dialog.create.variant-title.placeholder')}
           value={typeof value.metadata?.title === 'string' ? value.metadata.title : ''}
@@ -229,61 +254,67 @@ export function VariantForm(props: {
         </Stack>
 
         <Stack space={2}>
-          {conditionRows.map((row, index) => (
-            <Stack key={row.id} space={2}>
-              <Flex align="center" gap={2}>
-                <Box flex={1}>
-                  <TextInput
-                    autoFocus={index > 0}
-                    aria-invalid={duplicateConditionKeyIndexes.has(index) ? 'true' : undefined}
-                    aria-label={t('dialog.create.condition-key.label')}
-                    customValidity={
-                      duplicateConditionKeyIndexes.has(index)
-                        ? t('dialog.create.condition-key.duplicate')
-                        : undefined
-                    }
-                    data-testid="variant-form-condition-key"
-                    fontSize={1}
-                    onChange={(event) =>
-                      handleConditionChange(index, 'key', event.currentTarget.value)
-                    }
-                    placeholder={t('dialog.create.condition-key.placeholder')}
-                    value={row.key}
+          {conditionRows.map((row, index) => {
+            const validation = conditionsValidation.get(index) ?? getEmptyConditionRowValidation()
+            const valueValidation = showValidation ? validation.value : null
+            const conditionValidationError = validation.key || valueValidation
+
+            return (
+              <Stack key={row.id} space={2}>
+                <Flex align="center" gap={2}>
+                  <Box flex={1}>
+                    <TextInput
+                      autoFocus={index > 0}
+                      aria-label={t('dialog.create.condition-key.label')}
+                      customValidity={validation.key ? t(validation.key) : undefined}
+                      aria-invalid={Boolean(validation.key)}
+                      onChange={(event) =>
+                        handleConditionChange(index, 'key', event.currentTarget.value)
+                      }
+                      placeholder={t('dialog.create.condition-key.placeholder')}
+                      data-testid="variant-form-condition-key"
+                      value={row.key}
+                    />
+                  </Box>
+                  <Box flex={1}>
+                    <TextInput
+                      aria-label={t('dialog.create.condition-value.label')}
+                      customValidity={valueValidation ? t(valueValidation) : undefined}
+                      aria-invalid={Boolean(valueValidation)}
+                      onChange={(event) =>
+                        handleConditionChange(index, 'value', event.currentTarget.value)
+                      }
+                      placeholder={t('dialog.create.condition-value.placeholder')}
+                      data-testid="variant-form-condition-value"
+                      value={row.value}
+                    />
+                  </Box>
+                  <Button
+                    disabled={isConditionRowEmpty(row) && conditionRows.length === 1}
+                    icon={TrashIcon}
+                    mode="bleed"
+                    onClick={() => handleRemoveCondition(index)}
+                    tone="critical"
+                    tooltipProps={{content: t('dialog.create.remove-condition')}}
+                    type="button"
                   />
-                </Box>
-                <Box flex={1}>
-                  <TextInput
-                    aria-label={t('dialog.create.condition-value.label')}
-                    data-testid="variant-form-condition-value"
-                    fontSize={1}
-                    onChange={(event) =>
-                      handleConditionChange(index, 'value', event.currentTarget.value)
+                </Flex>
+                {conditionValidationError && (
+                  <TextWithTone
+                    data-testid={
+                      validation.key
+                        ? 'variant-form-condition-key-error'
+                        : 'variant-form-condition-value-error'
                     }
-                    placeholder={t('dialog.create.condition-value.placeholder')}
-                    value={row.value}
-                  />
-                </Box>
-                <Button
-                  disabled={isConditionRowEmpty(row) && conditionRows.length === 1}
-                  icon={TrashIcon}
-                  mode="bleed"
-                  onClick={() => handleRemoveCondition(index)}
-                  tone="critical"
-                  tooltipProps={{content: t('dialog.create.remove-condition')}}
-                  type="button"
-                />
-              </Flex>
-              {duplicateConditionKeyIndexes.has(index) && (
-                <TextWithTone
-                  data-testid="variant-form-condition-key-error"
-                  size={1}
-                  tone="critical"
-                >
-                  {t('dialog.create.condition-key.duplicate')}
-                </TextWithTone>
-              )}
-            </Stack>
-          ))}
+                    size={1}
+                    tone="critical"
+                  >
+                    {t(conditionValidationError)}
+                  </TextWithTone>
+                )}
+              </Stack>
+            )
+          })}
         </Stack>
 
         <Flex>

--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -1,5 +1,6 @@
+import {isPortableTextBlock, toPlainText} from '@portabletext/toolkit'
 import {AddIcon, TrashIcon} from '@sanity/icons'
-import {type Path} from '@sanity/types'
+import {type PortableTextBlock, type Path} from '@sanity/types'
 import {Box, Flex, Stack, Text, TextArea, TextInput} from '@sanity/ui'
 import {randomKey} from '@sanity/util/content'
 import {type ChangeEvent, useCallback, useId, useMemo, useState} from 'react'
@@ -75,6 +76,14 @@ function getConditionRowsInvalid(rows: ConditionRow[]): boolean {
     rows.some((row) => !isConditionRowComplete(row)) ||
     getDuplicateConditionKeyIndexes(rows).size > 0
   )
+}
+
+function getPortableTextDescriptionValue(description?: PortableTextBlock[]): string {
+  if (!Array.isArray(description) || !description.every(isPortableTextBlock)) {
+    return ''
+  }
+
+  return toPlainText(description)
 }
 
 export type VariantFormChangeHandler = (path: Path, value: unknown) => void
@@ -205,6 +214,7 @@ export function VariantForm(props: {
           onChange={handleDescriptionChange}
           placeholder={t('dialog.create.description.placeholder')}
           rows={3}
+          value={getPortableTextDescriptionValue(value.metadata?.description)}
         />
       </Stack>
 

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
@@ -73,15 +73,25 @@ describe('CreateVariantDialog', () => {
 
     await renderDialog()
 
-    expect(screen.getByTestId('submit-variant-button')).toBeDisabled()
+    expect(screen.getByTestId('submit-variant-button')).toBeEnabled()
 
     await user.type(screen.getByTestId('variant-form-condition-key'), 'audience')
-    await user.type(screen.getByTestId('variant-form-condition-value'), 'loyal-customers')
-    expect(screen.getByTestId('submit-variant-button')).toBeDisabled()
+    expect(screen.queryByTestId('variant-form-condition-value-error')).not.toBeInTheDocument()
 
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    expect(screen.getByTestId('variant-form-title-error')).toHaveTextContent('Title is required')
+    expect(screen.getByTestId('variant-form-condition-value-error')).toHaveTextContent(
+      'Condition value is required',
+    )
+    expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
+
+    await user.type(screen.getByTestId('variant-form-condition-value'), 'loyal-customers')
     await user.type(screen.getByTestId('variant-form-title'), 'Loyal customers')
+    await user.click(screen.getByTestId('submit-variant-button'))
+
     await waitFor(() => {
-      expect(screen.getByTestId('submit-variant-button')).toBeEnabled()
+      expect(variantOperationsMock.createVariant).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -109,25 +119,110 @@ describe('CreateVariantDialog', () => {
     expect(screen.getByTestId('variant-form-condition-key-error')).toHaveTextContent(
       'Condition keys must be unique',
     )
-    expect(screen.getByTestId('submit-variant-button')).toBeDisabled()
+    expect(screen.getByTestId('submit-variant-button')).toBeEnabled()
+
+    await user.click(screen.getByTestId('submit-variant-button'))
+    expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
 
     await user.type(conditionKeys[1]!, '2')
 
     await waitFor(() => {
       expect(screen.queryByTestId('variant-form-condition-key-error')).not.toBeInTheDocument()
-      expect(screen.getByTestId('submit-variant-button')).toBeEnabled()
+    })
+
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.createVariant).toHaveBeenCalledTimes(1)
     })
   })
 
-  it('shows a title validation message after the field is touched', async () => {
+  it('shows an error for reserved and invalid condition keys', async () => {
     const user = userEvent.setup()
 
     await renderDialog()
 
-    const titleInput = screen.getByTestId('variant-form-title')
+    await user.type(screen.getByTestId('variant-form-title'), 'Loyal customers')
+    await user.type(screen.getByTestId('variant-form-condition-key'), '_system')
+    await user.type(screen.getByTestId('variant-form-condition-value'), 'loyal')
 
-    await user.click(titleInput)
-    await user.tab()
+    expect(screen.getByTestId('variant-form-condition-key-error')).toHaveTextContent(
+      'Condition keys cannot start with _ or $',
+    )
+    expect(screen.getByTestId('submit-variant-button')).toBeEnabled()
+
+    await user.click(screen.getByTestId('submit-variant-button'))
+    expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
+
+    await user.clear(screen.getByTestId('variant-form-condition-key'))
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'Audience')
+
+    expect(screen.getByTestId('variant-form-condition-key-error')).toHaveTextContent(
+      'Condition keys must be lowercase, start with a letter, and use letters, numbers, underscores, or hyphens',
+    )
+
+    await user.click(screen.getByTestId('submit-variant-button'))
+    expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
+  })
+
+  it('shows an error for invalid condition values', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-title'), 'Loyal customers')
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'audience')
+    await user.type(screen.getByTestId('variant-form-condition-value'), 'loyal:customers')
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    expect(screen.getByTestId('variant-form-condition-value-error')).toHaveTextContent(
+      'Condition values cannot contain colons',
+    )
+    expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
+  })
+
+  it('requires a condition key before submitting a row with a value', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-title'), 'Loyal customers')
+    await user.type(screen.getByTestId('variant-form-condition-value'), 'loyal-customers')
+    expect(screen.getByTestId('variant-form-condition-key-error')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    expect(screen.getByTestId('variant-form-condition-key-error')).toHaveTextContent(
+      'Condition key is required',
+    )
+    expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
+  })
+
+  it('supports free-text condition keys and values', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-title'), 'Experiment users')
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'experiment')
+    await user.type(screen.getByTestId('variant-form-condition-value'), 'control')
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.createVariant).toHaveBeenCalledTimes(1)
+    })
+
+    const createdVariant = variantOperationsMock.createVariant.mock.calls[0]![0]
+
+    expect(createdVariant.conditions).toEqual({experiment: 'control'})
+  })
+
+  it('shows a title validation message after submit is attempted', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.click(screen.getByTestId('submit-variant-button'))
 
     expect(screen.getByTestId('variant-form-title-error')).toHaveTextContent('Title is required')
   })

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
@@ -2,7 +2,6 @@ import {render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {flushMicrotasksThisIsACodeSmell} from '../../../../../../test/testUtils/flushMicrotasks'
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
 import {variantsUsEnglishLocaleBundle} from '../../../i18n'
 import {CreateVariantDialog} from '../CreateVariantDialog'
@@ -11,6 +10,15 @@ const variantOperationsMock = vi.hoisted(() => ({
   createVariant: vi.fn(),
   updateVariant: vi.fn(),
   deleteVariant: vi.fn(),
+}))
+
+const toastMock = vi.hoisted(() => ({
+  push: vi.fn(),
+}))
+
+vi.mock('@sanity/ui', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useToast: vi.fn(() => toastMock),
 }))
 
 vi.mock('../../../store/useVariantOperations', () => ({
@@ -33,7 +41,7 @@ describe('CreateVariantDialog', () => {
     const result = render(<CreateVariantDialog onCancel={onCancel} onSubmit={onSubmit} />, {
       wrapper,
     })
-    await flushMicrotasksThisIsACodeSmell()
+    await screen.findByRole('dialog', {name: 'Create variant'})
     return result
   }
 
@@ -161,6 +169,12 @@ describe('CreateVariantDialog', () => {
       expect(consoleError).toHaveBeenCalledWith(error)
     })
 
+    expect(toastMock.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'error',
+        title: 'Unable to create variant',
+      }),
+    )
     expect(onCancel).not.toHaveBeenCalled()
     expect(onSubmit).not.toHaveBeenCalled()
     expect(screen.getByRole('dialog', {name: 'Create variant'})).toBeInTheDocument()

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/VariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/VariantDialog.test.tsx
@@ -1,0 +1,125 @@
+import {render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {variantsUsEnglishLocaleBundle} from '../../../i18n'
+import {type EditableSystemVariant} from '../../../types'
+import {getVariantDefaults} from '../../../util/variantDefaults'
+import {VariantDialog} from '../VariantDialog'
+
+const toastMock = vi.hoisted(() => ({
+  push: vi.fn(),
+}))
+
+vi.mock('@sanity/ui', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useToast: vi.fn(() => toastMock),
+}))
+
+describe('VariantDialog', () => {
+  const onCancel = vi.fn()
+  const onSubmit = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    onSubmit.mockResolvedValue(undefined)
+  })
+
+  const renderDialog = async (props?: {
+    initialValue?: EditableSystemVariant
+    renderCancelButton?: boolean
+  }) => {
+    const wrapper = await createTestProvider({
+      resources: [variantsUsEnglishLocaleBundle],
+    })
+    const result = render(
+      <VariantDialog
+        confirmDataTestId="save-variant-button"
+        confirmText="Save"
+        errorTitle="Unable to update variant"
+        header="Edit variant"
+        id="edit-variant-dialog"
+        initialValue={props?.initialValue ?? getVariantDefaults()}
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+        renderCancelButton={props?.renderCancelButton}
+      />,
+      {wrapper},
+    )
+    await screen.findByRole('dialog', {name: 'Edit variant'})
+    return result
+  }
+
+  it('renders a cancel button when renderCancelButton is enabled', async () => {
+    await renderDialog({renderCancelButton: true})
+
+    expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument()
+  })
+
+  it('does not render a cancel button in create mode', async () => {
+    await renderDialog({renderCancelButton: false})
+
+    expect(screen.queryByRole('button', {name: 'Cancel'})).not.toBeInTheDocument()
+  })
+
+  it('calls onCancel when cancel is pressed', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog({renderCancelButton: true})
+
+    await user.click(screen.getByRole('button', {name: 'Cancel'}))
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('calls onCancel when the dialog close button is pressed', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog({renderCancelButton: true})
+
+    await user.click(screen.getByLabelText('Close dialog'))
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('disables submit while the form is invalid', async () => {
+    await renderDialog()
+
+    expect(screen.getByTestId('save-variant-button')).toBeDisabled()
+  })
+
+  it('shows an error toast and keeps the dialog open when submit fails', async () => {
+    const error = new Error('update failed')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    onSubmit.mockRejectedValue(error)
+    const user = userEvent.setup()
+
+    await renderDialog({
+      initialValue: {
+        ...getVariantDefaults(),
+        metadata: {title: 'Alpha audience', description: []},
+        conditions: {audience: 'alpha'},
+      },
+      renderCancelButton: true,
+    })
+
+    await user.click(screen.getByTestId('save-variant-button'))
+
+    await waitFor(() => {
+      expect(toastMock.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          title: 'Unable to update variant',
+        }),
+      )
+    })
+    expect(consoleError).toHaveBeenCalledWith(error)
+    expect(screen.getByRole('dialog', {name: 'Edit variant'})).toBeInTheDocument()
+    expect(onCancel).not.toHaveBeenCalled()
+
+    consoleError.mockRestore()
+  })
+})

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/VariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/VariantDialog.test.tsx
@@ -85,10 +85,17 @@ describe('VariantDialog', () => {
     expect(onSubmit).not.toHaveBeenCalled()
   })
 
-  it('disables submit while the form is invalid', async () => {
+  it('allows submit while the form is invalid and shows validation on click', async () => {
+    const user = userEvent.setup()
+
     await renderDialog()
 
-    expect(screen.getByTestId('save-variant-button')).toBeDisabled()
+    expect(screen.getByTestId('save-variant-button')).toBeEnabled()
+
+    await user.click(screen.getByTestId('save-variant-button'))
+
+    expect(screen.getByTestId('variant-form-title-error')).toHaveTextContent('Title is required')
+    expect(onSubmit).not.toHaveBeenCalled()
   })
 
   it('shows an error toast and keeps the dialog open when submit fails', async () => {

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -58,8 +58,6 @@ const variantsLocaleStrings = {
   'detail.not-found.description': 'The requested variant could not be found.',
   /** Title for the missing Variant detail page. */
   'detail.not-found.title': 'Variant not found',
-  /** Placeholder text on the Variant detail page. */
-  'detail.placeholder': 'Variant detail editing will be added in a future iteration.',
   /** Title for the create variant dialog. */
   'dialog.create.title': 'Create variant',
   /** Confirm action for the create variant dialog. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -38,6 +38,8 @@ const variantsLocaleStrings = {
   'detail.action.edit-variant': 'Edit variant',
   /** Back action on the Variant detail page. */
   'detail.back': 'Back to variants',
+  /** Created status label in the Variant detail footer. */
+  'detail.footer.created': 'Created',
   /** Loading message on the Variant detail page. */
   'detail.loading': 'Loading variant',
   /** Fallback text when a variant has no description. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -88,6 +88,17 @@ const variantsLocaleStrings = {
   'dialog.create.condition-key.label': 'Key',
   /** Validation message when a condition key is repeated. */
   'dialog.create.condition-key.duplicate': 'Condition keys must be unique',
+  /** Validation message when a condition key uses a reserved prefix. */
+  'dialog.create.condition-key.reserved': 'Condition keys cannot start with _ or $',
+  /** Validation message when a condition key has an invalid format. */
+  'dialog.create.condition-key.invalid':
+    'Condition keys must be lowercase, start with a letter, and use letters, numbers, underscores, or hyphens',
+  /** Validation message when a condition key is missing. */
+  'dialog.create.condition-key.required': 'Condition key is required',
+  /** Validation message when a condition value is missing. */
+  'dialog.create.condition-value.required': 'Condition value is required',
+  /** Validation message when a condition value has an invalid format. */
+  'dialog.create.condition-value.invalid': 'Condition values cannot contain colons',
   /** Placeholder for the condition key field in the create variant dialog. */
   'dialog.create.condition-key.placeholder': 'e.g. audience',
   /** Label for the condition value field in the create variant dialog. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -34,12 +34,24 @@ const variantsLocaleStrings = {
   'overview.table.no-conditions': 'No conditions',
   /** Title for the Variants overview. */
   'overview.title': 'Variants',
+  /** Edit action on the Variant detail page. */
+  'detail.action.edit-variant': 'Edit variant',
   /** Back action on the Variant detail page. */
   'detail.back': 'Back to variants',
   /** Loading message on the Variant detail page. */
   'detail.loading': 'Loading variant',
   /** Fallback text when a variant has no description. */
   'detail.no-description': 'No description yet.',
+  /** Empty state for variant document table. */
+  'detail.documents.no-documents': 'No documents in this variant',
+  /** Edited column header for variant document table. */
+  'detail.documents.table.edited': 'Edited',
+  /** Search placeholder for variant document table. */
+  'detail.documents.table.search-placeholder': 'Search documents',
+  /** Type column header for variant document table. */
+  'detail.documents.table.type': 'Type',
+  /** Version column header for variant document table. */
+  'detail.documents.table.version': 'Version',
   /** Description for the missing Variant detail page. */
   'detail.not-found.description': 'The requested variant could not be found.',
   /** Title for the missing Variant detail page. */
@@ -84,6 +96,14 @@ const variantsLocaleStrings = {
   'dialog.create.condition-value.placeholder': 'e.g. loyal-customers',
   /** Error toast title when variant creation fails. */
   'dialog.create.error.title': 'Unable to create variant',
+  /** Title for the edit variant dialog. */
+  'dialog.edit.title': 'Edit variant',
+  /** Confirm action for the edit variant dialog. */
+  'dialog.edit.action.confirm': 'Save',
+  /** Cancel action for the edit variant dialog. */
+  'dialog.edit.action.cancel': 'Cancel',
+  /** Error toast title when variant editing fails. */
+  'dialog.edit.error.title': 'Unable to update variant',
 }
 
 /**

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -2,7 +2,6 @@ import {render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {flushMicrotasksThisIsACodeSmell} from '../../../../../test/testUtils/flushMicrotasks'
 import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
 import {variantAlphaAudience} from '../../__fixtures__/variants.fixture'
 import {variantsUsEnglishLocaleBundle} from '../../i18n'
@@ -69,7 +68,24 @@ describe('VariantDetail', () => {
     variantsMock.loading = false
     variantsMock.error = undefined
     routerState.variantId = undefined
-    variantOperationsMock.updateVariant.mockResolvedValue(undefined)
+    variantOperationsMock.updateVariant.mockImplementation(async (variant) => {
+      const existingVariant = variantsMock.byId.get(variant._id)
+
+      if (!existingVariant) {
+        return variant
+      }
+
+      const updatedVariant: SystemVariant = {
+        ...existingVariant,
+        ...variant,
+        metadata: variant.metadata ?? existingVariant.metadata,
+      }
+
+      variantsMock.byId.set(variant._id, updatedVariant)
+      variantsMock.data = Array.from(variantsMock.byId.values())
+
+      return updatedVariant
+    })
   })
 
   const setVariants = (variants: SystemVariant[]) => {
@@ -82,7 +98,6 @@ describe('VariantDetail', () => {
       resources: [variantsUsEnglishLocaleBundle],
     })
     const result = render(<VariantDetail />, {wrapper})
-    await flushMicrotasksThisIsACodeSmell()
     return result
   }
 
@@ -191,6 +206,10 @@ describe('VariantDetail', () => {
     await waitFor(() => {
       expect(screen.queryByRole('dialog', {name: 'Edit variant'})).not.toBeInTheDocument()
     })
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', {level: 1, name: 'Beta audience'})).toBeInTheDocument()
+    })
   })
 
   it('does not save while condition rows are invalid', async () => {
@@ -228,6 +247,24 @@ describe('VariantDetail', () => {
       expect(screen.queryByRole('dialog', {name: 'Edit variant'})).not.toBeInTheDocument()
     })
     expect(variantOperationsMock.updateVariant).not.toHaveBeenCalled()
+  })
+
+  it('closes the edit dialog without saving when the dialog close button is pressed', async () => {
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderDetail()
+
+    await user.click(screen.getByRole('button', {name: 'Edit variant'}))
+    await user.type(await screen.findByTestId('variant-form-title'), ' updated')
+    await user.click(screen.getByLabelText('Close dialog'))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', {name: 'Edit variant'})).not.toBeInTheDocument()
+    })
+    expect(variantOperationsMock.updateVariant).not.toHaveBeenCalled()
+    expect(screen.getByRole('heading', {level: 1, name: 'Alpha audience'})).toBeInTheDocument()
   })
 
   it('shows a toast and keeps the dialog open when updating fails', async () => {
@@ -278,6 +315,40 @@ describe('VariantDetail', () => {
       expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
       expect(mockNavigate).toHaveBeenCalledWith({})
     })
+  })
+
+  it('shows a toast and stays on the detail page when deletion fails', async () => {
+    const error = new Error('delete failed')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    variantOperationsMock.deleteVariant.mockRejectedValue(error)
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderDetail()
+
+    const menuButton = screen
+      .getAllByRole('button')
+      .find((button) => button.id === 'variant-detail-actions-alpha-audience')
+
+    if (!menuButton) throw new Error('Variant detail actions menu button not found')
+
+    await user.click(menuButton)
+    await user.click(await screen.findByText('Delete variant'))
+
+    await waitFor(() => {
+      expect(toastMock.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          title: 'Unable to delete variant',
+        }),
+      )
+    })
+    expect(consoleError).toHaveBeenCalledWith(error)
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(screen.getByRole('heading', {level: 1, name: 'Alpha audience'})).toBeInTheDocument()
+
+    consoleError.mockRestore()
   })
 
   it('shows not found when variant id does not match any document', async () => {

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -24,6 +24,21 @@ const variantsMock = vi.hoisted(() => ({
   error: undefined as Error | undefined,
 }))
 
+const variantOperationsMock = vi.hoisted(() => ({
+  createVariant: vi.fn(),
+  updateVariant: vi.fn(),
+  deleteVariant: vi.fn(),
+}))
+
+const toastMock = vi.hoisted(() => ({
+  push: vi.fn(),
+}))
+
+vi.mock('@sanity/ui', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useToast: vi.fn(() => toastMock),
+}))
+
 vi.mock('sanity/router', async (importOriginal) => ({
   ...(await importOriginal()),
   useRouter: vi.fn(() => ({
@@ -42,14 +57,19 @@ vi.mock('../../store/useAllVariants', () => ({
   })),
 }))
 
+vi.mock('../../store/useVariantOperations', () => ({
+  useVariantOperations: vi.fn(() => variantOperationsMock),
+}))
+
 describe('VariantDetail', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     variantsMock.data = []
     variantsMock.byId = new Map()
     variantsMock.loading = false
     variantsMock.error = undefined
     routerState.variantId = undefined
-    mockNavigate.mockClear()
+    variantOperationsMock.updateVariant.mockResolvedValue(undefined)
   })
 
   const setVariants = (variants: SystemVariant[]) => {
@@ -75,9 +95,24 @@ describe('VariantDetail', () => {
     expect(screen.getByTestId('loading-block')).toBeInTheDocument()
   })
 
-  it('renders title, description fallback, and placeholder when variant exists', async () => {
+  it('renders title, description, conditions, and edit action when variant exists', async () => {
+    const variantWithDescription: SystemVariant = {
+      ...variantAlphaAudience,
+      metadata: {
+        ...variantAlphaAudience.metadata,
+        description: [
+          {
+            _key: 'description',
+            _type: 'block',
+            children: [{_key: 'span', _type: 'span', marks: [], text: 'Developer audience'}],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      },
+    }
     routerState.variantId = getVariantId(variantAlphaAudience._id)
-    setVariants([variantAlphaAudience])
+    setVariants([variantWithDescription])
 
     await renderDetail()
 
@@ -85,11 +120,140 @@ describe('VariantDetail', () => {
       expect(screen.getByRole('heading', {level: 1, name: 'Alpha audience'})).toBeInTheDocument()
     })
 
-    expect(screen.getByText('No description yet.')).toBeInTheDocument()
-    expect(
-      screen.getByText('Variant detail editing will be added in a future iteration.'),
-    ).toBeInTheDocument()
+    expect(screen.getByText('Developer audience')).toBeInTheDocument()
+    expect(screen.getByText('audience: "alpha", locale: "en-US"')).toBeInTheDocument()
+    expect(screen.getByRole('button', {name: 'Edit variant'})).toBeInTheDocument()
     expect(screen.getByRole('button', {name: 'Back to variants'})).toBeInTheDocument()
+    expect(screen.getByText('Version')).toBeInTheDocument()
+    expect(screen.getByText('Type')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Search documents')).toBeInTheDocument()
+    expect(screen.getByText('Edited')).toBeInTheDocument()
+    expect(screen.getByText('No documents in this variant')).toBeInTheDocument()
+  })
+
+  it('opens the edit dialog with existing variant values', async () => {
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderDetail()
+
+    await user.click(screen.getByRole('button', {name: 'Edit variant'}))
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', {name: 'Edit variant'})).toBeInTheDocument()
+    })
+
+    expect(screen.getByTestId('variant-form-title')).toHaveValue('Alpha audience')
+    expect(screen.getAllByTestId('variant-form-condition-key')).toHaveLength(2)
+    expect(screen.getByTestId('save-variant-button')).toBeEnabled()
+  })
+
+  it('saves edited variant values from the dialog', async () => {
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderDetail()
+
+    await user.click(screen.getByRole('button', {name: 'Edit variant'}))
+    await user.clear(await screen.findByTestId('variant-form-title'))
+    await user.type(screen.getByTestId('variant-form-title'), 'Beta audience')
+    await user.type(screen.getByTestId('variant-form-description'), 'Audience for beta users')
+
+    const conditionValues = screen.getAllByTestId('variant-form-condition-value')
+    await user.clear(conditionValues[0]!)
+    await user.type(conditionValues[0]!, 'beta')
+    await user.click(screen.getByTestId('save-variant-button'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.updateVariant).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conditions: {audience: 'beta', locale: 'en-US'},
+          metadata: expect.objectContaining({
+            title: 'Beta audience',
+            description: [
+              expect.objectContaining({
+                children: [
+                  expect.objectContaining({
+                    text: 'Audience for beta users',
+                  }),
+                ],
+              }),
+            ],
+          }),
+        }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', {name: 'Edit variant'})).not.toBeInTheDocument()
+    })
+  })
+
+  it('does not save while condition rows are invalid', async () => {
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderDetail()
+
+    await user.click(screen.getByRole('button', {name: 'Edit variant'}))
+    const conditionKeys = screen.getAllByTestId('variant-form-condition-key')
+    await user.clear(conditionKeys[1]!)
+    await user.type(conditionKeys[1]!, 'audience')
+
+    expect(screen.getByTestId('variant-form-condition-key-error')).toHaveTextContent(
+      'Condition keys must be unique',
+    )
+
+    expect(screen.getByTestId('save-variant-button')).toBeDisabled()
+    expect(variantOperationsMock.updateVariant).not.toHaveBeenCalled()
+  })
+
+  it('closes the edit dialog without saving when cancel is pressed', async () => {
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderDetail()
+
+    await user.click(screen.getByRole('button', {name: 'Edit variant'}))
+    await user.type(await screen.findByTestId('variant-form-title'), ' updated')
+    await user.click(screen.getByRole('button', {name: 'Cancel'}))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', {name: 'Edit variant'})).not.toBeInTheDocument()
+    })
+    expect(variantOperationsMock.updateVariant).not.toHaveBeenCalled()
+  })
+
+  it('shows a toast and keeps the dialog open when updating fails', async () => {
+    const error = new Error('update failed')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    variantOperationsMock.updateVariant.mockRejectedValue(error)
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderDetail()
+
+    await user.click(screen.getByRole('button', {name: 'Edit variant'}))
+    await user.type(await screen.findByTestId('variant-form-title'), ' updated')
+    await user.click(screen.getByTestId('save-variant-button'))
+
+    await waitFor(() => {
+      expect(toastMock.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          title: 'Unable to update variant',
+        }),
+      )
+    })
+    expect(consoleError).toHaveBeenCalledWith(error)
+    expect(screen.getByRole('dialog', {name: 'Edit variant'})).toBeInTheDocument()
+
+    consoleError.mockRestore()
   })
 
   it('shows not found when variant id does not match any document', async () => {

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -129,6 +129,8 @@ describe('VariantDetail', () => {
     expect(screen.getByPlaceholderText('Search documents')).toBeInTheDocument()
     expect(screen.getByText('Edited')).toBeInTheDocument()
     expect(screen.getByText('No documents in this variant')).toBeInTheDocument()
+    expect(screen.getByText(/^Created/)).toBeInTheDocument()
+    expect(screen.getByTestId('variant-detail-footer-actions')).toBeInTheDocument()
   })
 
   it('opens the edit dialog with existing variant values', async () => {
@@ -254,6 +256,28 @@ describe('VariantDetail', () => {
     expect(screen.getByRole('dialog', {name: 'Edit variant'})).toBeInTheDocument()
 
     consoleError.mockRestore()
+  })
+
+  it('deletes the variant from the footer menu and navigates back to overview', async () => {
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderDetail()
+
+    const menuButton = screen
+      .getAllByRole('button')
+      .find((button) => button.id === 'variant-detail-actions-alpha-audience')
+
+    if (!menuButton) throw new Error('Variant detail actions menu button not found')
+
+    await user.click(menuButton)
+    await user.click(await screen.findByText('Delete variant'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
+      expect(mockNavigate).toHaveBeenCalledWith({})
+    })
   })
 
   it('shows not found when variant id does not match any document', async () => {

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -228,7 +228,8 @@ describe('VariantDetail', () => {
       'Condition keys must be unique',
     )
 
-    expect(screen.getByTestId('save-variant-button')).toBeDisabled()
+    expect(screen.getByTestId('save-variant-button')).toBeEnabled()
+    await user.click(screen.getByTestId('save-variant-button'))
     expect(variantOperationsMock.updateVariant).not.toHaveBeenCalled()
   })
 

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetailMenuButton.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetailMenuButton.test.tsx
@@ -5,12 +5,30 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
 import {variantAlphaAudience} from '../../__fixtures__/variants.fixture'
 import {variantsUsEnglishLocaleBundle} from '../../i18n'
-import {VariantMenuButton} from '../overview/VariantMenuButton'
+import {VariantDetailMenuButton} from '../detail/VariantDetailMenuButton'
+
+const mockNavigate = vi.fn()
 
 const variantOperationsMock = vi.hoisted(() => ({
   createVariant: vi.fn(),
   updateVariant: vi.fn(),
   deleteVariant: vi.fn(),
+}))
+
+const toastMock = vi.hoisted(() => ({
+  push: vi.fn(),
+}))
+
+vi.mock('@sanity/ui', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useToast: vi.fn(() => toastMock),
+}))
+
+vi.mock('sanity/router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRouter: vi.fn(() => ({
+    navigate: mockNavigate,
+  })),
 }))
 
 vi.mock('../../store/useVariantOperations', () => ({
@@ -28,7 +46,7 @@ function createDeferred<T = void>() {
   return {promise, resolve, reject}
 }
 
-describe('VariantMenuButton', () => {
+describe('VariantDetailMenuButton', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     variantOperationsMock.deleteVariant.mockResolvedValue(undefined)
@@ -38,12 +56,12 @@ describe('VariantMenuButton', () => {
     const wrapper = await createTestProvider({
       resources: [variantsUsEnglishLocaleBundle],
     })
-    const result = render(<VariantMenuButton variant={variantAlphaAudience} />, {wrapper})
+    const result = render(<VariantDetailMenuButton variant={variantAlphaAudience} />, {wrapper})
     await screen.findByRole('button')
     return result
   }
 
-  it('deletes the variant when delete is selected', async () => {
+  it('deletes the variant and navigates back to overview when delete is selected', async () => {
     const user = userEvent.setup()
 
     await renderMenuButton()
@@ -53,6 +71,7 @@ describe('VariantMenuButton', () => {
 
     await waitFor(() => {
       expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
+      expect(mockNavigate).toHaveBeenCalledWith({})
     })
   })
 
@@ -77,5 +96,30 @@ describe('VariantMenuButton', () => {
     await waitFor(() => {
       expect(menuButton).toBeEnabled()
     })
+  })
+
+  it('shows a toast and stays on the detail page when deletion fails', async () => {
+    const error = new Error('delete failed')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    variantOperationsMock.deleteVariant.mockRejectedValue(error)
+    const user = userEvent.setup()
+
+    await renderMenuButton()
+
+    await user.click(screen.getByRole('button'))
+    await user.click(await screen.findByText('Delete variant'))
+
+    await waitFor(() => {
+      expect(toastMock.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          title: 'Unable to delete variant',
+        }),
+      )
+    })
+    expect(consoleError).toHaveBeenCalledWith(error)
+    expect(mockNavigate).not.toHaveBeenCalled()
+
+    consoleError.mockRestore()
   })
 })

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -3,7 +3,6 @@ import {userEvent} from '@testing-library/user-event'
 import {type Ref, forwardRef, type HTMLProps} from 'react'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {flushMicrotasksThisIsACodeSmell} from '../../../../../test/testUtils/flushMicrotasks'
 import {setupVirtualListEnv} from '../../../../../test/testUtils/setupVirtualListEnv'
 import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
 import {variantAlphaAudience, variantNorwegianMarket} from '../../__fixtures__/variants.fixture'
@@ -105,7 +104,7 @@ describe('VariantsOverview', () => {
       resources: [variantsUsEnglishLocaleBundle],
     })
     const view = render(<VariantsOverview />, {wrapper})
-    await flushMicrotasksThisIsACodeSmell()
+    await screen.findByPlaceholderText('Search variant definitions…', {}, {timeout: 5000})
     return view
   }
 

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -194,7 +194,13 @@ describe('VariantsOverview', () => {
 
     await waitFor(() => expect(screen.getAllByTestId('table-row')).toHaveLength(1))
 
-    await user.click(within(screen.getAllByTestId('table-row')[0]!).getByRole('button'))
+    const menuButton = screen
+      .getAllByRole('button')
+      .find((button) => button.id === 'variant-actions-alpha-audience')
+
+    if (!menuButton) throw new Error('Variant actions menu button not found')
+
+    await user.click(menuButton)
     await user.click(await screen.findByText('Delete variant'))
   })
 

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsTool.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsTool.test.tsx
@@ -2,7 +2,6 @@ import {render, screen, waitFor} from '@testing-library/react'
 import {forwardRef, type HTMLProps} from 'react'
 import {describe, expect, it, vi} from 'vitest'
 
-import {flushMicrotasksThisIsACodeSmell} from '../../../../../test/testUtils/flushMicrotasks'
 import {setupVirtualListEnv} from '../../../../../test/testUtils/setupVirtualListEnv'
 import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
 import {variantAlphaAudience} from '../../__fixtures__/variants.fixture'
@@ -63,7 +62,6 @@ describe('VariantsTool', () => {
       resources: [variantsUsEnglishLocaleBundle],
     })
     const result = render(<VariantsTool />, {wrapper})
-    await flushMicrotasksThisIsACodeSmell()
     return result
   }
 

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
@@ -1,16 +1,28 @@
-import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
+import {type SanityDocument} from '@sanity/client'
+import {Box, Card, Container, Flex, Stack, Text} from '@sanity/ui'
+import {useState} from 'react'
 import {useRouter} from 'sanity/router'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {LoadingBlock} from '../../../components'
 import {useTranslation} from '../../../i18n'
+import {EditVariantDialog} from '../../components/dialog/EditVariantDialog'
 import {variantsLocaleNamespace} from '../../i18n'
 import {useAllVariants} from '../../store/useAllVariants'
-import {decodeVariantIdFromRoute, getVariantDescription, getVariantTitle} from '../util'
+import {
+  decodeVariantIdFromRoute,
+  getVariantConditionsText,
+  getVariantDescription,
+  getVariantTitle,
+} from '../util'
+import {VariantDocumentsTable} from './VariantDocumentsTable'
+
+const EMPTY_VARIANT_DOCUMENTS: SanityDocument[] = []
 
 export function VariantDetail() {
   const router = useRouter()
   const {t} = useTranslation(variantsLocaleNamespace)
+  const [editDialogOpen, setEditDialogOpen] = useState(false)
   const variantIdRaw =
     typeof router.state.variantId === 'string' ? router.state.variantId : undefined
   const variantId = decodeVariantIdFromRoute(variantIdRaw)
@@ -45,29 +57,54 @@ export function VariantDetail() {
   }
 
   const description = getVariantDescription(variant)
+  const conditionsText = getVariantConditionsText(variant.conditions)
 
   return (
     <Flex direction="column" flex={1} height="fill">
       <Card borderBottom flex="none" padding={3}>
         <Button mode="bleed" onClick={() => router.navigate({})} text={t('detail.back')} />
       </Card>
-      <Box padding={4}>
-        <Card border padding={4} radius={3}>
-          <Stack space={4}>
-            <Stack space={3}>
-              <Text as="h1" size={4} weight="bold">
-                {getVariantTitle(variant)}
-              </Text>
-              <Text muted size={1}>
-                {description || t('detail.no-description')}
-              </Text>
-            </Stack>
-            <Text muted size={1}>
-              {t('detail.placeholder')}
-            </Text>
-          </Stack>
-        </Card>
+      <Container flex="none" width={3}>
+        <Flex direction="column" paddingX={3}>
+          <Card paddingY={5}>
+            <Flex align="flex-start" gap={4} justify="space-between">
+              <Stack space={3}>
+                <Text as="h1" size={4} weight="bold">
+                  {getVariantTitle(variant)}
+                </Text>
+                <Text muted size={1}>
+                  {description || t('detail.no-description')}
+                </Text>
+              </Stack>
+              <Button
+                onClick={() => setEditDialogOpen(true)}
+                text={t('detail.action.edit-variant')}
+              />
+            </Flex>
+
+            <Box paddingTop={4}>
+              <Stack space={2}>
+                <Text size={1} weight="medium">
+                  {t('dialog.create.conditions.title')}
+                </Text>
+                <Text muted size={1}>
+                  {conditionsText || t('overview.table.no-conditions')}
+                </Text>
+              </Stack>
+            </Box>
+          </Card>
+        </Flex>
+      </Container>
+      <Box paddingBottom={4}>
+        <VariantDocumentsTable documents={EMPTY_VARIANT_DOCUMENTS} />
       </Box>
+      {editDialogOpen && (
+        <EditVariantDialog
+          onCancel={() => setEditDialogOpen(false)}
+          onSubmit={() => setEditDialogOpen(false)}
+          variant={variant}
+        />
+      )}
     </Flex>
   )
 }

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
@@ -15,6 +15,7 @@ import {
   getVariantDescription,
   getVariantTitle,
 } from '../util'
+import {VariantDetailFooter} from './VariantDetailFooter'
 import {VariantDocumentsTable} from './VariantDocumentsTable'
 
 const EMPTY_VARIANT_DOCUMENTS: SanityDocument[] = []
@@ -60,44 +61,47 @@ export function VariantDetail() {
   const conditionsText = getVariantConditionsText(variant.conditions)
 
   return (
-    <Flex direction="column" flex={1} height="fill">
+    <Flex direction="column" flex={1} height="fill" overflow="hidden">
       <Card borderBottom flex="none" padding={3}>
         <Button mode="bleed" onClick={() => router.navigate({})} text={t('detail.back')} />
       </Card>
-      <Container flex="none" width={3}>
-        <Flex direction="column" paddingX={3}>
-          <Card paddingY={5}>
-            <Flex align="flex-start" gap={4} justify="space-between">
-              <Stack space={3}>
-                <Text as="h1" size={4} weight="bold">
-                  {getVariantTitle(variant)}
-                </Text>
-                <Text muted size={1}>
-                  {description || t('detail.no-description')}
-                </Text>
-              </Stack>
-              <Button
-                onClick={() => setEditDialogOpen(true)}
-                text={t('detail.action.edit-variant')}
-              />
-            </Flex>
+      <Flex direction="column" flex={1} height="fill" overflow="hidden" style={{minHeight: 0}}>
+        <Container flex="none" width={3}>
+          <Flex direction="column" paddingX={3}>
+            <Card paddingY={5}>
+              <Flex align="flex-start" gap={4} justify="space-between">
+                <Stack space={3}>
+                  <Text as="h1" size={4} weight="bold">
+                    {getVariantTitle(variant)}
+                  </Text>
+                  <Text muted size={1}>
+                    {description || t('detail.no-description')}
+                  </Text>
+                </Stack>
+                <Button
+                  onClick={() => setEditDialogOpen(true)}
+                  text={t('detail.action.edit-variant')}
+                />
+              </Flex>
 
-            <Box paddingTop={4}>
-              <Stack space={2}>
-                <Text size={1} weight="medium">
-                  {t('dialog.create.conditions.title')}
-                </Text>
-                <Text muted size={1}>
-                  {conditionsText || t('overview.table.no-conditions')}
-                </Text>
-              </Stack>
-            </Box>
-          </Card>
+              <Box paddingTop={4}>
+                <Stack space={2}>
+                  <Text size={1} weight="medium">
+                    {t('dialog.create.conditions.title')}
+                  </Text>
+                  <Text muted size={1}>
+                    {conditionsText || t('overview.table.no-conditions')}
+                  </Text>
+                </Stack>
+              </Box>
+            </Card>
+          </Flex>
+        </Container>
+        <Flex direction="column" flex={1} overflow="hidden" style={{minHeight: 0}}>
+          <VariantDocumentsTable documents={EMPTY_VARIANT_DOCUMENTS} />
         </Flex>
-      </Container>
-      <Box paddingBottom={4}>
-        <VariantDocumentsTable documents={EMPTY_VARIANT_DOCUMENTS} />
-      </Box>
+      </Flex>
+      <VariantDetailFooter variant={variant} />
       {editDialogOpen && (
         <EditVariantDialog
           onCancel={() => setEditDialogOpen(false)}

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetailFooter.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetailFooter.tsx
@@ -1,0 +1,38 @@
+import {DiamondIcon} from '@sanity/icons'
+import {Box, Card, Flex, Text} from '@sanity/ui'
+
+import {RelativeTime} from '../../../components'
+import {useTranslation} from '../../../i18n'
+import {variantsLocaleNamespace} from '../../i18n'
+import {type SystemVariant} from '../../types'
+import {VariantDetailMenuButton} from './VariantDetailMenuButton'
+
+export function VariantDetailFooter({variant}: {variant: SystemVariant}): React.JSX.Element {
+  const {t} = useTranslation(variantsLocaleNamespace)
+
+  return (
+    <Card flex="none">
+      <Card borderTop marginX={2} style={{opacity: 0.6}} />
+
+      <Flex padding={3}>
+        <Flex flex={1} gap={1}>
+          <Card>
+            <Flex align="center" gap={2}>
+              <Text size={1}>
+                <DiamondIcon />
+              </Text>
+              <Text muted size={1}>
+                {t('detail.footer.created')}{' '}
+                <RelativeTime time={variant._createdAt} useTemporalPhrase minimal />
+              </Text>
+            </Flex>
+          </Card>
+        </Flex>
+
+        <Flex flex="none" gap={1} data-testid="variant-detail-footer-actions">
+          <VariantDetailMenuButton variant={variant} />
+        </Flex>
+      </Flex>
+    </Card>
+  )
+}

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetailFooter.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetailFooter.tsx
@@ -1,5 +1,5 @@
 import {DiamondIcon} from '@sanity/icons'
-import {Box, Card, Flex, Text} from '@sanity/ui'
+import {Card, Flex, Text} from '@sanity/ui'
 
 import {RelativeTime} from '../../../components'
 import {useTranslation} from '../../../i18n'

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetailMenuButton.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetailMenuButton.tsx
@@ -29,7 +29,7 @@ export function VariantDetailMenuButton({variant}: {variant: SystemVariant}): Re
       toast.push({
         closable: true,
         status: 'error',
-        title: t('overview.action.delete-variant.error'),
+        title: t('overview.action.delete-variant.error.title'),
       })
       setIsDeleting(false)
     }
@@ -42,6 +42,9 @@ export function VariantDetailMenuButton({variant}: {variant: SystemVariant}): Re
       menu={
         <Menu>
           <MenuItem
+            // TODO: This action now doesn't validate the documents count in a variant, once we can
+            // start adding documents to a variant we should revisit this to validate the documents count.
+            // If it has documents we should probably disable the delete action or at least handle it differently.
             disabled={isDeleting}
             onClick={handleDelete}
             text={t('overview.action.delete-variant')}

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetailMenuButton.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetailMenuButton.tsx
@@ -1,0 +1,55 @@
+import {Menu, useToast} from '@sanity/ui'
+import {useCallback, useState} from 'react'
+import {useRouter} from 'sanity/router'
+
+import {MenuButton, MenuItem} from '../../../../ui-components'
+import {ContextMenuButton} from '../../../components/contextMenuButton'
+import {useTranslation} from '../../../i18n'
+import {variantsLocaleNamespace} from '../../i18n'
+import {useVariantOperations} from '../../store/useVariantOperations'
+import {type SystemVariant} from '../../types'
+import {getVariantId} from '../util'
+
+export function VariantDetailMenuButton({variant}: {variant: SystemVariant}): React.JSX.Element {
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const router = useRouter()
+  const toast = useToast()
+  const {deleteVariant} = useVariantOperations()
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const handleDelete = useCallback(async () => {
+    setIsDeleting(true)
+
+    try {
+      await deleteVariant(variant._id)
+      setIsDeleting(false)
+      router.navigate({})
+    } catch (error) {
+      console.error(error)
+      toast.push({
+        closable: true,
+        status: 'error',
+        title: t('overview.action.delete-variant.error'),
+      })
+      setIsDeleting(false)
+    }
+  }, [deleteVariant, router, t, toast, variant._id])
+
+  return (
+    <MenuButton
+      button={<ContextMenuButton disabled={isDeleting} loading={isDeleting} />}
+      id={`variant-detail-actions-${getVariantId(variant._id)}`}
+      menu={
+        <Menu>
+          <MenuItem
+            disabled={isDeleting}
+            onClick={handleDelete}
+            text={t('overview.action.delete-variant')}
+            tone="critical"
+          />
+        </Menu>
+      }
+      popover={{placement: 'bottom-end', portal: true}}
+    />
+  )
+}

--- a/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
@@ -16,7 +16,7 @@ interface VariantDocumentRow {
 }
 
 const TABLE_CARD_STYLE: CSSProperties = {
-  height: 320,
+  height: '100%',
   overflow: 'auto',
 }
 
@@ -149,7 +149,7 @@ export function VariantDocumentsTable({
   const rows = useMemo(() => documents.map((document) => ({document})), [documents])
 
   return (
-    <Card ref={setScrollContainerRef} style={TABLE_CARD_STYLE}>
+    <Card flex={1} ref={setScrollContainerRef} style={TABLE_CARD_STYLE}>
       <Table<VariantDocumentRow>
         columnDefs={columnDefs}
         data={rows}

--- a/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
@@ -1,0 +1,165 @@
+import {type SanityDocument} from '@sanity/client'
+import {Box, Card, Flex, Text} from '@sanity/ui'
+import {type CSSProperties, memo, useMemo, useState} from 'react'
+
+import {RelativeTime} from '../../../components/RelativeTime'
+import {useSchema} from '../../../hooks'
+import {type UseTranslationResponse, useTranslation} from '../../../i18n'
+import {SanityDefaultPreview} from '../../../preview/components/SanityDefaultPreview'
+import {Table} from '../../../releases/tool/components/Table/Table'
+import {Headers} from '../../../releases/tool/components/Table/TableHeader'
+import {type Column} from '../../../releases/tool/components/Table/types'
+import {variantsLocaleNamespace} from '../../i18n'
+
+interface VariantDocumentRow {
+  document: SanityDocument
+}
+
+const TABLE_CARD_STYLE: CSSProperties = {
+  height: 320,
+  overflow: 'auto',
+}
+
+function getDocumentPreviewTitle(document: SanityDocument): string {
+  const title = document.title || document.name
+
+  return typeof title === 'string' && title.trim() ? title : document._id
+}
+
+const MemoDocumentType = memo(
+  function DocumentType({type}: {type: string}) {
+    const schema = useSchema()
+    const schemaType = schema.get(type)
+
+    return <Text size={1}>{schemaType?.title || type}</Text>
+  },
+  (prev, next) => prev.type === next.type,
+)
+
+function getVariantDocumentColumnDefs(
+  t: UseTranslationResponse<'variants', undefined>['t'],
+): Column<VariantDocumentRow>[] {
+  return [
+    {
+      id: 'version',
+      width: null,
+      style: {minWidth: 100},
+      sorting: false,
+      header: (props) => (
+        <Flex {...props.headerProps} paddingY={3} sizing="border">
+          <Headers.BasicHeader text={t('detail.documents.table.version')} />
+        </Flex>
+      ),
+      cell: ({cellProps}) => (
+        <Flex align="center" {...cellProps}>
+          <Box paddingX={2}>
+            <Text muted size={1}>
+              -
+            </Text>
+          </Box>
+        </Flex>
+      ),
+    },
+    {
+      id: 'document._type',
+      width: null,
+      style: {minWidth: 100},
+      sorting: true,
+      header: (props) => (
+        <Flex {...props.headerProps} paddingY={3} sizing="border">
+          <Headers.SortHeaderButton text={t('detail.documents.table.type')} {...props} />
+        </Flex>
+      ),
+      cell: ({cellProps, datum}) => (
+        <Flex align="center" {...cellProps}>
+          <Box paddingX={2}>
+            {!datum.isLoading && <MemoDocumentType type={datum.document._type} />}
+          </Box>
+        </Flex>
+      ),
+    },
+    {
+      id: 'search',
+      width: null,
+      style: {minWidth: 'min(50%, calc(100vw - 80px))', maxWidth: 'min(50%, calc(100vw - 80px))'},
+      sortTransform: ({document}) => getDocumentPreviewTitle(document).toLowerCase(),
+      header: (props) => (
+        <Headers.TableHeaderSearch
+          {...props}
+          placeholder={t('detail.documents.table.search-placeholder')}
+        />
+      ),
+      cell: ({cellProps, datum}) => (
+        <Box {...cellProps} flex={1} padding={1} paddingRight={2} sizing="border">
+          {datum.isLoading ? (
+            <SanityDefaultPreview isPlaceholder />
+          ) : (
+            <SanityDefaultPreview
+              title={getDocumentPreviewTitle(datum.document)}
+              subtitle={datum.document._id}
+            />
+          )}
+        </Box>
+      ),
+    },
+    {
+      id: 'document._updatedAt',
+      sorting: true,
+      width: 130,
+      header: (props) => (
+        <Flex {...props.headerProps} paddingY={3} sizing="border">
+          <Headers.SortHeaderButton text={t('detail.documents.table.edited')} {...props} />
+        </Flex>
+      ),
+      cell: ({cellProps, datum}) => (
+        <Flex {...cellProps} align="center" paddingX={2} paddingY={3} style={{minWidth: 130}}>
+          {!datum.isLoading && datum.document._updatedAt && (
+            <Text muted size={1}>
+              <RelativeTime time={datum.document._updatedAt} useTemporalPhrase minimal />
+            </Text>
+          )}
+        </Flex>
+      ),
+    },
+  ]
+}
+
+function filterDocuments(rows: VariantDocumentRow[], searchTerm: string): VariantDocumentRow[] {
+  const normalizedSearchTerm = searchTerm.trim().toLowerCase()
+
+  if (!normalizedSearchTerm) {
+    return rows
+  }
+
+  return rows.filter(({document}) =>
+    [getDocumentPreviewTitle(document), document._id, document._type].some((value) =>
+      value.toLowerCase().includes(normalizedSearchTerm),
+    ),
+  )
+}
+
+export function VariantDocumentsTable({
+  documents,
+}: {
+  documents: SanityDocument[]
+}): React.JSX.Element {
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(null)
+  const columnDefs = useMemo(() => getVariantDocumentColumnDefs(t), [t])
+  const rows = useMemo(() => documents.map((document) => ({document})), [documents])
+
+  return (
+    <Card ref={setScrollContainerRef} style={TABLE_CARD_STYLE}>
+      <Table<VariantDocumentRow>
+        columnDefs={columnDefs}
+        data={rows}
+        defaultSort={{column: 'search', direction: 'asc'}}
+        emptyState={t('detail.documents.no-documents')}
+        // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals
+        rowId="document._id"
+        scrollContainerRef={scrollContainerRef}
+        searchFilter={filterDocuments}
+      />
+    </Card>
+  )
+}

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
@@ -1,0 +1,88 @@
+import {type SanityDocument} from '@sanity/client'
+import {render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {describe, expect, it, vi} from 'vitest'
+
+import {setupVirtualListEnv} from '../../../../../../test/testUtils/setupVirtualListEnv'
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {variantsUsEnglishLocaleBundle} from '../../../i18n'
+import {VariantDocumentsTable} from '../VariantDocumentsTable'
+
+vi.mock('../../../../preview/components/SanityDefaultPreview', () => ({
+  SanityDefaultPreview: vi.fn(({isPlaceholder, title, subtitle}) => (
+    <div data-testid={isPlaceholder ? 'preview-placeholder' : 'preview'}>
+      {!isPlaceholder && title && <div>{title}</div>}
+      {!isPlaceholder && subtitle && <div>{subtitle}</div>}
+    </div>
+  )),
+}))
+
+setupVirtualListEnv()
+
+const mockDocuments: SanityDocument[] = [
+  {
+    _id: 'drafts.article-first',
+    _type: 'article',
+    _rev: 'rev-1',
+    _createdAt: '2025-01-01T00:00:00Z',
+    _updatedAt: '2025-06-01T00:00:00Z',
+    title: 'First article',
+  },
+  {
+    _id: 'drafts.article-second',
+    _type: 'article',
+    _rev: 'rev-2',
+    _createdAt: '2025-01-02T00:00:00Z',
+    _updatedAt: '2025-06-02T00:00:00Z',
+    title: 'Second article',
+  },
+]
+
+describe('VariantDocumentsTable', () => {
+  const renderTable = async (documents: SanityDocument[] = mockDocuments) => {
+    const wrapper = await createTestProvider({
+      resources: [variantsUsEnglishLocaleBundle],
+    })
+    const result = render(<VariantDocumentsTable documents={documents} />, {wrapper})
+    await screen.findByPlaceholderText('Search documents')
+    return result
+  }
+
+  it('shows an empty state when there are no documents', async () => {
+    await renderTable([])
+
+    expect(screen.getByText('No documents in this variant')).toBeInTheDocument()
+  })
+
+  it('renders document rows with title, type, and edited columns', async () => {
+    await renderTable()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(2)
+    })
+
+    expect(screen.getByText('First article')).toBeInTheDocument()
+    expect(screen.getByText('Second article')).toBeInTheDocument()
+    expect(screen.getByText('drafts.article-first')).toBeInTheDocument()
+    expect(screen.getAllByText('article')).toHaveLength(2)
+  })
+
+  it('filters documents when searching by title, id, or type', async () => {
+    const user = userEvent.setup()
+
+    await renderTable()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(2)
+    })
+
+    await user.type(screen.getByPlaceholderText('Search documents'), 'Second')
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(1)
+    })
+
+    expect(screen.getByText('Second article')).toBeInTheDocument()
+    expect(screen.queryByText('First article')).not.toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/core/variants/util/__tests__/conditionValidation.test.ts
+++ b/packages/sanity/src/core/variants/util/__tests__/conditionValidation.test.ts
@@ -1,0 +1,48 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+  getConditionKeyValidationError,
+  getConditionValueValidationError,
+} from '../conditionValidation'
+
+describe('conditionValidation', () => {
+  describe('getConditionKeyValidationError', () => {
+    it('accepts valid lowercase keys', () => {
+      expect(getConditionKeyValidationError('audience')).toBeUndefined()
+      expect(getConditionKeyValidationError('locale_code')).toBeUndefined()
+      expect(getConditionKeyValidationError('tier-1')).toBeUndefined()
+    })
+
+    it('rejects reserved prefixes', () => {
+      expect(getConditionKeyValidationError('_system')).toBe('reserved')
+      expect(getConditionKeyValidationError('$param')).toBe('reserved')
+    })
+
+    it('rejects invalid key formats', () => {
+      expect(getConditionKeyValidationError('Audience')).toBe('invalid')
+      expect(getConditionKeyValidationError('1audience')).toBe('invalid')
+      expect(getConditionKeyValidationError('audience:segment')).toBe('invalid')
+      expect(getConditionKeyValidationError('a'.repeat(65))).toBe('invalid')
+    })
+
+    it('ignores empty keys while editing', () => {
+      expect(getConditionKeyValidationError('')).toBeUndefined()
+      expect(getConditionKeyValidationError('   ')).toBeUndefined()
+    })
+  })
+
+  describe('getConditionValueValidationError', () => {
+    it('accepts non-empty values', () => {
+      expect(getConditionValueValidationError('loyal')).toBeUndefined()
+    })
+
+    it('rejects empty values', () => {
+      expect(getConditionValueValidationError('')).toBe('empty')
+      expect(getConditionValueValidationError('   ')).toBe('empty')
+    })
+
+    it('rejects values with colons', () => {
+      expect(getConditionValueValidationError('loyal:customers')).toBe('invalid')
+    })
+  })
+})

--- a/packages/sanity/src/core/variants/util/__tests__/variantDefaults.test.ts
+++ b/packages/sanity/src/core/variants/util/__tests__/variantDefaults.test.ts
@@ -1,0 +1,34 @@
+import {describe, expect, it} from 'vitest'
+
+import {createPortableTextDescription} from '../variantDefaults'
+
+describe('createPortableTextDescription', () => {
+  it('returns an empty array for whitespace-only input', () => {
+    expect(createPortableTextDescription('')).toEqual([])
+    expect(createPortableTextDescription('   ')).toEqual([])
+  })
+
+  it('preserves untrimmed text in the portable text block', () => {
+    const description = createPortableTextDescription('  hello world  ')
+
+    expect(description).toHaveLength(1)
+    expect(description[0]?.children[0]?.text).toBe('  hello world  ')
+  })
+
+  it('creates a single normal block for non-empty input', () => {
+    const description = createPortableTextDescription('Developer audience')
+
+    expect(description).toEqual([
+      expect.objectContaining({
+        _type: 'block',
+        style: 'normal',
+        children: [
+          expect.objectContaining({
+            _type: 'span',
+            text: 'Developer audience',
+          }),
+        ],
+      }),
+    ])
+  })
+})

--- a/packages/sanity/src/core/variants/util/conditionValidation.ts
+++ b/packages/sanity/src/core/variants/util/conditionValidation.ts
@@ -1,0 +1,42 @@
+const CONDITION_KEY_REGEX = /^[a-z][a-z0-9_-]{0,63}$/
+const CONDITION_SEPARATOR = ':'
+const RESERVED_KEY_PREFIXES = ['_', '$'] as const
+
+export type ConditionKeyValidationError = 'invalid' | 'reserved'
+export type ConditionValueValidationError = 'empty' | 'invalid'
+
+export function getConditionKeyValidationError(
+  key: string,
+): ConditionKeyValidationError | undefined {
+  const trimmedKey = key.trim()
+
+  if (!trimmedKey) {
+    return undefined
+  }
+
+  for (const prefix of RESERVED_KEY_PREFIXES) {
+    if (trimmedKey.startsWith(prefix)) {
+      return 'reserved'
+    }
+  }
+
+  if (trimmedKey.includes(CONDITION_SEPARATOR) || !CONDITION_KEY_REGEX.test(trimmedKey)) {
+    return 'invalid'
+  }
+
+  return undefined
+}
+
+export function getConditionValueValidationError(
+  value: string,
+): ConditionValueValidationError | undefined {
+  if (!value.trim()) {
+    return 'empty'
+  }
+
+  if (value.includes(CONDITION_SEPARATOR)) {
+    return 'invalid'
+  }
+
+  return undefined
+}

--- a/packages/sanity/src/core/variants/util/variantDefaults.ts
+++ b/packages/sanity/src/core/variants/util/variantDefaults.ts
@@ -39,7 +39,7 @@ export function createPortableTextDescription(text: string): PortableTextBlock[]
           _key: randomKey(12),
           _type: 'span',
           marks: [],
-          text: trimmedText,
+          text,
         },
       ],
       markDefs: [],


### PR DESCRIPTION
### Description
This PR continues the work on the variants tool by allowing us to edit an existing variant.
It builds a detail page, similar to releases detail in where you can see the documents that are part of that variant , which is in purpose empty now. This will be populated in a following step.

<img width="1125" height="614" alt="Screenshot 2026-05-20 at 09 39 06" src="https://github.com/user-attachments/assets/29ed9eac-3ed7-4a3e-bdc1-c5b7463517c7" />

Clicking on edit variant opens the variant form inside a dialog, this won't be the eventual experience but setting up inline editing requires a lot of code and given we don't have the definite UI yet I think it's not worth doing this right now, this is intended to give us an initial implementation from which we can start building and editing the documents.


https://github.com/user-attachments/assets/82936541-89e6-4f82-9d2f-80ae0890b659


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Open the variants tool, select an existing variant and click to edit, it should be possible to edit it.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a internal
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
