### PR TITLE
chore(core): updates to variant detail page

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/documentTable/searchDocumentRelease.ts
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/searchDocumentRelease.ts
@@ -5,17 +5,18 @@ import {extractSearchableText} from './extractSearchableText'
 /**
  * This is a temporary way of doing the search without the previews
  * until we have it moved to the server side
+ * Each document is searchable by title, name, and combined text of title and name, this could be different
+ * than the displayed title, given the displayed title is resolved by the preview prepare function, but we cannot use that one
+ * here because we will be over-fetching the documents, we will need to resolve the preview for hundreds of documents if we do that.
+ *
+ * So this is an intermediate solution to allow the search to work without the resolved preview values.
+ *
  *
  * @param document - The document to search
  * @param searchTerm - The search term
  * @returns True if the document matches the search term, false otherwise
  */
-export function searchDocumentRelease(
-  document: SanityDocument & {
-    publishedDocumentExists: boolean
-  },
-  searchTerm: string,
-) {
+export function searchDocumentRelease(document: SanityDocument, searchTerm: string) {
   // if there is no search term or the document has no title or name, return false
   if (!searchTerm || searchTerm.trim().length === 0 || (!document.title && !document.name)) {
     return false

--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -22,10 +22,20 @@ import {RELEASES_STUDIO_CLIENT_OPTIONS} from '../../util/releasesClient'
 
 const bundleDocumentsCache: Record<string, BundleDocumentsObservableResult> = Object.create(null)
 
+/** @internal */
+export function resetBundleDocumentsCacheForTests(): void {
+  for (const key of Object.keys(bundleDocumentsCache)) {
+    delete bundleDocumentsCache[key]
+  }
+}
+
 export interface DocumentValidationStatus extends ValidationStatus {
   hasError: boolean
 }
 
+/**
+ * TODO: Rename this fo DocumentInBundle, adapt in releases and variants to it's own specific types.
+ */
 export interface DocumentInRelease {
   memoKey: string
   isPending?: boolean
@@ -217,7 +227,13 @@ export const getBundleDocumentsObservable = ({
   return bundleDocumentsCache[cacheKey]
 }
 
-const BUNDLE_DOCUMENTS_INITIAL_STATE = {
+const BUNDLE_DOCUMENTS_EMPTY = {
+  loading: false,
+  results: [],
+  error: null,
+}
+
+const BUNDLE_DOCUMENTS_LOADING = {
   loading: true,
   results: [],
   error: null,
@@ -234,30 +250,34 @@ export function useBundleDocuments(options: {
   params: Record<string, unknown>
   cacheKey: string
   skipValidation?: (document: SanityDocument) => boolean
+  enabled?: boolean
 }): {
   loading: boolean
   results: DocumentInRelease[]
   error: null | Error
 } {
-  const {groqFilter, params, cacheKey, skipValidation} = options
+  const {groqFilter, params, cacheKey, skipValidation, enabled = true} = options
   const documentPreviewStore = useDocumentPreviewStore()
   const {getClient, i18n, currentUser} = useSource()
   const schema = useSchema()
 
   const bundleDocumentsObservable = useMemo(
     () =>
-      getBundleDocumentsObservable({
-        schema,
-        documentPreviewStore,
-        getClient,
-        i18n,
-        currentUser,
-        groqFilter,
-        params,
-        cacheKey,
-        skipValidation,
-      }),
+      enabled
+        ? getBundleDocumentsObservable({
+            schema,
+            documentPreviewStore,
+            getClient,
+            i18n,
+            currentUser,
+            groqFilter,
+            params,
+            cacheKey,
+            skipValidation,
+          })
+        : of(BUNDLE_DOCUMENTS_EMPTY),
     [
+      enabled,
       schema,
       documentPreviewStore,
       getClient,
@@ -270,5 +290,8 @@ export function useBundleDocuments(options: {
     ],
   )
 
-  return useObservable(bundleDocumentsObservable, BUNDLE_DOCUMENTS_INITIAL_STATE)
+  return useObservable(
+    bundleDocumentsObservable,
+    enabled ? BUNDLE_DOCUMENTS_LOADING : BUNDLE_DOCUMENTS_EMPTY,
+  )
 }

--- a/packages/sanity/src/core/variants/README.md
+++ b/packages/sanity/src/core/variants/README.md
@@ -140,24 +140,24 @@ Covered behavior:
 - back navigation
 - read-only title, description, and condition summary
 - edit dialog
-- placeholder documents table
+- documents table wired to display variant documents
 - footer with creation status and a detail-specific actions menu
 
 The detail actions menu is separate from the overview row menu. This is intentional because the two menus are expected to diverge as the detail page gains more actions.
 
-## Documents Table Placeholder
+## Documents Table
 
-`tool/detail/VariantDocumentsTable.tsx` is a placeholder for the future list of documents that belong to a variant.
+`tool/detail/VariantDocumentsTable.tsx` lists documents that belong to a variant.
 
-It currently receives an empty `SanityDocument[]`, but it already follows the release table layout:
+Data flow:
 
-- `Version` column placeholder
-- document type column
-- document preview/search column
-- edited date column
-- empty state
+- `useVariantDocuments(variantId)` fetches a flat list of variant-scoped document versions via `_system.variant._ref == $variantId`
+- `groupVariantDocumentsByGroup()` optionally groups that flat list into one row per document group
+- the table renders bundle chips, type, preview, and edited columns using the shared releases table component
 
-Pending work is to connect this to the real source of documents for a variant.
+To revert to one row per document version, pass the flat `useVariantDocuments()` results directly to the table and switch `rowId` from `groupId` to `document._id`.
+
+There is a tracked TODO to replace the fallback GROQ filter with `sanity::partOfVariant($variantId)` when the native function ships.
 
 ## Footer
 
@@ -170,7 +170,7 @@ Covered behavior:
 - detail-specific menu button
 - delete action navigates back to the overview after success
 
-The delete action currently does not confirm or check whether the variant has documents. That is pending until variant membership is implemented.
+The delete action currently does not confirm or check whether the variant has documents.
 
 ## Test Coverage
 
@@ -223,7 +223,7 @@ Local browser execution has previously hit `EMFILE: too many open files, watch` 
 ## Pending Work
 
 - Drop the local `SanityClientWithVariantsActions` typing wrapper once `@sanity/client` exports the variant definition action types.
-- Wire the detail documents table to the real list of documents that belong to a variant.
+- Replace `_system.variant._ref` document membership queries with `sanity::partOfVariant($variantId)`.
 - Decide how document counts affect deleting variants.
 - Add a delete confirmation or disabled state once variants can have documents.
 - Expand the detail-specific actions menu independently from the overview row menu.

--- a/packages/sanity/src/core/variants/README.md
+++ b/packages/sanity/src/core/variants/README.md
@@ -151,13 +151,11 @@ The detail actions menu is separate from the overview row menu. This is intentio
 
 Data flow:
 
-- `useVariantDocuments(variantId)` fetches a flat list of variant-scoped document versions via `_system.variant._ref == $variantId`
+- `useVariantDocuments(variantId)` fetches a flat list of variant-scoped document versions.
 - `groupVariantDocumentsByGroup()` optionally groups that flat list into one row per document group
 - the table renders bundle chips, type, preview, and edited columns using the shared releases table component
 
 To revert to one row per document version, pass the flat `useVariantDocuments()` results directly to the table and switch `rowId` from `groupId` to `document._id`.
-
-There is a tracked TODO to replace the fallback GROQ filter with `sanity::partOfVariant($variantId)` when the native function ships.
 
 ## Footer
 
@@ -223,7 +221,6 @@ Local browser execution has previously hit `EMFILE: too many open files, watch` 
 ## Pending Work
 
 - Drop the local `SanityClientWithVariantsActions` typing wrapper once `@sanity/client` exports the variant definition action types.
-- Replace `_system.variant._ref` document membership queries with `sanity::partOfVariant($variantId)`.
 - Decide how document counts affect deleting variants.
 - Add a delete confirmation or disabled state once variants can have documents.
 - Expand the detail-specific actions menu independently from the overview row menu.

--- a/packages/sanity/src/core/variants/hooks/__tests__/useVariantDocuments.test.ts
+++ b/packages/sanity/src/core/variants/hooks/__tests__/useVariantDocuments.test.ts
@@ -1,0 +1,115 @@
+import {renderHook, waitFor} from '@testing-library/react'
+import {of} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {resetBundleDocumentsCacheForTests} from '../../../releases/tool/detail/useBundleDocuments'
+import {RELEASES_STUDIO_CLIENT_OPTIONS} from '../../../releases/util/releasesClient'
+import {variantAlphaAudience} from '../../__fixtures__/variants.fixture'
+import {useVariantDocuments} from '../useVariantDocuments'
+
+const validateDocumentWithReferencesMock = vi.hoisted(() =>
+  vi.fn(() =>
+    of({
+      isValidating: false,
+      validation: [{level: 'error', message: 'Title is required', path: ['title']}],
+      revision: 'rev-1',
+    }),
+  ),
+)
+
+const documentPreviewStoreMock = vi.hoisted(() => ({
+  unstable_observeDocumentIdSet: vi.fn(() => of({status: 'connected' as const, documentIds: []})),
+  unstable_observeDocument: vi.fn(() => of(null)),
+  unstable_observeDocumentPairAvailability: vi.fn(() =>
+    of({published: {available: true}, draft: {available: true}}),
+  ),
+}))
+
+vi.mock('../../../validation', async (importOriginal) => ({
+  ...(await importOriginal()),
+  validateDocumentWithReferences: validateDocumentWithReferencesMock,
+}))
+
+vi.mock('../../../store/datastores', () => ({
+  useDocumentPreviewStore: vi.fn(() => documentPreviewStoreMock),
+}))
+
+describe('useVariantDocuments', () => {
+  beforeEach(() => {
+    resetBundleDocumentsCacheForTests()
+    validateDocumentWithReferencesMock.mockClear()
+    documentPreviewStoreMock.unstable_observeDocumentIdSet.mockReset()
+    documentPreviewStoreMock.unstable_observeDocument.mockReset()
+    documentPreviewStoreMock.unstable_observeDocumentIdSet.mockReturnValue(
+      of({status: 'connected' as const, documentIds: []}),
+    )
+    documentPreviewStoreMock.unstable_observeDocument.mockReturnValue(of(null))
+  })
+
+  it('returns an empty result when no variant id is provided', async () => {
+    const wrapper = await createTestProvider()
+
+    const {result} = renderHook(() => useVariantDocuments(undefined), {wrapper})
+
+    expect(result.current).toEqual({
+      loading: false,
+      results: [],
+      error: null,
+    })
+    expect(documentPreviewStoreMock.unstable_observeDocumentIdSet).not.toHaveBeenCalled()
+  })
+
+  it('queries variant membership with the fallback _system.variant filter', async () => {
+    const wrapper = await createTestProvider()
+
+    renderHook(() => useVariantDocuments(variantAlphaAudience._id), {wrapper})
+
+    expect(documentPreviewStoreMock.unstable_observeDocumentIdSet).toHaveBeenCalledWith(
+      '_system.variant._ref == $variantId',
+      {variantId: variantAlphaAudience._id},
+      {apiVersion: RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion},
+    )
+  })
+
+  it('validates each variant document and exposes hasError on the result', async () => {
+    const document = {
+      _id: 'drafts.scope.article-1',
+      _type: 'article',
+      _rev: 'rev-1',
+      _createdAt: '2025-06-01T00:00:00Z',
+      _updatedAt: '2025-06-01T00:00:00Z',
+      _system: {
+        bundleId: 'drafts',
+        release: null,
+        variant: {_ref: variantAlphaAudience._id, _weak: true},
+        group: {_ref: 'article-1', _weak: true},
+        scopeId: null,
+      },
+    }
+
+    documentPreviewStoreMock.unstable_observeDocumentIdSet.mockReturnValue(
+      of({status: 'connected' as const, documentIds: [document._id]}),
+    )
+    documentPreviewStoreMock.unstable_observeDocument.mockReturnValue(of(document))
+
+    const wrapper = await createTestProvider()
+    const {result} = renderHook(() => useVariantDocuments(variantAlphaAudience._id), {wrapper})
+
+    await waitFor(() => {
+      expect(result.current.results).toHaveLength(1)
+    })
+
+    expect(validateDocumentWithReferencesMock).toHaveBeenCalled()
+    expect(result.current.results[0]?.validation.hasError).toBe(true)
+    expect(result.current.results[0]?.validation.validation).toEqual([
+      {level: 'error', message: 'Title is required', path: ['title']},
+    ])
+    expect(result.current.results[0]?.version).toEqual({
+      documentId: document._id,
+      bundleId: 'drafts',
+      releaseRef: null,
+      updatedAt: document._updatedAt,
+    })
+  })
+})

--- a/packages/sanity/src/core/variants/hooks/__tests__/useVariantDocuments.test.ts
+++ b/packages/sanity/src/core/variants/hooks/__tests__/useVariantDocuments.test.ts
@@ -60,13 +60,13 @@ describe('useVariantDocuments', () => {
     expect(documentPreviewStoreMock.unstable_observeDocumentIdSet).not.toHaveBeenCalled()
   })
 
-  it('queries variant membership with the fallback _system.variant filter', async () => {
+  it('queries variant membership with sanity::partOfVariant', async () => {
     const wrapper = await createTestProvider()
 
     renderHook(() => useVariantDocuments(variantAlphaAudience._id), {wrapper})
 
     expect(documentPreviewStoreMock.unstable_observeDocumentIdSet).toHaveBeenCalledWith(
-      '_system.variant._ref == $variantId',
+      'sanity::partOfVariant($variantId)',
       {variantId: variantAlphaAudience._id},
       {apiVersion: RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion},
     )

--- a/packages/sanity/src/core/variants/hooks/useVariantDocuments.ts
+++ b/packages/sanity/src/core/variants/hooks/useVariantDocuments.ts
@@ -10,9 +10,8 @@ import {toVariantDocumentVersion} from '../tool/detail/variantDocumentVersion'
 /**
  * Hook to fetch the documents that belong to a variant.
  *
- * Reuses the generic {@link useBundleDocuments} machinery. Currently filters by
- * `_system.variant._ref` until `sanity::partOfVariant($variantId)` is supported
- * in content lake.
+ * Reuses the generic {@link useBundleDocuments} machinery with
+ * `sanity::partOfVariant($variantId)`.
  *
  * @internal
  */

--- a/packages/sanity/src/core/variants/hooks/useVariantDocuments.ts
+++ b/packages/sanity/src/core/variants/hooks/useVariantDocuments.ts
@@ -4,27 +4,49 @@ import {
   type DocumentInRelease,
   useBundleDocuments,
 } from '../../releases/tool/detail/useBundleDocuments'
-import {getVariantId} from '../tool/util'
+import {type DocumentInVariant} from '../tool/detail/types'
+import {toVariantDocumentVersion} from '../tool/detail/variantDocumentVersion'
 
 /**
  * Hook to fetch the documents that belong to a variant.
  *
- * Reuses the generic {@link useBundleDocuments} machinery with
- * `sanity::partOfVariant($variantId)`.
+ * Reuses the generic {@link useBundleDocuments} machinery. Currently filters by
+ * `_system.variant._ref` until `sanity::partOfVariant($variantId)` is supported
+ * in content lake.
  *
  * @internal
  */
-export function useVariantDocuments(variantDocumentId: string): {
+export function useVariantDocuments(variantId: string | undefined): {
   loading: boolean
-  results: DocumentInRelease[]
+  results: DocumentInVariant[]
   error: null | Error
 } {
-  const variantId = getVariantId(variantDocumentId)
-  const params = useMemo(() => ({variantId}), [variantId])
+  const enabled = Boolean(variantId)
+  const params = useMemo(() => ({variantId: variantId ?? ''}), [variantId])
 
-  return useBundleDocuments({
+  const {loading, results, error} = useBundleDocuments({
     groqFilter: `sanity::partOfVariant($variantId)`,
     params,
-    cacheKey: `variant-${variantId}`,
+    cacheKey: enabled ? `variant-${variantId}` : 'variant-disabled',
+    enabled,
+  })
+
+  const variantResults = useMemo(
+    () => (enabled ? toDocumentInVariants(results) : []),
+    [enabled, results],
+  )
+
+  return {
+    loading: enabled && loading,
+    results: variantResults,
+    error: enabled ? error : null,
+  }
+}
+
+function toDocumentInVariants(results: DocumentInRelease[]): DocumentInVariant[] {
+  return results.flatMap((result) => {
+    const version = toVariantDocumentVersion(result.document)
+
+    return version ? [{...result, version}] : []
   })
 }

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -40,8 +40,6 @@ const variantsLocaleStrings = {
   'overview.search.placeholder': 'Search variant definitions…',
   /** Column header for the variant title column in the overview table. */
   'overview.table.variant': 'Variant',
-  /** Column header for document count in the overview table. */
-  'overview.table.documents': 'Documents',
   /** Fallback text when a variant has no conditions. */
   'overview.table.no-conditions': 'No conditions',
   /** Title for the Variants overview. */
@@ -64,12 +62,14 @@ const variantsLocaleStrings = {
   'detail.documents.table.search-placeholder': 'Search documents',
   /** Type column header for variant document table. */
   'detail.documents.table.type': 'Type',
-  /** Version column header for variant document table. */
-  'detail.documents.table.version': 'Version',
-  /** Version chip label for a document that belongs to the published bundle. */
-  'detail.documents.table.version.published': 'Published',
-  /** Version chip label for a document that belongs to the drafts bundle. */
-  'detail.documents.table.version.drafts': 'Drafts',
+  /** Bundle column header for variant document table. */
+  'detail.documents.table.bundle': 'Bundle',
+  /** Validation error tooltip for a single error in the variant document table. */
+  'detail.documents.table.validation.error_one': '{{count}} validation error',
+  /** Validation error tooltip for multiple errors in the variant document table. */
+  'detail.documents.table.validation.error_other': '{{count}} validation errors',
+  /** Error message when variant documents fail to load. */
+  'detail.documents.error': 'Unable to load documents for this variant',
   /** Description for the missing Variant detail page. */
   'detail.not-found.description': 'The requested variant could not be found.',
   /** Title for the missing Variant detail page. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -40,6 +40,8 @@ const variantsLocaleStrings = {
   'overview.search.placeholder': 'Search variant definitions…',
   /** Column header for the variant title column in the overview table. */
   'overview.table.variant': 'Variant',
+  /** Column header for the documents count column in the overview table. */
+  'overview.table.documents': 'Documents',
   /** Fallback text when a variant has no conditions. */
   'overview.table.no-conditions': 'No conditions',
   /** Title for the Variants overview. */

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -60,6 +60,22 @@ vi.mock('../../store/useVariantOperations', () => ({
   useVariantOperations: vi.fn(() => variantOperationsMock),
 }))
 
+vi.mock('../../hooks/useVariantDocuments', () => ({
+  useVariantDocuments: vi.fn(() => ({
+    loading: false,
+    results: [],
+    error: null,
+  })),
+}))
+
+vi.mock('../../../releases/store/useActiveReleases', () => ({
+  useActiveReleases: vi.fn(() => ({
+    data: [],
+    loading: false,
+    error: null,
+  })),
+}))
+
 describe('VariantDetail', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -139,7 +155,7 @@ describe('VariantDetail', () => {
     expect(screen.getByText('audience: "alpha", locale: "en-US"')).toBeInTheDocument()
     expect(screen.getByRole('button', {name: 'Edit variant'})).toBeInTheDocument()
     expect(screen.getByRole('button', {name: 'Back to variants'})).toBeInTheDocument()
-    expect(screen.getByText('Version')).toBeInTheDocument()
+    expect(screen.getByText('Bundle')).toBeInTheDocument()
     expect(screen.getByText('Type')).toBeInTheDocument()
     expect(screen.getByPlaceholderText('Search documents')).toBeInTheDocument()
     expect(screen.getByText('Edited')).toBeInTheDocument()

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -139,7 +139,6 @@ describe('VariantsOverview', () => {
 
     expect(screen.getByText('Alpha audience')).toBeInTheDocument()
     expect(screen.getByText('Norwegian market')).toBeInTheDocument()
-    expect(screen.getAllByText('0')).toHaveLength(2)
   })
 
   it('filters variants when searching by title or condition', async () => {

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsTool.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsTool.test.tsx
@@ -54,6 +54,22 @@ vi.mock('../../store/useAllVariants', () => ({
   })),
 }))
 
+vi.mock('../../hooks/useVariantDocuments', () => ({
+  useVariantDocuments: vi.fn(() => ({
+    loading: false,
+    results: [],
+    error: null,
+  })),
+}))
+
+vi.mock('../../../releases/store/useActiveReleases', () => ({
+  useActiveReleases: vi.fn(() => ({
+    data: [],
+    loading: false,
+    error: null,
+  })),
+}))
+
 setupVirtualListEnv()
 
 describe('VariantsTool', () => {

--- a/packages/sanity/src/core/variants/tool/__tests__/util.test.ts
+++ b/packages/sanity/src/core/variants/tool/__tests__/util.test.ts
@@ -91,14 +91,16 @@ describe('variants tool utilities', () => {
     ])
   })
 
-  it('treats undefined bundle ids as published', () => {
+  it('treats undefined and published bundle ids as published', () => {
     expect(isPublishedBundleId(undefined)).toBe(true)
+    expect(isPublishedBundleId('published')).toBe(true)
     expect(isPublishedBundleId('drafts')).toBe(false)
     expect(isPublishedBundleId('rASAP')).toBe(false)
   })
 
   it('identifies release bundle ids', () => {
     expect(isReleaseBundle(undefined)).toBe(false)
+    expect(isReleaseBundle('published')).toBe(false)
     expect(isReleaseBundle('drafts')).toBe(false)
     expect(isReleaseBundle('rASAP')).toBe(true)
   })

--- a/packages/sanity/src/core/variants/tool/__tests__/util.test.ts
+++ b/packages/sanity/src/core/variants/tool/__tests__/util.test.ts
@@ -9,6 +9,8 @@ import {
   getVariantDescription,
   getVariantId,
   getVariantTitle,
+  isPublishedBundleId,
+  isReleaseBundle,
 } from '../util'
 
 describe('variants tool utilities', () => {
@@ -87,5 +89,17 @@ describe('variants tool utilities', () => {
     expect(filterVariantsForSearch([developerVariant, localeVariant], 'nb-no')).toEqual([
       localeVariant,
     ])
+  })
+
+  it('treats undefined bundle ids as published', () => {
+    expect(isPublishedBundleId(undefined)).toBe(true)
+    expect(isPublishedBundleId('drafts')).toBe(false)
+    expect(isPublishedBundleId('rASAP')).toBe(false)
+  })
+
+  it('identifies release bundle ids', () => {
+    expect(isReleaseBundle(undefined)).toBe(false)
+    expect(isReleaseBundle('drafts')).toBe(false)
+    expect(isReleaseBundle('rASAP')).toBe(true)
   })
 })

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
@@ -13,8 +13,10 @@ import {
   decodeVariantIdFromRoute,
   getVariantConditionsText,
   getVariantDescription,
+  getVariantId,
   getVariantTitle,
 } from '../util'
+import {groupVariantDocumentsByGroup} from './groupVariantDocumentsByGroup'
 import {VariantDetailFooter} from './VariantDetailFooter'
 import {VariantDocumentsTable} from './VariantDocumentsTable'
 
@@ -28,12 +30,14 @@ export function VariantDetail() {
   const {byId, loading} = useAllVariants()
 
   const variant = variantId ? byId.get(variantId) : undefined
+  const {
+    loading: documentsLoading,
+    results: variantDocuments,
+    error: variantDocumentsError,
+  } = useVariantDocuments(variant?._id)
 
-  const {results: variantDocuments, loading: documentsLoading} = useVariantDocuments(
-    variantId ?? '',
-  )
-  const documents = useMemo(
-    () => variantDocuments.map((result) => result.document),
+  const tableRows = useMemo(
+    () => groupVariantDocumentsByGroup(variantDocuments),
     [variantDocuments],
   )
 
@@ -104,7 +108,19 @@ export function VariantDetail() {
           </Flex>
         </Container>
         <Flex direction="column" flex={1} overflow="hidden" style={{minHeight: 0}}>
-          <VariantDocumentsTable documents={documents} loading={documentsLoading} />
+          {variantDocumentsError ? (
+            <Box padding={4}>
+              <Text muted size={1}>
+                {t('detail.documents.error')}
+              </Text>
+            </Box>
+          ) : (
+            <VariantDocumentsTable
+              loading={documentsLoading}
+              rows={tableRows}
+              variantId={getVariantId(variant._id)}
+            />
+          )}
         </Flex>
       </Flex>
       <VariantDetailFooter variant={variant} />

--- a/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
@@ -2,6 +2,7 @@ import {Card} from '@sanity/ui'
 import {type CSSProperties, useMemo, useState} from 'react'
 
 import {useTranslation} from '../../../i18n'
+import {useActiveReleases} from '../../../releases/store/useActiveReleases'
 import {Table} from '../../../releases/tool/components/Table/Table'
 import {type Column} from '../../../releases/tool/components/Table/types'
 import {searchDocumentRelease} from '../../../releases/tool/detail/documentTable/searchDocumentRelease'
@@ -36,9 +37,14 @@ export function VariantDocumentsTable({
 }): React.JSX.Element {
   const {t} = useTranslation(variantsLocaleNamespace)
   const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(null)
+  const {data: releases} = useActiveReleases()
+  const releasesById = useMemo(
+    () => new Map(releases.map((release) => [release._id, release])),
+    [releases],
+  )
   const columnDefs = useMemo<Column<DocumentInVariantGroup>[]>(
-    () => getVariantDocumentTableColumnDefs(t, variantId),
-    [t, variantId],
+    () => getVariantDocumentTableColumnDefs(t, variantId, releasesById),
+    [t, variantId, releasesById],
   )
 
   return (

--- a/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
@@ -1,212 +1,28 @@
-import {type ReleaseDocument, type SanityDocument} from '@sanity/client'
-import {type DocumentSystem} from '@sanity/types'
-import {Badge, type BadgeTone, Box, Card, Flex, Text} from '@sanity/ui'
-import {type CSSProperties, memo, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
+import {Card} from '@sanity/ui'
+import {type CSSProperties, useMemo, useState} from 'react'
 
-import {RelativeTime} from '../../../components/RelativeTime'
-import {useSchema} from '../../../hooks'
-import {type UseTranslationResponse, useTranslation} from '../../../i18n'
-import {SanityDefaultPreview} from '../../../preview/components/SanityDefaultPreview'
-import {useReleasesStore} from '../../../releases/store/useReleasesStore'
+import {useTranslation} from '../../../i18n'
 import {Table} from '../../../releases/tool/components/Table/Table'
-import {Headers} from '../../../releases/tool/components/Table/TableHeader'
 import {type Column} from '../../../releases/tool/components/Table/types'
-import {getReleaseIdFromReleaseDocumentId} from '../../../releases/util/getReleaseIdFromReleaseDocumentId'
-import {getReleaseTitleDetails} from '../../../releases/util/getReleaseTitleDetails'
-import {getReleaseTone} from '../../../releases/util/getReleaseTone'
 import {variantsLocaleNamespace} from '../../i18n'
-
-interface VariantDocumentVersion {
-  label: string
-  tone: BadgeTone
-}
-
-interface VariantDocumentRow {
-  document: SanityDocument
-  version: VariantDocumentVersion
-}
-
-/**
- * Derives the bundle a variant document belongs to from its `_system` metadata and returns the
- * label and tone for its version chip. Variant documents are scoped to both a variant and a bundle
- * (a release, the published bundle, or drafts).
- */
-function getVariantDocumentVersion({
-  document,
-  releasesById,
-  t,
-}: {
-  document: SanityDocument
-  releasesById: Map<string, ReleaseDocument> | undefined
-  t: UseTranslationResponse<'variants', undefined>['t']
-}): VariantDocumentVersion {
-  const system = document._system as DocumentSystem | undefined
-  const releaseRef = system?.release?._ref
-
-  if (releaseRef) {
-    const release = releasesById?.get(releaseRef)
-
-    if (release) {
-      const {displayTitle} = getReleaseTitleDetails(
-        release.metadata?.title,
-        getReleaseIdFromReleaseDocumentId(release._id),
-      )
-
-      return {label: displayTitle, tone: getReleaseTone(release)}
-    }
-
-    return {label: getReleaseIdFromReleaseDocumentId(releaseRef), tone: 'default'}
-  }
-
-  if (system?.bundleId === 'drafts') {
-    return {label: t('detail.documents.table.version.drafts'), tone: getReleaseTone('drafts')}
-  }
-
-  return {label: t('detail.documents.table.version.published'), tone: getReleaseTone('published')}
-}
+import {type DocumentInVariantGroup} from './types'
+import {getVariantDocumentTableColumnDefs} from './variantDocumentTable/VariantDocumentTableColumnDefs'
 
 const TABLE_CARD_STYLE: CSSProperties = {
   height: '100%',
   overflow: 'auto',
 }
 
-function getDocumentPreviewTitle(document: SanityDocument): string {
+function getDocumentPreviewTitle(document: DocumentInVariantGroup['document']): string {
   const title = document.title || document.name
 
   return typeof title === 'string' && title.trim() ? title : document._id
 }
 
-const MemoDocumentType = memo(
-  function DocumentType({type}: {type: string}) {
-    const schema = useSchema()
-    const schemaType = schema.get(type)
-
-    return <Text size={1}>{schemaType?.title || type}</Text>
-  },
-  (prev, next) => prev.type === next.type,
-)
-
-function getVariantDocumentVersionSortRank(document: SanityDocument): number {
-  const system = document._system as DocumentSystem | undefined
-
-  if (system?.release?._ref) {
-    return 2
-  }
-
-  if (system?.bundleId === 'drafts') {
-    return 1
-  }
-
-  return 0
-}
-
-function getVariantDocumentGroupSortKey({document, version}: VariantDocumentRow): string {
-  const groupRef = (document._system as DocumentSystem | undefined)?.group._ref ?? document._id
-  const versionRank = getVariantDocumentVersionSortRank(document)
-
-  // Group by document family, then order versions Published → Drafts → Releases.
-  return `${groupRef}\0${versionRank}\0${version.label}\0${document._id}`
-}
-
-function getVariantDocumentColumnDefs(
-  t: UseTranslationResponse<'variants', undefined>['t'],
-): Column<VariantDocumentRow>[] {
-  return [
-    {
-      id: 'documentGroup',
-      hidden: true,
-      width: null,
-      sorting: true,
-      sortTransform: getVariantDocumentGroupSortKey,
-    },
-    {
-      id: 'version',
-      width: null,
-      style: {minWidth: 100},
-      sorting: false,
-      header: (props) => (
-        <Flex {...props.headerProps} paddingY={3} sizing="border">
-          <Headers.BasicHeader text={t('detail.documents.table.version')} />
-        </Flex>
-      ),
-      cell: ({cellProps, datum}) => (
-        <Flex align="center" {...cellProps}>
-          <Box paddingX={2}>
-            {!datum.isLoading && datum.version && (
-              <Badge fontSize={1} mode="outline" radius={2} tone={datum.version.tone}>
-                {datum.version.label}
-              </Badge>
-            )}
-          </Box>
-        </Flex>
-      ),
-    },
-    {
-      id: 'document._type',
-      width: null,
-      style: {minWidth: 100},
-      sorting: true,
-      header: (props) => (
-        <Flex {...props.headerProps} paddingY={3} sizing="border">
-          <Headers.SortHeaderButton text={t('detail.documents.table.type')} {...props} />
-        </Flex>
-      ),
-      cell: ({cellProps, datum}) => (
-        <Flex align="center" {...cellProps}>
-          <Box paddingX={2}>
-            {!datum.isLoading && <MemoDocumentType type={datum.document._type} />}
-          </Box>
-        </Flex>
-      ),
-    },
-    {
-      id: 'search',
-      width: null,
-      style: {minWidth: 'min(50%, calc(100vw - 80px))', maxWidth: 'min(50%, calc(100vw - 80px))'},
-      sortTransform: ({document}) => getDocumentPreviewTitle(document).toLowerCase(),
-      header: (props) => (
-        <Headers.TableHeaderSearch
-          {...props}
-          placeholder={t('detail.documents.table.search-placeholder')}
-        />
-      ),
-      cell: ({cellProps, datum}) => (
-        <Box {...cellProps} flex={1} padding={1} paddingRight={2} sizing="border">
-          {datum.isLoading ? (
-            <SanityDefaultPreview isPlaceholder />
-          ) : (
-            <SanityDefaultPreview
-              title={getDocumentPreviewTitle(datum.document)}
-              subtitle={datum.document._id}
-            />
-          )}
-        </Box>
-      ),
-    },
-    {
-      id: 'document._updatedAt',
-      sorting: true,
-      width: 130,
-      header: (props) => (
-        <Flex {...props.headerProps} paddingY={3} sizing="border">
-          <Headers.SortHeaderButton text={t('detail.documents.table.edited')} {...props} />
-        </Flex>
-      ),
-      cell: ({cellProps, datum}) => (
-        <Flex {...cellProps} align="center" paddingX={2} paddingY={3} style={{minWidth: 130}}>
-          {!datum.isLoading && datum.document._updatedAt && (
-            <Text muted size={1}>
-              <RelativeTime time={datum.document._updatedAt} useTemporalPhrase minimal />
-            </Text>
-          )}
-        </Flex>
-      ),
-    },
-  ]
-}
-
-function filterDocuments(rows: VariantDocumentRow[], searchTerm: string): VariantDocumentRow[] {
+function filterDocuments(
+  rows: DocumentInVariantGroup[],
+  searchTerm: string,
+): DocumentInVariantGroup[] {
   const normalizedSearchTerm = searchTerm.trim().toLowerCase()
 
   if (!normalizedSearchTerm) {
@@ -221,37 +37,30 @@ function filterDocuments(rows: VariantDocumentRow[], searchTerm: string): Varian
 }
 
 export function VariantDocumentsTable({
-  documents,
+  rows,
   loading = false,
+  variantId,
 }: {
-  documents: SanityDocument[]
+  rows: DocumentInVariantGroup[]
   loading?: boolean
+  variantId?: string
 }): React.JSX.Element {
   const {t} = useTranslation(variantsLocaleNamespace)
   const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(null)
-  const {state$} = useReleasesStore()
-  const releasesState = useObservable(state$)
-  const releasesById = releasesState?.releases
-  const columnDefs = useMemo(() => getVariantDocumentColumnDefs(t), [t])
-  const rows = useMemo(
-    () =>
-      documents.map((document) => ({
-        document,
-        version: getVariantDocumentVersion({document, releasesById, t}),
-      })),
-    [documents, releasesById, t],
+  const columnDefs = useMemo<Column<DocumentInVariantGroup>[]>(
+    () => getVariantDocumentTableColumnDefs(t, variantId),
+    [t, variantId],
   )
 
   return (
     <Card flex={1} ref={setScrollContainerRef} style={TABLE_CARD_STYLE}>
-      <Table<VariantDocumentRow>
+      <Table<DocumentInVariantGroup>
         columnDefs={columnDefs}
         data={rows}
-        defaultSort={{column: 'documentGroup', direction: 'asc'}}
         emptyState={t('detail.documents.no-documents')}
         loading={loading}
         // oxlint-disable-next-line @sanity/i18n/no-attribute-string-literals
-        rowId="document._id"
+        rowId="groupId"
         scrollContainerRef={scrollContainerRef}
         searchFilter={filterDocuments}
       />

--- a/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
@@ -6,17 +6,12 @@ import {Table} from '../../../releases/tool/components/Table/Table'
 import {type Column} from '../../../releases/tool/components/Table/types'
 import {variantsLocaleNamespace} from '../../i18n'
 import {type DocumentInVariantGroup} from './types'
+import {getDocumentPreviewTitle} from './variantDocumentTable/getDocumentPreviewTitle'
 import {getVariantDocumentTableColumnDefs} from './variantDocumentTable/VariantDocumentTableColumnDefs'
 
 const TABLE_CARD_STYLE: CSSProperties = {
   height: '100%',
   overflow: 'auto',
-}
-
-function getDocumentPreviewTitle(document: DocumentInVariantGroup['document']): string {
-  const title = document.title || document.name
-
-  return typeof title === 'string' && title.trim() ? title : document._id
 }
 
 function filterDocuments(
@@ -57,6 +52,7 @@ export function VariantDocumentsTable({
       <Table<DocumentInVariantGroup>
         columnDefs={columnDefs}
         data={rows}
+        defaultSort={{column: 'documentGroup', direction: 'asc'}}
         emptyState={t('detail.documents.no-documents')}
         loading={loading}
         // oxlint-disable-next-line @sanity/i18n/no-attribute-string-literals

--- a/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
@@ -4,9 +4,9 @@ import {type CSSProperties, useMemo, useState} from 'react'
 import {useTranslation} from '../../../i18n'
 import {Table} from '../../../releases/tool/components/Table/Table'
 import {type Column} from '../../../releases/tool/components/Table/types'
+import {searchDocumentRelease} from '../../../releases/tool/detail/documentTable/searchDocumentRelease'
 import {variantsLocaleNamespace} from '../../i18n'
 import {type DocumentInVariantGroup} from './types'
-import {getDocumentPreviewTitle} from './variantDocumentTable/getDocumentPreviewTitle'
 import {getVariantDocumentTableColumnDefs} from './variantDocumentTable/VariantDocumentTableColumnDefs'
 
 const TABLE_CARD_STYLE: CSSProperties = {
@@ -18,17 +18,11 @@ function filterDocuments(
   rows: DocumentInVariantGroup[],
   searchTerm: string,
 ): DocumentInVariantGroup[] {
-  const normalizedSearchTerm = searchTerm.trim().toLowerCase()
-
-  if (!normalizedSearchTerm) {
+  if (!searchTerm.trim()) {
     return rows
   }
 
-  return rows.filter(({document}) =>
-    [getDocumentPreviewTitle(document), document._id, document._type].some((value) =>
-      value.toLowerCase().includes(normalizedSearchTerm),
-    ),
-  )
+  return rows.filter(({document}) => searchDocumentRelease(document, searchTerm))
 }
 
 export function VariantDocumentsTable({

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentBundleChips.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentBundleChips.test.tsx
@@ -1,0 +1,85 @@
+import {render, screen} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {type DocumentInVariantGroup} from '../types'
+import {VariantDocumentBundleChips} from '../variantDocumentTable/VariantDocumentBundleChips'
+
+vi.mock('sanity/router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  IntentLink: vi.fn(({children, intent, searchParams, params, ...props}) => (
+    <a data-testid="release-intent-link" data-intent={intent} {...props}>
+      {children}
+    </a>
+  )),
+}))
+
+const activeRelease = {
+  _id: '_.releases.rASAP',
+  _type: 'system.release',
+  _rev: 'rev-1',
+  _createdAt: '2025-01-01T00:00:00Z',
+  _updatedAt: '2025-01-01T00:00:00Z',
+  state: 'active',
+  metadata: {
+    title: 'Summer launch',
+    releaseType: 'asap',
+  },
+} as const
+
+vi.mock('../../../../releases/store/useActiveReleases', () => ({
+  useActiveReleases: vi.fn(() => ({
+    data: [activeRelease],
+    loading: false,
+    error: null,
+  })),
+}))
+
+const groupedRow: DocumentInVariantGroup = {
+  memoKey: 'group-1',
+  groupId: 'article-1',
+  document: {
+    _id: 'published.scope.article-1',
+    _type: 'article',
+    _rev: 'rev-1',
+    _createdAt: '2025-06-01T00:00:00Z',
+    _updatedAt: '2025-06-03T00:00:00Z',
+  },
+  version: {
+    documentId: 'published.scope.article-1',
+    releaseRef: null,
+    updatedAt: '2025-06-03T00:00:00Z',
+  },
+  versions: [
+    {
+      documentId: 'published.scope.article-1',
+      releaseRef: null,
+      updatedAt: '2025-06-03T00:00:00Z',
+    },
+    {
+      documentId: 'drafts.scope.article-1',
+      bundleId: 'drafts',
+      releaseRef: null,
+      updatedAt: '2025-06-01T00:00:00Z',
+    },
+    {
+      documentId: 'versions.rASAP.scope.article-1',
+      bundleId: 'rASAP',
+      releaseRef: '_.releases.rASAP',
+      updatedAt: '2025-06-02T00:00:00Z',
+    },
+  ],
+}
+
+describe('VariantDocumentBundleChips', () => {
+  it('renders published, draft, and linked release chips', async () => {
+    const wrapper = await createTestProvider()
+
+    render(<VariantDocumentBundleChips versions={groupedRow.versions} />, {wrapper})
+
+    expect(screen.getByText('Published')).toBeInTheDocument()
+    expect(screen.getByText('Draft')).toBeInTheDocument()
+    expect(screen.getByText('Summer launch')).toBeInTheDocument()
+    expect(screen.getByTestId('release-intent-link')).toHaveAttribute('data-intent', 'release')
+  })
+})

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentBundleChips.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentBundleChips.test.tsx
@@ -27,13 +27,7 @@ const activeRelease = {
   },
 } as const
 
-vi.mock('../../../../releases/store/useActiveReleases', () => ({
-  useActiveReleases: vi.fn(() => ({
-    data: [activeRelease],
-    loading: false,
-    error: null,
-  })),
-}))
+const releasesById = new Map([[activeRelease._id, activeRelease]])
 
 const groupedRow: DocumentInVariantGroup = {
   memoKey: 'group-1',
@@ -75,7 +69,10 @@ describe('VariantDocumentBundleChips', () => {
   it('renders published, draft, and linked release chips', async () => {
     const wrapper = await createTestProvider()
 
-    render(<VariantDocumentBundleChips versions={groupedRow.versions} />, {wrapper})
+    render(
+      <VariantDocumentBundleChips versions={groupedRow.versions} releasesById={releasesById} />,
+      {wrapper},
+    )
 
     expect(screen.getByText('Published')).toBeInTheDocument()
     expect(screen.getByText('Draft')).toBeInTheDocument()

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentPreview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentPreview.test.tsx
@@ -1,0 +1,103 @@
+import {render} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {type DocumentInVariantGroup} from '../types'
+import {VariantDocumentPreview} from '../variantDocumentTable/VariantDocumentPreview'
+
+const intentLinkMock = vi.fn(({children, intent, searchParams, params, ...props}) => (
+  <a data-testid="edit-intent-link" data-intent={intent} {...props}>
+    {children}
+  </a>
+))
+
+vi.mock('sanity/router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  IntentLink: (props: React.ComponentProps<'a'>) => intentLinkMock(props),
+}))
+
+vi.mock('../../../../preview/components/SanityDefaultPreview', () => ({
+  SanityDefaultPreview: vi.fn(() => <div data-testid="preview" />),
+}))
+
+vi.mock('../../../../tasks/hooks/useDocumentPreviewValues', () => ({
+  useDocumentPreviewValues: vi.fn(() => ({isLoading: false, value: {title: 'Article'}})),
+}))
+
+vi.mock('../../../../store/presence/useDocumentPresence', () => ({
+  useDocumentPresence: vi.fn(() => []),
+}))
+
+const createRow = (
+  bundleId: DocumentInVariantGroup['version']['bundleId'],
+): DocumentInVariantGroup => ({
+  memoKey: 'group-1',
+  groupId: 'article-1',
+  document: {
+    _id: 'drafts.scope.article-1',
+    _type: 'article',
+    _rev: 'rev-1',
+    _createdAt: '2025-06-01T00:00:00Z',
+    _updatedAt: '2025-06-01T00:00:00Z',
+  },
+  version: {
+    documentId: 'drafts.scope.article-1',
+    bundleId,
+    releaseRef: bundleId === 'rASAP' ? '_.releases.rASAP' : null,
+    updatedAt: '2025-06-01T00:00:00Z',
+  },
+  versions: [],
+})
+
+const VARIANT_ID = 'alpha-audience'
+
+describe('VariantDocumentPreview', () => {
+  beforeEach(() => {
+    intentLinkMock.mockClear()
+  })
+
+  it('omits perspective search params for drafts', async () => {
+    const wrapper = await createTestProvider()
+
+    render(<VariantDocumentPreview row={createRow('drafts')} variantId={VARIANT_ID} />, {wrapper})
+
+    expect(intentLinkMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: 'edit',
+        searchParams: [['variant', VARIANT_ID]],
+      }),
+    )
+  })
+
+  it('adds perspective=published for published bundle versions', async () => {
+    const wrapper = await createTestProvider()
+
+    render(<VariantDocumentPreview row={createRow(undefined)} variantId={VARIANT_ID} />, {
+      wrapper,
+    })
+
+    expect(intentLinkMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        searchParams: [
+          ['variant', VARIANT_ID],
+          ['perspective', 'published'],
+        ],
+      }),
+    )
+  })
+
+  it('adds perspective=<releaseId> for release bundle versions', async () => {
+    const wrapper = await createTestProvider()
+
+    render(<VariantDocumentPreview row={createRow('rASAP')} variantId={VARIANT_ID} />, {wrapper})
+
+    expect(intentLinkMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        searchParams: [
+          ['variant', VARIANT_ID],
+          ['perspective', 'rASAP'],
+        ],
+      }),
+    )
+  })
+})

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentPreview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentPreview.test.tsx
@@ -11,6 +11,8 @@ const intentLinkMock = vi.fn(({children, intent, searchParams, params, ...props}
   </a>
 ))
 
+const useDocumentPreviewValuesMock = vi.fn(() => ({isLoading: false, value: {title: 'Article'}}))
+
 vi.mock('sanity/router', async (importOriginal) => ({
   ...(await importOriginal()),
   IntentLink: (props: React.ComponentProps<'a'>) => intentLinkMock(props),
@@ -21,7 +23,7 @@ vi.mock('../../../../preview/components/SanityDefaultPreview', () => ({
 }))
 
 vi.mock('../../../../tasks/hooks/useDocumentPreviewValues', () => ({
-  useDocumentPreviewValues: vi.fn(() => ({isLoading: false, value: {title: 'Article'}})),
+  useDocumentPreviewValues: (...args: unknown[]) => useDocumentPreviewValuesMock(...args),
 }))
 
 vi.mock('../../../../store/presence/useDocumentPresence', () => ({
@@ -54,6 +56,7 @@ const VARIANT_ID = 'alpha-audience'
 describe('VariantDocumentPreview', () => {
   beforeEach(() => {
     intentLinkMock.mockClear()
+    useDocumentPreviewValuesMock.mockClear()
   })
 
   it('omits perspective search params for drafts', async () => {
@@ -97,6 +100,42 @@ describe('VariantDocumentPreview', () => {
           ['variant', VARIANT_ID],
           ['perspective', 'rASAP'],
         ],
+      }),
+    )
+  })
+
+  it('resolves previews in the published perspective stack', async () => {
+    const wrapper = await createTestProvider()
+
+    render(<VariantDocumentPreview row={createRow(undefined)} variantId={VARIANT_ID} />, {wrapper})
+
+    expect(useDocumentPreviewValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        perspectiveStack: ['published'],
+      }),
+    )
+  })
+
+  it('resolves previews in the drafts perspective stack', async () => {
+    const wrapper = await createTestProvider()
+
+    render(<VariantDocumentPreview row={createRow('drafts')} variantId={VARIANT_ID} />, {wrapper})
+
+    expect(useDocumentPreviewValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        perspectiveStack: ['drafts'],
+      }),
+    )
+  })
+
+  it('resolves previews in the release perspective stack with drafts fallback', async () => {
+    const wrapper = await createTestProvider()
+
+    render(<VariantDocumentPreview row={createRow('rASAP')} variantId={VARIANT_ID} />, {wrapper})
+
+    expect(useDocumentPreviewValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        perspectiveStack: ['rASAP', 'drafts'],
       }),
     )
   })

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
@@ -138,7 +138,7 @@ describe('VariantDocumentsTable', () => {
     expect(screen.getByText('Bundle')).toBeInTheDocument()
   })
 
-  it('filters documents when searching by title, id, or type', async () => {
+  it('filters documents when searching by title or name', async () => {
     const user = userEvent.setup()
 
     await renderTable()
@@ -190,24 +190,24 @@ describe('VariantDocumentsTable', () => {
     expect(renderedTitles).toEqual(['Alpha article', 'Zulu article'])
   })
 
-  it('finds whitespace-only titles by document id when searching', async () => {
+  it('finds documents by name when title is missing', async () => {
     const user = userEvent.setup()
     const rows: DocumentInVariantGroup[] = [
       {
         ...mockRows[0]!,
-        groupId: 'article-whitespace',
-        memoKey: 'group-whitespace',
+        groupId: 'article-named',
+        memoKey: 'group-named',
         document: {
           ...mockRows[0]!.document,
-          _id: 'drafts.scope.article-whitespace',
-          title: '   ',
+          title: undefined,
+          name: 'Named article',
         },
       },
     ]
 
     await renderTable(rows)
 
-    await user.type(screen.getByPlaceholderText('Search documents'), 'article-whitespace')
+    await user.type(screen.getByPlaceholderText('Search documents'), 'Named')
 
     await waitFor(() => {
       expect(screen.getAllByTestId('table-row')).toHaveLength(1)

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
@@ -31,6 +31,14 @@ vi.mock('../variantDocumentTable/VariantDocumentBundleChips', () => ({
   )),
 }))
 
+vi.mock('../../../../releases/store/useActiveReleases', () => ({
+  useActiveReleases: vi.fn(() => ({
+    data: [],
+    loading: false,
+    error: null,
+  })),
+}))
+
 setupVirtualListEnv()
 
 const defaultValidation = {

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
@@ -156,4 +156,61 @@ describe('VariantDocumentsTable', () => {
     expect(screen.getByText('Second article')).toBeInTheDocument()
     expect(screen.queryByText('First article')).not.toBeInTheDocument()
   })
+
+  it('sorts grouped rows by document group id on first load', async () => {
+    const rows: DocumentInVariantGroup[] = [
+      {
+        ...mockRows[1]!,
+        groupId: 'z-group',
+        memoKey: 'group-z',
+        document: {
+          ...mockRows[1]!.document,
+          title: 'Zulu article',
+        },
+      },
+      {
+        ...mockRows[0]!,
+        groupId: 'a-group',
+        memoKey: 'group-a',
+        document: {
+          ...mockRows[0]!.document,
+          title: 'Alpha article',
+        },
+      },
+    ]
+
+    await renderTable(rows)
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(2)
+    })
+
+    const renderedTitles = screen.getAllByTestId('preview').map((node) => node.textContent)
+
+    expect(renderedTitles).toEqual(['Alpha article', 'Zulu article'])
+  })
+
+  it('finds whitespace-only titles by document id when searching', async () => {
+    const user = userEvent.setup()
+    const rows: DocumentInVariantGroup[] = [
+      {
+        ...mockRows[0]!,
+        groupId: 'article-whitespace',
+        memoKey: 'group-whitespace',
+        document: {
+          ...mockRows[0]!.document,
+          _id: 'drafts.scope.article-whitespace',
+          title: '   ',
+        },
+      },
+    ]
+
+    await renderTable(rows)
+
+    await user.type(screen.getByPlaceholderText('Search documents'), 'article-whitespace')
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(1)
+    })
+  })
 })

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
@@ -1,5 +1,3 @@
-import {type SanityDocument} from '@sanity/client'
-import {type DocumentSystem} from '@sanity/types'
 import {render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
 import {describe, expect, it, vi} from 'vitest'
@@ -7,6 +5,7 @@ import {describe, expect, it, vi} from 'vitest'
 import {setupVirtualListEnv} from '../../../../../../test/testUtils/setupVirtualListEnv'
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
 import {variantsUsEnglishLocaleBundle} from '../../../i18n'
+import {type DocumentInVariantGroup} from '../types'
 import {VariantDocumentsTable} from '../VariantDocumentsTable'
 
 vi.mock('../../../../preview/components/SanityDefaultPreview', () => ({
@@ -18,35 +17,95 @@ vi.mock('../../../../preview/components/SanityDefaultPreview', () => ({
   )),
 }))
 
+vi.mock('../variantDocumentTable/VariantDocumentPreview', () => ({
+  VariantDocumentPreview: vi.fn(({row}) => (
+    <div data-testid="preview">{row.document.title || row.document._id}</div>
+  )),
+}))
+
+vi.mock('../variantDocumentTable/VariantDocumentBundleChips', () => ({
+  VariantDocumentBundleChips: vi.fn(({versions}) => (
+    <div data-testid="bundle-chips">
+      {versions.map((version) => version.bundleId ?? 'published').join(',')}
+    </div>
+  )),
+}))
+
 setupVirtualListEnv()
 
-const mockDocuments: SanityDocument[] = [
+const defaultValidation = {
+  hasError: false,
+  isValidating: false,
+  validation: [],
+} as const
+
+const mockRows: DocumentInVariantGroup[] = [
   {
-    _id: 'drafts.article-first',
-    _type: 'article',
-    _rev: 'rev-1',
-    _createdAt: '2025-01-01T00:00:00Z',
-    _updatedAt: '2025-06-01T00:00:00Z',
-    title: 'First article',
+    memoKey: 'group-1',
+    groupId: 'article-1',
+    validation: defaultValidation,
+    document: {
+      _id: 'published.scope.article-1',
+      _type: 'article',
+      _rev: 'rev-1',
+      _createdAt: '2025-01-01T00:00:00Z',
+      _updatedAt: '2025-06-01T00:00:00Z',
+      title: 'First article',
+    },
+    version: {
+      documentId: 'published.scope.article-1',
+      releaseRef: null,
+      updatedAt: '2025-06-01T00:00:00Z',
+    },
+    versions: [
+      {
+        documentId: 'published.scope.article-1',
+        releaseRef: null,
+        updatedAt: '2025-06-01T00:00:00Z',
+      },
+      {
+        documentId: 'drafts.scope.article-1',
+        bundleId: 'drafts',
+        releaseRef: null,
+        updatedAt: '2025-05-01T00:00:00Z',
+      },
+    ],
   },
   {
-    _id: 'drafts.article-second',
-    _type: 'article',
-    _rev: 'rev-2',
-    _createdAt: '2025-01-02T00:00:00Z',
-    _updatedAt: '2025-06-02T00:00:00Z',
-    title: 'Second article',
+    memoKey: 'group-2',
+    groupId: 'article-2',
+    validation: defaultValidation,
+    document: {
+      _id: 'drafts.scope.article-2',
+      _type: 'article',
+      _rev: 'rev-2',
+      _createdAt: '2025-01-02T00:00:00Z',
+      _updatedAt: '2025-06-02T00:00:00Z',
+      title: 'Second article',
+    },
+    version: {
+      documentId: 'drafts.scope.article-2',
+      bundleId: 'drafts',
+      releaseRef: null,
+      updatedAt: '2025-06-02T00:00:00Z',
+    },
+    versions: [
+      {
+        documentId: 'drafts.scope.article-2',
+        bundleId: 'drafts',
+        releaseRef: null,
+        updatedAt: '2025-06-02T00:00:00Z',
+      },
+    ],
   },
 ]
 
 describe('VariantDocumentsTable', () => {
-  const renderTable = async (documents: SanityDocument[] = mockDocuments, loading = false) => {
+  const renderTable = async (rows: DocumentInVariantGroup[] = mockRows, loading = false) => {
     const wrapper = await createTestProvider({
       resources: [variantsUsEnglishLocaleBundle],
     })
-    const result = render(<VariantDocumentsTable documents={documents} loading={loading} />, {
-      wrapper,
-    })
+    const result = render(<VariantDocumentsTable rows={rows} loading={loading} />, {wrapper})
     await screen.findByPlaceholderText('Search documents')
     return result
   }
@@ -64,7 +123,7 @@ describe('VariantDocumentsTable', () => {
     expect(screen.queryByText('No documents in this variant')).not.toBeInTheDocument()
   })
 
-  it('renders document rows with title, type, and edited columns', async () => {
+  it('renders document rows with bundle, title, type, and edited columns', async () => {
     await renderTable()
 
     await waitFor(() => {
@@ -73,8 +132,10 @@ describe('VariantDocumentsTable', () => {
 
     expect(screen.getByText('First article')).toBeInTheDocument()
     expect(screen.getByText('Second article')).toBeInTheDocument()
-    expect(screen.getByText('drafts.article-first')).toBeInTheDocument()
     expect(screen.getAllByText('article')).toHaveLength(2)
+    expect(screen.getByText('published,drafts')).toBeInTheDocument()
+    expect(screen.getByText('drafts')).toBeInTheDocument()
+    expect(screen.getByText('Bundle')).toBeInTheDocument()
   })
 
   it('filters documents when searching by title, id, or type', async () => {
@@ -94,58 +155,5 @@ describe('VariantDocumentsTable', () => {
 
     expect(screen.getByText('Second article')).toBeInTheDocument()
     expect(screen.queryByText('First article')).not.toBeInTheDocument()
-  })
-
-  it('groups documents by their document group ref', async () => {
-    const sharedGroupRef = 'article-group'
-    const groupedDocuments: SanityDocument[] = [
-      {
-        _id: 'versions.summer.article-a',
-        _type: 'article',
-        _rev: 'rev-1',
-        _createdAt: '2025-01-01T00:00:00Z',
-        _updatedAt: '2025-06-01T00:00:00Z',
-        title: 'Summer article',
-        _system: {
-          group: {_ref: sharedGroupRef, _weak: true},
-          bundleId: 'drafts',
-        } satisfies DocumentSystem,
-      },
-      {
-        _id: 'article-other',
-        _type: 'article',
-        _rev: 'rev-2',
-        _createdAt: '2025-01-02T00:00:00Z',
-        _updatedAt: '2025-06-02T00:00:00Z',
-        title: 'Other article',
-        _system: {
-          group: {_ref: 'other-group', _weak: true},
-          bundleId: 'drafts',
-        } satisfies DocumentSystem,
-      },
-      {
-        _id: 'versions.published.article-a',
-        _type: 'article',
-        _rev: 'rev-3',
-        _createdAt: '2025-01-03T00:00:00Z',
-        _updatedAt: '2025-06-03T00:00:00Z',
-        title: 'Published article',
-        _system: {
-          group: {_ref: sharedGroupRef, _weak: true},
-        } satisfies DocumentSystem,
-      },
-    ]
-
-    await renderTable(groupedDocuments)
-
-    await waitFor(() => {
-      expect(screen.getAllByTestId('table-row')).toHaveLength(3)
-    })
-
-    const rowTitles = screen.getAllByTestId('table-row').map((row) => row.textContent)
-
-    expect(rowTitles[0]).toContain('Published article')
-    expect(rowTitles[1]).toContain('Summer article')
-    expect(rowTitles[2]).toContain('Other article')
   })
 })

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/getDocumentPreviewTitle.test.ts
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/getDocumentPreviewTitle.test.ts
@@ -1,0 +1,18 @@
+import {describe, expect, it} from 'vitest'
+
+import {getDocumentPreviewTitle} from '../variantDocumentTable/getDocumentPreviewTitle'
+
+describe('getDocumentPreviewTitle', () => {
+  it('falls back to document id for whitespace-only titles', () => {
+    expect(
+      getDocumentPreviewTitle({
+        _id: 'drafts.scope.article-1',
+        _type: 'article',
+        _rev: 'rev-1',
+        _createdAt: '2025-01-01T00:00:00Z',
+        _updatedAt: '2025-01-01T00:00:00Z',
+        title: '   ',
+      }),
+    ).toBe('drafts.scope.article-1')
+  })
+})

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/groupVariantDocumentsByGroup.test.ts
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/groupVariantDocumentsByGroup.test.ts
@@ -1,0 +1,151 @@
+import {describe, expect, it} from 'vitest'
+
+import {variantAlphaAudience} from '../../../__fixtures__/variants.fixture'
+import {groupVariantDocumentsByGroup} from '../groupVariantDocumentsByGroup'
+import {type DocumentInVariant} from '../types'
+
+const GROUP_ID = 'article-1'
+
+const defaultValidation = {
+  hasError: false,
+  isValidating: false,
+  validation: [],
+} as const
+
+const createDocumentInVariant = ({
+  documentId,
+  bundleId,
+  updatedAt,
+  releaseRef = null,
+  validation = defaultValidation,
+}: {
+  documentId: string
+  bundleId: undefined | 'drafts' | 'rASAP'
+  updatedAt: string
+  releaseRef?: string | null
+  validation?: DocumentInVariant['validation']
+}): DocumentInVariant => ({
+  memoKey: documentId,
+  document: {
+    _id: documentId,
+    _type: 'article',
+    _rev: `${documentId}-rev`,
+    _createdAt: updatedAt,
+    _updatedAt: updatedAt,
+    _system: {
+      bundleId: bundleId ?? null,
+      release: releaseRef ? {_ref: releaseRef, _weak: true} : null,
+      variant: {_ref: variantAlphaAudience._id, _weak: true},
+      group: {_ref: GROUP_ID, _weak: true},
+      scopeId: null,
+    },
+  },
+  version: {
+    documentId,
+    bundleId,
+    releaseRef,
+    updatedAt,
+  },
+  validation,
+})
+
+describe('groupVariantDocumentsByGroup', () => {
+  it('returns one row per document group', () => {
+    const rows = groupVariantDocumentsByGroup([
+      createDocumentInVariant({
+        documentId: 'drafts.scope.article-1',
+        bundleId: 'drafts',
+        updatedAt: '2025-06-01T00:00:00Z',
+      }),
+      createDocumentInVariant({
+        documentId: 'versions.rASAP.scope.article-1',
+        bundleId: 'rASAP',
+        updatedAt: '2025-06-02T00:00:00Z',
+        releaseRef: '_.releases.rASAP',
+      }),
+    ])
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.groupId).toBe(GROUP_ID)
+    expect(rows[0]?.versions).toHaveLength(2)
+  })
+
+  it('uses the latest edited document as the representative row document', () => {
+    const rows = groupVariantDocumentsByGroup([
+      createDocumentInVariant({
+        documentId: 'drafts.scope.article-1',
+        bundleId: 'drafts',
+        updatedAt: '2025-06-01T00:00:00Z',
+      }),
+      createDocumentInVariant({
+        documentId: 'published.scope.article-1',
+        bundleId: undefined,
+        updatedAt: '2025-06-03T00:00:00Z',
+      }),
+    ])
+
+    expect(rows[0]?.document._id).toBe('published.scope.article-1')
+  })
+
+  it('sorts bundle chips as published, drafts, then releases by document id', () => {
+    const rows = groupVariantDocumentsByGroup([
+      createDocumentInVariant({
+        documentId: 'versions.rB.scope.article-1',
+        bundleId: 'rB',
+        updatedAt: '2025-06-04T00:00:00Z',
+        releaseRef: '_.releases.rB',
+      }),
+      createDocumentInVariant({
+        documentId: 'drafts.scope.article-1',
+        bundleId: 'drafts',
+        updatedAt: '2025-06-01T00:00:00Z',
+      }),
+      createDocumentInVariant({
+        documentId: 'published.scope.article-1',
+        bundleId: undefined,
+        updatedAt: '2025-06-03T00:00:00Z',
+      }),
+      createDocumentInVariant({
+        documentId: 'versions.rA.scope.article-1',
+        bundleId: 'rA',
+        updatedAt: '2025-06-02T00:00:00Z',
+        releaseRef: '_.releases.rA',
+      }),
+    ])
+
+    expect(rows[0]?.versions.map((version) => version.bundleId)).toEqual([
+      undefined,
+      'drafts',
+      'rA',
+      'rB',
+    ])
+  })
+
+  it('aggregates validation errors across grouped document versions', () => {
+    const rows = groupVariantDocumentsByGroup([
+      createDocumentInVariant({
+        documentId: 'drafts.scope.article-1',
+        bundleId: 'drafts',
+        updatedAt: '2025-06-01T00:00:00Z',
+        validation: {
+          hasError: false,
+          isValidating: false,
+          validation: [],
+        },
+      }),
+      createDocumentInVariant({
+        documentId: 'published.scope.article-1',
+        bundleId: undefined,
+        updatedAt: '2025-06-03T00:00:00Z',
+        validation: {
+          hasError: true,
+          isValidating: false,
+          validation: [{level: 'error', message: 'Title is required', path: ['title']}],
+        },
+      }),
+    ])
+
+    expect(rows[0]?.validation.hasError).toBe(true)
+    expect(rows[0]?.validation.validation).toHaveLength(1)
+  })
+})

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/variantDocumentVersion.test.ts
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/variantDocumentVersion.test.ts
@@ -1,0 +1,54 @@
+import {describe, expect, it} from 'vitest'
+
+import {variantAlphaAudience} from '../../../__fixtures__/variants.fixture'
+import {toVariantDocumentVersion} from '../variantDocumentVersion'
+
+describe('toVariantDocumentVersion', () => {
+  it('keeps published variant documents with null bundleId as undefined', () => {
+    expect(
+      toVariantDocumentVersion({
+        _id: 'published.scope.article-1',
+        _type: 'article',
+        _rev: 'rev-1',
+        _createdAt: '2025-06-01T00:00:00Z',
+        _updatedAt: '2025-06-03T00:00:00Z',
+        _system: {
+          bundleId: null,
+          release: null,
+          variant: {_ref: variantAlphaAudience._id, _weak: true},
+          group: {_ref: 'article-1', _weak: true},
+          scopeId: 'scope',
+        },
+      }),
+    ).toEqual({
+      documentId: 'published.scope.article-1',
+      bundleId: undefined,
+      releaseRef: null,
+      updatedAt: '2025-06-03T00:00:00Z',
+    })
+  })
+
+  it('passes through drafts bundle ids unchanged', () => {
+    expect(
+      toVariantDocumentVersion({
+        _id: 'drafts.scope.article-1',
+        _type: 'article',
+        _rev: 'rev-1',
+        _createdAt: '2025-06-01T00:00:00Z',
+        _updatedAt: '2025-06-01T00:00:00Z',
+        _system: {
+          bundleId: 'drafts',
+          release: null,
+          variant: {_ref: variantAlphaAudience._id, _weak: true},
+          group: {_ref: 'article-1', _weak: true},
+          scopeId: null,
+        },
+      }),
+    ).toEqual({
+      documentId: 'drafts.scope.article-1',
+      bundleId: 'drafts',
+      releaseRef: null,
+      updatedAt: '2025-06-01T00:00:00Z',
+    })
+  })
+})

--- a/packages/sanity/src/core/variants/tool/detail/groupVariantDocumentsByGroup.ts
+++ b/packages/sanity/src/core/variants/tool/detail/groupVariantDocumentsByGroup.ts
@@ -19,10 +19,7 @@ function getBundleSortOrder(bundleId: PerspectiveBundle | undefined): number {
   return 2
 }
 
-/**
- * @internal
- */
-export function compareVariantDocumentVersions(
+function compareVariantDocumentVersions(
   left: VariantDocumentVersion,
   right: VariantDocumentVersion,
 ): number {

--- a/packages/sanity/src/core/variants/tool/detail/groupVariantDocumentsByGroup.ts
+++ b/packages/sanity/src/core/variants/tool/detail/groupVariantDocumentsByGroup.ts
@@ -1,0 +1,98 @@
+import {type PerspectiveBundle} from '../../../perspective/types'
+import {isPublishedBundleId} from '../util'
+import {
+  type DocumentInVariant,
+  type DocumentInVariantGroup,
+  type DocumentValidationStatus,
+  type VariantDocumentVersion,
+} from './types'
+
+function getBundleSortOrder(bundleId: PerspectiveBundle | undefined): number {
+  if (isPublishedBundleId(bundleId)) {
+    return 0
+  }
+
+  if (bundleId === 'drafts') {
+    return 1
+  }
+
+  return 2
+}
+
+/**
+ * @internal
+ */
+export function compareVariantDocumentVersions(
+  left: VariantDocumentVersion,
+  right: VariantDocumentVersion,
+): number {
+  const leftOrder = getBundleSortOrder(left.bundleId)
+  const rightOrder = getBundleSortOrder(right.bundleId)
+
+  if (leftOrder !== rightOrder) {
+    return leftOrder - rightOrder
+  }
+
+  return left.documentId.localeCompare(right.documentId)
+}
+
+function pickRepresentativeDocument(documents: DocumentInVariant[]): DocumentInVariant {
+  return documents.reduce((latest, current) => {
+    const latestUpdatedAt = latest.document._updatedAt ?? ''
+    const currentUpdatedAt = current.document._updatedAt ?? ''
+
+    return currentUpdatedAt > latestUpdatedAt ? current : latest
+  })
+}
+
+function aggregateValidation(documents: DocumentInVariant[]): DocumentValidationStatus {
+  const representative = pickRepresentativeDocument(documents)
+
+  return {
+    isValidating: documents.some((document) => document.validation.isValidating),
+    validation: documents.flatMap((document) => document.validation.validation),
+    revision: representative.validation.revision,
+    hasError: documents.some((document) => document.validation.hasError),
+  }
+}
+
+/**
+ * Groups flat variant document versions into one row per document group.
+ *
+ * @internal
+ */
+export function groupVariantDocumentsByGroup(
+  documents: DocumentInVariant[],
+): DocumentInVariantGroup[] {
+  const groups = new Map<string, DocumentInVariant[]>()
+
+  for (const document of documents) {
+    const groupId = document.document._system?.group?._ref
+
+    if (!groupId) {
+      continue
+    }
+
+    const existingGroup = groups.get(groupId)
+
+    if (existingGroup) {
+      existingGroup.push(document)
+    } else {
+      groups.set(groupId, [document])
+    }
+  }
+
+  return Array.from(groups.entries()).map(([groupId, groupDocuments]) => {
+    const representative = pickRepresentativeDocument(groupDocuments)
+    const versions = groupDocuments
+      .map((item) => item.version)
+      .toSorted(compareVariantDocumentVersions)
+
+    return {
+      ...representative,
+      groupId,
+      versions,
+      validation: aggregateValidation(groupDocuments),
+    }
+  })
+}

--- a/packages/sanity/src/core/variants/tool/detail/types.ts
+++ b/packages/sanity/src/core/variants/tool/detail/types.ts
@@ -1,0 +1,42 @@
+import {type SanityDocument} from '@sanity/client'
+
+import {type PerspectiveBundle} from '../../../perspective/types'
+import {type DocumentValidationStatus} from '../../../releases/tool/detail/useBundleDocuments'
+
+export type {DocumentValidationStatus}
+
+/**
+ * Bundle metadata for a single variant-scoped document version.
+ *
+ * @internal
+ */
+export interface VariantDocumentVersion {
+  documentId: string
+  /** Undefined when the document belongs to the published bundle. */
+  bundleId?: PerspectiveBundle
+  releaseRef: string | null
+  updatedAt: string
+}
+
+/**
+ * A single variant-scoped document version returned by {@link useVariantDocuments}.
+ *
+ * @internal
+ */
+export interface DocumentInVariant {
+  memoKey: string
+  document: SanityDocument
+  version: VariantDocumentVersion
+  validation: DocumentValidationStatus
+}
+
+/**
+ * A document group row for the variant detail table.
+ * Produced by {@link groupVariantDocumentsByGroup} from a flat {@link DocumentInVariant} list.
+ *
+ * @internal
+ */
+export interface DocumentInVariantGroup extends DocumentInVariant {
+  groupId: string
+  versions: VariantDocumentVersion[]
+}

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
@@ -1,0 +1,124 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {Badge, Flex} from '@sanity/ui'
+import {type ForwardedRef, forwardRef, useMemo} from 'react'
+import {IntentLink} from 'sanity/router'
+
+import {useTranslation} from '../../../../i18n'
+import {ReleaseTitle} from '../../../../releases/components/ReleaseTitle'
+import {RELEASES_INTENT} from '../../../../releases/plugin'
+import {useActiveReleases} from '../../../../releases/store/useActiveReleases'
+import {getReleaseDocumentIdFromReleaseId} from '../../../../releases/util/getReleaseDocumentIdFromReleaseId'
+import {getReleaseIdFromReleaseDocumentId} from '../../../../releases/util/getReleaseIdFromReleaseDocumentId'
+import {isPublishedBundleId, isReleaseBundle} from '../../util'
+import {type VariantDocumentVersion} from '../types'
+
+function getReleaseDocumentForVersion(
+  version: VariantDocumentVersion,
+  releasesById: Map<string, ReleaseDocument>,
+): ReleaseDocument | undefined {
+  if (version.releaseRef) {
+    return releasesById.get(version.releaseRef)
+  }
+
+  if (isReleaseBundle(version.bundleId)) {
+    const releaseDocumentId = getReleaseDocumentIdFromReleaseId(version.bundleId!)
+
+    return releasesById.get(releaseDocumentId)
+  }
+
+  return undefined
+}
+
+function ReleaseBundleChip({release}: {release: ReleaseDocument}) {
+  const {t} = useTranslation()
+  const releaseId = getReleaseIdFromReleaseDocumentId(release._id)
+
+  const ReleaseIntentLink = useMemo(
+    () =>
+      forwardRef(function ReleaseIntentLink(
+        linkProps: React.ComponentProps<'a'>,
+        ref: ForwardedRef<HTMLAnchorElement>,
+      ) {
+        return (
+          <IntentLink {...linkProps} ref={ref} intent={RELEASES_INTENT} params={{id: releaseId}} />
+        )
+      }),
+    [releaseId],
+  )
+
+  return (
+    <ReleaseTitle
+      title={release.metadata?.title}
+      fallback={t('release.placeholder-untitled-release')}
+    >
+      {({displayTitle}) => (
+        <ReleaseIntentLink>
+          <Badge radius={2} tone="primary">
+            {displayTitle}
+          </Badge>
+        </ReleaseIntentLink>
+      )}
+    </ReleaseTitle>
+  )
+}
+
+function StaticBundleChip({label, tone}: {label: string; tone: 'positive' | 'default'}) {
+  return (
+    <Badge radius={2} tone={tone}>
+      {label}
+    </Badge>
+  )
+}
+
+export function VariantDocumentBundleChips({
+  versions,
+}: {
+  versions: VariantDocumentVersion[]
+}): React.JSX.Element {
+  const {t} = useTranslation()
+  const {data: releases} = useActiveReleases()
+  const releasesById = useMemo(
+    () => new Map(releases.map((release) => [release._id, release])),
+    [releases],
+  )
+
+  return (
+    <Flex align="center" gap={1} wrap="wrap">
+      {versions.map((version) => {
+        if (isPublishedBundleId(version.bundleId)) {
+          return (
+            <StaticBundleChip
+              key={version.documentId}
+              label={t('release.chip.published')}
+              tone="positive"
+            />
+          )
+        }
+
+        if (version.bundleId === 'drafts') {
+          return (
+            <StaticBundleChip
+              key={version.documentId}
+              label={t('release.chip.draft')}
+              tone="default"
+            />
+          )
+        }
+
+        const release = getReleaseDocumentForVersion(version, releasesById)
+
+        if (release) {
+          return <ReleaseBundleChip key={version.documentId} release={release} />
+        }
+
+        return (
+          <StaticBundleChip
+            key={version.documentId}
+            label={t('release.placeholder-untitled-release')}
+            tone="default"
+          />
+        )
+      })}
+    </Flex>
+  )
+}

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
@@ -1,5 +1,5 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {Badge, Flex} from '@sanity/ui'
+import {Badge, Box, Flex} from '@sanity/ui'
 import {type ForwardedRef, forwardRef, useMemo} from 'react'
 import {IntentLink} from 'sanity/router'
 
@@ -83,42 +83,47 @@ export function VariantDocumentBundleChips({
   )
 
   return (
-    <Flex align="center" gap={1} wrap="wrap">
-      {versions.map((version) => {
-        if (isPublishedBundleId(version.bundleId)) {
-          return (
-            <StaticBundleChip
-              key={version.documentId}
-              label={t('release.chip.published')}
-              tone="positive"
-            />
-          )
-        }
+    // The column has a bounded width, but the number of chips is unbounded, so the chips are
+    // laid out on a single, non-wrapping line that scrolls horizontally when it overflows the
+    // column width, rather than wrapping or stretching the column and breaking the table layout.
+    <Box overflow="auto" style={{minWidth: 0, maxWidth: '100%'}}>
+      <Flex align="center" gap={1} wrap="nowrap" style={{width: 'max-content'}}>
+        {versions.map((version) => {
+          if (isPublishedBundleId(version.bundleId)) {
+            return (
+              <StaticBundleChip
+                key={version.documentId}
+                label={t('release.chip.published')}
+                tone="positive"
+              />
+            )
+          }
 
-        if (version.bundleId === 'drafts') {
+          if (version.bundleId === 'drafts') {
+            return (
+              <StaticBundleChip
+                key={version.documentId}
+                label={t('release.chip.draft')}
+                tone="default"
+              />
+            )
+          }
+
+          const release = getReleaseDocumentForVersion(version, releasesById)
+
+          if (release) {
+            return <ReleaseBundleChip key={version.documentId} release={release} />
+          }
+
           return (
             <StaticBundleChip
               key={version.documentId}
-              label={t('release.chip.draft')}
+              label={t('release.placeholder-untitled-release')}
               tone="default"
             />
           )
-        }
-
-        const release = getReleaseDocumentForVersion(version, releasesById)
-
-        if (release) {
-          return <ReleaseBundleChip key={version.documentId} release={release} />
-        }
-
-        return (
-          <StaticBundleChip
-            key={version.documentId}
-            label={t('release.placeholder-untitled-release')}
-            tone="default"
-          />
-        )
-      })}
-    </Flex>
+        })}
+      </Flex>
+    </Box>
   )
 }

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
@@ -39,7 +39,7 @@ function ReleaseBundleChip({release}: {release: ReleaseDocument}) {
       fallback={t('release.placeholder-untitled-release')}
     >
       {({displayTitle}) => (
-        <IntentLink intent="edit" params={{id: releaseId}}>
+        <IntentLink intent={RELEASES_INTENT} params={{id: releaseId}}>
           <Badge radius={2} tone="primary">
             {displayTitle}
           </Badge>

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
@@ -1,12 +1,10 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {Badge, Box, Flex} from '@sanity/ui'
-import {useMemo} from 'react'
 import {IntentLink} from 'sanity/router'
 
 import {useTranslation} from '../../../../i18n'
 import {ReleaseTitle} from '../../../../releases/components/ReleaseTitle'
 import {RELEASES_INTENT} from '../../../../releases/plugin'
-import {useActiveReleases} from '../../../../releases/store/useActiveReleases'
 import {getReleaseDocumentIdFromReleaseId} from '../../../../releases/util/getReleaseDocumentIdFromReleaseId'
 import {getReleaseIdFromReleaseDocumentId} from '../../../../releases/util/getReleaseIdFromReleaseDocumentId'
 import {isPublishedBundleId, isReleaseBundle} from '../../util'
@@ -59,15 +57,12 @@ function StaticBundleChip({label, tone}: {label: string; tone: 'positive' | 'def
 
 export function VariantDocumentBundleChips({
   versions,
+  releasesById,
 }: {
   versions: VariantDocumentVersion[]
+  releasesById: Map<string, ReleaseDocument>
 }): React.JSX.Element {
   const {t} = useTranslation()
-  const {data: releases} = useActiveReleases()
-  const releasesById = useMemo(
-    () => new Map(releases.map((release) => [release._id, release])),
-    [releases],
-  )
 
   return (
     <Box style={{minWidth: 0, width: '100%', overflowX: 'auto', overflowY: 'hidden'}}>

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
@@ -1,5 +1,5 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {Badge, Flex} from '@sanity/ui'
+import {Badge, Box, Flex} from '@sanity/ui'
 import {useMemo} from 'react'
 import {IntentLink} from 'sanity/router'
 
@@ -70,42 +70,44 @@ export function VariantDocumentBundleChips({
   )
 
   return (
-    <Flex align="center" gap={1} wrap="nowrap" style={{width: 'max-content'}}>
-      {versions.map((version) => {
-        if (isPublishedBundleId(version.bundleId)) {
-          return (
-            <StaticBundleChip
-              key={version.documentId}
-              label={t('release.chip.published')}
-              tone="positive"
-            />
-          )
-        }
+    <Box style={{minWidth: 0, width: '100%', overflowX: 'auto', overflowY: 'hidden'}}>
+      <Flex align="center" gap={1} wrap="nowrap" style={{width: 'max-content'}}>
+        {versions.map((version) => {
+          if (isPublishedBundleId(version.bundleId)) {
+            return (
+              <StaticBundleChip
+                key={version.documentId}
+                label={t('release.chip.published')}
+                tone="positive"
+              />
+            )
+          }
 
-        if (version.bundleId === 'drafts') {
+          if (version.bundleId === 'drafts') {
+            return (
+              <StaticBundleChip
+                key={version.documentId}
+                label={t('release.chip.draft')}
+                tone="default"
+              />
+            )
+          }
+
+          const release = getReleaseDocumentForVersion(version, releasesById)
+
+          if (release) {
+            return <ReleaseBundleChip key={version.documentId} release={release} />
+          }
+
           return (
             <StaticBundleChip
               key={version.documentId}
-              label={t('release.chip.draft')}
+              label={t('release.placeholder-untitled-release')}
               tone="default"
             />
           )
-        }
-
-        const release = getReleaseDocumentForVersion(version, releasesById)
-
-        if (release) {
-          return <ReleaseBundleChip key={version.documentId} release={release} />
-        }
-
-        return (
-          <StaticBundleChip
-            key={version.documentId}
-            label={t('release.placeholder-untitled-release')}
-            tone="default"
-          />
-        )
-      })}
-    </Flex>
+        })}
+      </Flex>
+    </Box>
   )
 }

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
@@ -33,30 +33,17 @@ function ReleaseBundleChip({release}: {release: ReleaseDocument}) {
   const {t} = useTranslation()
   const releaseId = getReleaseIdFromReleaseDocumentId(release._id)
 
-  const ReleaseIntentLink = useMemo(
-    () =>
-      forwardRef(function ReleaseIntentLink(
-        linkProps: React.ComponentProps<'a'>,
-        ref: ForwardedRef<HTMLAnchorElement>,
-      ) {
-        return (
-          <IntentLink {...linkProps} ref={ref} intent={RELEASES_INTENT} params={{id: releaseId}} />
-        )
-      }),
-    [releaseId],
-  )
-
   return (
     <ReleaseTitle
       title={release.metadata?.title}
       fallback={t('release.placeholder-untitled-release')}
     >
       {({displayTitle}) => (
-        <ReleaseIntentLink>
+        <IntentLink intent="edit" params={{id: releaseId}}>
           <Badge radius={2} tone="primary">
             {displayTitle}
           </Badge>
-        </ReleaseIntentLink>
+        </IntentLink>
       )}
     </ReleaseTitle>
   )
@@ -83,47 +70,42 @@ export function VariantDocumentBundleChips({
   )
 
   return (
-    // The column has a bounded width, but the number of chips is unbounded, so the chips are
-    // laid out on a single, non-wrapping line that scrolls horizontally when it overflows the
-    // column width, rather than wrapping or stretching the column and breaking the table layout.
-    <Box overflow="auto" style={{minWidth: 0, maxWidth: '100%'}}>
-      <Flex align="center" gap={1} wrap="nowrap" style={{width: 'max-content'}}>
-        {versions.map((version) => {
-          if (isPublishedBundleId(version.bundleId)) {
-            return (
-              <StaticBundleChip
-                key={version.documentId}
-                label={t('release.chip.published')}
-                tone="positive"
-              />
-            )
-          }
-
-          if (version.bundleId === 'drafts') {
-            return (
-              <StaticBundleChip
-                key={version.documentId}
-                label={t('release.chip.draft')}
-                tone="default"
-              />
-            )
-          }
-
-          const release = getReleaseDocumentForVersion(version, releasesById)
-
-          if (release) {
-            return <ReleaseBundleChip key={version.documentId} release={release} />
-          }
-
+    <Flex align="center" gap={1} wrap="nowrap" style={{width: 'max-content'}}>
+      {versions.map((version) => {
+        if (isPublishedBundleId(version.bundleId)) {
           return (
             <StaticBundleChip
               key={version.documentId}
-              label={t('release.placeholder-untitled-release')}
+              label={t('release.chip.published')}
+              tone="positive"
+            />
+          )
+        }
+
+        if (version.bundleId === 'drafts') {
+          return (
+            <StaticBundleChip
+              key={version.documentId}
+              label={t('release.chip.draft')}
               tone="default"
             />
           )
-        })}
-      </Flex>
-    </Box>
+        }
+
+        const release = getReleaseDocumentForVersion(version, releasesById)
+
+        if (release) {
+          return <ReleaseBundleChip key={version.documentId} release={release} />
+        }
+
+        return (
+          <StaticBundleChip
+            key={version.documentId}
+            label={t('release.placeholder-untitled-release')}
+            tone="default"
+          />
+        )
+      })}
+    </Flex>
   )
 }

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
@@ -1,6 +1,6 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {Badge, Box, Flex} from '@sanity/ui'
-import {type ForwardedRef, forwardRef, useMemo} from 'react'
+import {Badge, Flex} from '@sanity/ui'
+import {useMemo} from 'react'
 import {IntentLink} from 'sanity/router'
 
 import {useTranslation} from '../../../../i18n'

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentPreview.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentPreview.tsx
@@ -1,0 +1,101 @@
+import {Card} from '@sanity/ui'
+import {type ForwardedRef, forwardRef, useMemo} from 'react'
+import {IntentLink} from 'sanity/router'
+
+import {type PreviewLayoutKey} from '../../../../components/previews/types'
+import {DocumentPreviewPresence} from '../../../../presence'
+import {SanityDefaultPreview} from '../../../../preview/components/SanityDefaultPreview'
+import {useDocumentPresence} from '../../../../store/presence/useDocumentPresence'
+import {useDocumentPreviewValues} from '../../../../tasks/hooks/useDocumentPreviewValues'
+import {getPublishedId} from '../../../../util/draftUtils'
+import {isPublishedBundleId} from '../../util'
+import {type DocumentInVariantGroup} from '../types'
+
+interface VariantDocumentPreviewProps {
+  row: DocumentInVariantGroup
+  layout?: PreviewLayoutKey
+  variantId?: string
+}
+
+function getVersionPerspectiveNavigation(
+  bundleId: DocumentInVariantGroup['version']['bundleId'],
+  variantId?: string,
+): {
+  perspectiveStack: string[]
+  searchParams: Array<[string, string]> | undefined
+} {
+  const searchParams: Array<[string, string]> = variantId ? [['variant', variantId]] : []
+
+  if (isPublishedBundleId(bundleId)) {
+    return {
+      perspectiveStack: [],
+      searchParams: [...searchParams, ['perspective', 'published']],
+    }
+  }
+
+  if (bundleId === 'drafts') {
+    return {
+      perspectiveStack: ['drafts'],
+      searchParams: searchParams.length > 0 ? searchParams : undefined,
+    }
+  }
+
+  return {
+    perspectiveStack: [bundleId ?? ''],
+    searchParams: [...searchParams, ['perspective', bundleId ?? '']],
+  }
+}
+
+export function VariantDocumentPreview({
+  row,
+  layout,
+  variantId,
+}: VariantDocumentPreviewProps): React.JSX.Element {
+  const publishedId = getPublishedId(row.groupId)
+  const documentPresence = useDocumentPresence(row.document._id)
+  const {perspectiveStack, searchParams} = getVersionPerspectiveNavigation(
+    row.version.bundleId,
+    variantId,
+  )
+
+  const LinkComponent = useMemo(
+    () =>
+      forwardRef(function LinkComponent(linkProps, ref: ForwardedRef<HTMLAnchorElement>) {
+        return (
+          <IntentLink
+            {...linkProps}
+            intent="edit"
+            params={{
+              id: publishedId,
+              type: row.document._type,
+            }}
+            searchParams={searchParams}
+            ref={ref}
+          />
+        )
+      }),
+    [publishedId, row.document._type, searchParams],
+  )
+
+  const previewPresence = useMemo(
+    () => documentPresence?.length > 0 && <DocumentPreviewPresence presence={documentPresence} />,
+    [documentPresence],
+  )
+
+  const {isLoading: previewLoading, value: resolvedPreview} = useDocumentPreviewValues({
+    documentId: row.document._id,
+    documentType: row.document._type,
+    perspectiveStack,
+  })
+
+  return (
+    <Card tone="inherit" as={LinkComponent} radius={2} data-as="a">
+      <SanityDefaultPreview
+        {...(resolvedPreview || {})}
+        status={previewPresence}
+        isPlaceholder={previewLoading}
+        layout={layout}
+      />
+    </Card>
+  )
+}

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentPreview.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentPreview.tsx
@@ -52,7 +52,7 @@ function getVersionPerspectiveNavigation(
 
   if (isPublishedBundleId(bundleId)) {
     return {
-      perspectiveStack: [],
+      perspectiveStack: ['published'],
       searchParams: [...searchParams, ['perspective', 'published']],
     }
   }
@@ -65,7 +65,7 @@ function getVersionPerspectiveNavigation(
   }
 
   return {
-    perspectiveStack: [bundleId ?? ''],
+    perspectiveStack: [bundleId ?? '', 'drafts'],
     searchParams: [...searchParams, ['perspective', bundleId ?? '']],
   }
 }

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentPreview.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentPreview.tsx
@@ -17,6 +17,30 @@ interface VariantDocumentPreviewProps {
   variantId?: string
 }
 
+interface VariantDocumentPreviewLinkProps extends React.ComponentPropsWithoutRef<'a'> {
+  publishedId: string
+  documentType: string
+  searchParams: Array<[string, string]> | undefined
+}
+
+const VariantDocumentPreviewLink = forwardRef(function VariantDocumentPreviewLink(
+  {publishedId, documentType, searchParams, ...linkProps}: VariantDocumentPreviewLinkProps,
+  ref: ForwardedRef<HTMLAnchorElement>,
+) {
+  return (
+    <IntentLink
+      {...linkProps}
+      intent="edit"
+      params={{
+        id: publishedId,
+        type: documentType,
+      }}
+      searchParams={searchParams}
+      ref={ref}
+    />
+  )
+})
+
 function getVersionPerspectiveNavigation(
   bundleId: DocumentInVariantGroup['version']['bundleId'],
   variantId?: string,
@@ -53,31 +77,9 @@ export function VariantDocumentPreview({
 }: VariantDocumentPreviewProps): React.JSX.Element {
   const publishedId = getPublishedId(row.groupId)
   const documentPresence = useDocumentPresence(row.document._id)
-  const {perspectiveStack, searchParams} = getVersionPerspectiveNavigation(
-    row.version.bundleId,
-    variantId,
-  )
-
-  const LinkComponent = useMemo(
-    () =>
-      forwardRef(function LinkComponent(
-        linkProps: React.ComponentPropsWithoutRef<'a'>,
-        ref: ForwardedRef<HTMLAnchorElement>,
-      ) {
-        return (
-          <IntentLink
-            {...linkProps}
-            intent="edit"
-            params={{
-              id: publishedId,
-              type: row.document._type,
-            }}
-            searchParams={searchParams}
-            ref={ref}
-          />
-        )
-      }),
-    [publishedId, row.document._type, searchParams],
+  const {perspectiveStack, searchParams} = useMemo(
+    () => getVersionPerspectiveNavigation(row.version.bundleId, variantId),
+    [row.version.bundleId, variantId],
   )
 
   const previewPresence = useMemo(
@@ -92,7 +94,15 @@ export function VariantDocumentPreview({
   })
 
   return (
-    <Card tone="inherit" as={LinkComponent} radius={2} data-as="a">
+    <Card
+      tone="inherit"
+      as={VariantDocumentPreviewLink}
+      publishedId={publishedId}
+      documentType={row.document._type}
+      searchParams={searchParams}
+      radius={2}
+      data-as="a"
+    >
       <SanityDefaultPreview
         {...(resolvedPreview || {})}
         status={previewPresence}

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentPreview.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentPreview.tsx
@@ -60,7 +60,10 @@ export function VariantDocumentPreview({
 
   const LinkComponent = useMemo(
     () =>
-      forwardRef(function LinkComponent(linkProps, ref: ForwardedRef<HTMLAnchorElement>) {
+      forwardRef(function LinkComponent(
+        linkProps: React.ComponentPropsWithoutRef<'a'>,
+        ref: ForwardedRef<HTMLAnchorElement>,
+      ) {
         return (
           <IntentLink
             {...linkProps}

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
@@ -52,8 +52,8 @@ export const getVariantDocumentTableColumnDefs = (
   },
   {
     id: 'bundle',
-    width: null,
-    style: {minWidth: 100, maxWidth: 220},
+    width: 140,
+    style: {minWidth: 100, maxWidth: 140},
     sorting: false,
     header: (props) => (
       <Flex {...props.headerProps} paddingY={3} sizing="border">
@@ -61,8 +61,12 @@ export const getVariantDocumentTableColumnDefs = (
       </Flex>
     ),
     cell: ({cellProps, datum}) => (
-      <Flex align="center" {...cellProps} style={{...cellProps.style, minWidth: 0}}>
-        <Box paddingX={2} style={{minWidth: 0, overflow: 'hidden'}}>
+      <Flex
+        align="center"
+        {...cellProps}
+        style={{...cellProps.style, flex: '0 1 auto', minWidth: 0, overflow: 'hidden'}}
+      >
+        <Box flex={1} paddingX={2} style={{minWidth: 0, overflow: 'hidden'}}>
           {!datum.isLoading && <VariantDocumentBundleChips versions={datum.versions} />}
         </Box>
       </Flex>

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
@@ -1,3 +1,4 @@
+import {type ReleaseDocument} from '@sanity/client'
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
 import {Box, Flex, Text} from '@sanity/ui'
 // eslint-disable-next-line @sanity/i18n/no-i18next-import -- figure out how to have the linter be fine with importing types-only
@@ -41,7 +42,8 @@ const MemoDocumentType = memo(
 
 export const getVariantDocumentTableColumnDefs = (
   t: TFunction<'variants'>,
-  variantId?: string,
+  variantId: string | undefined,
+  releasesById: Map<string, ReleaseDocument>,
 ): Column<DocumentInVariantGroup>[] => [
   {
     id: 'documentGroup',
@@ -67,7 +69,9 @@ export const getVariantDocumentTableColumnDefs = (
         style={{...cellProps.style, flex: '0 1 auto', minWidth: 0, overflow: 'hidden'}}
       >
         <Box flex={1} paddingX={2} style={{minWidth: 0, overflow: 'hidden'}}>
-          {!datum.isLoading && <VariantDocumentBundleChips versions={datum.versions} />}
+          {!datum.isLoading && (
+            <VariantDocumentBundleChips versions={datum.versions} releasesById={releasesById} />
+          )}
         </Box>
       </Flex>
     ),

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
@@ -12,6 +12,7 @@ import {SanityDefaultPreview} from '../../../../preview/components/SanityDefault
 import {Headers} from '../../../../releases/tool/components/Table/TableHeader'
 import {type Column} from '../../../../releases/tool/components/Table/types'
 import {type DocumentInVariantGroup} from '../types'
+import {getDocumentPreviewTitle} from './getDocumentPreviewTitle'
 import {VariantDocumentBundleChips} from './VariantDocumentBundleChips'
 import {VariantDocumentPreview} from './VariantDocumentPreview'
 
@@ -42,6 +43,13 @@ export const getVariantDocumentTableColumnDefs = (
   t: TFunction<'variants'>,
   variantId?: string,
 ): Column<DocumentInVariantGroup>[] => [
+  {
+    id: 'documentGroup',
+    hidden: true,
+    width: null,
+    sorting: true,
+    sortTransform: (row) => row.groupId,
+  },
   {
     id: 'bundle',
     width: null,
@@ -82,13 +90,7 @@ export const getVariantDocumentTableColumnDefs = (
     id: 'search',
     width: null,
     style: {minWidth: 'min(50%, calc(100vw - 80px))', maxWidth: 'min(50%, calc(100vw - 80px))'},
-    sortTransform(value) {
-      return (
-        String(
-          value.document?.title || value.document?.name || value.document?._id,
-        ).toLowerCase() || 0
-      )
-    },
+    sortTransform: ({document}) => getDocumentPreviewTitle(document).toLowerCase(),
     header: (props) => (
       <Headers.TableHeaderSearch
         {...props}

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
@@ -1,0 +1,172 @@
+import {ErrorOutlineIcon} from '@sanity/icons'
+import {Box, Flex, Text} from '@sanity/ui'
+// eslint-disable-next-line @sanity/i18n/no-i18next-import -- figure out how to have the linter be fine with importing types-only
+import {type TFunction} from 'i18next'
+import {memo} from 'react'
+
+import {ToneIcon} from '../../../../../ui-components/toneIcon/ToneIcon'
+import {Tooltip} from '../../../../../ui-components/tooltip'
+import {RelativeTime} from '../../../../components/RelativeTime'
+import {useSchema} from '../../../../hooks'
+import {SanityDefaultPreview} from '../../../../preview/components/SanityDefaultPreview'
+import {Headers} from '../../../../releases/tool/components/Table/TableHeader'
+import {type Column} from '../../../../releases/tool/components/Table/types'
+import {type DocumentInVariantGroup} from '../types'
+import {VariantDocumentBundleChips} from './VariantDocumentBundleChips'
+import {VariantDocumentPreview} from './VariantDocumentPreview'
+
+const MemoVariantDocumentPreview = memo(
+  function MemoVariantDocumentPreview({
+    row,
+    variantId,
+  }: {
+    row: DocumentInVariantGroup
+    variantId?: string
+  }) {
+    return <VariantDocumentPreview row={row} variantId={variantId} />
+  },
+  (prev, next) => prev.row.memoKey === next.row.memoKey && prev.variantId === next.variantId,
+)
+
+const MemoDocumentType = memo(
+  function DocumentType({type}: {type: string}) {
+    const schema = useSchema()
+    const schemaType = schema.get(type)
+
+    return <Text size={1}>{schemaType?.title || type}</Text>
+  },
+  (prev, next) => prev.type === next.type,
+)
+
+export const getVariantDocumentTableColumnDefs = (
+  t: TFunction<'variants'>,
+  variantId?: string,
+): Column<DocumentInVariantGroup>[] => [
+  {
+    id: 'bundle',
+    width: null,
+    style: {minWidth: 100},
+    sorting: false,
+    header: (props) => (
+      <Flex {...props.headerProps} paddingY={3} sizing="border">
+        <Headers.BasicHeader text={t('detail.documents.table.bundle')} />
+      </Flex>
+    ),
+    cell: ({cellProps, datum}) => (
+      <Flex align="center" {...cellProps}>
+        <Box paddingX={2}>
+          {!datum.isLoading && <VariantDocumentBundleChips versions={datum.versions} />}
+        </Box>
+      </Flex>
+    ),
+  },
+  {
+    id: 'document._type',
+    width: null,
+    style: {minWidth: 100},
+    sorting: true,
+    header: (props) => (
+      <Flex {...props.headerProps} paddingY={3} sizing="border">
+        <Headers.SortHeaderButton text={t('detail.documents.table.type')} {...props} />
+      </Flex>
+    ),
+    cell: ({cellProps, datum}) => (
+      <Flex align="center" {...cellProps}>
+        <Box paddingX={2}>
+          {!datum.isLoading && <MemoDocumentType type={datum.document._type} />}
+        </Box>
+      </Flex>
+    ),
+  },
+  {
+    id: 'search',
+    width: null,
+    style: {minWidth: 'min(50%, calc(100vw - 80px))', maxWidth: 'min(50%, calc(100vw - 80px))'},
+    sortTransform(value) {
+      return (
+        String(
+          value.document?.title || value.document?.name || value.document?._id,
+        ).toLowerCase() || 0
+      )
+    },
+    header: (props) => (
+      <Headers.TableHeaderSearch
+        {...props}
+        placeholder={t('detail.documents.table.search-placeholder')}
+      />
+    ),
+    cell: ({cellProps, datum}) => (
+      <Box {...cellProps} flex={1} padding={1} paddingRight={2} sizing="border">
+        {datum.isLoading ? (
+          <SanityDefaultPreview isPlaceholder />
+        ) : (
+          <MemoVariantDocumentPreview row={datum} variantId={variantId} />
+        )}
+      </Box>
+    ),
+  },
+  {
+    id: 'document._updatedAt',
+    sorting: true,
+    width: 130,
+    header: (props) => (
+      <Flex {...props.headerProps} paddingY={3} sizing="border">
+        <Headers.SortHeaderButton text={t('detail.documents.table.edited')} {...props} />
+      </Flex>
+    ),
+    cell: ({cellProps, datum}) => (
+      <Flex {...cellProps} align="center" paddingX={2} paddingY={3} style={{minWidth: 130}}>
+        {!datum.isLoading && datum.document._updatedAt && (
+          <Text muted size={1}>
+            <RelativeTime time={datum.document._updatedAt} useTemporalPhrase minimal />
+          </Text>
+        )}
+      </Flex>
+    ),
+  },
+  {
+    id: 'validation',
+    sorting: false,
+    width: 50,
+    header: ({headerProps}) => (
+      <Flex {...headerProps} paddingY={3} sizing="border">
+        <Headers.BasicHeader text={''} />
+      </Flex>
+    ),
+    cell: ({cellProps, datum}) => {
+      if (datum.isLoading) return null
+
+      const validationErrorCount = datum.validation.validation.filter(
+        (validation) => validation.level === 'error',
+      ).length
+
+      return (
+        <Flex {...cellProps} flex={1} padding={1} justify="center" align="center" sizing="border">
+          {datum.validation.hasError && (
+            <Tooltip
+              portal
+              placement="bottom-end"
+              content={
+                <Text muted size={1}>
+                  <Flex align="center" gap={3} padding={1}>
+                    <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
+                    {t(
+                      validationErrorCount === 1
+                        ? 'detail.documents.table.validation.error_one'
+                        : 'detail.documents.table.validation.error_other',
+                      {count: validationErrorCount},
+                    )}
+                  </Flex>
+                </Text>
+              }
+            >
+              <Text size={1}>
+                <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
+              </Text>
+            </Tooltip>
+          )}
+        </Flex>
+      )
+    },
+  },
+]

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
@@ -45,7 +45,7 @@ export const getVariantDocumentTableColumnDefs = (
   {
     id: 'bundle',
     width: null,
-    style: {minWidth: 100},
+    style: {minWidth: 100, maxWidth: 220},
     sorting: false,
     header: (props) => (
       <Flex {...props.headerProps} paddingY={3} sizing="border">
@@ -53,8 +53,8 @@ export const getVariantDocumentTableColumnDefs = (
       </Flex>
     ),
     cell: ({cellProps, datum}) => (
-      <Flex align="center" {...cellProps}>
-        <Box paddingX={2}>
+      <Flex align="center" {...cellProps} style={{...cellProps.style, minWidth: 0}}>
+        <Box paddingX={2} style={{minWidth: 0, overflow: 'hidden'}}>
           {!datum.isLoading && <VariantDocumentBundleChips versions={datum.versions} />}
         </Box>
       </Flex>

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
@@ -1,4 +1,4 @@
-import {ErrorOutlineIcon} from '@sanity/icons'
+import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
 import {Box, Flex, Text} from '@sanity/ui'
 // eslint-disable-next-line @sanity/i18n/no-i18next-import -- figure out how to have the linter be fine with importing types-only
 import {type TFunction} from 'i18next'

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/getDocumentPreviewTitle.ts
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/getDocumentPreviewTitle.ts
@@ -1,0 +1,7 @@
+import {type SanityDocument} from '@sanity/client'
+
+export function getDocumentPreviewTitle(document: SanityDocument): string {
+  const title = document.title || document.name
+
+  return typeof title === 'string' && title.trim() ? title : document._id
+}

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentVersion.ts
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentVersion.ts
@@ -1,0 +1,23 @@
+import {type SanityDocument} from '@sanity/client'
+import {type DocumentSystem} from '@sanity/types'
+
+import {DOCUMENT_SYSTEM_FIELD} from '../../../preview/constants'
+import {type VariantDocumentVersion} from './types'
+
+/**
+ * @internal
+ */
+export function toVariantDocumentVersion(document: SanityDocument): VariantDocumentVersion | null {
+  const system = document[DOCUMENT_SYSTEM_FIELD] as DocumentSystem | undefined
+
+  if (!system?.group?._ref) {
+    return null
+  }
+
+  return {
+    documentId: document._id,
+    bundleId: system.bundleId ?? undefined,
+    releaseRef: system.release?._ref ?? null,
+    updatedAt: document._updatedAt ?? '',
+  }
+}

--- a/packages/sanity/src/core/variants/tool/util.ts
+++ b/packages/sanity/src/core/variants/tool/util.ts
@@ -1,9 +1,27 @@
 import {isPortableTextBlock, toPlainText} from '@portabletext/toolkit'
 
+import {type PerspectiveBundle} from '../../perspective/types'
 import {VARIANT_DOCUMENTS_PATH} from '../store/constants'
 import {type SystemVariant} from '../types'
 
 const VARIANT_ID_PREFIX = `${VARIANT_DOCUMENTS_PATH}.`
+
+/**
+ * Published documents omit `bundleId` on `_system`. Call sites should treat `undefined` as
+ * published without rewriting the value.
+ *
+ * @internal
+ */
+export function isPublishedBundleId(bundleId: PerspectiveBundle | undefined): boolean {
+  return bundleId === undefined
+}
+
+/**
+ * @internal
+ */
+export function isReleaseBundle(bundleId: PerspectiveBundle | undefined): boolean {
+  return !isPublishedBundleId(bundleId) && bundleId !== 'drafts'
+}
 
 /**
  * @internal

--- a/packages/sanity/src/core/variants/tool/util.ts
+++ b/packages/sanity/src/core/variants/tool/util.ts
@@ -7,13 +7,13 @@ import {type SystemVariant} from '../types'
 const VARIANT_ID_PREFIX = `${VARIANT_DOCUMENTS_PATH}.`
 
 /**
- * Published documents omit `bundleId` on `_system`. Call sites should treat `undefined` as
- * published without rewriting the value.
+ * Published documents omit `bundleId` on `_system`, but `PerspectiveBundle` also includes the
+ * `'published'` literal. Call sites should treat both as published without rewriting the value.
  *
  * @internal
  */
 export function isPublishedBundleId(bundleId: PerspectiveBundle | undefined): boolean {
-  return bundleId === undefined
+  return bundleId === undefined || bundleId === 'published'
 }
 
 /**


### PR DESCRIPTION
### Description
Changes the variant detail page to show the preview of the documents in the list.
Clicking a document now will open it in structure and will set the correct variant in the sticky params.

It also groups the documents by document group, so if a document has a draft, published or release variants they will be displayed together. 
Next nice step here would be to have a expand button in where each of the variant documents will render in the list. 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a internal facing feature
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes document fetching, grouping, and edit-intent navigation (variant + perspective params) on an internal beta tool; risk is moderate due to navigation correctness and shared `useBundleDocuments` behavior, mitigated by extensive tests.
> 
> **Overview**
> Wires the **variant detail** documents list to real membership data and replaces the placeholder table with a release-style experience.
> 
> **Data loading:** `useVariantDocuments` now accepts an optional variant id, skips fetches when disabled, maps results to `DocumentInVariant` with bundle/version metadata, and relies on a new `enabled` flag on shared `useBundleDocuments` (plus a test cache reset helper).
> 
> **Grouping & UI:** Flat versions are collapsed to **one row per document group** via `groupVariantDocumentsByGroup` (latest edit as representative, aggregated validation, bundle chips ordered published → drafts → releases). The table shows a **Bundle** column (chips with release intent links), clickable **previews** that open the document in structure with `variant` and the correct `perspective` search params, and a validation error column. Load failures surface a dedicated error message on the detail page.
> 
> **Tests & docs:** Broad unit coverage for hooks, grouping, bundle chips, preview navigation, and table behavior; README updated to describe the live documents table flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2567c5121a34b8b2c814c50ebcc15cc957c35c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->