### PR TITLE
fix(release-notes): handle breaking-change commit headers

### DIFF
--- a/packages/@repo/release-notes/bin/release-notes.ts
+++ b/packages/@repo/release-notes/bin/release-notes.ts
@@ -14,6 +14,7 @@ import {writeChangelogFiles} from '../src/commands/writeChangelogFiles'
 import {writeCommitCheck} from '../src/commands/writeCommitCheck'
 import {writePrChecks} from '../src/commands/writePrChecks'
 import {type CommitAuthor, type KnownEnvVar, type PullRequest} from '../src/types'
+import {isBreakingChange} from '../src/utils/isBreakingChange'
 import {stripPr} from '../src/utils/stripPrNumber'
 
 function getAdminStudioUrl(): string {
@@ -336,7 +337,9 @@ function formatEntry({
   releaseId: GenerateChangeLogResult['releaseId']
 }) {
   const entryKey = conventionalCommit.hash!.slice(0, 8)
-  const originalCommitMessage = stripPr(conventionalCommit.header || '', pr?.number)
+  const breakingMarker = isBreakingChange(conventionalCommit) ? '⚠️ ' : ''
+  const originalCommitMessage =
+    breakingMarker + stripPr(conventionalCommit.header || '', pr?.number)
   const entryPath = encodeURIComponent(`changelog[_key=="${entryKey}"]`)
   const changelogEntryUrl = `${getAdminStudioUrl()}/intent/edit/id=${changelogDocumentId.published};path=${entryPath}/?perspective=${releaseId}`
 

--- a/packages/@repo/release-notes/src/commands/createOrUpdateChangelogDocs.ts
+++ b/packages/@repo/release-notes/src/commands/createOrUpdateChangelogDocs.ts
@@ -23,6 +23,7 @@ import {type PullRequestInfo, type StudioChangelogEntry} from '../types'
 import {getCommits, getSemverTags} from '../utils/getCommits'
 import {getCommitAuthor, getMergedPRForCommit} from '../utils/github'
 import {getSanityDocumentIdsForBaseVersion} from '../utils/ids'
+import {isBreakingChange} from '../utils/isBreakingChange'
 import {parseRenovateReleaseNotes} from '../utils/parseRenovateReleaseNotes'
 import {
   markdownToPortableText,
@@ -169,14 +170,20 @@ async function getReleaseNotesMutations(
       : extractReleaseNotes(markdownToPortableText(pr.body))
     : []
 
+  const breaking = isBreakingChange(conventionalCommit)
+
+  // Breaking changes are never auto-excluded based on commit type/scope
+  // (e.g. a `chore!:` commit still needs release notes), but an explicit
+  // "no release notes" opt-out in the PR description is still respected.
   const excludeReleaseNotes =
     shouldExcludeReleaseNotes(releaseNoteBlocks) ||
     (isBot && releaseNoteBlocks.length === 0) ||
-    conventionalCommit.type === 'chore' ||
-    conventionalCommit.type === 'test' ||
-    conventionalCommit.scope === 'dev' ||
-    conventionalCommit.scope === 'build' ||
-    conventionalCommit.scope === 'test'
+    (!breaking &&
+      (conventionalCommit.type === 'chore' ||
+        conventionalCommit.type === 'test' ||
+        conventionalCommit.scope === 'dev' ||
+        conventionalCommit.scope === 'build' ||
+        conventionalCommit.scope === 'test'))
 
   // Prefer the commit's git author over the PR user — when a commit lands on
   // main through someone else's PR (e.g. a rebase-merged integration branch),
@@ -197,6 +204,7 @@ async function getReleaseNotesMutations(
       : undefined,
     authorAssociation: pr?.author_association.toLowerCase(),
     exclude: excludeReleaseNotes,
+    breaking,
     subject: cleanSubject,
     header: conventionalCommit.header || '',
     coAuthors: conventionalCommit.body ? descriptionToCoAuthors(conventionalCommit.body) : [],

--- a/packages/@repo/release-notes/src/types.ts
+++ b/packages/@repo/release-notes/src/types.ts
@@ -38,6 +38,7 @@ export type StudioChangelogEntry = {
   coAuthors: CoAuthor[]
   authorAssociation?: string
   exclude: boolean
+  breaking?: boolean
   hash?: string
   pr?: number
   contents: NormalizedMarkdownBlock[]

--- a/packages/@repo/release-notes/src/typings/conventional-changelog-conventionalcommits.d.ts
+++ b/packages/@repo/release-notes/src/typings/conventional-changelog-conventionalcommits.d.ts
@@ -1,0 +1,14 @@
+declare module 'conventional-changelog-conventionalcommits' {
+  import {type ParserStreamOptions} from 'conventional-commits-parser'
+
+  /**
+   * Minimal typing for the untyped `conventional-changelog-conventionalcommits`
+   * preset — only the parts used by this package.
+   */
+  export default function createPreset(config?: unknown): Promise<{
+    parser: ParserStreamOptions
+    commits: unknown
+    writer: unknown
+    whatBump: unknown
+  }>
+}

--- a/packages/@repo/release-notes/src/utils/__test__/isBreakingChange.test.ts
+++ b/packages/@repo/release-notes/src/utils/__test__/isBreakingChange.test.ts
@@ -1,0 +1,45 @@
+import {CommitParser} from 'conventional-commits-parser'
+import {describe, expect, it} from 'vitest'
+
+import {getParserOptions} from '../getCommits'
+import {isBreakingChange} from '../isBreakingChange'
+
+async function parse(message: string) {
+  return new CommitParser(await getParserOptions()).parse(message)
+}
+
+describe('getParserOptions', () => {
+  it('parses headers with the breaking-change marker', async () => {
+    const commit = await parse('feat!: upgrade to vite 8 (#12960)')
+    expect(commit.type).toBe('feat')
+    expect(commit.subject).toBe('upgrade to vite 8 (#12960)')
+  })
+
+  it('parses scoped headers with the breaking-change marker', async () => {
+    const commit = await parse('feat(core)!: remove deprecated auth.mode config (#12865)')
+    expect(commit.type).toBe('feat')
+    expect(commit.scope).toBe('core')
+    expect(commit.subject).toBe('remove deprecated auth.mode config (#12865)')
+  })
+})
+
+describe('isBreakingChange', () => {
+  it('detects the `!` header marker', async () => {
+    expect(isBreakingChange(await parse('fix!: drop support for node 20 (#12859)'))).toBe(true)
+    expect(isBreakingChange(await parse('chore(deps)!: bump @portabletext/editor to v7'))).toBe(
+      true,
+    )
+  })
+
+  it('detects BREAKING CHANGE footers', async () => {
+    const commit = await parse(
+      'feat(studio): use groq2024 search strategy by default\n\nBREAKING CHANGE: the legacy search strategy is no longer available',
+    )
+    expect(isBreakingChange(commit)).toBe(true)
+  })
+
+  it('returns false for non-breaking commits', async () => {
+    expect(isBreakingChange(await parse('feat(form): add new array input component'))).toBe(false)
+    expect(isBreakingChange(await parse('fix(cli): handle missing config'))).toBe(false)
+  })
+})

--- a/packages/@repo/release-notes/src/utils/getCommits.ts
+++ b/packages/@repo/release-notes/src/utils/getCommits.ts
@@ -1,4 +1,15 @@
 import {type ConventionalGitClient} from '@conventional-changelog/git-client'
+import createPreset from 'conventional-changelog-conventionalcommits'
+
+/**
+ * Parser options from the `conventionalcommits` preset (the same preset used
+ * for version bumping and CHANGELOG.md generation). Unlike the parser
+ * defaults, these handle the breaking-change marker (`feat!:`) and populate
+ * `notes` for it.
+ */
+export async function getParserOptions() {
+  return (await createPreset()).parser
+}
 
 export async function getSemverTags(gitClient: ConventionalGitClient, params?: {tags: string[]}) {
   const tags: string[] = []
@@ -31,15 +42,19 @@ export async function* getCommits(
   } else {
     reverseTags.unshift('')
   }
+  const parserOptions = await getParserOptions()
   const streams = []
   for (let i = 1, len = reverseTags.length; i < len; i++) {
     streams.push(
-      gitClient.getCommits({
-        ...params,
-        from: reverseTags[i - 1],
-        to: reverseTags[i],
-        path,
-      }),
+      gitClient.getCommits(
+        {
+          ...params,
+          from: reverseTags[i - 1],
+          to: reverseTags[i],
+          path,
+        },
+        parserOptions,
+      ),
     )
   }
   for (const stream of streams) {

--- a/packages/@repo/release-notes/src/utils/isBreakingChange.ts
+++ b/packages/@repo/release-notes/src/utils/isBreakingChange.ts
@@ -1,0 +1,11 @@
+import {type Commit} from 'conventional-commits-parser'
+
+/**
+ * A commit is a breaking change when it carries a BREAKING CHANGE note —
+ * either from a `BREAKING CHANGE:`/`BREAKING-CHANGE:` footer or from the `!`
+ * header marker (e.g. `feat!:`), which the conventionalcommits parser options
+ * turn into a note via `breakingHeaderPattern`.
+ */
+export function isBreakingChange(commit: Commit): boolean {
+  return commit.notes.some((note) => note.title.startsWith('BREAKING'))
+}


### PR DESCRIPTION
### Description

Parses commits with the conventionalcommits preset options so feat!:/fix!: get a type/subject, add a breaking flag to changelog entries, and never auto-exclude breaking commits by type/scope.


### What to review
This fixes some minor gaps discovered during the v6 release

### Testing
Tests included

### Notes for release
n/a