### PR TITLE
fix(releases): allow scrolling in description field when content exceeds max height

### DIFF
--- a/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
@@ -118,19 +118,17 @@ export function TitleDescriptionForm({
     })
 
   useEffect(() => {
-    if (descriptionRef.current) {
-      setScrollHeight(descriptionRef.current.scrollHeight)
-    }
-    if (titleRef.current) {
-      resizeTextarea(titleRef.current)
-    }
-  }, [])
-
-  useEffect(() => {
     if (titleRef.current) {
       resizeTextarea(titleRef.current)
     }
   }, [release.metadata.title])
+
+  useEffect(() => {
+    if (descriptionRef.current) {
+      resizeTextarea(descriptionRef.current)
+      setScrollHeight(descriptionRef.current.scrollHeight)
+    }
+  }, [release.metadata.description])
 
   const handleTitleChange = useCallback(
     (event: ChangeEvent<HTMLTextAreaElement>) => {

--- a/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
@@ -84,6 +84,11 @@ const DescriptionTextArea = styled.textarea((props) => {
 export const getIsReleaseOpen = (release: EditableReleaseDocument): boolean =>
   release.state !== 'archived' && release.state !== 'published'
 
+function resizeTextarea(element: HTMLTextAreaElement): void {
+  element.style.height = 'auto'
+  element.style.height = `${element.scrollHeight}px`
+}
+
 export function TitleDescriptionForm({
   release,
   onChange,
@@ -94,8 +99,8 @@ export function TitleDescriptionForm({
   disabled?: boolean
 }): React.JSX.Element {
   const isReleaseOpen = getIsReleaseOpen(release)
-  const titleRef = useRef<HTMLTextAreaElement | null>(null)
-  const descriptionRef = useRef<HTMLTextAreaElement | null>(null)
+  const titleRef = useRef<HTMLTextAreaElement>(null)
+  const descriptionRef = useRef<HTMLTextAreaElement>(null)
   const [scrollHeight, setScrollHeight] = useState(46)
   const {t} = useTranslation()
 
@@ -113,22 +118,17 @@ export function TitleDescriptionForm({
     })
 
   useEffect(() => {
-    // make sure that the text area for the description has the right height initially
     if (descriptionRef.current) {
       setScrollHeight(descriptionRef.current.scrollHeight)
     }
-    // Auto-resize title textarea
     if (titleRef.current) {
-      titleRef.current.style.height = 'auto'
-      titleRef.current.style.height = `${titleRef.current.scrollHeight}px`
+      resizeTextarea(titleRef.current)
     }
   }, [])
 
   useEffect(() => {
-    // Auto-resize title textarea when value changes
     if (titleRef.current) {
-      titleRef.current.style.height = 'auto'
-      titleRef.current.style.height = `${titleRef.current.scrollHeight}px`
+      resizeTextarea(titleRef.current)
     }
   }, [release.metadata.title])
 
@@ -136,14 +136,10 @@ export function TitleDescriptionForm({
     (event: ChangeEvent<HTMLTextAreaElement>) => {
       event.preventDefault()
       const title = event.target.value
-      // save the values to make input snappier while requests happen in the background
       updateLocalData({title})
       onChange({...release, metadata: {...release.metadata, title}})
-
-      // Auto-resize the textarea
       if (titleRef.current) {
-        titleRef.current.style.height = 'auto'
-        titleRef.current.style.height = `${titleRef.current.scrollHeight}px`
+        resizeTextarea(titleRef.current)
       }
     },
     [onChange, release, updateLocalData],
@@ -155,20 +151,12 @@ export function TitleDescriptionForm({
       if (!isReleaseOpen) return
 
       const description = event.target.value
-      // save the values to make input snappier while requests happen in the background
       updateLocalData({description})
       onChange({...release, metadata: {...release.metadata, description}})
 
-      /** we must reset the height in order to make sure that if the text area shrinks,
-       * that the actual input will change height as well */
+      // Reset to 'auto' first so the textarea can shrink when text is removed
       if (descriptionRef.current) {
-        descriptionRef.current.style.overflow = 'hidden'
-        descriptionRef.current.style.height = 'auto'
-        descriptionRef.current.style.height = `${descriptionRef.current.scrollHeight}px`
-
-        if (parseInt(descriptionRef.current.style.height, 10) > MAX_DESCRIPTION_HEIGHT) {
-          descriptionRef.current.style.overflow = 'auto'
-        }
+        resizeTextarea(descriptionRef.current)
       }
 
       setScrollHeight(event.currentTarget.scrollHeight)
@@ -203,6 +191,7 @@ export function TitleDescriptionForm({
           style={{
             height: `${scrollHeight}px`,
             maxHeight: MAX_DESCRIPTION_HEIGHT,
+            overflowY: scrollHeight > MAX_DESCRIPTION_HEIGHT ? 'auto' : 'hidden',
           }}
           data-testid="release-form-description"
           disabled={disabled}


### PR DESCRIPTION
### Description

The description field in the release edit dialog did not scroll once its content passed the maximum height, leaving longer descriptions unreachable. Overflow was set imperatively inside the change handler and only while typing, so a description that exceeded the cap on initial render or from a programmatic update never gained a scrollbar.

This PR drives the textarea's vertical overflow from render state instead: `overflowY` is `auto` once `scrollHeight` passes `MAX_DESCRIPTION_HEIGHT`, otherwise `hidden`. It also folds the repeated auto-resize logic into a single `resizeTextarea` helper and tightens the textarea ref types.

Before
<img width="912" height="690" alt="ReleaseScrollBEFOREPR" src="https://github.com/user-attachments/assets/4ca75a39-1c14-43cf-9089-bb9ac8b54911" />

After
<img width="912" height="690" alt="ReleaseScrollAFTERPR" src="https://github.com/user-attachments/assets/89bc3699-85f7-4f8c-b017-667792a058a0" />

### What to review

Open a release in the edit dialog and type (or paste) a description longer than the field's max height. The field should grow to the cap, then scroll. Confirm the title field still auto-grows and that removing text shrinks the description back down.

### Testing

Existing `ReleaseForm` tests pass (9/9). No unit test covers the scroll behaviour itself: it depends on layout-driven `scrollHeight`, which jsdom does not compute, so it was verified manually in the dialog.

### Notes for release

The description field in the release dialog now scrolls when its content exceeds the maximum height.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI behavior in the release title/description form with no auth, data, or API changes.
> 
> **Overview**
> Fixes the release edit dialog **description** field so long text stays reachable after it hits the **200px** cap. Overflow is no longer toggled only while typing in the change handler; **`overflowY`** is set from render state (`auto` when tracked **`scrollHeight`** exceeds **`MAX_DESCRIPTION_HEIGHT`**, otherwise `hidden`), including on initial load and external metadata updates.
> 
> Auto-resize for title and description is consolidated into a shared **`resizeTextarea`** helper, with effects keyed to **`release.metadata.title`** and **`release.metadata.description`** so sizing stays in sync when values change outside the input handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd5a8f683b07ff5cddf9afdb76d54e7c2ed8b08a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->