### PR TITLE
fix(core): draw change connector when hovering image and file diffs

### DIFF
--- a/packages/sanity/src/core/changeIndicators/helpers/findMostSpecificTarget.test.ts
+++ b/packages/sanity/src/core/changeIndicators/helpers/findMostSpecificTarget.test.ts
@@ -1,0 +1,108 @@
+import {type Path} from '@sanity/types'
+import * as PathUtils from '@sanity/util/paths'
+import {describe, expect, it} from 'vitest'
+
+import {type TrackedArea, type TrackedChange} from '../tracker'
+import {findMostSpecificTarget} from './findMostSpecificTarget'
+
+function trackedChange(path: Path, options: {isChanged?: boolean} = {}): TrackedChange {
+  return {
+    element: null,
+    path,
+    isChanged: options.isChanged ?? true,
+    hasFocus: false,
+    hasHover: false,
+    hasRevertHover: false,
+    zIndex: 1,
+  }
+}
+
+function toValues(
+  entries: [string, TrackedChange | TrackedArea][],
+): Map<string, TrackedChange | TrackedArea> {
+  return new Map(entries)
+}
+
+function fieldId(path: Path): string {
+  return `field-${PathUtils.toString(path)}`
+}
+
+function changeId(path: Path): string {
+  return `change-${PathUtils.toString(path)}`
+}
+
+describe('findMostSpecificTarget', () => {
+  it('returns the target registered at the exact same path', () => {
+    const field = trackedChange(['title'])
+    const values = toValues([
+      [fieldId(['title']), field],
+      [changeId(['title']), trackedChange(['title'])],
+    ])
+
+    expect(findMostSpecificTarget('field', changeId(['title']), values)).toBe(field)
+  })
+
+  it('falls back to the closest less specific target', () => {
+    // Hovering the image input in the form (registered at `image.asset`) should find the
+    // change registered for the whole image field.
+    const change = trackedChange(['image'])
+    const values = toValues([
+      [fieldId(['image', 'asset']), trackedChange(['image', 'asset'])],
+      [changeId(['image']), change],
+    ])
+
+    expect(findMostSpecificTarget('change', fieldId(['image', 'asset']), values)).toBe(change)
+  })
+
+  it('falls back to the closest changed target nested inside the path', () => {
+    // Hovering the image diff in the changes panel (registered at `image`) should find the
+    // form-side change indicator, which image inputs register at `image.asset`.
+    const field = trackedChange(['image', 'asset'])
+    const values = toValues([
+      [fieldId(['image', 'asset']), field],
+      [changeId(['image']), trackedChange(['image'])],
+    ])
+
+    expect(findMostSpecificTarget('field', changeId(['image']), values)).toBe(field)
+  })
+
+  it('prefers the least deeply nested changed target inside the path', () => {
+    const shallow = trackedChange(['address', 'city'])
+    const deep = trackedChange(['address', 'location', 'lat'])
+    const values = toValues([
+      [fieldId(['address', 'location', 'lat']), deep],
+      [fieldId(['address', 'city']), shallow],
+      [changeId(['address']), trackedChange(['address'])],
+    ])
+
+    expect(findMostSpecificTarget('field', changeId(['address']), values)).toBe(shallow)
+  })
+
+  it('ignores unchanged targets nested inside the path', () => {
+    const values = toValues([
+      [fieldId(['address', 'city']), trackedChange(['address', 'city'], {isChanged: false})],
+      [changeId(['address']), trackedChange(['address'])],
+    ])
+
+    expect(findMostSpecificTarget('field', changeId(['address']), values)).toBeUndefined()
+  })
+
+  it('does not match targets in a different branch of the tree', () => {
+    const values = toValues([
+      [fieldId(['bar', 'baz']), trackedChange(['bar', 'baz'])],
+      [changeId(['foo']), trackedChange(['foo'])],
+    ])
+
+    expect(findMostSpecificTarget('field', changeId(['foo']), values)).toBeUndefined()
+  })
+
+  it('matches a target whose path only differs by a trailing key', () => {
+    const field = trackedChange(['body', {_key: 'abc123'}], {isChanged: false})
+    const values = toValues([
+      [fieldId(['body', {_key: 'abc123'}]), field],
+      [changeId(['body']), trackedChange(['body'])],
+    ])
+
+    expect(findMostSpecificTarget('field', changeId(['body']), values)).toBe(field)
+  })
+})

--- a/packages/sanity/src/core/changeIndicators/helpers/findMostSpecificTarget.ts
+++ b/packages/sanity/src/core/changeIndicators/helpers/findMostSpecificTarget.ts
@@ -31,6 +31,31 @@ export function findMostSpecificTarget(
     }
   }
 
