### PR TITLE
refactor(releases): abstract bundle documents into reusable hook

### DIFF
--- a/packages/sanity/src/core/config/releases/actions.ts
+++ b/packages/sanity/src/core/config/releases/actions.ts
@@ -1,7 +1,7 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {type ComponentType, type ReactNode} from 'react'
 
-import {type DocumentInRelease} from '../../releases/tool/detail/useBundleDocuments'
+import {type DocumentInBundle} from '../../releases/tool/detail/useBundleDocuments'
 import {type ConfigContext} from '../types'
 
 /**
@@ -9,7 +9,7 @@ import {type ConfigContext} from '../types'
  */
 export interface ReleaseActionProps {
   release: ReleaseDocument
-  documents: DocumentInRelease[]
+  documents: DocumentInBundle[]
 }
 
 /**

--- a/packages/sanity/src/core/releases/components/ReleaseActionsResolver.tsx
+++ b/packages/sanity/src/core/releases/components/ReleaseActionsResolver.tsx
@@ -6,12 +6,12 @@ import {
   type ReleaseActionComponent,
   type ReleaseActionDescription,
 } from '../../config/releases/actions'
-import {type DocumentInRelease} from '../tool/detail/useBundleDocuments'
+import {type DocumentInBundle} from '../tool/detail/useBundleDocuments'
 
 export interface ReleaseActionsResolverProps {
   actions: ReleaseActionComponent[]
   release: ReleaseDocument
-  documents: DocumentInRelease[]
+  documents: DocumentInBundle[]
   onActions: (actions: ReleaseActionDescription[]) => void
   children?: (props: {states: ReleaseActionDescription[]}) => ReactNode
 }

--- a/packages/sanity/src/core/releases/hooks/__tests__/useCustomReleaseActions.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useCustomReleaseActions.test.tsx
@@ -6,7 +6,7 @@ import {type Source} from '../../../config/types'
 import {useSource} from '../../../studio'
 import {activeASAPRelease} from '../../__fixtures__/release.fixture'
 import {documentsInRelease} from '../../tool/detail/__tests__/__mocks__/useBundleDocuments.mock'
-import {type DocumentInRelease} from '../../tool/detail/useBundleDocuments'
+import {type DocumentInBundle} from '../../tool/detail/useBundleDocuments'
 import {useCustomReleaseActions} from '../useCustomReleaseActions'
 
 vi.mock('../../../studio', () => ({
@@ -181,7 +181,7 @@ describe('useCustomReleaseActions', () => {
         _type: 'document',
         title: 'Document 3',
       },
-    ] as DocumentInRelease[]
+    ] as DocumentInBundle[]
     rerender(newMockDocuments)
 
     expect(mockActionsFunction).toHaveBeenCalledTimes(2)

--- a/packages/sanity/src/core/releases/hooks/useCustomReleaseActions.ts
+++ b/packages/sanity/src/core/releases/hooks/useCustomReleaseActions.ts
@@ -3,7 +3,7 @@ import {useMemo} from 'react'
 
 import {type ReleaseActionComponent} from '../../config/releases/actions'
 import {useSource} from '../../studio'
-import {type DocumentInRelease} from '../tool/detail/useBundleDocuments'
+import {type DocumentInBundle} from '../tool/detail/useBundleDocuments'
 
 /**
  * Hook to get custom/configured release actions for a release
@@ -12,7 +12,7 @@ import {type DocumentInRelease} from '../tool/detail/useBundleDocuments'
  */
 export function useCustomReleaseActions(
   release: ReleaseDocument,
-  documents: DocumentInRelease[] = [],
+  documents: DocumentInBundle[] = [],
 ): ReleaseActionComponent[] {
   const source = useSource()
 

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenu.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenu.tsx
@@ -16,7 +16,7 @@ import {releasesLocaleNamespace} from '../../../i18n'
 import {useReleaseOperations} from '../../../store'
 import {useReleasePermissions} from '../../../store/useReleasePermissions'
 import {getReleaseDefaults} from '../../../util/util'
-import {type DocumentInRelease} from '../../detail/useBundleDocuments'
+import {type DocumentInBundle} from '../../detail/useBundleDocuments'
 import {ReleasePublishAllButton} from '../releaseCTAButtons/ReleasePublishAllButton'
 import {ReleaseScheduleButton} from '../releaseCTAButtons/ReleaseScheduleButton'
 import {type ReleaseAction} from './releaseActions'
@@ -25,7 +25,7 @@ import {type ReleaseMenuButtonProps} from './ReleaseMenuButton'
 export type ReleaseMenuProps = Omit<ReleaseMenuButtonProps, 'documentsCount'> & {
   disabled: boolean
   setSelectedAction: Dispatch<SetStateAction<ReleaseAction | undefined>>
-  documents: DocumentInRelease[]
+  documents: DocumentInBundle[]
 }
 
 export const ReleaseMenu = ({

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenuButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenuButton.tsx
@@ -19,7 +19,7 @@ import {isReleaseLimitError} from '../../../store/isReleaseLimitError'
 import {useReleaseOperations} from '../../../store/useReleaseOperations'
 import {createReleaseId} from '../../../util/createReleaseId'
 import {getReleaseIdFromReleaseDocumentId} from '../../../util/getReleaseIdFromReleaseDocumentId'
-import {type DocumentInRelease} from '../../detail/useBundleDocuments'
+import {type DocumentInBundle} from '../../detail/useBundleDocuments'
 import {DuplicateReleaseToastLink} from './DuplicateReleaseToastLink'
 import {RELEASE_ACTION_MAP, type ReleaseAction} from './releaseActions'
 import {ReleaseMenu} from './ReleaseMenu'
@@ -49,7 +49,7 @@ export type ReleaseMenuButtonProps = {
   ignoreCTA?: boolean
   release: ReleaseDocument
   documentsCount: number
-  documents?: DocumentInRelease[]
+  documents?: DocumentInBundle[]
 }
 
 export const ReleaseMenuButton = ({

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/__tests__/ReleaseMenuButton.test.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/__tests__/ReleaseMenuButton.test.tsx
@@ -40,8 +40,8 @@ vi.mock('../../../../store/useReleasePermissions', () => ({
   useReleasePermissions: vi.fn(() => useReleasePermissionsMockReturn),
 }))
 
-vi.mock('../../../detail/useBundleDocuments', () => ({
-  useBundleDocuments: vi.fn(() => useBundleDocumentsMockReturnWithResults),
+vi.mock('../../../detail/useReleaseDocuments', () => ({
+  useReleaseDocuments: vi.fn(() => useBundleDocumentsMockReturnWithResults),
 }))
 
 vi.mock('../../../../contexts/upsell/useReleasesUpsell', () => ({

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
@@ -15,11 +15,11 @@ import {releasesLocaleNamespace} from '../../../i18n'
 import {isReleaseDocument} from '../../../index'
 import {useReleaseOperations} from '../../../store/useReleaseOperations'
 import {useReleasePermissions} from '../../../store/useReleasePermissions'
-import {type DocumentInRelease} from '../../detail/useBundleDocuments'
+import {type DocumentInBundle} from '../../detail/useBundleDocuments'
 
 interface ReleasePublishAllButtonProps {
   release: ReleaseDocument
-  documents: DocumentInRelease[]
+  documents: DocumentInBundle[]
   disabled?: boolean
   isMenuItem?: boolean
   onConfirmDialogOpen?: () => void

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/ReleaseRevertButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/ReleaseRevertButton.tsx
@@ -17,13 +17,13 @@ import {useReleasePermissions} from '../../../../store/useReleasePermissions'
 import {createReleaseId} from '../../../../util/createReleaseId'
 import {getReleaseIdFromReleaseDocumentId} from '../../../../util/getReleaseIdFromReleaseDocumentId'
 import {getReleaseDefaults} from '../../../../util/util'
-import {type DocumentInRelease} from '../../../detail/useBundleDocuments'
+import {type DocumentInBundle} from '../../../detail/useBundleDocuments'
 import {useDocumentRevertStates} from './useDocumentRevertStates'
 import {usePostPublishTransactions} from './usePostPublishTransactions'
 
 interface ReleasePublishAllButtonProps {
   release: ReleaseDocument
-  documents: DocumentInRelease[]
+  documents: DocumentInBundle[]
   disabled?: boolean
 }
 
@@ -36,7 +36,7 @@ const ConfirmReleaseDialog = ({
   release,
 }: {
   revertReleaseStatus: RevertReleaseStatus
-  documents: DocumentInRelease[]
+  documents: DocumentInBundle[]
   setRevertReleaseStatus: (status: RevertReleaseStatus) => void
   release: ReleaseDocument
 }) => {

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/__tests__/useDocumentRevertStates.test.ts
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/__tests__/useDocumentRevertStates.test.ts
@@ -6,7 +6,7 @@ import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
 import {useClient} from '../../../../../../hooks/useClient'
 import {getTransactionsLogs} from '../../../../../../store/translog/getTransactionsLogs'
-import {type DocumentInRelease} from '../../../../detail/useBundleDocuments'
+import {type DocumentInBundle} from '../../../../detail/useBundleDocuments'
 import {useDocumentRevertStates} from '../useDocumentRevertStates'
 
 vi.mock('../../../../../../hooks/useClient', () => ({
@@ -21,7 +21,7 @@ describe('useDocumentRevertStates', () => {
   const mockDocuments = [
     {document: {_id: 'versions.r1.doc1', _rev: 'rev1'}},
     {document: {_id: 'versions.r1.doc2', _rev: 'rev2'}},
-  ] as DocumentInRelease[]
+  ] as DocumentInBundle[]
 
   /** @todo improve the useClient mock */
   const mockClient = {

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/__tests__/usePostPublishTransactions.test.ts
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/__tests__/usePostPublishTransactions.test.ts
@@ -4,7 +4,7 @@ import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
 import {useClient} from '../../../../../../hooks/useClient'
 import {getTransactionsLogs} from '../../../../../../store/translog/getTransactionsLogs'
-import {type DocumentInRelease} from '../../../../detail/useBundleDocuments'
+import {type DocumentInBundle} from '../../../../detail/useBundleDocuments'
 import {usePostPublishTransactions} from '../usePostPublishTransactions'
 
 vi.mock('../../../../../../hooks/useClient', () => ({
@@ -24,7 +24,7 @@ describe('usePostPublishTransactions', () => {
   const mockDocuments = [
     {document: {_id: 'doc1', _rev: 'rev1'}},
     {document: {_id: 'doc2', _rev: 'rev2'}},
-  ] as DocumentInRelease[]
+  ] as DocumentInBundle[]
 
   const mockClient = {getUrl: vi.fn(), config: vi.fn()}
 

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/useDocumentRevertStates.ts
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/useDocumentRevertStates.ts
@@ -8,7 +8,7 @@ import {getTransactionsLogs} from '../../../../../store/translog/getTransactions
 import {getPublishedId} from '../../../../../util/draftUtils'
 import {promiseWithResolvers} from '../../../../../util/promiseWithResolvers'
 import {RELEASES_STUDIO_CLIENT_OPTIONS} from '../../../../util/releasesClient'
-import {type DocumentInRelease} from '../../../detail/useBundleDocuments'
+import {type DocumentInBundle} from '../../../detail/useBundleDocuments'
 
 export type RevertDocument = SanityDocument & {
   _system?: {
@@ -20,7 +20,7 @@ type RevertDocuments = RevertDocument[]
 
 type DocumentRevertStates = RevertDocuments | null | undefined
 
-export const useDocumentRevertStates = (releaseDocuments: DocumentInRelease[]) => {
+export const useDocumentRevertStates = (releaseDocuments: DocumentInBundle[]) => {
   const client = useClient(RELEASES_STUDIO_CLIENT_OPTIONS)
   const observableClient = client.observable
   const transactionId = releaseDocuments[0]?.document._rev

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/usePostPublishTransactions.ts
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/usePostPublishTransactions.ts
@@ -6,9 +6,9 @@ import {useClient} from '../../../../../hooks/useClient'
 import {getTransactionsLogs} from '../../../../../store/translog/getTransactionsLogs'
 import {getPublishedId} from '../../../../../util/draftUtils'
 import {RELEASES_STUDIO_CLIENT_OPTIONS} from '../../../../util/releasesClient'
-import {type DocumentInRelease} from '../../../detail/useBundleDocuments'
+import {type DocumentInBundle} from '../../../detail/useBundleDocuments'
 
-export const usePostPublishTransactions = (documents: DocumentInRelease[]) => {
+export const usePostPublishTransactions = (documents: DocumentInBundle[]) => {
   const client = useClient(RELEASES_STUDIO_CLIENT_OPTIONS)
   const transactionId = documents[0]?.document._rev
 

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
@@ -26,11 +26,11 @@ import {releasesLocaleNamespace} from '../../../i18n'
 import {isReleaseScheduledOrScheduling} from '../../../index'
 import {useReleaseOperations} from '../../../store/useReleaseOperations'
 import {useReleasePermissions} from '../../../store/useReleasePermissions'
-import {type DocumentInRelease} from '../../detail/useBundleDocuments'
+import {type DocumentInBundle} from '../../detail/useBundleDocuments'
 
 interface ReleaseScheduleButtonProps {
   release: ReleaseDocument
-  documents: DocumentInRelease[]
+  documents: DocumentInBundle[]
   disabled?: boolean
   isMenuItem?: boolean
   onConfirmDialogOpen?: () => void

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseUnscheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseUnscheduleButton.tsx
@@ -9,11 +9,11 @@ import {Translate, useTranslation} from '../../../../i18n'
 import {UnscheduledRelease} from '../../../__telemetry__/releases.telemetry'
 import {releasesLocaleNamespace} from '../../../i18n'
 import {useReleaseOperations} from '../../../store/useReleaseOperations'
-import {type DocumentInRelease} from '../../detail/useBundleDocuments'
+import {type DocumentInBundle} from '../../detail/useBundleDocuments'
 
 interface ReleaseScheduleButtonProps {
   release: ReleaseDocument
-  documents: DocumentInRelease[]
+  documents: DocumentInBundle[]
   disabled?: boolean
 }
 

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
@@ -19,7 +19,7 @@ import {isNotArchivedRelease} from '../../util/util'
 import {ArchivedReleaseBanner} from './ArchivedReleaseBanner'
 import {ReleaseDetailsEditor} from './ReleaseDetailsEditor'
 import {ReleaseTypePicker} from './ReleaseTypePicker'
-import {type DocumentInRelease} from './useBundleDocuments'
+import {type DocumentInBundle} from './useBundleDocuments'
 import {ValidationProgressIndicator} from './ValidationProgressIndicator'
 
 export function ReleaseDashboardDetails({
@@ -27,7 +27,7 @@ export function ReleaseDashboardDetails({
   documents,
 }: {
   release: ReleaseDocument
-  documents: DocumentInRelease[]
+  documents: DocumentInBundle[]
 }) {
   const {state} = release
 

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardFooter.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardFooter.tsx
@@ -10,10 +10,10 @@ import {ReleaseUnscheduleButton} from '../components/releaseCTAButtons/ReleaseUn
 import {ReleaseMenuButton} from '../components/ReleaseMenuButton/ReleaseMenuButton'
 import {type ReleaseEvent} from './events/types'
 import {ReleaseStatusItems} from './ReleaseStatusItems'
-import {type DocumentInRelease} from './useBundleDocuments'
+import {type DocumentInBundle} from './useBundleDocuments'
 
 export function ReleaseDashboardFooter(props: {
-  documents: DocumentInRelease[]
+  documents: DocumentInBundle[]
   release: ReleaseDocument
   events: ReleaseEvent[]
 }) {

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
@@ -18,7 +18,7 @@ import {ReleaseDashboardDetails} from './ReleaseDashboardDetails'
 import {ReleaseDashboardFooter} from './ReleaseDashboardFooter'
 import {ReleaseDashboardHeader} from './ReleaseDashboardHeader'
 import {ReleaseSummary} from './ReleaseSummary'
-import {useBundleDocuments} from './useBundleDocuments'
+import {useReleaseDocuments} from './useReleaseDocuments'
 
 export type ReleaseInspector = 'activity'
 const MotionCard = motion.create(Card)
@@ -36,7 +36,7 @@ export function ReleaseDetail() {
     loading: documentsLoading,
     results,
     error: bundleDocumentsError,
-  } = useBundleDocuments(releaseId)
+  } = useReleaseDocuments(releaseId)
   const releaseEvents = useReleaseEvents(releaseId)
 
   const releaseInDetail = data

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -20,16 +20,16 @@ import {DocumentActions} from './documentTable/DocumentActions'
 import {getDocumentTableColumnDefs} from './documentTable/DocumentTableColumnDefs'
 import {searchDocumentRelease} from './documentTable/searchDocumentRelease'
 import {type DocumentFilterType, documentMatchesFilter} from './releaseDocumentActions'
-import {type DocumentInRelease} from './useBundleDocuments'
+import {type DocumentInBundle} from './useBundleDocuments'
 
-export type DocumentInReleaseDetail = DocumentInRelease & {
+export type DocumentInReleaseDetail = DocumentInBundle & {
   // TODO: Get this value from the document, it can be calculated by checking if there is a corresponding document with no version attached
   isAdded?: boolean
 }
 export type BundleDocumentRow = DocumentInReleaseDetail
 
 export interface ReleaseSummaryProps {
-  documents: DocumentInRelease[]
+  documents: DocumentInBundle[]
   release: ReleaseDocument
   isLoading?: boolean
 }
@@ -87,7 +87,7 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
   const handleAddDocumentClick = useCallback(() => setAddDocumentDialog(true), [])
 
   const filterRows = useCallback(
-    (data: DocumentInRelease[], searchTerm: string) => {
+    (data: DocumentInBundle[], searchTerm: string) => {
       // this is a temporary way of doing the search without the previews
       // until we have it moved to the server side
       return data.filter((doc) => {

--- a/packages/sanity/src/core/releases/tool/detail/ValidationProgressIndicator.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ValidationProgressIndicator.tsx
@@ -7,13 +7,13 @@ import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {releasesLocaleNamespace} from '../../i18n'
 import {getDocumentValidationLoading} from '../../util/getDocumentValidationLoading'
-import {type DocumentInRelease} from './useBundleDocuments'
+import {type DocumentInBundle} from './useBundleDocuments'
 
 export function ValidationProgressIndicator({
   documents,
   layout = 'default',
 }: {
-  documents: DocumentInRelease[]
+  documents: DocumentInBundle[]
   layout?: 'default' | 'minimal'
 }) {
   const totalCount = documents.length

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
@@ -63,8 +63,8 @@ vi.mock('../../../store/useReleasePermissions', () => ({
   useReleasePermissions: vi.fn(() => useReleasePermissionsMockReturn),
 }))
 
-vi.mock('../useBundleDocuments', () => ({
-  useBundleDocuments: vi.fn(() => useBundleDocumentsMockReturn),
+vi.mock('../useReleaseDocuments', () => ({
+  useReleaseDocuments: vi.fn(() => useBundleDocumentsMockReturn),
 }))
 
 vi.mock('../events/useReleaseEvents', () => ({

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
@@ -42,8 +42,8 @@ vi.mock('../../../index', () => ({
   }),
 }))
 
-vi.mock('../useBundleDocuments', () => ({
-  useBundleDocuments: vi.fn(() => useBundleDocumentsMockReturnWithResults),
+vi.mock('../useReleaseDocuments', () => ({
+  useReleaseDocuments: vi.fn(() => useBundleDocumentsMockReturnWithResults),
 }))
 
 vi.mock('../../../../preview/components/SanityDefaultPreview', () => ({

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/__mocks__/useBundleDocuments.mock.ts
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/__mocks__/useBundleDocuments.mock.ts
@@ -1,8 +1,9 @@
 import {type Mock, type Mocked} from 'vitest'
 
-import {type DocumentInRelease, useBundleDocuments} from '../../useBundleDocuments'
+import {type DocumentInBundle} from '../../useBundleDocuments'
+import {useReleaseDocuments} from '../../useReleaseDocuments'
 
-export const documentsInRelease: DocumentInRelease = {
+export const documentsInRelease: DocumentInBundle = {
   memoKey: 'a',
   document: {
     _id: 'a',
@@ -19,18 +20,18 @@ export const documentsInRelease: DocumentInRelease = {
   },
 }
 
-export const useBundleDocumentsMockReturn: Mocked<ReturnType<typeof useBundleDocuments>> = {
+export const useBundleDocumentsMockReturn: Mocked<ReturnType<typeof useReleaseDocuments>> = {
   loading: false,
   results: [],
   error: null,
 }
 
 export const useBundleDocumentsMockReturnWithResults: Mocked<
-  ReturnType<typeof useBundleDocuments>
+  ReturnType<typeof useReleaseDocuments>
 > = {
   loading: false,
   results: [documentsInRelease],
   error: null,
 }
 
-export const mockUseBundleDocuments = useBundleDocuments as Mock<typeof useBundleDocuments>
+export const mockUseBundleDocuments = useReleaseDocuments as Mock<typeof useReleaseDocuments>

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/releaseDocumentActions.test.ts
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/releaseDocumentActions.test.ts
@@ -5,7 +5,7 @@ import {
   type DocumentFilterType,
   documentMatchesFilter,
 } from '../releaseDocumentActions'
-import {type DocumentInRelease} from '../useBundleDocuments'
+import {type DocumentInBundle} from '../useBundleDocuments'
 
 function createMockDocument(
   overrides: Partial<{
@@ -14,7 +14,7 @@ function createMockDocument(
     publishedDocumentExists: boolean
     systemDelete: boolean
   }> = {},
-): DocumentInRelease {
+): DocumentInBundle {
   const {
     isPending = false,
     hasError = false,

--- a/packages/sanity/src/core/releases/tool/detail/components/ReleaseDocumentFilterTabs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/components/ReleaseDocumentFilterTabs.tsx
@@ -11,10 +11,10 @@ import {
   FILTER_TAB_CONFIGS,
   type FilterTabConfig,
 } from '../releaseDocumentActions'
-import {type DocumentInRelease} from '../useBundleDocuments'
+import {type DocumentInBundle} from '../useBundleDocuments'
 
 interface ReleaseDocumentFilterTabsProps {
-  documents: DocumentInRelease[]
+  documents: DocumentInBundle[]
   releaseState: ReleaseState
   isLoading?: boolean
   activeFilter: DocumentFilterType
@@ -69,7 +69,7 @@ export function ReleaseDocumentFilterTabs({
 }
 
 interface ReleaseDocumentFilterTabsInnerProps {
-  documents: DocumentInRelease[]
+  documents: DocumentInBundle[]
   activeFilter: DocumentFilterType
   onFilterChange: (filter: DocumentFilterType) => void
   t: ReturnType<typeof useTranslation>['t']

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -21,7 +21,7 @@ import {Headers} from '../../components/Table/TableHeader'
 import {type Column, type InjectedTableProps} from '../../components/Table/types'
 import {getDocumentActionType, getReleaseDocumentActionConfig} from '../releaseDocumentActions'
 import {type BundleDocumentRow} from '../ReleaseSummary'
-import {type DocumentInRelease} from '../useBundleDocuments'
+import {type DocumentInBundle} from '../useBundleDocuments'
 import {useReleaseHistory} from './useReleaseHistory'
 
 const MemoReleaseDocumentPreview = memo(
@@ -31,7 +31,7 @@ const MemoReleaseDocumentPreview = memo(
     releaseState,
     documentRevision,
   }: {
-    item: DocumentInRelease
+    item: DocumentInBundle
     releaseId: string
     releaseState?: ReleaseState
     documentRevision?: string

--- a/packages/sanity/src/core/releases/tool/detail/releaseDocumentActions.ts
+++ b/packages/sanity/src/core/releases/tool/detail/releaseDocumentActions.ts
@@ -1,6 +1,6 @@
 import {isGoingToUnpublish} from '../../util/isGoingToUnpublish'
 import {type BundleDocumentRow} from './ReleaseSummary'
-import {type DocumentInRelease} from './useBundleDocuments'
+import {type DocumentInBundle} from './useBundleDocuments'
 
 export type DocumentFilterType = 'all' | 'added' | 'changed' | 'unpublished' | 'errors'
 
@@ -46,7 +46,7 @@ export type ActionCounts = Record<'added' | 'changed' | 'unpublished' | 'errors'
  * Counts documents by their action type and validation errors
  */
 export function countDocumentsByAction(
-  documents: (DocumentInRelease | BundleDocumentRow)[],
+  documents: (DocumentInBundle | BundleDocumentRow)[],
 ): ActionCounts {
   return documents.reduce<ActionCounts>(
     (acc, doc) => {
@@ -67,7 +67,7 @@ export function countDocumentsByAction(
  * Checks if a document matches the given filter type
  */
 export function documentMatchesFilter(
-  doc: DocumentInRelease | BundleDocumentRow,
+  doc: DocumentInBundle | BundleDocumentRow,
   filter: DocumentFilterType,
 ): boolean {
   if (filter === 'all') return true
@@ -79,7 +79,7 @@ export function documentMatchesFilter(
  * Determines the action type for a document based on its state
  */
 export function getDocumentActionType(
-  document: DocumentInRelease | BundleDocumentRow,
+  document: DocumentInBundle | BundleDocumentRow,
 ): DocumentActionConfig['key'] | null {
   if (!document.document || document.isPending) {
     return null

--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -34,8 +34,10 @@ import {isGoingToUnpublish} from '../../util/isGoingToUnpublish'
  * Entries are keyed by the caller-provided `cacheKey` and removed once the last
  * subscriber unsubscribes (see `finalize` below).
  */
-const bundleDocumentsCache: Record<string, Observable<BundleDocumentsResult<unknown>>> =
-  Object.create(null)
+const bundleDocumentsCache: Record<
+  string,
+  Observable<BundleDocumentsResult<unknown>>
+> = Object.create(null)
 
 /** @internal */
 export function resetBundleDocumentsCacheForTests(): void {
@@ -233,6 +235,25 @@ interface UseBundleDocumentsOptions<TResult> extends BundleDocumentsConfig<TResu
   enabled?: boolean
 }
 
+// Resolves (and memoizes) the shared observable for a given `cacheKey`. Kept out of the hook body
+// so that the module-level cache is never mutated directly from within a hook.
+function getOrCreateBundleDocumentsObservable<TResult>(
+  cacheKey: string,
+  create: () => Observable<BundleDocumentsResult<TResult>>,
+): Observable<BundleDocumentsResult<TResult>> {
+  if (!bundleDocumentsCache[cacheKey]) {
+    bundleDocumentsCache[cacheKey] = create().pipe(
+      startWith({loading: true, results: [], error: null}),
+      finalize(() => {
+        delete bundleDocumentsCache[cacheKey]
+      }),
+      shareReplay(1),
+    ) as Observable<BundleDocumentsResult<unknown>>
+  }
+
+  return bundleDocumentsCache[cacheKey] as Observable<BundleDocumentsResult<TResult>>
+}
+
 /**
  * Generic hook that subscribes to {@link getBundleDocumentsObservable} with a shared, ref-counted
  * cache keyed by `cacheKey`. Release-specific and variant-specific hooks build on top of this.
@@ -257,8 +278,8 @@ export function useBundleDocuments<TResult>({
       return of<BundleDocumentsResult<TResult>>({loading: false, results: [], error: null})
     }
 
-    if (!bundleDocumentsCache[cacheKey]) {
-      bundleDocumentsCache[cacheKey] = getBundleDocumentsObservable<TResult>({
+    return getOrCreateBundleDocumentsObservable<TResult>(cacheKey, () =>
+      getBundleDocumentsObservable<TResult>({
         schema,
         documentPreviewStore,
         i18n,
@@ -269,16 +290,8 @@ export function useBundleDocuments<TResult>({
         clientOptions,
         observeDocument,
         mapDocument,
-      }).pipe(
-        startWith({loading: true, results: [], error: null}),
-        finalize(() => {
-          delete bundleDocumentsCache[cacheKey]
-        }),
-        shareReplay(1),
-      ) as Observable<BundleDocumentsResult<unknown>>
-    }
-
-    return bundleDocumentsCache[cacheKey] as Observable<BundleDocumentsResult<TResult>>
+      }),
+    )
   }, [
     cacheKey,
     enabled,

--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -1,11 +1,9 @@
-import {type ReleaseDocument} from '@sanity/client'
 import {
   type CurrentUser,
   isValidationErrorMarker,
   type SanityDocument,
   type Schema,
 } from '@sanity/types'
-import {uuid} from '@sanity/uuid'
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
 import {combineLatest, from, type Observable, of} from 'rxjs'
@@ -13,17 +11,15 @@ import {mergeMapArray} from 'rxjs-mergemap-array'
 import {
   catchError,
   delay,
-  distinctUntilChanged,
-  expand,
   filter,
   finalize,
   map,
-  reduce,
   shareReplay,
   startWith,
   switchMap,
 } from 'rxjs/operators'
 
+import {type SourceClientOptions} from '../../../config/types'
 import {useSchema} from '../../../hooks'
 import {type LocaleSource} from '../../../i18n/types'
 import {type DocumentPreviewStore} from '../../../preview'
@@ -31,75 +27,130 @@ import {useDocumentPreviewStore} from '../../../store/datastores'
 import {useSource} from '../../../studio'
 import {schedulerYield} from '../../../util/schedulerYield'
 import {validateDocumentWithReferences, type ValidationStatus} from '../../../validation'
-import {useReleasesStore} from '../../store/useReleasesStore'
-import {getReleaseDocumentIdFromReleaseId} from '../../util/getReleaseDocumentIdFromReleaseId'
 import {isGoingToUnpublish} from '../../util/isGoingToUnpublish'
-import {RELEASES_STUDIO_CLIENT_OPTIONS} from '../../util/releasesClient'
 
-const bundleDocumentsCache: Record<string, ReleaseDocumentsObservableResult> = Object.create(null)
+/**
+ * Generic cache shared by every consumer of the bundle documents machinery.
+ * Entries are keyed by the caller-provided `cacheKey` and removed once the last
+ * subscriber unsubscribes (see `finalize` below).
+ */
+const bundleDocumentsCache: Record<string, Observable<BundleDocumentsResult<unknown>>> =
+  Object.create(null)
+
+/** @internal */
+export function resetBundleDocumentsCacheForTests(): void {
+  for (const key of Object.keys(bundleDocumentsCache)) {
+    delete bundleDocumentsCache[key]
+  }
+}
 
 export interface DocumentValidationStatus extends ValidationStatus {
   hasError: boolean
 }
 
-export interface DocumentInRelease {
+export interface DocumentInBundle {
   memoKey: string
   isPending?: boolean
   document: SanityDocument & {publishedDocumentExists: boolean}
   validation: DocumentValidationStatus
 }
 
-type ReleaseDocumentsObservableResult = Observable<{
+export interface BundleDocumentsResult<TResult> {
   loading: boolean
-  results: DocumentInRelease[]
+  results: TResult[]
   error: Error | null
-}>
+}
 
-const getActiveReleaseDocumentsObservable = ({
-  schema,
-  documentPreviewStore,
-  i18n,
-  getClient,
-  releaseId,
-  currentUser,
-}: {
+interface BundleDocumentsContext {
   schema: Schema
   documentPreviewStore: DocumentPreviewStore
   i18n: LocaleSource
   getClient: ReturnType<typeof useSource>['getClient']
-  releaseId: string
   currentUser?: Omit<CurrentUser, 'role'> | null
-}): ReleaseDocumentsObservableResult => {
-  const groqFilter = `sanity::partOfRelease($releaseId)`
+}
 
-  // Helper function to create validation observable
-  const createValidationObservable = (ctx: any, document: SanityDocument) => {
-    if (isGoingToUnpublish(document)) {
-      return of({
-        isValidating: false,
-        validation: [],
-        revision: document._rev,
-        hasError: false,
-      } satisfies DocumentValidationStatus)
-    }
+interface BundleDocumentsConfig<TResult> {
+  /** The groq filter used to resolve the set of documents that belong to the bundle. */
+  groqFilter: string
+  /** Parameters referenced by `groqFilter` (for example `{releaseId}` or `{variantId}`). */
+  queryParams: Record<string, string>
+  /** Client options (used for the api version of the underlying observe calls). */
+  clientOptions: SourceClientOptions
+  /**
+   * Optional override for how a single document is observed. Defaults to a plain
+   * `unstable_observeDocument` (filtering out empty results). Releases override this to
+   * additionally resolve whether a published document exists.
+   */
+  observeDocument?: (id: string) => Observable<SanityDocument>
+  /**
+   * Maps an observed document + its validation into the shape returned by the hook.
+   * Returning `null` drops the document from the results.
+   */
+  mapDocument: (document: SanityDocument, validation: DocumentValidationStatus) => TResult | null
+}
 
-    // scheduledYield is used to provide some control over the main thread
-    return from(schedulerYield(() => Promise.resolve())).pipe(
-      switchMap(() =>
-        validateDocumentWithReferences(ctx, of(document), false).pipe(
-          map((validationStatus) => ({
-            ...validationStatus,
-            hasError: validationStatus.validation.some((marker) => isValidationErrorMarker(marker)),
-          })),
-        ),
-      ),
-    )
+type ValidationContext = Parameters<typeof validateDocumentWithReferences>[0]
+
+// Helper to create the validation observable for a single document.
+const createValidationObservable = (
+  ctx: ValidationContext,
+  document: SanityDocument,
+): Observable<DocumentValidationStatus> => {
+  if (isGoingToUnpublish(document)) {
+    return of({
+      isValidating: false,
+      validation: [],
+      revision: document._rev,
+      hasError: false,
+    } satisfies DocumentValidationStatus)
   }
 
-  // Helper function to process a single document and set up the associated validation observable
-  const processDocument = (id: string) => {
-    const ctx = {
-      observeDocument: documentPreviewStore.unstable_observeDocument,
+  // scheduledYield is used to provide some control over the main thread
+  return from(schedulerYield(() => Promise.resolve())).pipe(
+    switchMap(() =>
+      validateDocumentWithReferences(ctx, of(document), false).pipe(
+        map((validationStatus) => ({
+          ...validationStatus,
+          hasError: validationStatus.validation.some((marker) => isValidationErrorMarker(marker)),
+        })),
+      ),
+    ),
+  )
+}
+
+/**
+ * The underlying machinery that resolves a set of documents (matched by a groq filter), observes
+ * each of them, validates them and batches the work as to not overwhelm the main thread.
+ *
+ * This is intentionally agnostic of releases/variants; callers parameterize it via `groqFilter`,
+ * `queryParams`, `observeDocument` and `mapDocument`.
+ *
+ * @internal
+ */
+export function getBundleDocumentsObservable<TResult>({
+  schema,
+  documentPreviewStore,
+  i18n,
+  getClient,
+  currentUser,
+  groqFilter,
+  queryParams,
+  clientOptions,
+  observeDocument,
+  mapDocument,
+}: BundleDocumentsContext & BundleDocumentsConfig<TResult>): Observable<
+  BundleDocumentsResult<TResult>
+> {
+  const observe =
+    observeDocument ??
+    ((id: string) =>
+      documentPreviewStore
+        .unstable_observeDocument(id, {apiVersion: clientOptions.apiVersion})
+        .pipe(filter(Boolean)))
+
+  // Process a single document and set up the associated validation observable.
+  const processDocument = (id: string): Observable<TResult | null> => {
+    const ctx: ValidationContext = {
       observeDocumentPairAvailability:
         documentPreviewStore.unstable_observeDocumentPairAvailability,
       i18n,
@@ -108,37 +159,18 @@ const getActiveReleaseDocumentsObservable = ({
       currentUser,
     }
 
-    const document$ = documentPreviewStore
-      .unstable_observeDocument(id, {
-        apiVersion: RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion,
-      })
-      .pipe(
-        filter(Boolean),
-        switchMap((doc) => {
-          return documentPreviewStore.unstable_observeDocumentPairAvailability(id).pipe(
-            map((availability) => ({
-              ...doc,
-              publishedDocumentExists: availability.published.available,
-            })),
-          )
-        }),
-      )
+    const document$ = observe(id)
 
     const validation$ = document$.pipe(
       switchMap((document) => createValidationObservable(ctx, document)),
     )
 
     return combineLatest([document$, validation$]).pipe(
-      map(([document, validation]) => ({
-        document,
-        validation,
-        memoKey: uuid(),
-      })),
+      map(([document, validation]) => mapDocument(document, validation)),
     )
   }
 
-  // Helper function to process a group of document Ids
-  // Used to process documents as to not overwhelm the main thread
+  // Process a group of document ids. Used to process documents as to not overwhelm the main thread.
   const processDocumentIdsGroup = (documentIdsGroup: string[], groupIndex: number) => {
     // On the first batch there is no delay
     const batchDelay = groupIndex === 0 ? 0 : 100
@@ -150,26 +182,22 @@ const getActiveReleaseDocumentsObservable = ({
   }
 
   return documentPreviewStore
-    .unstable_observeDocumentIdSet(
-      groqFilter,
-      {releaseId},
-      {
-        apiVersion: RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion,
-      },
-    )
+    .unstable_observeDocumentIdSet(groqFilter, queryParams, {
+      apiVersion: clientOptions.apiVersion,
+    })
     .pipe(
       map((state) => state.documentIds || []),
       switchMap((documentIds) => {
         // If no documents, return empty results immediately
         if (documentIds.length === 0) {
-          return of([])
+          return of<(TResult | null)[]>([])
         }
 
         // Process in smaller groups as to not overwhelm the main thread
         // depending on the browser it can handle a different number of calls at once, this felt like a good balance
         // given the tests done
         const batchSize = 5
-        const documentIdsGroups = []
+        const documentIdsGroups: string[][] = []
         for (let i = 0; i < documentIds.length; i += batchSize) {
           documentIdsGroups.push(documentIds.slice(i, i + batchSize))
         }
@@ -186,175 +214,85 @@ const getActiveReleaseDocumentsObservable = ({
           ),
         ).pipe(
           // Flatten all batch results into a single array
-          // This is done to avoid having to nest the results and keep the strutcture as it was before
           map((groupResults) => groupResults.flat()),
         )
       }),
-      map((results) => ({loading: false, results, error: null})),
-      catchError((error) => {
-        return of({loading: false, results: [], error})
-      }),
-    )
-}
-
-const getPublishedArchivedReleaseDocumentsObservable = ({
-  getClient,
-  release,
-}: {
-  getClient: ReturnType<typeof useSource>['getClient']
-  release: ReleaseDocument
-}): ReleaseDocumentsObservableResult => {
-  const client = getClient(RELEASES_STUDIO_CLIENT_OPTIONS)
-  const observableClient = client.observable
-  const dataset = client.config().dataset
-
-  if (!release.finalDocumentStates?.length) return of({loading: false, results: [], error: null})
-
-  function batchRequestDocumentFromHistory(startIndex: number) {
-    const finalIndex = startIndex + 10
-    return observableClient
-      .request<{documents: DocumentInRelease['document'][]}>({
-        url: `/data/history/${dataset}/documents/${release.finalDocumentStates
-          ?.slice(startIndex, finalIndex)
-          .map((d) => d.id)
-          .join(',')}?lastRevision=true`,
-      })
-      .pipe(map(({documents}) => ({documents, finalIndex})))
-  }
-
-  const documents$ = batchRequestDocumentFromHistory(0).pipe(
-    expand((response) => {
-      if (release.finalDocumentStates && response.finalIndex < release.finalDocumentStates.length) {
-        // Continue with next batch
-        return batchRequestDocumentFromHistory(response.finalIndex)
-      }
-      // End recursion by emitting an empty observable
-      return of()
-    }),
-    reduce(
-      (documents: DocumentInRelease['document'][], batch) => documents.concat(batch.documents),
-      [],
-    ),
-  )
-
-  return documents$.pipe(
-    map((documents) => ({
-      loading: false,
-      results: documents.map((document) => ({
-        document,
-        memoKey: uuid(),
-        validation: {validation: [], hasError: false, isValidating: false},
+      map((results) => ({
+        loading: false,
+        results: results.filter((result): result is TResult => result !== null),
+        error: null,
       })),
-      error: null,
-    })),
-    catchError((error) => {
-      return of({loading: false, results: [], error})
-    }),
-  )
-}
-
-const getReleaseDocumentsObservable = ({
-  schema,
-  documentPreviewStore,
-  getClient,
-  releaseId,
-  i18n,
-  releasesState$,
-  currentUser,
-}: {
-  schema: Schema
-  documentPreviewStore: DocumentPreviewStore
-  getClient: ReturnType<typeof useSource>['getClient']
-  releaseId: string
-  i18n: LocaleSource
-  releasesState$: ReturnType<typeof useReleasesStore>['state$']
-  currentUser?: Omit<CurrentUser, 'role'> | null
-}): ReleaseDocumentsObservableResult => {
-  if (!bundleDocumentsCache[releaseId]) {
-    bundleDocumentsCache[releaseId] = releasesState$.pipe(
-      map((releasesState) =>
-        releasesState.releases.get(getReleaseDocumentIdFromReleaseId(releaseId)),
-      ),
-      filter(Boolean), // Removes falsey values
-      distinctUntilChanged((prev, next) => {
-        // Only skip re-validation if the core fields that affect document validation haven't changed
-        // Return true to skip, false to trigger re-validation
-        // _rev wasn't enough since it changed on every edit of the release document itself
-        return prev.state === next.state && prev.finalDocumentStates === next.finalDocumentStates
-      }),
-      switchMap((release) => {
-        // Create cache key based on fields that affect document validation + _rev
-        const cacheKey = [
-          releaseId,
-          release.state,
-          release.finalDocumentStates?.flatMap((doc) => doc.id),
-          release._rev,
-        ].join('-')
-
-        if (!bundleDocumentsCache[cacheKey]) {
-          let observable: ReleaseDocumentsObservableResult
-
-          if (release.state === 'published' || release.state === 'archived') {
-            observable = getPublishedArchivedReleaseDocumentsObservable({
-              getClient,
-              release,
-            })
-          } else {
-            observable = getActiveReleaseDocumentsObservable({
-              schema,
-              documentPreviewStore,
-              i18n,
-              getClient,
-              releaseId,
-              currentUser,
-            })
-          }
-
-          bundleDocumentsCache[cacheKey] = observable.pipe(
-            finalize(() => {
-              delete bundleDocumentsCache[cacheKey]
-            }),
-            shareReplay(1),
-          )
-        }
-
-        return bundleDocumentsCache[cacheKey]
-      }),
-      startWith({loading: true, results: [], error: null}),
-      shareReplay(1),
+      catchError((error) => of({loading: false, results: [] as TResult[], error})),
     )
-  }
-
-  return bundleDocumentsCache[releaseId]
 }
 
-export function useBundleDocuments(releaseId: string): {
-  loading: boolean
-  results: DocumentInRelease[]
-  error: null | Error
-} {
+interface UseBundleDocumentsOptions<TResult> extends BundleDocumentsConfig<TResult> {
+  /** Identifies the cached observable. Subscribers sharing a `cacheKey` share the same stream. */
+  cacheKey: string
+  /** When `false`, the hook short-circuits to an empty result without subscribing. */
+  enabled?: boolean
+}
+
+/**
+ * Generic hook that subscribes to {@link getBundleDocumentsObservable} with a shared, ref-counted
+ * cache keyed by `cacheKey`. Release-specific and variant-specific hooks build on top of this.
+ *
+ * @internal
+ */
+export function useBundleDocuments<TResult>({
+  cacheKey,
+  enabled = true,
+  groqFilter,
+  queryParams,
+  clientOptions,
+  observeDocument,
+  mapDocument,
+}: UseBundleDocumentsOptions<TResult>): BundleDocumentsResult<TResult> {
   const documentPreviewStore = useDocumentPreviewStore()
   const {getClient, i18n, currentUser} = useSource()
   const schema = useSchema()
-  const {state$: releasesState$} = useReleasesStore()
 
-  const releaseDocumentsObservable = useMemo(
-    () =>
-      getReleaseDocumentsObservable({
+  const documentsObservable = useMemo(() => {
+    if (!enabled) {
+      return of<BundleDocumentsResult<TResult>>({loading: false, results: [], error: null})
+    }
+
+    if (!bundleDocumentsCache[cacheKey]) {
+      bundleDocumentsCache[cacheKey] = getBundleDocumentsObservable<TResult>({
         schema,
         documentPreviewStore,
-        getClient,
-        releaseId,
         i18n,
-        releasesState$,
+        getClient,
         currentUser,
-      }),
-    [schema, documentPreviewStore, getClient, releaseId, i18n, releasesState$, currentUser],
-  )
+        groqFilter,
+        queryParams,
+        clientOptions,
+        observeDocument,
+        mapDocument,
+      }).pipe(
+        startWith({loading: true, results: [], error: null}),
+        finalize(() => {
+          delete bundleDocumentsCache[cacheKey]
+        }),
+        shareReplay(1),
+      ) as Observable<BundleDocumentsResult<unknown>>
+    }
 
-  return useObservable(releaseDocumentsObservable, {
-    loading: true,
-    results: [],
-    error: null,
-  })
+    return bundleDocumentsCache[cacheKey] as Observable<BundleDocumentsResult<TResult>>
+  }, [
+    cacheKey,
+    enabled,
+    schema,
+    documentPreviewStore,
+    i18n,
+    getClient,
+    currentUser,
+    groqFilter,
+    queryParams,
+    clientOptions,
+    observeDocument,
+    mapDocument,
+  ])
+
+  return useObservable(documentsObservable, {loading: enabled, results: [], error: null})
 }

--- a/packages/sanity/src/core/releases/tool/detail/useReleaseDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useReleaseDocuments.ts
@@ -1,0 +1,244 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {type CurrentUser, type SanityDocument, type Schema} from '@sanity/types'
+import {uuid} from '@sanity/uuid'
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {combineLatest, type Observable, of} from 'rxjs'
+import {
+  catchError,
+  distinctUntilChanged,
+  expand,
+  filter,
+  finalize,
+  map,
+  reduce,
+  shareReplay,
+  startWith,
+  switchMap,
+} from 'rxjs/operators'
+
+import {useSchema} from '../../../hooks'
+import {type LocaleSource} from '../../../i18n/types'
+import {type DocumentPreviewStore} from '../../../preview'
+import {useDocumentPreviewStore} from '../../../store/datastores'
+import {useSource} from '../../../studio'
+import {useReleasesStore} from '../../store/useReleasesStore'
+import {getReleaseDocumentIdFromReleaseId} from '../../util/getReleaseDocumentIdFromReleaseId'
+import {RELEASES_STUDIO_CLIENT_OPTIONS} from '../../util/releasesClient'
+import {
+  type BundleDocumentsResult,
+  type DocumentInBundle,
+  getBundleDocumentsObservable,
+} from './useBundleDocuments'
+
+type ReleaseDocumentsObservableResult = Observable<BundleDocumentsResult<DocumentInBundle>>
+
+const releaseDocumentsCache: Record<string, ReleaseDocumentsObservableResult> = Object.create(null)
+
+const getActiveReleaseDocumentsObservable = ({
+  schema,
+  documentPreviewStore,
+  i18n,
+  getClient,
+  releaseId,
+  currentUser,
+}: {
+  schema: Schema
+  documentPreviewStore: DocumentPreviewStore
+  i18n: LocaleSource
+  getClient: ReturnType<typeof useSource>['getClient']
+  releaseId: string
+  currentUser?: Omit<CurrentUser, 'role'> | null
+}): ReleaseDocumentsObservableResult =>
+  getBundleDocumentsObservable<DocumentInBundle>({
+    schema,
+    documentPreviewStore,
+    i18n,
+    getClient,
+    currentUser,
+    groqFilter: `sanity::partOfRelease($releaseId)`,
+    queryParams: {releaseId},
+    clientOptions: RELEASES_STUDIO_CLIENT_OPTIONS,
+    // Releases additionally resolve whether a published version of the document exists.
+    observeDocument: (id: string) =>
+      documentPreviewStore
+        .unstable_observeDocument(id, {apiVersion: RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion})
+        .pipe(
+          filter(Boolean),
+          switchMap((doc) =>
+            documentPreviewStore.unstable_observeDocumentPairAvailability(id).pipe(
+              map((availability) => ({
+                ...doc,
+                publishedDocumentExists: availability.published.available,
+              })),
+            ),
+          ),
+        ),
+    mapDocument: (document, validation) => ({
+      document: document as DocumentInBundle['document'],
+      validation,
+      memoKey: uuid(),
+    }),
+  })
+
+const getPublishedArchivedReleaseDocumentsObservable = ({
+  getClient,
+  release,
+}: {
+  getClient: ReturnType<typeof useSource>['getClient']
+  release: ReleaseDocument
+}): ReleaseDocumentsObservableResult => {
+  const client = getClient(RELEASES_STUDIO_CLIENT_OPTIONS)
+  const observableClient = client.observable
+  const dataset = client.config().dataset
+
+  if (!release.finalDocumentStates?.length) return of({loading: false, results: [], error: null})
+
+  function batchRequestDocumentFromHistory(startIndex: number) {
+    const finalIndex = startIndex + 10
+    return observableClient
+      .request<{documents: DocumentInBundle['document'][]}>({
+        url: `/data/history/${dataset}/documents/${release.finalDocumentStates
+          ?.slice(startIndex, finalIndex)
+          .map((d) => d.id)
+          .join(',')}?lastRevision=true`,
+      })
+      .pipe(map(({documents}) => ({documents, finalIndex})))
+  }
+
+  const documents$ = batchRequestDocumentFromHistory(0).pipe(
+    expand((response) => {
+      if (release.finalDocumentStates && response.finalIndex < release.finalDocumentStates.length) {
+        // Continue with next batch
+        return batchRequestDocumentFromHistory(response.finalIndex)
+      }
+      // End recursion by emitting an empty observable
+      return of()
+    }),
+    reduce(
+      (documents: DocumentInBundle['document'][], batch) => documents.concat(batch.documents),
+      [],
+    ),
+  )
+
+  return documents$.pipe(
+    map((documents) => ({
+      loading: false,
+      results: documents.map((document) => ({
+        document,
+        memoKey: uuid(),
+        validation: {validation: [], hasError: false, isValidating: false},
+      })),
+      error: null,
+    })),
+    catchError((error) => {
+      return of({loading: false, results: [], error})
+    }),
+  )
+}
+
+const getReleaseDocumentsObservable = ({
+  schema,
+  documentPreviewStore,
+  getClient,
+  releaseId,
+  i18n,
+  releasesState$,
+  currentUser,
+}: {
+  schema: Schema
+  documentPreviewStore: DocumentPreviewStore
+  getClient: ReturnType<typeof useSource>['getClient']
+  releaseId: string
+  i18n: LocaleSource
+  releasesState$: ReturnType<typeof useReleasesStore>['state$']
+  currentUser?: Omit<CurrentUser, 'role'> | null
+}): ReleaseDocumentsObservableResult => {
+  if (!releaseDocumentsCache[releaseId]) {
+    releaseDocumentsCache[releaseId] = releasesState$.pipe(
+      map((releasesState) =>
+        releasesState.releases.get(getReleaseDocumentIdFromReleaseId(releaseId)),
+      ),
+      filter(Boolean), // Removes falsey values
+      distinctUntilChanged((prev, next) => {
+        // Only skip re-validation if the core fields that affect document validation haven't changed
+        // Return true to skip, false to trigger re-validation
+        // _rev wasn't enough since it changed on every edit of the release document itself
+        return prev.state === next.state && prev.finalDocumentStates === next.finalDocumentStates
+      }),
+      switchMap((release) => {
+        // Create cache key based on fields that affect document validation + _rev
+        const cacheKey = [
+          releaseId,
+          release.state,
+          release.finalDocumentStates?.flatMap((doc) => doc.id),
+          release._rev,
+        ].join('-')
+
+        if (!releaseDocumentsCache[cacheKey]) {
+          let observable: ReleaseDocumentsObservableResult
+
+          if (release.state === 'published' || release.state === 'archived') {
+            observable = getPublishedArchivedReleaseDocumentsObservable({
+              getClient,
+              release,
+            })
+          } else {
+            observable = getActiveReleaseDocumentsObservable({
+              schema,
+              documentPreviewStore,
+              i18n,
+              getClient,
+              releaseId,
+              currentUser,
+            })
+          }
+
+          releaseDocumentsCache[cacheKey] = observable.pipe(
+            finalize(() => {
+              delete releaseDocumentsCache[cacheKey]
+            }),
+            shareReplay(1),
+          )
+        }
+
+        return releaseDocumentsCache[cacheKey]
+      }),
+      startWith({loading: true, results: [], error: null}),
+      shareReplay(1),
+    )
+  }
+
+  return releaseDocumentsCache[releaseId]
+}
+
+export function useReleaseDocuments(releaseId: string): {
+  loading: boolean
+  results: DocumentInBundle[]
+  error: null | Error
+} {
+  const documentPreviewStore = useDocumentPreviewStore()
+  const {getClient, i18n, currentUser} = useSource()
+  const schema = useSchema()
+  const {state$: releasesState$} = useReleasesStore()
+
+  const releaseDocumentsObservable = useMemo(
+    () =>
+      getReleaseDocumentsObservable({
+        schema,
+        documentPreviewStore,
+        getClient,
+        releaseId,
+        i18n,
+        releasesState$,
+        currentUser,
+      }),
+    [schema, documentPreviewStore, getClient, releaseId, i18n, releasesState$, currentUser],
+  )
+
+  return useObservable(releaseDocumentsObservable, {
+    loading: true,
+    results: [],
+    error: null,
+  })
+}

--- a/packages/sanity/src/core/releases/tool/overview/ReleaseMenuButtonWrapper.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleaseMenuButtonWrapper.tsx
@@ -2,7 +2,7 @@ import {type ReleaseDocument} from '@sanity/client'
 
 import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
 import {ReleaseMenuButton} from '../components/ReleaseMenuButton/ReleaseMenuButton'
-import {useBundleDocuments} from '../detail/useBundleDocuments'
+import {useReleaseDocuments} from '../detail/useReleaseDocuments'
 
 export const ReleaseMenuButtonWrapper = ({
   release,
@@ -11,7 +11,7 @@ export const ReleaseMenuButtonWrapper = ({
   release: ReleaseDocument
   documentsCount: number
 }) => {
-  const {results: documents} = useBundleDocuments(getReleaseIdFromReleaseDocumentId(release._id))
+  const {results: documents} = useReleaseDocuments(getReleaseIdFromReleaseDocumentId(release._id))
 
   return (
     <ReleaseMenuButton release={release} documentsCount={documentsCount} documents={documents} />

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
@@ -95,8 +95,8 @@ vi.mock('../../../store/useReleasesMetadata', () => ({
   useReleasesMetadata: vi.fn(() => useReleasesMetadataMockReturn),
 }))
 
-vi.mock('../../detail/useBundleDocuments', () => ({
-  useBundleDocuments: vi.fn(() => useBundleDocumentsMockReturnWithResults),
+vi.mock('../../detail/useReleaseDocuments', () => ({
+  useReleaseDocuments: vi.fn(() => useBundleDocumentsMockReturnWithResults),
 }))
 
 vi.mock('../../../store/useReleasePermissions', () => ({

--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseColumnValidationLoading.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseColumnValidationLoading.tsx
@@ -1,12 +1,12 @@
 import {Spinner} from '@sanity/ui'
 
 import {getReleaseIdFromReleaseDocumentId} from '../../../util/getReleaseIdFromReleaseDocumentId'
-import {useBundleDocuments} from '../../detail/useBundleDocuments'
+import {useReleaseDocuments} from '../../detail/useReleaseDocuments'
 import {ValidationProgressIndicator} from '../../detail/ValidationProgressIndicator'
 
 export function ReleaseColumnValidationLoading({releaseId}: {releaseId: string}) {
   const rId = getReleaseIdFromReleaseDocumentId(releaseId)
-  const {results: documents, loading} = useBundleDocuments(rId)
+  const {results: documents, loading} = useReleaseDocuments(rId)
 
   return loading ? (
     <Spinner size={1} muted />

--- a/packages/sanity/src/core/releases/util/getDocumentValidationLoading.ts
+++ b/packages/sanity/src/core/releases/util/getDocumentValidationLoading.ts
@@ -1,4 +1,4 @@
-import {type DocumentInRelease} from '../tool/detail/useBundleDocuments'
+import {type DocumentInBundle} from '../tool/detail/useBundleDocuments'
 import {isGoingToUnpublish} from './isGoingToUnpublish'
 
 /**
@@ -6,7 +6,7 @@ import {isGoingToUnpublish} from './isGoingToUnpublish'
  * @param documents - The list of documents to get the validation loading state for
  * @returns
  */
-export const getDocumentValidationLoading = (documents: DocumentInRelease[]) => {
+export const getDocumentValidationLoading = (documents: DocumentInBundle[]) => {
   let hasError = false
   let isValidating = false
   let validatedCount = 0

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftDocument.ts
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftDocument.ts
@@ -3,7 +3,7 @@ import {type PreviewValue, type ValidationMarker} from '@sanity/types'
 
 import {useSchema} from '../../hooks'
 import {unstable_useValuePreview as useValuePreview} from '../../preview/useValuePreview'
-import {useBundleDocuments} from '../../releases/tool/detail/useBundleDocuments'
+import {useReleaseDocuments} from '../../releases/tool/detail/useReleaseDocuments'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
 
 /**
@@ -25,7 +25,7 @@ export function useScheduledDraftDocument(
 } {
   const {includePreview = false} = options
   const releaseId = releaseDocumentId ? getReleaseIdFromReleaseDocumentId(releaseDocumentId) : ''
-  const {results: documents, loading, error} = useBundleDocuments(releaseId)
+  const {results: documents, loading, error} = useReleaseDocuments(releaseId)
   const schema = useSchema()
 
   const firstDocument = documents?.[0]?.document

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
@@ -15,6 +15,7 @@ import {
   getVariantDescription,
   getVariantTitle,
 } from '../util'
+import {useVariantDocuments} from './useVariantDocuments'
 import {VariantDetailFooter} from './VariantDetailFooter'
 import {VariantDocumentsTable} from './VariantDocumentsTable'
 
@@ -28,6 +29,19 @@ export function VariantDetail() {
     typeof router.state.variantId === 'string' ? router.state.variantId : undefined
   const variantId = decodeVariantIdFromRoute(variantIdRaw)
   const {byId, loading} = useAllVariants()
+  const {
+    results: variantDocuments,
+    loading: variantDocumentsLoading,
+    error: variantDocumentsError,
+  } = useVariantDocuments(variantId)
+
+  // oxlint-disable-next-line no-console
+  console.log('variant documents', {
+    variantId,
+    loading: variantDocumentsLoading,
+    error: variantDocumentsError,
+    results: variantDocuments,
+  })
 
   const variant = variantId ? byId.get(variantId) : undefined
 
@@ -98,6 +112,11 @@ export function VariantDetail() {
           </Flex>
         </Container>
         <Flex direction="column" flex={1} overflow="hidden" style={{minHeight: 0}}>
+          <Box paddingX={3} paddingBottom={2}>
+            <Text muted size={1}>
+              {variantDocuments.length}
+            </Text>
+          </Box>
           <VariantDocumentsTable documents={EMPTY_VARIANT_DOCUMENTS} />
         </Flex>
       </Flex>

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/useVariantDocuments.test.ts
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/useVariantDocuments.test.ts
@@ -1,0 +1,107 @@
+import {renderHook, waitFor} from '@testing-library/react'
+import {of} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {variantAlphaAudience} from '../../../__fixtures__/variants.fixture'
+import {resetVariantDocumentsCacheForTests, useVariantDocuments} from '../useVariantDocuments'
+
+const validateDocumentWithReferencesMock = vi.hoisted(() =>
+  vi.fn(() =>
+    of({
+      isValidating: false,
+      validation: [{level: 'error', message: 'Title is required', path: ['title']}],
+      revision: 'rev-1',
+    }),
+  ),
+)
+
+const documentPreviewStoreMock = vi.hoisted(() => ({
+  unstable_observeDocumentIdSet: vi.fn(() => of({status: 'connected' as const, documentIds: []})),
+  unstable_observeDocument: vi.fn(() => of(null)),
+  unstable_observeDocumentPairAvailability: vi.fn(() =>
+    of({published: {available: true}, draft: {available: true}}),
+  ),
+}))
+
+vi.mock('../../../../validation', async (importOriginal) => ({
+  ...(await importOriginal()),
+  validateDocumentWithReferences: validateDocumentWithReferencesMock,
+}))
+
+vi.mock('../../../../store/datastores', () => ({
+  useDocumentPreviewStore: vi.fn(() => documentPreviewStoreMock),
+}))
+
+describe('useVariantDocuments', () => {
+  beforeEach(() => {
+    resetVariantDocumentsCacheForTests()
+    validateDocumentWithReferencesMock.mockClear()
+    documentPreviewStoreMock.unstable_observeDocumentIdSet.mockReset()
+    documentPreviewStoreMock.unstable_observeDocument.mockReset()
+    documentPreviewStoreMock.unstable_observeDocumentIdSet.mockReturnValue(
+      of({status: 'connected' as const, documentIds: []}),
+    )
+    documentPreviewStoreMock.unstable_observeDocument.mockReturnValue(of(null))
+  })
+
+  it('returns an empty result when no variant id is provided', async () => {
+    const wrapper = await createTestProvider()
+
+    const {result} = renderHook(() => useVariantDocuments(undefined), {wrapper})
+
+    expect(result.current).toEqual({
+      loading: false,
+      results: [],
+      error: null,
+    })
+    expect(documentPreviewStoreMock.unstable_observeDocumentIdSet).not.toHaveBeenCalled()
+  })
+
+  it('queries variant membership with the fallback _system.variant filter', async () => {
+    const wrapper = await createTestProvider()
+
+    renderHook(() => useVariantDocuments(variantAlphaAudience._id), {wrapper})
+
+    expect(documentPreviewStoreMock.unstable_observeDocumentIdSet).toHaveBeenCalledWith(
+      '_system.variant._ref == $variantId',
+      {variantId: variantAlphaAudience._id},
+      expect.objectContaining({apiVersion: 'X'}),
+    )
+  })
+
+  it('validates each variant document and exposes hasError on the result', async () => {
+    const document = {
+      _id: 'drafts.scope.article-1',
+      _type: 'article',
+      _rev: 'rev-1',
+      _createdAt: '2025-06-01T00:00:00Z',
+      _updatedAt: '2025-06-01T00:00:00Z',
+      _system: {
+        bundleId: 'drafts',
+        release: null,
+        variant: {_ref: variantAlphaAudience._id, _weak: true},
+        group: {_ref: 'article-1', _weak: true},
+        scopeId: null,
+      },
+    }
+
+    documentPreviewStoreMock.unstable_observeDocumentIdSet.mockReturnValue(
+      of({status: 'connected' as const, documentIds: [document._id]}),
+    )
+    documentPreviewStoreMock.unstable_observeDocument.mockReturnValue(of(document))
+
+    const wrapper = await createTestProvider()
+    const {result} = renderHook(() => useVariantDocuments(variantAlphaAudience._id), {wrapper})
+
+    await waitFor(() => {
+      expect(result.current.results).toHaveLength(1)
+    })
+
+    expect(validateDocumentWithReferencesMock).toHaveBeenCalled()
+    expect(result.current.results[0]?.validation.hasError).toBe(true)
+    expect(result.current.results[0]?.validation.validation).toEqual([
+      {level: 'error', message: 'Title is required', path: ['title']},
+    ])
+  })
+})

--- a/packages/sanity/src/core/variants/tool/detail/useVariantDocuments.ts
+++ b/packages/sanity/src/core/variants/tool/detail/useVariantDocuments.ts
@@ -1,0 +1,58 @@
+import {type SanityDocument} from '@sanity/types'
+import {uuid} from '@sanity/uuid'
+import {useMemo} from 'react'
+
+import {
+  type DocumentValidationStatus,
+  resetBundleDocumentsCacheForTests,
+  useBundleDocuments,
+} from '../../../releases/tool/detail/useBundleDocuments'
+import {VARIANTS_STUDIO_CLIENT_OPTIONS} from '../../store/constants'
+
+/**
+ * A single document that belongs to a variant.
+ *
+ * @internal
+ */
+export interface DocumentInVariant {
+  memoKey: string
+  document: SanityDocument
+  validation: DocumentValidationStatus
+}
+
+// TODO: replace with sanity::partOfVariant($variantId) when the native GROQ function ships
+const VARIANT_DOCUMENTS_GROQ_FILTER = '_system.variant._ref == $variantId'
+
+const mapVariantDocument = (
+  document: SanityDocument,
+  validation: DocumentValidationStatus,
+): DocumentInVariant => ({
+  memoKey: uuid(),
+  document,
+  validation,
+})
+
+/** @internal */
+export const resetVariantDocumentsCacheForTests = resetBundleDocumentsCacheForTests
+
+/**
+ * Loads every document that belongs to the given variant, validating each one.
+ *
+ * @internal
+ */
+export function useVariantDocuments(variantId?: string): {
+  loading: boolean
+  results: DocumentInVariant[]
+  error: Error | null
+} {
+  const queryParams = useMemo(() => ({variantId: variantId ?? ''}), [variantId])
+
+  return useBundleDocuments<DocumentInVariant>({
+    cacheKey: variantId ?? '',
+    enabled: Boolean(variantId),
+    groqFilter: VARIANT_DOCUMENTS_GROQ_FILTER,
+    queryParams,
+    clientOptions: VARIANTS_STUDIO_CLIENT_OPTIONS,
+    mapDocument: mapVariantDocument,
+  })
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Abstracts the releases `useBundleDocuments` hook into generic, reusable machinery so it can also power variant document loading.

- `useBundleDocuments` is now a generic engine: a `getBundleDocumentsObservable` factory plus a generic `useBundleDocuments` hook, parameterized by `groqFilter`, `queryParams`, `clientOptions`, an optional `observeDocument` override, and a `mapDocument` callback. It keeps the shared pipeline (groq id-set subscription, batched processing, per-document validation, ref-counted cache).
- A new `useReleaseDocuments` hook holds the release-specific bits that were previously inlined: `releasesState$` switching, the published/archived history fetch, the `publishedDocumentExists` augmentation, and the `sanity::partOfRelease` filter. All release callers and test mocks now use `useReleaseDocuments`.
- `DocumentInRelease` is renamed to the generic `DocumentInBundle` (exported from `useBundleDocuments`). The release-specific `DocumentInReleaseDetail` type keeps its name.
- A new `useVariantDocuments` hook (in the variants folder) delegates to the generic engine using the variant membership filter (`_system.variant._ref == $variantId`). `VariantDetail` now renders the resolved document count and logs the hook output for debugging.

The modules intentionally stay in their current locations; a follow-up PR will relocate the shared machinery to a neutral location.

### What to review

- `packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts` — the generic engine and hook.
- `packages/sanity/src/core/releases/tool/detail/useReleaseDocuments.ts` — release-specific behavior preserved verbatim (active vs published/archived switching, caching).
- `packages/sanity/src/core/variants/tool/detail/useVariantDocuments.ts` and `VariantDetail.tsx` — the new variant hook and its wiring.
- The `DocumentInRelease` → `DocumentInBundle` rename across the releases surface, and the repointed test mocks.

### Testing

- Added a colocated `useVariantDocuments.test.ts` mirroring the engine behavior (filter, params, api version, validation `hasError`).
- Existing release tests were repointed to mock `useReleaseDocuments` and should pass unchanged in behavior.

### Notes for release

N/A – Internal refactor enabling variant document loading; the variant document table wiring is not user-facing yet (debug count/log only).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6adb2ae-83cf-4e44-bb75-2aa4b4e2917a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6adb2ae-83cf-4e44-bb75-2aa4b4e2917a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

