### PR TITLE
fix(portable-text): shallow-depth assumptions in the Portable Text Input

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -13,16 +13,13 @@ import {
   type RangeDecoration,
   type RegistrableNode,
   type TextBlockRenderProps,
+  useEditor,
 } from '@portabletext/editor'
 import {NodePlugin} from '@portabletext/editor/plugins'
 import {DndProvider, useDropPosition} from '@portabletext/plugin-dnd'
 import {ListIndexProvider, useListIndex} from '@portabletext/plugin-list-index'
-import {
-  type ObjectSchemaType,
-  type Path,
-  type PortableTextBlock,
-  type PortableTextTextBlock,
-} from '@sanity/types'
+import {getSanitySubSchema} from '@portabletext/sanity-bridge'
+import {type Path, type PortableTextBlock, type PortableTextTextBlock} from '@sanity/types'
 import {
   BoundaryElementProvider,
   Box,
@@ -114,6 +111,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
 
   const schemaTypes = usePortableTextMemberSchemaTypes()
   const setElementRef = useSetPortableTextMemberItemElementRef()
+  const editor = useEditor()
 
   // Wrap the consumer's onPaste to enrich PasteData.schemaTypes with
   // Sanity-specific PortableTextMemberSchemaTypes instead of the editor's
@@ -242,12 +240,14 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
   const renderBlockObject = useCallback(
     (blockProps: BlockObjectRenderProps) => {
       const {attributes, focused: blockFocused, node, path: blockPath, selected} = blockProps
-      const sanitySchemaType: ObjectSchemaType | undefined = schemaTypes.blockObjects.find(
-        (type) => type.name === node._type,
-      )
+      const sanitySchemaType = getSanitySubSchema(
+        schemaTypes.portableText,
+        editor.getSnapshot().context.value,
+        blockPath,
+      ).blockObjects.find((t) => t.name === node._type)
       if (!sanitySchemaType) {
-        // `schemaTypes.blockObjects` lists only the array's top-level object
-        // types, so a type defined deeper (e.g. inside a container) isn't here.
+        // `getSanitySubSchema` returned the sub-schema at this path, but no
+        // block-object type in it matches `node._type`.
         throw new Error(`Could not find Sanity schema type for block object: ${node._type}`)
       }
       return (
@@ -289,7 +289,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     [
       floatingBoundary,
       scrollElement,
-      schemaTypes.blockObjects,
+      schemaTypes.portableText,
       isFullscreen,
       onItemClose,
       onItemOpen,
@@ -307,18 +307,21 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       renderItem,
       renderPreview,
       setElementRef,
+      editor,
     ],
   )
 
   const renderInlineObject = useCallback(
     (childProps: InlineObjectRenderProps) => {
       const {attributes, focused: childFocused, node, path: childPath, selected} = childProps
-      const sanitySchemaType: ObjectSchemaType | undefined = schemaTypes.inlineObjects.find(
-        (type) => type.name === node._type,
-      )
+      const sanitySchemaType = getSanitySubSchema(
+        schemaTypes.portableText,
+        editor.getSnapshot().context.value,
+        childPath,
+      ).inlineObjects.find((t) => t.name === node._type)
       if (!sanitySchemaType) {
-        // `schemaTypes.inlineObjects` lists only the array's top-level inline
-        // types, so a type defined deeper (e.g. inside a container) isn't here.
+        // `getSanitySubSchema` returned the sub-schema at this path, but no
+        // inline-object type in it matches `node._type`.
         throw new Error(`Could not find Sanity schema type for inline object: ${node._type}`)
       }
       return (
@@ -353,7 +356,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       )
     },
     [
-      schemaTypes.inlineObjects,
+      schemaTypes.portableText,
       floatingBoundary,
       onItemClose,
       onItemOpen,
@@ -370,6 +373,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       renderItem,
       renderPreview,
       setElementRef,
+      editor,
     ],
   )
 
@@ -394,9 +398,12 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
         schemaType: aSchemaType,
         value: aValue,
       } = annotationProps
-      const sanitySchemaType = schemaTypes.annotations.find(
-        (type) => type.name === aSchemaType.name,
-      )
+      const annotationPath = [...aPath.slice(0, -2), 'markDefs', {_key: aValue._key}]
+      const sanitySchemaType = getSanitySubSchema(
+        schemaTypes.portableText,
+        editor.getSnapshot().context.value,
+        annotationPath,
+      ).annotations.find((t) => t.name === aSchemaType.name)
       if (!sanitySchemaType) {
         // This should never happen
         throw new Error(`Could not find Sanity schema type for annotation: ${aSchemaType.name}`)
@@ -430,7 +437,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       )
     },
     [
-      schemaTypes.annotations,
+      schemaTypes.portableText,
       floatingBoundary,
       scrollElement,
       focused,
@@ -448,6 +455,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       renderItem,
       renderPreview,
       setElementRef,
+      editor,
     ],
   )
   const ariaDescribedBy = elementProps['aria-describedby']

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -564,6 +564,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
   // Scroll to the DOM element of the "opened" portable text member when relevant.
   useTrackFocusPath({
     focusPath,
+    ptInputPath: path,
     boundaryElement: scrollElement,
     onItemClose,
   })

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/FocusTracking.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/FocusTracking.browser.test.tsx
@@ -163,7 +163,7 @@ describe('Portable Text Input', () => {
     const $inlineObject = page.getByTestId('inline-preview')
     await $inlineObject.click()
     await expect.poll(lastPath).toEqual(['body', {_key: 'g'}, 'children', {_key: 'i'}])
-    const $blockObject = page.getByTestId('pte-block-object')
+    const $blockObject = page.getByTestId('pte-block-object').first()
     await $blockObject.click()
     await expect.poll(lastPath).toEqual(['body', {_key: 'k'}])
   })

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/FocusTracking.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/FocusTracking.browser.test.tsx
@@ -46,6 +46,41 @@ const document: SanityDocument = {
       _key: 'k',
       text: 'Hello world',
     },
