### PR TITLE
refactor(internal): migrate internal clis from yargs to optique

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -77,9 +77,9 @@ jobs:
           {
             echo "notes<<EOF"
             pnpm --silent release-notes generate-changelog \
-              --baseVersion=${{ steps.get-base-version.outputs.base-version }} \
-              --tentativeVersion="${{steps.release-as.outputs.version}}" \
-              --outputFormat=pr-description
+              --base-version=${{ steps.get-base-version.outputs.base-version }} \
+              --tentative-version="${{steps.release-as.outputs.version}}" \
+              --output-format=pr-description
             echo "EOF"
           } >> $GITHUB_OUTPUT
         env:
@@ -91,7 +91,7 @@ jobs:
 
       - name: Draft release notes for upcoming release
         id: draft-release-notes
-        run: pnpm --silent release-notes draft-release-notes --baseVersion=${{ steps.get-base-version.outputs.base-version }}
+        run: pnpm --silent release-notes draft-release-notes --base-version=${{ steps.get-base-version.outputs.base-version }}
         env:
           RELEASE_NOTES_SANITY_PROJECT_ID: ${{ vars.RELEASE_NOTES_SANITY_PROJECT_ID }}
           RELEASE_NOTES_SANITY_DATASET: ${{ vars.RELEASE_NOTES_SANITY_DATASET }}
@@ -118,7 +118,7 @@ jobs:
       - name: Post release notes reminder to the associated PR
         run: |
           pnpm --silent release-notes comment-pr-after-merge \
-          --baseVersion=${{ steps.get-base-version.outputs.base-version }} \
+          --base-version=${{ steps.get-base-version.outputs.base-version }} \
           --commit=${{ github.sha }}
         env:
           RELEASE_NOTES_SANITY_PROJECT_ID: ${{ vars.RELEASE_NOTES_SANITY_PROJECT_ID }}

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Generate GitHub release
         id: generate-github-release
         run: |
-          pnpm --silent release-notes publish-releases --targetVersion="${{needs.build-and-validate.outputs.version}}"
+          pnpm --silent release-notes publish-releases --target-version="${{needs.build-and-validate.outputs.version}}"
 
         env:
           RELEASE_NOTES_SANITY_PROJECT_ID: ${{ vars.RELEASE_NOTES_SANITY_PROJECT_ID }}

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Bump next versions
-        run: pnpm --silent release-notes bump --preid=next --suffixType=commits-ahead
+        run: pnpm --silent release-notes bump --preid=next --suffix-type=commits-ahead
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped

--- a/dev/efps/index.ts
+++ b/dev/efps/index.ts
@@ -7,13 +7,17 @@ import path from 'node:path'
 import process from 'node:process'
 import {fileURLToPath} from 'node:url'
 
+import {object} from '@optique/core/constructs'
+import {message} from '@optique/core/message'
+import {optional} from '@optique/core/modifiers'
+import {option} from '@optique/core/primitives'
+import {string} from '@optique/core/valueparser'
+import {run} from '@optique/run'
 import {readEnv} from '@repo/utils'
 import {createClient} from '@sanity/client'
 import chalk from 'chalk'
 import Table from 'cli-table3'
 import Ora from 'ora'
-import yargs from 'yargs'
-import {hideBin} from 'yargs/helpers'
 
 import {exec} from './helpers/exec'
 import {readEnvVar} from './readEnvVar'
