### PR TITLE
fix(vision): make saved queries side panel scrollable

### DIFF
--- a/packages/@sanity/vision/src/components/QueryRecall.css.ts
+++ b/packages/@sanity/vision/src/components/QueryRecall.css.ts
@@ -1,15 +1,17 @@
 import {style} from '@vanilla-extract/css'
 
 export const fixedHeader = style({
-  position: 'sticky',
-  top: 0,
+  flexShrink: 0,
   background: 'var(--card-bg-color)',
   zIndex: 1,
 })
 
 export const scrollContainer = style({
-  height: 'auto',
+  minHeight: 0,
   width: '100%',
   minWidth: 0,
-  overflow: 'visible',
+})
+
+export const queryList = style({
+  minHeight: 0,
 })

--- a/packages/@sanity/vision/src/components/QueryRecall.tsx
+++ b/packages/@sanity/vision/src/components/QueryRecall.tsx
@@ -29,7 +29,7 @@ import {ContextMenuButton, UserAvatar, useDateTimeFormat, useTranslation} from '
 
 import {type QueryConfig, useSavedQueries} from '../hooks/useSavedQueries'
 import {visionLocaleNamespace} from '../i18n'
-import {fixedHeader, scrollContainer} from './QueryRecall.css'
+import {fixedHeader, queryList, scrollContainer} from './QueryRecall.css'
 import {type ParsedUrlState} from './VisionGui'
 import {StyledLabel} from './VisionGui.styled'
 
@@ -37,8 +37,14 @@ function FixedHeader(props: ComponentProps<typeof Stack>) {
   return <Stack {...props} className={fixedHeader} />
 }
 
