### PR TITLE
refactor(comments): query PT-native `data-pt-text` for click detection

### DIFF
--- a/packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx
+++ b/packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx
@@ -315,7 +315,7 @@ function CommentsInspectorInner(
       // Clear the selected path when clicking outside the comments inspector.
       // We do this only when the comments inspector is the top layer.
       const isPTETarget =
-        event.target instanceof HTMLElement && event.target?.hasAttribute('data-slate-string')
+        event.target instanceof HTMLElement && event.target?.hasAttribute('data-pt-text')
 
       if (!isPTETarget) {
         handleDeselectPath()


### PR DESCRIPTION
### Description

`CommentsInspector` checks whether a click landed on Portable Text content (to decide whether to clear the selected comment path) by querying the Slate-named `data-slate-string` attribute. PTE emits PT-native `data-pt-*` attributes for this, and `data-pt-text` is the one that marks a string element. Query that instead of the Slate-named attribute.

This is the only `data-slate-*` reference in Studio source.

### What to review

`packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx` — a single `hasAttribute` swap. Behavior is unchanged: PTE emits `data-pt-text` on the same element, so path-deselection works as before. Verify by opening the comments inspector and clicking inside vs outside the editor: the selected path clears on outside clicks only.

### Testing

Manual: comments inspector path-deselection behaves identically. No automated test added; it's a single equivalent-attribute swap with no behavior change.

### Notes for release

N/A – Internal only.
