### PR TITLE
fix(core): delay first telemetry flush until org id hydrates

### DIFF
--- a/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
+++ b/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
@@ -31,6 +31,13 @@ const sessionId = createSessionId()
 /** Telemetry only runs on client */
 const isClient = typeof window !== 'undefined'
 
+/**
+ * Upper bound on how long the first batched flush is held back waiting for the
+ * organization id to hydrate. Events flush regardless once this elapses, so
+ * telemetry is never withheld indefinitely.
+ */
+const ORG_ID_HYDRATION_TIMEOUT_MS = 4000
+
 interface PluginWithNestedPlugins {
   plugins?: PluginWithNestedPlugins[]
 }
@@ -95,6 +102,25 @@ export function StudioTelemetryProvider(props: {children: ReactNode}) {
   // without causing re-memoization of the store
   const contextRef = useRef<TelemetryContext | null>(null)
 
+  // org_id is stamped onto every event at flush time from contextRef, but it
+  // resolves from an async fetch that starts null. Events that flush before it
+  // resolves ship org_id: null permanently. Gate the first batched flush until
+  // org_id hydrates, falling back to a bounded timeout so events are never
+  // withheld indefinitely. Once hydrated this gate is a no-op, leaving
+  // steady-state flushing identical to today.
+  const orgIdHydratedRef = useRef(false)
+  const hydrationDeadlineRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!isClient) return
+    // Anchor the bounded window on mount, so the gate measures elapsed time
+    // from when the provider first rendered.
+    if (hydrationDeadlineRef.current === null) {
+      hydrationDeadlineRef.current = performance.now() + ORG_ID_HYDRATION_TIMEOUT_MS
+    }
+    if (orgId) orgIdHydratedRef.current = true
+  }, [orgId])
+
   // Update context ref when dynamic values change
   // Telemetry only runs on client - no SSR fallbacks needed
   useEffect(() => {
@@ -152,6 +178,17 @@ export function StudioTelemetryProvider(props: {children: ReactNode}) {
       // Each event is enriched with the current context
       sendEvents: (batch) => {
         if (!isClient || !contextRef.current) return Promise.resolve()
+
+        // Hold the first flush back until org_id hydrates, but no longer than
+        // the bounded timeout. Rejecting re-buffers the batch in the store, so
+        // it retries on the next flush instead of shipping org_id: null.
+        const deadline = hydrationDeadlineRef.current
+        const withinHydrationWindow = deadline === null || performance.now() < deadline
+        const awaitingOrgId = !orgIdHydratedRef.current && withinHydrationWindow
+        if (awaitingOrgId) {
+          return Promise.reject(new Error('Awaiting org_id hydration before first telemetry flush'))
+        }
+
         const context = contextRef.current
         const enrichedBatch = batch.map((event) => ({
           ...event,

--- a/packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx
+++ b/packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx
@@ -321,6 +321,9 @@ describe('StudioTelemetryProvider', () => {
       value: null,
     } as never)
 
+    const nowSpy = vi.spyOn(performance, 'now')
+    nowSpy.mockReturnValue(0)
+
     render(
       <DeferredTelemetryProvider>
         <StudioTelemetryProvider>
@@ -328,6 +331,10 @@ describe('StudioTelemetryProvider', () => {
         </StudioTelemetryProvider>
       </DeferredTelemetryProvider>,
     )
+
+    // Advance past the bounded hydration window so the gate lets the (still
+    // null) orgId flush through.
+    nowSpy.mockReturnValue(10000)
 
     const testBatch = [{name: 'Test Event'}]
     await capturedStoreOptions.sendEvents!(testBatch)
@@ -345,6 +352,91 @@ describe('StudioTelemetryProvider', () => {
         }),
       }),
     )
+
+    nowSpy.mockRestore()
+  })
+
+  it('holds the first flush back while orgId is still hydrating', async () => {
+    vi.mocked(useProjectOrganizationId).mockReturnValue({
+      value: null,
+    } as never)
+
+    render(
+      <DeferredTelemetryProvider>
+        <StudioTelemetryProvider>
+          <div>Test Child</div>
+        </StudioTelemetryProvider>
+      </DeferredTelemetryProvider>,
+    )
+
+    const testBatch = [{name: 'Early Event'}]
+
+    // While orgId is null and within the bounded window, the flush is rejected
+    // so the store re-buffers and retries instead of shipping org_id: null.
+    await expect(capturedStoreOptions.sendEvents!(testBatch)).rejects.toThrow(/org_id/)
+    expect(mockClient.request).not.toHaveBeenCalled()
+  })
+
+  it('flushes once orgId has hydrated', async () => {
+    render(
+      <DeferredTelemetryProvider>
+        <StudioTelemetryProvider>
+          <div>Test Child</div>
+        </StudioTelemetryProvider>
+      </DeferredTelemetryProvider>,
+    )
+
+    const testBatch = [{name: 'Hydrated Event'}]
+    await capturedStoreOptions.sendEvents!(testBatch)
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          batch: expect.arrayContaining([
+            expect.objectContaining({
+              context: expect.objectContaining({orgId: 'org-123'}),
+            }),
+          ]),
+        }),
+      }),
+    )
+  })
+
+  it('flushes despite null orgId once the hydration timeout has elapsed', async () => {
+    vi.mocked(useProjectOrganizationId).mockReturnValue({
+      value: null,
+    } as never)
+
+    const nowSpy = vi.spyOn(performance, 'now')
+    nowSpy.mockReturnValue(0)
+
+    render(
+      <DeferredTelemetryProvider>
+        <StudioTelemetryProvider>
+          <div>Test Child</div>
+        </StudioTelemetryProvider>
+      </DeferredTelemetryProvider>,
+    )
+
+    // Advance past the bounded hydration window.
+    nowSpy.mockReturnValue(10000)
+
+    const testBatch = [{name: 'Late Event'}]
+    await capturedStoreOptions.sendEvents!(testBatch)
+
+    expect(mockClient.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          batch: expect.arrayContaining([
+            expect.objectContaining({
+              context: expect.objectContaining({orgId: null}),
+            }),
+          ]),
+        }),
+      }),
+    )
+
+    nowSpy.mockRestore()
   })
 
   it('includes screen dimensions in context', async () => {


### PR DESCRIPTION
### Description

Studio events ship with `org_id: null` for a meaningful slice of early-session traffic. `org_id` is stamped onto each batch at flush time in `StudioTelemetryProvider`, read from a `contextRef` that starts `null` and only fills in once an async organization fetch resolves. Any event that flushes before that fetch resolves - early-session actions, and the `visibilitychange` / `sendBeacon` page-hide flush - ships `org_id: null` permanently. Events that fire structurally later from inside provider effects (StudioLoaded, WorkspaceFeaturesObserved) almost always carry `org_id`, which is why coverage looks partial rather than absent.

This PR closes the early-session gap with a bounded hydration gate on the first batched flush. While `org_id` has not yet hydrated and we are still inside a short bounded window (4s, anchored on mount), `sendEvents` rejects. Rejection re-buffers the batch in the shared store via its existing catch-and-requeue path, so the events retry on the next flush instead of shipping `org_id: null`. Once `org_id` hydrates the gate is a no-op and steady-state flushing is identical to today. The timeout fallback guarantees events are never withheld indefinitely: once the window elapses, batches flush regardless of `org_id`.

The page-hide / beacon tail is intentionally left ungated - it must never be held, so events flushed at page-hide before hydration may still carry `org_id: null`. That truly-cannot-resolve tail is unavoidable; the goal here is the early-session gap, not the page-hide case.

This is one of two PRs for SAPP-3824. The companion PR fixes a separate root cause: a transient organization-fetch failure overwriting an already-resolved `org_id` with `null` in `projectStore`. The two fixes are independent and intentionally scoped to separate PRs.

Resolves part of SAPP-3824.

### What to review

The gate logic in `StudioTelemetryProvider.tsx`: the bounded window is anchored on mount in an effect (`hydrationDeadlineRef`), `orgIdHydratedRef` flips once `orgId` resolves, and `sendEvents` rejects only while awaiting hydration inside the window. Confirm the gate relies on the store's existing reject-then-requeue behaviour rather than any new store API, that `sendBeacon` is deliberately ungated, and that the bound (4s) is sensibly shorter than the 30s flush interval so it never adds steady-state delay.

### Testing

Added unit tests in `StudioTelemetryProvider.test.tsx` covering the three paths: the first flush is held (rejects, no request sent) while `org_id` is null and within the window; the flush proceeds normally once `org_id` has hydrated; and the flush proceeds with `org_id: null` once the bounded window has elapsed (timeout fallback). All 13 tests in the file pass.

### Notes for release

N/A
