### PR TITLE
fix(CLDX-5683): preserve an explicit empty block decorator set

### DIFF
--- a/packages/@sanity/schema/src/descriptors/convert.ts
+++ b/packages/@sanity/schema/src/descriptors/convert.ts
@@ -357,6 +357,11 @@ function convertTypeDef(schemaType: SchemaType, path: string, opts: Options): Ty
  * They're encoded with the same `convertUnknown` walker used for style/list options,
  * so the decorator shape (incl. `i18nTitleKey`, and `icon` as a function/jsx marker)
  * matches how the descriptor serializes every other option list.
+ *
+ * An explicit empty set (`marks.decorators: []`, which disables all decorators) is
+ * preserved as `[]` — it's distinct from a block with no decorators declared, which
+ * compiles to the default set. Collapsing it to `undefined` would make the consumer
+ * fall back to the defaults, silently re-enabling decorators the schema disabled.
  */
 function maybeBlockMarks(schemaType: SchemaType): BlockMarks | undefined {
   if (schemaType.jsonType !== 'object' || !isType(schemaType, 'block')) {
@@ -368,7 +373,7 @@ function maybeBlockMarks(schemaType: SchemaType): BlockMarks | undefined {
   )
   const childrenOf = (childrenField?.type as ArraySchemaType | undefined)?.of
   const spanType = childrenOf?.find((memberType) => memberType.name === 'span')
-  if (!spanType || !isSpanSchemaType(spanType) || spanType.decorators.length === 0) {
+  if (!spanType || !isSpanSchemaType(spanType)) {
     return undefined
   }
 

--- a/packages/sanity/test/descriptors/schema.test.tsx
+++ b/packages/sanity/test/descriptors/schema.test.tsx
@@ -2627,6 +2627,22 @@ describe('Block', () => {
       decorators: [{value: 'weak', title: 'Weak'}],
     })
   })
+
+  test('explicit empty decorator set is preserved', async () => {
+    // `marks.decorators: []` disables all decorators and compiles to an empty span
+    // decorator set — distinct from a block with no decorators declared (which gets
+    // the defaults). The descriptor must carry `[]` so a consumer doesn't fall back
+    // to the default set and silently re-enable them.
+    // (justConvertType: the manifest extractor drops empty title/value arrays, so the
+    // manifest round-trip check doesn't apply to this descriptor-only behavior.)
+    const type = await justConvertType({
+      name: 'paragraph',
+      type: 'block',
+      marks: {decorators: []},
+    })
+
+    expect(type.typeDef.marks).toEqual({decorators: []})
+  })
 })
 
 describe('Type-specific options', () => {


### PR DESCRIPTION
### Description

Follow-up to [CLDX-5683](https://linear.app/sanity/issue/CLDX-5683/schema-descriptor-drops-portable-text-block-decorators-manifest-keeps) / #13288 — fixes an edge case found in review after merge.

A portable-text block can disable **all** decorators with `marks: {decorators: []}`. That empty array is valid and is preserved through compilation (`span.decorators === []`), and it's semantically distinct from a block that declares no decorators (which compiles to the default set of 5).

`maybeBlockMarks` collapsed the empty array to `undefined` (`spanType.decorators.length === 0` → return), so the descriptor dropped `marks` entirely. A consumer then sees no decorator info and falls back to the **default** set — silently re-enabling the decorators the schema deliberately disabled.

This emits `marks.decorators: []` for the explicit-empty case, keeping it distinct from the default set. Non-empty and default blocks are unaffected.

### What to review

- `maybeBlockMarks` in `convert.ts`: dropping the `length === 0` early-return. `convertUnknown([])` returns `[]`, so an empty set now serializes as `marks.decorators: []`; non-blocks still return `undefined` via the `isSpanSchemaType` guard.
- The new test uses `justConvertType` rather than `convertType` on purpose: the manifest extractor also drops empty title/value arrays (a separate, pre-existing behavior), so the manifest↔descriptor round-trip assertion doesn't apply to this descriptor-only fix.

### Testing

Covered by a new unit test asserting a block with `marks: {decorators: []}` serializes to `marks.decorators: []`. Full descriptor suite passes (149); typecheck/lint/format clean. No user-facing browser flow — the effect surfaces in descriptor consumers once they read the corrected wire shape.

### Notes for release

N/A
