### PR TITLE
fix(releases): truncate document type column with tooltip on overflow

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -4,7 +4,7 @@ import {Badge, Box, Flex, Text} from '@sanity/ui'
 import {toString as pathToString} from '@sanity/util/paths'
 // oxlint-disable-next-line @sanity/i18n/no-i18next-import -- figure out how to have the linter be fine with importing types-only
 import {type TFunction} from 'i18next'
-import {memo, useEffect, useRef, useState} from 'react'
+import {memo, useCallback, useEffect, useRef, useState} from 'react'
 import {IntentLink} from 'sanity/router'
 import {styled} from 'styled-components'
 
@@ -66,26 +66,54 @@ export function DocumentType({type}: {type: string}) {
   const schema = useSchema()
   const title = schema.get(type)?.title || 'Not found'
 
-  const spanRef = useRef<HTMLSpanElement>(null)
+  const elementRef = useRef<HTMLSpanElement | null>(null)
   const [isTruncated, setIsTruncated] = useState(false)
 
-  // Re-measures on mount, on element resize, and whenever `title` changes - a content
-  // change alone does not resize the box, so the ResizeObserver would otherwise miss it.
+  const checkTruncation = useCallback(() => {
+    const element = elementRef.current
+    if (element) setIsTruncated(element.scrollWidth > element.clientWidth)
+  }, [])
+
+  // A callback ref ensures React invokes measurement the moment the node attaches, regardless
+  // of which commit that happens in - avoiding the race where a useEffect fires before the ref
+  // is populated. Returning a cleanup function from the callback is the React 19 mechanism for
+  // disconnecting the observer when the node detaches.
+  const measureRef = useCallback(
+    (element: HTMLSpanElement | null) => {
+      elementRef.current = element
+      if (!element) return undefined
+
+      checkTruncation()
+
+      const observer = new ResizeObserver(checkTruncation)
+      observer.observe(element)
+
+      // Web fonts usually finish loading after the first paint. The font swap widens the
+      // text and triggers the CSS ellipsis, but the span's box stays locked to the column
+      // width - so the ResizeObserver never fires and the overflow would go undetected.
+      let cancelled = false
+      void document.fonts?.ready.then(() => {
+        if (!cancelled) checkTruncation()
+      })
+
+      return () => {
+        cancelled = true
+        observer.disconnect()
+        elementRef.current = null
+      }
+    },
+    [checkTruncation],
+  )
+
+  // A title change rewrites the text without resizing the box, so the ResizeObserver would
+  // miss it - re-measure explicitly when the title changes.
   useEffect(() => {
-    const element = spanRef.current
-    if (!element) return undefined
-
-    const checkTruncation = () => setIsTruncated(element.scrollWidth > element.clientWidth)
     checkTruncation()
-
-    const observer = new ResizeObserver(checkTruncation)
-    observer.observe(element)
-    return () => observer.disconnect()
-  }, [title])
+  }, [title, checkTruncation])
 
   const textElement = (
     <Text size={1}>
-      <TruncatedSpan ref={spanRef}>{title}</TruncatedSpan>
+      <TruncatedSpan ref={measureRef}>{title}</TruncatedSpan>
     </Text>
   )
 

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -89,7 +89,7 @@ export function DocumentType({type}: {type: string}) {
       // The late font swap widens the text but not the column-locked box, so the
       // ResizeObserver never fires - re-measure once fonts settle.
       let cancelled = false
-      void document.fonts?.ready.then(() => {
+      void document.fonts?.ready?.then(() => {
         if (!cancelled) checkTruncation()
       })
 

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -74,10 +74,8 @@ export function DocumentType({type}: {type: string}) {
     if (element) setIsTruncated(element.scrollWidth > element.clientWidth)
   }, [])
 
-  // A callback ref ensures React invokes measurement the moment the node attaches, regardless
-  // of which commit that happens in - avoiding the race where a useEffect fires before the ref
-  // is populated. Returning a cleanup function from the callback is the React 19 mechanism for
-  // disconnecting the observer when the node detaches.
+  // A callback ref measures on attach, avoiding the race where a useEffect fires before the
+  // ref is populated. The returned cleanup runs when the node detaches.
   const measureRef = useCallback(
     (element: HTMLSpanElement | null) => {
       elementRef.current = element
@@ -88,9 +86,8 @@ export function DocumentType({type}: {type: string}) {
       const observer = new ResizeObserver(checkTruncation)
       observer.observe(element)
 
-      // Web fonts usually finish loading after the first paint. The font swap widens the
-      // text and triggers the CSS ellipsis, but the span's box stays locked to the column
-      // width - so the ResizeObserver never fires and the overflow would go undetected.
+      // The late font swap widens the text but not the column-locked box, so the
+      // ResizeObserver never fires - re-measure once fonts settle.
       let cancelled = false
       void document.fonts?.ready.then(() => {
         if (!cancelled) checkTruncation()
@@ -105,8 +102,7 @@ export function DocumentType({type}: {type: string}) {
     [checkTruncation],
   )
 
-  // A title change rewrites the text without resizing the box, so the ResizeObserver would
-  // miss it - re-measure explicitly when the title changes.
+  // A title change rewrites the text without resizing the box, so re-measure on title change.
   useEffect(() => {
     checkTruncation()
   }, [title, checkTruncation])
@@ -178,10 +174,8 @@ export const getDocumentTableColumnDefs: (
   ...(releaseState === 'archived' || releaseState === 'published' ? [] : [documentActionColumn(t)]),
   {
     id: 'document._type',
-    // Fixed width so the header and body cells agree: the table renders the header row and
-    // each body row as independent flexboxes, so a content-sized column (width: null) settles
-    // at the short header's width in the header row and the long title's width in the body row,
-    // misaligning the two. A fixed width is what every other column here relies on to line up.
+    // Header and body rows are independent flexboxes, so a content-sized column (width: null)
+    // settles at different widths in each and misaligns. A fixed width keeps them in sync.
     width: 150,
     sorting: true,
     header: (props) => (

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -4,8 +4,9 @@ import {Badge, Box, Flex, Text} from '@sanity/ui'
 import {toString as pathToString} from '@sanity/util/paths'
 // oxlint-disable-next-line @sanity/i18n/no-i18next-import -- figure out how to have the linter be fine with importing types-only
 import {type TFunction} from 'i18next'
-import {memo} from 'react'
+import {memo, useCallback, useState} from 'react'
 import {IntentLink} from 'sanity/router'
+import {styled} from 'styled-components'
 
 import {ToneIcon} from '../../../../../ui-components/toneIcon/ToneIcon'
 import {Tooltip} from '../../../../../ui-components/tooltip'
@@ -52,14 +53,57 @@ const MemoReleaseDocumentPreview = memo(
   (prev, next) => prev.item.memoKey === next.item.memoKey && prev.releaseId === next.releaseId,
 )
 
-const MemoDocumentType = memo(
-  function DocumentType({type}: {type: string}) {
-    const schema = useSchema()
-    const schemaType = schema.get(type)
-    return <Text size={1}>{schemaType?.title || 'Not found'}</Text>
-  },
-  (prev, next) => prev.type === next.type,
-)
+/**
+ * Inner span that clips with an ellipsis. Rendered inside a {@link Text} so it inherits
+ * the correct font size, but carries its own overflow CSS because @sanity/ui's
+ * `textOverflow="ellipsis"` prop is inert in this render path.
+ */
+const TruncatedSpan = styled.span`
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`
+
+/** @internal - exported for unit testing only */
+export function DocumentType({type}: {type: string}) {
+  const schema = useSchema()
+  const schemaType = schema.get(type)
+  const title = schemaType?.title || 'Not found'
+
+  const [isTruncated, setIsTruncated] = useState(false)
+
+  const refCallback = useCallback((element: HTMLElement | null) => {
+    if (!element) return
+
+    const checkTruncation = () => setIsTruncated(element.scrollWidth > element.clientWidth)
+
+    checkTruncation()
+
+    const observer = new ResizeObserver(checkTruncation)
+    observer.observe(element)
+
+    return () => observer.disconnect()
+  }, [])
+
+  const textElement = (
+    <Text size={1}>
+      <TruncatedSpan ref={refCallback}>{title}</TruncatedSpan>
+    </Text>
+  )
+
+  if (isTruncated) {
+    return (
+      <Tooltip portal content={<Text size={1}>{title}</Text>}>
+        {textElement}
+      </Tooltip>
+    )
+  }
+
+  return textElement
+}
+
+const MemoDocumentType = memo(DocumentType, (prev, next) => prev.type === next.type)
 
 const documentActionColumn: (t: TFunction<'releases'>) => Column<BundleDocumentRow> = (t) => ({
   id: 'action',
@@ -110,7 +154,7 @@ export const getDocumentTableColumnDefs: (
   {
     id: 'document._type',
     width: null,
-    style: {minWidth: 100},
+    style: {minWidth: 100, maxWidth: 200},
     sorting: true,
     header: (props) => (
       <Flex {...props.headerProps} paddingY={3} sizing="border">
@@ -119,7 +163,7 @@ export const getDocumentTableColumnDefs: (
     ),
     cell: ({cellProps, datum}) => (
       <Flex align="center" {...cellProps}>
-        <Box paddingX={2}>
+        <Box paddingX={2} style={{minWidth: 0}}>
           {!datum.isLoading && <MemoDocumentType type={datum.document._type} />}
         </Box>
       </Flex>

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -73,15 +73,14 @@ export function DocumentType({type}: {type: string}) {
   // change alone does not resize the box, so the ResizeObserver would otherwise miss it.
   useEffect(() => {
     const element = spanRef.current
-    if (element) {
-      const checkTruncation = () => setIsTruncated(element.scrollWidth > element.clientWidth)
-      checkTruncation()
+    if (!element) return undefined
 
-      const observer = new ResizeObserver(checkTruncation)
-      observer.observe(element)
-      return () => observer.disconnect()
-    }
-    return undefined
+    const checkTruncation = () => setIsTruncated(element.scrollWidth > element.clientWidth)
+    checkTruncation()
+
+    const observer = new ResizeObserver(checkTruncation)
+    observer.observe(element)
+    return () => observer.disconnect()
   }, [title])
 
   const textElement = (
@@ -151,8 +150,11 @@ export const getDocumentTableColumnDefs: (
   ...(releaseState === 'archived' || releaseState === 'published' ? [] : [documentActionColumn(t)]),
   {
     id: 'document._type',
-    width: null,
-    style: {minWidth: 100, maxWidth: 200},
+    // Fixed width so the header and body cells agree: the table renders the header row and
+    // each body row as independent flexboxes, so a content-sized column (width: null) settles
+    // at the short header's width in the header row and the long title's width in the body row,
+    // misaligning the two. A fixed width is what every other column here relies on to line up.
+    width: 150,
     sorting: true,
     header: (props) => (
       <Flex {...props.headerProps} paddingY={3} sizing="border">

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -4,7 +4,7 @@ import {Badge, Box, Flex, Text} from '@sanity/ui'
 import {toString as pathToString} from '@sanity/util/paths'
 // oxlint-disable-next-line @sanity/i18n/no-i18next-import -- figure out how to have the linter be fine with importing types-only
 import {type TFunction} from 'i18next'
-import {memo, useCallback, useState} from 'react'
+import {memo, useEffect, useRef, useState} from 'react'
 import {IntentLink} from 'sanity/router'
 import {styled} from 'styled-components'
 
@@ -53,11 +53,7 @@ const MemoReleaseDocumentPreview = memo(
   (prev, next) => prev.item.memoKey === next.item.memoKey && prev.releaseId === next.releaseId,
 )
 
-/**
- * Inner span that clips with an ellipsis. Rendered inside a {@link Text} so it inherits
- * the correct font size, but carries its own overflow CSS because @sanity/ui's
- * `textOverflow="ellipsis"` prop is inert in this render path.
- */
+// Carries its own overflow CSS because @sanity/ui's `textOverflow` prop is inert here.
 const TruncatedSpan = styled.span`
   display: block;
   white-space: nowrap;
@@ -68,27 +64,29 @@ const TruncatedSpan = styled.span`
 /** @internal - exported for unit testing only */
 export function DocumentType({type}: {type: string}) {
   const schema = useSchema()
-  const schemaType = schema.get(type)
-  const title = schemaType?.title || 'Not found'
+  const title = schema.get(type)?.title || 'Not found'
 
+  const spanRef = useRef<HTMLSpanElement>(null)
   const [isTruncated, setIsTruncated] = useState(false)
 
-  const refCallback = useCallback((element: HTMLElement | null) => {
-    if (!element) return
+  // Re-measures on mount, on element resize, and whenever `title` changes - a content
+  // change alone does not resize the box, so the ResizeObserver would otherwise miss it.
+  useEffect(() => {
+    const element = spanRef.current
+    if (element) {
+      const checkTruncation = () => setIsTruncated(element.scrollWidth > element.clientWidth)
+      checkTruncation()
 
-    const checkTruncation = () => setIsTruncated(element.scrollWidth > element.clientWidth)
-
-    checkTruncation()
-
-    const observer = new ResizeObserver(checkTruncation)
-    observer.observe(element)
-
-    return () => observer.disconnect()
-  }, [])
+      const observer = new ResizeObserver(checkTruncation)
+      observer.observe(element)
+      return () => observer.disconnect()
+    }
+    return undefined
+  }, [title])
 
   const textElement = (
     <Text size={1}>
-      <TruncatedSpan ref={refCallback}>{title}</TruncatedSpan>
+      <TruncatedSpan ref={spanRef}>{title}</TruncatedSpan>
     </Text>
   )
 

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentTableColumnDefs.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentTableColumnDefs.test.tsx
@@ -9,8 +9,6 @@ vi.mock('../../../../../hooks', () => ({
   useSchema: vi.fn(),
 }))
 
-// Stub only the Text component so tests run without a styled-components theme context.
-// Use importOriginal so every other @sanity/ui export remains intact.
 vi.mock('@sanity/ui', async (importOriginal) => ({
   ...(await importOriginal()),
   Text: ({children, size: _size}: {children: React.ReactNode; size?: number}) => (
@@ -75,10 +73,14 @@ describe('DocumentType', () => {
     it('renders a tooltip containing the full title when the text is truncated', () => {
       mockUseSchema.mockReturnValue(buildMockSchema('A Very Long Schema Type Title That Overflows'))
 
-      // Override the global ResizeObserver so observe() immediately fires the callback.
-      // Combined with the scrollWidth override below, this puts isTruncated into the true branch.
       const originalResizeObserver = globalThis.ResizeObserver
+      const originalDescriptor = Object.getOwnPropertyDescriptor(
+        HTMLElement.prototype,
+        'scrollWidth',
+      )
 
+      // Fire the observer callback synchronously on observe() and report every element as
+      // wider than its visible box, driving the effect's check into the truncated branch.
       globalThis.ResizeObserver = class {
         private callback: () => void
 
@@ -99,12 +101,6 @@ describe('DocumentType', () => {
         }
       } as unknown as typeof ResizeObserver
 
-      // Make every HTMLElement report as wider-than-visible so the truncation
-      // condition (scrollWidth > clientWidth) is met when the ref callback fires.
-      const originalDescriptor = Object.getOwnPropertyDescriptor(
-        HTMLElement.prototype,
-        'scrollWidth',
-      )
       Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
         configurable: true,
         get() {
@@ -112,18 +108,20 @@ describe('DocumentType', () => {
         },
       })
 
-      render(<DocumentType type="longType" />)
+      try {
+        render(<DocumentType type="longType" />)
 
-      // Restore before assertions so subsequent tests are not affected.
-      if (originalDescriptor) {
-        Object.defineProperty(HTMLElement.prototype, 'scrollWidth', originalDescriptor)
+        expect(screen.getByTestId('tooltip-wrapper')).toBeInTheDocument()
+        expect(screen.getByTestId('tooltip-content')).toHaveTextContent(
+          'A Very Long Schema Type Title That Overflows',
+        )
+      } finally {
+        // Restore in finally so a thrown assertion cannot leak overrides into later tests.
+        if (originalDescriptor) {
+          Object.defineProperty(HTMLElement.prototype, 'scrollWidth', originalDescriptor)
+        }
+        globalThis.ResizeObserver = originalResizeObserver
       }
-      globalThis.ResizeObserver = originalResizeObserver
-
-      expect(screen.getByTestId('tooltip-wrapper')).toBeInTheDocument()
-      expect(screen.getByTestId('tooltip-content')).toHaveTextContent(
-        'A Very Long Schema Type Title That Overflows',
-      )
     })
   })
 })

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentTableColumnDefs.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentTableColumnDefs.test.tsx
@@ -92,13 +92,9 @@ describe('DocumentType', () => {
           this.callback()
         }
 
-        unobserve(): void {
-          // no-op
-        }
+        unobserve(): void {}
 
-        disconnect(): void {
-          // no-op
-        }
+        disconnect(): void {}
       } as unknown as typeof ResizeObserver
 
       Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentTableColumnDefs.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentTableColumnDefs.test.tsx
@@ -61,8 +61,7 @@ describe('DocumentType', () => {
     it('does not render a tooltip when the text is not truncated (scrollWidth === clientWidth)', () => {
       mockUseSchema.mockReturnValue(buildMockSchema('Short Title'))
 
-      // The callback ref measures on mount; scrollWidth and clientWidth both default to 0
-      // in jsdom, so isTruncated stays false and no tooltip is rendered.
+      // scrollWidth and clientWidth both default to 0 in jsdom, so nothing reads as truncated.
       render(<DocumentType type="shortType" />)
 
       expect(screen.queryByTestId('tooltip-wrapper')).not.toBeInTheDocument()
@@ -78,9 +77,7 @@ describe('DocumentType', () => {
         'scrollWidth',
       )
 
-      // Report every element as wider than its visible box so the measurement lands in the
-      // truncated branch. The ResizeObserver fires its callback on observe() as well, but the
-      // callback ref already measures synchronously on mount.
+      // Report every element as wider than its visible box so the measurement reads as truncated.
       globalThis.ResizeObserver = class {
         private callback: () => void
 
@@ -129,9 +126,8 @@ describe('DocumentType', () => {
       )
       const originalFonts = Object.getOwnPropertyDescriptor(document, 'fonts')
 
-      // The text fits until the web font swaps in: scrollWidth only exceeds clientWidth (0)
-      // after fonts settle. This isolates the fonts.ready re-measure from the mount measure,
-      // which would otherwise see the text as fitting and never render the tooltip.
+      // Text fits until the font swaps in (scrollWidth exceeds clientWidth only after fonts
+      // settle), isolating the fonts.ready re-measure from the mount measure.
       let fontsLoaded = false
       let resolveFontsReady!: () => void
       const fontsReady = new Promise<void>((resolve) => {

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentTableColumnDefs.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentTableColumnDefs.test.tsx
@@ -1,5 +1,5 @@
 import {type Schema} from '@sanity/types'
-import {render, screen} from '@testing-library/react'
+import {render, screen, waitFor} from '@testing-library/react'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {useSchema} from '../../../../../hooks'
@@ -61,9 +61,8 @@ describe('DocumentType', () => {
     it('does not render a tooltip when the text is not truncated (scrollWidth === clientWidth)', () => {
       mockUseSchema.mockReturnValue(buildMockSchema('Short Title'))
 
-      // The global ResizeObserver mock (from test setup) is a no-op so the callback
-      // never fires. scrollWidth and clientWidth both default to 0 in jsdom,
-      // so isTruncated stays false.
+      // The callback ref measures on mount; scrollWidth and clientWidth both default to 0
+      // in jsdom, so isTruncated stays false and no tooltip is rendered.
       render(<DocumentType type="shortType" />)
 
       expect(screen.queryByTestId('tooltip-wrapper')).not.toBeInTheDocument()
@@ -79,8 +78,9 @@ describe('DocumentType', () => {
         'scrollWidth',
       )
 
-      // Fire the observer callback synchronously on observe() and report every element as
-      // wider than its visible box, driving the effect's check into the truncated branch.
+      // Report every element as wider than its visible box so the measurement lands in the
+      // truncated branch. The ResizeObserver fires its callback on observe() as well, but the
+      // callback ref already measures synchronously on mount.
       globalThis.ResizeObserver = class {
         private callback: () => void
 
@@ -117,6 +117,64 @@ describe('DocumentType', () => {
           Object.defineProperty(HTMLElement.prototype, 'scrollWidth', originalDescriptor)
         }
         globalThis.ResizeObserver = originalResizeObserver
+      }
+    })
+
+    it('re-measures once web fonts load and reveals the overflow', async () => {
+      mockUseSchema.mockReturnValue(buildMockSchema('A Title That Only Overflows Once Fonts Load'))
+
+      const originalDescriptor = Object.getOwnPropertyDescriptor(
+        HTMLElement.prototype,
+        'scrollWidth',
+      )
+      const originalFonts = Object.getOwnPropertyDescriptor(document, 'fonts')
+
+      // The text fits until the web font swaps in: scrollWidth only exceeds clientWidth (0)
+      // after fonts settle. This isolates the fonts.ready re-measure from the mount measure,
+      // which would otherwise see the text as fitting and never render the tooltip.
+      let fontsLoaded = false
+      let resolveFontsReady!: () => void
+      const fontsReady = new Promise<void>((resolve) => {
+        resolveFontsReady = resolve
+      })
+      Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+        configurable: true,
+        get() {
+          return fontsLoaded ? 400 : 0
+        },
+      })
+      Object.defineProperty(document, 'fonts', {
+        configurable: true,
+        value: {ready: fontsReady},
+      })
+
+      try {
+        render(<DocumentType type="lateFontType" />)
+
+        // No tooltip on mount - the text still fits.
+        expect(screen.queryByTestId('tooltip-wrapper')).not.toBeInTheDocument()
+
+        // The font swap widens the text, then fonts.ready resolves and the re-measure runs.
+        fontsLoaded = true
+        resolveFontsReady()
+
+        await waitFor(() => {
+          expect(screen.getByTestId('tooltip-wrapper')).toBeInTheDocument()
+        })
+        expect(screen.getByTestId('tooltip-content')).toHaveTextContent(
+          'A Title That Only Overflows Once Fonts Load',
+        )
+      } finally {
+        if (originalDescriptor) {
+          Object.defineProperty(HTMLElement.prototype, 'scrollWidth', originalDescriptor)
+        }
+        if (originalFonts) {
+          Object.defineProperty(document, 'fonts', originalFonts)
+        } else {
+          // jsdom has no `document.fonts` by default; remove the stub we added.
+          // @ts-expect-error -- deleting an optional DOM property in teardown
+          delete document.fonts
+        }
       }
     })
   })

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentTableColumnDefs.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentTableColumnDefs.test.tsx
@@ -1,0 +1,129 @@
+import {type Schema} from '@sanity/types'
+import {render, screen} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {useSchema} from '../../../../../hooks'
+import {DocumentType} from '../DocumentTableColumnDefs'
+
+vi.mock('../../../../../hooks', () => ({
+  useSchema: vi.fn(),
+}))
+
+// Stub only the Text component so tests run without a styled-components theme context.
+// Use importOriginal so every other @sanity/ui export remains intact.
+vi.mock('@sanity/ui', async (importOriginal) => ({
+  ...(await importOriginal()),
+  Text: ({children, size: _size}: {children: React.ReactNode; size?: number}) => (
+    <span data-ui="Text">{children}</span>
+  ),
+}))
+
+// Stub Tooltip so we can assert its presence without a portal/full DOM tree.
+vi.mock('../../../../../../ui-components/tooltip', () => ({
+  Tooltip: ({children, content}: {children: React.ReactNode; content: React.ReactNode}) => (
+    <div data-testid="tooltip-wrapper">
+      <div data-testid="tooltip-content">{content}</div>
+      {children}
+    </div>
+  ),
+}))
+
+const mockUseSchema = vi.mocked(useSchema)
+
+function buildMockSchema(typeTitle: string | undefined): Schema {
+  return {
+    get: vi.fn().mockReturnValue(typeTitle !== undefined ? {title: typeTitle} : undefined),
+  } as unknown as Schema
+}
+
+describe('DocumentType', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('title rendering', () => {
+    it('renders the schema type title when the type is found', () => {
+      mockUseSchema.mockReturnValue(buildMockSchema('My Article Type'))
+
+      render(<DocumentType type="myArticle" />)
+
+      expect(screen.getByText('My Article Type')).toBeInTheDocument()
+    })
+
+    it('renders "Not found" when the schema type is not registered', () => {
+      mockUseSchema.mockReturnValue(buildMockSchema(undefined))
+
+      render(<DocumentType type="unknownType" />)
+
+      expect(screen.getByText('Not found')).toBeInTheDocument()
+    })
+  })
+
+  describe('truncation tooltip', () => {
+    it('does not render a tooltip when the text is not truncated (scrollWidth === clientWidth)', () => {
+      mockUseSchema.mockReturnValue(buildMockSchema('Short Title'))
+
+      // The global ResizeObserver mock (from test setup) is a no-op so the callback
+      // never fires. scrollWidth and clientWidth both default to 0 in jsdom,
+      // so isTruncated stays false.
+      render(<DocumentType type="shortType" />)
+
+      expect(screen.queryByTestId('tooltip-wrapper')).not.toBeInTheDocument()
+      expect(screen.getByText('Short Title')).toBeInTheDocument()
+    })
+
+    it('renders a tooltip containing the full title when the text is truncated', () => {
+      mockUseSchema.mockReturnValue(buildMockSchema('A Very Long Schema Type Title That Overflows'))
+
+      // Override the global ResizeObserver so observe() immediately fires the callback.
+      // Combined with the scrollWidth override below, this puts isTruncated into the true branch.
+      const originalResizeObserver = globalThis.ResizeObserver
+
+      globalThis.ResizeObserver = class {
+        private callback: () => void
+
+        constructor(callback: () => void) {
+          this.callback = callback
+        }
+
+        observe(): void {
+          this.callback()
+        }
+
+        unobserve(): void {
+          // no-op
+        }
+
+        disconnect(): void {
+          // no-op
+        }
+      } as unknown as typeof ResizeObserver
+
+      // Make every HTMLElement report as wider-than-visible so the truncation
+      // condition (scrollWidth > clientWidth) is met when the ref callback fires.
+      const originalDescriptor = Object.getOwnPropertyDescriptor(
+        HTMLElement.prototype,
+        'scrollWidth',
+      )
+      Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+        configurable: true,
+        get() {
+          return 400
+        },
+      })
+
+      render(<DocumentType type="longType" />)
+
+      // Restore before assertions so subsequent tests are not affected.
+      if (originalDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, 'scrollWidth', originalDescriptor)
+      }
+      globalThis.ResizeObserver = originalResizeObserver
+
+      expect(screen.getByTestId('tooltip-wrapper')).toBeInTheDocument()
+      expect(screen.getByTestId('tooltip-content')).toHaveTextContent(
+        'A Very Long Schema Type Title That Overflows',
+      )
+    })
+  })
+})


### PR DESCRIPTION
### Description

In the releases document table, the Type column had no fixed width, so its header and body cells sized independently - the header to the short word "Type", each body cell to its longer type title. The table renders the header row and each body row as independent flexboxes with no shared column grid, so the two never lined up, and long titles stretched the column with no truncation.

This PR gives the Type column a fixed width so the header and body cells always agree, renders the title in an ellipsis-truncating span, and shows a tooltip with the full title only when the text is actually truncated.

### What to review

- The Type column uses a fixed `width` rather than `width: null`. The table has no shared column model, so a content-sized column settles at a different width in the header and body rows, which is what misaligned them.
- `DocumentType` detects truncation by comparing `scrollWidth > clientWidth`, wired through a callback ref on the span. An earlier `useEffect` + `useRef` version never worked: the ref was null when the effect ran, so the `ResizeObserver` was never attached and the tooltip never appeared. The callback ref measures the moment the node attaches; a `ResizeObserver` catches column resizes, `document.fonts.ready` re-measures after the web-font swap widens the text, and a `title`-keyed effect re-measures when a virtualized cell is reused for a different type.
- `TruncatedSpan` carries its own overflow CSS because `@sanity/ui`'s `textOverflow` prop is inert in this render path.
- The cell `Box` gets `minWidth: 0` so it can shrink below its content width inside the flex row, which is what lets the ellipsis engage.

Before
<img width="1136" height="248" alt="Screenshot 2026-06-29 at 17 44 15" src="https://github.com/user-attachments/assets/54623483-b8c4-4ed2-9ef2-2a080e1c6a48" />

After
<img width="730" height="266" alt="Screenshot 2026-06-29 at 17 43 52" src="https://github.com/user-attachments/assets/50fb4ae4-a036-494c-aa05-930cf0dfb6f3" />


### Testing

Unit tests for `DocumentType` cover title rendering (found and not-found schema types) and the tooltip branches - no tooltip when the text fits, a tooltip with the full title when truncated, and a case isolating the `document.fonts.ready` re-measure. Verified live in the dev studio that the truncation state flips and the tooltip renders for an overflowing type name.

### Notes for release

The document type column in the releases table now has a fixed width and truncates long type names with an ellipsis, showing the full name in a tooltip on hover.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes in the releases document table with no auth, data, or API impact.
> 
> **Overview**
> Fixes **Type** column misalignment and overflow in the releases document table by giving the column a **fixed width (150px)** so header and body rows agree, and by shrinking the cell with **`minWidth: 0`** so ellipsis can apply.
> 
> **`DocumentType`** now renders schema titles in a **`TruncatedSpan`** (custom ellipsis CSS) and shows a **tooltip with the full title only when text is truncated**, detected via **`scrollWidth > clientWidth`**. Measurement uses a **callback ref** (avoids empty ref on mount), **ResizeObserver** for resizes, **`document.fonts.ready`** after web-font swap, and re-measure when the title changes for virtualized cells.
> 
> Adds **unit tests** for title/not-found rendering and tooltip behavior (including post-font-load re-measure).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e59b6c8ce269da31304797cbc64dc8fd640770c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->