### PR TITLE
test(e2e): fix internationalized array locators for plugin v5

### DIFF
--- a/dev/test-studio/preview/InternationalizedArrayTest.tsx
+++ b/dev/test-studio/preview/InternationalizedArrayTest.tsx
@@ -9,10 +9,12 @@ export function InternationalizedArrayTest(): React.JSX.Element {
     {
       _id: string
       title: string | null
-      titles: {_key: string; value: string}[] | null
+      // `language` is set in sanity-plugin-internationalized-array v5+ data,
+      // while v4 data stores the language id in `_key`
+      titles: {_key: string; language?: string; value: string}[] | null
     }[]
   >(
-    /* groq */ `*[_type == "internationalizedArrayTest"]{_id,"title":title[_key == "en"].value,"titles": title[_key != "en" && defined(value)]{_key,value}}`,
+    /* groq */ `*[_type == "internationalizedArrayTest"]{_id,"title":title[language == "en" || _key == "en"].value,"titles": title[language != "en" && _key != "en" && defined(value)]{_key,language,value}}`,
   )
 
   if (error) {
@@ -56,13 +58,13 @@ export function InternationalizedArrayTest(): React.JSX.Element {
           >
             <h1>{item.title || 'Untitled'}</h1>
             <dl>
-              {item.titles?.map(({_key, value}) => (
+              {item.titles?.map(({_key, language, value}) => (
                 <Fragment key={_key}>
                   <dt
                     data-sanity={dataAttribute.scope(['title', {_key}]).toString()}
                     data-sanity-drag-group={item._id}
                   >
-                    {displayNames.of(_key)}
+                    {displayNames.of(language ?? _key)}
                   </dt>
                   <dd>{value}</dd>
                 </Fragment>

--- a/e2e/tests/enhanced-object-dialog/componentItemSmoke.spec.ts
+++ b/e2e/tests/enhanced-object-dialog/componentItemSmoke.spec.ts
@@ -23,7 +23,10 @@ test.describe('Enhanced Object Dialog - schema with component item and input smo
   test(`opening - when clicking the internationalized array string field, the modal should not open`, async ({
     page,
   }) => {
-    const input = page.getByTestId('field-greeting[_key=="en"].value').getByTestId('string-input')
+    // In sanity-plugin-internationalized-array v5, item `_key`s are random (the
+    // language lives in a dedicated `language` field), so target the value
+    // input by its language label instead of a hardcoded `_key`
+    const input = page.getByTestId('field-greeting').getByRole('textbox', {name: 'EN'})
     await expect(input).toBeEnabled()
     await input.click()
     await expect(page.getByTestId('nested-object-dialog')).not.toBeVisible()
@@ -35,17 +38,18 @@ test.describe('Enhanced Object Dialog - schema with component item and input smo
   test(`opening - when clicking the internationalized array string field, and click the next one, the modal should not open`, async ({
     page,
   }) => {
-    const input = page.getByTestId('field-greeting[_key=="en"].value').getByTestId('string-input')
+    const greetingField = page.getByTestId('field-greeting')
+    const input = greetingField.getByRole('textbox', {name: 'EN'})
     await expect(input).toBeVisible()
     await expect(input).toBeEnabled()
     await input.click()
     await expect(page.getByTestId('nested-object-dialog')).not.toBeVisible()
     await input.fill('Test')
 
-    await page.getByRole('button', {name: 'FR'}).click()
+    await greetingField.getByRole('button', {name: 'FR'}).click()
     await expect(page.getByTestId('nested-object-dialog')).not.toBeVisible()
 
-    const inputFr = page.getByTestId('field-greeting[_key=="fr"].value').getByTestId('string-input')
+    const inputFr = greetingField.getByRole('textbox', {name: 'FR'})
     await expect(inputFr).toBeVisible()
     await expect(inputFr).toBeEnabled()
     await inputFr.click()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

E2E has been red on `main` since `sanity-plugin-internationalized-array` was bumped from v4 to v5 (#12665). v5 moved the language id from `_key` to a dedicated `language` field, making `_key` a random string — so the hardcoded `field-greeting[_key=="en"].value` test ids in `componentItemSmoke.spec.ts` no longer match anything (`element(s) not found` in both chromium and firefox, shard 2). This is locator drift, not a product regression: the CI artifact DOM snapshot shows the Greeting field rendering correctly (default `EN` item present, `FR` add button enabled); the tests fail before reaching their actual "modal should not open" assertions.

The new locators target the value inputs by their accessible language label (`EN`/`FR`, from the plugin's default `languageDisplay: 'codeOnly'`) scoped to `field-greeting`, which is stable across random keys. A `_key=="[^"]+"` regex testid (the convention used by neighboring specs) was ruled out for the second test because both language items match it, requiring positional `.nth()` filtering.

Also makes the test-studio presentation preview for `internationalizedArrayTest` tolerant of both data formats: the GROQ filter accepts `language == "en" || _key == "en"` (migration guide step 1, since the dataset still holds v4-format documents), and `Intl.DisplayNames.of()` now receives `language ?? _key` — a random v5 `_key` is an invalid language tag and would throw.

### What to review

- `e2e/tests/enhanced-object-dialog/componentItemSmoke.spec.ts` — the two updated tests; behavior and assertions are unchanged, only locators.
- `dev/test-studio/preview/InternationalizedArrayTest.tsx` — backwards-compatible GROQ filter and language display fallback.

### Testing

- E2E secrets aren't available locally, so validation is via CI on this PR (the previously failing `playwright-test (chromium|firefox, 2, 4)` shards).
- Verified locator strategy against the failing run's `error-context.md` DOM snapshot (`textbox "EN"`, `button "FR"` inside the Greeting field).
- `oxfmt`, `oxlint`, `eslint`, and `tsgo` pass on the changed files.

### Notes for release

N/A – Internal only (e2e tests and dev studio preview)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1d59a68-8d89-499a-a674-2f66ed8767c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1d59a68-8d89-499a-a674-2f66ed8767c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

