### PR TITLE
feat(core): use schema preview selection for search

### DIFF
--- a/packages/sanity/src/core/search/common/__tests__/deriveSearchWeightsFromType.test.ts
+++ b/packages/sanity/src/core/search/common/__tests__/deriveSearchWeightsFromType.test.ts
@@ -2,7 +2,10 @@ import {type CrossDatasetReferenceSchemaType, defineField, defineType} from '@sa
 import {describe, expect, it} from 'vitest'
 
 import {createSchema} from '../../../schema'
-import {deriveSearchWeightsFromType} from '../deriveSearchWeightsFromType'
+import {
+  deriveSearchWeightsFromType,
+  getPreviewSelectionPathWeights,
+} from '../deriveSearchWeightsFromType'
 
 describe('deriveSearchWeightsFromType', () => {
   it('finds all the strings and PT fields within a document type', () => {
@@ -477,6 +480,148 @@ describe('deriveSearchWeightsFromType', () => {
       }),
     ).toMatchObject({
       typeName: 'testType',
+    })
+  })
+
+  it('includes reference fields used in the preview selection in search weights', () => {
+    const schema = createSchema({
+      name: 'default',
+      types: [
+        defineType({
+          name: 'author',
+          type: 'document',
+          fields: [defineField({name: 'name', type: 'string'})],
+        }),
+        defineType({
+          name: 'article',
+          type: 'document',
+          preview: {
+            select: {
+              title: 'title',
+              category: 'category',
+              subtitle: 'author.name',
+            },
+            prepare({title, category, subtitle: authorName}) {
+              return {
+                title,
+                subtitle: [category, authorName].filter(Boolean).join(' · '),
+              }
+            },
+          },
+          fields: [
+            defineField({name: 'title', type: 'string'}),
+            defineField({name: 'category', type: 'string'}),
+            defineField({
+              name: 'author',
+              type: 'reference',
+              to: [{type: 'author'}],
+            }),
+          ],
+        }),
+      ],
+    })
+
+    const result = deriveSearchWeightsFromType({
+      schemaType: schema.get('article')!,
+      maxDepth: 5,
+    })
+
+    expect(result.paths).toEqual(
+      expect.arrayContaining([
+        {path: 'title', weight: 10},
+        {path: 'category', weight: 1},
+        {path: 'author.name', weight: 5},
+      ]),
+    )
+  })
+})
+
+describe('getPreviewSelectionPathWeights', () => {
+  const schema = createSchema({
+    name: 'default',
+    types: [
+      {
+        name: 'author',
+        type: 'document',
+        fields: [
+          {name: 'name', type: 'string'},
+          {name: 'age', type: 'number'},
+          {name: 'slug', type: 'slug'},
+          {name: 'bestFriend', type: 'reference', to: [{type: 'author'}]},
+        ],
+      },
+      {
+        name: 'book',
+        type: 'document',
+        fields: [
+          {name: 'title', type: 'string'},
+          {name: 'publicationYear', type: 'number'},
+          {name: 'slug', type: 'slug'},
+          {name: 'author', type: 'reference', to: [{type: 'author'}]},
+          {name: 'coverImage', type: 'image'},
+        ],
+      },
+    ],
+  })
+
+  const bookType = schema.get('book')!
+
+  it('resolves reference paths to searchable leaves using the preview weight', () => {
+    expect(
+      getPreviewSelectionPathWeights(
+        bookType,
+        5,
+        {'author.name': 'subtitle', 'author.bestFriend.name': 'authorBFF'},
+        new Set(),
+      ),
+    ).toEqual({
+      'author.name': {path: 'author.name', weight: 5, type: 'string'},
+      // custom selection keys fall back to a non-default weight so they are
+      // matched by the groq2024 strategy
+      'author.bestFriend.name': {path: 'author.bestFriend.name', weight: 5, type: 'string'},
+    })
+  })
+
+  it('ignores paths that do not resolve to a searchable (string/pt) leaf', () => {
+    expect(
+      getPreviewSelectionPathWeights(
+        bookType,
+        5,
+        {
+          'author.age': 'subtitle', // number behind a reference
+          'publicationYear': 'subtitle', // number
+          'coverImage': 'media', // image object
+          'author.missing': 'subtitle', // nonexistent field
+        },
+        new Set(),
+      ),
+    ).toEqual({})
+  })
+
+  it('skips paths already collected by leaf traversal and array paths', () => {
+    expect(
+      getPreviewSelectionPathWeights(
+        bookType,
+        5,
+        {'title': 'title', 'author.name': 'subtitle', 'someArray[]': 'subtitle'},
+        new Set(['title']),
+      ),
+    ).toEqual({
+      'author.name': {path: 'author.name', weight: 5, type: 'string'},
+    })
+  })
+
+  it('targets the `.current` leaf for slug fields (directly and through references)', () => {
+    expect(
+      getPreviewSelectionPathWeights(
+        bookType,
+        5,
+        {'slug': 'subtitle', 'author.slug': 'authorSlug'},
+        new Set(),
+      ),
+    ).toEqual({
+      'slug.current': {path: 'slug.current', weight: 5, type: 'string'},
+      'author.slug.current': {path: 'author.slug.current', weight: 5, type: 'string'},
     })
   })
 })

