### PR TITLE
refactor: reduce vite 8 delta, ensure vitest uses predictable vite version

### DIFF
--- a/dev/auth-test-studio/package.json
+++ b/dev/auth-test-studio/package.json
@@ -12,7 +12,7 @@
     "start": "sanity preview --port 3340"
   },
   "dependencies": {
-    "babel-plugin-react-compiler": "1.0.0",
+    "babel-plugin-react-compiler": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "sanity": "workspace:*",

--- a/dev/e2e-embedded-studio-vite/vite.config.ts
+++ b/dev/e2e-embedded-studio-vite/vite.config.ts
@@ -1,8 +1,8 @@
-import react from '@vitejs/plugin-react'
+import viteReact from '@vitejs/plugin-react'
 import {defineConfig} from 'vite'
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [viteReact()],
   define: {
     'import.meta.env.SANITY_E2E_PROJECT_ID': JSON.stringify(process.env.SANITY_E2E_PROJECT_ID),
     'import.meta.env.SANITY_E2E_DATASET': JSON.stringify(process.env.SANITY_E2E_DATASET),

--- a/dev/efps/package.json
+++ b/dev/efps/package.json
@@ -30,7 +30,7 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@types/yargs": "^17.0.35",
-    "babel-plugin-react-compiler": "1.0.0",
+    "babel-plugin-react-compiler": "catalog:",
     "chalk": "^4.1.2",
     "cli-table3": "^0.6.5",
     "dotenv": "^16.6.1",

--- a/dev/embedded-studio/vite.config.ts
+++ b/dev/embedded-studio/vite.config.ts
@@ -1,7 +1,7 @@
-import react from '@vitejs/plugin-react'
+import viteReact from '@vitejs/plugin-react'
 import {defineConfig} from 'vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [viteReact()],
 })

--- a/dev/page-building-studio/package.json
+++ b/dev/page-building-studio/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@sanity/vision": "workspace:*",
-    "babel-plugin-react-compiler": "1.0.0",
+    "babel-plugin-react-compiler": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-icons": "^5.6.0",

--- a/dev/starter-studio/package.json
+++ b/dev/starter-studio/package.json
@@ -12,7 +12,7 @@
     "start": "sanity preview --port 3337"
   },
   "dependencies": {
-    "babel-plugin-react-compiler": "1.0.0",
+    "babel-plugin-react-compiler": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "sanity": "workspace:*",

--- a/dev/studio-e2e-testing/package.json
+++ b/dev/studio-e2e-testing/package.json
@@ -21,7 +21,7 @@
     "@sanity/icons": "^3.7.4",
     "@sanity/ui": "catalog:",
     "@sanity/vision": "workspace:*",
-    "babel-plugin-react-compiler": "1.0.0",
+    "babel-plugin-react-compiler": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "sanity": "workspace:*",

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -69,7 +69,7 @@
     "@types/react-dom": "catalog:",
     "@vanilla-extract/css": "catalog:",
     "@vanilla-extract/vite-plugin": "catalog:",
-    "babel-plugin-react-compiler": "1.0.0",
+    "babel-plugin-react-compiler": "catalog:",
     "chokidar": "^3.6.0",
     "eslint": "catalog:",
     "rimraf": "catalog:",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "turbo": "^2.7.5",
     "typedoc": "^0.28.16",
     "vercel": "^48.12.1",
+    "vite": "catalog:",
     "vitest": "catalog:"
   },
   "packageManager": "pnpm@11.1.2",

--- a/packages/@repo/bundle-manager/package.json
+++ b/packages/@repo/bundle-manager/package.json
@@ -42,6 +42,7 @@
     "@types/yargs": "^17.0.35",
     "@typescript/native-preview": "catalog:",
     "eslint": "catalog:",
