### PR TITLE
feat(comments): anchor text comments on the block's data path

### DIFF
--- a/dev/test-studio/schema/standard/portableText/customPlugins.tsx
+++ b/dev/test-studio/schema/standard/portableText/customPlugins.tsx
@@ -2,7 +2,13 @@ import {defineContainer} from '@portabletext/editor'
 import {defineBehavior, effect, forward, raise} from '@portabletext/editor/behaviors'
 import {BehaviorPlugin, NodePlugin} from '@portabletext/editor/plugins'
 import {CharacterPairDecoratorPlugin} from '@portabletext/plugin-character-pair-decorator'
-import {defineArrayMember, defineField, defineType, type PortableTextPluginsProps} from 'sanity'
+import {
+  defineArrayMember,
+  defineField,
+  defineType,
+  type PortableTextPluginsProps,
+  useFormValue,
+} from 'sanity'
 
 const CONTAINER_NODES = [
   defineContainer({
@@ -137,11 +143,19 @@ const containerScaffoldBehaviors = [
 ]
 
 function ContainerPlugins(props: PortableTextPluginsProps) {
+  // Flips the same document between inline container rendering and
+  // dialog-edited block objects; see the `containersEnabled` field description.
+  const containersEnabled = useFormValue(['containersEnabled']) !== false
+
   return (
     <>
       {props.renderDefault(props)}
-      <NodePlugin nodes={CONTAINER_NODES} />
-      <BehaviorPlugin behaviors={containerScaffoldBehaviors} />
+      {containersEnabled ? (
+        <>
+          <NodePlugin nodes={CONTAINER_NODES} />
+          <BehaviorPlugin behaviors={containerScaffoldBehaviors} />
+        </>
+      ) : null}
     </>
   )
 }
@@ -151,6 +165,14 @@ export const customPlugins = defineType({
   title: 'Custom Plugins',
   type: 'document',
   fields: [
+    {
+      type: 'boolean',
+      name: 'containersEnabled',
+      title: 'Render containers inline',
+      description:
+        'When off, the Container Table field renders `table` and `codeBlock` as block objects edited through the dialog. Author a comment on nested text in one mode and toggle to verify it resolves in the other.',
+      initialValue: true,
+    },
     {
       type: 'array',
       name: 'containerTable',

--- a/packages/sanity/src/core/comments/__tests__/buildRangeDecorationSelectionsFromComments/nestedContainer.test.ts
+++ b/packages/sanity/src/core/comments/__tests__/buildRangeDecorationSelectionsFromComments/nestedContainer.test.ts
@@ -1,0 +1,140 @@
+import {type Path} from '@sanity/types'
+import {describe, expect, test} from 'vitest'
+
+import {type CommentDocument} from '../../types'
+import {buildRangeDecorationSelectionsFromComments, COMMENT_INDICATORS} from '../../utils'
+
+const value = [
+  {
+    _key: 'callout',
+    _type: 'callout',
+    content: [
+      {
+        _key: 'b1',
+        _type: 'block',
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 's1', marks: [], text: 'Hello there world'}],
+      },
+    ],
+  },
+]
+
+const documentValue = {
+  _id: 'doc1',
+  _type: 'article',
+  body: value,
+}
+
+const comment = (): CommentDocument => ({
+  _id: 'c1',
+  _type: 'comment',
+  _createdAt: '',
+  _rev: '',
+  authorId: '',
+  message: null,
+  threadId: '',
+  status: 'open',
+  reactions: null,
+  target: {
+    documentRevisionId: '',
+    path: {
+      field: 'body[_key=="callout"].content',
+      selection: {
+        type: 'text',
+        value: [
+          {_key: 'b1', text: `Hello ${COMMENT_INDICATORS[0]}there${COMMENT_INDICATORS[1]} world`},
+        ],
+      },
+    },
+    documentType: '',
+    document: {
+      _dataset: '',
+      _projectId: '',
+      _ref: '',
+      _type: 'crossDatasetReference',
+      _weak: false,
+    },
+  },
+})
+
+describe('comments: buildRangeDecorationSelectionsFromComments (nested container)', () => {
+  test('body editor (inline): descends `field` and prefixes the decoration with the container path', () => {
+    const [decoration] = buildRangeDecorationSelectionsFromComments({
+      value,
+      comments: [comment()],
+      documentValue,
+      basePath: ['body'],
+    })
+
+    expect(decoration.selection).toEqual({
+      anchor: {
+        offset: 6,
+        path: [{_key: 'callout'}, 'content', {_key: 'b1'}, 'children', {_key: 's1'}],
+      },
+      focus: {
+        offset: 11,
+        path: [{_key: 'callout'}, 'content', {_key: 'b1'}, 'children', {_key: 's1'}],
+      },
+    })
+  })
+
+  test('excludes a comment whose `field` belongs to a sibling editor', () => {
+    const siblingComment = comment()
+    siblingComment.target.path!.field = 'summary'
+
+    expect(
+      buildRangeDecorationSelectionsFromComments({
+        value,
+        comments: [siblingComment],
+        documentValue,
+        basePath: ['body'],
+      }),
+    ).toEqual([])
+  })
+
+  test('skips a comment with an unparseable stored `field` instead of throwing', () => {
+    const corruptComment = comment()
+    corruptComment.target.path!.field = '[[['
+
+    expect(
+      buildRangeDecorationSelectionsFromComments({
+        value,
+        comments: [corruptComment],
+        documentValue,
+        basePath: ['body'],
+      }),
+    ).toEqual([])
+  })
+
+  test('skips a comment with no stored `field` instead of throwing', () => {
+    const malformedComment = comment()
+    malformedComment.target.path!.field = ''
+
+    expect(
+      buildRangeDecorationSelectionsFromComments({
+        value,
+        comments: [malformedComment],
+        documentValue,
+        basePath: ['body'],
+      }),
+    ).toEqual([])
+  })
+
+  test('the litmus: the dialog editor resolves the same comment to the same span (shallower path, same offsets)', () => {
+    const contentValue = value[0].content
+    const dialogBasePath: Path = ['body', {_key: 'callout'}, 'content']
+
+    const [decoration] = buildRangeDecorationSelectionsFromComments({
+      value: contentValue,
+      comments: [comment()],
+      documentValue,
+      basePath: dialogBasePath,
+    })
+
+    expect(decoration.selection).toEqual({
+      anchor: {offset: 6, path: [{_key: 'b1'}, 'children', {_key: 's1'}]},
+      focus: {offset: 11, path: [{_key: 'b1'}, 'children', {_key: 's1'}]},
+    })
+  })
+})

--- a/packages/sanity/src/core/comments/__tests__/buildTextSelectionFromFragment.test.ts
+++ b/packages/sanity/src/core/comments/__tests__/buildTextSelectionFromFragment.test.ts
@@ -1,0 +1,158 @@
+import {type EditorSelection} from '@portabletext/editor'
+import {describe, expect, test} from 'vitest'
+
+import {COMMENT_INDICATORS} from '../utils/inline-comments/buildRangeDecorationSelectionsFromComments'
+import {buildTextSelectionFromFragment} from '../utils/inline-comments/buildTextSelectionFromFragment'
+
+const documentValue = {
+  _id: 'doc1',
+  _type: 'article',
+  body: [
+    {
+      _key: 'b1',
+      _type: 'block',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 's1', marks: [], text: 'Hello world'}],
+    },
+    {
+      _key: 'callout',
+      _type: 'callout',
+      content: [
+        {
+          _key: 'b1',
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 's1', marks: [], text: 'Nested there world'}],
+        },
+      ],
+    },
+  ],
+}
+
+const bodyBlock = documentValue.body[0] as {
+  _key: string
+  _type: string
+  style: string
+  markDefs: unknown[]
+  children: Array<{_type: string; _key: string; marks: string[]; text: string}>
+}
+const nestedBlock = (documentValue.body[1] as {content: Array<typeof bodyBlock>}).content[0]
+
+function fragmentOf(block: typeof bodyBlock, sliceText: string) {
+  return [
+    {
+      _key: block._key,
+      _type: block._type,
+      style: block.style,
+      markDefs: block.markDefs,
+      children: [{...block.children[0], text: sliceText}],
+    },
+  ]
+}
+
+const selectionOnBlock = (
+  block: typeof bodyBlock,
+  anchor: number,
+  focus: number,
+): EditorSelection => ({
+  anchor: {path: [{_key: block._key}, 'children', {_key: block.children[0]._key}], offset: anchor},
+  focus: {path: [{_key: block._key}, 'children', {_key: block.children[0]._key}], offset: focus},
+})
+
+describe('comments: buildTextSelectionFromFragment', () => {
+  test('root editor: resolves the block through the document value and wraps commented text', () => {
+    const result = buildTextSelectionFromFragment({
+      fragment: fragmentOf(bodyBlock, 'Hello'),
+      documentValue,
+      basePath: ['body'],
+      selection: selectionOnBlock(bodyBlock, 0, 5),
+    })
+
+    expect(result.value[0]._key).toBe('b1')
+    expect(result.value[0].text).toBe(`${COMMENT_INDICATORS[0]}Hello${COMMENT_INDICATORS[1]} world`)
+  })
+
+  test('multi-block selection: middle blocks resolve and wrap their full text', () => {
+    const multiBlockDocument = {
+      _id: 'doc1',
+      _type: 'article',
+      body: [
+        {
+          _key: 'first',
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 's1', marks: [], text: 'First block'}],
+        },
+        {
+          _key: 'middle',
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 's1', marks: [], text: 'Middle block'}],
+        },
+        {
+          _key: 'last',
+          _type: 'block',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 's1', marks: [], text: 'Last block'}],
+        },
+      ],
+    }
+
+    // Selection from "block" in `first` through "Last" in `last`, so the
+    // fragment covers all three blocks and `middle` is neither the anchor
+    // nor the focus block.
+    const result = buildTextSelectionFromFragment({
+      fragment: [
+        {
+          ...multiBlockDocument.body[0],
+          children: [{...multiBlockDocument.body[0].children[0], text: 'block'}],
+        },
+        multiBlockDocument.body[1],
+        {
+          ...multiBlockDocument.body[2],
+          children: [{...multiBlockDocument.body[2].children[0], text: 'Last'}],
+        },
+      ],
+      documentValue: multiBlockDocument,
+      basePath: ['body'],
+      selection: {
+        anchor: {path: [{_key: 'first'}, 'children', {_key: 's1'}], offset: 6},
+        focus: {path: [{_key: 'last'}, 'children', {_key: 's1'}], offset: 4},
+      },
+    })
+
+    expect(result.value).toEqual([
+      {
+        _key: 'first',
+        text: `First ${COMMENT_INDICATORS[0]}block${COMMENT_INDICATORS[1]}`,
+      },
+      {
+        _key: 'middle',
+        text: `${COMMENT_INDICATORS[0]}Middle block${COMMENT_INDICATORS[1]}`,
+      },
+      {
+        _key: 'last',
+        text: `${COMMENT_INDICATORS[0]}Last${COMMENT_INDICATORS[1]} block`,
+      },
+    ])
+  })
+
+  test('nested-container editor: resolves the same-keyed block inside the container', () => {
+    const result = buildTextSelectionFromFragment({
+      fragment: fragmentOf(nestedBlock, 'Neste'),
+      documentValue,
+      basePath: ['body', {_key: 'callout'}, 'content'],
+      selection: selectionOnBlock(nestedBlock, 0, 5),
+    })
+
+    expect(result.value[0]._key).toBe('b1')
+    expect(result.value[0].text).toBe(
+      `${COMMENT_INDICATORS[0]}Neste${COMMENT_INDICATORS[1]}d there world`,
+    )
+  })
+})

