### PR TITLE
fix(comments): submit the editor's live value, not the debounced draft

### DIFF
--- a/packages/sanity/src/core/comments/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/core/comments/components/list/CommentsListItem.tsx
@@ -155,9 +155,9 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
   const handleMouseEnter = () => setMouseOver(true)
   const handleMouseLeave = () => setMouseOver(false)
 
-  const handleReplySubmit = () => {
+  const handleReplySubmit = (nextValue: CommentMessage) => {
     const nextComment: CommentBaseCreatePayload = {
-      message: value,
+      message: nextValue,
       parentCommentId: parentComment._id,
       status: parentComment?.status || 'open',
       // Since this is a reply to an existing comment, we use the same thread ID as the parent

--- a/packages/sanity/src/core/comments/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/core/comments/components/list/CommentsListItemLayout.tsx
@@ -296,10 +296,13 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
     [_id, onReactionSelect],
   )
 
-  const handleEditSubmit = useCallback(() => {
-    onEdit(_id, {message: value})
-    setIsEditing(false)
-  }, [_id, onEdit, value])
+  const handleEditSubmit = useCallback(
+    (nextValue: CommentMessage) => {
+      onEdit(_id, {message: nextValue})
+      setIsEditing(false)
+    },
+    [_id, onEdit],
+  )
 
   const handleOpenStatusChange = useCallback(() => {
     onStatusChange?.(_id, comment.status === 'open' ? 'resolved' : 'open')

--- a/packages/sanity/src/core/comments/components/list/CreateNewThreadInput.tsx
+++ b/packages/sanity/src/core/comments/components/list/CreateNewThreadInput.tsx
@@ -39,10 +39,13 @@ export function CreateNewThreadInput(props: CreateNewThreadInputProps) {
   const [value, setValue] = useState<CommentMessage>(EMPTY_PT_ARRAY)
   const commentInputHandle = useRef<CommentInputHandle | null>(null)
 
-  const handleSubmit = useCallback(() => {
-    onNewThreadCreate?.(value)
-    setValue(EMPTY_PT_ARRAY)
-  }, [onNewThreadCreate, value])
+  const handleSubmit = useCallback(
+    (nextValue: CommentMessage) => {
+      onNewThreadCreate?.(nextValue)
+      setValue(EMPTY_PT_ARRAY)
+    },
+    [onNewThreadCreate],
+  )
 
   const hasValue = useMemo(() => hasCommentMessageValue(value), [value])
 

--- a/packages/sanity/src/core/comments/components/pte/comment-input/CommentInput.tsx
+++ b/packages/sanity/src/core/comments/components/pte/comment-input/CommentInput.tsx
@@ -1,13 +1,13 @@
 import {
+  type Editor,
   type EditorEmittedEvent,
   EditorProvider,
   keyGenerator,
-  PortableTextEditor,
   type RenderBlockFunction,
   useEditor,
-  usePortableTextEditor,
 } from '@portabletext/editor'
 import {EventListenerPlugin} from '@portabletext/editor/plugins'
+import {getValue} from '@portabletext/editor/selectors'
 import {OneLinePlugin} from '@portabletext/plugin-one-line'
 import {sanitySchemaToPortableTextSchema} from '@portabletext/sanity-bridge'
 import {type CurrentUser, type PortableTextBlock} from '@sanity/types'
@@ -35,13 +35,12 @@ import {CommentInputProvider} from './CommentInputProvider'
 
 /**
  * `EditorProvider` doesn't have a `ref` prop. This plugin takes care of
- * imperatively forwarding the ref.
+ * imperatively forwarding the editor instance.
  */
-const EditorRefPlugin = forwardRef<PortableTextEditor | null>(function EditorRefPlugin(_, ref) {
-  const portableTextEditor = usePortableTextEditor()
-  const portableTextEditorRef = useRef(portableTextEditor)
+const EditorRefPlugin = forwardRef<Editor | null>(function EditorRefPlugin(_, ref) {
+  const editor = useEditor()
 
-  useImperativeHandle(ref, () => portableTextEditorRef.current, [])
+  useImperativeHandle(ref, () => editor, [editor])
 
   return null
 })
@@ -71,7 +70,7 @@ export interface CommentInputProps {
   onFocus?: (e: FormEvent<HTMLDivElement>) => void
   onKeyDown?: (e: KeyboardEvent) => void
   onMentionMenuOpenChange?: (open: boolean) => void
-  onSubmit?: () => void
+  onSubmit?: (value: PortableTextBlock[]) => void
   placeholder?: ReactNode
   readOnly?: boolean
   renderBlock?: RenderBlockFunction
@@ -124,7 +123,7 @@ export const CommentInput = forwardRef<CommentInputHandle, CommentInputProps>(
       withAvatar = true,
     } = props
     const [focused, setFocused] = useState<boolean>(false)
-    const editorRef = useRef<PortableTextEditor | null>(null)
+    const editorRef = useRef<Editor | null>(null)
     const editorContainerRef = useRef<HTMLDivElement | null>(null)
     const [showDiscardDialog, setShowDiscardDialog] = useState<boolean>(false)
 
@@ -137,8 +136,7 @@ export const CommentInput = forwardRef<CommentInputHandle, CommentInputProps>(
 
     const requestFocus = useCallback(() => {
       requestAnimationFrame(() => {
-        if (!editorRef.current) return
-        PortableTextEditor.focus(editorRef.current)
+        editorRef.current?.send({type: 'focus'})
       })
     }, [])
 
@@ -175,7 +173,14 @@ export const CommentInput = forwardRef<CommentInputHandle, CommentInputProps>(
     }, [])
 
     const handleSubmit = useCallback(() => {
-      onSubmit?.()
+      // Read the editor's live value directly rather than the value mirrored
+      // through the debounced `mutation` event, which can lag the latest
+      // keystrokes by up to the flush interval and truncate the comment when
+      // the user submits without pausing.
+      const currentValue = editorRef.current
+        ? getValue(editorRef.current.getSnapshot())
+        : EMPTY_ARRAY
+      onSubmit?.(currentValue)
       resetEditorInstance()
       requestFocus()
       scrollToEditor()
@@ -205,9 +210,7 @@ export const CommentInput = forwardRef<CommentInputHandle, CommentInputProps>(
       return {
         focus: requestFocus,
         blur() {
-          if (editorRef.current) {
-            PortableTextEditor.blur(editorRef.current)
-          }
+          editorRef.current?.send({type: 'blur'})
         },
         scrollTo: scrollToEditor,
         reset: resetEditorInstance,

--- a/packages/sanity/src/core/comments/plugin/field/CommentsField.tsx
+++ b/packages/sanity/src/core/comments/plugin/field/CommentsField.tsx
@@ -222,58 +222,60 @@ function CommentFieldInner(
     upsellData,
   ])
 
-  const handleCommentAdd = useCallback(() => {
-    if (value) {
-      // Since this is a new comment, we generate a new thread ID
-      const newThreadId = uuid()
+  const handleCommentAdd = useCallback(
+    (nextValue: PortableTextBlock[]) => {
+      if (nextValue) {
+        // Since this is a new comment, we generate a new thread ID
+        const newThreadId = uuid()
 
-      // Construct the comment payload
-      const nextComment: CommentCreatePayload = {
-        type: 'field',
-        fieldPath: PathUtils.toString(props.path),
-        message: value,
-        parentCommentId: undefined,
-        status: 'open',
-        threadId: newThreadId,
-        // New comments have no reactions
-        reactions: EMPTY_ARRAY,
+        // Construct the comment payload
+        const nextComment: CommentCreatePayload = {
+          type: 'field',
+          fieldPath: PathUtils.toString(props.path),
+          message: nextValue,
+          parentCommentId: undefined,
+          status: 'open',
+          threadId: newThreadId,
+          // New comments have no reactions
+          reactions: EMPTY_ARRAY,
+        }
+
+        // Execute the create mutation
+        void operation.create(nextComment)
+
+        // If a comment is added to a field when viewing resolved comments, we switch
+        // to open comments and scroll to the comment that was just added
+        // Open the inspector when a new comment is added
+        onCommentsOpen?.()
+
+        if (status === 'resolved') {
+          // Set the status to 'open' so that the comment is visible
+          setStatus('open')
+        }
+
+        resetMessageValue()
+
+        // Scroll to the thread
+        setSelectedPath({
+          threadId: newThreadId,
+          origin: 'form',
+          fieldPath: PathUtils.toString(props.path),
+        })
+
+        scrollToGroup(newThreadId)
       }
-
-      // Execute the create mutation
-      void operation.create(nextComment)
-
-      // If a comment is added to a field when viewing resolved comments, we switch
-      // to open comments and scroll to the comment that was just added
-      // Open the inspector when a new comment is added
-      onCommentsOpen?.()
-
-      if (status === 'resolved') {
-        // Set the status to 'open' so that the comment is visible
-        setStatus('open')
-      }
-
-      resetMessageValue()
-
-      // Scroll to the thread
-      setSelectedPath({
-        threadId: newThreadId,
-        origin: 'form',
-        fieldPath: PathUtils.toString(props.path),
-      })
-
-      scrollToGroup(newThreadId)
-    }
-  }, [
-    onCommentsOpen,
-    operation,
-    props.path,
-    resetMessageValue,
-    scrollToGroup,
-    setSelectedPath,
-    setStatus,
-    status,
-    value,
-  ])
+    },
+    [
+      onCommentsOpen,
+      operation,
+      props.path,
+      resetMessageValue,
+      scrollToGroup,
+      setSelectedPath,
+      setStatus,
+      status,
+    ],
+  )
 
   const handleClose = useCallback(() => setAuthoringPath(null), [setAuthoringPath])
 

--- a/packages/sanity/src/core/comments/plugin/field/CommentsFieldButton.tsx
+++ b/packages/sanity/src/core/comments/plugin/field/CommentsFieldButton.tsx
@@ -33,7 +33,7 @@ interface CommentsFieldButtonProps {
   onChange: (value: PortableTextBlock[]) => void
   onClick?: () => void
   onClose: () => void
-  onCommentAdd: () => void
+  onCommentAdd: (value: PortableTextBlock[]) => void
   onDiscard: () => void
   onInputKeyDown?: (event: React.KeyboardEvent) => void
   open: boolean
@@ -71,10 +71,13 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
     addCommentButtonElement?.focus()
   }, [addCommentButtonElement, open, onClose])
 
-  const handleSubmit = useCallback(() => {
-    onCommentAdd()
-    closePopover()
-  }, [closePopover, onCommentAdd])
+  const handleSubmit = useCallback(
+    (nextValue: PortableTextBlock[]) => {
+      onCommentAdd(nextValue)
+      closePopover()
+    },
+    [closePopover, onCommentAdd],
+  )
 
   const hasValue = useMemo(() => hasCommentMessageValue(value), [value])
 

--- a/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
+++ b/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
@@ -157,65 +157,67 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
       .map((c) => c.parentComment)
   }, [comments.data.open, stringFieldPath])
 
-  const handleSubmit = useCallback(() => {
-    if (!nextCommentSelection || !editorRef.current) return
+  const handleSubmit = useCallback(
+    (nextValue: CommentMessage) => {
+      if (!nextCommentSelection || !editorRef.current) return
 
-    const editorValue = PortableTextEditor.getValue(editorRef.current)
+      const editorValue = PortableTextEditor.getValue(editorRef.current)
 
-    if (!editorValue) return
+      if (!editorValue) return
 
-    const textSelection = buildTextSelectionFromFragment({
-      fragment: fragment || EMPTY_ARRAY,
-      selection: nextCommentSelection,
-      value: editorValue,
-    })
+      const textSelection = buildTextSelectionFromFragment({
+        fragment: fragment || EMPTY_ARRAY,
+        selection: nextCommentSelection,
+        value: editorValue,
+      })
 
-    const threadId = uuid()
+      const threadId = uuid()
 
-    void operation.create({
-      type: 'field',
-      contentSnapshot: fragment,
-      fieldPath: stringFieldPath,
-      message: nextCommentValue,
-      parentCommentId: undefined,
-      reactions: EMPTY_ARRAY,
-      selection: textSelection,
-      status: 'open',
-      threadId,
-    })
+      void operation.create({
+        type: 'field',
+        contentSnapshot: fragment,
+        fieldPath: stringFieldPath,
+        message: nextValue,
+        parentCommentId: undefined,
+        reactions: EMPTY_ARRAY,
+        selection: textSelection,
+        status: 'open',
+        threadId,
+      })
 
-    // Open the inspector when a new comment is added
-    onCommentsOpen?.()
+      // Open the inspector when a new comment is added
+      onCommentsOpen?.()
 
-    // Set the status to 'open' so that the comment is visible
-    if (status === 'resolved') {
-      setStatus('open')
-    }
+      // Set the status to 'open' so that the comment is visible
+      if (status === 'resolved') {
+        setStatus('open')
+      }
 
-    // Set the selected path to the new comment
-    setSelectedPath({
-      fieldPath: stringFieldPath,
-      threadId,
-      origin: 'form',
-    })
+      // Set the selected path to the new comment
+      setSelectedPath({
+        fieldPath: stringFieldPath,
+        threadId,
+        origin: 'form',
+      })
 
-    // Scroll to the comment
-    scrollToGroup(threadId)
+      // Scroll to the comment
+      scrollToGroup(threadId)
 
-    resetStates()
-  }, [
-    nextCommentSelection,
-    operation,
-    stringFieldPath,
-    nextCommentValue,
-    onCommentsOpen,
-    status,
-    setSelectedPath,
-    scrollToGroup,
-    resetStates,
-    setStatus,
-    fragment,
-  ])
+      resetStates()
+    },
+    [
+      nextCommentSelection,
+      operation,
+      stringFieldPath,
+      onCommentsOpen,
+      status,
+      setSelectedPath,
+      scrollToGroup,
+      resetStates,
+      setStatus,
+      fragment,
+    ],
+  )
 
   const handleDecoratorClick = useCallback(
     (commentId: string) => {


### PR DESCRIPTION
### Description

Fixes [EDEX-1300](https://linear.app/sanity/issue/EDEX-1300/portable-text-comments-get-truncated-when-added-after-rapid-typing): comments get silently truncated when submitted mid-typing.

The comment input tracked its draft from the editor's `mutation` event, which `@portabletext/editor` flushes on a 1s interval (the eager per-keystroke flush is gated behind a 250ms typing debounce that continuous typing keeps resetting). So the keystrokes since the last tick live only in the editor, and submitting in that window persists the stale, truncated draft. This is the observable cost of [`4a95498`](https://github.com/sanity-io/sanity/commit/4a9549804b95acc3f9303adf55fe9a4c3528fee5), which moved draft tracking from the instant `patch` event to the debounced `mutation` event for a normalized value.

Submit now reads the editor's live value via `getValue(editor.getSnapshot())` instead of the lagging mirror, threaded through `onSubmit(value)` to the five submit handlers. The snapshot value is still the normalized working value, so that commit's guarantee holds. Reading off the non-deprecated API means `editorRef` holds the `useEditor()` instance, so `focus`/`blur` move to `editor.send(...)`.

### What to review

Type a sentence into a comment without pausing, submit with Enter and with the button: the saved comment should match, and reopening shouldn't pre-fill a truncated draft. Covers all four surfaces (new thread, reply, edit, inline).

### Testing

Manual, per above. Straight swap from debounced-state-at-submit to live-snapshot-at-submit; no automated coverage (existing suites assert payload shape, not submit-time freshness against the flush cadence).

### Notes for release

Fixes a bug where a comment could be silently truncated when submitted during fast, uninterrupted typing, dropping the characters typed just before it was saved.