+    "vite": "catalog:",
     "vitest": "catalog:"
   },
   "engines": {

--- a/packages/@repo/package.bundle/package.json
+++ b/packages/@repo/package.bundle/package.json
@@ -17,6 +17,7 @@
     "@types/lodash-es": "^4.17.12",
     "@vanilla-extract/vite-plugin": "catalog:",
     "@vitejs/plugin-react": "catalog:",
+    "babel-plugin-react-compiler": "catalog:",
     "eslint": "catalog:",
     "lodash-es": "^4.18.1",
     "vite": "catalog:",

--- a/packages/@repo/package.bundle/src/package.bundle.ts
+++ b/packages/@repo/package.bundle/src/package.bundle.ts
@@ -1,5 +1,5 @@
 import {vanillaExtractPlugin} from '@vanilla-extract/vite-plugin'
-import react from '@vitejs/plugin-react'
+import viteReact from '@vitejs/plugin-react'
 import escapeRegExp from 'lodash-es/escapeRegExp.js'
 import {type Plugin, type UserConfig} from 'vite'
 
@@ -14,7 +14,7 @@ export const defaultConfig: UserConfig = {
     'process.env': {},
   },
   plugins: [
-    react({
+    viteReact({
       babel: {plugins: [['babel-plugin-react-compiler', {target: '19'}]]},
     }),
     vanillaExtractPlugin(),

--- a/packages/@repo/release-notes/package.json
+++ b/packages/@repo/release-notes/package.json
@@ -58,6 +58,7 @@
     "@types/turndown": "^5.0.6",
     "@types/yargs": "^17.0.33",
     "@typescript/native-preview": "catalog:",
+    "vite": "catalog:",
     "vitest": "catalog:"
   },
   "engines": {

--- a/packages/@repo/test-config/package.json
+++ b/packages/@repo/test-config/package.json
@@ -8,6 +8,7 @@
     "./vitest": "./vitest/index.mjs"
   },
   "devDependencies": {
+    "vite": "catalog:",
     "vitest": "catalog:"
   }
 }

--- a/packages/@repo/test-dts-exports/package.json
+++ b/packages/@repo/test-dts-exports/package.json
@@ -29,6 +29,7 @@
     "eslint": "catalog:",
     "ts-morph": "^26.0.0",
     "typescript": "5.9.3",
+    "vite": "catalog:",
     "vitest": "catalog:",
     "zod": "^4.1.12"
   }

--- a/packages/@sanity/mutator/package.json
+++ b/packages/@sanity/mutator/package.json
@@ -71,6 +71,7 @@
     "@typescript/native-preview": "catalog:",
     "eslint": "catalog:",
     "rimraf": "catalog:",
+    "vite": "catalog:",
     "vitest": "catalog:"
   },
   "browserslist": [

--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -89,6 +89,7 @@
     "@typescript/native-preview": "catalog:",
     "eslint": "catalog:",
     "rimraf": "catalog:",
+    "vite": "catalog:",
     "vitest": "catalog:"
   },
   "browserslist": [

--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -70,6 +70,7 @@
     "eslint": "catalog:",
     "react": "catalog:",
     "rimraf": "catalog:",
+    "vite": "catalog:",
     "vitest": "catalog:"
   },
   "peerDependencies": {

--- a/packages/@sanity/types/vitest.config.mts
+++ b/packages/@sanity/types/vitest.config.mts
@@ -1,5 +1,5 @@
 import {defineConfig} from '@repo/test-config/vitest'
-import react from '@vitejs/plugin-react'
+import viteReact from '@vitejs/plugin-react'
 
 export default defineConfig({
   test: {
@@ -8,5 +8,5 @@ export default defineConfig({
       ignoreSourceErrors: false,
     },
   },
-  plugins: [react({babel: {plugins: [['babel-plugin-react-compiler', {target: '19'}]]}})],
+  plugins: [viteReact()],
 })

--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -140,6 +140,7 @@
     "@typescript/native-preview": "catalog:",
     "eslint": "catalog:",
     "rimraf": "catalog:",
+    "vite": "catalog:",
     "vitest": "catalog:"
   },
   "browserslist": [

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -99,7 +99,7 @@
     "@vanilla-extract/css": "catalog:",
     "@vanilla-extract/vite-plugin": "catalog:",
     "@vitejs/plugin-react": "catalog:",
-    "babel-plugin-react-compiler": "1.0.0",
+    "babel-plugin-react-compiler": "catalog:",
     "babel-plugin-styled-components": "catalog:",
     "eslint": "catalog:",
     "jsdom": "catalog:",

--- a/packages/@sanity/vision/vitest.config.mts
+++ b/packages/@sanity/vision/vitest.config.mts
@@ -1,6 +1,6 @@
 import {defineConfig} from '@repo/test-config/vitest'
 import {vanillaExtractPlugin} from '@vanilla-extract/vite-plugin'
-import react from '@vitejs/plugin-react'
+import viteReact from '@vitejs/plugin-react'
 
 export default defineConfig({
   test: {
@@ -8,6 +8,6 @@ export default defineConfig({
   },
   plugins: [
     vanillaExtractPlugin(),
-    react({babel: {plugins: [['babel-plugin-react-compiler', {target: '19'}]]}}),
+    viteReact({babel: {plugins: [['babel-plugin-react-compiler', {target: '19'}]]}}),
   ],
 })

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -291,7 +291,7 @@
     "@vanilla-extract/vite-plugin": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "@vitest/expect": "^4.1.8",
-    "babel-plugin-react-compiler": "1.0.0",
+    "babel-plugin-react-compiler": "catalog:",
     "babel-plugin-styled-components": "catalog:",
     "blob-polyfill": "^9.0.20240710",
     "eslint": "catalog:",

--- a/packages/sanity/playwright-ct.config.ts
+++ b/packages/sanity/playwright-ct.config.ts
@@ -3,7 +3,7 @@ import {fileURLToPath} from 'node:url'
 
 import {defineConfig, devices} from '@playwright/experimental-ct-react'
 import {vanillaExtractPlugin} from '@vanilla-extract/vite-plugin'
-import react from '@vitejs/plugin-react'
+import viteReact from '@vitejs/plugin-react'
 import {defaultClientConditions} from 'vite'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -60,7 +60,7 @@ export default defineConfig({
         // @ts-expect-error - Playwright CT and the workspace use different Vite versions
         vanillaExtractPlugin(),
         // @ts-expect-error - Playwright CT and the workspace use different Vite versions
-        react({
+        viteReact({
           babel: {plugins: [['babel-plugin-react-compiler', {target: '19'}]]},
         }),
       ],

--- a/packages/sanity/vitest.config.mts
+++ b/packages/sanity/vitest.config.mts
@@ -1,6 +1,6 @@
 import {defineConfig} from '@repo/test-config/vitest'
 import {vanillaExtractPlugin} from '@vanilla-extract/vite-plugin'
-import react from '@vitejs/plugin-react'
+import viteReact from '@vitejs/plugin-react'
 
 export default defineConfig({
   test: {
@@ -19,7 +19,7 @@ export default defineConfig({
   },
   plugins: [
     vanillaExtractPlugin(),
-    react({
+    viteReact({
       babel: {plugins: [['babel-plugin-react-compiler', {target: '19'}]]},
     }),
   ],

--- a/perf/studio/package.json
+++ b/perf/studio/package.json
@@ -14,7 +14,7 @@
     "start": "sanity preview --port 3300"
   },
   "dependencies": {
-    "babel-plugin-react-compiler": "1.0.0",
+    "babel-plugin-react-compiler": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "sanity": "workspace:*",

--- a/perf/tests/package.json
+++ b/perf/tests/package.json
@@ -32,6 +32,7 @@
     "esbuild": "0.28.0",
     "eslint": "catalog:",
     "tsx": "^4.21.0",
+    "vite": "catalog:",
     "vitest": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ catalogs:
     '@vitejs/plugin-react':
       specifier: ^5.1.2
       version: 5.2.0
+    babel-plugin-react-compiler:
+      specifier: ^1.0.0
+      version: 1.0.0
     babel-plugin-styled-components:
       specifier: ^2.1.4
       version: 2.1.4
@@ -177,6 +180,9 @@ importers:
       vercel:
         specifier: ^48.12.1
         version: 48.12.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.4)(typescript@6.0.0-beta)
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@edge-runtime/vm@3.2.0)(@types/node@24.10.13)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -184,7 +190,7 @@ importers:
   dev/auth-test-studio:
     dependencies:
       babel-plugin-react-compiler:
-        specifier: 1.0.0
+        specifier: 'catalog:'
         version: 1.0.0
       react:
         specifier: 'catalog:'
@@ -332,7 +338,7 @@ importers:
         specifier: ^17.0.35
         version: 17.0.35
       babel-plugin-react-compiler:
-        specifier: 1.0.0
+        specifier: 'catalog:'
         version: 1.0.0
       chalk:
         specifier: ^4.1.2
@@ -417,7 +423,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@sanity/vision
       babel-plugin-react-compiler:
-        specifier: 1.0.0
+        specifier: 'catalog:'
         version: 1.0.0
       react:
         specifier: 'catalog:'
@@ -476,7 +482,7 @@ importers:
   dev/starter-studio:
     dependencies:
       babel-plugin-react-compiler:
-        specifier: 1.0.0
+        specifier: 'catalog:'
         version: 1.0.0
       react:
         specifier: 'catalog:'
@@ -522,7 +528,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@sanity/vision
       babel-plugin-react-compiler:
-        specifier: 1.0.0
+        specifier: 'catalog:'
         version: 1.0.0
       react:
         specifier: 'catalog:'
@@ -741,7 +747,7 @@ importers:
         specifier: 'catalog:'
         version: 5.2.2(@types/node@24.10.13)(babel-plugin-macros@3.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(vite@7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
       babel-plugin-react-compiler:
-        specifier: 1.0.0
+        specifier: 'catalog:'
         version: 1.0.0
       eslint:
         specifier: 'catalog:'
@@ -828,6 +834,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.7.0)
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@edge-runtime/vm@3.2.0)(@types/node@24.10.13)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -903,6 +912,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 5.2.0(vite@7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0))
+      babel-plugin-react-compiler:
+        specifier: 'catalog:'
+        version: 1.0.0
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.7.0)
@@ -1024,12 +1036,18 @@ importers:
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260421.2
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@edge-runtime/vm@3.2.0)(@types/node@24.10.13)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/@repo/test-config:
     devDependencies:
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@edge-runtime/vm@3.2.0)(@types/node@24.10.13)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -1079,6 +1097,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@edge-runtime/vm@3.2.0)(@types/node@24.10.13)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -1229,6 +1250,9 @@ importers:
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@edge-runtime/vm@3.2.0)(@types/node@24.10.13)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -1299,6 +1323,9 @@ importers:
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@edge-runtime/vm@3.2.0)(@types/node@24.10.13)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -1348,6 +1375,9 @@ importers:
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@edge-runtime/vm@3.2.0)(@types/node@24.10.13)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -1400,6 +1430,9 @@ importers:
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@edge-runtime/vm@3.2.0)(@types/node@24.10.13)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -1522,7 +1555,7 @@ importers:
         specifier: 'catalog:'
         version: 5.2.0(vite@7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0))
       babel-plugin-react-compiler:
-        specifier: 1.0.0
+        specifier: 'catalog:'
         version: 1.0.0
       babel-plugin-styled-components:
         specifier: 'catalog:'
@@ -1982,7 +2015,7 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8
       babel-plugin-react-compiler:
-        specifier: 1.0.0
+        specifier: 'catalog:'
         version: 1.0.0
       babel-plugin-styled-components:
         specifier: 'catalog:'
@@ -2051,7 +2084,7 @@ importers:
   perf/studio:
     dependencies:
       babel-plugin-react-compiler:
-        specifier: 1.0.0
+        specifier: 'catalog:'
         version: 1.0.0
       react:
         specifier: 'catalog:'
@@ -2127,6 +2160,9 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.22.3
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@edge-runtime/vm@3.2.0)(@types/node@24.10.13)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.3(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.3)(yaml@2.9.0))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,7 @@ catalog:
   '@vanilla-extract/css': ^1.19.0
   '@vanilla-extract/vite-plugin': ^5.2.0
   '@vitejs/plugin-react': ^5.1.2
