### PR TITLE
fix(core): guard against undefined CSS global in node test environments

### DIFF
--- a/packages/sanity/src/core/form/components/FormNodeDivergenceDetail.tsx
+++ b/packages/sanity/src/core/form/components/FormNodeDivergenceDetail.tsx
@@ -9,7 +9,7 @@ import {useWorkspace} from '../../studio/workspace'
 import {useDocumentDivergences} from '../contexts/DivergencesProvider'
 
 const canUseAnchorPositioning =
-  'CSS' in globalThis && typeof CSS.supports === 'function'
+  'CSS' in globalThis && typeof CSS !== 'undefined' && typeof CSS.supports === 'function'
     ? CSS.supports('(position-anchor: --anchor)')
     : false
 


### PR DESCRIPTION
## Description

Test runners like Vitest crash with:

```
TypeError: Cannot read properties of undefined (reading 'supports')
```

when running with the `node` environment (i.e. without `jsdom` or `happy-dom`).

The `canUseAnchorPositioning` check in `FormNodeDivergenceDetail.tsx` only verified `'CSS' in globalThis`. In some node-based test environments the `CSS` identifier is present on the global object but evaluates to `undefined`, so accessing `CSS.supports` throws at module evaluation time.

This adds a `typeof CSS !== 'undefined'` guard before calling `CSS.supports`, so the module can be imported under the plain `node` test environment and does **not** require `jsdom` or `happy-dom`.

```ts
const canUseAnchorPositioning =
  'CSS' in globalThis && typeof CSS !== 'undefined' && typeof CSS.supports === 'function'
    ? CSS.supports('(position-anchor: --anchor)')
    : false
```

### Failing CI this fixes

This crash is hit by downstream consumers that import `sanity` in a `node` test environment, e.g. the `sanity-naive-html-serializer` plugin test suite:

https://github.com/sanity-io/plugins/actions/runs/27822476065/job/82338810916?pr=1355

```
TypeError: Cannot read properties of undefined (reading 'supports')
 ❯ node_modules/sanity/src/core/divergence/components/DivergenceDetail.tsx
 ❯ test/BaseDocumentSerializer/documentLevelSerialization.test.ts
```

(The stack trace surfaces in the published `sanity@6.1.0` bundle via the divergence module import chain; the offending module-level `CSS.supports` call lives in `FormNodeDivergenceDetail.tsx`.)

## What to review

- The added `typeof CSS !== 'undefined'` guard in `packages/sanity/src/core/form/components/FormNodeDivergenceDetail.tsx` correctly short-circuits before touching `CSS.supports`.

## Testing

- Importing the module under a Vitest `node` environment no longer throws.

## Notes for release

Fixes a crash in test runners using the `node` environment caused by accessing `CSS.supports` when the `CSS` global is undefined.