### PR TITLE
feat(studio): use `groq2024` search strategy by default

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -404,7 +404,7 @@ export default defineConfig([
       },
     },
     search: {
-      strategy: 'groq2024',
+      strategy: 'groqLegacy',
     },
     mediaLibrary: {
       enabled: true,

--- a/packages/@sanity/types/src/search/types.ts
+++ b/packages/@sanity/types/src/search/types.ts
@@ -1,7 +1,7 @@
 /**
  * @public
  */
-export const searchStrategies = ['groqLegacy', 'groq2024'] as const
+export const searchStrategies = ['groq2024', 'groqLegacy'] as const
 
 /**
  * @public

--- a/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
+++ b/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
@@ -519,34 +519,11 @@ describe('search strategy selection', () => {
     expect(workspace.search.strategy).toBe('groq2024')
   })
 
-  it('infers strategy based on `enableLegacySearch`', async () => {
+  it('respects `strategy`', async () => {
     const workspaceA = await createWorkspaceFromConfig({
       projectId,
       dataset,
       search: {
-        enableLegacySearch: true,
-      },
-    })
-
-    expect(workspaceA.search.strategy).toBe('groqLegacy')
-
-    const workspaceB = await createWorkspaceFromConfig({
-      projectId,
-      dataset,
-      search: {
-        enableLegacySearch: false,
-      },
-    })
-
-    expect(workspaceB.search.strategy).toBe('groq2024')
-  })
-
-  it('gives precedence to `strategy`', async () => {
-    const workspaceA = await createWorkspaceFromConfig({
-      projectId,
-      dataset,
-      search: {
-        enableLegacySearch: true,
         strategy: 'groq2024',
       },
     })
@@ -557,7 +534,6 @@ describe('search strategy selection', () => {
       projectId,
       dataset,
       search: {
-        enableLegacySearch: false,
         strategy: 'groqLegacy',
       },
     })
@@ -571,11 +547,11 @@ describe('search strategy selection', () => {
       dataset,
       plugins: [
         getSearchOptionsPlugin({
-          enableLegacySearch: false,
+          strategy: 'groq2024',
         }),
       ],
       search: {
-        enableLegacySearch: true,
+        strategy: 'groqLegacy',
       },
     })
 
@@ -586,75 +562,15 @@ describe('search strategy selection', () => {
       dataset,
       plugins: [
         getSearchOptionsPlugin({
-          enableLegacySearch: true,
-        }),
-      ],
-      search: {
-        enableLegacySearch: false,
-      },
-    })
-
-    expect(workspaceB.search.strategy).toBe('groq2024')
-
-    const workspaceC = await createWorkspaceFromConfig({
-      projectId,
-      dataset,
-      plugins: [
-        getSearchOptionsPlugin({
-          enableLegacySearch: false,
-        }),
-      ],
-      search: {
-        strategy: 'groqLegacy',
-      },
-    })
-
-    expect(workspaceC.search.strategy).toBe('groqLegacy')
-
-    const workspaceD = await createWorkspaceFromConfig({
-      projectId,
-      dataset,
-      plugins: [
-        getSearchOptionsPlugin({
-          strategy: 'groq2024',
-        }),
-      ],
-      search: {
-        strategy: 'groqLegacy',
-      },
-    })
-
-    expect(workspaceD.search.strategy).toBe('groqLegacy')
-
-    const workspaceE = await createWorkspaceFromConfig({
-      projectId,
-      dataset,
-      plugins: [
-        getSearchOptionsPlugin({
-          strategy: 'groq2024',
-        }),
-      ],
-      search: {
-        enableLegacySearch: true,
-      },
-    })
-
-    expect(workspaceE.search.strategy).toBe('groq2024')
-
-    const workspaceF = await createWorkspaceFromConfig({
-      projectId,
-      dataset,
-      plugins: [
-        getSearchOptionsPlugin({
           strategy: 'groqLegacy',
         }),
       ],
       search: {
-        enableLegacySearch: false,
+        strategy: 'groq2024',
       },
     })
 
-    expect(workspaceF.search.strategy).toBe('groqLegacy')
+    expect(workspaceB.search.strategy).toBe('groq2024')
   })
 })
 

--- a/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
+++ b/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
@@ -516,7 +516,7 @@ describe('search strategy selection', () => {
       dataset,
     })
 
-    expect(workspace.search.strategy).toBeTypeOf('string')
+    expect(workspace.search.strategy).toBe('groq2024')
   })
 
   it('infers strategy based on `enableLegacySearch`', async () => {

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -605,17 +605,6 @@ export const partialIndexingEnabledReducer = (opts: {
   return result
 }
 
-export const legacySearchEnabledReducer: ConfigPropertyReducer<boolean, ConfigContext> = (
-  prev,
-  {search},
-): boolean => {
-  if (typeof search?.enableLegacySearch !== 'undefined') {
-    return search.enableLegacySearch
-  }
-
-  return prev
-}
-
 export const draftsEnabledReducer: ConfigPropertyReducer<boolean, ConfigContext> = (
   prev,
   {document},
@@ -631,17 +620,6 @@ export const draftsEnabledReducer: ConfigPropertyReducer<boolean, ConfigContext>
   return prev
 }
 
-/**
- * Some projects may already be using the `enableLegacySearch` option. In order to gracefully
- * migrate to the `strategy` option, this reducer produces a value that respects any existing
- * `enableLegacySearch` option.
- *
- * If the project currently enables the Text Search API search strategy by setting
- * `enableLegacySearch` to `false`, this is mapped to the `groq2024` strategy.
- *
- * Any explicitly defined `strategy` value will take precedence over the value inferred from
- * `enableLegacySearch`.
- */
 export const searchStrategyReducer = ({
   config,
   initialValue,
@@ -651,41 +629,22 @@ export const searchStrategyReducer = ({
 }): SearchStrategy => {
   const flattenedConfig = flattenConfig(config, [])
 
-  type SearchStrategyReducerState = [
-    implicit: SearchStrategy | undefined,
-    explicit: SearchStrategy | undefined,
-  ]
+  return flattenedConfig.reduce<SearchStrategy>((currentStrategy, entry) => {
+    const {strategy} = entry.config.search ?? {}
 
-  const [implicit, explicit] = flattenedConfig.reduce<SearchStrategyReducerState>(
-    ([currentImplicit, currentExplicit], entry) => {
-      const {enableLegacySearch, strategy} = entry.config.search ?? {}
-
-      // The strategy has been explicitly defined.
-      if (typeof strategy !== 'undefined') {
-        if (!isSearchStrategy(strategy)) {
-          const listFormatter = new Intl.ListFormat('en-US', {
-            type: 'disjunction',
-          })
-          const options = listFormatter.format(searchStrategies.map((value) => `"${value}"`))
-          const received =
-            typeof strategy === 'string' ? `"${strategy}"` : getPrintableType(strategy)
-          throw new Error(`Expected \`search.strategy\` to be ${options}, but received ${received}`)
-        }
-
-        return [currentImplicit, strategy]
+    if (typeof strategy !== 'undefined') {
+      if (!isSearchStrategy(strategy)) {
+        const listFormatter = new Intl.ListFormat('en-US', {type: 'disjunction'})
+        const options = listFormatter.format(searchStrategies.map((value) => `"${value}"`))
+        const received = typeof strategy === 'string' ? `"${strategy}"` : getPrintableType(strategy)
+        throw new Error(`Expected \`search.strategy\` to be ${options}, but received ${received}`)
       }
 
-      // The strategy has been implicitly defined.
-      if (typeof enableLegacySearch === 'boolean') {
-        return [enableLegacySearch ? 'groqLegacy' : 'groq2024', currentExplicit]
-      }
+      return strategy
+    }
 
-      return [currentImplicit, currentExplicit]
-    },
-    [undefined, undefined],
-  )
-
-  return explicit ?? implicit ?? initialValue
+    return currentStrategy
+  }, initialValue)
 }
 
 export const announcementsEnabledReducer = (opts: {

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -814,7 +814,7 @@ function resolveSource({
       },
       strategy: searchStrategyReducer({
         config,
-        initialValue: 'groqLegacy',
+        initialValue: 'groq2024',
       }),
       enableLegacySearch: resolveConfigProperty({
         config,

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -48,7 +48,6 @@ import {
   initialDocumentBadges,
   initialLanguageFilter,
   internalTasksReducer,
-  legacySearchEnabledReducer,
   mediaLibraryEnabledReducer,
   mediaLibraryFrontendHostReducer,
   mediaLibraryLibraryIdReducer,
@@ -815,13 +814,6 @@ function resolveSource({
       strategy: searchStrategyReducer({
         config,
         initialValue: 'groq2024',
-      }),
-      enableLegacySearch: resolveConfigProperty({
-        config,
-        context,
-        reducer: legacySearchEnabledReducer,
-        propertyName: 'enableLegacySearch',
-        initialValue: true,
       }),
       // we will use this when we add search config to PluginOptions
       /*filters: resolveConfigProperty({

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -495,8 +495,6 @@ export interface PluginOptions {
      * Control the strategy used for searching documents. This should generally only be used if you
      * wish to try experimental search strategies.
      *
-     * This option takes precedence over the deprecated `search.enableLegacySearch` option.
-     *
      * Can be one of:
      *
      * * - `"groq2024"`: (default) Perform full text searching using the GROQ Query API and its
@@ -505,13 +503,6 @@ export interface PluginOptions {
      *   using the GROQ Query API.
      */
     strategy?: SearchStrategy
-
-    /**
-     * Enables the legacy Query API search strategy.
-     *
-     * @deprecated Use `search.strategy` instead.
-     */
-    enableLegacySearch?: boolean
   }
 
   /** Configuration for Scheduled drafts */
@@ -1004,8 +995,6 @@ export interface Source {
     unstable_partialIndexing?: {
       enabled: boolean
     }
-
-    enableLegacySearch?: boolean
     strategy?: SearchStrategy
   }
 

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -499,10 +499,10 @@ export interface PluginOptions {
      *
      * Can be one of:
      *
-     * - `"groqLegacy"` (default): Use client-side tokenization and schema introspection to search
-     *   using the GROQ Query API.
-     * - `"groq2024"`: (experimental) Perform full text searching using the GROQ Query API and its
+     * * - `"groq2024"`: (default) Perform full text searching using the GROQ Query API and its
      *   new `text::matchQuery` function.
+     * - `"groqLegacy"` (legacy): Use client-side tokenization and schema introspection to search
+     *   using the GROQ Query API.
      */
     strategy?: SearchStrategy
 


### PR DESCRIPTION
### Description

This branch switches to the `groq2024` search strategy by default, and removes the deprecated `enableLegacySearch` configuration option.

To switch back to the legacy search strategy, set the `search.strategy` configuration option to `"groqLegacy"`.

### What to review

- `groq2024` is used by default (e.g. in the Default Test Studio workspace).
- `groqLegacy` can be switched off by setting `search.strategy` (e.g. in the Playground Test Studio workspace).

### Testing

The `groq2024` strategy has been available and used in production for several releases.

### Notes for release

The enhanced GROQ search strategy (`groq2024`) is now switched on for all studios by default. To switch back to the legacy search strategy, set the `search.strategy` configuration option to `"groqLegacy"`.