### PR TITLE
fix(types): preserve defined preview in schema helpers

### DIFF
--- a/packages/@sanity/types/src/schema/define.ts
+++ b/packages/@sanity/types/src/schema/define.ts
@@ -3,7 +3,10 @@ import {
   type DefineSchemaBase,
   type DefineSchemaOptions,
   type MaybeAllowUnknownProps,
+  type MaybePreview,
+  type MaybePreviewProperty,
   type NarrowPreview,
+  type PreserveDefinedPreview,
   type StrictDefinition,
   type WidenInitialValue,
   type WidenValidation,
@@ -177,17 +180,19 @@ export function defineType<
   TPrepareValue extends Record<keyof TSelect, any> | undefined,
   TAlias extends IntrinsicTypeName | undefined,
   TStrict extends StrictDefinition,
+  TPreview extends MaybePreview<TSelect, TPrepareValue> | undefined,
 >(
   schemaDefinition: {
     type: TType
     name: TName
   } & DefineSchemaBase<TType, TAlias> &
     NarrowPreview<TType, TAlias, TSelect, TPrepareValue> &
+    MaybePreviewProperty<TType, TAlias, TPreview> &
     MaybeAllowUnknownProps<TStrict>,
 
   defineOptions?: DefineSchemaOptions<TStrict, TAlias>,
-): typeof schemaDefinition {
-  return schemaDefinition
+): typeof schemaDefinition & PreserveDefinedPreview<TPreview> {
+  return schemaDefinition as typeof schemaDefinition & PreserveDefinedPreview<TPreview>
 }
 
 /**
@@ -217,19 +222,27 @@ export function defineField<
   TPrepareValue extends Record<keyof TSelect, any> | undefined,
   TAlias extends IntrinsicTypeName | undefined,
   TStrict extends StrictDefinition,
+  TPreview extends MaybePreview<TSelect, TPrepareValue> | undefined,
 >(
   schemaField: {
     type: TType
     name: TName
   } & DefineSchemaBase<TType, TAlias> &
     NarrowPreview<TType, TAlias, TSelect, TPrepareValue> &
+    MaybePreviewProperty<TType, TAlias, TPreview> &
     MaybeAllowUnknownProps<TStrict> &
     FieldDefinitionBase,
 
   defineOptions?: DefineSchemaOptions<TStrict, TAlias>,
-): typeof schemaField & WidenValidation & WidenInitialValue {
+): typeof schemaField &
+  PreserveDefinedPreview<TPreview> &
+  WidenValidation &
+  WidenInitialValue {
   // TODO: re-evaluate the need for this cast
-  return schemaField as typeof schemaField & WidenValidation & WidenInitialValue
+  return schemaField as typeof schemaField &
+    PreserveDefinedPreview<TPreview> &
+    WidenValidation &
+    WidenInitialValue
 }
 
 /**
@@ -259,6 +272,7 @@ export function defineArrayMember<
   TPrepareValue extends Record<keyof TSelect, any> | undefined,
   TAlias extends IntrinsicTypeName | undefined,
   TStrict extends StrictDefinition,
+  TPreview extends MaybePreview<TSelect, TPrepareValue> | undefined,
 >(
   arrayOfSchema: {
     type: TType
@@ -271,12 +285,19 @@ export function defineArrayMember<
     name?: TName
   } & DefineArrayMemberBase<TType, TAlias> &
     NarrowPreview<TType, TAlias, TSelect, TPrepareValue> &
+    MaybePreviewProperty<TType, TAlias, TPreview> &
     MaybeAllowUnknownProps<TStrict>,
 
   defineOptions?: DefineSchemaOptions<TStrict, TAlias>,
-): typeof arrayOfSchema & WidenValidation & WidenInitialValue {
+): typeof arrayOfSchema &
+  PreserveDefinedPreview<TPreview> &
+  WidenValidation &
+  WidenInitialValue {
   // TODO: re-evaluate the need for this cast
-  return arrayOfSchema as typeof arrayOfSchema & WidenValidation & WidenInitialValue
+  return arrayOfSchema as typeof arrayOfSchema &
+    PreserveDefinedPreview<TPreview> &
+    WidenValidation &
+    WidenInitialValue
 }
 
 /**

--- a/packages/@sanity/types/src/schema/defineTypes.ts
+++ b/packages/@sanity/types/src/schema/defineTypes.ts
@@ -96,6 +96,20 @@ export type NarrowPreview<
     : unknown
 
 /** @beta */
+export type MaybePreviewProperty<
+  TType extends string,
+  TAlias extends IntrinsicTypeName | undefined,
+  TPreview,
+> = DefineSchemaType<TType, TAlias> extends {preview?: object}
+  ? {preview?: TPreview}
+  : unknown
+
+/** @beta */
+export type PreserveDefinedPreview<TPreview> = TPreview extends undefined
+  ? unknown
+  : {preview: TPreview}
+
+/** @beta */
 // Must type-widen some fields on the way out of the define functions to be compatible with FieldDefinition and ArrayDefinition
 export interface WidenValidation {
   validation?: SchemaValidationValue

--- a/packages/@sanity/types/test/document.test.ts
+++ b/packages/@sanity/types/test/document.test.ts
@@ -85,7 +85,7 @@ describe('document types', () => {
         fields: [{type: 'string', name: 'string'}],
       })
 
-      defineType({
+      const documentWithPreview = defineType({
         type: 'document',
         name: 'custom-document',
         preview: {
@@ -99,6 +99,8 @@ describe('document types', () => {
         },
         fields: [{type: 'string', name: 'string'}],
       })
+
+      documentWithPreview.preview.prepare({title: 'Title', subtitle: 'Subtitle'})
 
       defineType({
         type: 'document',
@@ -131,7 +133,7 @@ describe('document types', () => {
         fields: [{type: 'string', name: 'string'}],
       })
 
-      defineField({
+      const fieldWithPreview = defineField({
         type: 'object',
         name: 'custom-object-field',
         preview: {
@@ -146,6 +148,25 @@ describe('document types', () => {
         },
         fields: [{type: 'string', name: 'string'}],
       })
+
+      fieldWithPreview.preview.prepare({title: 'Title'})
+
+      const arrayMemberWithPreview = defineArrayMember({
+        type: 'object',
+        name: 'custom-array-object',
+        preview: {
+          select: {
+            title: 'a',
+            subtitle: 'b',
+          },
+          prepare: ({title, subtitle}) => {
+            return {title, subtitle}
+          },
+        },
+        fields: [{type: 'string', name: 'string'}],
+      })
+
+      arrayMemberWithPreview.preview.prepare({title: 'Title', subtitle: 'Subtitle'})
 
       defineArrayMember({
         type: 'object',

--- a/packages/@sanity/types/test/document.test.ts
+++ b/packages/@sanity/types/test/document.test.ts
@@ -102,6 +102,15 @@ describe('document types', () => {
 
       documentWithPreview.preview.prepare({title: 'Title', subtitle: 'Subtitle'})
 
+      const documentWithoutPreview = defineType({
+        type: 'document',
+        name: 'custom-document',
+        fields: [{type: 'string', name: 'string'}],
+      })
+
+      //@ts-expect-error preview is not known to be required when it was not defined
+      const previewIsRequired: {preview: unknown} = documentWithoutPreview
+
       defineType({
         type: 'document',
         name: 'custom-document',


### PR DESCRIPTION
### Description

Sanity currently type-checks preview definitions, but loses the fact that a preview was provided when returning the schema from the define helpers.

```ts
const schema = defineType({
  type: 'document',
  name: 'question',
  fields: [],
  preview: {
    select: {title: 'title'},
    prepare: ({title}) => ({title}),
  },
})

// Current returned type is effectively:
// { preview?: { prepare?: (...) => PreviewValue } }

schema.preview.prepare({title: 'Question'})
//      ^^^^^^^ ^^^^^^^
// unnecessarily typed as possibly undefined, despite being defined above
```

This preserves explicitly supplied previews on the return type for the schema define helpers, so callers do not need non-null assertions when accessing preview configuration that is present in the schema declaration. Existing preview select/prepare type-safety is kept intact.

### What to review

- Confirm the return type only preserves previews when a preview is actually supplied.
- Confirm preview is still only allowed for schema types that support preview configuration.
- Confirm the existing preview select/prepare key inference still behaves as before.
- Consider whether this should remain a targeted preview fix, or whether the define helpers should preserve more of the exact user-provided schema shape for other optional properties too.

### Testing

Added type-level coverage for accessing supplied preview prepare functions directly from values returned by the define helpers.

### Notes for release

TypeScript: schema define helpers now preserve explicitly provided preview configuration on their return types, avoiding unnecessary non-null assertions when accessing previews declared inline.
