### PR TITLE
test(presentation): add local repro for wrong-dataset previewUrlSecret report

### DIFF
--- a/dev/test-studio/PRESENTATION_DATASET_REPRO.md
+++ b/dev/test-studio/PRESENTATION_DATASET_REPRO.md
@@ -1,0 +1,118 @@
+# Repro: Presentation tool writes `sanity.previewUrlSecret` to the wrong dataset
+
+Tracking: Linear `SAPP-3833` / GitHub [sanity-io/sanity#12794](https://github.com/sanity-io/sanity/issues/12794)
+
+## Reported bug
+
+> In a multi-workspace Studio with different datasets per workspace, the Presentation
+> tool's `create-preview-secret.ts` always writes `sanity.previewUrlSecret` documents to
+> the **first workspace's dataset**, ignoring the active workspace's dataset configuration.
+> This causes `defineEnableDraftMode` (from `next-sanity`) on the frontend to return 401,
+> because the frontend queries the correct dataset where the secret doesn't exist.
+>
+> This works correctly with `sanity dev` locally — **only the hosted Studio is affected**
+> (`*.sanity.studio`, proxied through `www.sanity.io/@org/studio/appId/...` with
+> `_context={"mode":"core-ui"}`).
+
+## Reproduction workspaces
+
+Two workspaces were added to [`sanity.config.ts`](./sanity.config.ts) matching the report's
+shape — same `projectId` (`ppsg7ml5`), different `dataset`, both with the Presentation tool:
+
+| Workspace name                 | basePath                        | dataset   |
+| ------------------------------ | ------------------------------- | --------- |
+| `presentation-dataset-repro-a` | `/presentation-dataset-repro-a` | `test`    |
+| `presentation-dataset-repro-b` | `/presentation-dataset-repro-b` | `test-us` |
+
+Each also registers a second Presentation-tool instance named `presentation-repro`
+(nav label **"Presentation (repro)"**) with an explicit `previewUrl.previewMode`. This
+extra tool instance is required for the repro: `sharedSettings`' default Presentation tool
+configures `previewUrl` as a bare string, and
+[`resolve-preview-mode.ts`](../../packages/sanity/src/presentation/actors/resolve-preview-mode.ts)
+short-circuits to `false` whenever `previewUrlOption` is a string/function/undefined —
+skipping the entire `previewMode` state region (and therefore `create preview secret`)
+in the [`previewUrlMachine`](../../packages/sanity/src/presentation/machines/preview-url.ts).
+Use **"Presentation (repro)"**, not the plain "Presentation" tool, to exercise this code path.
+
+## Local reproduction steps
+
+1. `pnpm build && pnpm dev` (see root `AGENTS.md` for the `STUDIO_AUTH_TOKEN` hash-auth trick
+   for headless/cloud environments).
+2. Open `http://localhost:3333/presentation-dataset-repro-a/presentation-repro`, wait for the
+   tool to load (the preview iframe doesn't need to succeed — the secret is created before
+   the iframe navigates).
+3. Query dataset `test` for the secret: `*[_type == "sanity.previewUrlSecret"]{_id, _createdAt, studioUrl}`
+   (e.g. via the "Vision" tool scoped to that workspace, or the HTTP API). Confirm a fresh
+   document exists with `studioUrl` pointing at `presentation-dataset-repro-a`.
+4. Switch to workspace B (`http://localhost:3333/presentation-dataset-repro-b/presentation-repro`),
+   via in-app navigation and/or a hard reload of the URL.
+5. Query dataset `test-us` the same way and confirm its own fresh document, then re-query
+   dataset `test` to confirm nothing new/changed leaked in from workspace B.
+
+## What we found locally
+
+Ran the steps above (see `preview_url_secret_dataset_isolation_evidence.log` captured
+alongside this investigation):
+
+- Opening workspace A's repro tool created a new `sanity.previewUrlSecret` document **in
+  dataset `test`** with `studioUrl` correctly pointing at `presentation-dataset-repro-a`.
+- Opening workspace B's repro tool created a new document **in dataset `test-us`** with
+  `studioUrl` correctly pointing at `presentation-dataset-repro-b`.
+- A hard reload of workspace B's tool created yet another fresh document, still correctly
+  scoped to `test-us`, with dataset `test` left untouched.
+
+**Locally, the bug does not reproduce** — this matches the original report, which explicitly
+states `sanity dev` works correctly and the divergence only appears in the hosted Studio.
+
+## Code-path analysis (is the report valid?)
+
+Chain that's supposed to scope the mutation to the active workspace's dataset:
+
+1. [`usePreviewUrlActorRef.ts`](../../packages/sanity/src/presentation/usePreviewUrlActorRef.ts)
+   calls `useClient({apiVersion: API_VERSION})` and wires it into the `'create preview secret'`
+   actor ([`create-preview-secret.ts`](../../packages/sanity/src/presentation/actors/create-preview-secret.ts)),
+   which calls `createPreviewSecret(client, ...)` — the mutation that writes
+   `sanity.previewUrlSecret`.
+2. `useClient` ([`useClient.ts`](../../packages/sanity/src/core/hooks/useClient.ts)) resolves
+   `useSource().getClient(options)`.
+3. The `SourceProvider` feeding that hook comes from
+   [`WorkspaceLoader.tsx`](../../packages/sanity/src/core/studio/workspaceLoader/WorkspaceLoader.tsx)
+   (`workspace.unstable_sources[0]`), itself derived from `useActiveWorkspace()`, which
+   re-resolves per matched `basePath`
+   ([`ActiveWorkspaceMatcher.tsx`](../../packages/sanity/src/core/studio/activeWorkspaceMatcher/ActiveWorkspaceMatcher.tsx)).
+4. Each source's `getClient` closure is built per-source in
+   [`prepareConfig.tsx`](../../packages/sanity/src/core/config/prepareConfig.tsx) (`resolveSource`),
+   from a `client` that comes out of that source's `AuthStore.state`.
+5. **Leading in-repo suspect for the hosted-only divergence:** `getAuthStore`/`createAuthStore`
+   ([`createAuthStore.ts`](../../packages/sanity/src/core/store/authStore/createAuthStore.ts))
+   is memoized process-wide via lodash `memoize`, keyed by `canonicalHash(options)` (which
+   includes `dataset`/`projectId`/`apiHost`/auth-config, but excludes two function fields).
+   If, only in the hosted core-ui environment, some hashed field ends up equal across two
+   differently-configured workspaces, they could collide onto the same memoized `AuthStore`
+   (and thus the same `client`) — which would exactly reproduce "always writes to the first
+   workspace's dataset, persists after reload" (the cache lives at module scope).
+6. Every consumer of the hosted "core-ui" rendering context
+   (`isCoreUiRenderingContext`/[`coreUiRenderingContext.ts`](../../packages/sanity/src/core/store/renderingContext/coreUiRenderingContext.ts))
+   was checked — it's only read by capability gating and dashboard/canvas URL helpers
+   (`ResourcesButton.tsx`, `useStudioUrl.ts`, canvas link hooks), **never** by
+   workspace/auth/client resolution. The reporter's own theory ("core-ui interferes with
+   client/dataset resolution") isn't directly substantiated by anything in this package.
+
+**Assessment:** this is a valid, well-evidenced report (concrete repro steps + Network-tab
+logs for both the broken hosted case and the working local case in the original issue). The
+code that's supposed to scope the secret write to the active workspace's dataset looks
+correct on inspection, and our local reproduction above confirms it behaves correctly here —
+consistent with the reporter's own "local dev works" observation. We could not reproduce the
+hosted-only divergence from this sandbox: it requires Sanity's hosted `*.sanity.studio` /
+core-ui infrastructure (a real org + `sanity deploy` / `autoUpdates: true`), which isn't
+available in this environment.
+
+## Suggested next step to confirm the hosted-only divergence
+
+Deploy this exact `dev/test-studio` config (or a minimal standalone studio using the same
+`presentation-dataset-repro-a`/`b` shape) with `sanity deploy` / `autoUpdates: true` to a real
+hosted `*.sanity.studio` URL, then repeat the steps above against
+`https://<studio>.sanity.studio/presentation-dataset-repro-b/presentation-repro`, checking the
+Network tab (or the same dataset queries) for which dataset the mutation actually lands in.
+If it reproduces there, the `createAuthStore` memoization hypothesis above (or another
+core-ui-specific interaction) is the next thing to instrument.

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -341,6 +341,57 @@ export default defineConfig([
     subtitle: 'Workspace with a nonexistent dataset',
     basePath: '/nonexistent-dataset',
   },
+  // Reproduction workspaces for https://github.com/sanity-io/sanity/issues/12794
+  // ("Presentation tool writes sanity.previewUrlSecret to wrong dataset in
+  // multi-workspace hosted Studio"). Same projectId, different datasets, both
+  // with the Presentation tool enabled — matches the reported config shape.
+  // The extra `presentation-repro` tool instance below sets an explicit
+  // `previewMode`, so opening it actually resolves a (non-`false`) preview
+  // mode and triggers `create preview secret` — the default `sharedSettings`
+  // presentationTool uses a bare string `previewUrl`, which makes
+  // `resolve-preview-mode.ts` short-circuit to `false` and skip secret
+  // creation entirely.
+  // Locally this is expected to work correctly (see reproduction notes in
+  // dev/test-studio/PRESENTATION_DATASET_REPRO.md); the reported bug only
+  // manifests in the hosted (core-ui) Studio.
+  {
+    ...defaultWorkspace,
+    name: 'presentation-dataset-repro-a',
+    title: 'Presentation dataset repro (A)',
+    subtitle: 'SAPP-3833 / sanity-io/sanity#12794 — dataset "test"',
+    dataset: 'test',
+    basePath: '/presentation-dataset-repro-a',
+    plugins: [
+      ...defaultWorkspace.plugins,
+      presentationTool({
+        name: 'presentation-repro',
+        title: 'Presentation (repro)',
+        previewUrl: {
+          initial: '/preview/index.html',
+          previewMode: {enable: '/preview/index.html'},
+        },
+      }),
+    ],
+  },
+  {
+    ...defaultWorkspace,
+    name: 'presentation-dataset-repro-b',
+    title: 'Presentation dataset repro (B)',
+    subtitle: 'SAPP-3833 / sanity-io/sanity#12794 — dataset "test-us"',
+    dataset: 'test-us',
+    basePath: '/presentation-dataset-repro-b',
+    plugins: [
+      ...defaultWorkspace.plugins,
+      presentationTool({
+        name: 'presentation-repro',
+        title: 'Presentation (repro)',
+        previewUrl: {
+          initial: '/preview/index.html',
+          previewMode: {enable: '/preview/index.html'},
+        },
+      }),
+    ],
+  },
   {
     ...defaultWorkspace,
     name: 'admin-only',

--- a/packages/sanity/src/core/store/authStore/__tests__/createAuthStore.memoize.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/createAuthStore.memoize.test.ts
@@ -1,0 +1,111 @@
+import {type ClientConfig as SanityClientConfig, type SanityClient} from '@sanity/client'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createAuthStore} from '../createAuthStore'
+
+// Mock supportsLocalStorage to return true so createBroadcastStorage uses localStorage.
+// In jsdom/Node.js it returns false because process.versions.node is defined.
+vi.mock('../../../util/supportsLocalStorage', () => ({
+  supportsLocalStorage: true,
+}))
+
+/**
+ * A no-op client factory. All test cases in this file share the exact same
+ * function reference/source, so `clientFactory` never contributes to
+ * `canonicalHash` differences between calls — only the explicitly varied
+ * option (e.g. `dataset`) does.
+ */
+const noopClientFactory = (_options: SanityClientConfig): SanityClient =>
+  ({
+    request: () => Promise.resolve({}),
+  }) as unknown as SanityClient
+
+/**
+ * Regression coverage for https://github.com/sanity-io/sanity/issues/12794
+ * ("Presentation tool writes sanity.previewUrlSecret to wrong dataset in
+ * multi-workspace hosted Studio").
+ *
+ * `createAuthStore` is memoized process-wide via lodash `memoize`, keyed by
+ * `canonicalHash(options)` (see createAuthStore.ts). Every source's `client`
+ * (used by `useClient`/`getClient`, and therefore by the Presentation tool's
+ * `create-preview-secret.ts`) comes from that store's `state.client`
+ * (see prepareConfig.tsx `resolveSource`). If two workspaces with different
+ * `dataset`s ever resolved to the *same* memoized AuthStore, they'd share the
+ * same underlying client — reproducing exactly the reported symptom (writes
+ * always land in one dataset, regardless of the active workspace).
+ *
+ * These tests assert the memo key stays isolated per `dataset`/`projectId`,
+ * which is the one shared/global piece of state in this call chain that a
+ * hosted-only cache collision could plausibly live in.
+ */
+describe('createAuthStore: memoization key isolation', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('returns the exact same store instance for identical options (memoized)', () => {
+    const projectId = `memo-test-${Math.random().toString(36).slice(2)}`
+
+    const storeA = createAuthStore({
+      projectId,
+      dataset: 'production',
+      loginMethod: 'cookie',
+      clientFactory: noopClientFactory,
+    })
+    const storeB = createAuthStore({
+      projectId,
+      dataset: 'production',
+      loginMethod: 'cookie',
+      clientFactory: noopClientFactory,
+    })
+
+    expect(storeB).toBe(storeA)
+  })
+
+  it('returns different store instances for the same projectId but different datasets', () => {
+    const projectId = `memo-test-${Math.random().toString(36).slice(2)}`
+
+    const productionStore = createAuthStore({
+      projectId,
+      dataset: 'production',
+      loginMethod: 'cookie',
+      clientFactory: noopClientFactory,
+    })
+    const developmentStore = createAuthStore({
+      projectId,
+      dataset: 'development',
+      loginMethod: 'cookie',
+      clientFactory: noopClientFactory,
+    })
+
+    expect(
+      developmentStore,
+      'a different `dataset` must not collide onto the first-registered AuthStore/client',
+    ).not.toBe(productionStore)
+  })
+
+  it('returns different store instances for the same dataset but different projectIds', () => {
+    const dataset = 'production'
+    const projectIdA = `memo-test-a-${Math.random().toString(36).slice(2)}`
+    const projectIdB = `memo-test-b-${Math.random().toString(36).slice(2)}`
+
+    const storeA = createAuthStore({
+      projectId: projectIdA,
+      dataset,
+      loginMethod: 'cookie',
+      clientFactory: noopClientFactory,
+    })
+    const storeB = createAuthStore({
+      projectId: projectIdB,
+      dataset,
+      loginMethod: 'cookie',
+      clientFactory: noopClientFactory,
+    })
+
+    expect(storeB).not.toBe(storeA)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Investigation for Linear `SAPP-3833` / [sanity-io/sanity#12794](https://github.com/sanity-io/sanity/issues/12794): a report that the Presentation tool writes `sanity.previewUrlSecret` to the first workspace's dataset instead of the active one, but only in the hosted (core-ui) Studio — the reporter confirms local `sanity dev` works correctly. This PR adds a local reproduction harness and a targeted regression test; it is **not a fix**, since the hosted-only divergence can't be exercised from this sandbox.

Traced the write path (`usePreviewUrlActorRef` → `useClient` → `useSource().getClient()` → per-source client from `resolveSource`'s `AuthStore.state`) and it's correctly scoped to the active workspace on inspection. The one process-wide shared/memoized piece of state in that chain is `createAuthStore` (lodash `memoize` keyed by `canonicalHash` of its options) — a plausible place for a hosted-only cache collision, though nothing in `packages/sanity` ties the "core-ui" rendering context into workspace/auth/client resolution to confirm it.

### What to review

- `dev/test-studio/sanity.config.ts`: two new workspaces (`presentation-dataset-repro-a`/`-b`, same `projectId`, datasets `test`/`test-us`) plus a second `presentation-repro` Presentation-tool instance with an explicit `previewMode` — needed because the default `sharedSettings` Presentation tool uses a bare string `previewUrl`, which `resolve-preview-mode.ts` short-circuits to `false`, skipping secret creation entirely.
- `dev/test-studio/PRESENTATION_DATASET_REPRO.md`: repro steps, the evidence gathered locally, and the code-path/validity analysis.
- `packages/sanity/src/core/store/authStore/__tests__/createAuthStore.memoize.test.ts`: new regression test asserting `createAuthStore`'s memo key stays isolated per `dataset`/`projectId`.

### Testing

- Added `createAuthStore.memoize.test.ts`; ran via `pnpm vitest run --project=sanity packages/sanity/src/core/store/authStore/` (60/60 passing).
- `pnpm check:oxlint` and `pnpm check:types` both clean.
- Manually verified the new repro workspaces end-to-end with `pnpm dev`: opened the "Presentation (repro)" tool in workspace A and workspace B (including a hard reload of workspace B), and queried both datasets directly via the HTTP API before/after. Each workspace's secret landed in its own dataset only — locally the bug does not reproduce, consistent with the original report. Evidence log and screenshots captured during this session.

### Notes for release

N/A – internal test/dev-studio tooling only, no production code changed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b03b2295-0c72-435e-8e09-48ec08527f18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b03b2295-0c72-435e-8e09-48ec08527f18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

