### PR TITLE
fix(portable-text): size the drop indicator to the block, not the full editable

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
@@ -120,6 +120,10 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $isOneLine:
       $isOneLine ? '0' : theme.sanity.space[$isFullscreen ? 9 : 5]}px;
 
     & > [data-pt-block] {
+      /* Positioning context for the absolutely-positioned drop indicator so it
+         sizes to the block (the centred text column) instead of the full-width
+         .pt-editable, which overshoots the block in fullscreen. */
+      position: relative;
       margin: 0 auto;
       max-width: ${(props) => getTheme_v2(props.theme).container[1]}px;
     }


### PR DESCRIPTION
### Description

The drag drop indicator overshoots the block in fullscreen. It is absolutely positioned with `width: calc(100% - 2 * space)`, so it sizes against its nearest positioned ancestor. Blocks are centred to the text column via `& > [data-pt-block] { margin: 0 auto; max-width: container[1] }`, but the block was never a positioning context, so the indicator resolved against `.pt-editable`, the full editable width. At normal width `.pt-editable` is close to the block so it looks contained; in fullscreen `.pt-editable` expands to the screen and the indicator sticks out past the block on both sides.

The fix makes the block a positioning context (`position: relative` on `& > [data-pt-block]`) so the indicator sizes to the centred text column.

### What to review

That `position: relative` is the right home: it goes on the rule that already centres the block (`margin: 0 auto; max-width`), so the block is the natural containing block for its absolutely-positioned drop indicator. The indicator's own rule (`left` / `right` / `width: calc(100% - 2 * space)`) is unchanged; only what `100%` resolves against changes, from `.pt-editable` to the block.

### Testing

Drag a block in a Portable Text field while in fullscreen: before, the drop indicator spans most of the editable; after, it is contained to the text column. No automated test: this is a CSS positioning fix and is not asserted by the Portable Text browser tests.

### Notes for release

In the expanded (fullscreen) Portable Text editor, the drag-and-drop drop indicator (the line that marks where a dragged block will land) stretched the full width of the editor instead of lining up with the content. It now aligns to the content column.
