### PR TITLE
fix(structure): memoize incoming refs filter

### DIFF
--- a/dev/test-studio/schema/author.ts
+++ b/dev/test-studio/schema/author.ts
@@ -25,9 +25,10 @@ export default defineType({
         // title: 'Incoming references with the same role',
         description: 'This are other authors with the same role as this one',
         filter: (context) => {
+          const role = typeof context.document?.role === 'string' ? context.document.role : ''
           return {
             filter: `role == $role`,
-            filterParams: {role: context.document?.role || ''},
+            filterParams: {role},
           }
         },
         actions: [RemoveReferenceAction],

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx
@@ -54,17 +54,31 @@ export function IncomingReferencesType({
   const {displayed} = useDocumentPane()
   const {getClient} = useSource()
   const displayedId = displayed?._id as string
+  /**
+   * `filter` is a function or a string, if it's a function it will get a new reference on every render
+   * `filterParams` is an object, so it will also get a new reference on every render.
+   *
+   * If they are not memoized the `references$` observable will be recreated on every render,
+   * causing the list to jump even when the resolved GROQ filter is unchanged.
+   *
+   * It is safe to capture the initial values here because both come from the schema, not
+   * from React render state. Schema changes reload the studio, so pinning the first reference for this mount
+   * does not stale meaningful configuration.
+   */
+  const [memoizedFilter] = useState(() => filter)
+  const [memoizedFilterParams] = useState(() => filterParams)
+
   const references$ = useMemo(
     () =>
       getIncomingReferences({
         documentId: displayedId,
         documentPreviewStore,
         type: type.type,
-        filter,
-        filterParams,
+        filter: memoizedFilter,
+        filterParams: memoizedFilterParams,
         getClient,
       }),
-    [documentPreviewStore, type, filter, filterParams, displayedId, getClient],
+    [documentPreviewStore, type.type, memoizedFilter, memoizedFilterParams, displayedId, getClient],
   )
 
   const {documents, loading} = useObservable(references$, INITIAL_STATE)


### PR DESCRIPTION
### Description

Memoizes incoming references filter and filter params avoiding UI flickering when the document changes and the component re renders.

Incoming-reference decorations re renders with each keystroke.
Each render produces a new `filter` function and `filterParams` object, even when their behavior is identical. Those fresh references invalidated the `references$` useMemo, recreated the observable, and re-fired `startWith(INITIAL_STATE)`, so the list flashed "loading" and jumped on every keystroke even though the resolved GROQ filter never changed.

The RxJS pipeline already dedupes correctly (on _rev and on the resolved {filter, filterParams}), so the churn was purely upstream in React — hence the fix lives at the memo boundary, not in the stream.


https://github.com/user-attachments/assets/84d20aa9-6729-40d9-8393-9051a985b9e8



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review


<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

Editing an unrelated field on a document with an incoming-references decoration no longer flashes the loading state or shifts the list; it only refetches when the resolved filter actually changes (e.g. changing role).

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes incoming references input flashing loading state.
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
