### PR TITLE
feat(core)!: remove deprecated auth.mode config

### DIFF
--- a/packages/sanity/src/core/config/__tests__/prepareConfig.test.ts
+++ b/packages/sanity/src/core/config/__tests__/prepareConfig.test.ts
@@ -140,10 +140,10 @@ describe('prepareConfig — divergent auth warning', () => {
 
   it('does not warn when two workspaces declare the same auth config with different property order', () => {
     // AuthConfig is fingerprinted via a canonical (key-sorted) hash so that
-    // `{loginMethod: 'cookie', mode: 'replace'}` and
-    // `{mode: 'replace', loginMethod: 'cookie'}` compare equal — property
-    // declaration order and autoformatter reordering must not produce false
-    // positives.
+    // `{loginMethod: 'cookie', redirectOnSingle: true}` and
+    // `{redirectOnSingle: true, loginMethod: 'cookie'}` compare equal —
+    // property declaration order and autoformatter reordering must not
+    // produce false positives.
     const projectId = `order-${Math.random().toString(36).slice(2)}`
     const warningsBefore = getCollectedConfigWarnings().length
 
@@ -152,13 +152,13 @@ describe('prepareConfig — divergent auth warning', () => {
         name: 'w1',
         projectId,
         basePath: '/w1',
-        auth: {loginMethod: 'cookie', mode: 'replace', redirectOnSingle: true},
+        auth: {loginMethod: 'cookie', redirectOnSingle: true},
       }),
       createWorkspace({
         name: 'w2',
         projectId,
         basePath: '/w2',
-        auth: {redirectOnSingle: true, mode: 'replace', loginMethod: 'cookie'},
+        auth: {redirectOnSingle: true, loginMethod: 'cookie'},
       }),
     ])
 

--- a/packages/sanity/src/core/config/auth/types.ts
+++ b/packages/sanity/src/core/config/auth/types.ts
@@ -30,14 +30,6 @@ export interface AuthConfig {
   loginMethod?: LoginMethod
 
   /**
-   * Whether to append the providers specified in `providers` with the default providers from the
-   * API, or replace the default providers with the ones specified.
-   *
-   * @deprecated Use the function form of `providers` instead for more control
-   */
-  mode?: 'append' | 'replace'
-
-  /**
    * If true, the "Choose login provider" (eg "Google, "GitHub", "E-mail/password") screen
    * will be skipped if only a single provider is configured in the `providers` array -
    * instead it will redirect unauthenticated users straight to the authentication URL.
@@ -50,9 +42,8 @@ export interface AuthConfig {
    * providers. This can be used to selectively replace, add or remove providers from the
    * list of choices.
    *
-   * @remarks If a static array of providers is provided, the `mode` property is taken into account
-   *   when determining what to do with it - `append` will append the providers to the default set
-   *   of providers, while `replace` will replace the default providers with the ones specified.
+   * @remarks If a static array of providers is provided it will replace the default
+   * providers with the ones specified.
    *
    * If not set, the default providers will be used.
    */

--- a/packages/sanity/src/core/store/authStore/__tests__/createLoginComponent.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/createLoginComponent.test.ts
@@ -46,8 +46,6 @@ describe('getProviders', () => {
 
     await getProviders({
       client: client as unknown as SanityClient,
-      mode: 'append',
-      providers: [],
     })
 
     expect(requestConfigs).toHaveLength(1)
@@ -55,13 +53,12 @@ describe('getProviders', () => {
     expect(requestConfigs[0]?.withCredentials).toBe(false)
   })
 
-  it('skips /auth/providers entirely in replace mode with a provider array', async () => {
+  it('skips /auth/providers entirely when a static provider array is passed', async () => {
     const {client, requestConfigs} = createMockClient({token: 'expired-token'})
     const customProviders = [{name: 'github', title: 'GitHub', url: 'https://example.com/login'}]
 
     const result = await getProviders({
       client: client as unknown as SanityClient,
-      mode: 'replace',
       providers: customProviders,
     })
 

--- a/packages/sanity/src/core/store/authStore/createLoginComponent.tsx
+++ b/packages/sanity/src/core/store/authStore/createLoginComponent.tsx
@@ -20,11 +20,11 @@ interface GetProvidersOptions extends AuthConfig {
 /** @internal */
 export async function getProviders({
   client,
-  mode,
-  providers: customProviders = [],
+  providers: customProviders,
 }: GetProvidersOptions): Promise<AuthProvider[]> {
-  // Short-circuit if we're in replace mode without needing the default providers
-  if (mode === 'replace' && Array.isArray(customProviders)) {
+  // If a static array is provided, use it as-is (replaces defaults) and skip
+  // the /auth/providers request entirely.
+  if (Array.isArray(customProviders)) {
     return customProviders
   }
 
@@ -38,29 +38,11 @@ export async function getProviders({
     uri: '/auth/providers',
   })
 
-  // If a custom reducer function is passed, allow it to modify the default list of providers
-  // any way it wants - eg replace, append, remove etc.
-  if (typeof customProviders === 'function') {
-    return customProviders(providers)
-  }
-
-  // If no providers are specified, use the default list
-  if (customProviders.length === 0) {
-    return providers
-  }
-
-  // -- Note: Deprecated flow below: we now prefer the reducer pattern above --
-  // Replace mode: use the provided list as-is
-  if (mode === 'replace') {
-    return customProviders
-  }
-
-  // Append mode (default):
-  // Append to the list of official providers, but replace any provider that has
-  // the same URL with the custom one (allows customizing the title, name)
-  return providers
-    .filter((official) => customProviders.some((provider) => provider.url !== official.url))
-    .concat(customProviders)
+  return customProviders
+    ? // If a custom reducer function is passed, allow it to modify the default list of providers
+      // any way it wants - eg replace, append, remove etc.
+      customProviders(providers)
+    : providers
 }
 
 interface CreateLoginComponentOptions extends AuthConfig {


### PR DESCRIPTION
> [!NOTE]
> Staged for v6 with `next-major` as base branch


### Description
Removes deprecated `auth.mode` config and makes `replace` the default. This should be less surprising overall.

The function form of `auth.providers` can still be used to append or to otherwise customize the default list.

### What to review

### Testing
Tests updated

### Notes for release

BREAKING CHANGE: The `auth.mode` option ('append' | 'replace') is removed. A static `auth.providers` array now replaces the defaults. Use the function form of `auth.providers` to append to or otherwise customize the default list:

```js
auth: {
  providers: (prev) => [
    ...prev,
    {
      name: 'sanity',
      title: 'Email / Password',
      url: 'https://api.sanity.io/v1/auth/login/sanity',
    },
  ],
},​​​‌﻿‍﻿​‍​‍‌‍﻿﻿‌﻿​‍‌‍‍‌‌‍‌﻿‌‍‍‌‌‍﻿‍​‍​‍​﻿‍‍​‍​‍‌﻿​﻿‌‍​‌‌‍﻿‍‌‍‍‌‌﻿‌​‌﻿‍‌​‍﻿‍‌‍‍‌‌‍﻿﻿​‍​‍​‍﻿​​‍​‍‌‍‍​‌﻿​‍‌‍‌‌‌‍‌‍​‍​‍​﻿‍‍​‍​‍‌‍‍​‌﻿‌​‌﻿‌​‌﻿​​‌﻿​﻿​﻿‍‍​‍﻿﻿​‍﻿﻿‌‍​‌‌‍‌​‌‍﻿‌‌‍‍‌‌‍﻿‍​‍﻿‍‌﻿​﻿‌‍​‌‌‍﻿‍‌‍‍‌‌﻿‌​‌﻿‍‌​‍﻿‍‌‍‍‌‌‍﻿﻿​‍﻿﻿‌‍‍‌‌‍﻿‍‌﻿‌​‌‍‌‌‌‍﻿‍‌﻿‌​​‍﻿﻿‌‍‌‌‌‍‌​‌‍‍‌‌﻿‌​​‍﻿﻿‌‍﻿‌‌‍﻿﻿‌‍‌​‌‍‌‌​﻿﻿‌‌﻿​​‌﻿​‍‌‍‌‌‌﻿​﻿‌‍‌‌‌‍﻿‍‌﻿‌​‌‍​‌‌﻿‌​‌‍‍‌‌‍﻿﻿‌‍﻿‍​﻿‍﻿‌‍‍‌‌‍‌​​﻿﻿‌​﻿​‌​﻿‌‍​﻿‍‌‌‍​‍​﻿‍‌​﻿​‍‌‍​‍‌‍​‍​‍﻿‌‌‍‌‌​﻿‌﻿​﻿‌‍‌‍‌​​‍﻿‌​﻿‌​‌‍‌​​﻿‌​‌‍‌‌​‍﻿‌​﻿‍‌​﻿‍‌​﻿​‌​﻿​﻿​‍﻿‌​﻿‌​​﻿‍‌​﻿​‍​﻿‌﻿​﻿​﻿​﻿​‍‌‍​‍​﻿‌‌‌‍‌‌‌‍‌‌​﻿​‍​﻿‍‌​﻿‍﻿‌﻿‌​‌﻿‍‌‌﻿​​‌‍‌‌​﻿﻿‌‌﻿​​‌‍﻿﻿‌﻿​﻿‌﻿‌​​﻿‍﻿‌﻿​​‌‍​‌‌﻿‌​‌‍‍​​﻿﻿‌‌﻿‌​‌‍‌‌‌﻿‍​‌﻿‌​​‍‌‌​﻿‌‌‌​​‍‌‌﻿﻿‌‍‍﻿‌‍‌‌‌﻿‍‌​‍‌‌​﻿​﻿‌​‌​​‍‌‌​﻿​﻿‌​‌​​‍‌‌​﻿​‍​﻿​‍​﻿‌﻿‌‍‌​‌‍​﻿‌‍‌​​﻿‍​​﻿​﻿‌‍‌‍‌‍‌​​﻿​‌​﻿‍‌​﻿​‌‌‍​‌​‍‌‌​﻿​‍​﻿​‍​‍‌‌​﻿‌‌‌​‌​​‍﻿‍‌‍​﻿‌‍﻿﻿‌‍‌​‌‍‌‌​﻿﻿﻿‌‍​‍‌‍​‌‌﻿​﻿‌‍‌‌‌‌‌‌‌﻿​‍‌‍﻿​​﻿﻿‌‌‍‍​‌﻿‌​‌﻿‌​‌﻿​​‌﻿​﻿​‍‌‌​﻿​﻿‌​​‌​‍‌‌​﻿​‍‌​‌‍​‍‌‌​﻿​‍‌​‌‍‌‍​‌‌‍‌​‌‍﻿‌‌‍‍‌‌‍﻿‍​‍﻿‍‌﻿​﻿‌‍​‌‌‍﻿‍‌‍‍‌‌﻿‌​‌﻿‍‌​‍﻿‍‌‍‍‌‌‍﻿﻿​‍‌‍‌‍‍‌‌‍‌​​﻿﻿‌​﻿​‌​﻿‌‍​﻿‍‌‌‍​‍​﻿‍‌​﻿​‍‌‍​‍‌‍​‍​‍﻿‌‌‍‌‌​﻿‌﻿​﻿‌‍‌‍‌​​‍﻿‌​﻿‌​‌‍‌​​﻿‌​‌‍‌‌​‍﻿‌​﻿‍‌​﻿‍‌​﻿​‌​﻿​﻿​‍﻿‌​﻿‌​​﻿‍‌​﻿​‍​﻿‌﻿​﻿​﻿​﻿​‍‌‍​‍​﻿‌‌‌‍‌‌‌‍‌‌​﻿​‍​﻿‍‌​‍‌‍‌﻿‌​‌﻿‍‌‌﻿​​‌‍‌‌​﻿﻿‌‌﻿​​‌‍﻿﻿‌﻿​﻿‌﻿‌​​‍‌‍‌﻿​​‌‍​‌‌﻿‌​‌‍‍​​﻿﻿‌‌﻿‌​‌‍‌‌‌﻿‍​‌﻿‌​​‍‌‌​﻿‌‌‌​​‍‌‌﻿﻿‌‍‍﻿‌‍‌‌‌﻿‍‌​‍‌‌​﻿​﻿‌​‌​​‍‌‌​﻿​﻿‌​‌​​‍‌‌​﻿​‍​﻿​‍​﻿‌﻿‌‍‌​‌‍​﻿‌‍‌​​﻿‍​​﻿​﻿‌‍‌‍‌‍‌​​﻿​‌​﻿‍‌​﻿​‌‌‍​‌​‍‌‌​﻿​‍​﻿​‍​‍‌‌​﻿‌‌‌​‌​​‍﻿‍‌‍​﻿‌‍﻿﻿‌‍‌​‌‍‌‌​‍‌‍‌﻿​​‌‍‌‌‌﻿​‍‌﻿​﻿‌﻿​​‌‍‌‌‌‍​﻿‌﻿‌​‌‍‍‌‌﻿‌‍‌‍‌‌​﻿﻿‌‌‍​‌‌‍‌﻿‌‍‌‌‌‍﻿‍‌﻿‌​​‍﻿‌‌‌‌‍‌‌‌‍‌​﻿​​﻿‌​‌​​‌‌​‍​​‍​‍‌﻿﻿‌
```