### PR TITLE
fix(structure): delegate intent resolution request failures to studio error handler

### DIFF
--- a/packages/sanity/src/structure/components/structureTool/intentResolver/IntentResolver.tsx
+++ b/packages/sanity/src/structure/components/structureTool/intentResolver/IntentResolver.tsx
@@ -1,5 +1,5 @@
 import {memo, useCallback, useEffect, useState} from 'react'
-import {isRecord, useDocumentStore} from 'sanity'
+import {isRecord, useDocumentStore, useStudioErrorHandler} from 'sanity'
 import {useRouter, useRouterState} from 'sanity/router'
 
 import {resolveIntent} from '../../../structureResolvers'
@@ -28,6 +28,7 @@ export const IntentResolver = memo(function IntentResolver() {
   )
   const {rootPaneNode, structureContext} = useStructureTool()
   const documentStore = useDocumentStore()
+  const errorHandler = useStudioErrorHandler()
   const [error, setError] = useState<unknown>(null)
 
   // this re-throws errors so that parent ErrorBoundary's can handle them properly
@@ -61,13 +62,15 @@ export const IntentResolver = memo(function IntentResolver() {
         navigate({panes}, {replace: true})
       }
 
-      effect().catch(setError)
+      // Delegate infrastructure failures (network, 5xx, 429) to the studio's request-error
+      // dialog, whose "Try again" re-runs the resolution.
+      errorHandler.attempt(effect, {retryable: true}).catch(setError)
 
       return () => {
         cancelled = true
       }
     }
-  }, [documentStore, maybeIntent, navigate, rootPaneNode, structureContext])
+  }, [documentStore, errorHandler, maybeIntent, navigate, rootPaneNode, structureContext])
 
   return null
 })

