### PR TITLE
chore(test): stabilize inline object remove browser test in firefox

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/ObjectBlock.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/ObjectBlock.browser.test.tsx
@@ -64,12 +64,22 @@ describe('Portable Text Input', () => {
       const $pte = await getFocusedPortableTextEditor('field-body')
       await page.getByRole('button', {name: 'Insert Inline Object (inline)'}).first().click()
 
-      // Assertion: the annotation toolbar popover should be visible
+      // Insert opens the inline object edit dialog; close it so the floating toolbar can show.
+      await expect.element(page.getByTestId('popover-edit-dialog')).toBeVisible()
+      await page.getByTestId('close-popover-edit-dialog-button').click()
+      await expect.element(page.getByTestId('popover-edit-dialog')).not.toBeInTheDocument()
+
+      // Focus the inline object to surface the toolbar.
+      await page.getByText('Custom preview block:').click()
+
+      const $removeButton = page.getByTestId('remove-inline-object-button')
       await expect.element(page.getByTestId('inline-object-toolbar-popover')).toBeVisible()
-      await expect.element(page.getByTestId('remove-inline-object-button')).toBeVisible()
-      // The toolbar popover floats and continuously repositions, so the button
-      // never passes the "stable" actionability check. Force the click past it.
-      await page.getByTestId('remove-inline-object-button').click({force: true})
+      await expect.element($removeButton).toBeVisible()
+
+      // The toolbar popover floats and continuously repositions in Firefox, so
+      // Playwright's actionability checks are flaky. Click via the DOM node instead.
+      await userEvent.click($removeButton.element())
+
       await expect
         .element(page.getByTestId('inline-object-toolbar-popover'))
         .not.toBeInTheDocument()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The Firefox browser test "Inline object toolbars works as expected when removing the object" was flaky because it tried to click the floating toolbar remove button while the inline object edit dialog was still open. Inserting an inline object calls `onMemberOpen`, which opens the edit dialog and hides the toolbar (`open={!inlineObjectOpen && popoverOpen}`). The test's visibility assertions could pass during a brief transition window, but the click then failed with "Element is not visible" or timed out on retry.

The fix follows the same setup used by the sibling test ("after opening and closing the edit dialog"): close the edit dialog, focus the inline object, then remove it. The remove click uses `userEvent.click` on the DOM node instead of Playwright's locator click, avoiding instability from the continuously repositioning floating popover in Firefox.

### What to review

- `packages/sanity/src/core/form/inputs/PortableText/__tests__/ObjectBlock.browser.test.tsx` — the "removing the object" test setup and click strategy

### Testing

```bash
SANITY_VITEST_BROWSER=firefox pnpm vitest run -c vitest.browser.config.mts \
  src/core/form/inputs/PortableText/__tests__/ObjectBlock.browser.test.tsx
```

All 9 tests in the file pass on Firefox locally.

### Notes for release

N/A – Internal only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91d749e5-7855-40f5-b44b-855b331bd940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91d749e5-7855-40f5-b44b-855b331bd940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

