### PR TITLE
chore(core): update variants operation store to use system actions

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -457,6 +457,11 @@ export default defineConfig([
     mediaLibrary: {
       enabled: true,
     },
+    beta: {
+      variants: {
+        enabled: true,
+      },
+    },
   },
   {
     name: 'growth',

--- a/packages/sanity/src/core/variants/ACTIONS.md
+++ b/packages/sanity/src/core/variants/ACTIONS.md
@@ -1,0 +1,152 @@
+# Variant Definition Actions
+
+Variant definition writes should use the actions API instead of direct document mutations. The actions target the persisted `system.variant` definition documents under `_.variants.*`.
+
+## Variant Definition Document
+
+The actions operate on variant definition documents with this persisted shape:
+
+```ts
+interface VariantDefinitionDocument {
+  _id: `_.variants.${string}`
+  _type: 'system.variant'
+  name: string
+  conditions: Record<string, string>
+  priority: number
+  metadata?: Record<string, unknown>
+}
+```
+
+`variantId` is the generated short ID suffix, not the full document ID. For example, a `variantId` such as `Ab12cd34` maps to the stored document ID `_.variants.Ab12cd34`.
+
+## `sanity.action.variant.definition.create`
+
+Creates a new variant definition document.
+
+Required fields:
+
+- `actionType: 'sanity.action.variant.definition.create'`
+- `variantId`: the short variant name used to create `_.variants.{variantId}`
+
+Optional fields:
+
+- `conditions`: exact-match condition map. Empty conditions are accepted, but such a definition is inert for matching.
+- `priority`: numeric priority. Defaults to `0` when omitted.
+- `metadata`: free-form metadata for Studio UI concerns such as `title` and `description`.
+
+Example:
+
+```ts
+await client.action({
+  actionType: 'sanity.action.variant.definition.create',
+  variantId: 'Ab12cd34',
+  conditions: {audience: 'loyal'},
+  priority: 0,
+  metadata: {title: 'Loyal customers'},
+})
+```
+
+Behavior:
+
+- Creates `_.variants.{variantId}` with `_type: 'system.variant'` and `name: variantId`.
+- Fails when a variant definition with the same ID already exists.
+- Validates the variant ID as a single path segment.
+- Validates condition keys and values.
+- Applies variant definition feature and count-limit checks on the API side.
+
+Condition validation:
+
+- Keys must be lowercase, start with a letter, and match `[a-z][a-z0-9_-]{0,63}`.
+- Keys with reserved prefixes `_` or `$` are rejected.
+- Values must be non-empty valid UTF-8 strings.
+
+## `sanity.action.variant.definition.edit`
+
+Edits an existing variant definition document.
+
+Required fields:
+
+- `actionType: 'sanity.action.variant.definition.edit'`
+- `variantId`: the short variant name for `_.variants.{variantId}`
+- `patch`: a patch without an `_id`; the action applies it to the matching variant definition document
+
+Optional fields:
+
+- `ifRevisionId`: optimistic concurrency guard. The action fails if the current document revision does not match.
+
+Example:
+
+```ts
+await client.action({
+  actionType: 'sanity.action.variant.definition.edit',
+  variantId: 'Ab12cd34',
+  patch: {
+    set: {
+      'conditions': {audience: 'loyal', locale: 'en-US'},
+      'priority': 10,
+      'metadata.title': 'Loyal customers in the US',
+    },
+  },
+})
+```
+
+Behavior:
+
+- Fails if the variant definition does not exist.
+- Fails when `ifRevisionId` is provided and does not match the current document revision.
+- Allows patches only under mutable paths:
+  - `conditions` or `conditions.*`
+  - `priority`
+  - `metadata` or `metadata.*`
+- Rejects patches to immutable fields such as `_id`, `_type`, `name`, and system timestamps.
+- Validates the resulting variant definition document after applying the patch.
+
+Useful patch patterns:
+
+```ts
+await client.action({
+  actionType: 'sanity.action.variant.definition.edit',
+  variantId: 'Ab12cd34',
+  patch: {
+    set: {conditions: {audience: 'loyal'}},
+  },
+})
+
+await client.action({
+  actionType: 'sanity.action.variant.definition.edit',
+  variantId: 'Ab12cd34',
+  patch: {
+    unset: ['metadata'],
+  },
+})
+```
+
+## `sanity.action.variant.definition.delete`
+
+Deletes an existing variant definition document.
+
+Required fields:
+
+- `actionType: 'sanity.action.variant.definition.delete'`
+- `variantId`: the short variant name for `_.variants.{variantId}`
+
+Optional fields:
+
+- `ifRevisionId`: optimistic concurrency guard. The action fails if the current document revision does not match.
+
+Example:
+
+```ts
+await client.action({
+  actionType: 'sanity.action.variant.definition.delete',
+  variantId: 'Ab12cd34',
+})
+```
+
+Behavior:
+
+- Fails if the variant definition does not exist.
+- Fails when `ifRevisionId` is provided and does not match the current document revision.
+- Submits a delete for `_.variants.{variantId}`.
+- Does not cascade delete variant documents.
+- Strong references to the variant definition block deletion through the mutation engine, and the action surfaces that integrity error.

--- a/packages/sanity/src/core/variants/store/__tests__/createVariantOperationsStore.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/createVariantOperationsStore.test.ts
@@ -1,12 +1,17 @@
+import {type SanityClient} from '@sanity/client'
 import {describe, expect, it, vi} from 'vitest'
 
 import {type EditableSystemVariant} from '../../types'
 import {VARIANT_DOCUMENTS_PATH} from '../constants'
 import {createVariantOperationsStore} from '../createVariantOperationsStore'
 
+const VARIANT_ID = 'Ab12cd34'
+const DOCUMENT_ID = `${VARIANT_DOCUMENTS_PATH}.${VARIANT_ID}`
+const ACTION_RESULT = {transactionId: 'txn-1'}
+
 function createEditableVariant(): EditableSystemVariant {
   return {
-    _id: `${VARIANT_DOCUMENTS_PATH}.Ab12cd34`,
+    _id: DOCUMENT_ID as `_.variants.${string}`,
     _type: 'system.variant',
     conditions: {audience: 'loyal-customers'},
     priority: 0,
@@ -18,41 +23,51 @@ function createEditableVariant(): EditableSystemVariant {
 }
 
 describe('createVariantOperationsStore', () => {
-  it('creates a variant document', async () => {
+  it('creates a variant definition with the create action', async () => {
     const variant = createEditableVariant()
     const client = {
-      create: vi.fn().mockResolvedValue(variant),
+      action: vi.fn().mockResolvedValue(ACTION_RESULT),
     }
 
-    const store = createVariantOperationsStore({client: client as never})
+    const store = createVariantOperationsStore({client: client as SanityClient})
 
-    await expect(store.createVariant(variant)).resolves.toEqual(variant)
-    expect(client.create).toHaveBeenCalledWith(variant)
+    await expect(store.createVariant(variant)).resolves.toEqual(ACTION_RESULT)
+    expect(client.action).toHaveBeenCalledWith(
+      {
+        actionType: 'sanity.action.variant.definition.create',
+        variantId: VARIANT_ID,
+        conditions: variant.conditions,
+        priority: variant.priority,
+        metadata: variant.metadata,
+      },
+      {tag: 'variants.create'},
+    )
   })
 
-  it('updates a variant document', async () => {
+  it('updates a variant definition with the edit action', async () => {
     const variant = createEditableVariant()
-    const patch = {
-      set: vi.fn().mockReturnThis(),
-      unset: vi.fn().mockReturnThis(),
-      commit: vi.fn().mockResolvedValue(variant),
-    }
     const client = {
-      patch: vi.fn().mockReturnValue(patch),
+      action: vi.fn().mockResolvedValue(ACTION_RESULT),
     }
 
-    const store = createVariantOperationsStore({client: client as never})
+    const store = createVariantOperationsStore({client: client as SanityClient})
 
-    await expect(store.updateVariant(variant)).resolves.toEqual(variant)
+    await expect(store.updateVariant(variant)).resolves.toEqual(ACTION_RESULT)
 
-    expect(client.patch).toHaveBeenCalledWith(variant._id)
-    expect(patch.set).toHaveBeenCalledWith({
-      conditions: variant.conditions,
-      metadata: variant.metadata,
-      priority: variant.priority,
-    })
-    expect(patch.set).toHaveBeenCalledTimes(1)
-    expect(patch.commit).toHaveBeenCalledTimes(1)
+    expect(client.action).toHaveBeenCalledWith(
+      {
+        actionType: 'sanity.action.variant.definition.edit',
+        variantId: VARIANT_ID,
+        patch: {
+          set: {
+            conditions: variant.conditions,
+            metadata: variant.metadata,
+            priority: variant.priority,
+          },
+        },
+      },
+      {tag: 'variants.edit'},
+    )
   })
 
   it('unsets metadata when updating a variant without metadata', async () => {
@@ -63,33 +78,45 @@ describe('createVariantOperationsStore', () => {
       conditions: variant.conditions,
       priority: variant.priority,
     }
-    const patch = {
-      set: vi.fn().mockReturnThis(),
-      unset: vi.fn().mockReturnThis(),
-      commit: vi.fn().mockResolvedValue(variantWithoutMetadata),
-    }
     const client = {
-      patch: vi.fn().mockReturnValue(patch),
+      action: vi.fn().mockResolvedValue(ACTION_RESULT),
     }
 
-    const store = createVariantOperationsStore({client: client as never})
+    const store = createVariantOperationsStore({client: client as SanityClient})
 
-    await expect(store.updateVariant(variantWithoutMetadata)).resolves.toEqual(
-      variantWithoutMetadata,
+    await expect(store.updateVariant(variantWithoutMetadata)).resolves.toEqual(ACTION_RESULT)
+
+    expect(client.action).toHaveBeenCalledWith(
+      {
+        actionType: 'sanity.action.variant.definition.edit',
+        variantId: VARIANT_ID,
+        patch: {
+          set: {
+            conditions: variantWithoutMetadata.conditions,
+            priority: variantWithoutMetadata.priority,
+          },
+          unset: ['metadata'],
+        },
+      },
+      {tag: 'variants.edit'},
     )
-
-    expect(patch.unset).toHaveBeenCalledWith(['metadata'])
   })
 
-  it('deletes a variant document', async () => {
+  it('deletes a variant definition with the delete action', async () => {
     const client = {
-      delete: vi.fn().mockResolvedValue(undefined),
+      action: vi.fn().mockResolvedValue(ACTION_RESULT),
     }
 
-    const store = createVariantOperationsStore({client: client as never})
+    const store = createVariantOperationsStore({client: client as SanityClient})
 
-    await store.deleteVariant(`${VARIANT_DOCUMENTS_PATH}.Ab12cd34`)
+    await expect(store.deleteVariant(DOCUMENT_ID)).resolves.toEqual(ACTION_RESULT)
 
-    expect(client.delete).toHaveBeenCalledWith(`${VARIANT_DOCUMENTS_PATH}.Ab12cd34`)
+    expect(client.action).toHaveBeenCalledWith(
+      {
+        actionType: 'sanity.action.variant.definition.delete',
+        variantId: VARIANT_ID,
+      },
+      {tag: 'variants.delete'},
+    )
   })
 })

--- a/packages/sanity/src/core/variants/store/__tests__/createVariantsStore.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/createVariantsStore.test.ts
@@ -45,6 +45,7 @@ describe('createVariantsStore', () => {
     expect(fetchQuery).toContain('_rev')
     expect(fetchQuery).toContain('_createdAt')
     expect(fetchQuery).toContain('_updatedAt')
+    expect(fetchQuery).toContain('name')
     expect(fetchQuery).toContain('"priority": coalesce(priority, 0)')
     expect(fetchQuery).toContain('| order(_createdAt desc)')
     expect(fetch).toHaveBeenCalledWith(

--- a/packages/sanity/src/core/variants/store/constants.ts
+++ b/packages/sanity/src/core/variants/store/constants.ts
@@ -3,11 +3,10 @@ import {type SourceClientOptions} from '../../config/types'
 // api extractor take issues with 'as const' for literals
 // oxlint-disable-next-line prefer-as-const
 export const VARIANT_DOCUMENT_TYPE: 'system.variant' = 'system.variant'
-// Temporary path for variant document IDs.
-// IDs are built as `${VARIANT_DOCUMENTS_PATH}.<suffix>` (for example, `variants.alpha-audience`).
-// This path will change when variants move under the system namespace.
+// System path for variant definition document IDs.
+// IDs are built as `${VARIANT_DOCUMENTS_PATH}.<suffix>` (for example, `_.variants.Ab12cd34`).
 // oxlint-disable-next-line typescript/prefer-as-const
-export const VARIANT_DOCUMENTS_PATH: 'variants' = 'variants'
+export const VARIANT_DOCUMENTS_PATH: '_.variants' = '_.variants'
 
 /**
  * @internal This is the client options used for the variants studio client, using the `X` API version for now

--- a/packages/sanity/src/core/variants/store/createVariantOperationsStore.ts
+++ b/packages/sanity/src/core/variants/store/createVariantOperationsStore.ts
@@ -1,26 +1,38 @@
 import {type SanityClient} from '@sanity/client'
 
-import {type EditableSystemVariant, type SystemVariant} from '../types'
+import {getVariantId} from '../tool/util'
+import {type EditableSystemVariant} from '../types'
+import {variantsClient, type VariantDefinitionActionResult} from './variantsClient'
 
 export interface VariantOperationsStore {
-  createVariant: (variant: EditableSystemVariant) => Promise<SystemVariant>
-  updateVariant: (variant: EditableSystemVariant) => Promise<SystemVariant>
-  deleteVariant: (variantId: string) => Promise<unknown>
+  createVariant: (variant: EditableSystemVariant) => Promise<VariantDefinitionActionResult>
+  updateVariant: (variant: EditableSystemVariant) => Promise<VariantDefinitionActionResult>
+  deleteVariant: (variantId: string) => Promise<VariantDefinitionActionResult>
 }
 
 /**
- * Temporary using the client with direct groq mutations, like create, set, delete...
- * Needs to be updated once we have the variant client actions.
+ * Variant definition writes use the actions API. See ../ACTIONS.md.
  */
 export function createVariantOperationsStore(options: {
   client: SanityClient
 }): VariantOperationsStore {
-  const {client} = options
+  const client = variantsClient(options.client)
 
-  const handleCreateVariant = (variant: EditableSystemVariant) =>
-    client.create(variant) as Promise<SystemVariant>
+  const handleCreateVariant = async (variant: EditableSystemVariant) => {
+    const variantId = getVariantId(variant._id)
+    const action = {
+      actionType: 'sanity.action.variant.definition.create' as const,
+      variantId,
+      conditions: variant.conditions,
+      priority: variant.priority,
+      ...(variant.metadata ? {metadata: variant.metadata} : {}),
+    }
 
-  const handleUpdateVariant = (variant: EditableSystemVariant) => {
+    return await client.action(action, {tag: 'variants.create'})
+  }
+
+  const handleUpdateVariant = async (variant: EditableSystemVariant) => {
+    const variantId = getVariantId(variant._id)
     const setPayload: Pick<EditableSystemVariant, 'conditions' | 'priority'> &
       Partial<Pick<EditableSystemVariant, 'metadata'>> = {
       conditions: variant.conditions,
@@ -31,16 +43,34 @@ export function createVariantOperationsStore(options: {
       setPayload.metadata = variant.metadata
     }
 
-    const patch = client.patch(variant._id).set(setPayload)
-
-    if (!variant.metadata) {
-      patch.unset(['metadata'])
+    const patch: {
+      set: typeof setPayload
+      unset?: ['metadata']
+    } = {
+      set: setPayload,
     }
 
-    return patch.commit() as Promise<SystemVariant>
+    if (!variant.metadata) {
+      patch.unset = ['metadata']
+    }
+
+    const action = {
+      actionType: 'sanity.action.variant.definition.edit' as const,
+      variantId,
+      patch,
+    }
+
+    return await client.action(action, {tag: 'variants.edit'})
   }
 
-  const handleDeleteVariant = (variantId: string) => client.delete(variantId)
+  const handleDeleteVariant = async (variantIdOrDocumentId: string) => {
+    const action = {
+      actionType: 'sanity.action.variant.definition.delete' as const,
+      variantId: getVariantId(variantIdOrDocumentId),
+    }
+
+    return await client.action(action, {tag: 'variants.delete'})
+  }
 
   return {
     createVariant: handleCreateVariant,

--- a/packages/sanity/src/core/variants/store/createVariantsStore.ts
+++ b/packages/sanity/src/core/variants/store/createVariantsStore.ts
@@ -18,6 +18,7 @@ const QUERY_PROJECTION = `{
   _rev,
   _createdAt,
   _updatedAt,
+  name,
   conditions,
   "priority": coalesce(priority, 0),
   metadata,

--- a/packages/sanity/src/core/variants/store/variantsClient.ts
+++ b/packages/sanity/src/core/variants/store/variantsClient.ts
@@ -17,7 +17,7 @@ export interface VariantDefinitionActionResult {
 export interface VariantDefinitionCreateAction {
   actionType: 'sanity.action.variant.definition.create'
   variantId: string
-  conditions: EditableSystemVariant['conditions']
+  conditions?: EditableSystemVariant['conditions']
   priority?: number
   metadata?: EditableSystemVariant['metadata']
 }

--- a/packages/sanity/src/core/variants/store/variantsClient.ts
+++ b/packages/sanity/src/core/variants/store/variantsClient.ts
@@ -1,0 +1,65 @@
+import {type BaseActionOptions, type SanityClient} from '@sanity/client'
+
+import {type EditableSystemVariant} from '../types'
+
+/**
+ * Variant definition actions resolve to the transaction id of the submitted
+ * mutation, not the affected document.
+ */
+export interface VariantDefinitionActionResult {
+  transactionId: string
+}
+
+/**
+ * Variant definition action payloads. See ../ACTIONS.md.
+ *
+ */
+export interface VariantDefinitionCreateAction {
+  actionType: 'sanity.action.variant.definition.create'
+  variantId: string
+  conditions: EditableSystemVariant['conditions']
+  priority?: number
+  metadata?: EditableSystemVariant['metadata']
+}
+
+export interface VariantDefinitionEditAction {
+  actionType: 'sanity.action.variant.definition.edit'
+  variantId: string
+  patch: {
+    set: Pick<EditableSystemVariant, 'conditions' | 'priority'> &
+      Partial<Pick<EditableSystemVariant, 'metadata'>>
+    unset?: ['metadata']
+  }
+  ifRevisionId?: string
+}
+
+export interface VariantDefinitionDeleteAction {
+  actionType: 'sanity.action.variant.definition.delete'
+  variantId: string
+  ifRevisionId?: string
+}
+
+export type VariantDefinitionAction =
+  | VariantDefinitionCreateAction
+  | VariantDefinitionEditAction
+  | VariantDefinitionDeleteAction
+
+/**
+ * Temporary client typing until sanity/client exports variant definition actions.
+ *
+ */
+export interface SanityClientWithVariantsActions extends Omit<SanityClient, 'action'> {
+  action(
+    action: VariantDefinitionAction,
+    options?: BaseActionOptions,
+  ): Promise<VariantDefinitionActionResult>
+}
+
+/**
+ * Returns a client whose `action` method accepts variant definition actions.
+ * Remove once sanity/client exports these action types.
+ *
+ */
+export function variantsClient(client: SanityClient): SanityClientWithVariantsActions {
+  return client as unknown as SanityClientWithVariantsActions
+}

--- a/packages/sanity/src/core/variants/types.ts
+++ b/packages/sanity/src/core/variants/types.ts
@@ -5,6 +5,7 @@ import {type VARIANT_DOCUMENT_TYPE, type VARIANT_DOCUMENTS_PATH} from './store/c
 export interface SystemVariant extends SanityDocument {
   _type: typeof VARIANT_DOCUMENT_TYPE
   _id: `${typeof VARIANT_DOCUMENTS_PATH}.${string}`
+  name?: string
   conditions: Record<string, string>
   priority: number // defaults to 0.
   metadata?: {


### PR DESCRIPTION
### Description

Variant definition writes in Studio were still using direct client mutations against a temporary `variants.*` path. The API now exposes dedicated definition actions under `_.variants.*`, with server-side validation and feature/limit checks — Studio now uses those actions.

This PR wires create/edit/delete through the definition actions, moves the document path to `_.variants`, aligns condition key/value validation with the API contract.


### What to review

- **`store/createVariantOperationsStore.ts` + `store/variantsClient.ts`** — action payloads, return types, and the temporary client typing shim
- **`ACTIONS.md`** — does the documented contract match what we're sending?
- **`store/constants.ts`** — path change from `variants` → `_.variants` ripples through queries, fixtures, and e2e
- 
### Testing

- Unit tests updated/added for operations store, condition validation, create/edit dialogs.

### Notes for release

N/A – Part of feature 