### PR TITLE
feat(schema): add descriptor upload client

### DIFF
--- a/packages/@repo/test-dts-exports/test/fixtures/@sanity.schema._internal.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/@sanity.schema._internal.test-d.ts
@@ -24,6 +24,9 @@ import type {
   ManifestWorkspaceFile,
   ParsedWorkspaceSchemaId,
   parseWorkspaceSchemaId,
+  PreparedSchemaUpload,
+  prepareSchemaUpload,
+  PrepareSchemaUploadOptions,
   Problem,
   ProblemPath,
   ProblemPathPropertySegment,
@@ -109,6 +112,15 @@ describe('@sanity/schema/_internal', () => {
   })
   test('parseWorkspaceSchemaId', () => {
     expectTypeOf<typeof parseWorkspaceSchemaId>().toBeFunction()
+  })
+  test('PreparedSchemaUpload', () => {
+    expectTypeOf<PreparedSchemaUpload>().toBeObject()
+  })
+  test('prepareSchemaUpload', () => {
+    expectTypeOf<typeof prepareSchemaUpload>().toBeFunction()
+  })
+  test('PrepareSchemaUploadOptions', () => {
+    expectTypeOf<PrepareSchemaUploadOptions>().not.toBeNever()
   })
   test('Problem', () => {
     expectTypeOf<Problem>().toBeObject()

--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -69,6 +69,7 @@
     "@sanity/generate-help-url": "^4.0.0",
     "@sanity/types": "workspace:*",
     "arrify": "^3.0.0",
+    "get-it": "^8.8.0",
     "groq-js": "^1.30.3",
     "humanize-list": "^1.0.1",
     "leven": "^4.1.0",

--- a/packages/@sanity/schema/src/_exports/_internal.ts
+++ b/packages/@sanity/schema/src/_exports/_internal.ts
@@ -1,6 +1,9 @@
 export {DescriptorConverter} from '../descriptors/convert'
 export * from '../descriptors/sync'
 export {
+  type PreparedSchemaUpload,
+  prepareSchemaUpload,
+  type PrepareSchemaUploadOptions,
   uploadSchema,
   type UploadSchemaOptions,
   type UploadSchemaPhase,

--- a/packages/@sanity/schema/src/_exports/_internal.ts
+++ b/packages/@sanity/schema/src/_exports/_internal.ts
@@ -1,5 +1,7 @@
 export {DescriptorConverter} from '../descriptors/convert'
 export * from '../descriptors/sync'
+export {uploadSchema, type UploadSchemaOptions} from '../descriptors/uploadSchema'
+export type {DescriptorRequester} from '../descriptors/transport'
 export {isActionEnabled} from '../legacy/actionUtils'
 export {
   DEFAULT_MAX_FIELD_DEPTH,

--- a/packages/@sanity/schema/src/_exports/_internal.ts
+++ b/packages/@sanity/schema/src/_exports/_internal.ts
@@ -1,6 +1,10 @@
 export {DescriptorConverter} from '../descriptors/convert'
 export * from '../descriptors/sync'
-export {uploadSchema, type UploadSchemaOptions} from '../descriptors/uploadSchema'
+export {
+  uploadSchema,
+  type UploadSchemaOptions,
+  type UploadSchemaPhase,
+} from '../descriptors/uploadSchema'
 export type {DescriptorRequester} from '../descriptors/transport'
 export {isActionEnabled} from '../legacy/actionUtils'
 export {

--- a/packages/@sanity/schema/src/descriptors/transport.ts
+++ b/packages/@sanity/schema/src/descriptors/transport.ts
@@ -1,0 +1,65 @@
+import {getIt, type RequestOptions} from 'get-it'
+import {base, httpErrors, jsonRequest, jsonResponse, promise, retry} from 'get-it/middleware'
+
+/**
+ * Headers applied to each request.
+ *
+ * @internal
+ */
+export type RequestHeaders = Record<string, string>
+
+/**
+ * Request shape the client passes to the transport. Aliases get-it's
+ * `RequestOptions` so the bundled requester and any caller-injected one share a
+ * single contract; the client itself only ever sets `url`, `method`, `body`,
+ * and `headers`.
+ *
+ * @internal
+ */
+export type DescriptorRequestOptions = RequestOptions
+
+/**
+ * The transport seam. The client calls this for every request; the return value
+ * is the parsed response body. Any requester with the shape
+ * `<B>(options): Promise<B>` — such as a configured `get-it` instance — is
+ * structurally assignable, so callers can bring their own transport.
+ *
+ * @internal
+ */
+export type DescriptorRequester = <T>(options: DescriptorRequestOptions) => Promise<T>
+
+/**
+ * Retry on rate-limit (429) and server (5xx) responses.
+ *
+ * @internal
+ */
+export function defaultShouldRetry(err: unknown): boolean {
+  const statusCode = (err as {response?: {statusCode?: number}} | undefined)?.response?.statusCode
+  return statusCode === 429 || (typeof statusCode === 'number' && statusCode >= 500)
+}
+
+/**
+ * @internal
+ */
+export interface GetItRequesterOptions {
+  baseUrl: string
+}
+
+/**
+ * Build the default get-it requester. Auth and headers are NOT applied here —
+ * `uploadSchema`'s `request` helper merges them into each request's `headers` so
+ * the same path serves both this transport and a caller-injected requester.
+ *
+ * @internal
+ */
+export function createGetItRequester(options: GetItRequesterOptions): DescriptorRequester {
+  const requester = getIt([
+    base(options.baseUrl),
+    jsonResponse(),
+    jsonRequest(),
+    httpErrors(),
+    retry({shouldRetry: defaultShouldRetry}),
+    promise({onlyBody: true}),
+  ])
+  return <T>(opts: DescriptorRequestOptions) => requester(opts) as Promise<T>
+}

--- a/packages/@sanity/schema/src/descriptors/uploadSchema.test.ts
+++ b/packages/@sanity/schema/src/descriptors/uploadSchema.test.ts
@@ -1,0 +1,234 @@
+import {describe, expect, test} from 'vitest'
+
+import {Schema} from '../legacy/Schema'
+import {builtinTypes} from '../sanity/builtinTypes'
+import {groupProblems} from '../sanity/groupProblems'
+import {validateSchema} from '../sanity/validateSchema'
+import {defaultShouldRetry, type DescriptorRequestOptions} from './transport'
+import {uploadSchema} from './uploadSchema'
+
+describe('defaultShouldRetry', () => {
+  test('retries on 429 and 5xx, not on 4xx or non-http errors', () => {
+    expect(defaultShouldRetry({response: {statusCode: 429}})).toBe(true)
+    expect(defaultShouldRetry({response: {statusCode: 503}})).toBe(true)
+    expect(defaultShouldRetry({response: {statusCode: 404}})).toBe(false)
+    expect(defaultShouldRetry({response: {statusCode: 200}})).toBe(false)
+    expect(defaultShouldRetry(new Error('boom'))).toBe(false)
+    expect(defaultShouldRetry(undefined)).toBe(false)
+  })
+})
+
+// taken from sanity/src/core/schema/createSchema.ts
+function createSchema(schemaDef: {name: string; types: any[]}, skipBuiltins = false) {
+  const validated = validateSchema(schemaDef.types).getTypes()
+  const validation = groupProblems(validated)
+  const hasErrors = validation.some((group) =>
+    group.problems.some((problem) => problem.severity === 'error'),
+  )
+
+  return Schema.compile({
+    name: 'test',
+    types: hasErrors
+      ? []
+      : [...schemaDef.types, ...(skipBuiltins ? [] : builtinTypes)].filter(Boolean),
+  })
+}
+
+function makeSchema() {
+  return createSchema({
+    name: 'test',
+    types: [{name: 'author', type: 'document', fields: [{name: 'name', type: 'string'}]}],
+  })
+}
+
+/** Build an uploadSchema caller backed by a recording fake requester. */
+function recording(responder: (opts: DescriptorRequestOptions) => unknown) {
+  const calls: DescriptorRequestOptions[] = []
+  const requester = async <T>(opts: DescriptorRequestOptions): Promise<T> => {
+    calls.push(opts)
+    return responder(opts) as T
+  }
+  return {requester, calls}
+}
+
+describe('uploadSchema — transport guards', () => {
+  test('throws when neither baseUrl nor requester is provided', async () => {
+    await expect(
+      // @ts-expect-error - exactly one of baseUrl/requester is required (compile-time guard)
+      uploadSchema(makeSchema(), {contextKey: 'studio:1'}),
+    ).rejects.toThrow(/requester.*baseUrl|baseUrl.*requester/i)
+  })
+
+  test('throws when both baseUrl and requester are provided', async () => {
+    const {requester} = recording(() => ({}))
+    await expect(
+      // @ts-expect-error - cannot provide both baseUrl and requester (compile-time guard)
+      uploadSchema(makeSchema(), {
+        contextKey: 'studio:1',
+        baseUrl: 'https://api.example',
+        requester,
+      }),
+    ).rejects.toThrow(/both/i)
+  })
+})
+
+describe('uploadSchema — header merging', () => {
+  test('derives Authorization from token and forwards headers; header entry overrides token', async () => {
+    const {requester, calls} = recording((opts) => {
+      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
+      if (opts.url.endsWith('/commit')) return {}
+      throw new Error(`unexpected call to ${opts.url}`)
+    })
+    await uploadSchema(makeSchema(), {
+      contextKey: 'studio:1',
+      requester,
+      token: 'tok',
+      headers: {'x-sanity-project-id': 'p1'},
+    })
+    expect(calls[0]!.headers).toMatchObject({
+      'Authorization': 'Bearer tok',
+      'x-sanity-project-id': 'p1',
+    })
+
+    const override = recording((opts) => {
+      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
+      if (opts.url.endsWith('/commit')) return {}
+      throw new Error(`unexpected call to ${opts.url}`)
+    })
+    await uploadSchema(makeSchema(), {
+      contextKey: 'studio:1',
+      requester: override.requester,
+      token: 'tok',
+      headers: {Authorization: 'Bearer other'},
+    })
+    expect(override.calls[0]!.headers).toMatchObject({Authorization: 'Bearer other'})
+  })
+
+  test('a lowercase authorization header suppresses the derived token (no duplicate)', async () => {
+    const {requester, calls} = recording((opts) => {
+      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
+      if (opts.url.endsWith('/commit')) return {}
+      throw new Error(`unexpected call to ${opts.url}`)
+    })
+    await uploadSchema(makeSchema(), {
+      contextKey: 'studio:1',
+      requester,
+      token: 'tok',
+      headers: {authorization: 'Bearer other'},
+    })
+    const sent = calls[0]!.headers!
+    expect(sent['authorization']).toBe('Bearer other')
+    expect(sent['Authorization']).toBeUndefined()
+  })
+})
+
+describe('uploadSchema — synchronization', () => {
+  test('claim returns complete → commits without a synchronize call, returns descriptorId', async () => {
+    const {requester, calls} = recording((opts) => {
+      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
+      if (opts.url.endsWith('/commit')) return {}
+      throw new Error(`unexpected call to ${opts.url}`)
+    })
+    const id = await uploadSchema(makeSchema(), {contextKey: 'studio:1', requester})
+    expect(typeof id).toBe('string')
+    expect(id.length).toBeGreaterThan(0)
+    expect(calls.map((c) => c.url)).toEqual([
+      '/v2025-06-01/descriptors/claim',
+      '/v2025-06-01/descriptors/commit',
+    ])
+  })
+
+  test('incomplete then complete → one synchronize round then commit, returns id', async () => {
+    let descriptorId = ''
+    const {requester, calls} = recording((opts) => {
+      if (opts.url.endsWith('/claim')) {
+        descriptorId = (opts.body as {descriptorId: string}).descriptorId
+        return {synchronization: {type: 'incomplete', missingIds: [descriptorId]}, commitId: 'c1'}
+      }
+      if (opts.url.endsWith('/synchronize')) return {type: 'complete'}
+      if (opts.url.endsWith('/commit')) return {}
+      throw new Error(`unexpected call to ${opts.url}`)
+    })
+    const id = await uploadSchema(makeSchema(), {contextKey: 'studio:1', requester})
+    expect(id).toBe(descriptorId)
+    expect(calls.map((c) => c.url)).toEqual([
+      '/v2025-06-01/descriptors/claim',
+      '/v2025-06-01/descriptors/synchronize',
+      '/v2025-06-01/descriptors/commit',
+    ])
+  })
+
+  test('claim POSTs a permanent claim, then commits with the returned commitId', async () => {
+    const {requester, calls} = recording((opts) => {
+      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
+      if (opts.url.endsWith('/commit')) return {}
+      throw new Error(`unexpected call to ${opts.url}`)
+    })
+    await uploadSchema(makeSchema(), {contextKey: 'studio:1', requester})
+
+    const claimBody = calls[0]!.body as {contextKey: string; permanent: boolean}
+    expect(claimBody.contextKey).toBe('studio:1')
+    expect(claimBody.permanent).toBe(true)
+
+    const commitCall = calls.find((c) => c.url.endsWith('/commit'))!
+    expect(commitCall.body).toEqual({contextKey: 'studio:1', id: 'c1'})
+  })
+
+  test('throws when the permanent claim response is missing commitId', async () => {
+    const {requester} = recording((opts) => {
+      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}}
+      throw new Error(`unexpected call to ${opts.url}`)
+    })
+    await expect(uploadSchema(makeSchema(), {contextKey: 'studio:1', requester})).rejects.toThrow(
+      /missing `commitId`/,
+    )
+  })
+
+  test('claim already complete returns the id even with maxSyncIterations 0', async () => {
+    const {requester, calls} = recording((opts) => {
+      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
+      if (opts.url.endsWith('/commit')) return {}
+      throw new Error(`unexpected call to ${opts.url}`)
+    })
+    const id = await uploadSchema(makeSchema(), {
+      contextKey: 'studio:1',
+      requester,
+      maxSyncIterations: 0,
+    })
+    expect(typeof id).toBe('string')
+    expect(calls.map((c) => c.url)).toEqual([
+      '/v2025-06-01/descriptors/claim',
+      '/v2025-06-01/descriptors/commit',
+    ])
+  })
+
+  test('throws on a negative or non-integer maxSyncIterations', async () => {
+    const {requester} = recording((opts) => {
+      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
+      if (opts.url.endsWith('/commit')) return {}
+      throw new Error(`unexpected call to ${opts.url}`)
+    })
+    await expect(
+      uploadSchema(makeSchema(), {contextKey: 'studio:1', requester, maxSyncIterations: -1}),
+    ).rejects.toThrow(/non-negative integer/)
+    await expect(
+      uploadSchema(makeSchema(), {contextKey: 'studio:1', requester, maxSyncIterations: 2.5}),
+    ).rejects.toThrow(/non-negative integer/)
+  })
+
+  test('never completes → throws and does not commit', async () => {
+    const {requester, calls} = recording((opts) => {
+      if (opts.url.endsWith('/claim')) {
+        const did = (opts.body as {descriptorId: string}).descriptorId
+        return {synchronization: {type: 'incomplete', missingIds: [did]}, commitId: 'c1'}
+      }
+      if (opts.url.endsWith('/commit')) return {}
+      const did = (opts.body as {id: string}).id
+      return {type: 'incomplete', missingIds: [did]}
+    })
+    await expect(
+      uploadSchema(makeSchema(), {contextKey: 'studio:1', requester, maxSyncIterations: 2}),
+    ).rejects.toThrow(/didn't succeed in 2 iterations/)
+    expect(calls.some((c) => c.url.endsWith('/commit'))).toBe(false)
+  })
+})

--- a/packages/@sanity/schema/src/descriptors/uploadSchema.test.ts
+++ b/packages/@sanity/schema/src/descriptors/uploadSchema.test.ts
@@ -5,7 +5,7 @@ import {builtinTypes} from '../sanity/builtinTypes'
 import {groupProblems} from '../sanity/groupProblems'
 import {validateSchema} from '../sanity/validateSchema'
 import {defaultShouldRetry, type DescriptorRequestOptions} from './transport'
-import {uploadSchema} from './uploadSchema'
+import {uploadSchema, type UploadSchemaPhase} from './uploadSchema'
 
 describe('defaultShouldRetry', () => {
   test('retries on 429 and 5xx, not on 4xx or non-http errors', () => {
@@ -230,5 +230,143 @@ describe('uploadSchema — synchronization', () => {
       uploadSchema(makeSchema(), {contextKey: 'studio:1', requester, maxSyncIterations: 2}),
     ).rejects.toThrow(/didn't succeed in 2 iterations/)
     expect(calls.some((c) => c.url.endsWith('/commit'))).toBe(false)
+  })
+})
+
+describe('uploadSchema — onPhaseComplete', () => {
+  test('claim already complete → emits convert, claim, commit, total in order (no synchronize)', async () => {
+    const {requester} = recording((opts) => {
+      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
+      if (opts.url.endsWith('/commit')) return {}
+      throw new Error(`unexpected call to ${opts.url}`)
+    })
+    const events: UploadSchemaPhase[] = []
+    await uploadSchema(makeSchema(), {
+      contextKey: 'studio:1',
+      requester,
+      onPhaseComplete: (event) => events.push(event),
+    })
+    expect(events.map((e) => e.phase)).toEqual(['convert', 'claim', 'commit', 'total'])
+  })
+
+  test('incomplete then complete → one synchronize phase (iteration 0) before commit and total', async () => {
+    const {requester} = recording((opts) => {
+      if (opts.url.endsWith('/claim')) {
+        const did = (opts.body as {descriptorId: string}).descriptorId
+        return {synchronization: {type: 'incomplete', missingIds: [did]}, commitId: 'c1'}
+      }
+      if (opts.url.endsWith('/synchronize')) return {type: 'complete'}
+      if (opts.url.endsWith('/commit')) return {}
+      throw new Error(`unexpected call to ${opts.url}`)
+    })
+    const events: UploadSchemaPhase[] = []
+    await uploadSchema(makeSchema(), {
+      contextKey: 'studio:1',
+      requester,
+      onPhaseComplete: (event) => events.push(event),
+    })
+    expect(events.map((e) => e.phase)).toEqual([
+      'convert',
+      'claim',
+      'synchronize',
+      'commit',
+      'total',
+    ])
+    const synchronize = events.find((e) => e.phase === 'synchronize')!
+    expect(synchronize.iteration).toBe(0)
+  })
+
+  test('iteration is present only on synchronize phases and is zero-based', async () => {
+    let round = 0
+    const {requester} = recording((opts) => {
+      if (opts.url.endsWith('/claim')) {
+        const did = (opts.body as {descriptorId: string}).descriptorId
+        return {synchronization: {type: 'incomplete', missingIds: [did]}, commitId: 'c1'}
+      }
+      if (opts.url.endsWith('/synchronize')) {
+        round += 1
+        // Stay incomplete for the first round (echo the requested id so the sync
+        // protocol keeps asking), then complete on the second.
+        if (round >= 2) return {type: 'complete'}
+        const did = (opts.body as {id: string}).id
+        return {type: 'incomplete', missingIds: [did]}
+      }
+      if (opts.url.endsWith('/commit')) return {}
+      throw new Error(`unexpected call to ${opts.url}`)
+    })
+    const events: UploadSchemaPhase[] = []
+    await uploadSchema(makeSchema(), {
+      contextKey: 'studio:1',
+      requester,
+      onPhaseComplete: (event) => events.push(event),
+    })
+    const syncIterations = events.filter((e) => e.phase === 'synchronize').map((e) => e.iteration)
+    expect(syncIterations).toEqual([0, 1])
+    for (const event of events) {
+      if (event.phase !== 'synchronize') expect(event.iteration).toBeUndefined()
+    }
+  })
+
+  test('every emitted durationSeconds is a finite number >= 0', async () => {
+    const {requester} = recording((opts) => {
+      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
+      if (opts.url.endsWith('/commit')) return {}
+      throw new Error(`unexpected call to ${opts.url}`)
+    })
+    const events: UploadSchemaPhase[] = []
+    await uploadSchema(makeSchema(), {
+      contextKey: 'studio:1',
+      requester,
+      onPhaseComplete: (event) => events.push(event),
+    })
+    expect(events.length).toBeGreaterThan(0)
+    for (const event of events) {
+      expect(Number.isFinite(event.durationSeconds)).toBe(true)
+      expect(event.durationSeconds).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  test('a hook that throws is swallowed; the upload still resolves the descriptorId', async () => {
+    const {requester} = recording((opts) => {
+      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
+      if (opts.url.endsWith('/commit')) return {}
+      throw new Error(`unexpected call to ${opts.url}`)
+    })
+    const id = await uploadSchema(makeSchema(), {
+      contextKey: 'studio:1',
+      requester,
+      onPhaseComplete: () => {
+        throw new Error('boom')
+      },
+    })
+    expect(typeof id).toBe('string')
+    expect(id.length).toBeGreaterThan(0)
+  })
+
+  test('failure path → emits convert, claim, synchronize but neither commit nor total', async () => {
+    const {requester} = recording((opts) => {
+      if (opts.url.endsWith('/claim')) {
+        const did = (opts.body as {descriptorId: string}).descriptorId
+        return {synchronization: {type: 'incomplete', missingIds: [did]}, commitId: 'c1'}
+      }
+      if (opts.url.endsWith('/commit')) return {}
+      const did = (opts.body as {id: string}).id
+      return {type: 'incomplete', missingIds: [did]}
+    })
+    const events: UploadSchemaPhase[] = []
+    await expect(
+      uploadSchema(makeSchema(), {
+        contextKey: 'studio:1',
+        requester,
+        maxSyncIterations: 2,
+        onPhaseComplete: (event) => events.push(event),
+      }),
+    ).rejects.toThrow(/didn't succeed in 2 iterations/)
+    const phases = events.map((e) => e.phase)
+    expect(phases).toContain('convert')
+    expect(phases).toContain('claim')
+    expect(phases).toContain('synchronize')
+    expect(phases).not.toContain('commit')
+    expect(phases).not.toContain('total')
   })
 })

--- a/packages/@sanity/schema/src/descriptors/uploadSchema.test.ts
+++ b/packages/@sanity/schema/src/descriptors/uploadSchema.test.ts
@@ -5,7 +5,7 @@ import {builtinTypes} from '../sanity/builtinTypes'
 import {groupProblems} from '../sanity/groupProblems'
 import {validateSchema} from '../sanity/validateSchema'
 import {defaultShouldRetry, type DescriptorRequestOptions} from './transport'
-import {uploadSchema, type UploadSchemaPhase} from './uploadSchema'
+import {prepareSchemaUpload, uploadSchema, type UploadSchemaPhase} from './uploadSchema'
 
 describe('defaultShouldRetry', () => {
   test('retries on 429 and 5xx, not on 4xx or non-http errors', () => {
@@ -51,34 +51,53 @@ function recording(responder: (opts: DescriptorRequestOptions) => unknown) {
   return {requester, calls}
 }
 
-describe('uploadSchema — transport guards', () => {
-  test('throws when neither baseUrl nor requester is provided', async () => {
+/** A responder for a permanent claim that completes immediately (no synchronize). */
+function permanentComplete(opts: DescriptorRequestOptions) {
+  if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
+  if (opts.url.endsWith('/commit')) return {}
+  throw new Error(`unexpected call to ${opts.url}`)
+}
+
+/** A responder for a temporary claim that completes immediately (no synchronize, no commit). */
+function temporaryComplete(opts: DescriptorRequestOptions) {
+  if (opts.url.endsWith('/claim')) {
+    return {synchronization: {type: 'complete'}, expiresAt: '2099-01-01T00:00:00Z'}
+  }
+  throw new Error(`unexpected call to ${opts.url}`)
+}
+
+describe('transport guards', () => {
+  test('prepareSchemaUpload throws when neither baseUrl nor requester is provided', async () => {
     await expect(
       // @ts-expect-error - exactly one of baseUrl/requester is required (compile-time guard)
-      uploadSchema(makeSchema(), {contextKey: 'studio:1'}),
+      prepareSchemaUpload(makeSchema(), {contextKey: 'studio:1', claim: 'permanent'}),
     ).rejects.toThrow(/requester.*baseUrl|baseUrl.*requester/i)
   })
 
-  test('throws when both baseUrl and requester are provided', async () => {
+  test('prepareSchemaUpload throws when both baseUrl and requester are provided', async () => {
     const {requester} = recording(() => ({}))
     await expect(
       // @ts-expect-error - cannot provide both baseUrl and requester (compile-time guard)
-      uploadSchema(makeSchema(), {
+      prepareSchemaUpload(makeSchema(), {
         contextKey: 'studio:1',
+        claim: 'permanent',
         baseUrl: 'https://api.example',
         requester,
       }),
     ).rejects.toThrow(/both/i)
   })
+
+  test('uploadSchema throws when neither baseUrl nor requester is provided', async () => {
+    await expect(
+      // @ts-expect-error - exactly one of baseUrl/requester is required (compile-time guard)
+      uploadSchema(makeSchema(), {contextKey: 'studio:1'}),
+    ).rejects.toThrow(/requester.*baseUrl|baseUrl.*requester/i)
+  })
 })
 
-describe('uploadSchema — header merging', () => {
+describe('header merging', () => {
   test('derives Authorization from token and forwards headers; header entry overrides token', async () => {
-    const {requester, calls} = recording((opts) => {
-      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
-      if (opts.url.endsWith('/commit')) return {}
-      throw new Error(`unexpected call to ${opts.url}`)
-    })
+    const {requester, calls} = recording(permanentComplete)
     await uploadSchema(makeSchema(), {
       contextKey: 'studio:1',
       requester,
@@ -90,11 +109,7 @@ describe('uploadSchema — header merging', () => {
       'x-sanity-project-id': 'p1',
     })
 
-    const override = recording((opts) => {
-      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
-      if (opts.url.endsWith('/commit')) return {}
-      throw new Error(`unexpected call to ${opts.url}`)
-    })
+    const override = recording(permanentComplete)
     await uploadSchema(makeSchema(), {
       contextKey: 'studio:1',
       requester: override.requester,
@@ -105,11 +120,7 @@ describe('uploadSchema — header merging', () => {
   })
 
   test('a lowercase authorization header suppresses the derived token (no duplicate)', async () => {
-    const {requester, calls} = recording((opts) => {
-      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
-      if (opts.url.endsWith('/commit')) return {}
-      throw new Error(`unexpected call to ${opts.url}`)
-    })
+    const {requester, calls} = recording(permanentComplete)
     await uploadSchema(makeSchema(), {
       contextKey: 'studio:1',
       requester,
@@ -122,13 +133,141 @@ describe('uploadSchema — header merging', () => {
   })
 })
 
-describe('uploadSchema — synchronization', () => {
-  test('claim returns complete → commits without a synchronize call, returns descriptorId', async () => {
-    const {requester, calls} = recording((opts) => {
-      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
-      if (opts.url.endsWith('/commit')) return {}
+describe('prepareSchemaUpload — temporary claim', () => {
+  test('POSTs permanent:false, does not commit, returns no commit thunk', async () => {
+    const {requester, calls} = recording(temporaryComplete)
+    const {descriptorId, commit} = await prepareSchemaUpload(makeSchema(), {
+      contextKey: 'studio:1',
+      requester,
+      claim: 'temporary',
+    })
+    expect(typeof descriptorId).toBe('string')
+    expect(descriptorId.length).toBeGreaterThan(0)
+    expect(commit).toBeUndefined()
+
+    const claimBody = calls[0]!.body as {contextKey: string; permanent: boolean}
+    expect(claimBody.permanent).toBe(false)
+    expect(claimBody.contextKey).toBe('studio:1')
+    expect(calls.map((c) => c.url)).toEqual(['/v2025-06-01/descriptors/claim'])
+  })
+
+  test('does not require a commitId in the claim response', async () => {
+    const {requester} = recording((opts) => {
+      // A temporary claim response carries `expiresAt`, never `commitId`.
+      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}}
       throw new Error(`unexpected call to ${opts.url}`)
     })
+    const {descriptorId} = await prepareSchemaUpload(makeSchema(), {
+      contextKey: 'studio:1',
+      requester,
+      claim: 'temporary',
+    })
+    expect(typeof descriptorId).toBe('string')
+  })
+
+  test('runs the synchronize loop but never commits', async () => {
+    const {requester, calls} = recording((opts) => {
+      if (opts.url.endsWith('/claim')) {
+        const did = (opts.body as {descriptorId: string}).descriptorId
+        return {synchronization: {type: 'incomplete', missingIds: [did]}, expiresAt: 'soon'}
+      }
+      if (opts.url.endsWith('/synchronize')) return {type: 'complete'}
+      throw new Error(`unexpected call to ${opts.url}`)
+    })
+    await prepareSchemaUpload(makeSchema(), {contextKey: 'studio:1', requester, claim: 'temporary'})
+    expect(calls.map((c) => c.url)).toEqual([
+      '/v2025-06-01/descriptors/claim',
+      '/v2025-06-01/descriptors/synchronize',
+    ])
+  })
+})
+
+describe('prepareSchemaUpload — permanent claim', () => {
+  test('POSTs permanent:true and returns a commit thunk that is not yet called', async () => {
+    const {requester, calls} = recording(permanentComplete)
+    const {descriptorId, commit} = await prepareSchemaUpload(makeSchema(), {
+      contextKey: 'studio:1',
+      requester,
+      claim: 'permanent',
+    })
+    expect(typeof descriptorId).toBe('string')
+    expect(typeof commit).toBe('function')
+
+    const claimBody = calls[0]!.body as {permanent: boolean}
+    expect(claimBody.permanent).toBe(true)
+    // Only the claim has been sent; no commit until the thunk runs.
+    expect(calls.map((c) => c.url)).toEqual(['/v2025-06-01/descriptors/claim'])
+  })
+
+  test('invoking commit() issues exactly one /commit with the returned commitId', async () => {
+    const {requester, calls} = recording(permanentComplete)
+    const {commit} = await prepareSchemaUpload(makeSchema(), {
+      contextKey: 'studio:1',
+      requester,
+      claim: 'permanent',
+    })
+    await commit!()
+    const commitCalls = calls.filter((c) => c.url.endsWith('/commit'))
+    expect(commitCalls).toHaveLength(1)
+    expect(commitCalls[0]!.body).toEqual({contextKey: 'studio:1', id: 'c1'})
+  })
+
+  test('throws when the permanent claim response is missing commitId', async () => {
+    const {requester} = recording((opts) => {
+      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}}
+      throw new Error(`unexpected call to ${opts.url}`)
+    })
+    await expect(
+      prepareSchemaUpload(makeSchema(), {contextKey: 'studio:1', requester, claim: 'permanent'}),
+    ).rejects.toThrow(/missing `commitId`/)
+  })
+})
+
+describe('synchronization', () => {
+  test('claim already complete returns the id even with maxSyncIterations 0', async () => {
+    const {requester, calls} = recording(permanentComplete)
+    const id = await uploadSchema(makeSchema(), {
+      contextKey: 'studio:1',
+      requester,
+      maxSyncIterations: 0,
+    })
+    expect(typeof id).toBe('string')
+    expect(calls.map((c) => c.url)).toEqual([
+      '/v2025-06-01/descriptors/claim',
+      '/v2025-06-01/descriptors/commit',
+    ])
+  })
+
+  test('throws on a negative or non-integer maxSyncIterations', async () => {
+    const {requester} = recording(permanentComplete)
+    await expect(
+      uploadSchema(makeSchema(), {contextKey: 'studio:1', requester, maxSyncIterations: -1}),
+    ).rejects.toThrow(/non-negative integer/)
+    await expect(
+      uploadSchema(makeSchema(), {contextKey: 'studio:1', requester, maxSyncIterations: 2.5}),
+    ).rejects.toThrow(/non-negative integer/)
+  })
+
+  test('never completes → throws and does not commit', async () => {
+    const {requester, calls} = recording((opts) => {
+      if (opts.url.endsWith('/claim')) {
+        const did = (opts.body as {descriptorId: string}).descriptorId
+        return {synchronization: {type: 'incomplete', missingIds: [did]}, commitId: 'c1'}
+      }
+      if (opts.url.endsWith('/commit')) return {}
+      const did = (opts.body as {id: string}).id
+      return {type: 'incomplete', missingIds: [did]}
+    })
+    await expect(
+      uploadSchema(makeSchema(), {contextKey: 'studio:1', requester, maxSyncIterations: 2}),
+    ).rejects.toThrow(/didn't succeed in 2 iterations/)
+    expect(calls.some((c) => c.url.endsWith('/commit'))).toBe(false)
+  })
+})
+
+describe('uploadSchema', () => {
+  test('claim returns complete → commits inline without a synchronize call, returns descriptorId', async () => {
+    const {requester, calls} = recording(permanentComplete)
     const id = await uploadSchema(makeSchema(), {contextKey: 'studio:1', requester})
     expect(typeof id).toBe('string')
     expect(id.length).toBeGreaterThan(0)
@@ -158,12 +297,8 @@ describe('uploadSchema — synchronization', () => {
     ])
   })
 
-  test('claim POSTs a permanent claim, then commits with the returned commitId', async () => {
-    const {requester, calls} = recording((opts) => {
-      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
-      if (opts.url.endsWith('/commit')) return {}
-      throw new Error(`unexpected call to ${opts.url}`)
-    })
+  test('claims permanently, then commits with the returned commitId', async () => {
+    const {requester, calls} = recording(permanentComplete)
     await uploadSchema(makeSchema(), {contextKey: 'studio:1', requester})
 
     const claimBody = calls[0]!.body as {contextKey: string; permanent: boolean}
@@ -173,73 +308,11 @@ describe('uploadSchema — synchronization', () => {
     const commitCall = calls.find((c) => c.url.endsWith('/commit'))!
     expect(commitCall.body).toEqual({contextKey: 'studio:1', id: 'c1'})
   })
-
-  test('throws when the permanent claim response is missing commitId', async () => {
-    const {requester} = recording((opts) => {
-      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}}
-      throw new Error(`unexpected call to ${opts.url}`)
-    })
-    await expect(uploadSchema(makeSchema(), {contextKey: 'studio:1', requester})).rejects.toThrow(
-      /missing `commitId`/,
-    )
-  })
-
-  test('claim already complete returns the id even with maxSyncIterations 0', async () => {
-    const {requester, calls} = recording((opts) => {
-      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
-      if (opts.url.endsWith('/commit')) return {}
-      throw new Error(`unexpected call to ${opts.url}`)
-    })
-    const id = await uploadSchema(makeSchema(), {
-      contextKey: 'studio:1',
-      requester,
-      maxSyncIterations: 0,
-    })
-    expect(typeof id).toBe('string')
-    expect(calls.map((c) => c.url)).toEqual([
-      '/v2025-06-01/descriptors/claim',
-      '/v2025-06-01/descriptors/commit',
-    ])
-  })
-
-  test('throws on a negative or non-integer maxSyncIterations', async () => {
-    const {requester} = recording((opts) => {
-      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
-      if (opts.url.endsWith('/commit')) return {}
-      throw new Error(`unexpected call to ${opts.url}`)
-    })
-    await expect(
-      uploadSchema(makeSchema(), {contextKey: 'studio:1', requester, maxSyncIterations: -1}),
-    ).rejects.toThrow(/non-negative integer/)
-    await expect(
-      uploadSchema(makeSchema(), {contextKey: 'studio:1', requester, maxSyncIterations: 2.5}),
-    ).rejects.toThrow(/non-negative integer/)
-  })
-
-  test('never completes → throws and does not commit', async () => {
-    const {requester, calls} = recording((opts) => {
-      if (opts.url.endsWith('/claim')) {
-        const did = (opts.body as {descriptorId: string}).descriptorId
-        return {synchronization: {type: 'incomplete', missingIds: [did]}, commitId: 'c1'}
-      }
-      if (opts.url.endsWith('/commit')) return {}
-      const did = (opts.body as {id: string}).id
-      return {type: 'incomplete', missingIds: [did]}
-    })
-    await expect(
-      uploadSchema(makeSchema(), {contextKey: 'studio:1', requester, maxSyncIterations: 2}),
-    ).rejects.toThrow(/didn't succeed in 2 iterations/)
-    expect(calls.some((c) => c.url.endsWith('/commit'))).toBe(false)
-  })
 })
 
-describe('uploadSchema — onPhaseComplete', () => {
-  test('claim already complete → emits convert, claim, commit, total in order (no synchronize)', async () => {
-    const {requester} = recording((opts) => {
-      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
-      if (opts.url.endsWith('/commit')) return {}
-      throw new Error(`unexpected call to ${opts.url}`)
-    })
+describe('onPhaseComplete', () => {
+  test('uploadSchema, claim already complete → emits convert, claim, commit, total in order', async () => {
+    const {requester} = recording(permanentComplete)
     const events: UploadSchemaPhase[] = []
     await uploadSchema(makeSchema(), {
       contextKey: 'studio:1',
@@ -249,7 +322,7 @@ describe('uploadSchema — onPhaseComplete', () => {
     expect(events.map((e) => e.phase)).toEqual(['convert', 'claim', 'commit', 'total'])
   })
 
-  test('incomplete then complete → one synchronize phase (iteration 0) before commit and total', async () => {
+  test('uploadSchema, incomplete then complete → synchronize (iteration 0) before commit and total', async () => {
     const {requester} = recording((opts) => {
       if (opts.url.endsWith('/claim')) {
         const did = (opts.body as {descriptorId: string}).descriptorId
@@ -274,6 +347,33 @@ describe('uploadSchema — onPhaseComplete', () => {
     ])
     const synchronize = events.find((e) => e.phase === 'synchronize')!
     expect(synchronize.iteration).toBe(0)
+  })
+
+  test('prepareSchemaUpload (permanent) emits convert, claim only; commit() emits commit; no total', async () => {
+    const {requester} = recording(permanentComplete)
+    const events: UploadSchemaPhase[] = []
+    const {commit} = await prepareSchemaUpload(makeSchema(), {
+      contextKey: 'studio:1',
+      requester,
+      claim: 'permanent',
+      onPhaseComplete: (event) => events.push(event),
+    })
+    expect(events.map((e) => e.phase)).toEqual(['convert', 'claim'])
+    await commit!()
+    expect(events.map((e) => e.phase)).toEqual(['convert', 'claim', 'commit'])
+    expect(events.some((e) => e.phase === 'total')).toBe(false)
+  })
+
+  test('prepareSchemaUpload (temporary) emits convert, claim only; never commit or total', async () => {
+    const {requester} = recording(temporaryComplete)
+    const events: UploadSchemaPhase[] = []
+    await prepareSchemaUpload(makeSchema(), {
+      contextKey: 'studio:1',
+      requester,
+      claim: 'temporary',
+      onPhaseComplete: (event) => events.push(event),
+    })
+    expect(events.map((e) => e.phase)).toEqual(['convert', 'claim'])
   })
 
   test('iteration is present only on synchronize phases and is zero-based', async () => {
@@ -308,11 +408,7 @@ describe('uploadSchema — onPhaseComplete', () => {
   })
 
   test('every emitted durationSeconds is a finite number >= 0', async () => {
-    const {requester} = recording((opts) => {
-      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
-      if (opts.url.endsWith('/commit')) return {}
-      throw new Error(`unexpected call to ${opts.url}`)
-    })
+    const {requester} = recording(permanentComplete)
     const events: UploadSchemaPhase[] = []
     await uploadSchema(makeSchema(), {
       contextKey: 'studio:1',
@@ -327,11 +423,7 @@ describe('uploadSchema — onPhaseComplete', () => {
   })
 
   test('a hook that throws is swallowed; the upload still resolves the descriptorId', async () => {
-    const {requester} = recording((opts) => {
-      if (opts.url.endsWith('/claim')) return {synchronization: {type: 'complete'}, commitId: 'c1'}
-      if (opts.url.endsWith('/commit')) return {}
-      throw new Error(`unexpected call to ${opts.url}`)
-    })
+    const {requester} = recording(permanentComplete)
     const id = await uploadSchema(makeSchema(), {
       contextKey: 'studio:1',
       requester,

--- a/packages/@sanity/schema/src/descriptors/uploadSchema.ts
+++ b/packages/@sanity/schema/src/descriptors/uploadSchema.ts
@@ -14,14 +14,30 @@ const DEFAULT_MAX_SYNC_ITERATIONS = 5
 const sharedConverter = new DescriptorConverter()
 
 /**
- * The permanent-claim response shape `uploadSchema` reads: the info needed to
- * start synchronization, plus the `commitId` that must be passed to `/commit`
- * to finalize the permanent claim.
+ * Fields common to both claim responses: enough to start synchronizing.
  */
-interface ClaimResponse {
+interface BaseClaimResponse {
   synchronization: SchemaSynchronizationResult
+}
+
+/**
+ * Response to a permanent claim (`permanent: true`). Carries the `commitId` that
+ * must be passed to `/commit` to pin the descriptor; until then nothing is
+ * retained.
+ */
+interface PermanentClaimResponse extends BaseClaimResponse {
   commitId: string
 }
+
+/**
+ * Response to a temporary claim (`permanent: false`). Carries `expiresAt`; the
+ * descriptor is retained only until then and there is nothing to commit.
+ */
+interface TemporaryClaimResponse extends BaseClaimResponse {
+  expiresAt: string
+}
+
+type ClaimResponse = PermanentClaimResponse | TemporaryClaimResponse
 
 /**
  * Merge an optional bearer token and per-call headers. A caller-supplied
@@ -43,7 +59,7 @@ function mergeHeaders(
 }
 
 /**
- * A completed phase of an `uploadSchema` call, passed to `onPhaseComplete`.
+ * A completed phase of an upload, passed to `onPhaseComplete`.
  *
  * @internal
  */
@@ -52,10 +68,14 @@ export interface UploadSchemaPhase {
    * - `convert`     — schema → descriptor set. Awaited but CPU-bound; the shared
    *   converter's `WeakMap` cache makes this ~0s on a repeat upload of the same
    *   compiled `Schema` instance.
-   * - `claim`       — the permanent-claim request.
+   * - `claim`       — the claim request (permanent or temporary).
    * - `synchronize` — one synchronize iteration (see `iteration`).
-   * - `commit`      — the commit request that pins the descriptor.
-   * - `total`       — the whole `uploadSchema` call; emitted last, on success only.
+   * - `commit`      — the commit request that pins a permanent claim. Emitted by
+   *   the `commit()` thunk returned from `prepareSchemaUpload`, or inline by
+   *   `uploadSchema`. Never emitted for a temporary claim.
+   * - `total`       — the whole `uploadSchema` call; emitted last, on success
+   *   only. `prepareSchemaUpload` does not emit `total` (a standalone caller can
+   *   time the awaited promise itself).
    */
   phase: 'convert' | 'claim' | 'synchronize' | 'commit' | 'total'
   /** Elapsed wall-clock time for this phase, in seconds. */
@@ -77,9 +97,7 @@ interface BaseUploadSchemaOptions {
   maxSyncIterations?: number
   /**
    * Optional observability hook. Invoked once per phase as it completes, with
-   * the elapsed wall-clock time for that phase. The success-only `total` is
-   * emitted last; a failing call emits whatever phases completed but neither
-   * `commit` nor `total`.
+   * the elapsed wall-clock time for that phase.
    *
    * Fire-and-forget: the return value is ignored and any error it throws is
    * swallowed, so instrumentation can never break or slow an upload.
@@ -90,70 +108,94 @@ interface BaseUploadSchemaOptions {
 /**
  * Transport — provide exactly one of `baseUrl` or `requester`. The mutually
  * exclusive shape makes "both" and "neither" a compile-time error.
- *
- * @internal
  */
-export type UploadSchemaOptions = BaseUploadSchemaOptions &
-  (
-    | {
-        /** Base URL for the bundled get-it transport. */
-        baseUrl: string
-        requester?: never
-      }
-    | {
-        /** Bring-your-own transport. Use instead of `baseUrl` to control auth, retries, etc. */
-        requester: DescriptorRequester
-        baseUrl?: never
-      }
-  )
+type TransportOptions =
+  | {
+      /** Base URL for the bundled get-it transport. */
+      baseUrl: string
+      requester?: never
+    }
+  | {
+      /** Bring-your-own transport. Use instead of `baseUrl` to control auth, retries, etc. */
+      requester: DescriptorRequester
+      baseUrl?: never
+    }
 
 /**
- * Convert a Sanity schema to a descriptor set and upload it permanently:
- * permanently claim the id, run the synchronization loop until complete, then
- * commit the claim to pin the descriptor. Returns the content-addressed
- * descriptor id.
+ * Options for {@link prepareSchemaUpload}.
  *
  * @internal
  */
-export async function uploadSchema(schema: Schema, options: UploadSchemaOptions): Promise<string> {
+export type PrepareSchemaUploadOptions = BaseUploadSchemaOptions &
+  TransportOptions & {
+    /**
+     * Claim lifecycle for the uploaded descriptor — chosen here because the kind
+     * of claim is fixed in the `/claim` request and cannot be changed later:
+     *
+     * - `'permanent'` — claim with `permanent: true`. The response carries a
+     *   `commitId` and the descriptor is **not** retained until committed. The
+     *   returned `PreparedSchemaUpload` includes a `commit()` thunk to finalize
+     *   it (e.g. after a dependent write succeeds). Never calling `commit()`
+     *   leaves the claim to expire — nothing is pinned.
+     * - `'temporary'` — claim with `permanent: false`. The response carries
+     *   `expiresAt`; there is nothing to commit, so no `commit()` thunk is
+     *   returned. The descriptor is retained only until the claim expires (or
+     *   until pinned by a referencing permanent descriptor — e.g. a manifest
+     *   that lists it).
+     */
+    claim: 'temporary' | 'permanent'
+  }
+
+/**
+ * Options for {@link uploadSchema}.
+ *
+ * @internal
+ */
+export type UploadSchemaOptions = BaseUploadSchemaOptions & TransportOptions
+
+/**
+ * Result of {@link prepareSchemaUpload}: the synchronized descriptor id and,
+ * for a permanent claim, a `commit()` thunk to pin it later.
+ *
+ * @internal
+ */
+export interface PreparedSchemaUpload {
+  /** Content-addressed descriptor id of the synchronized schema. */
+  descriptorId: string
+  /**
+   * Present only for `claim: 'permanent'`. Finalizes the permanent claim by
+   * committing it. Safe to skip: not calling it leaves the claim to expire.
+   */
+  commit?: () => Promise<void>
+}
+
+function resolveRequester(options: TransportOptions): DescriptorRequester {
   // The union type already forbids "both"/"neither" for typed callers; these
   // guards keep clear errors for untyped (JS) callers. The property checks also
   // let TypeScript narrow the union, so no non-null assertions are needed.
   if (options.requester !== undefined && options.baseUrl !== undefined) {
     throw new Error('uploadSchema: provide either `requester` or `baseUrl`, not both')
   }
-
-  let requester: DescriptorRequester
   if (options.requester !== undefined) {
-    requester = options.requester
-  } else if (options.baseUrl !== undefined) {
-    requester = createGetItRequester({baseUrl: options.baseUrl})
-  } else {
-    throw new Error('uploadSchema: one of `requester` or `baseUrl` is required')
+    return options.requester
   }
-
-  const apiVersion = options.apiVersion ?? DEFAULT_API_VERSION
-  const maxSyncIterations = options.maxSyncIterations ?? DEFAULT_MAX_SYNC_ITERATIONS
-  if (!Number.isInteger(maxSyncIterations) || maxSyncIterations < 0) {
-    throw new Error('uploadSchema: `maxSyncIterations` must be a non-negative integer')
+  if (options.baseUrl !== undefined) {
+    return createGetItRequester({baseUrl: options.baseUrl})
   }
+  throw new Error('uploadSchema: one of `requester` or `baseUrl` is required')
+}
 
-  // Headers are invariant across the claim/synchronize requests in a single
-  // call, so merge them once rather than per request.
-  const headers = mergeHeaders(options.token, options.headers)
-  function request<T>(opts: {url: string; method: 'GET' | 'POST'; body?: unknown}): Promise<T> {
-    return requester<T>({...opts, headers})
-  }
-
-  function url(path: string): string {
-    return `/${apiVersion}/descriptors/${path}`
-  }
-
-  // Fire-and-forget phase timing. The hook is observation only, so a throwing
-  // hook must never surface as an upload failure. `startedAt` is captured before
-  // the awaited work and read here at completion.
-  const {onPhaseComplete} = options
-  function emit(phase: UploadSchemaPhase['phase'], startedAt: number, iteration?: number): void {
+/**
+ * Build the fire-and-forget phase emitter. The hook is observation only, so a
+ * throwing hook must never surface as an upload failure. Each `startedAt` is
+ * captured before the awaited work and read at completion.
+ */
+function makeEmit(onPhaseComplete: ((event: UploadSchemaPhase) => void) | undefined) {
+  return function emit(
+    phase: UploadSchemaPhase['phase'],
+    startedAt: number,
+    iteration?: number,
+  ): void {
     if (!onPhaseComplete) return
     const event: UploadSchemaPhase = {
       phase,
@@ -166,49 +208,95 @@ export async function uploadSchema(schema: Schema, options: UploadSchemaOptions)
       // observability must never break the upload
     }
   }
+}
 
-  const startedTotal = performance.now()
+/**
+ * Convert a Sanity schema to a descriptor set, claim its id, and synchronize
+ * until complete — but do **not** commit. For a permanent claim, the returned
+ * `commit()` thunk finalizes the claim when the caller is ready (e.g. after a
+ * dependent write succeeds); for a temporary claim no thunk is returned. This is
+ * the building block `uploadSchema` is built on, exposed for callers that need
+ * to control the claim/commit lifecycle.
+ *
+ * @internal
+ */
+export async function prepareSchemaUpload(
+  schema: Schema,
+  options: PrepareSchemaUploadOptions,
+): Promise<PreparedSchemaUpload> {
+  const requester = resolveRequester(options)
+
+  const apiVersion = options.apiVersion ?? DEFAULT_API_VERSION
+  const maxSyncIterations = options.maxSyncIterations ?? DEFAULT_MAX_SYNC_ITERATIONS
+  if (!Number.isInteger(maxSyncIterations) || maxSyncIterations < 0) {
+    throw new Error('uploadSchema: `maxSyncIterations` must be a non-negative integer')
+  }
+
+  const {contextKey} = options
+  const permanent = options.claim === 'permanent'
+
+  // Headers are invariant across every request in a single call, so merge them
+  // once rather than per request.
+  const headers = mergeHeaders(options.token, options.headers)
+  function request<T>(opts: {url: string; method: 'GET' | 'POST'; body?: unknown}): Promise<T> {
+    return requester<T>({...opts, headers})
+  }
+
+  function url(path: string): string {
+    return `/${apiVersion}/descriptors/${path}`
+  }
+
+  const emit = makeEmit(options.onPhaseComplete)
 
   const startedConvert = performance.now()
   const sync = await sharedConverter.get(schema)
   const descriptorId = sync.set.id
   emit('convert', startedConvert)
 
-  // A permanent claim returns a `commitId` (rather than the temporary claim's
-  // `expiresAt`); the descriptor is not pinned until that id is committed below.
+  // A permanent claim returns a `commitId` (the descriptor is not pinned until
+  // it is committed); a temporary claim returns `expiresAt` and has nothing to
+  // commit. The `permanent` flag in the request body is what selects between
+  // them, so the lifecycle must be decided here, before any commit could run.
   const startedClaim = performance.now()
   const claimResponse = await request<ClaimResponse>({
     url: url('claim'),
     method: 'POST',
-    body: {descriptorId, contextKey: options.contextKey, permanent: true},
+    body: {descriptorId, contextKey, permanent},
   })
   emit('claim', startedClaim)
 
-  if (!claimResponse.commitId) {
-    throw new Error('uploadSchema: claim response is missing `commitId` for the permanent claim')
+  let commitId: string | undefined
+  if (permanent) {
+    commitId = (claimResponse as PermanentClaimResponse).commitId
+    if (!commitId) {
+      throw new Error('uploadSchema: claim response is missing `commitId` for the permanent claim')
+    }
   }
 
   let syncResult: SchemaSynchronizationResult = claimResponse.synchronization
   // Completeness is checked at the top of each pass — before the iteration
-  // budget is consumed — so an already-complete claim commits even when
+  // budget is consumed — so an already-complete claim is ready even when
   // `maxSyncIterations` is 0. The `<=` lets the final pass detect completeness
   // (or break) after the last synchronize request.
   for (let i = 0; i <= maxSyncIterations; i++) {
     const syncRequest = processSchemaSynchronization(sync, syncResult)
     if (syncRequest === null) {
-      // Synchronization is complete — finalize the permanent claim so the
-      // descriptor survives indefinitely. Only commit on success; the
-      // iteration-exhaustion path below intentionally leaves the claim
-      // uncommitted (it will expire) rather than pinning a partial upload.
-      const startedCommit = performance.now()
-      await request({
-        url: url('commit'),
-        method: 'POST',
-        body: {contextKey: options.contextKey, id: claimResponse.commitId},
-      })
-      emit('commit', startedCommit)
-      emit('total', startedTotal)
-      return descriptorId
+      // Synchronization is complete. For a permanent claim, hand back a `commit`
+      // thunk so the caller can pin the descriptor when ready; for a temporary
+      // claim there is nothing to commit. The iteration-exhaustion path below
+      // intentionally throws rather than returning a partially-synced upload.
+      const commit = permanent
+        ? async (): Promise<void> => {
+            const startedCommit = performance.now()
+            await request({
+              url: url('commit'),
+              method: 'POST',
+              body: {contextKey, id: commitId},
+            })
+            emit('commit', startedCommit)
+          }
+        : undefined
+      return {descriptorId, commit}
     }
     if (i === maxSyncIterations) {
       break
@@ -223,4 +311,29 @@ export async function uploadSchema(schema: Schema, options: UploadSchemaOptions)
   }
 
   throw new Error(`Schema synchronization didn't succeed in ${maxSyncIterations} iterations`)
+}
+
+/**
+ * Convert a Sanity schema to a descriptor set and upload it permanently:
+ * permanently claim the id, run the synchronization loop until complete, then
+ * commit the claim to pin the descriptor. Returns the content-addressed
+ * descriptor id.
+ *
+ * A convenience over {@link prepareSchemaUpload} — it prepares a permanent claim
+ * and commits it inline. Callers that need a temporary claim, or that need to
+ * commit in a later step, should use `prepareSchemaUpload` directly.
+ *
+ * @internal
+ */
+export async function uploadSchema(schema: Schema, options: UploadSchemaOptions): Promise<string> {
+  const startedTotal = performance.now()
+  const emit = makeEmit(options.onPhaseComplete)
+
+  const {descriptorId, commit} = await prepareSchemaUpload(schema, {...options, claim: 'permanent'})
+  // `claim: 'permanent'` always yields a `commit` thunk; the assertion documents
+  // that invariant rather than guarding a reachable branch.
+  await commit!()
+
+  emit('total', startedTotal)
+  return descriptorId
 }

--- a/packages/@sanity/schema/src/descriptors/uploadSchema.ts
+++ b/packages/@sanity/schema/src/descriptors/uploadSchema.ts
@@ -42,6 +42,28 @@ function mergeHeaders(
   }
 }
 
+/**
+ * A completed phase of an `uploadSchema` call, passed to `onPhaseComplete`.
+ *
+ * @internal
+ */
+export interface UploadSchemaPhase {
+  /**
+   * - `convert`     — schema → descriptor set. Awaited but CPU-bound; the shared
+   *   converter's `WeakMap` cache makes this ~0s on a repeat upload of the same
+   *   compiled `Schema` instance.
+   * - `claim`       — the permanent-claim request.
+   * - `synchronize` — one synchronize iteration (see `iteration`).
+   * - `commit`      — the commit request that pins the descriptor.
+   * - `total`       — the whole `uploadSchema` call; emitted last, on success only.
+   */
+  phase: 'convert' | 'claim' | 'synchronize' | 'commit' | 'total'
+  /** Elapsed wall-clock time for this phase, in seconds. */
+  durationSeconds: number
+  /** Zero-based iteration index. Present only for `phase: 'synchronize'`. */
+  iteration?: number
+}
+
 interface BaseUploadSchemaOptions {
   /** Context key the server uses to scope/optimize synchronization, e.g. `studio:<appId>`. */
   contextKey: string
@@ -53,6 +75,16 @@ interface BaseUploadSchemaOptions {
   apiVersion?: string
   /** Max synchronize iterations before throwing. Default 5. */
   maxSyncIterations?: number
+  /**
+   * Optional observability hook. Invoked once per phase as it completes, with
+   * the elapsed wall-clock time for that phase. The success-only `total` is
+   * emitted last; a failing call emits whatever phases completed but neither
+   * `commit` nor `total`.
+   *
+   * Fire-and-forget: the return value is ignored and any error it throws is
+   * swallowed, so instrumentation can never break or slow an upload.
+   */
+  onPhaseComplete?: (event: UploadSchemaPhase) => void
 }
 
 /**
@@ -117,16 +149,40 @@ export async function uploadSchema(schema: Schema, options: UploadSchemaOptions)
     return `/${apiVersion}/descriptors/${path}`
   }
 
+  // Fire-and-forget phase timing. The hook is observation only, so a throwing
+  // hook must never surface as an upload failure. `startedAt` is captured before
+  // the awaited work and read here at completion.
+  const {onPhaseComplete} = options
+  function emit(phase: UploadSchemaPhase['phase'], startedAt: number, iteration?: number): void {
+    if (!onPhaseComplete) return
+    const event: UploadSchemaPhase = {
+      phase,
+      durationSeconds: (performance.now() - startedAt) / 1000,
+    }
+    if (iteration !== undefined) event.iteration = iteration
+    try {
+      onPhaseComplete(event)
+    } catch {
+      // observability must never break the upload
+    }
+  }
+
+  const startedTotal = performance.now()
+
+  const startedConvert = performance.now()
   const sync = await sharedConverter.get(schema)
   const descriptorId = sync.set.id
+  emit('convert', startedConvert)
 
   // A permanent claim returns a `commitId` (rather than the temporary claim's
   // `expiresAt`); the descriptor is not pinned until that id is committed below.
+  const startedClaim = performance.now()
   const claimResponse = await request<ClaimResponse>({
     url: url('claim'),
     method: 'POST',
     body: {descriptorId, contextKey: options.contextKey, permanent: true},
   })
+  emit('claim', startedClaim)
 
   if (!claimResponse.commitId) {
     throw new Error('uploadSchema: claim response is missing `commitId` for the permanent claim')
@@ -144,21 +200,26 @@ export async function uploadSchema(schema: Schema, options: UploadSchemaOptions)
       // descriptor survives indefinitely. Only commit on success; the
       // iteration-exhaustion path below intentionally leaves the claim
       // uncommitted (it will expire) rather than pinning a partial upload.
+      const startedCommit = performance.now()
       await request({
         url: url('commit'),
         method: 'POST',
         body: {contextKey: options.contextKey, id: claimResponse.commitId},
       })
+      emit('commit', startedCommit)
+      emit('total', startedTotal)
       return descriptorId
     }
     if (i === maxSyncIterations) {
       break
     }
+    const startedSync = performance.now()
     syncResult = await request<SchemaSynchronizationResult>({
       url: url('synchronize'),
       method: 'POST',
       body: syncRequest,
     })
+    emit('synchronize', startedSync, i)
   }
 
   throw new Error(`Schema synchronization didn't succeed in ${maxSyncIterations} iterations`)

--- a/packages/@sanity/schema/src/descriptors/uploadSchema.ts
+++ b/packages/@sanity/schema/src/descriptors/uploadSchema.ts
@@ -1,0 +1,165 @@
+import {type Schema} from '@sanity/types'
+
+import {DescriptorConverter} from './convert'
+import {processSchemaSynchronization, type SchemaSynchronizationResult} from './sync'
+import {createGetItRequester, type DescriptorRequester, type RequestHeaders} from './transport'
+
+const DEFAULT_API_VERSION = 'v2025-06-01'
+const DEFAULT_MAX_SYNC_ITERATIONS = 5
+
+// A single shared converter so its `WeakMap` cache survives across calls. The
+// converted descriptor set is deterministic and content-addressed, so sharing
+// is purely an optimization — repeat uploads of the same compiled `Schema`
+// instance skip the (type-traversal + hashing) conversion.
+const sharedConverter = new DescriptorConverter()
+
+/**
+ * The permanent-claim response shape `uploadSchema` reads: the info needed to
+ * start synchronization, plus the `commitId` that must be passed to `/commit`
+ * to finalize the permanent claim.
+ */
+interface ClaimResponse {
+  synchronization: SchemaSynchronizationResult
+  commitId: string
+}
+
+/**
+ * Merge an optional bearer token and per-call headers. A caller-supplied
+ * `Authorization` header wins over the derived token; the match is
+ * case-insensitive (HTTP header names are), so a lowercase `authorization`
+ * suppresses the derived header rather than producing a duplicate.
+ */
+function mergeHeaders(
+  token: string | undefined,
+  headers: RequestHeaders | undefined,
+): RequestHeaders {
+  const hasAuthHeader = headers
+    ? Object.keys(headers).some((key) => key.toLowerCase() === 'authorization')
+    : false
+  return {
+    ...(token && !hasAuthHeader ? {Authorization: `Bearer ${token}`} : {}),
+    ...headers,
+  }
+}
+
+interface BaseUploadSchemaOptions {
+  /** Context key the server uses to scope/optimize synchronization, e.g. `studio:<appId>`. */
+  contextKey: string
+  /** Headers applied to every request. */
+  headers?: RequestHeaders
+  /** Convenience auth applied as `Authorization: Bearer <token>` on every request. */
+  token?: string
+  /** Descriptor API version path segment. Default 'v2025-06-01'. */
+  apiVersion?: string
+  /** Max synchronize iterations before throwing. Default 5. */
+  maxSyncIterations?: number
+}
+
+/**
+ * Transport — provide exactly one of `baseUrl` or `requester`. The mutually
+ * exclusive shape makes "both" and "neither" a compile-time error.
+ *
+ * @internal
+ */
+export type UploadSchemaOptions = BaseUploadSchemaOptions &
+  (
+    | {
+        /** Base URL for the bundled get-it transport. */
+        baseUrl: string
+        requester?: never
+      }
+    | {
+        /** Bring-your-own transport. Use instead of `baseUrl` to control auth, retries, etc. */
+        requester: DescriptorRequester
+        baseUrl?: never
+      }
+  )
+
+/**
+ * Convert a Sanity schema to a descriptor set and upload it permanently:
+ * permanently claim the id, run the synchronization loop until complete, then
+ * commit the claim to pin the descriptor. Returns the content-addressed
+ * descriptor id.
+ *
+ * @internal
+ */
+export async function uploadSchema(schema: Schema, options: UploadSchemaOptions): Promise<string> {
+  // The union type already forbids "both"/"neither" for typed callers; these
+  // guards keep clear errors for untyped (JS) callers. The property checks also
+  // let TypeScript narrow the union, so no non-null assertions are needed.
+  if (options.requester !== undefined && options.baseUrl !== undefined) {
+    throw new Error('uploadSchema: provide either `requester` or `baseUrl`, not both')
+  }
+
+  let requester: DescriptorRequester
+  if (options.requester !== undefined) {
+    requester = options.requester
+  } else if (options.baseUrl !== undefined) {
+    requester = createGetItRequester({baseUrl: options.baseUrl})
+  } else {
+    throw new Error('uploadSchema: one of `requester` or `baseUrl` is required')
+  }
+
+  const apiVersion = options.apiVersion ?? DEFAULT_API_VERSION
+  const maxSyncIterations = options.maxSyncIterations ?? DEFAULT_MAX_SYNC_ITERATIONS
+  if (!Number.isInteger(maxSyncIterations) || maxSyncIterations < 0) {
+    throw new Error('uploadSchema: `maxSyncIterations` must be a non-negative integer')
+  }
+
+  // Headers are invariant across the claim/synchronize requests in a single
+  // call, so merge them once rather than per request.
+  const headers = mergeHeaders(options.token, options.headers)
+  function request<T>(opts: {url: string; method: 'GET' | 'POST'; body?: unknown}): Promise<T> {
+    return requester<T>({...opts, headers})
+  }
+
+  function url(path: string): string {
+    return `/${apiVersion}/descriptors/${path}`
+  }
+
+  const sync = await sharedConverter.get(schema)
+  const descriptorId = sync.set.id
+
+  // A permanent claim returns a `commitId` (rather than the temporary claim's
+  // `expiresAt`); the descriptor is not pinned until that id is committed below.
+  const claimResponse = await request<ClaimResponse>({
+    url: url('claim'),
+    method: 'POST',
+    body: {descriptorId, contextKey: options.contextKey, permanent: true},
+  })
+
+  if (!claimResponse.commitId) {
+    throw new Error('uploadSchema: claim response is missing `commitId` for the permanent claim')
+  }
+
+  let syncResult: SchemaSynchronizationResult = claimResponse.synchronization
+  // Completeness is checked at the top of each pass — before the iteration
+  // budget is consumed — so an already-complete claim commits even when
+  // `maxSyncIterations` is 0. The `<=` lets the final pass detect completeness
+  // (or break) after the last synchronize request.
+  for (let i = 0; i <= maxSyncIterations; i++) {
+    const syncRequest = processSchemaSynchronization(sync, syncResult)
+    if (syncRequest === null) {
+      // Synchronization is complete — finalize the permanent claim so the
+      // descriptor survives indefinitely. Only commit on success; the
+      // iteration-exhaustion path below intentionally leaves the claim
+      // uncommitted (it will expire) rather than pinning a partial upload.
+      await request({
+        url: url('commit'),
+        method: 'POST',
+        body: {contextKey: options.contextKey, id: claimResponse.commitId},
+      })
+      return descriptorId
+    }
+    if (i === maxSyncIterations) {
+      break
+    }
+    syncResult = await request<SchemaSynchronizationResult>({
+      url: url('synchronize'),
+      method: 'POST',
+      body: syncRequest,
+    })
+  }
+
+  throw new Error(`Schema synchronization didn't succeed in ${maxSyncIterations} iterations`)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1151,6 +1151,9 @@ importers:
       arrify:
         specifier: ^3.0.0
         version: 3.0.0
+      get-it:
+        specifier: ^8.8.0
+        version: 8.8.0
       groq-js:
         specifier: ^1.30.3
         version: 1.30.3


### PR DESCRIPTION
### Description

Adds `@sanity/schema/_internal` schema-upload helpers that replace the hand-rolled claim/synchronize/commit code in `brett`.

One hard-coded lifecycle (permanent claim + inline commit) doesn't fit every caller, so the building block exposes the choice. `prepareSchemaUpload` does convert → claim → synchronize and **defers the commit**: a permanent claim returns a `commit()` thunk the caller invokes when ready (e.g. after a dependent DB write succeeds), and a temporary claim returns none — retained until it expires, or until a referencing permanent descriptor (e.g. a manifest) pins it transitively.

The `claim: 'temporary' | 'permanent'` option lives on the claim call (not inferred from whether the caller later commits) because the two are *different* `/claim` requests with *different* responses — temporary returns `expiresAt` and has nothing to commit; permanent returns a `commitId`. The kind is fixed in the request body before any `commitId` exists, so commit-or-not can't express it. `uploadSchema` is the convenience wrapper: permanent claim, committed inline, returns the descriptor id.

Rejected alternatives: a single `claim` flag with always-inline commit (can't express brett's claim → write → commit-after-success sequencing); changing `uploadSchema`'s return type to `{descriptorId, commit?}` (breaks the `Promise<string>` contract for no gain once `prepareSchemaUpload` carries the two-phase case).

FIXES SDK-1727

### What to review

- `uploadSchema.ts` — `prepareSchemaUpload` (claim lifecycle + deferred `commit()` thunk) and the `uploadSchema` wrapper. Note the phase-event ordering: `prepareSchemaUpload` emits `convert/claim/synchronize`, the `commit()` thunk emits `commit`, and `uploadSchema` emits `total` after commit — so the wrapper's order stays `convert → claim → [sync] → commit → total`.
- `transport.ts` — get-it requester + retry predicate (429/5xx); `baseUrl` xor `requester`, enforced at compile time and runtime.
- `onPhaseComplete` observability hook is fire-and-forget (a throwing hook never breaks an upload).
- Package: `@sanity/schema` only.

### Testing

- `uploadSchema.test.ts` (26 tests): transport guards, header merging, temporary vs permanent claim bodies, the deferred `commit()` thunk (exactly one `/commit` with the right body; none until invoked), the missing-`commitId` guard, the sync iteration limit, and `onPhaseComplete` ordering for both entry points.
- Typecheck, oxlint, and the `@sanity/schema/_internal` dts export fixture pass.

### Notes for release

N/A – internal only (`@sanity/schema/_internal`), consumed by brett.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New networked schema upload path with auth header merging and two-phase permanent commit; internal-only but wrong commit timing or sync limits could leave descriptors unpinned or fail uploads in brett.
> 
> **Overview**
> Adds **`@sanity/schema/_internal`** helpers to upload compiled schemas to the descriptor API (claim → synchronize → optional commit), replacing ad-hoc claim/synchronize/commit logic in consumers like brett.
> 
> **`prepareSchemaUpload`** converts the schema via a shared cached `DescriptorConverter`, posts **`/claim`** with **`claim: 'temporary' | 'permanent'`**, runs the existing **`processSchemaSynchronization`** loop against **`/synchronize`**, and returns **`descriptorId`** plus an optional **`commit()`** thunk for permanent claims only. **`uploadSchema`** is the one-shot path: permanent claim, inline commit, **`Promise<string>`** descriptor id.
> 
> Transport is **`baseUrl`** (new **`get-it`** stack with 429/5xx retry) **xor** injectable **`DescriptorRequester`**. Requests merge **`token`** / **`headers`** (caller **`Authorization`** wins). **`onPhaseComplete`** reports phase timings without failing uploads.
> 
> Exports and DTS fixture tests cover the new types; **`uploadSchema.test.ts`** exercises lifecycles, sync limits, and phase ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9028afb84f11de9f86afae907607a9d06c0da3c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->