+    {
+      _type: 'table',
+      _key: 't',
+      rows: [
+        {
+          _type: 'row',
+          _key: 'r',
+          cells: [
+            {
+              _type: 'cell',
+              _key: 'c',
+              content: [
+                {
+                  _type: 'block',
+                  _key: 'm',
+                  children: [{_type: 'span', _key: 'n', text: 'Nested Foo'}],
+                  markDefs: [],
+                },
+                {
+                  _type: 'block',
+                  _key: 'o',
+                  children: [{_type: 'span', _key: 'p', text: 'Nested Bar'}],
+                  markDefs: [],
+                },
+                {
+                  _type: 'cellObjectBlock',
+                  _key: 'q',
+                  text: 'Nested object',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
   ],
 }
 
@@ -148,6 +183,88 @@ describe('Portable Text Input', () => {
       await expect.element($pteTextbox).toHaveFocus()
       // Focus moved away from the block object, so its input unmounts entirely.
       await expect.element(blockObjectInput).not.toBeInTheDocument()
+    })
+    it(`for span paths inside a container`, async () => {
+      const {waitForFocusedNodeText} = testHelpers()
+      const {rerender} = await render(
+        <FocusTrackingStory
+          document={document}
+          focusPath={[
+            'body',
+            {_key: 't'},
+            'rows',
+            {_key: 'r'},
+            'cells',
+            {_key: 'c'},
+            'content',
+            {_key: 'm'},
+            'children',
+            {_key: 'n'},
+            'text',
+          ]}
+        />,
+      )
+      await waitForFocusedNodeText('Nested Foo')
+      await rerender(
+        <FocusTrackingStory
+          document={document}
+          focusPath={[
+            'body',
+            {_key: 't'},
+            'rows',
+            {_key: 'r'},
+            'cells',
+            {_key: 'c'},
+            'content',
+            {_key: 'o'},
+            'children',
+            {_key: 'p'},
+            'text',
+          ]}
+        />,
+      )
+      await waitForFocusedNodeText('Nested Bar')
+    })
+    it(`for block paths inside a container`, async () => {
+      const {rerender} = await render(
+        <FocusTrackingStory
+          document={document}
+          focusPath={[
+            'body',
+            {_key: 't'},
+            'rows',
+            {_key: 'r'},
+            'cells',
+            {_key: 'c'},
+            'content',
+            {_key: 'q'},
+          ]}
+        />,
+      )
+      const $portableTextInput = page.getByTestId('field-body')
+      const $pteTextbox = $portableTextInput.getByRole('textbox')
+      await expect.element($pteTextbox).not.toHaveFocus()
+      const cellObjectBlockInput = page
+        .getByTestId('cellObjectBlockInputField')
+        .getByRole('textbox')
+      await expect.element(cellObjectBlockInput).toBeVisible()
+      await rerender(
+        <FocusTrackingStory
+          document={document}
+          focusPath={[
+            'body',
+            {_key: 't'},
+            'rows',
+            {_key: 'r'},
+            'cells',
+            {_key: 'c'},
+            'content',
+            {_key: 'm'},
+          ]}
+        />,
+      )
+      await expect.element($pteTextbox).toHaveFocus()
+      await expect.element(cellObjectBlockInput).not.toBeInTheDocument()
     })
   })
   it(`reports focus on spans with with .text prop, and everything else without`, async () => {

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/FocusTrackingStory.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/FocusTrackingStory.tsx
@@ -1,8 +1,46 @@
+import {defineContainer} from '@portabletext/editor'
+import {NodePlugin} from '@portabletext/editor/plugins'
 import {type SanityDocument} from '@sanity/client'
 import {defineArrayMember, defineField, defineType, type Path} from '@sanity/types'
+import {type PortableTextPluginsProps} from 'sanity'
 
 import {TestForm} from '../../../../../../test/browser/TestForm'
 import {TestWrapper} from '../../../../../../test/browser/TestWrapper'
+
+const CONTAINER_NODES = [
+  defineContainer({
+    type: 'table',
+    arrayField: 'rows',
+    render: ({children, attributes}) => (
+      <table {...attributes}>
+        <tbody>{children}</tbody>
+      </table>
+    ),
+    of: [
+      defineContainer({
+        type: 'row',
+        arrayField: 'cells',
+        render: ({children, attributes}) => <tr {...attributes}>{children}</tr>,
+        of: [
+          defineContainer({
+            type: 'cell',
+            arrayField: 'content',
+            render: ({children, attributes}) => <td {...attributes}>{children}</td>,
+          }),
+        ],
+      }),
+    ],
+  }),
+]
+
+function ContainerPlugins(props: PortableTextPluginsProps) {
+  return (
+    <>
+      {props.renderDefault(props)}
+      <NodePlugin nodes={CONTAINER_NODES} />
+    </>
+  )
+}
 
 const SCHEMA_TYPES = [
   defineType({
@@ -48,7 +86,61 @@ const SCHEMA_TYPES = [
               ),
             },
           }),
+          defineArrayMember({
+            type: 'object',
+            name: 'table',
+            fields: [
+              defineField({
+                type: 'array',
+                name: 'rows',
+                of: [
+                  defineArrayMember({
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      defineField({
+                        type: 'array',
+                        name: 'cells',
+                        of: [
+                          defineArrayMember({
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              defineField({
+                                type: 'array',
+                                name: 'content',
+                                of: [
+                                  defineArrayMember({type: 'block'}),
+                                  defineArrayMember({
+                                    type: 'object',
+                                    name: 'cellObjectBlock',
+                                    fields: [{type: 'string', name: 'text'}],
+                                    components: {
+                                      input: (inputProps) => (
+                                        <div data-testid="cellObjectBlockInputField">
+                                          {inputProps.renderDefault(inputProps)}
+                                        </div>
+                                      ),
+                                    },
+                                  }),
+                                ],
+                              }),
+                            ],
+                          }),
+                        ],
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
         ],
+        components: {
+          portableText: {
+            plugins: ContainerPlugins,
+          },
+        },
       }),
     ],
   }),

--- a/packages/sanity/src/core/form/inputs/PortableText/contexts/PortableTextMemberItemElementRefsProvider.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/contexts/PortableTextMemberItemElementRefsProvider.tsx
@@ -11,12 +11,12 @@ export type SetPortableTextMemberItemElementRef = ({
   key,
   elementRef,
 }: {
-  key: PortableTextMemberItem['member']['key']
+  key: PortableTextMemberItem['key']
   elementRef: PortableTextEditorElement | null
 }) => void
 
 export function usePortableTextMemberItemElementRefs(): Record<
-  PortableTextMemberItem['member']['key'],
+  PortableTextMemberItem['key'],
   PortableTextEditorElement | null | undefined
 > {
   const behaviorSubject = useContext(PortableTextMemberItemElementRefsContext)

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/usePortableTextMembers.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/usePortableTextMembers.tsx
@@ -61,11 +61,24 @@ export function usePortableTextMemberItemsFromProps(
       node: ObjectFormNode
     }[] = []
 
-    for (const member of members) {
-      if (member.kind === 'item') {
+    // Walk `members` plus any nested portable-text arrays inside
+    // object-blocks (containers) iteratively, so members at any depth
+    // show up in the flat list.
+    const stack: (typeof members)[] = [members]
+    while (stack.length) {
+      const arrayMembers = stack.pop()!
+      for (const member of arrayMembers) {
+        if (member.kind !== 'item') continue
         const isObjectBlock = !isBlockType(member.item.schemaType)
         if (isObjectBlock) {
           result.push({kind: 'objectBlock', member, node: member.item})
+          // Only descend into arrays whose items are objects. Non-object
+          // arrays (primitives, references) surface no block-shaped items.
+          for (const field of member.item.members) {
+            if (field.kind === 'field' && isMemberArrayOfObjects(field)) {
+              stack.push(field.field.members)
+            }
+          }
         } else {
           // Also include regular text blocks with validation, presence, changes or that are open or focused.
           // This is a performance optimization to avoid accounting for blocks that

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -1,9 +1,11 @@
 import {
   PortableTextEditor,
+  useEditor,
   usePortableTextEditor,
   usePortableTextEditorSelection,
 } from '@portabletext/editor'
-import {isKeyedObject, type KeyedObject, type Path} from '@sanity/types'
+import {getEnclosingBlock, getSpan} from '@portabletext/editor/traversal'
+import {type Path} from '@sanity/types'
 import {isEqual} from '@sanity/util/paths'
 import {useLayoutEffect, useRef} from 'react'
 import scrollIntoView from 'scroll-into-view-if-needed'
@@ -13,17 +15,19 @@ import {usePortableTextMemberItems} from './usePortableTextMembers'
 
 interface Props {
   focusPath: Path
+  ptInputPath: Path
   boundaryElement: HTMLElement | null
   onItemClose: () => void
 }
 
 // This hook will track the form focusPath and make sure editor content is visible (opened), scrolled to, and (potentially) focused accordingly.
 export function useTrackFocusPath(props: Props): void {
-  const {focusPath, boundaryElement, onItemClose} = props
+  const {focusPath, ptInputPath, boundaryElement, onItemClose} = props
 
   const portableTextMemberItems = usePortableTextMemberItems()
   const elementRefs = usePortableTextMemberItemElementRefs()
-  const editor = usePortableTextEditor()
+  const editor = useEditor()
+  const legacyEditor = usePortableTextEditor()
   const selection = usePortableTextEditorSelection()
 
   // Read selection from a ref instead of subscribing to it, so our own select() calls below don't
@@ -73,8 +77,25 @@ export function useTrackFocusPath(props: Props): void {
     // Find the focused editor member item (if any)
     const focusedItem = portableTextMemberItems.find((m) => m.member.item.focused)
 
-    // The related editor member to scroll to, or focus, according to the given focusPath
-    const relatedEditorItem = focusedItem || openItem
+    // Resolve the enclosing block for focusPath from the editor snapshot.
+    const snapshot = editor.getSnapshot()
+    const enclosingBlock = getEnclosingBlock(snapshot, focusPath)
+    const blockPath = enclosingBlock?.path
+    const span = getSpan(snapshot, focusPath)
+
+    // `blockPath` is editor-relative; member paths are doc-absolute. Compare
+    // against the full absolute path so blocks that share `_key` across depth
+    // don't collide (`_key` is unique per parent array, not globally).
+    const enclosingBlockItem = blockPath
+      ? portableTextMemberItems.find((m) =>
+          isEqual(m.member.item.path, [...ptInputPath, ...blockPath]),
+        )
+      : undefined
+
+    // The related editor member to scroll to, or focus, according to the given focusPath.
+    // Prefer the path-resolved enclosing block: open/focused heuristics fall back to
+    // ancestor containers at depth when nothing inside them is explicitly open.
+    const relatedEditorItem = focusedItem || enclosingBlockItem || openItem
     const elementRef = relatedEditorItem ? elementRefs[relatedEditorItem.member.key] : undefined
 
     if (relatedEditorItem && elementRef) {
@@ -95,48 +116,23 @@ export function useTrackFocusPath(props: Props): void {
       }
 
       const isTextBlock = relatedEditorItem.kind === 'textBlock'
-      const isBlockFocusPath = focusPath.length === 1
 
       // Track focus and selection for focusPaths that are either inside text blocks,
       // or is pointing to the block itself (text and object blocks)
-      if (isTextBlock || isBlockFocusPath) {
-        const textBlockChildKey =
-          isTextBlock && isKeyedObject(focusPath[2]) ? focusPath[2]._key : undefined
-        const child =
-          textBlockChildKey && Array.isArray(relatedEditorItem.node.value?.children)
-            ? (relatedEditorItem.node.value?.children.find((c) => c._key === textBlockChildKey) as
-                | KeyedObject
-                | undefined)
-            : undefined
-
-        // Is the focusPath pointing to span's `.text` property?
-        const isSpanTextFocusPath =
-          (child &&
-            child._type === 'span' &&
-            focusPath.length === 4 &&
-            focusPath[1] === 'children' &&
-            focusPath[3] === 'text') ||
-          false
-
-        // Is focus directly on a text block child?
-        const isTextChildFocusPath =
-          isTextBlock &&
-          ((focusPath.length === 3 && focusPath[1] === 'children') || isSpanTextFocusPath)
-
+      if (isTextBlock || relatedEditorItem.kind === 'objectBlock') {
         let path: Path = []
-        // Known text block child
-        if (isTextChildFocusPath) {
-          path = focusPath.slice(0, 3)
-        } else if (
-          // Known text block, but unknown child. Select first child in that block.
-          isTextBlock &&
-          isBlockFocusPath &&
-          Array.isArray(relatedEditorItem.node.value?.children)
-        ) {
-          path = [focusPath[0], 'children', {_key: relatedEditorItem.node.value?.children[0]._key}]
+        if (span) {
+          // focusPath is on a span or descends into a primitive field on one. Use the span's path.
+          path = span.path
+        } else if (isTextBlock && blockPath && isEqual(focusPath, blockPath)) {
+          // Known text block, but no child in the focusPath. Select first child.
+          const children = enclosingBlock?.node.children
+          if (Array.isArray(children) && children.length) {
+            path = [...blockPath, 'children', {_key: children[0]._key}]
+          }
+        } else if (blockPath && isEqual(focusPath, blockPath)) {
           // Directly pointing to a non-text block
-        } else if (isBlockFocusPath) {
-          path = [{_key: relatedEditorItem.key}]
+          path = blockPath
         }
 
         // Select and focus the editor if we produced a path
@@ -148,19 +144,28 @@ export function useTrackFocusPath(props: Props): void {
             currentSelection?.focus.path &&
             isEqual(currentSelection.focus.path.slice(0, path.length), path)
           if (isTextBlock && isSameSelection) {
-            PortableTextEditor.select(editor, null)
+            PortableTextEditor.select(legacyEditor, null)
           }
 
-          PortableTextEditor.select(editor, {
+          PortableTextEditor.select(legacyEditor, {
             anchor: {path, offset: 0},
             focus: {path, offset: 0},
           })
           // Object blocks open their interface when focused, so only call focus for text blocks.
           if (isTextBlock) {
-            PortableTextEditor.focus(editor)
+            PortableTextEditor.focus(legacyEditor)
           }
         }
       }
     }
-  }, [boundaryElement, editor, elementRefs, focusPath, onItemClose, portableTextMemberItems])
+  }, [
+    boundaryElement,
+    editor,
+    elementRefs,
+    focusPath,
+    legacyEditor,
+    onItemClose,
+    portableTextMemberItems,
+    ptInputPath,
+  ])
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -96,7 +96,7 @@ export function useTrackFocusPath(props: Props): void {
     // Prefer the path-resolved enclosing block: open/focused heuristics fall back to
     // ancestor containers at depth when nothing inside them is explicitly open.
     const relatedEditorItem = focusedItem || enclosingBlockItem || openItem
-    const elementRef = relatedEditorItem ? elementRefs[relatedEditorItem.member.key] : undefined
+    const elementRef = relatedEditorItem ? elementRefs[relatedEditorItem.key] : undefined
 
     if (relatedEditorItem && elementRef) {
       if (boundaryElement) {

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Annotation.tsx
@@ -222,7 +222,7 @@ export function Annotation(props: AnnotationProps): React.JSX.Element {
   const setRef = useCallback(
     (elm: HTMLSpanElement) => {
       if (memberItem) {
-        setElementRef({key: memberItem.member.key, elementRef: elm})
+        setElementRef({key: memberItem.key, elementRef: elm})
       }
       setSpanElement(elm) // update state here so the reference element is available on first render
     },

--- a/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/BlockObject.tsx
@@ -298,7 +298,7 @@ export function BlockObject(props: BlockObjectProps) {
   const setRef = useCallback(
     (elm: HTMLDivElement) => {
       if (memberItem) {
-        setElementRef({key: memberItem.member.key, elementRef: elm})
+        setElementRef({key: memberItem.key, elementRef: elm})
       }
       setDivElement(elm) // update state here so the reference element is available on first render
     },

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObject.tsx
@@ -211,7 +211,7 @@ export const InlineObject = (props: InlineObjectProps): React.JSX.Element => {
   const setRef = useCallback(
     (elm: HTMLDivElement) => {
       if (memberItem) {
-        setElementRef({key: memberItem.member.key, elementRef: elm})
+        setElementRef({key: memberItem.key, elementRef: elm})
       }
       setDivElement(elm) // update state here so the reference element is available on first render
     },

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/AnnotationObjectEditModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/AnnotationObjectEditModal.tsx
@@ -38,7 +38,7 @@ export function AnnotationObjectEditModal(props: {
     return null
   }
 
-  const elementRef = elementRefs[openAnnotation.member.key]
+  const elementRef = elementRefs[openAnnotation.key]
 
   if (!elementRef) {
     return null

--- a/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
@@ -308,7 +308,7 @@ export function TextBlock(props: TextBlockProps) {
   const setRef = useCallback(
     (elm: HTMLDivElement) => {
       if (memberItem) {
-        setElementRef({key: memberItem.member.key, elementRef: elm})
+        setElementRef({key: memberItem.key, elementRef: elm})
       }
       setDivElement(elm) // update state here so the reference element is available on first render
     },


### PR DESCRIPTION
### Description

With #13315 Studio's PT UI now composes nicely with PTE Containers. However, shallow-depth assumptions in Studio still broke certain functionality.

#### The four fixes

**`fix(portable-text): resolve render-callback schema types by path`** — `Compositor`'s `renderBlockObject`, `renderInlineObject`, and `renderAnnotation` looked schema types up by scanning the flat `schemaTypes.{blockObjects,inlineObjects,annotations}` arrays. Those arrays only describe the root portable-text array, so container-nested types would either miss-and-throw or get the wrong schema type. The fix is to resolve each type with `getSanitySubSchema` from `@portabletext/sanity-bridge` which fetches the correct sub schema depending on the level of nesting inside PTE.

**`fix(portable-text): collect form members at any depth`** — `usePortableTextMemberItemsFromProps` walked the root `members` array flat and didn't look inside block object fields for nested arrays. That left Container descendants missing from the precomputed `portableTextMemberItems` list, so the focus-tracking and member-input lookups that consult it never found them. The fix is to recursively descend into "array of objects" field members.

**`fix(portable-text): track focus into nested-container blocks`** — `useTrackFocusPath` mapped the form focusPath to an editor selection by reading absolute path segments (`focusPath.length === 1` for a block, `focusPath[1] === 'children'` for a span, `focusPath[3] === 'text'` for span text). Those shape checks only hold at the root of the Portable Text document, so a `focusPath` into a nested-container block fell through every branch silently. The fix is to compose first-class PTE traversal utils to verify what the path is pointing to.

**`fix(portable-text): key the element-ref registry by full path`** — the registry that maps members to their rendered DOM elements used `memberItem.member.key` (the member's bare local `_key`). Keys in PTE are unique inside their parent array, not across the document, so two spans keyed `s0` (one in each block) overwrote each other's element refs. The fix is to key by path instead of `_key`.

### What to review

I deliberately tried to keep this PR small and focused. Primary changes are in `usePortableTextMemberItemsFromProps` and `useTrackFocusPath`. The rest is simple call-site updates.

Note: This PR fixes logic related to focus paths pointing at spans, but that actually doesn't seem to work since the form store's members list doesn't include spans. Maybe something to look into in a separate PR.

### Testing

1. Open a document in https://test-studio-git-feat-pt-path-aware-lookups.sanity.dev/test/structure/input-standard;portable-text;customPlugins and add a table in the "Container Table" PT Input.
2. Add a image or an inline note in a table cell and verify that you can double-click to edit.
3. Add an annotation to some text in a table cell.
4. To test focus tracking, the "easiest" way is to construct a URL like `https://test-studio-git-feat-pt-path-aware-lookups.sanity.dev/test/structure/input-standard;portable-text;customPlugins;717a1bff-0a8d-4cad-b531-46425e74ef4c,path=containerTable[_key=="445810a7bb73"].rows[_key=="2e4bbfb36491"].cells[_key=="439c24e0a1e4"].content[_key=="be1d49ff4c72"]` and verify that Studio puts the caret in the text block nested in the table cell.
5. The "key the element-ref registry by full path" fix is more a correctness fix that is hard to test since it requires objects with duplicate keys in the document.

### Notes for release

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core portable-text focus, schema resolution, and member enumeration used by editing modals and deep-link URLs; behavior is localized to PT input with new browser coverage but regressions could affect nested-container editing and scroll/focus sync.
> 
> **Overview**
> Fixes **Portable Text Input** behavior when content lives inside PTE **containers** (e.g. table cells), where the UI previously assumed root-level paths and flat schema/member lists.
> 
> **`Compositor`** resolves block objects, inline objects, and annotations with **`getSanitySubSchema`** at each node’s editor path (plus editor snapshot) instead of scanning root-only `schemaTypes.*` arrays, so nested types render with the correct Sanity schema.
> 
> **`usePortableTextMemberItemsFromProps`** iteratively walks into **array-of-objects** fields inside object blocks so annotations, inline/block objects, and nested text blocks are included in the flat member list used for inputs and focus tracking. DOM element refs are keyed by **`memberItem.key`** (full path string), aligning lookups with **`usePortableTextMemberItem(pathToString(...))`** and avoiding `_key` collisions across depths.
> 
> **`useTrackFocusPath`** takes **`ptInputPath`**, uses **`getEnclosingBlock`** / **`getSpan`** to map form `focusPath` to editor-relative selection, and matches members by **absolute document path** rather than shallow segment shapes (`focusPath.length === 1`, etc.).
> 
> Browser tests add a **nested table** fixture and cover focus tracking for spans and blocks inside containers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32ada349a92bbce55189a347ca260b266c37073f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->