### PR TITLE
feat(perspective): support setting variant and perspective atomically

### DIFF
--- a/packages/sanity/src/core/perspective/__tests__/useSetPerspective.test.ts
+++ b/packages/sanity/src/core/perspective/__tests__/useSetPerspective.test.ts
@@ -1,0 +1,62 @@
+import {renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getPerspectiveParam, useSetPerspective} from '../useSetPerspective'
+
+const mockNavigate = vi.fn()
+
+vi.mock('sanity/router', () => ({
+  useRouter: vi.fn(() => ({navigate: mockNavigate})),
+}))
+
+vi.mock('../useGetDefaultPerspective', () => ({
+  useGetDefaultPerspective: vi.fn(() => 'drafts'),
+}))
+
+describe('getPerspectiveParam', () => {
+  it('returns an empty string when no perspective is provided', () => {
+    expect(getPerspectiveParam(undefined, 'drafts')).toBe('')
+  })
+
+  it('returns an empty string when the perspective equals the default perspective', () => {
+    expect(getPerspectiveParam('drafts', 'drafts')).toBe('')
+    expect(getPerspectiveParam('published', 'published')).toBe('')
+  })
+
+  it('returns the perspective when it differs from the default perspective', () => {
+    expect(getPerspectiveParam('published', 'drafts')).toBe('published')
+    expect(getPerspectiveParam('rSomeRelease', 'drafts')).toBe('rSomeRelease')
+  })
+})
+
+describe('useSetPerspective', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear()
+  })
+
+  it('clears the perspective param when setting the default perspective', () => {
+    const {result} = renderHook(() => useSetPerspective())
+
+    result.current('drafts')
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      stickyParams: {
+        excludedPerspectives: null,
+        perspective: '',
+      },
+    })
+  })
+
+  it('sets the perspective param for non-default perspectives', () => {
+    const {result} = renderHook(() => useSetPerspective())
+
+    result.current('rSomeRelease')
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      stickyParams: {
+        excludedPerspectives: null,
+        perspective: 'rSomeRelease',
+      },
+    })
+  })
+})

--- a/packages/sanity/src/core/perspective/__tests__/useSetVariant.test.ts
+++ b/packages/sanity/src/core/perspective/__tests__/useSetVariant.test.ts
@@ -1,0 +1,85 @@
+import {renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {variantAlphaAudience} from '../../variants/__fixtures__/variants.fixture'
+import {useSetVariant} from '../useSetVariant'
+
+const mockNavigate = vi.fn()
+
+vi.mock('sanity/router', () => ({
+  useRouter: vi.fn(() => ({navigate: mockNavigate})),
+}))
+
+vi.mock('../useGetDefaultPerspective', () => ({
+  useGetDefaultPerspective: vi.fn(() => 'drafts'),
+}))
+
+describe('useSetVariant', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear()
+  })
+
+  it('sets the variant sticky param without touching the perspective', () => {
+    const {result} = renderHook(() => useSetVariant())
+
+    result.current(variantAlphaAudience)
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      stickyParams: {
+        variant: 'alpha-audience',
+      },
+    })
+  })
+
+  it('clears the variant sticky param when no variant is provided', () => {
+    const {result} = renderHook(() => useSetVariant())
+
+    result.current(undefined)
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      stickyParams: {
+        variant: null,
+      },
+    })
+  })
+
+  it('sets the variant and perspective sticky params in a single navigation', () => {
+    const {result} = renderHook(() => useSetVariant())
+
+    result.current(variantAlphaAudience, {perspective: 'published'})
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).toHaveBeenCalledWith({
+      stickyParams: {
+        variant: 'alpha-audience',
+        perspective: 'published',
+      },
+    })
+  })
+
+  it('clears the perspective sticky param when the perspective is the default perspective', () => {
+    const {result} = renderHook(() => useSetVariant())
+
+    result.current(variantAlphaAudience, {perspective: 'drafts'})
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      stickyParams: {
+        variant: 'alpha-audience',
+        perspective: '',
+      },
+    })
+  })
+
+  it('sets a release id as the perspective sticky param', () => {
+    const {result} = renderHook(() => useSetVariant())
+
+    result.current(variantAlphaAudience, {perspective: 'rSomeRelease'})
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      stickyParams: {
+        variant: 'alpha-audience',
+        perspective: 'rSomeRelease',
+      },
+    })
+  })
+})

