### PR TITLE
feat(core): make reference fields searchable in list previews

### DIFF
--- a/packages/sanity/src/core/search/common/deriveReferenceSearchSpecs.test.ts
+++ b/packages/sanity/src/core/search/common/deriveReferenceSearchSpecs.test.ts
@@ -192,4 +192,48 @@ describe('deriveReferenceSearchSpecs', () => {
 
     expect(specs).toEqual([])
   })
+
+  it('skips chained reference paths (more than one hop)', () => {
+    const specs = specsForType(
+      [
+        defineType({
+          name: 'author',
+          type: 'document',
+          fields: [
+            defineField({name: 'name', type: 'string'}),
+            defineField({name: 'bestFriend', type: 'reference', to: [{type: 'author'}]}),
+          ],
+        }),
+        defineType({
+          name: 'book',
+          type: 'document',
+          preview: {select: {subtitle: 'author.bestFriend.name'}},
+          fields: [defineField({name: 'author', type: 'reference', to: [{type: 'author'}]})],
+        }),
+      ],
+      'book',
+    )
+
+    expect(specs).toEqual([])
+  })
+
+  it('respects maxDepth and caches results per depth', () => {
+    const book = createSchema({
+      name: 'test',
+      types: [
+        author,
+        defineType({
+          name: 'book',
+          type: 'document',
+          preview: {select: {subtitle: 'author.name'}},
+          fields: [defineField({name: 'author', type: 'reference', to: [{type: 'author'}]})],
+        }),
+      ],
+    }).get('book')!
+
+    expect(deriveReferenceSearchSpecs({schemaType: book, maxDepth: 0})).toEqual([])
+    expect(deriveReferenceSearchSpecs({schemaType: book, maxDepth: 10})).toEqual([
+      {targetType: 'author', leafPath: 'name', weight: 5},
+    ])
+  })
 })

--- a/packages/sanity/src/core/search/common/deriveReferenceSearchSpecs.test.ts
+++ b/packages/sanity/src/core/search/common/deriveReferenceSearchSpecs.test.ts
@@ -1,0 +1,195 @@
+import {defineField, defineType} from '@sanity/types'
+import {describe, expect, it} from 'vitest'
+
+import {createSchema} from '../../schema'
+import {deriveReferenceSearchSpecs} from './deriveReferenceSearchSpecs'
+
+const MAX_DEPTH = 10
+
+function specsForType(types: ReturnType<typeof defineType>[], typeName: string) {
+  const schemaType = createSchema({name: 'test', types}).get(typeName)
+  if (schemaType === undefined) {
+    throw new Error(`Type "${typeName}" was not found in the compiled test schema`)
+  }
+  return deriveReferenceSearchSpecs({schemaType, maxDepth: MAX_DEPTH})
+}
+
+const author = defineType({
+  name: 'author',
+  type: 'document',
+  fields: [
+    defineField({name: 'name', type: 'string'}),
+    defineField({name: 'publicationYear', type: 'number'}),
+  ],
+})
+
+describe('deriveReferenceSearchSpecs', () => {
+  it('derives a spec for a reference-traversing preview path', () => {
+    const specs = specsForType(
+      [
+        author,
+        defineType({
+          name: 'book',
+          type: 'document',
+          preview: {select: {title: 'title', subtitle: 'author.name'}},
+          fields: [
+            defineField({name: 'title', type: 'string'}),
+            defineField({name: 'author', type: 'reference', to: [{type: 'author'}]}),
+          ],
+        }),
+      ],
+      'book',
+    )
+
+    expect(specs).toEqual([{targetType: 'author', leafPath: 'name', weight: 5}])
+  })
+
+  it('ignores non-reference preview paths', () => {
+    const specs = specsForType(
+      [
+        defineType({
+          name: 'book',
+          type: 'document',
+          preview: {select: {title: 'title', subtitle: 'summary'}},
+          fields: [
+            defineField({name: 'title', type: 'string'}),
+            defineField({name: 'summary', type: 'string'}),
+          ],
+        }),
+      ],
+      'book',
+    )
+
+    expect(specs).toEqual([])
+  })
+
+  it('only emits specs for searchable string/pt/slug leaves', () => {
+    const specs = specsForType(
+      [
+        author,
+        defineType({
+          name: 'book',
+          type: 'document',
+          preview: {select: {subtitle: 'author.publicationYear'}},
+          fields: [defineField({name: 'author', type: 'reference', to: [{type: 'author'}]})],
+        }),
+      ],
+      'book',
+    )
+
+    expect(specs).toEqual([])
+  })
+
+  it('targets the `.current` leaf of a referenced slug', () => {
+    const specs = specsForType(
+      [
+        defineType({
+          name: 'author',
+          type: 'document',
+          fields: [defineField({name: 'handle', type: 'slug'})],
+        }),
+        defineType({
+          name: 'book',
+          type: 'document',
+          preview: {select: {subtitle: 'author.handle'}},
+          fields: [defineField({name: 'author', type: 'reference', to: [{type: 'author'}]})],
+        }),
+      ],
+      'book',
+    )
+
+    expect(specs).toEqual([{targetType: 'author', leafPath: 'handle.current', weight: 5}])
+  })
+
+  it('flags portable text leaves with `pt::text`', () => {
+    const specs = specsForType(
+      [
+        defineType({
+          name: 'author',
+          type: 'document',
+          fields: [defineField({name: 'bio', type: 'array', of: [{type: 'block'}]})],
+        }),
+        defineType({
+          name: 'book',
+          type: 'document',
+          preview: {select: {subtitle: 'author.bio'}},
+          fields: [defineField({name: 'author', type: 'reference', to: [{type: 'author'}]})],
+        }),
+      ],
+      'book',
+    )
+
+    expect(specs).toEqual([{targetType: 'author', leafPath: 'bio', weight: 5, mapWith: 'pt::text'}])
+  })
+
+  it('emits a spec per target type of a multi-target reference', () => {
+    const specs = specsForType(
+      [
+        author,
+        defineType({
+          name: 'organisation',
+          type: 'document',
+          fields: [defineField({name: 'name', type: 'string'})],
+        }),
+        defineType({
+          name: 'book',
+          type: 'document',
+          preview: {select: {subtitle: 'creator.name'}},
+          fields: [
+            defineField({
+              name: 'creator',
+              type: 'reference',
+              to: [{type: 'author'}, {type: 'organisation'}],
+            }),
+          ],
+        }),
+      ],
+      'book',
+    )
+
+    expect(specs).toEqual([
+      {targetType: 'author', leafPath: 'name', weight: 5},
+      {targetType: 'organisation', leafPath: 'name', weight: 5},
+    ])
+  })
+
+  it('uses the preview key to weight the spec (title outranks subtitle)', () => {
+    const specs = specsForType(
+      [
+        author,
+        defineType({
+          name: 'book',
+          type: 'document',
+          preview: {select: {title: 'author.name'}},
+          fields: [defineField({name: 'author', type: 'reference', to: [{type: 'author'}]})],
+        }),
+      ],
+      'book',
+    )
+
+    expect(specs).toEqual([{targetType: 'author', leafPath: 'name', weight: 10}])
+  })
+
+  it('skips array-of-reference preview paths', () => {
+    const specs = specsForType(
+      [
+        author,
+        defineType({
+          name: 'book',
+          type: 'document',
+          preview: {select: {subtitle: 'authors.0.name'}},
+          fields: [
+            defineField({
+              name: 'authors',
+              type: 'array',
+              of: [{type: 'reference', to: [{type: 'author'}]}],
+            }),
+          ],
+        }),
+      ],
+      'book',
+    )
+
+    expect(specs).toEqual([])
+  })
+})

