### PR TITLE
refactor(core): abstract use bundle documents , reuse for variants

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
@@ -18,7 +18,7 @@ import {ReleaseDashboardDetails} from './ReleaseDashboardDetails'
 import {ReleaseDashboardFooter} from './ReleaseDashboardFooter'
 import {ReleaseDashboardHeader} from './ReleaseDashboardHeader'
 import {ReleaseSummary} from './ReleaseSummary'
-import {useBundleDocuments} from './useBundleDocuments'
+import {useReleaseDocuments} from './useReleaseDocuments'
 
 export type ReleaseInspector = 'activity'
 const MotionCard = motion.create(Card)
@@ -36,7 +36,7 @@ export function ReleaseDetail() {
     loading: documentsLoading,
     results,
     error: bundleDocumentsError,
-  } = useBundleDocuments(releaseId)
+  } = useReleaseDocuments(releaseId)
   const releaseEvents = useReleaseEvents(releaseId)
 
   const releaseInDetail = data

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
@@ -28,11 +28,11 @@ import {
 } from '../../../store/__tests__/__mocks/useReleasePermissions.mock'
 import {getReleaseIdFromReleaseDocumentId} from '../../../util/getReleaseIdFromReleaseDocumentId'
 import {ReleaseDetail} from '../ReleaseDetail'
