### PR TITLE
fix: only offer reload-to-update for versions auto-update will serve

### DIFF
--- a/packages/sanity/src/_singletons/context/PackageVersionInfoContext.tsx
+++ b/packages/sanity/src/_singletons/context/PackageVersionInfoContext.tsx
@@ -25,7 +25,9 @@ export type PackageVersionInfoContextValue = {
    * If an importmap for the sanity module exists in the DOM, includes details
    * will be undefined if no importmap is found
    */
-  importMapInfo?: {valid: false; error: Error} | {valid: true; minVersion: SemVer; appId?: string}
+  importMapInfo?:
+    | {valid: false; error: Error}
+    | {valid: true; minVersion: SemVer; versionRange: string; appId?: string}
 
   /**
    * What is the version tagged as latest (periodically checked)
@@ -38,7 +40,10 @@ export type PackageVersionInfoContextValue = {
   currentVersion: SemVer
 
   /**
-   * What is the current auto-updating version (as periodically resolved via module server and configured via manage)
+   * What is the current auto-updating version (as periodically resolved via module server and configured via manage).
+   * Only set if the version can actually be reached by reloading the studio: the module CDN's
+   * `resolvedVersion` when provided, otherwise the configured version if it's within the import
+   * map's version range.
    */
   autoUpdatingVersion?: SemVer
 }

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -38,6 +38,13 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'about-dialog.version-info.how-to-upgrade': 'Update now',
   /** "Latest version" header in version info dialog */
   'about-dialog.version-info.latest-version.header': 'Latest version',
