### PR TITLE
fix(sanity): base reload prompt on served package version, drop range heuristic

### DIFF
--- a/packages/sanity/src/_singletons/context/PackageVersionInfoContext.tsx
+++ b/packages/sanity/src/_singletons/context/PackageVersionInfoContext.tsx
@@ -25,9 +25,7 @@ export type PackageVersionInfoContextValue = {
    * If an importmap for the sanity module exists in the DOM, includes details
    * will be undefined if no importmap is found
    */
-  importMapInfo?:
-    | {valid: false; error: Error}
-    | {valid: true; minVersion: SemVer; versionRange: string; appId?: string}
+  importMapInfo?: {valid: false; error: Error} | {valid: true; minVersion: SemVer; appId?: string}
 
   /**
    * What is the version tagged as latest (periodically checked)
@@ -41,9 +39,8 @@ export type PackageVersionInfoContextValue = {
 
   /**
    * What is the current auto-updating version (as periodically resolved via module server and configured via manage).
-   * Only set if the version can actually be reached by reloading the studio: the module CDN's
-   * `resolvedVersion` when provided, otherwise the configured version if it's within the import
-   * map's version range.
+   * This is the version the module CDN will serve for the studio's import map URL, so a reload
+   * applies exactly this version — it may also be below the current version (e.g. a pinned rollback).
    */
   autoUpdatingVersion?: SemVer
 }

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -38,13 +38,6 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'about-dialog.version-info.how-to-upgrade': 'Update now',
   /** "Latest version" header in version info dialog */
   'about-dialog.version-info.latest-version.header': 'Latest version',
