### PR TITLE
feat(variants): show live document counts in variants overview

### DIFF
--- a/packages/sanity/src/core/variants/hooks/__tests__/useVariantsDocumentCounts.test.ts
+++ b/packages/sanity/src/core/variants/hooks/__tests__/useVariantsDocumentCounts.test.ts
@@ -37,24 +37,20 @@ function createMockClient() {
 
 describe('buildVariantsDocumentCountsQuery', () => {
   it('builds one aggregate fetch query and one listen filter covering all variants', () => {
-    const {fetch, listen, keyToVariantId} = buildVariantsDocumentCountsQuery([
+    const {fetch, listen} = buildVariantsDocumentCountsQuery([
       variantAlphaAudience._id,
       variantNorwegianMarket._id,
     ])
 
     expect(fetch).toBe(
       '{' +
-        '"v0": count(array::unique(*[sanity::partOfVariant("alpha-audience")]._system.group._ref)),' +
-        '"v1": count(array::unique(*[sanity::partOfVariant("norwegian-market")]._system.group._ref))' +
+        '"_.variants.alpha-audience": count(array::unique(*[sanity::partOfVariant("alpha-audience")]._system.group._ref)),' +
+        '"_.variants.norwegian-market": count(array::unique(*[sanity::partOfVariant("norwegian-market")]._system.group._ref))' +
         '}',
     )
     expect(listen).toBe(
       '*[sanity::partOfVariant("alpha-audience") || sanity::partOfVariant("norwegian-market")]',
     )
-    expect(keyToVariantId).toEqual({
-      v0: variantAlphaAudience._id,
-      v1: variantNorwegianMarket._id,
-    })
   })
 })
 
@@ -75,7 +71,7 @@ describe('getVariantsDocumentCounts', () => {
 
   it('opens a single listener and maps the aggregate response to counts per variant id', async () => {
     const {client, fetch, listen, listener$} = createMockClient()
-    fetch.mockReturnValue(of({v0: 2, v1: 0}))
+    fetch.mockReturnValue(of({[variantAlphaAudience._id]: 2, [variantNorwegianMarket._id]: 0}))
 
     const valuesPromise = firstValueFrom(
       getVariantsDocumentCounts(client, [
@@ -120,7 +116,9 @@ describe('getVariantsDocumentCounts', () => {
     vi.useFakeTimers()
 
     const {client, fetch, listener$} = createMockClient()
-    fetch.mockReturnValueOnce(of({v0: 1})).mockReturnValueOnce(of({v0: 2}))
+    fetch
+      .mockReturnValueOnce(of({[variantAlphaAudience._id]: 1}))
+      .mockReturnValueOnce(of({[variantAlphaAudience._id]: 2}))
 
     const valuesPromise = firstValueFrom(
       getVariantsDocumentCounts(client, [variantAlphaAudience._id]).pipe(take(3), toArray()),
@@ -169,7 +167,7 @@ describe('useVariantsDocumentCounts', () => {
   it('returns live counts and stops loading after the first fetch', async () => {
     const {client, fetch, listener$} = createMockClient()
     useClientMock.mockReturnValue(client)
-    fetch.mockReturnValue(of({v0: 3}))
+    fetch.mockReturnValue(of({[variantAlphaAudience._id]: 3}))
 
     const wrapper = await createTestProvider()
     const {result} = renderHook(() => useVariantsDocumentCounts([variantAlphaAudience._id]), {

--- a/packages/sanity/src/core/variants/hooks/__tests__/useVariantsDocumentCounts.test.ts
+++ b/packages/sanity/src/core/variants/hooks/__tests__/useVariantsDocumentCounts.test.ts
@@ -5,34 +5,55 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
 import {variantAlphaAudience, variantNorwegianMarket} from '../../__fixtures__/variants.fixture'
+import {type VariantStoreState} from '../../store/reducer'
+import {type SystemVariant} from '../../types'
 import {
   buildVariantsDocumentCountsQuery,
   getVariantsDocumentCounts,
   useVariantsDocumentCounts,
+  type VariantsDocumentCountsState,
 } from '../useVariantsDocumentCounts'
 
 const useClientMock = vi.hoisted(() => vi.fn())
+const useVariantsStoreMock = vi.hoisted(() => vi.fn())
 
 vi.mock('../../../hooks', async (importOriginal) => ({
   ...(await importOriginal()),
   useClient: useClientMock,
 }))
 
+vi.mock('../../store/useVariantsStore', () => ({
+  useVariantsStore: useVariantsStoreMock,
+}))
+
+type ListenerEvent = {
+  type: 'welcome' | 'mutation'
+  transition?: 'update'
+  visibility?: 'query'
+}
+
 function createMockClient() {
-  const listener$ = new Subject<{
-    type: 'welcome' | 'mutation'
-    transition?: 'update'
-    visibility?: 'query'
-  }>()
+  const listeners: Subject<ListenerEvent>[] = []
   const fetch = vi.fn()
-  const listen = vi.fn(() => listener$)
+  const listen = vi.fn(() => {
+    const listener$ = new Subject<ListenerEvent>()
+    listeners.push(listener$)
+    return listener$
+  })
   const client = {
     listen,
     observable: {fetch},
     withConfig: vi.fn(() => client),
   } as unknown as SanityClient
 
-  return {client, fetch, listen, listener$}
+  return {client, fetch, listen, listeners}
+}
+
+function makeVariantsState(variants: SystemVariant[]): VariantStoreState {
+  return {
+    variants: new Map(variants.map((variant) => [variant._id, variant])),
+    state: 'loaded',
+  }
 }
 
 describe('buildVariantsDocumentCountsQuery', () => {
@@ -62,7 +83,7 @@ describe('getVariantsDocumentCounts', () => {
   it('emits empty data without fetching or listening when there are no variants', async () => {
     const {client, fetch, listen} = createMockClient()
 
-    const value = await firstValueFrom(getVariantsDocumentCounts(client, []))
+    const value = await firstValueFrom(getVariantsDocumentCounts(client, of(makeVariantsState([]))))
 
     expect(value).toEqual({data: {}, loading: false, error: null})
     expect(fetch).not.toHaveBeenCalled()
@@ -70,17 +91,17 @@ describe('getVariantsDocumentCounts', () => {
   })
 
   it('opens a single listener and maps the aggregate response to counts per variant id', async () => {
-    const {client, fetch, listen, listener$} = createMockClient()
+    const {client, fetch, listen, listeners} = createMockClient()
     fetch.mockReturnValue(of({[variantAlphaAudience._id]: 2, [variantNorwegianMarket._id]: 0}))
 
     const valuesPromise = firstValueFrom(
-      getVariantsDocumentCounts(client, [
-        variantAlphaAudience._id,
-        variantNorwegianMarket._id,
-      ]).pipe(take(2), toArray()),
+      getVariantsDocumentCounts(
+        client,
+        of(makeVariantsState([variantAlphaAudience, variantNorwegianMarket])),
+      ).pipe(take(2), toArray()),
     )
 
-    listener$.next({type: 'welcome'})
+    listeners[0]!.next({type: 'welcome'})
 
     const values = await valuesPromise
 
@@ -115,18 +136,21 @@ describe('getVariantsDocumentCounts', () => {
   it('refetches counts when the listener emits a mutation', async () => {
     vi.useFakeTimers()
 
-    const {client, fetch, listener$} = createMockClient()
+    const {client, fetch, listeners} = createMockClient()
     fetch
       .mockReturnValueOnce(of({[variantAlphaAudience._id]: 1}))
       .mockReturnValueOnce(of({[variantAlphaAudience._id]: 2}))
 
     const valuesPromise = firstValueFrom(
-      getVariantsDocumentCounts(client, [variantAlphaAudience._id]).pipe(take(3), toArray()),
+      getVariantsDocumentCounts(client, of(makeVariantsState([variantAlphaAudience]))).pipe(
+        take(3),
+        toArray(),
+      ),
     )
 
-    listener$.next({type: 'welcome'})
+    listeners[0]!.next({type: 'welcome'})
     await vi.advanceTimersByTimeAsync(0)
-    listener$.next({type: 'mutation', transition: 'update', visibility: 'query'})
+    listeners[0]!.next({type: 'mutation', transition: 'update', visibility: 'query'})
     await vi.advanceTimersByTimeAsync(1000)
 
     const values = await valuesPromise
@@ -140,22 +164,119 @@ describe('getVariantsDocumentCounts', () => {
     })
   })
 
-  it('exposes fetch errors', async () => {
-    const {client, fetch, listener$} = createMockClient()
-    const error = new Error('Failed to fetch counts')
-    fetch.mockImplementation(() => {
-      throw error
-    })
+  it('switches to a new listener and preserves counts when the variant set changes', async () => {
+    const {client, fetch, listen, listeners} = createMockClient()
+    const variantsState$ = new Subject<VariantStoreState>()
 
-    const valuesPromise = firstValueFrom(
-      getVariantsDocumentCounts(client, [variantAlphaAudience._id]).pipe(take(2), toArray()),
+    fetch
+      .mockReturnValueOnce(of({[variantAlphaAudience._id]: 1}))
+      .mockReturnValueOnce(of({[variantAlphaAudience._id]: 1, [variantNorwegianMarket._id]: 4}))
+
+    const emissions: VariantsDocumentCountsState[] = []
+    const subscription = getVariantsDocumentCounts(client, variantsState$).subscribe((value) =>
+      emissions.push(value),
     )
 
-    listener$.next({type: 'welcome'})
+    variantsState$.next(makeVariantsState([variantAlphaAudience]))
+    listeners[0]!.next({type: 'welcome'})
 
-    const values = await valuesPromise
+    await vi.waitFor(() => {
+      expect(emissions.at(-1)).toEqual({
+        data: {[variantAlphaAudience._id]: 1},
+        loading: false,
+        error: null,
+      })
+    })
 
-    expect(values.at(-1)).toEqual({data: null, loading: false, error})
+    // Adding a variant closes the previous listener and opens a new one covering both
+    // variants, inside the same outer subscription.
+    variantsState$.next(makeVariantsState([variantAlphaAudience, variantNorwegianMarket]))
+
+    expect(listen).toHaveBeenCalledTimes(2)
+    expect(listeners[0]!.observed).toBe(false)
+    expect(listen).toHaveBeenLastCalledWith(
+      '*[sanity::partOfVariant("alpha-audience") || sanity::partOfVariant("norwegian-market")]',
+      {},
+      expect.anything(),
+    )
+
+    // While the new fetch is pending, the previously fetched counts are preserved.
+    expect(emissions.at(-1)).toEqual({
+      data: {[variantAlphaAudience._id]: 1},
+      loading: false,
+      error: null,
+    })
+
+    listeners[1]!.next({type: 'welcome'})
+
+    await vi.waitFor(() => {
+      expect(emissions.at(-1)).toEqual({
+        data: {
+          [variantAlphaAudience._id]: 1,
+          [variantNorwegianMarket._id]: 4,
+        },
+        loading: false,
+        error: null,
+      })
+    })
+
+    subscription.unsubscribe()
+  })
+
+  it('ignores store emissions that do not change the variant set', () => {
+    const {client, fetch, listen, listeners} = createMockClient()
+    const variantsState$ = new Subject<VariantStoreState>()
+
+    fetch.mockReturnValue(of({[variantAlphaAudience._id]: 1}))
+
+    const subscription = getVariantsDocumentCounts(client, variantsState$).subscribe()
+
+    variantsState$.next(makeVariantsState([variantAlphaAudience]))
+    listeners[0]!.next({type: 'welcome'})
+    variantsState$.next(makeVariantsState([{...variantAlphaAudience, priority: 9}]))
+
+    expect(listen).toHaveBeenCalledTimes(1)
+    expect(listeners[0]!.observed).toBe(true)
+
+    subscription.unsubscribe()
+  })
+
+  it('exposes fetch errors and keeps reacting to variant set changes', async () => {
+    const {client, fetch, listeners} = createMockClient()
+    const variantsState$ = new Subject<VariantStoreState>()
+    const error = new Error('Failed to fetch counts')
+
+    fetch
+      .mockImplementationOnce(() => {
+        throw error
+      })
+      .mockReturnValueOnce(of({[variantNorwegianMarket._id]: 4}))
+
+    const emissions: VariantsDocumentCountsState[] = []
+    const subscription = getVariantsDocumentCounts(client, variantsState$).subscribe((value) =>
+      emissions.push(value),
+    )
+
+    variantsState$.next(makeVariantsState([variantAlphaAudience]))
+    listeners[0]!.next({type: 'welcome'})
+
+    await vi.waitFor(() => {
+      expect(emissions.at(-1)).toEqual({data: null, loading: false, error})
+    })
+
+    // The outer stream survives the error: a variant set change starts a new listener.
+    variantsState$.next(makeVariantsState([variantNorwegianMarket]))
+    listeners[1]!.next({type: 'welcome'})
+
+    await vi.waitFor(() => {
+      expect(emissions.at(-1)).toEqual({
+        data: {[variantNorwegianMarket._id]: 4},
+        loading: false,
+        error: null,
+      })
+    })
+
+    subscription.unsubscribe()
   })
 })
 
@@ -164,19 +285,21 @@ describe('useVariantsDocumentCounts', () => {
     vi.clearAllMocks()
   })
 
-  it('returns live counts and stops loading after the first fetch', async () => {
-    const {client, fetch, listener$} = createMockClient()
+  it('returns live counts for the variants held by the variants store', async () => {
+    const {client, fetch, listeners} = createMockClient()
     useClientMock.mockReturnValue(client)
+    useVariantsStoreMock.mockReturnValue({
+      state$: of(makeVariantsState([variantAlphaAudience])),
+      dispatch: vi.fn(),
+    })
     fetch.mockReturnValue(of({[variantAlphaAudience._id]: 3}))
 
     const wrapper = await createTestProvider()
-    const {result} = renderHook(() => useVariantsDocumentCounts([variantAlphaAudience._id]), {
-      wrapper,
-    })
+    const {result} = renderHook(() => useVariantsDocumentCounts(), {wrapper})
 
     expect(result.current).toEqual({data: null, loading: true, error: null})
 
-    listener$.next({type: 'welcome'})
+    listeners[0]!.next({type: 'welcome'})
 
     await waitFor(() => {
       expect(result.current).toEqual({
@@ -190,9 +313,13 @@ describe('useVariantsDocumentCounts', () => {
   it('returns empty data without a listener when there are no variants', async () => {
     const {client, fetch, listen} = createMockClient()
     useClientMock.mockReturnValue(client)
+    useVariantsStoreMock.mockReturnValue({
+      state$: of(makeVariantsState([])),
+      dispatch: vi.fn(),
+    })
 
     const wrapper = await createTestProvider()
-    const {result} = renderHook(() => useVariantsDocumentCounts([]), {wrapper})
+    const {result} = renderHook(() => useVariantsDocumentCounts(), {wrapper})
 
     expect(result.current).toEqual({data: {}, loading: false, error: null})
     expect(fetch).not.toHaveBeenCalled()

--- a/packages/sanity/src/core/variants/hooks/__tests__/useVariantsDocumentCounts.test.ts
+++ b/packages/sanity/src/core/variants/hooks/__tests__/useVariantsDocumentCounts.test.ts
@@ -1,0 +1,203 @@
+import {type SanityClient} from '@sanity/client'
+import {renderHook, waitFor} from '@testing-library/react'
+import {firstValueFrom, of, Subject, take, toArray} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {variantAlphaAudience, variantNorwegianMarket} from '../../__fixtures__/variants.fixture'
+import {
+  buildVariantsDocumentCountsQuery,
+  getVariantsDocumentCounts,
+  useVariantsDocumentCounts,
+} from '../useVariantsDocumentCounts'
+
+const useClientMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../hooks', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useClient: useClientMock,
+}))
+
+function createMockClient() {
+  const listener$ = new Subject<{
+    type: 'welcome' | 'mutation'
+    transition?: 'update'
+    visibility?: 'query'
+  }>()
+  const fetch = vi.fn()
+  const listen = vi.fn(() => listener$)
+  const client = {
+    listen,
+    observable: {fetch},
+    withConfig: vi.fn(() => client),
+  } as unknown as SanityClient
+
+  return {client, fetch, listen, listener$}
+}
+
+describe('buildVariantsDocumentCountsQuery', () => {
+  it('builds one aggregate fetch query and one listen filter covering all variants', () => {
+    const {fetch, listen, keyToVariantId} = buildVariantsDocumentCountsQuery([
+      variantAlphaAudience._id,
+      variantNorwegianMarket._id,
+    ])
+
+    expect(fetch).toBe(
+      '{' +
+        '"v0": count(array::unique(*[sanity::partOfVariant("alpha-audience")]._system.group._ref)),' +
+        '"v1": count(array::unique(*[sanity::partOfVariant("norwegian-market")]._system.group._ref))' +
+        '}',
+    )
+    expect(listen).toBe(
+      '*[sanity::partOfVariant("alpha-audience") || sanity::partOfVariant("norwegian-market")]',
+    )
+    expect(keyToVariantId).toEqual({
+      v0: variantAlphaAudience._id,
+      v1: variantNorwegianMarket._id,
+    })
+  })
+})
+
+describe('getVariantsDocumentCounts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('emits empty data without fetching or listening when there are no variants', async () => {
+    const {client, fetch, listen} = createMockClient()
+
+    const value = await firstValueFrom(getVariantsDocumentCounts(client, []))
+
+    expect(value).toEqual({data: {}, loading: false, error: null})
+    expect(fetch).not.toHaveBeenCalled()
+    expect(listen).not.toHaveBeenCalled()
+  })
+
+  it('opens a single listener and maps the aggregate response to counts per variant id', async () => {
+    const {client, fetch, listen, listener$} = createMockClient()
+    fetch.mockReturnValue(of({v0: 2, v1: 0}))
+
+    const valuesPromise = firstValueFrom(
+      getVariantsDocumentCounts(client, [
+        variantAlphaAudience._id,
+        variantNorwegianMarket._id,
+      ]).pipe(take(2), toArray()),
+    )
+
+    listener$.next({type: 'welcome'})
+
+    const values = await valuesPromise
+
+    expect(listen).toHaveBeenCalledTimes(1)
+    expect(listen).toHaveBeenCalledWith(
+      '*[sanity::partOfVariant("alpha-audience") || sanity::partOfVariant("norwegian-market")]',
+      {},
+      expect.objectContaining({
+        events: ['welcome', 'mutation', 'reconnect'],
+        includeAllVersions: true,
+        includeResult: false,
+        visibility: 'query',
+        tag: 'variants-doc-counts.listen',
+      }),
+    )
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('count(array::unique('),
+      {},
+      expect.objectContaining({tag: 'variants-doc-counts.listen', perspective: 'raw'}),
+    )
+    expect(values[0]).toEqual({data: null, loading: true, error: null})
+    expect(values[1]).toEqual({
+      data: {
+        [variantAlphaAudience._id]: 2,
+        [variantNorwegianMarket._id]: 0,
+      },
+      loading: false,
+      error: null,
+    })
+  })
+
+  it('refetches counts when the listener emits a mutation', async () => {
+    vi.useFakeTimers()
+
+    const {client, fetch, listener$} = createMockClient()
+    fetch.mockReturnValueOnce(of({v0: 1})).mockReturnValueOnce(of({v0: 2}))
+
+    const valuesPromise = firstValueFrom(
+      getVariantsDocumentCounts(client, [variantAlphaAudience._id]).pipe(take(3), toArray()),
+    )
+
+    listener$.next({type: 'welcome'})
+    await vi.advanceTimersByTimeAsync(0)
+    listener$.next({type: 'mutation', transition: 'update', visibility: 'query'})
+    await vi.advanceTimersByTimeAsync(1000)
+
+    const values = await valuesPromise
+    vi.useRealTimers()
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(values.at(-1)).toEqual({
+      data: {[variantAlphaAudience._id]: 2},
+      loading: false,
+      error: null,
+    })
+  })
+
+  it('exposes fetch errors', async () => {
+    const {client, fetch, listener$} = createMockClient()
+    const error = new Error('Failed to fetch counts')
+    fetch.mockImplementation(() => {
+      throw error
+    })
+
+    const valuesPromise = firstValueFrom(
+      getVariantsDocumentCounts(client, [variantAlphaAudience._id]).pipe(take(2), toArray()),
+    )
+
+    listener$.next({type: 'welcome'})
+
+    const values = await valuesPromise
+
+    expect(values.at(-1)).toEqual({data: null, loading: false, error})
+  })
+})
+
+describe('useVariantsDocumentCounts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns live counts and stops loading after the first fetch', async () => {
+    const {client, fetch, listener$} = createMockClient()
+    useClientMock.mockReturnValue(client)
+    fetch.mockReturnValue(of({v0: 3}))
+
+    const wrapper = await createTestProvider()
+    const {result} = renderHook(() => useVariantsDocumentCounts([variantAlphaAudience._id]), {
+      wrapper,
+    })
+
+    expect(result.current).toEqual({data: null, loading: true, error: null})
+
+    listener$.next({type: 'welcome'})
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        data: {[variantAlphaAudience._id]: 3},
+        loading: false,
+        error: null,
+      })
+    })
+  })
+
+  it('returns empty data without a listener when there are no variants', async () => {
+    const {client, fetch, listen} = createMockClient()
+    useClientMock.mockReturnValue(client)
+
+    const wrapper = await createTestProvider()
+    const {result} = renderHook(() => useVariantsDocumentCounts([]), {wrapper})
+
+    expect(result.current).toEqual({data: {}, loading: false, error: null})
+    expect(fetch).not.toHaveBeenCalled()
+    expect(listen).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sanity/src/core/variants/hooks/useVariantsDocumentCounts.ts
+++ b/packages/sanity/src/core/variants/hooks/useVariantsDocumentCounts.ts
@@ -10,18 +10,18 @@ import {VARIANTS_STUDIO_CLIENT_OPTIONS} from '../store/constants'
 import {getVariantId} from '../tool/util'
 
 /**
- * The fetch and listen GROQ queries used to keep per-variant document counts fresh,
- * plus the mapping from projection keys back to variant definition document ids.
+ * The fetch and listen GROQ queries used to keep per-variant document counts fresh.
  *
  * @internal
  */
 export interface VariantsDocumentCountsQuery {
-  /** Aggregate object query returning one count per variant, keyed by `keyToVariantId` keys. */
+  /**
+   * Aggregate object query returning one count per variant, keyed by variant definition
+   * document id (`_.variants.*`).
+   */
   fetch: string
   /** Filter matching every document in any of the variants, used for the single listener. */
   listen: string
-  /** Maps projection keys (`v0`, `v1`, ...) back to variant definition document ids. */
-  keyToVariantId: Record<string, string>
 }
 
 /**
@@ -39,23 +39,21 @@ export interface VariantsDocumentCountsQuery {
 export function buildVariantsDocumentCountsQuery(
   variantDocumentIds: string[],
 ): VariantsDocumentCountsQuery {
-  const keyToVariantId: Record<string, string> = {}
   const projections: string[] = []
   const filters: string[] = []
 
-  variantDocumentIds.forEach((variantDocumentId, index) => {
-    const key = `v${index}`
+  for (const variantDocumentId of variantDocumentIds) {
     const membership = `sanity::partOfVariant(${JSON.stringify(getVariantId(variantDocumentId))})`
 
-    keyToVariantId[key] = variantDocumentId
-    projections.push(`"${key}": count(array::unique(*[${membership}]._system.group._ref))`)
+    projections.push(
+      `${JSON.stringify(variantDocumentId)}: count(array::unique(*[${membership}]._system.group._ref))`,
+    )
     filters.push(membership)
-  })
+  }
 
   return {
     fetch: `{${projections.join(',')}}`,
     listen: `*[${filters.join(' || ')}]`,
-    keyToVariantId,
   }
 }
 
@@ -91,7 +89,7 @@ export function getVariantsDocumentCounts(
     return of(EMPTY_STATE)
   }
 
-  const {fetch, listen, keyToVariantId} = buildVariantsDocumentCountsQuery(variantDocumentIds)
+  const {fetch, listen} = buildVariantsDocumentCountsQuery(variantDocumentIds)
 
   return listenQuery(
     client,
@@ -104,9 +102,9 @@ export function getVariantsDocumentCounts(
     map(
       (response: Record<string, number>): VariantsDocumentCountsState => ({
         data: Object.fromEntries(
-          Object.entries(keyToVariantId).map(([key, variantDocumentId]) => [
+          variantDocumentIds.map((variantDocumentId) => [
             variantDocumentId,
-            response?.[key] ?? 0,
+            response?.[variantDocumentId] ?? 0,
           ]),
         ),
         loading: false,

--- a/packages/sanity/src/core/variants/hooks/useVariantsDocumentCounts.ts
+++ b/packages/sanity/src/core/variants/hooks/useVariantsDocumentCounts.ts
@@ -2,11 +2,13 @@ import {type SanityClient} from '@sanity/client'
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
 import {type Observable, of} from 'rxjs'
-import {catchError, map, startWith} from 'rxjs/operators'
+import {catchError, distinctUntilChanged, map, scan, startWith, switchMap} from 'rxjs/operators'
 
 import {useClient} from '../../hooks'
 import {listenQuery} from '../../store'
 import {VARIANTS_STUDIO_CLIENT_OPTIONS} from '../store/constants'
+import {type VariantStoreState} from '../store/reducer'
+import {useVariantsStore} from '../store/useVariantsStore'
 import {getVariantId} from '../tool/util'
 
 /**
@@ -72,16 +74,11 @@ const INITIAL_STATE: VariantsDocumentCountsState = {data: null, loading: true, e
 const EMPTY_STATE: VariantsDocumentCountsState = {data: {}, loading: false, error: null}
 
 /**
- * Creates an observable that keeps a live count of the documents in each of the given
- * variants.
- *
- * Uses a single listener (one OR-chained `sanity::partOfVariant()` filter covering all
- * variants) that triggers a throttled refetch of one aggregate count query, via
- * {@link listenQuery}.
- *
- * @internal
+ * Fetches the document counts for one set of variants and keeps them fresh: a single listener
+ * (one OR-chained `sanity::partOfVariant()` filter covering all the variants) triggers a
+ * throttled refetch of one aggregate count query, via {@link listenQuery}.
  */
-export function getVariantsDocumentCounts(
+function listenVariantsDocumentCounts(
   client: SanityClient,
   variantDocumentIds: string[],
 ): Observable<VariantsDocumentCountsState> {
@@ -112,32 +109,59 @@ export function getVariantsDocumentCounts(
       }),
     ),
     startWith(INITIAL_STATE),
+    // catchError stays on this inner observable so the outer stream in
+    // `getVariantsDocumentCounts` keeps reacting to variant list changes after a failure.
     catchError((error) => of({data: null, loading: false, error})),
   )
 }
 
 /**
- * Keeps a live count of the documents in each of the given variants, using a single listener
- * and a single aggregate count query (see {@link getVariantsDocumentCounts}).
+ * Creates an observable that keeps a live count of the documents in each variant held by the
+ * variants store.
  *
- * When the set of variant ids changes, the previous listener is closed and a new one is
- * opened — there is never more than one active listener — and the counts reload.
+ * The variant ids are derived from the store's `state$`, so the returned observable never
+ * needs to be recreated: when the set of variants changes, the current listener is closed
+ * and a new fetch + listener is started inside the same stream (`switchMap`) — there is
+ * never more than one active listener. Previously fetched counts are carried across the
+ * switch (`scan`), so existing rows don't flash back to a loading state.
  *
  * @internal
  */
-export function useVariantsDocumentCounts(
-  variantDocumentIds: string[],
-): VariantsDocumentCountsState {
-  const client = useClient(VARIANTS_STUDIO_CLIENT_OPTIONS)
-
-  // Document ids cannot contain commas, so a sorted joined string is a stable identity key
-  // that ignores array identity and ordering.
-  const idsKey = useMemo(() => variantDocumentIds.toSorted().join(','), [variantDocumentIds])
-
-  const observable = useMemo(
-    () => getVariantsDocumentCounts(client, idsKey ? idsKey.split(',') : []),
-    [client, idsKey],
+export function getVariantsDocumentCounts(
+  client: SanityClient,
+  variantsState$: Observable<VariantStoreState>,
+): Observable<VariantsDocumentCountsState> {
+  return variantsState$.pipe(
+    // Document ids cannot contain commas, so a sorted joined string is a stable identity
+    // key that lets `distinctUntilChanged` ignore store emissions (e.g. variant metadata
+    // edits) that don't change the set of variants.
+    map((state) => Array.from(state.variants.keys()).toSorted().join(',')),
+    distinctUntilChanged(),
+    switchMap((idsKey) => listenVariantsDocumentCounts(client, idsKey ? idsKey.split(',') : [])),
+    scan(
+      (previous, next): VariantsDocumentCountsState => ({
+        // Keep the previous counts while the next fetch is loading (or errored), so counts
+        // for unchanged variants remain visible across variant list changes.
+        data: next.data ? {...previous.data, ...next.data} : previous.data,
+        loading: next.loading && previous.data === null,
+        error: next.error,
+      }),
+      INITIAL_STATE,
+    ),
   )
+}
+
+/**
+ * Keeps a live count of the documents in each variant, using a single listener and a single
+ * aggregate count query (see {@link getVariantsDocumentCounts}).
+ *
+ * @internal
+ */
+export function useVariantsDocumentCounts(): VariantsDocumentCountsState {
+  const client = useClient(VARIANTS_STUDIO_CLIENT_OPTIONS)
+  const {state$} = useVariantsStore()
+
+  const observable = useMemo(() => getVariantsDocumentCounts(client, state$), [client, state$])
 
   return useObservable(observable, INITIAL_STATE)
 }

--- a/packages/sanity/src/core/variants/hooks/useVariantsDocumentCounts.ts
+++ b/packages/sanity/src/core/variants/hooks/useVariantsDocumentCounts.ts
@@ -142,7 +142,7 @@ export function getVariantsDocumentCounts(
       (previous, next): VariantsDocumentCountsState => ({
         // Keep the previous counts while the next fetch is loading (or errored), so counts
         // for unchanged variants remain visible across variant list changes.
-        data: next.data ? {...previous.data, ...next.data} : previous.data,
+        data: next.data ? {...(previous.data ?? {}), ...next.data} : previous.data,
         loading: next.loading && previous.data === null,
         error: next.error,
       }),

--- a/packages/sanity/src/core/variants/hooks/useVariantsDocumentCounts.ts
+++ b/packages/sanity/src/core/variants/hooks/useVariantsDocumentCounts.ts
@@ -1,5 +1,5 @@
 import {type SanityClient} from '@sanity/client'
-import {useEffect, useMemo, useState} from 'react'
+import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
 import {type Observable, of} from 'rxjs'
 import {catchError, map, startWith} from 'rxjs/operators'
@@ -121,9 +121,7 @@ export function getVariantsDocumentCounts(
  * and a single aggregate count query (see {@link getVariantsDocumentCounts}).
  *
  * When the set of variant ids changes, the previous listener is closed and a new one is
- * opened — there is never more than one active listener. Previously fetched counts are
- * retained while the queries are rebuilt, so existing rows don't flash back to a loading
- * state when a variant is added or removed.
+ * opened — there is never more than one active listener — and the counts reload.
  *
  * @internal
  */
@@ -141,28 +139,5 @@ export function useVariantsDocumentCounts(
     [client, idsKey],
   )
 
-  const state = useObservable(observable, INITIAL_STATE)
-
-  // Patch counts into local state so previously fetched counts survive query rebuilds
-  // (same approach as `ReleasesMetadataProvider`).
-  const [mergedData, setMergedData] = useState<Record<string, number> | null>(null)
-
-  useEffect(
-    () =>
-      // oxlint-disable-next-line react/react-compiler
-      setMergedData((previous) => {
-        if (!state.data) return previous
-        return {...previous, ...state.data}
-      }),
-    [state.data],
-  )
-
-  return useMemo(
-    () => ({
-      data: mergedData,
-      loading: state.loading && mergedData === null,
-      error: state.error,
-    }),
-    [mergedData, state.loading, state.error],
-  )
+  return useObservable(observable, INITIAL_STATE)
 }

--- a/packages/sanity/src/core/variants/hooks/useVariantsDocumentCounts.ts
+++ b/packages/sanity/src/core/variants/hooks/useVariantsDocumentCounts.ts
@@ -1,0 +1,170 @@
+import {type SanityClient} from '@sanity/client'
+import {useEffect, useMemo, useState} from 'react'
+import {useObservable} from 'react-rx'
+import {type Observable, of} from 'rxjs'
+import {catchError, map, startWith} from 'rxjs/operators'
+
+import {useClient} from '../../hooks'
+import {listenQuery} from '../../store'
+import {VARIANTS_STUDIO_CLIENT_OPTIONS} from '../store/constants'
+import {getVariantId} from '../tool/util'
+
+/**
+ * The fetch and listen GROQ queries used to keep per-variant document counts fresh,
+ * plus the mapping from projection keys back to variant definition document ids.
+ *
+ * @internal
+ */
+export interface VariantsDocumentCountsQuery {
+  /** Aggregate object query returning one count per variant, keyed by `keyToVariantId` keys. */
+  fetch: string
+  /** Filter matching every document in any of the variants, used for the single listener. */
+  listen: string
+  /** Maps projection keys (`v0`, `v1`, ...) back to variant definition document ids. */
+  keyToVariantId: Record<string, string>
+}
+
+/**
+ * Builds a single aggregate fetch query that counts the documents in each variant, and a
+ * single listen filter covering all of them.
+ *
+ * Documents are counted per document group (`_system.group._ref`), so the count matches the
+ * number of rows in the variant detail table, where versions of the same document are grouped.
+ *
+ * `sanity::partOfVariant()` matches on the short variant id (the `_.variants.` path prefix is
+ * stripped via {@link getVariantId}).
+ *
+ * @internal
+ */
+export function buildVariantsDocumentCountsQuery(
+  variantDocumentIds: string[],
+): VariantsDocumentCountsQuery {
+  const keyToVariantId: Record<string, string> = {}
+  const projections: string[] = []
+  const filters: string[] = []
+
+  variantDocumentIds.forEach((variantDocumentId, index) => {
+    const key = `v${index}`
+    const membership = `sanity::partOfVariant(${JSON.stringify(getVariantId(variantDocumentId))})`
+
+    keyToVariantId[key] = variantDocumentId
+    projections.push(`"${key}": count(array::unique(*[${membership}]._system.group._ref))`)
+    filters.push(membership)
+  })
+
+  return {
+    fetch: `{${projections.join(',')}}`,
+    listen: `*[${filters.join(' || ')}]`,
+    keyToVariantId,
+  }
+}
+
+/** @internal */
+export interface VariantsDocumentCountsState {
+  /**
+   * Document counts keyed by variant definition document id (`_.variants.*`), or `null` before
+   * the first fetch has completed (or after an error).
+   */
+  data: Record<string, number> | null
+  loading: boolean
+  error: Error | null
+}
+
+const INITIAL_STATE: VariantsDocumentCountsState = {data: null, loading: true, error: null}
+const EMPTY_STATE: VariantsDocumentCountsState = {data: {}, loading: false, error: null}
+
+/**
+ * Creates an observable that keeps a live count of the documents in each of the given
+ * variants.
+ *
+ * Uses a single listener (one OR-chained `sanity::partOfVariant()` filter covering all
+ * variants) that triggers a throttled refetch of one aggregate count query, via
+ * {@link listenQuery}.
+ *
+ * @internal
+ */
+export function getVariantsDocumentCounts(
+  client: SanityClient,
+  variantDocumentIds: string[],
+): Observable<VariantsDocumentCountsState> {
+  if (variantDocumentIds.length === 0) {
+    return of(EMPTY_STATE)
+  }
+
+  const {fetch, listen, keyToVariantId} = buildVariantsDocumentCountsQuery(variantDocumentIds)
+
+  return listenQuery(
+    client,
+    {fetch, listen},
+    {},
+    // Variant-scoped documents are version documents, which are only visible to queries
+    // using the raw perspective.
+    {tag: 'variants-doc-counts.listen', perspective: 'raw'},
+  ).pipe(
+    map(
+      (response: Record<string, number>): VariantsDocumentCountsState => ({
+        data: Object.fromEntries(
+          Object.entries(keyToVariantId).map(([key, variantDocumentId]) => [
+            variantDocumentId,
+            response?.[key] ?? 0,
+          ]),
+        ),
+        loading: false,
+        error: null,
+      }),
+    ),
+    startWith(INITIAL_STATE),
+    catchError((error) => of({data: null, loading: false, error})),
+  )
+}
+
+/**
+ * Keeps a live count of the documents in each of the given variants, using a single listener
+ * and a single aggregate count query (see {@link getVariantsDocumentCounts}).
+ *
+ * When the set of variant ids changes, the previous listener is closed and a new one is
+ * opened — there is never more than one active listener. Previously fetched counts are
+ * retained while the queries are rebuilt, so existing rows don't flash back to a loading
+ * state when a variant is added or removed.
+ *
+ * @internal
+ */
+export function useVariantsDocumentCounts(
+  variantDocumentIds: string[],
+): VariantsDocumentCountsState {
+  const client = useClient(VARIANTS_STUDIO_CLIENT_OPTIONS)
+
+  // Document ids cannot contain commas, so a sorted joined string is a stable identity key
+  // that ignores array identity and ordering.
+  const idsKey = useMemo(() => variantDocumentIds.toSorted().join(','), [variantDocumentIds])
+
+  const observable = useMemo(
+    () => getVariantsDocumentCounts(client, idsKey ? idsKey.split(',') : []),
+    [client, idsKey],
+  )
+
+  const state = useObservable(observable, INITIAL_STATE)
+
+  // Patch counts into local state so previously fetched counts survive query rebuilds
+  // (same approach as `ReleasesMetadataProvider`).
+  const [mergedData, setMergedData] = useState<Record<string, number> | null>(null)
+
+  useEffect(
+    () =>
+      // oxlint-disable-next-line react/react-compiler
+      setMergedData((previous) => {
+        if (!state.data) return previous
+        return {...previous, ...state.data}
+      }),
+    [state.data],
+  )
+
+  return useMemo(
+    () => ({
+      data: mergedData,
+      loading: state.loading && mergedData === null,
+      error: state.error,
+    }),
+    [mergedData, state.loading, state.error],
+  )
+}

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -30,6 +30,12 @@ const variantOperationsMock = vi.hoisted(() => ({
   deleteVariant: vi.fn(),
 }))
 
+const documentCountsMock = vi.hoisted(() => ({
+  data: null as Record<string, number> | null,
+  loading: true,
+  error: null as Error | null,
+}))
+
 vi.mock('sanity/router', async (importOriginal) => ({
   ...(await importOriginal()),
   useRouter: vi.fn(() => ({
@@ -72,6 +78,14 @@ vi.mock('../../store/useVariantOperations', () => ({
   useVariantOperations: vi.fn(() => variantOperationsMock),
 }))
 
+vi.mock('../../hooks/useVariantsDocumentCounts', () => ({
+  useVariantsDocumentCounts: vi.fn(() => ({
+    data: documentCountsMock.data,
+    loading: documentCountsMock.loading,
+    error: documentCountsMock.error,
+  })),
+}))
+
 setupVirtualListEnv()
 
 describe('VariantsOverview', () => {
@@ -81,6 +95,9 @@ describe('VariantsOverview', () => {
     variantsMock.loading = false
     variantsMock.error = undefined
     routerState.variantId = undefined
+    documentCountsMock.data = null
+    documentCountsMock.loading = true
+    documentCountsMock.error = null
     mockNavigate.mockClear()
     variantOperationsMock.createVariant.mockReset()
     variantOperationsMock.deleteVariant.mockReset()
@@ -139,6 +156,45 @@ describe('VariantsOverview', () => {
 
     expect(screen.getByText('Alpha audience')).toBeInTheDocument()
     expect(screen.getByText('Norwegian market')).toBeInTheDocument()
+  })
+
+  it('renders live document counts for each variant', async () => {
+    setVariants([variantAlphaAudience, variantNorwegianMarket])
+    documentCountsMock.data = {
+      [variantAlphaAudience._id]: 2,
+      [variantNorwegianMarket._id]: 0,
+    }
+    documentCountsMock.loading = false
+
+    await renderOverview()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(2)
+    })
+
+    const rows = screen.getAllByTestId('table-row')
+    const alphaRow = rows.find((row) => within(row).queryByText('Alpha audience'))
+    const norwegianRow = rows.find((row) => within(row).queryByText('Norwegian market'))
+
+    expect(alphaRow).toBeDefined()
+    expect(norwegianRow).toBeDefined()
+    expect(within(alphaRow!).getByText('2')).toBeInTheDocument()
+    expect(within(norwegianRow!).getByText('0')).toBeInTheDocument()
+  })
+
+  it('renders a fallback in the documents column when counts fail to load', async () => {
+    setVariants([variantAlphaAudience])
+    documentCountsMock.data = null
+    documentCountsMock.loading = false
+    documentCountsMock.error = new Error('network')
+
+    await renderOverview()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(1)
+    })
+
+    expect(within(screen.getAllByTestId('table-row')[0]!).getByText('-')).toBeInTheDocument()
   })
 
   it('filters variants when searching by title or condition', async () => {

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
@@ -8,13 +8,14 @@ import {Button} from '../../../../ui-components/button/Button'
 import {useTranslation} from '../../../i18n'
 import {Table, type TableProps} from '../../../releases/tool/components/Table/Table'
 import {CreateVariantDialog} from '../../components/dialog/CreateVariantDialog'
+import {useVariantsDocumentCounts} from '../../hooks/useVariantsDocumentCounts'
 import {variantsLocaleNamespace} from '../../i18n'
 import {useAllVariants} from '../../store/useAllVariants'
 import {type SystemVariant} from '../../types'
 import {filterVariantsForSearch, getVariantId} from '../util'
 import {VariantMenuButton} from './VariantMenuButton'
 import {VariantsEmptyState} from './VariantsEmptyState'
-import {variantsOverviewColumnDefs} from './VariantsOverviewColumnDefs'
+import {type TableVariant, variantsOverviewColumnDefs} from './VariantsOverviewColumnDefs'
 
 const VARIANT_TABLE_ROW_ID = '_id'
 
@@ -40,14 +41,23 @@ export function VariantsOverview() {
 
   const columnDefs = useMemo(() => variantsOverviewColumnDefs(t), [t])
   const renderRowActions = useCallback<
-    NonNullable<TableProps<SystemVariant, undefined>['rowActions']>
+    NonNullable<TableProps<TableVariant, undefined>['rowActions']>
   >(({datum}) => <VariantMenuButton variant={datum as SystemVariant} />, [])
 
   const variantsList = useMemo(() => variants ?? [], [variants])
 
+  const variantIds = useMemo(() => variantsList.map((variant) => variant._id), [variantsList])
+  const {data: documentCounts, error: documentCountsError} = useVariantsDocumentCounts(variantIds)
+
   const filteredVariants = useMemo(
-    () => filterVariantsForSearch(variantsList, searchQuery),
-    [variantsList, searchQuery],
+    () =>
+      filterVariantsForSearch(variantsList, searchQuery).map(
+        (variant): TableVariant => ({
+          ...variant,
+          documentCount: documentCounts?.[variant._id] ?? (documentCountsError ? null : undefined),
+        }),
+      ),
+    [variantsList, searchQuery, documentCounts, documentCountsError],
   )
 
   const hasVariants = variantsList.length > 0
@@ -120,7 +130,7 @@ export function VariantsOverview() {
 
       {/* Full-width scroll region so table borders span the tool pane (same pattern as release detail summary). */}
       <Box flex={1} overflow="auto" ref={setScrollContainerRef}>
-        <Table<SystemVariant>
+        <Table<TableVariant>
           columnDefs={columnDefs}
           data={filteredVariants}
           emptyState={tableEmptyState}

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
@@ -46,8 +46,7 @@ export function VariantsOverview() {
 
   const variantsList = useMemo(() => variants ?? [], [variants])
 
-  const variantIds = useMemo(() => variantsList.map((variant) => variant._id), [variantsList])
-  const {data: documentCounts, error: documentCountsError} = useVariantsDocumentCounts(variantIds)
+  const {data: documentCounts, error: documentCountsError} = useVariantsDocumentCounts()
 
   const filteredVariants = useMemo(
     () =>

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
@@ -9,8 +9,20 @@ import {variantsLocaleNamespace} from '../../i18n'
 import {type SystemVariant} from '../../types'
 import {getVariantId, getVariantConditionsText, getVariantTitle} from '../util'
 
-const VariantDocumentsCell: VisibleColumn<SystemVariant>['cell'] = ({cellProps, datum}) => {
-  if (datum.isLoading) {
+/**
+ * A variant row in the overview table, with its live document count attached.
+ *
+ * `documentCount` is `undefined` while the count is being fetched and `null` when it could
+ * not be fetched.
+ *
+ * @internal
+ */
+export interface TableVariant extends SystemVariant {
+  documentCount?: number | null
+}
+
+const VariantDocumentsCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, datum}) => {
+  if (datum.isLoading || datum.documentCount === undefined) {
     return (
       <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border">
         <Text size={1}>
@@ -23,13 +35,13 @@ const VariantDocumentsCell: VisibleColumn<SystemVariant>['cell'] = ({cellProps, 
   return (
     <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border">
       <Text muted size={1}>
-        0
+        {datum.documentCount === null ? '-' : datum.documentCount}
       </Text>
     </Flex>
   )
 }
 
-const VariantTitleCell: VisibleColumn<SystemVariant>['cell'] = ({cellProps, datum: variant}) => {
+const VariantTitleCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, datum: variant}) => {
   const {t} = useTranslation(variantsLocaleNamespace)
 
   const encodedVariantId = getVariantId(variant._id)
@@ -82,7 +94,7 @@ const VariantTitleCell: VisibleColumn<SystemVariant>['cell'] = ({cellProps, datu
 
 export function variantsOverviewColumnDefs(
   t: UseTranslationResponse<'variants', undefined>['t'],
-): Column<SystemVariant>[] {
+): Column<TableVariant>[] {
   return [
     {
       id: 'metadata.title',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The Documents column in the variants overview was a hardcoded `0` placeholder. This wires it to real data and keeps it live: one aggregate GROQ query counts the documents in every variant at once, and a single listener (one OR-chained `sanity::partOfVariant()` filter covering all variants) triggers throttled refetches via the existing `listenQuery` helper — the same pattern used by the releases metadata aggregator, but with only one listener and one fetch for the whole table.

Counts are per document group (`count(array::unique(...[]._system.group._ref))`), so the overview number matches the row count of the variant detail table, which groups versions by `_system.group._ref`. Counting raw version documents was rejected because a variant with draft + published versions of one document would show 2 in the overview but 1 row in the detail view.

The fetch uses `perspective: 'raw'` because variant-scoped version documents are not visible to queries under other perspectives (verified against the `ppsg7ml5`/`test` dataset on API version `X`).

### What to review

- `packages/sanity/src/core/variants/hooks/useVariantsDocumentCounts.ts` — query builder, observable, and hook. The observable is driven by the variants store's `state$`: when the variant set changes, the current listener is closed and a new fetch + listener starts inside the same stream (`switchMap`), so there is never more than one active listener; `scan` carries previously fetched counts across the switch so existing rows don't flash back to skeletons. `distinctUntilChanged` on the sorted id set keeps unrelated store emissions (e.g. variant metadata edits) from tearing down the listener.
- `VariantsOverview.tsx` / `VariantsOverviewColumnDefs.tsx` — counts merged into table rows as `TableVariant.documentCount`; `undefined` renders a skeleton, `null` (fetch error) renders `-`.
- Only the `sanity` package is affected; the feature is gated behind `beta.variants.enabled`.

### Testing

- Unit tests for the query builder, the observable (single listener with combined filter, mutation-driven refetch, listener switch on variant set changes with count retention, error surfacing with outer-stream survival), and the hook, plus overview tests for rendered counts and the error fallback.
- Manually verified in the test studio against project `ppsg7ml5`: counts match ground-truth GROQ queries, update live (without reload) when documents are added to a variant, and creating/deleting a variant keeps existing counts visible while the listener switches.

### Notes for release

N/A – Part of the variants beta feature, not enabled by default.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f31b470-5def-46e1-8563-b44e74bd9a66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f31b470-5def-46e1-8563-b44e74bd9a66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