@@ -73,11 +77,16 @@ const resultsDir = path.join(
     .toLowerCase()}`,
 )
 
-const argv = await yargs(hideBin(process.argv)).option('shard', {
-  describe:
-    'Shard number in the format "1/3" where 1 is the current shard and 3 is the total shards',
-  type: 'string',
-}).argv
+const argv = run(
+  object({
+    shard: optional(
+      option('--shard', string({metavar: 'CURRENT/TOTAL'}), {
+        description: message`Shard number in the format "1/3" where 1 is the current shard and 3 is the total shards`,
+      }),
+    ),
+  }),
+  {programName: 'efps', help: 'option'},
+)
 
 // Function to parse shard argument
 function parseShard(shard: string) {
@@ -183,7 +192,7 @@ async function runAbTest(test: EfpsTest) {
       // Run attempts sequentially to get stable measurements, but both branches run in parallel
       for (let attempt = 0; attempt < TEST_ATTEMPTS; attempt++) {
         const attemptMessage = TEST_ATTEMPTS > 1 ? ` [${attempt + 1}/${TEST_ATTEMPTS}]` : ''
-        const message = `Running test '${test.name}' on ${branchLabel}${attemptMessage}`
+        const progressMessage = `Running test '${test.name}' on ${branchLabel}${attemptMessage}`
 
         try {
           // Note: We can't use spinner here since both branches run in parallel
@@ -205,10 +214,12 @@ async function runAbTest(test: EfpsTest) {
               },
             }),
           )
-          spinner.succeed(`${message}`)
+          spinner.succeed(`${progressMessage}`)
         } catch (error) {
           lastError = error
-          spinner.fail(`${message} - failed, ${TEST_ATTEMPTS - attempt - 1} attempts remaining`)
+          spinner.fail(
+            `${progressMessage} - failed, ${TEST_ATTEMPTS - attempt - 1} attempts remaining`,
+          )
         }
       }
 

--- a/dev/efps/index.ts
+++ b/dev/efps/index.ts
@@ -85,7 +85,7 @@ const argv = run(
       }),
     ),
   }),
-  {programName: 'efps', help: 'option'},
+  {programName: 'efps', help: 'both', aboveError: 'usage'},
 )
 
 // Function to parse shard argument

--- a/dev/efps/package.json
+++ b/dev/efps/package.json
@@ -23,11 +23,12 @@
     "tsx": "^4.22.4"
   },
   "devDependencies": {
+    "@optique/core": "catalog:",
+    "@optique/run": "catalog:",
     "@repo/utils": "workspace:*",
     "@sanity/client": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "@types/yargs": "^17.0.35",
     "babel-plugin-react-compiler": "catalog:",
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
@@ -38,7 +39,6 @@
     "react-dom": "catalog:",
     "sanity": "workspace:*",
     "source-map": "^0.7.6",
-    "tinyglobby": "^0.2.17",
-    "yargs": "^18.0.0"
+    "tinyglobby": "^0.2.17"
   }
 }

--- a/packages/@repo/bundle-manager/bin/bundle-manager.ts
+++ b/packages/@repo/bundle-manager/bin/bundle-manager.ts
@@ -1,59 +1,62 @@
 #!/usr/bin/env -S pnpm tsx
 
-import yargs from 'yargs'
+import {object, or} from '@optique/core/constructs'
+import {message} from '@optique/core/message'
+import {multiple, optional} from '@optique/core/modifiers'
+import {command, constant, option} from '@optique/core/primitives'
+import {string} from '@optique/core/valueparser'
+import {run} from '@optique/run'
 
 import {tagVersion, uploadBundles} from '../src'
 import {verify} from '../src/commands/verify'
 
-const task = yargs(process.argv.slice(2))
-  .usage('$0 <command>')
-  .command({
-    command: 'publish',
-    describe: 'Publish package bundles from dist folders',
-    builder: (cmd) =>
-      cmd.options({
-        'tag': {type: 'string', array: true, demandOption: false},
-        // !!WARNING!! JS files are cached for 1y, so only use this only for development/testing purposes
-        'as-version': {
+const parser = or(
+  command(
+    'publish',
+    object({
+      action: constant('publish'),
+      tag: multiple(
+        option('--tag', string(), {
+          description: message`Dist tag(s) to publish the bundles under`,
+        }),
+      ),
+      // !!WARNING!! JS files are cached for 1y, so only use this only for development/testing purposes
+      asVersion: optional(
+        option('--as-version', string(), {
           hidden: true,
-          type: 'string',
-          demandOption: false,
-          description: `Specify the version to upload bundles as. !!WARNING!! Only for development purposes!`,
-        },
-      }),
-    handler: (args) => {
-      uploadBundles({tags: args.tag, asVersion: args.asVersion})
-        .catch((err) => {
-          console.error(err)
-          process.exit(1)
-        })
-        .catch(console.error)
-    },
-  })
-  .command({
-    command: 'tag',
-    describe: 'Tag a version',
-    builder: (cmd) =>
-      cmd.options({
-        'tag': {type: 'string', demandOption: true},
-        'target-version': {type: 'string', demandOption: true},
-      }),
-    handler: (args) => {
-      tagVersion({tag: args.tag, version: args.targetVersion})
-        .catch((err) => {
-          console.error(err)
-          process.exit(1)
-        })
-        .catch(console.error)
-    },
-  })
-  .command({
-    command: 'verify',
-    describe: 'Verify read/write access to bucket',
-    handler: () => verify(),
-  })
-  .demandCommand(1, 'must provide a valid command')
-  .help('h')
-  .alias('h', 'help').argv
+          description: message`Specify the version to upload bundles as. !!WARNING!! Only for development purposes!`,
+        }),
+      ),
+    }),
+    {description: message`Publish package bundles from dist folders`},
+  ),
+  command(
+    'tag',
+    object({
+      action: constant('tag'),
+      tag: option('--tag', string()),
+      targetVersion: option('--target-version', string()),
+    }),
+    {description: message`Tag a version`},
+  ),
+  command('verify', object({action: constant('verify')}), {
+    description: message`Verify read/write access to bucket`,
+  }),
+)
 
-Promise.resolve(task).catch(console.error)
+const args = run(parser, {programName: 'bundle-manager', help: 'both', aboveError: 'usage'})
+
+switch (args.action) {
+  case 'publish':
+    await uploadBundles({
+      tags: args.tag.length > 0 ? [...args.tag] : undefined,
+      asVersion: args.asVersion,
+    })
+    break
+  case 'tag':
+    await tagVersion({tag: args.tag, version: args.targetVersion})
+    break
+  case 'verify':
+    await verify()
+    break
+}

--- a/packages/@repo/bundle-manager/bin/bundle-manager.ts
+++ b/packages/@repo/bundle-manager/bin/bundle-manager.ts
@@ -44,7 +44,11 @@ const parser = or(
   }),
 )
 
-const args = run(parser, {programName: 'bundle-manager', help: 'both', aboveError: 'usage'})
+const args = run(parser, {
+  programName: 'bundle-manager',
+  help: {command: true, option: {names: ['-h', '--help']}},
+  aboveError: 'usage',
+})
 
 switch (args.action) {
   case 'publish':

--- a/packages/@repo/bundle-manager/package.json
+++ b/packages/@repo/bundle-manager/package.json
@@ -26,18 +26,18 @@
   },
   "dependencies": {
     "@google-cloud/storage": "^7.21.0",
+    "@optique/core": "catalog:",
+    "@optique/run": "catalog:",
     "@repo/utils": "workspace:*",
     "lodash-es": "^4.18.1",
     "read-package-up": "^12.0.0",
-    "semver": "^7.8.5",
-    "yargs": "^18.0.0"
+    "semver": "^7.8.5"
   },
   "devDependencies": {
     "@repo/test-config": "workspace:*",
     "@repo/tsconfig": "workspace:*",
     "@types/lodash-es": "^4.17.12",
     "@types/semver": "^7.7.1",
-    "@types/yargs": "^17.0.35",
     "@typescript/native-preview": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"

--- a/packages/@repo/release-notes/README.md
+++ b/packages/@repo/release-notes/README.md
@@ -10,16 +10,16 @@ Run from the repo root with the package binary:
 
 ```bash
 pnpm release-notes generate-changelog \
