### PR TITLE
chore(core): add variants conditions autocomplete

### DIFF
--- a/packages/sanity/src/core/variants/components/dialog/ConditionAutocompleteInput.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/ConditionAutocompleteInput.tsx
@@ -1,0 +1,66 @@
+import {Autocomplete} from '@sanity/ui'
+import {useCallback, useId, useState} from 'react'
+
+import {type ConditionSuggestionOption, filterConditionOption} from './conditionSuggestions'
+
+interface ConditionAutocompleteInputProps {
+  ariaLabel: string
+  autoFocus?: boolean
+  customValidity?: string
+  invalid?: boolean
+  onChange: (value: string) => void
+  options: ConditionSuggestionOption[]
+  placeholder: string
+  testId: string
+  value: string
+}
+
+export function ConditionAutocompleteInput(
+  props: ConditionAutocompleteInputProps,
+): React.JSX.Element {
+  const {
+    ariaLabel,
+    autoFocus,
+    customValidity,
+    invalid,
+    onChange,
+    options,
+    placeholder,
+    testId,
+    value,
+  } = props
+  const id = useId()
+  const [focused, setFocused] = useState(false)
+
+  const handleQueryChange = useCallback(
+    (nextValue: string | null) => {
+      // `onChange` fires when an option is selected. Free-text typing is exposed
+      // through `onQueryChange`; `null` means the internal query closed.
+      if (nextValue !== null) {
+        onChange(nextValue)
+      }
+    },
+    [onChange],
+  )
+
+  return (
+    <Autocomplete
+      id={id}
+      aria-invalid={invalid ? 'true' : undefined}
+      aria-label={ariaLabel}
+      autoFocus={autoFocus}
+      customValidity={customValidity}
+      data-testid={testId}
+      filterOption={filterConditionOption}
+      fontSize={1}
+      onBlur={() => setFocused(false)}
+      onChange={onChange}
+      onFocus={() => setFocused(true)}
+      onQueryChange={handleQueryChange}
+      openButton
+      options={options}
+      placeholder={placeholder}
+      value={focused ? undefined : value}
+    />
+  )
+}

--- a/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
@@ -1,7 +1,6 @@
 import {at, set} from '@sanity/mutate'
 import {applyPatches} from '@sanity/mutate/_unstable_apply'
 import {Box, Card, Flex, useToast} from '@sanity/ui'
-import {toString} from '@sanity/util/paths'
 import {type FormEvent, useCallback, useState} from 'react'
 
 import {Button, Dialog} from '../../../../ui-components'
