### PR TITLE
feat(core): add view-as navbar for  variant selection

### DIFF
--- a/packages/sanity/src/core/perspective/navbar/AnimatedTextWidth.tsx
+++ b/packages/sanity/src/core/perspective/navbar/AnimatedTextWidth.tsx
@@ -1,0 +1,51 @@
+import {motion} from 'motion/react'
+import {type ReactNode, useCallback, useLayoutEffect, useRef, useState} from 'react'
+
+/**
+ * Animates width changes when label text changes, e.g. when switching perspectives or variants.
+ *
+ * @internal
+ */
+export function AnimatedTextWidth({children, text}: {children: ReactNode; text: string}) {
+  const textRef = useRef<HTMLDivElement>(null)
+  const [containerWidth, setContainerWidth] = useState<null | number>(null)
+  const [isAnimating, setIsAnimating] = useState(false)
+
+  useLayoutEffect(() => {
+    if (!textRef.current) return
+    const newWidth = textRef.current.offsetWidth
+    setContainerWidth(newWidth)
+  }, [text])
+
+  const onAnimationStart = useCallback(() => {
+    setIsAnimating(true)
+  }, [])
+  const onAnimationComplete = useCallback(() => {
+    setIsAnimating(false)
+  }, [])
+
+  return (
+    <motion.div
+      style={{
+        display: 'inline-block',
+        width: containerWidth === null ? 'auto' : containerWidth,
+        overflow: isAnimating ? 'hidden' : 'visible',
+      }}
+      animate={{width: containerWidth || 'auto'}}
+      transition={{type: 'spring', bounce: 0, duration: 0.3}}
+      onAnimationStart={onAnimationStart}
+      onAnimationComplete={onAnimationComplete}
+    >
+      <div
+        ref={textRef}
+        style={{
+          display: 'inline-block',
+          whiteSpace: 'nowrap',
+          verticalAlign: 'middle',
+        }}
+      >
+        {children}
+      </div>
+    </motion.div>
+  )
+}

--- a/packages/sanity/src/core/perspective/navbar/currentGlobalPerspectiveLabel.tsx
+++ b/packages/sanity/src/core/perspective/navbar/currentGlobalPerspectiveLabel.tsx
@@ -1,17 +1,7 @@
 import {type ReleaseDocument} from '@sanity/client'
 // eslint-disable-next-line no-restricted-imports -- Bundle Button requires more fine-grained styling than studio button
 import {Box, Button, Text} from '@sanity/ui'
