### PR TITLE
chore(deps): bump @sanity/ui to 3.3.0 and fix polymorphic type errors

### DIFF
--- a/packages/@sanity/vision/src/components/QueryRecall.tsx
+++ b/packages/@sanity/vision/src/components/QueryRecall.tsx
@@ -361,7 +361,7 @@ export function QueryRecall({
         <Flex padding={3} paddingTop={2} paddingBottom={0} justify="space-between" align="center">
           <StyledLabel muted>{t('label.saved-queries')}</StyledLabel>
           <Button
-            label={t('action.save-query')}
+            aria-label={t('action.save-query')}
             icon={AddIcon}
             disabled={saving}
             onClick={() => void handleSave()}
@@ -418,7 +418,6 @@ export function QueryRecall({
           return (
             <Card
               key={q._key}
-              width={'fill'}
               paddingX={compactMode ? 3 : 4}
               paddingY={compactMode ? 3 : 4}
               tone="default"
@@ -568,12 +567,10 @@ export function QueryRecall({
                     placement="top"
                     portal
                   >
-                    <Code muted size={1}>
-                      {shortQueryPreview}
-                    </Code>
+                    <Code size={1}>{shortQueryPreview}</Code>
                   </Tooltip>
                 ) : (
-                  <Code muted />
+                  <Code />
                 )}
 
                 {compactMode ? (
@@ -671,7 +668,6 @@ export function QueryRecall({
                   <Button
                     mode="ghost"
                     tone="default"
-                    size={1}
                     padding={2}
                     style={{
                       height: '24px',
@@ -699,7 +695,7 @@ export function QueryRecall({
           header={t('label.share')}
           onClose={() => setShareDialogQuery(null)}
           footer={
-            <Flex width="fill" justify="flex-end" gap={3} padding={3} align="center">
+            <Flex justify="flex-end" gap={3} padding={3} align="center">
               <Button
                 mode="bleed"
                 padding={2}

--- a/packages/@sanity/vision/src/components/SaveResultButtons.tsx
+++ b/packages/@sanity/vision/src/components/SaveResultButtons.tsx
@@ -1,6 +1,6 @@
 import {DocumentSheetIcon} from '@sanity/icons'
 import {Button, Tooltip} from '@sanity/ui'
-import {type MouseEvent} from 'react'
+import {type ElementType, type MouseEvent} from 'react'
 import {useTranslation} from 'sanity'
 
 import {visionLocaleNamespace} from '../i18n'
@@ -9,7 +9,7 @@ interface SaveButtonProps {
   blobUrl: string | undefined
 }
 
-function preventSave(evt: MouseEvent<HTMLButtonElement>) {
+function preventSave(evt: MouseEvent<HTMLAnchorElement>) {
   return evt.preventDefault()
 }
 
@@ -19,7 +19,7 @@ export function SaveCsvButton({blobUrl}: SaveButtonProps) {
 
   const button = (
     <Button
-      as="a"
+      as={'a' as ElementType}
       disabled={isDisabled}
       download={isDisabled ? undefined : 'query-result.csv'}
       href={blobUrl}

--- a/packages/@sanity/vision/src/components/SaveResultButtons.tsx
+++ b/packages/@sanity/vision/src/components/SaveResultButtons.tsx
@@ -1,6 +1,5 @@
 import {DocumentSheetIcon} from '@sanity/icons'
 import {Button, Tooltip} from '@sanity/ui'
-import {type ElementType, type MouseEvent} from 'react'
 import {useTranslation} from 'sanity'
 
 import {visionLocaleNamespace} from '../i18n'
@@ -9,35 +8,37 @@ interface SaveButtonProps {
   blobUrl: string | undefined
 }
 
-function preventSave(evt: MouseEvent<HTMLAnchorElement>) {
-  return evt.preventDefault()
-}
-
 export function SaveCsvButton({blobUrl}: SaveButtonProps) {
   const {t} = useTranslation(visionLocaleNamespace)
-  const isDisabled = !blobUrl
 
-  const button = (
+  // An anchor cannot be disabled, so when there is nothing to download we render a plain
+  // disabled button (which also prevents the click natively) instead of a disabled link.
+  if (!blobUrl) {
+    return (
+      <Tooltip content={t('result.save-result-as-csv.not-csv-encodable')} placement="top">
+        <Button
+          disabled
+          icon={DocumentSheetIcon}
+          mode="ghost"
+          // oxlint-disable-next-line @sanity/i18n/no-attribute-string-literals
+          text="CSV" // String is a File extension
+          tone="default"
+        />
+      </Tooltip>
+    )
+  }
+
+  return (
     <Button
-      as={'a' as ElementType}
-      disabled={isDisabled}
-      download={isDisabled ? undefined : 'query-result.csv'}
+      as="a"
+      download="query-result.csv"
       href={blobUrl}
       icon={DocumentSheetIcon}
       mode="ghost"
-      onClick={isDisabled ? preventSave : undefined}
       // oxlint-disable-next-line @sanity/i18n/no-attribute-string-literals
       text="CSV" // String is a File extension
       tone="default"
     />
-  )
-
-  return isDisabled ? (
-    <Tooltip content={t('result.save-result-as-csv.not-csv-encodable')} placement="top">
-      {button}
-    </Tooltip>
-  ) : (
-    button
   )
 }
 

--- a/packages/sanity/src/core/comments/components/list/CommentsList.tsx
+++ b/packages/sanity/src/core/comments/components/list/CommentsList.tsx
@@ -77,7 +77,7 @@ export interface CommentsListHandle {
 
 const CommentsListInner = forwardRef(function CommentsListInner(
   props: CommentsListProps,
-  ref: React.Ref<HTMLDivElement>,
+  ref: React.Ref<HTMLUListElement>,
 ) {
   const {
     beforeListNode,

--- a/packages/sanity/src/core/comments/components/list/styles.ts
+++ b/packages/sanity/src/core/comments/components/list/styles.ts
@@ -1,23 +1,20 @@
 import {hues} from '@sanity/color'
 import {Card} from '@sanity/ui'
-import {type Theme} from '@sanity/ui/theme'
 import {css, styled} from 'styled-components'
 
 import {COMMENTS_HIGHLIGHT_HUE_KEY} from '../../constants'
 
-export const ThreadCard = styled(Card).attrs({padding: 3, radius: 3, sizing: 'border'})(
-  (props: {theme: Theme}) => {
-    const {theme} = props
-    const isDark = theme.sanity.color.dark
-    const activeBg = hues[COMMENTS_HIGHLIGHT_HUE_KEY][isDark ? 900 : 50].hex
-    const defaultBg = hues.gray[isDark ? 900 : 50].hex
+export const ThreadCard = styled(Card).attrs({padding: 3, radius: 3, sizing: 'border'})((props) => {
+  const {theme} = props
+  const isDark = theme.sanity.color.dark
+  const activeBg = hues[COMMENTS_HIGHLIGHT_HUE_KEY][isDark ? 900 : 50].hex
+  const defaultBg = hues.gray[isDark ? 900 : 50].hex
 
-    return css`
-      background-color: ${defaultBg};
+  return css`
+    background-color: ${defaultBg};
 
-      &[data-active='true'] {
-        background-color: ${activeBg};
-      }
-    `
-  },
-)
+    &[data-active='true'] {
+      background-color: ${activeBg};
+    }
+  `
+})

--- a/packages/sanity/src/core/comments/components/list/styles.ts
+++ b/packages/sanity/src/core/comments/components/list/styles.ts
@@ -1,16 +1,12 @@
 import {hues} from '@sanity/color'
-import {Card, type CardProps} from '@sanity/ui'
+import {Card} from '@sanity/ui'
 import {type Theme} from '@sanity/ui/theme'
 import {css, styled} from 'styled-components'
 
 import {COMMENTS_HIGHLIGHT_HUE_KEY} from '../../constants'
 
-interface ThreadCardProps extends Omit<CardProps, 'tone'> {
-  theme: Theme
-}
-
 export const ThreadCard = styled(Card).attrs({padding: 3, radius: 3, sizing: 'border'})(
-  (props: ThreadCardProps) => {
+  (props: {theme: Theme}) => {
     const {theme} = props
     const isDark = theme.sanity.color.dark
     const activeBg = hues[COMMENTS_HIGHLIGHT_HUE_KEY][isDark ? 900 : 50].hex

--- a/packages/sanity/src/core/components/commandList/CommandList.tsx
+++ b/packages/sanity/src/core/components/commandList/CommandList.tsx
@@ -657,7 +657,7 @@ const CommandListItemComponent = forwardRef(function CommandListItem(
     virtualIndex: number
     virtualRowStart: number
   },
-  forwardedRef: React.ForwardedRef<HTMLDivElement>,
+  forwardedRef: React.ForwardedRef<HTMLLIElement>,
 ) {
   const {
     children,

--- a/packages/sanity/src/core/components/previewCard/PreviewCard.tsx
+++ b/packages/sanity/src/core/components/previewCard/PreviewCard.tsx
@@ -1,5 +1,12 @@
 import {Card, type CardProps} from '@sanity/ui'
-import {type ForwardedRef, forwardRef, type HTMLProps, useContext, useMemo} from 'react'
+import {
+  type ElementType,
+  type ForwardedRef,
+  forwardRef,
+  type HTMLProps,
+  useContext,
+  useMemo,
+} from 'react'
 import {PreviewCardContext} from 'sanity/_singletons'
 import {css, styled} from 'styled-components'
 
@@ -36,7 +43,7 @@ export function usePreviewCard(): PreviewCardContextValue {
 
 /** @internal */
 export const PreviewCard = forwardRef(function PreviewCard(
-  props: CardProps & Omit<HTMLProps<HTMLDivElement>, 'height'>,
+  props: CardProps<ElementType> & Omit<HTMLProps<HTMLDivElement>, 'height'>,
   ref: ForwardedRef<HTMLDivElement>,
 ) {
   const {children, selected, as, ...restProps} = props

--- a/packages/sanity/src/core/components/resizer/Resizable.tsx
+++ b/packages/sanity/src/core/components/resizer/Resizable.tsx
@@ -1,5 +1,5 @@
 import {Box, type BoxProps} from '@sanity/ui'
-import {type HTMLProps, useCallback, useMemo, useRef, useState} from 'react'
+import {type ElementType, type HTMLProps, useCallback, useMemo, useRef, useState} from 'react'
 import {styled} from 'styled-components'
 
 import {Resizer} from './Resizer'
@@ -22,7 +22,7 @@ const Root = styled(Box)`
  * Provides a resizable container with a resizer handle.
  */
 export function Resizable(
-  props: ResizableProps & BoxProps & Omit<HTMLProps<HTMLDivElement>, 'as'>,
+  props: ResizableProps & BoxProps<ElementType> & Omit<HTMLProps<HTMLDivElement>, 'as'>,
 ) {
   const {
     as: forwardedAs,

--- a/packages/sanity/src/core/components/textWithTone/TextWithTone.tsx
+++ b/packages/sanity/src/core/components/textWithTone/TextWithTone.tsx
@@ -1,9 +1,9 @@
-import {type ButtonTone, Text} from '@sanity/ui'
-import {type ComponentProps, forwardRef, type Ref} from 'react'
+import {type ButtonTone, Text, type TextProps} from '@sanity/ui'
+import {forwardRef, type Ref} from 'react'
 import {styled} from 'styled-components'
 
 /** @internal */
-export interface TextWithToneProps extends ComponentProps<typeof Text> {
+export type TextWithToneProps = TextProps & {
   tone: ButtonTone
   dimmed?: boolean
 }

--- a/packages/sanity/src/core/field/diff/components/DiffInspectWrapper.tsx
+++ b/packages/sanity/src/core/field/diff/components/DiffInspectWrapper.tsx
@@ -26,7 +26,9 @@ const Meta = styled.div`
 `
 
 /** @internal */
-export function DiffInspectWrapper(props: DiffInspectWrapperProps & BoxProps): React.JSX.Element {
+export function DiffInspectWrapper(
+  props: DiffInspectWrapperProps & Omit<BoxProps, 'as'>,
+): React.JSX.Element {
   const {children, as, change, ...restProps} = props
   const isHovering = useRef(false)
   const [isInspecting, setIsInspecting] = useState(false)

--- a/packages/sanity/src/core/form/components/breadcrumbs/DialogBreadcrumbs.tsx
+++ b/packages/sanity/src/core/form/components/breadcrumbs/DialogBreadcrumbs.tsx
@@ -170,7 +170,7 @@ function BreadcrumbMenuItem({
   return (
     <MenuItem padding={1} onClick={handleClick}>
       <Flex align="center" style={{minWidth: 0, maxWidth: '250px'}}>
-        {siblingInfo && <Badge size={1}>#{siblingInfo.index}</Badge>}
+        {siblingInfo && <Badge>#{siblingInfo.index}</Badge>}
         <Box
           paddingLeft={siblingInfo?.index ? 1 : 0}
           paddingY={1}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -7,14 +7,7 @@ import {
   useClickOutsideEvent,
   useGlobalKeyDown,
 } from '@sanity/ui'
-import {
-  type PropsWithChildren,
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react'
+import {type ComponentProps, type ReactNode, useCallback, useEffect, useRef, useState} from 'react'
 import FocusLock from 'react-focus-lock'
 import {type PortableTextEditorElement} from 'sanity/_singletons'
 
@@ -39,7 +32,7 @@ interface PopoverEditDialogProps {
  * Wrapper for focus lock that maintains scroll on the popover
  * Unlike Fragment (on some react versions) this does not absorb the ref prop
  */
-const NoopContainer = ({children, ...props}: PropsWithChildren) => (
+const NoopContainer = ({children, ...props}: ComponentProps<'div'>) => (
   <div
     {...props}
     // Makes the div focusable so clicking on the popover will move the focus away from the input once focus lock is active

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/PreviewItem.tsx
@@ -87,9 +87,9 @@ export function PreviewItem<Item extends ObjectItem = ObjectItem>(props: Preview
   const sortable = parentSchemaType.options?.sortable !== false
   const insertableTypes = parentSchemaType.of
 
-  const [previewCardElement, setPreviewCardElement] = useState<HTMLDivElement | null>(null)
-  const previewCardRef = useRef<HTMLDivElement | null>(null)
-  useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(
+  const [previewCardElement, setPreviewCardElement] = useState<HTMLButtonElement | null>(null)
+  const previewCardRef = useRef<HTMLButtonElement | null>(null)
+  useImperativeHandle<HTMLButtonElement | null, HTMLButtonElement | null>(
     previewCardRef,
     () => previewCardElement,
     [previewCardElement],

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfOptionsInput/ArrayOfObjectOptionsInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfOptionsInput/ArrayOfObjectOptionsInput.tsx
@@ -120,7 +120,7 @@ export function ArrayOfObjectOptionsInput(props: ArrayOfObjectsInputProps) {
 
           return (
             // oxlint-disable-next-line no-array-index-key
-            <Flex key={index} align="center" as="label" muted={disabled}>
+            <Flex key={index} align="center" as="label">
               <Checkbox
                 disabled={disabled}
                 checked={checked}

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfOptionsInput/ArrayOfPrimitiveOptionsInput.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfOptionsInput/ArrayOfPrimitiveOptionsInput.tsx
@@ -86,7 +86,7 @@ export function ArrayOfPrimitiveOptionsInput(props: ArrayOfPrimitivesInputProps)
 
           return (
             // oxlint-disable-next-line no-array-index-key
-            <Flex key={index} align="center" as="label" muted={disabled}>
+            <Flex key={index} align="center" as="label">
               <Checkbox
                 disabled={disabled}
                 checked={checked}

--- a/packages/sanity/src/core/form/inputs/arrays/common/list.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/common/list.tsx
@@ -19,7 +19,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import {CSS} from '@dnd-kit/utilities'
-import {Box, type Card, Grid} from '@sanity/ui'
+import {Box, type CardProps, Grid} from '@sanity/ui'
 import {
   type ComponentProps,
   type ForwardedRef,
@@ -202,7 +202,7 @@ interface ItemProps {
 }
 
 export const Item = forwardRef(function Item(
-  props: ItemProps & ComponentProps<typeof Card>,
+  props: ItemProps & CardProps,
   ref: ForwardedRef<HTMLDivElement>,
 ) {
   const {sortable, disableTransition, ...rest} = props

--- a/packages/sanity/src/core/form/inputs/files/common/uploadTarget/UploadTargetCard.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/uploadTarget/UploadTargetCard.tsx
@@ -1,10 +1,11 @@
-import {Card} from '@sanity/ui'
+import {Card, type CardProps} from '@sanity/ui'
+import {type ComponentType} from 'react'
 import {styled} from 'styled-components'
 
 import {withFocusRing} from '../../../../components/withFocusRing'
 import {uploadTarget} from './uploadTarget'
 
-const StyledCard = styled(Card)`
+const StyledCard = styled(Card as ComponentType<CardProps>)`
   height: 100%;
 `
 

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/OpenInSourceDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/OpenInSourceDialog.tsx
@@ -90,7 +90,6 @@ export function OpenInSourceDialog(props: OpenInSourceDialogProps): ReactNode {
       width={3}
       footer={
         <Card
-          width="full"
           height="fill"
           padding={3}
           shadow={1}
@@ -99,7 +98,7 @@ export function OpenInSourceDialog(props: OpenInSourceDialogProps): ReactNode {
             minHeight: '2dvh',
           }}
         >
-          <Flex width="full" gap={3} align="center" justify="space-between">
+          <Flex gap={3} align="center" justify="space-between">
             <Button
               onClick={onSelectNewAsset}
               text={selectNewAssetButtonLabel}

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/SelectAssetsDialog.tsx
@@ -202,7 +202,6 @@ export function SelectAssetsDialog(props: SelectAssetsDialogProps): ReactNode {
       width={3}
       footer={
         <Card
-          width="full"
           height="fill"
           padding={3}
           shadow={1}
@@ -211,8 +210,8 @@ export function SelectAssetsDialog(props: SelectAssetsDialogProps): ReactNode {
             minHeight: '2dvh',
           }}
         >
-          <Flex width="full" gap={3} justify="flex-end">
-            <Flex width="full" gap={2} justify="flex-end" align="center">
+          <Flex gap={3} justify="flex-end">
+            <Flex gap={2} justify="flex-end" align="center">
               {validation.length > 0 && (
                 <FormFieldValidationStatus fontSize={2} placement="top" validation={validation} />
               )}

--- a/packages/sanity/src/core/limits/context/documents/DocumentLimitsUpsellPanel.tsx
+++ b/packages/sanity/src/core/limits/context/documents/DocumentLimitsUpsellPanel.tsx
@@ -22,7 +22,7 @@ export function DocumentLimitsUpsellPanel() {
   }
 
   return (
-    <Flex height="fill" width="fill" justify="center" align="center" padding={4}>
+    <Flex height="fill" justify="center" align="center" padding={4}>
       <motion.div
         initial={{opacity: 0, scale: 0.95}}
         animate={{opacity: 1, scale: 1}}

--- a/packages/sanity/src/core/perspective/navbar/currentGlobalPerspectiveLabel.tsx
+++ b/packages/sanity/src/core/perspective/navbar/currentGlobalPerspectiveLabel.tsx
@@ -1,7 +1,7 @@
 import {type ReleaseDocument} from '@sanity/client'
 // oxlint-disable-next-line no-restricted-imports -- Bundle Button requires more fine-grained styling than studio button
 import {Box, Button, Text} from '@sanity/ui'
-import {type ForwardedRef, forwardRef, type ReactNode, useMemo} from 'react'
+import {type ForwardedRef, forwardRef, useMemo} from 'react'
 import {IntentLink} from 'sanity/router'
 import {styled} from 'styled-components'
 
@@ -27,7 +27,7 @@ const ReleasesLink = ({selectedPerspective}: {selectedPerspective: ReleaseDocume
   const ReleasesIntentLink = useMemo(
     () =>
       forwardRef(function ReleasesIntentLink(
-        {children, ...intentProps}: {children: ReactNode},
+        {children, ...intentProps}: React.ComponentPropsWithoutRef<'a'>,
         linkRef: ForwardedRef<HTMLAnchorElement>,
       ) {
         return (

--- a/packages/sanity/src/core/releases/components/dialog/ReleaseForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/ReleaseForm.tsx
@@ -79,7 +79,7 @@ export function ReleaseForm(props: {
     [handleOnChangeAndStorage, value],
   )
 
-  const handleReleaseTypeChange = useCallback<MouseEventHandler<HTMLDivElement>>(
+  const handleReleaseTypeChange = useCallback<MouseEventHandler<HTMLButtonElement>>(
     (event) => {
       const pickedReleaseType = event.currentTarget.dataset.value
 

--- a/packages/sanity/src/core/releases/components/documentHeader/dialog/CopyToNewReleaseDialog.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/dialog/CopyToNewReleaseDialog.tsx
@@ -173,7 +173,7 @@ export function CopyToNewReleaseDialog(props: {
         )}
         <ReleaseForm onChange={handleOnChange} value={release} />
 
-        <Flex width="full" gap={3} justify="flex-end" paddingTop={3} align="center">
+        <Flex gap={3} justify="flex-end" paddingTop={3} align="center">
           <Button
             disabled={isSubmitting}
             text={t('common.dialog.cancel-button.text')}

--- a/packages/sanity/src/core/releases/tool/components/ReleaseDocumentPreview.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseDocumentPreview.tsx
@@ -58,7 +58,10 @@ export function ReleaseDocumentPreview({
 
   const LinkComponent = useMemo(
     () =>
-      forwardRef(function LinkComponent(linkProps, ref: ForwardedRef<HTMLAnchorElement>) {
+      forwardRef(function LinkComponent(
+        linkProps: React.ComponentPropsWithoutRef<'a'>,
+        ref: ForwardedRef<HTMLAnchorElement>,
+      ) {
         return (
           <IntentLink
             {...linkProps}

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -2,7 +2,14 @@ import {Box, Card, type CardProps, Flex, rem, Text, useTheme} from '@sanity/ui'
 import {useVirtualizer, type VirtualItem} from '@tanstack/react-virtual'
 import {isValid} from 'date-fns/isValid'
 import get from 'lodash-es/get.js'
-import {type CSSProperties, Fragment, type HTMLProps, type RefAttributes, useMemo} from 'react'
+import {
+  type CSSProperties,
+  type ElementType,
+  Fragment,
+  type HTMLProps,
+  type RefAttributes,
+  useMemo,
+} from 'react'
 
 import {TooltipDelayGroupProvider} from '../../../../../ui-components'
 import {TableEmptyState} from './TableEmptyState'
@@ -16,7 +23,7 @@ type RowDatum<TableData, AdditionalRowTableData> = (AdditionalRowTableData exten
   : TableData & AdditionalRowTableData) & {isLoading?: boolean}
 
 export type TableRowProps = Omit<
-  CardProps & Omit<HTMLProps<HTMLDivElement>, 'height' | 'as'>,
+  CardProps<ElementType> & Omit<HTMLProps<HTMLDivElement>, 'height' | 'as'>,
   'ref'
 > &
   RefAttributes<HTMLDivElement>
@@ -162,7 +169,7 @@ const TableInner = <TableData, AdditionalRowTableData>({
             borderBottom
             display="flex"
             data-index={datum.index}
-            as="tr"
+            as={'tr' as ElementType}
             style={{
               height: `${datum.virtualRow.size}px`,
               position: 'absolute',

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -2,14 +2,7 @@ import {Box, Card, type CardProps, Flex, rem, Text, useTheme} from '@sanity/ui'
 import {useVirtualizer, type VirtualItem} from '@tanstack/react-virtual'
 import {isValid} from 'date-fns/isValid'
 import get from 'lodash-es/get.js'
-import {
-  type CSSProperties,
-  type ElementType,
-  Fragment,
-  type HTMLProps,
-  type RefAttributes,
-  useMemo,
-} from 'react'
+import {type CSSProperties, type ElementType, Fragment, useMemo} from 'react'
 
 import {TooltipDelayGroupProvider} from '../../../../../ui-components'
 import {TableEmptyState} from './TableEmptyState'
@@ -22,11 +15,7 @@ type RowDatum<TableData, AdditionalRowTableData> = (AdditionalRowTableData exten
   ? TableData
   : TableData & AdditionalRowTableData) & {isLoading?: boolean}
 
-export type TableRowProps = Omit<
-  CardProps<ElementType> & Omit<HTMLProps<HTMLDivElement>, 'height' | 'as'>,
-  'ref'
-> &
-  RefAttributes<HTMLDivElement>
+export type TableRowProps = CardProps<ElementType>
 
 type VirtualDatum = {
   virtualRow: VirtualItem
@@ -169,7 +158,7 @@ const TableInner = <TableData, AdditionalRowTableData>({
             borderBottom
             display="flex"
             data-index={datum.index}
-            as={'tr' as ElementType}
+            as="tr"
             style={{
               height: `${datum.virtualRow.size}px`,
               position: 'absolute',

--- a/packages/sanity/src/core/scheduled-publishing/components/dialogs/DialogFooter.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/dialogs/DialogFooter.tsx
@@ -15,7 +15,7 @@ interface Props {
 const DialogFooter = (props: Props) => {
   const {buttonText = 'Action', disabled, icon, onAction, onComplete, tone = 'positive'} = props
   return (
-    <Flex width="full" gap={3} justify="flex-end">
+    <Flex gap={3} justify="flex-end">
       <Button mode="bleed" onClick={onComplete} text="Cancel" />
       {onAction && (
         <Button disabled={disabled} icon={icon} onClick={onAction} text={buttonText} tone={tone} />

--- a/packages/sanity/src/core/scheduled-publishing/tool/Tool.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/tool/Tool.tsx
@@ -46,7 +46,7 @@ function ScheduledDraftsBanner() {
 
   if (isScheduledDraftsEnabled) {
     return (
-      <Card padding={4} tone="caution" width="fill">
+      <Card padding={4} tone="caution">
         <Flex gap={3} align="center" justify="center">
           <Text size={1} weight="medium">
             Scheduled Drafts is enabled for this Studio. All new Scheduled Drafts will be{' '}

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/PopoverContent.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/PopoverContent.tsx
@@ -21,7 +21,7 @@ interface PopoverContentProps {
 
 export function PopoverContent({content, handleClose, handleOpenNext}: PopoverContentProps) {
   return (
-    <Card radius={3} overflow={'hidden'} width={0}>
+    <Card radius={3} overflow={'hidden'}>
       <Container width={0}>
         {content.image && (
           <Image src={content.image.asset.url} alt={content.image.asset.altText ?? ''} />
@@ -34,7 +34,7 @@ export function PopoverContent({content, handleClose, handleOpenNext}: PopoverCo
             <UpsellDescriptionSerializer blocks={content.descriptionText} />
           </Box>
         </Flex>
-        <Flex width="full" gap={3} justify="flex-end" padding={3}>
+        <Flex gap={3} justify="flex-end" padding={3}>
           {content.secondaryButton?.text && (
             <Button
               mode="bleed"

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentListOption.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentListOption.tsx
@@ -1,6 +1,6 @@
 import {type CurrentUser} from '@sanity/types'
 import {Box, Card, Flex, Text} from '@sanity/ui'
-import {isValidElement, type MouseEvent, useCallback, useMemo} from 'react'
+import {type ElementType, isValidElement, type MouseEvent, useCallback, useMemo} from 'react'
 import {isValidElementType} from 'react-is'
 import {useIntentLink} from 'sanity/router'
 
@@ -57,7 +57,7 @@ export function NewDocumentListOption(props: NewDocumentListOptionProps) {
     >
       <div>
         <Card
-          as={option.hasPermission ? 'a' : 'button'}
+          as={(option.hasPermission ? 'a' : 'button') as ElementType}
           data-testid={`create-new-${option.templateId}`}
           disabled={!option.hasPermission}
           href={href}

--- a/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentListOption.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/new-document/NewDocumentListOption.tsx
@@ -1,6 +1,6 @@
 import {type CurrentUser} from '@sanity/types'
 import {Box, Card, Flex, Text} from '@sanity/ui'
-import {type ElementType, isValidElement, type MouseEvent, useCallback, useMemo} from 'react'
+import {isValidElement, type MouseEvent, useCallback, useMemo} from 'react'
 import {isValidElementType} from 'react-is'
 import {useIntentLink} from 'sanity/router'
 
@@ -46,6 +46,20 @@ export function NewDocumentListOption(props: NewDocumentListOptionProps) {
   const {title} = useI18nText(option)
   const {icon: Icon} = option
 
+  const cardContent = (
+    <Flex align="center" gap={3}>
+      {Icon && (
+        <Box>
+          <Text size={preview === 'inline' ? 1 : undefined}>
+            {isValidElement(Icon) && Icon}
+            {isValidElementType(Icon) && <Icon />}
+          </Text>
+        </Box>
+      )}
+      <Text size={preview === 'inline' ? 1 : undefined}>{title}</Text>
+    </Flex>
+  )
+
   return (
     <Tooltip
       key={option.id}
@@ -56,28 +70,31 @@ export function NewDocumentListOption(props: NewDocumentListOptionProps) {
       }
     >
       <div>
-        <Card
-          as={(option.hasPermission ? 'a' : 'button') as ElementType}
-          data-testid={`create-new-${option.templateId}`}
-          disabled={!option.hasPermission}
-          href={href}
-          marginBottom={1}
-          onClick={handleDocumentClick}
-          padding={preview === 'inline' ? 3 : 4}
-          radius={2}
-        >
-          <Flex align="center" gap={3}>
-            {Icon && (
-              <Box>
-                <Text size={preview === 'inline' ? 1 : undefined}>
-                  {isValidElement(Icon) && Icon}
-                  {isValidElementType(Icon) && <Icon />}
-                </Text>
-              </Box>
-            )}
-            <Text size={preview === 'inline' ? 1 : undefined}>{title}</Text>
-          </Flex>
-        </Card>
+        {option.hasPermission ? (
+          <Card
+            as="a"
+            data-testid={`create-new-${option.templateId}`}
+            href={href}
+            marginBottom={1}
+            onClick={handleDocumentClick}
+            padding={preview === 'inline' ? 3 : 4}
+            radius={2}
+          >
+            {cardContent}
+          </Card>
+        ) : (
+          <Card
+            as="button"
+            data-testid={`create-new-${option.templateId}`}
+            disabled
+            marginBottom={1}
+            onClick={handleDocumentClick}
+            padding={preview === 'inline' ? 3 : 4}
+            radius={2}
+          >
+            {cardContent}
+          </Card>
+        )}
       </div>
     </Tooltip>
   )

--- a/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
@@ -177,7 +177,7 @@ export function StudioInfoDialog(props: StudioInfoDialogProps) {
                   <Badge tone={versionBadgeTone}>
                     {ensureVersionPrefix(currentVersion.version)}
                   </Badge>
-                  <Badge size={1}>
+                  <Badge>
                     {currentVersionType === 'development'
                       ? t('about-dialog.version-info.tooltip.development')
                       : currentVersionType === 'prerelease'

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/debug/_DebugDocumentTypes.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/debug/_DebugDocumentTypes.tsx
@@ -22,7 +22,7 @@ export function DebugDocumentTypes({filter}: DebugDocumentTypesProps) {
         <Code size={0} weight="medium">
           Document types
         </Code>
-        <Code muted size={0} style={{whiteSpace: 'normal'}}>
+        <Code size={0} style={{whiteSpace: 'normal'}}>
           {fieldDefinition?.documentTypes && fieldDefinition.documentTypes.length > 0
             ? fieldDefinition.documentTypes?.join(', ')
             : '(all)'}

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/debug/_DebugDocumentTypesNarrowed.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/debug/_DebugDocumentTypesNarrowed.tsx
@@ -13,7 +13,7 @@ export function DebugDocumentTypesNarrowed() {
         <Code size={1} weight="medium">
           Document types (narrowed)
         </Code>
-        <Code muted size={1} style={{whiteSpace: 'normal'}}>
+        <Code size={1} style={{whiteSpace: 'normal'}}>
           {documentTypesNarrowed.length > 0 ? documentTypesNarrowed.join(', ') : '(All)'}
         </Code>
       </Stack>

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/debug/_DebugFilterValues.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/debug/_DebugFilterValues.tsx
@@ -21,13 +21,13 @@ export function DebugFilterValues({filter}: DebugFilterValuesProps) {
           Filter
         </Code>
         {fieldDefinition?.fieldPath && <Code size={0}>fieldPath: {fieldDefinition.fieldPath}</Code>}
-        <Code muted size={0} style={{whiteSpace: 'normal'}}>
+        <Code size={0} style={{whiteSpace: 'normal'}}>
           filterName: {filter.filterName}
         </Code>
-        <Code muted size={0} style={{whiteSpace: 'normal'}}>
+        <Code size={0} style={{whiteSpace: 'normal'}}>
           operatorType: {filter.operatorType}
         </Code>
-        <Code muted size={0} style={{whiteSpace: 'normal'}}>
+        <Code size={0} style={{whiteSpace: 'normal'}}>
           value: {typeof filter?.value === 'undefined' ? '' : JSON.stringify(filter.value)}
         </Code>
       </Stack>

--- a/packages/sanity/src/core/tasks/components/form/fields/TargetField.tsx
+++ b/packages/sanity/src/core/tasks/components/form/fields/TargetField.tsx
@@ -97,7 +97,10 @@ function Preview(props: {value: TaskTarget; handleRemove: () => void}) {
   const {t} = useTranslation(tasksLocaleNamespace)
   const CardLink = useMemo(
     () =>
-      forwardRef(function LinkComponent(linkProps, ref: ForwardedRef<HTMLAnchorElement>) {
+      forwardRef(function LinkComponent(
+        linkProps: React.ComponentPropsWithoutRef<'a'>,
+        ref: ForwardedRef<HTMLAnchorElement>,
+      ) {
         const versionId = getVersionFromId(documentId)
 
         return (

--- a/packages/sanity/src/core/tasks/components/list/DocumentPreview.tsx
+++ b/packages/sanity/src/core/tasks/components/list/DocumentPreview.tsx
@@ -36,7 +36,10 @@ export function DocumentPreview({
 
   const Link = useMemo(
     () =>
-      forwardRef(function LinkComponent(linkProps, ref: React.ForwardedRef<HTMLAnchorElement>) {
+      forwardRef(function LinkComponent(
+        linkProps: React.ComponentPropsWithoutRef<'a'>,
+        ref: React.ForwardedRef<HTMLAnchorElement>,
+      ) {
         return (
           <StyledIntentLink
             {...linkProps}

--- a/packages/sanity/src/media-library/plugin/VideoInput/VideoActionsMenu.tsx
+++ b/packages/sanity/src/media-library/plugin/VideoInput/VideoActionsMenu.tsx
@@ -1,5 +1,5 @@
 import {Box, Card} from '@sanity/ui'
-import {type CSSProperties, lazy, type ReactNode, type RefObject, Suspense} from 'react'
+import {lazy, type ReactNode, type RefObject, Suspense} from 'react'
 
 import {MenuActionsWrapper} from '../../../core/form/inputs/files/common/MenuActionsWrapper.styled'
 import {OptionsMenuPopover} from '../../../core/form/inputs/files/common/OptionsMenuPopover'
@@ -46,11 +46,9 @@ export function VideoActionsMenu(props: Props) {
         <RatioBox
           tone="transparent"
           $isPortrait={aspectRatio !== undefined && aspectRatio < 0.75}
-          style={
-            {
-              '--aspect-ratio': aspectRatio,
-            } as CSSProperties
-          }
+          style={{
+            '--aspect-ratio': aspectRatio,
+          }}
         >
           {playbackId && (
             <Suspense fallback={<VideoSkeleton aspectRatio={aspectRatio} />}>

--- a/packages/sanity/src/media-library/plugin/VideoInput/VideoSkeleton.tsx
+++ b/packages/sanity/src/media-library/plugin/VideoInput/VideoSkeleton.tsx
@@ -1,6 +1,5 @@
 import {ResetIcon} from '@sanity/icons'
 import {Flex, Skeleton, Text} from '@sanity/ui'
-import {type CSSProperties} from 'react'
 
 import {useTranslation} from '../../../core/i18n'
 import {Button} from '../../../ui-components/button'
@@ -21,7 +20,7 @@ export function VideoSkeleton({error, retry, aspectRatio}: VideoSkeletonProps) {
     <RatioBox
       tone={error ? 'critical' : 'transparent'}
       $isPortrait={ratio < 0.75}
-      style={{'--aspect-ratio': ratio} as CSSProperties}
+      style={{'--aspect-ratio': ratio}}
     >
       {error ? (
         <Flex

--- a/packages/sanity/src/presentation/editor/ContentEditor.tsx
+++ b/packages/sanity/src/presentation/editor/ContentEditor.tsx
@@ -116,8 +116,7 @@ export function ContentEditor(props: {
           {mainDocumentState.document ? (
             <PreviewCard
               __unstable_focusRing
-              // oxlint-disable-next-line no-explicit-any
-              as={MainDocumentLink as any}
+              as={MainDocumentLink}
               data-as="a"
               radius={2}
               sizing="border"

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/ReferencePreviewLink.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/ReferencePreviewLink.tsx
@@ -1,7 +1,6 @@
 import {type SchemaType} from '@sanity/types'
 import {type ReactNode, useCallback} from 'react'
 import {
-  type FIXME,
   getPublishedId,
   PreviewCard,
   type SanityDocument,
@@ -42,7 +41,7 @@ export function ReferencePreviewLink(props: ReferencePreviewLinkProps) {
   )
 
   return (
-    <PreviewCard __unstable_focusRing as={Link as FIXME} data-as="a" onClick={onClick} radius={2}>
+    <PreviewCard __unstable_focusRing as={Link} data-as="a" onClick={onClick} radius={2}>
       <PaneItemPreview
         documentPreviewStore={documentPreviewStore}
         icon={type?.icon}

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencePreview.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencePreview.tsx
@@ -1,7 +1,6 @@
 import {type Path, type SanityDocument, type SchemaType} from '@sanity/types'
 import {type ReactNode, useCallback} from 'react'
 import {
-  type FIXME,
   getPublishedId,
   pathToString,
   PreviewCard,
@@ -39,7 +38,7 @@ export function IncomingReferencePreview(props: IncomingReferencePreviewProps) {
   )
 
   return (
-    <PreviewCard __unstable_focusRing as={Link as FIXME} data-as="a" radius={2}>
+    <PreviewCard __unstable_focusRing as={Link} data-as="a" radius={2}>
       <PaneItemPreview
         documentPreviewStore={documentPreviewStore}
         icon={type.icon || false}

--- a/packages/sanity/src/structure/components/paneItem/PaneItem.tsx
+++ b/packages/sanity/src/structure/components/paneItem/PaneItem.tsx
@@ -161,7 +161,6 @@ export function PaneItem(props: PaneItemProps) {
       data-testid={`pane-item-${title}`}
       __unstable_focusRing
       as={ChildLink as FIXME}
-      // @ts-expect-error - `childId` is a valid prop on `ChildLink`
       childId={id}
       data-as="a"
       margin={margin}

--- a/packages/sanity/src/structure/diffView/components/DiffViewPane.tsx
+++ b/packages/sanity/src/structure/diffView/components/DiffViewPane.tsx
@@ -108,11 +108,9 @@ export const DiffViewPane = forwardRef<HTMLDivElement, DiffViewPaneProps>(functi
           <BoundaryElementProvider element={boundaryElement}>
             <DiffViewPaneLayout
               ref={setBoundaryElement}
-              style={
-                {
-                  '--grid-area': `${role}-document`,
-                } as CSSProperties
-              }
+              style={{
+                '--grid-area': `${role}-document`,
+              }}
               borderLeft={role === 'next'}
             >
               <Scroller

--- a/packages/sanity/src/structure/diffView/versionMode/components/VersionModeHeader.tsx
+++ b/packages/sanity/src/structure/diffView/versionMode/components/VersionModeHeader.tsx
@@ -4,6 +4,8 @@ import {
   Box,
   // oxlint-disable-next-line no-restricted-imports -- we need more control over how the `Button` component is rendered
   Button,
+  // oxlint-disable-next-line no-restricted-imports -- the resolved menu button props are spread onto the `@sanity/ui` Button above
+  type ButtonProps,
   type ButtonTone,
   Flex,
   Menu,
@@ -14,7 +16,7 @@ import {
 } from '@sanity/ui'
 // oxlint-disable-next-line @sanity/i18n/no-i18next-import -- figure out how to have the linter be fine with importing types-only
 import {type TFunction} from 'i18next'
-import {type ComponentProps, type ComponentType, useMemo} from 'react'
+import {type ComponentType, useMemo} from 'react'
 import {
   type DocumentLayoutProps,
   getDraftId,
@@ -350,7 +352,7 @@ function getMenuButtonProps({
   selected?: TargetPerspective
   tCore: TFunction
   tStructure: TFunction
-}): Pick<ComponentProps<typeof Button>, 'text' | 'tone' | 'icon' | 'iconRight' | 'disabled'> {
+}): Pick<ButtonProps, 'text' | 'tone' | 'icon' | 'iconRight' | 'disabled'> {
   if (releasesState === 'pending') {
     return {
       text: tCore('common.loading'),

--- a/packages/sanity/src/structure/panes/document/documentInspector/DocumentInspectorHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentInspector/DocumentInspectorHeader.tsx
@@ -1,6 +1,6 @@
 import {CloseIcon} from '@sanity/icons'
 import {Box, Card, type CardProps, Flex, Text} from '@sanity/ui'
-import {type HTMLProps, type ReactNode} from 'react'
+import {type ElementType, type HTMLProps, type ReactNode} from 'react'
 import {useTranslation} from 'sanity'
 import {styled} from 'styled-components'
 
@@ -8,7 +8,7 @@ import {Button} from '../../../../ui-components'
 import {structureLocaleNamespace} from '../../../i18n'
 
 export interface DocumentInspectorHeaderProps {
-  as?: CardProps['as']
+  as?: ElementType
   closeButtonLabel: string
   flex?: CardProps['flex']
   onClose: () => void

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -407,7 +407,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
     <PaneContent>
       <Flex height="fill">
         {showFormView && (
-          <Flex height="fill" direction="column" width="fill" flex={2}>
+          <Flex height="fill" direction="column" flex={2}>
             <LegacyLayerProvider zOffset="paneHeader">
               {banners}
               <DocumentPanelSubHeader />

--- a/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/DocumentPanel.tsx
@@ -111,7 +111,7 @@ export const DocumentPanel = function DocumentPanel(props: DocumentPanelProps) {
   const {features} = useStructureTool()
   const [_portalElement, setPortalElement] = useState<HTMLDivElement | null>(null)
   const [documentScrollElement, setDocumentScrollElement] = useState<HTMLDivElement | null>(null)
-  const formContainerElement = useRef<HTMLDivElement | null>(null)
+  const formContainerElement = useRef<HTMLFormElement | null>(null)
   const workspace = useWorkspace()
 
   const requiredPermission = value._createdAt ? 'update' : 'create'

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/CanvasLinkedBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/CanvasLinkedBanner.tsx
@@ -47,7 +47,7 @@ const CanvasPopoverContent = ({
     : t('canvas.banner.editable.popover-description')
 
   return (
-    <Card radius={3} overflow={'hidden'} width={0} ref={ref}>
+    <Card radius={3} overflow={'hidden'} ref={ref}>
       <Container width={0}>
         <Image src={CANVAS_IMAGE_URL} alt={'Canvas'} />
         <Flex paddingX={4} paddingBottom={4} paddingTop={3} direction={'column'}>
@@ -66,7 +66,7 @@ const CanvasPopoverContent = ({
             <Text size={1}>{popoverDescription}</Text>
           </Box>
         </Flex>
-        <Flex width="full" gap={3} justify="flex-end" paddingX={4} paddingBottom={4}>
+        <Flex gap={3} justify="flex-end" paddingX={4} paddingBottom={4}>
           <Button
             mode="bleed"
             text={t('canvas.banner.popover-button-text')}

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -1,5 +1,6 @@
 import {Box, Flex, focusFirstDescendant, Spinner, Text} from '@sanity/ui'
 import {
+  type ElementType,
   type FormEvent,
   forwardRef,
   useCallback,
@@ -175,7 +176,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
     <FormContainer hidden={hidden}>
       <PresenceOverlay margins={margins}>
         <Box
-          as="form"
+          as={'form' as ElementType}
           onSubmit={preventDefault}
           ref={setRef}
           data-testid="form-view"

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -1,6 +1,5 @@
 import {Box, Flex, focusFirstDescendant, Spinner, Text} from '@sanity/ui'
 import {
-  type ElementType,
   type FormEvent,
   forwardRef,
   useCallback,
@@ -41,7 +40,7 @@ interface FormViewProps {
 
 const preventDefault = (ev: FormEvent) => ev.preventDefault()
 
-export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormView(props, ref) {
+export const FormView = forwardRef<HTMLFormElement, FormViewProps>(function FormView(props, ref) {
   const {hidden, margins} = props
 
   const {
@@ -136,7 +135,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
     // React to changes in hasRev only
   }, [hasRev])
 
-  const [formRef, setFormRef] = useState<null | HTMLDivElement>(null)
+  const [formRef, setFormRef] = useState<null | HTMLFormElement>(null)
   const [hasFocusedAnyPath, setHasFocusedAnyPath] = useState(false)
 
   useEffect(() => {
@@ -159,7 +158,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
   }, [focusPath])
 
   const setRef = useCallback(
-    (node: HTMLDivElement | null) => {
+    (node: HTMLFormElement | null) => {
       setFormRef(node)
       if (typeof ref === 'function') {
         ref(node)
@@ -176,7 +175,7 @@ export const FormView = forwardRef<HTMLDivElement, FormViewProps>(function FormV
     <FormContainer hidden={hidden}>
       <PresenceOverlay margins={margins}>
         <Box
-          as={'form' as ElementType}
+          as="form"
           onSubmit={preventDefault}
           ref={setRef}
           data-testid="form-view"

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/NonReleaseVersionsSelect.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/NonReleaseVersionsSelect.tsx
@@ -128,7 +128,7 @@ export function NonReleaseVersionsSelect(props: {
         zOffset={10}
         content={
           <Container width={1}>
-            <Flex width={1} padding={3} gap={2} wrap="wrap">
+            <Flex padding={3} gap={2} wrap="wrap">
               {otherNonReleaseVersions.map((nonReleaseVersion) => {
                 const scopeId = nonReleaseVersion._system.scopeId!
                 const selected = selectedPerspective === scopeId

--- a/packages/sanity/src/structure/panes/document/timeline/events/EventsTimelineMenu.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/events/EventsTimelineMenu.tsx
@@ -203,7 +203,7 @@ export function EventsTimelineMenu({event, events, mode, placement}: TimelineMen
         portal
         ref={setPopoverRef}
       >
-        <Flex width={'fill'}>
+        <Flex>
           <Button
             data-testid={open ? 'timeline-menu-close-button' : 'timeline-menu-open-button'}
             disabled={loading || !events.length}

--- a/packages/sanity/src/structure/panes/document/timeline/timelineItem.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/timelineItem.tsx
@@ -131,7 +131,7 @@ export function TimelineItem({
   }, [timestamp, dateFormat])
 
   const handleClick = useCallback(
-    (evt: MouseEvent<HTMLDivElement>) => {
+    (evt: MouseEvent<HTMLButtonElement>) => {
       evt.preventDefault()
       evt.stopPropagation()
 

--- a/packages/sanity/src/structure/panes/document/timeline/timelineMenu.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/timelineMenu.tsx
@@ -189,7 +189,7 @@ export function TimelineMenu({chunk, mode, placement}: TimelineMenuProps) {
         portal
         ref={setPopoverRef}
       >
-        <Flex width={'fill'}>
+        <Flex>
           <Button
             data-testid={open ? 'timeline-menu-close-button' : 'timeline-menu-open-button'}
             disabled={!ready}

--- a/packages/sanity/src/ui-components/button/Button.tsx
+++ b/packages/sanity/src/ui-components/button/Button.tsx
@@ -1,13 +1,13 @@
 /* oxlint-disable no-restricted-imports */
 
 import {Button as UIButton, type ButtonProps as UIButtonProps} from '@sanity/ui'
-import {type ForwardedRef, forwardRef, type HTMLProps} from 'react'
+import {type ElementType, type ForwardedRef, forwardRef, type HTMLProps} from 'react'
 import {styled} from 'styled-components'
 
 import {Tooltip, type TooltipProps} from '..'
 
 type BaseButtonProps = Pick<
-  UIButtonProps,
+  UIButtonProps<ElementType>,
   | 'as'
   | 'icon'
   | 'iconRight'

--- a/packages/sanity/src/ui-components/confirmPopover/ConfirmPopover.tsx
+++ b/packages/sanity/src/ui-components/confirmPopover/ConfirmPopover.tsx
@@ -114,7 +114,6 @@ function ConfirmPopoverContent({
             mode="ghost"
             padding={2}
             text={cancelButtonText || t('common.dialog.cancel-button.text')}
-            size={1}
           />
           <UIButton
             data-testid="confirm-popover-confirm-button"
@@ -123,7 +122,6 @@ function ConfirmPopoverContent({
             padding={2}
             text={confirmButtonText || t('common.dialog.confirm-button.text')}
             tone={tone}
-            size={1}
           />
         </Grid>
       </Box>

--- a/packages/sanity/src/ui-components/dialog/Dialog.tsx
+++ b/packages/sanity/src/ui-components/dialog/Dialog.tsx
@@ -77,7 +77,7 @@ export const Dialog = forwardRef(function Dialog(
       ref={ref}
       footer={
         (footer?.confirmButton || footer?.cancelButton) && (
-          <Flex width="full" gap={3} justify="flex-end" padding={3} align="center">
+          <Flex gap={3} justify="flex-end" padding={3} align="center">
             {footer?.description && (
               <Box flex={1} paddingLeft={1}>
                 <Text size={1} muted>

--- a/packages/sanity/src/ui-components/menuGroup/MenuGroup.tsx
+++ b/packages/sanity/src/ui-components/menuGroup/MenuGroup.tsx
@@ -1,6 +1,6 @@
 /* oxlint-disable no-restricted-imports */
 import {MenuGroup as UIMenuGroup, type MenuGroupProps as UIMenuGroupProps} from '@sanity/ui'
-import {type HTMLProps} from 'react'
+import {type ComponentProps} from 'react'
 
 import {Tooltip, type TooltipProps} from '../tooltip/Tooltip'
 
@@ -14,7 +14,7 @@ export type MenuGroupProps = Pick<UIMenuGroupProps, 'icon' | 'popover' | 'text' 
  */
 export const MenuGroup = (
   props: MenuGroupProps &
-    Omit<HTMLProps<HTMLDivElement>, 'as' | 'height' | 'ref' | 'tabIndex' | 'popover'> & {
+    Omit<ComponentProps<'button'>, 'as' | 'height' | 'ref' | 'tabIndex' | 'popover'> & {
       tooltipProps?: TooltipProps | null
     },
 ) => {

--- a/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
+++ b/packages/sanity/src/ui-components/menuItem/MenuItem.tsx
@@ -8,7 +8,15 @@ import {
   Stack,
   Text,
 } from '@sanity/ui'
-import {forwardRef, type HTMLProps, isValidElement, type ReactNode, type Ref, useMemo} from 'react'
+import {
+  type ElementType,
+  forwardRef,
+  type HTMLProps,
+  isValidElement,
+  type ReactNode,
+  type Ref,
+  useMemo,
+} from 'react'
 import {isValidElementType} from 'react-is'
 import {styled} from 'styled-components'
 
@@ -25,7 +33,7 @@ const SubtitleText = styled(Text)`
 
 /** @internal */
 export type MenuItemProps = Pick<
-  UIMenuItemProps,
+  UIMenuItemProps<ElementType>,
   'as' | 'icon' | 'iconRight' | 'pressed' | 'selected' | 'tone' | 'hotkeys'
 > & {
   badgeText?: string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,8 +26,8 @@ catalogs:
       specifier: ^1.1.0
       version: 1.1.0
     '@sanity/ui':
-      specifier: ^3.2.0
-      version: 3.2.0
+      specifier: ^3.3.0
+      version: 3.3.0
     '@types/node':
       specifier: ^24.13.2
       version: 24.13.2
@@ -131,10 +131,10 @@ importers:
         version: 4.1.0
       esbuild-register:
         specifier: 'catalog:'
-        version: 3.6.0(esbuild@0.28.1)(supports-color@8.1.1)
+        version: 3.6.0(esbuild@0.28.1)
       eslint-import-resolver-typescript:
         specifier: ^4.4.5
-        version: 4.4.5(eslint@10.5.0)(supports-color@8.1.1)
+        version: 4.4.5(eslint@10.5.0)
       eslint-plugin-boundaries:
         specifier: ^6.0.2
         version: 6.0.2(eslint-import-resolver-typescript@4.4.5)(eslint@10.5.0)
@@ -143,10 +143,10 @@ importers:
         version: 6.1.4
       eslint-plugin-testing-library:
         specifier: ^7.16.2
-        version: 7.16.2(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3)
+        version: 7.16.2(eslint@10.5.0)(typescript@5.9.3)
       eslint-plugin-tsdoc:
         specifier: ^0.5.2
-        version: 0.5.2(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3)
+        version: 0.5.2(eslint@10.5.0)(typescript@5.9.3)
       knip:
         specifier: ^6.21.0
         version: 6.21.0
@@ -188,7 +188,7 @@ importers:
         version: 0.28.19(typescript@5.9.3)
       vercel:
         specifier: ^54.17.3
-        version: 54.17.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)(supports-color@8.1.1)
+        version: 54.17.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)
       vite:
         specifier: 'catalog:'
         version: 8.1.0(@types/node@24.13.2)(@vitejs/devtools@0.3.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -246,7 +246,7 @@ importers:
         version: 3.7.4(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -372,7 +372,7 @@ importers:
     dependencies:
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -499,7 +499,7 @@ importers:
         version: 3.7.4(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/vision':
         specifier: workspace:*
         version: link:../../packages/@sanity/vision
@@ -532,7 +532,7 @@ importers:
     dependencies:
       '@sanity/code-input':
         specifier: ^7.1.6
-        version: 7.1.6(@babel/runtime@7.29.7)(@codemirror/theme-one-dark@6.1.3)(@sanity/styled-components@6.1.24)(codemirror@6.0.2)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(sanity@packages+sanity)
+        version: 7.1.6(@babel/runtime@7.29.7)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(codemirror@6.0.2)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(sanity@packages+sanity)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -554,7 +554,7 @@ importers:
     dependencies:
       '@portabletext/editor':
         specifier: ^7.9.0
-        version: 7.9.0(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+        version: 7.9.0(@types/react@19.2.17)(react@19.2.7)
       '@portabletext/html':
         specifier: ^1.1.0
         version: 1.1.0
@@ -596,7 +596,7 @@ importers:
         version: 2.2.2(react@19.2.7)
       '@sanity/migrate':
         specifier: 'catalog:'
-        version: 7.0.3(@oclif/core@4.11.7)(@sanity/cli-core@2.1.2)(supports-color@8.1.1)(xstate@5.32.2)
+        version: 7.0.3(@oclif/core@4.11.7)(@sanity/cli-core@2.1.2)(xstate@5.32.2)
       '@sanity/preview-url-secret':
         specifier: ^4.0.7
         version: 4.0.7(@sanity/client@7.23.0)
@@ -608,7 +608,7 @@ importers:
         version: link:../../packages/@sanity/types
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/util':
         specifier: workspace:*
         version: link:../../packages/@sanity/util
@@ -848,7 +848,7 @@ importers:
         version: link:../tsconfig
       '@sanity/pkg-utils':
         specifier: 'catalog:'
-        version: 10.8.1(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(supports-color@8.1.1)(typescript@5.9.3)
+        version: 10.8.1(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@5.9.3)
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -1077,7 +1077,7 @@ importers:
         version: link:../../@repo/tsconfig
       '@sanity/pkg-utils':
         specifier: 'catalog:'
-        version: 10.8.1(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(supports-color@8.1.1)(typescript@5.9.3)
+        version: 10.8.1(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@5.9.3)
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260421.2
@@ -1114,7 +1114,7 @@ importers:
         version: link:../../@repo/tsconfig
       '@sanity/pkg-utils':
         specifier: 'catalog:'
-        version: 10.8.1(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(supports-color@8.1.1)(typescript@5.9.3)
+        version: 10.8.1(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@5.9.3)
       '@types/debug':
         specifier: ^4.1.13
         version: 4.1.13
@@ -1181,7 +1181,7 @@ importers:
         version: 3.7.4(react@19.2.7)
       '@sanity/pkg-utils':
         specifier: 'catalog:'
-        version: 10.8.1(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(supports-color@8.1.1)(typescript@5.9.3)
+        version: 10.8.1(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@5.9.3)
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -1224,10 +1224,10 @@ importers:
         version: link:../../@repo/tsconfig
       '@sanity/insert-menu':
         specifier: 3.0.8
-        version: 3.0.8(@sanity/types@packages+@sanity+types)(react-dom@19.2.7)(react@19.2.7)(styled-components@6.4.2)
+        version: 3.0.8(@emotion/is-prop-valid@1.4.0)(@sanity/types@packages+@sanity+types)(react-dom@19.2.7)(react@19.2.7)(styled-components@6.4.2)
       '@sanity/pkg-utils':
         specifier: 'catalog:'
-        version: 10.8.1(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(supports-color@8.1.1)(typescript@5.9.3)
+        version: 10.8.1(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@5.9.3)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -1282,7 +1282,7 @@ importers:
         version: link:../../@repo/tsconfig
       '@sanity/pkg-utils':
         specifier: 'catalog:'
-        version: 10.8.1(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(supports-color@8.1.1)(typescript@5.9.3)
+        version: 10.8.1(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@5.9.3)
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -1342,7 +1342,7 @@ importers:
         version: 1.0.4
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/uuid':
         specifier: ^3.0.3
         version: 3.0.3
@@ -1454,7 +1454,7 @@ importers:
         version: link:../@repo/tsconfig
       '@sanity/pkg-utils':
         specifier: 'catalog:'
-        version: 10.8.1(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(supports-color@8.1.1)(typescript@5.9.3)
+        version: 10.8.1(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@5.9.3)
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -1493,7 +1493,7 @@ importers:
         version: 3.13.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)
       '@portabletext/editor':
         specifier: ^7.9.0
-        version: 7.9.0(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+        version: 7.9.0(@types/react@19.2.17)(react@19.2.7)
       '@portabletext/html':
         specifier: ^1.1.0
         version: 1.1.0
@@ -1586,7 +1586,7 @@ importers:
         version: 0.23.0
       '@sanity/migrate':
         specifier: 'catalog:'
-        version: 7.0.3(@oclif/core@4.11.7)(@sanity/cli-core@2.1.2)(supports-color@8.1.1)(xstate@5.32.2)
+        version: 7.0.3(@oclif/core@4.11.7)(@sanity/cli-core@2.1.2)(xstate@5.32.2)
       '@sanity/mutate':
         specifier: ^0.18.1
         version: 0.18.1(xstate@5.32.2)
@@ -1616,7 +1616,7 @@ importers:
         version: link:../@sanity/types
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/util':
         specifier: workspace:*
         version: link:../@sanity/util
@@ -5666,6 +5666,15 @@ packages:
 
   '@sanity/ui@3.2.0':
     resolution: {integrity: sha512-bWi2zz8ixZcGHh1YXsgliHRaA9Vw11V5lkJN6SGZcuvbrwPFm6j71Cc3jL1l2MQ11I0HmUYmQ5E76+cT4SznYA==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      react: ^18 || >=19.0.0-0
+      react-dom: ^18 || >=19.0.0-0
+      react-is: ^18 || >=19.0.0-0
+      styled-components: ^5.2 || ^6
+
+  '@sanity/ui@3.3.0':
+    resolution: {integrity: sha512-jjIqfusBeYtyuHkW56M0WH9gsprSw3eOnxq+IGSp2/3zpqQR2mOEN9lHVlmaPmqz8vugkDAojPNZFR83wCm0yw==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       react: ^18 || >=19.0.0-0
@@ -13859,7 +13868,7 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@portabletext/editor@7.9.0(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)':
+  '@portabletext/editor@7.9.0(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@portabletext/html': 1.1.0
       '@portabletext/keyboard-shortcuts': 2.1.3
@@ -13896,7 +13905,7 @@ snapshots:
 
   '@portabletext/plugin-character-pair-decorator@8.0.26(@portabletext/editor@7.9.0)(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.9.0(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.9.0(@types/react@19.2.17)(react@19.2.7)
       '@xstate/react': 6.1.0(@types/react@19.2.17)(react@19.2.7)(xstate@5.32.2)
       react: 19.2.7
       xstate: 5.32.2
@@ -13905,12 +13914,12 @@ snapshots:
 
   '@portabletext/plugin-dnd@1.0.11(@portabletext/editor@7.9.0)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.9.0(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.9.0(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
 
   '@portabletext/plugin-input-rule@5.0.26(@portabletext/editor@7.9.0)(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.9.0(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.9.0(@types/react@19.2.17)(react@19.2.7)
       '@xstate/react': 6.1.0(@types/react@19.2.17)(react@19.2.7)(xstate@5.32.2)
       react: 19.2.7
       xstate: 5.32.2
@@ -13919,12 +13928,12 @@ snapshots:
 
   '@portabletext/plugin-list-index@1.0.11(@portabletext/editor@7.9.0)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.9.0(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.9.0(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
 
   '@portabletext/plugin-markdown-shortcuts@8.0.26(@portabletext/editor@7.9.0)(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.9.0(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.9.0(@types/react@19.2.17)(react@19.2.7)
       '@portabletext/plugin-character-pair-decorator': 8.0.26(@portabletext/editor@7.9.0)(@types/react@19.2.17)(react@19.2.7)
       '@portabletext/plugin-input-rule': 5.0.26(@portabletext/editor@7.9.0)(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
@@ -13933,17 +13942,17 @@ snapshots:
 
   '@portabletext/plugin-one-line@7.0.26(@portabletext/editor@7.9.0)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.9.0(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.9.0(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
 
   '@portabletext/plugin-paste-link@4.0.26(@portabletext/editor@7.9.0)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.9.0(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.9.0(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
 
   '@portabletext/plugin-typography@8.0.26(@portabletext/editor@7.9.0)(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.9.0(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.9.0(@types/react@19.2.17)(react@19.2.7)
       '@portabletext/plugin-input-rule': 5.0.26(@portabletext/editor@7.9.0)(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
     transitivePeerDependencies:
@@ -14435,7 +14444,7 @@ snapshots:
       '@sanity/generate-help-url': 4.0.0
       '@sanity/id-utils': 1.0.0
       '@sanity/import': 6.0.3(@sanity/client@7.23.0)
-      '@sanity/migrate': 7.0.3(@oclif/core@4.11.7)(@sanity/cli-core@2.1.2)(supports-color@8.1.1)(xstate@5.32.2)
+      '@sanity/migrate': 7.0.3(@oclif/core@4.11.7)(@sanity/cli-core@2.1.2)(xstate@5.32.2)
       '@sanity/runtime-cli': 17.0.0(@types/node@24.13.2)(@vitejs/devtools@0.3.3)(esbuild@0.28.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       '@sanity/schema': link:packages/@sanity/schema
       '@sanity/telemetry': 1.1.0(react@19.2.7)
@@ -14528,7 +14537,7 @@ snapshots:
       nanoid: 3.3.13
       rxjs: 7.8.2
 
-  '@sanity/code-input@7.1.6(@babel/runtime@7.29.7)(@codemirror/theme-one-dark@6.1.3)(@sanity/styled-components@6.1.24)(codemirror@6.0.2)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(sanity@packages+sanity)':
+  '@sanity/code-input@7.1.6(@babel/runtime@7.29.7)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(codemirror@6.0.2)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(sanity@packages+sanity)':
     dependencies:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/lang-java': 6.0.2
@@ -14637,7 +14646,7 @@ snapshots:
     dependencies:
       '@sanity/icons': 3.7.4(react@19.2.7)
       '@sanity/mutator': link:packages/@sanity/mutator
-      '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+      '@sanity/ui': 3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/util': link:packages/@sanity/util
       '@sanity/uuid': 3.0.3
       react: 19.2.7
@@ -14679,7 +14688,7 @@ snapshots:
   '@sanity/google-maps-input@6.0.1(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(sanity@packages+sanity)':
     dependencies:
       '@sanity/icons': 3.7.4(react@19.2.7)
-      '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+      '@sanity/ui': 3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@vis.gl/react-google-maps': 1.8.3(react-dom@19.2.7)(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -14734,11 +14743,11 @@ snapshots:
       - react-dom
       - styled-components
 
-  '@sanity/insert-menu@3.0.8(@sanity/types@packages+@sanity+types)(react-dom@19.2.7)(react@19.2.7)(styled-components@6.4.2)':
+  '@sanity/insert-menu@3.0.8(@emotion/is-prop-valid@1.4.0)(@sanity/types@packages+@sanity+types)(react-dom@19.2.7)(react@19.2.7)(styled-components@6.4.2)':
     dependencies:
       '@sanity/icons': 3.7.4(react@19.2.7)
       '@sanity/types': link:packages/@sanity/types
-      '@sanity/ui': 3.2.0(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.2)
+      '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.2)
       lodash-es: 4.18.1
       react: 19.2.7
       react-is: 19.2.7
@@ -14781,7 +14790,7 @@ snapshots:
     dependencies:
       '@sanity/comlink': 4.0.1
 
-  '@sanity/migrate@7.0.3(@oclif/core@4.11.7)(@sanity/cli-core@2.1.2)(supports-color@8.1.1)(xstate@5.32.2)':
+  '@sanity/migrate@7.0.3(@oclif/core@4.11.7)(@sanity/cli-core@2.1.2)(xstate@5.32.2)':
     dependencies:
       '@oclif/core': 4.11.7
       '@sanity/cli-core': 2.1.2(@noble/hashes@2.2.0)(@types/node@24.13.2)(@vitejs/devtools@0.3.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)
@@ -14855,64 +14864,7 @@ snapshots:
       rolldown: 1.1.3
       rolldown-plugin-dts: 0.26.0(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.21.3)(rolldown@1.1.3)(typescript@5.9.3)
       rollup: 4.62.2
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.28.1)(rollup@4.62.2)(supports-color@8.1.1)
-      rxjs: 7.8.2
-      treeify: 1.1.0
-      tsx: 4.22.4
-      typescript: 5.9.3
-      zod: 4.4.3
-      zod-validation-error: 5.0.0(zod@4.4.3)
-    optionalDependencies:
-      babel-plugin-react-compiler: 1.0.0
-    transitivePeerDependencies:
-      - '@ts-macro/tsc'
-      - '@types/babel__core'
-      - '@types/node'
-      - '@typescript/native-preview'
-      - babel-plugin-macros
-      - oxc-resolver
-      - supports-color
-      - vue-tsc
-
-  '@sanity/pkg-utils@10.8.1(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(supports-color@8.1.1)(typescript@5.9.3)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
-      '@microsoft/api-extractor': 7.58.9(@types/node@24.13.2)
-      '@microsoft/tsdoc-config': 0.18.1
-      '@optimize-lodash/rollup-plugin': 6.0.0(rollup@4.62.2)
-      '@rollup/plugin-alias': 6.0.0(rollup@4.62.2)
-      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)(rollup@4.62.2)
-      '@rollup/plugin-commonjs': 29.0.3(rollup@4.62.2)
-      '@rollup/plugin-json': 6.1.0(rollup@4.62.2)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.62.2)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.62.2)
-      '@rollup/plugin-terser': 1.0.0(rollup@4.62.2)
-      '@sanity/browserslist-config': 1.0.5
-      '@sanity/parse-package-json': 2.2.1
-      '@vanilla-extract/rollup-plugin': 1.5.3(babel-plugin-macros@3.1.0)(rollup@4.62.2)
-      browserslist: 4.28.2
-      cac: 7.0.0
-      chalk: 5.6.2
-      chokidar: 5.0.0
-      empathic: 2.0.1
-      esbuild: 0.28.1
-      find-config: 1.0.0
-      get-latest-version: 6.0.1
-      git-url-parse: 16.1.0
-      globby: 16.2.0
-      jsonc-parser: 3.3.1
-      lightningcss: 1.32.0
-      mkdirp: 3.0.1
-      outdent: 0.8.0
-      prettier: 3.8.4
-      pretty-bytes: 7.1.0
-      prompts: 2.4.2
-      rimraf: 6.1.3
-      rolldown: 1.1.3
-      rolldown-plugin-dts: 0.26.0(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.21.3)(rolldown@1.1.3)(typescript@5.9.3)
-      rollup: 4.62.2
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.28.1)(rollup@4.62.2)(supports-color@8.1.1)
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.28.1)(rollup@4.62.2)
       rxjs: 7.8.2
       treeify: 1.1.0
       tsx: 4.22.4
@@ -15092,7 +15044,7 @@ snapshots:
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
 
-  '@sanity/ui@3.2.0(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.2)':
+  '@sanity/ui@3.2.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.2)':
     dependencies:
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7)(react@19.2.7)
       '@juggle/resize-observer': 3.4.0
@@ -15106,6 +15058,24 @@ snapshots:
       react-is: 19.2.7
       react-refractor: 4.0.0(react@19.2.7)
       styled-components: 6.4.2(react-dom@19.2.7)(react@19.2.7)
+      use-effect-event: 2.0.3(react@19.2.7)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+
+  '@sanity/ui@3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7)(react@19.2.7)
+      '@juggle/resize-observer': 3.4.0
+      '@sanity/color': 3.0.6
+      '@sanity/icons': 3.7.4(react@19.2.7)
+      csstype: 3.2.3
+      motion: 12.42.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react@19.2.7)
+      react: 19.2.7
+      react-compiler-runtime: 1.0.0(react@19.2.7)
+      react-dom: 19.2.7(react@19.2.7)
+      react-is: 19.2.7
+      react-refractor: 4.0.0(react@19.2.7)
+      styled-components: '@sanity/styled-components@6.1.24(react-dom@19.2.7)(react@19.2.7)'
       use-effect-event: 2.0.3(react@19.2.7)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
@@ -15148,7 +15118,7 @@ snapshots:
       '@sanity/mutate': 0.18.1(xstate@5.32.2)
       '@sanity/presentation-comlink': 2.1.0(@sanity/client@7.23.0)(@sanity/types@packages+@sanity+types)
       '@sanity/preview-url-secret': 4.0.7(@sanity/client@7.23.0)
-      '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+      '@sanity/ui': 3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/visual-editing-csm': 3.0.9(@sanity/client@7.23.0)(@sanity/types@packages+@sanity+types)(typescript@5.9.3)
       '@vercel/stega': 1.1.0
       dequal: 2.0.3
@@ -15539,7 +15509,7 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/project-service@8.56.1(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.56.1(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.61.1
@@ -15548,7 +15518,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.61.1(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.61.1(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.61.1
@@ -15579,9 +15549,9 @@ snapshots:
 
   '@typescript-eslint/types@8.61.1': {}
 
-  '@typescript-eslint/typescript-estree@8.56.1(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.56.1(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.56.1(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
@@ -15594,9 +15564,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.61.1(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.61.1(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.61.1(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.61.1(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.61.1
       '@typescript-eslint/visitor-keys': 8.61.1
@@ -15609,23 +15579,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.56.1(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.56.1(eslint@10.5.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
       eslint: 10.5.0(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.61.1(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
       '@typescript-eslint/scope-manager': 8.61.1
       '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/typescript-estree': 8.61.1(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@5.9.3)
       eslint: 10.5.0(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -17362,7 +17332,7 @@ snapshots:
 
   es-toolkit@1.49.0: {}
 
-  esbuild-register@3.6.0(esbuild@0.28.1)(supports-color@8.1.1):
+  esbuild-register@3.6.0(esbuild@0.28.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       esbuild: 0.28.1
@@ -17456,7 +17426,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.4.5(eslint@10.5.0)(supports-color@8.1.1):
+  eslint-import-resolver-typescript@4.4.5(eslint@10.5.0):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.5.0(jiti@2.7.0)
@@ -17475,7 +17445,7 @@ snapshots:
     optionalDependencies:
       eslint: 10.5.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 4.4.5(eslint@10.5.0)(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 4.4.5(eslint@10.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17499,20 +17469,20 @@ snapshots:
       lodash: 4.18.1
       requireindex: 1.1.0
 
-  eslint-plugin-testing-library@7.16.2(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3):
+  eslint-plugin-testing-library@7.16.2(eslint@10.5.0)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/scope-manager': 8.61.1
-      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0)(typescript@5.9.3)
       eslint: 10.5.0(jiti@2.7.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-tsdoc@0.5.2(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3):
+  eslint-plugin-tsdoc@0.5.2(eslint@10.5.0)(typescript@5.9.3):
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@typescript-eslint/utils': 8.56.1(eslint@10.5.0)(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@10.5.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -17949,7 +17919,7 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  get-uri@6.0.5(supports-color@8.1.1):
+  get-uri@6.0.5:
     dependencies:
       basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
@@ -19271,12 +19241,12 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  pac-proxy-agent@7.2.0(supports-color@8.1.1):
+  pac-proxy-agent@7.2.0:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
-      get-uri: 6.0.5(supports-color@8.1.1)
+      get-uri: 6.0.5
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       pac-resolver: 7.0.1
@@ -19495,14 +19465,14 @@ snapshots:
 
   protocols@2.0.2: {}
 
-  proxy-agent@6.4.0(supports-color@8.1.1):
+  proxy-agent@6.4.0:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
-      pac-proxy-agent: 7.2.0(supports-color@8.1.1)
+      pac-proxy-agent: 7.2.0
       proxy-from-env: 1.1.0
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
@@ -19917,7 +19887,7 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.3
       '@rolldown/binding-win32-x64-msvc': 1.1.3
 
-  rollup-plugin-esbuild@6.2.1(esbuild@0.28.1)(rollup@4.62.2)(supports-color@8.1.1):
+  rollup-plugin-esbuild@6.2.1(esbuild@0.28.1)(rollup@4.62.2):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
@@ -19994,7 +19964,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sandbox@3.1.2(supports-color@8.1.1):
+  sandbox@3.1.2:
     dependencies:
       '@vercel/sandbox': 2.1.1
       async-retry: 1.3.3
@@ -20008,7 +19978,7 @@ snapshots:
   sanity-plugin-asset-source-unsplash@7.0.10(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(@types/react@19.2.17)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(sanity@packages+sanity):
     dependencies:
       '@sanity/icons': 3.7.4(react@19.2.7)
-      '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+      '@sanity/ui': 3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       lodash-es: 4.18.1
       react: 19.2.7
       react-photo-album: 3.6.0(@types/react@19.2.17)(react@19.2.7)
@@ -20044,7 +20014,7 @@ snapshots:
       '@sanity/client': 7.23.0
       '@sanity/color': 3.0.6
       '@sanity/icons': 3.7.4(react@19.2.7)
-      '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+      '@sanity/ui': 3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/uuid': 3.0.3
       '@tanem/react-nprogress': 5.0.63(react-dom@19.2.7)(react@19.2.7)
       copy-to-clipboard: 3.3.3
@@ -20079,7 +20049,7 @@ snapshots:
       '@sanity/asset-utils': 2.3.0
       '@sanity/icons': 3.7.4(react@19.2.7)
       '@sanity/image-url': 2.1.1
-      '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+      '@sanity/ui': 3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-fast-compare: 3.2.2
@@ -20826,7 +20796,7 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vercel@54.17.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)(supports-color@8.1.1):
+  vercel@54.17.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2):
     dependencies:
       '@vercel/backends': 0.8.18(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)
       '@vercel/blob': 2.4.0
@@ -20859,8 +20829,8 @@ snapshots:
       form-data: 4.0.6
       jose: 5.9.6
       luxon: 3.7.2
-      proxy-agent: 6.4.0(supports-color@8.1.1)
-      sandbox: 3.1.2(supports-color@8.1.1)
+      proxy-agent: 6.4.0
+      sandbox: 3.1.2
       smol-toml: 1.5.2
       zod: 4.1.11
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,7 +532,7 @@ importers:
     dependencies:
       '@sanity/code-input':
         specifier: ^7.1.6
-        version: 7.1.6(@babel/runtime@7.29.7)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(codemirror@6.0.2)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(sanity@packages+sanity)
+        version: 7.1.6(@babel/runtime@7.29.7)(@codemirror/theme-one-dark@6.1.3)(@sanity/styled-components@6.1.24)(codemirror@6.0.2)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(sanity@packages+sanity)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -1224,7 +1224,7 @@ importers:
         version: link:../../@repo/tsconfig
       '@sanity/insert-menu':
         specifier: 3.0.8
-        version: 3.0.8(@emotion/is-prop-valid@1.4.0)(@sanity/types@packages+@sanity+types)(react-dom@19.2.7)(react@19.2.7)(styled-components@6.4.2)
+        version: 3.0.8(@sanity/types@packages+@sanity+types)(react-dom@19.2.7)(react@19.2.7)(styled-components@6.4.2)
       '@sanity/pkg-utils':
         specifier: 'catalog:'
         version: 10.8.1(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@5.9.3)
@@ -5663,15 +5663,6 @@ packages:
     resolution: {integrity: sha512-pIy9yXosuA2duaJH0J1V8RYrabGB/Jh77FGYozr2pGwmCFwnLw/W/FS99qbcsJZa3wXHSMhMRyYq7IbulbijZw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
-
-  '@sanity/ui@3.2.0':
-    resolution: {integrity: sha512-bWi2zz8ixZcGHh1YXsgliHRaA9Vw11V5lkJN6SGZcuvbrwPFm6j71Cc3jL1l2MQ11I0HmUYmQ5E76+cT4SznYA==}
-    engines: {node: '>=20.19 <22 || >=22.12'}
-    peerDependencies:
-      react: ^18 || >=19.0.0-0
-      react-dom: ^18 || >=19.0.0-0
-      react-is: ^18 || >=19.0.0-0
-      styled-components: ^5.2 || ^6
 
   '@sanity/ui@3.3.0':
     resolution: {integrity: sha512-jjIqfusBeYtyuHkW56M0WH9gsprSw3eOnxq+IGSp2/3zpqQR2mOEN9lHVlmaPmqz8vugkDAojPNZFR83wCm0yw==}
@@ -14315,7 +14306,7 @@ snapshots:
       '@sanity/color': 3.0.6
       '@sanity/icons': 3.7.4(react@19.2.7)
       '@sanity/mutator': link:packages/@sanity/mutator
-      '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+      '@sanity/ui': 3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       date-fns: 4.4.0
       lodash-es: 4.18.1
       react: 19.2.7
@@ -14537,7 +14528,7 @@ snapshots:
       nanoid: 3.3.13
       rxjs: 7.8.2
 
-  '@sanity/code-input@7.1.6(@babel/runtime@7.29.7)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(codemirror@6.0.2)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(sanity@packages+sanity)':
+  '@sanity/code-input@7.1.6(@babel/runtime@7.29.7)(@codemirror/theme-one-dark@6.1.3)(@sanity/styled-components@6.1.24)(codemirror@6.0.2)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(sanity@packages+sanity)':
     dependencies:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/lang-java': 6.0.2
@@ -14553,7 +14544,7 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@sanity/icons': 3.7.4(react@19.2.7)
       '@sanity/lezer-groq': 1.0.4
-      '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+      '@sanity/ui': 3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@uiw/codemirror-themes': 4.25.10(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)
       '@uiw/react-codemirror': 4.25.10(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.1)(codemirror@6.0.2)(react-dom@19.2.7)(react@19.2.7)
       react: 19.2.7
@@ -14734,7 +14725,7 @@ snapshots:
     dependencies:
       '@sanity/icons': 3.7.4(react@19.2.7)
       '@sanity/types': link:packages/@sanity/types
-      '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+      '@sanity/ui': 3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       lodash-es: 4.18.1
       react: 19.2.7
       react-is: 19.2.7
@@ -14743,11 +14734,11 @@ snapshots:
       - react-dom
       - styled-components
 
-  '@sanity/insert-menu@3.0.8(@emotion/is-prop-valid@1.4.0)(@sanity/types@packages+@sanity+types)(react-dom@19.2.7)(react@19.2.7)(styled-components@6.4.2)':
+  '@sanity/insert-menu@3.0.8(@sanity/types@packages+@sanity+types)(react-dom@19.2.7)(react@19.2.7)(styled-components@6.4.2)':
     dependencies:
       '@sanity/icons': 3.7.4(react@19.2.7)
       '@sanity/types': link:packages/@sanity/types
-      '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.2)
+      '@sanity/ui': 3.3.0(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.2)
       lodash-es: 4.18.1
       react: 19.2.7
       react-is: 19.2.7
@@ -14761,7 +14752,7 @@ snapshots:
   '@sanity/language-filter@5.0.4(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(sanity@packages+sanity)':
     dependencies:
       '@sanity/icons': 3.7.4(react@19.2.7)
-      '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+      '@sanity/ui': 3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-rx: 4.2.2(react@19.2.7)(rxjs@7.8.2)
@@ -15026,42 +15017,6 @@ snapshots:
       '@actions/github': 9.1.1
       yaml: 2.9.0
 
-  '@sanity/ui@3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7)(react@19.2.7)
-      '@juggle/resize-observer': 3.4.0
-      '@sanity/color': 3.0.6
-      '@sanity/icons': 3.7.4(react@19.2.7)
-      csstype: 3.2.3
-      motion: 12.42.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react@19.2.7)
-      react: 19.2.7
-      react-compiler-runtime: 1.0.0(react@19.2.7)
-      react-dom: 19.2.7(react@19.2.7)
-      react-is: 19.2.7
-      react-refractor: 4.0.0(react@19.2.7)
-      styled-components: '@sanity/styled-components@6.1.24(react-dom@19.2.7)(react@19.2.7)'
-      use-effect-event: 2.0.3(react@19.2.7)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-
-  '@sanity/ui@3.2.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.2)':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7)(react@19.2.7)
-      '@juggle/resize-observer': 3.4.0
-      '@sanity/color': 3.0.6
-      '@sanity/icons': 3.7.4(react@19.2.7)
-      csstype: 3.2.3
-      motion: 12.42.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react@19.2.7)
-      react: 19.2.7
-      react-compiler-runtime: 1.0.0(react@19.2.7)
-      react-dom: 19.2.7(react@19.2.7)
-      react-is: 19.2.7
-      react-refractor: 4.0.0(react@19.2.7)
-      styled-components: 6.4.2(react-dom@19.2.7)(react@19.2.7)
-      use-effect-event: 2.0.3(react@19.2.7)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-
   '@sanity/ui@3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)':
     dependencies:
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7)(react@19.2.7)
@@ -15076,6 +15031,24 @@ snapshots:
       react-is: 19.2.7
       react-refractor: 4.0.0(react@19.2.7)
       styled-components: '@sanity/styled-components@6.1.24(react-dom@19.2.7)(react@19.2.7)'
+      use-effect-event: 2.0.3(react@19.2.7)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+
+  '@sanity/ui@3.3.0(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.2)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7)(react@19.2.7)
+      '@juggle/resize-observer': 3.4.0
+      '@sanity/color': 3.0.6
+      '@sanity/icons': 3.7.4(react@19.2.7)
+      csstype: 3.2.3
+      motion: 12.42.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react@19.2.7)
+      react: 19.2.7
+      react-compiler-runtime: 1.0.0(react@19.2.7)
+      react-dom: 19.2.7(react@19.2.7)
+      react-is: 19.2.7
+      react-refractor: 4.0.0(react@19.2.7)
+      styled-components: 6.4.2(react-dom@19.2.7)(react@19.2.7)
       use-effect-event: 2.0.3(react@19.2.7)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
@@ -19994,7 +19967,7 @@ snapshots:
     dependencies:
       '@sanity/icons': 3.7.4(react@19.2.7)
       '@sanity/language-filter': 5.0.4(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(sanity@packages+sanity)
-      '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+      '@sanity/ui': 3.3.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/util': link:packages/@sanity/util
       lodash-es: 4.18.1
       react: 19.2.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ catalog:
   '@sanity/migrate': ^7.0.3
   '@sanity/pkg-utils': ^10.8.1
   '@sanity/telemetry': ^1.1.0
-  '@sanity/ui': ^3.2.0
+  '@sanity/ui': ^3.3.0
   '@types/node': ^24.13.2
   '@types/react': ^19.2.17
   '@types/react-dom': ^19.2.3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

`@sanity/ui@3.3.0` backports the polymorphic `as` typings from v4 (sanity-io/ui#2209). Component prop types are now precise: the `as` prop drives which element/props are valid, instead of every component accepting the union of all HTML attributes (`AllHTMLAttributes`). Bumping the catalog from `^3.2.0` surfaces a large amount of previously-hidden invalid usage that the old loose types silently accepted, and lets us drop suppressions/casts that only existed to work around the old typing.

Every change is type-only or removes a runtime no-op, so no behavior change is intended.

The changes fall into a few buckets:

- **Polymorphic wrappers** (`ui-components/{Button,MenuItem,MenuGroup}`): these picked `as` from the UI prop types, which now default the element generic — so `as` collapsed to the literal `'button'`, breaking every `as="a"` / `as={LinkComponent}` call site. They now pick from `…Props<ElementType>`; `MenuGroup` also switches its passthrough props to `ComponentProps<'button'>` since `MenuGroup` renders a button (not the wider `AllHTMLAttributes`).
- **Invalid no-op props removed**: `muted`/`size` on `Badge`/`Code`/`Flex`, `size` on `@sanity/ui` `Button`, and `width` on `Flex`/`Card`/`Box`. These were only ever accepted as invalid HTML attributes on a `div`/`pre` and had no runtime effect. (`Container`/`Panel`/`Button` legitimately keep `width`.)
- **`ComponentProps<typeof PolymorphicComponent>` replaced with the exported prop types** (`ButtonProps`, `TextProps`, `CardProps`): for the new generic function components this resolved to an `any`-based index type, which made `Pick`ed props spuriously required and broke `forwardRef`/`styled` inference.
- **Custom Box/Card-based components widened `as` to `ElementType`** (`PreviewCard`, `Resizable`, `DocumentInspectorHeader`, `DiffInspectWrapper`, `TableRowProps`) so string and component `as` values type-check; inline `forwardRef` link components used as `as={…}` targets are typed with `ComponentPropsWithoutRef<'a'>` so forwarded `children`/`style`/`data-*` are accepted.
- **Ref / event-handler element types corrected** where a component renders as a different element than its ref/handler assumed — e.g. `CommentsList` (`Stack as="ul"` → `HTMLUListElement`), `CommandListItem` (`as="li"` → `HTMLLIElement`), `PreviewItem` (`Card as="button"` → `HTMLButtonElement`), `FormView` (`Box as="form"` → `HTMLFormElement`, incl. its `DocumentPanel` ref), and click handlers on `@sanity/ui` `MenuItem`/`Button`/`Card`.
- **Genuine element-type conflicts resolved by conditional rendering** rather than widening: `NewDocumentListOption` and Vision's CSV download button rendered `as={cond ? 'a' : 'button'}` / a disabled `<a>` — now they render a real `<a href>` when actionable and a `<button disabled>` otherwise (a disabled anchor is invalid HTML anyway; this also drops a manual click-prevention handler).
- **Now-unnecessary suppressions/casts removed**: a `@ts-expect-error`, several `as FIXME` / `as any` on `PreviewCard as={…}` (redundant once `as` accepts `ElementType`), and `as CSSProperties` casts flagged by the newly-enforced `no-unnecessary-type-assertion` rule.
- One genuinely-invalid prop fixed rather than dropped: an icon-only `Button` in Vision used `label` (a no-op) → changed to `aria-label`.

### What to review

- `packages/sanity/src/ui-components/{button,menuItem,menuGroup}` — the wrapper `as`/props typing changes cascade to many call sites.
- The no-op prop removals (`width`/`muted`/`size`) — confirm these were not intended styling (they were HTML attributes ignored by the DOM element).
- `NewDocumentListOption` and Vision `SaveResultButtons` conditional-render refactors.
- `packages/@sanity/vision` also has a handful of fixes.

### Testing

`pnpm check:types`, `pnpm check:oxlint`, and `pnpm check:format` all pass. Unit tests pass: `sanity` (3926 passed) and `@sanity/vision` (5 passed), including the `FormView`, `NewDocumentListOption`, and `ReleaseName` suites for the touched components. No tests were added since these are type-only / no-op-removal changes with no behavioral delta.

### Notes for release

N/A – Internal only (dependency bump + type fixes, no user-facing behavior change).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e997702e-aaad-467c-bce0-011daceda5d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e997702e-aaad-467c-bce0-011daceda5d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

