### PR TITLE
ci(release): align v5 release workflow with main

### DIFF
--- a/.github/workflows/create-v5-release-pr.yml
+++ b/.github/workflows/create-v5-release-pr.yml
@@ -105,6 +105,7 @@ jobs:
               --branch=v5 \
               --source=studio-v5 \
               --distTag=maintenance-v5 \
+              --inFlightChecks=false \
               --baseVersion="$BASE_VERSION" \
               --tentativeVersion="$VERSION" \
               --outputFormat=pr-description

--- a/.github/workflows/create-v5-release-pr.yml
+++ b/.github/workflows/create-v5-release-pr.yml
@@ -28,6 +28,10 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Ensure v5 exists locally
+        # generate-changelog walks commits on the branch ref, which must exist locally
+        run: git checkout -B v5 origin/v5 && git switch -
+
       - uses: ./.github/actions/setup
 
       - uses: actions/create-github-app-token@v3
@@ -43,6 +47,12 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Get base version
+        # store the current version and use as base version when generating changelog documents
+        id: get-base-version
+        run: |
+          echo "base-version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
 
       - name: Update version
         run: pnpm --silent release-notes bump
@@ -78,37 +88,6 @@ jobs:
           RELEASE_AS: ${{ steps.release-as.outputs.version }}
           LAST_TAG: ${{ steps.last-tag.outputs.tag }}
 
-      - name: Generate release notes
-        # capture the root changelog entry before writing CHANGELOG.md files so it
-        # can be used as the PR description. The changelog entry's compare link
-        # points at the new version tag, which doesn't exist until the release is
-        # published, so for the PR description we point it at the release sha instead
-        id: release-notes
-        run: |
-          {
-            echo "notes<<EOF"
-            pnpm --silent release-notes write-changelog-files --version="$VERSION" --dryRun |
-              sed "s|/compare/$LAST_TAG\.\.\.v$VERSION|/compare/$LAST_TAG...$GITHUB_SHA|"
-            echo "EOF"
-          } >> $GITHUB_OUTPUT
-        env:
-          VERSION: ${{ steps.release-as.outputs.version }}
-          LAST_TAG: ${{ steps.last-tag.outputs.tag }}
-
-      - name: Generate commit log
-        # the generated changelog entry only includes user-facing commit types, so
-        # also include the full commit log in the PR description
-        id: commit-log
-        run: |
-          {
-            echo "commits<<EOF"
-            git log --pretty=format:'- %s (%h)' "$LAST_TAG"..HEAD
-            echo ""
-            echo "EOF"
-          } >> $GITHUB_OUTPUT
-        env:
-          LAST_TAG: ${{ steps.last-tag.outputs.tag }}
-
       - name: Write CHANGELOG.md files
         run: pnpm --silent release-notes write-changelog-files --version=${{ steps.release-as.outputs.version }}
 
@@ -117,6 +96,43 @@ jobs:
         run: |
           echo "message=chore(release): publish v${{ steps.release-as.outputs.version }}" >> $GITHUB_OUTPUT
 