--- a/packages/sanity/src/core/search/common/deriveSearchWeightsFromType.ts
+++ b/packages/sanity/src/core/search/common/deriveSearchWeightsFromType.ts
@@ -1,4 +1,5 @@
 import {
+  isReferenceSchemaType,
   type CrossDatasetType,
   type SchemaType,
   type SearchConfiguration,
@@ -21,6 +22,11 @@ const PREVIEW_FIELD_WEIGHT_MAP = {
   subtitle: 5,
   description: 1.5,
 }
+// Reference-traversing preview fields could use custom selection keys (e.g.
+// `authorName`) rather than `title`/`subtitle`/`description`, so they need a
+// fallback weight.
+const DEFAULT_PREVIEW_SELECT_WEIGHT = 5
+
 const BASE_WEIGHTS: Record<string, Omit<SearchWeightEntry, 'path'>> = {
   _id: {weight: 1, type: 'string'},
   _type: {weight: 1, type: 'string'},
@@ -153,6 +159,99 @@ const getDefaultWeights = (schemaType: SchemaType) => {
   return typeof result === 'number' ? null : 1
 }
 
+function findFieldType(type: SchemaType | undefined, fieldName: string): SchemaType | undefined {
+  for (const chainType of getTypeChain(type)) {
+    if (chainType.jsonType === 'object' && chainType.fields?.length) {
+      const field = chainType.fields.find(({name}) => name === fieldName)
+      if (field) return field.type
+    }
+  }
+  return undefined
+}
+
+/**
+ * Resolves a (dot-notation) preview `select` path to the "type" of its
+ * searchable leaf, following references. Returns `null` when the path does not
+ * resolve to a string / portable text / slug field.
+ *
+ * This reuses the same leaf classification as `getLeafWeights` (via
+ * `isStringField` / `isPtField` / `isSlugField`), but walks a single explicit
+ * path and follows references — which `getLeafWeights` intentionally does not,
+ * to avoid traversing the entire reference graph.
+ */
+function resolveLeafType(
+  type: SchemaType | undefined,
+  segments: string[],
+  depth: number,
+  maxDepth: number,
+): 'string' | 'pt' | 'slug' | null {
+  if (!type || depth > maxDepth) return null
+
+  if (segments.length === 0) {
+    if (isPtField(type)) return 'pt'
+    // Slug is reported separately so callers can target its `.current` leaf,
+    // consistent with `getFullyQualifiedPath` in the default leaf traversal.
+    if (isSlugField(type)) return 'slug'
+    if (isStringField(type)) return 'string'
+    return null
+  }
+
+  const [head, ...rest] = segments
+  const fieldType = findFieldType(type, head)
+  if (!fieldType) return null
+
+  if (isReferenceSchemaType(fieldType) && 'to' in fieldType) {
+    for (const target of fieldType.to) {
+      const leaf = resolveLeafType(target, rest, depth + 1, maxDepth)
+      if (leaf) return leaf
+    }
+    return null
+  }
+
+  return resolveLeafType(fieldType, rest, depth + 1, maxDepth)
+}
+
+/**
+ * Derives search weights for preview `select` paths that the default leaf
+ * traversal misses because they traverse references (e.g. `author.name`).
+ * These fields are displayed in list previews, so they should be searchable.
+ *
+ * The resulting dot-notation path is compiled to a GROQ expression (e.g.
+ * `author->name`) by `compileFieldPath` when the search query is built.
+ *
+ * @internal
+ */
+export function getPreviewSelectionPathWeights(
+  schemaType: SchemaType,
+  maxDepth: number,
+  selectionKeysBySelectionPath: Record<string, string>,
+  existingPaths: Set<string>,
+): Record<string, SearchWeightEntry> {
+  const weights: Record<string, SearchWeightEntry> = {}
+
+  for (const [path, previewKey] of Object.entries(selectionKeysBySelectionPath)) {
+    // Already handled by the default leaf traversal, or an array path (already
+    // valid GROQ that doesn't need reference resolution).
+    if (existingPaths.has(path) || path.includes('[]')) continue
+
+    const leaf = resolveLeafType(schemaType, path.split('.'), 0, maxDepth)
+    if (!leaf) continue
+
+    // A slug is searchable on its `.current` string, so target that leaf.
+    const resolvedPath = leaf === 'slug' && !path.endsWith('.current') ? `${path}.current` : path
+
+    weights[resolvedPath] = {
+      path: resolvedPath,
+      weight:
+        PREVIEW_FIELD_WEIGHT_MAP[previewKey as keyof typeof PREVIEW_FIELD_WEIGHT_MAP] ??
+        DEFAULT_PREVIEW_SELECT_WEIGHT,
+      type: leaf === 'pt' ? 'pt' : 'string',
+    }
+  }
+
+  return weights
+}
+
 const getPreviewWeights = (
   schemaType: SchemaType | CrossDatasetType | undefined,
   maxDepth: number,
@@ -203,10 +302,24 @@ const getPreviewWeights = (
     )
   }
 
-  return getLeafWeights(schemaType, maxDepth, (type, path) => {
+  const previewSelectionPathWeights = isSchemaType(schemaType)
+    ? getPreviewSelectionPathWeights(
+        schemaType,
+        maxDepth,
+        selectionKeysBySelectionPath,
+        new Set(Object.keys(defaultWeights)),
+      )
+    : {}
+
+  const previewWeightsFromLeafTraversal = getLeafWeights(schemaType, maxDepth, (type, path) => {
     const nested = nestedWeightsBySelectionPath[getFullyQualifiedPath(type, path)]
     return nested ? nested.weight : null
   })
+
+  return {
+    ...previewSelectionPathWeights,
+    ...previewWeightsFromLeafTraversal,
+  }
 }
 
 export interface DeriveSearchWeightsFromTypeOptions {

--- a/packages/sanity/src/core/search/common/deriveSearchWeightsFromType2024.ts
+++ b/packages/sanity/src/core/search/common/deriveSearchWeightsFromType2024.ts
@@ -7,6 +7,7 @@ import {
 import {toString as pathToString} from '@sanity/util/paths'
 
 import {isRecord} from '../../util'
+import {getPreviewSelectionPathWeights} from './deriveSearchWeightsFromType'
 import {type SearchPath, type SearchSpec} from './types'
 
 interface SearchWeightEntry {
@@ -216,10 +217,24 @@ const getPreviewWeights = (
     )
   }
 
-  return getLeafWeights(schemaType, maxDepth, (type, path) => {
+  const previewSelectionPathWeights = isSchemaType(schemaType)
+    ? getPreviewSelectionPathWeights(
+        schemaType,
+        maxDepth,
+        selectionKeysBySelectionPath,
+        new Set(Object.keys(defaultWeights)),
+      )
+    : {}
+
+  const previewWeightsFromLeafTraversal = getLeafWeights(schemaType, maxDepth, (type, path) => {
     const nested = nestedWeightsBySelectionPath[getFullyQualifiedPath(type, path)]
     return nested ? nested.weight : null
   })
+
+  return {
+    ...previewSelectionPathWeights,
+    ...previewWeightsFromLeafTraversal,
+  }
 }
 
 interface DeriveSearchWeightsFromTypeOptions {

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
@@ -619,5 +619,51 @@ describe('createSearchQuery', () => {
 
       expect(query).toContain('cover[].cards[].title match text::query($__query), 5)')
     })
+
+    // https://github.com/sanity-io/sanity/issues/4775
+    it('compiles reference paths from the preview selection to dereferenced GROQ', () => {
+      const referenceSchema = Schema.compile({
+        types: [
+          defineType({
+            name: 'author',
+            type: 'document',
+            fields: [defineField({name: 'name', type: 'string'})],
+          }),
+          defineType({
+            name: 'book',
+            type: 'document',
+            preview: {
+              select: {
+                title: 'title',
+                // reference traversal — should become searchable
+                subtitle: 'author.name',
+                // number field — must not be boosted
+                year: 'publicationYear',
+              },
+            },
+            fields: [
+              defineField({name: 'title', type: 'string'}),
+              defineField({name: 'publicationYear', type: 'number'}),
+              defineField({name: 'author', type: 'reference', to: [{type: 'author'}]}),
+            ],
+          }),
+        ],
+      })
+
+      const {query} = createSearchQuery(
+        {
+          query: 'tolkien',
+          types: [referenceSchema.get('book')],
+        },
+        '',
+      )
+
+      // `subtitle: 'author.name'` is boosted via its dereferenced expression.
+      expect(query).toContain('author->name match text::query($__query), 5')
+      // The raw dotted path must not leak, and the number field selected in the
+      // preview must not be boosted.
+      expect(query).not.toContain('author.name match')
+      expect(query).not.toContain('publicationYear')
+    })
   })
 })

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
@@ -6,6 +6,7 @@ import {
 } from '@sanity/types'
 import groupBy from 'lodash-es/groupBy.js'
 
+import {compileFieldPath} from '../common/compileFieldPath'
 import {compileSortExpression, type CompiledSortEntry} from '../common/compileSortExpression'
 import {deriveSearchWeightsFromType2024} from '../common/deriveSearchWeightsFromType2024'
 import {prefixLast} from '../common/token'
@@ -42,7 +43,6 @@ interface SearchQuery {
    */
   compiledSortEntries: CompiledSortEntry[]
 }
-
 function isSchemaType(
   maybeSchemaType: SchemaType | CrossDatasetType | undefined,
 ): maybeSchemaType is SchemaType {
@@ -69,19 +69,22 @@ export function createSearchQuery(
   }: SearchOptions & SearchFactoryOptions = {},
 ): SearchQuery {
   const specs = searchTerms.types
-    .map((schemaType) =>
-      deriveSearchWeightsFromType2024({
+    .map((schemaType) => {
+      return {
         schemaType,
-        maxDepth: maxDepth || DEFAULT_MAX_FIELD_DEPTH,
-        isCrossDataset: isCrossDataset,
-        processPaths: (paths) => paths.filter(({weight}) => weight !== 1),
-      }),
-    )
-    .filter(({paths}) => paths.length !== 0)
+        searchSpec: deriveSearchWeightsFromType2024({
+          schemaType,
+          maxDepth: maxDepth || DEFAULT_MAX_FIELD_DEPTH,
+          isCrossDataset: isCrossDataset,
+          processPaths: (paths) => paths.filter(({weight}) => weight !== 1),
+        }),
+      }
+    })
+    .filter(({searchSpec}) => searchSpec.paths.length !== 0)
 
   // Note: Computing this is unnecessary when `!isScored`.
-  const flattenedSpecs = specs.flatMap(({typeName, paths}) =>
-    paths.map((path) => ({...path, typeName})),
+  const flattenedSpecs = specs.flatMap(({schemaType, searchSpec}) =>
+    searchSpec.paths.map((path) => ({...path, typeName: searchSpec.typeName, schemaType})),
   )
 
   // Note: Computing this is unnecessary when `!isScored`.
@@ -95,7 +98,12 @@ export function createSearchQuery(
       if (entries.some(({weight}) => weight === 0)) {
         return []
       }
-      return `boost(_type in ${JSON.stringify(entries.map((entry) => entry.typeName))} && ${entries[0].path} match text::query($__query), ${entries[0].weight})`
+      // `[]` array paths are already valid GROQ that `compileFieldPath` can't parse;
+      // only dotted (reference) paths need schema-walking to insert `->`.
+      const path = entries[0].path.includes('[]')
+        ? entries[0].path
+        : compileFieldPath(entries[0].schemaType, entries[0].path)
+      return `boost(_type in ${JSON.stringify(entries.map((entry) => entry.typeName))} && ${path} match text::query($__query), ${entries[0].weight})`
     })
     .concat(baseMatch)
 

--- a/packages/sanity/src/core/search/weighted/createSearchQuery.test.ts
+++ b/packages/sanity/src/core/search/weighted/createSearchQuery.test.ts
@@ -573,6 +573,51 @@ describe('createSearchQuery', () => {
           '[0...$__limit]',
       )
     })
+
+    // https://github.com/sanity-io/sanity/issues/4775
+    it('compiles reference paths from the preview selection to dereferenced GROQ', () => {
+      const referenceSchema = Schema.compile({
+        types: [
+          defineType({
+            name: 'author',
+            type: 'document',
+            fields: [defineField({name: 'name', type: 'string'})],
+          }),
+          defineType({
+            name: 'book',
+            type: 'document',
+            preview: {
+              select: {
+                title: 'title',
+                // reference traversal — should become searchable
+                subtitle: 'author.name',
+                // number field — must not become a constraint
+                year: 'publicationYear',
+              },
+            },
+            fields: [
+              defineField({name: 'title', type: 'string'}),
+              defineField({name: 'publicationYear', type: 'number'}),
+              defineField({name: 'author', type: 'reference', to: [{type: 'author'}]}),
+            ],
+          }),
+        ],
+      })
+
+      const {query} = createSearchQuery({
+        query: 'term',
+        types: [referenceSchema.get('book')],
+      })
+
+      // `subtitle: 'author.name'` traverses a reference, so it is compiled to
+      // `author->name` in both the match constraint and the score selection.
+      expect(query).toContain('author->name match $t0')
+      expect(query).toMatch(/"w\d+": author->name/)
+      // The raw dotted path must not leak, and the number field selected in the
+      // preview must not be added as a searchable path.
+      expect(query).not.toContain('author.name match')
+      expect(query).not.toContain('publicationYear')
+    })
   })
 })
 

