### PR TITLE
chore(sanity): lint `getVariantsDocumentCounts`

### DIFF
--- a/packages/sanity/src/core/variants/hooks/useVariantsDocumentCounts.ts
+++ b/packages/sanity/src/core/variants/hooks/useVariantsDocumentCounts.ts
@@ -142,7 +142,7 @@ export function getVariantsDocumentCounts(
       (previous, next): VariantsDocumentCountsState => ({
         // Keep the previous counts while the next fetch is loading (or errored), so counts
         // for unchanged variants remain visible across variant list changes.
-        data: next.data ? {...(previous.data ?? {}), ...next.data} : previous.data,
+        data: next.data ? {...previous.data, ...next.data} : previous.data,
         loading: next.loading && previous.data === null,
         error: next.error,
       }),


### PR DESCRIPTION
### Description

Fixes dangling lint error that made its way into `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line behavioral equivalent change in variant count UI state; no auth, data migration, or API surface impact.
> 
> **Overview**
> Fixes a lint issue in **`getVariantsDocumentCounts`** by simplifying how the `scan` reducer merges incoming counts with prior state.
> 
> When new count data arrives, the reducer now uses `{...previous.data, ...next.data}` instead of `{...(previous.data ?? {}), ...next.data}`. The intent is unchanged: keep existing per-variant counts visible while refetches run, then overlay the latest results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18416d7249235e694a81cfdb7f434809c4e3f60e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->