### PR TITLE
test(portable-text): pin editing flows to the document value

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/CustomBlockComponentsStory.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/CustomBlockComponentsStory.tsx
@@ -1,0 +1,48 @@
+import {type SanityDocument} from '@sanity/client'
+import {defineArrayMember, defineField, defineType} from '@sanity/types'
+
+import {TestForm} from '../../../../../../test/browser/TestForm'
+import {TestWrapper} from '../../../../../../test/browser/TestWrapper'
+import {type BlockListItemProps, type BlockStyleProps} from '../../../types'
+
+function CustomStyleComponent(props: BlockStyleProps) {
+  return <div data-testid="custom-style-component">{props.renderDefault(props)}</div>
+}
+
+function CustomListItemComponent(props: BlockListItemProps) {
+  return <div data-testid="custom-list-component">{props.renderDefault(props)}</div>
+}
+
+const SCHEMA_TYPES = [
+  defineType({
+    type: 'document',
+    name: 'test',
+    title: 'Test',
+    fields: [
+      defineField({
+        type: 'array',
+        name: 'customComponents',
+        of: [
+          defineArrayMember({
+            type: 'block',
+            styles: [
+              {title: 'Normal', value: 'normal'},
+              {title: 'Custom Style', value: 'custom', component: CustomStyleComponent},
+            ],
+            lists: [
+              {title: 'Custom List', value: 'customList', component: CustomListItemComponent},
+            ],
+          }),
+        ],
+      }),
+    ],
+  }),
+]
+
+export function CustomBlockComponentsStory({document}: {document?: SanityDocument}) {
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <TestForm document={document} />
+    </TestWrapper>
+  )
+}

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/Decorators.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/Decorators.browser.test.tsx
@@ -82,6 +82,29 @@ describe('Portable Text Input', () => {
       }
     })
 
+    it('applying a decorator writes `marks` to the document value', async () => {
+      const {
+        getFocusedPortableTextEditor,
+        getModifierKey,
+        insertPortableText,
+        toggleHotkey,
+        waitForDocumentState,
+      } = testHelpers()
+      void render(<DecoratorsStory />)
+      const $pte = await getFocusedPortableTextEditor('field-defaultDecorators')
+      const modifierKey = getModifierKey()
+
+      await toggleHotkey('b', modifierKey)
+      await insertPortableText('bold text', $pte)
+
+      // Assertion: the span carries the decorator mark
+      const documentState = await waitForDocumentState((state) => {
+        const span = state?.defaultDecorators?.[0]?.children?.[0]
+        return span?.text === 'bold text' && span?.marks?.includes('strong')
+      })
+      expect(documentState.defaultDecorators[0].children[0].marks).toEqual(['strong'])
+    })
+
     describe('Toolbar buttons', () => {
       it('Should display all default decorator buttons', async () => {
         const {getFocusedPortableTextInput} = testHelpers()

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/Lists.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/Lists.browser.test.tsx
@@ -1,0 +1,66 @@
+import {describe, expect, it} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {page} from 'vitest/browser'
+
+import {testHelpers} from '../../../../../../test/browser/testHelpers'
+import {CustomBlockComponentsStory} from './CustomBlockComponentsStory'
+import {StylesStory} from './StylesStory'
+
+describe('Portable Text Input', () => {
+  describe('Lists', () => {
+    it('toggling a list writes `listItem`/`level` and emits the counter attributes', async () => {
+      const {
+        getFocusedPortableTextInput,
+        getFocusedPortableTextEditor,
+        insertPortableText,
+        findBySelector,
+        waitForDocumentState,
+      } = testHelpers()
+      void render(<StylesStory />)
+
+      const $portableTextInput = await getFocusedPortableTextInput('field-defaultStyles')
+      const $pte = await getFocusedPortableTextEditor('field-defaultStyles')
+      await insertPortableText('List item text', $pte)
+
+      const $numberButton = await findBySelector(
+        $portableTextInput,
+        'button[data-testid="action-button-number"]:not([disabled])',
+      )
+      await $numberButton.click()
+
+      const documentState = await waitForDocumentState(
+        (state) => state?.defaultStyles?.[0]?.listItem === 'number',
+      )
+      expect(documentState.defaultStyles[0].listItem).toEqual('number')
+      expect(documentState.defaultStyles[0].level).toEqual(1)
+
+      // The ordered-list counter CSS keys off these editor-emitted attributes.
+      const $listBlock = await findBySelector($pte, '[data-pt-block="text"][data-level]')
+      expect($listBlock.element().getAttribute('data-level')).toEqual('1')
+      expect($listBlock.element().hasAttribute('data-list-index')).toBe(true)
+    })
+
+    it('renders a consumer-provided list component', async () => {
+      const {
+        getFocusedPortableTextInput,
+        getFocusedPortableTextEditor,
+        insertPortableText,
+        findBySelector,
+      } = testHelpers()
+      void render(<CustomBlockComponentsStory />)
+      const $portableTextInput = await getFocusedPortableTextInput('field-customComponents')
+      const $pte = await getFocusedPortableTextEditor('field-customComponents')
+      await insertPortableText('List text', $pte)
+
+      const $listButton = await findBySelector(
+        $portableTextInput,
+        'button[data-testid="action-button-customList"]:not([disabled])',
+      )
+      await $listButton.click()
+
+      // Assertion: the consumer's list component is invoked through the render
+      // path (it wraps `renderDefault`, so this also proves it was passed in)
+      await expect.element(page.getByTestId('custom-list-component')).toBeVisible()
+    })
+  })
+})

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/ObjectBlock.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/ObjectBlock.browser.test.tsx
@@ -204,5 +204,29 @@ describe('Portable Text Input', () => {
         .element(page.getByRole('button', {name: 'Insert Object Without Title (block)'}))
         .toBeVisible()
     })
+
+    it('editing an inline object field syncs to the document value', async () => {
+      const {getFocusedPortableTextEditor, waitForDocumentState} = testHelpers()
+      void render(<ObjectBlockStory />)
+      const $pte = await getFocusedPortableTextEditor('field-body')
+      await page.getByRole('button', {name: 'Insert Inline Object (inline)'}).first().click()
+      const $locatorDialog = page.getByTestId('popover-edit-dialog')
+      // Assertion: the inline object edit dialog should be visible
+      await expect.element($locatorDialog).toBeVisible()
+
+      await $locatorDialog.getByRole('textbox').fill('Hello note')
+
+      // Assertion: the edited field is reflected in the document value
+      const documentState = await waitForDocumentState((state) => {
+        const child = state?.body?.[0]?.children?.find(
+          (member: {_type: string}) => member._type !== 'span',
+        )
+        return child?.title === 'Hello note'
+      })
+      const inlineObject = documentState.body[0].children.find(
+        (member: {_type: string}) => member._type !== 'span',
+      )
+      expect(inlineObject.title).toEqual('Hello note')
+    })
   })
 })

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/Styles.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/Styles.browser.test.tsx
@@ -3,6 +3,7 @@ import {render} from 'vitest-browser-react'
 import {page} from 'vitest/browser'
 
 import {testHelpers} from '../../../../../../test/browser/testHelpers'
