### PR TITLE
chore(ailf): expand tasks

### DIFF
--- a/packages/@repo/ailf/.ailf/tasks/add-reference-fields.reference.ts
+++ b/packages/@repo/ailf/.ailf/tasks/add-reference-fields.reference.ts
@@ -1,0 +1,77 @@
+import {defineConfig, defineType, defineField, defineArrayMember} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Blog',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'author',
+        title: 'Author',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'name',
+            title: 'Name',
+            type: 'string',
+          }),
+        ],
+      }),
+      defineType({
+        name: 'category',
+        title: 'Category',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+        ],
+      }),
+      defineType({
+        name: 'post',
+        title: 'Post',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'author',
+            title: 'Author',
+            type: 'reference',
+            to: [{type: 'author'}],
+            validation: (rule) => rule.required(),
+          }),
+          defineField({
+            name: 'categories',
+            title: 'Categories',
+            type: 'array',
+            of: [
+              defineArrayMember({
+                type: 'reference',
+                to: [{type: 'category'}],
+              }),
+            ],
+            validation: (rule) => rule.max(3),
+          }),
+          defineField({
+            name: 'body',
+            title: 'Body',
+            type: 'array',
+            of: [
+              defineArrayMember({
+                type: 'block',
+              }),
+            ],
+          }),
+        ],
+      }),
+    ],
+  },
+})

--- a/packages/@repo/ailf/.ailf/tasks/add-reference-fields.task.ts
+++ b/packages/@repo/ailf/.ailf/tasks/add-reference-fields.task.ts
@@ -1,0 +1,113 @@
+import {defineTask} from '@sanity/ailf'
+
+export default defineTask({
+  mode: 'literacy',
+  id: 'add-reference-fields',
+  title: 'Add reference fields',
+  area: 'studio',
+  context: {
+    docs: [
+      {
+        path: 'studio/reference-type',
+      },
+    ],
+  },
+  docCoverage: true,
+  referenceSolution: 'tasks/add-reference-fields.reference.ts',
+  prompt: {
+    text: `Posts need an author and up to three categories. Add a required
+reference to the author type, and an array of references to the category
+type capped at three items.
+
+This is the existing Studio configuration:
+
+\`\`\`ts
+import {defineConfig, defineType, defineField, defineArrayMember} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Blog',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'author',
+        title: 'Author',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'name',
+            title: 'Name',
+            type: 'string',
+          }),
+        ],
+      }),
+      defineType({
+        name: 'category',
+        title: 'Category',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+        ],
+      }),
+      defineType({
+        name: 'post',
+        title: 'Post',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'body',
+            title: 'Body',
+            type: 'array',
+            of: [
+              defineArrayMember({
+                type: 'block',
+              }),
+            ],
+          }),
+        ],
+      }),
+    ],
+  },
+})
+\`\`\``,
+  },
+  assertions: [
+    {
+      type: 'llm-rubric',
+      template: 'task-completion',
+      criteria: [
+        {
+          id: 'adds-author-reference',
+          text: 'The `post` type has a field of type `reference` with `to` pointing at the `author` type.',
+        },
+        {
+          id: 'author-is-required',
+          text: 'The author reference field has a validation rule making it required.',
+        },
+        {
+          id: 'adds-category-reference-array',
+          text: 'The `post` type has an `array` field whose members are references to the `category` type.',
+        },
+        {
+          id: 'categories-capped-at-three',
+          text: 'The category array field has a validation rule capping it at three items.',
+        },
+        {
+          id: 'exports-studio-configuration',
+          text: 'Exports a valid Studio configuration.',
+        },
+      ],
+    },
+  ],
+})

--- a/packages/@repo/ailf/.ailf/tasks/add-slug-field.reference.ts
+++ b/packages/@repo/ailf/.ailf/tasks/add-slug-field.reference.ts
@@ -1,0 +1,39 @@
+import {defineConfig, defineType, defineField} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Blog',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'post',
+        title: 'Post',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'slug',
+            title: 'Slug',
+            type: 'slug',
+            options: {
+              source: 'title',
+              maxLength: 96,
+            },
+            validation: (rule) => rule.required(),
+          }),
+          defineField({
+            name: 'publishedAt',
+            title: 'Published at',
+            type: 'datetime',
+          }),
+        ],
+      }),
+    ],
+  },
+})

