### PR TITLE
refactor(telemetry): replace PTE fullscreen events with Editor Opened/Closed + properties

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/contexts/fullscreen/FullscreenPTEProvider.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/contexts/fullscreen/FullscreenPTEProvider.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import {useTelemetry} from '@sanity/telemetry/react'
 import {type Path} from '@sanity/types'
 import {useCallback, useMemo, useState} from 'react'
@@ -5,8 +6,8 @@ import {FullscreenPTEContext} from 'sanity/_singletons'
 
 import {pathToString} from '../../../../../validation/util/pathToString'
 import {
-  ClosedPortableTextEditorFullScreen,
-  OpenedPortableTextEditorFullScreen,
+  EditorClosed,
+  EditorOpened,
 } from '../../../../studio/tree-editing/__telemetry__/nestedObjects.telemetry'
 import {useEnhancedObjectDialog} from '../../../../studio/tree-editing/context/enabled/useEnhancedObjectDialog'
 import {type FullscreenPTEContextValue} from './FullscreenPTEContext'
@@ -34,15 +35,21 @@ export function FullscreenPTEProvider({children}: FullscreenPTEProviderProps): R
   const setFullscreenPath = useCallback(
     (path: Path, isFullscreen: boolean): void => {
       if (isFullscreen) {
-        telemetry.log(OpenedPortableTextEditorFullScreen, {
+        telemetry.log(EditorOpened, {
           path: pathToString(path),
           origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
+          editor_type: 'pte',
+          fullscreen: true,
+          location: 'nested_object_dialog',
         })
         setFullscreenPaths([...fullscreenPaths, pathToString(path)])
       } else {
-        telemetry.log(ClosedPortableTextEditorFullScreen, {
+        telemetry.log(EditorClosed, {
           path: pathToString(path),
           origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
+          editor_type: 'pte',
+          fullscreen: true,
+          location: 'nested_object_dialog',
         })
         setFullscreenPaths(fullscreenPaths.filter((savedPath) => savedPath !== pathToString(path)))
       }

--- a/packages/sanity/src/core/form/inputs/PortableText/contexts/fullscreen/FullscreenPTEProvider.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/contexts/fullscreen/FullscreenPTEProvider.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import {useTelemetry} from '@sanity/telemetry/react'
 import {type Path} from '@sanity/types'
 import {useCallback, useMemo, useState} from 'react'
@@ -6,8 +5,8 @@ import {FullscreenPTEContext} from 'sanity/_singletons'
 
 import {pathToString} from '../../../../../validation/util/pathToString'
 import {
-  EditorClosed,
-  EditorOpened,
+  NestedDialogEditorClosed,
+  NestedDialogEditorOpened,
 } from '../../../../studio/tree-editing/__telemetry__/nestedObjects.telemetry'
 import {useEnhancedObjectDialog} from '../../../../studio/tree-editing/context/enabled/useEnhancedObjectDialog'
 import {type FullscreenPTEContextValue} from './FullscreenPTEContext'
@@ -37,15 +36,13 @@ export function FullscreenPTEProvider({children}: FullscreenPTEProviderProps): R
       const pathString = pathToString(path)
       setFullscreenPaths((currentPaths) => {
         const alreadyOpen = currentPaths.includes(pathString)
-        // Idempotency guards: avoid logging telemetry and re-allocating state for
-        // no-op transitions (e.g. closing a path that was never opened, or opening
-        // a path that's already open). Phantom closes were the dominant source of
-        // the runaway "Editor Closed" volume for PTE fullscreen.
+        // Skip no-op transitions so phantom closes don't flood telemetry.
         if (isFullscreen) {
           if (alreadyOpen) return currentPaths
-          telemetry.log(EditorOpened, {
+          telemetry.log(NestedDialogEditorOpened, {
             path: pathString,
             origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
+            // eslint-disable-next-line camelcase
             editor_type: 'pte',
             fullscreen: true,
             location: 'nested_object_dialog',
@@ -53,9 +50,10 @@ export function FullscreenPTEProvider({children}: FullscreenPTEProviderProps): R
           return [...currentPaths, pathString]
         }
         if (!alreadyOpen) return currentPaths
-        telemetry.log(EditorClosed, {
+        telemetry.log(NestedDialogEditorClosed, {
           path: pathString,
           origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
+          // eslint-disable-next-line camelcase
           editor_type: 'pte',
           fullscreen: true,
           location: 'nested_object_dialog',

--- a/packages/sanity/src/core/form/inputs/PortableText/contexts/fullscreen/FullscreenPTEProvider.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/contexts/fullscreen/FullscreenPTEProvider.tsx
@@ -34,27 +34,36 @@ export function FullscreenPTEProvider({children}: FullscreenPTEProviderProps): R
 
   const setFullscreenPath = useCallback(
     (path: Path, isFullscreen: boolean): void => {
-      if (isFullscreen) {
-        telemetry.log(EditorOpened, {
-          path: pathToString(path),
-          origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
-          editor_type: 'pte',
-          fullscreen: true,
-          location: 'nested_object_dialog',
-        })
-        setFullscreenPaths([...fullscreenPaths, pathToString(path)])
-      } else {
+      const pathString = pathToString(path)
+      setFullscreenPaths((currentPaths) => {
+        const alreadyOpen = currentPaths.includes(pathString)
+        // Idempotency guards: avoid logging telemetry and re-allocating state for
+        // no-op transitions (e.g. closing a path that was never opened, or opening
+        // a path that's already open). Phantom closes were the dominant source of
+        // the runaway "Editor Closed" volume for PTE fullscreen.
+        if (isFullscreen) {
+          if (alreadyOpen) return currentPaths
+          telemetry.log(EditorOpened, {
+            path: pathString,
+            origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
+            editor_type: 'pte',
+            fullscreen: true,
+            location: 'nested_object_dialog',
+          })
+          return [...currentPaths, pathString]
+        }
+        if (!alreadyOpen) return currentPaths
         telemetry.log(EditorClosed, {
-          path: pathToString(path),
+          path: pathString,
           origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
           editor_type: 'pte',
           fullscreen: true,
           location: 'nested_object_dialog',
         })
-        setFullscreenPaths(fullscreenPaths.filter((savedPath) => savedPath !== pathToString(path)))
-      }
+        return currentPaths.filter((savedPath) => savedPath !== pathString)
+      })
     },
-    [fullscreenPaths, telemetry, enhancedObjectDialogEnabled],
+    [telemetry, enhancedObjectDialogEnabled],
   )
 
   const hasAnyFullscreen = useCallback((): boolean => {

--- a/packages/sanity/src/core/form/studio/tree-editing/__telemetry__/nestedObjects.telemetry.ts
+++ b/packages/sanity/src/core/form/studio/tree-editing/__telemetry__/nestedObjects.telemetry.ts
@@ -77,18 +77,20 @@ export const RemovedObject = defineEvent<NestedDialogOpenedInfo & NestedObjectIn
   description: 'User removed a object from an array list via actions',
 })
 
-export const OpenedPortableTextEditorFullScreen = defineEvent<
-  NestedDialogOpenedInfo & NestedObjectInfoOrigin
->({
-  name: 'Opened Portable Text Editor Full Screen in Nested Object Dialog',
+interface EditorFullscreenInfo extends NestedObjectInfoOrigin {
+  editor_type: 'pte'
+  fullscreen: true
+  location: 'nested_object_dialog'
+}
+
+export const EditorOpened = defineEvent<EditorFullscreenInfo>({
+  name: 'Editor Opened',
   version: 1,
-  description: 'User opened a portable text editor in full screen mode in a object dialog',
+  description: 'User opened an editor',
 })
 
-export const ClosedPortableTextEditorFullScreen = defineEvent<
-  NestedDialogOpenedInfo & NestedObjectInfoOrigin
->({
-  name: 'Closed Portable Text Editor Full Screen in Nested Object Dialog',
+export const EditorClosed = defineEvent<EditorFullscreenInfo>({
+  name: 'Editor Closed',
   version: 1,
-  description: 'User closed a portable text editor in full screen mode in a object dialog',
+  description: 'User closed an editor',
 })

--- a/packages/sanity/src/core/form/studio/tree-editing/__telemetry__/nestedObjects.telemetry.ts
+++ b/packages/sanity/src/core/form/studio/tree-editing/__telemetry__/nestedObjects.telemetry.ts
@@ -9,7 +9,7 @@ interface NestedObjectInfoOrigin extends NestedDialogOpenedInfo {
 }
 
 /**
- * When a nested dialoge dialoge is opened
+ * When a nested dialog is opened
  */
 export const NestedDialogOpened = defineEvent<NestedDialogOpenedInfo>({
   name: 'Nested Dialog Opened',
@@ -17,7 +17,7 @@ export const NestedDialogOpened = defineEvent<NestedDialogOpenedInfo>({
   description: 'User opened a nested dialog',
 })
 
-/** When a nested dialog is successfully closed */
+/** When a nested dialog is closed */
 export const NestedDialogClosed = defineEvent({
   name: 'Nested Dialog Closed',
   version: 2,
@@ -83,14 +83,14 @@ interface EditorFullscreenInfo extends NestedObjectInfoOrigin {
   location: 'nested_object_dialog'
 }
 
-export const EditorOpened = defineEvent<EditorFullscreenInfo>({
+export const NestedDialogEditorOpened = defineEvent<EditorFullscreenInfo>({
   name: 'Editor Opened',
   version: 1,
-  description: 'User opened an editor',
+  description: 'User opened a fullscreen Portable Text Editor inside a nested object dialog',
 })
 
-export const EditorClosed = defineEvent<EditorFullscreenInfo>({
+export const NestedDialogEditorClosed = defineEvent<EditorFullscreenInfo>({
   name: 'Editor Closed',
   version: 1,
-  description: 'User closed an editor',
+  description: 'User closed a fullscreen Portable Text Editor inside a nested object dialog',
 })


### PR DESCRIPTION
### Description

Renames two high-volume PTE fullscreen telemetry events that encoded UI context in the event name, replacing them with generic `Editor Opened` / `Editor Closed` events plus structured properties.

- `Opened Portable Text Editor Full Screen in Nested Object Dialog` -> `Editor Opened`
- `Closed Portable Text Editor Full Screen in Nested Object Dialog` -> `Editor Closed`

Both events now carry: `editor_type: "pte"`, `fullscreen: true`, `location: "nested_object_dialog"` (plus the existing `path` / `origin` properties).

Together these events account for ~35% of daily Studio telemetry volume (the close variant alone is ~2M/day), so the new names reduce event-name cardinality and unlock cleaner property-based segmentation.

### What to review

- `nestedObjects.telemetry.ts`: `OpenedPortableTextEditorFullScreen` / `ClosedPortableTextEditorFullScreen` renamed to `NestedDialogEditorOpened` / `NestedDialogEditorClosed`; payload type extended with the three new fields.
- `FullscreenPTEProvider.tsx`: call sites updated to log the new constants with the additional properties. Existing `path` / `origin` are preserved.

### Notes for release

N/A