### PR TITLE
ci(e2e): disable pnpm pre-run dep verification after sanity-ui tarball injection

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -125,6 +125,10 @@ jobs:
           VERCEL_SANITY_API_DEPLOY_TOKEN: ${{ secrets.VERCEL_SANITY_API_DEPLOY_TOKEN }}
           # the id is based on the PR number and the workflow run id
           SANITY_E2E_DATASET: ${{ github.event_name == 'pull_request' && format('pr-{0}-{1}-{2}', github.event.number, matrix.project, github.run_id) || vars.SANITY_E2E_DATASET_STAGING }}
+          # the tarball `pnpm add -w` above rewrites the `@sanity/ui` override, so pnpm's
+          # pre-run dependency verification would trigger a frozen install here and fail
+          # with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH
+          npm_config_verify_deps_before_run: "false"
         run: pnpm e2e:setup && pnpm e2e:build
 
   playwright-test:


### PR DESCRIPTION
### Description

The reusable e2e-ui workflow (consumed at @main by sanity-io/ui CI) injects the packed @sanity/ui tarball via `pnpm add -w`, which rewrites the `@sanity/ui@3` override. pnpm 11's verify-deps-before-run then triggers an implicit frozen install when `pnpm e2e:setup` starts and rejects it with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`, failing the install (chromium/firefox) jobs on every sanity-io/ui PR (byte-identical failure on the unrelated bot branch actions/react-compiler-main, run 26402825165, and on sanity-io/ui#2206 / #2207).

This PR sets `npm_config_verify_deps_before_run: 'false'` on the `pnpm e2e:setup && pnpm e2e:build` step in the `install` job - the only pnpm script invocation that runs after the tarball injection (the `playwright-test` job runs a plain `pnpm install` without injecting, and `build-cli` ends at the injection).

### What to review

- The mutation is deliberate and scoped to a throwaway CI checkout, so skipping pnpm's pre-run verification for this one step is safe.

### Testing

After this lands on main, re-running the failed Run Studio End-to-end tests jobs on sanity-io/ui#2206 should turn them green (and un-skip playwright-test).

### Notes for release

N/A

### How this fits

Unblocks green CI for sanity-io/ui PRs - immediately needed for https://github.com/sanity-io/ui/pull/2206 and https://github.com/sanity-io/ui/pull/2207 (part of the studio startup performance effort), but fixes the install jobs for every ui PR.
