### PR TITLE
chore(debug-proxy): add intermittent 5xx incident scenario

### DIFF
--- a/packages/@repo/debug-proxy/README.md
+++ b/packages/@repo/debug-proxy/README.md
@@ -45,6 +45,7 @@ Configuration is via CLI flags (`--help` for the full list):
 - `--listener-ttl` — disconnect SSE listeners after N seconds to simulate flaky connections
 - `--flap <on>[:<off>]` — simulate flapping connectivity (online → offline → online → …): proxy normally for `<on>` seconds, then go "offline" for `<off>` seconds, repeating. While offline, new requests are reset at the socket level and live SSE streams are cut, so clients see real network-failure errors rather than HTTP error responses. A single number means equal phases, e.g. `--flap 30:15` or `--flap 20`
 - `--latency <ms>[:<maxMs>]` — delay each request by this many milliseconds before forwarding it upstream, simulating a slow network; a range applies random jitter per request, e.g. `--latency 800` or `--latency 200:1500`
+- `--error-probability <0..1>` — simulate an incident: each request independently fails with a random 5xx (`500`/`502`/`503`/`504`) instead of being forwarded upstream, at this probability. The response carries a JSON body shaped like a real Sanity API error, and the upstream is never contacted (so it also covers the "request never reached the backend" case). CORS preflights (`OPTIONS`) are never faulted, so the real request still gets a chance to fail. e.g. `--error-probability 0.2`
 - Fault toggles: `--sse-faults`, `--drop-probability`, `--reset-probability`, `--org-401`
 
 Pass flags through pnpm like so:
@@ -131,6 +132,7 @@ Routes are matched in order — the first route whose `match` returns `true` win
 - Scenarios (RxJS operators over the SSE event stream): `randomLatency`, `sendReset`, `duplicateMutations`, `dropMutations`, `shuffleEventDelivery`.
 - `createConnectionFlapper({onlineMs, offlineMs})` — cycles simulated connectivity; `flapper.wrap(handler)` makes any handler's requests fail like a dead network during the offline phases (and cuts in-flight streams on each transition).
 - `withLatency(handler, {minMs, maxMs})` — holds each request back by a random delay in the range before forwarding it upstream.
+- `intermittentServiceErrors(probability)` — wraps a handler so that, with the given probability, a request short-circuits with a synthetic random 5xx response instead of being forwarded upstream (skipping `OPTIONS` preflights). Use it to simulate an incident where endpoints intermittently return various server errors.
 - Route matchers: `urlIncludes`, `isListenEndpoint`, `isGetOrgIdEndpoint`, `anyOf`, `allOf`.
 
 ## Writing a new scenario

--- a/packages/@repo/debug-proxy/src/cli.ts
+++ b/packages/@repo/debug-proxy/src/cli.ts
@@ -14,6 +14,7 @@ import {createConnectionFlapper} from './connectivity'
 import {createDebugProxy, type ProxyHandler} from './createDebugProxy'
 import {withLatency} from './latency'
 import {createRequestProxy, createSSEProxy} from './proxy'