--- a/packages/sanity/src/core/comments/__tests__/getCommentFieldPath.test.ts
+++ b/packages/sanity/src/core/comments/__tests__/getCommentFieldPath.test.ts
@@ -1,0 +1,111 @@
+import {type Path} from '@sanity/types'
+import {describe, expect, test} from 'vitest'
+
+import {getCommentFieldPath} from '../utils/inline-comments/buildTextSelectionFromFragment'
+
+const CALLOUT = {_key: 'callout'}
+const BLOCK = {_key: 'b1'}
+const SPAN = {_key: 's1'}
+
+const textBlock = (key: string, text: string) => ({
+  _type: 'block',
+  _key: key,
+  children: [{_type: 'span', _key: 's1', text, marks: []}],
+  markDefs: [],
+  style: 'normal',
+})
+
+describe('getCommentFieldPath', () => {
+  test('root block: field is the editor path', () => {
+    const documentValue = {body: [textBlock('b1', 'root')]}
+    const basePath: Path = ['body']
+    const selectionPath: Path = [BLOCK, 'children', SPAN, 'text']
+    expect(getCommentFieldPath(documentValue, basePath, selectionPath)).toBe('body')
+  })
+
+  test('inline container (body editor): field descends to the nested array', () => {
+    const documentValue = {
+      body: [{_type: 'callout', _key: 'callout', content: [textBlock('b1', 'nested')]}],
+    }
+    const basePath: Path = ['body']
+    const selectionPath: Path = [CALLOUT, 'content', BLOCK, 'children', SPAN, 'text']
+    expect(getCommentFieldPath(documentValue, basePath, selectionPath)).toBe(
+      'body[_key=="callout"].content',
+    )
+  })
+
+  test('dialog/void-object (nested input): same field as inline, from a deeper basePath', () => {
+    const documentValue = {
+      body: [{_type: 'callout', _key: 'callout', content: [textBlock('b1', 'nested')]}],
+    }
+    const basePath: Path = ['body', CALLOUT, 'content']
+    const selectionPath: Path = [BLOCK, 'children', SPAN, 'text']
+    expect(getCommentFieldPath(documentValue, basePath, selectionPath)).toBe(
+      'body[_key=="callout"].content',
+    )
+  })
+
+  test('inline and dialog renderings produce an identical field', () => {
+    const documentValue = {
+      body: [{_type: 'callout', _key: 'callout', content: [textBlock('b1', 'nested')]}],
+    }
+    const inline = getCommentFieldPath(
+      documentValue,
+      ['body'],
+      [CALLOUT, 'content', BLOCK, 'children', SPAN, 'text'],
+    )
+    const dialog = getCommentFieldPath(
+      documentValue,
+      ['body', CALLOUT, 'content'],
+      [BLOCK, 'children', SPAN, 'text'],
+    )
+    expect(inline).toBe(dialog)
+  })
+
+  test('depth-2 nesting (table > row > cell > content) descends every level', () => {
+    const documentValue = {
+      body: [
+        {
+          _type: 'table',
+          _key: 't1',
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [{_type: 'cell', _key: 'c1', content: [textBlock('b1', 'nested')]}],
+            },
+          ],
+        },
+      ],
+    }
+    const selectionPath: Path = [
+      {_key: 't1'},
+      'rows',
+      {_key: 'r1'},
+      'cells',
+      {_key: 'c1'},
+      'content',
+      BLOCK,
+      'children',
+      SPAN,
+      'text',
+    ]
+    expect(getCommentFieldPath(documentValue, ['body'], selectionPath)).toBe(
+      'body[_key=="t1"].rows[_key=="r1"].cells[_key=="c1"].content',
+    )
+  })
+
+  test('returns undefined when the selection path has no enclosing text block in the document', () => {
+    const documentValue = {body: []}
+    const basePath: Path = ['body']
+    const selectionPath: Path = [BLOCK, 'children', SPAN, 'text']
+    expect(getCommentFieldPath(documentValue, basePath, selectionPath)).toBeUndefined()
+  })
+
+  test('returns undefined for a block-object selection (no text block to anchor on)', () => {
+    const documentValue = {body: [{_type: 'image', _key: 'img1', asset: {}}]}
+    const basePath: Path = ['body']
+    const selectionPath: Path = [{_key: 'img1'}]
+    expect(getCommentFieldPath(documentValue, basePath, selectionPath)).toBeUndefined()
+  })
+})

