### PR TITLE
feat(debug-proxy): add network flap and latency simulation

### DIFF
--- a/packages/@repo/debug-proxy/README.md
+++ b/packages/@repo/debug-proxy/README.md
@@ -43,6 +43,8 @@ Configuration is via CLI flags (`--help` for the full list):
 - `--force-http1` — don't offer h2 in the TLS handshake, forcing clients down to HTTP/1.1 over TLS; useful for testing how the studio handles a legacy protocol (e.g. the `isUsingLegacyHttp` warning)
 - `--api-host` — upstream API (`api.sanity.io` or `api.sanity.work` for staging)
 - `--listener-ttl` — disconnect SSE listeners after N seconds to simulate flaky connections
+- `--flap <on>[:<off>]` — simulate flapping connectivity (online → offline → online → …): proxy normally for `<on>` seconds, then go "offline" for `<off>` seconds, repeating. While offline, new requests are reset at the socket level and live SSE streams are cut, so clients see real network-failure errors rather than HTTP error responses. A single number means equal phases, e.g. `--flap 30:15` or `--flap 20`
+- `--latency <ms>[:<maxMs>]` — delay each request by this many milliseconds before forwarding it upstream, simulating a slow network; a range applies random jitter per request, e.g. `--latency 800` or `--latency 200:1500`
 - Fault toggles: `--sse-faults`, `--drop-probability`, `--reset-probability`, `--org-401`
 
 Pass flags through pnpm like so:
@@ -127,6 +129,8 @@ Routes are matched in order — the first route whose `match` returns `true` win
 - `createRequestProxy({transformHeaders?, transformBody?})` — the core proxy primitive (RxJS operators over response headers/body).
 - `createSSEProxy(operator?)` — builds on `createRequestProxy` for streaming endpoints; parses the byte stream into discrete `SSEEvent`s.
 - Scenarios (RxJS operators over the SSE event stream): `randomLatency`, `sendReset`, `duplicateMutations`, `dropMutations`, `shuffleEventDelivery`.
+- `createConnectionFlapper({onlineMs, offlineMs})` — cycles simulated connectivity; `flapper.wrap(handler)` makes any handler's requests fail like a dead network during the offline phases (and cuts in-flight streams on each transition).
+- `withLatency(handler, {minMs, maxMs})` — holds each request back by a random delay in the range before forwarding it upstream.
 - Route matchers: `urlIncludes`, `isListenEndpoint`, `isGetOrgIdEndpoint`, `anyOf`, `allOf`.
 
 ## Writing a new scenario

--- a/packages/@repo/debug-proxy/src/cli.ts
+++ b/packages/@repo/debug-proxy/src/cli.ts
@@ -10,7 +10,9 @@ import {parseArgs, promisify} from 'node:util'
 import {getCertificate} from '@vitejs/plugin-basic-ssl'
 import {map, pipe, takeUntil, tap, timer} from 'rxjs'
 
-import {createDebugProxy} from './createDebugProxy'
+import {createConnectionFlapper} from './connectivity'
+import {createDebugProxy, type ProxyHandler} from './createDebugProxy'
+import {withLatency} from './latency'
 import {createRequestProxy, createSSEProxy} from './proxy'
 import {isGetOrgIdEndpoint, isListenEndpoint} from './routes'
 import {
@@ -36,6 +38,15 @@ Options:
                               use api.sanity.work for staging)
   --listener-ttl <seconds>    disconnect SSE listeners after this many seconds
                               to simulate flaky connections (default: never)
+  --flap <on>[:<off>]         simulate flapping connectivity: proxy normally
+                              for <on> seconds, then go "offline" for <off>
+                              seconds (new requests reset, live streams cut),
+                              repeating. A single number means equal phases,
+                              e.g. --flap 30:15 or --flap 20
+  --latency <ms>[:<maxMs>]    delay each request by this many milliseconds
+                              before forwarding it upstream; a range applies
+                              random jitter per request, e.g. --latency 800
+                              or --latency 200:1500
   --sse-faults                apply the SSE fault scenarios (shuffle, duplicate,
                               latency, reset, drop) to the listener endpoint
   --drop-probability <0..1>   probability a mutation event is dropped
