### PR TITLE
fix(bundle-manager): disable keep-alive for GCS auth to avoid premature close

### DIFF
--- a/packages/@repo/bundle-manager/src/helpers/createStorageClient.ts
+++ b/packages/@repo/bundle-manager/src/helpers/createStorageClient.ts
@@ -1,3 +1,5 @@
+import {Agent} from 'node:https'
+
 import {Storage} from '@google-cloud/storage'
 import {readEnv} from '@repo/utils'
 
@@ -8,15 +10,20 @@ import {type KnownEnvVar} from '../types'
  * standard `GOOGLE_PROJECT_ID`, `GCLOUD_SERVICE_KEY` and `GCLOUD_BUCKET`
  * environment variables.
  *
- * The auth transporter (gaxios) is told to make its requests with the runtime's
- * global `fetch` (undici) instead of its default `node-fetch@2`. Node 24.17.0's
- * fix for CVE-2026-48931 added a public `'data'` listener to idle keep-alive
- * agent sockets, which trips `node-fetch@2`'s `fixResponseChunkedTransferBadEnding`
- * false-positive and surfaces as `ERR_STREAM_PREMATURE_CLOSE` when fetching
- * OAuth tokens from googleapis.com. Routing through undici takes the buggy
- * `node-fetch@2` detector out of the path entirely (rather than just avoiding
- * the socket reuse that triggers it), so it is robust to future Node changes.
- * gaxios itself \(retries, interceptors, error handling\) is unchanged.
+ * The auth transporter (gaxios → `node-fetch@2`) is given an agent with
+ * keep-alive disabled. Node 24.17.0's fix for CVE-2026-48931 added a public
+ * `'data'` listener to idle keep-alive agent sockets; when such a socket is
+ * reused, `node-fetch@2`'s `fixResponseChunkedTransferBadEnding` heuristic
+ * misreads that listener as an unfinished body and throws a false
+ * `ERR_STREAM_PREMATURE_CLOSE` while fetching OAuth tokens from googleapis.com.
+ * Using a fresh socket per request avoids the reuse that triggers the bug.
+ *
+ * Note: we deliberately do not swap `gaxios`'s `fetchImplementation` to the
+ * global `fetch` (undici) here. Doing so fixes the token fetch but breaks
+ * `@google-cloud/storage`'s resumable upload, which passes an `abort-controller`
+ * polyfill signal that undici rejects ("Expected signal to be an instance of
+ * AbortSignal"). Keeping `node-fetch@2` and just disabling socket reuse avoids
+ * both bugs.
  *
  * @see https://github.com/nodejs/node/issues/63989
  */
@@ -24,6 +31,6 @@ export function createStorageClient(): Storage {
   return new Storage({
     projectId: readEnv<KnownEnvVar>('GOOGLE_PROJECT_ID'),
     credentials: JSON.parse(readEnv<KnownEnvVar>('GCLOUD_SERVICE_KEY')),
-    clientOptions: {transporterOptions: {fetchImplementation: globalThis.fetch}},
+    clientOptions: {transporterOptions: {agent: new Agent({keepAlive: false})}},
   })
 }


### PR DESCRIPTION
### Description
Alternative attempt at fixing the premature close issue, as https://github.com/sanity-io/sanity/pull/13258 surfaced an incompatibility issue with node's global fetch and gaxios:

`
error: [TypeError: RequestInit: Expected signal ("AbortSignal ***") to be an instance of AbortSignal.]
`

### What to review


### Testing
Lets see if it works after merge this time

### Notes for release

n/a – internal