### PR TITLE
fix(bundle-manager): route GCS auth through global fetch to avoid premature close

### DIFF
--- a/packages/@repo/bundle-manager/src/commands/tagVersion.ts
+++ b/packages/@repo/bundle-manager/src/commands/tagVersion.ts
@@ -1,17 +1,14 @@
-import {Storage} from '@google-cloud/storage'
 import {readEnv} from '@repo/utils'
 
 import {isValidTag} from '../assert'
 import {corePkgs, VALID_TAGS} from '../constants'
+import {createStorageClient} from '../helpers/createStorageClient'
 import {updateManifestWith} from '../helpers/updateManifestWith'
 import {tagVersion as tagManifestVersion} from '../operations/tagVersion'
 import {type KnownEnvVar} from '../types'
 import {cleanDirName, currentUnixTime} from '../utils'
 
-const storage = new Storage({
-  projectId: readEnv<KnownEnvVar>('GOOGLE_PROJECT_ID'),
-  credentials: JSON.parse(readEnv<KnownEnvVar>('GCLOUD_SERVICE_KEY')),
-})
+const storage = createStorageClient()
 
 const bucket = storage.bucket(readEnv<KnownEnvVar>('GCLOUD_BUCKET'))
 

--- a/packages/@repo/bundle-manager/src/commands/uploadBundles.ts
+++ b/packages/@repo/bundle-manager/src/commands/uploadBundles.ts
@@ -3,22 +3,20 @@ import {readdir, readFile, stat, writeFile} from 'node:fs/promises'
 import {type SourceMapPayload} from 'node:module'
 import path from 'node:path'
 
-import {Storage, type UploadOptions} from '@google-cloud/storage'
+import {type UploadOptions} from '@google-cloud/storage'
 import {MONOREPO_ROOT, readEnv} from '@repo/utils'
 import {type NormalizedReadResult, readPackageUp} from 'read-package-up'
 
 import {isValidTag} from '../assert'
 import {appVersion, corePkgs, VALID_TAGS} from '../constants'
+import {createStorageClient} from '../helpers/createStorageClient'
 import {updateManifestWith} from '../helpers/updateManifestWith'
 import {addVersion} from '../operations/addVersion'
 import {tagVersion} from '../operations/tagVersion'
 import {type DistTag, type KnownEnvVar, type Manifest} from '../types'
 import {cleanDirName, currentUnixTime} from '../utils'
 
-const storage = new Storage({
-  projectId: readEnv<KnownEnvVar>('GOOGLE_PROJECT_ID'),
-  credentials: JSON.parse(readEnv<KnownEnvVar>('GCLOUD_SERVICE_KEY')),
-})
+const storage = createStorageClient()
 
 const bucket = storage.bucket(readEnv<KnownEnvVar>('GCLOUD_BUCKET'))
 

--- a/packages/@repo/bundle-manager/src/commands/verify.ts
+++ b/packages/@repo/bundle-manager/src/commands/verify.ts
@@ -1,13 +1,10 @@
-import {Storage} from '@google-cloud/storage'
 import {readEnv} from '@repo/utils'
 
+import {createStorageClient} from '../helpers/createStorageClient'
 import {updateManifestWith} from '../helpers/updateManifestWith'
 import {type KnownEnvVar} from '../types'
 
-const storage = new Storage({
-  projectId: readEnv<KnownEnvVar>('GOOGLE_PROJECT_ID'),
-  credentials: JSON.parse(readEnv<KnownEnvVar>('GCLOUD_SERVICE_KEY')),
-})
+const storage = createStorageClient()
 
 const bucket = storage.bucket(readEnv<KnownEnvVar>('GCLOUD_BUCKET'))
 

--- a/packages/@repo/bundle-manager/src/helpers/createStorageClient.ts
+++ b/packages/@repo/bundle-manager/src/helpers/createStorageClient.ts
@@ -1,0 +1,29 @@
+import {Storage} from '@google-cloud/storage'
+import {readEnv} from '@repo/utils'
+
+import {type KnownEnvVar} from '../types'
+
+/**
+ * Creates the GCS `Storage` client used to publish bundles, configured from the
+ * standard `GOOGLE_PROJECT_ID`, `GCLOUD_SERVICE_KEY` and `GCLOUD_BUCKET`
+ * environment variables.
+ *
+ * The auth transporter (gaxios) is told to make its requests with the runtime's
+ * global `fetch` (undici) instead of its default `node-fetch@2`. Node 24.17.0's
+ * fix for CVE-2026-48931 added a public `'data'` listener to idle keep-alive
+ * agent sockets, which trips `node-fetch@2`'s `fixResponseChunkedTransferBadEnding`
+ * false-positive and surfaces as `ERR_STREAM_PREMATURE_CLOSE` when fetching
+ * OAuth tokens from googleapis.com. Routing through undici takes the buggy
+ * `node-fetch@2` detector out of the path entirely (rather than just avoiding
+ * the socket reuse that triggers it), so it is robust to future Node changes.
+ * gaxios itself \(retries, interceptors, error handling\) is unchanged.
+ *
+ * @see https://github.com/nodejs/node/issues/63989
+ */
+export function createStorageClient(): Storage {
+  return new Storage({
+    projectId: readEnv<KnownEnvVar>('GOOGLE_PROJECT_ID'),
+    credentials: JSON.parse(readEnv<KnownEnvVar>('GCLOUD_SERVICE_KEY')),
+    clientOptions: {transporterOptions: {fetchImplementation: globalThis.fetch}},
+  })
+}


### PR DESCRIPTION
### Description

The release pipeline started failing consistently at the "Upload bundles to staging bucket" step with `ERR_STREAM_PREMATURE_CLOSE` while fetching an OAuth token from `googleapis.com` — surfaced (misleadingly) as `Failed to copy files from sanity`. The break coincided with #13233 migrating CI setup to `pnpm/setup@v1`, which floated `node@lts` up from toolcache Node 24.16.0 to 24.17.0.

The actual cause is a Node 24.17.0 regression, which will be fixed in an upcoming release.

In the meantime, routes gaxios's auth requests through the runtime's global `fetch` (undici) via the `fetchImplementation` option gaxios already exposes, taking the buggy `node-fetch@2` detector out of the path entirely.

### What to review


### Testing
bundle uploading should work again once merged to main

### Notes for release

N/A – Internal release tooling only.
