### PR TITLE
feat(variants): show variant documents on detail page

### DIFF
--- a/packages/sanity/src/core/variants/README.md
+++ b/packages/sanity/src/core/variants/README.md
@@ -140,24 +140,24 @@ Covered behavior:
 - back navigation
 - read-only title, description, and condition summary
 - edit dialog
-- placeholder documents table
+- documents table wired to variant membership
 - footer with creation status and a detail-specific actions menu
 
 The detail actions menu is separate from the overview row menu. This is intentional because the two menus are expected to diverge as the detail page gains more actions.
 
-## Documents Table Placeholder
+## Documents Table
 
-`tool/detail/VariantDocumentsTable.tsx` is a placeholder for the future list of documents that belong to a variant.
+`tool/detail/VariantDocumentsTable.tsx` lists documents that belong to a variant.
 
-It currently receives an empty `SanityDocument[]`, but it already follows the release table layout:
+Data flow:
 
-- `Version` column placeholder
-- document type column
-- document preview/search column
-- edited date column
-- empty state
+- `useVariantDocuments(variantId)` fetches a flat list of variant-scoped document versions via `_system.variant._ref == $variantId`
+- `groupVariantDocumentsByGroup()` optionally groups that flat list into one row per document group
+- the table renders bundle chips, type, preview, and edited columns using the shared releases table component
 
-Pending work is to connect this to the real source of documents for a variant.
+To revert to one row per document version, pass the flat `useVariantDocuments()` results directly to the table and switch `rowId` from `groupId` to `document._id`.
+
+There is a tracked TODO to replace the fallback GROQ filter with `sanity::partOfVariant($variantId)` when the native function ships.
 
 ## Footer
 
@@ -170,7 +170,7 @@ Covered behavior:
 - detail-specific menu button
 - delete action navigates back to the overview after success
 
-The delete action currently does not confirm or check whether the variant has documents. That is pending until variant membership is implemented.
+The delete action currently does not confirm or check whether the variant has documents.
 
 ## Test Coverage
 
@@ -223,7 +223,7 @@ Local browser execution has previously hit `EMFILE: too many open files, watch` 
 ## Pending Work
 
 - Drop the local `SanityClientWithVariantsActions` typing wrapper once `@sanity/client` exports the variant definition action types.