+import {intermittentServiceErrors} from './requestScenarios'
 import {isGetOrgIdEndpoint, isListenEndpoint} from './routes'
 import {
   dropMutations,
@@ -47,6 +48,10 @@ Options:
                               before forwarding it upstream; a range applies
                               random jitter per request, e.g. --latency 800
                               or --latency 200:1500
+  --error-probability <0..1>  simulate an incident: each request independently
+                              fails with a random 5xx (500/502/503/504) instead
+                              of being forwarded upstream, at this probability
+                              (default: 0)
   --sse-faults                apply the SSE fault scenarios (shuffle, duplicate,
                               latency, reset, drop) to the listener endpoint
   --drop-probability <0..1>   probability a mutation event is dropped
@@ -76,6 +81,7 @@ function parseFlags() {
         'listener-ttl': {type: 'string', default: '0'},
         'flap': {type: 'string'},
         'latency': {type: 'string'},
+        'error-probability': {type: 'string', default: '0'},
         'sse-faults': {type: 'boolean', default: false},
         'drop-probability': {type: 'string', default: '0'},
         'reset-probability': {type: 'string', default: '0'},
@@ -164,6 +170,7 @@ const API_HOST = flags['api-host']
 const LISTENER_TTL_MS = intFlag('listener-ttl', flags['listener-ttl']) * 1000
 const FLAP = flags.flap === undefined ? undefined : flapFlag(flags.flap)
 const LATENCY = flags.latency === undefined ? undefined : latencyFlag(flags.latency)
+const ERROR_PROBABILITY = probabilityFlag('error-probability', flags['error-probability'])
 const ENABLE_SSE_FAULTS = flags['sse-faults']
 const DROPPED_MUTATION_PROBABILITY = probabilityFlag('drop-probability', flags['drop-probability'])
 const RESET_PROBABILITY = probabilityFlag('reset-probability', flags['reset-probability'])
@@ -391,10 +398,15 @@ const flapper = FLAP
     })
   : undefined
 
+// --error-probability sits between the (optional) latency delay and the handler
+// so a faulted request returns its 5xx immediately rather than after the delay.
+const faultRequests = intermittentServiceErrors(ERROR_PROBABILITY)
+
 // Network-level scenarios applied to every handler: --latency delays each
 // request, --flap sits outside it so offline resets stay immediate.
 const withNetworkScenarios = (handler: ProxyHandler): ProxyHandler => {
-  const delayed = LATENCY ? withLatency(handler, LATENCY) : handler
+  const faulted = faultRequests(handler)
+  const delayed = LATENCY ? withLatency(faulted, LATENCY) : faulted
   return flapper ? flapper.wrap(delayed) : delayed
 }
 
@@ -451,5 +463,11 @@ if (LATENCY) {
     LATENCY.minMs === LATENCY.maxMs
       ? `Latency: ${LATENCY.minMs}ms per request`
       : `Latency: ${LATENCY.minMs}–${LATENCY.maxMs}ms per request (random jitter)`,
+  )
+}
+
+if (ERROR_PROBABILITY > 0) {
+  console.info(
+    `Simulated incident: ${Math.round(ERROR_PROBABILITY * 100)}% of requests fail with a random 5xx (500/502/503/504)`,
   )
 }

--- a/packages/@repo/debug-proxy/src/index.ts
+++ b/packages/@repo/debug-proxy/src/index.ts
@@ -24,6 +24,7 @@ export {
   type Retry,
   type SSEEvent,
 } from './proxy'
