### PR TITLE
fix(sanity): set correct dimensions for PTE block image preview

### DIFF
--- a/packages/sanity/src/core/components/previews/helpers.tsx
+++ b/packages/sanity/src/core/components/previews/helpers.tsx
@@ -1,10 +1,10 @@
-import {type ElementType, type ReactNode} from 'react'
+import {type ElementType, isValidElement, type ReactNode} from 'react'
 import {isValidElementType} from 'react-is'
 
-import {type PreviewLayoutKey, type PreviewMediaDimensions} from './types'
+import {type PreviewProps, type PreviewLayoutKey, type PreviewMediaDimensions} from './types'
 
 export function renderPreviewMedia<Layout = PreviewLayoutKey>(
-  value: ReactNode | ElementType<{layout: Layout; dimensions: PreviewMediaDimensions}>,
+  value: PreviewProps<Layout>['media'],
   layout: Layout,
   dimensions: PreviewMediaDimensions,
 ): ReactNode {
@@ -17,8 +17,17 @@ export function renderPreviewMedia<Layout = PreviewLayoutKey>(
     return <div>{value}</div>
   }
 
-  // @todo: find out why `value` isn't infered as `ReactNode` here
-  return value as any
+  const isReactNode =
+    isValidElement(value) ||
+    value === null ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+
+  if (isReactNode) {
+    return value
+  }
+
+  return null
 }
 
 export function renderPreviewNode<Layout = PreviewLayoutKey>(

--- a/packages/sanity/src/core/components/previews/helpers.tsx
+++ b/packages/sanity/src/core/components/previews/helpers.tsx
@@ -1,6 +1,9 @@
+import {tryGetImageDimensions} from '@sanity/asset-utils'
 import {type ElementType, isValidElement, type ReactNode} from 'react'
 import {isValidElementType} from 'react-is'
+import {getDevicePixelRatio} from 'use-device-pixel-ratio'
 
+import {PREVIEW_SIZES} from './constants'
 import {type PreviewProps, type PreviewLayoutKey, type PreviewMediaDimensions} from './types'
 
 export function renderPreviewMedia<Layout = PreviewLayoutKey>(
@@ -46,4 +49,24 @@ export function renderPreviewNode<Layout = PreviewLayoutKey>(
 
   // @todo: find out why `value` isn't infered as `ReactNode` here
   return (value as any) || fallbackNode
+}
+
+export function resolveBlockImageDimensions(
+  source: Parameters<typeof tryGetImageDimensions>[0],
+): PreviewMediaDimensions | undefined {
+  const sourceDimensions = tryGetImageDimensions(source)
+
+  if (typeof sourceDimensions === 'undefined') {
+    return undefined
+  }
+
+  const max = PREVIEW_SIZES.blockImage.media
+  const scale = Math.min(max.width / sourceDimensions.width, 1)
+
+  return {
+    width: Math.round(sourceDimensions.width * scale),
+    height: Math.round(sourceDimensions.height * scale),
+    fit: 'max',
+    dpr: getDevicePixelRatio(),
+  }
 }

--- a/packages/sanity/src/core/components/previews/types.ts
+++ b/packages/sanity/src/core/components/previews/types.ts
@@ -1,3 +1,4 @@
+import {type SanityImageSource} from '@sanity/asset-utils'
 import {type ImageUrlFitMode, type SchemaType} from '@sanity/types'
 import {type ComponentType, type ReactNode} from 'react'
 
@@ -55,7 +56,10 @@ export interface PreviewProps<TLayoutKey = PreviewLayoutKey> {
   imageUrl?: string
   isPlaceholder?: boolean
   layout?: TLayoutKey
-  media?: ReactNode | ComponentType<{dimensions: PreviewMediaDimensions; layout: TLayoutKey}>
+  media?:
+    | ReactNode
+    | SanityImageSource
+    | ComponentType<{dimensions: PreviewMediaDimensions; layout: TLayoutKey}>
   mediaDimensions?: PreviewMediaDimensions
   progress?: number
   status?: ReactNode | ComponentType<{layout: TLayoutKey}>

--- a/packages/sanity/src/core/preview/components/SanityDefaultPreview.tsx
+++ b/packages/sanity/src/core/preview/components/SanityDefaultPreview.tsx
@@ -21,6 +21,7 @@ import {isValidElementType} from 'react-is'
 
 import {Tooltip} from '../../../ui-components'
 import {type PreviewMediaDimensions, type PreviewProps} from '../../components/previews'
+import {resolveBlockImageDimensions} from '../../components/previews/helpers'
 import {useAccessPolicy} from '../../form/inputs/files/ImageInput/useAccessPolicy'
 import {useImageUrl} from '../../form/inputs/files/ImageInput/useImageUrl'
 import {useClient} from '../../hooks'
@@ -186,14 +187,30 @@ export const SanityDefaultPreview = memo(function SanityDefaultPreview(
     return renderIcon
   }, [Icon, imageUrl, mediaProp, renderIcon, renderMedia, title])
 
+  const resolvedMediaDimensions = useMemo<PreviewMediaDimensions | undefined>(() => {
+    if (props.mediaDimensions) {
+      return props.mediaDimensions
+    }
+
+    if (layout !== 'blockImage') {
+      return undefined
+    }
+
+    if (!isImageSource(mediaProp)) {
+      return undefined
+    }
+
+    return resolveBlockImageDimensions(mediaProp)
+  }, [layout, mediaProp, props.mediaDimensions])
+
   const previewProps: Omit<PreviewProps, 'renderDefault'> = useMemo(
     () => ({
       ...restProps,
-      // @todo: fix `TS2769: No overload matches this call.`
-      media: media as any,
+      media,
+      mediaDimensions: resolvedMediaDimensions,
       title,
     }),
-    [media, restProps, title],
+    [media, resolvedMediaDimensions, restProps, title],
   )
 
   const LayoutComponent = _previewComponents[layout || 'default'] as ComponentType<

--- a/packages/sanity/src/core/preview/components/__tests__/SanityDefaultPreview.test.tsx
+++ b/packages/sanity/src/core/preview/components/__tests__/SanityDefaultPreview.test.tsx
@@ -1,8 +1,14 @@
-import {isSanityImageUrl, parseImageAssetUrl} from '@sanity/asset-utils'
+import {
+  isImageSource,
+  isSanityImageUrl,
+  parseImageAssetUrl,
+  tryGetImageDimensions,
+} from '@sanity/asset-utils'
 import {createImageUrlBuilder} from '@sanity/image-url'
 import {render} from '@testing-library/react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
+import {type PreviewMediaDimensions, type PreviewProps} from '../../../components/previews'
 import {useImageUrl} from '../../../form/inputs/files/ImageInput/useImageUrl'
 import {useClient} from '../../../hooks'
 import {_previewComponents} from '../_previewComponents'
@@ -14,19 +20,26 @@ vi.mock('../../../form/inputs/files/ImageInput/useImageUrl')
 vi.mock('@sanity/image-url')
 
 let capturedMedia: unknown
+let capturedMediaDimensions: PreviewMediaDimensions | undefined
 
-vi.mock('../_previewComponents', () => ({
-  _previewComponents: {
-    default: vi.fn((props: {media?: unknown}) => {
-      capturedMedia = props.media
-      return null
-    }),
-  },
-}))
+vi.mock('../_previewComponents', () => {
+  const captureProps = (props: {media?: unknown; mediaDimensions?: PreviewMediaDimensions}) => {
+    capturedMedia = props.media
+    capturedMediaDimensions = props.mediaDimensions
+    return null
+  }
+  return {
+    _previewComponents: {
+      default: vi.fn(captureProps),
+      blockImage: vi.fn(captureProps),
+    },
+  }
+})
 
 beforeEach(() => {
   vi.clearAllMocks()
   capturedMedia = undefined
+  capturedMediaDimensions = undefined
 
   vi.mocked(useClient).mockReturnValue({} as ReturnType<typeof useClient>)
   vi.mocked(createImageUrlBuilder).mockReturnValue({} as ReturnType<typeof createImageUrlBuilder>)
@@ -36,8 +49,22 @@ beforeEach(() => {
   })
 })
 
-function renderPreview(media: unknown): void {
+function renderPreview(media: PreviewProps['media']): void {
   render(<SanityDefaultPreview layout="default" media={media} title="Test" />)
+}
+
+function renderBlockImagePreview(
+  media: PreviewProps['media'],
+  mediaDimensions?: PreviewMediaDimensions,
+): void {
+  render(
+    <SanityDefaultPreview
+      layout="blockImage"
+      media={media}
+      mediaDimensions={mediaDimensions}
+      title="Test"
+    />,
+  )
 }
 
 describe('SanityDefaultPreview - Sanity URL handling (fix/edx-1307)', () => {
@@ -92,5 +119,91 @@ describe('SanityDefaultPreview - Sanity URL handling (fix/edx-1307)', () => {
 
     expect(typeof capturedMedia).toBe('function')
     expect(parseImageAssetUrl).toHaveBeenCalledTimes(0)
+  })
+})
+
+describe('SanityDefaultPreview - blockImage media dimensions', () => {
+  it('should resolve actual image dimensions for blockImage layout', () => {
+    vi.mocked(isSanityImageUrl).mockReturnValue(false)
+    vi.mocked(isImageSource).mockReturnValue(true)
+    vi.mocked(tryGetImageDimensions).mockReturnValue({
+      width: 1920,
+      height: 1080,
+      aspectRatio: 1920 / 1080,
+    })
+
+    const imageSource = {
+      _type: 'image',
+      asset: {_ref: 'image-abc123-1920x1080-jpg', _type: 'reference'},
+    }
+
+    renderBlockImagePreview(imageSource)
+
+    expect(tryGetImageDimensions).toHaveBeenCalledWith(imageSource)
+    // 1920 -> capped to 600 (PREVIEW_SIZES.blockImage.media.width)
+    expect(capturedMediaDimensions?.width).toBe(600)
+    // 1080 * (600/1920) = 337.5 -> rounded to 338
+    expect(capturedMediaDimensions?.height).toBe(338)
+    expect(capturedMediaDimensions?.fit).toBe('max')
+  })
+
+  it('should not override mediaDimensions for non-blockImage layouts', () => {
+    vi.mocked(isSanityImageUrl).mockReturnValue(false)
+    vi.mocked(isImageSource).mockReturnValue(true)
+    vi.mocked(tryGetImageDimensions).mockReturnValue({
+      width: 1920,
+      height: 1080,
+      aspectRatio: 1920 / 1080,
+    })
+
+    const imageSource = {
+      _type: 'image',
+      asset: {_ref: 'image-abc123-1920x1080-jpg', _type: 'reference'},
+    }
+
+    renderPreview(imageSource)
+
+    expect(capturedMediaDimensions).toBeUndefined()
+  })
+
+  it('should respect caller-provided mediaDimensions for blockImage layout', () => {
+    vi.mocked(isSanityImageUrl).mockReturnValue(false)
+    vi.mocked(isImageSource).mockReturnValue(true)
+    vi.mocked(tryGetImageDimensions).mockReturnValue({
+      width: 1920,
+      height: 1080,
+      aspectRatio: 1920 / 1080,
+    })
+
+    const imageSource = {
+      _type: 'image',
+      asset: {_ref: 'image-abc123-1920x1080-jpg', _type: 'reference'},
+    }
+
+    const explicitDimensions: PreviewMediaDimensions = {
+      width: 200,
+      height: 150,
+      fit: 'crop',
+    }
+
+    renderBlockImagePreview(imageSource, explicitDimensions)
+
+    expect(capturedMediaDimensions).toEqual(explicitDimensions)
+    expect(tryGetImageDimensions).not.toHaveBeenCalled()
+  })
+
+  it('should gracefully fall back when image dimensions cannot be resolved', () => {
+    vi.mocked(isSanityImageUrl).mockReturnValue(false)
+    vi.mocked(isImageSource).mockReturnValue(true)
+    vi.mocked(tryGetImageDimensions).mockReturnValue(undefined)
+
+    const imageSource = {
+      _type: 'image',
+      asset: {_ref: 'image-broken', _type: 'reference'},
+    }
+
+    renderBlockImagePreview(imageSource)
+
+    expect(capturedMediaDimensions).toBeUndefined()
   })
 })


### PR DESCRIPTION
### Description

This branch updates PTE's block image preview componentry to use the image's known dimensions, if available, rather than falling back to the 600x400 pixel default. These defaults produce a cropped and/or zoomed preview for any image that doesn't match the default aspect ratio.

| Before | After |
| --- | --- |
| <img width="1076" height="1148" alt="before-media-library" src="https://github.com/user-attachments/assets/6bc7cb81-289a-46bb-9a68-127c8652b16f" /> | <img width="1076" height="1148" alt="after-media-library" src="https://github.com/user-attachments/assets/e4980c87-261d-43e0-804e-f413724a1956" /> |
| <img width="1076" height="1148" alt="before-dataset" src="https://github.com/user-attachments/assets/611d6737-25b3-46d6-9f8f-886fdf7a45c0" /> | <img width="1076" height="1148" alt="after-dataset" src="https://github.com/user-attachments/assets/579d97d5-8295-4833-b75c-f74e4370e1f4" /> |
| <img width="1076" height="1148" alt="before-portrait" src="https://github.com/user-attachments/assets/66652fb9-04d1-4569-98b7-c7458f4ac578" /> | <img width="1076" height="1483" alt="Screenshot 2026-05-21 at 15 39 31" src="https://github.com/user-attachments/assets/d0310090-7c6c-4dba-ab40-7fe42d55c133" /> |

### What to review

Image dimensions inference, and the new layout constraints. Most notably: the block size of portrait images is now unbounded (see the third example above). In my opinion, this is the right UX.

### Testing

Tested images of various orientations uploaded to the dataset, and Media Library.

### Notes for release

Improves Portable Text editor block image previews: images are now displayed in the correct aspect ratio, preventing cropping and zooming.