### PR TITLE
fix(i18n): mark stable resources for translation

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -1,9 +1,11 @@
+import {defineLocalesResources} from '../../i18n'
+
 /**
  * Defined locale strings for the releases tool, in US English.
  *
  * @internal
  */
-const releasesLocaleStrings = {
+const releasesLocaleStrings = defineLocalesResources('releases', {
   /** Action text for adding a document to release */
   'action.add-document': 'Add document',
   /** Action text for archiving a release */
@@ -542,7 +544,7 @@ const releasesLocaleStrings = {
 
   /** Toast error message when bulk scheduling of active drafts fails */
   'toast.confirm-active-scheduled-drafts.error': 'Failed to schedule drafts: {{error}}',
-}
+})
 
 /**
  * @alpha

--- a/packages/sanity/src/core/singleDocRelease/i18n/resources.ts
+++ b/packages/sanity/src/core/singleDocRelease/i18n/resources.ts
@@ -1,9 +1,11 @@
+import {defineLocalesResources} from '../../i18n'
+
 /**
  * Defined locale strings for the single doc release tool, in US English.
  *
  * @internal
  */
-const singleDocReleaseLocaleStrings = {
+const singleDocReleaseLocaleStrings = defineLocalesResources('singleDocRelease', {
   /** Action text for scheduling publish of a draft document */
   'action.schedule-publish': 'Schedule publish',
   /** Tooltip text for when a document is scheduled for publishing */
@@ -28,7 +30,7 @@ const singleDocReleaseLocaleStrings = {
     'Schedule and lock draft documents for publishing at a future date and time.',
   /** Empty state action documentation for scheduled drafts */
   'empty-state.action.documentation': 'Learn about scheduling',
-}
+})
 
 /**
  * @alpha

--- a/packages/sanity/src/presentation/i18n/resources.ts
+++ b/packages/sanity/src/presentation/i18n/resources.ts
@@ -1,4 +1,6 @@
-export default {
+import {defineLocalesResources} from 'sanity'
+
+export default defineLocalesResources('presentation', {
   /** The title shown above the document list */
   'document-list-pane.document-list.title': 'Documents on this page',
   /** The text shown if the document list is unable to render */
@@ -125,4 +127,4 @@ export default {
   'share-preview-menu.copy-url.text': 'Copy preview link',
   /** Fallback message shown when the current user is not permitted to share previews */
   'share-preview-menu.error_missing-grants': "You don't have permission to share previews. ",
-}
+})


### PR DESCRIPTION
### Description

The locales repo only reconciles namespaces that are marked with `defineLocalesResources`, so stable resources that remain plain objects never become available for translation. This marks the existing Releases, single document release, and Presentation resources for extraction while leaving the WIP Variants resources out of the translation flow.

### What to review

- Confirm these three namespaces are ready to be picked up by `sanity-io/locales`.
- Confirm `variants` should remain unmarked for now.

### Testing

- Pre-commit hook passed, including oxlint on the changed TypeScript files.
- Read IDE lints for the edited files: no errors.

### Notes for release

N/A – Internal only