### PR TITLE
chore(divergence): apply oxfmt 0.54 formatting to DivergenceDetail

### DIFF
--- a/packages/sanity/src/core/divergence/components/DivergenceDetail.tsx
+++ b/packages/sanity/src/core/divergence/components/DivergenceDetail.tsx
@@ -128,10 +128,11 @@ export const DivergenceDetail: ComponentType<DivergenceDetailProps> = ({
               />
             ) : (
               <>
-                {diff && DiffComponent && (
-                  // eslint-disable-next-line react-hooks/static-components
-                  <DiffComponent diff={diff} schemaType={divergence.schemaType} />
-                )}
+                {diff &&
+                  DiffComponent && (
+                    // eslint-disable-next-line react-hooks/static-components
+                    <DiffComponent diff={diff} schemaType={divergence.schemaType} />
+                  )}
               </>
             )}
           </Card>


### PR DESCRIPTION
main's `formatCheck` is failing because the `oxfmt` bump to ^0.54.0 (#13066) flags `DivergenceDetail.tsx` as unformatted. This applies the 0.54.0 formatting to that one file (JSX `&&` wrapping only, no behaviour change), unblocking `formatCheck` on main and all open PRs.

### Notes for release
N/A