### PR TITLE
refactor(telemetry): rename camelcase document pane events to title case

### DIFF
--- a/packages/sanity/src/structure/panes/document/__telemetry__/documentPanes.telemetry.ts
+++ b/packages/sanity/src/structure/panes/document/__telemetry__/documentPanes.telemetry.ts
@@ -4,7 +4,7 @@ import {defineEvent} from '@sanity/telemetry'
  * @internal
  */
 export const DocumentURLCopied = defineEvent({
-  name: 'DocumentURLCopied',
+  name: 'Document URL Copied',
   version: 1,
   description: 'User copied document URL to clipboard',
 })
@@ -13,7 +13,7 @@ export const DocumentURLCopied = defineEvent({
  * @internal
  */
 export const DocumentIDCopied = defineEvent({
-  name: 'DocumentIDCopied',
+  name: 'Document ID Copied',
   version: 1,
   description: 'User copied document ID to clipboard',
 })
@@ -22,7 +22,7 @@ export const DocumentIDCopied = defineEvent({
  * @internal
  */
 export const InlineChangesSwitchedOn = defineEvent({
-  name: 'InlineChangesSwitchedOn',
+  name: 'Inline Changes Switched On',
   version: 1,
   description: 'User switched on display of inline changes',
 })
@@ -31,7 +31,7 @@ export const InlineChangesSwitchedOn = defineEvent({
  * @internal
  */
 export const InlineChangesSwitchedOff = defineEvent({
-  name: 'InlineChangesSwitchedOff',
+  name: 'Inline Changes Switched Off',
   version: 1,
   description: 'User switched off display of inline changes',
 })

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
@@ -175,7 +175,7 @@ describe('CopyDocumentActions', () => {
       await clickMenuItem('copy-link-to-document')
 
       expect(mockTelemetryLog).toHaveBeenCalledWith(
-        expect.objectContaining({name: 'DocumentURLCopied'}),
+        expect.objectContaining({name: 'Document URL Copied'}),
       )
     })
   })
@@ -264,7 +264,7 @@ describe('CopyDocumentActions', () => {
       await clickMenuItem('copy-document-id')
 
       expect(mockTelemetryLog).toHaveBeenCalledWith(
-        expect.objectContaining({name: 'DocumentIDCopied'}),
+        expect.objectContaining({name: 'Document ID Copied'}),
       )
     })
   })


### PR DESCRIPTION
### Description

Renames four document-pane telemetry event `name` strings from camelCase to Title Case, per SAPP-3817. The exported JS identifiers (`DocumentURLCopied`, etc.) are unchanged - only the emitted event `name` values change.

- `DocumentURLCopied` -> `Document URL Copied`
- `DocumentIDCopied` -> `Document ID Copied`
- `InlineChangesSwitchedOn` -> `Inline Changes Switched On`
- `InlineChangesSwitchedOff` -> `Inline Changes Switched Off`

Resolves SAPP-3817.

### What to review

- Confirm only the `name:` literals changed in `documentPanes.telemetry.ts` and that the exported identifiers are untouched.
- Confirm the two updated assertions in `CopyDocumentActions.test.tsx` match the new Title Case names.
- Most importantly: confirm the downstream dbt/Looker migration is planned and sequenced (see warning above) before this is marked ready.

### Testing

`pnpm run test run CopyDocumentActions` - 13 passed. The two assertions covering the URL- and ID-copied events were updated to the new names and pass.

### Notes for release

N/A