--- a/packages/@repo/ailf/.ailf/tasks/add-slug-field.task.ts
+++ b/packages/@repo/ailf/.ailf/tasks/add-slug-field.task.ts
@@ -1,0 +1,84 @@
+import {defineTask} from '@sanity/ailf'
+
+export default defineTask({
+  mode: 'literacy',
+  id: 'add-slug-field',
+  title: 'Add a slug field',
+  area: 'studio',
+  context: {
+    docs: [
+      {
+        path: 'studio/slug-type',
+      },
+    ],
+  },
+  docCoverage: true,
+  referenceSolution: 'tasks/add-slug-field.reference.ts',
+  prompt: {
+    text: `We need URLs for blog posts. Add a slug field that editors can
+generate from the post title, limited to 96 characters. A post must not pass
+validation without a slug.
+
+This is the existing Studio configuration:
+
+\`\`\`ts
+import {defineConfig, defineType, defineField} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Blog',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'post',
+        title: 'Post',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'publishedAt',
+            title: 'Published at',
+            type: 'datetime',
+          }),
+        ],
+      }),
+    ],
+  },
+})
+\`\`\``,
+  },
+  assertions: [
+    {
+      type: 'llm-rubric',
+      template: 'task-completion',
+      criteria: [
+        {
+          id: 'adds-slug-field',
+          text: 'The `post` type has a field of type `slug`.',
+        },
+        {
+          id: 'slug-source-is-title',
+          text: 'The slug field has `options.source` set to the `title` field.',
+        },
+        {
+          id: 'slug-max-length',
+          text: 'The slug field has `options.maxLength` set to 96.',
+        },
+        {
+          id: 'slug-is-required',
+          text: 'The slug field has a validation rule making it required.',
+        },
+        {
+          id: 'exports-studio-configuration',
+          text: 'Exports a valid Studio configuration.',
+        },
+      ],
+    },
+  ],
+})

--- a/packages/@repo/ailf/.ailf/tasks/add-sort-orders.reference.ts
+++ b/packages/@repo/ailf/.ailf/tasks/add-sort-orders.reference.ts
@@ -1,0 +1,41 @@
+import {defineConfig, defineType, defineField} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Blog',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'post',
+        title: 'Post',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'publishedAt',
+            title: 'Published at',
+            type: 'datetime',
+          }),
+        ],
+        orderings: [
+          {
+            name: 'publishedAtDesc',
+            title: 'Publish date, newest first',
+            by: [{field: 'publishedAt', direction: 'desc'}],
+          },
+          {
+            name: 'titleAsc',
+            title: 'Title, A–Z',
+            by: [{field: 'title', direction: 'asc'}],
+          },
+        ],
+      }),
+    ],
+  },
+})

--- a/packages/@repo/ailf/.ailf/tasks/add-sort-orders.task.ts
+++ b/packages/@repo/ailf/.ailf/tasks/add-sort-orders.task.ts
@@ -1,0 +1,84 @@
+import {defineTask} from '@sanity/ailf'
+
+export default defineTask({
+  mode: 'literacy',
+  id: 'add-sort-orders',
+  title: 'Add custom sort orders',
+  area: 'studio',
+  context: {
+    docs: [
+      {
+        path: 'studio/sort-orders',
+      },
+    ],
+  },
+  docCoverage: true,
+  referenceSolution: 'tasks/add-sort-orders.reference.ts',
+  prompt: {
+    text: `Editors want to browse posts by newest publish date first, and
+alphabetically by title. Add these two sort options to the post type, listing
+newest-first before the alphabetical option.
+
+This is the existing Studio configuration:
+
+\`\`\`ts
+import {defineConfig, defineType, defineField} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Blog',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'post',
+        title: 'Post',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'publishedAt',
+            title: 'Published at',
+            type: 'datetime',
+          }),
+        ],
+      }),
+    ],
+  },
+})
+\`\`\``,
+  },
+  assertions: [
+    {
+      type: 'llm-rubric',
+      template: 'task-completion',
+      criteria: [
+        {
+          id: 'adds-orderings',
+          text: 'The `post` type has an `orderings` array with two sort orders.',
+        },
+        {
+          id: 'newest-first-ordering',
+          text: 'One ordering sorts by `publishedAt` descending, and it is listed first.',
+        },
+        {
+          id: 'alphabetical-ordering',
+          text: 'One ordering sorts by `title` ascending.',
+        },
+        {
+          id: 'orderings-have-name-and-title',
+          text: 'Each ordering has both a `name` and a human-readable `title`.',
+        },
+        {
+          id: 'exports-studio-configuration',
+          text: 'Exports a valid Studio configuration.',
+        },
+      ],
+    },
+  ],
+})

--- a/packages/@repo/ailf/.ailf/tasks/conditional-field-visibility.reference.ts
+++ b/packages/@repo/ailf/.ailf/tasks/conditional-field-visibility.reference.ts
@@ -1,0 +1,35 @@
+import {defineConfig, defineType, defineField} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Blog',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'post',
+        title: 'Post',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'isExternal',
+            title: 'Link to external site?',
+            type: 'boolean',
+          }),
+          defineField({
+            name: 'externalUrl',
+            title: 'External URL',
+            type: 'url',
+            hidden: ({document}) => !document?.isExternal,
+          }),
+        ],
+      }),
+    ],
+  },
+})