@@ -63,6 +74,8 @@ function parseFlags() {
         'http1-port': {type: 'string', default: '3050'},
         'api-host': {type: 'string', default: 'api.sanity.io'},
         'listener-ttl': {type: 'string', default: '0'},
+        'flap': {type: 'string'},
+        'latency': {type: 'string'},
         'sse-faults': {type: 'boolean', default: false},
         'drop-probability': {type: 'string', default: '0'},
         'reset-probability': {type: 'string', default: '0'},
@@ -93,6 +106,46 @@ function intFlag(name: string, value: string): number {
   return Number(value)
 }
 
+/** Parse the --flap value (`<on>[:<off>]` in seconds) into phase durations. */
+function flapFlag(value: string): {onlineMs: number; offlineMs: number} {
+  const [on, off = on, ...rest] = value.split(':')
+  const onlineSec = Number(on)
+  const offlineSec = Number(off)
+  if (
+    rest.length > 0 ||
+    !Number.isFinite(onlineSec) ||
+    !Number.isFinite(offlineSec) ||
+    onlineSec <= 0 ||
+    offlineSec <= 0
+  ) {
+    console.error(
+      `Invalid --flap: expected "<onlineSeconds>:<offlineSeconds>" (or a single number for equal phases), got "${value}"`,
+    )
+    process.exit(1)
+  }
+  return {onlineMs: onlineSec * 1000, offlineMs: offlineSec * 1000}
+}
+
+/** Parse the --latency value (`<ms>[:<maxMs>]`) into a delay range. */
+function latencyFlag(value: string): {minMs: number; maxMs: number} {
+  const [min, max = min, ...rest] = value.split(':')
+  const minMs = Number(min)
+  const maxMs = Number(max)
+  if (
+    rest.length > 0 ||
+    !Number.isInteger(minMs) ||
+    !Number.isInteger(maxMs) ||
+    minMs < 0 ||
+    maxMs < minMs
+  ) {
+    console.error(
+      `Invalid --latency: expected "<ms>" or "<minMs>:<maxMs>" (non-negative, max >= min), got "${value}"`,
+    )
+    process.exit(1)
+  }
+  return {minMs, maxMs}
+}
+
 /** Parse a flag as a probability in [0, 1], exiting with a clear error if not. */
 function probabilityFlag(name: string, value: string): number {
   const parsed = value.trim() === '' ? NaN : Number(value)
@@ -109,6 +162,8 @@ const ENABLE_HTTP1 = flags.http1
 const HTTP1_PORT = intFlag('http1-port', flags['http1-port'])
 const API_HOST = flags['api-host']
 const LISTENER_TTL_MS = intFlag('listener-ttl', flags['listener-ttl']) * 1000
+const FLAP = flags.flap === undefined ? undefined : flapFlag(flags.flap)
+const LATENCY = flags.latency === undefined ? undefined : latencyFlag(flags.latency)
 const ENABLE_SSE_FAULTS = flags['sse-faults']
 const DROPPED_MUTATION_PROBABILITY = probabilityFlag('drop-probability', flags['drop-probability'])
 const RESET_PROBABILITY = probabilityFlag('reset-probability', flags['reset-probability'])
@@ -292,13 +347,66 @@ const orgEndpointProxy = createRequestProxy({
     ),
 })
 
+// Render a live, in-place countdown to the next flap transition. On a TTY the
+// line rewrites itself each second via carriage return; otherwise (piped, e.g.
+// under run-p) we skip the ticking and just log the transition once, since
+// carriage returns would render as noise.
+const isTty = process.stdout.isTTY
+let countdownTimer: ReturnType<typeof setInterval> | undefined
+
+function startCountdown(online: boolean, phaseMs: number) {
+  clearInterval(countdownTimer)
+  const label = online ? 'online' : 'offline'
+  const deadline = Date.now() + phaseMs
+
+  if (!isTty) {
+    console.info(`[debug-proxy] network ${label} for the next ${Math.round(phaseMs / 1000)}s`)
+    return
+  }
+
+  const render = () => {
+    const remaining = Math.max(0, Math.ceil((deadline - Date.now()) / 1000))
+    // \r returns to the line start; padding clears any longer previous line
+    process.stdout.write(`\r[debug-proxy] network ${label} — next change in ${remaining}s   `)
+    if (remaining <= 0) {
+      clearInterval(countdownTimer)
+    }
+  }
+  render()
+  countdownTimer = setInterval(render, 1000)
+  countdownTimer.unref?.()
+}
+
+// One flapper shared across all routes and both listeners — every request
+// rides the same simulated network.
+const flapper = FLAP
+  ? createConnectionFlapper({
+      ...FLAP,
+      onTransition: (online) => {
+        if (isTty) {
+          process.stdout.write('\n')
+        }
+        startCountdown(online, online ? FLAP.onlineMs : FLAP.offlineMs)
+      },
+    })
+  : undefined
+
+// Network-level scenarios applied to every handler: --latency delays each
+// request, --flap sits outside it so offline resets stay immediate.
+const withNetworkScenarios = (handler: ProxyHandler): ProxyHandler => {
+  const delayed = LATENCY ? withLatency(handler, LATENCY) : handler
+  return flapper ? flapper.wrap(delayed) : delayed
+}
+
 const routes = [
-  ...(FORCE_ORG_401 ? [{match: isGetOrgIdEndpoint(), handler: orgEndpointProxy}] : []),
+  ...(FORCE_ORG_401
+    ? [{match: isGetOrgIdEndpoint(), handler: withNetworkScenarios(orgEndpointProxy)}]
+    : []),
   // Only intercept the listener endpoint when a scenario needs it — with no
   // scenarios active, even SSE flows through the byte-transparent default
-  // handler
+  // handler (which is still subject to --flap and --latency)
   ...(ENABLE_SSE_FAULTS || LISTENER_TTL_MS > 0
-    ? [{match: isListenEndpoint(), handler: listenEndpointProxy}]
+    ? [{match: isListenEndpoint(), handler: withNetworkScenarios(listenEndpointProxy)}]
     : []),
 ]
 
@@ -306,6 +414,7 @@ const sharedConfig = {
   apiHost: API_HOST,
   token: SANITY_TOKEN,
   routes,
+  defaultHandler: withNetworkScenarios(createRequestProxy()),
 }
 
 const tlsProxy = createDebugProxy({
@@ -326,4 +435,21 @@ if (ENABLE_HTTP1) {
   const http1Proxy = createDebugProxy({...sharedConfig, port: HTTP1_PORT})
   await http1Proxy.listen()
   console.info(`HTTP/1.1 (cleartext) proxy listening on http://localhost:${HTTP1_PORT}`)
+}
+
+if (FLAP) {
+  console.info(
+    `Flapping connectivity: ${FLAP.onlineMs / 1000}s online → ${FLAP.offlineMs / 1000}s offline, repeating`,
+  )
+  // Start the countdown for the initial (online) phase now that the startup
+  // banner has printed, so the in-place countdown line stays at the bottom.
+  startCountdown(true, FLAP.onlineMs)
+}
+
+if (LATENCY) {
+  console.info(
+    LATENCY.minMs === LATENCY.maxMs
+      ? `Latency: ${LATENCY.minMs}ms per request`
+      : `Latency: ${LATENCY.minMs}–${LATENCY.maxMs}ms per request (random jitter)`,
+  )
 }

--- a/packages/@repo/debug-proxy/src/connectivity.test.ts
+++ b/packages/@repo/debug-proxy/src/connectivity.test.ts
@@ -1,0 +1,103 @@
+import {EventEmitter} from 'node:events'
+
+import {Subscription} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {createConnectionFlapper} from './connectivity'
+import {type ProxyRequest, type ProxyResponse, type ProxyTarget} from './proxy'
+
+function fakeResponse() {
+  const emitter = new EventEmitter() as EventEmitter & {destroyed: boolean; destroy: () => void}
+  emitter.destroyed = false
+  emitter.destroy = () => {
+    emitter.destroyed = true
+    emitter.emit('close')
+  }
+  return emitter as unknown as ProxyResponse & {destroyed: boolean}
+}
+
+const req = {} as ProxyRequest
+const target = {} as ProxyTarget
+
+describe('createConnectionFlapper', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  test('delegates to the handler while online', () => {
+    const flapper = createConnectionFlapper({onlineMs: 1000, offlineMs: 1000})
+    const handler = vi.fn(() => new Subscription())
+    const res = fakeResponse()
+
+    flapper.wrap(handler)(req, res, target)
+
+    expect(flapper.isOnline()).toBe(true)
+    expect(handler).toHaveBeenCalledWith(req, res, target)
+    expect(res.destroyed).toBe(false)
+    flapper.stop()
+  })
+
+  test('resets new requests while offline and recovers when back online', () => {
+    const flapper = createConnectionFlapper({onlineMs: 1000, offlineMs: 500})
+    const handler = vi.fn(() => new Subscription())
+    const wrapped = flapper.wrap(handler)
+
+    vi.advanceTimersByTime(1000)
+    expect(flapper.isOnline()).toBe(false)
+
+    const offlineRes = fakeResponse()
+    wrapped(req, offlineRes, target)
+    expect(offlineRes.destroyed).toBe(true)
+    expect(handler).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(500)
+    expect(flapper.isOnline()).toBe(true)
+
+    const onlineRes = fakeResponse()
+    wrapped(req, onlineRes, target)
+    expect(handler).toHaveBeenCalledOnce()
+    expect(onlineRes.destroyed).toBe(false)
+    flapper.stop()
+  })
+
+  test('tears down in-flight responses on the transition to offline', () => {
+    const flapper = createConnectionFlapper({onlineMs: 1000, offlineMs: 1000})
+    const wrapped = flapper.wrap(() => new Subscription())
+    const streaming = fakeResponse()
+    wrapped(req, streaming, target)
+
+    vi.advanceTimersByTime(1000)
+    expect(streaming.destroyed).toBe(true)
+    flapper.stop()
+  })
+
+  test('does not tear down responses that completed before going offline', () => {
+    const flapper = createConnectionFlapper({onlineMs: 1000, offlineMs: 1000})
+    const wrapped = flapper.wrap(() => new Subscription())
+    const res = fakeResponse()
+    wrapped(req, res, target)
+    res.emit('close')
+
+    const destroy = vi.spyOn(res, 'destroy')
+    vi.advanceTimersByTime(1000)
+    expect(destroy).not.toHaveBeenCalled()
+    flapper.stop()
+  })
+
+  test('reports every transition and keeps cycling', () => {
+    const onTransition = vi.fn()
+    const flapper = createConnectionFlapper({onlineMs: 1000, offlineMs: 500, onTransition})
+
+    vi.advanceTimersByTime(1000)
+    vi.advanceTimersByTime(500)
+    vi.advanceTimersByTime(1000)
+    expect(onTransition.mock.calls).toEqual([[false], [true], [false]])
+    flapper.stop()
+  })
+
+  test('stop() freezes the current state', () => {
+    const flapper = createConnectionFlapper({onlineMs: 1000, offlineMs: 1000})
+    flapper.stop()
+    vi.advanceTimersByTime(10_000)
+    expect(flapper.isOnline()).toBe(true)
+  })
+})

--- a/packages/@repo/debug-proxy/src/connectivity.ts
+++ b/packages/@repo/debug-proxy/src/connectivity.ts
@@ -1,0 +1,73 @@
+import {Subscription} from 'rxjs'
+
+import {type ProxyHandler} from './createDebugProxy'
+import {type ProxyResponse} from './proxy'
+
+export interface ConnectionFlapperOptions {
+  /** How long the simulated network stays up, in milliseconds. */
+  onlineMs: number
+  /** How long it stays down, in milliseconds. */
+  offlineMs: number
+  /** Called on every transition with the new state. */
+  onTransition?: ((online: boolean) => void) | undefined
+}
+
+export interface ConnectionFlapper {
+  /** Whether the simulated network is currently up. */
+  isOnline: () => boolean
+  /** Wrap a handler so its requests are subject to the connectivity cycle. */
+  wrap: (handler: ProxyHandler) => ProxyHandler
+  /** Stop cycling; the current state (online or offline) becomes permanent. */
+  stop: () => void
+}
+
+/**
+ * Simulates flapping connectivity (online → offline → online → …) by cycling
+ * between two states on a timer. While online, wrapped handlers proxy
+ * normally. On the transition to offline every in-flight response — including
+ * live SSE streams — is torn down, and while offline new requests are reset
+ * at the socket/stream level, so clients observe the same failure signature
+ * as a dead network (`TypeError: Failed to fetch`, `ERR_CONNECTION_RESET`)
+ * rather than a clean HTTP error response.
+ *
+ * One flapper can wrap any number of handlers; they all share the same cycle,
+ * the way every request shares the one network cable being pulled.
+ */
+export function createConnectionFlapper(options: ConnectionFlapperOptions): ConnectionFlapper {
+  const {onlineMs, offlineMs, onTransition} = options
+  let online = true
+  let timer: ReturnType<typeof setTimeout>
+  const live = new Set<ProxyResponse>()
+
+  const schedule = () => {
+    timer = setTimeout(
+      () => {
+        online = !online
+        if (!online) {
+          for (const res of live) {
+            res.destroy()
+          }
+          live.clear()
+        }
+        onTransition?.(online)
+        schedule()
+      },
+      online ? onlineMs : offlineMs,
+    )
+  }
+  schedule()
+
+  return {
+    isOnline: () => online,
+    wrap: (handler) => (req, res, target) => {
+      if (!online) {
+        res.destroy()
+        return new Subscription()
+      }
+      live.add(res)
+      res.on('close', () => live.delete(res))
+      return handler(req, res, target)
+    },
+    stop: () => clearTimeout(timer),
+  }
+}

--- a/packages/@repo/debug-proxy/src/index.ts
+++ b/packages/@repo/debug-proxy/src/index.ts
@@ -1,4 +1,10 @@
 export {
+  type ConnectionFlapper,
+  type ConnectionFlapperOptions,
+  createConnectionFlapper,
+} from './connectivity'
+export {type LatencyOptions, withLatency} from './latency'
+export {
   createDebugProxy,
   type DebugProxyConfig,
   type DebugProxyServer,

--- a/packages/@repo/debug-proxy/src/latency.test.ts
+++ b/packages/@repo/debug-proxy/src/latency.test.ts
@@ -1,0 +1,67 @@
+import {Subscription} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {withLatency} from './latency'
+import {type ProxyRequest, type ProxyResponse, type ProxyTarget} from './proxy'
+
+const req = {} as ProxyRequest
+const target = {} as ProxyTarget
+
+function fakeResponse(): ProxyResponse {
+  return {destroyed: false} as ProxyResponse
+}
+
+describe('withLatency', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  test('holds the request for the configured delay before forwarding', () => {
+    const handler = vi.fn(() => new Subscription())
+    const wrapped = withLatency(handler, {minMs: 500, maxMs: 500})
+    const res = fakeResponse()
+
+    wrapped(req, res, target)
+    expect(handler).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(499)
+    expect(handler).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(handler).toHaveBeenCalledWith(req, res, target)
+  })
+
+  test('forwards within the jitter range', () => {
+    const handler = vi.fn(() => new Subscription())
+    const wrapped = withLatency(handler, {minMs: 100, maxMs: 300})
+
+    wrapped(req, fakeResponse(), target)
+    vi.advanceTimersByTime(99)
+    expect(handler).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(201)
+    expect(handler).toHaveBeenCalledOnce()
+  })
+
+  test('skips forwarding when the client disconnects during the delay', () => {
+    const handler = vi.fn(() => new Subscription())
+    const wrapped = withLatency(handler, {minMs: 500, maxMs: 500})
+    const res = fakeResponse()
+
+    wrapped(req, res, target)
+    ;(res as {destroyed: boolean}).destroyed = true
+
+    vi.advanceTimersByTime(500)
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  test('unsubscribing cancels a pending forward', () => {
+    const handler = vi.fn(() => new Subscription())
+    const wrapped = withLatency(handler, {minMs: 500, maxMs: 500})
+
+    const subscription = wrapped(req, fakeResponse(), target)
+    subscription.unsubscribe()
+
+    vi.advanceTimersByTime(500)
+    expect(handler).not.toHaveBeenCalled()
+  })
+})

--- a/packages/@repo/debug-proxy/src/latency.ts
+++ b/packages/@repo/debug-proxy/src/latency.ts
@@ -1,0 +1,31 @@
+import {Subscription} from 'rxjs'
+
+import {type ProxyHandler} from './createDebugProxy'
+
+export interface LatencyOptions {
+  /** Minimum delay per request, in milliseconds. */
+  minMs: number
+  /** Maximum delay per request, in milliseconds. Equal to minMs = fixed delay. */
+  maxMs: number
+}
+
+/**
+ * Wrap a handler so each request is held back by a random delay in
+ * [minMs, maxMs] before being forwarded upstream — simulating a slow network
+ * at the request level (time to first byte). For per-event latency on a live
+ * SSE stream, see `randomLatency` in the scenarios module.
+ */
+export function withLatency(handler: ProxyHandler, {minMs, maxMs}: LatencyOptions): ProxyHandler {
+  return (req, res, target) => {
+    const subscription = new Subscription()
+    const delay = Math.round(minMs + Math.random() * (maxMs - minMs))
+    const timeout = setTimeout(() => {
+      // The client may have given up while we were sitting on the request
+      if (!res.destroyed) {
+        subscription.add(handler(req, res, target))
+      }
+    }, delay)
+    subscription.add(() => clearTimeout(timeout))
+    return subscription
+  }
+}


### PR DESCRIPTION
### Description

Adds `--flap` and `--latency` flags to our `@repo/debug-proxy` for simulating flaky connectivity and slow responses.

#### Example
This will repeatedly simulate connection up for 20s, then disconnected for 5s

```sh
pn dev:proxy --flap 20:5
```

### What to review


### Testing
yep

### Notes for release
n/a – internal dev tooling