### PR TITLE
feat(comments): anchor text comments on the block's data path

### DIFF
--- a/packages/sanity/src/core/comments/__tests__/buildRangeDecorationSelectionsFromComments/nestedContainer.test.ts
+++ b/packages/sanity/src/core/comments/__tests__/buildRangeDecorationSelectionsFromComments/nestedContainer.test.ts
@@ -1,0 +1,91 @@
+import {type Path} from '@sanity/types'
+import {describe, expect, test} from 'vitest'
+
+import {type CommentDocument} from '../../types'
+import {buildRangeDecorationSelectionsFromComments, COMMENT_INDICATORS} from '../../utils'
+
+// A callout block in `body` whose `content` holds the commented text block.
+const value = [
+  {
+    _key: 'callout',
+    _type: 'callout',
+    content: [
+      {
+        _key: 'b1',
+        _type: 'block',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's1', marks: [], text: 'Hello there world'}],
+      },
+    ],
+  },
+]
+
+const comment = (): CommentDocument => ({
+  _id: 'c1',
+  _type: 'comment',
+  _createdAt: '',
+  _rev: '',
+  authorId: '',
+  message: null,
+  threadId: '',
+  status: 'open',
+  reactions: null,
+  target: {
+    documentRevisionId: '',
+    path: {
+      field: 'body[_key=="callout"].content',
+      selection: {
+        type: 'text',
+        value: [
+          {_key: 'b1', text: `Hello ${COMMENT_INDICATORS[0]}there${COMMENT_INDICATORS[1]} world`},
+        ],
+      },
+    },
+    documentType: '',
+    document: {
+      _dataset: '',
+      _projectId: '',
+      _ref: '',
+      _type: 'crossDatasetReference',
+      _weak: false,
+    },
+  },
+})
+
+describe('comments: buildRangeDecorationSelectionsFromComments (nested container)', () => {
+  test('body editor (inline): descends `field` and prefixes the decoration with the container path', () => {
+    const [decoration] = buildRangeDecorationSelectionsFromComments({
+      value,
+      comments: [comment()],
+      basePath: ['body'],
+    })
+
+    expect(decoration.selection).toEqual({
+      anchor: {
+        offset: 6,
+        path: [{_key: 'callout'}, 'content', {_key: 'b1'}, 'children', {_key: 's1'}],
+      },
+      focus: {
+        offset: 11,
+        path: [{_key: 'callout'}, 'content', {_key: 'b1'}, 'children', {_key: 's1'}],
+      },
+    })
+  })
+
+  test('the litmus: the dialog editor resolves the same comment to the same span (shallower path, same offsets)', () => {
+    const contentValue = value[0].content
+    const dialogBasePath: Path = ['body', {_key: 'callout'}, 'content']
+
+    const [decoration] = buildRangeDecorationSelectionsFromComments({
+      value: contentValue,
+      comments: [comment()],
+      basePath: dialogBasePath,
+    })
+
+    expect(decoration.selection).toEqual({
+      anchor: {offset: 6, path: [{_key: 'b1'}, 'children', {_key: 's1'}]},
+      focus: {offset: 11, path: [{_key: 'b1'}, 'children', {_key: 's1'}]},
+    })
+  })
+})

--- a/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
+++ b/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
@@ -39,6 +39,8 @@ import {
   buildCommentRangeDecorations,
   buildRangeDecorationSelectionsFromComments,
   buildTextSelectionFromFragment,
+  editorOwnsCommentField,
+  getCommentFieldPath,
 } from '../../../utils'
 import {getSelectionBoundingRect, useAuthoringReferenceElement} from '../helpers'
 import {FloatingButtonPopover} from './FloatingButtonPopover'
@@ -109,6 +111,13 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
     useState<RangeDecoration[]>(EMPTY_ARRAY)
 
   const stringFieldPath = useMemo(() => PathUtils.toString(props.path), [props.path])
