### PR TITLE
chore(sanity): add data to document group inventory machine

### DIFF
--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -32,6 +32,7 @@ import {getReleaseDocumentIdFromReleaseId} from '../../releases/util/getReleaseD
 import {useReleasesToolAvailable} from '../../schedules/hooks/useReleasesToolAvailable'
 import {isAgentBundleName} from '../../store'
 import {useAgentBundlesStore} from '../../store/agent/useAgentBundles'
+import {useWorkspace} from '../../studio'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
 import {
   getPublishedId,
@@ -103,6 +104,8 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
   referringDocuments$,
   components,
 }) => {
+  const {beta} = useWorkspace()
+  const variantsEnabled = beta?.variants?.enabled
   const {t} = useTranslation(studioLocaleNamespace)
   const {t: feedbackT} = useTranslation(feedbackLocaleNamespace)
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
@@ -143,6 +146,7 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
   const inventoryRef = useActorRef(inventoryMachine, {
     input: {
       t,
+      variantsEnabled,
       selectionMachine: useMemo(
         () =>
           selectionMachine.provide({

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -8,7 +8,7 @@ import {getTheme_v2 as getThemeV2} from '@sanity/ui/theme'
 import {useActorRef, useSelector} from '@xstate/react'
 import {type ComponentType, useMemo, type ChangeEvent, useState, useEffect} from 'react'
 import {useObservable} from 'react-rx'
-import {combineLatest, debounceTime, map, type Observable, startWith, Subject} from 'rxjs'
+import {combineLatest, debounceTime, map, type Observable, of, startWith, Subject} from 'rxjs'
 import {styled, css} from 'styled-components'
 import {type ActorRefFromLogic, fromObservable, fromPromise} from 'xstate'
 
@@ -41,6 +41,8 @@ import {
   isPublishedId,
   isVersionId,
 } from '../../util/draftUtils'
+import {type VariantStoreState} from '../../variants/store/reducer'
+import {useVariantsStore} from '../../variants/store/useVariantsStore'
 import {deletionMachine, type ReferringDocuments} from '../machines/deletionMachine'
 import {documentGroupInventoryMachine} from '../machines/documentGroupInventoryMachine'
 import {selectionMachine} from '../machines/selectionMachine'
@@ -113,6 +115,7 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
   const versionState = useDocumentVersionsObservable({documentId})
   const {state$: releases} = useReleasesStore()
   const {state$: agentBundles} = useAgentBundlesStore()
+  const {state$: variants} = useVariantsStore()
   const [containerElement, setContainerElement] = useState<HTMLDivElement | null>(null)
   const filterStringEvent = useMemo(() => new Subject<ChangeEvent<HTMLInputElement>>(), [])
   const [menuPortalElement, setMenuPortalElement] = useState<HTMLDivElement | null>(null)
@@ -134,13 +137,15 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
     () =>
       documentGroupInventoryMachine.provide({
         actors: {
-          meta: fromObservable(() => combineLatest({versionState, releases, agentBundles})),
+          meta: fromObservable(() =>
+            combineLatest({versionState, releases, variants, agentBundles}),
+          ),
         },
         actions: {
           onFeedbackBegin: feedbackDialogOpened,
         },
       }),
-    [versionState, releases, agentBundles, feedbackDialogOpened],
+    [versionState, releases, variants, agentBundles, feedbackDialogOpened],
   )
 
   const inventoryRef = useActorRef(inventoryMachine, {

--- a/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.test.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.test.ts
@@ -1,4 +1,4 @@
-import {type ReleaseDocument} from '@sanity/client'
+import {type MultipleMutationResult, type ReleaseDocument} from '@sanity/client'
 import {BehaviorSubject, of} from 'rxjs'
 import {describe, expect, it, vi} from 'vitest'
 import {createActor, fromObservable, fromPromise} from 'xstate'
@@ -69,10 +69,15 @@ function withCrossDatasetReferences(
   return {crossDatasetReferences: {totalCount: references.length, references}}
 }
 
+// Loaded variants store state with no variants, the way the component wires
+// it up when the variants feature is disabled.
+const loadedVariants: Meta['variants'] = {variants: new Map(), state: 'loaded'}
+
 // Minimal meta that drives the selection machine straight to `ready`.
 const loadedMeta = {
   versionState: {data: ['drafts.foo', 'foo'], loading: false, error: null},
   releases: {releases: new Map(), state: 'loaded' as const},
+  variants: loadedVariants,
   agentBundles: {bundles: [], loading: false},
 } as unknown as Meta
 
@@ -100,14 +105,19 @@ function createTestActor(
       input: {
         selectionMachine,
         t,
+        // These tests exercise the flat variant list; grouped variant sets are
+        // gated behind the variants feature flag.
+        variantsEnabled: false,
         deletionMachine: deletionMachine.provide({
           actors: {
-            referringDocuments: fromObservable(() => references$),
-            deleteVariants: fromPromise(async () => {
-              // Defaults to a resolving no-op; tests override to exercise outcomes.
-              if (deleteVariants) return deleteVariants()
-              return undefined
+            deleteVariants: fromPromise<MultipleMutationResult, {ids: string[]}>(async () => {
+              // Defaults to a resolving no-op; tests override to exercise
+              // outcomes. The mutation result is never inspected by the
+              // machine, so a stub suffices.
+              if (deleteVariants) await deleteVariants()
+              return {transactionId: 'stub', documentIds: [], results: []}
             }),
+            referringDocuments: fromObservable(() => references$),
           },
           actions: requestDeletionConfirmation ? {requestDeletionConfirmation} : {},
         }),
@@ -440,6 +450,7 @@ describe('documentGroupInventoryMachine', () => {
         error: null,
       },
       releases: {releases, state: 'loaded' as const},
+      variants: loadedVariants,
       agentBundles: {bundles: [], loading: false},
     } as unknown as Meta
 
@@ -472,6 +483,7 @@ describe('documentGroupInventoryMachine', () => {
         error: null,
       },
       releases: {releases: new Map(), state: 'loaded' as const},
+      variants: loadedVariants,
       agentBundles: {
         bundles: [
           {id: 'agent-abc', applicationKey: 'app-1'},
@@ -501,6 +513,7 @@ describe('documentGroupInventoryMachine', () => {
     const meta = {
       versionState: {data: [], loading: false, error: new Error('meta failed')},
       releases: {releases: new Map(), state: 'loaded' as const},
+      variants: loadedVariants,
       agentBundles: {bundles: [], loading: false},
     } as unknown as Meta
 

--- a/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.ts
@@ -31,6 +31,7 @@ interface DocumentGroupInventoryContext {
   sets: VariantSet[]
   releases: Map<string, ReleaseDocument>
   t: TFunction
+  variantsEnabled: boolean | undefined
 }
 
 type DocumentGroupInventoryEvents =
@@ -43,7 +44,12 @@ type DocumentGroupInventoryEvents =
 export const documentGroupInventoryMachine = setup({
   // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   types: {} as {
-    input: {selectionMachine: SelectionLogic; deletionMachine: DeletionLogic; t: TFunction}
+    input: {
+      selectionMachine: SelectionLogic
+      deletionMachine: DeletionLogic
+      t: TFunction
+      variantsEnabled: boolean | undefined
+    }
     context: DocumentGroupInventoryContext
     events: DocumentGroupInventoryEvents
   },
@@ -67,6 +73,7 @@ export const documentGroupInventoryMachine = setup({
     sets: [],
     releases: new Map(),
     t: input.t,
+    variantsEnabled: input.variantsEnabled,
   }),
   invoke: {
     src: 'meta',
@@ -74,7 +81,12 @@ export const documentGroupInventoryMachine = setup({
       actions: [
         assign({
           sets: ({context, event}) =>
-            computeSets({meta: event.snapshot.context, current: context.sets, t: context.t}),
+            computeSets({
+              meta: event.snapshot.context,
+              current: context.sets,
+              t: context.t,
+              variantsEnabled: context.variantsEnabled,
+            }),
           releases: ({event}) => event.snapshot.context?.releases.releases ?? new Map(),
         }),
         sendTo(
@@ -140,10 +152,12 @@ function computeSets({
   meta,
   current,
   t,
+  variantsEnabled,
 }: {
   meta: Meta | undefined
   current: VariantSet[]
   t: TFunction
+  variantsEnabled: boolean | undefined
 }): VariantSet[] {
   if (!meta) {
     return current

--- a/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.ts
@@ -8,6 +8,7 @@ import {type ReleasesReducerState} from '../../releases/store/reducer'
 import {getReleaseDocumentIdFromReleaseId} from '../../releases/util/getReleaseDocumentIdFromReleaseId'
 import {isAgentBundleName, type AgentBundlesState} from '../../store/agent/createAgentBundlesStore'
 import {getVersionFromId, isDraftId, isPublishedId} from '../../util/draftUtils'
+import {type VariantStoreState} from '../../variants/store/reducer'
 import {type deletionMachine} from './deletionMachine'
 import {type selectionMachine, type Variant} from './selectionMachine'
 
@@ -17,6 +18,7 @@ type DeletionLogic = typeof deletionMachine
 export interface Meta {
   versionState: DocumentPerspectiveState
   releases: ReleasesReducerState
+  variants: VariantStoreState
   agentBundles: AgentBundlesState
 }
 


### PR DESCRIPTION
### Description

This branch exposes the Content Variants preview state (whether Content Variants is switched on) and the list of variant definitions to the document group inventory machine. If Content Variants is not switched on, the list immediately resolves to an empty map.

These changes lay the foundations for including variants in the document group inventory.

### What to review

New data exposed to the document group inventory machine.

### Testing

State machine tests updated to operate with Content Variants switched off at this stage, given this branch doesn't include any behavioural changes when Content Variants is switched on.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Foundational state-machine wiring only; inventory listing and deletion behavior are unchanged while variants remain disabled.
> 
> **Overview**
> **Plumbing for Content Variants in document group inventory** — no user-visible inventory behavior changes yet when variants are off (the default).
> 
> `DocumentGroupInventory` now reads `beta?.variants?.enabled` from the workspace and subscribes to `useVariantsStore()`. The machine’s `meta` observable combines `variants` with existing `versionState`, `releases`, and `agentBundles`. Machine input and context gain `variantsEnabled`, and `Meta` gains `variants: VariantStoreState`.
> 
> `computeSets` is updated to accept `variantsEnabled` but still builds the same single `studio:all` set from version state; variant definitions are not used for grouping in this PR.
> 
> Tests include `variants` in meta fixtures, pass `variantsEnabled: false`, and tighten the `deleteVariants` test actor stub to return a typed `MultipleMutationResult`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 613944ff756e7bb628e766a8aed129597f130eed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->