--- a/packages/sanity/src/core/comments/helpers.ts
+++ b/packages/sanity/src/core/comments/helpers.ts
@@ -1,4 +1,5 @@
-import {isPortableTextSpan, isPortableTextTextBlock} from '@sanity/types'
+import {isPortableTextSpan, isPortableTextTextBlock, type Path} from '@sanity/types'
+import * as PathUtils from '@sanity/util/paths'
 import isEqual from 'lodash-es/isEqual.js'
 import {useMemo, useState} from 'react'
 
@@ -42,6 +43,21 @@ export function commentIntentIfDiffers(
     return intent
   }
   return undefined
+}
+
+/**
+ * Parse a comment's persisted `fieldPath` string. Returns `undefined` for
+ * empty or unparseable values: `fieldPath` is stored data, and a corrupt
+ * comment must not crash rendering.
+ * @internal
+ */
+export function parseCommentFieldPath(fieldPath: string | null | undefined): Path | undefined {
+  if (!fieldPath) return undefined
+  try {
+    return PathUtils.fromString(fieldPath)
+  } catch {
+    return undefined
+  }
 }
 
 /**

--- a/packages/sanity/src/core/comments/plugin/field/CommentsField.tsx
+++ b/packages/sanity/src/core/comments/plugin/field/CommentsField.tsx
@@ -1,5 +1,5 @@
 import {hues} from '@sanity/color'
-import {type PortableTextBlock} from '@sanity/types'
+import {type Path, type PortableTextBlock} from '@sanity/types'
 import {Stack, useBoundaryElement} from '@sanity/ui'
 import * as PathUtils from '@sanity/util/paths'
 import {uuid} from '@sanity/uuid'
@@ -11,7 +11,7 @@ import {type FieldProps} from '../../../form'
 import {getSchemaTypeTitle} from '../../../schema'
 import {useCurrentUser} from '../../../store'
 import {COMMENTS_HIGHLIGHT_HUE_KEY} from '../../constants'
-import {isTextSelectionComment} from '../../helpers'
+import {isTextSelectionComment, parseCommentFieldPath} from '../../helpers'
 import {
   applyCommentsFieldAttr,
   useComments,
@@ -129,8 +129,8 @@ function CommentFieldInner(
   const isSelected = useMemo(() => {
     if (!isCommentsOpen) return false
     if (selectedPath?.origin === 'form' || selectedPath?.origin === 'url') return false
-    return selectedPath?.fieldPath === stringPath
-  }, [isCommentsOpen, selectedPath?.fieldPath, selectedPath?.origin, stringPath])
+    return belongsToField(selectedPath?.fieldPath, props.path)
+  }, [isCommentsOpen, selectedPath?.fieldPath, selectedPath?.origin, props.path])
 
   const isInlineCommentThread = useMemo(() => {
     return comments.data.open
@@ -138,14 +138,16 @@ function CommentFieldInner(
       .some((x) => isTextSelectionComment(x.parentComment))
   }, [comments.data.open, selectedPath?.threadId])
 
-  // Total number of comments for the current field
+  // Total number of comments for the current field, including comments on
+  // blocks nested below it (container-nested and dialog-authored comments
+  // store the block's data path as their `fieldPath`).
   const count = useMemo(() => {
     const commentsCount = comments.data.open
-      .map((c) => (c.fieldPath === stringPath ? c.commentsCount : 0))
+      .map((c) => (belongsToField(c.fieldPath, props.path) ? c.commentsCount : 0))
       .reduce((acc, val) => acc + val, 0)
 
     return commentsCount || 0
-  }, [comments.data.open, stringPath])
+  }, [comments.data.open, props.path])
 
   const hasComments = Boolean(count > 0)
 
@@ -170,22 +172,22 @@ function CommentFieldInner(
       // 3. Open the comments inspector
       onCommentsOpen?.()
 
-      // 4. Find the latest comment thread ID for the current field
-      const scrollToThreadId = comments.data.open.find(
-        (c) => c.fieldPath === PathUtils.toString(props.path),
-      )?.threadId
+      // 4. Find the latest comment thread for the current field
+      const latestThread = comments.data.open.find((c) => belongsToField(c.fieldPath, props.path))
 
       // 5. Set the latest thread ID as the selected thread ID
-      //    and scroll to the it.
-      if (scrollToThreadId) {
-        // handleSetThreadToScrollTo(scrollToThreadId)
+      //    and scroll to the it. The selected path carries the thread's own
+      //    `fieldPath`: the inspector marks a thread selected by comparing
+      //    against the stored path, which for nested threads is deeper than
+      //    this field's path.
+      if (latestThread) {
         setSelectedPath({
-          threadId: scrollToThreadId,
+          threadId: latestThread.threadId,
           origin: 'form',
-          fieldPath: PathUtils.toString(props.path),
+          fieldPath: latestThread.fieldPath,
         })
 
-        scrollToGroup(scrollToThreadId)
+        scrollToGroup(latestThread.threadId)
       }
 
       return
@@ -344,4 +346,12 @@ function CommentFieldInner(
       </AnimatePresence>
     </FieldStack>
   )
+}
+
+/**
+ * Whether a comment's stored `fieldPath` sits at or below the field's path.
+ */
+function belongsToField(fieldPath: string | null | undefined, path: Path): boolean {
+  const commentFieldPath = parseCommentFieldPath(fieldPath)
+  return commentFieldPath ? PathUtils.startsWith(path, commentFieldPath) : false
 }