-import {motion} from 'motion/react'
-import {
-  type ForwardedRef,
-  forwardRef,
-  type ReactNode,
-  useCallback,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import {type ForwardedRef, forwardRef, type ReactNode, useMemo} from 'react'
 import {IntentLink} from 'sanity/router'
 import {styled} from 'styled-components'
 
@@ -25,54 +15,11 @@ import {isAgentBundleName} from '../../store/agent/createAgentBundlesStore'
 import {useAgentBundles} from '../../store/agent/useAgentBundles'
 import {oversizedButtonStyle} from '../styles'
 import {type TargetPerspective} from '../types'
+import {AnimatedTextWidth} from './AnimatedTextWidth'
 
 const OversizedButton = styled(IntentLink)`
   ${oversizedButtonStyle}
 `
-
-function AnimatedTextWidth({children, text}: {children: ReactNode; text: string}) {
-  const textRef = useRef<HTMLDivElement>(null)
-  const [containerWidth, setContainerWidth] = useState<null | number>(null) // in pixels
-  const [isAnimating, setIsAnimating] = useState(false)
-
-  useLayoutEffect(() => {
-    if (!textRef.current) return
-    const newWidth = textRef.current.offsetWidth
-    setContainerWidth(newWidth)
-  }, [text])
-
-  const onAnimationStart = useCallback(() => {
-    setIsAnimating(true)
-  }, [])
-  const onAnimationComplete = useCallback(() => {
-    setIsAnimating(false)
-  }, [])
-
-  return (
-    <motion.div
-      style={{
-        display: 'inline-block',
-        width: containerWidth === null ? 'auto' : containerWidth, // use auto on first render
-        overflow: isAnimating ? 'hidden' : 'visible',
-      }}
-      animate={{width: containerWidth || 'auto'}}
-      transition={{type: 'spring', bounce: 0, duration: 0.3}}
-      onAnimationStart={onAnimationStart}
-      onAnimationComplete={onAnimationComplete}
-    >
-      <div
-        ref={textRef}
-        style={{
-          display: 'inline-block',
-          whiteSpace: 'nowrap',
-          verticalAlign: 'middle',
-        }}
-      >
-        {children}
-      </div>
-    </motion.div>
-  )
-}
 
 const ReleasesLink = ({selectedPerspective}: {selectedPerspective: ReleaseDocument}) => {
   const {t} = useTranslation()

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -8,6 +8,18 @@ const variantsLocaleStrings = {
   'navbar.view-as': 'View as',
   /** Label for the version selector in the variants navigation row. */
   'navbar.version': 'Version',
+  /** Label for the variant selector in the variants navigation row. */
+  'navbar.variant': 'Variant',
+  /** Default option label when no variant is selected. */
+  'navbar.variant.default': 'All users (Default)',
+  /** Placeholder for the variant filter input in the dropdown. */
+  'navbar.variant.filter-placeholder': 'Filter variants…',
+  /** Section header for non-default variants in the dropdown. */
+  'navbar.variant.other': 'Other variants',
+  /** Label for clearing version and variant selections. */
+  'navbar.clear': 'Clear',
+  /** Tooltip for clearing the selected variant. */
+  'navbar.variant.clear': 'Clear variant selection',
   /** Label for the Variants overview create action. */
   'overview.action.create-variant': 'Create variant',
   /** Label for the Variants overview delete action. */

--- a/packages/sanity/src/core/variants/plugin/components/CurrentVariantLabel.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/CurrentVariantLabel.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports -- Button requires props, only supported by @sanity/ui
 import {Box, Flex, Button, Text} from '@sanity/ui'
 import {type ForwardedRef, forwardRef, type HTMLProps, useMemo} from 'react'
-import {StateLink} from 'sanity/router'
+import {IntentLink} from 'sanity/router'
 import {styled} from 'styled-components'
 
 import {useTranslation} from '../../../i18n'
@@ -10,9 +10,10 @@ import {oversizedButtonStyle} from '../../../perspective/styles'
 import {variantsLocaleNamespace} from '../../i18n'
 import {getVariantId, getVariantTitle} from '../../tool/util'
 import {type SystemVariant} from '../../types'
+import {VARIANTS_INTENT} from '../index'
 import {RhombusIcon} from './PersonalizationIcons'
 
-const OversizedButton = styled(StateLink)`
+const OversizedButton = styled(IntentLink)`
   ${oversizedButtonStyle}
 `
 
@@ -29,7 +30,8 @@ function VariantDetailLink({variant}: {variant: SystemVariant}) {
           <OversizedButton
             {...linkProps}
             ref={ref}
-            state={{tool: 'variants', variantId: encodedVariantId}}
+            intent={VARIANTS_INTENT}
+            params={{id: encodedVariantId}}
           />
         )
       }),

--- a/packages/sanity/src/core/variants/plugin/components/CurrentVariantLabel.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/CurrentVariantLabel.tsx
@@ -1,0 +1,84 @@
+// eslint-disable-next-line no-restricted-imports -- Button requires props, only supported by @sanity/ui
+import {Box, Flex, Button, Text} from '@sanity/ui'
+import {type ForwardedRef, forwardRef, type HTMLProps, useMemo} from 'react'
+import {StateLink} from 'sanity/router'
+import {styled} from 'styled-components'
+
+import {useTranslation} from '../../../i18n'
+import {AnimatedTextWidth} from '../../../perspective/navbar/AnimatedTextWidth'
+import {oversizedButtonStyle} from '../../../perspective/styles'
+import {variantsLocaleNamespace} from '../../i18n'
+import {getVariantId, getVariantTitle} from '../../tool/util'
+import {type SystemVariant} from '../../types'
+import {RhombusIcon} from './PersonalizationIcons'
+
+const OversizedButton = styled(StateLink)`
+  ${oversizedButtonStyle}
+`
+
+function VariantDetailLink({variant}: {variant: SystemVariant}) {
+  const encodedVariantId = getVariantId(variant._id)
+
+  const VariantLink = useMemo(
+    () =>
+      forwardRef(function VariantLinkComponent(
+        linkProps: HTMLProps<HTMLAnchorElement>,
+        ref: ForwardedRef<HTMLAnchorElement>,
+      ) {
+        return (
+          <OversizedButton
+            {...linkProps}
+            ref={ref}
+            state={{tool: 'variants', variantId: encodedVariantId}}
+          />
+        )
+      }),
+    [encodedVariantId],
+  )
+
+  return (
+    <Button
+      as={VariantLink}
+      data-as="a"
+      data-testid="variants-nav-label-link"
+      icon={RhombusIcon}
+      mode="bleed"
+      padding={2}
+      radius="full"
+      style={{maxWidth: '180px'}}
+      text={getVariantTitle(variant)}
+    />
+  )
+}
+
+/**
+ * @internal
+ */
+export function CurrentVariantLabel({
+  selectedVariant,
+}: {
+  selectedVariant?: SystemVariant
+}): React.JSX.Element {
+  const {t} = useTranslation(variantsLocaleNamespace)
+
+  const animationKey = selectedVariant?._id ?? 'default'
+
+  return (
+    <AnimatedTextWidth text={animationKey}>
+      {!selectedVariant ? (
+        <Box padding={2} style={{userSelect: 'none', overflow: 'hidden'}}>
+          <Flex align="center" gap={2}>
+            <Text size={0}>
+              <RhombusIcon />
+            </Text>
+            <Text data-testid="variants-nav-label" size={1} textOverflow="ellipsis" weight="medium">
+              {t('navbar.variant.default')}
+            </Text>
+          </Flex>
+        </Box>
+      ) : (
+        <VariantDetailLink variant={selectedVariant} />
+      )}
+    </AnimatedTextWidth>
+  )
+}

--- a/packages/sanity/src/core/variants/plugin/components/PersonalizationIcons.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/PersonalizationIcons.tsx
@@ -1,8 +1,5 @@
 import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVGProps} from 'react'
 
-/**
- * @public
- */
 export const RhombusIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
 > = forwardRef(function RhombusIcon(props, ref) {

--- a/packages/sanity/src/core/variants/plugin/components/PersonalizationIcons.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/PersonalizationIcons.tsx
@@ -1,0 +1,28 @@
+import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVGProps} from 'react'
+
+/**
+ * @public
+ */
+export const RhombusIcon: ForwardRefExoticComponent<
+  Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
+> = forwardRef(function RhombusIcon(props, ref) {
+  return (
+    <svg
+      data-sanity-icon="rhombus"
+      width="1em"
+      height="1em"
+      viewBox="0 0 21 21"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+      ref={ref}
+    >
+      <path
+        d="M10.5 3.78L17.22 10.5L10.5 17.22L3.78 10.5L10.5 3.78Z"
+        stroke="currentColor"
+        strokeWidth={1.2}
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+})

--- a/packages/sanity/src/core/variants/plugin/components/VariantsMenu.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/VariantsMenu.tsx
@@ -1,0 +1,175 @@
+import {ChevronDownIcon} from '@sanity/icons'
+// eslint-disable-next-line no-restricted-imports -- Button requires props, only supported by @sanity/ui
+import {Box, Button, Menu, MenuDivider, Text, TextInput} from '@sanity/ui'
+import {useCallback, useMemo, useState} from 'react'
+import {useRouter} from 'sanity/router'
+import {styled} from 'styled-components'
+
+import {MenuButton, MenuItem} from '../../../../ui-components'
+import {useTranslation} from '../../../i18n'
+import {oversizedButtonStyle} from '../../../perspective/styles'
+import {variantsLocaleNamespace} from '../../i18n'
+import {useAllVariants} from '../../store/useAllVariants'
+import {
+  decodeVariantIdFromRoute,
+  filterVariantsForSearch,
+  getVariantId,
+  getVariantTitle,
+} from '../../tool/util'
+import {type SystemVariant} from '../../types'
+import {RhombusIcon} from './PersonalizationIcons'
+
+const StyledMenu = styled(Menu)`
+  min-width: 240px;
+  max-width: 320px;
+
+  > [data-ui='Stack'] {
+    gap: 0;
+  }
+`
+
+const SectionHeader = styled(Text)`
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+`
+
+const OversizedButton = styled(Button)`
+  ${oversizedButtonStyle}
+`
+
+/**
+ * @internal
+ */
+export function VariantsMenu(): React.JSX.Element {
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const router = useRouter()
+  const {data: variants} = useAllVariants()
+  const [filterQuery, setFilterQuery] = useState('')
+
+  const selectedVariantDocumentId = decodeVariantIdFromRoute(
+    router.stickyParams.variant ?? undefined,
+  )
+  const selectedVariant = useMemo(
+    () =>
+      selectedVariantDocumentId
+        ? variants.find((variant) => variant._id === selectedVariantDocumentId)
+        : undefined,
+    [selectedVariantDocumentId, variants],
+  )
+
+  const filteredVariants = useMemo(
+    () => filterVariantsForSearch(variants, filterQuery),
+    [filterQuery, variants],
+  )
+
+  const setVariantSelection = useCallback(
+    (variant: SystemVariant | undefined) => {
+      router.navigate({
+        stickyParams: {
+          variant: variant ? getVariantId(variant._id) : null,
+        },
+      })
+    },
+    [router],
+  )
+
+  const handleSelectDefault = useCallback(() => {
+    setVariantSelection(undefined)
+    setFilterQuery('')
+  }, [setVariantSelection])
+
+  const handleSelectVariant = useCallback(
+    (variant: SystemVariant) => {
+      setVariantSelection(variant)
+      setFilterQuery('')
+    },
+    [setVariantSelection],
+  )
+
+  const handleFilterChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setFilterQuery(event.currentTarget.value)
+  }, [])
+
+  const handleMenuClose = useCallback(() => {
+    setFilterQuery('')
+  }, [])
+
+  const isDefaultSelected = !selectedVariant
+
+  return (
+    <MenuButton
+      button={
+        <OversizedButton
+          data-testid="variants-nav-menu-button"
+          iconRight={ChevronDownIcon}
+          mode="bleed"
+          padding={2}
+          radius="full"
+        />
+      }
+      id="variants-nav-menu"
+      onClose={handleMenuClose}
+      menu={
+        <StyledMenu data-testid="variants-nav-menu" padding={0}>
+          <Box padding={2}>
+            <TextInput
+              fontSize={1}
+              onChange={handleFilterChange}
+              placeholder={t('navbar.variant.filter-placeholder')}
+              radius={2}
+              value={filterQuery}
+            />
+          </Box>
+
+          <MenuDivider />
+
+          <MenuItem
+            data-testid="variant-default"
+            icon={RhombusIcon}
+            onClick={handleSelectDefault}
+            pressed={isDefaultSelected}
+            selected={isDefaultSelected}
+            text={t('navbar.variant.default')}
+          />
+
+          {filteredVariants.length > 0 && (
+            <>
+              <Box padding={3} paddingBottom={2}>
+                <SectionHeader muted size={0} weight="medium">
+                  {t('navbar.variant.other')}
+                </SectionHeader>
+              </Box>
+
+              {filteredVariants.map((variant) => {
+                const isSelected = selectedVariant?._id === variant._id
+
+                return (
+                  <MenuItem
+                    key={variant._id}
+                    data-testid={`variant-${getVariantId(variant._id)}`}
+                    icon={RhombusIcon}
+                    onClick={() => handleSelectVariant(variant)}
+                    pressed={isSelected}
+                    selected={isSelected}
+                    text={getVariantTitle(variant)}
+                  />
+                )
+              })}
+            </>
+          )}
+        </StyledMenu>
+      }
+      popover={{
+        __unstable_margins: [0, 0, 32, 0],
+        constrainSize: true,
+        fallbackPlacements: ['bottom-end'],
+        placement: 'bottom-end',
+        portal: true,
+        // @ts-expect-error PopoverProps doesn't include `style`, but the Popover implementation accepts it via React.HTMLProps<HTMLDivElement>
+        style: {overflow: 'hidden'} as React.CSSProperties,
+        tone: 'default',
+        zOffset: 3000,
+      }}
+    />
+  )
+}

--- a/packages/sanity/src/core/variants/plugin/components/VariantsNav.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/VariantsNav.tsx
@@ -1,0 +1,49 @@
+import {Card} from '@sanity/ui'
+import {useRouter} from 'sanity/router'
+import {styled} from 'styled-components'
+
+import {useAllVariants} from '../../store/useAllVariants'
+import {decodeVariantIdFromRoute} from '../../tool/util'
+import {CurrentVariantLabel} from './CurrentVariantLabel'
+import {VariantsMenu} from './VariantsMenu'
+
+const VariantsNavContainer = styled(Card)`
+  position: relative;
+  display: flex;
+  &:not([hidden]) {
+    display: flex;
+  }
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  margin: -3px 0;
+
+  a:hover,
+  button:hover {
+    position: relative;
+    z-index: 2;
+  }
+`
+
+/**
+ * @internal
+ */
+export function VariantsNav(): React.JSX.Element {
+  const router = useRouter()
+  const {byId} = useAllVariants()
+
+  const selectedVariantDocumentId = decodeVariantIdFromRoute(
+    router.stickyParams.variant ?? undefined,
+  )
+
+  const selectedVariant = selectedVariantDocumentId
+    ? byId.get(selectedVariantDocumentId)
+    : undefined
+
+  return (
+    <VariantsNavContainer flex="none" tone="inherit" radius="full" data-ui="VariantsNav">
+      <CurrentVariantLabel selectedVariant={selectedVariant} />
+      <VariantsMenu />
+    </VariantsNavContainer>
+  )
+}

--- a/packages/sanity/src/core/variants/plugin/components/VariantsStudioNavbar.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/VariantsStudioNavbar.tsx
@@ -1,24 +1,53 @@
 import {Card, Flex, Text} from '@sanity/ui'
+import {AnimatePresence, motion} from 'motion/react'
+import {useCallback} from 'react'
+import {useRouter} from 'sanity/router'
 import {styled} from 'styled-components'
 
+import {Button} from '../../../../ui-components/button/Button'
 import {type NavbarProps} from '../../../config/studio/types'
 import {useTranslation} from '../../../i18n'
 import {ReleasesNav} from '../../../perspective/navbar/ReleasesNav'
 import {usePerspective} from '../../../perspective/usePerspective'
 import {getReleaseTone} from '../../../releases/util/getReleaseTone'
+import {isDraftPerspective, isPublishedPerspective} from '../../../releases/util/util'
 import {variantsLocaleNamespace} from '../../i18n'
+import {useAllVariants} from '../../store/useAllVariants'
+import {decodeVariantIdFromRoute} from '../../tool/util'
+import {VariantsNav} from './VariantsNav'
 
-const ReleaseNavContainer = styled(Card)`
-  /* overflow: hidden; */
-
-  // Reset the margin for the releases nav
-  [data-ui='ReleasesNav'] {
+const NavRowContainer = styled(Card)`
+  [data-ui='ReleasesNav'],
+  [data-ui='VariantsNav'] {
     margin: 0;
   }
 `
+
 export function VariantsStudioNavbar(props: NavbarProps) {
   const {t} = useTranslation(variantsLocaleNamespace)
   const {selectedPerspective} = usePerspective()
+  const router = useRouter()
+  const {byId} = useAllVariants()
+
+  const selectedVariantDocumentId = decodeVariantIdFromRoute(
+    router.stickyParams.variant ?? undefined,
+  )
+  const hasVariantSelection = Boolean(
+    selectedVariantDocumentId && byId.get(selectedVariantDocumentId),
+  )
+  const hasNonDefaultPerspective =
+    !isDraftPerspective(selectedPerspective) && !isPublishedPerspective(selectedPerspective)
+  const canClear = hasVariantSelection || hasNonDefaultPerspective
+
+  const handleClearViewAs = useCallback(() => {
+    router.navigate({
+      stickyParams: {
+        excludedPerspectives: null,
+        perspective: '',
+        variant: null,
+      },
+    })
+  }, [router])
 
   return (
     <Flex direction="column">
@@ -28,7 +57,7 @@ export function VariantsStudioNavbar(props: NavbarProps) {
           <Text weight="medium" size={1}>
             {t('navbar.view-as')}
           </Text>
-          <ReleaseNavContainer
+          <NavRowContainer
             tone={getReleaseTone(selectedPerspective)}
             border
             radius={4}
@@ -42,7 +71,41 @@ export function VariantsStudioNavbar(props: NavbarProps) {
               </Card>
               <ReleasesNav withReleasesToolButton border={false} />
             </Flex>
-          </ReleaseNavContainer>
+          </NavRowContainer>
+          <NavRowContainer
+            tone={hasVariantSelection ? 'suggest' : 'default'}
+            border
+            radius={4}
+            paddingLeft={1}
+          >
+            <Flex marginLeft={1}>
+              <Card borderRight tone="inherit">
+                <Flex align="center" paddingX={2} height={'fill'}>
+                  <Text size={1}>{t('navbar.variant')}</Text>
+                </Flex>
+              </Card>
+              <VariantsNav />
+            </Flex>
+          </NavRowContainer>
+          <AnimatePresence initial={false}>
+            {canClear && (
+              <motion.div
+                key="view-as-clear-button"
+                animate={{clipPath: 'inset(0 0% 0 0%)', opacity: 1}}
+                exit={{clipPath: 'inset(0 50% 0 50%)', opacity: 0}}
+                initial={{clipPath: 'inset(0 50% 0 50%)', opacity: 0}}
+                style={{display: 'flex'}}
+                transition={{type: 'spring', bounce: 0, duration: 0.3}}
+              >
+                <Button
+                  data-testid="view-as-clear-button"
+                  mode="bleed"
+                  onClick={handleClearViewAs}
+                  text={t('navbar.clear')}
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
         </Flex>
       </Card>
     </Flex>

--- a/packages/sanity/src/core/variants/plugin/components/VariantsStudioNavbar.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/VariantsStudioNavbar.tsx
@@ -12,8 +12,6 @@ import {usePerspective} from '../../../perspective/usePerspective'
 import {getReleaseTone} from '../../../releases/util/getReleaseTone'
 import {isDraftPerspective, isPublishedPerspective} from '../../../releases/util/util'
 import {variantsLocaleNamespace} from '../../i18n'
-import {useAllVariants} from '../../store/useAllVariants'
-import {decodeVariantIdFromRoute} from '../../tool/util'
 import {VariantsNav} from './VariantsNav'
 
 const NavRowContainer = styled(Card)`
@@ -27,14 +25,8 @@ export function VariantsStudioNavbar(props: NavbarProps) {
   const {t} = useTranslation(variantsLocaleNamespace)
   const {selectedPerspective} = usePerspective()
   const router = useRouter()
-  const {byId} = useAllVariants()
 
-  const selectedVariantDocumentId = decodeVariantIdFromRoute(
-    router.stickyParams.variant ?? undefined,
-  )
-  const hasVariantSelection = Boolean(
-    selectedVariantDocumentId && byId.get(selectedVariantDocumentId),
-  )
+  const hasVariantSelection = Boolean(router.stickyParams.variant)
   const hasNonDefaultPerspective =
     !isDraftPerspective(selectedPerspective) && !isPublishedPerspective(selectedPerspective)
   const canClear = hasVariantSelection || hasNonDefaultPerspective

--- a/packages/sanity/src/core/variants/plugin/components/__tests__/VariantsNav.test.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/__tests__/VariantsNav.test.tsx
@@ -1,0 +1,218 @@
+import {render, screen, waitFor, within} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {forwardRef, type HTMLProps} from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {flushMicrotasksThisIsACodeSmell} from '../../../../../../test/testUtils/flushMicrotasks'
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {variantAlphaAudience, variantNorwegianMarket} from '../../../__fixtures__/variants.fixture'
+import {variantsUsEnglishLocaleBundle} from '../../../i18n'
+import {getVariantId} from '../../../tool/util'
+import {type SystemVariant} from '../../../types'
+import {VariantsNav} from '../VariantsNav'
+
+const mockNavigate = vi.fn()
+
+const routerMock = vi.hoisted(() => ({
+  stickyParams: {} as Record<string, string | undefined>,
+}))
+
+const variantsMock = vi.hoisted(() => ({
+  data: [] as SystemVariant[],
+  byId: new Map<string, SystemVariant>(),
+  loading: false,
+  error: undefined as Error | undefined,
+}))
+
+vi.mock('sanity/router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRouter: vi.fn(() => ({
+    stickyParams: routerMock.stickyParams,
+    navigate: mockNavigate,
+    resolvePathFromState: vi.fn(({tool, variantId}: {tool?: string; variantId?: string}) => {
+      if (tool === 'variants' && variantId) {
+        return `/variants/${variantId}`
+      }
+      return '/'
+    }),
+  })),
+  StateLink: forwardRef(function MockStateLink(
+    {state, ...rest}: {state?: {tool?: string; variantId?: string}} & HTMLProps<HTMLAnchorElement>,
+    ref,
+  ) {
+    const href =
+      state?.tool === 'variants' && state.variantId ? `/variants/${state.variantId}` : '/'
+    return <a {...rest} ref={ref} href={href} />
+  }),
+}))
+
+vi.mock('../../../store/useAllVariants', () => ({
+  useAllVariants: vi.fn(() => ({
+    data: variantsMock.data,
+    byId: variantsMock.byId,
+    loading: variantsMock.loading,
+    error: variantsMock.error,
+  })),
+}))
+
+describe('VariantsNav', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    routerMock.stickyParams = {}
+    variantsMock.data = [variantAlphaAudience, variantNorwegianMarket]
+    variantsMock.byId = new Map([
+      [variantAlphaAudience._id, variantAlphaAudience],
+      [variantNorwegianMarket._id, variantNorwegianMarket],
+    ])
+    variantsMock.loading = false
+    variantsMock.error = undefined
+  })
+
+  const renderNav = async () => {
+    const wrapper = await createTestProvider({
+      resources: [variantsUsEnglishLocaleBundle],
+    })
+    const view = render(<VariantsNav />, {wrapper})
+    await flushMicrotasksThisIsACodeSmell()
+    return view
+  }
+
+  const openMenu = async () => {
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('variants-nav-menu-button'))
+    await waitFor(() => {
+      expect(screen.getByTestId('variants-nav-menu')).toBeInTheDocument()
+    })
+    return user
+  }
+
+  it('renders the default label when no variant is selected', async () => {
+    await renderNav()
+
+    expect(screen.getByTestId('variants-nav-label')).toHaveTextContent('All users (Default)')
+    expect(screen.queryByTestId('variants-nav-label-link')).not.toBeInTheDocument()
+  })
+
+  it('shows default label until the selected variant is resolved', async () => {
+    variantsMock.loading = true
+    variantsMock.byId = new Map()
+    routerMock.stickyParams = {variant: getVariantId(variantAlphaAudience._id)}
+
+    await renderNav()
+
+    expect(screen.getByTestId('variants-nav-label')).toHaveTextContent('All users (Default)')
+    expect(screen.queryByTestId('variants-nav-label-link')).not.toBeInTheDocument()
+  })
+
+  it('lists the default item and other variants in the menu', async () => {
+    await renderNav()
+    await openMenu()
+
+    const menu = screen.getByTestId('variants-nav-menu')
+    expect(within(menu).getByText('All users (Default)')).toBeInTheDocument()
+    expect(within(menu).getByText('Other variants')).toBeInTheDocument()
+    expect(within(menu).getByText('Alpha audience')).toBeInTheDocument()
+    expect(within(menu).getByText('Norwegian market')).toBeInTheDocument()
+  })
+
+  it('selects a variant via sticky params', async () => {
+    await renderNav()
+    const user = await openMenu()
+
+    await user.click(screen.getByTestId(`variant-${getVariantId(variantAlphaAudience._id)}`))
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      stickyParams: {
+        variant: getVariantId(variantAlphaAudience._id),
+      },
+    })
+  })
+
+  it('shows selected state in the navbar and menu when a variant is selected', async () => {
+    routerMock.stickyParams = {variant: getVariantId(variantAlphaAudience._id)}
+
+    await renderNav()
+    const user = await openMenu()
+
+    expect(screen.getByTestId('variants-nav-label-link')).toHaveTextContent('Alpha audience')
+
+    const defaultItem = screen.getByTestId('variant-default')
+    expect(defaultItem).not.toHaveAttribute('data-selected')
+
+    const selectedItem = screen.getByTestId(`variant-${getVariantId(variantAlphaAudience._id)}`)
+    expect(selectedItem).toHaveAttribute('data-selected')
+  })
+
+  it('links to the variant detail page when a variant is selected', async () => {
+    routerMock.stickyParams = {variant: getVariantId(variantAlphaAudience._id)}
+
+    await renderNav()
+
+    expect(screen.getByTestId('variants-nav-label-link')).toHaveAttribute(
+      'href',
+      `/variants/${getVariantId(variantAlphaAudience._id)}`,
+    )
+  })
+
+  it('clears selection when choosing the default option', async () => {
+    routerMock.stickyParams = {variant: getVariantId(variantAlphaAudience._id)}
+
+    await renderNav()
+    const user = await openMenu()
+
+    await user.click(screen.getByTestId('variant-default'))
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      stickyParams: {
+        variant: null,
+      },
+    })
+  })
+
+  it('filters variants in the menu', async () => {
+    await renderNav()
+    const user = await openMenu()
+
+    await user.type(screen.getByPlaceholderText('Filter variants…'), 'Norwegian')
+
+    const menu = screen.getByTestId('variants-nav-menu')
+    expect(within(menu).queryByText('Alpha audience')).not.toBeInTheDocument()
+    expect(within(menu).getByText('Norwegian market')).toBeInTheDocument()
+  })
+
+  it('shows default as selected when sticky variant does not exist', async () => {
+    routerMock.stickyParams = {variant: 'missing-variant'}
+
+    await renderNav()
+    await openMenu()
+
+    expect(screen.getByTestId('variants-nav-label')).toHaveTextContent('All users (Default)')
+    expect(screen.getByTestId('variant-default')).toHaveAttribute('data-selected')
+  })
+
+  it('clears the filter when the menu is closed without selecting', async () => {
+    await renderNav()
+    const user = await openMenu()
+
+    const filterInput = screen.getByPlaceholderText('Filter variants…')
+    await user.type(filterInput, 'Norwegian')
+    expect(filterInput).toHaveValue('Norwegian')
+
+    await user.click(screen.getByTestId('variants-nav-menu-button'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variants-nav-menu-button')).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      )
+    })
+
+    await user.click(screen.getByTestId('variants-nav-menu-button'))
+    await waitFor(() => {
+      expect(screen.getByTestId('variants-nav-menu')).toBeInTheDocument()
+    })
+
+    expect(screen.getByPlaceholderText('Filter variants…')).toHaveValue('')
+    expect(screen.getByText('Alpha audience')).toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/core/variants/plugin/components/__tests__/VariantsNav.test.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/__tests__/VariantsNav.test.tsx
@@ -9,6 +9,7 @@ import {variantAlphaAudience, variantNorwegianMarket} from '../../../__fixtures_
 import {variantsUsEnglishLocaleBundle} from '../../../i18n'
 import {getVariantId} from '../../../tool/util'
 import {type SystemVariant} from '../../../types'
+import {VARIANTS_INTENT} from '../../index'
 import {VariantsNav} from '../VariantsNav'
 
 const mockNavigate = vi.fn()
@@ -36,12 +37,15 @@ vi.mock('sanity/router', async (importOriginal) => ({
       return '/'
     }),
   })),
-  StateLink: forwardRef(function MockStateLink(
-    {state, ...rest}: {state?: {tool?: string; variantId?: string}} & HTMLProps<HTMLAnchorElement>,
+  IntentLink: forwardRef(function MockIntentLink(
+    {
+      intent,
+      params,
+      ...rest
+    }: {intent?: string; params?: {id?: string}} & HTMLProps<HTMLAnchorElement>,
     ref,
   ) {
-    const href =
-      state?.tool === 'variants' && state.variantId ? `/variants/${state.variantId}` : '/'
+    const href = intent === VARIANTS_INTENT && params?.id ? `/variants/${params.id}` : '/'
     return <a {...rest} ref={ref} href={href} />
   }),
 }))

--- a/packages/sanity/src/core/variants/plugin/components/__tests__/VariantsStudioNavbar.test.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/__tests__/VariantsStudioNavbar.test.tsx
@@ -87,6 +87,15 @@ describe('VariantsStudioNavbar', () => {
     expect(screen.getByTestId('view-as-clear-button')).toBeInTheDocument()
   })
 
+  it('shows clear when sticky variant is set but not resolved in the store', async () => {
+    routerMock.stickyParams = {variant: 'missing-variant'}
+    variantsMock.byId = new Map()
+
+    await renderNavbar()
+
+    expect(screen.getByTestId('view-as-clear-button')).toBeInTheDocument()
+  })
+
   it('clears version and variant when clear is clicked', async () => {
     usePerspectiveMockReturn.selectedPerspective = activeASAPRelease
     routerMock.stickyParams = {variant: getVariantId(variantAlphaAudience._id)}

--- a/packages/sanity/src/core/variants/plugin/components/__tests__/VariantsStudioNavbar.test.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/__tests__/VariantsStudioNavbar.test.tsx
@@ -1,0 +1,107 @@
+import {render, screen} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {flushMicrotasksThisIsACodeSmell} from '../../../../../../test/testUtils/flushMicrotasks'
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {usePerspectiveMockReturn} from '../../../../perspective/__mocks__/usePerspective.mock'
+import {activeASAPRelease} from '../../../../releases/__fixtures__/release.fixture'
+import {variantAlphaAudience} from '../../../__fixtures__/variants.fixture'
+import {variantsUsEnglishLocaleBundle} from '../../../i18n'
+import {getVariantId} from '../../../tool/util'
+import {type SystemVariant} from '../../../types'
+import {VariantsStudioNavbar} from '../VariantsStudioNavbar'
+
+const mockNavigate = vi.fn()
+
+const routerMock = vi.hoisted(() => ({
+  stickyParams: {} as Record<string, string | undefined>,
+}))
+
+const variantsMock = vi.hoisted(() => ({
+  byId: new Map<string, SystemVariant>(),
+}))
+
+vi.mock('sanity/router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRouter: vi.fn(() => ({
+    stickyParams: routerMock.stickyParams,
+    navigate: mockNavigate,
+  })),
+}))
+
+vi.mock('../../../store/useAllVariants', () => ({
+  useAllVariants: vi.fn(() => ({
+    byId: variantsMock.byId,
+  })),
+}))
+
+vi.mock('../../../../perspective/usePerspective', () => ({
+  usePerspective: vi.fn(() => usePerspectiveMockReturn),
+}))
+
+vi.mock('../../../../perspective/navbar/ReleasesNav', () => ({
+  ReleasesNav: () => <div data-testid="releases-nav" />,
+}))
+
+vi.mock('../VariantsNav', () => ({
+  VariantsNav: () => <div data-testid="variants-nav" />,
+}))
+
+describe('VariantsStudioNavbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    routerMock.stickyParams = {}
+    variantsMock.byId = new Map([[variantAlphaAudience._id, variantAlphaAudience]])
+    usePerspectiveMockReturn.selectedPerspective = 'drafts'
+  })
+
+  const renderNavbar = async () => {
+    const wrapper = await createTestProvider({
+      resources: [variantsUsEnglishLocaleBundle],
+    })
+    const view = render(<VariantsStudioNavbar renderDefault={() => null} />, {wrapper})
+    await flushMicrotasksThisIsACodeSmell()
+    return view
+  }
+
+  it('does not show clear when version and variant are at default', async () => {
+    await renderNavbar()
+
+    expect(screen.queryByTestId('view-as-clear-button')).not.toBeInTheDocument()
+  })
+
+  it('shows clear when a non-default perspective is selected', async () => {
+    usePerspectiveMockReturn.selectedPerspective = activeASAPRelease
+
+    await renderNavbar()
+
+    expect(screen.getByTestId('view-as-clear-button')).toBeInTheDocument()
+  })
+
+  it('shows clear when a variant is selected', async () => {
+    routerMock.stickyParams = {variant: getVariantId(variantAlphaAudience._id)}
+
+    await renderNavbar()
+
+    expect(screen.getByTestId('view-as-clear-button')).toBeInTheDocument()
+  })
+
+  it('clears version and variant when clear is clicked', async () => {
+    usePerspectiveMockReturn.selectedPerspective = activeASAPRelease
+    routerMock.stickyParams = {variant: getVariantId(variantAlphaAudience._id)}
+
+    await renderNavbar()
+
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('view-as-clear-button'))
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      stickyParams: {
+        excludedPerspectives: null,
+        perspective: '',
+        variant: null,
+      },
+    })
+  })
+})

--- a/packages/sanity/src/core/variants/plugin/index.tsx
+++ b/packages/sanity/src/core/variants/plugin/index.tsx
@@ -10,6 +10,11 @@ import {VariantsStudioNavbar} from './components/VariantsStudioNavbar'
  */
 export const VARIANTS_NAME = 'sanity/variants'
 
+/**
+ * @internal
+ */
+export const VARIANTS_INTENT = 'variant'
+
 const VARIANTS_TOOL_NAME = 'variants'
 
 /**
@@ -29,6 +34,13 @@ export const variants = definePlugin({
       component: VariantsTool,
       router: route.create('/', [route.create('/:variantId')]),
       __internalApplicationType: VARIANTS_NAME,
+      canHandleIntent: (intent) => intent === VARIANTS_INTENT,
+      getIntentState(intent, params) {
+        if (intent === VARIANTS_INTENT) {
+          return {variantId: params.id}
+        }
+        return null
+      },
     },
   ],
   i18n: {

--- a/packages/sanity/src/router/stickyParams.ts
+++ b/packages/sanity/src/router/stickyParams.ts
@@ -8,4 +8,5 @@ export const STICKY_PARAMS: string[] = [
   'sidebar',
   'selectedTask',
   'viewMode',
+  'variant',
 ]


### PR DESCRIPTION
### Description

This adds a global **View as** row to the variants plugin navbar so version (perspective) and variant can be chosen together, matching the interaction model of the existing perspective navbar rather than inventing a separate picker pattern.

The variant selector mirrors `ReleasesNav`: the label navigates to the variant detail page when selected, the chevron opens the list, and width animates on change via a shared `AnimatedTextWidth` extracted from the perspective label. Selection persists in the `variant` sticky param. 
A **Clear** control appears when either picker is non-default and resets both perspective and variant in one action.

Alternatives considered: a single combined pill with an inline remove action — rejected to keep version and variant pickers visually and behaviorally consistent with the perspective navbar.

<img width="1019" height="438" alt="Screenshot 2026-05-21 at 13 20 36" src="https://github.com/user-attachments/assets/7e15b845-a295-474b-b234-b090df2868e8" />
<img width="1012" height="477" alt="Screenshot 2026-05-21 at 13 20 43" src="https://github.com/user-attachments/assets/d8cbbfaa-d3e2-4421-a521-5cd0302f1055" />
<img width="1013" height="321" alt="Screenshot 2026-05-21 at 13 20 47" src="https://github.com/user-attachments/assets/e080c4f0-ed0f-4ab7-b068-535670029c3d" />

### What to review

- `VariantsNav`, `CurrentVariantLabel`, and `VariantsMenu` — interaction parity with `ReleasesNav` / `GlobalPerspectiveMenu` (split hover targets, label link vs chevron menu)
- `AnimatedTextWidth` extraction in `packages/sanity/src/core/perspective/navbar/` — shared between perspective and variant labels without changing perspective behavior
- `stickyParams.ts` — new `variant` param registration
- `VariantsStudioNavbar` — row layout, suggest tone on variant selection, animated Clear button visibility and reset logic (`perspective: ''`, `variant: null`)

Affected package: `packages/sanity` (variants plugin + perspective navbar)

### Testing

- `VariantsNav.test.tsx` — default label, menu listing, sticky-param selection, selected state, detail-page link, default clears selection, filtering
- `VariantsStudioNavbar.test.tsx` — Clear hidden at defaults, shown for non-default perspective or variant, clears both on click

Manual: open dev studio with variants enabled, select a release and a variant, confirm URL sticky params, label navigation to variant detail, chevron menu, width animation, and Clear resetting both pickers.

### Notes for release

N/A – Part of variants feature (internal, not yet end-user facing)