### PR TITLE
feat(core): warn when no login providers are available

### DIFF
--- a/dev/auth-test-studio/sanity.config.ts
+++ b/dev/auth-test-studio/sanity.config.ts
@@ -200,4 +200,17 @@ function createWorkspaces(env: {projectId: string; dataset: string; apiHost?: st
   ] satisfies WorkspaceOptions[]
 }
 
-export default defineConfig(envs.flatMap(createWorkspaces))
+export default defineConfig([
+  ...envs.flatMap(createWorkspaces),
+  {
+    ...shared,
+    ...production.ppsg7ml5,
+    name: `noProviders`,
+    title: `Test workspace without auth providers`,
+    basePath: `/ppsg7ml5/noProviders`,
+    auth: {
+      providers: [],
+      mode: 'replace',
+    },
+  } satisfies WorkspaceOptions,
+])

--- a/packages/sanity/src/core/store/authStore/__tests__/createLoginComponent.test.tsx
+++ b/packages/sanity/src/core/store/authStore/__tests__/createLoginComponent.test.tsx
@@ -4,6 +4,7 @@ import {render, screen, waitFor} from '@testing-library/react'
 import {of} from 'rxjs'
 import {afterEach, describe, expect, it, vi} from 'vitest'
 
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
 import {createLoginComponent, getProviders} from '../createLoginComponent'
 
 interface MockClient {
@@ -151,5 +152,78 @@ describe('LoginComponent redirectOnSingle', () => {
 
     await waitFor(() => expect(setHref).toHaveBeenCalledTimes(1))
     expect(setHref).toHaveBeenCalledWith(expect.stringContaining('/auth/saml/login'))
+  })
+})
+
+function createEmptyProviderLogin() {
+  const client = {
+    withConfig: () => client,
+    request: vi.fn(() => Promise.resolve({providers: [], thirdPartyLogin: true})),
+  } as unknown as SanityClient
+
+  return createLoginComponent({
+    client$: of(client),
+    loginMethod: 'dual',
+    providers: [],
+    wasLogout: () => false,
+    isHandlingCallback: () => false,
+  })
+}
+
+describe('LoginComponent with no providers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows a warning instead of an empty chooser when providers resolve empty', async () => {
+    // `providers: []` replaces the default providers with none (rather than
+    // falling back to defaults), so the chooser would otherwise render an empty,
+    // dead-end dialog. We surface a caution card explaining the misconfiguration.
+    const LoginComponent = createEmptyProviderLogin()
+
+    render(
+      <ThemeProvider theme={studioTheme}>
+        <LoginComponent projectId="p" basePath="/" />
+      </ThemeProvider>,
+    )
+
+    await screen.findByText('No login providers available')
+    expect(screen.queryByText('Choose login provider')).toBeNull()
+  })
+
+  it('offers to switch workspaces when onChooseAnotherWorkspace is provided', async () => {
+    const onChooseAnotherWorkspace = vi.fn()
+    const LoginComponent = createEmptyProviderLogin()
+    // The button label is translated, so render inside the i18n provider to
+    // resolve the key rather than asserting on the raw key.
+    const TestProvider = await createTestProvider()
+
+    render(
+      <TestProvider>
+        <LoginComponent
+          projectId="p"
+          basePath="/"
+          onChooseAnotherWorkspace={onChooseAnotherWorkspace}
+        />
+      </TestProvider>,
+    )
+
+    const button = await screen.findByText('Choose another workspace')
+    button.click()
+    expect(onChooseAnotherWorkspace).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides the switch action when onChooseAnotherWorkspace is not provided', async () => {
+    // There's only one workspace to use, so there's nothing to switch to.
+    const LoginComponent = createEmptyProviderLogin()
+
+    render(
+      <ThemeProvider theme={studioTheme}>
+        <LoginComponent projectId="p" basePath="/" />
+      </ThemeProvider>,
+    )
+
+    await screen.findByText('No login providers available')
+    expect(screen.queryByText('Choose another workspace')).toBeNull()
   })
 })

--- a/packages/sanity/src/core/store/authStore/createLoginComponent.tsx
+++ b/packages/sanity/src/core/store/authStore/createLoginComponent.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable i18next/no-literal-string */
 import {type AuthProvider, type AuthProviderResponse, type SanityClient} from '@sanity/client'
