### PR TITLE
feat(core): adds document level presence

### DIFF
--- a/packages/sanity/src/core/form/store/__tests__/formState.test.ts
+++ b/packages/sanity/src/core/form/store/__tests__/formState.test.ts
@@ -507,6 +507,35 @@ describe.each(
   })
 })
 
+describe('presence path filtering', () => {
+  test('document-level presence (path: []) does not propagate to child fields', () => {
+    const docLevelPresence = {
+      path: [] as Path,
+      lastActiveAt: '2024-09-12T21:59:08.362Z',
+      sessionId: 'docSession',
+      user: {id: 'docUser'},
+    }
+    const fieldPresence = {
+      path: ['title'] as Path,
+      lastActiveAt: '2024-09-12T21:59:08.362Z',
+      sessionId: 'fieldSession',
+      user: {id: 'fieldUser'},
+    }
+
+    const formState = prepareFormState({
+      ...defaultOptions,
+      presence: [docLevelPresence, fieldPresence],
+    })
+
+    const titleNode = Array.from(traverseForm(formState)).find(
+      ([node]) => node.path.length === 1 && toString(node.path) === 'title',
+    )?.[0]
+
+    expect(titleNode).toBeDefined()
+    expect(titleNode?.presence).toEqual([fieldPresence])
+  })
+})
+
 describe('hidden', () => {
   const pathsToTest: {
     path: Path

--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -10,7 +10,15 @@ import {
 } from '@sanity/types'
 import {pathFor} from '@sanity/util/paths'
 import throttle from 'lodash-es/throttle.js'
-import {type RefObject, useEffect, useInsertionEffect, useMemo, useRef, useState} from 'react'
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useInsertionEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import deepEquals from 'react-fast-compare'
 
 import {
@@ -506,17 +514,25 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
     onSetOpenPath(path)
   }
 
-  const updatePresence = (nextFocusPath: Path, payload?: OnPathFocusPayload) => {
-    presenceStore.setLocation([
-      {
-        type: 'document',
-        documentId: value._id,
-        path: nextFocusPath,
-        lastActiveAt: new Date().toISOString(),
-        selection: payload?.selection,
-      },
-    ])
-  }
+  const updatePresence = useCallback(
+    (nextFocusPath: Path, payload?: OnPathFocusPayload) => {
+      presenceStore.setLocation([
+        {
+          type: 'document',
+          documentId: value._id,
+          path: nextFocusPath,
+          lastActiveAt: new Date().toISOString(),
+          selection: payload?.selection,
+        },
+      ])
+    },
+    [presenceStore, value._id],
+  )
+
+  // Announce presence on the document root when the form mounts
+  useEffect(() => {
+    updatePresence(EMPTY_ARRAY)
+  }, [updatePresence])
 
   const updatePresenceThrottled = throttle(updatePresence, 1000, {leading: true, trailing: true})
   const focusPathRef = useRef<Path>([])
@@ -544,8 +560,9 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
       onFocusPath?.(EMPTY_ARRAY)
     }
 
-    // note: we're deliberately not syncing presence here since it would make the user avatar disappear when a
-    // user clicks outside a field without focusing another one
+    // Move presence to the document root (no specific field).
+    // DocumentPanelHeader renders these — see document-level-presence cluster.
+    updatePresenceThrottled(EMPTY_ARRAY)
   }
 
   const handleProgrammaticFocus = (nextPath: Path) => {

--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -534,7 +534,17 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
     updatePresence(EMPTY_ARRAY)
   }, [updatePresence])
 
-  const updatePresenceThrottled = throttle(updatePresence, 1000, {leading: true, trailing: true})
+  const updatePresenceThrottled = useMemo(
+    () => throttle(updatePresence, 1000, {leading: true, trailing: true}),
+    [updatePresence],
+  )
+
+  useEffect(() => {
+    return () => {
+      updatePresenceThrottled.cancel()
+    }
+  }, [updatePresenceThrottled])
+
   const focusPathRef = useRef<Path>([])
 
   const handleFocus = (_nextFocusPath: Path, payload?: OnPathFocusPayload) => {

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -13,7 +13,14 @@ import {
   useRef,
   useState,
 } from 'react'
-import {type DocumentActionDescription, useFieldActions, useTranslation, useZIndex} from 'sanity'
+import {
+  FieldPresenceInner,
+  type DocumentActionDescription,
+  useDocumentPresence,
+  useFieldActions,
+  useTranslation,
+  useZIndex,
+} from 'sanity'
 import {css, styled} from 'styled-components'
 
 import {Button, TooltipDelayGroupProvider} from '../../../../../ui-components'
@@ -149,6 +156,11 @@ export const DocumentPanelHeader = memo(
     const showPaneGroupCloseButton = !showSplitPaneCloseButton && !showBackButton && !!BackLink
 
     const {t} = useTranslation(structureLocaleNamespace)
+    const presence = useDocumentPresence(documentId)
+    const documentLevelPresence = useMemo(
+      () => presence.filter((p) => p.path.length === 0),
+      [presence],
+    )
 
     const isMaximizedPane = useMemo(() => {
       return (
@@ -217,6 +229,11 @@ export const DocumentPanelHeader = memo(
 
               <Box flex="none" paddingRight={3}>
                 <Flex align="center" gap={1}>
+                  {documentLevelPresence.length > 0 && (
+                    <Box data-testid="document-level-presence" marginRight={2}>
+                      <FieldPresenceInner presence={documentLevelPresence} stack />
+                    </Box>
+                  )}
                   {unstable_languageFilter.length > 0 && (
                     <>
                       {unstable_languageFilter.map((LanguageFilterComponent, idx) => {


### PR DESCRIPTION
### Description
Fixes https://github.com/sanity-io/sanity/issues/12620

When focus left a field, we stopped updating presence but kept the last field path—so collaborators still saw the avatar on that field. The old blur handler skipped `setLocation` on purpose so the user would not “disappear” entirely; there was no document-level surface to show them.

This PR treats presence as **field or document**: blur syncs `path: []`, and a header avatar cluster shows users on the document but not on a specific field. Opening a document also announces document-level presence immediately so collaborators see someone is here before they focus a field.


https://github.com/user-attachments/assets/e2cfacaf-81dd-49a1-8e24-f6e9a7ae7eea



### What to review

Changes to `useDocumentForm` announcing presence when the document mounts and changes to `DocumentPanelHeader` adding document presence.


### Testing

- `useDocumentForm.presence.test.ts` — mount announce, focus path, blur → `path: []` (regression), doc id change re-announce (fake timers for throttle).
- `formState.test.ts` — document-level presence does not propagate to child fields.
- Manual (recommended): two Studio sessions on the same doc — blur a field, presence should update.
- Change to another document, presence should move to the other document

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Collaborators now see when someone is on a document even before they focus a field, their avatar appears in the document pane header.

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
