### PR TITLE
feat(portable-text): resolve render-callback schema types via path-aware lookup

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -8,8 +8,14 @@ import {
   type OnPasteFn as EditorOnPasteFn,
   type PasteData as EditorPasteData,
   type RangeDecoration,
+  useEditor,
 } from '@portabletext/editor'
-import {type Path, type PortableTextBlock, type PortableTextTextBlock} from '@sanity/types'
+import {
+  isObjectSchemaType,
+  type Path,
+  type PortableTextBlock,
+  type PortableTextTextBlock,
+} from '@sanity/types'
 import {
   BoundaryElementProvider,
   Box,
@@ -21,6 +27,7 @@ import {
 import {type ReactNode, useCallback, useMemo, useState} from 'react'
 
 import {ChangeIndicator} from '../../../changeIndicators'
+import {resolveSchemaTypeForPath} from '../../../studio/copyPaste/resolveSchemaTypeForPath'
 import {EMPTY_ARRAY} from '../../../util'
 import {ActivateOnFocus} from '../../components/ActivateOnFocus/ActivateOnFocus'
 import {type ArrayOfObjectsInputProps, type RenderCustomMarkers} from '../../types'
@@ -98,6 +105,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
   } = props
 
   const schemaTypes = usePortableTextMemberSchemaTypes()
+  const editor = useEditor()
   const setElementRef = useSetPortableTextMemberItemElementRef()
 
   // Wrap the consumer's onPaste to enrich PasteData.schemaTypes with
@@ -147,6 +155,15 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     (blockProps: EditorBlockRenderProps) => {
       const {children, focused: blockFocused, path: blockPath, selected, value: block} = blockProps
       const fullyQualifiedPath = path.concat(blockPath)
+      const sanitySchemaType = resolveSchemaTypeForPath(
+        schemaTypes.portableText,
+        blockPath,
+        editor.getSnapshot().context.value,
+      )
+      if (!sanitySchemaType || !isObjectSchemaType(sanitySchemaType)) {
+        // This should never happen
+        throw new Error(`Could not find Sanity schema type for text block: ${block._type}`)
+      }
 
       return (
         <TextBlock
@@ -169,7 +186,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
           renderCustomMarkers={_renderCustomMarkers}
           renderPreview={renderPreview}
           renderBlock={renderBlock}
-          schemaType={schemaTypes.block}
+          schemaType={sanitySchemaType}
           selected={selected}
           setElementRef={setElementRef}
           value={block as PortableTextTextBlock}
@@ -180,6 +197,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       )
     },
     [
+      editor,
       _renderBlockActions,
       _renderCustomMarkers,
       floatingBoundary,
@@ -197,7 +215,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       renderInput,
       renderItem,
       renderPreview,
-      schemaTypes.block,
+      schemaTypes.portableText,
       scrollElement,
       setElementRef,
     ],
@@ -212,10 +230,12 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
         schemaType: blockSchemaType,
         value: blockValue,
       } = blockProps
-      const sanitySchemaType = schemaTypes.blockObjects.find(
-        (type) => type.name === blockSchemaType.name,
+      const sanitySchemaType = resolveSchemaTypeForPath(
+        schemaTypes.portableText,
+        blockPath,
+        editor.getSnapshot().context.value,
       )
-      if (!sanitySchemaType) {
+      if (!sanitySchemaType || !isObjectSchemaType(sanitySchemaType)) {
         // This should never happen
         throw new Error(
           `Could not find Sanity schema type for block object: ${blockSchemaType.name}`,
@@ -251,9 +271,10 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       )
     },
     [
+      editor,
       floatingBoundary,
       scrollElement,
-      schemaTypes.blockObjects,
+      schemaTypes.portableText,
       isFullscreen,
       onItemClose,
       onItemOpen,
@@ -302,10 +323,12 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       if (isSpan) {
         return children
       }
-      const sanitySchemaType = schemaTypes.inlineObjects.find(
-        (type) => type.name === childSchemaType.name,
+      const sanitySchemaType = resolveSchemaTypeForPath(
+        schemaTypes.portableText,
+        childPath,
+        editor.getSnapshot().context.value,
       )
-      if (!sanitySchemaType) {
+      if (!sanitySchemaType || !isObjectSchemaType(sanitySchemaType)) {
         // This should never happen
         throw new Error(
           `Could not find Sanity schema type for inline object: ${childSchemaType.name}`,
@@ -338,8 +361,9 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       )
     },
     [
+      editor,
       schemaTypes.span.name,
-      schemaTypes.inlineObjects,
+      schemaTypes.portableText,
       floatingBoundary,
       onItemClose,
       onItemOpen,
@@ -369,10 +393,17 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
         schemaType: aSchemaType,
         value: aValue,
       } = annotationProps
-      const sanitySchemaType = schemaTypes.annotations.find(
-        (type) => type.name === aSchemaType.name,
+      // `aPath` points at the span where the annotation is applied
+      // (`[...blockPath, 'children', {_key: spanKey}]`); resolving the
+      // annotation type means walking to the block's `markDefs` entry,
+      // not the span itself.
+      const annotationPath = [...aPath.slice(0, -2), 'markDefs', {_key: aValue._key}]
+      const sanitySchemaType = resolveSchemaTypeForPath(
+        schemaTypes.portableText,
+        annotationPath,
+        editor.getSnapshot().context.value,
       )
-      if (!sanitySchemaType) {
+      if (!sanitySchemaType || !isObjectSchemaType(sanitySchemaType)) {
         // This should never happen
         throw new Error(`Could not find Sanity schema type for annotation: ${aSchemaType.name}`)
       }
@@ -405,7 +436,8 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       )
     },
     [
-      schemaTypes.annotations,
+      editor,
+      schemaTypes.portableText,
       floatingBoundary,
       scrollElement,
       focused,


### PR DESCRIPTION
### Description

Prepares the Portable Text input to handle schemas where a block type defines its own children or styles — e.g. a `code-block` whose `lines` allow a `codeAnnotation` only valid inside code-blocks, or a table cell whose `content` allows a `block` with cell-specific styles.

Today's render callbacks resolve Sanity schema types from flat top-level lists, so a `codeAnnotation` isn't in `schemaTypes.blockObjects` and the lookup crashes; a cell-specific block silently renders against the root block's schema.

Switch the four render callbacks — `renderTextBlock`, `renderObjectBlock`, `editorRenderChild`, `editorRenderAnnotation` — to `resolveSchemaTypeForPath` from `core/studio/copyPaste/`. It walks the schema along the node's path and returns the type at that location. Already used in copy-paste, breadcrumbs, document-list, structure pane.

For existing schemas the walk hits the same root member as the previous lookups. No user-visible change today.

### What to review

- We read `editor.getSnapshot().context.value` instead of Compositor's `value` prop — the prop lags the live editor state during active editing.
- `resolveSchemaTypeForPath` returns `SchemaType | undefined`; narrowed with `isObjectSchemaType` to preserve the throw-on-missing assertion.
- Annotation path is built from the block path (`aPath.slice(0, -2)`), depth-agnostic.
- Other `usePortableTextMemberSchemaTypes()` callsites are unchanged. Some are intentionally root-level (toolbar void-block check, editor-wide options like `oneLine`); a few are latent gaps for nested schemas (decorator/style/list lookups, annotation/inline parent type) that aren't addressed here.

### Notes for release

For schemas with nested block definitions, user `renderBlock` callbacks now receive the schema type valid at the rendered block's location — so `componentProps.schemaType.styles` reflects cell-specific styles inside a cell instead of root styles. Correct at depth, but worth a callout for consumers with a custom `renderBlock` shipping nested schemas.