### PR TITLE
feat(core): consume early-auth probe to skip a pre-mount users/me round-trip

### DIFF
--- a/packages/sanity/src/core/store/authStore/__tests__/createAuthStore.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/createAuthStore.test.ts
@@ -887,6 +887,41 @@ describe('early auth probe integration', () => {
     expect(usersMeCallCount).toBe(0)
   })
 
+  it('case 2b: settled ok probe with id-less user ({}) -> falls back to getCurrentUser; malformed body never surfaces', async () => {
+    let usersMeCallCount = 0
+
+    const factory = (_options: SanityClientConfig): SanityClient =>
+      ({
+        request: vi.fn(({uri}: {uri: string}) => {
+          if (uri === '/users/me') {
+            usersMeCallCount += 1
+            return Promise.resolve(MOCK_USER)
+          }
+          return Promise.resolve({})
+        }),
+      }) as unknown as SanityClient
+
+    // Probe resolves with a body that looks like ok but has no id — malformed 200 envelope.
+    seedEarlyAuth({promise: Promise.resolve({type: 'ok', user: {}})})
+
+    const store = _createAuthStore({
+      projectId: PROJECT_ID,
+      dataset: DATASET,
+      loginMethod: 'cookie',
+      clientFactory: factory,
+      getSessionId: () => undefined,
+      consumeHashToken: () => undefined,
+    })
+
+    const state = await waitForState(store, (s) => s.authenticated)
+
+    // The fallback must have fired exactly once
+    expect(usersMeCallCount).toBe(1)
+    // The emitted user must be the real MOCK_USER, never the empty junk object
+    expect(state.currentUser).toEqual(MOCK_USER)
+    expect((state.currentUser as CurrentUser | null)?.id).toBe('mock-user-123')
+  })
+
   it('case 3: projectId mismatch -> falls back to getCurrentUser, request count 1', async () => {
     let usersMeCallCount = 0
 
@@ -948,19 +983,11 @@ describe('early auth probe integration', () => {
   it('case 5: pending probe -> fallback fires immediately while probe is still pending; fallback result wins', async () => {
     let usersMeCallCount = 0
 
-    // Resolve control: we control when getCurrentUser returns
-    let resolveGetCurrentUser!: () => void
-    const getCurrentUserBarrier = new Promise<void>((resolve) => {
-      resolveGetCurrentUser = resolve
-    })
-
     const factory = (_options: SanityClientConfig): SanityClient =>
       ({
         request: vi.fn(({uri}: {uri: string}) => {
           if (uri === '/users/me') {
             usersMeCallCount += 1
-            // Return immediately (barrier already resolves synchronously here)
-            void getCurrentUserBarrier
             return Promise.resolve(MOCK_USER)
           }
           return Promise.resolve({})
@@ -988,8 +1015,67 @@ describe('early auth probe integration', () => {
     expect(state.currentUser).toEqual(MOCK_USER)
     // Assert the /users/me request was fired while the probe was still pending
     expect(usersMeCallCount).toBe(1)
+  })
 
-    resolveGetCurrentUser()
+  it('case 5b: pending probe settles with valid user before fallback resolves -> probe wins, /users/me fired exactly once (hedge)', async () => {
+    let usersMeCallCount = 0
+
+    // Deferred probe: starts pending so the store enters the hedge race path.
+    let resolveProbe!: (value: {type: 'ok'; user: typeof MOCK_USER}) => void
+    const probeDeferred = new Promise<{type: 'ok'; user: typeof MOCK_USER}>((resolve) => {
+      resolveProbe = resolve
+    })
+
+    // Fallback that never resolves — probe wins the race.
+    // We still count the call to confirm the hedge fired.
+    let usersMeResolve!: (value: CurrentUser) => void
+    const factoryBlockingFallback = (_options: SanityClientConfig): SanityClient =>
+      ({
+        request: vi.fn(({uri}: {uri: string}) => {
+          if (uri === '/users/me') {
+            usersMeCallCount += 1
+            // Block forever — probe wins the race
+            return new Promise<CurrentUser>((resolve) => {
+              usersMeResolve = resolve
+            })
+          }
+          return Promise.resolve({})
+        }),
+      }) as unknown as SanityClient
+
+    seedEarlyAuth({promise: probeDeferred})
+
+    const store = _createAuthStore({
+      projectId: PROJECT_ID,
+      dataset: DATASET,
+      loginMethod: 'cookie',
+      clientFactory: factoryBlockingFallback,
+      getSessionId: () => undefined,
+      consumeHashToken: () => undefined,
+    })
+
+    // Subscribe immediately so initial$ starts executing.
+    // The probe is still pending so the store enters the hedge race:
+    // it fires fetchCurrentUser() (incrementing usersMeCallCount) then awaits Promise.race.
+    const statePromise = waitForState(store, (s) => s.authenticated)
+
+    // Flush enough microtasks for initial$ to reach the Promise.race.
+    // initial$ does: await Promise.resolve() x2 (settled-check) + settled check -> PENDING
+    // -> fires fetchCurrentUser -> awaits Promise.race. That's ~5 await hops total.
+    for (let tick = 0; tick < 10; tick++) {
+      await Promise.resolve()
+    }
+
+    // Now /users/me must have been called (hedge fired). Resolve the probe so it wins.
+    expect(usersMeCallCount).toBe(1)
+    resolveProbe({type: 'ok', user: MOCK_USER})
+
+    const state = await statePromise
+
+    expect(state.authenticated).toBe(true)
+    expect(state.currentUser).toEqual(MOCK_USER)
+    // Unblock the fallback promise to avoid dangling promises
+    usersMeResolve(MOCK_USER)
   })
 
   it('case 6: pending probe + fallback rejects (CorsOriginError) -> rejection propagates', async () => {

--- a/packages/sanity/src/core/store/authStore/__tests__/createAuthStore.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/createAuthStore.test.ts
@@ -9,6 +9,7 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {CorsOriginError} from '../../cors'
 import {_createAuthStore} from '../createAuthStore'
+import {_clearEarlyAuthGlobal, type EarlyAuthProbeEntry} from '../earlyAuthProbe'
 import {type AuthStore} from '../types'
 
 // Mock supportsLocalStorage to return true so createBroadcastStorage uses localStorage.
@@ -786,5 +787,240 @@ describe('createAuthStore: cross-tab sync', () => {
       // can render CorsOriginErrorScreen.
       await expect(firstValueFrom(store.state)).rejects.toBeInstanceOf(CorsOriginError)
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Early auth probe integration
+// ---------------------------------------------------------------------------
+
+function seedEarlyAuth(overrides?: Partial<EarlyAuthProbeEntry>): void {
+  const entry: EarlyAuthProbeEntry = {
+    projectId: PROJECT_ID,
+    apiHost: 'api.sanity.io',
+    credential: 'cookie',
+    token: null,
+    startedAt: Date.now(),
+    promise: Promise.resolve({type: 'ok', user: MOCK_USER}),
+    ...overrides,
+  }
+  // @ts-expect-error - window.__sanityEarlyAuth not declared
+  window.__sanityEarlyAuth = entry
+}
+
+describe('early auth probe integration', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    window.location.hash = ''
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    window.location.hash = ''
+    _clearEarlyAuthGlobal()
+    vi.restoreAllMocks()
+  })
+
+  it('case 1: matching fresh settled ok probe -> getCurrentUser request count is 0; store emits probe user', async () => {
+    let usersMeCallCount = 0
+
+    const factory = (_options: SanityClientConfig): SanityClient =>
+      ({
+        request: vi.fn(({uri}: {uri: string}) => {
+          if (uri === '/users/me') {
+            usersMeCallCount += 1
+            return Promise.resolve(MOCK_USER)
+          }
+          return Promise.resolve({})
+        }),
+      }) as unknown as SanityClient
+
+    // Seed a matching, fresh, synchronously-resolved probe
+    seedEarlyAuth({promise: Promise.resolve({type: 'ok', user: MOCK_USER})})
+
+    const store = _createAuthStore({
+      projectId: PROJECT_ID,
+      dataset: DATASET,
+      loginMethod: 'cookie',
+      clientFactory: factory,
+      getSessionId: () => undefined,
+      consumeHashToken: () => undefined,
+    })
+
+    const state = await waitForState(store, (s) => s.authenticated)
+
+    expect(state.authenticated).toBe(true)
+    expect(state.currentUser).toEqual(MOCK_USER)
+    // Probe was used; no /users/me request should have been made
+    expect(usersMeCallCount).toBe(0)
+  })
+
+  it('case 2: matching settled unauthenticated probe -> store emits authenticated:false, request count 0', async () => {
+    let usersMeCallCount = 0
+
+    const factory = (_options: SanityClientConfig): SanityClient =>
+      ({
+        request: vi.fn(({uri}: {uri: string}) => {
+          if (uri === '/users/me') {
+            usersMeCallCount += 1
+            return Promise.resolve(MOCK_USER)
+          }
+          return Promise.resolve({})
+        }),
+      }) as unknown as SanityClient
+
+    seedEarlyAuth({promise: Promise.resolve({type: 'unauthenticated'})})
+
+    const store = _createAuthStore({
+      projectId: PROJECT_ID,
+      dataset: DATASET,
+      loginMethod: 'cookie',
+      clientFactory: factory,
+      getSessionId: () => undefined,
+      consumeHashToken: () => undefined,
+    })
+
+    const state = await waitForState(store, (s) => !s.authenticated)
+
+    expect(state.authenticated).toBe(false)
+    expect(state.currentUser).toBeNull()
+    expect(usersMeCallCount).toBe(0)
+  })
+
+  it('case 3: projectId mismatch -> falls back to getCurrentUser, request count 1', async () => {
+    let usersMeCallCount = 0
+
+    const factory = (_options: SanityClientConfig): SanityClient =>
+      ({
+        request: vi.fn(({uri}: {uri: string}) => {
+          if (uri === '/users/me') {
+            usersMeCallCount += 1
+            return Promise.resolve(MOCK_USER)
+          }
+          return Promise.resolve({})
+        }),
+      }) as unknown as SanityClient
+
+    // Probe with mismatched projectId
+    seedEarlyAuth({projectId: 'wrong-project'})
+
+    const store = _createAuthStore({
+      projectId: PROJECT_ID,
+      dataset: DATASET,
+      loginMethod: 'cookie',
+      clientFactory: factory,
+      getSessionId: () => undefined,
+      consumeHashToken: () => undefined,
+    })
+
+    await waitForState(store, (s) => s.authenticated)
+    expect(usersMeCallCount).toBe(1)
+  })
+
+  it('case 4: absent probe -> falls back to getCurrentUser, request count 1', async () => {
+    let usersMeCallCount = 0
+
+    const factory = (_options: SanityClientConfig): SanityClient =>
+      ({
+        request: vi.fn(({uri}: {uri: string}) => {
+          if (uri === '/users/me') {
+            usersMeCallCount += 1
+            return Promise.resolve(MOCK_USER)
+          }
+          return Promise.resolve({})
+        }),
+      }) as unknown as SanityClient
+
+    // No probe seeded
+    const store = _createAuthStore({
+      projectId: PROJECT_ID,
+      dataset: DATASET,
+      loginMethod: 'cookie',
+      clientFactory: factory,
+      getSessionId: () => undefined,
+      consumeHashToken: () => undefined,
+    })
+
+    await waitForState(store, (s) => s.authenticated)
+    expect(usersMeCallCount).toBe(1)
+  })
+
+  it('case 5: pending probe -> fallback fires immediately while probe is still pending; fallback result wins', async () => {
+    let usersMeCallCount = 0
+
+    // Resolve control: we control when getCurrentUser returns
+    let resolveGetCurrentUser!: () => void
+    const getCurrentUserBarrier = new Promise<void>((resolve) => {
+      resolveGetCurrentUser = resolve
+    })
+
+    const factory = (_options: SanityClientConfig): SanityClient =>
+      ({
+        request: vi.fn(({uri}: {uri: string}) => {
+          if (uri === '/users/me') {
+            usersMeCallCount += 1
+            // Return immediately (barrier already resolves synchronously here)
+            void getCurrentUserBarrier
+            return Promise.resolve(MOCK_USER)
+          }
+          return Promise.resolve({})
+        }),
+      }) as unknown as SanityClient
+
+    // A probe promise that never settles — the hedge must fire the fallback anyway
+    const neverSettlingProbe = new Promise<never>(() => {})
+    seedEarlyAuth({promise: neverSettlingProbe})
+
+    const store = _createAuthStore({
+      projectId: PROJECT_ID,
+      dataset: DATASET,
+      loginMethod: 'cookie',
+      clientFactory: factory,
+      getSessionId: () => undefined,
+      consumeHashToken: () => undefined,
+    })
+
+    // Wait for the store to emit. Since the probe never settles,
+    // the fallback must have fired immediately and won.
+    const state = await waitForState(store, (s) => s.authenticated)
+
+    expect(state.authenticated).toBe(true)
+    expect(state.currentUser).toEqual(MOCK_USER)
+    // Assert the /users/me request was fired while the probe was still pending
+    expect(usersMeCallCount).toBe(1)
+
+    resolveGetCurrentUser()
+  })
+
+  it('case 6: pending probe + fallback rejects (CorsOriginError) -> rejection propagates', async () => {
+    const nonAuthError = Object.assign(new Error('Network error'), {
+      statusCode: 0,
+      isNetworkError: true,
+    })
+
+    const factory = (_options: SanityClientConfig): SanityClient =>
+      ({
+        request: vi.fn(({uri, withCredentials}: {uri: string; withCredentials?: boolean}) => {
+          if (uri === '/users/me') return Promise.reject(nonAuthError)
+          if (uri === '/ping' && withCredentials === false) return Promise.resolve({})
+          return Promise.resolve({})
+        }),
+      }) as unknown as SanityClient
+
+    // Never-settling probe: hedge fires fallback; fallback rejects with CorsOriginError
+    const neverSettlingProbe = new Promise<never>(() => {})
+    seedEarlyAuth({promise: neverSettlingProbe})
+
+    const store = _createAuthStore({
+      projectId: PROJECT_ID,
+      dataset: DATASET,
+      loginMethod: 'cookie',
+      clientFactory: factory,
+      getSessionId: () => undefined,
+      consumeHashToken: () => undefined,
+    })
+
+    // The CorsOriginError rejection must propagate out of initial$
+    await expect(firstValueFrom(store.state)).rejects.toBeInstanceOf(CorsOriginError)
   })
 })

--- a/packages/sanity/src/core/store/authStore/__tests__/earlyAuthProbe.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/earlyAuthProbe.test.ts
@@ -150,6 +150,30 @@ describe('consumeEarlyAuthProbe guard matrix', () => {
     expect(value).toBe(EARLY_PROBE_MISS)
   })
 
+  it('case 16: ok result with no id ({}) -> resolves to EARLY_PROBE_MISS (id-guard)', async () => {
+    seedProbe({promise: Promise.resolve({type: 'ok', user: {}})})
+    const result = consumeEarlyAuthProbe(BASE_OPTS)
+    expect(result).not.toBe(EARLY_PROBE_MISS)
+    const value = await (result as Promise<unknown>)
+    expect(value).toBe(EARLY_PROBE_MISS)
+  })
+
+  it('case 17: ok result with user: null -> resolves to EARLY_PROBE_MISS (id-guard)', async () => {
+    seedProbe({promise: Promise.resolve({type: 'ok', user: null})})
+    const result = consumeEarlyAuthProbe(BASE_OPTS)
+    expect(result).not.toBe(EARLY_PROBE_MISS)
+    const value = await (result as Promise<unknown>)
+    expect(value).toBe(EARLY_PROBE_MISS)
+  })
+
+  it('case 18: ok result with non-string id ({id: 123}) -> resolves to EARLY_PROBE_MISS (id-guard)', async () => {
+    seedProbe({promise: Promise.resolve({type: 'ok', user: {id: 123}})})
+    const result = consumeEarlyAuthProbe(BASE_OPTS)
+    expect(result).not.toBe(EARLY_PROBE_MISS)
+    const value = await (result as Promise<unknown>)
+    expect(value).toBe(EARLY_PROBE_MISS)
+  })
+
   it('case 14: consume-once: second call with identical opts -> EARLY_PROBE_MISS (global deleted on first)', () => {
     seedProbe()
 

--- a/packages/sanity/src/core/store/authStore/__tests__/earlyAuthProbe.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/earlyAuthProbe.test.ts
@@ -1,0 +1,172 @@
+import {type CurrentUser} from '@sanity/types'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import {
+  _clearEarlyAuthGlobal,
+  consumeEarlyAuthProbe,
+  EARLY_PROBE_MISS,
+  type EarlyAuthProbeEntry,
+} from '../earlyAuthProbe'
+
+const MOCK_USER: CurrentUser = {
+  id: 'user-abc',
+  name: 'Test User',
+  email: 'test@example.com',
+  profileImage: '',
+  provider: 'google',
+  role: '',
+  roles: [{name: 'administrator', title: 'Administrator'}],
+}
+
+const BASE_OPTS = {
+  projectId: 'myproject',
+  apiHost: 'https://api.sanity.io',
+  credential: 'cookie' as const,
+  token: null,
+}
+
+function seedProbe(overrides?: Partial<EarlyAuthProbeEntry>): void {
+  const entry: EarlyAuthProbeEntry = {
+    projectId: 'myproject',
+    apiHost: 'api.sanity.io',
+    credential: 'cookie',
+    token: null,
+    startedAt: Date.now(),
+    promise: Promise.resolve({type: 'ok', user: MOCK_USER}),
+    ...overrides,
+  }
+  // @ts-expect-error - window.__sanityEarlyAuth not declared
+  window.__sanityEarlyAuth = entry
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  // Only clear global if window is available (after unstubAllGlobals it should be)
+  if (typeof window !== 'undefined') {
+    _clearEarlyAuthGlobal()
+  }
+})
+
+describe('consumeEarlyAuthProbe guard matrix', () => {
+  it('case 1: window undefined -> EARLY_PROBE_MISS (SSR guard)', () => {
+    vi.stubGlobal('window', undefined)
+    const result = consumeEarlyAuthProbe(BASE_OPTS)
+    expect(result).toBe(EARLY_PROBE_MISS)
+  })
+
+  it('case 2: global absent -> EARLY_PROBE_MISS (synchronous)', () => {
+    const result = consumeEarlyAuthProbe(BASE_OPTS)
+    expect(result).toBe(EARLY_PROBE_MISS)
+  })
+
+  it('case 3: full match + probe resolves ok -> resolves to user', async () => {
+    seedProbe({promise: Promise.resolve({type: 'ok', user: MOCK_USER})})
+    const result = consumeEarlyAuthProbe(BASE_OPTS)
+    expect(result).not.toBe(EARLY_PROBE_MISS)
+    const user = await (result as Promise<unknown>)
+    expect(user).toBe(MOCK_USER)
+  })
+
+  it('case 4: projectId mismatch -> EARLY_PROBE_MISS (synchronous)', () => {
+    seedProbe({projectId: 'other-project'})
+    const result = consumeEarlyAuthProbe(BASE_OPTS)
+    expect(result).toBe(EARLY_PROBE_MISS)
+  })
+
+  it('case 5: apiHost mismatch -> EARLY_PROBE_MISS (synchronous)', () => {
+    seedProbe({apiHost: 'api.other.io'})
+    const result = consumeEarlyAuthProbe(BASE_OPTS)
+    expect(result).toBe(EARLY_PROBE_MISS)
+  })
+
+  it('case 6: apiHost stored bare vs opts URL -> MATCH (normalization)', async () => {
+    // probe stores 'api.sanity.io'; opts provides 'https://api.sanity.io' -> should match
+    seedProbe({apiHost: 'api.sanity.io'})
+    const result = consumeEarlyAuthProbe({...BASE_OPTS, apiHost: 'https://api.sanity.io'})
+    expect(result).not.toBe(EARLY_PROBE_MISS)
+    const user = await (result as Promise<unknown>)
+    expect(user).toBe(MOCK_USER)
+  })
+
+  it('case 7: credential mismatch (probe token, opts cookie) -> EARLY_PROBE_MISS', () => {
+    seedProbe({credential: 'token', token: 'tok-x'})
+    const result = consumeEarlyAuthProbe({...BASE_OPTS, credential: 'cookie', token: null})
+    expect(result).toBe(EARLY_PROBE_MISS)
+  })
+
+  it('case 8: token mismatch (tok-a vs tok-b) -> EARLY_PROBE_MISS', () => {
+    seedProbe({credential: 'token', token: 'tok-a'})
+    const result = consumeEarlyAuthProbe({...BASE_OPTS, credential: 'token', token: 'tok-b'})
+    expect(result).toBe(EARLY_PROBE_MISS)
+  })
+
+  it('case 9: startedAt 6 minutes ago -> EARLY_PROBE_MISS (age cap)', () => {
+    const sixMinutesAgo = Date.now() - 6 * 60 * 1000
+    seedProbe({startedAt: sixMinutesAgo})
+    const result = consumeEarlyAuthProbe(BASE_OPTS)
+    expect(result).toBe(EARLY_PROBE_MISS)
+  })
+
+  it('case 10: startedAt 4 minutes ago -> proceeds (within 5-minute window)', async () => {
+    const fourMinutesAgo = Date.now() - 4 * 60 * 1000
+    seedProbe({startedAt: fourMinutesAgo, promise: Promise.resolve({type: 'ok', user: MOCK_USER})})
+    const result = consumeEarlyAuthProbe(BASE_OPTS)
+    expect(result).not.toBe(EARLY_PROBE_MISS)
+    const user = await (result as Promise<unknown>)
+    expect(user).toBe(MOCK_USER)
+  })
+
+  it('case 11: probe resolves unauthenticated -> resolves to null', async () => {
+    seedProbe({promise: Promise.resolve({type: 'unauthenticated'})})
+    const result = consumeEarlyAuthProbe(BASE_OPTS)
+    expect(result).not.toBe(EARLY_PROBE_MISS)
+    const value = await (result as Promise<unknown>)
+    expect(value).toBeNull()
+  })
+
+  it('case 12: probe resolves error -> resolves to EARLY_PROBE_MISS (preserves CorsOriginError path)', async () => {
+    seedProbe({promise: Promise.resolve({type: 'error', status: 500})})
+    const result = consumeEarlyAuthProbe(BASE_OPTS)
+    expect(result).not.toBe(EARLY_PROBE_MISS)
+    const value = await (result as Promise<unknown>)
+    expect(value).toBe(EARLY_PROBE_MISS)
+  })
+
+  it('case 13: probe.promise rejects -> resolves to EARLY_PROBE_MISS (NEVER rejects)', async () => {
+    // Create the rejection before seeding so we can attach a handler immediately
+    // to prevent "unhandled rejection" from bubbling up in the test runner.
+    const rejection = new Promise<never>((_, reject) => reject(new Error('network failure')))
+    // Attach a no-op catch here so the promise itself is always handled,
+    // regardless of when consumeEarlyAuthProbe attaches its own .catch.
+    rejection.catch(() => {})
+
+    seedProbe({promise: rejection})
+    const result = consumeEarlyAuthProbe(BASE_OPTS)
+    expect(result).not.toBe(EARLY_PROBE_MISS)
+
+    // Must not throw/reject
+    const value = await (result as Promise<unknown>)
+    expect(value).toBe(EARLY_PROBE_MISS)
+  })
+
+  it('case 14: consume-once: second call with identical opts -> EARLY_PROBE_MISS (global deleted on first)', () => {
+    seedProbe()
+
+    // First call consumes the global
+    const first = consumeEarlyAuthProbe(BASE_OPTS)
+    expect(first).not.toBe(EARLY_PROBE_MISS)
+
+    // Second call with same opts -> miss (global already deleted)
+    const second = consumeEarlyAuthProbe(BASE_OPTS)
+    expect(second).toBe(EARLY_PROBE_MISS)
+  })
+
+  it('case 15: StrictMode analogue: two calls with identical opts -> second is EARLY_PROBE_MISS', () => {
+    seedProbe()
+
+    void consumeEarlyAuthProbe(BASE_OPTS)
+    const secondResult = consumeEarlyAuthProbe(BASE_OPTS)
+    expect(secondResult).toBe(EARLY_PROBE_MISS)
+  })
+})

--- a/packages/sanity/src/core/store/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/authStore/createAuthStore.ts
@@ -146,6 +146,10 @@ async function exchangeSessionForToken(client: SanityClient, sessionId: string):
   return token
 }
 
+// Deliberate defer-forever primitive: used in the filtered race arm when a probe result
+// is EARLY_PROBE_MISS, so the fallback (including CorsOriginError rejection) always decides.
+const NEVER_SETTLES = new Promise<never>(() => {})
+
 /**
  * @internal
  */
@@ -252,6 +256,7 @@ export function _createAuthStore({
 
   const initial$ = of(initialWorkspaceClient).pipe(
     mergeMap(async (client): Promise<AuthState> => {
+      // token-mode-without-token intentionally matches a cookie-credentialed probe (both fall back to cookie semantics).
       const earlyCredential: 'cookie' | 'token' =
         loginMethod === 'cookie' ? 'cookie' : currentTokenState?.token ? 'token' : 'cookie'
       const earlyToken = currentTokenState?.token ?? null
@@ -282,7 +287,7 @@ export function _createAuthStore({
           // Probe arm is filtered — a MISS settlement stays silent (never resolves),
           // so the fallback (incl. CorsOriginError rejection) always decides on a probe miss.
           const probeArm = probeResult.then((value) =>
-            value === EARLY_PROBE_MISS ? new Promise<never>(() => {}) : value,
+            value === EARLY_PROBE_MISS ? NEVER_SETTLES : value,
           )
           currentUser = await Promise.race([probeArm, fetchCurrentUser()])
         } else if (settled === EARLY_PROBE_MISS) {

--- a/packages/sanity/src/core/store/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/authStore/createAuthStore.ts
@@ -32,6 +32,7 @@ import {
 import {createBroadcastState} from './createBroadcastState'
 import {createBroadcastStorage} from './createBroadcastStorage'
 import {createLoginComponent} from './createLoginComponent'
+import {consumeEarlyAuthProbe, EARLY_PROBE_MISS} from './earlyAuthProbe'
 import {consumeHashToken as defaultConsumeHashToken} from './hashToken'
 import {clearHashSessionId, getHashSessionId as defaultGetSessionId} from './sessionId'
 import {
@@ -251,7 +252,46 @@ export function _createAuthStore({
 
   const initial$ = of(initialWorkspaceClient).pipe(
     mergeMap(async (client): Promise<AuthState> => {
-      const currentUser = await getCurrentUser(client, 'initial', corsErrorContext)
+      const earlyCredential: 'cookie' | 'token' =
+        loginMethod === 'cookie' ? 'cookie' : currentTokenState?.token ? 'token' : 'cookie'
+      const earlyToken = currentTokenState?.token ?? null
+      const earlyApiHost = hostOptions.apiHost ?? 'https://api.sanity.io'
+
+      const probeResult = consumeEarlyAuthProbe({
+        projectId,
+        apiHost: earlyApiHost,
+        credential: earlyCredential,
+        token: earlyToken,
+      })
+
+      const fetchCurrentUser = () => getCurrentUser(client, 'initial', corsErrorContext)
+
+      let currentUser: CurrentUser | null | undefined
+      if (probeResult === EARLY_PROBE_MISS) {
+        currentUser = await fetchCurrentUser()
+      } else {
+        // Settled-check: flush two microtask ticks so a synchronously-resolved probe.promise
+        // (2 .then/.catch hops through consumeEarlyAuthProbe's chain) can fully settle.
+        // PENDING wins only after an additional flush, so a settled probe always beats it.
+        await Promise.resolve()
+        await Promise.resolve()
+        const PENDING = Symbol('pending')
+        const settled = await Promise.race([probeResult, Promise.resolve(PENDING)])
+        if (settled === PENDING) {
+          // Hedge: fire fallback immediately, race both arms.
+          // Probe arm is filtered — a MISS settlement stays silent (never resolves),
+          // so the fallback (incl. CorsOriginError rejection) always decides on a probe miss.
+          const probeArm = probeResult.then((value) =>
+            value === EARLY_PROBE_MISS ? new Promise<never>(() => {}) : value,
+          )
+          currentUser = await Promise.race([probeArm, fetchCurrentUser()])
+        } else if (settled === EARLY_PROBE_MISS) {
+          currentUser = await fetchCurrentUser()
+        } else {
+          currentUser = settled
+        }
+      }
+
       const authenticated = Boolean(currentUser?.id)
       // Seed cookieAuthState once from the initial probe result. This moves
       // the channel out of 'pending' so cookieAuthChanged$ starts emitting

--- a/packages/sanity/src/core/store/authStore/earlyAuthProbe.ts
+++ b/packages/sanity/src/core/store/authStore/earlyAuthProbe.ts
@@ -1,0 +1,123 @@
+import {type CurrentUser} from '@sanity/types'
+
+/**
+ * Sentinel returned synchronously when the early-auth probe is absent,
+ * mismatched, stale, or produced an error result. Callers compare with
+ * strict equality (`=== EARLY_PROBE_MISS`).
+ *
+ * @internal
+ */
+export const EARLY_PROBE_MISS: unique symbol = Symbol('early-auth-probe-miss')
+
+/**
+ * Shape of the note the CLI inline script parks on `window.__sanityEarlyAuth`
+ * during HTML parse.
+ *
+ * @internal
+ */
+export interface EarlyAuthProbeEntry {
+  projectId: string
+  /** Bare host, e.g. `api.sanity.io` — no protocol prefix. */
+  apiHost: string
+  credential: 'cookie' | 'token'
+  token: string | null
+  startedAt: number
+  promise: Promise<
+    {type: 'unauthenticated'} | {type: 'ok'; user: unknown} | {type: 'error'; status: number}
+  >
+}
+
+/**
+ * Options for `consumeEarlyAuthProbe`, matching the credential values
+ * the CLI inline script would have used when firing the probe.
+ *
+ * @internal
+ */
+export interface ConsumeOptions {
+  projectId: string
+  /** Full URL form, e.g. `https://api.sanity.io`. Protocol is stripped before comparing. */
+  apiHost: string
+  credential: 'cookie' | 'token'
+  token: string | null
+}
+
+/** Strip protocol from a host-or-URL string so bare hosts and full URLs compare equal. */
+function normalizeHost(value: string): string {
+  return value.replace(/^https?:\/\//, '')
+}
+
+/**
+ * Read and consume `window.__sanityEarlyAuth`, validating it against the
+ * provided options.
+ *
+ * Returns `EARLY_PROBE_MISS` synchronously when:
+ * - running outside a browser (SSR / schema-extraction)
+ * - the global is absent
+ * - any of projectId, apiHost, credential, or token mismatches
+ * - the probe's `startedAt` is older than 5 minutes (bfcache stale-result guard)
+ *
+ * Otherwise returns a `Promise<CurrentUser | null | typeof EARLY_PROBE_MISS>`
+ * that NEVER rejects — `{type:'error'}` results and any rejection both map to
+ * `EARLY_PROBE_MISS` so callers can safely `await` without a `.catch`.
+ *
+ * The global is deleted on the FIRST call regardless of validation result,
+ * making this StrictMode-safe: a second call always returns `EARLY_PROBE_MISS`.
+ *
+ * @internal
+ */
+export function consumeEarlyAuthProbe(
+  options: ConsumeOptions,
+): Promise<CurrentUser | null | typeof EARLY_PROBE_MISS> | typeof EARLY_PROBE_MISS {
+  if (typeof window === 'undefined') {
+    return EARLY_PROBE_MISS
+  }
+
+  // @ts-expect-error - window.__sanityEarlyAuth is not declared; use ts-expect-error per monorepo convention
+  const probe: EarlyAuthProbeEntry | undefined = window.__sanityEarlyAuth
+
+  // @ts-expect-error - window.__sanityEarlyAuth is not declared; use ts-expect-error per monorepo convention
+  delete window.__sanityEarlyAuth
+
+  if (!probe) {
+    return EARLY_PROBE_MISS
+  }
+
+  const hostMatches = normalizeHost(probe.apiHost) === normalizeHost(options.apiHost)
+  const fieldsMatch =
+    probe.projectId === options.projectId &&
+    hostMatches &&
+    probe.credential === options.credential &&
+    probe.token === options.token
+
+  if (!fieldsMatch) {
+    return EARLY_PROBE_MISS
+  }
+
+  const fiveMinutesMs = 5 * 60 * 1000
+  if (Date.now() - probe.startedAt > fiveMinutesMs) {
+    return EARLY_PROBE_MISS
+  }
+
+  return probe.promise
+    .then((result) => {
+      if (result.type === 'ok') {
+        return result.user as CurrentUser
+      }
+      if (result.type === 'unauthenticated') {
+        return null
+      }
+      // type === 'error': preserve the CorsOriginError /ping path in getCurrentUser
+      return EARLY_PROBE_MISS
+    })
+    .catch(() => EARLY_PROBE_MISS)
+}
+
+/**
+ * Test helper: clears `window.__sanityEarlyAuth` for use in `afterEach`.
+ *
+ * @internal
+ */
+export function _clearEarlyAuthGlobal(): void {
+  // @ts-expect-error - window.__sanityEarlyAuth is not declared
+  window.__sanityEarlyAuth = undefined
+}

--- a/packages/sanity/src/core/store/authStore/earlyAuthProbe.ts
+++ b/packages/sanity/src/core/store/authStore/earlyAuthProbe.ts
@@ -22,6 +22,7 @@ export interface EarlyAuthProbeEntry {
   credential: 'cookie' | 'token'
   token: string | null
   startedAt: number
+  // Raw body from the CLI inline script; validated at the ok-branch id-guard (trust boundary).
   promise: Promise<
     {type: 'unauthenticated'} | {type: 'ok'; user: unknown} | {type: 'error'; status: number}
   >
@@ -75,6 +76,7 @@ export function consumeEarlyAuthProbe(
   // @ts-expect-error - window.__sanityEarlyAuth is not declared; use ts-expect-error per monorepo convention
   const probe: EarlyAuthProbeEntry | undefined = window.__sanityEarlyAuth
 
+  // Consume-once: delete must happen before any validation that could early-return.
   // @ts-expect-error - window.__sanityEarlyAuth is not declared; use ts-expect-error per monorepo convention
   delete window.__sanityEarlyAuth
 
@@ -98,10 +100,15 @@ export function consumeEarlyAuthProbe(
     return EARLY_PROBE_MISS
   }
 
+  // The 2-tick flush in createAuthStore initial$ depends on this chain being exactly 2
+  // hops (.then + .catch). Adding a hop here breaks the settled-fast-path — update both together.
   return probe.promise
     .then((result) => {
       if (result.type === 'ok') {
-        return result.user as CurrentUser
+        // Validate the raw body before trusting it — a malformed 200 (empty object,
+        // error envelope) must not flow through as a junk CurrentUser.
+        const maybeUser = result.user as {id?: unknown} | null | undefined
+        return typeof maybeUser?.id === 'string' ? (result.user as CurrentUser) : EARLY_PROBE_MISS
       }
       if (result.type === 'unauthenticated') {
         return null


### PR DESCRIPTION
### Description

Studio auth serializes the full bundle download and eval before the first `/users/me` request fires. The companion CLI PR (https://github.com/sanity-io/cli/pull/1294) moves that request into HTML parse via an inline probe that parks its result on `window.__sanityEarlyAuth`.

This PR makes `createAuthStore` consume that result: `earlyAuthProbe.ts` validates the parked probe (projectId/apiHost/credential/token match, user-shape guard, 5-minute age cap, consume-once) and `initial$` hedges on a pending probe. A settled hit means zero `getCurrentUser` requests; every mismatch, malformed body, error, or rejection falls back to today's behavior exactly, including the `CorsOriginError` ping path. An absent global is a clean miss, so this ships safely ahead of the CLI side - no release-order hazard.

Why it matters (validated against 14 days of prod telemetry, 137k sessions): the auth round-trip is serialized after bundle eval on every studio load today, and the probe pre-pays it during HTML parse - a steady ~4-5% median (p50) improvement, ~100-150ms on every load for every user once studios rebuild on the new CLI. Slow-network users gain the most per load (3g round-trips run 0.5-2s). One projectId per build covers ~80% of loads, and the change is strictly additive: every miss costs nothing and falls through to today's behavior exactly.

### What to review

- `earlyAuthProbe.ts` - the guard matrix and never-rejecting contract. The `.then().catch()` chain is exactly 2 hops; the settled-check in `createAuthStore` depends on this (documented at both sites).
- `createAuthStore.ts` `initial$` - hedge-on-pending: the filtered probe arm (`NEVER_SETTLES`) defers a probe miss to the fallback while fallback rejections propagate.
- Telemetry: probe requests carry a new `sanity.studio.auth.early-probe` tag, and on hits the `sanity.studio.users.get-current.initial` tag disappears (intentional). The hedge can briefly double `/users/me` on slow networks - dashboard the new tag before GA.

### Testing

18-case guard matrix in `earlyAuthProbe.test.ts` (mismatches, host normalization, age cap, malformed bodies, reject-to-miss, consume-once) plus 8 integration cases in `createAuthStore.test.ts` asserting `/users/me` request counts per path: zero on hit, exactly one on miss, both hedge race outcomes, `CorsOriginError` propagation. Pre-existing tests pass untouched.

### Notes for release

N/A

### How this fits

Part of the studio startup performance effort: ~83% of auth-ready time is bundle execution/render before the login screen, the rest is the auth round-trip - this PR removes that round-trip from the serial path, a consistent ~4-5% median auth-ready win on every load. It is the consumer half; the injector half is https://github.com/sanity-io/cli/pull/1294. Independent of the other startup PRs and safe to land in any order (absent global = no-op).


