### PR TITLE
feat(variants): add pin button to variants tool

### DIFF
--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -48,6 +48,10 @@ const variantsLocaleStrings = {
   'overview.title': 'Variants',
   /** Edit action on the Variant detail page. */
   'detail.action.edit-variant': 'Edit variant',
+  /** Tooltip for pinning a variant to the studio. */
+  'detail.pin-variant': 'Pin variant to studio',
+  /** Tooltip for unpinning a variant from the studio. */
+  'detail.unpin-variant': 'Unpin variant from studio',
   /** Back action on the Variant detail page. */
   'detail.back': 'Back to variants',
   /** Created status label in the Variant detail footer. */

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -10,6 +10,18 @@ import {type SystemVariant} from '../../types'
 import {VariantDetail} from '../detail/VariantDetail'
 import {getVariantId} from '../util'
 
+const mockedSetVariant = vi.fn()
+
+vi.mock('../../../perspective/useSetVariant', () => ({
+  useSetVariant: vi.fn(() => mockedSetVariant),
+}))
+
+vi.mock('../../../perspective/usePerspective', () => ({
+  usePerspective: vi.fn(() => ({
+    selectedVariant: undefined,
+  })),
+}))
+
 const mockNavigate = vi.fn()
 
 const routerState = vi.hoisted(() => ({
@@ -79,6 +91,7 @@ vi.mock('../../../releases/store/useActiveReleases', () => ({
 describe('VariantDetail', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockedSetVariant.mockClear()
     variantsMock.data = []
     variantsMock.byId = new Map()
     variantsMock.loading = false
@@ -154,6 +167,7 @@ describe('VariantDetail', () => {
     expect(screen.getByText('Developer audience')).toBeInTheDocument()
     expect(screen.getByText('audience: "alpha", locale: "en-US"')).toBeInTheDocument()
     expect(screen.getByRole('button', {name: 'Edit variant'})).toBeInTheDocument()
+    expect(screen.getByTestId('pin-variant-button')).toBeInTheDocument()
     expect(screen.getByRole('button', {name: 'Back to variants'})).toBeInTheDocument()
     expect(screen.getByText('Bundle')).toBeInTheDocument()
     expect(screen.getByText('Type')).toBeInTheDocument()
@@ -162,6 +176,18 @@ describe('VariantDetail', () => {
     expect(screen.getByText('No documents in this variant')).toBeInTheDocument()
     expect(screen.getByText(/^Created/)).toBeInTheDocument()
     expect(screen.getByTestId('variant-detail-footer-actions')).toBeInTheDocument()
+  })
+
+  it('pins a variant from the detail page', async () => {
+    routerState.variantId = getVariantId(variantAlphaAudience._id)
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderDetail()
+
+    await user.click(screen.getByTestId('pin-variant-button'))
+
+    expect(mockedSetVariant).toHaveBeenCalledWith(variantAlphaAudience)
   })
 
   it('opens the edit dialog with existing variant values', async () => {

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantPinButton.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantPinButton.test.tsx
@@ -1,0 +1,62 @@
+import {render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {
+  mockUsePerspective,
+  usePerspectiveMockReturn,
+} from '../../../perspective/__mocks__/usePerspective.mock'
+import {variantAlphaAudience} from '../../__fixtures__/variants.fixture'
+import {variantsUsEnglishLocaleBundle} from '../../i18n'
+import {VariantPinButton} from '../components/VariantPinButton'
+
+const mockedSetVariant = vi.fn()
+
+vi.mock('../../../perspective/useSetVariant', () => ({
+  useSetVariant: vi.fn(() => mockedSetVariant),
+}))
+
+vi.mock('../../../perspective/usePerspective', () => ({
+  usePerspective: vi.fn(() => usePerspectiveMockReturn),
+}))
+
+const renderTest = async () => {
+  const wrapper = await createTestProvider({
+    resources: [variantsUsEnglishLocaleBundle],
+  })
+
+  render(<VariantPinButton variant={variantAlphaAudience} />, {wrapper})
+
+  await waitFor(() => {
+    expect(screen.getByTestId('pin-variant-button')).toBeInTheDocument()
+  })
+}
+
+describe('VariantPinButton', () => {
+  it('pins a variant when it is not selected', async () => {
+    mockUsePerspective.mockReturnValue({
+      ...usePerspectiveMockReturn,
+      selectedVariant: undefined,
+    })
+
+    await renderTest()
+
+    await userEvent.click(screen.getByTestId('pin-variant-button'))
+
+    expect(mockedSetVariant).toHaveBeenCalledWith(variantAlphaAudience)
+  })
+
+  it('unpins a variant when it is selected', async () => {
+    mockUsePerspective.mockReturnValue({
+      ...usePerspectiveMockReturn,
+      selectedVariant: variantAlphaAudience,
+    })
+
+    await renderTest()
+
+    await userEvent.click(screen.getByTestId('pin-variant-button'))
+
+    expect(mockedSetVariant).toHaveBeenCalledWith(undefined)
+  })
+})

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -11,6 +11,18 @@ import {type EditableSystemVariant, type SystemVariant} from '../../types'
 import {VariantsOverview} from '../overview/VariantsOverview'
 import {getVariantId} from '../util'
 
+const mockedSetVariant = vi.fn()
+
+vi.mock('../../../perspective/useSetVariant', () => ({
+  useSetVariant: vi.fn(() => mockedSetVariant),
+}))
+
+vi.mock('../../../perspective/usePerspective', () => ({
+  usePerspective: vi.fn(() => ({
+    selectedVariant: undefined,
+  })),
+}))
+
 const mockNavigate = vi.fn()
 
 const routerState = vi.hoisted(() => ({
@@ -82,6 +94,7 @@ describe('VariantsOverview', () => {
     variantsMock.error = undefined
     routerState.variantId = undefined
     mockNavigate.mockClear()
+    mockedSetVariant.mockClear()
     variantOperationsMock.createVariant.mockReset()
     variantOperationsMock.deleteVariant.mockReset()
     variantOperationsMock.createVariant.mockImplementation(
@@ -182,6 +195,21 @@ describe('VariantsOverview', () => {
     expect(mockNavigate).toHaveBeenCalledWith({
       variantId: getVariantId(variantAlphaAudience._id),
     })
+  })
+
+  it('pins a variant from the overview table', async () => {
+    setVariants([variantAlphaAudience])
+    const user = userEvent.setup()
+
+    await renderOverview()
+
+    await waitFor(() => expect(screen.getAllByTestId('table-row')).toHaveLength(1))
+
+    await user.click(screen.getByTestId('pin-variant-button'))
+
+    expect(mockedSetVariant).toHaveBeenCalledWith(
+      expect.objectContaining({_id: variantAlphaAudience._id}),
+    )
   })
 
   it('deletes a variant from the row actions menu', async () => {

--- a/packages/sanity/src/core/variants/tool/components/VariantPinButton.tsx
+++ b/packages/sanity/src/core/variants/tool/components/VariantPinButton.tsx
@@ -1,0 +1,54 @@
+import {PinIcon} from '@sanity/icons/Pin'
+import {PinFilledIcon} from '@sanity/icons/PinFilled'
+import {useCallback} from 'react'
+
+import {Button} from '../../../../ui-components/button/Button'
+import {useTranslation} from '../../../i18n'
+import {usePerspective} from '../../../perspective/usePerspective'
+import {useSetVariant} from '../../../perspective/useSetVariant'
+import {variantsLocaleNamespace} from '../../i18n'
+import {type SystemVariant} from '../../types'
+import {getVariantTitle} from '../util'
+
+export function VariantPinButton({
+  variant,
+  'data-testid': dataTestId = 'pin-variant-button',
+}: {
+  'variant': SystemVariant
+  'data-testid'?: string
+}) {
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const {selectedVariant} = usePerspective()
+  const setVariant = useSetVariant()
+
+  const isPinned = selectedVariant?._id === variant._id
+  const variantTitle = getVariantTitle(variant)
+
+  const handlePinVariant = useCallback(() => {
+    if (isPinned) {
+      setVariant(undefined)
+    } else {
+      setVariant(variant)
+    }
+  }, [isPinned, setVariant, variant])
+
+  return (
+    <Button
+      aria-label={
+        isPinned
+          ? `${t('detail.unpin-variant')}: "${variantTitle}"`
+          : `${t('detail.pin-variant')}: "${variantTitle}"`
+      }
+      aria-live="assertive"
+      data-testid={dataTestId}
+      icon={isPinned ? PinFilledIcon : PinIcon}
+      mode="bleed"
+      onClick={handlePinVariant}
+      radius="full"
+      selected={isPinned}
+      tooltipProps={{
+        content: isPinned ? t('detail.unpin-variant') : t('detail.pin-variant'),
+      }}
+    />
+  )
+}

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
@@ -9,6 +9,7 @@ import {EditVariantDialog} from '../../components/dialog/EditVariantDialog'
 import {useVariantDocuments} from '../../hooks/useVariantDocuments'
 import {variantsLocaleNamespace} from '../../i18n'
 import {useAllVariants} from '../../store/useAllVariants'
+import {VariantPinButton} from '../components/VariantPinButton'
 import {
   decodeVariantIdFromRoute,
   getVariantConditionsText,
@@ -81,9 +82,12 @@ export function VariantDetail() {
             <Card paddingY={5}>
               <Flex align="flex-start" gap={4} justify="space-between">
                 <Stack space={3}>
-                  <Text as="h1" size={4} weight="bold">
-                    {getVariantTitle(variant)}
-                  </Text>
+                  <Flex align="center" gap={1}>
+                    <VariantPinButton variant={variant} />
+                    <Text as="h1" size={4} weight="bold">
+                      {getVariantTitle(variant)}
+                    </Text>
+                  </Flex>
                   <Text muted size={1}>
                     {description || t('detail.no-description')}
                   </Text>

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
@@ -7,6 +7,7 @@ import {Headers} from '../../../releases/tool/components/Table/TableHeader'
 import {type Column, type VisibleColumn} from '../../../releases/tool/components/Table/types'
 import {variantsLocaleNamespace} from '../../i18n'
 import {type SystemVariant} from '../../types'
+import {VariantPinButton} from '../components/VariantPinButton'
 import {getVariantId, getVariantConditionsText, getVariantTitle} from '../util'
 
 const VariantDocumentsCell: VisibleColumn<SystemVariant>['cell'] = ({cellProps, datum}) => {
@@ -64,18 +65,21 @@ const VariantTitleCell: VisibleColumn<SystemVariant>['cell'] = ({cellProps, datu
 
   return (
     <Box {...cellProps} flex={1} paddingLeft={3} paddingRight={2} paddingY={1} sizing="border">
-      <Card as={VariantLink} data-as="a" flex={1} padding={2} radius={2} tone="inherit">
-        <Flex align="center" gap={3}>
-          <Stack flex={1} space={2}>
-            <Text size={1} weight="medium">
-              {getVariantTitle(variant)}
-            </Text>
-            <Text muted size={1}>
-              {conditionsText || t('overview.table.no-conditions')}
-            </Text>
-          </Stack>
-        </Flex>
-      </Card>
+      <Flex align="center" gap={3}>
+        <VariantPinButton variant={variant} />
+        <Card as={VariantLink} data-as="a" flex={1} padding={2} radius={2} tone="inherit">
+          <Flex align="center" gap={3}>
+            <Stack flex={1} space={2}>
+              <Text size={1} weight="medium">
+                {getVariantTitle(variant)}
+              </Text>
+              <Text muted size={1}>
+                {conditionsText || t('overview.table.no-conditions')}
+              </Text>
+            </Stack>
+          </Flex>
+        </Card>
+      </Flex>
     </Box>
   )
 }


### PR DESCRIPTION
### Description

Closes SAPP-3997. Variants lacked a way to pin a variant to the studio perspective from the tool itself — users had to use the navbar variant selector. This mirrors the existing releases pin UX so pinning is available in the overview table and next to the title on the detail page.

Pin/unpin uses `useSetVariant` (same sticky `variant` param as the navbar), with a shared `VariantPinButton` component to keep overview and detail behavior aligned.

<img width="910" height="290" alt="Screenshot 2026-07-09 at 18 00 39" src="https://github.com/user-attachments/assets/eafd4eba-5673-4ded-8ad2-6700accd3153" />
<img width="743" height="207" alt="Screenshot 2026-07-09 at 18 00 28" src="https://github.com/user-attachments/assets/3d034d89-80a4-4061-8150-0150c590b746" />

### What to review

- `packages/sanity/src/core/variants/tool/components/VariantPinButton.tsx` — shared pin logic and a11y labels
- `VariantsOverviewColumnDefs.tsx` — pin button placement in table rows (outside the navigation link)
- `VariantDetail.tsx` — pin button next to the title heading

### Testing

- `VariantPinButton.test.tsx` — pin and unpin behavior
- `VariantsOverview.test.tsx` — pin from overview table
- `VariantDetail.test.tsx` — pin from detail page

```bash
pnpm vitest run --project=sanity packages/sanity/src/core/variants/tool/__tests__/VariantPinButton.test.tsx packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
```

### Notes for release

N/A – Part of Content Variants closed beta