### PR TITLE
test(e2e): fix firefox test flake

### DIFF
--- a/e2e/studio-test.ts
+++ b/e2e/studio-test.ts
@@ -1,5 +1,5 @@
 // oxlint-disable-next-line no-restricted-imports
-import {test as baseTest} from '@playwright/test'
+import {expect, test as baseTest} from '@playwright/test'
 import {createClient, type SanityClient, type SanityDocument} from '@sanity/client'
 import {uuid} from '@sanity/uuid'
 
@@ -108,11 +108,24 @@ export const test = baseTest.extend<SanityFixtures>({
       const id = _testContext.getUniqueDocumentId()
 
       await page.goto(`${navigationPath};${id}`)
-      await page.locator('[data-testid="form-view"]').waitFor({state: 'visible', timeout: 30_000})
+      const formView = page.locator('[data-testid="form-view"]')
+      await formView.waitFor({state: 'visible', timeout: 30_000})
 
-      await page
-        .locator('[data-testid="form-view"]:not([data-read-only="true"])')
-        .waitFor({state: 'visible', timeout: 30_000})
+      // Require the form to stay editable across consecutive polls: a brand-new
+      // draft can briefly flip editable on a cached snapshot before reverting to
+      // read-only while it finishes connecting, and a plain `waitFor` would latch
+      // onto that transient render and return while controls are still disabled.
+      let consecutiveEditableReads = 0
+      await expect
+        .poll(
+          async () => {
+            const readOnly = await formView.getAttribute('data-read-only')
+            consecutiveEditableReads = readOnly === null ? consecutiveEditableReads + 1 : 0
+            return consecutiveEditableReads
+          },
+          {timeout: 30_000, intervals: [100]},
+        )
+        .toBeGreaterThanOrEqual(3)
 
       return id
     }

--- a/e2e/tests/enhanced-object-dialog/smoke.spec.ts
+++ b/e2e/tests/enhanced-object-dialog/smoke.spec.ts
@@ -136,10 +136,12 @@ test.describe('Enhanced Object Dialog - popover dialog', () => {
     // wait for form to be attached
     await createDraftDocument('/content/input-debug;objectsDebug')
 
-    await page
+    const addItemButton = page
       .getByTestId('field-animalsWithPopover')
       .getByRole('button', {name: 'Add item'})
-      .click()
+    // Clicking before the field is enabled is a no-op and the popover never opens.
+    await expect(addItemButton).toBeEnabled()
+    await addItemButton.click()
   })
 
   test(`the popover dialog should open on arrays that open with a popover and open the enhanced object dialog when opening nested objects`, async ({

--- a/e2e/tests/inputs/array.spec.ts
+++ b/e2e/tests/inputs/array.spec.ts
@@ -49,8 +49,11 @@ test(`file drop event should not propagate to dialog parent`, async ({
   // Ensure the list contains one item.
   await expect(item).toHaveCount(1)
 
-  // Open the dialog.
-  await page.getByRole('button', {name: fileName}).click()
+  // Open the dialog. The button stays disabled until the asset finishes
+  // uploading, which can exceed the default click timeout under CI load.
+  const fileButton = page.getByRole('button', {name: fileName})
+  await expect(fileButton).toBeEnabled({timeout: 30_000})
+  await fileButton.click()
   await expect(page.getByRole('dialog')).toBeVisible()
 
   // Drop the file again; this time, while the dialog is open.
@@ -160,7 +163,7 @@ test(`Scenario: Adding new array item before using the context menu`, async ({
 
   // And the "insert dialog" is closed
   await closeDialogButton.click()
-  await insertDialog.isHidden()
+  await expect(insertDialog).toBeHidden()
 
   // Then a new "(Dog)Dog" is inserted before "Book titleBy <unknown>"
   await expect(items.first()).toHaveText('(Dog)Dog')
@@ -171,8 +174,7 @@ test(`Scenario: Adding new array item after using the context menu`, async ({
   page,
   createDraftDocument,
 }) => {
-  const {popoverMenu, popoverMenuItem, insertDialog, input, closeDialogButton, items} =
-    createArrayFieldLocators(page)
+  const {popoverMenu, popoverMenuItem, insertDialog, input, items} = createArrayFieldLocators(page)
 
   // Given an array field allowing multiple types
   await createDraftDocument('/content/input-standard;arraysTest')
@@ -222,7 +224,7 @@ test(`Scenario: Adding new array item after using the context menu`, async ({
 
   // And the "insert dialog" is closed
   await page.keyboard.press('Escape')
-  await insertDialog.isHidden()
+  await expect(insertDialog).toBeHidden()
 
   // Then a new "(Cat)Cat" is inserted after "Book titleBy <unknown>"
   await expect(items.first()).toBeVisible()
@@ -258,25 +260,20 @@ async function addInitialArrayItem(
   page: Page,
   item: {menuItemLabel: string; inputLabel: string; content: string},
 ) {
-  const {
-    addItemButton,
-    popoverMenu,
-    popoverMenuItem,
-    insertDialog,
-    input,
-    closeDialogButton,
-    items,
-  } = createArrayFieldLocators(page)
+  const {addItemButton, popoverMenu, popoverMenuItem, insertDialog, input, items} =
+    createArrayFieldLocators(page)
 
   await addItemButton.click()
-  await popoverMenu.isVisible()
+  // Use auto-retrying `expect` rather than `locator.isVisible()`, which returns
+  // immediately and let the `fill` below race the dialog opening.
+  await expect(popoverMenu).toBeVisible()
   await popoverMenuItem(item.menuItemLabel).click()
-  await insertDialog.isVisible()
+  await expect(insertDialog).toBeVisible()
   await input(item.inputLabel).fill(item.content)
   await page.keyboard.press('Escape')
-  await insertDialog.isHidden()
+  await expect(insertDialog).toBeHidden()
   const insertedItem = items.first()
-  await insertedItem.isVisible()
+  await expect(insertedItem).toBeVisible()
 
   return insertedItem
 }

--- a/packages/sanity/src/core/form/inputs/files/common/fileTarget/utils/extractFiles.test.ts
+++ b/packages/sanity/src/core/form/inputs/files/common/fileTarget/utils/extractFiles.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, it} from 'vitest'
+
+import {extractDroppedFiles} from './extractFiles'
+
+function createFile(name: string): File {
+  return new File(['content'], name, {type: 'text/plain'})
+}
+
+/**
+ * Builds a DataTransfer-like object whose file only surfaces through `items`
+ * (with `webkitGetAsEntry()` returning null), mirroring how Firefox exposes a
+ * programmatically constructed DataTransfer.
+ */
+function createItemsOnlyDataTransfer(file: File): DataTransfer {
+  const item = {
+    kind: 'file' as const,
+    type: file.type,
+    getAsFile: () => file,
+    webkitGetAsEntry: () => null,
+  } as unknown as DataTransferItem
+
+  return {
+    files: [] as unknown as FileList,
+    items: [item] as unknown as DataTransferItemList,
+  } as unknown as DataTransfer
+}
+
+describe('extractDroppedFiles', () => {
+  it('reads files from `dataTransfer.files` when available', async () => {
+    const file = createFile('a.txt')
+    const dataTransfer = {
+      files: [file] as unknown as FileList,
+      items: [] as unknown as DataTransferItemList,
+    } as unknown as DataTransfer
+
+    await expect(extractDroppedFiles(dataTransfer)).resolves.toEqual([file])
+  })
+
+  it('falls back to `getAsFile()` when `webkitGetAsEntry()` returns null', async () => {
+    const file = createFile('capybara.jpg')
+
+    await expect(extractDroppedFiles(createItemsOnlyDataTransfer(file))).resolves.toEqual([file])
+  })
+})

--- a/packages/sanity/src/core/form/inputs/files/common/fileTarget/utils/extractFiles.ts
+++ b/packages/sanity/src/core/form/inputs/files/common/fileTarget/utils/extractFiles.ts
@@ -40,8 +40,12 @@ function normalizeItems(items: DataTransferItem[]) {
         } catch {
           return toArray(item.getAsFile())
         }
+        // `webkitGetAsEntry()` returns null for items that aren't backed by a
+        // real filesystem entry — notably files in a programmatically built
+        // DataTransfer on Firefox. The entry is only needed to detect
+        // directories, so fall back to reading the file directly.
         if (!entry) {
-          return []
+          return toArray(item.getAsFile())
         }
         return entry.isDirectory ? walk(entry as FIXME) : toArray(item.getAsFile())
       }


### PR DESCRIPTION
### Description

Fixes two Firefox related CI flakes:

- On Firefox a programmatically built DataTransfer (used by e2e drop tests) has empty `.files` and items whose `webkitGetAsEntry()` returns `null`, so the dropped file was dropped and the upload never started. This PR falls back to `getAsFile()`.
- Polls for stable form readiness in createDraftDocument. Now we'll wait for the uploaded item button to enable, and replace no-op `isVisible`/`isHidden` checks with auto-retrying expect assertions.

### What to review
Might also  fix an uploading issue in FF that we've been unaware of?

### Testing

### Notes for release
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Production change is a narrow fallback in file-drop parsing with unit tests; e2e-only timing/assertion hardening elsewhere.
> 
> **Overview**
> Fixes Firefox-related CI flakes and a real gap in file-drop handling when `DataTransfer` items have no filesystem entry.
> 
> **`extractDroppedFiles`** now calls **`getAsFile()`** when **`webkitGetAsEntry()`** returns `null` (common for programmatic transfers in Firefox), instead of treating the drop as empty. Vitest coverage mirrors Firefox’s items-only shape.
> 
> **E2E harness:** **`createDraftDocument`** polls until the form view is editable for **3 consecutive** reads so tests don’t proceed on a briefly editable cached snapshot. Specs wait for **enabled** controls (upload button, “Add item”) and swap one-shot **`isVisible`/`isHidden`** checks for auto-retrying **`expect`** assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c30abf751a675707e0c3ebf8684bb1765931567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->