### PR TITLE
refactor(telemetry): rename Canvas Opened from studio event to Canvas Opened

### DIFF
--- a/packages/sanity/src/core/canvas/__telemetry__/canvas.telemetry.ts
+++ b/packages/sanity/src/core/canvas/__telemetry__/canvas.telemetry.ts
@@ -46,8 +46,8 @@ export const CanvasUnlinkApproved = defineEvent({
 })
 
 export type OpenCanvasOrigin = 'action' | 'banner'
-export const CanvasOpened = defineEvent<{origin: OpenCanvasOrigin}>({
-  name: 'Canvas Opened from studio',
+export const CanvasOpened = defineEvent<{origin: OpenCanvasOrigin; source: 'studio'}>({
+  name: 'Canvas Opened',
   version: 1,
   description: 'User clicked "Edit in Canvas"',
 })

--- a/packages/sanity/src/core/canvas/useCanvasTelemetry.ts
+++ b/packages/sanity/src/core/canvas/useCanvasTelemetry.ts
@@ -47,7 +47,7 @@ export function useCanvasTelemetry(): CanvasTelemetryHookValue {
         telemetry.log(CanvasLinkDialogRejected, {diffs: getDiffTypesCount(diffs)}),
       unlinkCtaClicked: () => telemetry.log(CanvasUnlinkCtaClicked),
       unlinkApproved: () => telemetry.log(CanvasUnlinkApproved),
-      canvasOpened: (origin) => telemetry.log(CanvasOpened, {origin}),
+      canvasOpened: (origin) => telemetry.log(CanvasOpened, {origin, source: 'studio'}),
     }),
     [telemetry],
   )


### PR DESCRIPTION
### Description

Studio telemetry currently fires `Canvas Opened from studio`, baking the source context into the event name. The March 2026 telemetry audit (SAPP-3818) flagged this alongside two CLI-side events.

This PR renames the event to `Canvas Opened` and adds a `source: 'studio'` property so analytics keeps the dimension. The Manifest and Schema events from SAPP-3818 live in the separate `sanity-io/cli` repo and are tracked separately in SAPP-3865.

### What to review

- `packages/sanity/src/core/canvas/__telemetry__/canvas.telemetry.ts` - event name and payload type
- `packages/sanity/src/core/canvas/useCanvasTelemetry.ts` - call site passes `source: 'studio'`

### Testing

`pnpm chore:format:fix`, `pnpm chore:oxlint:fix`, `pnpm lint:fix`, and `pnpm check:types` all clean.

### Notes for release

N/A