### PR TITLE
feat(core): update variants operation store to use system actions

### DIFF
--- a/dev/studio-e2e-testing/sanity.config.ts
+++ b/dev/studio-e2e-testing/sanity.config.ts
@@ -143,6 +143,11 @@ const defaultConfig = defineConfig({
   mediaLibrary: {
     enabled: true,
   },
+  beta: {
+    variants: {
+      enabled: true,
+    },
+  },
 })
 
 export default defineConfig([

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -457,6 +457,11 @@ export default defineConfig([
     mediaLibrary: {
       enabled: true,
     },
+    beta: {
+      variants: {
+        enabled: true,
+      },
+    },
   },
   {
     name: 'growth',

--- a/e2e/tests/variants/variantTool.spec.ts
+++ b/e2e/tests/variants/variantTool.spec.ts
@@ -1,0 +1,408 @@
+import {expect, type Page, type TestInfo} from '@playwright/test'
+import {type SanityClient} from '@sanity/client'
+
+import {test} from '../../studio-test'
+
+const VARIANT_DOCUMENTS_PATH = 'variants'
+const VARIANT_DOCUMENT_TYPE = 'system.variant'
+
+const E2E_VARIANT_TITLE_RUN_ID = `${Date.now().toString(36)}${Math.random()
+  .toString(36)
+  .slice(2, 10)}`
+
+interface VariantDocument {
+  _id: `${typeof VARIANT_DOCUMENTS_PATH}.${string}`
+  _type: typeof VARIANT_DOCUMENT_TYPE
+  conditions: Record<string, string>
+  priority: number
+  metadata?: {
+    title?: string
+    [key: string]: unknown
+  }
+}
+
+function normalizeTitlePart(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+function createVariantTitlePrefix(testInfo: TestInfo = test.info()): string {
+  const projectName = normalizeTitlePart(testInfo.project.name)
+  const testName = normalizeTitlePart(testInfo.title)
+
+  return `E2E Variants ${E2E_VARIANT_TITLE_RUN_ID} ${projectName} worker ${testInfo.parallelIndex} retry ${testInfo.retry} ${testName}`
+}
+
+async function deleteVariantDocuments(
+  sanityClient: SanityClient,
+  titlePrefix: string,
+): Promise<void> {
+  await sanityClient.delete({
+    query: `*[
+      _type == $variantDocumentType &&
+      _id in path("${VARIANT_DOCUMENTS_PATH}.*") &&
+      metadata.title match $titleGlob
+    ]`,
+    params: {
+      titleGlob: `${titlePrefix}*`,
+      variantDocumentType: VARIANT_DOCUMENT_TYPE,
+    },
+  })
+}
+
+function createRunId(label: string): string {
+  const {parallelIndex, project, retry} = test.info()
+  const projectName = project.name.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+
+  return `${label}-${projectName}-${parallelIndex}-${retry}-${E2E_VARIANT_TITLE_RUN_ID}`
+}
+
+function getVariantShortId(variantDocumentId: string): string {
+  return variantDocumentId.startsWith(`${VARIANT_DOCUMENTS_PATH}.`)
+    ? variantDocumentId.slice(`${VARIANT_DOCUMENTS_PATH}.`.length)
+    : variantDocumentId
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+async function openVariantsTool(page: Page): Promise<void> {
+  await page.goto('/variants')
+  await expect(page.getByRole('heading', {name: 'Variants'})).toBeVisible()
+}
+
+async function openCreateVariantDialog(page: Page) {
+  await page.getByRole('button', {name: 'Create variant'}).first().click()
+
+  const dialog = page.getByRole('dialog', {name: 'Create variant'})
+  await expect(dialog).toBeVisible()
+
+  return dialog
+}
+
+function getConditionKeyInputs(pageOrDialog: Page | ReturnType<Page['getByRole']>) {
+  return pageOrDialog.getByTestId('variant-form-condition-key')
+}
+
+function getConditionValueInputs(pageOrDialog: Page | ReturnType<Page['getByRole']>) {
+  return pageOrDialog.getByTestId('variant-form-condition-value')
+}
+
+async function fillConditionRow(
+  dialog: ReturnType<Page['getByRole']>,
+  index: number,
+  key: string,
+  value: string,
+): Promise<void> {
+  await getConditionKeyInputs(dialog).nth(index).fill(key)
+  await getConditionValueInputs(dialog).nth(index).fill(value)
+}
+
+async function findVariantDocumentByTitle(
+  sanityClient: SanityClient,
+  title: string,
+): Promise<VariantDocument | null> {
+  return sanityClient.fetch<VariantDocument | null>(
+    `*[
+      _type == "${VARIANT_DOCUMENT_TYPE}" &&
+      _id in path("${VARIANT_DOCUMENTS_PATH}.*") &&
+      metadata.title == $title
+    ][0]{
+      _id,
+      _type,
+      conditions,
+      priority,
+      metadata,
+    }`,
+    {title},
+  )
+}
+
+async function waitForVariantDocument(
+  sanityClient: SanityClient,
+  title: string,
+): Promise<VariantDocument> {
+  let document: VariantDocument | null = null
+
+  await expect
+    .poll(
+      async () => {
+        document = await findVariantDocumentByTitle(sanityClient, title)
+
+        return document?._id ?? null
+      },
+      {message: `variant document "${title}" should be persisted`},
+    )
+    .not.toBeNull()
+
+  if (!document) {
+    throw new Error(`Variant document "${title}" was not found`)
+  }
+
+  return document
+}
+
+async function submitCreateVariantDialog(
+  page: Page,
+  sanityClient: SanityClient,
+  title: string,
+): Promise<VariantDocument> {
+  await expect(page.getByTestId('submit-variant-button')).toBeEnabled()
+  await page.getByTestId('submit-variant-button').click()
+
+  await expect(page).toHaveURL(/\/variants\/[^/?#]+$/)
+  expect(new URL(page.url()).pathname).not.toContain('_.variants')
+
+  const document = await waitForVariantDocument(sanityClient, title)
+
+  const shortVariantId = getVariantShortId(document._id)
+  expect(new URL(page.url()).pathname).toMatch(
+    new RegExp(`/variants/${escapeRegExp(shortVariantId)}$`),
+  )
+
+  return document
+}
+
+function getVariantRow(page: Page, title: string) {
+  return page.getByTestId('table-row').filter({hasText: title})
+}
+
+test.describe('Variants create flow', () => {
+  test.afterEach(async ({sanityClient}, testInfo) => {
+    await deleteVariantDocuments(sanityClient, createVariantTitlePrefix(testInfo))
+  })
+
+  test('creates a variant and persists conditions', async ({page, sanityClient}) => {
+    const runId = createRunId('happy')
+    const title = `${createVariantTitlePrefix()} Loyal Customers ${runId}`
+    const value = `loyal-${runId}`
+
+    await openVariantsTool(page)
+    const dialog = await openCreateVariantDialog(page)
+
+    await dialog.getByTestId('variant-form-title').fill(title)
+    await fillConditionRow(dialog, 0, 'audience', value)
+
+    const document = await submitCreateVariantDialog(page, sanityClient, title)
+
+    expect(document._id).toMatch(new RegExp(`^${escapeRegExp(VARIANT_DOCUMENTS_PATH)}\\.`))
+    expect(document._type).toBe(VARIANT_DOCUMENT_TYPE)
+    expect(document.metadata?.title).toBe(title)
+    expect(document.conditions).toEqual({audience: value})
+  })
+
+  test('validates title and complete condition rows', async ({page}) => {
+    await openVariantsTool(page)
+    const dialog = await openCreateVariantDialog(page)
+    const submitButton = dialog.getByTestId('submit-variant-button')
+    const addConditionButton = dialog.getByRole('button', {name: 'Add condition'})
+    const titleInput = dialog.getByTestId('variant-form-title')
+
+    await expect(submitButton).toBeDisabled()
+    await expect(addConditionButton).toBeDisabled()
+
+    await titleInput.focus()
+    await titleInput.blur()
+    await expect(dialog.getByTestId('variant-form-title-error')).toHaveText('Title is required')
+
+    await titleInput.fill(`${createVariantTitlePrefix()} Validation ${createRunId('validation')}`)
+    await expect(dialog.getByTestId('variant-form-title-error')).toBeHidden()
+
+    await getConditionKeyInputs(dialog).first().fill('audience')
+    await expect(submitButton).toBeDisabled()
+    await expect(addConditionButton).toBeDisabled()
+
+    await getConditionValueInputs(dialog).first().fill('loyal')
+    await expect(submitButton).toBeEnabled()
+    await expect(addConditionButton).toBeEnabled()
+
+    await addConditionButton.click()
+    await expect(getConditionKeyInputs(dialog)).toHaveCount(2)
+    await expect(addConditionButton).toBeDisabled()
+    await expect(submitButton).toBeDisabled()
+  })
+
+  test('keeps duplicate condition keys invalid until the edited key is unique', async ({
+    page,
+    sanityClient,
+  }) => {
+    const runId = createRunId('duplicate')
+    const title = `${createVariantTitlePrefix()} Duplicate Keys ${runId}`
+
+    await openVariantsTool(page)
+    const dialog = await openCreateVariantDialog(page)
+
+    await dialog.getByTestId('variant-form-title').fill(title)
+    await fillConditionRow(dialog, 0, 'audience', 'us')
+    await dialog.getByRole('button', {name: 'Add condition'}).click()
+
+    const secondKeyInput = getConditionKeyInputs(dialog).nth(1)
+
+    await secondKeyInput.fill('audience')
+    await getConditionValueInputs(dialog).nth(1).fill('fr')
+    await expect(dialog.getByTestId('variant-form-condition-key-error')).toHaveText(
+      'Condition keys must be unique',
+    )
+    await expect(dialog.getByTestId('submit-variant-button')).toBeDisabled()
+
+    await secondKeyInput.fill('audience2')
+    await expect(secondKeyInput).toHaveValue('audience2')
+    await expect(dialog.getByTestId('variant-form-condition-key-error')).toBeHidden()
+
+    const document = await submitCreateVariantDialog(page, sanityClient, title)
+
+    expect(document.conditions).toEqual({
+      audience: 'us',
+      audience2: 'fr',
+    })
+  })
+
+  test('preserves partial condition key editing from new to newton', async ({
+    page,
+    sanityClient,
+  }) => {
+    const runId = createRunId('partial')
+    const title = `${createVariantTitlePrefix()} Partial Key ${runId}`
+
+    await openVariantsTool(page)
+    const dialog = await openCreateVariantDialog(page)
+
+    await dialog.getByTestId('variant-form-title').fill(title)
+    await fillConditionRow(dialog, 0, 'new', 'us')
+    await dialog.getByRole('button', {name: 'Add condition'}).click()
+
+    const secondKeyInput = getConditionKeyInputs(dialog).nth(1)
+
+    await secondKeyInput.type('new')
+    await expect(secondKeyInput).toHaveValue('new')
+    await expect(dialog.getByTestId('variant-form-condition-key-error')).toHaveText(
+      'Condition keys must be unique',
+    )
+
+    await secondKeyInput.type('ton')
+    await expect(secondKeyInput).toHaveValue('newton')
+    await expect(dialog.getByTestId('variant-form-condition-key-error')).toBeHidden()
+
+    await getConditionValueInputs(dialog).nth(1).fill('gb')
+    await expect(dialog.getByTestId('submit-variant-button')).toBeEnabled()
+
+    const document = await submitCreateVariantDialog(page, sanityClient, title)
+
+    expect(document.conditions).toEqual({
+      new: 'us',
+      newton: 'gb',
+    })
+  })
+
+  test('suggests condition keys and values from existing variants', async ({
+    page,
+    sanityClient,
+  }) => {
+    const runId = createRunId('autocomplete')
+    const seededAudienceTitle = `${createVariantTitlePrefix()} Autocomplete Audience Seed ${runId}`
+    const seededLanguageTitle = `${createVariantTitlePrefix()} Autocomplete Language Seed ${runId}`
+    const title = `${createVariantTitlePrefix()} Autocomplete Created ${runId}`
+    const audienceValue = `returning-${runId}`
+    const languageValue = `en-${runId}`
+
+    const seededAudienceVariant: VariantDocument = {
+      _id: `${VARIANT_DOCUMENTS_PATH}.${runId}-audience` as const,
+      _type: VARIANT_DOCUMENT_TYPE,
+      conditions: {audience: audienceValue},
+      metadata: {title: seededAudienceTitle},
+      priority: 0,
+    }
+    const seededLanguageVariant: VariantDocument = {
+      _id: `${VARIANT_DOCUMENTS_PATH}.${runId}-language` as const,
+      _type: VARIANT_DOCUMENT_TYPE,
+      conditions: {language: languageValue},
+      metadata: {title: seededLanguageTitle},
+      priority: 0,
+    }
+
+    await sanityClient.createOrReplace(seededAudienceVariant)
+    await sanityClient.createOrReplace(seededLanguageVariant)
+
+    await openVariantsTool(page)
+    await expect(getVariantRow(page, seededAudienceTitle)).toBeVisible()
+    await expect(getVariantRow(page, seededLanguageTitle)).toBeVisible()
+
+    const dialog = await openCreateVariantDialog(page)
+
+    await dialog.getByTestId('variant-form-title').fill(title)
+
+    await getConditionKeyInputs(dialog).first().fill('aud')
+    await page.getByRole('option', {name: 'audience', exact: true}).click()
+    await expect(getConditionKeyInputs(dialog).first()).toHaveValue('audience')
+
+    await getConditionValueInputs(dialog).first().fill('ret')
+    await expect(page.getByRole('option', {name: audienceValue, exact: true})).toBeVisible()
+    await expect(page.getByRole('option', {name: languageValue, exact: true})).toBeHidden()
+    await page.getByRole('option', {name: audienceValue, exact: true}).click()
+
+    const document = await submitCreateVariantDialog(page, sanityClient, title)
+
+    expect(document.conditions).toEqual({audience: audienceValue})
+  })
+
+  test('deletes a seeded variant from the overview', async ({page, sanityClient}) => {
+    const runId = createRunId('delete')
+    const variantId = `${VARIANT_DOCUMENTS_PATH}.${runId}` as const
+    const title = `${createVariantTitlePrefix()} Delete Variant ${runId}`
+    const value = `delete-${runId}`
+
+    const seededVariant: VariantDocument = {
+      _id: variantId,
+      _type: VARIANT_DOCUMENT_TYPE,
+      conditions: {audience: value},
+      metadata: {title},
+      priority: 0,
+    }
+
+    await sanityClient.createOrReplace(seededVariant)
+
+    await openVariantsTool(page)
+
+    const row = getVariantRow(page, title)
+    await expect(row).toBeVisible()
+
+    await row.getByRole('button').last().click()
+    await page.getByRole('menuitem', {name: 'Delete variant'}).click()
+    await expect(page.getByRole('menuitem', {name: 'Delete variant'})).toBeHidden()
+
+    await expect(row).toBeHidden()
+    await expect.poll(async () => sanityClient.getDocument(variantId)).toBeUndefined()
+  })
+
+  test('deletes a seeded variant from the detail page', async ({page, sanityClient}) => {
+    const runId = createRunId('delete-detail')
+    const variantId = `${VARIANT_DOCUMENTS_PATH}.${runId}` as const
+    const shortVariantId = getVariantShortId(variantId)
+    const title = `${createVariantTitlePrefix()} Delete Detail Variant ${runId}`
+    const value = `delete-detail-${runId}`
+
+    const seededVariant: VariantDocument = {
+      _id: variantId,
+      _type: VARIANT_DOCUMENT_TYPE,
+      conditions: {audience: value},
+      metadata: {title},
+      priority: 0,
+    }
+
+    await sanityClient.createOrReplace(seededVariant)
+
+    await page.goto(`/variants/${shortVariantId}`)
+    await expect(page.getByRole('heading', {name: title})).toBeVisible()
+
+    await page.locator(`#variant-detail-actions-${shortVariantId}`).click()
+    await page.getByRole('menuitem', {name: 'Delete variant'}).click()
+    await expect(page.getByRole('menuitem', {name: 'Delete variant'})).toBeHidden()
+
+    await expect(page.getByRole('heading', {name: 'Variants'})).toBeVisible()
+    await expect(getVariantRow(page, title)).toBeHidden()
+    await expect.poll(async () => sanityClient.getDocument(variantId)).toBeUndefined()
+  })
+})

--- a/e2e/tests/variants/variantTool.spec.ts
+++ b/e2e/tests/variants/variantTool.spec.ts
@@ -3,7 +3,7 @@ import {type SanityClient} from '@sanity/client'
 
 import {test} from '../../studio-test'
 
-const VARIANT_DOCUMENTS_PATH = 'variants'
+const VARIANT_DOCUMENTS_PATH = '_.variants'
 const VARIANT_DOCUMENT_TYPE = 'system.variant'
 
 const E2E_VARIANT_TITLE_RUN_ID = `${Date.now().toString(36)}${Math.random()
@@ -13,6 +13,7 @@ const E2E_VARIANT_TITLE_RUN_ID = `${Date.now().toString(36)}${Math.random()
 interface VariantDocument {
   _id: `${typeof VARIANT_DOCUMENTS_PATH}.${string}`
   _type: typeof VARIANT_DOCUMENT_TYPE
+  name?: string
   conditions: Record<string, string>
   priority: number
   metadata?: {
@@ -35,21 +36,51 @@ function createVariantTitlePrefix(testInfo: TestInfo = test.info()): string {
   return `E2E Variants ${E2E_VARIANT_TITLE_RUN_ID} ${projectName} worker ${testInfo.parallelIndex} retry ${testInfo.retry} ${testName}`
 }
 
+async function createVariantDefinition(
+  sanityClient: SanityClient,
+  options: {
+    variantId: string
+    conditions?: Record<string, string>
+    priority?: number
+    metadata?: VariantDocument['metadata']
+  },
+): Promise<void> {
+  // Variant definition actions are available at runtime, but their payloads are
+  // not yet typed on SanityClient.action(). The shape below matches the API
+  // contract in packages/sanity/src/core/variants/ACTIONS.md; remove `as never`
+  // once @sanity/client exports these action types.
+  await sanityClient.action({
+    actionType: 'sanity.action.variant.definition.create',
+    variantId: options.variantId,
+    conditions: options.conditions ?? {},
+    priority: options.priority ?? 0,
+    metadata: options.metadata,
+  } as never)
+}
+
 async function deleteVariantDocuments(
   sanityClient: SanityClient,
   titlePrefix: string,
 ): Promise<void> {
-  await sanityClient.delete({
-    query: `*[
+  const documents = await sanityClient.fetch<Array<{_id: string}>>(
+    `*[
       _type == $variantDocumentType &&
       _id in path("${VARIANT_DOCUMENTS_PATH}.*") &&
       metadata.title match $titleGlob
-    ]`,
-    params: {
+    ]{_id}`,
+    {
       titleGlob: `${titlePrefix}*`,
       variantDocumentType: VARIANT_DOCUMENT_TYPE,
     },
-  })
+  )
+
+  for (const document of documents) {
+    // Same untyped-action workaround as createVariantDefinition above.
+    await sanityClient.action({
+      actionType: 'sanity.action.variant.definition.delete',
+      variantId: getVariantShortId(document._id),
+    } as never)
+  }
 }
 
 function createRunId(label: string): string {
@@ -113,6 +144,7 @@ async function findVariantDocumentByTitle(
     ][0]{
       _id,
       _type,
+      name,
       conditions,
       priority,
       metadata,
@@ -154,7 +186,7 @@ async function submitCreateVariantDialog(
   await page.getByTestId('submit-variant-button').click()
 
   await expect(page).toHaveURL(/\/variants\/[^/?#]+$/)
-  expect(new URL(page.url()).pathname).not.toContain('_.variants')
+  expect(new URL(page.url()).pathname).not.toContain(`${VARIANT_DOCUMENTS_PATH}.`)
 
   const document = await waitForVariantDocument(sanityClient, title)
 
@@ -308,23 +340,16 @@ test.describe('Variants create flow', () => {
     const audienceValue = `returning-${runId}`
     const languageValue = `en-${runId}`
 
-    const seededAudienceVariant: VariantDocument = {
-      _id: `${VARIANT_DOCUMENTS_PATH}.${runId}-audience` as const,
-      _type: VARIANT_DOCUMENT_TYPE,
+    await createVariantDefinition(sanityClient, {
+      variantId: `${runId}-audience`,
       conditions: {audience: audienceValue},
       metadata: {title: seededAudienceTitle},
-      priority: 0,
-    }
-    const seededLanguageVariant: VariantDocument = {
-      _id: `${VARIANT_DOCUMENTS_PATH}.${runId}-language` as const,
-      _type: VARIANT_DOCUMENT_TYPE,
+    })
+    await createVariantDefinition(sanityClient, {
+      variantId: `${runId}-language`,
       conditions: {language: languageValue},
       metadata: {title: seededLanguageTitle},
-      priority: 0,
-    }
-
-    await sanityClient.createOrReplace(seededAudienceVariant)
-    await sanityClient.createOrReplace(seededLanguageVariant)
+    })
 
     await openVariantsTool(page)
     await expect(getVariantRow(page, seededAudienceTitle)).toBeVisible()
@@ -350,19 +375,16 @@ test.describe('Variants create flow', () => {
 
   test('deletes a seeded variant from the overview', async ({page, sanityClient}) => {
     const runId = createRunId('delete')
-    const variantId = `${VARIANT_DOCUMENTS_PATH}.${runId}` as const
+    const variantId = `${runId}` as const
+    const documentId = `${VARIANT_DOCUMENTS_PATH}.${variantId}` as const
     const title = `${createVariantTitlePrefix()} Delete Variant ${runId}`
     const value = `delete-${runId}`
 
-    const seededVariant: VariantDocument = {
-      _id: variantId,
-      _type: VARIANT_DOCUMENT_TYPE,
+    await createVariantDefinition(sanityClient, {
+      variantId,
       conditions: {audience: value},
       metadata: {title},
-      priority: 0,
-    }
-
-    await sanityClient.createOrReplace(seededVariant)
+    })
 
     await openVariantsTool(page)
 
@@ -374,25 +396,22 @@ test.describe('Variants create flow', () => {
     await expect(page.getByRole('menuitem', {name: 'Delete variant'})).toBeHidden()
 
     await expect(row).toBeHidden()
-    await expect.poll(async () => sanityClient.getDocument(variantId)).toBeUndefined()
+    await expect.poll(async () => sanityClient.getDocument(documentId)).toBeUndefined()
   })
 
   test('deletes a seeded variant from the detail page', async ({page, sanityClient}) => {
     const runId = createRunId('delete-detail')
-    const variantId = `${VARIANT_DOCUMENTS_PATH}.${runId}` as const
-    const shortVariantId = getVariantShortId(variantId)
+    const variantId = `${runId}` as const
+    const documentId = `${VARIANT_DOCUMENTS_PATH}.${variantId}` as const
+    const shortVariantId = getVariantShortId(documentId)
     const title = `${createVariantTitlePrefix()} Delete Detail Variant ${runId}`
     const value = `delete-detail-${runId}`
 
-    const seededVariant: VariantDocument = {
-      _id: variantId,
-      _type: VARIANT_DOCUMENT_TYPE,
+    await createVariantDefinition(sanityClient, {
+      variantId,
       conditions: {audience: value},
       metadata: {title},
-      priority: 0,
-    }
-
-    await sanityClient.createOrReplace(seededVariant)
+    })
 
     await page.goto(`/variants/${shortVariantId}`)
     await expect(page.getByRole('heading', {name: title})).toBeVisible()
@@ -403,6 +422,6 @@ test.describe('Variants create flow', () => {
 
     await expect(page.getByRole('heading', {name: 'Variants'})).toBeVisible()
     await expect(getVariantRow(page, title)).toBeHidden()
-    await expect.poll(async () => sanityClient.getDocument(variantId)).toBeUndefined()
+    await expect.poll(async () => sanityClient.getDocument(documentId)).toBeUndefined()
   })
 })

--- a/e2e/tests/variants/variantTool.spec.ts
+++ b/e2e/tests/variants/variantTool.spec.ts
@@ -233,28 +233,35 @@ test.describe('Variants create flow', () => {
     const addConditionButton = dialog.getByRole('button', {name: 'Add condition'})
     const titleInput = dialog.getByTestId('variant-form-title')
 
-    await expect(submitButton).toBeDisabled()
+    await expect(submitButton).toBeEnabled()
     await expect(addConditionButton).toBeDisabled()
 
-    await titleInput.focus()
-    await titleInput.blur()
+    await submitButton.click()
     await expect(dialog.getByTestId('variant-form-title-error')).toHaveText('Title is required')
+    await expect(dialog.getByTestId('variant-form-condition-value-error')).toHaveText(
+      'Condition value is required',
+    )
 
     await titleInput.fill(`${createVariantTitlePrefix()} Validation ${createRunId('validation')}`)
     await expect(dialog.getByTestId('variant-form-title-error')).toBeHidden()
 
     await getConditionKeyInputs(dialog).first().fill('audience')
-    await expect(submitButton).toBeDisabled()
+    await expect(submitButton).toBeEnabled()
     await expect(addConditionButton).toBeDisabled()
+    await expect(dialog.getByTestId('variant-form-condition-value-error')).toBeHidden()
+
+    await submitButton.click()
+    await expect(dialog.getByTestId('variant-form-condition-value-error')).toHaveText(
+      'Condition value is required',
+    )
 
     await getConditionValueInputs(dialog).first().fill('loyal')
-    await expect(submitButton).toBeEnabled()
     await expect(addConditionButton).toBeEnabled()
 
     await addConditionButton.click()
     await expect(getConditionKeyInputs(dialog)).toHaveCount(2)
     await expect(addConditionButton).toBeDisabled()
-    await expect(submitButton).toBeDisabled()
+    await expect(submitButton).toBeEnabled()
   })
 
   test('keeps duplicate condition keys invalid until the edited key is unique', async ({
@@ -278,7 +285,9 @@ test.describe('Variants create flow', () => {
     await expect(dialog.getByTestId('variant-form-condition-key-error')).toHaveText(
       'Condition keys must be unique',
     )
-    await expect(dialog.getByTestId('submit-variant-button')).toBeDisabled()
+    await expect(dialog.getByTestId('submit-variant-button')).toBeEnabled()
+
+    await dialog.getByTestId('submit-variant-button').click()
 
     await secondKeyInput.fill('audience2')
     await expect(secondKeyInput).toHaveValue('audience2')

--- a/packages/sanity/src/core/variants/ACTIONS.md
+++ b/packages/sanity/src/core/variants/ACTIONS.md
@@ -1,0 +1,152 @@
+# Variant Definition Actions
+
+Variant definition writes should use the actions API instead of direct document mutations. The actions target the persisted `system.variant` definition documents under `_.variants.*`.
+
+## Variant Definition Document
+
+The actions operate on variant definition documents with this persisted shape:
+
+```ts
+interface VariantDefinitionDocument {
+  _id: `_.variants.${string}`
+  _type: 'system.variant'
+  name: string
+  conditions: Record<string, string>
+  priority: number
+  metadata?: Record<string, unknown>
+}
+```
+
+`variantId` is the generated short ID suffix, not the full document ID. For example, a `variantId` such as `Ab12cd34` maps to the stored document ID `_.variants.Ab12cd34`.
+
+## `sanity.action.variant.definition.create`
+
+Creates a new variant definition document.
+
+Required fields:
+
+- `actionType: 'sanity.action.variant.definition.create'`
+- `variantId`: the short variant name used to create `_.variants.{variantId}`
+
+Optional fields:
+
+- `conditions`: exact-match condition map. Empty conditions are accepted, but such a definition is inert for matching.
+- `priority`: numeric priority. Defaults to `0` when omitted.
+- `metadata`: free-form metadata for Studio UI concerns such as `title` and `description`.
+
+Example:
+
+```ts
+await client.action({
+  actionType: 'sanity.action.variant.definition.create',
+  variantId: 'Ab12cd34',
+  conditions: {audience: 'loyal'},
+  priority: 0,
+  metadata: {title: 'Loyal customers'},
+})
+```
+
+Behavior:
+
+- Creates `_.variants.{variantId}` with `_type: 'system.variant'` and `name: variantId`.
+- Fails when a variant definition with the same ID already exists.
+- Validates the variant ID as a single path segment.
+- Validates condition keys and values.
+- Applies variant definition feature and count-limit checks on the API side.
+
+Condition validation:
+
+- Keys must be lowercase, start with a letter, and match `[a-z][a-z0-9_-]{0,63}`.
+- Keys with reserved prefixes `_` or `$` are rejected.
+- Values must be non-empty valid UTF-8 strings.
+
+## `sanity.action.variant.definition.edit`
+
+Edits an existing variant definition document.
+
+Required fields:
+
+- `actionType: 'sanity.action.variant.definition.edit'`
+- `variantId`: the short variant name for `_.variants.{variantId}`
+- `patch`: a patch without an `_id`; the action applies it to the matching variant definition document
+
+Optional fields:
+
+- `ifRevisionId`: optimistic concurrency guard. The action fails if the current document revision does not match.
+
+Example:
+
+```ts
+await client.action({
+  actionType: 'sanity.action.variant.definition.edit',
+  variantId: 'Ab12cd34',
+  patch: {
+    set: {
+      'conditions': {audience: 'loyal', locale: 'en-US'},
+      'priority': 10,
+      'metadata.title': 'Loyal customers in the US',
+    },
+  },
+})
+```
+
+Behavior:
+
+- Fails if the variant definition does not exist.
+- Fails when `ifRevisionId` is provided and does not match the current document revision.
+- Allows patches only under mutable paths:
+  - `conditions` or `conditions.*`
+  - `priority`
+  - `metadata` or `metadata.*`
+- Rejects patches to immutable fields such as `_id`, `_type`, `name`, and system timestamps.
+- Validates the resulting variant definition document after applying the patch.
+
+Useful patch patterns:
+
+```ts
+await client.action({
+  actionType: 'sanity.action.variant.definition.edit',
+  variantId: 'Ab12cd34',
+  patch: {
+    set: {conditions: {audience: 'loyal'}},
+  },
+})
+
+await client.action({
+  actionType: 'sanity.action.variant.definition.edit',
+  variantId: 'Ab12cd34',
+  patch: {
+    unset: ['metadata'],
+  },
+})
+```
+
+## `sanity.action.variant.definition.delete`
+
+Deletes an existing variant definition document.
+
+Required fields:
+
+- `actionType: 'sanity.action.variant.definition.delete'`
+- `variantId`: the short variant name for `_.variants.{variantId}`
+
+Optional fields:
+
+- `ifRevisionId`: optimistic concurrency guard. The action fails if the current document revision does not match.
+
+Example:
+
+```ts
+await client.action({
+  actionType: 'sanity.action.variant.definition.delete',
+  variantId: 'Ab12cd34',
+})
+```
+
+Behavior:
+
+- Fails if the variant definition does not exist.
+- Fails when `ifRevisionId` is provided and does not match the current document revision.
+- Submits a delete for `_.variants.{variantId}`.
+- Does not cascade delete variant documents.
+- Strong references to the variant definition block deletion through the mutation engine, and the action surfaces that integrity error.

--- a/packages/sanity/src/core/variants/README.md
+++ b/packages/sanity/src/core/variants/README.md
@@ -6,13 +6,13 @@ This document describes the current architecture of the Variants Studio tool, wh
 
 The Variants tool is registered by `plugin/index.tsx` under the `sanity/variants` plugin name and is gated by `beta.variants.enabled`. The tool route is `/variants`, with detail pages mounted at `/variants/:variantId`.
 
-Variant definitions are currently stored as regular documents:
+Variant definitions are stored as system documents:
 
 - Document type: `system.variant`
-- Temporary ID path: `variants.*`
+- System document path: `_.variants.*`
 - Type shape: `SystemVariant` in `types.ts`
 
-The `variants.*` path is intentional for now. The final system-document path is expected to change later, so code should keep using `VARIANT_DOCUMENTS_PATH` instead of hardcoding either `variants` or `_.variants`.
+Code should keep using `VARIANT_DOCUMENTS_PATH` instead of hardcoding `_.variants`.
 
 ## Data Model
 
@@ -36,11 +36,11 @@ Read state lives in `store/createVariantsStore.ts`.
 
 Write operations live in `store/createVariantOperationsStore.ts`.
 
-- `createVariant` uses `client.create`.
-- `updateVariant` patches `conditions`, `priority`, and optional `metadata`.
-- `deleteVariant` uses `client.delete`.
+- `createVariant` uses `sanity.action.variant.definition.create`.
+- `updateVariant` uses `sanity.action.variant.definition.edit`.
+- `deleteVariant` uses `sanity.action.variant.definition.delete`.
 
-These operations are intentionally temporary. They use direct client document mutations until dedicated variant client actions exist.
+The dedicated variant definition action contracts are documented in [ACTIONS.md](./ACTIONS.md).
 
 ## Routing
 
@@ -51,7 +51,7 @@ Route helpers live in `tool/util.ts`:
 - `getVariantId` strips the document path for readable URLs.
 - `decodeVariantIdFromRoute` turns a short URL segment back into the full document ID.
 
-The overview links to short URLs such as `/variants/loyal-customers`, not full IDs such as `/variants/variants.loyal-customers`.
+The overview links to short URLs such as `/variants/Ab12cd34`, not full IDs such as `/variants/_.variants.Ab12cd34`.
 
 ## Overview Page
 
@@ -222,8 +222,6 @@ Local browser execution has previously hit `EMFILE: too many open files, watch` 
 
 ## Pending Work
 
-- Replace direct document mutations with dedicated variant client actions when available.
-- Move from the temporary `variants.*` path to the final system-document path when supported.
 - Wire the detail documents table to the real list of documents that belong to a variant.
 - Decide how document counts affect deleting variants.
 - Add a delete confirmation or disabled state once variants can have documents.

--- a/packages/sanity/src/core/variants/README.md
+++ b/packages/sanity/src/core/variants/README.md
@@ -1,0 +1,231 @@
+# Variants Tool Architecture
+
+This document describes the current architecture of the Variants Studio tool, what functionality is already covered, and the main work that is still pending.
+
+## Scope
+
+The Variants tool is registered by `plugin/index.tsx` under the `sanity/variants` plugin name and is gated by `beta.variants.enabled`. The tool route is `/variants`, with detail pages mounted at `/variants/:variantId`.
+
+Variant definitions are currently stored as regular documents:
+
+- Document type: `system.variant`
+- Temporary ID path: `variants.*`
+- Type shape: `SystemVariant` in `types.ts`
+
+The `variants.*` path is intentional for now. The final system-document path is expected to change later, so code should keep using `VARIANT_DOCUMENTS_PATH` instead of hardcoding either `variants` or `_.variants`.
+
+## Data Model
+
+A variant document currently contains:
+
+- `_id` and `_type`
+- `conditions: Record<string, string>`
+- `priority`, defaulting to `0`
+- optional `metadata`, currently used for `title` and Portable Text `description`
+
+`conditions` is persisted as an object because that is the shape expected by the document. The UI does not edit that object directly. It keeps condition rows locally while the user is typing so duplicate keys, incomplete rows, and partial key edits do not collapse or lose values.
+
+## Store And Operations
+
+Read state lives in `store/createVariantsStore.ts`.
+
+- The store is lazily initialized on first subscription.
+- It uses `listenQuery` to fetch and keep all variants fresh.
+- The state is shared through `useVariantsStore` and consumed by `useAllVariants`.
+- The query filters by `VARIANT_DOCUMENT_TYPE` and `VARIANT_DOCUMENTS_PATH`.
+
+Write operations live in `store/createVariantOperationsStore.ts`.
+
+- `createVariant` uses `client.create`.
+- `updateVariant` patches `conditions`, `priority`, and optional `metadata`.
+- `deleteVariant` uses `client.delete`.
+
+These operations are intentionally temporary. They use direct client document mutations until dedicated variant client actions exist.
+
+## Routing
+
+`tool/VariantsTool.tsx` switches between overview and detail based on `router.state.variantId`.
+
+Route helpers live in `tool/util.ts`:
+
+- `getVariantId` strips the document path for readable URLs.
+- `decodeVariantIdFromRoute` turns a short URL segment back into the full document ID.
+
+The overview links to short URLs such as `/variants/loyal-customers`, not full IDs such as `/variants/variants.loyal-customers`.
+
+## Overview Page
+
+`tool/overview/VariantsOverview.tsx` renders the main variants table.
+
+Covered behavior:
+
+- Loading, error, and empty states.
+- Search by title, ID suffix, condition keys, and condition values.
+- Table rows that navigate to the detail route.
+- Create variant button.
+- Row actions menu with `Delete variant`.
+
+The table uses the shared releases table component so the row layout, sorting, and virtualization match other Studio tooling.
+
+## Create And Edit Dialogs
+
+Create and edit share the same dialog shell and form:
+
+- `components/dialog/VariantDialog.tsx` owns submit state, validation display, save button state, and error toasts.
+- `CreateVariantDialog.tsx` provides default variant values and calls `createVariant`.
+- `EditVariantDialog.tsx` converts an existing `SystemVariant` into `EditableSystemVariant` and calls `updateVariant`.
+- `VariantForm.tsx` owns title, description, and condition row editing.
+
+The detail page intentionally uses a read-only summary plus an edit dialog instead of inline editing. Inline title/description editing was considered, but the dialog approach is simpler while the feature is still evolving and lets create/edit share the same validation behavior.
+
+## Condition Row UX
+
+`VariantForm` keeps an array of condition rows:
+
+```ts
+interface ConditionRow {
+  id: string
+  key: string
+  value: string
+}
+```
+
+This row state is an important part of the form architecture. Persisting conditions as an object is fine after validation, but object keys are awkward while editing:
+
+- duplicate keys collapse in an object
+- incomplete rows cannot be represented safely
+- partial key edits can move or lose values
+
+The form only serializes rows back to `variant.conditions` when every row has both a key and value and there are no duplicate keys.
+
+Covered behavior:
+
+- title is required
+- at least one complete condition is required
+- add-condition is disabled until the current row is complete
+- duplicate keys show an inline error
+- the remove button is disabled for a single empty row
+- partial key editing remains safe
+
+## Condition Autocomplete
+
+Condition key/value autocomplete is intentionally data-driven. We do not maintain a separate list of allowed keys or values.
+
+`components/dialog/conditionSuggestions.ts` derives suggestions from existing variants:
+
+- key suggestions are the unique keys already used in other variant conditions
+- value suggestions are scoped to the selected key
+- values for unrelated keys are not suggested
+- suggestions are filtered case-insensitively
+- free-text keys and values are still allowed
+
+`ConditionAutocompleteInput.tsx` wraps `@sanity/ui` `Autocomplete`.
+
+Important behavior:
+
+- selecting a suggestion is handled through `onChange`
+- free-text typing is handled through `onQueryChange`
+- `onQueryChange(null)` means the autocomplete query closed and should not clear the row
+- while the input is focused, the wrapper avoids forcing the current row value back into `Autocomplete.value`, because doing so closes the suggestion popover while typing
+
+The autocomplete is a consistency aid, not a schema constraint. Users can still introduce new condition patterns when needed.
+
+## Detail Page
+
+`tool/detail/VariantDetail.tsx` renders the current detail surface.
+
+Covered behavior:
+
+- loading and not-found states
+- back navigation
+- read-only title, description, and condition summary
+- edit dialog
+- placeholder documents table
+- footer with creation status and a detail-specific actions menu
+
+The detail actions menu is separate from the overview row menu. This is intentional because the two menus are expected to diverge as the detail page gains more actions.
+
+## Documents Table Placeholder
+
+`tool/detail/VariantDocumentsTable.tsx` is a placeholder for the future list of documents that belong to a variant.
+
+It currently receives an empty `SanityDocument[]`, but it already follows the release table layout:
+
+- `Version` column placeholder
+- document type column
+- document preview/search column
+- edited date column
+- empty state
+
+Pending work is to connect this to the real source of documents for a variant.
+
+## Footer
+
+`VariantDetailFooter.tsx` mirrors the release detail footer pattern.
+
+Covered behavior:
+
+- created status on the left
+- right-side action slot
+- detail-specific menu button
+- delete action navigates back to the overview after success
+
+The delete action currently does not confirm or check whether the variant has documents. That is pending until variant membership is implemented.
+
+## Test Coverage
+
+Focused unit/integration coverage lives under `packages/sanity/src/core/variants`.
+
+Covered areas include:
+
+- variants store query/listen behavior
+- create/update/delete operations
+- ID generation
+- invalid variant detection
+- overview table behavior and routing
+- create/edit dialog validation and submit behavior
+- condition row validation and partial-edit regressions
+- condition suggestion helpers
+- detail page rendering, edit dialog, footer, and detail delete menu
+
+Focused command:
+
+```sh
+pnpm vitest run --project=sanity packages/sanity/src/core/variants/
+```
+
+E2E coverage lives in `e2e/tests/variants/createVariant.spec.ts`.
+
+Covered areas include:
+
+- happy-path create flow
+- required title and complete condition validation
+- duplicate condition keys
+- partial key editing
+- autocomplete suggestions from existing variants
+- delete flow from the overview
+- cleanup by title prefix
+
+Useful e2e type check:
+
+```sh
+pnpm exec tsgo --project e2e/tsconfig.json --noEmit
+```
+
+The focused browser e2e command is:
+
+```sh
+pnpm test:e2e -- --project=chromium e2e/tests/variants/createVariant.spec.ts
+```
+
+Local browser execution has previously hit `EMFILE: too many open files, watch` before launching the browser. The spec has been authored and typechecked, but should be run in an environment without that watcher limit.
+
+## Pending Work
+
+- Replace direct document mutations with dedicated variant client actions when available.
+- Move from the temporary `variants.*` path to the final system-document path when supported.
+- Wire the detail documents table to the real list of documents that belong to a variant.
+- Decide how document counts affect deleting variants.
+- Add a delete confirmation or disabled state once variants can have documents.
+- Expand the detail-specific actions menu independently from the overview row menu.
+- Reassess whether inline detail editing is needed after the dialog-based edit flow has been used.

--- a/packages/sanity/src/core/variants/components/dialog/ConditionAutocompleteInput.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/ConditionAutocompleteInput.tsx
@@ -1,0 +1,66 @@
+import {Autocomplete} from '@sanity/ui'
+import {useCallback, useId, useState} from 'react'
+
+import {type ConditionSuggestionOption, filterConditionOption} from './conditionSuggestions'
+
+interface ConditionAutocompleteInputProps {
+  ariaLabel: string
+  autoFocus?: boolean
+  customValidity?: string
+  invalid?: boolean
+  onChange: (value: string) => void
+  options: ConditionSuggestionOption[]
+  placeholder: string
+  testId: string
+  value: string
+}
+
+export function ConditionAutocompleteInput(
+  props: ConditionAutocompleteInputProps,
+): React.JSX.Element {
+  const {
+    ariaLabel,
+    autoFocus,
+    customValidity,
+    invalid,
+    onChange,
+    options,
+    placeholder,
+    testId,
+    value,
+  } = props
+  const id = useId()
+  const [focused, setFocused] = useState(false)
+
+  const handleQueryChange = useCallback(
+    (nextValue: string | null) => {
+      // `onChange` fires when an option is selected. Free-text typing is exposed
+      // through `onQueryChange`; `null` means the internal query closed.
+      if (nextValue !== null) {
+        onChange(nextValue)
+      }
+    },
+    [onChange],
+  )
+
+  return (
+    <Autocomplete
+      id={id}
+      aria-invalid={invalid ? 'true' : undefined}
+      aria-label={ariaLabel}
+      autoFocus={autoFocus}
+      customValidity={customValidity}
+      data-testid={testId}
+      filterOption={filterConditionOption}
+      fontSize={1}
+      onBlur={() => setFocused(false)}
+      onChange={onChange}
+      onFocus={() => setFocused(true)}
+      onQueryChange={handleQueryChange}
+      openButton
+      options={options}
+      placeholder={placeholder}
+      value={focused ? undefined : value}
+    />
+  )
+}

--- a/packages/sanity/src/core/variants/components/dialog/CreateVariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/CreateVariantDialog.tsx
@@ -1,17 +1,10 @@
-import {at, set} from '@sanity/mutate'
-import {applyPatches} from '@sanity/mutate/_unstable_apply'
-import {Box, Card, Flex, useToast} from '@sanity/ui'
-import {toString} from '@sanity/util/paths'
-import {type FormEvent, useCallback, useState} from 'react'
+import {useCallback, useMemo} from 'react'
 
-import {Button, Dialog} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
 import {variantsLocaleNamespace} from '../../i18n'
 import {useVariantOperations} from '../../store/useVariantOperations'
-import {type EditableSystemVariant} from '../../types'
-import {getIsVariantInvalid} from '../../util/getIsVariantInvalid'
 import {getVariantDefaults} from '../../util/variantDefaults'
-import {VariantForm, type VariantFormChangeHandler} from './VariantForm'
+import {VariantDialog} from './VariantDialog'
 
 interface CreateVariantDialogProps {
   onCancel: () => void
@@ -20,82 +13,28 @@ interface CreateVariantDialogProps {
 
 export function CreateVariantDialog(props: CreateVariantDialogProps): React.JSX.Element {
   const {onCancel, onSubmit} = props
-  const toast = useToast()
   const {t} = useTranslation(variantsLocaleNamespace)
   const {createVariant} = useVariantOperations()
-  const [variant, setVariant] = useState(getVariantDefaults)
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [showValidation, setShowValidation] = useState(false)
-  const [conditionsInvalid, setConditionsInvalid] = useState(false)
-  const invalid = getIsVariantInvalid(variant) || conditionsInvalid
-
-  const handleVariantChange = useCallback<VariantFormChangeHandler>((path, nextValue) => {
-    setVariant(
-      (currentVariant) =>
-        applyPatches([at(toString(path), set(nextValue))], currentVariant) as EditableSystemVariant,
-    )
-  }, [])
+  const initialValue = useMemo(() => getVariantDefaults(), [])
 
   const handleSubmit = useCallback(
-    async (event: FormEvent<HTMLFormElement>) => {
-      event.preventDefault()
-
-      if (getIsVariantInvalid(variant) || conditionsInvalid) {
-        setShowValidation(true)
-        return
-      }
-
-      setIsSubmitting(true)
-
-      try {
-        await createVariant(variant)
-        setIsSubmitting(false)
-        onSubmit(variant._id)
-      } catch (error) {
-        setIsSubmitting(false)
-        console.error(error)
-        toast.push({
-          closable: true,
-          status: 'error',
-          title: t('dialog.create.error.title'),
-        })
-      }
+    async (variant: typeof initialValue) => {
+      await createVariant(variant)
+      onSubmit(variant._id)
     },
-    [conditionsInvalid, createVariant, onSubmit, t, toast, variant],
+    [createVariant, onSubmit],
   )
 
   return (
-    <Dialog
-      __unstable_autoFocus={false}
+    <VariantDialog
+      confirmDataTestId="submit-variant-button"
+      confirmText={t('dialog.create.action.confirm')}
+      errorTitle={t('dialog.create.error.title')}
       header={t('dialog.create.title')}
       id="create-variant-dialog"
-      onClickOutside={isSubmitting ? undefined : onCancel}
-      onClose={isSubmitting ? undefined : onCancel}
-      padding={false}
-      width={1}
-    >
-      <Card borderTop padding={4}>
-        <form onSubmit={handleSubmit}>
-          <Box paddingBottom={4}>
-            <VariantForm
-              onChange={handleVariantChange}
-              onConditionValidityChange={setConditionsInvalid}
-              showValidation={showValidation}
-              value={variant}
-            />
-          </Box>
-          <Flex justify="flex-end" paddingTop={5}>
-            <Button
-              data-testid="submit-variant-button"
-              disabled={isSubmitting || invalid}
-              loading={isSubmitting}
-              size="large"
-              text={t('dialog.create.action.confirm')}
-              type="submit"
-            />
-          </Flex>
-        </form>
-      </Card>
-    </Dialog>
+      initialValue={initialValue}
+      onCancel={onCancel}
+      onSubmit={handleSubmit}
+    />
   )
 }

--- a/packages/sanity/src/core/variants/components/dialog/EditVariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/EditVariantDialog.tsx
@@ -1,0 +1,52 @@
+import {useCallback, useMemo} from 'react'
+
+import {useTranslation} from '../../../i18n'
+import {variantsLocaleNamespace} from '../../i18n'
+import {useVariantOperations} from '../../store/useVariantOperations'
+import {type EditableSystemVariant, type SystemVariant} from '../../types'
+import {VariantDialog} from './VariantDialog'
+
+interface EditVariantDialogProps {
+  onCancel: () => void
+  onSubmit: () => void
+  variant: SystemVariant
+}
+
+function toEditableVariant(variant: SystemVariant): EditableSystemVariant {
+  return {
+    _id: variant._id,
+    _type: variant._type,
+    conditions: variant.conditions,
+    priority: variant.priority,
+    metadata: variant.metadata,
+  }
+}
+
+export function EditVariantDialog(props: EditVariantDialogProps): React.JSX.Element {
+  const {onCancel, onSubmit, variant: initialVariant} = props
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const {updateVariant} = useVariantOperations()
+  const initialValue = useMemo(() => toEditableVariant(initialVariant), [initialVariant])
+
+  const handleSubmit = useCallback(
+    async (variant: EditableSystemVariant) => {
+      await updateVariant(variant)
+      onSubmit()
+    },
+    [onSubmit, updateVariant],
+  )
+
+  return (
+    <VariantDialog
+      confirmDataTestId="save-variant-button"
+      confirmText={t('dialog.edit.action.confirm')}
+      errorTitle={t('dialog.edit.error.title')}
+      header={t('dialog.edit.title')}
+      id="edit-variant-dialog"
+      initialValue={initialValue}
+      onCancel={onCancel}
+      onSubmit={handleSubmit}
+      renderCancelButton
+    />
+  )
+}

--- a/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
@@ -109,7 +109,7 @@ export function VariantDialog(props: VariantDialogProps): React.JSX.Element {
             )}
             <Button
               data-testid={confirmDataTestId}
-              disabled={isSubmitting || invalid}
+              disabled={isSubmitting}
               loading={isSubmitting}
               size="large"
               text={confirmText}

--- a/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
@@ -1,0 +1,123 @@
+import {at, set} from '@sanity/mutate'
+import {applyPatches} from '@sanity/mutate/_unstable_apply'
+import {Box, Card, Flex, useToast} from '@sanity/ui'
+import {toString} from '@sanity/util/paths'
+import {type FormEvent, useCallback, useState} from 'react'
+
+import {Button, Dialog} from '../../../../ui-components'
+import {useTranslation} from '../../../i18n'
+import {variantsLocaleNamespace} from '../../i18n'
+import {type EditableSystemVariant} from '../../types'
+import {getIsVariantInvalid} from '../../util/getIsVariantInvalid'
+import {VariantForm, type VariantFormChangeHandler} from './VariantForm'
+
+interface VariantDialogProps {
+  confirmDataTestId: string
+  confirmText: string
+  errorTitle: string
+  header: string
+  id: string
+  initialValue: EditableSystemVariant
+  onCancel: () => void
+  onSubmit: (variant: EditableSystemVariant) => Promise<void>
+  renderCancelButton?: boolean
+}
+
+export function VariantDialog(props: VariantDialogProps): React.JSX.Element {
+  const {
+    confirmDataTestId,
+    confirmText,
+    errorTitle,
+    header,
+    id,
+    initialValue,
+    onCancel,
+    onSubmit,
+    renderCancelButton = false,
+  } = props
+  const toast = useToast()
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const [variant, setVariant] = useState(initialValue)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [showValidation, setShowValidation] = useState(false)
+  const [conditionsInvalid, setConditionsInvalid] = useState(false)
+  const invalid = getIsVariantInvalid(variant) || conditionsInvalid
+
+  const handleVariantChange = useCallback<VariantFormChangeHandler>((path, nextValue) => {
+    setVariant(
+      (currentVariant) =>
+        applyPatches([at(toString(path), set(nextValue))], currentVariant) as EditableSystemVariant,
+    )
+  }, [])
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+
+      if (invalid) {
+        setShowValidation(true)
+        return
+      }
+
+      setIsSubmitting(true)
+
+      try {
+        await onSubmit(variant)
+        setIsSubmitting(false)
+      } catch (error) {
+        setIsSubmitting(false)
+        console.error(error)
+        toast.push({
+          closable: true,
+          status: 'error',
+          title: errorTitle,
+        })
+      }
+    },
+    [errorTitle, invalid, onSubmit, toast, variant],
+  )
+
+  return (
+    <Dialog
+      __unstable_autoFocus={false}
+      header={header}
+      id={id}
+      onClickOutside={isSubmitting ? undefined : onCancel}
+      onClose={isSubmitting ? undefined : onCancel}
+      padding={false}
+      width={1}
+    >
+      <Card borderTop padding={4}>
+        <form onSubmit={handleSubmit}>
+          <Box paddingBottom={4}>
+            <VariantForm
+              onChange={handleVariantChange}
+              onConditionValidityChange={setConditionsInvalid}
+              showValidation={showValidation}
+              value={variant}
+            />
+          </Box>
+          <Flex gap={2} justify="flex-end" paddingTop={5}>
+            {renderCancelButton && (
+              <Button
+                disabled={isSubmitting}
+                mode="ghost"
+                onClick={onCancel}
+                text={t('dialog.edit.action.cancel')}
+                type="button"
+              />
+            )}
+            <Button
+              data-testid={confirmDataTestId}
+              disabled={isSubmitting || invalid}
+              loading={isSubmitting}
+              size="large"
+              text={confirmText}
+              type="submit"
+            />
+          </Flex>
+        </form>
+      </Card>
+    </Dialog>
+  )
+}

--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -8,7 +8,7 @@ import {type ChangeEvent, useCallback, useId, useMemo, useState} from 'react'
 import {Button} from '../../../../ui-components'
 import {TextWithTone} from '../../../components/textWithTone/TextWithTone'
 import {useTranslation} from '../../../i18n'
-import {variantsLocaleNamespace} from '../../i18n'
+import {type VariantsLocaleResourceKeys, variantsLocaleNamespace} from '../../i18n'
 import {useAllVariants} from '../../store/useAllVariants'
 import {type EditableSystemVariant} from '../../types'
 import {
@@ -24,6 +24,11 @@ interface ConditionRow {
   id: string
   key: string
   value: string
+}
+
+interface ConditionRowValidation {
+  key: VariantsLocaleResourceKeys | null
+  value: VariantsLocaleResourceKeys | null
 }
 
 function getConditionRows(conditions: EditableSystemVariant['conditions']): ConditionRow[] {
@@ -53,70 +58,51 @@ function isConditionRowEmpty(row: ConditionRow): boolean {
   return !row.key.trim() && !row.value.trim()
 }
 
-function isConditionRowComplete(row: ConditionRow): boolean {
-  return Boolean(row.key.trim() && row.value.trim())
+function getEmptyConditionRowValidation(): ConditionRowValidation {
+  return {key: null, value: null}
 }
 
-function getInvalidConditionKeyIndexes(rows: ConditionRow[]): Map<number, 'invalid' | 'reserved'> {
-  const invalidIndexes = new Map<number, 'invalid' | 'reserved'>()
-
-  rows.forEach((row, index) => {
-    const error = getConditionKeyValidationError(row.key)
-
-    if (error) {
-      invalidIndexes.set(index, error)
-    }
-  })
-
-  return invalidIndexes
-}
-
-function getInvalidConditionValueIndexes(rows: ConditionRow[]): Set<number> {
-  const invalidIndexes = new Set<number>()
-
-  rows.forEach((row, index) => {
-    const key = row.key.trim()
-
-    if (!key) {
-      return
-    }
-
-    if (getConditionValueValidationError(row.value)) {
-      invalidIndexes.add(index)
-    }
-  })
-
-  return invalidIndexes
-}
-
-function getDuplicateConditionKeyIndexes(rows: ConditionRow[]): Set<number> {
+function getConditionRowsValidation(rows: ConditionRow[]): Map<number, ConditionRowValidation> {
+  const conditionRowsValidation = new Map<number, ConditionRowValidation>()
   const seenKeys = new Set<string>()
-  const duplicateIndexes = new Set<number>()
 
   rows.forEach((row, index) => {
+    const validation: ConditionRowValidation = {key: null, value: null}
     const key = row.key.trim()
+    const value = row.value.trim()
 
-    if (!key) {
-      return
+    if (key) {
+      if (seenKeys.has(key)) {
+        validation.key = 'dialog.create.condition-key.duplicate'
+      } else {
+        seenKeys.add(key)
+      }
+
+      const keyError = getConditionKeyValidationError(row.key)
+
+      if (!validation.key && keyError === 'reserved') {
+        validation.key = 'dialog.create.condition-key.reserved'
+      } else if (!validation.key && keyError === 'invalid') {
+        validation.key = 'dialog.create.condition-key.invalid'
+      }
+    } else if (value) {
+      validation.key = 'dialog.create.condition-key.required'
     }
 
-    if (seenKeys.has(key)) {
-      duplicateIndexes.add(index)
-    } else {
-      seenKeys.add(key)
+    if ((key || isConditionRowEmpty(row)) && getConditionValueValidationError(row.value)) {
+      validation.value = 'dialog.create.condition-value.required'
     }
+
+    conditionRowsValidation.set(index, validation)
   })
 
-  return duplicateIndexes
+  return conditionRowsValidation
 }
 
-function getConditionRowsInvalid(rows: ConditionRow[]): boolean {
-  return (
-    rows.some((row) => !isConditionRowComplete(row)) ||
-    getDuplicateConditionKeyIndexes(rows).size > 0 ||
-    getInvalidConditionKeyIndexes(rows).size > 0 ||
-    getInvalidConditionValueIndexes(rows).size > 0
-  )
+function hasConditionRowsValidationErrors(
+  validation: Map<number, ConditionRowValidation>,
+): boolean {
+  return Array.from(validation.values()).some(({key, value}) => key || value)
 }
 
 function getPortableTextDescriptionValue(description?: PortableTextBlock[]): string {
@@ -140,33 +126,20 @@ export function VariantForm(props: {
   const {data: variants} = useAllVariants()
   const titleId = useId()
   const descriptionId = useId()
-  const [titleTouched, setTitleTouched] = useState(false)
   // `conditions` is stored as an object, but object keys are awkward to edit live:
   // duplicates collapse and partial key edits like "far" -> "favorite" can lose data.
   // Keep rows locally while editing, then commit back once they serialize cleanly.
   const [conditionRows, setConditionRows] = useState(() => getConditionRows(value.conditions))
-  const duplicateConditionKeyIndexes = useMemo(
-    () => getDuplicateConditionKeyIndexes(conditionRows),
-    [conditionRows],
-  )
-  const invalidConditionKeyIndexes = useMemo(
-    () => getInvalidConditionKeyIndexes(conditionRows),
-    [conditionRows],
-  )
-  const invalidConditionValueIndexes = useMemo(
-    () => getInvalidConditionValueIndexes(conditionRows),
+  const conditionsValidation = useMemo(
+    () => getConditionRowsValidation(conditionRows),
     [conditionRows],
   )
 
   const hasTitle = Boolean(getVariantTitleValue(value))
-  const showTitleError = (showValidation || titleTouched) && !hasTitle
+  const showTitleError = showValidation && !hasTitle
   const lastConditionRow = conditionRows[conditionRows.length - 1]
   const canAddCondition = Boolean(
-    lastConditionRow &&
-    isConditionRowComplete(lastConditionRow) &&
-    duplicateConditionKeyIndexes.size === 0 &&
-    invalidConditionKeyIndexes.size === 0 &&
-    invalidConditionValueIndexes.size === 0,
+    lastConditionRow && !hasConditionRowsValidationErrors(conditionsValidation),
   )
 
   const updateConditionRows = useCallback(
@@ -175,7 +148,8 @@ export function VariantForm(props: {
 
       setConditionRows(rows)
 
-      const nextRowsInvalid = getConditionRowsInvalid(rows)
+      const nextRowsValidation = getConditionRowsValidation(rows)
+      const nextRowsInvalid = hasConditionRowsValidationErrors(nextRowsValidation)
       onConditionValidityChange?.(nextRowsInvalid)
 
       if (nextRows.length === 0 || !nextRowsInvalid) {
@@ -243,7 +217,6 @@ export function VariantForm(props: {
           data-testid="variant-form-title"
           fontSize={2}
           id={titleId}
-          onBlur={() => setTitleTouched(true)}
           onChange={handleTitleChange}
           placeholder={t('dialog.create.variant-title.placeholder')}
           value={typeof value.metadata?.title === 'string' ? value.metadata.title : ''}
@@ -281,99 +254,69 @@ export function VariantForm(props: {
         </Stack>
 
         <Stack space={2}>
-          {conditionRows.map((row, index) => (
-            <Stack key={row.id} space={2}>
-              <Flex align="center" gap={2}>
-                <Box flex={1}>
-                  <ConditionAutocompleteInput
-                    autoFocus={index > 0}
-                    ariaLabel={t('dialog.create.condition-key.label')}
-                    customValidity={
-                      duplicateConditionKeyIndexes.has(index)
-                        ? t('dialog.create.condition-key.duplicate')
-                        : invalidConditionKeyIndexes.get(index) === 'reserved'
-                          ? t('dialog.create.condition-key.reserved')
-                          : invalidConditionKeyIndexes.get(index) === 'invalid'
-                            ? t('dialog.create.condition-key.invalid')
-                            : undefined
-                    }
-                    invalid={
-                      duplicateConditionKeyIndexes.has(index) ||
-                      invalidConditionKeyIndexes.has(index)
-                    }
-                    onChange={(nextValue) => handleConditionChange(index, 'key', nextValue)}
-                    options={getConditionKeyOptions(variants, conditionRows, index)}
-                    placeholder={t('dialog.create.condition-key.placeholder')}
-                    testId="variant-form-condition-key"
-                    value={row.key}
+          {conditionRows.map((row, index) => {
+            const validation = conditionsValidation.get(index) ?? getEmptyConditionRowValidation()
+            // const validation.key = validation.key
+            // validation.key === 'dialog.create.condition-key.required' && !showValidation
+            //   ? null
+            //   : validation.key
+            const valueValidation = showValidation ? validation.value : null
+            const conditionValidationError = validation.key || valueValidation
+
+            return (
+              <Stack key={row.id} space={2}>
+                <Flex align="center" gap={2}>
+                  <Box flex={1}>
+                    <ConditionAutocompleteInput
+                      autoFocus={index > 0}
+                      ariaLabel={t('dialog.create.condition-key.label')}
+                      customValidity={validation.key ? t(validation.key) : undefined}
+                      invalid={Boolean(validation.key)}
+                      onChange={(nextValue) => handleConditionChange(index, 'key', nextValue)}
+                      options={getConditionKeyOptions(variants, conditionRows, index)}
+                      placeholder={t('dialog.create.condition-key.placeholder')}
+                      testId="variant-form-condition-key"
+                      value={row.key}
+                    />
+                  </Box>
+                  <Box flex={1}>
+                    <ConditionAutocompleteInput
+                      ariaLabel={t('dialog.create.condition-value.label')}
+                      customValidity={valueValidation ? t(valueValidation) : undefined}
+                      invalid={Boolean(valueValidation)}
+                      onChange={(nextValue) => handleConditionChange(index, 'value', nextValue)}
+                      options={getConditionValueOptions(variants, row.key)}
+                      placeholder={t('dialog.create.condition-value.placeholder')}
+                      testId="variant-form-condition-value"
+                      value={row.value}
+                    />
+                  </Box>
+                  <Button
+                    disabled={isConditionRowEmpty(row) && conditionRows.length === 1}
+                    icon={TrashIcon}
+                    mode="bleed"
+                    onClick={() => handleRemoveCondition(index)}
+                    tone="critical"
+                    tooltipProps={{content: t('dialog.create.remove-condition')}}
+                    type="button"
                   />
-                </Box>
-                <Box flex={1}>
-                  <ConditionAutocompleteInput
-                    ariaLabel={t('dialog.create.condition-value.label')}
-                    customValidity={
-                      invalidConditionValueIndexes.has(index)
-                        ? t('dialog.create.condition-value.required')
-                        : undefined
-                    }
-                    invalid={invalidConditionValueIndexes.has(index)}
-                    onChange={(nextValue) => handleConditionChange(index, 'value', nextValue)}
-                    options={getConditionValueOptions(variants, row.key)}
-                    placeholder={t('dialog.create.condition-value.placeholder')}
-                    testId="variant-form-condition-value"
-                    value={row.value}
-                  />
-                </Box>
-                <Button
-                  disabled={isConditionRowEmpty(row) && conditionRows.length === 1}
-                  icon={TrashIcon}
-                  mode="bleed"
-                  onClick={() => handleRemoveCondition(index)}
-                  tone="critical"
-                  tooltipProps={{content: t('dialog.create.remove-condition')}}
-                  type="button"
-                />
-              </Flex>
-              {duplicateConditionKeyIndexes.has(index) && (
-                <TextWithTone
-                  data-testid="variant-form-condition-key-error"
-                  size={1}
-                  tone="critical"
-                >
-                  {t('dialog.create.condition-key.duplicate')}
-                </TextWithTone>
-              )}
-              {!duplicateConditionKeyIndexes.has(index) &&
-                invalidConditionKeyIndexes.get(index) === 'reserved' && (
+                </Flex>
+                {conditionValidationError && (
                   <TextWithTone
-                    data-testid="variant-form-condition-key-error"
+                    data-testid={
+                      validation.key
+                        ? 'variant-form-condition-key-error'
+                        : 'variant-form-condition-value-error'
+                    }
                     size={1}
                     tone="critical"
                   >
-                    {t('dialog.create.condition-key.reserved')}
+                    {t(conditionValidationError)}
                   </TextWithTone>
                 )}
-              {!duplicateConditionKeyIndexes.has(index) &&
-                invalidConditionKeyIndexes.get(index) === 'invalid' && (
-                  <TextWithTone
-                    data-testid="variant-form-condition-key-error"
-                    size={1}
-                    tone="critical"
-                  >
-                    {t('dialog.create.condition-key.invalid')}
-                  </TextWithTone>
-                )}
-              {invalidConditionValueIndexes.has(index) && (
-                <TextWithTone
-                  data-testid="variant-form-condition-value-error"
-                  size={1}
-                  tone="critical"
-                >
-                  {t('dialog.create.condition-value.required')}
-                </TextWithTone>
-              )}
-            </Stack>
-          ))}
+              </Stack>
+            )
+          })}
         </Stack>
 
         <Flex>

--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -11,6 +11,10 @@ import {useTranslation} from '../../../i18n'
 import {variantsLocaleNamespace} from '../../i18n'
 import {useAllVariants} from '../../store/useAllVariants'
 import {type EditableSystemVariant} from '../../types'
+import {
+  getConditionKeyValidationError,
+  getConditionValueValidationError,
+} from '../../util/conditionValidation'
 import {getVariantTitleValue} from '../../util/getIsVariantInvalid'
 import {createPortableTextDescription} from '../../util/variantDefaults'
 import {ConditionAutocompleteInput} from './ConditionAutocompleteInput'
@@ -53,6 +57,38 @@ function isConditionRowComplete(row: ConditionRow): boolean {
   return Boolean(row.key.trim() && row.value.trim())
 }
 
+function getInvalidConditionKeyIndexes(rows: ConditionRow[]): Map<number, 'invalid' | 'reserved'> {
+  const invalidIndexes = new Map<number, 'invalid' | 'reserved'>()
+
+  rows.forEach((row, index) => {
+    const error = getConditionKeyValidationError(row.key)
+
+    if (error) {
+      invalidIndexes.set(index, error)
+    }
+  })
+
+  return invalidIndexes
+}
+
+function getInvalidConditionValueIndexes(rows: ConditionRow[]): Set<number> {
+  const invalidIndexes = new Set<number>()
+
+  rows.forEach((row, index) => {
+    const key = row.key.trim()
+
+    if (!key) {
+      return
+    }
+
+    if (getConditionValueValidationError(row.value)) {
+      invalidIndexes.add(index)
+    }
+  })
+
+  return invalidIndexes
+}
+
 function getDuplicateConditionKeyIndexes(rows: ConditionRow[]): Set<number> {
   const seenKeys = new Set<string>()
   const duplicateIndexes = new Set<number>()
@@ -77,7 +113,9 @@ function getDuplicateConditionKeyIndexes(rows: ConditionRow[]): Set<number> {
 function getConditionRowsInvalid(rows: ConditionRow[]): boolean {
   return (
     rows.some((row) => !isConditionRowComplete(row)) ||
-    getDuplicateConditionKeyIndexes(rows).size > 0
+    getDuplicateConditionKeyIndexes(rows).size > 0 ||
+    getInvalidConditionKeyIndexes(rows).size > 0 ||
+    getInvalidConditionValueIndexes(rows).size > 0
   )
 }
 
@@ -111,6 +149,14 @@ export function VariantForm(props: {
     () => getDuplicateConditionKeyIndexes(conditionRows),
     [conditionRows],
   )
+  const invalidConditionKeyIndexes = useMemo(
+    () => getInvalidConditionKeyIndexes(conditionRows),
+    [conditionRows],
+  )
+  const invalidConditionValueIndexes = useMemo(
+    () => getInvalidConditionValueIndexes(conditionRows),
+    [conditionRows],
+  )
 
   const hasTitle = Boolean(getVariantTitleValue(value))
   const showTitleError = (showValidation || titleTouched) && !hasTitle
@@ -118,7 +164,9 @@ export function VariantForm(props: {
   const canAddCondition = Boolean(
     lastConditionRow &&
     isConditionRowComplete(lastConditionRow) &&
-    duplicateConditionKeyIndexes.size === 0,
+    duplicateConditionKeyIndexes.size === 0 &&
+    invalidConditionKeyIndexes.size === 0 &&
+    invalidConditionValueIndexes.size === 0,
   )
 
   const updateConditionRows = useCallback(
@@ -243,9 +291,16 @@ export function VariantForm(props: {
                     customValidity={
                       duplicateConditionKeyIndexes.has(index)
                         ? t('dialog.create.condition-key.duplicate')
-                        : undefined
+                        : invalidConditionKeyIndexes.get(index) === 'reserved'
+                          ? t('dialog.create.condition-key.reserved')
+                          : invalidConditionKeyIndexes.get(index) === 'invalid'
+                            ? t('dialog.create.condition-key.invalid')
+                            : undefined
                     }
-                    invalid={duplicateConditionKeyIndexes.has(index)}
+                    invalid={
+                      duplicateConditionKeyIndexes.has(index) ||
+                      invalidConditionKeyIndexes.has(index)
+                    }
                     onChange={(nextValue) => handleConditionChange(index, 'key', nextValue)}
                     options={getConditionKeyOptions(variants, conditionRows, index)}
                     placeholder={t('dialog.create.condition-key.placeholder')}
@@ -256,6 +311,12 @@ export function VariantForm(props: {
                 <Box flex={1}>
                   <ConditionAutocompleteInput
                     ariaLabel={t('dialog.create.condition-value.label')}
+                    customValidity={
+                      invalidConditionValueIndexes.has(index)
+                        ? t('dialog.create.condition-value.required')
+                        : undefined
+                    }
+                    invalid={invalidConditionValueIndexes.has(index)}
                     onChange={(nextValue) => handleConditionChange(index, 'value', nextValue)}
                     options={getConditionValueOptions(variants, row.key)}
                     placeholder={t('dialog.create.condition-value.placeholder')}
@@ -280,6 +341,35 @@ export function VariantForm(props: {
                   tone="critical"
                 >
                   {t('dialog.create.condition-key.duplicate')}
+                </TextWithTone>
+              )}
+              {!duplicateConditionKeyIndexes.has(index) &&
+                invalidConditionKeyIndexes.get(index) === 'reserved' && (
+                  <TextWithTone
+                    data-testid="variant-form-condition-key-error"
+                    size={1}
+                    tone="critical"
+                  >
+                    {t('dialog.create.condition-key.reserved')}
+                  </TextWithTone>
+                )}
+              {!duplicateConditionKeyIndexes.has(index) &&
+                invalidConditionKeyIndexes.get(index) === 'invalid' && (
+                  <TextWithTone
+                    data-testid="variant-form-condition-key-error"
+                    size={1}
+                    tone="critical"
+                  >
+                    {t('dialog.create.condition-key.invalid')}
+                  </TextWithTone>
+                )}
+              {invalidConditionValueIndexes.has(index) && (
+                <TextWithTone
+                  data-testid="variant-form-condition-value-error"
+                  size={1}
+                  tone="critical"
+                >
+                  {t('dialog.create.condition-value.required')}
                 </TextWithTone>
               )}
             </Stack>

--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -9,9 +9,12 @@ import {Button} from '../../../../ui-components'
 import {TextWithTone} from '../../../components/textWithTone/TextWithTone'
 import {useTranslation} from '../../../i18n'
 import {variantsLocaleNamespace} from '../../i18n'
+import {useAllVariants} from '../../store/useAllVariants'
 import {type EditableSystemVariant} from '../../types'
 import {getVariantTitleValue} from '../../util/getIsVariantInvalid'
 import {createPortableTextDescription} from '../../util/variantDefaults'
+import {ConditionAutocompleteInput} from './ConditionAutocompleteInput'
+import {getConditionKeyOptions, getConditionValueOptions} from './conditionSuggestions'
 
 interface ConditionRow {
   id: string
@@ -96,6 +99,7 @@ export function VariantForm(props: {
 }) {
   const {onChange, onConditionValidityChange, showValidation = false, value} = props
   const {t} = useTranslation(variantsLocaleNamespace)
+  const {data: variants} = useAllVariants()
   const titleId = useId()
   const descriptionId = useId()
   const [titleTouched, setTitleTouched] = useState(false)
@@ -233,33 +237,29 @@ export function VariantForm(props: {
             <Stack key={row.id} space={2}>
               <Flex align="center" gap={2}>
                 <Box flex={1}>
-                  <TextInput
+                  <ConditionAutocompleteInput
                     autoFocus={index > 0}
-                    aria-invalid={duplicateConditionKeyIndexes.has(index) ? 'true' : undefined}
-                    aria-label={t('dialog.create.condition-key.label')}
+                    ariaLabel={t('dialog.create.condition-key.label')}
                     customValidity={
                       duplicateConditionKeyIndexes.has(index)
                         ? t('dialog.create.condition-key.duplicate')
                         : undefined
                     }
-                    data-testid="variant-form-condition-key"
-                    fontSize={1}
-                    onChange={(event) =>
-                      handleConditionChange(index, 'key', event.currentTarget.value)
-                    }
+                    invalid={duplicateConditionKeyIndexes.has(index)}
+                    onChange={(nextValue) => handleConditionChange(index, 'key', nextValue)}
+                    options={getConditionKeyOptions(variants, conditionRows, index)}
                     placeholder={t('dialog.create.condition-key.placeholder')}
+                    testId="variant-form-condition-key"
                     value={row.key}
                   />
                 </Box>
                 <Box flex={1}>
-                  <TextInput
-                    aria-label={t('dialog.create.condition-value.label')}
-                    data-testid="variant-form-condition-value"
-                    fontSize={1}
-                    onChange={(event) =>
-                      handleConditionChange(index, 'value', event.currentTarget.value)
-                    }
+                  <ConditionAutocompleteInput
+                    ariaLabel={t('dialog.create.condition-value.label')}
+                    onChange={(nextValue) => handleConditionChange(index, 'value', nextValue)}
+                    options={getConditionValueOptions(variants, row.key)}
                     placeholder={t('dialog.create.condition-value.placeholder')}
+                    testId="variant-form-condition-value"
                     value={row.value}
                   />
                 </Box>

--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -1,5 +1,6 @@
+import {isPortableTextBlock, toPlainText} from '@portabletext/toolkit'
 import {AddIcon, TrashIcon} from '@sanity/icons'
-import {type Path} from '@sanity/types'
+import {type PortableTextBlock, type Path} from '@sanity/types'
 import {Box, Flex, Stack, Text, TextArea, TextInput} from '@sanity/ui'
 import {randomKey} from '@sanity/util/content'
 import {type ChangeEvent, useCallback, useId, useMemo, useState} from 'react'
@@ -75,6 +76,14 @@ function getConditionRowsInvalid(rows: ConditionRow[]): boolean {
     rows.some((row) => !isConditionRowComplete(row)) ||
     getDuplicateConditionKeyIndexes(rows).size > 0
   )
+}
+
+function getPortableTextDescriptionValue(description?: PortableTextBlock[]): string {
+  if (!Array.isArray(description) || !description.every(isPortableTextBlock)) {
+    return ''
+  }
+
+  return toPlainText(description)
 }
 
 export type VariantFormChangeHandler = (path: Path, value: unknown) => void
@@ -205,6 +214,7 @@ export function VariantForm(props: {
           onChange={handleDescriptionChange}
           placeholder={t('dialog.create.description.placeholder')}
           rows={3}
+          value={getPortableTextDescriptionValue(value.metadata?.description)}
         />
       </Stack>
 

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
@@ -2,7 +2,6 @@ import {render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {flushMicrotasksThisIsACodeSmell} from '../../../../../../test/testUtils/flushMicrotasks'
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
 import {variantsUsEnglishLocaleBundle} from '../../../i18n'
 import {CreateVariantDialog} from '../CreateVariantDialog'
@@ -11,6 +10,15 @@ const variantOperationsMock = vi.hoisted(() => ({
   createVariant: vi.fn(),
   updateVariant: vi.fn(),
   deleteVariant: vi.fn(),
+}))
+
+const toastMock = vi.hoisted(() => ({
+  push: vi.fn(),
+}))
+
+vi.mock('@sanity/ui', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useToast: vi.fn(() => toastMock),
 }))
 
 vi.mock('../../../store/useVariantOperations', () => ({
@@ -33,7 +41,7 @@ describe('CreateVariantDialog', () => {
     const result = render(<CreateVariantDialog onCancel={onCancel} onSubmit={onSubmit} />, {
       wrapper,
     })
-    await flushMicrotasksThisIsACodeSmell()
+    await screen.findByRole('dialog', {name: 'Create variant'})
     return result
   }
 
@@ -161,6 +169,12 @@ describe('CreateVariantDialog', () => {
       expect(consoleError).toHaveBeenCalledWith(error)
     })
 
+    expect(toastMock.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'error',
+        title: 'Unable to create variant',
+      }),
+    )
     expect(onCancel).not.toHaveBeenCalled()
     expect(onSubmit).not.toHaveBeenCalled()
     expect(screen.getByRole('dialog', {name: 'Create variant'})).toBeInTheDocument()

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
@@ -136,6 +136,29 @@ describe('CreateVariantDialog', () => {
     })
   })
 
+  it('shows an error for reserved and invalid condition keys', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-title'), 'Loyal customers')
+    await user.type(screen.getByTestId('variant-form-condition-key'), '_system')
+    await user.type(screen.getByTestId('variant-form-condition-value'), 'loyal')
+
+    expect(screen.getByTestId('variant-form-condition-key-error')).toHaveTextContent(
+      'Condition keys cannot start with _ or $',
+    )
+    expect(screen.getByTestId('submit-variant-button')).toBeDisabled()
+
+    await user.clear(screen.getByTestId('variant-form-condition-key'))
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'Audience')
+
+    expect(screen.getByTestId('variant-form-condition-key-error')).toHaveTextContent(
+      'Condition keys must be lowercase, start with a letter, and use letters, numbers, underscores, or hyphens',
+    )
+    expect(screen.getByTestId('submit-variant-button')).toBeDisabled()
+  })
+
   it('suggests existing condition keys while typing', async () => {
     const user = userEvent.setup()
 

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
@@ -3,7 +3,9 @@ import {userEvent} from '@testing-library/user-event'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {variantAlphaAudience, variantNorwegianMarket} from '../../../__fixtures__/variants.fixture'
 import {variantsUsEnglishLocaleBundle} from '../../../i18n'
+import {type SystemVariant} from '../../../types'
 import {CreateVariantDialog} from '../CreateVariantDialog'
 
 const variantOperationsMock = vi.hoisted(() => ({
@@ -16,6 +18,13 @@ const toastMock = vi.hoisted(() => ({
   push: vi.fn(),
 }))
 
+const variantsMock = vi.hoisted(() => ({
+  data: [] as SystemVariant[],
+  byId: new Map<string, SystemVariant>(),
+  loading: false,
+  error: undefined as Error | undefined,
+}))
+
 vi.mock('@sanity/ui', async (importOriginal) => ({
   ...(await importOriginal()),
   useToast: vi.fn(() => toastMock),
@@ -25,12 +34,20 @@ vi.mock('../../../store/useVariantOperations', () => ({
   useVariantOperations: vi.fn(() => variantOperationsMock),
 }))
 
+vi.mock('../../../store/useAllVariants', () => ({
+  useAllVariants: vi.fn(() => variantsMock),
+}))
+
 describe('CreateVariantDialog', () => {
   const onCancel = vi.fn()
   const onSubmit = vi.fn()
 
   beforeEach(() => {
     vi.clearAllMocks()
+    variantsMock.data = [variantAlphaAudience, variantNorwegianMarket]
+    variantsMock.byId = new Map(variantsMock.data.map((variant) => [variant._id, variant]))
+    variantsMock.loading = false
+    variantsMock.error = undefined
     variantOperationsMock.createVariant.mockResolvedValue(undefined)
   })
 
@@ -52,13 +69,13 @@ describe('CreateVariantDialog', () => {
 
     expect(screen.getByRole('button', {name: 'Add condition'})).toBeDisabled()
 
-    await user.type(screen.getByRole('textbox', {name: 'Key'}), 'audience')
+    await user.type(screen.getByRole('combobox', {name: 'Key'}), 'audience')
     expect(screen.getByRole('button', {name: 'Add condition'})).toBeDisabled()
 
-    await user.type(screen.getByRole('textbox', {name: 'Value'}), 'loyal-customers')
+    await user.type(screen.getByRole('combobox', {name: 'Value'}), 'loyal-customers')
 
     await waitFor(() => {
-      expect(screen.getByRole('textbox', {name: 'Value'})).toHaveValue('loyal-customers')
+      expect(screen.getByRole('combobox', {name: 'Value'})).toHaveValue('loyal-customers')
       expect(screen.getByRole('button', {name: 'Add condition'})).toBeEnabled()
     })
 
@@ -91,8 +108,8 @@ describe('CreateVariantDialog', () => {
     await renderDialog()
 
     await user.type(screen.getByTestId('variant-form-title'), 'Loyal customers')
-    await user.type(screen.getByRole('textbox', {name: 'Key'}), 'audience')
-    await user.type(screen.getByRole('textbox', {name: 'Value'}), 'us')
+    await user.type(screen.getByRole('combobox', {name: 'Key'}), 'audience')
+    await user.type(screen.getByRole('combobox', {name: 'Value'}), 'us')
 
     await waitFor(() => {
       expect(screen.getByRole('button', {name: 'Add condition'})).toBeEnabled()
@@ -117,6 +134,54 @@ describe('CreateVariantDialog', () => {
       expect(screen.queryByTestId('variant-form-condition-key-error')).not.toBeInTheDocument()
       expect(screen.getByTestId('submit-variant-button')).toBeEnabled()
     })
+  })
+
+  it('suggests existing condition keys while typing', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'aud')
+
+    expect(await screen.findByText('audience')).toBeInTheDocument()
+    expect(screen.queryByText('locale')).not.toBeInTheDocument()
+  })
+
+  it('suggests condition values scoped to the selected key', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'loc')
+    await user.click(await screen.findByText('locale'))
+    await waitFor(() => {
+      expect(screen.getByTestId('variant-form-condition-key')).toHaveValue('locale')
+    })
+
+    const openButtons = screen.getAllByRole('button', {name: 'Open'})
+    await user.click(openButtons[1]!)
+
+    expect(await screen.findByText('nb-NO')).toBeInTheDocument()
+    expect(screen.queryByText('alpha')).not.toBeInTheDocument()
+  })
+
+  it('still supports free-text condition keys and values', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-title'), 'Experiment users')
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'experiment')
+    await user.type(screen.getByTestId('variant-form-condition-value'), 'control')
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.createVariant).toHaveBeenCalledTimes(1)
+    })
+
+    const createdVariant = variantOperationsMock.createVariant.mock.calls[0]![0]
+
+    expect(createdVariant.conditions).toEqual({experiment: 'control'})
   })
 
   it('shows a title validation message after the field is touched', async () => {

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
@@ -90,15 +90,25 @@ describe('CreateVariantDialog', () => {
 
     await renderDialog()
 
-    expect(screen.getByTestId('submit-variant-button')).toBeDisabled()
+    expect(screen.getByTestId('submit-variant-button')).toBeEnabled()
 
     await user.type(screen.getByTestId('variant-form-condition-key'), 'audience')
-    await user.type(screen.getByTestId('variant-form-condition-value'), 'loyal-customers')
-    expect(screen.getByTestId('submit-variant-button')).toBeDisabled()
+    expect(screen.queryByTestId('variant-form-condition-value-error')).not.toBeInTheDocument()
 
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    expect(screen.getByTestId('variant-form-title-error')).toHaveTextContent('Title is required')
+    expect(screen.getByTestId('variant-form-condition-value-error')).toHaveTextContent(
+      'Condition value is required',
+    )
+    expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
+
+    await user.type(screen.getByTestId('variant-form-condition-value'), 'loyal-customers')
     await user.type(screen.getByTestId('variant-form-title'), 'Loyal customers')
+    await user.click(screen.getByTestId('submit-variant-button'))
+
     await waitFor(() => {
-      expect(screen.getByTestId('submit-variant-button')).toBeEnabled()
+      expect(variantOperationsMock.createVariant).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -126,13 +136,21 @@ describe('CreateVariantDialog', () => {
     expect(screen.getByTestId('variant-form-condition-key-error')).toHaveTextContent(
       'Condition keys must be unique',
     )
-    expect(screen.getByTestId('submit-variant-button')).toBeDisabled()
+    expect(screen.getByTestId('submit-variant-button')).toBeEnabled()
+
+    await user.click(screen.getByTestId('submit-variant-button'))
+    expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
 
     await user.type(conditionKeys[1]!, '2')
 
     await waitFor(() => {
       expect(screen.queryByTestId('variant-form-condition-key-error')).not.toBeInTheDocument()
-      expect(screen.getByTestId('submit-variant-button')).toBeEnabled()
+    })
+
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.createVariant).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -148,7 +166,10 @@ describe('CreateVariantDialog', () => {
     expect(screen.getByTestId('variant-form-condition-key-error')).toHaveTextContent(
       'Condition keys cannot start with _ or $',
     )
-    expect(screen.getByTestId('submit-variant-button')).toBeDisabled()
+    expect(screen.getByTestId('submit-variant-button')).toBeEnabled()
+
+    await user.click(screen.getByTestId('submit-variant-button'))
+    expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
 
     await user.clear(screen.getByTestId('variant-form-condition-key'))
     await user.type(screen.getByTestId('variant-form-condition-key'), 'Audience')
@@ -156,7 +177,26 @@ describe('CreateVariantDialog', () => {
     expect(screen.getByTestId('variant-form-condition-key-error')).toHaveTextContent(
       'Condition keys must be lowercase, start with a letter, and use letters, numbers, underscores, or hyphens',
     )
-    expect(screen.getByTestId('submit-variant-button')).toBeDisabled()
+
+    await user.click(screen.getByTestId('submit-variant-button'))
+    expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
+  })
+
+  it('requires a condition key before submitting a row with a value', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-title'), 'Loyal customers')
+    await user.type(screen.getByTestId('variant-form-condition-value'), 'loyal-customers')
+    expect(screen.getByTestId('variant-form-condition-key-error')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    expect(screen.getByTestId('variant-form-condition-key-error')).toHaveTextContent(
+      'Condition key is required',
+    )
+    expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
   })
 
   it('suggests existing condition keys while typing', async () => {
@@ -207,15 +247,12 @@ describe('CreateVariantDialog', () => {
     expect(createdVariant.conditions).toEqual({experiment: 'control'})
   })
 
-  it('shows a title validation message after the field is touched', async () => {
+  it('shows a title validation message after submit is attempted', async () => {
     const user = userEvent.setup()
 
     await renderDialog()
 
-    const titleInput = screen.getByTestId('variant-form-title')
-
-    await user.click(titleInput)
-    await user.tab()
+    await user.click(screen.getByTestId('submit-variant-button'))
 
     expect(screen.getByTestId('variant-form-title-error')).toHaveTextContent('Title is required')
   })

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/VariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/VariantDialog.test.tsx
@@ -1,0 +1,125 @@
+import {render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {variantsUsEnglishLocaleBundle} from '../../../i18n'
+import {type EditableSystemVariant} from '../../../types'
+import {getVariantDefaults} from '../../../util/variantDefaults'
+import {VariantDialog} from '../VariantDialog'
+
+const toastMock = vi.hoisted(() => ({
+  push: vi.fn(),
+}))
+
+vi.mock('@sanity/ui', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useToast: vi.fn(() => toastMock),
+}))
+
+describe('VariantDialog', () => {
+  const onCancel = vi.fn()
+  const onSubmit = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    onSubmit.mockResolvedValue(undefined)
+  })
+
+  const renderDialog = async (props?: {
+    initialValue?: EditableSystemVariant
+    renderCancelButton?: boolean
+  }) => {
+    const wrapper = await createTestProvider({
+      resources: [variantsUsEnglishLocaleBundle],
+    })
+    const result = render(
+      <VariantDialog
+        confirmDataTestId="save-variant-button"
+        confirmText="Save"
+        errorTitle="Unable to update variant"
+        header="Edit variant"
+        id="edit-variant-dialog"
+        initialValue={props?.initialValue ?? getVariantDefaults()}
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+        renderCancelButton={props?.renderCancelButton}
+      />,
+      {wrapper},
+    )
+    await screen.findByRole('dialog', {name: 'Edit variant'})
+    return result
+  }
+
+  it('renders a cancel button when renderCancelButton is enabled', async () => {
+    await renderDialog({renderCancelButton: true})
+
+    expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument()
+  })
+
+  it('does not render a cancel button in create mode', async () => {
+    await renderDialog({renderCancelButton: false})
+
+    expect(screen.queryByRole('button', {name: 'Cancel'})).not.toBeInTheDocument()
+  })
+
+  it('calls onCancel when cancel is pressed', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog({renderCancelButton: true})
+
+    await user.click(screen.getByRole('button', {name: 'Cancel'}))
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('calls onCancel when the dialog close button is pressed', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog({renderCancelButton: true})
+
+    await user.click(screen.getByLabelText('Close dialog'))
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('disables submit while the form is invalid', async () => {
+    await renderDialog()
+
+    expect(screen.getByTestId('save-variant-button')).toBeDisabled()
+  })
+
+  it('shows an error toast and keeps the dialog open when submit fails', async () => {
+    const error = new Error('update failed')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    onSubmit.mockRejectedValue(error)
+    const user = userEvent.setup()
+
+    await renderDialog({
+      initialValue: {
+        ...getVariantDefaults(),
+        metadata: {title: 'Alpha audience', description: []},
+        conditions: {audience: 'alpha'},
+      },
+      renderCancelButton: true,
+    })
+
+    await user.click(screen.getByTestId('save-variant-button'))
+
+    await waitFor(() => {
+      expect(toastMock.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          title: 'Unable to update variant',
+        }),
+      )
+    })
+    expect(consoleError).toHaveBeenCalledWith(error)
+    expect(screen.getByRole('dialog', {name: 'Edit variant'})).toBeInTheDocument()
+    expect(onCancel).not.toHaveBeenCalled()
+
+    consoleError.mockRestore()
+  })
+})

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/VariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/VariantDialog.test.tsx
@@ -85,10 +85,17 @@ describe('VariantDialog', () => {
     expect(onSubmit).not.toHaveBeenCalled()
   })
 
-  it('disables submit while the form is invalid', async () => {
+  it('allows submit while the form is invalid and shows validation on click', async () => {
+    const user = userEvent.setup()
+
     await renderDialog()
 
-    expect(screen.getByTestId('save-variant-button')).toBeDisabled()
+    expect(screen.getByTestId('save-variant-button')).toBeEnabled()
+
+    await user.click(screen.getByTestId('save-variant-button'))
+
+    expect(screen.getByTestId('variant-form-title-error')).toHaveTextContent('Title is required')
+    expect(onSubmit).not.toHaveBeenCalled()
   })
 
   it('shows an error toast and keeps the dialog open when submit fails', async () => {

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/conditionSuggestions.test.ts
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/conditionSuggestions.test.ts
@@ -1,0 +1,51 @@
+import {describe, expect, it} from 'vitest'
+
+import {variantAlphaAudience, variantNorwegianMarket} from '../../../__fixtures__/variants.fixture'
+import {
+  filterConditionOption,
+  getConditionKeyOptions,
+  getConditionValueOptions,
+} from '../conditionSuggestions'
+
+describe('conditionSuggestions', () => {
+  const variants = [variantAlphaAudience, variantNorwegianMarket]
+
+  describe('getConditionKeyOptions', () => {
+    it('returns unique sorted condition keys from existing variants', () => {
+      expect(getConditionKeyOptions(variants, [{key: ''}], 0)).toEqual([
+        {value: 'audience'},
+        {value: 'locale'},
+        {value: 'market'},
+      ])
+    })
+
+    it('excludes keys used by other rows while keeping the current row key selectable', () => {
+      const rows = [{key: 'audience'}, {key: 'locale'}]
+
+      expect(getConditionKeyOptions(variants, rows, 0)).toEqual([
+        {value: 'audience'},
+        {value: 'market'},
+      ])
+    })
+  })
+
+  describe('getConditionValueOptions', () => {
+    it('returns unique sorted values for the selected condition key', () => {
+      expect(getConditionValueOptions(variants, 'locale')).toEqual([
+        {value: 'en-US'},
+        {value: 'nb-NO'},
+      ])
+    })
+
+    it('returns no values when the condition key is empty', () => {
+      expect(getConditionValueOptions(variants, '   ')).toEqual([])
+    })
+  })
+
+  describe('filterConditionOption', () => {
+    it('matches options case-insensitively after trimming the query', () => {
+      expect(filterConditionOption('  EN', {value: 'en-US'})).toBe(true)
+      expect(filterConditionOption('fr', {value: 'en-US'})).toBe(false)
+    })
+  })
+})

--- a/packages/sanity/src/core/variants/components/dialog/conditionSuggestions.ts
+++ b/packages/sanity/src/core/variants/components/dialog/conditionSuggestions.ts
@@ -1,0 +1,74 @@
+import {type SystemVariant} from '../../types'
+
+export interface ConditionSuggestionOption {
+  value: string
+}
+
+function toSortedOptions(values: Iterable<string>): ConditionSuggestionOption[] {
+  return Array.from(values)
+    .filter(Boolean)
+    .toSorted((a, b) => a.localeCompare(b))
+    .map((value) => ({value}))
+}
+
+/**
+ * @internal
+ */
+export function getConditionKeyOptions(
+  variants: SystemVariant[],
+  rows: ReadonlyArray<{key: string}>,
+  currentRowIndex: number,
+): ConditionSuggestionOption[] {
+  const usedKeys = new Set(
+    rows
+      .filter((_, index) => index !== currentRowIndex)
+      .map((row) => row.key.trim())
+      .filter(Boolean),
+  )
+  const keys = new Set<string>()
+
+  variants.forEach((variant) => {
+    Object.keys(variant.conditions).forEach((key) => {
+      const trimmedKey = key.trim()
+
+      if (trimmedKey && !usedKeys.has(trimmedKey)) {
+        keys.add(trimmedKey)
+      }
+    })
+  })
+
+  return toSortedOptions(keys)
+}
+
+/**
+ * @internal
+ */
+export function getConditionValueOptions(
+  variants: SystemVariant[],
+  conditionKey: string,
+): ConditionSuggestionOption[] {
+  const key = conditionKey.trim()
+
+  if (!key) {
+    return []
+  }
+
+  const values = new Set<string>()
+
+  variants.forEach((variant) => {
+    const value = variant.conditions[key]?.trim()
+
+    if (value) {
+      values.add(value)
+    }
+  })
+
+  return toSortedOptions(values)
+}
+
+/**
+ * @internal
+ */
+export function filterConditionOption(query: string, option: ConditionSuggestionOption): boolean {
+  return option.value.toLowerCase().includes(query.trim().toLowerCase())
+}

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -58,8 +58,6 @@ const variantsLocaleStrings = {
   'detail.not-found.description': 'The requested variant could not be found.',
   /** Title for the missing Variant detail page. */
   'detail.not-found.title': 'Variant not found',
-  /** Placeholder text on the Variant detail page. */
-  'detail.placeholder': 'Variant detail editing will be added in a future iteration.',
   /** Title for the create variant dialog. */
   'dialog.create.title': 'Create variant',
   /** Confirm action for the create variant dialog. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -38,6 +38,8 @@ const variantsLocaleStrings = {
   'detail.action.edit-variant': 'Edit variant',
   /** Back action on the Variant detail page. */
   'detail.back': 'Back to variants',
+  /** Created status label in the Variant detail footer. */
+  'detail.footer.created': 'Created',
   /** Loading message on the Variant detail page. */
   'detail.loading': 'Loading variant',
   /** Fallback text when a variant has no description. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -88,6 +88,13 @@ const variantsLocaleStrings = {
   'dialog.create.condition-key.label': 'Key',
   /** Validation message when a condition key is repeated. */
   'dialog.create.condition-key.duplicate': 'Condition keys must be unique',
+  /** Validation message when a condition key uses a reserved prefix. */
+  'dialog.create.condition-key.reserved': 'Condition keys cannot start with _ or $',
+  /** Validation message when a condition key has an invalid format. */
+  'dialog.create.condition-key.invalid':
+    'Condition keys must be lowercase, start with a letter, and use letters, numbers, underscores, or hyphens',
+  /** Validation message when a condition value is missing. */
+  'dialog.create.condition-value.required': 'Condition value is required',
   /** Placeholder for the condition key field in the create variant dialog. */
   'dialog.create.condition-key.placeholder': 'e.g. audience',
   /** Label for the condition value field in the create variant dialog. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -93,6 +93,8 @@ const variantsLocaleStrings = {
   /** Validation message when a condition key has an invalid format. */
   'dialog.create.condition-key.invalid':
     'Condition keys must be lowercase, start with a letter, and use letters, numbers, underscores, or hyphens',
+  /** Validation message when a condition key is missing. */
+  'dialog.create.condition-key.required': 'Condition key is required',
   /** Validation message when a condition value is missing. */
   'dialog.create.condition-value.required': 'Condition value is required',
   /** Placeholder for the condition key field in the create variant dialog. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -34,12 +34,24 @@ const variantsLocaleStrings = {
   'overview.table.no-conditions': 'No conditions',
   /** Title for the Variants overview. */
   'overview.title': 'Variants',
+  /** Edit action on the Variant detail page. */
+  'detail.action.edit-variant': 'Edit variant',
   /** Back action on the Variant detail page. */
   'detail.back': 'Back to variants',
   /** Loading message on the Variant detail page. */
   'detail.loading': 'Loading variant',
   /** Fallback text when a variant has no description. */
   'detail.no-description': 'No description yet.',
+  /** Empty state for variant document table. */
+  'detail.documents.no-documents': 'No documents in this variant',
+  /** Edited column header for variant document table. */
+  'detail.documents.table.edited': 'Edited',
+  /** Search placeholder for variant document table. */
+  'detail.documents.table.search-placeholder': 'Search documents',
+  /** Type column header for variant document table. */
+  'detail.documents.table.type': 'Type',
+  /** Version column header for variant document table. */
+  'detail.documents.table.version': 'Version',
   /** Description for the missing Variant detail page. */
   'detail.not-found.description': 'The requested variant could not be found.',
   /** Title for the missing Variant detail page. */
@@ -84,6 +96,14 @@ const variantsLocaleStrings = {
   'dialog.create.condition-value.placeholder': 'e.g. loyal-customers',
   /** Error toast title when variant creation fails. */
   'dialog.create.error.title': 'Unable to create variant',
+  /** Title for the edit variant dialog. */
+  'dialog.edit.title': 'Edit variant',
+  /** Confirm action for the edit variant dialog. */
+  'dialog.edit.action.confirm': 'Save',
+  /** Cancel action for the edit variant dialog. */
+  'dialog.edit.action.cancel': 'Cancel',
+  /** Error toast title when variant editing fails. */
+  'dialog.edit.error.title': 'Unable to update variant',
 }
 
 /**

--- a/packages/sanity/src/core/variants/store/__tests__/createVariantOperationsStore.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/createVariantOperationsStore.test.ts
@@ -1,12 +1,16 @@
+import {type SanityClient} from '@sanity/client'
 import {describe, expect, it, vi} from 'vitest'
 
-import {type EditableSystemVariant} from '../../types'
+import {type EditableSystemVariant, type VariantDefinitionDocument} from '../../types'
 import {VARIANT_DOCUMENTS_PATH} from '../constants'
 import {createVariantOperationsStore} from '../createVariantOperationsStore'
 
+const VARIANT_ID = 'Ab12cd34'
+const DOCUMENT_ID = `${VARIANT_DOCUMENTS_PATH}.${VARIANT_ID}`
+
 function createEditableVariant(): EditableSystemVariant {
   return {
-    _id: `${VARIANT_DOCUMENTS_PATH}.Ab12cd34`,
+    _id: DOCUMENT_ID as `_.variants.${string}`,
     _type: 'system.variant',
     conditions: {audience: 'loyal-customers'},
     priority: 0,
@@ -17,42 +21,66 @@ function createEditableVariant(): EditableSystemVariant {
   }
 }
 
+function createVariantDefinitionDocument(
+  variant: EditableSystemVariant,
+): VariantDefinitionDocument {
+  return {
+    ...variant,
+    name: VARIANT_ID,
+    _rev: 'rev-1',
+    _createdAt: '2026-01-01T00:00:00Z',
+    _updatedAt: '2026-01-01T00:00:00Z',
+  }
+}
+
 describe('createVariantOperationsStore', () => {
-  it('creates a variant document', async () => {
+  it('creates a variant definition with the create action', async () => {
     const variant = createEditableVariant()
+    const persistedVariant = createVariantDefinitionDocument(variant)
     const client = {
-      create: vi.fn().mockResolvedValue(variant),
+      action: vi.fn().mockResolvedValue(persistedVariant),
     }
 
-    const store = createVariantOperationsStore({client: client as never})
+    const store = createVariantOperationsStore({client: client as SanityClient})
 
-    await expect(store.createVariant(variant)).resolves.toEqual(variant)
-    expect(client.create).toHaveBeenCalledWith(variant)
+    await expect(store.createVariant(variant)).resolves.toEqual(persistedVariant)
+    expect(client.action).toHaveBeenCalledWith(
+      {
+        actionType: 'sanity.action.variant.definition.create',
+        variantId: VARIANT_ID,
+        conditions: variant.conditions,
+        priority: variant.priority,
+        metadata: variant.metadata,
+      },
+      {tag: 'variants.create'},
+    )
   })
 
-  it('updates a variant document', async () => {
+  it('updates a variant definition with the edit action', async () => {
     const variant = createEditableVariant()
-    const patch = {
-      set: vi.fn().mockReturnThis(),
-      unset: vi.fn().mockReturnThis(),
-      commit: vi.fn().mockResolvedValue(variant),
-    }
+    const persistedVariant = createVariantDefinitionDocument(variant)
     const client = {
-      patch: vi.fn().mockReturnValue(patch),
+      action: vi.fn().mockResolvedValue(persistedVariant),
     }
 
-    const store = createVariantOperationsStore({client: client as never})
+    const store = createVariantOperationsStore({client: client as SanityClient})
 
-    await expect(store.updateVariant(variant)).resolves.toEqual(variant)
+    await expect(store.updateVariant(variant)).resolves.toEqual(persistedVariant)
 
-    expect(client.patch).toHaveBeenCalledWith(variant._id)
-    expect(patch.set).toHaveBeenCalledWith({
-      conditions: variant.conditions,
-      metadata: variant.metadata,
-      priority: variant.priority,
-    })
-    expect(patch.set).toHaveBeenCalledTimes(1)
-    expect(patch.commit).toHaveBeenCalledTimes(1)
+    expect(client.action).toHaveBeenCalledWith(
+      {
+        actionType: 'sanity.action.variant.definition.edit',
+        variantId: VARIANT_ID,
+        patch: {
+          set: {
+            conditions: variant.conditions,
+            metadata: variant.metadata,
+            priority: variant.priority,
+          },
+        },
+      },
+      {tag: 'variants.edit'},
+    )
   })
 
   it('unsets metadata when updating a variant without metadata', async () => {
@@ -63,33 +91,48 @@ describe('createVariantOperationsStore', () => {
       conditions: variant.conditions,
       priority: variant.priority,
     }
-    const patch = {
-      set: vi.fn().mockReturnThis(),
-      unset: vi.fn().mockReturnThis(),
-      commit: vi.fn().mockResolvedValue(variantWithoutMetadata),
-    }
+    const persistedVariant = createVariantDefinitionDocument(variantWithoutMetadata)
     const client = {
-      patch: vi.fn().mockReturnValue(patch),
+      action: vi.fn().mockResolvedValue(persistedVariant),
     }
 
-    const store = createVariantOperationsStore({client: client as never})
+    const store = createVariantOperationsStore({client: client as SanityClient})
 
-    await expect(store.updateVariant(variantWithoutMetadata)).resolves.toEqual(
-      variantWithoutMetadata,
+    await expect(store.updateVariant(variantWithoutMetadata)).resolves.toEqual(persistedVariant)
+
+    expect(client.action).toHaveBeenCalledWith(
+      {
+        actionType: 'sanity.action.variant.definition.edit',
+        variantId: VARIANT_ID,
+        patch: {
+          set: {
+            conditions: variantWithoutMetadata.conditions,
+            priority: variantWithoutMetadata.priority,
+          },
+          unset: ['metadata'],
+        },
+      },
+      {tag: 'variants.edit'},
     )
-
-    expect(patch.unset).toHaveBeenCalledWith(['metadata'])
   })
 
-  it('deletes a variant document', async () => {
+  it('deletes a variant definition with the delete action', async () => {
+    const variant = createEditableVariant()
+    const persistedVariant = createVariantDefinitionDocument(variant)
     const client = {
-      delete: vi.fn().mockResolvedValue(undefined),
+      action: vi.fn().mockResolvedValue(persistedVariant),
     }
 
-    const store = createVariantOperationsStore({client: client as never})
+    const store = createVariantOperationsStore({client: client as SanityClient})
 
-    await store.deleteVariant(`${VARIANT_DOCUMENTS_PATH}.Ab12cd34`)
+    await expect(store.deleteVariant(DOCUMENT_ID)).resolves.toEqual(persistedVariant)
 
-    expect(client.delete).toHaveBeenCalledWith(`${VARIANT_DOCUMENTS_PATH}.Ab12cd34`)
+    expect(client.action).toHaveBeenCalledWith(
+      {
+        actionType: 'sanity.action.variant.definition.delete',
+        variantId: VARIANT_ID,
+      },
+      {tag: 'variants.delete'},
+    )
   })
 })

--- a/packages/sanity/src/core/variants/store/__tests__/createVariantsStore.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/createVariantsStore.test.ts
@@ -45,6 +45,7 @@ describe('createVariantsStore', () => {
     expect(fetchQuery).toContain('_rev')
     expect(fetchQuery).toContain('_createdAt')
     expect(fetchQuery).toContain('_updatedAt')
+    expect(fetchQuery).toContain('name')
     expect(fetchQuery).toContain('"priority": coalesce(priority, 0)')
     expect(fetchQuery).toContain('| order(_createdAt desc)')
     expect(fetch).toHaveBeenCalledWith(

--- a/packages/sanity/src/core/variants/store/constants.ts
+++ b/packages/sanity/src/core/variants/store/constants.ts
@@ -3,11 +3,10 @@ import {type SourceClientOptions} from '../../config/types'
 // api extractor take issues with 'as const' for literals
 // oxlint-disable-next-line prefer-as-const
 export const VARIANT_DOCUMENT_TYPE: 'system.variant' = 'system.variant'
-// Temporary path for variant document IDs.
-// IDs are built as `${VARIANT_DOCUMENTS_PATH}.<suffix>` (for example, `variants.alpha-audience`).
-// This path will change when variants move under the system namespace.
+// System path for variant definition document IDs.
+// IDs are built as `${VARIANT_DOCUMENTS_PATH}.<suffix>` (for example, `_.variants.Ab12cd34`).
 // oxlint-disable-next-line typescript/prefer-as-const
-export const VARIANT_DOCUMENTS_PATH: 'variants' = 'variants'
+export const VARIANT_DOCUMENTS_PATH: '_.variants' = '_.variants'
 
 /**
  * @internal This is the client options used for the variants studio client, using the `X` API version for now

--- a/packages/sanity/src/core/variants/store/createVariantOperationsStore.ts
+++ b/packages/sanity/src/core/variants/store/createVariantOperationsStore.ts
@@ -1,26 +1,40 @@
 import {type SanityClient} from '@sanity/client'
 
-import {type EditableSystemVariant, type SystemVariant} from '../types'
+import {getVariantId} from '../tool/util'
+import {type EditableSystemVariant, type VariantDefinitionDocument} from '../types'
+import {variantsClient} from './variantsClient'
 
 export interface VariantOperationsStore {
-  createVariant: (variant: EditableSystemVariant) => Promise<SystemVariant>
-  updateVariant: (variant: EditableSystemVariant) => Promise<SystemVariant>
-  deleteVariant: (variantId: string) => Promise<unknown>
+  createVariant: (variant: EditableSystemVariant) => Promise<VariantDefinitionDocument>
+  updateVariant: (variant: EditableSystemVariant) => Promise<VariantDefinitionDocument>
+  deleteVariant: (variantId: string) => Promise<VariantDefinitionDocument>
 }
 
 /**
- * Temporary using the client with direct groq mutations, like create, set, delete...
- * Needs to be updated once we have the variant client actions.
+ * Variant definition writes use the actions API. See ../ACTIONS.md.
  */
 export function createVariantOperationsStore(options: {
   client: SanityClient
 }): VariantOperationsStore {
-  const {client} = options
+  const client = variantsClient(options.client)
 
-  const handleCreateVariant = (variant: EditableSystemVariant) =>
-    client.create(variant) as Promise<SystemVariant>
+  const handleCreateVariant = async (variant: EditableSystemVariant) => {
+    const variantId = getVariantId(variant._id)
+    const action = {
+      actionType: 'sanity.action.variant.definition.create' as const,
+      variantId,
+      conditions: variant.conditions,
+      priority: variant.priority,
+      ...(variant.metadata ? {metadata: variant.metadata} : {}),
+    }
 
-  const handleUpdateVariant = (variant: EditableSystemVariant) => {
+    const document = await client.action(action, {tag: 'variants.create'})
+
+    return document
+  }
+
+  const handleUpdateVariant = async (variant: EditableSystemVariant) => {
+    const variantId = getVariantId(variant._id)
     const setPayload: Pick<EditableSystemVariant, 'conditions' | 'priority'> &
       Partial<Pick<EditableSystemVariant, 'metadata'>> = {
       conditions: variant.conditions,
@@ -31,16 +45,38 @@ export function createVariantOperationsStore(options: {
       setPayload.metadata = variant.metadata
     }
 
-    const patch = client.patch(variant._id).set(setPayload)
-
-    if (!variant.metadata) {
-      patch.unset(['metadata'])
+    const patch: {
+      set: typeof setPayload
+      unset?: ['metadata']
+    } = {
+      set: setPayload,
     }
 
-    return patch.commit() as Promise<SystemVariant>
+    if (!variant.metadata) {
+      patch.unset = ['metadata']
+    }
+
+    const action = {
+      actionType: 'sanity.action.variant.definition.edit' as const,
+      variantId,
+      patch,
+    }
+
+    const document = await client.action(action, {tag: 'variants.edit'})
+
+    return document
   }
 
-  const handleDeleteVariant = (variantId: string) => client.delete(variantId)
+  const handleDeleteVariant = async (variantIdOrDocumentId: string) => {
+    const action = {
+      actionType: 'sanity.action.variant.definition.delete' as const,
+      variantId: getVariantId(variantIdOrDocumentId),
+    }
+
+    const document = await client.action(action, {tag: 'variants.delete'})
+
+    return document
+  }
 
   return {
     createVariant: handleCreateVariant,

--- a/packages/sanity/src/core/variants/store/createVariantsStore.ts
+++ b/packages/sanity/src/core/variants/store/createVariantsStore.ts
@@ -18,6 +18,7 @@ const QUERY_PROJECTION = `{
   _rev,
   _createdAt,
   _updatedAt,
+  name,
   conditions,
   "priority": coalesce(priority, 0),
   metadata,

--- a/packages/sanity/src/core/variants/store/variantsClient.ts
+++ b/packages/sanity/src/core/variants/store/variantsClient.ts
@@ -1,0 +1,70 @@
+import {type Action, type BaseActionOptions, type SanityClient} from '@sanity/client'
+
+import {type EditableSystemVariant, type VariantDefinitionDocument} from '../types'
+
+/**
+ * Variant definition action payloads. See ../ACTIONS.md.
+ *
+ */
+export interface VariantDefinitionCreateAction {
+  actionType: 'sanity.action.variant.definition.create'
+  variantId: string
+  conditions: EditableSystemVariant['conditions']
+  priority?: number
+  metadata?: EditableSystemVariant['metadata']
+}
+
+export interface VariantDefinitionEditAction {
+  actionType: 'sanity.action.variant.definition.edit'
+  variantId: string
+  patch: {
+    set: Pick<EditableSystemVariant, 'conditions' | 'priority'> &
+      Partial<Pick<EditableSystemVariant, 'metadata'>>
+    unset?: ['metadata']
+  }
+  ifRevisionId?: string
+}
+
+export interface VariantDefinitionDeleteAction {
+  actionType: 'sanity.action.variant.definition.delete'
+  variantId: string
+  ifRevisionId?: string
+}
+
+export type VariantDefinitionAction =
+  | VariantDefinitionCreateAction
+  | VariantDefinitionEditAction
+  | VariantDefinitionDeleteAction
+
+/**
+ * Temporary client typing until sanity/client exports variant definition actions.
+ *
+ */
+export interface SanityClientWithVariantsActions extends Omit<SanityClient, 'action'> {
+  action(
+    action: VariantDefinitionAction,
+    options?: BaseActionOptions,
+  ): Promise<VariantDefinitionDocument>
+}
+
+/**
+ * Returns a client whose `action` method accepts variant definition actions.
+ * Remove once sanity/client exports these action types.
+ *
+ */
+export function variantsClient(client: SanityClient): SanityClientWithVariantsActions {
+  const baseAction = (
+    action: VariantDefinitionAction,
+    options?: BaseActionOptions,
+  ): Promise<VariantDefinitionDocument> =>
+    client.action(
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+      action as unknown as Action,
+      options,
+    ) as unknown as Promise<VariantDefinitionDocument>
+
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return Object.assign(Object.create(Object.getPrototypeOf(client) as object), client, {
+    action: baseAction,
+  }) as SanityClientWithVariantsActions
+}

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -2,7 +2,6 @@ import {render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {flushMicrotasksThisIsACodeSmell} from '../../../../../test/testUtils/flushMicrotasks'
 import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
 import {variantAlphaAudience} from '../../__fixtures__/variants.fixture'
 import {variantsUsEnglishLocaleBundle} from '../../i18n'
@@ -69,7 +68,24 @@ describe('VariantDetail', () => {
     variantsMock.loading = false
     variantsMock.error = undefined
     routerState.variantId = undefined
-    variantOperationsMock.updateVariant.mockResolvedValue(undefined)
+    variantOperationsMock.updateVariant.mockImplementation(async (variant) => {
+      const existingVariant = variantsMock.byId.get(variant._id)
+
+      if (!existingVariant) {
+        return variant
+      }
+
+      const updatedVariant: SystemVariant = {
+        ...existingVariant,
+        ...variant,
+        metadata: variant.metadata ?? existingVariant.metadata,
+      }
+
+      variantsMock.byId.set(variant._id, updatedVariant)
+      variantsMock.data = Array.from(variantsMock.byId.values())
+
+      return updatedVariant
+    })
   })
 
   const setVariants = (variants: SystemVariant[]) => {
@@ -82,7 +98,6 @@ describe('VariantDetail', () => {
       resources: [variantsUsEnglishLocaleBundle],
     })
     const result = render(<VariantDetail />, {wrapper})
-    await flushMicrotasksThisIsACodeSmell()
     return result
   }
 
@@ -191,6 +206,10 @@ describe('VariantDetail', () => {
     await waitFor(() => {
       expect(screen.queryByRole('dialog', {name: 'Edit variant'})).not.toBeInTheDocument()
     })
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', {level: 1, name: 'Beta audience'})).toBeInTheDocument()
+    })
   })
 
   it('does not save while condition rows are invalid', async () => {
@@ -228,6 +247,24 @@ describe('VariantDetail', () => {
       expect(screen.queryByRole('dialog', {name: 'Edit variant'})).not.toBeInTheDocument()
     })
     expect(variantOperationsMock.updateVariant).not.toHaveBeenCalled()
+  })
+
+  it('closes the edit dialog without saving when the dialog close button is pressed', async () => {
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderDetail()
+
+    await user.click(screen.getByRole('button', {name: 'Edit variant'}))
+    await user.type(await screen.findByTestId('variant-form-title'), ' updated')
+    await user.click(screen.getByLabelText('Close dialog'))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', {name: 'Edit variant'})).not.toBeInTheDocument()
+    })
+    expect(variantOperationsMock.updateVariant).not.toHaveBeenCalled()
+    expect(screen.getByRole('heading', {level: 1, name: 'Alpha audience'})).toBeInTheDocument()
   })
 
   it('shows a toast and keeps the dialog open when updating fails', async () => {
@@ -278,6 +315,40 @@ describe('VariantDetail', () => {
       expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
       expect(mockNavigate).toHaveBeenCalledWith({})
     })
+  })
+
+  it('shows a toast and stays on the detail page when deletion fails', async () => {
+    const error = new Error('delete failed')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    variantOperationsMock.deleteVariant.mockRejectedValue(error)
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderDetail()
+
+    const menuButton = screen
+      .getAllByRole('button')
+      .find((button) => button.id === 'variant-detail-actions-alpha-audience')
+
+    if (!menuButton) throw new Error('Variant detail actions menu button not found')
+
+    await user.click(menuButton)
+    await user.click(await screen.findByText('Delete variant'))
+
+    await waitFor(() => {
+      expect(toastMock.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          title: 'Unable to delete variant',
+        }),
+      )
+    })
+    expect(consoleError).toHaveBeenCalledWith(error)
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(screen.getByRole('heading', {level: 1, name: 'Alpha audience'})).toBeInTheDocument()
+
+    consoleError.mockRestore()
   })
 
   it('shows not found when variant id does not match any document', async () => {

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -24,6 +24,21 @@ const variantsMock = vi.hoisted(() => ({
   error: undefined as Error | undefined,
 }))
 
+const variantOperationsMock = vi.hoisted(() => ({
+  createVariant: vi.fn(),
+  updateVariant: vi.fn(),
+  deleteVariant: vi.fn(),
+}))
+
+const toastMock = vi.hoisted(() => ({
+  push: vi.fn(),
+}))
+
+vi.mock('@sanity/ui', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useToast: vi.fn(() => toastMock),
+}))
+
 vi.mock('sanity/router', async (importOriginal) => ({
   ...(await importOriginal()),
   useRouter: vi.fn(() => ({
@@ -42,14 +57,19 @@ vi.mock('../../store/useAllVariants', () => ({
   })),
 }))
 
+vi.mock('../../store/useVariantOperations', () => ({
+  useVariantOperations: vi.fn(() => variantOperationsMock),
+}))
+
 describe('VariantDetail', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     variantsMock.data = []
     variantsMock.byId = new Map()
     variantsMock.loading = false
     variantsMock.error = undefined
     routerState.variantId = undefined
-    mockNavigate.mockClear()
+    variantOperationsMock.updateVariant.mockResolvedValue(undefined)
   })
 
   const setVariants = (variants: SystemVariant[]) => {
@@ -75,9 +95,24 @@ describe('VariantDetail', () => {
     expect(screen.getByTestId('loading-block')).toBeInTheDocument()
   })
 
-  it('renders title, description fallback, and placeholder when variant exists', async () => {
+  it('renders title, description, conditions, and edit action when variant exists', async () => {
+    const variantWithDescription: SystemVariant = {
+      ...variantAlphaAudience,
+      metadata: {
+        ...variantAlphaAudience.metadata,
+        description: [
+          {
+            _key: 'description',
+            _type: 'block',
+            children: [{_key: 'span', _type: 'span', marks: [], text: 'Developer audience'}],
+            markDefs: [],
+            style: 'normal',
+          },
+        ],
+      },
+    }
     routerState.variantId = getVariantId(variantAlphaAudience._id)
-    setVariants([variantAlphaAudience])
+    setVariants([variantWithDescription])
 
     await renderDetail()
 
@@ -85,11 +120,140 @@ describe('VariantDetail', () => {
       expect(screen.getByRole('heading', {level: 1, name: 'Alpha audience'})).toBeInTheDocument()
     })
 
-    expect(screen.getByText('No description yet.')).toBeInTheDocument()
-    expect(
-      screen.getByText('Variant detail editing will be added in a future iteration.'),
-    ).toBeInTheDocument()
+    expect(screen.getByText('Developer audience')).toBeInTheDocument()
+    expect(screen.getByText('audience: "alpha", locale: "en-US"')).toBeInTheDocument()
+    expect(screen.getByRole('button', {name: 'Edit variant'})).toBeInTheDocument()
     expect(screen.getByRole('button', {name: 'Back to variants'})).toBeInTheDocument()
+    expect(screen.getByText('Version')).toBeInTheDocument()
+    expect(screen.getByText('Type')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Search documents')).toBeInTheDocument()
+    expect(screen.getByText('Edited')).toBeInTheDocument()
+    expect(screen.getByText('No documents in this variant')).toBeInTheDocument()
+  })
+
+  it('opens the edit dialog with existing variant values', async () => {
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderDetail()
+
+    await user.click(screen.getByRole('button', {name: 'Edit variant'}))
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', {name: 'Edit variant'})).toBeInTheDocument()
+    })
+
+    expect(screen.getByTestId('variant-form-title')).toHaveValue('Alpha audience')
+    expect(screen.getAllByTestId('variant-form-condition-key')).toHaveLength(2)
+    expect(screen.getByTestId('save-variant-button')).toBeEnabled()
+  })
+
+  it('saves edited variant values from the dialog', async () => {
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderDetail()
+
+    await user.click(screen.getByRole('button', {name: 'Edit variant'}))
+    await user.clear(await screen.findByTestId('variant-form-title'))
+    await user.type(screen.getByTestId('variant-form-title'), 'Beta audience')
+    await user.type(screen.getByTestId('variant-form-description'), 'Audience for beta users')
+
+    const conditionValues = screen.getAllByTestId('variant-form-condition-value')
+    await user.clear(conditionValues[0]!)
+    await user.type(conditionValues[0]!, 'beta')
+    await user.click(screen.getByTestId('save-variant-button'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.updateVariant).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conditions: {audience: 'beta', locale: 'en-US'},
+          metadata: expect.objectContaining({
+            title: 'Beta audience',
+            description: [
+              expect.objectContaining({
+                children: [
+                  expect.objectContaining({
+                    text: 'Audience for beta users',
+                  }),
+                ],
+              }),
+            ],
+          }),
+        }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', {name: 'Edit variant'})).not.toBeInTheDocument()
+    })
+  })
+
+  it('does not save while condition rows are invalid', async () => {
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderDetail()
+
+    await user.click(screen.getByRole('button', {name: 'Edit variant'}))
+    const conditionKeys = screen.getAllByTestId('variant-form-condition-key')
+    await user.clear(conditionKeys[1]!)
+    await user.type(conditionKeys[1]!, 'audience')
+
+    expect(screen.getByTestId('variant-form-condition-key-error')).toHaveTextContent(
+      'Condition keys must be unique',
+    )
+
+    expect(screen.getByTestId('save-variant-button')).toBeDisabled()
+    expect(variantOperationsMock.updateVariant).not.toHaveBeenCalled()
+  })
+
+  it('closes the edit dialog without saving when cancel is pressed', async () => {
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderDetail()
+
+    await user.click(screen.getByRole('button', {name: 'Edit variant'}))
+    await user.type(await screen.findByTestId('variant-form-title'), ' updated')
+    await user.click(screen.getByRole('button', {name: 'Cancel'}))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', {name: 'Edit variant'})).not.toBeInTheDocument()
+    })
+    expect(variantOperationsMock.updateVariant).not.toHaveBeenCalled()
+  })
+
+  it('shows a toast and keeps the dialog open when updating fails', async () => {
+    const error = new Error('update failed')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    variantOperationsMock.updateVariant.mockRejectedValue(error)
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderDetail()
+
+    await user.click(screen.getByRole('button', {name: 'Edit variant'}))
+    await user.type(await screen.findByTestId('variant-form-title'), ' updated')
+    await user.click(screen.getByTestId('save-variant-button'))
+
+    await waitFor(() => {
+      expect(toastMock.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          title: 'Unable to update variant',
+        }),
+      )
+    })
+    expect(consoleError).toHaveBeenCalledWith(error)
+    expect(screen.getByRole('dialog', {name: 'Edit variant'})).toBeInTheDocument()
+
+    consoleError.mockRestore()
   })
 
   it('shows not found when variant id does not match any document', async () => {

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -129,6 +129,8 @@ describe('VariantDetail', () => {
     expect(screen.getByPlaceholderText('Search documents')).toBeInTheDocument()
     expect(screen.getByText('Edited')).toBeInTheDocument()
     expect(screen.getByText('No documents in this variant')).toBeInTheDocument()
+    expect(screen.getByText(/^Created/)).toBeInTheDocument()
+    expect(screen.getByTestId('variant-detail-footer-actions')).toBeInTheDocument()
   })
 
   it('opens the edit dialog with existing variant values', async () => {
@@ -254,6 +256,28 @@ describe('VariantDetail', () => {
     expect(screen.getByRole('dialog', {name: 'Edit variant'})).toBeInTheDocument()
 
     consoleError.mockRestore()
+  })
+
+  it('deletes the variant from the footer menu and navigates back to overview', async () => {
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderDetail()
+
+    const menuButton = screen
+      .getAllByRole('button')
+      .find((button) => button.id === 'variant-detail-actions-alpha-audience')
+
+    if (!menuButton) throw new Error('Variant detail actions menu button not found')
+
+    await user.click(menuButton)
+    await user.click(await screen.findByText('Delete variant'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
+      expect(mockNavigate).toHaveBeenCalledWith({})
+    })
   })
 
   it('shows not found when variant id does not match any document', async () => {

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -228,7 +228,8 @@ describe('VariantDetail', () => {
       'Condition keys must be unique',
     )
 
-    expect(screen.getByTestId('save-variant-button')).toBeDisabled()
+    expect(screen.getByTestId('save-variant-button')).toBeEnabled()
+    await user.click(screen.getByTestId('save-variant-button'))
     expect(variantOperationsMock.updateVariant).not.toHaveBeenCalled()
   })
 

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetailMenuButton.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetailMenuButton.test.tsx
@@ -5,12 +5,30 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
 import {variantAlphaAudience} from '../../__fixtures__/variants.fixture'
 import {variantsUsEnglishLocaleBundle} from '../../i18n'
-import {VariantMenuButton} from '../overview/VariantMenuButton'
+import {VariantDetailMenuButton} from '../detail/VariantDetailMenuButton'
+
+const mockNavigate = vi.fn()
 
 const variantOperationsMock = vi.hoisted(() => ({
   createVariant: vi.fn(),
   updateVariant: vi.fn(),
   deleteVariant: vi.fn(),
+}))
+
+const toastMock = vi.hoisted(() => ({
+  push: vi.fn(),
+}))
+
+vi.mock('@sanity/ui', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useToast: vi.fn(() => toastMock),
+}))
+
+vi.mock('sanity/router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRouter: vi.fn(() => ({
+    navigate: mockNavigate,
+  })),
 }))
 
 vi.mock('../../store/useVariantOperations', () => ({
@@ -28,7 +46,7 @@ function createDeferred<T = void>() {
   return {promise, resolve, reject}
 }
 
-describe('VariantMenuButton', () => {
+describe('VariantDetailMenuButton', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     variantOperationsMock.deleteVariant.mockResolvedValue(undefined)
@@ -38,12 +56,12 @@ describe('VariantMenuButton', () => {
     const wrapper = await createTestProvider({
       resources: [variantsUsEnglishLocaleBundle],
     })
-    const result = render(<VariantMenuButton variant={variantAlphaAudience} />, {wrapper})
+    const result = render(<VariantDetailMenuButton variant={variantAlphaAudience} />, {wrapper})
     await screen.findByRole('button')
     return result
   }
 
-  it('deletes the variant when delete is selected', async () => {
+  it('deletes the variant and navigates back to overview when delete is selected', async () => {
     const user = userEvent.setup()
 
     await renderMenuButton()
@@ -53,6 +71,7 @@ describe('VariantMenuButton', () => {
 
     await waitFor(() => {
       expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
+      expect(mockNavigate).toHaveBeenCalledWith({})
     })
   })
 
@@ -77,5 +96,30 @@ describe('VariantMenuButton', () => {
     await waitFor(() => {
       expect(menuButton).toBeEnabled()
     })
+  })
+
+  it('shows a toast and stays on the detail page when deletion fails', async () => {
+    const error = new Error('delete failed')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    variantOperationsMock.deleteVariant.mockRejectedValue(error)
+    const user = userEvent.setup()
+
+    await renderMenuButton()
+
+    await user.click(screen.getByRole('button'))
+    await user.click(await screen.findByText('Delete variant'))
+
+    await waitFor(() => {
+      expect(toastMock.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          title: 'Unable to delete variant',
+        }),
+      )
+    })
+    expect(consoleError).toHaveBeenCalledWith(error)
+    expect(mockNavigate).not.toHaveBeenCalled()
+
+    consoleError.mockRestore()
   })
 })

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -3,7 +3,6 @@ import {userEvent} from '@testing-library/user-event'
 import {type Ref, forwardRef, type HTMLProps} from 'react'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {flushMicrotasksThisIsACodeSmell} from '../../../../../test/testUtils/flushMicrotasks'
 import {setupVirtualListEnv} from '../../../../../test/testUtils/setupVirtualListEnv'
 import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
 import {variantAlphaAudience, variantNorwegianMarket} from '../../__fixtures__/variants.fixture'
@@ -105,7 +104,7 @@ describe('VariantsOverview', () => {
       resources: [variantsUsEnglishLocaleBundle],
     })
     const view = render(<VariantsOverview />, {wrapper})
-    await flushMicrotasksThisIsACodeSmell()
+    await screen.findByPlaceholderText('Search variant definitions…', {}, {timeout: 5000})
     return view
   }
 

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -194,7 +194,13 @@ describe('VariantsOverview', () => {
 
     await waitFor(() => expect(screen.getAllByTestId('table-row')).toHaveLength(1))
 
-    await user.click(within(screen.getAllByTestId('table-row')[0]!).getByRole('button'))
+    const menuButton = screen
+      .getAllByRole('button')
+      .find((button) => button.id === 'variant-actions-alpha-audience')
+
+    if (!menuButton) throw new Error('Variant actions menu button not found')
+
+    await user.click(menuButton)
     await user.click(await screen.findByText('Delete variant'))
   })
 

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsTool.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsTool.test.tsx
@@ -2,7 +2,6 @@ import {render, screen, waitFor} from '@testing-library/react'
 import {forwardRef, type HTMLProps} from 'react'
 import {describe, expect, it, vi} from 'vitest'
 
-import {flushMicrotasksThisIsACodeSmell} from '../../../../../test/testUtils/flushMicrotasks'
 import {setupVirtualListEnv} from '../../../../../test/testUtils/setupVirtualListEnv'
 import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
 import {variantAlphaAudience} from '../../__fixtures__/variants.fixture'
@@ -63,7 +62,6 @@ describe('VariantsTool', () => {
       resources: [variantsUsEnglishLocaleBundle],
     })
     const result = render(<VariantsTool />, {wrapper})
-    await flushMicrotasksThisIsACodeSmell()
     return result
   }
 

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
@@ -1,16 +1,28 @@
-import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
+import {type SanityDocument} from '@sanity/client'
+import {Box, Card, Container, Flex, Stack, Text} from '@sanity/ui'
+import {useState} from 'react'
 import {useRouter} from 'sanity/router'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {LoadingBlock} from '../../../components'
 import {useTranslation} from '../../../i18n'
+import {EditVariantDialog} from '../../components/dialog/EditVariantDialog'
 import {variantsLocaleNamespace} from '../../i18n'
 import {useAllVariants} from '../../store/useAllVariants'
-import {decodeVariantIdFromRoute, getVariantDescription, getVariantTitle} from '../util'
+import {
+  decodeVariantIdFromRoute,
+  getVariantConditionsText,
+  getVariantDescription,
+  getVariantTitle,
+} from '../util'
+import {VariantDocumentsTable} from './VariantDocumentsTable'
+
+const EMPTY_VARIANT_DOCUMENTS: SanityDocument[] = []
 
 export function VariantDetail() {
   const router = useRouter()
   const {t} = useTranslation(variantsLocaleNamespace)
+  const [editDialogOpen, setEditDialogOpen] = useState(false)
   const variantIdRaw =
     typeof router.state.variantId === 'string' ? router.state.variantId : undefined
   const variantId = decodeVariantIdFromRoute(variantIdRaw)
@@ -45,29 +57,54 @@ export function VariantDetail() {
   }
 
   const description = getVariantDescription(variant)
+  const conditionsText = getVariantConditionsText(variant.conditions)
 
   return (
     <Flex direction="column" flex={1} height="fill">
       <Card borderBottom flex="none" padding={3}>
         <Button mode="bleed" onClick={() => router.navigate({})} text={t('detail.back')} />
       </Card>
-      <Box padding={4}>
-        <Card border padding={4} radius={3}>
-          <Stack space={4}>
-            <Stack space={3}>
-              <Text as="h1" size={4} weight="bold">
-                {getVariantTitle(variant)}
-              </Text>
-              <Text muted size={1}>
-                {description || t('detail.no-description')}
-              </Text>
-            </Stack>
-            <Text muted size={1}>
-              {t('detail.placeholder')}
-            </Text>
-          </Stack>
-        </Card>
+      <Container flex="none" width={3}>
+        <Flex direction="column" paddingX={3}>
+          <Card paddingY={5}>
+            <Flex align="flex-start" gap={4} justify="space-between">
+              <Stack space={3}>
+                <Text as="h1" size={4} weight="bold">
+                  {getVariantTitle(variant)}
+                </Text>
+                <Text muted size={1}>
+                  {description || t('detail.no-description')}
+                </Text>
+              </Stack>
+              <Button
+                onClick={() => setEditDialogOpen(true)}
+                text={t('detail.action.edit-variant')}
+              />
+            </Flex>
+
+            <Box paddingTop={4}>
+              <Stack space={2}>
+                <Text size={1} weight="medium">
+                  {t('dialog.create.conditions.title')}
+                </Text>
+                <Text muted size={1}>
+                  {conditionsText || t('overview.table.no-conditions')}
+                </Text>
+              </Stack>
+            </Box>
+          </Card>
+        </Flex>
+      </Container>
+      <Box paddingBottom={4}>
+        <VariantDocumentsTable documents={EMPTY_VARIANT_DOCUMENTS} />
       </Box>
+      {editDialogOpen && (
+        <EditVariantDialog
+          onCancel={() => setEditDialogOpen(false)}
+          onSubmit={() => setEditDialogOpen(false)}
+          variant={variant}
+        />
+      )}
     </Flex>
   )
 }

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
@@ -15,6 +15,7 @@ import {
   getVariantDescription,
   getVariantTitle,
 } from '../util'
+import {VariantDetailFooter} from './VariantDetailFooter'
 import {VariantDocumentsTable} from './VariantDocumentsTable'
 
 const EMPTY_VARIANT_DOCUMENTS: SanityDocument[] = []
@@ -60,44 +61,47 @@ export function VariantDetail() {
   const conditionsText = getVariantConditionsText(variant.conditions)
 
   return (
-    <Flex direction="column" flex={1} height="fill">
+    <Flex direction="column" flex={1} height="fill" overflow="hidden">
       <Card borderBottom flex="none" padding={3}>
         <Button mode="bleed" onClick={() => router.navigate({})} text={t('detail.back')} />
       </Card>
-      <Container flex="none" width={3}>
-        <Flex direction="column" paddingX={3}>
-          <Card paddingY={5}>
-            <Flex align="flex-start" gap={4} justify="space-between">
-              <Stack space={3}>
-                <Text as="h1" size={4} weight="bold">
-                  {getVariantTitle(variant)}
-                </Text>
-                <Text muted size={1}>
-                  {description || t('detail.no-description')}
-                </Text>
-              </Stack>
-              <Button
-                onClick={() => setEditDialogOpen(true)}
-                text={t('detail.action.edit-variant')}
-              />
-            </Flex>
+      <Flex direction="column" flex={1} height="fill" overflow="hidden" style={{minHeight: 0}}>
+        <Container flex="none" width={3}>
+          <Flex direction="column" paddingX={3}>
+            <Card paddingY={5}>
+              <Flex align="flex-start" gap={4} justify="space-between">
+                <Stack space={3}>
+                  <Text as="h1" size={4} weight="bold">
+                    {getVariantTitle(variant)}
+                  </Text>
+                  <Text muted size={1}>
+                    {description || t('detail.no-description')}
+                  </Text>
+                </Stack>
+                <Button
+                  onClick={() => setEditDialogOpen(true)}
+                  text={t('detail.action.edit-variant')}
+                />
+              </Flex>
 
-            <Box paddingTop={4}>
-              <Stack space={2}>
-                <Text size={1} weight="medium">
-                  {t('dialog.create.conditions.title')}
-                </Text>
-                <Text muted size={1}>
-                  {conditionsText || t('overview.table.no-conditions')}
-                </Text>
-              </Stack>
-            </Box>
-          </Card>
+              <Box paddingTop={4}>
+                <Stack space={2}>
+                  <Text size={1} weight="medium">
+                    {t('dialog.create.conditions.title')}
+                  </Text>
+                  <Text muted size={1}>
+                    {conditionsText || t('overview.table.no-conditions')}
+                  </Text>
+                </Stack>
+              </Box>
+            </Card>
+          </Flex>
+        </Container>
+        <Flex direction="column" flex={1} overflow="hidden" style={{minHeight: 0}}>
+          <VariantDocumentsTable documents={EMPTY_VARIANT_DOCUMENTS} />
         </Flex>
-      </Container>
-      <Box paddingBottom={4}>
-        <VariantDocumentsTable documents={EMPTY_VARIANT_DOCUMENTS} />
-      </Box>
+      </Flex>
+      <VariantDetailFooter variant={variant} />
       {editDialogOpen && (
         <EditVariantDialog
           onCancel={() => setEditDialogOpen(false)}

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetailFooter.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetailFooter.tsx
@@ -1,0 +1,38 @@
+import {DiamondIcon} from '@sanity/icons'
+import {Box, Card, Flex, Text} from '@sanity/ui'
+
+import {RelativeTime} from '../../../components'
+import {useTranslation} from '../../../i18n'
+import {variantsLocaleNamespace} from '../../i18n'
+import {type SystemVariant} from '../../types'
+import {VariantDetailMenuButton} from './VariantDetailMenuButton'
+
+export function VariantDetailFooter({variant}: {variant: SystemVariant}): React.JSX.Element {
+  const {t} = useTranslation(variantsLocaleNamespace)
+
+  return (
+    <Card flex="none">
+      <Card borderTop marginX={2} style={{opacity: 0.6}} />
+
+      <Flex padding={3}>
+        <Flex flex={1} gap={1}>
+          <Card>
+            <Flex align="center" gap={2}>
+              <Text size={1}>
+                <DiamondIcon />
+              </Text>
+              <Text muted size={1}>
+                {t('detail.footer.created')}{' '}
+                <RelativeTime time={variant._createdAt} useTemporalPhrase minimal />
+              </Text>
+            </Flex>
+          </Card>
+        </Flex>
+
+        <Flex flex="none" gap={1} data-testid="variant-detail-footer-actions">
+          <VariantDetailMenuButton variant={variant} />
+        </Flex>
+      </Flex>
+    </Card>
+  )
+}

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetailFooter.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetailFooter.tsx
@@ -1,5 +1,5 @@
 import {DiamondIcon} from '@sanity/icons'
-import {Box, Card, Flex, Text} from '@sanity/ui'
+import {Card, Flex, Text} from '@sanity/ui'
 
 import {RelativeTime} from '../../../components'
 import {useTranslation} from '../../../i18n'

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetailMenuButton.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetailMenuButton.tsx
@@ -29,7 +29,7 @@ export function VariantDetailMenuButton({variant}: {variant: SystemVariant}): Re
       toast.push({
         closable: true,
         status: 'error',
-        title: t('overview.action.delete-variant.error'),
+        title: t('overview.action.delete-variant.error.title'),
       })
       setIsDeleting(false)
     }
@@ -42,6 +42,9 @@ export function VariantDetailMenuButton({variant}: {variant: SystemVariant}): Re
       menu={
         <Menu>
           <MenuItem
+            // TODO: This action now doesn't validate the documents count in a variant, once we can
+            // start adding documents to a variant we should revisit this to validate the documents count.
+            // If it has documents we should probably disable the delete action or at least handle it differently.
             disabled={isDeleting}
             onClick={handleDelete}
             text={t('overview.action.delete-variant')}

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetailMenuButton.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetailMenuButton.tsx
@@ -1,0 +1,55 @@
+import {Menu, useToast} from '@sanity/ui'
+import {useCallback, useState} from 'react'
+import {useRouter} from 'sanity/router'
+
+import {MenuButton, MenuItem} from '../../../../ui-components'
+import {ContextMenuButton} from '../../../components/contextMenuButton'
+import {useTranslation} from '../../../i18n'
+import {variantsLocaleNamespace} from '../../i18n'
+import {useVariantOperations} from '../../store/useVariantOperations'
+import {type SystemVariant} from '../../types'
+import {getVariantId} from '../util'
+
+export function VariantDetailMenuButton({variant}: {variant: SystemVariant}): React.JSX.Element {
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const router = useRouter()
+  const toast = useToast()
+  const {deleteVariant} = useVariantOperations()
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const handleDelete = useCallback(async () => {
+    setIsDeleting(true)
+
+    try {
+      await deleteVariant(variant._id)
+      setIsDeleting(false)
+      router.navigate({})
+    } catch (error) {
+      console.error(error)
+      toast.push({
+        closable: true,
+        status: 'error',
+        title: t('overview.action.delete-variant.error'),
+      })
+      setIsDeleting(false)
+    }
+  }, [deleteVariant, router, t, toast, variant._id])
+
+  return (
+    <MenuButton
+      button={<ContextMenuButton disabled={isDeleting} loading={isDeleting} />}
+      id={`variant-detail-actions-${getVariantId(variant._id)}`}
+      menu={
+        <Menu>
+          <MenuItem
+            disabled={isDeleting}
+            onClick={handleDelete}
+            text={t('overview.action.delete-variant')}
+            tone="critical"
+          />
+        </Menu>
+      }
+      popover={{placement: 'bottom-end', portal: true}}
+    />
+  )
+}

--- a/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
@@ -16,7 +16,7 @@ interface VariantDocumentRow {
 }
 
 const TABLE_CARD_STYLE: CSSProperties = {
-  height: 320,
+  height: '100%',
   overflow: 'auto',
 }
 
@@ -149,7 +149,7 @@ export function VariantDocumentsTable({
   const rows = useMemo(() => documents.map((document) => ({document})), [documents])
 
   return (
-    <Card ref={setScrollContainerRef} style={TABLE_CARD_STYLE}>
+    <Card flex={1} ref={setScrollContainerRef} style={TABLE_CARD_STYLE}>
       <Table<VariantDocumentRow>
         columnDefs={columnDefs}
         data={rows}

--- a/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
@@ -1,0 +1,165 @@
+import {type SanityDocument} from '@sanity/client'
+import {Box, Card, Flex, Text} from '@sanity/ui'
+import {type CSSProperties, memo, useMemo, useState} from 'react'
+
+import {RelativeTime} from '../../../components/RelativeTime'
+import {useSchema} from '../../../hooks'
+import {type UseTranslationResponse, useTranslation} from '../../../i18n'
+import {SanityDefaultPreview} from '../../../preview/components/SanityDefaultPreview'
+import {Table} from '../../../releases/tool/components/Table/Table'
+import {Headers} from '../../../releases/tool/components/Table/TableHeader'
+import {type Column} from '../../../releases/tool/components/Table/types'
+import {variantsLocaleNamespace} from '../../i18n'
+
+interface VariantDocumentRow {
+  document: SanityDocument
+}
+
+const TABLE_CARD_STYLE: CSSProperties = {
+  height: 320,
+  overflow: 'auto',
+}
+
+function getDocumentPreviewTitle(document: SanityDocument): string {
+  const title = document.title || document.name
+
+  return typeof title === 'string' && title.trim() ? title : document._id
+}
+
+const MemoDocumentType = memo(
+  function DocumentType({type}: {type: string}) {
+    const schema = useSchema()
+    const schemaType = schema.get(type)
+
+    return <Text size={1}>{schemaType?.title || type}</Text>
+  },
+  (prev, next) => prev.type === next.type,
+)
+
+function getVariantDocumentColumnDefs(
+  t: UseTranslationResponse<'variants', undefined>['t'],
+): Column<VariantDocumentRow>[] {
+  return [
+    {
+      id: 'version',
+      width: null,
+      style: {minWidth: 100},
+      sorting: false,
+      header: (props) => (
+        <Flex {...props.headerProps} paddingY={3} sizing="border">
+          <Headers.BasicHeader text={t('detail.documents.table.version')} />
+        </Flex>
+      ),
+      cell: ({cellProps}) => (
+        <Flex align="center" {...cellProps}>
+          <Box paddingX={2}>
+            <Text muted size={1}>
+              -
+            </Text>
+          </Box>
+        </Flex>
+      ),
+    },
+    {
+      id: 'document._type',
+      width: null,
+      style: {minWidth: 100},
+      sorting: true,
+      header: (props) => (
+        <Flex {...props.headerProps} paddingY={3} sizing="border">
+          <Headers.SortHeaderButton text={t('detail.documents.table.type')} {...props} />
+        </Flex>
+      ),
+      cell: ({cellProps, datum}) => (
+        <Flex align="center" {...cellProps}>
+          <Box paddingX={2}>
+            {!datum.isLoading && <MemoDocumentType type={datum.document._type} />}
+          </Box>
+        </Flex>
+      ),
+    },
+    {
+      id: 'search',
+      width: null,
+      style: {minWidth: 'min(50%, calc(100vw - 80px))', maxWidth: 'min(50%, calc(100vw - 80px))'},
+      sortTransform: ({document}) => getDocumentPreviewTitle(document).toLowerCase(),
+      header: (props) => (
+        <Headers.TableHeaderSearch
+          {...props}
+          placeholder={t('detail.documents.table.search-placeholder')}
+        />
+      ),
+      cell: ({cellProps, datum}) => (
+        <Box {...cellProps} flex={1} padding={1} paddingRight={2} sizing="border">
+          {datum.isLoading ? (
+            <SanityDefaultPreview isPlaceholder />
+          ) : (
+            <SanityDefaultPreview
+              title={getDocumentPreviewTitle(datum.document)}
+              subtitle={datum.document._id}
+            />
+          )}
+        </Box>
+      ),
+    },
+    {
+      id: 'document._updatedAt',
+      sorting: true,
+      width: 130,
+      header: (props) => (
+        <Flex {...props.headerProps} paddingY={3} sizing="border">
+          <Headers.SortHeaderButton text={t('detail.documents.table.edited')} {...props} />
+        </Flex>
+      ),
+      cell: ({cellProps, datum}) => (
+        <Flex {...cellProps} align="center" paddingX={2} paddingY={3} style={{minWidth: 130}}>
+          {!datum.isLoading && datum.document._updatedAt && (
+            <Text muted size={1}>
+              <RelativeTime time={datum.document._updatedAt} useTemporalPhrase minimal />
+            </Text>
+          )}
+        </Flex>
+      ),
+    },
+  ]
+}
+
+function filterDocuments(rows: VariantDocumentRow[], searchTerm: string): VariantDocumentRow[] {
+  const normalizedSearchTerm = searchTerm.trim().toLowerCase()
+
+  if (!normalizedSearchTerm) {
+    return rows
+  }
+
+  return rows.filter(({document}) =>
+    [getDocumentPreviewTitle(document), document._id, document._type].some((value) =>
+      value.toLowerCase().includes(normalizedSearchTerm),
+    ),
+  )
+}
+
+export function VariantDocumentsTable({
+  documents,
+}: {
+  documents: SanityDocument[]
+}): React.JSX.Element {
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(null)
+  const columnDefs = useMemo(() => getVariantDocumentColumnDefs(t), [t])
+  const rows = useMemo(() => documents.map((document) => ({document})), [documents])
+
+  return (
+    <Card ref={setScrollContainerRef} style={TABLE_CARD_STYLE}>
+      <Table<VariantDocumentRow>
+        columnDefs={columnDefs}
+        data={rows}
+        defaultSort={{column: 'search', direction: 'asc'}}
+        emptyState={t('detail.documents.no-documents')}
+        // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals
+        rowId="document._id"
+        scrollContainerRef={scrollContainerRef}
+        searchFilter={filterDocuments}
+      />
+    </Card>
+  )
+}

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
@@ -1,0 +1,88 @@
+import {type SanityDocument} from '@sanity/client'
+import {render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {describe, expect, it, vi} from 'vitest'
+
+import {setupVirtualListEnv} from '../../../../../../test/testUtils/setupVirtualListEnv'
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {variantsUsEnglishLocaleBundle} from '../../../i18n'
+import {VariantDocumentsTable} from '../VariantDocumentsTable'
+
+vi.mock('../../../../preview/components/SanityDefaultPreview', () => ({
+  SanityDefaultPreview: vi.fn(({isPlaceholder, title, subtitle}) => (
+    <div data-testid={isPlaceholder ? 'preview-placeholder' : 'preview'}>
+      {!isPlaceholder && title && <div>{title}</div>}
+      {!isPlaceholder && subtitle && <div>{subtitle}</div>}
+    </div>
+  )),
+}))
+
+setupVirtualListEnv()
+
+const mockDocuments: SanityDocument[] = [
+  {
+    _id: 'drafts.article-first',
+    _type: 'article',
+    _rev: 'rev-1',
+    _createdAt: '2025-01-01T00:00:00Z',
+    _updatedAt: '2025-06-01T00:00:00Z',
+    title: 'First article',
+  },
+  {
+    _id: 'drafts.article-second',
+    _type: 'article',
+    _rev: 'rev-2',
+    _createdAt: '2025-01-02T00:00:00Z',
+    _updatedAt: '2025-06-02T00:00:00Z',
+    title: 'Second article',
+  },
+]
+
+describe('VariantDocumentsTable', () => {
+  const renderTable = async (documents: SanityDocument[] = mockDocuments) => {
+    const wrapper = await createTestProvider({
+      resources: [variantsUsEnglishLocaleBundle],
+    })
+    const result = render(<VariantDocumentsTable documents={documents} />, {wrapper})
+    await screen.findByPlaceholderText('Search documents')
+    return result
+  }
+
+  it('shows an empty state when there are no documents', async () => {
+    await renderTable([])
+
+    expect(screen.getByText('No documents in this variant')).toBeInTheDocument()
+  })
+
+  it('renders document rows with title, type, and edited columns', async () => {
+    await renderTable()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(2)
+    })
+
+    expect(screen.getByText('First article')).toBeInTheDocument()
+    expect(screen.getByText('Second article')).toBeInTheDocument()
+    expect(screen.getByText('drafts.article-first')).toBeInTheDocument()
+    expect(screen.getAllByText('article')).toHaveLength(2)
+  })
+
+  it('filters documents when searching by title, id, or type', async () => {
+    const user = userEvent.setup()
+
+    await renderTable()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(2)
+    })
+
+    await user.type(screen.getByPlaceholderText('Search documents'), 'Second')
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(1)
+    })
+
+    expect(screen.getByText('Second article')).toBeInTheDocument()
+    expect(screen.queryByText('First article')).not.toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/core/variants/types.ts
+++ b/packages/sanity/src/core/variants/types.ts
@@ -5,6 +5,7 @@ import {type VARIANT_DOCUMENT_TYPE, type VARIANT_DOCUMENTS_PATH} from './store/c
 export interface SystemVariant extends SanityDocument {
   _type: typeof VARIANT_DOCUMENT_TYPE
   _id: `${typeof VARIANT_DOCUMENTS_PATH}.${string}`
+  name?: string
   conditions: Record<string, string>
   priority: number // defaults to 0.
   metadata?: {
@@ -12,6 +13,13 @@ export interface SystemVariant extends SanityDocument {
     description?: PortableTextBlock[]
     [key: string]: unknown // <-- Here we can store anything useful for the UI
   }
+}
+
+/**
+ * @internal
+ */
+export interface VariantDefinitionDocument extends SystemVariant {
+  name: string
 }
 
 /**

--- a/packages/sanity/src/core/variants/util/__tests__/conditionValidation.test.ts
+++ b/packages/sanity/src/core/variants/util/__tests__/conditionValidation.test.ts
@@ -1,0 +1,43 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+  getConditionKeyValidationError,
+  getConditionValueValidationError,
+} from '../conditionValidation'
+
+describe('conditionValidation', () => {
+  describe('getConditionKeyValidationError', () => {
+    it('accepts valid lowercase keys', () => {
+      expect(getConditionKeyValidationError('audience')).toBeUndefined()
+      expect(getConditionKeyValidationError('locale_code')).toBeUndefined()
+      expect(getConditionKeyValidationError('tier-1')).toBeUndefined()
+    })
+
+    it('rejects reserved prefixes', () => {
+      expect(getConditionKeyValidationError('_system')).toBe('reserved')
+      expect(getConditionKeyValidationError('$param')).toBe('reserved')
+    })
+
+    it('rejects invalid key formats', () => {
+      expect(getConditionKeyValidationError('Audience')).toBe('invalid')
+      expect(getConditionKeyValidationError('1audience')).toBe('invalid')
+      expect(getConditionKeyValidationError('a'.repeat(65))).toBe('invalid')
+    })
+
+    it('ignores empty keys while editing', () => {
+      expect(getConditionKeyValidationError('')).toBeUndefined()
+      expect(getConditionKeyValidationError('   ')).toBeUndefined()
+    })
+  })
+
+  describe('getConditionValueValidationError', () => {
+    it('accepts non-empty values', () => {
+      expect(getConditionValueValidationError('loyal')).toBeUndefined()
+    })
+
+    it('rejects empty values', () => {
+      expect(getConditionValueValidationError('')).toBe('empty')
+      expect(getConditionValueValidationError('   ')).toBe('empty')
+    })
+  })
+})

--- a/packages/sanity/src/core/variants/util/__tests__/variantDefaults.test.ts
+++ b/packages/sanity/src/core/variants/util/__tests__/variantDefaults.test.ts
@@ -1,0 +1,34 @@
+import {describe, expect, it} from 'vitest'
+
+import {createPortableTextDescription} from '../variantDefaults'
+
+describe('createPortableTextDescription', () => {
+  it('returns an empty array for whitespace-only input', () => {
+    expect(createPortableTextDescription('')).toEqual([])
+    expect(createPortableTextDescription('   ')).toEqual([])
+  })
+
+  it('preserves untrimmed text in the portable text block', () => {
+    const description = createPortableTextDescription('  hello world  ')
+
+    expect(description).toHaveLength(1)
+    expect(description[0]?.children[0]?.text).toBe('  hello world  ')
+  })
+
+  it('creates a single normal block for non-empty input', () => {
+    const description = createPortableTextDescription('Developer audience')
+
+    expect(description).toEqual([
+      expect.objectContaining({
+        _type: 'block',
+        style: 'normal',
+        children: [
+          expect.objectContaining({
+            _type: 'span',
+            text: 'Developer audience',
+          }),
+        ],
+      }),
+    ])
+  })
+})

--- a/packages/sanity/src/core/variants/util/conditionValidation.ts
+++ b/packages/sanity/src/core/variants/util/conditionValidation.ts
@@ -1,0 +1,34 @@
+const CONDITION_KEY_REGEX = /^[a-z][a-z0-9_-]{0,63}$/
+const RESERVED_KEY_PREFIXES = ['_', '$'] as const
+
+export type ConditionKeyValidationError = 'invalid' | 'reserved'
+
+export function getConditionKeyValidationError(
+  key: string,
+): ConditionKeyValidationError | undefined {
+  const trimmedKey = key.trim()
+
+  if (!trimmedKey) {
+    return undefined
+  }
+
+  for (const prefix of RESERVED_KEY_PREFIXES) {
+    if (trimmedKey.startsWith(prefix)) {
+      return 'reserved'
+    }
+  }
+
+  if (!CONDITION_KEY_REGEX.test(trimmedKey)) {
+    return 'invalid'
+  }
+
+  return undefined
+}
+
+export function getConditionValueValidationError(value: string): 'empty' | undefined {
+  if (!value.trim()) {
+    return 'empty'
+  }
+
+  return undefined
+}

--- a/packages/sanity/src/core/variants/util/variantDefaults.ts
+++ b/packages/sanity/src/core/variants/util/variantDefaults.ts
@@ -39,7 +39,7 @@ export function createPortableTextDescription(text: string): PortableTextBlock[]
           _key: randomKey(12),
           _type: 'span',
           marks: [],
-          text: trimmedText,
+          text,
         },
       ],
       markDefs: [],


### PR DESCRIPTION
### Description

Variant definition writes in Studio were still using direct client mutations against a temporary `variants.*` path. The API now exposes dedicated definition actions under `_.variants.*`, with server-side validation and feature/limit checks — Studio now uses those actions.

This PR wires create/edit/delete through the definition actions, moves the document path to `_.variants`, aligns condition key/value validation with the API contract.


### What to review

- **`store/createVariantOperationsStore.ts` + `store/variantsClient.ts`** — action payloads, return types, and the temporary client typing shim
- **`ACTIONS.md`** — does the documented contract match what we're sending?
- **`components/dialog/VariantForm.tsx` + `util/conditionValidation.ts`** — condition validation rules (keys: lowercase/reserved prefix/format; values: non-empty, spaces allowed)
- **`store/constants.ts`** — path change from `variants` → `_.variants` ripples through queries, fixtures, and e2e
- 
### Testing

- Unit tests updated/added for operations store, condition validation, create/edit dialogs.
- E2e coverage in `e2e/tests/variants/variantTool.spec.ts` for create, validation, duplicate keys, autocomplete, and delete flows

### Notes for release

N/A – Part of feature 