### PR TITLE
test(e2e): clear keyvalue state before studio loads in flaky specs

### DIFF
--- a/e2e/helpers/clearKeyValueKey.ts
+++ b/e2e/helpers/clearKeyValueKey.ts
@@ -1,4 +1,12 @@
-import {ClientError, type SanityClient} from '@sanity/client'
+import {type SanityClient} from '@sanity/client'
+
+function getStatusCode(err: unknown): number | undefined {
+  if (typeof err !== 'object' || err === null) return undefined
+  const {statusCode, response} = err as {statusCode?: unknown; response?: {statusCode?: unknown}}
+  if (typeof statusCode === 'number') return statusCode
+  if (typeof response?.statusCode === 'number') return response.statusCode
+  return undefined
+}
 
 /**
  * Deletes a key from the per-user server keyvalue store (`/users/me/keyvalue`),
@@ -9,11 +17,11 @@ import {ClientError, type SanityClient} from '@sanity/client'
 export async function clearKeyValueKey(client: SanityClient, key: string): Promise<void> {
   try {
     await client.withConfig({apiVersion: '2024-03-12'}).request({
-      uri: `/users/me/keyvalue/${key}`,
+      uri: `/users/me/keyvalue/${encodeURIComponent(key)}`,
       method: 'DELETE',
     })
   } catch (err) {
-    if (err instanceof ClientError && err.statusCode === 404) {
+    if (getStatusCode(err) === 404) {
       return
     }
     throw err

--- a/e2e/helpers/clearKeyValueKey.ts
+++ b/e2e/helpers/clearKeyValueKey.ts
@@ -1,0 +1,21 @@
+import {ClientError, type SanityClient} from '@sanity/client'
+
+/**
+ * Deletes a key from the per-user server keyvalue store (`/users/me/keyvalue`),
+ * ignoring the 404 the API responds with when the key doesn't exist. Any other
+ * failure (auth, network, etc.) is rethrown so tests don't silently proceed
+ * against stale state.
+ */
+export async function clearKeyValueKey(client: SanityClient, key: string): Promise<void> {
+  try {
+    await client.withConfig({apiVersion: '2024-03-12'}).request({
+      uri: `/users/me/keyvalue/${key}`,
+      method: 'DELETE',
+    })
+  } catch (err) {
+    if (err instanceof ClientError && err.statusCode === 404) {
+      return
+    }
+    throw err
+  }
+}

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -1,3 +1,4 @@
+export * from './clearKeyValueKey'
 export * from './constants'
 export * from './createFileDataTransferHandle'
 export * from './createUniqueDocument'

--- a/e2e/tests/desk/documentTypeListContextMenu.spec.ts
+++ b/e2e/tests/desk/documentTypeListContextMenu.spec.ts
@@ -1,5 +1,6 @@
 import {expect} from '@playwright/test'
 
+import {clearKeyValueKey} from '../../helpers'
 import {test} from '../../studio-test'
 
 const SORT_KEY = 'studio.structure-tool.sort-order.author'
