### PR TITLE
feat(core): add document `_system` to useDocumentVersions

### DIFF
--- a/packages/@sanity/types/src/documents/types.ts
+++ b/packages/@sanity/types/src/documents/types.ts
@@ -54,7 +54,7 @@ export interface DocumentSystem {
   /**
    * It will be empty for the group document (aka published document)
    */
-  bundleId: 'drafts' | (string & {}) | undefined
+  bundleId: 'drafts' | (string & {}) | null
   /**
    * A weak reference to the release document that the version belongs to.
    */

--- a/packages/@sanity/types/src/documents/types.ts
+++ b/packages/@sanity/types/src/documents/types.ts
@@ -42,6 +42,27 @@ export interface KeyedObject {
 /**
  * @internal
  */
+export interface DocumentSystemRef {
+  _ref: string
+  _weak: true
+}
+
+/**
+ * @internal
+ */
+export interface DocumentSystem {
+  bundleId: 'drafts' | '$published' | (string & {})
+  release: DocumentSystemRef | null
+  variant: DocumentSystemRef | null
+  group: DocumentSystemRef | null
+  // Normal drafts and published documents don't have a scope id.
+  // Variants, release documents and anonymous versions have a scope id.
+  scopeId: string | null
+}
+
+/**
+ * @internal
+ */
 export interface StrictVersionLayeringOptions {
   /**
    * By default, version layering includes all document versions, regardless of their expected

--- a/packages/@sanity/types/src/documents/types.ts
+++ b/packages/@sanity/types/src/documents/types.ts
@@ -54,7 +54,7 @@ export interface DocumentSystem {
   bundleId: 'drafts' | '$published' | (string & {})
   release: DocumentSystemRef | null
   variant: DocumentSystemRef | null
-  group: DocumentSystemRef | null
+  group: DocumentSystemRef
   // Normal drafts and published documents don't have a scope id.
   // Variants, release documents and anonymous versions have a scope id.
   scopeId: string | null

--- a/packages/@sanity/types/src/documents/types.ts
+++ b/packages/@sanity/types/src/documents/types.ts
@@ -51,12 +51,25 @@ export interface DocumentSystemRef {
  * @internal
  */
 export interface DocumentSystem {
-  bundleId: 'drafts' | '$published' | (string & {})
+  /**
+   * It will be empty for the group document (aka published document)
+   */
+  bundleId: 'drafts' | (string & {}) | undefined
+  /**
+   * A weak reference to the release document that the version belongs to.
+   */
   release: DocumentSystemRef | null
+  /**
+   * A weak reference to the variant document that the version belongs to.
+   */
   variant: DocumentSystemRef | null
+  /**
+   * A weak reference to the group document (aka published document).
+   */
   group: DocumentSystemRef
-  // Normal drafts and published documents don't have a scope id.
-  // Variants, release documents and anonymous versions have a scope id.
+  /**
+   * Available only for version documents.
+   */
   scopeId: string | null
 }
 

--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -156,7 +156,9 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
   const schema = useSchema()
   const presenceStore = usePresenceStore()
   const {data: releases} = useActiveReleases()
-  const {data: documentVersions} = useDocumentVersions({documentId})
+  const {data: documentVersions, loading: documentVersionsLoading} = useDocumentVersions({
+    documentId,
+  })
   const workspace = useWorkspace()
 
   const enhancedObjectDialogEnabled = true
@@ -344,7 +346,11 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
 
   const isNonExistent = !value?._id
 
-  const ready = connectionState === 'connected' && editState.ready && !initialValue?.loading
+  const ready =
+    connectionState === 'connected' &&
+    editState.ready &&
+    !initialValue?.loading &&
+    !documentVersionsLoading
 
   const selectedPerspective = useMemo(() => {
     return getSelectedPerspective(selectedPerspectiveName, releases)

--- a/packages/sanity/src/core/preview/constants.tsx
+++ b/packages/sanity/src/core/preview/constants.tsx
@@ -36,3 +36,6 @@ export const INVALID_PREVIEW_FALLBACK: PreviewValue = {
   subtitle: 'Check the error log in the console',
   media: <WarningOutlineIcon />,
 }
+
+// oxlint-disable-next-line typescript/prefer-as-const
+export const DOCUMENT_SYSTEM_FIELD: '_system' = '_system'

--- a/packages/sanity/src/core/preview/constants.tsx
+++ b/packages/sanity/src/core/preview/constants.tsx
@@ -37,4 +37,5 @@ export const INVALID_PREVIEW_FALLBACK: PreviewValue = {
   media: <WarningOutlineIcon />,
 }
 
-export const DOCUMENT_SYSTEM_FIELD = '_system' as const
+// oxlint-disable-next-line typescript/prefer-as-const
+export const DOCUMENT_SYSTEM_FIELD: '_system' = '_system'

--- a/packages/sanity/src/core/preview/constants.tsx
+++ b/packages/sanity/src/core/preview/constants.tsx
@@ -37,5 +37,4 @@ export const INVALID_PREVIEW_FALLBACK: PreviewValue = {
   media: <WarningOutlineIcon />,
 }
 
-// oxlint-disable-next-line typescript/prefer-as-const
-export const DOCUMENT_SYSTEM_FIELD: '_system' = '_system'
+export const DOCUMENT_SYSTEM_FIELD = '_system' as const

--- a/packages/sanity/src/core/preview/documentPreviewStore.ts
+++ b/packages/sanity/src/core/preview/documentPreviewStore.ts
@@ -5,7 +5,7 @@ import {
   type StackablePerspective,
   type WelcomeEvent,
 } from '@sanity/client'
-import {type PrepareViewOptions, type SanityDocument} from '@sanity/types'
+import {type DocumentSystem, type PrepareViewOptions, type SanityDocument} from '@sanity/types'
 import {combineLatest, type Observable} from 'rxjs'
 import {distinctUntilChanged, filter, map} from 'rxjs/operators'
 
@@ -14,6 +14,7 @@ import {
   createDocumentStackAvailabilityObserver,
   createPreviewAvailabilityObserver,
 } from './availability'
+import {DOCUMENT_SYSTEM_FIELD} from './constants'
 import {createGlobalListener} from './createGlobalListener'
 import {createObserveDocument, type ObserveDocumentAPIConfig} from './createObserveDocument'
 import {createPathObserver} from './createPathObserver'
@@ -62,6 +63,11 @@ export interface DocumentPreviewStore {
     apiConfig?: ApiConfig,
     perspective?: StackablePerspective[],
   ) => Observable<string | undefined>
+  observeDocumentSystemFromId: (
+    id: string,
+    apiConfig?: ApiConfig,
+    perspective?: StackablePerspective[],
+  ) => Observable<DocumentSystem | undefined>
 
   /**
    *
@@ -170,6 +176,26 @@ export function createDocumentPreviewStore({
       distinctUntilChanged(),
     )
   }
+  function observeDocumentSystemFromId(
+    id: string,
+    apiConfig?: ApiConfig,
+    perspective?: StackablePerspective[],
+    // TODO: This shouldn't be undefined once the documents are migrated.
+  ): Observable<DocumentSystem | undefined> {
+    return observePaths(
+      {_type: 'reference', _ref: id},
+      [DOCUMENT_SYSTEM_FIELD],
+      apiConfig,
+      perspective,
+    ).pipe(
+      map((res) =>
+        isRecord(res) && isRecord(res[DOCUMENT_SYSTEM_FIELD])
+          ? (res[DOCUMENT_SYSTEM_FIELD] as unknown as DocumentSystem)
+          : undefined,
+      ),
+      distinctUntilChanged(),
+    )
+  }
 
   const observeDocumentIdSet = createDocumentIdSetObserver(versionedClient)
 
@@ -195,7 +221,7 @@ export function createDocumentPreviewStore({
     observePaths,
     observeForPreview,
     observeDocumentTypeFromId,
-
+    observeDocumentSystemFromId,
     unstable_observeDocumentIdSet: observeDocumentIdSet,
     unstable_observeDocument: observeDocument,
     unstable_observeDocuments: (ids: string[]) =>

--- a/packages/sanity/src/core/releases/hooks/__tests__/__mocks__/useDocumentVersions.mock.ts
+++ b/packages/sanity/src/core/releases/hooks/__tests__/__mocks__/useDocumentVersions.mock.ts
@@ -4,6 +4,7 @@ import {type DocumentPerspectiveState, useDocumentVersions} from '../../useDocum
 
 export const useDocumentVersionsReturn: Mocked<DocumentPerspectiveState> = {
   data: [],
+  versions: [],
   error: null,
   loading: true,
 }

--- a/packages/sanity/src/core/releases/hooks/__tests__/getOrCreateDocumentVersionsObservable.test.ts
+++ b/packages/sanity/src/core/releases/hooks/__tests__/getOrCreateDocumentVersionsObservable.test.ts
@@ -5,7 +5,7 @@ import {type DocumentPreviewStore} from '../../../preview'
 import {getOrCreateDocumentVersionsObservable, observableCache} from '../useDocumentVersions'
 
 describe('getOrCreateDocumentVersionsObservable', () => {
-  it('emits loading: true while document system metadata is being resolved', async () => {
+  it('emits loading: true while document stub fields are being resolved', async () => {
     observableCache.clear()
 
     const documentPreviewStore = {
@@ -17,17 +17,21 @@ describe('getOrCreateDocumentVersionsObservable', () => {
             documentIds: ['drafts.article-1'],
           }),
         ),
-      observeDocumentSystemFromId: vi
-        .fn<DocumentPreviewStore['observeDocumentSystemFromId']>()
-        .mockReturnValue(
-          of({
+      observePaths: vi.fn<DocumentPreviewStore['observePaths']>().mockReturnValue(
+        of({
+          _id: 'drafts.article-1',
+          _rev: 'rev-1',
+          _createdAt: '2024-01-01T00:00:00.000Z',
+          _updatedAt: '2024-01-02T00:00:00.000Z',
+          _system: {
             bundleId: 'drafts',
             release: null,
             variant: null,
             group: {_ref: 'article-1', _weak: true},
             scopeId: null,
-          }),
-        ),
+          },
+        }),
+      ),
     } as unknown as DocumentPreviewStore
 
     const emissions = await firstValueFrom(
@@ -38,6 +42,15 @@ describe('getOrCreateDocumentVersionsObservable', () => {
         dataset: 'test',
       }).pipe(toArray()),
     )
+
+    expect(documentPreviewStore.observePaths).toHaveBeenCalledWith({_id: 'drafts.article-1'}, [
+      '_id',
+      '_type',
+      '_rev',
+      '_createdAt',
+      '_updatedAt',
+      '_system',
+    ])
 
     expect(emissions).toEqual([
       {
@@ -51,9 +64,9 @@ describe('getOrCreateDocumentVersionsObservable', () => {
         versions: [
           {
             _id: 'drafts.article-1',
-            _rev: '',
-            _createdAt: '',
-            _updatedAt: '',
+            _rev: 'rev-1',
+            _createdAt: '2024-01-01T00:00:00.000Z',
+            _updatedAt: '2024-01-02T00:00:00.000Z',
             _system: {
               bundleId: 'drafts',
               release: null,

--- a/packages/sanity/src/core/releases/hooks/__tests__/getOrCreateDocumentVersionsObservable.test.ts
+++ b/packages/sanity/src/core/releases/hooks/__tests__/getOrCreateDocumentVersionsObservable.test.ts
@@ -1,0 +1,71 @@
+import {firstValueFrom, of, toArray} from 'rxjs'
+import {describe, expect, it, vi} from 'vitest'
+
+import {type DocumentPreviewStore} from '../../../preview'
+import {getOrCreateDocumentVersionsObservable, observableCache} from '../useDocumentVersions'
+
+describe('getOrCreateDocumentVersionsObservable', () => {
+  it('emits loading: true while document system metadata is being resolved', async () => {
+    observableCache.clear()
+
+    const documentPreviewStore = {
+      unstable_observeDocumentIdSet: vi
+        .fn<DocumentPreviewStore['unstable_observeDocumentIdSet']>()
+        .mockReturnValue(
+          of({
+            status: 'connected',
+            documentIds: ['drafts.article-1'],
+          }),
+        ),
+      observeDocumentSystemFromId: vi
+        .fn<DocumentPreviewStore['observeDocumentSystemFromId']>()
+        .mockReturnValue(
+          of({
+            bundleId: 'drafts',
+            release: null,
+            variant: null,
+            group: {_ref: 'article-1', _weak: true},
+            scopeId: null,
+          }),
+        ),
+    } as unknown as DocumentPreviewStore
+
+    const emissions = await firstValueFrom(
+      getOrCreateDocumentVersionsObservable({
+        documentPreviewStore,
+        publishedId: 'article-1',
+        projectId: 'test-project',
+        dataset: 'test',
+      }).pipe(toArray()),
+    )
+
+    expect(emissions).toEqual([
+      {
+        data: ['drafts.article-1'],
+        versions: [],
+        error: null,
+        loading: true,
+      },
+      {
+        data: ['drafts.article-1'],
+        versions: [
+          {
+            _id: 'drafts.article-1',
+            _rev: '',
+            _createdAt: '',
+            _updatedAt: '',
+            _system: {
+              bundleId: 'drafts',
+              release: null,
+              variant: null,
+              group: {_ref: 'article-1', _weak: true},
+              scopeId: null,
+            },
+          },
+        ],
+        error: null,
+        loading: false,
+      },
+    ])
+  })
+})

--- a/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
@@ -49,7 +49,7 @@ async function setupMocks({
   versionIds: string[]
   /**
    * When `false`, versions are returned without `_system`, so the hook
-   * falls back to `temporallyBuildDocumentSystem`.
+   * falls back to `temporarilyBuildDocumentSystem`.
    */
   observeSystem?: boolean
 }) {
@@ -156,7 +156,7 @@ describe('useDocumentVersions', () => {
     ])
   })
 
-  it('should fall back to a temporally built system when the document has no system', async () => {
+  it('should fall back to a temporarily built system when the document has no system', async () => {
     await setupMocks({
       releases: [activeASAPRelease],
       versionIds: ['versions.rASAP.document-1'],

--- a/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
@@ -2,19 +2,14 @@ import {type ReleaseDocument} from '@sanity/client'
 import {getPublishedId} from '@sanity/client/csm'
 import {type DocumentSystem} from '@sanity/types'
 import {renderHook, waitFor} from '@testing-library/react'
-import {delay, of} from 'rxjs'
-import {describe, expect, it, type Mock, vi} from 'vitest'
+import {NEVER, of} from 'rxjs'
+import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
 import {type DocumentPreviewStore} from '../../../preview'
-import {type DocumentIdSetObserverState} from '../../../preview/liveDocumentIdSet'
 import {useDocumentPreviewStore} from '../../../store'
 import {activeASAPRelease, activeScheduledRelease} from '../../__fixtures__/release.fixture'
 import {useActiveReleasesMockReturn} from '../../store/__tests__/__mocks/useActiveReleases.mock'
-import {
-  type DocumentPerspectiveState,
-  getOrCreateDocumentVersionsObservable,
-  useDocumentVersions,
-} from '../useDocumentVersions'
+import {observableCache, useDocumentVersions} from '../useDocumentVersions'
 
 vi.mock('../../../hooks/useDataset', () => ({
   useDataset: vi.fn().mockReturnValue('test'),
@@ -23,14 +18,6 @@ vi.mock('../../../hooks/useDataset', () => ({
 vi.mock('../../../hooks/useProjectId', () => ({
   useProjectId: vi.fn().mockReturnValue('test-project'),
 }))
-
-vi.mock('../useDocumentVersions', async () => {
-  const actual = await vi.importActual('../useDocumentVersions')
-  return {
-    ...actual,
-    getOrCreateDocumentVersionsObservable: vi.fn(),
-  }
-})
 
 vi.mock('../../../store', () => ({
   useDocumentPreviewStore: vi.fn(),
@@ -44,6 +31,7 @@ async function setupMocks({
   releases,
   versionIds,
   observeSystem = true,
+  pendingIdSet = false,
 }: {
   releases: ReleaseDocument[]
   versionIds: string[]
@@ -52,36 +40,49 @@ async function setupMocks({
    * falls back to `temporarilyBuildDocumentSystem`.
    */
   observeSystem?: boolean
+  /** When `true`, the id set observable never emits (initial loading state). */
+  pendingIdSet?: boolean
 }) {
   const mockDocumentPreviewStore = useDocumentPreviewStore as Mock<typeof useDocumentPreviewStore>
-  const mockGetOrCreateDocumentVersionsObservable = getOrCreateDocumentVersionsObservable as Mock<
-    typeof getOrCreateDocumentVersionsObservable
-  >
 
   mockDocumentPreviewStore.mockReturnValue({
     unstable_observeDocumentIdSet: vi
       .fn<DocumentPreviewStore['unstable_observeDocumentIdSet']>()
-      .mockImplementation(() =>
-        of({status: 'connected', documentIds: versionIds} as DocumentIdSetObserverState).pipe(
-          // simulate async initial emission
-          delay(0),
-        ),
+      .mockReturnValue(
+        pendingIdSet
+          ? NEVER
+          : of({
+              status: 'connected',
+              documentIds: versionIds,
+            }),
       ),
-    observeDocumentSystemFromId: vi
-      .fn<DocumentPreviewStore['observeDocumentSystemFromId']>()
-      .mockImplementation((id) =>
-        of(
+    observePaths: vi
+      .fn<DocumentPreviewStore['observePaths']>()
+      .mockImplementation((value: {_id: string}) => {
+        const id = value._id
+        return of(
           observeSystem
-            ? ({
-                bundleId: 'drafts',
-                release: null,
-                variant: null,
-                group: {_ref: getPublishedId(id), _weak: true},
-                scopeId: getPublishedId(id),
-              } satisfies DocumentSystem)
-            : undefined,
-        ),
-      ),
+            ? {
+                _id: id,
+                _rev: '',
+                _createdAt: '',
+                _updatedAt: '',
+                _system: {
+                  bundleId: 'drafts',
+                  release: null,
+                  variant: null,
+                  group: {_ref: getPublishedId(id), _weak: true},
+                  scopeId: getPublishedId(id),
+                } satisfies DocumentSystem,
+              }
+            : {
+                _id: id,
+                _rev: '',
+                _createdAt: '',
+                _updatedAt: '',
+              },
+        )
+      }),
   } as unknown as DocumentPreviewStore)
 
   const {useActiveReleases} = await import('../../store/useActiveReleases')
@@ -89,34 +90,19 @@ async function setupMocks({
     ...useActiveReleasesMockReturn,
     data: releases,
   })
-
-  mockGetOrCreateDocumentVersionsObservable.mockImplementation(() =>
-    of({
-      data: versionIds,
-      versions: versionIds.map((id) => ({
-        _id: id,
-        _rev: '',
-        _createdAt: '',
-        _updatedAt: '',
-        _system: observeSystem
-          ? ({
-              bundleId: 'drafts',
-              release: null,
-              variant: null,
-              group: {_ref: getPublishedId(id), _weak: true},
-              scopeId: getPublishedId(id),
-            } satisfies DocumentSystem)
-          : undefined,
-      })),
-      loading: false,
-      error: null,
-    } as DocumentPerspectiveState).pipe(delay(0)),
-  )
 }
 
 describe('useDocumentVersions', () => {
+  beforeEach(() => {
+    observableCache.clear()
+  })
+
   it('should return initial state', async () => {
-    await setupMocks({releases: [activeASAPRelease, activeScheduledRelease], versionIds: []})
+    await setupMocks({
+      releases: [activeASAPRelease, activeScheduledRelease],
+      versionIds: [],
+      pendingIdSet: true,
+    })
 
     const {result} = renderHook(() => useDocumentVersions({documentId: 'document-1'}))
     expect(result.current.loading).toBe(true)
@@ -127,6 +113,9 @@ describe('useDocumentVersions', () => {
   it('should return an empty array if no versions are found', async () => {
     await setupMocks({releases: [activeASAPRelease, activeScheduledRelease], versionIds: []})
     const {result} = renderHook(() => useDocumentVersions({documentId: 'document-1'}))
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
     expect(result.current.data).toEqual([])
   })
 

--- a/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
@@ -1,4 +1,6 @@
 import {type ReleaseDocument} from '@sanity/client'
+import {getPublishedId} from '@sanity/client/csm'
+import {type DocumentSystem} from '@sanity/types'
 import {renderHook, waitFor} from '@testing-library/react'
 import {delay, of} from 'rxjs'
 import {describe, expect, it, type Mock, vi} from 'vitest'
@@ -7,6 +9,7 @@ import {type DocumentPreviewStore} from '../../../preview'
 import {type DocumentIdSetObserverState} from '../../../preview/liveDocumentIdSet'
 import {useDocumentPreviewStore} from '../../../store'
 import {activeASAPRelease, activeScheduledRelease} from '../../__fixtures__/release.fixture'
+import {useActiveReleasesMockReturn} from '../../store/__tests__/__mocks/useActiveReleases.mock'
 import {
   type DocumentPerspectiveState,
   getOrCreateDocumentVersionsObservable,
@@ -33,7 +36,23 @@ vi.mock('../../../store', () => ({
   useDocumentPreviewStore: vi.fn(),
 }))
 
-async function setupMocks({versionIds}: {releases: ReleaseDocument[]; versionIds: string[]}) {
+vi.mock('../../store/useActiveReleases', () => ({
+  useActiveReleases: vi.fn(() => useActiveReleasesMockReturn),
+}))
+
+async function setupMocks({
+  releases,
+  versionIds,
+  observeSystem = true,
+}: {
+  releases: ReleaseDocument[]
+  versionIds: string[]
+  /**
+   * When `false`, versions are returned without `_system`, so the hook
+   * falls back to `temporallyBuildDocumentSystem`.
+   */
+  observeSystem?: boolean
+}) {
   const mockDocumentPreviewStore = useDocumentPreviewStore as Mock<typeof useDocumentPreviewStore>
   const mockGetOrCreateDocumentVersionsObservable = getOrCreateDocumentVersionsObservable as Mock<
     typeof getOrCreateDocumentVersionsObservable
@@ -48,11 +67,47 @@ async function setupMocks({versionIds}: {releases: ReleaseDocument[]; versionIds
           delay(0),
         ),
       ),
+    observeDocumentSystemFromId: vi
+      .fn<DocumentPreviewStore['observeDocumentSystemFromId']>()
+      .mockImplementation((id) =>
+        of(
+          observeSystem
+            ? ({
+                bundleId: 'drafts',
+                release: null,
+                variant: null,
+                group: {_ref: getPublishedId(id), _weak: true},
+                scopeId: getPublishedId(id),
+              } satisfies DocumentSystem)
+            : undefined,
+        ),
+      ),
   } as unknown as DocumentPreviewStore)
+
+  const {useActiveReleases} = await import('../../store/useActiveReleases')
+  vi.mocked(useActiveReleases).mockReturnValue({
+    ...useActiveReleasesMockReturn,
+    data: releases,
+  })
 
   mockGetOrCreateDocumentVersionsObservable.mockImplementation(() =>
     of({
       data: versionIds,
+      versions: versionIds.map((id) => ({
+        _id: id,
+        _rev: '',
+        _createdAt: '',
+        _updatedAt: '',
+        _system: observeSystem
+          ? ({
+              bundleId: 'drafts',
+              release: null,
+              variant: null,
+              group: {_ref: getPublishedId(id), _weak: true},
+              scopeId: getPublishedId(id),
+            } satisfies DocumentSystem)
+          : undefined,
+      })),
       loading: false,
       error: null,
     } as DocumentPerspectiveState).pipe(delay(0)),
@@ -84,5 +139,74 @@ describe('useDocumentVersions', () => {
     await waitFor(() => {
       expect(result.current.data).toEqual(['versions.rASAP.document-1'])
     })
+    expect(result.current.versions).toEqual([
+      {
+        _id: 'versions.rASAP.document-1',
+        _rev: '',
+        _createdAt: '',
+        _updatedAt: '',
+        _system: {
+          bundleId: 'drafts',
+          release: null,
+          variant: null,
+          group: {_ref: 'document-1', _weak: true},
+          scopeId: 'document-1',
+        },
+      },
+    ])
+  })
+
+  it('should fall back to a temporally built system when the document has no system', async () => {
+    await setupMocks({
+      releases: [activeASAPRelease],
+      versionIds: ['versions.rASAP.document-1'],
+      observeSystem: false,
+    })
+    const {result} = renderHook(() => useDocumentVersions({documentId: 'document-1'}))
+    await waitFor(() => {
+      expect(result.current.data).toEqual(['versions.rASAP.document-1'])
+    })
+    expect(result.current.versions).toEqual([
+      {
+        _id: 'versions.rASAP.document-1',
+        _rev: '',
+        _createdAt: '',
+        _updatedAt: '',
+        _system: {
+          bundleId: 'rASAP',
+          release: {_ref: '_.releases.rASAP', _weak: true},
+          variant: null,
+          group: {_ref: 'document-1', _weak: true},
+          scopeId: 'rASAP',
+        },
+      },
+    ])
+  })
+
+  it('should build a drafts system when a draft document has no system', async () => {
+    await setupMocks({
+      releases: [activeASAPRelease],
+      versionIds: ['drafts.document-1'],
+      observeSystem: false,
+    })
+    const {result} = renderHook(() => useDocumentVersions({documentId: 'document-1'}))
+    await waitFor(() => {
+      expect(result.current.data).toEqual(['drafts.document-1'])
+    })
+    expect(result.current.versions).toEqual([
+      {
+        _id: 'drafts.document-1',
+        _rev: '',
+        _createdAt: '',
+        _updatedAt: '',
+        _system: {
+          bundleId: 'drafts',
+          release: null,
+          variant: null,
+          group: {_ref: 'document-1', _weak: true},
+          scopeId: null,
+        },
+      },
+    ])
   })
 })

--- a/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
@@ -1,7 +1,8 @@
 import {type QueryParams, type ReleaseDocument} from '@sanity/client'
 import {getVersionFromId, isPublishedId} from '@sanity/client/csm'
 import {type DocumentSystem} from '@sanity/types'
-import {useEffect, useMemo, useState} from 'react'
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
 import {
   catchError,
   combineLatest,
@@ -10,6 +11,7 @@ import {
   type Observable,
   of,
   shareReplay,
+  startWith,
   switchMap,
 } from 'rxjs'
 
@@ -68,7 +70,6 @@ export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPe
   const projectId = useProjectId()
   const documentPreviewStore = useDocumentPreviewStore()
   const {data: releases} = useActiveReleases()
-  const [results, setResults] = useState<DocumentPerspectiveState>(INITIAL_VALUE)
 
   const observable: Observable<DocumentPerspectiveState> = useMemo(() => {
     return getOrCreateDocumentVersionsObservable({
@@ -96,12 +97,7 @@ export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPe
     )
   }, [dataset, documentPreviewStore, projectId, publishedId, releases])
 
-  useEffect(() => {
-    const subscription = observable.subscribe((result) => {
-      setResults(result)
-    })
-    return () => subscription.unsubscribe()
-  }, [observable])
+  const results = useObservable(observable, INITIAL_VALUE)
 
   return results
 }
@@ -184,6 +180,13 @@ export function getOrCreateDocumentVersionsObservable(options: {
           return of({data: [], versions: [], error: null, loading: false})
         }
 
+        const loadingState: DocumentPerspectiveState = {
+          data: documentIds,
+          versions: [],
+          error: null,
+          loading: true,
+        }
+
         return combineLatest(
           documentIds.map((id) =>
             documentPreviewStore.observeDocumentSystemFromId(id).pipe(
@@ -204,6 +207,7 @@ export function getOrCreateDocumentVersionsObservable(options: {
             error: null,
             loading: false,
           })),
+          startWith(loadingState),
         )
       }),
       catchError((error) => {

--- a/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
@@ -1,13 +1,28 @@
-import {type QueryParams} from '@sanity/client'
+import {type QueryParams, type ReleaseDocument} from '@sanity/client'
+import {getVersionFromId, isPublishedId} from '@sanity/client/csm'
+import {type DocumentSystem} from '@sanity/types'
 import {useEffect, useMemo, useState} from 'react'
-import {catchError, finalize, map, type Observable, of, shareReplay} from 'rxjs'
+import {
+  catchError,
+  combineLatest,
+  finalize,
+  map,
+  type Observable,
+  of,
+  shareReplay,
+  switchMap,
+} from 'rxjs'
 
 import {useDataset} from '../../hooks/useDataset'
 import {useProjectId} from '../../hooks/useProjectId'
+import {DOCUMENT_SYSTEM_FIELD} from '../../preview/constants'
 import {type DocumentPreviewStore} from '../../preview/documentPreviewStore'
 import {useDocumentPreviewStore} from '../../store'
 import {getPublishedId} from '../../util/draftUtils'
 import {createSWR} from '../../util/rxSwr'
+import {type VersionInfoDocumentStub} from '../store/types'
+import {useActiveReleases} from '../store/useActiveReleases'
+import {getReleaseIdFromReleaseDocumentId} from '../util/getReleaseIdFromReleaseDocumentId'
 import {RELEASES_STUDIO_CLIENT_OPTIONS} from '../util/releasesClient'
 
 export interface DocumentPerspectiveProps {
@@ -16,12 +31,20 @@ export interface DocumentPerspectiveProps {
 
 export interface DocumentPerspectiveState {
   data: string[]
+  versions: VersionInfoDocumentStub[]
   error?: unknown
   loading: boolean
 }
 
-const INITIAL_VALUE = {
+const EMPTY_VERSION_STUB_FIELDS = {
+  _rev: '',
+  _createdAt: '',
+  _updatedAt: '',
+} as const satisfies Pick<VersionInfoDocumentStub, '_rev' | '_createdAt' | '_updatedAt'>
+
+const INITIAL_VALUE: DocumentPerspectiveState = {
   data: [],
+  versions: [],
   error: null,
   loading: true,
 }
@@ -44,6 +67,7 @@ export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPe
   const dataset = useDataset()
   const projectId = useProjectId()
   const documentPreviewStore = useDocumentPreviewStore()
+  const {data: releases} = useActiveReleases()
   const [results, setResults] = useState<DocumentPerspectiveState>(INITIAL_VALUE)
 
   const observable: Observable<DocumentPerspectiveState> = useMemo(() => {
@@ -52,8 +76,25 @@ export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPe
       publishedId,
       projectId,
       dataset,
-    })
-  }, [dataset, documentPreviewStore, projectId, publishedId])
+    }).pipe(
+      map((result) => {
+        return {
+          ...result,
+          versions: result.versions.map((version) => {
+            return {
+              ...version,
+              [DOCUMENT_SYSTEM_FIELD]: version._system?.group
+                ? version._system
+                : {
+                    ...version._system,
+                    ...temporallyBuildDocumentSystem(version._id, releases),
+                  },
+            }
+          }),
+        }
+      }),
+    )
+  }, [dataset, documentPreviewStore, projectId, publishedId, releases])
 
   useEffect(() => {
     const subscription = observable.subscribe((result) => {
@@ -63,6 +104,40 @@ export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPe
   }, [observable])
 
   return results
+}
+
+/**
+ * Temporally builds the document _system for a given document id.
+ * This is used until the documents are migrated to the new _system.
+ * And only if the documents are not variant documents.
+ *
+ * Variants will include the _system field.
+ */
+const temporallyBuildDocumentSystem = (id: string, releases: ReleaseDocument[]): DocumentSystem => {
+  const versionId = getVersionFromId(id)
+  const releaseDocument = releases.find(
+    (release) => getReleaseIdFromReleaseDocumentId(release._id) === versionId,
+  )
+  if (versionId) {
+    return {
+      bundleId: versionId,
+      release: releaseDocument ? {_ref: releaseDocument._id, _weak: true} : null,
+      variant: null,
+      group: {
+        _ref: getPublishedId(id),
+        _weak: true,
+      },
+      scopeId: versionId,
+    }
+  }
+
+  return {
+    bundleId: isPublishedId(id) ? '$published' : 'drafts',
+    release: null,
+    variant: null,
+    group: {_ref: getPublishedId(id), _weak: true},
+    scopeId: versionId || null,
+  }
 }
 
 /**
@@ -100,13 +175,41 @@ export function getOrCreateDocumentVersionsObservable(options: {
     })
     .pipe(
       swr(cacheKey),
-      map(({value}) => ({
-        data: value.documentIds,
-        error: null,
-        loading: false,
-      })),
+      map(({value}) => value.documentIds),
+      switchMap((documentIds): Observable<DocumentPerspectiveState> => {
+        if (documentIds.length === 0) {
+          return of({data: [], versions: [], error: null, loading: false})
+        }
+
+        return combineLatest(
+          documentIds.map((id) =>
+            documentPreviewStore.observeDocumentSystemFromId(id).pipe(
+              map(
+                (_system) =>
+                  ({
+                    _id: id,
+                    ...EMPTY_VERSION_STUB_FIELDS,
+                    [DOCUMENT_SYSTEM_FIELD]: _system,
+                  }) satisfies VersionInfoDocumentStub,
+              ),
+            ),
+          ),
+        ).pipe(
+          map((versions) => ({
+            data: documentIds,
+            versions,
+            error: null,
+            loading: false,
+          })),
+        )
+      }),
       catchError((error) => {
-        return of({error, data: [] as string[], loading: false})
+        return of({
+          error,
+          data: [] as string[],
+          versions: [] as VersionInfoDocumentStub[],
+          loading: false,
+        })
       }),
       finalize(() => {
         observableCache.delete(cacheKey)

--- a/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
@@ -1,5 +1,5 @@
 import {type QueryParams, type ReleaseDocument} from '@sanity/client'
-import {getVersionFromId, isPublishedId} from '@sanity/client/csm'
+import {getVersionFromId} from '@sanity/client/csm'
 import {type DocumentSystem} from '@sanity/types'
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
@@ -20,6 +20,7 @@ import {useProjectId} from '../../hooks/useProjectId'
 import {DOCUMENT_SYSTEM_FIELD} from '../../preview/constants'
 import {type DocumentPreviewStore} from '../../preview/documentPreviewStore'
 import {useDocumentPreviewStore} from '../../store'
+import {isDraftId} from '../../util'
 import {getPublishedId} from '../../util/draftUtils'
 import {isRecord} from '../../util/isRecord'
 import {createSWR} from '../../util/rxSwr'
@@ -126,7 +127,7 @@ const temporarilyBuildDocumentSystem = (
   }
 
   return {
-    bundleId: isPublishedId(id) ? '$published' : 'drafts',
+    bundleId: isDraftId(id) ? 'drafts' : null,
     release: null,
     variant: null,
     group: {_ref: getPublishedId(id), _weak: true},

--- a/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
@@ -21,6 +21,7 @@ import {DOCUMENT_SYSTEM_FIELD} from '../../preview/constants'
 import {type DocumentPreviewStore} from '../../preview/documentPreviewStore'
 import {useDocumentPreviewStore} from '../../store'
 import {getPublishedId} from '../../util/draftUtils'
+import {isRecord} from '../../util/isRecord'
 import {createSWR} from '../../util/rxSwr'
 import {type VersionInfoDocumentStub} from '../store/types'
 import {useActiveReleases} from '../store/useActiveReleases'
@@ -37,12 +38,6 @@ export interface DocumentPerspectiveState {
   error?: unknown
   loading: boolean
 }
-
-const EMPTY_VERSION_STUB_FIELDS = {
-  _rev: '',
-  _createdAt: '',
-  _updatedAt: '',
-} as const satisfies Pick<VersionInfoDocumentStub, '_rev' | '_createdAt' | '_updatedAt'>
 
 const INITIAL_VALUE: DocumentPerspectiveState = {
   data: [],
@@ -139,6 +134,8 @@ const temporarilyBuildDocumentSystem = (
   }
 }
 
+const DOCUMENT_STUB_PATHS = ['_id', '_type', '_rev', '_createdAt', '_updatedAt', '_system']
+
 /**
  * Retrieves an observable that emits document IDs matching the document versions that exist for a specific id
  *
@@ -189,13 +186,16 @@ export function getOrCreateDocumentVersionsObservable(options: {
 
         return combineLatest(
           documentIds.map((id) =>
-            documentPreviewStore.observeDocumentSystemFromId(id).pipe(
+            documentPreviewStore.observePaths({_id: id}, DOCUMENT_STUB_PATHS).pipe(
+              map((versionInfo) => (isRecord(versionInfo) ? versionInfo : undefined)),
               map(
-                (_system) =>
+                (versionInfo) =>
                   ({
                     _id: id,
-                    ...EMPTY_VERSION_STUB_FIELDS,
-                    [DOCUMENT_SYSTEM_FIELD]: _system,
+                    _rev: versionInfo?._rev ?? '',
+                    _createdAt: versionInfo?._createdAt ?? '',
+                    _updatedAt: versionInfo?._updatedAt ?? '',
+                    [DOCUMENT_SYSTEM_FIELD]: versionInfo?.[DOCUMENT_SYSTEM_FIELD] as DocumentSystem,
                   }) satisfies VersionInfoDocumentStub,
               ),
             ),

--- a/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
@@ -87,7 +87,7 @@ export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPe
                 ? version._system
                 : {
                     ...version._system,
-                    ...temporallyBuildDocumentSystem(version._id, releases),
+                    ...temporarilyBuildDocumentSystem(version._id, releases),
                   },
             }
           }),
@@ -107,18 +107,21 @@ export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPe
 }
 
 /**
- * Temporally builds the document _system for a given document id.
+ * Temporarily builds the document _system for a given document id.
  * This is used until the documents are migrated to the new _system.
  * And only if the documents are not variant documents.
  *
  * Variants will include the _system field.
  */
-const temporallyBuildDocumentSystem = (id: string, releases: ReleaseDocument[]): DocumentSystem => {
+const temporarilyBuildDocumentSystem = (
+  id: string,
+  releases: ReleaseDocument[],
+): DocumentSystem => {
   const versionId = getVersionFromId(id)
-  const releaseDocument = releases.find(
-    (release) => getReleaseIdFromReleaseDocumentId(release._id) === versionId,
-  )
   if (versionId) {
+    const releaseDocument = releases.find(
+      (release) => getReleaseIdFromReleaseDocumentId(release._id) === versionId,
+    )
     return {
       bundleId: versionId,
       release: releaseDocument ? {_ref: releaseDocument._id, _weak: true} : null,

--- a/packages/sanity/src/core/releases/store/types.ts
+++ b/packages/sanity/src/core/releases/store/types.ts
@@ -1,4 +1,5 @@
 import {type ReleaseDocument, type ReleaseType} from '@sanity/client'
+import {type DocumentSystem} from '@sanity/types'
 import {type Dispatch} from 'react'
 import {type Observable} from 'rxjs'
 
@@ -51,4 +52,5 @@ export interface VersionInfoDocumentStub {
   _rev: string
   _createdAt: string
   _updatedAt: string
+  _system?: DocumentSystem
 }

--- a/packages/sanity/src/core/releases/store/useDocumentVersionInfo.ts
+++ b/packages/sanity/src/core/releases/store/useDocumentVersionInfo.ts
@@ -39,7 +39,7 @@ export function useDocumentVersionInfo(documentId: string) {
                   .observePaths({_id: getVersionId(publishedId, releaseId)}, DOCUMENT_STUB_PATHS)
                   .pipe(
                     map((value) =>
-                      // TODO: Map _system with the temporally built system function available in useDocumentVersions
+                      // TODO: Map _system with the temporarily built system function available in useDocumentVersions
                       exists(value) ? (value as VersionInfoDocumentStub) : undefined,
                     ),
                   ),

--- a/packages/sanity/src/core/releases/store/useDocumentVersionInfo.ts
+++ b/packages/sanity/src/core/releases/store/useDocumentVersionInfo.ts
@@ -13,11 +13,12 @@ import {useReleasesIds} from './useReleasesIds'
 function exists(value: any) {
   return value?._rev
 }
-const DOCUMENT_STUB_PATHS = ['_id', '_type', '_rev', '_createdAt', '_updatedAt']
+const DOCUMENT_STUB_PATHS = ['_id', '_type', '_rev', '_createdAt', '_updatedAt', '_system']
 
 const NO_VERSIONS = {} as Record<string, VersionInfoDocumentStub | undefined>
 
 /**
+ * TODO: Deprecate this function and use useDocumentVersions instead.
  * Takes a document id, and returns information about what other versions of the document currently exists
  * @param documentId - The document id. Should be the published id
  * @internal
@@ -38,6 +39,7 @@ export function useDocumentVersionInfo(documentId: string) {
                   .observePaths({_id: getVersionId(publishedId, releaseId)}, DOCUMENT_STUB_PATHS)
                   .pipe(
                     map((value) =>
+                      // TODO: Map _system with the temporally built system function available in useDocumentVersions
                       exists(value) ? (value as VersionInfoDocumentStub) : undefined,
                     ),
                   ),

--- a/packages/sanity/src/core/releases/store/useDocumentVersionInfo.ts
+++ b/packages/sanity/src/core/releases/store/useDocumentVersionInfo.ts
@@ -18,7 +18,6 @@ const DOCUMENT_STUB_PATHS = ['_id', '_type', '_rev', '_createdAt', '_updatedAt',
 const NO_VERSIONS = {} as Record<string, VersionInfoDocumentStub | undefined>
 
 /**
- * TODO: Deprecate this function and use useDocumentVersions instead.
  * Takes a document id, and returns information about what other versions of the document currently exists
  * @param documentId - The document id. Should be the published id
  * @internal


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

This is a focused extraction from #13092. It adds `_system` metadata support to `useDocumentVersions` and the preview store's new `observeDocumentSystemFromId` observer, without the variant creation UI, perspective provider changes, or structure-layer work from the parent PR.

Documents that have not yet been migrated may not include `_system`. The hook falls back to `temporarilyBuildDocumentSystem `, which derives bundle/release/group from document IDs and active releases until migration is complete. Variant documents are expected to ship with `_system` already populated.


The data returned will have a shape similar to this:
```json
[
    // Published doc
    {
        "_id": "195138c7-4e0e-4914-a9b0-c8b1ede66236",
        "_rev": "Emm452bR2UKEyTWpYkg344",
        "_createdAt": "2025-02-05T14:39:55Z",
        "_updatedAt": "2025-02-27T13:54:10Z",
        "_system": {
            "bundleId": null,
            "release": null,
            "variant": null,
            "group": {
                "_ref": "195138c7-4e0e-4914-a9b0-c8b1ede66236",
                "_weak": true
            },
            "scopeId": null
        }
    },
    // Draft doc
    {
        "_id": "drafts.195138c7-4e0e-4914-a9b0-c8b1ede66236",
        "_rev": "4c7e35c2-85d8-4593-bc91-a1026619977a",
        "_createdAt": "2025-02-05T14:39:55Z",
        "_updatedAt": "2026-06-05T14:50:45Z",
        "_system": {
            "bundleId": "drafts",
            "release": null,
            "variant": null,
            "group": {
                "_ref": "195138c7-4e0e-4914-a9b0-c8b1ede66236",
                "_weak": true
            },
            "scopeId": null
        }
    },
   // Draft variant 
    {
        "_id": "versions.ji9Tzd8J0rlb5wuJ.195138c7-4e0e-4914-a9b0-c8b1ede66236",
        "_rev": "LwmRunf0H6Wwy6O5Z1wWV2",
        "_createdAt": "2025-02-05T14:39:55Z",
        "_updatedAt": "2026-06-05T14:50:45Z",
        "_system": {
            "base": {
                "id": "drafts.195138c7-4e0e-4914-a9b0-c8b1ede66236",
                "rev": "4c7e35c2-85d8-4593-bc91-a1026619977a"
            },
            "bundleId": "drafts",
            "group": {
                "_ref": "195138c7-4e0e-4914-a9b0-c8b1ede66236",
                "_weak": true
            },
            "scopeId": "ji9Tzd8J0rlb5wuJ",
            "variant": {
                "_ref": "_.variants.XBeVtHmN"
            }
        }
    },
]

```


### What to review

- `packages/sanity/src/core/preview/documentPreviewStore.ts` — new `observeDocumentSystemFromId` API
- `packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx` — `versions` return value and temporal `_system` fallback
- `packages/@sanity/types/src/documents/types.ts` — `DocumentSystem` type definitions
- `packages/sanity/src/core/releases/store/types.ts` — optional `_system` on `VersionInfoDocumentStub`

### Testing

- Extended `useDocumentVersions.test.tsx` with coverage for observed `_system`, temporal fallback for release versions, and draft documents
- All releases hook tests pass (`pnpm vitest run --project=sanity packages/sanity/src/core/releases/hooks/__tests__/`)
- Type check passes (`pnpm check:types`)

### Notes for release

N/A – Internal only. Prepares `useDocumentVersions` for variant-aware document metadata; no user-facing behavior change yet.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87d3d55c-82f4-4a0e-9d66-72d806b0c2f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87d3d55c-82f4-4a0e-9d66-72d806b0c2f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

