### PR TITLE
fix(form): apply default width to annotation edit popover when modal has no width

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/helpers.test.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/helpers.test.ts
@@ -1,0 +1,38 @@
+import {type ObjectSchemaType} from '@sanity/types'
+import {describe, expect, it} from 'vitest'
+
+import {_getModalOption} from './helpers'
+
+const withModal = (modal: unknown): ObjectSchemaType =>
+  ({options: {modal}}) as unknown as ObjectSchemaType
+
+describe('_getModalOption', () => {
+  it('returns undefined when no modal option is set', () => {
+    expect(_getModalOption({} as ObjectSchemaType)).toBeUndefined()
+    expect(_getModalOption({options: {}} as unknown as ObjectSchemaType)).toBeUndefined()
+  })
+
+  it('returns an undefined width (not an empty array) when modal is set without a width', () => {
+    // Regression test for the narrow annotation popover: an empty array here would
+    // bypass the edit dialog width defaults and collapse the popover to auto width.
+    const result = _getModalOption(withModal({type: 'popover'}))
+    expect(result?.type).toBe('popover')
+    expect(result?.width).toBeUndefined()
+  })
+
+  it('parses an explicit numeric width', () => {
+    expect(_getModalOption(withModal({type: 'popover', width: 1}))?.width).toEqual([1])
+  })
+
+  it('parses a responsive width array', () => {
+    expect(_getModalOption(withModal({type: 'dialog', width: [0, 1, 2]}))?.width).toEqual([0, 1, 2])
+  })
+
+  it("parses an 'auto' width", () => {
+    expect(_getModalOption(withModal({width: 'auto'}))?.width).toEqual(['auto'])
+  })
+
+  it('ignores an invalid modal type', () => {
+    expect(_getModalOption(withModal({type: 'sidebar'}))?.type).toBeUndefined()
+  })
+})

--- a/packages/sanity/src/core/form/inputs/PortableText/object/helpers.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/helpers.ts
@@ -15,12 +15,19 @@ const parseModalType = (value: unknown): 'popover' | 'dialog' | undefined => {
 
 export function _getModalOption(
   schemaType: ObjectSchemaType,
-): {type?: 'dialog' | 'popover'; width: (number | 'auto')[]} | undefined {
+): {type?: 'dialog' | 'popover'; width?: (number | 'auto')[]} | undefined {
   const raw = schemaType.options?.modal
-  return typeof raw === 'object' && raw !== null
-    ? {
-        type: parseModalType(raw.type),
-        width: parseResponsiveWidth(raw.width),
-      }
-    : undefined
+  if (typeof raw !== 'object' || raw === null) {
+    return undefined
+  }
+  const width = parseResponsiveWidth(raw.width)
+  return {
+    type: parseModalType(raw.type),
+    // Return `undefined` (not an empty array) when no width is configured, so the
+    // edit modal components fall back to their own width defaults (popover 960px /
+    // dialog 640px). An empty array is "defined" and would otherwise collapse the
+    // popover to content/auto width — making e.g. a reference field inside an
+    // annotation render uselessly narrow.
+    width: width.length > 0 ? width : undefined,
+  }
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/ObjectEditModal.tsx
@@ -45,7 +45,10 @@ export function ObjectEditModal(props: {
     onClose()
   }, [onClose])
 
-  const modalWidth = schemaModalOption?.width
+  // Treat an empty width array as "unset" so the edit dialog components apply
+  // their own width defaults instead of collapsing to content/auto width.
+  const rawModalWidth = schemaModalOption?.width
+  const modalWidth = rawModalWidth && rawModalWidth.length > 0 ? rawModalWidth : undefined
 
   if (modalType === 'popover') {
     return (


### PR DESCRIPTION
## Description

A Portable Text annotation/object type that sets `options.modal` as an object **without** a `width` (e.g. `{modal: {type: 'popover'}}` — common for link/internal-link annotations) rendered its edit popover at collapsed content/auto width. A reference field inside such an annotation became unusable: its autocomplete results (which match the reference width) were truncated. Fixes [SAPP-3617](https://linear.app/sanity/issue/SAPP-3617).

**Root cause:** `_getModalOption()` returned `width: []` (an empty array) for the unspecified-width case. `[]` is *defined*, so it bypassed the edit-dialog width defaults (popover `2` = 960px / dialog `1` = 640px), and Sanity UI resolved no container width → auto/content width. Annotations with an explicit `width`, or with no `options.modal` at all, were unaffected — which is why the bug was config-dependent (only `modal` object present + `width` absent triggered it).

**Fix:** `_getModalOption` now returns `width: undefined` when no width is configured, so the component defaults apply. `ObjectEditModal` also treats an empty width array as unset (defense-in-depth). This also fixes block and inline objects configured the same way (they share `ObjectEditModal`).

## What to review

- `helpers.ts` — `_getModalOption` returns `undefined` (not `[]`) when no width is set; return type made optional (`width?`).
- `ObjectEditModal.tsx` — empty width array treated as `undefined`.
- `helpers.test.ts` — new unit tests.

## Testing

- **New unit test for `_getModalOption`** (6 cases): no modal → `undefined`; modal without width → `width: undefined` (the regression case — **fails before the fix**, where it was `[]`); explicit numeric / responsive-array / `'auto'` widths parsed; invalid modal type ignored.
- `pnpm --filter sanity check:types` clean; existing PortableText tests pass.
- **Manual QA:** in the dev studio, an annotation type with a reference field and `options:{modal:{type:'popover'}}` (no width) now opens at the default 960px with full-width reference results; types with an explicit `width` or no `modal` option are unchanged.

> Verification note: the visible effect is the annotation edit popover rendering at its default width. Reproducing it live requires applying an annotation inside the Slate-based PTE (not practical to automate reliably), so this is covered by the unit test (which fails without the fix) plus the traced root cause rather than an automated screenshot.

## Notes for release

Fixed Portable Text annotation/object edit popovers (e.g. link annotations containing a reference field) rendering too narrow when the type set `options.modal` without a `width` — they now use the default width, so embedded reference fields and their autocomplete results are usable.