--- a/packages/@repo/ailf/.ailf/tasks/conditional-field-visibility.task.ts
+++ b/packages/@repo/ailf/.ailf/tasks/conditional-field-visibility.task.ts
@@ -1,0 +1,82 @@
+import {defineTask} from '@sanity/ailf'
+
+export default defineTask({
+  mode: 'literacy',
+  id: 'conditional-field-visibility',
+  title: 'Conditionally hide a field',
+  area: 'studio',
+  context: {
+    docs: [
+      {
+        path: 'studio/conditional-fields',
+      },
+    ],
+  },
+  docCoverage: true,
+  referenceSolution: 'tasks/conditional-field-visibility.reference.ts',
+  prompt: {
+    text: `Posts can link out to an external site, but the "External URL" field
+is confusing editors when it is not relevant. Change the schema so the
+"External URL" field only appears when the "Link to external site?" toggle is
+on.
+
+This is the existing Studio configuration:
+
+\`\`\`ts
+import {defineConfig, defineType, defineField} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Blog',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'post',
+        title: 'Post',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'isExternal',
+            title: 'Link to external site?',
+            type: 'boolean',
+          }),
+          defineField({
+            name: 'externalUrl',
+            title: 'External URL',
+            type: 'url',
+          }),
+        ],
+      }),
+    ],
+  },
+})
+\`\`\``,
+  },
+  assertions: [
+    {
+      type: 'llm-rubric',
+      template: 'task-completion',
+      criteria: [
+        {
+          id: 'hides-external-url-conditionally',
+          text: 'The `post.externalUrl` field has a `hidden` callback that hides the field when `isExternal` is not `true`, reading the sibling value from the callback context (e.g. `document` or `parent`).',
+        },
+        {
+          id: 'keeps-external-url-field',
+          text: 'The `post.externalUrl` field remains in the schema with type `url`.',
+        },
+        {
+          id: 'exports-studio-configuration',
+          text: 'Exports a valid Studio configuration.',
+        },
+      ],
+    },
+  ],
+})

--- a/packages/@repo/ailf/.ailf/tasks/configure-list-preview.reference.ts
+++ b/packages/@repo/ailf/.ailf/tasks/configure-list-preview.reference.ts
@@ -1,0 +1,61 @@
+import {defineConfig, defineType, defineField} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Blog',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'author',
+        title: 'Author',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'name',
+            title: 'Name',
+            type: 'string',
+          }),
+        ],
+      }),
+      defineType({
+        name: 'post',
+        title: 'Post',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'coverImage',
+            title: 'Cover image',
+            type: 'image',
+          }),
+          defineField({
+            name: 'author',
+            title: 'Author',
+            type: 'reference',
+            to: [{type: 'author'}],
+          }),
+        ],
+        preview: {
+          select: {
+            title: 'title',
+            authorName: 'author.name',
+            media: 'coverImage',
+          },
+          prepare({title, authorName, media}) {
+            return {
+              title,
+              subtitle: authorName,
+              media,
+            }
+          },
+        },
+      }),
+    ],
+  },
+})

--- a/packages/@repo/ailf/.ailf/tasks/configure-list-preview.task.ts
+++ b/packages/@repo/ailf/.ailf/tasks/configure-list-preview.task.ts
@@ -1,0 +1,116 @@
+import {defineTask} from '@sanity/ailf'
+
+export default defineTask({
+  mode: 'literacy',
+  id: 'configure-list-preview',
+  title: 'Configure document list previews',
+  area: 'studio',
+  context: {
+    docs: [
+      {
+        path: 'studio/previews-list-views',
+      },
+    ],
+  },
+  docCoverage: true,
+  referenceSolution: 'tasks/configure-list-preview.reference.ts',
+  prompt: {
+    text: `Posts in the document list currently only show their title. Configure
+the post preview so the list shows the post title, the referenced author's
+name as the subtitle, and the cover image as the thumbnail.
+
+This is the existing Studio configuration:
+
+\`\`\`ts
+import {defineConfig, defineType, defineField} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Blog',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'author',
+        title: 'Author',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'name',
+            title: 'Name',
+            type: 'string',
+          }),
+        ],
+      }),
+      defineType({
+        name: 'post',
+        title: 'Post',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'coverImage',
+            title: 'Cover image',
+            type: 'image',
+          }),
+          defineField({
+            name: 'author',
+            title: 'Author',
+            type: 'reference',
+            to: [{type: 'author'}],
+          }),
+        ],
+      }),
+    ],
+  },
+})
+\`\`\``,
+  },
+  assertions: [
+    {
+      type: 'llm-rubric',
+      template: 'task-completion',
+      criteria: [
+        {
+          id: 'adds-preview-configuration',
+          text: 'The `post` type has a `preview` configuration.',
+        },
+        {
+          id: 'selects-author-name-through-reference',
+          text: 'The preview `select` follows the author reference to select the author name (e.g. `author.name`).',
+        },
+        {
+          id: 'shows-title-subtitle-media',
+          text: 'The prepared preview shows the post title as title, the author name as subtitle, and the cover image as media.',
+        },
+        {
+          id: 'exports-studio-configuration',
+          text: 'Exports a valid Studio configuration.',
+        },
+      ],
+    },
+    {
+      type: 'llm-rubric',
+      template: 'code-correctness',
+      criteria: [
+        {
+          id: 'select-uses-dot-notation-join',
+          text: 'The `select` object uses dot notation to resolve values through the reference (e.g. `author.name`) rather than attempting to select the reference object itself.',
+        },
+        {
+          id: 'prepare-returns-preview-shape',
+          text: 'If a `prepare` function is used, it returns an object using the `title`, `subtitle`, and `media` keys.',
+        },
+        {
+          id: 'no-deprecated-preview-patterns',
+          text: 'Uses the current `preview` property on the schema type, with no deprecated preview APIs or React preview components.',
+        },
+      ],
+    },
+  ],
+})

