### PR TITLE
fix(core): respect parent array field initialValue over member fields

### DIFF
--- a/packages/sanity/src/core/templates/__tests__/resolve.test.ts
+++ b/packages/sanity/src/core/templates/__tests__/resolve.test.ts
@@ -493,4 +493,94 @@ describe('resolveInitialValue', () => {
       expect(initialValue).toHaveBeenCalledTimes(2) // null and undefined are treated differently
     })
   })
+
+  describe('array member initial value precedence', () => {
+    const getTestSchema = () =>
+      SchemaBuilder.compile({
+        name: 'default',
+        types: [
+          {
+            name: 'precedenceTest',
+            type: 'document',
+            fields: [
+              {
+                name: 'portableText',
+                type: 'array',
+                initialValue: [{_type: 'textItem', value: 'Parent'}],
+                of: [
+                  {type: 'block'},
+                  {
+                    name: 'textItem',
+                    type: 'object',
+                    fields: [{name: 'value', type: 'string', initialValue: 'Child'}],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+
+    const precedenceTemplate: Template = {
+      id: 'precedenceTest',
+      title: 'Precedence test',
+      schemaType: 'precedenceTest',
+      value: {},
+    }
+
+    test('parent array field initialValue takes precedence over array member field initialValue', async () => {
+      const result = await resolveInitialValue(
+        getTestSchema(),
+        precedenceTemplate,
+        {},
+        mockConfigContext,
+      )
+
+      expect(result.portableText).toHaveLength(1)
+      expect(result.portableText[0]).toMatchObject({
+        _type: 'textItem',
+        value: 'Parent',
+      })
+      expect(result.portableText[0]).toHaveProperty('_key')
+    })
+
+    test('array member field initialValue is used when the parent does not specify it', async () => {
+      const schemaWithoutParentValue = SchemaBuilder.compile({
+        name: 'default',
+        types: [
+          {
+            name: 'precedenceTest',
+            type: 'document',
+            fields: [
+              {
+                name: 'portableText',
+                type: 'array',
+                initialValue: [{_type: 'textItem'}],
+                of: [
+                  {type: 'block'},
+                  {
+                    name: 'textItem',
+                    type: 'object',
+                    fields: [{name: 'value', type: 'string', initialValue: 'Child'}],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+
+      const result = await resolveInitialValue(
+        schemaWithoutParentValue,
+        precedenceTemplate,
+        {},
+        mockConfigContext,
+      )
+
+      expect(result.portableText[0]).toMatchObject({
+        _type: 'textItem',
+        value: 'Child',
+      })
+    })
+  })
 })

--- a/packages/sanity/src/core/templates/resolve.ts
+++ b/packages/sanity/src/core/templates/resolve.ts
@@ -258,8 +258,18 @@ async function resolveInitialArrayValue<Params extends Record<string, unknown>>(
       const itemType = getItemType(type as ArraySchemaType, initialItem)!
       return isObjectSchemaType(itemType)
         ? {
-            ...initialItem,
-            ...(await resolveInitialValueForType(itemType, params, maxDepth - 1, context, options)),
+            // The initial value defined on the parent array field takes precedence over
+            // initial values resolved from the array member type's own fields.
+            ...deepAssign(
+              (await resolveInitialValueForType(
+                itemType,
+                params,
+                maxDepth - 1,
+                context,
+                options,
+              )) || {},
+              initialItem as Record<string, unknown>,
+            ),
             _key: randomKey(),
           }
         : initialItem


### PR DESCRIPTION
### Description

An `array` field ignored the parent field's `initialValue` whenever a member also set `initialValue` on its own fields — the child won, contradicting the [documented precedence](https://www.sanity.io/docs/studio/initial-value-templates#fc4957c3bdef) and diverging from plain object fields. Reported via a Portable Text field, but it's generic to array resolution, not PTE-specific.

The member resolver spread member values *after* the parent item, so the child clobbered the parent. Fixed by routing through the same `deepAssign(childValues, parentItem)` the object resolver already uses — which also upgrades the merge from shallow to deep, matching object-field behavior.

### What to review

- Confirm the `deepAssign` argument order matches `resolveInitialObjectValue`

### Testing

Two regression tests in `resolve.test.ts` (parent wins; member fills gaps the parent omits). Templates suite passes (48 tests), no type errors.

### Notes for release

Fixed a bug where an array field with an `initialValue` set on both the parent field and a child field within `defineArrayMember` would incorrectly use the child field's value. The parent's `initialValue` now takes precedence, consistent with object fields and the documented behavior; the child's `initialValue` still fills any keys the parent omits.
