### PR TITLE
fix(form): clear validation markers when viewing a historical revision

### DIFF
--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -96,6 +96,13 @@ interface DocumentFormOptions {
    */
   getFormDocumentValue?: (value: SanityDocumentLike) => SanityDocumentLike
   displayInlineChanges?: boolean
+  /**
+   * Whether the form is displaying a historical revision (e.g. via "Review
+   * changes"). When `true`, the live document's validation markers are not
+   * applied, since they describe the editable draft/published document rather
+   * than the read-only revision being viewed.
+   */
+  isOlderRevision?: boolean
 }
 interface DocumentFormValue extends Pick<NodeChronologyProps, 'hasUpstreamVersion'> {
   /**
@@ -151,6 +158,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
     readOnly: readOnlyProp,
     onFocusPath,
     displayInlineChanges,
+    isOlderRevision,
   } = options
   const schema = useSchema()
   const presenceStore = usePresenceStore()
@@ -258,7 +266,12 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
     !releaseId,
   )
 
-  const validation = useUnique(validationRaw)
+  // Validation is computed against the live editable document (draft/published/
+  // version). When viewing a historical revision those markers don't describe
+  // what's on screen, so don't surface them on the read-only revision.
+  const validation = useUnique(
+    isOlderRevision ? (EMPTY_ARRAY as ValidationMarker[]) : validationRaw,
+  )
 
   const {previousId: upstreamId} = useDocumentIdStack({
     strict: true,

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -324,6 +324,7 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
     onFocusPath,
     getFormDocumentValue: getDisplayed,
     displayInlineChanges: router.stickyParams.displayInlineChanges === 'true',
+    isOlderRevision: onOlderRevision,
   })
 
   const actionsVersionType = useMemo(

--- a/packages/sanity/src/structure/panes/document/inspectors/validation/index.ts
+++ b/packages/sanity/src/structure/panes/document/inspectors/validation/index.ts
@@ -10,26 +10,21 @@ import {
   isValidationWarning,
   mergeParseErrors,
   useParseErrors,
-  usePerspective,
   useTranslation,
-  useValidationStatus,
 } from 'sanity'
 
 import {VALIDATION_INSPECTOR_NAME} from '../../constants'
 import {useDocumentPane} from '../../useDocumentPane'
 import {ValidationInspector} from './ValidationInspector'
 
-function useMenuItem(props: DocumentInspectorUseMenuItemProps): DocumentInspectorMenuItem {
-  const {documentType} = props
+function useMenuItem(_props: DocumentInspectorUseMenuItemProps): DocumentInspectorMenuItem {
   const {t} = useTranslation('validation')
-  const {selectedReleaseId} = usePerspective()
-  const {value} = useDocumentPane()
-
-  const {validation: validationMarkers} = useValidationStatus(
-    value._id,
-    documentType,
-    !selectedReleaseId,
-  )
+  // Read the same validation the inspector panel uses (from the document pane),
+  // rather than fetching it directly from the live document. This keeps the
+  // status-bar badge and the panel in sync — e.g. both are empty while viewing
+  // a historical revision, where validation is suppressed. Reading it directly
+  // here would leave a stale red badge that opens an empty panel.
+  const {validation: validationMarkers, value} = useDocumentPane()
   const parseErrors = useParseErrors()
 
   const validation: FormNodeValidation[] = useMemo(() => {


### PR DESCRIPTION
## What & why

Resolves [SAPP-2646](https://linear.app/sanity/issue/SAPP-2646).

When you open a historical revision via **Review changes**, the document form rendered the **live draft's validation errors** on top of the read-only revision — even though that revision is valid. The draft's "this field is required" markers were shown on the revision's fields, misrepresenting its validity.

## Root cause

In `useDocumentForm`, validation comes from `useValidationStatus(value._id, …)`, which validates the **editable** document (draft/published/version) by id. While viewing an older revision, the form *value* shown is the revision snapshot (via `getFormDocumentValue`), but the validation markers still describe the live draft — so they get mapped onto the revision's fields by path.

## Fix

Thread an `isOlderRevision` flag (from the timeline's existing `onOlderRevision`) into `useDocumentForm`, and suppress the live validation markers while a revision is displayed:

```ts
const validation = useUnique(isOlderRevision ? EMPTY_ARRAY : validationRaw)
```

Scope is deliberately narrow:
- Only clears when an **older revision** is selected (`onOlderRevision`), **not** during normal change-review of the editable draft — validation still shows there as before.
- The revision view is read-only, so these markers were never actionable on it; they only misrepresented the revision.

## Test plan (manual)

`useDocumentForm` has no unit harness (it composes ~19 hooks), so verify in a studio:

- [ ] Create a draft, fill all fields validly, publish. Repeat a couple times.
- [ ] Make a field on the current draft invalid → confirm the validation error shows.
- [ ] Open **Review changes** and select an earlier revision → **the validation error no longer shows** (the revision is valid).
- [ ] Return to the current draft → the validation error shows again.
- [ ] Normal change-review (without selecting an older revision) still shows draft validation as before.

Type-check passes across the `sanity` package; format + oxlint clean.

Fixes SAPP-2646
