### PR TITLE
fix(sanity): restore document form open path from URL

### DIFF
--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -298,7 +298,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
     }
   }, [presenceStore, value._id])
 
-  const [openPath, onSetOpenPath] = useState<Path>(EMPTY_ARRAY)
+  const [openPath, onSetOpenPath] = useState<Path>(initialFocusPath || EMPTY_ARRAY)
   const [fieldGroupState, onSetFieldGroupState] = useState<StateTree<string>>()
   const [collapsedPaths, onSetCollapsedPath] = useState<StateTree<boolean>>()
   const [collapsedFieldSets, onSetCollapsedFieldSets] = useState<StateTree<boolean>>()


### PR DESCRIPTION
### Description

This small change partially fixes SAPP-3679, which reports two issues affecting Portable Text annotation popovers:

1. When opening a PTE annotation, the browser URL is updated to reflect this. However, the document form's initial open path intermittently fails to respect popover state persisted to the URL. This manifests as a couple of strange user experiences:
a. When navigating to a URL that reflects an open PTE annotation popover, the document editor scrolls to the parent PTE, but does not always restore the open state of the popover. e.g. `http://localhost:3333/test/structure/input-standard;portable-text;pt_allTheBellsAndWhistles;48b5b4fb-72ec-449d-9c79-513298a433a9%2Cpath%3Dbody%255B_key%253D%253D%25225ce0d5a67df1%2522%255D.markDefs%255B_key%253D%253D%2522683ca5f4940a%2522%255D`.
b. When navigating to a URL that reflects an open PTE annotation popover inside an object, inside an array, the object editor itself intermittently fails to open. e.g. `http://localhost:3333/test/structure/input-standard;arraysTest;12a22c42-0e74-4ce5-8eed-3793f34e1d9a%2Cpath%3DdeeplyNestedBody%255B_key%253D%253D%2522c444afe03a63%2522%255D.text%255B_key%253D%253D%2522968f3d7b3600%2522%255D.markDefs%255B_key%253D%253D%252226857282d3dd%2522%255D`.
2. There is unexpected auto-scrolling behaviour when navigating to a URL that reflects a PTE annotation popover.

This PR addresses issue 1: the open path is now restored from the URL. We'll investigate the auto-focus issues separately.

### What to review

Using the initial focus path to populate the initial open path.

### Testing

Tested various deep-links in Test Studio, existing tests pass.

### Notes for release

Fixes intermittent issue preventing navigating by URL to Portable Text Editor deep-links.