### PR TITLE
fix(core): only cancel commits for known-terminal client errors

### DIFF
--- a/packages/sanity/src/core/store/document/document-pair/checkoutPair.test.ts
+++ b/packages/sanity/src/core/store/document/document-pair/checkoutPair.test.ts
@@ -361,7 +361,7 @@ describe('checkoutPair -- failed commit routing', () => {
   })
 
   test('a 409 (conflict) commit failure is cancelled, not retried', async () => {
-    // 409 is in the 4xx-except-429 range → terminal client error → cancel.
+    // 409 is in the terminal allowlist → cancel.
     const conflictError = Object.assign(new Error('Conflict'), {statusCode: 409})
     mockedActionRequest.mockImplementation(() => throwError(() => conflictError) as any)
 
@@ -382,6 +382,102 @@ describe('checkoutPair -- failed commit routing', () => {
 
     await vi.advanceTimersByTimeAsync(60_000)
     expect(mockedActionRequest).toHaveBeenCalledTimes(1)
+
+    consistency.sub.unsubscribe()
+    sub.unsubscribe()
+  })
+
+  test('a 413 (payload too large) commit failure is cancelled, not retried', async () => {
+    // 413 is terminal: resubmitting the same oversized payload can never
+    // succeed, so retrying would stall the document forever. Cancel instead.
+    const tooLargeError = Object.assign(new Error('Payload Too Large'), {statusCode: 413})
+    mockedActionRequest.mockImplementation(() => throwError(() => tooLargeError) as any)
+
+    const {draft, published} = checkoutPair(client as any as SanityClient, idPair, of(true))
+    const combined = merge(draft.events, published.events)
+    const sub = combined.subscribe()
+    const consistency = collectConsistency(draft.consistency$)
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    draft.mutate(draft.patch([{set: {title: 'way too big'}}]))
+    draft.commit()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mockedActionRequest).toHaveBeenCalledTimes(1)
+    // Cancel path: reset to server HEAD → consistent again.
+    expect(consistency.values.at(-1)).toBe(true)
+
+    // Terminal: never retried.
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(mockedActionRequest).toHaveBeenCalledTimes(1)
+
+    consistency.sub.unsubscribe()
+    sub.unsubscribe()
+  })
+
+  test('a 408 (request timeout) commit failure is retried, not cancelled', async () => {
+    // 408 is a 4xx but transient — a timeout says nothing about the mutation
+    // itself, so the buffered edits must be retained and re-attempted. Guards
+    // the opt-in terminal set against regressing to a blanket 4xx rule.
+    const timeoutError = Object.assign(new Error('Request Timeout'), {statusCode: 408})
+    // Only the first attempt fails; the retry succeeds via the default mock.
+    mockedActionRequest.mockImplementationOnce(() => throwError(() => timeoutError) as any)
+
+    const {draft, published} = checkoutPair(client as any as SanityClient, idPair, of(true))
+    const combined = merge(draft.events, published.events)
+    const sub = combined.subscribe()
+    const consistency = collectConsistency(draft.consistency$)
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    draft.mutate(draft.patch([{set: {title: 'timed out'}}]))
+    draft.commit()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mockedActionRequest).toHaveBeenCalledTimes(1)
+    // Failure path: still unsynced, buffer retained.
+    expect(consistency.values.at(-1)).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(mockedActionRequest).toHaveBeenCalledTimes(2)
+    expect(mockedActionRequest.mock.calls[1][0]).toEqual([
+      {
+        actionType: 'sanity.action.document.edit',
+        draftId: 'draftId',
+        publishedId: 'publishedId',
+        patch: {set: {title: 'timed out'}},
+      },
+    ])
+
+    consistency.sub.unsubscribe()
+    sub.unsubscribe()
+  })
+
+  test('an unclassified 4xx (418) commit failure is retried, not cancelled — unknown codes take the conservative path', async () => {
+    // A 4xx we haven't explicitly classified as terminal must NOT discard the
+    // user's edits: wrongly retrying leaves a visibly stalled document with
+    // the buffer intact (recoverable), wrongly cancelling silently destroys
+    // work. Unknown codes therefore default to retry.
+    const teapotError = Object.assign(new Error("I'm a teapot"), {statusCode: 418})
+    mockedActionRequest.mockImplementationOnce(() => throwError(() => teapotError) as any)
+
+    const {draft, published} = checkoutPair(client as any as SanityClient, idPair, of(true))
+    const combined = merge(draft.events, published.events)
+    const sub = combined.subscribe()
+    const consistency = collectConsistency(draft.consistency$)
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    draft.mutate(draft.patch([{set: {title: 'unknown 4xx'}}]))
+    draft.commit()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mockedActionRequest).toHaveBeenCalledTimes(1)
+    expect(consistency.values.at(-1)).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(mockedActionRequest).toHaveBeenCalledTimes(2)
 
     consistency.sub.unsubscribe()
     sub.unsubscribe()

--- a/packages/sanity/src/core/store/document/document-pair/checkoutPair.test.ts
+++ b/packages/sanity/src/core/store/document/document-pair/checkoutPair.test.ts
@@ -1,4 +1,4 @@
-import {type SanityClient} from '@sanity/client'
+import {ClientError, type SanityClient} from '@sanity/client'
 import {merge, NEVER, of, type Observable, Subject, throwError} from 'rxjs'
 import {delay} from 'rxjs/operators'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
@@ -416,6 +416,89 @@ describe('checkoutPair -- failed commit routing', () => {
     sub.unsubscribe()
   })
 
+  test('a 401 tagged as session expiry (SIO-401-AEX) is retried, not cancelled', async () => {
+    // A session-expiry 401 says nothing about the mutation itself — after
+    // re-authentication the same commit can succeed. The buffered edits must
+    // therefore be preserved and retried, not wiped to server HEAD mid-edit.
+    // (The session itself is handled by the force-logout flow, not here.)
+    const sessionExpiredError = new ClientError({
+      statusCode: 401,
+      headers: {},
+      body: {error: 'Unauthorized', errorCode: 'SIO-401-AEX'},
+      url: 'https://abc123.api.sanity.io/v1/data/actions/production',
+      method: 'POST',
+    } as never)
+    // Only the first attempt fails; the retry succeeds via the default mock —
+    // as it would after the user re-authenticates.
+    mockedActionRequest.mockImplementationOnce(() => throwError(() => sessionExpiredError) as any)
+
+    const {draft, published} = checkoutPair(client as any as SanityClient, idPair, of(true))
+    const combined = merge(draft.events, published.events)
+    const sub = combined.subscribe()
+    const consistency = collectConsistency(draft.consistency$)
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    draft.mutate(draft.patch([{set: {title: 'session expired'}}]))
+    draft.commit()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mockedActionRequest).toHaveBeenCalledTimes(1)
+    // Failure path: still unsynced, buffer retained.
+    expect(consistency.values.at(-1)).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(mockedActionRequest).toHaveBeenCalledTimes(2)
+    expect(mockedActionRequest.mock.calls[1][0]).toEqual([
+      {
+        actionType: 'sanity.action.document.edit',
+        draftId: 'draftId',
+        publishedId: 'publishedId',
+        patch: {set: {title: 'session expired'}},
+      },
+    ])
+
+    consistency.sub.unsubscribe()
+    sub.unsubscribe()
+  })
+
+  test('a 401 without the session-expiry tag is cancelled, not retried', async () => {
+    // A plain 401 is a resource-level denial (e.g. missing grant — some
+    // endpoints answer those with 401, not 403): terminal for this user, so
+    // retrying can never succeed. Guards the session-expiry carve-out against
+    // widening into "all 401s retry".
+    const deniedError = new ClientError({
+      statusCode: 401,
+      headers: {},
+      body: {error: 'Unauthorized'},
+      url: 'https://abc123.api.sanity.io/v1/data/actions/production',
+      method: 'POST',
+    } as never)
+    mockedActionRequest.mockImplementation(() => throwError(() => deniedError) as any)
+
+    const {draft, published} = checkoutPair(client as any as SanityClient, idPair, of(true))
+    const combined = merge(draft.events, published.events)
+    const sub = combined.subscribe()
+    const consistency = collectConsistency(draft.consistency$)
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    draft.mutate(draft.patch([{set: {title: 'denied'}}]))
+    draft.commit()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(mockedActionRequest).toHaveBeenCalledTimes(1)
+    // Cancel path: reset to server HEAD → consistent again.
+    expect(consistency.values.at(-1)).toBe(true)
+
+    // Terminal: never retried.
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(mockedActionRequest).toHaveBeenCalledTimes(1)
+
+    consistency.sub.unsubscribe()
+    sub.unsubscribe()
+  })
+
   test('a 408 (request timeout) commit failure is retried, not cancelled', async () => {
     // 408 is a 4xx but transient — a timeout says nothing about the mutation
     // itself, so the buffered edits must be retained and re-attempted. Guards
@@ -483,9 +566,9 @@ describe('checkoutPair -- failed commit routing', () => {
     sub.unsubscribe()
   })
 
-  test('a 429 (too many requests) commit failure is retried, not cancelled — guards the !== 429 boundary', async () => {
-    // 429 is in the 4xx range but is explicitly excluded from the terminal
-    // client-error branch: it is transient (rate limiting) and must retry.
+  test('a 429 (too many requests) commit failure is retried, not cancelled — transient 4xx stays out of the terminal allowlist', async () => {
+    // 429 is in the 4xx range but not in the terminal allowlist: it is
+    // transient (rate limiting) and must retry.
     const rateLimitError = Object.assign(new Error('Too Many Requests'), {statusCode: 429})
     // Only the first attempt fails; the retry succeeds via the default mock.
     mockedActionRequest.mockImplementationOnce(() => throwError(() => rateLimitError) as any)

--- a/packages/sanity/src/core/store/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/document/document-pair/checkoutPair.ts
@@ -22,6 +22,7 @@ import {
   withLatestFrom,
 } from 'rxjs/operators'
 
+import {isSessionExpiredError} from '../../../util/apiErrors'
 import {type DocumentVariantType} from '../../../util/getDocumentVariantType'
 import {
   type BufferedDocumentEvent,
@@ -231,6 +232,13 @@ function commitMutations(
  * cancelling a transient error silently destroys the user's work. Statuses
  * not listed here — including transient 4xx like 408/429 and any 4xx we
  * haven't classified — take the conservative retry path.
+ *
+ * 401 is terminal only for resource-level denials (e.g. a missing grant —
+ * some endpoints answer those with 401, not 403). A 401 tagged as session
+ * expiry (`SIO-401-AEX`) is carved out below: it says nothing about the
+ * mutation itself, and re-authenticating can make the retry succeed, so the
+ * buffered edits must be preserved rather than wiped mid-edit. The session
+ * itself is handled separately by the force-logout flow.
  */
 const TERMINAL_COMMIT_STATUSES = new Set([400, 401, 402, 403, 404, 409, 410, 412, 413, 422])
 
@@ -257,8 +265,8 @@ function submitCommitRequest(
       // succeed by retrying, so the commit is rejected and the buffer reset
       // to server HEAD (see TERMINAL_COMMIT_STATUSES for the rationale).
       // Everything else — 5xx, transient 4xx (408/429), unclassified 4xx,
-      // network errors — fails, so the mutator keeps the buffer and retries
-      // with backoff.
+      // session-expiry 401s, network errors — fails, so the mutator keeps
+      // the buffer and retries with backoff.
       // `error` can be any thrown value — guard before using `in`, which
       // throws on primitives.
       const statusCode =
@@ -268,7 +276,11 @@ function submitCommitRequest(
         typeof error.statusCode === 'number'
           ? error.statusCode
           : undefined
-      if (statusCode !== undefined && TERMINAL_COMMIT_STATUSES.has(statusCode)) {
+      if (
+        statusCode !== undefined &&
+        TERMINAL_COMMIT_STATUSES.has(statusCode) &&
+        !isSessionExpiredError(error)
+      ) {
         request.cancel(error)
       } else {
         request.failure(error)

--- a/packages/sanity/src/core/store/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/document/document-pair/checkoutPair.ts
@@ -221,6 +221,19 @@ function commitMutations(
   })
 }
 
+/**
+ * The 4xx statuses we positively know are terminal for a commit: resubmitting
+ * the same mutation can never succeed, so the buffered edits are cancelled
+ * (rejected + reset to server HEAD) instead of retried. Opt-in by explicit
+ * status rather than a blanket 4xx rule, because the buckets have opposite
+ * failure modes: wrongly retrying a terminal error leaves the document
+ * visibly stalled with the edits preserved (recoverable), while wrongly
+ * cancelling a transient error silently destroys the user's work. Statuses
+ * not listed here — including transient 4xx like 408/429 and any 4xx we
+ * haven't classified — take the conservative retry path.
+ */
+const TERMINAL_COMMIT_STATUSES = new Set([400, 401, 402, 403, 404, 409, 410, 412, 413, 422])
+
 function submitCommitRequest(
   client: SanityClient,
   idPair: IdPair,
@@ -240,12 +253,12 @@ function submitCommitRequest(
     // Complete instead — the failure has already been routed through its
     // proper channel.
     catchError((error) => {
-      // 4xx (except 429) is a client error: terminal, the buffered
-      // mutations can't succeed by retrying, so cancel (which rejects the
-      // commit and resets the buffer to server HEAD). 5xx / 429 / network
-      // are transient: fail, so the mutator keeps the buffer and retries
-      // with backoff. Note `< 500` — 500 itself is a server error and
-      // must retry, not cancel.
+      // A known-terminal client error cancels: the buffered mutations can't
+      // succeed by retrying, so the commit is rejected and the buffer reset
+      // to server HEAD (see TERMINAL_COMMIT_STATUSES for the rationale).
+      // Everything else — 5xx, transient 4xx (408/429), unclassified 4xx,
+      // network errors — fails, so the mutator keeps the buffer and retries
+      // with backoff.
       // `error` can be any thrown value — guard before using `in`, which
       // throws on primitives.
       const statusCode =
@@ -255,9 +268,7 @@ function submitCommitRequest(
         typeof error.statusCode === 'number'
           ? error.statusCode
           : undefined
-      const isTerminalClientError =
-        statusCode !== undefined && statusCode >= 400 && statusCode < 500 && statusCode !== 429
-      if (isTerminalClientError) {
+      if (statusCode !== undefined && TERMINAL_COMMIT_STATUSES.has(statusCode)) {
         request.cancel(error)
       } else {
         request.failure(error)

--- a/packages/sanity/src/core/studio/requestErrors/classify.ts
+++ b/packages/sanity/src/core/studio/requestErrors/classify.ts
@@ -1,6 +1,11 @@
 import {ClientError, ServerError} from '@sanity/client'
 import isNativeNetworkError from 'is-network-error'
 
+// These live in `util` so that non-studio code (e.g. the document store) can
+// depend on them without importing from `studio`; re-exported here to keep
+// the public API surface and existing import sites unchanged.
+export {getApiErrorCode, isSessionExpiredError, isUnauthorizedError} from '../../util/apiErrors'
+
 /** @internal */
 export function isTimeoutError(
   error: unknown,
@@ -91,24 +96,6 @@ export function classifyRequestError(err: unknown): RequestErrorClassification |
   return null
 }
 
-/** @internal */
-export function isUnauthorizedError(err: unknown): err is ClientError {
-  return err instanceof ClientError && err.statusCode === 401
-}
-
-/**
- * Whether a 401 positively signals a dead session. Every API endpoint tags
- * session-expiry 401s with the `SIO-401-AEX` error code; a 401 *without*
- * it is a resource-level denial (e.g. an authenticated user lacking a
- * grant — some endpoints answer those with 401, not 403) and must stay
- * caller-domain rather than force a logout.
- *
- * @internal
- */
-export function isSessionExpiredError(err: unknown): err is ClientError {
-  return isUnauthorizedError(err) && getApiErrorCode(err) === 'SIO-401-AEX'
-}
-
 /**
  * A workspace-level configuration error: the project or dataset the
  * studio is pointed at doesn't exist. Unlike the infrastructure errors
@@ -175,32 +162,6 @@ export function classifyConfigError(err: unknown): ConfigErrorClassification | n
   }
 
   return null
-}
-
-/**
- * The API's machine-readable `errorCode` from a client error response body
- * (e.g. `SIO-401-AEX` for an expired session), or `undefined` if absent. The
- * `ClientError` exposes the parsed body on `response.body` (typed `unknown`);
- * fall back to the stringified `responseBody` since older error shapes only
- * carry that.
- *
- * @internal
- */
-export function getApiErrorCode(err: unknown): string | undefined {
-  if (!(err instanceof ClientError)) return undefined
-  const fromResponse = readErrorCode(err.response?.body)
-  if (fromResponse) return fromResponse
-  try {
-    return readErrorCode(JSON.parse(err.responseBody ?? ''))
-  } catch {
-    return undefined
-  }
-}
-
-function readErrorCode(value: unknown): string | undefined {
-  if (typeof value !== 'object' || value === null || !('errorCode' in value)) return undefined
-  const code = value.errorCode
-  return typeof code === 'string' ? code : undefined
 }
 
 /**

--- a/packages/sanity/src/core/util/apiErrors.ts
+++ b/packages/sanity/src/core/util/apiErrors.ts
@@ -1,0 +1,45 @@
+import {ClientError} from '@sanity/client'
+
+/** @internal */
+export function isUnauthorizedError(err: unknown): err is ClientError {
+  return err instanceof ClientError && err.statusCode === 401
+}
+
+/**
+ * Whether a 401 positively signals a dead session. Every API endpoint tags
+ * session-expiry 401s with the `SIO-401-AEX` error code; a 401 *without*
+ * it is a resource-level denial (e.g. an authenticated user lacking a
+ * grant — some endpoints answer those with 401, not 403) and must stay
+ * caller-domain rather than force a logout.
+ *
+ * @internal
+ */
+export function isSessionExpiredError(err: unknown): err is ClientError {
+  return isUnauthorizedError(err) && getApiErrorCode(err) === 'SIO-401-AEX'
+}
+
+/**
+ * The API's machine-readable `errorCode` from a client error response body
+ * (e.g. `SIO-401-AEX` for an expired session), or `undefined` if absent. The
+ * `ClientError` exposes the parsed body on `response.body` (typed `unknown`);
+ * fall back to the stringified `responseBody` since older error shapes only
+ * carry that.
+ *
+ * @internal
+ */
+export function getApiErrorCode(err: unknown): string | undefined {
+  if (!(err instanceof ClientError)) return undefined
+  const fromResponse = readErrorCode(err.response?.body)
+  if (fromResponse) return fromResponse
+  try {
+    return readErrorCode(JSON.parse(err.responseBody ?? ''))
+  } catch {
+    return undefined
+  }
+}
+
+function readErrorCode(value: unknown): string | undefined {
+  if (typeof value !== 'object' || value === null || !('errorCode' in value)) return undefined
+  const code = value.errorCode
+  return typeof code === 'string' ? code : undefined
+}


### PR DESCRIPTION
### Description
When a document commit fails with a 4xx, the mutator either cancels (rejects the commit and resets the buffer to server `HEAD`, discarding the user's buffered edits) or fails (keeps the buffer and retries with backoff). The blanket "4xx except 429 → cancel" rule from #13367 was overly pessimistic for transient statuses: a 408 timeout says nothing about the mutation itself, yet the edits were thrown away, and the same happened for any 4xx we never classified.

Wrongly retrying a terminal error leaves the document visibly stalled with the edits preserved (recoverable), while wrongly cancelling a transient error discard local edits. Cancellation is therefore now opt-in via an explicit status allowlist (`TERMINAL_COMMIT_STATUSES`); everything else, e.g. 5xx, 408/429, unclassified 4xx, network errors — gets retried.

Also, any 401 with session expiry (`SIO-401-AEX`) is in theory recoverable by the user, so it takes the retry path instead. (Right now, its only recoverable by logging in in a new tab, but in the future we might offer a login flow that preserves local state, e.g. using window.open). Session expiry is most likely to hit someone mid-edit. A plain 401 stays terminal. 
### What to review

- The allowlist membership in `checkoutPair.ts`: is any listed status actually transient, or any missing statuses we should consider terminal?

### Testing
Unit tests included

### Notes for release
N/A


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core document save/retry behavior and can silently preserve stalled state vs. previously dropping edits on any 4xx; wrong allowlist membership would affect data loss vs. recovery.
> 
> **Overview**
> Replaces the blanket **4xx except 429 → cancel** rule in document commit error handling with an explicit **`TERMINAL_COMMIT_STATUSES`** allowlist in `checkoutPair.ts`. Only listed codes (e.g. 400, 409, **413**) call `request.cancel` and reset the buffer to server HEAD; **408**, **429**, unclassified 4xx (e.g. **418**), 5xx, and network errors keep the buffer and retry with backoff.
> 
> This avoids discarding buffered edits on transient or unknown client errors while still cancelling when resubmitting the same mutation cannot succeed.
> 
> Adds routing tests for **413** (cancel, no retry), **408** and **418** (retry with same mutation), and tightens the **409** test comment to match the allowlist model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b45f78967cdb19bd3a061155d259d44c870747c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->