### PR TITLE
fix(sanity): condense and batch version observer requests

### DIFF
--- a/packages/sanity/src/core/preview/__test__/observeVersionDocumentIds.test.ts
+++ b/packages/sanity/src/core/preview/__test__/observeVersionDocumentIds.test.ts
@@ -1,0 +1,191 @@
+import {type SanityClient} from '@sanity/client'
+import {firstValueFrom, from, of, Subject} from 'rxjs'
+import {take, toArray} from 'rxjs/operators'
+import {describe, expect, it} from 'vitest'
+
+import {bufferByByteSize, createObserveVersionDocumentIds} from '../observeVersionDocumentIds'
+import {type InvalidationChannelEvent} from '../types'
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function parsePublishedIds(query: string): string[] {
+  const matches = query.match(/sanity::versionOf\("([^"]+)"\)/g) ?? []
+  return matches.map((match) => match.replace(/^sanity::versionOf\("/, '').replace(/"\)$/, ''))
+}
+
+function createMockClient(onFetch: (query: string) => string[][]) {
+  const fetchCalls: string[] = []
+  const client = {
+    withConfig: () => client,
+    observable: {
+      fetch: (query: string) => {
+        fetchCalls.push(query)
+        return of(onFetch(query))
+      },
+    },
+  }
+  return {client: client as unknown as SanityClient, fetchCalls}
+}
+
+describe('bufferByByteSize', () => {
+  it('buffers values into chunks bounded by the byte limit', async () => {
+    const chunks = await firstValueFrom(
+      from(['a', 'bb', 'ccc', 'dddd']).pipe(
+        bufferByByteSize((value) => value.length, 5),
+        toArray(),
+      ),
+    )
+
+    // running totals close just before reaching the limit of 5:
+    // a(1), bb(+2=3); ccc would make 6 -> close [a,bb]; ccc(3), dddd would make 7 -> close [ccc]
+    expect(chunks).toEqual([['a', 'bb'], ['ccc'], ['dddd']])
+  })
+
+  it('emits an oversized value as its own chunk', async () => {
+    const chunks = await firstValueFrom(
+      from(['x', 'enormous']).pipe(
+        bufferByByteSize((value) => value.length, 3),
+        toArray(),
+      ),
+    )
+
+    expect(chunks).toEqual([['x'], ['enormous']])
+  })
+})
+
+describe('observeVersionDocumentIds', () => {
+  it('batches discovery for multiple published ids into a single query', async () => {
+    const {client, fetchCalls} = createMockClient((query) =>
+      parsePublishedIds(query).map((id) => [`drafts.${id}`, `versions.r1.${id}`]),
+    )
+    const invalidationChannel = new Subject<InvalidationChannelEvent>()
+    const observe = createObserveVersionDocumentIds({client, invalidationChannel})
+
+    const publishedIds = ['article-1', 'article-2', 'article-3']
+    const results: Record<string, string[]> = {}
+    const subscriptions = publishedIds.map((id) =>
+      observe(id)
+        .pipe(take(1))
+        .subscribe((ids) => {
+          results[id] = ids
+        }),
+    )
+
+    invalidationChannel.next({type: 'connected'})
+    await wait(150)
+    subscriptions.forEach((sub) => sub.unsubscribe())
+
+    // All three published ids resolved in a single combined query
+    expect(fetchCalls).toHaveLength(1)
+    expect(fetchCalls[0]).toContain('sanity::versionOf("article-1")')
+    expect(fetchCalls[0]).toContain('sanity::versionOf("article-2")')
+    expect(fetchCalls[0]).toContain('sanity::versionOf("article-3")')
+
+    expect(results).toEqual({
+      'article-1': ['drafts.article-1', 'versions.r1.article-1'],
+      'article-2': ['drafts.article-2', 'versions.r1.article-2'],
+      'article-3': ['drafts.article-3', 'versions.r1.article-3'],
+    })
+  })
+
+  it('chunks large batches into multiple queries and reassembles results', async () => {
+    const longPrefix = 'a'.repeat(990)
+    const publishedIds = Array.from({length: 15}, (_, i) => `${longPrefix}-${i}`)
+
+    const {client, fetchCalls} = createMockClient((query) =>
+      parsePublishedIds(query).map((id) => [`drafts.${id}`]),
+    )
+    const invalidationChannel = new Subject<InvalidationChannelEvent>()
+    const observe = createObserveVersionDocumentIds({client, invalidationChannel})
+
+    const results: Record<string, string[]> = {}
+    const subscriptions = publishedIds.map((id) =>
+      observe(id)
+        .pipe(take(1))
+        .subscribe((ids) => {
+          results[id] = ids
+        }),
+    )
+
+    invalidationChannel.next({type: 'connected'})
+    await wait(200)
+    subscriptions.forEach((sub) => sub.unsubscribe())
+
+    expect(fetchCalls.length).toBeGreaterThan(1)
+    for (const id of publishedIds) {
+      expect(results[id]).toEqual([`drafts.${id}`])
+    }
+  })
+
+  it('refetches the set when a relevant mutation arrives', async () => {
+    const versionsByPublishedId: Record<string, string[]> = {
+      'article-1': ['drafts.article-1'],
+    }
+    const {client, fetchCalls} = createMockClient((query) =>
+      parsePublishedIds(query).map((id) => versionsByPublishedId[id] ?? []),
+    )
+    const invalidationChannel = new Subject<InvalidationChannelEvent>()
+    const observe = createObserveVersionDocumentIds({client, invalidationChannel})
+
+    const emissions: string[][] = []
+    const subscription = observe('article-1').subscribe((ids) => emissions.push(ids))
+
+    invalidationChannel.next({type: 'connected'})
+    await wait(150)
+
+    // A new version appears for the same published id
+    versionsByPublishedId['article-1'] = ['drafts.article-1', 'versions.rNew.article-1']
+    invalidationChannel.next({
+      type: 'mutation',
+      documentId: 'versions.rNew.article-1',
+      visibility: 'query',
+    })
+    await wait(150)
+
+    subscription.unsubscribe()
+
+    expect(emissions).toEqual([
+      ['drafts.article-1'],
+      ['drafts.article-1', 'versions.rNew.article-1'],
+    ])
+    expect(fetchCalls).toHaveLength(2)
+  })
+
+  it('ignores mutations for unrelated documents', async () => {
+    const {client, fetchCalls} = createMockClient((query) =>
+      parsePublishedIds(query).map((id) => [`drafts.${id}`]),
+    )
+    const invalidationChannel = new Subject<InvalidationChannelEvent>()
+    const observe = createObserveVersionDocumentIds({client, invalidationChannel})
+
+    const emissions: string[][] = []
+    const subscription = observe('article-1').subscribe((ids) => emissions.push(ids))
+
+    invalidationChannel.next({type: 'connected'})
+    await wait(150)
+
+    // Mutation for a version of a different published id
+    invalidationChannel.next({
+      type: 'mutation',
+      documentId: 'versions.rNew.article-2',
+      visibility: 'query',
+    })
+    await wait(150)
+
+    subscription.unsubscribe()
+
+    expect(emissions).toEqual([['drafts.article-1']])
+    expect(fetchCalls).toHaveLength(1)
+  })
+
+  it('caches and shares the observable for the same published id', () => {
+    const {client} = createMockClient(() => [])
+    const invalidationChannel = new Subject<InvalidationChannelEvent>()
+    const observe = createObserveVersionDocumentIds({client, invalidationChannel})
+
+    expect(observe('article-1')).toBe(observe('article-1'))
+    expect(observe('article-1')).not.toBe(observe('article-2'))
+  })
+})