--- a/packages/@repo/ailf/.ailf/tasks/create-singleton-settings.reference.ts
+++ b/packages/@repo/ailf/.ailf/tasks/create-singleton-settings.reference.ts
@@ -1,0 +1,64 @@
+import {defineConfig, defineType, defineField} from 'sanity'
+import {structureTool} from 'sanity/structure'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Blog',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  plugins: [
+    structureTool({
+      structure: (S) =>
+        S.list()
+          .title('Content')
+          .items([
+            S.listItem()
+              .title('Site settings')
+              .id('siteSettings')
+              .child(S.document().schemaType('siteSettings').documentId('siteSettings')),
+            S.divider(),
+            ...S.documentTypeListItems().filter((item) => item.getId() !== 'siteSettings'),
+          ]),
+    }),
+  ],
+  schema: {
+    types: [
+      defineType({
+        name: 'siteSettings',
+        title: 'Site settings',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'siteTitle',
+            title: 'Site title',
+            type: 'string',
+          }),
+        ],
+      }),
+      defineType({
+        name: 'post',
+        title: 'Post',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+        ],
+      }),
+      defineType({
+        name: 'author',
+        title: 'Author',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'name',
+            title: 'Name',
+            type: 'string',
+          }),
+        ],
+      }),
+    ],
+  },
+})

--- a/packages/@repo/ailf/.ailf/tasks/create-singleton-settings.task.ts
+++ b/packages/@repo/ailf/.ailf/tasks/create-singleton-settings.task.ts
@@ -1,0 +1,127 @@
+import {defineTask} from '@sanity/ailf'
+
+export default defineTask({
+  mode: 'literacy',
+  id: 'create-singleton-settings',
+  title: 'Create a singleton settings document',
+  area: 'studio',
+  context: {
+    docs: [
+      {
+        path: 'studio/structure-builder-cheat-sheet',
+      },
+      {
+        path: 'studio/structure-builder-introduction',
+      },
+    ],
+  },
+  docCoverage: true,
+  referenceSolution: 'tasks/create-singleton-settings.reference.ts',
+  prompt: {
+    text: `We have one global "Site settings" document. Make the Studio treat it
+as a singleton: a structure item that opens the one settings document directly
+(using the fixed document ID \`siteSettings\`), with the remaining document
+types listed as normal.
+
+This is the existing Studio configuration:
+
+\`\`\`ts
+import {defineConfig, defineType, defineField} from 'sanity'
+import {structureTool} from 'sanity/structure'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Blog',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  plugins: [structureTool()],
+  schema: {
+    types: [
+      defineType({
+        name: 'siteSettings',
+        title: 'Site settings',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'siteTitle',
+            title: 'Site title',
+            type: 'string',
+          }),
+        ],
+      }),
+      defineType({
+        name: 'post',
+        title: 'Post',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+        ],
+      }),
+      defineType({
+        name: 'author',
+        title: 'Author',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'name',
+            title: 'Name',
+            type: 'string',
+          }),
+        ],
+      }),
+    ],
+  },
+})
+\`\`\``,
+  },
+  assertions: [
+    {
+      type: 'llm-rubric',
+      template: 'task-completion',
+      criteria: [
+        {
+          id: 'custom-structure-defined',
+          text: 'The `structureTool` plugin is configured with a custom `structure` resolver.',
+        },
+        {
+          id: 'singleton-opens-fixed-document',
+          text: 'The structure contains a "Site settings" item that opens a single document editor for the `siteSettings` type with the fixed document ID `siteSettings`.',
+        },
+        {
+          id: 'other-types-still-listed',
+          text: 'The `post` and `author` document types are still browsable as regular document type lists.',
+        },
+        {
+          id: 'settings-excluded-from-type-lists',
+          text: 'The `siteSettings` type does not also appear as a regular document type list.',
+        },
+        {
+          id: 'exports-studio-configuration',
+          text: 'Exports a valid Studio configuration.',
+        },
+      ],
+    },
+    {
+      type: 'llm-rubric',
+      template: 'code-correctness',
+      criteria: [
+        {
+          id: 'uses-structure-builder-api',
+          text: 'Uses the Structure Builder (`S`) methods correctly, e.g. `S.list()`, `S.listItem()`, and `S.document().schemaType(...).documentId(...)` for the singleton.',
+        },
+        {
+          id: 'filters-default-list-items',
+          text: 'If default document type list items are reused (e.g. `S.documentTypeListItems()`), the `siteSettings` type is filtered out rather than duplicated.',
+        },
+        {
+          id: 'no-deprecated-desk-tool',
+          text: 'Uses `structureTool` from `sanity/structure`, not the deprecated `deskTool`.',
+        },
+      ],
+    },
+  ],
+})

