### PR TITLE
fix(sanity): incorrect form auto-focus

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -66,6 +66,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
     inspectOpen,
     compareValue,
     hasUpstreamVersion,
+    focusPath,
   } = useDocumentPane()
   const {selectedReleaseId, selectedPerspective} = usePerspective()
   const documentStore = useDocumentStore()
@@ -135,17 +136,25 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
   }, [hasRev])
 
   const [formRef, setFormRef] = useState<null | HTMLDivElement>(null)
+  const [hasFocusedAnyPath, setHasFocusedAnyPath] = useState(false)
 
-  // We only want to run it on first mount
-  const [focusedFirstDescendant, setFocusedFirstDescendant] = useState(false)
   useEffect(() => {
-    // Only focus on the first descendant if there is not already a focus path
-    // This is to avoid stealing focus from intent links
-    if (!focusedFirstDescendant && ready && !formState?.focusPath.length && formRef) {
-      setFocusedFirstDescendant(true)
+    // Only auto-focus if no path has been focused yet.
+    //
+    // This is to avoid stealing focus from intent links, and to prevent
+    // auto-focusing the first descendant after blurring a path that was focused
+    // for any reason (e.g. by this auto-focus mechanism itself, or by
+    // navigating to a deep-link).
+    if (!hasFocusedAnyPath && ready && !formState?.focusPath.length && formRef) {
       focusFirstDescendant(formRef)
     }
-  }, [focusedFirstDescendant, formRef, formState?.focusPath.length, ready])
+  }, [hasFocusedAnyPath, formRef, formState?.focusPath.length, ready])
+
+  useEffect(() => {
+    if (focusPath.length !== 0) {
+      setHasFocusedAnyPath(true)
+    }
+  }, [focusPath])
 
   const setRef = useCallback(
     (node: HTMLDivElement | null) => {

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/__tests__/FormView.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/__tests__/FormView.test.tsx
@@ -1,0 +1,230 @@
+import {focusFirstDescendant} from '@sanity/ui'
+import {render, type RenderResult} from '@testing-library/react'
+import {EMPTY} from 'rxjs'
+import {test as baseTest, describe, expect, type Mock, type MockedFunction, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {useDocumentPane} from '../../../useDocumentPane'
+import {useDocumentTitle} from '../../../useDocumentTitle'
+import {FormView} from '../FormView'
+
+vi.mock('@sanity/ui', async (importOriginal) => {
+  const ui = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...ui,
+    focusFirstDescendant: vi.fn(),
+  }
+})
+
+vi.mock('sanity', async (importOriginal) => {
+  const sanity = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...sanity,
+    useDocumentStore: vi.fn(() => ({
+      pair: {
+        documentEvents: vi.fn(() => EMPTY),
+      },
+    })),
+    useDocumentPresence: vi.fn(() => []),
+    useConditionalToast: vi.fn(),
+  }
+})
+
+vi.mock('../../../useDocumentPane', () => ({
+  useDocumentPane: vi.fn(),
+}))
+
+vi.mock('../../../useDocumentTitle', () => ({
+  useDocumentTitle: vi.fn(() => ({title: 'Test Title'})),
+}))
+
+const mockUseDocumentPane = useDocumentPane as MockedFunction<typeof useDocumentPane>
+const mockUseDocumentTitle = useDocumentTitle as MockedFunction<typeof useDocumentTitle>
+const mockFocusFirstDescendant = focusFirstDescendant as Mock<typeof focusFirstDescendant>
+
+type DocumentPaneValue = ReturnType<typeof useDocumentPane>
+
+function buildDocumentPaneValue(overrides: Partial<DocumentPaneValue> = {}): DocumentPaneValue {
+  return {
+    collapsedFieldSets: undefined,
+    collapsedPaths: undefined,
+    displayed: {_id: 'test-id', _type: 'testType'},
+    editState: {
+      id: 'test-id',
+      type: 'testType',
+      transactionSyncLock: {enabled: false},
+      liveEdit: false,
+      ready: true,
+      draft: null,
+      published: null,
+      version: undefined,
+    },
+    documentId: 'test-id',
+    documentType: 'testType',
+    fieldActions: [],
+    onChange: vi.fn(),
+    validation: [],
+    ready: true,
+    formState: null,
+    onFocus: vi.fn(),
+    connectionState: 'connected',
+    onBlur: vi.fn(),
+    onSetCollapsedPath: vi.fn(),
+    onPathOpen: vi.fn(),
+    onSetCollapsedFieldSet: vi.fn(),
+    onSetActiveFieldGroup: vi.fn(),
+    openPath: [],
+    inspectOpen: false,
+    compareValue: null,
+    hasUpstreamVersion: false,
+    focusPath: [],
+    ...overrides,
+  } as unknown as DocumentPaneValue
+}
+
+interface FormViewFixtures {
+  /**
+   * The mocked `focusFirstDescendant` from `@sanity/ui`. Call history is
+   * cleared before each test and again on teardown.
+   */
+  focusFirstDescendantSpy: Mock<typeof focusFirstDescendant>
+  /**
+   * Configures the mocked `useDocumentPane` to return a document pane value
+   * with the provided overrides applied to a sensible default. A baseline
+   * value is applied before every test, and the mock is fully reset on
+   * teardown.
+   */
+  setDocumentPane: (overrides?: Partial<DocumentPaneValue>) => void
+  /**
+   * Renders the `FormView` under test (with `hidden` set to bypass
+   * `FormBuilder` — the auto-focus effect does not depend on this prop).
+   * Returns the testing-library result with a no-argument `rerender` helper
+   * for repeating the same render with updated mock state. The rendered tree
+   * is unmounted on teardown.
+   */
+  renderFormView: () => RenderResult & {rerender: () => void}
+}
+
+const test = baseTest.extend<FormViewFixtures>({
+  // oxlint-disable-next-line no-empty-pattern
+  focusFirstDescendantSpy: async ({}, consume) => {
+    mockFocusFirstDescendant.mockClear()
+    await consume(mockFocusFirstDescendant)
+    mockFocusFirstDescendant.mockClear()
+  },
+  // oxlint-disable-next-line no-empty-pattern
+  setDocumentPane: async ({}, consume) => {
+    const setDocumentPane = (overrides: Partial<DocumentPaneValue> = {}) => {
+      mockUseDocumentPane.mockReturnValue(buildDocumentPaneValue(overrides))
+    }
+    // Apply a baseline value so tests that render without explicitly
+    // configuring the document pane don't crash on undefined return values.
+    setDocumentPane()
+    await consume(setDocumentPane)
+    mockUseDocumentPane.mockReset()
+  },
+  // oxlint-disable-next-line no-empty-pattern
+  renderFormView: async ({}, consume) => {
+    mockUseDocumentTitle.mockReturnValue({title: 'Test Title'})
+    const wrapper = await createTestProvider()
+    const formViewElement = <FormView hidden margins={[0, 0, 0, 0]} />
+    let rendered: RenderResult | undefined
+
+    const renderFormView = () => {
+      const result = render(formViewElement, {wrapper})
+      rendered = result
+      // Capture the original `rerender` so the wrapper below doesn't recurse
+      // into itself when invoked.
+      const originalRerender = result.rerender
+      return Object.assign(result, {
+        rerender: () => originalRerender(formViewElement),
+      })
+    }
+
+    await consume(renderFormView)
+
+    rendered?.unmount()
+    mockUseDocumentTitle.mockReset()
+  },
+})
+
+describe('FormView', () => {
+  describe('auto-focus behavior', () => {
+    test('auto-focuses the first descendant when no path is focused on mount', ({
+      focusFirstDescendantSpy,
+      setDocumentPane,
+      renderFormView,
+    }) => {
+      setDocumentPane({focusPath: []})
+      renderFormView()
+
+      expect(focusFirstDescendantSpy).toHaveBeenCalledTimes(1)
+    })
+
+    test('does not auto-focus when a path is already focused on mount (deep-link)', ({
+      focusFirstDescendantSpy,
+      setDocumentPane,
+      renderFormView,
+    }) => {
+      setDocumentPane({
+        focusPath: ['title'],
+        formState: {focusPath: ['title']} as DocumentPaneValue['formState'],
+      })
+      renderFormView()
+
+      expect(focusFirstDescendantSpy).not.toHaveBeenCalled()
+    })
+
+    test('does not auto-focus after a deep-linked path is blurred', ({
+      focusFirstDescendantSpy,
+      setDocumentPane,
+      renderFormView,
+    }) => {
+      // Initial render: deep-link focuses a path.
+      setDocumentPane({
+        focusPath: ['title'],
+        formState: {focusPath: ['title']} as DocumentPaneValue['formState'],
+      })
+      const {rerender} = renderFormView()
+
+      expect(focusFirstDescendantSpy).not.toHaveBeenCalled()
+
+      // User blurs the deep-linked path: focusPath becomes empty. Auto-focus
+      // must NOT run, because the user already had a focused path.
+      setDocumentPane({
+        focusPath: [],
+        formState: {focusPath: []} as DocumentPaneValue['formState'],
+      })
+      rerender()
+
+      expect(focusFirstDescendantSpy).not.toHaveBeenCalled()
+    })
+
+    test('does not auto-focus again after an initially auto-focused path is blurred', ({
+      focusFirstDescendantSpy,
+      setDocumentPane,
+      renderFormView,
+    }) => {
+      // Initial render: no focused path, so auto-focus kicks in.
+      setDocumentPane({focusPath: []})
+      const {rerender} = renderFormView()
+
+      expect(focusFirstDescendantSpy).toHaveBeenCalledTimes(1)
+
+      // Simulate a path getting focused (e.g. by the auto-focus mechanism, or
+      // by the user).
+      setDocumentPane({
+        focusPath: ['title'],
+        formState: {focusPath: ['title']} as DocumentPaneValue['formState'],
+      })
+      rerender()
+
+      // The user blurs the path: focusPath becomes empty again. Auto-focus
+      // must not run a second time.
+      setDocumentPane({focusPath: []})
+      rerender()
+
+      expect(focusFirstDescendantSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+})


### PR DESCRIPTION
### Description

This branch completes the fix for the issues reported in SAPP-3679.

Studio previously failed to acknowledge form focus had already been set after navigating to a deep-link (a URL containing the `path` parameter).

This caused Studio to incorrectly apply its auto-focus mechanism after a user blurred the path they had navigated to, focusing the first form descendant, and causing the browser to scroll it into view.

Studio now correctly observes focus has been given to an input by virtue of navigating to a deep-link, and skips its auto-focus mechanism after that path has been blurred.

#### Before
https://github.com/user-attachments/assets/8b9181c4-6103-4403-9dec-82acd6bbecdc
`https://test-studio-git-main.sanity.dev/test/structure/input-standard;portable-text;pt_allTheBellsAndWhistles;48b5b4fb-72ec-449d-9c79-513298a433a9%2Cpath%3Dbody%255B_key%253D%253D%25225ce0d5a67df1%2522%255D.markDefs%255B_key%253D%253D%2522683ca5f4940a%2522%255D`

#### After
https://github.com/user-attachments/assets/7721c200-5e1c-4721-9345-1242b83e2c57
`https://test-studio-iwqlylpfj.sanity.dev/test/structure/input-standard;portable-text;pt_allTheBellsAndWhistles;48b5b4fb-72ec-449d-9c79-513298a433a9%2Cpath%3Dbody%255B_key%253D%253D%25225ce0d5a67df1%2522%255D.markDefs%255B_key%253D%253D%2522683ca5f4940a%2522%255D`

### What to review

Auto-focusing behaviour in the document editor when a deep-link is and isn't used.

### Testing

Verified in Test Studio, and added unit tests.

### Notes for release

Fixes an issue causing the document editor to unexpectedly scroll to the top in certain circumstances after entering Studio using a deep-link.