### PR TITLE
fix(core): retain last known org id when project fetch fails

### DIFF
--- a/packages/sanity/src/core/store/project/projectStore.test.ts
+++ b/packages/sanity/src/core/store/project/projectStore.test.ts
@@ -1,0 +1,99 @@
+import {type SanityClient} from '@sanity/client'
+import {defer, of, throwError} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createProjectStore} from './projectStore'
+import {type ProjectData} from './types'
+
+const REFETCH_INTERVAL = 5 * 60 * 1000
+
+const createMockProjectData = (organizationId: string): ProjectData =>
+  ({
+    id: 'test-project',
+    organizationId,
+    organization: {id: organizationId, name: `org-${organizationId}`},
+  }) as unknown as ProjectData
+
+interface MockClientOptions {
+  projectId: string
+  requestImplementation: () => ReturnType<SanityClient['observable']['request']>
+}
+
+const createMockClient = ({projectId, requestImplementation}: MockClientOptions) => {
+  const client = {
+    config: () => ({projectId, dataset: 'test-dataset'}),
+    withConfig: () => client,
+    observable: {
+      request: vi.fn(requestImplementation),
+    },
+  }
+
+  return client as unknown as SanityClient
+}
+
+describe('createProjectStore getOrganizationId', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('retains the last known organization id when a refetch fails transiently', async () => {
+    let callCount = 0
+
+    // Each unique projectId gets its own memoized stream, so transient state
+    // does not leak between tests.
+    const client = createMockClient({
+      projectId: 'transient-failure-project',
+      requestImplementation: () =>
+        defer(() => {
+          callCount += 1
+          // First fetch succeeds, the refetch fails, the next refetch succeeds.
+          if (callCount === 2) {
+            return throwError(() => new Error('transient network failure'))
+          }
+          return of(createMockProjectData(callCount === 1 ? 'org-a' : 'org-b'))
+        }),
+    })
+
+    const store = createProjectStore({client})
+
+    const emitted: Array<string | null> = []
+    const subscription = store.getOrganizationId().subscribe((value) => emitted.push(value))
+
+    // First successful fetch.
+    await vi.advanceTimersByTimeAsync(0)
+    expect(emitted.at(-1)).toBe('org-a')
+
+    // Refetch fails: the stream must retain the previously-good org id rather
+    // than clobbering it with null.
+    await vi.advanceTimersByTimeAsync(REFETCH_INTERVAL)
+    expect(emitted).not.toContain(null)
+    expect(emitted.at(-1)).toBe('org-a')
+
+    // Next refetch succeeds with a new value.
+    await vi.advanceTimersByTimeAsync(REFETCH_INTERVAL)
+    expect(emitted.at(-1)).toBe('org-b')
+
+    subscription.unsubscribe()
+  })
+
+  it('emits null only when no organization id has ever been resolved', async () => {
+    const client = createMockClient({
+      projectId: 'always-failing-project',
+      requestImplementation: () => throwError(() => new Error('persistent failure')),
+    })
+
+    const store = createProjectStore({client})
+
+    const emitted: Array<string | null> = []
+    const subscription = store.getOrganizationId().subscribe((value) => emitted.push(value))
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(emitted).toEqual([null])
+
+    subscription.unsubscribe()
+  })
+})

--- a/packages/sanity/src/core/store/project/projectStore.ts
+++ b/packages/sanity/src/core/store/project/projectStore.ts
@@ -1,11 +1,13 @@
 import {type SanityClient} from '@sanity/client'
 import {
   catchError,
+  distinctUntilChanged,
   map,
   type Observable,
   of,
   repeat,
   ReplaySubject,
+  scan,
   share,
   shareReplay,
   timer,
@@ -37,6 +39,12 @@ const getProjectOrg = memoize(
           return of(null)
         }),
         repeat({delay: REFETCH_INTERVAL}),
+        // A transient refetch failure emits `null`. Retain the last known
+        // project data so a failed refetch does not clobber a previously-good
+        // organization id (which would strip org_id from telemetry events
+        // flushed during the refetch window). See SAPP-3824.
+        scan<ProjectData | null, ProjectData | null>((lastKnown, next) => next ?? lastKnown, null),
+        distinctUntilChanged(),
         share({
           connector: () => new ReplaySubject(1),
           resetOnComplete: true,


### PR DESCRIPTION
### Description

Studio events do not carry `org_id` themselves; it is stamped onto the whole batch at flush time from a context populated by an async `GET /projects/:id?includeOrganization=true`. In `projectStore.ts`, `getProjectOrg` wrapped that request as `catchError(() => of(null))` inside `repeat({delay: REFETCH_INTERVAL})` (5 minutes). A single transient fetch failure therefore emitted `null`, which overwrote a previously-good organization id and held it null across the entire refetch window - permanently stripping `org_id` from any event flushed during that window.

This change makes `getProjectOrg` retain the last known non-null project data. After `repeat`, the stream is fed through a `scan` that keeps the last good value (`(lastKnown, next) => next ?? lastKnown`) followed by `distinctUntilChanged`, so a failed refetch no longer clobbers good state with `null`. `null` is only ever emitted when no organization id has been resolved yet (genuine first-fetch failure).

This is one of two PRs addressing SAPP-3824. This PR fixes the transient-failure null overwrite; a companion PR addresses first-flush hydration timing. References SAPP-3824.

### What to review

- `packages/sanity/src/core/store/project/projectStore.ts` - the `scan` + `distinctUntilChanged` retention of the last known org data after `repeat`.
- Confirm the change is scoped to org-id retention and does not touch flush timing or the telemetry provider (the companion PR's concern).

### Testing

Added `projectStore.test.ts` covering two cases: a transient refetch failure retains the previously-good org id (never emits `null` mid-stream and recovers to the new value on the next successful refetch), and a persistent failure with no prior good value emits `null`. Run with `pnpm vitest run --project=sanity packages/sanity/src/core/store/project/projectStore.test.ts`.

### Notes for release

N/A
