### PR TITLE
fix: only show document sync state toast on actual commit failures

### DIFF
--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -393,8 +393,8 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
     const createActionDisabled = isNonExistent && !isActionEnabled(schemaType, 'create')
     const reconnecting = connectionState === 'reconnecting'
     const isLocked = editState.transactionSyncLock?.enabled
-    // Lock once edits have stalled, and keep it locked while the backlog
-    // is flushing after reconnect (`recovering`) — we're not in sync yet.
+    // Lock once edits have stalled, and keep it locked while a failed
+    // commit is being retried (`recovering`) — we're not in sync yet.
     const syncBlocked = syncState === 'stalled' || syncState === 'recovering'
     const willBeUnpublished = value ? isGoingToUnpublish(value) : false
 

--- a/packages/sanity/src/core/hooks/__tests__/useDocumentSyncState.test.ts
+++ b/packages/sanity/src/core/hooks/__tests__/useDocumentSyncState.test.ts
@@ -15,16 +15,20 @@ describe('deriveDocumentSyncState', () => {
   function subscribe(
     consistency$: Subject<boolean>,
     connection$: BehaviorSubject<ConnectionState>,
+    commitFailed$: BehaviorSubject<boolean>,
   ) {
     const states: DocumentSyncState[] = []
-    const sub = deriveDocumentSyncState(consistency$, connection$).subscribe((s) => states.push(s))
+    const sub = deriveDocumentSyncState(consistency$, connection$, commitFailed$).subscribe((s) =>
+      states.push(s),
+    )
     return {states, sub}
   }
 
   it('stays synced while consistent', () => {
     const consistency$ = new Subject<boolean>()
     const connection$ = new BehaviorSubject<ConnectionState>('connected')
-    const {states, sub} = subscribe(consistency$, connection$)
+    const commitFailed$ = new BehaviorSubject(false)
+    const {states, sub} = subscribe(consistency$, connection$, commitFailed$)
     consistency$.next(true)
     vi.advanceTimersByTime(60_000)
     expect(states).toEqual(['synced'])
@@ -35,7 +39,8 @@ describe('deriveDocumentSyncState', () => {
     const consistency$ = new Subject<boolean>()
     // Disconnected so the blip would escalate if it lasted.
     const connection$ = new BehaviorSubject<ConnectionState>('reconnecting')
-    const {states, sub} = subscribe(consistency$, connection$)
+    const commitFailed$ = new BehaviorSubject(false)
+    const {states, sub} = subscribe(consistency$, connection$, commitFailed$)
     consistency$.next(false)
     vi.advanceTimersByTime(5_000)
     consistency$.next(true)
@@ -45,9 +50,12 @@ describe('deriveDocumentSyncState', () => {
   })
 
   it('escalates synced → pending → stalled while unsynced AND disconnected', () => {
+    // Disconnection is a problem in itself — the escalation requires no
+    // commit-failure evidence.
     const consistency$ = new Subject<boolean>()
     const connection$ = new BehaviorSubject<ConnectionState>('reconnecting')
-    const {states, sub} = subscribe(consistency$, connection$)
+    const commitFailed$ = new BehaviorSubject(false)
+    const {states, sub} = subscribe(consistency$, connection$, commitFailed$)
     consistency$.next(false)
     expect(states).toEqual(['synced'])
 
@@ -62,32 +70,109 @@ describe('deriveDocumentSyncState', () => {
     sub.unsubscribe()
   })
 
-  it('shows `recovering` (not pending/stalled) when unsynced but connected', () => {
+  it('stays synced while unsynced-but-connected when no commit has failed (slow backlog)', () => {
+    // THE regression this state machine must not reintroduce: a connected
+    // document with a slow-draining backlog (sustained typing, saturated
+    // request pipeline) but commits succeeding must never warn or lock.
     const consistency$ = new Subject<boolean>()
     const connection$ = new BehaviorSubject<ConnectionState>('connected')
-    const {states, sub} = subscribe(consistency$, connection$)
+    const commitFailed$ = new BehaviorSubject(false)
+    const {states, sub} = subscribe(consistency$, connection$, commitFailed$)
     consistency$.next(false)
-    // The pending floor still applies, so nothing shows for the first 10s
-    // (a normal commit completes well within that and never flashes).
-    vi.advanceTimersByTime(5_000)
+    // Stay unsynced far past every threshold — still nothing to show.
+    vi.advanceTimersByTime(120_000)
     expect(states).toEqual(['synced'])
-    // Past the floor, connected → assume the backlog is flushing, not stuck.
-    vi.advanceTimersByTime(5_000)
+    consistency$.next(true)
+    expect(states).toEqual(['synced'])
+    sub.unsubscribe()
+  })
+
+  it('shows `recovering` when unsynced, connected, and a commit failed', () => {
+    const consistency$ = new Subject<boolean>()
+    const connection$ = new BehaviorSubject<ConnectionState>('connected')
+    const commitFailed$ = new BehaviorSubject(false)
+    const {states, sub} = subscribe(consistency$, connection$, commitFailed$)
+    consistency$.next(false)
+    commitFailed$.next(true)
+    // The pending floor still applies, so nothing shows for the first 10s
+    // (a failure retried successfully within that never flashes).
+    vi.advanceTimersByTime(10_000)
+    expect(states).toEqual(['synced'])
+    // Past the floor there's still a short debounce, giving the retry a
+    // chance to get through before anything is shown.
+    vi.advanceTimersByTime(5_500)
     expect(states).toEqual(['synced', 'recovering'])
     sub.unsubscribe()
   })
 
-  it('falls back recovering → stalled when connected but the backlog never drains', () => {
+  it('does not flash recovering for a failure whose retry succeeds within the debounce', () => {
+    // Even past the pending floor (e.g. sustained typing with a long-lived
+    // backlog), a single transient failure must not flash the toast if the
+    // retry promptly gets through.
     const consistency$ = new Subject<boolean>()
     const connection$ = new BehaviorSubject<ConnectionState>('connected')
-    const {states, sub} = subscribe(consistency$, connection$)
+    const commitFailed$ = new BehaviorSubject(false)
+    const {states, sub} = subscribe(consistency$, connection$, commitFailed$)
     consistency$.next(false)
-    // Past the pending floor and connected → start by reassuring (`recovering`).
-    vi.advanceTimersByTime(10_000)
+    // Unsynced well past the floor with commits succeeding — nothing shown.
+    vi.advanceTimersByTime(15_000)
+    expect(states).toEqual(['synced'])
+    // A commit fails, and its retry (~1s backoff) succeeds within the
+    // debounce window.
+    commitFailed$.next(true)
+    vi.advanceTimersByTime(2_000)
+    commitFailed$.next(false)
+    vi.advanceTimersByTime(60_000)
+    expect(states).toEqual(['synced'])
+    sub.unsubscribe()
+  })
+
+  it('does not show anything if the failed commit recovers before the pending floor', () => {
+    const consistency$ = new Subject<boolean>()
+    const connection$ = new BehaviorSubject<ConnectionState>('connected')
+    const commitFailed$ = new BehaviorSubject(false)
+    const {states, sub} = subscribe(consistency$, connection$, commitFailed$)
+    consistency$.next(false)
+    commitFailed$.next(true)
+    // The retry succeeds well within the pending floor.
+    vi.advanceTimersByTime(5_000)
+    commitFailed$.next(false)
+    vi.advanceTimersByTime(60_000)
+    expect(states).toEqual(['synced'])
+    sub.unsubscribe()
+  })
+
+  it('clears recovering → synced as soon as a retry succeeds, before consistency returns', () => {
+    const consistency$ = new Subject<boolean>()
+    const connection$ = new BehaviorSubject<ConnectionState>('connected')
+    const commitFailed$ = new BehaviorSubject(false)
+    const {states, sub} = subscribe(consistency$, connection$, commitFailed$)
+    consistency$.next(false)
+    commitFailed$.next(true)
+    vi.advanceTimersByTime(15_500)
     expect(states).toEqual(['synced', 'recovering'])
-    // But if commits never get through (consistency stays false), a live
-    // connection is not enough — after the grace window stop reassuring and
-    // lock as `stalled`.
+    // A retry lands (commit success) while the backlog is still draining —
+    // commits are getting through again, so stop warning immediately.
+    commitFailed$.next(false)
+    expect(states).toEqual(['synced', 'recovering', 'synced'])
+    vi.advanceTimersByTime(60_000)
+    expect(states).toEqual(['synced', 'recovering', 'synced'])
+    sub.unsubscribe()
+  })
+
+  it('falls back recovering → stalled when connected but commits keep failing', () => {
+    const consistency$ = new Subject<boolean>()
+    const connection$ = new BehaviorSubject<ConnectionState>('connected')
+    const commitFailed$ = new BehaviorSubject(false)
+    const {states, sub} = subscribe(consistency$, connection$, commitFailed$)
+    consistency$.next(false)
+    commitFailed$.next(true)
+    // Past the pending floor and the debounce, connected + failing → start
+    // by reassuring.
+    vi.advanceTimersByTime(15_500)
+    expect(states).toEqual(['synced', 'recovering'])
+    // But if the retries never get through (still failing, still unsynced),
+    // stop reassuring after the grace window and lock as `stalled`.
     vi.advanceTimersByTime(10_000)
     expect(states).toEqual(['synced', 'recovering', 'stalled'])
     // And it stays stalled.
@@ -99,9 +184,11 @@ describe('deriveDocumentSyncState', () => {
   it('clears recovering → synced if the backlog drains within the grace window', () => {
     const consistency$ = new Subject<boolean>()
     const connection$ = new BehaviorSubject<ConnectionState>('connected')
-    const {states, sub} = subscribe(consistency$, connection$)
+    const commitFailed$ = new BehaviorSubject(false)
+    const {states, sub} = subscribe(consistency$, connection$, commitFailed$)
     consistency$.next(false)
-    vi.advanceTimersByTime(10_000)
+    commitFailed$.next(true)
+    vi.advanceTimersByTime(15_500)
     expect(states).toEqual(['synced', 'recovering'])
     // Backlog drains before the grace timer fires → straight back to synced,
     // never escalating to stalled.
@@ -112,19 +199,27 @@ describe('deriveDocumentSyncState', () => {
     sub.unsubscribe()
   })
 
-  it('switches stalled → recovering the moment the connection returns', () => {
+  it('switches stalled → recovering shortly after the connection returns', () => {
     const consistency$ = new Subject<boolean>()
     const connection$ = new BehaviorSubject<ConnectionState>('reconnecting')
-    const {states, sub} = subscribe(consistency$, connection$)
+    const commitFailed$ = new BehaviorSubject(false)
+    const {states, sub} = subscribe(consistency$, connection$, commitFailed$)
     consistency$.next(false)
+    // Commit attempts fail with network errors while offline.
+    commitFailed$.next(true)
     vi.advanceTimersByTime(30_000)
     expect(states).toEqual(['synced', 'pending', 'stalled'])
 
-    // Reconnect while edits still haven't flushed.
+    // Reconnect while edits still haven't flushed. The debounce holds the
+    // current state briefly — if the flush succeeds within it, we'd go
+    // straight back to synced without ever showing `recovering`.
     connection$.next('connected')
+    expect(states).toEqual(['synced', 'pending', 'stalled'])
+    vi.advanceTimersByTime(5_500)
     expect(states).toEqual(['synced', 'pending', 'stalled', 'recovering'])
 
     // Backlog drains.
+    commitFailed$.next(false)
     consistency$.next(true)
     expect(states).toEqual(['synced', 'pending', 'stalled', 'recovering', 'synced'])
     sub.unsubscribe()
@@ -133,14 +228,17 @@ describe('deriveDocumentSyncState', () => {
   it('after reconnect, falls back recovering → stalled if commits still never land', () => {
     const consistency$ = new Subject<boolean>()
     const connection$ = new BehaviorSubject<ConnectionState>('reconnecting')
-    const {states, sub} = subscribe(consistency$, connection$)
+    const commitFailed$ = new BehaviorSubject(false)
+    const {states, sub} = subscribe(consistency$, connection$, commitFailed$)
     consistency$.next(false)
+    commitFailed$.next(true)
     vi.advanceTimersByTime(30_000)
     expect(states).toEqual(['synced', 'pending', 'stalled'])
 
     // Reconnect, but commits keep failing (e.g. a document-specific 5xx
     // retrying on backoff while the listener is perfectly connected).
     connection$.next('connected')
+    vi.advanceTimersByTime(5_500)
     expect(states).toEqual(['synced', 'pending', 'stalled', 'recovering'])
 
     // We don't reassure forever: past the grace window, back to stalled.
@@ -150,21 +248,24 @@ describe('deriveDocumentSyncState', () => {
   })
 
   it('does not flap recovering ↔ stalled when the stage timer ticks while connected', () => {
-    // Regression guard for the custom `distinctUntilChanged` comparator +
-    // `isConnected$` boolean collapse. While connected and unsynced, the state
-    // machine shows `recovering` then falls back to `stalled` after the grace
-    // window. Independently, the underlying stage$ timer keeps ticking
-    // (pending → stalled at STALLED_AFTER_MS = 30s). That stage tick must NOT
-    // re-fire the connected branch's switchMap — otherwise its grace timer
-    // restarts and the state flaps back to `recovering` before settling on
-    // `stalled` again.
+    // Regression guard for collapsing the inputs to the underlying sync
+    // state before the time-boxed switchMap. While connected and failing,
+    // the state machine shows `recovering` then falls back to `stalled`
+    // after the grace window. Independently, the underlying stage$ timer
+    // keeps ticking (pending → stalled at STALLED_AFTER_MS = 30s). That
+    // stage tick must NOT re-fire the retrying switchMap — otherwise its
+    // grace timer restarts and the state flaps back to `recovering` before
+    // settling on `stalled` again.
     const consistency$ = new Subject<boolean>()
     const connection$ = new BehaviorSubject<ConnectionState>('connected')
-    const {states, sub} = subscribe(consistency$, connection$)
+    const commitFailed$ = new BehaviorSubject(false)
+    const {states, sub} = subscribe(consistency$, connection$, commitFailed$)
     consistency$.next(false)
+    commitFailed$.next(true)
 
-    // Past the pending floor (10s), connected → `recovering`.
-    vi.advanceTimersByTime(10_000)
+    // Past the pending floor (10s) and the debounce (5.5s), connected +
+    // failing → `recovering`.
+    vi.advanceTimersByTime(15_500)
     expect(states).toEqual(['synced', 'recovering'])
 
     // Grace window (10s) elapses without draining → `stalled`.
@@ -172,9 +273,9 @@ describe('deriveDocumentSyncState', () => {
     expect(states).toEqual(['synced', 'recovering', 'stalled'])
 
     // Cross the 30s STALLED_AFTER_MS boundary, where stage$ ticks
-    // pending → stalled underneath. With the flap-guard this is a no-op; the
-    // state stays `stalled`. Without it, switchMap re-fires and we'd see a
-    // spurious `recovering` (then `stalled` again).
+    // pending → stalled underneath. With the input collapse this is a no-op;
+    // the state stays `stalled`. Without it, switchMap re-fires and we'd see a
+    // spurious gap (debounce) then `recovering` and `stalled` again.
     vi.advanceTimersByTime(20_000)
     expect(states).toEqual(['synced', 'recovering', 'stalled'])
 
@@ -187,11 +288,13 @@ describe('deriveDocumentSyncState', () => {
   it('handles a connected → disconnected → connected cycle while unsynced', () => {
     const consistency$ = new Subject<boolean>()
     const connection$ = new BehaviorSubject<ConnectionState>('connected')
-    const {states, sub} = subscribe(consistency$, connection$)
+    const commitFailed$ = new BehaviorSubject(false)
+    const {states, sub} = subscribe(consistency$, connection$, commitFailed$)
     consistency$.next(false)
+    commitFailed$.next(true)
 
-    // Connected past the pending floor → `recovering`.
-    vi.advanceTimersByTime(10_000)
+    // Connected + failing past the pending floor and debounce → `recovering`.
+    vi.advanceTimersByTime(15_500)
     expect(states).toEqual(['synced', 'recovering'])
 
     // Connection drops while still unsynced. The stage has already escalated
@@ -205,8 +308,10 @@ describe('deriveDocumentSyncState', () => {
     vi.advanceTimersByTime(20_000)
     expect(states).toEqual(['synced', 'recovering', 'pending', 'stalled'])
 
-    // Connection returns while still unsynced → back to `recovering`.
+    // Connection returns while still unsynced and failing → back to
+    // `recovering` after the debounce.
     connection$.next('connected')
+    vi.advanceTimersByTime(5_500)
     expect(states).toEqual(['synced', 'recovering', 'pending', 'stalled', 'recovering'])
 
     // Backlog finally drains → `synced`.
@@ -218,7 +323,8 @@ describe('deriveDocumentSyncState', () => {
   it('recovers to synced as soon as consistency returns, and restarts cleanly', () => {
     const consistency$ = new Subject<boolean>()
     const connection$ = new BehaviorSubject<ConnectionState>('reconnecting')
-    const {states, sub} = subscribe(consistency$, connection$)
+    const commitFailed$ = new BehaviorSubject(false)
+    const {states, sub} = subscribe(consistency$, connection$, commitFailed$)
     consistency$.next(false)
     vi.advanceTimersByTime(30_000)
     expect(states).toEqual(['synced', 'pending', 'stalled'])

--- a/packages/sanity/src/core/hooks/useDocumentSyncState.ts
+++ b/packages/sanity/src/core/hooks/useDocumentSyncState.ts
@@ -8,29 +8,36 @@ import {type ConnectionState, connectionState} from './useConnectionState'
 
 /**
  * Staged "is this document syncing?" signal, derived from the document's
- * consistency state combined with the realtime connection state.
+ * consistency state combined with the realtime connection state and whether
+ * the latest commit attempt actually failed.
  *
  * - `synced`: no pending local mutations, or they're committing normally.
+ *   This includes a slow-draining backlog: while the connection is live and
+ *   no commit has failed, a document that stays unsynced for a while (e.g.
+ *   sustained typing while the request pipeline is saturated) is not an
+ *   error condition, and nothing is shown.
  * - `pending`: local mutations have been unsynced for a short while
- *   (`PENDING_AFTER_MS`) and we still don't have a live connection —
- *   a commit is failing/retrying. Non-blocking; the editor stays usable.
+ *   (`PENDING_AFTER_MS`) and we don't have a live connection. Non-blocking;
+ *   the editor stays usable.
  * - `stalled`: still unsynced and disconnected past `STALLED_AFTER_MS` —
  *   the editor goes read-only to stop the user piling more edits onto a
  *   document that isn't reaching the server.
- * - `recovering`: still unsynced, but the connection is back — we're
- *   flushing the buffered backlog. Editing stays locked (we're not in
- *   sync yet), but the message reassures the user that submissions have
- *   resumed rather than telling them they're stuck. Clears to `synced`
- *   the moment the backlog drains.
+ * - `recovering`: unsynced past the pending floor, the connection is live,
+ *   and the latest commit attempt *failed* — the mutator is retrying it on
+ *   backoff. This covers both the flush right after a reconnect and a
+ *   document-specific 5xx that retries while the listener stays perfectly
+ *   connected. Editing stays locked (we're not in sync yet), but the
+ *   message reassures the user that we're saving rather than telling them
+ *   they're stuck. Entry is debounced by `RECOVERING_DEBOUNCE_MS`, so a
+ *   failure whose retry promptly succeeds never shows at all; once shown,
+ *   it clears the moment a retry succeeds or the backlog drains.
  *
- *   `recovering` is time-boxed: a live realtime connection does not
- *   guarantee that *commits* are succeeding (a document-specific 5xx
- *   retries on backoff while the listener stays perfectly connected, and
- *   the mutator eventually stops retrying after ~200 attempts — see
- *   `BufferedDocument._cycleCommitter`). If we stay unsynced for
- *   `RECOVERING_GRACE_MS` after the connection returns, the backlog clearly
- *   isn't draining, so we fall back to `stalled` rather than reassure the
- *   user indefinitely while nothing reaches the server.
+ *   `recovering` is time-boxed: if we stay unsynced-and-failing for
+ *   `RECOVERING_GRACE_MS`, the backlog clearly isn't draining (the mutator
+ *   eventually stops retrying after ~200 attempts — see
+ *   `BufferedDocument._cycleCommitter`), so we fall back to `stalled`
+ *   rather than reassure the user indefinitely while nothing reaches the
+ *   server.
  *
  * @internal
  */
@@ -41,12 +48,20 @@ const PENDING_AFTER_MS = 10_000
 /** How long before we escalate to a read-only lock. */
 const STALLED_AFTER_MS = 30_000
 /**
- * How long we trust "connection is back" to mean "the backlog is flushing"
- * before concluding commits aren't actually getting through and showing
- * `stalled` instead. Kept short: a healthy backlog drains in well under a
- * second once the connection is live.
+ * How long we keep reassuring (`recovering`) while connected and retrying a
+ * failed commit, before concluding commits aren't getting through and
+ * showing `stalled` instead.
  */
 const RECOVERING_GRACE_MS = 10_000
+/**
+ * How long a commit failure must persist (while connected and past the
+ * pending floor) before we show `recovering`. The mutator's retry backoff
+ * is `commit.tries * 1000` (see `BufferedDocument._cycleCommitter`), so the
+ * first two retries land at ~1s and ~3s after the failure — this gives both
+ * a chance to succeed without the toast ever flashing for a transient
+ * failure.
+ */
+const RECOVERING_DEBOUNCE_MS = 5_500
 
 const INITIAL: DocumentSyncState = 'synced'
 
@@ -55,7 +70,8 @@ type UnsyncedStage = 'synced' | 'pending' | 'stalled'
 
 /**
  * Maps the consistency stream (`true` = synced, `false` = unsynced local
- * mutations) and the connection state to the staged
+ * mutations), the connection state, and the commit-failure stream (`true` =
+ * the latest commit attempt failed and is being retried) to the staged
  * {@link DocumentSyncState}. Pure — extracted so the timing/combination
  * behavior can be unit-tested without the document store.
  *
@@ -64,6 +80,7 @@ type UnsyncedStage = 'synced' | 'pending' | 'stalled'
 export function deriveDocumentSyncState(
   consistency$: Observable<boolean>,
   connectionState$: Observable<ConnectionState>,
+  commitFailed$: Observable<boolean>,
 ): Observable<DocumentSyncState> {
   const stage$: Observable<UnsyncedStage> = consistency$.pipe(
     switchMap((isConsistent) => {
@@ -81,44 +98,64 @@ export function deriveDocumentSyncState(
     distinctUntilChanged(),
   )
 
-  // Whether the connection is live, collapsed to a boolean. We only care
-  // about connected-vs-not here, and we must NOT let `stage` ticks
-  // (pending → stalled) feed the connected branch's switchMap below, or its
-  // grace timer would restart on every tick and flap recovering ↔ stalled.
+  // Whether the connection is live, collapsed to a boolean — we only care
+  // about connected-vs-not here.
   const isConnected$ = connectionState$.pipe(
     map((connection) => connection === 'connected'),
     distinctUntilChanged(),
   )
 
-  return combineLatest([stage$, isConnected$]).pipe(
-    // Collapse inputs that the branch logic treats identically, so the
-    // switchMap below doesn't re-fire (and restart its grace timer) on a
-    // change it would map to the same behavior. While connected, the
-    // pending → stalled tick is such a no-op: the connected branch ignores
-    // which stage we're in, so without this it would flap recovering ↔
-    // stalled every time the stage timer ticks underneath.
-    distinctUntilChanged(([prevStage, prevConn], [stage, conn]) => {
-      if (prevConn !== conn) return false
-      if (conn) return (prevStage === 'synced') === (stage === 'synced')
-      return prevStage === stage
+  return combineLatest([stage$, isConnected$, commitFailed$.pipe(distinctUntilChanged())]).pipe(
+    // Collapse the inputs to the underlying sync situation they describe —
+    // the timing policy below (debounce, grace window) then maps it to the
+    // presented DocumentSyncState.
+    map(([stage, isConnected, commitFailed]) => {
+      // Consistent, or a fresh unsynced period under the pending floor —
+      // nothing to show.
+      if (stage === 'synced') return 'synced'
+
+      // Unsynced and not connected: the staged warning/lock. Disconnection
+      // is a problem in itself — buffered edits can't reach the server —
+      // so no commit-failure evidence is required here.
+      if (!isConnected) return stage === 'pending' ? 'disconnected-pending' : 'disconnected-stalled'
+
+      // Unsynced but connected. Only escalate when a commit actually
+      // failed: a backlog that is merely slow to drain (commits succeeding
+      // while the user keeps editing, or a saturated request pipeline)
+      // must not warn — and certainly must not lock the editor.
+      return commitFailed ? 'retrying' : 'synced'
     }),
-    // switchMap (not map) because the connected branch is time-boxed.
-    switchMap(([stage, isConnected]): Observable<DocumentSyncState> => {
-      // Still synced (or recovered) — nothing to show.
-      if (stage === 'synced') return of<DocumentSyncState>('synced')
+    // Dropping identical consecutive values here is what keeps the
+    // switchMap below from re-firing (and restarting its timers) on an
+    // input change that maps to the same underlying state. While retrying,
+    // the pending → stalled stage tick is such a no-op: without this it
+    // would flap recovering ↔ stalled every time the stage timer ticks
+    // underneath.
+    distinctUntilChanged(),
+    // switchMap (not map) because the retrying state is time-boxed.
+    switchMap((state): Observable<DocumentSyncState> => {
+      if (state === 'synced') return of<DocumentSyncState>('synced')
 
-      // Unsynced and not connected: the staged warning/lock.
-      if (!isConnected) return of<DocumentSyncState>(stage)
+      if (state === 'disconnected-pending') return of<DocumentSyncState>('pending')
 
-      // Unsynced AND the connection is back. For a short grace window we
-      // assume the backlog is flushing and reassure (`recovering`). If it
-      // hasn't drained by then, commits aren't getting through after all —
-      // fall back to `stalled` so we don't reassure indefinitely. (When the
-      // backlog *does* drain, consistency$ flips to `true`, stage becomes
-      // 'synced', and switchMap tears this timer down before it fires.)
-      return timer(RECOVERING_GRACE_MS).pipe(
-        map((): DocumentSyncState => 'stalled'),
-        startWith<DocumentSyncState>('recovering'),
+      if (state === 'disconnected-stalled') return of<DocumentSyncState>('stalled')
+
+      // Connected, unsynced, and the latest commit failed. Hold the
+      // previous state for a short debounce first — if the retry gets
+      // through within it, nothing is ever shown. Then reassure
+      // (`recovering`) for a grace window; if we're still
+      // unsynced-and-failing when it fires, commits aren't landing — fall
+      // back to `stalled` so we don't reassure indefinitely. (A successful
+      // retry flips `commitFailed` off and a drained backlog flips the
+      // stage to 'synced' — either tears these timers down via switchMap
+      // before they fire.)
+      return timer(RECOVERING_DEBOUNCE_MS).pipe(
+        switchMap(() =>
+          timer(RECOVERING_GRACE_MS).pipe(
+            map((): DocumentSyncState => 'stalled'),
+            startWith<DocumentSyncState>('recovering'),
+          ),
+        ),
       )
     }),
     startWith(INITIAL),
@@ -139,6 +176,9 @@ export function useDocumentSyncState(
       deriveDocumentSyncState(
         documentStore.pair.consistencyStatus(publishedDocId, docTypeName, version),
         connectionState(documentStore, publishedDocId, docTypeName, version),
+        documentStore.pair
+          .commitErrorStatus(publishedDocId, docTypeName, version)
+          .pipe(map((commitError) => commitError !== undefined)),
       ),
     [docTypeName, documentStore, publishedDocId, version],
   )

--- a/packages/sanity/src/core/store/document/document-pair/checkoutPair.test.ts
+++ b/packages/sanity/src/core/store/document/document-pair/checkoutPair.test.ts
@@ -602,6 +602,170 @@ describe('checkoutPair -- failed commit routing', () => {
   })
 })
 
+describe('checkoutPair -- commitError$', () => {
+  // `commitError$` is the signal that lets the document sync state
+  // distinguish "commits are failing" from "the backlog is merely slow": it
+  // must only carry an error while the most recent commit attempt failed and
+  // is being retried by the mutator.
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function collectCommitError(pair: {commitError$: Observable<{error: unknown} | undefined>}) {
+    const values: ({error: unknown} | undefined)[] = []
+    const sub = pair.commitError$.subscribe((v) => values.push(v))
+    return {values, sub}
+  }
+
+  test('stays undefined while commits succeed', async () => {
+    const pair = checkoutPair(client as any as SanityClient, idPair, of(true))
+    const {draft, published} = pair
+    const sub = merge(draft.events, published.events).subscribe()
+    const commitError = collectCommitError(pair)
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    draft.mutate(draft.patch([{set: {title: 'all good'}}]))
+    draft.commit()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(commitError.values).toEqual([undefined])
+
+    commitError.sub.unsubscribe()
+    sub.unsubscribe()
+  })
+
+  test('carries the error on a retryable failure and clears when the retry succeeds', async () => {
+    const serverError = Object.assign(new Error('Internal Server Error'), {statusCode: 500})
+    // Only the first attempt fails; the retry uses the default mock and
+    // succeeds — as when a transient 5xx clears.
+    mockedActionRequest.mockImplementationOnce(() => throwError(() => serverError) as any)
+
+    const pair = checkoutPair(client as any as SanityClient, idPair, of(true))
+    const {draft, published} = pair
+    const sub = merge(draft.events, published.events).subscribe()
+    const commitError = collectCommitError(pair)
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    draft.mutate(draft.patch([{set: {title: 'new title'}}]))
+    draft.commit()
+    await vi.advanceTimersByTimeAsync(0)
+
+    // First attempt failed → the retry is pending, and the error that
+    // caused it is exposed.
+    expect(commitError.values).toEqual([undefined, {error: serverError}])
+
+    // Advance past the first retry backoff (1000ms); the retry succeeds.
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(commitError.values).toEqual([undefined, {error: serverError}, undefined])
+
+    commitError.sub.unsubscribe()
+    sub.unsubscribe()
+  })
+
+  test('stays undefined for a terminal (cancelled) failure — nothing is being retried', async () => {
+    const clientError = Object.assign(new Error('Bad Request'), {statusCode: 400})
+    mockedActionRequest.mockImplementation(() => throwError(() => clientError) as any)
+
+    const pair = checkoutPair(client as any as SanityClient, idPair, of(true))
+    const {draft, published} = pair
+    const sub = merge(draft.events, published.events).subscribe()
+    const commitError = collectCommitError(pair)
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    draft.mutate(draft.patch([{set: {title: 'bad request'}}]))
+    draft.commit()
+    await vi.advanceTimersByTimeAsync(0)
+
+    // The commit was cancelled and the buffer reset — no retry is in flight,
+    // so the signal must not report a failure being recovered from.
+    expect(commitError.values).toEqual([undefined])
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(commitError.values).toEqual([undefined])
+
+    commitError.sub.unsubscribe()
+    sub.unsubscribe()
+  })
+
+  test('replays the current value to late subscribers', async () => {
+    const serverError = Object.assign(new Error('Internal Server Error'), {statusCode: 500})
+    // Every attempt fails, so the failure state persists across retries.
+    mockedActionRequest.mockImplementation(() => throwError(() => serverError) as any)
+
+    const pair = checkoutPair(client as any as SanityClient, idPair, of(true))
+    const {draft, published} = pair
+    const sub = merge(draft.events, published.events).subscribe()
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    draft.mutate(draft.patch([{set: {title: 'new title'}}]))
+    draft.commit()
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Subscribe only after the failure happened (as the sync-state hook does
+    // when a document pane mounts against an already-checked-out pair).
+    const late = collectCommitError(pair)
+    expect(late.values).toEqual([{error: serverError}])
+
+    late.sub.unsubscribe()
+    sub.unsubscribe()
+  })
+
+  test('a listener reconnect does not mask an ongoing commit failure', async () => {
+    // The reset is keyed on the pair returning to CONSISTENCY, not on
+    // listener reconnects: a live listener says nothing about commit
+    // health. When the connection blips and resyncs while the mutator is
+    // still retrying a failing commit, the error must (re)assert itself
+    // rather than staying cleared.
+    const serverError = Object.assign(new Error('Internal Server Error'), {statusCode: 500})
+    // EVERY attempt fails — the outage outlives the reconnect.
+    mockedActionRequest.mockImplementation(() => throwError(() => serverError) as any)
+
+    const listenerSubject = new Subject()
+    const testClient = {
+      ...client,
+      observable: {
+        ...client.observable,
+        listen: () => merge(of({type: 'welcome'}).pipe(delay(0)), listenerSubject),
+      },
+    }
+
+    const pair = checkoutPair(testClient as any as SanityClient, idPair, of(true))
+    const {draft, published} = pair
+    const sub = merge(draft.events, published.events).subscribe()
+    const commitError = collectCommitError(pair)
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    draft.mutate(draft.patch([{set: {title: 'new title'}}]))
+    draft.commit()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(commitError.values.at(-1)).toEqual({error: serverError})
+
+    // The listener reconnects and resyncs (fresh snapshots force the pair
+    // back to consistency), but the buffered edits are still being retried
+    // against a failing endpoint.
+    listenerSubject.next({type: 'welcome'})
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Once the retry fires (backoff is `tries * 1000`) and fails, the error
+    // is exposed again — the reconnect did not permanently mask it.
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(commitError.values.at(-1)).toEqual({error: serverError})
+
+    commitError.sub.unsubscribe()
+    sub.unsubscribe()
+  })
+})
+
 function createMutationEvent(
   transactionId: string,
   documentId: string,

--- a/packages/sanity/src/core/store/document/document-pair/checkoutPair.ts
+++ b/packages/sanity/src/core/store/document/document-pair/checkoutPair.ts
@@ -7,14 +7,16 @@ import {
 import {type Mutation} from '@sanity/mutator'
 import {type SanityDocument} from '@sanity/types'
 import omit from 'lodash-es/omit.js'
-import {defer, EMPTY, from, merge, type Observable, timer} from 'rxjs'
+import {combineLatest, defer, EMPTY, from, merge, type Observable, of, timer} from 'rxjs'
 import {
   catchError,
+  distinctUntilChanged,
   filter,
   map,
   mergeMap,
   scan,
   share,
+  shareReplay,
   startWith,
   switchMap,
   takeUntil,
@@ -110,11 +112,32 @@ export interface DocumentVersion {
 }
 
 /**
+ * The error thrown by the most recent failed commit attempt. Wrapped in an
+ * object (rather than emitted raw) because a commit can reject with any
+ * thrown value — including `undefined`, which would otherwise be
+ * indistinguishable from the healthy state.
+ *
+ * @internal
+ */
+export type CommitError = {error: unknown}
+
+/**
  * @hidden
  * @beta */
 export type Pair = {
   /** @internal */
   transactionsPendingEvents$: Observable<PendingMutationsEvent>
+  /**
+   * The error from the most recent commit attempt while it failed and is
+   * being retried by the mutator, or `undefined` while commits are healthy.
+   * Resets to `undefined` on the next successful (or terminally cancelled)
+   * commit, and when the pair returns to a consistent state — i.e. the
+   * buffered edits the failure was about no longer exist. Distinguishes
+   * "commits are failing" from "the backlog is merely slow" — see
+   * `useDocumentSyncState`.
+   * @internal
+   */
+  commitError$: Observable<CommitError | undefined>
   published: DocumentVersion
   draft: DocumentVersion
   version?: DocumentVersion
@@ -243,15 +266,31 @@ function commitMutations(
  */
 const TERMINAL_COMMIT_STATUSES = new Set([400, 401, 402, 403, 404, 409, 410, 412, 413, 422])
 
+/**
+ * The result of a single commit attempt. Failures are routed to the mutator
+ * (`request.failure` → retry with backoff, `request.cancel` → terminal
+ * reset) *before* being emitted here, so this stream doubles as a
+ * side-channel for observing commit health without erroring the document
+ * event streams.
+ */
+type CommitAttemptResult =
+  | {
+      type: 'success'
+      result: (MultipleActionResult | MutationResult) & {_perfTimings?: PerfTimings}
+    }
+  | {type: 'failure'; error: unknown}
+  | {type: 'cancel'; error: unknown}
+
 function submitCommitRequest(
   client: SanityClient,
   idPair: IdPair,
   request: CommitRequest,
-): Observable<MultipleActionResult | MutationResult> {
+): Observable<CommitAttemptResult> {
   return from(commitActions(client, idPair, request.mutation.params)).pipe(
     tap({
       next: () => request.success(),
     }),
+    map((result): CommitAttemptResult => ({type: 'success', result})),
     // A failed commit is reported to the mutator via `request.cancel` /
     // `request.failure` (which rejects the corresponding commit promise so
     // the buffered document can retry/rebase on reconnect). After that, we
@@ -259,8 +298,8 @@ function submitCommitRequest(
     // `commits$` → `combinedEvents` → the document `events` stream, and an
     // errored events stream is rethrown by `useObservable` (react-rx) when
     // `useEditState` reads it during render, crashing the document pane.
-    // Complete instead — the failure has already been routed through its
-    // proper channel.
+    // Emit the attempt result as a value instead — the failure has already
+    // been routed through its proper channel.
     catchError((error) => {
       // A known-terminal client error cancels: the buffered mutations can't
       // succeed by retrying, so the commit is rejected and the buffer reset
@@ -283,10 +322,10 @@ function submitCommitRequest(
         !isInvalidSessionError(error)
       ) {
         request.cancel(error)
-      } else {
-        request.failure(error)
+        return of<CommitAttemptResult>({type: 'cancel', error})
       }
-      return EMPTY
+      request.failure(error)
+      return of<CommitAttemptResult>({type: 'failure', error})
     }),
   )
 }
@@ -378,31 +417,86 @@ export function checkoutPair(
     version ? version.commitRequest$ : EMPTY,
   ).pipe(share())
 
-  const commits$ = commitRequests$.pipe(
+  const commitAttemptResults$ = commitRequests$.pipe(
     mergeMap((commitRequest) => {
       const apiRequestSentAt = Date.now()
       return submitCommitRequest(client, idPair, commitRequest).pipe(
-        map((result) => ({
-          ...result,
-          _perfTimings: {
-            firstMutationReceivedAt: commitRequest.firstMutationReceivedAt,
-            apiRequestSentAt,
-            apiResponseReceivedAt: Date.now(),
-          },
-        })),
+        map(
+          (attemptResult): CommitAttemptResult =>
+            attemptResult.type === 'success'
+              ? {
+                  ...attemptResult,
+                  result: {
+                    ...attemptResult.result,
+                    _perfTimings: {
+                      firstMutationReceivedAt: commitRequest.firstMutationReceivedAt,
+                      apiRequestSentAt,
+                      apiResponseReceivedAt: Date.now(),
+                    },
+                  },
+                }
+              : attemptResult,
+        ),
       )
     }),
     share(),
   )
+
+  // The successful commits — failures/cancels have already been routed to the
+  // mutator and must not reach the document event streams (see
+  // `submitCommitRequest`).
+  const commits$ = commitAttemptResults$.pipe(
+    filter(
+      (attemptResult): attemptResult is Extract<CommitAttemptResult, {type: 'success'}> =>
+        attemptResult.type === 'success',
+    ),
+    map((attemptResult) => attemptResult.result),
+    share(),
+  )
+
+  // Whether every buffered document in the pair is free of pending local
+  // mutations — the pair-level version of the per-document `consistency$`.
+  const consistent$ = combineLatest([
+    draft.consistency$,
+    published.consistency$,
+    version ? version.consistency$ : of(true),
+  ]).pipe(
+    map((states) => states.every(Boolean)),
+    distinctUntilChanged(),
+  )
+
+  // The error from the most recent commit attempt while the mutator is
+  // retrying it on backoff, `undefined` while commits are healthy. Multicast
+  // with replay so late subscribers (the sync-state hook mounts after the
+  // pair is checked out) see the current value, not just future attempt
+  // results — the silenced merge into `combinedEvents` below keeps it
+  // recording for the pair's lifetime.
+  const commitError$ = merge(
+    commitAttemptResults$.pipe(
+      map((attemptResult): CommitError | undefined =>
+        attemptResult.type === 'failure' ? {error: attemptResult.error} : undefined,
+      ),
+    ),
+    // Returning to consistency means the buffered edits the failure was
+    // about are gone — drained, discarded, or reset to server HEAD by a
+    // fresh snapshot — so nothing is being retried anymore. Note this is
+    // deliberately NOT keyed on listener reconnects (welcome/welcome-back):
+    // a live listener says nothing about commit health, and a reconnect
+    // while still unsynced must not mask an ongoing failure.
+    consistent$.pipe(
+      filter((isConsistent) => isConsistent),
+      map(() => undefined),
+    ),
+  ).pipe(startWith(undefined), distinctUntilChanged(), shareReplay({bufferSize: 1, refCount: true}))
 
   const pendingEnd$ = transactionsPendingEvents$.pipe(filter((ev) => ev.phase === 'end'))
   const commitResolved$ = merge(pendingEnd$, commits$)
 
   // Each new commit request restarts the timer via switchMap.
   // The timer is cancelled when the commit succeeds or pending mutations resolve.
-  // Note: a *failed* commit no longer emits on `commits$` (it completes via
-  // `catchError` in `submitCommitRequest`), so `commitResolved$` does not fire
-  // for it — a commit that fails after SLOW_COMMIT_TIMEOUT_MS still triggers
+  // Note: a *failed* commit does not emit on `commits$` (failures are filtered
+  // out of `commitAttemptResults$` above), so `commitResolved$` does not fire for
+  // it — a commit that fails after SLOW_COMMIT_TIMEOUT_MS still triggers
   // `onSlowCommit`. That's intentional: it was slow, and it's now failing.
   const slowCommitWarning$ = onSlowCommit
     ? commitRequests$.pipe(
@@ -441,6 +535,7 @@ export function checkoutPair(
         : merge(commits$, listenerEvents$),
       slowCommitWarning$,
       rebaseEvents$,
+      commitError$,
     ),
   ).pipe(
     mergeMap(() => EMPTY),
@@ -449,6 +544,7 @@ export function checkoutPair(
 
   return {
     transactionsPendingEvents$,
+    commitError$,
     draft: {
       ...draft,
       events: merge(combinedEvents, connectionChangeEvents$, draft.events).pipe(

--- a/packages/sanity/src/core/store/document/document-pair/commitErrorStatus.ts
+++ b/packages/sanity/src/core/store/document/document-pair/commitErrorStatus.ts
@@ -1,0 +1,36 @@
+import {type SanityClient} from '@sanity/client'
+import {type Observable} from 'rxjs'
+import {distinctUntilChanged, shareReplay, switchMap} from 'rxjs/operators'
+
+import {type DocumentStoreExtraOptions} from '../getPairListener'
+import {type IdPair} from '../types'
+import {memoize} from '../utils/createMemoizer'
+import {type CommitError} from './checkoutPair'
+import {memoizedPair} from './memoizedPair'
+import {memoizeKeyGen} from './memoizeKeyGen'
+
+// The error from the most recent commit attempt for the document pair while
+// it failed and is being retried by the mutator, or `undefined` while
+// commits are healthy. Combined with consistency and connection state to
+// distinguish "commits are failing" from "the backlog is merely slow" — see
+// `useDocumentSyncState`.
+export const commitErrorStatus: (
+  client: SanityClient,
+  idPair: IdPair,
+  typeName: string,
+  extraOptions?: DocumentStoreExtraOptions,
+) => Observable<CommitError | undefined> = memoize(
+  (
+    client: SanityClient,
+    idPair: IdPair,
+    typeName: string,
+    extraOptions?: DocumentStoreExtraOptions,
+  ) => {
+    return memoizedPair(client, idPair, typeName, extraOptions).pipe(
+      switchMap((pair) => pair.commitError$),
+      distinctUntilChanged(),
+      shareReplay({bufferSize: 1, refCount: true}),
+    )
+  },
+  memoizeKeyGen,
+)

--- a/packages/sanity/src/core/store/document/document-store.ts
+++ b/packages/sanity/src/core/store/document/document-store.ts
@@ -18,7 +18,13 @@ import {
 } from '../../util'
 import {type ValidationStatus} from '../../validation'
 import {type HistoryStore} from '../history'
-import {checkoutPair, type DocumentVersionEvent, type Pair} from './document-pair/checkoutPair'
+import {
+  checkoutPair,
+  type CommitError,
+  type DocumentVersionEvent,
+  type Pair,
+} from './document-pair/checkoutPair'
+import {commitErrorStatus} from './document-pair/commitErrorStatus'
 import {consistencyStatus} from './document-pair/consistencyStatus'
 import {documentEvents} from './document-pair/documentEvents'
 import {editOperations} from './document-pair/editOperations'
@@ -79,6 +85,12 @@ export interface DocumentStore {
   resolveTypeForDocument: (id: string, specifiedType?: string) => Observable<string>
 
   pair: {
+    /** @internal */
+    commitErrorStatus: (
+      publishedId: string,
+      type: string,
+      version?: string,
+    ) => Observable<CommitError | undefined>
     consistencyStatus: (publishedId: string, type: string, version?: string) => Observable<boolean>
     /** @internal */
     documentEvents: (
@@ -190,6 +202,14 @@ export function createDocumentStore({
       return resolveTypeForDocument(client, id, specifiedType)
     },
     pair: {
+      commitErrorStatus(publishedId, type, version) {
+        return commitErrorStatus(
+          ctx.client,
+          getIdPairFromPublished(publishedId, version),
+          type,
+          extraOptions,
+        )
+      },
       consistencyStatus(publishedId, type, version) {
         return consistencyStatus(
           ctx.client,

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -99,7 +99,8 @@ export const FormView = forwardRef<HTMLFormElement, FormViewProps>(function Form
   // Staged "changes aren't syncing" toast. Three non-synced states:
   //  - pending:    unsynced + disconnected, warning (editing still open)
   //  - stalled:    unsynced + disconnected for longer, editing locked
-  //  - recovering: connection back, flushing the backlog (still locked,
+  //  - recovering: connected but a commit failed and is being retried, e.g.
+  //                flushing the backlog after a reconnect (still locked,
   //                but reassure rather than alarm)
   // One toast id so the states replace each other rather than stack, and
   // it auto-dismisses when the document syncs again.


### PR DESCRIPTION
### Description
The "Saving your changes…" toast (and editor readOnly) currently happens when the backlog of commits stays non-empty for a prolonged time. This could cause a slow-but-healthy backlog of commits to put the form into readOnly state.

This PR makes it so that the toast is instead activated by commits failing and being retried. This is implemented by giving `checkoutPair` a new `commitError$` stream which includes the last failure's error. This is cleared on success/cancel or when the document pair returns to a consistent state.

### What to review


### Testing
Unit tests included

### Notes for release

Fixes an issue that could sometimes set the document editor to read only while waiting for changes to be saved on slow connections

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches document editing lock/read-only and sync UX in the core commit pipeline; behavior is heavily tested but mistakes could hide real outages or leave the editor editable when saves are failing.
> 
> **Overview**
> Fixes false **read-only** and “Saving your changes…” sync UI when the commit backlog is merely slow but commits are still succeeding (e.g. sustained typing on a saturated pipeline).
> 
> **`checkoutPair`** now exposes **`commitError$`**: the last error while a commit is being **retried** (not terminal cancels). Commit attempts are modeled as success/failure/cancel values so failures don’t error the document `events` stream. The signal clears on successful commit, terminal cancel, or when the pair is **consistent** again — and is **not** cleared just because the realtime listener reconnects.
> 
> **`useDocumentSyncState`** combines consistency, connection, and commit failure. While **connected** and unsynced, it stays **`synced`** unless a commit actually failed; **`recovering`** (and the existing lock via `stalled`/`recovering`) only applies when retries are in flight, with debounce so transient failures don’t flash the toast. **Disconnected** behavior is unchanged: pending → stalled without needing commit-failure evidence.
> 
> Wiring: `documentStore.pair.commitErrorStatus`, expanded unit tests for the state machine and `commitError$`, and small comment tweaks in the form layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c04376891b9c1cb4ce9581047d3533833f76747. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->