--- a/packages/sanity/src/core/preview/documentPreviewStore.ts
+++ b/packages/sanity/src/core/preview/documentPreviewStore.ts
@@ -22,6 +22,7 @@ import {createPreviewObserver} from './createPreviewObserver'
 import {createObservePathsDocumentPair} from './documentPair'
 import {createDocumentIdSetObserver, type DocumentIdSetObserverState} from './liveDocumentIdSet'
 import {createObserveFields} from './observeFields'
+import {createObserveVersionDocumentIds} from './observeVersionDocumentIds'
 import {
   type ApiConfig,
   type DocumentStackAvailability,
@@ -102,6 +103,7 @@ export interface DocumentPreviewStore {
    * transitions on the received listener events.
    * This provides a lightweight way of subscribing to a list of ids for simple cases where you just want to subscribe to a set of documents ids
    * that matches a particular filter.
+   *
    * @hidden
    * @beta
    * @param filter - A groq filter to use for the document set
@@ -122,7 +124,23 @@ export interface DocumentPreviewStore {
   ) => Observable<DocumentIdSetObserverState>
 
   /**
+   * Observes the set of version and variant document ids that exist for a given
+   * document group id.
+   *
+   * Unlike `unstable_observeDocumentIdSet`, this does not open a dedicated
+   * real-time listener for each published id. Instead, it is driven by the
+   * shared global listener and batches the discovery queries for all observed
+   * document group ids into a single combined query, returning the ids in
+   * ascending order.
+   *
+   * @hidden
+   * @beta
+   */
+  unstable_observeVersionDocumentIds: (publishedId: string) => Observable<string[]>
+
+  /**
    * Observe a complete document with the given ID
+   *
    * @hidden
    * @beta
    */
@@ -130,8 +148,10 @@ export interface DocumentPreviewStore {
     id: string,
     clientConfig?: ObserveDocumentAPIConfig,
   ) => Observable<SanityDocument | undefined>
+
   /**
    * Observe a list of complete documents with the given IDs
+   *
    * @hidden
    * @beta
    */
@@ -199,6 +219,11 @@ export function createDocumentPreviewStore({
 
   const observeDocumentIdSet = createDocumentIdSetObserver(versionedClient)
 
+  const observeVersionDocumentIds = createObserveVersionDocumentIds({
+    client: versionedClient,
+    invalidationChannel,
+  })
+
   const observeForPreview = createPreviewObserver({observeDocumentTypeFromId, observePaths})
 
   const observeDocumentStackAvailability = createDocumentStackAvailabilityObserver(
@@ -223,6 +248,7 @@ export function createDocumentPreviewStore({
     observeDocumentTypeFromId,
     observeDocumentSystemFromId,
     unstable_observeDocumentIdSet: observeDocumentIdSet,
+    unstable_observeVersionDocumentIds: observeVersionDocumentIds,
     unstable_observeDocument: observeDocument,
     unstable_observeDocuments: (ids: string[]) =>
       combineLatest(ids.map((id) => observeDocument(id))),

--- a/packages/sanity/src/core/preview/observeVersionDocumentIds.ts
+++ b/packages/sanity/src/core/preview/observeVersionDocumentIds.ts
@@ -1,0 +1,189 @@
+import {type SanityClient} from '@sanity/client'
+import isEqual from 'lodash-es/isEqual.js'
+import {concat, from, type Observable, of, type OperatorFunction, retry, Subject, timer} from 'rxjs'
+import {
+  bufferWhen,
+  distinctUntilChanged,
+  filter,
+  finalize,
+  map,
+  mergeMap,
+  shareReplay,
+  switchMap,
+  tap,
+  toArray,
+} from 'rxjs/operators'
+
+import {RELEASES_STUDIO_CLIENT_OPTIONS} from '../releases/util/releasesClient'
+import {versionedClient} from '../studioClient'
+import {MAX_DOCUMENT_ID_CHUNK_SIZE} from '../util/const'
+import {getPublishedId} from '../util/draftUtils'
+import {type InvalidationChannelEvent} from './types'
+import {debounceCollect} from './utils/debounceCollect'
+
+/**
+ * Approximate per-id overhead of a single document group member subquery.
+ */
+const VERSION_OF_QUERY_OVERHEAD = '*[sanity::versionOf("")]._id,'.length
+
+/**
+ * Maximum number of batch queries to keep in flight at once.
+ */
+const MAX_CONCURRENT_BATCH_FETCHES = 10
+
+/**
+ * Create a function that observes the set of version and variant document ids
+ * that exist for the provided document group id.
+ *
+ * Unlike `createDocumentIdSetObserver`, which opens a dedicated listener for
+ * each document group id, this observer is driven by the shared global
+ * `invalidationChannel`. It condenses the queries for all observed document
+ * group ids into a single GROQ query (one `sanity::versionOf()` call per id),
+ * batching the request if it exceeds `MAX_DOCUMENT_ID_BATCH_SIZE`.
+ *
+ * @internal
+ */
+export function createObserveVersionDocumentIds(options: {
+  client: SanityClient
+  invalidationChannel: Observable<InvalidationChannelEvent>
+}): (documentGroupId: string) => Observable<string[]> {
+  const {client, invalidationChannel} = options
+  const releasesClient = versionedClient(client, RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion)
+
+  const fetchFast = debounceCollect(
+    (collectedArgs: [documentGroupId: string][]) =>
+      fetchVersionIdSets(releasesClient, collectedArgs),
+    100,
+  )
+
+  const fetchSlow = debounceCollect(
+    (collectedArgs: [documentGroupId: string][]) =>
+      fetchVersionIdSets(releasesClient, collectedArgs),
+    1000,
+  )
+
+  const cache = new Map<string, Observable<string[]>>()
+
+  return function observeVersionDocumentIds(documentGroupId: string): Observable<string[]> {
+    const cachedInstance = cache.get(documentGroupId)
+
+    if (cachedInstance) {
+      return cachedInstance
+    }
+
+    const instance = invalidationChannel.pipe(
+      filter(
+        (event) =>
+          event.type === 'connected' || getPublishedId(event.documentId) === documentGroupId,
+      ),
+      switchMap((event) => {
+        if (event.type === 'connected' || event.visibility === 'query') {
+          return fetchFast(documentGroupId).pipe(
+            mergeMap((ids) => {
+              // A newly created version may not be indexed yet when its mutation
+              // event arrives. If the mutated document isn't reflected in the
+              // fresh result, schedule a slow refetch to catch up (mirroring the
+              // fast/slow fallback in `observeFields`).
+              const maybeIndexPending =
+                event.type === 'mutation' &&
+                event.documentId !== documentGroupId &&
+                !ids.includes(event.documentId)
+
+              if (maybeIndexPending) {
+                return concat(of(ids), fetchSlow(documentGroupId))
+              }
+
+              return of(ids)
+            }),
+          )
+        }
+        return fetchSlow(documentGroupId)
+      }),
+      distinctUntilChanged(isEqual),
+      finalize(() => cache.delete(documentGroupId)),
+      shareReplay({
+        refCount: true,
+        bufferSize: 1,
+      }),
+    )
+
+    cache.set(documentGroupId, instance)
+    return instance
+  }
+}
+
+/**
+ * Buffer source values into batches, closing the current batch just before a
+ * value would push its cumulative byte size to or beyond `maxBytes`. The
+ * overflowing value becomes the first entry of the next batch; a value whose
+ * own size already meets the limit is emitted as a single-element batch.
+ *
+ * @internal
+ */
+export function bufferByByteSize<Type extends string>(
+  byteSize: (value: Type) => number,
+  maxBytes: number,
+): OperatorFunction<Type, Type[]> {
+  return (source) => {
+    const closeBuffer = new Subject<void>()
+    let bufferedBytes = 0
+
+    return source.pipe(
+      tap((value) => {
+        const size = byteSize(value)
+        // Close the current (non-empty) buffer before this value would exceed
+        // the limit, so the overflowing value becomes the first entry of the
+        // next buffer instead.
+        if (bufferedBytes > 0 && bufferedBytes + size >= maxBytes) {
+          bufferedBytes = 0
+          closeBuffer.next()
+        }
+        bufferedBytes += size
+      }),
+      bufferWhen(() => closeBuffer),
+    )
+  }
+}
+
+function buildQuery(documentGroupIds: string[]): string {
+  const subQueries = documentGroupIds.map((id) => `*[sanity::versionOf(${JSON.stringify(id)})]._id`)
+  return `[${subQueries.join(',')}]`
+}
+
+function fetchBatch(client: SanityClient, ids: string[]): Observable<string[][]> {
+  return client.observable
+    .fetch<string[][]>(buildQuery(ids), {}, {tag: 'preview.observe-version-ids'})
+    .pipe(
+      retry({delay: (_: unknown, attempt) => timer(Math.min(30_000, attempt * 1000))}),
+      // Sort each set ascending so consumers get a stable order.
+      map((result) => result.map((versionIds) => [...versionIds].sort())),
+    )
+}
+
+function fetchVersionIdSets(
+  client: SanityClient,
+  collectedArgs: [documentGroupIds: string][],
+): Observable<string[][]> {
+  const documentGroupIds = collectedArgs.map(([documentGroupId]) => documentGroupId)
+
+  if (documentGroupIds.length === 0) {
+    return of([])
+  }
+
+  return from(documentGroupIds).pipe(
+    // Split into batches small enough that each combined query stays within the
+    // max query size.
+    bufferByByteSize((id) => id.length + VERSION_OF_QUERY_OVERHEAD, MAX_DOCUMENT_ID_CHUNK_SIZE),
+    // Fetch batches in parallel, tracking each batch's position so results can
+    // be reordered.
+    mergeMap(
+      (batch, index) => fetchBatch(client, batch).pipe(map((result) => ({index, result}))),
+      MAX_CONCURRENT_BATCH_FETCHES,
+    ),
+    toArray(),
+    // Restore source order (parallel fetches may settle out of order), and
+    // flatten the batch results back into a single array aligned with
+    // `documentGroupIds`.
+    map((settled) => settled.sort((a, b) => a.index - b.index).flatMap(({result}) => result)),
+  )
+}

--- a/packages/sanity/src/core/releases/hooks/__tests__/getOrCreateDocumentVersionsObservable.test.ts
+++ b/packages/sanity/src/core/releases/hooks/__tests__/getOrCreateDocumentVersionsObservable.test.ts
@@ -9,14 +9,9 @@ describe('getOrCreateDocumentVersionsObservable', () => {
     observableCache.clear()
 
     const documentPreviewStore = {
-      unstable_observeDocumentIdSet: vi
-        .fn<DocumentPreviewStore['unstable_observeDocumentIdSet']>()
-        .mockReturnValue(
-          of({
-            status: 'connected',
-            documentIds: ['drafts.article-1'],
-          }),
-        ),
+      unstable_observeVersionDocumentIds: vi
+        .fn<DocumentPreviewStore['unstable_observeVersionDocumentIds']>()
+        .mockReturnValue(of(['drafts.article-1'])),
       observePaths: vi.fn<DocumentPreviewStore['observePaths']>().mockReturnValue(
         of({
           _id: 'drafts.article-1',

--- a/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
@@ -40,22 +40,15 @@ async function setupMocks({
    * falls back to `temporarilyBuildDocumentSystem`.
    */
   observeSystem?: boolean
-  /** When `true`, the id set observable never emits (initial loading state). */
+  /** When `true`, the version document ids observable never emits (initial loading state). */
   pendingIdSet?: boolean
 }) {
   const mockDocumentPreviewStore = useDocumentPreviewStore as Mock<typeof useDocumentPreviewStore>
 
   mockDocumentPreviewStore.mockReturnValue({
-    unstable_observeDocumentIdSet: vi
-      .fn<DocumentPreviewStore['unstable_observeDocumentIdSet']>()
-      .mockReturnValue(
-        pendingIdSet
-          ? NEVER
-          : of({
-              status: 'connected',
-              documentIds: versionIds,
-            }),
-      ),
+    unstable_observeVersionDocumentIds: vi
+      .fn<DocumentPreviewStore['unstable_observeVersionDocumentIds']>()
+      .mockReturnValue(pendingIdSet ? NEVER : of(versionIds)),
     observePaths: vi
       .fn<DocumentPreviewStore['observePaths']>()
       .mockImplementation((value: {_id: string}) => {

--- a/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
@@ -1,4 +1,4 @@
-import {type QueryParams, type ReleaseDocument} from '@sanity/client'
+import {type ReleaseDocument} from '@sanity/client'
 import {getVersionFromId} from '@sanity/client/csm'
 import {type DocumentSystem} from '@sanity/types'
 import {useMemo} from 'react'
@@ -27,7 +27,6 @@ import {createSWR} from '../../util/rxSwr'
 import {type VersionInfoDocumentStub} from '../store/types'
 import {useActiveReleases} from '../store/useActiveReleases'
 import {getReleaseIdFromReleaseDocumentId} from '../util/getReleaseIdFromReleaseDocumentId'
-import {RELEASES_STUDIO_CLIENT_OPTIONS} from '../util/releasesClient'
 
 export interface DocumentPerspectiveProps {
   documentId: string
@@ -49,7 +48,7 @@ const INITIAL_VALUE: DocumentPerspectiveState = {
 
 // Create a singleton cache for observables
 export const observableCache = new Map<string, Observable<DocumentPerspectiveState>>()
-const swr = createSWR<{documentIds: string[]}>({maxSize: 100})
+const swr = createSWR<string[]>({maxSize: 100})
 
 /**
  * Fetches the document versions for a given document
@@ -150,7 +149,6 @@ const DOCUMENT_STUB_PATHS = ['_id', '_type', '_rev', '_createdAt', '_updatedAt',
  *
  * @param options - The options for creating or retrieving the observable.
  * options.documentPreviewStore - The store used to observe document IDs.
- * options.params - The query params to use for the observable.
  * options.publishedId - The ID of the published document.
  * options.projectId - The project ID.
  * options.dataset - The dataset name.
@@ -161,12 +159,11 @@ const DOCUMENT_STUB_PATHS = ['_id', '_type', '_rev', '_createdAt', '_updatedAt',
  */
 export function getOrCreateDocumentVersionsObservable(options: {
   documentPreviewStore: DocumentPreviewStore
-  params?: QueryParams
   publishedId: string
   projectId: string
   dataset: string
 }): Observable<DocumentPerspectiveState> {
-  const {documentPreviewStore, projectId, dataset, publishedId, params = undefined} = options
+  const {documentPreviewStore, projectId, dataset, publishedId} = options
   const cacheKey = `${projectId}-${dataset}-${publishedId}`
 
   const cachedObservable = observableCache.get(cacheKey)
@@ -174,64 +171,60 @@ export function getOrCreateDocumentVersionsObservable(options: {
     return cachedObservable
   }
 
-  const newObservable = documentPreviewStore
-    .unstable_observeDocumentIdSet(`sanity::versionOf("${publishedId}")`, params, {
-      apiVersion: RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion,
-    })
-    .pipe(
-      swr(cacheKey),
-      map(({value}) => value.documentIds),
-      switchMap((documentIds): Observable<DocumentPerspectiveState> => {
-        if (documentIds.length === 0) {
-          return of({data: [], versions: [], error: null, loading: false})
-        }
+  const newObservable = documentPreviewStore.unstable_observeVersionDocumentIds(publishedId).pipe(
+    swr(cacheKey),
+    map(({value}) => value),
+    switchMap((documentIds): Observable<DocumentPerspectiveState> => {
+      if (documentIds.length === 0) {
+        return of({data: [], versions: [], error: null, loading: false})
+      }
 
-        const loadingState: DocumentPerspectiveState = {
-          data: documentIds,
-          versions: [],
-          error: null,
-          loading: true,
-        }
+      const loadingState: DocumentPerspectiveState = {
+        data: documentIds,
+        versions: [],
+        error: null,
+        loading: true,
+      }
 
-        return combineLatest(
-          documentIds.map((id) =>
-            documentPreviewStore.observePaths({_id: id}, DOCUMENT_STUB_PATHS).pipe(
-              map((versionInfo) => (isRecord(versionInfo) ? versionInfo : undefined)),
-              map(
-                (versionInfo) =>
-                  ({
-                    _id: id,
-                    _rev: versionInfo?._rev ?? '',
-                    _createdAt: versionInfo?._createdAt ?? '',
-                    _updatedAt: versionInfo?._updatedAt ?? '',
-                    [DOCUMENT_SYSTEM_FIELD]: versionInfo?.[DOCUMENT_SYSTEM_FIELD] as DocumentSystem,
-                  }) satisfies VersionInfoDocumentStub,
-              ),
+      return combineLatest(
+        documentIds.map((id) =>
+          documentPreviewStore.observePaths({_id: id}, DOCUMENT_STUB_PATHS).pipe(
+            map((versionInfo) => (isRecord(versionInfo) ? versionInfo : undefined)),
+            map(
+              (versionInfo) =>
+                ({
+                  _id: id,
+                  _rev: versionInfo?._rev ?? '',
+                  _createdAt: versionInfo?._createdAt ?? '',
+                  _updatedAt: versionInfo?._updatedAt ?? '',
+                  [DOCUMENT_SYSTEM_FIELD]: versionInfo?.[DOCUMENT_SYSTEM_FIELD] as DocumentSystem,
+                }) satisfies VersionInfoDocumentStub,
             ),
           ),
-        ).pipe(
-          map((versions) => ({
-            data: documentIds,
-            versions,
-            error: null,
-            loading: false,
-          })),
-          startWith(loadingState),
-        )
-      }),
-      catchError((error) => {
-        return of({
-          error,
-          data: [] as string[],
-          versions: [] as VersionInfoDocumentStub[],
+        ),
+      ).pipe(
+        map((versions) => ({
+          data: documentIds,
+          versions,
+          error: null,
           loading: false,
-        })
-      }),
-      finalize(() => {
-        observableCache.delete(cacheKey)
-      }),
-      shareReplay({refCount: true, bufferSize: 1}),
-    )
+        })),
+        startWith(loadingState),
+      )
+    }),
+    catchError((error) => {
+      return of({
+        error,
+        data: [] as string[],
+        versions: [] as VersionInfoDocumentStub[],
+        loading: false,
+      })
+    }),
+    finalize(() => {
+      observableCache.delete(cacheKey)
+    }),
+    shareReplay({refCount: true, bufferSize: 1}),
+  )
 
   observableCache.set(cacheKey, newObservable)
   return newObservable


### PR DESCRIPTION
### Description

This branch adds a `unstable_observeVersionDocumentIds` method to the document preview store, which can be used to discover and subscribe to all existing versions/variant ids of a given document group id.

It's heavily based on `createObserveFields`: **it condenses and batches requests**, and uses the existing `invalidationChannel` to drive refetching. It also employs the same fast and slow fetching strategies to deal with documents that may not yet be indexed in Content Lake.

PR #13113 updated Studio codebase to replace many instances of the `useDocumentVersionInfo` React hook with the `useDocumentVersions` hook. This was problematic, because that hook spawns a `unstable_observeDocumentIdSet` listener for _every_ list preview shown in the app; simply opening a reference picker could inundate the app with listeners, causing the document list previews to hang in perpetuity.

This branch solve the problem by condensing and batching the requests.

### What to review

The new `unstable_observeVersionDocumentIds` method.

### Testing

Added new tests. Verified document list previews no longer hang after variant functionality is restored (see #13334).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time version discovery used broadly by list previews and releases UI; incorrect batching or invalidation could cause stale or missing version ids, though behavior is covered by new tests and mirrors an existing observeFields pattern.
> 
> **Overview**
> Adds **`unstable_observeVersionDocumentIds`** on the document preview store so Studio can discover draft/version ids for a published document group without opening a **per-id** `unstable_observeDocumentIdSet` listener.
> 
> The new **`createObserveVersionDocumentIds`** path drives refetches from the shared **`invalidationChannel`**, **debounce-collects** many published ids into combined GROQ queries (`sanity::versionOf` per id), **chunks** oversized batches via **`bufferByByteSize`**, and uses **fast/slow** refetch when indexing may lag—mirroring **`observeFields`**. Observables are **cached** per published id.
> 
> **`useDocumentVersions`** / **`getOrCreateDocumentVersionsObservable`** now subscribe to this API instead of `unstable_observeDocumentIdSet`, fixing list previews hanging when many references each spawned their own listener. Tests cover batching, chunking, mutation-driven refetch, and hook mocks were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd2c59e966348fb0a7911b05e643bc53e75c2e80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->