### PR TITLE
fix(comments): make the editor the single source of truth for the draft

### DIFF
--- a/.husky/_/pre-commit
+++ b/.husky/_/pre-commit
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+if [ "$LEFTHOOK_VERBOSE" = "1" -o "$LEFTHOOK_VERBOSE" = "true" ]; then
+  set -x
+fi
+
+if [ "$LEFTHOOK" = "0" ]; then
+  exit 0
+fi
+
+call_lefthook()
+{
+  if test -n "$LEFTHOOK_BIN"
+  then
+    "$LEFTHOOK_BIN" "$@"
+  elif lefthook -h >/dev/null 2>&1
+  then
+    lefthook "$@"
+  elif /Users/christian.groengaard/code/sanity-comment-draft-source-of-truth/node_modules/.pnpm/lefthook-darwin-arm64@2.1.9/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
+  then
+    /Users/christian.groengaard/code/sanity-comment-draft-source-of-truth/node_modules/.pnpm/lefthook-darwin-arm64@2.1.9/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
+  else
+    dir="$(git rev-parse --show-toplevel)"
+    osArch=$(uname | tr '[:upper:]' '[:lower:]')
+    cpuArch=$(uname -m | sed 's/aarch64/arm64/;s/x86_64/x64/')
+    if test -f "$dir/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook"
+    then
+      "$dir/node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook" "$@"
+    elif test -f "$dir/node_modules/@evilmartians/lefthook/bin/lefthook-${osArch}-${cpuArch}/lefthook"
+    then
+      "$dir/node_modules/@evilmartians/lefthook/bin/lefthook-${osArch}-${cpuArch}/lefthook" "$@"
+    elif test -f "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook"
+    then
+      "$dir/node_modules/@evilmartians/lefthook-installer/bin/lefthook" "$@"
+    elif test -f "$dir/node_modules/lefthook/bin/index.js"
+    then
+      "$dir/node_modules/lefthook/bin/index.js" "$@"
+    elif go tool lefthook -h >/dev/null 2>&1
+    then
+      go tool lefthook "$@"
+    elif bundle exec lefthook -h >/dev/null 2>&1
+    then
+      bundle exec lefthook "$@"
+    elif yarn lefthook -h >/dev/null 2>&1
+    then
+      yarn lefthook "$@"
+    elif pnpm lefthook -h >/dev/null 2>&1
+    then
+      pnpm lefthook "$@"
+    elif swift package lefthook >/dev/null 2>&1
+    then
+      swift package --build-path .build/lefthook --disable-sandbox lefthook "$@"
+    elif command -v mint >/dev/null 2>&1
+    then
+      mint run csjones/lefthook-plugin "$@"
+    elif uv run lefthook -h >/dev/null 2>&1
+    then
+      uv run lefthook "$@"
+    elif mise exec -- lefthook -h >/dev/null 2>&1
+    then
+      mise exec -- lefthook "$@"
+    elif devbox run lefthook -h >/dev/null 2>&1
+    then
+      devbox run lefthook "$@"
+    else
+      echo "Can't find lefthook in PATH"
+    fi
+  fi
+}
+
+call_lefthook run "pre-commit" "$@"

--- a/packages/sanity/src/core/comments/components/list/CommentsListItem.tsx
+++ b/packages/sanity/src/core/comments/components/list/CommentsListItem.tsx
@@ -142,13 +142,10 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
     replies = EMPTY_ARRAY,
   } = props
   const {t} = useTranslation(commentsLocaleNamespace)
-  const [value, setValue] = useState<CommentMessage>(EMPTY_ARRAY)
   const [collapsed, setCollapsed] = useState<boolean>(true)
   const replyInputRef = useRef<CommentInputHandle>(null)
 
   const {isTopLayer} = useLayer()
-
-  const hasValue = useMemo(() => hasCommentMessageValue(value), [value])
 
   const [mouseOver, setMouseOver] = useState<boolean>(false)
 
@@ -171,17 +168,15 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
     }
 
     onReply?.(nextComment)
-    setValue(EMPTY_ARRAY)
   }
 
   const startDiscard = useCallback(() => {
-    if (!hasValue) {
-      setValue(EMPTY_ARRAY)
+    if (!hasCommentMessageValue(replyInputRef.current?.getValue() ?? null)) {
       return
     }
 
     replyInputRef.current?.discardDialogController.open()
-  }, [hasValue])
+  }, [])
 
   const handleInputKeyDown = useCallback(
     (event: KeyboardEvent) => {
@@ -204,7 +199,6 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
   }, [])
 
   const confirmDiscard = useCallback(() => {
-    setValue(EMPTY_ARRAY)
     replyInputRef.current?.discardDialogController.close()
     replyInputRef.current?.focus()
   }, [])