--- a/packages/sanity/src/core/search/common/deriveReferenceSearchSpecs.ts
+++ b/packages/sanity/src/core/search/common/deriveReferenceSearchSpecs.ts
@@ -31,7 +31,7 @@ const PREVIEW_FIELD_WEIGHT_MAP: Record<string, number> = {
 // Fallback for custom selection keys (e.g. `authorName`) that aren't title/subtitle/description.
 const DEFAULT_PREVIEW_SELECT_WEIGHT = 5
 
-const CACHE = new WeakMap<SchemaType, ReferenceSearchSpec[]>()
+const CACHE = new WeakMap<SchemaType, Map<number, ReferenceSearchSpec[]>>()
 
 const getTypeChain = (type: SchemaType | undefined): SchemaType[] =>
   type ? [type, ...getTypeChain(type.type)] : []
@@ -84,8 +84,9 @@ function resolveLeaf(
     if (isPtField(type)) {
       return {leafPath: '', mapWith: 'pt::text'}
     }
-    // A slug is searchable on its `.current` string.
-    if (isSlugField(type)) {
+    // A slug is searchable on its `.current` string - but only if that field
+    // actually resolves, so a custom object named `slug` doesn't emit a dead clause.
+    if (isSlugField(type) && isStringField(findFieldType(type, 'current'))) {
       return {leafPath: 'current'}
     }
     if (isStringField(type)) {
@@ -157,7 +158,8 @@ export function deriveReferenceSearchSpecs({
     return []
   }
 
-  const cached = CACHE.get(schemaType)
+  const cachedByDepth = CACHE.get(schemaType) ?? new Map<number, ReferenceSearchSpec[]>()
+  const cached = cachedByDepth.get(maxDepth)
   if (cached) {
     return cached
   }
@@ -198,6 +200,7 @@ export function deriveReferenceSearchSpecs({
   }
 
   const specs = Array.from(byTargetAndLeaf.values())
-  CACHE.set(schemaType, specs)
+  cachedByDepth.set(maxDepth, specs)
+  CACHE.set(schemaType, cachedByDepth)
   return specs
 }

--- a/packages/sanity/src/core/search/common/deriveReferenceSearchSpecs.ts
+++ b/packages/sanity/src/core/search/common/deriveReferenceSearchSpecs.ts
@@ -1,0 +1,203 @@
+import {
+  isReferenceSchemaType,
+  type CrossDatasetType,
+  type ObjectSchemaType,
+  type SchemaType,
+} from '@sanity/types'
+
+/**
+ * @internal
+ *
+ * A searchable leaf on a *referenced* document surfaced in a list preview (e.g.
+ * `subtitle: 'author.name'`). Normal search-weight derivation stops at reference
+ * boundaries, so these leaves are otherwise unsearchable. We surface them by
+ * resolving matching referenced documents up front and boosting the referring
+ * documents via `references()` — not by compiling `author->name`, which crashes
+ * `groq2024`'s `score()` and forces a non-index-accelerated per-document join.
+ */
+export interface ReferenceSearchSpec {
+  targetType: string
+  leafPath: string
+  weight: number
+  mapWith?: 'pt::text'
+}
+
+const PREVIEW_FIELD_WEIGHT_MAP: Record<string, number> = {
+  title: 10,
+  subtitle: 5,
+  description: 1.5,
+}
+
+// Fallback for custom selection keys (e.g. `authorName`) that aren't title/subtitle/description.
+const DEFAULT_PREVIEW_SELECT_WEIGHT = 5
+
+const CACHE = new WeakMap<SchemaType, ReferenceSearchSpec[]>()
+
+const getTypeChain = (type: SchemaType | undefined): SchemaType[] =>
+  type ? [type, ...getTypeChain(type.type)] : []
+
+const isStringField = (type: SchemaType | undefined): boolean => type?.jsonType === 'string'
+
+const isPtField = (type: SchemaType | undefined): boolean =>
+  type?.jsonType === 'array' &&
+  type.of.some((arrayMemberType) =>
+    getTypeChain(arrayMemberType).some(({name}) => name === 'block'),
+  )
+
+const isSlugField = (type: SchemaType | undefined): boolean =>
+  getTypeChain(type).some(({jsonType, name}) => jsonType === 'object' && name === 'slug')
+
+function isSchemaType(input: SchemaType | CrossDatasetType | undefined): input is SchemaType {
+  return typeof input !== 'undefined' && 'name' in input
+}
+
+function findFieldType(type: SchemaType | undefined, fieldName: string): SchemaType | undefined {
+  for (const chainType of getTypeChain(type)) {
+    if (chainType.jsonType === 'object' && chainType.fields?.length) {
+      const field = chainType.fields.find(({name}) => name === fieldName)
+      if (field) {
+        return field.type
+      }
+    }
+  }
+  return undefined
+}
+
+interface ResolvedLeaf {
+  leafPath: string
+  mapWith?: 'pt::text'
+}
+
+// Resolves the leaf path within a referenced document. Bails on a further
+// reference or array so the match stays single-hop and index-accelerated.
+function resolveLeaf(
+  type: SchemaType | undefined,
+  segments: string[],
+  depth: number,
+  maxDepth: number,
+): ResolvedLeaf | undefined {
+  if (type === undefined || depth > maxDepth) {
+    return undefined
+  }
+
+  if (segments.length === 0) {
+    if (isPtField(type)) {
+      return {leafPath: '', mapWith: 'pt::text'}
+    }
+    // A slug is searchable on its `.current` string.
+    if (isSlugField(type)) {
+      return {leafPath: 'current'}
+    }
+    if (isStringField(type)) {
+      return {leafPath: ''}
+    }
+    return undefined
+  }
+
+  const [head, ...rest] = segments
+  const fieldType = findFieldType(type, head)
+  if (fieldType === undefined || isReferenceSchemaType(fieldType)) {
+    return undefined
+  }
+
+  const resolved = resolveLeaf(fieldType, rest, depth + 1, maxDepth)
+  if (resolved === undefined) {
+    return undefined
+  }
+
+  return {
+    leafPath: resolved.leafPath === '' ? head : `${head}.${resolved.leafPath}`,
+    mapWith: resolved.mapWith,
+  }
+}
+
+interface ReferenceBoundary {
+  targetTypes: ObjectSchemaType[]
+  leafSegments: string[]
+}
+
+function walkToReference(
+  type: SchemaType | undefined,
+  segments: string[],
+  depth: number,
+  maxDepth: number,
+): ReferenceBoundary | undefined {
+  if (type === undefined || depth > maxDepth || segments.length === 0) {
+    return undefined
+  }
+
+  const [head, ...rest] = segments
+  const fieldType = findFieldType(type, head)
+  if (fieldType === undefined) {
+    return undefined
+  }
+
+  if (isReferenceSchemaType(fieldType) && 'to' in fieldType) {
+    return {targetTypes: fieldType.to, leafSegments: rest}
+  }
+
+  return walkToReference(fieldType, rest, depth + 1, maxDepth)
+}
+
+/**
+ * @internal
+ *
+ * Derives specs from a type's preview `select` paths that traverse a reference.
+ * Only single-hop paths to a searchable leaf are supported; array paths and
+ * chained references are skipped.
+ */
+export function deriveReferenceSearchSpecs({
+  schemaType,
+  maxDepth,
+}: {
+  schemaType: SchemaType | CrossDatasetType
+  maxDepth: number
+}): ReferenceSearchSpec[] {
+  if (!isSchemaType(schemaType)) {
+    return []
+  }
+
+  const cached = CACHE.get(schemaType)
+  if (cached) {
+    return cached
+  }
+
+  const select = schemaType.preview?.select
+  const byTargetAndLeaf = new Map<string, ReferenceSearchSpec>()
+
+  for (const [selectionKey, rawPath] of Object.entries(select ?? {})) {
+    // Skip array paths (e.g. `authors.0.name`): arrays of references are unsupported here.
+    if (rawPath.replace(/\.\d+/g, '[]').includes('[]')) {
+      continue
+    }
+
+    const boundary = walkToReference(schemaType, rawPath.split('.'), 0, maxDepth)
+    if (boundary === undefined || boundary.leafSegments.length === 0) {
+      continue
+    }
+
+    const weight = PREVIEW_FIELD_WEIGHT_MAP[selectionKey] ?? DEFAULT_PREVIEW_SELECT_WEIGHT
+
+    for (const targetType of boundary.targetTypes) {
+      const leaf = resolveLeaf(targetType, boundary.leafSegments, 0, maxDepth)
+      if (leaf === undefined || leaf.leafPath === '') {
+        continue
+      }
+
+      const dedupeKey = `${targetType.name}:${leaf.leafPath}`
+      const existing = byTargetAndLeaf.get(dedupeKey)
+      if (existing === undefined || existing.weight < weight) {
+        byTargetAndLeaf.set(dedupeKey, {
+          targetType: targetType.name,
+          leafPath: leaf.leafPath,
+          weight,
+          ...(leaf.mapWith ? {mapWith: leaf.mapWith} : {}),
+        })
+      }
+    }
+  }
+
+  const specs = Array.from(byTargetAndLeaf.values())
+  CACHE.set(schemaType, specs)
+  return specs
+}

--- a/packages/sanity/src/core/search/common/index.ts
+++ b/packages/sanity/src/core/search/common/index.ts
@@ -1,5 +1,6 @@
 export * from './compileFieldPath'
 export * from './compileSortExpression'
+export * from './deriveReferenceSearchSpecs'
 export * from './deriveSearchWeightsFromType'
 export * from './deriveSearchWeightsFromType2024'
 export * from './getSearchableTypes'

--- a/packages/sanity/src/core/search/groq2024/createGroq2024Search.test.ts
+++ b/packages/sanity/src/core/search/groq2024/createGroq2024Search.test.ts
@@ -1,0 +1,98 @@
+import {type SanityClient} from '@sanity/client'
+import {type SchemaType} from '@sanity/types'
+import {lastValueFrom, of, throwError} from 'rxjs'
+import {describe, expect, it, type Mock, vi} from 'vitest'
+
+import {createSchema} from '../../schema'
+import {getSearchableTypes} from '../common/getSearchableTypes'
+import {createGroq2024Search} from './createGroq2024Search'
+
+const schema = createSchema({
+  name: 'test',
+  types: [
+    {
+      name: 'author',
+      type: 'document',
+      fields: [{name: 'name', type: 'string'}],
+    },
+    {
+      name: 'book',
+      type: 'document',
+      preview: {select: {title: 'title', subtitle: 'author.name'}},
+      fields: [
+        {name: 'title', type: 'string'},
+        {name: 'author', type: 'reference', to: [{type: 'author'}]},
+      ],
+    },
+    {
+      name: 'note',
+      type: 'document',
+      preview: {select: {title: 'title'}},
+      fields: [{name: 'title', type: 'string'}],
+    },
+  ],
+})
+
+function typeByName(name: string): SchemaType {
+  const type = getSearchableTypes(schema).find((candidate) => candidate.name === name)
+  if (!type) {
+    throw new Error(`Type "${name}" not searchable in test schema`)
+  }
+  return type
+}
+
+function createMockClient(fetch: Mock): SanityClient {
+  return {observable: {fetch}} as unknown as SanityClient
+}
+
+describe('createGroq2024Search two-phase orchestration', () => {
+  it('resolves reference ids then runs the main search with normalised published ids', async () => {
+    const fetch = vi
+      .fn()
+      .mockReturnValueOnce(of(['drafts.author-1', 'author-1', 'versions.rABC.author-2']))
+      .mockReturnValueOnce(of([{_id: 'book-1', _type: 'book'}]))
+    const search = createGroq2024Search([typeByName('book')], createMockClient(fetch), {})
+
+    const result = await lastValueFrom(search({query: 'jane', types: [typeByName('book')]}))
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    const [resolveQuery] = fetch.mock.calls[0]
+    expect(resolveQuery).toContain('[0...1000]._id')
+    const [, mainParams] = fetch.mock.calls[1]
+    expect(mainParams.__refIds).toEqual(['author-1', 'author-2'])
+    expect(result.hits).toEqual([{hit: {_id: 'book-1', _type: 'book'}}])
+  })
+
+  it('skips phase one when no searched type has a reference-preview path', async () => {
+    const fetch = vi.fn().mockReturnValue(of([]))
+    const search = createGroq2024Search([typeByName('note')], createMockClient(fetch), {})
+
+    await lastValueFrom(search({query: 'jane', types: [typeByName('note')]}))
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch.mock.calls[0][1].__refIds).toBeUndefined()
+  })
+
+  it('skips phase one when there is no search term', async () => {
+    const fetch = vi.fn().mockReturnValue(of([]))
+    const search = createGroq2024Search([typeByName('book')], createMockClient(fetch), {})
+
+    await lastValueFrom(search({query: '', types: [typeByName('book')]}))
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to a plain search when phase one fails', async () => {
+    const fetch = vi
+      .fn()
+      .mockReturnValueOnce(throwError(() => new Error('reference resolution failed')))
+      .mockReturnValueOnce(of([{_id: 'book-1', _type: 'book'}]))
+    const search = createGroq2024Search([typeByName('book')], createMockClient(fetch), {})
+
+    const result = await lastValueFrom(search({query: 'jane', types: [typeByName('book')]}))
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(fetch.mock.calls[1][1].__refIds).toBeUndefined()
+    expect(result.hits).toEqual([{hit: {_id: 'book-1', _type: 'book'}}])
+  })
+})

--- a/packages/sanity/src/core/search/groq2024/createGroq2024Search.test.ts
+++ b/packages/sanity/src/core/search/groq2024/createGroq2024Search.test.ts
@@ -82,6 +82,19 @@ describe('createGroq2024Search two-phase orchestration', () => {
     expect(fetch).toHaveBeenCalledTimes(1)
   })
 
+  it('excludes the overfetched element when no limit is passed', async () => {
+    const overfetched = Array.from({length: 1001}, (_unused, index) => ({
+      _id: `note-${index}`,
+      _type: 'note',
+    }))
+    const fetch = vi.fn().mockReturnValue(of(overfetched))
+    const search = createGroq2024Search([typeByName('note')], createMockClient(fetch), {})
+
+    const result = await lastValueFrom(search({query: 'jane', types: [typeByName('note')]}))
+
+    expect(result.hits).toHaveLength(1000)
+  })
+
   it('falls back to a plain search when phase one fails', async () => {
     const fetch = vi
       .fn()

--- a/packages/sanity/src/core/search/groq2024/createGroq2024Search.ts
+++ b/packages/sanity/src/core/search/groq2024/createGroq2024Search.ts
@@ -1,7 +1,7 @@
 import {getPublishedId} from '@sanity/client/csm'
 import {DEFAULT_MAX_FIELD_DEPTH} from '@sanity/schema/_internal'
 import {type CrossDatasetType, type SanityDocumentLike, type SchemaType} from '@sanity/types'
-import {map, mergeMap, type Observable} from 'rxjs'
+import {catchError, map, mergeMap, type Observable, of} from 'rxjs'
 
 import {deriveReferenceSearchSpecs} from '../common/deriveReferenceSearchSpecs'
 import {
@@ -104,6 +104,9 @@ export const createGroq2024Search: SearchStrategyFactory<Groq2024SearchResults> 
         perspective: mergedOptions.perspective,
       })
       .pipe(
+        // Reference resolution is an enhancement: if phase one fails, fall back
+        // to a plain search rather than failing the base term-match too.
+        catchError(() => of<string[]>([])),
         mergeMap((resolvedIds) => {
           // References always point at the published id, so normalise resolved
           // (possibly draft/version) ids before matching with `references()`.

--- a/packages/sanity/src/core/search/groq2024/createGroq2024Search.ts
+++ b/packages/sanity/src/core/search/groq2024/createGroq2024Search.ts
@@ -1,11 +1,15 @@
+import {getPublishedId} from '@sanity/client/csm'
+import {DEFAULT_MAX_FIELD_DEPTH} from '@sanity/schema/_internal'
 import {type CrossDatasetType, type SanityDocumentLike, type SchemaType} from '@sanity/types'
-import {map} from 'rxjs'
+import {map, mergeMap, type Observable} from 'rxjs'
 
+import {deriveReferenceSearchSpecs} from '../common/deriveReferenceSearchSpecs'
 import {
   type Groq2024SearchResults,
   type SearchStrategyFactory,
   type SearchTerms,
 } from '../common/types'
+import {createReferenceResolveQuery} from './createReferenceResolveQuery'
 import {createSearchQuery} from './createSearchQuery'
 import {getNextCursor} from './getNextCursor'
 
@@ -41,31 +45,77 @@ export const createGroq2024Search: SearchStrategyFactory<Groq2024SearchResults> 
       ...searchOptions,
     }
 
-    const {query, params, options, sortOrder, compiledSortEntries} = createSearchQuery(
-      searchTerms,
-      searchParams,
-      mergedOptions,
-    )
+    const rawQuery = typeof searchParams === 'string' ? searchParams : searchParams.query
 
-    return client.observable.fetch<SanityDocumentLike[]>(query, params, options).pipe(
-      map((hits) => {
-        const hasNextPage =
-          typeof searchOptions.limit !== 'undefined' && hits.length > searchOptions.limit
-
-        // Search overfetches by 1 to determine whether there is another page to fetch. Therefore,
-        // the penultimate result must be used to determine the start of the next page.
-        const lastResult = hasNextPage ? hits.at(-2) : hits.at(-1)
-
-        return {
-          type: 'groq2024',
-          // Search overfetches by 1 to determine whether there is another page to fetch. Therefore,
-          // exclude the final result if it's beyond the limit.
-          hits: hits.map((hit) => ({hit})).slice(0, searchOptions.limit),
-          nextCursor: hasNextPage
-            ? getNextCursor({lastResult, sortOrder, compiledSortEntries})
-            : undefined,
-        }
+    // Phase-one reference resolution is skipped when there is no term or no
+    // reference-traversing preview path, leaving the query identical to a plain search.
+    const referenceSpecs = searchTerms.types.flatMap((schemaType) =>
+      deriveReferenceSearchSpecs({
+        schemaType,
+        maxDepth: mergedOptions.maxDepth || DEFAULT_MAX_FIELD_DEPTH,
       }),
     )
+    const maxReferenceWeight = referenceSpecs.reduce(
+      (highest, spec) => Math.max(highest, spec.weight),
+      0,
+    )
+
+    const runMainSearch = (referenceIds?: string[]): Observable<Groq2024SearchResults> => {
+      const {query, params, options, sortOrder, compiledSortEntries} = createSearchQuery(
+        searchTerms,
+        searchParams,
+        mergedOptions,
+        {referenceIds, referenceWeight: maxReferenceWeight},
+      )
+
+      return client.observable.fetch<SanityDocumentLike[]>(query, params, options).pipe(
+        map((hits) => {
+          const hasNextPage =
+            typeof searchOptions.limit !== 'undefined' && hits.length > searchOptions.limit
+
+          // Search overfetches by 1 to determine whether there is another page to fetch. Therefore,
+          // the penultimate result must be used to determine the start of the next page.
+          const lastResult = hasNextPage ? hits.at(-2) : hits.at(-1)
+
+          return {
+            type: 'groq2024' as const,
+            // Search overfetches by 1 to determine whether there is another page to fetch. Therefore,
+            // exclude the final result if it's beyond the limit.
+            hits: hits.map((hit) => ({hit})).slice(0, searchOptions.limit),
+            nextCursor: hasNextPage
+              ? getNextCursor({lastResult, sortOrder, compiledSortEntries})
+              : undefined,
+          }
+        }),
+      )
+    }
+
+    const resolveQuery = rawQuery
+      ? createReferenceResolveQuery(referenceSpecs, rawQuery)
+      : undefined
+
+    if (resolveQuery === undefined) {
+      return runMainSearch()
+    }
+
+    return client.observable
+      .fetch<string[]>(resolveQuery.query, resolveQuery.params, {
+        tag: mergedOptions.tag,
+        perspective: mergedOptions.perspective,
+      })
+      .pipe(
+        mergeMap((resolvedIds) => {
+          // References always point at the published id, so normalise resolved
+          // (possibly draft/version) ids before matching with `references()`.
+          const publishedIds = Array.from(
+            new Set(
+              (resolvedIds ?? [])
+                .filter((resolvedId): resolvedId is string => typeof resolvedId === 'string')
+                .map((resolvedId) => getPublishedId(resolvedId)),
+            ),
+          )
+          return runMainSearch(publishedIds.length > 0 ? publishedIds : undefined)
+        }),
+      )
   }
 }

--- a/packages/sanity/src/core/search/groq2024/createGroq2024Search.ts
+++ b/packages/sanity/src/core/search/groq2024/createGroq2024Search.ts
@@ -79,9 +79,10 @@ export const createGroq2024Search: SearchStrategyFactory<Groq2024SearchResults> 
 
           return {
             type: 'groq2024' as const,
-            // Search overfetches by 1 to determine whether there is another page to fetch. Therefore,
-            // exclude the final result if it's beyond the limit.
-            hits: hits.map((hit) => ({hit})).slice(0, searchOptions.limit),
+            // Search overfetches by 1 to detect a next page. Slice to the effective
+            // limit - falling back to `__limit - 1` when no limit was passed - so the
+            // overfetched element never leaks.
+            hits: hits.map((hit) => ({hit})).slice(0, searchOptions.limit ?? params.__limit - 1),
             nextCursor: hasNextPage
               ? getNextCursor({lastResult, sortOrder, compiledSortEntries})
               : undefined,

--- a/packages/sanity/src/core/search/groq2024/createReferenceResolveQuery.test.ts
+++ b/packages/sanity/src/core/search/groq2024/createReferenceResolveQuery.test.ts
@@ -1,0 +1,50 @@
+import {describe, expect, it} from 'vitest'
+
+import {type ReferenceSearchSpec} from '../common/deriveReferenceSearchSpecs'
+import {createReferenceResolveQuery} from './createReferenceResolveQuery'
+
+describe('createReferenceResolveQuery', () => {
+  it('returns undefined when there are no specs', () => {
+    expect(createReferenceResolveQuery([], 'jane')).toBeUndefined()
+  })
+
+  it('builds an index-accelerated id-resolving query without dereferences', () => {
+    const specs: ReferenceSearchSpec[] = [{targetType: 'author', leafPath: 'name', weight: 5}]
+
+    const resolve = createReferenceResolveQuery(specs, 'jane')
+
+    expect(resolve?.query).toBe(
+      '*[(_type == "author" && name match text::query($__query))][0...1000]._id',
+    )
+    // The slice bound must be a literal: GROQ rejects a parameterised slice.
+    expect(resolve?.query).not.toContain('$__refResolveLimit')
+    // The slice must precede `._id`, else it binds to the string and yields nulls.
+    expect(resolve?.query).not.toContain('._id[0...')
+    expect(resolve?.query).not.toContain('->')
+    expect(resolve?.params.__query).toBe('jane*')
+  })
+
+  it('ORs a clause per target/leaf and dedupes identical clauses', () => {
+    const specs: ReferenceSearchSpec[] = [
+      {targetType: 'author', leafPath: 'name', weight: 5},
+      {targetType: 'organisation', leafPath: 'name', weight: 5},
+      {targetType: 'author', leafPath: 'name', weight: 10},
+    ]
+
+    const resolve = createReferenceResolveQuery(specs, 'acme')
+
+    expect(resolve?.query).toBe(
+      '*[(_type == "author" && name match text::query($__query)) || (_type == "organisation" && name match text::query($__query))][0...1000]._id',
+    )
+  })
+
+  it('wraps portable-text leaves in pt::text', () => {
+    const specs: ReferenceSearchSpec[] = [
+      {targetType: 'author', leafPath: 'bio', weight: 5, mapWith: 'pt::text'},
+    ]
+
+    const resolve = createReferenceResolveQuery(specs, 'jane')
+
+    expect(resolve?.query).toContain('pt::text(bio) match text::query($__query)')
+  })
+})

--- a/packages/sanity/src/core/search/groq2024/createReferenceResolveQuery.test.ts
+++ b/packages/sanity/src/core/search/groq2024/createReferenceResolveQuery.test.ts
@@ -1,3 +1,4 @@
+import {parse} from 'groq-js'
 import {describe, expect, it} from 'vitest'
 
 import {type ReferenceSearchSpec} from '../common/deriveReferenceSearchSpecs'
@@ -46,5 +47,19 @@ describe('createReferenceResolveQuery', () => {
     const resolve = createReferenceResolveQuery(specs, 'jane')
 
     expect(resolve?.query).toContain('pt::text(bio) match text::query($__query)')
+  })
+
+  // String assertions can't catch invalid GROQ; parse the generated query to guard
+  // against syntax regressions (e.g. the slice-binding bug that returned nulls).
+  it('produces syntactically valid GROQ', () => {
+    const specs: ReferenceSearchSpec[] = [
+      {targetType: 'author', leafPath: 'name', weight: 5},
+      {targetType: 'author', leafPath: 'bio', weight: 5, mapWith: 'pt::text'},
+      {targetType: 'organisation', leafPath: 'slug.current', weight: 10},
+    ]
+
+    const resolve = createReferenceResolveQuery(specs, 'jane')
+
+    expect(() => parse(resolve!.query)).not.toThrow()
   })
 })

--- a/packages/sanity/src/core/search/groq2024/createReferenceResolveQuery.ts
+++ b/packages/sanity/src/core/search/groq2024/createReferenceResolveQuery.ts
@@ -1,0 +1,49 @@
+import {type ReferenceSearchSpec} from '../common/deriveReferenceSearchSpecs'
+import {prefixLast} from '../common/token'
+
+// Bounds the resolved-id set for very common terms. Inlined as a literal because
+// GROQ rejects a parameterised slice bound ("slicing must use constant numbers").
+const REFERENCE_RESOLVE_LIMIT = 1000
+
+/**
+ * @internal
+ */
+export interface ReferenceResolveQuery {
+  query: string
+  params: {__query: string}
+}
+
+/**
+ * @internal
+ *
+ * Builds the phase-one query resolving ids of documents whose preview-referenced
+ * leaves match the term. Each clause is an index-accelerated `_type == … && leaf
+ * match …`, so no per-document join occurs. Returns `undefined` when there are no
+ * specs to resolve.
+ */
+export function createReferenceResolveQuery(
+  specs: ReferenceSearchSpec[],
+  rawQuery: string,
+): ReferenceResolveQuery | undefined {
+  if (specs.length === 0) {
+    return undefined
+  }
+
+  const clauses = Array.from(
+    new Set(
+      specs.map((spec) => {
+        const matchTarget = spec.mapWith ? `${spec.mapWith}(${spec.leafPath})` : spec.leafPath
+        return `(_type == "${spec.targetType}" && ${matchTarget} match text::query($__query))`
+      }),
+    ),
+  )
+
+  return {
+    // Slice before projecting `._id`: `..._id[0...n]` binds the slice to the
+    // `_id` string and yields `null` per element; `...[0...n]._id` is correct.
+    query: `*[${clauses.join(' || ')}][0...${REFERENCE_RESOLVE_LIMIT}]._id`,
+    params: {
+      __query: prefixLast(rawQuery),
+    },
+  }
+}

--- a/packages/sanity/src/core/search/groq2024/createReferenceResolveQuery.ts
+++ b/packages/sanity/src/core/search/groq2024/createReferenceResolveQuery.ts
@@ -1,8 +1,10 @@
 import {type ReferenceSearchSpec} from '../common/deriveReferenceSearchSpecs'
 import {prefixLast} from '../common/token'
 
-// Bounds the resolved-id set for very common terms. Inlined as a literal because
-// GROQ rejects a parameterised slice bound ("slicing must use constant numbers").
+// Bounds the resolved-id set for very common terms. Reference matching is
+// best-effort: beyond this cap some referring documents silently won't surface.
+// Inlined as a literal because GROQ rejects a parameterised slice bound
+// ("slicing must use constant numbers").
 const REFERENCE_RESOLVE_LIMIT = 1000
 
 /**

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
@@ -650,4 +650,57 @@ describe('createSearchQuery', () => {
       expect(query).toContain('cover[].cards[].title match text::query($__query), 5)')
     })
   })
+
+  // https://github.com/sanity-io/sanity/issues/4775
+  describe('reference search (phase two)', () => {
+    const getType = () => Schema.compile({types: schemaTypes}).get('basic-schema-test')
+
+    it('leaves the query untouched when no reference ids are supplied', () => {
+      const withoutIds = createSearchQuery({query: 'test', types: [getType()]}, '')
+      const withEmptyIds = createSearchQuery(
+        {query: 'test', types: [getType()]},
+        '',
+        {},
+        {
+          referenceIds: [],
+        },
+      )
+
+      expect(withEmptyIds.query).toBe(withoutIds.query)
+      expect(withEmptyIds.params).not.toHaveProperty('__refIds')
+    })
+
+    it('boosts referring documents via references() without any dereference', () => {
+      const {query, params} = createSearchQuery(
+        {query: 'test', types: [getType()]},
+        '',
+        {},
+        {
+          referenceIds: ['author-1', 'author-2'],
+          referenceWeight: 5,
+        },
+      )
+
+      // The reference match is index-accelerated and accepted by score().
+      expect(query).toContain('boost(references($__refIds), 5)')
+      // The regression that broke production: a dereference must never reach score().
+      expect(query).not.toContain('->')
+      expect(params.__refIds).toEqual(['author-1', 'author-2'])
+    })
+
+    it('ORs references() into the filter when the search is unscored', () => {
+      const {query} = createSearchQuery(
+        {query: 'test', types: [getType()]},
+        '',
+        {sort: [{field: 'title', direction: 'asc'}]},
+        {referenceIds: ['author-1']},
+      )
+
+      expect(query).toContain(
+        '([@, _id] match text::query($__query) || references($__rawQuery)) || references($__refIds)',
+      )
+      expect(query).not.toContain('score(')
+      expect(query).not.toContain('->')
+    })
+  })
 })

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
@@ -51,6 +51,17 @@ function isSchemaType(
 
 /**
  * @internal
+ *
+ * Published ids resolved in phase one of the reference search, surfaced via
+ * `references()` rather than a `->` dereference (which `score()` rejects).
+ */
+export interface ReferenceSearchOptions {
+  referenceIds?: string[]
+  referenceWeight?: number
+}
+
+/**
+ * @internal
  */
 export function createSearchQuery(
   searchTerms: SearchTerms<SchemaType | CrossDatasetType | GlobalDocumentReferenceType>,
@@ -67,7 +78,9 @@ export function createSearchQuery(
     comments,
     filter,
   }: SearchOptions & SearchFactoryOptions = {},
+  {referenceIds, referenceWeight = 5}: ReferenceSearchOptions = {},
 ): SearchQuery {
+  const hasReferenceIds = Array.isArray(referenceIds) && referenceIds.length > 0
   const specs = searchTerms.types
     .map((schemaType) =>
       deriveSearchWeightsFromType2024({
@@ -89,6 +102,9 @@ export function createSearchQuery(
 
   const baseMatch = '([@, _id] match text::query($__query) || references($__rawQuery))'
 
+  // `references()` is index-accelerated and accepted by `score()`, unlike `->`.
+  const referenceBoost = hasReferenceIds ? [`boost(references($__refIds), ${referenceWeight})`] : []
+
   // Note: Computing this is unnecessary when `!isScored`.
   const score = Object.entries(groupedSpecs)
     .flatMap(([, entries]) => {
@@ -97,6 +113,7 @@ export function createSearchQuery(
       }
       return `boost(_type in ${JSON.stringify(entries.map((entry) => entry.typeName))} && ${entries[0].path} match text::query($__query), ${entries[0].weight})`
     })
+    .concat(referenceBoost)
     .concat(baseMatch)
 
   const inputSortOrder = sort ?? [{field: '_score', direction: 'desc'}]
@@ -114,10 +131,14 @@ export function createSearchQuery(
     projectionIndex: compiledSortEntries[index].projectionIndex,
   }))
 
+  // Unscored has no `[_score > 0]` gate, so the reference match must live in the
+  // filter for documents found only through a referenced leaf to surface.
+  const unscoredMatch = hasReferenceIds ? `(${baseMatch} || references($__refIds))` : baseMatch
+
   const filters: string[] = [
     '_type in $__types',
     // If the search request doesn't use scoring, directly filter documents.
-    isScored ? [] : baseMatch,
+    isScored ? [] : unscoredMatch,
     filter ? `(${filter})` : [],
     searchTerms.filter ? `(${searchTerms.filter})` : [],
     cursor ?? [],
@@ -146,6 +167,7 @@ export function createSearchQuery(
     __limit: (limit ?? DEFAULT_LIMIT) + 1,
     __query: prefixLast(rawQuery),
     __rawQuery: rawQuery,
+    ...(hasReferenceIds ? {__refIds: referenceIds} : {}),
     ...params,
   }
 


### PR DESCRIPTION
### Description

Fields shown in a list preview through a reference - for example `subtitle: 'author.name'` - were not searchable, while regular fields were. A previous fix (#12925) compiled these paths into dereferenced GROQ (`author->name`) and was reverted: under the now-default `groq2024` strategy that crashed all search with "score() function received unexpected expression", and the equivalent filter form forced a non-index-accelerated per-document join. Fixes #4775 (SAPP-3879).

This PR makes reference-preview fields searchable without any query-time dereference, using a two-phase approach: phase one resolves the ids of referenced documents whose preview leaf matches the term via an index-accelerated `_type == … && leaf match …` query; phase two surfaces the referring documents by boosting `references($ids)` inside `score()`. Both `references()` and the resolution query are index-accelerated, so the per-document join that caused the revert does not recur. When a searched type has no reference-traversing preview path, the query is byte-identical to before and phase one is skipped.

### What to review

- `deriveReferenceSearchSpecs.ts` - walks `preview.select`, follows a single reference hop, and derives `{targetType, leafPath, weight}` for string/PT/slug leaves; array paths and chained references are intentionally skipped. The spec cache is keyed per `maxDepth`.
- `createReferenceResolveQuery.ts` - the phase-one query. Note the slice is `[0...1000]._id`, not `._id[0...1000]` (the latter binds the slice to the `_id` string and returns nulls), and the bound is a literal because GROQ rejects a parameterised slice. Matching beyond 1000 ids is best-effort.
- `createSearchQuery.ts` - injects `boost(references($__refIds), weight)` into `score()` and ORs `references($__refIds)` into the unscored filter path; output is unchanged when no reference ids are passed.
- `createGroq2024Search.ts` - orchestrates phase one then phase two, normalising resolved ids through `getPublishedId` since references always point at the published id. If phase one fails, it falls back to a plain search rather than failing the base term-match.

<img width="1280" height="872" alt="before-after" src="https://github.com/user-attachments/assets/8206f1c2-497b-426c-b7a1-67d47f58b5fc" />

### Testing

Unit tests cover spec derivation (including chained-reference, slug, PT, multi-target, and `maxDepth`-boundary cases), the phase-one query shape, the score/filter injection, and the two-phase orchestration (sequence, id normalisation, skip-when-no-specs, and the phase-one-failure fallback). Tests assert no `->` ever reaches `score()` or a filter, and parse the phase-one query through `groq-js` to catch syntax regressions. Verified end-to-end against a live dataset: searching an author's name surfaces books that reference that author (titles not containing the term), both phase queries return 200, and the old `->` form was confirmed to still produce the original crash. Measured latency shows `references()` with a large id array is not a performance cliff; the added cost is one index-accelerated round-trip on searches over reference-preview types.

### Notes for release

List preview and global search now match on reference fields used in a document's preview (for example a `subtitle` of `author.name`), not just direct fields.
