### PR TITLE
feat(core): add selectedVariant and bundle to perspective context

### DIFF
--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -11,6 +11,7 @@ export * from './FIXME'
 export * from './form'
 export * from './hooks'
 export * from './i18n'
+export {getSelectedVariant} from './perspective/getSelectedVariant'
 export {
   isPerspectiveWriteable,
   type PerspectiveNotWriteableReason,
@@ -106,5 +107,6 @@ export {getDocumentIdForCanvasLink} from './canvas/utils/getDocumentIdForCanvasL
 export {useDivergenceNavigator} from './divergence/divergenceNavigator'
 export {useDocumentLimitsUpsellContext} from './limits/context/documents/DocumentLimitUpsellProvider'
 export {isDocumentLimitError} from './limits/context/documents/isDocumentLimitError'
+export {useSetVariant} from './perspective/useSetVariant'
 export {ReleaseAvatarIcon} from './releases/components/ReleaseAvatar'
 export {DEFAULT_ANNOTATIONS, DEFAULT_DECORATORS} from '@sanity/schema'

--- a/packages/sanity/src/core/perspective/GlobalPerspectiveProvider.tsx
+++ b/packages/sanity/src/core/perspective/GlobalPerspectiveProvider.tsx
@@ -37,9 +37,13 @@ export function GlobalPerspectiveProvider({children}: {children: ReactNode}) {
     [router.stickyParams.excludedPerspectives],
   )
 
+  const selectedVariantName =
+    typeof router.stickyParams.variant === 'string' ? router.stickyParams.variant : undefined
+
   return (
     <PerspectiveProvider
       selectedPerspectiveName={selectedPerspectiveName}
+      selectedVariantName={selectedVariantName}
       excludedPerspectives={excludedPerspectives}
     >
       {children}

--- a/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
+++ b/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
@@ -7,7 +7,10 @@ import {useActiveReleases} from '../releases/store/useActiveReleases'
 import {useWorkspace} from '../studio/workspace'
 import {isSystemBundleName} from '../util/draftUtils'
 import {EMPTY_ARRAY} from '../util/empty'
+import {getBundleIdFromPerspective} from '../variants/documents/getBundleIdFromPerspective'
+import {useAllVariants} from '../variants/store/useAllVariants'
 import {getSelectedPerspective} from './getSelectedPerspective'
+import {getSelectedVariant} from './getSelectedVariant'
 import {type PerspectiveContextValue, type ReleaseId} from './types'
 
 /**
@@ -16,13 +19,16 @@ import {type PerspectiveContextValue, type ReleaseId} from './types'
 export function PerspectiveProvider({
   children,
   selectedPerspectiveName,
+  selectedVariantName,
   excludedPerspectives = EMPTY_ARRAY,
 }: {
   children: React.ReactNode
   selectedPerspectiveName: 'published' | ReleaseId | undefined
+  selectedVariantName?: string
   excludedPerspectives?: string[]
 }) {
   const {data: releases} = useActiveReleases()
+  const {byId: variantsById} = useAllVariants()
 
   const {
     document: {
@@ -46,6 +52,11 @@ export function PerspectiveProvider({
     [releases, selectedPerspectiveName, excludedPerspectives, isDraftModelEnabled],
   )
 
+  const selectedVariant = useMemo(
+    () => getSelectedVariant({selectedVariantName, variantsById}),
+    [selectedVariantName, variantsById],
+  )
+
   const value: PerspectiveContextValue = useMemo(() => {
     // For regular releases and published, use as-is
     return {
@@ -58,6 +69,8 @@ export function PerspectiveProvider({
             .find((releaseName) => releaseName === selectedPerspectiveName),
       perspectiveStack,
       excludedPerspectives,
+      selectedVariant,
+      bundle: getBundleIdFromPerspective(selectedPerspective).bundleId,
     }
   }, [
     selectedPerspectiveName,
@@ -65,6 +78,7 @@ export function PerspectiveProvider({
     selectedPerspective,
     perspectiveStack,
     excludedPerspectives,
+    selectedVariant,
   ])
 
   return <PerspectiveContext.Provider value={value}>{children}</PerspectiveContext.Provider>

--- a/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
+++ b/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
@@ -70,7 +70,7 @@ export function PerspectiveProvider({
       perspectiveStack,
       excludedPerspectives,
       selectedVariant,
-      bundle: getBundleIdFromPerspective(selectedPerspective).bundleId,
+      bundle: getBundleIdFromPerspective(selectedPerspective),
     }
   }, [
     selectedPerspectiveName,

--- a/packages/sanity/src/core/perspective/__mocks__/usePerspective.mock.ts
+++ b/packages/sanity/src/core/perspective/__mocks__/usePerspective.mock.ts
@@ -9,6 +9,8 @@ export const perspectiveContextValueMock: Mocked<PerspectiveContextValue> = {
   selectedPerspective: 'drafts',
   perspectiveStack: ['drafts'],
   excludedPerspectives: [],
+  selectedVariant: undefined,
+  bundle: 'drafts',
 }
 export const usePerspectiveMockReturn = perspectiveContextValueMock
 

--- a/packages/sanity/src/core/perspective/__tests__/getSelectedVariant.test.ts
+++ b/packages/sanity/src/core/perspective/__tests__/getSelectedVariant.test.ts
@@ -1,0 +1,42 @@
+import {describe, expect, it} from 'vitest'
+
+import {variantAlphaAudience} from '../../variants/__fixtures__/variants.fixture'
+import {getSelectedVariant} from '../getSelectedVariant'
+
+describe('getSelectedVariant', () => {
+  it('returns undefined when no sticky variant is set', () => {
+    expect(
+      getSelectedVariant({
+        selectedVariantName: undefined,
+        variantsById: new Map([[variantAlphaAudience._id, variantAlphaAudience]]),
+      }),
+    ).toBeUndefined()
+  })
+
+  it('returns undefined when byId is still empty', () => {
+    expect(
+      getSelectedVariant({
+        selectedVariantName: 'alpha-audience',
+        variantsById: new Map(),
+      }),
+    ).toBeUndefined()
+  })
+
+  it('resolves sticky short id to variant definition', () => {
+    expect(
+      getSelectedVariant({
+        selectedVariantName: 'alpha-audience',
+        variantsById: new Map([[variantAlphaAudience._id, variantAlphaAudience]]),
+      }),
+    ).toBe(variantAlphaAudience)
+  })
+
+  it('returns undefined when sticky variant does not exist in byId', () => {
+    expect(
+      getSelectedVariant({
+        selectedVariantName: 'missing-variant',
+        variantsById: new Map([[variantAlphaAudience._id, variantAlphaAudience]]),
+      }),
+    ).toBeUndefined()
+  })
+})

--- a/packages/sanity/src/core/perspective/getSelectedVariant.ts
+++ b/packages/sanity/src/core/perspective/getSelectedVariant.ts
@@ -1,0 +1,27 @@
+import {decodeVariantIdFromRoute} from '../variants/tool/util'
+import {type SystemVariant} from '../variants/types'
+
+/**
+ * Resolves the sticky variant short id to a variant definition.
+ * Returns undefined while loading (empty byId) or when the variant does not exist.
+ *
+ * @internal
+ */
+export function getSelectedVariant(options: {
+  selectedVariantName: string | undefined
+  variantsById: Map<string, SystemVariant>
+}): SystemVariant | undefined {
+  const {selectedVariantName, variantsById} = options
+
+  if (!selectedVariantName) {
+    return undefined
+  }
+
+  const variantDocumentId = decodeVariantIdFromRoute(selectedVariantName)
+
+  if (!variantDocumentId) {
+    return undefined
+  }
+
+  return variantsById.get(variantDocumentId)
+}

--- a/packages/sanity/src/core/perspective/types.ts
+++ b/packages/sanity/src/core/perspective/types.ts
@@ -31,7 +31,7 @@ export type SelectedPerspective = TargetPerspective
  */
 export type PerspectiveStack = ExtractArray<ClientPerspective>
 
-export type PerspectiveBundle = '$published' | 'drafts' | (string & {})
+export type PerspectiveBundle = 'published' | 'drafts' | (string & {})
 /**
  * @beta
  */
@@ -60,7 +60,7 @@ export interface PerspectiveContextValue {
    */
   selectedVariant: SystemVariant | undefined
   /**
-   * The selected bundle, either `$published`, `drafts` or a release id or the bundle id for anonymous bundles like agent documents.
+   * The selected bundle, either `published`, `drafts` or a release id or the bundle id for anonymous bundles like agent documents.
    */
   bundle: PerspectiveBundle
 }

--- a/packages/sanity/src/core/perspective/types.ts
+++ b/packages/sanity/src/core/perspective/types.ts
@@ -4,6 +4,7 @@ import {type MenuItem} from '@sanity/ui'
 import {type ComponentProps} from 'react'
 
 import {type SystemBundle} from '../util/draftUtils'
+import {type SystemVariant} from '../variants/types'
 
 /**
  * @beta
@@ -30,6 +31,7 @@ export type SelectedPerspective = TargetPerspective
  */
 export type PerspectiveStack = ExtractArray<ClientPerspective>
 
+export type PerspectiveBundle = '$published' | 'drafts' | (string & {})
 /**
  * @beta
  */
@@ -51,6 +53,16 @@ export interface PerspectiveContextValue {
   perspectiveStack: PerspectiveStack
   /* The excluded perspectives */
   excludedPerspectives: string[]
+  /**
+   * Resolved variant definition; undefined = default (all users) or still loading
+   * @beta
+   * @internal
+   */
+  selectedVariant: SystemVariant | undefined
+  /**
+   * The selected bundle, either `$published`, `drafts` or a release id or the bundle id for anonymous bundles like agent documents.
+   */
+  bundle: PerspectiveBundle
 }
 
 /**

--- a/packages/sanity/src/core/perspective/useSetVariant.tsx
+++ b/packages/sanity/src/core/perspective/useSetVariant.tsx
@@ -1,0 +1,27 @@
+import {useCallback} from 'react'
+import {useRouter} from 'sanity/router'
+
+import {getVariantId} from '../variants/tool/util'
+import {type SystemVariant} from '../variants/types'
+
+/**
+ * React hook to set the variant in the router.
+ * Do not use in production, this can change in any release.
+ * @internal
+ * @beta
+ */
+export function useSetVariant() {
+  const router = useRouter()
+
+  const setVariant = useCallback(
+    (variant: SystemVariant | undefined) => {
+      router.navigate({
+        stickyParams: {
+          variant: variant ? getVariantId(variant._id) : null,
+        },
+      })
+    },
+    [router],
+  )
+  return setVariant
+}

--- a/packages/sanity/src/core/variants/documents/__tests__/getBundleIdFromPerspective.test.ts
+++ b/packages/sanity/src/core/variants/documents/__tests__/getBundleIdFromPerspective.test.ts
@@ -1,0 +1,49 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {describe, expect, it} from 'vitest'
+
+import {RELEASE_DOCUMENT_TYPE} from '../../../releases/store/constants'
+import {getBundleIdFromPerspective} from '../getBundleIdFromPerspective'
+
+const releaseDocument: ReleaseDocument = {
+  _id: '_.releases.rSummer123',
+  name: 'rSummer123',
+  _type: RELEASE_DOCUMENT_TYPE,
+  _rev: 'rev',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-01T00:00:00Z',
+  state: 'active',
+  metadata: {
+    title: 'Summer',
+    releaseType: 'asap',
+  },
+}
+
+describe('getBundleIdFromPerspective', () => {
+  it('maps drafts perspective to drafts bundle', () => {
+    expect(getBundleIdFromPerspective('drafts')).toEqual({
+      bundleId: 'drafts',
+      release: null,
+    })
+  })
+
+  it('maps published perspective to $published bundle', () => {
+    expect(getBundleIdFromPerspective('published')).toEqual({
+      bundleId: '$published',
+      release: null,
+    })
+  })
+
+  it('maps release document to release id and ref', () => {
+    expect(getBundleIdFromPerspective(releaseDocument)).toEqual({
+      bundleId: 'rSummer123',
+      release: {_ref: '_.releases.rSummer123', _weak: true},
+    })
+  })
+
+  it('maps anonymous bundle string to bundle id without release ref', () => {
+    expect(getBundleIdFromPerspective('my-bundle')).toEqual({
+      bundleId: 'my-bundle',
+      release: null,
+    })
+  })
+})

--- a/packages/sanity/src/core/variants/documents/__tests__/getBundleIdFromPerspective.test.ts
+++ b/packages/sanity/src/core/variants/documents/__tests__/getBundleIdFromPerspective.test.ts
@@ -23,8 +23,8 @@ describe('getBundleIdFromPerspective', () => {
     expect(getBundleIdFromPerspective('drafts')).toBe('drafts')
   })
 
-  it('maps published perspective to $published bundle', () => {
-    expect(getBundleIdFromPerspective('published')).toBe('$published')
+  it('maps published perspective to published bundle', () => {
+    expect(getBundleIdFromPerspective('published')).toBe('published')
   })
 
   it('maps release document to release id', () => {

--- a/packages/sanity/src/core/variants/documents/__tests__/getBundleIdFromPerspective.test.ts
+++ b/packages/sanity/src/core/variants/documents/__tests__/getBundleIdFromPerspective.test.ts
@@ -20,30 +20,18 @@ const releaseDocument: ReleaseDocument = {
 
 describe('getBundleIdFromPerspective', () => {
   it('maps drafts perspective to drafts bundle', () => {
-    expect(getBundleIdFromPerspective('drafts')).toEqual({
-      bundleId: 'drafts',
-      release: null,
-    })
+    expect(getBundleIdFromPerspective('drafts')).toBe('drafts')
   })
 
   it('maps published perspective to $published bundle', () => {
-    expect(getBundleIdFromPerspective('published')).toEqual({
-      bundleId: '$published',
-      release: null,
-    })
+    expect(getBundleIdFromPerspective('published')).toBe('$published')
   })
 
-  it('maps release document to release id and ref', () => {
-    expect(getBundleIdFromPerspective(releaseDocument)).toEqual({
-      bundleId: 'rSummer123',
-      release: {_ref: '_.releases.rSummer123', _weak: true},
-    })
+  it('maps release document to release id', () => {
+    expect(getBundleIdFromPerspective(releaseDocument)).toBe('rSummer123')
   })
 
-  it('maps anonymous bundle string to bundle id without release ref', () => {
-    expect(getBundleIdFromPerspective('my-bundle')).toEqual({
-      bundleId: 'my-bundle',
-      release: null,
-    })
+  it('maps anonymous bundle string to bundle id', () => {
+    expect(getBundleIdFromPerspective('my-bundle')).toBe('my-bundle')
   })
 })

--- a/packages/sanity/src/core/variants/documents/getBundleIdFromPerspective.ts
+++ b/packages/sanity/src/core/variants/documents/getBundleIdFromPerspective.ts
@@ -7,7 +7,7 @@ export function getBundleIdFromPerspective(
   selectedPerspective: TargetPerspective,
 ): PerspectiveBundle {
   if (isPublishedPerspective(selectedPerspective)) {
-    return '$published'
+    return 'published'
   }
 
   if (isDraftPerspective(selectedPerspective)) {

--- a/packages/sanity/src/core/variants/documents/getBundleIdFromPerspective.ts
+++ b/packages/sanity/src/core/variants/documents/getBundleIdFromPerspective.ts
@@ -1,0 +1,35 @@
+import {type DocumentSystem, type DocumentSystemRef} from '@sanity/types'
+
+import {type TargetPerspective} from '../../perspective/types'
+import {isReleaseDocument} from '../../releases/store/types'
+import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
+import {isDraftPerspective, isPublishedPerspective} from '../../releases/util/util'
+
+export function getBundleIdFromPerspective(
+  selectedPerspective: TargetPerspective,
+): Pick<DocumentSystem, 'bundleId' | 'release'> {
+  if (isPublishedPerspective(selectedPerspective)) {
+    return {bundleId: '$published', release: null}
+  }
+
+  if (isDraftPerspective(selectedPerspective)) {
+    return {bundleId: 'drafts', release: null}
+  }
+
+  if (isReleaseDocument(selectedPerspective)) {
+    const releaseRef: DocumentSystemRef = {
+      _ref: selectedPerspective._id,
+      _weak: true,
+    }
+    return {
+      bundleId: getReleaseIdFromReleaseDocumentId(selectedPerspective._id),
+      release: releaseRef,
+    }
+  }
+
+  if (typeof selectedPerspective === 'string') {
+    return {bundleId: selectedPerspective, release: null}
+  }
+
+  return {bundleId: 'drafts', release: null}
+}

--- a/packages/sanity/src/core/variants/documents/getBundleIdFromPerspective.ts
+++ b/packages/sanity/src/core/variants/documents/getBundleIdFromPerspective.ts
@@ -1,35 +1,26 @@
-import {type DocumentSystem, type DocumentSystemRef} from '@sanity/types'
-
-import {type TargetPerspective} from '../../perspective/types'
+import {type PerspectiveBundle, type TargetPerspective} from '../../perspective/types'
 import {isReleaseDocument} from '../../releases/store/types'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
 import {isDraftPerspective, isPublishedPerspective} from '../../releases/util/util'
 
 export function getBundleIdFromPerspective(
   selectedPerspective: TargetPerspective,
-): Pick<DocumentSystem, 'bundleId' | 'release'> {
+): PerspectiveBundle {
   if (isPublishedPerspective(selectedPerspective)) {
-    return {bundleId: '$published', release: null}
+    return '$published'
   }
 
   if (isDraftPerspective(selectedPerspective)) {
-    return {bundleId: 'drafts', release: null}
+    return 'drafts'
   }
 
   if (isReleaseDocument(selectedPerspective)) {
-    const releaseRef: DocumentSystemRef = {
-      _ref: selectedPerspective._id,
-      _weak: true,
-    }
-    return {
-      bundleId: getReleaseIdFromReleaseDocumentId(selectedPerspective._id),
-      release: releaseRef,
-    }
+    return getReleaseIdFromReleaseDocumentId(selectedPerspective._id)
   }
 
   if (typeof selectedPerspective === 'string') {
-    return {bundleId: selectedPerspective, release: null}
+    return selectedPerspective
   }
 
-  return {bundleId: 'drafts', release: null}
+  return 'drafts'
 }

--- a/packages/sanity/src/core/variants/plugin/components/VariantsMenu.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/VariantsMenu.tsx
@@ -8,6 +8,7 @@ import {styled} from 'styled-components'
 import {MenuButton, MenuItem} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
 import {oversizedButtonStyle} from '../../../perspective/styles'
+import {useSetVariant} from '../../../perspective/useSetVariant'
 import {variantsLocaleNamespace} from '../../i18n'
 import {useAllVariants} from '../../store/useAllVariants'
 import {
@@ -43,6 +44,7 @@ const OversizedButton = styled(Button)`
 export function VariantsMenu(): React.JSX.Element {
   const {t} = useTranslation(variantsLocaleNamespace)
   const router = useRouter()
+  const setVariant = useSetVariant()
   const {data: variants} = useAllVariants()
   const [filterQuery, setFilterQuery] = useState('')
 
@@ -62,28 +64,17 @@ export function VariantsMenu(): React.JSX.Element {
     [filterQuery, variants],
   )
 
-  const setVariantSelection = useCallback(
-    (variant: SystemVariant | undefined) => {
-      router.navigate({
-        stickyParams: {
-          variant: variant ? getVariantId(variant._id) : null,
-        },
-      })
-    },
-    [router],
-  )
-
   const handleSelectDefault = useCallback(() => {
-    setVariantSelection(undefined)
+    setVariant(undefined)
     setFilterQuery('')
-  }, [setVariantSelection])
+  }, [setVariant])
 
   const handleSelectVariant = useCallback(
     (variant: SystemVariant) => {
-      setVariantSelection(variant)
+      setVariant(variant)
       setFilterQuery('')
     },
-    [setVariantSelection],
+    [setVariant],
   )
 
   const handleFilterChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/sanity/src/core/variants/store/__tests__/createVariantsStore.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/createVariantsStore.test.ts
@@ -1,6 +1,6 @@
 import {type SanityClient} from '@sanity/client'
 import {filter, firstValueFrom, of, Subject, take, throwError, toArray} from 'rxjs'
-import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createMockVariant} from '../../__fixtures__/createMockVariant'
 import {VARIANT_DOCUMENTS_PATH} from '../constants'
@@ -27,12 +27,16 @@ describe('createVariantsStore', () => {
     vi.clearAllMocks()
   })
 
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('loads variants from the variants system document path', async () => {
     const variant = createMockVariant('a')
     const {client, fetch, listen, listener$} = createMockClient()
     fetch.mockReturnValue(of([variant]))
 
-    const store = createVariantsStore({client})
+    const store = createVariantsStore({client, enabled: true})
     const valuesPromise = firstValueFrom(store.state$.pipe(take(3), toArray()))
 
     listener$.next({type: 'welcome'})
@@ -70,18 +74,23 @@ describe('createVariantsStore', () => {
   })
 
   it('keeps variants updated when the listener refetches', async () => {
+    vi.useFakeTimers()
+
     const firstVariant = createMockVariant('a')
     const updatedVariant = createMockVariant('b', 1)
     const {client, fetch, listener$} = createMockClient()
     fetch.mockReturnValueOnce(of([firstVariant])).mockReturnValueOnce(of([updatedVariant]))
 
-    const store = createVariantsStore({client})
+    const store = createVariantsStore({client, enabled: true})
     const valuesPromise = firstValueFrom(store.state$.pipe(take(4), toArray()))
 
     listener$.next({type: 'welcome'})
+    await vi.advanceTimersByTimeAsync(0)
     listener$.next({type: 'mutation', transition: 'update', visibility: 'query'})
+    await vi.advanceTimersByTimeAsync(1000)
 
     const values = await valuesPromise
+    vi.useRealTimers()
     const lastValue = values.at(-1)!
 
     expect(fetch).toHaveBeenCalledTimes(2)
@@ -95,7 +104,7 @@ describe('createVariantsStore', () => {
     const {client, fetch, listener$} = createMockClient()
     fetch.mockReturnValue(of([variantA, variantB]))
 
-    const store = createVariantsStore({client})
+    const store = createVariantsStore({client, enabled: true})
     const loadedPromise = firstValueFrom(
       store.state$.pipe(
         filter(({state, variants}) => state === 'loaded' && variants.size === 2),
@@ -125,7 +134,7 @@ describe('createVariantsStore', () => {
     const {client, fetch, listener$} = createMockClient()
     fetch.mockReturnValue(throwError(() => error))
 
-    const store = createVariantsStore({client})
+    const store = createVariantsStore({client, enabled: true})
     const valuesPromise = firstValueFrom(store.state$.pipe(take(3), toArray()))
 
     listener$.next({type: 'welcome'})

--- a/packages/sanity/src/core/variants/store/__tests__/createVariantsStore.test.ts
+++ b/packages/sanity/src/core/variants/store/__tests__/createVariantsStore.test.ts
@@ -31,6 +31,17 @@ describe('createVariantsStore', () => {
     vi.useRealTimers()
   })
 
+  it('does not fetch or listen when disabled', async () => {
+    const {client, fetch, listen} = createMockClient()
+
+    const store = createVariantsStore({client, enabled: false})
+    const value = await firstValueFrom(store.state$)
+
+    expect(value).toMatchObject({state: 'loaded'})
+    expect(fetch).not.toHaveBeenCalled()
+    expect(listen).not.toHaveBeenCalled()
+  })
+
   it('loads variants from the variants system document path', async () => {
     const variant = createMockVariant('a')
     const {client, fetch, listen, listener$} = createMockClient()

--- a/packages/sanity/src/core/variants/store/createVariantsStore.ts
+++ b/packages/sanity/src/core/variants/store/createVariantsStore.ts
@@ -51,8 +51,13 @@ export function createVariantsStore(context: {
   const {client, enabled} = context
 
   if (!enabled) {
+    const disabledState: VariantStoreState = {
+      variants: new Map(),
+      state: 'loaded' as const,
+    }
+
     return {
-      state$: of(INITIAL_STATE),
+      state$: of(disabledState),
       dispatch: () => {
         // noop
       },

--- a/packages/sanity/src/core/variants/store/createVariantsStore.ts
+++ b/packages/sanity/src/core/variants/store/createVariantsStore.ts
@@ -44,8 +44,20 @@ export interface VariantStore {
  * it will keep listening for the duration of the app's lifecycle. Subsequent subscriptions will be
  * given the latest state upon subscription.
  */
-export function createVariantsStore(context: {client: SanityClient}): VariantStore {
-  const {client} = context
+export function createVariantsStore(context: {
+  client: SanityClient
+  enabled: boolean
+}): VariantStore {
+  const {client, enabled} = context
+
+  if (!enabled) {
+    return {
+      state$: of(INITIAL_STATE),
+      dispatch: () => {
+        // noop
+      },
+    }
+  }
 
   const dispatch$ = new Subject<VariantStoreAction>()
 

--- a/packages/sanity/src/core/variants/store/useVariantsStore.ts
+++ b/packages/sanity/src/core/variants/store/useVariantsStore.ts
@@ -8,8 +8,9 @@ import {createVariantsStore, type VariantStore} from './createVariantsStore'
 
 /** @internal */
 export function useVariantsStore(): VariantStore {
-  const resourceCache = useResourceCache()
   const workspace = useWorkspace()
+  const variantsEnabled = Boolean(workspace.beta?.variants?.enabled)
+  const resourceCache = useResourceCache()
   const studioClient = useClient(VARIANTS_STUDIO_CLIENT_OPTIONS)
 
   return useMemo(() => {
@@ -20,6 +21,7 @@ export function useVariantsStore(): VariantStore {
       }) ||
       createVariantsStore({
         client: studioClient,
+        enabled: variantsEnabled,
       })
 
     resourceCache.set({
@@ -29,5 +31,5 @@ export function useVariantsStore(): VariantStore {
     })
 
     return variantStore
-  }, [resourceCache, workspace, studioClient])
+  }, [variantsEnabled, resourceCache, workspace, studioClient])
 }

--- a/packages/sanity/src/structure/__mocks__/usePerspective.mock.ts
+++ b/packages/sanity/src/structure/__mocks__/usePerspective.mock.ts
@@ -7,6 +7,8 @@ export const perspectiveContextValueMock: Mocked<PerspectiveContextValue> = {
   selectedPerspective: 'drafts',
   perspectiveStack: ['drafts'],
   excludedPerspectives: [],
+  selectedVariant: undefined,
+  bundle: 'drafts',
 }
 export const usePerspectiveMockReturn = perspectiveContextValueMock
 

--- a/packages/sanity/src/structure/panes/document/DocumentPerspectiveProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPerspectiveProvider.tsx
@@ -1,5 +1,6 @@
 import {type ReactNode} from 'react'
 import {PerspectiveProvider, usePerspective} from 'sanity'
+import {useRouter} from 'sanity/router'
 
 import {usePaneRouter} from '../../components/paneRouter/usePaneRouter'
 
@@ -10,11 +11,16 @@ import {usePaneRouter} from '../../components/paneRouter/usePaneRouter'
 export function DocumentPerspectiveProvider({children}: {children: ReactNode}) {
   const paneRouter = usePaneRouter()
   const {excludedPerspectives} = usePerspective()
+  const router = useRouter()
+  const selectedVariantName =
+    typeof router.stickyParams.variant === 'string' ? router.stickyParams.variant : undefined
+
   const {scheduledDraft} = paneRouter.params as {scheduledDraft?: string}
   if (scheduledDraft) {
     return (
       <PerspectiveProvider
         selectedPerspectiveName={scheduledDraft}
+        selectedVariantName={selectedVariantName}
         excludedPerspectives={excludedPerspectives}
       >
         {children}

--- a/packages/sanity/src/structure/panes/documentList/__tests__/PaneContainer.test.tsx
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/PaneContainer.test.tsx
@@ -30,6 +30,8 @@ vi.mock('sanity', async (importOriginal) => ({
       selectedPerspective: 'drafts',
       selectedPerspectiveName: undefined,
       selectedReleaseId: undefined,
+      selectedVariant: undefined,
+      bundle: 'drafts',
     }),
   ),
 }))

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -356,6 +356,7 @@ exports[`exports snapshot 1`] = `
     "getReleaseTone": "function",
     "getSchemaTypeTitle": "function",
     "getSearchableTypes": "function",
+    "getSelectedVariant": "function",
     "getTemplatePermissions": "function",
     "getValueAtPath": "function",
     "getValueError": "function",

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -653,6 +653,7 @@ exports[`exports snapshot 1`] = `
     "useSearchMaxFieldDepth": "function",
     "useSearchState": "function",
     "useSetPerspective": "function",
+    "useSetVariant": "function",
     "useSingleDocRelease": "function",
     "useSource": "function",
     "useStudioFeedbackTags": "function",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

This is a focused extraction from #13092. It adds variant awareness to the perspective context so downstream features (variant document creation, perspective list display) can read `selectedVariant` and `bundle` from `usePerspective()` instead of re-deriving them.

`PerspectiveProvider` now resolves the sticky router `variant` param via `getSelectedVariant`, and derives the active bundle from the selected perspective via `getBundleIdFromPerspective`. `useSetVariant` provides the symmetric write path for updating the router variant param.

The variants store is gated behind `beta.variants` because `PerspectiveProvider` now subscribes to `useAllVariants()` — without the guard, every studio would fetch variant definitions even when the feature is disabled.

### What to review

- `PerspectiveProvider` / `GlobalPerspectiveProvider` — new `selectedVariant` and `bundle` context fields
- `getSelectedVariant` and `getBundleIdFromPerspective` helpers
- `useSetVariant` hook
- Variants store `enabled` guard in `createVariantsStore` / `useVariantsStore`
- `DocumentPerspectiveProvider` — passes through sticky variant param

### Testing

- `getSelectedVariant.test.ts` — variant resolution from router param
- `getBundleIdFromPerspective.test.ts` — bundle mapping for drafts/published/releases
- `createVariantsStore.test.ts` — updated for `enabled` flag
- `PaneContainer.test.tsx` — mock updated with new context fields
- `exports.test.ts` — snapshot updated for `getSelectedVariant` and `useSetVariant`

### Notes for release

N/A – Part of variant documents feature. Internal APIs marked `@internal` / `@beta`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb598981-2f3e-4c8b-a5b0-8cc9686939e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb598981-2f3e-4c8b-a5b0-8cc9686939e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