--- a/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
+++ b/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
@@ -12,13 +12,27 @@ import {uuid} from '@sanity/uuid'
 import debounce from 'lodash-es/debounce.js'
 import isEqual from 'lodash-es/isEqual.js'
 import {AnimatePresence} from 'motion/react'
-import {memo, startTransition, useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {
+  memo,
+  startTransition,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 
-import {type EditorChange, type PortableTextInputProps, useFieldActions} from '../../../../form'
+import {
+  type EditorChange,
+  type PortableTextInputProps,
+  useFieldActions,
+  useFormValue,
+} from '../../../../form'
 import {useCurrentUser} from '../../../../store'
 import {useAddonDataset} from '../../../../studio/addonDataset/useAddonDataset'
 import {CommentInlineHighlightSpan} from '../../../components'
-import {isTextSelectionComment} from '../../../helpers'
+import {isTextSelectionComment, parseCommentFieldPath} from '../../../helpers'
 import {
   useComments,
   useCommentsEnabled,
@@ -37,6 +51,7 @@ import {
   buildCommentRangeDecorations,
   buildRangeDecorationSelectionsFromComments,
   buildTextSelectionFromFragment,
+  getCommentFieldPath,
 } from '../../../utils'
 import {getSelectionBoundingRect, useAuthoringReferenceElement} from '../helpers'
 import {FloatingButtonPopover} from './FloatingButtonPopover'
@@ -86,6 +101,16 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
 
   const editorRef = useRef<PortableTextEditor | null>(null)
 
+  // Read through a ref because `useFormValue([])` changes identity on every
+  // keystroke: keeping it out of dependency arrays keeps decoration rebuilds
+  // keyed on comment changes. The layout effect updates the ref synchronously
+  // with the commit, so event handlers never observe a stale value.
+  const documentValue = useFormValue([])
+  const documentValueRef = useRef(documentValue)
+  useLayoutEffect(() => {
+    documentValueRef.current = documentValue
+  }, [documentValue])
+
   // A reference to the authoring decoration element that highlights the selected text
   // when starting to author a comment.
   const [authoringDecorationElement, setAuthoringDecorationElement] =
@@ -106,7 +131,6 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
   const [addedCommentsDecorations, setAddedCommentsDecorations] =
     useState<RangeDecoration[]>(EMPTY_ARRAY)
 
-  const stringFieldPath = useMemo(() => PathUtils.toString(props.path), [props.path])
   const [fragment, setFragment] = useState<PortableTextBlock[] | null>(null)
 
   const getFragment = useCallback(() => {
@@ -150,23 +174,35 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
 
   const textComments = useMemo(() => {
     return comments.data.open
-      .filter((comment) => comment.fieldPath === stringFieldPath)
       .filter((c) => isTextSelectionComment(c.parentComment))
+      .filter((c) => {
+        // Keep the per-editor work proportional to the editor's own comments.
+        const fieldPath = parseCommentFieldPath(c.fieldPath)
+        return fieldPath ? PathUtils.startsWith(props.path, fieldPath) : false
+      })
       .map((c) => c.parentComment)
-  }, [comments.data.open, stringFieldPath])
+  }, [comments.data.open, props.path])
 
   const handleSubmit = useCallback(
     (nextValue: CommentMessage) => {
       if (!nextCommentSelection || !editorRef.current) return
 
-      const editorValue = PortableTextEditor.getValue(editorRef.current)
+      const normalizedSelection = nextCommentSelection.backward
+        ? {backward: false, anchor: nextCommentSelection.focus, focus: nextCommentSelection.anchor}
+        : nextCommentSelection
 
-      if (!editorValue) return
+      const fieldPath = getCommentFieldPath(
+        documentValueRef.current,
+        props.path,
+        normalizedSelection.focus.path,
+      )
+      if (!fieldPath) return
 
       const textSelection = buildTextSelectionFromFragment({
         fragment: fragment || EMPTY_ARRAY,
-        selection: nextCommentSelection,
-        value: editorValue,
+        selection: normalizedSelection,
+        documentValue: documentValueRef.current,
+        basePath: props.path,
       })
 
       const threadId = uuid()
@@ -174,7 +210,7 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
       void operation.create({
         type: 'field',
         contentSnapshot: fragment,
-        fieldPath: stringFieldPath,
+        fieldPath,
         message: nextValue,
         parentCommentId: undefined,
         reactions: EMPTY_ARRAY,
@@ -193,7 +229,7 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
 
       // Set the selected path to the new comment
       setSelectedPath({
-        fieldPath: stringFieldPath,
+        fieldPath,
         threadId,
         origin: 'form',
       })
@@ -206,7 +242,7 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
     [
       nextCommentSelection,
       operation,
-      stringFieldPath,
+      props.path,
       onCommentsOpen,
       status,
       setSelectedPath,
@@ -327,6 +363,8 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
       const [updatedDecoration] = buildRangeDecorationSelectionsFromComments({
         comments: [comment],
         value: editorValue,
+        documentValue: documentValueRef.current,
+        basePath: props.path,
       })
 
       const nextRange = updatedDecoration?.range ? [updatedDecoration.range] : EMPTY_ARRAY
@@ -380,7 +418,7 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
       })
       return next.filter((p) => p.selection !== null)
     })
-  }, [addedCommentsDecorations, getComment, operation])
+  }, [addedCommentsDecorations, getComment, operation, props.path])
 
   const handleBuildRangeDecorations = useCallback(
     (commentsToDecorate: CommentDocument[]) => {
@@ -396,12 +434,15 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
         onDecorationMoved: handleRangeDecorationMoved,
         selectedThreadId: selectedPath?.threadId || null,
         value: editorValue,
+        documentValue: documentValueRef.current,
+        basePath: props.path,
       })
     },
     [
       currentHoveredCommentId,
       handleDecoratorClick,
       handleRangeDecorationMoved,
+      props.path,
       selectedPath?.threadId,
     ],
   )

