### PR TITLE
chore(ci): set up release automation for v5

### DIFF
--- a/.github/workflows/create-v5-release-pr.yml
+++ b/.github/workflows/create-v5-release-pr.yml
@@ -1,0 +1,94 @@
+name: Create v5 Release PR
+
+on:
+  push:
+    branches:
+      - v5
+
+permissions:
+  contents: read
+
+jobs:
+  create-or-update-pr:
+    # this runs in v5, and we want to skip running it when release PRs are merged
+    if: >
+      !startsWith(github.event.head_commit.message, 'chore(release): publish')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: ./.github/actions/setup
+
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+
+      - name: Build
+        run: pnpm build --output-logs=full --log-order=grouped
+
+      - name: Configure git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Update version
+        run: pnpm --silent release-notes bump
+
+      - name: Get version
+        id: release-as
+        run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
+
+      - name: Generate release notes
+        # capture the root changelog entry before writing CHANGELOG.md files so it
+        # can be used as the PR description
+        id: release-notes
+        run: |
+          {
+            echo "notes<<EOF"
+            pnpm --silent release-notes write-changelog-files --version=${{ steps.release-as.outputs.version }} --dryRun
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Write CHANGELOG.md files
+        run: pnpm --silent release-notes write-changelog-files --version=${{ steps.release-as.outputs.version }}
+
+      - name: Sync workspace lockfile
+        run: pnpm install --lockfile-only
+
+      - name: Get version commit message
+        id: version-commit
+        run: |
+          echo "message=chore(release): publish v${{ steps.release-as.outputs.version }}" >> $GITHUB_OUTPUT
+
+      - name: Create or update PR
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        id: create-pull-request
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          title: "${{steps.version-commit.outputs.message}}"
+          body: |
+            🤖 I have created a release **squib** **squob**
+
+            Merging this PR will publish v${{steps.release-as.outputs.version}} to npm under the `maintenance-v5` dist-tag 🚀
+
+            ${{steps.release-notes.outputs.notes}}
+          commit-message: "${{steps.version-commit.outputs.message}}"
+          branch: ci/release-v5
+          labels: "release:v5"
+          sign-commits: true
+          base: v5
+          team-reviewers: "@sanity-io/studio"
+          draft: true

--- a/.github/workflows/release-v5.yml
+++ b/.github/workflows/release-v5.yml
@@ -1,0 +1,169 @@
+name: Release @v5
+
+on:
+  push:
+    branches:
+      - v5
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Only run NPM publishing
+        required: true
+        default: false
+        type: boolean
+
+permissions: {}
+
+jobs:
+  build-and-validate:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.head_commit.message, 'chore(release): publish ')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    outputs:
+      version: ${{ steps.release-as.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup
+
+      - name: Build
+        run: pnpm build --output-logs=full --log-order=grouped
+
+      - name: Get version
+        id: release-as
+        run: |
+          version=$(jq -r .version package.json)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Validate version
+        run: |
+          echo "Release version: $RELEASE_AS"
+          if [[ ! "$RELEASE_AS" =~ ^5\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid version for a v5 maintenance release: $RELEASE_AS"
+            exit 1
+          fi
+        env:
+          RELEASE_AS: ${{ steps.release-as.outputs.version }}
+
+  git-operations:
+    if: ${{ github.event.inputs.publish != 'true' }}
+    needs: build-and-validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Configure git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Tag and push version
+        run: |
+          git tag v$RELEASE_AS -m v$RELEASE_AS
+          git push origin v$RELEASE_AS
+        env:
+          RELEASE_AS: ${{ needs.build-and-validate.outputs.version}}
+
+  npm-publish:
+    needs: [build-and-validate, git-operations]
+    if: always() && needs.build-and-validate.result == 'success' && (needs.git-operations.result == 'success' || needs.git-operations.result == 'skipped')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # to enable use of OIDC for npm provenance
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      EXPECTED_NPM_USER: sanity-svc.npm
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+
+      - name: Build
+        run: pnpm build --output-logs=full --log-order=grouped
+
+      - name: Set publishing config
+        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_PUBLISH_TOKEN}"
+        env:
+          NPM_PUBLISH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}
+
+      - name: Check valid token
+        run: |
+          WHOAMI_RESULT=$(pnpm whoami)
+          echo "pnpm whoami result: $WHOAMI_RESULT"
+          if [ "$WHOAMI_RESULT" != "$EXPECTED_NPM_USER" ]; then
+            echo "Error: pnpm whoami returned '$WHOAMI_RESULT', expected '$EXPECTED_NPM_USER'"
+            exit 1
+          fi
+          echo "✅ npm authentication validated - using $EXPECTED_NPM_USER account"
+
+      - name: Publish packages to npm
+        run: pnpm -r publish --tag maintenance-v5 --provenance
+
+  bundle-upload:
+    needs: npm-publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup
+
+      - name: Build
+        run: pnpm build --output-logs=full --log-order=grouped
+
+      - name: Build bundles for staging
+        env:
+          # sets the __SANITY_STAGING__ global variable to true in built bundles
+          SANITY_INTERNAL_ENV: "staging"
+        run: pnpm run build:bundle
+
+      - name: Upload bundles to staging bucket
+        env:
+          GOOGLE_PROJECT_ID: ${{ secrets.GCS_STAGING_PROJECT_ID }}
+          GCLOUD_SERVICE_KEY: ${{ secrets.GCS_STAGING_SERVICE_KEY }}
+          GCLOUD_BUCKET: ${{ secrets.GCS_STAGING_BUCKET }}
+        # maintenance releases are published by version only and must not move
+        # the latest/next bundle tags
+        run: pnpm bundle-manager publish
+
+      - name: Build bundles for production
+        run: pnpm run build:bundle
+
+      - name: Upload bundles to production bucket
+        env:
+          GOOGLE_PROJECT_ID: ${{ secrets.GCS_PRODUCTION_PROJECT_ID }}
+          GCLOUD_SERVICE_KEY: ${{ secrets.GCS_PRODUCTION_SERVICE_KEY }}
+          GCLOUD_BUCKET: ${{ secrets.GCS_PRODUCTION_BUCKET }}
+        # maintenance releases are published by version only and must not move
+        # the latest/next bundle tags
+        run: pnpm bundle-manager publish
+
+  notify-on-failure:
+    needs: [npm-publish, bundle-upload]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_CI_ALERTS }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":alert-dot: The workflow \"${{github.workflow}}\" on <${{ github.server_url }}/${{ github.repository }}|${{github.repository}}> failed in branch <${{ github.server_url }}/${{ github.repository }}/tree/${{github.ref_name}}|${{github.ref_name}}> (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run >)"
+            }


