### PR TITLE
fix(structure): make delete dialog copy count-aware

### DIFF
--- a/e2e/tests/document-actions/delete.spec.ts
+++ b/e2e/tests/document-actions/delete.spec.ts
@@ -15,7 +15,7 @@ test(`unpublished documents can be deleted`, async ({page, createDraftDocument})
 
   await page.getByTestId('action-menu-button').click()
   await page.getByTestId('action-Delete').click()
-  await page.getByRole('button', {name: 'Delete all versions'}).click()
+  await page.getByRole('button', {name: 'Delete document'}).click()
 
   await expect(page.getByText('The document was successfully deleted')).toBeVisible()
 })
@@ -35,7 +35,7 @@ test(`published documents can be deleted`, async ({page, createDraftDocument}) =
 
   await page.getByTestId('action-menu-button').click()
   await page.getByTestId('action-Delete').click()
-  await page.getByRole('button', {name: 'Delete all versions'}).click()
+  await page.getByRole('button', {name: 'Delete document'}).click()
 
   await expect(page.getByText('The document was successfully deleted')).toBeVisible()
 })
@@ -65,7 +65,7 @@ test(`deleted document shows the right name from last revision`, async ({
   // Delete the document
   await page.getByTestId('action-menu-button').click()
   await page.getByTestId('action-Delete').click()
-  await page.getByRole('button', {name: 'Delete all versions'}).click()
+  await page.getByRole('button', {name: 'Delete document'}).click()
 
   // Wait for deletion to complete
   await expect(page.getByText('The document was successfully deleted')).toBeVisible()

--- a/e2e/tests/document-actions/delete.spec.ts
+++ b/e2e/tests/document-actions/delete.spec.ts
@@ -15,7 +15,7 @@ test(`unpublished documents can be deleted`, async ({page, createDraftDocument})
 
   await page.getByTestId('action-menu-button').click()
   await page.getByTestId('action-Delete').click()
-  await page.getByRole('button', {name: 'Delete document'}).click()
+  await page.getByTestId('confirm-button').click()
 
   await expect(page.getByText('The document was successfully deleted')).toBeVisible()
 })
@@ -35,7 +35,7 @@ test(`published documents can be deleted`, async ({page, createDraftDocument}) =
 
   await page.getByTestId('action-menu-button').click()
   await page.getByTestId('action-Delete').click()
-  await page.getByRole('button', {name: 'Delete document'}).click()
+  await page.getByTestId('confirm-button').click()
 
   await expect(page.getByText('The document was successfully deleted')).toBeVisible()
 })
@@ -65,7 +65,7 @@ test(`deleted document shows the right name from last revision`, async ({
   // Delete the document
   await page.getByTestId('action-menu-button').click()
   await page.getByTestId('action-Delete').click()
-  await page.getByRole('button', {name: 'Delete document'}).click()
+  await page.getByTestId('confirm-button').click()
 
   // Wait for deletion to complete
   await expect(page.getByText('The document was successfully deleted')).toBeVisible()

--- a/e2e/tests/document-actions/liveEdit.spec.ts
+++ b/e2e/tests/document-actions/liveEdit.spec.ts
@@ -30,8 +30,9 @@ test(`liveEdited document can be created, edited, and deleted`, async ({
   await expect(deleteAction).toBeVisible()
   await deleteAction.click()
   await expect(page.getByTestId('pane-footer-document-status')).toBeHidden()
-  await expect(page.getByRole('button', {name: 'Delete all versions'})).toBeVisible()
-  await page.getByRole('button', {name: 'Delete all versions'}).click()
+  const confirmDeleteButton = page.getByTestId('confirm-button')
+  await expect(confirmDeleteButton).toBeVisible()
+  await confirmDeleteButton.click()
 
   await expect(page.getByText('The document was successfully deleted')).toBeVisible()
 })

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx
@@ -80,10 +80,12 @@ export function ConfirmDeleteDialog({
     hasUnknownDatasetNames,
   } = useReferringDocuments(id)
   const documentTitle = <DocTitle document={useMemo(() => ({_id: id, _type: type}), [id, type])} />
-  const showConfirmButton = !isLoading
   const {data: documentVersions, loading: versionsLoading} = useDocumentVersions({
     documentId: getPublishedId(id),
   })
+  // Wait for the version count too, so the button copy doesn't flash from
+  // "Delete all versions" to "Delete document" while the count loads
+  const showConfirmButton = !isLoading && !versionsLoading
 
   const handleConfirm = useCallback(() => {
     onConfirm(documentVersions, {
@@ -107,8 +109,14 @@ export function ConfirmDeleteDialog({
           ? {
               text:
                 totalCount > 0
-                  ? t('confirm-delete-dialog.confirm-anyway-button.text', {context: action})
-                  : t('confirm-delete-dialog.confirm-button.text', {context: action}),
+                  ? t('confirm-delete-dialog.confirm-anyway-button.text', {
+                      context: action,
+                      count: documentVersions.length,
+                    })
+                  : t('confirm-delete-dialog.confirm-button.text', {
+                      context: action,
+                      count: documentVersions.length,
+                    }),
               onClick: handleConfirm,
             }
           : undefined,

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
@@ -82,6 +82,7 @@ export function ConfirmDeleteDialogBody({
             t={t}
             i18nKey="confirm-delete-dialog.confirmation.text"
             context={action}
+            values={{count: documentVersions.length}}
             components={{DocumentTitle: () => <strong>{documentTitle}</strong>}}
           />
         </Text>

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/__tests__/ConfirmDeleteDialog.test.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/__tests__/ConfirmDeleteDialog.test.tsx
@@ -16,8 +16,11 @@ vi.mock('../useReferringDocuments', () => ({
   useReferringDocuments: vi.fn(),
 }))
 
-vi.mock('../ConfirmDeleteDialogBody', () => ({
-  ConfirmDeleteDialogBody: () => <div data-testid="dialog-body" />,
+// Keep the real ConfirmDeleteDialogBody so the count-aware confirmation copy is
+// exercised; only stub VersionsPreviewList, which previews each version through
+// the preview store (no data in this test).
+vi.mock('../VersionsPreviewList', () => ({
+  VersionsPreviewList: () => null,
 }))
 
 vi.mock('../../DocTitle', () => ({
@@ -59,6 +62,8 @@ describe('ConfirmDeleteDialog', () => {
 
     expect(await screen.findByText('Delete document')).toBeInTheDocument()
     expect(screen.queryByText('Delete all versions')).not.toBeInTheDocument()
+    // The body confirmation copy is singular too.
+    expect(screen.getByText('Are you sure you want to delete this document?')).toBeInTheDocument()
   })
 
   it('uses all-versions copy when multiple versions exist', async () => {
@@ -70,6 +75,10 @@ describe('ConfirmDeleteDialog', () => {
     })
 
     expect(await screen.findByText('Delete all versions')).toBeInTheDocument()
+    // The body confirmation copy is the plural variant.
+    expect(
+      screen.getByText('Are you sure you want to delete all the versions of this document?'),
+    ).toBeInTheDocument()
   })
 
   it('uses single-document copy on the delete-anyway button when references exist', async () => {

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/__tests__/ConfirmDeleteDialog.test.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/__tests__/ConfirmDeleteDialog.test.tsx
@@ -1,0 +1,105 @@
+import {render, screen} from '@testing-library/react'
+import {useDocumentVersions} from 'sanity'
+import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {structureUsEnglishLocaleBundle} from '../../../i18n'
+import {ConfirmDeleteDialog} from '../ConfirmDeleteDialog'
+import {useReferringDocuments} from '../useReferringDocuments'
+
+vi.mock('sanity', async (importActual) => ({
+  ...((await importActual()) as Record<string, unknown>),
+  useDocumentVersions: vi.fn(),
+}))
+
+vi.mock('../useReferringDocuments', () => ({
+  useReferringDocuments: vi.fn(),
+}))
+
+vi.mock('../ConfirmDeleteDialogBody', () => ({
+  ConfirmDeleteDialogBody: () => <div data-testid="dialog-body" />,
+}))
+
+vi.mock('../../DocTitle', () => ({
+  DocTitle: () => <span>Doc title</span>,
+}))
+
+const mockUseDocumentVersions = useDocumentVersions as Mock<typeof useDocumentVersions>
+const mockUseReferringDocuments = useReferringDocuments as Mock<typeof useReferringDocuments>
+
+const noReferences = {
+  internalReferences: {totalCount: 0, references: []},
+  crossDatasetReferences: {totalCount: 0, references: []},
+  isLoading: false,
+  totalCount: 0,
+  projectIds: [],
+  datasetNames: [],
+  hasUnknownDatasetNames: false,
+} as unknown as ReturnType<typeof useReferringDocuments>
+
+const withVersions = (count: number) =>
+  ({
+    data: Array.from({length: count}, (_, i) => `versions.r${i}.doc`),
+    loading: false,
+  }) as unknown as ReturnType<typeof useDocumentVersions>
+
+describe('ConfirmDeleteDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseReferringDocuments.mockReturnValue(noReferences)
+  })
+
+  it('uses single-document copy when only one version exists', async () => {
+    mockUseDocumentVersions.mockReturnValue(withVersions(1))
+    const wrapper = await createTestProvider({resources: [structureUsEnglishLocaleBundle]})
+
+    render(<ConfirmDeleteDialog id="doc1" type="post" onCancel={vi.fn()} onConfirm={vi.fn()} />, {
+      wrapper,
+    })
+
+    expect(await screen.findByText('Delete document')).toBeInTheDocument()
+    expect(screen.queryByText('Delete all versions')).not.toBeInTheDocument()
+  })
+
+  it('uses all-versions copy when multiple versions exist', async () => {
+    mockUseDocumentVersions.mockReturnValue(withVersions(3))
+    const wrapper = await createTestProvider({resources: [structureUsEnglishLocaleBundle]})
+
+    render(<ConfirmDeleteDialog id="doc1" type="post" onCancel={vi.fn()} onConfirm={vi.fn()} />, {
+      wrapper,
+    })
+
+    expect(await screen.findByText('Delete all versions')).toBeInTheDocument()
+  })
+
+  it('uses single-document copy on the delete-anyway button when references exist', async () => {
+    mockUseDocumentVersions.mockReturnValue(withVersions(1))
+    mockUseReferringDocuments.mockReturnValue({
+      ...noReferences,
+      totalCount: 2,
+    } as unknown as ReturnType<typeof useReferringDocuments>)
+    const wrapper = await createTestProvider({resources: [structureUsEnglishLocaleBundle]})
+
+    render(<ConfirmDeleteDialog id="doc1" type="post" onCancel={vi.fn()} onConfirm={vi.fn()} />, {
+      wrapper,
+    })
+
+    expect(await screen.findByText('Delete anyway')).toBeInTheDocument()
+    expect(screen.queryByText('Delete all versions anyway')).not.toBeInTheDocument()
+  })
+
+  it('hides the confirm button while the version count loads', async () => {
+    mockUseDocumentVersions.mockReturnValue({data: [], loading: true} as unknown as ReturnType<
+      typeof useDocumentVersions
+    >)
+    const wrapper = await createTestProvider({resources: [structureUsEnglishLocaleBundle]})
+
+    render(<ConfirmDeleteDialog id="doc1" type="post" onCancel={vi.fn()} onConfirm={vi.fn()} />, {
+      wrapper,
+    })
+
+    expect(screen.queryByText('Delete document')).not.toBeInTheDocument()
+    expect(screen.queryByText('Delete all versions')).not.toBeInTheDocument()
+    expect(screen.queryByText('Delete all versions anyway')).not.toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -387,14 +387,28 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'confirm-delete-dialog.cdr-table.project-id.label': 'Project ID',
   /** The text in the "Delete anyway" button in the confirm delete dialog that confirms the action */
   'confirm-delete-dialog.confirm-anyway-button.text_delete': 'Delete all versions anyway',
+  /** The text in the "Delete anyway" button when the document only has a single version */
+  'confirm-delete-dialog.confirm-anyway-button.text_delete_one': 'Delete anyway',
+  /** The text in the "Delete anyway" button when the document has multiple versions */
+  'confirm-delete-dialog.confirm-anyway-button.text_delete_other': 'Delete all versions anyway',
   /** The text in the "Unpublish anyway" button in the confirm delete dialog that confirms the action */
   'confirm-delete-dialog.confirm-anyway-button.text_unpublish': 'Unpublish anyway',
   /** The text in the "Delete now" button in the confirm delete dialog that confirms the action */
   'confirm-delete-dialog.confirm-button.text_delete': 'Delete all versions',
+  /** The text in the "Delete now" button when the document only has a single version */
+  'confirm-delete-dialog.confirm-button.text_delete_one': 'Delete document',
+  /** The text in the "Delete now" button when the document has multiple versions */
+  'confirm-delete-dialog.confirm-button.text_delete_other': 'Delete all versions',
   /** The text in the "Unpublish now" button in the confirm delete dialog that confirms the action */
   'confirm-delete-dialog.confirm-button.text_unpublish': 'Unpublish now',
   /** If no referring documents are found, this text appears above the cancel and confirmation buttons */
   'confirm-delete-dialog.confirmation.text_delete':
+    'Are you sure you want to delete all the versions of this document?',
+  /** The confirmation text when the document only has a single version */
+  'confirm-delete-dialog.confirmation.text_delete_one':
+    'Are you sure you want to delete this document?',
+  /** The confirmation text when the document has multiple versions */
+  'confirm-delete-dialog.confirmation.text_delete_other':
     'Are you sure you want to delete all the versions of this document?',
   /** If no referring documents are found, this text appears above the cancel and confirmation buttons */
   'confirm-delete-dialog.confirmation.text_unpublish':


### PR DESCRIPTION
## Description

The delete confirmation dialog always said *"Are you sure you want to delete **all the versions** of this document?"* with a **"Delete all versions"** button — even when the document had a single version (e.g. just a draft, nothing published or in a release). Fixes [SAPP-3700](https://linear.app/sanity/issue/SAPP-3700).

The dialog already fetches every variant via `useDocumentVersions`, but never passed the count to the copy.

**Fix:** count-aware i18next context+plural keys (same mechanism already used by `cdr-summary.subtitle` in this dialog). With a single version:
- confirmation → *"Are you sure you want to delete this document?"*
- confirm button → *"Delete document"*
- delete-anyway button → *"Delete anyway"*

Multiple versions keep the existing "all versions" wording.

Also gates the confirm button on the version count finishing loading (`!versionsLoading`) so the copy doesn't briefly flash the all-versions wording while the count resolves (it defaults to `[]`).

**Unpublish is unaffected:** it has no plural variants, and i18next resolves `key_context_plural → key_context → key`, so `text_unpublish` still resolves. The base `text_delete` keys are kept as fallbacks for other locales until retranslated.

## What to review

- New `_delete_one` / `_delete_other` keys in `resources.ts` (base keys retained).
- `count` passed to the two `t()` calls in `ConfirmDeleteDialog.tsx` + `showConfirmButton` gated on `!versionsLoading`.
- `values={{count}}` on the confirmation `Translate` in `ConfirmDeleteDialogBody.tsx`.

> The exact wording is low-risk and matches the dialog header ("Delete document?"), but worth a quick product-copy sign-off. A 2-variant document (draft + published) still shows "all versions" — matches current behavior; the issue only flags the single-variant case.

## Testing

New `ConfirmDeleteDialog.test.tsx` (4 cases): single-version copy, multi-version copy, single-version delete-anyway copy, and confirm button hidden while the count loads. Typecheck clean.

## Notes for release

The delete confirmation dialog now uses singular copy ("Delete document" / "Are you sure you want to delete this document?") when a document has only one version, instead of always saying "all versions".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and loading-gating only in the delete confirmation UI; delete behavior and unpublish paths are unchanged aside from safer button timing.
> 
> **Overview**
> The structure **delete confirmation dialog** no longer always says “all versions.” It passes `documentVersions.length` into i18next plural keys so a **single version** gets *“Delete document”* / *“Are you sure you want to delete this document?”* (and *“Delete anyway”* when references exist); **multiple versions** keep the existing “all versions” wording. **Unpublish** copy is unchanged.
> 
> The confirm button is hidden until **referring documents and version list** finish loading (`!versionsLoading`), avoiding a brief flash of plural button text while the count resolves.
> 
> New **`_delete_one` / `_delete_other`** strings were added in `resources.ts` (base keys kept as fallbacks). **E2E** delete flows click `confirm-button` instead of matching the old “Delete all versions” label. **Unit tests** cover single vs multi-version copy, delete-anyway singular copy, and confirm hidden while versions load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed2d0b028b1beec720f94ed80fcf0a8ce1cdc751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->