### PR TITLE
feat(releases): add bundle column to release detail document table

### DIFF
--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -442,6 +442,8 @@ const releasesLocaleStrings = defineLocalesResources('releases', {
   'table-header.title': 'Release',
   /** Header for the document table in the release tool - type */
   'table-header.type': 'Type',
+  /** Header for the document table in the release tool - bundle */
+  'table-header.bundle': 'Bundle',
   /** Header for the document table in the release tool - action */
   'table-header.action': 'Action',
 

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -444,6 +444,8 @@ const releasesLocaleStrings = defineLocalesResources('releases', {
   'table-header.type': 'Type',
   /** Header for the document table in the release tool - bundle */
   'table-header.bundle': 'Bundle',
+  /** Default bundle label for non-variant documents in the release detail table */
+  'table-cell.bundle.default': 'Default',
   /** Header for the document table in the release tool - action */
   'table-header.action': 'Action',
 

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -6,9 +6,11 @@ import {type CSSProperties, useCallback, useEffect, useMemo, useState} from 'rea
 
 import {Button} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
+import {useWorkspace} from '../../../studio/workspace'
 import {getVersionId} from '../../../util/draftUtils'
 import {getDocumentVariantType} from '../../../util/getDocumentVariantType'
 import {isCardinalityOneRelease} from '../../../util/releaseUtils'
+import {useAllVariants} from '../../../variants/store/useAllVariants'
 import {AddedVersion} from '../../__telemetry__/releases.telemetry'
 import {releasesLocaleNamespace} from '../../i18n'
 import {useReleaseOperations} from '../../store/useReleaseOperations'
@@ -65,6 +67,9 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
   const [activeFilter, setActiveFilter] = useState<DocumentFilterType>('all')
 
   const {t} = useTranslation(releasesLocaleNamespace)
+  const {beta} = useWorkspace()
+  const variantsEnabled = Boolean(beta?.variants?.enabled)
+  const {byId: variantsById} = useAllVariants()
 
   const releaseId = getReleaseIdFromReleaseDocumentId(release._id)
 
@@ -80,8 +85,8 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
   )
 
   const documentTableColumnDefs = useMemo(
-    () => getDocumentTableColumnDefs(release._id, release.state, t),
-    [release._id, release.state, t],
+    () => getDocumentTableColumnDefs(release._id, release.state, t, variantsEnabled, variantsById),
+    [release._id, release.state, t, variantsEnabled, variantsById],
   )
 
   const handleAddDocumentClick = useCallback(() => setAddDocumentDialog(true), [])

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -15,6 +15,7 @@ import {RelativeTime} from '../../../../components/RelativeTime'
 import {useSchema} from '../../../../hooks'
 import {SanityDefaultPreview} from '../../../../preview/components/SanityDefaultPreview'
 import {getVariantIdFromDocument} from '../../../../variants/tool/util'
+import {type SystemVariant} from '../../../../variants/types'
 import {getReleaseIdFromReleaseDocumentId} from '../../../util/getReleaseIdFromReleaseDocumentId'
 import {isGoingToUnpublish} from '../../../util/isGoingToUnpublish'
 import {getReleaseDocumentIntent} from '../../components/getReleaseDocumentIntent'
@@ -24,6 +25,8 @@ import {type Column, type InjectedTableProps} from '../../components/Table/types
 import {getDocumentActionType, getReleaseDocumentActionConfig} from '../releaseDocumentActions'
 import {type BundleDocumentRow} from '../ReleaseSummary'
 import {type DocumentInRelease} from '../types'
+import {getVariantBundleSortKey} from './getVariantBundleSortKey'
+import {ReleaseVariantBundleChip} from './ReleaseVariantBundleChip'
 import {useReleaseHistory} from './useReleaseHistory'
 
 const MemoReleaseDocumentPreview = memo(
@@ -129,6 +132,33 @@ export function DocumentType({type}: {type: string}) {
 
 const MemoDocumentType = memo(DocumentType, (prev, next) => prev.type === next.type)
 
+const bundleColumn: (
+  t: TFunction<'releases'>,
+  variantsById: Map<string, SystemVariant>,
+) => Column<BundleDocumentRow> = (t, variantsById) => ({
+  id: 'bundle',
+  width: 140,
+  style: {minWidth: 100, maxWidth: 140},
+  sorting: true,
+  sortTransform: (row) => getVariantBundleSortKey(row, variantsById),
+  header: (props) => (
+    <Flex {...props.headerProps} paddingY={3} sizing="border">
+      <Headers.SortHeaderButton text={t('table-header.bundle')} {...props} />
+    </Flex>
+  ),
+  cell: ({cellProps, datum}) => (
+    <Flex
+      align="center"
+      {...cellProps}
+      style={{...cellProps.style, flex: '0 1 auto', minWidth: 0, overflow: 'hidden'}}
+    >
+      <Box flex={1} paddingX={2} style={{minWidth: 0, overflow: 'hidden'}}>
+        {!datum.isLoading && <ReleaseVariantBundleChip document={datum.document} />}
+      </Box>
+    </Flex>
+  ),
+})
+
 const documentActionColumn: (t: TFunction<'releases'>) => Column<BundleDocumentRow> = (t) => ({
   id: 'action',
   width: null,
@@ -169,7 +199,9 @@ export const getDocumentTableColumnDefs: (
   releaseId: string,
   releaseState: ReleaseState,
   t: TFunction<'releases'>,
-) => Column<BundleDocumentRow>[] = (releaseId, releaseState, t) => [
+  variantsEnabled: boolean,
+  variantsById: Map<string, SystemVariant>,
+) => Column<BundleDocumentRow>[] = (releaseId, releaseState, t, variantsEnabled, variantsById) => [
   /**
    * Hiding action for archived and published releases of v1.0
    * This will be added once Events API has reverse order lookup supported
@@ -194,6 +226,7 @@ export const getDocumentTableColumnDefs: (
       </Flex>
     ),
   },
+  ...(variantsEnabled ? [bundleColumn(t, variantsById)] : []),
   {
     id: 'search',
     width: null,

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/ReleaseVariantBundleChip.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/ReleaseVariantBundleChip.tsx
@@ -1,10 +1,12 @@
-import {Box} from '@sanity/ui'
+import {Box, Text} from '@sanity/ui'
 import {IntentLink} from 'sanity/router'
 
+import {useTranslation} from '../../../../i18n'
 import {VARIANTS_INTENT} from '../../../../variants/plugin'
 import {useAllVariants} from '../../../../variants/store/useAllVariants'
 import {getVariantId, getVariantTitle} from '../../../../variants/tool/util'
 import {Chip} from '../../../components/Chip'
+import {releasesLocaleNamespace} from '../../../i18n'
 import {type BundleDocument} from '../useBundleDocuments'
 import {getVariantDefinitionRef} from './getVariantBundleSortKey'
 
@@ -20,11 +22,24 @@ export function ReleaseVariantBundleChip({
   document,
 }: {
   document: BundleDocument['document']
-}): React.JSX.Element | null {
+}): React.JSX.Element {
+  const {t} = useTranslation(releasesLocaleNamespace)
   const {byId: variantsById} = useAllVariants()
   const variantRef = getVariantDefinitionRef(document)
 
-  if (!variantRef) return null
+  if (!variantRef) {
+    return (
+      <Box
+        data-testid={`release-variant-bundle-default-${document._id}`}
+        paddingX={2}
+        style={{minWidth: 0}}
+      >
+        <Text muted size={1}>
+          {t('table-cell.bundle.default')}
+        </Text>
+      </Box>
+    )
+  }
 
   const label = getVariantBundleLabel(variantRef, variantsById)
 

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/ReleaseVariantBundleChip.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/ReleaseVariantBundleChip.tsx
@@ -1,0 +1,42 @@
+import {type SanityDocument} from '@sanity/client'
+import {Box} from '@sanity/ui'
+import {IntentLink} from 'sanity/router'
+
+import {VARIANTS_INTENT} from '../../../../variants/plugin'
+import {useAllVariants} from '../../../../variants/store/useAllVariants'
+import {getVariantId, getVariantTitle} from '../../../../variants/tool/util'
+import {Chip} from '../../../components/Chip'
+import {getVariantDefinitionRef} from './getVariantBundleSortKey'
+
+function getVariantBundleLabel(
+  variantRef: string,
+  variantsById: ReturnType<typeof useAllVariants>['byId'],
+): string {
+  const variant = variantsById.get(variantRef)
+  return variant ? getVariantTitle(variant) : getVariantId(variantRef)
+}
+
+export function ReleaseVariantBundleChip({
+  document,
+}: {
+  document: SanityDocument
+}): React.JSX.Element | null {
+  const {byId: variantsById} = useAllVariants()
+  const variantRef = getVariantDefinitionRef(document)
+
+  if (!variantRef) return null
+
+  const label = getVariantBundleLabel(variantRef, variantsById)
+
+  return (
+    <Box style={{minWidth: 0, overflow: 'hidden'}}>
+      <IntentLink intent={VARIANTS_INTENT} params={{id: getVariantId(variantRef)}}>
+        <Chip
+          data-testid={`release-variant-bundle-chip-${document._id}`}
+          mode="bleed"
+          text={label}
+        />
+      </IntentLink>
+    </Box>
+  )
+}

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/ReleaseVariantBundleChip.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/ReleaseVariantBundleChip.tsx
@@ -1,4 +1,3 @@
-import {type SanityDocument} from '@sanity/client'
 import {Box} from '@sanity/ui'
 import {IntentLink} from 'sanity/router'
 
@@ -6,6 +5,7 @@ import {VARIANTS_INTENT} from '../../../../variants/plugin'
 import {useAllVariants} from '../../../../variants/store/useAllVariants'
 import {getVariantId, getVariantTitle} from '../../../../variants/tool/util'
 import {Chip} from '../../../components/Chip'
+import {type BundleDocument} from '../useBundleDocuments'
 import {getVariantDefinitionRef} from './getVariantBundleSortKey'
 
 function getVariantBundleLabel(
@@ -19,7 +19,7 @@ function getVariantBundleLabel(
 export function ReleaseVariantBundleChip({
   document,
 }: {
-  document: SanityDocument
+  document: BundleDocument['document']
 }): React.JSX.Element | null {
   const {byId: variantsById} = useAllVariants()
   const variantRef = getVariantDefinitionRef(document)

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/ReleaseVariantBundleChip.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/ReleaseVariantBundleChip.test.tsx
@@ -1,9 +1,10 @@
-import {render, screen} from '@testing-library/react'
+import {render, screen, waitFor} from '@testing-library/react'
 import {describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
 import {DOCUMENT_SYSTEM_FIELD} from '../../../../../preview/constants'
 import {variantAlphaAudience} from '../../../../../variants/__fixtures__/variants.fixture'
+import {releasesUsEnglishLocaleBundle} from '../../../../i18n'
 import {ReleaseVariantBundleChip} from '../ReleaseVariantBundleChip'
 
 const useAllVariantsMock = vi.fn()
@@ -29,9 +30,9 @@ vi.mock('sanity/router', async (importOriginal) => ({
 const groupRef = {_type: 'reference' as const, _ref: 'article-1', _weak: true as const}
 
 describe('ReleaseVariantBundleChip', () => {
-  it('renders nothing when the document has no variant ref', async () => {
+  it('renders muted Default text when the document has no variant ref', async () => {
     useAllVariantsMock.mockReturnValue({byId: new Map()})
-    const wrapper = await createTestProvider()
+    const wrapper = await createTestProvider({resources: [releasesUsEnglishLocaleBundle]})
 
     render(
       <ReleaseVariantBundleChip
@@ -41,14 +42,18 @@ describe('ReleaseVariantBundleChip', () => {
           _rev: 'rev-1',
           _createdAt: '2025-01-01T00:00:00Z',
           _updatedAt: '2025-01-01T00:00:00Z',
+          publishedDocumentExists: true,
         }}
       />,
       {wrapper},
     )
 
-    expect(
-      screen.queryByTestId('release-variant-bundle-chip-versions.rASAP.article-1'),
-    ).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('release-variant-bundle-default-versions.rASAP.article-1'),
+      ).toHaveTextContent('Default')
+    })
+    expect(screen.queryByTestId('variant-intent-link')).not.toBeInTheDocument()
   })
 
   it('renders a chip with the variant title and links to the variant detail page', async () => {

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/ReleaseVariantBundleChip.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/ReleaseVariantBundleChip.test.tsx
@@ -1,0 +1,118 @@
+import {render, screen} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {DOCUMENT_SYSTEM_FIELD} from '../../../../../preview/constants'
+import {variantAlphaAudience} from '../../../../../variants/__fixtures__/variants.fixture'
+import {ReleaseVariantBundleChip} from '../ReleaseVariantBundleChip'
+
+const useAllVariantsMock = vi.fn()
+
+vi.mock('../../../../../variants/store/useAllVariants', () => ({
+  useAllVariants: () => useAllVariantsMock(),
+}))
+
+vi.mock('sanity/router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  IntentLink: vi.fn(({children, intent, params, ...props}) => (
+    <a
+      data-testid="variant-intent-link"
+      data-intent={intent}
+      data-params={JSON.stringify(params)}
+      {...props}
+    >
+      {children}
+    </a>
+  )),
+}))
+
+const groupRef = {_type: 'reference' as const, _ref: 'article-1', _weak: true as const}
+
+describe('ReleaseVariantBundleChip', () => {
+  it('renders nothing when the document has no variant ref', async () => {
+    useAllVariantsMock.mockReturnValue({byId: new Map()})
+    const wrapper = await createTestProvider()
+
+    render(
+      <ReleaseVariantBundleChip
+        document={{
+          _id: 'versions.rASAP.article-1',
+          _type: 'article',
+          _rev: 'rev-1',
+          _createdAt: '2025-01-01T00:00:00Z',
+          _updatedAt: '2025-01-01T00:00:00Z',
+        }}
+      />,
+      {wrapper},
+    )
+
+    expect(
+      screen.queryByTestId('release-variant-bundle-chip-versions.rASAP.article-1'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders a chip with the variant title and links to the variant detail page', async () => {
+    useAllVariantsMock.mockReturnValue({
+      byId: new Map([[variantAlphaAudience._id, variantAlphaAudience]]),
+    })
+    const wrapper = await createTestProvider()
+
+    render(
+      <ReleaseVariantBundleChip
+        document={{
+          _id: 'versions.rASAP.scope.article-1',
+          _type: 'article',
+          _rev: 'rev-1',
+          _createdAt: '2025-01-01T00:00:00Z',
+          _updatedAt: '2025-01-01T00:00:00Z',
+          [DOCUMENT_SYSTEM_FIELD]: {
+            bundleId: 'rASAP',
+            release: {_ref: '_.releases.rASAP', _weak: true},
+            variant: {_ref: variantAlphaAudience._id, _weak: true},
+            group: groupRef,
+            scopeId: 'scope',
+          },
+        }}
+      />,
+      {wrapper},
+    )
+
+    expect(
+      screen.getByTestId('release-variant-bundle-chip-versions.rASAP.scope.article-1'),
+    ).toHaveTextContent('Alpha audience')
+    expect(screen.getByTestId('variant-intent-link')).toHaveAttribute('data-intent', 'variant')
+    expect(screen.getByTestId('variant-intent-link')).toHaveAttribute(
+      'data-params',
+      JSON.stringify({id: 'alpha-audience'}),
+    )
+  })
+
+  it('falls back to the short variant id when the definition is missing', async () => {
+    useAllVariantsMock.mockReturnValue({byId: new Map()})
+    const wrapper = await createTestProvider()
+
+    render(
+      <ReleaseVariantBundleChip
+        document={{
+          _id: 'versions.rASAP.scope.article-1',
+          _type: 'article',
+          _rev: 'rev-1',
+          _createdAt: '2025-01-01T00:00:00Z',
+          _updatedAt: '2025-01-01T00:00:00Z',
+          [DOCUMENT_SYSTEM_FIELD]: {
+            bundleId: 'rASAP',
+            release: {_ref: '_.releases.rASAP', _weak: true},
+            variant: {_ref: '_.variants.missing-variant', _weak: true},
+            group: groupRef,
+            scopeId: 'scope',
+          },
+        }}
+      />,
+      {wrapper},
+    )
+
+    expect(
+      screen.getByTestId('release-variant-bundle-chip-versions.rASAP.scope.article-1'),
+    ).toHaveTextContent('missing-variant')
+  })
+})

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/getDocumentTableColumnDefs.test.ts
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/getDocumentTableColumnDefs.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it, vi} from 'vitest'
+
+import {variantAlphaAudience} from '../../../../../variants/__fixtures__/variants.fixture'
+import {getDocumentTableColumnDefs} from '../DocumentTableColumnDefs'
+
+const t = ((key: string) => key) as Parameters<typeof getDocumentTableColumnDefs>[2]
+
+const variantsById = new Map([[variantAlphaAudience._id, variantAlphaAudience]])
+
+describe('getDocumentTableColumnDefs', () => {
+  it('omits the bundle column when variants are disabled', () => {
+    const columns = getDocumentTableColumnDefs('_.releases.rASAP', 'active', t, false, variantsById)
+    const columnIds = columns.map((column) => column.id)
+
+    expect(columnIds).not.toContain('bundle')
+    expect(columnIds.indexOf('document._type')).toBeLessThan(columnIds.indexOf('search'))
+  })
+
+  it('includes the bundle column after type when variants are enabled', () => {
+    const columns = getDocumentTableColumnDefs('_.releases.rASAP', 'active', t, true, variantsById)
+    const columnIds = columns.map((column) => column.id)
+
+    expect(columnIds).toContain('bundle')
+    expect(columnIds.indexOf('bundle')).toBe(columnIds.indexOf('document._type') + 1)
+
+    const bundleColumn = columns.find((column) => column.id === 'bundle')
+    expect(bundleColumn).toMatchObject({
+      sorting: true,
+      width: 140,
+    })
+    expect(
+      bundleColumn && 'sortTransform' in bundleColumn && bundleColumn.sortTransform,
+    ).toBeTypeOf('function')
+  })
+})

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/getVariantBundleSortKey.test.ts
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/getVariantBundleSortKey.test.ts
@@ -5,12 +5,12 @@ import {
   variantAlphaAudience,
   variantNorwegianMarket,
 } from '../../../../../variants/__fixtures__/variants.fixture'
+import {type BundleDocument} from '../../useBundleDocuments'
 import {getVariantBundleSortKey, getVariantDefinitionRef} from '../getVariantBundleSortKey'
-import {type BundleDocumentRow} from '../ReleaseSummary'
 
 const groupRef = {_type: 'reference' as const, _ref: 'article-1', _weak: true as const}
 
-function createRow(document: BundleDocumentRow['document']): BundleDocumentRow {
+function createRow(document: BundleDocument['document']): BundleDocument {
   return {
     memoKey: document._id,
     document,

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/getVariantBundleSortKey.test.ts
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/getVariantBundleSortKey.test.ts
@@ -69,7 +69,7 @@ describe('getVariantDefinitionRef', () => {
 })
 
 describe('getVariantBundleSortKey', () => {
-  it('returns an empty string for documents without a variant ref', () => {
+  it('returns "default" for documents without a variant ref', () => {
     const row = createRow({
       _id: 'versions.rASAP.article-1',
       _type: 'article',
@@ -79,7 +79,7 @@ describe('getVariantBundleSortKey', () => {
       publishedDocumentExists: true,
     })
 
-    expect(getVariantBundleSortKey(row, variantsById)).toBe('')
+    expect(getVariantBundleSortKey(row, variantsById)).toBe('default')
   })
 
   it('returns the lowercase variant title when the definition exists', () => {
@@ -169,8 +169,8 @@ describe('getVariantBundleSortKey', () => {
     )
 
     expect(sorted.map((row) => row.document._id)).toEqual([
-      'versions.rASAP.article-3',
       'versions.rASAP.scope.article-1',
+      'versions.rASAP.article-3',
       'versions.rASAP.scope.article-2',
     ])
   })

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/getVariantBundleSortKey.test.ts
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/getVariantBundleSortKey.test.ts
@@ -1,0 +1,177 @@
+import {describe, expect, it} from 'vitest'
+
+import {DOCUMENT_SYSTEM_FIELD} from '../../../../../preview/constants'
+import {
+  variantAlphaAudience,
+  variantNorwegianMarket,
+} from '../../../../../variants/__fixtures__/variants.fixture'
+import {getVariantBundleSortKey, getVariantDefinitionRef} from '../getVariantBundleSortKey'
+import {type BundleDocumentRow} from '../ReleaseSummary'
+
+const groupRef = {_type: 'reference' as const, _ref: 'article-1', _weak: true as const}
+
+function createRow(document: BundleDocumentRow['document']): BundleDocumentRow {
+  return {
+    memoKey: document._id,
+    document,
+    validation: {
+      hasError: false,
+      isValidating: false,
+      validation: [],
+    },
+  }
+}
+
+const variantsById = new Map([
+  [variantAlphaAudience._id, variantAlphaAudience],
+  [variantNorwegianMarket._id, variantNorwegianMarket],
+])
+
+describe('getVariantDefinitionRef', () => {
+  it('returns the variant definition ref when present on the document', () => {
+    const document = {
+      _id: 'versions.rASAP.scope.article-1',
+      _type: 'article',
+      _rev: 'rev-1',
+      _createdAt: '2025-01-01T00:00:00Z',
+      _updatedAt: '2025-01-01T00:00:00Z',
+      publishedDocumentExists: true,
+      [DOCUMENT_SYSTEM_FIELD]: {
+        bundleId: 'rASAP',
+        release: {_ref: '_.releases.rASAP', _weak: true},
+        variant: {_ref: variantAlphaAudience._id, _weak: true},
+        group: groupRef,
+        scopeId: 'scope',
+      },
+    }
+
+    expect(getVariantDefinitionRef(document)).toBe(variantAlphaAudience._id)
+  })
+
+  it('returns undefined when the document has no variant ref', () => {
+    const document = {
+      _id: 'versions.rASAP.article-1',
+      _type: 'article',
+      _rev: 'rev-1',
+      _createdAt: '2025-01-01T00:00:00Z',
+      _updatedAt: '2025-01-01T00:00:00Z',
+      publishedDocumentExists: true,
+      [DOCUMENT_SYSTEM_FIELD]: {
+        bundleId: 'rASAP',
+        release: {_ref: '_.releases.rASAP', _weak: true},
+        group: groupRef,
+        scopeId: null,
+      },
+    }
+
+    expect(getVariantDefinitionRef(document)).toBeUndefined()
+  })
+})
+
+describe('getVariantBundleSortKey', () => {
+  it('returns an empty string for documents without a variant ref', () => {
+    const row = createRow({
+      _id: 'versions.rASAP.article-1',
+      _type: 'article',
+      _rev: 'rev-1',
+      _createdAt: '2025-01-01T00:00:00Z',
+      _updatedAt: '2025-01-01T00:00:00Z',
+      publishedDocumentExists: true,
+    })
+
+    expect(getVariantBundleSortKey(row, variantsById)).toBe('')
+  })
+
+  it('returns the lowercase variant title when the definition exists', () => {
+    const row = createRow({
+      _id: 'versions.rASAP.scope.article-1',
+      _type: 'article',
+      _rev: 'rev-1',
+      _createdAt: '2025-01-01T00:00:00Z',
+      _updatedAt: '2025-01-01T00:00:00Z',
+      publishedDocumentExists: true,
+      [DOCUMENT_SYSTEM_FIELD]: {
+        bundleId: 'rASAP',
+        release: {_ref: '_.releases.rASAP', _weak: true},
+        variant: {_ref: variantAlphaAudience._id, _weak: true},
+        group: groupRef,
+        scopeId: 'scope',
+      },
+    })
+
+    expect(getVariantBundleSortKey(row, variantsById)).toBe('alpha audience')
+  })
+
+  it('falls back to the short variant id when the definition is missing', () => {
+    const row = createRow({
+      _id: 'versions.rASAP.scope.article-1',
+      _type: 'article',
+      _rev: 'rev-1',
+      _createdAt: '2025-01-01T00:00:00Z',
+      _updatedAt: '2025-01-01T00:00:00Z',
+      publishedDocumentExists: true,
+      [DOCUMENT_SYSTEM_FIELD]: {
+        bundleId: 'rASAP',
+        release: {_ref: '_.releases.rASAP', _weak: true},
+        variant: {_ref: '_.variants.missing-variant', _weak: true},
+        group: groupRef,
+        scopeId: 'scope',
+      },
+    })
+
+    expect(getVariantBundleSortKey(row, variantsById)).toBe('missing-variant')
+  })
+
+  it('sorts rows by variant title in alphabetical order', () => {
+    const alphaRow = createRow({
+      _id: 'versions.rASAP.scope.article-1',
+      _type: 'article',
+      _rev: 'rev-1',
+      _createdAt: '2025-01-01T00:00:00Z',
+      _updatedAt: '2025-01-01T00:00:00Z',
+      publishedDocumentExists: true,
+      [DOCUMENT_SYSTEM_FIELD]: {
+        bundleId: 'rASAP',
+        release: {_ref: '_.releases.rASAP', _weak: true},
+        variant: {_ref: variantAlphaAudience._id, _weak: true},
+        group: groupRef,
+        scopeId: 'scope',
+      },
+    })
+    const norwegianRow = createRow({
+      _id: 'versions.rASAP.scope.article-2',
+      _type: 'article',
+      _rev: 'rev-2',
+      _createdAt: '2025-01-01T00:00:00Z',
+      _updatedAt: '2025-01-01T00:00:00Z',
+      publishedDocumentExists: true,
+      [DOCUMENT_SYSTEM_FIELD]: {
+        bundleId: 'rASAP',
+        release: {_ref: '_.releases.rASAP', _weak: true},
+        variant: {_ref: variantNorwegianMarket._id, _weak: true},
+        group: groupRef,
+        scopeId: 'scope',
+      },
+    })
+    const defaultRow = createRow({
+      _id: 'versions.rASAP.article-3',
+      _type: 'article',
+      _rev: 'rev-3',
+      _createdAt: '2025-01-01T00:00:00Z',
+      _updatedAt: '2025-01-01T00:00:00Z',
+      publishedDocumentExists: true,
+    })
+
+    const sorted = [norwegianRow, defaultRow, alphaRow].toSorted((left, right) =>
+      getVariantBundleSortKey(left, variantsById).localeCompare(
+        getVariantBundleSortKey(right, variantsById),
+      ),
+    )
+
+    expect(sorted.map((row) => row.document._id)).toEqual([
+      'versions.rASAP.article-3',
+      'versions.rASAP.scope.article-1',
+      'versions.rASAP.scope.article-2',
+    ])
+  })
+})

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/getVariantBundleSortKey.ts
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/getVariantBundleSortKey.ts
@@ -1,0 +1,27 @@
+import {VARIANT_DOCUMENTS_PATH} from '../../../../variants/store/constants'
+import {getVariantId, getVariantIdFromDocument, getVariantTitle} from '../../../../variants/tool/util'
+import {type SystemVariant} from '../../../../variants/types'
+import {type BundleDocument} from '../useBundleDocuments'
+
+/** @internal - exported for unit testing only */
+export function getVariantDefinitionRef(
+  document: BundleDocument['document'],
+): string | undefined {
+  const shortVariantId = getVariantIdFromDocument(document)
+  if (!shortVariantId) return undefined
+
+  return `${VARIANT_DOCUMENTS_PATH}.${shortVariantId}`
+}
+
+/** @internal - exported for unit testing only */
+export function getVariantBundleSortKey(
+  row: BundleDocument,
+  variantsById: Map<string, SystemVariant>,
+): string {
+  const variantRef = getVariantDefinitionRef(row.document)
+  if (!variantRef) return ''
+
+  const variant = variantsById.get(variantRef)
+  const label = variant ? getVariantTitle(variant) : getVariantId(variantRef)
+  return label.toLowerCase()
+}

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/getVariantBundleSortKey.ts
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/getVariantBundleSortKey.ts
@@ -7,6 +7,9 @@ import {
 import {type SystemVariant} from '../../../../variants/types'
 import {type BundleDocument} from '../useBundleDocuments'
 
+/** Sort key for non-variant documents in the bundle column. */
+const DEFAULT_BUNDLE_SORT_KEY = 'default'
+
 /** @internal - exported for unit testing only */
 export function getVariantDefinitionRef(document: BundleDocument['document']): string | undefined {
   const shortVariantId = getVariantIdFromDocument(document)
@@ -21,7 +24,7 @@ export function getVariantBundleSortKey(
   variantsById: Map<string, SystemVariant>,
 ): string {
   const variantRef = getVariantDefinitionRef(row.document)
-  if (!variantRef) return ''
+  if (!variantRef) return DEFAULT_BUNDLE_SORT_KEY
 
   const variant = variantsById.get(variantRef)
   const label = variant ? getVariantTitle(variant) : getVariantId(variantRef)

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/getVariantBundleSortKey.ts
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/getVariantBundleSortKey.ts
@@ -1,12 +1,14 @@
 import {VARIANT_DOCUMENTS_PATH} from '../../../../variants/store/constants'
-import {getVariantId, getVariantIdFromDocument, getVariantTitle} from '../../../../variants/tool/util'
+import {
+  getVariantId,
+  getVariantIdFromDocument,
+  getVariantTitle,
+} from '../../../../variants/tool/util'
 import {type SystemVariant} from '../../../../variants/types'
 import {type BundleDocument} from '../useBundleDocuments'
 
 /** @internal - exported for unit testing only */
-export function getVariantDefinitionRef(
-  document: BundleDocument['document'],
-): string | undefined {
+export function getVariantDefinitionRef(document: BundleDocument['document']): string | undefined {
   const shortVariantId = getVariantIdFromDocument(document)
   if (!shortVariantId) return undefined
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Release detail documents that belong to a variant bundle carry their variant definition on `_system.variant._ref`, but the releases table had no way to see or navigate to that definition. This adds a **Bundle** column (after Type) when `beta.variants.enabled` is on, showing a chip that links to the variant detail page.

Sorting uses a shared `getVariantBundleSortKey` helper so rows order by variant definition title (falling back to the short id when the definition is not loaded).



### What to review

- [`DocumentTableColumnDefs.tsx`](packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx) — conditional column wiring and sort transform
- [`ReleaseVariantBundleChip.tsx`](packages/sanity/src/core/releases/tool/detail/documentTable/ReleaseVariantBundleChip.tsx) — chip + `IntentLink` to variants tool
- [`getVariantBundleSortKey.ts`](packages/sanity/src/core/releases/tool/detail/documentTable/getVariantBundleSortKey.ts) — sort key resolution
- [`ReleaseSummary.tsx`](packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx) — passes `variantsEnabled` and `variantsById`

### Testing

```bash
pnpm vitest run --project=sanity packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/
```

Added unit tests for column gating, chip rendering/navigation, and sort key behavior.

### Notes for release

N/A – Part of feature variants. The Bundle column only appears when `beta.variants.enabled` is true in Studio config.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f1cad82-a4e9-4b23-86c2-e88ff71eafd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f1cad82-a4e9-4b23-86c2-e88ff71eafd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

