### PR TITLE
feat(structure): sort document list search results by relevance

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+if [ "$LEFTHOOK_VERBOSE" = "1" -o "$LEFTHOOK_VERBOSE" = "true" ]; then
+  set -x
+fi
+
+if [ "$LEFTHOOK" = "0" ]; then
+  exit 0
+fi
+
+call_lefthook()
+{
+  if test -n "$LEFTHOOK_BIN"
+  then
+    "$LEFTHOOK_BIN" "$@"
+  elif lefthook -h >/dev/null 2>&1
+  then
+    lefthook "$@"
+  elif /Users/eoin.falconer/Documents/GitHub/sanity/.claude/worktrees/agent-ade93ef6caab46124/node_modules/.pnpm/lefthook-darwin-arm64@2.1.9/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
+  then
+    /Users/eoin.falconer/Documents/GitHub/sanity/.claude/worktrees/agent-ade93ef6caab46124/node_modules/.pnpm/lefthook-darwin-arm64@2.1.9/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
+  else
+    dir="$(git rev-parse --show-toplevel)"
+    osArch=$(uname | tr '[:upper:]' '[:lower:]')
+    cpuArch=$(uname -m | sed 's/aarch64/arm64/;s/x86_64/x64/')
+    if test -f "$dir/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook"
+    then
+      "$dir/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook" "$@"
+    elif test -f "$dir/node_modules/@evilmartians/lefthook/bin/lefthook-${osArch}-${cpuArch}/lefthook"
+    then
+      "$dir/node_modules/@evilmartians/lefthook/bin/lefthook-${osArch}-${cpuArch}/lefthook" "$@"
+    elif test -f "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook"
+    then
+      "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook" "$@"
+    elif test -f "$dir/node_modules/lefthook/bin/index.js"
+    then
+      "$dir/node_modules/lefthook/bin/index.js" "$@"
+    elif go tool lefthook -h >/dev/null 2>&1
+    then
+      go tool lefthook "$@"
+    elif bundle exec lefthook -h >/dev/null 2>&1
+    then
+      bundle exec lefthook "$@"
+    elif yarn lefthook -h >/dev/null 2>&1
+    then
+      yarn lefthook "$@"
+    elif pnpm lefthook -h >/dev/null 2>&1
+    then
+      pnpm lefthook "$@"
+    elif swift package lefthook >/dev/null 2>&1
+    then
+      swift package --build-path .build/lefthook --disable-sandbox lefthook "$@"
+    elif command -v mint >/dev/null 2>&1
+    then
+      mint run csjones/lefthook-plugin "$@"
+    elif uv run lefthook -h >/dev/null 2>&1
+    then
+      uv run lefthook "$@"
+    elif mise exec -- lefthook -h >/dev/null 2>&1
+    then
+      mise exec -- lefthook "$@"
+    elif devbox run lefthook -h >/dev/null 2>&1
+    then
+      devbox run lefthook "$@"
+    else
+      echo "Can't find lefthook in PATH"
+    fi
+  fi
+}
+
+call_lefthook run "pre-commit" "$@"

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
@@ -116,6 +116,36 @@ describe('createSearchQuery', () => {
   })
 
   describe('searchOptions', () => {
+    // The document list pane ranks search results by relevance by passing a
+    // `_score`-primary sort (with the configured order as a tiebreaker). This
+    // asserts that such a sort produces a genuinely relevance-ranked query:
+    // the `score(boost(...))` pipeline runs, zero-score docs are filtered out,
+    // and results are ordered by `_score` first, then the configured field.
+    it('ranks by relevance when a _score-primary sort is provided (document list pane)', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
+      const {query} = createSearchQuery(
+        {
+          query: 'test',
+          types: [testType],
+        },
+        '',
+        {
+          sort: [
+            {field: '_score', direction: 'desc'},
+            {field: '_updatedAt', direction: 'desc'},
+          ],
+        },
+      )
+
+      expect(query).toMatchInlineSnapshot(`
+        "// findability-mvi:5
+        *[_type in $__types] | score(boost(_type in ["basic-schema-test"] && title match text::query($__query), 10), ([@, _id] match text::query($__query) || references($__rawQuery))) [_score > 0] {_type, _id, _originalId, "orderings": [_score, _updatedAt]} | order(orderings[0] desc,orderings[1] desc) [0...$__limit]"
+      `)
+    })
+
     it('should use provided limit (plus one to determine existence of next page)', () => {
       const testType = Schema.compile({
         types: schemaTypes,

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -577,6 +577,14 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'panes.document-list-pane.search-input.aria-label': 'Search list',
   /** The search input for the search input on the document list pane */
   'panes.document-list-pane.search-input.placeholder': 'Search list',
+  /** The aria-label for the sort-order control shown beneath the document list search input */
+  'panes.document-list-pane.search-ordering.aria-label': 'Change search result ordering',
+  /** The label for the sort-order control beneath the search input, summarising the applied ordering (e.g. "Sorted by relevance") */
+  'panes.document-list-pane.search-ordering.label': 'Sorted by {{order}}',
+  /** The label for the relevance (best match) option in the document list search sort-order control */
+  'panes.document-list-pane.search-ordering.relevance': 'Relevance',
+  /** The sort-order control summary shown when results are ranked by relevance */
+  'panes.document-list-pane.search-ordering.summary-relevance': 'Sorted by relevance',
   /** The tooltip text shown when a sort menu item references fields not present in the current schema */
   'panes.document-list-pane.sort-order.disabled-reason':
     'This sorting option uses fields that are not part of this document type',

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
@@ -1,5 +1,5 @@
 import {SearchIcon, SpinnerIcon} from '@sanity/icons'
-import {Box, TextInput} from '@sanity/ui'
+import {Box, Stack, TextInput} from '@sanity/ui'
 import {memo, useCallback, useEffect, useMemo, useState} from 'react'
 import {useObservableEvent} from 'react-rx'
 import {debounce, map, type Observable, of, tap, timer} from 'rxjs'
@@ -21,6 +21,12 @@ import {structureLocaleNamespace} from '../../i18n'
 import {type BaseStructureToolPaneProps} from '../types'
 import {EMPTY_RECORD, FULL_LIST_LIMIT} from './constants'
 import {DocumentListPaneContent} from './DocumentListPaneContent'
+import {
+  DocumentListPaneSearchOrdering,
+  getSearchOrderingId,
+  isSortOrderingMenuItem,
+  RELEVANCE_ORDERING_ID,
+} from './DocumentListPaneSearchOrdering'
 import {applyOrderingFunctions, findStaticTypesInFilter} from './helpers'
 import {useShallowUnique} from './PaneContainer'
 import {type LoadingVariant, type SortOrder} from './types'
@@ -97,6 +103,13 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   const [searchQuery, setSearchQuery] = useState<string>('')
   const [searchInputValue, setSearchInputValue] = useState<string>('')
   const [searchInputElement, setSearchInputElement] = useState<HTMLInputElement | null>(null)
+  // The ordering applied while a search term is present. Defaults to relevance
+  // ranking, and resets back to relevance whenever the search is cleared.
+  const [searchOrderingId, setSearchOrderingId] = useState<string>(RELEVANCE_ORDERING_ID)
+
+  // The query the list actually searches on. Whitespace-only input is treated as
+  // empty, so the search-scoped UI must key off the trimmed value too.
+  const trimmedSearchQuery = searchQuery.trim()
 
   const sortWithOrderingFn =
     typeName && sortOrderRaw
@@ -104,6 +117,34 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
       : sortOrderRaw
 
   const sortOrder = useUnique(sortWithOrderingFn)
+
+  // The list's configured orderings, surfaced as choices in the search sort
+  // control (relevance plus these).
+  const searchOrderings = useMemo(
+    () => (pane.menuItems || []).filter(isSortOrderingMenuItem),
+    [pane.menuItems],
+  )
+
+  // While searching, relevance ranking is the default. If the editor picks one
+  // of the configured orderings instead, apply that order and disable scoring.
+  const useRelevance = searchOrderingId === RELEVANCE_ORDERING_ID
+  const selectedSearchOrdering = useRelevance
+    ? undefined
+    : searchOrderings.find((ordering) => getSearchOrderingId(ordering) === searchOrderingId)
+  const searchSchemaType = typeName ? schema.get(typeName) : undefined
+  const effectiveSortOrder = useUnique(
+    selectedSearchOrdering?.params?.by
+      ? // Run the chosen ordering through `applyOrderingFunctions` so it picks up
+        // the same field mappers (e.g. `lower`, `dateTime`) the header sort menu
+        // uses — otherwise the same ordering would sort differently here.
+        // `applyOrderingFunctions` requires a concrete schema type, so only apply
+        // it when the type is statically resolvable; otherwise fall back to the
+        // raw ordering rather than passing `undefined`.
+        searchSchemaType
+        ? applyOrderingFunctions({by: selectedSearchOrdering.params.by}, searchSchemaType as any)
+        : {by: selectedSearchOrdering.params.by}
+      : sortOrder,
+  )
 
   const client = useClient({
     ...DEFAULT_STUDIO_CLIENT_OPTIONS,
@@ -128,8 +169,9 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
     filter,
     perspective: perspectiveStack,
     params,
-    searchQuery: searchQuery?.trim(),
-    sortOrder,
+    searchQuery: trimmedSearchQuery,
+    sortOrder: effectiveSortOrder,
+    searchSortByRelevance: useRelevance,
   })
 
   const isLoading = documentListIsLoading || releases.loading
@@ -174,6 +216,15 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
     setEnableSearchSpinner()
   }, [paneKey, handleClearSearch])
 
+  useEffect(() => {
+    // Relevance ranking is search-scoped: whenever the term is cleared (via the
+    // clear button, Escape, emptying the field, or switching panes), reset the
+    // applied ordering back to relevance.
+    if (!trimmedSearchQuery) {
+      setSearchOrderingId(RELEVANCE_ORDERING_ID)
+    }
+  }, [trimmedSearchQuery])
+
   const loadingVariant: LoadingVariant = useMemo(() => {
     if (connected && isLoading && enableSearchSpinner === paneKey) {
       return 'spinner'
@@ -200,28 +251,37 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   return (
     <>
       <Box paddingX={3} paddingBottom={3}>
-        <TextInput
-          aria-label={t('panes.document-list-pane.search-input.aria-label')}
-          autoComplete="off"
-          border={false}
-          clearButton={Boolean(searchQuery)}
-          fontSize={[2, 2, 1]}
-          icon={textInputIcon}
-          iconRight={
-            !connected || (loadingVariant === 'subtle' && !searchInputValue)
-              ? DelayedSubtleSpinnerIcon
-              : null
-          }
-          onChange={handleQueryChange}
-          onClear={handleClearSearch}
-          onKeyDown={handleSearchKeyDown}
-          padding={2}
-          placeholder={t('panes.document-list-pane.search-input.placeholder')}
-          radius={2}
-          ref={setSearchInputElement}
-          spellCheck={false}
-          value={searchInputValue}
-        />
+        <Stack space={3}>
+          <TextInput
+            aria-label={t('panes.document-list-pane.search-input.aria-label')}
+            autoComplete="off"
+            border={false}
+            clearButton={Boolean(searchQuery)}
+            fontSize={[2, 2, 1]}
+            icon={textInputIcon}
+            iconRight={
+              !connected || (loadingVariant === 'subtle' && !searchInputValue)
+                ? DelayedSubtleSpinnerIcon
+                : null
+            }
+            onChange={handleQueryChange}
+            onClear={handleClearSearch}
+            onKeyDown={handleSearchKeyDown}
+            padding={2}
+            placeholder={t('panes.document-list-pane.search-input.placeholder')}
+            radius={2}
+            ref={setSearchInputElement}
+            spellCheck={false}
+            value={searchInputValue}
+          />
+          {trimmedSearchQuery && (
+            <DocumentListPaneSearchOrdering
+              orderings={searchOrderings}
+              value={searchOrderingId}
+              onChange={setSearchOrderingId}
+            />
+          )}
+        </Stack>
       </Box>
       <DocumentListPaneContent
         key={paneKey}

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPaneSearchOrdering.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPaneSearchOrdering.tsx
@@ -1,0 +1,148 @@
+import {SortIcon} from '@sanity/icons'
+import {Box, Menu, MenuDivider, Text} from '@sanity/ui'
+import {memo, useId} from 'react'
+import {useGetI18nText, useTranslation} from 'sanity'
+
+import {Button, MenuButton, MenuItem} from '../../../ui-components'
+import {structureLocaleNamespace} from '../../i18n'
+import {type PaneMenuItem} from '../../types'
+
+/**
+ * Identifier for the (virtual) "relevance" ordering. Relevance isn't one of the
+ * pane's configured orderings — it's the score-based ranking applied while a
+ * search term is present, so it gets its own reserved id.
+ *
+ * @internal
+ */
+export const RELEVANCE_ORDERING_ID = 'relevance'
+
+/**
+ * Stable id for a sort-order menu item, derived from its sort spec so it
+ * survives re-renders without relying on the optional `id` field.
+ *
+ * @internal
+ */
+export function getSearchOrderingId(menuItem: PaneMenuItem): string {
+  return menuItem.id ?? JSON.stringify(menuItem.params?.by ?? [])
+}
+
+/**
+ * Whether a pane menu item represents a sort ordering.
+ *
+ * @internal
+ */
+export function isSortOrderingMenuItem(menuItem: PaneMenuItem): boolean {
+  return menuItem.action === 'setSortOrder' && Array.isArray(menuItem.params?.by)
+}
+
+interface OrderingMenuItemProps {
+  menuItem: PaneMenuItem
+  selected: boolean
+  onSelect: (id: string) => void
+}
+
+/**
+ * A single ordering option. Rendered as its own component so it can resolve its
+ * localized title via `useGetI18nText` (each item may carry its own i18n
+ * record).
+ */
+function OrderingMenuItem({menuItem, selected, onSelect}: OrderingMenuItemProps) {
+  const getI18nText = useGetI18nText(menuItem)
+  const {title} = getI18nText(menuItem)
+
+  return (
+    <MenuItem
+      onClick={() => onSelect(getSearchOrderingId(menuItem))}
+      pressed={selected}
+      text={title}
+    />
+  )
+}
+
+interface DocumentListPaneSearchOrderingProps {
+  orderings: PaneMenuItem[]
+  value: string
+  onChange: (id: string) => void
+}
+
+/**
+ * Sort-order control shown beneath the document list search input while a
+ * search term is present. Defaults to relevance ranking, and lets the editor
+ * temporarily apply one of the list's configured orderings instead.
+ */
+export const DocumentListPaneSearchOrdering = memo(function DocumentListPaneSearchOrdering(
+  props: DocumentListPaneSearchOrderingProps,
+) {
+  const {orderings, value, onChange} = props
+  const {t} = useTranslation(structureLocaleNamespace)
+  const menuButtonId = useId()
+
+  const relevanceTitle = t('panes.document-list-pane.search-ordering.relevance')
+
+  const selectedOrdering =
+    value === RELEVANCE_ORDERING_ID
+      ? undefined
+      : orderings.find((ordering) => getSearchOrderingId(ordering) === value)
+
+  // Resolve the active ordering's localized title for the button label. The
+  // relevance case uses its own complete string rather than interpolating a
+  // case-transformed title, which is unreliable across locales.
+  const getI18nText = useGetI18nText(selectedOrdering)
+  const buttonText = selectedOrdering
+    ? t('panes.document-list-pane.search-ordering.label', {
+        order: getI18nText(selectedOrdering).title,
+      })
+    : t('panes.document-list-pane.search-ordering.summary-relevance')
+
+  // With no configured orderings there's nothing to choose between, so render a
+  // plain, non-interactive label instead of an empty menu.
+  if (orderings.length === 0) {
+    return (
+      <Box paddingX={2} paddingBottom={1}>
+        <Text muted size={1} data-testid="document-list-search-ordering">
+          {buttonText}
+        </Text>
+      </Box>
+    )
+  }
+
+  return (
+    <Box paddingBottom={1}>
+      <MenuButton
+        button={
+          <Button
+            data-testid="document-list-search-ordering"
+            icon={SortIcon}
+            mode="bleed"
+            text={buttonText}
+            tone="default"
+            aria-label={t('panes.document-list-pane.search-ordering.aria-label')}
+          />
+        }
+        id={menuButtonId}
+        menu={
+          <Menu>
+            <MenuItem
+              onClick={() => onChange(RELEVANCE_ORDERING_ID)}
+              pressed={value === RELEVANCE_ORDERING_ID}
+              text={relevanceTitle}
+            />
+            <MenuDivider />
+            {orderings.map((ordering) => {
+              const id = getSearchOrderingId(ordering)
+              return (
+                <OrderingMenuItem
+                  key={id}
+                  menuItem={ordering}
+                  onSelect={onChange}
+                  selected={value === id}
+                />
+              )
+            })}
+          </Menu>
+        }
+        popover={{placement: 'bottom-start', portal: true, radius: 2}}
+      />
+    </Box>
+  )
+})

--- a/packages/sanity/src/structure/panes/documentList/__tests__/DocumentListPane.test.tsx
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/DocumentListPane.test.tsx
@@ -1,0 +1,113 @@
+import {render, screen} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {defineConfig, type PerspectiveContextValue} from 'sanity'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {structureUsEnglishLocaleBundle} from '../../../i18n'
+import {type DocumentListPaneNode} from '../../../types'
+import {DocumentListPane} from '../DocumentListPane'
+import {useDocumentList} from '../useDocumentList'
+
+vi.mock('../useDocumentList', () => ({
+  useDocumentList: vi.fn(),
+}))
+
+// Stub out the heavy results content so we can focus on the search header.
+vi.mock('../DocumentListPaneContent', () => ({
+  DocumentListPaneContent: () => null,
+}))
+
+vi.mock('sanity', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useActiveReleases: vi.fn(() => ({loading: false, data: []})),
+  usePerspective: vi.fn(
+    (): PerspectiveContextValue => ({
+      perspectiveStack: ['drafts'],
+      excludedPerspectives: [],
+      selectedPerspective: 'drafts',
+      selectedPerspectiveName: undefined,
+      selectedReleaseId: undefined,
+    }),
+  ),
+  useReconnectingToast: vi.fn(),
+}))
+
+const mockUseDocumentList = vi.mocked(useDocumentList)
+
+const ORDERING_TESTID = 'document-list-search-ordering'
+
+function getPaneProps() {
+  return {
+    paneKey: 'test-pane',
+    index: 0,
+    itemId: 'itemId',
+    isActive: true,
+    pane: {
+      id: 'author',
+      type: 'documentList',
+      title: 'Authors',
+      options: {filter: '_type == "author"'},
+    } as DocumentListPaneNode,
+  }
+}
+
+describe('DocumentListPane search ordering indicator', () => {
+  beforeEach(() => {
+    mockUseDocumentList.mockReturnValue({
+      error: null,
+      onRetry: vi.fn(),
+      isLoading: false,
+      items: [],
+      isRetrying: false,
+      canRetry: false,
+      retryCount: 0,
+      autoRetry: false,
+      connected: true,
+      fromCache: false,
+      onLoadFullList: vi.fn(),
+      isLoadingFullList: false,
+    })
+  })
+
+  it('does not show the relevance indicator when there is no search term', async () => {
+    const wrapper = await createTestProvider({
+      config: defineConfig({projectId: 'test', dataset: 'test'}),
+      resources: [structureUsEnglishLocaleBundle],
+    })
+
+    render(<DocumentListPane {...getPaneProps()} />, {wrapper})
+
+    expect(screen.queryByTestId(ORDERING_TESTID)).toBeNull()
+  })
+
+  it('shows the relevance indicator once a search term is entered', async () => {
+    const wrapper = await createTestProvider({
+      config: defineConfig({projectId: 'test', dataset: 'test'}),
+      resources: [structureUsEnglishLocaleBundle],
+    })
+
+    render(<DocumentListPane {...getPaneProps()} />, {wrapper})
+
+    await userEvent.type(await screen.findByLabelText('Search list'), 'exodus')
+
+    const indicator = await screen.findByTestId(ORDERING_TESTID)
+    expect(indicator).toHaveTextContent('Sorted by relevance')
+  })
+
+  it('treats a whitespace-only query as empty and hides the indicator', async () => {
+    const wrapper = await createTestProvider({
+      config: defineConfig({projectId: 'test', dataset: 'test'}),
+      resources: [structureUsEnglishLocaleBundle],
+    })
+
+    render(<DocumentListPane {...getPaneProps()} />, {wrapper})
+
+    await userEvent.type(await screen.findByLabelText('Search list'), '   ')
+
+    // The query is effectively empty, so the search-scoped sort control must not
+    // appear. Allow time for the debounced query to settle before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 400))
+    expect(screen.queryByTestId(ORDERING_TESTID)).toBeNull()
+  })
+})

--- a/packages/sanity/src/structure/panes/documentList/__tests__/DocumentListPaneSearchOrdering.test.tsx
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/DocumentListPaneSearchOrdering.test.tsx
@@ -1,0 +1,87 @@
+import {render, screen} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {structureUsEnglishLocaleBundle} from '../../../i18n'
+import {type PaneMenuItem} from '../../types'
+import {
+  DocumentListPaneSearchOrdering,
+  getSearchOrderingId,
+  RELEVANCE_ORDERING_ID,
+} from '../DocumentListPaneSearchOrdering'
+
+const ORDERINGS: PaneMenuItem[] = [
+  {
+    id: 'updated-desc',
+    title: 'Last edited',
+    action: 'setSortOrder',
+    params: {by: [{field: '_updatedAt', direction: 'desc'}]},
+  },
+  {
+    id: 'title-asc',
+    title: 'Title',
+    action: 'setSortOrder',
+    params: {by: [{field: 'title', direction: 'asc'}]},
+  },
+]
+
+async function renderControl(props: {
+  value?: string
+  onChange?: (id: string) => void
+  orderings?: PaneMenuItem[]
+}) {
+  const wrapper = await createTestProvider({resources: [structureUsEnglishLocaleBundle]})
+  render(
+    <DocumentListPaneSearchOrdering
+      orderings={props.orderings ?? ORDERINGS}
+      value={props.value ?? RELEVANCE_ORDERING_ID}
+      onChange={props.onChange ?? vi.fn()}
+    />,
+    {wrapper},
+  )
+}
+
+describe('DocumentListPaneSearchOrdering', () => {
+  it('summarises relevance ranking by default', async () => {
+    await renderControl({})
+    expect(await screen.findByTestId('document-list-search-ordering')).toHaveTextContent(
+      'Sorted by relevance',
+    )
+  })
+
+  it('summarises the chosen configured ordering when one is active', async () => {
+    await renderControl({value: getSearchOrderingId(ORDERINGS[0])})
+    expect(await screen.findByTestId('document-list-search-ordering')).toHaveTextContent(
+      'Sorted by Last edited',
+    )
+  })
+
+  it('lets the editor switch to a configured ordering', async () => {
+    const onChange = vi.fn()
+    await renderControl({onChange})
+
+    await userEvent.click(await screen.findByTestId('document-list-search-ordering'))
+    await userEvent.click(await screen.findByText('Title'))
+
+    expect(onChange).toHaveBeenCalledWith(getSearchOrderingId(ORDERINGS[1]))
+  })
+
+  it('lets the editor switch back to relevance', async () => {
+    const onChange = vi.fn()
+    await renderControl({value: getSearchOrderingId(ORDERINGS[0]), onChange})
+
+    await userEvent.click(await screen.findByTestId('document-list-search-ordering'))
+    await userEvent.click(await screen.findByText('Relevance'))
+
+    expect(onChange).toHaveBeenCalledWith(RELEVANCE_ORDERING_ID)
+  })
+
+  it('falls back to a plain label when the list has no configured orderings', async () => {
+    await renderControl({orderings: []})
+    const label = await screen.findByTestId('document-list-search-ordering')
+    expect(label).toHaveTextContent('Sorted by relevance')
+    // Plain text, not a button.
+    expect(label.tagName).not.toBe('BUTTON')
+  })
+})

--- a/packages/sanity/src/structure/panes/documentList/__tests__/listenSearchQuery.test.ts
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/listenSearchQuery.test.ts
@@ -1,0 +1,62 @@
+import {type SearchSort} from 'sanity'
+import {describe, expect, it} from 'vitest'
+
+import {resolveSearchOrdering} from '../listenSearchQuery'
+
+const CONFIGURED_SORT: SearchSort[] = [{field: '_updatedAt', direction: 'desc'}]
+
+describe('resolveSearchOrdering', () => {
+  it('keeps the configured order and skips score sorting when there is no search term', () => {
+    expect(
+      resolveSearchOrdering({searchQuery: '', sortBy: CONFIGURED_SORT, searchStrategy: 'groq2024'}),
+    ).toEqual({skipSortByScore: true, sort: CONFIGURED_SORT})
+  })
+
+  it('ranks by relevance (groq2024) by prepending a _score sort entry, keeping the configured order as a tiebreaker', () => {
+    expect(
+      resolveSearchOrdering({
+        searchQuery: 'exodus',
+        sortBy: CONFIGURED_SORT,
+        searchStrategy: 'groq2024',
+      }),
+    ).toEqual({
+      skipSortByScore: false,
+      sort: [
+        {field: '_score', direction: 'desc'},
+        {field: '_updatedAt', direction: 'desc'},
+      ],
+    })
+  })
+
+  it('defaults to groq2024 relevance behaviour when no strategy is provided', () => {
+    expect(resolveSearchOrdering({searchQuery: 'exodus', sortBy: CONFIGURED_SORT})).toEqual({
+      skipSortByScore: false,
+      sort: [
+        {field: '_score', direction: 'desc'},
+        {field: '_updatedAt', direction: 'desc'},
+      ],
+    })
+  })
+
+  it('ranks by relevance (groqLegacy) via client-side score sorting without injecting a _score field', () => {
+    expect(
+      resolveSearchOrdering({
+        searchQuery: 'exodus',
+        sortBy: CONFIGURED_SORT,
+        searchStrategy: 'groqLegacy',
+      }),
+    ).toEqual({skipSortByScore: false, sort: CONFIGURED_SORT})
+  })
+
+  it('keeps the chosen order and skips scoring when relevance is disabled, even with a search term', () => {
+    const chosenSort: SearchSort[] = [{field: 'title', direction: 'asc'}]
+    expect(
+      resolveSearchOrdering({
+        searchQuery: 'exodus',
+        sortBy: chosenSort,
+        searchStrategy: 'groq2024',
+        useRelevance: false,
+      }),
+    ).toEqual({skipSortByScore: true, sort: chosenSort})
+  })
+})

--- a/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
+++ b/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
@@ -24,6 +24,7 @@ import {
   type SanityDocumentLike,
   type Schema,
   type SearchOptions,
+  type SearchSort,
   type SearchStrategy,
 } from 'sanity'
 
@@ -42,6 +43,11 @@ interface ListenQueryOptions {
   staticTypeNames?: string[] | null
   maxFieldDepth?: number
   searchStrategy?: SearchStrategy
+  /**
+   * Whether to rank results by relevance when a search term is present.
+   * Defaults to `true`. See {@link resolveSearchOrdering}.
+   */
+  sortByRelevance?: boolean
 }
 
 export type SearchQueryEvent =
@@ -58,6 +64,55 @@ export interface SearchQueryState {
 
 const swr = createSWR<{connected: boolean; documents: SanityDocumentLike[]}>({maxSize: 100})
 
+/**
+ * Resolve the score/sort options for a list pane search request.
+ *
+ * When a search term is present, results are ranked by relevance so the most
+ * relevant documents surface first (matching the behaviour of global search).
+ * The configured/selected sort order is preserved as a tiebreaker. With an
+ * empty query there are no scores to sort by, so the configured order is kept
+ * untouched.
+ *
+ * The two search strategies express relevance differently:
+ * - `groq2024` is driven by the presence of a `_score` sort entry, which
+ *   activates the server-side `score(boost(...))` pipeline.
+ * - `groqLegacy` computes scores client-side and sorts by them unless
+ *   `skipSortByScore` is set.
+ *
+ * @internal
+ */
+export function resolveSearchOrdering(options: {
+  searchQuery: string
+  sortBy: SearchSort[]
+  searchStrategy?: SearchStrategy
+  /**
+   * Whether to rank by relevance when a search term is present. Defaults to
+   * `true`. Set to `false` when the editor has explicitly chosen one of the
+   * configured orderings instead of relevance.
+   */
+  useRelevance?: boolean
+}): {skipSortByScore: boolean; sort: SearchSort[]} {
+  const {searchQuery, sortBy, searchStrategy, useRelevance = true} = options
+  const sortByRelevance = Boolean(searchQuery) && useRelevance
+
+  if (!sortByRelevance) {
+    return {skipSortByScore: true, sort: sortBy}
+  }
+
+  // `groqLegacy` cannot order by a projected `_score` field, so it relies on
+  // client-side score sorting (`skipSortByScore: false`) with the configured
+  // order kept as a tiebreaker. `groq2024` ranks by relevance by prepending a
+  // `_score` sort entry.
+  if (searchStrategy === 'groqLegacy') {
+    return {skipSortByScore: false, sort: sortBy}
+  }
+
+  return {
+    skipSortByScore: false,
+    sort: [{field: '_score', direction: 'desc'}, ...sortBy],
+  }
+}
+
 export function listenSearchQuery(options: ListenQueryOptions): Observable<SearchQueryState> {
   const {
     client,
@@ -69,6 +124,7 @@ export function listenSearchQuery(options: ListenQueryOptions): Observable<Searc
     filter: groqFilter,
     searchQuery,
     staticTypeNames,
+    sortByRelevance,
     maxFieldDepth,
     searchStrategy,
   } = options
@@ -160,11 +216,18 @@ export function listenSearchQuery(options: ListenQueryOptions): Observable<Searc
               types,
             }
 
+            const {skipSortByScore, sort} = resolveSearchOrdering({
+              searchQuery: searchQuery || '',
+              sortBy,
+              searchStrategy,
+              useRelevance: sortByRelevance,
+            })
+
             const searchOptions: SearchOptions = {
               comments: [`findability-source: ${searchQuery ? 'list-query' : 'list'}`],
               limit,
-              skipSortByScore: true,
-              sort: sortBy,
+              skipSortByScore,
+              sort,
               perspective,
             }
 

--- a/packages/sanity/src/structure/panes/documentList/useDocumentList.ts
+++ b/packages/sanity/src/structure/panes/documentList/useDocumentList.ts
@@ -43,6 +43,11 @@ interface UseDocumentListOpts {
   params: Record<string, unknown>
   searchQuery: string | null
   sortOrder?: SortOrder
+  /**
+   * Whether to rank results by relevance when a search term is present.
+   * Defaults to `true`.
+   */
+  searchSortByRelevance?: boolean
 }
 
 interface DocumentListState {
@@ -107,6 +112,7 @@ export function useDocumentList(opts: UseDocumentListOpts): UseDocumentListHookV
     sortOrder,
     searchQuery,
     perspective,
+    searchSortByRelevance = true,
   } = opts
   const {strategy: searchStrategy} = useWorkspace().search
   const schema = useSchema()
@@ -135,6 +141,7 @@ export function useDocumentList(opts: UseDocumentListOpts): UseDocumentListHookV
       staticTypeNames: typeNameFromFilter,
       maxFieldDepth,
       searchStrategy,
+      sortByRelevance: searchSortByRelevance,
     }
 
     const partialList$ = listenSearchQuery(listenSearchQueryArgs).pipe(
@@ -259,6 +266,7 @@ export function useDocumentList(opts: UseDocumentListOpts): UseDocumentListHookV
     perspective,
     searchQuery,
     sortOrder,
+    searchSortByRelevance,
     typeNameFromFilter,
     maxFieldDepth,
     searchStrategy,


### PR DESCRIPTION
## What & why

Resolves [SAPP-41](https://linear.app/sanity/issue/SAPP-41/document-list-search-apply-default-sorting-by-relevance).

Searching in the document list pane never ranked results by relevance — it kept the configured sort order, so any document mentioning the term *anywhere* (including deep in Portable Text bodies) sat alongside exact title matches with no ordering. This is a long-standing source of editor confusion and support requests.

The root cause: the list pane hard-coded a non-scored search path, so the `score(boost(...))` ranking (and therefore search weights) were entirely inert here.

## Changes

- **Relevance ranking when searching.** When a search term is present, results are ranked by relevance, matching global search. The configured/selected sort order is kept as a **tiebreaker**. With an empty query, the configured order is untouched.
  - `groq2024` (default): prepends a `_score` sort entry, activating the server-side `score(boost(...))` pipeline.
  - `groqLegacy`: client-side score sorting, configured order as tiebreak.
- **Sort-order control beneath the search input** (shown only while searching), defaulting to **Relevance**. Editors can temporarily switch to one of the list's existing orderings; clearing the term resets to relevance.
- **Search weights now work in the list pane** as a side effect — previously `weight: 0` on a body field did nothing here.

Scope follows the ticket's agreed boundary: relevance is computed on the document's own fields (referenced documents are not scored).

## Verification

- Deterministic query-level test proving the generated GROQ ranks by `_score` first, then the configured field (`createSearchQuery.test.ts`).
- Unit tests for the ordering decision across both strategies and the relevance on/off paths.
- Render tests for the sort-order control (default label, switching orderings, switching back to relevance, no-orderings fallback).
- Full `documentList` suite green; type check, format, oxlint clean.