--- a/packages/sanity/src/core/comments/utils/inline-comments/buildCommentRangeDecorations.tsx
+++ b/packages/sanity/src/core/comments/utils/inline-comments/buildCommentRangeDecorations.tsx
@@ -1,5 +1,5 @@
 import {type RangeDecoration, type RangeDecorationOnMovedDetails} from '@portabletext/editor'
-import {type PortableTextBlock} from '@sanity/types'
+import {type Path, type PortableTextBlock} from '@sanity/types'
 import {memo, useCallback, useEffect, useRef, useState} from 'react'
 
 import {CommentInlineHighlightSpan} from '../../components'
@@ -97,6 +97,8 @@ interface BuildRangeDecorationsProps {
   onDecorationMoved: (details: RangeDecorationOnMovedDetails) => void
   selectedThreadId: string | null
   value: PortableTextBlock[] | undefined
+  documentValue?: unknown
+  basePath?: Path
 }
 
 /**
@@ -112,8 +114,15 @@ export function buildCommentRangeDecorations(props: BuildRangeDecorationsProps) 
     onDecorationMoved,
     selectedThreadId,
     value,
+    documentValue,
+    basePath,
   } = props
-  const rangeSelections = buildRangeDecorationSelectionsFromComments({comments, value})
+  const rangeSelections = buildRangeDecorationSelectionsFromComments({
+    comments,
+    value,
+    documentValue,
+    basePath,
+  })
 
   const decorations = rangeSelections.map(({selection, comment, range}) => {
     const decoration: RangeDecoration = {

--- a/packages/sanity/src/core/comments/utils/inline-comments/buildRangeDecorationSelectionsFromComments.ts
+++ b/packages/sanity/src/core/comments/utils/inline-comments/buildRangeDecorationSelectionsFromComments.ts
@@ -13,11 +13,14 @@ import {
 import {
   isPortableTextSpan,
   isPortableTextTextBlock,
+  type Path,
   type PortableTextBlock,
   type PortableTextTextBlock,
 } from '@sanity/types'
+import * as PathUtils from '@sanity/util/paths'
 
-import {isTextSelectionComment} from '../../helpers'
+import {getValueAtPath} from '../../../field'
+import {isTextSelectionComment, parseCommentFieldPath} from '../../helpers'
 import {type CommentDocument, type CommentsTextSelectionItem} from '../../types'
 
 // This must be set high to avoid false positives
@@ -57,6 +60,13 @@ const EMPTY_ARRAY: [] = []
 export interface BuildCommentsRangeDecorationsProps {
   value: PortableTextBlock[] | undefined
   comments: CommentDocument[]
+  /**
+   * Document value the stored `field` paths resolve against. Falls back to a
+   * top-level `value.find` on the editor slice when absent.
+   */
+  documentValue?: unknown
+  /** The editor's own document path. */
+  basePath?: Path
 }
 
 /**
@@ -75,7 +85,7 @@ export interface BuildCommentsRangeDecorationsResultItem {
 export function buildRangeDecorationSelectionsFromComments(
   props: BuildCommentsRangeDecorationsProps,
 ): BuildCommentsRangeDecorationsResultItem[] {
-  const {value, comments} = props
+  const {value, comments, documentValue, basePath} = props
 
   if (!value || value.length === 0) return EMPTY_ARRAY
 
@@ -83,8 +93,26 @@ export function buildRangeDecorationSelectionsFromComments(
   const decorators: BuildCommentsRangeDecorationsResultItem[] = []
 
   textSelections.forEach((comment) => {
+    let relative: Path = []
+    if (documentValue !== undefined && basePath) {
+      const fieldPath = parseCommentFieldPath(comment.target.path?.field)
+      if (!fieldPath) {
+        // A comment without a parseable `field` cannot resolve to a block.
+        return
+      }
+      if (!PathUtils.startsWith(basePath, fieldPath)) return
+      relative = fieldPath.slice(basePath.length)
+    }
+
     comment.target.path?.selection?.value.forEach((selectionMember) => {
-      const matchedBlock = value.find((block) => block._key === selectionMember._key)
+      const matchedBlock =
+        documentValue !== undefined && basePath
+          ? (getValueAtPath(documentValue, [
+              ...basePath,
+              ...relative,
+              {_key: selectionMember._key},
+            ]) as PortableTextBlock | undefined)
+          : value.find((block) => block._key === selectionMember._key)
       if (!matchedBlock || !isPortableTextTextBlock(matchedBlock)) {
         return
       }
@@ -149,6 +177,7 @@ export function buildRangeDecorationSelectionsFromComments(
           selection: {
             anchor: {
               path: [
+                ...relative,
                 {_key: matchedBlock._key},
                 'children',
                 {_key: matchedBlock.children[childIndexAnchor]._key},
@@ -157,6 +186,7 @@ export function buildRangeDecorationSelectionsFromComments(
             },
             focus: {
               path: [
+                ...relative,
                 {_key: matchedBlock._key},
                 'children',
                 {_key: matchedBlock.children[childIndexFocus]._key},

--- a/packages/sanity/src/core/comments/utils/inline-comments/buildTextSelectionFromFragment.ts
+++ b/packages/sanity/src/core/comments/utils/inline-comments/buildTextSelectionFromFragment.ts
@@ -1,18 +1,22 @@
 import {type EditorSelection} from '@portabletext/editor'
 import {toPlainText} from '@portabletext/react'
 import {
-  isKeySegment,
   isPortableTextSpan,
   isPortableTextTextBlock,
+  type Path,
   type PortableTextBlock,
+  type PortableTextTextBlock,
 } from '@sanity/types'
+import * as PathUtils from '@sanity/util/paths'
 
+import {getValueAtPath} from '../../../field'
 import {type CommentTextSelection} from '../../types'
 import {COMMENT_INDICATORS} from './buildRangeDecorationSelectionsFromComments'
 
 interface BuildSelectionFromFragmentProps {
   fragment: PortableTextBlock[]
-  value: PortableTextBlock[]
+  documentValue: unknown
+  basePath: Path
   selection: EditorSelection
 }
 
@@ -22,27 +26,43 @@ interface BuildSelectionFromFragmentProps {
 export function buildTextSelectionFromFragment(
   props: BuildSelectionFromFragmentProps,
 ): CommentTextSelection {
-  const {fragment, value, selection} = props
+  const {fragment, documentValue, basePath, selection} = props
   if (!selection) {
     throw new Error('Selection is required')
   }
   const normalizedSelection: EditorSelection = selection.backward
     ? {backward: false, anchor: selection.focus, focus: selection.anchor}
     : selection
+
+  const {block: anchorBlock, path: anchorBlockPath} =
+    findEnclosingTextBlock(documentValue, basePath, normalizedSelection.anchor.path) ?? {}
+  const {block: focusBlock, path: focusBlockPath} =
+    findEnclosingTextBlock(documentValue, basePath, normalizedSelection.focus.path) ?? {}
+
+  // A selection spanning three or more blocks has fragment blocks that are
+  // neither the anchor nor the focus block. They live in the same containing
+  // arrays, so resolve every fragment block by `_key` within those arrays.
+  const containingArrays: Array<Array<unknown>> = []
+  for (const blockPath of [anchorBlockPath, focusBlockPath]) {
+    if (!blockPath) continue
+    const containingArray = getValueAtPath(documentValue, [...basePath, ...blockPath.slice(0, -1)])
+    if (Array.isArray(containingArray) && !containingArrays.includes(containingArray)) {
+      containingArrays.push(containingArray)
+    }
+  }
+
   const textSelection: CommentTextSelection = {
     type: 'text',
     value: fragment.map((fragmentBlock) => {
-      const originalBlock = value.find((b) => b._key === fragmentBlock._key)
+      const originalBlock = findBlockByKey(containingArrays, fragmentBlock._key)
       if (!isPortableTextTextBlock(originalBlock)) {
         return {
           _key: fragmentBlock._key,
           text: '',
         }
       }
-      const anchorBlockKey =
-        isKeySegment(normalizedSelection.anchor.path[0]) && normalizedSelection.anchor.path[0]._key
-      const focusBlockKey =
-        isKeySegment(normalizedSelection.focus.path[0]) && normalizedSelection.focus.path[0]._key
+      const anchorBlockKey = anchorBlock?._key
+      const focusBlockKey = focusBlock?._key
       const fragmentBlockText = toPlainText([fragmentBlock])
       const fragmentStartSpan = isPortableTextTextBlock(fragmentBlock)
         ? fragmentBlock.children[0]
@@ -86,4 +106,54 @@ export function buildTextSelectionFromFragment(
   }
 
   return textSelection
+}
+
+/**
+ * The data path to the block's containing array. Returns `undefined` if no
+ * enclosing text block exists at the selection path.
+ *
+ * @internal
+ */
+export function getCommentFieldPath(
+  documentValue: unknown,
+  basePath: Path,
+  selectionPath: Path,
+): string | undefined {
+  const enclosingBlockPath = findEnclosingTextBlock(documentValue, basePath, selectionPath)?.path
+  if (!enclosingBlockPath) return undefined
+  return PathUtils.toString([...basePath, ...enclosingBlockPath.slice(0, -1)])
+}
+
+/**
+ * Walk `path` up to root against the document value from `basePath`, returning
+ * the deepest enclosing text block and the segments (relative to `basePath`)
+ * that reach it. Selection paths from PTE are editor-relative.
+ */
+function findEnclosingTextBlock(
+  documentValue: unknown,
+  basePath: Path,
+  path: Path,
+): {block: PortableTextTextBlock; path: Path} | undefined {
+  for (let end = path.length; end > 0; end--) {
+    const relative = path.slice(0, end)
+    const candidate = getValueAtPath(documentValue, [...basePath, ...relative])
+    if (isPortableTextTextBlock(candidate)) {
+      return {block: candidate, path: relative}
+    }
+  }
+  return undefined
+}
+
+function findBlockByKey(
+  arrays: Array<Array<unknown>>,
+  key: string,
+): PortableTextTextBlock | undefined {
+  for (const array of arrays) {
+    for (const block of array) {
+      if (isPortableTextTextBlock(block) && block._key === key) {
+        return block
+      }
+    }
+  }
+  return undefined
 }