+import {CustomBlockComponentsStory} from './CustomBlockComponentsStory'
 import {StylesStory} from './StylesStory'
 
 const DEFAULT_STYLE_NAMES = [
@@ -44,6 +45,57 @@ describe('Portable Text Input', () => {
           .querySelector('button#block-style-select')
         expect(styleSelectButton).toBeNull()
       })
+    })
+
+    it('applying a block style writes `style` to the document value', async () => {
+      const {
+        getFocusedPortableTextInput,
+        getFocusedPortableTextEditor,
+        insertPortableText,
+        waitForDocumentState,
+      } = testHelpers()
+      void render(<StylesStory />)
+      const $portableTextInput = await getFocusedPortableTextInput('field-defaultStyles')
+      const $pte = await getFocusedPortableTextEditor('field-defaultStyles')
+      await insertPortableText('Heading text', $pte)
+
+      await $portableTextInput.getByTestId('block-style-select').click()
+      await page.getByRole('menu').getByText('Heading 1', {exact: true}).click()
+
+      // Assertion: the block carries the selected style
+      const documentState = await waitForDocumentState(
+        (state) => state?.defaultStyles?.[0]?.style === 'h1',
+      )
+      expect(documentState.defaultStyles[0].style).toEqual('h1')
+    })
+
+    it('renders a consumer-provided style component', async () => {
+      const {getFocusedPortableTextEditor} = testHelpers()
+      void render(
+        <CustomBlockComponentsStory
+          document={{
+            _id: '123',
+            _type: 'test',
+            _createdAt: new Date().toISOString(),
+            _updatedAt: new Date().toISOString(),
+            _rev: '123',
+            customComponents: [
+              {
+                _key: 'b1',
+                _type: 'block',
+                style: 'custom',
+                children: [{_key: 's1', _type: 'span', text: 'Styled text', marks: []}],
+                markDefs: [],
+              },
+            ],
+          }}
+        />,
+      )
+      await getFocusedPortableTextEditor('field-customComponents')
+
+      // Assertion: the consumer's style component is invoked through the render
+      // path (it wraps `renderDefault`, so this also proves it was passed in)
+      await expect.element(page.getByTestId('custom-style-component')).toBeVisible()
     })
   })
 })


### PR DESCRIPTION
### Description

The Portable Text input's browser test suite asserts DOM and toolbar state thoroughly but rarely the resulting **document value**. That leaves a gap: a change to the render path between a user action and the editor's value (for example the `defineX` catch-all render swap in #13315) could produce a plausible-looking DOM while emitting a wrong value, and the existing tests would stay green.

This PR adds value assertions for the core editing flows, each reusing an existing Story and the `waitForDocumentState` / `findBySelector` helpers:

- **Block style** — applying `Heading 1` writes `style: 'h1'` to the value.
- **Decorator** — applying `strong` writes `marks: ['strong']` to the span.
- **List** — toggling a numbered list writes `listItem: 'number'` / `level: 1`, and asserts the editor emits the `data-level` / `data-list-index` attributes the ordered-list counter CSS depends on.
- **Inline object** — editing an inline object's field in its edit dialog syncs to the value (this is the flow the recently-fixed [portabletext/editor#2871](https://github.com/portabletext/editor/pull/2871) regressed: a custom inline-object field was silently dropped).

These land on `main` ahead of the render-pipeline work so they form a baseline: green on the legacy render path now, and they must stay green after the swap.

### What to review

- That each assertion targets the value, not just the DOM, and uses the established helpers rather than ad-hoc DOM queries.
- `ListItems.browser.test.tsx` additionally asserts the counter attributes, since those are called out as the primary risk in #13315's release notes.

### Testing

`SANITY_VITEST_BROWSER=chromium pnpm --filter sanity exec vitest run -c vitest.browser.config.mts <files>` — all four pass on `main`.

### Notes for release

N/A — test-only.
