### PR TITLE
chore(ci): bring back build metadata for prereleases

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -35,8 +35,7 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Bump canary versions
-        # `--no-build-metadata` works around https://github.com/pnpm/pnpm/issues/11518
-        run: pnpm --silent release-notes bump --preid=canary --no-build-metadata
+        run: pnpm --silent release-notes bump --preid=canary
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped

--- a/.github/workflows/release-next-major.yml
+++ b/.github/workflows/release-next-major.yml
@@ -35,8 +35,7 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Bump next-major versions
-        # `--no-build-metadata` works around https://github.com/pnpm/pnpm/issues/11518
-        run: pnpm --silent release-notes bump --preid=next-major --no-build-metadata
+        run: pnpm --silent release-notes bump --preid=next-major
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -38,8 +38,7 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Bump next versions
-        # `--no-build-metadata` works around https://github.com/pnpm/pnpm/issues/11518
-        run: pnpm --silent release-notes bump --preid=next --suffixType=commits-ahead --no-build-metadata
+        run: pnpm --silent release-notes bump --preid=next --suffixType=commits-ahead
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped


### PR DESCRIPTION
### Description
Now that https://github.com/pnpm/pnpm/issues/11518 has been fixed, we can bring back build metadata on our prereleases.

Note: leaving the CLI option in place in case we'll need it in the future.

### What to review
Makes sense?

### Testing
Non-trivial to test without merging and verifying that build metadata (`+<sha>`) is included with the version.

### Notes for release
n/a