### PR TITLE
fix: prevent pnpm warnings polluting list packages output

### DIFF
--- a/.github/workflows/tag-stable.yml
+++ b/.github/workflows/tag-stable.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Update npm dist-tags to stable
         run: |
           # Get all published (non-private) packages in the workspace
-          packages=$(pnpm tsx scripts/listPublishedPackages.ts)
+          packages=$(pnpm --silent tsx scripts/listPublishedPackages.ts)
           version="${{ needs.get-version.outputs.version }}"
 
           echo "Using version: $version"


### PR DESCRIPTION
### Description

We use pnpm as a script runner. Its warnings are polluting the output we expect, even though the script runs successfully. As a quick fix, this branch runs pnpm silently.