### PR TITLE
chore(e2e): add variants e2e tests and readme

### DIFF
--- a/dev/studio-e2e-testing/sanity.config.ts
+++ b/dev/studio-e2e-testing/sanity.config.ts
@@ -143,6 +143,11 @@ const defaultConfig = defineConfig({
   mediaLibrary: {
     enabled: true,
   },
+  beta: {
+    variants: {
+      enabled: true,
+    },
+  },
 })
 
 export default defineConfig([

--- a/e2e/tests/variants/variantTool.spec.ts
+++ b/e2e/tests/variants/variantTool.spec.ts
@@ -410,7 +410,9 @@ test.describe('Variants create flow', () => {
     const row = getVariantRow(page, title)
     await expect(row).toBeVisible()
 
-    await row.getByRole('button').last().click()
+    // Target the stable actions-menu id rather than the last button in the row,
+    // which would break if the row gains more buttons. `variantId` is the short id.
+    await page.locator(`#variant-actions-${variantId}`).click()
     await page.getByRole('menuitem', {name: 'Delete variant'}).click()
     await expect(page.getByRole('menuitem', {name: 'Delete variant'})).toBeHidden()
 

--- a/e2e/tests/variants/variantTool.spec.ts
+++ b/e2e/tests/variants/variantTool.spec.ts
@@ -1,0 +1,446 @@
+import {expect, type Page, type TestInfo} from '@playwright/test'
+import {type SanityClient} from '@sanity/client'
+
+import {test} from '../../studio-test'
+
+const VARIANT_DOCUMENTS_PATH = '_.variants'
+const VARIANT_DOCUMENT_TYPE = 'system.variant'
+
+// Variant definition actions are only routable on a newer API version than the
+// shared e2e client default (2021-08-31). This matches the version the studio
+// uses for these calls (VARIANTS_STUDIO_CLIENT_OPTIONS).
+const VARIANTS_API_VERSION = 'X'
+
+function getVariantsClient(sanityClient: SanityClient): SanityClient {
+  return sanityClient.withConfig({apiVersion: VARIANTS_API_VERSION})
+}
+
+const E2E_VARIANT_TITLE_RUN_ID = `${Date.now().toString(36)}${Math.random()
+  .toString(36)
+  .slice(2, 10)}`
+
+interface VariantDocument {
+  _id: `${typeof VARIANT_DOCUMENTS_PATH}.${string}`
+  _type: typeof VARIANT_DOCUMENT_TYPE
+  name?: string
+  conditions: Record<string, string>
+  priority: number
+  metadata?: {
+    title?: string
+    [key: string]: unknown
+  }
+}
+
+function normalizeTitlePart(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+function createVariantTitlePrefix(testInfo: TestInfo = test.info()): string {
+  const projectName = normalizeTitlePart(testInfo.project.name)
+  const testName = normalizeTitlePart(testInfo.title)
+
+  return `E2E Variants ${E2E_VARIANT_TITLE_RUN_ID} ${projectName} worker ${testInfo.parallelIndex} retry ${testInfo.retry} ${testName}`
+}
+
+async function createVariantDefinition(
+  sanityClient: SanityClient,
+  options: {
+    variantId: string
+    conditions?: Record<string, string>
+    priority?: number
+    metadata?: VariantDocument['metadata']
+  },
+): Promise<void> {
+  // Variant definition actions are available at runtime, but their payloads are
+  // not yet typed on SanityClient.action(). The shape below matches the API
+  // contract in packages/sanity/src/core/variants/ACTIONS.md; remove `as never`
+  // once @sanity/client exports these action types.
+  await getVariantsClient(sanityClient).action({
+    actionType: 'sanity.action.variant.definition.create',
+    variantId: options.variantId,
+    conditions: options.conditions ?? {},
+    priority: options.priority ?? 0,
+    metadata: options.metadata,
+  } as never)
+}
+
+async function deleteVariantDocuments(
+  sanityClient: SanityClient,
+  titlePrefix: string,
+): Promise<void> {
+  const client = getVariantsClient(sanityClient)
+
+  const documents = await client.fetch<Array<{_id: string}>>(
+    `*[
+      _type == $variantDocumentType &&
+      _id in path("${VARIANT_DOCUMENTS_PATH}.*") &&
+      metadata.title match $titleGlob
+    ]{_id}`,
+    {
+      titleGlob: `${titlePrefix}*`,
+      variantDocumentType: VARIANT_DOCUMENT_TYPE,
+    },
+  )
+
+  for (const document of documents) {
+    // Same untyped-action workaround as createVariantDefinition above.
+    await client.action({
+      actionType: 'sanity.action.variant.definition.delete',
+      variantId: getVariantShortId(document._id),
+    } as never)
+  }
+}
+
+function createRunId(label: string): string {
+  const {parallelIndex, project, retry} = test.info()
+  const projectName = project.name.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+
+  return `${label}-${projectName}-${parallelIndex}-${retry}-${E2E_VARIANT_TITLE_RUN_ID}`
+}
+
+function getVariantShortId(variantDocumentId: string): string {
+  return variantDocumentId.startsWith(`${VARIANT_DOCUMENTS_PATH}.`)
+    ? variantDocumentId.slice(`${VARIANT_DOCUMENTS_PATH}.`.length)
+    : variantDocumentId
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+async function openVariantsTool(page: Page): Promise<void> {
+  await page.goto('/variants')
+  await expect(page.getByRole('heading', {name: 'Variants'})).toBeVisible()
+}
+
+async function openCreateVariantDialog(page: Page) {
+  await page.getByRole('button', {name: 'Create variant'}).first().click()
+
+  const dialog = page.getByRole('dialog', {name: 'Create variant'})
+  await expect(dialog).toBeVisible()
+
+  return dialog
+}
+
+function getConditionKeyInputs(pageOrDialog: Page | ReturnType<Page['getByRole']>) {
+  return pageOrDialog.getByTestId('variant-form-condition-key')
+}
+
+function getConditionValueInputs(pageOrDialog: Page | ReturnType<Page['getByRole']>) {
+  return pageOrDialog.getByTestId('variant-form-condition-value')
+}
+
+async function fillConditionRow(
+  dialog: ReturnType<Page['getByRole']>,
+  index: number,
+  key: string,
+  value: string,
+): Promise<void> {
+  await getConditionKeyInputs(dialog).nth(index).fill(key)
+  await getConditionValueInputs(dialog).nth(index).fill(value)
+}
+
+async function findVariantDocumentByTitle(
+  sanityClient: SanityClient,
+  title: string,
+): Promise<VariantDocument | null> {
+  return sanityClient.fetch<VariantDocument | null>(
+    `*[
+      _type == "${VARIANT_DOCUMENT_TYPE}" &&
+      _id in path("${VARIANT_DOCUMENTS_PATH}.*") &&
+      metadata.title == $title
+    ][0]{
+      _id,
+      _type,
+      name,
+      conditions,
+      priority,
+      metadata,
+    }`,
+    {title},
+  )
+}
+
+async function waitForVariantDocument(
+  sanityClient: SanityClient,
+  title: string,
+): Promise<VariantDocument> {
+  let document: VariantDocument | null = null
+
+  await expect
+    .poll(
+      async () => {
+        document = await findVariantDocumentByTitle(sanityClient, title)
+
+        return document?._id ?? null
+      },
+      {message: `variant document "${title}" should be persisted`},
+    )
+    .not.toBeNull()
+
+  if (!document) {
+    throw new Error(`Variant document "${title}" was not found`)
+  }
+
+  return document
+}
+
+async function submitCreateVariantDialog(
+  page: Page,
+  sanityClient: SanityClient,
+  title: string,
+): Promise<VariantDocument> {
+  await expect(page.getByTestId('submit-variant-button')).toBeEnabled()
+  await page.getByTestId('submit-variant-button').click()
+
+  await expect(page).toHaveURL(/\/variants\/[^/?#]+$/)
+  expect(new URL(page.url()).pathname).not.toContain(`${VARIANT_DOCUMENTS_PATH}.`)
+
+  const document = await waitForVariantDocument(sanityClient, title)
+
+  const shortVariantId = getVariantShortId(document._id)
+  expect(new URL(page.url()).pathname).toMatch(
+    new RegExp(`/variants/${escapeRegExp(shortVariantId)}$`),
+  )
+
+  return document
+}
+
+function getVariantRow(page: Page, title: string) {
+  return page.getByTestId('table-row').filter({hasText: title})
+}
+
+test.describe('Variants create flow', () => {
+  test.afterEach(async ({sanityClient}, testInfo) => {
+    // Teardown failures should not mask passing assertions; log and continue.
+    try {
+      await deleteVariantDocuments(sanityClient, createVariantTitlePrefix(testInfo))
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn('Failed to clean up variant documents:', error)
+    }
+  })
+
+  test('creates a variant and persists conditions', async ({page, sanityClient}) => {
+    const runId = createRunId('happy')
+    const title = `${createVariantTitlePrefix()} Loyal Customers ${runId}`
+    const value = `loyal-${runId}`
+
+    await openVariantsTool(page)
+    const dialog = await openCreateVariantDialog(page)
+
+    await dialog.getByTestId('variant-form-title').fill(title)
+    await fillConditionRow(dialog, 0, 'audience', value)
+
+    const document = await submitCreateVariantDialog(page, sanityClient, title)
+
+    expect(document._id).toMatch(new RegExp(`^${escapeRegExp(VARIANT_DOCUMENTS_PATH)}\\.`))
+    expect(document._type).toBe(VARIANT_DOCUMENT_TYPE)
+    expect(document.metadata?.title).toBe(title)
+    expect(document.conditions).toEqual({audience: value})
+  })
+
+  test('validates title and complete condition rows', async ({page}) => {
+    await openVariantsTool(page)
+    const dialog = await openCreateVariantDialog(page)
+    const submitButton = dialog.getByTestId('submit-variant-button')
+    const addConditionButton = dialog.getByRole('button', {name: 'Add condition'})
+    const titleInput = dialog.getByTestId('variant-form-title')
+
+    await expect(submitButton).toBeEnabled()
+    await expect(addConditionButton).toBeDisabled()
+
+    await submitButton.click()
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByTestId('variant-form-title-error')).toHaveText('Title is required')
+
+    await titleInput.fill(`${createVariantTitlePrefix()} Validation ${createRunId('validation')}`)
+    await expect(dialog.getByTestId('variant-form-title-error')).toBeHidden()
+
+    // A condition row needs both a key and a value before another row can be added.
+    await getConditionKeyInputs(dialog).first().fill('audience')
+    await expect(addConditionButton).toBeDisabled()
+
+    await getConditionValueInputs(dialog).first().fill('loyal')
+    await expect(addConditionButton).toBeEnabled()
+
+    await addConditionButton.click()
+    await expect(getConditionKeyInputs(dialog)).toHaveCount(2)
+    await expect(addConditionButton).toBeDisabled()
+  })
+
+  test('keeps duplicate condition keys invalid until the edited key is unique', async ({
+    page,
+    sanityClient,
+  }) => {
+    const runId = createRunId('duplicate')
+    const title = `${createVariantTitlePrefix()} Duplicate Keys ${runId}`
+
+    await openVariantsTool(page)
+    const dialog = await openCreateVariantDialog(page)
+
+    await dialog.getByTestId('variant-form-title').fill(title)
+    await fillConditionRow(dialog, 0, 'audience', 'us')
+    await dialog.getByRole('button', {name: 'Add condition'}).click()
+
+    const secondKeyInput = getConditionKeyInputs(dialog).nth(1)
+
+    await secondKeyInput.fill('audience')
+    await getConditionValueInputs(dialog).nth(1).fill('fr')
+    await expect(dialog.getByTestId('variant-form-condition-key-error')).toHaveText(
+      'Condition keys must be unique',
+    )
+
+    await dialog.getByTestId('submit-variant-button').click()
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByTestId('variant-form-condition-key-error')).toBeVisible()
+
+    await secondKeyInput.fill('audience2')
+    await expect(secondKeyInput).toHaveValue('audience2')
+    await expect(dialog.getByTestId('variant-form-condition-key-error')).toBeHidden()
+
+    const document = await submitCreateVariantDialog(page, sanityClient, title)
+
+    expect(document.conditions).toEqual({
+      audience: 'us',
+      audience2: 'fr',
+    })
+  })
+
+  test('preserves partial condition key editing from new to newton', async ({
+    page,
+    sanityClient,
+  }) => {
+    const runId = createRunId('partial')
+    const title = `${createVariantTitlePrefix()} Partial Key ${runId}`
+
+    await openVariantsTool(page)
+    const dialog = await openCreateVariantDialog(page)
+
+    await dialog.getByTestId('variant-form-title').fill(title)
+    await fillConditionRow(dialog, 0, 'new', 'us')
+    await dialog.getByRole('button', {name: 'Add condition'}).click()
+
+    const secondKeyInput = getConditionKeyInputs(dialog).nth(1)
+
+    await secondKeyInput.type('new')
+    await expect(secondKeyInput).toHaveValue('new')
+    await expect(dialog.getByTestId('variant-form-condition-key-error')).toHaveText(
+      'Condition keys must be unique',
+    )
+
+    await secondKeyInput.type('ton')
+    await expect(secondKeyInput).toHaveValue('newton')
+    await expect(dialog.getByTestId('variant-form-condition-key-error')).toBeHidden()
+
+    await getConditionValueInputs(dialog).nth(1).fill('gb')
+    await expect(dialog.getByTestId('submit-variant-button')).toBeEnabled()
+
+    const document = await submitCreateVariantDialog(page, sanityClient, title)
+
+    expect(document.conditions).toEqual({
+      new: 'us',
+      newton: 'gb',
+    })
+  })
+
+  // Skipped because autocomplete is not implemented yet, waiting for PR https://github.com/sanity-io/sanity/pull/12858
+  test.skip('suggests condition keys and values from existing variants', async ({
+    page,
+    sanityClient,
+  }) => {
+    const runId = createRunId('autocomplete')
+    const seededAudienceTitle = `${createVariantTitlePrefix()} Autocomplete Audience Seed ${runId}`
+    const seededLanguageTitle = `${createVariantTitlePrefix()} Autocomplete Language Seed ${runId}`
+    const title = `${createVariantTitlePrefix()} Autocomplete Created ${runId}`
+    const audienceValue = `returning-${runId}`
+    const languageValue = `en-${runId}`
+
+    await createVariantDefinition(sanityClient, {
+      variantId: `${runId}-audience`,
+      conditions: {audience: audienceValue},
+      metadata: {title: seededAudienceTitle},
+    })
+    await createVariantDefinition(sanityClient, {
+      variantId: `${runId}-language`,
+      conditions: {language: languageValue},
+      metadata: {title: seededLanguageTitle},
+    })
+
+    await openVariantsTool(page)
+    await expect(getVariantRow(page, seededAudienceTitle)).toBeVisible()
+    await expect(getVariantRow(page, seededLanguageTitle)).toBeVisible()
+
+    const dialog = await openCreateVariantDialog(page)
+
+    await dialog.getByTestId('variant-form-title').fill(title)
+
+    await getConditionKeyInputs(dialog).first().fill('aud')
+    await page.getByRole('option', {name: 'audience', exact: true}).click()
+    await expect(getConditionKeyInputs(dialog).first()).toHaveValue('audience')
+
+    await getConditionValueInputs(dialog).first().fill('ret')
+    await expect(page.getByRole('option', {name: audienceValue, exact: true})).toBeVisible()
+    await expect(page.getByRole('option', {name: languageValue, exact: true})).toBeHidden()
+    await page.getByRole('option', {name: audienceValue, exact: true}).click()
+
+    const document = await submitCreateVariantDialog(page, sanityClient, title)
+
+    expect(document.conditions).toEqual({audience: audienceValue})
+  })
+
+  test('deletes a seeded variant from the overview', async ({page, sanityClient}) => {
+    const runId = createRunId('delete')
+    const variantId = `${runId}` as const
+    const documentId = `${VARIANT_DOCUMENTS_PATH}.${variantId}` as const
+    const title = `${createVariantTitlePrefix()} Delete Variant ${runId}`
+    const value = `delete-${runId}`
+
+    await createVariantDefinition(sanityClient, {
+      variantId,
+      conditions: {audience: value},
+      metadata: {title},
+    })
+
+    await openVariantsTool(page)
+
+    const row = getVariantRow(page, title)
+    await expect(row).toBeVisible()
+
+    await row.getByRole('button').last().click()
+    await page.getByRole('menuitem', {name: 'Delete variant'}).click()
+    await expect(page.getByRole('menuitem', {name: 'Delete variant'})).toBeHidden()
+
+    await expect(row).toBeHidden()
+    await expect.poll(async () => sanityClient.getDocument(documentId)).toBeUndefined()
+  })
+
+  test('deletes a seeded variant from the detail page', async ({page, sanityClient}) => {
+    const runId = createRunId('delete-detail')
+    const variantId = `${runId}` as const
+    const documentId = `${VARIANT_DOCUMENTS_PATH}.${variantId}` as const
+    const shortVariantId = getVariantShortId(documentId)
+    const title = `${createVariantTitlePrefix()} Delete Detail Variant ${runId}`
+    const value = `delete-detail-${runId}`
+
+    await createVariantDefinition(sanityClient, {
+      variantId,
+      conditions: {audience: value},
+      metadata: {title},
+    })
+
+    await page.goto(`/variants/${shortVariantId}`)
+    await expect(page.getByRole('heading', {name: title})).toBeVisible()
+
+    await page.locator(`#variant-detail-actions-${shortVariantId}`).click()
+    await page.getByRole('menuitem', {name: 'Delete variant'}).click()
+    await expect(page.getByRole('menuitem', {name: 'Delete variant'})).toBeHidden()
+
+    await expect(page.getByRole('heading', {name: 'Variants'})).toBeVisible()
+    await expect(getVariantRow(page, title)).toBeHidden()
+    await expect.poll(async () => sanityClient.getDocument(documentId)).toBeUndefined()
+  })
+})

--- a/e2e/tests/variants/variantTool.spec.ts
+++ b/e2e/tests/variants/variantTool.spec.ts
@@ -1,0 +1,408 @@
+import {expect, type Page, type TestInfo} from '@playwright/test'
+import {type SanityClient} from '@sanity/client'
+
+import {test} from '../../studio-test'
+
+const VARIANT_DOCUMENTS_PATH = 'variants'
+const VARIANT_DOCUMENT_TYPE = 'system.variant'
+
+const E2E_VARIANT_TITLE_RUN_ID = `${Date.now().toString(36)}${Math.random()
+  .toString(36)
+  .slice(2, 10)}`
+
+interface VariantDocument {
+  _id: `${typeof VARIANT_DOCUMENTS_PATH}.${string}`
+  _type: typeof VARIANT_DOCUMENT_TYPE
+  conditions: Record<string, string>
+  priority: number
+  metadata?: {
+    title?: string
+    [key: string]: unknown
+  }
+}
+
+function normalizeTitlePart(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+function createVariantTitlePrefix(testInfo: TestInfo = test.info()): string {
+  const projectName = normalizeTitlePart(testInfo.project.name)
+  const testName = normalizeTitlePart(testInfo.title)
+
+  return `E2E Variants ${E2E_VARIANT_TITLE_RUN_ID} ${projectName} worker ${testInfo.parallelIndex} retry ${testInfo.retry} ${testName}`
+}
+
+async function deleteVariantDocuments(
+  sanityClient: SanityClient,
+  titlePrefix: string,
+): Promise<void> {
+  await sanityClient.delete({
+    query: `*[
+      _type == $variantDocumentType &&
+      _id in path("${VARIANT_DOCUMENTS_PATH}.*") &&
+      metadata.title match $titleGlob
+    ]`,
+    params: {
+      titleGlob: `${titlePrefix}*`,
+      variantDocumentType: VARIANT_DOCUMENT_TYPE,
+    },
+  })
+}
+
+function createRunId(label: string): string {
+  const {parallelIndex, project, retry} = test.info()
+  const projectName = project.name.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+
+  return `${label}-${projectName}-${parallelIndex}-${retry}-${E2E_VARIANT_TITLE_RUN_ID}`
+}
+
+function getVariantShortId(variantDocumentId: string): string {
+  return variantDocumentId.startsWith(`${VARIANT_DOCUMENTS_PATH}.`)
+    ? variantDocumentId.slice(`${VARIANT_DOCUMENTS_PATH}.`.length)
+    : variantDocumentId
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+async function openVariantsTool(page: Page): Promise<void> {
+  await page.goto('/variants')
+  await expect(page.getByRole('heading', {name: 'Variants'})).toBeVisible()
+}
+
+async function openCreateVariantDialog(page: Page) {
+  await page.getByRole('button', {name: 'Create variant'}).first().click()
+
+  const dialog = page.getByRole('dialog', {name: 'Create variant'})
+  await expect(dialog).toBeVisible()
+
+  return dialog
+}
+
+function getConditionKeyInputs(pageOrDialog: Page | ReturnType<Page['getByRole']>) {
+  return pageOrDialog.getByTestId('variant-form-condition-key')
+}
+
+function getConditionValueInputs(pageOrDialog: Page | ReturnType<Page['getByRole']>) {
+  return pageOrDialog.getByTestId('variant-form-condition-value')
+}
+
+async function fillConditionRow(
+  dialog: ReturnType<Page['getByRole']>,
+  index: number,
+  key: string,
+  value: string,
+): Promise<void> {
+  await getConditionKeyInputs(dialog).nth(index).fill(key)
+  await getConditionValueInputs(dialog).nth(index).fill(value)
+}
+
+async function findVariantDocumentByTitle(
+  sanityClient: SanityClient,
+  title: string,
+): Promise<VariantDocument | null> {
+  return sanityClient.fetch<VariantDocument | null>(
+    `*[
+      _type == "${VARIANT_DOCUMENT_TYPE}" &&
+      _id in path("${VARIANT_DOCUMENTS_PATH}.*") &&
+      metadata.title == $title
+    ][0]{
+      _id,
+      _type,
+      conditions,
+      priority,
+      metadata,
+    }`,
+    {title},
+  )
+}
+
+async function waitForVariantDocument(
+  sanityClient: SanityClient,
+  title: string,
+): Promise<VariantDocument> {
+  let document: VariantDocument | null = null
+
+  await expect
+    .poll(
+      async () => {
+        document = await findVariantDocumentByTitle(sanityClient, title)
+
+        return document?._id ?? null
+      },
+      {message: `variant document "${title}" should be persisted`},
+    )
+    .not.toBeNull()
+
+  if (!document) {
+    throw new Error(`Variant document "${title}" was not found`)
+  }
+
+  return document
+}
+
+async function submitCreateVariantDialog(
+  page: Page,
+  sanityClient: SanityClient,
+  title: string,
+): Promise<VariantDocument> {
+  await expect(page.getByTestId('submit-variant-button')).toBeEnabled()
+  await page.getByTestId('submit-variant-button').click()
+
+  await expect(page).toHaveURL(/\/variants\/[^/?#]+$/)
+  expect(new URL(page.url()).pathname).not.toContain('_.variants')
+
+  const document = await waitForVariantDocument(sanityClient, title)
+
+  const shortVariantId = getVariantShortId(document._id)
+  expect(new URL(page.url()).pathname).toMatch(
+    new RegExp(`/variants/${escapeRegExp(shortVariantId)}$`),
+  )
+
+  return document
+}
+
+function getVariantRow(page: Page, title: string) {
+  return page.getByTestId('table-row').filter({hasText: title})
+}
+
+test.describe('Variants create flow', () => {
+  test.afterEach(async ({sanityClient}, testInfo) => {
+    await deleteVariantDocuments(sanityClient, createVariantTitlePrefix(testInfo))
+  })
+
+  test('creates a variant and persists conditions', async ({page, sanityClient}) => {
+    const runId = createRunId('happy')
+    const title = `${createVariantTitlePrefix()} Loyal Customers ${runId}`
+    const value = `loyal-${runId}`
+
+    await openVariantsTool(page)
+    const dialog = await openCreateVariantDialog(page)
+
+    await dialog.getByTestId('variant-form-title').fill(title)
+    await fillConditionRow(dialog, 0, 'audience', value)
+
+    const document = await submitCreateVariantDialog(page, sanityClient, title)
+
+    expect(document._id).toMatch(new RegExp(`^${escapeRegExp(VARIANT_DOCUMENTS_PATH)}\\.`))
+    expect(document._type).toBe(VARIANT_DOCUMENT_TYPE)
+    expect(document.metadata?.title).toBe(title)
+    expect(document.conditions).toEqual({audience: value})
+  })
+
+  test('validates title and complete condition rows', async ({page}) => {
+    await openVariantsTool(page)
+    const dialog = await openCreateVariantDialog(page)
+    const submitButton = dialog.getByTestId('submit-variant-button')
+    const addConditionButton = dialog.getByRole('button', {name: 'Add condition'})
+    const titleInput = dialog.getByTestId('variant-form-title')
+
+    await expect(submitButton).toBeDisabled()
+    await expect(addConditionButton).toBeDisabled()
+
+    await titleInput.focus()
+    await titleInput.blur()
+    await expect(dialog.getByTestId('variant-form-title-error')).toHaveText('Title is required')
+
+    await titleInput.fill(`${createVariantTitlePrefix()} Validation ${createRunId('validation')}`)
+    await expect(dialog.getByTestId('variant-form-title-error')).toBeHidden()
+
+    await getConditionKeyInputs(dialog).first().fill('audience')
+    await expect(submitButton).toBeDisabled()
+    await expect(addConditionButton).toBeDisabled()
+
+    await getConditionValueInputs(dialog).first().fill('loyal')
+    await expect(submitButton).toBeEnabled()
+    await expect(addConditionButton).toBeEnabled()
+
+    await addConditionButton.click()
+    await expect(getConditionKeyInputs(dialog)).toHaveCount(2)
+    await expect(addConditionButton).toBeDisabled()
+    await expect(submitButton).toBeDisabled()
+  })
+
+  test('keeps duplicate condition keys invalid until the edited key is unique', async ({
+    page,
+    sanityClient,
+  }) => {
+    const runId = createRunId('duplicate')
+    const title = `${createVariantTitlePrefix()} Duplicate Keys ${runId}`
+
+    await openVariantsTool(page)
+    const dialog = await openCreateVariantDialog(page)
+
+    await dialog.getByTestId('variant-form-title').fill(title)
+    await fillConditionRow(dialog, 0, 'audience', 'us')
+    await dialog.getByRole('button', {name: 'Add condition'}).click()
+
+    const secondKeyInput = getConditionKeyInputs(dialog).nth(1)
+
+    await secondKeyInput.fill('audience')
+    await getConditionValueInputs(dialog).nth(1).fill('fr')
+    await expect(dialog.getByTestId('variant-form-condition-key-error')).toHaveText(
+      'Condition keys must be unique',
+    )
+    await expect(dialog.getByTestId('submit-variant-button')).toBeDisabled()
+
+    await secondKeyInput.fill('audience2')
+    await expect(secondKeyInput).toHaveValue('audience2')
+    await expect(dialog.getByTestId('variant-form-condition-key-error')).toBeHidden()
+
+    const document = await submitCreateVariantDialog(page, sanityClient, title)
+
+    expect(document.conditions).toEqual({
+      audience: 'us',
+      audience2: 'fr',
+    })
+  })
+
+  test('preserves partial condition key editing from new to newton', async ({
+    page,
+    sanityClient,
+  }) => {
+    const runId = createRunId('partial')
+    const title = `${createVariantTitlePrefix()} Partial Key ${runId}`
+
+    await openVariantsTool(page)
+    const dialog = await openCreateVariantDialog(page)
+
+    await dialog.getByTestId('variant-form-title').fill(title)
+    await fillConditionRow(dialog, 0, 'new', 'us')
+    await dialog.getByRole('button', {name: 'Add condition'}).click()
+
+    const secondKeyInput = getConditionKeyInputs(dialog).nth(1)
+
+    await secondKeyInput.type('new')
+    await expect(secondKeyInput).toHaveValue('new')
+    await expect(dialog.getByTestId('variant-form-condition-key-error')).toHaveText(
+      'Condition keys must be unique',
+    )
+
+    await secondKeyInput.type('ton')
+    await expect(secondKeyInput).toHaveValue('newton')
+    await expect(dialog.getByTestId('variant-form-condition-key-error')).toBeHidden()
+
+    await getConditionValueInputs(dialog).nth(1).fill('gb')
+    await expect(dialog.getByTestId('submit-variant-button')).toBeEnabled()
+
+    const document = await submitCreateVariantDialog(page, sanityClient, title)
+
+    expect(document.conditions).toEqual({
+      new: 'us',
+      newton: 'gb',
+    })
+  })
+
+  test('suggests condition keys and values from existing variants', async ({
+    page,
+    sanityClient,
+  }) => {
+    const runId = createRunId('autocomplete')
+    const seededAudienceTitle = `${createVariantTitlePrefix()} Autocomplete Audience Seed ${runId}`
+    const seededLanguageTitle = `${createVariantTitlePrefix()} Autocomplete Language Seed ${runId}`
+    const title = `${createVariantTitlePrefix()} Autocomplete Created ${runId}`
+    const audienceValue = `returning-${runId}`
+    const languageValue = `en-${runId}`
+
+    const seededAudienceVariant: VariantDocument = {
+      _id: `${VARIANT_DOCUMENTS_PATH}.${runId}-audience` as const,
+      _type: VARIANT_DOCUMENT_TYPE,
+      conditions: {audience: audienceValue},
+      metadata: {title: seededAudienceTitle},
+      priority: 0,
+    }
+    const seededLanguageVariant: VariantDocument = {
+      _id: `${VARIANT_DOCUMENTS_PATH}.${runId}-language` as const,
+      _type: VARIANT_DOCUMENT_TYPE,
+      conditions: {language: languageValue},
+      metadata: {title: seededLanguageTitle},
+      priority: 0,
+    }
+
+    await sanityClient.createOrReplace(seededAudienceVariant)
+    await sanityClient.createOrReplace(seededLanguageVariant)
+
+    await openVariantsTool(page)
+    await expect(getVariantRow(page, seededAudienceTitle)).toBeVisible()
+    await expect(getVariantRow(page, seededLanguageTitle)).toBeVisible()
+
+    const dialog = await openCreateVariantDialog(page)
+
+    await dialog.getByTestId('variant-form-title').fill(title)
+
+    await getConditionKeyInputs(dialog).first().fill('aud')
+    await page.getByRole('option', {name: 'audience', exact: true}).click()
+    await expect(getConditionKeyInputs(dialog).first()).toHaveValue('audience')
+
+    await getConditionValueInputs(dialog).first().fill('ret')
+    await expect(page.getByRole('option', {name: audienceValue, exact: true})).toBeVisible()
+    await expect(page.getByRole('option', {name: languageValue, exact: true})).toBeHidden()
+    await page.getByRole('option', {name: audienceValue, exact: true}).click()
+
+    const document = await submitCreateVariantDialog(page, sanityClient, title)
+
+    expect(document.conditions).toEqual({audience: audienceValue})
+  })
+
+  test('deletes a seeded variant from the overview', async ({page, sanityClient}) => {
+    const runId = createRunId('delete')
+    const variantId = `${VARIANT_DOCUMENTS_PATH}.${runId}` as const
+    const title = `${createVariantTitlePrefix()} Delete Variant ${runId}`
+    const value = `delete-${runId}`
+
+    const seededVariant: VariantDocument = {
+      _id: variantId,
+      _type: VARIANT_DOCUMENT_TYPE,
+      conditions: {audience: value},
+      metadata: {title},
+      priority: 0,
+    }
+
+    await sanityClient.createOrReplace(seededVariant)
+
+    await openVariantsTool(page)
+
+    const row = getVariantRow(page, title)
+    await expect(row).toBeVisible()
+
+    await row.getByRole('button').last().click()
+    await page.getByRole('menuitem', {name: 'Delete variant'}).click()
+    await expect(page.getByRole('menuitem', {name: 'Delete variant'})).toBeHidden()
+
+    await expect(row).toBeHidden()
+    await expect.poll(async () => sanityClient.getDocument(variantId)).toBeUndefined()
+  })
+
+  test('deletes a seeded variant from the detail page', async ({page, sanityClient}) => {
+    const runId = createRunId('delete-detail')
+    const variantId = `${VARIANT_DOCUMENTS_PATH}.${runId}` as const
+    const shortVariantId = getVariantShortId(variantId)
+    const title = `${createVariantTitlePrefix()} Delete Detail Variant ${runId}`
+    const value = `delete-detail-${runId}`
+
+    const seededVariant: VariantDocument = {
+      _id: variantId,
+      _type: VARIANT_DOCUMENT_TYPE,
+      conditions: {audience: value},
+      metadata: {title},
+      priority: 0,
+    }
+
+    await sanityClient.createOrReplace(seededVariant)
+
+    await page.goto(`/variants/${shortVariantId}`)
+    await expect(page.getByRole('heading', {name: title})).toBeVisible()
+
+    await page.locator(`#variant-detail-actions-${shortVariantId}`).click()
+    await page.getByRole('menuitem', {name: 'Delete variant'}).click()
+    await expect(page.getByRole('menuitem', {name: 'Delete variant'})).toBeHidden()
+
+    await expect(page.getByRole('heading', {name: 'Variants'})).toBeVisible()
+    await expect(getVariantRow(page, title)).toBeHidden()
+    await expect.poll(async () => sanityClient.getDocument(variantId)).toBeUndefined()
+  })
+})

--- a/e2e/tests/variants/variantTool.spec.ts
+++ b/e2e/tests/variants/variantTool.spec.ts
@@ -347,8 +347,7 @@ test.describe('Variants create flow', () => {
     })
   })
 
-  // Skipped because autocomplete is not implemented yet, waiting for PR https://github.com/sanity-io/sanity/pull/12858
-  test.skip('suggests condition keys and values from existing variants', async ({
+  test('suggests condition keys and values from existing variants', async ({
     page,
     sanityClient,
   }) => {

--- a/packages/sanity/src/core/variants/README.md
+++ b/packages/sanity/src/core/variants/README.md
@@ -1,0 +1,231 @@
+# Variants Tool Architecture
+
+This document describes the current architecture of the Variants Studio tool, what functionality is already covered, and the main work that is still pending.
+
+## Scope
+
+The Variants tool is registered by `plugin/index.tsx` under the `sanity/variants` plugin name and is gated by `beta.variants.enabled`. The tool route is `/variants`, with detail pages mounted at `/variants/:variantId`.
+
+Variant definitions are currently stored as regular documents:
+
+- Document type: `system.variant`
+- Temporary ID path: `variants.*`
+- Type shape: `SystemVariant` in `types.ts`
+
+The `variants.*` path is intentional for now. The final system-document path is expected to change later, so code should keep using `VARIANT_DOCUMENTS_PATH` instead of hardcoding either `variants` or `_.variants`.
+
+## Data Model
+
+A variant document currently contains:
+
+- `_id` and `_type`
+- `conditions: Record<string, string>`
+- `priority`, defaulting to `0`
+- optional `metadata`, currently used for `title` and Portable Text `description`
+
+`conditions` is persisted as an object because that is the shape expected by the document. The UI does not edit that object directly. It keeps condition rows locally while the user is typing so duplicate keys, incomplete rows, and partial key edits do not collapse or lose values.
+
+## Store And Operations
+
+Read state lives in `store/createVariantsStore.ts`.
+
+- The store is lazily initialized on first subscription.
+- It uses `listenQuery` to fetch and keep all variants fresh.
+- The state is shared through `useVariantsStore` and consumed by `useAllVariants`.
+- The query filters by `VARIANT_DOCUMENT_TYPE` and `VARIANT_DOCUMENTS_PATH`.
+
+Write operations live in `store/createVariantOperationsStore.ts`.
+
+- `createVariant` uses `client.create`.
+- `updateVariant` patches `conditions`, `priority`, and optional `metadata`.
+- `deleteVariant` uses `client.delete`.
+
+These operations are intentionally temporary. They use direct client document mutations until dedicated variant client actions exist.
+
+## Routing
+
+`tool/VariantsTool.tsx` switches between overview and detail based on `router.state.variantId`.
+
+Route helpers live in `tool/util.ts`:
+
+- `getVariantId` strips the document path for readable URLs.
+- `decodeVariantIdFromRoute` turns a short URL segment back into the full document ID.
+
+The overview links to short URLs such as `/variants/loyal-customers`, not full IDs such as `/variants/variants.loyal-customers`.
+
+## Overview Page
+
+`tool/overview/VariantsOverview.tsx` renders the main variants table.
+
+Covered behavior:
+
+- Loading, error, and empty states.
+- Search by title, ID suffix, condition keys, and condition values.
+- Table rows that navigate to the detail route.
+- Create variant button.
+- Row actions menu with `Delete variant`.
+
+The table uses the shared releases table component so the row layout, sorting, and virtualization match other Studio tooling.
+
+## Create And Edit Dialogs
+
+Create and edit share the same dialog shell and form:
+
+- `components/dialog/VariantDialog.tsx` owns submit state, validation display, save button state, and error toasts.
+- `CreateVariantDialog.tsx` provides default variant values and calls `createVariant`.
+- `EditVariantDialog.tsx` converts an existing `SystemVariant` into `EditableSystemVariant` and calls `updateVariant`.
+- `VariantForm.tsx` owns title, description, and condition row editing.
+
+The detail page intentionally uses a read-only summary plus an edit dialog instead of inline editing. Inline title/description editing was considered, but the dialog approach is simpler while the feature is still evolving and lets create/edit share the same validation behavior.
+
+## Condition Row UX
+
+`VariantForm` keeps an array of condition rows:
+
+```ts
+interface ConditionRow {
+  id: string
+  key: string
+  value: string
+}
+```
+
+This row state is an important part of the form architecture. Persisting conditions as an object is fine after validation, but object keys are awkward while editing:
+
+- duplicate keys collapse in an object
+- incomplete rows cannot be represented safely
+- partial key edits can move or lose values
+
+The form only serializes rows back to `variant.conditions` when every row has both a key and value and there are no duplicate keys.
+
+Covered behavior:
+
+- title is required
+- at least one complete condition is required
+- add-condition is disabled until the current row is complete
+- duplicate keys show an inline error
+- the remove button is disabled for a single empty row
+- partial key editing remains safe
+
+## Condition Autocomplete
+
+Condition key/value autocomplete is intentionally data-driven. We do not maintain a separate list of allowed keys or values.
+
+`components/dialog/conditionSuggestions.ts` derives suggestions from existing variants:
+
+- key suggestions are the unique keys already used in other variant conditions
+- value suggestions are scoped to the selected key
+- values for unrelated keys are not suggested
+- suggestions are filtered case-insensitively
+- free-text keys and values are still allowed
+
+`ConditionAutocompleteInput.tsx` wraps `@sanity/ui` `Autocomplete`.
+
+Important behavior:
+
+- selecting a suggestion is handled through `onChange`
+- free-text typing is handled through `onQueryChange`
+- `onQueryChange(null)` means the autocomplete query closed and should not clear the row
+- while the input is focused, the wrapper avoids forcing the current row value back into `Autocomplete.value`, because doing so closes the suggestion popover while typing
+
+The autocomplete is a consistency aid, not a schema constraint. Users can still introduce new condition patterns when needed.
+
+## Detail Page
+
+`tool/detail/VariantDetail.tsx` renders the current detail surface.
+
+Covered behavior:
+
+- loading and not-found states
+- back navigation
+- read-only title, description, and condition summary
+- edit dialog
+- placeholder documents table
+- footer with creation status and a detail-specific actions menu
+
+The detail actions menu is separate from the overview row menu. This is intentional because the two menus are expected to diverge as the detail page gains more actions.
+
+## Documents Table Placeholder
+
+`tool/detail/VariantDocumentsTable.tsx` is a placeholder for the future list of documents that belong to a variant.
+
+It currently receives an empty `SanityDocument[]`, but it already follows the release table layout:
+
+- `Version` column placeholder
+- document type column
+- document preview/search column
+- edited date column
+- empty state
+
+Pending work is to connect this to the real source of documents for a variant.
+
+## Footer
+
+`VariantDetailFooter.tsx` mirrors the release detail footer pattern.
+
+Covered behavior:
+
+- created status on the left
+- right-side action slot
+- detail-specific menu button
+- delete action navigates back to the overview after success
+
+The delete action currently does not confirm or check whether the variant has documents. That is pending until variant membership is implemented.
+
+## Test Coverage
+
+Focused unit/integration coverage lives under `packages/sanity/src/core/variants`.
+
+Covered areas include:
+
+- variants store query/listen behavior
+- create/update/delete operations
+- ID generation
+- invalid variant detection
+- overview table behavior and routing
+- create/edit dialog validation and submit behavior
+- condition row validation and partial-edit regressions
+- condition suggestion helpers
+- detail page rendering, edit dialog, footer, and detail delete menu
+
+Focused command:
+
+```sh
+pnpm vitest run --project=sanity packages/sanity/src/core/variants/
+```
+
+E2E coverage lives in `e2e/tests/variants/createVariant.spec.ts`.
+
+Covered areas include:
+
+- happy-path create flow
+- required title and complete condition validation
+- duplicate condition keys
+- partial key editing
+- autocomplete suggestions from existing variants
+- delete flow from the overview
+- cleanup by title prefix
+
+Useful e2e type check:
+
+```sh
+pnpm exec tsgo --project e2e/tsconfig.json --noEmit
+```
+
+The focused browser e2e command is:
+
+```sh
+pnpm test:e2e -- --project=chromium e2e/tests/variants/createVariant.spec.ts
+```
+
+Local browser execution has previously hit `EMFILE: too many open files, watch` before launching the browser. The spec has been authored and typechecked, but should be run in an environment without that watcher limit.
+
+## Pending Work
+
+- Replace direct document mutations with dedicated variant client actions when available.
+- Move from the temporary `variants.*` path to the final system-document path when supported.
+- Wire the detail documents table to the real list of documents that belong to a variant.
+- Decide how document counts affect deleting variants.
+- Add a delete confirmation or disabled state once variants can have documents.
+- Expand the detail-specific actions menu independently from the overview row menu.
+- Reassess whether inline detail editing is needed after the dialog-based edit flow has been used.

--- a/packages/sanity/src/core/variants/README.md
+++ b/packages/sanity/src/core/variants/README.md
@@ -6,13 +6,13 @@ This document describes the current architecture of the Variants Studio tool, wh
 
 The Variants tool is registered by `plugin/index.tsx` under the `sanity/variants` plugin name and is gated by `beta.variants.enabled`. The tool route is `/variants`, with detail pages mounted at `/variants/:variantId`.
 
-Variant definitions are currently stored as regular documents:
+Variant definitions are stored as system documents:
 
 - Document type: `system.variant`
-- Temporary ID path: `variants.*`
+- ID path: `_.variants.*`
 - Type shape: `SystemVariant` in `types.ts`
 
-The `variants.*` path is intentional for now. The final system-document path is expected to change later, so code should keep using `VARIANT_DOCUMENTS_PATH` instead of hardcoding either `variants` or `_.variants`.
+`_.variants.*` is the definitive system path for variant definition document IDs. Code should reference `VARIANT_DOCUMENTS_PATH` rather than hardcoding the literal so the path stays defined in a single place.
 
 ## Data Model
 
@@ -34,13 +34,13 @@ Read state lives in `store/createVariantsStore.ts`.
 - The state is shared through `useVariantsStore` and consumed by `useAllVariants`.
 - The query filters by `VARIANT_DOCUMENT_TYPE` and `VARIANT_DOCUMENTS_PATH`.
 
-Write operations live in `store/createVariantOperationsStore.ts`.
+Write operations live in `store/createVariantOperationsStore.ts` and go through the actions API (see `ACTIONS.md`).
 
-- `createVariant` uses `client.create`.
-- `updateVariant` patches `conditions`, `priority`, and optional `metadata`.
-- `deleteVariant` uses `client.delete`.
+- `createVariant` issues a `sanity.action.variant.definition.create` action.
+- `updateVariant` issues a `sanity.action.variant.definition.edit` action that sets `conditions`, `priority`, and optional `metadata` (unsetting `metadata` when absent).
+- `deleteVariant` issues a `sanity.action.variant.definition.delete` action.
 
-These operations are intentionally temporary. They use direct client document mutations until dedicated variant client actions exist.
+The action payloads are typed locally through the temporary `SanityClientWithVariantsActions` wrapper in `store/variantsClient.ts`. That wrapper exists only until `@sanity/client` exports these variant definition action types.
 
 ## Routing
 
@@ -51,7 +51,7 @@ Route helpers live in `tool/util.ts`:
 - `getVariantId` strips the document path for readable URLs.
 - `decodeVariantIdFromRoute` turns a short URL segment back into the full document ID.
 
-The overview links to short URLs such as `/variants/loyal-customers`, not full IDs such as `/variants/variants.loyal-customers`.
+The overview links to short URLs such as `/variants/loyal-customers`, not full IDs such as `/variants/_.variants.loyal-customers`.
 
 ## Overview Page
 
@@ -194,7 +194,7 @@ Focused command:
 pnpm vitest run --project=sanity packages/sanity/src/core/variants/
 ```
 
-E2E coverage lives in `e2e/tests/variants/createVariant.spec.ts`.
+E2E coverage lives in `e2e/tests/variants/variantTool.spec.ts`.
 
 Covered areas include:
 
@@ -215,15 +215,14 @@ pnpm exec tsgo --project e2e/tsconfig.json --noEmit
 The focused browser e2e command is:
 
 ```sh
-pnpm test:e2e -- --project=chromium e2e/tests/variants/createVariant.spec.ts
+pnpm test:e2e -- --project=chromium e2e/tests/variants/variantTool.spec.ts
 ```
 
 Local browser execution has previously hit `EMFILE: too many open files, watch` before launching the browser. The spec has been authored and typechecked, but should be run in an environment without that watcher limit.
 
 ## Pending Work
 
-- Replace direct document mutations with dedicated variant client actions when available.
-- Move from the temporary `variants.*` path to the final system-document path when supported.
+- Drop the local `SanityClientWithVariantsActions` typing wrapper once `@sanity/client` exports the variant definition action types.
 - Wire the detail documents table to the real list of documents that belong to a variant.
 - Decide how document counts affect deleting variants.
 - Add a delete confirmation or disabled state once variants can have documents.


### PR DESCRIPTION
### Description
Adds variants README for internal documentation and agents to understand it.
Adds e2e tests for the variants tool.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