-- Wire the detail documents table to the real list of documents that belong to a variant.
+- Replace `_system.variant._ref` document membership queries with `sanity::partOfVariant($variantId)`.
 - Decide how document counts affect deleting variants.
 - Add a delete confirmation or disabled state once variants can have documents.
 - Expand the detail-specific actions menu independently from the overview row menu.

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -64,8 +64,14 @@ const variantsLocaleStrings = {
   'detail.documents.table.search-placeholder': 'Search documents',
   /** Type column header for variant document table. */
   'detail.documents.table.type': 'Type',
-  /** Version column header for variant document table. */
-  'detail.documents.table.version': 'Version',
+  /** Bundle column header for variant document table. */
+  'detail.documents.table.bundle': 'Bundle',
+  /** Validation error tooltip for a single error in the variant document table. */
+  'detail.documents.table.validation.error_one': '{{count}} validation error',
+  /** Validation error tooltip for multiple errors in the variant document table. */
+  'detail.documents.table.validation.error_other': '{{count}} validation errors',
+  /** Error message when variant documents fail to load. */
+  'detail.documents.error': 'Unable to load documents for this variant',
   /** Description for the missing Variant detail page. */
   'detail.not-found.description': 'The requested variant could not be found.',
   /** Title for the missing Variant detail page. */

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -60,6 +60,22 @@ vi.mock('../../store/useVariantOperations', () => ({
   useVariantOperations: vi.fn(() => variantOperationsMock),
 }))
 
+vi.mock('../detail/useVariantDocuments', () => ({
+  useVariantDocuments: vi.fn(() => ({
+    loading: false,
+    results: [],
+    error: null,
+  })),
+}))
+
+vi.mock('../../../releases/store/useActiveReleases', () => ({
+  useActiveReleases: vi.fn(() => ({
+    data: [],
+    loading: false,
+    error: null,
+  })),
+}))
+
 describe('VariantDetail', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -139,7 +155,7 @@ describe('VariantDetail', () => {
     expect(screen.getByText('audience: "alpha", locale: "en-US"')).toBeInTheDocument()
     expect(screen.getByRole('button', {name: 'Edit variant'})).toBeInTheDocument()
     expect(screen.getByRole('button', {name: 'Back to variants'})).toBeInTheDocument()
-    expect(screen.getByText('Version')).toBeInTheDocument()
+    expect(screen.getByText('Bundle')).toBeInTheDocument()
     expect(screen.getByText('Type')).toBeInTheDocument()
     expect(screen.getByPlaceholderText('Search documents')).toBeInTheDocument()
     expect(screen.getByText('Edited')).toBeInTheDocument()

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -72,6 +72,10 @@ vi.mock('../../store/useVariantOperations', () => ({
   useVariantOperations: vi.fn(() => variantOperationsMock),
 }))
 
+vi.mock('../overview/useVariantDocumentGroupCounts', () => ({
+  useVariantDocumentGroupCounts: vi.fn(() => new Map()),
+}))
+
 setupVirtualListEnv()
 
 describe('VariantsOverview', () => {

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsTool.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsTool.test.tsx
@@ -54,6 +54,26 @@ vi.mock('../../store/useAllVariants', () => ({
   })),
 }))
 
+vi.mock('../overview/useVariantDocumentGroupCounts', () => ({
+  useVariantDocumentGroupCounts: vi.fn(() => new Map()),
+}))
+
+vi.mock('../detail/useVariantDocuments', () => ({
+  useVariantDocuments: vi.fn(() => ({
+    loading: false,
+    results: [],
+    error: null,
+  })),
+}))
+
+vi.mock('../../../releases/store/useActiveReleases', () => ({
+  useActiveReleases: vi.fn(() => ({
+    data: [],
+    loading: false,
+    error: null,
+  })),
+}))
+
 setupVirtualListEnv()
 
 describe('VariantsTool', () => {

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
@@ -1,11 +1,12 @@
-import {type SanityDocument} from '@sanity/client'
 import {Box, Card, Container, Flex, Stack, Text} from '@sanity/ui'
-import {useState} from 'react'
+import {useMemo, useState} from 'react'
 import {useRouter} from 'sanity/router'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {LoadingBlock} from '../../../components'
 import {useTranslation} from '../../../i18n'
+import {useActiveReleases} from '../../../releases/store/useActiveReleases'
+import {getReleaseTitleDetails} from '../../../releases/util/getReleaseTitleDetails'
 import {EditVariantDialog} from '../../components/dialog/EditVariantDialog'
 import {variantsLocaleNamespace} from '../../i18n'
 import {useAllVariants} from '../../store/useAllVariants'
@@ -15,14 +16,16 @@ import {
   getVariantDescription,
   getVariantTitle,
 } from '../util'
+import {groupVariantDocumentsByGroup} from './groupVariantDocumentsByGroup'
+import {useVariantDocuments} from './useVariantDocuments'
 import {VariantDetailFooter} from './VariantDetailFooter'
 import {VariantDocumentsTable} from './VariantDocumentsTable'
-
-const EMPTY_VARIANT_DOCUMENTS: SanityDocument[] = []
 
 export function VariantDetail() {
   const router = useRouter()
   const {t} = useTranslation(variantsLocaleNamespace)
+  const {t: tCore} = useTranslation()
+  const {data: releases} = useActiveReleases()
   const [editDialogOpen, setEditDialogOpen] = useState(false)
   const variantIdRaw =
     typeof router.state.variantId === 'string' ? router.state.variantId : undefined
@@ -30,6 +33,27 @@ export function VariantDetail() {
   const {byId, loading} = useAllVariants()
 
   const variant = variantId ? byId.get(variantId) : undefined
+  const {
+    loading: documentsLoading,
+    results: variantDocuments,
+    error: variantDocumentsError,
+  } = useVariantDocuments(variant?._id)
+
+  const getReleaseTitle = useMemo(() => {
+    const releasesById = new Map(releases.map((release) => [release._id, release]))
+    const releaseTitleFallback = tCore('release.placeholder-untitled-release')
+
+    return (releaseRef: string) => {
+      const release = releasesById.get(releaseRef)
+
+      return getReleaseTitleDetails(release?.metadata?.title, releaseTitleFallback).fullTitle
+    }
+  }, [releases, tCore])
+
+  const tableRows = useMemo(
+    () => groupVariantDocumentsByGroup(variantDocuments, getReleaseTitle),
+    [getReleaseTitle, variantDocuments],
+  )
 
   if (loading) {
     return <LoadingBlock fill title={t('detail.loading')} />
@@ -98,7 +122,15 @@ export function VariantDetail() {
           </Flex>
         </Container>
         <Flex direction="column" flex={1} overflow="hidden" style={{minHeight: 0}}>
-          <VariantDocumentsTable documents={EMPTY_VARIANT_DOCUMENTS} />
+          {variantDocumentsError ? (
+            <Box padding={4}>
+              <Text muted size={1}>
+                {t('detail.documents.error')}
+              </Text>
+            </Box>
+          ) : (
+            <VariantDocumentsTable loading={documentsLoading} rows={tableRows} />
+          )}
         </Flex>
       </Flex>
       <VariantDetailFooter variant={variant} />

--- a/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
@@ -1,130 +1,28 @@
-import {type SanityDocument} from '@sanity/client'
-import {Box, Card, Flex, Text} from '@sanity/ui'
-import {type CSSProperties, memo, useMemo, useState} from 'react'
+import {Card} from '@sanity/ui'
+import {type CSSProperties, useMemo, useState} from 'react'
 
-import {RelativeTime} from '../../../components/RelativeTime'
-import {useSchema} from '../../../hooks'
-import {type UseTranslationResponse, useTranslation} from '../../../i18n'
-import {SanityDefaultPreview} from '../../../preview/components/SanityDefaultPreview'
+import {useTranslation} from '../../../i18n'
 import {Table} from '../../../releases/tool/components/Table/Table'
-import {Headers} from '../../../releases/tool/components/Table/TableHeader'
 import {type Column} from '../../../releases/tool/components/Table/types'
 import {variantsLocaleNamespace} from '../../i18n'
-
-interface VariantDocumentRow {
-  document: SanityDocument
-}
+import {type DocumentInVariantGroup} from './types'
+import {getVariantDocumentTableColumnDefs} from './variantDocumentTable/VariantDocumentTableColumnDefs'
 
 const TABLE_CARD_STYLE: CSSProperties = {
   height: '100%',
   overflow: 'auto',
 }
 
-function getDocumentPreviewTitle(document: SanityDocument): string {
+function getDocumentPreviewTitle(document: DocumentInVariantGroup['document']): string {
   const title = document.title || document.name
 
   return typeof title === 'string' && title.trim() ? title : document._id
 }
 
-const MemoDocumentType = memo(
-  function DocumentType({type}: {type: string}) {
-    const schema = useSchema()
-    const schemaType = schema.get(type)
-
-    return <Text size={1}>{schemaType?.title || type}</Text>
-  },
-  (prev, next) => prev.type === next.type,
-)
-
-function getVariantDocumentColumnDefs(
-  t: UseTranslationResponse<'variants', undefined>['t'],
-): Column<VariantDocumentRow>[] {
-  return [
-    {
-      id: 'version',
-      width: null,
-      style: {minWidth: 100},
-      sorting: false,
-      header: (props) => (
-        <Flex {...props.headerProps} paddingY={3} sizing="border">
-          <Headers.BasicHeader text={t('detail.documents.table.version')} />
-        </Flex>
-      ),
-      cell: ({cellProps}) => (
-        <Flex align="center" {...cellProps}>
-          <Box paddingX={2}>
-            <Text muted size={1}>
-              -
-            </Text>
-          </Box>
-        </Flex>
-      ),
-    },
-    {
-      id: 'document._type',
-      width: null,
-      style: {minWidth: 100},
-      sorting: true,
-      header: (props) => (
-        <Flex {...props.headerProps} paddingY={3} sizing="border">
-          <Headers.SortHeaderButton text={t('detail.documents.table.type')} {...props} />
-        </Flex>
-      ),
-      cell: ({cellProps, datum}) => (
-        <Flex align="center" {...cellProps}>
-          <Box paddingX={2}>
-            {!datum.isLoading && <MemoDocumentType type={datum.document._type} />}
-          </Box>
-        </Flex>
-      ),
-    },
-    {
-      id: 'search',
-      width: null,
-      style: {minWidth: 'min(50%, calc(100vw - 80px))', maxWidth: 'min(50%, calc(100vw - 80px))'},
-      sortTransform: ({document}) => getDocumentPreviewTitle(document).toLowerCase(),
-      header: (props) => (
-        <Headers.TableHeaderSearch
-          {...props}
-          placeholder={t('detail.documents.table.search-placeholder')}
-        />
-      ),
-      cell: ({cellProps, datum}) => (
-        <Box {...cellProps} flex={1} padding={1} paddingRight={2} sizing="border">
-          {datum.isLoading ? (
-            <SanityDefaultPreview isPlaceholder />
-          ) : (
-            <SanityDefaultPreview
-              title={getDocumentPreviewTitle(datum.document)}
-              subtitle={datum.document._id}
-            />
-          )}
-        </Box>
-      ),
-    },
-    {
-      id: 'document._updatedAt',
-      sorting: true,
-      width: 130,
-      header: (props) => (
-        <Flex {...props.headerProps} paddingY={3} sizing="border">
-          <Headers.SortHeaderButton text={t('detail.documents.table.edited')} {...props} />
-        </Flex>
-      ),
-      cell: ({cellProps, datum}) => (
-        <Flex {...cellProps} align="center" paddingX={2} paddingY={3} style={{minWidth: 130}}>
-          {!datum.isLoading && datum.document._updatedAt && (
-            <Text muted size={1}>
-              <RelativeTime time={datum.document._updatedAt} useTemporalPhrase minimal />
-            </Text>
-          )}
-        </Flex>
-      ),
-    },
-  ]
-}
-
-function filterDocuments(rows: VariantDocumentRow[], searchTerm: string): VariantDocumentRow[] {
+function filterDocuments(
+  rows: DocumentInVariantGroup[],
+  searchTerm: string,
+): DocumentInVariantGroup[] {
   const normalizedSearchTerm = searchTerm.trim().toLowerCase()
 
   if (!normalizedSearchTerm) {
@@ -139,24 +37,29 @@ function filterDocuments(rows: VariantDocumentRow[], searchTerm: string): Varian
 }
 
 export function VariantDocumentsTable({
-  documents,
+  rows,
+  loading = false,
 }: {
-  documents: SanityDocument[]
+  rows: DocumentInVariantGroup[]
+  loading?: boolean
 }): React.JSX.Element {
   const {t} = useTranslation(variantsLocaleNamespace)
   const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(null)
-  const columnDefs = useMemo(() => getVariantDocumentColumnDefs(t), [t])
-  const rows = useMemo(() => documents.map((document) => ({document})), [documents])
+  const columnDefs = useMemo<Column<DocumentInVariantGroup>[]>(
+    () => getVariantDocumentTableColumnDefs(t),
+    [t],
+  )
 
   return (
     <Card flex={1} ref={setScrollContainerRef} style={TABLE_CARD_STYLE}>
-      <Table<VariantDocumentRow>
+      <Table<DocumentInVariantGroup>
         columnDefs={columnDefs}
         data={rows}
         defaultSort={{column: 'search', direction: 'asc'}}
         emptyState={t('detail.documents.no-documents')}
-        // oxlint-disable-next-line @sanity/i18n/no-attribute-string-literals
-        rowId="document._id"
+        loading={loading}
+        // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals
+        rowId="groupId"
         scrollContainerRef={scrollContainerRef}
         searchFilter={filterDocuments}
       />

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentBundleChips.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentBundleChips.test.tsx
@@ -1,0 +1,87 @@
+import {render, screen} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {type DocumentInVariantGroup} from '../types'
+import {VariantDocumentBundleChips} from '../variantDocumentTable/VariantDocumentBundleChips'
+
+vi.mock('sanity/router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  IntentLink: vi.fn(({children, ...props}) => (
+    <a data-testid="release-intent-link" {...props}>
+      {children}
+    </a>
+  )),
+}))
+
+const activeRelease = {
+  _id: '_.releases.rASAP',
+  _type: 'system.release',
+  _rev: 'rev-1',
+  _createdAt: '2025-01-01T00:00:00Z',
+  _updatedAt: '2025-01-01T00:00:00Z',
+  state: 'active',
+  metadata: {
+    title: 'Summer launch',
+    releaseType: 'asap',
+  },
+} as const
+
+vi.mock('../../../../releases/store/useActiveReleases', () => ({
+  useActiveReleases: vi.fn(() => ({
+    data: [activeRelease],
+    loading: false,
+    error: null,
+  })),
+}))
+
+const groupedRow: DocumentInVariantGroup = {
+  memoKey: 'group-1',
+  groupId: 'article-1',
+  document: {
+    _id: 'published.scope.article-1',
+    _type: 'article',
+    _rev: 'rev-1',
+    _createdAt: '2025-06-01T00:00:00Z',
+    _updatedAt: '2025-06-03T00:00:00Z',
+  },
+  version: {
+    documentId: 'published.scope.article-1',
+    bundleId: '$published',
+    releaseRef: null,
+    updatedAt: '2025-06-03T00:00:00Z',
+  },
+  versions: [
+    {
+      documentId: 'published.scope.article-1',
+      bundleId: '$published',
+      releaseRef: null,
+      updatedAt: '2025-06-03T00:00:00Z',
+    },
+    {
+      documentId: 'drafts.scope.article-1',
+      bundleId: 'drafts',
+      releaseRef: null,
+      updatedAt: '2025-06-01T00:00:00Z',
+    },
+    {
+      documentId: 'versions.rASAP.scope.article-1',
+      bundleId: 'rASAP',
+      releaseRef: '_.releases.rASAP',
+      updatedAt: '2025-06-02T00:00:00Z',
+    },
+  ],
+}
+
+describe('VariantDocumentBundleChips', () => {
+  it('renders published, draft, and linked release chips', async () => {
+    const wrapper = await createTestProvider()
+
+    render(<VariantDocumentBundleChips versions={groupedRow.versions} />, {wrapper})
+
+    expect(screen.getByText('Published')).toBeInTheDocument()
+    expect(screen.getByText('Draft')).toBeInTheDocument()
+    expect(screen.getByText('Summer launch')).toBeInTheDocument()
+    expect(screen.getByTestId('release-intent-link')).toHaveAttribute('intent', 'release')
+  })
+})

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentPreview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentPreview.test.tsx
@@ -1,0 +1,93 @@
+import {render} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {type DocumentInVariantGroup} from '../types'
+import {VariantDocumentPreview} from '../variantDocumentTable/VariantDocumentPreview'
+
+const intentLinkMock = vi.fn(({children, ...props}) => (
+  <a data-testid="edit-intent-link" {...props}>
+    {children}
+  </a>
+))
+
+vi.mock('sanity/router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  IntentLink: (props: React.ComponentProps<'a'>) => intentLinkMock(props),
+}))
+
+vi.mock('../../../../preview/components/SanityDefaultPreview', () => ({
+  SanityDefaultPreview: vi.fn(() => <div data-testid="preview" />),
+}))
+
+vi.mock('../../../../tasks/hooks/useDocumentPreviewValues', () => ({
+  useDocumentPreviewValues: vi.fn(() => ({isLoading: false, value: {title: 'Article'}})),
+}))
+
+vi.mock('../../../../store/presence/useDocumentPresence', () => ({
+  useDocumentPresence: vi.fn(() => []),
+}))
+
+const createRow = (
+  bundleId: DocumentInVariantGroup['version']['bundleId'],
+): DocumentInVariantGroup => ({
+  memoKey: 'group-1',
+  groupId: 'article-1',
+  document: {
+    _id: 'drafts.scope.article-1',
+    _type: 'article',
+    _rev: 'rev-1',
+    _createdAt: '2025-06-01T00:00:00Z',
+    _updatedAt: '2025-06-01T00:00:00Z',
+  },
+  version: {
+    documentId: 'drafts.scope.article-1',
+    bundleId,
+    releaseRef: bundleId === 'rASAP' ? '_.releases.rASAP' : null,
+    updatedAt: '2025-06-01T00:00:00Z',
+  },
+  versions: [],
+})
+
+describe('VariantDocumentPreview', () => {
+  beforeEach(() => {
+    intentLinkMock.mockClear()
+  })
+
+  it('omits perspective search params for drafts', async () => {
+    const wrapper = await createTestProvider()
+
+    render(<VariantDocumentPreview row={createRow('drafts')} />, {wrapper})
+
+    expect(intentLinkMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: 'edit',
+        searchParams: undefined,
+      }),
+    )
+  })
+
+  it('adds perspective=published for published bundle versions', async () => {
+    const wrapper = await createTestProvider()
+
+    render(<VariantDocumentPreview row={createRow('$published')} />, {wrapper})
+
+    expect(intentLinkMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        searchParams: [['perspective', 'published']],
+      }),
+    )
+  })
+
+  it('adds perspective=<releaseId> for release bundle versions', async () => {
+    const wrapper = await createTestProvider()
+
+    render(<VariantDocumentPreview row={createRow('rASAP')} />, {wrapper})
+
+    expect(intentLinkMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        searchParams: [['perspective', 'rASAP']],
+      }),
+    )
+  })
+})

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
@@ -1,4 +1,3 @@
-import {type SanityDocument} from '@sanity/client'
 import {render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
 import {describe, expect, it, vi} from 'vitest'
@@ -6,6 +5,7 @@ import {describe, expect, it, vi} from 'vitest'
 import {setupVirtualListEnv} from '../../../../../../test/testUtils/setupVirtualListEnv'
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
 import {variantsUsEnglishLocaleBundle} from '../../../i18n'
+import {type DocumentInVariantGroup} from '../types'
 import {VariantDocumentsTable} from '../VariantDocumentsTable'
 
 vi.mock('../../../../preview/components/SanityDefaultPreview', () => ({
@@ -17,33 +17,95 @@ vi.mock('../../../../preview/components/SanityDefaultPreview', () => ({
   )),
 }))
 
+vi.mock('../variantDocumentTable/VariantDocumentPreview', () => ({
+  VariantDocumentPreview: vi.fn(({row}) => (
+    <div data-testid="preview">{row.document.title || row.document._id}</div>
+  )),
+}))
+
+vi.mock('../variantDocumentTable/VariantDocumentBundleChips', () => ({
+  VariantDocumentBundleChips: vi.fn(({versions}) => (
+    <div data-testid="bundle-chips">{versions.map((version) => version.bundleId).join(',')}</div>
+  )),
+}))
+
 setupVirtualListEnv()
 
-const mockDocuments: SanityDocument[] = [
+const defaultValidation = {
+  hasError: false,
+  isValidating: false,
+  validation: [],
+} as const
+
+const mockRows: DocumentInVariantGroup[] = [
   {
-    _id: 'drafts.article-first',
-    _type: 'article',
-    _rev: 'rev-1',
-    _createdAt: '2025-01-01T00:00:00Z',
-    _updatedAt: '2025-06-01T00:00:00Z',
-    title: 'First article',
+    memoKey: 'group-1',
+    groupId: 'article-1',
+    validation: defaultValidation,
+    document: {
+      _id: 'published.scope.article-1',
+      _type: 'article',
+      _rev: 'rev-1',
+      _createdAt: '2025-01-01T00:00:00Z',
+      _updatedAt: '2025-06-01T00:00:00Z',
+      title: 'First article',
+    },
+    version: {
+      documentId: 'published.scope.article-1',
+      bundleId: '$published',
+      releaseRef: null,
+      updatedAt: '2025-06-01T00:00:00Z',
+    },
+    versions: [
+      {
+        documentId: 'published.scope.article-1',
+        bundleId: '$published',
+        releaseRef: null,
+        updatedAt: '2025-06-01T00:00:00Z',
+      },
+      {
+        documentId: 'drafts.scope.article-1',
+        bundleId: 'drafts',
+        releaseRef: null,
+        updatedAt: '2025-05-01T00:00:00Z',
+      },
+    ],
   },
   {
-    _id: 'drafts.article-second',
-    _type: 'article',
-    _rev: 'rev-2',
-    _createdAt: '2025-01-02T00:00:00Z',
-    _updatedAt: '2025-06-02T00:00:00Z',
-    title: 'Second article',
+    memoKey: 'group-2',
+    groupId: 'article-2',
+    validation: defaultValidation,
+    document: {
+      _id: 'drafts.scope.article-2',
+      _type: 'article',
+      _rev: 'rev-2',
+      _createdAt: '2025-01-02T00:00:00Z',
+      _updatedAt: '2025-06-02T00:00:00Z',
+      title: 'Second article',
+    },
+    version: {
+      documentId: 'drafts.scope.article-2',
+      bundleId: 'drafts',
+      releaseRef: null,
+      updatedAt: '2025-06-02T00:00:00Z',
+    },
+    versions: [
+      {
+        documentId: 'drafts.scope.article-2',
+        bundleId: 'drafts',
+        releaseRef: null,
+        updatedAt: '2025-06-02T00:00:00Z',
+      },
+    ],
   },
 ]
 
 describe('VariantDocumentsTable', () => {
-  const renderTable = async (documents: SanityDocument[] = mockDocuments) => {
+  const renderTable = async (rows: DocumentInVariantGroup[] = mockRows) => {
     const wrapper = await createTestProvider({
       resources: [variantsUsEnglishLocaleBundle],
     })
-    const result = render(<VariantDocumentsTable documents={documents} />, {wrapper})
+    const result = render(<VariantDocumentsTable rows={rows} />, {wrapper})
     await screen.findByPlaceholderText('Search documents')
     return result
   }
@@ -54,7 +116,7 @@ describe('VariantDocumentsTable', () => {
     expect(screen.getByText('No documents in this variant')).toBeInTheDocument()
   })
 
-  it('renders document rows with title, type, and edited columns', async () => {
+  it('renders document rows with bundle, title, type, and edited columns', async () => {
     await renderTable()
 
     await waitFor(() => {
@@ -63,8 +125,10 @@ describe('VariantDocumentsTable', () => {
 
     expect(screen.getByText('First article')).toBeInTheDocument()
     expect(screen.getByText('Second article')).toBeInTheDocument()
-    expect(screen.getByText('drafts.article-first')).toBeInTheDocument()
     expect(screen.getAllByText('article')).toHaveLength(2)
+    expect(screen.getByText('$published,drafts')).toBeInTheDocument()
+    expect(screen.getByText('drafts')).toBeInTheDocument()
+    expect(screen.getByText('Bundle')).toBeInTheDocument()
   })
 
   it('filters documents when searching by title, id, or type', async () => {

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/groupVariantDocumentsByGroup.test.ts
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/groupVariantDocumentsByGroup.test.ts
@@ -1,0 +1,154 @@
+import {describe, expect, it} from 'vitest'
+
+import {variantAlphaAudience} from '../../../__fixtures__/variants.fixture'
+import {groupVariantDocumentsByGroup} from '../groupVariantDocumentsByGroup'
+import {type DocumentInVariant} from '../types'
+
+const GROUP_ID = 'article-1'
+
+const defaultValidation = {
+  hasError: false,
+  isValidating: false,
+  validation: [],
+} as const
+
+const createDocumentInVariant = ({
+  documentId,
+  bundleId,
+  updatedAt,
+  releaseRef = null,
+  validation = defaultValidation,
+}: {
+  documentId: string
+  bundleId: '$published' | 'drafts' | 'rASAP'
+  updatedAt: string
+  releaseRef?: string | null
+  validation?: DocumentInVariant['validation']
+}): DocumentInVariant => ({
+  memoKey: documentId,
+  document: {
+    _id: documentId,
+    _type: 'article',
+    _rev: `${documentId}-rev`,
+    _createdAt: updatedAt,
+    _updatedAt: updatedAt,
+    _system: {
+      bundleId,
+      release: releaseRef ? {_ref: releaseRef, _weak: true} : null,
+      variant: {_ref: variantAlphaAudience._id, _weak: true},
+      group: {_ref: GROUP_ID, _weak: true},
+      scopeId: null,
+    },
+  },
+  version: {
+    documentId,
+    bundleId,
+    releaseRef,
+    updatedAt,
+  },
+  validation,
+})
+
+describe('groupVariantDocumentsByGroup', () => {
+  it('returns one row per document group', () => {
+    const rows = groupVariantDocumentsByGroup([
+      createDocumentInVariant({
+        documentId: 'drafts.scope.article-1',
+        bundleId: 'drafts',
+        updatedAt: '2025-06-01T00:00:00Z',
+      }),
+      createDocumentInVariant({
+        documentId: 'versions.rASAP.scope.article-1',
+        bundleId: 'rASAP',
+        updatedAt: '2025-06-02T00:00:00Z',
+        releaseRef: '_.releases.rASAP',
+      }),
+    ])
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.groupId).toBe(GROUP_ID)
+    expect(rows[0]?.versions).toHaveLength(2)
+  })
+
+  it('uses the latest edited document as the representative row document', () => {
+    const rows = groupVariantDocumentsByGroup([
+      createDocumentInVariant({
+        documentId: 'drafts.scope.article-1',
+        bundleId: 'drafts',
+        updatedAt: '2025-06-01T00:00:00Z',
+      }),
+      createDocumentInVariant({
+        documentId: 'published.scope.article-1',
+        bundleId: '$published',
+        updatedAt: '2025-06-03T00:00:00Z',
+      }),
+    ])
+
+    expect(rows[0]?.document._id).toBe('published.scope.article-1')
+  })
+
+  it('sorts bundle chips as published, drafts, then releases', () => {
+    const rows = groupVariantDocumentsByGroup(
+      [
+        createDocumentInVariant({
+          documentId: 'versions.rB.scope.article-1',
+          bundleId: 'rB',
+          updatedAt: '2025-06-04T00:00:00Z',
+          releaseRef: '_.releases.rB',
+        }),
+        createDocumentInVariant({
+          documentId: 'drafts.scope.article-1',
+          bundleId: 'drafts',
+          updatedAt: '2025-06-01T00:00:00Z',
+        }),
+        createDocumentInVariant({
+          documentId: 'published.scope.article-1',
+          bundleId: '$published',
+          updatedAt: '2025-06-03T00:00:00Z',
+        }),
+        createDocumentInVariant({
+          documentId: 'versions.rA.scope.article-1',
+          bundleId: 'rA',
+          updatedAt: '2025-06-02T00:00:00Z',
+          releaseRef: '_.releases.rA',
+        }),
+      ],
+      (releaseRef) => (releaseRef === '_.releases.rA' ? 'A release' : 'B release'),
+    )
+
+    expect(rows[0]?.versions.map((version) => version.bundleId)).toEqual([
+      '$published',
+      'drafts',
+      'rA',
+      'rB',
+    ])
+  })
+
+  it('aggregates validation errors across grouped document versions', () => {
+    const rows = groupVariantDocumentsByGroup([
+      createDocumentInVariant({
+        documentId: 'drafts.scope.article-1',
+        bundleId: 'drafts',
+        updatedAt: '2025-06-01T00:00:00Z',
+        validation: {
+          hasError: false,
+          isValidating: false,
+          validation: [],
+        },
+      }),
+      createDocumentInVariant({
+        documentId: 'published.scope.article-1',
+        bundleId: '$published',
+        updatedAt: '2025-06-03T00:00:00Z',
+        validation: {
+          hasError: true,
+          isValidating: false,
+          validation: [{level: 'error', message: 'Title is required', path: ['title']}],
+        },
+      }),
+    ])
+
+    expect(rows[0]?.validation.hasError).toBe(true)
+    expect(rows[0]?.validation.validation).toHaveLength(1)
+  })
+})

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/useVariantDocuments.test.ts
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/useVariantDocuments.test.ts
@@ -1,0 +1,107 @@
+import {renderHook, waitFor} from '@testing-library/react'
+import {of} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {variantAlphaAudience} from '../../../__fixtures__/variants.fixture'
+import {resetVariantDocumentsCacheForTests, useVariantDocuments} from '../useVariantDocuments'
+
+const validateDocumentWithReferencesMock = vi.hoisted(() =>
+  vi.fn(() =>
+    of({
+      isValidating: false,
+      validation: [{level: 'error', message: 'Title is required', path: ['title']}],
+      revision: 'rev-1',
+    }),
+  ),
+)
+
+const documentPreviewStoreMock = vi.hoisted(() => ({
+  unstable_observeDocumentIdSet: vi.fn(() => of({status: 'connected' as const, documentIds: []})),
+  unstable_observeDocument: vi.fn(() => of(null)),
+  unstable_observeDocumentPairAvailability: vi.fn(() =>
+    of({published: {available: true}, draft: {available: true}}),
+  ),
+}))
+
+vi.mock('../../../../validation', async (importOriginal) => ({
+  ...(await importOriginal()),
+  validateDocumentWithReferences: validateDocumentWithReferencesMock,
+}))
+
+vi.mock('../../../../store/datastores', () => ({
+  useDocumentPreviewStore: vi.fn(() => documentPreviewStoreMock),
+}))
+
+describe('useVariantDocuments', () => {
+  beforeEach(() => {
+    resetVariantDocumentsCacheForTests()
+    validateDocumentWithReferencesMock.mockClear()
+    documentPreviewStoreMock.unstable_observeDocumentIdSet.mockReset()
+    documentPreviewStoreMock.unstable_observeDocument.mockReset()
+    documentPreviewStoreMock.unstable_observeDocumentIdSet.mockReturnValue(
+      of({status: 'connected' as const, documentIds: []}),
+    )
+    documentPreviewStoreMock.unstable_observeDocument.mockReturnValue(of(null))
+  })
+
+  it('returns an empty result when no variant id is provided', async () => {
+    const wrapper = await createTestProvider()
+
+    const {result} = renderHook(() => useVariantDocuments(undefined), {wrapper})
+
+    expect(result.current).toEqual({
+      loading: false,
+      results: [],
+      error: null,
+    })
+    expect(documentPreviewStoreMock.unstable_observeDocumentIdSet).not.toHaveBeenCalled()
+  })
+
+  it('queries variant membership with the fallback _system.variant filter', async () => {
+    const wrapper = await createTestProvider()
+
+    renderHook(() => useVariantDocuments(variantAlphaAudience._id), {wrapper})
+
+    expect(documentPreviewStoreMock.unstable_observeDocumentIdSet).toHaveBeenCalledWith(
+      '_system.variant._ref == $variantId',
+      {variantId: variantAlphaAudience._id},
+      expect.objectContaining({apiVersion: 'X'}),
+    )
+  })
+
+  it('validates each variant document and exposes hasError on the result', async () => {
+    const document = {
+      _id: 'drafts.scope.article-1',
+      _type: 'article',
+      _rev: 'rev-1',
+      _createdAt: '2025-06-01T00:00:00Z',
+      _updatedAt: '2025-06-01T00:00:00Z',
+      _system: {
+        bundleId: 'drafts',
+        release: null,
+        variant: {_ref: variantAlphaAudience._id, _weak: true},
+        group: {_ref: 'article-1', _weak: true},
+        scopeId: null,
+      },
+    }
+
+    documentPreviewStoreMock.unstable_observeDocumentIdSet.mockReturnValue(
+      of({status: 'connected' as const, documentIds: [document._id]}),
+    )
+    documentPreviewStoreMock.unstable_observeDocument.mockReturnValue(of(document))
+
+    const wrapper = await createTestProvider()
+    const {result} = renderHook(() => useVariantDocuments(variantAlphaAudience._id), {wrapper})
+
+    await waitFor(() => {
+      expect(result.current.results).toHaveLength(1)
+    })
+
+    expect(validateDocumentWithReferencesMock).toHaveBeenCalled()
+    expect(result.current.results[0]?.validation.hasError).toBe(true)
+    expect(result.current.results[0]?.validation.validation).toEqual([
+      {level: 'error', message: 'Title is required', path: ['title']},
+    ])
+  })
+})

--- a/packages/sanity/src/core/variants/tool/detail/groupVariantDocumentsByGroup.ts
+++ b/packages/sanity/src/core/variants/tool/detail/groupVariantDocumentsByGroup.ts
@@ -1,0 +1,113 @@
+import {type PerspectiveBundle} from '../../../perspective/types'
+import {getReleaseIdFromReleaseDocumentId} from '../../../releases/util/getReleaseIdFromReleaseDocumentId'
+import {
+  type DocumentInVariant,
+  type DocumentInVariantGroup,
+  type DocumentValidationStatus,
+  type VariantDocumentVersion,
+} from './types'
+import {getDocumentGroupId} from './variantDocumentVersion'
+
+const BUNDLE_SORT_ORDER: Record<string, number> = {
+  $published: 0,
+  drafts: 1,
+}
+
+/**
+ * @internal
+ */
+export function compareVariantDocumentVersions(
+  left: VariantDocumentVersion,
+  right: VariantDocumentVersion,
+  getReleaseTitle: (releaseRef: string) => string,
+): number {
+  const leftOrder = getBundleSortOrder(left.bundleId)
+  const rightOrder = getBundleSortOrder(right.bundleId)
+
+  if (leftOrder !== rightOrder) {
+    return leftOrder - rightOrder
+  }
+
+  if (isReleaseBundle(left.bundleId) && isReleaseBundle(right.bundleId)) {
+    const leftTitle = left.releaseRef ? getReleaseTitle(left.releaseRef) : left.bundleId
+    const rightTitle = right.releaseRef ? getReleaseTitle(right.releaseRef) : right.bundleId
+
+    return leftTitle.localeCompare(rightTitle)
+  }
+
+  return left.documentId.localeCompare(right.documentId)
+}
+
+function getBundleSortOrder(bundleId: PerspectiveBundle): number {
+  return BUNDLE_SORT_ORDER[bundleId] ?? 2
+}
+
+function isReleaseBundle(bundleId: PerspectiveBundle): boolean {
+  return bundleId !== '$published' && bundleId !== 'drafts'
+}
+
+function pickRepresentativeDocument(documents: DocumentInVariant[]): DocumentInVariant {
+  return documents.reduce((latest, current) => {
+    const latestUpdatedAt = latest.document._updatedAt ?? ''
+    const currentUpdatedAt = current.document._updatedAt ?? ''
+
+    return currentUpdatedAt > latestUpdatedAt ? current : latest
+  })
+}
+
+function aggregateValidation(documents: DocumentInVariant[]): DocumentValidationStatus {
+  const representative = pickRepresentativeDocument(documents)
+
+  return {
+    isValidating: documents.some((document) => document.validation.isValidating),
+    validation: documents.flatMap((document) => document.validation.validation),
+    revision: representative.validation.revision,
+    hasError: documents.some((document) => document.validation.hasError),
+  }
+}
+
+/**
+ * Groups flat variant document versions into one row per document group.
+ *
+ * @internal
+ */
+export function groupVariantDocumentsByGroup(
+  documents: DocumentInVariant[],
+  getReleaseTitle: (releaseRef: string) => string = defaultReleaseTitle,
+): DocumentInVariantGroup[] {
+  const groups = new Map<string, DocumentInVariant[]>()
+
+  for (const document of documents) {
+    const groupId = getDocumentGroupId(document.document)
+
+    if (!groupId) {
+      continue
+    }
+
+    const existingGroup = groups.get(groupId)
+
+    if (existingGroup) {
+      existingGroup.push(document)
+    } else {
+      groups.set(groupId, [document])
+    }
+  }
+
+  return Array.from(groups.entries()).map(([groupId, groupDocuments]) => {
+    const representative = pickRepresentativeDocument(groupDocuments)
+    const versions = groupDocuments
+      .map((item) => item.version)
+      .toSorted((left, right) => compareVariantDocumentVersions(left, right, getReleaseTitle))
+
+    return {
+      ...representative,
+      groupId,
+      versions,
+      validation: aggregateValidation(groupDocuments),
+    }
+  })
+}
+
+function defaultReleaseTitle(releaseRef: string): string {
+  return getReleaseIdFromReleaseDocumentId(releaseRef)
+}

--- a/packages/sanity/src/core/variants/tool/detail/types.ts
+++ b/packages/sanity/src/core/variants/tool/detail/types.ts
@@ -1,0 +1,46 @@
+import {type SanityDocument} from '@sanity/client'
+
+import {type PerspectiveBundle} from '../../../perspective/types'
+import {type ValidationStatus} from '../../../validation'
+
+/**
+ * @internal
+ */
+export interface DocumentValidationStatus extends ValidationStatus {
+  hasError: boolean
+}
+
+/**
+ * Bundle metadata for a single variant-scoped document version.
+ *
+ * @internal
+ */
+export interface VariantDocumentVersion {
+  documentId: string
+  bundleId: PerspectiveBundle
+  releaseRef: string | null
+  updatedAt: string
+}
+
+/**
+ * A single variant-scoped document version returned by {@link useVariantDocuments}.
+ *
+ * @internal
+ */
+export interface DocumentInVariant {
+  memoKey: string
+  document: SanityDocument
+  version: VariantDocumentVersion
+  validation: DocumentValidationStatus
+}
+
+/**
+ * A document group row for the variant detail table.
+ * Produced by {@link groupVariantDocumentsByGroup} from a flat {@link DocumentInVariant} list.
+ *
+ * @internal
+ */
+export interface DocumentInVariantGroup extends DocumentInVariant {
+  groupId: string
+  versions: VariantDocumentVersion[]
+}

--- a/packages/sanity/src/core/variants/tool/detail/useVariantDocuments.ts
+++ b/packages/sanity/src/core/variants/tool/detail/useVariantDocuments.ts
@@ -1,0 +1,237 @@
+import {type SanityDocument} from '@sanity/client'
+import {type CurrentUser, isValidationErrorMarker, type Schema} from '@sanity/types'
+import {uuid} from '@sanity/uuid'
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {combineLatest, from, type Observable, of} from 'rxjs'
+import {mergeMapArray} from 'rxjs-mergemap-array'
+import {
+  catchError,
+  delay,
+  filter,
+  finalize,
+  map,
+  shareReplay,
+  startWith,
+  switchMap,
+} from 'rxjs/operators'
+
+import {useSchema} from '../../../hooks'
+import {type LocaleSource} from '../../../i18n/types'
+import {type DocumentPreviewStore} from '../../../preview'
+import {isGoingToUnpublish} from '../../../releases/util/isGoingToUnpublish'
+import {useDocumentPreviewStore} from '../../../store/datastores'
+import {useSource} from '../../../studio'
+import {schedulerYield} from '../../../util/schedulerYield'
+import {validateDocumentWithReferences} from '../../../validation'
+import {VARIANTS_STUDIO_CLIENT_OPTIONS} from '../../store/constants'
+import {type DocumentInVariant, type DocumentValidationStatus} from './types'
+import {toVariantDocumentVersion} from './variantDocumentVersion'
+
+const variantDocumentsCache: Record<string, VariantDocumentsObservableResult> = Object.create(null)
+
+/** @internal */
+export function resetVariantDocumentsCacheForTests(): void {
+  for (const key of Object.keys(variantDocumentsCache)) {
+    delete variantDocumentsCache[key]
+  }
+}
+
+type VariantDocumentsObservableResult = Observable<{
+  loading: boolean
+  results: DocumentInVariant[]
+  error: Error | null
+}>
+
+// TODO: replace with sanity::partOfVariant($variantId) when the native GROQ function ships
+const VARIANT_DOCUMENTS_GROQ_FILTER = '_system.variant._ref == $variantId'
+
+const getVariantDocumentsObservable = ({
+  documentPreviewStore,
+  variantId,
+  schema,
+  i18n,
+  getClient,
+  currentUser,
+}: {
+  documentPreviewStore: DocumentPreviewStore
+  variantId: string
+  schema: Schema
+  i18n: LocaleSource
+  getClient: ReturnType<typeof useSource>['getClient']
+  currentUser?: Omit<CurrentUser, 'role'> | null
+}): VariantDocumentsObservableResult => {
+  const createValidationObservable = (
+    ctx: Parameters<typeof validateDocumentWithReferences>[0],
+    document: SanityDocument,
+  ) => {
+    if (isGoingToUnpublish(document)) {
+      return of({
+        isValidating: false,
+        validation: [],
+        revision: document._rev,
+        hasError: false,
+      } satisfies DocumentValidationStatus)
+    }
+
+    return from(schedulerYield(() => Promise.resolve())).pipe(
+      switchMap(() =>
+        validateDocumentWithReferences(ctx, of(document), false).pipe(
+          map((validationStatus) => ({
+            ...validationStatus,
+            hasError: validationStatus.validation.some((marker) => isValidationErrorMarker(marker)),
+          })),
+        ),
+      ),
+    )
+  }
+
+  const processDocument = (id: string) => {
+    const ctx = {
+      observeDocument: documentPreviewStore.unstable_observeDocument,
+      observeDocumentPairAvailability:
+        documentPreviewStore.unstable_observeDocumentPairAvailability,
+      i18n,
+      getClient,
+      schema,
+      currentUser,
+    }
+
+    const document$ = documentPreviewStore
+      .unstable_observeDocument(id, {
+        apiVersion: VARIANTS_STUDIO_CLIENT_OPTIONS.apiVersion,
+      })
+      .pipe(filter(Boolean))
+
+    const validation$ = document$.pipe(
+      switchMap((document) => createValidationObservable(ctx, document)),
+    )
+
+    return combineLatest([document$, validation$]).pipe(
+      map(([document, validation]) => {
+        const version = toVariantDocumentVersion(document as SanityDocument)
+
+        if (!version) {
+          return null
+        }
+
+        return {
+          document: document as SanityDocument,
+          version,
+          validation,
+          memoKey: uuid(),
+        } satisfies DocumentInVariant
+      }),
+      filter((result): result is DocumentInVariant => result !== null),
+    )
+  }
+
+  const processDocumentIdsGroup = (documentIdsGroup: string[], groupIndex: number) => {
+    const batchDelay = groupIndex === 0 ? 0 : 100
+
+    return of(documentIdsGroup).pipe(
+      delay(batchDelay),
+      mergeMapArray((documentId: string) => processDocument(documentId)),
+    )
+  }
+
+  return documentPreviewStore
+    .unstable_observeDocumentIdSet(
+      VARIANT_DOCUMENTS_GROQ_FILTER,
+      {variantId},
+      {
+        apiVersion: VARIANTS_STUDIO_CLIENT_OPTIONS.apiVersion,
+      },
+    )
+    .pipe(
+      map((state) => state.documentIds || []),
+      switchMap((documentIds) => {
+        if (documentIds.length === 0) {
+          return of([])
+        }
+
+        const batchSize = 5
+        const documentIdsGroups = []
+
+        for (let i = 0; i < documentIds.length; i += batchSize) {
+          documentIdsGroups.push(documentIds.slice(i, i + batchSize))
+        }
+
+        return combineLatest(
+          documentIdsGroups.map((batch, batchIndex) =>
+            processDocumentIdsGroup(batch, batchIndex).pipe(delay(batchIndex * 100)),
+          ),
+        ).pipe(map((groupResults) => groupResults.flat()))
+      }),
+      map((results) => ({loading: false, results, error: null})),
+      catchError((error) => of({loading: false, results: [], error})),
+    )
+}
+
+const getOrCreateVariantDocumentsObservable = ({
+  documentPreviewStore,
+  variantId,
+  schema,
+  i18n,
+  getClient,
+  currentUser,
+}: {
+  documentPreviewStore: DocumentPreviewStore
+  variantId: string
+  schema: Schema
+  i18n: LocaleSource
+  getClient: ReturnType<typeof useSource>['getClient']
+  currentUser?: Omit<CurrentUser, 'role'> | null
+}): VariantDocumentsObservableResult => {
+  if (!variantDocumentsCache[variantId]) {
+    variantDocumentsCache[variantId] = getVariantDocumentsObservable({
+      documentPreviewStore,
+      variantId,
+      schema,
+      i18n,
+      getClient,
+      currentUser,
+    }).pipe(
+      finalize(() => {
+        delete variantDocumentsCache[variantId]
+      }),
+      shareReplay(1),
+    )
+  }
+
+  return variantDocumentsCache[variantId]
+}
+
+/**
+ * @internal
+ */
+export function useVariantDocuments(variantId: string | undefined): {
+  loading: boolean
+  results: DocumentInVariant[]
+  error: Error | null
+} {
+  const documentPreviewStore = useDocumentPreviewStore()
+  const {getClient, i18n, currentUser} = useSource()
+  const schema = useSchema()
+
+  const variantDocumentsObservable = useMemo(() => {
+    if (!variantId) {
+      return of({loading: false, results: [], error: null})
+    }
+
+    return getOrCreateVariantDocumentsObservable({
+      documentPreviewStore,
+      variantId,
+      schema,
+      i18n,
+      getClient,
+      currentUser,
+    }).pipe(startWith({loading: true, results: [], error: null}))
+  }, [currentUser, documentPreviewStore, getClient, i18n, schema, variantId])
+
+  return useObservable(variantDocumentsObservable, {
+    loading: Boolean(variantId),
+    results: [],
+    error: null,
+  })
+}

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
@@ -1,0 +1,127 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {Badge, Flex} from '@sanity/ui'
+import {type ForwardedRef, forwardRef, useMemo} from 'react'
+import {IntentLink} from 'sanity/router'
+
+import {useTranslation} from '../../../../i18n'
+import {ReleaseTitle} from '../../../../releases/components/ReleaseTitle'
+import {RELEASES_INTENT} from '../../../../releases/plugin'
+import {useActiveReleases} from '../../../../releases/store/useActiveReleases'
+import {getReleaseDocumentIdFromReleaseId} from '../../../../releases/util/getReleaseDocumentIdFromReleaseId'
+import {getReleaseIdFromReleaseDocumentId} from '../../../../releases/util/getReleaseIdFromReleaseDocumentId'
+import {type VariantDocumentVersion} from '../types'
+
+function isReleaseBundle(bundleId: VariantDocumentVersion['bundleId']): boolean {
+  return bundleId !== '$published' && bundleId !== 'drafts'
+}
+
+function getReleaseDocumentForVersion(
+  version: VariantDocumentVersion,
+  releasesById: Map<string, ReleaseDocument>,
+): ReleaseDocument | undefined {
+  if (version.releaseRef) {
+    return releasesById.get(version.releaseRef)
+  }
+
+  if (isReleaseBundle(version.bundleId)) {
+    const releaseDocumentId = getReleaseDocumentIdFromReleaseId(version.bundleId)
+
+    return releasesById.get(releaseDocumentId)
+  }
+
+  return undefined
+}
+
+function ReleaseBundleChip({release}: {release: ReleaseDocument}) {
+  const {t} = useTranslation()
+  const releaseId = getReleaseIdFromReleaseDocumentId(release._id)
+
+  const ReleaseIntentLink = useMemo(
+    () =>
+      forwardRef(function ReleaseIntentLink(
+        linkProps: React.ComponentProps<'a'>,
+        ref: ForwardedRef<HTMLAnchorElement>,
+      ) {
+        return (
+          <IntentLink {...linkProps} ref={ref} intent={RELEASES_INTENT} params={{id: releaseId}} />
+        )
+      }),
+    [releaseId],
+  )
+
+  return (
+    <ReleaseTitle
+      title={release.metadata?.title}
+      fallback={t('release.placeholder-untitled-release')}
+    >
+      {({displayTitle}) => (
+        <ReleaseIntentLink>
+          <Badge radius={2} tone="primary">
+            {displayTitle}
+          </Badge>
+        </ReleaseIntentLink>
+      )}
+    </ReleaseTitle>
+  )
+}
+
+function StaticBundleChip({label, tone}: {label: string; tone: 'positive' | 'default'}) {
+  return (
+    <Badge radius={2} tone={tone}>
+      {label}
+    </Badge>
+  )
+}
+
+export function VariantDocumentBundleChips({
+  versions,
+}: {
+  versions: VariantDocumentVersion[]
+}): React.JSX.Element {
+  const {t} = useTranslation()
+  const {data: releases} = useActiveReleases()
+  const releasesById = useMemo(
+    () => new Map(releases.map((release) => [release._id, release])),
+    [releases],
+  )
+
+  return (
+    <Flex align="center" gap={1} wrap="wrap">
+      {versions.map((version) => {
+        if (version.bundleId === '$published') {
+          return (
+            <StaticBundleChip
+              key={version.documentId}
+              label={t('release.chip.published')}
+              tone="positive"
+            />
+          )
+        }
+
+        if (version.bundleId === 'drafts') {
+          return (
+            <StaticBundleChip
+              key={version.documentId}
+              label={t('release.chip.draft')}
+              tone="default"
+            />
+          )
+        }
+
+        const release = getReleaseDocumentForVersion(version, releasesById)
+
+        if (release) {
+          return <ReleaseBundleChip key={version.documentId} release={release} />
+        }
+
+        return (
+          <StaticBundleChip
+            key={version.documentId}
+            label={t('release.placeholder-untitled-release')}
+            tone="default"
+          />
+        )
+      })}
+    </Flex>
+  )
+}

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentPreview.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentPreview.tsx
@@ -1,0 +1,96 @@
+import {Card} from '@sanity/ui'
+import {type ForwardedRef, forwardRef, useMemo} from 'react'
+import {IntentLink} from 'sanity/router'
+
+import {type PreviewLayoutKey} from '../../../../components/previews/types'
+import {DocumentPreviewPresence} from '../../../../presence'
+import {SanityDefaultPreview} from '../../../../preview/components/SanityDefaultPreview'
+import {useDocumentPresence} from '../../../../store/presence/useDocumentPresence'
+import {useDocumentPreviewValues} from '../../../../tasks/hooks/useDocumentPreviewValues'
+import {getPublishedId} from '../../../../util/draftUtils'
+import {type DocumentInVariantGroup} from '../types'
+
+interface VariantDocumentPreviewProps {
+  row: DocumentInVariantGroup
+  layout?: PreviewLayoutKey
+}
+
+function getPerspectiveStackForVersion(
+  bundleId: DocumentInVariantGroup['version']['bundleId'],
+): string[] {
+  if (bundleId === '$published') {
+    return []
+  }
+
+  if (bundleId === 'drafts') {
+    return ['drafts']
+  }
+
+  return [bundleId]
+}
+
+function getSearchParamsForVersion(
+  bundleId: DocumentInVariantGroup['version']['bundleId'],
+): Array<[string, string]> | undefined {
+  if (bundleId === '$published') {
+    return [['perspective', 'published']]
+  }
+
+  if (bundleId === 'drafts') {
+    // Drafts is the default structure perspective — omit it from the URL.
+    return undefined
+  }
+
+  return [['perspective', bundleId]]
+}
+
+export function VariantDocumentPreview({
+  row,
+  layout,
+}: VariantDocumentPreviewProps): React.JSX.Element {
+  const publishedId = getPublishedId(row.groupId)
+  const documentPresence = useDocumentPresence(row.document._id)
+  const perspectiveStack = getPerspectiveStackForVersion(row.version.bundleId)
+  const searchParams = getSearchParamsForVersion(row.version.bundleId)
+
+  const LinkComponent = useMemo(
+    () =>
+      forwardRef(function LinkComponent(linkProps, ref: ForwardedRef<HTMLAnchorElement>) {
+        return (
+          <IntentLink
+            {...linkProps}
+            intent="edit"
+            params={{
+              id: publishedId,
+              type: row.document._type,
+            }}
+            searchParams={searchParams}
+            ref={ref}
+          />
+        )
+      }),
+    [publishedId, row.document._type, searchParams],
+  )
+
+  const previewPresence = useMemo(
+    () => documentPresence?.length > 0 && <DocumentPreviewPresence presence={documentPresence} />,
+    [documentPresence],
+  )
+
+  const {isLoading: previewLoading, value: resolvedPreview} = useDocumentPreviewValues({
+    documentId: row.document._id,
+    documentType: row.document._type,
+    perspectiveStack,
+  })
+
+  return (
+    <Card tone="inherit" as={LinkComponent} radius={2} data-as="a">
+      <SanityDefaultPreview
+        {...(resolvedPreview || {})}
+        status={previewPresence}
+        isPlaceholder={previewLoading}
+        layout={layout}
+      />
+    </Card>
+  )
+}

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
@@ -1,0 +1,165 @@
+import {ErrorOutlineIcon} from '@sanity/icons'
+import {Box, Flex, Text} from '@sanity/ui'
+// eslint-disable-next-line @sanity/i18n/no-i18next-import -- figure out how to have the linter be fine with importing types-only
+import {type TFunction} from 'i18next'
+import {memo} from 'react'
+
+import {ToneIcon} from '../../../../../ui-components/toneIcon/ToneIcon'
+import {Tooltip} from '../../../../../ui-components/tooltip'
+import {RelativeTime} from '../../../../components/RelativeTime'
+import {useSchema} from '../../../../hooks'
+import {SanityDefaultPreview} from '../../../../preview/components/SanityDefaultPreview'
+import {Headers} from '../../../../releases/tool/components/Table/TableHeader'
+import {type Column} from '../../../../releases/tool/components/Table/types'
+import {type DocumentInVariantGroup} from '../types'
+import {VariantDocumentBundleChips} from './VariantDocumentBundleChips'
+import {VariantDocumentPreview} from './VariantDocumentPreview'
+
+const MemoVariantDocumentPreview = memo(
+  function MemoVariantDocumentPreview({row}: {row: DocumentInVariantGroup}) {
+    return <VariantDocumentPreview row={row} />
+  },
+  (prev, next) => prev.row.memoKey === next.row.memoKey,
+)
+
+const MemoDocumentType = memo(
+  function DocumentType({type}: {type: string}) {
+    const schema = useSchema()
+    const schemaType = schema.get(type)
+
+    return <Text size={1}>{schemaType?.title || type}</Text>
+  },
+  (prev, next) => prev.type === next.type,
+)
+
+export const getVariantDocumentTableColumnDefs = (
+  t: TFunction<'variants'>,
+): Column<DocumentInVariantGroup>[] => [
+  {
+    id: 'bundle',
+    width: null,
+    style: {minWidth: 100},
+    sorting: false,
+    header: (props) => (
+      <Flex {...props.headerProps} paddingY={3} sizing="border">
+        <Headers.BasicHeader text={t('detail.documents.table.bundle')} />
+      </Flex>
+    ),
+    cell: ({cellProps, datum}) => (
+      <Flex align="center" {...cellProps}>
+        <Box paddingX={2}>
+          {!datum.isLoading && <VariantDocumentBundleChips versions={datum.versions} />}
+        </Box>
+      </Flex>
+    ),
+  },
+  {
+    id: 'document._type',
+    width: null,
+    style: {minWidth: 100},
+    sorting: true,
+    header: (props) => (
+      <Flex {...props.headerProps} paddingY={3} sizing="border">
+        <Headers.SortHeaderButton text={t('detail.documents.table.type')} {...props} />
+      </Flex>
+    ),
+    cell: ({cellProps, datum}) => (
+      <Flex align="center" {...cellProps}>
+        <Box paddingX={2}>
+          {!datum.isLoading && <MemoDocumentType type={datum.document._type} />}
+        </Box>
+      </Flex>
+    ),
+  },
+  {
+    id: 'search',
+    width: null,
+    style: {minWidth: 'min(50%, calc(100vw - 80px))', maxWidth: 'min(50%, calc(100vw - 80px))'},
+    sortTransform(value) {
+      return (
+        String(
+          value.document?.title || value.document?.name || value.document?._id,
+        ).toLowerCase() || 0
+      )
+    },
+    header: (props) => (
+      <Headers.TableHeaderSearch
+        {...props}
+        placeholder={t('detail.documents.table.search-placeholder')}
+      />
+    ),
+    cell: ({cellProps, datum}) => (
+      <Box {...cellProps} flex={1} padding={1} paddingRight={2} sizing="border">
+        {datum.isLoading ? (
+          <SanityDefaultPreview isPlaceholder />
+        ) : (
+          <MemoVariantDocumentPreview row={datum} />
+        )}
+      </Box>
+    ),
+  },
+  {
+    id: 'document._updatedAt',
+    sorting: true,
+    width: 130,
+    header: (props) => (
+      <Flex {...props.headerProps} paddingY={3} sizing="border">
+        <Headers.SortHeaderButton text={t('detail.documents.table.edited')} {...props} />
+      </Flex>
+    ),
+    cell: ({cellProps, datum}) => (
+      <Flex {...cellProps} align="center" paddingX={2} paddingY={3} style={{minWidth: 130}}>
+        {!datum.isLoading && datum.document._updatedAt && (
+          <Text muted size={1}>
+            <RelativeTime time={datum.document._updatedAt} useTemporalPhrase minimal />
+          </Text>
+        )}
+      </Flex>
+    ),
+  },
+  {
+    id: 'validation',
+    sorting: false,
+    width: 50,
+    header: ({headerProps}) => (
+      <Flex {...headerProps} paddingY={3} sizing="border">
+        <Headers.BasicHeader text={''} />
+      </Flex>
+    ),
+    cell: ({cellProps, datum}) => {
+      if (datum.isLoading) return null
+
+      const validationErrorCount = datum.validation.validation.filter(
+        (validation) => validation.level === 'error',
+      ).length
+
+      return (
+        <Flex {...cellProps} flex={1} padding={1} justify="center" align="center" sizing="border">
+          {datum.validation.hasError && (
+            <Tooltip
+              portal
+              placement="bottom-end"
+              content={
+                <Text muted size={1}>
+                  <Flex align="center" gap={3} padding={1}>
+                    <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
+                    {t(
+                      validationErrorCount === 1
+                        ? 'detail.documents.table.validation.error_one'
+                        : 'detail.documents.table.validation.error_other',
+                      {count: validationErrorCount},
+                    )}
+                  </Flex>
+                </Text>
+              }
+            >
+              <Text size={1}>
+                <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
+              </Text>
+            </Tooltip>
+          )}
+        </Flex>
+      )
+    },
+  },
+]

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentVersion.ts
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentVersion.ts
@@ -1,0 +1,32 @@
+import {type SanityDocument} from '@sanity/client'
+import {type DocumentSystem} from '@sanity/types'
+
+import {DOCUMENT_SYSTEM_FIELD} from '../../../preview/constants'
+import {type VariantDocumentVersion} from './types'
+
+/**
+ * @internal
+ */
+export function toVariantDocumentVersion(document: SanityDocument): VariantDocumentVersion | null {
+  const system = document[DOCUMENT_SYSTEM_FIELD] as DocumentSystem | undefined
+
+  if (!system?.group?._ref) {
+    return null
+  }
+
+  return {
+    documentId: document._id,
+    bundleId: system.bundleId ?? 'drafts',
+    releaseRef: system.release?._ref ?? null,
+    updatedAt: document._updatedAt ?? '',
+  }
+}
+
+/**
+ * @internal
+ */
+export function getDocumentGroupId(document: SanityDocument): string | null {
+  const system = document[DOCUMENT_SYSTEM_FIELD] as DocumentSystem | undefined
+
+  return system?.group?._ref ?? null
+}

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
@@ -11,6 +11,8 @@ import {variantsLocaleNamespace} from '../../i18n'
 import {useAllVariants} from '../../store/useAllVariants'
 import {type SystemVariant} from '../../types'
 import {filterVariantsForSearch, getVariantId} from '../util'
+import {type VariantOverviewRow} from './types'
+import {useVariantDocumentGroupCounts} from './useVariantDocumentGroupCounts'
 import {VariantMenuButton} from './VariantMenuButton'
 import {VariantsEmptyState} from './VariantsEmptyState'
 import {variantsOverviewColumnDefs} from './VariantsOverviewColumnDefs'
@@ -39,14 +41,24 @@ export function VariantsOverview() {
 
   const columnDefs = useMemo(() => variantsOverviewColumnDefs(t), [t])
   const renderRowActions = useCallback<
-    NonNullable<TableProps<SystemVariant, undefined>['rowActions']>
+    NonNullable<TableProps<VariantOverviewRow, undefined>['rowActions']>
   >(({datum}) => <VariantMenuButton variant={datum as SystemVariant} />, [])
 
   const variantsList = useMemo(() => variants ?? [], [variants])
+  const documentGroupCounts = useVariantDocumentGroupCounts()
+
+  const variantsWithDocumentCounts = useMemo<VariantOverviewRow[]>(
+    () =>
+      variantsList.map((variant) => ({
+        ...variant,
+        documentGroupCount: documentGroupCounts.get(variant._id) ?? 0,
+      })),
+    [documentGroupCounts, variantsList],
+  )
 
   const filteredVariants = useMemo(
-    () => filterVariantsForSearch(variantsList, searchQuery),
-    [variantsList, searchQuery],
+    () => filterVariantsForSearch(variantsWithDocumentCounts, searchQuery),
+    [searchQuery, variantsWithDocumentCounts],
   )
 
   const hasVariants = variantsList.length > 0
@@ -119,7 +131,7 @@ export function VariantsOverview() {
 
       {/* Full-width scroll region so table borders span the tool pane (same pattern as release detail summary). */}
       <Box flex={1} overflow="auto" ref={setScrollContainerRef}>
-        <Table<SystemVariant>
+        <Table<VariantOverviewRow>
           columnDefs={columnDefs}
           data={filteredVariants}
           emptyState={tableEmptyState}

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
@@ -6,11 +6,14 @@ import {type UseTranslationResponse, useTranslation} from '../../../i18n'
 import {Headers} from '../../../releases/tool/components/Table/TableHeader'
 import {type Column, type VisibleColumn} from '../../../releases/tool/components/Table/types'
 import {variantsLocaleNamespace} from '../../i18n'
-import {type SystemVariant} from '../../types'
 import {getVariantId, getVariantConditionsText, getVariantTitle} from '../util'
+import {type VariantOverviewRow} from './types'
 
-const VariantDocumentsCell: VisibleColumn<SystemVariant>['cell'] = ({cellProps, datum}) => {
-  if (datum.isLoading) {
+const VariantDocumentsCell: VisibleColumn<VariantOverviewRow>['cell'] = ({
+  cellProps,
+  datum: variant,
+}) => {
+  if (variant.isLoading) {
     return (
       <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border">
         <Text size={1}>
@@ -23,13 +26,16 @@ const VariantDocumentsCell: VisibleColumn<SystemVariant>['cell'] = ({cellProps, 
   return (
     <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border">
       <Text muted size={1}>
-        0
+        {variant.documentGroupCount ?? 0}
       </Text>
     </Flex>
   )
 }
 
-const VariantTitleCell: VisibleColumn<SystemVariant>['cell'] = ({cellProps, datum: variant}) => {
+const VariantTitleCell: VisibleColumn<VariantOverviewRow>['cell'] = ({
+  cellProps,
+  datum: variant,
+}) => {
   const {t} = useTranslation(variantsLocaleNamespace)
 
   const encodedVariantId = getVariantId(variant._id)
@@ -82,7 +88,7 @@ const VariantTitleCell: VisibleColumn<SystemVariant>['cell'] = ({cellProps, datu
 
 export function variantsOverviewColumnDefs(
   t: UseTranslationResponse<'variants', undefined>['t'],
-): Column<SystemVariant>[] {
+): Column<VariantOverviewRow>[] {
   return [
     {
       id: 'metadata.title',

--- a/packages/sanity/src/core/variants/tool/overview/__tests__/useVariantDocumentGroupCounts.test.ts
+++ b/packages/sanity/src/core/variants/tool/overview/__tests__/useVariantDocumentGroupCounts.test.ts
@@ -1,0 +1,76 @@
+import {renderHook, waitFor} from '@testing-library/react'
+import {of} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {VARIANT_DOCUMENTS_PATH, VARIANT_DOCUMENT_TYPE} from '../../../store/constants'
+import {
+  resetVariantDocumentGroupCountsCacheForTests,
+  useVariantDocumentGroupCounts,
+} from '../useVariantDocumentGroupCounts'
+
+const listenQueryMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../../store', async (importOriginal) => ({
+  ...(await importOriginal()),
+  listenQuery: listenQueryMock,
+}))
+
+describe('useVariantDocumentGroupCounts', () => {
+  beforeEach(() => {
+    resetVariantDocumentGroupCountsCacheForTests()
+    listenQueryMock.mockReset()
+  })
+
+  it('returns an empty map before listenQuery emits', async () => {
+    listenQueryMock.mockReturnValue(of([]))
+
+    const wrapper = await createTestProvider()
+    const {result} = renderHook(() => useVariantDocumentGroupCounts(), {wrapper})
+
+    expect(result.current).toEqual(new Map())
+  })
+
+  it('maps variant document counts from listenQuery results', async () => {
+    listenQueryMock.mockReturnValue(
+      of([
+        {_id: '_.variants.alpha', documentsCount: 3},
+        {_id: '_.variants.beta', documentsCount: 0},
+      ]),
+    )
+
+    const wrapper = await createTestProvider()
+    const {result} = renderHook(() => useVariantDocumentGroupCounts(), {wrapper})
+
+    await waitFor(() => {
+      expect(result.current).toEqual(
+        new Map([
+          ['_.variants.alpha', 3],
+          ['_.variants.beta', 0],
+        ]),
+      )
+    })
+  })
+
+  it('queries all variant documents with server-side counts', async () => {
+    listenQueryMock.mockReturnValue(of([]))
+
+    const wrapper = await createTestProvider()
+    renderHook(() => useVariantDocumentGroupCounts(), {wrapper})
+
+    expect(listenQueryMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining(`_type=="${VARIANT_DOCUMENT_TYPE}"`),
+      {},
+      expect.objectContaining({
+        tag: 'variants.document-group-counts.listen',
+        apiVersion: 'X',
+      }),
+    )
+
+    const query = listenQueryMock.mock.calls[0][1] as string
+
+    expect(query).toContain(`_id in path("${VARIANT_DOCUMENTS_PATH}.*")`)
+    expect(query).toContain('"documentsCount": count(*[_system.variant._ref == ^._id])')
+  })
+})

--- a/packages/sanity/src/core/variants/tool/overview/types.ts
+++ b/packages/sanity/src/core/variants/tool/overview/types.ts
@@ -1,0 +1,8 @@
+import {type SystemVariant} from '../../types'
+
+/**
+ * @internal
+ */
+export interface VariantOverviewRow extends SystemVariant {
+  documentGroupCount?: number
+}

--- a/packages/sanity/src/core/variants/tool/overview/useVariantDocumentGroupCounts.ts
+++ b/packages/sanity/src/core/variants/tool/overview/useVariantDocumentGroupCounts.ts
@@ -1,0 +1,69 @@
+import {type SanityClient} from '@sanity/client'
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {catchError, map, type Observable, of, shareReplay, startWith} from 'rxjs'
+
+import {listenQuery} from '../../../store'
+import {useSource} from '../../../studio'
+import {
+  VARIANT_DOCUMENTS_PATH,
+  VARIANT_DOCUMENT_TYPE,
+  VARIANTS_STUDIO_CLIENT_OPTIONS,
+} from '../../store/constants'
+
+const VARIANT_DOCUMENT_COUNTS_QUERY = `*[_type=="${VARIANT_DOCUMENT_TYPE}" && _id in path("${VARIANT_DOCUMENTS_PATH}.*")]{
+  _id,
+  "documentsCount": count(*[_system.variant._ref == ^._id])
+}`
+
+interface VariantDocumentCountResult {
+  _id: string
+  documentsCount: number
+}
+
+let countsObservable: Observable<Map<string, number>> | undefined
+
+/** @internal */
+export function resetVariantDocumentGroupCountsCacheForTests(): void {
+  countsObservable = undefined
+}
+
+function toVariantDocumentGroupCountsMap(
+  results: VariantDocumentCountResult[],
+): Map<string, number> {
+  return new Map(results.map((result) => [result._id, result.documentsCount ?? 0]))
+}
+
+function getVariantDocumentGroupCountsObservable(
+  client: SanityClient,
+): Observable<Map<string, number>> {
+  if (!countsObservable) {
+    countsObservable = listenQuery(
+      client,
+      VARIANT_DOCUMENT_COUNTS_QUERY,
+      {},
+      {
+        tag: 'variants.document-group-counts.listen',
+        apiVersion: VARIANTS_STUDIO_CLIENT_OPTIONS.apiVersion,
+      },
+    ).pipe(
+      map(toVariantDocumentGroupCountsMap),
+      catchError(() => of(new Map<string, number>())),
+      shareReplay(1),
+    )
+  }
+
+  return countsObservable
+}
+
+/**
+ * @internal
+ */
+export function useVariantDocumentGroupCounts(): Map<string, number> {
+  const {getClient} = useSource()
+  const client = getClient(VARIANTS_STUDIO_CLIENT_OPTIONS)
+
+  const observable = useMemo(() => getVariantDocumentGroupCountsObservable(client), [client])
+
+  return useObservable(observable.pipe(startWith(new Map<string, number>())), new Map())
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Rebased onto `main` (after #13105 merged variant documents creation). History cleaned to a single commit for the variant detail documents feature.

Wires the variant detail documents table to real variant-scoped content:
- Fetch documents via `useVariantDocuments` with `_system.variant._ref` filter
- Group versions by document group with bundle chips and edit intents
- Validate each document and surface errors in the table
- Show live document counts on the variants overview via `listenQuery`

## What to review

- `useVariantDocuments.ts` — fetch, validation, and batching
- `groupVariantDocumentsByGroup.ts` — one row per document group
- `VariantDocumentTableColumnDefs.tsx` — table columns including validation
- `useVariantDocumentGroupCounts.ts` — overview counts via listenQuery

## Testing

- Unit tests for hook, grouping, table, bundle chips, preview links, and overview counts
- `pnpm vitest run --project=sanity packages/sanity/src/core/variants/tool/detail` passes

## Notes for release

N/A – Part of variants feature work
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30736332-4f8b-48c5-96db-e24dc67dd631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30736332-4f8b-48c5-96db-e24dc67dd631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