@@ -338,7 +332,6 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
             currentUser={currentUser}
             expandOnFocus
             mentionOptions={mentionOptions}
-            onChange={setValue}
             onDiscardCancel={cancelDiscard}
             onDiscardConfirm={confirmDiscard}
             onKeyDown={handleInputKeyDown}
@@ -350,7 +343,6 @@ export const CommentsListItem = memo(function CommentsListItem(props: CommentsLi
             }
             readOnly={readOnly || mode === 'upsell'}
             ref={replyInputRef}
-            value={value}
             withAvatar={avatarConfig.replyAvatar}
           />
         )}

--- a/packages/sanity/src/core/comments/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/core/comments/components/list/CommentsListItemLayout.tsx
@@ -11,6 +11,7 @@ import {
   useClickOutsideEvent,
 } from '@sanity/ui'
 import {getTheme_v2} from '@sanity/ui/theme'
+import isEqual from 'lodash-es/isEqual.js'
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {IntentLink} from 'sanity/router'
 import {css, styled} from 'styled-components'
@@ -24,7 +25,7 @@ import {
 } from '../../../hooks'
 import {Translate, useTranslation} from '../../../i18n'
 import {useUser} from '../../../store'
-import {hasCommentMessageValue, isTextSelectionComment, useCommentHasChanged} from '../../helpers'
+import {hasCommentMessageValue, isTextSelectionComment} from '../../helpers'
 import {commentsLocaleNamespace} from '../../i18n'
 import {
   type CommentContext,
@@ -196,16 +197,19 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
   const [user] = useUser(authorId)
   const {t} = useTranslation(commentsLocaleNamespace)
 
-  const [value, setValue] = useState<CommentMessage>(message)
   const [isEditing, setIsEditing] = useState<boolean>(false)
   const rootElementRef = useRef<HTMLDivElement | null>(null)
-  const startMessage = useRef<CommentMessage>(message)
+  // The message as it was when editing started: the editor's initial value,
+  // and the reference `readEditorHasChanges` compares against. Frozen so a
+  // remote update to the comment cannot clobber the draft mid-edit.
+  const [editStartMessage, setEditStartMessage] = useState<CommentMessage>(message)
   const [menuOpen, setMenuOpen] = useState<boolean>(false)
 
   const commentInputRef = useRef<CommentInputHandle>(null)
 
-  const hasChanges = useCommentHasChanged(value)
-  const hasValue = useMemo(() => hasCommentMessageValue(value), [value])
+  const readEditorHasChanges = useCallback(() => {
+    return !isEqual(editStartMessage, commentInputRef.current?.getValue() ?? null)
+  }, [editStartMessage])
 
   // Filter out reactions that's been optimistically removed from the comment.
   const reactions = (
@@ -225,17 +229,6 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
   const formattedLastEditAt = editedDate ? dateTimeFormat.format(editedDate) : null
   const displayError = hasError || isRetrying
 
-  // If the message has changed we need to update the value in the state
-  // so that, when the user starts editing, the input is populated with the
-  // latest message value.
-  useEffect(() => {
-    if (isEditing) return
-
-    startMessage.current = message
-    // oxlint-disable-next-line react/react-compiler
-    setValue(message)
-  }, [isEditing, message])
-
   const handleMenuOpen = useCallback(() => setMenuOpen(true), [])
   const handleMenuClose = useCallback(() => setMenuOpen(false), [])
   const handleCopyLink = useCallback(() => onCopyLink?.(_id), [_id, onCopyLink])
@@ -250,16 +243,16 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
 
   const cancelEdit = useCallback(() => {
     setIsEditing(false)
-    setValue(startMessage.current)
   }, [])
 
   const startDiscard = useCallback(() => {
-    if (!hasValue || !hasChanges) {
+    const currentValue = commentInputRef.current?.getValue() ?? null
+    if (!hasCommentMessageValue(currentValue) || !readEditorHasChanges()) {
       cancelEdit()
       return
     }
     commentInputRef.current?.discardDialogController.open()
-  }, [cancelEdit, hasChanges, hasValue])
+  }, [cancelEdit, readEditorHasChanges])
 
   const handleInputKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
@@ -308,23 +301,32 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
   }, [_id, comment.status, onStatusChange])
 
   const toggleEdit = useCallback(() => {
+    setEditStartMessage(message)
     setIsEditing((v) => !v)
-  }, [])
+  }, [message])
 
   const handleCloseMenu = useCallback(() => setMenuOpen(false), [])
 
   const handleRootKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === 'Escape' && !hasChanges) {
+      if (event.key === 'Escape' && !readEditorHasChanges()) {
         cancelEdit()
       }
     },