--- a/packages/sanity/src/structure/components/structureTool/intentResolver/IntentResolver.tsx
+++ b/packages/sanity/src/structure/components/structureTool/intentResolver/IntentResolver.tsx
@@ -41,6 +41,11 @@ export const IntentResolver = memo(function IntentResolver() {
 
       let cancelled = false
       async function effect() {
+        // The request-error dialog's "Try again" can re-run this thunk after
+        // the effect has been cleaned up (intent changed or unmounted) —
+        // resolve immediately instead of re-fetching for a stale intent.
+        if (cancelled) return
+
         const {id, type} = await ensureDocumentIdAndType(
           documentStore,
           typeof params.id === 'string' ? params.id : undefined,

--- a/packages/sanity/src/structure/components/structureTool/intentResolver/__tests__/IntentResolver.test.tsx
+++ b/packages/sanity/src/structure/components/structureTool/intentResolver/__tests__/IntentResolver.test.tsx
@@ -72,7 +72,7 @@ describe('IntentResolver', () => {
 
   function renderResolver(channel = createRequestErrorChannel()) {
     const boundary = {current: null as Boundary | null}
-    render(
+    const {unmount} = render(
       <StudioErrorHandlerContext.Provider value={channel}>
         <Boundary
           ref={(instance) => {
@@ -83,7 +83,7 @@ describe('IntentResolver', () => {
         </Boundary>
       </StudioErrorHandlerContext.Provider>,
     )
-    return {channel, boundary}
+    return {channel, boundary, unmount}
   }
 
   it('delegates infrastructure failures to the request-error channel instead of crashing', async () => {
@@ -111,6 +111,23 @@ describe('IntentResolver', () => {
       expect(mockNavigate).toHaveBeenCalledWith({panes: []}, {replace: true})
     })
     expect(mockResolveTypeForDocument).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not re-fetch when the claimed error is retried after unmount', async () => {
+    mockResolveTypeForDocument.mockReturnValue(throwError(socketTimeoutError))
+
+    const {channel, unmount} = renderResolver()
+
+    await firstValueFrom(channel.claim$.pipe(filter(Boolean)))
+    unmount()
+    channel.retry()
+
+    expect(await firstValueFrom(channel.claim$)).toBeUndefined()
+    // let the re-run of the (now cancelled) thunk settle before asserting
+    // that it didn't issue another request
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mockResolveTypeForDocument).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).not.toHaveBeenCalled()
   })
 
   it('re-throws caller-domain errors into the error boundary', async () => {

--- a/packages/sanity/src/structure/components/structureTool/intentResolver/__tests__/IntentResolver.test.tsx
+++ b/packages/sanity/src/structure/components/structureTool/intentResolver/__tests__/IntentResolver.test.tsx
@@ -1,0 +1,126 @@
+import {render, waitFor} from '@testing-library/react'
+import {Component, type ReactNode} from 'react'
+import {firstValueFrom, of, throwError} from 'rxjs'
+import {filter} from 'rxjs/operators'
+import {createRequestErrorChannel, type DocumentStore} from 'sanity'
+import {StudioErrorHandlerContext} from 'sanity/_singletons'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {PaneResolutionError} from '../../../../structureResolvers'
+import * as USE_STRUCTURE_TOOL from '../../../../useStructureTool'
+import {IntentResolver} from '../IntentResolver'
+
+const {mockNavigate, mockRouterState, mockResolveTypeForDocument, mockResolveIntent} = vi.hoisted(
+  () => ({
+    mockNavigate: vi.fn(),
+    mockRouterState: {current: {} as Record<string, unknown>},
+    mockResolveTypeForDocument: vi.fn(),
+    mockResolveIntent: vi.fn(),
+  }),
+)
+
+vi.mock('sanity', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useDocumentStore: () =>
+    ({resolveTypeForDocument: mockResolveTypeForDocument}) as unknown as DocumentStore,
+}))
+
+vi.mock('sanity/router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useRouter: () => ({navigate: mockNavigate}),
+  useRouterState: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector(mockRouterState.current),
+}))
+
+vi.mock('../../../../structureResolvers', async (importOriginal) => ({
+  ...(await importOriginal()),
+  resolveIntent: mockResolveIntent,
+}))
+
+vi.spyOn(USE_STRUCTURE_TOOL, 'useStructureTool').mockImplementation(
+  () =>
+    ({
+      rootPaneNode: {},
+      structureContext: {},
+    }) as unknown as ReturnType<typeof USE_STRUCTURE_TOOL.useStructureTool>,
+)
+
+class Boundary extends Component<{children: ReactNode}, {error: unknown}> {
+  state: {error: unknown} = {error: null}
+
+  static getDerivedStateFromError(error: unknown) {
+    return {error}
+  }
+
+  render() {
+    return this.state.error ? null : this.props.children
+  }
+}
+
+function socketTimeoutError() {
+  return Object.assign(new Error('Socket timed out on request to https://x.api.sanity.io/…'), {
+    code: 'ESOCKETTIMEDOUT',
+  })
+}
+
+describe('IntentResolver', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRouterState.current = {intent: 'edit', params: {id: 'doc-id'}}
+    mockResolveIntent.mockResolvedValue([])
+  })
+
+  function renderResolver(channel = createRequestErrorChannel()) {
+    const boundary = {current: null as Boundary | null}
+    render(
+      <StudioErrorHandlerContext.Provider value={channel}>
+        <Boundary
+          ref={(instance) => {
+            boundary.current = instance
+          }}
+        >
+          <IntentResolver />
+        </Boundary>
+      </StudioErrorHandlerContext.Provider>,
+    )
+    return {channel, boundary}
+  }
+
+  it('delegates infrastructure failures to the request-error channel instead of crashing', async () => {
+    mockResolveTypeForDocument.mockReturnValue(throwError(socketTimeoutError))
+
+    const {channel, boundary} = renderResolver()
+
+    const claim = await firstValueFrom(channel.claim$.pipe(filter(Boolean)))
+    expect(claim).toMatchObject({type: 'networkError', retryable: true})
+    expect(boundary.current?.state.error).toBeNull()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('re-runs intent resolution when the claimed error is retried', async () => {
+    mockResolveTypeForDocument
+      .mockReturnValueOnce(throwError(socketTimeoutError))
+      .mockReturnValueOnce(of('author'))
+
+    const {channel} = renderResolver()
+
+    await firstValueFrom(channel.claim$.pipe(filter(Boolean)))
+    channel.retry()
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({panes: []}, {replace: true})
+    })
+    expect(mockResolveTypeForDocument).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-throws caller-domain errors into the error boundary', async () => {
+    mockRouterState.current = {intent: 'edit', params: {}}
+
+    const {channel, boundary} = renderResolver()
+
+    await waitFor(() => {
+      expect(boundary.current?.state.error).toBeInstanceOf(PaneResolutionError)
+    })
+    expect(await firstValueFrom(channel.claim$)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Description
Similar fix as #13427, delegates infra structure error handling to studio when intent resolver fetches document type.

### Testing
Quickest way to test is probably to add request blocking on the request tagged with `sanity.studio.document.resolve-type`

### Notes for release
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized navigation/error-handling change in structure intent resolution with tests; no auth, data writes, or broad API surface changes.
> 
> **Overview**
> **Intent resolution** no longer crashes the structure tool on transient API failures (timeouts, 5xx, 429) when resolving document type during navigation. Those failures go through the studio **request-error** dialog with a retryable **Try again** flow, matching the pattern from #13427.
> 
> The async resolution thunk is wrapped in `useStudioErrorHandler().attempt(..., { retryable: true })`, with an extra **`cancelled` guard** at the start so a retry after the intent changed or the component unmounted does not re-fetch for a stale intent. **Caller-domain** failures (e.g. `PaneResolutionError` from missing params) still propagate to the parent error boundary.
> 
> New **`IntentResolver` tests** cover channel delegation, successful retry, no-op retry after unmount, and domain errors bypassing the request-error channel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b041e4de89d70fa6c3f552e84a9cfc250e92e62c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->