### PR TITLE
fix(presentation): handle null client.fetch results in PostMessageSchema

### DIFF
--- a/packages/sanity/src/presentation/overlays/schema/PostMessageSchema.tsx
+++ b/packages/sanity/src/presentation/overlays/schema/PostMessageSchema.tsx
@@ -82,12 +82,13 @@ function PostMessageSchema(props: PostMessageSchemaProps): React.JSX.Element | n
               perspective,
             },
           )
-          /**
-           * PostMessageSchema.tsx:85 Uncaught (in promise) TypeError: Cannot read properties of null (reading '0')
-    at PostMessageSchema.tsx:85:67
-           */
+          // `client.fetch` returns `null` when no document matches the active perspective,
+          // and individual projection entries are `null` when the document exists but the
+          // path doesn't resolve. Drop those entries so we only emit fully resolved types.
           const mapped = arr
-            .map((path, i) => (result?.[i] ? {path: path, type: result[i]} : null))
+            .map((path, i) =>
+              typeof result?.[i] === 'string' ? {path: path, type: result[i]} : null,
+            )
             .filter((item) => item !== null)
           return {id, paths: mapped}
         }),

--- a/packages/sanity/src/presentation/overlays/schema/PostMessageSchema.tsx
+++ b/packages/sanity/src/presentation/overlays/schema/PostMessageSchema.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-nested-callbacks */
 import {type ClientPerspective} from '@sanity/client'
-import {type UnresolvedPath} from '@sanity/presentation-comlink'
+import {type ResolvedSchemaTypeMap, type UnresolvedPath} from '@sanity/presentation-comlink'
 import {memo, useEffect} from 'react'
 import {
   getPublishedId,
@@ -74,7 +74,7 @@ function PostMessageSchema(props: PostMessageSchemaProps): React.JSX.Element | n
           const projection = arr.map((path, i) => `"${i}": ${path}[0]._type`).join(',')
           const query = `*[_id == $id][0]{${projection}}`
           // Should implement max 25 concurrent queries here
-          const result = await client.fetch(
+          const result = await client.fetch<Record<number, string | null> | null>(
             query,
             {id: getPublishedId(id)},
             {
@@ -82,12 +82,18 @@ function PostMessageSchema(props: PostMessageSchemaProps): React.JSX.Element | n
               perspective,
             },
           )
-          const mapped = arr.map((path, i) => ({path: path, type: result[i]}))
+          /**
+           * PostMessageSchema.tsx:85 Uncaught (in promise) TypeError: Cannot read properties of null (reading '0')
+    at PostMessageSchema.tsx:85:67
+           */
+          const mapped = arr
+            .map((path, i) => (result?.[i] ? {path: path, type: result[i]} : null))
+            .filter((item) => item !== null)
           return {id, paths: mapped}
         }),
       )
 
-      const newState = new Map()
+      const newState: ResolvedSchemaTypeMap = new Map()
       unionTypes.forEach((action) => {
         newState.set(action.id, new Map(action.paths.map(({path, type}) => [path, type])))
       })


### PR DESCRIPTION
### Description

Splits the `PostMessageSchema.tsx` null-handling fix out of #12885 so it can land independently.

When the Visual Editing schema union-type resolver runs against a document that does not exist on the active perspective, `client.fetch` returns `null` for the document selection. The previous code immediately dereferenced `result[i]`, producing:

`PostMessageSchema.tsx:85 Uncaught (in promise) TypeError: Cannot read properties of null (reading '0')`

This change:

- Types the `client.fetch` call as `Record<number, string | null> | null` instead of letting it default to `any`.
- Safely skips paths whose result is `null` / missing when building the resolved union-type map.
- Types `newState` as `ResolvedSchemaTypeMap` for clarity.

### What to review

- `packages/sanity/src/presentation/overlays/schema/PostMessageSchema.tsx`: the null-safe `mapped` construction and the new typed `client.fetch<Record<number, string | null> | null>` call.
- Note for reviewers: the change from `client.fetch(...)` to `client.fetch<Record<number, string | null> | null>(...)` makes the return type explicit. Previously the result fell back to `any` (the default `R = Any` in `@sanity/client`), so `result[i]` could silently dereference `null`. With the explicit typing, any future code path where content lake might return `null` on a query (e.g. a document not visible on the active perspective) is forced to be handled — TypeScript will now catch this class of bug at compile time, instead of letting it sneak through as implicit `any`.

### Testing

Verified the regression manually against the Presentation tool by opening a document that does not exist on the selected perspective and confirming the runtime `TypeError` no longer occurs.

No automated test was added: `PostMessageSchema` is a side-effect-only component (returns `null`, registers `comlink.on` handlers), and a useful unit test would require mocking `useWorkspace`, `useClient`, and a comlink handler-capture harness — disproportionate to the size of the fix. The explicit typing of `client.fetch` provides type-level coverage for the failure mode.

### Notes for release

Fix a regression in the Visual Editing schema union-type resolver that could throw `TypeError: Cannot read properties of null` when resolving paths on documents that don't exist on the active perspective.

Made with [Cursor](https://cursor.com)