### PR TITLE
fix(core): exclude dereference paths from groq2024 score boosts

### DIFF
--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
@@ -621,7 +621,7 @@ describe('createSearchQuery', () => {
     })
 
     // https://github.com/sanity-io/sanity/issues/4775
-    it('compiles reference paths from the preview selection to dereferenced GROQ', () => {
+    it('excludes reference-traversing preview paths from score()', () => {
       const referenceSchema = Schema.compile({
         types: [
           defineType({
@@ -658,11 +658,14 @@ describe('createSearchQuery', () => {
         '',
       )
 
-      // `subtitle: 'author.name'` is boosted via its dereferenced expression.
-      expect(query).toContain('author->name match text::query($__query), 5')
-      // The raw dotted path must not leak, and the number field selected in the
-      // preview must not be boosted.
-      expect(query).not.toContain('author.name match')
+      // Content Lake's `score()` rejects dereferences with "score() function
+      // received unexpected expression", so `subtitle: 'author.name'` must not
+      // be boosted — neither as `author->name` nor as the raw dotted path.
+      expect(query).not.toContain('author->name')
+      expect(query).not.toContain('author.name')
+      // Plain preview paths are still boosted, and the number field selected
+      // in the preview must not be.
+      expect(query).toContain('title match text::query($__query), 10')
       expect(query).not.toContain('publicationYear')
     })
   })

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
@@ -103,6 +103,12 @@ export function createSearchQuery(
       const path = entries[0].path.includes('[]')
         ? entries[0].path
         : compileFieldPath(entries[0].schemaType, entries[0].path)
+      // Content Lake's `score()` only accepts simple attribute paths in match
+      // expressions; a dereference fails the entire query with "score()
+      // function received unexpected expression".
+      if (path.includes('->')) {
+        return []
+      }
       return `boost(_type in ${JSON.stringify(entries.map((entry) => entry.typeName))} && ${path} match text::query($__query), ${entries[0].weight})`
     })
     .concat(baseMatch)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Since #12925 (shipped in v5.31.0), preview `select` paths that traverse references (e.g. `select: {subtitle: 'author.name'}`) are included in search weights and compiled to GROQ dereferences (`author->name`). The `groq2024` strategy embeds these in `score()` boosts, but Content Lake's `score()` [does not accept dereferences](https://www.sanity.io/docs/specifications/groq-functions) — it rejects the entire query with `score() function received unexpected expression`. The result is that every scored `groq2024` search (global search, reference search) fails for any searched type whose preview selects through a reference, surfacing to users as "Reference search failed: score() function received unexpected expression". The regression slipped through because unit tests evaluate queries with groq-js, which intentionally does not enforce `score()` restrictions (see sanity-io/sanity#7496).

This fix drops dereference paths from `score()` boosts. The #4775 feature keeps working under `groqLegacy` (the v5 default strategy), which matches these paths in the filter and projection — both valid contexts for dereferences. Under `groq2024` these fields simply don't contribute to matching or ranking, same as before 5.31.0.

Alternatives considered:

- Reverting #12925 and re-opening #4775 — unnecessary: only the `groq2024` `score()` embedding is invalid; the `groqLegacy` part of the feature works.
- Moving the dereference match into the filter in scored mode — `[_score > 0]` would still drop documents that only match via the dereferenced field, and admitting score-0 documents changes ranking semantics; not appropriate for a regression hotfix.
- Filtering in `deriveSearchWeightsFromType2024` — whether a dotted path traverses a reference is only known after `compileFieldPath` resolves it against the schema (e.g. `slug.current` is dotted but not a reference traversal), so the check belongs at the boost construction site.

Same fix targeting `main` exists as #13025.

### What to review

- `packages/sanity/src/core/search/groq2024/createSearchQuery.ts` — the guard dropping `->` paths from boosts
- `packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts` — the test from #12925 asserted the invalid output; it now asserts exclusion

Only the `sanity` package is affected, `groq2024` strategy only. `groqLegacy` (weighted) output is unchanged.

### Testing

Updated the regression test for #4775 to assert dereference paths never appear in the generated `groq2024` query while plain preview paths remain boosted. All 170 tests under `packages/sanity/src/core/search` pass (including vitest typecheck). Verified the generated queries for a schema with `subtitle: 'author.name'`: `groq2024` no longer emits `->` inside `score()`; `groqLegacy` still matches `author->name` in the filter/projection where dereferences are valid.

### Notes for release

Fixes "Reference search failed: score() function received unexpected expression" when searching with the `groq2024` search strategy. Searches involving document types whose preview `select` traverses a reference (e.g. `subtitle: 'author.name'`) no longer fail. Note that these reference-traversed preview fields do not contribute to search matching or ranking under `groq2024` (matching pre-5.31.0 behavior); they remain searchable under the default `groqLegacy` strategy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5b4ca37-010c-4967-a7cd-f632a8073c57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5b4ca37-010c-4967-a7cd-f632a8073c57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

