### PR TITLE
fix(structure): restore default sort order and layout in document list pane

### DIFF
--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -506,10 +506,18 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'menu-items.layout.compact-view': 'Compact view',
   /** The menu item title to use the detailed view */
   'menu-items.layout.detailed-view': 'Detailed view',
+  /** The menu item title that restores the structure-configured default layout */
+  'menu-items.layout.restore-default': 'Default view',
+  /** Tooltip shown when the restore-default layout item is disabled (default already in use) */
+  'menu-items.layout.restore-default.disabled-reason': 'Already using the default view',
   /** The menu item title to Sort by Created */
   'menu-items.sort-by.created': 'Sort by Created',
   /** The menu item title to Sort by Last Edited */
   'menu-items.sort-by.last-edited': 'Sort by Last Edited',
+  /** The menu item title that restores the structure-configured default sort order */
+  'menu-items.sort-by.restore-default': 'Default sort',
+  /** Tooltip shown when the restore-default sort item is disabled (default already in use) */
+  'menu-items.sort-by.restore-default.disabled-reason': 'Already using the default sort order',
 
   /** The link text of the no document type screen that appears directly below the subtitle */
   'no-document-types-screen.link-text': 'Learn how to add a document type →',

--- a/packages/sanity/src/structure/panes/documentList/PaneContainer.tsx
+++ b/packages/sanity/src/structure/panes/documentList/PaneContainer.tsx
@@ -108,6 +108,48 @@ export const addSelectedStateToMenuItems = (options: {
   })
 }
 