--- a/packages/sanity/src/core/perspective/__tests__/useSetVariant.test.ts
+++ b/packages/sanity/src/core/perspective/__tests__/useSetVariant.test.ts
@@ -52,6 +52,7 @@ describe('useSetVariant', () => {
     expect(mockNavigate).toHaveBeenCalledWith({
       stickyParams: {
         variant: 'alpha-audience',
+        excludedPerspectives: null,
         perspective: 'published',
       },
     })
@@ -65,6 +66,7 @@ describe('useSetVariant', () => {
     expect(mockNavigate).toHaveBeenCalledWith({
       stickyParams: {
         variant: 'alpha-audience',
+        excludedPerspectives: null,
         perspective: '',
       },
     })
@@ -78,6 +80,7 @@ describe('useSetVariant', () => {
     expect(mockNavigate).toHaveBeenCalledWith({
       stickyParams: {
         variant: 'alpha-audience',
+        excludedPerspectives: null,
         perspective: 'rSomeRelease',
       },
     })

--- a/packages/sanity/src/core/perspective/useSetPerspective.tsx
+++ b/packages/sanity/src/core/perspective/useSetPerspective.tsx
@@ -1,8 +1,24 @@
 import {useCallback} from 'react'
 import {useRouter} from 'sanity/router'
 
+import {type SystemBundle} from '../util/draftUtils'
 import {type ReleaseId} from './types'
 import {useGetDefaultPerspective} from './useGetDefaultPerspective'
+
+/**
+ * Resolves the value of the `perspective` sticky param for a given perspective. Default states
+ * (no perspective, or the default perspective) resolve to an empty string so the param is removed.
+ *
+ * @internal
+ */
+export function getPerspectiveParam(
+  perspective: SystemBundle | ReleaseId | undefined,
+  defaultPerspective: SystemBundle,
+) {
+  if (!perspective) return ''
+  if (perspective === defaultPerspective) return ''
+  return perspective
+}
 
 /**
  * @internal
@@ -13,9 +29,8 @@ export function useSetPerspective() {
   const defaultPerspective = useGetDefaultPerspective()
 
   const setPerspective = useCallback(
-    (releaseId: 'published' | 'drafts' | ReleaseId | undefined) => {
-      // Remove perspective parameter for default states, otherwise use the specific release ID
-      const newPerspective = !releaseId || releaseId === defaultPerspective ? '' : releaseId
+    (releaseId: SystemBundle | ReleaseId | undefined) => {
+      const newPerspective = getPerspectiveParam(releaseId, defaultPerspective)
 
       router.navigate({
         stickyParams: {

--- a/packages/sanity/src/core/perspective/useSetVariant.tsx
+++ b/packages/sanity/src/core/perspective/useSetVariant.tsx
@@ -1,27 +1,38 @@
 import {useCallback} from 'react'
 import {useRouter} from 'sanity/router'
 
+import {type SystemBundle} from '../util/draftUtils'
 import {getVariantId} from '../variants/tool/util'
 import {type SystemVariant} from '../variants/types'
+import {type ReleaseId} from './types'
+import {useGetDefaultPerspective} from './useGetDefaultPerspective'
+import {getPerspectiveParam} from './useSetPerspective'
 
 /**
  * React hook to set the variant in the router.
+ * Optionally sets the perspective in the same navigation, so both sticky params
+ * are updated atomically (a single history entry, no intermediate render).
  * Do not use in production, this can change in any release.
  * @internal
  * @beta
  */
 export function useSetVariant() {
   const router = useRouter()
-
+  const defaultPerspective = useGetDefaultPerspective()
   const setVariant = useCallback(
-    (variant: SystemVariant | undefined) => {
+    (variant: SystemVariant | undefined, options?: {perspective?: SystemBundle | ReleaseId}) => {
+      const {perspective} = options ?? {}
+
       router.navigate({
         stickyParams: {
           variant: variant ? getVariantId(variant._id) : null,
+          ...(perspective
+            ? {perspective: getPerspectiveParam(perspective, defaultPerspective)}
+            : {}),
         },
       })
     },
-    [router],
+    [router, defaultPerspective],
   )
   return setVariant
 }

--- a/packages/sanity/src/core/perspective/useSetVariant.tsx
+++ b/packages/sanity/src/core/perspective/useSetVariant.tsx
@@ -27,7 +27,10 @@ export function useSetVariant() {
         stickyParams: {
           variant: variant ? getVariantId(variant._id) : null,
           ...(perspective
-            ? {perspective: getPerspectiveParam(perspective, defaultPerspective)}
+            ? {
+                excludedPerspectives: null,
+                perspective: getPerspectiveParam(perspective, defaultPerspective),
+              }
             : {}),
         },
       })

--- a/packages/sanity/src/structure/hooks/useDocumentPerspectiveList.ts
+++ b/packages/sanity/src/structure/hooks/useDocumentPerspectiveList.ts
@@ -260,7 +260,11 @@ export function useDocumentPerspectiveList(): DocumentPerspectiveList {
     (version: VersionInfoDocumentStub) => {
       const variantId = version._system.variant?._ref
       const variant = variantId ? variants.get(variantId) : undefined
-      setVariant(variant ?? undefined)
+      // Published version documents omit `bundleId`, so treat a missing bundle as published.
+      // Passing the perspective alongside the variant updates both sticky params atomically.
+      const versionBundle = version._system.bundleId
+      const perspective = !versionBundle ? 'published' : versionBundle
+      setVariant(variant ?? undefined, {perspective})
     },
     [setVariant, variants],
   )

--- a/packages/sanity/src/structure/hooks/useDocumentPerspectiveList.ts
+++ b/packages/sanity/src/structure/hooks/useDocumentPerspectiveList.ts
@@ -21,6 +21,7 @@ import {
   useAllVariants,
   type VersionInfoDocumentStub,
   useSetVariant,
+  getTargetDocument,
 } from 'sanity'
 
 import {isLiveEditEnabled} from '../components/paneItem/helpers'
@@ -58,6 +59,8 @@ interface DocumentPerspectiveList {
   variantVersions: VersionInfoDocumentStub[]
   /** Handles the selection of a variant. */
   handleVariantSelectionChange: (version: VersionInfoDocumentStub) => void
+  /** Display props for the currently selected variant in the active bundle, if any. */
+  selectedVariantDisplay: {displayName: string; tone: BadgeTone} | null
 }
 
 /**
@@ -71,7 +74,7 @@ interface DocumentPerspectiveList {
  * @internal
  */
 export function useDocumentPerspectiveList(): DocumentPerspectiveList {
-  const {selectedReleaseId, selectedPerspectiveName} = usePerspective()
+  const {selectedReleaseId, selectedPerspectiveName, selectedVariant, bundle} = usePerspective()
   const setPerspective = useSetPerspective()
   const {params} = usePaneRouter()
   const schema = useSchema()
@@ -232,7 +235,7 @@ export function useDocumentPerspectiveList(): DocumentPerspectiveList {
       const variantTitle = variant ? getVariantTitle(variant) : (variantId ?? '')
       return {
         displayName: `${variantTitle} [${version._system.bundleId || 'published'}]`,
-        tone: 'caution' as const,
+        tone: version._system.bundleId ? ('caution' as const) : ('positive' as const),
       }
     },
     [getAgentVersionDisplay, variants],
@@ -269,6 +272,24 @@ export function useDocumentPerspectiveList(): DocumentPerspectiveList {
     [setVariant, variants],
   )
 
+  // Temporarily display the selected variant in the header; this will be replaced by the inventory.
+  const selectedVariantDisplay = useMemo(() => {
+    if (!selectedVariant) {
+      return null
+    }
+
+    const targetVariantDocument = getTargetDocument({
+      bundle,
+      variant: selectedVariant._id,
+      documentVersions,
+    })
+
+    if (targetVariantDocument) {
+      return getVersionDisplay(targetVariantDocument)
+    }
+    return null
+  }, [selectedVariant, bundle, documentVersions, getVersionDisplay])
+
   return {
     filteredReleases,
     getVersionDisplay,
@@ -284,5 +305,6 @@ export function useDocumentPerspectiveList(): DocumentPerspectiveList {
     nonReleaseVersions,
     variantVersions,
     handleVariantSelectionChange,
+    selectedVariantDisplay,
   }
 }

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -1,6 +1,7 @@
 import {Stack, Text} from '@sanity/ui'
 import {memo} from 'react'
 import {
+  Chip,
   getReleaseIdFromReleaseDocumentId,
   getReleaseTone,
   isGoingToUnpublish,
@@ -95,6 +96,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
     isPublishedChipDisabled,
     isPublishSelected,
     nonReleaseVersions,
+    selectedVariantDisplay,
   } = useDocumentPerspectiveList()
 
   return (
@@ -274,6 +276,14 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
         getVersionDisplay={getVersionDisplay}
         mode="versions"
       />
+      {selectedVariantDisplay ? (
+        <Chip
+          selected
+          tone={selectedVariantDisplay.tone}
+          mode="bleed"
+          text={selectedVariantDisplay.displayName}
+        />
+      ) : null}
       {variantVersions.length > 0 ? (
         <NonReleaseVersionsSelect
           nonReleaseVersions={variantVersions}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Extracted from #13156 so the sticky-param plumbing can land ahead of the variant-editing work. Selecting a variant version that lives in a different bundle than the current perspective previously required two separate `router.navigate` calls (one for `variant`, one for `perspective`), producing two history entries and an intermediate render with a mismatched variant/perspective pair.

`useSetVariant` now accepts an optional `{perspective}` so both sticky params are updated in a single navigation. The perspective-param normalization in `useSetPerspective` is extracted into `getPerspectiveParam` so both hooks share it, and `useDocumentPerspectiveList` derives the perspective from the selected variant version's `_system.bundleId` (missing bundle = published) when handling variant selection.

`useDocumentPerspectiveList` also exposes `selectedVariantDisplay` — display props for the active variant version in the current bundle (via `getTargetDocument`) — and uses a positive tone for published-bundle variant versions instead of always caution. `DocumentPerspectiveList` renders that as a selected bleed chip in the document header.

### What to review

- `packages/sanity/src/core/perspective/useSetPerspective.tsx` — `getPerspectiveParam` extraction; the `SystemBundle` type change to the callback signature is equivalent to the previous `'published' | 'drafts'` literals
- `packages/sanity/src/core/perspective/useSetVariant.tsx` — atomic sticky-param update; the second argument is optional so existing callers are unaffected
- `packages/sanity/src/structure/hooks/useDocumentPerspectiveList.ts` — `handleVariantSelectionChange` switches perspective to the selected version's bundle; `selectedVariantDisplay` and variant chip tone
- `packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx` — selected variant chip in the header

Affects the `sanity` package only.

### Testing

- Added unit tests for `getPerspectiveParam` / `useSetPerspective` and for `useSetVariant` (with and without the `perspective` option, default-perspective clearing, release ids)
- `pnpm build`, `pnpm check:types`, `pnpm lint:fix` and the perspective/structure-hooks/releases-hooks/`DocumentPerspectiveList` test suites all pass

### Notes for release

N/A – Part of feature variants (requires `beta.variants.enabled`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d69ea04d-42a4-46b8-95f1-1f87dcdf40d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d69ea04d-42a4-46b8-95f1-1f87dcdf40d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

