### PR TITLE
perf(core): defer schema compilation until after auth resolves

### DIFF
--- a/packages/sanity/src/core/config/__tests__/prepareConfig.test.ts
+++ b/packages/sanity/src/core/config/__tests__/prepareConfig.test.ts
@@ -1,8 +1,25 @@
+import {createClient} from '@sanity/client'
+import {firstValueFrom} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
+import type * as SchemaModule from '../../schema'
+import {createSchema} from '../../schema'
+import {createMockAuthStore} from '../../store'
 import {getCollectedConfigWarnings} from '../configWarnings'
 import {prepareConfig} from '../prepareConfig'
+import {SchemaError} from '../SchemaError'
 import {type WorkspaceOptions} from '../types'
+
+// Wrap createSchema in a spy so ordering tests can assert call timing.
+// Using importActual on the small internal schema module (not the full 'sanity'
+// package) is safe and avoids the timeout risk documented in MEMORY.md.
+vi.mock('../../schema', async () => {
+  const actual = await vi.importActual<typeof SchemaModule>('../../schema')
+  return {
+    ...actual,
+    createSchema: vi.fn(actual.createSchema),
+  }
+})
 
 // Minimum viable workspace for prepareConfig — avoids pulling in real
 // schema/client resolution. projectId is randomized per test so the
@@ -189,5 +206,107 @@ describe('prepareConfig — workspace hidden property', () => {
     ])
 
     expect(workspaces.find((w) => w.name === 'callback')?.hidden).toBe(hidden)
