### PR TITLE
ci(pkg-pr-new): keep pnpm notices out of the package-list output

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -25,7 +25,10 @@ jobs:
       - id: pre-flight
         run: |
           PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
-          PACKAGES=$(pnpm tsx scripts/listPublishedPackages.ts)
+          # --silent keeps pnpm's own notices (e.g. the deprecated "$" overrides
+          # warning) off stdout, so $PACKAGES is the single package list line and
+          # the $GITHUB_OUTPUT write stays a valid key=value.
+          PACKAGES=$(pnpm --silent tsx scripts/listPublishedPackages.ts)
           echo "packages=${PACKAGES}" >> "$GITHUB_OUTPUT"
           VERSION="$(jq -r .version package.json)-pr.$PR_NUMBER+$(git rev-parse --short HEAD)"
           echo "process.env.PKG_VERSION will be set to ${VERSION} when building"


### PR DESCRIPTION
### Description

The `Publish Pull Requests with pkg.pr.new` workflow fails in its `pre-flight` step on any preview-labeled PR:

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format 'packages/@sanity/diff packages/@sanity/mutator ... packages/sanity'
```

**Cause:** the step captures the package list with

```bash
PACKAGES=$(pnpm tsx scripts/listPublishedPackages.ts)
echo "packages=${PACKAGES}" >> "$GITHUB_OUTPUT"
```

pnpm prints config notices to **stdout** — currently the `The "$" version reference syntax in overrides is deprecated (used by: @sanity/ui@3, vitest)` warning — so `$PACKAGES` ends up as two lines (warning + package list). The `$GITHUB_OUTPUT` write then emits a bare second line that isn't `key=value`, which the runner rejects.

**Fix:** run the script with `pnpm --silent` so only the script's own stdout (the package list) is captured. Verified locally that `--silent` reduces captured stdout to the single package-list line.

This is unrelated to any package code — it surfaced because [#13284](https://github.com/sanity-io/sanity/pull/13284) carries the `trigger: preview` label, which is what gates this job from running.

### What to review

- `.github/workflows/pkg-pr-new.yml` — the one-line change adding `--silent` to the `pnpm tsx scripts/listPublishedPackages.ts` invocation in the `pre-flight` step.

### Testing

Reproduced and verified locally:

```bash
# before: two lines captured (pnpm warning + package list) -> invalid $GITHUB_OUTPUT
$ pnpm tsx scripts/listPublishedPackages.ts 2>/dev/null | wc -l
2
# after: single package-list line
$ pnpm --silent tsx scripts/listPublishedPackages.ts 2>/dev/null | wc -l
1
```

CI exercises the full path on this PR (it should be labeled `trigger: preview` to run the publish job).

### Notes for release

N/A – CI/tooling only.