### PR TITLE
fix(core): react strict-mode improvements

### DIFF
--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -1,6 +1,6 @@
 import {DeferredTelemetryProvider} from '@sanity/telemetry/react'
 import {ToastProvider} from '@sanity/ui'
-import {type ReactNode, useMemo} from 'react'
+import {type ReactNode, useEffect, useMemo} from 'react'
 
 import {LoadingBlock} from '../components/loadingBlock'
 import {errorReporter} from '../error/errorReporter'
@@ -54,13 +54,12 @@ export function StudioProvider({
   unstable_history: history,
   unstable_noAuthBoundary: noAuthBoundary,
 }: StudioProviderProps) {
-  // We initialize the error reporter as early as possible in order to catch anything that could
-  // occur during configuration loading, React rendering etc. StudioProvider is often the highest
-  // mounted React component that is shared across embedded and standalone studios.
-  errorReporter.initialize()
-
-  // Register refractor languages on first render (deferred from module scope for faster import)
-  ensureRefractorLanguages()
+  // Run in an effect to keep render pure; both calls are idempotent and buffer/guard
+  // their own work, so StrictMode's double mount is safe.
+  useEffect(() => {
+    errorReporter.initialize()
+    ensureRefractorLanguages()
+  }, [])
 
   // Extract the first workspace's projectId for use in error screens
   const primaryProjectId = useMemo(() => {

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
@@ -60,10 +60,12 @@ export function SearchResultItem({
 
   useEffect(() => {
     if (state.canDisableAction) {
-      grantsStore
+      const subscription = grantsStore
         .checkDocumentPermission('create', {_id: documentId, _type: documentType})
         .subscribe(setCreatePermission)
+      return () => subscription.unsubscribe()
     }
+    return undefined
   }, [documentId, documentType, grantsStore, state.canDisableAction])
 
   // the current search result exists in the release provided by the search provider

--- a/packages/sanity/src/core/studio/manifest/LiveManifestRegisterProvider.tsx
+++ b/packages/sanity/src/core/studio/manifest/LiveManifestRegisterProvider.tsx
@@ -20,14 +20,17 @@ export function LiveManifestRegisterProvider() {
   const {theme} = useRootTheme()
 
   useEffect(() => {
-    if (!userApplication || workspaces.length === 0) {
-      // Nothing to register
-      return
-    }
-    // Upload once when workspaces are available
-    registerStudioManifest(userApplication, workspaces, theme).catch((err) => {
-      debug('Failed to upload studio manifest', err)
+    if (!userApplication || workspaces.length === 0) return undefined
+
+    // Abort the in-flight upload on cleanup so StrictMode's double mount, or a dep change,
+    // leaves only the latest upload running rather than racing duplicate requests.
+    const controller = new AbortController()
+    registerStudioManifest(userApplication, workspaces, theme, controller.signal).catch((error) => {
+      if (error?.name === 'AbortError') return
+      debug('Failed to upload studio manifest', error)
     })
+
+    return () => controller.abort()
   }, [userApplication, workspaces, theme])
 
   return null

--- a/packages/sanity/src/core/studio/manifest/__tests__/LiveManifestRegisterProvider.test.tsx
+++ b/packages/sanity/src/core/studio/manifest/__tests__/LiveManifestRegisterProvider.test.tsx
@@ -1,0 +1,70 @@
+import {render} from '@testing-library/react'
+import {StrictMode} from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {useLiveUserApplication} from '../../liveUserApplication/useLiveUserApplication'
+import {useWorkspaces} from '../../workspaces'
+import {LiveManifestRegisterProvider} from '../LiveManifestRegisterProvider'
+import {registerStudioManifest} from '../registerLiveStudioManifest'
+
+const theme = {}
+
+vi.mock('@sanity/ui', () => ({
+  useRootTheme: vi.fn(() => ({theme})),
+}))
+vi.mock('../../liveUserApplication/useLiveUserApplication', () => ({
+  useLiveUserApplication: vi.fn(),
+}))
+vi.mock('../../workspaces', () => ({
+  useWorkspaces: vi.fn(),
+}))
+vi.mock('../registerLiveStudioManifest', () => ({
+  registerStudioManifest: vi.fn().mockResolvedValue(undefined),
+}))
+
+describe('LiveManifestRegisterProvider', () => {
+  const userApplication = {id: 'app-1', projectId: 'project-1'}
+  const workspaces = [{name: 'default', projectId: 'project-1'}]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useWorkspaces).mockReturnValue(workspaces as never)
+    vi.mocked(useLiveUserApplication).mockReturnValue({userApplication} as never)
+  })
+
+  it('registers the manifest with the resolved user application, workspaces and theme', () => {
+    render(<LiveManifestRegisterProvider />)
+    expect(registerStudioManifest).toHaveBeenCalledWith(
+      userApplication,
+      workspaces,
+      theme,
+      expect.any(AbortSignal),
+    )
+  })
+
+  it('aborts the superseded upload when remounted under StrictMode', () => {
+    render(
+      <StrictMode>
+        <LiveManifestRegisterProvider />
+      </StrictMode>,
+    )
+
+    // StrictMode mounts, unmounts, then remounts: the first upload's signal is aborted by
+    // cleanup, so only the second upload runs to completion.
+    const [firstCall, secondCall] = vi.mocked(registerStudioManifest).mock.calls
+    expect(firstCall[3]?.aborted).toBe(true)
+    expect(secondCall[3]?.aborted).toBe(false)
+  })
+
+  it('does not register when there is no user application', () => {
+    vi.mocked(useLiveUserApplication).mockReturnValue({userApplication: undefined} as never)
+    render(<LiveManifestRegisterProvider />)
+    expect(registerStudioManifest).not.toHaveBeenCalled()
+  })
+
+  it('does not register when there are no workspaces', () => {
+    vi.mocked(useWorkspaces).mockReturnValue([] as never)
+    render(<LiveManifestRegisterProvider />)
+    expect(registerStudioManifest).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sanity/src/core/studio/manifest/__tests__/registerLiveStudioManifest.test.tsx
+++ b/packages/sanity/src/core/studio/manifest/__tests__/registerLiveStudioManifest.test.tsx
@@ -302,4 +302,33 @@ describe('registerStudioManifest', () => {
       expect(callArgs.body.value.workspaces[0].subtitle).toBeUndefined()
     })
   })
+
+  describe('abort signal', () => {
+    it('should forward the abort signal to the request', async () => {
+      const controller = new AbortController()
+
+      await registerStudioManifest(
+        mockUserApplication,
+        [createMockWorkspace()],
+        mockTheme,
+        controller.signal,
+      )
+
+      expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({signal: controller.signal}))
+    })
+
+    it('should skip the POST when the signal is already aborted', async () => {
+      const controller = new AbortController()
+      controller.abort()
+
+      await registerStudioManifest(
+        mockUserApplication,
+        [createMockWorkspace()],
+        mockTheme,
+        controller.signal,
+      )
+
+      expect(mockRequest).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/sanity/src/core/studio/manifest/registerLiveStudioManifest.tsx
+++ b/packages/sanity/src/core/studio/manifest/registerLiveStudioManifest.tsx
@@ -40,6 +40,7 @@ async function resolveSchemaDescriptorId(workspace: WorkspaceSummary): Promise<s
  * @param userApplication - The user application
  * @param workspaces - Array of all workspaces in the Studio
  * @param theme - The Studio theme to use for rendering icons
+ * @param signal - Aborts the upload when the registering effect is torn down
  * @returns Promise that resolves when upload is complete
  * @internal
  */
@@ -47,6 +48,7 @@ export async function registerStudioManifest(
   userApplication: UserApplication,
   workspaces: WorkspaceSummary[],
   theme: RootTheme,
+  signal?: AbortSignal,
 ): Promise<void> {
   const {id, projectId} = userApplication
 
@@ -81,6 +83,11 @@ export async function registerStudioManifest(
     return // if the user isn't authenticated, nothing to do
   }
 
+  // Bail before posting if the registering effect has already been torn down.
+  if (signal?.aborted) {
+    return
+  }
+
   // Post the live manifest via the global api
   await client.withConfig(DEFAULT_STUDIO_CLIENT_OPTIONS).request({
     method: 'POST',
@@ -89,5 +96,6 @@ export async function registerStudioManifest(
       value: liveManifest,
     },
     tag: 'live-manifest-register',
+    signal,
   })
 }

--- a/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
+++ b/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
@@ -184,8 +184,11 @@ export function StudioTelemetryProvider(props: {children: ReactNode}) {
   // eslint-disable-next-line react-hooks/refs
   const store = useMemo(() => createBatchedStore(sessionId, storeOptions), [storeOptions])
 
+  // Per-instance guard so StrictMode's double-invoked mount effect logs StudioLoaded once.
+  const studioLoadedFiredRef = useRef(false)
   useEffect(() => {
-    if (!isClient || !contextRef.current) return
+    if (!isClient || !contextRef.current || studioLoadedFiredRef.current) return
+    studioLoadedFiredRef.current = true
     const ctx = contextRef.current
     store.logger.log(StudioLoaded, {
       studioVersion: SANITY_VERSION,

--- a/packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx
+++ b/packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx
@@ -2,7 +2,7 @@ import type * as SanityTelemetry from '@sanity/telemetry'
 /* eslint-disable import/first */
 // Regular imports first
 import {render} from '@testing-library/react'
-import {type ReactNode} from 'react'
+import {StrictMode, type ReactNode} from 'react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 // Disable console.logging of telemetry events in tests
@@ -501,5 +501,20 @@ describe('StudioTelemetryProvider', () => {
         screenInnerWidth: expect.any(Number),
       }),
     )
+  })
+
+  it('emits StudioLoaded only once when mounted in StrictMode', () => {
+    render(
+      <StrictMode>
+        <DeferredTelemetryProvider>
+          <StudioTelemetryProvider>
+            <div>Test Child</div>
+          </StudioTelemetryProvider>
+        </DeferredTelemetryProvider>
+      </StrictMode>,
+    )
+
+    const studioLoadedCalls = mockLog.mock.calls.filter(([event]) => event === StudioLoaded)
+    expect(studioLoadedCalls).toHaveLength(1)
   })
 })


### PR DESCRIPTION
### Description

React strict mode is being enabled by default in the next-major branch (#12916), and that work surfaced several latent bugs in the studio: a manifest upload that races duplicate requests when its effect deps change, telemetry that double-logs `StudioLoaded`, a search-result permission subscription that never unsubscribes, and side effects run during render in `StudioProvider`. These are real defects independent of strict mode, and they should land on main ahead of the next-major merge to shrink that merge's surface area.

This PR ports those fixes from #12916 to main while deliberately excluding the one behavioural change - flipping `reactStrictMode` to default on. `renderStudio.tsx` is left identical to main, so the studio's default stays unchanged; only the safety fixes and their tests land.

### What to review

- `renderStudio.tsx` is intentionally absent from the diff - confirm the default-on flip was excluded.
- `LiveManifestRegisterProvider.tsx` and `registerLiveStudioManifest.tsx` - upload now cancels via an `AbortController` on effect cleanup, and `AbortError` rejections are swallowed.
- `StudioProvider.tsx` - `errorReporter.initialize()` and `ensureRefractorLanguages()` move into a mount effect to keep render pure.
- `StudioTelemetryProvider.tsx` - a per-instance ref guard ensures `StudioLoaded` logs once.

### Testing

Added unit tests covering the manifest abort-on-remount and the telemetry single-log behaviour under `<StrictMode>`. All affected suites pass (30 tests); format, oxlint, and types are green.

### Notes for release

N/A