### PR DESCRIPTION
### Description

If you comment on text inside a container (for example a table cell), the comment never shows up. Comments record which field they belong to using the editor's own path, and they look up their blocks at the top level of the editor's value. Both of those assumptions only hold for text at the root of the field. For text nested inside a container, the comment gets stored with the wrong location and an empty text snapshot, and the highlight never renders.

The fix is to store the block's actual location in the document (its data path) and to find blocks by walking the document value instead. The saving side and the rendering side now follow the same rule.

A nice consequence: a comment is now tied to where the block lives in the document, not to which editor it was written in. The same comment shows up whether the block renders inline in the body editor or in the dialog editor, and comments written before a field adopts containers keep working after, with no migration.

### What to review

The path walking in the two utilities, and the wiring in `CommentsPortableTextInput.tsx`.

The branch also carries a standalone `fix(comments)` commit for a pre-existing bug this work surfaced: the field's comment badge, button, and selected highlight matched comments by exact path equality, so comments authored on nested content (dialog-authored comments have always stored deep paths) were invisible to the field. They match by path prefix now, which means the badge starts counting dialog-authored comments it has always missed on `main`. Root-level and dialog editors go through the same code paths and should behave exactly like on `main`.

### Testing

The `customPlugins` document in `dev/test-studio` has a "Render containers inline" toggle on the Container Table field:

