### PR TITLE
chore(sanity): move vite back to devDependency

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -256,7 +256,6 @@
     "use-hot-module-reload": "^2.0.0",
     "use-sync-external-store": "^1.6.0",
     "uuid": "^11.1.0",
-    "vite": "catalog:",
     "web-vitals": "^5.1.0",
     "xstate": "^5.32.0"
   },
@@ -307,6 +306,7 @@
     "styled-components": "catalog:",
     "swr": "2.2.5",
     "tsx": "^4.22.4",
+    "vite": "catalog:",
     "vitest": "catalog:",
     "vitest-browser-react": "catalog:",
     "vitest-package-exports": "^1.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1926,9 +1926,6 @@ importers:
       uuid:
         specifier: ^11.1.0
         version: 11.1.1
-      vite:
-        specifier: 'catalog:'
-        version: 8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       web-vitals:
         specifier: ^5.1.0
         version: 5.3.0
@@ -2074,6 +2071,9 @@ importers:
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@edge-runtime/vm@3.2.0)(@types/node@24.13.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@24.13.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

`vite` was promoted to a production dependency in #13017 so `@sanity/cli` and the studio toolchain would resolve the same Vite 8 version while `@sanity/runtime-cli` still depended on Vite 7. That workaround is no longer needed once sanity-io/runtime-cli#511 lands upstream.

This moves `vite` back to `devDependencies` so it is not shipped transitively with the published `sanity` package.

### What to review

- `packages/sanity/package.json` — `vite` moved from `dependencies` to `devDependencies`

### Testing

- `pnpm install` — lockfile updated, `sanity` still resolves `vite@8.0.16` as a dev dependency
- `pnpm check:deps` — passes

### Notes for release

N/A – Internal only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4f96452-6cd4-45af-9ee9-3b0750ab00ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4f96452-6cd4-45af-9ee9-3b0750ab00ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

