### PR TITLE
perf(core): deduplicate document version and permission subscriptions

### DIFF
--- a/packages/sanity/src/core/releases/hooks/__tests__/getOrCreateDocumentVersionsObservable.test.ts
+++ b/packages/sanity/src/core/releases/hooks/__tests__/getOrCreateDocumentVersionsObservable.test.ts
@@ -81,32 +81,32 @@ describe('getOrCreateDocumentVersionsObservable', () => {
 
 /**
  * Builds a `documentPreviewStore` whose version documents carry no `_system`,
- * so the with-system factory always runs the `temporarilyBuildDocumentSystem`
- * stitch. `observePathsSpy` counts how often the leaf observable is created,
- * which stays flat across additional subscribers because the base observable is
- * shared.
+ * so the with-system factory always runs the `buildDocumentSystem`
+ * stitch. `observePathsSpy` counts how often the leaf observable is created.
  */
 function createSystemlessPreviewStore(versionIds: string[]) {
   const observePathsSpy = vi
     .fn<DocumentPreviewStore['observePaths']>()
-    .mockImplementation((value: {_id: string}) =>
-      of({_id: value._id, _rev: '', _createdAt: '', _updatedAt: ''}),
+    .mockImplementation((value) =>
+      of({
+        _id: '_id' in value ? value._id : '',
+        _rev: '',
+        _createdAt: '',
+        _updatedAt: '',
+      }),
     )
 
-  const documentPreviewStore = {
+  const documentPreviewStore: Partial<DocumentPreviewStore> = {
     unstable_observeVersionDocumentIds: vi
       .fn<DocumentPreviewStore['unstable_observeVersionDocumentIds']>()
       .mockReturnValue(of(versionIds)),
     observePaths: observePathsSpy,
-  } as unknown as DocumentPreviewStore
+  }
 
-  return {documentPreviewStore, observePathsSpy}
+  return {documentPreviewStore: documentPreviewStore as DocumentPreviewStore, observePathsSpy}
 }
 
-const asapReleaseDocument = {
-  _id: '_.releases.rASAP',
-  name: 'rASAP',
-} as unknown as ReleaseDocument
+const asapReleaseDocument = {_id: '_.releases.rASAP'} as ReleaseDocument
 
 describe('getOrCreateDocumentVersionsWithSystemObservable', () => {
   beforeEach(() => {

--- a/packages/sanity/src/core/releases/hooks/__tests__/getOrCreateDocumentVersionsObservable.test.ts
+++ b/packages/sanity/src/core/releases/hooks/__tests__/getOrCreateDocumentVersionsObservable.test.ts
@@ -1,8 +1,15 @@
-import {firstValueFrom, of, toArray} from 'rxjs'
-import {describe, expect, it, vi} from 'vitest'
+import {type ReleaseDocument} from '@sanity/client'
+import {BehaviorSubject, firstValueFrom, of, toArray} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {type DocumentPreviewStore} from '../../../preview'
-import {getOrCreateDocumentVersionsObservable, observableCache} from '../useDocumentVersions'
+import {
+  type DocumentPerspectiveState,
+  getOrCreateDocumentVersionsObservable,
+  getOrCreateDocumentVersionsWithSystemObservable,
+  observableCache,
+  withSystemCache,
+} from '../useDocumentVersions'
 
 describe('getOrCreateDocumentVersionsObservable', () => {
   it('emits loading: true while document stub fields are being resolved', async () => {
@@ -69,5 +76,135 @@ describe('getOrCreateDocumentVersionsObservable', () => {
         loading: false,
       },
     ])
+  })
+})
+
+/**
+ * Builds a `documentPreviewStore` whose version documents carry no `_system`,
+ * so the with-system factory always runs the `temporarilyBuildDocumentSystem`
+ * stitch. `observePathsSpy` counts how often the leaf observable is created,
+ * which stays flat across additional subscribers because the base observable is
+ * shared.
+ */
+function createSystemlessPreviewStore(versionIds: string[]) {
+  const observePathsSpy = vi
+    .fn<DocumentPreviewStore['observePaths']>()
+    .mockImplementation((value: {_id: string}) =>
+      of({_id: value._id, _rev: '', _createdAt: '', _updatedAt: ''}),
+    )
+
+  const documentPreviewStore = {
+    unstable_observeVersionDocumentIds: vi
+      .fn<DocumentPreviewStore['unstable_observeVersionDocumentIds']>()
+      .mockReturnValue(of(versionIds)),
+    observePaths: observePathsSpy,
+  } as unknown as DocumentPreviewStore
+
+  return {documentPreviewStore, observePathsSpy}
+}
+
+const asapReleaseDocument = {
+  _id: '_.releases.rASAP',
+  name: 'rASAP',
+} as unknown as ReleaseDocument
+
+describe('getOrCreateDocumentVersionsWithSystemObservable', () => {
+  beforeEach(() => {
+    observableCache.clear()
+    withSystemCache.clear()
+  })
+
+  it('runs the derivation once for N subscribers', async () => {
+    const {documentPreviewStore, observePathsSpy} = createSystemlessPreviewStore([
+      'versions.rASAP.document-1',
+    ])
+    const releases$ = new BehaviorSubject<ReleaseDocument[]>([asapReleaseDocument])
+
+    const observable = getOrCreateDocumentVersionsWithSystemObservable({
+      documentPreviewStore,
+      publishedId: 'document-1',
+      projectId: 'test-project',
+      dataset: 'test',
+      releases$,
+    })
+
+    const subscriberCount = 5
+    const subscriptions = Array.from({length: subscriberCount}, () => observable.subscribe())
+
+    // The base observable's leaf `observePaths` is created once for the single
+    // version id, regardless of how many subscribers attach to the shared chain.
+    expect(observePathsSpy).toHaveBeenCalledTimes(1)
+
+    subscriptions.forEach((subscription) => subscription.unsubscribe())
+  })
+
+  it('pushing a new releases$ array updates all subscribers', async () => {
+    const {documentPreviewStore} = createSystemlessPreviewStore(['versions.rASAP.document-1'])
+    // Start with no releases so the stitched `_system.release` is undefined.
+    const releases$ = new BehaviorSubject<ReleaseDocument[]>([])
+
+    const observable = getOrCreateDocumentVersionsWithSystemObservable({
+      documentPreviewStore,
+      publishedId: 'document-1',
+      projectId: 'test-project',
+      dataset: 'test',
+      releases$,
+    })
+
+    const latestBySubscriber: Array<DocumentPerspectiveState> = [{} as never, {} as never]
+    const subscriptions = latestBySubscriber.map((_placeholder, index) =>
+      observable.subscribe((state) => {
+        latestBySubscriber[index] = state
+      }),
+    )
+
+    // Before the new releases arrive, no release is matched.
+    latestBySubscriber.forEach((state) => {
+      expect(state.versions[0]._system.release).toBeUndefined()
+    })
+
+    // Pushing a new releases array flows through combineLatest (dataflow), not a
+    // stale closure, so every subscriber sees the newly matched release.
+    releases$.next([asapReleaseDocument])
+
+    latestBySubscriber.forEach((state) => {
+      expect(state.versions[0]._system.release).toEqual({_ref: '_.releases.rASAP', _weak: true})
+    })
+
+    subscriptions.forEach((subscription) => subscription.unsubscribe())
+  })
+
+  it('keeps the cache warm across a brief gap, then evicts after the grace period', () => {
+    vi.useFakeTimers()
+    const {documentPreviewStore} = createSystemlessPreviewStore(['versions.rASAP.document-1'])
+    const releases$ = new BehaviorSubject<ReleaseDocument[]>([asapReleaseDocument])
+
+    const observable = getOrCreateDocumentVersionsWithSystemObservable({
+      documentPreviewStore,
+      publishedId: 'document-1',
+      projectId: 'test-project',
+      dataset: 'test',
+      releases$,
+    })
+
+    const firstSubscription = observable.subscribe()
+    const secondSubscription = observable.subscribe()
+
+    expect(withSystemCache.size).toBe(1)
+
+    firstSubscription.unsubscribe()
+    secondSubscription.unsubscribe()
+
+    // The grace-period share keeps the entry warm across subscriber churn, so a
+    // zero-subscriber gap shorter than the grace period does not evict it.
+    vi.advanceTimersByTime(100)
+    expect(withSystemCache.size).toBe(1)
+
+    // Once the grace period elapses with no subscribers, finalize evicts the key
+    // and there is no leak.
+    vi.advanceTimersByTime(2_000)
+    expect(withSystemCache.size).toBe(0)
+
+    vi.useRealTimers()
   })
 })

--- a/packages/sanity/src/core/releases/hooks/__tests__/getOrCreateDocumentVersionsObservable.test.ts
+++ b/packages/sanity/src/core/releases/hooks/__tests__/getOrCreateDocumentVersionsObservable.test.ts
@@ -134,6 +134,8 @@ describe('getOrCreateDocumentVersionsWithSystemObservable', () => {
     // The base observable's leaf `observePaths` is created once for the single
     // version id, regardless of how many subscribers attach to the shared chain.
     expect(observePathsSpy).toHaveBeenCalledTimes(1)
+    // The stitch layer (withSystemCache) also builds exactly one entry for N subscribers.
+    expect(withSystemCache.size).toBe(1)
 
     subscriptions.forEach((subscription) => subscription.unsubscribe())
   })

--- a/packages/sanity/src/core/releases/hooks/__tests__/getOrCreateDocumentVersionsObservable.test.ts
+++ b/packages/sanity/src/core/releases/hooks/__tests__/getOrCreateDocumentVersionsObservable.test.ts
@@ -114,7 +114,7 @@ describe('getOrCreateDocumentVersionsWithSystemObservable', () => {
     withSystemCache.clear()
   })
 
-  it('runs the derivation once for N subscribers', async () => {
+  it('runs the derivation once for N subscribers', () => {
     const {documentPreviewStore, observePathsSpy} = createSystemlessPreviewStore([
       'versions.rASAP.document-1',
     ])
@@ -138,7 +138,7 @@ describe('getOrCreateDocumentVersionsWithSystemObservable', () => {
     subscriptions.forEach((subscription) => subscription.unsubscribe())
   })
 
-  it('pushing a new releases$ array updates all subscribers', async () => {
+  it('pushing a new releases$ array updates all subscribers', () => {
     const {documentPreviewStore} = createSystemlessPreviewStore(['versions.rASAP.document-1'])
     // Start with no releases so the stitched `_system.release` is undefined.
     const releases$ = new BehaviorSubject<ReleaseDocument[]>([])
@@ -151,8 +151,9 @@ describe('getOrCreateDocumentVersionsWithSystemObservable', () => {
       releases$,
     })
 
-    const latestBySubscriber: Array<DocumentPerspectiveState> = [{} as never, {} as never]
-    const subscriptions = latestBySubscriber.map((_placeholder, index) =>
+    const subscriberCount = 2
+    const latestBySubscriber: Array<DocumentPerspectiveState> = []
+    const subscriptions = Array.from({length: subscriberCount}, (_unused, index) =>
       observable.subscribe((state) => {
         latestBySubscriber[index] = state
       }),

--- a/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
@@ -2,18 +2,19 @@ import {type ReleaseDocument} from '@sanity/client'
 import {getPublishedId} from '@sanity/client/csm'
 import {type DocumentSystem} from '@sanity/types'
 import {renderHook, waitFor} from '@testing-library/react'
-import {concat, NEVER, of} from 'rxjs'
+import {BehaviorSubject, concat, NEVER, of} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
 import {type DocumentPreviewStore} from '../../../preview'
 import {useDocumentPreviewStore} from '../../../store'
 import {activeASAPRelease, activeScheduledRelease} from '../../__fixtures__/release.fixture'
-import {useActiveReleasesMockReturn} from '../../store/__tests__/__mocks/useActiveReleases.mock'
+import {type ReleasesReducerState} from '../../store/reducer'
 import {
   type DocumentPerspectiveState,
   getOrCreateDocumentVersionsObservable,
   observableCache,
   useDocumentVersions,
+  withSystemCache,
 } from '../useDocumentVersions'
 
 vi.mock('../../../hooks/useDataset', () => ({
@@ -28,8 +29,15 @@ vi.mock('../../../store', () => ({
   useDocumentPreviewStore: vi.fn(),
 }))
 
-vi.mock('../../store/useActiveReleases', () => ({
-  useActiveReleases: vi.fn(() => useActiveReleasesMockReturn),
+const initialReleasesState: ReleasesReducerState = {
+  releases: new Map(),
+  state: 'loaded',
+}
+const mockReleasesState$ = new BehaviorSubject<ReleasesReducerState>(initialReleasesState)
+const mockDispatch = vi.fn()
+
+vi.mock('../../store/useReleasesStore', () => ({
+  useReleasesStore: () => ({state$: mockReleasesState$, dispatch: mockDispatch}),
 }))
 
 async function setupMocks({
@@ -81,16 +89,17 @@ async function setupMocks({
       }),
   } as unknown as DocumentPreviewStore)
 
-  const {useActiveReleases} = await import('../../store/useActiveReleases')
-  vi.mocked(useActiveReleases).mockReturnValue({
-    ...useActiveReleasesMockReturn,
-    data: releases,
+  mockReleasesState$.next({
+    releases: new Map(releases.map((release) => [release._id, release])),
+    state: 'loaded',
   })
 }
 
 describe('useDocumentVersions', () => {
   beforeEach(() => {
     observableCache.clear()
+    withSystemCache.clear()
+    mockReleasesState$.next(initialReleasesState)
   })
 
   it('should return initial state', async () => {

--- a/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
@@ -50,7 +50,7 @@ async function setupMocks({
   versionIds: string[]
   /**
    * When `false`, versions are returned without `_system`, so the hook
-   * falls back to `temporarilyBuildDocumentSystem`.
+   * falls back to `buildDocumentSystem`.
    */
   observeSystem?: boolean
   /** When `true`, the version document ids observable never emits (initial loading state). */

--- a/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
@@ -161,7 +161,7 @@ const temporarilyBuildDocumentSystem = (
 
 const DOCUMENT_STUB_PATHS = ['_id', '_type', '_rev', '_createdAt', '_updatedAt', '_system']
 
-function getOrCreateDocumentVersionsWithSystemObservable(options: {
+export function getOrCreateDocumentVersionsWithSystemObservable(options: {
   documentPreviewStore: DocumentPreviewStore
   publishedId: string
   projectId: string

--- a/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
@@ -130,10 +130,7 @@ export function useDocumentVersionsObservable(
  *
  * Variants will include the _system field.
  */
-const temporarilyBuildDocumentSystem = (
-  id: string,
-  releases: ReleaseDocument[],
-): DocumentSystem => {
+const buildDocumentSystem = (id: string, releases: ReleaseDocument[]): DocumentSystem => {
   const versionId = getVersionFromId(id)
   if (versionId) {
     const releaseDocument = releases.find(
@@ -156,7 +153,39 @@ const temporarilyBuildDocumentSystem = (
   }
 }
 
+const resolveVersionSystem = (
+  version: VersionInfoDocumentStub,
+  releases: ReleaseDocument[],
+): DocumentSystem => {
+  if (version._system?.group) return version._system
+
+  return {
+    ...version._system,
+    ...buildDocumentSystem(version._id, releases),
+  }
+}
+
 const DOCUMENT_STUB_PATHS = ['_id', '_type', '_rev', '_createdAt', '_updatedAt', '_system']
+
+function getOrCreateCachedObservable<T>(
+  cache: Map<string, Observable<T>>,
+  cacheKey: string,
+  createObservable: () => Observable<T>,
+): Observable<T> {
+  const cached = cache.get(cacheKey)
+  if (cached) return cached
+
+  const observable = createObservable().pipe(
+    finalize(() => cache.delete(cacheKey)),
+    share({
+      connector: () => new ReplaySubject(1),
+      resetOnRefCountZero: () => timer(TEARDOWN_GRACE_PERIOD),
+    }),
+  )
+
+  cache.set(cacheKey, observable)
+  return observable
+}
 
 export function getOrCreateDocumentVersionsWithSystemObservable(options: {
   documentPreviewStore: DocumentPreviewStore
@@ -168,34 +197,25 @@ export function getOrCreateDocumentVersionsWithSystemObservable(options: {
   const {documentPreviewStore, projectId, dataset, publishedId, releases$} = options
   const cacheKey = `${projectId}-${dataset}-${publishedId}`
 
-  const cached = withSystemCache.get(cacheKey)
-  if (cached) return cached
-
-  const withSystem = combineLatest([
-    getOrCreateDocumentVersionsObservable({documentPreviewStore, publishedId, projectId, dataset}),
-    releases$,
-  ]).pipe(
-    map(([result, releases]) => ({
-      ...result,
-      versions: result.versions.map((version) => ({
-        ...version,
-        [DOCUMENT_SYSTEM_FIELD]: version._system?.group
-          ? version._system
-          : {
-              ...version._system,
-              ...temporarilyBuildDocumentSystem(version._id, releases),
-            },
+  return getOrCreateCachedObservable(withSystemCache, cacheKey, () =>
+    combineLatest([
+      getOrCreateDocumentVersionsObservable({
+        documentPreviewStore,
+        publishedId,
+        projectId,
+        dataset,
+      }),
+      releases$,
+    ]).pipe(
+      map(([result, releases]) => ({
+        ...result,
+        versions: result.versions.map((version) => ({
+          ...version,
+          [DOCUMENT_SYSTEM_FIELD]: resolveVersionSystem(version, releases),
+        })),
       })),
-    })),
-    finalize(() => withSystemCache.delete(cacheKey)),
-    share({
-      connector: () => new ReplaySubject(1),
-      resetOnRefCountZero: () => timer(TEARDOWN_GRACE_PERIOD),
-    }),
+    ),
   )
-
-  withSystemCache.set(cacheKey, withSystem)
-  return withSystem
 }
 
 /**
@@ -220,69 +240,56 @@ export function getOrCreateDocumentVersionsObservable(options: {
   const {documentPreviewStore, projectId, dataset, publishedId} = options
   const cacheKey = `${projectId}-${dataset}-${publishedId}`
 
-  const cachedObservable = observableCache.get(cacheKey)
-  if (cachedObservable) {
-    return cachedObservable
-  }
+  return getOrCreateCachedObservable(observableCache, cacheKey, () =>
+    documentPreviewStore.unstable_observeVersionDocumentIds(publishedId).pipe(
+      swr(cacheKey),
+      map(({value}) => value),
+      switchMap((documentIds): Observable<DocumentPerspectiveState> => {
+        if (documentIds.length === 0) {
+          return of({data: [], versions: [], error: null, loading: false})
+        }
 
-  const newObservable = documentPreviewStore.unstable_observeVersionDocumentIds(publishedId).pipe(
-    swr(cacheKey),
-    map(({value}) => value),
-    switchMap((documentIds): Observable<DocumentPerspectiveState> => {
-      if (documentIds.length === 0) {
-        return of({data: [], versions: [], error: null, loading: false})
-      }
+        const loadingState: DocumentPerspectiveState = {
+          data: documentIds,
+          versions: [],
+          error: null,
+          loading: true,
+        }
 
-      const loadingState: DocumentPerspectiveState = {
-        data: documentIds,
-        versions: [],
-        error: null,
-        loading: true,
-      }
-
-      return combineLatest(
-        documentIds.map((id) =>
-          documentPreviewStore.observePaths({_id: id}, DOCUMENT_STUB_PATHS).pipe(
-            map((versionInfo) => (isRecord(versionInfo) ? versionInfo : undefined)),
-            map(
-              (versionInfo) =>
-                ({
-                  _id: id,
-                  _rev: versionInfo?._rev ?? '',
-                  _createdAt: versionInfo?._createdAt ?? '',
-                  _updatedAt: versionInfo?._updatedAt ?? '',
-                  [DOCUMENT_SYSTEM_FIELD]: versionInfo?.[DOCUMENT_SYSTEM_FIELD] as DocumentSystem,
-                }) satisfies VersionInfoDocumentStub,
+        return combineLatest(
+          documentIds.map((id) =>
+            documentPreviewStore.observePaths({_id: id}, DOCUMENT_STUB_PATHS).pipe(
+              map((versionInfo) => (isRecord(versionInfo) ? versionInfo : undefined)),
+              map(
+                (versionInfo) =>
+                  ({
+                    _id: id,
+                    _rev: versionInfo?._rev ?? '',
+                    _createdAt: versionInfo?._createdAt ?? '',
+                    _updatedAt: versionInfo?._updatedAt ?? '',
+                    [DOCUMENT_SYSTEM_FIELD]: versionInfo?.[DOCUMENT_SYSTEM_FIELD] as DocumentSystem,
+                  }) satisfies VersionInfoDocumentStub,
+              ),
             ),
           ),
-        ),
-      ).pipe(
-        map((versions) => ({
-          data: documentIds,
-          versions,
-          error: null,
+        ).pipe(
+          map((versions) => ({
+            data: documentIds,
+            versions,
+            error: null,
+            loading: false,
+          })),
+          startWith(loadingState),
+        )
+      }),
+      catchError((error) => {
+        return of({
+          error,
+          data: [] as string[],
+          versions: [] as VersionInfoDocumentStub[],
           loading: false,
-        })),
-        startWith(loadingState),
-      )
-    }),
-    catchError((error) => {
-      return of({
-        error,
-        data: [] as string[],
-        versions: [] as VersionInfoDocumentStub[],
-        loading: false,
-      })
-    }),
-    finalize(() => {
-      observableCache.delete(cacheKey)
-    }),
-    share({
-      connector: () => new ReplaySubject(1),
-      resetOnRefCountZero: () => timer(TEARDOWN_GRACE_PERIOD),
-    }),
+        })
+      }),
+    ),
   )
-
-  observableCache.set(cacheKey, newObservable)
-  return newObservable
 }

--- a/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
@@ -52,7 +52,7 @@ const INITIAL_VALUE: DocumentPerspectiveState = {
 
 // Create a singleton cache for observables
 export const observableCache = new Map<string, Observable<DocumentPerspectiveState>>()
-// releases flow via combineLatest, never in the cache key — avoids cache thrash on every release edit
+// releases flow via combineLatest, never in the cache key, to avoid cache thrash on every release edit
 export const withSystemCache = new Map<string, Observable<DocumentPerspectiveState>>()
 const swr = createSWR<string[]>({maxSize: 100})
 

--- a/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
@@ -27,8 +27,10 @@ import {getPublishedId} from '../../util/draftUtils'
 import {isRecord} from '../../util/isRecord'
 import {createSWR} from '../../util/rxSwr'
 import {type VersionInfoDocumentStub} from '../store/types'
-import {useActiveReleases} from '../store/useActiveReleases'
+import {useReleasesStore} from '../store/useReleasesStore'
+import {ARCHIVED_RELEASE_STATES} from '../util/const'
 import {getReleaseIdFromReleaseDocumentId} from '../util/getReleaseIdFromReleaseDocumentId'
+import {sortReleases} from './utils'
 
 export interface DocumentPerspectiveProps {
   documentId: string
@@ -50,6 +52,8 @@ const INITIAL_VALUE: DocumentPerspectiveState = {
 
 // Create a singleton cache for observables
 export const observableCache = new Map<string, Observable<DocumentPerspectiveState>>()
+// releases flow via combineLatest, never in the cache key — avoids cache thrash on every release edit
+export const withSystemCache = new Map<string, Observable<DocumentPerspectiveState>>()
 const swr = createSWR<string[]>({maxSize: 100})
 
 // How long to keep the pipeline alive after the last subscriber unsubscribes.
@@ -91,33 +95,33 @@ export function useDocumentVersionsObservable(
   const dataset = useDataset()
   const projectId = useProjectId()
   const documentPreviewStore = useDocumentPreviewStore()
-  const {data: releases} = useActiveReleases()
+  const {state$: releasesState$} = useReleasesStore()
 
-  const observable: Observable<DocumentPerspectiveState> = useMemo(() => {
-    return getOrCreateDocumentVersionsObservable({
-      documentPreviewStore,
-      publishedId,
-      projectId,
-      dataset,
-    }).pipe(
-      map((result) => {
-        return {
-          ...result,
-          versions: result.versions.map((version) => {
-            return {
-              ...version,
-              [DOCUMENT_SYSTEM_FIELD]: version._system?.group
-                ? version._system
-                : {
-                    ...version._system,
-                    ...temporarilyBuildDocumentSystem(version._id, releases),
-                  },
-            }
-          }),
-        }
+  const releases$ = useMemo(
+    () =>
+      releasesState$.pipe(
+        map((state) =>
+          sortReleases(
+            Array.from(state.releases.values()).filter(
+              (release) => !ARCHIVED_RELEASE_STATES.includes(release.state),
+            ),
+          ).reverse(),
+        ),
+      ),
+    [releasesState$],
+  )
+
+  const observable: Observable<DocumentPerspectiveState> = useMemo(
+    () =>
+      getOrCreateDocumentVersionsWithSystemObservable({
+        documentPreviewStore,
+        publishedId,
+        projectId,
+        dataset,
+        releases$,
       }),
-    )
-  }, [dataset, documentPreviewStore, projectId, publishedId, releases])
+    [dataset, documentPreviewStore, projectId, publishedId, releases$],
+  )
 
   return observable
 }
@@ -156,6 +160,46 @@ const temporarilyBuildDocumentSystem = (
 }
 
 const DOCUMENT_STUB_PATHS = ['_id', '_type', '_rev', '_createdAt', '_updatedAt', '_system']
+
+function getOrCreateDocumentVersionsWithSystemObservable(options: {
+  documentPreviewStore: DocumentPreviewStore
+  publishedId: string
+  projectId: string
+  dataset: string
+  releases$: Observable<ReleaseDocument[]>
+}): Observable<DocumentPerspectiveState> {
+  const {documentPreviewStore, projectId, dataset, publishedId, releases$} = options
+  const cacheKey = `${projectId}-${dataset}-${publishedId}`
+
+  const cached = withSystemCache.get(cacheKey)
+  if (cached) return cached
+
+  const withSystem = combineLatest([
+    getOrCreateDocumentVersionsObservable({documentPreviewStore, publishedId, projectId, dataset}),
+    releases$,
+  ]).pipe(
+    map(([result, releases]) => ({
+      ...result,
+      versions: result.versions.map((version) => ({
+        ...version,
+        [DOCUMENT_SYSTEM_FIELD]: version._system?.group
+          ? version._system
+          : {
+              ...version._system,
+              ...temporarilyBuildDocumentSystem(version._id, releases),
+            },
+      })),
+    })),
+    finalize(() => withSystemCache.delete(cacheKey)),
+    share({
+      connector: () => new ReplaySubject(1),
+      resetOnRefCountZero: () => timer(TEARDOWN_GRACE_PERIOD),
+    }),
+  )
+
+  withSystemCache.set(cacheKey, withSystem)
+  return withSystem
+}
 
 /**
  * Retrieves an observable that emits document IDs matching the document versions that exist for a specific id

--- a/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
@@ -30,7 +30,6 @@ import {type VersionInfoDocumentStub} from '../store/types'
 import {useReleasesStore} from '../store/useReleasesStore'
 import {ARCHIVED_RELEASE_STATES} from '../util/const'
 import {getReleaseIdFromReleaseDocumentId} from '../util/getReleaseIdFromReleaseDocumentId'
-import {sortReleases} from './utils'
 
 export interface DocumentPerspectiveProps {
   documentId: string
@@ -101,11 +100,9 @@ export function useDocumentVersionsObservable(
     () =>
       releasesState$.pipe(
         map((state) =>
-          sortReleases(
-            Array.from(state.releases.values()).filter(
-              (release) => !ARCHIVED_RELEASE_STATES.includes(release.state),
-            ),
-          ).reverse(),
+          Array.from(state.releases.values()).filter(
+            (release) => !ARCHIVED_RELEASE_STATES.includes(release.state),
+          ),
         ),
       ),
     [releasesState$],

--- a/packages/sanity/src/core/store/document/document-pair/validation.test.ts
+++ b/packages/sanity/src/core/store/document/document-pair/validation.test.ts
@@ -627,4 +627,91 @@ describe('validation', () => {
 
     mockEditStateSubject.complete()
   })
+
+  describe('memoization by currentUser', () => {
+    it('returns DISTINCT observables for different currentUser ids', () => {
+      const client = getMockClient()
+      const mockEditStateSubject = new Subject<EditStateFor>()
+      mockEditState.mockImplementation(() => mockEditStateSubject.asObservable())
+
+      // Use a random published id to avoid collisions with the module-level cache from other tests
+      const publishedId = `movie-${Math.random().toString(36).slice(2)}`
+      const idPair = {publishedId, draftId: `drafts.${publishedId}`}
+      const sharedCtx = {
+        client,
+        getClient: () => client,
+        schema,
+        observeDocumentPairAvailability: () => EMPTY,
+        i18n: getFallbackLocaleSource(),
+      }
+
+      const observableUserA = validation(
+        {...sharedCtx, currentUser: {id: 'user-a'}},
+        idPair,
+        'movie',
+        'draft',
+      )
+      const observableUserB = validation(
+        {...sharedCtx, currentUser: {id: 'user-b'}},
+        idPair,
+        'movie',
+        'draft',
+      )
+
+      expect(observableUserA).not.toBe(observableUserB)
+    })
+
+    it('returns the SAME observable for the same currentUser id', () => {
+      const client = getMockClient()
+      const mockEditStateSubject = new Subject<EditStateFor>()
+      mockEditState.mockImplementation(() => mockEditStateSubject.asObservable())
+
+      const publishedId = `movie-${Math.random().toString(36).slice(2)}`
+      const idPair = {publishedId, draftId: `drafts.${publishedId}`}
+      const sharedCtx = {
+        client,
+        getClient: () => client,
+        schema,
+        observeDocumentPairAvailability: () => EMPTY,
+        i18n: getFallbackLocaleSource(),
+        currentUser: {id: 'user-c'},
+      }
+
+      const firstObservable = validation(sharedCtx, idPair, 'movie', 'draft')
+      const secondObservable = validation(sharedCtx, idPair, 'movie', 'draft')
+
+      expect(firstObservable).toBe(secondObservable)
+    })
+
+    it('returns DISTINCT observables for null vs defined currentUser', () => {
+      const client = getMockClient()
+      const mockEditStateSubject = new Subject<EditStateFor>()
+      mockEditState.mockImplementation(() => mockEditStateSubject.asObservable())
+
+      const publishedId = `movie-${Math.random().toString(36).slice(2)}`
+      const idPair = {publishedId, draftId: `drafts.${publishedId}`}
+      const sharedCtx = {
+        client,
+        getClient: () => client,
+        schema,
+        observeDocumentPairAvailability: () => EMPTY,
+        i18n: getFallbackLocaleSource(),
+      }
+
+      const observableWithUser = validation(
+        {...sharedCtx, currentUser: {id: 'user-d'}},
+        idPair,
+        'movie',
+        'draft',
+      )
+      const observableWithoutUser = validation(
+        {...sharedCtx, currentUser: null},
+        idPair,
+        'movie',
+        'draft',
+      )
+
+      expect(observableWithUser).not.toBe(observableWithoutUser)
+    })
+  })
 })

--- a/packages/sanity/src/core/store/document/document-pair/validation.ts
+++ b/packages/sanity/src/core/store/document/document-pair/validation.ts
@@ -103,6 +103,10 @@ export const validation = memoize(
         : validationTarget === 'version'
           ? idPair.versionId
           : idPair.publishedId
-    return `${memoizeKeyGen(ctx.client, idPair, typeName)}-${documentId}-${validatePublishedReferences}`
+    // Include the user id so an in-place user switch gets its own cache entry;
+    // the module-level memo cache is never cleared, so without this a new user
+    // would replay the previous user's validation result.
+    const userId = ctx.currentUser?.id ?? ''
+    return `${memoizeKeyGen(ctx.client, idPair, typeName)}-${documentId}-${validatePublishedReferences}-${userId}`
   },
 )

--- a/packages/sanity/src/core/store/grants/__tests__/documentPairPermissions.test.ts
+++ b/packages/sanity/src/core/store/grants/__tests__/documentPairPermissions.test.ts
@@ -96,6 +96,32 @@ describe('getDocumentPairPermissions (Pattern-B memoization)', () => {
     expect(publishObservable).not.toBe(deleteObservable)
   })
 
+  it('returns the SAME observable for ids that normalize to the same published id', () => {
+    createSnapshotPairMock()
+    const grantsStore = createGrantsStore()
+    const publishedId = `book-${Math.random().toString(36).slice(2)}`
+
+    const shared = {client, schema, grantsStore, type: 'book', permission: 'publish'} as const
+
+    const fromPublishedId = getDocumentPairPermissions({...shared, id: publishedId})
+    const fromDraftId = getDocumentPairPermissions({...shared, id: `drafts.${publishedId}`})
+
+    expect(fromPublishedId).toBe(fromDraftId)
+  })
+
+  it('returns DISTINCT observables for different version', () => {
+    createSnapshotPairMock()
+    const grantsStore = createGrantsStore()
+    const id = `book-${Math.random().toString(36).slice(2)}`
+
+    const shared = {client, schema, grantsStore, id, type: 'book', permission: 'publish'} as const
+
+    const versionA = getDocumentPairPermissions({...shared, version: 'rABC'})
+    const versionB = getDocumentPairPermissions({...shared, version: 'rXYZ'})
+
+    expect(versionA).not.toBe(versionB)
+  })
+
   it('builds the underlying chain only once for N subscribers', () => {
     const {draft$, published$, version$} = createSnapshotPairMock()
     const grantsStore = createGrantsStore()

--- a/packages/sanity/src/core/store/grants/__tests__/documentPairPermissions.test.ts
+++ b/packages/sanity/src/core/store/grants/__tests__/documentPairPermissions.test.ts
@@ -1,0 +1,138 @@
+import {type SanityClient} from '@sanity/client'
+import {type SanityDocument} from '@sanity/types'
+import {of, Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createMockSanityClient} from '../../../../../test/mocks/mockSanityClient'
+import {createSchema} from '../../../schema'
+import {snapshotPair} from '../../document'
+import {getDocumentPairPermissions} from '../documentPairPermissions'
+import {type GrantsStore} from '../types'
+
+vi.mock('../../document', () => ({snapshotPair: vi.fn()}))
+
+const mockedSnapshotPair = vi.mocked(snapshotPair)
+
+const schema = createSchema({
+  name: 'default',
+  types: [{name: 'book', type: 'document', fields: [{name: 'title', type: 'string'}]}],
+})
+
+const client = createMockSanityClient() as unknown as SanityClient
+
+/**
+ * A `snapshotPair` mock whose draft/published/version snapshots are driven by
+ * `Subject`s, plus a spy that counts how many times the mock factory itself is
+ * invoked (i.e. how many times the underlying chain is built).
+ */
+function createSnapshotPairMock() {
+  const draft$ = new Subject<SanityDocument | null>()
+  const published$ = new Subject<SanityDocument | null>()
+  const version$ = new Subject<SanityDocument | null>()
+
+  mockedSnapshotPair.mockImplementation(
+    () =>
+      of({
+        draft: {snapshots$: draft$.asObservable()},
+        published: {snapshots$: published$.asObservable()},
+        version: {snapshots$: version$.asObservable()},
+      }) as unknown as ReturnType<typeof snapshotPair>,
+  )
+
+  return {draft$, published$, version$}
+}
+
+/**
+ * A minimal `grantsStore` whose `checkDocumentPermission` always grants and
+ * carries a spy so tests can count how many grant-check passes occur.
+ */
+function createGrantsStore(): GrantsStore {
+  return {
+    checkDocumentPermission: vi.fn().mockReturnValue(of({granted: true, reason: ''})),
+  }
+}
+
+describe('getDocumentPairPermissions (Pattern-B memoization)', () => {
+  beforeEach(() => {
+    mockedSnapshotPair.mockReset()
+  })
+
+  it('returns the SAME observable instance for repeated calls with identical options', () => {
+    createSnapshotPairMock()
+    const grantsStore = createGrantsStore()
+    // Unique id per run dodges the module-level memoize cache from other tests.
+    const id = `book-${Math.random().toString(36).slice(2)}`
+
+    const options = {client, schema, grantsStore, id, type: 'book', permission: 'publish'} as const
+
+    const firstObservable = getDocumentPairPermissions(options)
+    const secondObservable = getDocumentPairPermissions(options)
+
+    expect(firstObservable).toBe(secondObservable)
+  })
+
+  it('returns DISTINCT observables for different permission', () => {
+    createSnapshotPairMock()
+    const grantsStore = createGrantsStore()
+    const id = `book-${Math.random().toString(36).slice(2)}`
+
+    const publishObservable = getDocumentPairPermissions({
+      client,
+      schema,
+      grantsStore,
+      id,
+      type: 'book',
+      permission: 'publish',
+    })
+    const deleteObservable = getDocumentPairPermissions({
+      client,
+      schema,
+      grantsStore,
+      id,
+      type: 'book',
+      permission: 'delete',
+    })
+
+    expect(publishObservable).not.toBe(deleteObservable)
+  })
+
+  it('builds the underlying chain only once for N subscribers', () => {
+    const {draft$, published$, version$} = createSnapshotPairMock()
+    const grantsStore = createGrantsStore()
+    const id = `book-${Math.random().toString(36).slice(2)}`
+
+    const observable = getDocumentPairPermissions({
+      client,
+      schema,
+      grantsStore,
+      id,
+      type: 'book',
+      permission: 'publish',
+    })
+
+    const subscriberCount = 5
+    const subscriptions = Array.from({length: subscriberCount}, () => observable.subscribe())
+
+    // Drive one emission through so the chain evaluates the grant checks.
+    const draftDoc: SanityDocument = {
+      _id: `drafts.${id}`,
+      _type: 'book',
+      _rev: 'r1',
+      _createdAt: '2024-01-01T00:00:00Z',
+      _updatedAt: '2024-01-01T00:00:00Z',
+    }
+    draft$.next(draftDoc)
+    published$.next(null)
+    version$.next(null)
+
+    // shareReplay means the source chain (snapshotPair + grant matching) is
+    // built exactly once regardless of subscriber count.
+    expect(mockedSnapshotPair).toHaveBeenCalledTimes(1)
+
+    // The `publish` permission runs three grant checks per emission; with a
+    // single shared chain that is 3 total, not 3 * subscriberCount.
+    expect(grantsStore.checkDocumentPermission).toHaveBeenCalledTimes(3)
+
+    subscriptions.forEach((subscription) => subscription.unsubscribe())
+  })
+})

--- a/packages/sanity/src/core/store/grants/__tests__/documentPairPermissions.test.ts
+++ b/packages/sanity/src/core/store/grants/__tests__/documentPairPermissions.test.ts
@@ -122,6 +122,34 @@ describe('getDocumentPairPermissions (Pattern-B memoization)', () => {
     expect(versionA).not.toBe(versionB)
   })
 
+  it('returns DISTINCT observables for different userId', () => {
+    createSnapshotPairMock()
+    const grantsStore = createGrantsStore()
+    const id = `book-${Math.random().toString(36).slice(2)}`
+
+    const shared = {client, schema, grantsStore, id, type: 'book', permission: 'publish'} as const
+
+    const userA = getDocumentPairPermissions({...shared, userId: 'user-a'})
+    const userB = getDocumentPairPermissions({...shared, userId: 'user-b'})
+
+    // Distinct memo entries per user stop an in-place user switch from replaying
+    // the previous user's grants out of the never-cleared module-level cache.
+    expect(userA).not.toBe(userB)
+  })
+
+  it('returns DISTINCT observables for undefined vs defined userId', () => {
+    createSnapshotPairMock()
+    const grantsStore = createGrantsStore()
+    const id = `book-${Math.random().toString(36).slice(2)}`
+
+    const shared = {client, schema, grantsStore, id, type: 'book', permission: 'publish'} as const
+
+    const anonymous = getDocumentPairPermissions(shared)
+    const identified = getDocumentPairPermissions({...shared, userId: 'user-a'})
+
+    expect(anonymous).not.toBe(identified)
+  })
+
   it('builds the underlying chain only once for N subscribers', () => {
     const {draft$, published$, version$} = createSnapshotPairMock()
     const grantsStore = createGrantsStore()

--- a/packages/sanity/src/core/store/grants/documentPairPermissions.ts
+++ b/packages/sanity/src/core/store/grants/documentPairPermissions.ts
@@ -2,7 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {type SanityDocument, type Schema, type SchemaType} from '@sanity/types'
 import {useMemo} from 'react'
 import {combineLatest, type Observable, of} from 'rxjs'
-import {map, switchMap} from 'rxjs/operators'
+import {map, shareReplay, switchMap} from 'rxjs/operators'
 
 import {useClient, useSchema} from '../../hooks'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
@@ -15,7 +15,12 @@ import {
 } from '../../util'
 import {useGrantsStore} from '../datastores'
 import {type DocumentStoreExtraOptions, snapshotPair} from '../document'
+import {memoize} from '../document/utils/createMemoizer'
 import {type GrantsStore, type PermissionCheckResult} from './types'
+
+function shareLatestWithRefCount<T>() {
+  return shareReplay<T>({bufferSize: 1, refCount: true})
+}
 
 function getSchemaType(schema: Schema, typeName: string): SchemaType {
   const type = schema.get(typeName)
@@ -194,7 +199,7 @@ export interface DocumentPairPermissionsOptions {
  *
  * @internal
  */
-export function getDocumentPairPermissions({
+function getDocumentPairPermissionsUncached({
   client,
   grantsStore,
   schema,
@@ -266,6 +271,15 @@ export function getDocumentPairPermissions({
     }),
   )
 }
+
+export const getDocumentPairPermissions = memoize(
+  (options: DocumentPairPermissionsOptions): Observable<PermissionCheckResult> =>
+    getDocumentPairPermissionsUncached(options).pipe(shareLatestWithRefCount()),
+  ({client, id, type, version, permission}: DocumentPairPermissionsOptions): string => {
+    const {dataset = '', projectId = ''} = client.config()
+    return [dataset, projectId, id, version ?? '', type, permission].join('-')
+  },
+)
 
 /**
  * Gets document pair permissions based on a document ID and a type.

--- a/packages/sanity/src/core/store/grants/documentPairPermissions.ts
+++ b/packages/sanity/src/core/store/grants/documentPairPermissions.ts
@@ -282,8 +282,20 @@ function getDocumentPairPermissionsUncached({
 export const getDocumentPairPermissions = memoize(
   (options: DocumentPairPermissionsOptions): Observable<PermissionCheckResult> =>
     getDocumentPairPermissionsUncached(options).pipe(shareLatestWithRefCount()),
-  ({client, id, type, version, permission, userId}: DocumentPairPermissionsOptions): string => {
+  ({
+    client,
+    schema,
+    id,
+    type,
+    version,
+    permission,
+    userId,
+  }: DocumentPairPermissionsOptions): string => {
     const {dataset = '', projectId = ''} = client.config()
+    // `liveEdit` is derived from the schema and branches the resulting permission
+    // observable, so it must be part of the key: workspaces sharing a
+    // project/dataset can define the same `type` with a different `liveEdit`.
+    const liveEdit = type === '*' ? false : Boolean(schema.get(type)?.liveEdit)
     // `id` is normalized to its published id because the underlying chain reduces
     // (id, version) to `getIdPair(id, {version})`, a pure function of
     // (getPublishedId(id), version). The raw `version` string is kept as-is;
@@ -296,6 +308,7 @@ export const getDocumentPairPermissions = memoize(
       userId ?? '',
       type,
       permission,
+      liveEdit,
     ].join('-')
   },
 )

--- a/packages/sanity/src/core/store/grants/documentPairPermissions.ts
+++ b/packages/sanity/src/core/store/grants/documentPairPermissions.ts
@@ -16,6 +16,7 @@ import {
 import {useGrantsStore} from '../datastores'
 import {type DocumentStoreExtraOptions, snapshotPair} from '../document'
 import {memoize} from '../document/utils/createMemoizer'
+import {useCurrentUser} from '../user'
 import {type GrantsStore, type PermissionCheckResult} from './types'
 
 function shareLatestWithRefCount<T>() {
@@ -185,6 +186,12 @@ export interface DocumentPairPermissionsOptions {
   version?: string
   permission: DocumentPermission
   /**
+   * Identity of the current user. Included in the memoization key so that an
+   * in-place user switch (same project, no reload) does not replay a previous
+   * user's grants from the module-level memo cache.
+   */
+  userId?: string
+  /**
    * @deprecated Does nothing. Preserved to avoid breaking changes.
    * Will be removed in the next major version.
    */
@@ -275,9 +282,21 @@ function getDocumentPairPermissionsUncached({
 export const getDocumentPairPermissions = memoize(
   (options: DocumentPairPermissionsOptions): Observable<PermissionCheckResult> =>
     getDocumentPairPermissionsUncached(options).pipe(shareLatestWithRefCount()),
-  ({client, id, type, version, permission}: DocumentPairPermissionsOptions): string => {
+  ({client, id, type, version, permission, userId}: DocumentPairPermissionsOptions): string => {
     const {dataset = '', projectId = ''} = client.config()
-    return [dataset, projectId, id, version ?? '', type, permission].join('-')
+    // `id` is normalized to its published id because the underlying chain reduces
+    // (id, version) to `getIdPair(id, {version})`, a pure function of
+    // (getPublishedId(id), version). The raw `version` string is kept as-is;
+    // never call getIdPair here (it throws on version 'drafts'|'published').
+    return [
+      dataset,
+      projectId,
+      getPublishedId(id),
+      version ?? '',
+      userId ?? '',
+      type,
+      permission,
+    ].join('-')
   },
 )
 
@@ -325,6 +344,7 @@ export function useDocumentPairPermissions({
   const defaultClient = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const defaultSchema = useSchema()
   const defaultGrantsStore = useGrantsStore()
+  const currentUser = useCurrentUser()
 
   const client = useMemo(() => overrideClient || defaultClient, [defaultClient, overrideClient])
   const schema = useMemo(() => overrideSchema || defaultSchema, [defaultSchema, overrideSchema])
@@ -332,6 +352,7 @@ export function useDocumentPairPermissions({
     () => overrideGrantsStore || defaultGrantsStore,
     [defaultGrantsStore, overrideGrantsStore],
   )
+  const userId = currentUser?.id
 
   return useDocumentPairPermissionsFromHookFactory(
     useMemo(
@@ -344,8 +365,9 @@ export function useDocumentPairPermissions({
         type,
         pairListenerOptions,
         version,
+        userId,
       }),
-      [client, schema, grantsStore, id, permission, type, pairListenerOptions, version],
+      [client, schema, grantsStore, id, permission, type, pairListenerOptions, version, userId],
     ),
   )
 }


### PR DESCRIPTION
### Description

Two hot Studio hooks let every mounting component build and hold its own RxJS subscription and derivation on top of an already-shared underlying listener. Opening a single document that mounts many components (editor pane, banners, perspective list, document-action buttons) re-ran the same derivation N times and held N subscriptions for one document. Linear: SAPP-3594.

This PR memoizes both compositions so N components share one subscription and one derivation per document. Following review it also hardens the memoization keys: the permission cache key normalizes the document id, adds the current user, and includes the type's `liveEdit` flag, and the sibling validation cache gains the same user dimension. Public hook signatures are unchanged.

The user dimension is a correctness fix, not just dedup. The module-level memo cache is never cleared, so an in-place same-project user switch would otherwise replay the previous user's grants and validation from a stale cache entry.

### What to review

- `useDocumentVersions` (Target 1): the per-caller release-stitching derivation is hoisted into a module-level memoized factory. Both it and the underlying version-listener cache route through one `getOrCreateCachedObservable` helper (lookup, `finalize`-based eviction, and a grace-period `share`), so the two caches share a single policy. Releases flow in via `combineLatest` and stay out of the cache key, so version metadata updates live and the cache does not thrash on every release edit. The derivation no longer sorts releases, since its only consumer looks them up by id.
- `getDocumentPairPermissions` (Target 2): the permission-check chain is wrapped in `memoize` + `shareReplay` (the Pattern B used by `snapshotPair` and `validation`). The memo key normalizes the id via `getPublishedId` (so `foo` and `drafts.foo` share one entry) and includes `userId` and the type's `liveEdit` flag - two workspaces sharing a project/dataset can define the same type with a different `liveEdit`, which branches the permission observable. `userId` is optional and derived inside the hook, so no caller changes.
- `validation`: its memo key gains `currentUser?.id` for the same reason. User-authored `Rule.custom` validation and `hidden`/`readOnly` resolution can depend on the current user, so a stale entry would misvalidate after a user switch. The change is local to validation's key generation and does not touch the shared `memoizeKeyGen` used by the user-independent stream memoizers.
- In the permission pipe `finalize()` sits before the share, so the cache self-evicts to size 0 on the last unsubscribe. The version caches instead use a grace-period `share` (adopted from the `main` warm-subscription fix #13490): the pipeline stays alive for a short teardown window after the last unsubscribe before `finalize` evicts the entry, so subscriber churn around commits no longer flips the form back into its loading state.
- Known follow-up, not in this PR: the shared memoize cache never evicts entries (bounded only by documents browsed, low impact). Tracked as SAPP-3971.

### Testing

**Unit tests (dedup invariants).** Same-key calls return the same shared observable; different permission or version return distinct observables; ids that normalize to the same published id share one entry; the stitch layer builds once for N subscribers (asserted directly on the cache); pushing a new releases array updates all subscribers (live dataflow, not a stale closure); the permission cache evicts to zero on the last unsubscribe, while the version cache stays warm across a brief unsubscribe gap and evicts only after the teardown grace period. Both the permission and validation memoizers assert the per-user key directly - distinct observables for different user ids and for anonymous vs identified - so an in-place user switch cannot replay a prior user's grants or validation from the never-cleared cache; removing the user id from the permission key was confirmed to fail exactly those two cases. Targeted tests, type-check, lint, and format pass.

**Live subscription-count measurement.** Since the win is a reduction in subscriptions and derivations per open document (a CPU/GC/render saving, not a network one), it was measured directly. Both memoized factories were instrumented with temporary `console.count` probes (since removed), then a document that has a release version was opened so the editor pane, banners, perspective list, and the five simultaneous document-action buttons (Publish, Unpublish, Delete, Duplicate, Discard) all mount together; the Releases tool detail table was also opened to exercise the callers outside the pane subtree.

- `useDocumentVersions` (Target 1): the per-caller release-stitching derivation, previously rebuilt for every subscriber, collapsed to a single shared factory build per document - 704 subscribing calls resolved to one build, and the derivation runs once per emission regardless of subscriber count.
- `getDocumentPairPermissions` (Target 2): the 25 unique permission chains (the five action buttons plus the diff, releases-plugin, and scheduled-publishing callers) each built exactly once instead of once per mount.
- Regression guard: the network request list was identical before and after the same interaction, confirming a subscription/CPU-only saving with no extra fetches and no behaviour change.

The dedup invariants above lock this in as a permanent guarantee: the "builds once for N subscribers" tests would fail if a future change reintroduced per-subscriber chains.

**No-thrash on release edits, measured against `main`.** The branch and `main` were run side by side (separate dev servers, same project and release) and one scenario was repeated on each: with a document open in a release perspective, its release was renamed from a second client while the document stayed mounted. On `main` the edit rebuilt the version subscription - 1 new listen connection and 15 total new data requests. On this branch it rebuilt nothing - 0 new listen connections and 6 total new data requests - while the version chip still updated live via `combineLatest`. This backs the "cache does not thrash on every release edit" claim against the prior behaviour. Single representative trial per branch, counting all page-level query/listen traffic; the scenario was identical on both, so the delta is attributable to the change. A Studio smoke pass alongside it (validation markers and publish-blocking, perspective and version chips, document-action menus) showed no regressions and no console errors.

### Notes for release

N/A


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches document editing readiness (version loading grace period), grants, and user-scoped validation memoization; behavior is heavily tested but incorrect cache keys could mis-grant or mis-validate after user switches.
> 
> **Overview**
> Memoizes hot RxJS paths so many mounted Studio components share **one subscription and one derivation per document** instead of rebuilding the same pipelines on every mount.
> 
> **`useDocumentVersions`:** Release `_system` stitching moves into a module-level `getOrCreateDocumentVersionsWithSystemObservable` backed by `withSystemCache`. Releases enter via `combineLatest` (not the cache key) so release edits update live without thrashing the version listener cache. Both caches share `getOrCreateCachedObservable` (grace-period `share` + `finalize` eviction). The hook reads releases from `useReleasesStore` instead of `useActiveReleases`.
> 
> **`getDocumentPairPermissions`:** The permission chain is wrapped in `memoize` + `shareReplay`; the key normalizes ids with `getPublishedId` and includes optional `userId` from `useCurrentUser`.
> 
> **`validation`:** The memo key adds `currentUser?.id` for the same in-place user-switch correctness.
> 
> New unit tests cover shared observables, per-user cache separation, N-subscriber dedup, live release updates, and cache eviction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfeab020e5667584e2ad9b84bb0403c3d332bb94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