+
+  // The data paths this editor draws inline (e.g. container content) and so
+  // owns comments for, beyond its own `stringFieldPath`. Empty until the
+  // container render pipeline supplies them; the routing then stays exact-match
+  // and every editor owns exactly its own field path, matching today.
+  const renderedInlinePaths = EMPTY_ARRAY as ReadonlyArray<string>
+
   const [fragment, setFragment] = useState<PortableTextBlock[] | null>(null)
 
   const getFragment = useCallback(() => {
@@ -152,10 +161,12 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
 
   const textComments = useMemo(() => {
     return comments.data.open
-      .filter((comment) => comment.fieldPath === stringFieldPath)
+      .filter((comment) =>
+        editorOwnsCommentField(props.path, comment.fieldPath, renderedInlinePaths),
+      )
       .filter((c) => isTextSelectionComment(c.parentComment))
       .map((c) => c.parentComment)
-  }, [comments.data.open, stringFieldPath])
+  }, [comments.data.open, props.path, renderedInlinePaths])
 
   const handleSubmit = useCallback(() => {
     if (!nextCommentSelection || !editorRef.current) return
@@ -172,10 +183,19 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
 
     const threadId = uuid()
 
+    // The comment's `field` is the data path to the commented block's
+    // containing array, derived from the document location, not this editor's
+    // path. For root blocks and dialog/void-object renderings this equals
+    // `stringFieldPath`; for content rendered inline in a container it descends
+    // to the nested array, so the anchor is identical across renderings.
+    const fieldPath = nextCommentSelection
+      ? getCommentFieldPath(props.path, nextCommentSelection.focus.path)
+      : stringFieldPath
+
     void operation.create({
       type: 'field',
       contentSnapshot: fragment,
-      fieldPath: stringFieldPath,
+      fieldPath,
       message: nextCommentValue,
       parentCommentId: undefined,
       reactions: EMPTY_ARRAY,
@@ -194,7 +214,7 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
 
     // Set the selected path to the new comment
     setSelectedPath({
-      fieldPath: stringFieldPath,
+      fieldPath,
       threadId,
       origin: 'form',
     })
@@ -206,6 +226,7 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
   }, [
     nextCommentSelection,
     operation,
+    props.path,
     stringFieldPath,
     nextCommentValue,
     onCommentsOpen,
@@ -327,6 +348,7 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
       const [updatedDecoration] = buildRangeDecorationSelectionsFromComments({
         comments: [comment],
         value: editorValue,
+        basePath: props.path,
       })
 
       const nextRange = updatedDecoration?.range ? [updatedDecoration.range] : EMPTY_ARRAY
@@ -380,7 +402,7 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
       })
       return next.filter((p) => p.selection !== null)
     })
-  }, [addedCommentsDecorations, getComment, operation])
+  }, [addedCommentsDecorations, getComment, operation, props.path])
 
   const handleBuildRangeDecorations = useCallback(
     (commentsToDecorate: CommentDocument[]) => {
@@ -396,12 +418,14 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
         onDecorationMoved: handleRangeDecorationMoved,
         selectedThreadId: selectedPath?.threadId || null,
         value: editorValue,
+        basePath: props.path,
       })
     },
     [
       currentHoveredCommentId,
       handleDecoratorClick,
       handleRangeDecorationMoved,
+      props.path,
       selectedPath?.threadId,
     ],
   )

--- a/packages/sanity/src/core/comments/utils/inline-comments/buildCommentRangeDecorations.tsx
+++ b/packages/sanity/src/core/comments/utils/inline-comments/buildCommentRangeDecorations.tsx
@@ -1,5 +1,5 @@
 import {type RangeDecoration, type RangeDecorationOnMovedDetails} from '@portabletext/editor'
-import {type PortableTextBlock} from '@sanity/types'
+import {type Path, type PortableTextBlock} from '@sanity/types'
 import {memo, useCallback, useEffect, useRef, useState} from 'react'
 
 import {CommentInlineHighlightSpan} from '../../components'
