### PR TITLE
fix(core): skip studio manifest upload without deployStudio grant

### DIFF
--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -25,6 +25,7 @@ import {type AuthStore, createAuthStore, isAuthStore} from '../store'
 import {validateWorkspaces} from '../studio'
 import {filterDefinitions} from '../studio/components/navbar/search/definitions/defaultFilters'
 import {operatorDefinitions} from '../studio/components/navbar/search/definitions/operators/defaultOperators'
+import {fetchCanDeployStudio} from '../studio/manifest/canDeployStudio'
 import {uploadSchema} from '../studio/manifest/uploadSchema'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../studioClient'
 import {type InitialValueTemplateItem, type Template, type TemplateItem} from '../templates'
@@ -669,6 +670,25 @@ function resolveSource({
 
   const variantsEnabled = variantsEnabledReducer({config, initialValue: false})
 
+  // Upload the schema descriptor to Content Lake, but only when the user is
+  // authenticated and actually holds the `deployStudio` grant. Checking the
+  // grant first avoids firing a POST that would 403 for users without it.
+  const schemaDescriptorId: Promise<string | undefined> = authenticated
+    ? (async () => {
+        const studioClient = getClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+        if (!(await fetchCanDeployStudio(studioClient))) {
+          debug('Skipping schema upload: user lacks the deployStudio grant')
+          return undefined
+        }
+        return uploadSchema(schema, studioClient)
+      })().catch((err) => {
+        // Resolve to `undefined` (rather than rejecting) so consumers awaiting
+        // `schemaDescriptorId` don't have to handle a rejection.
+        debug('Uploading schema failed', {err})
+        return undefined
+      })
+    : Promise.resolve(undefined)
+
   const source: Source = {
     type: 'source',
     name: config.name,
@@ -837,12 +857,7 @@ function resolveSource({
       i18next: i18n.i18next,
       staticInitialValueTemplateItems,
       options: config,
-      schemaDescriptorId: authenticated
-        ? catchTap(uploadSchema(schema, getClient(DEFAULT_STUDIO_CLIENT_OPTIONS)), (err) => {
-            debug('Uploading schema failed', {err})
-            return undefined
-          })
-        : Promise.resolve(undefined),
+      schemaDescriptorId,
     },
     onUncaughtError: (error: Error, errorInfo: ErrorInfo) => {
       return onUncaughtErrorResolver({
@@ -956,13 +971,4 @@ function joinBasePath(rootPath: string, basePath?: string) {
     .join('/')
 
   return `/${joined}`
-}
-
-/**
- * Registers a catch to a promise (to prevent it from being caught by the
- * "unhandled promise" handler) while returning the original promise.
- */
-function catchTap<T>(promise: Promise<T>, cb: (reason: unknown) => void): Promise<T> {
-  promise.catch(cb)
-  return promise
 }

--- a/packages/sanity/src/core/store/project/projectStore.ts
+++ b/packages/sanity/src/core/store/project/projectStore.ts
@@ -67,6 +67,29 @@ const getOrganizationData = memoize(
   (client) => `${client.config().projectId}-${client.config().dataset}`,
 )
 
+/**
+ * Fetches the project grants for the current user, shared and replayed so all
+ * permission checks reuse a single request. Memoized so callers outside the
+ * project store (e.g. the schema/manifest upload gate) hit the same cached
+ * observable instead of issuing a duplicate `/grants` request.
+ *
+ * Keyed by `projectId-dataset`, matching the other memoized requests in this
+ * module, so a client for a different project/dataset never reuses another's
+ * grants.
+ *
+ * @internal
+ */
+export const getProjectGrants = memoize(
+  (client: SanityClient): Observable<ProjectGrants> =>
+    client.observable
+      .request<ProjectGrants>({
+        url: `/projects/${client.config().projectId}/grants`,
+        tag: 'get-grants',
+      })
+      .pipe(shareReplay(1)),
+  (client) => `${client.config().projectId}-${client.config().dataset}`,
+)
+
 /** @internal */
 export function createProjectStore(context: {client: SanityClient}): ProjectStore {
   const {client} = context
@@ -87,20 +110,12 @@ export function createProjectStore(context: {client: SanityClient}): ProjectStor
     })
   }
 
-  // Share and replay the grants result so permission checks reuse the same response.
-  const grants$ = versionedClient.observable
-    .request<ProjectGrants>({
-      url: `/projects/${projectId}/grants`,
-      tag: 'get-grants',
-    })
-    .pipe(shareReplay(1))
-
   const projectOrgData$ = getProjectOrg(versionedClient)
 
   return {
     get,
     getDatasets,
-    getGrants: () => grants$,
+    getGrants: () => getProjectGrants(versionedClient),
     getOrganizationData: () => projectOrgData$.pipe(map((res) => res?.organization ?? null)),
     getOrganizationId: () => projectOrgData$.pipe(map((res) => res?.organizationId ?? null)),
   }

--- a/packages/sanity/src/core/studio/components/navbar/resources/useCanDeployStudio.ts
+++ b/packages/sanity/src/core/studio/components/navbar/resources/useCanDeployStudio.ts
@@ -2,24 +2,17 @@ import {useObservable} from 'react-rx'
 import {map, of} from 'rxjs'
 
 import {useProjectStore} from '../../../../store/datastores'
-
-const DEPLOY_STUDIO_PERMISSION = 'sanity.project'
-const DEPLOY_STUDIO_GRANT = 'deployStudio'
+import {hasDeployStudioGrant} from '../../../manifest/canDeployStudio'
 
 /**
- * A hook that returns whether the current user can invite members to the project.
+ * A hook that returns whether the current user can deploy the studio.
  *
  * @internal
  */
 export function useCanDeployStudio(enabled: boolean = true): boolean {
   const projectStore = useProjectStore()
 
-  const result$ = projectStore.getGrants().pipe(
-    map((grants) => {
-      const permission = grants[DEPLOY_STUDIO_PERMISSION]
-      return !!permission?.some((p) => p.grants.some((g) => g.name === DEPLOY_STUDIO_GRANT))
-    }),
-  )
+  const result$ = projectStore.getGrants().pipe(map(hasDeployStudioGrant))
 
   // If the hook is disabled, don't subscribe to the observable
   const canDeploy$ = enabled ? result$ : of(false)

--- a/packages/sanity/src/core/studio/manifest/__tests__/canDeployStudio.test.ts
+++ b/packages/sanity/src/core/studio/manifest/__tests__/canDeployStudio.test.ts
@@ -1,0 +1,73 @@
+import {type SanityClient} from '@sanity/client'
+import {of, throwError} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getProjectGrants} from '../../../store/project/projectStore'
+import {type ProjectGrants} from '../../../store/project/types'
+import {fetchCanDeployStudio, hasDeployStudioGrant} from '../canDeployStudio'
+
+vi.mock('../../../store/project/projectStore', () => ({
+  getProjectGrants: vi.fn(),
+}))
+
+function grantsWith(grantNames: string[]): ProjectGrants {
+  return {
+    'sanity.project': [
+      {
+        id: 'role',
+        name: 'role',
+        title: 'Role',
+        description: null,
+        isCustom: false,
+        config: {},
+        grants: grantNames.map((name) => ({name, params: {}})),
+      },
+    ],
+  }
+}
+
+describe('hasDeployStudioGrant', () => {
+  it('returns true when the deployStudio grant is present', () => {
+    expect(hasDeployStudioGrant(grantsWith(['deployStudio']))).toBe(true)
+  })
+
+  it('returns false when the deployStudio grant is absent', () => {
+    expect(hasDeployStudioGrant(grantsWith(['read']))).toBe(false)
+  })
+
+  it('returns false when there are no sanity.project grants', () => {
+    expect(hasDeployStudioGrant({})).toBe(false)
+  })
+})
+
+function createMockClient(projectId: string | undefined) {
+  return {
+    config: () => ({projectId}),
+  } as unknown as SanityClient
+}
+
+describe('fetchCanDeployStudio', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('resolves true when the user has the deployStudio grant', async () => {
+    vi.mocked(getProjectGrants).mockReturnValue(of(grantsWith(['deployStudio'])))
+    await expect(fetchCanDeployStudio(createMockClient('proj1'))).resolves.toBe(true)
+  })
+
+  it('resolves false when the user lacks the deployStudio grant', async () => {
+    vi.mocked(getProjectGrants).mockReturnValue(of(grantsWith(['read'])))
+    await expect(fetchCanDeployStudio(createMockClient('proj1'))).resolves.toBe(false)
+  })
+
+  it('resolves false (without fetching grants) when there is no projectId', async () => {
+    await expect(fetchCanDeployStudio(createMockClient(undefined))).resolves.toBe(false)
+    expect(getProjectGrants).not.toHaveBeenCalled()
+  })
+
+  it('resolves false when the grants observable errors', async () => {
+    vi.mocked(getProjectGrants).mockReturnValue(throwError(() => new Error('403')))
+    await expect(fetchCanDeployStudio(createMockClient('proj1'))).resolves.toBe(false)
+  })
+})

--- a/packages/sanity/src/core/studio/manifest/__tests__/registerLiveStudioManifest.test.tsx
+++ b/packages/sanity/src/core/studio/manifest/__tests__/registerLiveStudioManifest.test.tsx
@@ -5,11 +5,18 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {type Source, type WorkspaceSummary} from '../../../config/types'
 import {type AuthStore} from '../../../store'
 import {type UserApplication} from '../../../store/userApplications'
+import {fetchCanDeployStudio} from '../canDeployStudio'
 import {registerStudioManifest} from '../registerLiveStudioManifest'
 
 // Mock the icon module to avoid styled-components complexity in tests
 vi.mock('../icon', () => ({
   resolveIcon: vi.fn(() => '<svg>mock-icon</svg>'),
+}))
+
+// Gate the manifest POST on the deployStudio grant; default to granted so the
+// existing registration tests exercise the POST path.
+vi.mock('../canDeployStudio', () => ({
+  fetchCanDeployStudio: vi.fn(() => Promise.resolve(true)),
 }))
 
 const mockTheme: RootTheme = buildTheme()
@@ -229,6 +236,15 @@ describe('registerStudioManifest', () => {
 
     it('should skip registration when workspaces array is empty', async () => {
       await registerStudioManifest(mockUserApplication, [], mockTheme)
+
+      expect(mockRequest).not.toHaveBeenCalled()
+    })
+
+    it('should skip the POST when the user lacks the deployStudio grant', async () => {
+      vi.mocked(fetchCanDeployStudio).mockResolvedValueOnce(false)
+      const workspace = createMockWorkspace()
+
+      await registerStudioManifest(mockUserApplication, [workspace], mockTheme)
 
       expect(mockRequest).not.toHaveBeenCalled()
     })

--- a/packages/sanity/src/core/studio/manifest/canDeployStudio.ts
+++ b/packages/sanity/src/core/studio/manifest/canDeployStudio.ts
@@ -1,0 +1,41 @@
+import {type SanityClient} from '@sanity/client'
+import {catchError, firstValueFrom, of} from 'rxjs'
+
+import {getProjectGrants} from '../../store/project/projectStore'
+import {type ProjectGrants} from '../../store/project/types'
+
+const DEPLOY_STUDIO_PERMISSION = 'sanity.project'
+const DEPLOY_STUDIO_GRANT = 'deployStudio'
+
+/**
+ * Returns whether the given project grants include the `deployStudio` grant.
+ *
+ * Writing the schema descriptor and live studio manifest to Content Lake both
+ * require this grant, so it's used to gate those uploads and avoid wasteful
+ * 403 Forbidden requests for users who lack the permission.
+ *
+ * @internal
+ */
+export function hasDeployStudioGrant(grants: ProjectGrants | null | undefined): boolean {
+  const permission = grants?.[DEPLOY_STUDIO_PERMISSION]
+  return !!permission?.some((p) => p.grants.some((g) => g.name === DEPLOY_STUDIO_GRANT))
+}
+
+/**
+ * Resolves whether the current user is allowed to deploy the studio (i.e. write
+ * the schema descriptor and manifest), based on the project grants.
+ *
+ * Reuses the shared, memoized project grants observable, so this does not issue
+ * a duplicate `/grants` request when the studio also reads grants elsewhere
+ * (e.g. the navbar). Resolves to `false` if grants can't be fetched, so a
+ * transient error never triggers an upload that would 403.
+ *
+ * @internal
+ */
+export function fetchCanDeployStudio(client: SanityClient): Promise<boolean> {
+  if (!client.config().projectId) return Promise.resolve(false)
+
+  return firstValueFrom(
+    getProjectGrants(client).pipe(catchError(() => of<ProjectGrants>({}))),
+  ).then(hasDeployStudioGrant)
+}

--- a/packages/sanity/src/core/studio/manifest/registerLiveStudioManifest.tsx
+++ b/packages/sanity/src/core/studio/manifest/registerLiveStudioManifest.tsx
@@ -5,6 +5,7 @@ import {type Source, type WorkspaceSummary} from '../../config/types'
 import {type UserApplication} from '../../store/userApplications'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
 import {SANITY_VERSION} from '../../version'
+import {fetchCanDeployStudio} from './canDeployStudio'
 import {generateStudioManifest} from './generateStudioManifest'
 import {resolveIcon} from './icon'
 
@@ -83,13 +84,22 @@ export async function registerStudioManifest(
     return // if the user isn't authenticated, nothing to do
   }
 
+  // Skip the POST when the user lacks the `deployStudio` grant, to avoid a 403.
+  // The schema upload is gated on the same grant, so in practice the manifest
+  // is already empty in that case; this is an explicit guard so registration
+  // doesn't depend on that implicit coupling.
+  const studioClient = client.withConfig(DEFAULT_STUDIO_CLIENT_OPTIONS)
+  if (!(await fetchCanDeployStudio(studioClient))) {
+    return
+  }
+
   // Bail before posting if the registering effect has already been torn down.
   if (signal?.aborted) {
     return
   }
 
   // Post the live manifest via the global api
-  await client.withConfig(DEFAULT_STUDIO_CLIENT_OPTIONS).request({
+  await studioClient.request({
     method: 'POST',
     uri: `/projects/${projectId}/user-applications/${id}/config/live-manifest`,
     body: {

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -351,6 +351,7 @@ exports[`exports snapshot 1`] = `
     "getPreviewPaths": "function",
     "getPreviewStateObservable": "function",
     "getPreviewValueWithFallback": "function",
+    "getProjectGrants": "function",
     "getProviderTitle": "function",
     "getPublishedId": "function",
     "getReferencePaths": "function",


### PR DESCRIPTION
### Description
We always try to upload the studio manifest, even if the user doesn't have permissions to upload it, causing wasteful `403 Forbidden` post requests in many cases.

This PR gates schema descriptor and live manifest uploads on the deployStudio grant to avoid firing off these requests for users who lack the permission.

### What to review


### Testing
Tests included

### Notes for release
n/a