### PR TITLE
chore: revert "chore(lint): make no-unnecessary-type-assertion an error with grandfathered suppressions (#13375)"

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -270,14 +270,7 @@
     "no-redundant-type-constituents": "warn",
     "no-unnecessary-template-expression": "off",
     "no-unnecessary-type-arguments": "warn",
-    // Set to error (not warn) because this is the only fixable rule whose `--fix` rewrites code,
-    // and its autofix frequently removes load-bearing assertions (e.g. XState `{} as {...}` setup
-    // typings) and breaks the build. Pre-existing violations are grandfathered with inline
-    // `oxlint-disable-next-line` suppressions (a handful of multi-line assertions that the
-    // next-line directive cannot target use a scoped `oxlint-disable`/`oxlint-enable` block
-    // instead) so `--fix` leaves existing code untouched, while new violations are surfaced as
-    // errors that must be addressed (or suppressed) explicitly.
-    "no-unnecessary-type-assertion": "error",
+    "no-unnecessary-type-assertion": "warn",
     "no-unsafe-type-assertion": "warn",
     "restrict-template-expressions": "warn",
     "unbound-method": "warn",

--- a/packages/@sanity/mutator/src/document/SquashingBuffer.ts
+++ b/packages/@sanity/mutator/src/document/SquashingBuffer.ts
@@ -239,7 +239,6 @@ export class SquashingBuffer {
 
     nextOps.push(...this.staged)
     if (nextOps.length > 0) {
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       this.PRESTAGE = new Mutation({mutations: nextOps}).apply(this.PRESTAGE) as Doc
       this.staged = []
       this.setOperations = {}
@@ -269,7 +268,6 @@ export class SquashingBuffer {
       // @todo was this supposed to be `this.out.length > 0`?
       // surely this is always `true`?
       if (this.out) {
-        // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
         this.PRESTAGE = new Mutation({mutations: this.out}).apply(this.BASIS) as Doc
       } else {
         this.PRESTAGE = this.BASIS

--- a/packages/@sanity/schema/src/descriptors/convert.ts
+++ b/packages/@sanity/schema/src/descriptors/convert.ts
@@ -368,7 +368,6 @@ function maybeBlockMarks(schemaType: SchemaType): BlockMarks | undefined {
     return undefined
   }
 
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   const childrenField = (schemaType as ObjectSchemaType).fields?.find(
     (field) => field.name === 'children',
   )

--- a/packages/@sanity/schema/src/manifest/createSchemaFromManifestTypes.ts
+++ b/packages/@sanity/schema/src/manifest/createSchemaFromManifestTypes.ts
@@ -261,7 +261,6 @@ function applyRuleSpec(rule: IRule, ruleSpec: unknown): IRule {
             return s
           })
         }
-        // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
         return rule.uri(uriOptions as UriValidationOptions)
       }
       break
@@ -315,7 +314,6 @@ function isRegexPattern(val: unknown): val is {type: 'regex'; pattern: string} {
     typeof val === 'object' &&
     val !== null &&
     'type' in val &&
-    // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
     (val as {type: unknown}).type === 'regex' &&
     'pattern' in val &&
     typeof (val as {pattern: unknown}).pattern === 'string'

--- a/packages/@sanity/types/src/schema/asserters.ts
+++ b/packages/@sanity/types/src/schema/asserters.ts
@@ -38,7 +38,6 @@ export function isDocumentSchemaType(type: unknown): type is ObjectSchemaType {
     return false
   }
 
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   let current: SchemaType | undefined = type as SchemaType
   while (current) {
     if (current.name === 'document') {

--- a/packages/@sanity/util/src/paths.ts
+++ b/packages/@sanity/util/src/paths.ts
@@ -49,8 +49,7 @@ export function get(obj: unknown, path: Path | string, defaultVal?: unknown): un
     if (typeof segment === 'string') {
       acc =
         typeof acc === 'object' && acc !== null
-          ? // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
-            ((acc as Record<string, unknown>)[segment] as Record<string, unknown>)
+          ? ((acc as Record<string, unknown>)[segment] as Record<string, unknown>)
           : undefined
     }
 

--- a/packages/sanity/src/core/documentGroupInventory/machines/deletionMachine.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/deletionMachine.ts
@@ -67,7 +67,6 @@ type DeletionEvents =
   | {type: 'selection.changed'; selectedIds: Set<string>}
 
 export const deletionMachine = setup({
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   types: {} as {
     context: DeletionContext
     events: DeletionEvents

--- a/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.ts
@@ -44,7 +44,6 @@ type DocumentGroupInventoryEvents =
   | {type: 'feedback.end'}
 
 export const documentGroupInventoryMachine = setup({
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   types: {} as {
     input: {
       selectionMachine: SelectionLogic

--- a/packages/sanity/src/core/documentGroupInventory/machines/selectionMachine.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/selectionMachine.ts
@@ -25,7 +25,6 @@ type SelectionEvents =
   | {type: 'filterString.set'; value: string}
 
 export const selectionMachine = setup({
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   types: {} as {
     context: SelectionContext
     events: SelectionEvents

--- a/packages/sanity/src/core/error/types/isErrorWithDetails.ts
+++ b/packages/sanity/src/core/error/types/isErrorWithDetails.ts
@@ -4,5 +4,4 @@ export const isErrorWithDetails = (error: unknown): error is ErrorWithDetails =>
   typeof error === 'object' &&
   error !== null &&
   'details' in error &&
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   typeof (error as {details: unknown}).details === 'object'

--- a/packages/sanity/src/core/field/diff/changes/buildChangeList.ts
+++ b/packages/sanity/src/core/field/diff/changes/buildChangeList.ts
@@ -45,7 +45,6 @@ function buildChangeList(
 
   if (!diffComponent) {
     if (schemaType.jsonType === 'object' && diff.type === 'object') {
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       return buildObjectChangeList(schemaType as ObjectSchemaType, diff, path, titlePath, context)
     }
 
@@ -149,7 +148,6 @@ function buildFieldChange(
 
   const fieldPath = path.concat([field.name])
   const fieldTitlePath = titlePath.concat([field.type.title || field.name])
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   return buildChangeList(field.type as any, fieldDiff, fieldPath, fieldTitlePath, context)
 }
 
@@ -177,7 +175,6 @@ function buildFieldsetChangeList(
 
     const fieldPath = path.concat([field.name])
     const fieldTitlePath = fieldSetTitlePath.concat([field.type.title || field.name])
-    /* oxlint-disable typescript/no-unnecessary-type-assertion */
     changes.push(
       ...buildChangeList(
         {
@@ -185,7 +182,6 @@ function buildFieldsetChangeList(
           hidden: fieldSetHidden,
           ...field.type,
         } as any,
-        /* oxlint-enable typescript/no-unnecessary-type-assertion */
         fieldDiff,
         fieldPath,
         fieldTitlePath,

--- a/packages/sanity/src/core/field/diff/changes/undoChange.ts
+++ b/packages/sanity/src/core/field/diff/changes/undoChange.ts
@@ -194,7 +194,6 @@ function buildMovePatches(
       unset: [pathToString(path)],
     },
     {
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       insert: {...insertLocation, items: [fromValue]} as any,
     },
   ]
@@ -277,7 +276,6 @@ function getParentStubs(path: Path, rootDiff: ObjectDiff, stubbed: Set<string>):
       const prevSeg = isKeyedObject(prevItem) ? {_key: prevItem._key} : indexAtPrev - 1
       const after = pathToString(subPath.concat(indexAtPrev < 1 ? 0 : prevSeg))
       stubs.push({setIfMissing: {[pathStr]: []}})
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       stubs.push({insert: {after, items: [getStubValue(nextItem)]} as any})
 
       i++

--- a/packages/sanity/src/core/field/diff/components/FieldChange.tsx
+++ b/packages/sanity/src/core/field/diff/components/FieldChange.tsx
@@ -152,7 +152,6 @@ export function FieldChange(
                   <DiffContext.Provider value={value}>
                     <DiffComponent
                       diff={change.diff}
-                      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
                       schemaType={change.schemaType as ObjectSchemaType}
                     />
                   </DiffContext.Provider>

--- a/packages/sanity/src/core/field/schema/helpers.ts
+++ b/packages/sanity/src/core/field/schema/helpers.ts
@@ -42,11 +42,9 @@ function resolveArrayMemberType(
   const typeName = resolveTypeName(value)
   const declared = schemaType.of.find((candidate) => candidate.name === typeName)
   if (declared) {
-    // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
     return declared as any
   }
 
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   return (schemaType.of.length === 1 ? schemaType.of[0] : undefined) as any
 }
 

--- a/packages/sanity/src/core/field/validation/index.ts
+++ b/packages/sanity/src/core/field/validation/index.ts
@@ -46,7 +46,6 @@ export function getValueError(value: unknown, schemaType: SchemaType): FieldValu
 
   if (isObjectType(schemaType) && isObjectValue(value)) {
     for (const field of schemaType.fields) {
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       const fieldError = getValueError(value[field.name], field.type as SchemaType)
       if (fieldError) {
         return fieldError

--- a/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/CrossDatasetReferencePreview.tsx
+++ b/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/CrossDatasetReferencePreview.tsx
@@ -64,7 +64,6 @@ export function CrossDatasetReferencePreview(props: {
         ) : (
           <img
             src={createImageUrlBuilder({dataset, projectId})
-              // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
               .image(previewMedia as FIXME)
               .withOptions(dimensions)
               .url()}

--- a/packages/sanity/src/core/form/inputs/DateInputs/DateTimeInput.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/DateTimeInput.tsx
@@ -179,7 +179,6 @@ export function DateTimeInput(props: DateTimeInputProps) {
   const published = getPublishedId(_id as string)
   const timeZoneScope = useMemo(
     () => ({
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       type: 'input' as TimeZoneScopeType,
       defaultTimeZone: displayTimeZone,
       // we want to make sure that if allowTimeZoneSwitch is switched to false that we respect the default only

--- a/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/GlobalDocumentReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/GlobalDocumentReferenceInput.tsx
@@ -147,7 +147,6 @@ export function GlobalDocumentReferenceInput(props: GlobalDocumentReferenceInput
     return {_id}
   }, [value])
 
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   const loadableReferenceInfo = useReferenceInfo(refDoc as FIXME, getReferenceInfoMemo)
 
   const [autocompletePopoverReferenceElement, setAutocompletePopoverReferenceElement] =

--- a/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/GlobalDocumentReferencePreview.tsx
+++ b/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/GlobalDocumentReferencePreview.tsx
@@ -68,7 +68,6 @@ export function GlobalDocumentReferencePreview(props: {
         ) : (
           <img
             src={createImageUrlBuilder(projectDataset)
-              // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
               .image(previewMedia as FIXME)
               .withOptions(dimensions)
               .url()}

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInputPreview.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInputPreview.tsx
@@ -58,7 +58,6 @@ export function ReferenceInputPreview(props: ReferenceInputProps & {children: Re
   const {readOnly, focused, renderPreview, onChange, onPathFocus, id: inputId} = props
 
   const handleClear = useCallback(() => onChange(unset()), [onChange])
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   const value: Reference | undefined = props.value as any
 
   const {EditReferenceLink, getReferenceInfo, selectedState, isCurrentDocumentLiveEdit} =

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceLinkCard.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceLinkCard.tsx
@@ -49,7 +49,6 @@ export const ReferenceLinkCard = forwardRef(function ReferenceLinkCard(
       {...cardProps}
       {...linkProps}
       data-ui="ReferenceLinkCard"
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       ref={ref as unknown as ForwardedRef<HTMLDivElement>}
     />
   )

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputHotspotInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputHotspotInput.tsx
@@ -36,7 +36,6 @@ export function ImageInputHotspotInput(props: {
             <ImageToolInput
               {...imageInputProps}
               imageUrl={imageUrl}
-              // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
               value={value as FIXME}
               presence={inputProps.presence}
               changed={changed}

--- a/packages/sanity/src/core/form/inputs/files/ImageToolInput/imagetool/hooks/usePointerHandlers.ts
+++ b/packages/sanity/src/core/form/inputs/files/ImageToolInput/imagetool/hooks/usePointerHandlers.ts
@@ -63,7 +63,6 @@ export function usePointerHandlers({
       initialCropRef.current = {...(value.crop || DEFAULT_CROP)}
       initialHotspotRef.current = {...(value.hotspot || DEFAULT_HOTSPOT)}
 
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       const element = e.currentTarget as SVGElement
       const handle = element.dataset.handle
 

--- a/packages/sanity/src/core/form/members/array/items/ArrayOfPrimitivesItem.tsx
+++ b/packages/sanity/src/core/form/members/array/items/ArrayOfPrimitivesItem.tsx
@@ -144,13 +144,11 @@ export function ArrayOfPrimitivesItem(props: PrimitiveMemberItemProps) {
     return {
       changed: member.item.changed,
       level: member.item.level,
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       value: member.item.value as FIXME,
       compareValue: member.item.compareValue,
       __unstable_computeDiff: member.item.__unstable_computeDiff,
       hasUpstreamVersion: member.item.hasUpstreamVersion,
       readOnly: member.item.readOnly,
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       schemaType: member.item.schemaType as FIXME,
       id: member.item.id,
       path: member.item.path,
@@ -213,7 +211,6 @@ export function ArrayOfPrimitivesItem(props: PrimitiveMemberItemProps) {
       hasUpstreamVersion={member.item.hasUpstreamVersion}
       title={member.item.schemaType.title}
       description={member.item.schemaType.description}
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       schemaType={member.item.schemaType as FIXME}
       parentSchemaType={member.parentSchemaType}
       onInsert={onInsert}

--- a/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ArrayOfObjectsField.tsx
@@ -366,7 +366,6 @@ export function ArrayOfObjectsField(props: {
       handleSelectAssetFromSourceShared({
         assetsFromSource: assets,
         onChange: (patches) =>
-          // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
           handleChange(PatchEvent.from(patches as PatchEvent).prefixAll({_key: key})),
         type: schemaType,
         resolveUploader,
@@ -469,7 +468,6 @@ export function ArrayOfObjectsField(props: {
     return {
       level: member.field.level,
       members: member.field.members,
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       value: member.field.value as any,
       readOnly: member.field.readOnly,
       schemaType: member.field.schemaType,

--- a/packages/sanity/src/core/form/members/object/fields/ArrayOfPrimitivesField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/ArrayOfPrimitivesField.tsx
@@ -345,7 +345,6 @@ export function ArrayOfPrimitivesField(props: {
     return {
       level: member.field.level,
       members: member.field.members,
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       value: member.field.value as any,
       compareValue: member.field.compareValue,
       readOnly: member.field.readOnly,

--- a/packages/sanity/src/core/form/members/object/fields/PrimitiveField.tsx
+++ b/packages/sanity/src/core/form/members/object/fields/PrimitiveField.tsx
@@ -140,12 +140,10 @@ export function PrimitiveField(props: {
         .map((item) => item.message)
         .join('\n') || undefined
     return {
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       value: member.field.value as any,
       compareValue: member.field.compareValue,
       __unstable_computeDiff: member.field.__unstable_computeDiff,
       readOnly: member.field.readOnly,
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       schemaType: member.field.schemaType as any,
       changed: member.field.changed,
       hasUpstreamVersion: member.field.hasUpstreamVersion,
@@ -191,11 +189,9 @@ export function PrimitiveField(props: {
       name={member.name}
       path={member.field.path}
       presence={member.field.presence}
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       schemaType={member.field.schemaType as any}
       title={member.field.schemaType.title}
       validation={validation}
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       value={member.field.value as any}
       render={renderField}
     >

--- a/packages/sanity/src/core/form/store/formState.ts
+++ b/packages/sanity/src/core/form/store/formState.ts
@@ -814,7 +814,6 @@ export function createPrepareFormState({
         ...parent,
         comparisonValue: fieldComparisonValue,
         value: fieldValue,
-        // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
         schemaType: field.type as PrimitiveSchemaType,
         path: fieldPath,
         readOnly: scopedReadOnly,

--- a/packages/sanity/src/core/form/studio/tree-editing/utils/build-tree-editing-state/buildArrayStatePTE.ts
+++ b/packages/sanity/src/core/form/studio/tree-editing/utils/build-tree-editing-state/buildArrayStatePTE.ts
@@ -125,7 +125,6 @@ export function buildArrayStatePTE(props: BuildArrayStatePTEProps): {
     if (openPathStartsWithBlock && shouldBeInBreadcrumb(blockPath, openPath, documentValue)) {
       const blockBreadcrumb: DialogItem = {
         children: EMPTY_ARRAY,
-        // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
         parentSchemaType: childField.type as ArraySchemaType,
         path: blockPath,
         schemaType: blockSchemaType,
@@ -169,8 +168,7 @@ export function buildArrayStatePTE(props: BuildArrayStatePTEProps): {
             )
 
             const itemSchemaType = targetItem
-              ? // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
-                getItemType(blockField.type as ArraySchemaType, targetItem)
+              ? getItemType(blockField.type as ArraySchemaType, targetItem)
               : null
 
             // Skip setting relativePath for references
@@ -186,7 +184,6 @@ export function buildArrayStatePTE(props: BuildArrayStatePTEProps): {
 
           if (shouldBeInBreadcrumb(blockFieldPath, openPath, documentValue)) {
             const breadcrumbsResult = buildBreadcrumbsState({
-              // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
               arraySchemaType: blockField.type as ArraySchemaType,
               arrayValue: arrayFieldValue as Record<string, unknown>[],
               itemPath: blockFieldPath,
@@ -207,7 +204,6 @@ export function buildArrayStatePTE(props: BuildArrayStatePTEProps): {
 
           // If it's an inline custom object/object array/span, skip siblings
           const skipChildren = shouldSkipSiblingCount({
-            // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
             arraySchemaType: childField.type as ArraySchemaType,
             fieldPath: blockFieldPath,
           })
@@ -232,7 +228,6 @@ export function buildArrayStatePTE(props: BuildArrayStatePTEProps): {
       // Add this block as a menu item (similar to how buildArrayState adds array items)
       childrenMenuItems.push({
         children: blockChildrenMenuItems,
-        // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
         parentSchemaType: childField.type as ArraySchemaType,
         path: blockPath,
         schemaType: blockSchemaType,

--- a/packages/sanity/src/core/form/studio/tree-editing/utils/build-tree-editing-state/buildTreeEditingState.ts
+++ b/packages/sanity/src/core/form/studio/tree-editing/utils/build-tree-editing-state/buildTreeEditingState.ts
@@ -62,7 +62,6 @@ export function buildTreeEditingState(props: BuildTreeEditingStateProps): TreeEd
     return EMPTY_TREE_STATE
   }
 
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   const rootTitle = getSchemaTypeTitle(rootField.type as ObjectSchemaType)
 
   if (!isArrayOfObjectsSchemaType(rootField.type)) {

--- a/packages/sanity/src/core/preview/createPathObserver.ts
+++ b/packages/sanity/src/core/preview/createPathObserver.ts
@@ -82,7 +82,6 @@ function observePaths(
             ...createEmpty(nextHeads),
             ...(isReference(value) ? {...value, ...refApiConfig} : value),
             ...snapshot,
-            // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
           } as Previewable,
           paths,
           observeFields,

--- a/packages/sanity/src/core/preview/utils/prepareForPreview.ts
+++ b/packages/sanity/src/core/preview/utils/prepareForPreview.ts
@@ -213,8 +213,7 @@ export function invokePrepare(
   try {
     return {
       returnValue: prepare
-        ? // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
-          (prepare(value, viewOptions) as Record<string, unknown>)
+        ? (prepare(value, viewOptions) as Record<string, unknown>)
         : defaultPrepare(value),
       errors: EMPTY,
     }

--- a/packages/sanity/src/core/releases/components/dialog/UnpublishVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/UnpublishVersionDialog.tsx
@@ -118,7 +118,6 @@ export function UnpublishVersionDialog(props: {
               Label: ({children}) => {
                 return (
                   <span
-                    /* oxlint-disable typescript/no-unnecessary-type-assertion */
                     style={
                       {
                         color: `var(--card-badge-${tone ?? 'default'}-fg-color)`,
@@ -129,7 +128,6 @@ export function UnpublishVersionDialog(props: {
                         fontWeight: 500,
                       } as CSSProperties
                     }
-                    /* oxlint-enable typescript/no-unnecessary-type-assertion */
                   >
                     {children}
                   </span>

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
@@ -216,7 +216,6 @@ export const ReleasePublishAllButton = ({
         isPublishButtonDisabled || publishBundleStatus === 'publishing' || documents.length === 0,
       text: t('action.publish-all-documents'),
       handleOnClick: handleInitialPublish,
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       tooltipProps: {
         disabled: !isPublishButtonDisabled,
         content: publishTooltipContent,

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
@@ -372,7 +372,6 @@ export const ReleaseScheduleButton = ({
       disabled: isScheduleButtonDisabled || status === 'scheduling' || documents.length === 0,
       text: t('action.schedule'),
       handleOnClick: handleOnInitialSchedule,
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       tooltipProps: {
         disabled: !tooltipText,
         content: scheduleTooltipContent,

--- a/packages/sanity/src/core/scheduled-publishing/components/dateInputs/DateTimeInput.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/dateInputs/DateTimeInput.tsx
@@ -116,7 +116,6 @@ export const DateTimeInput = forwardRef(function DateTimeInput(
 
       // Check is value is a valid date
       if (!isValid(parsed)) {
-        // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
         return {
           isValid: false,
           error: `Invalid date. Must be in the format "${inputDateTimeFormat}"`,
@@ -125,14 +124,12 @@ export const DateTimeInput = forwardRef(function DateTimeInput(
 
       // Check if value adheres to custom validation rules
       if (!customValidation(parsed)) {
-        // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
         return {
           isValid: false,
           error: customValidationMessage,
         } as ParseResult
       }
 
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       return {
         isValid: true,
         date: parsed,

--- a/packages/sanity/src/core/scheduled-publishing/hooks/useSchemaType.ts
+++ b/packages/sanity/src/core/scheduled-publishing/hooks/useSchemaType.ts
@@ -14,7 +14,6 @@ export function useScheduleSchemaType(schedule: Schedule): SchemaType | undefine
     if (!schemaName) {
       return undefined
     }
-    // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
     return schema.get(schemaName) as SchemaType
   }, [schemaName, schema])
 }

--- a/packages/sanity/src/core/schema/createSchema.ts
+++ b/packages/sanity/src/core/schema/createSchema.ts
@@ -29,6 +29,5 @@ export function createSchema(schemaDef: {name: string; types: any[]}): Schema {
   // ;(compiled as any)._source = schemaDef
   ;(compiled as any)._validation = validation
 
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   return inferValidation(compiled as Schema)
 }

--- a/packages/sanity/src/core/store/authStore/utils/asserters.ts
+++ b/packages/sanity/src/core/store/authStore/utils/asserters.ts
@@ -29,6 +29,5 @@ export function isCookielessCompatibleLoginMethod(
   loginMethod: LoginMethod,
 ): loginMethod is CookielessCompatibleLoginMethod {
   const cookielessCompatibleLoginMethods = ['dual', 'token']
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   return cookielessCompatibleLoginMethods.includes(loginMethod as CookielessCompatibleLoginMethod)
 }

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/reference/Reference.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/reference/Reference.tsx
@@ -56,7 +56,6 @@ export function SearchFilterReferenceInput({
       })
       .reduce<SchemaType[]>((acc, val) => {
         if (acc.findIndex((v) => v.name === val?.name) < 0) {
-          // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
           acc.push(val as SchemaType)
         }
         return acc

--- a/packages/sanity/src/core/studio/copyPaste/resolveSchemaTypeForPath.ts
+++ b/packages/sanity/src/core/studio/copyPaste/resolveSchemaTypeForPath.ts
@@ -62,7 +62,6 @@ export function resolveSchemaTypeForPath(
       const item = getItemType(arraySchemaType, itemValue)
 
       if (item) {
-        // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
         currentField = item as ObjectSchemaType
 
         return
@@ -75,7 +74,6 @@ export function resolveSchemaTypeForPath(
     ) as ObjectSchemaType
 
     if (nextField?.type) {
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       currentField = nextField.type as ObjectSchemaType
     }
   })

--- a/packages/sanity/src/core/studio/copyPaste/transferValue.ts
+++ b/packages/sanity/src/core/studio/copyPaste/transferValue.ts
@@ -339,7 +339,6 @@ export async function transferValue({
     }
   }
 
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   const sourceValueAtPath = getValueAtPath(sourceValue as TypedObject, sourcePath)
 
   // Objects
@@ -349,9 +348,7 @@ export async function transferValue({
   ) {
     const isDocumentLevelPaste = targetRootPath.length === 0
     return collateObjectValue({
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       sourceValue: sourceValueAtPath as TypedObject,
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       targetSchemaType: targetSchemaTypeAtPath as ObjectSchemaType,
       targetRootValue,
       targetRootPath,
@@ -376,7 +373,6 @@ export async function transferValue({
 
     return collateArrayValue({
       sourceValue: wrappedSourceValueAtPath,
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       targetSchemaType: targetSchemaTypeAtPath as ArraySchemaType,
       targetRootValue,
       targetRootPath,
@@ -421,7 +417,6 @@ export async function transferValue({
 
     return collateArrayValue({
       sourceValue: Array.isArray(sourceValueAtPath) ? sourceValueAtPath : wrappedSourceValue,
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       targetSchemaType: targetSchemaTypeAtPath as ArraySchemaType,
       targetRootValue,
       targetRootPath,
@@ -650,7 +645,6 @@ async function collateObjectValue({
           const getClient = (clientOptions: {apiVersion: string}) =>
             (options.client as SanityClient).withConfig(clientOptions)
           const isMatch = await documentMatchesGroqFilter({
-            // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
             rootDocumentValue: (targetRootValue || {}) as SanityDocument,
             referencedDocument: reference,
             schemaTypeOptions: targetSchemaType.options,
@@ -769,12 +763,10 @@ async function collateObjectValue({
       // Object field
     } else if (memberIsObject) {
       const collated = await collateObjectValue({
-        /* oxlint-disable typescript/no-unnecessary-type-assertion */
         sourceValue: getValueAtPath(
           sourceValue as TypedObject,
           targetPath.concat(member.name),
         ) as TypedObject,
-        /* oxlint-enable typescript/no-unnecessary-type-assertion */
         targetPath: [],
         targetSchemaType: memberSchemaType,
         targetRootValue,
@@ -793,7 +785,6 @@ async function collateObjectValue({
       const genericValue = sourceValue ? (sourceValue as TypedObject)[member.name] : undefined
       const collated = await collateArrayValue({
         sourceValue: genericValue,
-        // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
         targetSchemaType: memberSchemaType as ArraySchemaType,
         targetRootValue,
         targetRootPath,

--- a/packages/sanity/src/core/validation/util/typeString.ts
+++ b/packages/sanity/src/core/validation/util/typeString.ts
@@ -16,7 +16,6 @@ export function typeString(obj: unknown): string {
   const stringType = _toString.call(obj).slice(8, -1)
   if (obj === null || obj === undefined) return stringType.toLowerCase()
 
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   const constructorType = (obj as object).constructor
   if (constructorType && !isBuiltIn(constructorType)) return constructorType.name
   return stringType

--- a/packages/sanity/src/core/validation/validators/dateValidator.ts
+++ b/packages/sanity/src/core/validation/validators/dateValidator.ts
@@ -75,8 +75,7 @@ export const dateValidators: Validators = {
     }
 
     const dateTimeOptions: DateTimeOptions = isRecord(type.options)
-      ? // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
-        (type.options as DateTimeOptions)
+      ? (type.options as DateTimeOptions)
       : {}
 
     return (
@@ -108,8 +107,7 @@ export const dateValidators: Validators = {
     }
 
     const dateTimeOptions: DateTimeOptions = isRecord(type.options)
-      ? // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
-        (type.options as DateTimeOptions)
+      ? (type.options as DateTimeOptions)
       : {}
 
     return (

--- a/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
@@ -43,12 +43,10 @@ export function VariantDialog(props: VariantDialogProps): React.JSX.Element {
   const invalid = getIsVariantInvalid(variant) || conditionsInvalid
 
   const handleVariantChange = useCallback<VariantFormChangeHandler>((path, nextValue) => {
-    /* oxlint-disable typescript/no-unnecessary-type-assertion */
     setVariant(
       (currentVariant) =>
         applyPatches([at(path, set(nextValue))], currentVariant) as EditableSystemVariant,
     )
-    /* oxlint-enable typescript/no-unnecessary-type-assertion */
   }, [])
 
   const handleSubmit = useCallback(

--- a/packages/sanity/src/media-library/plugin/VideoInput/VideoAsset.tsx
+++ b/packages/sanity/src/media-library/plugin/VideoInput/VideoAsset.tsx
@@ -23,12 +23,10 @@ function isVideoSource(source: unknown): source is {asset: {_ref: string}} {
   if (typeof source !== 'object' || source === null || !('asset' in source)) {
     return false
   }
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   const asset = (source as {asset: unknown}).asset
   if (typeof asset !== 'object' || asset === null || !('_ref' in asset)) {
     return false
   }
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   const ref = (asset as {_ref: unknown})._ref
   return typeof ref === 'string' && ref.startsWith('media-library:')
 }

--- a/packages/sanity/src/presentation/editor/PostMessagePreviewSnapshots.tsx
+++ b/packages/sanity/src/presentation/editor/PostMessagePreviewSnapshots.tsx
@@ -73,7 +73,6 @@ const PostMessagePreviews: FC<PostMessagePreviewsProps> = (props) => {
                 const snapshot = p.snapshot as PreviewValue & {
                   _id: string
                 }
-                // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
                 return {
                   _id: getPublishedId(snapshot._id),
                   title: snapshot.title,

--- a/packages/sanity/src/presentation/getIntentState.ts
+++ b/packages/sanity/src/presentation/getIntentState.ts
@@ -46,7 +46,6 @@ export function getIntentState(
       _searchParams.preview || new URLSearchParams(window.location.search).get('preview') || '/'
 
     if (payload && typeof payload === 'object') {
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       _searchParams.templateParams = encodeJsonParams(payload as Record<string, unknown>)
     }
 

--- a/packages/sanity/src/presentation/machines/presentation-machine.ts
+++ b/packages/sanity/src/presentation/machines/presentation-machine.ts
@@ -13,7 +13,6 @@ type Event =
   | {type: 'iframe reload'}
 
 export const presentationMachine = setup({
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   types: {} as {
     context: Context
     events: Event

--- a/packages/sanity/src/presentation/machines/preview-url.ts
+++ b/packages/sanity/src/presentation/machines/preview-url.ts
@@ -50,7 +50,6 @@ export const previewUrlSecretDocument = {
 }
 
 export const previewUrlMachine = setup({
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   types: {} as {
     context: Context
     events: Event

--- a/packages/sanity/src/presentation/overlays/schema/extract.tsx
+++ b/packages/sanity/src/presentation/overlays/schema/extract.tsx
@@ -380,7 +380,6 @@ export function extractSchema(workspace: Workspace): SchemaType[] {
     if (options.insertMenu) {
       opts.insertMenu = {
         ...options.insertMenu,
-        // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
         views: (options.insertMenu as InsertMenuOptions).views?.map((view) =>
           view.name === 'grid'
             ? {

--- a/packages/sanity/src/presentation/useVercelBypassSecret.ts
+++ b/packages/sanity/src/presentation/useVercelBypassSecret.ts
@@ -12,7 +12,6 @@ export function useVercelBypassSecret(): [
 ] {
   const client = useClient({apiVersion: API_VERSION})
   const [vercelProtectionBypassReadyState, ready] = useReducer(
-    // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
     () => 'ready' as 'ready' | 'loading',
     'loading',
   )

--- a/packages/sanity/src/router/types.ts
+++ b/packages/sanity/src/router/types.ts
@@ -360,7 +360,6 @@ export const isNavigateOptions = (
 
   // if state exists then it should be of RouterState type
   if ('state' in maybeNavigateOptions) {
-    // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
     const {state} = maybeNavigateOptions as {state: unknown}
     // allow null or undefined or RouterState (including empty object)
     return state === null || state === undefined || typeof state === 'object'

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/CrossDatasetIncomingReference/getCrossDatasetIncomingReferences.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/CrossDatasetIncomingReference/getCrossDatasetIncomingReferences.tsx
@@ -100,7 +100,6 @@ export function getCrossDatasetIncomingReferences({
               type: document.documentType,
               id: document.documentId,
               preview: {
-                // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
                 published: {
                   _id: document.documentId,
                   title: `Document Id: ${document.documentId}`,

--- a/packages/sanity/src/structure/getIntentState.ts
+++ b/packages/sanity/src/structure/getIntentState.ts
@@ -50,7 +50,6 @@ export function getIntentState(
       return {
         panes: panes
           .slice(0, i)
-          // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
           .concat([[{id: editDocumentId, params: paneParams, payload}]]) as RouterPanes,
       }
     }

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -254,8 +254,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
                   isVersion: true,
                   release,
                   isGoingToUnpublish: editState?.version
-                    ? // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
-                      isGoingToUnpublish(editState?.version as SanityDocumentLike)
+                    ? isGoingToUnpublish(editState?.version as SanityDocumentLike)
                     : false,
                 }}
               />

--- a/packages/sanity/src/structure/panes/documentList/helpers.ts
+++ b/packages/sanity/src/structure/panes/documentList/helpers.ts
@@ -71,7 +71,6 @@ export function fromStaticSortOrder(
 }
 
 export function removePublishedWithDrafts(documents: SanityDocumentLike[]): DocumentListPaneItem[] {
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   return collate(documents).map((entry) => {
     const doc = entry.draft || entry.published || entry.versions[0]
     const hasDraft = Boolean(entry.draft)

--- a/packages/sanity/src/structure/structureBuilder/List.ts
+++ b/packages/sanity/src/structure/structureBuilder/List.ts
@@ -71,7 +71,6 @@ function maybeSerializeListItem(
 
   const listItem = item as ListItem
   if (listItem && listItem.type === 'divider') {
-    // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
     return item as Divider
   }
 

--- a/packages/sanity/src/structure/structureResolvers/createResolvedPaneNodeStream.ts
+++ b/packages/sanity/src/structure/structureResolvers/createResolvedPaneNodeStream.ts
@@ -255,8 +255,7 @@ function resolvePaneTree({
           nextStream = resolvePaneTree({
             unresolvedPane:
               typeof paneNode.child === 'function'
-                ? // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
-                  (memoBind(paneNode, 'child') as PaneNodeResolver)
+                ? (memoBind(paneNode, 'child') as PaneNodeResolver)
                 : paneNode.child,
             flattenedRouterPanes: rest,
             parent: paneNode,

--- a/packages/sanity/test/form/renderFileInput.tsx
+++ b/packages/sanity/test/form/renderFileInput.tsx
@@ -62,7 +62,6 @@ export async function renderFileInput(options: {
       directUploads: true,
       observeAsset,
       resolveUploader,
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       schemaType: schemaType as FileSchemaType,
       value: value as Record<string, any>,
     }

--- a/packages/sanity/test/form/renderImageInput.tsx
+++ b/packages/sanity/test/form/renderImageInput.tsx
@@ -66,7 +66,6 @@ export async function renderImageInput(options: {
       isUploading: false,
       observeAsset,
       resolveUploader,
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       schemaType: schemaType as ImageSchemaType,
       value: value as Record<string, any>,
     }

--- a/packages/sanity/test/form/renderVideoInput.tsx
+++ b/packages/sanity/test/form/renderVideoInput.tsx
@@ -77,7 +77,6 @@ export async function renderVideoInput(options: {
       directUploads: true,
       observeAsset,
       resolveUploader,
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       schemaType: schemaType as VideoSchemaType,
       value: value as Record<string, unknown>,
     }

--- a/scripts/trigger-triage/src/archive.ts
+++ b/scripts/trigger-triage/src/archive.ts
@@ -110,7 +110,6 @@ export async function runArchive(opts: RunArchiveOptions): Promise<CliResult> {
     return {stdout, stderr, exitCode: 0}
   }
 
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   const miriadEnv = resolveMiriadEnv(env as MiriadEnvSource)
   const createMiriadClient =
     opts.createMiriadClient ?? ((clientOpts) => new MiriadRestClient(clientOpts))
@@ -138,7 +137,6 @@ async function main(): Promise<void> {
   try {
     const result = await runArchive({
       argv: process.argv.slice(2),
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       env: process.env as MiriadEnvSource,
       loadEnv: loadLocalEnv,
     })

--- a/scripts/trigger-triage/src/index.ts
+++ b/scripts/trigger-triage/src/index.ts
@@ -130,7 +130,6 @@ export async function runTriage(opts: RunTriageOptions): Promise<TriageResult> {
     return {stdout, stderr, exitCode: 0}
   }
 
-  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
   const miriadEnv = resolveMiriadEnv(env as MiriadEnvSource)
   const createMiriadClient =
     opts.createMiriadClient ?? ((clientOpts) => new MiriadRestClient(clientOpts))
@@ -153,7 +152,6 @@ async function main(): Promise<void> {
   try {
     const result = await runTriage({
       argv: process.argv.slice(2),
-      // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
       env: process.env as MiriadEnvSource,
       loadEnv: loadLocalEnv,
     })


### PR DESCRIPTION
This reverts commit 8650c2ebdc07f89ae3b37a0368188b3e7c3d1c12. Oxlint is still stripping type assertions, despite the presence of `// oxlint-disable-next-line typescript/no-unnecessary-type-assertion` comments.

This risks breaking typings e.g. in XState machines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-config and comment-only cleanup with no intentional logic changes; risk is limited to future autofix or stricter lint behavior on those assertions.
> 
> **Overview**
> Reverts the earlier lint tightening that made **`no-unnecessary-type-assertion`** an **error** with grandfathered `oxlint-disable` comments. In **`.oxlintrc.json`** the rule is **`warn`** again and the long rationale for error-level enforcement is removed.
> 
> Across **`@sanity/*`**, **`sanity`**, and **`scripts/trigger-triage`**, this PR strips hundreds of **`typescript/no-unnecessary-type-assertion`** disable directives while leaving the underlying **`as`** casts in place (XState `types: {} as {…}`, schema/diff/form `FIXME`/`any` bridges, patch `insert` shapes, etc.). Runtime behavior is unchanged; the goal is to stop relying on suppressions that **`oxlint --fix`** can still violate by removing load-bearing assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b638d39b0ce615dca1e2f2e9515d6ea02c9b863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->