+  babel-plugin-react-compiler: ^1.0.0
   babel-plugin-styled-components: ^2.1.4
   esbuild-register: ^3.6.0
   eslint: ^9.39.4


### PR DESCRIPTION
### Description

Vite 8 prep, split into two independent goals:

**1. Make `vite` resolution predictable.** `vitest` has a peer dependency on `vite`. Most workspaces declared only `vitest`, so on a fresh lockfile the unconstrained `vite` peer is free to float to the newest major — that's why the lock-file-maintenance PR (#12946) pulled in Vite 8 and [failed CI](https://github.com/sanity-io/sanity/actions/runs/26923521321/job/79428821355?pr=12946). We already force `vitest` to the catalog via a `$vitest` override, but there was no equivalent guard for `vite`. Rather than add another override, every workspace that uses `vitest` now also declares `vite: "catalog:"` (the catalog pins `^7.3.1`), so the peer always resolves to the workspace-controlled version.

**2. Shrink the eventual Vite 8 upgrade diff (#12922)** by landing its uncontroversial housekeeping early: `babel-plugin-react-compiler` moves into the pnpm catalog (it was hard-pinned to `1.0.0` in several places), and `@vitejs/plugin-react` is imported as `viteReact` across our Vite/Vitest/Playwright CT configs to match the updated naming convention.

### What to review

Most of the diff is mechanical (`react` → `viteReact` rename, `1.0.0` → `catalog:`). Two changes are intentional and worth a closer look:

- **`packages/@sanity/types/vitest.config.mts`** no longer runs `babel-plugin-react-compiler`. It was unnecessary — none of the `@sanity/types` vitest tests render React components, and the `@sanity/types` source itself has no code the compiler would transform.
- **`packages/@repo/package.bundle`** uses the react compiler correctly in `src/package.bundle.ts`, but never declared `babel-plugin-react-compiler` in its `package.json`; the missing dependency is now added.

Otherwise: the `vite: "catalog:"` additions across `dev/*`, `perf/*`, `packages/*` and root are the actual fix for goal 1, and `pnpm-workspace.yaml` gains the `babel-plugin-react-compiler` catalog entry (`vite` was already cataloged at `^7.3.1`).

### Testing

No new automated tests — this is dependency/config wiring covered by existing CI (unit tests, `test:exports`, and `depcheck`, which catches the previously-missing `babel-plugin-react-compiler` dependency in `@repo/package.bundle`). The concrete signal is that `pnpm install` now resolves `vite` to the catalog `^7.3.1` instead of floating to v8.

### Notes for release

N/A – Internal tooling and dependency wiring.