-  /** Explanation shown when a new major version exists but can't be applied by auto-update */
-  'about-dialog.version-info.major-upgrade.description':
-    'Sanity Studio v{{latestVersion}} is available, but auto-update can’t install it because it’s a new major version. To update, upgrade the studio’s dependencies and redeploy it.',
-  /** Header for the note shown when a new major version exists but can't be applied by auto-update */
-  'about-dialog.version-info.major-upgrade.header': 'New major version available',
-  /** "Learn how to upgrade" link for the major version upgrade note */
-  'about-dialog.version-info.major-upgrade.view-documentation': 'Learn how to upgrade',
   /** Info text when auto updates is enabled and a new version is available */
   'about-dialog.version-info.new-auto-update-version-available': 'New version available',
   /** "New version" header in version info dialog - Note that this is not necessary a *higher* version compared to current:

--- a/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/resources/StudioInfoDialog.tsx
@@ -1,6 +1,5 @@
 import {CogIcon} from '@sanity/icons/Cog'
 import {GithubIcon} from '@sanity/icons/Github'
-import {InfoOutlineIcon} from '@sanity/icons/InfoOutline'
 import {LaunchIcon} from '@sanity/icons/Launch'
 import {RefreshIcon} from '@sanity/icons/Refresh'
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
@@ -148,42 +147,6 @@ export function StudioInfoDialog(props: StudioInfoDialogProps) {
       </Card>
     ) : null
 
-  // A newer major version exists, but auto-update can't reach it (a reload only serves versions
-  // within the import map's version range unless the major jump has been explicitly allowed) —
-  // updating requires upgrading the studio's dependencies and redeploying
-  const majorUpgradeNote =
-    isAutoUpdating &&
-    latestTaggedVersion &&
-    latestTaggedVersion.major > currentVersion.major &&
-    (!autoUpdatingVersion || autoUpdatingVersion.major < latestTaggedVersion.major) ? (
-      <Card padding={4} tone="primary">
-        <Flex align="flex-start" gap={3}>
-          <TextWithTone tone="primary">
-            <InfoOutlineIcon />
-          </TextWithTone>
-          <Stack space={4}>
-            <TextWithTone size={1} tone="primary" weight="medium">
-              {t('about-dialog.version-info.major-upgrade.header')}
-            </TextWithTone>
-            <TextWithTone size={1} tone="primary">
-              {t('about-dialog.version-info.major-upgrade.description', {
-                latestVersion: latestTaggedVersion.version,
-              })}
-            </TextWithTone>
-            <Text muted size={1}>
-              <a
-                href="https://www.sanity.io/docs/upgrade"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {t('about-dialog.version-info.major-upgrade.view-documentation')} &rarr;
-              </a>
-            </Text>
-          </Stack>
-        </Flex>
-      </Card>
-    ) : null
-
   const versionBadgeTone =
     currentVersionType === 'development'
       ? 'caution'
@@ -294,8 +257,9 @@ export function StudioInfoDialog(props: StudioInfoDialogProps) {
                 </Badge>
 
                 {
-                  // save some space by not showing "how to update"-button
-                  currentVersionType ? null : (
+                  // this row only renders when a reload won't deliver the latest version, so
+                  // link to how to upgrade manually (hidden on dev/prerelease builds to save space)
+                  currentVersionType !== 'default' ? null : (
                     <Button
                       as="a"
                       href="https://www.sanity.io/docs/upgrade"
@@ -350,7 +314,6 @@ export function StudioInfoDialog(props: StudioInfoDialogProps) {
               </Flex>
             </Card>
           ) : null}
-          {majorUpgradeNote}
           {importMapWarning}
         </Stack>
         <Stack paddingX={3}>

--- a/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
+++ b/packages/sanity/src/core/studio/packageVersionStatus/PackageVersionStatusProvider.tsx
@@ -6,12 +6,11 @@ import semver from 'semver'
 import {getSanityImportMapUrl} from '../../environment/importMap'
 import {SANITY_VERSION} from '../../version'
 import {
-  type AutoUpdatingVersionInfo,
   fetchLatestAutoUpdatingVersion,
   fetchLatestAvailableVersionForPackage,
   type LatestVersionInfo,
 } from './fetchLatestVersions'
-import {isReloadableVersion, parseImportMapModuleCdnUrl} from './utils'
+import {parseImportMapModuleCdnUrl} from './utils'
 
 // How often to check for new versions
 const POLL_INTERVAL_MS = 1000 * 60 * 15 // check every 15 minutes
@@ -67,11 +66,7 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
       )
     }
     return result.valid
-      ? {
-          ...result,
-          versionRange: result.minVersion,
-          minVersion: semver.coerce(result.minVersion, {includePrerelease: true})!,
-        }
+      ? {...result, minVersion: semver.coerce(result.minVersion, {includePrerelease: true})!}
       : result
   }, [])
   const currentVersion = useMemo(() => getCurrentVersion(), [])
@@ -79,30 +74,17 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
   const isAutoUpdating = Boolean(importMapInfo)
 
   const lastCheckRef = useRef<number>(undefined)
-  const [autoUpdatingVersionRaw, setAutoUpdatingVersionRaw] = useState<AutoUpdatingVersionInfo>()
+  const [autoUpdatingVersionRaw, setAutoUpdatingVersionRaw] = useState<string>()
   const [latestTaggedVersionRaw, setLatestTaggedVersionRaw] = useState<string>()
 
-  const autoUpdatingVersion = useMemo(() => {
-    if (!autoUpdatingVersionRaw) {
-      return undefined
-    }
-    const {resolvedVersion, packageVersion} = autoUpdatingVersionRaw
-    // Prefer the version resolved by the module CDN — the exact version a reload will serve
-    if (resolvedVersion) {
-      return semver.parse(resolvedVersion) ?? undefined
-    }
-    if (!packageVersion) {
-      return undefined
-    }
-    // Module CDN responses without `resolvedVersion` only tell us the version the app is
-    // configured to update to, which may not be servable for the import map's version range
-    // (e.g. a new major that hasn't been allowed for auto-update). Reloading wouldn't update
-    // anything in that case — ignore the version instead of sending users into a reload loop.
-    if (importMapInfo?.valid && !isReloadableVersion(packageVersion, importMapInfo.versionRange)) {
-      return undefined
-    }
-    return semver.parse(packageVersion) ?? undefined
-  }, [autoUpdatingVersionRaw, importMapInfo])
+  // The version the module CDN will serve for the studio's import map URL on reload (resolved
+  // within the URL's version range, including explicitly allowed major jumps). Never base this
+  // on `latest` — it ignores the range and reloading can't reach it.
+  const autoUpdatingVersion = useMemo(
+    () =>
+      autoUpdatingVersionRaw ? (semver.parse(autoUpdatingVersionRaw) ?? undefined) : undefined,
+    [autoUpdatingVersionRaw],
+  )
   const latestTaggedVersion = useMemo(
     () =>
       latestTaggedVersionRaw ? (semver.parse(latestTaggedVersionRaw) ?? undefined) : undefined,
@@ -126,7 +108,10 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
 
     // fetch the current version of the sanity package on the 'latest' tag
     const resolveLatestTaggedVersion = DEBUG_LATEST_VERSION
-      ? Promise.resolve<LatestVersionInfo>({latest: DEBUG_VALUES.latestVersion})
+      ? Promise.resolve<LatestVersionInfo>({
+          latest: DEBUG_VALUES.latestVersion,
+          packageVersion: DEBUG_VALUES.latestVersion,
+        })
       : fetchLatestAvailableVersionForPackage({
           packageName: REFERENCE_PACKAGE,
           minVersion: importMapInfo?.valid ? importMapInfo.minVersion : currentVersion,
@@ -135,7 +120,7 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
 
     // fetch the current version based on manage/brett configuration for appid
     const resolveAutoUpdatingVersion = DEBUG_AUTO_UPDATE_VERSION
-      ? Promise.resolve<AutoUpdatingVersionInfo>({packageVersion: DEBUG_VALUES.autoUpdateVersion})
+      ? Promise.resolve(DEBUG_VALUES.autoUpdateVersion)
       : importMapInfo?.valid
         ? importMapInfo.appId
           ? fetchLatestAutoUpdatingVersion({
@@ -143,11 +128,9 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
               minVersion: importMapInfo?.valid ? importMapInfo.minVersion : currentVersion,
               appId: importMapInfo.appId,
             })
-          : // if studio is auto-updating but has no appId, the auto-updating version will be from `latest`
-            resolveLatestTaggedVersion.then(
-              (result) =>
-                result && {packageVersion: result.latest, resolvedVersion: result.resolvedVersion},
-            )
+          : // if studio is auto-updating but has no appId, the auto-updating version comes from the
+            // latest-channel metadata — its `packageVersion` is resolved for the same version range
+            resolveLatestTaggedVersion.then((result) => result?.packageVersion)
         : undefined
 
     void Promise.all([resolveLatestTaggedVersion, resolveAutoUpdatingVersion])
@@ -156,7 +139,7 @@ export function PackageVersionStatusProvider({children}: {children: ReactNode}) 
         // than rejecting), so only overwrite state when we actually got a value.
         // This keeps the previously known versions on a transient failure and
         // we try again on the next tick.
-        if (nextAutoUpdatingVersion?.resolvedVersion || nextAutoUpdatingVersion?.packageVersion) {
+        if (typeof nextAutoUpdatingVersion !== 'undefined') {
           setAutoUpdatingVersionRaw(nextAutoUpdatingVersion)
         }
         if (nextLatestVersion?.latest) {

--- a/packages/sanity/src/core/studio/packageVersionStatus/fetchLatestVersions.ts
+++ b/packages/sanity/src/core/studio/packageVersionStatus/fetchLatestVersions.ts
@@ -37,18 +37,15 @@ function getModuleUrl({
   return `${MODULES_URL}/${packageName}/${tag}/^${minVersion.version}/t${timestamp}`
 }
 
-export interface AutoUpdatingVersionInfo {
-  /** The version the app is configured to update to (may not be servable for the import map's version range) */
-  packageVersion?: string
-  /** The exact version the module CDN will serve for the studio's import map URL, if provided by the server */
-  resolvedVersion?: string
-}
-
+/**
+ * Resolves the version the module CDN will serve for the studio's import map URL on reload
+ * (the `packageVersion` of the app's module metadata)
+ */
 export const fetchLatestAutoUpdatingVersion = async (options: {
   packageName: string
   minVersion: SemVer
   appId: string
-}): Promise<AutoUpdatingVersionInfo | undefined> => {
+}) => {
   const {packageName, minVersion, appId} = options
 
   try {
@@ -61,37 +58,32 @@ export const fetchLatestAutoUpdatingVersion = async (options: {
     if (!res.ok) {
       throw new Error(`HTTP ${res.status} ${res.statusText}`)
     }
+    // `return await` (not bare `return`) so a JSON parse rejection is
+    // caught by this try/catch instead of escaping to the caller.
     const data = await res.json()
-    return {
-      packageVersion: data.packageVersion as string,
-      resolvedVersion: data.resolvedVersion as string | undefined,
-    }
+    return data.packageVersion as string
   } catch (err) {
-    // Best-effort check — the caller keeps previously known versions and retries on the next poll
-    console.warn(
-      new Error(
-        `[sanity] Failed to fetch version for package "${packageName}" (using appId=${appId})`,
-        {
-          cause: err,
-        },
-      ),
+    console.error(
+      new Error(`Failed to fetch version for package "${packageName}" (using appId=${appId})`, {
+        cause: err,
+      }),
     )
     return undefined
   }
 }
 
 export interface LatestVersionInfo {
-  /** The latest version published to the tag (may not be servable for the import map's version range) */
+  /** The latest version published to the tag, ignoring the version range — for messaging only, a reload may not serve it */
   latest?: string
-  /** The exact version the module CDN will serve for the studio's import map URL, if provided by the server */
-  resolvedVersion?: string
+  /** The version the module CDN will serve for this URL (resolved within the version range) */
+  packageVersion: string
 }
 
 export const fetchLatestAvailableVersionForPackage = async (options: {
   packageName: string
   minVersion: SemVer
   tag?: string
-}): Promise<LatestVersionInfo | undefined> => {
+}) => {
   const {packageName, minVersion, tag = 'latest'} = options
   try {
     // On every request it should be a new timestamp, so we can actually get a new version notification
@@ -103,15 +95,16 @@ export const fetchLatestAvailableVersionForPackage = async (options: {
     if (!res.ok) {
       throw new Error(`HTTP ${res.status} ${res.statusText}`)
     }
+    // `return await` (not bare `return`) so a JSON parse rejection is
+    // caught by this try/catch instead of escaping to the caller.
     const data = await res.json()
     return {
       latest: data.latest as string,
-      resolvedVersion: data.resolvedVersion as string | undefined,
+      packageVersion: data.packageVersion as string,
     }
   } catch (err) {
-    // Best-effort check — the caller keeps previously known versions and retries on the next poll
-    console.warn(
-      `[sanity] Failed to fetch version for package (using tag=${tag})`,
+    console.error(
+      `Failed to fetch version for package (using tag=${tag})`,
       packageName,
       'Error:',
       err,

--- a/packages/sanity/src/core/studio/packageVersionStatus/utils.test.ts
+++ b/packages/sanity/src/core/studio/packageVersionStatus/utils.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest'
 
-import {isReloadableVersion, parseImportMapModuleCdnUrl} from './utils'
+import {parseImportMapModuleCdnUrl} from './utils'
 
 describe('parseImportMapModuleCdnUrl for legacy urls', () => {
   it('returns undefined but warns if an invalid module url is given', () => {
@@ -94,24 +94,5 @@ describe('parseImportMapModuleCdnUrl for app-id urls', () => {
         "valid": false,
       }
     `)
-  })
-})
-
-describe('isReloadableVersion', () => {
-  it('accepts versions within the import map range', () => {
-    expect(isReloadableVersion('5.32.0', '^5.31.1')).toBe(true)
-    expect(isReloadableVersion('5.31.1', '^5.31.1')).toBe(true)
-    // downgrades within the range (e.g. a version pinned via manage) are still reachable
-    expect(isReloadableVersion('5.25.0', '^5.20.0')).toBe(true)
-  })
-  it('rejects versions outside the import map range', () => {
-    // a new major will never be served on reload
-    expect(isReloadableVersion('6.4.0', '^5.31.1')).toBe(false)
-    expect(isReloadableVersion('4.9.0', '^5.31.1')).toBe(false)
-  })
-  it('accepts prerelease versions within the range', () => {
-    expect(isReloadableVersion('5.32.0-next.5', '^5.31.1')).toBe(true)
-    // but not prereleases of the next major
-    expect(isReloadableVersion('6.0.0-next.1', '^5.31.1')).toBe(false)
   })
 })

--- a/packages/sanity/src/core/studio/packageVersionStatus/utils.ts
+++ b/packages/sanity/src/core/studio/packageVersionStatus/utils.ts
@@ -1,4 +1,4 @@
-import semver, {type SemVer} from 'semver'
+import semver from 'semver'
 
 const MODULE_PATH_REGEX = /^\/v1\/modules\/sanity\/[^/]+\/[^/]+\/[^/]+\/?$/
 // /v1/modules/by-app/some-appid-123/t1755876954/%5E4.5.0/sanity
@@ -33,18 +33,6 @@ export function parseImportMapModuleCdnUrl(
     appId,
     minVersion,
   }
-}
-
-/**
- * Checks whether a version resolved from the module CDN can actually be reached by reloading the
- * studio, given the version range from the studio's import map. The module CDN never serves a
- * version outside this range (e.g. a new major), so prompting the user to reload into one would
- * only send them into a reload loop.
- */
-export function isReloadableVersion(version: SemVer | string, versionRange: string): boolean {
-  // `includePrerelease` so that studios configured to auto-update to a prerelease tag still get
-  // the reload prompt, as long as the prerelease is within the import map's range
-  return semver.satisfies(version, versionRange, {includePrerelease: true})
 }
 
 function rawParseModuleCDNUrl(


### PR DESCRIPTION
### Description

Partial revert of #13451, which missed the target, as the fix is a lot simpler.

The original issue was caused by the "reload-to-update"-prompt being derived from the module metadata's `latest` field, which ignores the import map's version range, so when a new major was published, studios offered an update that a reload could never deliver, leaving users in a reload loop. The prompt is now instead based on `packageVersion`, the exact version the module CDN will serve for the studio's import map URL (including explicitly allowed major jumps and pinned rollbacks). 

So this PR replaces the range-check heuristic from #13451; latest is kept for informational display only, with an "Update" link to the upgrade docs when auto-update won't deliver it.

### What to review
This is probably best reviewed as the sum of #13451 and this PR: https://github.com/sanity-io/sanity/compare/11edcfa620b4cc5af5714c0c1287e127c6b7bf36..fix/auto-update-served-version

### Testing


### Notes for release

N/A: Already covered by #13451

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how auto-update and reload messaging are computed for all import-map studios; wrong CDN metadata could still mislead users, but the logic is narrower and removes the prior reload-loop case.
> 
> **Overview**
> Fixes auto-update UX by driving **reload prompts** from the module CDN’s **`packageVersion`** (the version a reload will actually load) instead of **`latest`** or client-side semver range checks that could suggest updates a reload could never apply.
> 
> **Version resolution** is simplified: `fetchLatestAutoUpdatingVersion` and the latest-tag fetch now expose **`packageVersion`** as the reload target; **`resolvedVersion`**, **`AutoUpdatingVersionInfo`**, and **`isReloadableVersion`** are removed. **`importMapInfo`** no longer carries **`versionRange`**.
> 
> **About dialog**: the separate **major version available** banner and strings are removed; the **manual upgrade** link on the latest-version row is shown when that row appears (i.e. when a reload won’t reach latest), still hidden for dev/prerelease builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04b42a026f1e090dd92f8f35bcc7b86dfe71aca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->