### PR TITLE
fix(studio): handle request errors in non-critical fetch paths

### DIFF
--- a/packages/sanity/src/core/form/studio/assetSourceDataset/shared/SelectAssetsDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceDataset/shared/SelectAssetsDialog.tsx
@@ -1,6 +1,6 @@
 import {DownloadIcon, InfoOutlineIcon} from '@sanity/icons'
 import {type Asset, type AssetFromSource, type AssetSourceComponentProps} from '@sanity/types'
-import {Card, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Flex, Stack, Text, useToast} from '@sanity/ui'
 import uniqueId from 'lodash-es/uniqueId.js'
 import {
   type ForwardedRef,
@@ -108,6 +108,7 @@ const SelectAssetsComponent = function SelectAssetsComponent(
   const [_elementId] = useState(() => `default-asset-source-${uniqueId()}`)
   const currentPageNumber = useRef(0)
   const {t} = useTranslation()
+  const toast = useToast()
   const fetch$ = useRef<Subscription>(undefined)
   const [assets, setAssets] = useState<Asset[]>([])
   const [isLastPage, setIsLastPage] = useState(false)
@@ -129,14 +130,26 @@ const SelectAssetsComponent = function SelectAssetsComponent(
       if (typeof accept !== 'undefined') {
         fetch$.current = versionedClient.observable
           .fetch(buildQuery(start, end, assetTypeParam, accept), {}, {tag})
-          .subscribe((result) => {
-            setIsLastPage(result.length < PER_PAGE)
-            setAssets((prevState) => prevState.concat(result))
-            setIsLoading(false)
+          .subscribe({
+            next: (result) => {
+              setIsLastPage(result.length < PER_PAGE)
+              setAssets((prevState) => prevState.concat(result))
+              setIsLoading(false)
+            },
+            error: (err) => {
+              // Without this the dialog would spin forever (and the error
+              // would surface as an unhandled rxjs error).
+              console.error(err)
+              setIsLoading(false)
+              toast.push({
+                status: 'error',
+                title: t('asset-source.dialog.load-error'),
+              })
+            },
           })
       }
     },
-    [assetType, accept, versionedClient],
+    [assetType, accept, versionedClient, toast, t],
   )
 
   const handleDeleteFinished = useCallback(

--- a/packages/sanity/src/core/form/studio/assetSourceDataset/shared/SelectAssetsDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceDataset/shared/SelectAssetsDialog.tsx
@@ -141,6 +141,9 @@ const SelectAssetsComponent = function SelectAssetsComponent(
               // would surface as an unhandled rxjs error).
               console.error(err)
               setIsLoading(false)
+              // Roll back the page that failed to load so the next "Load more"
+              // retries it instead of skipping ahead and leaving a gap.
+              currentPageNumber.current = pageNumber > 0 ? pageNumber - 1 : 0
               toast.push({
                 status: 'error',
                 title: t('asset-source.dialog.load-error'),

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -135,6 +135,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Insert asset error */
   'asset-source.dialog.insert-asset-error':
     'Error inserting asset. See the console for more information.',
+  /** Toast title shown when the list of assets failed to load */
+  'asset-source.dialog.load-error': 'Failed to load assets',
   /** Select asset dialog load more items */
   'asset-source.dialog.load-more': 'Load more',
   /** Text shown when selecting a file but there's no files to select from

--- a/packages/sanity/src/core/network/isUsingLegacyHttp.test.ts
+++ b/packages/sanity/src/core/network/isUsingLegacyHttp.test.ts
@@ -107,6 +107,9 @@ describe('isUsingLegacyHttp', () => {
 
   describe('error handling', () => {
     it('emits undefined instead of erroring when the probe request fails', async () => {
+      // Silence (and assert) the expected warning from the error path.
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
       // e.g. the browser is offline or the request is blocked
       vi.mocked(fetch).mockRejectedValue(new TypeError('Failed to fetch'))
 
@@ -130,6 +133,7 @@ describe('isUsingLegacyHttp', () => {
       } as unknown as SanityClient
 
       await expect(firstValueFrom(isUsingLegacyHttp(client))).resolves.toBeUndefined()
+      expect(warnSpy).toHaveBeenCalled()
     })
   })
 })

--- a/packages/sanity/src/core/network/isUsingLegacyHttp.test.ts
+++ b/packages/sanity/src/core/network/isUsingLegacyHttp.test.ts
@@ -104,4 +104,32 @@ describe('isUsingLegacyHttp', () => {
       expect(bodyWasConsumed).toBe(true)
     })
   })
+
+  describe('error handling', () => {
+    it('emits undefined instead of erroring when the probe request fails', async () => {
+      // e.g. the browser is offline or the request is blocked
+      vi.mocked(fetch).mockRejectedValue(new TypeError('Failed to fetch'))
+
+      // PerformanceObserver that never reports any entries
+      vi.stubGlobal(
+        'PerformanceObserver',
+        class {
+          observe() {
+            // never emits
+          }
+          disconnect() {
+            // noop
+          }
+        },
+      )
+      // oxlint-disable-next-line typescript/no-extraneous-class
+      vi.stubGlobal('PerformanceResourceTiming', class FakePerformanceResourceTiming {})
+
+      const client = {
+        getUrl: (path: string) => `https://test.api.sanity.io/v2025-02-19${path}`,
+      } as unknown as SanityClient
+
+      await expect(firstValueFrom(isUsingLegacyHttp(client))).resolves.toBeUndefined()
+    })
+  })
 })

--- a/packages/sanity/src/core/network/isUsingLegacyHttp.ts
+++ b/packages/sanity/src/core/network/isUsingLegacyHttp.ts
@@ -1,6 +1,6 @@
 import {type SanityClient} from '@sanity/client'
 import {defer, firstValueFrom, Observable, of, take, timeout} from 'rxjs'
-import {filter, map, mergeMap} from 'rxjs/operators'
+import {catchError, filter, map, mergeMap} from 'rxjs/operators'
 
 /**
  * The /ping route is special in that it allows any origin to access it, and crucially
@@ -67,7 +67,8 @@ function getProtocolForApi(client: SanityClient): Observable<string | undefined>
 /**
  * Creates an Observable that sets up a PerformanceObserver, issues the network request,
  * and emits the `nextHopProtocol` once the resource timing shows up. If the request
- * fails, the Observable will emit an error.
+ * fails (e.g. the browser is offline or the request is blocked), the Observable emits
+ * `undefined` to indicate that the protocol could not be detected.
  *
  * @internal
  */
@@ -97,6 +98,13 @@ function detectProtocol(checkUrl: string): Observable<string | undefined> {
     // Race the actual timing detection against a 2.5s timer.
     // If the timer wins, we emit undefined to indicate we couldn’t detect the protocol.
     timeout({first: 2500, with: () => of(undefined)}),
+    // A failed request (offline, blocked, etc.) also means we couldn’t detect the
+    // protocol — warn and emit undefined instead of erroring so consumers don’t
+    // have to treat a failed probe as an exceptional condition.
+    catchError((error) => {
+      console.warn('[sanity] Could not detect network protocol:', error)
+      return of(undefined)
+    }),
   )
 }
 

--- a/packages/sanity/src/core/network/isUsingLegacyHttp.ts
+++ b/packages/sanity/src/core/network/isUsingLegacyHttp.ts
@@ -81,6 +81,11 @@ function detectProtocol(checkUrl: string): Observable<string | undefined> {
       ),
       take(1),
       map((entry) => localStorage._sanity_debugProtocol ?? entry.nextHopProtocol),
+      // The timing entry may never arrive (e.g. the fetch failed before any
+      // resource timing was recorded). Settle after the same window as the
+      // outer race so this promise resolves and the PerformanceObserver is
+      // torn down deterministically instead of leaking a subscription.
+      timeout({first: 2500, with: () => of(undefined)}),
     ),
   )
 

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -125,8 +125,16 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
 
     void Promise.all([resolveLatestTaggedVersion, resolveAutoUpdatingVersion])
       .then(([nextLatestVersion, nextAutoUpdatingVersion]) => {
-        setAutoUpdatingVersionRaw(nextAutoUpdatingVersion)
-        setLatestTaggedVersionRaw(nextLatestVersion)
+        // `fetchLatestVersions` resolves `undefined` on a failed fetch (rather
+        // than rejecting), so only overwrite state when we actually got a value.
+        // This keeps the previously known versions on a transient failure and
+        // we try again on the next tick.
+        if (typeof nextAutoUpdatingVersion !== 'undefined') {
+          setAutoUpdatingVersionRaw(nextAutoUpdatingVersion)
+        }
+        if (typeof nextLatestVersion !== 'undefined') {
+          setLatestTaggedVersionRaw(nextLatestVersion)
+        }
       })
       .catch((err) => {
         // Best-effort version poll — keep the previously known versions

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -128,6 +128,11 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
         setAutoUpdatingVersionRaw(nextAutoUpdatingVersion)
         setLatestTaggedVersionRaw(nextLatestVersion)
       })
+      .catch((err) => {
+        // Best-effort version poll — keep the previously known versions
+        // and try again on the next tick.
+        console.warn('[sanity] Failed to check for new studio versions:', err)
+      })
       .finally(() => setVersionCheckStatus({lastCheckedAt: new Date(), checking: false}))
   }, [currentVersion, importMapInfo])
 

--- a/packages/sanity/src/core/studio/packageVersionStatus/fetchLatestVersions.ts
+++ b/packages/sanity/src/core/studio/packageVersionStatus/fetchLatestVersions.ts
@@ -51,7 +51,13 @@ export const fetchLatestAutoUpdatingVersion = async (options: {
         accept: 'application/json',
       },
     })
-    return res.json().then((data): string => data.packageVersion)
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} ${res.statusText}`)
+    }
+    // `return await` (not bare `return`) so a JSON parse rejection is
+    // caught by this try/catch instead of escaping to the caller.
+    const data = await res.json()
+    return data.packageVersion as string
   } catch (err) {
     console.error(
       new Error(`Failed to fetch version for package "${packageName}" (using appId=${appId})`, {
@@ -75,7 +81,13 @@ export const fetchLatestAvailableVersionForPackage = async (options: {
         accept: 'application/json',
       },
     })
-    return res.json().then((data): string => data.latest)
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} ${res.statusText}`)
+    }
+    // `return await` (not bare `return`) so a JSON parse rejection is
+    // caught by this try/catch instead of escaping to the caller.
+    const data = await res.json()
+    return data.latest as string
   } catch (err) {
     console.error(
       `Failed to fetch version for package (using tag=${tag})`,

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/CrossDatasetIncomingReference/getCrossDatasetIncomingReferences.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/CrossDatasetIncomingReference/getCrossDatasetIncomingReferences.tsx
@@ -1,6 +1,6 @@
 import {DocumentIcon} from '@sanity/icons'
 import {type PreviewValue} from '@sanity/types'
-import {catchError, map, type Observable, of, startWith} from 'rxjs'
+import {catchError, map, type Observable, of, startWith, switchMap} from 'rxjs'
 import {mergeMapArray} from 'rxjs-mergemap-array'
 import {
   type DocumentAvailability,
@@ -58,97 +58,105 @@ export function getCrossDatasetIncomingReferences({
   documents: CrossDatasetIncomingReferenceDocument[]
   loading: boolean
 }> {
-  // Here we get all the references to this document from the any other dataset
+  // Here we get all the references to this document from the any other dataset.
+  // `fetchCrossDatasetReferences` is poll-driven (it re-emits on visibility
+  // changes), so we run the per-emission pipeline inside a `switchMap` and catch
+  // there. That way a transient failure of a single poll degrades to an empty
+  // list without completing the outer observable, allowing a later poll tick to
+  // recover. Consumers render this via `useObservable`, which rethrows stream
+  // errors during render and would crash the document pane.
   return fetchCrossDatasetReferences(documentId, {versionedClient: client}).pipe(
-    map((result) => {
-      if (!result) return []
-      if (!type?.dataset) {
-        // Return all the references that contain a datasetName and a documentId.
-        return result.references.filter(
-          (ref) => ref.documentId && ref.datasetName,
-        ) as CompleteReferencesResponse[]
-      }
-      // Return all the references with document id and where the datasetName matches with the dataset provided.
-      return result.references.filter(
-        (ref) => ref.datasetName === type.dataset && ref.documentId,
-      ) as CompleteReferencesResponse[]
-    }),
-    // Now that we have all the references from the dataset the user defined, we need to get the document type from the documentId
-    mergeMapArray((document) =>
-      documentPreviewStore
-        .observeDocumentTypeFromId(getPublishedId(document.documentId), {
-          dataset: document.datasetName,
-          projectId: document.projectId,
-        })
-        .pipe(map((documentType) => ({...document, documentType}))),
-    ),
-
-    mergeMapArray((document) => {
-      if (!document.documentType) return of(null)
-      if (!type) {
-        // If we don't have a type defined with the preview we can't derive how the document preview will look
-        // So let's use the document Id as the title, dataset name as subtitle and a default icon.
-        // as next step we will implement an option to configure the inspector and provide a preview and url config
-        // for each of the types.
-        return of({
-          type: document.documentType,
-          id: document.documentId,
-          preview: {
-            published: {
-              _id: document.documentId,
-              title: `Document Id: ${document.documentId}`,
-              subtitle: `Dataset: ${document.datasetName} - Project Id: ${document.projectId}`,
-              media: <DocumentIcon />,
-            } as PreviewValue,
-          },
-          availability: {available: true, reason: 'READABLE'} as const,
-          projectId: document.projectId,
-          dataset: document.datasetName,
-        })
-      }
-
-      // We filter the documents so only the documents of the type the user defined are included
-      if (document.documentType !== type.type) return of(null)
-      const previewPaths = getPreviewPaths(type.preview) || []
-      //  Now we get the preview values for the document so we can display it in the preview
-      return documentPreviewStore
-        .observePaths({_id: getPublishedId(document.documentId)}, previewPaths, {
-          dataset: document.datasetName,
-          projectId: document.projectId,
-        })
-        .pipe(
-          map((result) => {
-            const previewValue = prepareForPreview(result, {
-              type: type.type,
-              title: type.title || '',
-              icon: () => <DocumentIcon />,
-              preview: type.preview,
+    switchMap((referencesResult) =>
+      of(referencesResult).pipe(
+        map((res) => {
+          if (!res) return []
+          if (!type?.dataset) {
+            // Return all the references that contain a datasetName and a documentId.
+            return res.references.filter(
+              (ref) => ref.documentId && ref.datasetName,
+            ) as CompleteReferencesResponse[]
+          }
+          // Return all the references with document id and where the datasetName matches with the dataset provided.
+          return res.references.filter(
+            (ref) => ref.datasetName === type.dataset && ref.documentId,
+          ) as CompleteReferencesResponse[]
+        }),
+        // Now that we have all the references from the dataset the user defined, we need to get the document type from the documentId
+        mergeMapArray((document) =>
+          documentPreviewStore
+            .observeDocumentTypeFromId(getPublishedId(document.documentId), {
+              dataset: document.datasetName,
+              projectId: document.projectId,
             })
-            return {
-              type: document.documentType as string,
+            .pipe(map((documentType) => ({...document, documentType}))),
+        ),
+
+        mergeMapArray((document) => {
+          if (!document.documentType) return of(null)
+          if (!type) {
+            // If we don't have a type defined with the preview we can't derive how the document preview will look
+            // So let's use the document Id as the title, dataset name as subtitle and a default icon.
+            return of({
+              type: document.documentType,
               id: document.documentId,
               preview: {
                 published: {
-                  ...previewValue,
-                  media: previewValue.media ?? <DocumentIcon />,
-                },
+                  _id: document.documentId,
+                  title: `Document Id: ${document.documentId}`,
+                  subtitle: `Dataset: ${document.datasetName} - Project Id: ${document.projectId}`,
+                  media: <DocumentIcon />,
+                } as PreviewValue,
               },
               availability: {available: true, reason: 'READABLE'} as const,
               projectId: document.projectId,
               dataset: document.datasetName,
-            }
-          }),
-        )
-    }),
-    map((documents) => ({documents: documents.filter(isNonNullable), loading: false})),
+            })
+          }
+
+          // We filter the documents so only the documents of the type the user defined are included
+          if (document.documentType !== type.type) return of(null)
+          const previewPaths = getPreviewPaths(type.preview) || []
+          //  Now we get the preview values for the document so we can display it in the preview
+          return documentPreviewStore
+            .observePaths({_id: getPublishedId(document.documentId)}, previewPaths, {
+              dataset: document.datasetName,
+              projectId: document.projectId,
+            })
+            .pipe(
+              map((result) => {
+                const previewValue = prepareForPreview(result, {
+                  type: type.type,
+                  title: type.title || '',
+                  icon: () => <DocumentIcon />,
+                  preview: type.preview,
+                })
+                return {
+                  type: document.documentType as string,
+                  id: document.documentId,
+                  preview: {
+                    published: {
+                      ...previewValue,
+                      media: previewValue.media ?? <DocumentIcon />,
+                    },
+                  },
+                  availability: {available: true, reason: 'READABLE'} as const,
+                  projectId: document.projectId,
+                  dataset: document.datasetName,
+                }
+              }),
+            )
+        }),
+        map((documents) => ({documents: documents.filter(isNonNullable), loading: false})),
+        // Cross-dataset queries are failure-prone (token / dataset permission
+        // errors). Degrade this poll tick to an empty list instead of erroring;
+        // catching inside the `switchMap` keeps the outer stream alive so a
+        // later poll can recover.
+        catchError((err) => {
+          console.error(new Error('Failed to load cross-dataset incoming references', {cause: err}))
+          return of({documents: [], loading: false})
+        }),
+      ),
+    ),
     startWith(INITIAL_STATE),
-    // Cross-dataset queries are failure-prone (token / dataset permission
-    // errors). Consumers render this via `useObservable`, which rethrows
-    // stream errors during render and would crash the document pane.
-    // Degrade to an empty list instead.
-    catchError((err) => {
-      console.error(new Error('Failed to load cross-dataset incoming references', {cause: err}))
-      return of({documents: [], loading: false})
-    }),
   )
 }

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/CrossDatasetIncomingReference/getCrossDatasetIncomingReferences.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/CrossDatasetIncomingReference/getCrossDatasetIncomingReferences.tsx
@@ -1,6 +1,6 @@
 import {DocumentIcon} from '@sanity/icons'
 import {type PreviewValue} from '@sanity/types'
-import {map, type Observable, of, startWith} from 'rxjs'
+import {catchError, map, type Observable, of, startWith} from 'rxjs'
 import {mergeMapArray} from 'rxjs-mergemap-array'
 import {
   type DocumentAvailability,
@@ -142,5 +142,13 @@ export function getCrossDatasetIncomingReferences({
     }),
     map((documents) => ({documents: documents.filter(isNonNullable), loading: false})),
     startWith(INITIAL_STATE),
+    // Cross-dataset queries are failure-prone (token / dataset permission
+    // errors). Consumers render this via `useObservable`, which rethrows
+    // stream errors during render and would crash the document pane.
+    // Degrade to an empty list instead.
+    catchError((err) => {
+      console.error(new Error('Failed to load cross-dataset incoming references', {cause: err}))
+      return of({documents: [], loading: false})
+    }),
   )
 }

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx
@@ -116,7 +116,6 @@ export function IncomingReferencesType({
           ...(publishedExists ? {} : {_weak: true, _strengthenOnPublish: {type: referenced.type}}),
         })
         if (!linkedDocument) {
-          setNewReferenceId(null)
           toast.push({
             title: 'Not possible to link to document',
             description: 'The document you are trying to link cannot be linked to',
@@ -131,21 +130,21 @@ export function IncomingReferencesType({
           linkedDocument._id = getDraftId(documentId)
         }
         await client.createOrReplace(linkedDocument)
-        // Clear the optimistic placeholder on success. The effect below also
-        // clears it once the linked document shows up in `documents`, but that
-        // never happens if the references stream has degraded to an empty list
-        // (e.g. after a load error), so don't rely on it alone.
-        setNewReferenceId(null)
       } catch (err) {
         // The fetch or write failed (e.g. insufficient permissions) —
-        // reset the optimistic row and tell the user.
-        setNewReferenceId(null)
+        // tell the user.
         console.error(err)
         toast.push({
           title: 'Failed to link document',
           description: err instanceof Error ? err.message : undefined,
           status: 'error',
         })
+      } finally {
+        // Always clear the optimistic placeholder. The effect below also clears
+        // it once the linked document shows up in `documents`, but that never
+        // happens if the references stream has degraded to an empty list (e.g.
+        // after a load error), so don't rely on it alone.
+        setNewReferenceId(null)
       }
     },
     [client, onLinkDocument, referenced, publishedExists, toast, schemaType],

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx
@@ -106,32 +106,44 @@ export function IncomingReferencesType({
     async (documentId: string) => {
       setIsAdding(false)
       setNewReferenceId(documentId)
-      const liveEdit = Boolean(schemaType?.liveEdit)
-      const document = await client.fetch('*[_id == $id][0]', {id: documentId})
+      try {
+        const liveEdit = Boolean(schemaType?.liveEdit)
+        const document = await client.fetch('*[_id == $id][0]', {id: documentId})
 
-      const linkedDocument = onLinkDocument?.(document, {
-        _type: 'reference',
-        _ref: getPublishedId(referenced.id),
-        ...(publishedExists ? {} : {_weak: true, _strengthenOnPublish: {type: referenced.type}}),
-      })
-      if (!linkedDocument) {
+        const linkedDocument = onLinkDocument?.(document, {
+          _type: 'reference',
+          _ref: getPublishedId(referenced.id),
+          ...(publishedExists ? {} : {_weak: true, _strengthenOnPublish: {type: referenced.type}}),
+        })
+        if (!linkedDocument) {
+          setNewReferenceId(null)
+          toast.push({
+            title: 'Not possible to link to document',
+            description: 'The document you are trying to link cannot be linked to',
+            status: 'error',
+          })
+          return
+        }
+
+        // if the document is published and the schema is not live edit, we want to update the draft id, not the published id
+        // If it's a version, we can update the version document.
+        if (isPublishedId(documentId) && !liveEdit) {
+          linkedDocument._id = getDraftId(documentId)
+        }
+        await client.createOrReplace(linkedDocument)
+      } catch (err) {
+        // The fetch or write failed (e.g. insufficient permissions) —
+        // reset the optimistic row and tell the user.
         setNewReferenceId(null)
+        console.error(err)
         toast.push({
-          title: 'Not possible to link to document',
-          description: 'The document you are trying to link cannot be linked to',
+          title: 'Failed to link document',
+          description: err instanceof Error ? err.message : undefined,
           status: 'error',
         })
-        return
       }
-
-      // if the document is published and the schema is not live edit, we want to update the draft id, not the published id
-      // If it's a version, we can update the version document.
-      if (isPublishedId(documentId) && !liveEdit) {
-        linkedDocument._id = getDraftId(documentId)
-      }
-      await client.createOrReplace(linkedDocument)
     },
-    [client, onLinkDocument, referenced, publishedExists, toast, schemaType?.liveEdit],
+    [client, onLinkDocument, referenced, publishedExists, toast, schemaType],
   )
 
   useEffect(() => {

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx
@@ -131,6 +131,11 @@ export function IncomingReferencesType({
           linkedDocument._id = getDraftId(documentId)
         }
         await client.createOrReplace(linkedDocument)
+        // Clear the optimistic placeholder on success. The effect below also
+        // clears it once the linked document shows up in `documents`, but that
+        // never happens if the references stream has degraded to an empty list
+        // (e.g. after a load error), so don't rely on it alone.
+        setNewReferenceId(null)
       } catch (err) {
         // The fetch or write failed (e.g. insufficient permissions) —
         // reset the optimistic row and tell the user.

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/getIncomingReferences.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/getIncomingReferences.tsx
@@ -120,14 +120,17 @@ export function getIncomingReferences({
 
           map((documents) => ({documents, loading: false})),
           startWith(INITIAL_STATE),
+          // Catch inside the `switchMap` so a failure of this inner stream
+          // degrades to an empty list without completing the outer observable.
+          // Consumers render this via `useObservable`, which rethrows stream
+          // errors during render and would crash the document pane. Keeping the
+          // outer stream alive means a later `filterResolver` emission can
+          // re-subscribe and recover from a transient error.
+          catchError((err) => {
+            console.error(new Error('Failed to load incoming references', {cause: err}))
+            return of({documents: [], loading: false})
+          }),
         )
-    }),
-    // Consumers render this via `useObservable`, which rethrows stream
-    // errors during render and would crash the document pane. Degrade to
-    // an empty list instead.
-    catchError((err) => {
-      console.error(new Error('Failed to load incoming references', {cause: err}))
-      return of({documents: [], loading: false})
     }),
   )
 }

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/getIncomingReferences.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/getIncomingReferences.tsx
@@ -1,4 +1,13 @@
-import {distinctUntilChanged, filter, map, type Observable, of, startWith, switchMap} from 'rxjs'
+import {
+  catchError,
+  distinctUntilChanged,
+  filter,
+  map,
+  type Observable,
+  of,
+  startWith,
+  switchMap,
+} from 'rxjs'
 import {mergeMapArray} from 'rxjs-mergemap-array'
 import {
   type DocumentPreviewStore,
@@ -112,6 +121,13 @@ export function getIncomingReferences({
           map((documents) => ({documents, loading: false})),
           startWith(INITIAL_STATE),
         )
+    }),
+    // Consumers render this via `useObservable`, which rethrows stream
+    // errors during render and would crash the document pane. Degrade to
+    // an empty list instead.
+    catchError((err) => {
+      console.error(new Error('Failed to load incoming references', {cause: err}))
+      return of({documents: [], loading: false})
     }),
   )
 }

--- a/packages/sanity/src/structure/structureBuilder/util/resolveTypeForDocument.ts
+++ b/packages/sanity/src/structure/structureBuilder/util/resolveTypeForDocument.ts
@@ -8,11 +8,15 @@ export async function resolveTypeForDocument(
   const query = '*[sanity::versionOf($publishedId)][0]._type'
 
   try {
-    return await getClient(DEFAULT_STUDIO_CLIENT_OPTIONS).fetch(
+    // `fetch` resolves to `null` when no document matches the query. Coalesce
+    // to `undefined` so the return type stays accurate and callers only have to
+    // handle a single "not resolved" value.
+    const type = await getClient(DEFAULT_STUDIO_CLIENT_OPTIONS).fetch<string | null>(
       query,
       {publishedId: getPublishedId(id)},
       {tag: 'structure.resolve-type'},
     )
+    return type ?? undefined
   } catch (err) {
     // Returning undefined keeps pane resolution from crashing on a failed
     // request during navigation. The two callers handle it differently:

--- a/packages/sanity/src/structure/structureBuilder/util/resolveTypeForDocument.ts
+++ b/packages/sanity/src/structure/structureBuilder/util/resolveTypeForDocument.ts
@@ -7,11 +7,18 @@ export async function resolveTypeForDocument(
 ): Promise<string | undefined> {
   const query = '*[sanity::versionOf($publishedId)][0]._type'
 
-  const type = await getClient(DEFAULT_STUDIO_CLIENT_OPTIONS).fetch(
-    query,
-    {publishedId: getPublishedId(id)},
-    {tag: 'structure.resolve-type'},
-  )
-
-  return type
+  try {
+    return await getClient(DEFAULT_STUDIO_CLIENT_OPTIONS).fetch(
+      query,
+      {publishedId: getPublishedId(id)},
+      {tag: 'structure.resolve-type'},
+    )
+  } catch (err) {
+    // Returning undefined keeps pane resolution from crashing on a failed
+    // request during navigation. The two callers handle it differently:
+    // DocumentList falls back to the "unknown document type" pane, while
+    // Document throws a SerializeError (no type could be resolved).
+    console.error(new Error(`Failed to resolve document type for "${id}"`, {cause: err}))
+    return undefined
+  }
 }


### PR DESCRIPTION
### Description

Fixes a handful of unhandled rejections and stuck loading states found in an error-handling audit. Adds local error handling (catch / error callbacks / catchError) to floating promises and next-only subscriptions:

- `fetchLatestVersions`: res.ok check + return await so JSON parse failures hit the try/catch
- dataset asset picker: error handler on the page fetch, was spinning forever, now pops a toast
- incoming references: try/catch + toast around link flow; catchError in both reference observables (useObservable rethrow was crashing the document pane)
- `resolveTypeForDocument` in structure: return undefined on failure so pane resolution does not crash during navigation
- network protocol detection: warn + undefined instead of erroring into a next-only subscribe at studio boot

### What to review
These should all be safe and prevent a few cases of the studio from crashing from network failures

### Testing


### Notes for release
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are defensive error handling on best-effort UI paths; behavior on success is unchanged, with intentional empty-list degradation on reference load failures.
> 
> **Overview**
> Hardens **non-critical network and RxJS paths** so transient failures degrade gracefully instead of infinite spinners, unhandled rejections, or document-pane crashes.
> 
> **Dataset asset picker** (`SelectAssetsDialog`): page fetches now use a subscription `error` handler—stops loading, rolls back the page counter for retry, and shows a toast (`asset-source.dialog.load-error`).
> 
> **Studio version polling**: `fetchLatestVersions` checks `res.ok` and uses `return await` on JSON parse; `PackageVersionStatusProvider` only updates version state when fetches return values and logs warnings on unexpected rejections.
> 
> **HTTP protocol probe** (`isUsingLegacyHttp`): failed or timed-out probes emit `undefined` with `catchError`/`timeout` instead of erroring; new test covers offline fetch.
> 
> **Incoming references**: `catchError` inside `switchMap` on same-dataset and cross-dataset observables returns an empty list while keeping the outer stream alive for later polls; link flow is wrapped in try/catch/finally with error toasts and always clears the optimistic placeholder.
> 
> **Structure navigation**: `resolveTypeForDocument` catches fetch failures and returns `undefined` so pane resolution does not throw during navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa19bd79af474679a0cea5cda71c468d7403e444. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->