### PR TITLE
chore(debug-proxy): add token-expiry scenario

### DIFF
--- a/packages/@repo/debug-proxy/README.md
+++ b/packages/@repo/debug-proxy/README.md
@@ -46,6 +46,7 @@ Configuration is via CLI flags (`--help` for the full list):
 - `--flap <on>[:<off>]` — simulate flapping connectivity (online → offline → online → …): proxy normally for `<on>` seconds, then go "offline" for `<off>` seconds, repeating. While offline, new requests are reset at the socket level and live SSE streams are cut, so clients see real network-failure errors rather than HTTP error responses. A single number means equal phases, e.g. `--flap 30:15` or `--flap 20`
 - `--latency <ms>[:<maxMs>]` — delay each request by this many milliseconds before forwarding it upstream, simulating a slow network; a range applies random jitter per request, e.g. `--latency 800` or `--latency 200:1500`
 - `--error-probability <0..1>` — simulate an incident: each request independently fails with a random 5xx (`500`/`502`/`503`/`504`) instead of being forwarded upstream, at this probability. The response carries a JSON body shaped like a real Sanity API error, and the upstream is never contacted (so it also covers the "request never reached the backend" case). CORS preflights (`OPTIONS`) are never faulted, so the real request still gets a chance to fail. e.g. `--error-probability 0.2`
+- `--expire-token <seconds>` — after `<seconds>`, answer every API request with the API's expired-session 401 (`SIO-401-AEX`) instead of forwarding it upstream, simulating a token that expires mid-session. The studio keeps working until the deadline, then sees its session lapse and enters its re-authentication flow. Use `0` to start expired, e.g. `--expire-token 30` or `--expire-token 0`
 - Fault toggles: `--sse-faults`, `--drop-probability`, `--reset-probability`, `--org-401`
 
 Pass flags through pnpm like so:
@@ -130,10 +131,11 @@ Routes are matched in order — the first route whose `match` returns `true` win
 - `createRequestProxy({transformHeaders?, transformBody?})` — the core proxy primitive (RxJS operators over response headers/body).
 - `createSSEProxy(operator?)` — builds on `createRequestProxy` for streaming endpoints; parses the byte stream into discrete `SSEEvent`s.
 - Scenarios (RxJS operators over the SSE event stream): `randomLatency`, `sendReset`, `duplicateMutations`, `dropMutations`, `shuffleEventDelivery`.
+- `expiredToken(handler, isExpired?)` — wraps a handler so that, once `isExpired()` returns true, every request is answered with the API's expired-session 401 instead of being forwarded upstream (CORS preflights always pass through). Pair with a time-based predicate to expire mid-session, or scope it to `isAuthEndpoint()` to fail only the auth probes.
 - `createConnectionFlapper({onlineMs, offlineMs})` — cycles simulated connectivity; `flapper.wrap(handler)` makes any handler's requests fail like a dead network during the offline phases (and cuts in-flight streams on each transition).
 - `withLatency(handler, {minMs, maxMs})` — holds each request back by a random delay in the range before forwarding it upstream.
 - `intermittentServiceErrors(probability)` — wraps a handler so that, with the given probability, a request short-circuits with a synthetic random 5xx response instead of being forwarded upstream (skipping `OPTIONS` preflights). Use it to simulate an incident where endpoints intermittently return various server errors.
-- Route matchers: `urlIncludes`, `isListenEndpoint`, `isGetOrgIdEndpoint`, `anyOf`, `allOf`.
+- Route matchers: `urlIncludes`, `isListenEndpoint`, `isGetOrgIdEndpoint`, `isAuthEndpoint`, `anyOf`, `allOf`.
 
 ## Writing a new scenario
 

