### PR TITLE
fix(sanity): delegate grants request errors to request error handler

### DIFF
--- a/packages/sanity/src/core/store/datastores.ts
+++ b/packages/sanity/src/core/store/datastores.ts
@@ -7,7 +7,7 @@ import {useObservable} from 'react-rx'
 import {useClient, useSchema, useTemplates} from '../hooks'
 import {useTranslation} from '../i18n/hooks/useTranslation'
 import {createDocumentPreviewStore, type DocumentPreviewStore} from '../preview'
-import {useSource, useWorkspace} from '../studio'
+import {useSource, useStudioErrorHandler, useWorkspace} from '../studio'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../studioClient'
 import {createComlinkStore} from './comlink/createComlinkStore'
 import {type ComlinkStore} from './comlink/types'
@@ -82,22 +82,23 @@ export function useGrantsStore(): GrantsStore {
   const client = getClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const currentUser = useCurrentUser()
   const resourceCache = useResourceCache()
+  const errorHandler = useStudioErrorHandler()
 
   return useMemo(() => {
     const grantsStore =
       resourceCache.get<GrantsStore>({
         namespace: 'grantsStore',
-        dependencies: [client, currentUser],
-      }) || createGrantsStore({client, userId: currentUser?.id || null})
+        dependencies: [client, currentUser, errorHandler],
+      }) || createGrantsStore({client, userId: currentUser?.id || null, errorHandler})
 
     resourceCache.set({
       namespace: 'grantsStore',
-      dependencies: [client, currentUser],
+      dependencies: [client, currentUser, errorHandler],
       value: grantsStore,
     })
 
     return grantsStore
-  }, [client, currentUser, resourceCache])
+  }, [client, currentUser, errorHandler, resourceCache])
 }
 
 /**

--- a/packages/sanity/src/core/store/grants/__tests__/createGrantsStore.test.ts
+++ b/packages/sanity/src/core/store/grants/__tests__/createGrantsStore.test.ts
@@ -4,7 +4,7 @@ import {first} from 'rxjs/operators'
 import {describe, expect, it, type Mock, vi} from 'vitest'
 
 import {viewer} from '../debug/exampleGrants'
-import {createGrantsStore} from '../grantsStore'
+import {createGrantsStore, type GrantsStoreErrorHandler} from '../grantsStore'
 
 function createMockClient(data: {requests?: Record<string, any>} = {}): SanityClient {
   const mockConfig = {
@@ -68,5 +68,42 @@ describe('checkDocumentPermission', () => {
         },
       ],
     ])
+  })
+
+  it('delegates request failures to the error handler and recovers when it re-runs the request', async () => {
+    const client = createMockClient({
+      requests: {
+        '/acl': viewer,
+      },
+    })
+    // First attempt fails with a network error; the re-run falls back to
+    // the default mock and succeeds.
+    const networkError = new Error('Request error while attempting to reach host')
+    ;(client.request as Mock).mockRejectedValueOnce(networkError)
+
+    // Ad-hoc handler implementing the recovery contract: re-run a failed
+    // retryable request and resolve off the successful attempt.
+    const delegated: unknown[] = []
+    const errorHandler: GrantsStoreErrorHandler = {
+      attempt: (thunk, options) =>
+        thunk().catch((err) => {
+          if (!options?.retryable) throw err
+          delegated.push(err)
+          return thunk()
+        }),
+    }
+
+    const {checkDocumentPermission} = createGrantsStore({client, userId: null, errorHandler})
+
+    // The failure is handed to the handler instead of erroring the
+    // permission stream; the stream resolves off the re-run request.
+    await expect(
+      firstValueFrom(checkDocumentPermission('read', {_id: 'example-id', _type: 'book'})),
+    ).resolves.toEqual({
+      granted: true,
+      reason: 'Matching grant',
+    })
+    expect(delegated).toEqual([networkError])
+    expect(client.request).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/sanity/src/core/store/grants/grantsStore.ts
+++ b/packages/sanity/src/core/store/grants/grantsStore.ts
@@ -15,18 +15,44 @@ import {
   type PermissionCheckResult,
 } from './types'
 
+/**
+ * Handles failures of requests made by the grants store. The store has no
+ * way to recover when the grants request fails — every permission check
+ * depends on it — so it hands the failed request to this handler instead
+ * of erroring its permission streams.
+ *
+ * @internal
+ */
+export interface GrantsStoreErrorHandler {
+  /**
+   * Runs `thunk` and takes responsibility for its failures. An
+   * implementation may recover by re-invoking the thunk — the returned
+   * promise resolves with the first successful attempt. Failures the
+   * handler cannot take responsibility for reject the returned promise.
+   *
+   * `retryable: true` is the store's assertion that the request is
+   * idempotent and safe to re-run.
+   */
+  attempt<T>(thunk: () => Promise<T>, options?: {retryable?: boolean}): Promise<T>
+}
+
 async function getDatasetGrants(
   client: SanityClient,
   projectId: string,
   dataset: string,
+  errorHandler: GrantsStoreErrorHandler | undefined,
 ): Promise<Grant[]> {
   // `acl` stands for access control list and returns a list of grants
-  const grants: Grant[] = await client.request({
-    uri: `/projects/${projectId}/datasets/${dataset}/acl`,
-    tag: 'acl.get',
-  })
+  const fetchGrants = () =>
+    client.request<Grant[]>({
+      uri: `/projects/${projectId}/datasets/${dataset}/acl`,
+      tag: 'acl.get',
+    })
 
-  return grants
+  // Every permission check depends on this read, so there is no local
+  // recovery if it fails — delegate failures to the error handler when one
+  // is provided. Retryable: it's an idempotent GET, safe to re-run.
+  return errorHandler ? errorHandler.attempt(fetchGrants, {retryable: true}) : fetchGrants()
 }
 
 function getParams(userId: string | null): EvaluationParams {
@@ -60,6 +86,11 @@ async function matchesFilter(userId: string | null, filter: string, document: Sa
 interface GrantsStoreOptionsCurrentUser {
   client: SanityClient
   /**
+   * Optional handler for failures of requests made by the store. When
+   * omitted, request failures propagate to the permission streams.
+   */
+  errorHandler?: GrantsStoreErrorHandler
+  /**
    * @deprecated The `currentUser` option is deprecated. Use `userId` instead.
    */
   currentUser: CurrentUser | null
@@ -67,6 +98,11 @@ interface GrantsStoreOptionsCurrentUser {
 
 interface GrantsStoreOptionsUserId {
   client: SanityClient
+  /**
+   * Optional handler for failures of requests made by the store. When
+   * omitted, request failures propagate to the permission streams.
+   */
+  errorHandler?: GrantsStoreErrorHandler
   userId: string | null
 }
 
@@ -75,7 +111,7 @@ export type GrantsStoreOptions = GrantsStoreOptionsCurrentUser | GrantsStoreOpti
 
 /** @internal */
 export function createGrantsStore(opts: GrantsStoreOptions): GrantsStore {
-  const {client} = opts
+  const {client, errorHandler} = opts
   const versionedClient = client.withConfig({apiVersion: '2021-06-07'})
   const userId = 'userId' in opts ? opts.userId : opts?.currentUser?.id || null
 
@@ -84,7 +120,7 @@ export function createGrantsStore(opts: GrantsStoreOptions): GrantsStore {
       if (!projectId || !dataset) {
         throw new Error('Missing projectId or dataset')
       }
-      return getDatasetGrants(versionedClient, projectId, dataset)
+      return getDatasetGrants(versionedClient, projectId, dataset, errorHandler)
     }),
   )
 


### PR DESCRIPTION
### Description
This wraps the grants ACL fetch in `attempt()` so infra failures reach the studio's request-error dialog with retry instead of erroring the permission streams.

### What to review


### Testing
Unit tests included.

Easiest way to test manually is to open preview build, enable request blocking on the acl request and make sure it reaches the error dialog

### Notes for release
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how permission checks fail when ACL loading breaks, but uses an existing retry dialog pattern on an idempotent GET; omitted handler preserves prior stream-error behavior.
> 
> **Overview**
> When the dataset **ACL** (`acl.get`) request fails, permission checks no longer break their Rx streams outright. The grants store now routes that idempotent fetch through an optional **`GrantsStoreErrorHandler.attempt()`**, marked **`retryable: true`**, so infra/network failures can be handled centrally instead of erroring every permission observable.
> 
> **`useGrantsStore`** wires in **`useStudioErrorHandler()`** and passes it into **`createGrantsStore`**, with the resource cache keyed on the handler as well. Without an error handler, behavior stays the same: failures still propagate to permission streams.
> 
> A unit test covers delegation on a failed first request and recovery when the handler re-runs the thunk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee9d2c1274d5e759ef1c58d2c95d40fa1f3abc66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->