+  /** Explanation shown when a new major version exists but can't be applied by auto-update */
+  'about-dialog.version-info.major-upgrade.description':
+    'Sanity Studio v{{latestVersion}} is available, but auto-update can’t install it because it’s a new major version. To update, upgrade the studio’s dependencies and redeploy it.',
+  /** Header for the note shown when a new major version exists but can't be applied by auto-update */
+  'about-dialog.version-info.major-upgrade.header': 'New major version available',
+  /** "Learn how to upgrade" link for the major version upgrade note */
+  'about-dialog.version-info.major-upgrade.view-documentation': 'Learn how to upgrade',
   /** Info text when auto updates is enabled and a new version is available */
   'about-dialog.version-info.new-auto-update-version-available': 'New version available',
   /** "New version" header in version info dialog - Note that this is not necessary a *higher* version compared to current:

--- a/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
@@ -1,5 +1,6 @@
 import {CogIcon} from '@sanity/icons/Cog'
 import {GithubIcon} from '@sanity/icons/Github'
+import {InfoOutlineIcon} from '@sanity/icons/InfoOutline'
 import {LaunchIcon} from '@sanity/icons/Launch'
 import {RefreshIcon} from '@sanity/icons/Refresh'
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
@@ -147,6 +148,42 @@ export function StudioInfoDialog(props: StudioInfoDialogProps) {
       </Card>
     ) : null
 
+  // A newer major version exists, but auto-update can't reach it (a reload only serves versions
+  // within the import map's version range unless the major jump has been explicitly allowed) —
+  // updating requires upgrading the studio's dependencies and redeploying
+  const majorUpgradeNote =
+    isAutoUpdating &&
+    latestTaggedVersion &&
+    latestTaggedVersion.major > currentVersion.major &&
+    (!autoUpdatingVersion || autoUpdatingVersion.major < latestTaggedVersion.major) ? (
+      <Card padding={4} tone="primary">
+        <Flex align="flex-start" gap={3}>
+          <TextWithTone tone="primary">
+            <InfoOutlineIcon />
+          </TextWithTone>
+          <Stack space={4}>
+            <TextWithTone size={1} tone="primary" weight="medium">
+              {t('about-dialog.version-info.major-upgrade.header')}
+            </TextWithTone>
+            <TextWithTone size={1} tone="primary">
+              {t('about-dialog.version-info.major-upgrade.description', {
+                latestVersion: latestTaggedVersion.version,
+              })}
+            </TextWithTone>
+            <Text muted size={1}>
+              <a
+                href="https://www.sanity.io/docs/upgrade"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {t('about-dialog.version-info.major-upgrade.view-documentation')} &rarr;
+              </a>
+            </Text>
+          </Stack>
+        </Flex>
+      </Card>
+    ) : null
+
   const versionBadgeTone =
     currentVersionType === 'development'
       ? 'caution'
@@ -242,7 +279,7 @@ export function StudioInfoDialog(props: StudioInfoDialogProps) {
                 />
               </Flex>
             </>
-          ) : !isUpToDate || currentVersionType ? (
+          ) : isUpToDate ? null : (
             <>
               <Flex justify="flex-end" align="center">
                 <Text size={1} weight="semibold">
@@ -273,7 +310,7 @@ export function StudioInfoDialog(props: StudioInfoDialogProps) {
                 }
               </Flex>
             </>
-          ) : null}
+          )}
         </Grid>
         <Stack space={2} paddingY={3}>
           {isAutoUpdating ? (
@@ -313,6 +350,7 @@ export function StudioInfoDialog(props: StudioInfoDialogProps) {
               </Flex>
             </Card>
           ) : null}
+          {majorUpgradeNote}
           {importMapWarning}
         </Stack>
         <Stack paddingX={3}>

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -134,7 +134,7 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
 
     // fetch the current version based on manage/brett configuration for appid
     const resolveAutoUpdatingVersion = DEBUG_AUTO_UPDATE_VERSION
-      ? Promise.resolve({packageVersion: DEBUG_VALUES.autoUpdateVersion})
+      ? Promise.resolve<AutoUpdatingVersionInfo>({packageVersion: DEBUG_VALUES.autoUpdateVersion})
       : importMapInfo?.valid
         ? importMapInfo.appId
           ? fetchLatestAutoUpdatingVersion({
@@ -155,7 +155,7 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
         // than rejecting), so only overwrite state when we actually got a value.
         // This keeps the previously known versions on a transient failure and
         // we try again on the next tick.
-        if (nextAutoUpdatingVersion) {
+        if (nextAutoUpdatingVersion?.resolvedVersion || nextAutoUpdatingVersion?.packageVersion) {
           setAutoUpdatingVersionRaw(nextAutoUpdatingVersion)
         }
         if (nextLatestVersion?.latest) {

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -89,7 +89,7 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
     const {resolvedVersion, packageVersion} = autoUpdatingVersionRaw
     // Prefer the version resolved by the module CDN — the exact version a reload will serve
     if (resolvedVersion) {
-      return semver.parse(resolvedVersion)!
+      return semver.parse(resolvedVersion) ?? undefined
     }
     if (!packageVersion) {
       return undefined
@@ -101,10 +101,11 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
     if (importMapInfo?.valid && !isReloadableVersion(packageVersion, importMapInfo.versionRange)) {
       return undefined
     }
-    return semver.parse(packageVersion)!
+    return semver.parse(packageVersion) ?? undefined
   }, [autoUpdatingVersionRaw, importMapInfo])
   const latestTaggedVersion = useMemo(
-    () => (latestTaggedVersionRaw ? semver.parse(latestTaggedVersionRaw)! : undefined),
+    () =>
+      latestTaggedVersionRaw ? (semver.parse(latestTaggedVersionRaw) ?? undefined) : undefined,
     [latestTaggedVersionRaw],
   )
 

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -6,10 +6,12 @@ import semver from 'semver'
 import {getSanityImportMapUrl} from '../../environment/importMap'
 import {SANITY_VERSION} from '../../version'
 import {
+  type AutoUpdatingVersionInfo,
   fetchLatestAutoUpdatingVersion,
   fetchLatestAvailableVersionForPackage,
+  type LatestVersionInfo,
 } from './fetchLatestVersions'
-import {parseImportMapModuleCdnUrl} from './utils'
+import {isReloadableVersion, parseImportMapModuleCdnUrl} from './utils'
 
 // How often to check for new versions
 const POLL_INTERVAL_MS = 1000 * 60 * 15 // check every 15 minutes
@@ -65,7 +67,11 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
       )
     }
     return result.valid
-      ? {...result, minVersion: semver.coerce(result.minVersion, {includePrerelease: true})!}
+      ? {
+          ...result,
+          versionRange: result.minVersion,
+          minVersion: semver.coerce(result.minVersion, {includePrerelease: true})!,
+        }
       : result
   }, [])
   const currentVersion = useMemo(() => getCurrentVersion(), [])
@@ -73,13 +79,30 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
   const isAutoUpdating = Boolean(importMapInfo)
 
   const lastCheckRef = useRef<number>(undefined)
-  const [autoUpdatingVersionRaw, setAutoUpdatingVersionRaw] = useState<string>()
+  const [autoUpdatingVersionRaw, setAutoUpdatingVersionRaw] = useState<AutoUpdatingVersionInfo>()
   const [latestTaggedVersionRaw, setLatestTaggedVersionRaw] = useState<string>()
 
-  const autoUpdatingVersion = useMemo(
-    () => (autoUpdatingVersionRaw ? semver.parse(autoUpdatingVersionRaw)! : undefined),
-    [autoUpdatingVersionRaw],
-  )
+  const autoUpdatingVersion = useMemo(() => {
+    if (!autoUpdatingVersionRaw) {
+      return undefined
+    }
+    const {resolvedVersion, packageVersion} = autoUpdatingVersionRaw
+    // Prefer the version resolved by the module CDN — the exact version a reload will serve
+    if (resolvedVersion) {
+      return semver.parse(resolvedVersion)!
+    }
+    if (!packageVersion) {
+      return undefined
+    }
+    // Module CDN responses without `resolvedVersion` only tell us the version the app is
+    // configured to update to, which may not be servable for the import map's version range
+    // (e.g. a new major that hasn't been allowed for auto-update). Reloading wouldn't update
+    // anything in that case — ignore the version instead of sending users into a reload loop.
+    if (importMapInfo?.valid && !isReloadableVersion(packageVersion, importMapInfo.versionRange)) {
+      return undefined
+    }
+    return semver.parse(packageVersion)!
+  }, [autoUpdatingVersionRaw, importMapInfo])
   const latestTaggedVersion = useMemo(
     () => (latestTaggedVersionRaw ? semver.parse(latestTaggedVersionRaw)! : undefined),
     [latestTaggedVersionRaw],
@@ -102,7 +125,7 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
 
     // fetch the current version of the sanity package on the 'latest' tag
     const resolveLatestTaggedVersion = DEBUG_LATEST_VERSION
-      ? Promise.resolve(DEBUG_VALUES.latestVersion)
+      ? Promise.resolve<LatestVersionInfo>({latest: DEBUG_VALUES.latestVersion})
       : fetchLatestAvailableVersionForPackage({
           packageName: REFERENCE_PACKAGE,
           minVersion: importMapInfo?.valid ? importMapInfo.minVersion : currentVersion,
@@ -111,7 +134,7 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
 
     // fetch the current version based on manage/brett configuration for appid
     const resolveAutoUpdatingVersion = DEBUG_AUTO_UPDATE_VERSION
-      ? Promise.resolve(DEBUG_VALUES.autoUpdateVersion)
+      ? Promise.resolve({packageVersion: DEBUG_VALUES.autoUpdateVersion})
       : importMapInfo?.valid
         ? importMapInfo.appId
           ? fetchLatestAutoUpdatingVersion({
@@ -120,7 +143,10 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
               appId: importMapInfo.appId,
             })
           : // if studio is auto-updating but has no appId, the auto-updating version will be from `latest`
-            resolveLatestTaggedVersion
+            resolveLatestTaggedVersion.then(
+              (result) =>
+                result && {packageVersion: result.latest, resolvedVersion: result.resolvedVersion},
+            )
         : undefined
 
     void Promise.all([resolveLatestTaggedVersion, resolveAutoUpdatingVersion])
@@ -129,11 +155,11 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
         // than rejecting), so only overwrite state when we actually got a value.
         // This keeps the previously known versions on a transient failure and
         // we try again on the next tick.
-        if (typeof nextAutoUpdatingVersion !== 'undefined') {
+        if (nextAutoUpdatingVersion) {
           setAutoUpdatingVersionRaw(nextAutoUpdatingVersion)
         }
-        if (typeof nextLatestVersion !== 'undefined') {
-          setLatestTaggedVersionRaw(nextLatestVersion)
+        if (nextLatestVersion?.latest) {
+          setLatestTaggedVersionRaw(nextLatestVersion.latest)
         }
       })
       .catch((err) => {

--- a/packages/sanity/src/core/studio/packageVersionStatus/fetchLatestVersions.ts
+++ b/packages/sanity/src/core/studio/packageVersionStatus/fetchLatestVersions.ts
@@ -67,10 +67,14 @@ export const fetchLatestAutoUpdatingVersion = async (options: {
       resolvedVersion: data.resolvedVersion as string | undefined,
     }
   } catch (err) {
-    console.error(
-      new Error(`Failed to fetch version for package "${packageName}" (using appId=${appId})`, {
-        cause: err,
-      }),
+    // Best-effort check — the caller keeps previously known versions and retries on the next poll
+    console.warn(
+      new Error(
+        `[sanity] Failed to fetch version for package "${packageName}" (using appId=${appId})`,
+        {
+          cause: err,
+        },
+      ),
     )
     return undefined
   }
@@ -105,8 +109,9 @@ export const fetchLatestAvailableVersionForPackage = async (options: {
       resolvedVersion: data.resolvedVersion as string | undefined,
     }
   } catch (err) {
-    console.error(
-      `Failed to fetch version for package (using tag=${tag})`,
+    // Best-effort check — the caller keeps previously known versions and retries on the next poll
+    console.warn(
+      `[sanity] Failed to fetch version for package (using tag=${tag})`,
       packageName,
       'Error:',
       err,

--- a/packages/sanity/src/core/studio/packageVersionStatus/fetchLatestVersions.ts
+++ b/packages/sanity/src/core/studio/packageVersionStatus/fetchLatestVersions.ts
@@ -37,11 +37,18 @@ function getModuleUrl({
   return `${MODULES_URL}/${packageName}/${tag}/^${minVersion.version}/t${timestamp}`
 }
 
+export interface AutoUpdatingVersionInfo {
+  /** The version the app is configured to update to (may not be servable for the import map's version range) */
+  packageVersion?: string
+  /** The exact version the module CDN will serve for the studio's import map URL, if provided by the server */
+  resolvedVersion?: string
+}
+
 export const fetchLatestAutoUpdatingVersion = async (options: {
   packageName: string
   minVersion: SemVer
   appId: string
-}) => {
+}): Promise<AutoUpdatingVersionInfo | undefined> => {
   const {packageName, minVersion, appId} = options
 
   try {
@@ -54,10 +61,11 @@ export const fetchLatestAutoUpdatingVersion = async (options: {
     if (!res.ok) {
       throw new Error(`HTTP ${res.status} ${res.statusText}`)
     }
-    // `return await` (not bare `return`) so a JSON parse rejection is
-    // caught by this try/catch instead of escaping to the caller.
     const data = await res.json()
-    return data.packageVersion as string
+    return {
+      packageVersion: data.packageVersion as string,
+      resolvedVersion: data.resolvedVersion as string | undefined,
+    }
   } catch (err) {
     console.error(
       new Error(`Failed to fetch version for package "${packageName}" (using appId=${appId})`, {
@@ -68,11 +76,18 @@ export const fetchLatestAutoUpdatingVersion = async (options: {
   }
 }
 
+export interface LatestVersionInfo {
+  /** The latest version published to the tag (may not be servable for the import map's version range) */
+  latest?: string
+  /** The exact version the module CDN will serve for the studio's import map URL, if provided by the server */
+  resolvedVersion?: string
+}
+
 export const fetchLatestAvailableVersionForPackage = async (options: {
   packageName: string
   minVersion: SemVer
   tag?: string
-}) => {
+}): Promise<LatestVersionInfo | undefined> => {
   const {packageName, minVersion, tag = 'latest'} = options
   try {
     // On every request it should be a new timestamp, so we can actually get a new version notification
@@ -84,10 +99,11 @@ export const fetchLatestAvailableVersionForPackage = async (options: {
     if (!res.ok) {
       throw new Error(`HTTP ${res.status} ${res.statusText}`)
     }
-    // `return await` (not bare `return`) so a JSON parse rejection is
-    // caught by this try/catch instead of escaping to the caller.
     const data = await res.json()
-    return data.latest as string
+    return {
+      latest: data.latest as string,
+      resolvedVersion: data.resolvedVersion as string | undefined,
+    }
   } catch (err) {
     console.error(
       `Failed to fetch version for package (using tag=${tag})`,

--- a/packages/sanity/src/core/studio/packageVersionStatus/utils.test.ts
+++ b/packages/sanity/src/core/studio/packageVersionStatus/utils.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest'
 
-import {parseImportMapModuleCdnUrl} from './utils'
+import {isReloadableVersion, parseImportMapModuleCdnUrl} from './utils'
 
 describe('parseImportMapModuleCdnUrl for legacy urls', () => {
   it('returns undefined but warns if an invalid module url is given', () => {
@@ -94,5 +94,24 @@ describe('parseImportMapModuleCdnUrl for app-id urls', () => {
         "valid": false,
       }
     `)
+  })
+})
+
+describe('isReloadableVersion', () => {
+  it('accepts versions within the import map range', () => {
+    expect(isReloadableVersion('5.32.0', '^5.31.1')).toBe(true)
+    expect(isReloadableVersion('5.31.1', '^5.31.1')).toBe(true)
+    // downgrades within the range (e.g. a version pinned via manage) are still reachable
+    expect(isReloadableVersion('5.25.0', '^5.20.0')).toBe(true)
+  })
+  it('rejects versions outside the import map range', () => {
+    // a new major will never be served on reload
+    expect(isReloadableVersion('6.4.0', '^5.31.1')).toBe(false)
+    expect(isReloadableVersion('4.9.0', '^5.31.1')).toBe(false)
+  })
+  it('accepts prerelease versions within the range', () => {
+    expect(isReloadableVersion('5.32.0-next.5', '^5.31.1')).toBe(true)
+    // but not prereleases of the next major
+    expect(isReloadableVersion('6.0.0-next.1', '^5.31.1')).toBe(false)
   })
 })

--- a/packages/sanity/src/core/studio/packageVersionStatus/utils.ts
+++ b/packages/sanity/src/core/studio/packageVersionStatus/utils.ts
@@ -1,4 +1,4 @@
-import semver from 'semver'
+import semver, {type SemVer} from 'semver'
 
 const MODULE_PATH_REGEX = /^\/v1\/modules\/sanity\/[^/]+\/[^/]+\/[^/]+\/?$/
 // /v1/modules/by-app/some-appid-123/t1755876954/%5E4.5.0/sanity
@@ -33,6 +33,18 @@ export function parseImportMapModuleCdnUrl(
     appId,
     minVersion,
   }
+}
+
+/**
+ * Checks whether a version resolved from the module CDN can actually be reached by reloading the
+ * studio, given the version range from the studio's import map. The module CDN never serves a
+ * version outside this range (e.g. a new major), so prompting the user to reload into one would
+ * only send them into a reload loop.
+ */
+export function isReloadableVersion(version: SemVer | string, versionRange: string): boolean {
+  // `includePrerelease` so that studios configured to auto-update to a prerelease tag still get
+  // the reload prompt, as long as the prerelease is within the import map's range
+  return semver.satisfies(version, versionRange, {includePrerelease: true})
 }
 
 function rawParseModuleCDNUrl(


### PR DESCRIPTION
### Description

Auto-updating studios decide whether to show the "Reload to update" prompt by polling the module CDN's version-check endpoints, but the value they used (`packageVersion` / `latest`) is the version the app is *configured* to update to and not necessarily one the CDN will actually serve for the import map.

For example: When a new major is published, a v5.31.1 studio prompts "Reload to update to v6.4.0", but the reload still serves v5.31.1 again, and the prompt immediately returns, and the user is stuck in an endless reload loop.

This PR makes is so that `autoUpdatingVersion` actually means "the version you get after reloading", and it prefers the new `resolvedVersion` field from the module CDN.

When the latest version is a major above what auto-update can reach, the "About"-dialog now shows a note explaining that updating requires upgrading dependencies and redeploying, with a link to the upgrade guide.

Note: this PR is safe to merge independently of any module CDN changes.

### Testing
Test added

### Notes for release

- Fixes an issue where auto-updating studios would offer "Reload to update" for a major version the Studio can't auto-update to, causing the prompt to reappear indefinitely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Studio UX and version-polling logic only; no auth, data, or deployment pipeline changes, with unit tests for `isReloadableVersion`.
> 
> **Overview**
> Fixes auto-updating studios that showed **Reload to update** for versions a reload cannot actually serve (e.g. a new major while the import map stays on the previous major), which could trap users in a reload loop.
> 
> **`autoUpdatingVersion`** now means the version you get after reloading: module CDN responses prefer **`resolvedVersion`**, and configured **`packageVersion` / `latest`** is only used when it satisfies the import map range via new **`isReloadableVersion`**. Import map context exposes **`versionRange`** for that check.
> 
> The About dialog adds a **major upgrade** note (with i18n and upgrade docs link) when a newer major exists but auto-update cannot reach it, and tightens when the manual “latest version” row appears versus up-to-date auto-update studios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b3c847b66326343616f0dbbdb548e472dafe274. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->