### PR TITLE
fix(core): increase AuthenticateScreen width

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
@@ -1,5 +1,5 @@
 import {AddIcon, ArrowLeftIcon} from '@sanity/icons'
-import {Box, Flex, Stack} from '@sanity/ui'
+import {Box, Container, Flex, Stack} from '@sanity/ui'
 import {useCallback, useState} from 'react'
 
 import {Button} from '../../../../../../ui-components'
@@ -46,74 +46,78 @@ export function WorkspaceAuth() {
 
   if (LoginComponent && selectedWorkspace) {
     return (
-      <Stack space={2}>
-        {visibleWorkspaces.length > 1 && (
-          <Flex>
-            <Button
-              icon={ArrowLeftIcon}
-              mode="bleed"
-              onClick={handleBack}
-              text={t('workspaces.action.choose-another-workspace')}
-            />
-          </Flex>
-        )}
-
-        <Layout
-          header={
-            <Box padding={3}>
-              <WorkspacePreview
-                icon={selectedWorkspace.icon}
-                title={selectedWorkspace.title}
-                subtitle={selectedWorkspace?.subtitle}
+      <Container width={0}>
+        <Stack space={2}>
+          {visibleWorkspaces.length > 1 && (
+            <Flex>
+              <Button
+                icon={ArrowLeftIcon}
+                mode="bleed"
+                onClick={handleBack}
+                text={t('workspaces.action.choose-another-workspace')}
               />
-            </Box>
-          }
-        >
-          <Stack padding={2} paddingBottom={3} paddingTop={4}>
-            <LoginComponent
-              key={selectedWorkspaceName}
-              projectId={selectedWorkspace.projectId}
-              redirectPath={
-                window.location.pathname.startsWith(selectedWorkspace.basePath)
-                  ? // NOTE: the fragment cannot be preserved because it's used
-                    // to transfer an sid to a token
-                    `${window.location.pathname}${window.location.search}`
-                  : selectedWorkspace.basePath
-              }
-            />
-          </Stack>
-        </Layout>
-      </Stack>
+            </Flex>
+          )}
+
+          <Layout
+            header={
+              <Box padding={3}>
+                <WorkspacePreview
+                  icon={selectedWorkspace.icon}
+                  title={selectedWorkspace.title}
+                  subtitle={selectedWorkspace?.subtitle}
+                />
+              </Box>
+            }
+          >
+            <Stack padding={2} paddingBottom={3} paddingTop={4}>
+              <LoginComponent
+                key={selectedWorkspaceName}
+                projectId={selectedWorkspace.projectId}
+                redirectPath={
+                  window.location.pathname.startsWith(selectedWorkspace.basePath)
+                    ? // NOTE: the fragment cannot be preserved because it's used
+                      // to transfer an sid to a token
+                      `${window.location.pathname}${window.location.search}`
+                    : selectedWorkspace.basePath
+                }
+              />
+            </Stack>
+          </Layout>
+        </Stack>
+      </Container>
     )
   }
 
   return (
-    <Layout
-      header={t('workspaces.choose-your-workspace-label')}
-      footer={
-        <Stack padding={1}>
-          <Button
-            as="a"
-            href={WORKSPACES_DOCS_URL}
-            icon={AddIcon}
-            mode="bleed"
-            rel="noopener noreferrer"
-            size="large"
-            target="__blank"
-            text={t('workspaces.action.add-workspace')}
-          />
+    <Container width={1}>
+      <Layout
+        header={t('workspaces.choose-your-workspace-label')}
+        footer={
+          <Stack padding={1}>
+            <Button
+              as="a"
+              href={WORKSPACES_DOCS_URL}
+              icon={AddIcon}
+              mode="bleed"
+              rel="noopener noreferrer"
+              size="large"
+              target="__blank"
+              text={t('workspaces.action.add-workspace')}
+            />
+          </Stack>
+        }
+      >
+        <Stack space={1} paddingX={1} paddingY={2}>
+          {visibleWorkspaces.map((workspace) => (
+            <WorkspaceAuthCard
+              key={workspace.name}
+              workspace={workspace}
+              onSelect={(state) => handleCardSelect(workspace.name, state)}
+            />
+          ))}
         </Stack>
-      }
-    >
-      <Stack space={1} paddingX={1} paddingY={2}>
-        {visibleWorkspaces.map((workspace) => (
-          <WorkspaceAuthCard
-            key={workspace.name}
-            workspace={workspace}
-            onSelect={(state) => handleCardSelect(workspace.name, state)}
-          />
-        ))}
-      </Stack>
-    </Layout>
+      </Layout>
+    </Container>
   )
 }

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
@@ -1,6 +1,9 @@
 import {AddIcon, ArrowLeftIcon} from '@sanity/icons'
