### PR TITLE
chore(lint): turn off no-unnecessary-type-assertion

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -270,7 +270,9 @@
     "no-redundant-type-constituents": "warn",
     "no-unnecessary-template-expression": "off",
     "no-unnecessary-type-arguments": "warn",
-    "no-unnecessary-type-assertion": "warn",
+    // Kept off: the auto-fix strips `types: {} as {...}` declarations that xstate's `setup()`
+    // requires for typing input/context/events, so `--fix` breaks type checking
+    "no-unnecessary-type-assertion": "off",
     "no-unsafe-type-assertion": "warn",
     "restrict-template-expressions": "warn",
     "unbound-method": "warn",
@@ -306,7 +308,6 @@
         "no-base-to-string": "off",
         "no-unnecessary-boolean-literal-compare": "off",
         "no-unnecessary-template-expression": "off",
-        "no-unnecessary-type-assertion": "off",
         "no-unsafe-type-assertion": "off",
         "unbound-method": "off"
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The `no-unnecessary-type-assertion` auto-fix strips `types: {} as {...}` declarations from xstate `setup()` calls. xstate relies on that assertion to type `input`/`context`/`events`, so every run of the automated lint-fix workflow (`oxlint --fix`) broke type checking — see [#13485](https://github.com/sanity-io/sanity/pull/13485), where the fix bot removed the assertions in `documentGroupInventoryMachine.ts` and `preview-url.ts` and `typeCheck` failed with `Property 'selectionMachine' does not exist on type '{}'` etc. Making it an error with grandfathered suppressions was already tried and reverted (ebae0cee6d), so the rule is now off entirely. The now-redundant test-file override for the same rule is removed too.

### What to review

`.oxlintrc.json` only: the rule moves from `warn` to `off`, with a comment explaining why, and the dead override entry under `**/*.test.*` is dropped.

### Testing

Reproduced the bug on `main`: `oxlint --disable-nested-config --fix` rewrote `documentGroupInventoryMachine.ts` from `types: {} as {...}` to `types: {}`. With this change the same command leaves the xstate machine files untouched, and `pnpm check:oxlint`, `pnpm chore:oxlint:fix`, and `pnpm check:format` all pass with a clean tree.

### Notes for release

N/A – Internal only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6280af28-5cf1-42e8-8e27-e27b124258af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6280af28-5cf1-42e8-8e27-e27b124258af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

