### PR TITLE
chore(sanity): list variants in document group inventory

### DIFF
--- a/e2e/tests/document-actions/unpublish.spec.ts
+++ b/e2e/tests/document-actions/unpublish.spec.ts
@@ -33,8 +33,14 @@ test(`should be able to unpublish a published document`, async ({page, createDra
 
   const inventoryButton = page.getByTestId('action-document-group-inventory')
   const inventory = page.getByTestId('document-group-inventory')
-  const publishedVariant = inventory.getByRole('button', {name: 'Published', exact: true})
-  const draftVariant = inventory.getByRole('button', {name: 'Draft', exact: true})
+
+  const publishedVariant = inventory
+    .locator('[data-variant-set="Published"]')
+    .getByRole('button', {name: 'All users (Default)', exact: true})
+
+  const draftVariant = inventory
+    .locator('[data-variant-set="Draft"]')
+    .getByRole('button', {name: 'All users (Default)', exact: true})
 
   // Open the inventory and switch to the published variant.
   await inventoryButton.click()

--- a/e2e/tests/releases/displayDocument/DisplayedDocument.spec.ts
+++ b/e2e/tests/releases/displayDocument/DisplayedDocument.spec.ts
@@ -31,8 +31,16 @@ test.describe.configure({mode: 'serial'})
  * It lists the document's existing variants (Published, Draft, releases) in a popover, with the
  * currently selected perspective marked via a `data-selected` attribute on the variant row.
  */
-function getInventoryVariant(page: Page, variantName: string) {
-  return page.getByTestId(`document-group-inventory-variant-${variantName.replaceAll(' ', '-')}`)
+function getInventoryVariant(
+  page: Page,
+  variantSet: string = 'Published',
+  variantName: string = 'All users (Default)',
+) {
+  const inventory = page.getByTestId('document-group-inventory')
+
+  return inventory.locator(
+    `[data-variant-set="${variantSet}"] [data-variant-name="${variantName}"]`,
+  )
 }
 
 async function openDocumentGroupInventory(page: Page) {

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -21,6 +21,8 @@ import {useSchema} from '../../hooks/useSchema'
 import {useTranslation} from '../../i18n'
 import {feedbackLocaleNamespace, studioLocaleNamespace} from '../../i18n/localeNamespaces'
 import {type TargetPerspective} from '../../perspective/types'
+import {type SetVariant, useSetVariant} from '../../perspective/useSetVariant'
+import {getReleaseIdFromReleaseDocumentId} from '../../releases'
 import {VersionContextMenuDialogs} from '../../releases/components/documentHeader/contextMenu/VersionContextMenuDialogs'
 import {VersionContextMenuPopover} from '../../releases/components/documentHeader/contextMenu/VersionContextMenuPopover'
 import {ReleaseAvatarIcon} from '../../releases/components/ReleaseAvatar'
@@ -40,12 +42,18 @@ import {
   isDraftId,
   isPublishedId,
   isVersionId,
+  type SystemBundle,
 } from '../../util/draftUtils'
+import {readVersionType} from '../../util/versionsUtils'
 import {type VariantStoreState} from '../../variants/store/reducer'
 import {useVariantsStore} from '../../variants/store/useVariantsStore'
+import {isVariantId} from '../../variants/types'
 import {deletionMachine, type ReferringDocuments} from '../machines/deletionMachine'
-import {documentGroupInventoryMachine} from '../machines/documentGroupInventoryMachine'
-import {selectionMachine} from '../machines/selectionMachine'
+import {
+  documentGroupInventoryMachine,
+  type VariantSet as VariantSetType,
+} from '../machines/documentGroupInventoryMachine'
+import {selectionMachine, type Variant} from '../machines/selectionMachine'
 import {
   type DocumentGroupInventoryPerspectiveList,
   type DocumentGroupInventoryReferencePreviewLinkProps,
@@ -73,10 +81,6 @@ export interface DocumentGroupInventoryProps {
    */
   portalElementName: string
   /**
-   * Navigate to the provided perspective.
-   */
-  navigatePerspective: (perspective: TargetPerspective) => void
-  /**
    * Derived perspective list state for the inventory document.
    */
   perspectiveList: DocumentGroupInventoryPerspectiveList
@@ -101,7 +105,6 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
   documentType,
   documentId,
   portalElementName,
-  navigatePerspective,
   perspectiveList,
   referringDocuments$,
   components,
@@ -120,6 +123,7 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
   const filterStringEvent = useMemo(() => new Subject<ChangeEvent<HTMLInputElement>>(), [])
   const [menuPortalElement, setMenuPortalElement] = useState<HTMLDivElement | null>(null)
   const {feedbackDialogOpened} = useFeedbackTelemetry()
+  const setVariant = useSetVariant()
 
   const filterString = useMemo(
     () =>
@@ -242,27 +246,7 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
               documentType={documentType}
               menuPortalElement={menuPortalElement}
               perspectiveList={perspectiveList}
-              onPrimaryAction={(variantId) => {
-                let perspective: TargetPerspective | undefined
-
-                switch (true) {
-                  case isPublishedId(variantId):
-                    perspective = 'published'
-                    break
-                  case isDraftId(variantId):
-                    perspective = 'drafts'
-                    break
-                  case isVersionId(variantId):
-                    perspective = getVersionFromId(variantId)
-                    break
-                  default:
-                    perspective = undefined
-                }
-
-                if (typeof perspective !== 'undefined') {
-                  navigatePerspective(perspective)
-                }
-              }}
+              onPrimaryAction={setVariant}
             />
           )}
         </Body>
@@ -305,7 +289,7 @@ const Select: ComponentType<{
   machine: ActorRefFromLogic<typeof selectionMachine>
   inventoryRef: ActorRefFromLogic<typeof documentGroupInventoryMachine>
   documentType: string
-  onPrimaryAction: (variantId: string) => void
+  onPrimaryAction: SetVariant
   menuPortalElement: HTMLElement | null
   perspectiveList: DocumentGroupInventoryPerspectiveList
 }> = ({
@@ -335,15 +319,10 @@ const Select: ComponentType<{
   return (
     <Stack gap={5}>
       {sets.map((set) => (
-        <VariantSet key={set.key}>
+        <VariantSet key={set.key} data-variant-set={set.name}>
           <VariantSetHeader as="header">
             <Text size={1} weight="bold">
-              {t('document-group-inventory.title', {
-                count: set.variants.length,
-                subject: t('document-group.subject.version', {
-                  count: set.variants.length,
-                }),
-              })}
+              {set.name}
             </Text>
             <TextButton
               onClick={() => {
@@ -382,11 +361,11 @@ const Select: ComponentType<{
 }
 
 const Variant: ComponentType<{
-  variant: {id: string; name: string}
+  variant: Variant
   machine: ActorRefFromLogic<typeof selectionMachine>
   inventoryRef: ActorRefFromLogic<typeof documentGroupInventoryMachine>
   documentType: string
-  onPrimaryAction: (variantId: string) => void
+  onPrimaryAction: SetVariant
   isSelectable: boolean
   menuPortalElement: HTMLElement | null
   perspectiveList: DocumentGroupInventoryPerspectiveList
@@ -459,16 +438,39 @@ const Variant: ComponentType<{
 
   return (
     <>
-      <VariantSetEntry
-        data-testid={`document-group-inventory-variant-${variant.name.replaceAll(' ', '-')}`}
-        data-selected={isSelected || undefined}
-      >
+      <VariantSetEntry data-variant-name={variant.name} data-selected={isSelected || undefined}>
         <div className="atom">
           <button
             type="button"
             className="primary-action"
             ref={setReferenceElement}
-            onClick={() => onPrimaryAction(variant.id)}
+            onClick={() => {
+              let bundle
+
+              switch (readVersionType(variant.document)) {
+                case 'release':
+                  bundle = getReleaseIdFromReleaseDocumentId(
+                    variant?.document?._system.release?._ref ?? '',
+                  )
+                  break
+                case 'published':
+                  bundle = 'published'
+                  break
+                case 'draft':
+                  bundle = 'drafts'
+                  break
+              }
+
+              const variantId = isVariantId(variant.document?._system?.variant?._ref)
+                ? variant.document._system.variant._ref
+                : undefined
+
+              const agentId = isAgentBundleName(getVersionFromId(variant.id))
+                ? getVersionFromId(variant.id)
+                : undefined
+
+              onPrimaryAction({variantId, perspective: agentId ?? bundle})
+            }}
             onContextMenu={contextMenuHandler}
           >
             {variant.name}

--- a/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.test.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.test.ts
@@ -4,7 +4,9 @@ import {describe, expect, it, vi} from 'vitest'
 import {createActor, fromObservable, fromPromise} from 'xstate'
 
 import {type TFunction} from '../../i18n/types'
+import {type VersionInfoDocumentStub} from '../../releases/store/types'
 import {getReleaseDocumentIdFromReleaseId} from '../../releases/util/getReleaseDocumentIdFromReleaseId'
+import {getPublishedId, getVersionFromId, isDraftId, isVersionId} from '../../util/draftUtils'
 import {deletionMachine} from './deletionMachine'
 import {documentGroupInventoryMachine, type Meta} from './documentGroupInventoryMachine'
 import {selectionMachine} from './selectionMachine'
@@ -73,9 +75,37 @@ function withCrossDatasetReferences(
 // it up when the variants feature is disabled.
 const loadedVariants: Meta['variants'] = {variants: new Map(), state: 'loaded'}
 
+// Builds the version document stub the way `useDocumentVersions` emits it,
+// deriving `_system` from the document id.
+function versionStub(id: string): VersionInfoDocumentStub {
+  const bundleId = getVersionFromId(id)
+  const group = {_ref: getPublishedId(id), _weak: true} as const
+
+  return {
+    _id: id,
+    _rev: 'rev',
+    _createdAt: '2024-01-01T00:00:00.000Z',
+    _updatedAt: '2024-01-01T00:00:00.000Z',
+    _system: isDraftId(id)
+      ? {bundleId: 'drafts', group}
+      : isVersionId(id) && typeof bundleId === 'string'
+        ? {
+            bundleId,
+            release: {_ref: getReleaseDocumentIdFromReleaseId(bundleId), _weak: true},
+            group,
+          }
+        : {group},
+  }
+}
+
 // Minimal meta that drives the selection machine straight to `ready`.
 const loadedMeta = {
-  versionState: {data: ['drafts.foo', 'foo'], loading: false, error: null},
+  versionState: {
+    data: ['drafts.foo', 'foo'],
+    versions: [versionStub('drafts.foo'), versionStub('foo')],
+    loading: false,
+    error: null,
+  },
   releases: {releases: new Map(), state: 'loaded' as const},
   variants: loadedVariants,
   agentBundles: {bundles: [], loading: false},
@@ -443,9 +473,11 @@ describe('documentGroupInventoryMachine', () => {
     const releases = new Map<string, ReleaseDocument>([
       [getReleaseDocumentIdFromReleaseId('rABC'), release],
     ])
+    const data = ['drafts.foo', 'foo', 'versions.rABC.foo', 'versions.rXYZ.foo']
     const meta = {
       versionState: {
-        data: ['drafts.foo', 'foo', 'versions.rABC.foo', 'versions.rXYZ.foo'],
+        data,
+        versions: data.map(versionStub),
         loading: false,
         error: null,
       },
@@ -455,11 +487,15 @@ describe('documentGroupInventoryMachine', () => {
     } as unknown as Meta
 
     const expectedVariants = [
-      {id: 'drafts.foo', name: 'Draft'},
-      {id: 'foo', name: 'Published'},
-      {id: 'versions.rABC.foo', name: 'My Release'},
-      // Falls back to the raw id when the release metadata is unknown.
-      {id: 'versions.rXYZ.foo', name: 'versions.rXYZ.foo'},
+      {id: 'drafts.foo', name: 'release.chip.draft', document: versionStub('drafts.foo')},
+      {id: 'foo', name: 'release.chip.published', document: versionStub('foo')},
+      {id: 'versions.rABC.foo', name: 'My Release', document: versionStub('versions.rABC.foo')},
+      // Falls back to the release ref when the release metadata is unknown.
+      {
+        id: 'versions.rXYZ.foo',
+        name: getReleaseDocumentIdFromReleaseId('rXYZ'),
+        document: versionStub('versions.rXYZ.foo'),
+      },
     ]
 
     const {inventoryRef, selectionRef} = createTestActor(loading, {meta})
@@ -476,9 +512,11 @@ describe('documentGroupInventoryMachine', () => {
   })
 
   it('surfaces the most recent agent bundle and hides agent bundle versions from the version state', () => {
+    const data = ['drafts.foo', 'foo', 'versions.agent-abc.foo']
     const meta = {
       versionState: {
-        data: ['drafts.foo', 'foo', 'versions.agent-abc.foo'],
+        data,
+        versions: data.map(versionStub),
         loading: false,
         error: null,
       },
@@ -494,11 +532,11 @@ describe('documentGroupInventoryMachine', () => {
     } as unknown as Meta
 
     const expectedVariants = [
-      {id: 'drafts.foo', name: 'Draft'},
-      {id: 'foo', name: 'Published'},
       // Agent bundle versions are dropped from the version state and only the
-      // most recent bundle is appended, labelled through the translator.
+      // most recent bundle is prepended, labelled through the translator.
       {id: 'versions.agent-abc.foo', name: 'version.agent-bundle.proposed-changes'},
+      {id: 'drafts.foo', name: 'release.chip.draft', document: versionStub('drafts.foo')},
+      {id: 'foo', name: 'release.chip.published', document: versionStub('foo')},
     ]
 
     const {inventoryRef, selectionRef} = createTestActor(loading, {meta})
@@ -511,7 +549,7 @@ describe('documentGroupInventoryMachine', () => {
 
   it('drives the selection machine into the error state when meta reports an error', () => {
     const meta = {
-      versionState: {data: [], loading: false, error: new Error('meta failed')},
+      versionState: {data: [], versions: [], loading: false, error: new Error('meta failed')},
       releases: {releases: new Map(), state: 'loaded' as const},
       variants: loadedVariants,
       agentBundles: {bundles: [], loading: false},

--- a/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.ts
@@ -5,10 +5,9 @@ import {assign, forwardTo, fromObservable, sendTo, setup, type ActorRefFromLogic
 import {type TFunction} from '../../i18n/types'
 import {type DocumentPerspectiveState} from '../../releases/hooks/useDocumentVersions'
 import {type ReleasesReducerState} from '../../releases/store/reducer'
-import {getReleaseDocumentIdFromReleaseId} from '../../releases/util/getReleaseDocumentIdFromReleaseId'
-import {isAgentBundleName, type AgentBundlesState} from '../../store/agent/createAgentBundlesStore'
-import {getVersionFromId, isDraftId, isPublishedId} from '../../util/draftUtils'
+import {type AgentBundlesState} from '../../store/agent/createAgentBundlesStore'
 import {type VariantStoreState} from '../../variants/store/reducer'
+import {computeSets} from '../utils/computeSets'
 import {type deletionMachine} from './deletionMachine'
 import {type selectionMachine, type Variant} from './selectionMachine'
 
@@ -24,6 +23,7 @@ export interface Meta {
 
 export interface VariantSet {
   key: string
+  name: string
   variants: Variant[]
 }
 
@@ -147,61 +147,4 @@ function metaHasError(meta: Meta | undefined): boolean {
 
 function metaIsLoaded(meta: Meta | undefined): boolean {
   return meta?.versionState.loading === false && meta.releases.state === 'loaded'
-}
-
-function computeSets({
-  meta,
-  current,
-  t,
-  variantsEnabled,
-}: {
-  meta: Meta | undefined
-  current: VariantSet[]
-  t: TFunction
-  variantsEnabled: boolean | undefined
-}): VariantSet[] {
-  if (!meta) {
-    return current
-  }
-
-  const {releases} = meta.releases
-  const userBundleIds = new Set(meta.agentBundles.bundles.map(({id}) => id))
-  const proposedChangesId = meta.versionState.data.find((id) => {
-    const bundleId = getVersionFromId(id)
-    return typeof bundleId === 'string' && userBundleIds.has(bundleId)
-  })
-
-  return [
-    {
-      key: 'studio:all',
-      variants: meta.versionState.data
-        .filter((id) => !isAgentBundleName(getVersionFromId(id)))
-        .map((id) => ({
-          id,
-          name: getVariantName(id, releases),
-        }))
-        .concat(
-          typeof proposedChangesId === 'undefined'
-            ? []
-            : {
-                id: proposedChangesId,
-                name: t('version.agent-bundle.proposed-changes'),
-              },
-        ),
-    },
-  ]
-}
-
-function getVariantName(documentId: string, releases: Map<string, ReleaseDocument>): string {
-  if (isDraftId(documentId)) {
-    return 'Draft'
-  }
-
-  if (isPublishedId(documentId)) {
-    return 'Published'
-  }
-
-  const version = getVersionFromId(documentId)
-  const release = version ? releases.get(getReleaseDocumentIdFromReleaseId(version)) : undefined
-  return release?.metadata.title ?? documentId
 }

--- a/packages/sanity/src/core/documentGroupInventory/machines/selectionMachine.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/selectionMachine.ts
@@ -1,9 +1,14 @@
+import {type ReleaseDocument} from '@sanity/client'
 import {EMPTY} from 'rxjs'
 import {and, assign, fromObservable, sendParent, setup, stateIn} from 'xstate'
+
+import {type VersionInfoDocumentStub} from '../../releases'
 
 export interface Variant {
   id: string
   name: string
+  document?: VersionInfoDocumentStub
+  releaseDocument?: ReleaseDocument
 }
 
 interface SelectionContext {

--- a/packages/sanity/src/core/documentGroupInventory/utils/computeSets.test.ts
+++ b/packages/sanity/src/core/documentGroupInventory/utils/computeSets.test.ts
@@ -1,0 +1,339 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {type DocumentSystem} from '@sanity/types'
+import {describe, expect, it} from 'vitest'
+
+import {type TFunction} from '../../i18n/types'
+import {type VersionInfoDocumentStub} from '../../releases/store/types'
+import {getReleaseDocumentIdFromReleaseId} from '../../releases/util/getReleaseDocumentIdFromReleaseId'
+import {type AgentBundle} from '../../store/agent/createAgentBundlesStore'
+import {
+  variantAlphaAudience,
+  variantNorwegianMarket,
+} from '../../variants/__fixtures__/variants.fixture'
+import {type SystemVariant} from '../../variants/types'
+import {type Meta} from '../machines/documentGroupInventoryMachine'
+import {computeSets} from './computeSets'
+
+const t = ((key: string) => key) as unknown as TFunction
+
+const PUBLISHED_ID = 'article'
+const RELEASE_ID = 'rABC'
+const AGENT_BUNDLE_ID = 'agent-abc123'
+
+const releaseDocument = {metadata: {title: 'My release'}} as unknown as ReleaseDocument
+
+// Builds the version document stub the way `useDocumentVersions` emits it.
+function stub(id: string, system: Partial<DocumentSystem> = {}): VersionInfoDocumentStub {
+  return {
+    _id: id,
+    _rev: 'rev',
+    _createdAt: '2026-01-01T00:00:00.000Z',
+    _updatedAt: '2026-01-01T00:00:00.000Z',
+    _system: {
+      group: {_ref: PUBLISHED_ID, _weak: true},
+      ...system,
+    },
+  }
+}
+
+// The base (variant-less) draft of the document group.
+function draft(): VersionInfoDocumentStub {
+  return stub(`drafts.${PUBLISHED_ID}`, {bundleId: 'drafts'})
+}
+
+// The base (variant-less) published document. The group document references
+// itself, which is how published documents are recognised.
+function published(): VersionInfoDocumentStub {
+  return stub(PUBLISHED_ID)
+}
+
+// A base (variant-less) version of the document inside a release.
+function releaseVersion(releaseId: string): VersionInfoDocumentStub {
+  return stub(`versions.${releaseId}.${PUBLISHED_ID}`, {
+    bundleId: releaseId,
+    release: {_ref: getReleaseDocumentIdFromReleaseId(releaseId), _weak: true},
+  })
+}
+
+// A version held in an agent bundle, produced by Content Agent.
+function agentVersion(bundleId: string): VersionInfoDocumentStub {
+  return stub(`versions.${bundleId}.${PUBLISHED_ID}`, {bundleId})
+}
+
+// A draft of a variant, outside any release.
+function variantDraft(variant: SystemVariant, scopeId: string): VersionInfoDocumentStub {
+  return stub(`drafts.${scopeId}.${PUBLISHED_ID}`, {
+    bundleId: 'drafts',
+    variant: {_ref: variant._id, _weak: true},
+    scopeId,
+  })
+}
+
+// A published variant, outside any release.
+function variantPublished(variant: SystemVariant, scopeId: string): VersionInfoDocumentStub {
+  return stub(`published.${scopeId}.${PUBLISHED_ID}`, {
+    variant: {_ref: variant._id, _weak: true},
+    scopeId,
+  })
+}
+
+// A version of a variant inside a release.
+function variantInRelease(
+  variant: SystemVariant,
+  scopeId: string,
+  releaseId: string,
+): VersionInfoDocumentStub {
+  return stub(`versions.${releaseId}.${scopeId}.${PUBLISHED_ID}`, {
+    bundleId: releaseId,
+    release: {_ref: getReleaseDocumentIdFromReleaseId(releaseId), _weak: true},
+    variant: {_ref: variant._id, _weak: true},
+    scopeId,
+  })
+}
+
+function createMeta({
+  versions,
+  releases = new Map(),
+  variants = new Map(),
+  bundles = [],
+}: {
+  versions: VersionInfoDocumentStub[]
+  releases?: Map<string, ReleaseDocument>
+  variants?: Map<string, SystemVariant>
+  bundles?: AgentBundle[]
+}): Meta {
+  return {
+    versionState: {
+      data: versions.map(({_id}) => _id),
+      versions,
+      loading: false,
+      error: null,
+    },
+    releases: {releases, state: 'loaded'},
+    variants: {variants, state: 'loaded'},
+    agentBundles: {bundles, loading: false},
+  }
+}
+
+describe('computeSets', () => {
+  describe('when Content Variants is not enabled', () => {
+    it('assembles a single set from draft, published, release, and agent documents', () => {
+      const versions = [
+        draft(),
+        published(),
+        releaseVersion(RELEASE_ID),
+        agentVersion(AGENT_BUNDLE_ID),
+      ]
+
+      const meta = createMeta({
+        versions,
+        releases: new Map([[getReleaseDocumentIdFromReleaseId(RELEASE_ID), releaseDocument]]),
+        // The agent bundle is owned by the current user.
+        bundles: [{id: AGENT_BUNDLE_ID, applicationKey: 'application-key'}],
+      })
+
+      expect(computeSets({meta, current: [], t, variantsEnabled: false})).toEqual([
+        {
+          key: 'studio:all',
+          name: 'document-group-inventory.title',
+          variants: [
+            // The user's agent bundle surfaces as "proposed changes" first,
+            // while the raw agent version is hidden from the list.
+            {
+              id: `versions.${AGENT_BUNDLE_ID}.${PUBLISHED_ID}`,
+              name: 'version.agent-bundle.proposed-changes',
+            },
+            {id: `drafts.${PUBLISHED_ID}`, name: 'release.chip.draft', document: versions[0]},
+            {id: PUBLISHED_ID, name: 'release.chip.published', document: versions[1]},
+            {
+              id: `versions.${RELEASE_ID}.${PUBLISHED_ID}`,
+              name: 'My release',
+              document: versions[2],
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  describe('when Content Variants is enabled', () => {
+    it('assembles a set per bundle from draft, published, release, variant, and agent documents', () => {
+      const versions = [
+        draft(),
+        variantDraft(variantAlphaAudience, 'scopeA'),
+        variantDraft(variantNorwegianMarket, 'scopeB'),
+        published(),
+        variantPublished(variantAlphaAudience, 'scopeA'),
+        variantPublished(variantNorwegianMarket, 'scopeB'),
+        releaseVersion(RELEASE_ID),
+        variantInRelease(variantAlphaAudience, 'scopeA', RELEASE_ID),
+        agentVersion(AGENT_BUNDLE_ID),
+      ]
+
+      const meta = createMeta({
+        versions,
+        releases: new Map([[getReleaseDocumentIdFromReleaseId(RELEASE_ID), releaseDocument]]),
+        variants: new Map([
+          [variantAlphaAudience._id, variantAlphaAudience],
+          [variantNorwegianMarket._id, variantNorwegianMarket],
+        ]),
+        // The agent bundle is owned by the current user.
+        bundles: [{id: AGENT_BUNDLE_ID, applicationKey: 'application-key'}],
+      })
+
+      expect(computeSets({meta, current: [], t, variantsEnabled: true})).toEqual([
+        {
+          key: 'studio:content-agent',
+          name: 'content-agent',
+          variants: [
+            {
+              id: `versions.${AGENT_BUNDLE_ID}.${PUBLISHED_ID}`,
+              name: 'version.agent-bundle.proposed-changes',
+            },
+          ],
+        },
+        {
+          key: 'drafts',
+          name: 'release.chip.draft',
+          variants: [
+            {
+              id: `drafts.${PUBLISHED_ID}`,
+              name: 'document-group.base-variant',
+              releaseDocument: undefined,
+              document: versions[0],
+            },
+            {
+              id: `drafts.scopeA.${PUBLISHED_ID}`,
+              name: 'Alpha audience',
+              releaseDocument: undefined,
+              document: versions[1],
+            },
+            {
+              id: `drafts.scopeB.${PUBLISHED_ID}`,
+              name: 'Norwegian market',
+              releaseDocument: undefined,
+              document: versions[2],
+            },
+          ],
+        },
+        {
+          key: 'published',
+          name: 'release.chip.published',
+          variants: [
+            {
+              id: PUBLISHED_ID,
+              name: 'document-group.base-variant',
+              releaseDocument: undefined,
+              document: versions[3],
+            },
+            {
+              id: `published.scopeA.${PUBLISHED_ID}`,
+              name: 'Alpha audience',
+              releaseDocument: undefined,
+              document: versions[4],
+            },
+            {
+              id: `published.scopeB.${PUBLISHED_ID}`,
+              name: 'Norwegian market',
+              releaseDocument: undefined,
+              document: versions[5],
+            },
+          ],
+        },
+        {
+          key: getReleaseDocumentIdFromReleaseId(RELEASE_ID),
+          name: 'My release',
+          variants: [
+            {
+              id: `versions.${RELEASE_ID}.${PUBLISHED_ID}`,
+              name: 'document-group.base-variant',
+              releaseDocument,
+              document: versions[6],
+            },
+            {
+              id: `versions.${RELEASE_ID}.scopeA.${PUBLISHED_ID}`,
+              name: 'Alpha audience',
+              releaseDocument,
+              document: versions[7],
+            },
+          ],
+        },
+      ])
+    })
+
+    it('groups variant drafts into the drafts set alongside the base draft', () => {
+      const versions = [
+        draft(),
+        variantDraft(variantAlphaAudience, 'scopeA'),
+        variantDraft(variantNorwegianMarket, 'scopeB'),
+      ]
+
+      const meta = createMeta({
+        versions,
+        variants: new Map([
+          [variantAlphaAudience._id, variantAlphaAudience],
+          [variantNorwegianMarket._id, variantNorwegianMarket],
+        ]),
+      })
+
+      const sets = computeSets({meta, current: [], t, variantsEnabled: true})
+
+      expect(sets).toHaveLength(1)
+      expect(sets[0]?.key).toBe('drafts')
+      expect(sets[0]?.variants.map(({id}) => id)).toEqual([
+        `drafts.${PUBLISHED_ID}`,
+        `drafts.scopeA.${PUBLISHED_ID}`,
+        `drafts.scopeB.${PUBLISHED_ID}`,
+      ])
+    })
+
+    it('groups published variants into the published set alongside the published document', () => {
+      const versions = [
+        published(),
+        variantPublished(variantAlphaAudience, 'scopeA'),
+        variantPublished(variantNorwegianMarket, 'scopeB'),
+      ]
+
+      const meta = createMeta({
+        versions,
+        variants: new Map([
+          [variantAlphaAudience._id, variantAlphaAudience],
+          [variantNorwegianMarket._id, variantNorwegianMarket],
+        ]),
+      })
+
+      const sets = computeSets({meta, current: [], t, variantsEnabled: true})
+
+      expect(sets).toHaveLength(1)
+      expect(sets[0]?.key).toBe('published')
+      expect(sets[0]?.variants.map(({id}) => id)).toEqual([
+        PUBLISHED_ID,
+        `published.scopeA.${PUBLISHED_ID}`,
+        `published.scopeB.${PUBLISHED_ID}`,
+      ])
+    })
+
+    it('groups variants inside a release under that release', () => {
+      const versions = [
+        releaseVersion(RELEASE_ID),
+        variantInRelease(variantAlphaAudience, 'scopeA', RELEASE_ID),
+      ]
+
+      const meta = createMeta({
+        versions,
+        releases: new Map([[getReleaseDocumentIdFromReleaseId(RELEASE_ID), releaseDocument]]),
+        variants: new Map([[variantAlphaAudience._id, variantAlphaAudience]]),
+      })
+
+      const sets = computeSets({meta, current: [], t, variantsEnabled: true})
+
+      expect(sets).toHaveLength(1)
+      expect(sets[0]?.key).toBe(getReleaseDocumentIdFromReleaseId(RELEASE_ID))
+      expect(sets[0]?.name).toBe('My release')
+      expect(sets[0]?.variants.map(({name}) => name)).toEqual([
+        'document-group.base-variant',
+        'Alpha audience',
+      ])
+    })
+  })
+})

--- a/packages/sanity/src/core/documentGroupInventory/utils/computeSets.ts
+++ b/packages/sanity/src/core/documentGroupInventory/utils/computeSets.ts
@@ -1,0 +1,186 @@
+import {type ReleaseDocument} from '@sanity/client'
+
+import {type TFunction} from '../../i18n/types'
+import {type VersionInfoDocumentStub} from '../../releases'
+import {isAgentBundleName} from '../../store/agent/createAgentBundlesStore'
+import {getVersionFromId, type SystemBundle} from '../../util/draftUtils'
+import {readVersionType} from '../../util/versionsUtils'
+import {type SystemVariant} from '../../variants/types'
+import {type Meta, type VariantSet} from '../machines/documentGroupInventoryMachine'
+import {type Variant} from '../machines/selectionMachine'
+
+/**
+ * @internal
+ */
+export function computeSets({
+  meta,
+  current,
+  t,
+  variantsEnabled,
+}: {
+  meta: Meta | undefined
+  current: VariantSet[]
+  t: TFunction
+  variantsEnabled: boolean | undefined
+}): VariantSet[] {
+  if (!meta) {
+    return current
+  }
+
+  const {releases} = meta.releases
+  const {variants} = meta.variants
+  const userBundleIds = new Set(meta.agentBundles.bundles.map(({id}) => id))
+
+  const proposedChangesId = meta.versionState.data.find((id) => {
+    const bundleId = getVersionFromId(id)
+    return typeof bundleId === 'string' && userBundleIds.has(bundleId)
+  })
+
+  if (!variantsEnabled) {
+    const hasVariants = meta.versionState.versions.some(
+      (version) => typeof version._system.variant !== 'undefined',
+    )
+
+    if (hasVariants) {
+      console.warn(`Content Variants is switched off, but there are variants of this document.
+Switch Content Variants on in your Studio configuration to ensure variants are displayed correctly (set \`beta.variants.enabled\` to \`true\`).`)
+    }
+
+    const variants: Variant[] = meta.versionState.versions
+      .filter((version) => !isAgentBundleName(getVersionFromId(version._id)))
+      .map<Variant>((version) => ({
+        id: version._id,
+        name: getVersionName({document: version, releases, t}),
+        document: version,
+      }))
+
+    if (typeof proposedChangesId !== 'undefined') {
+      variants.unshift({
+        id: proposedChangesId,
+        name: t('version.agent-bundle.proposed-changes'),
+      })
+    }
+
+    return [
+      {
+        key: 'studio:all',
+        name: t('document-group-inventory.title', {
+          count: variants.length,
+          subject: t('document-group.subject.version', {
+            count: variants.length,
+          }),
+        }),
+        variants,
+      },
+    ]
+  }
+
+  const variantsByRelease = meta.versionState.versions
+    .filter((version) => !isAgentBundleName(getVersionFromId(version._id)))
+    .reduce<Map<string, VersionInfoDocumentStub[]>>((currentVariantsByRelease, version) => {
+      let bundle
+
+      switch (readVersionType(version)) {
+        case 'release':
+          bundle = version._system.release?._ref
+          break
+        case 'published':
+          bundle = 'published'
+          break
+        case 'draft':
+          bundle = 'drafts'
+          break
+      }
+
+      if (typeof bundle === 'undefined') {
+        return currentVariantsByRelease
+      }
+
+      if (!currentVariantsByRelease.has(bundle)) {
+        currentVariantsByRelease.set(bundle, [])
+      }
+
+      const currentVersions = currentVariantsByRelease.get(bundle)
+      currentVersions?.push(version)
+
+      return currentVariantsByRelease
+    }, new Map())
+
+  const sets = [...variantsByRelease.entries()].map<VariantSet>(([releaseId, releaseVariants]) => {
+    return {
+      key: releaseId,
+      name: getReleaseName({releaseId, releases, t}),
+      variants: releaseVariants.map<Variant>((variant) => ({
+        id: variant._id,
+        name: getVariantName({document: variant, variants, t}),
+        releaseDocument: releases.get(releaseId),
+        document: variant,
+      })),
+    }
+  })
+
+  if (typeof proposedChangesId !== 'undefined') {
+    return sets.toSpliced(0, 0, {
+      key: 'studio:content-agent',
+      name: t('content-agent'),
+      variants: [
+        {
+          id: proposedChangesId,
+          name: t('version.agent-bundle.proposed-changes'),
+        },
+      ],
+    })
+  }
+
+  return sets
+}
+
+interface GetNameOptions {
+  releases: Map<string, ReleaseDocument>
+  t: TFunction
+}
+
+function getVariantName({
+  document,
+  variants,
+  t,
+}: Pick<GetNameOptions, 't'> & {
+  document: VersionInfoDocumentStub
+  variants: Map<string, SystemVariant>
+}): string {
+  const releaseDocumentId = document._system.variant?._ref
+  const release = releaseDocumentId ? variants.get(releaseDocumentId) : undefined
+  return release?.metadata?.title ?? t('document-group.base-variant')
+}
+
+function getVersionName({
+  document,
+  releases,
+  t,
+}: GetNameOptions & {document: VersionInfoDocumentStub}): string {
+  const state = readVersionType(document)
+
+  if (state === 'draft') {
+    return t('release.chip.draft')
+  }
+
+  if (state === 'published') {
+    return t('release.chip.published')
+  }
+
+  const release = releases.get(document._system.release?._ref ?? '')
+  return release?.metadata.title ?? document._system.release?._ref ?? document._id
+}
+
+function getReleaseName({releaseId, releases, t}: GetNameOptions & {releaseId: string}): string {
+  if (releaseId === ('published' satisfies SystemBundle)) {
+    return t(`release.chip.published`)
+  }
+
+  if (releaseId === ('drafts' satisfies SystemBundle)) {
+    return t(`release.chip.draft`)
+  }
+
+  const release = releases.get(releaseId)
+  return release?.metadata.title ?? releaseId
+}

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -308,6 +308,9 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   /** Short weekday name for Wednesday */
   'calendar.weekday-names.short.wednesday': 'Wed',
 
+  /** The name of Content Agent, the product. */
+  'content-agent': 'Content Agent',
+
   /** Label for the close button label in Review Changes pane */
   'changes.action.close-label': 'Close history',
   /** Cancel label for revert button prompt action */
@@ -527,6 +530,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
 
   /** --- Document group --- */
 
+  /** The label given to a document group's base variant */
+  'document-group.base-variant': 'All users (Default)',
   /** The text in the "Cancel" button in the confirm delete dialog that cancels the action */
   'document-group.delete.cancel-button.text': 'Cancel',
   /** Used in `document-group.delete.cdr-summary.title` */

--- a/packages/sanity/src/core/perspective/__tests__/useSetVariant.test.ts
+++ b/packages/sanity/src/core/perspective/__tests__/useSetVariant.test.ts
@@ -22,7 +22,7 @@ describe('useSetVariant', () => {
   it('sets the variant sticky param without touching the perspective', () => {
     const {result} = renderHook(() => useSetVariant())
 
-    result.current(variantAlphaAudience._id)
+    result.current({variantId: variantAlphaAudience._id})
 
     expect(mockNavigate).toHaveBeenCalledWith({
       stickyParams: {
@@ -34,7 +34,7 @@ describe('useSetVariant', () => {
   it('clears the variant sticky param when no variant is provided', () => {
     const {result} = renderHook(() => useSetVariant())
 
-    result.current(undefined)
+    result.current({variantId: undefined})
 
     expect(mockNavigate).toHaveBeenCalledWith({
       stickyParams: {
@@ -46,7 +46,7 @@ describe('useSetVariant', () => {
   it('sets the variant and perspective sticky params in a single navigation', () => {
     const {result} = renderHook(() => useSetVariant())
 
-    result.current(variantAlphaAudience._id, {perspective: 'published'})
+    result.current({variantId: variantAlphaAudience._id, perspective: 'published'})
 
     expect(mockNavigate).toHaveBeenCalledTimes(1)
     expect(mockNavigate).toHaveBeenCalledWith({
@@ -61,7 +61,7 @@ describe('useSetVariant', () => {
   it('clears the perspective sticky param when the perspective is the default perspective', () => {
     const {result} = renderHook(() => useSetVariant())
 
-    result.current(variantAlphaAudience._id, {perspective: 'drafts'})
+    result.current({variantId: variantAlphaAudience._id, perspective: 'drafts'})
 
     expect(mockNavigate).toHaveBeenCalledWith({
       stickyParams: {
@@ -75,7 +75,7 @@ describe('useSetVariant', () => {
   it('sets a release id as the perspective sticky param', () => {
     const {result} = renderHook(() => useSetVariant())
 
-    result.current(variantAlphaAudience._id, {perspective: 'rSomeRelease'})
+    result.current({variantId: variantAlphaAudience._id, perspective: 'rSomeRelease'})
 
     expect(mockNavigate).toHaveBeenCalledWith({
       stickyParams: {

--- a/packages/sanity/src/core/perspective/useSetVariant.tsx
+++ b/packages/sanity/src/core/perspective/useSetVariant.tsx
@@ -8,7 +8,10 @@ import {type ReleaseId} from './types'
 import {useGetDefaultPerspective} from './useGetDefaultPerspective'
 import {getPerspectiveParam} from './useSetPerspective'
 
-type SetVariant = (
+/**
+ * @internal
+ */
+export type SetVariant = (
   options:
     | {
         variantId: SystemVariant['_id'] | undefined

--- a/packages/sanity/src/core/perspective/useSetVariant.tsx
+++ b/packages/sanity/src/core/perspective/useSetVariant.tsx
@@ -8,6 +8,18 @@ import {type ReleaseId} from './types'
 import {useGetDefaultPerspective} from './useGetDefaultPerspective'
 import {getPerspectiveParam} from './useSetPerspective'
 
+type SetVariant = (
+  options:
+    | {
+        variantId: SystemVariant['_id'] | undefined
+        perspective?: SystemBundle | ReleaseId
+      }
+    | {
+        variantId?: SystemVariant['_id']
+        perspective: SystemBundle | ReleaseId
+      },
+) => void
+
 /**
  * React hook to set the variant in the router.
  * Optionally sets the perspective in the same navigation, so both sticky params
@@ -16,16 +28,12 @@ import {getPerspectiveParam} from './useSetPerspective'
  * @internal
  * @beta
  */
-export function useSetVariant() {
+export function useSetVariant(): SetVariant {
   const router = useRouter()
   const defaultPerspective = useGetDefaultPerspective()
-  const setVariant = useCallback(
-    (
-      variantId: SystemVariant['_id'] | undefined,
-      options?: {perspective?: SystemBundle | ReleaseId},
-    ) => {
-      const {perspective} = options ?? {}
 
+  return useCallback<SetVariant>(
+    ({variantId, perspective}) => {
       router.navigate({
         stickyParams: {
           variant: variantId ? getVariantId(variantId) : null,
@@ -40,5 +48,4 @@ export function useSetVariant() {
     },
     [router, defaultPerspective],
   )
-  return setVariant
 }

--- a/packages/sanity/src/core/releases/store/__tests__/useDocumentVersionInfo.test.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/useDocumentVersionInfo.test.ts
@@ -18,11 +18,7 @@ const publishedVersion: VersionInfoDocumentStub = {
   _createdAt: '2024-01-01T00:00:00Z',
   _updatedAt: '2024-01-02T00:00:00Z',
   _system: {
-    bundleId: null,
-    release: null,
-    variant: null,
     group: {_ref: publishedId, _weak: true},
-    scopeId: null,
   },
 }
 
@@ -33,10 +29,7 @@ const draftVersion: VersionInfoDocumentStub = {
   _updatedAt: '2024-01-03T00:00:00Z',
   _system: {
     bundleId: 'drafts',
-    release: null,
-    variant: null,
     group: {_ref: publishedId, _weak: true},
-    scopeId: null,
   },
 }
 
@@ -48,7 +41,6 @@ const releaseVersion: VersionInfoDocumentStub = {
   _system: {
     bundleId: 'release1',
     release: {_ref: '_.releases.release1', _weak: true},
-    variant: null,
     group: {_ref: publishedId, _weak: true},
     scopeId: 'release1',
   },
@@ -61,7 +53,6 @@ const variantVersion: VersionInfoDocumentStub = {
   _updatedAt: '2024-01-05T00:00:00Z',
   _system: {
     bundleId: 'drafts',
-    release: null,
     variant: {_ref: '_.variants.test', _weak: true},
     group: {_ref: publishedId, _weak: true},
     scopeId: 'scope1',

--- a/packages/sanity/src/core/releases/util/__tests__/getDocumentVersionInfoFromVersions.test.ts
+++ b/packages/sanity/src/core/releases/util/__tests__/getDocumentVersionInfoFromVersions.test.ts
@@ -11,11 +11,7 @@ const publishedVersion: VersionInfoDocumentStub = {
   _createdAt: '2024-01-01T00:00:00Z',
   _updatedAt: '2024-01-02T00:00:00Z',
   _system: {
-    bundleId: null,
-    release: null,
-    variant: null,
     group: {_ref: publishedId, _weak: true},
-    scopeId: null,
   },
 }
 
@@ -26,10 +22,7 @@ const draftVersion: VersionInfoDocumentStub = {
   _updatedAt: '2024-01-03T00:00:00Z',
   _system: {
     bundleId: 'drafts',
-    release: null,
-    variant: null,
     group: {_ref: publishedId, _weak: true},
-    scopeId: null,
   },
 }
 
@@ -41,7 +34,6 @@ const releaseVersion: VersionInfoDocumentStub = {
   _system: {
     bundleId: 'release1',
     release: {_ref: '_.releases.release1', _weak: true},
-    variant: null,
     group: {_ref: publishedId, _weak: true},
     scopeId: 'release1',
   },
@@ -54,7 +46,6 @@ const variantVersion: VersionInfoDocumentStub = {
   _updatedAt: '2024-01-05T00:00:00Z',
   _system: {
     bundleId: 'drafts',
-    release: null,
     variant: {_ref: '_.variants.test', _weak: true},
     group: {_ref: publishedId, _weak: true},
     scopeId: 'scope1',

--- a/packages/sanity/src/core/releases/util/getDocumentVersionInfoFromVersions.ts
+++ b/packages/sanity/src/core/releases/util/getDocumentVersionInfoFromVersions.ts
@@ -37,8 +37,21 @@ export function getDocumentVersionInfoFromVersions(versions: VersionInfoDocument
 
   const nonVariantVersions = versions.filter((version) => !isVariantVersion(version))
 
-  const published = nonVariantVersions.find(isPublishedVersion)
-  const draft = nonVariantVersions.find(isDraftVersion)
+  const published = nonVariantVersions.find((version) =>
+    isPublishedVersion(version, {
+      constraint: {
+        baseVariant: true,
+      },
+    }),
+  )
+
+  const draft = nonVariantVersions.find((version) =>
+    isDraftVersion(version, {
+      constraint: {
+        baseVariant: true,
+      },
+    }),
+  )
 
   const releaseVersions: Record<string, VersionInfoDocumentStub | undefined> = {}
 

--- a/packages/sanity/src/core/util/versionsUtils.test.ts
+++ b/packages/sanity/src/core/util/versionsUtils.test.ts
@@ -46,6 +46,8 @@ const releaseVersion = createVersion('versions.a.doc1', {
   },
 })
 
+const agentVersion = createVersion('versions.agent-x.doc1')
+
 describe('isPublishedVersion', () => {
   describe('default constraint (anyVariant)', () => {
     it('returns true for the base published version', () => {
@@ -149,5 +151,28 @@ describe('isDraftVersion', () => {
     it('returns false for the base published version', () => {
       expect(isDraftVersion(publishedBase, {constraint: {baseVariant: true}})).toBe(false)
     })
+  })
+})
+
+describe('readVersionType', () => {
+  it('classifies the base published version as published', () => {
+    expect(readVersionType(publishedBase)).toBe('published')
+  })
+
+  it('classifies drafts as draft', () => {
+    expect(readVersionType(draftBase)).toBe('draft')
+    expect(readVersionType(draftVariant)).toBe('draft')
+  })
+
+  it('classifies release versions as version', () => {
+    expect(readVersionType(releaseVersion)).toBe('release')
+  })
+
+  it('classifies agent versions as agent', () => {
+    expect(readVersionType(agentVersion)).toBe('agent')
+  })
+
+  it('returns undefined for undefined input', () => {
+    expect(readVersionType(undefined)).toBeUndefined()
   })
 })

--- a/packages/sanity/src/core/util/versionsUtils.test.ts
+++ b/packages/sanity/src/core/util/versionsUtils.test.ts
@@ -1,0 +1,153 @@
+import {describe, expect, it} from 'vitest'
+
+import {type VersionInfoDocumentStub} from '../releases/store/types'
+import {isDraftVersion, isPublishedVersion, readVersionType} from './versionsUtils'
+
+function createVersion(
+  _id: string,
+  system: Partial<VersionInfoDocumentStub['_system']> = {},
+): VersionInfoDocumentStub {
+  return {
+    _id,
+    _rev: 'rev',
+    _createdAt: '2026-01-01T00:00:00.000Z',
+    _updatedAt: '2026-01-01T00:00:00.000Z',
+    _system: {
+      group: {
+        _ref: 'doc1',
+        _weak: true,
+      },
+      ...system,
+    },
+  }
+}
+
+const publishedBase = createVersion('doc1')
+
+const publishedVariant = createVersion('variant-doc', {
+  variant: {_ref: '_.variants.a', _weak: true},
+})
+
+const draftBase = createVersion('drafts.doc1', {bundleId: 'drafts'})
+
+const draftVariant = createVersion('drafts.variant-doc', {
+  bundleId: 'drafts',
+  variant: {
+    _ref: '_.variants.a',
+    _weak: true,
+  },
+})
+
+const releaseVersion = createVersion('versions.a.doc1', {
+  bundleId: 'bundleA',
+  release: {
+    _ref: '_.variants.a',
+    _weak: true,
+  },
+})
+
+describe('isPublishedVersion', () => {
+  describe('default constraint (anyVariant)', () => {
+    it('returns true for the base published version', () => {
+      expect(isPublishedVersion(publishedBase)).toBe(true)
+    })
+
+    it('returns true for a published variant', () => {
+      expect(isPublishedVersion(publishedVariant)).toBe(true)
+    })
+
+    it('returns false for drafts', () => {
+      expect(isPublishedVersion(draftBase)).toBe(false)
+      expect(isPublishedVersion(draftVariant)).toBe(false)
+    })
+
+    it('returns false for release versions', () => {
+      expect(isPublishedVersion(releaseVersion)).toBe(false)
+    })
+  })
+
+  describe('variant constraint', () => {
+    it('returns true for a published variant matching the release id', () => {
+      expect(isPublishedVersion(publishedVariant, {constraint: {variant: 'a'}})).toBe(true)
+    })
+
+    it('returns false for a published variant with a different release id', () => {
+      expect(isPublishedVersion(publishedVariant, {constraint: {variant: 'b'}})).toBe(false)
+    })
+
+    it('returns false for the base published version', () => {
+      expect(isPublishedVersion(publishedBase, {constraint: {variant: 'a'}})).toBe(false)
+    })
+
+    it('returns false for a draft variant matching the release id', () => {
+      expect(isPublishedVersion(draftVariant, {constraint: {variant: 'a'}})).toBe(false)
+    })
+  })
+
+  describe('baseVariant constraint', () => {
+    it('returns true for the base published version', () => {
+      expect(isPublishedVersion(publishedBase, {constraint: {baseVariant: true}})).toBe(true)
+    })
+
+    it('returns false for a published variant', () => {
+      expect(isPublishedVersion(publishedVariant, {constraint: {baseVariant: true}})).toBe(false)
+    })
+
+    it('returns false for the base draft', () => {
+      expect(isPublishedVersion(draftBase, {constraint: {baseVariant: true}})).toBe(false)
+    })
+  })
+})
+
+describe('isDraftVersion', () => {
+  describe('default constraint (anyVariant)', () => {
+    it('returns true for the base draft', () => {
+      expect(isDraftVersion(draftBase)).toBe(true)
+    })
+
+    it('returns true for a draft variant', () => {
+      expect(isDraftVersion(draftVariant)).toBe(true)
+    })
+
+    it('returns false for published versions', () => {
+      expect(isDraftVersion(publishedBase)).toBe(false)
+      expect(isDraftVersion(publishedVariant)).toBe(false)
+    })
+
+    it('returns false for release versions', () => {
+      expect(isDraftVersion(releaseVersion)).toBe(false)
+    })
+  })
+
+  describe('variant constraint', () => {
+    it('returns true for a draft variant matching the release id', () => {
+      expect(isDraftVersion(draftVariant, {constraint: {variant: 'a'}})).toBe(true)
+    })
+
+    it('returns false for a draft variant with a different release id', () => {
+      expect(isDraftVersion(draftVariant, {constraint: {variant: 'b'}})).toBe(false)
+    })
+
+    it('returns false for the base draft', () => {
+      expect(isDraftVersion(draftBase, {constraint: {variant: 'a'}})).toBe(false)
+    })
+
+    it('returns false for a published variant matching the release id', () => {
+      expect(isDraftVersion(publishedVariant, {constraint: {variant: 'a'}})).toBe(false)
+    })
+  })
+
+  describe('baseVariant constraint', () => {
+    it('returns true for the base draft', () => {
+      expect(isDraftVersion(draftBase, {constraint: {baseVariant: true}})).toBe(true)
+    })
+
+    it('returns false for a draft variant', () => {
+      expect(isDraftVersion(draftVariant, {constraint: {baseVariant: true}})).toBe(false)
+    })
+
+    it('returns false for the base published version', () => {
+      expect(isDraftVersion(publishedBase, {constraint: {baseVariant: true}})).toBe(false)
+    })
+  })
+})

--- a/packages/sanity/src/core/util/versionsUtils.ts
+++ b/packages/sanity/src/core/util/versionsUtils.ts
@@ -1,6 +1,7 @@
 import {type VersionInfoDocumentStub} from '../releases/store/types'
+import {isAgentBundleName} from '../store/agent/createAgentBundlesStore'
 import {getVariantId} from '../variants/tool/util'
-import {getDraftId} from './draftUtils'
+import {getDraftId, getVersionFromId} from './draftUtils'
 
 type VariantConstraint =
   | {
@@ -29,6 +30,9 @@ type VariantConstraint =
        */
       anyVariant: true
     }
+
+/** @beta */
+export type VersionType = 'draft' | 'published' | 'release' | 'agent'
 
 /**
  * Uses the `_system` field to check if a version is a published version.
@@ -118,4 +122,32 @@ export function isVariantVersion(version: VersionInfoDocumentStub): boolean {
  */
 export function isReleaseVersion(version: VersionInfoDocumentStub): boolean {
   return Boolean(version._system?.release)
+}
+
+/**
+ * Uses the _system field to determine the version type of a document.
+ * @beta
+ */
+export function readVersionType(
+  version: VersionInfoDocumentStub | undefined,
+): VersionType | undefined {
+  if (typeof version === 'undefined') {
+    return undefined
+  }
+
+  if (isAgentBundleName(getVersionFromId(version._id))) {
+    return 'agent'
+  }
+
+  if (isPublishedVersion(version)) {
+    return 'published'
+  }
+
+  if (isReleaseVersion(version)) {
+    return 'release'
+  }
+
+  if (isDraftVersion(version)) {
+    return 'draft'
+  }
 }

--- a/packages/sanity/src/core/util/versionsUtils.ts
+++ b/packages/sanity/src/core/util/versionsUtils.ts
@@ -1,26 +1,107 @@
 import {type VersionInfoDocumentStub} from '../releases/store/types'
+import {getVariantId} from '../variants/tool/util'
+import {getDraftId} from './draftUtils'
+
+type VariantConstraint =
+  | {
+      /**
+       * Match only the provided variant id.
+       *
+       * This value **must** be the bare variant id ("x", rather than "_.variants.x").
+       */
+      variant: string
+      baseVariant?: never
+      anyVariant?: never
+    }
+  | {
+      variant?: never
+      /**
+       * Match only the base variant.
+       */
+      baseVariant: true
+      anyVariant?: never
+    }
+  | {
+      variant?: never
+      baseVariant?: never
+      /**
+       * Match any variant.
+       */
+      anyVariant: true
+    }
 
 /**
- * Uses the _system field to check if a version is a published version
+ * Uses the `_system` field to check if a version is a published version.
+ *
+ * By default, any published variant will match. Use the constraint options to
+ * limit matching to the base variant, or to a particular variant id.
+ *
  * @beta
  */
-export function isPublishedVersion(version: VersionInfoDocumentStub): boolean {
-  return (
-    version._system.group._ref === version._id &&
-    !version._system.variant &&
-    !version._system.release &&
-    !version._system.bundleId
-  )
+export function isPublishedVersion(
+  version: VersionInfoDocumentStub,
+  options: {constraint: VariantConstraint} = {constraint: {anyVariant: true}},
+): boolean {
+  const {constraint} = options
+  const isPublished = !isReleaseVersion(version) && typeof version._system.bundleId === 'undefined'
+
+  if (!isPublished) {
+    return false
+  }
+
+  if ('variant' in constraint) {
+    return (
+      isVariantVersion(version) &&
+      getVariantId(version._system.variant?._ref ?? '') === constraint.variant
+    )
+  }
+
+  if (constraint.baseVariant) {
+    return !isVariantVersion(version) && version._system.group._ref === version._id
+  }
+
+  if (constraint.anyVariant) {
+    return true
+  }
+
+  return false
 }
 
 /**
- * Uses the _system field to check if a version is a draft version
+ * Uses the `_system` field to check if a version is a draft version.
+ *
+ * By default, any draft variant will match. Use the constraint options to
+ * limit matching to the base variant, or to a particular variant id.
+ *
  * @beta
  */
-export function isDraftVersion(version: VersionInfoDocumentStub): boolean {
-  return (
-    !version._system?.variant && !version._system?.release && version._system?.bundleId === 'drafts'
-  )
+export function isDraftVersion(
+  version: VersionInfoDocumentStub,
+  options: {constraint: VariantConstraint} = {constraint: {anyVariant: true}},
+): boolean {
+  const {constraint} = options
+  const isDraft = version._system?.bundleId === 'drafts'
+
+  if (!isDraft) {
+    return false
+  }
+
+  if ('variant' in constraint) {
+    return (
+      isVariantVersion(version) &&
+      getVariantId(version._system.variant?._ref ?? '') === constraint.variant
+    )
+  }
+
+  if (constraint.baseVariant) {
+    return !isVariantVersion(version) && version._id === getDraftId(version._system.group._ref)
+  }
+
+  if (constraint.anyVariant) {
+    return true
+  }
+
+  return false
 }
 
 /**

--- a/packages/sanity/src/core/variants/plugin/components/VariantsMenu.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/VariantsMenu.tsx
@@ -65,13 +65,13 @@ export function VariantsMenu(): React.JSX.Element {
   )
 
   const handleSelectDefault = useCallback(() => {
-    setVariant(undefined)
+    setVariant({variantId: undefined})
     setFilterQuery('')
   }, [setVariant])
 
   const handleSelectVariant = useCallback(
     (variant: SystemVariant) => {
-      setVariant(variant._id)
+      setVariant({variantId: variant._id})
       setFilterQuery('')
     },
     [setVariant],

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -187,7 +187,7 @@ describe('VariantDetail', () => {
 
     await user.click(screen.getByTestId('pin-variant-button'))
 
-    expect(mockedSetVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
+    expect(mockedSetVariant).toHaveBeenCalledWith({variantId: variantAlphaAudience._id})
   })
 
   it('opens the edit dialog with existing variant values', async () => {

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantPinButton.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantPinButton.test.tsx
@@ -44,7 +44,7 @@ describe('VariantPinButton', () => {
 
     await userEvent.click(screen.getByTestId('pin-variant-button'))
 
-    expect(mockedSetVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
+    expect(mockedSetVariant).toHaveBeenCalledWith({variantId: variantAlphaAudience._id})
   })
 
   it('unpins a variant when it is selected', async () => {
@@ -57,6 +57,6 @@ describe('VariantPinButton', () => {
 
     await userEvent.click(screen.getByTestId('pin-variant-button'))
 
-    expect(mockedSetVariant).toHaveBeenCalledWith(undefined)
+    expect(mockedSetVariant).toHaveBeenCalledWith({variantId: undefined})
   })
 })

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -263,7 +263,7 @@ describe('VariantsOverview', () => {
 
     await user.click(screen.getByTestId('pin-variant-button'))
 
-    expect(mockedSetVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
+    expect(mockedSetVariant).toHaveBeenCalledWith({variantId: variantAlphaAudience._id})
   })
 
   it('deletes a variant from the row actions menu', async () => {

--- a/packages/sanity/src/core/variants/tool/components/VariantPinButton.tsx
+++ b/packages/sanity/src/core/variants/tool/components/VariantPinButton.tsx
@@ -26,9 +26,13 @@ export function VariantPinButton({
 
   const handlePinVariant = useCallback(() => {
     if (isPinned) {
-      setVariant(undefined)
+      setVariant({
+        variantId: undefined,
+      })
     } else {
-      setVariant(variant._id)
+      setVariant({
+        variantId: variant._id,
+      })
     }
   }, [isPinned, setVariant, variant])
 

--- a/packages/sanity/src/core/variants/types.test.ts
+++ b/packages/sanity/src/core/variants/types.test.ts
@@ -1,0 +1,33 @@
+import {describe, expect, it} from 'vitest'
+
+import {isVariantId} from './types'
+
+describe('isVariantId', () => {
+  it.each(['_.variants.XBeVtHmN', '_.variants.abc_d', '_.variants.ABC_01-'])(
+    'returns true for variant id %j',
+    (id) => {
+      expect(isVariantId(id)).toBe(true)
+    },
+  )
+
+  it.each([
+    'XBeVtHmN',
+    'drafts.abc',
+    '_.abc',
+    '_.variants.',
+    '_.variants',
+    'variants.XBeVtHmN',
+    '_.variants.abc!',
+    ' _.variants.XBeVtHmN',
+    '_.variants.XBeVtHmN ',
+  ])('returns false for non-variant string %j', (value) => {
+    expect(isVariantId(value)).toBe(false)
+  })
+
+  it.each([undefined, null, 42, {}, ['_.variants.XBeVtHmN']])(
+    'returns false for non-string value %j',
+    (value) => {
+      expect(isVariantId(value)).toBe(false)
+    },
+  )
+})

--- a/packages/sanity/src/core/variants/types.ts
+++ b/packages/sanity/src/core/variants/types.ts
@@ -2,9 +2,14 @@ import {type SanityDocument, type PortableTextBlock} from '@sanity/types'
 
 import {type VARIANT_DOCUMENT_TYPE, type VARIANT_DOCUMENTS_PATH} from './store/constants'
 
+/**
+ * @internal
+ */
+export type VariantId = `${typeof VARIANT_DOCUMENTS_PATH}.${string}`
+
 export interface SystemVariant extends SanityDocument {
   _type: typeof VARIANT_DOCUMENT_TYPE
-  _id: `${typeof VARIANT_DOCUMENTS_PATH}.${string}`
+  _id: VariantId
   name?: string
   conditions: Record<string, string>
   priority: number // defaults to 0.

--- a/packages/sanity/src/core/variants/types.ts
+++ b/packages/sanity/src/core/variants/types.ts
@@ -27,3 +27,14 @@ export type EditableSystemVariant = Pick<
   SystemVariant,
   '_id' | '_type' | 'conditions' | 'priority' | 'metadata'
 >
+
+/**
+ * @internal
+ */
+export function isVariantId(maybeVariantId: unknown): maybeVariantId is VariantId {
+  if (typeof maybeVariantId !== 'string') {
+    return false
+  }
+
+  return maybeVariantId.match(/^_\.variants\.['a-zA-Z0-9._-]+$/) !== null
+}

--- a/packages/sanity/src/structure/hooks/useDocumentPerspectiveList.ts
+++ b/packages/sanity/src/structure/hooks/useDocumentPerspectiveList.ts
@@ -267,7 +267,7 @@ export function useDocumentPerspectiveList(): DocumentPerspectiveList {
       // Passing the perspective alongside the variant updates both sticky params atomically.
       const versionBundle = version._system.bundleId
       const perspective = !versionBundle ? 'published' : versionBundle
-      setVariant(variant?._id, {perspective})
+      setVariant({variantId: variant?._id, perspective})
     },
     [setVariant, variants],
   )

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -11,6 +11,7 @@ import {
   useDocumentStore,
   usePausedScheduledDraft,
   usePerspective,
+  useSetVariant,
   useSource,
 } from 'sanity'
 
@@ -51,7 +52,6 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
   const {documentId, documentType} = useDocumentPane()
   const showingRevision = Boolean(params?.rev)
 
-  const {navigate: navigatePerspective} = usePerspectiveNavigator()
   const perspectiveList = useDocumentPerspectiveList()
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const documentStore = useDocumentStore()
@@ -118,7 +118,6 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
             documentId={displayed._id}
             documentType={documentType}
             portalElementName={DOCUMENT_PANEL_PORTAL_ELEMENT}
-            navigatePerspective={navigatePerspective}
             perspectiveList={perspectiveList}
             referringDocuments$={referringDocuments$}
             components={documentGroupInventoryComponents}

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -528,6 +528,7 @@ exports[`exports snapshot 1`] = `
     "prepareConfig": "function",
     "prepareForPreview": "function",
     "prepareTemplates": "function",
+    "readVersionType": "function",
     "remoteSnapshots": "function",
     "removeDupes": "function",
     "removeMissingReferences": "function",


### PR DESCRIPTION
### Description

This branch implements release-grouped variant listing in the document group inventory.

- Variants are grouped by release/bundle, following the default ordering of releases used to illustrate "release layering".
- Agent versions are prepended, in a dedicated "Content agent" set, using the name "Proposed changes".
- The non-content-variants branch of the UI has been updated so that "Proposed changes" versions are prepended, to ensure consistent behaviour between the branches.
- The document group machine logs a console warning if it encounters variant documents, but Content Variants is not switched on.

<img width="1564" height="1164" alt="Screenshot 2026-07-13 at 16 32 34" src="https://github.com/user-attachments/assets/17cca001-789b-4b72-9959-1fc7c26526db" />

<img width="1564" height="1164" alt="Screenshot 2026-07-13 at 16 32 21" src="https://github.com/user-attachments/assets/3a3edbf9-2417-48c0-a7a8-907b056e3b11" />

### What to review

Variant listing in the document group inventory.

### Testing

Updated state machine tests where relevant. Will follow up with more rigorous testing once behaviour has solidified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches document pane navigation (variant + perspective sticky params) and version classification used to pick draft/published in release tooling; misclassification could show the wrong document or bundle.
> 
> **Overview**
> **Document group inventory** now builds variant rows from full version stubs via a new `computeSets` helper. With **Content Variants** enabled, entries are grouped into sets per bundle (Draft, Published, each release) plus a prepended **Content Agent** “Proposed changes” row; with variants off, behavior stays a single flat list but agent “proposed changes” is also prepended and a console warning fires if variant documents exist while the flag is off.
> 
> Selecting a row no longer uses an injected `navigatePerspective` callback. Clicks call **`useSetVariant`** with an options object (`variantId` and `perspective` derived from `_system` via `readVersionType`), so variant and perspective sticky params update together. Set headers use `set.name`; rows expose `data-variant-set` / `data-variant-name` instead of per-name test ids.
> 
> Supporting changes: **`versionsUtils`** gains constrained `isDraftVersion` / `isPublishedVersion`, **`readVersionType`**, and **`getDocumentVersionInfoFromVersions`** now resolves base draft/published only; **`isVariantId`** type guard; i18n for **All users (Default)** and Content Agent; E2E and machine/unit tests updated for the new grouping and API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49b3ad43ce6fde2f3854034e21876100ba3dfb9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->