### PR TITLE
chore(sanity): add `beta.documentGroupInventory.enabled` configuration

### DIFF
--- a/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
+++ b/packages/sanity/src/core/config/__tests__/resolveConfig.test.ts
@@ -506,6 +506,129 @@ describe('beta variants config', () => {
   })
 })
 
+describe('beta document group inventory config', () => {
+  const projectId = 'ppsg7ml5'
+  const dataset = 'production'
+
+  it('defaults document group inventory to false', async () => {
+    const source = await createSourceFromConfig({projectId, dataset})
+
+    expect(source.beta?.documentGroupInventory?.enabled).toBe(false)
+  })
+
+  it('resolves document group inventory from root config', async () => {
+    const source = await createSourceFromConfig({
+      projectId,
+      dataset,
+      beta: {documentGroupInventory: {enabled: true}},
+    })
+
+    expect(source.beta?.documentGroupInventory?.enabled).toBe(true)
+  })
+
+  it('resolves document group inventory from plugin config', async () => {
+    const source = await createSourceFromConfig({
+      projectId,
+      dataset,
+      plugins: [
+        definePlugin({
+          name: 'sanity/beta-document-group-inventory',
+          beta: {documentGroupInventory: {enabled: true}},
+        })(),
+      ],
+    })
+
+    expect(source.beta?.documentGroupInventory?.enabled).toBe(true)
+  })
+
+  it('lets root config override plugin document group inventory config', async () => {
+    const source = await createSourceFromConfig({
+      projectId,
+      dataset,
+      plugins: [
+        definePlugin({
+          name: 'sanity/beta-document-group-inventory',
+          beta: {documentGroupInventory: {enabled: true}},
+        })(),
+      ],
+      beta: {documentGroupInventory: {enabled: false}},
+    })
+
+    expect(source.beta?.documentGroupInventory?.enabled).toBe(false)
+  })
+
+  it('infers document group inventory when variants is enabled', async () => {
+    const source = await createSourceFromConfig({
+      projectId,
+      dataset,
+      beta: {variants: {enabled: true}},
+    })
+
+    expect(source.beta?.documentGroupInventory?.enabled).toBe(true)
+  })
+
+  it('cannot be switched off when variants is enabled', async () => {
+    const source = await createSourceFromConfig({
+      projectId,
+      dataset,
+      beta: {
+        variants: {enabled: true},
+        documentGroupInventory: {enabled: false},
+      },
+    })
+
+    expect(source.beta?.documentGroupInventory?.enabled).toBe(true)
+  })
+
+  it('throws when document group inventory is not an object', async () => {
+    await expect(
+      createSourceFromConfig({
+        projectId,
+        dataset,
+        beta: {
+          // @ts-expect-error should be an object
+          documentGroupInventory: 'enabled',
+        },
+      }),
+    ).rejects.toThrow('Expected `beta.documentGroupInventory` to be an object, but received string')
+  })
+
+  it('throws when document group inventory enabled is not a boolean', async () => {
+    await expect(
+      createSourceFromConfig({
+        projectId,
+        dataset,
+        beta: {
+          documentGroupInventory: {
+            // @ts-expect-error should be a boolean
+            enabled: 'enabled',
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      'Expected `beta.documentGroupInventory.enabled` to be a boolean, but received string',
+    )
+  })
+
+  it('throws when document group inventory enabled is invalid even if variants is enabled', async () => {
+    await expect(
+      createSourceFromConfig({
+        projectId,
+        dataset,
+        beta: {
+          variants: {enabled: true},
+          documentGroupInventory: {
+            // @ts-expect-error should be a boolean
+            enabled: 'enabled',
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      'Expected `beta.documentGroupInventory.enabled` to be a boolean, but received string',
+    )
+  })
+})
+
 describe('search strategy selection', () => {
   const projectId = 'ppsg7ml5'
   const dataset = 'production'

--- a/packages/sanity/src/core/config/configPropertyReducers.ts
+++ b/packages/sanity/src/core/config/configPropertyReducers.ts
@@ -494,6 +494,48 @@ export const variantsEnabledReducer = (opts: {
   return result
 }
 
+export const documentGroupInventoryEnabledReducer = ({
+  config,
+  initialValue,
+}: {
+  config: PluginOptions
+  initialValue: boolean
+}): boolean => {
+  const flattenedConfig = flattenConfig(config, [])
+
+  return flattenedConfig.reduce<boolean>((value, {config: innerConfig}) => {
+    const documentGroupInventory: unknown = innerConfig.beta?.documentGroupInventory
+
+    if (typeof documentGroupInventory === 'undefined') {
+      return value
+    }
+
+    if (!isRecord(documentGroupInventory)) {
+      throw new Error(
+        `Expected \`beta.documentGroupInventory\` to be an object, but received ${getPrintableType(
+          documentGroupInventory,
+        )}`,
+      )
+    }
+
+    const enabled = documentGroupInventory.enabled
+
+    if (typeof enabled === 'undefined') {
+      return value
+    }
+
+    if (typeof enabled === 'boolean') {
+      return enabled
+    }
+
+    throw new Error(
+      `Expected \`beta.documentGroupInventory.enabled\` to be a boolean, but received ${getPrintableType(
+        enabled,
+      )}`,
+    )
+  }, initialValue)
+}
+
 export const mediaLibraryEnabledReducer = (opts: {
   config: PluginOptions
   initialValue: boolean

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -38,6 +38,7 @@ import {
   documentAskToEditEnabledReducer,
   documentBadgesReducer,
   documentCommentsEnabledReducer,
+  documentGroupInventoryEnabledReducer,
   documentInspectorsReducer,
   documentLanguageFilterReducer,
   draftsEnabledReducer,
@@ -666,6 +667,8 @@ function resolveSource({
     })
   }
 
+  const variantsEnabled = variantsEnabledReducer({config, initialValue: false})
+
   const source: Source = {
     type: 'source',
     name: config.name,
@@ -857,7 +860,13 @@ function resolveSource({
         releases: eventsAPIReducer({config, initialValue: false, key: 'releases'}),
       },
       variants: {
-        enabled: variantsEnabledReducer({config, initialValue: false}),
+        enabled: variantsEnabled,
+      },
+      documentGroupInventory: {
+        // The document group inventory is an inherent part of the variants experience.
+        // It cannot be switched off while variants are switched on.
+        enabled:
+          documentGroupInventoryEnabledReducer({config, initialValue: false}) || variantsEnabled,
       },
     },
 

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -1338,4 +1338,17 @@ export interface BetaFeatures {
   variants?: {
     enabled?: boolean
   }
+  /**
+   * Control whether the preview of the new document group inventory is
+   * switched on.
+   *
+   * This is the new UI for managing and navigating versions and variants of
+   * documents. It replaces the version chips that currently appear at the top
+   * of the document editor.
+   *
+   * It is switched on automatically when `beta.variants.enabled` is true.
+   */
+  documentGroupInventory?: {
+    enabled?: boolean
+  }
 }


### PR DESCRIPTION
### Description

This branch adds a `beta.documentGroupInventory.enabled` configuration option, which will be used to gate preview access to the new document group inventory.

This option is always switched on when the variants beta is switched on.

### What to review

The new configuration.

### Testing

Added unit tests to assert correct configuration resolution.