1. Comment on some text inside a table cell.
2. Toggle inline rendering off: the same comment shows up in the dialog editor.
3. Toggle back on: it shows up inline again.

Unit tests cover the nested-container case on both the saving and rendering side, selections spanning multiple blocks, isolation between sibling editors, and a guard treating comments with a missing or unparseable stored `field` as non-matching instead of crashing the render.

### Notes for release

n/a - I don't think we need to mention this since PTE Containers haven't been documented in Studio yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches comment create/render paths and path resolution across editors; behavior change for nested content is intentional but regression risk on root-level PTE and multi-editor documents.
> 
> **Overview**
> Fixes inline comment highlights and persistence for text inside **nested Portable Text** (e.g. table cells, callouts) by storing and resolving comments against the block’s **data path** in the document, not the editor’s top-level field path.
> 
> **Saving:** `getCommentFieldPath` and an updated `buildTextSelectionFromFragment` walk the full document from the editor’s `basePath`, resolve blocks by `_key` in nested arrays, and support multi-block selections. **Rendering:** `buildRangeDecorationSelectionsFromComments` parses the stored `field` path, scopes comments per editor via path prefix, looks up blocks with `getValueAtPath`, and prefixes PTE selection paths with container segments so the same thread works in the **body editor** and a **nested dialog** editor.
> 
> `CommentsPortableTextInput` passes `documentValue` (via a ref to avoid decoration churn) and `basePath` through create/update/decoration flows. `CommentsField` uses **path-prefix** matching (`belongsToField`) so badges, selection, and the comment button include nested/dialog-authored threads. Corrupt or missing stored `field` paths are skipped via `parseCommentFieldPath` instead of crashing.
> 
> Adds unit tests and a **Render containers inline** toggle on the `customPlugins` test document to flip inline containers vs dialog editing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c28423e9a3dc8ff4afa45316c256ef635fd24b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->