### PR TITLE
feat(core): add document delete references telemetry

### DIFF
--- a/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx
@@ -21,6 +21,18 @@ const LoadingContainer = styled(Flex).attrs({
   height: 110px;
 `
 
+/**
+ * The reference counts known at the point a delete is confirmed, surfaced so
+ * callers can record telemetry about how heavily referenced a document was.
+ *
+ * @internal
+ */
+export interface DeleteReferenceCounts {
+  totalReferenceCount: number
+  internalReferenceCount: number
+  crossDatasetReferenceCount: number
+}
+
 /** @internal */
 export interface ConfirmDeleteDialogProps {
   /**
@@ -39,7 +51,7 @@ export interface ConfirmDeleteDialogProps {
    */
   action?: 'delete' | 'unpublish'
   onCancel: () => void
-  onConfirm: (versions: string[]) => void
+  onConfirm: (versions: string[], referenceCounts: DeleteReferenceCounts) => void
 }
 
 /**
@@ -74,8 +86,12 @@ export function ConfirmDeleteDialog({
   })
 
   const handleConfirm = useCallback(() => {
-    onConfirm(documentVersions)
-  }, [onConfirm, documentVersions])
+    onConfirm(documentVersions, {
+      totalReferenceCount: totalCount,
+      internalReferenceCount: internalReferences?.totalCount ?? 0,
+      crossDatasetReferenceCount: crossDatasetReferences?.totalCount ?? 0,
+    })
+  }, [onConfirm, documentVersions, totalCount, internalReferences, crossDatasetReferences])
 
   return (
     <Dialog

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/index.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/index.tsx
@@ -4,9 +4,13 @@ import {useTranslation} from 'sanity'
 
 import {Dialog, ErrorBoundary} from '../../../ui-components'
 import {structureLocaleNamespace} from '../../i18n'
-import {ConfirmDeleteDialog, type ConfirmDeleteDialogProps} from './ConfirmDeleteDialog'
+import {
+  ConfirmDeleteDialog,
+  type ConfirmDeleteDialogProps,
+  type DeleteReferenceCounts,
+} from './ConfirmDeleteDialog'
 
-export type {ConfirmDeleteDialogProps}
+export type {ConfirmDeleteDialogProps, DeleteReferenceCounts}
 
 type ArgType<T> = T extends (arg: infer U) => unknown ? U : never
 type ErrorInfo = ArgType<ComponentProps<typeof ErrorBoundary>['onCatch']>

--- a/packages/sanity/src/structure/documentActions/DeleteAction.tsx
+++ b/packages/sanity/src/structure/documentActions/DeleteAction.tsx
@@ -25,12 +25,9 @@ const DISABLED_REASON_TITLE_KEY = {
   NOT_READY: 'action.delete.disabled.not-ready',
 }
 
-// A delete waits for the document to become consistent, then runs. If another
-// operation supersedes it first, operationEvents cancels the in-flight delete by
-// design and no outcome ever emits, so the await would hang and leave the action
-// stuck "deleting". The bound guarantees the state resets. 30s clears a real
-// delete (consistency wait plus round-trip on a slow connection) yet still
-// recovers the UI when no outcome arrives.
+// operationEvents switchMaps per document, so a superseding operation drops the
+// delete before it emits an outcome. The telemetry wait is bounded so its
+// subscription is released when no outcome ever arrives.
 const DELETE_OUTCOME_TIMEOUT = 30000
 
 // React Compiler needs functions that are hooks to have the `use` prefix, pascal case are treated as a component, these are hooks even though they're confusingly named `DocumentActionComponent`
@@ -54,7 +51,7 @@ export const useDeleteAction: DocumentActionComponent = ({id, type, draft, versi
   }, [])
 
   const handleConfirm = useCallback(
-    async (versions: string[], referenceCounts: DeleteReferenceCounts) => {
+    (versions: string[], referenceCounts: DeleteReferenceCounts) => {
       const {
         totalReferenceCount: referenceCount,
         internalReferenceCount,
@@ -72,25 +69,25 @@ export const useDeleteAction: DocumentActionComponent = ({id, type, draft, versi
 
       telemetry.log(DocumentDeleted, {...referenceInfo, stage: 'confirmed'})
 
-      // set up the listener before executing so we don't miss the outcome
-      const deleteOutcome = firstValueFrom(
+      // Log the result without gating UI state on it. Subscribe before executing
+      // so we don't miss the outcome.
+      void firstValueFrom(
         documentStore.pair.operationEvents(id, type).pipe(
           filter((event) => event.op === 'delete'),
           map((event) => event.type),
           timeout({first: DELETE_OUTCOME_TIMEOUT}),
           catchError(() => of('dropped' as const)),
         ),
-      )
+      ).then((outcome) => {
+        if (outcome !== 'dropped') {
+          telemetry.log(DocumentDeleted, {
+            ...referenceInfo,
+            stage: outcome === 'success' ? 'deleted' : 'failed',
+          })
+        }
+      })
 
       deleteOp.execute(versions)
-
-      const outcome = await deleteOutcome
-      if (outcome !== 'dropped') {
-        telemetry.log(DocumentDeleted, {
-          ...referenceInfo,
-          stage: outcome === 'success' ? 'deleted' : 'failed',
-        })
-      }
       setIsDeleting(false)
     },
     [deleteOp, documentStore.pair, id, telemetry, type],

--- a/packages/sanity/src/structure/documentActions/DeleteAction.tsx
+++ b/packages/sanity/src/structure/documentActions/DeleteAction.tsx
@@ -1,5 +1,7 @@
 import {TrashIcon} from '@sanity/icons'
+import {useTelemetry} from '@sanity/telemetry/react'
 import {useCallback, useMemo, useState} from 'react'
+import {filter, firstValueFrom} from 'rxjs'
 import {
   type DocumentActionComponent,
   getVersionFromId,
@@ -9,12 +11,14 @@ import {
   useCurrentUser,
   useDocumentOperation,
   useDocumentPairPermissions,
+  useDocumentStore,
   useDocumentVersionTypeSortedList,
   useTranslation,
 } from 'sanity'
 
-import {ConfirmDeleteDialog} from '../components'
+import {ConfirmDeleteDialog, type DeleteReferenceCounts} from '../components'
 import {structureLocaleNamespace} from '../i18n'
+import {DocumentDeleted} from './__telemetry__/documentActions.telemetry'
 
 const DISABLED_REASON_TITLE_KEY = {
   NOTHING_TO_DELETE: 'action.delete.disabled.nothing-to-delete',
@@ -29,6 +33,8 @@ export const useDeleteAction: DocumentActionComponent = ({id, type, draft, versi
   const {delete: deleteOp} = useDocumentOperation(id, type, bundleId)
   const [isDeleting, setIsDeleting] = useState(false)
   const [isConfirmDialogOpen, setConfirmDialogOpen] = useState(false)
+  const documentStore = useDocumentStore()
+  const telemetry = useTelemetry()
 
   const {t} = useTranslation(structureLocaleNamespace)
 
@@ -40,13 +46,42 @@ export const useDeleteAction: DocumentActionComponent = ({id, type, draft, versi
   }, [])
 
   const handleConfirm = useCallback(
-    (versions: string[]) => {
+    async (versions: string[], referenceCounts: DeleteReferenceCounts) => {
+      const {
+        totalReferenceCount: referenceCount,
+        internalReferenceCount,
+        crossDatasetReferenceCount,
+      } = referenceCounts
+      const referenceInfo = {
+        documentId: id,
+        referenceCount,
+        internalReferenceCount,
+        crossDatasetReferenceCount,
+      }
+
       setConfirmDialogOpen(false)
       setIsDeleting(true)
+
+      telemetry.log(DocumentDeleted, {...referenceInfo, stage: 'confirmed'})
+
+      // set up the listener before executing so we don't miss the outcome
+      const deleteOutcome = firstValueFrom(
+        documentStore.pair.operationEvents(id, type).pipe(filter((event) => event.op === 'delete')),
+      )
+
       deleteOp.execute(versions)
-      setIsDeleting(false)
+
+      try {
+        const outcome = await deleteOutcome
+        telemetry.log(DocumentDeleted, {
+          ...referenceInfo,
+          stage: outcome.type === 'success' ? 'deleted' : 'failed',
+        })
+      } finally {
+        setIsDeleting(false)
+      }
     },
-    [deleteOp],
+    [deleteOp, documentStore.pair, id, telemetry, type],
   )
 
   const handle = useCallback(() => {

--- a/packages/sanity/src/structure/documentActions/DeleteAction.tsx
+++ b/packages/sanity/src/structure/documentActions/DeleteAction.tsx
@@ -1,7 +1,7 @@
 import {TrashIcon} from '@sanity/icons'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {useCallback, useMemo, useState} from 'react'
-import {filter, firstValueFrom} from 'rxjs'
+import {catchError, filter, firstValueFrom, map, of, timeout} from 'rxjs'
 import {
   type DocumentActionComponent,
   getVersionFromId,
@@ -24,6 +24,10 @@ const DISABLED_REASON_TITLE_KEY = {
   NOTHING_TO_DELETE: 'action.delete.disabled.nothing-to-delete',
   NOT_READY: 'action.delete.disabled.not-ready',
 }
+
+// A superseding operation on the same document cancels the delete before it
+// emits any outcome, so the wait is bounded to guarantee the action state resets.
+const DELETE_OUTCOME_TIMEOUT = 30000
 
 // React Compiler needs functions that are hooks to have the `use` prefix, pascal case are treated as a component, these are hooks even though they're confusingly named `DocumentActionComponent`
 /** @internal */
@@ -66,20 +70,24 @@ export const useDeleteAction: DocumentActionComponent = ({id, type, draft, versi
 
       // set up the listener before executing so we don't miss the outcome
       const deleteOutcome = firstValueFrom(
-        documentStore.pair.operationEvents(id, type).pipe(filter((event) => event.op === 'delete')),
+        documentStore.pair.operationEvents(id, type).pipe(
+          filter((event) => event.op === 'delete'),
+          map((event) => event.type),
+          timeout({first: DELETE_OUTCOME_TIMEOUT}),
+          catchError(() => of('dropped' as const)),
+        ),
       )
 
       deleteOp.execute(versions)
 
-      try {
-        const outcome = await deleteOutcome
+      const outcome = await deleteOutcome
+      if (outcome !== 'dropped') {
         telemetry.log(DocumentDeleted, {
           ...referenceInfo,
-          stage: outcome.type === 'success' ? 'deleted' : 'failed',
+          stage: outcome === 'success' ? 'deleted' : 'failed',
         })
-      } finally {
-        setIsDeleting(false)
       }
+      setIsDeleting(false)
     },
     [deleteOp, documentStore.pair, id, telemetry, type],
   )

--- a/packages/sanity/src/structure/documentActions/DeleteAction.tsx
+++ b/packages/sanity/src/structure/documentActions/DeleteAction.tsx
@@ -25,8 +25,12 @@ const DISABLED_REASON_TITLE_KEY = {
   NOT_READY: 'action.delete.disabled.not-ready',
 }
 
-// A superseding operation on the same document cancels the delete before it
-// emits any outcome, so the wait is bounded to guarantee the action state resets.
+// A delete waits for the document to become consistent, then runs. If another
+// operation supersedes it first, operationEvents cancels the in-flight delete by
+// design and no outcome ever emits, so the await would hang and leave the action
+// stuck "deleting". The bound guarantees the state resets. 30s clears a real
+// delete (consistency wait plus round-trip on a slow connection) yet still
+// recovers the UI when no outcome arrives.
 const DELETE_OUTCOME_TIMEOUT = 30000
 
 // React Compiler needs functions that are hooks to have the `use` prefix, pascal case are treated as a component, these are hooks even though they're confusingly named `DocumentActionComponent`

--- a/packages/sanity/src/structure/documentActions/__telemetry__/documentActions.telemetry.ts
+++ b/packages/sanity/src/structure/documentActions/__telemetry__/documentActions.telemetry.ts
@@ -54,3 +54,28 @@ export const PublishButtonDisabledComplete = defineEvent<
   version: 1,
   description: 'Logs when the publish button becomes enabled again',
 })
+
+interface DocumentDeletedInfo {
+  /**
+   * Combines internal and cross-dataset references, and counts strong and weak
+   * references together; the API does not expose a strong/weak breakdown.
+   */
+  referenceCount: number
+  internalReferenceCount: number
+  crossDatasetReferenceCount: number
+}
+
+interface DeleteStageInfo {
+  /**
+   * `confirmed` fires on user intent regardless of outcome; a `failed` stage
+   * typically means incoming strong references blocked the deletion.
+   */
+  stage: 'confirmed' | 'deleted' | 'failed'
+}
+
+export const DocumentDeleted = defineEvent<DocumentIdInfo & DocumentDeletedInfo & DeleteStageInfo>({
+  name: 'Document Deleted',
+  version: 1,
+  description:
+    'Logs when a document delete is confirmed, completed, or failed, including how many documents referred to it',
+})


### PR DESCRIPTION
### Description

The delete document action emits no telemetry today, so we cannot tell how often users delete documents that have incoming references, nor how often a delete is blocked by strong references - which surface as an error only after the attempt.

This PR adds a single staged `DocumentDeleted` telemetry event. It fires with the referring-document counts (total, internal, and cross-dataset) when the user confirms a delete, then fires again reporting whether the operation completed or failed. Together these reveal how frequently users delete heavily-referenced documents and how often they hit the strong-reference error.

### What to review

- `documentActions.telemetry.ts` - the event mirrors the existing `PublishButtonClicked` staged pattern (`stage: 'confirmed' | 'deleted' | 'failed'`).
- `DeleteAction.tsx` - the outcome is observed via `documentStore.pair.operationEvents`, the same subscription `DuplicateAction` uses, filtered on both delete success and error.
- Strong and weak references cannot be split: GROQ `references()` returns a combined count, so the `failed` stage stands in as the strong-reference signal, since only strong references block deletion.
- `ConfirmDeleteDialog` gains a second `onConfirm` argument carrying the counts; the shared unpublish caller ignores it.

### Testing

No automated test was added: the delete action has no existing test harness and the dialog's test file is a stub. Verified with the sanity package type-check, oxlint on the changed files, and the targeted existing tests for the affected area.

### Notes for release

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry and a backward-compatible dialog callback extension only; delete behavior and UI are unchanged.
> 
> **Overview**
> Adds **staged `DocumentDeleted` telemetry** so product can see how often users delete documents with incoming references and how often deletes fail (e.g. strong-reference blocks).
> 
> **`ConfirmDeleteDialog`** now passes **`DeleteReferenceCounts`** (total, internal, cross-dataset) as a second argument to `onConfirm`; types are re-exported from the dialog barrel. Unpublish callers can ignore the new argument.
> 
> **`DeleteAction`** logs `DocumentDeleted` with `stage: 'confirmed'` when the user confirms, then subscribes to **`documentStore.pair.operationEvents`** (same pattern as duplicate) to log `stage: 'deleted'` or `'failed'`, with a 30s timeout so superseded operations do not leak subscriptions. UI flow is unchanged—telemetry does not gate `deleteOp.execute`.
> 
> **`documentActions.telemetry.ts`** defines the new event and payload fields; strong vs weak references are not split in counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec9cd1500077eadee589ea016ab50070ab55f548. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->