### PR TITLE
fix(test-dts-exports): ignore css exports in dts checker

### DIFF
--- a/packages/@repo/test-dts-exports/generate.mjs
+++ b/packages/@repo/test-dts-exports/generate.mjs
@@ -30,6 +30,10 @@ for (const packageName of Object.keys(dependencies)) {
     continue
   }
   for (const [key, value] of Object.entries(packageJson.exports)) {
+    // Skip CSS exports (e.g. `./bundle.css`) as they have no type declarations
+    if (key.endsWith('.css')) {
+      continue
+    }
     if (typeof value === 'object' && 'default' in value) {
       const bareIdentifier = path.join(packageName, key)
       const dtsFilePath = path.join(packageName, value.default).replace(/\.(m|c)?js$/, '.d.ts')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The [`Run pnpm generate:dts-exports if needed` workflow](https://github.com/sanity-io/sanity/actions/runs/28233719946/job/83643417481) has been failing on every push to `main`. The `./bundle.css` conditional exports (re-added in d0ce99f46b) point their `default` condition at `./lib/bundle.css.js`, so the generator rewrites that to `./lib/bundle.css.d.ts` and crashes with `FileNotFoundError` — CSS exports have no type declarations.

The checker only exists to assert TypeScript export shapes, so CSS subpaths should simply be skipped. Keyed off the export key ending in `.css` rather than sniffing the resolved file, since the key is the unambiguous signal that a subpath is a stylesheet.

### What to review

- Single guard in `packages/@repo/test-dts-exports/generate.mjs` that `continue`s on `.css` export keys before resolving a `.d.ts`.

### Testing

- `pnpm generate:dts-exports` now completes (exit 0) where it previously crashed; no `bundle.css` fixtures are emitted.
- `@repo/test-dts-exports` suite passes (2873 tests, no type errors).

### Notes for release

N/A – Internal tooling only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11b3f82a-db3e-492a-ad2b-afb9872c23e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11b3f82a-db3e-492a-ad2b-afb9872c23e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

