### PR TITLE
fix: handle `Calling require for "react"` error

### DIFF
--- a/packages/@repo/package.bundle/package.json
+++ b/packages/@repo/package.bundle/package.json
@@ -3,6 +3,7 @@
   "version": "5.30.0",
   "private": true,
   "description": "Shared package bundle configuration",
+  "type": "module",
   "main": "./src/package.bundle.ts",
   "types": "./src/package.bundle.ts",
   "scripts": {

--- a/packages/@repo/package.bundle/src/package.bundle.ts
+++ b/packages/@repo/package.bundle/src/package.bundle.ts
@@ -2,7 +2,7 @@ import babel from '@rolldown/plugin-babel'
 import {vanillaExtractPlugin} from '@vanilla-extract/vite-plugin'
 import viteReact, {reactCompilerPreset} from '@vitejs/plugin-react'
 import escapeRegExp from 'lodash-es/escapeRegExp.js'
-import {type Plugin, type UserConfig} from 'vite'
+import {esmExternalRequirePlugin, type Plugin, type UserConfig} from 'vite'
 
 import packageJson from '../package.json' with {type: 'json'}
 
@@ -19,15 +19,7 @@ export const defaultConfig: UserConfig = {
     babel({presets: [reactCompilerPreset({target: '19'})]}),
     vanillaExtractPlugin(),
     stripCssImportsPlugin(),
-  ],
-  build: {
-    emptyOutDir: true,
-    sourcemap: true,
-    lib: {
-      entry: {},
-      formats: ['es'],
-    },
-    rolldownOptions: {
+    esmExternalRequirePlugin({
       // self-externals are required here in order to ensure that the presentation
       // tool and future transitive dependencies that require sanity do not
       // re-include sanity in their bundle
@@ -38,7 +30,18 @@ export const defaultConfig: UserConfig = {
           new RegExp(`^${escapeRegExp(dependency)}\\/`),
         ],
       ),
+    }),
+  ],
+  build: {
+    emptyOutDir: true,
+    sourcemap: true,
+    lib: {
+      entry: {},
+      formats: ['es'],
+    },
+    rolldownOptions: {
       output: {
+        minify: true,
         exports: 'named',
         dir: 'dist',
         format: 'es',
@@ -49,6 +52,21 @@ export const defaultConfig: UserConfig = {
         // CSS assets get a predictable name so the module server can serve them at a known URL
         assetFileNames: (assetInfo) =>
           assetInfo.names?.some((n) => n.endsWith('.css')) ? 'index.css' : '[name]-[hash][extname]',
+      },
+      transform: {
+        // Same options as pkg-utils: https://github.com/sanity-io/pkg-utils/blob/f4e229e2641049008b375caf67576130be83fcdd/packages/%40sanity/pkg-utils/src/node/tasks/rollup/resolveRollupConfig.ts#L220-L227
+        plugins: {
+          styledComponents: {
+            // Unnecessary, as the way we use styled-components in Sanity is usually by wrapping `@sanity/ui` primitives, not declaring new ones like "const Button = styled.button``"
+            fileName: false,
+            // Native template literals take less space than this transpilation
+            transpileTemplateLiterals: false,
+            // Massively helps dead code elimination and tree-shaking
+            pure: true,
+            // disabled, as pkg-utils tends to be used for npm publishing, while other tooling, like `sanity dev`, `next dev`, etc are used for testing
+            cssProp: false,
+          },
+        },
       },
       treeshake: true,
     },


### PR DESCRIPTION
### Description

When testing on admin it turns out we need to use `esmExternalRequirePlugin` on `package.bundle.ts` as well ([we already do in the new CLI](https://github.com/search?q=repo%3Asanity-io%2Fcli%20esmExternalRequirePlugin&type=code)) to avoid seeing this error:
```
Uncaught error: Calling `require` for "react" in an environment that doesn't expose the `require` function. See https://rolldown.rs/in-depth/bundling-cjs#require-external-modules for more details.
https://modules.sanity-cdn.com/modules/v1/sanity/6.0.0-next-major.20260605135709/bare/chunk-jwUa06l-.mjs:20:8
Error: Calling `require` for "react" in an environment that doesn't expose the `require` function. See https://rolldown.rs/in-depth/bundling-cjs#require-external-modules for more details.
    at https://modules.sanity-cdn.com/modules/v1/sanity/6.0.0-next-major.20260605135709/bare/chunk-jwUa06l-.mjs:20:8
    at https://modules.sanity-cdn.com/modules/v1/sanity/6.0.0-next-major.20260605135709/bare/v4-DpqPFH3W.mjs:4520:12
    at https://modules.sanity-cdn.com/modules/v1/sanity/6.0.0-next-major.20260605135709/bare/chunk-jwUa06l-.mjs:2:257
    at https://modules.sanity-cdn.com/modules/v1/sanity/6.0.0-next-major.20260605135709/bare/v4-DpqPFH3W.mjs:4660:10
```

### What to review

I've also enabled `minify: true` as the chunk comes in at 4MB at the moment which is a lot even with gzip, and some styled components optimizations that match what we do for `sanity` when published to npm.

### Testing

Have to merge and wait for the module server to upload the new `next-major` and bump the admin studio test branch to fully verify we're in the green.

### Notes for release

N/A