### PR TITLE
test(efps): wait for each keystroke to register before typing next

### DIFF
--- a/dev/efps/helpers/measureBlockingTime.ts
+++ b/dev/efps/helpers/measureBlockingTime.ts
@@ -3,9 +3,10 @@ import {type Page} from 'playwright'
 const BLOCKING_TASK_THRESHOLD = 50
 
 export function measureBlockingTime(page: Page): () => Promise<number> {
-  const idleGapLengthsPromise = page.evaluate(
-    // Had to add this so we can run the tests
-    new Function(`
+  const idleGapLengthsPromise = page
+    .evaluate(
+      // Had to add this so we can run the tests
+      new Function(`
     return (async function() {
       const idleGapLengths = []
       const done = false
@@ -29,14 +30,23 @@ export function measureBlockingTime(page: Page): () => Promise<number> {
       return idleGapLengths
     })()
   `) as () => Promise<number[]>,
-  )
+    )
+    // This evaluate starts running immediately (before it is awaited in
+    // `getBlockingTime`). If the page/context is torn down first — e.g. the
+    // A/B harness closes browsers after one side fails — this promise would
+    // otherwise reject with no handler attached, surfacing as an *unhandled
+    // rejection* that crashes the whole process and bypasses the per-attempt
+    // retry machinery. Swallow that here so the failure stays catchable.
+    .catch((): number[] => [])
 
   async function getBlockingTime() {
-    await page.evaluate(
-      new Function(`
+    await page
+      .evaluate(
+        new Function(`
       document.dispatchEvent(new CustomEvent('__blockingTimeFinish'))
     `) as () => void,
-    )
+      )
+      .catch(() => {})
 
     const idleGapLengths = await idleGapLengthsPromise
 

--- a/dev/efps/helpers/measureFpsForInput.ts
+++ b/dev/efps/helpers/measureFpsForInput.ts
@@ -3,6 +3,7 @@ import {type Page} from 'playwright'
 import {type EfpsResult} from '../types'
 import {aggregateLatencies} from './aggregateLatencies'
 import {measureBlockingTime} from './measureBlockingTime'
+import {setUpMarkers, typeCharacterReliably} from './typeCharacterReliably'
 
 interface MeasureFpsForInputOptions {
   label?: string
@@ -78,6 +79,12 @@ export async function measureFpsForInput({
       el: HTMLInputElement | HTMLTextAreaElement,
     ) => Promise<{value: string; timestamp: number}[]>,
   )
+  // This evaluate runs until the field blurs and is only awaited later. If the
+  // context is torn down first — the A/B harness closes both browsers once one
+  // side settles — this promise would reject with no handler attached, an
+  // *unhandled rejection* that crashes the process and bypasses retries.
+  // Swallow that here so a failing run stays catchable.
+  const safeRendersPromise = rendersPromise.catch((): {value: string; timestamp: number}[] => [])
   await new Promise((resolve) => setTimeout(resolve, 500))
 
   const inputEvents: {character: string; timestamp: number}[] = []
@@ -85,20 +92,34 @@ export async function measureFpsForInput({
   const startingMarker = '__START__|'
   const endingMarker = '__END__'
 
-  await input.pressSequentially(endingMarker)
-  await new Promise((resolve) => setTimeout(resolve, 500))
-  for (let i = 0; i < endingMarker.length; i++) {
-    await input.press('ArrowLeft')
-  }
-  await input.pressSequentially(startingMarker)
+  await setUpMarkers({
+    page,
+    input,
+    startingMarker,
+    endingMarker,
+    getValue: () => input.inputValue(),
+    timeout,
+    clearFirst: true,
+  })
   await new Promise((resolve) => setTimeout(resolve, 500))
 
   const getBlockingTime = measureBlockingTime(page)
 
   for (const character of characters) {
-    inputEvents.push({character, timestamp: Date.now()})
-    await input.pressSequentially(character)
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    // Type the character and confirm it registered before moving on, retrying
+    // if it was swallowed by a transient read-only flip. The returned timestamp
+    // is the moment the landing keystroke was dispatched, so a retried
+    // character's latency isn't inflated. See `typeCharacterReliably`.
+    const timestamp = await typeCharacterReliably({
+      page,
+      input,
+      character,
+      startingMarker,
+      endingMarker,
+      getValue: () => input.inputValue(),
+      timeout,
+    })
+    inputEvents.push({character, timestamp})
   }
 
   await input.blur()
@@ -106,7 +127,7 @@ export async function measureFpsForInput({
   await page.evaluate(() => window.document.dispatchEvent(new CustomEvent('__finish')))
 
   const blockingTime = await getBlockingTime()
-  const renderEvents = await rendersPromise
+  const renderEvents = await safeRendersPromise
 
   await new Promise((resolve) => setTimeout(resolve, 500))
 

--- a/dev/efps/helpers/measureFpsForPte.ts
+++ b/dev/efps/helpers/measureFpsForPte.ts
@@ -3,6 +3,7 @@ import {type Page} from 'playwright'
 import {type EfpsResult} from '../types'
 import {aggregateLatencies} from './aggregateLatencies'
 import {measureBlockingTime} from './measureBlockingTime'
+import {setUpMarkers, typeCharacterReliably} from './typeCharacterReliably'
 
 interface MeasureFpsForPteOptions {
   fieldName: string
@@ -74,6 +75,14 @@ export async function measureFpsForPte({
       }[]
     >,
   )
+  // This evaluate runs until the field blurs and is only awaited later. If the
+  // context is torn down first — the A/B harness closes both browsers once one
+  // side settles — this promise would reject with no handler attached, an
+  // *unhandled rejection* that crashes the process and bypasses retries.
+  // Swallow that here so a failing run stays catchable.
+  const safeRendersPromise = rendersPromise.catch(
+    (): {value: string; timestamp: number; textContentProcessingTime: number}[] => [],
+  )
   await new Promise((resolve) => setTimeout(resolve, 500))
 
   const inputEvents: {character: string; timestamp: number}[] = []
@@ -81,25 +90,38 @@ export async function measureFpsForPte({
   const startingMarker = '___START___|'
   const endingMarker = '___END___'
 
-  await contentEditable.pressSequentially(endingMarker)
-  await new Promise((resolve) => setTimeout(resolve, 500))
-  for (let i = 0; i < endingMarker.length; i++) {
-    await contentEditable.press('ArrowLeft')
-  }
-  await contentEditable.pressSequentially(startingMarker)
+  await setUpMarkers({
+    page,
+    input: contentEditable,
+    startingMarker,
+    endingMarker,
+    getValue: async () => (await contentEditable.textContent()) ?? '',
+    timeout,
+  })
   await new Promise((resolve) => setTimeout(resolve, 500))
 
   const getBlockingTime = measureBlockingTime(page)
   for (const character of characters) {
-    inputEvents.push({character, timestamp: Date.now()})
-    await contentEditable.pressSequentially(character)
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    // Type the character and confirm it registered before moving on, retrying
+    // if it was swallowed by a transient read-only flip. The returned timestamp
+    // is the moment the landing keystroke was dispatched, so a retried
+    // character's latency isn't inflated. See `typeCharacterReliably`.
+    const timestamp = await typeCharacterReliably({
+      page,
+      input: contentEditable,
+      character,
+      startingMarker,
+      endingMarker,
+      getValue: async () => (await contentEditable.textContent()) ?? '',
+      timeout,
+    })
+    inputEvents.push({character, timestamp})
   }
 
   await contentEditable.blur()
 
   const blockingTime = await getBlockingTime()
-  const renderEvents = await rendersPromise
+  const renderEvents = await safeRendersPromise
 
   const latencies = inputEvents.map((inputEvent) => {
     const matchingEvent = renderEvents.find(({value}) => {

--- a/dev/efps/helpers/typeCharacterReliably.ts
+++ b/dev/efps/helpers/typeCharacterReliably.ts
@@ -1,0 +1,159 @@
+import {type Locator, type Page} from 'playwright'
+
+/**
+ * The eFPS harness measures render latency by typing a run of characters into a
+ * field, bracketed by two marker strings, and matching each character to a
+ * render event where it appears *between* the markers.
+ *
+ * The catch: the Studio document form can briefly flip to read-only mid-typing
+ * (e.g. while an async subscription such as `useDocumentVersions` resolves and
+ * re-renders the pane). A keystroke dispatched during that window is silently
+ * swallowed — and worse, the caret jumps to the end of the field, so naively
+ * re-typing lands the character in the wrong place. Left unhandled this
+ * surfaced as the flaky "No matching event" failure, and it can also corrupt
+ * the markers themselves if the flip lands during marker setup.
+ *
+ * The helpers here make both the marker setup and the measured typing resilient
+ * to that flip: type only while the form is editable, verify each character
+ * actually landed where expected, and retry (re-placing the caret) if not.
+ */
+
+const ATTEMPT_TIMEOUT = 2_000
+const MAX_ATTEMPTS = 10
+
+/**
+ * Types the ending and starting markers with the caret positioned between them,
+ * retrying until both markers are present in the value. Must be robust to the
+ * read-only flip landing during setup (which would otherwise leave the markers
+ * mangled and every subsequent match failing).
+ */
+export async function setUpMarkers({
+  page,
+  input,
+  startingMarker,
+  endingMarker,
+  getValue,
+  timeout,
+  clearFirst = false,
+}: {
+  page: Page
+  input: Locator
+  startingMarker: string
+  endingMarker: string
+  getValue: () => Promise<string>
+  timeout: number
+  /**
+   * Clear the field before typing the markers. Safe for single-value inputs
+   * (which start empty); must stay off for the Portable Text editor, whose
+   * value is pre-existing document prose the markers are typed into.
+   */
+  clearFirst?: boolean
+}): Promise<void> {
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    await waitForEditable(page, timeout)
+
+    if (clearFirst) {
+      // Start from a clean field so a partial previous attempt can't corrupt
+      // the markers (e.g. `_ENaD__` from a flip mid-setup).
+      await input.press('ControlOrMeta+a')
+      await input.press('Delete')
+    }
+
+    await input.pressSequentially(endingMarker)
+    for (let i = 0; i < endingMarker.length; i++) await input.press('ArrowLeft')
+    await input.pressSequentially(startingMarker)
+
+    const deadline = Date.now() + ATTEMPT_TIMEOUT
+    for (;;) {
+      const value = await getValue()
+      if (value.includes(startingMarker) && value.includes(endingMarker)) return
+      if (Date.now() >= deadline) break
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+  }
+
+  throw new Error(
+    `Failed to set up markers after ${MAX_ATTEMPTS} attempts ` +
+      `(last value: ${JSON.stringify(await getValue())})`,
+  )
+}
+
+/**
+ * Types a single character and confirms it registered by polling the value
+ * until the character appears *between* the markers, retrying if it was
+ * swallowed by a read-only flip.
+ *
+ * The between-markers check matters because the value can contain the character
+ * elsewhere — the markers themselves include letters (e.g. `S`, `T`, `A`, `R`
+ * in `__START__`), and a rich-text field's value includes any pre-existing
+ * document prose.
+ *
+ * Returns the timestamp of the keystroke that actually landed, so a retried
+ * character's measured latency isn't inflated by the time spent waiting out the
+ * read-only flip.
+ */
+export async function typeCharacterReliably({
+  page,
+  input,
+  character,
+  startingMarker,
+  endingMarker,
+  getValue,
+  timeout,
+}: {
+  page: Page
+  input: Locator
+  character: string
+  startingMarker: string
+  endingMarker: string
+  getValue: () => Promise<string>
+  timeout: number
+}): Promise<number> {
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    // Only type while the form is editable — typing during a read-only flip
+    // drops the keystroke and moves the caret.
+    await waitForEditable(page, timeout)
+
+    // On a retry the caret may have moved (a swallowed keystroke sends it to
+    // the end of the field). Re-place it between the markers before typing.
+    if (attempt > 0) {
+      await input.press('End')
+      for (let i = 0; i < endingMarker.length; i++) await input.press('ArrowLeft')
+    }
+
+    const timestamp = Date.now()
+    await input.pressSequentially(character)
+
+    const deadline = Date.now() + ATTEMPT_TIMEOUT
+    for (;;) {
+      if (containsBetweenMarkers(await getValue(), character, startingMarker, endingMarker)) {
+        return timestamp
+      }
+      if (Date.now() >= deadline) break
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+  }
+
+  throw new Error(
+    `Failed to type ${JSON.stringify(character)} after ${MAX_ATTEMPTS} attempts ` +
+      `(last value: ${JSON.stringify(await getValue())})`,
+  )
+}
+
+function waitForEditable(page: Page, timeout: number): Promise<void> {
+  return page
+    .locator('[data-testid="form-view"]:not([data-read-only="true"])')
+    .waitFor({state: 'visible', timeout})
+}
+
+function containsBetweenMarkers(
+  value: string,
+  character: string,
+  startingMarker: string,
+  endingMarker: string,
+): boolean {
+  if (!value.includes(startingMarker) || !value.includes(endingMarker)) return false
+  const [, afterStartingMarker] = value.split(startingMarker)
+  const [beforeEndingMarker] = afterStartingMarker.split(endingMarker)
+  return beforeEndingMarker.includes(character)
+}


### PR DESCRIPTION
### Description

eFPS CI began failing on nearly every PR from 2026-06-30 ~16:48 UTC with `No matching event for <char>`, on both A/B sides — because both build from `main`, and the trigger landed there.

Root cause (observed via an instrumented Playwright run): the document form briefly flips read-only mid-typing while the `useDocumentVersions` subscription resolves, silently swallowing a keystroke and moving the caret to the field end. The harness never confirmed each keystroke landed, so the dropped char had no matching render event. That subscription was added to `DocumentPaneProvider`/`DocumentPanel` by the "restore variant documents" change deployed ~90s before the first failure.

Fix: type only while the form is editable (both marker setup and each keystroke), verify each char landed *between* the markers, and retry with caret re-placement if not. Also guard the render-events and blocking-time `page.evaluate` promises with `.catch` — created early, awaited late, they rejected uncaught when the harness closed browsers after one side settled, crashing the process (`Target page … closed`) and bypassing retries.

Ruled out: a fixed per-char delay (still flaked), the Playwright 1.61.1 bump (version-independent), and poll-then-retry-in-place (caret had moved, so retries landed after the marker).

### What to review

- `dev/efps/helpers/typeCharacterReliably.ts` (new) — editable-gate, between-markers match, caret re-placement on retry.
- `measureFpsForInput.ts` / `measureFpsForPte.ts` — use the helper; `.catch` on `rendersPromise` (PTE passes `clearFirst: false`, its value is real prose).
- `measureBlockingTime.ts` — `.catch` guards.
- Harness only; no product code.

### Testing

Repro under CPU throttling (which reliably induces the flip): 8/8 at 4x, 10/10 at 6x, flip firing every trial. eFPS CI green across all 3 shards.

### Notes for release

N/A – Internal tooling only (eFPS harness).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to internal eFPS harness helpers; no product or Studio runtime behavior is modified.
> 
> **Overview**
> Fixes flaky eFPS **"No matching event"** failures by making the Playwright typing harness wait for an editable form, confirm each keystroke landed between the markers, and retry with caret re-placement when Studio briefly goes read-only mid-run.
> 
> Adds **`typeCharacterReliably.ts`** with `setUpMarkers` and `typeCharacterReliably`, used by **`measureFpsForInput`** and **`measureFpsForPte`** instead of blind `pressSequentially` loops. Input fields clear before marker setup (`clearFirst: true`); PTE keeps existing prose (`clearFirst` omitted). Keystroke timestamps come from the attempt that actually registered, so retries do not inflate latency.
> 
> **`measureBlockingTime`** and the long-lived render **`evaluate`** promises now use **`.catch`** so browser/context teardown during A/B harness shutdown does not surface as unhandled rejections that crash the process and skip per-attempt retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a16c4fc8b1085efdeb0bbbea3d90c309357e170d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->