### PR TITLE
test(test-studio): reproduce editor focus loss on custom style/list component toggle

### DIFF
--- a/dev/test-studio/schema/standard/portableText/customPlugins.tsx
+++ b/dev/test-studio/schema/standard/portableText/customPlugins.tsx
@@ -14,6 +14,44 @@ export const customPlugins = defineType({
     },
 
     /**
+     * Focus Test (custom highlight) -- MAIN render pipeline, no clean break
+     */
+    {
+      type: 'array',
+      name: 'focusTest',
+      title: 'Focus Test (custom style/list component)',
+      description:
+        'With the caret in the editor, toggle the Highlight style or the Arrow list; checking whether a consumer `component` override drops editor focus.',
+      of: [
+        defineArrayMember({
+          type: 'block',
+          styles: [
+            {value: 'normal', title: 'Normal'},
+            {
+              value: 'highlight',
+              title: 'Highlight',
+              component: ({children}) => (
+                <span style={{backgroundColor: 'yellow', padding: '0 0.2em'}}>{children}</span>
+              ),
+            },
+          ],
+          lists: [
+            {
+              value: 'arrow',
+              title: 'Arrow',
+              component: ({children}) => (
+                <span>
+                  {'\u2794 '}
+                  {children}
+                </span>
+              ),
+            },
+          ],
+        }),
+      ],
+    },
+
+    /**
      * One-Line Editor
      *
      * Uses the `OneLinePlugin` to restrict the editor to one line of text.


### PR DESCRIPTION
Throwaway repro PR for testing in the Vercel prod preview. Do not merge.

Adds a **Focus Test (custom style/list component)** field to the Custom Plugins document: a plain text block with a custom `highlight` block style and a custom `arrow` list item, each backed by a consumer `component` override.

### What to test in the preview

Open a **Custom Plugins** document, find the field, put the caret in the editor, and toggle **Highlight** (style) or **Arrow** (list) from the toolbar.

The bug we're chasing: toggling a style/list whose schema type has a custom `component` drops focus out of the editor. In Studio's `Style`/`ListItem` the render branches `CustomComponent ? <CustomComponent> : <DefaultComponent>`, so the toggle changes the React component type at that DOM position and remounts the editable text node the caret lives in; the editor's post-toolbar focus restore then lands on a node that no longer exists.

It reproduces in local dev across editor 7.5.2 to 7.8.1, and with React StrictMode disabled (single mount), so it is not a StrictMode dev artifact. This preview confirms whether it also reproduces in a production build.

This branch is off `main` (legacy render pipeline), so it isolates the editor behaviour from the container clean-break work.
