### PR TITLE
fix(sanity): reduce `unstable_observeVersionDocumentIds` invalidations

### DIFF
--- a/dev/efps/helpers/measureFpsForInput.ts
+++ b/dev/efps/helpers/measureFpsForInput.ts
@@ -28,23 +28,25 @@ export async function measureFpsForInput({
   const formView = page.locator('[data-testid="form-view"]')
   await formView.waitFor({state: 'visible', timeout})
 
-  const input = page
-    .locator(
-      `[data-testid="field-${fieldName}"] input[type="text"], ` +
-        `[data-testid="field-${fieldName}"] textarea`,
-    )
-    .first()
+  const field = page.locator(`[data-testid="field-${fieldName}"]`)
+  const input = field.locator('input[type="text"], textarea').first()
   await input.waitFor({state: 'visible', timeout})
   const characters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
   await input.click()
   await new Promise((resolve) => setTimeout(resolve, 500))
 
-  const rendersPromise = input.evaluate(
+  // The recorder is attached to the stable field wrapper (with a delegated,
+  // capture-phase 'input' listener on the document) rather than to the input
+  // element itself: a transient read-only flip can remount the element
+  // mid-run, which would silently kill element-bound listeners/observers and
+  // leave the characters typed after the remount without matching render
+  // events ("No matching event" failures).
+  const rendersPromise = field.evaluate(
     // Had to add this so we can run the tests
     // oxlint-disable-next-line no-implied-eval
     new Function(
-      'el',
+      'field',
       `
     return (async function() {
       const updates = []
@@ -52,15 +54,24 @@ export async function measureFpsForInput({
       // For textarea, use MutationObserver on text content
       // For input, use 'input' event because MutationObserver on 'value' attribute
       // doesn't work - React/Sanity updates the value property, not the attribute
-      if (el instanceof HTMLTextAreaElement) {
-        const mutationObserver = new MutationObserver(() => {
-          updates.push({value: el.value, timestamp: Date.now()})
+      const isTextArea = field.querySelector('textarea') !== null
+      let mutationObserver
+      let onInput
+
+      if (isTextArea) {
+        mutationObserver = new MutationObserver(() => {
+          const textarea = field.querySelector('textarea')
+          if (textarea) updates.push({value: textarea.value, timestamp: Date.now()})
         })
-        mutationObserver.observe(el, {childList: true, characterData: true, subtree: true})
+        mutationObserver.observe(field, {childList: true, characterData: true, subtree: true})
       } else {
-        el.addEventListener('input', () => {
-          updates.push({value: el.value, timestamp: Date.now()})
-        })
+        onInput = (event) => {
+          const target = event.target
+          if (!target || !field.contains(target)) return
+          if (typeof target.value !== 'string') return
+          updates.push({value: target.value, timestamp: Date.now()})
+        }
+        document.addEventListener('input', onInput, true)
       }
 
       // End on the explicit __finish signal from the harness rather than on
@@ -71,12 +82,13 @@ export async function measureFpsForInput({
         document.addEventListener('__finish', resolve, {once: true})
       })
 
+      if (mutationObserver) mutationObserver.disconnect()
+      if (onInput) document.removeEventListener('input', onInput, true)
+
       return updates
     })()
   `,
-    ) as (
-      el: HTMLInputElement | HTMLTextAreaElement,
-    ) => Promise<{value: string; timestamp: number}[]>,
+    ) as (el: HTMLElement) => Promise<{value: string; timestamp: number}[]>,
   )
   // This evaluate runs until the `__finish` event and is only awaited later.
   // If the context is torn down first — the A/B harness closes both browsers
@@ -134,7 +146,13 @@ export async function measureFpsForInput({
     const matchingEvent = renderEvents.find(({value}) =>
       containsBetweenMarkers(value, inputEvent.character, startingMarker, endingMarker),
     )
-    if (!matchingEvent) throw new Error(`No matching event for ${inputEvent.character}`)
+    if (!matchingEvent) {
+      throw new Error(
+        `No matching event for ${JSON.stringify(inputEvent.character)} ` +
+          `(${renderEvents.length} render events recorded; ` +
+          `last recorded value: ${JSON.stringify(tail(renderEvents.at(-1)?.value))})`,
+      )
+    }
 
     return matchingEvent.timestamp - inputEvent.timestamp
   })
@@ -145,4 +163,10 @@ export async function measureFpsForInput({
     label: label || fieldName,
     runDuration: Date.now() - start,
   }
+}
+
+/** The last part of a (potentially huge) recorded value — the markers live at the end. */
+function tail(value: string | undefined): string {
+  if (value === undefined) return '(no events recorded)'
+  return value.length > 200 ? `…${value.slice(-200)}` : value
 }

--- a/dev/efps/helpers/measureFpsForInput.ts
+++ b/dev/efps/helpers/measureFpsForInput.ts
@@ -63,13 +63,12 @@ export async function measureFpsForInput({
         })
       }
 
+      // End on the explicit __finish signal from the harness rather than on
+      // blur — a transient read-only flip can blur the field mid-run, which
+      // would end the recording early and leave the characters typed after the
+      // flip without matching render events.
       await new Promise((resolve) => {
-        const handler = () => {
-          el.removeEventListener('blur', handler)
-          resolve()
-        }
-
-        el.addEventListener('blur', handler)
+        document.addEventListener('__finish', resolve, {once: true})
       })
 
       return updates
@@ -79,10 +78,10 @@ export async function measureFpsForInput({
       el: HTMLInputElement | HTMLTextAreaElement,
     ) => Promise<{value: string; timestamp: number}[]>,
   )
-  // This evaluate runs until the field blurs and is only awaited later. If the
-  // context is torn down first — the A/B harness closes both browsers once one
-  // side settles — this promise would reject with no handler attached, an
-  // *unhandled rejection* that crashes the process and bypasses retries.
+  // This evaluate runs until the `__finish` event and is only awaited later.
+  // If the context is torn down first — the A/B harness closes both browsers
+  // once one side settles — this promise would reject with no handler attached,
+  // an *unhandled rejection* that crashes the process and bypasses retries.
   // Swallow that here so a failing run stays catchable.
   const safeRendersPromise = rendersPromise.catch((): {value: string; timestamp: number}[] => [])
   await new Promise((resolve) => setTimeout(resolve, 500))

--- a/dev/efps/helpers/measureFpsForInput.ts
+++ b/dev/efps/helpers/measureFpsForInput.ts
@@ -3,7 +3,7 @@ import {type Page} from 'playwright'
 import {type EfpsResult} from '../types'
 import {aggregateLatencies} from './aggregateLatencies'
 import {measureBlockingTime} from './measureBlockingTime'
-import {setUpMarkers, typeCharacterReliably} from './typeCharacterReliably'
+import {containsBetweenMarkers, setUpMarkers, typeCharacterReliably} from './typeCharacterReliably'
 
 interface MeasureFpsForInputOptions {
   label?: string
@@ -132,13 +132,9 @@ export async function measureFpsForInput({
   await new Promise((resolve) => setTimeout(resolve, 500))
 
   const latencies = inputEvents.map((inputEvent) => {
-    const matchingEvent = renderEvents.find(({value}) => {
-      if (!value.includes(startingMarker) || !value.includes(endingMarker)) return false
-
-      const [, afterStartingMarker] = value.split(startingMarker)
-      const [beforeEndingMarker] = afterStartingMarker.split(endingMarker)
-      return beforeEndingMarker.includes(inputEvent.character)
-    })
+    const matchingEvent = renderEvents.find(({value}) =>
+      containsBetweenMarkers(value, inputEvent.character, startingMarker, endingMarker),
+    )
     if (!matchingEvent) throw new Error(`No matching event for ${inputEvent.character}`)
 
     return matchingEvent.timestamp - inputEvent.timestamp

--- a/dev/efps/helpers/measureFpsForPte.ts
+++ b/dev/efps/helpers/measureFpsForPte.ts
@@ -3,7 +3,7 @@ import {type Page} from 'playwright'
 import {type EfpsResult} from '../types'
 import {aggregateLatencies} from './aggregateLatencies'
 import {measureBlockingTime} from './measureBlockingTime'
-import {setUpMarkers, typeCharacterReliably} from './typeCharacterReliably'
+import {containsBetweenMarkers, setUpMarkers, typeCharacterReliably} from './typeCharacterReliably'
 
 interface MeasureFpsForPteOptions {
   fieldName: string
@@ -124,13 +124,9 @@ export async function measureFpsForPte({
   const renderEvents = await safeRendersPromise
 
   const latencies = inputEvents.map((inputEvent) => {
-    const matchingEvent = renderEvents.find(({value}) => {
-      if (!value.includes(startingMarker) || !value.includes(endingMarker)) return false
-
-      const [, afterStartingMarker] = value.split(startingMarker)
-      const [beforeEndingMarker] = afterStartingMarker.split(endingMarker)
-      return beforeEndingMarker.includes(inputEvent.character)
-    })
+    const matchingEvent = renderEvents.find(({value}) =>
+      containsBetweenMarkers(value, inputEvent.character, startingMarker, endingMarker),
+    )
     if (!matchingEvent) throw new Error(`No matching event for ${inputEvent.character}`)
 
     return matchingEvent.timestamp - inputEvent.timestamp - matchingEvent.textContentProcessingTime

--- a/dev/efps/helpers/measureFpsForPte.ts
+++ b/dev/efps/helpers/measureFpsForPte.ts
@@ -33,7 +33,15 @@ export async function measureFpsForPte({
   const contentEditable = pteField.locator('[contenteditable="true"]')
   await contentEditable.waitFor({state: 'visible', timeout})
 
-  const rendersPromise = contentEditable.evaluate(
+  // The recorder is attached to the stable field wrapper rather than the
+  // contenteditable itself, and it runs until the harness dispatches the
+  // `__finish` event rather than until blur. Both matter for resilience to a
+  // transient read-only flip mid-run (see `typeCharacterReliably`): a flip
+  // remounts/blurs the editable, which would detach a MutationObserver bound to
+  // it and end a blur-based recording early — leaving no render events for the
+  // characters typed after the flip ("No matching event" failures). `childList`
+  // is also observed so text landing in freshly created DOM nodes isn't missed.
+  const rendersPromise = pteField.evaluate(
     // Had to add this so we can run the tests
     new Function(
       'el',
@@ -53,16 +61,13 @@ export async function measureFpsForPte({
         })
       })
 
-      mutationObserver.observe(el, {subtree: true, characterData: true})
+      mutationObserver.observe(el, {subtree: true, characterData: true, childList: true})
 
       await new Promise((resolve) => {
-        const handler = () => {
-          el.removeEventListener('blur', handler)
-          resolve()
-        }
-
-        el.addEventListener('blur', handler)
+        document.addEventListener('__finish', resolve, {once: true})
       })
+
+      mutationObserver.disconnect()
 
       return updates
     })()
@@ -75,10 +80,10 @@ export async function measureFpsForPte({
       }[]
     >,
   )
-  // This evaluate runs until the field blurs and is only awaited later. If the
-  // context is torn down first — the A/B harness closes both browsers once one
-  // side settles — this promise would reject with no handler attached, an
-  // *unhandled rejection* that crashes the process and bypasses retries.
+  // This evaluate runs until the `__finish` event and is only awaited later.
+  // If the context is torn down first — the A/B harness closes both browsers
+  // once one side settles — this promise would reject with no handler attached,
+  // an *unhandled rejection* that crashes the process and bypasses retries.
   // Swallow that here so a failing run stays catchable.
   const safeRendersPromise = rendersPromise.catch(
     (): {value: string; timestamp: number; textContentProcessingTime: number}[] => [],
@@ -119,6 +124,8 @@ export async function measureFpsForPte({
   }
 
   await contentEditable.blur()
+
+  await page.evaluate(() => window.document.dispatchEvent(new CustomEvent('__finish')))
 
   const blockingTime = await getBlockingTime()
   const renderEvents = await safeRendersPromise

--- a/dev/efps/helpers/measureFpsForPte.ts
+++ b/dev/efps/helpers/measureFpsForPte.ts
@@ -134,7 +134,13 @@ export async function measureFpsForPte({
     const matchingEvent = renderEvents.find(({value}) =>
       containsBetweenMarkers(value, inputEvent.character, startingMarker, endingMarker),
     )
-    if (!matchingEvent) throw new Error(`No matching event for ${inputEvent.character}`)
+    if (!matchingEvent) {
+      throw new Error(
+        `No matching event for ${JSON.stringify(inputEvent.character)} ` +
+          `(${renderEvents.length} render events recorded; ` +
+          `last recorded value: ${JSON.stringify(tail(renderEvents.at(-1)?.value))})`,
+      )
+    }
 
     return matchingEvent.timestamp - inputEvent.timestamp - matchingEvent.textContentProcessingTime
   })
@@ -145,4 +151,10 @@ export async function measureFpsForPte({
     label: label || fieldName,
     runDuration: Date.now() - start,
   }
+}
+
+/** The last part of a (potentially huge) recorded value — the markers live at the end. */
+function tail(value: string | undefined): string {
+  if (value === undefined) return '(no events recorded)'
+  return value.length > 200 ? `…${value.slice(-200)}` : value
 }

--- a/dev/efps/helpers/typeCharacterReliably.ts
+++ b/dev/efps/helpers/typeCharacterReliably.ts
@@ -16,6 +16,14 @@ import {type Locator, type Page} from 'playwright'
  * The helpers here make both the marker setup and the measured typing resilient
  * to that flip: type only while the form is editable, verify each character
  * actually landed where expected, and retry (re-placing the caret) if not.
+ *
+ * The markers are anchored at the very end of the field's value so their
+ * placement is deterministic (a click into a large Portable Text field can land
+ * the caret anywhere in the prose). Caret recovery, however, positions the
+ * caret directly before the live ending marker via the DOM selection APIs — a
+ * stray character from a failed attempt can land *after* the ending marker (a
+ * caret jump goes to the very end of the field), so any fixed-distance stepping
+ * from the end would be off by the length of the debris.
  */
 
 const ATTEMPT_TIMEOUT = 2_000
@@ -59,6 +67,12 @@ export async function setUpMarkers({
       await input.press('Delete')
     }
 
+    // Anchor the markers at the very end of the value — both so their position
+    // is deterministic (a click into a large Portable Text field can land the
+    // caret anywhere in the prose) and so caret recovery can reliably find them
+    // again (see `moveCaretToEnd`).
+    await moveCaretToEnd(input)
+
     await input.pressSequentially(endingMarker)
     for (let i = 0; i < endingMarker.length; i++) await input.press('ArrowLeft')
     await input.pressSequentially(startingMarker)
@@ -66,7 +80,12 @@ export async function setUpMarkers({
     const deadline = Date.now() + ATTEMPT_TIMEOUT
     for (;;) {
       const value = await getValue()
-      if (value.includes(startingMarker) && value.includes(endingMarker)) return
+      // Require the pair to be adjacent: nothing has been typed between the
+      // markers yet, so `___START______END___` must appear as one unit. A flip
+      // mid-setup can leave both markers present but separated (the caret
+      // jumped between typing one and the other), which would poison every
+      // subsequent between-markers match.
+      if (value.includes(startingMarker + endingMarker)) return
       if (Date.now() >= deadline) break
       await new Promise((resolve) => setTimeout(resolve, 10))
     }
@@ -114,11 +133,13 @@ export async function typeCharacterReliably({
     // drops the keystroke and moves the caret.
     await waitForEditable(page, timeout)
 
-    // On a retry the caret may have moved (a swallowed keystroke sends it to
-    // the end of the field). Re-place it between the markers before typing.
+    // On a retry the caret may have moved (a caret jump sends it to the end of
+    // the field, where a stray copy of the character may also have landed —
+    // possibly *after* the ending marker). Re-place it directly before the
+    // ending marker; positioning relative to the end of the value would be
+    // thrown off by such debris.
     if (attempt > 0) {
-      await input.press('End')
-      for (let i = 0; i < endingMarker.length; i++) await input.press('ArrowLeft')
+      await placeCaretBeforeEndingMarker(input, {startingMarker, endingMarker})
     }
 
     const timestamp = Date.now()
@@ -146,14 +167,129 @@ function waitForEditable(page: Page, timeout: number): Promise<void> {
     .waitFor({state: 'visible', timeout})
 }
 
-function containsBetweenMarkers(
+/**
+ * Moves the caret to the very end of the input's value.
+ *
+ * Uses the DOM selection APIs rather than keyboard navigation: `End` only
+ * reaches the end of the current line/block in a multi-block contenteditable
+ * (like the Portable Text editor), and the document-end shortcut differs per
+ * platform (`Control+End` vs `Meta+ArrowDown`).
+ */
+async function moveCaretToEnd(input: Locator): Promise<void> {
+  await input.evaluate((el) => {
+    // Focus before positioning the caret — focusing afterwards (which the next
+    // key press would do implicitly) can reset the selection.
+    if (el instanceof HTMLElement) el.focus()
+
+    if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+      const length = el.value.length
+      el.setSelectionRange(length, length)
+      return
+    }
+
+    const document = el.ownerDocument
+    const selection = document.getSelection()
+    if (!selection) return
+    const range = document.createRange()
+    range.selectNodeContents(el)
+    range.collapse(false)
+    selection.removeAllRanges()
+    selection.addRange(range)
+  })
+}
+
+/**
+ * Places the caret directly before the live ending marker — the first
+ * occurrence of `endingMarker` after the *last* occurrence of `startingMarker`,
+ * mirroring `containsBetweenMarkers`. Falls back to the end of the value if the
+ * markers can't be found.
+ *
+ * NOTE: the evaluate callback must not define any *named* inner functions
+ * (including arrow functions assigned to variables). The harness runs through
+ * `tsx`, and esbuild's `keepNames` transform wraps such definitions in a
+ * `__name(...)` helper call — Playwright serializes the callback with
+ * `toString()` and runs it in the page, where that helper doesn't exist
+ * (`ReferenceError: __name is not defined`).
+ */
+async function placeCaretBeforeEndingMarker(
+  input: Locator,
+  markers: {startingMarker: string; endingMarker: string},
+): Promise<void> {
+  await input.evaluate((el, {startingMarker, endingMarker}) => {
+    // Focus before positioning the caret — focusing afterwards (which the next
+    // key press would do implicitly) can reset the selection.
+    if (el instanceof HTMLElement) el.focus()
+
+    if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+      const value = el.value
+      const valueStartIndex = value.lastIndexOf(startingMarker)
+      const index = value.indexOf(
+        endingMarker,
+        valueStartIndex === -1 ? 0 : valueStartIndex + startingMarker.length,
+      )
+      const caret = index === -1 ? value.length : index
+      el.setSelectionRange(caret, caret)
+      return
+    }
+
+    const document = el.ownerDocument
+    const selection = document.getSelection()
+    if (!selection) return
+
+    // Concatenate the text nodes (mirroring `textContent`) while tracking each
+    // node's global offset, so the marker's global index can be mapped back to
+    // a (node, offset) selection position.
+    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT)
+    const nodes: {node: Node; start: number}[] = []
+    let text = ''
+    while (walker.nextNode()) {
+      nodes.push({node: walker.currentNode, start: text.length})
+      text += walker.currentNode.nodeValue ?? ''
+    }
+
+    const textStartIndex = text.lastIndexOf(startingMarker)
+    const index =
+      nodes.length === 0
+        ? -1
+        : text.indexOf(
+            endingMarker,
+            textStartIndex === -1 ? 0 : textStartIndex + startingMarker.length,
+          )
+
+    const range = document.createRange()
+    if (index === -1) {
+      range.selectNodeContents(el)
+      range.collapse(false)
+    } else {
+      let target = nodes[0]
+      for (const entry of nodes) {
+        if (entry.start > index) break
+        target = entry
+      }
+      range.setStart(target.node, index - target.start)
+      range.collapse(true)
+    }
+    selection.removeAllRanges()
+    selection.addRange(range)
+  }, markers)
+}
+
+/**
+ * Whether `character` appears between the markers. Uses the *last* occurrence
+ * of the starting marker: the live marker pair is anchored at the end of the
+ * value, and an aborted earlier `setUpMarkers` attempt can leave a stray
+ * (partial or complete) marker earlier in the prose.
+ */
+export function containsBetweenMarkers(
   value: string,
   character: string,
   startingMarker: string,
   endingMarker: string,
 ): boolean {
-  if (!value.includes(startingMarker) || !value.includes(endingMarker)) return false
-  const [, afterStartingMarker] = value.split(startingMarker)
-  const [beforeEndingMarker] = afterStartingMarker.split(endingMarker)
-  return beforeEndingMarker.includes(character)
+  const startIndex = value.lastIndexOf(startingMarker)
+  if (startIndex === -1) return false
+  const afterStartingMarker = value.slice(startIndex + startingMarker.length)
+  const endIndex = afterStartingMarker.indexOf(endingMarker)
+  if (endIndex === -1) return false
+  return afterStartingMarker.slice(0, endIndex).includes(character)
 }

--- a/packages/sanity/src/core/preview/observeVersionDocumentIds.ts
+++ b/packages/sanity/src/core/preview/observeVersionDocumentIds.ts
@@ -74,7 +74,10 @@ export function createObserveVersionDocumentIds(options: {
     const instance = invalidationChannel.pipe(
       filter(
         (event) =>
-          event.type === 'connected' || getPublishedId(event.documentId) === documentGroupId,
+          event.type === 'connected' ||
+          (getPublishedId(event.documentId) === documentGroupId &&
+            event.type === 'mutation' &&
+            ['appear', 'disappear'].includes(event.transition)),
       ),
       switchMap((event) => {
         if (event.type === 'connected' || event.visibility === 'query') {

--- a/packages/sanity/src/core/preview/types.ts
+++ b/packages/sanity/src/core/preview/types.ts
@@ -1,4 +1,4 @@
-import {type StackablePerspective} from '@sanity/client'
+import {type MutationEvent, type StackablePerspective} from '@sanity/client'
 import {
   type CrossDatasetType,
   type GlobalDocumentReferenceType,
@@ -143,9 +143,7 @@ export interface DraftsModelDocument<T extends SanityDocumentLike = SanityDocume
  * @hidden
  * @beta
  */
-export type InvalidationChannelEvent =
-  | {type: 'connected'}
-  | {type: 'mutation'; documentId: string; visibility: string}
+export type InvalidationChannelEvent = {type: 'connected'} | MutationEvent
 
 /**
  * @hidden

--- a/packages/sanity/src/core/releases/store/__tests__/reducer.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/reducer.test.ts
@@ -1,0 +1,124 @@
+import {describe, expect, it} from 'vitest'
+
+import {activeASAPRelease, activeScheduledRelease} from '../../__fixtures__/release.fixture'
+import {releasesReducer, type ReleasesReducerState} from '../reducer'
+
+describe('releasesReducer', () => {
+  describe('RELEASES_SET', () => {
+    it('stores the payload keyed by release id', () => {
+      const initialState: ReleasesReducerState = {
+        releases: new Map(),
+        state: 'loaded',
+      }
+
+      const nextState = releasesReducer(initialState, {
+        type: 'RELEASES_SET',
+        payload: [activeASAPRelease, activeScheduledRelease],
+      })
+
+      expect(Array.from(nextState.releases.keys())).toEqual([
+        activeASAPRelease._id,
+        activeScheduledRelease._id,
+      ])
+      expect(nextState.releases.get(activeASAPRelease._id)).toBe(activeASAPRelease)
+    })
+
+    it('preserves state identity when the payload is equivalent to the current state', () => {
+      const initialState: ReleasesReducerState = {
+        releases: new Map([[activeASAPRelease._id, activeASAPRelease]]),
+        state: 'loaded',
+      }
+
+      const nextState = releasesReducer(initialState, {
+        type: 'RELEASES_SET',
+        // Equivalent payload (same `_id` and `_rev`), but a fresh document instance — as produced
+        // by the refetch-on-listener-event behaviour in `createReleaseStore`
+        payload: [{...activeASAPRelease}],
+      })
+
+      expect(nextState).toBe(initialState)
+      expect(nextState.releases).toBe(initialState.releases)
+    })
+
+    it('returns a new map when a release has a new revision', () => {
+      const initialState: ReleasesReducerState = {
+        releases: new Map([[activeASAPRelease._id, activeASAPRelease]]),
+        state: 'loaded',
+      }
+
+      const nextState = releasesReducer(initialState, {
+        type: 'RELEASES_SET',
+        payload: [{...activeASAPRelease, _rev: 'newRev'}],
+      })
+
+      expect(nextState).not.toBe(initialState)
+      expect(nextState.releases.get(activeASAPRelease._id)?._rev).toBe('newRev')
+    })
+
+    it('returns a new map when a release is added', () => {
+      const initialState: ReleasesReducerState = {
+        releases: new Map([[activeASAPRelease._id, activeASAPRelease]]),
+        state: 'loaded',
+      }
+
+      const nextState = releasesReducer(initialState, {
+        type: 'RELEASES_SET',
+        payload: [activeASAPRelease, activeScheduledRelease],
+      })
+
+      expect(nextState).not.toBe(initialState)
+      expect(nextState.releases.size).toBe(2)
+    })
+
+    it('returns a new map when a release is removed', () => {
+      const initialState: ReleasesReducerState = {
+        releases: new Map([
+          [activeASAPRelease._id, activeASAPRelease],
+          [activeScheduledRelease._id, activeScheduledRelease],
+        ]),
+        state: 'loaded',
+      }
+
+      const nextState = releasesReducer(initialState, {
+        type: 'RELEASES_SET',
+        payload: [activeASAPRelease],
+      })
+
+      expect(nextState).not.toBe(initialState)
+      expect(nextState.releases.size).toBe(1)
+    })
+
+    it('returns a new map when a release is replaced by another with the same count', () => {
+      const initialState: ReleasesReducerState = {
+        releases: new Map([[activeASAPRelease._id, activeASAPRelease]]),
+        state: 'loaded',
+      }
+
+      const nextState = releasesReducer(initialState, {
+        type: 'RELEASES_SET',
+        payload: [activeScheduledRelease],
+      })
+
+      expect(nextState).not.toBe(initialState)
+      expect(Array.from(nextState.releases.keys())).toEqual([activeScheduledRelease._id])
+    })
+  })
+
+  describe('LOADING_STATE_CHANGED', () => {
+    it('updates loading state without touching releases', () => {
+      const releases = new Map([[activeASAPRelease._id, activeASAPRelease]])
+      const initialState: ReleasesReducerState = {
+        releases,
+        state: 'loading',
+      }
+
+      const nextState = releasesReducer(initialState, {
+        type: 'LOADING_STATE_CHANGED',
+        payload: {loading: false, error: undefined},
+      })
+
+      expect(nextState.state).toBe('loaded')
+      expect(nextState.releases).toBe(releases)
+    })
+  })
+})

--- a/packages/sanity/src/core/releases/store/__tests__/useActiveReleases.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/useActiveReleases.test.ts
@@ -9,6 +9,7 @@ import {
   activeScheduledRelease,
   archivedScheduledRelease,
 } from '../../__fixtures__/release.fixture'
+import {releaseStoreSortedReleases} from '../createReleaseStore'
 import {useActiveReleases} from '../useActiveReleases'
 
 interface ReleasesState {
@@ -23,10 +24,12 @@ const initialState: ReleasesState = {
 }
 
 const mockState$ = new BehaviorSubject<ReleasesState>(initialState)
+const mockSortedReleases$ = mockState$.pipe(releaseStoreSortedReleases())
 const mockDispatch = vi.fn()
 
 const mockUseReleasesStore = vi.fn(() => ({
   state$: mockState$,
+  sortedReleases$: mockSortedReleases$,
   dispatch: mockDispatch,
 }))
 

--- a/packages/sanity/src/core/releases/store/createReleaseStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseStore.ts
@@ -22,9 +22,16 @@ import {distinctUntilChanged, map, startWith} from 'rxjs/operators'
 
 import {type DocumentPreviewStore} from '../../preview'
 import {listenQuery} from '../../store'
+import {sortReleases} from '../hooks/utils'
+import {ARCHIVED_RELEASE_STATES} from '../util/const'
 import {RELEASE_DOCUMENT_TYPE, RELEASE_DOCUMENTS_PATH} from './constants'
 import {createReleaseMetadataAggregator} from './createReleaseMetadataAggregator'
-import {releasesReducer, type ReleasesReducerAction, type ReleasesReducerState} from './reducer'
+import {
+  releasesAreEqual,
+  releasesReducer,
+  type ReleasesReducerAction,
+  type ReleasesReducerState,
+} from './reducer'
 import {type ReleaseStore} from './types'
 
 type ActionWrapper = {action: ReleasesReducerAction}
@@ -148,14 +155,42 @@ export function createReleaseStore(context: {
 
   const errorCount$ = state$.pipe(releaseStoreErrorCount(), shareReplay(1))
 
+  const sortedReleases$ = state$.pipe(releaseStoreSortedReleases(), shareReplay(1))
+
   const getMetadataStateForSlugs$ = createReleaseMetadataAggregator(client)
 
   return {
     state$,
     errorCount$,
+    sortedReleases$,
     getMetadataStateForSlugs$,
     dispatch,
   }
+}
+
+/**
+ * Derives the sorted array of active (non-archived) releases from the reducer state.
+ *
+ * The releases are compared by content (each release's `_rev`), so the emitted array reference is
+ * stable across unrelated state updates (e.g. loading state changes or refetches yielding
+ * identical data), allowing consumers to safely memoize on it.
+ *
+ * @internal
+ */
+export function releaseStoreSortedReleases(): OperatorFunction<
+  ReleasesReducerState,
+  ReleaseDocument[]
+> {
+  return pipe(
+    distinctUntilChanged((previous, next) => releasesAreEqual(previous.releases, next.releases)),
+    map(({releases}) =>
+      sortReleases(
+        Array.from(releases.values()).filter(
+          (release) => !ARCHIVED_RELEASE_STATES.includes(release.state),
+        ),
+      ).reverse(),
+    ),
+  )
 }
 
 /**

--- a/packages/sanity/src/core/releases/store/reducer.ts
+++ b/packages/sanity/src/core/releases/store/reducer.ts
@@ -72,7 +72,13 @@ export function releasesReducer(
   }
 }
 
-function releasesAreEqual(
+/**
+ * Compares two release maps by content, using each release's `_rev` as the
+ * change signal.
+ *
+ * @internal
+ */
+export function releasesAreEqual(
   previous: Map<string, ReleaseDocument>,
   next: Map<string, ReleaseDocument>,
 ): boolean {

--- a/packages/sanity/src/core/releases/store/reducer.ts
+++ b/packages/sanity/src/core/releases/store/reducer.ts
@@ -55,6 +55,12 @@ export function releasesReducer(
       // Create an object with the BUNDLE id as key
       const releasesById = createReleasesSet(action.payload)
 
+      // Maintain a stable value when the release content is unchanged, allowing
+      // the value to be safely memoized by consumers.
+      if (releasesAreEqual(state.releases, releasesById)) {
+        return state
+      }
+
       return {
         ...state,
         releases: releasesById,
@@ -64,4 +70,22 @@ export function releasesReducer(
     default:
       return state
   }
+}
+
+function releasesAreEqual(
+  previous: Map<string, ReleaseDocument>,
+  next: Map<string, ReleaseDocument>,
+): boolean {
+  if (previous.size !== next.size) {
+    return false
+  }
+
+  for (const [id, release] of next) {
+    const previousRelease = previous.get(id)
+    if (!previousRelease || previousRelease._rev !== release._rev) {
+      return false
+    }
+  }
+
+  return true
 }

--- a/packages/sanity/src/core/releases/store/types.ts
+++ b/packages/sanity/src/core/releases/store/types.ts
@@ -40,6 +40,12 @@ export interface ReleaseStore {
    * This is determined by the presence of the `error` field in the release document.
    */
   errorCount$: Observable<number>
+  /**
+   * Sorted array of releases, excluding archived releases. Emits a new array only when the
+   * underlying release data changes, keeping the array reference stable across unrelated store
+   * updates so consumers can safely memoize on it.
+   */
+  sortedReleases$: Observable<ReleaseDocument[]>
   getMetadataStateForSlugs$: (slugs: string[]) => Observable<MetadataWrapper>
   dispatch: Dispatch<ReleasesReducerAction>
 }

--- a/packages/sanity/src/core/releases/store/useActiveReleases.ts
+++ b/packages/sanity/src/core/releases/store/useActiveReleases.ts
@@ -2,8 +2,7 @@ import {type ReleaseDocument} from '@sanity/client'
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
 
-import {sortReleases} from '../hooks/utils'
-import {ARCHIVED_RELEASE_STATES} from '../util/const'
+import {EMPTY_ARRAY} from '../../util/empty'
 import {type ReleasesReducerAction} from './reducer'
 import {useReleasesStore} from './useReleasesStore'
 
@@ -22,25 +21,17 @@ interface ReleasesState {
  * @internal
  */
 export function useActiveReleases(): ReleasesState {
-  const {state$, dispatch} = useReleasesStore()
+  const {state$, sortedReleases$, dispatch} = useReleasesStore()
   const state = useObservable(state$)!
-  const releasesAsArray = useMemo(
-    () =>
-      sortReleases(
-        Array.from(state.releases.values()).filter(
-          (release) => !ARCHIVED_RELEASE_STATES.includes(release.state),
-        ),
-      ).reverse(),
-    [state.releases],
-  )
+  const data = useObservable(sortedReleases$, EMPTY_ARRAY)
 
   return useMemo(
     () => ({
-      data: releasesAsArray,
+      data,
       dispatch,
       error: state.error,
       loading: ['loading', 'initialising'].includes(state.state),
     }),
-    [releasesAsArray, state.error, state.state, dispatch],
+    [data, state.error, state.state, dispatch],
   )
 }


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
