### PR TITLE
fix(CLDX-5683): preserve portable text block decorators in schema descriptor

### DIFF
--- a/packages/@sanity/schema/src/descriptors/convert.ts
+++ b/packages/@sanity/schema/src/descriptors/convert.ts
@@ -8,18 +8,19 @@ import {
   type ArraySchemaType,
   type FieldGroupDefinition,
   type FieldsetDefinition,
+  isSpanSchemaType,
   type ObjectSchemaType,
   type ReferenceSchemaType,
   type Rule as IRule,
   type Schema,
   type SchemaType,
-  type SpanSchemaType,
 } from '@sanity/types'
 import isEqual from 'lodash-es/isEqual.js'
 import isObject from 'lodash-es/isObject.js'
 
 import {Rule} from '../legacy/Rule'
 import {OWN_PROPS_NAME} from '../legacy/types/constants'
+import {isType} from '../manifest/manifestTypeHelpers'
 import {IdleScheduler, type Scheduler, SYNC_SCHEDULER} from './scheduler'
 import {
   type ArrayElement,
@@ -349,20 +350,6 @@ function convertTypeDef(schemaType: SchemaType, path: string, opts: Options): Ty
 }
 
 /**
- * Walks the type chain to check whether `schemaType` is (a subtype of) `typeName`.
- * Mirrors `isType` from the manifest extractor so block detection stays consistent
- * between the two serializers.
- */
-function isType(schemaType: SchemaType, typeName: string): boolean {
-  let current: SchemaType | undefined = schemaType
-  while (current) {
-    if (current.name === typeName) return true
-    current = current.type
-  }
-  return false
-}
-
-/**
  * Serializes a portable-text block's decorators, mirroring `resolveEnabledDecorators`
  * in the manifest extractor (`extractManifestSchemaTypes.ts`).
  *
@@ -381,19 +368,20 @@ function maybeBlockMarks(schemaType: SchemaType): BlockMarks | undefined {
   )
   const childrenOf = (childrenField?.type as ArraySchemaType | undefined)?.of
   const spanType = childrenOf?.find((memberType) => memberType.name === 'span')
-  if (!spanType || !('decorators' in spanType)) {
+  if (!spanType || !isSpanSchemaType(spanType)) {
     return undefined
   }
 
-  const decorators = convertTitledValues((spanType as SpanSchemaType).decorators)
+  const decorators = convertTitledValues(spanType.decorators)
   return decorators ? {decorators} : undefined
 }
 
 /**
  * Reduces a list of title/value definitions to the serializable `{value, title?}`
- * shape, dropping anything without a string `value`. Mirrors `resolveTitleValueArray`
- * in the manifest extractor (which is why non-serializable extras such as `icon` and
- * `i18nTitleKey` are intentionally stripped).
+ * shape, dropping anything without a non-empty string `value`. Mirrors
+ * `resolveTitleValueArray` in the manifest extractor — including its rejection of
+ * empty-string values — which is why non-serializable extras such as `icon` and
+ * `i18nTitleKey` are intentionally stripped.
  */
 function convertTitledValues(possibleArray: unknown): BlockTitledValue[] | undefined {
   if (!Array.isArray(possibleArray)) return undefined
@@ -401,7 +389,7 @@ function convertTitledValues(possibleArray: unknown): BlockTitledValue[] | undef
   const titledValues = possibleArray
     .filter(
       (item): item is {value: string; title?: unknown} =>
-        isObject(item) && 'value' in item && typeof item.value === 'string',
+        isObject(item) && 'value' in item && typeof item.value === 'string' && item.value !== '',
     )
     .map((item) => ({
       value: item.value,

--- a/packages/@sanity/schema/src/descriptors/convert.ts
+++ b/packages/@sanity/schema/src/descriptors/convert.ts
@@ -13,6 +13,7 @@ import {
   type Rule as IRule,
   type Schema,
   type SchemaType,
+  type SpanSchemaType,
 } from '@sanity/types'
 import isEqual from 'lodash-es/isEqual.js'
 import isObject from 'lodash-es/isObject.js'
@@ -23,6 +24,8 @@ import {IdleScheduler, type Scheduler, SYNC_SCHEDULER} from './scheduler'
 import {
   type ArrayElement,
   type ArrayTypeDef,
+  type BlockMarks,
+  type BlockTitledValue,
   type CommonTypeDef,
   type CoreTypeDef,
   type CyclicMarker,
@@ -334,9 +337,78 @@ function convertTypeDef(schemaType: SchemaType, path: string, opts: Options): Ty
         ...common,
       } satisfies ReferenceTypeDef
     }
-    default:
-      return {extends: schemaType.type.name, ...common} satisfies SubtypeDef
+    default: {
+      const marks = maybeBlockMarks(schemaType)
+      return {
+        extends: schemaType.type.name,
+        ...common,
+        ...(marks && {marks}),
+      } satisfies SubtypeDef
+    }
   }
+}
+
+/**
+ * Walks the type chain to check whether `schemaType` is (a subtype of) `typeName`.
+ * Mirrors `isType` from the manifest extractor so block detection stays consistent
+ * between the two serializers.
+ */
+function isType(schemaType: SchemaType, typeName: string): boolean {
+  let current: SchemaType | undefined = schemaType
+  while (current) {
+    if (current.name === typeName) return true
+    current = current.type
+  }
+  return false
+}
+
+/**
+ * Serializes a portable-text block's decorators, mirroring `resolveEnabledDecorators`
+ * in the manifest extractor (`extractManifestSchemaTypes.ts`).
+ *
+ * The generic converter already picks up styles/lists/annotations/inline objects
+ * because they're field-expressed on a compiled block. Decorators are the exception:
+ * they live as `span.decorators` metadata with no field representation, so without
+ * this they'd be dropped from the descriptor entirely.
+ */
+function maybeBlockMarks(schemaType: SchemaType): BlockMarks | undefined {
+  if (schemaType.jsonType !== 'object' || !isType(schemaType, 'block')) {
+    return undefined
+  }
+
+  const childrenField = (schemaType as ObjectSchemaType).fields?.find(
+    (field) => field.name === 'children',
+  )
+  const childrenOf = (childrenField?.type as ArraySchemaType | undefined)?.of
+  const spanType = childrenOf?.find((memberType) => memberType.name === 'span')
+  if (!spanType || !('decorators' in spanType)) {
+    return undefined
+  }
+
+  const decorators = convertTitledValues((spanType as SpanSchemaType).decorators)
+  return decorators ? {decorators} : undefined
+}
+
+/**
+ * Reduces a list of title/value definitions to the serializable `{value, title?}`
+ * shape, dropping anything without a string `value`. Mirrors `resolveTitleValueArray`
+ * in the manifest extractor (which is why non-serializable extras such as `icon` and
+ * `i18nTitleKey` are intentionally stripped).
+ */
+function convertTitledValues(possibleArray: unknown): BlockTitledValue[] | undefined {
+  if (!Array.isArray(possibleArray)) return undefined
+
+  const titledValues = possibleArray
+    .filter(
+      (item): item is {value: string; title?: unknown} =>
+        isObject(item) && 'value' in item && typeof item.value === 'string',
+    )
+    .map((item) => ({
+      value: item.value,
+      ...(typeof item.title === 'string' ? {title: item.title} : {}),
+    }))
+
+  return titledValues.length > 0 ? titledValues : undefined
 }
 
 function maybeString(val: unknown): string | undefined {

--- a/packages/@sanity/schema/src/descriptors/convert.ts
+++ b/packages/@sanity/schema/src/descriptors/convert.ts
@@ -26,7 +26,6 @@ import {
   type ArrayElement,
   type ArrayTypeDef,
   type BlockMarks,
-  type BlockTitledValue,
   type CommonTypeDef,
   type CoreTypeDef,
   type CyclicMarker,
@@ -348,13 +347,16 @@ function convertTypeDef(schemaType: SchemaType, path: string, opts: Options): Ty
 }
 
 /**
- * Serializes a portable-text block's decorators, mirroring `resolveEnabledDecorators`
- * in the manifest extractor (`extractManifestSchemaTypes.ts`).
+ * Serializes a portable-text block's decorators.
  *
  * The generic converter already picks up styles/lists/annotations/inline objects
  * because they're field-expressed on a compiled block. Decorators are the exception:
  * they live as `span.decorators` metadata with no field representation, so without
  * this they'd be dropped from the descriptor entirely.
+ *
+ * They're encoded with the same `convertUnknown` walker used for style/list options,
+ * so the decorator shape (incl. `i18nTitleKey`, and `icon` as a function/jsx marker)
+ * matches how the descriptor serializes every other option list.
  */
 function maybeBlockMarks(schemaType: SchemaType): BlockMarks | undefined {
   if (schemaType.jsonType !== 'object' || !isType(schemaType, 'block')) {
@@ -366,35 +368,12 @@ function maybeBlockMarks(schemaType: SchemaType): BlockMarks | undefined {
   )
   const childrenOf = (childrenField?.type as ArraySchemaType | undefined)?.of
   const spanType = childrenOf?.find((memberType) => memberType.name === 'span')
-  if (!spanType || !isSpanSchemaType(spanType)) {
+  if (!spanType || !isSpanSchemaType(spanType) || spanType.decorators.length === 0) {
     return undefined
   }
 
-  const decorators = convertTitledValues(spanType.decorators)
-  return decorators ? {decorators} : undefined
-}
-
-/**
- * Reduces a list of title/value definitions to the serializable `{value, title?}`
- * shape, dropping anything without a non-empty string `value`. Mirrors
- * `resolveTitleValueArray` in the manifest extractor — including its rejection of
- * empty-string values — which is why non-serializable extras such as `icon` and
- * `i18nTitleKey` are intentionally stripped.
- */
-function convertTitledValues(possibleArray: unknown): BlockTitledValue[] | undefined {
-  if (!Array.isArray(possibleArray)) return undefined
-
-  const titledValues = possibleArray
-    .filter(
-      (item): item is {value: string; title?: unknown} =>
-        isObject(item) && 'value' in item && typeof item.value === 'string' && item.value !== '',
-    )
-    .map((item) => ({
-      value: item.value,
-      ...(typeof item.title === 'string' ? {title: item.title} : {}),
-    }))
-
-  return titledValues.length > 0 ? titledValues : undefined
+  const decorators = convertUnknown(spanType.decorators)
+  return decorators === undefined ? undefined : {decorators}
 }
 
 function maybeString(val: unknown): string | undefined {

--- a/packages/@sanity/schema/src/descriptors/convert.ts
+++ b/packages/@sanity/schema/src/descriptors/convert.ts
@@ -338,14 +338,12 @@ function convertTypeDef(schemaType: SchemaType, path: string, opts: Options): Ty
         ...common,
       } satisfies ReferenceTypeDef
     }
-    default: {
-      const marks = maybeBlockMarks(schemaType)
+    default:
       return {
         extends: schemaType.type.name,
         ...common,
-        ...(marks && {marks}),
+        marks: maybeBlockMarks(schemaType),
       } satisfies SubtypeDef
-    }
   }
 }
 

--- a/packages/@sanity/schema/src/descriptors/types.ts
+++ b/packages/@sanity/schema/src/descriptors/types.ts
@@ -48,20 +48,18 @@ export interface CommonTypeDef extends EncodableObject {
   marks?: BlockMarks
 }
 
-/** A title/value pair, e.g. a single block decorator (`{value: 'strong', title: 'Strong'}`). */
-export type BlockTitledValue = {
-  value: string
-  title?: string
-}
-
 /**
  * Unlike the manifest and userland `marks` (which carry both `decorators` and
  * `annotations`), the descriptor's `marks` carries only `decorators`. Annotations
  * are field-expressed on a compiled block (via the `markDefs` field) and so are
  * already represented in the descriptor — duplicating them here would be redundant.
+ *
+ * Decorators are serialized with the same generic encoder as style/list options, so
+ * they keep extras like `i18nTitleKey` and encode a non-serializable `icon` as a
+ * marker — consistent with how the descriptor serializes every other option list.
  */
 export type BlockMarks = {
-  decorators: BlockTitledValue[]
+  decorators: EncodableValue
 }
 
 /** In some scenarios we need to encode special information. */

--- a/packages/@sanity/schema/src/descriptors/types.ts
+++ b/packages/@sanity/schema/src/descriptors/types.ts
@@ -36,6 +36,26 @@ export interface CommonTypeDef extends EncodableObject {
   rows?: string
 
   orderings?: ObjectOrdering[]
+
+  /**
+   * Portable-text block marks. Only present on `block` types.
+   *
+   * Styles, lists and annotations are field-expressed on a compiled block (so the
+   * generic walker serializes them as ordinary fields), but decorators are span
+   * metadata with no field representation. They're carried here explicitly so the
+   * descriptor stays consistent with the manifest extractor.
+   */
+  marks?: BlockMarks
+}
+
+/** A title/value pair, e.g. a single block decorator (`{value: 'strong', title: 'Strong'}`). */
+export type BlockTitledValue = {
+  value: string
+  title?: string
+}
+
+export type BlockMarks = {
+  decorators: BlockTitledValue[]
 }
 
 /** In some scenarios we need to encode special information. */

--- a/packages/@sanity/schema/src/descriptors/types.ts
+++ b/packages/@sanity/schema/src/descriptors/types.ts
@@ -54,6 +54,12 @@ export type BlockTitledValue = {
   title?: string
 }
 
+/**
+ * Unlike the manifest and userland `marks` (which carry both `decorators` and
+ * `annotations`), the descriptor's `marks` carries only `decorators`. Annotations
+ * are field-expressed on a compiled block (via the `markDefs` field) and so are
+ * already represented in the descriptor — duplicating them here would be redundant.
+ */
 export type BlockMarks = {
   decorators: BlockTitledValue[]
 }

--- a/packages/sanity/test/descriptors/schema.test.tsx
+++ b/packages/sanity/test/descriptors/schema.test.tsx
@@ -2535,14 +2535,23 @@ describe('Block', () => {
     expect(level.typeDef.extends).toBe('number')
 
     // Decorators are span metadata (not a field), so they're carried explicitly
-    // on the block typeDef. A default block exposes the default decorator set.
+    // on the block typeDef. A default block exposes the default decorator set,
+    // serialized like style/list options (so `i18nTitleKey` is preserved).
     expect(type.typeDef.marks).toEqual({
       decorators: [
-        {value: 'strong', title: 'Strong'},
-        {value: 'em', title: 'Italic'},
-        {value: 'code', title: 'Code'},
-        {value: 'underline', title: 'Underline'},
-        {value: 'strike-through', title: 'Strike'},
+        {value: 'strong', title: 'Strong', i18nTitleKey: 'inputs.portable-text.decorator.strong'},
+        {value: 'em', title: 'Italic', i18nTitleKey: 'inputs.portable-text.decorator.emphasis'},
+        {value: 'code', title: 'Code', i18nTitleKey: 'inputs.portable-text.decorator.code'},
+        {
+          value: 'underline',
+          title: 'Underline',
+          i18nTitleKey: 'inputs.portable-text.decorator.underline',
+        },
+        {
+          value: 'strike-through',
+          title: 'Strike',
+          i18nTitleKey: 'inputs.portable-text.decorator.strike-through',
+        },
       ],
     })
   })

--- a/packages/sanity/test/descriptors/schema.test.tsx
+++ b/packages/sanity/test/descriptors/schema.test.tsx
@@ -2533,6 +2533,18 @@ describe('Block', () => {
     )
     assert(level)
     expect(level.typeDef.extends).toBe('number')
+
+    // Decorators are span metadata (not a field), so they're carried explicitly
+    // on the block typeDef. A default block exposes the default decorator set.
+    expect(type.typeDef.marks).toEqual({
+      decorators: [
+        {value: 'strong', title: 'Strong'},
+        {value: 'em', title: 'Italic'},
+        {value: 'code', title: 'Code'},
+        {value: 'underline', title: 'Underline'},
+        {value: 'strike-through', title: 'Strike'},
+      ],
+    })
   })
 
   test('custom settings', async () => {
@@ -2600,6 +2612,11 @@ describe('Block', () => {
     )
     assert(level)
     expect(level.typeDef.extends).toBe('number')
+
+    // Custom decorators replace the defaults and must survive into the descriptor.
+    expect(type.typeDef.marks).toEqual({
+      decorators: [{value: 'weak', title: 'Weak'}],
+    })
   })
 })
 