@@ -19,15 +20,7 @@ test('clicking default sort order and direction sets value in storage', async ({
   // stored per user (shared across CI runs), and the studio only PUTs when the
   // selected sort order actually changes — leftover state from another run
   // would make the click below a no-op and time out waiting for the PUT.
-  // Ignore error if the key doesn't exist (the API responds 404).
-  try {
-    await sanityClient.withConfig({apiVersion: '2024-03-12'}).request({
-      uri: `/users/me/keyvalue/${SORT_KEY}`,
-      method: 'DELETE',
-    })
-  } catch {
-    // Key doesn't exist, which is fine
-  }
+  await clearKeyValueKey(sanityClient, SORT_KEY)
 
   await page.goto('/content/author')
 
@@ -69,16 +62,8 @@ test('clicking custom sort order and direction sets value in storage', async ({
   test.skip(browserName !== 'chromium')
 
   // Clear any existing sort order key BEFORE the studio loads, so the click
-  // below always changes the selected sort order and issues a PUT (ignore
-  // error if key doesn't exist)
-  try {
-    await sanityClient.withConfig({apiVersion: '2024-03-12'}).request({
-      uri: `/users/me/keyvalue/${CUSTOM_SORT_KEY}`,
-      method: 'DELETE',
-    })
-  } catch {
-    // Key doesn't exist, which is fine
-  }
+  // below always changes the selected sort order and issues a PUT
+  await clearKeyValueKey(sanityClient, CUSTOM_SORT_KEY)
 
   await page.goto('/content/book')
 
@@ -118,16 +103,8 @@ test('clicking list view sets value in storage', async ({page, sanityClient, bro
   test.skip(browserName !== 'chromium')
 
   // Clear any existing layout key BEFORE the studio loads, so the clicks
-  // below always change the layout and issue a PUT (ignore error if key
-  // doesn't exist)
-  try {
-    await sanityClient.withConfig({apiVersion: '2024-03-12'}).request({
-      uri: `/users/me/keyvalue/${LAYOUT_KEY}`,
-      method: 'DELETE',
-    })
-  } catch {
-    // Key doesn't exist, which is fine
-  }
+  // below always change the layout and issue a PUT
+  await clearKeyValueKey(sanityClient, LAYOUT_KEY)
 
   await page.goto('/content/author')
 

--- a/e2e/tests/desk/documentTypeListContextMenu.spec.ts
+++ b/e2e/tests/desk/documentTypeListContextMenu.spec.ts
@@ -15,20 +15,21 @@ test('clicking default sort order and direction sets value in storage', async ({
   // For now, only test in Chromium due to flakiness in Firefox and WebKit
   test.skip(browserName !== 'chromium')
 
-  await page.goto('/content/author')
-
-  const existingKeys = await sanityClient.withConfig({apiVersion: '2024-03-12'}).request({
-    uri: `/users/me/keyvalue/${SORT_KEY}`,
-  })
-
-  // If the value is not null there are existingKeys, delete them in that case
-  if (existingKeys[0].value !== null) {
-    // Clear the sort order
+  // Clear any existing sort order key BEFORE the studio loads. The key is
+  // stored per user (shared across CI runs), and the studio only PUTs when the
+  // selected sort order actually changes — leftover state from another run
+  // would make the click below a no-op and time out waiting for the PUT.
+  // Ignore error if the key doesn't exist (the API responds 404).
+  try {
     await sanityClient.withConfig({apiVersion: '2024-03-12'}).request({
       uri: `/users/me/keyvalue/${SORT_KEY}`,
       method: 'DELETE',
     })
+  } catch {
+    // Key doesn't exist, which is fine
   }
+
+  await page.goto('/content/author')
 
   const keyValueRequest = page.waitForResponse(async (response) => {
     return response.url().includes('/users/me/keyvalue') && response.request().method() === 'PUT'
@@ -67,9 +68,9 @@ test('clicking custom sort order and direction sets value in storage', async ({
   // For now, only test in Chromium due to flakiness in Firefox and WebKit
   test.skip(browserName !== 'chromium')
 
-  await page.goto('/content/book')
-
-  // Clear any existing sort order key (ignore error if key doesn't exist)
+  // Clear any existing sort order key BEFORE the studio loads, so the click
+  // below always changes the selected sort order and issues a PUT (ignore
+  // error if key doesn't exist)
   try {
     await sanityClient.withConfig({apiVersion: '2024-03-12'}).request({
       uri: `/users/me/keyvalue/${CUSTOM_SORT_KEY}`,
@@ -78,6 +79,8 @@ test('clicking custom sort order and direction sets value in storage', async ({
   } catch {
     // Key doesn't exist, which is fine
   }
+
+  await page.goto('/content/book')
 
   const keyValueRequest = page.waitForResponse(
     async (response) => {
@@ -114,9 +117,9 @@ test('clicking list view sets value in storage', async ({page, sanityClient, bro
   // For now, only test in Chromium due to flakiness in Firefox and WebKit
   test.skip(browserName !== 'chromium')
 
-  await page.goto('/content/author')
-
-  // Clear any existing layout key (ignore error if key doesn't exist)
+  // Clear any existing layout key BEFORE the studio loads, so the clicks
+  // below always change the layout and issue a PUT (ignore error if key
+  // doesn't exist)
   try {
     await sanityClient.withConfig({apiVersion: '2024-03-12'}).request({
       uri: `/users/me/keyvalue/${LAYOUT_KEY}`,
@@ -125,6 +128,8 @@ test('clicking list view sets value in storage', async ({page, sanityClient, bro
   } catch {
     // Key doesn't exist, which is fine
   }
+
+  await page.goto('/content/author')
 
   const contextMenuButton = page.getByTestId('pane').getByTestId('pane-context-menu-button')
   await expect(contextMenuButton).toBeVisible()

--- a/e2e/tests/desk/inspectDialog.spec.ts
+++ b/e2e/tests/desk/inspectDialog.spec.ts
@@ -9,8 +9,23 @@ test('clicking inspect mode sets value in storage', async ({
   page,
   createDraftDocument,
   browserName,
+  sanityClient,
 }) => {
   test.slow(browserName === 'firefox')
+
+  // Clear any existing inspect-view-mode key BEFORE the studio loads. The key
+  // is stored per user (shared across CI runs) — if a previous run left it as
+  // 'raw', the Raw JSON tab is already active, clicking it changes nothing, no
+  // PUT is issued and the test times out. Ignore error if the key doesn't exist.
+  try {
+    await sanityClient.withConfig({apiVersion: '2024-03-12'}).request({
+      uri: `/users/me/keyvalue/${INSPECT_KEY}`,
+      method: 'DELETE',
+    })
+  } catch {
+    // Key doesn't exist, which is fine
+  }
+
   // Create document and wait for it to be fully loaded
   await createDraftDocument('/content/book')
   await page.waitForLoadState('load', WAIT_OPTIONS)

--- a/e2e/tests/desk/inspectDialog.spec.ts
+++ b/e2e/tests/desk/inspectDialog.spec.ts
@@ -1,5 +1,6 @@
 import {expect} from '@playwright/test'
 
+import {clearKeyValueKey} from '../../helpers'
 import {test} from '../../studio-test'
 
 const INSPECT_KEY = 'studio.structure-tool.inspect-view-mode'
@@ -16,15 +17,8 @@ test('clicking inspect mode sets value in storage', async ({
   // Clear any existing inspect-view-mode key BEFORE the studio loads. The key
   // is stored per user (shared across CI runs) — if a previous run left it as
   // 'raw', the Raw JSON tab is already active, clicking it changes nothing, no
-  // PUT is issued and the test times out. Ignore error if the key doesn't exist.
-  try {
-    await sanityClient.withConfig({apiVersion: '2024-03-12'}).request({
-      uri: `/users/me/keyvalue/${INSPECT_KEY}`,
-      method: 'DELETE',
-    })
-  } catch {
-    // Key doesn't exist, which is fine
-  }
+  // PUT is issued and the test times out.
+  await clearKeyValueKey(sanityClient, INSPECT_KEY)
 
   // Create document and wait for it to be fully loaded
   await createDraftDocument('/content/book')


### PR DESCRIPTION
### Description
Clears per-user keyvalue keys (which are shared across concurrent CI runs) before the studio loads and guards the cleanup calls against 404s, so sort-order/layout/inspect clicks always produce the PUT the specs wait for instead of no-oping on leftover state.

### What to review
Note that this is still prone to cross-run races, but the dominant source of these failures appears to be leftover half-way state from earlier failed attempts (which made retries and subsequent runs fail deterministically).

### Testing
Should remove a bit of flake

### Notes for release
n/a