-import {Badge, Flex, Heading, Stack, Text} from '@sanity/ui'
+import {ArrowLeftIcon, WarningOutlineIcon} from '@sanity/icons'
+import {Badge, Box, Card, Flex, Heading, Stack, Text} from '@sanity/ui'
 import {useCallback, useEffect, useState} from 'react'
 import {useObservable} from 'react-rx'
 import {type Observable} from 'rxjs'
@@ -8,6 +9,7 @@ import {type Observable} from 'rxjs'
 import {Button, type ButtonProps} from '../../../ui-components'
 import {LoadingBlock} from '../../components/loadingBlock'
 import {type AuthConfig} from '../../config'
+import {useTranslation} from '../../i18n'
 import {CustomLogo, providerLogos} from './providerLogos'
 import {type LoginComponentProps} from './types'
 
@@ -121,6 +123,7 @@ export function createLoginComponent({
   ...providerOptions
 }: CreateLoginComponentOptions) {
   function LoginComponent({projectId, ...props}: LoginComponentProps) {
+    const {t} = useTranslation()
     const redirectPath = props.redirectPath || props.basePath || '/'
 
     const [providerData, setProviderData] = useState<{
@@ -200,6 +203,57 @@ export function createLoginComponent({
 
     if (loading) {
       return <LoadingBlock showText />
+    }
+
+    // No providers resolved — typically a misconfiguration where `auth.providers`
+    // is an empty array together with `mode: 'replace'`, which swaps the default
+    // providers out for nothing. Surface a warning instead of an empty, dead-end
+    // chooser.
+    if (providers.length === 0) {
+      return (
+        <Card padding={4} radius={2} shadow={1} tone="caution">
+          <Flex>
+            <Box>
+              <Text size={1}>
+                <WarningOutlineIcon />
+              </Text>
+            </Box>
+            <Stack flex={1} marginLeft={3} space={4}>
+              <Text as="h1" size={1} weight="medium">
+                No login providers available
+              </Text>
+              <Text as="p" muted size={1}>
+                The <code>auth.providers</code> setting in your Studio configuration resolved to an
+                empty list. This usually means an empty array is combined with{' '}
+                <code>mode: 'replace'</code>, which replaces the default providers with none.
+              </Text>
+              <Text as="p" muted size={1}>
+                Add at least one provider, or remove <code>mode: 'replace'</code> to keep the
+                defaults.
+              </Text>
+              {props.onChooseAnotherWorkspace && (
+                <Flex>
+                  <Button
+                    icon={ArrowLeftIcon}
+                    mode="ghost"
+                    onClick={props.onChooseAnotherWorkspace}
+                    text={t('workspaces.action.choose-another-workspace')}
+                  />
+                </Flex>
+              )}
+              <Text as="p" muted size={1}>
+                <a
+                  href="https://www.sanity.io/docs/configuration#dc516e8cb39e"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  Learn about auth configuration &rarr;
+                </a>
+              </Text>
+            </Stack>
+          </Flex>
+        </Card>
+      )
     }
 
     return (

--- a/packages/sanity/src/core/store/authStore/types.ts
+++ b/packages/sanity/src/core/store/authStore/types.ts
@@ -89,12 +89,24 @@ export type LoginComponentProps =
       /** @deprecated use redirectPath instead */
       basePath: string
       redirectPath?: string
+      /**
+       * Invoked when the user chooses to switch workspaces from the login screen
+       * (e.g. when the active workspace has no usable login providers). Only
+       * provided when more than one workspace is available to switch to.
+       */
+      onChooseAnotherWorkspace?: () => void
     }
   | {
       projectId: string
       redirectPath: string
       /** @deprecated use redirectPath instead */
       basePath?: string
+      /**
+       * Invoked when the user chooses to switch workspaces from the login screen
+       * (e.g. when the active workspace has no usable login providers). Only
+       * provided when more than one workspace is available to switch to.
+       */
+      onChooseAnotherWorkspace?: () => void
     }
 
 /**

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
@@ -26,41 +26,41 @@ const StyledContainer = styled(Container)((props) => {
 export function WorkspaceAuth() {
   const {visibleWorkspaces} = useVisibleWorkspaces()
   const {activeWorkspace, setActiveWorkspace} = useActiveWorkspace()
-  const [selectedWorkspaceName, setSelectedWorkspaceName] = useState<string | null>(
-    activeWorkspace?.name || null,
-  )
-  const selectedWorkspace =
-    visibleWorkspaces.length === 1
-      ? visibleWorkspaces[0]
-      : visibleWorkspaces.find((workspace) => workspace.name === selectedWorkspaceName)
+  // The workspace we show the login for is always the active one, so its URL
+  // (basePath) and the rendered login stay in sync. `showChooser` is the only
+  // local UI state: whether the user is looking at the workspace picker instead
+  // of the active workspace's login form.
+  const [showChooser, setShowChooser] = useState(false)
+  const {t} = useTranslation()
+
+  const canChooseAnotherWorkspace = visibleWorkspaces.length > 1
+  const selectedWorkspace = activeWorkspace
   const LoginComponent = selectedWorkspace?.auth?.LoginComponent
 
-  const handleBack = useCallback(() => setSelectedWorkspaceName(null), [])
-  const {t} = useTranslation()
+  const handleBack = useCallback(() => setShowChooser(true), [])
 
   const handleCardSelect = useCallback(
     (workspaceName: string, state: 'loading' | 'logged-in' | 'logged-out' | 'no-access') => {
       // While loading, navigate; the destination's auth boundary will handle login if needed.
-      if (
-        (state === 'logged-in' || state === 'loading') &&
-        workspaceName !== activeWorkspace.name
-      ) {
-        setActiveWorkspace(workspaceName)
-        return
-      }
-
-      if (state === 'logged-out') {
-        setSelectedWorkspaceName(workspaceName)
+      if (state === 'logged-in' || state === 'loading' || state === 'logged-out') {
+        // Switch the active workspace so the URL reflects the chosen workspace.
+        // For a logged-out workspace the AuthBoundary keeps us on this screen,
+        // now scoped to (and showing the login for) the new workspace at its own
+        // basePath, instead of leaving the URL pointing at the previous one.
+        if (workspaceName !== activeWorkspace.name) {
+          setActiveWorkspace(workspaceName)
+        }
+        setShowChooser(false)
       }
     },
     [activeWorkspace.name, setActiveWorkspace],
   )
 
-  if (LoginComponent && selectedWorkspace) {
+  if (LoginComponent && selectedWorkspace && !showChooser) {
     return (
       <Container width={0}>
         <Stack space={2}>
-          {visibleWorkspaces.length > 1 && (
+          {canChooseAnotherWorkspace && (
             <Flex>
               <Button
                 icon={ArrowLeftIcon}
@@ -84,7 +84,7 @@ export function WorkspaceAuth() {
           >
             <Stack padding={2} paddingBottom={3} paddingTop={4}>
               <LoginComponent
-                key={selectedWorkspaceName}
+                key={selectedWorkspace.name}
                 projectId={selectedWorkspace.projectId}
                 redirectPath={
                   window.location.pathname.startsWith(selectedWorkspace.basePath)
@@ -96,7 +96,7 @@ export function WorkspaceAuth() {
                 // Only offer switching when there's somewhere else to switch to.
                 // Lets the login UI (e.g. the no-providers warning) route back to
                 // the workspace chooser without a full reload.
-                onChooseAnotherWorkspace={visibleWorkspaces.length > 1 ? handleBack : undefined}
+                onChooseAnotherWorkspace={canChooseAnotherWorkspace ? handleBack : undefined}
               />
             </Stack>
           </Layout>

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuth.tsx
@@ -93,6 +93,10 @@ export function WorkspaceAuth() {
                       `${window.location.pathname}${window.location.search}`
                     : selectedWorkspace.basePath
                 }
+                // Only offer switching when there's somewhere else to switch to.
+                // Lets the login UI (e.g. the no-providers warning) route back to
+                // the workspace chooser without a full reload.
+                onChooseAnotherWorkspace={visibleWorkspaces.length > 1 ? handleBack : undefined}
               />
             </Stack>
           </Layout>


### PR DESCRIPTION
### Description

Adds a warning if auth config resolves to empty list of providers.

Before / After
<table>
<tr><td>
<img alt="before" src="https://github.com/user-attachments/assets/00540a3e-34be-4607-9233-8fac4bc1af03" />
</td><td>
<img alt="after" src="https://github.com/user-attachments/assets/61d543fc-2362-41d5-81de-a939dee564d9" />
</td></tr>
</table>

### What to review
Also noticed we didn't update the url when switching to another workspace, so included a fix for that in 9766add60703791f761d5068c772152211e7e85b.

see it in action here: https://auth-test-studio-git-warn-when-no-provider.sanity.dev/ppsg7ml5/noProviders
(note: you might need to log out, the warning won't appear if you're already logged in)

### Testing
- Tests included

### Notes for release
- Studio will now show a warning if auth config resolves to no providers