### PR TITLE
fix(form): keep edit dialog open on cmd+up inside text editors

### DIFF
--- a/packages/sanity/src/core/form/components/EnhancedObjectDialog.test.tsx
+++ b/packages/sanity/src/core/form/components/EnhancedObjectDialog.test.tsx
@@ -1,0 +1,154 @@
+import {render} from '@testing-library/react'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {EnhancedObjectDialog} from './EnhancedObjectDialog'
+
+const close = vi.fn()
+const navigateTo = vi.fn()
+const log = vi.fn()
+
+let mockState: {isTop: boolean; stack: {id: string; path: (string | {_key: string})[]}[]}
+
+vi.mock('../../hooks/useDialogStack', () => ({
+  useDialogStack: () => ({
+    dialogId: 'dialog-1',
+    topEntry: mockState.stack[mockState.stack.length - 1] ?? null,
+    stack: mockState.stack,
+    isTop: mockState.isTop,
+    close,
+    navigateTo,
+  }),
+}))
+
+vi.mock('../useFormBuilder', () => ({
+  useFormBuilder: () => ({__internal: {inspectOpen: false}}),
+}))
+
+vi.mock('@sanity/telemetry/react', () => ({
+  useTelemetry: () => ({log}),
+}))
+
+// Keep the real useGlobalKeyDown (it registers the window keydown listener under
+// test) but render Box as a plain div so we don't need a full Sanity theme context.
+vi.mock('@sanity/ui', async (importActual) => ({
+  ...(await importActual<typeof import('@sanity/ui')>()),
+  Box: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
+}))
+
+// Render the dialog chrome as plain pass-throughs so the test stays focused on the
+// global keydown handler (no theme/portal/presence setup required). Partial mocks
+// preserve the other real exports (e.g. Button used by DialogBreadcrumbs).
+vi.mock('../../../ui-components', async (importActual) => ({
+  ...(await importActual<typeof import('../../../ui-components')>()),
+  Dialog: ({children}: {children: React.ReactNode}) => <div data-testid="dialog">{children}</div>,
+}))
+vi.mock('../../components', async (importActual) => ({
+  ...(await importActual<typeof import('../../components')>()),
+  PopoverDialog: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
+}))
+vi.mock('../../presence', async (importActual) => ({
+  ...(await importActual<typeof import('../../presence')>()),
+  PresenceOverlay: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
+}))
+
+function renderDialog() {
+  return render(
+    <EnhancedObjectDialog type="dialog" header="Header" width={1}>
+      <div />
+    </EnhancedObjectDialog>,
+  )
+}
+
+function dispatchKeyDown(
+  target: Element,
+  init: KeyboardEventInit,
+): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {bubbles: true, cancelable: true, ...init})
+  target.dispatchEvent(event)
+  return event
+}
+
+describe('EnhancedObjectDialog: Cmd/Ctrl+ArrowUp handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Stack depth >= 2 so the navigate-up / close branch is reachable.
+    mockState = {isTop: true, stack: [{id: 'dialog-1', path: ['arr', {_key: 'k'}]}]}
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('ignores the shortcut when focus is inside an <input> (SAPP-3704)', () => {
+    renderDialog()
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+
+    const event = dispatchKeyDown(input, {key: 'ArrowUp', metaKey: true})
+
+    expect(close).not.toHaveBeenCalled()
+    expect(navigateTo).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('ignores the shortcut when focus is inside a <textarea>', () => {
+    renderDialog()
+    const textarea = document.createElement('textarea')
+    document.body.appendChild(textarea)
+
+    const event = dispatchKeyDown(textarea, {key: 'ArrowUp', metaKey: true})
+
+    expect(close).not.toHaveBeenCalled()
+    expect(navigateTo).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('ignores the shortcut when focus is inside a contentEditable element (code/PTE editor)', () => {
+    renderDialog()
+    const editable = document.createElement('div')
+    editable.setAttribute('contenteditable', 'true')
+    // jsdom does not always derive isContentEditable from the attribute, so set it explicitly.
+    Object.defineProperty(editable, 'isContentEditable', {configurable: true, value: true})
+    document.body.appendChild(editable)
+
+    const event = dispatchKeyDown(editable, {key: 'ArrowUp', metaKey: true})
+
+    expect(close).not.toHaveBeenCalled()
+    expect(navigateTo).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('handles the shortcut when focus is on a non-editable element', () => {
+    renderDialog()
+    const button = document.createElement('button')
+    document.body.appendChild(button)
+
+    const event = dispatchKeyDown(button, {key: 'ArrowUp', metaKey: true})
+
+    // stack depth 2 -> parent path length 1 -> close()
+    expect(close).toHaveBeenCalledTimes(1)
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('handles ctrl+ArrowUp on a non-editable element too', () => {
+    renderDialog()
+    const button = document.createElement('button')
+    document.body.appendChild(button)
+
+    dispatchKeyDown(button, {key: 'ArrowUp', ctrlKey: true})
+
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when the dialog is not the top dialog', () => {
+    mockState = {isTop: false, stack: [{id: 'dialog-1', path: ['arr', {_key: 'k'}]}]}
+    renderDialog()
+    const button = document.createElement('button')
+    document.body.appendChild(button)
+
+    dispatchKeyDown(button, {key: 'ArrowUp', metaKey: true})
+
+    expect(close).not.toHaveBeenCalled()
+    expect(navigateTo).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sanity/src/core/form/components/EnhancedObjectDialog.test.tsx
+++ b/packages/sanity/src/core/form/components/EnhancedObjectDialog.test.tsx
@@ -77,7 +77,7 @@ describe('EnhancedObjectDialog: Cmd/Ctrl+ArrowUp handler', () => {
     document.body.innerHTML = ''
   })
 
-  it('ignores the shortcut when focus is inside an <input> (SAPP-3704)', () => {
+  it('ignores the shortcut when focus is inside an <input>', () => {
     renderDialog()
     const input = document.createElement('input')
     document.body.appendChild(input)

--- a/packages/sanity/src/core/form/components/EnhancedObjectDialog.test.tsx
+++ b/packages/sanity/src/core/form/components/EnhancedObjectDialog.test.tsx
@@ -31,7 +31,7 @@ vi.mock('@sanity/telemetry/react', () => ({
 // Keep the real useGlobalKeyDown (it registers the window keydown listener under
 // test) but render Box as a plain div so we don't need a full Sanity theme context.
 vi.mock('@sanity/ui', async (importActual) => ({
-  ...(await importActual<typeof import('@sanity/ui')>()),
+  ...((await importActual()) as Record<string, unknown>),
   Box: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
 }))
 
@@ -39,15 +39,15 @@ vi.mock('@sanity/ui', async (importActual) => ({
 // global keydown handler (no theme/portal/presence setup required). Partial mocks
 // preserve the other real exports (e.g. Button used by DialogBreadcrumbs).
 vi.mock('../../../ui-components', async (importActual) => ({
-  ...(await importActual<typeof import('../../../ui-components')>()),
+  ...((await importActual()) as Record<string, unknown>),
   Dialog: ({children}: {children: React.ReactNode}) => <div data-testid="dialog">{children}</div>,
 }))
 vi.mock('../../components', async (importActual) => ({
-  ...(await importActual<typeof import('../../components')>()),
+  ...((await importActual()) as Record<string, unknown>),
   PopoverDialog: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
 }))
 vi.mock('../../presence', async (importActual) => ({
-  ...(await importActual<typeof import('../../presence')>()),
+  ...((await importActual()) as Record<string, unknown>),
   PresenceOverlay: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
 }))
 
@@ -59,10 +59,7 @@ function renderDialog() {
   )
 }
 
-function dispatchKeyDown(
-  target: Element,
-  init: KeyboardEventInit,
-): KeyboardEvent {
+function dispatchKeyDown(target: Element, init: KeyboardEventInit): KeyboardEvent {
   const event = new KeyboardEvent('keydown', {bubbles: true, cancelable: true, ...init})
   target.dispatchEvent(event)
   return event

--- a/packages/sanity/src/core/form/components/EnhancedObjectDialog.test.tsx
+++ b/packages/sanity/src/core/form/components/EnhancedObjectDialog.test.tsx
@@ -68,7 +68,8 @@ function dispatchKeyDown(target: Element, init: KeyboardEventInit): KeyboardEven
 describe('EnhancedObjectDialog: Cmd/Ctrl+ArrowUp handler', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // Stack depth >= 2 so the navigate-up / close branch is reachable.
+    // The top stack entry's path length must be > 1 for the navigate-up / close
+    // branch to be reachable (the handler checks `lastStackPath.length > 1`).
     mockState = {isTop: true, stack: [{id: 'dialog-1', path: ['arr', {_key: 'k'}]}]}
   })
 
@@ -122,7 +123,7 @@ describe('EnhancedObjectDialog: Cmd/Ctrl+ArrowUp handler', () => {
 
     const event = dispatchKeyDown(button, {key: 'ArrowUp', metaKey: true})
 
-    // stack depth 2 -> parent path length 1 -> close()
+    // path length 2 -> parent path length 1 -> close()
     expect(close).toHaveBeenCalledTimes(1)
     expect(event.defaultPrevented).toBe(true)
   })

--- a/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
+++ b/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
@@ -9,6 +9,7 @@ import {PopoverDialog} from '../../components'
 import {pathToString} from '../../field/paths/helpers'
 import {useDialogStack} from '../../hooks/useDialogStack'
 import {PresenceOverlay} from '../../presence'
+import {isNativeEditableElement} from '../../studio/copyPaste/utils'
 import {VirtualizerScrollInstanceProvider} from '../inputs/arrays/ArrayOfObjectsInput/List/VirtualizerScrollInstanceProvider'
 import {
   NavigatedToNestedObjectViaCloseButton,
@@ -130,6 +131,13 @@ export function EnhancedObjectDialog(props: PopoverProps | DialogProps): React.J
 
   const handleGlobalKeyDown = useCallback(
     (event: KeyboardEvent) => {
+      // Ignore the shortcut while the user is editing text (e.g. inside a code
+      // block editor, the Portable Text editor, an input or a textarea), where
+      // Cmd/Ctrl+ArrowUp has its own meaning (move the caret to the top).
+      if (event.target && isNativeEditableElement(event.target)) {
+        return
+      }
+
       // Only the top dialog should respond to the keyboard shortcut
       if (isTop && (event.metaKey || event.ctrlKey) && event.key === 'ArrowUp') {
         event.preventDefault()


### PR DESCRIPTION
## Description

`Cmd/Ctrl+ArrowUp` inside a code block (CodeMirror, via `@sanity/code-input`), the Portable Text editor, or any `<input>`/`<textarea>` closed the surrounding edit dialog instead of letting the editor move the caret to the top. Fixes [SAPP-3704](https://linear.app/sanity/issue/SAPP-3704).

**Root cause:** `EnhancedObjectDialog` (used for array-item / nested-object editing, and for PTE block objects via `ObjectEditModal`) registers a global `window` keydown handler for its "navigate up the nested-object stack / close" shortcut (`Cmd/Ctrl+ArrowUp`). The handler didn't inspect the event target, so it fired even when the keystroke originated inside a child editor. CodeMirror binds `Mod-ArrowUp` to `cursorDocStart` and calls `preventDefault` but not `stopPropagation`, so the event bubbled up to `window` and the dialog closed.

**Fix:** bail out of the handler when the event originates from a native-editable element (`isNativeEditableElement`), matching the existing pattern in `useGlobalCopyPasteElementHandler`. The shortcut still works when focus is on non-editable dialog chrome.

## What to review

- `EnhancedObjectDialog.tsx` — the early-return guard at the top of `handleGlobalKeyDown`.
- `EnhancedObjectDialog.test.tsx` — new regression test.

## Testing

- **New unit test (6 cases):** editable targets (`input` / `textarea` / `contentEditable`) → handler is a no-op and `preventDefault` is not called; non-editable target → shortcut still navigates/closes; `ctrl` variant; non-top dialog is a no-op. Fails without the guard, passes with it.
- **Verified in the dev studio** (array-of-objects item dialog): with the guard, `Cmd+Up` from a field inside the dialog leaves it open (`defaultPrevented: false`, dialog stays). Temporarily reverting the guard reproduced the bug (`defaultPrevented: true`, dialog navigates away/closes).
- `pnpm --filter sanity check:types` clean.

## Notes for release

Fixed a bug where pressing `Cmd/Ctrl+ArrowUp` while editing a code block or text field inside an object or array edit dialog would close the dialog instead of moving the cursor to the top.