### PR TITLE
fix(core): delegate useProject request errors to the studio error channel

### DIFF
--- a/packages/sanity/src/core/store/project/useProject.test.tsx
+++ b/packages/sanity/src/core/store/project/useProject.test.tsx
@@ -1,0 +1,84 @@
+import {ClientError} from '@sanity/client'
+import {act, renderHook, waitFor} from '@testing-library/react'
+import {type ReactNode} from 'react'
+import {firstValueFrom, of, throwError} from 'rxjs'
+import {StudioErrorHandlerContext} from 'sanity/_singletons'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import {createRequestErrorChannel} from '../../studio/requestErrors/createRequestErrorChannel'
+import {type StudioErrorHandler} from '../../studio/requestErrors/types'
+import {useProjectStore} from '../datastores'
+import {type ProjectData, type ProjectStore} from './types'
+import {useProject} from './useProject'
+
+vi.mock('../datastores', () => ({useProjectStore: vi.fn()}))
+
+const projectData = {id: 'abc123', displayName: 'Test project'} as ProjectData
+
+function sessionExpiredError(): ClientError {
+  return new ClientError({
+    statusCode: 401,
+    headers: {},
+    body: {
+      error: 'Unauthorized',
+      errorCode: 'SIO-401-AEX',
+      message: 'Session is expired, please re-authenticate',
+    },
+    url: 'https://abc123.api.sanity.io/v1/projects/abc123',
+    method: 'GET',
+  } as never)
+}
+
+function setup(get: ProjectStore['get'], errorHandler?: StudioErrorHandler) {
+  vi.mocked(useProjectStore).mockReturnValue({get} as ProjectStore)
+  const wrapper = ({children}: {children: ReactNode}) => (
+    <StudioErrorHandlerContext.Provider value={errorHandler ?? null}>
+      {children}
+    </StudioErrorHandlerContext.Provider>
+  )
+  return renderHook(() => useProject(), {wrapper})
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useProject', () => {
+  it('emits the fetched project data', async () => {
+    const {result} = setup(() => of(projectData))
+    await waitFor(() => expect(result.current.value).toEqual(projectData))
+  })
+
+  it('delegates a session-expired 401 to the error channel (unauthorized claim)', async () => {
+    const channel = createRequestErrorChannel()
+    const {result} = setup(() => throwError(() => sessionExpiredError()), channel)
+    await waitFor(async () =>
+      expect(await firstValueFrom(channel.claim$)).toMatchObject({
+        type: 'unauthorized',
+        projectId: 'abc123',
+      }),
+    )
+    expect(result.current.value).toBeNull()
+  })
+
+  it('re-runs the fetch when the error dialog retries', async () => {
+    const channel = createRequestErrorChannel()
+    const get = vi
+      .fn<ProjectStore['get']>()
+      .mockReturnValueOnce(
+        throwError(() => new ClientError({statusCode: 429, headers: {}, body: {}} as never)),
+      )
+      .mockReturnValueOnce(of(projectData))
+    const {result} = setup(get, channel)
+    await waitFor(async () =>
+      expect(await firstValueFrom(channel.claim$)).toMatchObject({type: 'rateLimited'}),
+    )
+    act(() => channel.retry())
+    await waitFor(() => expect(result.current.value).toEqual(projectData))
+    expect(get).toHaveBeenCalledTimes(2)
+  })
+
+  // Note: errors the channel does NOT claim (caller-domain 4xx, etc.) are
+  // intentionally left unhandled by the hook — they propagate through
+  // rxjs's unhandled-error path so they stay visible to error monitoring.
+})

--- a/packages/sanity/src/core/store/project/useProject.ts
+++ b/packages/sanity/src/core/store/project/useProject.ts
@@ -1,19 +1,22 @@
 import {useEffect, useState} from 'react'
+import {from} from 'rxjs'
 
+import {useStudioErrorHandler} from '../../studio'
 import {useProjectStore} from '../datastores'
 import {type ProjectData} from './types'
 
 /** @internal */
 export function useProject(): {value: ProjectData | null} {
   const projectStore = useProjectStore()
+  const errorHandler = useStudioErrorHandler()
   const [value, setValue] = useState<ProjectData | null>(null)
 
   useEffect(() => {
-    const project$ = projectStore.get()
-    const sub = project$.subscribe(setValue)
-
+    const sub = from(errorHandler.attempt(() => projectStore.get(), {retryable: true})).subscribe(
+      setValue,
+    )
     return () => sub.unsubscribe()
-  }, [projectStore])
+  }, [errorHandler, projectStore])
 
   return {value}
 }


### PR DESCRIPTION
### Description
This wraps the useProject fetch in `attempt()` so infra failures reach the studio's request-error dialog with retry instead of erroring the permission streams.

### What to review

### Testing
Unit tests included

Easiest way to test manually is to open preview build, enable request blocking on the project store fetch and make sure it reaches the error dialog

### Notes for release
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how project bootstrap failures interact with session/unauthorized and retry UX; behavior is localized to `useProject` but affects early studio load when the project API fails.
> 
> **Overview**
> **`useProject` now routes project-store fetch failures through the studio request-error handler** instead of subscribing to `projectStore.get()` directly.
> 
> The hook wraps the fetch in `errorHandler.attempt(..., { retryable: true })` and subscribes via RxJS `from()`, so infra errors (e.g. session 401, rate limits) surface in the shared error dialog and can be retried. Successful loads still update hook state the same way; unclaimed caller-domain errors are left to propagate for monitoring.
> 
> **New unit tests** cover happy path, unauthorized 401 claims on the channel, and retry re-invoking the store after a rate-limit failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ec398939d417a294417559db93be59263a97a8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->