### PR TITLE
feat(portable-text): compose PTE Containers with existing Studio PTE UI

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -399,6 +399,7 @@
                 "animate",
                 "closed",
                 "documentType",
+                "edge",
                 "exit",
                 "fill",
                 "full",

--- a/dev/test-studio/schema/standard/portableText/customPlugins.tsx
+++ b/dev/test-studio/schema/standard/portableText/customPlugins.tsx
@@ -1,13 +1,260 @@
-import {defineBehavior, effect, forward} from '@portabletext/editor/behaviors'
-import {BehaviorPlugin} from '@portabletext/editor/plugins'
+import {defineContainer} from '@portabletext/editor'
+import {defineBehavior, effect, forward, raise} from '@portabletext/editor/behaviors'
+import {BehaviorPlugin, NodePlugin} from '@portabletext/editor/plugins'
 import {CharacterPairDecoratorPlugin} from '@portabletext/plugin-character-pair-decorator'
-import {defineArrayMember, defineType} from 'sanity'
+import {defineArrayMember, defineField, defineType, type PortableTextPluginsProps} from 'sanity'
+
+const CONTAINER_NODES = [
+  defineContainer({
+    type: 'table',
+    arrayField: 'rows',
+    render: ({children, attributes}) => (
+      <table {...attributes} style={{borderCollapse: 'collapse'}}>
+        <tbody>{children}</tbody>
+      </table>
+    ),
+    of: [
+      defineContainer({
+        type: 'row',
+        arrayField: 'cells',
+        render: ({children, attributes}) => <tr {...attributes}>{children}</tr>,
+        of: [
+          defineContainer({
+            type: 'cell',
+            arrayField: 'content',
+            render: ({children, attributes}) => (
+              <td {...attributes} style={{border: '1px solid #ccc', padding: '4px 8px'}}>
+                {children}
+              </td>
+            ),
+          }),
+        ],
+      }),
+    ],
+  }),
+  defineContainer({
+    type: 'codeBlock',
+    arrayField: 'code',
+    render: ({children, attributes}) => (
+      <pre
+        {...attributes}
+        style={{
+          background: '#f6f6f6',
+          border: '1px solid #ddd',
+          borderRadius: 4,
+          padding: '8px 12px',
+          fontFamily: 'monospace',
+          whiteSpace: 'pre-wrap',
+        }}
+      >
+        {children}
+      </pre>
+    ),
+  }),
+]
+
+// Keys come from the editor's own `keyGenerator` (off the behavior snapshot)
+// so they honour any configured generator.
+function emptyTextBlock(keyGenerator: () => string) {
+  return {
+    _key: keyGenerator(),
+    _type: 'block',
+    style: 'normal',
+    markDefs: [],
+    children: [{_key: keyGenerator(), _type: 'span', text: '', marks: []}],
+  }
+}
+
+function emptyTableCell(keyGenerator: () => string) {
+  return {
+    _key: keyGenerator(),
+    _type: 'cell',
+    content: [emptyTextBlock(keyGenerator)],
+  }
+}
+
+function emptyTableRow(keyGenerator: () => string) {
+  return {
+    _key: keyGenerator(),
+    _type: 'row',
+    cells: [
+      emptyTableCell(keyGenerator),
+      emptyTableCell(keyGenerator),
+      emptyTableCell(keyGenerator),
+    ],
+  }
+}
+
+// The guard skips containers that already have content, which also stops the
+// raise below from re-triggering.
+const containerScaffoldBehaviors = [
+  defineBehavior({
+    on: 'insert.block',
+    guard: ({event}) => {
+      if (event.block._type !== 'table') {
+        return false
+      }
+      const rows = 'rows' in event.block ? event.block.rows : undefined
+      return !(Array.isArray(rows) && rows.length > 0)
+    },
+    actions: [
+      ({event, snapshot}) => [
+        raise({
+          ...event,
+          block: {
+            ...event.block,
+            rows: [
+              emptyTableRow(snapshot.context.keyGenerator),
+              emptyTableRow(snapshot.context.keyGenerator),
+              emptyTableRow(snapshot.context.keyGenerator),
+            ],
+          },
+        }),
+      ],
+    ],
+  }),
+  defineBehavior({
+    on: 'insert.block',
+    guard: ({event}) => {
+      if (event.block._type !== 'codeBlock') {
+        return false
+      }
+      const code = 'code' in event.block ? event.block.code : undefined
+      return !(Array.isArray(code) && code.length > 0)
+    },
+    actions: [
+      ({event, snapshot}) => [
+        raise({
+          ...event,
+          block: {
+            ...event.block,
+            code: [emptyTextBlock(snapshot.context.keyGenerator)],
+          },
+        }),
+      ],
+    ],
+  }),
+]
+
+function ContainerPlugins(props: PortableTextPluginsProps) {
+  return (
+    <>
+      {props.renderDefault(props)}
+      <NodePlugin nodes={CONTAINER_NODES} />
+      <BehaviorPlugin behaviors={containerScaffoldBehaviors} />
+    </>
+  )
+}
 
 export const customPlugins = defineType({
   name: 'customPlugins',
   title: 'Custom Plugins',
   type: 'document',
   fields: [
+    {
+      type: 'array',
+      name: 'containerTable',
+      title: 'Container Table',
+      description:
+        'A defineContainer table (table > row > cell). Images and text blocks live at the root and inside cells. The field enables container support.',
+      of: [
+        defineArrayMember({
+          type: 'block',
+          of: [
+            defineArrayMember({
+              type: 'object',
+              name: 'inlineNote',
+              title: 'Inline note',
+              fields: [defineField({type: 'string', name: 'text', title: 'Text'})],
+              preview: {select: {title: 'text'}},
+            }),
+          ],
+        }),
+        defineArrayMember({
+          type: 'image',
+          options: {hotspot: true},
+          fields: [defineField({name: 'alt', type: 'string', title: 'Alternative text'})],
+        }),
+        defineArrayMember({
+          type: 'object',
+          name: 'table',
+          fields: [
+            defineField({
+              type: 'array',
+              name: 'rows',
+              of: [
+                defineArrayMember({
+                  type: 'object',
+                  name: 'row',
+                  fields: [
+                    defineField({
+                      type: 'array',
+                      name: 'cells',
+                      of: [
+                        defineArrayMember({
+                          type: 'object',
+                          name: 'cell',
+                          fields: [
+                            defineField({
+                              type: 'array',
+                              name: 'content',
+                              of: [
+                                defineArrayMember({
+                                  type: 'block',
+                                  of: [
+                                    defineArrayMember({
+                                      type: 'object',
+                                      name: 'inlineNote',
+                                      title: 'Inline note',
+                                      fields: [
+                                        defineField({type: 'string', name: 'text', title: 'Text'}),
+                                      ],
+                                      preview: {select: {title: 'text'}},
+                                    }),
+                                  ],
+                                }),
+                                defineArrayMember({
+                                  type: 'image',
+                                  options: {hotspot: true},
+                                  fields: [
+                                    defineField({
+                                      name: 'alt',
+                                      type: 'string',
+                                      title: 'Alternative text',
+                                    }),
+                                  ],
+                                }),
+                              ],
+                            }),
+                          ],
+                        }),
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ],
+        }),
+        defineArrayMember({
+          type: 'object',
+          name: 'codeBlock',
+          title: 'Code block',
+          fields: [
+            defineField({
+              type: 'array',
+              name: 'code',
+              of: [defineArrayMember({type: 'block', marks: {decorators: []}})],
+            }),
+          ],
+        }),
+      ],
+      components: {
+        portableText: {
+          plugins: ContainerPlugins,
+        },
+      },
+    },
     {
       type: 'string',
       name: 'title',

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -144,6 +144,8 @@
     "@portabletext/editor": "^7.8.1",
     "@portabletext/html": "^1.1.0",
     "@portabletext/patches": "^2.0.5",
+    "@portabletext/plugin-dnd": "^1.0.1",
+    "@portabletext/plugin-list-index": "^1.0.4",
     "@portabletext/plugin-markdown-shortcuts": "^8.0.24",
     "@portabletext/plugin-one-line": "^7.0.24",
     "@portabletext/plugin-paste-link": "^4.0.24",

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -1,15 +1,28 @@
 import {
   type BlockAnnotationRenderProps,
-  type BlockChildRenderProps as EditorChildRenderProps,
-  type BlockRenderProps as EditorBlockRenderProps,
+  type BlockObjectRenderProps,
+  defineBlockObject,
+  defineInlineObject,
+  defineTextBlock,
   type EditorSelection,
   type HotkeyOptions,
+  type InlineObjectRenderProps,
   type OnCopyFn,
   type OnPasteFn as EditorOnPasteFn,
   type PasteData as EditorPasteData,
   type RangeDecoration,
+  type RegistrableNode,
+  type TextBlockRenderProps,
 } from '@portabletext/editor'
-import {type Path, type PortableTextBlock, type PortableTextTextBlock} from '@sanity/types'
+import {NodePlugin} from '@portabletext/editor/plugins'
+import {DndProvider, useDropPosition} from '@portabletext/plugin-dnd'
+import {ListIndexProvider, useListIndex} from '@portabletext/plugin-list-index'
+import {
+  type ObjectSchemaType,
+  type Path,
+  type PortableTextBlock,
+  type PortableTextTextBlock,
+} from '@sanity/types'
 import {
   BoundaryElementProvider,
   Box,
@@ -41,6 +54,8 @@ import {CombinedAnnotationPopover} from './object/CombinedAnnotationPopover'
 import {InlineObject} from './object/InlineObject'
 import {AnnotationObjectEditModal} from './object/modals/AnnotationObjectEditModal'
 import {TextBlock} from './text'
+import {ListItem} from './text/ListItem'
+import {Style} from './text/Style'
 
 interface InputProps extends ArrayOfObjectsInputProps<PortableTextBlock> {
   elementRef: React.RefObject<HTMLDivElement | null>
@@ -144,39 +159,60 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
   const [portalElement, setPortalElement] = useState<HTMLDivElement | null>(null)
 
   const renderTextBlock = useCallback(
-    (blockProps: EditorBlockRenderProps) => {
-      const {children, focused: blockFocused, path: blockPath, selected, value: block} = blockProps
+    (textBlockProps: TextBlockRenderProps) => {
+      const {attributes, focused: blockFocused, node, path: blockPath, selected} = textBlockProps
+      const block = node
       const fullyQualifiedPath = path.concat(blockPath)
+      let inner = textBlockProps.children
+      if (block.style !== undefined) {
+        inner = (
+          <Style block={block} focused={blockFocused} selected={selected}>
+            {inner}
+          </Style>
+        )
+      }
+      if (block.listItem !== undefined) {
+        inner = (
+          <ListItem block={block} focused={blockFocused} selected={selected}>
+            {inner}
+          </ListItem>
+        )
+      }
 
       return (
-        <TextBlock
-          floatingBoundary={floatingBoundary}
-          focused={blockFocused}
-          isFullscreen={isFullscreen}
-          onItemClose={onItemClose}
-          onItemOpen={onItemOpen}
-          onItemRemove={onItemRemove}
-          onPathFocus={onPathFocus}
-          path={path.concat(blockPath)}
-          readOnly={readOnly}
-          referenceBoundary={scrollElement}
-          renderAnnotation={renderAnnotation}
-          renderField={renderField}
-          renderInlineBlock={renderInlineBlock}
-          renderInput={renderInput}
-          renderItem={renderItem}
-          renderBlockActions={_renderBlockActions}
-          renderCustomMarkers={_renderCustomMarkers}
-          renderPreview={renderPreview}
-          renderBlock={renderBlock}
-          schemaType={schemaTypes.block}
-          selected={selected}
-          setElementRef={setElementRef}
-          value={block as PortableTextTextBlock}
-          anchorIdent={pathToAnchorIdent('input', fullyQualifiedPath)}
-        >
-          {children}
-        </TextBlock>
+        <TextBlockShell attributes={attributes} block={block} path={blockPath}>
+          <BlockDropIndicator path={blockPath} edge="start" />
+          <TextBlock
+            floatingBoundary={floatingBoundary}
+            focused={blockFocused}
+            isFullscreen={isFullscreen}
+            onItemClose={onItemClose}
+            onItemOpen={onItemOpen}
+            onItemRemove={onItemRemove}
+            onPathFocus={onPathFocus}
+            path={fullyQualifiedPath}
+            readOnly={readOnly}
+            referenceBoundary={scrollElement}
+            renderAnnotation={renderAnnotation}
+            renderField={renderField}
+            renderInlineBlock={renderInlineBlock}
+            renderInput={renderInput}
+            renderItem={renderItem}
+            renderBlockActions={_renderBlockActions}
+            renderCustomMarkers={_renderCustomMarkers}
+            renderPreview={renderPreview}
+            renderBlock={renderBlock}
+            schemaType={schemaTypes.block}
+            selected={selected}
+            setElementRef={setElementRef}
+            value={block}
+            anchorIdent={pathToAnchorIdent('input', fullyQualifiedPath)}
+            relativePath={blockPath}
+          >
+            {inner}
+          </TextBlock>
+          <BlockDropIndicator path={blockPath} edge="end" />
+        </TextBlockShell>
       )
     },
     [
@@ -203,51 +239,51 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     ],
   )
 
-  const renderObjectBlock = useCallback(
-    (blockProps: EditorBlockRenderProps) => {
-      const {
-        focused: blockFocused,
-        path: blockPath,
-        selected: blockSelected,
-        schemaType: blockSchemaType,
-        value: blockValue,
-      } = blockProps
-      const sanitySchemaType = schemaTypes.blockObjects.find(
-        (type) => type.name === blockSchemaType.name,
+  const renderBlockObject = useCallback(
+    (blockProps: BlockObjectRenderProps) => {
+      const {attributes, focused: blockFocused, node, path: blockPath, selected} = blockProps
+      const sanitySchemaType: ObjectSchemaType | undefined = schemaTypes.blockObjects.find(
+        (type) => type.name === node._type,
       )
       if (!sanitySchemaType) {
-        // This should never happen
-        throw new Error(
-          `Could not find Sanity schema type for block object: ${blockSchemaType.name}`,
-        )
+        // `schemaTypes.blockObjects` lists only the array's top-level object
+        // types, so a type defined deeper (e.g. inside a container) isn't here.
+        throw new Error(`Could not find Sanity schema type for block object: ${node._type}`)
       }
       return (
-        <BlockObject
-          floatingBoundary={floatingBoundary}
-          focused={blockFocused}
-          isFullscreen={isFullscreen}
-          onItemClose={onItemClose}
-          onItemOpen={onItemOpen}
-          onItemRemove={onItemRemove}
-          onPathFocus={onPathFocus}
-          path={path.concat(blockPath)}
-          readOnly={readOnly}
-          referenceBoundary={scrollElement}
-          relativePath={blockPath}
-          renderAnnotation={renderAnnotation}
-          renderBlock={renderBlock}
-          renderBlockActions={_renderBlockActions}
-          renderCustomMarkers={_renderCustomMarkers}
-          renderField={renderField}
-          renderInlineBlock={renderInlineBlock}
-          renderInput={renderInput}
-          renderItem={renderItem}
-          renderPreview={renderPreview}
-          schemaType={sanitySchemaType}
-          selected={blockSelected}
-          setElementRef={setElementRef}
-          value={blockValue}
-        />
+        <div {...attributes}>
+          <BlockDropIndicator path={blockPath} edge="start" />
+          {blockProps.children}
+          <div contentEditable={false} draggable={!readOnly}>
+            <BlockObject
+              floatingBoundary={floatingBoundary}
+              focused={blockFocused}
+              isFullscreen={isFullscreen}
+              onItemClose={onItemClose}
+              onItemOpen={onItemOpen}
+              onItemRemove={onItemRemove}
+              onPathFocus={onPathFocus}
+              path={path.concat(blockPath)}
+              readOnly={readOnly}
+              referenceBoundary={scrollElement}
+              relativePath={blockPath}
+              renderAnnotation={renderAnnotation}
+              renderBlock={renderBlock}
+              renderBlockActions={_renderBlockActions}
+              renderCustomMarkers={_renderCustomMarkers}
+              renderField={renderField}
+              renderInlineBlock={renderInlineBlock}
+              renderInput={renderInput}
+              renderItem={renderItem}
+              renderPreview={renderPreview}
+              schemaType={sanitySchemaType}
+              selected={selected}
+              setElementRef={setElementRef}
+              value={node}
+            />
+          </div>
+          <BlockDropIndicator path={blockPath} edge="end" />
+        </div>
       )
     },
     [
@@ -274,71 +310,49 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     ],
   )
 
-  // This is the function that is sent to PortableTextEditor's renderBlock callback
-  const editorRenderBlock = useCallback(
-    (blockProps: EditorBlockRenderProps) => {
-      const {value: block} = blockProps
-      const isTextBlock = block._type === schemaTypes.block.name
-      if (isTextBlock) {
-        return renderTextBlock(blockProps)
-      }
-      return renderObjectBlock(blockProps)
-    },
-    [schemaTypes.block.name, renderObjectBlock, renderTextBlock],
-  )
-
-  // This is the function that is sent to PortableTextEditor's renderChild callback
-  const editorRenderChild = useCallback(
-    (childProps: EditorChildRenderProps) => {
-      const {
-        children,
-        focused: childFocused,
-        path: childPath,
-        selected,
-        schemaType: childSchemaType,
-        value: child,
-      } = childProps
-      const isSpan = child._type === schemaTypes.span.name
-      if (isSpan) {
-        return children
-      }
-      const sanitySchemaType = schemaTypes.inlineObjects.find(
-        (type) => type.name === childSchemaType.name,
+  const renderInlineObject = useCallback(
+    (childProps: InlineObjectRenderProps) => {
+      const {attributes, focused: childFocused, node, path: childPath, selected} = childProps
+      const sanitySchemaType: ObjectSchemaType | undefined = schemaTypes.inlineObjects.find(
+        (type) => type.name === node._type,
       )
       if (!sanitySchemaType) {
-        // This should never happen
-        throw new Error(
-          `Could not find Sanity schema type for inline object: ${childSchemaType.name}`,
-        )
+        // `schemaTypes.inlineObjects` lists only the array's top-level inline
+        // types, so a type defined deeper (e.g. inside a container) isn't here.
+        throw new Error(`Could not find Sanity schema type for inline object: ${node._type}`)
       }
       return (
-        <InlineObject
-          floatingBoundary={floatingBoundary}
-          focused={childFocused}
-          onItemClose={onItemClose}
-          onItemOpen={onItemOpen}
-          onPathFocus={onPathFocus}
-          path={path.concat(childPath)}
-          readOnly={readOnly}
-          referenceBoundary={scrollElement}
-          relativePath={childPath}
-          renderAnnotation={renderAnnotation}
-          renderBlock={renderBlock}
-          renderCustomMarkers={renderCustomMarkers}
-          renderField={renderField}
-          renderInlineBlock={renderInlineBlock}
-          renderInput={renderInput}
-          renderItem={renderItem}
-          renderPreview={renderPreview}
-          schemaType={sanitySchemaType}
-          selected={selected}
-          setElementRef={setElementRef}
-          value={child}
-        />
+        <span {...attributes}>
+          {childProps.children}
+          <span draggable={!readOnly} style={{display: 'inline-block'}}>
+            <InlineObject
+              floatingBoundary={floatingBoundary}
+              focused={childFocused}
+              onItemClose={onItemClose}
+              onItemOpen={onItemOpen}
+              onPathFocus={onPathFocus}
+              path={path.concat(childPath)}
+              readOnly={readOnly}
+              referenceBoundary={scrollElement}
+              relativePath={childPath}
+              renderAnnotation={renderAnnotation}
+              renderBlock={renderBlock}
+              renderCustomMarkers={renderCustomMarkers}
+              renderField={renderField}
+              renderInlineBlock={renderInlineBlock}
+              renderInput={renderInput}
+              renderItem={renderItem}
+              renderPreview={renderPreview}
+              schemaType={sanitySchemaType}
+              selected={selected}
+              setElementRef={setElementRef}
+              value={node}
+            />
+          </span>
+        </span>
       )
     },
     [
-      schemaTypes.span.name,
       schemaTypes.inlineObjects,
       floatingBoundary,
       onItemClose,
@@ -357,6 +371,17 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       renderPreview,
       setElementRef,
     ],
+  )
+
+  // Stable reference: `NodePlugin` re-runs its registration effect when
+  // `nodes` changes by reference.
+  const catchAllNodes = useMemo<RegistrableNode[]>(
+    () => [
+      defineTextBlock({type: '*', render: renderTextBlock}),
+      defineBlockObject({type: '*', render: renderBlockObject}),
+      defineInlineObject({type: '*', render: renderInlineObject}),
+    ],
+    [renderTextBlock, renderBlockObject, renderInlineObject],
   )
 
   const editorRenderAnnotation = useCallback(
@@ -482,8 +507,6 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
             rangeDecorations={rangeDecorations}
             readOnly={readOnly}
             renderAnnotation={editorRenderAnnotation}
-            renderBlock={editorRenderBlock}
-            renderChild={editorRenderChild}
             setPortalElement={setPortalElement}
             scrollElement={scrollElement}
             setScrollElement={setScrollElement}
@@ -514,8 +537,6 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       path,
       rangeDecorations,
       editorRenderAnnotation,
-      editorRenderBlock,
-      editorRenderChild,
       scrollElement,
     ],
   )
@@ -546,36 +567,95 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
 
   return (
     <SelectedAnnotationsProvider>
-      <PortalProvider __unstable_elements={portalElements} element={portal.element}>
-        <BoundaryElementProvider element={floatingBoundary}>
-          <ActivateOnFocus onActivate={onActivate} isOverlayActive={!isActive}>
-            <ChangeIndicator
-              disabled={isFullscreen}
-              hasFocus={Boolean(focused)}
-              isChanged={changed}
-              path={path}
-            >
-              <Root
-                data-focused={editorFocused ? '' : undefined}
-                data-read-only={readOnly ? '' : undefined}
-              >
-                <Box data-wrapper="" ref={setWrapperElement}>
-                  <Portal __unstable_name={isFullscreen ? 'expanded' : 'collapsed'}>
-                    {isFullscreen ? <ExpandedLayer>{editorNode}</ExpandedLayer> : editorNode}
-                    <AnnotationObjectEditModal
-                      focused={focused}
-                      onItemClose={onItemClose}
-                      referenceBoundary={scrollElement}
-                    />
-                    <CombinedAnnotationPopover referenceBoundary={scrollElement} />
-                  </Portal>
-                </Box>
-                <div data-border="" />
-              </Root>
-            </ChangeIndicator>
-          </ActivateOnFocus>
-        </BoundaryElementProvider>
-      </PortalProvider>
+      <DndProvider>
+        <ListIndexProvider>
+          <NodePlugin nodes={catchAllNodes} />
+          <PortalProvider __unstable_elements={portalElements} element={portal.element}>
+            <BoundaryElementProvider element={floatingBoundary}>
+              <ActivateOnFocus onActivate={onActivate} isOverlayActive={!isActive}>
+                <ChangeIndicator
+                  disabled={isFullscreen}
+                  hasFocus={Boolean(focused)}
+                  isChanged={changed}
+                  path={path}
+                >
+                  <Root
+                    data-focused={editorFocused ? '' : undefined}
+                    data-read-only={readOnly ? '' : undefined}
+                  >
+                    <Box data-wrapper="" ref={setWrapperElement}>
+                      <Portal __unstable_name={isFullscreen ? 'expanded' : 'collapsed'}>
+                        {isFullscreen ? <ExpandedLayer>{editorNode}</ExpandedLayer> : editorNode}
+                        <AnnotationObjectEditModal
+                          focused={focused}
+                          onItemClose={onItemClose}
+                          referenceBoundary={scrollElement}
+                        />
+                        <CombinedAnnotationPopover referenceBoundary={scrollElement} />
+                      </Portal>
+                    </Box>
+                    <div data-border="" />
+                  </Root>
+                </ChangeIndicator>
+              </ActivateOnFocus>
+            </BoundaryElementProvider>
+          </PortalProvider>
+        </ListIndexProvider>
+      </DndProvider>
     </SelectedAnnotationsProvider>
+  )
+}
+
+function DropIndicator() {
+  return (
+    <div
+      className="pt-drop-indicator"
+      contentEditable={false}
+      style={{
+        position: 'absolute',
+        width: '100%',
+        height: 1,
+        borderBottom: '1px solid currentColor',
+        zIndex: 5,
+      }}
+    >
+      <span />
+    </div>
+  )
+}
+
+function BlockDropIndicator(props: {path: Path; edge: 'start' | 'end'}) {
+  const dropPosition = useDropPosition(props.path)
+  return dropPosition === props.edge ? <DropIndicator /> : null
+}
+
+// Reproduces the list classes and `data-level`/`data-list-index` the engine's
+// own text-block render emits: Studio's CSS keys ordered-list numbering off
+// `[data-level][data-list-index]` and inter-item spacing off `.pt-list-item*`.
+// `data-list-index` comes from `useListIndex`; the new pipeline doesn't expose
+// the engine's list-index map.
+function TextBlockShell(props: {
+  attributes: TextBlockRenderProps['attributes']
+  block: PortableTextTextBlock
+  children: ReactNode
+  path: Path
+}) {
+  const {attributes, block, children, path: blockPath} = props
+  const listIndex = useListIndex(blockPath)
+  // `level` is optional even on list items; default it to 1 so `data-level` is
+  // always present for `Editor.styles`' `[data-level][data-list-index]`
+  // ordered-list counter.
+  const level = block.listItem !== undefined ? (block.level ?? 1) : block.level
+  return (
+    <div
+      {...attributes}
+      className={
+        block.listItem !== undefined ? `pt-list-item pt-list-item-${block.listItem}` : undefined
+      }
+      {...(level !== undefined ? {'data-level': level} : {})}
+      {...(listIndex !== undefined ? {'data-list-index': listIndex} : {})}
+    >
+      {children}
+    </div>
   )
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.styles.tsx
@@ -126,6 +126,20 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $isOneLine:
       max-width: ${(props) => getTheme_v2(props.theme).container[1]}px;
     }
 
+    /* Container nodes are consumer-rendered and miss the inner-padding gutter
+     * the text-block/object components apply. Padding a container is unreliable
+     * (a table ignores it for cell layout), so narrow the box via max-width
+     * minus the gutter on both sides instead, centred by the margin auto above. */
+    & > [data-pt-block='container'] {
+      width: calc(
+        100% - ${({$isFullscreen, theme}) => 2 * theme.sanity.space[$isFullscreen ? 5 : 3]}px
+      );
+      max-width: calc(
+        ${(props) => getTheme_v2(props.theme).container[1]}px -
+          ${({$isFullscreen, theme}) => 2 * theme.sanity.space[$isFullscreen ? 5 : 3]}px
+      );
+    }
+
     & .pt-drop-indicator {
       pointer-events: none;
       border: 1px solid var(--card-focus-ring-color) !important;
@@ -148,6 +162,19 @@ export const EditableWrapper = styled(Card)<{$isFullscreen: boolean; $isOneLine:
             $isFullscreen ? rem(theme.sanity.space[5] * 2) : rem(theme.sanity.space[3] * 2)} +
           2px
       ) !important;
+    }
+
+    /* A block nested in a container is its own positioning context, so its drop
+       indicator sizes to the block (the cell) instead of escaping to the
+       container, and spans the full width: the container owns the gutter. */
+    & [data-pt-block] [data-pt-block] {
+      position: relative;
+    }
+
+    & [data-pt-block] [data-pt-block] .pt-drop-indicator {
+      left: 0;
+      right: 0;
+      width: 100% !important;
     }
   }
 `

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -1,7 +1,5 @@
 import {
   type BlockDecoratorRenderProps,
-  type BlockListItemRenderProps,
-  type BlockStyleRenderProps,
   type EditorSelection,
   type HotkeyOptions,
   type OnCopyFn,
@@ -10,8 +8,6 @@ import {
   type PortableTextEditableProps,
   type RangeDecoration,
   type RenderAnnotationFunction,
-  type RenderBlockFunction,
-  type RenderChildFunction,
 } from '@portabletext/editor'
 import {type Path} from '@sanity/types'
 import {BoundaryElementProvider, useBoundaryElement, useGlobalKeyDown, useLayer} from '@sanity/ui'
@@ -26,8 +22,6 @@ import {EditableCard, EditableWrapper, Root, Scroller, ToolbarCard} from './Edit
 import {useScrollSelectionIntoView} from './hooks/useScrollSelectionIntoView'
 import {useSpellCheck} from './hooks/useSpellCheck'
 import {Decorator} from './text'
-import {ListItem} from './text/ListItem'
-import {Style} from './text/Style'
 import {Toolbar} from './toolbar'
 
 const noOutlineStyle = {outline: 'none'} as const
@@ -59,8 +53,6 @@ interface EditorProps {
   readOnly?: boolean
   rangeDecorations?: RangeDecoration[]
   renderAnnotation: RenderAnnotationFunction
-  renderBlock: RenderBlockFunction
-  renderChild: RenderChildFunction
   scrollElement: HTMLElement | null
   setPortalElement?: (portalElement: HTMLDivElement | null) => void
   setScrollElement: (scrollElement: HTMLElement | null) => void
@@ -87,8 +79,6 @@ export function Editor(props: EditorProps): ReactNode {
     readOnly,
     rangeDecorations,
     renderAnnotation,
-    renderBlock,
-    renderChild,
     scrollElement,
     setPortalElement,
     setScrollElement,
@@ -129,14 +119,6 @@ export function Editor(props: EditorProps): ReactNode {
     return <Decorator {...decoratorProps} />
   }, [])
 
-  const renderStyle = useCallback((styleProps: BlockStyleRenderProps) => {
-    return <Style {...styleProps} />
-  }, [])
-
-  const renderListItem = useCallback((listItemProps: BlockListItemRenderProps) => {
-    return <ListItem {...listItemProps} />
-  }, [])
-
   const scrollSelectionIntoView = useScrollSelectionIntoView(scrollElement)
 
   const editable = useMemo(() => {
@@ -148,12 +130,8 @@ export function Editor(props: EditorProps): ReactNode {
       rangeDecorations,
       'ref': elementRef,
       renderAnnotation,
-      renderBlock,
-      renderChild,
       renderDecorator,
-      renderListItem,
       renderPlaceholder,
-      renderStyle,
       scrollSelectionIntoView,
       'selection': initialSelection,
       spellCheck,
@@ -170,12 +148,8 @@ export function Editor(props: EditorProps): ReactNode {
     onPaste,
     rangeDecorations,
     renderAnnotation,
-    renderBlock,
-    renderChild,
     renderDecorator,
-    renderListItem,
     renderPlaceholder,
-    renderStyle,
     scrollSelectionIntoView,
     spellCheck,
   ])

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -111,6 +111,8 @@ export function BlockObject(props: BlockObjectProps) {
     setElementRef,
     value,
   } = props
+  // A path deeper than the root array means the block is nested in a container.
+  const nested = relativePath.length > 1
   const {onChange} = useFormCallbacks()
   const {Markers} = useFormBuilder().__internal.components
   const hoveredChange = useHoveredChange()
@@ -172,6 +174,12 @@ export function BlockObject(props: BlockObjectProps) {
   )
 
   const innerPaddingProps: ResponsivePaddingProps = useMemo(() => {
+    if (nested) {
+      // A nested block sits inside a container that owns horizontal spacing
+      // (e.g. a table cell's padding), so the root gutter is dropped.
+      return {paddingX: 0}
+    }
+
     if (isFullscreen && !renderBlockActions) {
       return {paddingX: 5}
     }
@@ -188,7 +196,7 @@ export function BlockObject(props: BlockObjectProps) {
     }
 
     return {paddingX: 3}
-  }, [isFullscreen, renderBlockActions])
+  }, [isFullscreen, renderBlockActions, nested])
 
   const {validation, hasError, hasWarning, hasInfo} = useMemberValidation(memberItem?.node)
   const parentSchemaType = schemaTypes.portableText

--- a/packages/sanity/src/core/form/inputs/PortableText/text/ListItem.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/ListItem.tsx
@@ -8,20 +8,22 @@ const DefaultComponent = (dProps: BlockListItemProps) => {
   return <>{dProps.children}</>
 }
 
-export const ListItem = (props: BlockListItemRenderProps) => {
-  const {block, children, schemaType, selected, focused, level, value} = props
+type ListItemProps = Pick<BlockListItemRenderProps, 'block' | 'children' | 'focused' | 'selected'>
+
+export const ListItem = (props: ListItemProps) => {
+  const {block, children, selected, focused} = props
   const schemaTypes = usePortableTextMemberSchemaTypes()
-  const sanitySchemaType = schemaTypes.lists.find((type) => type.value === schemaType.value)
+  const sanitySchemaType = schemaTypes.lists.find((type) => type.value === block.listItem)
   if (!sanitySchemaType) {
     // This should never happen
-    throw new Error(`Could not find Sanity schema type for list item: ${schemaType.value}`)
+    throw new Error(`Could not find Sanity schema type for list item: ${block.listItem}`)
   }
-  const {title, component: CustomComponent} = sanitySchemaType
+  const {title, value, component: CustomComponent} = sanitySchemaType
   return useMemo(() => {
     const componentProps = {
       block,
       focused,
-      level,
+      level: block.level ?? 1,
       renderDefault: DefaultComponent,
       schemaType: sanitySchemaType,
       selected,
@@ -33,5 +35,5 @@ export const ListItem = (props: BlockListItemRenderProps) => {
     ) : (
       <DefaultComponent {...componentProps}>{children}</DefaultComponent>
     )
-  }, [CustomComponent, block, children, focused, level, sanitySchemaType, selected, title, value])
+  }, [CustomComponent, block, children, focused, sanitySchemaType, selected, title, value])
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/text/Style.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/Style.tsx
@@ -5,13 +5,15 @@ import {type BlockStyleProps} from '../../../types'
 import {usePortableTextMemberSchemaTypes} from '../contexts/PortableTextMemberSchemaTypes'
 import {Normal as FallbackComponent, TEXT_STYLES, TextContainer} from './textStyles'
 
-export const Style = (props: BlockStyleRenderProps) => {
-  const {block, focused, children, selected, schemaType} = props
+type StyleProps = Pick<BlockStyleRenderProps, 'block' | 'children' | 'focused' | 'selected'>
+
+export const Style = (props: StyleProps) => {
+  const {block, focused, children, selected} = props
   const schemaTypes = usePortableTextMemberSchemaTypes()
-  const sanitySchemaType = schemaTypes.styles.find((type) => type.value === schemaType.value)
+  const sanitySchemaType = schemaTypes.styles.find((type) => type.value === block.style)
   if (!sanitySchemaType) {
     // This should never happen
-    throw new Error(`Could not find Sanity schema type for style: ${schemaType.value}`)
+    throw new Error(`Could not find Sanity schema type for style: ${block.style}`)
   }
   const DefaultComponentWithFallback = useMemo(
     () =>

--- a/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
@@ -72,6 +72,7 @@ export interface TextBlockProps {
   spellCheck?: boolean
   value: PortableTextTextBlock
   anchorIdent?: string
+  relativePath: Path
 }
 
 export function TextBlock(props: TextBlockProps) {
@@ -101,7 +102,10 @@ export function TextBlock(props: TextBlockProps) {
     spellCheck,
     value,
     anchorIdent,
+    relativePath,
   } = props
+  // A path deeper than the root array means the block is nested in a container.
+  const nested = relativePath.length > 1
   const {Markers} = useFormBuilder().__internal.components
   const markers = usePortableTextMarkers(path)
   const [divElement, setDivElement] = useState<HTMLDivElement | null>(null)
@@ -184,6 +188,12 @@ export function TextBlock(props: TextBlockProps) {
   }, [value.listItem, value.level, children])
 
   const innerPaddingProps: ResponsivePaddingProps = useMemo(() => {
+    if (nested) {
+      // A nested block sits inside a container that owns horizontal spacing
+      // (e.g. a table cell's padding), so the root gutter is dropped.
+      return {paddingX: 0}
+    }
+
     if (isFullscreen && !renderBlockActions) {
       return {paddingX: 5}
     }
@@ -200,7 +210,7 @@ export function TextBlock(props: TextBlockProps) {
     }
 
     return {paddingX: 3}
-  }, [isFullscreen, renderBlockActions])
+  }, [isFullscreen, renderBlockActions, nested])
 
   const outerPaddingProps: ResponsivePaddingProps = useMemo(() => {
     if (value.listItem) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1501,6 +1501,12 @@ importers:
       '@portabletext/patches':
         specifier: ^2.0.5
         version: 2.0.5
+      '@portabletext/plugin-dnd':
+        specifier: ^1.0.1
+        version: 1.0.9(@portabletext/editor@7.8.1)(react@19.2.7)
+      '@portabletext/plugin-list-index':
+        specifier: ^1.0.4
+        version: 1.0.9(@portabletext/editor@7.8.1)(react@19.2.7)
       '@portabletext/plugin-markdown-shortcuts':
         specifier: ^8.0.24
         version: 8.0.24(@portabletext/editor@7.8.1)(@types/react@19.2.17)(react@19.2.7)
@@ -4807,8 +4813,22 @@ packages:
       '@portabletext/editor': ^7.8.1
       react: ^19.2
 
+  '@portabletext/plugin-dnd@1.0.9':
+    resolution: {integrity: sha512-+bFSNpVkCE1X889bG3MbUctHlHy4uZX2Obp9x9ffD95580MHmvEBlwO5PUK7fzAeBAV2MKHVHc+dQE3XtZeF5w==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      '@portabletext/editor': ^7.8.1
+      react: ^19.2
+
   '@portabletext/plugin-input-rule@5.0.24':
     resolution: {integrity: sha512-XvQ5IcQb6z5V7MiaF3hY7drvutPmZlH8SAJyQONZts5PaUo5aYT4di54QNE6n7uDuX9xJhIRKzC2zvqJUEKEiA==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      '@portabletext/editor': ^7.8.1
+      react: ^19.2
+
+  '@portabletext/plugin-list-index@1.0.9':
+    resolution: {integrity: sha512-wjxN5SX5C3x6R1Ed+5KjxwTkKa0kpayuZ7BDVHU9uWhpsDZxPSH6+//kjUPiBO5TB9kvYLh9vU3BE1HzB8FOdQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       '@portabletext/editor': ^7.8.1
@@ -13909,6 +13929,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  '@portabletext/plugin-dnd@1.0.9(@portabletext/editor@7.8.1)(react@19.2.7)':
+    dependencies:
+      '@portabletext/editor': 7.8.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+
   '@portabletext/plugin-input-rule@5.0.24(@portabletext/editor@7.8.1)(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@portabletext/editor': 7.8.1(@types/react@19.2.17)(react@19.2.7)
@@ -13917,6 +13942,11 @@ snapshots:
       xstate: 5.32.1
     transitivePeerDependencies:
       - '@types/react'
+
+  '@portabletext/plugin-list-index@1.0.9(@portabletext/editor@7.8.1)(react@19.2.7)':
+    dependencies:
+      '@portabletext/editor': 7.8.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
 
   '@portabletext/plugin-markdown-shortcuts@8.0.24(@portabletext/editor@7.8.1)(@types/react@19.2.17)(react@19.2.7)':
     dependencies:


### PR DESCRIPTION
### Description

This PR prepares the Portable Text Input for Containers. Containers are a new concept in PTE that allow you to define nested, editable structures. With this PR, Containers in Studio are about 80% there: a `defineContainer` registered in a userland Portable Text plugin composes cleanly with Studio's existing Portable Text UI. This means you can define a `table` Container with minimal config and add block objects like images or inline objects like stock tickers and they will look like they look at the root:

<img width="679" height="270" alt="Screenshot 2026-06-26 at 09 32 46" src="https://github.com/user-attachments/assets/1ae268b8-7850-4e46-b5ce-c9aec8a2669f" />

Similarly, block style (h1, blockquote, etc), lists, decorators and annotations also render correctly.

The remaining 20% is shallow-depth assumptions in Studio places like comment storing and focus tracking, which still read root-level paths. Double-clicking an image inside a Container doesn't open its edit dialog yet. Comments anchored to text inside a Container don't anchor correctly yet. These will be addressed in separate PRs in the spirit of keeping this one focused.

#### How it works:

With this PR, the render pipeline switches from the `PortableTextEditable` render callbacks (`renderBlock`/`renderChild`/`renderListItem`/`renderStyle`) to PTE's `defineX` (`defineTextBlock`/`defineBlockObject`/`defineInlineObject`) renderers, because `defineContainer` only works in the new pipeline.

The `Compositor` registers catch-all (`type: '*'`) versions of `defineTextBlock`, `defineBlockObject`, and `defineInlineObject` which make them act like regular render callbacks, except they work at any depth and also will be called inside Containers too.

(For now, `renderAnnotation` and `renderDecorator` stay as render props because the engine passes them through both pipelines unchanged.)

Switching away from the legacy render callbacks meant Studio had to reimplement a few things the old pipeline shipped out of the box. Drop position now comes from `@portabletext/plugin-dnd` and ordered-list numbering from `@portabletext/plugin-list-index`. The new pipeline is intentionally minimal: it gives the consumer full control over the rendered DOM, so it doesn't ship these things automatically. Consumers that want drop indicators or list numbering add the plugin; consumers that don't, don't pay for it.

#### Implications

The implication of switching to PTE's new render pipeline, is that PTE no longer emits legacy `data-slate-*` attributes or CSS class names. Since the new render pipeline offers full control for consumers, it's also a chance for PTE to only emit `data-pt-*` attributes that are strictly needed for its own engine. These attributes already exist on the legacy pipeline and in Studio today, the only difference is that the new pipeline strips the redundant attributes.

As an example, this is how a text block in PTE with `style: 'h1'` used to be rendered:

```html
<div 
  data-slate-node="element" 
  data-pt-path="[_key=="9a19e5fa9549"]"
  class="pt-block pt-text-block pt-text-block-style-h1"
  data-block-key="9a19e5fa9549"
  data-block-name="block"
  data-block-type="text"
  data-pt-block="text"
  data-style="h1">
</div>
```

And this is how it renders today in the new pipeline:

```html
<div 
  data-pt-path="[_key=="9a19e5fa9549"]"
  data-pt-block="text">
</div>
```

A block object looked like this:

```html
<div
  data-slate-node="element" 
  data-slate-void="true" 
  data-pt-path="[_key=="4b71d3a98eeb"]"
  class="pt-block pt-object-block" 
  data-block-key="4b71d3a98eeb" 
  data-block-name="image" 
  data-block-type="object" 
  data-pt-block="object">
</div>
```

And now looks like this:

```html
<div
  data-pt-path="[_key=="4b71d3a98eeb"]"
  data-pt-block="object">
</div>
```

This PR advocates for a **Clean break** approach where Studio only adds back the CSS classes and data attributes that it actually needs in its own code. This means that all `data-slate-*` attributes disappear along with most CSS classes redundant non-`pt` data attributes. **This might have adverse effects for Studio consumers who rely on some of these low-level undocumented DOM properties and it's ultimately up to the Studio team to decide if they want to allow that**. The **Clean break** approach has been evaluated along with three other options in an internal document, but it is still not too late to re-add some of the legacy DOM properties if we want.

> [!NOTE]
> None of the removed attributes or classes are referenced inside Studio's own source — this change is non-breaking for Studio itself and only affects consumers targeting them in custom CSS, DOM queries, or tests.

### What to review

- `Compositor.tsx` is the bulk. The three catch-all render functions reconstruct what each legacy callback did: the text-block style/list-item wrapping, the block-object void/drag wrapper, and the inline-object spacer/drag wrapper. Inline comments map each back to the callback it replaces.
- `@portabletext/plugin-dnd` and `@portabletext/plugin-list-index` are added as deps.
- `Editor.styles.tsx` narrows root-level Containers to the text content column and resets drop-indicator positioning for blocks nested in a Container. A Container element (e.g. `<table>`, `<pre>`) doesn't accept Studio's gutter padding the way text blocks do, so the constraint is expressed as width. Nested blocks drop their own gutter because the Container owns horizontal spacing.
- `dev/test-studio` gains `defineContainer` demos (a table and a code block) that exercise the catch-all renderers with nested content.

### Testing

Open https://test-studio-git-feat-portable-text-container-render-clean-break.sanity.dev/test/structure/input-standard;portable-text;customPlugins and try adding a table or a code block. It is intentionally minimal, but serves as validation that Studio's render pipeline now composes with Containers.

We also need to verify that root-level PTE editing in Studio works as before. I've already done thorough testing here myself.

### Notes for release

The Portable Text Input drops a set of legacy `data-slate-*` attributes, CSS classes, and non-`pt` data attributes from its editing DOM. The `data-pt-*` equivalents have shipped alongside them for some time, so consumers targeting any of these in custom CSS, DOM queries, or tests should migrate to the `data-pt-*` attributes.

#### Removed `data-slate-*` attributes

| Removed | Use instead |
|---|---|
| `data-slate-node="element"` | `data-pt-block="text" \| "object" \| "container"`, or `data-pt-inline="object"` for inline objects |
| `data-slate-node="text"` | `data-pt-inline="span"` |
| `data-slate-void` | `data-pt-block="object"` or `data-pt-inline="object"` |
| `data-slate-leaf` | `data-pt-marks` |
| `data-slate-string` | `data-pt-text` |
| `data-slate-zero-width` | `data-pt-zero-width` |
| `data-slate-spacer` | `data-pt-spacer` |

`data-slate-editor` and `data-slate-node="value"` on the root editable element are not removed in this PR but will be in a future PTE release.

#### Removed CSS classes

| Removed | Use instead |
|---|---|
| `pt-block` | `[data-pt-block]` (covers text, object, and container) |
| `pt-text-block` | `[data-pt-block="text"]` |
| `pt-text-block-style-{style}` | n/a |
| `pt-list-item-level-{level}` | `data-level="{level}"` |
| `pt-object-block` | `[data-pt-block="object"]` |
| `pt-inline-object` | `[data-pt-inline="object"]` |

`pt-list-item`, `pt-list-item-{listItem}`, and `pt-drop-indicator` are kept; Studio's new pipeline re-emits them where the legacy pipeline did, so Studio's own CSS can keep targeting them.

#### Removed non-`pt` data attributes

| Removed | Use instead |
|---|---|
| `data-block-key` | `data-pt-path` (the keyed path encodes the key) |
| `data-block-name` | n/a |
| `data-block-type` | `data-pt-block="text" \| "object" \| "container"` |
| `data-list-item` | `.pt-list-item` (still emitted), or `.pt-list-item-{listItem}` for the specific list type |
| `data-child-key` | `data-pt-path` on the parent block (the keyed path encodes the child key) |
| `data-child-name` | n/a |
| `data-child-type` | `data-pt-inline="span" \| "object"` |

`data-level` and `data-list-index` are kept on list items; Studio's CSS counter for ordered lists keys off them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core form editing for all Portable Text fields and changes public editing DOM; nested block-object schema lookup still only resolves top-level types, which can throw for deeper container types until follow-ups land.
> 
> **Overview**
> Switches the Studio Portable Text input from legacy `PortableTextEditable` callbacks (`renderBlock` / `renderChild` / `renderStyle` / `renderListItem`) to PTE’s **`defineTextBlock` / `defineBlockObject` / `defineInlineObject`** pipeline via catch-all `NodePlugin` nodes, so **`defineContainer`** and nested blocks reuse the same Studio chrome at any depth.
> 
> **Compositor** wraps the editor with **`@portabletext/plugin-dnd`** and **`@portabletext/plugin-list-index`**, re-adds drop indicators and list **`data-level` / `data-list-index`** / `.pt-list-item*` on a **`TextBlockShell`**, and moves style/list wrapping into the text-block renderer. Block and inline objects get drag wrappers and start/end drop indicators.
> 
> **Editor** stops passing block/child render props; annotations and decorators stay on the editable. **TextBlock** / **BlockObject** drop root horizontal padding when **`relativePath.length > 1`** (container nesting). **Editor.styles** constrains root **`[data-pt-block='container']`** width to the content column and fixes drop-indicator layout for blocks inside containers.
> 
> **test-studio** adds a **`containerTable`** field with table/code **`defineContainer`** demos, scaffold **`insert.block`** behaviors, and a custom **`ContainerPlugins`** hook. Lint config allows the **`edge`** attribute on drop indicators.
> 
> **Release note:** editing DOM sheds many legacy **`data-slate-*`**, redundant classes, and non-`pt` data attributes; Studio re-emits what its CSS needs (`data-pt-*`, list attrs, drop indicator class). Custom CSS/DOM that targeted removed attributes may break.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb53cc8a2555326b716362fe001e740af540e9b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->