-import {Box, Container, Flex, Stack} from '@sanity/ui'
+import {Box, Container, Flex, rem, Stack} from '@sanity/ui'
+// eslint-disable-next-line camelcase
+import {getTheme_v2} from '@sanity/ui/theme'
 import {useCallback, useState} from 'react'
+import {styled} from 'styled-components'
 
 import {Button} from '../../../../../../ui-components'
 import {useTranslation} from '../../../../../i18n'
@@ -10,6 +13,15 @@ import {WORKSPACES_DOCS_URL} from '../constants'
 import {WorkspacePreview} from '../WorkspacePreview'
 import {Layout} from './Layout'
 import {WorkspaceAuthCard} from './WorkspaceAuthCard'
+
+const StyledContainer = styled(Container)((props) => {
+  const theme = getTheme_v2(props.theme)
+  const {container} = theme
+  return {
+    width: 'auto',
+    minWidth: rem(container[0]),
+  }
+})
 
 export function WorkspaceAuth() {
   const {visibleWorkspaces} = useVisibleWorkspaces()
@@ -90,7 +102,7 @@ export function WorkspaceAuth() {
   }
 
   return (
-    <Container width={1}>
+    <StyledContainer width={1}>
       <Layout
         header={t('workspaces.choose-your-workspace-label')}
         footer={
@@ -118,6 +130,6 @@ export function WorkspaceAuth() {
           ))}
         </Stack>
       </Layout>
-    </Container>
+    </StyledContainer>
   )
 }

--- a/packages/sanity/src/core/studio/screens/AuthenticateScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/AuthenticateScreen.tsx
@@ -6,9 +6,7 @@ export function AuthenticateScreen() {
   return (
     <Card height="fill" overflow="auto" paddingX={4}>
       <Flex height="fill" direction="column" align="center" justify="center" paddingTop={4}>
-        <Container width={0}>
-          <WorkspaceAuth />
-        </Container>
+        <WorkspaceAuth />
       </Flex>
     </Card>
   )

--- a/packages/sanity/src/core/studio/screens/AuthenticateScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/AuthenticateScreen.tsx
@@ -1,4 +1,4 @@
-import {Card, Container, Flex} from '@sanity/ui'
+import {Card, Flex} from '@sanity/ui'
 
 import {WorkspaceAuth} from '../components/navbar/workspace'
 


### PR DESCRIPTION
### Description
Images are better than words in this case
**Before**
<img width="388" height="931" alt="Screenshot 2026-06-03 at 11 59 59" src="https://github.com/user-attachments/assets/77bd235f-e79c-4d01-ba70-7a46767ba11d" />

**After**
<img width="634" height="945" alt="Screenshot 2026-06-03 at 12 00 44" src="https://github.com/user-attachments/assets/a033f049-2144-4f1a-a8b9-7d7214d3b706" />


**Workspace login remains the same**
<img width="419" height="446" alt="Screenshot 2026-06-03 at 11 59 35" src="https://github.com/user-attachments/assets/a1ac8b91-bbae-499b-8d17-3d3eca61e23f" />
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Increase AuthenticateScreen width
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