-  --baseVersion 5.7.0 \
-  --tentativeVersion 5.7.1 \
-  --outputFormat pr-description
+  --base-version 5.7.0 \
+  --tentative-version 5.7.1 \
+  --output-format pr-description
 ```
 
 Arguments:
 
-- `--baseVersion` (required): previous released version, used to select commits.
-- `--tentativeVersion` (required): upcoming version string.
-- `--outputFormat` (optional): set to `pr-description` to print a PR-ready summary.
+- `--base-version` (required): previous released version, used to select commits.
+- `--tentative-version` (required): upcoming version string.
+- `--output-format` (optional): set to `pr-description` to print a PR-ready summary.
 
 ## Environment Variables
 
@@ -39,7 +39,7 @@ The command creates or updates:
 - An API version document referencing the changelog.
 - A content release for the upcoming version.
 
-When `--outputFormat pr-description` is provided, it prints a Markdown summary with a link to edit the draft
+When `--output-format pr-description` is provided, it prints a Markdown summary with a link to edit the draft
 changelog in the admin studio.
 
 ## Development

--- a/packages/@repo/release-notes/bin/release-notes.ts
+++ b/packages/@repo/release-notes/bin/release-notes.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S pnpm tsx
 import {object, or} from '@optique/core/constructs'
-import {message} from '@optique/core/message'
-import {map, optional, withDefault} from '@optique/core/modifiers'
-import {command, constant, option} from '@optique/core/primitives'
+import {message, type Message} from '@optique/core/message'
+import {optional, withDefault} from '@optique/core/modifiers'
+import {command, constant, negatableFlag, option} from '@optique/core/primitives'
 import {choice, integer, string} from '@optique/core/valueparser'
 import {run} from '@optique/run'
 import {readEnv} from '@repo/utils'
@@ -26,8 +26,9 @@ function getAdminStudioUrl(): string {
   return readEnv<KnownEnvVar>('RELEASE_NOTES_ADMIN_STUDIO_URL')
 }
 
-const dryRun = option('--dryRun', {
-  description: message`Dry run`,
+const dryRun = (description: Message) => option('--dry-run', {description})
+const currentBaseVersion = option('--base-version', string(), {
+  description: message`Current base version. E.g. the current version in package.json`,
 })
 
 const parser = or(
@@ -41,20 +42,19 @@ const parser = or(
         }),
       ),
       suffixType: withDefault(
-        option('--suffixType', choice(['timestamp', 'commits-ahead']), {
-          description: message`Prerelease suffix strategy: timestamp (default) or commit count`,
+        option('--suffix-type', choice(['timestamp', 'commits-ahead']), {
+          description: message`Prerelease suffix strategy`,
         }),
         'timestamp' as const,
       ),
-      buildMetadata: map(
-        option('--no-buildMetadata', {
-          description: message`Skip appending +<commitHash> build metadata to the version`,
-        }),
-        (noBuildMetadata) => !noBuildMetadata,
+      buildMetadata: withDefault(
+        negatableFlag(
+          {positive: '--build-metadata', negative: '--no-build-metadata'},
+          {description: message`Append +<commitHash> build metadata to the version`},
+        ),
+        true,
       ),
-      dryRun: option('--dryRun', {
-        description: message`Print the new version without writing files`,
-      }),
+      dryRun: dryRun(message`Print the new version without writing files`),
     }),
     {description: message`Bump version for all monorepo packages based on conventional commits`},
   ),
@@ -65,9 +65,7 @@ const parser = or(
       version: option('--version', string(), {
         description: message`The version to generate the changelog entry for, e.g. 5.19.0`,
       }),
-      dryRun: option('--dryRun', {
-        description: message`Print changelog to stdout without writing files`,
-      }),
+      dryRun: dryRun(message`Print changelog to stdout without writing files`),
     }),
     {description: message`Write CHANGELOG.md entries to root and all public packages`},
   ),
@@ -76,17 +74,17 @@ const parser = or(
     object({
       action: constant('generate-changelog'),
       outputFormat: optional(
-        option('--outputFormat', choice(['pr-description']), {
-          description: message`Output format for changelog generation. Currently only pr-description supported.`,
+        option('--output-format', choice(['pr-description']), {
+          description: message`Output format for changelog generation`,
         }),
       ),
-      baseVersion: option('--baseVersion', string(), {
+      baseVersion: option('--base-version', string(), {
         description: message`Base version for changelog generation. Should be the previous version.`,
       }),
-      tentativeVersion: option('--tentativeVersion', string(), {
+      tentativeVersion: option('--tentative-version', string(), {
         description: message`Tentative next version`,
       }),
-      dryRun,
+      dryRun: dryRun(message`Run without creating or updating release note documents`),
     }),
     {description: message`Generate release note documents for release PR`},
   ),
@@ -94,10 +92,10 @@ const parser = or(
     'publish-releases',
     object({
       action: constant('publish-releases'),
-      targetVersion: option('--targetVersion', string(), {
-        description: message`Version`,
+      targetVersion: option('--target-version', string(), {
+        description: message`Target version to publish releases for`,
       }),
-      dryRun,
+      dryRun: dryRun(message`Run without publishing the changelog or GitHub release`),
     }),
     {
       description: message`Publish pending sanity.io Changelog & github release from the given target version`,
@@ -108,11 +106,9 @@ const parser = or(
     object({
       action: constant('comment-pr-after-merge'),
       commit: option('--commit', string(), {
-        description: message`Version`,
+        description: message`Commit SHA to find the associated PR(s) for`,
       }),
-      baseVersion: option('--baseVersion', string(), {
-        description: message`Current base version. E.g. the current version in package.json`,
-      }),
+      baseVersion: currentBaseVersion,
     }),
     {description: message`Create a comment on the PR(s) associated with a commit`},
   ),
@@ -123,9 +119,7 @@ const parser = or(
     'draft-release-notes',
     object({
       action: constant('draft-release-notes'),
-      baseVersion: option('--baseVersion', string(), {
-        description: message`Current base version. E.g. the current version in package.json`,
-      }),
+      baseVersion: currentBaseVersion,
     }),
     {description: message`Draft release notes`},
   ),
@@ -144,7 +138,13 @@ const parser = or(
   ),
 )
 
-const args = run(parser, {programName: 'release-notes', help: 'both', aboveError: 'usage'})
+const args = run(parser, {
+  programName: 'release-notes',
+  help: {command: true, option: {names: ['-h', '--help']}},
+  aboveError: 'usage',
+  showDefault: true,
+  showChoices: true,
+})
 
 switch (args.action) {
   case 'bump':
@@ -184,7 +184,9 @@ switch (args.action) {
       targetVersion: args.targetVersion,
       dryRun: args.dryRun,
     })
-    console.info('ℹ️ This was a dry run. Nothing has been released.')
+    if (args.dryRun) {
+      console.info('ℹ️ This was a dry run. Nothing has been released.')
+    }
     break
   case 'comment-pr-after-merge':
     await commentPrAfterMerge({

--- a/packages/@repo/release-notes/bin/release-notes.ts
+++ b/packages/@repo/release-notes/bin/release-notes.ts
@@ -1,9 +1,14 @@
 #!/usr/bin/env -S pnpm tsx
+import {object, or} from '@optique/core/constructs'
+import {message} from '@optique/core/message'
+import {map, optional, withDefault} from '@optique/core/modifiers'
+import {command, constant, option} from '@optique/core/primitives'
+import {choice, integer, string} from '@optique/core/valueparser'
+import {run} from '@optique/run'
 import {readEnv} from '@repo/utils'
 import {type DraftId, type PublishedId, type VersionId} from '@sanity/id-utils'
 import {type Commit, type CommitBase, type CommitMeta} from 'conventional-commits-parser'
 import {type pMapSkip} from 'p-map'
-import yargs from 'yargs'
 
 import {bump} from '../src/commands/bump'
 import {commentPrAfterMerge} from '../src/commands/commentPrAfterMerge'
@@ -21,226 +26,183 @@ function getAdminStudioUrl(): string {
   return readEnv<KnownEnvVar>('RELEASE_NOTES_ADMIN_STUDIO_URL')
 }
 
-await yargs(process.argv.slice(2))
-  .strict()
-  .usage('$0 <command>')
-  .command({
-    command: 'bump',
-    describe: 'Bump version for all monorepo packages based on conventional commits',
-    builder: (cmd) =>
-      cmd.options({
-        preid: {
-          description: 'Prerelease identifier (e.g. next, canary, next-major)',
-          type: 'string',
-        },
-        suffixType: {
-          description: 'Prerelease suffix strategy: timestamp (default) or commit count',
-          type: 'string',
-          choices: ['timestamp', 'commits-ahead'] as const,
-          default: 'timestamp' as const,
-        },
-        buildMetadata: {
-          description: 'Append +<commitHash> build metadata to the version (default: true)',
-          type: 'boolean',
-          default: true,
-        },
-        dryRun: {
-          description: 'Print the new version without writing files',
-          type: 'boolean',
-        },
-      }),
-    handler: async (args) => {
-      try {
-        await bump({
-          preid: args.preid,
-          suffixType: args.suffixType,
-          buildMetadata: args.buildMetadata,
-          dryRun: args.dryRun,
-        })
-      } catch (error) {
-        console.error(error)
-        process.exit(1)
-      }
-    },
-  })
-  .command({
-    command: 'write-changelog-files',
-    describe: 'Write CHANGELOG.md entries to root and all public packages',
-    builder: (cmd) =>
-      cmd.version(false).options({
-        version: {
-          description: 'The version to generate the changelog entry for, e.g. 5.19.0',
-          type: 'string',
-          demandOption: true,
-        },
-        dryRun: {
-          description: 'Print changelog to stdout without writing files',
-          type: 'boolean',
-        },
-      }),
-    handler: async (args) => {
-      try {
-        await writeChangelogFiles({
-          version: args.version,
-          dryRun: args.dryRun,
-        })
-      } catch (error) {
-        console.error(error)
-        process.exit(1)
-      }
-    },
-  })
-  .command({
-    command: 'generate-changelog',
-    describe: 'Generate release note documents for release PR',
-    builder: (cmd) =>
-      cmd.options({
-        outputFormat: {
-          type: 'string',
-          demandOption: false,
-          description:
-            'Output format for changelog generation. Currently only `pr-description` supported.',
-          enum: [
-            // outputs PR summary description
-            'pr-description',
-          ],
-        },
-        baseVersion: {
-          description: 'Base version for changelog generation. Should be the previous version.',
-          type: 'string',
-          demandOption: true,
-        },
-        tentativeVersion: {
-          description: 'Tentative next version',
-          type: 'string',
-          demandOption: true,
-        },
-        dryRun: {
-          description: 'Dry run',
-          type: 'boolean',
-        },
-      }),
-    handler: async (args) => {
-      try {
-        const result = await createOrUpdateChangelogDocs({
-          baseVersion: args.baseVersion,
-          tentativeVersion: args.tentativeVersion,
-          dryRun: args.dryRun,
-        })
-        if (args.outputFormat === 'pr-description') {
-          console.log(
-            generateChangeLogSummary(
-              {tentativeVersion: args.tentativeVersion, baseVersion: args.baseVersion},
-              result,
-            ),
-          )
-        } else {
-          console.log(result)
-        }
-      } catch (error) {
-        console.error(error)
-        process.exit(1)
-      }
-    },
-  })
-  .command({
-    command: 'publish-releases',
-    describe: 'Publish pending sanity.io Changelog & github release from the given target version',
-    builder: (cmd) =>
-      cmd.options({
-        targetVersion: {
-          description: 'Version',
-          type: 'string',
-          demandOption: true,
-        },
-        dryRun: {
-          description: 'Dry run',
-          type: 'boolean',
-        },
-      }),
-    handler: async (args) => {
-      try {
-        await publishReleases({
-          targetVersion: args.targetVersion,
-          dryRun: Boolean(args.dryRun),
-        })
-        console.info('ℹ️ This was a dry run. Nothing has been released.')
-      } catch (error) {
-        console.error(error)
-        process.exit(1)
-      }
-    },
-  })
-  .command({
-    command: 'comment-pr-after-merge',
-    describe: 'Create a comment on the PR(s) associated with a commit',
-    builder: (cmd) =>
-      cmd.options({
-        commit: {
-          description: 'Version',
-          type: 'string',
-          demandOption: true,
-        },
-        baseVersion: {
-          description: 'Current base version. E.g. the current version in package.json',
-          type: 'string',
-          demandOption: true,
-        },
-      }),
-    handler: async (args) => {
-      try {
-        await commentPrAfterMerge({
-          baseVersion: args.baseVersion,
-          commit: args.commit,
-          adminStudioBaseUrl: getAdminStudioUrl(),
-        })
-      } catch (error) {
-        console.error(error)
-        process.exit(1)
-      }
-    },
-  })
-  .command({
-    command: 'status-check-prs',
-    describe: 'Update in-flight release status checks for all open PRs',
-    handler: () => writePrChecks().then(() => void 0),
-  })
-  .command({
-    command: 'draft-release-notes',
+const dryRun = option('--dryRun', {
+  description: message`Dry run`,
+})
 
-    describe: 'Draft release notes',
-    builder: (cmd) =>
-      cmd.options({
-        baseVersion: {
-          description: 'Current base version. E.g. the current version in package.json',
-          type: 'string',
-          demandOption: true,
-        },
+const parser = or(
+  command(
+    'bump',
+    object({
+      action: constant('bump'),
+      preid: optional(
+        option('--preid', string(), {
+          description: message`Prerelease identifier (e.g. next, canary, next-major)`,
+        }),
+      ),
+      suffixType: withDefault(
+        option('--suffixType', choice(['timestamp', 'commits-ahead']), {
+          description: message`Prerelease suffix strategy: timestamp (default) or commit count`,
+        }),
+        'timestamp' as const,
+      ),
+      buildMetadata: map(
+        option('--no-buildMetadata', {
+          description: message`Skip appending +<commitHash> build metadata to the version`,
+        }),
+        (noBuildMetadata) => !noBuildMetadata,
+      ),
+      dryRun: option('--dryRun', {
+        description: message`Print the new version without writing files`,
       }),
-    handler: (args) => draftReleaseNotes({baseVersion: args.baseVersion}).then(() => void 0),
-  })
-  .command({
-    command: 'status-check-commit',
-    describe: 'Update in-flight release status checks for a single commit',
-    builder: (cmd) =>
-      cmd.options({
-        commit: {
-          description: 'Head commit to run check on',
-          type: 'string',
-          demandOption: true,
-        },
-        pr: {
-          description: 'Current pull request',
-          type: 'number',
-          demandOption: true,
-        },
+    }),
+    {description: message`Bump version for all monorepo packages based on conventional commits`},
+  ),
+  command(
+    'write-changelog-files',
+    object({
+      action: constant('write-changelog-files'),
+      version: option('--version', string(), {
+        description: message`The version to generate the changelog entry for, e.g. 5.19.0`,
       }),
-    handler: (args) =>
-      writeCommitCheck({commit: args.commit, currentPrNumber: args.pr}).then(() => void 0),
-  })
-  .demandCommand(1, 'must provide a valid command')
-  .help('h')
-  .alias('h', 'help').argv
+      dryRun: option('--dryRun', {
+        description: message`Print changelog to stdout without writing files`,
+      }),
+    }),
+    {description: message`Write CHANGELOG.md entries to root and all public packages`},
+  ),
+  command(
+    'generate-changelog',
+    object({
+      action: constant('generate-changelog'),
+      outputFormat: optional(
+        option('--outputFormat', choice(['pr-description']), {
+          description: message`Output format for changelog generation. Currently only pr-description supported.`,
+        }),
+      ),
+      baseVersion: option('--baseVersion', string(), {
+        description: message`Base version for changelog generation. Should be the previous version.`,
+      }),
+      tentativeVersion: option('--tentativeVersion', string(), {
+        description: message`Tentative next version`,
+      }),
+      dryRun,
+    }),
+    {description: message`Generate release note documents for release PR`},
+  ),
+  command(
+    'publish-releases',
+    object({
+      action: constant('publish-releases'),
+      targetVersion: option('--targetVersion', string(), {
+        description: message`Version`,
+      }),
+      dryRun,
+    }),
+    {
+      description: message`Publish pending sanity.io Changelog & github release from the given target version`,
+    },
+  ),
+  command(
+    'comment-pr-after-merge',
+    object({
+      action: constant('comment-pr-after-merge'),
+      commit: option('--commit', string(), {
+        description: message`Version`,
+      }),
+      baseVersion: option('--baseVersion', string(), {
+        description: message`Current base version. E.g. the current version in package.json`,
+      }),
+    }),
+    {description: message`Create a comment on the PR(s) associated with a commit`},
+  ),
+  command('status-check-prs', object({action: constant('status-check-prs')}), {
+    description: message`Update in-flight release status checks for all open PRs`,
+  }),
+  command(
+    'draft-release-notes',
+    object({
+      action: constant('draft-release-notes'),
+      baseVersion: option('--baseVersion', string(), {
+        description: message`Current base version. E.g. the current version in package.json`,
+      }),
+    }),
+    {description: message`Draft release notes`},
+  ),
+  command(
+    'status-check-commit',
+    object({
+      action: constant('status-check-commit'),
+      commit: option('--commit', string(), {
+        description: message`Head commit to run check on`,
+      }),
+      pr: option('--pr', integer(), {
+        description: message`Current pull request`,
+      }),
+    }),
+    {description: message`Update in-flight release status checks for a single commit`},
+  ),
+)
+
+const args = run(parser, {programName: 'release-notes', help: 'both', aboveError: 'usage'})
+
+switch (args.action) {
+  case 'bump':
+    await bump({
+      preid: args.preid,
+      suffixType: args.suffixType,
+      buildMetadata: args.buildMetadata,
+      dryRun: args.dryRun,
+    })
+    break
+  case 'write-changelog-files':
+    await writeChangelogFiles({
+      version: args.version,
+      dryRun: args.dryRun,
+    })
+    break
+  case 'generate-changelog': {
+    const result = await createOrUpdateChangelogDocs({
+      baseVersion: args.baseVersion,
+      tentativeVersion: args.tentativeVersion,
+      dryRun: args.dryRun,
+    })
+    if (args.outputFormat === 'pr-description') {
+      console.log(
+        generateChangeLogSummary(
+          {tentativeVersion: args.tentativeVersion, baseVersion: args.baseVersion},
+          result,
+        ),
+      )
+    } else {
+      console.log(result)
+    }
+    break
+  }
+  case 'publish-releases':
+    await publishReleases({
+      targetVersion: args.targetVersion,
+      dryRun: args.dryRun,
+    })
+    console.info('ℹ️ This was a dry run. Nothing has been released.')
+    break
+  case 'comment-pr-after-merge':
+    await commentPrAfterMerge({
+      baseVersion: args.baseVersion,
+      commit: args.commit,
+      adminStudioBaseUrl: getAdminStudioUrl(),
+    })
+    break
+  case 'status-check-prs':
+    await writePrChecks()
+    break
+  case 'draft-release-notes':
+    await draftReleaseNotes({baseVersion: args.baseVersion})
+    break
+  case 'status-check-commit':
+    await writeCommitCheck({commit: args.commit, currentPrNumber: args.pr})
+    break
+}
 
 type GenerateChangeLogResult = {
   success?: boolean

--- a/packages/@repo/release-notes/package.json
+++ b/packages/@repo/release-notes/package.json
@@ -29,6 +29,8 @@
     "@anthropic-ai/sdk": "^0.105.0",
     "@conventional-changelog/git-client": "^2.7.0",
     "@octokit/rest": "^22.0.1",
+    "@optique/core": "catalog:",
+    "@optique/run": "catalog:",
     "@portabletext/toolkit": "^5.0.2",
     "@sanity/client": "catalog:",
     "@sanity/id-utils": "^1.0.0",
@@ -43,8 +45,7 @@
     "lodash-es": "^4.18.1",
     "p-map": "^7.0.4",
     "semver": "^7.8.5",
-    "turndown": "^7.2.4",
-    "yargs": "^18.0.0"
+    "turndown": "^7.2.4"
   },
   "devDependencies": {
     "@portabletext/markdown": "^1.4.3",
@@ -54,7 +55,6 @@
     "@types/lodash-es": "^4.17.12",
     "@types/semver": "^7.7.1",
     "@types/turndown": "^5.0.6",
-    "@types/yargs": "^17.0.35",
     "@typescript/native-preview": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,12 @@ settings:
 
 catalogs:
   default:
+    '@optique/core':
+      specifier: ^1.1.1
+      version: 1.1.1
+    '@optique/run':
+      specifier: ^1.1.1
+      version: 1.1.1
     '@playwright/test':
       specifier: 1.61.1
       version: 1.61.1
@@ -131,10 +137,10 @@ importers:
         version: 4.1.0
       esbuild-register:
         specifier: 'catalog:'
-        version: 3.6.0(esbuild@0.28.1)(supports-color@8.1.1)
+        version: 3.6.0(esbuild@0.28.1)
       eslint-import-resolver-typescript:
         specifier: ^4.4.5
-        version: 4.4.5(eslint@10.5.0)(supports-color@8.1.1)
+        version: 4.4.5(eslint@10.5.0)
       eslint-plugin-boundaries:
         specifier: ^6.0.2
         version: 6.0.2(eslint-import-resolver-typescript@4.4.5)(eslint@10.5.0)
@@ -143,10 +149,10 @@ importers:
         version: 6.1.5
       eslint-plugin-testing-library:
         specifier: ^7.16.2
-        version: 7.16.2(eslint@10.5.0)(supports-color@8.1.1)(typescript@6.0.3)
+        version: 7.16.2(eslint@10.5.0)(typescript@6.0.3)
       eslint-plugin-tsdoc:
         specifier: ^0.5.2
-        version: 0.5.2(eslint@10.5.0)(supports-color@8.1.1)(typescript@6.0.3)
+        version: 0.5.2(eslint@10.5.0)(typescript@6.0.3)
       knip:
         specifier: ^6.21.0
         version: 6.21.0
@@ -188,7 +194,7 @@ importers:
         version: 0.28.19(typescript@6.0.3)
       vercel:
         specifier: ^54.17.3
-        version: 54.17.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)(supports-color@8.1.1)
+        version: 54.17.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)
       vite:
         specifier: 'catalog:'
         version: 8.1.2(@types/node@24.13.2)(@vitejs/devtools@0.3.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -316,6 +322,12 @@ importers:
         specifier: ^4.22.4
         version: 4.22.4
     devDependencies:
+      '@optique/core':
+        specifier: 'catalog:'
+        version: 1.1.1
+      '@optique/run':
+        specifier: 'catalog:'
+        version: 1.1.1
       '@repo/utils':
         specifier: workspace:*
         version: link:../../packages/@repo/utils
@@ -328,9 +340,6 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
-      '@types/yargs':
-        specifier: ^17.0.35
-        version: 17.0.35
       babel-plugin-react-compiler:
         specifier: 'catalog:'
         version: 1.0.0
@@ -364,9 +373,6 @@ importers:
       tinyglobby:
         specifier: ^0.2.17
         version: 0.2.17
-      yargs:
-        specifier: ^18.0.0
-        version: 18.0.0
 
   dev/embedded-studio:
     dependencies:
@@ -554,7 +560,7 @@ importers:
     dependencies:
       '@portabletext/editor':
         specifier: ^7.10.1
-        version: 7.10.1(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+        version: 7.10.1(@types/react@19.2.17)(react@19.2.7)
       '@portabletext/html':
         specifier: ^1.1.0
         version: 1.1.0
@@ -596,7 +602,7 @@ importers:
         version: 2.2.2(react@19.2.7)
       '@sanity/migrate':
         specifier: 'catalog:'
-        version: 7.0.3(@oclif/core@4.11.7)(@sanity/cli-core@2.2.1)(supports-color@8.1.1)(xstate@5.32.2)
+        version: 7.0.3(@oclif/core@4.11.7)(@sanity/cli-core@2.2.1)(xstate@5.32.2)
       '@sanity/preview-url-secret':
         specifier: ^4.0.7
         version: 4.0.7(@sanity/client@7.23.0)
@@ -730,6 +736,12 @@ importers:
       '@google-cloud/storage':
         specifier: ^7.21.0
         version: 7.21.0
+      '@optique/core':
+        specifier: 'catalog:'
+        version: 1.1.1
+      '@optique/run':
+        specifier: 'catalog:'
+        version: 1.1.1
       '@repo/utils':
         specifier: workspace:*
         version: link:../utils
@@ -742,9 +754,6 @@ importers:
       semver:
         specifier: ^7.8.5
         version: 7.8.5
-      yargs:
-        specifier: ^18.0.0
-        version: 18.0.0
     devDependencies:
       '@repo/test-config':
         specifier: workspace:*
@@ -758,9 +767,6 @@ importers:
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1
-      '@types/yargs':
-        specifier: ^17.0.35
-        version: 17.0.35
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260421.2
@@ -848,7 +854,7 @@ importers:
         version: link:../tsconfig
       '@sanity/pkg-utils':
         specifier: 'catalog:'
-        version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(supports-color@8.1.1)(typescript@6.0.3)
+        version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -864,6 +870,12 @@ importers:
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
+      '@optique/core':
+        specifier: 'catalog:'
+        version: 1.1.1
+      '@optique/run':
+        specifier: 'catalog:'
+        version: 1.1.1
       '@portabletext/toolkit':
         specifier: ^5.0.2
         version: 5.0.2
@@ -909,9 +921,6 @@ importers:
       turndown:
         specifier: ^7.2.4
         version: 7.2.4
-      yargs:
-        specifier: ^18.0.0
-        version: 18.0.0
     devDependencies:
       '@portabletext/markdown':
         specifier: ^1.4.3
@@ -934,9 +943,6 @@ importers:
       '@types/turndown':
         specifier: ^5.0.6
         version: 5.0.6
-      '@types/yargs':
-        specifier: ^17.0.35
-        version: 17.0.35
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260421.2
@@ -1077,7 +1083,7 @@ importers:
         version: link:../../@repo/tsconfig
       '@sanity/pkg-utils':
         specifier: 'catalog:'
-        version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(supports-color@8.1.1)(typescript@6.0.3)
+        version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260421.2
@@ -1114,7 +1120,7 @@ importers:
         version: link:../../@repo/tsconfig
       '@sanity/pkg-utils':
         specifier: 'catalog:'
-        version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(supports-color@8.1.1)(typescript@6.0.3)
+        version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@types/debug':
         specifier: ^4.1.13
         version: 4.1.13
@@ -1181,7 +1187,7 @@ importers:
         version: 5.0.0(react@19.2.7)
       '@sanity/pkg-utils':
         specifier: 'catalog:'
-        version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(supports-color@8.1.1)(typescript@6.0.3)
+        version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -1227,7 +1233,7 @@ importers:
         version: 3.0.8(@sanity/types@packages+@sanity+types)(react-dom@19.2.7)(react@19.2.7)(styled-components@6.4.2)
       '@sanity/pkg-utils':
         specifier: 'catalog:'
-        version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(supports-color@8.1.1)(typescript@6.0.3)
+        version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -1282,7 +1288,7 @@ importers:
         version: link:../../@repo/tsconfig
       '@sanity/pkg-utils':
         specifier: 'catalog:'
-        version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(supports-color@8.1.1)(typescript@6.0.3)
+        version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -1454,7 +1460,7 @@ importers:
         version: link:../@repo/tsconfig
       '@sanity/pkg-utils':
         specifier: 'catalog:'
-        version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(supports-color@8.1.1)(typescript@6.0.3)
+        version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -1493,7 +1499,7 @@ importers:
         version: 3.13.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)
       '@portabletext/editor':
         specifier: ^7.10.1
-        version: 7.10.1(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+        version: 7.10.1(@types/react@19.2.17)(react@19.2.7)
       '@portabletext/html':
         specifier: ^1.1.0
         version: 1.1.0
@@ -1586,7 +1592,7 @@ importers:
         version: 0.23.0
       '@sanity/migrate':
         specifier: 'catalog:'
-        version: 7.0.3(@oclif/core@4.11.7)(@sanity/cli-core@2.2.1)(supports-color@8.1.1)(xstate@5.32.2)
+        version: 7.0.3(@oclif/core@4.11.7)(@sanity/cli-core@2.2.1)(xstate@5.32.2)
       '@sanity/mutate':
         specifier: ^0.18.1
         version: 0.18.1(xstate@5.32.2)
@@ -4000,6 +4006,14 @@ packages:
     resolution: {integrity: sha512-/v61xAfj3e3g14UDP9qriYgkifLuSwALrhcSiY3SfuzzDJ5pRBsfp//Ih3daJlUMrODvB6IUk7dGfxgnRwcxjg==}
     engines: {node: '>= 12'}
 
+  '@optique/core@1.1.1':
+    resolution: {integrity: sha512-tbZLdH5wEnh8IRG8KTmWPZCKHLmD4bXigoPdzoSUVi+V46qZTNEaTdqtR7EuEwhbPI0KQjLSYRZCxFTdr9OZkA==}
+    engines: {bun: '>=1.2.0', deno: '>=2.3.0', node: '>=20.0.0'}
+
+  '@optique/run@1.1.1':
+    resolution: {integrity: sha512-jSZeuiljDEWYkQ67bVDucRknzFVwiSH1j4ho2jFWfcdMMa+WDRSfZA3GZoHA8zKj0Bf6UbJ+FMs/2IReQ0KYNQ==}
+    engines: {bun: '>=1.2.0', deno: '>=2.3.0', node: '>=20.0.0'}
+
   '@oxc-parser/binding-android-arm-eabi@0.132.0':
     resolution: {integrity: sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6118,12 +6132,6 @@ packages:
   '@types/wicg-task-scheduling@2024.1.0':
     resolution: {integrity: sha512-9g5QVDU8Na3P6rPMbyYx5pS8UpGDfzys8T7Xq5HMTbI7elSq/YioGbBVAh2u67JGNTThZ3o9PK0/qBvaVOYPYQ==}
 
-  '@types/yargs-parser@21.0.3':
-    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
-
-  '@types/yargs@17.0.35':
-    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
-
   '@typescript-eslint/project-service@8.56.1':
     resolution: {integrity: sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -7138,10 +7146,6 @@ packages:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
 
-  cliui@9.0.1:
-    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
-    engines: {node: '>=20'}
-
   clone-deep@4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
     engines: {node: '>=6'}
@@ -8026,10 +8030,6 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
-
-  get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
@@ -11245,10 +11245,6 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
-  y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
-
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -11267,14 +11263,6 @@ packages:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
-
-  yargs-parser@22.0.0:
-    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
-  yargs@18.0.0:
-    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yauzl-clone@1.0.4:
     resolution: {integrity: sha512-igM2RRCf3k8TvZoxR2oguuw4z1xasOnA31joCqHIyLkeWrvAc2Jgay5ISQ2ZplinkoGaJ6orCz56Ey456c5ESA==}
@@ -13537,6 +13525,12 @@ snapshots:
       estree-walker: 2.0.2
       magic-string: 0.30.21
 
+  '@optique/core@1.1.1': {}
+
+  '@optique/run@1.1.1':
+    dependencies:
+      '@optique/core': 1.1.1
+
   '@oxc-parser/binding-android-arm-eabi@0.132.0':
     optional: true
 
@@ -13947,7 +13941,7 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@portabletext/editor@7.10.1(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)':
+  '@portabletext/editor@7.10.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@portabletext/html': 1.1.0
       '@portabletext/keyboard-shortcuts': 2.1.3
@@ -13984,7 +13978,7 @@ snapshots:
 
   '@portabletext/plugin-character-pair-decorator@8.0.28(@portabletext/editor@7.10.1)(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.1(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.1(@types/react@19.2.17)(react@19.2.7)
       '@xstate/react': 6.1.0(@types/react@19.2.17)(react@19.2.7)(xstate@5.32.2)
       react: 19.2.7
       xstate: 5.32.2
@@ -13993,12 +13987,12 @@ snapshots:
 
   '@portabletext/plugin-dnd@1.0.13(@portabletext/editor@7.10.1)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.1(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.1(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
 
   '@portabletext/plugin-input-rule@5.0.28(@portabletext/editor@7.10.1)(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.1(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.1(@types/react@19.2.17)(react@19.2.7)
       '@xstate/react': 6.1.0(@types/react@19.2.17)(react@19.2.7)(xstate@5.32.2)
       react: 19.2.7
       xstate: 5.32.2
@@ -14007,12 +14001,12 @@ snapshots:
 
   '@portabletext/plugin-list-index@1.0.13(@portabletext/editor@7.10.1)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.1(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.1(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
 
   '@portabletext/plugin-markdown-shortcuts@8.0.28(@portabletext/editor@7.10.1)(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.1(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.1(@types/react@19.2.17)(react@19.2.7)
       '@portabletext/plugin-character-pair-decorator': 8.0.28(@portabletext/editor@7.10.1)(@types/react@19.2.17)(react@19.2.7)
       '@portabletext/plugin-input-rule': 5.0.28(@portabletext/editor@7.10.1)(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
@@ -14021,17 +14015,17 @@ snapshots:
 
   '@portabletext/plugin-one-line@7.0.28(@portabletext/editor@7.10.1)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.1(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.1(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
 
   '@portabletext/plugin-paste-link@4.0.28(@portabletext/editor@7.10.1)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.1(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.1(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
 
   '@portabletext/plugin-typography@8.0.28(@portabletext/editor@7.10.1)(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.1(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.1(@types/react@19.2.17)(react@19.2.7)
       '@portabletext/plugin-input-rule': 5.0.28(@portabletext/editor@7.10.1)(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
     transitivePeerDependencies:
@@ -14535,7 +14529,7 @@ snapshots:
       '@sanity/generate-help-url': 4.0.0
       '@sanity/id-utils': 1.0.0
       '@sanity/import': 6.0.3(@sanity/client@7.23.0)
-      '@sanity/migrate': 7.0.3(@oclif/core@4.11.7)(@sanity/cli-core@2.2.1)(supports-color@8.1.1)(xstate@5.32.2)
+      '@sanity/migrate': 7.0.3(@oclif/core@4.11.7)(@sanity/cli-core@2.2.1)(xstate@5.32.2)
       '@sanity/runtime-cli': 17.0.0(@types/node@24.13.2)(@vitejs/devtools@0.3.3)(esbuild@0.28.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       '@sanity/schema': link:packages/@sanity/schema
       '@sanity/telemetry': 1.1.0(react@19.2.7)
@@ -14889,7 +14883,7 @@ snapshots:
     dependencies:
       '@sanity/comlink': 4.0.1
 
-  '@sanity/migrate@7.0.3(@oclif/core@4.11.7)(@sanity/cli-core@2.2.1)(supports-color@8.1.1)(xstate@5.32.2)':
+  '@sanity/migrate@7.0.3(@oclif/core@4.11.7)(@sanity/cli-core@2.2.1)(xstate@5.32.2)':
     dependencies:
       '@oclif/core': 4.11.7
       '@sanity/cli-core': 2.2.1(@noble/hashes@2.2.0)(@types/node@24.13.2)(@vitejs/devtools@0.3.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)
@@ -14963,64 +14957,7 @@ snapshots:
       rolldown: 1.1.3
       rolldown-plugin-dts: 0.26.0(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.21.3)(rolldown@1.1.3)(typescript@6.0.3)
       rollup: 4.62.2
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.28.1)(rollup@4.62.2)(supports-color@8.1.1)
-      rxjs: 7.8.2
-      treeify: 1.1.0
-      tsx: 4.22.4
-      typescript: 6.0.3
-      zod: 4.4.3
-      zod-validation-error: 5.0.0(zod@4.4.3)
-    optionalDependencies:
-      babel-plugin-react-compiler: 1.0.0
-    transitivePeerDependencies:
-      - '@ts-macro/tsc'
-      - '@types/babel__core'
-      - '@types/node'
-      - '@typescript/native-preview'
-      - babel-plugin-macros
-      - oxc-resolver
-      - supports-color
-      - vue-tsc
-
-  '@sanity/pkg-utils@10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(supports-color@8.1.1)(typescript@6.0.3)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
-      '@microsoft/api-extractor': 7.58.9(@types/node@24.13.2)
-      '@microsoft/tsdoc-config': 0.18.1
-      '@optimize-lodash/rollup-plugin': 6.0.0(rollup@4.62.2)
-      '@rollup/plugin-alias': 6.0.0(rollup@4.62.2)
-      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)(rollup@4.62.2)
-      '@rollup/plugin-commonjs': 29.0.3(rollup@4.62.2)
-      '@rollup/plugin-json': 6.1.0(rollup@4.62.2)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.62.2)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.62.2)
-      '@rollup/plugin-terser': 1.0.0(rollup@4.62.2)
-      '@sanity/browserslist-config': 1.0.5
-      '@sanity/parse-package-json': 2.2.1
-      '@vanilla-extract/rollup-plugin': 1.5.3(babel-plugin-macros@3.1.0)(rollup@4.62.2)
-      browserslist: 4.28.4
-      cac: 7.0.0
-      chalk: 5.6.2
-      chokidar: 5.0.0
-      empathic: 2.0.1
-      esbuild: 0.28.1
-      find-config: 1.0.0
-      get-latest-version: 6.0.1
-      git-url-parse: 16.1.0
-      globby: 16.2.0
-      jsonc-parser: 3.3.1
-      lightningcss: 1.32.0
-      mkdirp: 3.0.1
-      outdent: 0.8.0
-      prettier: 3.8.4
-      pretty-bytes: 7.1.0
-      prompts: 2.4.2
-      rimraf: 6.1.3
-      rolldown: 1.1.3
-      rolldown-plugin-dts: 0.26.0(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.21.3)(rolldown@1.1.3)(typescript@6.0.3)
-      rollup: 4.62.2
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.28.1)(rollup@4.62.2)(supports-color@8.1.1)
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.28.1)(rollup@4.62.2)
       rxjs: 7.8.2
       treeify: 1.1.0
       tsx: 4.22.4
@@ -15666,13 +15603,7 @@ snapshots:
 
   '@types/wicg-task-scheduling@2024.1.0': {}
 
-  '@types/yargs-parser@21.0.3': {}
-
-  '@types/yargs@17.0.35':
-    dependencies:
-      '@types/yargs-parser': 21.0.3
-
-  '@typescript-eslint/project-service@8.56.1(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.56.1(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.61.1
@@ -15681,7 +15612,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.61.1(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.61.1(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.61.1
@@ -15712,9 +15643,9 @@ snapshots:
 
   '@typescript-eslint/types@8.61.1': {}
 
-  '@typescript-eslint/typescript-estree@8.56.1(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.56.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.56.1(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.56.1(typescript@6.0.3)
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
@@ -15727,9 +15658,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.61.1(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.61.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.61.1(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.61.1(typescript@6.0.3)
       '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.61.1
       '@typescript-eslint/visitor-keys': 8.61.1
@@ -15742,23 +15673,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.56.1(eslint@10.5.0)(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.56.1(eslint@10.5.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@6.0.3)
       eslint: 10.5.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.61.1(eslint@10.5.0)(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.61.1(eslint@10.5.0)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0)
       '@typescript-eslint/scope-manager': 8.61.1
       '@typescript-eslint/types': 8.61.1
-      '@typescript-eslint/typescript-estree': 8.61.1(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
       eslint: 10.5.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -17051,12 +16982,6 @@ snapshots:
 
   cli-width@4.1.0: {}
 
-  cliui@9.0.1:
-    dependencies:
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-      wrap-ansi: 9.0.2
-
   clone-deep@4.0.1:
     dependencies:
       is-plain-object: 2.0.4
@@ -17503,7 +17428,7 @@ snapshots:
 
   es-toolkit@1.49.0: {}
 
-  esbuild-register@3.6.0(esbuild@0.28.1)(supports-color@8.1.1):
+  esbuild-register@3.6.0(esbuild@0.28.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       esbuild: 0.28.1
@@ -17597,7 +17522,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.4.5(eslint@10.5.0)(supports-color@8.1.1):
+  eslint-import-resolver-typescript@4.4.5(eslint@10.5.0):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.5.0(jiti@2.7.0)
@@ -17616,7 +17541,7 @@ snapshots:
     optionalDependencies:
       eslint: 10.5.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 4.4.5(eslint@10.5.0)(supports-color@8.1.1)
+      eslint-import-resolver-typescript: 4.4.5(eslint@10.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17639,20 +17564,20 @@ snapshots:
     dependencies:
       requireindex: 1.1.0
 
-  eslint-plugin-testing-library@7.16.2(eslint@10.5.0)(supports-color@8.1.1)(typescript@6.0.3):
+  eslint-plugin-testing-library@7.16.2(eslint@10.5.0)(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/scope-manager': 8.61.1
-      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0)(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0)(typescript@6.0.3)
       eslint: 10.5.0(jiti@2.7.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-tsdoc@0.5.2(eslint@10.5.0)(supports-color@8.1.1)(typescript@6.0.3):
+  eslint-plugin-tsdoc@0.5.2(eslint@10.5.0)(typescript@6.0.3):
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@typescript-eslint/utils': 8.56.1(eslint@10.5.0)(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@10.5.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -18028,8 +17953,6 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
-  get-caller-file@2.0.5: {}
-
   get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
@@ -18089,7 +18012,7 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  get-uri@6.0.5(supports-color@8.1.1):
+  get-uri@6.0.5:
     dependencies:
       basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
@@ -19413,12 +19336,12 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  pac-proxy-agent@7.2.0(supports-color@8.1.1):
+  pac-proxy-agent@7.2.0:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
-      get-uri: 6.0.5(supports-color@8.1.1)
+      get-uri: 6.0.5
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       pac-resolver: 7.0.1
@@ -19637,14 +19560,14 @@ snapshots:
 
   protocols@2.0.2: {}
 
-  proxy-agent@6.4.0(supports-color@8.1.1):
+  proxy-agent@6.4.0:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
-      pac-proxy-agent: 7.2.0(supports-color@8.1.1)
+      pac-proxy-agent: 7.2.0
       proxy-from-env: 1.1.0
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
@@ -20060,7 +19983,7 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.3
       '@rolldown/binding-win32-x64-msvc': 1.1.3
 
-  rollup-plugin-esbuild@6.2.1(esbuild@0.28.1)(rollup@4.62.2)(supports-color@8.1.1):
+  rollup-plugin-esbuild@6.2.1(esbuild@0.28.1)(rollup@4.62.2):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
@@ -20137,7 +20060,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sandbox@3.1.2(supports-color@8.1.1):
+  sandbox@3.1.2:
     dependencies:
       '@vercel/sandbox': 2.1.1
       async-retry: 1.3.3
@@ -20971,7 +20894,7 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vercel@54.17.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)(supports-color@8.1.1):
+  vercel@54.17.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2):
     dependencies:
       '@vercel/backends': 0.8.18(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(rollup@4.62.2)
       '@vercel/blob': 2.4.0
@@ -21004,8 +20927,8 @@ snapshots:
       form-data: 4.0.6
       jose: 5.9.6
       luxon: 3.7.2
-      proxy-agent: 6.4.0(supports-color@8.1.1)
-      sandbox: 3.1.2(supports-color@8.1.1)
+      proxy-agent: 6.4.0
+      sandbox: 3.1.2
       smol-toml: 1.5.2
       zod: 4.1.11
     transitivePeerDependencies:
@@ -21023,7 +20946,7 @@ snapshots:
       es-module-lexer: 2.1.0
       obug: 2.1.3
       pathe: 2.0.3
-      vite: 8.1.2(@types/node@24.13.2)(@vitejs/devtools@0.3.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.1.3(@types/node@24.13.2)(@vitejs/devtools@0.3.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -21255,8 +21178,6 @@ snapshots:
 
   xtend@4.0.2: {}
 
-  y18n@5.0.8: {}
-
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
@@ -21266,17 +21187,6 @@ snapshots:
   yaml@1.10.3: {}
 
   yaml@2.9.0: {}
-
-  yargs-parser@22.0.0: {}
-
-  yargs@18.0.0:
-    dependencies:
-      cliui: 9.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      string-width: 7.2.0
-      y18n: 5.0.8
-      yargs-parser: 22.0.0
 
   yauzl-clone@1.0.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,8 @@ allowBuilds:
   unrs-resolver: false
 
 catalog:
+  '@optique/core': ^1.1.1
+  '@optique/run': ^1.1.1
   '@playwright/test': 1.61.1
   '@rolldown/plugin-babel': ^0.2.3
   '@sanity/client': ^7.23.0


### PR DESCRIPTION
### Description

Migrates our internal CLIs from yargs to [Optique](https://optique.dev/)

### What to review
Should not change behavior in any significant way. Also standardizes on `--kebab-case` for cli flags


### Notes for release
n/a – only affects internal CLIs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release and next-publish automation entrypoints and renames CLI flags, so any scripts still using camelCase flags will break; behavior is intended to stay the same aside from the publish-releases dry-run message fix.
> 
> **Overview**
> Replaces **yargs** with [**Optique**](https://optique.dev/) (`@optique/core`, `@optique/run`) for internal CLIs: `release-notes`, `bundle-manager`, and the `efps` perf runner. **yargs** is removed from those packages and added to the pnpm catalog for Optique.
> 
> CLI flags are standardized to **`--kebab-case`** (e.g. `--base-version`, `--suffix-type`, `--output-format`, `--target-version`). **GitHub Actions** workflows that invoke `release-notes` are updated to match.
> 
> `release-notes` and `bundle-manager` now use Optique `or`/`command` parsers and a top-level `switch` on `args.action` instead of yargs `.command()` handlers. **`publish-releases`** only prints the dry-run notice when `--dry-run` is set (previously it always logged that line).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b481c2ceae205428a59d96a4311ef15148a032d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->