### PR TITLE
test(e2e): de-flake document-action publish and discard-changes specs

### DIFF
--- a/e2e/studio-test.ts
+++ b/e2e/studio-test.ts
@@ -115,6 +115,21 @@ export const test = baseTest.extend<SanityFixtures>({
         .locator('[data-testid="form-view"]:not([data-read-only="true"])')
         .waitFor({state: 'visible', timeout: 30_000})
 
+      // The `form-view` element is rendered before the form fields themselves are.
+      // While the document pair is still connecting (or `formState` is momentarily
+      // `null`), `form-view` only contains a loading spinner / "form hidden" text —
+      // no inputs. `document-panel-document-title` (the form header) is rendered by
+      // `FormView` in the *same* branch as `FormBuilder`, i.e. only once
+      // `formState !== null` and the fields are mounted and interactive.
+      //
+      // Waiting for it here closes a race where callers immediately `.fill()` a
+      // field that has not yet mounted, which surfaced in CI as `locator.fill`
+      // timing out. This does not change what any test asserts; it only awaits a
+      // precondition every caller already implicitly depends on.
+      await page
+        .locator('[data-testid="document-panel-document-title"]')
+        .waitFor({state: 'visible', timeout: 30_000})
+
       return id
     }
 

--- a/e2e/studio-test.ts
+++ b/e2e/studio-test.ts
@@ -118,17 +118,23 @@ export const test = baseTest.extend<SanityFixtures>({
       // The `form-view` element is rendered before the form fields themselves are.
       // While the document pair is still connecting (or `formState` is momentarily
       // `null`), `form-view` only contains a loading spinner / "form hidden" text —
-      // no inputs. `document-panel-document-title` (the form header) is rendered by
-      // `FormView` in the *same* branch as `FormBuilder`, i.e. only once
-      // `formState !== null` and the fields are mounted and interactive.
+      // no inputs. The `FormBuilder` renders each field wrapped in a
+      // `[data-testid="field-<name>"]` element, so waiting for the first field to
+      // be attached guarantees the form is mounted and its inputs are interactive.
       //
-      // Waiting for it here closes a race where callers immediately `.fill()` a
-      // field that has not yet mounted, which surfaced in CI as `locator.fill`
-      // timing out. This does not change what any test asserts; it only awaits a
-      // precondition every caller already implicitly depends on.
+      // This closes a race where callers immediately `.fill()` a field that has
+      // not yet mounted, which surfaced in CI as `locator.fill` timing out. It
+      // does not change what any test asserts; it only awaits a precondition every
+      // caller already implicitly depends on.
+      //
+      // Note: we target the field wrapper generically (rather than the form
+      // header) because some document types render fields without a visible title
+      // header, e.g. types with `__experimental_formPreviewTitle: false` such as
+      // the live-edit `playlist` type, whose header is not rendered at all.
       await page
-        .locator('[data-testid="document-panel-document-title"]')
-        .waitFor({state: 'visible', timeout: 30_000})
+        .locator('[data-testid="form-view"] [data-testid^="field-"]')
+        .first()
+        .waitFor({state: 'attached', timeout: 30_000})
 
       return id
     }

--- a/e2e/tests/comments/inline.spec.ts
+++ b/e2e/tests/comments/inline.spec.ts
@@ -66,11 +66,18 @@ async function inlineCommentCreationTest(props: InlineCommentCreationTestProps) 
   await expect(commentsList).toBeVisible()
 
   // 9. Verify that the comment appears within the list and correctly references the intended content.
+  //
+  // After the comment is created, the comments panel re-fetches and re-renders
+  // the thread from the backend; this round trip is slow-but-correct and under
+  // CI load can exceed the default 30s, producing a first-attempt failure that
+  // passes on retry. Give it more headroom instead of relying on the retry to
+  // mask it.
+  const COMMENT_SYNC_TIMEOUT = {timeout: 60 * 1000}
   const commentsListItem = page.getByTestId('comments-list-item')
-  await expect(commentsListItem).toBeVisible()
+  await expect(commentsListItem).toBeVisible(COMMENT_SYNC_TIMEOUT)
   const commentsListItemReferencedValue = page.getByTestId('comments-list-item-referenced-value')
-  await expect(commentsListItemReferencedValue).toBeVisible()
-  await expect(commentsListItemReferencedValue).toHaveText(PTE_CONTENT_TEXT)
+  await expect(commentsListItemReferencedValue).toBeVisible(COMMENT_SYNC_TIMEOUT)
+  await expect(commentsListItemReferencedValue).toHaveText(PTE_CONTENT_TEXT, COMMENT_SYNC_TIMEOUT)
 }
 
 test.describe('Inline comments:', () => {
@@ -81,6 +88,14 @@ test.describe('Inline comments:', () => {
   }) => {
     // For now, only test in other browsers except firefox due to flakiness in Firefox with the requests
     test.skip(browserName === 'firefox')
+    // This test drives a full comment lifecycle (select text, author, submit,
+    // wait for the backend to sync the thread into the comments panel, then
+    // resolve). The comment-sync round trip alone can take a large fraction of
+    // the default 60s test budget under CI load, leaving too little room for the
+    // remaining steps and causing a first-attempt timeout that passes on retry.
+    // Triple the budget so the slow-but-correct backend sync has room. Behaviour
+    // and assertions are unchanged.
+    test.slow()
     // 1. Create a new inline comment
     await inlineCommentCreationTest({page, createDraftDocument})
 

--- a/e2e/tests/document-actions/discardChanges.spec.ts
+++ b/e2e/tests/document-actions/discardChanges.spec.ts
@@ -1,6 +1,10 @@
 import {expect} from '@playwright/test'
 
-import {expectPublishedStatus} from '../../helpers/documentStatusAssertions'
+import {
+  expectCreatedOrEditedStatus,
+  expectEditedStatus,
+  expectPublishedStatus,
+} from '../../helpers/documentStatusAssertions'
 import {test} from '../../studio-test'
 
 test(`it is possible to discard changes if a changed document has no published version`, async ({
@@ -39,12 +43,18 @@ test(`is possible to discard changes if a changed document has a published versi
   const publishButton = page.getByTestId('action-publish')
   const actionMenuButton = page.getByTestId('action-menu-button')
   const discardChangesButton = page.getByTestId('action-Discardchanges')
-  const paneFooterDocumentStatusPulse = page.getByTestId('pane-footer-document-status-pulse')
   const paneFooterDocumentStatus = page.getByTestId('pane-footer-document-status')
 
   await titleInput.fill('This is a book')
-  // Wait for the document to finish saving
-  await expect(paneFooterDocumentStatusPulse).toBeHidden()
+  // Wait for the document to actually finish saving before asserting the publish
+  // button is enabled. Waiting for the status-pulse to be hidden is racy: the
+  // pulse element is absent (and therefore "hidden") in the window *before* the
+  // first sync starts, so that wait can resolve before the draft has been
+  // persisted, leaving the publish button disabled with reason NO_CHANGES.
+  // The status line only shows "Created"/"Edited" once syncing has settled and
+  // the draft has unsaved-then-saved changes, which is the real precondition for
+  // the button becoming enabled.
+  await expectCreatedOrEditedStatus(paneFooterDocumentStatus)
 
   // Wait for the document to be publishable
   await expect(publishButton).toBeEnabled({timeout: 30_000})
@@ -69,12 +79,14 @@ test(`displays the published document state after discarding changes`, async ({
   const actionMenuButton = page.getByTestId('action-menu-button')
   const discardChangesButton = page.getByTestId('action-Discardchanges')
   const confirmButton = page.getByTestId('confirm-button')
-  const paneFooterDocumentStatusPulse = page.getByTestId('pane-footer-document-status-pulse')
   const paneFooterDocumentStatus = page.getByTestId('pane-footer-document-status')
 
   await titleInput.fill('This is a book')
-  // Wait for the document to finish saving
-  await expect(paneFooterDocumentStatusPulse).toBeHidden()
+  // Wait for the document to actually finish saving before asserting the publish
+  // button is enabled. See the sibling test above for why the status-pulse
+  // `toBeHidden()` wait is racy; the status line reaching "Created"/"Edited" is
+  // the real "saved" signal.
+  await expectCreatedOrEditedStatus(paneFooterDocumentStatus)
 
   // Wait for the document to be publishable
   await expect(publishButton).toBeEnabled()
@@ -84,8 +96,9 @@ test(`displays the published document state after discarding changes`, async ({
 
   // Change the title.
   await titleInput.fill('This is not a book')
-  // Wait for the document to finish saving
-  await expect(paneFooterDocumentStatusPulse).toBeHidden()
+  // Wait for the edit to finish saving. The document now has a published version,
+  // so the status line shows "Edited" once the draft change has been persisted.
+  await expectEditedStatus(paneFooterDocumentStatus)
 
   // Discard the change.
   await actionMenuButton.click()

--- a/e2e/tests/document-actions/publish.spec.ts
+++ b/e2e/tests/document-actions/publish.spec.ts
@@ -30,6 +30,12 @@ test(`document panel displays correct title for published document`, async ({
   const isMac = await page.evaluate(() => /Mac|iPod|iPhone|iPad/.test(navigator.platform || ''))
   await expect(hotkeys).toHaveText(isMac ? 'CtrlOptionP' : 'CtrlAltP')
 
+  // Wait for the draft to finish saving before publishing. Clicking publish
+  // while the draft is still syncing leaves the button disabled (NO_CHANGES /
+  // NOT_READY); under backend load that can exceed the action timeout and flake.
+  // The status line reaching "Created"/"Edited" is the canonical saved signal.
+  await expectCreatedStatus(page.getByTestId('pane-footer-document-status'))
+
   // Wait for the document to be published.
   await page.getByTestId('action-publish').click()
   await expectPublishedStatus(page.getByTestId('pane-footer-document-status'))

--- a/e2e/tests/navbar/search.spec.ts
+++ b/e2e/tests/navbar/search.spec.ts
@@ -41,15 +41,44 @@ test('searching creates unique saved searches', async ({
   const searchInput = page.getByPlaceholder('Search', {exact: true})
   const searchResults = page.getByTestId('search-results')
 
-  // Helper to perform a search and click a result
+  // Helper to perform a search and click a result.
+  //
+  // The document is created at the start of this test and searched for
+  // immediately. The search index is eventually consistent, so the just-created
+  // document may not be returned by the first query even though the write has
+  // completed. Rather than rely on Playwright's whole-test retry to mask this,
+  // re-issue the query (clear + re-type) until the expected option appears. This
+  // awaits the real precondition (the document has become searchable) without
+  // changing what the test asserts.
   async function performSearch(query: string, optionName: string) {
     await expect(studioSearch).toBeVisible()
     await studioSearch.click({force: true})
     await expect(searchInput).toBeVisible()
-    await searchInput.fill(query)
-    await expect(searchResults).toBeVisible()
+
     const option = searchResults.getByRole('option', {name: optionName}).first()
-    await expect(option).toBeVisible()
+    const perAttemptTimeout = 10_000
+    const maxAttempts = 6
+
+    // oxlint-disable no-await-in-loop -- sequential index-lag retry is intentional
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      await searchInput.fill('')
+      await searchInput.fill(query)
+      await expect(searchResults).toBeVisible()
+
+      const appeared = await option
+        .waitFor({state: 'visible', timeout: perAttemptTimeout})
+        .then(() => true)
+        .catch(() => false)
+
+      if (appeared) break
+
+      if (attempt === maxAttempts) {
+        // Surface a normal assertion failure with the usual diagnostics.
+        await expect(option).toBeVisible()
+      }
+    }
+    // oxlint-enable no-await-in-loop
+
     await option.click({force: true})
     // Wait for search dialog to close
     await expect(searchResults).not.toBeVisible()

--- a/e2e/tests/presentation/presentation.spec.ts
+++ b/e2e/tests/presentation/presentation.spec.ts
@@ -19,9 +19,18 @@ test.describe('Presentation', () => {
 
     const previewIframeContents = previewIframe.first().contentFrame()
 
-    // Wait for the visual editing component to be ready inside the iframe
-    // This ensures the React app has hydrated and the useEffect has run
-    await expect(previewIframeContents.locator('sanity-visual-editing')).toBeAttached()
+    // Wait for the visual editing component to be ready inside the iframe.
+    // This ensures the React app has hydrated and the useEffect has run.
+    //
+    // The preview iframe boots a *separate* application (the visual-editing
+    // overlay) that must download, hydrate and register its custom element. On a
+    // cold Firefox worker under CI load this legitimately takes longer than the
+    // default 30s, producing a first-attempt timeout that passes on retry once
+    // the worker is warm. Give the slow-but-correct boot more headroom rather
+    // than relying on Playwright's retry to mask it. The assertion is unchanged.
+    await expect(previewIframeContents.locator('sanity-visual-editing')).toBeAttached({
+      timeout: 60_000,
+    })
   })
 
   test('should be able to toggle preview viewport', async ({page, browserName}) => {

--- a/e2e/tests/validation-test/validation.spec.ts
+++ b/e2e/tests/validation-test/validation.spec.ts
@@ -64,10 +64,15 @@ test.describe('Validation test', () => {
 
       await expect(arrayItemMenuButton).toBeVisible()
       await expect(arrayItemMenuButton).toBeEnabled()
+      // Opening the array-row context menu is slow-but-correct on a cold Firefox
+      // worker under CI load: the default 5s-per-attempt window expired before
+      // the menu rendered, producing a first-attempt failure that passed on
+      // retry. Give the menu more time to appear per attempt instead.
       await retryingClickUntilVisible(
         page,
         arrayItemMenuButton,
         page.getByRole('menuitem', {name: 'Remove'}),
+        {perAttemptTimeout: 15_000},
       )
       const removeMenuItem = page.getByRole('menuitem', {name: 'Remove'})
       await expect(removeMenuItem).toBeEnabled()
@@ -159,10 +164,12 @@ test.describe('Validation test', () => {
       const firstMenuButton = arrayItemMenuButton.first()
       await expect(firstMenuButton).toBeVisible()
       await expect(firstMenuButton).toBeEnabled()
+      // See note above: give the slow Firefox menu-open more time per attempt.
       await retryingClickUntilVisible(
         page,
         firstMenuButton,
         page.getByRole('menuitem', {name: 'Remove'}),
+        {perAttemptTimeout: 15_000},
       )
       const removeMenuItem = page.getByRole('menuitem', {name: 'Remove'})
       await expect(removeMenuItem).toBeEnabled()
@@ -232,10 +239,12 @@ test.describe('Validation test', () => {
       const arrayItemMenuButton = arrayItemMenuButtons.first()
       await expect(arrayItemMenuButton).toBeVisible()
       await expect(arrayItemMenuButton).toBeEnabled()
+      // See note above: give the slow Firefox menu-open more time per attempt.
       await retryingClickUntilVisible(
         page,
         arrayItemMenuButton,
         page.getByRole('menuitem', {name: 'Remove'}),
+        {perAttemptTimeout: 15_000},
       )
       const removeMenuItem = page.getByRole('menuitem', {name: 'Remove'})
       await expect(removeMenuItem).toBeEnabled()

--- a/e2e/tests/validation-test/validation.spec.ts
+++ b/e2e/tests/validation-test/validation.spec.ts
@@ -64,15 +64,10 @@ test.describe('Validation test', () => {
 
       await expect(arrayItemMenuButton).toBeVisible()
       await expect(arrayItemMenuButton).toBeEnabled()
-      // Opening the array-row context menu is slow-but-correct on a cold Firefox
-      // worker under CI load: the default 5s-per-attempt window expired before
-      // the menu rendered, producing a first-attempt failure that passed on
-      // retry. Give the menu more time to appear per attempt instead.
       await retryingClickUntilVisible(
         page,
         arrayItemMenuButton,
         page.getByRole('menuitem', {name: 'Remove'}),
-        {perAttemptTimeout: 15_000},
       )
       const removeMenuItem = page.getByRole('menuitem', {name: 'Remove'})
       await expect(removeMenuItem).toBeEnabled()
@@ -164,12 +159,10 @@ test.describe('Validation test', () => {
       const firstMenuButton = arrayItemMenuButton.first()
       await expect(firstMenuButton).toBeVisible()
       await expect(firstMenuButton).toBeEnabled()
-      // See note above: give the slow Firefox menu-open more time per attempt.
       await retryingClickUntilVisible(
         page,
         firstMenuButton,
         page.getByRole('menuitem', {name: 'Remove'}),
-        {perAttemptTimeout: 15_000},
       )
       const removeMenuItem = page.getByRole('menuitem', {name: 'Remove'})
       await expect(removeMenuItem).toBeEnabled()
@@ -239,12 +232,10 @@ test.describe('Validation test', () => {
       const arrayItemMenuButton = arrayItemMenuButtons.first()
       await expect(arrayItemMenuButton).toBeVisible()
       await expect(arrayItemMenuButton).toBeEnabled()
-      // See note above: give the slow Firefox menu-open more time per attempt.
       await retryingClickUntilVisible(
         page,
         arrayItemMenuButton,
         page.getByRole('menuitem', {name: 'Remove'}),
-        {perAttemptTimeout: 15_000},
       )
       const removeMenuItem = page.getByRole('menuitem', {name: 'Remove'})
       await expect(removeMenuItem).toBeEnabled()


### PR DESCRIPTION
## What & why

The document-action E2E specs flake under backend load. The failures observed in CI are all timing races, not behaviour bugs:

- `expect(publishButton).toBeEnabled({timeout: 30_000})` failing with "disabled"
- `page.locator('[data-testid="form-view"]').waitFor({state:'visible'})` timing out
- `locator.fill` timing out

## Root causes (genuine races)

1. **`createDraftDocument` returned too early.** It waited for `[data-testid="form-view"]` to be visible, but `FormView` renders that element *before* the fields — while the document pair is still connecting (or `formState` is momentarily `null`), `form-view` contains only a spinner. Callers that immediately `.fill()` a field raced field mount.
2. **Racy "saved" wait in discardChanges.** The save precondition was `expect(pane-footer-document-status-pulse).toBeHidden()`. The pulse element is *absent* (hence "hidden") in the window **before** the first sync starts, so that wait can resolve before the draft is persisted — leaving the publish button disabled with reason `NO_CHANGES`.
3. **Publish clicked before save settled** in one `publish.spec` test that didn't await the saved status (its siblings already do).

## Changes (behaviour-preserving — no assertion changed, nothing skipped/removed)

- **`e2e/studio-test.ts`** — `createDraftDocument` additionally awaits the first `field-*` wrapper, which `FormBuilder` renders only once `formState !== null` and the fields are mounted. Awaits a precondition every caller already implicitly depended on.
- **`e2e/tests/document-actions/discardChanges.spec.ts`** — replaced the racy `status-pulse` `toBeHidden()` save-waits with the canonical saved-status assertions (`expectCreatedOrEditedStatus` / `expectEditedStatus`). Publish/discard assertions unchanged.
- **`e2e/tests/document-actions/publish.spec.ts`** — added `expectCreatedStatus(...)` before the publish click in the one test that lacked it.
- Additional robustness for presentation (cold-iframe boot), search (index eventual-consistency), and inline (comment-sync round trips).

Each change carries an inline rationale comment.

## Status

The document-action de-flake is complete and verified working in healthy runs. The "5 consecutive green" goal is gated on the Vercel preview deploy warmth (cold deploys flake the whole suite uniformly) and a deterministic `componentItemSmoke` i18n-array failure during cold windows — both tracked as infra follow-ups. Left as a draft.
