### PR TITLE
fix(releases): preview the draft in the discard draft dialog

### DIFF
--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -104,7 +104,15 @@ export function DiscardVersionDialog(props: {
           <Preview
             value={{_id: isGoingToUnpublish ? getPublishedId(documentId) : documentId}}
             schemaType={schemaType}
-            perspectiveStack={isGoingToUnpublish ? [] : [currentRelease]}
+            // Resolve the preview under the perspective of what's being discarded:
+            // the published doc when unpublishing, the drafts perspective when
+            // discarding a draft, otherwise the release version. Without the
+            // explicit 'drafts' stack a draft falls back to its published value
+            // (or "Untitled" when none exists), so it wouldn't show the draft
+            // being discarded.
+            perspectiveStack={
+              isGoingToUnpublish ? [] : discardType === 'draft' ? ['drafts'] : [currentRelease]
+            }
           />
         ) : (
           <LoadingBlock />

--- a/packages/sanity/src/core/releases/components/dialog/__tests__/DiscardVersionDialog.test.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/__tests__/DiscardVersionDialog.test.tsx
@@ -1,0 +1,84 @@
+import {defineType} from '@sanity/types'
+import {render, waitFor} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {defineConfig} from '../../../../config'
+import {DiscardVersionDialog} from '../DiscardVersionDialog'
+
+const {previewSpy} = vi.hoisted(() => ({previewSpy: vi.fn()}))
+
+// Capture the props the document preview is rendered with so we can assert the
+// perspective the dialog resolves it under.
+vi.mock('../../../../preview', () => ({
+  Preview: (props: Record<string, unknown>) => {
+    previewSpy(props)
+    return null
+  },
+}))
+
+vi.mock('../../../../hooks/useDocumentOperation', () => ({
+  useDocumentOperation: vi.fn(() => ({discardChanges: {execute: vi.fn()}})),
+}))
+
+vi.mock('../../../hooks/useVersionOperations', () => ({
+  useVersionOperations: vi.fn(() => ({discardVersion: vi.fn()})),
+}))
+
+vi.mock('../../../../perspective/usePerspective', () => ({
+  usePerspective: vi.fn(() => ({selectedPerspective: 'drafts'})),
+}))
+
+const config = defineConfig({
+  projectId: 'test',
+  dataset: 'test',
+  schema: {
+    types: [
+      defineType({
+        name: 'testDoc',
+        type: 'document',
+        fields: [{name: 'title', type: 'string'}],
+      }),
+    ],
+  },
+})
+
+async function renderDialog(props: {documentId: string; isGoingToUnpublish?: boolean}) {
+  const wrapper = await createTestProvider({config})
+  render(
+    <DiscardVersionDialog
+      onClose={vi.fn()}
+      documentId={props.documentId}
+      documentType="testDoc"
+      fromPerspective="drafts"
+      isGoingToUnpublish={props.isGoingToUnpublish ?? false}
+    />,
+    {wrapper},
+  )
+  await waitFor(() => expect(previewSpy).toHaveBeenCalled())
+}
+
+describe('DiscardVersionDialog preview perspective', () => {
+  beforeEach(() => {
+    previewSpy.mockClear()
+  })
+
+  it('previews a discarded draft under the drafts perspective', async () => {
+    await renderDialog({documentId: 'drafts.my-doc'})
+    expect(previewSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({perspectiveStack: ['drafts']}),
+    )
+  })
+
+  it('previews a discarded release version under its release perspective', async () => {
+    await renderDialog({documentId: 'versions.rSummer.my-doc'})
+    expect(previewSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({perspectiveStack: ['rSummer']}),
+    )
+  })
+
+  it('previews the published document (empty perspective) when unpublishing', async () => {
+    await renderDialog({documentId: 'drafts.my-doc', isGoingToUnpublish: true})
+    expect(previewSpy).toHaveBeenLastCalledWith(expect.objectContaining({perspectiveStack: []}))
+  })
+})


### PR DESCRIPTION
## What & why

Resolves [SAPP-3748](https://linear.app/sanity/issue/SAPP-3748).

The "Discard changes" modal renders a preview of the document being discarded, but for a **draft** it showed the *published* version's details — or **"Untitled"** when no published version exists — instead of the draft.

## Root cause

`DiscardVersionDialog` resolves its preview under `perspectiveStack={[currentRelease]}`, where `currentRelease = getVersionNameFromId(documentId)`. A draft id has no release name, so the stack is effectively empty and the preview falls back to the published value (or nothing → "Untitled").

## Fix

Resolve the preview under the **`drafts`** perspective when discarding a draft:

```ts
perspectiveStack={
  isGoingToUnpublish ? [] : discardType === 'draft' ? ['drafts'] : [currentRelease]
}
```

Release-version and unpublish behaviours are unchanged.

## Tests

New `DiscardVersionDialog.test.tsx` mocks the `Preview` component and asserts the perspective the dialog resolves it under:
- draft → `['drafts']` (the fix)
- release version → `[<releaseName>]` (unchanged)
- unpublishing → `[]` (unchanged)

Type-check passes across the `sanity` package; format + oxlint clean.

Fixes SAPP-3748
