### PR TITLE
fix(core): variants details not rendering the documents

### DIFF
--- a/packages/sanity/src/core/variants/hooks/__tests__/useVariantDocuments.test.ts
+++ b/packages/sanity/src/core/variants/hooks/__tests__/useVariantDocuments.test.ts
@@ -67,7 +67,7 @@ describe('useVariantDocuments', () => {
 
     expect(documentPreviewStoreMock.unstable_observeDocumentIdSet).toHaveBeenCalledWith(
       'sanity::partOfVariant($variantId)',
-      {variantId: variantAlphaAudience._id},
+      {variantId: 'alpha-audience'},
       {apiVersion: RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion},
     )
   })

--- a/packages/sanity/src/core/variants/hooks/useVariantDocuments.ts
+++ b/packages/sanity/src/core/variants/hooks/useVariantDocuments.ts
@@ -6,6 +6,7 @@ import {
 } from '../../releases/tool/detail/useBundleDocuments'
 import {type DocumentInVariant} from '../tool/detail/types'
 import {toVariantDocumentVersion} from '../tool/detail/variantDocumentVersion'
+import {getVariantId} from '../tool/util'
 
 /**
  * Hook to fetch the documents that belong to a variant.
@@ -21,7 +22,7 @@ export function useVariantDocuments(variantId: string | undefined): {
   error: null | Error
 } {
   const enabled = Boolean(variantId)
-  const params = useMemo(() => ({variantId: variantId ?? ''}), [variantId])
+  const params = useMemo(() => ({variantId: variantId ? getVariantId(variantId) : ''}), [variantId])
 
   const {loading, results, error} = useBundleDocuments({
     groqFilter: `sanity::partOfVariant($variantId)`,


### PR DESCRIPTION
### Description
Fixes a rebase issue that changed the variantId used to query the partOfVariant documents.
It needs to use the shortId , so from `_.variants.foo` it should use `foo` to query.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a internal
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