-    [cancelEdit, hasChanges],
+    [cancelEdit, readEditorHasChanges],
   )
 
   useDidUpdate(isEditing, handleCloseMenu)
 
-  useClickOutsideEvent(!hasChanges && cancelEdit, () => [rootElementRef.current])
+  const handleClickOutside = useCallback(() => {
+    if (readEditorHasChanges()) {
+      // An edit with changes only closes through the discard dialog.
+      return
+    }
+    cancelEdit()
+  }, [cancelEdit, readEditorHasChanges])
+
+  useClickOutsideEvent(handleClickOutside, () => [rootElementRef.current])
 
   const name = user?.displayName ? (
     <Text size={1} weight="medium" textOverflow="ellipsis" title={user.displayName}>
@@ -438,14 +440,13 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
                 currentUser={currentUser}
                 focusOnMount
                 mentionOptions={mentionOptions}
-                onChange={setValue}
                 onDiscardCancel={cancelDiscard}
                 onDiscardConfirm={confirmDiscard}
                 onKeyDown={handleInputKeyDown}
                 onSubmit={handleEditSubmit}
                 readOnly={readOnly}
                 ref={commentInputRef}
-                value={value}
+                value={editStartMessage}
                 withAvatar={false}
               />
             </Stack>

--- a/packages/sanity/src/core/comments/components/list/CreateNewThreadInput.tsx
+++ b/packages/sanity/src/core/comments/components/list/CreateNewThreadInput.tsx
@@ -1,5 +1,5 @@
-import {type CurrentUser, type PortableTextBlock} from '@sanity/types'
-import {useCallback, useMemo, useRef, useState} from 'react'
+import {type CurrentUser} from '@sanity/types'
+import {useCallback, useRef} from 'react'
 
 import {type UserListWithPermissionsHookValue} from '../../../hooks'
 import {Translate, useTranslation} from '../../../i18n'
@@ -7,8 +7,6 @@ import {hasCommentMessageValue} from '../../helpers'
 import {commentsLocaleNamespace} from '../../i18n'
 import {type CommentMessage, type CommentsUIMode} from '../../types'
 import {CommentInput, type CommentInputHandle, type CommentInputProps} from '../pte'
-
-const EMPTY_PT_ARRAY: PortableTextBlock[] = []
 
 interface CreateNewThreadInputProps {
   currentUser: CurrentUser
@@ -36,25 +34,21 @@ export function CreateNewThreadInput(props: CreateNewThreadInputProps) {
   } = props
   const {t} = useTranslation(commentsLocaleNamespace)
 
-  const [value, setValue] = useState<CommentMessage>(EMPTY_PT_ARRAY)
   const commentInputHandle = useRef<CommentInputHandle | null>(null)
 
   const handleSubmit = useCallback(
     (nextValue: CommentMessage) => {
       onNewThreadCreate?.(nextValue)
-      setValue(EMPTY_PT_ARRAY)
     },
     [onNewThreadCreate],
   )
 
-  const hasValue = useMemo(() => hasCommentMessageValue(value), [value])
-
   const startDiscard = useCallback(() => {
-    if (!hasValue) {
+    if (!hasCommentMessageValue(commentInputHandle.current?.getValue() ?? null)) {
       return
     }
     commentInputHandle.current?.discardDialogController.open()
-  }, [hasValue])
+  }, [])
 
   const handleInputKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
@@ -75,7 +69,6 @@ export function CreateNewThreadInput(props: CreateNewThreadInputProps) {
   )
 
   const confirmDiscard = useCallback(() => {
-    setValue(EMPTY_PT_ARRAY)
     commentInputHandle.current?.discardDialogController.close()
     commentInputHandle.current?.focus()
   }, [])
@@ -101,7 +94,6 @@ export function CreateNewThreadInput(props: CreateNewThreadInputProps) {
       expandOnFocus
       mentionOptions={mentionOptions}
       onBlur={onBlur}
-      onChange={setValue}
       onDiscardCancel={cancelDiscard}
       onDiscardConfirm={confirmDiscard}
       onKeyDown={handleInputKeyDown}
@@ -110,7 +102,6 @@ export function CreateNewThreadInput(props: CreateNewThreadInputProps) {
       placeholder={placeholder}
       readOnly={readOnly || mode === 'upsell'}
       ref={commentInputHandle}
-      value={value}
     />
   )
 }

--- a/packages/sanity/src/core/comments/components/pte/comment-input/CommentInput.tsx
+++ b/packages/sanity/src/core/comments/components/pte/comment-input/CommentInput.tsx
@@ -5,6 +5,7 @@ import {
   keyGenerator,
   type RenderBlockFunction,
   useEditor,
+  useEditorSelector,
 } from '@portabletext/editor'
 import {EventListenerPlugin} from '@portabletext/editor/plugins'
 import {getValue} from '@portabletext/editor/selectors'
@@ -64,17 +65,29 @@ export interface CommentInputProps {
   focusOnMount?: boolean
   mentionOptions: UserListWithPermissionsHookValue
   onBlur?: (e: FormEvent<HTMLDivElement>) => void
-  onChange: (value: PortableTextBlock[]) => void
+  onChange?: (value: PortableTextBlock[]) => void
   onDiscardCancel?: () => void
   onDiscardConfirm: () => void
   onFocus?: (e: FormEvent<HTMLDivElement>) => void
   onKeyDown?: (e: KeyboardEvent) => void
   onMentionMenuOpenChange?: (open: boolean) => void
+  /**
+   * Reports the editor's value whenever it changes. The editor owns the
+   * draft; consumers only need this to persist the value continuously (a
+   * controlled form input, a draft cache). Composers read at their decision
+   * points via `onSubmit`'s argument and the handle's `getValue` instead.
+   */
   onSubmit?: (value: PortableTextBlock[]) => void
   placeholder?: ReactNode
   readOnly?: boolean
   renderBlock?: RenderBlockFunction
-  value: PortableTextBlock[] | null
+  /**
+   * The initial editor value, and (through `UpdateValuePlugin`) external
+   * updates for controlled usages. The editor does not report its own value
+   * back through this prop; read it via `onSubmit`, `onChange`, or the
+   * handle's `getValue`.
+   */
+  value?: PortableTextBlock[] | null
   withAvatar?: boolean
   avatarSize?: AvatarSize
 }
@@ -91,6 +104,7 @@ export interface CommentInputHandle {
   blur: () => void
   discardDialogController: CommentDiscardDialogController
   focus: () => void
+  getValue: () => PortableTextBlock[]
   scrollTo: () => void
   reset: () => void
 }
@@ -159,32 +173,24 @@ export const CommentInput = forwardRef<CommentInputHandle, CommentInputProps>(
         if (event.type === 'blurred') {
           setFocused(false)
         }
-
-        // Update the comment value whenever the comment is edited by the user.
-        if (event.type === 'mutation') {
-          onChange(event.value || EMPTY_ARRAY)
-        }
       },
-      [focusOnMount, onChange, requestFocus],
+      [focusOnMount, requestFocus],
     )
 
     const scrollToEditor = useCallback(() => {
       editorContainerRef.current?.scrollIntoView(SCROLL_INTO_VIEW_OPTIONS)
     }, [])
 