--- a/packages/sanity/src/core/search/weighted/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/weighted/createSearchQuery.ts
@@ -10,6 +10,7 @@ import uniq from 'lodash-es/uniq.js'
 import words from 'lodash-es/words.js'
 
 import {
+  compileFieldPath,
   compileSortExpression,
   deriveSearchWeightsFromType,
   ORDERINGS_PROJECTION_KEY,
@@ -41,16 +42,31 @@ export const DEFAULT_LIMIT = 1000
 
 const combinePaths: (paths: string[][]) => string[] = flow([flatten, union, compact])
 
-const pathWithMapper = ({mapWith, path}: SearchPath): string =>
-  mapWith ? `${mapWith}(${path})` : path
+const pathWithMapper = (
+  {mapWith, path: rawPath}: SearchPath,
+  schemaType: SchemaType | CrossDatasetType | undefined,
+): string => {
+  // `[]` array paths are already valid GROQ that `compileFieldPath` can't parse;
+  // only dotted (reference) paths need schema-walking to insert `->`.
+  const path =
+    !schemaType || rawPath.includes('[]') ? rawPath : compileFieldPath(schemaType, rawPath)
+  return mapWith ? `${mapWith}(${path})` : path
+}
 
 /**
  * Create GROQ constraints, given search terms and the full spec of available document types and fields.
  * Essentially a large list of all possible fields (joined by logical OR) to match our search terms against.
  */
-function createConstraints(terms: string[], specs: SearchSpec[]) {
+function createConstraints(
+  terms: string[],
+  specs: {schemaType: SchemaType | CrossDatasetType; searchSpec: SearchSpec}[],
+) {
   const combinedSearchPaths = combinePaths(
-    specs.map((configForType) => (configForType.paths || []).map((opt) => pathWithMapper(opt))),
+    specs.map((configForType) =>
+      (configForType.searchSpec.paths || []).map((opt) =>
+        pathWithMapper(opt, configForType.schemaType),
+      ),
+    ),
   )
 
   const constraints = terms
@@ -112,14 +128,17 @@ export function createSearchQuery(
     searchOpts
 
   const specs = searchTerms.types
-    .map((schemaType) =>
-      deriveSearchWeightsFromType({
+    .map((schemaType) => {
+      return {
         schemaType,
-        maxDepth: maxDepth || DEFAULT_MAX_FIELD_DEPTH,
-        isCrossDataset: isCrossDataset,
-      }),
-    )
-    .filter(({paths}) => paths.length)
+        searchSpec: deriveSearchWeightsFromType({
+          schemaType,
+          maxDepth: maxDepth || DEFAULT_MAX_FIELD_DEPTH,
+          isCrossDataset: isCrossDataset,
+        }),
+      }
+    })
+    .filter(({searchSpec}) => searchSpec.paths.length !== 0)
 
   // Extract search terms from string query, factoring in phrases wrapped in quotes
   const terms = extractTermsFromQuery(searchTerms.query)
@@ -134,12 +153,12 @@ export function createSearchQuery(
 
   const selections = searchOpts.skipSortByScore
     ? []
-    : specs.map((spec) => {
-        const constraint = `_type == "${spec.typeName}" => `
+    : specs.map(({searchSpec, schemaType}) => {
+        const constraint = `_type == "${searchSpec.typeName}" => `
         if (searchOpts.skipSortByScore) {
           return undefined
         }
-        const selection = `{ ${spec.paths.map((cfg, i) => `"w${i}": ${pathWithMapper(cfg)}`)} }`
+        const selection = `{ ${searchSpec.paths.map((cfg, i) => `"w${i}": ${pathWithMapper(cfg, schemaType)}`)} }`
         return `${constraint}${selection}`
       })
 
@@ -183,7 +202,7 @@ export function createSearchQuery(
     query: updatedQuery,
     params: {
       ...toGroqParams(terms),
-      __types: specs.map((spec) => spec.typeName),
+      __types: specs.map(({searchSpec}) => searchSpec.typeName),
       __limit: limit ?? DEFAULT_LIMIT,
       ...params,
     },
@@ -191,7 +210,7 @@ export function createSearchQuery(
       tag,
       perspective,
     },
-    searchSpec: specs,
+    searchSpec: specs.map(({searchSpec}) => searchSpec),
     terms,
   }
 }


### PR DESCRIPTION
### Description
Fixes https://github.com/sanity-io/sanity/issues/4775

Fields shown in a list item via a reference (e.g. `subtitle: 'author.name'`) were visible in previews but not searchable — issue #4775. Weight derivation skips references: in `getLeafWeights` (`deriveSearchWeightsFromType.ts`) the object-field recursion is gated by `!ignoredBuiltInObjectTypes.includes(t.name)`, and `reference` is in `ignoredBuiltInObjectTypes`, so `author.name` never became a search path — and the query never dereferenced it either.

Now preview `select` paths that traverse references are resolved to their searchable leaf and compiled to `author->name` in the query (reusing the same `compileFieldPath` that orderings use).

Example in books, now search by author.name returns the results because `author.name` and `author.bestFriend.name` is part of the book preview `select` https://github.com/sanity-io/sanity/blob/main/dev/test-studio/schema/book.ts#L169

https://github.com/user-attachments/assets/7878bf1e-1747-420c-a1ef-5f313d91340f


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
