### PR TITLE
ci(release): keep pnpm install output out of v5 release pr description

### DIFF
--- a/.github/workflows/create-v5-release-pr.yml
+++ b/.github/workflows/create-v5-release-pr.yml
@@ -47,6 +47,13 @@ jobs:
       - name: Update version
         run: pnpm --silent release-notes bump
 
+      - name: Sync lockfile and dependency state
+        # bump rewrites every package.json, which makes pnpm's verify-deps check
+        # consider node_modules stale. Without a full install here, the next pnpm
+        # invocation auto-installs and pollutes stdout — which below is captured
+        # as the PR description
+        run: pnpm install
+
       - name: Get version
         id: release-as
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
@@ -64,9 +71,6 @@ jobs:
 
       - name: Write CHANGELOG.md files
         run: pnpm --silent release-notes write-changelog-files --version=${{ steps.release-as.outputs.version }}
-
-      - name: Sync workspace lockfile
-        run: pnpm install --lockfile-only
 
       - name: Get version commit message
         id: version-commit

--- a/.github/workflows/create-v5-release-pr.yml
+++ b/.github/workflows/create-v5-release-pr.yml
@@ -58,6 +58,21 @@ jobs:
         id: release-as
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
 
+      - name: Block non-v5 releases
+        # a breaking-change commit (feat!:, fix!: or a BREAKING CHANGE footer) on
+        # this branch makes the version bump compute a new major version, which
+        # must never happen on the v5 maintenance branch
+        run: |
+          echo "Computed version: $RELEASE_AS"
+          if [[ ! "$RELEASE_AS" =~ ^5\. ]]; then
+            echo "::error::Computed version $RELEASE_AS is not a v5 maintenance release. Commits with breaking changes:"
+            git log --oneline "$(git describe --tags --abbrev=0 --first-parent)..HEAD" -E \
+              --grep='^[a-z]+(\([^)]*\))?!:' --grep='BREAKING CHANGE'
+            exit 1
+          fi
+        env:
+          RELEASE_AS: ${{ steps.release-as.outputs.version }}
+
       - name: Generate release notes
         # capture the root changelog entry before writing CHANGELOG.md files so it
         # can be used as the PR description


### PR DESCRIPTION
### What to review
- Fixes an issue causing stdout to appear in the release pr. See https://github.com/sanity-io/sanity/pull/13022
- Also included a guard against commits causing a major version bump
 
### Testing


### Notes for release
n/a