### PR TITLE
chore(sanity): document group inventory hint

### DIFF
--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventoryAction.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventoryAction.tsx
@@ -1,6 +1,6 @@
 import {ChevronDownIcon, ChevronUpIcon} from '@sanity/icons'
 import {LayerProvider, useClickOutsideEvent} from '@sanity/ui'
-import {type ComponentType, type PropsWithChildren, useMemo, useRef, useState} from 'react'
+import {type ComponentType, type PropsWithChildren, useMemo, useRef} from 'react'
 import {useObservable} from 'react-rx'
 import {map} from 'rxjs'
 import {styled} from 'styled-components'
@@ -17,9 +17,16 @@ export const DocumentGroupInventoryAction: ComponentType<
   PropsWithChildren<{
     documentId: string
     portalElementName: string
+    isDocumentGroupInventoryActive: boolean
+    setIsDocumentGroupInventoryActive: (active: boolean) => void
   }>
-> = ({children, documentId, portalElementName}) => {
-  const [isActive, setIsActive] = useState<boolean>(false)
+> = ({
+  children,
+  documentId,
+  portalElementName,
+  isDocumentGroupInventoryActive,
+  setIsDocumentGroupInventoryActive,
+}) => {
   const displayedRelease = useVersionRelease(documentId)
   const buttonElement = useRef<HTMLButtonElement | null>(null)
   const popoverElement = useRef<HTMLDivElement | null>(null)
@@ -43,7 +50,7 @@ export const DocumentGroupInventoryAction: ComponentType<
         }
       }
 
-      setIsActive(false)
+      setIsDocumentGroupInventoryActive(false)
     },
     () => [buttonElement.current, popoverElement.current],
   )
@@ -59,7 +66,7 @@ export const DocumentGroupInventoryAction: ComponentType<
         content={children}
         placement="top-end"
         padding={0}
-        open={isActive}
+        open={isDocumentGroupInventoryActive}
         portal={portalElementName}
       >
         <Button
@@ -67,9 +74,9 @@ export const DocumentGroupInventoryAction: ComponentType<
           data-testid="action-document-group-inventory"
           text={variantLabel(displayedRelease?.release)}
           tone="neutral"
-          onClick={() => setIsActive((current) => !current)}
+          onClick={() => setIsDocumentGroupInventoryActive(!isDocumentGroupInventoryActive)}
           icon={<VariantIcon perspective={displayedRelease.release} />}
-          iconRight={isActive ? ChevronDownIcon : ChevronUpIcon}
+          iconRight={isDocumentGroupInventoryActive ? ChevronDownIcon : ChevronUpIcon}
           tooltipProps={{}}
           mode="ghost"
         />

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -420,6 +420,9 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** The text shown if a document's title via a preview value cannot be determined due to an unknown schema type */
   'doc-title.unknown-schema-type.text': 'Unknown schema type: {{schemaType}}',
 
+  /** Hint shown to help guide users to the new document group inventory */
+  'document-group-inventory.onboarding-hint': 'Where did the version buttons go?',
+
   /** Tooltip text shown for the close button of the document inspector */
   'document-inspector.close-button.tooltip': 'Close',
   /** The title shown in the dialog header, when inspecting a valid document */

--- a/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
@@ -79,6 +79,8 @@ export interface DocumentPaneContextValue extends Pick<NodeChronologyProps, 'has
   timelineMode?: undefined
   setTimelineRange(since: string | null, rev: string | null): void
   setIsDeleting: (state: boolean) => void
