### PR TITLE
fix: use v6 peer dep for `sanity` in `@sanity/vision`

### DIFF
--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -114,7 +114,7 @@
   },
   "peerDependencies": {
     "react": "^19.2.2",
-    "sanity": "^4.0.0-0 || ^5.0.0-0",
+    "sanity": "^6.0.0-0",
     "styled-components": "^6.1.15"
   },
   "browserslist": [


### PR DESCRIPTION
### Description

Fixes peer dep warnings like:
```
studio
└─┬ @sanity/vision 6.0.0-next-major.20260608114200
  └── ✕ unmet peer sanity@"^4.0.0-0 || ^5.0.0-0": found 6.0.0-next-major.20260608114200
```

### What to review

Couldn't find any other problematic peer dep issues, this should be it

### Testing

Have to test in userland.

### Notes for release

N/A - it only affects projects testing the prerelease
