### PR TITLE
perf(util): inline the `date-fns` parser

### DIFF
--- a/packages/@sanity/util/package.json
+++ b/packages/@sanity/util/package.json
@@ -126,7 +126,6 @@
     "@date-fns/utc": "^2.1.1",
     "@sanity/client": "catalog:",
     "@sanity/types": "workspace:*",
-    "date-fns": "^4.4.0",
     "rxjs": "^7.8.2"
   },
   "devDependencies": {
@@ -136,6 +135,7 @@
     "@sanity/pkg-utils": "catalog:",
     "@types/node": "catalog:",
     "@typescript/native-preview": "catalog:",
+    "date-fns": "^4.4.0",
     "rimraf": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"

--- a/packages/@sanity/util/src/datetime-formatter/formatter.ts
+++ b/packages/@sanity/util/src/datetime-formatter/formatter.ts
@@ -1,5 +1,3 @@
-import {format} from 'date-fns/format'
-
 import sanitizeLocale from './sanitizeLocale'
 
 function getMonthName(
@@ -103,6 +101,20 @@ function getTimeZoneAbbreviation(date: Date) {
   }).formatToParts(date)
   const tz = parts.find((part) => part.type === 'timeZoneName')
   return tz ? tz.value : ''
+}
+
+/**
+ * ISO 8601 numeric offset like "+02:00" (withColon) or "+0200".
+ * `getTimezoneOffset()` reports minutes *behind* UTC, so it's negated; a zero
+ * offset renders as "+00:00"/"+0000", never "Z".
+ */
+function formatOffset(date: Date, withColon: boolean): string {
+  const offsetMinutes = -date.getTimezoneOffset()
+  const sign = offsetMinutes >= 0 ? '+' : '-'
+  const abs = Math.abs(offsetMinutes)
+  const hours = zeroPad(Math.floor(abs / 60), 2)
+  const minutes = zeroPad(abs % 60, 2)
+  return withColon ? `${sign}${hours}:${minutes}` : `${sign}${hours}${minutes}`
 }
 
 /**
@@ -254,8 +266,8 @@ function formatMomentLike(date: Date, formatStr: string): string {
     // Time zone offset
     {key: 'z', getValue: () => getTimeZoneAbbreviation(date)},
     {key: 'zz', getValue: () => getTimeZoneAbbreviation(date)},
-    {key: 'Z', getValue: () => format(date, 'xxx')},
-    {key: 'ZZ', getValue: () => format(date, 'xx')},
+    {key: 'Z', getValue: () => formatOffset(date, true)},
+    {key: 'ZZ', getValue: () => formatOffset(date, false)},
 
     // Time
     {key: 'LTS', getValue: () => getLocalizedDate(date, {timeStyle: 'medium'})},

--- a/packages/@sanity/util/src/legacyDateFormat.test.ts
+++ b/packages/@sanity/util/src/legacyDateFormat.test.ts
@@ -163,6 +163,25 @@ describe('legacyDateFormat', () => {
       // In our mocked Oslo timezone (UTC+1 in winter)
       expect(result).toBe('2024-11-17 16:30')
     })
+
+    describe('Z/ZZ timezone offset tokens', () => {
+      // A winter date pins each zone to standard time, avoiding DST ambiguity.
+      const winter = new Date('2025-01-15T12:00:00.000Z')
+
+      test('renders a negative offset with its sign', () => {
+        expect(format(winter, 'Z', {timeZone: 'America/New_York'})).toBe('-05:00')
+        expect(format(winter, 'ZZ', {timeZone: 'America/New_York'})).toBe('-0500')
+      })
+
+      test('renders a fractional (30-minute) offset', () => {
+        expect(format(winter, 'Z', {timeZone: 'Asia/Kolkata'})).toBe('+05:30')
+      })
+
+      test('renders a zero offset as +00:00, never "Z"', () => {
+        expect(format(winter, 'Z', {useUTC: true})).toBe('+00:00')
+        expect(format(winter, 'ZZ', {useUTC: true})).toBe('+0000')
+      })
+    })
   })
 
   describe('round-trip: parse and format', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1264,9 +1264,6 @@ importers:
       '@sanity/types':
         specifier: workspace:*
         version: link:../types
-      date-fns:
-        specifier: ^4.4.0
-        version: 4.4.0
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
@@ -1289,6 +1286,9 @@ importers:
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260421.2
+      date-fns:
+        specifier: ^4.4.0
+        version: 4.4.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

As part of a refactoring in the CLI I've been wondering why we are pulling in the whole `date-fns` dependency, which comes from `@sanity/util` and has a total installation size of 10.9MB.

I think on build we could inline its parser only. By moving it into `devDependencies` `pkg-utils` will tree-shake and inline/ bundle the dependency, so in production consumers are no longer forced to pull-in the whole package, but only the parser which is ~14kB gzipped and already bundled.

Local and isolated installation comparison:

||Before (date-fns) | After (inlined) | Speedup
|--|-- | -- | --
|Cold cache | ~1.1s | ~0.36s | ~3×
|Warm cache | ~0.55s | ~0.16s | ~3.4×
|node_modules on disk | 27M | 284K | −26M
|Files | 5,193 | 57 | −5,136

Downside is that consumers who are installing `date-fns` as direct dependency would duplicate the parser code, which I think is an acceptable tradeoff.

If we want, we could also inline `format`, which would add ~3.3kB gzipped to the bundle, but imo rolling our own is sufficient in this case.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Does the hand-rolled offset parser make sense and cover everything? 

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

No test changes - its a performance optimization, that should be covered by the existing tests. For the `format` replacement `formatOffset` I've added new ones.

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes published date formatting behavior for offset tokens and shifts how date-fns is shipped (bundled parser vs full dependency); regressions would show up in legacy date display/parsing paths across Studio/CLI consumers.
> 
> **Overview**
> **`@sanity/util` no longer lists `date-fns` as a production dependency**—it moves to `devDependencies` so the build can bundle only the parser paths (`date-fns/parse`, `date-fns/parseISO` in `legacyDateFormat`) instead of pulling the full package into consumers’ installs.
> 
> The Moment-like formatter **stops using `date-fns/format` for `Z` / `ZZ` tokens** and instead uses a local **`formatOffset`** helper based on `Date#getTimezoneOffset()` (colon vs no colon, explicit `+00:00` / `+0000` at UTC). **`legacyDateFormat.test.ts`** adds coverage for negative offsets, half-hour zones, and UTC zero offset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbf1760187b61051c12d803e8919bb4fafffb289. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->