### PR TITLE
fix(form): honor `enabled` on the markdown plugin alongside deprecated `config`

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -147,12 +147,12 @@ function DefaultMarkdownShortcutsPlugin(
 ) {
   const props = incomingProps ?? {}
 
-  if (!props.config) {
-    const {enabled, config, ...markdownShortcutsPluginProps} = props
+  if (props.enabled === false) {
+    return null
+  }
 
-    if (enabled === false) {
-      return null
-    }
+  if (!props.config) {
+    const {enabled: _enabled, config: _config, ...markdownShortcutsPluginProps} = props
 
     return <MarkdownShortcutsPlugin {...markdownShortcutsPluginProps} />
   }

--- a/packages/sanity/src/core/form/types/blockProps.test-d.ts
+++ b/packages/sanity/src/core/form/types/blockProps.test-d.ts
@@ -1,0 +1,20 @@
+import {expectTypeOf, test} from 'vitest'
+
+import {type PortableTextPluginsProps} from './blockProps'
+
+test('plugins.markdown accepts spreading the incoming value and overriding `enabled`', () => {
+  // A structural assertion misses this: the excess-property error only fires on
+  // literal assignment, so the spread is replicated in a real `renderDefault` call.
+  expectTypeOf((props: PortableTextPluginsProps) =>
+    props.renderDefault({
+      ...props,
+      plugins: {
+        ...props.plugins,
+        markdown: {
+          ...props.plugins.markdown,
+          enabled: false,
+        },
+      },
+    }),
+  ).toBeFunction()
+})

--- a/packages/sanity/src/core/form/types/blockProps.ts
+++ b/packages/sanity/src/core/form/types/blockProps.ts
@@ -457,6 +457,10 @@ export interface PortableTextPluginsProps {
            * @deprecated - add the configuration directly to `markdown` instead
            */
           config: MarkdownConfig
+          /**
+           * @defaultValue true
+           */
+          enabled?: boolean
         }
       | (MarkdownShortcutsPluginProps & {
           config?: undefined


### PR DESCRIPTION
### Description

Disabling the markdown shortcuts plugin from a custom `plugins` component didn't typecheck:

```tsx
plugins: {
  ...props.plugins,
  markdown: {...props.plugins.markdown, enabled: false},
}
```

`plugins.markdown` is a union whose deprecated `{config}` branch had no `enabled`, so `{config, enabled: false}` matched neither member. The plugin also ignored `enabled` at runtime when a `config` was set.

Adds `enabled?` to the `config` branch and checks `enabled === false` before branching on `config`.

### What to review

`blockProps.ts` and `Plugins.tsx`.

### Testing

`blockProps.test-d.ts` pins the spread pattern via `vitest --typecheck`.

### Notes for release

Spreading the incoming markdown plugin props and setting `enabled: false` now disables the built-in markdown shortcuts plugin. Previously this combination didn't typecheck.


