### PR TITLE
chore: make lefthook work without PATH trickery

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,10 +5,10 @@ pre-commit:
       glob: "*.{js,jsx,ts,tsx,mjs,cjs}"
       stage_fixed: true
       run: |
-        oxfmt --no-error-on-unmatched-pattern {staged_files}
-        oxlint --disable-nested-config --type-aware --fix --quiet {staged_files}
+        pnpm oxfmt --no-error-on-unmatched-pattern {staged_files}
+        pnpm oxlint --disable-nested-config --type-aware --fix --quiet {staged_files}
 
     - name: format-other
       glob: "*.{md,yml,yaml,css,json}"
       stage_fixed: true
-      run: oxfmt --no-error-on-unmatched-pattern {staged_files}
+      run: pnpm oxfmt --no-error-on-unmatched-pattern {staged_files}


### PR DESCRIPTION
### Description

Requiring node_modules binaries to be loaded into PATH is heresy
<img width="640" height="566" alt="image" src="https://github.com/user-attachments/assets/e96fcf12-2b69-4032-af1c-d8cf88dd0fe6" />


### What to review

Maybe I should review my own ways but I don't want to

### Testing

I tried to commit on main, it crashed and said it couldn't find oxfmt. I tried it on this PR and it works.

### Notes for release

N/A