--- a/packages/@repo/ailf/.ailf/tasks/image-hotspot-alt-text.reference.ts
+++ b/packages/@repo/ailf/.ailf/tasks/image-hotspot-alt-text.reference.ts
@@ -1,0 +1,40 @@
+import {defineConfig, defineType, defineField} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Magazine',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'article',
+        title: 'Article',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'coverImage',
+            title: 'Cover image',
+            type: 'image',
+            options: {
+              hotspot: true,
+            },
+            fields: [
+              defineField({
+                name: 'alt',
+                title: 'Alternative text',
+                type: 'string',
+                validation: (rule) => rule.required(),
+              }),
+            ],
+          }),
+        ],
+      }),
+    ],
+  },
+})

--- a/packages/@repo/ailf/.ailf/tasks/image-hotspot-alt-text.task.ts
+++ b/packages/@repo/ailf/.ailf/tasks/image-hotspot-alt-text.task.ts
@@ -1,0 +1,80 @@
+import {defineTask} from '@sanity/ailf'
+
+export default defineTask({
+  mode: 'literacy',
+  id: 'image-hotspot-alt-text',
+  title: 'Enable image hotspot and require alt text',
+  area: 'studio',
+  context: {
+    docs: [
+      {
+        path: 'studio/image-type',
+      },
+    ],
+  },
+  docCoverage: true,
+  referenceSolution: 'tasks/image-hotspot-alt-text.reference.ts',
+  prompt: {
+    text: `Our article cover images get cropped badly on different devices, and
+we are failing accessibility audits. Let editors control the crop focus of the
+cover image, and require alternative text on it.
+
+This is the existing Studio configuration:
+
+\`\`\`ts
+import {defineConfig, defineType, defineField} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Magazine',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'article',
+        title: 'Article',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'coverImage',
+            title: 'Cover image',
+            type: 'image',
+          }),
+        ],
+      }),
+    ],
+  },
+})
+\`\`\``,
+  },
+  assertions: [
+    {
+      type: 'llm-rubric',
+      template: 'task-completion',
+      criteria: [
+        {
+          id: 'enables-hotspot',
+          text: 'The `article.coverImage` field has `options.hotspot` set to `true`.',
+        },
+        {
+          id: 'adds-alt-text-field',
+          text: 'The `article.coverImage` field has an alternative text field of type `string` defined within the image `fields` array.',
+        },
+        {
+          id: 'alt-text-is-required',
+          text: 'The alternative text field has a validation rule making it required.',
+        },
+        {
+          id: 'exports-studio-configuration',
+          text: 'Exports a valid Studio configuration.',
+        },
+      ],
+    },
+  ],
+})

--- a/packages/@repo/ailf/.ailf/tasks/organize-fields-with-groups.reference.ts
+++ b/packages/@repo/ailf/.ailf/tasks/organize-fields-with-groups.reference.ts
@@ -1,0 +1,53 @@
+import {defineConfig, defineType, defineField} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Web shop',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'product',
+        title: 'Product',
+        type: 'document',
+        groups: [
+          {name: 'details', title: 'Details', default: true},
+          {name: 'seo', title: 'SEO'},
+        ],
+        fields: [
+          defineField({
+            name: 'name',
+            title: 'Name',
+            type: 'string',
+            group: 'details',
+          }),
+          defineField({
+            name: 'description',
+            title: 'Description',
+            type: 'text',
+            group: 'details',
+          }),
+          defineField({
+            name: 'price',
+            title: 'Price',
+            type: 'number',
+            group: 'details',
+          }),
+          defineField({
+            name: 'seoTitle',
+            title: 'SEO title',
+            type: 'string',
+            group: 'seo',
+          }),
+          defineField({
+            name: 'seoDescription',
+            title: 'SEO description',
+            type: 'text',
+            group: 'seo',
+          }),
+        ],
+      }),
+    ],
+  },
+})

