### PR TITLE
fix(build): strip leftover vite hash marker from published css

### DIFF
--- a/packages/@repo/package.bundle/src/__test__/package.bundle.test.ts
+++ b/packages/@repo/package.bundle/src/__test__/package.bundle.test.ts
@@ -162,6 +162,19 @@ describe('cleanupCssOutputPlugin() — Vite hash marker removal', () => {
     expect(bundle['theme.css'].source).toBe(':root{}')
   })
 
+  // Rolldown only appends a single marker per file, so this can't happen in
+  // practice — but it guards the regex's global flag: without `/g`, only the
+  // first marker would be removed.
+  it('removes every marker within a single CSS asset', () => {
+    const bundle = {
+      'index.css': {type: 'asset', source: 'a{}/*$vite$:1*/b{}/*$vite$:2*/'},
+    } as any
+
+    runPlugin(bundle)
+
+    expect(bundle['index.css'].source).toBe('a{}b{}')
+  })
+
   it('leaves CSS assets without the marker untouched', () => {
     const bundle = {
       'index.css': {type: 'asset', source: 'body{color:red}'},

--- a/packages/@repo/package.bundle/src/__test__/package.bundle.test.ts
+++ b/packages/@repo/package.bundle/src/__test__/package.bundle.test.ts
@@ -1,14 +1,14 @@
 import {describe, expect, it} from 'vitest'
 
-import {stripCssImportsPlugin} from '../package.bundle'
+import {cleanupCssOutputPlugin} from '../package.bundle'
 
 function runPlugin(bundle: Record<string, any>) {
-  const plugin = stripCssImportsPlugin()
+  const plugin = cleanupCssOutputPlugin()
   // generateBundle is a Rollup hook — call it directly with a mock context
   ;(plugin.generateBundle as Function).call({}, {} as never, bundle)
 }
 
-describe('stripCssImportsPlugin()', () => {
+describe('cleanupCssOutputPlugin() — CSS import stripping', () => {
   it('removes imports for CSS assets produced by the build', () => {
     const bundle = {
       // CSS asset produced by vanilla-extract
@@ -121,5 +121,77 @@ describe('stripCssImportsPlugin()', () => {
     expect(bundle['index.mjs'].code).not.toContain("import './theme.css'")
     // External CSS import preserved
     expect(bundle['index.mjs'].code).toContain("import 'external/styles.css'")
+  })
+})
+
+describe('cleanupCssOutputPlugin() — Vite hash marker removal', () => {
+  it('removes the leftover Vite hash-update marker from CSS assets', () => {
+    const bundle = {
+      'index.css': {
+        type: 'asset',
+        // mirrors the real CDN output, where the marker leaks onto a trailing line
+        source: '#sanity{--static-css-file-loaded-studio:true}\n/*$vite$:1*/',
+      },
+    } as any
+
+    runPlugin(bundle)
+
+    expect(bundle['index.css'].source).not.toContain('$vite$')
+    expect(bundle['index.css'].source).toContain('#sanity{--static-css-file-loaded-studio:true}')
+  })
+
+  it('removes markers with any numeric suffix', () => {
+    const bundle = {
+      'index.css': {type: 'asset', source: 'body{}/*$vite$:42*/'},
+    } as any
+
+    runPlugin(bundle)
+
+    expect(bundle['index.css'].source).toBe('body{}')
+  })
+
+  it('strips the marker from every CSS asset', () => {
+    const bundle = {
+      'index.css': {type: 'asset', source: 'body{}/*$vite$:1*/'},
+      'theme.css': {type: 'asset', source: ':root{}/*$vite$:1*/'},
+    } as any
+
+    runPlugin(bundle)
+
+    expect(bundle['index.css'].source).toBe('body{}')
+    expect(bundle['theme.css'].source).toBe(':root{}')
+  })
+
+  it('leaves CSS assets without the marker untouched', () => {
+    const bundle = {
+      'index.css': {type: 'asset', source: 'body{color:red}'},
+    } as any
+
+    runPlugin(bundle)
+
+    expect(bundle['index.css'].source).toBe('body{color:red}')
+  })
+
+  it('does not touch non-string CSS asset sources', () => {
+    const source = new Uint8Array([1, 2, 3])
+    const bundle = {
+      'index.css': {type: 'asset', source},
+    } as any
+
+    runPlugin(bundle)
+
+    expect(bundle['index.css'].source).toBe(source)
+  })
+
+  it('does not introduce the marker into JS chunks', () => {
+    const bundle = {
+      'index.css': {type: 'asset', source: 'body{}/*$vite$:1*/'},
+      'index.mjs': {type: 'chunk', code: 'export default {}\n'},
+    } as any
+
+    runPlugin(bundle)
+
+    expect(bundle['index.css'].source).toBe('body{}')
+    expect(bundle['index.mjs'].code).toBe('export default {}\n')
   })
 })

--- a/packages/@repo/package.bundle/src/package.bundle.ts
+++ b/packages/@repo/package.bundle/src/package.bundle.ts
@@ -18,7 +18,7 @@ export const defaultConfig: UserConfig = {
     viteReact(),
     babel({presets: [reactCompilerPreset({target: '19'})]}),
     vanillaExtractPlugin(),
-    stripCssImportsPlugin(),
+    cleanupCssOutputPlugin(),
     esmExternalRequirePlugin({
       // self-externals are required here in order to ensure that the presentation
       // tool and future transitive dependencies that require sanity do not
@@ -74,33 +74,56 @@ export const defaultConfig: UserConfig = {
 }
 
 /**
- * Strips CSS imports from JS chunks in the bundle output, but ONLY for CSS
- * files that were produced by the current build (e.g., by vanilla-extract).
+ * Matches Vite's internal "hash update marker": a CSS comment of the form
+ * `$vite$:N` that Rolldown's `vite-css-post` plugin appends to finalized CSS to
+ * force a different content hash (a workaround for a Chromium `crossorigin`
+ * caching bug, https://github.com/vitejs/vite/issues/18038).
  *
- * When building CDN bundles, CSS is served separately via `<link>` tags
- * (injected by the CLI's runtime script). The JS bundles should not contain
- * CSS import side-effects for these extracted CSS files, as the module server
- * serves JS and CSS as separate files.
- *
- * CSS imports from third-party packages that were bundled in (and whose CSS
- * was processed by Vite into the same output) are safe to strip too — their
- * styles end up in the combined CSS asset served via `<link>`. But imports
- * referencing CSS files NOT present in the bundle output are left untouched,
- * since stripping them could lose styles that aren't in our CSS output.
+ * The marker is meant to be stripped again before the asset is written, but
+ * Rolldown's library / non-code-split path (`build.lib` defaults
+ * `cssCodeSplit` to `false`) emits the combined CSS asset late in
+ * `generateBundle`, after its own strip step has already run, so the marker
+ * leaks into the published CSS. We remove it ourselves below. This mirrors
+ * Vite's own `viteHashUpdateMarkerRE`.
  */
-export function stripCssImportsPlugin(): Plugin {
+const VITE_HASH_UPDATE_MARKER_RE = /\/\*\$vite\$:\d+\*\//g
+
+/**
+ * Cleans up the CSS-related output of the CDN bundle build:
+ *
+ * 1. Strips CSS imports from JS chunks, but ONLY for CSS files that were
+ *    produced by the current build (e.g., by vanilla-extract). When building
+ *    CDN bundles, CSS is served separately via `<link>` tags (injected by the
+ *    CLI's runtime script), so the JS bundles should not contain CSS import
+ *    side-effects for these extracted CSS files. CSS imports from third-party
+ *    packages that were bundled in (and whose CSS was processed into the same
+ *    output) are safe to strip too — their styles end up in the combined CSS
+ *    asset served via `<link>`. Imports referencing CSS files NOT present in
+ *    the bundle output are left untouched, since stripping them could lose
+ *    styles that aren't in our CSS output.
+ *
+ * 2. Removes the leftover Vite hash-update marker (see
+ *    {@link VITE_HASH_UPDATE_MARKER_RE}) from the emitted CSS assets so the CSS
+ *    we publish to the CDN stays clean.
+ */
+export function cleanupCssOutputPlugin(): Plugin {
   return {
-    name: 'sanity/strip-css-imports',
+    name: 'sanity/cleanup-css-output',
     apply: 'build',
     enforce: 'post',
 
     generateBundle(_options, bundle) {
-      // 1. Collect CSS asset filenames produced by this build
-      //    (e.g., vanilla-extract output, Vite-processed CSS imports)
+      // 1. Collect CSS asset filenames produced by this build (e.g.,
+      //    vanilla-extract output, Vite-processed CSS imports) and, while we're
+      //    iterating, strip the internal Vite hash-update marker from each CSS
+      //    asset's source.
       const cssAssetNames = new Set<string>()
       for (const [fileName, entry] of Object.entries(bundle)) {
         if (entry.type === 'asset' && fileName.endsWith('.css')) {
           cssAssetNames.add(fileName)
+          if (typeof entry.source === 'string') {
+            entry.source = entry.source.replace(VITE_HASH_UPDATE_MARKER_RE, '')
+          }
         }
       }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

CSS published to `modules.sanity-cdn.com` from the `package.bundle.ts` flows ends with a stray `/*$vite$:1*/` comment (e.g. `bare/index.css` for `sanity@6.3.0-next.46`). That string is Vite's internal `viteHashUpdateMarker`: Rolldown's `vite-css-post` plugin appends it to finalized CSS to force a different content hash (workaround for [vitejs/vite#18038](https://github.com/vitejs/vite/issues/18038)) and is supposed to strip it again before write.

Our CDN bundles use `build.lib`, which defaults `cssCodeSplit` to `false`, so the combined CSS is emitted via Rolldown's non-code-split path **late** in `generateBundle` — after Rolldown's own strip pass has already run (its source even carries a `// TODO: we can't handle above emitted css assets` note). The marker therefore leaks only into our published library CSS; it does not appear in `sanity dev` (no production finalize step) or in userland `sanity build` (app build → code-split path strips it). It's an inert CSS comment, but it shouldn't be in what we ship.

Why not just bump Rolldown: `vite@8.1.0` pins `rolldown@1.1.2`, and the plugin was restructured in `1.1.3`, so we can't cleanly upgrade it in isolation. Stripping it ourselves is version-independent and mirrors Vite's own intended cleanup (`source.replace(viteHashUpdateMarkerRE, '')`).

### What to review

- `packages/@repo/package.bundle/src/package.bundle.ts`: the existing `stripCssImportsPlugin` is broadened to `cleanupCssOutputPlugin`, which now also removes the marker from emitted `.css` assets in `generateBundle`, using the same regex Vite uses (`/\/\*\$vite\$:\d+\*\//`).
- Affects only the CDN bundle build for `sanity` and `@sanity/vision`. No runtime, `sanity dev`, or userland behavior change.

### Testing

- Unit tests in `package.bundle.test.ts` (13 total): marker removal, numeric-suffix variants (`:N`), multiple markers within one asset (guards the regex global flag), multiple CSS assets, missing markers left as-is, non-string sources left untouched, and JS chunks untouched. `pnpm --filter @repo/package.bundle test` → 13 passed.
- Real bundle-build verification (built with Node 22.22.2, since the `.ts` config needs Node ≥22.18):
  - `@sanity/vision` `build:bundle` → `dist/index.css` (~5 kB) contains no marker. A/B check: with the strip disabled the file ends with `/*$vite$:1*/`; with it enabled the marker is gone — confirming the fix is what removes it.
  - `sanity` `build:bundle` emits `dist/index.css` = `#sanity{--static-css-file-loaded-studio:true}` (46 bytes, no marker), vs the published `6.3.0-next.46/bare/index.css` which was 58 bytes ending in the marker.
- `oxlint`, `oxfmt --check`, and `tsgo` type check all pass for the changed files.

### Notes for release

N/A – Internal only (build tooling; removes a stray Vite comment from CDN-published CSS).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14081159-1c08-42e4-a417-1508271222da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14081159-1c08-42e4-a417-1508271222da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

