### PR TITLE
fix(core): support modal width in Enhanced dialog

### DIFF
--- a/dev/test-studio/schema/debug/arrayModalWidthRepro.ts
+++ b/dev/test-studio/schema/debug/arrayModalWidthRepro.ts
@@ -240,7 +240,6 @@ export const arrayModalWidthRepro = defineType({
             annotations: [
               createModalAnnotation('responsiveWidth', 'Responsive width [2, 5]', {
                 type: 'dialog',
-                // @ts-expect-error arrays of widths are valid at runtime for objects
                 width: [2, 5],
               }),
             ],

--- a/dev/test-studio/schema/debug/arrayModalWidthRepro.ts
+++ b/dev/test-studio/schema/debug/arrayModalWidthRepro.ts
@@ -1,0 +1,274 @@
+/**
+ * Reproduction schema for https://github.com/sanity-io/sanity/issues/4741
+ *
+ * `options.modal` on **array fields** controls the edit UI for array items
+ * (`PreviewItem` / `GridItem` → `EnhancedObjectDialog` / `EditPortal`).
+ *
+ * `options.modal` on **object types** (e.g. PTE annotations) is read via
+ * `_getModalOption` → `ObjectEditModal`.
+ *
+ * Width is a theme container index (1–5 → 640–1920px) or `'auto'`, not pixels.
+ *
+ * Manual repro:
+ * 1. Structure → Inputs → Debug → Modal options repro (#4741).
+ * 2. Use the document tabs: Array dialog, Array popover, Object dialog, Object popover.
+ * 3. Arrays: click **Add item** per field; inspect `nested-object-dialog` or
+ *    `[data-ui="PopoverContainer"]`.
+ * 4. Objects: add text in the PTE field, apply each annotation mark, open the editor;
+ *    inspect `popover-edit-dialog` / `default-edit-object-dialog` / `nested-object-dialog`.
+ * 5. Edge cases tab: out-of-range width, responsive width, modal on array member vs array.
+ */
+import {defineArrayMember, defineField, defineType, type ModalOptions} from 'sanity'
+
+const MODAL_WIDTH_GROUPS = [
+  {name: 'arrayDialog', title: 'Array · dialog', default: true},
+  {name: 'arrayPopover', title: 'Array · popover'},
+  {name: 'objectDialog', title: 'Object · dialog'},
+  {name: 'objectPopover', title: 'Object · popover'},
+  {name: 'edgeCases', title: 'Edge cases'},
+] as const
+
+type ModalWidthGroup = (typeof MODAL_WIDTH_GROUPS)[number]['name']
+
+const arrayItemFields = [
+  defineField({
+    name: 'title',
+    type: 'string',
+    title: 'Title',
+  }),
+]
+
+const arrayItem = defineArrayMember({
+  type: 'object',
+  name: 'item',
+  fields: arrayItemFields,
+})
+
+type ModalWidthVariant = 'default' | '2' | '5' | 'auto'
+
+const MODAL_WIDTH_VARIANTS: {
+  key: ModalWidthVariant
+  title: string
+  width?: ModalOptions['width']
+}[] = [
+  {key: 'default', title: 'default (width omitted)', width: undefined},
+  {key: '2', title: 'width: 2 (~960px)', width: 2},
+  {key: '5', title: 'width: 5 (~1920px)', width: 5},
+  {key: 'auto', title: 'width: "auto"', width: 'auto'},
+]
+
+function buildArrayModalFields(
+  modalType: 'dialog' | 'popover',
+  group: ModalWidthGroup,
+): ReturnType<typeof defineField>[] {
+  return MODAL_WIDTH_VARIANTS.map(({key, title, width}) => {
+    const modal: ModalOptions = {type: modalType}
+    if (width !== undefined) {
+      modal.width = width
+    }
+
+    return defineField({
+      name: `${group}_${key}`,
+      title: `Array · ${modalType} · ${title}`,
+      description: `options.modal on the array field. type: "${modalType}"${
+        width === undefined
+          ? ', width omitted (studio falls back to 1)'
+          : `, width: ${JSON.stringify(width)}`
+      }.`,
+      type: 'array',
+      group,
+      options: {modal},
+      of: [arrayItem],
+    })
+  })
+}
+
+function createModalAnnotation(
+  name: string,
+  title: string,
+  modal: ModalOptions,
+): {
+  name: string
+  type: 'object'
+  title: string
+  fields: ReturnType<typeof defineField>[]
+  options: {modal: ModalOptions}
+} {
+  return {
+    name,
+    type: 'object',
+    title,
+    fields: [
+      defineField({
+        name: 'note',
+        type: 'string',
+        title: 'Note',
+      }),
+    ],
+    options: {modal},
+  }
+}
+
+function buildObjectModalPteField(
+  modalType: 'dialog' | 'popover',
+  group: ModalWidthGroup,
+): ReturnType<typeof defineField> {
+  const annotations = MODAL_WIDTH_VARIANTS.map(({key, title, width}) => {
+    const modal: ModalOptions = {type: modalType}
+    if (width !== undefined) {
+      modal.width = width
+    }
+
+    return createModalAnnotation(
+      `${group}_annotation_${key}`,
+      `Object · ${modalType} · ${title}`,
+      modal,
+    )
+  })
+
+  return defineField({
+    name: `${group}_pte`,
+    title: `Object · ${modalType} · all widths`,
+    description: `Portable Text with ${annotations.length} annotation types (one per width variant). Select text, open the annotation toolbar, and add each mark to compare modal behavior. options.modal is on the object type, not the array.`,
+    type: 'array',
+    group,
+    of: [
+      {
+        type: 'block',
+        marks: {
+          annotations,
+        },
+      },
+    ],
+  })
+}
+
+export const arrayModalWidthRepro = defineType({
+  name: 'arrayModalWidthReproTest',
+  type: 'document',
+  description:
+    'Tabbed repro for options.modal.type and options.modal.width on arrays and objects (PTE annotations).',
+  groups: [...MODAL_WIDTH_GROUPS],
+  fields: [
+    defineField({
+      name: 'title',
+      type: 'string',
+      group: 'arrayDialog',
+      initialValue: 'Issue #4741 — modal options repro',
+    }),
+    defineField({
+      name: 'notes',
+      type: 'text',
+      title: 'How to use',
+      group: 'arrayDialog',
+      readOnly: true,
+      initialValue: [
+        'Array tabs: Add item on each field; width comes from the array field options.modal.',
+        'Object tabs: Type in the PTE field, select text, add an annotation from the toolbar.',
+        'Edge cases: invalid width, responsive width array (objects only), modal on array member vs array field.',
+        'Not covered here: deprecated options.editModal, layout grid/tags, insertMenu.',
+      ].join('\n'),
+    }),
+    ...buildArrayModalFields('dialog', 'arrayDialog'),
+    ...buildArrayModalFields('popover', 'arrayPopover'),
+    buildObjectModalPteField('dialog', 'objectDialog'),
+    buildObjectModalPteField('popover', 'objectPopover'),
+    defineField({
+      name: 'edgeCases_arrayDialogWidth7',
+      title: 'Array · dialog · width: 7 (original issue)',
+      description:
+        'Out-of-range index from the GitHub report. Historically produced max-width: NaNrem on DialogCard.',
+      type: 'array',
+      group: 'edgeCases',
+      options: {
+        modal: {
+          type: 'dialog',
+          // @ts-expect-error 7 is not in ModalOptions (valid: 1–5 | auto)
+          width: 7,
+        },
+      },
+      of: [arrayItem],
+    }),
+    defineField({
+      name: 'edgeCases_arrayPopoverWidth7',
+      title: 'Array · popover · width: 7',
+      description: 'Same invalid index with popover; inspect PopoverContainer width.',
+      type: 'array',
+      group: 'edgeCases',
+      options: {
+        modal: {
+          type: 'popover',
+          // @ts-expect-error 7 is not in ModalOptions (valid: 1–5 | auto)
+          width: 7,
+        },
+      },
+      of: [arrayItem],
+    }),
+    defineField({
+      name: 'edgeCases_arrayModalOnMember',
+      title: 'Array — modal on item type (ignored when editing)',
+      description:
+        'The array field uses dialog width 2. Modal on the object member (popover width 5) is not applied when opening array items — only parentSchemaType (the array) is read.',
+      type: 'array',
+      group: 'edgeCases',
+      options: {
+        modal: {type: 'dialog', width: 2},
+      },
+      of: [
+        defineArrayMember({
+          type: 'object',
+          name: 'itemWithOwnModal',
+          title: 'Item (modal on type ignored)',
+          options: {
+            modal: {type: 'popover', width: 5},
+          },
+          fields: arrayItemFields,
+        }),
+      ],
+    }),
+    defineField({
+      name: 'edgeCases_objectResponsiveWidth',
+      title: 'Object · dialog · responsive width [2, 5]',
+      description:
+        'Objects support width as a number array for responsive breakpoints (parsed by _getModalOption). Arrays only accept a single number | auto.',
+      type: 'array',
+      group: 'edgeCases',
+      of: [
+        {
+          type: 'block',
+          marks: {
+            annotations: [
+              createModalAnnotation('responsiveWidth', 'Responsive width [2, 5]', {
+                type: 'dialog',
+                // @ts-expect-error arrays of widths are valid at runtime for objects
+                width: [2, 5],
+              }),
+            ],
+          },
+        },
+      ],
+    }),
+    defineField({
+      name: 'edgeCases_arrayModalTypeOmitted',
+      title: 'Array — modal.type omitted (defaults to dialog)',
+      description: 'Only width: 2 is set; modal.type falls back to "dialog" in PreviewItem.',
+      type: 'array',
+      group: 'edgeCases',
+      options: {
+        modal: {
+          width: 2,
+        },
+      },
+      of: [arrayItem],
+    }),
+  ],
+  preview: {
+    select: {title: 'title'},
+    prepare({title}) {
+      return {
+        title: title || 'Modal options repro (#4741)',
+        subtitle: 'Array + object modal.width tabs',
+      }
+    },
+  },
+})

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -13,6 +13,7 @@ import {
   tooltipAnnotationType,
 } from './debug/annotationCustomTypeTest'
 import {arrayCapabilities} from './debug/arrayCapabilities'
+import {arrayModalWidthRepro} from './debug/arrayModalWidthRepro'
 import {arrayOfStringsGridCustomInput} from './debug/arrayOfStringsGridCustomInput'
 import button from './debug/button'
 import {circularCrossDatasetReferenceTest} from './debug/circularCrossDatasetReference'
@@ -233,6 +234,7 @@ export function createSchemaTypes(projectId: string) {
     annotationCustomTypeTest,
     ctaType,
     tooltipAnnotationType,
+    arrayModalWidthRepro,
     arrayOfStringsGridCustomInput,
     button,
     collapsibleColumnsBug,

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -106,6 +106,7 @@ export const DEBUG_INPUT_TYPES = [
   'virtualizationDebug',
   'virtualizationInObject',
   'annotationCustomTypeTest',
+  'arrayModalWidthReproTest',
   'arrayOfStringsGridCustomInputTest',
   'withObjectFieldsOrder',
 ]

--- a/packages/@sanity/types/src/schema/definition/type/array.ts
+++ b/packages/@sanity/types/src/schema/definition/type/array.ts
@@ -6,6 +6,7 @@ import {
   type AutocompleteString,
   type InitialValueProperty,
   type SchemaValidationValue,
+  type ModalOptions,
 } from '../../types'
 import {
   type IntrinsicDefinitions,
@@ -62,7 +63,7 @@ export interface ArrayOptions<V = unknown> extends SearchConfiguration, BaseSche
   /** @deprecated This option does not have any effect anymore */
   direction?: 'horizontal' | 'vertical'
   sortable?: boolean
-  modal?: {type?: 'dialog' | 'popover'; width?: number | 'auto'}
+  modal?: ModalOptions
   /** @alpha This API may change */
   insertMenu?: InsertMenuOptions
   /**

--- a/packages/@sanity/types/src/schema/definition/type/object.ts
+++ b/packages/@sanity/types/src/schema/definition/type/object.ts
@@ -1,6 +1,6 @@
 import {type PreviewConfig} from '../../preview'
 import {type RuleDef, type ValidationBuilder} from '../../ruleBuilder'
-import {type InitialValueProperty} from '../../types'
+import {type InitialValueProperty, type ModalOptions} from '../../types'
 import {type FieldDefinition} from '../schemaDefinition'
 import {
   type BaseSchemaDefinition,
@@ -14,10 +14,7 @@ export interface ObjectOptions extends BaseSchemaTypeOptions {
   collapsible?: boolean
   collapsed?: boolean
   columns?: number
-  modal?: {
-    type?: 'dialog' | 'popover'
-    width?: number | number[] | 'auto'
-  }
+  modal?: ModalOptions
 }
 
 /** @public */

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -523,3 +523,9 @@ export interface FileSchemaType extends Omit<ObjectSchemaType, 'options'> {
 export interface ImageSchemaType extends Omit<ObjectSchemaType, 'options'> {
   options?: ImageOptions
 }
+
+/** @public */
+export interface ModalOptions {
+  type?: 'dialog' | 'popover'
+  width?: 1 | 2 | 3 | 4 | 5 | 'auto'
+}

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -525,7 +525,8 @@ export interface ImageSchemaType extends Omit<ObjectSchemaType, 'options'> {
 }
 
 /** @public */
+/** @public */
 export interface ModalOptions {
   type?: 'dialog' | 'popover'
-  width?: 1 | 2 | 3 | 4 | 5 | 'auto'
+  width?: 1 | 2 | 3 | 4 | 5 | 'auto' | (1 | 2 | 3 | 4 | 5 | 'auto')[]
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/object/helpers.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/helpers.ts
@@ -7,7 +7,7 @@ const parseResponsiveWidth = (value: unknown): (number | 'auto')[] => {
   if (typeof value === 'number') {
     return [value]
   }
-  return value === 'auto' ? ['auto'] : []
+  return value === 'auto' ? ['auto'] : [1]
 }
 const parseModalType = (value: unknown): 'popover' | 'dialog' | undefined => {
   return value === 'dialog' || value === 'popover' ? value : undefined

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
@@ -69,7 +69,7 @@ export function ObjectEditModal(props: {
       type="dialog"
       onClose={onClose}
       header={modalTitle}
-      width={1}
+      width={modalWidth ?? 1}
       autofocus={autoFocus}
     >
       {props.children}


### PR DESCRIPTION
### Description

Fixes [#4741](https://github.com/sanity-io/sanity/issues/4741): `options.modal.width` on object types (e.g. PTE annotations) was ignored in the enhanced object dialog path because `ObjectEditModal` hardcoded `width={1}`. Invalid or missing width values from `_getModalOption` could also resolve to an empty width array instead of a safe default.

Introduces a shared `ModalOptions` type (`width`: `1 | 2 | 3 | 4 | 5 | 'auto'`) so schema authors see valid container indices Adds a tabbed test-studio repro under **Inputs → Debug** for array vs object and dialog vs popover.

`1 | 2 | 3 | 4 | 5` are indexes into the Sanity UI theme `container` scale (not pixels or rem). The default scale maps roughly to 640px, 960px, 1280px, 1600px, and 1920px (`1`–`5`). `'auto'` is fullscreen-style width. Omitted width falls back to `1` (~640px).

Values like `7` are out of range (`container[7]` is undefined), and it will use the default sanity ui which is `100%`

The widths can be tested here https://test-studio-git-fix-gh-4741.sanity.dev/test/structure/input-debug;arrayModalWidthReproTest;c07d770a-6573-4758-a7f3-8cb8b53cace3%2Ctemplate%3DarrayModalWidthReproTest

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fix  `options.modal.width` on object types now applies in enhanced object dialogs.
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