--- a/packages/@repo/ailf/.ailf/tasks/organize-fields-with-groups.task.ts
+++ b/packages/@repo/ailf/.ailf/tasks/organize-fields-with-groups.task.ts
@@ -1,0 +1,99 @@
+import {defineTask} from '@sanity/ailf'
+
+export default defineTask({
+  mode: 'literacy',
+  id: 'organize-fields-with-groups',
+  title: 'Organize fields with groups',
+  area: 'studio',
+  context: {
+    docs: [
+      {
+        path: 'studio/field-groups',
+      },
+    ],
+  },
+  docCoverage: true,
+  referenceSolution: 'tasks/organize-fields-with-groups.reference.ts',
+  prompt: {
+    text: `The product document form has become unwieldy. Group the fields into
+"Details" and "SEO" tabs: put the SEO fields in the SEO tab and everything
+else in Details. Details should be the tab that is open by default.
+
+This is the existing Studio configuration:
+
+\`\`\`ts
+import {defineConfig, defineType, defineField} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Web shop',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'product',
+        title: 'Product',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'name',
+            title: 'Name',
+            type: 'string',
+          }),
+          defineField({
+            name: 'description',
+            title: 'Description',
+            type: 'text',
+          }),
+          defineField({
+            name: 'price',
+            title: 'Price',
+            type: 'number',
+          }),
+          defineField({
+            name: 'seoTitle',
+            title: 'SEO title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'seoDescription',
+            title: 'SEO description',
+            type: 'text',
+          }),
+        ],
+      }),
+    ],
+  },
+})
+\`\`\``,
+  },
+  assertions: [
+    {
+      type: 'llm-rubric',
+      template: 'task-completion',
+      criteria: [
+        {
+          id: 'defines-two-groups',
+          text: 'The `product` type defines two field groups titled "Details" and "SEO".',
+        },
+        {
+          id: 'assigns-seo-fields',
+          text: 'The `seoTitle` and `seoDescription` fields are assigned to the SEO group.',
+        },
+        {
+          id: 'assigns-detail-fields',
+          text: 'The `name`, `description`, and `price` fields are assigned to the Details group.',
+        },
+        {
+          id: 'details-is-default',
+          text: 'The Details group is marked as the default group.',
+        },
+        {
+          id: 'exports-studio-configuration',
+          text: 'Exports a valid Studio configuration.',
+        },
+      ],
+    },
+  ],
+})

--- a/packages/@repo/ailf/.ailf/tasks/require-field-validation.reference.ts
+++ b/packages/@repo/ailf/.ailf/tasks/require-field-validation.reference.ts
@@ -1,0 +1,41 @@
+import {defineConfig, defineType, defineField, defineArrayMember} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Blog',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'post',
+        title: 'Post',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'excerpt',
+            title: 'Excerpt',
+            type: 'text',
+            validation: (rule) =>
+              rule.required().max(200).error('An excerpt of 200 characters or less is required'),
+          }),
+          defineField({
+            name: 'body',
+            title: 'Body',
+            type: 'array',
+            of: [
+              defineArrayMember({
+                type: 'block',
+              }),
+            ],
+          }),
+        ],
+      }),
+    ],
+  },
+})

--- a/packages/@repo/ailf/.ailf/tasks/require-field-validation.task.ts
+++ b/packages/@repo/ailf/.ailf/tasks/require-field-validation.task.ts
@@ -1,0 +1,90 @@
+import {defineTask} from '@sanity/ailf'
+
+export default defineTask({
+  mode: 'literacy',
+  id: 'require-field-validation',
+  title: 'Require an excerpt with a length limit',
+  area: 'studio',
+  context: {
+    docs: [
+      {
+        path: 'studio/validation',
+      },
+    ],
+  },
+  docCoverage: true,
+  referenceSolution: 'tasks/require-field-validation.reference.ts',
+  prompt: {
+    text: `Editors keep publishing posts without an excerpt. Make the excerpt
+field mandatory, cap it at 200 characters, and show the message "An excerpt of
+200 characters or less is required" when validation fails.
+
+This is the existing Studio configuration:
+
+\`\`\`ts
+import {defineConfig, defineType, defineField, defineArrayMember} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Blog',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'post',
+        title: 'Post',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'excerpt',
+            title: 'Excerpt',
+            type: 'text',
+          }),
+          defineField({
+            name: 'body',
+            title: 'Body',
+            type: 'array',
+            of: [
+              defineArrayMember({
+                type: 'block',
+              }),
+            ],
+          }),
+        ],
+      }),
+    ],
+  },
+})
+\`\`\``,
+  },
+  assertions: [
+    {
+      type: 'llm-rubric',
+      template: 'task-completion',
+      criteria: [
+        {
+          id: 'excerpt-is-required',
+          text: 'The `post.excerpt` field has a validation rule making it required.',
+        },
+        {
+          id: 'excerpt-max-length',
+          text: 'The `post.excerpt` field has a validation rule capping its length at 200 characters.',
+        },
+        {
+          id: 'custom-error-message',
+          text: 'The validation failure message is "An excerpt of 200 characters or less is required".',
+        },
+        {
+          id: 'exports-studio-configuration',
+          text: 'Exports a valid Studio configuration.',
+        },
+      ],
+    },
+  ],
+})

--- a/packages/@repo/ailf/.ailf/tasks/restrict-portable-text.reference.ts
+++ b/packages/@repo/ailf/.ailf/tasks/restrict-portable-text.reference.ts
@@ -1,0 +1,59 @@
+import {defineConfig, defineType, defineField, defineArrayMember} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Blog',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'post',
+        title: 'Post',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'body',
+            title: 'Body',
+            type: 'array',
+            of: [
+              defineArrayMember({
+                type: 'block',
+                styles: [
+                  {title: 'Normal', value: 'normal'},
+                  {title: 'H2', value: 'h2'},
+                ],
+                lists: [{title: 'Bullet', value: 'bullet'}],
+                marks: {
+                  decorators: [
+                    {title: 'Strong', value: 'strong'},
+                    {title: 'Emphasis', value: 'em'},
+                  ],
+                  annotations: [
+                    defineArrayMember({
+                      name: 'link',
+                      title: 'Link',
+                      type: 'object',
+                      fields: [
+                        defineField({
+                          name: 'href',
+                          title: 'URL',
+                          type: 'url',
+                        }),
+                      ],
+                    }),
+                  ],
+                },
+              }),
+            ],
+          }),
+        ],
+      }),
+    ],
+  },
+})