@@ -46,7 +45,7 @@ export function VariantDialog(props: VariantDialogProps): React.JSX.Element {
   const handleVariantChange = useCallback<VariantFormChangeHandler>((path, nextValue) => {
     setVariant(
       (currentVariant) =>
-        applyPatches([at(toString(path), set(nextValue))], currentVariant) as EditableSystemVariant,
+        applyPatches([at(path, set(nextValue))], currentVariant) as EditableSystemVariant,
     )
   }, [])
 

--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -19,7 +19,11 @@ import {
 import {getVariantTitleValue} from '../../util/getIsVariantInvalid'
 import {createPortableTextDescription} from '../../util/variantDefaults'
 import {ConditionAutocompleteInput} from './ConditionAutocompleteInput'
-import {getConditionKeyOptions, getConditionValueOptions} from './conditionSuggestions'
+import {
+  buildConditionSuggestionIndex,
+  getConditionKeyOptions,
+  getConditionValueOptions,
+} from './conditionSuggestions'
 
 interface ConditionRow {
   id: string
@@ -129,6 +133,7 @@ export function VariantForm(props: {
   const {onChange, onConditionValidityChange, showValidation = false, value} = props
   const {t} = useTranslation(variantsLocaleNamespace)
   const {data: variants} = useAllVariants()
+  const suggestionIndex = useMemo(() => buildConditionSuggestionIndex(variants), [variants])
   const titleId = useId()
   const descriptionId = useId()
   // `conditions` is stored as an object, but object keys are awkward to edit live:
@@ -274,7 +279,7 @@ export function VariantForm(props: {
                       customValidity={validation.key ? t(validation.key) : undefined}
                       invalid={Boolean(validation.key)}
                       onChange={(nextValue) => handleConditionChange(index, 'key', nextValue)}
-                      options={getConditionKeyOptions(variants, conditionRows, index)}
+                      options={getConditionKeyOptions(suggestionIndex, conditionRows, index)}
                       placeholder={t('dialog.create.condition-key.placeholder')}
                       testId="variant-form-condition-key"
                       value={row.key}
@@ -286,7 +291,7 @@ export function VariantForm(props: {
                       customValidity={valueValidation ? t(valueValidation) : undefined}
                       invalid={Boolean(valueValidation)}
                       onChange={(nextValue) => handleConditionChange(index, 'value', nextValue)}
-                      options={getConditionValueOptions(variants, row.key)}
+                      options={getConditionValueOptions(suggestionIndex, row.key)}
                       placeholder={t('dialog.create.condition-value.placeholder')}
                       testId="variant-form-condition-value"
                       value={row.value}

--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -9,9 +9,12 @@ import {Button} from '../../../../ui-components'
 import {TextWithTone} from '../../../components/textWithTone/TextWithTone'
 import {useTranslation} from '../../../i18n'
 import {variantsLocaleNamespace} from '../../i18n'
+import {useAllVariants} from '../../store/useAllVariants'
 import {type EditableSystemVariant} from '../../types'
 import {getVariantTitleValue} from '../../util/getIsVariantInvalid'
 import {createPortableTextDescription} from '../../util/variantDefaults'
+import {ConditionAutocompleteInput} from './ConditionAutocompleteInput'
+import {getConditionKeyOptions, getConditionValueOptions} from './conditionSuggestions'
 
 interface ConditionRow {
   id: string
@@ -96,6 +99,7 @@ export function VariantForm(props: {
 }) {
   const {onChange, onConditionValidityChange, showValidation = false, value} = props
   const {t} = useTranslation(variantsLocaleNamespace)
+  const {data: variants} = useAllVariants()
   const titleId = useId()
   const descriptionId = useId()
   const [titleTouched, setTitleTouched] = useState(false)
@@ -233,33 +237,29 @@ export function VariantForm(props: {
             <Stack key={row.id} space={2}>
               <Flex align="center" gap={2}>
                 <Box flex={1}>
-                  <TextInput
+                  <ConditionAutocompleteInput
                     autoFocus={index > 0}
-                    aria-invalid={duplicateConditionKeyIndexes.has(index) ? 'true' : undefined}
-                    aria-label={t('dialog.create.condition-key.label')}
+                    ariaLabel={t('dialog.create.condition-key.label')}
                     customValidity={
                       duplicateConditionKeyIndexes.has(index)
                         ? t('dialog.create.condition-key.duplicate')
                         : undefined
                     }
-                    data-testid="variant-form-condition-key"
-                    fontSize={1}
-                    onChange={(event) =>
-                      handleConditionChange(index, 'key', event.currentTarget.value)
-                    }
+                    invalid={duplicateConditionKeyIndexes.has(index)}
+                    onChange={(nextValue) => handleConditionChange(index, 'key', nextValue)}
+                    options={getConditionKeyOptions(variants, conditionRows, index)}
                     placeholder={t('dialog.create.condition-key.placeholder')}
+                    testId="variant-form-condition-key"
                     value={row.key}
                   />
                 </Box>
                 <Box flex={1}>
-                  <TextInput
-                    aria-label={t('dialog.create.condition-value.label')}
-                    data-testid="variant-form-condition-value"
-                    fontSize={1}
-                    onChange={(event) =>
-                      handleConditionChange(index, 'value', event.currentTarget.value)
-                    }
+                  <ConditionAutocompleteInput
+                    ariaLabel={t('dialog.create.condition-value.label')}
+                    onChange={(nextValue) => handleConditionChange(index, 'value', nextValue)}
+                    options={getConditionValueOptions(variants, row.key)}
                     placeholder={t('dialog.create.condition-value.placeholder')}
+                    testId="variant-form-condition-value"
                     value={row.value}
                   />
                 </Box>

--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -1,6 +1,7 @@
 import {isPortableTextBlock, toPlainText} from '@portabletext/toolkit'
 import {AddIcon, TrashIcon} from '@sanity/icons'
-import {type PortableTextBlock, type Path} from '@sanity/types'
+import {type Path} from '@sanity/mutate'
+import {type PortableTextBlock} from '@sanity/types'
 import {Box, Flex, Stack, Text, TextArea, TextInput} from '@sanity/ui'
 import {randomKey} from '@sanity/util/content'
 import {type ChangeEvent, useCallback, useId, useMemo, useState} from 'react'
@@ -9,6 +10,7 @@ import {Button} from '../../../../ui-components'
 import {TextWithTone} from '../../../components/textWithTone/TextWithTone'
 import {useTranslation} from '../../../i18n'
 import {type VariantsLocaleResourceKeys, variantsLocaleNamespace} from '../../i18n'
+import {useAllVariants} from '../../store/useAllVariants'
 import {type EditableSystemVariant} from '../../types'
 import {
   getConditionKeyValidationError,
@@ -16,6 +18,8 @@ import {
 } from '../../util/conditionValidation'
 import {getVariantTitleValue} from '../../util/getIsVariantInvalid'
 import {createPortableTextDescription} from '../../util/variantDefaults'
+import {ConditionAutocompleteInput} from './ConditionAutocompleteInput'
+import {getConditionKeyOptions, getConditionValueOptions} from './conditionSuggestions'
 
 interface ConditionRow {
   id: string
@@ -124,6 +128,7 @@ export function VariantForm(props: {
 }) {
   const {onChange, onConditionValidityChange, showValidation = false, value} = props
   const {t} = useTranslation(variantsLocaleNamespace)
+  const {data: variants} = useAllVariants()
   const titleId = useId()
   const descriptionId = useId()
   // `conditions` is stored as an object, but object keys are awkward to edit live:
@@ -263,29 +268,27 @@ export function VariantForm(props: {
               <Stack key={row.id} space={2}>
                 <Flex align="center" gap={2}>
                   <Box flex={1}>
-                    <TextInput
+                    <ConditionAutocompleteInput
                       autoFocus={index > 0}
-                      aria-label={t('dialog.create.condition-key.label')}
+                      ariaLabel={t('dialog.create.condition-key.label')}
                       customValidity={validation.key ? t(validation.key) : undefined}
-                      aria-invalid={Boolean(validation.key)}
-                      onChange={(event) =>
-                        handleConditionChange(index, 'key', event.currentTarget.value)
-                      }
+                      invalid={Boolean(validation.key)}
+                      onChange={(nextValue) => handleConditionChange(index, 'key', nextValue)}
+                      options={getConditionKeyOptions(variants, conditionRows, index)}
                       placeholder={t('dialog.create.condition-key.placeholder')}
-                      data-testid="variant-form-condition-key"
+                      testId="variant-form-condition-key"
                       value={row.key}
                     />
                   </Box>
                   <Box flex={1}>
-                    <TextInput
-                      aria-label={t('dialog.create.condition-value.label')}
+                    <ConditionAutocompleteInput
+                      ariaLabel={t('dialog.create.condition-value.label')}
                       customValidity={valueValidation ? t(valueValidation) : undefined}
-                      aria-invalid={Boolean(valueValidation)}
-                      onChange={(event) =>
-                        handleConditionChange(index, 'value', event.currentTarget.value)
-                      }
+                      invalid={Boolean(valueValidation)}
+                      onChange={(nextValue) => handleConditionChange(index, 'value', nextValue)}
+                      options={getConditionValueOptions(variants, row.key)}
                       placeholder={t('dialog.create.condition-value.placeholder')}
-                      data-testid="variant-form-condition-value"
+                      testId="variant-form-condition-value"
                       value={row.value}
                     />
                   </Box>

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
@@ -3,7 +3,9 @@ import {userEvent} from '@testing-library/user-event'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {variantAlphaAudience, variantNorwegianMarket} from '../../../__fixtures__/variants.fixture'
 import {variantsUsEnglishLocaleBundle} from '../../../i18n'
+import {type SystemVariant} from '../../../types'
 import {CreateVariantDialog} from '../CreateVariantDialog'
 
 const variantOperationsMock = vi.hoisted(() => ({
@@ -16,6 +18,13 @@ const toastMock = vi.hoisted(() => ({
   push: vi.fn(),
 }))
 
+const variantsMock = vi.hoisted(() => ({
+  data: [] as SystemVariant[],
+  byId: new Map<string, SystemVariant>(),
+  loading: false,
+  error: undefined as Error | undefined,
+}))
+
 vi.mock('@sanity/ui', async (importOriginal) => ({
   ...(await importOriginal()),
   useToast: vi.fn(() => toastMock),
@@ -25,12 +34,20 @@ vi.mock('../../../store/useVariantOperations', () => ({
   useVariantOperations: vi.fn(() => variantOperationsMock),
 }))
 
+vi.mock('../../../store/useAllVariants', () => ({
+  useAllVariants: vi.fn(() => variantsMock),
+}))
+
 describe('CreateVariantDialog', () => {
   const onCancel = vi.fn()
   const onSubmit = vi.fn()
 
   beforeEach(() => {
     vi.clearAllMocks()
+    variantsMock.data = [variantAlphaAudience, variantNorwegianMarket]
+    variantsMock.byId = new Map(variantsMock.data.map((variant) => [variant._id, variant]))
+    variantsMock.loading = false
+    variantsMock.error = undefined
     variantOperationsMock.createVariant.mockResolvedValue(undefined)
   })
 
@@ -52,13 +69,13 @@ describe('CreateVariantDialog', () => {
 
     expect(screen.getByRole('button', {name: 'Add condition'})).toBeDisabled()
 
-    await user.type(screen.getByRole('textbox', {name: 'Key'}), 'audience')
+    await user.type(screen.getByRole('combobox', {name: 'Key'}), 'audience')
     expect(screen.getByRole('button', {name: 'Add condition'})).toBeDisabled()
 
-    await user.type(screen.getByRole('textbox', {name: 'Value'}), 'loyal-customers')
+    await user.type(screen.getByRole('combobox', {name: 'Value'}), 'loyal-customers')
 
     await waitFor(() => {
-      expect(screen.getByRole('textbox', {name: 'Value'})).toHaveValue('loyal-customers')
+      expect(screen.getByRole('combobox', {name: 'Value'})).toHaveValue('loyal-customers')
       expect(screen.getByRole('button', {name: 'Add condition'})).toBeEnabled()
     })
 
@@ -101,8 +118,8 @@ describe('CreateVariantDialog', () => {
     await renderDialog()
 
     await user.type(screen.getByTestId('variant-form-title'), 'Loyal customers')
-    await user.type(screen.getByRole('textbox', {name: 'Key'}), 'audience')
-    await user.type(screen.getByRole('textbox', {name: 'Value'}), 'us')
+    await user.type(screen.getByRole('combobox', {name: 'Key'}), 'audience')
+    await user.type(screen.getByRole('combobox', {name: 'Value'}), 'us')
 
     await waitFor(() => {
       expect(screen.getByRole('button', {name: 'Add condition'})).toBeEnabled()
@@ -135,6 +152,35 @@ describe('CreateVariantDialog', () => {
     await waitFor(() => {
       expect(variantOperationsMock.createVariant).toHaveBeenCalledTimes(1)
     })
+  })
+
+  it('suggests existing condition keys while typing', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'aud')
+
+    expect(await screen.findByText('audience')).toBeInTheDocument()
+    expect(screen.queryByText('locale')).not.toBeInTheDocument()
+  })
+
+  it('suggests condition values scoped to the selected key', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'loc')
+    await user.click(await screen.findByText('locale'))
+    await waitFor(() => {
+      expect(screen.getByTestId('variant-form-condition-key')).toHaveValue('locale')
+    })
+
+    const openButtons = screen.getAllByRole('button', {name: 'Open'})
+    await user.click(openButtons[1]!)
+
+    expect(await screen.findByText('nb-NO')).toBeInTheDocument()
+    expect(screen.queryByText('alpha')).not.toBeInTheDocument()
   })
 
   it('shows an error for reserved and invalid condition keys', async () => {

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
@@ -3,7 +3,9 @@ import {userEvent} from '@testing-library/user-event'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {variantAlphaAudience, variantNorwegianMarket} from '../../../__fixtures__/variants.fixture'
 import {variantsUsEnglishLocaleBundle} from '../../../i18n'
+import {type SystemVariant} from '../../../types'
 import {CreateVariantDialog} from '../CreateVariantDialog'
 
 const variantOperationsMock = vi.hoisted(() => ({
@@ -16,6 +18,13 @@ const toastMock = vi.hoisted(() => ({
   push: vi.fn(),
 }))
 
+const variantsMock = vi.hoisted(() => ({
+  data: [] as SystemVariant[],
+  byId: new Map<string, SystemVariant>(),
+  loading: false,
+  error: undefined as Error | undefined,
+}))
+
 vi.mock('@sanity/ui', async (importOriginal) => ({
   ...(await importOriginal()),
   useToast: vi.fn(() => toastMock),
@@ -25,12 +34,20 @@ vi.mock('../../../store/useVariantOperations', () => ({
   useVariantOperations: vi.fn(() => variantOperationsMock),
 }))
 
+vi.mock('../../../store/useAllVariants', () => ({
+  useAllVariants: vi.fn(() => variantsMock),
+}))
+
 describe('CreateVariantDialog', () => {
   const onCancel = vi.fn()
   const onSubmit = vi.fn()
 
   beforeEach(() => {
     vi.clearAllMocks()
+    variantsMock.data = [variantAlphaAudience, variantNorwegianMarket]
+    variantsMock.byId = new Map(variantsMock.data.map((variant) => [variant._id, variant]))
+    variantsMock.loading = false
+    variantsMock.error = undefined
     variantOperationsMock.createVariant.mockResolvedValue(undefined)
   })
 
@@ -52,13 +69,13 @@ describe('CreateVariantDialog', () => {
 
     expect(screen.getByRole('button', {name: 'Add condition'})).toBeDisabled()
 
-    await user.type(screen.getByRole('textbox', {name: 'Key'}), 'audience')
+    await user.type(screen.getByRole('combobox', {name: 'Key'}), 'audience')
     expect(screen.getByRole('button', {name: 'Add condition'})).toBeDisabled()
 
-    await user.type(screen.getByRole('textbox', {name: 'Value'}), 'loyal-customers')
+    await user.type(screen.getByRole('combobox', {name: 'Value'}), 'loyal-customers')
 
     await waitFor(() => {
-      expect(screen.getByRole('textbox', {name: 'Value'})).toHaveValue('loyal-customers')
+      expect(screen.getByRole('combobox', {name: 'Value'})).toHaveValue('loyal-customers')
       expect(screen.getByRole('button', {name: 'Add condition'})).toBeEnabled()
     })
 
@@ -91,8 +108,8 @@ describe('CreateVariantDialog', () => {
     await renderDialog()
 
     await user.type(screen.getByTestId('variant-form-title'), 'Loyal customers')
-    await user.type(screen.getByRole('textbox', {name: 'Key'}), 'audience')
-    await user.type(screen.getByRole('textbox', {name: 'Value'}), 'us')
+    await user.type(screen.getByRole('combobox', {name: 'Key'}), 'audience')
+    await user.type(screen.getByRole('combobox', {name: 'Value'}), 'us')
 
     await waitFor(() => {
       expect(screen.getByRole('button', {name: 'Add condition'})).toBeEnabled()
@@ -117,6 +134,54 @@ describe('CreateVariantDialog', () => {
       expect(screen.queryByTestId('variant-form-condition-key-error')).not.toBeInTheDocument()
       expect(screen.getByTestId('submit-variant-button')).toBeEnabled()
     })
+  })
+
+  it('suggests existing condition keys while typing', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'aud')
+
+    expect(await screen.findByText('audience')).toBeInTheDocument()
+    expect(screen.queryByText('locale')).not.toBeInTheDocument()
+  })
+
+  it('suggests condition values scoped to the selected key', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'loc')
+    await user.click(await screen.findByText('locale'))
+    await waitFor(() => {
+      expect(screen.getByTestId('variant-form-condition-key')).toHaveValue('locale')
+    })
+
+    const openButtons = screen.getAllByRole('button', {name: 'Open'})
+    await user.click(openButtons[1]!)
+
+    expect(await screen.findByText('nb-NO')).toBeInTheDocument()
+    expect(screen.queryByText('alpha')).not.toBeInTheDocument()
+  })
+
+  it('still supports free-text condition keys and values', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-title'), 'Experiment users')
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'experiment')
+    await user.type(screen.getByTestId('variant-form-condition-value'), 'control')
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.createVariant).toHaveBeenCalledTimes(1)
+    })
+
+    const createdVariant = variantOperationsMock.createVariant.mock.calls[0]![0]
+
+    expect(createdVariant.conditions).toEqual({experiment: 'control'})
   })
 
   it('shows a title validation message after the field is touched', async () => {

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/conditionSuggestions.test.ts
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/conditionSuggestions.test.ts
@@ -1,0 +1,51 @@
+import {describe, expect, it} from 'vitest'
+
+import {variantAlphaAudience, variantNorwegianMarket} from '../../../__fixtures__/variants.fixture'
+import {
+  filterConditionOption,
+  getConditionKeyOptions,
+  getConditionValueOptions,
+} from '../conditionSuggestions'
+
+describe('conditionSuggestions', () => {
+  const variants = [variantAlphaAudience, variantNorwegianMarket]
+
+  describe('getConditionKeyOptions', () => {
+    it('returns unique sorted condition keys from existing variants', () => {
+      expect(getConditionKeyOptions(variants, [{key: ''}], 0)).toEqual([
+        {value: 'audience'},
+        {value: 'locale'},
+        {value: 'market'},
+      ])
+    })
+
+    it('excludes keys used by other rows while keeping the current row key selectable', () => {
+      const rows = [{key: 'audience'}, {key: 'locale'}]
+
+      expect(getConditionKeyOptions(variants, rows, 0)).toEqual([
+        {value: 'audience'},
+        {value: 'market'},
+      ])
+    })
+  })
+
+  describe('getConditionValueOptions', () => {
+    it('returns unique sorted values for the selected condition key', () => {
+      expect(getConditionValueOptions(variants, 'locale')).toEqual([
+        {value: 'en-US'},
+        {value: 'nb-NO'},
+      ])
+    })
+
+    it('returns no values when the condition key is empty', () => {
+      expect(getConditionValueOptions(variants, '   ')).toEqual([])
+    })
+  })
+
+  describe('filterConditionOption', () => {
+    it('matches options case-insensitively after trimming the query', () => {
+      expect(filterConditionOption('  EN', {value: 'en-US'})).toBe(true)
+      expect(filterConditionOption('fr', {value: 'en-US'})).toBe(false)
+    })
+  })
+})

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/conditionSuggestions.test.ts
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/conditionSuggestions.test.ts
@@ -1,18 +1,96 @@
 import {describe, expect, it} from 'vitest'
 
+import {createMockVariant} from '../../../__fixtures__/createMockVariant'
 import {variantAlphaAudience, variantNorwegianMarket} from '../../../__fixtures__/variants.fixture'
+import {type SystemVariant} from '../../../types'
 import {
+  buildConditionSuggestionIndex,
   filterConditionOption,
   getConditionKeyOptions,
   getConditionValueOptions,
 } from '../conditionSuggestions'
 
+function variantWithConditions(id: string, conditions: Record<string, string>): SystemVariant {
+  return {...createMockVariant(id), conditions}
+}
+
 describe('conditionSuggestions', () => {
   const variants = [variantAlphaAudience, variantNorwegianMarket]
 
+  describe('buildConditionSuggestionIndex', () => {
+    it('collects unique sorted keys and per-key values from existing variants', () => {
+      const index = buildConditionSuggestionIndex(variants)
+
+      expect(index.keys).toEqual(['audience', 'locale', 'market'])
+      expect(index.valuesByKey.get('audience')).toEqual(['alpha'])
+      expect(index.valuesByKey.get('locale')).toEqual(['en-US', 'nb-NO'])
+      expect(index.valuesByKey.get('market')).toEqual(['nordics'])
+    })
+
+    it('produces the full key and per-key value index', () => {
+      const index = buildConditionSuggestionIndex(variants)
+
+      expect(index.keys).toEqual(['audience', 'locale', 'market'])
+      expect(Object.fromEntries(index.valuesByKey)).toEqual({
+        audience: ['alpha'],
+        locale: ['en-US', 'nb-NO'],
+        market: ['nordics'],
+      })
+    })
+
+    it('returns an empty index for no variants', () => {
+      const emptyIndex = buildConditionSuggestionIndex([])
+
+      expect(emptyIndex.keys).toEqual([])
+      expect(emptyIndex.valuesByKey.size).toBe(0)
+    })
+
+    it('deduplicates keys and values shared across variants', () => {
+      const result = buildConditionSuggestionIndex([
+        variantWithConditions('a', {audience: 'loyal'}),
+        variantWithConditions('b', {audience: 'loyal'}),
+        variantWithConditions('c', {audience: 'new'}),
+      ])
+
+      expect(result.keys).toEqual(['audience'])
+      expect(result.valuesByKey.get('audience')).toEqual(['loyal', 'new'])
+    })
+
+    it('sorts keys and values alphabetically', () => {
+      const result = buildConditionSuggestionIndex([
+        variantWithConditions('a', {zone: 'west', audience: 'returning'}),
+        variantWithConditions('b', {audience: 'new', market: 'eu'}),
+      ])
+
+      expect(result.keys).toEqual(['audience', 'market', 'zone'])
+      expect(result.valuesByKey.get('audience')).toEqual(['new', 'returning'])
+    })
+
+    it('trims surrounding whitespace from keys and values', () => {
+      const result = buildConditionSuggestionIndex([
+        variantWithConditions('a', {'  audience  ': '  loyal  '}),
+      ])
+
+      expect(result.keys).toEqual(['audience'])
+      expect(result.valuesByKey.get('audience')).toEqual(['loyal'])
+    })
+
+    it('ignores blank keys and does not index blank values', () => {
+      const result = buildConditionSuggestionIndex([
+        variantWithConditions('a', {'   ': 'orphan', 'audience': '   '}),
+      ])
+
+      expect(result.keys).toEqual(['audience'])
+      expect(result.valuesByKey.has('audience')).toBe(false)
+      expect(result.valuesByKey.size).toBe(0)
+    })
+  })
+
   describe('getConditionKeyOptions', () => {
     it('returns unique sorted condition keys from existing variants', () => {
-      expect(getConditionKeyOptions(variants, [{key: ''}], 0)).toEqual([
+      const index = buildConditionSuggestionIndex(variants)
+
+      expect(getConditionKeyOptions(index, [{key: ''}], 0)).toEqual([
         {value: 'audience'},
         {value: 'locale'},
         {value: 'market'},
@@ -20,9 +98,10 @@ describe('conditionSuggestions', () => {
     })
 
     it('excludes keys used by other rows while keeping the current row key selectable', () => {
+      const index = buildConditionSuggestionIndex(variants)
       const rows = [{key: 'audience'}, {key: 'locale'}]
 
-      expect(getConditionKeyOptions(variants, rows, 0)).toEqual([
+      expect(getConditionKeyOptions(index, rows, 0)).toEqual([
         {value: 'audience'},
         {value: 'market'},
       ])
@@ -31,14 +110,24 @@ describe('conditionSuggestions', () => {
 
   describe('getConditionValueOptions', () => {
     it('returns unique sorted values for the selected condition key', () => {
-      expect(getConditionValueOptions(variants, 'locale')).toEqual([
+      const index = buildConditionSuggestionIndex(variants)
+
+      expect(getConditionValueOptions(index, 'locale')).toEqual([
         {value: 'en-US'},
         {value: 'nb-NO'},
       ])
     })
 
     it('returns no values when the condition key is empty', () => {
-      expect(getConditionValueOptions(variants, '   ')).toEqual([])
+      const index = buildConditionSuggestionIndex(variants)
+
+      expect(getConditionValueOptions(index, '   ')).toEqual([])
+    })
+
+    it('returns no values for an unknown condition key', () => {
+      const index = buildConditionSuggestionIndex(variants)
+
+      expect(getConditionValueOptions(index, 'unknown')).toEqual([])
     })
   })
 

--- a/packages/sanity/src/core/variants/components/dialog/conditionSuggestions.ts
+++ b/packages/sanity/src/core/variants/components/dialog/conditionSuggestions.ts
@@ -1,0 +1,74 @@
+import {type SystemVariant} from '../../types'
+
+export interface ConditionSuggestionOption {
+  value: string
+}
+
+function toSortedOptions(values: Iterable<string>): ConditionSuggestionOption[] {
+  return Array.from(values)
+    .filter(Boolean)
+    .toSorted((a, b) => a.localeCompare(b))
+    .map((value) => ({value}))
+}
+
+/**
+ * @internal
+ */
+export function getConditionKeyOptions(
+  variants: SystemVariant[],
+  rows: ReadonlyArray<{key: string}>,
+  currentRowIndex: number,
+): ConditionSuggestionOption[] {
+  const usedKeys = new Set(
+    rows
+      .filter((_, index) => index !== currentRowIndex)
+      .map((row) => row.key.trim())
+      .filter(Boolean),
+  )
+  const keys = new Set<string>()
+
+  variants.forEach((variant) => {
+    Object.keys(variant.conditions).forEach((key) => {
+      const trimmedKey = key.trim()
+
+      if (trimmedKey && !usedKeys.has(trimmedKey)) {
+        keys.add(trimmedKey)
+      }
+    })
+  })
+
+  return toSortedOptions(keys)
+}
+
+/**
+ * @internal
+ */
+export function getConditionValueOptions(
+  variants: SystemVariant[],
+  conditionKey: string,
+): ConditionSuggestionOption[] {
+  const key = conditionKey.trim()
+
+  if (!key) {
+    return []
+  }
+
+  const values = new Set<string>()
+
+  variants.forEach((variant) => {
+    const value = variant.conditions[key]?.trim()
+
+    if (value) {
+      values.add(value)
+    }
+  })
+
+  return toSortedOptions(values)
+}
+
+/**
+ * @internal
+ */
+export function filterConditionOption(query: string, option: ConditionSuggestionOption): boolean {
+  return option.value.toLowerCase().includes(query.trim().toLowerCase())
+}

--- a/packages/sanity/src/core/variants/components/dialog/conditionSuggestions.ts
+++ b/packages/sanity/src/core/variants/components/dialog/conditionSuggestions.ts
@@ -4,47 +4,90 @@ export interface ConditionSuggestionOption {
   value: string
 }
 
-function toSortedOptions(values: Iterable<string>): ConditionSuggestionOption[] {
+/**
+ * Precomputed lookup of the condition keys and per-key values used across all
+ * existing variants. Building this once (e.g. in a `useMemo` keyed on the
+ * variants) keeps per-row option derivation cheap, since it avoids re-scanning
+ * every variant on each render/keystroke.
+ *
+ * @internal
+ */
+export interface ConditionSuggestionIndex {
+  /** Unique condition keys, sorted. */
+  keys: string[]
+  /** Unique values per condition key, sorted. */
+  valuesByKey: Map<string, string[]>
+}
+
+function sortValues(values: Iterable<string>): string[] {
   return Array.from(values)
     .filter(Boolean)
     .toSorted((a, b) => a.localeCompare(b))
-    .map((value) => ({value}))
+}
+
+/**
+ * @internal
+ */
+export function buildConditionSuggestionIndex(variants: SystemVariant[]): ConditionSuggestionIndex {
+  const keys = new Set<string>()
+  const valuesByKey = new Map<string, Set<string>>()
+
+  variants.forEach((variant) => {
+    Object.entries(variant.conditions).forEach(([rawKey, rawValue]) => {
+      const key = rawKey.trim()
+
+      if (!key) {
+        return
+      }
+
+      keys.add(key)
+
+      const value = rawValue?.trim()
+
+      if (!value) {
+        return
+      }
+
+      let values = valuesByKey.get(key)
+
+      if (!values) {
+        values = new Set<string>()
+        valuesByKey.set(key, values)
+      }
+
+      values.add(value)
+    })
+  })
+
+  return {
+    keys: sortValues(keys),
+    valuesByKey: new Map(Array.from(valuesByKey, ([key, values]) => [key, sortValues(values)])),
+  }
 }
 
 /**
  * @internal
  */
 export function getConditionKeyOptions(
-  variants: SystemVariant[],
+  index: ConditionSuggestionIndex,
   rows: ReadonlyArray<{key: string}>,
   currentRowIndex: number,
 ): ConditionSuggestionOption[] {
   const usedKeys = new Set(
     rows
-      .filter((_, index) => index !== currentRowIndex)
+      .filter((_, rowIndex) => rowIndex !== currentRowIndex)
       .map((row) => row.key.trim())
       .filter(Boolean),
   )
-  const keys = new Set<string>()
 
-  variants.forEach((variant) => {
-    Object.keys(variant.conditions).forEach((key) => {
-      const trimmedKey = key.trim()
-
-      if (trimmedKey && !usedKeys.has(trimmedKey)) {
-        keys.add(trimmedKey)
-      }
-    })
-  })
-
-  return toSortedOptions(keys)
+  return index.keys.filter((key) => !usedKeys.has(key)).map((value) => ({value}))
 }
 
 /**
  * @internal
  */
 export function getConditionValueOptions(
-  variants: SystemVariant[],
+  index: ConditionSuggestionIndex,
   conditionKey: string,
 ): ConditionSuggestionOption[] {
   const key = conditionKey.trim()
@@ -53,17 +96,7 @@ export function getConditionValueOptions(
     return []
   }
 
-  const values = new Set<string>()
-
-  variants.forEach((variant) => {
-    const value = variant.conditions[key]?.trim()
-
-    if (value) {
-      values.add(value)
-    }
-  })
-
-  return toSortedOptions(values)
+  return index.valuesByKey.get(key)?.map((value) => ({value})) ?? []
 }
 
 /**


### PR DESCRIPTION
### Description

Adds autocomplete suggestions to variant condition keys and values so users can reuse existing condition patterns without maintaining a separate configuration list.
Suggestions are derived directly from existing variant documents. 
For condition keys, we scan all existing variants and collect every key used in `variant.conditions`. 
For condition values, suggestions are scoped to the selected key: if the current row key is `audience`, we only suggest values previously used for `audience`, not unrelated values from other condition keys.

The form still supports free text. Autocomplete is only a consistency aid: users can pick known keys/values, but they can also type a new key or value when creating a new condition pattern.

https://github.com/user-attachments/assets/499b575d-3686-4659-a620-8908c8fdc214


### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
- Added unit coverage for condition suggestion helpers and dialog autocomplete behavior.

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
