### PR TITLE
chore(sanity): promote vite to production dependency

### DIFF
--- a/packages/@repo/package.bundle/src/package.bundle.ts
+++ b/packages/@repo/package.bundle/src/package.bundle.ts
@@ -15,7 +15,7 @@ export const defaultConfig: UserConfig = {
     'process.env': {},
   },
   plugins: [
-    ...viteReact(),
+    viteReact(),
     babel({presets: [reactCompilerPreset({target: '19'})]}),
     vanillaExtractPlugin(),
     stripCssImportsPlugin(),

--- a/packages/@sanity/vision/vitest.config.mts
+++ b/packages/@sanity/vision/vitest.config.mts
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   plugins: [
     vanillaExtractPlugin(),
-    ...viteReact(),
+    viteReact(),
     babel({presets: [reactCompilerPreset({target: '19'})]}),
   ],
 })

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -256,6 +256,7 @@
     "use-hot-module-reload": "^2.0.0",
     "use-sync-external-store": "^1.6.0",
     "uuid": "^11.1.0",
+    "vite": "catalog:",
     "web-vitals": "^5.1.0",
     "xstate": "^5.32.0"
   },
@@ -306,7 +307,6 @@
     "styled-components": "catalog:",
     "swr": "2.2.5",
     "tsx": "^4.22.4",
-    "vite": "catalog:",
     "vitest": "catalog:",
     "vitest-browser-react": "catalog:",
     "vitest-package-exports": "^1.1.2"

--- a/packages/sanity/vitest.browser.config.mts
+++ b/packages/sanity/vitest.browser.config.mts
@@ -1,5 +1,6 @@
+import babel from '@rolldown/plugin-babel'
 import {vanillaExtractPlugin} from '@vanilla-extract/vite-plugin'
-import react from '@vitejs/plugin-react'
+import viteReact, {reactCompilerPreset} from '@vitejs/plugin-react'
 import {playwright} from '@vitest/browser-playwright'
 import {defaultClientConditions, defineConfig} from 'vite'
 
@@ -24,9 +25,8 @@ if (selectedBrowser && browsers.length === 0) {
 export default defineConfig({
   plugins: [
     vanillaExtractPlugin(),
-    react({
-      babel: {plugins: [['babel-plugin-react-compiler', {target: '19'}]]},
-    }),
+    viteReact(),
+    babel({presets: [reactCompilerPreset({target: '19'})]}),
   ],
   resolve: {
     conditions: ['monorepo', ...defaultClientConditions],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11685,49 +11685,6 @@ packages:
       yaml:
         optional: true
 
-  vite@8.0.15:
-    resolution: {integrity: sha512-qpgllRxrLqwsMAGRdLhsEr9bepaOQk1rxH1xT2coBXLaEB/bfkqQj1j7RMxwMfnYrvO1ZnFMiwX+wBVgnsyn0g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.18
-      esbuild: ^0.27.0 || ^0.28.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      '@vitejs/devtools':
-        optional: true
-      esbuild:
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -16563,7 +16520,7 @@ snapshots:
     dependencies:
       '@vanilla-extract/css': 1.20.1(babel-plugin-macros@3.1.0)
       '@vanilla-extract/integration': 8.0.10(babel-plugin-macros@3.1.0)
-      vite: 8.0.15(@types/node@24.13.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-node: 6.0.0(@types/node@24.13.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -22387,7 +22344,7 @@ snapshots:
       es-module-lexer: 2.1.0
       obug: 2.1.1
       pathe: 2.0.3
-      vite: 8.0.15(@types/node@24.13.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -22425,22 +22382,6 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
-      terser: 5.48.0
-      tsx: 4.22.4
-      yaml: 2.9.0
-
-  vite@8.0.15(@types/node@24.13.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.3
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 24.13.0
-      esbuild: 0.28.0
-      fsevents: 2.3.3
-      jiti: 2.7.0
       terser: 5.48.0
       tsx: 4.22.4
       yaml: 2.9.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1926,6 +1926,9 @@ importers:
       uuid:
         specifier: ^11.1.0
         version: 11.1.1
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       web-vitals:
         specifier: ^5.1.0
         version: 5.3.0
@@ -2071,9 +2074,6 @@ importers:
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
-      vite:
-        specifier: 'catalog:'
-        version: 8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@edge-runtime/vm@3.2.0)(@types/node@24.13.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))


### PR DESCRIPTION
### Description

`@sanity/runtime-cli` (via `@sanity/cli`) still depends on Vite 7, while the monorepo catalog pins Vite 8. That left two Vite majors in the tree and risked `@sanity/cli` resolving a different version than the studio toolchain.

Promoting `vite` from a devDependency to a production dependency on `sanity` forces Vite 8 at the package level so CLI and studio agree, while runtime-cli keeps its isolated Vite 7 subtree for functions/blueprints.

Also fixes `@vitejs/plugin-react` usage: `viteReact()` returns a single plugin, not an array — spread was incorrect. Browser/vitest configs now use `@rolldown/plugin-babel` with `reactCompilerPreset` to match the Vite 8 plugin API.

### What to review

- `packages/sanity/package.json` — `vite` moved to `dependencies` (will ship transitively with published `sanity`)
- `packages/sanity/vitest.browser.config.mts`, `packages/@sanity/vision/vitest.config.mts`, `packages/@repo/package.bundle/src/package.bundle.ts` — plugin-react API alignment

### Testing

- `pnpm install` — lockfile resolves `sanity` → `vite@8.0.16`, `@sanity/runtime-cli` → `vite@7.3.5` (isolated)
- CI unit/browser tests

### Notes for release

N/A – Internal only

Made with [Cursor](https://cursor.com)