+import {documentsInRelease} from './__mocks__/useBundleDocuments.mock'
 import {
-  documentsInRelease,
-  mockUseBundleDocuments,
-  useBundleDocumentsMockReturn,
-} from './__mocks__/useBundleDocuments.mock'
+  mockUseReleaseDocuments,
+  useReleaseDocumentsMockReturn,
+} from './__mocks__/useReleaseDocuments.mock'
 import {useReleaseEventsMockReturn} from './__mocks__/useReleaseEvents.mock'
 
 vi.mock('sanity/router', async (importOriginal) => {
@@ -63,8 +63,8 @@ vi.mock('../../../store/useReleasePermissions', () => ({
   useReleasePermissions: vi.fn(() => useReleasePermissionsMockReturn),
 }))
 
-vi.mock('../useBundleDocuments', () => ({
-  useBundleDocuments: vi.fn(() => useBundleDocumentsMockReturn),
+vi.mock('../useReleaseDocuments', () => ({
+  useReleaseDocuments: vi.fn(() => useReleaseDocumentsMockReturn),
 }))
 
 vi.mock('../events/useReleaseEvents', () => ({
@@ -162,9 +162,9 @@ describe('ReleaseDetail', () => {
       vi.clearAllMocks()
 
       mockUseActiveReleases.mockClear()
-      mockUseBundleDocuments.mockClear()
+      mockUseReleaseDocuments.mockClear()
 
-      mockUseBundleDocuments.mockReturnValue({...useBundleDocumentsMockReturn, loading: true})
+      mockUseReleaseDocuments.mockReturnValue({...useReleaseDocumentsMockReturn, loading: true})
 
       mockUseActiveReleases.mockReturnValue({
         ...useActiveReleasesMockReturn,
@@ -211,7 +211,7 @@ describe('after releases have loaded', () => {
       beforeEach(async () => {
         vi.clearAllMocks()
 
-        mockUseBundleDocuments.mockReturnValue({
+        mockUseReleaseDocuments.mockReturnValue({
           loading: false,
           results: [
             {
@@ -237,7 +237,7 @@ describe('after releases have loaded', () => {
 
     describe('with passing document validation', () => {
       beforeEach(async () => {
-        mockUseBundleDocuments.mockReturnValue({
+        mockUseReleaseDocuments.mockReturnValue({
           loading: false,
           results: [documentsInRelease],
           error: null,
@@ -295,7 +295,7 @@ describe('after releases have loaded', () => {
 
     describe('with failing document validation', () => {
       beforeEach(async () => {
-        mockUseBundleDocuments.mockReturnValue({
+        mockUseReleaseDocuments.mockReturnValue({
           loading: false,
           results: [
             {

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/__mocks__/useReleaseDocuments.mock.ts
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/__mocks__/useReleaseDocuments.mock.ts
@@ -1,0 +1,20 @@
+import {type Mock, type Mocked} from 'vitest'
+
+import {useReleaseDocuments} from '../../useReleaseDocuments'
+import {documentsInRelease} from './useBundleDocuments.mock'
+
+export const useReleaseDocumentsMockReturn: Mocked<ReturnType<typeof useReleaseDocuments>> = {
+  loading: false,
+  results: [],
+  error: null,
+}
+
+export const useReleaseDocumentsMockReturnWithResults: Mocked<
+  ReturnType<typeof useReleaseDocuments>
+> = {
+  loading: false,
+  results: [documentsInRelease],
+  error: null,
+}
+
+export const mockUseReleaseDocuments = useReleaseDocuments as Mock<typeof useReleaseDocuments>

--- a/packages/sanity/src/core/releases/tool/detail/getPublishedArchivedReleaseDocumentsObservable.ts
+++ b/packages/sanity/src/core/releases/tool/detail/getPublishedArchivedReleaseDocumentsObservable.ts
@@ -1,0 +1,102 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {uuid} from '@sanity/uuid'
+import {of} from 'rxjs'
+import {catchError, expand, finalize, map, reduce, shareReplay} from 'rxjs/operators'
+
+import {type useSource} from '../../../studio'
+import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
+import {RELEASES_STUDIO_CLIENT_OPTIONS} from '../../util/releasesClient'
+import {type BundleDocumentsObservableResult, type DocumentInRelease} from './useBundleDocuments'
+
+const publishedArchivedReleaseDocumentsCache: Record<string, BundleDocumentsObservableResult> =
+  Object.create(null)
+
+const buildPublishedArchivedReleaseDocumentsObservable = ({
+  getClient,
+  release,
+}: {
+  getClient: ReturnType<typeof useSource>['getClient']
+  release: ReleaseDocument
+}): BundleDocumentsObservableResult => {
+  const client = getClient(RELEASES_STUDIO_CLIENT_OPTIONS)
+  const observableClient = client.observable
+  const dataset = client.config().dataset
+
+  if (!release.finalDocumentStates?.length) return of({loading: false, results: [], error: null})
+
+  function batchRequestDocumentFromHistory(startIndex: number) {
+    const finalIndex = startIndex + 10
+    return observableClient
+      .request<{documents: DocumentInRelease['document'][]}>({
+        url: `/data/history/${dataset}/documents/${release.finalDocumentStates
+          ?.slice(startIndex, finalIndex)
+          .map((d) => d.id)
+          .join(',')}?lastRevision=true`,
+      })
+      .pipe(map(({documents}) => ({documents, finalIndex})))
+  }
+
+  const documents$ = batchRequestDocumentFromHistory(0).pipe(
+    expand((response) => {
+      if (release.finalDocumentStates && response.finalIndex < release.finalDocumentStates.length) {
+        // Continue with next batch
+        return batchRequestDocumentFromHistory(response.finalIndex)
+      }
+      // End recursion by emitting an empty observable
+      return of()
+    }),
+    reduce(
+      (documents: DocumentInRelease['document'][], batch) => documents.concat(batch.documents),
+      [],
+    ),
+  )
+
+  return documents$.pipe(
+    map((documents) => ({
+      loading: false,
+      results: documents.map((document) => ({
+        document,
+        memoKey: uuid(),
+        validation: {validation: [], hasError: false, isValidating: false},
+      })),
+      error: null,
+    })),
+    catchError((error) => {
+      return of({loading: false, results: [], error})
+    }),
+  )
+}
+
+/**
+ * Resolves the documents of a published or archived release from the history API.
+ *
+ * Published and archived releases no longer have live versioned documents, so their content is
+ * reconstructed from the `finalDocumentStates` recorded on the release using the document history
+ * endpoint. No validation or availability checks are performed.
+ *
+ * Published and archived releases are terminal states, so the result is cached and shared across
+ * subscribers using a `<releaseId>-archived` cache key.
+ *
+ * @internal
+ */
+export const getPublishedArchivedReleaseDocumentsObservable = ({
+  getClient,
+  release,
+}: {
+  getClient: ReturnType<typeof useSource>['getClient']
+  release: ReleaseDocument
+}): BundleDocumentsObservableResult => {
+  const cacheKey = `${getReleaseIdFromReleaseDocumentId(release._id)}-archived`
+
+  if (!publishedArchivedReleaseDocumentsCache[cacheKey]) {
+    publishedArchivedReleaseDocumentsCache[cacheKey] =
+      buildPublishedArchivedReleaseDocumentsObservable({getClient, release}).pipe(
+        finalize(() => {
+          delete publishedArchivedReleaseDocumentsCache[cacheKey]
+        }),
+        shareReplay(1),
+      )
+  }
+
+  return publishedArchivedReleaseDocumentsCache[cacheKey]
+}

--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -1,4 +1,3 @@
-import {type ReleaseDocument} from '@sanity/client'
 import {
   type CurrentUser,
   isValidationErrorMarker,
@@ -10,19 +9,7 @@ import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
 import {combineLatest, from, type Observable, of} from 'rxjs'
 import {mergeMapArray} from 'rxjs-mergemap-array'
-import {
-  catchError,
-  delay,
-  distinctUntilChanged,
-  expand,
-  filter,
-  finalize,
-  map,
-  reduce,
-  shareReplay,
-  startWith,
-  switchMap,
-} from 'rxjs/operators'
+import {catchError, delay, filter, finalize, map, shareReplay, switchMap} from 'rxjs/operators'
 
 import {useSchema} from '../../../hooks'
 import {type LocaleSource} from '../../../i18n/types'
@@ -31,12 +18,9 @@ import {useDocumentPreviewStore} from '../../../store/datastores'
 import {useSource} from '../../../studio'
 import {schedulerYield} from '../../../util/schedulerYield'
 import {validateDocumentWithReferences, type ValidationStatus} from '../../../validation'
-import {useReleasesStore} from '../../store/useReleasesStore'
-import {getReleaseDocumentIdFromReleaseId} from '../../util/getReleaseDocumentIdFromReleaseId'
-import {isGoingToUnpublish} from '../../util/isGoingToUnpublish'
 import {RELEASES_STUDIO_CLIENT_OPTIONS} from '../../util/releasesClient'
 
-const bundleDocumentsCache: Record<string, ReleaseDocumentsObservableResult> = Object.create(null)
+const bundleDocumentsCache: Record<string, BundleDocumentsObservableResult> = Object.create(null)
 
 export interface DocumentValidationStatus extends ValidationStatus {
   hasError: boolean
@@ -49,32 +33,47 @@ export interface DocumentInRelease {
   validation: DocumentValidationStatus
 }
 
-type ReleaseDocumentsObservableResult = Observable<{
+export type BundleDocumentsObservableResult = Observable<{
   loading: boolean
   results: DocumentInRelease[]
   error: Error | null
 }>
 
-const getActiveReleaseDocumentsObservable = ({
-  schema,
-  documentPreviewStore,
-  i18n,
-  getClient,
-  releaseId,
-  currentUser,
-}: {
+interface BundleDocumentsObservableOptions {
   schema: Schema
   documentPreviewStore: DocumentPreviewStore
   i18n: LocaleSource
   getClient: ReturnType<typeof useSource>['getClient']
-  releaseId: string
   currentUser?: Omit<CurrentUser, 'role'> | null
-}): ReleaseDocumentsObservableResult => {
-  const groqFilter = `sanity::partOfRelease($releaseId)`
+  /**
+   * The GROQ filter used to resolve the set of documents to fetch,
+   * e.g. `sanity::partOfRelease($releaseId)` or `sanity::partOfVariant($variantId)`.
+   */
+  groqFilter: string
+  /**
+   * The params referenced by `groqFilter`, e.g. `{releaseId}` or `{variantId}`.
+   */
+  params: Record<string, unknown>
+  /**
+   * Returns `true` for documents that should not be validated (validation is short-circuited).
+   * Used, for example, to skip documents that are going to be unpublished in a release.
+   */
+  skipValidation?: (document: SanityDocument) => boolean
+}
 
+const buildBundleDocumentsObservable = ({
+  schema,
+  documentPreviewStore,
+  i18n,
+  getClient,
+  currentUser,
+  groqFilter,
+  params,
+  skipValidation,
+}: Omit<BundleDocumentsObservableOptions, 'cacheKey'>): BundleDocumentsObservableResult => {
   // Helper function to create validation observable
   const createValidationObservable = (ctx: any, document: SanityDocument) => {
-    if (isGoingToUnpublish(document)) {
+    if (skipValidation?.(document)) {
       return of({
         isValidating: false,
         validation: [],
@@ -150,13 +149,9 @@ const getActiveReleaseDocumentsObservable = ({
   }
 
   return documentPreviewStore
-    .unstable_observeDocumentIdSet(
-      groqFilter,
-      {releaseId},
-      {
-        apiVersion: RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion,
-      },
-    )
+    .unstable_observeDocumentIdSet(groqFilter, params, {
+      apiVersion: RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion,
+    })
     .pipe(
       map((state) => state.documentIds || []),
       switchMap((documentIds) => {
@@ -197,164 +192,83 @@ const getActiveReleaseDocumentsObservable = ({
     )
 }
 
-const getPublishedArchivedReleaseDocumentsObservable = ({
-  getClient,
-  release,
-}: {
-  getClient: ReturnType<typeof useSource>['getClient']
-  release: ReleaseDocument
-}): ReleaseDocumentsObservableResult => {
-  const client = getClient(RELEASES_STUDIO_CLIENT_OPTIONS)
-  const observableClient = client.observable
-  const dataset = client.config().dataset
-
-  if (!release.finalDocumentStates?.length) return of({loading: false, results: [], error: null})
-
-  function batchRequestDocumentFromHistory(startIndex: number) {
-    const finalIndex = startIndex + 10
-    return observableClient
-      .request<{documents: DocumentInRelease['document'][]}>({
-        url: `/data/history/${dataset}/documents/${release.finalDocumentStates
-          ?.slice(startIndex, finalIndex)
-          .map((d) => d.id)
-          .join(',')}?lastRevision=true`,
-      })
-      .pipe(map(({documents}) => ({documents, finalIndex})))
-  }
-
-  const documents$ = batchRequestDocumentFromHistory(0).pipe(
-    expand((response) => {
-      if (release.finalDocumentStates && response.finalIndex < release.finalDocumentStates.length) {
-        // Continue with next batch
-        return batchRequestDocumentFromHistory(response.finalIndex)
-      }
-      // End recursion by emitting an empty observable
-      return of()
-    }),
-    reduce(
-      (documents: DocumentInRelease['document'][], batch) => documents.concat(batch.documents),
-      [],
-    ),
-  )
-
-  return documents$.pipe(
-    map((documents) => ({
-      loading: false,
-      results: documents.map((document) => ({
-        document,
-        memoKey: uuid(),
-        validation: {validation: [], hasError: false, isValidating: false},
-      })),
-      error: null,
-    })),
-    catchError((error) => {
-      return of({loading: false, results: [], error})
-    }),
-  )
-}
-
-const getReleaseDocumentsObservable = ({
-  schema,
-  documentPreviewStore,
-  getClient,
-  releaseId,
-  i18n,
-  releasesState$,
-  currentUser,
-}: {
-  schema: Schema
-  documentPreviewStore: DocumentPreviewStore
-  getClient: ReturnType<typeof useSource>['getClient']
-  releaseId: string
-  i18n: LocaleSource
-  releasesState$: ReturnType<typeof useReleasesStore>['state$']
-  currentUser?: Omit<CurrentUser, 'role'> | null
-}): ReleaseDocumentsObservableResult => {
-  if (!bundleDocumentsCache[releaseId]) {
-    bundleDocumentsCache[releaseId] = releasesState$.pipe(
-      map((releasesState) =>
-        releasesState.releases.get(getReleaseDocumentIdFromReleaseId(releaseId)),
-      ),
-      filter(Boolean), // Removes falsey values
-      distinctUntilChanged((prev, next) => {
-        // Only skip re-validation if the core fields that affect document validation haven't changed
-        // Return true to skip, false to trigger re-validation
-        // _rev wasn't enough since it changed on every edit of the release document itself
-        return prev.state === next.state && prev.finalDocumentStates === next.finalDocumentStates
+/**
+ * Generic document-fetching machinery shared across releases and variants.
+ *
+ * Resolves the set of documents matching `groqFilter`/`params`, then observes each document along
+ * with its published availability and validation status. Results are batched to avoid overwhelming
+ * the main thread, and shared across subscribers via a module-level cache keyed by `cacheKey`.
+ *
+ * @internal
+ */
+export const getBundleDocumentsObservable = ({
+  cacheKey,
+  ...options
+}: BundleDocumentsObservableOptions & {cacheKey: string}): BundleDocumentsObservableResult => {
+  if (!bundleDocumentsCache[cacheKey]) {
+    bundleDocumentsCache[cacheKey] = buildBundleDocumentsObservable(options).pipe(
+      finalize(() => {
+        delete bundleDocumentsCache[cacheKey]
       }),
-      switchMap((release) => {
-        // Create cache key based on fields that affect document validation + _rev
-        const cacheKey = [
-          releaseId,
-          release.state,
-          release.finalDocumentStates?.flatMap((doc) => doc.id),
-          release._rev,
-        ].join('-')
-
-        if (!bundleDocumentsCache[cacheKey]) {
-          let observable: ReleaseDocumentsObservableResult
-
-          if (release.state === 'published' || release.state === 'archived') {
-            observable = getPublishedArchivedReleaseDocumentsObservable({
-              getClient,
-              release,
-            })
-          } else {
-            observable = getActiveReleaseDocumentsObservable({
-              schema,
-              documentPreviewStore,
-              i18n,
-              getClient,
-              releaseId,
-              currentUser,
-            })
-          }
-
-          bundleDocumentsCache[cacheKey] = observable.pipe(
-            finalize(() => {
-              delete bundleDocumentsCache[cacheKey]
-            }),
-            shareReplay(1),
-          )
-        }
-
-        return bundleDocumentsCache[cacheKey]
-      }),
-      startWith({loading: true, results: [], error: null}),
       shareReplay(1),
     )
   }
 
-  return bundleDocumentsCache[releaseId]
+  return bundleDocumentsCache[cacheKey]
 }
 
-export function useBundleDocuments(releaseId: string): {
+const BUNDLE_DOCUMENTS_INITIAL_STATE = {
+  loading: true,
+  results: [],
+  error: null,
+}
+
+/**
+ * Generic hook to fetch the documents matching a GROQ filter, along with their validation and
+ * published availability. Used by release- and variant-specific hooks.
+ *
+ * @internal
+ */
+export function useBundleDocuments(options: {
+  groqFilter: string
+  params: Record<string, unknown>
+  cacheKey: string
+  skipValidation?: (document: SanityDocument) => boolean
+}): {
   loading: boolean
   results: DocumentInRelease[]
   error: null | Error
 } {
+  const {groqFilter, params, cacheKey, skipValidation} = options
   const documentPreviewStore = useDocumentPreviewStore()
   const {getClient, i18n, currentUser} = useSource()
   const schema = useSchema()
-  const {state$: releasesState$} = useReleasesStore()
 
-  const releaseDocumentsObservable = useMemo(
+  const bundleDocumentsObservable = useMemo(
     () =>
-      getReleaseDocumentsObservable({
+      getBundleDocumentsObservable({
         schema,
         documentPreviewStore,
         getClient,
-        releaseId,
         i18n,
-        releasesState$,
         currentUser,
+        groqFilter,
+        params,
+        cacheKey,
+        skipValidation,
       }),
-    [schema, documentPreviewStore, getClient, releaseId, i18n, releasesState$, currentUser],
+    [
+      schema,
+      documentPreviewStore,
+      getClient,
+      i18n,
+      currentUser,
+      groqFilter,
+      params,
+      cacheKey,
+      skipValidation,
+    ],
   )
 
-  return useObservable(releaseDocumentsObservable, {
-    loading: true,
-    results: [],
-    error: null,
-  })
+  return useObservable(bundleDocumentsObservable, BUNDLE_DOCUMENTS_INITIAL_STATE)
 }

--- a/packages/sanity/src/core/releases/tool/detail/useReleaseDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useReleaseDocuments.ts
@@ -1,0 +1,120 @@
+import {type CurrentUser, type Schema} from '@sanity/types'
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {distinctUntilChanged, filter, map, shareReplay, startWith, switchMap} from 'rxjs/operators'
+
+import {useSchema} from '../../../hooks'
+import {type LocaleSource} from '../../../i18n/types'
+import {type DocumentPreviewStore} from '../../../preview'
+import {useDocumentPreviewStore} from '../../../store/datastores'
+import {useSource} from '../../../studio'
+import {useReleasesStore} from '../../store/useReleasesStore'
+import {getReleaseDocumentIdFromReleaseId} from '../../util/getReleaseDocumentIdFromReleaseId'
+import {isGoingToUnpublish} from '../../util/isGoingToUnpublish'
+import {getPublishedArchivedReleaseDocumentsObservable} from './getPublishedArchivedReleaseDocumentsObservable'
+import {
+  type BundleDocumentsObservableResult,
+  type DocumentInRelease,
+  getBundleDocumentsObservable,
+} from './useBundleDocuments'
+
+const getReleaseDocumentsObservable = ({
+  schema,
+  documentPreviewStore,
+  getClient,
+  releaseId,
+  i18n,
+  releasesState$,
+  currentUser,
+}: {
+  schema: Schema
+  documentPreviewStore: DocumentPreviewStore
+  getClient: ReturnType<typeof useSource>['getClient']
+  releaseId: string
+  i18n: LocaleSource
+  releasesState$: ReturnType<typeof useReleasesStore>['state$']
+  currentUser?: Omit<CurrentUser, 'role'> | null
+}): BundleDocumentsObservableResult => {
+  return releasesState$.pipe(
+    map((releasesState) =>
+      releasesState.releases.get(getReleaseDocumentIdFromReleaseId(releaseId)),
+    ),
+    filter(Boolean), // Removes falsey values
+    distinctUntilChanged((prev, next) => {
+      // Only skip re-validation if the core fields that affect document validation haven't changed
+      // Return true to skip, false to trigger re-validation
+      // _rev wasn't enough since it changed on every edit of the release document itself
+      return prev.state === next.state && prev.finalDocumentStates === next.finalDocumentStates
+    }),
+    switchMap((release) => {
+      // Published and archived releases are terminal and fetched from history;
+      // the observable caches itself by `<releaseId>-archived`.
+      if (release.state === 'published' || release.state === 'archived') {
+        return getPublishedArchivedReleaseDocumentsObservable({getClient, release})
+      }
+
+      // The document fetching/validation is cached in `getBundleDocumentsObservable` by `cacheKey`,
+      // which is derived from the release fields that affect document validation (+ `_rev`).
+      const cacheKey = [
+        releaseId,
+        release.state,
+        release.finalDocumentStates?.flatMap((doc) => doc.id),
+        release._rev,
+      ].join('-')
+
+      return getBundleDocumentsObservable({
+        schema,
+        documentPreviewStore,
+        i18n,
+        getClient,
+        currentUser,
+        groqFilter: `sanity::partOfRelease($releaseId)`,
+        params: {releaseId},
+        skipValidation: isGoingToUnpublish,
+        cacheKey,
+      })
+    }),
+    startWith({loading: true, results: [], error: null}),
+    shareReplay(1),
+  )
+}
+
+/**
+ * Hook to fetch the documents that belong to a release.
+ *
+ * Decides, based on the release state, whether to use the generic active-release pipeline
+ * ({@link getBundleDocumentsObservable}) or the published/archived history pipeline
+ * ({@link getPublishedArchivedReleaseDocumentsObservable}).
+ *
+ * @internal
+ */
+export function useReleaseDocuments(releaseId: string): {
+  loading: boolean
+  results: DocumentInRelease[]
+  error: null | Error
+} {
+  const documentPreviewStore = useDocumentPreviewStore()
+  const {getClient, i18n, currentUser} = useSource()
+  const schema = useSchema()
+  const {state$: releasesState$} = useReleasesStore()
+
+  const releaseDocumentsObservable = useMemo(
+    () =>
+      getReleaseDocumentsObservable({
+        schema,
+        documentPreviewStore,
+        getClient,
+        releaseId,
+        i18n,
+        releasesState$,
+        currentUser,
+      }),
+    [schema, documentPreviewStore, getClient, releaseId, i18n, releasesState$, currentUser],
+  )
+
+  return useObservable(releaseDocumentsObservable, {
+    loading: true,
+    results: [],
+    error: null,
+  })
+}

--- a/packages/sanity/src/core/releases/tool/overview/ReleaseMenuButtonWrapper.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleaseMenuButtonWrapper.tsx
@@ -2,7 +2,7 @@ import {type ReleaseDocument} from '@sanity/client'
 
 import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
 import {ReleaseMenuButton} from '../components/ReleaseMenuButton/ReleaseMenuButton'
-import {useBundleDocuments} from '../detail/useBundleDocuments'
+import {useReleaseDocuments} from '../detail/useReleaseDocuments'
 
 export const ReleaseMenuButtonWrapper = ({
   release,
@@ -11,7 +11,7 @@ export const ReleaseMenuButtonWrapper = ({
   release: ReleaseDocument
   documentsCount: number
 }) => {
-  const {results: documents} = useBundleDocuments(getReleaseIdFromReleaseDocumentId(release._id))
+  const {results: documents} = useReleaseDocuments(getReleaseIdFromReleaseDocumentId(release._id))
 
   return (
     <ReleaseMenuButton release={release} documentsCount={documentsCount} documents={documents} />

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
@@ -50,7 +50,7 @@ import {
   useReleasesMetadataMockReturn,
 } from '../../../store/__tests__/__mocks/useReleasesMetadata.mock'
 import {type ReleasesMetadata} from '../../../store/useReleasesMetadata'
-import {useBundleDocumentsMockReturnWithResults} from '../../detail/__tests__/__mocks__/useBundleDocuments.mock'
+import {useReleaseDocumentsMockReturnWithResults} from '../../detail/__tests__/__mocks__/useReleaseDocuments.mock'
 import {
   mockUseReleaseCreator,
   useReleaseCreatorMockReturn,
@@ -95,8 +95,8 @@ vi.mock('../../../store/useReleasesMetadata', () => ({
   useReleasesMetadata: vi.fn(() => useReleasesMetadataMockReturn),
 }))
 
-vi.mock('../../detail/useBundleDocuments', () => ({
-  useBundleDocuments: vi.fn(() => useBundleDocumentsMockReturnWithResults),
+vi.mock('../../detail/useReleaseDocuments', () => ({
+  useReleaseDocuments: vi.fn(() => useReleaseDocumentsMockReturnWithResults),
 }))
 
 vi.mock('../../../store/useReleasePermissions', () => ({

--- a/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseColumnValidationLoading.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/columnCells/ReleaseColumnValidationLoading.tsx
@@ -1,12 +1,12 @@
 import {Spinner} from '@sanity/ui'
 
 import {getReleaseIdFromReleaseDocumentId} from '../../../util/getReleaseIdFromReleaseDocumentId'
-import {useBundleDocuments} from '../../detail/useBundleDocuments'
+import {useReleaseDocuments} from '../../detail/useReleaseDocuments'
 import {ValidationProgressIndicator} from '../../detail/ValidationProgressIndicator'
 
 export function ReleaseColumnValidationLoading({releaseId}: {releaseId: string}) {
   const rId = getReleaseIdFromReleaseDocumentId(releaseId)
-  const {results: documents, loading} = useBundleDocuments(rId)
+  const {results: documents, loading} = useReleaseDocuments(rId)
 
   return loading ? (
     <Spinner size={1} muted />

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftDocument.ts
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftDocument.ts
@@ -3,7 +3,7 @@ import {type PreviewValue, type ValidationMarker} from '@sanity/types'
 
 import {useSchema} from '../../hooks'
 import {unstable_useValuePreview as useValuePreview} from '../../preview/useValuePreview'
-import {useBundleDocuments} from '../../releases/tool/detail/useBundleDocuments'
+import {useReleaseDocuments} from '../../releases/tool/detail/useReleaseDocuments'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
 
 /**
@@ -25,7 +25,7 @@ export function useScheduledDraftDocument(
 } {
   const {includePreview = false} = options
   const releaseId = releaseDocumentId ? getReleaseIdFromReleaseDocumentId(releaseDocumentId) : ''
-  const {results: documents, loading, error} = useBundleDocuments(releaseId)
+  const {results: documents, loading, error} = useReleaseDocuments(releaseId)
   const schema = useSchema()
 
   const firstDocument = documents?.[0]?.document

--- a/packages/sanity/src/core/variants/hooks/useVariantDocuments.ts
+++ b/packages/sanity/src/core/variants/hooks/useVariantDocuments.ts
@@ -8,11 +8,9 @@ import {
 /**
  * Hook to fetch the documents that belong to a variant.
  *
- * Reuses the generic {@link useBundleDocuments} machinery with the `sanity::partOfVariant`
- * GROQ filter.
- *
- * Note: `sanity::partOfVariant` is not yet supported in content lake, so this hook will
- * return no documents until that support lands.
+ * Reuses the generic {@link useBundleDocuments} machinery. Currently filters by
+ * `_system.variant._ref` until `sanity::partOfVariant($variantId)` is supported
+ * in content lake.
  *
  * @internal
  */

--- a/packages/sanity/src/core/variants/hooks/useVariantDocuments.ts
+++ b/packages/sanity/src/core/variants/hooks/useVariantDocuments.ts
@@ -1,0 +1,33 @@
+import {useMemo} from 'react'
+
+import {
+  type DocumentInRelease,
+  useBundleDocuments,
+} from '../../releases/tool/detail/useBundleDocuments'
+
+/**
+ * Hook to fetch the documents that belong to a variant.
+ *
+ * Reuses the generic {@link useBundleDocuments} machinery with the `sanity::partOfVariant`
+ * GROQ filter.
+ *
+ * Note: `sanity::partOfVariant` is not yet supported in content lake, so this hook will
+ * return no documents until that support lands.
+ *
+ * @internal
+ */
+export function useVariantDocuments(variantId: string): {
+  loading: boolean
+  results: DocumentInRelease[]
+  error: null | Error
+} {
+  const params = useMemo(() => ({variantId}), [variantId])
+
+  return useBundleDocuments({
+    // TODO: Switch to `sanity::partOfVariant` when content lake supports it.
+    // groqFilter: `sanity::partOfVariant($variantId)`,
+    groqFilter: `_system.variant._ref == $variantId`,
+    params,
+    cacheKey: `variant-${variantId}`,
+  })
+}

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -66,6 +66,10 @@ const variantsLocaleStrings = {
   'detail.documents.table.type': 'Type',
   /** Version column header for variant document table. */
   'detail.documents.table.version': 'Version',
+  /** Version chip label for a document that belongs to the published bundle. */
+  'detail.documents.table.version.published': 'Published',
+  /** Version chip label for a document that belongs to the drafts bundle. */
+  'detail.documents.table.version.drafts': 'Drafts',
   /** Description for the missing Variant detail page. */
   'detail.not-found.description': 'The requested variant could not be found.',
   /** Title for the missing Variant detail page. */

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
@@ -1,12 +1,12 @@
-import {type SanityDocument} from '@sanity/client'
 import {Box, Card, Container, Flex, Stack, Text} from '@sanity/ui'
-import {useState} from 'react'
+import {useMemo, useState} from 'react'
 import {useRouter} from 'sanity/router'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {LoadingBlock} from '../../../components'
 import {useTranslation} from '../../../i18n'
 import {EditVariantDialog} from '../../components/dialog/EditVariantDialog'
+import {useVariantDocuments} from '../../hooks/useVariantDocuments'
 import {variantsLocaleNamespace} from '../../i18n'
 import {useAllVariants} from '../../store/useAllVariants'
 import {
@@ -18,8 +18,6 @@ import {
 import {VariantDetailFooter} from './VariantDetailFooter'
 import {VariantDocumentsTable} from './VariantDocumentsTable'
 
-const EMPTY_VARIANT_DOCUMENTS: SanityDocument[] = []
-
 export function VariantDetail() {
   const router = useRouter()
   const {t} = useTranslation(variantsLocaleNamespace)
@@ -30,6 +28,12 @@ export function VariantDetail() {
   const {byId, loading} = useAllVariants()
 
   const variant = variantId ? byId.get(variantId) : undefined
+
+  const {results: variantDocuments} = useVariantDocuments(variantId ?? '')
+  const documents = useMemo(
+    () => variantDocuments.map((result) => result.document),
+    [variantDocuments],
+  )
 
   if (loading) {
     return <LoadingBlock fill title={t('detail.loading')} />
@@ -98,7 +102,7 @@ export function VariantDetail() {
           </Flex>
         </Container>
         <Flex direction="column" flex={1} overflow="hidden" style={{minHeight: 0}}>
-          <VariantDocumentsTable documents={EMPTY_VARIANT_DOCUMENTS} />
+          <VariantDocumentsTable documents={documents} />
         </Flex>
       </Flex>
       <VariantDetailFooter variant={variant} />

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
@@ -29,7 +29,9 @@ export function VariantDetail() {
 
   const variant = variantId ? byId.get(variantId) : undefined
 
-  const {results: variantDocuments} = useVariantDocuments(variantId ?? '')
+  const {results: variantDocuments, loading: documentsLoading} = useVariantDocuments(
+    variantId ?? '',
+  )
   const documents = useMemo(
     () => variantDocuments.map((result) => result.document),
     [variantDocuments],
@@ -102,7 +104,7 @@ export function VariantDetail() {
           </Flex>
         </Container>
         <Flex direction="column" flex={1} overflow="hidden" style={{minHeight: 0}}>
-          <VariantDocumentsTable documents={documents} />
+          <VariantDocumentsTable documents={documents} loading={documentsLoading} />
         </Flex>
       </Flex>
       <VariantDetailFooter variant={variant} />

--- a/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
@@ -1,18 +1,69 @@
-import {type SanityDocument} from '@sanity/client'
-import {Box, Card, Flex, Text} from '@sanity/ui'
+import {type ReleaseDocument, type SanityDocument} from '@sanity/client'
+import {type DocumentSystem} from '@sanity/types'
+import {Badge, type BadgeTone, Box, Card, Flex, Text} from '@sanity/ui'
 import {type CSSProperties, memo, useMemo, useState} from 'react'
+import {useObservable} from 'react-rx'
 
 import {RelativeTime} from '../../../components/RelativeTime'
 import {useSchema} from '../../../hooks'
 import {type UseTranslationResponse, useTranslation} from '../../../i18n'
 import {SanityDefaultPreview} from '../../../preview/components/SanityDefaultPreview'
+import {useReleasesStore} from '../../../releases/store/useReleasesStore'
 import {Table} from '../../../releases/tool/components/Table/Table'
 import {Headers} from '../../../releases/tool/components/Table/TableHeader'
 import {type Column} from '../../../releases/tool/components/Table/types'
+import {getReleaseIdFromReleaseDocumentId} from '../../../releases/util/getReleaseIdFromReleaseDocumentId'
+import {getReleaseTitleDetails} from '../../../releases/util/getReleaseTitleDetails'
+import {getReleaseTone} from '../../../releases/util/getReleaseTone'
 import {variantsLocaleNamespace} from '../../i18n'
+
+interface VariantDocumentVersion {
+  label: string
+  tone: BadgeTone
+}
 
 interface VariantDocumentRow {
   document: SanityDocument
+  version: VariantDocumentVersion
+}
+
+/**
+ * Derives the bundle a variant document belongs to from its `_system` metadata and returns the
+ * label and tone for its version chip. Variant documents are scoped to both a variant and a bundle
+ * (a release, the published bundle, or drafts).
+ */
+function getVariantDocumentVersion({
+  document,
+  releasesById,
+  t,
+}: {
+  document: SanityDocument
+  releasesById: Map<string, ReleaseDocument> | undefined
+  t: UseTranslationResponse<'variants', undefined>['t']
+}): VariantDocumentVersion {
+  const system = document._system as DocumentSystem | undefined
+  const releaseRef = system?.release?._ref
+
+  if (releaseRef) {
+    const release = releasesById?.get(releaseRef)
+
+    if (release) {
+      const {displayTitle} = getReleaseTitleDetails(
+        release.metadata?.title,
+        getReleaseIdFromReleaseDocumentId(release._id),
+      )
+
+      return {label: displayTitle, tone: getReleaseTone(release)}
+    }
+
+    return {label: getReleaseIdFromReleaseDocumentId(releaseRef), tone: 'default'}
+  }
+
+  if (system?.bundleId === 'drafts') {
+    return {label: t('detail.documents.table.version.drafts'), tone: getReleaseTone('drafts')}
+  }
+
+  return {label: t('detail.documents.table.version.published'), tone: getReleaseTone('published')}
 }
 
 const TABLE_CARD_STYLE: CSSProperties = {
@@ -36,10 +87,39 @@ const MemoDocumentType = memo(
   (prev, next) => prev.type === next.type,
 )
 
+function getVariantDocumentVersionSortRank(document: SanityDocument): number {
+  const system = document._system as DocumentSystem | undefined
+
+  if (system?.release?._ref) {
+    return 2
+  }
+
+  if (system?.bundleId === 'drafts') {
+    return 1
+  }
+
+  return 0
+}
+
+function getVariantDocumentGroupSortKey({document, version}: VariantDocumentRow): string {
+  const groupRef = (document._system as DocumentSystem | undefined)?.group._ref ?? document._id
+  const versionRank = getVariantDocumentVersionSortRank(document)
+
+  // Group by document family, then order versions Published → Drafts → Releases.
+  return `${groupRef}\0${versionRank}\0${version.label}\0${document._id}`
+}
+
 function getVariantDocumentColumnDefs(
   t: UseTranslationResponse<'variants', undefined>['t'],
 ): Column<VariantDocumentRow>[] {
   return [
+    {
+      id: 'documentGroup',
+      hidden: true,
+      width: null,
+      sorting: true,
+      sortTransform: getVariantDocumentGroupSortKey,
+    },
     {
       id: 'version',
       width: null,
@@ -50,12 +130,14 @@ function getVariantDocumentColumnDefs(
           <Headers.BasicHeader text={t('detail.documents.table.version')} />
         </Flex>
       ),
-      cell: ({cellProps}) => (
+      cell: ({cellProps, datum}) => (
         <Flex align="center" {...cellProps}>
           <Box paddingX={2}>
-            <Text muted size={1}>
-              -
-            </Text>
+            {!datum.isLoading && datum.version && (
+              <Badge fontSize={1} mode="outline" radius={2} tone={datum.version.tone}>
+                {datum.version.label}
+              </Badge>
+            )}
           </Box>
         </Flex>
       ),
@@ -145,15 +227,25 @@ export function VariantDocumentsTable({
 }): React.JSX.Element {
   const {t} = useTranslation(variantsLocaleNamespace)
   const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(null)
+  const {state$} = useReleasesStore()
+  const releasesState = useObservable(state$)
+  const releasesById = releasesState?.releases
   const columnDefs = useMemo(() => getVariantDocumentColumnDefs(t), [t])
-  const rows = useMemo(() => documents.map((document) => ({document})), [documents])
+  const rows = useMemo(
+    () =>
+      documents.map((document) => ({
+        document,
+        version: getVariantDocumentVersion({document, releasesById, t}),
+      })),
+    [documents, releasesById, t],
+  )
 
   return (
     <Card flex={1} ref={setScrollContainerRef} style={TABLE_CARD_STYLE}>
       <Table<VariantDocumentRow>
         columnDefs={columnDefs}
         data={rows}
-        defaultSort={{column: 'search', direction: 'asc'}}
+        defaultSort={{column: 'documentGroup', direction: 'asc'}}
         emptyState={t('detail.documents.no-documents')}
         // oxlint-disable-next-line @sanity/i18n/no-attribute-string-literals
         rowId="document._id"

--- a/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
@@ -222,8 +222,10 @@ function filterDocuments(rows: VariantDocumentRow[], searchTerm: string): Varian
 
 export function VariantDocumentsTable({
   documents,
+  loading = false,
 }: {
   documents: SanityDocument[]
+  loading?: boolean
 }): React.JSX.Element {
   const {t} = useTranslation(variantsLocaleNamespace)
   const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(null)
@@ -247,6 +249,7 @@ export function VariantDocumentsTable({
         data={rows}
         defaultSort={{column: 'documentGroup', direction: 'asc'}}
         emptyState={t('detail.documents.no-documents')}
+        loading={loading}
         // oxlint-disable-next-line @sanity/i18n/no-attribute-string-literals
         rowId="document._id"
         scrollContainerRef={scrollContainerRef}

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
@@ -1,4 +1,5 @@
 import {type SanityDocument} from '@sanity/client'
+import {type DocumentSystem} from '@sanity/types'
 import {render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
 import {describe, expect, it, vi} from 'vitest'
@@ -84,5 +85,58 @@ describe('VariantDocumentsTable', () => {
 
     expect(screen.getByText('Second article')).toBeInTheDocument()
     expect(screen.queryByText('First article')).not.toBeInTheDocument()
+  })
+
+  it('groups documents by their document group ref', async () => {
+    const sharedGroupRef = 'article-group'
+    const groupedDocuments: SanityDocument[] = [
+      {
+        _id: 'versions.summer.article-a',
+        _type: 'article',
+        _rev: 'rev-1',
+        _createdAt: '2025-01-01T00:00:00Z',
+        _updatedAt: '2025-06-01T00:00:00Z',
+        title: 'Summer article',
+        _system: {
+          group: {_ref: sharedGroupRef, _weak: true},
+          bundleId: 'drafts',
+        } satisfies DocumentSystem,
+      },
+      {
+        _id: 'article-other',
+        _type: 'article',
+        _rev: 'rev-2',
+        _createdAt: '2025-01-02T00:00:00Z',
+        _updatedAt: '2025-06-02T00:00:00Z',
+        title: 'Other article',
+        _system: {
+          group: {_ref: 'other-group', _weak: true},
+          bundleId: 'drafts',
+        } satisfies DocumentSystem,
+      },
+      {
+        _id: 'versions.published.article-a',
+        _type: 'article',
+        _rev: 'rev-3',
+        _createdAt: '2025-01-03T00:00:00Z',
+        _updatedAt: '2025-06-03T00:00:00Z',
+        title: 'Published article',
+        _system: {
+          group: {_ref: sharedGroupRef, _weak: true},
+        } satisfies DocumentSystem,
+      },
+    ]
+
+    await renderTable(groupedDocuments)
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(3)
+    })
+
+    const rowTitles = screen.getAllByTestId('table-row').map((row) => row.textContent)
+
+    expect(rowTitles[0]).toContain('Published article')
+    expect(rowTitles[1]).toContain('Summer article')
+    expect(rowTitles[2]).toContain('Other article')
   })
 })

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
@@ -40,11 +40,13 @@ const mockDocuments: SanityDocument[] = [
 ]
 
 describe('VariantDocumentsTable', () => {
-  const renderTable = async (documents: SanityDocument[] = mockDocuments) => {
+  const renderTable = async (documents: SanityDocument[] = mockDocuments, loading = false) => {
     const wrapper = await createTestProvider({
       resources: [variantsUsEnglishLocaleBundle],
     })
-    const result = render(<VariantDocumentsTable documents={documents} />, {wrapper})
+    const result = render(<VariantDocumentsTable documents={documents} loading={loading} />, {
+      wrapper,
+    })
     await screen.findByPlaceholderText('Search documents')
     return result
   }
@@ -53,6 +55,13 @@ describe('VariantDocumentsTable', () => {
     await renderTable([])
 
     expect(screen.getByText('No documents in this variant')).toBeInTheDocument()
+  })
+
+  it('shows loading skeleton rows while documents are loading', async () => {
+    await renderTable([], true)
+
+    expect(screen.getAllByTestId('table-row-skeleton')).toHaveLength(3)
+    expect(screen.queryByText('No documents in this variant')).not.toBeInTheDocument()
   })
 
   it('renders document rows with title, type, and edited columns', async () => {


### PR DESCRIPTION
### Description

`useBundleDocuments` mixed generic document-fetching (validation, availability, batching, caching) with release-specific behavior (archived/published history pipeline, `sanity::partOfRelease`, `isGoingToUnpublish`). That blocked reuse for variants, where we need the same machinery but a different GROQ filter and no release-only validation shortcuts.

This splits responsibilities into three layers:
- **`useBundleDocuments`** — generic hook/observable, parametrized by `groqFilter`, `params`, `cacheKey`, and optional `skipValidation`
- **`useReleaseDocuments`** — release-specific routing: active releases use the bundle pipeline; published/archived releases use the history API
- **`useVariantDocuments`** — variant wrapper that reuses the bundle pipeline (currently via `_system.variant._ref` until `sanity::partOfVariant` lands in content lake)

Caching lives in the fetchers themselves (`getBundleDocumentsObservable` for active bundles, `getPublishedArchivedReleaseDocumentsObservable` keyed by `<releaseId>-archived`), so release and variant consumers share subscriptions without duplicating cache logic in the hooks.

The variant detail table now lists documents with a version chip (Published / Drafts / release title via `getReleaseTitleDetails`), grouped by `_system.group._ref` and sorted Published → Drafts → Releases within each group.

Release behavior is unchanged from the caller's perspective — existing consumers now call `useReleaseDocuments` instead of `useBundleDocuments`.

Now you can visit variants and see the documents https://test-studio-git-abstract-use-bundle-documents.sanity.dev/test/variants/XBeVtHmN


https://github.com/user-attachments/assets/d1512d45-3c55-4471-bc9a-a564634c279e


Next step, enable the correct document preview for them and show validation on each of them.


### What to review

- [`useBundleDocuments.ts`](packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts) — generic API shape and cache key contract
- [`useReleaseDocuments.ts`](packages/sanity/src/core/releases/tool/detail/useReleaseDocuments.ts) — release state switching and cache key derivation from `releasesState$`
- [`getPublishedArchivedReleaseDocumentsObservable.ts`](packages/sanity/src/core/releases/tool/detail/getPublishedArchivedReleaseDocumentsObservable.ts) — self-contained archived/published caching
- [`useVariantDocuments.ts`](packages/sanity/src/core/variants/hooks/useVariantDocuments.ts) — temporary `_system.variant._ref` filter vs future `sanity::partOfVariant`
- [`VariantDocumentsTable.tsx`](packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx) — version chip rendering and group/version sort order

### Testing

### Notes for release
N/A – Internal only. Refactors release document fetching and scaffolds variant document listing in the variants tool; no public API changes.