### PR TITLE
ci(e2e): fix merge-reports failing on inconsistent artifact layout

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -289,21 +289,13 @@ jobs:
           path: all-blob-reports
 
       - name: Merge into HTML Report
-        # Blob reports are downloaded flat into all-blob-reports/ (merge-multiple: true),
-        # so point merge-reports at that directory directly.
-        #
-        # merge-reports exits 0 even when it finds no blobs, which silently
-        # produces neither an HTML report nor test-summary.json. Assert the
-        # report-*.zip files are present first, so a layout regression fails
-        # loudly here instead of surfacing as a cryptic error downstream.
+        # DIAGNOSTIC: merge-reports keeps producing no output despite blobs being
+        # present. Dump the downloaded tree so we can see exactly what
+        # download-artifact@v8 placed in all-blob-reports/ (decompressed blob
+        # reports vs still-zipped artifact archives) before deciding the fix.
         run: |
-          shopt -s nullglob
-          blobs=(all-blob-reports/*.zip)
-          if [ ${#blobs[@]} -eq 0 ]; then
-            echo "::error::No blob reports found in all-blob-reports/. The merge would silently produce nothing — check the upload artifact layout in the playwright-test job."
-            ls -laR all-blob-reports || true
-            exit 1
-          fi
+          echo "Downloaded tree:"
+          ls -laR all-blob-reports || true
           npx playwright merge-reports --reporter html,./e2e/reporters/summary.ts all-blob-reports
 
       - name: Extract test summary

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -206,6 +206,20 @@ jobs:
           SANITY_E2E_DATASET: ${{ (matrix.project == 'chromium') && env.CHROMIUM_DATASET || env.FIREFOX_DATASET }}
         run: pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
+      # The blob reporter names files report-<shard>.zip — the project is NOT in
+      # the filename, so chromium-1 and firefox-1 both produce report-1.zip. When
+      # the merge job flattens every shard's report into one directory
+      # (merge-multiple: true), those collide and overwrite each other, leaving an
+      # incoherent set that merge-reports silently refuses to merge. Rename each
+      # blob to embed the project so every shard's report is uniquely named.
+      - name: Make blob report filename unique
+        if: always()
+        run: |
+          shopt -s nullglob
+          for f in e2e/blob-report/report-*.zip; do
+            mv "$f" "e2e/blob-report/report-${{ matrix.project }}-$(basename "$f" | sed 's/^report-//')"
+          done
+
       # Upload the blob report on its own. With a single path, upload-artifact
       # roots the artifact at e2e/blob-report, so report-*.zip lands at the
       # artifact root and download-artifact (merge-multiple) flattens it into

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -206,13 +206,27 @@ jobs:
           SANITY_E2E_DATASET: ${{ (matrix.project == 'chromium') && env.CHROMIUM_DATASET || env.FIREFOX_DATASET }}
         run: pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
+      # Upload the blob report on its own. With a single path, upload-artifact
+      # roots the artifact at e2e/blob-report, so report-*.zip lands at the
+      # artifact root and download-artifact (merge-multiple) flattens it into
+      # all-blob-reports/ consistently every run. Bundling e2e/results here
+      # shifted the artifact root to e2e/ only when results existed, so the
+      # merge job's all-blob-reports/blob-report path broke intermittently.
       - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report-${{ matrix.project }}-${{ matrix.shardIndex }}
-          path: |
-            e2e/blob-report
-            e2e/results
+          path: e2e/blob-report
+          retention-days: 30
+
+      # Raw traces/videos as a separate artifact for local debugging. Named so
+      # it does NOT match the playwright-report-* glob the merge job downloads.
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: e2e-results-${{ matrix.project }}-${{ matrix.shardIndex }}
+          path: e2e/results
+          if-no-files-found: ignore
           retention-days: 30
 
   e2e-status:
@@ -261,13 +275,36 @@ jobs:
           path: all-blob-reports
 
       - name: Merge into HTML Report
-        run: npx playwright merge-reports --reporter html,./e2e/reporters/summary.ts all-blob-reports/blob-report
+        # Blob reports are downloaded flat into all-blob-reports/ (merge-multiple: true),
+        # so point merge-reports at that directory directly.
+        #
+        # merge-reports exits 0 even when it finds no blobs, which silently
+        # produces neither an HTML report nor test-summary.json. Assert the
+        # report-*.zip files are present first, so a layout regression fails
+        # loudly here instead of surfacing as a cryptic error downstream.
+        run: |
+          shopt -s nullglob
+          blobs=(all-blob-reports/*.zip)
+          if [ ${#blobs[@]} -eq 0 ]; then
+            echo "::error::No blob reports found in all-blob-reports/. The merge would silently produce nothing — check the upload artifact layout in the playwright-test job."
+            ls -laR all-blob-reports || true
+            exit 1
+          fi
+          npx playwright merge-reports --reporter html,./e2e/reporters/summary.ts all-blob-reports
 
       - name: Extract test summary
         id: summary
         run: |
           node -e "
-            const s = JSON.parse(require('fs').readFileSync('test-summary.json', 'utf8'));
+            const fs = require('fs');
+            // The merge step guarantees blobs were present, so a missing summary
+            // here is anomalous (e.g. the reporter failed to write). Surface it as
+            // a visible warning but don't fail the job over a reporting glitch.
+            if (!fs.existsSync('test-summary.json')) {
+              console.warn('::warning::test-summary.json not found after merge; skipping summary extraction');
+              process.exit(0);
+            }
+            const s = JSON.parse(fs.readFileSync('test-summary.json', 'utf8'));
             const parts = [];
             if (s.passed) parts.push('🟢 ' + s.passed + ' passed');
             if (s.failed) parts.push('🔴 ' + s.failed + ' failed');

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -206,20 +206,6 @@ jobs:
           SANITY_E2E_DATASET: ${{ (matrix.project == 'chromium') && env.CHROMIUM_DATASET || env.FIREFOX_DATASET }}
         run: pnpm test:e2e --project ${{ matrix.project }} --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
-      # The blob reporter names files report-<shard>.zip — the project is NOT in
-      # the filename, so chromium-1 and firefox-1 both produce report-1.zip. When
-      # the merge job flattens every shard's report into one directory
-      # (merge-multiple: true), those collide and overwrite each other, leaving an
-      # incoherent set that merge-reports silently refuses to merge. Rename each
-      # blob to embed the project so every shard's report is uniquely named.
-      - name: Make blob report filename unique
-        if: always()
-        run: |
-          shopt -s nullglob
-          for f in e2e/blob-report/report-*.zip; do
-            mv "$f" "e2e/blob-report/report-${{ matrix.project }}-$(basename "$f" | sed 's/^report-//')"
-          done
-
       # Upload the blob report on its own. With a single path, upload-artifact
       # roots the artifact at e2e/blob-report, so report-*.zip lands at the
       # artifact root and download-artifact (merge-multiple) flattens it into
@@ -289,23 +275,21 @@ jobs:
           path: all-blob-reports
 
       - name: Merge into HTML Report
-        # DIAGNOSTIC: merge-reports keeps producing no output despite blobs being
-        # present. Dump the downloaded tree so we can see exactly what
-        # download-artifact@v8 placed in all-blob-reports/ (decompressed blob
-        # reports vs still-zipped artifact archives) before deciding the fix.
-        run: |
-          echo "Downloaded tree:"
-          ls -laR all-blob-reports || true
-          npx playwright merge-reports --reporter html,./e2e/reporters/summary.ts all-blob-reports
+        # Use `pnpm exec`, not `npx`: from the repo root npx failed to launch the
+        # playwright CLI in CI (node never started — no output, no error), so
+        # merge-reports silently produced neither the HTML report nor
+        # test-summary.json. pnpm exec resolves the workspace-installed binary
+        # deterministically. Paths stay root-relative (cwd is the repo root).
+        run: pnpm exec playwright merge-reports --reporter html,./e2e/reporters/summary.ts all-blob-reports
 
       - name: Extract test summary
         id: summary
         run: |
           node -e "
             const fs = require('fs');
-            // The merge step guarantees blobs were present, so a missing summary
-            // here is anomalous (e.g. the reporter failed to write). Surface it as
-            // a visible warning but don't fail the job over a reporting glitch.
+            // Degrade gracefully if the merge didn't write a summary (e.g. no
+            // tests ran): surface a visible warning rather than failing the job
+            // over missing PR-comment data.
             if (!fs.existsSync('test-summary.json')) {
               console.warn('::warning::test-summary.json not found after merge; skipping summary extraction');
               process.exit(0);

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -275,12 +275,22 @@ jobs:
           path: all-blob-reports
 
       - name: Merge into HTML Report
-        # Use `pnpm exec`, not `npx`: from the repo root npx failed to launch the
-        # playwright CLI in CI (node never started — no output, no error), so
-        # merge-reports silently produced neither the HTML report nor
-        # test-summary.json. pnpm exec resolves the workspace-installed binary
-        # deterministically. Paths stay root-relative (cwd is the repo root).
-        run: pnpm exec playwright merge-reports --reporter html,./e2e/reporters/summary.ts all-blob-reports
+        # DIAGNOSTIC v2: merge still writes nothing. Capture the binary, version,
+        # full stdout+stderr, exit code, and the resulting tree to find out what
+        # the merge actually does in CI.
+        run: |
+          set -x
+          pwd
+          ls -la all-blob-reports
+          command -v playwright || true
+          pnpm exec playwright --version 2>&1 || echo "version cmd failed: $?"
+          echo "=== merge: html only ==="
+          pnpm exec playwright merge-reports --reporter html all-blob-reports 2>&1
+          echo "=== exit=$? ==="
+          echo "=== tree after merge ==="
+          ls -la . | head -40
+          ls -la playwright-report 2>&1 | head -5 || true
+          find . -maxdepth 2 -name 'index.html' -o -maxdepth 2 -name 'test-summary.json' 2>/dev/null | head
 
       - name: Extract test summary
         id: summary


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