@@ -97,6 +97,7 @@ interface BuildRangeDecorationsProps {
   onDecorationMoved: (details: RangeDecorationOnMovedDetails) => void
   selectedThreadId: string | null
   value: PortableTextBlock[] | undefined
+  basePath?: Path
 }
 
 /**
@@ -112,8 +113,9 @@ export function buildCommentRangeDecorations(props: BuildRangeDecorationsProps) 
     onDecorationMoved,
     selectedThreadId,
     value,
+    basePath,
   } = props
-  const rangeSelections = buildRangeDecorationSelectionsFromComments({comments, value})
+  const rangeSelections = buildRangeDecorationSelectionsFromComments({comments, value, basePath})
 
   const decorations = rangeSelections.map(({selection, comment, range}) => {
     const decoration: RangeDecoration = {

--- a/packages/sanity/src/core/comments/utils/inline-comments/buildRangeDecorationSelectionsFromComments.ts
+++ b/packages/sanity/src/core/comments/utils/inline-comments/buildRangeDecorationSelectionsFromComments.ts
@@ -13,12 +13,14 @@ import {
 import {
   isPortableTextSpan,
   isPortableTextTextBlock,
+  type Path,
   type PortableTextBlock,
   type PortableTextTextBlock,
 } from '@sanity/types'
 
 import {isTextSelectionComment} from '../../helpers'
 import {type CommentDocument, type CommentsTextSelectionItem} from '../../types'
+import {resolveCommentArray} from './dataPath'
 
 // This must be set high to avoid false positives
 // (for example, when there are multiple occurrences of the same word, and you delete the original commented word)
@@ -57,6 +59,15 @@ const EMPTY_ARRAY: [] = []
 export interface BuildCommentsRangeDecorationsProps {
   value: PortableTextBlock[] | undefined
   comments: CommentDocument[]
+  /**
+   * The editor's own document path. When provided, each comment's `field` is
+   * resolved relative to it: the editor descends to the block's containing
+   * array (the array is the editor value itself when `field` equals this path)
+   * and prefixes decoration selections so they address from the editor root.
+   * Omitted (e.g. in unit tests) means "search the top-level value", today's
+   * behavior.
+   */
+  basePath?: Path
 }
 
 /**
@@ -75,7 +86,7 @@ export interface BuildCommentsRangeDecorationsResultItem {
 export function buildRangeDecorationSelectionsFromComments(
   props: BuildCommentsRangeDecorationsProps,
 ): BuildCommentsRangeDecorationsResultItem[] {
-  const {value, comments} = props
+  const {value, comments, basePath} = props
 
   if (!value || value.length === 0) return EMPTY_ARRAY
 
@@ -83,8 +94,19 @@ export function buildRangeDecorationSelectionsFromComments(
   const decorators: BuildCommentsRangeDecorationsResultItem[] = []
 
   textSelections.forEach((comment) => {
+    const resolved = basePath
+      ? resolveCommentArray(
+          value as ReadonlyArray<Record<string, unknown>>,
+          basePath,
+          comment.target.path?.field ?? '',
+        )
+      : {array: value as ReadonlyArray<Record<string, unknown>>, prefix: [] as Path}
+    if (!resolved) return
+    const searchArray = resolved.array as unknown as PortableTextBlock[]
+    const {prefix} = resolved
+
     comment.target.path?.selection?.value.forEach((selectionMember) => {
-      const matchedBlock = value.find((block) => block._key === selectionMember._key)
+      const matchedBlock = searchArray.find((block) => block._key === selectionMember._key)
       if (!matchedBlock || !isPortableTextTextBlock(matchedBlock)) {
         return
       }
@@ -149,6 +171,7 @@ export function buildRangeDecorationSelectionsFromComments(
           selection: {
             anchor: {
               path: [
+                ...prefix,
                 {_key: matchedBlock._key},
                 'children',
                 {_key: matchedBlock.children[childIndexAnchor]._key},
@@ -157,6 +180,7 @@ export function buildRangeDecorationSelectionsFromComments(
             },
             focus: {
               path: [
+                ...prefix,
                 {_key: matchedBlock._key},
                 'children',
                 {_key: matchedBlock.children[childIndexFocus]._key},

--- a/packages/sanity/src/core/comments/utils/inline-comments/dataPath.test.ts
+++ b/packages/sanity/src/core/comments/utils/inline-comments/dataPath.test.ts
@@ -1,0 +1,94 @@
+import {type Path} from '@sanity/types'
+import {describe, expect, test} from 'vitest'
+
+import {editorOwnsCommentField, getCommentFieldPath, resolveCommentArray} from './dataPath'
+
+const CALLOUT = {_key: 'callout'}
+const BLOCK = {_key: 'b1'}
+const SPAN = {_key: 's1'}
+
+describe('comments dataPath: getCommentFieldPath', () => {
+  test('root block: field is the editor path (unchanged from today)', () => {
+    const basePath: Path = ['body']
+    const selectionPath: Path = [BLOCK, 'children', SPAN]
+    expect(getCommentFieldPath(basePath, selectionPath)).toBe('body')
+  })
+
+  test('inline container (body editor): field descends to the nested array', () => {
+    const basePath: Path = ['body']
+    const selectionPath: Path = [CALLOUT, 'content', BLOCK, 'children', SPAN]
+    expect(getCommentFieldPath(basePath, selectionPath)).toBe('body[_key=="callout"].content')
+  })
+
+  test('dialog/void-object (nested input): same field as inline, from a deeper basePath', () => {
+    const basePath: Path = ['body', CALLOUT, 'content']
+    const selectionPath: Path = [BLOCK, 'children', SPAN]
+    expect(getCommentFieldPath(basePath, selectionPath)).toBe('body[_key=="callout"].content')
+  })
+
+  test('the litmus: inline and dialog renderings produce an identical field', () => {
+    const inline = getCommentFieldPath(['body'], [CALLOUT, 'content', BLOCK, 'children', SPAN])
+    const dialog = getCommentFieldPath(['body', CALLOUT, 'content'], [BLOCK, 'children', SPAN])
+    expect(inline).toBe(dialog)
+  })
+})
+
+describe('comments dataPath: resolveCommentArray', () => {
+  const nestedValue = [
+    {
+      _key: 'callout',
+      _type: 'callout',
+      content: [{_key: 'b1', _type: 'block', children: [{_key: 's1', text: 'hello'}]}],
+    },
+  ]
+
+  test('field == basePath: empty descent, value as-is, no prefix (today)', () => {
+    const result = resolveCommentArray(nestedValue, ['body'], 'body')
+    expect(result).toEqual({array: nestedValue, prefix: []})
+  })
+
+  test('nested field: descends to the inner array and returns the keyed prefix', () => {
+    const result = resolveCommentArray(nestedValue, ['body'], 'body[_key=="callout"].content')
+    expect(result).toEqual({
+      array: nestedValue[0].content,
+      prefix: [{_key: 'callout'}, 'content'],
+    })
+  })
+
+  test('field not under basePath: undefined', () => {
+    expect(resolveCommentArray(nestedValue, ['body'], 'other')).toBeUndefined()
+  })
+
+  test('descent that does not resolve in the value: undefined', () => {
+    expect(
+      resolveCommentArray(nestedValue, ['body'], 'body[_key=="missing"].content'),
+    ).toBeUndefined()
+  })
+})
+
+describe('comments dataPath: editorOwnsCommentField', () => {
+  test('owns its own path', () => {
+    expect(editorOwnsCommentField(['body'], 'body')).toBe(true)
+  })
+
+  test('does not own a nested path when nothing is rendered inline (today)', () => {
+    expect(editorOwnsCommentField(['body'], 'body[_key=="callout"].content')).toBe(false)
+  })
+
+  test('owns a nested path it renders inline', () => {
+    expect(
+      editorOwnsCommentField(['body'], 'body[_key=="callout"].content', [
+        'body[_key=="callout"].content',
+      ]),
+    ).toBe(true)
+  })
+
+  test('the dialog content editor owns its own path regardless of inline paths', () => {
+    expect(
+      editorOwnsCommentField(
+        ['body', {_key: 'callout'}, 'content'],
+        'body[_key=="callout"].content',
+      ),
+    ).toBe(true)
+  })
+})

--- a/packages/sanity/src/core/comments/utils/inline-comments/dataPath.ts
+++ b/packages/sanity/src/core/comments/utils/inline-comments/dataPath.ts
@@ -1,0 +1,112 @@
+import {type Path, type PathSegment} from '@sanity/types'
+import * as PathUtils from '@sanity/util/paths'
+
+function isKeyedSegment(segment: PathSegment): segment is {_key: string} {
+  return typeof segment === 'object' && segment !== null && '_key' in segment
+}
+
+/**
+ * Given a fully-keyed selection path inside an editor (e.g.
+ * `[{_key: block}, 'children', {_key: span}]`), return the path to the block's
+ * containing array, relative to the editor root. For a root text block this is
+ * `[]`; for a block nested in a container it is e.g. `[{_key: callout}, 'content']`.
+ *
+ * Text-selection comments always focus inside a span of a text block, so the
+ * path ends in `[..., {_key: block}, 'children', {_key: span}]`. The containing
+ * array is everything before the block segment.
+ */
+function getContainingArrayPath(selectionPath: Path): Path {
+  const childrenIndex = selectionPath.lastIndexOf('children')
+
+  // Not the expected `[..., block, 'children', span]` shape: treat the block as
+  // a root-level block (empty relative path), preserving today's behavior.
+  if (childrenIndex <= 0) {
+    return []
+  }
+
+  return selectionPath.slice(0, childrenIndex - 1)
+}
+
+/**
+ * Compute a comment's `field`: the **data path** to the block's containing
+ * array, joining the editor's own document path (`basePath`) with the path from
+ * the editor root down to the block's parent array.
+ *
+ * This is rendering-agnostic. A callout's content yields
+ * `body[_key=="callout"].content` whether the editor is the body (inline
+ * container, `basePath = ['body']`) or the callout's own nested input
+ * (`basePath = ['body', {_key: callout}, 'content']`). For a root block it
+ * collapses to the editor path, matching what is stored today.
+ */
+export function getCommentFieldPath(basePath: Path, selectionPath: Path): string {
+  return PathUtils.toString([...basePath, ...getContainingArrayPath(selectionPath)])
+}
+
+/**
+ * The array of blocks an editor must search to resolve a comment, plus the path
+ * prefix to prepend to decoration selections so they are addressed from the
+ * editor root.
+ *
+ * When `field` is the editor's own path (root/dialog/void-object rendering),
+ * the descent is empty: the editor value is the array and the prefix is `[]`,
+ * byte-identical to resolving against the top-level value. When `field` is a
+ * data path nested below the editor (inline container), descend through the
+ * value to that array and return the keyed prefix.
+ *
+ * Returns `undefined` when `field` is not under `basePath` or the descent does
+ * not resolve (e.g. transient value mismatch).
+ */
+export function resolveCommentArray(
+  value: ReadonlyArray<Record<string, unknown>>,
+  basePath: Path,
+  field: string,
+): {array: ReadonlyArray<Record<string, unknown>>; prefix: Path} | undefined {
+  const fieldPath = PathUtils.fromString(field)
+
+  if (!PathUtils.startsWith(basePath, fieldPath)) {
+    return undefined
+  }
+
+  const relative = fieldPath.slice(basePath.length)
+
+  if (relative.length === 0) {
+    return {array: value, prefix: []}
+  }
+
+  let currentArray: ReadonlyArray<Record<string, unknown>> = value
+
+  for (let index = 0; index < relative.length; index++) {
+    const keyedSegment = relative[index]
+    if (!isKeyedSegment(keyedSegment)) {
+      return undefined
+    }
+    const node = currentArray.find((item) => item._key === keyedSegment._key)
+    const fieldSegment = relative[index + 1]
+    if (!node || typeof fieldSegment !== 'string') {
+      return undefined
+    }
+    const nextArray = node[fieldSegment]
+    if (!Array.isArray(nextArray)) {
+      return undefined
+    }
+    currentArray = nextArray as ReadonlyArray<Record<string, unknown>>
+    index++
+  }
+
+  return {array: currentArray, prefix: relative}
+}
+
+/**
+ * Whether the editor at `basePath` renders the data path `field`, and so should
+ * own that comment's decoration. It always owns its own path. It additionally
+ * owns nested data paths it draws inline (e.g. container content), supplied via
+ * `renderedInlinePaths`. With no inline paths (today), this collapses to exact
+ * match: one editor per field path.
+ */
+export function editorOwnsCommentField(
+  basePath: Path,
+  field: string,
+  renderedInlinePaths: ReadonlyArray<string> = [],
+): boolean {
+  return field === PathUtils.toString(basePath) || renderedInlinePaths.includes(field)
+}

