### PR TITLE
fix(sanity): full-screen PTE popover boundaries

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -10,7 +10,14 @@ import {
   type RangeDecoration,
 } from '@portabletext/editor'
 import {type Path, type PortableTextBlock, type PortableTextTextBlock} from '@sanity/types'
-import {Box, Portal, PortalProvider, useBoundaryElement, usePortal} from '@sanity/ui'
+import {
+  BoundaryElementProvider,
+  Box,
+  Portal,
+  PortalProvider,
+  useBoundaryElement,
+  usePortal,
+} from '@sanity/ui'
 import {type ReactNode, useCallback, useMemo, useState} from 'react'
 
 import {ChangeIndicator} from '../../../changeIndicators'
@@ -111,6 +118,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
   const boundaryElement = useBoundaryElement().element
   const [wrapperElement, setWrapperElement] = useState<HTMLDivElement | null>(null)
   const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null)
+  const floatingBoundary = isFullscreen ? scrollElement : boundaryElement
 
   const handleToggleFullscreen = useCallback(() => {
     onToggleFullscreen()
@@ -142,7 +150,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
 
       return (
         <TextBlock
-          floatingBoundary={boundaryElement}
+          floatingBoundary={floatingBoundary}
           focused={blockFocused}
           isFullscreen={isFullscreen}
           onItemClose={onItemClose}
@@ -174,7 +182,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     [
       _renderBlockActions,
       _renderCustomMarkers,
-      boundaryElement,
+      floatingBoundary,
       isFullscreen,
       onItemClose,
       onItemOpen,
@@ -215,7 +223,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       }
       return (
         <BlockObject
-          floatingBoundary={boundaryElement}
+          floatingBoundary={floatingBoundary}
           focused={blockFocused}
           isFullscreen={isFullscreen}
           onItemClose={onItemClose}
@@ -243,7 +251,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       )
     },
     [
-      boundaryElement,
+      floatingBoundary,
       scrollElement,
       schemaTypes.blockObjects,
       isFullscreen,
@@ -305,7 +313,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       }
       return (
         <InlineObject
-          floatingBoundary={boundaryElement}
+          floatingBoundary={floatingBoundary}
           focused={childFocused}
           onItemClose={onItemClose}
           onItemOpen={onItemOpen}
@@ -332,7 +340,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     [
       schemaTypes.span.name,
       schemaTypes.inlineObjects,
-      boundaryElement,
+      floatingBoundary,
       onItemClose,
       onItemOpen,
       onPathFocus,
@@ -371,7 +379,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       return (
         <Annotation
           editorNodeFocused={editorNodeFocused}
-          floatingBoundary={boundaryElement}
+          floatingBoundary={floatingBoundary}
           focused={Boolean(focused)}
           onItemClose={onItemClose}
           onItemOpen={onItemOpen}
@@ -398,7 +406,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     },
     [
       schemaTypes.annotations,
-      boundaryElement,
+      floatingBoundary,
       scrollElement,
       focused,
       onItemClose,
@@ -539,35 +547,34 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
   return (
     <SelectedAnnotationsProvider>
       <PortalProvider __unstable_elements={portalElements} element={portal.element}>
-        <ActivateOnFocus onActivate={onActivate} isOverlayActive={!isActive}>
-          <ChangeIndicator
-            disabled={isFullscreen}
-            hasFocus={Boolean(focused)}
-            isChanged={changed}
-            path={path}
-          >
-            <Root
-              data-focused={editorFocused ? '' : undefined}
-              data-read-only={readOnly ? '' : undefined}
+        <BoundaryElementProvider element={floatingBoundary}>
+          <ActivateOnFocus onActivate={onActivate} isOverlayActive={!isActive}>
+            <ChangeIndicator
+              disabled={isFullscreen}
+              hasFocus={Boolean(focused)}
+              isChanged={changed}
+              path={path}
             >
-              <Box data-wrapper="" ref={setWrapperElement}>
-                <Portal __unstable_name={isFullscreen ? 'expanded' : 'collapsed'}>
-                  {isFullscreen ? <ExpandedLayer>{editorNode}</ExpandedLayer> : editorNode}
-                  <AnnotationObjectEditModal
-                    focused={focused}
-                    onItemClose={onItemClose}
-                    referenceBoundary={scrollElement}
-                  />
-                  <CombinedAnnotationPopover
-                    floatingBoundary={boundaryElement}
-                    referenceBoundary={scrollElement}
-                  />
-                </Portal>
-              </Box>
-              <div data-border="" />
-            </Root>
-          </ChangeIndicator>
-        </ActivateOnFocus>
+              <Root
+                data-focused={editorFocused ? '' : undefined}
+                data-read-only={readOnly ? '' : undefined}
+              >
+                <Box data-wrapper="" ref={setWrapperElement}>
+                  <Portal __unstable_name={isFullscreen ? 'expanded' : 'collapsed'}>
+                    {isFullscreen ? <ExpandedLayer>{editorNode}</ExpandedLayer> : editorNode}
+                    <AnnotationObjectEditModal
+                      focused={focused}
+                      onItemClose={onItemClose}
+                      referenceBoundary={scrollElement}
+                    />
+                    <CombinedAnnotationPopover referenceBoundary={scrollElement} />
+                  </Portal>
+                </Box>
+                <div data-border="" />
+              </Root>
+            </ChangeIndicator>
+          </ActivateOnFocus>
+        </BoundaryElementProvider>
       </PortalProvider>
     </SelectedAnnotationsProvider>
   )

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -17,7 +17,7 @@ import {type Path} from '@sanity/types'
 import {BoundaryElementProvider, useBoundaryElement, useGlobalKeyDown, useLayer} from '@sanity/ui'
 // eslint-disable-next-line camelcase
 import {getTheme_v2} from '@sanity/ui/theme'
-import {type ReactNode, useCallback, useMemo} from 'react'
+import {type ReactNode, useCallback, useMemo, useState} from 'react'
 import {css, styled} from 'styled-components'
 
 import {TooltipDelayGroupProvider} from '../../../../ui-components'
@@ -100,6 +100,7 @@ export function Editor(props: EditorProps): ReactNode {
   const {isTopLayer} = useLayer()
 
   const {element: boundaryElement} = useBoundaryElement()
+  const [rootElement, setRootElement] = useState<HTMLDivElement | null>(null)
 
   // Let escape close fullscreen mode
   useGlobalKeyDown(
@@ -191,20 +192,27 @@ export function Editor(props: EditorProps): ReactNode {
   const collapsibleToolbar = id === FORM_BUILDER_DEFAULT_ID
 
   return (
-    <Root data-fullscreen={isFullscreen} data-testid="pt-editor" $isOneLine={isOneLine}>
+    <Root
+      data-fullscreen={isFullscreen}
+      data-testid="pt-editor"
+      ref={setRootElement}
+      $isOneLine={isOneLine}
+    >
       {isActive && !hideToolbar && (
-        <TooltipDelayGroupProvider>
-          <ToolbarCard data-testid="pt-editor__toolbar-card" shadow={1}>
-            <Toolbar
-              collapsible={collapsibleToolbar}
-              hotkeys={hotkeys}
-              isFullscreen={isFullscreen}
-              onMemberOpen={handleToolBarOnMemberOpen}
-              onToggleFullscreen={onToggleFullscreen}
-              readOnly={readOnly}
-            />
-          </ToolbarCard>
-        </TooltipDelayGroupProvider>
+        <BoundaryElementProvider element={isFullscreen ? rootElement : boundaryElement}>
+          <TooltipDelayGroupProvider>
+            <ToolbarCard data-testid="pt-editor__toolbar-card" shadow={1}>
+              <Toolbar
+                collapsible={collapsibleToolbar}
+                hotkeys={hotkeys}
+                isFullscreen={isFullscreen}
+                onMemberOpen={handleToolBarOnMemberOpen}
+                onToggleFullscreen={onToggleFullscreen}
+                readOnly={readOnly}
+              />
+            </ToolbarCard>
+          </TooltipDelayGroupProvider>
+        </BoundaryElementProvider>
       )}
 
       <EditableCard flex={1} tone={readOnly ? 'transparent' : 'default'}>

--- a/packages/sanity/src/core/form/inputs/PortableText/object/CombinedAnnotationPopover.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/CombinedAnnotationPopover.tsx
@@ -1,6 +1,6 @@
 import {PortableTextEditor, usePortableTextEditor} from '@portabletext/editor'
 import {EditIcon, TrashIcon} from '@sanity/icons'
-import {Box, Flex, Text, useGlobalKeyDown, useTheme} from '@sanity/ui'
+import {Box, Flex, Text, useBoundaryElement, useGlobalKeyDown, useTheme} from '@sanity/ui'
 import {type ReactNode, useCallback, useEffect, useMemo, useRef, useState} from 'react'
 
 import {Button, Popover, type PopoverProps} from '../../../../../ui-components'
@@ -10,12 +10,12 @@ import {useSelectedAnnotations} from '../contexts/SelectedAnnotationsContext'
 const POPOVER_FALLBACK_PLACEMENTS: PopoverProps['fallbackPlacements'] = ['top', 'bottom']
 
 interface CombinedAnnotationPopoverProps {
-  floatingBoundary: HTMLElement | null
   referenceBoundary: HTMLElement | null
 }
 
 export function CombinedAnnotationPopover(props: CombinedAnnotationPopoverProps): ReactNode {
-  const {floatingBoundary, referenceBoundary} = props
+  const {referenceBoundary} = props
+  const {element: floatingBoundary} = useBoundaryElement()
   const {annotations} = useSelectedAnnotations()
   const [cursorRect, setCursorRect] = useState<DOMRect | null>(null)
   const [popoverOpen, setPopoverOpen] = useState<boolean>(false)


### PR DESCRIPTION
### Description

Popovers rendered by PTE currently use the incorrect boundary when PTE is in full-screen mode. This can cause popovers (e.g. PTE menus, and PTE collapsed toolbar menu) to render in the wrong position, or simply not appear at all.

This branch fixes the problem by switching the boundary element when PTE is in full-screen mode.

### What to review

New boundary element in PTE, popovers rendered by PTE in full-screen and inline display modes.

For example, go to [a PTE document such as this](https://test-studio-5ytg1ykng.sanity.dev/test/structure/input-standard;portable-text;pt_allTheBellsAndWhistles;fee23561-da33-4e0d-aa02-3d1dadb90afd), narrow your viewport enough to cause the PTE toolbar to overflow, and then make the PTE full-screen. The formatting and PTE overflow menus should open as expected.

<img width="518" height="226" alt="Screenshot 2026-05-20 at 15 22 34" src="https://github.com/user-attachments/assets/57279391-fd76-4efd-a239-436a48c9ddde" />

### Testing

Manually verified reported issues in Test Studio are resolved.

### Notes for release

Fixes an issue preventing Portable Text toolbar menus rendering correctly.