### PR TITLE
fix(sanity): clip document group inventory border

### DIFF
--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -49,6 +49,7 @@ import {Footer} from './Footer'
 import {Header} from './Header'
 import {StatusBadge} from './VariantSet/StatusBadge'
 import {VariantCheckbox} from './VariantSet/VariantCheckbox'
+import {VariantSet} from './VariantSet/VariantSet'
 import {VariantSetEntry} from './VariantSet/VariantSetEntry'
 import {VariantSetHeader} from './VariantSet/VariantSetHeader'
 
@@ -318,49 +319,47 @@ const Select: ComponentType<{
   return (
     <Stack gap={5}>
       {sets.map((set) => (
-        <div key={set.key}>
-          <Card border radius={3}>
-            <VariantSetHeader as="header">
-              <Text size={1} weight="bold">
-                {t('document-group-inventory.title', {
+        <VariantSet key={set.key}>
+          <VariantSetHeader as="header">
+            <Text size={1} weight="bold">
+              {t('document-group-inventory.title', {
+                count: set.variants.length,
+                subject: t('document-group.subject.version', {
                   count: set.variants.length,
-                  subject: t('document-group.subject.version', {
-                    count: set.variants.length,
-                  }),
-                })}
+                }),
+              })}
+            </Text>
+            <TextButton
+              onClick={() => {
+                set.variants.forEach((variant) =>
+                  machine.send({type: 'selection.add', variantId: variant.id}),
+                )
+              }}
+            >
+              {/* These strings will be removed in the next iteration, so we've skipped internationalisation. */}
+              <Text size={1}>
+                {isSelectable
+                  ? `Select all ${set.variants.length}`
+                  : `${set.variants.length} documents`}
               </Text>
-              <TextButton
-                onClick={() => {
-                  set.variants.forEach((variant) =>
-                    machine.send({type: 'selection.add', variantId: variant.id}),
-                  )
-                }}
-              >
-                {/* These strings will be removed in the next iteration, so we've skipped internationalisation. */}
-                <Text size={1}>
-                  {isSelectable
-                    ? `Select all ${set.variants.length}`
-                    : `${set.variants.length} documents`}
-                </Text>
-              </TextButton>
-            </VariantSetHeader>
-            {set.variants
-              .filter(({id}) => !hasFilterString || filterMatchingVariantIds.has(id))
-              .map((variant) => (
-                <Variant
-                  key={variant.id}
-                  variant={variant}
-                  machine={machine}
-                  inventoryRef={inventoryRef}
-                  documentType={documentType}
-                  onPrimaryAction={onPrimaryAction}
-                  isSelectable={isSelectable}
-                  menuPortalElement={menuPortalElement}
-                  perspectiveList={perspectiveList}
-                />
-              ))}
-          </Card>
-        </div>
+            </TextButton>
+          </VariantSetHeader>
+          {set.variants
+            .filter(({id}) => !hasFilterString || filterMatchingVariantIds.has(id))
+            .map((variant) => (
+              <Variant
+                key={variant.id}
+                variant={variant}
+                machine={machine}
+                inventoryRef={inventoryRef}
+                documentType={documentType}
+                onPrimaryAction={onPrimaryAction}
+                isSelectable={isSelectable}
+                menuPortalElement={menuPortalElement}
+                perspectiveList={perspectiveList}
+              />
+            ))}
+        </VariantSet>
       ))}
     </Stack>
   )

--- a/packages/sanity/src/core/documentGroupInventory/components/VariantSet/VariantSet.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/VariantSet/VariantSet.tsx
@@ -1,0 +1,9 @@
+import {Card} from '@sanity/ui'
+import {styled} from 'styled-components'
+
+export const VariantSet = styled(Card).attrs({
+  border: true,
+  radius: 3,
+})`
+  overflow: hidden;
+`


### PR DESCRIPTION
### Description

This branch fixes elements inside document group inventory sets extending beyond their parent's border radius.

| Before | After |
| --- | --- |
| <img width="451" height="161" alt="before" src="https://github.com/user-attachments/assets/e7b4704c-be98-4b15-826b-5f532849bcab" /> | <img width="451" height="161" alt="after" src="https://github.com/user-attachments/assets/d5227879-d26b-42f4-9c9a-183373005d5c" /> |

### What to review

Updated styles.

### Testing

Verified across browsers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only refactor in document group inventory UI; no logic, data, or API changes.
> 
> **Overview**
> Fixes variant rows and headers visually spilling past the rounded border on each document group inventory set.
> 
> The bordered `Card` wrapper is moved into a new **`VariantSet`** styled component that keeps `border` and `radius={3}` and adds **`overflow: hidden`** so child content respects the corner radius. **`DocumentGroupInventory`** now renders each set with **`VariantSet`** instead of a plain `div` plus inline `Card`, with no behavior changes to selection or filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a80556d6a4e6504c16668dd6bc18269d0cff433c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->