### PR TITLE
refactor(sanity): non-discardable version actions mode

### DIFF
--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CanonicalReleaseContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CanonicalReleaseContextMenu.tsx
@@ -27,6 +27,11 @@ interface CanonicalReleaseContextMenuProps {
   hasCreatePermission: boolean | null
   hasDiscardPermission: boolean
   isPublished: boolean
+  /**
+   * Whether the UI permits discarding versions.
+   * Defaults to `true`.
+   */
+  isDiscardable?: boolean
   documentId: string
   documentType: string
   releases: ReleaseDocument[]
@@ -53,6 +58,7 @@ export const CanonicalReleaseContextMenu = memo(function CanonicalReleaseContext
     hasCreatePermission,
     hasDiscardPermission,
     isPublished,
+    isDiscardable = true,
     documentId,
     documentType,
   } = props
@@ -95,8 +101,8 @@ export const CanonicalReleaseContextMenu = memo(function CanonicalReleaseContext
           documentType={documentType}
         />
       )}
-      {!isPublished && (showCopyToReleaseMenuItem || release) && <MenuDivider />}
-      {!isPublished && (
+      {!isPublished && isDiscardable && (showCopyToReleaseMenuItem || release) && <MenuDivider />}
+      {!isPublished && isDiscardable && (
         <MenuItem
           icon={TrashIcon}
           onClick={onDiscard}

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
@@ -28,6 +28,11 @@ interface VersionContextMenuProps {
   release?: ReleaseDocument
   isScheduledDraft?: boolean
   scheduledDraftMenuActions?: UseScheduledDraftMenuActionsReturn
+  /**
+   * Whether the UI permits discarding versions.
+   * Defaults to `true`.
+   */
+  isDiscardable?: boolean
 }
 
 export const VersionContextMenu = memo(function VersionContextMenu(props: VersionContextMenuProps) {
@@ -49,6 +54,7 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: Versio
     release,
     isScheduledDraft,
     scheduledDraftMenuActions,
+    isDiscardable = true,
   } = props
   const isPublished = isPublishedId(documentId) && !isVersion
 
@@ -119,6 +125,7 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: Versio
       hasCreatePermission={hasCreatePermission}
       hasDiscardPermission={hasDiscardPermission || false}
       isPublished={isPublished}
+      isDiscardable={isDiscardable}
       documentId={documentId}
       documentType={type}
     />

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuDialogs.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuDialogs.tsx
@@ -26,6 +26,11 @@ export interface VersionContextMenuDialogsProps {
   onCreateVersion: (targetRelease: string) => void
   onCopyToDraftsNavigate: () => void
   isGoingToUnpublish?: boolean
+  /**
+   * Whether the UI permits discarding versions.
+   * Defaults to `true`.
+   */
+  isDiscardable?: boolean
   /** Dialogs rendered for scheduled draft actions, if any. */
   scheduledDraftDialogs?: ReactNode
 }
@@ -51,12 +56,13 @@ export const VersionContextMenuDialogs = memo(function VersionContextMenuDialogs
     onCreateVersion,
     onCopyToDraftsNavigate,
     isGoingToUnpublish = false,
+    isDiscardable = true,
     scheduledDraftDialogs,
   } = props
 
   return (
     <>
-      {dialogState === 'discard-version' && (
+      {dialogState === 'discard-version' && isDiscardable && (
         <DiscardVersionDialog
           onClose={onClose}
           documentId={isVersion ? getVersionId(documentId, bundleId) : documentId}

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuPopover.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuPopover.tsx
@@ -35,6 +35,11 @@ export interface VersionContextMenuPopoverProps {
   isScheduledDraft?: boolean
   scheduledDraftMenuActions?: UseScheduledDraftMenuActionsReturn
   /**
+   * Whether the UI permits discarding versions.
+   * Defaults to `true`.
+   */
+  isDiscardable?: boolean
+  /**
    * Whether the popover should be rendered in a portal. If the trigger is
    * already contained in a portal there is no need to also make the context
    * menu a portal (and it also breaks click-outside detection).
@@ -73,6 +78,7 @@ export const VersionContextMenuPopover = memo(function VersionContextMenuPopover
     release,
     isScheduledDraft = false,
     scheduledDraftMenuActions,
+    isDiscardable = true,
     portal = true,
   } = props
 
@@ -98,6 +104,7 @@ export const VersionContextMenuPopover = memo(function VersionContextMenuPopover
           release={release}
           isScheduledDraft={isScheduledDraft}
           scheduledDraftMenuActions={scheduledDraftMenuActions}
+          isDiscardable={isDiscardable}
         />
       }
       fallbackPlacements={[]}


### PR DESCRIPTION
### Description

This branch allows the version context menu to be rendered without the discard option. This allows it to be utilised by the variant inventory, which provides its own method for discarding/deleting versions.

### What to review

The new `isDiscardable` prop.

### Testing

Existing tests work, and verified the existing functionality is preserved.