### PR TITLE
test(form): characterize custom-style-component leaf remount behind editor focus loss

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/LeafStability.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/LeafStability.browser.test.tsx
@@ -1,0 +1,39 @@
+import {describe, expect, it} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {page} from 'vitest/browser'
+
+import {testHelpers} from '../../../../../../test/browser/testHelpers'
+import {LeafStabilityStory} from './LeafStabilityStory'
+
+describe('Portable Text Input', () => {
+  describe('Render stability', () => {
+    // Toggling a style whose schema type has a custom `component` makes Studio's
+    // `Style` render `CustomComponent` where it rendered `DefaultComponent`, so
+    // React remounts the subtree and the editable leaf is a new node. That
+    // remount is the churn the editor's focus restoration races (EDEX-1410). PTE
+    // itself does not remount the leaf (portabletext/editor#2865); the swap is in
+    // Studio's render and is inherent to a consumer `component` wrapping the
+    // editable children.
+    it('remounts the editable leaf when toggling a custom style component', async () => {
+      const {getFocusedPortableTextEditor, insertPortableText} = testHelpers()
+      void render(<LeafStabilityStory />)
+
+      const $editor = await getFocusedPortableTextEditor('field-customStyle')
+      await insertPortableText('foo', $editor)
+
+      const leafBefore = $editor.element().querySelector('[data-pt-marks]')
+      expect(leafBefore).not.toBeNull()
+
+      // Toggle the custom Highlight style from the toolbar.
+      const $field = page.getByTestId('field-customStyle')
+      await $field.getByTestId('block-style-select').click()
+      await page.getByRole('menu').getByText('Highlight', {exact: true}).click()
+
+      // Wait for the custom style component to render.
+      await expect.element(page.getByTestId('highlight-mark')).toBeInTheDocument()
+
+      const leafAfter = $editor.element().querySelector('[data-pt-marks]')
+      expect(leafAfter).not.toBe(leafBefore)
+    })
+  })
+})

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/LeafStabilityStory.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/LeafStabilityStory.tsx
@@ -1,0 +1,39 @@
+import {defineArrayMember, defineField, defineType} from '@sanity/types'
+
+import {TestForm} from '../../../../../../test/browser/TestForm'
+import {TestWrapper} from '../../../../../../test/browser/TestWrapper'
+
+const SCHEMA_TYPES = [
+  defineType({
+    type: 'document',
+    name: 'test',
+    title: 'Test',
+    fields: [
+      defineField({
+        type: 'array',
+        name: 'customStyle',
+        of: [
+          defineArrayMember({
+            type: 'block',
+            styles: [
+              {title: 'Normal', value: 'normal'},
+              {
+                title: 'Highlight',
+                value: 'highlight',
+                component: ({children}) => <mark data-testid="highlight-mark">{children}</mark>,
+              },
+            ],
+          }),
+        ],
+      }),
+    ],
+  }),
+]
+
+export function LeafStabilityStory() {
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <TestForm />
+    </TestWrapper>
+  )
+}


### PR DESCRIPTION
### Description

Adds a deterministic browser test characterizing the React-stability behavior behind [EDEX-1410](https://linear.app/sanity/issue/EDEX-1410): toggling a block style whose schema type has a custom `component` remounts the editable leaf (the `[data-pt-marks]` span holding the caret's text node).

`Style.tsx` renders `CustomComponent ? <CustomComponent> : <DefaultComponent>`. Switching a style with a custom `component` on or off flips the React component type at that DOM position, so React remounts the subtree and the leaf is a new node. The editor's async focus restoration then races React's commit and lands on a node that no longer exists, which is the sporadic focus loss (worse with devtools open, i.e. slower renders).

The test asserts the remount via node identity (`leafBefore !== leafAfter`), so it's green and race-free, unlike the focus symptom itself. It's the Studio-layer counterpart to [portabletext/editor#2865](https://github.com/portabletext/editor/pull/2865), which pins that PTE does *not* remount the leaf on its own; together they localize the churn to the consumer-`component` swap in Studio's render.

The remount is inherent: a consumer `component` wraps the editable children, so switching it can only remount them. The durable fix is therefore PTE-side (restore selection/focus after an externally-induced remount), tracked in EDEX-1410. This PR is the characterization/repro, not the fix.

### What to review

The story (`LeafStabilityStory`) and the single node-identity assertion. No production code changes.

### Testing

`LeafStability.browser.test.tsx`, deterministic (~1.4s), no focus assertion, no `waitFor` on focus.

### Notes for release

N/A (test only).
