### PR TITLE
fix: enable react compiler on `<Resizer>` component

### DIFF
--- a/e2e/studio-test.ts
+++ b/e2e/studio-test.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable react-hooks/rules-of-hooks */
 // oxlint-disable-next-line no-restricted-imports
 import {test as baseTest} from '@playwright/test'
 import {createClient, type SanityClient, type SanityDocument} from '@sanity/client'
@@ -68,7 +67,7 @@ interface SanityFixtures {
 export const test = baseTest.extend<SanityFixtures>({
   // Extends the goto function to preserve the base pathname if it exists in the baseURL
   // This is used to ensure the navigation goes to the correct workspace.
-  async page({page, context, baseURL}, use) {
+  async page({page, context, baseURL}, _use) {
     watchForStudioErrors(context)
 
     const originalGoto = page.goto.bind(page)
@@ -102,9 +101,9 @@ export const test = baseTest.extend<SanityFixtures>({
       route.fulfill({status: 200, contentType: 'application/json', body: 'null'}),
     )
 
-    await use(page)
+    await _use(page)
   },
-  async createDraftDocument({page, _testContext}, use) {
+  async createDraftDocument({page, _testContext}, _use) {
     async function createDraftDocument(navigationPath: string) {
       const id = _testContext.getUniqueDocumentId()
 
@@ -118,20 +117,20 @@ export const test = baseTest.extend<SanityFixtures>({
       return id
     }
 
-    await use(createDraftDocument)
+    await _use(createDraftDocument)
   },
 
-  async _testContext({sanityClient}, use) {
+  async _testContext({sanityClient}, _use) {
     const _testContext = new _TestSanityContext()
 
-    await use(_testContext)
+    await _use(_testContext)
 
     // Cleanup
     await _testContext.teardown(sanityClient)
   },
 
   // oxlint-disable-next-line no-empty-pattern
-  async sanityClient({}, use) {
+  async sanityClient({}, _use) {
     const client = createClient({
       projectId: process.env.SANITY_E2E_PROJECT_ID,
       dataset: process.env.SANITY_E2E_DATASET,
@@ -141,6 +140,6 @@ export const test = baseTest.extend<SanityFixtures>({
       apiHost: 'https://api.sanity.work',
     })
 
-    await use(client)
+    await _use(client)
   },
 })

--- a/e2e/tests/fixtures/copyPasteFixture.ts
+++ b/e2e/tests/fixtures/copyPasteFixture.ts
@@ -1,4 +1,3 @@
-/* oxlint-disable react-hooks/rules-of-hooks */
 import {test as base} from '../../studio-test'
 
 export const test = base.extend<{
@@ -7,7 +6,7 @@ export const test = base.extend<{
   getClipboardItems: () => Promise<ClipboardItem[]>
   getClipboardItemsAsText: () => Promise<string>
 }>({
-  page: async ({page}, use) => {
+  page: async ({page}, _use) => {
     const setupClipboardMocks = async () => {
       return page.addInitScript(() => {
         const mockClipboard = {
@@ -46,23 +45,23 @@ export const test = base.extend<{
       await setupClipboardMocks()
     })
 
-    await use(page)
+    await _use(page)
   },
 
-  setClipboardItems: async ({page}, use) => {
-    await use(async (items: ClipboardItem[]) => {
+  setClipboardItems: async ({page}, _use) => {
+    await _use(async (items: ClipboardItem[]) => {
       ;(window as any).__clipboardItems = items
     })
   },
 
-  getClipboardItems: async ({page}, use) => {
-    await use(() => {
+  getClipboardItems: async ({page}, _use) => {
+    await _use(() => {
       return page.evaluate(() => navigator.clipboard.read())
     })
   },
 
-  getClipboardItemsAsText: async ({page}, use) => {
-    await use(async () => {
+  getClipboardItemsAsText: async ({page}, _use) => {
+    await _use(async () => {
       return page.evaluate(async () => {
         const items = await navigator.clipboard.read()
         const textItem = items.find((item) => item.types.includes('text/plain'))
@@ -74,8 +73,8 @@ export const test = base.extend<{
     })
   },
 
-  getClipboardItemByMimeTypeAsText: async ({page}, use) => {
-    await use(async (mimeType: string) => {
+  getClipboardItemByMimeTypeAsText: async ({page}, _use) => {
+    await _use(async (mimeType: string) => {
       return page.evaluate(async (mime) => {
         const items = await navigator.clipboard.read()
         const textItem = items.find((item) => item.types.includes(mime))

--- a/packages/sanity/src/core/components/resizer/Resizer.tsx
+++ b/packages/sanity/src/core/components/resizer/Resizer.tsx
@@ -89,14 +89,12 @@ export function Resizer(props: {
         onResize(mouseXRef.current - e.pageX)
       }
 
-      const handleMouseUp = () => {
-        window.removeEventListener('mousemove', handleMouseMove)
-        // oxlint-disable-next-line react/react-compiler
-        window.removeEventListener('mouseup', handleMouseUp)
-      }
+      const controller = new AbortController()
+      const handleMouseUp = () => controller.abort()
 
-      window.addEventListener('mousemove', handleMouseMove)
-      window.addEventListener('mouseup', handleMouseUp)
+      const {signal} = controller
+      window.addEventListener('mousemove', handleMouseMove, {signal})
+      window.addEventListener('mouseup', handleMouseUp, {signal})
     },
     [onResize, onResizeStart],
   )

--- a/packages/sanity/src/core/divergence/utils/readOrderedFormMembers.test.ts
+++ b/packages/sanity/src/core/divergence/utils/readOrderedFormMembers.test.ts
@@ -1,4 +1,3 @@
-// oxlint-disable react-hooks/rules-of-hooks
 import {Schema} from '@sanity/schema'
 import {type ObjectSchemaType, defineArrayMember, defineField, defineType} from '@sanity/types'
 import {toString} from '@sanity/util/paths'
@@ -185,8 +184,8 @@ const it = baseIt.extend<{
   schema: ReturnType<typeof Schema.compile>
 }>({
   // oxlint-disable-next-line no-empty-pattern
-  prepareFormState: async ({}, use) => {
-    await use(
+  prepareFormState: async ({}, _use) => {
+    await _use(
       createPrepareFormState({
         decorators: {
           prepareArrayOfObjectsInputState: vi.fn,
@@ -201,8 +200,8 @@ const it = baseIt.extend<{
     )
   },
   // oxlint-disable-next-line no-empty-pattern
-  schema: async ({}, use) => {
-    await use(Schema.compile(schemaDefinition))
+  schema: async ({}, _use) => {
+    await _use(Schema.compile(schemaDefinition))
   },
 })
 

--- a/packages/sanity/src/core/form/store/utils/__tests__/getExpandOperations.test.ts
+++ b/packages/sanity/src/core/form/store/utils/__tests__/getExpandOperations.test.ts
@@ -1,4 +1,3 @@
-// oxlint-disable react-hooks/rules-of-hooks
 import {Schema} from '@sanity/schema'
 import {type ObjectSchemaType, defineField, defineType} from '@sanity/types'
 import {it as baseIt, expect, vi} from 'vitest'
@@ -156,8 +155,8 @@ const it = baseIt.extend<{
   schema: ReturnType<typeof Schema.compile>
 }>({
   // oxlint-disable-next-line no-empty-pattern
-  prepareFormState: async ({}, use) => {
-    await use(
+  prepareFormState: async ({}, _use) => {
+    await _use(
       createPrepareFormState({
         decorators: {
           prepareArrayOfObjectsInputState: vi.fn,
@@ -172,8 +171,8 @@ const it = baseIt.extend<{
     )
   },
   // oxlint-disable-next-line no-empty-pattern
-  schema: async ({}, use) => {
-    await use(Schema.compile(schemaDefinition))
+  schema: async ({}, _use) => {
+    await _use(Schema.compile(schemaDefinition))
   },
 })
 

--- a/packages/sanity/src/core/preview/useObserveDocument.ts
+++ b/packages/sanity/src/core/preview/useObserveDocument.ts
@@ -38,9 +38,8 @@ export function useUnstableObserveDocument<T extends SanityDocument>(
  * @internal
  * @beta
  */
-export const unstable_useObserveDocument = (
+export const unstable_useObserveDocument = function useObserveDocument(
   args: Parameters<typeof useUnstableObserveDocument>,
-) => {
-  // oxlint-disable-next-line react-hooks/rules-of-hooks -- deprecated wrapper for backwards compatibility
+) {
   return useUnstableObserveDocument(...args)
 }

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -20,10 +20,7 @@ import {type Previewable} from './types'
  * @internal
  * @deprecated use useValuePreview instead
  */
-export function unstable_useValuePreview(args: Parameters<typeof useValuePreview>[0]) {
-  // oxlint-disable-next-line react-hooks/rules-of-hooks -- deprecated wrapper for backwards compatibility
-  return useValuePreview(args)
-}
+export const unstable_useValuePreview = useValuePreview
 
 interface State {
   isLoading: boolean


### PR DESCRIPTION
### Description

Lil cleanup that allows react compiler to speedup `<Resizer>`.

### What to review

Also cleans up a few other suppressions while at it.

### Testing

CI green we good. Manually verified I can resize document inspector panels without issues.

### Notes for release

N/A
