### PR TITLE
feat(core): enable react strict mode by default in studio

### DIFF
--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -1,6 +1,6 @@
 import {DeferredTelemetryProvider} from '@sanity/telemetry/react'
 import {ToastProvider} from '@sanity/ui'
-import {type ReactNode, useMemo} from 'react'
+import {type ReactNode, useEffect, useMemo} from 'react'
 
 import {LoadingBlock} from '../components/loadingBlock'
 import {errorReporter} from '../error/errorReporter'
@@ -54,13 +54,12 @@ export function StudioProvider({
   unstable_history: history,
   unstable_noAuthBoundary: noAuthBoundary,
 }: StudioProviderProps) {
-  // We initialize the error reporter as early as possible in order to catch anything that could
-  // occur during configuration loading, React rendering etc. StudioProvider is often the highest
-  // mounted React component that is shared across embedded and standalone studios.
-  errorReporter.initialize()
-
-  // Register refractor languages on first render (deferred from module scope for faster import)
-  ensureRefractorLanguages()
+  // Run in an effect to keep render pure; both calls are idempotent and buffer/guard
+  // their own work, so StrictMode's double mount is safe.
+  useEffect(() => {
+    errorReporter.initialize()
+    ensureRefractorLanguages()
+  }, [])
 
   // Extract the first workspace's projectId for use in error screens
   const primaryProjectId = useMemo(() => {

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
@@ -60,10 +60,12 @@ export function SearchResultItem({
 
   useEffect(() => {
     if (state.canDisableAction) {
-      grantsStore
+      const subscription = grantsStore
         .checkDocumentPermission('create', {_id: documentId, _type: documentType})
         .subscribe(setCreatePermission)
+      return () => subscription.unsubscribe()
     }
+    return undefined
   }, [documentId, documentType, grantsStore, state.canDisableAction])
 
   // the current search result exists in the release provided by the search provider

--- a/packages/sanity/src/core/studio/manifest/LiveManifestRegisterProvider.tsx
+++ b/packages/sanity/src/core/studio/manifest/LiveManifestRegisterProvider.tsx
@@ -1,6 +1,6 @@
 import {useRootTheme} from '@sanity/ui'
 import debugit from 'debug'
-import {useEffect, useRef} from 'react'
+import {useEffect} from 'react'
 
 import {useLiveUserApplication} from '../liveUserApplication/useLiveUserApplication'
 import {useWorkspaces} from '../workspaces'
@@ -19,26 +19,18 @@ export function LiveManifestRegisterProvider() {
   const {userApplication} = useLiveUserApplication()
   const {theme} = useRootTheme()
 
-  const lastUploadedRef =
-    useRef<[typeof userApplication, typeof workspaces, typeof theme]>(undefined)
-
   useEffect(() => {
-    if (!userApplication || workspaces.length === 0) return
+    if (!userApplication || workspaces.length === 0) return undefined
 
-    // Skip StrictMode's double-invoked mount effect, where every dep is referentially
-    // identical, while still re-uploading whenever any dep genuinely changes.
-    const previous = lastUploadedRef.current
-    const unchanged =
-      previous &&
-      previous[0] === userApplication &&
-      previous[1] === workspaces &&
-      previous[2] === theme
-    if (unchanged) return
-
-    lastUploadedRef.current = [userApplication, workspaces, theme]
-    registerStudioManifest(userApplication, workspaces, theme).catch((err) => {
-      debug('Failed to upload studio manifest', err)
+    // Abort the in-flight upload on cleanup so StrictMode's double mount, or a dep change,
+    // leaves only the latest upload running rather than racing duplicate requests.
+    const controller = new AbortController()
+    registerStudioManifest(userApplication, workspaces, theme, controller.signal).catch((error) => {
+      if (error.name === 'AbortError') return
+      debug('Failed to upload studio manifest', error)
     })
+
+    return () => controller.abort()
   }, [userApplication, workspaces, theme])
 
   return null

--- a/packages/sanity/src/core/studio/manifest/LiveManifestRegisterProvider.tsx
+++ b/packages/sanity/src/core/studio/manifest/LiveManifestRegisterProvider.tsx
@@ -1,6 +1,6 @@
 import {useRootTheme} from '@sanity/ui'
 import debugit from 'debug'
-import {useEffect} from 'react'
+import {useEffect, useRef} from 'react'
 
 import {useLiveUserApplication} from '../liveUserApplication/useLiveUserApplication'
 import {useWorkspaces} from '../workspaces'
@@ -19,12 +19,23 @@ export function LiveManifestRegisterProvider() {
   const {userApplication} = useLiveUserApplication()
   const {theme} = useRootTheme()
 
+  const lastUploadedRef =
+    useRef<[typeof userApplication, typeof workspaces, typeof theme]>(undefined)
+
   useEffect(() => {
-    if (!userApplication || workspaces.length === 0) {
-      // Nothing to register
-      return
-    }
-    // Upload once when workspaces are available
+    if (!userApplication || workspaces.length === 0) return
+
+    // Skip StrictMode's double-invoked mount effect, where every dep is referentially
+    // identical, while still re-uploading whenever any dep genuinely changes.
+    const previous = lastUploadedRef.current
+    const unchanged =
+      previous &&
+      previous[0] === userApplication &&
+      previous[1] === workspaces &&
+      previous[2] === theme
+    if (unchanged) return
+
+    lastUploadedRef.current = [userApplication, workspaces, theme]
     registerStudioManifest(userApplication, workspaces, theme).catch((err) => {
       debug('Failed to upload studio manifest', err)
     })

--- a/packages/sanity/src/core/studio/manifest/LiveManifestRegisterProvider.tsx
+++ b/packages/sanity/src/core/studio/manifest/LiveManifestRegisterProvider.tsx
@@ -26,7 +26,7 @@ export function LiveManifestRegisterProvider() {
     // leaves only the latest upload running rather than racing duplicate requests.
     const controller = new AbortController()
     registerStudioManifest(userApplication, workspaces, theme, controller.signal).catch((error) => {
-      if (error.name === 'AbortError') return
+      if (error?.name === 'AbortError') return
       debug('Failed to upload studio manifest', error)
     })
 

--- a/packages/sanity/src/core/studio/manifest/__tests__/LiveManifestRegisterProvider.test.tsx
+++ b/packages/sanity/src/core/studio/manifest/__tests__/LiveManifestRegisterProvider.test.tsx
@@ -7,8 +7,10 @@ import {useWorkspaces} from '../../workspaces'
 import {LiveManifestRegisterProvider} from '../LiveManifestRegisterProvider'
 import {registerStudioManifest} from '../registerLiveStudioManifest'
 
+const theme = {}
+
 vi.mock('@sanity/ui', () => ({
-  useRootTheme: vi.fn(() => ({theme: {}})),
+  useRootTheme: vi.fn(() => ({theme})),
 }))
 vi.mock('../../liveUserApplication/useLiveUserApplication', () => ({
   useLiveUserApplication: vi.fn(),
@@ -30,27 +32,37 @@ describe('LiveManifestRegisterProvider', () => {
     vi.mocked(useLiveUserApplication).mockReturnValue({userApplication} as never)
   })
 
-  it('uploads the manifest once when mounted normally', () => {
+  it('registers the manifest with the resolved user application, workspaces and theme', () => {
     render(<LiveManifestRegisterProvider />)
-    expect(registerStudioManifest).toHaveBeenCalledTimes(1)
+    expect(registerStudioManifest).toHaveBeenCalledWith(
+      userApplication,
+      workspaces,
+      theme,
+      expect.any(AbortSignal),
+    )
   })
 
-  it('uploads the manifest only once when mounted in StrictMode', () => {
+  it('aborts the superseded upload when remounted under StrictMode', () => {
     render(
       <StrictMode>
         <LiveManifestRegisterProvider />
       </StrictMode>,
     )
-    expect(registerStudioManifest).toHaveBeenCalledTimes(1)
+
+    // StrictMode mounts, unmounts, then remounts: the first upload's signal is aborted by
+    // cleanup, so only the second upload runs to completion.
+    const [firstCall, secondCall] = vi.mocked(registerStudioManifest).mock.calls
+    expect(firstCall[3]?.aborted).toBe(true)
+    expect(secondCall[3]?.aborted).toBe(false)
   })
 
-  it('does not upload when there is no user application', () => {
+  it('does not register when there is no user application', () => {
     vi.mocked(useLiveUserApplication).mockReturnValue({userApplication: undefined} as never)
     render(<LiveManifestRegisterProvider />)
     expect(registerStudioManifest).not.toHaveBeenCalled()
   })
 
-  it('does not upload when there are no workspaces', () => {
+  it('does not register when there are no workspaces', () => {
     vi.mocked(useWorkspaces).mockReturnValue([] as never)
     render(<LiveManifestRegisterProvider />)
     expect(registerStudioManifest).not.toHaveBeenCalled()

--- a/packages/sanity/src/core/studio/manifest/__tests__/LiveManifestRegisterProvider.test.tsx
+++ b/packages/sanity/src/core/studio/manifest/__tests__/LiveManifestRegisterProvider.test.tsx
@@ -1,0 +1,58 @@
+import {render} from '@testing-library/react'
+import {StrictMode} from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {useLiveUserApplication} from '../../liveUserApplication/useLiveUserApplication'
+import {useWorkspaces} from '../../workspaces'
+import {LiveManifestRegisterProvider} from '../LiveManifestRegisterProvider'
+import {registerStudioManifest} from '../registerLiveStudioManifest'
+
+vi.mock('@sanity/ui', () => ({
+  useRootTheme: vi.fn(() => ({theme: {}})),
+}))
+vi.mock('../../liveUserApplication/useLiveUserApplication', () => ({
+  useLiveUserApplication: vi.fn(),
+}))
+vi.mock('../../workspaces', () => ({
+  useWorkspaces: vi.fn(),
+}))
+vi.mock('../registerLiveStudioManifest', () => ({
+  registerStudioManifest: vi.fn().mockResolvedValue(undefined),
+}))
+
+describe('LiveManifestRegisterProvider', () => {
+  const userApplication = {id: 'app-1', projectId: 'project-1'}
+  const workspaces = [{name: 'default', projectId: 'project-1'}]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useWorkspaces).mockReturnValue(workspaces as never)
+    vi.mocked(useLiveUserApplication).mockReturnValue({userApplication} as never)
+  })
+
+  it('uploads the manifest once when mounted normally', () => {
+    render(<LiveManifestRegisterProvider />)
+    expect(registerStudioManifest).toHaveBeenCalledTimes(1)
+  })
+
+  it('uploads the manifest only once when mounted in StrictMode', () => {
+    render(
+      <StrictMode>
+        <LiveManifestRegisterProvider />
+      </StrictMode>,
+    )
+    expect(registerStudioManifest).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not upload when there is no user application', () => {
+    vi.mocked(useLiveUserApplication).mockReturnValue({userApplication: undefined} as never)
+    render(<LiveManifestRegisterProvider />)
+    expect(registerStudioManifest).not.toHaveBeenCalled()
+  })
+
+  it('does not upload when there are no workspaces', () => {
+    vi.mocked(useWorkspaces).mockReturnValue([] as never)
+    render(<LiveManifestRegisterProvider />)
+    expect(registerStudioManifest).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sanity/src/core/studio/manifest/__tests__/registerLiveStudioManifest.test.tsx
+++ b/packages/sanity/src/core/studio/manifest/__tests__/registerLiveStudioManifest.test.tsx
@@ -302,4 +302,33 @@ describe('registerStudioManifest', () => {
       expect(callArgs.body.value.workspaces[0].subtitle).toBeUndefined()
     })
   })
+
+  describe('abort signal', () => {
+    it('should forward the abort signal to the request', async () => {
+      const controller = new AbortController()
+
+      await registerStudioManifest(
+        mockUserApplication,
+        [createMockWorkspace()],
+        mockTheme,
+        controller.signal,
+      )
+
+      expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({signal: controller.signal}))
+    })
+
+    it('should skip the POST when the signal is already aborted', async () => {
+      const controller = new AbortController()
+      controller.abort()
+
+      await registerStudioManifest(
+        mockUserApplication,
+        [createMockWorkspace()],
+        mockTheme,
+        controller.signal,
+      )
+
+      expect(mockRequest).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/sanity/src/core/studio/manifest/registerLiveStudioManifest.tsx
+++ b/packages/sanity/src/core/studio/manifest/registerLiveStudioManifest.tsx
@@ -40,6 +40,7 @@ async function resolveSchemaDescriptorId(workspace: WorkspaceSummary): Promise<s
  * @param userApplication - The user application
  * @param workspaces - Array of all workspaces in the Studio
  * @param theme - The Studio theme to use for rendering icons
+ * @param signal - Aborts the upload when the registering effect is torn down
  * @returns Promise that resolves when upload is complete
  * @internal
  */
@@ -47,6 +48,7 @@ export async function registerStudioManifest(
   userApplication: UserApplication,
   workspaces: WorkspaceSummary[],
   theme: RootTheme,
+  signal?: AbortSignal,
 ): Promise<void> {
   const {id, projectId} = userApplication
 
@@ -81,6 +83,11 @@ export async function registerStudioManifest(
     return // if the user isn't authenticated, nothing to do
   }
 
+  // Bail before posting if the registering effect has already been torn down.
+  if (signal?.aborted) {
+    return
+  }
+
   // Post the live manifest via the global api
   await client.withConfig(DEFAULT_STUDIO_CLIENT_OPTIONS).request({
     method: 'POST',
@@ -89,5 +96,6 @@ export async function registerStudioManifest(
       value: liveManifest,
     },
     tag: 'live-manifest-register',
+    signal,
   })
 }

--- a/packages/sanity/src/core/studio/renderStudio.tsx
+++ b/packages/sanity/src/core/studio/renderStudio.tsx
@@ -40,7 +40,7 @@ export function renderStudio(
   }
 
   const opts = typeof options === 'boolean' ? {reactStrictMode: options} : options
-  const {reactStrictMode = false, basePath} = opts
+  const {reactStrictMode = true, basePath} = opts
 
   const root = createRoot(rootElement)
 

--- a/packages/sanity/src/core/studio/renderStudio.tsx
+++ b/packages/sanity/src/core/studio/renderStudio.tsx
@@ -33,7 +33,7 @@ export function renderStudio(
 export function renderStudio(
   rootElement: HTMLElement | null,
   config: Config,
-  options: RenderStudioOptions | boolean = false,
+  options: RenderStudioOptions | boolean = {},
 ): () => void {
   if (!rootElement) {
     throw new Error('Missing root element to mount application into')

--- a/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
+++ b/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
@@ -184,8 +184,11 @@ export function StudioTelemetryProvider(props: {children: ReactNode}) {
   // eslint-disable-next-line react-hooks/refs
   const store = useMemo(() => createBatchedStore(sessionId, storeOptions), [storeOptions])
 
+  // Per-instance guard so StrictMode's double-invoked mount effect logs StudioLoaded once.
+  const studioLoadedFiredRef = useRef(false)
   useEffect(() => {
-    if (!isClient || !contextRef.current) return
+    if (!isClient || !contextRef.current || studioLoadedFiredRef.current) return
+    studioLoadedFiredRef.current = true
     const ctx = contextRef.current
     store.logger.log(StudioLoaded, {
       studioVersion: SANITY_VERSION,

--- a/packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx
+++ b/packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx
@@ -2,7 +2,7 @@ import type * as SanityTelemetry from '@sanity/telemetry'
 /* eslint-disable import/first */
 // Regular imports first
 import {render} from '@testing-library/react'
-import {type ReactNode} from 'react'
+import {StrictMode, type ReactNode} from 'react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 // Disable console.logging of telemetry events in tests
@@ -501,5 +501,20 @@ describe('StudioTelemetryProvider', () => {
         screenInnerWidth: expect.any(Number),
       }),
     )
+  })
+
+  it('emits StudioLoaded only once when mounted in StrictMode', () => {
+    render(
+      <StrictMode>
+        <DeferredTelemetryProvider>
+          <StudioTelemetryProvider>
+            <div>Test Child</div>
+          </StudioTelemetryProvider>
+        </DeferredTelemetryProvider>
+      </StrictMode>,
+    )
+
+    const studioLoadedCalls = mockLog.mock.calls.filter(([event]) => event === StudioLoaded)
+    expect(studioLoadedCalls).toHaveLength(1)
   })
 })


### PR DESCRIPTION
### Description

Enables React StrictMode by default in Studio V6 and makes Studio's own components safe under StrictMode's dev-time double-invoke. Flips the `renderStudio` default for `reactStrictMode` to `true`, so imperative/embedded callers that omit the option render under StrictMode. The default for CLI-launched studios (`sanity dev`) is flipped in the companion `@sanity/cli` PR. Part of [SAPP-3841](https://linear.app/sanity/issue/SAPP-3841).

Also fixes a genuine subscription leak in the navbar search result item (the document-permission check never unsubscribed). This leaked in production independent of StrictMode; the audit surfaced it.

### What to review

- `renderStudio.tsx` - the implementation default is now `{}` so the `reactStrictMode = true` destructuring default actually applies when the third argument is omitted (the previous `= false` boolean default silently overrode it). Only affects imperative `renderStudio` callers; CLI studios always pass an explicit value.
- `LiveManifestRegisterProvider.tsx` + `registerLiveStudioManifest.tsx` - the upload now accepts an `AbortSignal`; the effect aborts it on cleanup, so StrictMode's double mount (or a genuine dep change) cancels the superseded upload and only the latest runs. No dedup bookkeeping in the component.
- `StudioTelemetryProvider.tsx` - `useRef` one-shot guard so `StudioLoaded` logs once under StrictMode.
- `StudioProvider.tsx` - moved `errorReporter.initialize()` and `ensureRefractorLanguages()` into a mount effect for render purity; safe because pre-init errors are buffered and flushed on init.
- `SearchResultItem.tsx` - the permission-check subscription now unsubscribes on cleanup.

The dev studios already run with `reactStrictMode: true`, so no crash or warning-level incompatibilities remain. A sweep across ~191 useEffect sites found only silent, dev-only residue plus the one real leak fixed here.

### Testing

- `StudioTelemetryProvider.test.tsx` - asserts `StudioLoaded` logs once under `<StrictMode>`.
- `LiveManifestRegisterProvider.test.tsx` - asserts the component registers with the resolved inputs, that StrictMode's cleanup aborts the superseded upload's signal, and that it skips when there is no user application or no workspaces.
- `registerLiveStudioManifest.test.tsx` - asserts the abort signal is forwarded to the request and the POST is skipped when the signal is already aborted.
- Targeted tests pass; types and lint clean. CI runs the full suite.

### Notes for release

React StrictMode is now enabled by default for `renderStudio` callers in Studio V6. Embedded or programmatic studios that call `renderStudio(element, config)` without an options object render under `<React.StrictMode>`; pass `{reactStrictMode: false}` to opt out. StrictMode only affects development and is a no-op in production builds. The default for `sanity dev` is flipped in the companion `@sanity/cli` release.
