### PR TITLE
feat(variants): prevent variant deletion when it has documents

### DIFF
--- a/packages/sanity/src/core/variants/hooks/__tests__/useVariantDeleteAction.test.ts
+++ b/packages/sanity/src/core/variants/hooks/__tests__/useVariantDeleteAction.test.ts
@@ -1,0 +1,121 @@
+import {act, renderHook, waitFor} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {variantAlphaAudience} from '../../__fixtures__/variants.fixture'
+import {variantsUsEnglishLocaleBundle} from '../../i18n'
+import {useVariantDeleteAction} from '../useVariantDeleteAction'
+
+const variantOperationsMock = vi.hoisted(() => ({
+  createVariant: vi.fn(),
+  updateVariant: vi.fn(),
+  deleteVariant: vi.fn(),
+}))
+
+const toastMock = vi.hoisted(() => ({
+  push: vi.fn(),
+}))
+
+vi.mock('@sanity/ui', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useToast: vi.fn(() => toastMock),
+}))
+
+vi.mock('../../store/useVariantOperations', () => ({
+  useVariantOperations: vi.fn(() => variantOperationsMock),
+}))
+
+describe('useVariantDeleteAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    variantOperationsMock.deleteVariant.mockResolvedValue(undefined)
+  })
+
+  const renderDeleteAction = async (options?: Parameters<typeof useVariantDeleteAction>[1]) => {
+    const wrapper = await createTestProvider({
+      resources: [variantsUsEnglishLocaleBundle],
+    })
+
+    return renderHook(() => useVariantDeleteAction(variantAlphaAudience._id, options), {wrapper})
+  }
+
+  it('deletes the variant when it has no documents', async () => {
+    const onDeleted = vi.fn()
+    const {result} = await renderDeleteAction({documentCount: 0, onDeleted})
+
+    await waitFor(() => {
+      expect(result.current).not.toBeNull()
+    })
+
+    await act(async () => {
+      await result.current.handleDelete()
+    })
+
+    await waitFor(() => {
+      expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
+      expect(onDeleted).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('disables delete while documents are loading', async () => {
+    const {result} = await renderDeleteAction({documentCount: 0, documentsLoading: true})
+
+    expect(result.current.deleteDisabled).toBe(true)
+    expect(result.current.deleteDisabledTooltip).toBeUndefined()
+  })
+
+  it('disables delete while the document count is unknown', async () => {
+    const {result} = await renderDeleteAction({documentCount: undefined})
+
+    expect(result.current.deleteDisabled).toBe(true)
+    expect(result.current.deleteDisabledTooltip).toBeUndefined()
+  })
+
+  it('disables delete and exposes a singular tooltip when the variant has one document', async () => {
+    const {result} = await renderDeleteAction({documentCount: 1})
+
+    expect(result.current.deleteDisabled).toBe(true)
+    expect(result.current.deleteDisabledTooltip).toBe(
+      "This variant contains 1 document in it, it can't be removed until the documents have been removed.",
+    )
+
+    await act(async () => {
+      await result.current.handleDelete()
+    })
+
+    expect(variantOperationsMock.deleteVariant).not.toHaveBeenCalled()
+  })
+
+  it('disables delete and exposes a plural tooltip when the variant has multiple documents', async () => {
+    const {result} = await renderDeleteAction({documentCount: 2})
+
+    expect(result.current.deleteDisabled).toBe(true)
+    expect(result.current.deleteDisabledTooltip).toBe(
+      "This variant contains 2 documents in it, it can't be removed until the documents have been removed.",
+    )
+  })
+
+  it('shows a toast when deletion fails', async () => {
+    const error = new Error('delete failed')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    variantOperationsMock.deleteVariant.mockRejectedValue(error)
+
+    const {result} = await renderDeleteAction({documentCount: 0})
+
+    await act(async () => {
+      await result.current.handleDelete()
+    })
+
+    await waitFor(() => {
+      expect(toastMock.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          title: 'Unable to delete variant',
+        }),
+      )
+    })
+    expect(consoleError).toHaveBeenCalledWith(error)
+
+    consoleError.mockRestore()
+  })
+})

