### PR TITLE
feat(releases): deep-link release validation errors to the offending field

### DIFF
--- a/packages/sanity/src/core/releases/tool/components/ReleaseDocumentPreview.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseDocumentPreview.tsx
@@ -10,6 +10,7 @@ import {useDocumentPresence} from '../../../store/presence/useDocumentPresence'
 import {useDocumentPreviewValues} from '../../../tasks/hooks/useDocumentPreviewValues'
 import {getPublishedId} from '../../../util/draftUtils'
 import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
+import {getReleaseDocumentIntent} from './getReleaseDocumentIntent'
 
 interface ReleaseDocumentPreviewProps {
   documentId: string
@@ -23,9 +24,6 @@ interface ReleaseDocumentPreviewProps {
   isCardinalityOneRelease?: boolean
 }
 
-const isArchivedRelease = (releaseState: ReleaseState | undefined) =>
-  releaseState === 'archived' || releaseState === 'archiving' || releaseState === 'unarchiving'
-
 export function ReleaseDocumentPreview({
   documentId,
   documentTypeName,
@@ -38,33 +36,25 @@ export function ReleaseDocumentPreview({
 }: ReleaseDocumentPreviewProps) {
   const documentPresence = useDocumentPresence(documentId)
 
-  const intentParams = useMemo(() => {
-    if (isCardinalityOneRelease) {
-      return {
-        scheduledDraft: getReleaseIdFromReleaseDocumentId(releaseId),
-      }
-    }
-    if (releaseState === 'published') {
-      // We are inspecting this document through the published view of the doc.
-      return {
-        rev: `@release:${getReleaseIdFromReleaseDocumentId(releaseId)}`,
-        inspect: 'sanity/structure/history',
-      }
-    }
-
-    if (releaseState === 'archived') {
-      // We are "faking" the release as if it is still valid only to render the document
-      return {
-        rev: '@lastEdited',
-        inspect: 'sanity/structure/history',
-        historyEvent: documentRevision,
-        historyVersion: getReleaseIdFromReleaseDocumentId(releaseId),
-        archivedRelease: 'true',
-      }
-    }
-
-    return {}
-  }, [releaseState, releaseId, documentRevision, isCardinalityOneRelease])
+  const {params, searchParams} = useMemo(
+    () =>
+      getReleaseDocumentIntent({
+        documentId,
+        documentTypeName,
+        releaseId,
+        releaseState,
+        documentRevision,
+        isCardinalityOneRelease,
+      }),
+    [
+      documentId,
+      documentTypeName,
+      releaseId,
+      releaseState,
+      documentRevision,
+      isCardinalityOneRelease,
+    ],
+  )
 
   const LinkComponent = useMemo(
     () =>
@@ -73,28 +63,13 @@ export function ReleaseDocumentPreview({
           <IntentLink
             {...linkProps}
             intent="edit"
-            params={{
-              id: getPublishedId(documentId),
-              type: documentTypeName,
-              ...intentParams,
-            }}
-            searchParams={
-              isCardinalityOneRelease || isArchivedRelease(releaseState)
-                ? undefined
-                : [
-                    [
-                      'perspective',
-                      releaseState === 'published'
-                        ? 'published'
-                        : getReleaseIdFromReleaseDocumentId(releaseId),
-                    ],
-                  ]
-            }
+            params={params}
+            searchParams={searchParams}
             ref={ref}
           />
         )
       }),
-    [documentId, documentTypeName, intentParams, releaseState, releaseId, isCardinalityOneRelease],
+    [params, searchParams],
   )
 
   const previewPresence = useMemo(

--- a/packages/sanity/src/core/releases/tool/components/getReleaseDocumentIntent.test.ts
+++ b/packages/sanity/src/core/releases/tool/components/getReleaseDocumentIntent.test.ts
@@ -1,0 +1,67 @@
+import {describe, expect, it} from 'vitest'
+
+import {getPublishedId} from '../../../util/draftUtils'
+import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
+import {getReleaseDocumentIntent} from './getReleaseDocumentIntent'
+
+const RELEASE_ID = '_.releases.rTest'
+const RELEASE_NAME = getReleaseIdFromReleaseDocumentId(RELEASE_ID)
+const DOC_ID = 'versions.rTest.doc1'
+const PUBLISHED_ID = getPublishedId(DOC_ID)
+
+const base = {documentId: DOC_ID, documentTypeName: 'post', releaseId: RELEASE_ID}
+
+describe('getReleaseDocumentIntent', () => {
+  it('targets the release perspective for an active release', () => {
+    const {params, searchParams} = getReleaseDocumentIntent({...base})
+    expect(params).toEqual({id: PUBLISHED_ID, type: 'post'})
+    expect(searchParams).toEqual([['perspective', RELEASE_NAME]])
+  })
+
+  it('includes the focus path when provided', () => {
+    const {params} = getReleaseDocumentIntent({...base, path: 'body[_key=="abc"].title'})
+    expect(params).toMatchObject({
+      id: PUBLISHED_ID,
+      type: 'post',
+      path: 'body[_key=="abc"].title',
+    })
+  })
+
+  it('omits an empty focus path', () => {
+    const {params} = getReleaseDocumentIntent({...base, path: ''})
+    expect(params).not.toHaveProperty('path')
+  })
+
+  it('uses the published view for a published release', () => {
+    const {params, searchParams} = getReleaseDocumentIntent({...base, releaseState: 'published'})
+    expect(params).toMatchObject({
+      rev: `@release:${RELEASE_NAME}`,
+      inspect: 'sanity/structure/history',
+    })
+    expect(searchParams).toEqual([['perspective', 'published']])
+  })
+
+  it('fakes a valid release for an archived release (no perspective search param)', () => {
+    const {params, searchParams} = getReleaseDocumentIntent({
+      ...base,
+      releaseState: 'archived',
+      documentRevision: 'rev1',
+    })
+    expect(params).toMatchObject({
+      rev: '@lastEdited',
+      inspect: 'sanity/structure/history',
+      historyVersion: RELEASE_NAME,
+      archivedRelease: 'true',
+    })
+    expect(searchParams).toBeUndefined()
+  })
+
+  it('uses scheduledDraft (no perspective search param) for a cardinality-one release', () => {
+    const {params, searchParams} = getReleaseDocumentIntent({
+      ...base,
+      isCardinalityOneRelease: true,
+    })
+    expect(params).toMatchObject({scheduledDraft: RELEASE_NAME})
+    expect(searchParams).toBeUndefined()
+  })
+})

--- a/packages/sanity/src/core/releases/tool/components/getReleaseDocumentIntent.ts
+++ b/packages/sanity/src/core/releases/tool/components/getReleaseDocumentIntent.ts
@@ -1,0 +1,75 @@
+import {type ReleaseState} from '@sanity/client'
+
+import {getPublishedId} from '../../../util/draftUtils'
+import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
+
+const isArchivedRelease = (releaseState: ReleaseState | undefined) =>
+  releaseState === 'archived' || releaseState === 'archiving' || releaseState === 'unarchiving'
+
+interface ReleaseDocumentIntentOptions {
+  documentId: string
+  documentTypeName: string
+  releaseId: string
+  releaseState?: ReleaseState
+  documentRevision?: string
+  isCardinalityOneRelease?: boolean
+  /** Optional field path (stringified) to focus when the document opens. */
+  path?: string
+}
+
+/**
+ * Builds the `edit` intent params and search params used to open a document version
+ * within a release perspective. Shared so that both the document preview link and the
+ * validation deep-link resolve to the exact same document/perspective.
+ *
+ * @internal
+ */
+export function getReleaseDocumentIntent({
+  documentId,
+  documentTypeName,
+  releaseId,
+  releaseState,
+  documentRevision,
+  isCardinalityOneRelease,
+  path,
+}: ReleaseDocumentIntentOptions): {
+  params: Record<string, string | undefined>
+  searchParams: [string, string][] | undefined
+} {
+  const releaseName = getReleaseIdFromReleaseDocumentId(releaseId)
+
+  let intentParams: Record<string, string | undefined> = {}
+  if (isCardinalityOneRelease) {
+    intentParams = {scheduledDraft: releaseName}
+  } else if (releaseState === 'published') {
+    // We are inspecting this document through the published view of the doc.
+    intentParams = {
+      rev: `@release:${releaseName}`,
+      inspect: 'sanity/structure/history',
+    }
+  } else if (releaseState === 'archived') {
+    // We are "faking" the release as if it is still valid only to render the document
+    intentParams = {
+      rev: '@lastEdited',
+      inspect: 'sanity/structure/history',
+      historyEvent: documentRevision,
+      historyVersion: releaseName,
+      archivedRelease: 'true',
+    }
+  }
+
+  const searchParams: [string, string][] | undefined =
+    isCardinalityOneRelease || isArchivedRelease(releaseState)
+      ? undefined
+      : [['perspective', releaseState === 'published' ? 'published' : releaseName]]
+
+  return {
+    params: {
+      id: getPublishedId(documentId),
+      type: documentTypeName,
+      ...intentParams,
+      ...(path ? {path} : {}),
+    },
+    searchParams,
+  }
+}

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -1,9 +1,11 @@
 import {type ReleaseState} from '@sanity/client'
 import {ErrorOutlineIcon} from '@sanity/icons'
 import {Badge, Box, Flex, Text} from '@sanity/ui'
+import {toString as pathToString} from '@sanity/util/paths'
 // eslint-disable-next-line @sanity/i18n/no-i18next-import -- figure out how to have the linter be fine with importing types-only
 import {type TFunction} from 'i18next'
 import {memo} from 'react'
+import {IntentLink} from 'sanity/router'
 
 import {ToneIcon} from '../../../../../ui-components/toneIcon/ToneIcon'
 import {Tooltip} from '../../../../../ui-components/tooltip'
@@ -13,6 +15,7 @@ import {useSchema} from '../../../../hooks'
 import {SanityDefaultPreview} from '../../../../preview/components/SanityDefaultPreview'
 import {getReleaseIdFromReleaseDocumentId} from '../../../util/getReleaseIdFromReleaseDocumentId'
 import {isGoingToUnpublish} from '../../../util/isGoingToUnpublish'
+import {getReleaseDocumentIntent} from '../../components/getReleaseDocumentIntent'
 import {ReleaseDocumentPreview} from '../../components/ReleaseDocumentPreview'
 import {Headers} from '../../components/Table/TableHeader'
 import {type Column, type InjectedTableProps} from '../../components/Table/types'
@@ -175,9 +178,30 @@ export const getDocumentTableColumnDefs: (
     cell: ({cellProps, datum}) => {
       if (datum.isLoading) return null
 
-      const validationErrorCount = datum.validation.validation.filter(
+      const errors = datum.validation.validation.filter(
         (validation) => validation.level === 'error',
-      ).length
+      )
+      const validationErrorCount = errors.length
+
+      // Deep-link to the first field-level error (fall back to the first error). The
+      // existing params.path -> field-focus plumbing in DocumentPaneProvider scrolls to
+      // and focuses the field when the document opens.
+      const firstError = errors.find((error) => error.path.length > 0) ?? errors[0]
+      const focusPath = firstError ? pathToString(firstError.path) : undefined
+      const intent = getReleaseDocumentIntent({
+        documentId: datum.document._id,
+        documentTypeName: datum.document._type,
+        releaseId,
+        releaseState,
+        documentRevision: datum.document._rev,
+        path: focusPath,
+      })
+      const errorLabel = t(
+        validationErrorCount === 1
+          ? 'document-validation.error_one'
+          : 'document-validation.error_other',
+        {count: validationErrorCount},
+      )
 
       return (
         <Flex {...cellProps} flex={1} padding={1} justify="center" align="center" sizing="border">
@@ -189,18 +213,21 @@ export const getDocumentTableColumnDefs: (
                 <Text muted size={1}>
                   <Flex align={'center'} gap={3} padding={1}>
                     <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
-                    {t(
-                      validationErrorCount === 1
-                        ? 'document-validation.error_one'
-                        : 'document-validation.error_other',
-                      {count: validationErrorCount},
-                    )}
+                    {errorLabel}
                   </Flex>
                 </Text>
               }
             >
               <Text size={1}>
-                <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
+                <IntentLink
+                  intent="edit"
+                  params={intent.params}
+                  searchParams={intent.searchParams}
+                  aria-label={errorLabel}
+                  data-testid={`validation-error-link-${datum.document._id}`}
+                >
+                  <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
+                </IntentLink>
               </Text>
             </Tooltip>
           )}

--- a/packages/sanity/src/structure/getIntentState.test.ts
+++ b/packages/sanity/src/structure/getIntentState.test.ts
@@ -1,0 +1,39 @@
+import {beforeEach, describe, expect, it} from 'vitest'
+
+import {getIntentState, setActivePanes} from './getIntentState'
+import {type PaneNode} from './types'
+
+describe('getIntentState', () => {
+  beforeEach(() => setActivePanes([]))
+
+  it('preserves the `path` param when an open documentList pane handles an edit intent', () => {
+    // An active documentList pane that can resolve the edit intent for type "post".
+    setActivePanes([
+      {
+        type: 'documentList',
+        schemaTypeName: 'post',
+        options: {filter: '_type == $type'},
+      } as unknown as PaneNode,
+    ])
+
+    const result = getIntentState(
+      'edit',
+      {id: 'doc1', type: 'post', path: 'body[_key=="abc"].title'},
+      {panes: []},
+      undefined,
+    )
+
+    expect('panes' in result).toBe(true)
+    if ('panes' in result) {
+      const lastGroup = result.panes[result.panes.length - 1] as Array<{
+        params?: Record<string, string>
+      }>
+      expect(lastGroup[0].params?.path).toBe('body[_key=="abc"].title')
+    }
+  })
+
+  it('falls back to intent resolution when no open pane can handle it', () => {
+    const result = getIntentState('edit', {id: 'doc1', type: 'post'}, {panes: []}, undefined)
+    expect(result).toEqual({intent: 'edit', params: {id: 'doc1', type: 'post'}, payload: undefined})
+  })
+})

--- a/packages/sanity/src/structure/getIntentState.test.ts
+++ b/packages/sanity/src/structure/getIntentState.test.ts
@@ -18,7 +18,14 @@ describe('getIntentState', () => {
 
     const result = getIntentState(
       'edit',
-      {id: 'doc1', type: 'post', path: 'body[_key=="abc"].title'},
+      {
+        id: 'doc1',
+        type: 'post',
+        path: 'body[_key=="abc"].title',
+        // history/release params used to open a release version
+        historyVersion: 'rTest',
+        archivedRelease: 'true',
+      },
       {panes: []},
       undefined,
     )
@@ -28,7 +35,11 @@ describe('getIntentState', () => {
       const lastGroup = result.panes[result.panes.length - 1] as Array<{
         params?: Record<string, string>
       }>
+      // `path` (field deep-link) and the other document-pane params must survive the
+      // fast-path, matching the cold-path resolver.
       expect(lastGroup[0].params?.path).toBe('body[_key=="abc"].title')
+      expect(lastGroup[0].params?.historyVersion).toBe('rTest')
+      expect(lastGroup[0].params?.archivedRelease).toBe('true')
     }
   })
 

--- a/packages/sanity/src/structure/getIntentState.ts
+++ b/packages/sanity/src/structure/getIntentState.ts
@@ -60,7 +60,20 @@ export function getIntentState(
 
 function getPaneParams(
   intent: string,
-  {template, version, inspect, comment, task, scheduledDraft, path}: Record<string, string>,
+  {
+    template,
+    version,
+    inspect,
+    comment,
+    task,
+    scheduledDraft,
+    path,
+    rev,
+    since,
+    historyEvent,
+    historyVersion,
+    archivedRelease,
+  }: Record<string, string>,
 ): {
   template?: string
   version?: string
@@ -69,13 +82,32 @@ function getPaneParams(
   task?: string
   scheduledDraft?: string
   path?: string
+  rev?: string
+  since?: string
+  historyEvent?: string
+  historyVersion?: string
+  archivedRelease?: string
 } {
   switch (intent) {
     case 'create':
       return {template, version}
+    // Forward the document-pane intent params (notably `path` to deep-link/focus a
+    // field, and the history/release params used to open a release version). The
+    // cold-path resolver (`resolveIntent`) already forwards all params except id/type;
+    // this fast-path previously dropped everything outside a small hardcoded list.
     case 'edit':
-      // `path` deep-links to (and focuses) a specific field when the document opens.
-      return {inspect, comment, task, scheduledDraft, path}
+      return {
+        inspect,
+        comment,
+        task,
+        scheduledDraft,
+        path,
+        rev,
+        since,
+        historyEvent,
+        historyVersion,
+        archivedRelease,
+      }
     default:
       return EMPTY_PARAMS
   }

--- a/packages/sanity/src/structure/getIntentState.ts
+++ b/packages/sanity/src/structure/getIntentState.ts
@@ -58,56 +58,19 @@ export function getIntentState(
   return {intent: intent, params, payload}
 }
 
-function getPaneParams(
-  intent: string,
-  {
-    template,
-    version,
-    inspect,
-    comment,
-    task,
-    scheduledDraft,
-    path,
-    rev,
-    since,
-    historyEvent,
-    historyVersion,
-    archivedRelease,
-  }: Record<string, string>,
-): {
-  template?: string
-  version?: string
-  inspect?: string
-  comment?: string
-  task?: string
-  scheduledDraft?: string
-  path?: string
-  rev?: string
-  since?: string
-  historyEvent?: string
-  historyVersion?: string
-  archivedRelease?: string
-} {
+function getPaneParams(intent: string, params: Record<string, string>): Record<string, string> {
   switch (intent) {
     case 'create':
-      return {template, version}
-    // Forward the document-pane intent params (notably `path` to deep-link/focus a
-    // field, and the history/release params used to open a release version). The
-    // cold-path resolver (`resolveIntent`) already forwards all params except id/type;
-    // this fast-path previously dropped everything outside a small hardcoded list.
-    case 'edit':
-      return {
-        inspect,
-        comment,
-        task,
-        scheduledDraft,
-        path,
-        rev,
-        since,
-        historyEvent,
-        historyVersion,
-        archivedRelease,
-      }
+      return {template: params.template, version: params.version}
+    case 'edit': {
+      // Forward every param except those that identify the document (`id`/`type`) or
+      // are create-only (`template`). This mirrors the cold-path resolver
+      // (`resolveIntent`), which rest-spreads `otherParams`. Keeping the two in sync
+      // structurally is important: a hardcoded allow-list silently drops any newly
+      // added edit-intent param (this is exactly how `path` was being lost).
+      const {id: _id, type: _type, template: _template, ...rest} = params
+      return rest
+    }
     default:
       return EMPTY_PARAMS
   }

--- a/packages/sanity/src/structure/getIntentState.ts
+++ b/packages/sanity/src/structure/getIntentState.ts
@@ -60,7 +60,7 @@ export function getIntentState(
 
 function getPaneParams(
   intent: string,
-  {template, version, inspect, comment, task, scheduledDraft}: Record<string, string>,
+  {template, version, inspect, comment, task, scheduledDraft, path}: Record<string, string>,
 ): {
   template?: string
   version?: string
@@ -68,12 +68,14 @@ function getPaneParams(
   comment?: string
   task?: string
   scheduledDraft?: string
+  path?: string
 } {
   switch (intent) {
     case 'create':
       return {template, version}
     case 'edit':
-      return {inspect, comment, task, scheduledDraft}
+      // `path` deep-links to (and focuses) a specific field when the document opens.
+      return {inspect, comment, task, scheduledDraft, path}
     default:
       return EMPTY_PARAMS
   }


### PR DESCRIPTION
## Description

Editors are told a document in a content release has validation errors, but the release detail view's validation indicator was a **static icon** (with only an error-count tooltip) — there was no way to find *which* field. This makes the indicator a **link** that opens the document in the release perspective and focuses the first field-level validation error. Fixes [SAPP-3892](https://linear.app/sanity/issue/SAPP-3892).

It reuses the existing `params.path` field-focus mechanism (already used by the in-document validation inspector and the incoming-references deep links) — the release validation data already carries the marker paths, so this is mostly UI wiring.

## What to review

- **`getReleaseDocumentIntent.ts`** (new) — extracts `ReleaseDocumentPreview`'s intent/perspective derivation (active / published / archived / cardinality-one) into a shared helper, with an optional focus `path`. `ReleaseDocumentPreview` now uses it (single source of truth → the validation link resolves to the exact same document + perspective as the title link).
- **`DocumentTableColumnDefs.tsx`** — the validation column icon is now an `IntentLink` carrying `path` = the first field-level error's path (falls back to the first error). Existing count tooltip retained; `aria-label` added.
- **`getIntentState.ts`** — preserve the `path` param in the `edit` fast-path (the already-open-pane case), matching `resolveIntent`'s cold path which already forwards it.

## Testing

- **Unit:** `getReleaseDocumentIntent` (6 cases — params + perspective search params for active/published/archived/cardinality-one, plus path inclusion/omission); `getIntentState` (path preserved through the open-pane fast-path — **fails without the fix**).
- `pnpm --filter sanity check:types` clean; releases tool tests pass (the `ReleaseTypePicker` scheduled-time test is a pre-existing flake — passed on isolated re-run).
- **Manual QA:** in a release containing a document with a validation error, hover the release-table error icon (tooltip shows the count), then click it → the document opens in the release perspective with the first erroring field focused/scrolled into view.

> The end-to-end UX is covered by the unit tests (each link in the chain: helper → intent params → getIntentState → existing field-focus) plus the manual-QA steps above; I wasn't able to run an automated browser check this session (the local browser tooling dropped its handle).

## Notes for release

Clicking the validation error icon for a document in a content release now opens the document and jumps to the offending field, instead of only showing an error count.