### PR TITLE
fix(presentation): avoid iframe reload on perspective switch

### DIFF
--- a/packages/sanity/src/presentation/PostMessagePerspective.tsx
+++ b/packages/sanity/src/presentation/PostMessagePerspective.tsx
@@ -1,22 +1,25 @@
 import {type ClientPerspective} from '@sanity/client'
-import {type FC, memo, useEffect} from 'react'
+import {type FC, memo, startTransition, useEffect} from 'react'
 
 import {type VisualEditingConnection} from './types'
 
 export interface PostMessagePerspectiveProps {
   comlink: VisualEditingConnection
   perspective: ClientPerspective
+  setHandlesPerspectiveChange: (payload: boolean) => void
 }
 
 const PostMessagePerspective: FC<PostMessagePerspectiveProps> = (props) => {
-  const {comlink, perspective} = props
+  const {comlink, perspective, setHandlesPerspectiveChange} = props
 
   // Return the perspective when requested
   useEffect(() => {
-    return comlink.on('visual-editing/fetch-perspective', () => ({
-      perspective,
-    }))
-  }, [comlink, perspective])
+    return comlink.on('visual-editing/fetch-perspective', (payload) => {
+      // Report back whether the visual editing handler is set up to own perspective switching or not, if the payload is `undefined` then it means the visual editing instance isn't recent enough and we treat it as false
+      startTransition(() => setHandlesPerspectiveChange(payload?.handlesPerspectiveChange === true))
+      return {perspective}
+    })
+  }, [comlink, perspective, setHandlesPerspectiveChange])
 
   // Dispatch a perspective message when the perspective changes
   useEffect(() => {

--- a/packages/sanity/src/presentation/PresentationTool.tsx
+++ b/packages/sanity/src/presentation/PresentationTool.tsx
@@ -170,6 +170,9 @@ export default function PresentationTool(props: {
   const [overlaysConnection, setOverlaysConnection] = useStatus()
   const [loadersConnection, setLoadersConnection] = useStatus()
   const [previewKitConnection, setPreviewKitConnection] = useStatus()
+  const [_handlesPerspectiveChange, setHandlesPerspectiveChange] = useState(false)
+  // Loaders also handle perspective changes, and for legacy reasons we also consider them as a valid handler
+  const handlesPerspectiveChange = _handlesPerspectiveChange || loadersConnection === 'connected'
 
   const {open: handleOpenPopup} = usePopups(controller)
 
@@ -568,6 +571,7 @@ export default function PresentationTool(props: {
                           vercelProtectionBypass={vercelProtectionBypass}
                           presentationRef={presentationRef}
                           previewUrlRef={previewUrlRef}
+                          handlesPerspectiveChange={handlesPerspectiveChange}
                         />
                       </BoundaryElementProvider>
                     </Flex>
@@ -625,7 +629,11 @@ export default function PresentationTool(props: {
         )}
         {visualEditingComlink && <PostMessageFeatures comlink={visualEditingComlink} />}
         {visualEditingComlink && (
-          <PostMessagePerspective comlink={visualEditingComlink} perspective={perspective} />
+          <PostMessagePerspective
+            comlink={visualEditingComlink}
+            perspective={perspective}
+            setHandlesPerspectiveChange={setHandlesPerspectiveChange}
+          />
         )}
         {visualEditingComlink && <PostMessageTelemetry comlink={visualEditingComlink} />}
       </Suspense>

--- a/packages/sanity/src/presentation/preview/Preview.tsx
+++ b/packages/sanity/src/presentation/preview/Preview.tsx
@@ -83,6 +83,7 @@ export interface PreviewProps {
   viewport: PresentationViewport
   vercelProtectionBypass: string | null
   previewUrlRef: PreviewUrlRef
+  handlesPerspectiveChange: boolean
 }
 
 export const Preview = memo(
@@ -97,6 +98,7 @@ export const Preview = memo(
       vercelProtectionBypass,
       presentationRef,
       previewUrlRef,
+      handlesPerspectiveChange,
     } = props
 
     const [stablePerspective, setStablePerspective] = useState<typeof perspective | null>(null)
@@ -105,10 +107,11 @@ export const Preview = memo(
     )
     const previewUrl = useMemo(() => {
       const url = new URL(initialUrl)
-      // Always set the current perspective, overwriting any stale value that may
-      // have been baked into the resolved preview-mode URL at mount time (e.g.
-      // when a Content Agent document lives in a release but the initial
-      // perspective was "drafts").
+
+      // Always set the perspective, even if it's provided in the initial URL.
+      // The perspective can change over time, even in the brief time between the iframe starting to load,
+      // and a comlink node connecting to the iframe and reporting whether perspective switching is handled by the preview,
+      // or if perspective switching should reload the iframe.
       url.searchParams.set(urlSearchParamPreviewPerspective, urlPerspective)
 
       if (vercelProtectionBypass || url.searchParams.get(urlSearchParamVercelProtectionBypass)) {
@@ -128,15 +131,18 @@ export const Preview = memo(
 
     useEffect(() => {
       /**
-       * If the preview iframe is connected to the loader, we know that switching the perspective can be done without reloading the iframe.
+       * Once we know the preview can handle perspective changes in-place — either because the iframe reported it
+       * over comlink, or because a loader is connected (legacy fallback) — we capture the perspective that was used
+       * to load the preview, so `src` on `iframe` no longer changes when the perspective changes. Otherwise the
+       * iframe would do a full page reload, which is what we're trying to avoid unless absolutely necessary.
        */
-      if (loadersConnection === 'connected') {
+      if (handlesPerspectiveChange) {
         /**
          * Only set the stable perspective if it hasn't been set yet.
          */
         setStablePerspective((prev) => (prev === null ? perspective : prev))
       }
-    }, [loadersConnection, perspective])
+    }, [handlesPerspectiveChange, perspective])
 
     const {t} = useTranslation(presentationLocaleNamespace)
     const {devMode} = usePresentationTool()


### PR DESCRIPTION
### Description

Fixes a regression introduced by #12671 that caused the preview iframe to do a full page reload every time the perspective changed in Presentation. Mostly visible to `next-sanity@13` users relying on visual editing — users on `next-sanity@12` or earlier, integrations built on `@sanity/react-loader` or `@sanity/core-loader`, and `next-sanity@13` setups using the `usePresentationQuery` hook are not affected. Nevertheless, for those who _are_ affected it's super annoying.

Affected users on `next-sanity@13` should also bump to `next-sanity@^13.0.5` or later to pick up the matching client-side fix.

The Studio now negotiates over comlink whether the preview can switch perspective in-place; if it can, we stop rewriting the iframe `src` on perspective changes. Loaders are still treated as valid handlers for legacy compatibility. The capability state is intentionally sticky across transient comlink disconnects (HMR, brief navigation) so we don't flip back to URL-driven perspective during the reconnect gap and re-trigger the very reload we're trying to avoid.

#### Before

Repro: https://test-studio.sanity.dev/presentation-next-sanity/presentation/?preview=https%3A//next.sanity.dev/only-visual-editing%3Fsanity-preview-perspective%3Ddrafts

https://github.com/user-attachments/assets/c34bb97e-a57c-44c6-9dd1-d6de4e834062

#### After

Repro: https://test-studio-git-fix-presentation-perspective-switching.sanity.dev/presentation-next-sanity/presentation?preview=https%3A//next.sanity.dev/only-visual-editing

https://github.com/user-attachments/assets/26a9c46f-bcba-49b0-9c93-df88d309d13d

### What to review

- `packages/sanity/src/presentation/preview/Preview.tsx` — `urlPerspective` is always written so the initial iframe load is correct, but once the iframe reports it handles perspective in-place we capture a stable perspective so `iframe.src` no longer changes.
- `packages/sanity/src/presentation/PresentationTool.tsx` — sticky `_handlesPerspectiveChange` state, OR'd with `loadersConnection` for legacy handlers. The non-reset on comlink teardown is intentional (we assume the node will reconnect and re-report; resetting would briefly flip back to URL-driven perspective and undo the fix).
- `packages/sanity/src/presentation/PostMessagePerspective.tsx` — capability negotiation via the `visual-editing/fetch-perspective` payload; an `undefined` payload means the visual editing instance isn't recent enough and is treated as no-support.

### Testing

Verified manually against the before/after repros above (videos embedded). No automated tests added — the behavior depends on a comlink handshake against a live `next-sanity` preview, which the studio test suite doesn't currently exercise.

### Notes for release

Fixes a regression where switching the perspective in the Presentation tool caused the preview iframe to do a full page reload. Mainly visible to `next-sanity@13` users with visual editing enabled. Users on `next-sanity@12` or earlier, integrations built on `@sanity/react-loader` or `@sanity/core-loader`, and `next-sanity@13` setups using the `usePresentationQuery` hook were not affected.

Affected users on `next-sanity@13` should also bump to `next-sanity@^13.0.5` or later to pick up the matching client-side fix.