+  /* Neither an exact nor a less specific match exists, so look for the closest changed target
+   * nested inside the path. Some inputs only register change indicators at a deeper path than
+   * the change itself, e.g. image and file inputs register `<field>.asset`, while the changes
+   * panel registers the diff at `<field>`. Without this, hovering such a diff finds no
+   * form-side target, so no connector is drawn.
+   */
+  let closestDescendant: TrackedChange | undefined
+  for (const [targetId, target] of values) {
+    if (!('path' in target) || !targetId.startsWith(targetType)) {
+      continue
+    }
+
+    if (
+      target.isChanged &&
+      target.path.length > path.length &&
+      PathUtils.numEqualSegments(path, target.path) === path.length &&
+      (!closestDescendant || target.path.length < closestDescendant.path.length)
+    ) {
+      closestDescendant = target
+    }
+  }
+  if (closestDescendant) {
+    return closestDescendant
+  }
+
   let mostSpecific: TrackedChange | undefined
   for (const [targetId, target] of values) {
     if (!('path' in target) || !targetId.startsWith(targetType)) {

--- a/packages/sanity/src/core/changeIndicators/overlay/ConnectorsOverlay.test.tsx
+++ b/packages/sanity/src/core/changeIndicators/overlay/ConnectorsOverlay.test.tsx
@@ -1,4 +1,5 @@
 import {act, render, screen} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
 import {afterAll, beforeAll, describe, expect, it} from 'vitest'
 
 import {createTestProvider} from '../../../../test/testUtils/TestProvider'
@@ -112,6 +113,39 @@ describe('ConnectorsOverlay', () => {
     render(<Harness isReviewChangesOpen={false} />, {wrapper: TestProvider})
 
     const overlay = screen.getByTestId('change-connectors-overlay')
+
+    await waitForOverlayToSettle()
+    expect(overlay.querySelector('path')).toBeNull()
+  })
+
+  it('draws a connector when hovering a diff whose form field is registered at a deeper path', async () => {
+    // Image and file inputs register their change indicator at `<field>.asset` while the
+    // changes panel registers the diff at `<field>`.
+    const TestProvider = await createTestProvider()
+
+    render(
+      <ChangeConnectorRoot isReviewChangesOpen onOpenReviewChanges={() => {}} onSetFocus={() => {}}>
+        <ChangeIndicator hasFocus={false} isChanged path={['image', 'asset']}>
+          <div>field</div>
+        </ChangeIndicator>
+        <ChangeFieldWrapper hasRevertHover={false} path={['image']}>
+          <div>change</div>
+        </ChangeFieldWrapper>
+      </ChangeConnectorRoot>,
+      {wrapper: TestProvider},
+    )
+
+    const overlay = screen.getByTestId('change-connectors-overlay')
+
+    await waitForOverlayToSettle()
+    expect(overlay.querySelector('path')).toBeNull()
+
+    await userEvent.hover(screen.getByText('change'))
+
+    await waitForOverlayToSettle()
+    expect(overlay.querySelector('path')).not.toBeNull()
+
+    await userEvent.unhover(screen.getByText('change'))
 
     await waitForOverlayToSettle()
     expect(overlay.querySelector('path')).toBeNull()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Hovering an image (or file) diff in the Review changes panel drew no connector line, while hovering the same field on the form side did. The asymmetry comes from where each side registers its change indicator: image/file inputs register on the form at `<field>.asset`, but the changes panel registers the diff at `<field>`. `findMostSpecificTarget` could resolve from a deeper path up to a less specific one (form → panel), but not downwards (panel → form), so the panel-side hover found no form target and the connector was skipped.

The fix adds a walk-down fallback: when no exact or less specific match exists, resolve to the closest changed target nested inside the path. Alternatives considered:

- Registering an extra `ChangeFieldWrapper` at `<field>.asset` inside `ImageFieldDiff`/`FileFieldDiff`: only fixes the preview block (not the whole diff row, revert-hover, or other field types with the same registration asymmetry).
- Adding a field-level `ChangeIndicator` around image/file inputs on the form: would stack a second change bar next to the existing asset-level one.

### What to review

- `packages/sanity/src/core/changeIndicators/helpers/findMostSpecificTarget.ts` — the new fallback runs after the existing exact/less-specific lookups and before the legacy partial-match loop. It only matches targets that are `isChanged`, preventing connectors to unchanged sibling fields.
- Only the `sanity` package is affected; the helper is used exclusively by `ConnectorsOverlay`.

### Testing

- Added unit tests for `findMostSpecificTarget` covering exact, less specific, nested (the image case), unchanged-target skipping, sibling-branch rejection, and the preserved trailing-`_key` behavior.
- Added a `ConnectorsOverlay` test that hovers a diff registered at `image` with a form indicator registered at `image.asset` and asserts a connector is drawn (fails without the fix).
- Manually verified in the test studio with an author document (published + edited draft with a different image): hovering the image diff in the Review changes panel now draws the connector, and form-side hover still works.

[connector_appears_on_image_diff_hover_after_fix.mp4](https://cursor.com/agents/bc-e12f9a5d-ba9e-4a46-b31d-59c8711e474b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconnector_appears_on_image_diff_hover_after_fix.mp4)

[Connector shown when hovering the image diff in the Review changes panel](https://cursor.com/agents/bc-e12f9a5d-ba9e-4a46-b31d-59c8711e474b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconnector_shown_when_hovering_image_diff_in_panel.webp)

### Notes for release

Hovering an image or file diff in the Review changes panel now draws the change connector between the form field and the diff, matching the behavior of other field types.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e12f9a5d-ba9e-4a46-b31d-59c8711e474b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e12f9a5d-ba9e-4a46-b31d-59c8711e474b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

