### PR TITLE
fix(types): allow collapsible and collapsed options on geopoint fields

### DIFF
--- a/packages/@sanity/types/src/schema/definition/type/geopoint.ts
+++ b/packages/@sanity/types/src/schema/definition/type/geopoint.ts
@@ -1,6 +1,7 @@
 import {type RuleDef, type ValidationBuilder} from '../../ruleBuilder'
 import {type InitialValueProperty} from '../../types'
-import {type BaseSchemaDefinition, type BaseSchemaTypeOptions} from './common'
+import {type BaseSchemaDefinition} from './common'
+import {type ObjectOptions} from './object'
 
 /**
  * Geographical point representing a pair of latitude and longitude coordinates,
@@ -35,7 +36,7 @@ export interface GeopointValue {
 export interface GeopointRule extends RuleDef<GeopointRule, GeopointValue> {}
 
 /** @public */
-export interface GeopointOptions extends BaseSchemaTypeOptions {}
+export interface GeopointOptions extends ObjectOptions {}
 
 /** @public */
 export interface GeopointDefinition extends BaseSchemaDefinition {

--- a/packages/@sanity/types/test/geopoint.test.ts
+++ b/packages/@sanity/types/test/geopoint.test.ts
@@ -4,7 +4,11 @@ import {describe, it} from 'vitest'
  * Some of these tests have no expect statement;
  * use of ts-expect-error serves the same purpose - TypeScript is the testrunner here
  */
-import {type GeopointDefinition, type StringDefinition} from '../src/schema/definition'
+import {
+  type GeopointDefinition,
+  type GeopointOptions,
+  type StringDefinition,
+} from '../src/schema/definition'
 import {defineType} from '../src/schema/types'
 
 describe('geopoint types', () => {
@@ -37,6 +41,22 @@ describe('geopoint types', () => {
 
       // @ts-expect-error geopoint is not assignable to string
       const notAssignableToString: StringDefinition = geopointDef
+    })
+  })
+
+  describe('GeopointOptions', () => {
+    it('should support collapsible and collapsed, since geopoint is an object type', () => {
+      const collapsibleOptions: GeopointOptions = {
+        collapsible: true,
+        collapsed: true,
+      }
+    })
+
+    it('should not allow unknown options', () => {
+      const unknownOptions: GeopointOptions = {
+        // @ts-expect-error unknownOption is not part of GeopointOptions
+        unknownOption: true,
+      }
     })
   })
 })


### PR DESCRIPTION
### Description

Geopoint fields accept `collapsible` and `collapsed` at runtime - geopoint compiles to an `object` type, and the form layer resolves collapse generically for any object field. But `GeopointOptions` extended only `BaseSchemaTypeOptions` and never declared these props, so configuring them raised a TypeScript error even though the behaviour worked.

This PR makes `GeopointOptions` extend `ObjectOptions`, mirroring how `FileOptions` and `ImageOptions` already do. The collapse options (and the rest of the object-level options) now type-check on geopoint definitions. The change is purely additive to the type surface and touches no runtime code.

### What to review

- `GeopointOptions extends ObjectOptions` follows the existing `FileOptions extends ObjectOptions` precedent rather than hand-listing props, which also keeps `columns` available; `modal` is inert for an inline geopoint field but harmless to expose.

### Testing

Verified the fix resolves the reported error by compiling the usage before and after: `options: {collapsible, collapsed}` on a geopoint field emits `TS2353` against the old type and compiles clean against the new one. Added type-level coverage in `geopoint.test.ts`. Note this assertion is documentation-grade rather than a hard CI gate, since the root vitest config sets `typecheck.ignoreSourceErrors: true`, which suppresses test-file type errors repo-wide.

### Notes for release

Geopoint field options now support `collapsible` and `collapsed`, so geopoint fields can be configured as collapsible without a TypeScript error.
