### PR TITLE
fix(releases): return undefined for empty values in temporarilyBuildDocumentSystem

### DIFF
--- a/packages/@sanity/types/src/documents/types.ts
+++ b/packages/@sanity/types/src/documents/types.ts
@@ -54,15 +54,15 @@ export interface DocumentSystem {
   /**
    * It will be empty for the group document (aka published document)
    */
-  bundleId: 'drafts' | (string & {}) | null
+  bundleId?: 'drafts' | (string & {})
   /**
    * A weak reference to the release document that the version belongs to.
    */
-  release: DocumentSystemRef | null
+  release?: DocumentSystemRef
   /**
    * A weak reference to the variant document that the version belongs to.
    */
-  variant: DocumentSystemRef | null
+  variant?: DocumentSystemRef
   /**
    * A weak reference to the group document (aka published document).
    */
@@ -70,7 +70,7 @@ export interface DocumentSystem {
   /**
    * Available only for version documents.
    */
-  scopeId: string | null
+  scopeId?: string
 }
 
 /**

--- a/packages/sanity/src/core/releases/hooks/__tests__/getOrCreateDocumentVersionsObservable.test.ts
+++ b/packages/sanity/src/core/releases/hooks/__tests__/getOrCreateDocumentVersionsObservable.test.ts
@@ -25,10 +25,7 @@ describe('getOrCreateDocumentVersionsObservable', () => {
           _updatedAt: '2024-01-02T00:00:00.000Z',
           _system: {
             bundleId: 'drafts',
-            release: null,
-            variant: null,
             group: {_ref: 'article-1', _weak: true},
-            scopeId: null,
           },
         }),
       ),
@@ -69,10 +66,7 @@ describe('getOrCreateDocumentVersionsObservable', () => {
             _updatedAt: '2024-01-02T00:00:00.000Z',
             _system: {
               bundleId: 'drafts',
-              release: null,
-              variant: null,
               group: {_ref: 'article-1', _weak: true},
-              scopeId: null,
             },
           },
         ],

--- a/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
@@ -69,8 +69,6 @@ async function setupMocks({
                 _updatedAt: '',
                 _system: {
                   bundleId: 'drafts',
-                  release: null,
-                  variant: null,
                   group: {_ref: getPublishedId(id), _weak: true},
                   scopeId: getPublishedId(id),
                 } satisfies DocumentSystem,
@@ -136,8 +134,6 @@ describe('useDocumentVersions', () => {
         _updatedAt: '',
         _system: {
           bundleId: 'drafts',
-          release: null,
-          variant: null,
           group: {_ref: 'document-1', _weak: true},
           scopeId: 'document-1',
         },
@@ -164,7 +160,7 @@ describe('useDocumentVersions', () => {
         _system: {
           bundleId: 'rASAP',
           release: {_ref: '_.releases.rASAP', _weak: true},
-          variant: null,
+          variant: undefined,
           group: {_ref: 'document-1', _weak: true},
           scopeId: 'rASAP',
         },
@@ -190,10 +186,10 @@ describe('useDocumentVersions', () => {
         _updatedAt: '',
         _system: {
           bundleId: 'drafts',
-          release: null,
-          variant: null,
+          release: undefined,
+          variant: undefined,
           group: {_ref: 'document-1', _weak: true},
-          scopeId: null,
+          scopeId: undefined,
         },
       },
     ])

--- a/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
@@ -116,8 +116,7 @@ const temporarilyBuildDocumentSystem = (
     )
     return {
       bundleId: versionId,
-      release: releaseDocument ? {_ref: releaseDocument._id, _weak: true} : null,
-      variant: null,
+      release: releaseDocument ? {_ref: releaseDocument._id, _weak: true} : undefined,
       group: {
         _ref: getPublishedId(id),
         _weak: true,
@@ -127,11 +126,8 @@ const temporarilyBuildDocumentSystem = (
   }
 
   return {
-    bundleId: isDraftId(id) ? 'drafts' : null,
-    release: null,
-    variant: null,
+    bundleId: isDraftId(id) ? 'drafts' : undefined,
     group: {_ref: getPublishedId(id), _weak: true},
-    scopeId: versionId || null,
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The `useDocumentVersions` hook builds a temporary `_system` field via `temporarilyBuildDocumentSystem` when a document does not yet include one. Previously, empty fields in that built system (`bundleId`, `release`, `variant`, `scopeId`) were set to `null`. This changes those empty values instead.

The `DocumentSystem` type in `@sanity/types` is updated so these empty fields are optional (`?:`) rather than nullable — they will either exist or be `undefined`.

### What to review

- `packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx` — `temporarilyBuildDocumentSystem` now returns `undefined` instead of `null` for empty values.
- `packages/@sanity/types/src/documents/types.ts` — `DocumentSystem` `bundleId`, `release`, `variant`, and `scopeId` are now optional fields instead of `| null`.
- `packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx` — updated mocks/expectations to drop `null` values.

### Testing

Updated the existing unit tests covering the temporarily-built system fallback paths. `pnpm vitest run --project=sanity` for `useDocumentVersions.test.tsx` passes, along with `pnpm check:types` and `pnpm chore:format:fix`.

### Notes for release

N/A – Internal change to the temporarily built document `_system` field; empty values are now `undefined` instead of `null`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-525299b8-3b6f-43b5-9540-2b278aa22464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-525299b8-3b6f-43b5-9540-2b278aa22464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

