### PR TITLE
refactor(portable-text): migrate off legacy `pt-*` classes to native `data-pt-*` attributes

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
@@ -119,15 +119,10 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $isOneLine:
     padding-bottom: ${({$isFullscreen, $isOneLine, theme}) =>
       $isOneLine ? '0' : theme.sanity.space[$isFullscreen ? 9 : 5]}px;
 
-    & > .pt-block {
+    & > [data-pt-block] {
       margin: 0 auto;
       max-width: ${(props) => getTheme_v2(props.theme).container[1]}px;
     }
-
-    /* & > .pt-block {
-      & .pt-inline-object {
-      }
-    } */
 
     & .pt-drop-indicator {
       pointer-events: none;

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/DragAndDrop.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/DragAndDrop.browser.test.tsx
@@ -58,11 +58,11 @@ describe('Portable Text Input', () => {
       await getFocusedPortableTextEditor('field-body')
 
       // Drag and drop the 'Hello world' block to the position of 'Baz'
-      await dragAndDrop('.pt-editable [draggable="true"]', '.pt-block.pt-text-block:nth-child(3)')
+      await dragAndDrop('.pt-editable [draggable="true"]', '[data-pt-block="text"]:nth-child(3)')
 
       // NOTE: `document` is shadowed by the SanityDocument fixture above, so
       // reach for the DOM via `window.document`.
-      const fourthBlock = window.document.querySelector('.pt-block:nth-child(4)')
+      const fourthBlock = window.document.querySelector('[data-pt-block]:nth-child(4)')
       expect(fourthBlock?.textContent).toContain('Baz')
     })
 
@@ -81,7 +81,7 @@ describe('Portable Text Input', () => {
       // Drag and drop the 'Hello world' block to the position of 'Baz' without dropping it
       await dragWithoutDrop(
         '.pt-editable [draggable="true"]',
-        '.pt-block.pt-text-block:nth-child(3)',
+        '[data-pt-block="text"]:nth-child(3)',
       )
 
       // The "can't upload" warning is only shown for external file drags, never

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/NestedInput.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/NestedInput.browser.test.tsx
@@ -26,7 +26,7 @@ describe('Portable Text Input', () => {
       await expect.element($dialog).toBeVisible()
 
       // Assertion: Object preview should be visible in the main editor
-      const inlineObject = $portableTextInput.element().querySelector('.pt-inline-object')
+      const inlineObject = $portableTextInput.element().querySelector('[data-pt-inline="object"]')
       expect(inlineObject).toBeTruthy()
 
       // Find the nested portable text input within the dialog


### PR DESCRIPTION
### Description

PTE exposes native `data-pt-*` attributes for Portable Text structure (`data-pt-block`, `data-pt-inline`, …). They are the intended, stable hook for styling and querying the editor DOM, so Studio should prefer them over CSS classes.

Migrate the editor's block containment and the PT input test selectors to the attributes:

- block containment → `& > [data-pt-block]`
- test selectors → `[data-pt-block]` / `[data-pt-block="text"]` / `[data-pt-inline="object"]`

Each attribute is on the same element as the class it replaces, so this is behaviour-neutral.

### What to review

`Editor.styles.tsx` (block containment) and two PT input test files. Drag-and-drop layout tests pass unchanged.

### Testing

`pnpm test:browser` for the PT input (drag-and-drop, nested input) green.

### Notes for release

N/A – Internal.
