### PR TITLE
build(workspace): use catalog protocol for workspace overrides

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -85,8 +85,8 @@ minimumReleaseAgeExclude:
 
 overrides:
   # The e2e-ui.yml workflow needs a @sanity/ui related override in the root package.json in order for it's pnpm add -w ./artifacts/sanity-ui-*.tgz to work its magic.
-  '@sanity/ui@3': '$@sanity/ui'
-  vitest: $vitest
+  '@sanity/ui@3': 'catalog:'
+  vitest: 'catalog:'
 
 preferWorkspacePackages: true
 


### PR DESCRIPTION
### Description
Running pnpm install is a bit spammy now:
> [WARN] The "$" version reference syntax in overrides is deprecated (used by: @sanity/ui@3, vitest). Define the version in a catalog and reference it with the "catalog:" protocol instead. See https://pnpm.io/catalogs

This PR removes these warnings by following the recommendation to move to `catalog:` for overrides.

### What to review
Makes sense?

### Testing

### Notes for release
n/a