--- a/packages/sanity/src/core/variants/hooks/useVariantDeleteAction.ts
+++ b/packages/sanity/src/core/variants/hooks/useVariantDeleteAction.ts
@@ -1,0 +1,80 @@
+import {useToast} from '@sanity/ui'
+import {useCallback, useMemo, useState} from 'react'
+
+import {useTranslation} from '../../i18n'
+import {variantsLocaleNamespace} from '../i18n'
+import {useVariantOperations} from '../store/useVariantOperations'
+
+interface UseVariantDeleteActionOptions {
+  documentCount?: number | null
+  documentsLoading?: boolean
+  onDeleted?: () => void
+}
+
+/**
+ * Shared delete action state for variant menu buttons.
+ *
+ * @internal
+ */
+export function useVariantDeleteAction(
+  variantId: string,
+  options?: UseVariantDeleteActionOptions,
+): {
+  deleteDisabled: boolean
+  deleteDisabledTooltip: string | undefined
+  handleDelete: () => Promise<void>
+  isDeleting: boolean
+} {
+  const {documentCount, documentsLoading = false, onDeleted} = options ?? {}
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const toast = useToast()
+  const {deleteVariant} = useVariantOperations()
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const hasDocuments = typeof documentCount === 'number' && documentCount > 0
+  const countUnknown = documentsLoading || documentCount === undefined || documentCount === null
+
+  const deleteDisabled = isDeleting || countUnknown || hasDocuments
+
+  const deleteDisabledTooltip = useMemo(() => {
+    if (!hasDocuments || typeof documentCount !== 'number') {
+      return undefined
+    }
+
+    return t(
+      documentCount === 1
+        ? 'overview.action.delete-variant.disabled-hint_one'
+        : 'overview.action.delete-variant.disabled-hint_other',
+      {count: documentCount},
+    )
+  }, [documentCount, hasDocuments, t])
+
+  const handleDelete = useCallback(async () => {
+    if (countUnknown || hasDocuments) {
+      return
+    }
+
+    setIsDeleting(true)
+
+    try {
+      await deleteVariant(variantId)
+      setIsDeleting(false)
+      onDeleted?.()
+    } catch (error) {
+      console.error(error)
+      toast.push({
+        closable: true,
+        status: 'error',
+        title: t('overview.action.delete-variant.error.title'),
+      })
+      setIsDeleting(false)
+    }
+  }, [countUnknown, deleteVariant, hasDocuments, onDeleted, t, toast, variantId])
+
+  return {
+    deleteDisabled,
+    deleteDisabledTooltip,
+    handleDelete,
+    isDeleting,
+  }
+}

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -24,6 +24,12 @@ const variantsLocaleStrings = {
   'overview.action.create-variant': 'Create variant',
   /** Label for the Variants overview delete action. */
   'overview.action.delete-variant': 'Delete variant',
+  /** Tooltip when delete is disabled because the variant contains one document. */
+  'overview.action.delete-variant.disabled-hint_one':
+    "This variant contains {{count}} document in it, it can't be removed until the documents have been removed.",
+  /** Tooltip when delete is disabled because the variant contains multiple documents. */
+  'overview.action.delete-variant.disabled-hint_other':
+    "This variant contains {{count}} documents in it, it can't be removed until the documents have been removed.",
   /** Error toast title when variant deletion fails. */
   'overview.action.delete-variant.error.title': 'Unable to delete variant',
   /** Link label for Variants overview documentation (empty state). */

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetailMenuButton.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetailMenuButton.test.tsx
@@ -52,11 +52,24 @@ describe('VariantDetailMenuButton', () => {
     variantOperationsMock.deleteVariant.mockResolvedValue(undefined)
   })
 
-  const renderMenuButton = async () => {
+  const renderMenuButton = async ({
+    documentCount = 0,
+    documentsLoading = false,
+  }: {
+    documentCount?: number
+    documentsLoading?: boolean
+  } = {}) => {
     const wrapper = await createTestProvider({
       resources: [variantsUsEnglishLocaleBundle],
     })
-    const result = render(<VariantDetailMenuButton variant={variantAlphaAudience} />, {wrapper})
+    const result = render(
+      <VariantDetailMenuButton
+        documentCount={documentCount}
+        documentsLoading={documentsLoading}
+        variant={variantAlphaAudience}
+      />,
+      {wrapper},
+    )
     await screen.findByRole('button')
     return result
   }
@@ -121,5 +134,29 @@ describe('VariantDetailMenuButton', () => {
     expect(mockNavigate).not.toHaveBeenCalled()
 
     consoleError.mockRestore()
+  })
+
+  it('disables delete when the variant has documents', async () => {
+    const user = userEvent.setup()
+
+    await renderMenuButton({documentCount: 1})
+
+    await user.click(screen.getByRole('button'))
+    await user.click(await screen.findByText('Delete variant'))
+
+    expect(variantOperationsMock.deleteVariant).not.toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('disables delete while documents are loading', async () => {
+    const user = userEvent.setup()
+
+    await renderMenuButton({documentCount: 0, documentsLoading: true})
+
+    await user.click(screen.getByRole('button'))
+    await user.click(await screen.findByText('Delete variant'))
+
+    expect(variantOperationsMock.deleteVariant).not.toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalled()
   })
 })

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantMenuButton.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantMenuButton.test.tsx
@@ -34,11 +34,14 @@ describe('VariantMenuButton', () => {
     variantOperationsMock.deleteVariant.mockResolvedValue(undefined)
   })
 
-  const renderMenuButton = async () => {
+  const renderMenuButton = async (options?: {documentCount?: number | null}) => {
     const wrapper = await createTestProvider({
       resources: [variantsUsEnglishLocaleBundle],
     })
-    const result = render(<VariantMenuButton variant={variantAlphaAudience} />, {wrapper})
+    const result = render(
+      <VariantMenuButton documentCount={options?.documentCount} variant={variantAlphaAudience} />,
+      {wrapper},
+    )
     await screen.findByRole('button')
     return result
   }
@@ -46,7 +49,7 @@ describe('VariantMenuButton', () => {
   it('deletes the variant when delete is selected', async () => {
     const user = userEvent.setup()
 
-    await renderMenuButton()
+    await renderMenuButton({documentCount: 0})
 
     await user.click(screen.getByRole('button'))
     await user.click(await screen.findByText('Delete variant'))
@@ -61,7 +64,7 @@ describe('VariantMenuButton', () => {
     const deleteDeferred = createDeferred()
     variantOperationsMock.deleteVariant.mockReturnValue(deleteDeferred.promise)
 
-    await renderMenuButton()
+    await renderMenuButton({documentCount: 0})
 
     const menuButton = screen.getByRole('button')
 
@@ -77,5 +80,27 @@ describe('VariantMenuButton', () => {
     await waitFor(() => {
       expect(menuButton).toBeEnabled()
     })
+  })
+
+  it('disables delete when the variant has documents', async () => {
+    const user = userEvent.setup()
+
+    await renderMenuButton({documentCount: 1})
+
+    await user.click(screen.getByRole('button'))
+    await user.click(await screen.findByText('Delete variant'))
+
+    expect(variantOperationsMock.deleteVariant).not.toHaveBeenCalled()
+  })
+
+  it('disables delete while the document count is loading', async () => {
+    const user = userEvent.setup()
+
+    await renderMenuButton()
+
+    await user.click(screen.getByRole('button'))
+    await user.click(await screen.findByText('Delete variant'))
+
+    expect(variantOperationsMock.deleteVariant).not.toHaveBeenCalled()
   })
 })

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -242,6 +242,8 @@ describe('VariantsOverview', () => {
 
   it('deletes a variant from the row actions menu', async () => {
     setVariants([variantAlphaAudience])
+    documentCountsMock.data = {[variantAlphaAudience._id]: 0}
+    documentCountsMock.loading = false
     const user = userEvent.setup()
 
     await renderOverview()
@@ -256,6 +258,32 @@ describe('VariantsOverview', () => {
 
     await user.click(menuButton)
     await user.click(await screen.findByText('Delete variant'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
+    })
+  })
+
+  it('does not delete a variant from the row actions menu when it has documents', async () => {
+    setVariants([variantAlphaAudience])
+    documentCountsMock.data = {[variantAlphaAudience._id]: 2}
+    documentCountsMock.loading = false
+    const user = userEvent.setup()
+
+    await renderOverview()
+
+    await waitFor(() => expect(screen.getAllByTestId('table-row')).toHaveLength(1))
+
+    const menuButton = screen
+      .getAllByRole('button')
+      .find((button) => button.id === 'variant-actions-alpha-audience')
+
+    if (!menuButton) throw new Error('Variant actions menu button not found')
+
+    await user.click(menuButton)
+    await user.click(await screen.findByText('Delete variant'))
+
+    expect(variantOperationsMock.deleteVariant).not.toHaveBeenCalled()
   })
 
   it('shows empty state when there are no variants', async () => {

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
@@ -123,7 +123,11 @@ export function VariantDetail() {
           )}
         </Flex>
       </Flex>
-      <VariantDetailFooter variant={variant} />
+      <VariantDetailFooter
+        documentCount={tableRows.length}
+        documentsLoading={documentsLoading}
+        variant={variant}
+      />
       {editDialogOpen && (
         <EditVariantDialog
           onCancel={() => setEditDialogOpen(false)}

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetailFooter.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetailFooter.tsx
@@ -7,7 +7,15 @@ import {variantsLocaleNamespace} from '../../i18n'
 import {type SystemVariant} from '../../types'
 import {VariantDetailMenuButton} from './VariantDetailMenuButton'
 
-export function VariantDetailFooter({variant}: {variant: SystemVariant}): React.JSX.Element {
+export function VariantDetailFooter({
+  documentCount,
+  documentsLoading = false,
+  variant,
+}: {
+  documentCount: number
+  documentsLoading?: boolean
+  variant: SystemVariant
+}): React.JSX.Element {
   const {t} = useTranslation(variantsLocaleNamespace)
 
   return (
@@ -30,7 +38,11 @@ export function VariantDetailFooter({variant}: {variant: SystemVariant}): React.
         </Flex>
 
         <Flex flex="none" gap={1} data-testid="variant-detail-footer-actions">
-          <VariantDetailMenuButton variant={variant} />
+          <VariantDetailMenuButton
+            documentCount={documentCount}
+            documentsLoading={documentsLoading}
+            variant={variant}
+          />
         </Flex>
       </Flex>
     </Card>

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetailMenuButton.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetailMenuButton.tsx
@@ -1,39 +1,33 @@
-import {Menu, useToast} from '@sanity/ui'
-import {useCallback, useState} from 'react'
+import {Menu} from '@sanity/ui'
 import {useRouter} from 'sanity/router'
 
 import {MenuButton, MenuItem} from '../../../../ui-components'
 import {ContextMenuButton} from '../../../components/contextMenuButton'
 import {useTranslation} from '../../../i18n'
+import {useVariantDeleteAction} from '../../hooks/useVariantDeleteAction'
 import {variantsLocaleNamespace} from '../../i18n'
-import {useVariantOperations} from '../../store/useVariantOperations'
 import {type SystemVariant} from '../../types'
 import {getVariantId} from '../util'
 
-export function VariantDetailMenuButton({variant}: {variant: SystemVariant}): React.JSX.Element {
+export function VariantDetailMenuButton({
+  documentCount,
+  documentsLoading = false,
+  variant,
+}: {
+  documentCount: number
+  documentsLoading?: boolean
+  variant: SystemVariant
+}): React.JSX.Element {
   const {t} = useTranslation(variantsLocaleNamespace)
   const router = useRouter()
-  const toast = useToast()
-  const {deleteVariant} = useVariantOperations()
-  const [isDeleting, setIsDeleting] = useState(false)
-
-  const handleDelete = useCallback(async () => {
-    setIsDeleting(true)
-
-    try {
-      await deleteVariant(variant._id)
-      setIsDeleting(false)
-      router.navigate({})
-    } catch (error) {
-      console.error(error)
-      toast.push({
-        closable: true,
-        status: 'error',
-        title: t('overview.action.delete-variant.error.title'),
-      })
-      setIsDeleting(false)
-    }
-  }, [deleteVariant, router, t, toast, variant._id])
+  const {deleteDisabled, deleteDisabledTooltip, handleDelete, isDeleting} = useVariantDeleteAction(
+    variant._id,
+    {
+      documentCount,
+      documentsLoading,
+      onDeleted: () => router.navigate({}),
+    },
+  )
 
   return (
     <MenuButton
@@ -42,13 +36,11 @@ export function VariantDetailMenuButton({variant}: {variant: SystemVariant}): Re
       menu={
         <Menu>
           <MenuItem
-            // TODO: This action now doesn't validate the documents count in a variant, once we can
-            // start adding documents to a variant we should revisit this to validate the documents count.
-            // If it has documents we should probably disable the delete action or at least handle it differently.
-            disabled={isDeleting}
+            disabled={deleteDisabled}
             onClick={handleDelete}
             text={t('overview.action.delete-variant')}
             tone="critical"
+            tooltipProps={deleteDisabledTooltip ? {content: deleteDisabledTooltip} : undefined}
           />
         </Menu>
       }

--- a/packages/sanity/src/core/variants/tool/overview/VariantMenuButton.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantMenuButton.tsx
@@ -1,36 +1,25 @@
-import {Menu, useToast} from '@sanity/ui'
-import {useCallback, useState} from 'react'
+import {Menu} from '@sanity/ui'
 
 import {MenuButton, MenuItem} from '../../../../ui-components'
 import {ContextMenuButton} from '../../../components/contextMenuButton'
 import {useTranslation} from '../../../i18n'
+import {useVariantDeleteAction} from '../../hooks/useVariantDeleteAction'
 import {variantsLocaleNamespace} from '../../i18n'
-import {useVariantOperations} from '../../store/useVariantOperations'
 import {type SystemVariant} from '../../types'
 import {getVariantId} from '../util'
 
-export function VariantMenuButton({variant}: {variant: SystemVariant}) {
+export function VariantMenuButton({
+  documentCount,
+  variant,
+}: {
+  documentCount?: number | null
+  variant: SystemVariant
+}) {
   const {t} = useTranslation(variantsLocaleNamespace)
-  const toast = useToast()
-  const {deleteVariant} = useVariantOperations()
-  const [isDeleting, setIsDeleting] = useState(false)
-
-  const handleDelete = useCallback(async () => {
-    setIsDeleting(true)
-
-    try {
-      await deleteVariant(variant._id)
-      setIsDeleting(false)
-    } catch (error) {
-      console.error(error)
-      toast.push({
-        closable: true,
-        status: 'error',
-        title: t('overview.action.delete-variant.error.title'),
-      })
-      setIsDeleting(false)
-    }
-  }, [deleteVariant, t, toast, variant._id])
+  const {deleteDisabled, deleteDisabledTooltip, handleDelete, isDeleting} = useVariantDeleteAction(
+    variant._id,
+    {documentCount},
+  )
 
   return (
     <MenuButton
@@ -39,13 +28,11 @@ export function VariantMenuButton({variant}: {variant: SystemVariant}) {
       menu={
         <Menu>
           <MenuItem
-            // TODO: This action now doesn't validate the documents count in a variant, once we can
-            // start adding documents to a variant we should revisit this to validate the documents count.
-            // If it has documents we should probably disable the delete action or at least handle it differently.
-            disabled={isDeleting}
+            disabled={deleteDisabled}
             onClick={handleDelete}
             text={t('overview.action.delete-variant')}
             tone="critical"
+            tooltipProps={deleteDisabledTooltip ? {content: deleteDisabledTooltip} : undefined}
           />
         </Menu>
       }

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
@@ -42,7 +42,15 @@ export function VariantsOverview() {
   const columnDefs = useMemo(() => variantsOverviewColumnDefs(t), [t])
   const renderRowActions = useCallback<
     NonNullable<TableProps<TableVariant, undefined>['rowActions']>
-  >(({datum}) => <VariantMenuButton variant={datum as SystemVariant} />, [])
+  >(
+    ({datum}) => (
+      <VariantMenuButton
+        documentCount={(datum as TableVariant).documentCount}
+        variant={datum as SystemVariant}
+      />
+    ),
+    [],
+  )
 
   const variantsList = useMemo(() => variants ?? [], [variants])
 


### PR DESCRIPTION
### Description

Closes SAPP-3850. Variant definitions with documents should not be deletable from the Variants tool until those documents are removed.

<img width="1619" height="734" alt="Screenshot 2026-07-09 at 18 20 33" src="https://github.com/user-attachments/assets/f33877af-e520-4685-a02b-f1c42a08744e" />
<img width="662" height="135" alt="Screenshot 2026-07-09 at 18 20 39" src="https://github.com/user-attachments/assets/f5dfffea-b5a5-46ee-96c0-034350c87a84" />

### What to review

- `packages/sanity/src/core/variants/hooks/useVariantDeleteAction.ts` — shared disabled/tooltip/delete logic driven by `documentCount` + `documentsLoading`
- Overview wiring in `VariantsOverview.tsx` / `VariantMenuButton.tsx`
- Detail wiring in `VariantDetail.tsx` / `VariantDetailFooter.tsx` / `VariantDetailMenuButton.tsx`
- i18n tooltip strings in `packages/sanity/src/core/variants/i18n/resources.ts`

### Testing

- Added `useVariantDeleteAction` unit tests
- Updated overview, overview row menu, and detail menu button tests
- `pnpm vitest run --project=sanity packages/sanity/src/core/variants/hooks/__tests__/useVariantDeleteAction.test.ts packages/sanity/src/core/variants/hooks/__tests__/useVariantsDocumentCounts.test.ts packages/sanity/src/core/variants/tool/__tests__/VariantMenuButton.test.tsx packages/sanity/src/core/variants/tool/__tests__/VariantDetailMenuButton.test.tsx packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx`

### Notes for release

N/A – Part of the variants beta feature, not enabled by default.