--- a/packages/sanity/src/core/comments/utils/inline-comments/index.ts
+++ b/packages/sanity/src/core/comments/utils/inline-comments/index.ts
@@ -1,3 +1,4 @@
 export * from './buildCommentRangeDecorations'
 export * from './buildRangeDecorationSelectionsFromComments'
 export * from './buildTextSelectionFromFragment'
+export * from './dataPath'


### PR DESCRIPTION
### Description

A Portable Text comment must anchor identically no matter how the commented block is rendered: an edit dialog, a void object with its own nested input, or (soon) inline via `defineContainer`. Containers are a rendering flavor, not a new data location, and a comment's anchor must not leak which one is in play.

Today a comment's `field` is `PathUtils.toString(props.path)`, the rendering editor's form path; resolution finds the block with `value.find(_key)` over the editor's top-level blocks, routed by exact match (`comment.fieldPath === stringFieldPath`). That is correct only by coincidence: every Studio form path *is* a data path, so the rendering coordinate and the data coordinate line up. A callout rendered as a void object works because its `content` is its own nested input whose form path already is `body[_key=="callout"].content`. Nothing is broken today.

The coincidence breaks the moment one editor renders nested content inline. A `defineContainer` body editor would store `field: body` (too shallow to locate the nested block), the block is no longer a top-level block of the body value (resolution misses it), and exact-match routing cannot express "one editor owns deeply nested blocks."