+  isDocumentGroupInventoryActive: boolean
+  setIsDocumentGroupInventoryActive: (active: boolean) => void
   timelineError: Error | null
   /**
    * Soon to be deprecated with the upcoming `releases` changes.

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -175,6 +175,7 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
   } = useDocumentPaneInspector({documentId, documentType, params, setParams: setPaneParams})
 
   const [isDeleting, setIsDeleting] = useState(false)
+  const [isDocumentGroupInventoryActive, setIsDocumentGroupInventoryActive] = useState(false)
   const {lastRevisionDocument} = useDeletedDocumentLastRevision()
 
   /**
@@ -562,6 +563,8 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
         setTimelineRange,
         setIsDeleting,
         isDeleting,
+        isDocumentGroupInventoryActive,
+        setIsDocumentGroupInventoryActive,
         isDeleted,
         timelineError,
         timelineStore,
@@ -626,6 +629,7 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
       permissions,
       setTimelineRange,
       isDeleting,
+      isDocumentGroupInventoryActive,
       isDeleted,
       timelineError,
       timelineStore,

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -44,6 +44,7 @@ import {ActionDialogWrapper, ActionMenuListItem} from '../../statusBar/ActionMen
 import {useDocumentPane} from '../../useDocumentPane'
 import {FocusDocumentPaneClicked, FocusDocumentPaneCollapsed} from './__telemetry__/focus.telemetry'
 import {CopyDocumentActions} from './CopyDocumentActions'
+import {DocumentGroupInventoryHint} from './documentGroupInventoryHint/DocumentGroupInventoryHint'
 import {DocumentHeaderTitle} from './DocumentHeaderTitle'
 import {useChipScrollPosition} from './hook/useChipScrollPosition'
 import {DocumentPerspectiveList} from './perspective/DocumentPerspectiveList'
@@ -215,7 +216,7 @@ export const DocumentPanelHeader = memo(
             style={{lineHeight: 0, position: 'relative', zIndex: paneHeaderZIndex}}
             borderBottom
           >
-            <Flex gap={3} paddingY={3} justify="space-between">
+            <Flex gap={3} paddingY={3} justify="space-between" align="center">
               {!hasDocumentGroupInventory && (
                 <HorizontalScroller $showGradient={showGradient}>
                   <Flex
@@ -230,7 +231,11 @@ export const DocumentPanelHeader = memo(
                   </Flex>
                 </HorizontalScroller>
               )}
-              {hasDocumentGroupInventory && <div />}
+              {hasDocumentGroupInventory && (
+                <Box paddingX={3}>
+                  <DocumentGroupInventoryHint />
+                </Box>
+              )}
 
               <Box flex="none" paddingRight={3}>
                 <Flex align="center" gap={1}>

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/__telemetry__/documentGroupInventoryHint.telemetry.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/__telemetry__/documentGroupInventoryHint.telemetry.ts
@@ -1,0 +1,7 @@
+import {defineEvent} from '@sanity/telemetry'
+
+export const DocumentGroupInventoryHintPressed = defineEvent({
+  version: 1,
+  name: 'Document Group Inventory Hint Pressed',
+  description: 'User opened the document group inventory by pressing the onboarding hint.',
+})

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/documentGroupInventoryHint/DocumentGroupInventoryHint.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/documentGroupInventoryHint/DocumentGroupInventoryHint.tsx
@@ -1,0 +1,62 @@
+import {InfoOutlineIcon} from '@sanity/icons'
+import {useTelemetry} from '@sanity/telemetry/react'
+import {Flex, Text} from '@sanity/ui'
+import {useMemo, type ComponentType} from 'react'
+import {useObservable} from 'react-rx'
+import {useTranslation} from 'sanity'
+import {styled, css} from 'styled-components'
+
+import {structureLocaleNamespace} from '../../../../../i18n'
+import {useDocumentPane} from '../../../useDocumentPane'
+import {DocumentGroupInventoryHintPressed} from '../__telemetry__/documentGroupInventoryHint.telemetry'
+import {browserStorageAdapter, hintStatus, suppressHint} from './hintStatus'
+
+export const DocumentGroupInventoryHint: ComponentType = () => {
+  const {t} = useTranslation(structureLocaleNamespace)
+  const {setIsDocumentGroupInventoryActive} = useDocumentPane()
+  const telemetry = useTelemetry()
+  const status = useObservable(useMemo(() => hintStatus(browserStorageAdapter), []))
+
+  if (status === 'inactive') {
+    return null
+  }
+
+  return (
+    <TextButton
+      onClick={async () => {
+        telemetry.log(DocumentGroupInventoryHintPressed)
+        setIsDocumentGroupInventoryActive(true)
+        await suppressHint(browserStorageAdapter)
+      }}
+    >
+      <Text size={1} weight="medium">
+        <Flex gap={2} align="center" justify="flex-end">
+          <InfoOutlineIcon /> {t('document-group-inventory.onboarding-hint')}
+        </Flex>
+      </Text>
+    </TextButton>
+  )
+}
+
+const TextButton = styled.button(({theme}) => {
+  return css`
+    display: inline-block;
+    vertical-align: middle;
+    appearance: none;
+    border: 0;
+    margin: 0;
+    padding: 0;
+    outline: none;
+    all: unset;
+    color: var(--card-badge-suggest-fg-color);
+    cursor: pointer;
+
+    * {
+      color: inherit;
+    }
+
+    svg[data-sanity-icon] {
+      color: currentColor;
+    }
+  `
+})

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/documentGroupInventoryHint/hintStatus.test.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/documentGroupInventoryHint/hintStatus.test.ts
@@ -1,0 +1,128 @@
+import {firstValueFrom} from 'rxjs'
+import {describe, expect, test as base} from 'vitest'
+
+import {
+  type Storage,
+  type HintStatus,
+  hintStatus,
+  sessionCountToStatus,
+  suppressHint,
+} from './hintStatus'
+
+interface InMemoryBrowserStorageAdapter {
+  /** The storage adapter passed to `hintStatus`. */
+  readonly adapter: Storage
+  /** The persisted session count, mirroring the value held in `localStorage`. */
+  getCount: () => number
+  /**
+   * Simulate the start of a fresh browser session by clearing the
+   * session-scoped state, mirroring how `sessionStorage` is reset.
+   */
+  startNewSession: () => void
+}
+
+/**
+ * An in-memory stand-in for `browserStorageAdapter`. The session count is
+ * persisted across sessions (like `localStorage`), whereas the "has displayed"
+ * flag is scoped to a single session (like `sessionStorage`).
+ */
+function createInMemoryBrowserStorageAdapter(): InMemoryBrowserStorageAdapter {
+  let count = 0
+  let hasDisplayed = false
+
+  return {
+    adapter: {
+      readCount: async () => count,
+      writeCount: async (value) => {
+        count = value
+      },
+      readHasDisplayed: async () => hasDisplayed,
+      writeHasDisplayed: async (value) => {
+        hasDisplayed = value
+      },
+    },
+    getCount: () => count,
+    startNewSession: () => {
+      hasDisplayed = false
+    },
+  }
+}
+
+interface HintStatusFixtures {
+  /**
+   * Fresh in-memory storage, scoped to a single test.
+   */
+  storage: InMemoryBrowserStorageAdapter
+  /**
+   * Start a brand new session and resolve the resulting hint status.
+   */
+  displayHintInNewSession: () => Promise<HintStatus>
+}
+
+const test = base.extend<HintStatusFixtures>({
+  // oxlint-disable-next-line no-empty-pattern
+  storage: async ({}, consume) => {
+    await consume(createInMemoryBrowserStorageAdapter())
+  },
+  displayHintInNewSession: async ({storage}, consume) => {
+    await consume(async () => {
+      storage.startNewSession()
+      return firstValueFrom(hintStatus(storage.adapter))
+    })
+  },
+})
+
+test('is active when the hint has been displayed for fewer than three sessions', async ({
+  storage,
+  displayHintInNewSession,
+}) => {
+  expect(await displayHintInNewSession()).toBe('active')
+  expect(storage.getCount()).toBe(1)
+
+  expect(await displayHintInNewSession()).toBe('active')
+  expect(storage.getCount()).toBe(2)
+})
+
+test('remains active until the session count exceeds the limit, then stops incrementing the count', async ({
+  storage,
+  displayHintInNewSession,
+}) => {
+  // The count is incremented on every session while the hint is active, up to
+  // and including the session in which the count reaches the limit.
+  expect(await displayHintInNewSession()).toBe('active')
+  expect(await displayHintInNewSession()).toBe('active')
+  expect(await displayHintInNewSession()).toBe('active')
+  expect(await displayHintInNewSession()).toBe('active')
+  expect(storage.getCount()).toBe(4)
+
+  // Once the count exceeds the limit the hint becomes inactive, and the count
+  // is no longer incremented.
+  expect(await displayHintInNewSession()).toBe('inactive')
+  expect(await displayHintInNewSession()).toBe('inactive')
+  expect(storage.getCount()).toBe(4)
+})
+
+test('suppressing the hint writes the suppressed count to storage', async ({storage}) => {
+  await suppressHint(storage.adapter)
+
+  // `SUPPRESSED_COUNT` is -1, the value that marks the hint as suppressed.
+  expect(storage.getCount()).toBe(-1)
+})
+
+describe('sessionCountToStatus', () => {
+  test('is active while the session count is within the limit', () => {
+    expect(sessionCountToStatus(0)).toBe('active')
+    expect(sessionCountToStatus(1)).toBe('active')
+    expect(sessionCountToStatus(2)).toBe('active')
+    expect(sessionCountToStatus(3)).toBe('active')
+  })
+
+  test('is inactive once the session count exceeds the limit', () => {
+    expect(sessionCountToStatus(4)).toBe('inactive')
+    expect(sessionCountToStatus(5)).toBe('inactive')
+  })
+
+  test('is inactive when the hint has been suppressed', () => {
+    expect(sessionCountToStatus(-1)).toBe('inactive')
+  })
+})

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/documentGroupInventoryHint/hintStatus.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/documentGroupInventoryHint/hintStatus.ts
@@ -1,0 +1,118 @@
+import {combineLatest, from, map, type Observable, tap} from 'rxjs'
+
+export interface Storage {
+  readCount: () => Promise<number>
+  writeCount: (value: number) => Promise<void>
+  readHasDisplayed: () => Promise<boolean>
+  writeHasDisplayed: (value: boolean) => Promise<void>
+}
+
+export type HintStatus = 'inactive' | 'active'
+
+const STORAGE_NAMESPACE = ['studio', 'document-group-inventory', 'hint']
+const COUNT_KEY = ['session-count']
+const DISPLAYED_KEY = ['has-displayed']
+
+/**
+ * The number of sessions the hint is visible for.
+ */
+const SESSION_LIMIT = 3
+
+/**
+ * Special count value that indicates the hint has been intentionally
+ * suppressed.
+ */
+const SUPPRESSED_COUNT = -1
+
+export const browserStorageAdapter: Storage = {
+  readCount: async () => {
+    const item = localStorage.getItem(storageKey(COUNT_KEY))
+
+    if (item === null) {
+      return 0
+    }
+
+    let parsedItem
+
+    try {
+      parsedItem = JSON.parse(item)
+    } catch {
+      console.warn('Failed to parse:', item)
+      return 0
+    }
+
+    if (typeof parsedItem === 'number') {
+      return parsedItem
+    }
+
+    return 0
+  },
+  writeCount: async (value) => {
+    localStorage.setItem(storageKey(COUNT_KEY), JSON.stringify(value))
+  },
+  readHasDisplayed: async () => {
+    const item = sessionStorage.getItem(storageKey(DISPLAYED_KEY))
+
+    if (item === null) {
+      return false
+    }
+
+    let parsedItem
+
+    try {
+      parsedItem = JSON.parse(item)
+    } catch {
+      console.warn('Failed to parse:', item)
+      return false
+    }
+
+    if (typeof parsedItem !== 'boolean') {
+      return false
+    }
+
+    return parsedItem
+  },
+  writeHasDisplayed: async (value) => {
+    sessionStorage.setItem(storageKey(DISPLAYED_KEY), JSON.stringify(value))
+  },
+}
+
+export function hintStatus({
+  readCount,
+  writeCount,
+  readHasDisplayed,
+  writeHasDisplayed,
+}: Storage): Observable<HintStatus> {
+  return from(combineLatest([readCount(), readHasDisplayed()])).pipe(
+    map(
+      ([count, hasDisplayed]) =>
+        [count, sessionCountToStatus(count), hasDisplayed] satisfies [number, HintStatus, boolean],
+    ),
+    tap(async ([value, status, hasDisplayed]) => {
+      if (status === 'active' && !hasDisplayed) {
+        await Promise.all([writeCount(value + 1), writeHasDisplayed(true)])
+      }
+    }),
+    map(([, status]) => status),
+  )
+}
+
+export function suppressHint({writeCount}: Storage): Promise<void> {
+  return writeCount(SUPPRESSED_COUNT)
+}
+
+function storageKey(path: string[]): string {
+  return STORAGE_NAMESPACE.concat(path).join('.')
+}
+
+export function sessionCountToStatus(sessionCount: number): HintStatus {
+  if (sessionCount === SUPPRESSED_COUNT) {
+    return 'inactive'
+  }
+
+  if (sessionCount > SESSION_LIMIT) {
+    return 'inactive'
+  }
+
+  return 'active'
+}

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -45,7 +45,8 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
 ) {
   const {disabled, states} = props
   const {__internal_tasks, beta} = useSource()
-  const {displayed, editState} = useDocumentPane()
+  const {displayed, editState, isDocumentGroupInventoryActive, setIsDocumentGroupInventoryActive} =
+    useDocumentPane()
   const {params} = usePaneRouter()
   const {documentId, documentType} = useDocumentPane()
   const showingRevision = Boolean(params?.rev)
@@ -110,6 +111,8 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
         <DocumentGroupInventoryAction
           documentId={displayed._id}
           portalElementName={DOCUMENT_PANEL_PORTAL_ELEMENT}
+          isDocumentGroupInventoryActive={isDocumentGroupInventoryActive}
+          setIsDocumentGroupInventoryActive={setIsDocumentGroupInventoryActive}
         >
           <DocumentGroupInventory
             documentId={displayed._id}


### PR DESCRIPTION
### Description

This branch adds a button hinting where version chips have moved to which, when pressed, opens the document group inventory.

- The hint appears for the first three sessions only. This behaviour is powered by `sessionStorage` and `localStorage`; it doesn't sync across studios, browsers, or devices, but this is a reasonable trade-off for this preview feature.
- Once the user has followed the hint (by pressing it, which opens the inventory), it will not appear for any subsequent documents they view.

When following the hint (by pressing it, which opens the inventory), a "Document Group Inventory Hint Pressed" telemetry event is logged.

We'll follow up with focus and hover styling.

<img width="1442" height="1012" alt="Screenshot 2026-06-29 at 17 15 43" src="https://github.com/user-attachments/assets/d62770de-69fb-496a-bf10-253b8aff8280" />

### What to review

The hint and telemetry.

### Testing

Verified in Test Studio and added unit tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding UI and client-side local/session storage only; no changes to document data, auth, or publishing flows.
> 
> **Overview**
> Adds an onboarding hint in the document panel header when **document group inventory** is enabled, pointing users to where version controls moved (“Where did the version buttons go?”).
> 
> **Popover state** for the inventory is lifted from `DocumentGroupInventoryAction` into **document pane context** so the header hint can open the same popover as the status bar control. Clicking the hint logs **Document Group Inventory Hint Pressed** telemetry and permanently suppresses the hint via storage.
> 
> **Visibility** is driven by `hintStatus`: `localStorage` tracks session count (active for the first few sessions, with one increment per browser session) and `sessionStorage` avoids double-counting within a session; suppression writes a sentinel count. Unit tests cover the storage logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9964da53510e5fd5bb1e2865575f0080ccfe95cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->