-function ScrollContainer(props: ComponentProps<typeof Box>) {
-  return <Box {...props} className={scrollContainer} />
+function ScrollContainer(props: ComponentProps<typeof Flex>) {
+  return (
+    <Flex {...props} direction="column" flex={1} overflow="hidden" className={scrollContainer} />
+  )
+}
+
+function QueryList(props: ComponentProps<typeof Box>) {
+  return <Box {...props} flex={1} overflow="auto" className={queryList} />
 }
 
 export function QueryRecall({
@@ -407,180 +413,229 @@ export function QueryRecall({
           </TabList>
         </Box>
       </FixedHeader>
-      <Stack id="vision-query-recall-list" paddingY={3}>
-        {filteredQueries?.map((q, index) => {
-          const queryObj = getStateFromUrl(q.url)
-          const fullQueryPreview = queryObj?.query || ''
-          const shortQueryPreview = fullQueryPreview.split('{')[0]
-          const isSelected = selectedUrl === q.url
-          const canMutateQuery = !q.shared || q.isOwnedByCurrentUser
+      <QueryList id="vision-query-recall-list">
+        <Stack paddingY={3}>
+          {filteredQueries?.map((q, index) => {
+            const queryObj = getStateFromUrl(q.url)
+            const fullQueryPreview = queryObj?.query || ''
+            const shortQueryPreview = fullQueryPreview.split('{')[0]
+            const isSelected = selectedUrl === q.url
+            const canMutateQuery = !q.shared || q.isOwnedByCurrentUser
 
-          // Compare against current live state
-          const areQueriesEqual =
-            queryObj && currentQuery === queryObj.query && isEqual(currentParams, queryObj.params)
+            // Compare against current live state
+            const areQueriesEqual =
+              queryObj && currentQuery === queryObj.query && isEqual(currentParams, queryObj.params)
 
-          const isEdited = isSelected && !areQueriesEqual && canMutateQuery
-          return (
-            <Card
-              key={q._key}
-              paddingX={compactMode ? 3 : 4}
-              paddingY={compactMode ? 3 : 4}
-              tone="default"
-              onClick={(event) => {
-                const target = event.target as HTMLElement | null
-                if (target?.closest('[data-query-actions="true"]')) {
-                  return
-                }
-                setSelectedUrl(q.url) // Update the selected query immediately
-                const parsedUrl = getStateFromUrl(q.url)
-                if (parsedUrl) {
-                  setStateFromParsedUrl(parsedUrl)
-                }
-              }}
-              style={{
-                borderTop: index === 0 ? '1px solid var(--card-border-color)' : undefined,
-                position: 'relative',
-                borderBottom: '1px solid var(--card-border-color)',
-                borderLeft: isSelected
-                  ? '2px solid var(--card-muted-fg-color)'
-                  : '2px solid transparent',
-                cursor: 'pointer',
-              }}
-            >
-              <Stack space={compactMode ? 2 : 3}>
-                <Flex justify="space-between" align={'center'} style={{minHeight: '25px'}}>
-                  <Flex align="center" gap={2} paddingRight={1} style={{minWidth: 0, flex: 1}}>
-                    {editingKey === q._key ? (
-                      <TextInput
-                        value={editingTitle}
-                        onChange={(event) => setEditingTitle(event.currentTarget.value)}
-                        onKeyDown={(event) => {
-                          if (event.key === 'Enter') {
-                            void handleTitleSave(q, editingTitle)
-                          } else if (event.key === 'Escape') {
-                            setEditingKey(null)
+            const isEdited = isSelected && !areQueriesEqual && canMutateQuery
+            return (
+              <Card
+                key={q._key}
+                paddingX={compactMode ? 3 : 4}
+                paddingY={compactMode ? 3 : 4}
+                tone="default"
+                onClick={(event) => {
+                  const target = event.target as HTMLElement | null
+                  if (target?.closest('[data-query-actions="true"]')) {
+                    return
+                  }
+                  setSelectedUrl(q.url) // Update the selected query immediately
+                  const parsedUrl = getStateFromUrl(q.url)
+                  if (parsedUrl) {
+                    setStateFromParsedUrl(parsedUrl)
+                  }
+                }}
+                style={{
+                  borderTop: index === 0 ? '1px solid var(--card-border-color)' : undefined,
+                  position: 'relative',
+                  borderBottom: '1px solid var(--card-border-color)',
+                  borderLeft: isSelected
+                    ? '2px solid var(--card-muted-fg-color)'
+                    : '2px solid transparent',
+                  cursor: 'pointer',
+                }}
+              >
+                <Stack space={compactMode ? 2 : 3}>
+                  <Flex justify="space-between" align={'center'} style={{minHeight: '25px'}}>
+                    <Flex align="center" gap={2} paddingRight={1} style={{minWidth: 0, flex: 1}}>
+                      {editingKey === q._key ? (
+                        <TextInput
+                          value={editingTitle}
+                          onChange={(event) => setEditingTitle(event.currentTarget.value)}
+                          onKeyDown={(event) => {
+                            if (event.key === 'Enter') {
+                              void handleTitleSave(q, editingTitle)
+                            } else if (event.key === 'Escape') {
+                              setEditingKey(null)
+                            }
+                          }}
+                          onBlur={() => handleTitleSave(q, editingTitle)}
+                          autoFocus
+                          style={{maxWidth: '170px', height: '24px'}}
+                        />
+                      ) : (
+                        <Text
+                          weight="bold"
+                          size={compactMode ? 2 : 3}
+                          textOverflow="ellipsis"
+                          style={{
+                            maxWidth: compactMode ? '180px' : '220px',
+                            cursor: canMutateQuery ? 'pointer' : 'default',
+                            padding: '2px 0',
+                          }}
+                          title={
+                            optimisticTitles[q._key] ||
+                            q.title ||
+                            q._key.slice(q._key.length - 5, q._key.length)
                           }
-                        }}
-                        onBlur={() => handleTitleSave(q, editingTitle)}
-                        autoFocus
-                        style={{maxWidth: '170px', height: '24px'}}
-                      />
-                    ) : (
-                      <Text
-                        weight="bold"
-                        size={compactMode ? 2 : 3}
-                        textOverflow="ellipsis"
-                        style={{
-                          maxWidth: compactMode ? '180px' : '220px',
-                          cursor: canMutateQuery ? 'pointer' : 'default',
-                          padding: '2px 0',
-                        }}
-                        title={
-                          optimisticTitles[q._key] ||
-                          q.title ||
-                          q._key.slice(q._key.length - 5, q._key.length)
-                        }
-                        onClick={
-                          canMutateQuery
-                            ? () => {
-                                setEditingKey(q._key)
-                                setEditingTitle(q.title || q._key.slice(0, 5))
-                              }
-                            : undefined
-                        }
-                      >
-                        {optimisticTitles[q._key] ||
-                          q.title ||
-                          q._key.slice(q._key.length - 5, q._key.length)}
-                      </Text>
-                    )}
-                    {isEdited && (
-                      <Box
-                        style={{
-                          width: '6px',
-                          height: '6px',
-                          borderRadius: '50%',
-                          backgroundColor: 'var(--card-focus-ring-color)',
-                        }}
-                      />
-                    )}
-                  </Flex>
-                  <Flex align="center" gap={2}>
-                    <Box
-                      data-query-actions="true"
-                      style={{width: '25px', height: '25px', display: 'flex', alignItems: 'center'}}
-                    >
-                      {(!q.shared || canMutateQuery) && (
-                        <MenuButton
-                          button={<ContextMenuButton />}
-                          id={`${q._key}-menu`}
-                          menu={
-                            <Menu>
-                              {!q.shared && (
-                                <MenuItem
-                                  icon={UsersIcon}
-                                  padding={3}
-                                  text={t('label.share')}
-                                  onClick={(event) => {
-                                    event.stopPropagation()
-                                    handleShareQuery(q)
-                                  }}
-                                />
-                              )}
-                              {q.shared && canMutateQuery && (
-                                <MenuItem
-                                  icon={UnpublishIcon}
-                                  padding={3}
-                                  text={t('action.unshare')}
-                                  onClick={(event) => {
-                                    event.stopPropagation()
-                                    void handleUnshareQuery(q)
-                                  }}
-                                />
-                              )}
-                              {canMutateQuery && (
-                                <MenuItem
-                                  tone="critical"
-                                  padding={3}
-                                  icon={TrashIcon}
-                                  text={t('action.delete')}
-                                  onClick={(event) => {
-                                    event.stopPropagation()
-                                    void deleteQuery(q._key)
-                                  }}
-                                />
-                              )}
-                            </Menu>
+                          onClick={
+                            canMutateQuery
+                              ? () => {
+                                  setEditingKey(q._key)
+                                  setEditingTitle(q.title || q._key.slice(0, 5))
+                                }
+                              : undefined
                           }
-                          popover={{portal: true, placement: 'bottom-end', tone: 'default'}}
+                        >
+                          {optimisticTitles[q._key] ||
+                            q.title ||
+                            q._key.slice(q._key.length - 5, q._key.length)}
+                        </Text>
+                      )}
+                      {isEdited && (
+                        <Box
+                          style={{
+                            width: '6px',
+                            height: '6px',
+                            borderRadius: '50%',
+                            backgroundColor: 'var(--card-focus-ring-color)',
+                          }}
                         />
                       )}
-                    </Box>
-                  </Flex>
-                </Flex>
-
-                {fullQueryPreview ? (
-                  <Tooltip
-                    content={
+                    </Flex>
+                    <Flex align="center" gap={2}>
                       <Box
-                        padding={2}
-                        style={{maxWidth: '420px', maxHeight: '220px', overflow: 'auto'}}
+                        data-query-actions="true"
+                        style={{
+                          width: '25px',
+                          height: '25px',
+                          display: 'flex',
+                          alignItems: 'center',
+                        }}
                       >
-                        <Code size={1}>{fullQueryPreview}</Code>
+                        {(!q.shared || canMutateQuery) && (
+                          <MenuButton
+                            button={<ContextMenuButton />}
+                            id={`${q._key}-menu`}
+                            menu={
+                              <Menu>
+                                {!q.shared && (
+                                  <MenuItem
+                                    icon={UsersIcon}
+                                    padding={3}
+                                    text={t('label.share')}
+                                    onClick={(event) => {
+                                      event.stopPropagation()
+                                      handleShareQuery(q)
+                                    }}
+                                  />
+                                )}
+                                {q.shared && canMutateQuery && (
+                                  <MenuItem
+                                    icon={UnpublishIcon}
+                                    padding={3}
+                                    text={t('action.unshare')}
+                                    onClick={(event) => {
+                                      event.stopPropagation()
+                                      void handleUnshareQuery(q)
+                                    }}
+                                  />
+                                )}
+                                {canMutateQuery && (
+                                  <MenuItem
+                                    tone="critical"
+                                    padding={3}
+                                    icon={TrashIcon}
+                                    text={t('action.delete')}
+                                    onClick={(event) => {
+                                      event.stopPropagation()
+                                      void deleteQuery(q._key)
+                                    }}
+                                  />
+                                )}
+                              </Menu>
+                            }
+                            popover={{portal: true, placement: 'bottom-end', tone: 'default'}}
+                          />
+                        )}
                       </Box>
-                    }
-                    placement="top"
-                    portal
-                  >
-                    <Code size={1}>{shortQueryPreview}</Code>
-                  </Tooltip>
-                ) : (
-                  <Code />
-                )}
+                    </Flex>
+                  </Flex>
 
-                {compactMode ? (
-                  <Stack space={1} style={{paddingTop: 0, minHeight: '30px'}}>
-                    <Flex align="center" gap={2} style={{minHeight: '18px'}}>
+                  {fullQueryPreview ? (
+                    <Tooltip
+                      content={
+                        <Box
+                          padding={2}
+                          style={{maxWidth: '420px', maxHeight: '220px', overflow: 'auto'}}
+                        >
+                          <Code size={1}>{fullQueryPreview}</Code>
+                        </Box>
+                      }
+                      placement="top"
+                      portal
+                    >
+                      <Code size={1}>{shortQueryPreview}</Code>
+                    </Tooltip>
+                  ) : (
+                    <Code />
+                  )}
+
+                  {compactMode ? (
+                    <Stack space={1} style={{paddingTop: 0, minHeight: '30px'}}>
+                      <Flex align="center" gap={2} style={{minHeight: '18px'}}>
+                        <Box
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            width: '17px',
+                            height: '17px',
+                          }}
+                        >
+                          {q.shared ? (
+                            <UserAvatar size={0} user={q.authorId || ''} withTooltip />
+                          ) : (
+                            <Box
+                              style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                lineHeight: 0,
+                                color: 'var(--card-muted-fg-color)',
+                              }}
+                            >
+                              <LockIcon />
+                            </Box>
+                          )}
+                        </Box>
+                        <Badge
+                          mode="outline"
+                          tone={q.shared ? 'primary' : 'default'}
+                          style={{
+                            whiteSpace: 'nowrap',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                          }}
+                        >
+                          {q.shared ? t('label.shared') : t('label.personal')}
+                        </Badge>
+                      </Flex>
+                      <Text size={1} muted>
+                        {formatDate.format(new Date(q.savedAt || ''))}
+                      </Text>
+                    </Stack>
+                  ) : (
+                    <Flex align="center" gap={2} style={{paddingTop: '2px', minHeight: '20px'}}>
                       <Box
                         style={{
                           display: 'flex',
@@ -617,82 +672,40 @@ export function QueryRecall({
                       >
                         {q.shared ? t('label.shared') : t('label.personal')}
                       </Badge>
+                      <Text size={1} muted>
+                        •
+                      </Text>
+                      <Text size={1} muted>
+                        {formatDate.format(new Date(q.savedAt || ''))}
+                      </Text>
                     </Flex>
-                    <Text size={1} muted>
-                      {formatDate.format(new Date(q.savedAt || ''))}
-                    </Text>
-                  </Stack>
-                ) : (
-                  <Flex align="center" gap={2} style={{paddingTop: '2px', minHeight: '20px'}}>
-                    <Box
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        width: '17px',
-                        height: '17px',
-                      }}
-                    >
-                      {q.shared ? (
-                        <UserAvatar size={0} user={q.authorId || ''} withTooltip />
-                      ) : (
-                        <Box
-                          style={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            lineHeight: 0,
-                            color: 'var(--card-muted-fg-color)',
-                          }}
-                        >
-                          <LockIcon />
-                        </Box>
-                      )}
-                    </Box>
-                    <Badge
-                      mode="outline"
-                      tone={q.shared ? 'primary' : 'default'}
-                      style={{
-                        whiteSpace: 'nowrap',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                      }}
-                    >
-                      {q.shared ? t('label.shared') : t('label.personal')}
-                    </Badge>
-                    <Text size={1} muted>
-                      •
-                    </Text>
-                    <Text size={1} muted>
-                      {formatDate.format(new Date(q.savedAt || ''))}
-                    </Text>
-                  </Flex>
-                )}
+                  )}
 
-                {isEdited && (
-                  <Button
-                    mode="ghost"
-                    tone="default"
-                    padding={2}
-                    style={{
-                      height: '24px',
-                      position: 'absolute',
-                      right: '16px',
-                      bottom: '16px',
-                      fontSize: '12px',
-                    }}
-                    text={t('action.update')}
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      void handleUpdate(q)
-                    }}
-                  />
-                )}
-              </Stack>
-            </Card>
-          )
-        })}
-      </Stack>
+                  {isEdited && (
+                    <Button
+                      mode="ghost"
+                      tone="default"
+                      padding={2}
+                      style={{
+                        height: '24px',
+                        position: 'absolute',
+                        right: '16px',
+                        bottom: '16px',
+                        fontSize: '12px',
+                      }}
+                      text={t('action.update')}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        void handleUpdate(q)
+                      }}
+                    />
+                  )}
+                </Stack>
+              </Card>
+            )
+          })}
+        </Stack>
+      </QueryList>
       {shareDialogQuery && (
         <Dialog
           id="vision-query-recall-share-dialog"

--- a/packages/@sanity/vision/src/components/VisionGui.css.ts
+++ b/packages/@sanity/vision/src/components/VisionGui.css.ts
@@ -7,6 +7,18 @@ globalStyle(`${root} .sidebarPanes .Pane`, {
   overflowX: 'hidden',
 })
 
+export const queryRecallPaneContainer = style({
+  position: 'absolute',
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+})
+
+export const queryRecallPaneWrapper = style({
+  minHeight: 0,
+})
+
 globalStyle(`${root} .Resizer`, {
   background: 'var(--card-border-color)',
   opacity: 1,

--- a/packages/@sanity/vision/src/components/VisionGui.styled.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.styled.tsx
@@ -10,6 +10,8 @@ import {
   inputBackgroundContainerLeft,
   inputContainer,
   queryCopyLink,
+  queryRecallPaneContainer,
+  queryRecallPaneWrapper,
   result,
   resultContainer,
   resultContainerInvalid,
@@ -42,6 +44,22 @@ export function StyledLabel(props: ComponentProps<typeof Label>) {
 
 export function SplitpaneContainer(props: ComponentProps<typeof Box>) {
   return <Box {...props} className={splitpaneContainer} />
+}
+
+export function QueryRecallPaneContainer(props: ComponentProps<typeof Flex>) {
+  return <Flex {...props} direction="column" className={queryRecallPaneContainer} />
+}
+
+export function QueryRecallPaneWrapper(props: ComponentProps<typeof Flex>) {
+  return (
+    <Flex
+      {...props}
+      direction="column"
+      flex={1}
+      overflow="hidden"
+      className={queryRecallPaneWrapper}
+    />
+  )
 }
 
 export function QueryCopyLink(props: ComponentProps<'a'>) {

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -54,6 +54,8 @@ import {usePaneSize} from './usePaneSize'
 import {
   InputBackgroundContainerLeft,
   InputContainer,
+  QueryRecallPaneContainer,
+  QueryRecallPaneWrapper,
   Root,
   SplitpaneContainer,
   StyledLabel,
@@ -738,7 +740,7 @@ export function VisionGui(props: VisionGuiProps) {
               />
             </SplitPane>
           </Box>
-          <Box style={{position: 'relative', height: '100%'}}>
+          <QueryRecallPaneContainer>
             <Button
               mode="ghost"
               padding={2}
@@ -756,15 +758,17 @@ export function VisionGui(props: VisionGuiProps) {
                 {isQueryRecallCollapsed ? <ChevronLeftIcon /> : <ChevronRightIcon />}
               </div>
             </Button>
-            <QueryRecall
-              url={url}
-              getStateFromUrl={getStateFromUrl}
-              setStateFromParsedUrl={setStateFromParsedUrl}
-              currentQuery={query}
-              currentParams={params.parsed || {}}
-              generateUrl={generateUrl}
-            />
-          </Box>
+            <QueryRecallPaneWrapper>
+              <QueryRecall
+                url={url}
+                getStateFromUrl={getStateFromUrl}
+                setStateFromParsedUrl={setStateFromParsedUrl}
+                currentQuery={query}
+                currentParams={params.parsed || {}}
+                generateUrl={generateUrl}
+              />
+            </QueryRecallPaneWrapper>
+          </QueryRecallPaneContainer>
         </SplitPane>
       </SplitpaneContainer>
     </Root>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fixes SAPP-3983. The saved queries side panel in Vision could not scroll when the list grew taller than the viewport. 

https://github.com/user-attachments/assets/cf030247-8ba9-4dc8-af2f-996babfc797d


### What to review
### Testing

- Manual verification: open Vision with many saved queries and confirm the list scrolls while the header stays fixed

### Notes for release

The saved queries side panel in Vision is now scrollable when the list exceeds the available height.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50701b59-0d75-478a-89cc-1502080d8290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50701b59-0d75-478a-89cc-1502080d8290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