+  })
+})
+
+// Build a minimal Sanity client that satisfies resolveSource without making
+// real network requests.
+function createTestClient(projectId: string) {
+  return createClient({
+    projectId,
+    dataset: 'test',
+    apiVersion: '2021-06-07',
+    useCdn: false,
+  })
+}
+
+describe('prepareConfig — deferred schema compilation', () => {
+  const createSchemaSpy = vi.mocked(createSchema)
+
+  beforeEach(() => {
+    createSchemaSpy.mockClear()
+  })
+
+  describe('(a) ordering: createSchema not called until source$ is subscribed', () => {
+    it('does not call createSchema during prepareConfig; calls it exactly once on first subscription', async () => {
+      const projectId = `ordering-${Math.random().toString(36).slice(2)}`
+      const client = createTestClient(projectId)
+      const authStore = createMockAuthStore({client, currentUser: null})
+
+      const {workspaces} = prepareConfig([
+        createWorkspace({name: 'default', projectId, auth: authStore}),
+      ])
+
+      // Schema compile must NOT have run yet — prepareConfig is pre-auth.
+      expect(createSchemaSpy).not.toHaveBeenCalled()
+
+      const sourceObservable = workspaces[0].__internal.sources[0].source
+
+      // First subscription triggers auth.state emission -> getSchema() -> createSchema.
+      await firstValueFrom(sourceObservable)
+
+      expect(createSchemaSpy).toHaveBeenCalledTimes(1)
+
+      // Second subscription reuses the memoized schema; createSchema stays at 1.
+      await firstValueFrom(sourceObservable)
+
+      expect(createSchemaSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('(b) deferred schema error: SchemaError surfaces on source$ instead of synchronously', () => {
+    it('does not throw from prepareConfig when schema types are invalid; source$ errors with SchemaError', async () => {
+      const projectId = `schema-err-${Math.random().toString(36).slice(2)}`
+      const client = createTestClient(projectId)
+      const authStore = createMockAuthStore({client, currentUser: null})
+
+      // A type definition whose name collides with a built-in type triggers a
+      // schema validation error (severity: 'error') in @sanity/schema.
+      const invalidSchemaTypes = [{name: 'object', type: 'object', fields: []}]
+
+      // prepareConfig must NOT throw synchronously even with an invalid schema.
+      const {workspaces} = prepareConfig([
+        createWorkspace({
+          name: 'default',
+          projectId,
+          auth: authStore,
+          schema: {types: invalidSchemaTypes},
+        }),
+      ])
+
+      const sourceObservable = workspaces[0].__internal.sources[0].source
+
+      // Subscribing triggers the deferred compile; the SchemaError must surface.
+      let caughtError: unknown
+      await firstValueFrom(sourceObservable).catch((err) => {
+        caughtError = err
+      })
+
+      expect(caughtError).toBeInstanceOf(SchemaError)
+    })
+  })
+
+  describe('(c) end-to-end: valid workspace resolves Source with expected deferred schema', () => {
+    it('source$ emits a resolved Source whose schema contains the configured document types', async () => {
+      const projectId = `e2e-${Math.random().toString(36).slice(2)}`
+      const client = createTestClient(projectId)
+      const authStore = createMockAuthStore({client, currentUser: null})
+
+      const {workspaces} = prepareConfig([
+        createWorkspace({
+          name: 'default',
+          projectId,
+          auth: authStore,
+          schema: {
+            types: [{name: 'article', type: 'document', fields: [{name: 'title', type: 'string'}]}],
+          },
+        }),
+      ])
+
+      const resolvedSource = await firstValueFrom(workspaces[0].__internal.sources[0].source)
+
+      expect(resolvedSource.schema).toBeDefined()
+      expect(resolvedSource.schema.getTypeNames()).toContain('article')
+    })
   })
 })

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -339,35 +339,39 @@ export function prepareConfig(
         })
       }
 
-      const schema = createSchema({
-        name: source.name,
-        types: schemaTypes,
-      })
-
-      const schemaValidationProblemGroups = schema._validation
-      const schemaErrors = schemaValidationProblemGroups?.filter((msg) =>
-        msg.problems.some(isError),
-      )
-
-      if (schemaValidationProblemGroups && schemaErrors?.length) {
-        // TODO: consider using the `ConfigResolutionError`
-        throw new SchemaError(schema)
-      }
-
       const auth = getAuthStore(source)
       const i18n = prepareI18n(source)
+
+      // Compile the schema lazily on the first auth emission (post-auth) and
+      // memoize it so re-emissions of auth.state do not trigger recompilation.
+      let compiledSchema: Schema | undefined
+      const getSchema = (): Schema => {
+        if (compiledSchema) return compiledSchema
+        const schema = createSchema({name: source.name, types: schemaTypes})
+        const schemaValidationProblemGroups = schema._validation
+        const schemaErrors = schemaValidationProblemGroups?.filter((msg) =>
+          msg.problems.some(isError),
+        )
+        if (schemaValidationProblemGroups && schemaErrors?.length) {
+          // TODO: consider using the `ConfigResolutionError`
+          throw new SchemaError(schema)
+        }
+        compiledSchema = schema
+        return schema
+      }
+
       const source$ = auth.state.pipe(
-        map(({client, authenticated, currentUser}) => {
-          return resolveSource({
+        map(({client, authenticated, currentUser}) =>
+          resolveSource({
             config: source,
             client,
             currentUser,
-            schema,
+            schema: getSchema(),
             authenticated,
             auth,
             i18n,
-          })
-        }),
+          }),
+        ),
         shareReplay(1),
       )
 
@@ -377,7 +381,6 @@ export function prepareConfig(
         dataset: source.dataset,
         title: source.title || startCase(source.name),
         auth,
-        schema,
         i18n: i18n.source,
         source: source$,
       }
@@ -391,7 +394,6 @@ export function prepareConfig(
       basePath: joinBasePath(rootPath, rootSource.basePath),
       dataset: rootSource.dataset,
       apiHost: rootSource.apiHost,
-      schema: resolvedSources[0].schema,
       i18n: resolvedSources[0].i18n,
       customIcon: !!rootSource.icon,
       icon: normalizeIcon(rootSource.icon, title, `${rootSource.projectId} ${rootSource.dataset}`),

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -1109,7 +1109,11 @@ export interface WorkspaceSummary extends DefaultPluginsWorkspaceOptions {
    */
   apiHost?: string
   theme: StudioTheme
-  schema: Schema
+  /**
+   * Schema compiled from this workspace's source types. Resolved post-auth
+   * via the source observable; undefined until the first auth emission.
+   */
+  schema?: Schema
   i18n: LocaleSource
   /**
    * @internal
@@ -1122,7 +1126,11 @@ export interface WorkspaceSummary extends DefaultPluginsWorkspaceOptions {
       dataset: string
       title: string
       auth: AuthStore
-      schema: Schema
+      /**
+       * Schema compiled from this source's types. Resolved post-auth via the
+       * source observable; undefined until the first auth emission.
+       */
+      schema?: Schema
       i18n: LocaleSource
       source: Observable<Source>
     }>


### PR DESCRIPTION
### Description

`prepareConfig` compiles every workspace's schema synchronously inside the `resolvedSources` map, during the `WorkspacesProvider` render that sits above `AuthBoundary`. The auth store needs none of that work to resolve auth, so every schema in the config - one per workspace - is compiled before the studio can even decide whether the user is logged in. Production telemetry shows this pre-mount path is where the auth-ready metric lives.

This PR moves `createSchema` inside the `source$ = auth.state.pipe(map(...))` observable, so a schema compiles lazily on the first post-auth emission and only for sources that are actually subscribed (the active workspace). A memoized closure plus `shareReplay(1)` guarantees one compile per source across `auth.state` re-emissions. `WorkspaceSummary.schema` and `__internal.sources[].schema` become optional (`schema?: Schema`); `Source.schema` and `Workspace.schema` stay non-nullable.

One deliberate tradeoff: a schema validation error no longer throws synchronously from `prepareConfig`. It now errors the source observable, propagating through `WorkspaceLoader` to `StudioErrorBoundary` and rendering the same `SchemaErrorsScreen` - after auth resolves instead of before.

### What to review

- `getSchema()` memoization in `prepareConfig.tsx` - `auth.state` re-emits on token refresh and dual-cookie rechecks, so the closure must compile exactly once (the ordering test asserts call count stays at 1 across re-emissions)
- The deferred `SchemaError` path - it now reaches `StudioErrorBoundary` via the source observable rather than a synchronous throw; verified by test, but worth a second pair of eyes on `WorkspaceLoader`'s error handling
- The typing change in `types.ts` - `WorkspaceSummary.schema` is `@internal`; we audited every provider between `WorkspacesProvider` and `AuthBoundary` (visible-workspaces, workspace matcher, theme) and none read `.schema`

### Testing

Three new tests in `prepareConfig.test.ts`: an ordering test (the `createSchema` spy is uncalled after `prepareConfig`, called exactly once after the first source subscription, and stays at 1 across re-emissions), a deferred-error test (an invalid schema no longer throws synchronously but errors the source observable with `SchemaError`), and an end-to-end test (a valid workspace resolves a `Source` whose `schema.getTypeNames()` contains the configured types).

Benchmarked locally on production builds of `dev/test-studio` (logged-out and logged-in, 12 reloads each, interleaved to rule out drift): logged-out auth-ready median dropped 1049ms to 410ms and logged-in time-to-content 1792ms to 1170ms. Caveat: the test studio defines 23 workspaces, so these numbers mostly reflect eliminating 22 sibling compiles; single-workspace studios should expect a modest win, with the ordering guarantee (no schema compile before auth resolves) as the primary deliverable.

### Notes for release

Sanity Studio now defers schema compilation until after authentication resolves, and compiles only the active workspace's schema instead of every workspace's. Multi-workspace studios reach the auth/login state noticeably faster. Schema validation errors still render the same error screen, but they now surface after the auth check instead of before it.


### How this fits

Part of the studio startup performance effort (cutting pre-login execution from auth-ready p95). This PR removes eager per-workspace schema compilation from the pre-auth path - the win is modest for single-workspace studios but large for 20+-workspace ones. Independent of the other startup PRs; lands in any order.