--- a/packages/@repo/ailf/.ailf/tasks/restrict-portable-text.task.ts
+++ b/packages/@repo/ailf/.ailf/tasks/restrict-portable-text.task.ts
@@ -1,0 +1,111 @@
+import {defineTask} from '@sanity/ailf'
+
+export default defineTask({
+  mode: 'literacy',
+  id: 'restrict-portable-text',
+  title: 'Restrict Portable Text formatting',
+  area: 'studio',
+  context: {
+    docs: [
+      {
+        path: 'studio/block-type',
+      },
+      {
+        path: 'studio/portable-text-editor-configuration',
+      },
+    ],
+  },
+  docCoverage: true,
+  referenceSolution: 'tasks/restrict-portable-text.reference.ts',
+  prompt: {
+    text: `Editors are pasting in wildly formatted text. Restrict the post body
+so it only allows the Normal and H2 styles, only the bold (strong) and italic
+(emphasis) decorators, only bullet lists, and only link annotations — nothing
+else.
+
+This is the existing Studio configuration:
+
+\`\`\`ts
+import {defineConfig, defineType, defineField, defineArrayMember} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Blog',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'post',
+        title: 'Post',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'body',
+            title: 'Body',
+            type: 'array',
+            of: [
+              defineArrayMember({
+                type: 'block',
+              }),
+            ],
+          }),
+        ],
+      }),
+    ],
+  },
+})
+\`\`\``,
+  },
+  assertions: [
+    {
+      type: 'llm-rubric',
+      template: 'task-completion',
+      criteria: [
+        {
+          id: 'restricts-styles',
+          text: 'The block member of `post.body` restricts `styles` to only Normal (`normal`) and H2 (`h2`).',
+        },
+        {
+          id: 'restricts-decorators',
+          text: 'Decorators are restricted to only Strong (`strong`) and Emphasis (`em`).',
+        },
+        {
+          id: 'restricts-lists',
+          text: 'Lists are restricted to only bullet lists (`bullet`).',
+        },
+        {
+          id: 'restricts-annotations',
+          text: 'Annotations are restricted to only a link annotation.',
+        },
+        {
+          id: 'exports-studio-configuration',
+          text: 'Exports a valid Studio configuration.',
+        },
+      ],
+    },
+    {
+      type: 'llm-rubric',
+      template: 'code-correctness',
+      criteria: [
+        {
+          id: 'decorators-and-annotations-under-marks',
+          text: "The `decorators` and `annotations` configuration is nested under the block type's `marks` property, not placed at the top level of the block definition.",
+        },
+        {
+          id: 'uses-canonical-values',
+          text: 'Style, decorator, and list entries use the canonical values (`normal`, `h2`, `strong`, `em`, `bullet`) as `{title, value}` objects.',
+        },
+        {
+          id: 'link-annotation-shape',
+          text: 'The link annotation is defined as an object type with a URL field (e.g. an `href` field of type `url`).',
+        },
+      ],
+    },
+  ],
+})

--- a/packages/@repo/ailf/.ailf/tasks/set-initial-values.reference.ts
+++ b/packages/@repo/ailf/.ailf/tasks/set-initial-values.reference.ts
@@ -1,0 +1,42 @@
+import {defineConfig, defineType, defineField} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Events',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'event',
+        title: 'Event',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'doorsOpen',
+            title: 'Doors open',
+            type: 'boolean',
+            initialValue: true,
+          }),
+          defineField({
+            name: 'timezone',
+            title: 'Timezone',
+            type: 'string',
+            initialValue: 'Europe/Oslo',
+          }),
+          defineField({
+            name: 'date',
+            title: 'Date',
+            type: 'datetime',
+            initialValue: () => new Date().toISOString(),
+          }),
+        ],
+      }),
+    ],
+  },
+})