+export {intermittentServiceErrors} from './requestScenarios'
 export {allOf, anyOf, isGetOrgIdEndpoint, isListenEndpoint, urlIncludes} from './routes'
 export {
   dropMutations,

--- a/packages/@repo/debug-proxy/src/requestScenarios.test.ts
+++ b/packages/@repo/debug-proxy/src/requestScenarios.test.ts
@@ -1,0 +1,158 @@
+import {once} from 'node:events'
+import {type IncomingMessage, type ServerResponse} from 'node:http'
+import {connect, constants as h2constants} from 'node:http2'
+import {createServer} from 'node:https'
+import {type AddressInfo} from 'node:net'
+import {fileURLToPath} from 'node:url'
+
+import {getCertificate} from '@vitejs/plugin-basic-ssl'
+import {afterEach, beforeAll, describe, expect, test} from 'vitest'
+
+import {createDebugProxy, type DebugProxyServer} from './createDebugProxy'
+import {createRequestProxy} from './proxy'
+import {intermittentServiceErrors} from './requestScenarios'
+
+let pem: string
+
+beforeAll(async () => {
+  pem = await getCertificate(
+    fileURLToPath(new URL('../.certs', import.meta.url)),
+    'debug-proxy-test',
+    ['*.localhost'],
+  )
+})
+
+type UpstreamHandler = (req: IncomingMessage, res: ServerResponse) => void
+
+async function startUpstream(handler: UpstreamHandler): Promise<{
+  apiHost: string
+  close: () => Promise<void>
+}> {
+  const server = createServer({key: pem, cert: pem}, handler)
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  const {port} = server.address() as AddressInfo
+  return {
+    apiHost: `127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.closeAllConnections()
+        server.close((err) => (err ? reject(err) : resolve()))
+      }),
+  }
+}
+
+const cleanups: Array<() => Promise<void>> = []
+afterEach(async () => {
+  await Promise.all(cleanups.splice(0).map((fn) => fn()))
+})
+
+async function startProxy(
+  config: Parameters<typeof createDebugProxy>[0],
+): Promise<DebugProxyServer> {
+  const proxy = createDebugProxy(config)
+  await proxy.listen()
+  cleanups.push(() => proxy.close())
+  return proxy
+}
+
+function h2Request(
+  port: number,
+  path: string,
+  method = 'GET',
+): Promise<{status: number; body: string}> {
+  return new Promise((resolve, reject) => {
+    const client = connect(`https://127.0.0.1:${port}`, {rejectUnauthorized: false})
+    client.on('error', reject)
+    const req = client.request({
+      [h2constants.HTTP2_HEADER_PATH]: path,
+      [h2constants.HTTP2_HEADER_AUTHORITY]: 'localhost',
+      [h2constants.HTTP2_HEADER_METHOD]: method,
+    })
+    let status = 0
+    let body = ''
+    req.on('response', (headers) => (status = Number(headers[h2constants.HTTP2_HEADER_STATUS])))
+    req.setEncoding('utf8')
+    req.on('data', (chunk) => (body += chunk))
+    req.on('end', () => {
+      client.close()
+      resolve({status, body})
+    })
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+describe('intermittentServiceErrors', () => {
+  test('faults a request with a 5xx without reaching upstream when probability is 1', async () => {
+    let upstreamHit = false
+    const upstream = await startUpstream((req, res) => {
+      upstreamHit = true
+      res.writeHead(200).end('ok')
+    })
+    cleanups.push(upstream.close)
+
+    const proxy = await startProxy({
+      port: 0,
+      apiHost: upstream.apiHost,
+      tls: {key: pem, cert: pem},
+      insecureUpstream: true,
+      defaultHandler: intermittentServiceErrors(1)(
+        // a handler that, if reached, would proxy upstream — it must not be
+        (_req, _res) => {
+          throw new Error('handler should not run when the request faults')
+        },
+      ),
+    })
+    const port = (proxy.server.address() as AddressInfo).port
+
+    const res = await h2Request(port, '/v1/data/query/test')
+    expect(res.status).toBeGreaterThanOrEqual(500)
+    expect(res.status).toBeLessThan(600)
+    expect([500, 502, 503, 504]).toContain(res.status)
+    expect(JSON.parse(res.body).error.type).toBe('serverError')
+    expect(upstreamHit).toBe(false)
+  })
+
+  test('forwards the request unchanged when probability is 0', async () => {
+    const upstream = await startUpstream((req, res) => {
+      res.writeHead(200, {'content-type': 'application/json'})
+      res.end(JSON.stringify({ok: true}))
+    })
+    cleanups.push(upstream.close)
+
+    const proxy = await startProxy({
+      port: 0,
+      apiHost: upstream.apiHost,
+      tls: {key: pem, cert: pem},
+      insecureUpstream: true,
+    })
+    const port = (proxy.server.address() as AddressInfo).port
+
+    const res = await h2Request(port, '/v1/data/query/test')
+    expect(res.status).toBe(200)
+    expect(JSON.parse(res.body).ok).toBe(true)
+  })
+
+  test('never faults a CORS preflight (OPTIONS), so the real request can proceed', async () => {
+    const upstream = await startUpstream((req, res) => {
+      res.writeHead(204).end()
+    })
+    cleanups.push(upstream.close)
+
+    const proxy = await startProxy({
+      port: 0,
+      apiHost: upstream.apiHost,
+      tls: {key: pem, cert: pem},
+      insecureUpstream: true,
+      // Wrap a real pass-through handler: OPTIONS must skip the fault and reach
+      // upstream (a 204), even though probability is 1.
+      defaultHandler: intermittentServiceErrors(1)(createRequestProxy()),
+    })
+    const port = (proxy.server.address() as AddressInfo).port
+
+    const res = await h2Request(port, '/v1/data/query/test', 'OPTIONS')
+    // OPTIONS is forwarded to the (pass-through) handler, not faulted
+    expect(res.status).toBeLessThan(500)
+  })
+})

--- a/packages/@repo/debug-proxy/src/requestScenarios.ts
+++ b/packages/@repo/debug-proxy/src/requestScenarios.ts
@@ -1,0 +1,77 @@
+import {Subscription} from 'rxjs'
+
+import {type ProxyHandler} from './createDebugProxy'
+import {writeResponseHead} from './proxy'
+
+/** The 5xx status codes a faulted request is randomly assigned. */
+const SERVICE_ERROR_STATUSES = [500, 502, 503, 504] as const
+
+const STATUS_TEXT: Record<number, string> = {
+  500: 'Internal Server Error',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+  504: 'Gateway Timeout',
+}
+
+/**
+ * Wrap a handler so that, with the given probability, a request fails with a
+ * synthetic 5xx response instead of being forwarded upstream — simulating an
+ * incident where endpoints intermittently return various server errors.
+ *
+ * Each faulted request independently picks a status at random from
+ * {@link SERVICE_ERROR_STATUSES} (500/502/503/504). A short JSON body mirrors
+ * the shape of a real Sanity API error so clients parse it the same way. The
+ * upstream is never contacted for a faulted request, so this also exercises
+ * the "request never reached the backend" case.
+ *
+ * `probability` is clamped to [0, 1]; 0 forwards everything (a no-op wrapper).
+ */
+export function intermittentServiceErrors(
+  probability: number,
+): (handler: ProxyHandler) => ProxyHandler {
+  const p = Math.min(1, Math.max(0, probability))
+  return (handler) => {
+    if (p === 0) {
+      return handler
+    }
+    return (req, res, target) => {
+      if (Math.random() >= p) {
+        return handler(req, res, target)
+      }
+      const statusCode =
+        SERVICE_ERROR_STATUSES[Math.floor(Math.random() * SERVICE_ERROR_STATUSES.length)]
+      const statusText = STATUS_TEXT[statusCode] ?? 'Server Error'
+      const body = JSON.stringify({
+        error: {
+          type: 'serverError',
+          statusCode,
+          message: `[debug-proxy] simulated ${statusCode} ${statusText}`,
+        },
+      })
+      // Preflight requests must still succeed or the browser blocks the real
+      // request before our fault can be observed; only fault actual calls.
+      if (req.method === 'OPTIONS') {
+        return handler(req, res, target)
+      }
+      const originHeader = req.headers.origin
+      const origin = Array.isArray(originHeader) ? originHeader[0] : originHeader
+      const corsHeaders =
+        typeof origin === 'string'
+          ? {
+              'access-control-allow-origin': origin,
+              'access-control-allow-credentials': 'true',
+              'vary': 'origin',
+            }
+          : {'access-control-allow-origin': '*'}
+      writeResponseHead(res, statusCode, statusText, {
+        ...corsHeaders,
+        'content-type': 'application/json',
+        'content-length': Buffer.byteLength(body),
+      })
+      res.end(body)
+      // No upstream request was made, so there's nothing to tear down — return
+      // an already-empty subscription to satisfy the ProxyHandler signature.
+      return Subscription.EMPTY
+    }
+  }
+}


### PR DESCRIPTION
### Description
Adds a debug proxy scenario for simulating intermittent 5xx / incident scenario.


### Testing

Can be tested via e.g.:
```sh
pn dev:proxy  --error-probability 0.2
```

### Notes for release
n/a