### PR TITLE
feat(presentation): add tab bar to switch panes at narrow viewports

### DIFF
--- a/packages/sanity/src/presentation/PresentationContent.tsx
+++ b/packages/sanity/src/presentation/PresentationContent.tsx
@@ -25,13 +25,13 @@ export interface PresentationContentProps {
   documentsOnPage: {_id: string; _type: string}[]
   documentType: PresentationParamsContextValue['type']
   getCommentIntent: CommentIntentGetter
-  /** Removes the document panel from the layout (narrow mode, when another tab is active). */
+  /** Hide the document panel (narrow mode, another tab active). */
   hidden?: boolean
   mainDocumentState: MainDocumentState | undefined
   onEditReference: PresentationNavigate
   onFocusPath: (state: Required<PresentationStateParams>) => void
   onStructureParams: (params: StructureDocumentPaneParams) => void
-  /** Hides the preceding resizer (narrow mode, where panels never sit side-by-side). */
+  /** Hide the preceding resizer (narrow mode). */
   resizerHidden?: boolean
   searchParams: PresentationSearchParams
   setDisplayedDocument: Dispatch<SetStateAction<Partial<SanityDocument> | null | undefined>>

--- a/packages/sanity/src/presentation/PresentationContent.tsx
+++ b/packages/sanity/src/presentation/PresentationContent.tsx
@@ -10,6 +10,7 @@ import {ContentEditor} from './editor/ContentEditor'
 import {DisplayedDocumentBroadcasterProvider} from './loader/DisplayedDocumentBroadcaster'
 import {Panel} from './panels/Panel'
 import {PanelResizer} from './panels/PanelResizer'
+import {getPresentationPanelHtmlId} from './panels/PresentationNarrowTabBar'
 import {
   type MainDocumentState,
   type PresentationNavigate,
@@ -24,10 +25,14 @@ export interface PresentationContentProps {
   documentsOnPage: {_id: string; _type: string}[]
   documentType: PresentationParamsContextValue['type']
   getCommentIntent: CommentIntentGetter
+  /** Removes the document panel from the layout (narrow mode, when another tab is active). */
+  hidden?: boolean
   mainDocumentState: MainDocumentState | undefined
   onEditReference: PresentationNavigate
   onFocusPath: (state: Required<PresentationStateParams>) => void
   onStructureParams: (params: StructureDocumentPaneParams) => void
+  /** Hides the preceding resizer (narrow mode, where panels never sit side-by-side). */
+  resizerHidden?: boolean
   searchParams: PresentationSearchParams
   setDisplayedDocument: Dispatch<SetStateAction<Partial<SanityDocument> | null | undefined>>
   structureParams: StructureDocumentPaneParams
@@ -37,14 +42,22 @@ const PresentationContentWrapper: FunctionComponent<
   PropsWithChildren<{
     documentId?: string
     getCommentIntent: CommentIntentGetter
+    hidden?: boolean
+    resizerHidden?: boolean
     setDisplayedDocument: Dispatch<SetStateAction<Partial<SanityDocument> | null | undefined>>
   }>
 > = (props) => {
-  const {documentId, setDisplayedDocument, getCommentIntent} = props
+  const {documentId, hidden, resizerHidden, setDisplayedDocument, getCommentIntent} = props
   return (
     <>
-      <PanelResizer order={4} />
-      <Panel id="content" minWidth={325} order={5}>
+      <PanelResizer order={4} hidden={resizerHidden} />
+      <Panel
+        id="content"
+        htmlId={getPresentationPanelHtmlId('content')}
+        minWidth={325}
+        order={5}
+        hidden={hidden}
+      >
         <DisplayedDocumentBroadcasterProvider
           documentId={documentId}
           setDisplayedDocument={setDisplayedDocument}
@@ -64,10 +77,12 @@ export const PresentationContent: FunctionComponent<PresentationContentProps> = 
     documentsOnPage,
     documentType,
     getCommentIntent,
+    hidden,
     mainDocumentState,
     onEditReference,
     onFocusPath,
     onStructureParams,
+    resizerHidden,
     searchParams,
     setDisplayedDocument,
     structureParams,
@@ -77,6 +92,8 @@ export const PresentationContent: FunctionComponent<PresentationContentProps> = 
     <PresentationContentWrapper
       documentId={documentId}
       getCommentIntent={getCommentIntent}
+      hidden={hidden}
+      resizerHidden={resizerHidden}
       setDisplayedDocument={setDisplayedDocument}
     >
       <ContentEditor

--- a/packages/sanity/src/presentation/PresentationContent.tsx
+++ b/packages/sanity/src/presentation/PresentationContent.tsx
@@ -10,7 +10,7 @@ import {ContentEditor} from './editor/ContentEditor'
 import {DisplayedDocumentBroadcasterProvider} from './loader/DisplayedDocumentBroadcaster'
 import {Panel} from './panels/Panel'
 import {PanelResizer} from './panels/PanelResizer'
-import {getPresentationPanelHtmlId} from './panels/PresentationNarrowTabBar'
+import {getPresentationPanelHtmlId} from './panels/presentationLayoutTab'
 import {
   type MainDocumentState,
   type PresentationNavigate,

--- a/packages/sanity/src/presentation/PresentationNavigator.tsx
+++ b/packages/sanity/src/presentation/PresentationNavigator.tsx
@@ -19,9 +19,9 @@ export interface UsePresentationNavigatorState {
 
 /** @internal */
 export interface PresentationNavigatorProps {
-  /** Removes the navigator panel from the layout (narrow mode, when another tab is active). */
+  /** Hide the navigator panel (narrow mode, another tab active). */
   hidden?: boolean
-  /** Hides the navigator's resizer (narrow mode, where panels never sit side-by-side). */
+  /** Hide the navigator's resizer (narrow mode). */
   resizerHidden?: boolean
 }
 

--- a/packages/sanity/src/presentation/PresentationNavigator.tsx
+++ b/packages/sanity/src/presentation/PresentationNavigator.tsx
@@ -2,6 +2,7 @@ import {memo, useCallback, useMemo} from 'react'
 
 import {Panel} from './panels/Panel'
 import {PanelResizer} from './panels/PanelResizer'
+import {getPresentationPanelHtmlId} from './panels/PresentationNarrowTabBar'
 import {type NavigatorOptions} from './types'
 import {useLocalState} from './useLocalState'
 
@@ -17,9 +18,17 @@ export interface UsePresentationNavigatorState {
 }
 
 /** @internal */
+export interface PresentationNavigatorProps {
+  /** Removes the navigator panel from the layout (narrow mode, when another tab is active). */
+  hidden?: boolean
+  /** Hides the navigator's resizer (narrow mode, where panels never sit side-by-side). */
+  resizerHidden?: boolean
+}
+
+/** @internal */
 export function usePresentationNavigator(
   props: UsePresentationNavigatorProps,
-): [UsePresentationNavigatorState, () => React.JSX.Element] {
+): [UsePresentationNavigatorState, (props: PresentationNavigatorProps) => React.JSX.Element] {
   const {unstable_navigator} = props
 
   const navigatorProvided = !!unstable_navigator?.component
@@ -35,8 +44,8 @@ export function usePresentationNavigator(
   }, [navigatorProvided, setNavigatorEnabled])
 
   const Component = useCallback(
-    function PresentationNavigator() {
-      return <>{navigatorEnabled && <Navigator {...unstable_navigator!} />}</>
+    function PresentationNavigator(componentProps: PresentationNavigatorProps) {
+      return <>{navigatorEnabled && <Navigator {...unstable_navigator!} {...componentProps} />}</>
     },
     [navigatorEnabled, unstable_navigator],
   )
@@ -44,16 +53,23 @@ export function usePresentationNavigator(
   return [{navigatorEnabled, toggleNavigator}, Component]
 }
 
-function NavigatorComponent(props: NavigatorOptions) {
-  const {minWidth, maxWidth, component: NavigatorComponent} = props
+function NavigatorComponent(props: NavigatorOptions & PresentationNavigatorProps) {
+  const {minWidth, maxWidth, component: NavigatorComponent, hidden, resizerHidden} = props
   // eslint-disable-next-line no-eq-null
   const navigatorDisabled = minWidth != null && maxWidth != null && minWidth === maxWidth
   return (
     <>
-      <Panel id="navigator" minWidth={minWidth} maxWidth={maxWidth} order={1}>
+      <Panel
+        id="navigator"
+        htmlId={getPresentationPanelHtmlId('navigator')}
+        minWidth={minWidth}
+        maxWidth={maxWidth}
+        order={1}
+        hidden={hidden}
+      >
         <NavigatorComponent />
       </Panel>
-      <PanelResizer order={2} disabled={navigatorDisabled} />
+      <PanelResizer order={2} disabled={navigatorDisabled} hidden={resizerHidden} />
     </>
   )
 }

--- a/packages/sanity/src/presentation/PresentationNavigator.tsx
+++ b/packages/sanity/src/presentation/PresentationNavigator.tsx
@@ -2,7 +2,7 @@ import {memo, useCallback, useMemo} from 'react'
 
 import {Panel} from './panels/Panel'
 import {PanelResizer} from './panels/PanelResizer'
-import {getPresentationPanelHtmlId} from './panels/PresentationNarrowTabBar'
+import {getPresentationPanelHtmlId} from './panels/presentationLayoutTab'
 import {type NavigatorOptions} from './types'
 import {useLocalState} from './useLocalState'
 

--- a/packages/sanity/src/presentation/PresentationTool.tsx
+++ b/packages/sanity/src/presentation/PresentationTool.tsx
@@ -49,8 +49,8 @@ import {Panels} from './panels/Panels'
 import {
   getPresentationPanelHtmlId,
   type PresentationLayoutTab,
-  PresentationNarrowTabBar,
-} from './panels/PresentationNarrowTabBar'
+} from './panels/presentationLayoutTab'
+import {PresentationNarrowTabBar} from './panels/PresentationNarrowTabBar'
 import {PresentationContent} from './PresentationContent'
 import {PresentationNavigateProvider} from './PresentationNavigateProvider'
 import {usePresentationNavigator} from './PresentationNavigator'

--- a/packages/sanity/src/presentation/PresentationTool.tsx
+++ b/packages/sanity/src/presentation/PresentationTool.tsx
@@ -88,6 +88,17 @@ const Container = styled(Flex)`
   overflow-x: auto;
 `
 
+// The navigator tab only exists while the navigator is enabled. If it was the
+// selected tab when the navigator got toggled off, show the preview instead.
+function resolveActiveTab(
+  activeTab: PresentationLayoutTab,
+  navigatorEnabled: boolean,
+): PresentationLayoutTab {
+  if (activeTab === 'navigator' && navigatorEnabled) return 'navigator'
+  if (activeTab === 'navigator') return 'preview'
+  return activeTab
+}
+
 export default function PresentationTool(props: {
   tool: Tool<PresentationPluginOptions>
   canToggleSharePreviewAccess: boolean
@@ -476,10 +487,7 @@ export default function PresentationTool(props: {
   const isNarrow = mediaIndex <= NARROW_MEDIA_INDEX
 
   const [activeTab, setActiveTab] = useState<PresentationLayoutTab>('preview')
-  // The navigator tab only exists while the navigator is enabled; fall back to
-  // the preview if the navigator is toggled off while its tab is selected.
-  const navigatorTabUnavailable = activeTab === 'navigator' && ! navigatorEnabled
-  const resolvedTab: PresentationLayoutTab = navigatorTabUnavailable ? 'preview' : activeTab
+  const resolvedTab = resolveActiveTab(activeTab, navigatorEnabled)
 
   const handleRefresh = useCallback(
     (fallback: () => void) => {

--- a/packages/sanity/src/presentation/PresentationTool.tsx
+++ b/packages/sanity/src/presentation/PresentationTool.tsx
@@ -88,8 +88,7 @@ const Container = styled(Flex)`
   overflow-x: auto;
 `
 
-// The navigator tab only exists while the navigator is enabled. If it was the
-// selected tab when the navigator got toggled off, show the preview instead.
+// Fall back to the preview if the navigator tab is selected but no longer enabled.
 function resolveActiveTab(
   activeTab: PresentationLayoutTab,
   navigatorEnabled: boolean,
@@ -481,8 +480,7 @@ export default function PresentationTool(props: {
     unstable_navigator,
   })
 
-  // At narrow viewports the preview and document panels can't sit side-by-side
-  // comfortably, so they collapse into a tab bar that shows one pane at a time.
+  // Narrow viewports collapse the panels into a tab bar showing one pane at a time.
   const mediaIndex = useMediaIndex()
   const isNarrow = mediaIndex <= NARROW_MEDIA_INDEX
 

--- a/packages/sanity/src/presentation/PresentationTool.tsx
+++ b/packages/sanity/src/presentation/PresentationTool.tsx
@@ -14,7 +14,7 @@ import {
   urlSearchParamVercelProtectionBypass,
   urlSearchParamVercelSetBypassCookie,
 } from '@sanity/preview-url-secret/constants'
-import {BoundaryElementProvider, Flex} from '@sanity/ui'
+import {BoundaryElementProvider, Flex, useMediaIndex} from '@sanity/ui'
 import {useActorRef, useSelector} from '@xstate/react'
 import {
   lazy,
@@ -39,13 +39,18 @@ import {
 import {type RouterContextValue, useRouter} from 'sanity/router'
 import {styled} from 'styled-components'
 
-import {DEFAULT_TOOL_NAME, EDIT_INTENT_MODE} from './constants'
+import {DEFAULT_TOOL_NAME, EDIT_INTENT_MODE, NARROW_MEDIA_INDEX} from './constants'
 import PostMessageFeatures from './features/PostMessageFeatures'
 import {presentationMachine} from './machines/presentation-machine'
 import {type PreviewUrlRef} from './machines/preview-url'
 import {SharedStateProvider} from './overlays/SharedStateProvider'
 import {Panel} from './panels/Panel'
 import {Panels} from './panels/Panels'
+import {
+  getPresentationPanelHtmlId,
+  type PresentationLayoutTab,
+  PresentationNarrowTabBar,
+} from './panels/PresentationNarrowTabBar'
 import {PresentationContent} from './PresentationContent'
 import {PresentationNavigateProvider} from './PresentationNavigateProvider'
 import {usePresentationNavigator} from './PresentationNavigator'
@@ -465,6 +470,17 @@ export default function PresentationTool(props: {
     unstable_navigator,
   })
 
+  // At narrow viewports the preview and document panels can't sit side-by-side
+  // comfortably, so they collapse into a tab bar that shows one pane at a time.
+  const mediaIndex = useMediaIndex()
+  const isNarrow = mediaIndex <= NARROW_MEDIA_INDEX
+
+  const [activeTab, setActiveTab] = useState<PresentationLayoutTab>('preview')
+  // The navigator tab only exists while the navigator is enabled; fall back to
+  // the preview if the navigator is toggled off while its tab is selected.
+  const navigatorTabUnavailable = activeTab === 'navigator' && ! navigatorEnabled
+  const resolvedTab: PresentationLayoutTab = navigatorTabUnavailable ? 'preview' : activeTab
+
   const handleRefresh = useCallback(
     (fallback: () => void) => {
       presentationRef.send({type: 'iframe refresh'})
@@ -533,62 +549,78 @@ export default function PresentationTool(props: {
         <PresentationNavigateProvider navigate={navigate}>
           <PresentationParamsProvider params={params}>
             <SharedStateProvider comlink={visualEditingComlink}>
-              <Container data-testid="presentation-root" height="fill">
-                <Panels>
-                  <PresentationNavigator />
-                  <Panel
-                    id="preview"
-                    minWidth={325}
-                    defaultSize={navigatorEnabled ? 50 : 75}
-                    order={3}
-                  >
-                    <Flex direction="column" flex={1} height="fill" ref={setBoundaryElement}>
-                      <BoundaryElementProvider element={boundaryElement}>
-                        <Preview
-                          // @TODO move closer to the <iframe> element itself to allow for more precise handling of when to reload the iframe and when to reconnect when the target origin changes
-                          // Make sure the iframe is unmounted if the targetOrigin has changed
-                          key={targetOrigin}
-                          canSharePreviewAccess={canSharePreviewAccess}
-                          canToggleSharePreviewAccess={canToggleSharePreviewAccess}
-                          canUseSharedPreviewAccess={canUseSharedPreviewAccess}
-                          header={unstable_header}
-                          initialUrl={initialPreviewUrl}
-                          loadersConnection={loadersConnection}
-                          navigatorEnabled={navigatorEnabled}
-                          onPathChange={handlePreviewPath}
-                          onRefresh={handleRefresh}
-                          openPopup={handleOpenPopup}
-                          overlaysConnection={overlaysConnection}
-                          previewUrl={params.preview}
-                          perspective={perspective}
-                          ref={iframeRef}
-                          setViewport={setViewport}
-                          targetOrigin={targetOrigin}
-                          toggleNavigator={toggleNavigator}
-                          toggleOverlay={toggleOverlay}
-                          viewport={viewport}
-                          vercelProtectionBypass={vercelProtectionBypass}
-                          presentationRef={presentationRef}
-                          previewUrlRef={previewUrlRef}
-                          handlesPerspectiveChange={handlesPerspectiveChange}
-                        />
-                      </BoundaryElementProvider>
-                    </Flex>
-                  </Panel>
-                  <PresentationContent
-                    documentId={params.id}
-                    documentsOnPage={documentsOnPage}
-                    documentType={params.type}
-                    getCommentIntent={getCommentIntent}
-                    mainDocumentState={mainDocumentState}
-                    onEditReference={handleEditReference}
-                    onFocusPath={handleFocusPath}
-                    onStructureParams={handleStructureParams}
-                    searchParams={searchParams}
-                    setDisplayedDocument={setDisplayedDocument}
-                    structureParams={structureParams}
+              <Container data-testid="presentation-root" direction="column" height="fill">
+                {isNarrow && (
+                  <PresentationNarrowTabBar
+                    activeTab={resolvedTab}
+                    navigatorEnabled={navigatorEnabled}
+                    onTabChange={setActiveTab}
                   />
-                </Panels>
+                )}
+                <Flex direction="column" flex={1} style={{minHeight: 0}}>
+                  <Panels>
+                    <PresentationNavigator
+                      hidden={isNarrow && resolvedTab !== 'navigator'}
+                      resizerHidden={isNarrow}
+                    />
+                    <Panel
+                      id="preview"
+                      htmlId={getPresentationPanelHtmlId('preview')}
+                      minWidth={325}
+                      defaultSize={navigatorEnabled ? 50 : 75}
+                      order={3}
+                      hidden={isNarrow && resolvedTab !== 'preview'}
+                    >
+                      <Flex direction="column" flex={1} height="fill" ref={setBoundaryElement}>
+                        <BoundaryElementProvider element={boundaryElement}>
+                          <Preview
+                            // @TODO move closer to the <iframe> element itself to allow for more precise handling of when to reload the iframe and when to reconnect when the target origin changes
+                            // Make sure the iframe is unmounted if the targetOrigin has changed
+                            key={targetOrigin}
+                            canSharePreviewAccess={canSharePreviewAccess}
+                            canToggleSharePreviewAccess={canToggleSharePreviewAccess}
+                            canUseSharedPreviewAccess={canUseSharedPreviewAccess}
+                            header={unstable_header}
+                            initialUrl={initialPreviewUrl}
+                            loadersConnection={loadersConnection}
+                            navigatorEnabled={navigatorEnabled}
+                            onPathChange={handlePreviewPath}
+                            onRefresh={handleRefresh}
+                            openPopup={handleOpenPopup}
+                            overlaysConnection={overlaysConnection}
+                            previewUrl={params.preview}
+                            perspective={perspective}
+                            ref={iframeRef}
+                            setViewport={setViewport}
+                            targetOrigin={targetOrigin}
+                            toggleNavigator={toggleNavigator}
+                            toggleOverlay={toggleOverlay}
+                            viewport={viewport}
+                            vercelProtectionBypass={vercelProtectionBypass}
+                            presentationRef={presentationRef}
+                            previewUrlRef={previewUrlRef}
+                            handlesPerspectiveChange={handlesPerspectiveChange}
+                          />
+                        </BoundaryElementProvider>
+                      </Flex>
+                    </Panel>
+                    <PresentationContent
+                      documentId={params.id}
+                      documentsOnPage={documentsOnPage}
+                      documentType={params.type}
+                      getCommentIntent={getCommentIntent}
+                      hidden={isNarrow && resolvedTab !== 'content'}
+                      mainDocumentState={mainDocumentState}
+                      onEditReference={handleEditReference}
+                      onFocusPath={handleFocusPath}
+                      onStructureParams={handleStructureParams}
+                      resizerHidden={isNarrow}
+                      searchParams={searchParams}
+                      setDisplayedDocument={setDisplayedDocument}
+                      structureParams={structureParams}
+                    />
+                  </Panels>
+                </Flex>
               </Container>
             </SharedStateProvider>
           </PresentationParamsProvider>

--- a/packages/sanity/src/presentation/constants.ts
+++ b/packages/sanity/src/presentation/constants.ts
@@ -22,9 +22,5 @@ export const LOADER_QUERY_GC_INTERVAL = 30_000 // ms
 // The interval at which we check if existing popups have been closed
 export const POPUP_CHECK_INTERVAL = 1000 // ms
 
-// At or below this `@sanity/ui` media breakpoint index the preview and document
-// panels can no longer sit side-by-side without becoming cramped, so the layout
-// collapses them into a tab bar that shows a single pane at a time. Tuned to
-// trigger below ~900px, where the two 325px-minimum panels stop fitting
-// comfortably alongside the studio chrome.
+// Below this @sanity/ui breakpoint (~900px) the two 325px panels stop fitting side-by-side and collapse into tabs.
 export const NARROW_MEDIA_INDEX = 2

--- a/packages/sanity/src/presentation/constants.ts
+++ b/packages/sanity/src/presentation/constants.ts
@@ -21,3 +21,10 @@ export const LOADER_QUERY_GC_INTERVAL = 30_000 // ms
 
 // The interval at which we check if existing popups have been closed
 export const POPUP_CHECK_INTERVAL = 1000 // ms
+
+// At or below this `@sanity/ui` media breakpoint index the preview and document
+// panels can no longer sit side-by-side without becoming cramped, so the layout
+// collapses them into a tab bar that shows a single pane at a time. Tuned to
+// trigger below ~900px, where the two 325px-minimum panels stop fitting
+// comfortably alongside the studio chrome.
+export const NARROW_MEDIA_INDEX = 2

--- a/packages/sanity/src/presentation/i18n/resources.ts
+++ b/packages/sanity/src/presentation/i18n/resources.ts
@@ -33,6 +33,12 @@ export default defineLocalesResources('presentation', {
   'main-document.label': 'Main document',
   /** The warning message text shown when a defined resolver fails to return a main document */
   'main-document.missing.text': 'Missing a main document for <Code>{{path}}</Code>',
+  /** The label for the tab that shows the document editor at narrow viewports */
+  'narrow-tabs.content-tab.label': 'Structure',
+  /** The label for the tab that shows the navigator at narrow viewports */
+  'narrow-tabs.navigator-tab.label': 'Navigator',
+  /** The label for the tab that shows the preview at narrow viewports */
+  'narrow-tabs.preview-tab.label': 'Presentation',
   /** The label for a generic error message */
   'presentation-error.label': 'Error message',
   /** The text shown when the preview frame cannot connect to Presentation */

--- a/packages/sanity/src/presentation/panels/Panel.tsx
+++ b/packages/sanity/src/presentation/panels/Panel.tsx
@@ -4,10 +4,15 @@ import {styled} from 'styled-components'
 
 interface PanelProps extends PropsWithChildren {
   defaultSize?: number | null
+  /** Identifies the panel within the panel group; not rendered to the DOM. */
   id: string
+  /** Optional DOM id applied to the panel's root element, e.g. for `aria-controls`. */
+  htmlId?: string
   minWidth?: number
   maxWidth?: number
   order?: number
+  /** Removes the panel from the flex layout without unmounting it, preserving any iframe state. */
+  hidden?: boolean
 }
 
 const Root = styled.div`
@@ -20,9 +25,11 @@ export const Panel: FunctionComponent<PanelProps> = function ({
   children,
   defaultSize = null,
   id,
+  htmlId,
   minWidth,
   maxWidth,
   order = 0,
+  hidden = false,
 }) {
   const context = useContext(PresentationPanelsContext)
 
@@ -32,7 +39,10 @@ export const Panel: FunctionComponent<PanelProps> = function ({
 
   const {getPanelStyle, registerElement, unregisterElement} = context
 
-  const style = getPanelStyle(id)
+  // A hidden panel stays mounted (so the preview iframe keeps its state) but
+  // leaves the flex layout entirely, letting the remaining visible panel fill
+  // the container regardless of its persisted width.
+  const style = hidden ? {display: 'none'} : getPanelStyle(id)
 
   useLayoutEffect(() => {
     registerElement(id, {
@@ -49,5 +59,9 @@ export const Panel: FunctionComponent<PanelProps> = function ({
     }
   }, [id, defaultSize, order, maxWidth, minWidth, registerElement, unregisterElement])
 
-  return <Root style={style}>{children}</Root>
+  return (
+    <Root id={htmlId} style={style}>
+      {children}
+    </Root>
+  )
 }

--- a/packages/sanity/src/presentation/panels/Panel.tsx
+++ b/packages/sanity/src/presentation/panels/Panel.tsx
@@ -4,14 +4,14 @@ import {styled} from 'styled-components'
 
 interface PanelProps extends PropsWithChildren {
   defaultSize?: number | null
-  /** Identifies the panel within the panel group; not rendered to the DOM. */
+  /** Panel group key; not a DOM id. */
   id: string
-  /** Optional DOM id applied to the panel's root element, e.g. for `aria-controls`. */
+  /** DOM id for the root element (e.g. aria-controls target). */
   htmlId?: string
   minWidth?: number
   maxWidth?: number
   order?: number
-  /** Removes the panel from the flex layout without unmounting it, preserving any iframe state. */
+  /** Hide via display:none without unmounting (keeps iframe state). */
   hidden?: boolean
 }
 
@@ -39,9 +39,7 @@ export const Panel: FunctionComponent<PanelProps> = function ({
 
   const {getPanelStyle, registerElement, unregisterElement} = context
 
-  // A hidden panel stays mounted (so the preview iframe keeps its state) but
-  // leaves the flex layout entirely, letting the remaining visible panel fill
-  // the container regardless of its persisted width.
+  // Hidden panels stay mounted (preserving iframe state) but leave the flex layout so siblings fill the space.
   const style = hidden ? {display: 'none'} : getPanelStyle(id)
 
   useLayoutEffect(() => {

--- a/packages/sanity/src/presentation/panels/PanelResizer.tsx
+++ b/packages/sanity/src/presentation/panels/PanelResizer.tsx
@@ -89,9 +89,7 @@ export const PanelResizer: FunctionComponent<{
 
   const onMouseDown = useCallback(
     (event: ReactMouseEvent) => {
-      // A disabled or hidden resizer must not start a drag: the drag effect
-      // bails for both, so `activeResizer` would never be cleared and would
-      // leave every panel with pointer events disabled until a remount.
+      // Don't drag from a disabled/hidden resizer: the drag effect bails, stranding activeResizer.
       if (disabled || hidden) return
       startDragging(id, event.nativeEvent)
     },

--- a/packages/sanity/src/presentation/panels/PanelResizer.tsx
+++ b/packages/sanity/src/presentation/panels/PanelResizer.tsx
@@ -89,9 +89,13 @@ export const PanelResizer: FunctionComponent<{
 
   const onMouseDown = useCallback(
     (event: ReactMouseEvent) => {
+      // A disabled or hidden resizer must not start a drag: the drag effect
+      // bails for both, so `activeResizer` would never be cleared and would
+      // leave every panel with pointer events disabled until a remount.
+      if (disabled || hidden) return
       startDragging(id, event.nativeEvent)
     },
-    [id, startDragging],
+    [disabled, hidden, id, startDragging],
   )
 
   const onDrag = useCallback(

--- a/packages/sanity/src/presentation/panels/PanelResizer.tsx
+++ b/packages/sanity/src/presentation/panels/PanelResizer.tsx
@@ -12,8 +12,9 @@ import {styled} from 'styled-components'
 
 import {usePanelId} from './usePanelId'
 
-const Resizer = styled.div`
+const Resizer = styled.div<{$hidden: boolean}>`
   position: relative;
+  ${({$hidden}) => $hidden && `display: none;`}
 `
 const ResizerInner = styled.div<{
   $disabled: boolean
@@ -65,7 +66,8 @@ export const PanelResizer: FunctionComponent<{
   id?: string
   order: number
   disabled?: boolean
-}> = function ({id: propId, order, disabled = false}) {
+  hidden?: boolean
+}> = function ({id: propId, order, disabled = false, hidden = false}) {
   const el = useRef<HTMLDivElement>(null)
 
   const context = useContext(PresentationPanelsContext)
@@ -152,7 +154,7 @@ export const PanelResizer: FunctionComponent<{
   }, [id, order, registerElement, unregisterElement])
 
   return (
-    <Resizer onMouseDown={onMouseDown} ref={el}>
+    <Resizer $hidden={hidden} onMouseDown={onMouseDown} ref={el}>
       <ResizerInner $disabled={disabled}>
         <span />
         <span />

--- a/packages/sanity/src/presentation/panels/PresentationNarrowTabBar.tsx
+++ b/packages/sanity/src/presentation/panels/PresentationNarrowTabBar.tsx
@@ -13,9 +13,7 @@ interface PresentationNarrowTabBarProps {
 }
 
 /**
- * A tab bar shown above the panels at narrow viewports, allowing the user to
- * switch between showing the preview, the optional navigator, and the document
- * editor one at a time rather than cramming them side-by-side.
+ * Tab bar shown above the panels at narrow viewports to switch between panes one at a time.
  *
  * @internal
  */
@@ -24,16 +22,16 @@ export const PresentationNarrowTabBar: FunctionComponent<PresentationNarrowTabBa
     const {activeTab, navigatorEnabled, onTabChange} = props
     const {t} = useTranslation(presentationLocaleNamespace)
 
-    const tabs = useMemo<{id: PresentationLayoutTab; label: string}[]>(
-      () => [
+    const tabs = useMemo<{id: PresentationLayoutTab; label: string}[]>(() => {
+      const orderedTabs: {id: PresentationLayoutTab; label: string}[] = [
         {id: 'preview', label: t('narrow-tabs.preview-tab.label')},
-        ...(navigatorEnabled
-          ? [{id: 'navigator' as const, label: t('narrow-tabs.navigator-tab.label')}]
-          : []),
-        {id: 'content', label: t('narrow-tabs.content-tab.label')},
-      ],
-      [navigatorEnabled, t],
-    )
+      ]
+      if (navigatorEnabled) {
+        orderedTabs.push({id: 'navigator', label: t('narrow-tabs.navigator-tab.label')})
+      }
+      orderedTabs.push({id: 'content', label: t('narrow-tabs.content-tab.label')})
+      return orderedTabs
+    }, [navigatorEnabled, t])
 
     return (
       <Card borderBottom paddingX={2} paddingY={1}>

--- a/packages/sanity/src/presentation/panels/PresentationNarrowTabBar.tsx
+++ b/packages/sanity/src/presentation/panels/PresentationNarrowTabBar.tsx
@@ -1,0 +1,72 @@
+import {Card, TabList} from '@sanity/ui'
+import {type FunctionComponent, useMemo} from 'react'
+import {useTranslation} from 'sanity'
+
+import {Tab} from '../../ui-components'
+import {presentationLocaleNamespace} from '../i18n'
+
+/**
+ * Identifies which pane the narrow-viewport tab bar is currently showing. Maps
+ * directly onto the panels assembled in `PresentationTool`: the preview iframe,
+ * the optional navigator, and the document (structure) editor.
+ *
+ * @internal
+ */
+export type PresentationLayoutTab = 'preview' | 'navigator' | 'content'
+
+/**
+ * The DOM id applied to a panel's root element so its narrow-mode tab can
+ * reference it via `aria-controls`.
+ *
+ * @internal
+ */
+export function getPresentationPanelHtmlId(tab: PresentationLayoutTab): string {
+  return `presentation-narrow-panel-${tab}`
+}
+
+interface PresentationNarrowTabBarProps {
+  activeTab: PresentationLayoutTab
+  navigatorEnabled: boolean
+  onTabChange: (tab: PresentationLayoutTab) => void
+}
+
+/**
+ * A tab bar shown above the panels at narrow viewports, allowing the user to
+ * switch between showing the preview, the optional navigator, and the document
+ * editor one at a time rather than cramming them side-by-side.
+ *
+ * @internal
+ */
+export const PresentationNarrowTabBar: FunctionComponent<PresentationNarrowTabBarProps> =
+  function PresentationNarrowTabBar(props) {
+    const {activeTab, navigatorEnabled, onTabChange} = props
+    const {t} = useTranslation(presentationLocaleNamespace)
+
+    const tabs = useMemo<{id: PresentationLayoutTab; label: string}[]>(
+      () => [
+        {id: 'preview', label: t('narrow-tabs.preview-tab.label')},
+        ...(navigatorEnabled
+          ? [{id: 'navigator' as const, label: t('narrow-tabs.navigator-tab.label')}]
+          : []),
+        {id: 'content', label: t('narrow-tabs.content-tab.label')},
+      ],
+      [navigatorEnabled, t],
+    )
+
+    return (
+      <Card borderBottom paddingX={2} paddingY={1}>
+        <TabList space={1}>
+          {tabs.map((tab) => (
+            <Tab
+              key={tab.id}
+              aria-controls={getPresentationPanelHtmlId(tab.id)}
+              id={`presentation-narrow-tab-${tab.id}`}
+              label={tab.label}
+              onClick={() => onTabChange(tab.id)}
+              selected={activeTab === tab.id}
+            />
+          ))}
+        </TabList>
+      </Card>
+    )
+  }

--- a/packages/sanity/src/presentation/panels/PresentationNarrowTabBar.tsx
+++ b/packages/sanity/src/presentation/panels/PresentationNarrowTabBar.tsx
@@ -4,25 +4,7 @@ import {useTranslation} from 'sanity'
 
 import {Tab} from '../../ui-components'
 import {presentationLocaleNamespace} from '../i18n'
-
-/**
- * Identifies which pane the narrow-viewport tab bar is currently showing. Maps
- * directly onto the panels assembled in `PresentationTool`: the preview iframe,
- * the optional navigator, and the document (structure) editor.
- *
- * @internal
- */
-export type PresentationLayoutTab = 'preview' | 'navigator' | 'content'
-
-/**
- * The DOM id applied to a panel's root element so its narrow-mode tab can
- * reference it via `aria-controls`.
- *
- * @internal
- */
-export function getPresentationPanelHtmlId(tab: PresentationLayoutTab): string {
-  return `presentation-narrow-panel-${tab}`
-}
+import {getPresentationPanelHtmlId, type PresentationLayoutTab} from './presentationLayoutTab'
 
 interface PresentationNarrowTabBarProps {
   activeTab: PresentationLayoutTab

--- a/packages/sanity/src/presentation/panels/PresentationNarrowTabBar.tsx
+++ b/packages/sanity/src/presentation/panels/PresentationNarrowTabBar.tsx
@@ -1,4 +1,4 @@
-import {Card, TabList} from '@sanity/ui'
+import {Card, Flex, TabList} from '@sanity/ui'
 import {type FunctionComponent, useMemo} from 'react'
 import {useTranslation} from 'sanity'
 
@@ -55,18 +55,21 @@ export const PresentationNarrowTabBar: FunctionComponent<PresentationNarrowTabBa
 
     return (
       <Card borderBottom paddingX={2} paddingY={1}>
-        <TabList space={1}>
-          {tabs.map((tab) => (
-            <Tab
-              key={tab.id}
-              aria-controls={getPresentationPanelHtmlId(tab.id)}
-              id={`presentation-narrow-tab-${tab.id}`}
-              label={tab.label}
-              onClick={() => onTabChange(tab.id)}
-              selected={activeTab === tab.id}
-            />
-          ))}
-        </TabList>
+        {/* Center the tab group within the bar rather than letting it sit against the left edge. */}
+        <Flex justify="center">
+          <TabList space={1}>
+            {tabs.map((tab) => (
+              <Tab
+                key={tab.id}
+                aria-controls={getPresentationPanelHtmlId(tab.id)}
+                id={`presentation-narrow-tab-${tab.id}`}
+                label={tab.label}
+                onClick={() => onTabChange(tab.id)}
+                selected={activeTab === tab.id}
+              />
+            ))}
+          </TabList>
+        </Flex>
       </Card>
     )
   }

--- a/packages/sanity/src/presentation/panels/__tests__/PresentationNarrowTabBar.test.tsx
+++ b/packages/sanity/src/presentation/panels/__tests__/PresentationNarrowTabBar.test.tsx
@@ -1,0 +1,69 @@
+import {render, screen} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../test/testUtils/TestProvider'
+import {presentationUsEnglishLocaleBundle} from '../../i18n'
+import {PresentationNarrowTabBar} from '../PresentationNarrowTabBar'
+
+async function renderTabBar(props: {
+  activeTab?: 'preview' | 'navigator' | 'content'
+  navigatorEnabled?: boolean
+  onTabChange?: (tab: 'preview' | 'navigator' | 'content') => void
+}) {
+  const wrapper = await createTestProvider({
+    resources: [presentationUsEnglishLocaleBundle],
+  })
+
+  return render(
+    <PresentationNarrowTabBar
+      activeTab={props.activeTab ?? 'preview'}
+      navigatorEnabled={props.navigatorEnabled ?? false}
+      onTabChange={props.onTabChange ?? vi.fn()}
+    />,
+    {wrapper},
+  )
+}
+
+describe('PresentationNarrowTabBar', () => {
+  it('renders the preview and structure tabs but not the navigator when it is disabled', async () => {
+    await renderTabBar({navigatorEnabled: false})
+
+    // The locale bundle loads via a lazy import, so wait for the labels to resolve.
+    expect(await screen.findByRole('tab', {name: 'Presentation'})).toBeInTheDocument()
+    expect(screen.getByRole('tab', {name: 'Structure'})).toBeInTheDocument()
+    expect(screen.queryByRole('tab', {name: 'Navigator'})).not.toBeInTheDocument()
+  })
+
+  it('renders the navigator tab between preview and structure when it is enabled', async () => {
+    await renderTabBar({navigatorEnabled: true})
+
+    await screen.findByRole('tab', {name: 'Presentation'})
+    const tabs = screen.getAllByRole('tab').map((tab) => tab.textContent)
+    expect(tabs).toEqual(['Presentation', 'Navigator', 'Structure'])
+  })
+
+  it('marks the active tab as selected', async () => {
+    await renderTabBar({activeTab: 'content'})
+
+    expect(await screen.findByRole('tab', {name: 'Structure'})).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    expect(screen.getByRole('tab', {name: 'Presentation'})).toHaveAttribute(
+      'aria-selected',
+      'false',
+    )
+  })
+
+  it('calls onTabChange with the selected tab id when a tab is clicked', async () => {
+    const onTabChange = vi.fn()
+    await renderTabBar({navigatorEnabled: true, onTabChange})
+
+    await userEvent.click(await screen.findByRole('tab', {name: 'Structure'}))
+    expect(onTabChange).toHaveBeenCalledWith('content')
+
+    await userEvent.click(screen.getByRole('tab', {name: 'Navigator'}))
+    expect(onTabChange).toHaveBeenCalledWith('navigator')
+  })
+})

--- a/packages/sanity/src/presentation/panels/presentationLayoutTab.ts
+++ b/packages/sanity/src/presentation/panels/presentationLayoutTab.ts
@@ -1,0 +1,18 @@
+/**
+ * Identifies which pane the narrow-viewport tab bar is currently showing. Maps
+ * directly onto the panels assembled in `PresentationTool`: the preview iframe,
+ * the optional navigator, and the document (structure) editor.
+ *
+ * @internal
+ */
+export type PresentationLayoutTab = 'preview' | 'navigator' | 'content'
+
+/**
+ * The DOM id applied to a panel's root element so its narrow-mode tab can
+ * reference it via `aria-controls`.
+ *
+ * @internal
+ */
+export function getPresentationPanelHtmlId(tab: PresentationLayoutTab): string {
+  return `presentation-narrow-panel-${tab}`
+}

--- a/packages/sanity/src/presentation/panels/presentationLayoutTab.ts
+++ b/packages/sanity/src/presentation/panels/presentationLayoutTab.ts
@@ -1,15 +1,12 @@
 /**
- * Identifies which pane the narrow-viewport tab bar is currently showing. Maps
- * directly onto the panels assembled in `PresentationTool`: the preview iframe,
- * the optional navigator, and the document (structure) editor.
+ * Which pane the narrow-viewport tab bar shows: preview, navigator, or document editor.
  *
  * @internal
  */
 export type PresentationLayoutTab = 'preview' | 'navigator' | 'content'
 
 /**
- * The DOM id applied to a panel's root element so its narrow-mode tab can
- * reference it via `aria-controls`.
+ * DOM id of a panel's root, used as the `aria-controls` target for its tab.
  *
  * @internal
  */


### PR DESCRIPTION
### Description

At narrow viewports the Presentation tool previously rendered the live-preview iframe and the document (Structure) editor side-by-side, which left both panes cramped and clipped - effectively unusable on mobile and small windows.

This adds a tab bar at the top of the Presentation layout that appears only at narrow viewports. It lets you switch between showing the preview ("Presentation") and the document editor ("Structure") one at a time, plus a "Navigator" tab when a navigator component is configured. At wider viewports nothing changes: the existing side-by-side resizable layout is rendered exactly as before.

The inactive pane is hidden with `display: none` rather than unmounted, so the preview iframe keeps its state and does not reload when switching tabs. Persisted panel drag-widths are untouched and restored when the viewport widens again.

Resolves [SAPP-3480](https://linear.app/sanity/issue/SAPP-3480/presentation-in-studio-on-mobile-is-pretty-unusable-its-a-shame-since).

<img width="470" height="690" alt="viewportNarrowPresentationPR" src="https://github.com/user-attachments/assets/25cd9d47-5fd3-45d7-ab7f-b900eea108c1" />

### What to review

- `PresentationTool.tsx` - narrow-mode detection via `useMediaIndex` against the `NARROW_MEDIA_INDEX` breakpoint constant, the `activeTab` state, and how the `hidden` / `resizerHidden` props are wired into each pane.
- `PresentationNarrowTabBar.tsx` - the new tab bar (uses the studio `TabList` / `Tab` primitives), centered within the bar.
- `panels/Panel.tsx` and `panels/PanelResizer.tsx` - the `hidden` prop that removes a pane from the flex layout without unmounting it.
- The breakpoint value (`NARROW_MEDIA_INDEX = 2`, roughly below 900px) is the main thing likely to need tuning - it is a single constant.

Steps to verify: open the Presentation tool with a document open, narrow the browser window below ~900px, confirm the tab bar appears and switching tabs swaps the single visible pane. Switch away from and back to "Presentation" and confirm the preview iframe does not reload. Widen the window and confirm the side-by-side layout returns.

### Testing

Added unit tests for `PresentationNarrowTabBar` covering: rendering two tabs when the navigator is disabled, three tabs (in order) when enabled, the selected-tab state, and `onTabChange` firing with the correct tab id. Type check, lint, format, and build pass; existing presentation tests are unaffected.

### Notes for release

Presentation now adapts to narrow viewports. When the window is too small to show the preview and the document editor side-by-side, they collapse into a tab bar at the top so you can switch between "Presentation" and "Structure" (and "Navigator", when configured) one pane at a time, instead of a cramped split view. Wider viewports are unchanged.