This re-roots the comment's identity in the data layer. `field` becomes the data path to the block's containing array, computed from the document location, via three pure functions in `utils/inline-comments/dataPath.ts`:

- `getCommentFieldPath(basePath, selectionPath)` joins the editor's document path with the path from the editor root to the block's parent array. Collapses to today's value for root/dialog/void-object.
- `resolveCommentArray(value, basePath, field)` descends `field` relative to the editor's `props.path` and returns the inner array plus a keyed prefix; `field === basePath` is an empty descent (byte-identical to the previous top-level search). Decoration selections are prefixed so they address from the editor root.
- `editorOwnsCommentField(basePath, field, renderedInlinePaths)` replaces exact-match routing: an editor owns its own path plus the nested data paths it draws inline.

`renderedInlinePaths` is injected and empty until the container render pipeline (sanity#12963) supplies it, so routing stays exact-match and every editor owns exactly its own field path. Net behavior is unchanged today, and there is no data migration: existing `field` values are already data-layer coordinates, so they keep resolving and are forward-compatible (a comment authored under a dialog resolves unchanged once the same content renders inline). PTE needs no changes; it already exposes deep keyed paths inside containers in selection, DOM (`data-pt-path`), and model (`getFocusBlock`).

### What to review

- `utils/inline-comments/dataPath.ts` — the three pure functions and the guardrail that `field` stays at containing-array granularity (root comments stay `field = body`).
- `buildRangeDecorationSelectionsFromComments.ts` / `buildCommentRangeDecorations.tsx` — the descent + prefix; behavior-preserving when no `basePath` is passed.
- `CommentsPortableTextInput.tsx` — creation now derives `field` from `getCommentFieldPath`, routing uses `editorOwnsCommentField`, and both decoration call sites pass `basePath`. `renderedInlinePaths` is the seam containers will fill.

No reviewer setup needed; behavior is identical to `main` for all renderings that exist today (root, dialog, void object).

### Testing

- `dataPath.test.ts` — field computation (root vs nested vs deeper-basePath all agree on the same data path), the descent, and ownership.
- `nestedContainer.test.ts` — the resolver litmus: the same stored comment resolves to the same span whether the body editor descends to it (deep prefixed path) or the dialog editor holds it at root (shallow path, same offsets).
- The existing `buildRangeDecorationSelectionsFromComments` suites pass unchanged, confirming the empty-descent path is byte-identical.

Deferred (needs containers): the live end-to-end test that mounts a real inline-rendered callout, drives a selection through `getFocusBlock`, and asserts the decoration lands on the nested DOM. Draft until that can run and the container pipeline populates `renderedInlinePaths`.

### Notes for release

N/A – Internal, behavior-neutral. Establishes data-path comment anchoring ahead of inline container rendering; dormant (no observable change) until containers enable it.
