### PR TITLE
refactor(variants): use sanity::partOfVariant for document queries

### DIFF
--- a/packages/sanity/src/core/variants/hooks/useVariantDocuments.ts
+++ b/packages/sanity/src/core/variants/hooks/useVariantDocuments.ts
@@ -4,27 +4,26 @@ import {
   type DocumentInRelease,
   useBundleDocuments,
 } from '../../releases/tool/detail/useBundleDocuments'
+import {getVariantId} from '../tool/util'
 
 /**
  * Hook to fetch the documents that belong to a variant.
  *
- * Reuses the generic {@link useBundleDocuments} machinery. Currently filters by
- * `_system.variant._ref` until `sanity::partOfVariant($variantId)` is supported
- * in content lake.
+ * Reuses the generic {@link useBundleDocuments} machinery with
+ * `sanity::partOfVariant($variantId)`.
  *
  * @internal
  */
-export function useVariantDocuments(variantId: string): {
+export function useVariantDocuments(variantDocumentId: string): {
   loading: boolean
   results: DocumentInRelease[]
   error: null | Error
 } {
+  const variantId = getVariantId(variantDocumentId)
   const params = useMemo(() => ({variantId}), [variantId])
 
   return useBundleDocuments({
-    // TODO: Switch to `sanity::partOfVariant` when content lake supports it.
-    // groqFilter: `sanity::partOfVariant($variantId)`,
-    groqFilter: `_system.variant._ref == $variantId`,
+    groqFilter: `sanity::partOfVariant($variantId)`,
     params,
     cacheKey: `variant-${variantId}`,
   })


### PR DESCRIPTION
### Description

Content lake now supports `sanity::partOfVariant`, so the variant detail document list can use the dedicated GROQ function instead of filtering on `_system.variant._ref`.

The query param is normalized to the short variant id via `getVariantId`, matching how `sanity::partOfRelease($releaseId)` works for releases.

### What to review

- `packages/sanity/src/core/variants/hooks/useVariantDocuments.ts` — 

### Testing

- Open a variant in the Variants tool and confirm its documents load correctly
- No automated test changes; behavior should be equivalent to the previous `_system.variant._ref` filter

### Notes for release

N/A – Internal only