### PR TITLE
fix(core): allow pasting references to documents that only exist in a release

### DIFF
--- a/packages/sanity/src/core/studio/copyPaste/__test__/transferValue.test.ts
+++ b/packages/sanity/src/core/studio/copyPaste/__test__/transferValue.test.ts
@@ -297,6 +297,118 @@ describe('transferValue', () => {
       expect(transferValueResult?.targetValue[0]._key).not.toEqual('123')
     })
 
+    test('can copy reference where referenced document only exists as a version within a release', async () => {
+      const sourceValue = {
+        _type: 'referencesDocument',
+        _id: 'xxx',
+        // Strong reference created while a release was the selected perspective:
+        // `_strengthenOnPublish` is set, but `_weak` is not
+        reference: {
+          _type: 'reference',
+          _ref: 'yyy',
+          _strengthenOnPublish: {type: 'editor'},
+        },
+      }
+      const transferValueResult = await transferValue({
+        sourceRootSchemaType: schema.get('referencesDocument')!,
+        sourcePath: ['reference'],
+        sourceValue,
+        targetDocumentSchemaType: schema.get('referencesDocument')!,
+        targetRootSchemaType: schema.get('referencesDocument')!,
+        targetPath: ['reference'],
+        targetRootValue: {},
+        targetRootPath: ['reference'],
+        currentUser,
+        options: {
+          validateReferences: true,
+          // The referenced document only exists within a release
+          client: createMockClient([
+            {_type: 'editor', _id: 'versions.rSomeRelease.yyy', name: 'John Doe'},
+          ]),
+        },
+      })
+      expect(transferValueResult?.errors).toEqual([])
+      expect(transferValueResult?.targetValue).toEqual({
+        _type: 'reference',
+        _ref: 'yyy',
+        _weak: true,
+        _strengthenOnPublish: {type: 'editor'},
+      })
+    })
+
+    test('can copy reference where referenced document only exists as a draft', async () => {
+      const sourceValue = {
+        _type: 'referencesDocument',
+        _id: 'xxx',
+        reference: {
+          _type: 'reference',
+          _ref: 'yyy',
+          _weak: true,
+          _strengthenOnPublish: {type: 'editor'},
+        },
+      }
+      const transferValueResult = await transferValue({
+        sourceRootSchemaType: schema.get('referencesDocument')!,
+        sourcePath: ['reference'],
+        sourceValue,
+        targetDocumentSchemaType: schema.get('referencesDocument')!,
+        targetRootSchemaType: schema.get('referencesDocument')!,
+        targetPath: ['reference'],
+        targetRootValue: {},
+        targetRootPath: ['reference'],
+        currentUser,
+        options: {
+          validateReferences: true,
+          // The referenced document only exists as a draft
+          client: createMockClient([{_type: 'editor', _id: 'drafts.yyy', name: 'John Doe'}]),
+        },
+      })
+      expect(transferValueResult?.errors).toEqual([])
+      expect(transferValueResult?.targetValue).toEqual({
+        _type: 'reference',
+        _ref: 'yyy',
+        _weak: true,
+        _strengthenOnPublish: {type: 'editor'},
+      })
+    })
+
+    test('can copy reference with filter where referenced document only exists as a version within a release', async () => {
+      const sourceValue = {
+        _type: 'referencesDocument',
+        _id: 'xxx',
+        reference: {
+          _type: 'reference',
+          _ref: 'yyy',
+          _strengthenOnPublish: {type: 'editor'},
+        },
+      }
+      const transferValueResult = await transferValue({
+        sourceRootSchemaType: schema.get('referencesDocument')!,
+        sourcePath: ['reference'],
+        sourceValue,
+        targetDocumentSchemaType: schema.get('referencesDocument')!,
+        targetRootSchemaType: schema.get('referencesDocument')!,
+        targetPath: ['referenceWithFilter'],
+        targetRootValue: {},
+        targetRootPath: ['referenceWithFilter'],
+        currentUser,
+        options: {
+          validateReferences: true,
+          // The referenced document only exists within a release
+          client: createMockClient([
+            {_type: 'editor', _id: 'versions.rSomeRelease.yyy', name: 'yyy'},
+          ]),
+        },
+      })
+      expect(transferValueResult?.errors).toEqual([])
+      expect(transferValueResult?.targetValue).toEqual({
+        _type: 'reference',
+        _ref: 'yyy',
+        _weak: true,
+        _strengthenOnPublish: {type: 'editor'},
+      })
+    })
+
     test('will not copy reference into array of references where referenced document does not exist', async () => {
       const sourceValue = {
         _type: 'referencesDocument',

--- a/packages/sanity/src/core/studio/copyPaste/transferValue.ts
+++ b/packages/sanity/src/core/studio/copyPaste/transferValue.ts
@@ -39,7 +39,7 @@ import {type FIXME} from '../../FIXME'
 import {resolveConditionalProperty} from '../../form/store/conditional-property/resolveConditionalProperty'
 import {accepts} from '../../form/studio/uploads/accepts'
 import {randomKey} from '../../form/utils/randomKey'
-import {getIdPair} from '../../util/draftUtils'
+import {getPublishedId} from '../../util/draftUtils'
 import {isRecord} from '../../util/isRecord'
 import {documentMatchesGroqFilter} from './documentMatchesGroqFilter'
 import {resolveSchemaTypeForPath} from './resolveSchemaTypeForPath'
@@ -592,13 +592,15 @@ async function collateObjectValue({
     // Validate the actual reference value
     if (options?.validateReferences && options.client && isReference(sourceValue)) {
       try {
+        // `sanity::versionOf` matches the published document as well as any draft or release
+        // version of it, so references to documents that only exist within a release (e.g.
+        // created while a release was the selected perspective) validate correctly.
         // We need to fetch the whole reference document if a filter is defined
         const query = targetSchemaType.options?.filter
-          ? `*[_id in $ids]|order(_updatedAt)[0]`
-          : `*[_id in $ids]|order(_updatedAt)[0]{_id, _type}`
-        const {publishedId, draftId} = getIdPair(sourceValue._ref)
+          ? `*[sanity::versionOf($publishedId)]|order(_updatedAt)[0]`
+          : `*[sanity::versionOf($publishedId)]|order(_updatedAt)[0]{_id, _type}`
         const reference = await (options.client as SanityClient).fetch(query, {
-          ids: [publishedId, draftId],
+          publishedId: getPublishedId(sourceValue._ref),
         })
 
         // Test that we have an actual referenced object if this is not a weak reference


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Copying and pasting a field or object containing a strong reference failed with `Invalid clipboard item – The referenced document "..." does not exist` when the referenced document was created inside a release. Such documents only exist as version documents (`versions.<releaseId>.<documentId>`), but the paste-time reference validation in `transferValue` only queried for the published and draft IDs, so the existence check came up empty.

The validation query now uses `sanity::versionOf($publishedId)`, which matches the published document plus any draft or release version of it — the same approach already used by `resolveTypeForDocument` and the slug validator. An alternative of adding `versions.**` ID lookups to the existing `_id in $ids` query was rejected since the release ID isn't known at paste time and `sanity::versionOf` covers all variants natively.

### What to review

- `packages/sanity/src/core/studio/copyPaste/transferValue.ts` — the query change in reference validation (both the filtered and unfiltered variants).
- Only the `sanity` package is affected.

### Testing

- Added unit tests covering pasting a reference whose target exists only as a release version document (with and without a reference `filter`), and one for draft-only targets to guard the previous behavior. The mock client evaluates real GROQ via `groq-js`, which implements `sanity::versionOf`, so the new query is exercised for real.
- Verified the new tests fail without the fix and pass with it.
- Manual studio verification wasn't performed since the dev studio requires Sanity account authentication not available in this environment.

### Notes for release

Fixed an issue where pasting a copied field or object containing a strong reference would fail with `The referenced document "..." does not exist` if the referenced document had been created within a release and not yet published. References to release-only documents can now be copied and pasted as expected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39e3c34c-973d-4f67-944c-b3de52517b91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39e3c34c-973d-4f67-944c-b3de52517b91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

