### PR TITLE
feat(types): add user attribute types to CurrentUser

### DIFF
--- a/packages/@repo/test-dts-exports/test/fixtures/@sanity.types.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/@sanity.types.test-d.ts
@@ -68,6 +68,7 @@ import type {
   CrossDatasetReferenceValue,
   CrossDatasetType,
   CurrentUser,
+  CurrentUserAttribute,
   CustomValidator,
   CustomValidatorResult,
   DashboardNotificationPayload,
@@ -349,6 +350,8 @@ import type {
   UrlOptions,
   UrlRule,
   User,
+  UserAttributeType,
+  UserAttributeValue,
   ValidationBuilder,
   ValidationContext,
   ValidationError,
@@ -560,6 +563,9 @@ describe('@sanity/types', () => {
   })
   test('CurrentUser', () => {
     expectTypeOf<CurrentUser>().toBeObject()
+  })
+  test('CurrentUserAttribute', () => {
+    expectTypeOf<CurrentUserAttribute>().toBeObject()
   })
   test('CustomValidator', () => {
     expectTypeOf<CustomValidator<any>>().toBeObject()
@@ -1403,6 +1409,12 @@ describe('@sanity/types', () => {
   })
   test('User', () => {
     expectTypeOf<User>().toBeObject()
+  })
+  test('UserAttributeType', () => {
+    expectTypeOf<UserAttributeType>().not.toBeNever()
+  })
+  test('UserAttributeValue', () => {
+    expectTypeOf<UserAttributeValue>().not.toBeNever()
   })
   test('ValidationBuilder', () => {
     expectTypeOf<ValidationBuilder<any, any>>().not.toBeNever()

--- a/packages/@repo/test-dts-exports/test/fixtures/sanity.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/sanity.test-d.ts
@@ -327,6 +327,7 @@ import type {
   CrossDatasetReferenceValue,
   CrossDatasetType,
   CurrentUser,
+  CurrentUserAttribute,
   CustomValidator,
   CustomValidatorResult,
   DashboardNotificationPayload,
@@ -1658,6 +1659,8 @@ import type {
   useProjectId,
   useProjectStore,
   User,
+  UserAttributeType,
+  UserAttributeValue,
   UserAvatar,
   UserAvatarProps,
   UserColor,
@@ -2770,6 +2773,9 @@ describe('sanity', () => {
   })
   test('CurrentUser', () => {
     expectTypeOf<CurrentUser>().toBeObject()
+  })
+  test('CurrentUserAttribute', () => {
+    expectTypeOf<CurrentUserAttribute>().toBeObject()
   })
   test('CustomValidator', () => {
     expectTypeOf<CustomValidator<any>>().toBeObject()
@@ -6784,6 +6790,12 @@ describe('sanity', () => {
   })
   test('User', () => {
     expectTypeOf<User>().toBeObject()
+  })
+  test('UserAttributeType', () => {
+    expectTypeOf<UserAttributeType>().not.toBeNever()
+  })
+  test('UserAttributeValue', () => {
+    expectTypeOf<UserAttributeValue>().not.toBeNever()
   })
   test('UserAvatar', () => {
     expectTypeOf<typeof UserAvatar>().toBeFunction()

--- a/packages/@sanity/types/src/user/types.ts
+++ b/packages/@sanity/types/src/user/types.ts
@@ -15,15 +15,23 @@ export type UserAttributeType =
   | 'number-array'
   | 'boolean'
 
-/** @public */
-export type UserAttributeValue = string | number | boolean | string[] | number[]
+type UserAttributeValueByType = {
+  string: string
+  'string-array': string[]
+  integer: number
+  'integer-array': number[]
+  number: number
+  'number-array': number[]
+  boolean: boolean
+}
 
 /** @public */
-export interface CurrentUserAttribute {
-  key: string
-  type: UserAttributeType
-  value: UserAttributeValue
-}
+export type UserAttributeValue = UserAttributeValueByType[UserAttributeType]
+
+/** @public */
+export type CurrentUserAttribute = {
+  [T in UserAttributeType]: {key: string; type: T; value: UserAttributeValueByType[T]}
+}[UserAttributeType]
 
 /** @public */
 export interface CurrentUser {

--- a/packages/@sanity/types/src/user/types.ts
+++ b/packages/@sanity/types/src/user/types.ts
@@ -16,13 +16,13 @@ export type UserAttributeType =
   | 'boolean'
 
 type UserAttributeValueByType = {
-  string: string
+  'string': string
   'string-array': string[]
-  integer: number
+  'integer': number
   'integer-array': number[]
-  number: number
+  'number': number
   'number-array': number[]
-  boolean: boolean
+  'boolean': boolean
 }
 
 /** @public */

--- a/packages/@sanity/types/src/user/types.ts
+++ b/packages/@sanity/types/src/user/types.ts
@@ -6,6 +6,26 @@ export interface Role {
 }
 
 /** @public */
+export type UserAttributeType =
+  | 'string'
+  | 'string-array'
+  | 'integer'
+  | 'integer-array'
+  | 'number'
+  | 'number-array'
+  | 'boolean'
+
+/** @public */
+export type UserAttributeValue = string | number | boolean | string[] | number[]
+
+/** @public */
+export interface CurrentUserAttribute {
+  key: string
+  type: UserAttributeType
+  value: UserAttributeValue
+}
+
+/** @public */
 export interface CurrentUser {
   id: string
   name: string
@@ -15,6 +35,11 @@ export interface CurrentUser {
   /** @deprecated use `roles` instead */
   role: string
   roles: Role[]
+  /**
+   * Organization-scoped user attributes for the current project.
+   * Only present when returned by `/users/me` with a project context.
+   */
+  attributes?: CurrentUserAttribute[]
 }
 
 /** @public */

--- a/packages/sanity/src/core/store/authStore/__tests__/createAuthStore.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/createAuthStore.test.ts
@@ -24,6 +24,10 @@ const MOCK_USER: CurrentUser = {
   provider: 'google',
   role: '',
   roles: [{name: 'administrator', title: 'Administrator'}],
+  attributes: [
+    {key: 'department', type: 'string', value: 'engineering'},
+    {key: 'locale', type: 'string-array', value: ['EN', 'ES']},
+  ],
 }
 
 const PROJECT_ID = 'test-project'
@@ -1004,5 +1008,34 @@ describe('createAuthStore: cross-tab sync', () => {
       expect(diagnose).toHaveBeenCalled()
       expect(onRequestFailure).toHaveBeenCalledWith({type: 'project-not-found'}, expect.anything())
     })
+  })
+})
+
+describe('createAuthStore: currentUser attributes', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    window.location.hash = ''
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    window.location.hash = ''
+    vi.restoreAllMocks()
+  })
+
+  it('preserves attributes from /users/me response', async () => {
+    const mock = createMockClientFactory()
+
+    const store = _createAuthStore({
+      projectId: PROJECT_ID,
+      dataset: DATASET,
+      loginMethod: 'cookie',
+      clientFactory: mock.factory,
+      getSessionId: () => undefined,
+      consumeHashToken: () => undefined,
+    })
+
+    const state = await waitForState(store, (s) => s.authenticated)
+    expect(state.currentUser?.attributes).toEqual(MOCK_USER.attributes)
   })
 })

--- a/packages/sanity/src/core/store/user/hooks.ts
+++ b/packages/sanity/src/core/store/user/hooks.ts
@@ -37,6 +37,7 @@ export function useUser(userId: string): LoadingTuple<User | null | undefined> {
  *
  * if (currentUser) {
  *  console.log('Logged in as', currentUser.name)
+ *  const department = currentUser.attributes?.find((attr) => attr.key === 'department')
  * }
  * ```
  */

--- a/packages/sanity/test/mocks/mockSanityClient.ts
+++ b/packages/sanity/test/mocks/mockSanityClient.ts
@@ -72,6 +72,7 @@ export function createMockSanityClient(
         },
       ],
       provider: 'google',
+      attributes: [{key: 'department', type: 'string', value: 'engineering'}],
     },
 
     ...data.requests,


### PR DESCRIPTION
### Description

The `/users/me` endpoint can return organization-scoped user attributes when called with a project context, but `CurrentUser` in `@sanity/types` did not expose them. Studio plugins and custom document layouts that call `useCurrentUser()` had no typed way to read attributes like department or locale.

This adds public types for those attributes and wires them onto `CurrentUser.attributes`. No runtime auth-store changes were needed—the API response already flows through; the gap was purely in TypeScript surface area and test fixtures.

Alternatives considered:
- **Loose `Record<string, unknown>` on `CurrentUser`** — rejected; the API returns a structured `{ key, type, value }` shape worth modeling explicitly.
- **Adding attributes to the generic `User` type** — rejected; attributes are only returned for the authenticated user in project context, not for arbitrary user lookups.

### What to review

- **`packages/@sanity/types/src/user/types.ts`** — `UserAttributeType`, `UserAttributeValue`, `CurrentUserAttribute`, and the optional `attributes` field on `CurrentUser`. Confirm the union of attribute types matches the API contract.
- **`packages/sanity/src/core/store/authStore/__tests__/createAuthStore.test.ts`** — new test asserting attributes survive the auth store round-trip from `/users/me`.
- **DTS export fixtures** — ensure the new types are exported from both `@sanity/types` and `sanity` package entry points.

### Testing

- Added `createAuthStore: currentUser attributes` test verifying attributes from the mocked `/users/me` response are preserved on `state.currentUser`.
- Updated `mockSanityClient` fixture with sample attributes.
- Extended `@repo/test-dts-exports` fixtures for `CurrentUserAttribute`, `UserAttributeType`, and `UserAttributeValue`.

```bash
pnpm vitest run --project=sanity packages/sanity/src/core/store/authStore/__tests__/createAuthStore.test.ts
pnpm test:exports
```

### Notes for release

Studio developers can now access organization-scoped user attributes on the current user:

```ts
import {useCurrentUser} from 'sanity'

const currentUser = useCurrentUser()
const department = currentUser?.attributes?.find((attr) => attr.key === 'department')
```

`attributes` is optional and only present when `/users/me` is called with a project context. Supported attribute types: `string`, `string-array`, `integer`, `integer-array`, `number`, `number-array`, and `boolean`.

Made with [Cursor](https://cursor.com)