### PR TITLE
fix(core): remove sideEffects so injected bundle.css is not tree-shaken

### DIFF
--- a/packages/sanity/package.config.ts
+++ b/packages/sanity/package.config.ts
@@ -16,6 +16,15 @@ export default defineConfig({
   babel: {reactCompiler: true, styledComponents: true},
   reactCompilerOptions: {target: '19'},
 
+  strictOptions: {
+    ...baseConfig.strictOptions,
+    // pkg-utils injects an `import 'sanity/bundle.css'` side effect into the entry, so this package
+    // is not side-effect-free. Omitting `sideEffects` (treated as "everything has side effects")
+    // is the correct declaration here and keeps the css import from being tree-shaken away, so
+    // allow it rather than requiring an explicit `sideEffects` field.
+    noImplicitSideEffects: 'off',
+  },
+
   // Workaround for a long-standing rollup bug: when `moduleSideEffects` marks externals as
   // side-effect-free (e.g. 'no-external') in a multi-entry build, bare imports from other entries
   // leak into the first entry. The default `true` avoids this. Since the output is a library, the

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -31,10 +31,6 @@
     "mock-browser-env-stub-loader.mjs"
   ],
   "type": "module",
-  "sideEffects": [
-    "*.css",
-    "*.css.ts"
-  ],
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "exports": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Follow-up to #13322 and #13329.

#13322 re-added the prebuilt `bundle.css` export via conditional exports, where `@sanity/pkg-utils` injects `import "sanity/bundle.css"` into the built entrypoint. At the time, `sanity` core was left with its `sideEffects: ["*.css", "*.css.ts"]` allowlist because core "survived by coincidence": its entry ended with `export * from "@sanity/types"`, and that star re-export kept the barrel from being bypassed, so the injected CSS import was retained.

#13329 bumped pkg-utils to `10.7.2`, which fixed an issue where `./bundle.css` was being injected into **all** export entrypoints instead of only `index`. With that fix in place, the previous coincidence no longer holds: the `.js` barrel is marked side-effect-free by the `sideEffects` allowlist, so the production bundler bypasses it (pulling exports straight from the inner chunk) and drops the bare `import "sanity/bundle.css"`. The result is the `--static-css-file-loaded-studio` marker (set via core's `styles.css.ts`) going missing from `#sanity` on https://test-studio.sanity.dev.

The fix mirrors what #13322 already did for `@sanity/vision`:

- Remove the `sideEffects` field from `packages/sanity/package.json`. An absent field means "everything has side effects", which is accurate now that the entry imports global CSS, and it keeps the barrel from being tree-shaken so the injected CSS import is retained.
- Turn off pkg-utils' `noImplicitSideEffects` strict check for this package in `package.config.ts` (it otherwise flags the missing `sideEffects` field under `--strict`).

### What to review

- `packages/sanity/package.json`: removal of the `sideEffects` allowlist.
- `packages/sanity/package.config.ts`: `strictOptions.noImplicitSideEffects: 'off'` (same rationale and wording as `@sanity/vision`).
- Affected package: `sanity`.

### Testing

Packaging/build-config change with no runtime logic, so no unit tests.

- `pnpm --filter sanity... build` (`pkg-utils build --strict --check`) passes with the `sideEffects` field removed.
- Verified the built `packages/sanity/lib/index.js` now retains `import "sanity/bundle.css";` at the top of the entry, confirming it is no longer tree-shaken out of the production bundle.
- `pnpm check:oxlint` and format checks pass.

This relies on CI `test:exports` to verify the conditional exports still resolve across ESM/CJS/DTS, plus type checks.

### Notes for release

N/A – Internal only (build/packaging fix to ensure the studio's prebuilt CSS ships).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3621f591-108f-4334-af72-666f4c1ef8dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3621f591-108f-4334-af72-666f4c1ef8dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

