### PR TITLE
fix(presentation): handle agent bundle perspectives correctly

### DIFF
--- a/dev/test-studio/preview/main.tsx
+++ b/dev/test-studio/preview/main.tsx
@@ -1,4 +1,5 @@
-import {Box, Flex, studioTheme, Tab, TabList, TabPanel, ThemeProvider} from '@sanity/ui'
+import {type ClientPerspective} from '@sanity/client'
+import {Box, Card, Flex, Text, studioTheme, Tab, TabList, TabPanel, ThemeProvider} from '@sanity/ui'
 import {enableVisualEditing} from '@sanity/visual-editing'
 import {Suspense, useEffect, useState} from 'react'
 import {createRoot} from 'react-dom/client'
@@ -16,103 +17,114 @@ function Main() {
     'simple' | 'nested' | 'markdown' | 'longlist' | 'initialvalues' | 'intl-array'
   >('simple')
   return (
-    <>
-      <ThemeProvider theme={studioTheme}>
-        <Flex direction={'column'}>
-          <Box padding={4}>
-            <TabList space={2}>
-              <Tab
-                aria-controls="simple-panel"
-                id="simple-tab"
-                label="SimpleBlockPortableText"
-                onClick={() => setId('simple')}
-                selected={id === 'simple'}
-              />
-              <Tab
-                aria-controls="nested-panel"
-                id="nested-tab"
-                label="FieldGroups"
-                onClick={() => setId('nested')}
-                selected={id === 'nested'}
-              />
-              <Tab
-                aria-controls="markdown-panel"
-                id="markdown-tab"
-                label="Markdown"
-                onClick={() => setId('markdown')}
-                selected={id === 'markdown'}
-              />
-              <Tab
-                aria-controls="longlist-panel"
-                id="longlist-tab"
-                label="Long List"
-                onClick={() => setId('longlist')}
-                selected={id === 'longlist'}
-              />
-              <Tab
-                aria-controls="initialvalues-panel"
-                id="initialvalues-tab"
-                label="Initial Values"
-                onClick={() => setId('initialvalues')}
-                selected={id === 'initialvalues'}
-              />
-              <Tab
-                aria-controls="intl-array-panel"
-                id="intl-array-tab"
-                label="InternationalizedArrayTest"
-                onClick={() => setId('intl-array')}
-                selected={id === 'intl-array'}
-              />
-            </TabList>
-          </Box>
+    <ThemeProvider theme={studioTheme}>
+      <Flex direction={'column'}>
+        <Box padding={4}>
+          <TabList space={2}>
+            <Tab
+              aria-controls="simple-panel"
+              id="simple-tab"
+              label="SimpleBlockPortableText"
+              onClick={() => setId('simple')}
+              selected={id === 'simple'}
+            />
+            <Tab
+              aria-controls="nested-panel"
+              id="nested-tab"
+              label="FieldGroups"
+              onClick={() => setId('nested')}
+              selected={id === 'nested'}
+            />
+            <Tab
+              aria-controls="markdown-panel"
+              id="markdown-tab"
+              label="Markdown"
+              onClick={() => setId('markdown')}
+              selected={id === 'markdown'}
+            />
+            <Tab
+              aria-controls="longlist-panel"
+              id="longlist-tab"
+              label="Long List"
+              onClick={() => setId('longlist')}
+              selected={id === 'longlist'}
+            />
+            <Tab
+              aria-controls="initialvalues-panel"
+              id="initialvalues-tab"
+              label="Initial Values"
+              onClick={() => setId('initialvalues')}
+              selected={id === 'initialvalues'}
+            />
+            <Tab
+              aria-controls="intl-array-panel"
+              id="intl-array-tab"
+              label="InternationalizedArrayTest"
+              onClick={() => setId('intl-array')}
+              selected={id === 'intl-array'}
+            />
+          </TabList>
+        </Box>
 
-          {id === 'simple' && (
-            <TabPanel aria-labelledby="simple-tab" id="simple-panel">
-              <SimpleBlockPortableText />
-            </TabPanel>
-          )}
+        {id === 'simple' && (
+          <TabPanel aria-labelledby="simple-tab" id="simple-panel">
+            <SimpleBlockPortableText />
+          </TabPanel>
+        )}
 
-          {id === 'nested' && (
-            <TabPanel aria-labelledby="nested-tab" id="nested-panel">
-              <FieldGroups />
-            </TabPanel>
-          )}
+        {id === 'nested' && (
+          <TabPanel aria-labelledby="nested-tab" id="nested-panel">
+            <FieldGroups />
+          </TabPanel>
+        )}
 
-          {id === 'markdown' && (
-            <TabPanel aria-labelledby="markdown-tab" id="markdown-panel">
-              <Markdown />
-            </TabPanel>
-          )}
-          {id === 'longlist' && (
-            <TabPanel aria-labelledby="longlist-tab" id="longlist-panel">
-              <LongList />
-            </TabPanel>
-          )}
-          {id === 'initialvalues' && (
-            <TabPanel aria-labelledby="initialvalues-tab" id="initialvalues-panel">
-              <InitialValues />
-            </TabPanel>
-          )}
-          {id === 'intl-array' && (
-            <TabPanel aria-labelledby="intl-array-tab" id="intl-array-panel">
-              <InternationalizedArrayTest />
-            </TabPanel>
-          )}
-        </Flex>
-      </ThemeProvider>
-
+        {id === 'markdown' && (
+          <TabPanel aria-labelledby="markdown-tab" id="markdown-panel">
+            <Markdown />
+          </TabPanel>
+        )}
+        {id === 'longlist' && (
+          <TabPanel aria-labelledby="longlist-tab" id="longlist-panel">
+            <LongList />
+          </TabPanel>
+        )}
+        {id === 'initialvalues' && (
+          <TabPanel aria-labelledby="initialvalues-tab" id="initialvalues-panel">
+            <InitialValues />
+          </TabPanel>
+        )}
+        {id === 'intl-array' && (
+          <TabPanel aria-labelledby="intl-array-tab" id="intl-array-panel">
+            <InternationalizedArrayTest />
+          </TabPanel>
+        )}
+      </Flex>
       <Suspense fallback={null}>
         <VisualEditing />
       </Suspense>
-    </>
+    </ThemeProvider>
   )
 }
 
 function VisualEditing() {
-  useEffect(() => enableVisualEditing(), [])
+  const [perspective, setPerspective] = useState<ClientPerspective>('published')
+
+  useEffect(() => enableVisualEditing({onPerspectiveChange: setPerspective}), [])
   useLiveMode({})
 
-  return null
+  return (
+    <Card
+      padding={3}
+      radius={2}
+      shadow={2}
+      style={{bottom: 16, maxWidth: 420, position: 'fixed', right: 16, zIndex: 1000}}
+      tone="transparent"
+    >
+      <Text muted size={1}>
+        perspective: {JSON.stringify(perspective)}
+      </Text>
+    </Card>
+  )
 }
 
 const rootEl = document.getElementById('root')

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -657,6 +657,7 @@ export default defineConfig([
         allowOrigins: ['https://*.sanity.dev'],
         previewUrl: {
           // Intentionally using sanity.build instead of sanity.dev, to test that it's able to recover from the server side domain redirect to sanity.dev
+          // @TODO it is currently not able to recover, it fails eventually, investigate why
           initial: 'https://next.sanity.build',
           previewMode: {enable: '/api/draft-mode/enable'},
         },

--- a/packages/sanity/src/presentation/__tests__/usePresentationPerspective.test.ts
+++ b/packages/sanity/src/presentation/__tests__/usePresentationPerspective.test.ts
@@ -71,7 +71,7 @@ describe('usePresentationPerspective', () => {
     expect(result.current).toEqual([scheduledDraft, ...perspectiveStack])
   })
 
-  it('should return `[selectedPerspectiveName]` when `selectedPerspectiveName` is an agent bundle and no `scheduledDraft` is set', () => {
+  it('should return `perspectiveStack` when `selectedPerspectiveName` is an agent bundle and no `scheduledDraft` is set', () => {
     mockUsePerspective.mockReturnValue({
       selectedPerspectiveName: 'agent-wGEzfa',
       selectedReleaseId: undefined,

--- a/packages/sanity/src/presentation/__tests__/usePresentationPerspective.test.ts
+++ b/packages/sanity/src/presentation/__tests__/usePresentationPerspective.test.ts
@@ -70,4 +70,29 @@ describe('usePresentationPerspective', () => {
 
     expect(result.current).toEqual([scheduledDraft, ...perspectiveStack])
   })
+
+  it('should return `[selectedPerspectiveName]` when `selectedPerspectiveName` is an agent bundle and no `scheduledDraft` is set', () => {
+    mockUsePerspective.mockReturnValue({
+      selectedPerspectiveName: 'agent-wGEzfa',
+      selectedReleaseId: undefined,
+      perspectiveStack: ['agent-wGEzfa', 'drafts'],
+    } satisfies Partial<PerspectiveContextValue>)
+
+    const {result} = renderHook(() => usePresentationPerspective({scheduledDraft: undefined}))
+
+    expect(result.current).toEqual(['agent-wGEzfa', 'drafts'])
+  })
+
+  it('should include `scheduledDraft` before an agent bundle perspective when both are set', () => {
+    const scheduledDraft = 'drafts.scheduled-doc-id'
+    mockUsePerspective.mockReturnValue({
+      selectedPerspectiveName: 'agent-wGEzfa',
+      selectedReleaseId: undefined,
+      perspectiveStack: ['agent-wGEzfa', 'drafts'],
+    } satisfies Partial<PerspectiveContextValue>)
+
+    const {result} = renderHook(() => usePresentationPerspective({scheduledDraft}))
+
+    expect(result.current).toEqual([scheduledDraft, 'agent-wGEzfa', 'drafts'])
+  })
 })

--- a/packages/sanity/src/presentation/usePresentationPerspective.ts
+++ b/packages/sanity/src/presentation/usePresentationPerspective.ts
@@ -1,5 +1,6 @@
 import {usePerspective} from 'sanity'
 
+import {isAgentBundleName} from '../core/store/agent/createAgentBundlesStore'
 import {type PresentationPerspective} from './types'
 
 /**
@@ -12,11 +13,14 @@ export function usePresentationPerspective({
 }): PresentationPerspective {
   const {selectedPerspectiveName = 'drafts', selectedReleaseId, perspectiveStack} = usePerspective()
 
-  return selectedReleaseId || scheduledDraft
-    ? scheduledDraft
-      ? [scheduledDraft, ...perspectiveStack]
-      : perspectiveStack
-    : selectedPerspectiveName === 'published'
-      ? 'published'
-      : 'drafts'
+  if (selectedReleaseId || scheduledDraft || isAgentBundleName(selectedPerspectiveName)) {
+    if (scheduledDraft) {
+      return [scheduledDraft, ...perspectiveStack]
+    }
+    return perspectiveStack
+  }
+  if (selectedPerspectiveName === 'published') {
+    return 'published'
+  }
+  return 'drafts'
 }


### PR DESCRIPTION
### Description

Selecting an agent bundle in Presentation only ever previewed `drafts`, never the bundle's content. The root cause is in [`usePresentationPerspective`](packages/sanity/src/presentation/usePresentationPerspective.ts): the hook only forwarded `perspectiveStack` when `selectedReleaseId` or `scheduledDraft` was set, and because agent bundles aren't in `releases`, [`selectedReleaseId`](packages/sanity/src/core/perspective/PerspectiveProvider.tsx) is always undefined for them — so it fell through to `'drafts'`.

Why not the earlier attempt: #12671 tried to fix the same UX by syncing a perspective cookie, but it never affected the value the hook hands to the iframe, so the preview kept receiving `drafts`. In practice #12671 did not move the needle on this bug; this PR addresses the root cause in the hook itself.

How: branch on `isAgentBundleName(selectedPerspectiveName)` in addition to `selectedReleaseId`/`scheduledDraft`, so the agent bundle's `perspectiveStack` is forwarded to the iframe and still combines correctly with `scheduledDraft`.

### What to review

- [packages/sanity/src/presentation/usePresentationPerspective.ts](packages/sanity/src/presentation/usePresentationPerspective.ts) — the fix.
- [packages/sanity/src/presentation/__tests__/usePresentationPerspective.test.ts](packages/sanity/src/presentation/__tests__/usePresentationPerspective.test.ts) — covers both agent-bundle-alone and agent-bundle-plus-`scheduledDraft`.
- [dev/test-studio/preview/main.tsx](dev/test-studio/preview/main.tsx) — adds a small overlay in the preview iframe that prints the current perspective received via `useLiveMode` from `@sanity/react-loader` and `onPerspectiveChange` from `@sanity/visual-editing`. This is the same channel any consumer of `@sanity/core-loader` live mode uses, so the overlay reflects exactly what Presentation hands to the iframe.
- Packages affected: `sanity` (presentation); test-studio only for the preview overlay.

Reproduce the broken behavior on the pre-fix deployment:

- Agent bundle alone — overlay shows `"drafts"` instead of e.g. `["agent-wGEzfa","drafts"]`: https://test-studio-r7b2m67be.sanity.dev/test/presentation/simpleBlock/35cc0c45-1bcc-4105-93a7-f73608385d0f/?perspective=agent-wGEzfa
- Agent bundle + scheduled draft chip — already worked (the `scheduledDraft` branch was spreading `perspectiveStack`): https://test-studio-r7b2m67be.sanity.dev/test/presentation/simpleBlock/35cc0c45-1bcc-4105-93a7-f73608385d0f/?scheduledDraft=rwNbegEwZ&perspective=agent-wGEzfa

Verify the fix on this branch's deployment (toggle the scheduled draft chip on/off — both states should now show the agent bundle in the perspective): https://test-studio-git-sapp-3672.sanity.dev/test/presentation/simpleBlock/35cc0c45-1bcc-4105-93a7-f73608385d0f/?scheduledDraft=rwNbegEwZ&perspective=agent-wGEzfa

Equivalent route on the live test studio: https://test-studio.sanity.dev/test/presentation

### Testing

- Unit: two new cases in `usePresentationPerspective.test.ts` for the agent bundle, with and without `scheduledDraft`.
- Manual: open Presentation in the test studio, select an agent bundle (e.g. "Proposed changes"), and confirm the new preview overlay shows the bundle's perspective stack instead of `"drafts"`. Toggle a scheduled draft chip on top of it and confirm the scheduled draft appears at the head of the stack.

### Notes for release

Fixes Presentation previews when an agent bundle (e.g. Content Agent's "Proposed changes") is selected. Previously the preview iframe always received the `drafts` perspective regardless of the active agent bundle, so iframes rendered draft content instead of the bundle's content. Iframes now receive the agent bundle's full perspective stack, and combining an agent bundle with a scheduled draft chip continues to work as before. No API or behavior change for non-agent perspectives.