### PR TITLE
test(e2e): target internationalized array value input by "Value" label

### DIFF
--- a/e2e/tests/enhanced-object-dialog/componentItemSmoke.spec.ts
+++ b/e2e/tests/enhanced-object-dialog/componentItemSmoke.spec.ts
@@ -23,10 +23,9 @@ test.describe('Enhanced Object Dialog - schema with component item and input smo
   test(`opening - when clicking the internationalized array string field, the modal should not open`, async ({
     page,
   }) => {
-    // In sanity-plugin-internationalized-array v5, item `_key`s are random (the
-    // language lives in a dedicated `language` field), so target the value
-    // input by its language label instead of a hardcoded `_key`
-    const input = page.getByTestId('field-greeting').getByRole('textbox', {name: 'EN'})
+    // The value input renders outside the field wrapper and item keys are
+    // random, so match it by its unique "Value" label at page scope.
+    const input = page.getByRole('textbox', {name: 'Value'})
     await expect(input).toBeEnabled()
     await input.click()
     await expect(page.getByTestId('nested-object-dialog')).not.toBeVisible()
@@ -39,7 +38,7 @@ test.describe('Enhanced Object Dialog - schema with component item and input smo
     page,
   }) => {
     const greetingField = page.getByTestId('field-greeting')
-    const input = greetingField.getByRole('textbox', {name: 'EN'})
+    const input = page.getByRole('textbox', {name: 'Value'})
     await expect(input).toBeVisible()
     await expect(input).toBeEnabled()
     await input.click()
@@ -49,7 +48,8 @@ test.describe('Enhanced Object Dialog - schema with component item and input smo
     await greetingField.getByRole('button', {name: 'FR'}).click()
     await expect(page.getByTestId('nested-object-dialog')).not.toBeVisible()
 
-    const inputFr = greetingField.getByRole('textbox', {name: 'FR'})
+    // Adding FR yields a second "Value" input; `.last()` selects it.
+    const inputFr = page.getByRole('textbox', {name: 'Value'}).last()
     await expect(inputFr).toBeVisible()
     await expect(inputFr).toBeEnabled()
     await inputFr.click()


### PR DESCRIPTION
### Description

E2E has been red on `main` (and every PR branched from it) since shortly after #13016. `enhanced-object-dialog/componentItemSmoke.spec.ts:23` and `:38` fail deterministically in both chromium and firefox with `element(s) not found` for `getByTestId('field-greeting').getByRole('textbox', {name: 'EN'})`.

**Root cause: floating-caret plugin DOM drift, not a product regression.** #13016 fixed these locators for `sanity-plugin-internationalized-array` v5 and merged fully green on **5.1.3**. The test studio depends on `^5.1.4`, so CI auto-upgraded to a later patch (5.1.6+) whose rendering changed: the language codes (`EN`/`FR`) are now **buttons**, and the active language's value input is a `textbox` labelled **"Value"**. The old name-based locator no longer matches anything, and the tests fail before reaching their "modal should not open" assertions.

This targets the value input by its `"Value"` label instead. The second test adds FR and reads `.last()`, which resolves the FR input whether the plugin appends a second `"Value"` textbox or swaps the active one.

### What to review

- `e2e/tests/enhanced-object-dialog/componentItemSmoke.spec.ts` — locators only; behaviour and assertions unchanged.

### Testing

- Validated the locator strategy against the failing run's `error-context.md` DOM snapshot (accessibility tree shows `button "EN"`, `button "FR"`, and `textbox "Value"` inside the Greeting field).
- E2E secrets aren't available locally, so final confirmation is via CI on this PR. **Draft** until the `playwright-test (chromium|firefox, 2, 4)` shards go green; the `.last()` assumption for the FR input is the one thing only CI can confirm.

### Follow-up (not in this PR)

The deeper issue is the floating `^5.1.4` range letting the plugin's test-relevant DOM drift on patch releases with no Sanity-side change. Worth pinning `sanity-plugin-internationalized-array` (or gating its renovate bumps on green e2e) so this can't silently reoccur.

### Notes for release

N/A – internal (e2e test only).