--- a/packages/@repo/debug-proxy/src/cli.ts
+++ b/packages/@repo/debug-proxy/src/cli.ts
@@ -19,6 +19,7 @@ import {isGetOrgIdEndpoint, isListenEndpoint} from './routes'
 import {
   dropMutations,
   duplicateMutations,
+  expiredToken,
   randomLatency,
   sendReset,
   shuffleEventDelivery,
@@ -59,6 +60,11 @@ Options:
   --reset-probability <0..1>  probability a reset is sent instead of a mutation
                               (requires --sse-faults; default: 0)
   --org-401                   make the get-org-id endpoint return 401
+  --expire-token <seconds>    after <seconds>, answer every API request with the
+                              API's expired-session 401 (without forwarding
+                              upstream), simulating a token that expires
+                              mid-session. Use 0 to expire immediately, e.g.
+                              --expire-token 30 or --expire-token 0
   -h, --help                  show this help
 
 Environment:
@@ -86,6 +92,7 @@ function parseFlags() {
         'drop-probability': {type: 'string', default: '0'},
         'reset-probability': {type: 'string', default: '0'},
         'org-401': {type: 'boolean', default: false},
+        'expire-token': {type: 'string'},
         'help': {type: 'boolean', short: 'h', default: false},
       },
     }).values
@@ -175,6 +182,10 @@ const ENABLE_SSE_FAULTS = flags['sse-faults']
 const DROPPED_MUTATION_PROBABILITY = probabilityFlag('drop-probability', flags['drop-probability'])
 const RESET_PROBABILITY = probabilityFlag('reset-probability', flags['reset-probability'])
 const FORCE_ORG_401 = flags['org-401']
