### PR TITLE
feat(core): add page-visibility context to studio timing telemetry

### DIFF
--- a/packages/sanity/src/core/studio/AuthBoundary.tsx
+++ b/packages/sanity/src/core/studio/AuthBoundary.tsx
@@ -9,6 +9,7 @@ import {
 import {StudioAuthReadyMeasured} from './__telemetry__/bootstrap.telemetry'
 import {useActiveWorkspace} from './activeWorkspaceMatcher'
 import {AuthenticateScreen, NotAuthenticatedScreen, RequestAccessScreen} from './screens'
+import {getPageVisibilitySnapshot} from './telemetry/pageVisibility'
 
 // Module-level one-shot guard. Survives StrictMode double-mount in dev so the
 // event only fires once per page load (HMR resets this naturally).
@@ -56,9 +57,11 @@ export function AuthBoundary({
     if (authReadyFired) return
     if (loggedIn === 'loading') return
     authReadyFired = true
+    const durationMs = performance.now()
     telemetry.log(StudioAuthReadyMeasured, {
-      durationMs: performance.now(),
+      durationMs,
       authState: loggedIn,
+      ...getPageVisibilitySnapshot(durationMs),
     })
   }, [loggedIn, telemetry])
 

--- a/packages/sanity/src/core/studio/StudioLayout.tsx
+++ b/packages/sanity/src/core/studio/StudioLayout.tsx
@@ -22,6 +22,7 @@ import {
   useNavbarComponent,
 } from './studio-components-hooks'
 import {StudioErrorBoundary} from './StudioErrorBoundary'
+import {getPageVisibilitySnapshot} from './telemetry/pageVisibility'
 import {ToolMountTimer} from './ToolMountTimer'
 import {useWorkspace} from './workspace'
 
@@ -158,10 +159,12 @@ export function StudioLayoutComponent() {
     if (studioReadyFired) return
     if (!activeTool) return
     studioReadyFired = true
+    const durationMs = performance.now()
     telemetry.log(StudioReadyMeasured, {
-      durationMs: performance.now(),
+      durationMs,
       toolsCount: tools.length,
       activeToolName: activeTool.name,
+      ...getPageVisibilitySnapshot(durationMs),
     })
   }, [activeTool, telemetry, tools.length])
 

--- a/packages/sanity/src/core/studio/__telemetry__/bootstrap.telemetry.ts
+++ b/packages/sanity/src/core/studio/__telemetry__/bootstrap.telemetry.ts
@@ -1,5 +1,7 @@
 import {defineEvent} from '@sanity/telemetry'
 
+import {type PageVisibilitySnapshot} from '../telemetry/pageVisibility'
+
 /**
  * Time from browser navigation start to the moment Studio resolves the
  * auth state (logged-in, logged-out, or unauthorized).
@@ -14,10 +16,16 @@ import {defineEvent} from '@sanity/telemetry'
  * `performance.timeOrigin` (= browser navigation start). This matches the
  * baseline used by `web-vitals` for LCP/FCP.
  *
+ * The visibility fields (see {@link PageVisibilitySnapshot}) record whether the
+ * page was backgrounded during the load. Background tabs are throttled while
+ * `performance.now()` keeps advancing, so `wasHidden: true` loads carry an
+ * inflated `durationMs` and should be excluded when looking at user-perceived
+ * timings.
+ *
  * Does not fire in embedded Studios that set `unstable_noAuthBoundary`,
  * because the `AuthBoundary` component is not rendered in that case.
  */
