### PR TITLE
chore(test-studio): disable variants and enable document group inventory

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -307,6 +307,9 @@ const defaultWorkspace = defineConfig({
   },
   beta: {
     variants: {
+      enabled: false,
+    },
+    documentGroupInventory: {
       enabled: true,
     },
   },
@@ -474,6 +477,9 @@ export default defineConfig([
     },
     beta: {
       variants: {
+        enabled: false,
+      },
+      documentGroupInventory: {
         enabled: true,
       },
     },


### PR DESCRIPTION
### Description

The test-studio enabled `beta.variants.enabled` in the default and staging workspaces, which forced the variants perspective bar on and, through its coupling, also forced the document group inventory on. We want to exercise the document group inventory on its own, without the variants experience.

This PR sets `beta.variants.enabled` to `false` and adds an explicit `beta.documentGroupInventory.enabled: true` to both the default and staging workspaces. Because the inventory flag resolves to `documentGroupInventoryEnabledReducer(...) || variantsEnabled`, turning variants off is what lets the explicit inventory flag take effect rather than being overridden.

### What to review

- `dev/test-studio/sanity.config.ts` - the two `beta` blocks (default workspace and staging) now carry `variants.enabled: false` and `documentGroupInventory.enabled: true`.

### Notes for release

N/A