+const EXPIRE_TOKEN_AFTER_MS =
+  flags['expire-token'] === undefined
+    ? undefined
+    : intFlag('expire-token', flags['expire-token']) * 1000
 const SANITY_TOKEN = process.env.SANITY_TOKEN
 
 if (!SANITY_TOKEN) {
@@ -402,10 +413,22 @@ const flapper = FLAP
 // so a faulted request returns its 5xx immediately rather than after the delay.
 const faultRequests = intermittentServiceErrors(ERROR_PROBABILITY)
 
-// Network-level scenarios applied to every handler: --latency delays each
+// Session-expiry deadline: requests after this wall-clock time get the 401.
+// Computed once at startup; a 0s delay means "already past", i.e. expire now.
+const sessionExpiresAt =
+  EXPIRE_TOKEN_AFTER_MS === undefined ? undefined : Date.now() + EXPIRE_TOKEN_AFTER_MS
+const isSessionExpired = () => sessionExpiresAt !== undefined && Date.now() >= sessionExpiresAt
+
+// Network-level scenarios applied to every handler: --expire-token replaces the
+// response with the API's expired-session 401 once the deadline passes,
+// --error-probability faults requests with a random 5xx, --latency delays each
 // request, --flap sits outside it so offline resets stay immediate.
 const withNetworkScenarios = (handler: ProxyHandler): ProxyHandler => {
-  const faulted = faultRequests(handler)
+  // An expired session would fail at the API for any request, so this wraps the
+  // real handler rather than being scoped to a route.
+  const maybeExpired =
+    EXPIRE_TOKEN_AFTER_MS === undefined ? handler : expiredToken(handler, isSessionExpired)
+  const faulted = faultRequests(maybeExpired)
   const delayed = LATENCY ? withLatency(faulted, LATENCY) : faulted
   return flapper ? flapper.wrap(delayed) : delayed
 }
@@ -469,5 +492,13 @@ if (LATENCY) {
 if (ERROR_PROBABILITY > 0) {
   console.info(
     `Simulated incident: ${Math.round(ERROR_PROBABILITY * 100)}% of requests fail with a random 5xx (500/502/503/504)`,
+  )
+}
+
+if (EXPIRE_TOKEN_AFTER_MS !== undefined) {
+  console.info(
+    EXPIRE_TOKEN_AFTER_MS === 0
+      ? 'Session expiry: every API request returns the expired-session 401'
+      : `Session expiry: API requests return the expired-session 401 after ${EXPIRE_TOKEN_AFTER_MS / 1000}s`,
   )
 }

--- a/packages/@repo/debug-proxy/src/index.ts
+++ b/packages/@repo/debug-proxy/src/index.ts
@@ -25,10 +25,18 @@ export {
   type SSEEvent,
 } from './proxy'
 export {intermittentServiceErrors} from './requestScenarios'
-export {allOf, anyOf, isGetOrgIdEndpoint, isListenEndpoint, urlIncludes} from './routes'
+export {
+  allOf,
+  anyOf,
+  isAuthEndpoint,
+  isGetOrgIdEndpoint,
+  isListenEndpoint,
+  urlIncludes,
+} from './routes'
 export {
   dropMutations,
   duplicateMutations,
+  expiredToken,
   randomLatency,
   sendReset,
   shuffleEventDelivery,

--- a/packages/@repo/debug-proxy/src/routes.ts
+++ b/packages/@repo/debug-proxy/src/routes.ts
@@ -25,6 +25,16 @@ export function isGetOrgIdEndpoint(): RouteMatcher {
   return urlIncludes('get-org-id')
 }
 
+/**
+ * Match the endpoints the studio uses to establish/refresh auth state: the
+ * `/users/me` probe that decides whether the session is valid, and the
+ * `/auth/*` family (id/fetch/logout). Forcing these to 401 simulates an
+ * expired token (see {@link expiredToken}).
+ */
+export function isAuthEndpoint(): RouteMatcher {
+  return anyOf(urlIncludes('/users/me'), urlIncludes('/auth/'))
+}
+
 /** Combine matchers with logical OR. */
 export function anyOf(...matchers: RouteMatcher[]): RouteMatcher {
   return (req) => matchers.some((m) => m(req))

--- a/packages/@repo/debug-proxy/src/scenarios.test.ts
+++ b/packages/@repo/debug-proxy/src/scenarios.test.ts
@@ -1,8 +1,14 @@
 import {firstValueFrom, from, toArray} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
-import {type Message} from './proxy'
-import {dropMutations, duplicateMutations, randomLatency, sendReset} from './scenarios'
+import {type Message, type ProxyRequest, type ProxyResponse} from './proxy'
+import {
+  dropMutations,
+  duplicateMutations,
+  expiredToken,
+  randomLatency,
+  sendReset,
+} from './scenarios'
 
 function mutation(id: string): Message {
   return {type: 'message', message: {event: 'mutation', id, data: '{}'}}
@@ -42,6 +48,78 @@ describe('sendReset', () => {
     expect(out[1]?.message.event).toBe('reset')
     // preserves the original event id
     expect(out[1]?.message.id).toBe('a')
+  })
+})
+
+type FakeRes = {head?: {status: number; headers: Record<string, unknown>}; body?: string}
+
+function fakeReq(method: string, origin?: string): ProxyRequest {
+  return {method, headers: origin ? {origin} : {}} as unknown as ProxyRequest
+}
+
+function fakeRes(): {res: ProxyResponse; captured: FakeRes} {
+  const captured: FakeRes = {}
+  const res = {
+    writeHead: (status: number, _statusText: string, headers: Record<string, unknown>) => {
+      captured.head = {status, headers}
+    },
+    end: (body?: string) => {
+      captured.body = body
+    },
+  }
+  return {res: res as unknown as ProxyResponse, captured}
+}
+
+describe('expiredToken', () => {
+  const target = {url: new URL('https://example.localhost/v1/users/me')}
+
+  test('returns the expired-session 401 once expired, without calling upstream', () => {
+    let forwarded = false
+    const handler = expiredToken(
+      () => {
+        forwarded = true
+        return {unsubscribe: () => {}} as never
+      },
+      () => true,
+    )
+
+    const {res, captured} = fakeRes()
+    handler(fakeReq('GET'), res, target)
+
+    expect(forwarded).toBe(false)
+    expect(captured.head?.status).toBe(401)
+    expect(JSON.parse(captured.body ?? '{}')).toMatchObject({
+      statusCode: 401,
+      errorCode: 'SIO-401-AEX',
+    })
+  })
+
+  test('forwards to the wrapped handler while not yet expired', () => {
+    let forwarded = false
+    const handler = expiredToken(
+      () => {
+        forwarded = true
+        return {unsubscribe: () => {}} as never
+      },
+      () => false,
+    )
+
+    handler(fakeReq('GET'), fakeRes().res, target)
+    expect(forwarded).toBe(true)
+  })
+
+  test('always forwards CORS preflights so the browser can read the 401', () => {
+    let forwarded = false
+    const handler = expiredToken(
+      () => {
+        forwarded = true
+        return {unsubscribe: () => {}} as never
+      },
+      () => true,
+    )
+
+    handler(fakeReq('OPTIONS', 'https://app.localhost'), fakeRes().res, target)
+    expect(forwarded).toBe(true)
   })
 })
 

--- a/packages/@repo/debug-proxy/src/scenarios.ts
+++ b/packages/@repo/debug-proxy/src/scenarios.ts
@@ -8,9 +8,11 @@ import {
   type MonoTypeOperatorFunction,
   of,
   pipe,
+  Subscription,
 } from 'rxjs'
 
-import {type SSEEvent} from './proxy'
+import {type ProxyHandler} from './createDebugProxy'
+import {type SSEEvent, writeResponseHead} from './proxy'
 
 /**
  * Delay each event by a random duration in [min, max] ms. Uses `mergeMap` so
@@ -78,4 +80,43 @@ export function shuffleEventDelivery<T extends SSEEvent>(
       return [...welcome, ...shuffle(rest)]
     }),
   )
+}
+
+/** The body the API returns when a session token has expired. */
+const EXPIRED_SESSION_BODY = JSON.stringify({
+  error: 'Unauthorized',
+  statusCode: 401,
+  message: 'Session is expired, please re-authenticate',
+  errorCode: 'SIO-401-AEX',
+})
+
+/**
+ * Wrap a handler so that, once the session is considered expired, every request
+ * is answered with the API's expired-session 401 instead of being forwarded
+ * upstream — the real token is still valid, so there is no upstream response to
+ * rewrite. This simulates a token that expires mid-session: the studio keeps
+ * working until `isExpired()` flips, then sees its session lapse and should
+ * enter its re-authentication flow.
+ *
+ * `isExpired` is evaluated per request, so a time-based deadline expires the
+ * session live without restarting the proxy (pass `() => true` to start
+ * expired). CORS preflights (OPTIONS) always pass through so the browser can
+ * actually read the 401 once it fires.
+ */
+export function expiredToken(
+  handler: ProxyHandler,
+  isExpired: () => boolean = () => true,
+): ProxyHandler {
+  return (req, res, target) => {
+    if (req.method === 'OPTIONS' || !isExpired()) {
+      return handler(req, res, target)
+    }
+    writeResponseHead(res, 401, 'Unauthorized', {
+      'content-type': 'application/json',
+      'access-control-allow-origin': req.headers.origin ?? '*',
+      'access-control-allow-credentials': 'true',
+    })
+    res.end(EXPIRED_SESSION_BODY)
+    return new Subscription()
+  }
 }


### PR DESCRIPTION
### Description

Adds a [debug-proxy](https://github.com/sanity-io/sanity/tree/main/packages/%40repo/debug-proxy) scenario for session/token expiry

Usage:
```
pn dev:proxy --expire-token <seconds>
```
Also adds an api level `expiredToken()` handler that returns the API's expired-session 401 after a deadline.

### What to review

### Testing

Test manually via e.g.:

```sh
pn dev:proxy --expire-token 30
```

### Notes for release
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the internal dev-only debug-proxy package; no production Studio or API auth code is modified.
> 
> **Overview**
> Adds a **session expiry** fault mode to the local `@repo/debug-proxy` so you can exercise Studio re-auth when a token lapses mid-session.
> 
> New **`expiredToken(handler, isExpired?)`** wraps any handler: after `isExpired()` is true, non-`OPTIONS` requests get a synthetic **401** with the real API shape (`SIO-401-AEX`) and never hit upstream. The CLI flag **`--expire-token <seconds>`** sets a wall-clock deadline from startup (`0` = expired immediately); it is applied globally in `withNetworkScenarios`, before intermittent 5xx and latency.
> 
> Also exports **`isAuthEndpoint()`** (`/users/me`, `/auth/*`) for library setups that only want auth probes to fail, plus unit tests for the handler and README/help text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 895bba701c4b99fc3763f4a990d93afec35871ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->