### PR TITLE
fix(portable-text): resolve leaf-component schema types by path, not root lists

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/contexts/PortableTextMemberSchemaTypes.test.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/contexts/PortableTextMemberSchemaTypes.test.ts
@@ -1,0 +1,100 @@
+import {createPortableTextMemberSchemaTypes} from '@portabletext/sanity-bridge'
+import {
+  type ArraySchemaType,
+  defineArrayMember,
+  defineField,
+  defineType,
+  type PortableTextBlock,
+} from '@sanity/types'
+import {describe, expect, test} from 'vitest'
+
+import {createSchema} from '../../../../schema'
+import {resolveContainingArrayType} from './PortableTextMemberSchemaTypes'
+
+// The root `body` array allows the `normal` style only; the `callout` container's
+// `content` array allows `normal` plus a `code` style that exists nowhere at the
+// root. Resolving member types for a block must walk to its containing array, so
+// a container-nested block sees `code` and a root block does not.
+const schema = createSchema({
+  name: 'test',
+  types: [
+    defineType({
+      name: 'testDoc',
+      type: 'document',
+      fields: [
+        defineField({
+          name: 'body',
+          type: 'array',
+          of: [
+            defineArrayMember({type: 'block', styles: [{title: 'Normal', value: 'normal'}]}),
+            defineArrayMember({
+              type: 'object',
+              name: 'callout',
+              fields: [
+                defineField({
+                  name: 'content',
+                  type: 'array',
+                  of: [
+                    defineArrayMember({
+                      type: 'block',
+                      styles: [
+                        {title: 'Normal', value: 'normal'},
+                        {title: 'Code', value: 'code'},
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    }),
+  ],
+})
+
+const bodyType = schema.get('testDoc')!.fields!.find((field) => field.name === 'body')!
+  .type as ArraySchemaType
+
+const value = [
+  {
+    _type: 'block',
+    _key: 'b0',
+    style: 'normal',
+    children: [{_type: 'span', _key: 's0', text: 'root'}],
+  },
+  {
+    _type: 'callout',
+    _key: 'c0',
+    content: [
+      {
+        _type: 'block',
+        _key: 'cb0',
+        style: 'code',
+        children: [{_type: 'span', _key: 'cs0', text: 'nested'}],
+      },
+    ],
+  },
+]
+
+function stylesFor(arrayType: ArraySchemaType): Array<string> {
+  return createPortableTextMemberSchemaTypes(
+    arrayType as ArraySchemaType<PortableTextBlock>,
+  ).styles.map((style) => style.value)
+}
+
+describe('resolveContainingArrayType', () => {
+  test('a root block resolves the root array, with root styles only', () => {
+    const arrayType = resolveContainingArrayType(bodyType, [{_key: 'b0'}], value)
+    expect(stylesFor(arrayType)).toEqual(['normal'])
+  })
+
+  test('a container-nested block resolves the container array, with its own styles', () => {
+    const arrayType = resolveContainingArrayType(
+      bodyType,
+      [{_key: 'c0'}, 'content', {_key: 'cb0'}],
+      value,
+    )
+    expect(stylesFor(arrayType)).toEqual(['normal', 'code'])
+  })
+})

--- a/packages/sanity/src/core/form/inputs/PortableText/contexts/PortableTextMemberSchemaTypes.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/contexts/PortableTextMemberSchemaTypes.tsx
@@ -1,10 +1,18 @@
+import {useEditor} from '@portabletext/editor'
 import {
   createPortableTextMemberSchemaTypes,
   type PortableTextMemberSchemaTypes,
 } from '@portabletext/sanity-bridge'
-import {type ArraySchemaType, type PortableTextBlock} from '@sanity/types'
+import {
+  type ArraySchemaType,
+  isArraySchemaType,
+  type Path,
+  type PortableTextBlock,
+} from '@sanity/types'
 import {type ReactNode, use, useMemo} from 'react'
 import {PortableTextMemberSchemaTypesContext} from 'sanity/_singletons'
+
+import {resolveSchemaTypeForPath} from '../../../../studio/copyPaste/resolveSchemaTypeForPath'
 
 /**
  * Provider for Sanity-specific schema types for Portable Text.
@@ -44,4 +52,66 @@ export function usePortableTextMemberSchemaTypes(): PortableTextMemberSchemaType
     )
   }
   return context
+}
+
+// The processed member types are non-trivial to build, so cache them per
+// resolved array schema type. Array schema types are stable per compiled schema,
+// so a WeakMap reuses the result across every block and leaf rendered under the
+// same container, and never leaks across schema reloads.
+const memberTypesByArrayType = new WeakMap<ArraySchemaType, PortableTextMemberSchemaTypes>()
+
+function getMemberTypesForArrayType(arrayType: ArraySchemaType): PortableTextMemberSchemaTypes {
+  let memberTypes = memberTypesByArrayType.get(arrayType)
+  if (!memberTypes) {
+    memberTypes = createPortableTextMemberSchemaTypes(
+      arrayType as ArraySchemaType<PortableTextBlock>,
+    )
+    memberTypesByArrayType.set(arrayType, memberTypes)
+  }
+  return memberTypes
+}
+
+/**
+ * Resolves the Portable Text array schema type that contains the block at
+ * `blockPath`. Inside a container that is the container's array field; at the
+ * root (or when resolution fails) it is `rootArrayType`. The containing array
+ * sits one segment up from the block key.
+ *
+ * @internal
+ */
+export function resolveContainingArrayType(
+  rootArrayType: ArraySchemaType,
+  blockPath: Path,
+  value: unknown,
+): ArraySchemaType {
+  const arrayPath = blockPath.slice(0, -1)
+  if (arrayPath.length === 0) {
+    return rootArrayType
+  }
+  const arrayType = resolveSchemaTypeForPath(rootArrayType, arrayPath, value)
+  return arrayType && isArraySchemaType(arrayType) ? arrayType : rootArrayType
+}
+
+/**
+ * Resolves the `PortableTextMemberSchemaTypes` for the block at `blockPath` by
+ * walking to the block's containing array schema type. Inside a container the
+ * block's styles, decorators, lists, and child types come from the container's
+ * array, not the root Portable Text array; at the root it returns the same value
+ * as `usePortableTextMemberSchemaTypes`.
+ *
+ * @internal
+ */
+export function usePortableTextMemberSchemaTypesForBlockPath(
+  blockPath: Path,
+): PortableTextMemberSchemaTypes {
+  const rootMemberTypes = usePortableTextMemberSchemaTypes()
+  const editor = useEditor()
+  const arrayType = resolveContainingArrayType(
+    rootMemberTypes.portableText,
+    blockPath,
+    editor.getSnapshot().context.value,
+  )
+  return arrayType === rootMemberTypes.portableText
+    ? rootMemberTypes
+    : getMemberTypesForArrayType(arrayType)
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/text/Decorator.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/Decorator.tsx
@@ -4,7 +4,7 @@ import {useCallback, useMemo} from 'react'
 import {css, styled} from 'styled-components'
 
 import {type BlockDecoratorProps} from '../../../types'
-import {usePortableTextMemberSchemaTypes} from '../contexts/PortableTextMemberSchemaTypes'
+import {usePortableTextMemberSchemaTypesForBlockPath} from '../contexts/PortableTextMemberSchemaTypes'
 import {TEXT_DECORATOR_TAGS} from './constants'
 
 const Root = styled.span(({theme}: {theme: Theme}) => {
@@ -21,7 +21,9 @@ const Root = styled.span(({theme}: {theme: Theme}) => {
 
 export function Decorator(props: BlockDecoratorRenderProps) {
   const {value, focused, selected, children, schemaType} = props
-  const schemaTypes = usePortableTextMemberSchemaTypes()
+  // `props.path` points at the decorated span; the block (which defines the
+  // decorators) is two segments up (`[...blockPath, 'children', {_key}]`).
+  const schemaTypes = usePortableTextMemberSchemaTypesForBlockPath(props.path.slice(0, -2))
   const sanitySchemaType = schemaTypes.decorators.find((type) => type.value === schemaType.value)
   if (!sanitySchemaType) {
     // This should never happen

--- a/packages/sanity/src/core/form/inputs/PortableText/text/ListItem.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/ListItem.tsx
@@ -2,7 +2,7 @@ import {type BlockListItemRenderProps} from '@portabletext/editor'
 import {useMemo} from 'react'
 
 import {type BlockListItemProps} from '../../../types'
-import {usePortableTextMemberSchemaTypes} from '../contexts/PortableTextMemberSchemaTypes'
+import {usePortableTextMemberSchemaTypesForBlockPath} from '../contexts/PortableTextMemberSchemaTypes'
 
 const DefaultComponent = (dProps: BlockListItemProps) => {
   return <>{dProps.children}</>
@@ -10,7 +10,7 @@ const DefaultComponent = (dProps: BlockListItemProps) => {
 
 export const ListItem = (props: BlockListItemRenderProps) => {
   const {block, children, schemaType, selected, focused, level, value} = props
-  const schemaTypes = usePortableTextMemberSchemaTypes()
+  const schemaTypes = usePortableTextMemberSchemaTypesForBlockPath(props.path)
   const sanitySchemaType = schemaTypes.lists.find((type) => type.value === schemaType.value)
   if (!sanitySchemaType) {
     // This should never happen

--- a/packages/sanity/src/core/form/inputs/PortableText/text/Style.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/Style.tsx
@@ -2,12 +2,12 @@ import {type BlockStyleRenderProps} from '@portabletext/editor'
 import {useCallback, useMemo} from 'react'
 
 import {type BlockStyleProps} from '../../../types'
-import {usePortableTextMemberSchemaTypes} from '../contexts/PortableTextMemberSchemaTypes'
+import {usePortableTextMemberSchemaTypesForBlockPath} from '../contexts/PortableTextMemberSchemaTypes'
 import {Normal as FallbackComponent, TEXT_STYLES, TextContainer} from './textStyles'
 
 export const Style = (props: BlockStyleRenderProps) => {
   const {block, focused, children, selected, schemaType} = props
-  const schemaTypes = usePortableTextMemberSchemaTypes()
+  const schemaTypes = usePortableTextMemberSchemaTypesForBlockPath(props.path)
   const sanitySchemaType = schemaTypes.styles.find((type) => type.value === schemaType.value)
   if (!sanitySchemaType) {
     // This should never happen


### PR DESCRIPTION
### Description

`Style`, `Decorator`, and `ListItem` resolved their Sanity schema type by matching `schemaType.value` against the root-level `schemaTypes.styles`/`decorators`/`lists` from `usePortableTextMemberSchemaTypes()`, then threw if not found ("This should never happen"). A container-nested block with a cell-specific style/decorator/list is absent from those root lists, so rendering it threw and crashed the input.

This is the leaf-component half of #13300, which made the render *callbacks* path-aware. These three components still read root, so the render path is only half depth-correct without them.

The fix keeps the single root `PortableTextMemberSchemaTypesProvider` and adds one path-aware resolver, `usePortableTextMemberSchemaTypesForBlockPath(blockPath)`: it walks to the block's containing array schema type (via `resolveSchemaTypeForPath`, the same helper #13300 uses) and returns that array's processed member types, cached per array type with a `WeakMap`. The three components call it with their block path; the decorator derives the block path from its span path (`path.slice(0, -2)`, matching #13300's annotation handling). No nested providers.

Closes EDEX-1399.

### What to review

- The resolver lives in `contexts/PortableTextMemberSchemaTypes.tsx`. `resolveContainingArrayType` is the pure, unit-tested core; the hook is a thin wrapper that reads `editor.getSnapshot().context.value` for the union walk (non-reactive, as in #13300's Compositor).
- The cache is a module-level `WeakMap<ArraySchemaType, ...>`. Array schema types are stable per compiled schema, so it reuses `createPortableTextMemberSchemaTypes` across every block/leaf under the same container and never leaks across reloads.
- The decorator's `path.slice(0, -2)` (span path -> block path) is the one path-shape assumption.

### Testing

- Unit: `resolveContainingArrayType` (root block -> root styles; container-nested block -> the container's styles, including a `code` style that exists nowhere at the root).
- Behavior-neutral for flat schemas: the existing PT browser suite (Styles, Decorators, and the full `__tests__` set) passes unchanged on chromium.

### Notes for release

Portable Text blocks nested in a container (e.g. a table cell) that define their own styles, decorators, or list types no longer crash the editor; they resolve and render against the container's schema instead of the root array's.
