### PR TITLE
ci(playwright): pin browser version to the workspace and fix groq preview build

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Store Playwright's Version
         id: playwright-version
         run: |
-          PLAYWRIGHT_VERSION=$(npx playwright --version | sed 's/Version //')
+          PLAYWRIGHT_VERSION=$(pnpm exec playwright --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
           echo "Playwright's Version: $PLAYWRIGHT_VERSION"
           echo "version=${PLAYWRIGHT_VERSION}" >> "$GITHUB_OUTPUT"
       - name: Cache Playwright Browsers for Playwright's Version
@@ -72,10 +72,10 @@ jobs:
       # Always install them; otherwise a cache hit gives us the browser binary
       # but a missing shared library, crashing the run on startup.
       - name: Install Playwright system dependencies
-        run: npx playwright install-deps ${{ matrix.browser }}
+        run: pnpm exec playwright install-deps ${{ matrix.browser }}
       - name: Install Playwright Browsers
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-        run: npx playwright install ${{ matrix.browser }}
+        run: pnpm exec playwright install ${{ matrix.browser }}
 
       - name: Build packages
         # This should take only a few seconds as it'll restore the remote cache that got primed in the `install` job

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -74,7 +74,6 @@ jobs:
       - name: Install Playwright system dependencies
         run: pnpm exec playwright install-deps ${{ matrix.browser }}
       - name: Install Playwright Browsers
-        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: pnpm exec playwright install ${{ matrix.browser }}
 
       - name: Build packages

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Install Playwright system dependencies
         run: pnpm exec playwright install-deps ${{ matrix.browser }}
       - name: Install Playwright Browsers
+        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: pnpm exec playwright install ${{ matrix.browser }}
 
       - name: Build packages

--- a/.github/workflows/e2e-auth.yml
+++ b/.github/workflows/e2e-auth.yml
@@ -41,7 +41,7 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
-        if: steps.changes.outputs.has_changes == 'true'
+        if: steps.changes.outputs.has_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Build packages and auth-test-studio

--- a/.github/workflows/e2e-auth.yml
+++ b/.github/workflows/e2e-auth.yml
@@ -41,7 +41,7 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
-        if: steps.changes.outputs.has_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+        if: steps.changes.outputs.has_changes == 'true'
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Build packages and auth-test-studio

--- a/.github/workflows/e2e-auth.yml
+++ b/.github/workflows/e2e-auth.yml
@@ -29,7 +29,7 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true'
         id: playwright-version
         run: |
-          PLAYWRIGHT_VERSION=$(npx playwright --version | sed 's/Version //')
+          PLAYWRIGHT_VERSION=$(pnpm exec playwright --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
           echo "version=${PLAYWRIGHT_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright Browsers
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install Playwright Browsers
         if: steps.changes.outputs.has_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: Build packages and auth-test-studio
         if: steps.changes.outputs.has_changes == 'true'

--- a/.github/workflows/e2e-auth.yml
+++ b/.github/workflows/e2e-auth.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
+          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers-chromium
 
       - name: Install Playwright Browsers
         if: steps.changes.outputs.has_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e-embedded.yml
+++ b/.github/workflows/e2e-embedded.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
+          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers-chromium-firefox
 
       - name: Install Playwright Browsers
         if: steps.changes.outputs.has_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
@@ -76,7 +76,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
+          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers-chromium-firefox
 
       - name: Install Playwright Browsers
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e-embedded.yml
+++ b/.github/workflows/e2e-embedded.yml
@@ -42,7 +42,7 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
-        if: steps.changes.outputs.has_changes == 'true'
+        if: steps.changes.outputs.has_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium firefox
 
   test:
@@ -79,6 +79,7 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
+        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps ${{ matrix.project }}
 
       - name: Build

--- a/.github/workflows/e2e-embedded.yml
+++ b/.github/workflows/e2e-embedded.yml
@@ -42,7 +42,7 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
-        if: steps.changes.outputs.has_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+        if: steps.changes.outputs.has_changes == 'true'
         run: pnpm exec playwright install --with-deps chromium firefox
 
   test:
@@ -79,7 +79,6 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
-        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps ${{ matrix.project }}
 
       - name: Build

--- a/.github/workflows/e2e-embedded.yml
+++ b/.github/workflows/e2e-embedded.yml
@@ -29,7 +29,7 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true'
         id: playwright-version
         run: |
-          PLAYWRIGHT_VERSION=$(npx playwright --version | sed 's/Version //')
+          PLAYWRIGHT_VERSION=$(pnpm exec playwright --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
           echo "Playwright's Version: $PLAYWRIGHT_VERSION"
           echo "version=${PLAYWRIGHT_VERSION}" >> "$GITHUB_OUTPUT"
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install Playwright Browsers
         if: steps.changes.outputs.has_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium firefox
+        run: pnpm exec playwright install --with-deps chromium firefox
 
   test:
     if: needs.install.outputs.has_code_changes == 'true'
@@ -67,7 +67,7 @@ jobs:
       - name: Store Playwright's Version
         id: playwright-version
         run: |
-          PLAYWRIGHT_VERSION=$(npx playwright --version | sed 's/Version //')
+          PLAYWRIGHT_VERSION=$(pnpm exec playwright --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
           echo "Playwright's Version: $PLAYWRIGHT_VERSION"
           echo "version=${PLAYWRIGHT_VERSION}" >> "$GITHUB_OUTPUT"
 
@@ -80,7 +80,7 @@ jobs:
 
       - name: Install Playwright Browsers
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps ${{ matrix.project }}
+        run: pnpm exec playwright install --with-deps ${{ matrix.project }}
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -113,7 +113,6 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
-        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
 
       - name: Cache E2E test studio on PR
@@ -170,7 +169,6 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
-        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
 
       - name: Run E2E tests on PR

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -113,6 +113,7 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
+        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
 
       - name: Cache E2E test studio on PR
@@ -169,6 +170,7 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
+        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
 
       - name: Run E2E tests on PR

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Store Playwright's Version
         id: playwright-version
         run: |
-          PLAYWRIGHT_VERSION=$(npx playwright --version | sed 's/Version //')
+          PLAYWRIGHT_VERSION=$(pnpm exec playwright --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
           echo "Playwright's Version: $PLAYWRIGHT_VERSION"
           echo "version=${PLAYWRIGHT_VERSION}" >> "$GITHUB_OUTPUT"
 
@@ -114,7 +114,7 @@ jobs:
 
       - name: Install Playwright Browsers
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
+        run: pnpm exec playwright install --with-deps
 
       - name: Cache E2E test studio on PR
         # Always run with PRs logic, to ensure tests run by the UI repo doesn't conflict with tests run by the sanity repo
@@ -158,7 +158,7 @@ jobs:
       - name: Store Playwright's Version
         id: playwright-version
         run: |
-          PLAYWRIGHT_VERSION=$(npx playwright --version | sed 's/Version //')
+          PLAYWRIGHT_VERSION=$(pnpm exec playwright --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
           echo "Playwright's Version: $PLAYWRIGHT_VERSION"
           echo "version=${PLAYWRIGHT_VERSION}" >> "$GITHUB_OUTPUT"
 
@@ -171,7 +171,7 @@ jobs:
 
       - name: Install Playwright Browsers
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
+        run: pnpm exec playwright install --with-deps
 
       - name: Run E2E tests on PR
         # Always run with PRs logic, to ensure tests run by the UI repo doesn't conflict with tests run by the sanity repo
@@ -213,7 +213,7 @@ jobs:
       - name: Merge into HTML Report
         run: |
           if [ -d "playwright-report" ] && [ "$(ls -A playwright-report 2>/dev/null)" ]; then
-            npx playwright merge-reports --reporter html ./playwright-report
+            pnpm exec playwright merge-reports --reporter html ./playwright-report
           else
             echo "::warning::No playwright report files found, skipping merge"
           fi

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
+          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers-all
 
       - name: Install Playwright Browsers
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
@@ -167,7 +167,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
+          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers-all
 
       - name: Install Playwright Browsers
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,7 +64,7 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
-        if: steps.changes.outputs.has_changes == 'true'
+        if: steps.changes.outputs.has_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium firefox
 
   dataset-setup:
@@ -201,6 +201,7 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
+        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps ${{ matrix.project }}
 
       - name: Run E2E tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,7 +51,7 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true'
         id: playwright-version
         run: |
-          PLAYWRIGHT_VERSION=$(npx playwright --version | sed 's/Version //')
+          PLAYWRIGHT_VERSION=$(pnpm exec playwright --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
           echo "Playwright's Version: $PLAYWRIGHT_VERSION"
           echo "version=${PLAYWRIGHT_VERSION}" >> "$GITHUB_OUTPUT"
 
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install Playwright Browsers
         if: steps.changes.outputs.has_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium firefox
+        run: pnpm exec playwright install --with-deps chromium firefox
 
   dataset-setup:
     timeout-minutes: 10
@@ -189,7 +189,7 @@ jobs:
       - name: Store Playwright's Version
         id: playwright-version
         run: |
-          PLAYWRIGHT_VERSION=$(npx playwright --version | sed 's/Version //')
+          PLAYWRIGHT_VERSION=$(pnpm exec playwright --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
           echo "Playwright's Version: $PLAYWRIGHT_VERSION"
           echo "version=${PLAYWRIGHT_VERSION}" >> "$GITHUB_OUTPUT"
 
@@ -202,7 +202,7 @@ jobs:
 
       - name: Install Playwright Browsers
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps ${{ matrix.project }}
+        run: pnpm exec playwright install --with-deps ${{ matrix.project }}
 
       - name: Run E2E tests
         env:
@@ -266,7 +266,7 @@ jobs:
           path: all-blob-reports
 
       - name: Merge into HTML Report
-        run: npx playwright merge-reports --reporter html,./e2e/reporters/summary.ts all-blob-reports/blob-report
+        run: pnpm exec playwright merge-reports --reporter html,./e2e/reporters/summary.ts all-blob-reports/blob-report
 
       - name: Extract test summary
         id: summary

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,7 +64,7 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
-        if: steps.changes.outputs.has_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+        if: steps.changes.outputs.has_changes == 'true'
         run: pnpm exec playwright install --with-deps chromium firefox
 
   dataset-setup:
@@ -201,7 +201,6 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
-        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps ${{ matrix.project }}
 
       - name: Run E2E tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -104,6 +104,11 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
+      # preferWorkspacePackages resolves sanity-plugin-media's "groq" import to the
+      # packages/groq workspace package, whose entry points only exist once built.
+      - name: Build groq package
+        run: pnpm --filter groq build
+
       - name: Pull Vercel Environment Information
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_E2E_STUDIO_ORG_ID }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
+          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers-chromium-firefox
 
       - name: Install Playwright Browsers
         if: steps.changes.outputs.has_changes == 'true' && steps.cache-playwright-browsers.outputs.cache-hit != 'true'
@@ -198,7 +198,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
+          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers-chromium-firefox
 
       - name: Install Playwright Browsers
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'

--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -172,6 +172,7 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
+        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: pnpm playwright install --with-deps
 
       - name: Load Vercel Env Vars into GITHUB_ENV

--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -169,7 +169,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
+          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers-all
 
       - name: Install Playwright Browsers
         if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'

--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -172,7 +172,6 @@ jobs:
           key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers
 
       - name: Install Playwright Browsers
-        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
         run: pnpm playwright install --with-deps
 
       - name: Load Vercel Env Vars into GITHUB_ENV

--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Store Playwright's Version
         id: playwright-version
         run: |
-          PLAYWRIGHT_VERSION=$(npx playwright --version | sed 's/Version //')
+          PLAYWRIGHT_VERSION=$(pnpm exec playwright --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
           echo "Playwright's Version: $PLAYWRIGHT_VERSION"
           echo "version=${PLAYWRIGHT_VERSION}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/efps.yml
+++ b/.github/workflows/efps.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Store Playwright's Version
         id: playwright-version
         run: |
-          PLAYWRIGHT_VERSION=$(pnpm playwright --version | sed 's/Version //')
+          PLAYWRIGHT_VERSION=$(npx playwright --version | sed 's/Version //')
           echo "Playwright's Version: $PLAYWRIGHT_VERSION"
           echo "version=${PLAYWRIGHT_VERSION}" >> "$GITHUB_OUTPUT"
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "devtools:test-studio:build": "pnpm build && ENABLE_VITE_DEVTOOLS=true pnpm --filter sanity-test-studio sanity:build",
     "docs:typedocs:cleanup": "pnpm --filter=sanity docs:typedocs:cleanup",
     "docs:typedocs:generate": "pnpm --filter=sanity docs:typedocs:generate",
-    "e2e:build": "turbo run build --filter=studio-e2e-testing",
+    "e2e:build": "pnpm --filter groq build && turbo run build --filter=studio-e2e-testing",
     "e2e:cleanup": "tsx -r dotenv-flow/config e2e/scripts/cleanupDatasets",
     "e2e:codegen": "node -r dotenv-flow/config ./node_modules/.bin/sanity-test codegen",
     "e2e:dev": "pnpm --filter studio-e2e-testing dev",


### PR DESCRIPTION
### Description

The efps and e2e CI workflows fail on playwright. The efps "Store Playwright's Version" step captured `pnpm playwright --version`, but pnpm's `$`-syntax-override deprecation warning leaked into stdout and corrupted the captured value, breaking `$GITHUB_OUTPUT`. Separately, the workflows invoked `npx playwright`, which resolves npm's latest published version rather than the workspace-pinned one; once 1.61.0 was published, the browser cache and `playwright install` keyed and installed for 1.61.0 while the studios ran tests against the pinned version, leaving the required browser revision absent (`Executable doesn't exist at .../firefox-1532`).

This PR routes every playwright invocation through `pnpm exec playwright` (the workspace version) and extracts the version with `grep` so the warning is stripped. It scopes the browser cache keys by the installed browser set (`-chromium-firefox`, `-all`, `-chromium`, `-${matrix.browser}`) so a chromium-only install can no longer poison a firefox job's cache. It also builds `packages/groq` before the e2e studio bundle (the Vercel deploy-preview and `e2e:build`), because `preferWorkspacePackages` links sanity-plugin-media's `groq` import to the workspace package, whose entry points exist only once built.

### What to review

- Each cache key encodes both the playwright version (existing prefix) and the browser set it installs, so the key always describes its contents; the `cache-hit` guard is kept for speed.
- groq is built ahead of the studio bundle rather than altering dependency resolution.

### Notes for release

N/A
