### PR TITLE
chore(test-studio): disable variants perspective bar

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -307,7 +307,7 @@ const defaultWorkspace = defineConfig({
   },
   beta: {
     variants: {
-      enabled: true,
+      enabled: false,
     },
   },
 })
@@ -474,7 +474,7 @@ export default defineConfig([
     },
     beta: {
       variants: {
-        enabled: true,
+        enabled: false,
       },
     },
   },


### PR DESCRIPTION
### Description

The test-studio enabled the beta variants perspective bar in both the shared default workspace and the standalone staging workspace.

This PR flips `beta.variants.enabled` to `false` in both, turning the variants perspective bar off in the dev test-studio.

### Notes for release

N/A