+      - name: Prepare content release with release note document
+        id: release-notes
+        run: |
+          {
+            echo "notes<<EOF"
+            pnpm --silent release-notes generate-changelog \
+              --branch=v5 \
+              --source=studio-v5 \
+              --distTag=maintenance-v5 \
+              --baseVersion="$BASE_VERSION" \
+              --tentativeVersion="$VERSION" \
+              --outputFormat=pr-description
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+        env:
+          VERSION: ${{ steps.release-as.outputs.version }}
+          BASE_VERSION: ${{ steps.get-base-version.outputs.base-version }}
+          RELEASE_NOTES_SANITY_PROJECT_ID: ${{ vars.RELEASE_NOTES_SANITY_PROJECT_ID }}
+          RELEASE_NOTES_SANITY_DATASET: ${{ vars.RELEASE_NOTES_SANITY_DATASET }}
+          RELEASE_NOTES_ADMIN_STUDIO_URL: ${{ vars.RELEASE_NOTES_ADMIN_STUDIO_URL }}
+          RELEASE_NOTES_SANITY_TOKEN: ${{ secrets.RELEASE_NOTES_SANITY_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Draft release notes for upcoming release
+        run: |
+          pnpm --silent release-notes draft-release-notes \
+            --baseVersion="$BASE_VERSION" \
+            --source=studio-v5
+        env:
+          BASE_VERSION: ${{ steps.get-base-version.outputs.base-version }}
+          RELEASE_NOTES_SANITY_PROJECT_ID: ${{ vars.RELEASE_NOTES_SANITY_PROJECT_ID }}
+          RELEASE_NOTES_SANITY_DATASET: ${{ vars.RELEASE_NOTES_SANITY_DATASET }}
+          RELEASE_NOTES_ADMIN_STUDIO_URL: ${{ vars.RELEASE_NOTES_ADMIN_STUDIO_URL }}
+          RELEASE_NOTES_CLAUDE_API_KEY: ${{ secrets.RELEASE_NOTES_CLAUDE_API_KEY }}
+          RELEASE_NOTES_SANITY_TOKEN: ${{ secrets.RELEASE_NOTES_SANITY_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Create or update PR
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         id: create-pull-request
@@ -124,15 +140,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           title: "${{steps.version-commit.outputs.message}}"
           body: |
-            🤖 I have created a release **squib** **squob**
-
-            Merging this PR will publish v${{steps.release-as.outputs.version}} to npm under the `maintenance-v5` dist-tag 🚀
-
             ${{steps.release-notes.outputs.notes}}
-
-            ### Commits since ${{ steps.last-tag.outputs.tag }}
-
-            ${{ steps.commit-log.outputs.commits }}
           commit-message: "${{steps.version-commit.outputs.message}}"
           branch: ci/release-v5
           labels: "release:v5"

--- a/.github/workflows/release-v5.yml
+++ b/.github/workflows/release-v5.yml
@@ -73,6 +73,19 @@ jobs:
         env:
           RELEASE_AS: ${{ needs.build-and-validate.outputs.version}}
 
+  typedoc:
+    # the version tag is pushed with the workflow's GITHUB_TOKEN, which never
+    # triggers other workflows — so typedoc must be called explicitly here
+    needs: [build-and-validate, git-operations]
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: ./.github/workflows/typedoc.yml
+    with:
+      upload: true
+      version: ${{ needs.build-and-validate.outputs.version }}
+    secrets: inherit
+
   npm-publish:
     needs: [build-and-validate, git-operations]
     if: always() && needs.build-and-validate.result == 'success' && (needs.git-operations.result == 'success' || needs.git-operations.result == 'skipped')
@@ -110,6 +123,39 @@ jobs:
         # --publish-branch is required because pnpm's git checks only allow
         # publishing from master/main by default
         run: pnpm -r publish --tag maintenance-v5 --publish-branch=v5 --provenance
+
+  publish-releases:
+    # Publish sanity.io Changelog & github release
+    needs: [build-and-validate, npm-publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+
+      - name: Generate GitHub release
+        # --makeLatest=false so a maintenance release never replaces the repo's
+        # "Latest" GitHub release
+        run: |
+          pnpm --silent release-notes publish-releases \
+            --targetVersion="$VERSION" \
+            --source=studio-v5 \
+            --distTag=maintenance-v5 \
+            --makeLatest=false
+        env:
+          VERSION: ${{ needs.build-and-validate.outputs.version }}
+          RELEASE_NOTES_SANITY_PROJECT_ID: ${{ vars.RELEASE_NOTES_SANITY_PROJECT_ID }}
+          RELEASE_NOTES_SANITY_DATASET: ${{ vars.RELEASE_NOTES_SANITY_DATASET }}
+          RELEASE_NOTES_ADMIN_STUDIO_URL: ${{ vars.RELEASE_NOTES_ADMIN_STUDIO_URL }}
+          RELEASE_NOTES_SANITY_TOKEN: ${{ secrets.RELEASE_NOTES_SANITY_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   bundle-upload:
     needs: npm-publish
@@ -156,7 +202,7 @@ jobs:
         run: pnpm bundle-manager publish
 
   notify-on-failure:
-    needs: [npm-publish, bundle-upload]
+    needs: [npm-publish, bundle-upload, publish-releases]
     if: failure()
     runs-on: ubuntu-latest
     steps:

--- a/packages/@repo/release-notes/bin/release-notes.ts
+++ b/packages/@repo/release-notes/bin/release-notes.ts
@@ -133,6 +133,12 @@ await yargs(process.argv.slice(2))
           type: 'string',
           default: 'latest',
         },
+        inFlightChecks: {
+          description:
+            'Include the in-flight release check instructions in the PR description (only relevant for the main release line)',
+          type: 'boolean',
+          default: true,
+        },
         dryRun: {
           description: 'Dry run',
           type: 'boolean',
@@ -155,6 +161,7 @@ await yargs(process.argv.slice(2))
                 tentativeVersion: args.tentativeVersion,
                 baseVersion: args.baseVersion,
                 distTag: args.distTag,
+                inFlightChecks: args.inFlightChecks,
               },
               result,
             ),
@@ -321,7 +328,8 @@ function generateChangeLogSummary(
     tentativeVersion,
     baseVersion,
     distTag,
-  }: {tentativeVersion: string; baseVersion: string; distTag: string},
+    inFlightChecks,
+  }: {tentativeVersion: string; baseVersion: string; distTag: string; inFlightChecks: boolean},
   result: GenerateChangeLogResult,
 ) {
   const {changelogDocumentId, commitsWithPrs, releaseId} = result
@@ -345,6 +353,17 @@ function generateChangeLogSummary(
   const changelogUrl = `${getAdminStudioUrl()}/intent/edit/id=${changelogDocumentId.published}/?perspective=${releaseId}`
   const contentReleaseUrl = `${getAdminStudioUrl()}/intent/release/id=${releaseId}/?perspective=${releaseId}`
 
+  const releaseSteps = [
+    // the in-flight status checks only guard PRs on the main release line
+    ...(inFlightChecks
+      ? [
+          'Mark this PR as ready for review to block open PRs from being merged while release is in progress',
+        ]
+      : []),
+    `Ensure the [content release](${contentReleaseUrl}) is ready to go and passes validation`,
+    'Merge this PR',
+  ]
+
   return `
 🤖 I have created a release \`**squib**\` \`**squob**\`
 
@@ -353,9 +372,7 @@ function generateChangeLogSummary(
 Note: Entries in the changelog document can be safely edited and will never be overwritten by automation.
 
 ### 🚀 Steps to release
-1. Mark this PR as ready for review to block open PRs from being merged while release is in progress
-2. Ensure the [content release](${contentReleaseUrl}) is ready to go and passes validation
-3. Merge this PR
+${releaseSteps.map((step, index) => `${index + 1}. ${step}`).join('\n')}
 
 Once this PR is merged, automation will take care of the rest by:
 - Publishing **\`v${tentativeVersion}\`** of all public packages in this repo to the npm registry and tagging as \`${distTag}\`

--- a/packages/@repo/release-notes/bin/release-notes.ts
+++ b/packages/@repo/release-notes/bin/release-notes.ts
@@ -117,6 +117,22 @@ await yargs(process.argv.slice(2))
           type: 'string',
           demandOption: true,
         },
+        branch: {
+          description: 'Branch to collect commits from',
+          type: 'string',
+          default: 'main',
+        },
+        source: {
+          description:
+            'Source discriminator for changelog documents. Use a distinct value per release line (e.g. studio-v5) to keep documents from colliding.',
+          type: 'string',
+          default: 'studio',
+        },
+        distTag: {
+          description: 'npm dist-tag the release will be published under',
+          type: 'string',
+          default: 'latest',
+        },
         dryRun: {
           description: 'Dry run',
           type: 'boolean',
@@ -127,13 +143,19 @@ await yargs(process.argv.slice(2))
         const result = await createOrUpdateChangelogDocs({
           baseVersion: args.baseVersion,
           tentativeVersion: args.tentativeVersion,
+          branch: args.branch,
+          source: args.source,
           dryRun: args.dryRun,
         })
         if (args.outputFormat === 'pr-description') {
           // oxlint-disable-next-line no-console
           console.log(
             generateChangeLogSummary(
-              {tentativeVersion: args.tentativeVersion, baseVersion: args.baseVersion},
+              {
+                tentativeVersion: args.tentativeVersion,
+                baseVersion: args.baseVersion,
+                distTag: args.distTag,
+              },
               result,
             ),
           )
@@ -158,6 +180,22 @@ await yargs(process.argv.slice(2))
           type: 'string',
           demandOption: true,
         },
+        source: {
+          description:
+            'Source discriminator for changelog documents (must match generate-changelog)',
+          type: 'string',
+          default: 'studio',
+        },
+        distTag: {
+          description: 'npm dist-tag the release was published under',
+          type: 'string',
+          default: 'latest',
+        },
+        makeLatest: {
+          description: 'Mark the GitHub release as the latest release of the repo',
+          type: 'boolean',
+          default: true,
+        },
         dryRun: {
           description: 'Dry run',
           type: 'boolean',
@@ -167,6 +205,9 @@ await yargs(process.argv.slice(2))
       try {
         await publishReleases({
           targetVersion: args.targetVersion,
+          source: args.source,
+          distTag: args.distTag,
+          makeLatest: args.makeLatest,
           dryRun: Boolean(args.dryRun),
         })
         // oxlint-disable-next-line no-console
@@ -224,8 +265,15 @@ await yargs(process.argv.slice(2))
           type: 'string',
           demandOption: true,
         },
+        source: {
+          description:
+            'Source discriminator for changelog documents (must match generate-changelog)',
+          type: 'string',
+          default: 'studio',
+        },
       }),
-    handler: (args) => draftReleaseNotes({baseVersion: args.baseVersion}).then(() => void 0),
+    handler: (args) =>
+      draftReleaseNotes({baseVersion: args.baseVersion, source: args.source}).then(() => void 0),
   })
   .command({
     command: 'status-check-commit',
@@ -269,7 +317,11 @@ type GenerateChangeLogResult = {
 }
 
 function generateChangeLogSummary(
-  {tentativeVersion, baseVersion}: {tentativeVersion: string; baseVersion: string},
+  {
+    tentativeVersion,
+    baseVersion,
+    distTag,
+  }: {tentativeVersion: string; baseVersion: string; distTag: string},
   result: GenerateChangeLogResult,
 ) {
   const {changelogDocumentId, commitsWithPrs, releaseId} = result
@@ -306,7 +358,7 @@ Note: Entries in the changelog document can be safely edited and will never be o
 3. Merge this PR
 
 Once this PR is merged, automation will take care of the rest by:
-- Publishing **\`v${tentativeVersion}\`** of all public packages in this repo to the npm registry and tagging as \`latest\`
+- Publishing **\`v${tentativeVersion}\`** of all public packages in this repo to the npm registry and tagging as \`${distTag}\`
 - Publishing the [content release](${contentReleaseUrl}) for **\`v${tentativeVersion}\`**
 - Tagging, creating, and publishing a GitHub Release for **\`v${tentativeVersion}\`**
 - Building and uploading bundles for Auto Updating Studios

--- a/packages/@repo/release-notes/src/commands/createOrUpdateChangelogDocs.ts
+++ b/packages/@repo/release-notes/src/commands/createOrUpdateChangelogDocs.ts
@@ -35,9 +35,11 @@ import {uploadImages} from '../utils/uploadImages'
 export async function createOrUpdateChangelogDocs(args: {
   tentativeVersion?: string
   baseVersion: string
+  branch?: string
+  source?: string
   dryRun?: boolean
 }) {
-  const {tentativeVersion, baseVersion, dryRun} = args
+  const {tentativeVersion, baseVersion, branch = 'main', source = 'studio', dryRun} = args
   const client = getClient()
 
   // We obfuscate the base version id so we can use in the changelog document ids
@@ -46,15 +48,17 @@ export async function createOrUpdateChangelogDocs(args: {
   const gitClient = new ConventionalGitClient(MONOREPO_ROOT)
 
   const commits = getCommits(gitClient, await getSemverTags(gitClient), {
-    branch: 'main',
+    branch,
     releaseCount: 1,
   })
   const allCommits = await toArray(commits)
 
   const commitsWithPrs = await fetchCommitPrs(allCommits)
 
-  const {releaseId, changelogDocumentId, apiVersionDocId} =
-    getSanityDocumentIdsForBaseVersion(baseVersion)
+  const {releaseId, changelogDocumentId, apiVersionDocId} = getSanityDocumentIdsForBaseVersion(
+    baseVersion,
+    source,
+  )
 
   await ensureContentRelease(
     client,
@@ -94,7 +98,7 @@ export async function createOrUpdateChangelogDocs(args: {
     patch(changelogDocumentId.version, [
       at('releaseAutomation', setIfMissing({})),
       at('releaseAutomation.tentativeVersion', set(tentativeVersion)),
-      at('releaseAutomation.source', set('studio')),
+      at('releaseAutomation.source', set(source)),
       ...(await mergeChangelogBody(client, changelogDocumentId.version, commitsWithPrs, {dryRun})),
       at('publishedAt', set(new Date())),
       at(

--- a/packages/@repo/release-notes/src/commands/draftReleaseNotes.ts
+++ b/packages/@repo/release-notes/src/commands/draftReleaseNotes.ts
@@ -5,9 +5,12 @@ import {getClient} from '../client'
 import {generateHumanReadableReleaseNotes} from '../utils/generateHumanReadableReleaseNotes'
 import {getSanityDocumentIdsForBaseVersion} from '../utils/ids'
 
-export async function draftReleaseNotes(options: {baseVersion: string}) {
+export async function draftReleaseNotes(options: {baseVersion: string; source?: string}) {
   const client = getClient()
-  const {changelogDocumentId} = getSanityDocumentIdsForBaseVersion(options.baseVersion)
+  const {changelogDocumentId} = getSanityDocumentIdsForBaseVersion(
+    options.baseVersion,
+    options.source,
+  )
   const changelogDocument = await client.getDocument(changelogDocumentId.version)
   if (!changelogDocument) {
     throw new Error(`No changelog document found for base version ${options.baseVersion}`)

--- a/packages/@repo/release-notes/src/commands/publishReleases.ts
+++ b/packages/@repo/release-notes/src/commands/publishReleases.ts
@@ -6,12 +6,19 @@ import {getOctokit} from '../octokit'
 import {type StudioChangelogEntry} from '../types'
 import {stripPr} from '../utils/stripPrNumber'
 
-export async function publishReleases(options: {dryRun: boolean; targetVersion: string}) {
+export async function publishReleases(options: {
+  dryRun: boolean
+  targetVersion: string
+  source?: string
+  distTag?: string
+  makeLatest?: boolean
+}) {
+  const {source = 'studio', distTag = 'latest', makeLatest = true} = options
   const client = getClient()
   const octokit = getOctokit()
   const changelogDocuments = await client.fetch<{_id: string; changelog: StudioChangelogEntry[]}[]>(
-    '*[_type=="apiChange" && releaseAutomation.source == "studio" && releaseAutomation.tentativeVersion == $version]',
-    {version: options.targetVersion},
+    '*[_type=="apiChange" && releaseAutomation.source == $source && releaseAutomation.tentativeVersion == $version]',
+    {version: options.targetVersion, source},
     {perspective: 'raw'},
   )
 
@@ -77,9 +84,13 @@ ${changelogDocument.changelog
     body: ghReleaseTemplate({
       changelogDocumentId: getPublishedId(changelogDocumentId),
       targetVersion: options.targetVersion,
+      distTag,
       changelog: formattedChangelog,
     }),
     draft: false,
+    // maintenance releases must not become the repo's "Latest" GitHub release
+    // eslint-disable-next-line camelcase
+    make_latest: makeLatest ? ('true' as const) : ('false' as const),
   }
   if (options.dryRun) {
     console.log(
@@ -106,6 +117,7 @@ function mention(author: StudioChangelogEntry['author']) {
 function ghReleaseTemplate(vars: {
   changelogDocumentId: string
   targetVersion: string
+  distTag: string
   changelog: string
 }) {
   return `# Sanity Studio v${vars.targetVersion}
@@ -120,7 +132,7 @@ For the complete changelog with all details, please visit:
 To upgrade to this version, run:
 
 \`\`\`bash
-npm install sanity@latest
+npm install sanity@${vars.distTag}
 \`\`\`
 
 To initiate a new Sanity Studio project or learn more about upgrading, please refer to our comprehensive guide on [Installing and Upgrading Sanity Studio](https://www.sanity.io/docs/upgrade).

--- a/packages/@repo/release-notes/src/utils/ids.ts
+++ b/packages/@repo/release-notes/src/utils/ids.ts
@@ -5,8 +5,13 @@ const createId = (releaseId: string, input: string) => {
   return {published, version: getVersionId(published, releaseId), draft: getDraftId(published)}
 }
 
-export function getSanityDocumentIdsForBaseVersion(baseVersion: string) {
-  const baseVersionId = Buffer.from(baseVersion).toString('base64url')
+export function getSanityDocumentIdsForBaseVersion(baseVersion: string, source: string = 'studio') {
+  // the default source is excluded from the key to keep ids stable for documents
+  // created before the source discriminator was introduced. A non-default source
+  // (e.g. a maintenance branch) gets its own id namespace so it can't collide with
+  // a release from main that has the same base version
+  const key = source === 'studio' ? baseVersion : `${source}:${baseVersion}`
+  const baseVersionId = Buffer.from(key).toString('base64url')
 
   const releaseId = `rstudio-${baseVersionId}`
 


### PR DESCRIPTION
### Description

Brings v5 maintenance releases to parity with main's release pipeline:

- sanity.io changelog entry + content release (`generate-changelog`, now also used for the release PR description)
- GitHub release (`publish-releases`, with `--makeLatest=false` so a maintenance release never replaces v6 as "Latest")
- typedoc upload (explicit `workflow_call` — the version tag is pushed with `GITHUB_TOKEN`, which never triggers workflows)
- AI-drafted release notes (`draft-release-notes`)

### What to review

In `ids.ts`: changelog document ids must come out exactly as before when no `--source` is given, so main's releases keep finding their existing changelog documents. Only `--source=studio-v5` should produce different ids. Also the two new jobs (`typedoc`, `publish-releases`) in `release-v5.yml`.


### Testing

### Notes for release

N/A – Internal only