-export interface StudioAuthReadyMeasuredData {
+export interface StudioAuthReadyMeasuredData extends PageVisibilitySnapshot {
   /** ms since browser navigationStart (= `performance.now()` at log time) */
   durationMs: number
   /** resolved auth state at the moment this event fired */
@@ -26,10 +34,11 @@ export interface StudioAuthReadyMeasuredData {
 
 export const StudioAuthReadyMeasured = defineEvent<StudioAuthReadyMeasuredData>({
   name: 'Studio Auth Ready Measured',
-  version: 1,
+  version: 2,
   description:
     'Time from browser navigation start to the moment Studio resolves the ' +
-    'auth state (logged-in, logged-out, or unauthorized).',
+    'auth state (logged-in, logged-out, or unauthorized), with page-visibility ' +
+    'context to distinguish foreground loads from backgrounded ones.',
 })
 
 /**
@@ -42,8 +51,12 @@ export const StudioAuthReadyMeasured = defineEvent<StudioAuthReadyMeasuredData>(
  *
  * `durationMs` is `performance.now()` at log time, which is relative to
  * `performance.timeOrigin` (= browser navigation start).
+ *
+ * The visibility fields (see {@link PageVisibilitySnapshot}) record whether the
+ * page was backgrounded during the load, so `wasHidden: true` loads can be
+ * excluded when looking at user-perceived timings.
  */
-export interface StudioReadyMeasuredData {
+export interface StudioReadyMeasuredData extends PageVisibilitySnapshot {
   /** ms since browser navigationStart (= `performance.now()` at log time) */
   durationMs: number
   /** total number of tools registered in this workspace */
@@ -54,8 +67,9 @@ export interface StudioReadyMeasuredData {
 
 export const StudioReadyMeasured = defineEvent<StudioReadyMeasuredData>({
   name: 'Studio Ready Measured',
-  version: 1,
+  version: 2,
   description:
     'Time from browser navigation start to the moment the active tool has ' +
-    'first rendered and the Studio layout is interactive.',
+    'first rendered and the Studio layout is interactive, with page-visibility ' +
+    'context to distinguish foreground loads from backgrounded ones.',
 })

--- a/packages/sanity/src/core/studio/__tests__/AuthBoundary.test.tsx
+++ b/packages/sanity/src/core/studio/__tests__/AuthBoundary.test.tsx
@@ -107,6 +107,11 @@ describe('AuthBoundary telemetry', () => {
       expect.objectContaining({
         authState: 'logged-in',
         durationMs: expect.any(Number),
+        // Page-visibility context must be stamped onto the event. jsdom reports
+        // a visible document, so a clean foreground load is expected here.
+        wasHidden: false,
+        visibilityState: 'visible',
+        firstHiddenTime: null,
       }),
     )
     expect(studioAuthReadyCalls()[0][1].durationMs).toBeGreaterThanOrEqual(0)

--- a/packages/sanity/src/core/studio/__tests__/AuthBoundary.test.tsx
+++ b/packages/sanity/src/core/studio/__tests__/AuthBoundary.test.tsx
@@ -107,8 +107,7 @@ describe('AuthBoundary telemetry', () => {
       expect.objectContaining({
         authState: 'logged-in',
         durationMs: expect.any(Number),
-        // Page-visibility context must be stamped onto the event. jsdom reports
-        // a visible document, so a clean foreground load is expected here.
+        // jsdom reports a visible document, so the snapshot is a clean foreground load.
         wasHidden: false,
         visibilityState: 'visible',
         firstHiddenTime: null,

--- a/packages/sanity/src/core/studio/__tests__/StudioLayout.test.tsx
+++ b/packages/sanity/src/core/studio/__tests__/StudioLayout.test.tsx
@@ -140,8 +140,7 @@ describe('StudioLayoutComponent telemetry', () => {
         activeToolName: 'structure',
         toolsCount: 2,
         durationMs: expect.any(Number),
-        // Page-visibility context must be stamped onto the event. jsdom reports
-        // a visible document, so a clean foreground load is expected here.
+        // jsdom reports a visible document, so the snapshot is a clean foreground load.
         wasHidden: false,
         visibilityState: 'visible',
         firstHiddenTime: null,

--- a/packages/sanity/src/core/studio/__tests__/StudioLayout.test.tsx
+++ b/packages/sanity/src/core/studio/__tests__/StudioLayout.test.tsx
@@ -140,6 +140,11 @@ describe('StudioLayoutComponent telemetry', () => {
         activeToolName: 'structure',
         toolsCount: 2,
         durationMs: expect.any(Number),
+        // Page-visibility context must be stamped onto the event. jsdom reports
+        // a visible document, so a clean foreground load is expected here.
+        wasHidden: false,
+        visibilityState: 'visible',
+        firstHiddenTime: null,
       }),
     )
     expect(telemetryLog.mock.calls[0][1].durationMs).toBeGreaterThanOrEqual(0)

--- a/packages/sanity/src/core/studio/telemetry/__tests__/pageVisibility.test.ts
+++ b/packages/sanity/src/core/studio/telemetry/__tests__/pageVisibility.test.ts
@@ -41,6 +41,8 @@ describe('getPageVisibilitySnapshot', () => {
 
   it('captures a hide that happens after load, relative to the measured moment', async () => {
     vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+    // performance.now() is pinned to 500 so the handler latches firstHiddenTime
+    // to a deterministic value when the hide is dispatched below.
     vi.spyOn(performance, 'now').mockReturnValue(500)
 
     const getPageVisibilitySnapshot = await importFresh()

--- a/packages/sanity/src/core/studio/telemetry/__tests__/pageVisibility.test.ts
+++ b/packages/sanity/src/core/studio/telemetry/__tests__/pageVisibility.test.ts
@@ -41,8 +41,6 @@ describe('getPageVisibilitySnapshot', () => {
 
   it('captures a hide that happens after load, relative to the measured moment', async () => {
     vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
-    // performance.now() is pinned to 500 so the handler latches firstHiddenTime
-    // to a deterministic value when the hide is dispatched below.
     vi.spyOn(performance, 'now').mockReturnValue(500)
 
     const getPageVisibilitySnapshot = await importFresh()

--- a/packages/sanity/src/core/studio/telemetry/__tests__/pageVisibility.test.ts
+++ b/packages/sanity/src/core/studio/telemetry/__tests__/pageVisibility.test.ts
@@ -1,0 +1,79 @@
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+/**
+ * `pageVisibility` latches its state in a module-level variable that is
+ * initialised at import time, so each test imports the module fresh (after
+ * `vi.resetModules()`) with the desired `document.visibilityState` already in
+ * place.
+ */
+async function importFresh() {
+  const module = await import('../pageVisibility')
+  return module.getPageVisibilitySnapshot
+}
+
+describe('getPageVisibilitySnapshot', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.restoreAllMocks()
+  })
+
+  it('reports a clean foreground load when the page was never hidden', async () => {
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+
+    const getPageVisibilitySnapshot = await importFresh()
+    const snapshot = getPageVisibilitySnapshot(1000)
+
+    expect(snapshot.wasHidden).toBe(false)
+    expect(snapshot.firstHiddenTime).toBeNull()
+    expect(snapshot.visibilityState).toBe('visible')
+  })
+
+  it('flags a load that was already hidden at module init (background tab)', async () => {
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+
+    const getPageVisibilitySnapshot = await importFresh()
+    const snapshot = getPageVisibilitySnapshot(1000)
+
+    expect(snapshot.wasHidden).toBe(true)
+    expect(snapshot.firstHiddenTime).toBe(0)
+    expect(snapshot.visibilityState).toBe('hidden')
+  })
+
+  it('captures a hide that happens after load, relative to the measured moment', async () => {
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+    vi.spyOn(performance, 'now').mockReturnValue(500)
+
+    const getPageVisibilitySnapshot = await importFresh()
+    expect(getPageVisibilitySnapshot(1000).wasHidden).toBe(false)
+
+    // The page becomes hidden at t=500
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    // A measurement taken at t=1000 was preceded by the hide at t=500
+    expect(getPageVisibilitySnapshot(1000).wasHidden).toBe(true)
+    expect(getPageVisibilitySnapshot(1000).firstHiddenTime).toBe(500)
+
+    // A measurement taken at t=400 happened before the page was hidden
+    expect(getPageVisibilitySnapshot(400).wasHidden).toBe(false)
+  })
+
+  it('latches the first hide and ignores subsequent visibility changes', async () => {
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+    vi.spyOn(performance, 'now').mockReturnValue(300)
+
+    const getPageVisibilitySnapshot = await importFresh()
+
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    // Becomes visible again, then hidden again at a later time
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+    document.dispatchEvent(new Event('visibilitychange'))
+    vi.spyOn(performance, 'now').mockReturnValue(900)
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    expect(getPageVisibilitySnapshot(1000).firstHiddenTime).toBe(300)
+  })
+})

--- a/packages/sanity/src/core/studio/telemetry/pageVisibility.ts
+++ b/packages/sanity/src/core/studio/telemetry/pageVisibility.ts
@@ -1,27 +1,16 @@
 /**
- * Page visibility tracking for navigation-anchored timing telemetry.
+ * Tracks whether the document has been hidden during this page load.
  *
- * Timing events such as `Studio Auth Ready Measured` and `Studio Ready Measured`
- * record `performance.now()` relative to `performance.timeOrigin` (navigation
- * start). When a page loads in a background tab, or is hidden part-way through
- * loading, the browser throttles its work while `performance.now()` keeps
- * advancing in wall-clock time. The measured duration is then inflated by the
- * time the page spent hidden, even though no user was waiting on a spinner.
+ * The navigation-anchored timing events (`Studio Auth Ready Measured`,
+ * `Studio Ready Measured`) record `performance.now()` from navigation start. A
+ * backgrounded tab is throttled while `performance.now()` keeps advancing, so its
+ * measured durations are inflated even though no user was waiting. Stamping each
+ * event with a visibility snapshot lets analysis separate foreground loads from
+ * backgrounded ones instead of inferring it from a missing web-vitals event.
  *
- * This module records the first moment the document became hidden so that each
- * timing event can be stamped with whether it was affected. Analysis can then
- * separate genuine foreground loads from backgrounded ones with certainty,
- * rather than inferring it from the absence of a web-vitals event. The approach
- * mirrors the `firstHiddenTime` guard the `web-vitals` library applies to its
- * own metrics; web-vitals does not expose that watcher publicly, so the latch is
- * reimplemented here.
- *
- * The listener is registered when this module is first evaluated, which happens
- * during boot as the importing component modules load. It latches from that
- * point onward, and the initial value additionally covers a document that is
- * already hidden when the module first runs (the common case of a studio opened
- * in a background tab). The one case it cannot observe is a hide that both starts
- * and ends before this module evaluates.
+ * The latch mirrors web-vitals' `firstHiddenTime` guard, which is not publicly
+ * exported. The listener registers at module evaluation; the initial value also
+ * covers a document already hidden at that point (a load opened in the background).
  *
  * @internal
  */
@@ -29,10 +18,9 @@
 const isBrowser = typeof document !== 'undefined'
 
 /**
- * `performance.now()` of the first time the document was observed hidden, or
- * `Number.POSITIVE_INFINITY` while it has only ever been visible. Initialised to
- * `0` when the document is already hidden at module load, so a background-tab
- * load is captured even if the listener attaches after the fact.
+ * `performance.now()` of the first hide, or `Number.POSITIVE_INFINITY` while the
+ * document has only ever been visible. Prerendering documents report `'hidden'`,
+ * so they need no separate handling.
  */
 let firstHiddenTime =
   isBrowser && document.visibilityState === 'hidden' ? 0 : Number.POSITIVE_INFINITY
@@ -44,46 +32,31 @@ function handleVisibilityChange() {
 }
 
 if (isBrowser) {
-  // `capture` so we record the hide as early as possible in the event phase.
-  // `once` is intentionally omitted because the value is latched in the handler,
-  // so later visibility changes are ignored. The listener is never removed: it
-  // must observe for the whole page lifetime, and the latch makes repeat fires cheap.
+  // Latched once and never removed: it must observe for the whole page lifetime.
   document.addEventListener('visibilitychange', handleVisibilityChange, {capture: true})
 }
 
-/**
- * Visibility context for a single navigation-anchored timing measurement.
- *
- * @internal
- */
+/** @internal */
 export interface PageVisibilitySnapshot {
   /**
-   * Whether the document was hidden at any point between navigation start and
-   * the measured moment. A load with `wasHidden: false` is a clean foreground
-   * load; one with `wasHidden: true` may have an inflated duration.
+   * Whether the document was hidden at any point before the measured moment.
+   * `false` is a clean foreground load; `true` may have an inflated duration.
    */
   wasHidden: boolean
-  /** `document.visibilityState` at the moment the measurement was taken. */
   visibilityState: DocumentVisibilityState
-  /**
-   * `performance.now()` of the first time the document became hidden, rounded to
-   * a whole millisecond, or `null` if it remained visible throughout. Lets
-   * analysis quantify how much of a duration elapsed after the page was hidden.
-   */
+  /** ms of the first hide (rounded), or `null` if the document stayed visible. */
   firstHiddenTime: number | null
 }
 
 /**
- * Returns the visibility context for a measurement taken at `measuredAt`
- * (a `performance.now()` reading, defaulting to the current time).
+ * Visibility snapshot for a measurement taken at `measuredAt`, a `performance.now()`
+ * reading that defaults to the current time.
  *
  * @internal
  */
 export function getPageVisibilitySnapshot(
   measuredAt: number = isBrowser ? performance.now() : 0,
 ): PageVisibilitySnapshot {
-  // The non-browser branch is a safe default only; the call sites log from
-  // client-only effects, so a snapshot is never taken outside the browser.
   return {
     wasHidden: firstHiddenTime < measuredAt,
     visibilityState: isBrowser ? document.visibilityState : 'visible',

--- a/packages/sanity/src/core/studio/telemetry/pageVisibility.ts
+++ b/packages/sanity/src/core/studio/telemetry/pageVisibility.ts
@@ -13,14 +13,15 @@
  * separate genuine foreground loads from backgrounded ones with certainty,
  * rather than inferring it from the absence of a web-vitals event. The approach
  * mirrors the `firstHiddenTime` guard the `web-vitals` library applies to its
- * own metrics.
+ * own metrics; web-vitals does not expose that watcher publicly, so the latch is
+ * reimplemented here.
  *
- * The listener is attached at module-evaluation time so it captures hides that
- * happen during the initial boot, before any component mounts. The initial
- * value also accounts for a document that is already hidden when this module
- * first runs, which covers the common case of a studio opened in a background
- * tab. For maximal accuracy this module should be imported as early as possible
- * in the studio entry path.
+ * The listener is registered when this module is first evaluated, which happens
+ * during boot as the importing component modules load. It latches from that
+ * point onward, and the initial value additionally covers a document that is
+ * already hidden when the module first runs (the common case of a studio opened
+ * in a background tab). The one case it cannot observe is a hide that both starts
+ * and ends before this module evaluates.
  *
  * @internal
  */
@@ -30,8 +31,8 @@ const isBrowser = typeof document !== 'undefined'
 /**
  * `performance.now()` of the first time the document was observed hidden, or
  * `Number.POSITIVE_INFINITY` while it has only ever been visible. Initialised to
- * `0` when the document is already hidden (or prerendering) at module load, so a
- * background-tab load is captured even if the listener attaches after the fact.
+ * `0` when the document is already hidden at module load, so a background-tab
+ * load is captured even if the listener attaches after the fact.
  */
 let firstHiddenTime =
   isBrowser && document.visibilityState === 'hidden' ? 0 : Number.POSITIVE_INFINITY
@@ -45,7 +46,8 @@ function handleVisibilityChange() {
 if (isBrowser) {
   // `capture` so we record the hide as early as possible in the event phase.
   // `once` is intentionally omitted because the value is latched in the handler,
-  // so later visibility changes are ignored.
+  // so later visibility changes are ignored. The listener is never removed: it
+  // must observe for the whole page lifetime, and the latch makes repeat fires cheap.
   document.addEventListener('visibilitychange', handleVisibilityChange, {capture: true})
 }
 
@@ -80,6 +82,8 @@ export interface PageVisibilitySnapshot {
 export function getPageVisibilitySnapshot(
   measuredAt: number = isBrowser ? performance.now() : 0,
 ): PageVisibilitySnapshot {
+  // The non-browser branch is a safe default only; the call sites log from
+  // client-only effects, so a snapshot is never taken outside the browser.
   return {
     wasHidden: firstHiddenTime < measuredAt,
     visibilityState: isBrowser ? document.visibilityState : 'visible',

--- a/packages/sanity/src/core/studio/telemetry/pageVisibility.ts
+++ b/packages/sanity/src/core/studio/telemetry/pageVisibility.ts
@@ -1,0 +1,89 @@
+/**
+ * Page visibility tracking for navigation-anchored timing telemetry.
+ *
+ * Timing events such as `Studio Auth Ready Measured` and `Studio Ready Measured`
+ * record `performance.now()` relative to `performance.timeOrigin` (navigation
+ * start). When a page loads in a background tab, or is hidden part-way through
+ * loading, the browser throttles its work while `performance.now()` keeps
+ * advancing in wall-clock time. The measured duration is then inflated by the
+ * time the page spent hidden, even though no user was waiting on a spinner.
+ *
+ * This module records the first moment the document became hidden so that each
+ * timing event can be stamped with whether it was affected. Analysis can then
+ * separate genuine foreground loads from backgrounded ones with certainty,
+ * rather than inferring it from the absence of a web-vitals event. The approach
+ * mirrors the `firstHiddenTime` guard the `web-vitals` library applies to its
+ * own metrics.
+ *
+ * The listener is attached at module-evaluation time so it captures hides that
+ * happen during the initial boot, before any component mounts. The initial
+ * value also accounts for a document that is already hidden when this module
+ * first runs, which covers the common case of a studio opened in a background
+ * tab. For maximal accuracy this module should be imported as early as possible
+ * in the studio entry path.
+ *
+ * @internal
+ */
+
+const isBrowser = typeof document !== 'undefined'
+
+/**
+ * `performance.now()` of the first time the document was observed hidden, or
+ * `Number.POSITIVE_INFINITY` while it has only ever been visible. Initialised to
+ * `0` when the document is already hidden (or prerendering) at module load, so a
+ * background-tab load is captured even if the listener attaches after the fact.
+ */
+let firstHiddenTime =
+  isBrowser && document.visibilityState === 'hidden' ? 0 : Number.POSITIVE_INFINITY
+
+function handleVisibilityChange() {
+  if (document.visibilityState === 'hidden' && firstHiddenTime === Number.POSITIVE_INFINITY) {
+    firstHiddenTime = performance.now()
+  }
+}
+
+if (isBrowser) {
+  // `capture` so we record the hide as early as possible in the event phase.
+  // `once` is intentionally omitted because the value is latched in the handler,
+  // so later visibility changes are ignored.
+  document.addEventListener('visibilitychange', handleVisibilityChange, {capture: true})
+}
+
+/**
+ * Visibility context for a single navigation-anchored timing measurement.
+ *
+ * @internal
+ */
+export interface PageVisibilitySnapshot {
+  /**
+   * Whether the document was hidden at any point between navigation start and
+   * the measured moment. A load with `wasHidden: false` is a clean foreground
+   * load; one with `wasHidden: true` may have an inflated duration.
+   */
+  wasHidden: boolean
+  /** `document.visibilityState` at the moment the measurement was taken. */
+  visibilityState: DocumentVisibilityState
+  /**
+   * `performance.now()` of the first time the document became hidden, rounded to
+   * a whole millisecond, or `null` if it remained visible throughout. Lets
+   * analysis quantify how much of a duration elapsed after the page was hidden.
+   */
+  firstHiddenTime: number | null
+}
+
+/**
+ * Returns the visibility context for a measurement taken at `measuredAt`
+ * (a `performance.now()` reading, defaulting to the current time).
+ *
+ * @internal
+ */
+export function getPageVisibilitySnapshot(
+  measuredAt: number = isBrowser ? performance.now() : 0,
+): PageVisibilitySnapshot {
+  return {
+    wasHidden: firstHiddenTime < measuredAt,
+    visibilityState: isBrowser ? document.visibilityState : 'visible',
+    firstHiddenTime:
+      firstHiddenTime === Number.POSITIVE_INFINITY ? null : Math.round(firstHiddenTime),
+  }
+}


### PR DESCRIPTION
### Description

The `Studio Auth Ready Measured` and `Studio Ready Measured` telemetry events record `performance.now()` from navigation start, but carry no signal for whether the page loaded in a background tab. Background tabs are throttled while `performance.now()` keeps advancing in wall-clock time, so those loads log durations inflated by the time spent hidden. Today they are blended into the same p95 as real foreground loads, and the only way to separate them is an indirect proxy (the presence or absence of a web-vitals FCP event).

This PR stamps both events with a page-visibility snapshot (`wasHidden`, `visibilityState`, `firstHiddenTime`) so foreground and backgrounded loads can be distinguished directly. A module-level tracker latches the first time the document becomes hidden, mirroring the `firstHiddenTime` guard the `web-vitals` library applies to its own metrics. Both events are bumped to version 2; their names are unchanged, so existing queries keep working.

The web-vitals events (`Performance FCP/LCP/TTFB Measured`) are intentionally left untouched: web-vitals already self-guards on `firstHiddenTime` and suppresses metrics affected by a hidden load, so they do not have the same pollution problem.

### What to review

- `pageVisibility.ts`: the `visibilitychange` listener is registered at module-evaluation time, and `firstHiddenTime` initialises to `0` when the document is already hidden at load (the background-tab case). The docstring states the exact guarantee and its one blind spot.
- `AuthBoundary.tsx` and `StudioLayout.tsx`: `durationMs` is read once and reused as the snapshot's `measuredAt`, so `wasHidden` correlates against the same reading rather than a second `performance.now()` call.
- `bootstrap.telemetry.ts`: both payloads extend `PageVisibilitySnapshot` and bump to version 2.

### Testing

Added `pageVisibility.test.ts` covering a never-hidden load, a load already hidden at module init, a hide after load measured relative to the measured moment, and first-hide latching. The `AuthBoundary` and `StudioLayout` suites now assert that the visibility fields are stamped onto the logged events, so dropping the snapshot would fail a test.

### Notes for release

N/A