+/**
+ * Appends restore-default items to the Sort and Layout groups. Injected at
+ * render time so panes with custom `menuItems` still receive them.
+ *
+ * @internal exported for testing
+ */
+export const appendRestoreDefaultItems = (options: {
+  menuItems?: PaneMenuItem[]
+  isSortDefault: boolean
+  isLayoutDefault: boolean
+  restoreSortDisabledReason: string
+  restoreLayoutDisabledReason: string
+}): PaneMenuItem[] => {
+  const {
+    menuItems = [],
+    isSortDefault,
+    isLayoutDefault,
+    restoreSortDisabledReason,
+    restoreLayoutDisabledReason,
+  } = options
+
+  const restoreDefaultSortOrderItem: PaneMenuItem = {
+    group: 'sorting',
+    action: 'restoreDefaultSortOrder',
+    i18n: {title: {key: 'menu-items.sort-by.restore-default', ns: structureLocaleNamespace}},
+    title: 'Default sort',
+    params: {hideSelectionIndicator: true},
+    ...(isSortDefault && {disabled: {reason: restoreSortDisabledReason}}),
+  }
+
+  const restoreDefaultLayoutItem: PaneMenuItem = {
+    group: 'layout',
+    action: 'restoreDefaultLayout',
+    i18n: {title: {key: 'menu-items.layout.restore-default', ns: structureLocaleNamespace}},
+    title: 'Default view',
+    params: {hideSelectionIndicator: true},
+    ...(isLayoutDefault && {disabled: {reason: restoreLayoutDisabledReason}}),
+  }
+
+  return [...menuItems, restoreDefaultSortOrderItem, restoreDefaultLayoutItem]
+}
+
 export function useShallowUnique<ValueType>(value: ValueType): ValueType {
   const [previous, setPrevious] = useState<ValueType>(value)
   if (!shallowEquals(previous, value)) {
@@ -189,6 +231,15 @@ export const PaneContainer = memo(function PaneContainer(
     [setStoredSortOrder, schemaType, defaultSortOrder],
   )
 
+  // Write the default back so its matching menu item regains its checkmark.
+  const handleRestoreDefaultSortOrder = useCallback(async () => {
+    await setStoredSortOrder(toStaticSortOrder(defaultSortOrder))
+  }, [setStoredSortOrder, defaultSortOrder])
+
+  const handleRestoreDefaultLayout = useCallback(async () => {
+    await setLayout(defaultLayout)
+  }, [setLayout, defaultLayout])
+
   const [customMenuItemState, setCustomMenuItemState] = useState<CustomMenuItemState>({})
 
   const menuItemsWithIds = useMemo(() => addIdsToMenuItems(menuItems), [menuItems])
@@ -215,6 +266,25 @@ export const PaneContainer = memo(function PaneContainer(
     ],
   )
 
+  const isLayoutDefault = layout === defaultLayout
+  // Compare the stored static order, not the hydrated validatedSortOrder.
+  const isSortDefault = useMemo(
+    () => isEqual(storedSortOrderRaw?.by ?? [], toStaticSortOrder(defaultSortOrder).by),
+    [storedSortOrderRaw, defaultSortOrder],
+  )
+
+  const menuItemsWithRestoreDefaults = useMemo(
+    () =>
+      appendRestoreDefaultItems({
+        menuItems: menuItemsWithSelectedState,
+        isSortDefault,
+        isLayoutDefault,
+        restoreSortDisabledReason: t('menu-items.sort-by.restore-default.disabled-reason'),
+        restoreLayoutDisabledReason: t('menu-items.layout.restore-default.disabled-reason'),
+      }),
+    [menuItemsWithSelectedState, isSortDefault, isLayoutDefault, t],
+  )
+
   return (
     <SourceProvider name={sourceName || parentSourceName}>
       <Pane
@@ -236,10 +306,12 @@ export const PaneContainer = memo(function PaneContainer(
           index={index}
           initialValueTemplates={initialValueTemplates}
           menuItemGroups={menuItemGroups}
-          menuItems={menuItemsWithSelectedState}
+          menuItems={menuItemsWithRestoreDefaults}
           setLayout={setLayout}
           setSortOrder={handleSetSortOrder}
           setCustomMenuItemState={setCustomMenuItemState}
+          restoreDefaultLayout={handleRestoreDefaultLayout}
+          restoreDefaultSortOrder={handleRestoreDefaultSortOrder}
           title={title}
         />
         <DocumentListPane {...props} sortOrder={validatedSortOrder} layout={layout} />

--- a/packages/sanity/src/structure/panes/documentList/PaneHeader.tsx
+++ b/packages/sanity/src/structure/panes/documentList/PaneHeader.tsx
@@ -27,6 +27,8 @@ interface PaneHeaderProps {
   setLayout: (layout: GeneralPreviewLayoutKey) => void
   setSortOrder: (sortOrder: SortOrder) => void
   setCustomMenuItemState: (state: Record<string, unknown>) => void
+  restoreDefaultLayout: () => void
+  restoreDefaultSortOrder: () => void
   title: string
 }
 
@@ -41,6 +43,8 @@ export const PaneHeader = memo(
     setLayout,
     setSortOrder,
     setCustomMenuItemState,
+    restoreDefaultLayout,
+    restoreDefaultSortOrder,
     title,
   }: PaneHeaderProps) => {
     const {features} = useStructureTool()
@@ -56,6 +60,8 @@ export const PaneHeader = memo(
         setSortOrder: (sort: SortOrder) => {
           setSortOrder(sort)
         },
+        restoreDefaultLayout,
+        restoreDefaultSortOrder,
         setMenuItemState: (params: {_menuItemId: string; value?: unknown}) => {
           const id = params._menuItemId
           const value = params.value ?? true
@@ -72,7 +78,14 @@ export const PaneHeader = memo(
           }
         },
       }
-    }, [customMenuItemState, setLayout, setSortOrder, setCustomMenuItemState])
+    }, [
+      customMenuItemState,
+      setLayout,
+      setSortOrder,
+      setCustomMenuItemState,
+      restoreDefaultLayout,
+      restoreDefaultSortOrder,
+    ])
 
     return (
       <TooltipDelayGroupProvider>

--- a/packages/sanity/src/structure/panes/documentList/__tests__/addSelectedStateToMenuItems.test.ts
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/addSelectedStateToMenuItems.test.ts
@@ -3,7 +3,7 @@ import {type ObjectSchemaType} from '@sanity/types'
 import {describe, expect, test} from 'vitest'
 
 import {type PaneMenuItem} from '../../../types'
-import {addSelectedStateToMenuItems} from '../PaneContainer'
+import {addSelectedStateToMenuItems, appendRestoreDefaultItems} from '../PaneContainer'
 
 const mockSchema = Schema.compile({
   name: 'default',
@@ -159,5 +159,79 @@ describe('addSelectedStateToMenuItems', () => {
       expect(result![0].selected).toBe(true)
       expect(result![0].disabled).toEqual({reason: 'Sort order invalid'})
     })
+  })
+})
+
+describe('appendRestoreDefaultItems', () => {
+  const restoreOptions = {
+    isSortDefault: false,
+    isLayoutDefault: false,
+    restoreSortDisabledReason: 'Already using the default sort order',
+    restoreLayoutDisabledReason: 'Already using the default view',
+  }
+
+  test('appends a restore-default item to the sorting and layout groups', () => {
+    const existing: PaneMenuItem[] = [{id: 'existing', title: 'Existing', group: 'sorting'}]
+
+    const result = appendRestoreDefaultItems({menuItems: existing, ...restoreOptions})
+
+    expect(result).toHaveLength(3)
+    expect(result[0]).toBe(existing[0])
+
+    const sortItem = result.find((item) => item.action === 'restoreDefaultSortOrder')
+    const layoutItem = result.find((item) => item.action === 'restoreDefaultLayout')
+
+    expect(sortItem).toMatchObject({group: 'sorting', action: 'restoreDefaultSortOrder'})
+    expect(layoutItem).toMatchObject({group: 'layout', action: 'restoreDefaultLayout'})
+  })
+
+  test('hides the selection indicator on both restore items', () => {
+    const result = appendRestoreDefaultItems(restoreOptions)
+
+    expect(result.every((item) => item.params?.hideSelectionIndicator === true)).toBe(true)
+  })
+
+  test('restore items have no id so they do not trigger toggle-state tracking', () => {
+    const result = appendRestoreDefaultItems(restoreOptions)
+
+    expect(result.every((item) => item.id === undefined)).toBe(true)
+  })
+
+  test('restore items carry no icon', () => {
+    const result = appendRestoreDefaultItems(restoreOptions)
+
+    expect(result.every((item) => item.icon === undefined)).toBe(true)
+  })
+
+  test('handles an undefined menu item list', () => {
+    const result = appendRestoreDefaultItems(restoreOptions)
+
+    expect(result).toHaveLength(2)
+  })
+
+  test('disables only the sort restore item when sort is already default', () => {
+    const result = appendRestoreDefaultItems({...restoreOptions, isSortDefault: true})
+
+    const sortItem = result.find((item) => item.action === 'restoreDefaultSortOrder')
+    const layoutItem = result.find((item) => item.action === 'restoreDefaultLayout')
+
+    expect(sortItem!.disabled).toEqual({reason: 'Already using the default sort order'})
+    expect(layoutItem!.disabled).toBeUndefined()
+  })
+
+  test('disables only the layout restore item when layout is already default', () => {
+    const result = appendRestoreDefaultItems({...restoreOptions, isLayoutDefault: true})
+
+    const sortItem = result.find((item) => item.action === 'restoreDefaultSortOrder')
+    const layoutItem = result.find((item) => item.action === 'restoreDefaultLayout')
+
+    expect(layoutItem!.disabled).toEqual({reason: 'Already using the default view'})
+    expect(sortItem!.disabled).toBeUndefined()
+  })
+
+  test('leaves both restore items enabled when neither setting is default', () => {
+    const result = appendRestoreDefaultItems(restoreOptions)
+
+    expect(result.every((item) => item.disabled === undefined)).toBe(true)
   })
 })


### PR DESCRIPTION
### Description

In the structure tool's document list pane, once a user manually changed the sort order or layout there was no way to return to the structure-configured `defaultOrdering` / `defaultLayout`. The preference is server-synced, so clearing local storage does not help. Fixes #12835.

This PR adds two menu items - "Default sort" in the Sort group and "Default view" in the Layout group - that write the configured default back as the stored value, restoring the default ordering or layout. They are injected at render time so panes with custom `menuItems` also receive them, and are disabled when the pane is already on its default.

<img width="355" height="343" alt="Screenshot 2026-06-16 at 18 04 04" src="https://github.com/user-attachments/assets/9b52f102-f777-4a11-93c3-ba8bbcc7712e" />

### What to review

- `appendRestoreDefaultItems` in `PaneContainer.tsx` synthesises the items at render time and marks them disabled via the `isSortDefault` / `isLayoutDefault` flags.
- Restore writes the configured default value back. An earlier approach that cleared the stored key to `null` was dropped: the `null` round-trip through the server key-value store left the stored value empty, so the matching item never regained its checkmark.
- The items carry no `id`, so they do not opt into `setMenuItemState` toggle tracking.
- A custom pane whose `menuItemGroups` omit `sorting` / `layout` would render auto-created groups for these items - worth a look if that path matters to you.

### Testing

- Unit tests for `appendRestoreDefaultItems`: items appended to the correct groups, `hideSelectionIndicator` set, no `id` or icon, and disabled when already on default.
- Interaction test in `PaneContainer.test.tsx` asserting a click on "Default sort" writes the default sort order back.
- Manual verification in the dev studio.

### Notes for release

The structure tool's document list pane now provides Default sort and Default view menu items to restore the structure-configured default ordering and layout after a manual change.
