### PR TITLE
chore(sanity): include user's most recent agent bundle in document group inventory

### DIFF
--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -27,6 +27,7 @@ import {useActiveReleases} from '../../releases/store/useActiveReleases'
 import {useReleasesStore} from '../../releases/store/useReleasesStore'
 import {getReleaseDocumentIdFromReleaseId} from '../../releases/util/getReleaseDocumentIdFromReleaseId'
 import {useReleasesToolAvailable} from '../../schedules/hooks/useReleasesToolAvailable'
+import {useAgentBundlesStore} from '../../store/agent/useAgentBundles'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
 import {
   getPublishedId,
@@ -104,6 +105,7 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
   const schema = useSchema().get(documentType)
   const versionState = useDocumentVersionsObservable({documentId})
   const {state$: releases} = useReleasesStore()
+  const {state$: agentBundles} = useAgentBundlesStore()
   const [containerElement, setContainerElement] = useState<HTMLDivElement | null>(null)
   const filterStringEvent = useMemo(() => new Subject<ChangeEvent<HTMLInputElement>>(), [])
   const [menuPortalElement, setMenuPortalElement] = useState<HTMLDivElement | null>(null)
@@ -125,13 +127,13 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
     () =>
       documentGroupInventoryMachine.provide({
         actors: {
-          meta: fromObservable(() => combineLatest({versionState, releases})),
+          meta: fromObservable(() => combineLatest({versionState, releases, agentBundles})),
         },
         actions: {
           onFeedbackBegin: feedbackDialogOpened,
         },
       }),
-    [versionState, releases, feedbackDialogOpened],
+    [versionState, releases, agentBundles, feedbackDialogOpened],
   )
 
   const inventoryRef = useActorRef(inventoryMachine, {

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -27,6 +27,7 @@ import {useActiveReleases} from '../../releases/store/useActiveReleases'
 import {useReleasesStore} from '../../releases/store/useReleasesStore'
 import {getReleaseDocumentIdFromReleaseId} from '../../releases/util/getReleaseDocumentIdFromReleaseId'
 import {useReleasesToolAvailable} from '../../schedules/hooks/useReleasesToolAvailable'
+import {isAgentBundleName} from '../../store'
 import {useAgentBundlesStore} from '../../store/agent/useAgentBundles'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
 import {
@@ -138,6 +139,7 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
 
   const inventoryRef = useActorRef(inventoryMachine, {
     input: {
+      t,
       selectionMachine: useMemo(
         () =>
           selectionMachine.provide({
@@ -482,12 +484,16 @@ const Variant: ComponentType<{
             </StatusBadge>
           )}
           <Text size={1}>
-            <ReleaseAvatarIcon
-              release={
-                // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals -- this string is not shown to users
-                (isDraftVersion ? 'drafts' : isPublishedVersion ? 'published' : release) ?? ''
-              }
-            />
+            {isAgentBundleName(getVersionFromId(variant.id)) ? (
+              <ReleaseAvatarIcon tone="suggest" />
+            ) : (
+              <ReleaseAvatarIcon
+                release={
+                  // eslint-disable-next-line @sanity/i18n/no-attribute-string-literals -- this string is not shown to users
+                  (isDraftVersion ? 'drafts' : isPublishedVersion ? 'published' : release) ?? ''
+                }
+              />
+            )}
           </Text>
         </div>
       </VariantSetEntry>

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventoryAction.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventoryAction.tsx
@@ -8,10 +8,12 @@ import {styled} from 'styled-components'
 import {Button as BaseButton} from '../../../ui-components/button/Button'
 import {Popover} from '../../../ui-components/popover/Popover'
 import {useVersionRelease} from '../../hooks/useVersionRelease'
+import {type TFunction, useTranslation} from '../../i18n'
 import {type TargetPerspective} from '../../perspective/types'
 import {ReleaseAvatarIcon} from '../../releases/components/ReleaseAvatar'
 import {useDocumentVersionsObservable} from '../../releases/hooks/useDocumentVersions'
 import {isDraftPerspective, isPublishedPerspective} from '../../releases/util/util'
+import {isAgentBundleName} from '../../store'
 
 export const DocumentGroupInventoryAction: ComponentType<
   PropsWithChildren<{
@@ -27,6 +29,7 @@ export const DocumentGroupInventoryAction: ComponentType<
   isDocumentGroupInventoryActive,
   setIsDocumentGroupInventoryActive,
 }) => {
+  const {t} = useTranslation()
   const displayedRelease = useVersionRelease(documentId)
   const buttonElement = useRef<HTMLButtonElement | null>(null)
   const popoverElement = useRef<HTMLDivElement | null>(null)
@@ -72,7 +75,7 @@ export const DocumentGroupInventoryAction: ComponentType<
         <Button
           ref={buttonElement}
           data-testid="action-document-group-inventory"
-          text={variantLabel(displayedRelease?.release)}
+          text={variantLabel({perspective: displayedRelease?.release, t})}
           tone="neutral"
           onClick={() => setIsDocumentGroupInventoryActive(!isDocumentGroupInventoryActive)}
           icon={<VariantIcon perspective={displayedRelease.release} />}
@@ -85,9 +88,19 @@ export const DocumentGroupInventoryAction: ComponentType<
   )
 }
 
-function variantLabel(perspective: TargetPerspective | undefined): string {
+function variantLabel({
+  perspective,
+  t,
+}: {
+  perspective: TargetPerspective | undefined
+  t: TFunction
+}): string {
   if (typeof perspective === 'undefined') {
     return ''
+  }
+
+  if (isAgentBundleName(perspective)) {
+    return t('version.agent-bundle.proposed-changes')
   }
 
   if (isDraftPerspective(perspective)) {

--- a/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.test.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.test.ts
@@ -3,6 +3,7 @@ import {BehaviorSubject, of} from 'rxjs'
 import {describe, expect, it, vi} from 'vitest'
 import {createActor, fromObservable, fromPromise} from 'xstate'
 
+import {type TFunction} from '../../i18n/types'
 import {getReleaseDocumentIdFromReleaseId} from '../../releases/util/getReleaseDocumentIdFromReleaseId'
 import {deletionMachine} from './deletionMachine'
 import {documentGroupInventoryMachine, type Meta} from './documentGroupInventoryMachine'
@@ -75,6 +76,8 @@ const loadedMeta = {
   agentBundles: {bundles: [], loading: false},
 } as unknown as Meta
 
+const t = ((key: string) => key) as unknown as TFunction
+
 function createTestActor(
   initial: ReferringDocuments,
   {
@@ -96,6 +99,7 @@ function createTestActor(
     {
       input: {
         selectionMachine,
+        t,
         deletionMachine: deletionMachine.provide({
           actors: {
             referringDocuments: fromObservable(() => references$),
@@ -436,6 +440,7 @@ describe('documentGroupInventoryMachine', () => {
         error: null,
       },
       releases: {releases, state: 'loaded' as const},
+      agentBundles: {bundles: [], loading: false},
     } as unknown as Meta
 
     const expectedVariants = [
@@ -459,10 +464,44 @@ describe('documentGroupInventoryMachine', () => {
     expect(selectionRef.getSnapshot().context.variants).toEqual(expectedVariants)
   })
 
+  it('surfaces the most recent agent bundle and hides agent bundle versions from the version state', () => {
+    const meta = {
+      versionState: {
+        data: ['drafts.foo', 'foo', 'versions.agent-abc.foo'],
+        loading: false,
+        error: null,
+      },
+      releases: {releases: new Map(), state: 'loaded' as const},
+      agentBundles: {
+        bundles: [
+          {id: 'agent-abc', applicationKey: 'app-1'},
+          {id: 'agent-def', applicationKey: 'app-2'},
+        ],
+        loading: false,
+      },
+    } as unknown as Meta
+
+    const expectedVariants = [
+      {id: 'drafts.foo', name: 'Draft'},
+      {id: 'foo', name: 'Published'},
+      // Agent bundle versions are dropped from the version state and only the
+      // most recent bundle is appended, labelled through the translator.
+      {id: 'versions.agent-abc.foo', name: 'version.agent-bundle.proposed-changes'},
+    ]
+
+    const {inventoryRef, selectionRef} = createTestActor(loading, {meta})
+
+    const {sets} = inventoryRef.getSnapshot().context
+    expect(sets).toHaveLength(1)
+    expect(sets[0].variants).toEqual(expectedVariants)
+    expect(selectionRef.getSnapshot().context.variants).toEqual(expectedVariants)
+  })
+
   it('drives the selection machine into the error state when meta reports an error', () => {
     const meta = {
       versionState: {data: [], loading: false, error: new Error('meta failed')},
       releases: {releases: new Map(), state: 'loaded' as const},
+      agentBundles: {bundles: [], loading: false},
     } as unknown as Meta
 
     const {selectionRef} = createTestActor(loading, {meta})

--- a/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.test.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.test.ts
@@ -72,6 +72,7 @@ function withCrossDatasetReferences(
 const loadedMeta = {
   versionState: {data: ['drafts.foo', 'foo'], loading: false, error: null},
   releases: {releases: new Map(), state: 'loaded' as const},
+  agentBundles: {bundles: [], loading: false},
 } as unknown as Meta
 
 function createTestActor(

--- a/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.test.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.test.ts
@@ -5,7 +5,7 @@ import {createActor, fromObservable, fromPromise} from 'xstate'
 
 import {getReleaseDocumentIdFromReleaseId} from '../../releases/util/getReleaseDocumentIdFromReleaseId'
 import {deletionMachine} from './deletionMachine'
-import {documentGroupInventoryMachine, type SelectionMeta} from './documentGroupInventoryMachine'
+import {documentGroupInventoryMachine, type Meta} from './documentGroupInventoryMachine'
 import {selectionMachine} from './selectionMachine'
 
 interface IncomingReference {
@@ -72,7 +72,7 @@ function withCrossDatasetReferences(
 const loadedMeta = {
   versionState: {data: ['drafts.foo', 'foo'], loading: false, error: null},
   releases: {releases: new Map(), state: 'loaded' as const},
-} as unknown as SelectionMeta
+} as unknown as Meta
 
 function createTestActor(
   initial: ReferringDocuments,
@@ -83,7 +83,7 @@ function createTestActor(
   }: {
     requestDeletionConfirmation?: () => void
     deleteVariants?: () => Promise<unknown>
-    meta?: SelectionMeta
+    meta?: Meta
   } = {},
 ) {
   const references$ = new BehaviorSubject<ReferringDocuments>(initial)
@@ -435,7 +435,7 @@ describe('documentGroupInventoryMachine', () => {
         error: null,
       },
       releases: {releases, state: 'loaded' as const},
-    } as unknown as SelectionMeta
+    } as unknown as Meta
 
     const expectedVariants = [
       {id: 'drafts.foo', name: 'Draft'},
@@ -462,7 +462,7 @@ describe('documentGroupInventoryMachine', () => {
     const meta = {
       versionState: {data: [], loading: false, error: new Error('meta failed')},
       releases: {releases: new Map(), state: 'loaded' as const},
-    } as unknown as SelectionMeta
+    } as unknown as Meta
 
     const {selectionRef} = createTestActor(loading, {meta})
     expect(selectionRef.getSnapshot().matches('error')).toBe(true)

--- a/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.ts
@@ -5,7 +5,7 @@ import {assign, forwardTo, fromObservable, sendTo, setup, type ActorRefFromLogic
 import {type DocumentPerspectiveState} from '../../releases/hooks/useDocumentVersions'
 import {type ReleasesReducerState} from '../../releases/store/reducer'
 import {getReleaseDocumentIdFromReleaseId} from '../../releases/util/getReleaseDocumentIdFromReleaseId'
-import {type AgentBundlesState} from '../../store/agent/createAgentBundlesStore'
+import {isAgentBundleName, type AgentBundlesState} from '../../store/agent/createAgentBundlesStore'
 import {getVersionFromId, isDraftId, isPublishedId} from '../../util/draftUtils'
 import {type deletionMachine} from './deletionMachine'
 import {type selectionMachine, type Variant} from './selectionMachine'
@@ -142,7 +142,12 @@ function computeSets(meta: Meta | undefined, current: VariantSet[]): VariantSet[
   return [
     {
       key: 'studio:all',
-      variants: meta.versionState.data.map((id) => ({id, name: getVariantName(id, releases)})),
+      variants: meta.versionState.data
+        .filter((id) => !isAgentBundleName(getVersionFromId(id)))
+        .map((id) => ({
+          id,
+          name: getVariantName(id, releases),
+        })),
     },
   ]
 }

--- a/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.ts
@@ -2,6 +2,7 @@ import {type ReleaseDocument} from '@sanity/client'
 import {EMPTY} from 'rxjs'
 import {assign, forwardTo, fromObservable, sendTo, setup, type ActorRefFromLogic} from 'xstate'
 
+import {type TFunction} from '../../i18n/types'
 import {type DocumentPerspectiveState} from '../../releases/hooks/useDocumentVersions'
 import {type ReleasesReducerState} from '../../releases/store/reducer'
 import {getReleaseDocumentIdFromReleaseId} from '../../releases/util/getReleaseDocumentIdFromReleaseId'
@@ -29,6 +30,7 @@ interface DocumentGroupInventoryContext {
   deletionRef: ActorRefFromLogic<DeletionLogic>
   sets: VariantSet[]
   releases: Map<string, ReleaseDocument>
+  t: TFunction
 }
 
 type DocumentGroupInventoryEvents =
@@ -41,7 +43,7 @@ type DocumentGroupInventoryEvents =
 export const documentGroupInventoryMachine = setup({
   // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   types: {} as {
-    input: {selectionMachine: SelectionLogic; deletionMachine: DeletionLogic}
+    input: {selectionMachine: SelectionLogic; deletionMachine: DeletionLogic; t: TFunction}
     context: DocumentGroupInventoryContext
     events: DocumentGroupInventoryEvents
   },
@@ -64,13 +66,15 @@ export const documentGroupInventoryMachine = setup({
     }),
     sets: [],
     releases: new Map(),
+    t: input.t,
   }),
   invoke: {
     src: 'meta',
     onSnapshot: {
       actions: [
         assign({
-          sets: ({context, event}) => computeSets(event.snapshot.context, context.sets),
+          sets: ({context, event}) =>
+            computeSets({meta: event.snapshot.context, current: context.sets, t: context.t}),
           releases: ({event}) => event.snapshot.context?.releases.releases ?? new Map(),
         }),
         sendTo(
@@ -132,12 +136,25 @@ function metaIsLoaded(meta: Meta | undefined): boolean {
   return meta?.versionState.loading === false && meta.releases.state === 'loaded'
 }
 
-function computeSets(meta: Meta | undefined, current: VariantSet[]): VariantSet[] {
+function computeSets({
+  meta,
+  current,
+  t,
+}: {
+  meta: Meta | undefined
+  current: VariantSet[]
+  t: TFunction
+}): VariantSet[] {
   if (!meta) {
     return current
   }
 
   const {releases} = meta.releases
+  const userBundleIds = new Set(meta.agentBundles.bundles.map(({id}) => id))
+  const proposedChangesId = meta.versionState.data.find((id) => {
+    const bundleId = getVersionFromId(id)
+    return typeof bundleId === 'string' && userBundleIds.has(bundleId)
+  })
 
   return [
     {
@@ -147,7 +164,15 @@ function computeSets(meta: Meta | undefined, current: VariantSet[]): VariantSet[
         .map((id) => ({
           id,
           name: getVariantName(id, releases),
-        })),
+        }))
+        .concat(
+          typeof proposedChangesId === 'undefined'
+            ? []
+            : {
+                id: proposedChangesId,
+                name: t('version.agent-bundle.proposed-changes'),
+              },
+        ),
     },
   ]
 }

--- a/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.ts
@@ -5,6 +5,7 @@ import {assign, forwardTo, fromObservable, sendTo, setup, type ActorRefFromLogic
 import {type DocumentPerspectiveState} from '../../releases/hooks/useDocumentVersions'
 import {type ReleasesReducerState} from '../../releases/store/reducer'
 import {getReleaseDocumentIdFromReleaseId} from '../../releases/util/getReleaseDocumentIdFromReleaseId'
+import {type AgentBundlesState} from '../../store/agent/createAgentBundlesStore'
 import {getVersionFromId, isDraftId, isPublishedId} from '../../util/draftUtils'
 import {type deletionMachine} from './deletionMachine'
 import {type selectionMachine, type Variant} from './selectionMachine'
@@ -15,6 +16,7 @@ type DeletionLogic = typeof deletionMachine
 export interface Meta {
   versionState: DocumentPerspectiveState
   releases: ReleasesReducerState
+  agentBundles: AgentBundlesState
 }
 
 export interface VariantSet {

--- a/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.ts
@@ -12,7 +12,7 @@ import {type selectionMachine, type Variant} from './selectionMachine'
 type SelectionLogic = typeof selectionMachine
 type DeletionLogic = typeof deletionMachine
 
-export interface SelectionMeta {
+export interface Meta {
   versionState: DocumentPerspectiveState
   releases: ReleasesReducerState
 }
@@ -44,7 +44,7 @@ export const documentGroupInventoryMachine = setup({
     events: DocumentGroupInventoryEvents
   },
   actors: {
-    meta: fromObservable<SelectionMeta, unknown>(() => EMPTY),
+    meta: fromObservable<Meta, unknown>(() => EMPTY),
   },
   actions: {
     onFeedbackBegin: () => {},
@@ -118,7 +118,7 @@ export const documentGroupInventoryMachine = setup({
   },
 })
 
-function metaHasError(meta: SelectionMeta | undefined): boolean {
+function metaHasError(meta: Meta | undefined): boolean {
   if (!meta) {
     return false
   }
@@ -126,11 +126,11 @@ function metaHasError(meta: SelectionMeta | undefined): boolean {
   return Boolean(meta.versionState.error) || meta.releases.state === 'error'
 }
 
-function metaIsLoaded(meta: SelectionMeta | undefined): boolean {
+function metaIsLoaded(meta: Meta | undefined): boolean {
   return meta?.versionState.loading === false && meta.releases.state === 'loaded'
 }
 
-function computeSets(meta: SelectionMeta | undefined, current: VariantSet[]): VariantSet[] {
+function computeSets(meta: Meta | undefined, current: VariantSet[]): VariantSet[] {
   if (!meta) {
     return current
   }

--- a/packages/sanity/src/core/store/agent/useAgentBundles.ts
+++ b/packages/sanity/src/core/store/agent/useAgentBundles.ts
@@ -6,6 +6,7 @@ import {useProjectStore, useResourceCache} from '../../store'
 import {useWorkspace} from '../../studio'
 import {
   type AgentBundlesState,
+  type AgentBundlesStore,
   createAgentBundlesStore,
   INITIAL_STATE,
 } from './createAgentBundlesStore'
@@ -13,22 +14,17 @@ import {
 const CLIENT_OPTIONS = {apiVersion: 'v2025-02-19'} as const
 
 /**
- * Returns the current user's active agent bundles, streamed in real time from
- * the agent's SSE endpoint.
- *
- * The underlying SSE connection is shared across all callers within the same
- * workspace (via `useResourceCache`), so mounting this hook in multiple
- * components does not open multiple connections.
+ * Retrieve the shared agent bundles store, instantiating it if necessary.
  *
  * @internal
  */
-export function useAgentBundles(): AgentBundlesState {
+export function useAgentBundlesStore(): AgentBundlesStore {
   const resourceCache = useResourceCache()
   const workspace = useWorkspace()
   const client = useClient(CLIENT_OPTIONS)
   const projectStore = useProjectStore()
 
-  const store = useMemo(() => {
+  return useMemo(() => {
     const agentBundlesStore =
       resourceCache.get<ReturnType<typeof createAgentBundlesStore>>({
         namespace: 'AgentBundlesStore',
@@ -47,6 +43,19 @@ export function useAgentBundles(): AgentBundlesState {
 
     return agentBundlesStore
   }, [resourceCache, workspace, client, projectStore])
+}
 
-  return useObservable(store.state$, INITIAL_STATE)
+/**
+ * Returns the current user's active agent bundles, streamed in real time from
+ * the agent's SSE endpoint.
+ *
+ * The underlying SSE connection is shared across all callers within the same
+ * workspace (via `useResourceCache`), so mounting this hook in multiple
+ * components does not open multiple connections.
+ *
+ * @internal
+ */
+export function useAgentBundles(): AgentBundlesState {
+  const {state$} = useAgentBundlesStore()
+  return useObservable(state$, INITIAL_STATE)
 }


### PR DESCRIPTION
### Description

This branch replicates the Content Agent bundle handling employed by version chips in the document group inventory.

- Agent bundles owned by other users are never listed.
- The most recent agent bundle owned by the current user is listed as "Proposed changes".

<img width="1524" height="1032" alt="Screenshot 2026-07-01 at 14 00 35" src="https://github.com/user-attachments/assets/59ab5b2b-30eb-4827-ba89-25f8c894c499" />

### What to review

The agent bundle handling logic.

### Testing

- Verified behaviour with agent bundles created by current user, and other users.
- Added unit tests for state machine.
- We are iterating on this UI quickly, and will follow up with more thorough testing once intended behaviour has settled.

### Notes for release

Document group inventory preview: changes proposed by Content Agent can now be accessed using the "Proposed changes" item.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and variant-list derivation only; reuses existing agent-bundle helpers and i18n keys with unit test coverage, no auth or persistence changes.
> 
> **Overview**
> Aligns **document group inventory** with existing **Content Agent version chip** behavior so users can open agent-proposed document variants from the inventory popover.
> 
> The inventory machine’s **meta** stream now includes **`agentBundles`** (via new **`useAgentBundlesStore`**). **`computeSets`** strips all `agent-*` version IDs from the raw version list, then appends a single variant for the first version ID whose bundle id is in the current user’s bundles, labeled with **`version.agent-bundle.proposed-changes`**. The machine takes **`t`** so that label is translated.
> 
> **UI:** inventory rows for agent bundles use **`ReleaseAvatarIcon`** with **`tone="suggest"`** instead of release avatars; the header action button uses the same **“Proposed changes”** label when the active perspective is an agent bundle.
> 
> **Tests** cover the filtered/relabeled variant list; existing machine tests were updated for the expanded **Meta** shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 346f0ded2fd86691c85ee64b3e33c11832b5e7a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->