### PR TITLE
perf(core): lazy-load interaction-gated dialogs and document inspectors

### DIFF
--- a/packages/sanity/src/core/canvas/actions/LinkToCanvas/LinkToCanvasAction.tsx
+++ b/packages/sanity/src/core/canvas/actions/LinkToCanvas/LinkToCanvasAction.tsx
@@ -1,6 +1,6 @@
 import {type SanityDocument} from '@sanity/client'
 import {ComposeSparklesIcon} from '@sanity/icons'
-import {useCallback, useEffect, useMemo, useState} from 'react'
+import {lazy, useCallback, useEffect, useMemo, useState} from 'react'
 
 import {
   type DocumentActionComponent,
@@ -18,7 +18,11 @@ import {canvasLocaleNamespace} from '../../i18n'
 import {useCanvasTelemetry} from '../../useCanvasTelemetry'
 import {getDocumentIdForCanvasLink} from '../../utils/getDocumentIdForCanvasLink'
 import {useCanvasCompanionDoc} from '../useCanvasCompanionDoc'
-import {LinkToCanvasDialog} from './LinkToCanvasDialog'
+
+// Deferred so the dialog's module graph stays out of the eager action bundle; it only renders after the user opens it.
+const LinkToCanvasDialog = lazy(() =>
+  import('./LinkToCanvasDialog').then((module) => ({default: module.LinkToCanvasDialog})),
+)
 
 const useIsExcludedType = (type: string) => {
   const schema = useSchema()

--- a/packages/sanity/src/core/canvas/actions/UnlinkFromCanvas/UnlinkFromCanvasAction.tsx
+++ b/packages/sanity/src/core/canvas/actions/UnlinkFromCanvas/UnlinkFromCanvasAction.tsx
@@ -1,6 +1,6 @@
 import {UnlinkIcon} from '@sanity/icons'
 import {useToast} from '@sanity/ui'
-import {useCallback, useState} from 'react'
+import {lazy, useCallback, useState} from 'react'
 
 import {
   type DocumentActionComponent,
@@ -13,7 +13,13 @@ import {canvasLocaleNamespace} from '../../i18n'
 import {useCanvasTelemetry} from '../../useCanvasTelemetry'
 import {getDocumentIdForCanvasLink} from '../../utils/getDocumentIdForCanvasLink'
 import {useCanvasCompanionDoc} from '../useCanvasCompanionDoc'
-import {UnlinkFromCanvasDialog} from './UnlinkFromCanvasDialog'
+
+// Deferred so the dialog's module graph - the last eager motion/react importer in core - stays out of the eager action bundle; it only renders after the user opens it.
+const UnlinkFromCanvasDialog = lazy(() =>
+  import('./UnlinkFromCanvasDialog').then((module) => ({
+    default: module.UnlinkFromCanvasDialog,
+  })),
+)
 
 // React Compiler needs functions that are hooks to have the `use` prefix, pascal case are treated as a component, these are hooks even though they're confusingly named `DocumentActionComponent`
 export const useUnlinkFromCanvasAction: DocumentActionComponent = (props: DocumentActionProps) => {

--- a/packages/sanity/src/core/releases/plugin/documentActions/DiscardVersionAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/DiscardVersionAction.tsx
@@ -1,5 +1,5 @@
 import {TrashIcon} from '@sanity/icons'
-import {useCallback, useState} from 'react'
+import {lazy, useCallback, useState} from 'react'
 
 import {InsufficientPermissionsMessage} from '../../../components/InsufficientPermissionsMessage'
 import {
@@ -11,8 +11,14 @@ import {useTranslation} from '../../../i18n'
 import {usePerspective} from '../../../perspective/usePerspective'
 import {useDocumentPairPermissions} from '../../../store/grants/documentPairPermissions'
 import {useCurrentUser} from '../../../store/user/hooks'
-import {DiscardVersionDialog} from '../../components/dialog/DiscardVersionDialog'
 import {isGoingToUnpublish} from '../../util/isGoingToUnpublish'
+
+// Deferred so the dialog's module graph stays out of the eager action bundle; it only renders after the user opens it.
+const DiscardVersionDialog = lazy(() =>
+  import('../../components/dialog/DiscardVersionDialog').then((module) => ({
+    default: module.DiscardVersionDialog,
+  })),
+)
 
 // React Compiler needs functions that are hooks to have the `use` prefix, pascal case are treated as a component, these are hooks even though they're confusingly named `DocumentActionComponent`
 /** @internal */

--- a/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
@@ -1,6 +1,6 @@
 import {RevertIcon, TrashIcon, UnpublishIcon} from '@sanity/icons'
 import {useToast} from '@sanity/ui'
-import {useCallback, useState} from 'react'
+import {lazy, useCallback, useState} from 'react'
 
 import {InsufficientPermissionsMessage} from '../../../components/InsufficientPermissionsMessage'
 import {
@@ -11,10 +11,16 @@ import {
 import {useTranslation} from '../../../i18n'
 import {useDocumentPairPermissions} from '../../../store/grants/documentPairPermissions'
 import {useCurrentUser} from '../../../store/user/hooks'
-import {UnpublishVersionDialog} from '../../components/dialog/UnpublishVersionDialog'
 import {useVersionOperations} from '../../hooks/useVersionOperations'
 import {releasesLocaleNamespace} from '../../i18n'
 import {isGoingToUnpublish} from '../../util/isGoingToUnpublish'
+
+// Defer the dialog - only renders after user interaction
+const UnpublishVersionDialog = lazy(() =>
+  import('../../components/dialog/UnpublishVersionDialog').then((module) => ({
+    default: module.UnpublishVersionDialog,
+  })),
+)
 
 // React Compiler needs functions that are hooks to have the `use` prefix, pascal case are treated as a component, these are hooks even though they're confusingly named `DocumentActionComponent`
 /** @internal */

--- a/packages/sanity/src/core/scheduled-publishing/plugin/documentActions/schedule/ScheduleAction.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/plugin/documentActions/schedule/ScheduleAction.tsx
@@ -1,6 +1,6 @@
 import {CalendarIcon, ClockIcon} from '@sanity/icons'
 import {Box, Text} from '@sanity/ui'
-import {useCallback, useState} from 'react'
+import {lazy, Suspense, useCallback, useState} from 'react'
 
 import {InsufficientPermissionsMessage} from '../../../../components/InsufficientPermissionsMessage'
 import {
@@ -14,7 +14,6 @@ import {useCurrentUser} from '../../../../store/user/hooks'
 import {debugWithName} from '../../../../studio/timezones/utils/debug'
 import DialogFooter from '../../../components/dialogs/DialogFooter'
 import DialogHeader from '../../../components/dialogs/DialogHeader'
-import {EditScheduleForm} from '../../../components/editScheduleForm'
 import ErrorCallout from '../../../components/errorCallout/ErrorCallout'
 import {SCHEDULED_PUBLISHING_TIME_ZONE_SCOPE} from '../../../constants'
 import {DocumentActionPropsProvider} from '../../../contexts/documentActionProps'
@@ -23,7 +22,14 @@ import useScheduleForm from '../../../hooks/useScheduleForm'
 import useScheduleOperation from '../../../hooks/useScheduleOperation'
 import {useSchedulePublishingUpsell} from '../../../tool/contexts/SchedulePublishingUpsellProvider'
 import {NewScheduleInfo} from './NewScheduleInfo'
-import Schedules from './Schedules'
+
+// Deferred so the schedule form and schedule list stay out of the eager action bundle; they only render inside the dialog.
+const EditScheduleForm = lazy(() =>
+  import('../../../components/editScheduleForm/EditScheduleForm').then((module) => ({
+    default: module.EditScheduleForm,
+  })),
+)
+const Schedules = lazy(() => import('./Schedules'))
 
 const debug = debugWithName('ScheduleAction')
 
@@ -135,13 +141,15 @@ export const useScheduleAction: DocumentActionComponent = (props: DocumentAction
       />
     ) : (
       <DocumentActionPropsProvider value={props}>
-        {hasExistingSchedules ? (
-          <Schedules schedules={schedules} />
-        ) : (
-          <EditScheduleForm onChange={onFormChange} value={formData}>
-            <NewScheduleInfo id={id} schemaType={type} />
-          </EditScheduleForm>
-        )}
+        <Suspense fallback={null}>
+          {hasExistingSchedules ? (
+            <Schedules schedules={schedules} />
+          ) : (
+            <EditScheduleForm onChange={onFormChange} value={formData}>
+              <NewScheduleInfo id={id} schemaType={type} />
+            </EditScheduleForm>
+          )}
+        </Suspense>
       </DocumentActionPropsProvider>
     ),
     footer: !hasExistingSchedules && (

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.test.tsx
@@ -223,9 +223,9 @@ describe('useScheduledDraftMenuActions', () => {
         </TestProvider>,
       )
 
-      // Click menu item to open dialog
+      // Click menu item to open dialog (lazy-loaded, so await its appearance)
       await userEvent.click(screen.getByTestId('publish-now-menu-item'))
-      expect(screen.getByTestId('publish-scheduled-draft-dialog')).toBeInTheDocument()
+      expect(await screen.findByTestId('publish-scheduled-draft-dialog')).toBeInTheDocument()
 
       // Confirm action
       await userEvent.click(screen.getByTestId('confirm-publish'))
@@ -308,9 +308,9 @@ describe('useScheduledDraftMenuActions', () => {
         </TestProvider>,
       )
 
-      // Click menu item to open dialog
+      // Click menu item to open dialog (lazy-loaded, so await its appearance)
       await userEvent.click(screen.getByTestId('delete-schedule-menu-item'))
-      expect(screen.getByTestId('delete-scheduled-draft-dialog')).toBeInTheDocument()
+      expect(await screen.findByTestId('delete-scheduled-draft-dialog')).toBeInTheDocument()
 
       // Confirm action
       await userEvent.click(screen.getByTestId('confirm-delete'))

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.tsx
@@ -1,16 +1,30 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {CalendarIcon, EditIcon, PublishIcon, TrashIcon} from '@sanity/icons'
 import {useToast} from '@sanity/ui'
-import {type ComponentProps, useCallback, useMemo, useState} from 'react'
+import {type ComponentProps, lazy, Suspense, useCallback, useMemo, useState} from 'react'
 
 import {type MenuItem} from '../../../ui-components/menuItem'
 import {Translate, useTranslation} from '../../i18n'
 import {getErrorMessage} from '../../util'
-import {DeleteScheduledDraftDialog} from '../components/DeleteScheduledDraftDialog'
-import {PublishScheduledDraftDialog} from '../components/PublishScheduledDraftDialog'
-import {ScheduleDraftDialog} from '../components/ScheduleDraftDialog'
 import {useScheduledDraftDocument} from './useScheduledDraftDocument'
 import {useScheduleDraftOperations} from './useScheduleDraftOperations'
+
+// Deferred so the dialog module graphs stay out of the eager bundle; they only render after the user opens a menu action.
+const DeleteScheduledDraftDialog = lazy(() =>
+  import('../components/DeleteScheduledDraftDialog').then((module) => ({
+    default: module.DeleteScheduledDraftDialog,
+  })),
+)
+const PublishScheduledDraftDialog = lazy(() =>
+  import('../components/PublishScheduledDraftDialog').then((module) => ({
+    default: module.PublishScheduledDraftDialog,
+  })),
+)
+const ScheduleDraftDialog = lazy(() =>
+  import('../components/ScheduleDraftDialog').then((module) => ({
+    default: module.ScheduleDraftDialog,
+  })),
+)
 
 export type ScheduledDraftAction =
   | 'publish-now'
@@ -182,35 +196,42 @@ export function useScheduledDraftMenuActions(
   const dialogs = useMemo(() => {
     if (!selectedAction || !release) return null
 
+    // The lazy dialogs are wrapped locally since this hook's return value is consumed as a bare ReactNode.
     switch (selectedAction) {
       case 'publish-now':
         return (
-          <PublishScheduledDraftDialog
-            release={release}
-            documentType={documentType}
-            onClose={handleDialogClose}
-          />
+          <Suspense fallback={null}>
+            <PublishScheduledDraftDialog
+              release={release}
+              documentType={documentType}
+              onClose={handleDialogClose}
+            />
+          </Suspense>
         )
 
       case 'delete-schedule':
         return (
-          <DeleteScheduledDraftDialog
-            release={release}
-            documentType={documentType}
-            documentId={documentId}
-            onClose={handleDialogClose}
-          />
+          <Suspense fallback={null}>
+            <DeleteScheduledDraftDialog
+              release={release}
+              documentType={documentType}
+              documentId={documentId}
+              onClose={handleDialogClose}
+            />
+          </Suspense>
         )
 
       case 'schedule-publish':
         return (
-          <ScheduleDraftDialog
-            onClose={handleDialogClose}
-            onSchedule={handleSchedulePublish}
-            variant="schedule"
-            loading={isScheduling}
-            initialDate={release?.metadata?.intendedPublishAt}
-          />
+          <Suspense fallback={null}>
+            <ScheduleDraftDialog
+              onClose={handleDialogClose}
+              onSchedule={handleSchedulePublish}
+              variant="schedule"
+              loading={isScheduling}
+              initialDate={release?.metadata?.intendedPublishAt}
+            />
+          </Suspense>
         )
 
       default:

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/defineIncomingReferenceDecoration.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/defineIncomingReferenceDecoration.tsx
@@ -1,7 +1,14 @@
+import {lazy, Suspense} from 'react'
 import {type DecorationMember} from 'sanity'
 
-import {IncomingReferencesDecoration} from './IncomingReferencesDecoration'
 import {type IncomingReferencesOptions} from './types'
+
+// Deferred so the decoration's form-input module graph stays out of the eager structure barrel; it renders inside the document form, which has no guaranteed local Suspense boundary.
+const IncomingReferencesDecoration = lazy(() =>
+  import('./IncomingReferencesDecoration').then((module) => ({
+    default: module.IncomingReferencesDecoration,
+  })),
+)
 
 /**
  * Helper function to define an incoming references decoration.
@@ -32,6 +39,10 @@ export function defineIncomingReferenceDecoration(
   return {
     kind: 'decoration',
     key: options.name,
-    component: <IncomingReferencesDecoration {...options} />,
+    component: (
+      <Suspense fallback={null}>
+        <IncomingReferencesDecoration {...options} />
+      </Suspense>
+    ),
   }
 }

--- a/packages/sanity/src/structure/documentActions/DeleteAction.tsx
+++ b/packages/sanity/src/structure/documentActions/DeleteAction.tsx
@@ -1,5 +1,5 @@
 import {TrashIcon} from '@sanity/icons'
-import {useCallback, useMemo, useState} from 'react'
+import {lazy, useCallback, useMemo, useState} from 'react'
 import {
   type DocumentActionComponent,
   getVersionFromId,
@@ -13,8 +13,14 @@ import {
   useTranslation,
 } from 'sanity'
 
-import {ConfirmDeleteDialog} from '../components'
 import {structureLocaleNamespace} from '../i18n'
+
+// Imported directly rather than via the components barrel, which statically drags DocumentPane; deferred since the dialog only renders after the user opens it.
+const ConfirmDeleteDialog = lazy(() =>
+  import('../components/confirmDeleteDialog/ConfirmDeleteDialog').then((module) => ({
+    default: module.ConfirmDeleteDialog,
+  })),
+)
 
 const DISABLED_REASON_TITLE_KEY = {
   NOTHING_TO_DELETE: 'action.delete.disabled.nothing-to-delete',

--- a/packages/sanity/src/structure/documentActions/UnpublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/UnpublishAction.tsx
@@ -1,5 +1,5 @@
 import {UnpublishIcon} from '@sanity/icons'
-import {useCallback, useMemo, useState} from 'react'
+import {lazy, useCallback, useMemo, useState} from 'react'
 import {
   type DocumentActionComponent,
   type DocumentActionModalDialogProps,
@@ -11,8 +11,14 @@ import {
   useTranslation,
 } from 'sanity'
 
-import {ConfirmDeleteDialog} from '../components'
 import {structureLocaleNamespace} from '../i18n'
+
+// Imported directly rather than via the components barrel, which statically drags DocumentPane; deferred since the dialog only renders after the user opens it.
+const ConfirmDeleteDialog = lazy(() =>
+  import('../components/confirmDeleteDialog/ConfirmDeleteDialog').then((module) => ({
+    default: module.ConfirmDeleteDialog,
+  })),
+)
 
 const DISABLED_REASON_KEY = {
   NOT_PUBLISHED: 'action.unpublish.disabled.not-published',

--- a/packages/sanity/src/structure/panes/document/documentInspector/DocumentInspectorPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentInspector/DocumentInspectorPanel.tsx
@@ -1,6 +1,6 @@
 import {Box} from '@sanity/ui'
-import {useCallback} from 'react'
-import {Resizable} from 'sanity'
+import {Suspense, useCallback} from 'react'
+import {LoadingBlock, Resizable} from 'sanity'
 
 import {usePane} from '../../../components'
 import {useStructureTool} from '../../../useStructureTool'
@@ -28,8 +28,11 @@ export function DocumentInspectorPanel(
   if (collapsed || !inspector) return null
 
   const Component = inspector.component
+  // Inspector components are lazy-loaded, so guarantee a local Suspense boundary rather than relying on an ancestor.
   const element = (
-    <Component onClose={handleClose} documentId={documentId} documentType={documentType} />
+    <Suspense fallback={<LoadingBlock showText />}>
+      <Component onClose={handleClose} documentId={documentId} documentType={documentType} />
+    </Suspense>
   )
 
   if (features.resizablePanes) {

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/index.ts
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/index.ts
@@ -1,9 +1,14 @@
 import {RestoreIcon} from '@sanity/icons'
+import {lazy} from 'react'
 import {type DocumentInspector, useTranslation} from 'sanity'
 
 import {useStructureTool} from '../../../../useStructureTool'
 import {HISTORY_INSPECTOR_NAME} from '../../constants'
-import {ChangesTabs} from './ChangesTabs'
+
+// Deferred so the changes/diff inspector UI stays out of the eager structureTool graph; it only renders when the inspector is opened.
+const ChangesTabs = lazy(() =>
+  import('./ChangesTabs').then((module) => ({default: module.ChangesTabs})),
+)
 
 export const changesInspector: DocumentInspector = {
   name: HISTORY_INSPECTOR_NAME,

--- a/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/index.ts
+++ b/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/index.ts
@@ -1,8 +1,15 @@
 import {SyncIcon} from '@sanity/icons'
+import {lazy} from 'react'
 import {type DocumentInspector, useTranslation} from 'sanity'
 
 import {INCOMING_REFERENCES_INSPECTOR_NAME} from '../../constants'
-import {IncomingReferencesInspector} from './IncomingReferencesInspector'
+
+// Deferred so the incoming-references inspector UI stays out of the eager structureTool graph; it only renders when the inspector is opened.
+const IncomingReferencesInspector = lazy(() =>
+  import('./IncomingReferencesInspector').then((module) => ({
+    default: module.IncomingReferencesInspector,
+  })),
+)
 
 export const incomingReferencesInspector: DocumentInspector = {
   name: INCOMING_REFERENCES_INSPECTOR_NAME,

--- a/packages/sanity/src/structure/panes/document/inspectors/validation/index.ts
+++ b/packages/sanity/src/structure/panes/document/inspectors/validation/index.ts
@@ -1,5 +1,5 @@
 import {CheckmarkCircleIcon, ErrorOutlineIcon, WarningOutlineIcon} from '@sanity/icons'
-import {useMemo} from 'react'
+import {lazy, useMemo} from 'react'
 import {
   type DocumentInspector,
   type DocumentInspectorMenuItem,
@@ -17,7 +17,11 @@ import {
 
 import {VALIDATION_INSPECTOR_NAME} from '../../constants'
 import {useDocumentPane} from '../../useDocumentPane'
-import {ValidationInspector} from './ValidationInspector'
+
+// Deferred so the validation inspector UI stays out of the eager structureTool graph; it only renders when the inspector is opened.
+const ValidationInspector = lazy(() =>
+  import('./ValidationInspector').then((module) => ({default: module.ValidationInspector})),
+)
 
 function useMenuItem(props: DocumentInspectorUseMenuItemProps): DocumentInspectorMenuItem {
   const {documentType} = props

--- a/packages/sanity/src/structure/panes/document/statusBar/ActionStateDialog.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/ActionStateDialog.tsx
@@ -1,5 +1,5 @@
 import {PortalProvider, Text, usePortal} from '@sanity/ui'
-import {type ReactNode, useId} from 'react'
+import {type ReactNode, Suspense, useId} from 'react'
 import {type DocumentActionDialogProps} from 'sanity'
 
 import {Dialog} from '../../../../ui-components'
@@ -44,7 +44,11 @@ export function ActionStateDialog(props: ActionStateDialogProps) {
   }
 
   if (dialog.type === 'custom') {
-    return <DocumentActionPortalProvider>{dialog?.component}</DocumentActionPortalProvider>
+    return (
+      <DocumentActionPortalProvider>
+        <Suspense fallback={null}>{dialog?.component}</Suspense>
+      </DocumentActionPortalProvider>
+    )
   }
 
   // @todo: add validation?

--- a/packages/sanity/src/structure/panes/document/statusBar/dialogs/ModalDialog.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/dialogs/ModalDialog.tsx
@@ -2,7 +2,7 @@ import {
   Box,
   Dialog, // eslint-disable-line no-restricted-imports
 } from '@sanity/ui'
-import {useId} from 'react'
+import {Suspense, useId} from 'react'
 import {type DocumentActionModalDialogProps, LegacyLayerProvider} from 'sanity'
 
 import {DIALOG_WIDTH_TO_UI_WIDTH} from './constants'
@@ -33,7 +33,9 @@ export function ModalDialog(props: {dialog: DocumentActionModalDialogProps}) {
         onClickOutside={dialog.onClose}
         width={dialog.width === undefined ? 1 : DIALOG_WIDTH_TO_UI_WIDTH[dialog.width]}
       >
-        <Box padding={4}>{dialog.content}</Box>
+        <Box padding={4}>
+          <Suspense fallback={null}>{dialog.content}</Suspense>
+        </Box>
       </Dialog>
     </LegacyLayerProvider>
   )


### PR DESCRIPTION
### Description

Part of the post-auth eval-deferral initiative (auth-ready OKR). This PR makes no public API changes - it moves interaction-gated UI behind internal dynamic imports. A throwaway ceiling probe combining this with the full export-surface cut measured: eager bundle 5,181 KB -> 2,467 KB (-52%) and auth-ready -21-26% at 20x CPU throttle (A/B/A, N=12/block), prod central estimate ~-1.5s p95. In isolation this slice is expected to be timing-neutral.

Converts statically imported, interaction-gated dialog and inspector components to React.lazy so their module-eval no longer runs eagerly. Each affected component only renders after a user opens a dialog or inspector, so deferring it removes its module graph (and transitive form/preview/diff/motion machinery) from the eager bundle. The lazy reference is internal at every use site, so no export changes - the build d.ts gate is byte-identical to main across all entry points.

Covered components: the release Unpublish/Discard version dialogs; the scheduled-publishing EditScheduleForm and Schedules; the single-doc-release schedule menu dialogs (delete/publish/schedule); the canvas Link/Unlink dialogs (the Unlink dialog was the last eager motion/react importer in core); the structure ConfirmDeleteDialog imported directly rather than via the components barrel that statically drags DocumentPane; the incoming-references decoration; and the changes, validation, and incoming-references document inspectors.

### What to review

Suspense safety is the key thing to review. Each lazy component renders inside a guaranteed Suspense boundary: custom action dialogs render through ActionStateDialog and dialog-content actions through ModalDialog, both of which now wrap their rendered node in a local Suspense; the scheduled-draft menu dialogs are wrapped in the hook since their return value is consumed as a bare ReactNode by callers; document inspectors are wrapped in DocumentInspectorPanel; and the incoming-references decoration is wrapped where its component element is built. No lazy() wraps a factory or function evaluated at module scope - every lazy reference is rendered as a component.

### Testing

pnpm build passes including the strict d.ts gate; emitted .d.ts for sanity, sanity/structure, sanity/_internal, sanity/desk, and sanity/_singletons are identical to main. Targeted unit tests pass: useScheduledDraftMenuActions (two dialog assertions updated to findByTestId because the lazy dialogs now resolve asynchronously), the confirmDeleteDialog suite, and the validation getPathTitles suite. Format and lint pass.

### Notes for release

N/A