+    const readCurrentValue = useCallback(() => {
+      return editorRef.current ? getValue(editorRef.current.getSnapshot()) : EMPTY_ARRAY
+    }, [])
+
     const handleSubmit = useCallback(() => {
-      // Read the editor's live value directly rather than the value mirrored
-      // through the debounced `mutation` event, which can lag the latest
-      // keystrokes by up to the flush interval and truncate the comment when
-      // the user submits without pausing.
-      const currentValue = editorRef.current
-        ? getValue(editorRef.current.getSnapshot())
-        : EMPTY_ARRAY
-      onSubmit?.(currentValue)
+      onSubmit?.(readCurrentValue())
       resetEditorInstance()
       requestFocus()
       scrollToEditor()
-    }, [onSubmit, requestFocus, resetEditorInstance, scrollToEditor])
+    }, [onSubmit, readCurrentValue, requestFocus, resetEditorInstance, scrollToEditor])
 
     const handleDiscardConfirm = useCallback(() => {
       onDiscardConfirm()
@@ -212,12 +218,19 @@ export const CommentInput = forwardRef<CommentInputHandle, CommentInputProps>(
         blur() {
           editorRef.current?.send({type: 'blur'})
         },
+        getValue: readCurrentValue,
         scrollTo: scrollToEditor,
         reset: resetEditorInstance,
 
         discardDialogController,
       }
-    }, [discardDialogController, requestFocus, resetEditorInstance, scrollToEditor])
+    }, [
+      discardDialogController,
+      readCurrentValue,
+      requestFocus,
+      resetEditorInstance,
+      scrollToEditor,
+    ])
 
     const handleFocus = useCallback(
       (event: FocusEvent<HTMLDivElement>) => {
@@ -255,6 +268,7 @@ export const CommentInput = forwardRef<CommentInputHandle, CommentInputProps>(
           >
             <EditorRefPlugin ref={editorRef} />
             <EventListenerPlugin on={handleEvent} />
+            {onChange ? <ValueChangePlugin onChange={onChange} /> : null}
             <OneLinePlugin />
             <UpdateReadOnlyPlugin readOnly={readOnly ?? false} />
             <UpdateValuePlugin value={value ?? undefined} />
@@ -262,10 +276,10 @@ export const CommentInput = forwardRef<CommentInputHandle, CommentInputProps>(
               expandOnFocus={expandOnFocus}
               focused={focused}
               focusOnMount={focusOnMount}
+              initialMessage={value}
               mentionOptions={mentionOptions}
               onMentionMenuOpenChange={onMentionMenuOpenChange}
               readOnly={readOnly}
-              value={value}
             >
               {focusLock && <div ref={preDivRef} tabIndex={0} />}
 
@@ -314,6 +328,26 @@ function UpdateReadOnlyPlugin(props: {readOnly: boolean}) {
  * `EditorProvider` doesn't have a `value` prop. This plugin listens for the
  * prop change and sends an `update value` event to the editor.
  */
+/**
+ * Reports the editor's value to the consumer whenever it changes.
+ *
+ * The subscription is synchronous with the editor's value (no debounce, so a
+ * submit never reads a lagging draft) and lives inside the editor instance's
+ * React tree (so it dies with the instance and cannot fire during teardown,
+ * which used to resurrect a just-submitted draft into the consumer's state).
+ */
+function ValueChangePlugin(props: {onChange: (value: PortableTextBlock[]) => void}) {
+  const {onChange} = props
+  const editor = useEditor()
+  const value = useEditorSelector(editor, getValue)
+
+  useEffect(() => {
+    onChange(value || EMPTY_ARRAY)
+  }, [onChange, value])
+
+  return null
+}
+
 function UpdateValuePlugin(props: {value: Array<PortableTextBlock> | undefined}) {
   const editor = useEditor()
 

--- a/packages/sanity/src/core/comments/components/pte/comment-input/CommentInputProvider.tsx
+++ b/packages/sanity/src/core/comments/components/pte/comment-input/CommentInputProvider.tsx
@@ -1,11 +1,19 @@
-import {type EditorSelection, PortableTextEditor, usePortableTextEditor} from '@portabletext/editor'
+import {
+  type EditorSelection,
+  PortableTextEditor,
+  useEditor,
+  useEditorSelector,
+  usePortableTextEditor,
+} from '@portabletext/editor'
+import {getValue} from '@portabletext/editor/selectors'
 import {isPortableTextSpan, type Path} from '@sanity/types'
+import isEqual from 'lodash-es/isEqual.js'
 import {type ReactNode, useCallback, useMemo, useState} from 'react'
 import {CommentInputContext} from 'sanity/_singletons'
 
 import {useDidUpdate} from '../../../../form'
 import {type UserListWithPermissionsHookValue} from '../../../../hooks'
-import {hasCommentMessageValue, useCommentHasChanged} from '../../../helpers'
+import {hasCommentMessageValue} from '../../../helpers'
 import {type CommentMessage} from '../../../types'
 
 export interface CommentInputContextValue {
@@ -33,10 +41,11 @@ interface CommentInputProviderProps {
   expandOnFocus?: boolean
   focused: boolean
   focusOnMount?: boolean
+  /** The message the editor was initialized with; `hasChanges` compares against it. */
+  initialMessage?: CommentMessage
   mentionOptions: UserListWithPermissionsHookValue
   onMentionMenuOpenChange?: (open: boolean) => void
   readOnly?: boolean
-  value: CommentMessage
 }
 
 export function CommentInputProvider(props: CommentInputProviderProps) {
@@ -45,13 +54,18 @@ export function CommentInputProvider(props: CommentInputProviderProps) {
     expandOnFocus = false,
     focused,
     focusOnMount = false,
+    initialMessage,
     mentionOptions,
     onMentionMenuOpenChange,
-    value,
     readOnly,
   } = props
 
   const editor = usePortableTextEditor()
+
+  // The editor owns the draft: derive the value directly instead of routing
+  // it through the consumer's state and back down as a prop.
+  const editorInstance = useEditor()
+  const value = useEditorSelector(editorInstance, getValue)
 
   const [mentionsMenuOpen, setMentionsMenuOpen] = useState<boolean>(false)
   const [mentionsSearchTerm, setMentionsSearchTerm] = useState<string>('')
@@ -59,7 +73,13 @@ export function CommentInputProvider(props: CommentInputProviderProps) {
 
   const canSubmit = useMemo(() => hasCommentMessageValue(value), [value])
 
-  const hasChanges = useCommentHasChanged(value)
+  // Normalize "no message" to `null` on both sides so an empty editor equals
+  // an absent initial message.
+  const hasChanges = useMemo(() => {
+    const currentMessage = hasCommentMessageValue(value) ? value : null
+    const startMessage = hasCommentMessageValue(initialMessage ?? null) ? initialMessage : null
+    return !isEqual(startMessage ?? null, currentMessage)
+  }, [initialMessage, value])
 
   const focusEditor = useCallback(() => {
     if (readOnly) return

--- a/packages/sanity/src/core/comments/components/pte/comment-input/__tests__/CommentInput.browser.test.tsx
+++ b/packages/sanity/src/core/comments/components/pte/comment-input/__tests__/CommentInput.browser.test.tsx
@@ -61,5 +61,28 @@ describe('Comments', () => {
       await userEvent.keyboard('{Enter}')
       await submitted
     })
+
+    it('Should start the next comment empty after submitting the previous one', async () => {
+      const {insertPortableText} = testHelpers()
+      let resolve!: () => void
+      const submitted = Object.assign(new Promise<void>((r) => (resolve = r)), {resolve})
+
+      void render(<CommentsInputStory onSubmit={submitted.resolve} />)
+      const $editable = page.getByTestId('comment-input-editable')
+      await expect.element($editable).toBeVisible()
+      await insertPortableText('First comment', $editable)
+      await expect.element(page.getByTestId('comment-input-send-button')).toBeEnabled()
+      // Type more text and submit immediately, without waiting for any
+      // editor-to-consumer sync: the editor owns the draft, so the submit
+      // must carry the full text and the next comment must start empty.
+      await userEvent.keyboard(' typed')
+      await userEvent.keyboard('{Enter}')
+      await submitted
+
+      await expect.element($editable).not.toHaveTextContent('First comment')
+
+      await insertPortableText('Second comment', $editable)
+      await expect.element($editable).toHaveTextContent(/^Second comment$/)
+    })
   })
 })

--- a/packages/sanity/src/core/comments/components/pte/comment-input/__tests__/CommentInputStory.tsx
+++ b/packages/sanity/src/core/comments/components/pte/comment-input/__tests__/CommentInputStory.tsx
@@ -1,6 +1,5 @@
 import {type CurrentUser, type PortableTextBlock} from '@sanity/types'
 import noop from 'lodash-es/noop.js'
-import {useState} from 'react'
 import {CommentInput} from 'sanity'
 
 import {TestWrapper} from '../../../../../../../test/browser/TestWrapper'
@@ -42,7 +41,6 @@ export function CommentsInputStory({
   onSubmit?: () => void
   value?: PortableTextBlock[] | null
 }) {
-  const [valueState, setValueState] = useState<PortableTextBlock[] | null>(value)
   return (
     <TestWrapper schemaTypes={SCHEMA_TYPES}>
       <CommentInput
@@ -50,8 +48,7 @@ export function CommentsInputStory({
         placeholder="Your comment..."
         focusLock
         currentUser={currentUser}
-        onChange={setValueState}
-        value={valueState}
+        value={value}
         mentionOptions={MENTION_DATA}
         onDiscardConfirm={onDiscardConfirm}
         onDiscardCancel={onDiscardCancel}

--- a/packages/sanity/src/core/comments/helpers.ts
+++ b/packages/sanity/src/core/comments/helpers.ts
@@ -1,14 +1,6 @@
 import {isPortableTextSpan, isPortableTextTextBlock} from '@sanity/types'
-import isEqual from 'lodash-es/isEqual.js'
-import {useMemo, useState} from 'react'
 
 import {type CommentContext, type CommentDocument, type CommentMessage} from './types'
-
-export function useCommentHasChanged(message: CommentMessage): boolean {
-  const [prevMessage] = useState<CommentMessage>(message)
-
-  return useMemo(() => !isEqual(prevMessage, message), [prevMessage, message])
-}
 
 /**
  * @internal

--- a/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
+++ b/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
@@ -91,7 +91,6 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
   const [authoringDecorationElement, setAuthoringDecorationElement] =
     useState<HTMLSpanElement | null>(null)
 
-  const [nextCommentValue, setNextCommentValue] = useState<CommentMessage | null>(null)
   const [nextCommentSelection, setNextCommentSelection] = useState<EditorSelection | null>(null)
 
   const [currentSelection, setCurrentSelection] = useState<EditorSelection | null>(null)
@@ -123,7 +122,6 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
     setCurrentSelection(null)
     setCurrenSelectionRect(null)
     setNextCommentSelection(null)
-    setNextCommentValue(null)
     setCanSubmit(false)
     setAuthoringDecorationElement(null)
     setFragment(null)
@@ -555,12 +553,10 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
           <InlineCommentInputPopover
             currentUser={currentUser}
             mentionOptions={mentionOptions}
-            onChange={setNextCommentValue}
             onClickOutside={resetStates}
             onDiscardConfirm={handleCommentDiscardConfirm}
             onSubmit={handleSubmit}
             referenceElement={popoverAuthoringReferenceElement}
-            value={nextCommentValue}
           />
         )}
         <AnimatePresence>

--- a/packages/sanity/src/core/comments/plugin/input/components/InlineCommentInputPopover.tsx
+++ b/packages/sanity/src/core/comments/plugin/input/components/InlineCommentInputPopover.tsx
@@ -16,24 +16,20 @@ const RootStack = styled(Stack)`
 interface InlineCommentInputPopoverProps {
   currentUser: CurrentUser
   mentionOptions: CommentInputProps['mentionOptions']
-  onChange: CommentInputProps['onChange']
   onClickOutside: () => void
   onDiscardConfirm: CommentInputProps['onDiscardConfirm']
   onSubmit: CommentInputProps['onSubmit']
   referenceElement?: HTMLElement | null
-  value: CommentInputProps['value']
 }
 
 export function InlineCommentInputPopover(props: InlineCommentInputPopoverProps) {
   const {
     currentUser,
     mentionOptions,
-    onChange,
     onClickOutside,
     onDiscardConfirm,
     onSubmit,
     referenceElement,
-    value,
   } = props
 
   const commentInputRef = useRef<CommentInputHandle | null>(null)
@@ -50,7 +46,7 @@ export function InlineCommentInputPopover(props: InlineCommentInputPopoverProps)
 
   useClickOutsideEvent(
     () => {
-      const hasValue = hasCommentMessageValue(value)
+      const hasValue = hasCommentMessageValue(commentInputRef.current?.getValue() ?? null)
 
       if (hasValue) {
         commentInputRef.current?.discardDialogController.open()
@@ -69,12 +65,10 @@ export function InlineCommentInputPopover(props: InlineCommentInputPopoverProps)
         focusLock
         focusOnMount
         mentionOptions={mentionOptions}
-        onChange={onChange}
         onDiscardCancel={handleDiscardCancel}
         onDiscardConfirm={handleDiscardConfirm}
         onSubmit={onSubmit}
         ref={commentInputRef}
-        value={value}
       />
     </RootStack>
   )

--- a/packages/sanity/src/core/tasks/components/activity/TasksActivityCommentInput.tsx
+++ b/packages/sanity/src/core/tasks/components/activity/TasksActivityCommentInput.tsx
@@ -1,5 +1,6 @@
+import {type PortableTextBlock} from '@sanity/types'
 import {Card} from '@sanity/ui'
-import {useCallback, useMemo, useRef, useState} from 'react'
+import {useCallback, useRef} from 'react'
 
 import {
   CommentInput,
@@ -15,27 +16,22 @@ import {ActivityItem} from './TasksActivityItem'
 interface TasksCommentActivityInputProps {
   currentUser: CommentInputProps['currentUser']
   mentionOptions: CommentInputProps['mentionOptions']
-  onSubmit: (message: CommentInputProps['value']) => void
+  onSubmit: (message: PortableTextBlock[]) => void
 }
 
 export function TasksActivityCommentInput(props: TasksCommentActivityInputProps) {
   const {mentionOptions, currentUser, onSubmit} = props
   const {mode} = useTasksEnabled()
-  const [value, setValue] = useState<CommentInputProps['value']>(null)
   const editorRef = useRef<CommentInputHandle>(null)
 
-  const hasValue = useMemo(() => hasCommentMessageValue(value), [value])
-
-  const handleChange = useCallback((nextValue: CommentInputProps['value']) => {
-    setValue(nextValue)
-  }, [])
-
-  const handleSubmit = useCallback(() => {
-    if (hasValue) {
-      onSubmit(value)
-      setValue(null)
-    }
-  }, [hasValue, onSubmit, value])
+  const handleSubmit = useCallback(
+    (nextValue: PortableTextBlock[]) => {
+      if (hasCommentMessageValue(nextValue)) {
+        onSubmit(nextValue)
+      }
+    },
+    [onSubmit],
+  )
 
   const handleDiscardCancel = useCallback(() => {
     editorRef.current?.discardDialogController.close()
@@ -43,25 +39,20 @@ export function TasksActivityCommentInput(props: TasksCommentActivityInputProps)
 
   const handleDiscardConfirm = useCallback(() => {
     editorRef.current?.discardDialogController.close()
-    setValue(null)
   }, [])
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault()
-        e.stopPropagation()
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      e.stopPropagation()
 
-        if (hasValue) {
-          editorRef.current?.discardDialogController.open()
-        } else {
-          editorRef.current?.discardDialogController.close()
-          setValue(null)
-        }
+      if (hasCommentMessageValue(editorRef.current?.getValue() ?? null)) {
+        editorRef.current?.discardDialogController.open()
+      } else {
+        editorRef.current?.discardDialogController.close()
       }
-    },
-    [hasValue],
-  )
+    }
+  }, [])
   const {t} = useTranslation(tasksLocaleNamespace)
 
   return (
@@ -72,7 +63,6 @@ export function TasksActivityCommentInput(props: TasksCommentActivityInputProps)
           currentUser={currentUser}
           expandOnFocus
           mentionOptions={mentionOptions}
-          onChange={handleChange}
           onDiscardConfirm={handleDiscardConfirm}
           onDiscardCancel={handleDiscardCancel}
           onKeyDown={handleKeyDown}
@@ -84,7 +74,6 @@ export function TasksActivityCommentInput(props: TasksCommentActivityInputProps)
               : t('panel.comment.placeholder')
           }
           ref={editorRef}
-          value={value}
         />
       </Card>
     </ActivityItem>

--- a/packages/sanity/src/core/tasks/components/activity/TasksActivityLog.tsx
+++ b/packages/sanity/src/core/tasks/components/activity/TasksActivityLog.tsx
@@ -1,4 +1,4 @@
-import {type Path} from '@sanity/types'
+import {type Path, type PortableTextBlock} from '@sanity/types'
 import {Box, Flex, Stack, Text} from '@sanity/ui'
 import {uuid} from '@sanity/uuid'
 import {AnimatePresence, motion, type Variants} from 'motion/react'
@@ -95,7 +95,7 @@ export function TasksActivityLog(props: TasksActivityLogProps) {
     }
   }
 
-  const handleCommentCreate = async (message: CommentInputProps['value']) => {
+  const handleCommentCreate = async (message: PortableTextBlock[]) => {
     const commentId = uuid()
     const notification = handleGetNotificationValue(message, commentId)
 


### PR DESCRIPTION
### Description

Starting a new Portable Text comment after submitting one pre-fills the composer with the previous comment's text. This is the surviving half of the report behind #13104.

The root cause is that the composer's draft had two sources of truth: the editor owns the content, and every consumer mirrored a copy in React state, synced from the editor's `mutation` events. `mutation` is the editor's persistence channel, debounced while typing and deliberately flushed during teardown so document patches are never lost. Both properties corrupted the mirror: the debounce made submits read a lagging draft (the truncation #13104 worked around), and the teardown flush fired after consumers reset their draft on submit, writing the submitted text back into the state they had just cleared. The next composer opened with the resurrected draft.

Rather than patching the mirror's timing holes, this makes the editor the single source of truth. `CommentInputProvider` derives the value straight from the editor (`useEditorSelector(editor, getValue)`) for `canSubmit` and `hasChanges`, so the composer no longer routes its own value up through the consumer and back down as a prop. The five composer consumers drop their draft state entirely: submits carry the value through `onSubmit`'s argument, and interaction-time decisions (discard gating, click-outside) read through the handle's new `getValue()`. Both failure classes, lagging draft and resurrected draft, become unrepresentable.

`value` and `onChange` stay on `CommentInputProps` for the two genuine persistence consumers: the tasks `DescriptionInput` uses the pair as a controlled form input, and `CommentsField` caches drafts per change. `onChange` (now optional) is fed by a value subscription that is synchronous and dies with the editor instance, so it cannot report during teardown either.

Behavior deltas, all improvements: the send button enables immediately after typing instead of after the debounce; the edit flow's `hasChanges` compares against the message as it was when editing started, so a remote update mid-edit no longer clobbers the draft; and drafts cached on abrupt close include the final keystrokes they previously missed.

### What to review

`CommentInput.tsx` and `CommentInputProvider.tsx` carry the design; the consumer diffs are mechanical deletions of mirror state. The edit flow (`CommentsListItemLayout`) is the subtlest consumer: `editStartMessage` freezes the message at edit start and serves as both the editor's initial value and the `hasChanges` reference.

The browser test pins the headline contract end-to-end: type, submit immediately, and the next comment starts empty. It fails on `main` and passes here, verified in both directions.

### Testing

1. Enable Comments, comment on a span of Portable Text, submit with Enter right after typing (no pause): the full text should be saved, and highlighting a different span should open an empty composer.
2. Same for discarding a draft and for clicking outside the composer.
3. Reply to and edit an existing comment; in edit mode, Escape with unsaved changes should ask before discarding, and without changes should close silently.
4. Tasks: type a task description (persists as you type) and add a task comment.

### Notes for release

Fixes a bug where starting a new Portable Text comment after submitting the previous one would pre-fill the comment input with the text of the previous comment.

