### PR TITLE
fix(presentation): ChildLink now renders missing docs

### DIFF
--- a/packages/sanity/src/presentation/paneRouter/PresentationPaneRouterProvider.tsx
+++ b/packages/sanity/src/presentation/paneRouter/PresentationPaneRouterProvider.tsx
@@ -18,6 +18,7 @@ import {
 } from '../types'
 import {ChildLink} from './ChildLink'
 import {ReferenceChildLink} from './ReferenceChildLink'
+import {StructureIntentChildLink} from './StructureIntentChildLink'
 
 function encodeQueryString(params: Record<string, unknown> = {}): string {
   const parts = Object.entries(params)
@@ -109,14 +110,19 @@ export function PresentationPaneRouterProvider(
       routerPanesState: [],
       ChildLink: forwardRef<HTMLAnchorElement, ChildLinkProps>(
         function ContextChildLink(childLinkProps, ref) {
-          const {childId, ...rest} = childLinkProps
+          const {childId, childParameters, ...rest} = childLinkProps
           const doc = refs?.find((r) => r._id === childId || getPublishedId(r._id) === childId)
 
           if (!doc) {
-            console.warn(`ChildLink: No document found for childId "${childId}"`)
-            return null
+            return (
+              <StructureIntentChildLink
+                {...rest}
+                ref={ref}
+                childId={childId}
+                childParameters={childParameters}
+              />
+            )
           }
-
           return (
             <ChildLink
               {...rest}

--- a/packages/sanity/src/presentation/paneRouter/StructureIntentChildLink.tsx
+++ b/packages/sanity/src/presentation/paneRouter/StructureIntentChildLink.tsx
@@ -1,6 +1,6 @@
 import {type ForwardedRef, forwardRef} from 'react'
 import {getPublishedId} from 'sanity'
-import {IntentLink} from 'sanity/router'
+import {type IntentJsonParams, type IntentParameters, IntentLink} from 'sanity/router'
 import {type ChildLinkProps} from 'sanity/structure'
 
 /**
@@ -11,28 +11,28 @@ export const StructureIntentChildLink = forwardRef(function StructureIntentChild
   props: ChildLinkProps,
   ref: ForwardedRef<HTMLAnchorElement>,
 ) {
-  const {childId, childParameters, children, ...rest} = props
+  const {childId, childParameters, childPayload, children, ...rest} = props
   const childType = childParameters?.type
-  const path = childParameters?.path
 
   if (!childType) {
     return null
   }
+
+  const intentParams = {
+    ...childParameters,
+    id: getPublishedId(childId),
+    mode: 'structure',
+  }
+
+  const params: IntentParameters =
+    childPayload !== undefined ? [intentParams, childPayload as IntentJsonParams] : intentParams
 
   return (
     <IntentLink
       {...rest}
       ref={ref}
       intent="edit"
-      params={{
-        id: getPublishedId(childId),
-        type: childType,
-        mode: 'structure',
-        ...(path ? {path} : {}),
-        ...childParameters,
-        ...(childParameters?.template ? {template: childParameters.template} : {}),
-        ...(childParameters?.parentRefPath ? {parentRefPath: childParameters.parentRefPath} : {}),
-      }}
+      params={params}
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/packages/sanity/src/presentation/paneRouter/StructureIntentChildLink.tsx
+++ b/packages/sanity/src/presentation/paneRouter/StructureIntentChildLink.tsx
@@ -1,0 +1,42 @@
+import {type ForwardedRef, forwardRef} from 'react'
+import {getPublishedId} from 'sanity'
+import {IntentLink} from 'sanity/router'
+import {type ChildLinkProps} from 'sanity/structure'
+
+/**
+ * Opens a child document in the structure tool (new tab) when it is not part of the
+ * presentation preview surface.
+ */
+export const StructureIntentChildLink = forwardRef(function StructureIntentChildLink(
+  props: ChildLinkProps,
+  ref: ForwardedRef<HTMLAnchorElement>,
+) {
+  const {childId, childParameters, children, ...rest} = props
+  const childType = childParameters?.type
+  const path = childParameters?.path
+
+  if (!childType) {
+    return null
+  }
+
+  return (
+    <IntentLink
+      {...rest}
+      ref={ref}
+      intent="edit"
+      params={{
+        id: getPublishedId(childId),
+        type: childType,
+        mode: 'structure',
+        ...(path ? {path} : {}),
+        ...childParameters,
+        ...(childParameters?.template ? {template: childParameters.template} : {}),
+        ...(childParameters?.parentRefPath ? {parentRefPath: childParameters.parentRefPath} : {}),
+      }}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      {children}
+    </IntentLink>
+  )
+})

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferenceDocument.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferenceDocument.tsx
@@ -1,19 +1,15 @@
 import {Box, Card, Flex, Text} from '@sanity/ui'
 import {motion, type Variants} from 'motion/react'
-import {useCallback, useState} from 'react'
+import {useState} from 'react'
 import {
-  getPublishedId,
   getReferencePaths,
-  pathToString,
   SanityDefaultPreview,
   type SanityDocument,
   useSchema,
   useTranslation,
 } from 'sanity'
-import {useRouter} from 'sanity/router'
 
 import {structureLocaleNamespace} from '../../i18n'
-import {usePaneRouter} from '../paneRouter'
 import {IncomingReferenceDocumentActions} from './IncomingReferenceDocumentActions'
 import {IncomingReferencePreview} from './IncomingReferencePreview'
 import {type IncomingReferencesOptions} from './types'
@@ -48,26 +44,9 @@ export const IncomingReferenceDocument = (props: {
   const {document, referenceToId, actions} = props
   const referencePaths = getReferencePaths(document, referenceToId)
   const [isExecutingAction, setIsExecutingAction] = useState(false)
-  const id = document._id
   const schema = useSchema()
-  const {navigate} = useRouter()
-  const {routerPanesState, groupIndex} = usePaneRouter()
   const type = document?._type
   const {t} = useTranslation(structureLocaleNamespace)
-
-  const handleClick = useCallback(() => {
-    if (!referencePaths.length) {
-      // This should not happen because if we don't have reference paths, then this function won't be passed to the
-      // IncomingReferencePreview component
-      throw new Error('No reference paths found')
-    }
-    navigate({
-      panes: [
-        ...routerPanesState.slice(0, groupIndex + 1),
-        [{id: getPublishedId(id), params: {type, path: pathToString(referencePaths[0])}}],
-      ],
-    })
-  }, [routerPanesState, groupIndex, type, navigate, id, referencePaths])
 
   const schemaType = schema.get(type)
 
@@ -86,12 +65,7 @@ export const IncomingReferenceDocument = (props: {
         {/* In some cases when the document has been recently linked the value we get
           in the listener is not the latest, but a previous value with the document not yet linked, this handles that */}
         {referencePaths.length > 0 ? (
-          <IncomingReferencePreview
-            type={schemaType}
-            value={document}
-            onClick={handleClick}
-            path={referencePaths[0]}
-          />
+          <IncomingReferencePreview type={schemaType} value={document} path={referencePaths[0]} />
         ) : (
           <SanityDefaultPreview icon={schemaType.icon} layout={'default'} isPlaceholder />
         )}

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencePreview.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencePreview.tsx
@@ -13,14 +13,13 @@ import {PaneItemPreview} from '../paneItem/PaneItemPreview'
 import {usePaneRouter} from '../paneRouter'
 
 interface IncomingReferencePreviewProps {
-  onClick?: () => void
   type: SchemaType
   value: SanityDocument
   path: Path
 }
 
 export function IncomingReferencePreview(props: IncomingReferencePreviewProps) {
-  const {onClick, type, value, path} = props
+  const {type, value, path} = props
   const publishedId = getPublishedId(value?._id)
   const documentPresence = useDocumentPresence(publishedId)
   const documentPreviewStore = useDocumentPreviewStore()
@@ -40,7 +39,7 @@ export function IncomingReferencePreview(props: IncomingReferencePreviewProps) {
   )
 
   return (
-    <PreviewCard __unstable_focusRing as={Link as FIXME} data-as="a" onClick={onClick} radius={2}>
+    <PreviewCard __unstable_focusRing as={Link as FIXME} data-as="a" radius={2}>
       <PaneItemPreview
         documentPreviewStore={documentPreviewStore}
         icon={type.icon || false}

--- a/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/IncomingReferenceDocument.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/IncomingReferenceDocument.tsx
@@ -1,18 +1,8 @@
 import {Box, Card, Flex, Text} from '@sanity/ui'
 import {motion} from 'motion/react'
-import {useCallback} from 'react'
-import {
-  getPublishedId,
-  getReferencePaths,
-  pathToString,
-  type SanityDocument,
-  useSchema,
-  useTranslation,
-} from 'sanity'
-import {useRouter} from 'sanity/router'
+import {getReferencePaths, type SanityDocument, useSchema, useTranslation} from 'sanity'
 
 import {IncomingReferencePreview} from '../../../../components/incomingReferencesDecoration/IncomingReferencePreview'
-import {usePaneRouter} from '../../../../components/paneRouter/usePaneRouter'
 import {structureLocaleNamespace} from '../../../../i18n'
 
 const FadeInFlex = motion.create(Flex)
@@ -24,22 +14,7 @@ export const IncomingReferenceDocument = (props: {
   const {t} = useTranslation(structureLocaleNamespace)
   const {document, referenceToId} = props
   const referencePaths = getReferencePaths(document, referenceToId)
-  const id = document._id
   const schema = useSchema()
-  const {navigate} = useRouter()
-  const {routerPanesState, groupIndex} = usePaneRouter()
-
-  const type = document?._type
-
-  const handleClick = useCallback(() => {
-    if (!type) return // This should not happen
-    navigate({
-      panes: [
-        ...routerPanesState.slice(0, groupIndex + 1),
-        [{id: getPublishedId(id), params: {type, path: pathToString(referencePaths[0])}}],
-      ],
-    })
-  }, [routerPanesState, groupIndex, type, navigate, id, referencePaths])
 
   const schemaType = schema.get(document._type)
   if (!schemaType)
@@ -57,12 +32,7 @@ export const IncomingReferenceDocument = (props: {
     <Card radius={2} tone="default">
       <FadeInFlex initial={{opacity: 0}} animate={{opacity: 1}} gap={1} align="center">
         <Box flex={1}>
-          <IncomingReferencePreview
-            type={schemaType}
-            value={document}
-            onClick={handleClick}
-            path={referencePaths[0]}
-          />
+          <IncomingReferencePreview type={schemaType} value={document} path={referencePaths[0]} />
         </Box>
       </FadeInFlex>
     </Card>


### PR DESCRIPTION
### Description
In presentation ChildLink was not rendering the child if the document is not part of the documents that are loaded in that view, this is confusing and could lead to elements not showing in presentation while accurately showing in structure, for example this happened in the incoming references inspector:

[**The child is empty**](https://test-studio.sanity.dev/test/presentation/simpleBlock/99b9b5d7-688c-4d79-a2c3-2196e19bf71a/?inspect=sanity/structure/incoming-references)
<img width="1407" height="928" alt="Screenshot 2026-06-04 at 15 45 33" src="https://github.com/user-attachments/assets/a18ad4ee-dc76-4101-956f-4c77963ba158" />


[**And this is how it looks now**](https://test-studio-git-sapp-3974.sanity.dev/test/presentation/simpleBlock/99b9b5d7-688c-4d79-a2c3-2196e19bf71a/?inspect=sanity/structure/incoming-references)
<img width="1410" height="930" alt="Screenshot 2026-06-04 at 15 44 56" src="https://github.com/user-attachments/assets/f6013df0-4dbc-497a-b35f-e8fb9ea1497c" />

I also removed the unnecessary `onClick` handler in the card, given it's a link it doesn't need the onClick, seems a leftover from the initial implementation

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Fixes an issue in incoming references inspector which was not rendering the references when used inside presentation.
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
