### PR TITLE
fix(release-notes): credit commit author instead of merging PR's author

### DIFF
--- a/packages/@repo/release-notes/bin/release-notes.ts
+++ b/packages/@repo/release-notes/bin/release-notes.ts
@@ -13,7 +13,7 @@ import {publishReleases} from '../src/commands/publishReleases'
 import {writeChangelogFiles} from '../src/commands/writeChangelogFiles'
 import {writeCommitCheck} from '../src/commands/writeCommitCheck'
 import {writePrChecks} from '../src/commands/writePrChecks'
-import {type KnownEnvVar, type PullRequest} from '../src/types'
+import {type CommitAuthor, type KnownEnvVar, type PullRequest} from '../src/types'
 import {stripPr} from '../src/utils/stripPrNumber'
 
 function getAdminStudioUrl(): string {
@@ -263,7 +263,10 @@ type GenerateChangeLogResult = {
     draft: DraftId
   }
   commitsWithPrs: Array<
-    Exclude<{conventionalCommit: CommitBase & CommitMeta; pr: any}, typeof pMapSkip>
+    Exclude<
+      {conventionalCommit: CommitBase & CommitMeta; pr?: any; commitAuthor?: any},
+      typeof pMapSkip
+    >
   >
   releaseId: string
 }
@@ -283,6 +286,7 @@ function generateChangeLogSummary(
           .map((entry) =>
             formatEntry({
               pr: entry.pr,
+              commitAuthor: entry.commitAuthor,
               conventionalCommit: entry.conventionalCommit,
               changelogDocumentId,
               releaseId,
@@ -321,11 +325,13 @@ ${entriesSection}
 function formatEntry({
   conventionalCommit,
   pr,
+  commitAuthor,
   changelogDocumentId,
   releaseId,
 }: {
   conventionalCommit: Commit
   pr: PullRequest | undefined
+  commitAuthor: CommitAuthor | undefined
   changelogDocumentId: GenerateChangeLogResult['changelogDocumentId']
   releaseId: GenerateChangeLogResult['releaseId']
 }) {
@@ -342,7 +348,8 @@ function formatEntry({
     )
   }
 
-  const byline = pr?.user?.login ? `[${pr.user.login}](${pr.user.html_url})` : '—'
+  const author = commitAuthor ?? pr?.user
+  const byline = author?.login ? `[${author.login}](${author.html_url})` : '—'
   const prCell = pr ? `[#${pr.number}](${pr.html_url})` : '—'
   const releaseNoteLink = `[:pencil:&nbsp;Edit](${changelogEntryUrl})`
   return `${byline} | ${originalCommitMessage} | ${prCell} | ${conventionalCommit.hash} | ${releaseNoteLink}`

--- a/packages/@repo/release-notes/src/commands/createOrUpdateChangelogDocs.ts
+++ b/packages/@repo/release-notes/src/commands/createOrUpdateChangelogDocs.ts
@@ -21,7 +21,7 @@ import {getClient} from '../client'
 import {STUDIO_PLATFORM_DOCUMENT_ID} from '../constants'
 import {type PullRequestInfo, type StudioChangelogEntry} from '../types'
 import {getCommits, getSemverTags} from '../utils/getCommits'
-import {getMergedPRForCommit} from '../utils/github'
+import {getCommitAuthor, getMergedPRForCommit} from '../utils/github'
 import {getSanityDocumentIdsForBaseVersion} from '../utils/ids'
 import {parseRenovateReleaseNotes} from '../utils/parseRenovateReleaseNotes'
 import {
@@ -152,7 +152,7 @@ function createEntry(client: SanityClient, info: PullRequestInfo, {dryRun}: {dry
 
 async function getReleaseNotesMutations(
   client: SanityClient,
-  {pr, conventionalCommit}: PullRequestInfo,
+  {pr, commitAuthor, conventionalCommit}: PullRequestInfo,
   options: {dryRun?: boolean},
 ) {
   const cleanSubject = pr
@@ -178,19 +178,23 @@ async function getReleaseNotesMutations(
     conventionalCommit.scope === 'build' ||
     conventionalCommit.scope === 'test'
 
+  // Prefer the commit's git author over the PR user — when a commit lands on
+  // main through someone else's PR (e.g. a rebase-merged integration branch),
+  // the PR user is not the person who wrote the change.
+  const author = commitAuthor ?? pr?.user ?? undefined
+
   const entry: StudioChangelogEntry = {
     _type: 'changelogEntry',
     _key: conventionalCommit.hash!.slice(0, 8),
     pr: pr?.number,
-    author:
-      pr && pr.user
-        ? {
-            username: pr.user?.login,
-            url: pr.user?.html_url,
-            imageUrl: pr.user.avatar_url,
-            type: userType,
-          }
-        : undefined,
+    author: author
+      ? {
+          username: author.login,
+          url: author.html_url,
+          imageUrl: author.avatar_url,
+          type: author.type?.toLowerCase(),
+        }
+      : undefined,
     authorAssociation: pr?.author_association.toLowerCase(),
     exclude: excludeReleaseNotes,
     subject: cleanSubject,
@@ -246,12 +250,15 @@ async function ensureContentRelease(
   return {created}
 }
 
-async function fetchCommitPrs(commits: Commit[]) {
+async function fetchCommitPrs(commits: Commit[]): Promise<PullRequestInfo[]> {
   return pMap(
     commits,
     async (commit) => {
-      const pr = await getMergedPRForCommit('sanity-io', 'sanity', commit.hash!)
-      return {conventionalCommit: commit, pr}
+      const [pr, commitAuthor] = await Promise.all([
+        getMergedPRForCommit('sanity-io', 'sanity', commit.hash!, commit.header ?? undefined),
+        getCommitAuthor('sanity-io', 'sanity', commit.hash!),
+      ])
+      return {conventionalCommit: commit, pr, commitAuthor}
     },
     {concurrency: 4},
   )

--- a/packages/@repo/release-notes/src/types.ts
+++ b/packages/@repo/release-notes/src/types.ts
@@ -13,10 +13,16 @@ export type KnownEnvVar =
   | 'GITHUB_TOKEN'
 
 export type PullRequest =
-  RestEndpointMethodTypes['repos']['listPullRequestsAssociatedWithCommit']['response']['data'][number]
+  | RestEndpointMethodTypes['repos']['listPullRequestsAssociatedWithCommit']['response']['data'][number]
+  | RestEndpointMethodTypes['pulls']['get']['response']['data']
+
+export type CommitAuthor = NonNullable<
+  RestEndpointMethodTypes['repos']['getCommit']['response']['data']['author']
+>
 
 export type PullRequestInfo = {
   pr?: PullRequest
+  commitAuthor?: CommitAuthor
   conventionalCommit: Commit
 }
 

--- a/packages/@repo/release-notes/src/utils/__test__/github.test.ts
+++ b/packages/@repo/release-notes/src/utils/__test__/github.test.ts
@@ -1,0 +1,29 @@
+import {describe, expect, it} from 'vitest'
+
+import {getPrNumberFromSubject} from '../github'
+
+describe('getPrNumberFromSubject', () => {
+  it('returns the trailing PR number added by squash merge', () => {
+    expect(getPrNumberFromSubject('fix: bump @sanity/cli to ^7.1.0 (#13020)')).toBe(13020)
+  })
+
+  it('returns the last PR number for backported commits', () => {
+    expect(
+      getPrNumberFromSubject('fix(sanity): set touch-action on drag handle (#12931) (#12932)'),
+    ).toBe(12932)
+  })
+
+  it('returns undefined when the subject has no trailing PR number', () => {
+    expect(
+      getPrNumberFromSubject('feat(studio): remove deprecated `enableLegacySearch` option'),
+    ).toBeUndefined()
+  })
+
+  it('ignores PR numbers that are not at the end of the subject', () => {
+    expect(getPrNumberFromSubject('fix: revert (#123) related change')).toBeUndefined()
+  })
+
+  it('returns undefined for undefined subject', () => {
+    expect(getPrNumberFromSubject(undefined)).toBeUndefined()
+  })
+})

--- a/packages/@repo/release-notes/src/utils/github.ts
+++ b/packages/@repo/release-notes/src/utils/github.ts
@@ -1,6 +1,21 @@
 import {getOctokit} from '../octokit'
+import {type CommitAuthor, type PullRequest} from '../types'
 
-export async function getMergedPRForCommit(owner: string, repo: string, commitSha: string) {
+/**
+ * GitHub appends the PR number to the commit subject when squash-merging,
+ * e.g. `fix(core): something (#12345)`.
+ */
+export function getPrNumberFromSubject(subject: string | undefined): number | undefined {
+  const match = subject?.match(/\(#(\d+)\)\s*$/)
+  return match ? Number(match[1]) : undefined
+}
+
+export async function getMergedPRForCommit(
+  owner: string,
+  repo: string,
+  commitSha: string,
+  subject?: string,
+): Promise<PullRequest | undefined> {
   // Get PRs associated with the commit
   // see https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests
   const {data: prs} = await getOctokit().repos.listPullRequestsAssociatedWithCommit({
@@ -10,6 +25,50 @@ export async function getMergedPRForCommit(owner: string, repo: string, commitSh
     commit_sha: commitSha,
   })
 
-  // Find the merged PR (if any)
-  return prs.find((pr) => pr.merged_at !== null)
+  const mergedPrs = prs.filter((pr) => pr.merged_at !== null)
+
+  // A commit can be associated with several PRs, e.g. when it was merged into
+  // another branch through its own PR and later landed on main through a
+  // branch-integration PR. Trust the PR number GitHub put in the commit
+  // subject over the association list, so commits aren't attributed to the
+  // integration PR (and its author).
+  const subjectPrNumber = getPrNumberFromSubject(subject)
+  if (subjectPrNumber) {
+    const subjectPr = mergedPrs.find((pr) => pr.number === subjectPrNumber)
+    if (subjectPr) {
+      return subjectPr
+    }
+    // A rebase-merge rewrites commit SHAs, so the original PR may no longer be
+    // associated with the commit on main — fetch it directly instead.
+    const originalPr = await getOctokit()
+      .pulls.get({
+        owner,
+        repo,
+        // eslint-disable-next-line camelcase
+        pull_number: subjectPrNumber,
+      })
+      .then(
+        (response) => response.data,
+        () => undefined,
+      )
+    if (originalPr?.merged_at) {
+      return originalPr
+    }
+  }
+
+  return mergedPrs[0]
+}
+
+/**
+ * Returns the GitHub user matching the commit's git author, if any. Unlike the
+ * user of the PR that landed the commit on main, this stays correct when
+ * someone else's commits are merged through a rebase- or branch-integration PR.
+ */
+export async function getCommitAuthor(
+  owner: string,
+  repo: string,
+  commitSha: string,
+): Promise<CommitAuthor | undefined> {
+  const {data} = await getOctokit().repos.getCommit({owner, repo, ref: commitSha})
+  return data.author ?? undefined
 }


### PR DESCRIPTION
### Description

Release automation attributed every changelog entry to the opener of the PR that landed the commit on main, taken from the first merged PR in GitHub's commit→PR association list. When a PR is rebase-merged (like the v6 integration PR #13012), every commit gets a rewritten SHA that is only associated with the integration PR — so its opener was credited for everyone's commits, entries linked to the wrong PR, and release-note content was extracted from the wrong PR body (see the pending-changes table in #13021).

Two changes:

- Resolve the original PR from the `(#N)` suffix GitHub appends to squash-commit subjects, fetching it directly when the rewritten SHA is no longer associated with it. This fixes the PR link, the release-note extraction source, and subject cleanup.
- Attribute entries to the commit's git author (via the commits API) instead of the PR opener, falling back to the PR opener when GitHub can't match the author. This also covers commits with no PR suffix at all (e.g. commits pushed directly to an integration branch).

Matching on `merge_commit_sha` instead was ruled out: rebase merges rewrite SHAs, so the original PR's merge commit never matches the commit on main.

### What to review

Only `packages/@repo/release-notes` (internal tooling, nothing published):

- `src/utils/github.ts` — the PR selection order in `getMergedPRForCommit` and the new `getCommitAuthor`
- `src/commands/createOrUpdateChangelogDocs.ts` — author preference and fallback

Note: this adds one extra GitHub API call per commit (`repos.getCommit`), bounded by the existing concurrency limit.

### Testing

- New unit tests for `getPrNumberFromSubject` (trailing number, backport double-suffix, mid-subject numbers ignored)
- `pnpm --filter @repo/release-notes test` and `check:types` pass
- Diagnosis verified against real data: the v6 commits on main are authored by stipsan/Ash/jordanl17 et al. but were all credited to the #13012 opener in #13021

The end-to-end path (GitHub API calls) isn't covered by automated tests; it will be exercised by the next create-release-pr workflow run. Existing wrongly-attributed entries in the v6 changelog document are intentionally never overwritten by automation and must be deleted so the next run recreates them.

### Notes for release

N/A – Internal only (release tooling)
