### PR TITLE
fix(core): force logout only on 401s tagged as session expiry

### DIFF
--- a/dev/test-studio/plugins/error-reporting-test/ErrorReportingTest.tsx
+++ b/dev/test-studio/plugins/error-reporting-test/ErrorReportingTest.tsx
@@ -431,8 +431,9 @@ function RequestErrorsDemo() {
         const cerr = err as ClientError & {statusCode?: number}
         setResult(
           label,
-          `401 propagated to local catch: statusCode=${cerr.statusCode ?? '?'}. The studio ` +
-            `verified your real session via /auth/id and found it valid, so no forced logout.`,
+          `401 propagated to local catch: statusCode=${cerr.statusCode ?? '?'}. The 401 is not ` +
+            `tagged with the API's session-expiry code (SIO-401-AEX), so the studio treats it ` +
+            `as a resource-level denial — no forced logout.`,
         )
       }
     },
@@ -518,20 +519,21 @@ function RequestErrorsDemo() {
         result: results['Local handling only (no reporter)'],
       },
       {
-        label: '401 via reporter · verified, then propagated',
+        label: '401 via reporter · not session expiry, propagated',
         description: (
           <>
             Real 401 from <InlineCode>/users/me</InlineCode> using a bogus token, delegated via{' '}
-            <InlineCode>attempt()</InlineCode>. The studio probes <InlineCode>/auth/id</InlineCode>{' '}
-            with your real (valid) session → resource-level 401 → propagated to the local catch.{' '}
+            <InlineCode>attempt()</InlineCode>. The studio only claims 401s the API tags with its
+            session-expiry code (<InlineCode>SIO-401-AEX</InlineCode>); this one isn&apos;t tagged →
+            resource-level denial → propagated to the local catch.{' '}
             <Text as="span" weight="semibold">
               You will NOT be logged out.
             </Text>
           </>
         ),
-        onClick: () => triggerUnauthorized('401 via reporter · verified, then propagated'),
+        onClick: () => triggerUnauthorized('401 via reporter · not session expiry, propagated'),
         tone: 'caution',
-        result: results['401 via reporter · verified, then propagated'],
+        result: results['401 via reporter · not session expiry, propagated'],
       },
       {
         label: 'CORS misconfig · origin not allowed',

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -474,7 +474,7 @@ export default defineConfig([
     name: 'staging',
     title: 'Staging',
     subtitle: 'Staging dataset',
-    projectId: 'deadbeef',
+    projectId: 'exx11uqh',
     dataset: 'playground',
     ...envConfig.staging,
     plugins: [sharedSettings({projectId: 'exx11uqh'})],

--- a/packages/sanity/src/_singletons/context/LoggedOutReasonContext.ts
+++ b/packages/sanity/src/_singletons/context/LoggedOutReasonContext.ts
@@ -5,9 +5,12 @@ import {createContext} from 'sanity/_createContext'
  * banner above the login form. `undefined` when the logged-out state isn't the
  * result of a forced logout (e.g. a normal cold load with no session).
  *
+ * Currently a single-member union: forced logout only happens on API-tagged
+ * session expiry (`SIO-401-AEX`). Kept as a union so future reasons slot in.
+ *
  * @internal
  */
-export type LoggedOutReason = 'session-expired' | 'unauthorized'
+export type LoggedOutReason = 'session-expired'
 
 /** @internal */
 export const LoggedOutReasonContext = createContext<LoggedOutReason | undefined>(

--- a/packages/sanity/src/core/store/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/authStore/createAuthStore.ts
@@ -21,7 +21,7 @@ import {
 
 import {type AuthConfig} from '../../config/auth/types'
 import {isStaging} from '../../environment/isStaging'
-import {isUnauthorizedError} from '../../studio/requestErrors/classify'
+import {isNetworkError, isUnauthorizedError} from '../../studio/requestErrors/classify'
 import {
   type RequestFailureProbe,
   type RequestFailureResult,
@@ -177,10 +177,15 @@ const getCurrentUser = async (
     return typeof user?.id === 'string' ? user : undefined
   } catch (err) {
     // Reached only in the no-channel fallback path, or for errors the
-    // channel declined to claim.
-    if (err.isNetworkError && !err.message && err.request && err.request.url) {
-      const host = new URL(err.request.url).host
-      throw new Error(`Unknown network error attempting to reach ${host}`, {cause: err})
+    // channel declined to claim. Guarded: a thrown value can be anything,
+    // so don't touch properties until it's confirmed to be a network error.
+    if (isNetworkError(err) && !err.message) {
+      const url = (err as Error & {request?: {url?: string}}).request?.url
+      if (url) {
+        throw new Error(`Unknown network error attempting to reach ${new URL(url).host}`, {
+          cause: err,
+        })
+      }
     }
 
     // Some other error, just throw it

--- a/packages/sanity/src/core/store/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/document/document-pair/checkoutPair.ts
@@ -246,8 +246,15 @@ function submitCommitRequest(
       // are transient: fail, so the mutator keeps the buffer and retries
       // with backoff. Note `< 500` — 500 itself is a server error and
       // must retry, not cancel.
+      // `error` can be any thrown value — guard before using `in`, which
+      // throws on primitives.
       const statusCode =
-        'statusCode' in error && typeof error.statusCode === 'number' ? error.statusCode : undefined
+        typeof error === 'object' &&
+        error !== null &&
+        'statusCode' in error &&
+        typeof error.statusCode === 'number'
+          ? error.statusCode
+          : undefined
       const isTerminalClientError =
         statusCode !== undefined && statusCode >= 400 && statusCode < 500 && statusCode !== 429
       if (isTerminalClientError) {

--- a/packages/sanity/src/core/studio/requestErrors/RequestErrorDialog.tsx
+++ b/packages/sanity/src/core/studio/requestErrors/RequestErrorDialog.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable i18next/no-literal-string */
 import {LaunchIcon} from '@sanity/icons'
 import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
-import {useCallback, useEffect, useState} from 'react'
+import {startTransition, useCallback, useEffect, useState} from 'react'
 
 import {Dialog} from '../../../ui-components'
 import {type RequestErrorClaim} from './types'
@@ -53,9 +53,9 @@ export function useRetryCountdown(claim: {retryAfterSeconds?: number}): number {
     const initial = claim.retryAfterSeconds ?? 0
     // Reset the countdown when a new claim arrives (a re-rate-limited retry
     // produces a fresh claim with a new Retry-After). Intentional derived-state
-    // sync driven by the external claim, not a render cascade.
-    // oxlint-disable-next-line react/react-compiler
-    setSecondsLeft(initial)
+    // sync driven by the external claim, not a render cascade — deferred via
+    // startTransition so React can schedule the resulting re-render lazily.
+    startTransition(() => setSecondsLeft(initial))
     if (initial <= 0) return undefined
     const id = setInterval(() => {
       setSecondsLeft((current) => {
@@ -171,9 +171,9 @@ function RateLimitedDialog(props: {
   const [retrying, setRetrying] = useState(false)
   useEffect(() => {
     // A new claim object means the in-flight retry concluded — clear the
-    // disabled state. Intentional sync to the external claim, not a cascade.
-    // oxlint-disable-next-line react/react-compiler
-    setRetrying(false)
+    // disabled state. Intentional sync to the external claim, not a cascade —
+    // deferred via startTransition so React can schedule the re-render lazily.
+    startTransition(() => setRetrying(false))
   }, [claim])
   const handleRetry = useCallback(() => {
     setRetrying(true)

--- a/packages/sanity/src/core/studio/requestErrors/__tests__/requestErrors.test.ts
+++ b/packages/sanity/src/core/studio/requestErrors/__tests__/requestErrors.test.ts
@@ -7,6 +7,7 @@ import {
   classifyConfigError,
   classifyRequestError,
   getApiErrorCode,
+  isSessionExpiredError,
   parseRetryAfter,
 } from '../classify'
 import {createRequestErrorChannel, passthroughErrorHandler} from '../createRequestErrorChannel'
@@ -99,7 +100,8 @@ describe('classifyRequestError', () => {
   it('leaves caller-domain 4xx unclassified', () => {
     expect(classifyRequestError(clientErrorWith({statusCode: 403}))).toBeNull()
     expect(classifyRequestError(clientErrorWith({statusCode: 404}))).toBeNull()
-    // 401 is handled directly by the channel (→ forced logout), not classified here
+    // 401 is handled directly by the channel (forced logout when tagged
+    // SIO-401-AEX, re-thrown otherwise), not classified here
     expect(classifyRequestError(clientErrorWith({statusCode: 401}))).toBeNull()
   })
 
@@ -167,6 +169,30 @@ describe('classifyConfigError', () => {
       ),
     ).toBeNull()
     expect(classifyConfigError(new Error('nope'))).toBeNull()
+  })
+})
+
+describe('isSessionExpiredError', () => {
+  it('matches a 401 carrying the SIO-401-AEX code', () => {
+    const err = clientErrorWith({
+      statusCode: 401,
+      body: {error: 'Unauthorized', errorCode: 'SIO-401-AEX'},
+    })
+    expect(isSessionExpiredError(err)).toBe(true)
+  })
+
+  it('rejects a 401 without the code (resource-level denial)', () => {
+    expect(isSessionExpiredError(clientErrorWith({statusCode: 401}))).toBe(false)
+    expect(
+      isSessionExpiredError(clientErrorWith({statusCode: 401, body: {error: 'Unauthorized'}})),
+    ).toBe(false)
+  })
+
+  it('rejects non-401s and non-client errors', () => {
+    expect(
+      isSessionExpiredError(clientErrorWith({statusCode: 403, body: {errorCode: 'SIO-401-AEX'}})),
+    ).toBe(false)
+    expect(isSessionExpiredError(new Error('nope'))).toBe(false)
   })
 })
 
@@ -313,12 +339,14 @@ describe('createRequestErrorChannel', () => {
   })
 
   describe('401 handling', () => {
-    it('claims a 401 as unauthorized (forced logout follows), tagged with the projectId', async () => {
-      // A 401 means the session is gone — resource denials are 403s, which
-      // are caller-domain and never reach here.
+    const expiredSessionError = () =>
+      clientErrorWith({statusCode: 401, body: {error: 'Unauthorized', errorCode: 'SIO-401-AEX'}})
+
+    it('claims an expired-session 401 as unauthorized (forced logout follows), tagged with the projectId', async () => {
+      // Every endpoint tags session-expiry 401s with `SIO-401-AEX` — that
+      // positive signal is what drives the forced logout.
       const channel = createRequestErrorChannel()
-      const err = clientErrorWith({statusCode: 401})
-      void channel.attempt(() => Promise.reject(err))
+      void channel.attempt(() => Promise.reject(expiredSessionError()))
       await new Promise((resolve) => setTimeout(resolve, 0))
       expect(await latestClaim(channel)).toMatchObject({
         type: 'unauthorized',
@@ -326,12 +354,22 @@ describe('createRequestErrorChannel', () => {
       })
     })
 
-    it('parks concurrent 401s behind a single unauthorized claim', async () => {
+    it('re-throws 401s without the session-expired code (resource-level denials)', async () => {
+      // Some endpoints answer 401 (not 403) for authenticated users lacking
+      // a grant — those must stay caller-domain, not force a logout.
+      const channel = createRequestErrorChannel()
+      const err = clientErrorWith({statusCode: 401})
+      await expect(channel.attempt(() => Promise.reject(err))).rejects.toBe(err)
+      await expect(Promise.reject(err).catch(channel.handle)).rejects.toBe(err)
+      expect(await latestClaim(channel)).toBeUndefined()
+    })
+
+    it('parks concurrent expired-session 401s behind a single unauthorized claim', async () => {
       // The first 401 owns the dialog + logout; later 401s for the same
       // teardown (including the logout request re-401ing) park silently.
       const channel = createRequestErrorChannel()
-      void channel.attempt(() => Promise.reject(clientErrorWith({statusCode: 401})))
-      void channel.attempt(() => Promise.reject(clientErrorWith({statusCode: 401})))
+      void channel.attempt(() => Promise.reject(expiredSessionError()))
+      void channel.attempt(() => Promise.reject(expiredSessionError()))
       await new Promise((resolve) => setTimeout(resolve, 0))
       expect(await latestClaim(channel)).toMatchObject({type: 'unauthorized', projectId: 'abc123'})
     })

--- a/packages/sanity/src/core/studio/requestErrors/classify.ts
+++ b/packages/sanity/src/core/studio/requestErrors/classify.ts
@@ -72,8 +72,8 @@ export type RequestErrorClassification =
  *
  * Note: 401 is intentionally NOT classified here — whether a 401 means
  * "session expired" (studio concern) or "this resource refuses you"
- * (caller concern) requires probing the session, which the channel does
- * separately.
+ * (caller concern) is decided by the API's explicit error code, which the
+ * channel checks separately (see {@link isSessionExpiredError}).
  *
  * @internal
  */
@@ -94,6 +94,19 @@ export function classifyRequestError(err: unknown): RequestErrorClassification |
 /** @internal */
 export function isUnauthorizedError(err: unknown): err is ClientError {
   return err instanceof ClientError && err.statusCode === 401
+}
+
+/**
+ * Whether a 401 positively signals a dead session. Every API endpoint tags
+ * session-expiry 401s with the `SIO-401-AEX` error code; a 401 *without*
+ * it is a resource-level denial (e.g. an authenticated user lacking a
+ * grant — some endpoints answer those with 401, not 403) and must stay
+ * caller-domain rather than force a logout.
+ *
+ * @internal
+ */
+export function isSessionExpiredError(err: unknown): err is ClientError {
+  return isUnauthorizedError(err) && getApiErrorCode(err) === 'SIO-401-AEX'
 }
 
 /**

--- a/packages/sanity/src/core/studio/requestErrors/createRequestErrorChannel.ts
+++ b/packages/sanity/src/core/studio/requestErrors/createRequestErrorChannel.ts
@@ -1,6 +1,6 @@
 import {BehaviorSubject, isObservable, lastValueFrom, type Observable} from 'rxjs'
 
-import {classifyRequestError, isUnauthorizedError} from './classify'
+import {classifyRequestError, isSessionExpiredError} from './classify'
 import {
   type RequestErrorChannel,
   type RequestErrorClaim,
@@ -50,15 +50,15 @@ export function createRequestErrorChannel(): RequestErrorChannel {
    * caller-domain and should be re-thrown by the caller of this function.
    */
   function tryClaim(err: unknown, options: RequestErrorReportOptions, entry: ParkedEntry): boolean {
-    if (isUnauthorizedError(err)) {
-      // A 401 means the session is no longer authenticated — force logout.
-      // (Resource-level "forbidden" is a 403, which is caller-domain and
-      // never reaches here; if a denial ever arrives as a 401, that's an
-      // API bug to fix server-side, not something to disambiguate here.)
+    if (isSessionExpiredError(err)) {
+      // The API positively signals a dead session (`SIO-401-AEX`) — force
+      // logout. A 401 *without* that code is a resource-level denial
+      // (some endpoints answer 401, not 403, for authenticated users
+      // lacking a grant) and stays caller-domain, same as a 403.
       parked.push(entry)
-      // First 401 owns the dialog + logout; concurrent 401s for the same
-      // teardown (including the logout request's own 401) just park behind
-      // it rather than re-claiming.
+      // First expired-session 401 owns the dialog + logout; concurrent
+      // ones for the same teardown (including the logout request's own
+      // 401) just park behind it rather than re-claiming.
       if (claimSubject.getValue()?.type !== 'unauthorized') {
         claimSubject.next({type: 'unauthorized', error: err, projectId: projectIdFromError(err)})
       }

--- a/packages/sanity/src/core/studio/requestErrors/types.ts
+++ b/packages/sanity/src/core/studio/requestErrors/types.ts
@@ -61,9 +61,9 @@ export type RequestErrorClaim =
  *
  * Unclaimable errors (4xx other than 429, parse errors, ...) are
  * re-thrown unchanged, so downstream `.catch` / `catchError` handlers
- * still see them. 401s are claimed only after the studio verifies the
- * session is actually gone (probe), in which case a forced logout
- * follows; resource-level 401s are re-thrown to the caller.
+ * still see them. 401s are claimed only when the API explicitly tags them
+ * as session expiry (`SIO-401-AEX`), in which case a forced logout
+ * follows; untagged resource-level 401s are re-thrown to the caller.
  *
  * @beta
  */

--- a/packages/sanity/src/core/studio/screens/__tests__/LoggedOutToast.test.tsx
+++ b/packages/sanity/src/core/studio/screens/__tests__/LoggedOutToast.test.tsx
@@ -45,7 +45,10 @@ describe('LoggedOutToast', () => {
   })
 
   test('uses the generic copy for a non-expiry reason', async () => {
-    await renderWithReason('unauthorized')
+    // No such reason exists today ('session-expired' is the only member of
+    // the union), but the toast keeps a generic fallback so a future reason
+    // added without copy still renders something sensible.
+    await renderWithReason('some-future-reason' as LoggedOutReason)
     expect(useConditionalToast).toHaveBeenCalledWith(
       expect.objectContaining({
         enabled: true,

--- a/packages/sanity/src/core/studio/workspaces/WorkspacesProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaces/WorkspacesProvider.tsx
@@ -22,7 +22,7 @@ import {
 } from 'sanity/_singletons'
 
 import {type Config, prepareConfig} from '../../config'
-import {getApiErrorCode, isUnauthorizedError} from '../requestErrors/classify'
+import {isSessionExpiredError} from '../requestErrors/classify'
 import {createRequestErrorChannel} from '../requestErrors/createRequestErrorChannel'
 import {
   createRequestFailureProbe,
@@ -155,9 +155,12 @@ export function WorkspacesProvider({
   //     project/dataset makes the studio unusable and no plugin can recover
   //     from it — the studio claims this UX, replacing the workspace render
   //     with a guided full-screen view.
-  //  2. 401 → forced logout: a 401 means the session is gone (resource
-  //     denials are 403s, which stay caller-domain), so it's handled
-  //     globally rather than per-call-site.
+  //  2. expired-session 401 → forced logout: only 401s the API explicitly
+  //     tags as session expiry (`SIO-401-AEX`, sent by every endpoint) are
+  //     handled globally. Untagged 401s are resource-level denials (some
+  //     endpoints answer 401, not 403, for authenticated users lacking a
+  //     grant) and re-surface to the caller like any other caller-domain
+  //     error.
   //
   // Everything else — network errors, 5xx, 429 — propagates to the caller
   // unchanged. Callers that cannot recover locally delegate explicitly via
@@ -166,11 +169,11 @@ export function WorkspacesProvider({
     (requestOptions, originalRequest, client) => {
       return defer(() => originalRequest(requestOptions)).pipe(
         catchError((requestError: unknown, caught) => {
-          // A 401 from any request means the session is no longer
+          // An expired-session 401 means the session is no longer
           // authenticated. Hand it to the channel — it claims the
           // `unauthorized` state once, driving the forced logout below —
           // and park this request, since the session is being torn down.
-          if (isUnauthorizedError(requestError)) {
+          if (isSessionExpiredError(requestError)) {
             void requestErrorChannel.handle(requestError)
             return NEVER
           }
@@ -250,13 +253,9 @@ export function WorkspacesProvider({
   // Why we logged the user out, consumed by the login screen to surface a
   // toast. Derived from the live `unauthorized` claim, so it's present exactly
   // while the forced-logout state is — and clears on re-login (no persistence).
-  // The API's `SIO-401-AEX` means an expired session; any other 401 is generic.
-  const loggedOutReason =
-    claim?.type === 'unauthorized'
-      ? getApiErrorCode(claim.error) === 'SIO-401-AEX'
-        ? 'session-expired'
-        : 'unauthorized'
-      : undefined
+  // The channel only claims `SIO-401-AEX` 401s, so the reason is always an
+  // expired session.
+  const loggedOutReason = claim?.type === 'unauthorized' ? 'session-expired' : undefined
 
   // Fire forced logout on a verified `unauthorized` claim. Done in an
   // effect so the logout call doesn't run during a render commit.

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -477,6 +477,7 @@ exports[`exports snapshot 1`] = `
     "isSanityDocument": "function",
     "isScheduleDocumentVersionEvent": "function",
     "isSearchStrategy": "function",
+    "isSessionExpiredError": "function",
     "isSlug": "function",
     "isSpanSchemaType": "function",
     "isString": "function",


### PR DESCRIPTION
### Description

Follow-up addressing the review comments on #13367.

The substantive change is 401 handling: #13367 forced a logout on every 401, but some endpoints might answer 401 (not 403) for authenticated users lacking a grant, so a resource-level denial could tear down an otherwise healthy session. We now only consider 401s with the `SIO-401-AEX` error code as session expiry, and re-throws the rest to the caller.

The rest of the commits are minor smaller improvements:
- `startTransition` around the dialog's effect-driven state syncs
- type guards before property access on thrown values
- restoring the staging `projectId` left as `deadbeef` from testing
- and updating the error-playground 401 demo copy to describe the error-code-based logout.

### What to review
- Probably easiest to review commit-by-commit since most of the commits are single-line fixes.

### Testing

New unit tests in `requestErrors.test.ts`

### Notes for release

N/A – refinement of #13367, which is not yet released

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication teardown behavior for 401 responses; misclassification could either leave stale sessions or log users out on permission denials.
> 
> **Overview**
> Narrows **forced logout** so it runs only when a 401 includes the API’s session-expiry code **`SIO-401-AEX`**. Untagged 401s (e.g. grant denials on endpoints that return 401 instead of 403) are **re-thrown to callers** like other caller-domain errors, instead of tearing down a valid session.
> 
> Adds **`isSessionExpiredError`** and wires it through the request error channel, workspace request handler, and docs. **`LoggedOutReason`** drops the generic `'unauthorized'` variant; post-logout UI always treats forced logout as **`session-expired`**.
> 
> Smaller fixes: **`startTransition`** around effect-driven state in the request-error dialog, safer guards on thrown values in auth boot and document commit handling, staging **`projectId`** restored in test-studio, and updated error-playground copy/tests plus a new public export for **`isSessionExpiredError`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d68eadc1ad158f1075a88481337b18e1eec454ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->