### PR DESCRIPTION
### Description

Resolves [CLDX-5683](https://linear.app/sanity/issue/CLDX-5683/schema-descriptor-drops-portable-text-block-decorators-manifest-keeps).

When a schema is converted to a **schema descriptor** (the format served from Lexicon `descriptors/schemas/{id}`), a portable-text `block` type's declared **decorators** were dropped entirely. Styles, lists, annotations and inline objects survived; decorators did not. The sibling **manifest** extractor for the same schema *does* serialize decorators, so the two serializers disagreed.

The reason is that the descriptor converter is a generic type→descriptor walker. On a compiled block, most things are *field-expressed*, so the generic walker picks them up for free:

```
block (object)
├─ style      → string field, options.list   ✅ styles
├─ listItem   → string field, options.list   ✅ lists
├─ markDefs   → array of object types         ✅ annotations
└─ children   → array
   ├─ span    → marks: array<string>          ❌ decorators live on span.decorators
   │                                              (metadata, NOT a field → dropped)
   └─ …inline objects                         ✅ children.of
```

Decorators are the one exception: they are `span.decorators` metadata with no field representation, so the generic walker had nothing to grab.

This change adds portable-text-block handling to the descriptor converter so it serializes the span's decorators as a block-level `marks.decorators` on the typeDef, mirroring the manifest extractor's `resolveEnabledDecorators` (reduced to the serializable `{value, title?}` shape). The descriptor now reflects a block's full decorator vocabulary, consistent with the manifest.

This is the **producer** half. The matching **consumer** change (`@sanity/schema-descriptor-utils` `convertToDefinition`, which reconstructs `marks.decorators` from this shape so `createSchema` surfaces them) is in sanity-io/schema-descriptor-utils#20.

### What to review

- `convert.ts`: the new block detection and decorator extraction — does it mirror the manifest extractor's behavior (default vs. custom decorator sets, stripping non-serializable extras like `icon`/`i18nTitleKey`)?
- The wire shape (`marks: {decorators: [{value, title?}]}`) on the block typeDef — confirm it's a sensible, additive contract for descriptor consumers.
- Whether the block-level `marks` placement is the right call versus the field-expressed alternatives discussed in the issue.

### Testing

This is a low-level serialization change with no user-facing browser flow on its own — the visible effect (custom decorators offered in linked Studio fields) only appears once the consumer-side adoption (EDEX-1375) lands. It is covered by the descriptor test suite, including the existing manifest↔descriptor round-trip check, which now also asserts that a block's decorators survive for both the default decorator set and a custom one.

### Notes for release

N/A