### PR TITLE
refactor(sanity): reduce data needed by `setVariant` to simply the variant id

### DIFF
--- a/packages/sanity/src/core/perspective/__tests__/useSetVariant.test.ts
+++ b/packages/sanity/src/core/perspective/__tests__/useSetVariant.test.ts
@@ -22,7 +22,7 @@ describe('useSetVariant', () => {
   it('sets the variant sticky param without touching the perspective', () => {
     const {result} = renderHook(() => useSetVariant())
 
-    result.current(variantAlphaAudience)
+    result.current(variantAlphaAudience._id)
 
     expect(mockNavigate).toHaveBeenCalledWith({
       stickyParams: {
@@ -46,7 +46,7 @@ describe('useSetVariant', () => {
   it('sets the variant and perspective sticky params in a single navigation', () => {
     const {result} = renderHook(() => useSetVariant())
 
-    result.current(variantAlphaAudience, {perspective: 'published'})
+    result.current(variantAlphaAudience._id, {perspective: 'published'})
 
     expect(mockNavigate).toHaveBeenCalledTimes(1)
     expect(mockNavigate).toHaveBeenCalledWith({
@@ -61,7 +61,7 @@ describe('useSetVariant', () => {
   it('clears the perspective sticky param when the perspective is the default perspective', () => {
     const {result} = renderHook(() => useSetVariant())
 
-    result.current(variantAlphaAudience, {perspective: 'drafts'})
+    result.current(variantAlphaAudience._id, {perspective: 'drafts'})
 
     expect(mockNavigate).toHaveBeenCalledWith({
       stickyParams: {
@@ -75,7 +75,7 @@ describe('useSetVariant', () => {
   it('sets a release id as the perspective sticky param', () => {
     const {result} = renderHook(() => useSetVariant())
 
-    result.current(variantAlphaAudience, {perspective: 'rSomeRelease'})
+    result.current(variantAlphaAudience._id, {perspective: 'rSomeRelease'})
 
     expect(mockNavigate).toHaveBeenCalledWith({
       stickyParams: {

--- a/packages/sanity/src/core/perspective/useSetVariant.tsx
+++ b/packages/sanity/src/core/perspective/useSetVariant.tsx
@@ -20,12 +20,15 @@ export function useSetVariant() {
   const router = useRouter()
   const defaultPerspective = useGetDefaultPerspective()
   const setVariant = useCallback(
-    (variant: SystemVariant | undefined, options?: {perspective?: SystemBundle | ReleaseId}) => {
+    (
+      variantId: SystemVariant['_id'] | undefined,
+      options?: {perspective?: SystemBundle | ReleaseId},
+    ) => {
       const {perspective} = options ?? {}
 
       router.navigate({
         stickyParams: {
-          variant: variant ? getVariantId(variant._id) : null,
+          variant: variantId ? getVariantId(variantId) : null,
           ...(perspective
             ? {
                 excludedPerspectives: null,

--- a/packages/sanity/src/core/variants/plugin/components/VariantsMenu.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/VariantsMenu.tsx
@@ -71,7 +71,7 @@ export function VariantsMenu(): React.JSX.Element {
 
   const handleSelectVariant = useCallback(
     (variant: SystemVariant) => {
-      setVariant(variant)
+      setVariant(variant._id)
       setFilterQuery('')
     },
     [setVariant],

--- a/packages/sanity/src/structure/hooks/useDocumentPerspectiveList.ts
+++ b/packages/sanity/src/structure/hooks/useDocumentPerspectiveList.ts
@@ -267,7 +267,7 @@ export function useDocumentPerspectiveList(): DocumentPerspectiveList {
       // Passing the perspective alongside the variant updates both sticky params atomically.
       const versionBundle = version._system.bundleId
       const perspective = !versionBundle ? 'published' : versionBundle
-      setVariant(variant ?? undefined, {perspective})
+      setVariant(variant?._id, {perspective})
     },
     [setVariant, variants],
   )


### PR DESCRIPTION
### Description

When calling `setVariant`, the function signature currently requires that a complete `SystemVariant` object is provided. The function only needs the id. This change allows callers to use `setVariant` without first needing to resolve a complete `SystemVariant` object.

### What to review

`setVariant`  function.

### Testing

Tests pass, setting a variant works.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small internal/beta API signature change with updated call sites; router sticky-param behavior is unchanged.
> 
> **Overview**
> **`useSetVariant`** now takes a variant document id (`SystemVariant['_id'] | undefined`) instead of a full **`SystemVariant`**, and still maps it through **`getVariantId`** for router sticky params. Optional perspective handling is unchanged.
> 
> Call sites (**`VariantsMenu`**, **`useDocumentPerspectiveList`**) and unit tests were updated to pass **`variant._id`** (or **`variant?._id`**) so navigation behavior stays the same while callers no longer need a resolved variant object at the type level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 178b2bc417922d7b7b8ba4bb2045b928364eab2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->