### PR TITLE
fix(form): detect multi-block PT selection by enclosing block, not `path[0]`

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
@@ -1,9 +1,11 @@
 import {
   PortableTextEditor,
+  useEditor,
+  useEditorSelector,
   usePortableTextEditor,
-  usePortableTextEditorSelection,
 } from '@portabletext/editor'
-import {isKeySegment} from '@sanity/types'
+import {getSelectionEndBlock, getSelectionStartBlock} from '@portabletext/editor/selectors'
+import {isEqual} from '@sanity/util/paths'
 import {memo, useCallback, useMemo} from 'react'
 
 import {type PopoverProps} from '../../../../../ui-components'
@@ -30,17 +32,17 @@ export const ActionMenu = memo(function ActionMenu(props: ActionMenuProps) {
   const {disabled: disabledProp, groups, isFullscreen, collapsed} = props
   const focusBlock = useFocusBlock()
 
-  const editor = usePortableTextEditor()
+  const legacyEditor = usePortableTextEditor()
+  const editor = useEditor()
   const schemaTypes = usePortableTextMemberSchemaTypes()
-  const selection = usePortableTextEditorSelection()
   const {t} = useTranslation()
-  const isSelectingMultipleBlocks =
-    // Path at 0 is the block level, by comparing those we can detect if the user is selecting multiple blocks
-    selection && isKeySegment(selection.anchor.path[0]) && isKeySegment(selection.focus.path[0])
-      ? // In case of keyed segments
-        selection.anchor.path[0]._key !== selection?.focus.path[0]._key
-      : // In case of non-keyed segments
-        selection?.anchor.path[0] !== selection?.focus.path[0]
+  // Compare the enclosing block at each end by path (keys aren't unique across
+  // containers).
+  const isSelectingMultipleBlocks = useEditorSelector(editor, (snapshot) => {
+    const startBlock = getSelectionStartBlock(snapshot)
+    const endBlock = getSelectionEndBlock(snapshot)
+    return !!startBlock && !!endBlock && !isEqual(startBlock.path, endBlock.path)
+  })
 
   const isVoidBlock = focusBlock?._type !== schemaTypes.block.name
   const isEmptyTextBlock =
@@ -67,8 +69,8 @@ export const ActionMenu = memo(function ActionMenu(props: ActionMenuProps) {
   const activeKeys = useActiveActionKeys({actions})
 
   const handleMenuClose = useCallback(() => {
-    PortableTextEditor.focus(editor)
-  }, [editor])
+    PortableTextEditor.focus(legacyEditor)
+  }, [legacyEditor])
 
   const tooltipPlacement = isFullscreen ? 'bottom' : 'top'
 


### PR DESCRIPTION
### Description

`ActionMenu` disables annotations when the selection spans more than one block. It detected that by comparing `anchor.path[0]._key` with `focus.path[0]._key`, which assumes a block is always the top-level path segment. Soon, the editor will allow blocks nested deeper than that (e.g. inside a table cell), where `path[0]` is the container rather than the block, so the check can read a multi-block selection as a single block.

It now resolves the block at each end of the selection with `getSelectionStartBlock`/`getSelectionEndBlock` (resolved at any depth) and compares them by path (keys aren't unique across containers). Behavior is identical for the top-level documents Studio renders today; it only differs once blocks nest.

### What to review

`ActionMenu.tsx` only. Confirm annotations still disable across two top-level blocks and enable within a single block (both unchanged).

### Testing

No automated test: there is no toolbar test harness, and the changed behavior (a selection across nested blocks) cannot be produced with the documents Studio renders today. The added logic is a path comparison over editor selectors that are tested in `@portabletext/editor`. Types, lint, and format pass locally.

### Notes for release

N/A – No user-facing change.