### PR DESCRIPTION
### Description

v6 is releasing soon, at which point v5 becomes the maintenance line. This adds the v5 equivalents of the v4 maintenance release workflows (`create-v4-release-pr.yml` / `release-v4.yml`, which live on the `v4` branch) so that v5 maintenance releases are automated from day one. Both workflows trigger only on pushes to a `v5` branch, so they are inert on `main` — but landing them here means the `v5` branch inherits them automatically when it is cut at the v6 release point, instead of needing a follow-up PR against the new branch like we did for v4 (#12174).

The v4 workflows could not be ported directly because they predate the lerna → `@repo/release-notes` migration (#12513) and `lerna.json` no longer exists. These are instead derived from main's current `create-release-pr.yml` / `release-latest.yml`, with the same deliberate adaptations the v4 versions made: npm publish under a `maintenance-v5` dist-tag, bundle uploads without moving the `latest`/`next` tags, and no typedoc/sanity.io-changelog/GitHub-release jobs. The sanity.io changelog machinery (`generate-changelog`, `draft-release-notes`) was also left out because it hardcodes `branch: 'main'` in `getCommits`; the commands the v5 flow does use (`bump`, `write-changelog-files`) are branch-agnostic. Release notes for the release PR body come from `write-changelog-files --dryRun`, which prints the root changelog entry.

### What to review

- `release-v5.yml`: the version validation now requires a `5.x.y` version (stricter than v4's any-semver check) — a guard against publishing a wrong major from the maintenance branch
- `create-v5-release-pr.yml`: the PR-body release notes via `write-changelog-files --dryRun` are new (v4 used the removed `release:notes` script)
- Whether dropping the sanity.io changelog / GitHub release / typedoc jobs for maintenance releases matches expectations (it matches the v4 precedent)
- One open question: once the `v5` branch is cut, these two files can optionally be deleted from `main` again

### Testing

No automated tests — workflow-only change. Validated with `prettier --check` (passes) and `zizmor` (no medium/high findings; remaining low/info findings are the same patterns present in the existing release workflows). The workflows cannot run until a `v5` branch exists.

### Notes for release

N/A – Internal only