### PR TITLE
chore(deps): bump @portabletext/sanity-bridge to ^3.1.1

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -173,7 +173,7 @@
     "@portabletext/plugin-paste-link": "^4.0.8",
     "@portabletext/plugin-typography": "^8.0.8",
     "@portabletext/react": "^6.2.0",
-    "@portabletext/sanity-bridge": "^3.1.0",
+    "@portabletext/sanity-bridge": "^3.1.1",
     "@portabletext/to-html": "^5.0.2",
     "@portabletext/toolkit": "^5.0.2",
     "@rexxars/react-json-inspector": "^9.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1678,8 +1678,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0(react@19.2.7)
       '@portabletext/sanity-bridge':
-        specifier: ^3.1.0
-        version: 3.1.0
+        specifier: ^3.1.1
+        version: 3.1.1
       '@portabletext/to-html':
         specifier: ^5.0.2
         version: 5.0.2
@@ -4865,8 +4865,8 @@ packages:
     peerDependencies:
       react: ^18.2 || ^19
 
-  '@portabletext/sanity-bridge@3.1.0':
-    resolution: {integrity: sha512-0xvNcyehNI/afBxMed1RURcLk67m6BJ7N6EtW2vzBkzH0R/PUS12GuOnu307eK4Pw67DJp0hawIaKGcFD6nbMw==}
+  '@portabletext/sanity-bridge@3.1.1':
+    resolution: {integrity: sha512-7u/E82DjZ6wLTk1Sk7Isz3kZWADXGufH5WRVnfbbTLVYNoVuvyKVe4jtQ/MtGkNk0fAqlvmaddzrkMaRW7qR7A==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
   '@portabletext/schema@2.2.0':
@@ -14629,7 +14629,7 @@ snapshots:
       '@portabletext/types': 4.0.2
       react: 19.2.7
 
-  '@portabletext/sanity-bridge@3.1.0':
+  '@portabletext/sanity-bridge@3.1.1':
     dependencies:
       '@portabletext/schema': 2.2.0
       '@sanity/schema': link:packages/@sanity/schema


### PR DESCRIPTION
### Description

Bumps `@portabletext/sanity-bridge` to pick up the fix in [portabletext/editor#2774](https://github.com/portabletext/editor/pull/2774) for a freeze that triggers when many block-object types share a content array.

`v5.31.0` of Studio shipped earlier today with `^3.1.0` in its `package.json`. Fresh installs resolve to `3.1.1` automatically via the semver caret, but existing projects with a frozen lockfile stay on the broken bridge until they re-resolve. A v5 backport that bumps the declared range to `^3.1.1` would force the re-resolve. **Maybe something to consider?**