### PR TITLE
test(efps): improve pte measurement stability

### DIFF
--- a/dev/efps/helpers/measureFpsForInput.ts
+++ b/dev/efps/helpers/measureFpsForInput.ts
@@ -28,23 +28,25 @@ export async function measureFpsForInput({
   const formView = page.locator('[data-testid="form-view"]')
   await formView.waitFor({state: 'visible', timeout})
 
-  const input = page
-    .locator(
-      `[data-testid="field-${fieldName}"] input[type="text"], ` +
-        `[data-testid="field-${fieldName}"] textarea`,
-    )
-    .first()
+  const field = page.locator(`[data-testid="field-${fieldName}"]`)
+  const input = field.locator('input[type="text"], textarea').first()
   await input.waitFor({state: 'visible', timeout})
   const characters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
   await input.click()
   await new Promise((resolve) => setTimeout(resolve, 500))
 
-  const rendersPromise = input.evaluate(
+  // The recorder is attached to the stable field wrapper (with a delegated,
+  // capture-phase 'input' listener on the document) rather than to the input
+  // element itself: a transient read-only flip can remount the element
+  // mid-run, which would silently kill element-bound listeners/observers and
+  // leave the characters typed after the remount without matching render
+  // events ("No matching event" failures).
+  const rendersPromise = field.evaluate(
     // Had to add this so we can run the tests
     // oxlint-disable-next-line no-implied-eval
     new Function(
-      'el',
+      'field',
       `
     return (async function() {
       const updates = []
@@ -52,15 +54,24 @@ export async function measureFpsForInput({
       // For textarea, use MutationObserver on text content
       // For input, use 'input' event because MutationObserver on 'value' attribute
       // doesn't work - React/Sanity updates the value property, not the attribute
-      if (el instanceof HTMLTextAreaElement) {
-        const mutationObserver = new MutationObserver(() => {
-          updates.push({value: el.value, timestamp: Date.now()})
+      const isTextArea = field.querySelector('textarea') !== null
+      let mutationObserver
+      let onInput
+
+      if (isTextArea) {
+        mutationObserver = new MutationObserver(() => {
+          const textarea = field.querySelector('textarea')
+          if (textarea) updates.push({value: textarea.value, timestamp: Date.now()})
         })
-        mutationObserver.observe(el, {childList: true, characterData: true, subtree: true})
+        mutationObserver.observe(field, {childList: true, characterData: true, subtree: true})
       } else {
-        el.addEventListener('input', () => {
-          updates.push({value: el.value, timestamp: Date.now()})
-        })
+        onInput = (event) => {
+          const target = event.target
+          if (!target || !field.contains(target)) return
+          if (typeof target.value !== 'string') return
+          updates.push({value: target.value, timestamp: Date.now()})
+        }
+        document.addEventListener('input', onInput, true)
       }
 
       // End on the explicit __finish signal from the harness rather than on
@@ -71,12 +82,13 @@ export async function measureFpsForInput({
         document.addEventListener('__finish', resolve, {once: true})
       })
 
+      if (mutationObserver) mutationObserver.disconnect()
+      if (onInput) document.removeEventListener('input', onInput, true)
+
       return updates
     })()
   `,
-    ) as (
-      el: HTMLInputElement | HTMLTextAreaElement,
-    ) => Promise<{value: string; timestamp: number}[]>,
+    ) as (el: HTMLElement) => Promise<{value: string; timestamp: number}[]>,
   )
   // This evaluate runs until the `__finish` event and is only awaited later.
   // If the context is torn down first — the A/B harness closes both browsers
@@ -134,7 +146,13 @@ export async function measureFpsForInput({
     const matchingEvent = renderEvents.find(({value}) =>
       containsBetweenMarkers(value, inputEvent.character, startingMarker, endingMarker),
     )
-    if (!matchingEvent) throw new Error(`No matching event for ${inputEvent.character}`)
+    if (!matchingEvent) {
+      throw new Error(
+        `No matching event for ${JSON.stringify(inputEvent.character)} ` +
+          `(${renderEvents.length} render events recorded; ` +
+          `last recorded value: ${JSON.stringify(tail(renderEvents.at(-1)?.value))})`,
+      )
+    }
 
     return matchingEvent.timestamp - inputEvent.timestamp
   })
@@ -145,4 +163,10 @@ export async function measureFpsForInput({
     label: label || fieldName,
     runDuration: Date.now() - start,
   }
+}
+
+/** The last part of a (potentially huge) recorded value — the markers live at the end. */
+function tail(value: string | undefined): string {
+  if (value === undefined) return '(no events recorded)'
+  return value.length > 200 ? `…${value.slice(-200)}` : value
 }

--- a/dev/efps/helpers/measureFpsForInput.ts
+++ b/dev/efps/helpers/measureFpsForInput.ts
@@ -63,13 +63,12 @@ export async function measureFpsForInput({
         })
       }
 
+      // End on the explicit __finish signal from the harness rather than on
+      // blur — a transient read-only flip can blur the field mid-run, which
+      // would end the recording early and leave the characters typed after the
+      // flip without matching render events.
       await new Promise((resolve) => {
-        const handler = () => {
-          el.removeEventListener('blur', handler)
-          resolve()
-        }
-
-        el.addEventListener('blur', handler)
+        document.addEventListener('__finish', resolve, {once: true})
       })
 
       return updates
@@ -79,10 +78,10 @@ export async function measureFpsForInput({
       el: HTMLInputElement | HTMLTextAreaElement,
     ) => Promise<{value: string; timestamp: number}[]>,
   )
-  // This evaluate runs until the field blurs and is only awaited later. If the
-  // context is torn down first — the A/B harness closes both browsers once one
-  // side settles — this promise would reject with no handler attached, an
-  // *unhandled rejection* that crashes the process and bypasses retries.
+  // This evaluate runs until the `__finish` event and is only awaited later.
+  // If the context is torn down first — the A/B harness closes both browsers
+  // once one side settles — this promise would reject with no handler attached,
+  // an *unhandled rejection* that crashes the process and bypasses retries.
   // Swallow that here so a failing run stays catchable.
   const safeRendersPromise = rendersPromise.catch((): {value: string; timestamp: number}[] => [])
   await new Promise((resolve) => setTimeout(resolve, 500))

--- a/dev/efps/helpers/measureFpsForInput.ts
+++ b/dev/efps/helpers/measureFpsForInput.ts
@@ -3,7 +3,7 @@ import {type Page} from 'playwright'
 import {type EfpsResult} from '../types'
 import {aggregateLatencies} from './aggregateLatencies'
 import {measureBlockingTime} from './measureBlockingTime'
-import {setUpMarkers, typeCharacterReliably} from './typeCharacterReliably'
+import {containsBetweenMarkers, setUpMarkers, typeCharacterReliably} from './typeCharacterReliably'
 
 interface MeasureFpsForInputOptions {
   label?: string
@@ -132,13 +132,9 @@ export async function measureFpsForInput({
   await new Promise((resolve) => setTimeout(resolve, 500))
 
   const latencies = inputEvents.map((inputEvent) => {
-    const matchingEvent = renderEvents.find(({value}) => {
-      if (!value.includes(startingMarker) || !value.includes(endingMarker)) return false
-
-      const [, afterStartingMarker] = value.split(startingMarker)
-      const [beforeEndingMarker] = afterStartingMarker.split(endingMarker)
-      return beforeEndingMarker.includes(inputEvent.character)
-    })
+    const matchingEvent = renderEvents.find(({value}) =>
+      containsBetweenMarkers(value, inputEvent.character, startingMarker, endingMarker),
+    )
     if (!matchingEvent) throw new Error(`No matching event for ${inputEvent.character}`)
 
     return matchingEvent.timestamp - inputEvent.timestamp

--- a/dev/efps/helpers/measureFpsForPte.ts
+++ b/dev/efps/helpers/measureFpsForPte.ts
@@ -3,7 +3,7 @@ import {type Page} from 'playwright'
 import {type EfpsResult} from '../types'
 import {aggregateLatencies} from './aggregateLatencies'
 import {measureBlockingTime} from './measureBlockingTime'
-import {setUpMarkers, typeCharacterReliably} from './typeCharacterReliably'
+import {containsBetweenMarkers, setUpMarkers, typeCharacterReliably} from './typeCharacterReliably'
 
 interface MeasureFpsForPteOptions {
   fieldName: string
@@ -124,13 +124,9 @@ export async function measureFpsForPte({
   const renderEvents = await safeRendersPromise
 
   const latencies = inputEvents.map((inputEvent) => {
-    const matchingEvent = renderEvents.find(({value}) => {
-      if (!value.includes(startingMarker) || !value.includes(endingMarker)) return false
-
-      const [, afterStartingMarker] = value.split(startingMarker)
-      const [beforeEndingMarker] = afterStartingMarker.split(endingMarker)
-      return beforeEndingMarker.includes(inputEvent.character)
-    })
+    const matchingEvent = renderEvents.find(({value}) =>
+      containsBetweenMarkers(value, inputEvent.character, startingMarker, endingMarker),
+    )
     if (!matchingEvent) throw new Error(`No matching event for ${inputEvent.character}`)
 
     return matchingEvent.timestamp - inputEvent.timestamp - matchingEvent.textContentProcessingTime

--- a/dev/efps/helpers/measureFpsForPte.ts
+++ b/dev/efps/helpers/measureFpsForPte.ts
@@ -33,7 +33,15 @@ export async function measureFpsForPte({
   const contentEditable = pteField.locator('[contenteditable="true"]')
   await contentEditable.waitFor({state: 'visible', timeout})
 
-  const rendersPromise = contentEditable.evaluate(
+  // The recorder is attached to the stable field wrapper rather than the
+  // contenteditable itself, and it runs until the harness dispatches the
+  // `__finish` event rather than until blur. Both matter for resilience to a
+  // transient read-only flip mid-run (see `typeCharacterReliably`): a flip
+  // remounts/blurs the editable, which would detach a MutationObserver bound to
+  // it and end a blur-based recording early — leaving no render events for the
+  // characters typed after the flip ("No matching event" failures). `childList`
+  // is also observed so text landing in freshly created DOM nodes isn't missed.
+  const rendersPromise = pteField.evaluate(
     // Had to add this so we can run the tests
     new Function(
       'el',
@@ -53,16 +61,13 @@ export async function measureFpsForPte({
         })
       })
 
-      mutationObserver.observe(el, {subtree: true, characterData: true})
+      mutationObserver.observe(el, {subtree: true, characterData: true, childList: true})
 
       await new Promise((resolve) => {
-        const handler = () => {
-          el.removeEventListener('blur', handler)
-          resolve()
-        }
-
-        el.addEventListener('blur', handler)
+        document.addEventListener('__finish', resolve, {once: true})
       })
+
+      mutationObserver.disconnect()
 
       return updates
     })()
@@ -75,10 +80,10 @@ export async function measureFpsForPte({
       }[]
     >,
   )
-  // This evaluate runs until the field blurs and is only awaited later. If the
-  // context is torn down first — the A/B harness closes both browsers once one
-  // side settles — this promise would reject with no handler attached, an
-  // *unhandled rejection* that crashes the process and bypasses retries.
+  // This evaluate runs until the `__finish` event and is only awaited later.
+  // If the context is torn down first — the A/B harness closes both browsers
+  // once one side settles — this promise would reject with no handler attached,
+  // an *unhandled rejection* that crashes the process and bypasses retries.
   // Swallow that here so a failing run stays catchable.
   const safeRendersPromise = rendersPromise.catch(
     (): {value: string; timestamp: number; textContentProcessingTime: number}[] => [],
@@ -119,6 +124,8 @@ export async function measureFpsForPte({
   }
 
   await contentEditable.blur()
+
+  await page.evaluate(() => window.document.dispatchEvent(new CustomEvent('__finish')))
 
   const blockingTime = await getBlockingTime()
   const renderEvents = await safeRendersPromise

--- a/dev/efps/helpers/measureFpsForPte.ts
+++ b/dev/efps/helpers/measureFpsForPte.ts
@@ -134,7 +134,13 @@ export async function measureFpsForPte({
     const matchingEvent = renderEvents.find(({value}) =>
       containsBetweenMarkers(value, inputEvent.character, startingMarker, endingMarker),
     )
-    if (!matchingEvent) throw new Error(`No matching event for ${inputEvent.character}`)
+    if (!matchingEvent) {
+      throw new Error(
+        `No matching event for ${JSON.stringify(inputEvent.character)} ` +
+          `(${renderEvents.length} render events recorded; ` +
+          `last recorded value: ${JSON.stringify(tail(renderEvents.at(-1)?.value))})`,
+      )
+    }
 
     return matchingEvent.timestamp - inputEvent.timestamp - matchingEvent.textContentProcessingTime
   })
@@ -145,4 +151,10 @@ export async function measureFpsForPte({
     label: label || fieldName,
     runDuration: Date.now() - start,
   }
+}
+
+/** The last part of a (potentially huge) recorded value — the markers live at the end. */
+function tail(value: string | undefined): string {
+  if (value === undefined) return '(no events recorded)'
+  return value.length > 200 ? `…${value.slice(-200)}` : value
 }

--- a/dev/efps/helpers/typeCharacterReliably.ts
+++ b/dev/efps/helpers/typeCharacterReliably.ts
@@ -16,6 +16,14 @@ import {type Locator, type Page} from 'playwright'
  * The helpers here make both the marker setup and the measured typing resilient
  * to that flip: type only while the form is editable, verify each character
  * actually landed where expected, and retry (re-placing the caret) if not.
+ *
+ * The markers are anchored at the very end of the field's value so their
+ * placement is deterministic (a click into a large Portable Text field can land
+ * the caret anywhere in the prose). Caret recovery, however, positions the
+ * caret directly before the live ending marker via the DOM selection APIs — a
+ * stray character from a failed attempt can land *after* the ending marker (a
+ * caret jump goes to the very end of the field), so any fixed-distance stepping
+ * from the end would be off by the length of the debris.
  */
 
 const ATTEMPT_TIMEOUT = 2_000
@@ -59,6 +67,12 @@ export async function setUpMarkers({
       await input.press('Delete')
     }
 
+    // Anchor the markers at the very end of the value — both so their position
+    // is deterministic (a click into a large Portable Text field can land the
+    // caret anywhere in the prose) and so caret recovery can reliably find them
+    // again (see `moveCaretToEnd`).
+    await moveCaretToEnd(input)
+
     await input.pressSequentially(endingMarker)
     for (let i = 0; i < endingMarker.length; i++) await input.press('ArrowLeft')
     await input.pressSequentially(startingMarker)
@@ -66,7 +80,12 @@ export async function setUpMarkers({
     const deadline = Date.now() + ATTEMPT_TIMEOUT
     for (;;) {
       const value = await getValue()
-      if (value.includes(startingMarker) && value.includes(endingMarker)) return
+      // Require the pair to be adjacent: nothing has been typed between the
+      // markers yet, so `___START______END___` must appear as one unit. A flip
+      // mid-setup can leave both markers present but separated (the caret
+      // jumped between typing one and the other), which would poison every
+      // subsequent between-markers match.
+      if (value.includes(startingMarker + endingMarker)) return
       if (Date.now() >= deadline) break
       await new Promise((resolve) => setTimeout(resolve, 10))
     }
@@ -114,11 +133,13 @@ export async function typeCharacterReliably({
     // drops the keystroke and moves the caret.
     await waitForEditable(page, timeout)
 
-    // On a retry the caret may have moved (a swallowed keystroke sends it to
-    // the end of the field). Re-place it between the markers before typing.
+    // On a retry the caret may have moved (a caret jump sends it to the end of
+    // the field, where a stray copy of the character may also have landed —
+    // possibly *after* the ending marker). Re-place it directly before the
+    // ending marker; positioning relative to the end of the value would be
+    // thrown off by such debris.
     if (attempt > 0) {
-      await input.press('End')
-      for (let i = 0; i < endingMarker.length; i++) await input.press('ArrowLeft')
+      await placeCaretBeforeEndingMarker(input, {startingMarker, endingMarker})
     }
 
     const timestamp = Date.now()
@@ -146,14 +167,129 @@ function waitForEditable(page: Page, timeout: number): Promise<void> {
     .waitFor({state: 'visible', timeout})
 }
 
-function containsBetweenMarkers(
+/**
+ * Moves the caret to the very end of the input's value.
+ *
+ * Uses the DOM selection APIs rather than keyboard navigation: `End` only
+ * reaches the end of the current line/block in a multi-block contenteditable
+ * (like the Portable Text editor), and the document-end shortcut differs per
+ * platform (`Control+End` vs `Meta+ArrowDown`).
+ */
+async function moveCaretToEnd(input: Locator): Promise<void> {
+  await input.evaluate((el) => {
+    // Focus before positioning the caret — focusing afterwards (which the next
+    // key press would do implicitly) can reset the selection.
+    if (el instanceof HTMLElement) el.focus()
+
+    if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+      const length = el.value.length
+      el.setSelectionRange(length, length)
+      return
+    }
+
+    const document = el.ownerDocument
+    const selection = document.getSelection()
+    if (!selection) return
+    const range = document.createRange()
+    range.selectNodeContents(el)
+    range.collapse(false)
+    selection.removeAllRanges()
+    selection.addRange(range)
+  })
+}
+
+/**
+ * Places the caret directly before the live ending marker — the first
+ * occurrence of `endingMarker` after the *last* occurrence of `startingMarker`,
+ * mirroring `containsBetweenMarkers`. Falls back to the end of the value if the
+ * markers can't be found.
+ *
+ * NOTE: the evaluate callback must not define any *named* inner functions
+ * (including arrow functions assigned to variables). The harness runs through
+ * `tsx`, and esbuild's `keepNames` transform wraps such definitions in a
+ * `__name(...)` helper call — Playwright serializes the callback with
+ * `toString()` and runs it in the page, where that helper doesn't exist
+ * (`ReferenceError: __name is not defined`).
+ */
+async function placeCaretBeforeEndingMarker(
+  input: Locator,
+  markers: {startingMarker: string; endingMarker: string},
+): Promise<void> {
+  await input.evaluate((el, {startingMarker, endingMarker}) => {
+    // Focus before positioning the caret — focusing afterwards (which the next
+    // key press would do implicitly) can reset the selection.
+    if (el instanceof HTMLElement) el.focus()
+
+    if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+      const value = el.value
+      const valueStartIndex = value.lastIndexOf(startingMarker)
+      const index = value.indexOf(
+        endingMarker,
+        valueStartIndex === -1 ? 0 : valueStartIndex + startingMarker.length,
+      )
+      const caret = index === -1 ? value.length : index
+      el.setSelectionRange(caret, caret)
+      return
+    }
+
+    const document = el.ownerDocument
+    const selection = document.getSelection()
+    if (!selection) return
+
+    // Concatenate the text nodes (mirroring `textContent`) while tracking each
+    // node's global offset, so the marker's global index can be mapped back to
+    // a (node, offset) selection position.
+    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT)
+    const nodes: {node: Node; start: number}[] = []
+    let text = ''
+    while (walker.nextNode()) {
+      nodes.push({node: walker.currentNode, start: text.length})
+      text += walker.currentNode.nodeValue ?? ''
+    }
+
+    const textStartIndex = text.lastIndexOf(startingMarker)
+    const index =
+      nodes.length === 0
+        ? -1
+        : text.indexOf(
+            endingMarker,
+            textStartIndex === -1 ? 0 : textStartIndex + startingMarker.length,
+          )
+
+    const range = document.createRange()
+    if (index === -1) {
+      range.selectNodeContents(el)
+      range.collapse(false)
+    } else {
+      let target = nodes[0]
+      for (const entry of nodes) {
+        if (entry.start > index) break
+        target = entry
+      }
+      range.setStart(target.node, index - target.start)
+      range.collapse(true)
+    }
+    selection.removeAllRanges()
+    selection.addRange(range)
+  }, markers)
+}
+
+/**
+ * Whether `character` appears between the markers. Uses the *last* occurrence
+ * of the starting marker: the live marker pair is anchored at the end of the
+ * value, and an aborted earlier `setUpMarkers` attempt can leave a stray
+ * (partial or complete) marker earlier in the prose.
+ */
+export function containsBetweenMarkers(
   value: string,
   character: string,
   startingMarker: string,
   endingMarker: string,
 ): boolean {
-  if (!value.includes(startingMarker) || !value.includes(endingMarker)) return false
-  const [, afterStartingMarker] = value.split(startingMarker)
-  const [beforeEndingMarker] = afterStartingMarker.split(endingMarker)
-  return beforeEndingMarker.includes(character)
+  const startIndex = value.lastIndexOf(startingMarker)
+  if (startIndex === -1) return false
+  const afterStartingMarker = value.slice(startIndex + startingMarker.length)
+  const endIndex = afterStartingMarker.indexOf(endingMarker)
+  if (endIndex === -1) return false
+  return afterStartingMarker.slice(0, endIndex).includes(character)
 }


### PR DESCRIPTION
### Description

This branch addresses a few EFPS issues that have emerged recently:

1. Caret position management causing input string to be prepended rather than appended.
2. Failures if read-only state changes during measurement.

### What to review

EFPS tests.

### Testing

Verified EFPS test suite succeeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to dev EFPS test helpers; no production Studio or runtime behavior is modified.
> 
> **Overview**
> Hardens the **EFPS** Playwright harness so input and Portable Text latency runs stay reliable when the document form briefly goes read-only or remounts fields mid-run.
> 
> **Marker and caret logic** (`typeCharacterReliably`): markers are placed at the **end** of the value (via DOM selection, not keyboard `End`), setup must see an **adjacent** `start+end` pair, retries reposition the caret **before the live ending marker** (using the last `startingMarker`), and `containsBetweenMarkers` is shared/exported and keys off the **last** starting marker so stray partial markers in prose do not poison matches.
> 
> **Render recording** (`measureFpsForInput` / `measureFpsForPte`): observers/listeners attach to the stable **field wrapper** (capture-phase delegated `input` for text inputs; `MutationObserver` with `childList` for PTE) and stop on an explicit document **`__finish`** event instead of **blur**, so remounts and read-only flips do not end recording early or drop events. Failures now include render-event counts and a truncated tail of the last recorded value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 549d5a14d371d1e95439726434bf26ee48ab8157. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->