### PR TITLE
perf(core): lazy-load search filter input components from operator definitions

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/search/components/common/FilterLabel.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/common/FilterLabel.tsx
@@ -1,5 +1,5 @@
 import {Box, Flex} from '@sanity/ui'
-import {useMemo} from 'react'
+import {Suspense, useMemo} from 'react'
 import {styled} from 'styled-components'
 
 import {TextWithTone} from '../../../../../../components'
@@ -53,7 +53,13 @@ export function FilterLabel({filter, fontSize = 1, showContent = true}: FilterLa
         showContent ? (
           <CustomBox $flexShrink={1}>
             <TextWithTone tone="default" size={fontSize} textOverflow="ellipsis" weight="medium">
-              {ButtonValue ? <ButtonValue value={filterValue} /> : children}
+              {ButtonValue ? (
+                <Suspense fallback={null}>
+                  <ButtonValue value={filterValue} />
+                </Suspense>
+              ) : (
+                children
+              )}
             </TextWithTone>
           </CustomBox>
         ) : null,

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/FilterForm.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/FilterForm.tsx
@@ -1,6 +1,6 @@
 import {TrashIcon} from '@sanity/icons'
 import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
-import {type ErrorInfo, useCallback, useState} from 'react'
+import {type ErrorInfo, Suspense, useCallback, useState} from 'react'
 import FocusLock from 'react-focus-lock'
 
 import {Button, ErrorBoundary} from '../../../../../../../../ui-components'
@@ -71,13 +71,15 @@ export function FilterForm({filter}: FilterFormProps) {
           {/* Value */}
           {Component && (
             <Card borderTop padding={3}>
-              <Component
-                // re-render on new operators
-                key={filter.operatorType}
-                fieldDefinition={fieldDefinition}
-                onChange={handleValueChange}
-                value={filter.value}
-              />
+              <Suspense fallback={null}>
+                <Component
+                  // re-render on new operators
+                  key={filter.operatorType}
+                  fieldDefinition={fieldDefinition}
+                  onChange={handleValueChange}
+                  value={filter.value}
+                />
+              </Suspense>
             </Card>
           )}
 

--- a/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/arrayOperators.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/arrayOperators.ts
@@ -1,10 +1,6 @@
 import {type ReferenceValue} from '@sanity/types'
+import {type ComponentType, lazy} from 'react'
 
-import {SearchButtonValueReference} from '../../components/filters/common/ButtonValue'
-import {SearchFilterNumberInput} from '../../components/filters/filter/inputs/number/Number'
-import {SearchFilterNumberRangeInput} from '../../components/filters/filter/inputs/number/NumberRange'
-import {SearchFilterReferenceInput} from '../../components/filters/filter/inputs/reference/Reference'
-import {SearchFilterStringListInput} from '../../components/filters/filter/inputs/string/StringList'
 import {GteIcon} from '../../components/filters/icons/GteIcon'
 import {GtIcon} from '../../components/filters/icons/GtIcon'
 import {LteIcon} from '../../components/filters/icons/LteIcon'
@@ -16,6 +12,34 @@ import {
   type SearchOperatorInput,
 } from './operatorTypes'
 import {toJSON} from './operatorUtils'
+
+// Operator definitions are evaluated pre-auth via prepareConfig; lazy-load filter input
+// components to keep them out of the eager bundle.
+const SearchButtonValueReference = lazy(() =>
+  import('../../components/filters/common/ButtonValue').then((m) => ({
+    default: m.SearchButtonValueReference,
+  })),
+) as ComponentType<any>
+const SearchFilterNumberInput = lazy(() =>
+  import('../../components/filters/filter/inputs/number/Number').then((m) => ({
+    default: m.SearchFilterNumberInput,
+  })),
+) as ComponentType<any>
+const SearchFilterNumberRangeInput = lazy(() =>
+  import('../../components/filters/filter/inputs/number/NumberRange').then((m) => ({
+    default: m.SearchFilterNumberRangeInput,
+  })),
+) as ComponentType<any>
+const SearchFilterReferenceInput = lazy(() =>
+  import('../../components/filters/filter/inputs/reference/Reference').then((m) => ({
+    default: m.SearchFilterReferenceInput,
+  })),
+) as ComponentType<any>
+const SearchFilterStringListInput = lazy(() =>
+  import('../../components/filters/filter/inputs/string/StringList').then((m) => ({
+    default: m.SearchFilterStringListInput,
+  })),
+) as ComponentType<any>
 
 // @todo: don't manually cast `buttonValueComponent` and `inputComponent` once
 // we understand why `npm run etl` fails with 'Unable to follow symbol' errors

--- a/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/assetOperators.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/assetOperators.ts
@@ -1,7 +1,26 @@
-import {SearchButtonValueReference} from '../../components/filters/common/ButtonValue'
-import {SearchFilterAssetInput} from '../../components/filters/filter/inputs/asset/Asset'
+import {type ComponentType, lazy} from 'react'
+
 import {defineSearchOperator} from './operatorTypes'
 import {toJSON} from './operatorUtils'
+
+// Operator definitions are evaluated pre-auth via prepareConfig; lazy-load filter input
+// components to keep them out of the eager bundle.
+const SearchButtonValueReference = lazy(() =>
+  import('../../components/filters/common/ButtonValue').then((m) => ({
+    default: m.SearchButtonValueReference,
+  })),
+) as ComponentType<any>
+// SearchFilterAssetInput is a factory; create one lazy component per variant.
+const SearchFilterAssetFileInput = lazy(() =>
+  import('../../components/filters/filter/inputs/asset/Asset').then((m) => ({
+    default: m.SearchFilterAssetInput('file'),
+  })),
+) as ComponentType<any>
+const SearchFilterAssetImageInput = lazy(() =>
+  import('../../components/filters/filter/inputs/asset/Asset').then((m) => ({
+    default: m.SearchFilterAssetInput('image'),
+  })),
+) as ComponentType<any>
 
 // @todo: don't manually cast `buttonValueComponent` and `inputComponent` once
 // we understand why `npm run etl` fails with 'Unable to follow symbol' errors
@@ -13,7 +32,7 @@ export const assetOperators = {
     groqFilter: ({fieldPath, value}) =>
       value?._ref && fieldPath ? `${fieldPath}.asset._ref == ${toJSON(value._ref)}` : null,
     initialValue: null,
-    inputComponent: SearchFilterAssetInput('file'),
+    inputComponent: SearchFilterAssetFileInput,
     type: 'assetFileEqual',
   }),
   assetFileNotEqual: defineSearchOperator({
@@ -23,7 +42,7 @@ export const assetOperators = {
     groqFilter: ({fieldPath, value}) =>
       value?._ref && fieldPath ? `${fieldPath}.asset._ref != ${toJSON(value._ref)}` : null,
     initialValue: null,
-    inputComponent: SearchFilterAssetInput('file'),
+    inputComponent: SearchFilterAssetFileInput,
     type: 'assetFileNotEqual',
   }),
   assetImageEqual: defineSearchOperator({
@@ -33,7 +52,7 @@ export const assetOperators = {
     groqFilter: ({fieldPath, value}) =>
       value?._ref && fieldPath ? `${fieldPath}.asset._ref == ${toJSON(value._ref)}` : null,
     initialValue: null,
-    inputComponent: SearchFilterAssetInput('image'),
+    inputComponent: SearchFilterAssetImageInput,
     type: 'assetImageEqual',
   }),
   assetImageNotEqual: defineSearchOperator({
@@ -43,7 +62,7 @@ export const assetOperators = {
     groqFilter: ({fieldPath, value}) =>
       value?._ref && fieldPath ? `${fieldPath}.asset._ref != ${toJSON(value._ref)}` : null,
     initialValue: null,
-    inputComponent: SearchFilterAssetInput('image'),
+    inputComponent: SearchFilterAssetImageInput,
     type: 'assetImageNotEqual',
   }),
 }

--- a/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/booleanOperators.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/booleanOperators.ts
@@ -1,10 +1,19 @@
-import {SearchFilterBooleanInput} from '../../components/filters/filter/inputs/boolean/Boolean'
+import {type ComponentType, lazy} from 'react'
+
 import {
   defineSearchOperator,
   type SearchOperatorInput,
   type SearchOperatorParams,
 } from './operatorTypes'
 import {toJSON} from './operatorUtils'
+
+// Operator definitions are evaluated pre-auth via prepareConfig; lazy-load filter input
+// components to keep them out of the eager bundle.
+const SearchFilterBooleanInput = lazy(() =>
+  import('../../components/filters/filter/inputs/boolean/Boolean').then((m) => ({
+    default: m.SearchFilterBooleanInput,
+  })),
+) as ComponentType<any>
 
 // @todo: don't manually cast `buttonValueComponent` and `inputComponent` once
 // we understand why `npm run etl` fails with 'Unable to follow symbol' errors

--- a/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/dateOperators.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/dateOperators.ts
@@ -5,21 +5,8 @@ import {startOfDay} from 'date-fns/startOfDay'
 import {startOfMinute} from 'date-fns/startOfMinute'
 import {startOfToday} from 'date-fns/startOfToday'
 import {sub} from 'date-fns/sub'
+import {type ComponentType, lazy} from 'react'
 
-import {
-  SearchButtonValueDate,
-  SearchButtonValueDateLast,
-  SearchButtonValueDateRange,
-} from '../../components/filters/common/ButtonValue'
-import {SearchFilterDateAfterInput} from '../../components/filters/filter/inputs/date/DateAfter'
-import {SearchFilterDateBeforeInput} from '../../components/filters/filter/inputs/date/DateBefore'
-import {SearchFilterDateEqualInput} from '../../components/filters/filter/inputs/date/DateEqual'
-import {SearchFilterDateLastInput} from '../../components/filters/filter/inputs/date/DateLast'
-import {SearchFilterDateRangeInput} from '../../components/filters/filter/inputs/date/DateRange'
-import {SearchFilterDateTimeAfterInput} from '../../components/filters/filter/inputs/date/DateTimeAfter'
-import {SearchFilterDateTimeBeforeInput} from '../../components/filters/filter/inputs/date/DateTimeBefore'
-import {SearchFilterDateTimeEqualInput} from '../../components/filters/filter/inputs/date/DateTimeEqual'
-import {SearchFilterDateTimeRangeInput} from '../../components/filters/filter/inputs/date/DateTimeRange'
 import {
   defineSearchOperator,
   type SearchOperatorButtonValue,
@@ -27,6 +14,69 @@ import {
   type SearchOperatorParams,
 } from './operatorTypes'
 import {toJSON} from './operatorUtils'
+
+// Operator definitions are evaluated pre-auth via prepareConfig; lazy-load filter input
+// components to keep them out of the eager bundle.
+const SearchButtonValueDate = lazy(() =>
+  import('../../components/filters/common/ButtonValue').then((m) => ({
+    default: m.SearchButtonValueDate,
+  })),
+) as ComponentType<any>
+const SearchButtonValueDateLast = lazy(() =>
+  import('../../components/filters/common/ButtonValue').then((m) => ({
+    default: m.SearchButtonValueDateLast,
+  })),
+) as ComponentType<any>
+const SearchButtonValueDateRange = lazy(() =>
+  import('../../components/filters/common/ButtonValue').then((m) => ({
+    default: m.SearchButtonValueDateRange,
+  })),
+) as ComponentType<any>
+const SearchFilterDateAfterInput = lazy(() =>
+  import('../../components/filters/filter/inputs/date/DateAfter').then((m) => ({
+    default: m.SearchFilterDateAfterInput,
+  })),
+) as ComponentType<any>
+const SearchFilterDateBeforeInput = lazy(() =>
+  import('../../components/filters/filter/inputs/date/DateBefore').then((m) => ({
+    default: m.SearchFilterDateBeforeInput,
+  })),
+) as ComponentType<any>
+const SearchFilterDateEqualInput = lazy(() =>
+  import('../../components/filters/filter/inputs/date/DateEqual').then((m) => ({
+    default: m.SearchFilterDateEqualInput,
+  })),
+) as ComponentType<any>
+const SearchFilterDateLastInput = lazy(() =>
+  import('../../components/filters/filter/inputs/date/DateLast').then((m) => ({
+    default: m.SearchFilterDateLastInput,
+  })),
+) as ComponentType<any>
+const SearchFilterDateRangeInput = lazy(() =>
+  import('../../components/filters/filter/inputs/date/DateRange').then((m) => ({
+    default: m.SearchFilterDateRangeInput,
+  })),
+) as ComponentType<any>
+const SearchFilterDateTimeAfterInput = lazy(() =>
+  import('../../components/filters/filter/inputs/date/DateTimeAfter').then((m) => ({
+    default: m.SearchFilterDateTimeAfterInput,
+  })),
+) as ComponentType<any>
+const SearchFilterDateTimeBeforeInput = lazy(() =>
+  import('../../components/filters/filter/inputs/date/DateTimeBefore').then((m) => ({
+    default: m.SearchFilterDateTimeBeforeInput,
+  })),
+) as ComponentType<any>
+const SearchFilterDateTimeEqualInput = lazy(() =>
+  import('../../components/filters/filter/inputs/date/DateTimeEqual').then((m) => ({
+    default: m.SearchFilterDateTimeEqualInput,
+  })),
+) as ComponentType<any>
+const SearchFilterDateTimeRangeInput = lazy(() =>
+  import('../../components/filters/filter/inputs/date/DateTimeRange').then((m) => ({
+    default: m.SearchFilterDateTimeRangeInput,
+  })),
+) as ComponentType<any>
 
 // 'Before' and 'after' dates
 export interface OperatorDateDirectionValue {

--- a/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/numberOperators.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/numberOperators.ts
@@ -1,5 +1,5 @@
-import {SearchFilterNumberInput} from '../../components/filters/filter/inputs/number/Number'
-import {SearchFilterNumberRangeInput} from '../../components/filters/filter/inputs/number/NumberRange'
+import {type ComponentType, lazy} from 'react'
+
 import {GteIcon} from '../../components/filters/icons/GteIcon'
 import {GtIcon} from '../../components/filters/icons/GtIcon'
 import {LteIcon} from '../../components/filters/icons/LteIcon'
@@ -7,6 +7,19 @@ import {LtIcon} from '../../components/filters/icons/LtIcon'
 import {type OperatorNumberRangeValue} from './common'
 import {defineSearchOperator, type SearchOperatorInput} from './operatorTypes'
 import {toJSON} from './operatorUtils'
+
+// Operator definitions are evaluated pre-auth via prepareConfig; lazy-load filter input
+// components to keep them out of the eager bundle.
+const SearchFilterNumberInput = lazy(() =>
+  import('../../components/filters/filter/inputs/number/Number').then((m) => ({
+    default: m.SearchFilterNumberInput,
+  })),
+) as ComponentType<any>
+const SearchFilterNumberRangeInput = lazy(() =>
+  import('../../components/filters/filter/inputs/number/NumberRange').then((m) => ({
+    default: m.SearchFilterNumberRangeInput,
+  })),
+) as ComponentType<any>
 
 // @todo: don't manually cast `buttonValueComponent` and `inputComponent` once
 // we understand why `npm etl` fails with 'Unable to follow symbol' errors

--- a/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/portableTextOperators.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/portableTextOperators.ts
@@ -1,6 +1,15 @@
-import {SearchFilterStringInput} from '../../components/filters/filter/inputs/string/String'
+import {type ComponentType, lazy} from 'react'
+
 import {defineSearchOperator, type SearchOperatorInput} from './operatorTypes'
 import {toJSON} from './operatorUtils'
+
+// Operator definitions are evaluated pre-auth via prepareConfig; lazy-load filter input
+// components to keep them out of the eager bundle.
+const SearchFilterStringInput = lazy(() =>
+  import('../../components/filters/filter/inputs/string/String').then((m) => ({
+    default: m.SearchFilterStringInput,
+  })),
+) as ComponentType<any>
 
 // @todo: don't manually cast `buttonValueComponent` and `inputComponent` once
 // we understand why `npm etl` fails with 'Unable to follow symbol' errors

--- a/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/referenceOperators.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/referenceOperators.ts
@@ -1,14 +1,36 @@
 import {type ReferenceValue} from '@sanity/types'
+import {type ComponentType, lazy} from 'react'
 
-import {SearchButtonValueReference} from '../../components/filters/common/ButtonValue'
-import {SearchFilterAssetInput} from '../../components/filters/filter/inputs/asset/Asset'
-import {SearchFilterReferenceInput} from '../../components/filters/filter/inputs/reference/Reference'
 import {
   defineSearchOperator,
   type SearchOperatorButtonValue,
   type SearchOperatorInput,
 } from './operatorTypes'
 import {toJSON} from './operatorUtils'
+
+// Operator definitions are evaluated pre-auth via prepareConfig; lazy-load filter input
+// components to keep them out of the eager bundle.
+const SearchButtonValueReference = lazy(() =>
+  import('../../components/filters/common/ButtonValue').then((m) => ({
+    default: m.SearchButtonValueReference,
+  })),
+) as ComponentType<any>
+// SearchFilterAssetInput is a factory; create one lazy component per variant.
+const SearchFilterAssetFileInput = lazy(() =>
+  import('../../components/filters/filter/inputs/asset/Asset').then((m) => ({
+    default: m.SearchFilterAssetInput('file'),
+  })),
+) as ComponentType<any>
+const SearchFilterAssetImageInput = lazy(() =>
+  import('../../components/filters/filter/inputs/asset/Asset').then((m) => ({
+    default: m.SearchFilterAssetInput('image'),
+  })),
+) as ComponentType<any>
+const SearchFilterReferenceInput = lazy(() =>
+  import('../../components/filters/filter/inputs/reference/Reference').then((m) => ({
+    default: m.SearchFilterReferenceInput,
+  })),
+) as ComponentType<any>
 
 // @todo: don't manually cast `buttonValueComponent` and `inputComponent` once
 // we understand why `npm etl` fails with 'Unable to follow symbol' errors
@@ -39,7 +61,7 @@ export const referenceOperators = {
     buttonValueComponent: SearchButtonValueReference as SearchOperatorButtonValue<ReferenceValue>,
     groqFilter: ({value}) => (value?._ref ? `references(${toJSON(value._ref)})` : null),
     initialValue: null,
-    inputComponent: SearchFilterAssetInput('file'),
+    inputComponent: SearchFilterAssetFileInput,
     type: 'referencesAssetFile',
   }),
   referencesAssetImage: defineSearchOperator({
@@ -48,7 +70,7 @@ export const referenceOperators = {
     buttonValueComponent: SearchButtonValueReference as SearchOperatorButtonValue<ReferenceValue>,
     groqFilter: ({value}) => (value?._ref ? `references(${toJSON(value._ref)})` : null),
     initialValue: null,
-    inputComponent: SearchFilterAssetInput('image'),
+    inputComponent: SearchFilterAssetImageInput,
     type: 'referencesAssetImage',
   }),
   referencesDocument: defineSearchOperator({

--- a/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/slugOperators.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/slugOperators.ts
@@ -1,6 +1,15 @@
-import {SearchFilterStringInput} from '../../components/filters/filter/inputs/string/String'
+import {type ComponentType, lazy} from 'react'
+
 import {defineSearchOperator, type SearchOperatorInput} from './operatorTypes'
 import {toJSON} from './operatorUtils'
+
+// Operator definitions are evaluated pre-auth via prepareConfig; lazy-load filter input
+// components to keep them out of the eager bundle.
+const SearchFilterStringInput = lazy(() =>
+  import('../../components/filters/filter/inputs/string/String').then((m) => ({
+    default: m.SearchFilterStringInput,
+  })),
+) as ComponentType<any>
 
 // @todo: don't manually cast `buttonValueComponent` and `inputComponent` once
 // we understand why `npm etl` fails with 'Unable to follow symbol' errors

--- a/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/stringOperators.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/definitions/operators/stringOperators.ts
@@ -1,7 +1,20 @@
-import {SearchFilterStringInput} from '../../components/filters/filter/inputs/string/String'
-import {SearchFilterStringListInput} from '../../components/filters/filter/inputs/string/StringList'
+import {type ComponentType, lazy} from 'react'
+
 import {defineSearchOperator, type SearchOperatorInput} from './operatorTypes'
 import {toJSON} from './operatorUtils'
+
+// Operator definitions are evaluated pre-auth via prepareConfig; lazy-load filter input
+// components to keep them out of the eager bundle.
+const SearchFilterStringInput = lazy(() =>
+  import('../../components/filters/filter/inputs/string/String').then((m) => ({
+    default: m.SearchFilterStringInput,
+  })),
+) as ComponentType<any>
+const SearchFilterStringListInput = lazy(() =>
+  import('../../components/filters/filter/inputs/string/StringList').then((m) => ({
+    default: m.SearchFilterStringListInput,
+  })),
+) as ComponentType<any>
 
 // @todo: don't manually cast `buttonValueComponent` and `inputComponent` once
 // we understand why `npm etl` fails with 'Unable to follow symbol' errors


### PR DESCRIPTION
## Description

Part of the post-auth eval-deferral initiative (auth-ready OKR). A throwaway ceiling probe combining this change with the full export-surface cut measured: eager bundle 5,181 KB -> 2,467 KB (-52%) and auth-ready -21-26% at 20x CPU throttle (A/B/A, N=12/block), putting the prod central estimate at ~-1.5s p95. This PR ships an independent, non-breaking slice; in isolation it is expected to be timing-neutral - the wall-clock win materializes once the export-surface cut lands.

The nine search operator definition files (`arrayOperators`, `assetOperators`, `booleanOperators`, `dateOperators`, `numberOperators`, `portableTextOperators`, `referenceOperators`, `slugOperators`, `stringOperators`) previously statically imported ~29 filter UI components. These definitions are evaluated pre-auth via `prepareConfig`, pulling the entire search filter input subtree (and through it, parts of the form input registry and Preview) into the eager bundle. The fix replaces every static import of an `inputComponent` or `buttonValueComponent` with `React.lazy`, deferring the module load until the search filter popover is first opened.

`SearchFilterAssetInput` is a factory function called at module scope as `SearchFilterAssetInput('file' | 'image')`. Wrapping the factory itself in `lazy()` would crash at render time. Instead, per-variant lazy components (`SearchFilterAssetFileInput`, `SearchFilterAssetImageInput`) are created - the `.then()` callback calls the factory and wraps the result as the `default` export. This pattern is applied in both `assetOperators.ts` and `referenceOperators.ts`.

Icon imports remain static throughout - they are tiny leaf files and can render outside a Suspense boundary without issue.

`React.lazy` components must render inside a `<Suspense>` ancestor. Neither `FilterForm` (which renders `inputComponent`) nor `FilterLabel` (which renders `buttonValueComponent`) had one. A `<Suspense fallback={null}>` wrapper is added at each render site.

The `as any` casts from the experiment branch are replaced with `as ComponentType<any>` throughout. This is an acceptable typed cast given that the definition fields already use explicit casts via `SearchOperatorInput<T>` / `SearchOperatorButtonValue<T>` at the point of assignment into `defineSearchOperator`.

## Testing

All nine colocated operator test files pass. The tests only assert on `groqFilter` return values, not on component identity, so no test changes were required.

## Notes for release

N/A