### PR TITLE
refactor(sanity): reusable version actions

### DIFF
--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -1,37 +1,19 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {ComposeSparklesIcon, LockIcon, UnlockIcon} from '@sanity/icons'
-import {type BadgeTone, useClickOutsideEvent, useGlobalKeyDown, useToast} from '@sanity/ui'
-import {
-  memo,
-  type MouseEvent,
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import {type BadgeTone} from '@sanity/ui'
+import {memo, type ReactNode, useEffect, useMemo, useRef} from 'react'
 import {useObservable} from 'react-rx'
 
-import {Popover, Tooltip} from '../../../../ui-components'
+import {Tooltip} from '../../../../ui-components'
 import {useCanvasCompanionDocsStore} from '../../../canvas/store/useCanvasCompanionDocsStore'
-import {useTranslation} from '../../../i18n'
 import {useReleasesToolAvailable} from '../../../schedules/hooks/useReleasesToolAvailable'
-import {useSingleDocRelease} from '../../../singleDocRelease/context/SingleDocReleaseProvider'
-import {useScheduledDraftMenuActions} from '../../../singleDocRelease/hooks/useScheduledDraftMenuActions'
 import {getDraftId, getPublishedId, getVersionId} from '../../../util/draftUtils'
-import {isCardinalityOneRelease, isPausedCardinalityOneRelease} from '../../../util/releaseUtils'
-import {useVersionOperations} from '../../hooks/useVersionOperations'
-import {LATEST, PUBLISHED} from '../../util/const'
-import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
+import {isPausedCardinalityOneRelease} from '../../../util/releaseUtils'
+import {useVersionContextMenu} from '../../hooks/useVersionContextMenu'
 import {Chip} from '../Chip'
-import {DiscardVersionDialog} from '../dialog/DiscardVersionDialog'
 import {ReleaseAvatarIcon} from '../ReleaseAvatar'
-import {VersionContextMenu} from './contextMenu/VersionContextMenu'
-import {CopyToDraftsDialog} from './dialog/CopyToDraftsDialog'
-import {CopyToNewReleaseDialog} from './dialog/CopyToNewReleaseDialog'
-
-type VersionChipDialogState = 'idle' | 'discard-version' | 'create-release' | 'copy-to-drafts'
+import {VersionContextMenuDialogs} from './contextMenu/VersionContextMenuDialogs'
+import {VersionContextMenuPopover} from './contextMenu/VersionContextMenuPopover'
 
 const useVersionIsLinked = (documentId: string, fromRelease: string) => {
   const versionId = useMemo(() => {
@@ -48,8 +30,6 @@ const useVersionIsLinked = (documentId: string, fromRelease: string) => {
   const companionDocs = useObservable(companionDocs$)
   return companionDocs?.data.some((companion) => companion?.studioDocumentId === versionId)
 }
-
-const CONTEXT_MENU_CLOSED = {open: false as const}
 
 /**
  * @internal
@@ -103,102 +83,39 @@ export const VersionChip = memo(function VersionChip(props: {
   const releasesToolAvailable = useReleasesToolAvailable()
   const isLinked = useVersionIsLinked(documentId, bundleId)
 
-  const [contextMenu, setContextMenu] = useState<
-    {open: true; translate: {x: number; y: number}} | {open: false}
-  >({open: false})
-  const popoverRef = useRef<HTMLDivElement | null>(null)
-  const [dialogState, setDialogState] = useState<VersionChipDialogState>('idle')
-
   const chipRef = useRef<HTMLButtonElement | null>(null)
 
   useEffect(() => {
     if (selected) chipRef.current?.scrollIntoView({inline: 'center'})
   }, [selected])
 
-  const docId = isVersion ? getVersionId(documentId, bundleId) : documentId // operations recognises publish and draft as empty
-
-  const {createVersion} = useVersionOperations()
-  const toast = useToast()
-  const {t} = useTranslation()
-  const {onSetScheduledDraftPerspective} = useSingleDocRelease()
-
-  const close = useCallback(() => setContextMenu(CONTEXT_MENU_CLOSED), [])
-  const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null)
-
-  const handleContextMenu = useCallback((event: MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault()
-    const elementRect = event.currentTarget?.getBoundingClientRect()
-    setContextMenu({
-      open: true,
-      // note: this offsets the context menu popover position
-      // and depends on placement=bottom-start
-      translate: {x: event.clientX - elementRect.left, y: elementRect.top - event.clientY},
-    })
-  }, [])
-
-  useClickOutsideEvent(close, () => [popoverRef.current])
-
-  useGlobalKeyDown(
-    useCallback(
-      (event) => {
-        if (event.key === 'Escape') {
-          close()
-        }
-      },
-      [close],
-    ),
-  )
-
-  const openDiscardDialog = useCallback(() => {
-    setDialogState('discard-version')
-  }, [])
-
-  const openCreateReleaseDialog = useCallback(() => {
-    setDialogState('create-release')
-  }, [])
-
-  const openCopyToDraftsDialog = useCallback(() => {
-    setDialogState('copy-to-drafts')
-  }, [])
-
-  const handleAddVersion = useCallback(
-    async (targetRelease: string) => {
-      try {
-        await createVersion(getReleaseIdFromReleaseDocumentId(targetRelease), docId)
-      } catch (err) {
-        toast.push({
-          closable: true,
-          status: 'error',
-          title: t('release.action.create-version.failure'),
-          description: err.message,
-        })
-      }
-
-      close()
-    },
-    [close, createVersion, docId, t, toast],
-  )
+  const {
+    contextMenu,
+    handleContextMenu,
+    popoverRef,
+    referenceElement,
+    setReferenceElement,
+    dialogState,
+    closeDialog,
+    openDiscardDialog,
+    openCreateReleaseDialog,
+    openCopyToDraftsDialog,
+    handleAddVersion,
+    isScheduledDraft,
+    scheduledDraftMenuActions,
+    sourceReleasePerspective,
+  } = useVersionContextMenu({
+    documentId,
+    documentType,
+    bundleId,
+    isVersion,
+    disabled: contextMenuDisabled,
+    release,
+  })
 
   const contextMenuHandler = disabled || !releasesToolAvailable ? undefined : handleContextMenu
 
-  const isScheduledDraft = release && isVersion && isCardinalityOneRelease(release)
-
-  const handleEditScheduleComplete = useCallback(() => {
-    if (!release) return
-    onSetScheduledDraftPerspective(getReleaseIdFromReleaseDocumentId(release._id))
-  }, [release, onSetScheduledDraftPerspective])
-
-  const scheduledDraftMenuActions = useScheduledDraftMenuActions({
-    release,
-    documentType,
-    documentId,
-    disabled: contextMenuDisabled,
-    onActionComplete: handleEditScheduleComplete,
-  })
-
   const isPaused = isPausedCardinalityOneRelease(release)
-  const sourceReleasePerspective =
-    release ?? (bundleId === 'published' ? PUBLISHED : bundleId === 'draft' ? LATEST : bundleId)
 
   const rightIcon = useMemo(() => {
     if (isLinked) return <ComposeSparklesIcon />
@@ -228,73 +145,44 @@ export const VersionChip = memo(function VersionChip(props: {
         </span>
       </Tooltip>
 
-      <Popover
-        animate={false}
-        content={
-          <VersionContextMenu
-            documentId={documentId}
-            releases={releases}
-            releasesLoading={releasesLoading}
-            fromRelease={bundleId}
-            isVersion={isVersion}
-            onDiscard={openDiscardDialog}
-            onCreateRelease={openCreateReleaseDialog}
-            onCopyToDrafts={openCopyToDraftsDialog}
-            onCopyToDraftsNavigate={onCopyToDraftsNavigate}
-            disabled={contextMenuDisabled}
-            onCreateVersion={handleAddVersion}
-            locked={locked}
-            type={documentType}
-            isGoingToUnpublish={isGoingToUnpublish}
-            release={release}
-            isScheduledDraft={isScheduledDraft}
-            scheduledDraftMenuActions={scheduledDraftMenuActions}
-          />
-        }
-        fallbackPlacements={[]}
-        open={contextMenu.open}
-        portal={contextMenuPortal}
-        placement="bottom-start"
-        ref={popoverRef}
+      <VersionContextMenuPopover
+        contextMenu={contextMenu}
+        popoverRef={popoverRef}
         referenceElement={referenceElement}
-        zOffset={10}
-        style={
-          contextMenu.open
-            ? {transform: `translate(${contextMenu.translate.x}px, ${contextMenu.translate.y}px)`}
-            : undefined
-        }
+        documentId={documentId}
+        documentType={documentType}
+        bundleId={bundleId}
+        isVersion={isVersion}
+        releases={releases}
+        releasesLoading={releasesLoading}
+        onDiscard={openDiscardDialog}
+        onCreateRelease={openCreateReleaseDialog}
+        onCopyToDrafts={openCopyToDraftsDialog}
+        onCopyToDraftsNavigate={onCopyToDraftsNavigate}
+        onCreateVersion={handleAddVersion}
+        disabled={contextMenuDisabled}
+        locked={locked}
+        isGoingToUnpublish={isGoingToUnpublish}
+        release={release}
+        isScheduledDraft={isScheduledDraft}
+        scheduledDraftMenuActions={scheduledDraftMenuActions}
+        portal={contextMenuPortal}
       />
 
-      {dialogState === 'discard-version' && (
-        <DiscardVersionDialog
-          onClose={() => setDialogState('idle')}
-          documentId={isVersion ? getVersionId(documentId, bundleId) : documentId}
-          fromPerspective={text}
-          documentType={documentType}
-          isGoingToUnpublish={isGoingToUnpublish}
-        />
-      )}
-
-      {dialogState === 'create-release' && (
-        <CopyToNewReleaseDialog
-          onClose={() => setDialogState('idle')}
-          onCreateVersion={handleAddVersion}
-          documentId={isVersion ? getVersionId(documentId, bundleId) : documentId}
-          documentType={documentType}
-          release={sourceReleasePerspective}
-          title={text}
-        />
-      )}
-
-      {dialogState === 'copy-to-drafts' && (
-        <CopyToDraftsDialog
-          onClose={() => setDialogState('idle')}
-          documentId={documentId}
-          fromRelease={bundleId}
-          onNavigate={onCopyToDraftsNavigate}
-        />
-      )}
-      {isScheduledDraft && scheduledDraftMenuActions.dialogs}
+      <VersionContextMenuDialogs
+        dialogState={dialogState}
+        onClose={closeDialog}
+        documentId={documentId}
+        documentType={documentType}
+        bundleId={bundleId}
+        isVersion={isVersion}
+        title={text}
+        sourceReleasePerspective={sourceReleasePerspective}
+        onCreateVersion={handleAddVersion}
+        onCopyToDraftsNavigate={onCopyToDraftsNavigate}
+        isGoingToUnpublish={isGoingToUnpublish}
+        scheduledDraftDialogs={isScheduledDraft && scheduledDraftMenuActions.dialogs}
+      />
     </>
   )
 })

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuDialogs.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuDialogs.tsx
@@ -1,0 +1,91 @@
+import {memo, type ReactNode} from 'react'
+
+import {type TargetPerspective} from '../../../../perspective/types'
+import {getVersionId} from '../../../../util/draftUtils'
+import {type VersionContextMenuDialogState} from '../../../hooks/useVersionContextMenu'
+import {DiscardVersionDialog} from '../../dialog/DiscardVersionDialog'
+import {CopyToDraftsDialog} from '../dialog/CopyToDraftsDialog'
+import {CopyToNewReleaseDialog} from '../dialog/CopyToNewReleaseDialog'
+
+/**
+ * @internal
+ */
+export interface VersionContextMenuDialogsProps {
+  /** The dialog state returned by `useVersionContextMenu`. */
+  dialogState: VersionContextMenuDialogState
+  onClose: () => void
+  documentId: string
+  documentType: string
+  /** The perspective the menu acts on: 'published', 'draft', or a release ID. */
+  bundleId: string
+  isVersion: boolean
+  /** Display title of the perspective the dialogs act on. */
+  title: string
+  /** The release or system bundle the dialogs act on behalf of. */
+  sourceReleasePerspective: TargetPerspective
+  onCreateVersion: (targetRelease: string) => void
+  onCopyToDraftsNavigate: () => void
+  isGoingToUnpublish?: boolean
+  /** Dialogs rendered for scheduled draft actions, if any. */
+  scheduledDraftDialogs?: ReactNode
+}
+
+/**
+ * Renders the dialog (if any) opened from the version context menu. Use
+ * together with `useVersionContextMenu` and `VersionContextMenuPopover`.
+ *
+ * @internal
+ */
+export const VersionContextMenuDialogs = memo(function VersionContextMenuDialogs(
+  props: VersionContextMenuDialogsProps,
+) {
+  const {
+    dialogState,
+    onClose,
+    documentId,
+    documentType,
+    bundleId,
+    isVersion,
+    title,
+    sourceReleasePerspective,
+    onCreateVersion,
+    onCopyToDraftsNavigate,
+    isGoingToUnpublish = false,
+    scheduledDraftDialogs,
+  } = props
+
+  return (
+    <>
+      {dialogState === 'discard-version' && (
+        <DiscardVersionDialog
+          onClose={onClose}
+          documentId={isVersion ? getVersionId(documentId, bundleId) : documentId}
+          fromPerspective={title}
+          documentType={documentType}
+          isGoingToUnpublish={isGoingToUnpublish}
+        />
+      )}
+
+      {dialogState === 'create-release' && (
+        <CopyToNewReleaseDialog
+          onClose={onClose}
+          onCreateVersion={onCreateVersion}
+          documentId={isVersion ? getVersionId(documentId, bundleId) : documentId}
+          documentType={documentType}
+          release={sourceReleasePerspective}
+          title={title}
+        />
+      )}
+
+      {dialogState === 'copy-to-drafts' && (
+        <CopyToDraftsDialog
+          onClose={onClose}
+          documentId={documentId}
+          fromRelease={bundleId}
+          onNavigate={onCopyToDraftsNavigate}
+        />
+      )}
+      {scheduledDraftDialogs}
+    </>
+  )
+})

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuPopover.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuPopover.tsx
@@ -1,0 +1,117 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {memo, type RefObject} from 'react'
+
+import {Popover} from '../../../../../ui-components'
+import {type UseScheduledDraftMenuActionsReturn} from '../../../../singleDocRelease/hooks/useScheduledDraftMenuActions'
+import {type VersionContextMenuState} from '../../../hooks/useVersionContextMenu'
+import {VersionContextMenu} from './VersionContextMenu'
+
+/**
+ * @internal
+ */
+export interface VersionContextMenuPopoverProps {
+  /** The menu state returned by `useVersionContextMenu`. */
+  contextMenu: VersionContextMenuState
+  /** The popover ref returned by `useVersionContextMenu`. */
+  popoverRef: RefObject<HTMLDivElement | null>
+  /** The element the menu popover is positioned relative to. */
+  referenceElement: HTMLElement | null
+  documentId: string
+  documentType: string
+  /** The perspective the menu acts on: 'published', 'draft', or a release ID. */
+  bundleId: string
+  isVersion: boolean
+  releases: ReleaseDocument[]
+  releasesLoading: boolean
+  onDiscard: () => void
+  onCreateRelease: () => void
+  onCopyToDrafts: () => void
+  onCopyToDraftsNavigate: () => void
+  onCreateVersion: (targetRelease: string) => void
+  disabled?: boolean
+  locked?: boolean
+  isGoingToUnpublish?: boolean
+  release?: ReleaseDocument
+  isScheduledDraft?: boolean
+  scheduledDraftMenuActions?: UseScheduledDraftMenuActionsReturn
+  /**
+   * Whether the popover should be rendered in a portal. If the trigger is
+   * already contained in a portal there is no need to also make the context
+   * menu a portal (and it also breaks click-outside detection).
+   */
+  portal?: boolean
+}
+
+/**
+ * Renders the version context menu in a popover positioned where the context
+ * menu was opened. Use together with `useVersionContextMenu` and
+ * `VersionContextMenuDialogs`.
+ *
+ * @internal
+ */
+export const VersionContextMenuPopover = memo(function VersionContextMenuPopover(
+  props: VersionContextMenuPopoverProps,
+) {
+  const {
+    contextMenu,
+    popoverRef,
+    referenceElement,
+    documentId,
+    documentType,
+    bundleId,
+    isVersion,
+    releases,
+    releasesLoading,
+    onDiscard,
+    onCreateRelease,
+    onCopyToDrafts,
+    onCopyToDraftsNavigate,
+    onCreateVersion,
+    disabled = false,
+    locked = false,
+    isGoingToUnpublish = false,
+    release,
+    isScheduledDraft = false,
+    scheduledDraftMenuActions,
+    portal = true,
+  } = props
+
+  return (
+    <Popover
+      animate={false}
+      content={
+        <VersionContextMenu
+          documentId={documentId}
+          releases={releases}
+          releasesLoading={releasesLoading}
+          fromRelease={bundleId}
+          isVersion={isVersion}
+          onDiscard={onDiscard}
+          onCreateRelease={onCreateRelease}
+          onCopyToDrafts={onCopyToDrafts}
+          onCopyToDraftsNavigate={onCopyToDraftsNavigate}
+          disabled={disabled}
+          onCreateVersion={onCreateVersion}
+          locked={locked}
+          type={documentType}
+          isGoingToUnpublish={isGoingToUnpublish}
+          release={release}
+          isScheduledDraft={isScheduledDraft}
+          scheduledDraftMenuActions={scheduledDraftMenuActions}
+        />
+      }
+      fallbackPlacements={[]}
+      open={contextMenu.open}
+      portal={portal}
+      placement="bottom-start"
+      ref={popoverRef}
+      referenceElement={referenceElement}
+      zOffset={10}
+      style={
+        contextMenu.open
+          ? {transform: `translate(${contextMenu.translate.x}px, ${contextMenu.translate.y}px)`}
+          : undefined
+      }
+    />
+  )
+})

--- a/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
+++ b/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
@@ -1,0 +1,204 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {useClickOutsideEvent, useGlobalKeyDown, useToast} from '@sanity/ui'
+import {type MouseEvent, type RefObject, useCallback, useRef, useState} from 'react'
+
+import {useTranslation} from '../../i18n'
+import {type TargetPerspective} from '../../perspective/types'
+import {useSingleDocRelease} from '../../singleDocRelease/context/SingleDocReleaseProvider'
+import {
+  useScheduledDraftMenuActions,
+  type UseScheduledDraftMenuActionsReturn,
+} from '../../singleDocRelease/hooks/useScheduledDraftMenuActions'
+import {getVersionId} from '../../util/draftUtils'
+import {isCardinalityOneRelease} from '../../util/releaseUtils'
+import {LATEST, PUBLISHED} from '../util/const'
+import {getReleaseIdFromReleaseDocumentId} from '../util/getReleaseIdFromReleaseDocumentId'
+import {useVersionOperations} from './useVersionOperations'
+
+const CONTEXT_MENU_CLOSED = {open: false as const}
+
+/**
+ * The dialog currently opened from the version context menu.
+ *
+ * @internal
+ */
+export type VersionContextMenuDialogState =
+  | 'idle'
+  | 'discard-version'
+  | 'create-release'
+  | 'copy-to-drafts'
+
+/**
+ * Whether the version context menu is open and, if so, its offset from the
+ * reference element.
+ *
+ * @internal
+ */
+export type VersionContextMenuState =
+  | {open: true; translate: {x: number; y: number}}
+  | {open: false}
+
+/**
+ * @internal
+ */
+export interface UseVersionContextMenuOptions {
+  documentId: string
+  documentType: string
+  /** The perspective the menu acts on: 'published', 'draft', or a release ID. */
+  bundleId: string
+  isVersion: boolean
+  /** Disables the menu actions (the menu can still be opened). */
+  disabled?: boolean
+  release?: ReleaseDocument
+}
+
+/**
+ * @internal
+ */
+export interface UseVersionContextMenuReturn {
+  /** Whether the menu is open and, if so, its offset from the reference element. */
+  contextMenu: VersionContextMenuState
+  /** Attach to the `onContextMenu` event of the trigger element. */
+  handleContextMenu: (event: MouseEvent<HTMLButtonElement>) => void
+  closeContextMenu: () => void
+  /** Attach to the popover rendering the menu (used for click-outside detection). */
+  popoverRef: RefObject<HTMLDivElement | null>
+  /** The element the menu popover is positioned relative to. */
+  referenceElement: HTMLElement | null
+  setReferenceElement: (element: HTMLElement | null) => void
+  dialogState: VersionContextMenuDialogState
+  closeDialog: () => void
+  openDiscardDialog: () => void
+  openCreateReleaseDialog: () => void
+  openCopyToDraftsDialog: () => void
+  /** Creates a version of the document in the given release and closes the menu. */
+  handleAddVersion: (targetRelease: string) => Promise<void>
+  isScheduledDraft: boolean
+  scheduledDraftMenuActions: UseScheduledDraftMenuActionsReturn
+  /** The release or system bundle the menu acts on behalf of. */
+  sourceReleasePerspective: TargetPerspective
+}
+
+/**
+ * Manages the state and actions backing a version context menu: menu
+ * open/position state, dialog state, version creation and scheduled draft
+ * actions.
+ *
+ * Render the menu and its dialogs with `VersionContextMenuPopover` and
+ * `VersionContextMenuDialogs`.
+ *
+ * @internal
+ */
+export function useVersionContextMenu(
+  options: UseVersionContextMenuOptions,
+): UseVersionContextMenuReturn {
+  const {documentId, documentType, bundleId, isVersion, disabled = false, release} = options
+
+  const [contextMenu, setContextMenu] = useState<VersionContextMenuState>({open: false})
+  const popoverRef = useRef<HTMLDivElement | null>(null)
+  const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null)
+  const [dialogState, setDialogState] = useState<VersionContextMenuDialogState>('idle')
+
+  const docId = isVersion ? getVersionId(documentId, bundleId) : documentId // operations recognises publish and draft as empty
+
+  const {createVersion} = useVersionOperations()
+  const toast = useToast()
+  const {t} = useTranslation()
+  const {onSetScheduledDraftPerspective} = useSingleDocRelease()
+
+  const closeContextMenu = useCallback(() => setContextMenu(CONTEXT_MENU_CLOSED), [])
+
+  const handleContextMenu = useCallback((event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    const elementRect = event.currentTarget?.getBoundingClientRect()
+    setContextMenu({
+      open: true,
+      // note: this offsets the context menu popover position
+      // and depends on placement=bottom-start
+      translate: {x: event.clientX - elementRect.left, y: elementRect.top - event.clientY},
+    })
+  }, [])
+
+  useClickOutsideEvent(closeContextMenu, () => [popoverRef.current])
+
+  useGlobalKeyDown(
+    useCallback(
+      (event) => {
+        if (event.key === 'Escape') {
+          closeContextMenu()
+        }
+      },
+      [closeContextMenu],
+    ),
+  )
+
+  const closeDialog = useCallback(() => {
+    setDialogState('idle')
+  }, [])
+
+  const openDiscardDialog = useCallback(() => {
+    setDialogState('discard-version')
+  }, [])
+
+  const openCreateReleaseDialog = useCallback(() => {
+    setDialogState('create-release')
+  }, [])
+
+  const openCopyToDraftsDialog = useCallback(() => {
+    setDialogState('copy-to-drafts')
+  }, [])
+
+  const handleAddVersion = useCallback(
+    async (targetRelease: string) => {
+      try {
+        await createVersion(getReleaseIdFromReleaseDocumentId(targetRelease), docId)
+      } catch (err) {
+        toast.push({
+          closable: true,
+          status: 'error',
+          title: t('release.action.create-version.failure'),
+          description: err.message,
+        })
+      }
+
+      closeContextMenu()
+    },
+    [closeContextMenu, createVersion, docId, t, toast],
+  )
+
+  const isScheduledDraft = Boolean(release && isVersion && isCardinalityOneRelease(release))
+
+  const handleEditScheduleComplete = useCallback(() => {
+    if (!release) return
+    onSetScheduledDraftPerspective(getReleaseIdFromReleaseDocumentId(release._id))
+  }, [release, onSetScheduledDraftPerspective])
+
+  const scheduledDraftMenuActions = useScheduledDraftMenuActions({
+    release,
+    documentType,
+    documentId,
+    disabled,
+    onActionComplete: handleEditScheduleComplete,
+  })
+
+  const sourceReleasePerspective =
+    release ?? (bundleId === 'published' ? PUBLISHED : bundleId === 'draft' ? LATEST : bundleId)
+
+  return {
+    contextMenu,
+    handleContextMenu,
+    closeContextMenu,
+    popoverRef,
+    referenceElement,
+    setReferenceElement,
+    dialogState,
+    closeDialog,
+    openDiscardDialog,
+    openCreateReleaseDialog,
+    openCopyToDraftsDialog,
+    handleAddVersion,
+    isScheduledDraft,
+    scheduledDraftMenuActions,
+    sourceReleasePerspective,
+  }
+}


### PR DESCRIPTION
### Description

This branch transplants the existing version context menu program into a reusable `useVersionContextMenu` hook, allowing it to be used by the variant inventory.

### What to review

The moved code, and existing context menus inside version pills.

### Testing

Existing test pass, and verified existing version pill behaviour.