### PR TITLE
chore(deps): overrides smol-toml to v1.6.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14307,7 +14307,7 @@ snapshots:
       '@portabletext/types': 4.0.2
       '@sanity/client': 7.23.0
       '@sanity/color': 3.0.6
-      '@sanity/icons': 3.7.6(react@19.2.7)
+      '@sanity/icons': 3.7.4(react@19.2.7)
       '@sanity/mutator': link:packages/@sanity/mutator
       '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       date-fns: 4.4.0
@@ -14758,7 +14758,7 @@ snapshots:
 
   '@sanity/language-filter@5.0.4(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(sanity@packages+sanity)':
     dependencies:
-      '@sanity/icons': 3.7.6(react@19.2.7)
+      '@sanity/icons': 3.7.4(react@19.2.7)
       '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,7 @@ catalogs:
 
 overrides:
   vitest: ^4.1.9
+  smol-toml: 1.6.1
 
 importers:
 
@@ -10200,10 +10201,6 @@ packages:
     resolution: {integrity: sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==}
     engines: {node: '>=20.0.0'}
 
-  smol-toml@1.5.2:
-    resolution: {integrity: sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==}
-    engines: {node: '>= 18'}
-
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
@@ -14310,7 +14307,7 @@ snapshots:
       '@portabletext/types': 4.0.2
       '@sanity/client': 7.23.0
       '@sanity/color': 3.0.6
-      '@sanity/icons': 3.7.4(react@19.2.7)
+      '@sanity/icons': 3.7.6(react@19.2.7)
       '@sanity/mutator': link:packages/@sanity/mutator
       '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       date-fns: 4.4.0
@@ -14761,7 +14758,7 @@ snapshots:
 
   '@sanity/language-filter@5.0.4(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(sanity@packages+sanity)':
     dependencies:
-      '@sanity/icons': 3.7.4(react@19.2.7)
+      '@sanity/icons': 3.7.6(react@19.2.7)
       '@sanity/ui': 3.2.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -15931,7 +15928,7 @@ snapshots:
     dependencies:
       '@vercel/error-utils': 2.2.0
       js-yaml: 3.13.1
-      smol-toml: 1.5.2
+      smol-toml: 1.6.1
 
   '@vercel/fun@1.3.0':
     dependencies:
@@ -16084,7 +16081,7 @@ snapshots:
       fs-extra: 11.1.1
       js-yaml: 4.1.1
       minimatch: 10.1.1
-      smol-toml: 1.5.2
+      smol-toml: 1.6.1
       zod: 3.22.4
 
   '@vercel/python@6.47.2':
@@ -16120,7 +16117,7 @@ snapshots:
   '@vercel/rust@1.3.0':
     dependencies:
       execa: 5.1.1
-      smol-toml: 1.5.2
+      smol-toml: 1.6.1
 
   '@vercel/sandbox@2.1.1':
     dependencies:
@@ -20156,8 +20153,6 @@ snapshots:
 
   smob@1.6.2: {}
 
-  smol-toml@1.5.2: {}
-
   smol-toml@1.6.1: {}
 
   socks-proxy-agent@8.0.5:
@@ -20814,7 +20809,7 @@ snapshots:
       luxon: 3.7.2
       proxy-agent: 6.4.0
       sandbox: 3.1.2
-      smol-toml: 1.5.2
+      smol-toml: 1.6.1
       zod: 4.1.11
     transitivePeerDependencies:
       - '@emnapi/core'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -85,6 +85,7 @@ minimumReleaseAgeExclude:
 
 overrides:
   vitest: 'catalog:'
+  smol-toml: '1.6.1'
 
 preferWorkspacePackages: true
 


### PR DESCRIPTION
### Description

override smol-toml to v1.6.1 because of security vulnerability (https://github.com/advisories/GHSA-v3rj-xjv7-4jmq)

### What to review


### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

override smol-toml from v1.5.2 to v1.6.1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only patch bump via override with no application code changes; typical low-risk supply-chain remediation.
> 
> **Overview**
> Pins **smol-toml** to **1.6.1** via a new pnpm workspace **override**, replacing transitive **1.5.2** (addresses [GHSA-v3rj-xjv7-4jmq](https://github.com/advisories/GHSA-v3rj-xjv7-4jmq)).
> 
> The lockfile is refreshed so dependents such as **`@vercel/frameworks`**, **`@vercel/python-analysis`**, **`@vercel/rust`**, and the root **`vercel`** package all resolve **smol-toml@1.6.1**; the old **1.5.2** entry is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 766ab57287065572c3a4ca6a3dc749450ed3e006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->