### PR TITLE
fix(core): exclude dereference paths from groq2024 score boosts

### DIFF
--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
@@ -621,7 +621,7 @@ describe('createSearchQuery', () => {
     })
 
     // https://github.com/sanity-io/sanity/issues/4775
-    it('compiles reference paths from the preview selection to dereferenced GROQ', () => {
+    it('excludes reference-traversing preview paths from score()', () => {
       const referenceSchema = Schema.compile({
         types: [
           defineType({
@@ -658,11 +658,14 @@ describe('createSearchQuery', () => {
         '',
       )
 
-      // `subtitle: 'author.name'` is boosted via its dereferenced expression.
-      expect(query).toContain('author->name match text::query($__query), 5')
-      // The raw dotted path must not leak, and the number field selected in the
-      // preview must not be boosted.
-      expect(query).not.toContain('author.name match')
+      // Content Lake's `score()` rejects dereferences with "score() function
+      // received unexpected expression", so `subtitle: 'author.name'` must not
+      // be boosted — neither as `author->name` nor as the raw dotted path.
+      expect(query).not.toContain('author->name')
+      expect(query).not.toContain('author.name')
+      // Plain preview paths are still boosted, and the number field selected
+      // in the preview must not be.
+      expect(query).toContain('title match text::query($__query), 10')
       expect(query).not.toContain('publicationYear')
     })
   })

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
@@ -103,6 +103,12 @@ export function createSearchQuery(
       const path = entries[0].path.includes('[]')
         ? entries[0].path
         : compileFieldPath(entries[0].schemaType, entries[0].path)
+      // Content Lake's `score()` only accepts simple attribute paths in match
+      // expressions; a dereference fails the entire query with "score()
+      // function received unexpected expression".
+      if (path.includes('->')) {
+        return []
+      }
       return `boost(_type in ${JSON.stringify(entries.map((entry) => entry.typeName))} && ${path} match text::query($__query), ${entries[0].weight})`
     })
     .concat(baseMatch)


### PR DESCRIPTION
### Description

Since #12925, preview `select` paths that traverse references (e.g. `select: {subtitle: 'author.name'}`) are included in search weights and compiled to GROQ dereferences (`author->name`). The `groq2024` strategy embeds these in `score()` boosts, but Content Lake's `score()` only accepts simple attribute paths in match expressions — it rejects the entire query with `score() function received unexpected expression`. The result is that every scored groq2024 search (global search, reference search) fails for any searched type whose preview selects through a reference. Verified against a live dataset: `*[...] | score(boost(author->name match text::query("x"), 5), ...)` reproduces the API error verbatim; the same path in a plain filter works fine.

This fix drops dereference paths from `score()` boosts. They keep working in the `groqLegacy` strategy, which matches them in the filter instead — under groq2024 these fields simply don't contribute to ranking, same as before 5.31.0.

Alternatives considered:
- Moving the dereference match into the score clause unboosted, or into the filter — any expression inside `score()` hits the same backend restriction, and in scored mode adding it to the filter would change matching semantics (`&&` instead of contributing to score).
- Filtering in `deriveSearchWeightsFromType2024` — whether a dotted path traverses a reference is only known after `compileFieldPath` resolves it against the schema, so the check belongs at the boost construction site.

This regressed in 5.31.0 but only for studios opted into groq2024. Since main now makes groq2024 the default strategy (3d9442f5b3), this needs to land before the next release or it breaks search out of the box for any schema with reference-traversing previews.

### What to review

- `packages/sanity/src/core/search/groq2024/createSearchQuery.ts` — the guard dropping `->` paths from boosts
- `packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts` — the test from #12925 asserted the invalid output (groq-js, used locally, is permissive where Content Lake is not); it now asserts exclusion

Only the `sanity` package is affected, `groq2024` strategy only.

### Testing

Updated the regression test for #4775 to assert dereference paths never appear in the generated query while plain preview paths remain boosted. All 170 tests under `packages/sanity/src/core/search` pass. Backend behavior (rejection inside `score()`, acceptance in filters) verified manually with live GROQ queries against `ppsg7ml5/test`.

### Notes for release

Fixes "Reference search failed: score() function received unexpected expression" when searching with the `groq2024` search strategy. Searches involving document types whose preview `select` traverses a reference (e.g. `subtitle: 'author.name'`) no longer fail. These reference-traversed preview fields do not contribute to search ranking under `groq2024`, matching pre-5.31.0 behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