--- a/packages/@repo/ailf/.ailf/tasks/set-initial-values.task.ts
+++ b/packages/@repo/ailf/.ailf/tasks/set-initial-values.task.ts
@@ -1,0 +1,90 @@
+import {defineTask} from '@sanity/ailf'
+
+export default defineTask({
+  mode: 'literacy',
+  id: 'set-initial-values',
+  title: 'Set initial values',
+  area: 'studio',
+  context: {
+    docs: [
+      {
+        path: 'studio/initial-value-templates',
+      },
+    ],
+  },
+  docCoverage: true,
+  referenceSolution: 'tasks/set-initial-values.reference.ts',
+  prompt: {
+    text: `When editors create a new event, the "Doors open" toggle should
+default to on and the timezone should default to "Europe/Oslo". New events
+should also default their date to the moment they are created.
+
+This is the existing Studio configuration:
+
+\`\`\`ts
+import {defineConfig, defineType, defineField} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Events',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'event',
+        title: 'Event',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+          }),
+          defineField({
+            name: 'doorsOpen',
+            title: 'Doors open',
+            type: 'boolean',
+          }),
+          defineField({
+            name: 'timezone',
+            title: 'Timezone',
+            type: 'string',
+          }),
+          defineField({
+            name: 'date',
+            title: 'Date',
+            type: 'datetime',
+          }),
+        ],
+      }),
+    ],
+  },
+})
+\`\`\``,
+  },
+  assertions: [
+    {
+      type: 'llm-rubric',
+      template: 'task-completion',
+      criteria: [
+        {
+          id: 'doors-open-defaults-true',
+          text: 'The `event.doorsOpen` field has an initial value of `true`.',
+        },
+        {
+          id: 'timezone-defaults-oslo',
+          text: 'The `event.timezone` field has an initial value of "Europe/Oslo".',
+        },
+        {
+          id: 'date-defaults-to-now',
+          text: 'The `event.date` field has an initial value computed at creation time (a function returning the current timestamp), not a hardcoded date string.',
+        },
+        {
+          id: 'exports-studio-configuration',
+          text: 'Exports a valid Studio configuration.',
+        },
+      ],
+    },
+  ],
+})

--- a/packages/@repo/ailf/.ailf/tasks/string-dropdown-options.reference.ts
+++ b/packages/@repo/ailf/.ailf/tasks/string-dropdown-options.reference.ts
@@ -1,0 +1,37 @@
+import {defineConfig, defineType, defineField} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Book store',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'book',
+        title: 'Book',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'name',
+            title: 'Name',
+            type: 'string',
+          }),
+          defineField({
+            name: 'readingLevel',
+            title: 'Reading level',
+            type: 'string',
+            options: {
+              list: [
+                {title: 'Beginner', value: 'beginner'},
+                {title: 'Intermediate', value: 'intermediate'},
+                {title: 'Advanced', value: 'advanced'},
+              ],
+              layout: 'radio',
+            },
+          }),
+        ],
+      }),
+    ],
+  },
+})

--- a/packages/@repo/ailf/.ailf/tasks/string-dropdown-options.task.ts
+++ b/packages/@repo/ailf/.ailf/tasks/string-dropdown-options.task.ts
@@ -1,0 +1,80 @@
+import {defineTask} from '@sanity/ailf'
+
+export default defineTask({
+  mode: 'literacy',
+  id: 'string-dropdown-options',
+  title: 'Constrain a string field to predefined values',
+  area: 'studio',
+  context: {
+    docs: [
+      {
+        path: 'studio/string-type',
+      },
+    ],
+  },
+  docCoverage: true,
+  referenceSolution: 'tasks/string-dropdown-options.reference.ts',
+  prompt: {
+    text: `The "Reading level" field is free text and editors keep typing
+inconsistent values. Constrain it to Beginner, Intermediate, and Advanced,
+shown as a radio group, storing lowercase values.
+
+This is the existing Studio configuration:
+
+\`\`\`ts
+import {defineConfig, defineType, defineField} from 'sanity'
+
+export default defineConfig({
+  name: 'default',
+  title: 'Book store',
+  projectId: 'xxxxxxxx',
+  dataset: 'production',
+  schema: {
+    types: [
+      defineType({
+        name: 'book',
+        title: 'Book',
+        type: 'document',
+        fields: [
+          defineField({
+            name: 'name',
+            title: 'Name',
+            type: 'string',
+          }),
+          defineField({
+            name: 'readingLevel',
+            title: 'Reading level',
+            type: 'string',
+          }),
+        ],
+      }),
+    ],
+  },
+})
+\`\`\``,
+  },
+  assertions: [
+    {
+      type: 'llm-rubric',
+      template: 'task-completion',
+      criteria: [
+        {
+          id: 'adds-predefined-list',
+          text: 'The `book.readingLevel` field has an `options.list` with exactly the Beginner, Intermediate, and Advanced choices.',
+        },
+        {
+          id: 'stores-lowercase-values',
+          text: 'The list entries store lowercase values (`beginner`, `intermediate`, `advanced`) while displaying capitalized titles.',
+        },
+        {
+          id: 'uses-radio-layout',
+          text: 'The field is displayed as a radio group via `options.layout`.',
+        },
+        {
+          id: 'exports-studio-configuration',
+          text: 'Exports a valid Studio configuration.',
+        },
+      ],
+    },
+  ],
+})


### PR DESCRIPTION
### Description

This branch adds thirteen AILF tasks to bolster the initial task added in #13448. These cover a range of fundamental Studio configuration tasks.

### What to review

The new AILF tasks.

### Testing

AILF runs successfully for this branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit de85d38c19bab5c21a62aaaa88af40d57a033f93. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->