### PR TITLE
fix(form): re-focus portable text block on re-click from outside editor

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -32,8 +32,19 @@ export function useTrackFocusPath(props: Props): void {
       return
     }
 
-    // Don't do anything if the editor selection focus path is already equal to the focusPath
+    // The editor holds DOM focus when the user is actively editing inside it. In that case the
+    // editor manages its own selection and scrolling, so we should not interfere.
+    const editorHasDomFocus = Boolean(
+      boundaryElement &&
+      boundaryElement.ownerDocument.activeElement &&
+      boundaryElement.contains(boundaryElement.ownerDocument.activeElement),
+    )
+
+    // Don't do anything if the editor is focused and its selection focus path already equals the
+    // focusPath. When focus came from outside the editor (e.g. Visual Editing), the editor can
+    // retain a matching selection while blurred; we must still re-focus and scroll to it (#12894).
     if (
+      editorHasDomFocus &&
       selection?.focus.path &&
       isEqual(selection.focus.path, focusPath.slice(0, selection.focus.path.length))
     ) {
@@ -114,6 +125,18 @@ export function useTrackFocusPath(props: Props): void {
 
         // Select and focus the editor if we produced a path
         if (path.length) {
+          // Re-focusing a block that is already the editor's current selection is a no-op:
+          // the editor emits no selection change, so neither its native focus nor its
+          // scroll-into-view runs and the block can't be re-entered (#12894).
+          // Deselect first so the subsequent select is a genuine change.
+          const currentSelection = PortableTextEditor.getSelection(editor)
+          const isSameSelection =
+            currentSelection?.focus.path &&
+            isEqual(currentSelection.focus.path.slice(0, path.length), path)
+          if (isSameSelection) {
+            PortableTextEditor.select(editor, null)
+          }
+
           PortableTextEditor.select(editor, {
             anchor: {path, offset: 0},
             focus: {path, offset: 0},

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -34,11 +34,9 @@ export function useTrackFocusPath(props: Props): void {
 
     // The editor holds DOM focus when the user is actively editing inside it. In that case the
     // editor manages its own selection and scrolling, so we should not interfere.
-    const editorHasDomFocus = Boolean(
-      boundaryElement &&
-      boundaryElement.ownerDocument.activeElement &&
-      boundaryElement.contains(boundaryElement.ownerDocument.activeElement),
-    )
+    const editorHasDomFocus =
+      !!boundaryElement?.ownerDocument.activeElement &&
+      boundaryElement.contains(boundaryElement.ownerDocument.activeElement)
 
     // Don't do anything if the editor is focused and its selection focus path already equals the
     // focusPath. When focus came from outside the editor (e.g. Visual Editing), the editor can
@@ -129,11 +127,12 @@ export function useTrackFocusPath(props: Props): void {
           // the editor emits no selection change, so neither its native focus nor its
           // scroll-into-view runs and the block can't be re-entered (#12894).
           // Deselect first so the subsequent select is a genuine change.
-          const currentSelection = PortableTextEditor.getSelection(editor)
+          // Slice the selection path down to the target path length (the reverse of the guard
+          // above): we only care whether the editor is already sitting on this exact block,
+          // regardless of which child the caret is on.
           const isSameSelection =
-            currentSelection?.focus.path &&
-            isEqual(currentSelection.focus.path.slice(0, path.length), path)
-          if (isSameSelection) {
+            selection?.focus.path && isEqual(selection.focus.path.slice(0, path.length), path)
+          if (isTextBlock && isSameSelection) {
             PortableTextEditor.select(editor, null)
           }
 

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -5,7 +5,7 @@ import {
 } from '@portabletext/editor'
 import {isKeyedObject, type KeyedObject, type Path} from '@sanity/types'
 import {isEqual} from '@sanity/util/paths'
-import {useLayoutEffect} from 'react'
+import {useLayoutEffect, useRef} from 'react'
 import scrollIntoView from 'scroll-into-view-if-needed'
 
 import {usePortableTextMemberItemElementRefs} from '../contexts/PortableTextMemberItemElementRefsProvider'
@@ -26,34 +26,52 @@ export function useTrackFocusPath(props: Props): void {
   const editor = usePortableTextEditor()
   const selection = usePortableTextEditorSelection()
 
+  // Read selection from a ref instead of subscribing to it, so our own select() calls below don't
+  // re-fire the tracking effect into an infinite loop (#12894). Declared first to run before it.
+  const selectionRef = useRef(selection)
+  useLayoutEffect(() => {
+    selectionRef.current = selection
+  }, [selection])
+
   useLayoutEffect(() => {
     // Don't do anything if no focusPath to track
     if (focusPath.length === 0) {
       return
     }
 
-    // The editor holds DOM focus when the user is actively editing inside it. In that case the
-    // editor manages its own selection and scrolling, so we should not interfere.
+    // When the editor holds DOM focus the user is editing inside it; leave its selection/scroll alone.
     const editorHasDomFocus =
       !!boundaryElement?.ownerDocument.activeElement &&
       boundaryElement.contains(boundaryElement.ownerDocument.activeElement)
 
-    // Don't do anything if the editor is focused and its selection focus path already equals the
-    // focusPath. When focus came from outside the editor (e.g. Visual Editing), the editor can
-    // retain a matching selection while blurred; we must still re-focus and scroll to it (#12894).
+    const currentSelection = selectionRef.current
+
+    // The first open member of any kind, used below as the fallback target to scroll to / focus.
+    const openItem = portableTextMemberItems.find((m) => m.member.open)
+
+    // An open annotation/object/inline member has a popover mounted (focus portals outside the boundary).
+    // Text blocks mount none and are excluded, so a re-click from outside still re-focuses them (#12894).
+    const openEditingItem = portableTextMemberItems.find(
+      (m) =>
+        m.member.open &&
+        (m.kind === 'annotation' || m.kind === 'objectBlock' || m.kind === 'inlineObject'),
+    )
+
+    // Bail only when the selection matches the focusPath AND the editor still owns focus (real DOM
+    // focus, or an open editing popover). Focus from outside (Visual Editing) means neither (#12894).
     if (
-      editorHasDomFocus &&
-      selection?.focus.path &&
-      isEqual(selection.focus.path, focusPath.slice(0, selection.focus.path.length))
+      currentSelection?.focus.path &&
+      isEqual(
+        currentSelection.focus.path,
+        focusPath.slice(0, currentSelection.focus.path.length),
+      ) &&
+      (editorHasDomFocus || Boolean(openEditingItem))
     ) {
       return
     }
 
     // Find the focused editor member item (if any)
     const focusedItem = portableTextMemberItems.find((m) => m.member.item.focused)
-
-    // Find the opened member item (if any)
-    const openItem = portableTextMemberItems.find((m) => m.member.open)
 
     // The related editor member to scroll to, or focus, according to the given focusPath
     const relatedEditorItem = focusedItem || openItem
@@ -123,15 +141,12 @@ export function useTrackFocusPath(props: Props): void {
 
         // Select and focus the editor if we produced a path
         if (path.length) {
-          // Re-focusing a block that is already the editor's current selection is a no-op:
-          // the editor emits no selection change, so neither its native focus nor its
-          // scroll-into-view runs and the block can't be re-entered (#12894).
-          // Deselect first so the subsequent select is a genuine change.
-          // Slice the selection path down to the target path length (the reverse of the guard
-          // above): we only care whether the editor is already sitting on this exact block,
-          // regardless of which child the caret is on.
+          // Re-selecting the editor's current selection is a no-op (no event fires, so no native
+          // focus or scroll) and the block can't be re-entered (#12894). Deselect first to force a
+          // real change. isSameSelection slices the selection to the target length: same block, any child.
           const isSameSelection =
-            selection?.focus.path && isEqual(selection.focus.path.slice(0, path.length), path)
+            currentSelection?.focus.path &&
+            isEqual(currentSelection.focus.path.slice(0, path.length), path)
           if (isTextBlock && isSameSelection) {
             PortableTextEditor.select(editor, null)
           }
@@ -140,21 +155,12 @@ export function useTrackFocusPath(props: Props): void {
             anchor: {path, offset: 0},
             focus: {path, offset: 0},
           })
-          // Object blocks will have their interface opened when focused,
-          // so only call focus for regular text blocks
+          // Object blocks open their interface when focused, so only call focus for text blocks.
           if (isTextBlock) {
             PortableTextEditor.focus(editor)
           }
         }
       }
     }
-  }, [
-    boundaryElement,
-    editor,
-    elementRefs,
-    focusPath,
-    onItemClose,
-    portableTextMemberItems,
-    selection?.focus.path,
-  ])
+  }, [boundaryElement, editor, elementRefs, focusPath, onItemClose, portableTextMemberItems])
 }


### PR DESCRIPTION
### Description

Fixes #12894. Under Presentation / Visual Editing, after editing a Portable Text block and then clicking a non-PT element (for example the document title), clicking that same block again in the preview failed to re-focus and scroll the editor pane to it. The URL focus path and the preview overlay updated correctly, but the editor never scrolled back to the block, so it could not be re-entered. The workaround was to click a different block first.

Root cause: re-focusing the block that is already the editor's current/last selection is a no-op chain in `@portabletext/editor`. `applySelect` emits nothing when the selection is unchanged, so no selection event fires, the editor's own scroll-into-view never runs, and `DOMEditor.focus` early-returns because the editor is considered already focused. The only outer-pane scroll path (`useTrackFocusPath`) also bailed out via an early-return guard whenever the editor's selection already matched the focus path, even when DOM focus had moved elsewhere.

The fix is entirely in `useTrackFocusPath.tsx`:

- The early-return guard now only bails when the editor genuinely owns focus: either it holds DOM focus, or one of its own editing popovers/dialogs is open (an open member of kind annotation, objectBlock, or inlineObject). When focus came from outside the editor (Visual Editing, the document title) neither holds, so the hook proceeds and re-focuses/scrolls to the block (#12894). Text blocks are intentionally excluded from the open-popover check - their open flag is set merely by Visual Editing projecting a path into the block, so a re-click from outside still re-focuses them.
- Before re-selecting the target, if the editor's current selection already matches that path, it first calls `PortableTextEditor.select(editor, null)` so the subsequent `select` is a genuine change that emits the selection event driving focus and scroll. This deselect is gated to text blocks (object blocks open via form state and do not call `focus()`).
- The effect reads the editor selection from a ref rather than subscribing to it as a dependency. Subscribing caused the effect to re-fire on its own `select()` calls; in browsers where `focus()` does not synchronously restore DOM focus (observed as a hanging WebKit CI job) that produced an infinite re-select loop. Reading via a ref means only genuine `focusPath` / member changes re-run the effect.

| - | - |
|--------|--------|
| Before | <img width="912" height="690" alt="PresentationPTEFocusBeforePR" src="https://github.com/user-attachments/assets/a9e0a91e-61fe-4078-b514-92b6110813af" /> |
| After | <img width="912" height="690" alt="PresentationPTEFocusAfterPR" src="https://github.com/user-attachments/assets/8795887f-a6df-48fa-ad21-d79a27b1964b" /> |

### What to review

The change is confined to `packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx`. The three things worth a close look: (1) the open-popover guard excludes text blocks, which is what lets a re-click from outside re-focus a text block while still leaving annotation/object/inline-object edit popovers alone; (2) the deselect-then-reselect is gated to text blocks; (3) selection is read from a ref and removed from the effect dependency array, which is what prevents the effect from re-triggering itself in a loop. The guard narrowing should also be reviewed for any regression to normal in-editor editing, where the editor holds DOM focus and should continue to manage its own selection and scrolling untouched.

### Testing

Manually verified in the Presentation tool on a deep block in a long Portable Text field (far enough down that the editor pane must scroll to reach it): editing the block, clicking the document title, then re-clicking the same block now scrolls the editor pane back to it and re-enters it. First-click focus, title clicks, and near-top blocks behave as before. Annotation and object-block edit popovers keep their focus while editing.

Verified locally under all three browser engines (Vitest browser mode / Playwright): the existing `FocusTracking`, `Annotations`, and `ObjectBlock` browser suites pass, including WebKit (the engine where the earlier re-select loop manifested as a hang).

No new automated regression test is included here. The flat browser harness for this hook cannot reproduce the outer-pane scroll (all blocks are visible, so nothing needs to scroll); an e2e Playwright test driving a scrollable editor pane against a deep block is a sensible follow-up.

### Notes for release

Fixes a bug where, in Presentation / Visual Editing, you could not re-enter a Portable Text block by clicking it again in the preview after editing it and then clicking another element such as the document title. The editor now scrolls to and re-focuses the block on the repeated click.
