### PR TITLE
fix: keep editState + document versions warm across subscription churn

### DIFF
--- a/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
@@ -2,14 +2,19 @@ import {type ReleaseDocument} from '@sanity/client'
 import {getPublishedId} from '@sanity/client/csm'
 import {type DocumentSystem} from '@sanity/types'
 import {renderHook, waitFor} from '@testing-library/react'
-import {NEVER, of} from 'rxjs'
-import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
+import {concat, NEVER, of} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
 import {type DocumentPreviewStore} from '../../../preview'
 import {useDocumentPreviewStore} from '../../../store'
 import {activeASAPRelease, activeScheduledRelease} from '../../__fixtures__/release.fixture'
 import {useActiveReleasesMockReturn} from '../../store/__tests__/__mocks/useActiveReleases.mock'
-import {observableCache, useDocumentVersions} from '../useDocumentVersions'
+import {
+  type DocumentPerspectiveState,
+  getOrCreateDocumentVersionsObservable,
+  observableCache,
+  useDocumentVersions,
+} from '../useDocumentVersions'
 
 vi.mock('../../../hooks/useDataset', () => ({
   useDataset: vi.fn().mockReturnValue('test'),
@@ -186,5 +191,93 @@ describe('useDocumentVersions', () => {
         },
       },
     ])
+  })
+})
+
+/**
+ * Regression tests for the read-only flip: subscriber churn (components
+ * re-rendering/remounting around commits) momentarily drops the shared
+ * pipeline's refcount to zero. With a bare teardown the cache entry is
+ * deleted, and the re-created pipeline synchronously re-enters the
+ * `startWith(loadingState)` path (the version id set is non-empty for any
+ * document with a draft), so `loading: true` reaches `useDocumentForm`'s
+ * `ready` gate and flips the form read-only mid-typing — silently swallowing
+ * keystrokes.
+ */
+describe('getOrCreateDocumentVersionsObservable — subscriber churn', () => {
+  beforeEach(() => {
+    observableCache.clear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function createPreviewStore() {
+    // The production sources never complete (they follow the invalidation
+    // channel), so keep the mocks open-ended — a completing source would
+    // reset the share and mask the behavior under test.
+    const unstable_observeVersionDocumentIds = vi.fn(() => concat(of(['drafts.document-1']), NEVER))
+    const observePaths = vi.fn((value: unknown) =>
+      concat(
+        of({
+          _id: (value as {_id: string})._id,
+          _rev: '',
+          _createdAt: '',
+          _updatedAt: '',
+        }),
+        NEVER,
+      ),
+    )
+    return {
+      unstable_observeVersionDocumentIds,
+      observePaths,
+    } as unknown as DocumentPreviewStore
+  }
+
+  const options = (documentPreviewStore: DocumentPreviewStore) => ({
+    documentPreviewStore,
+    publishedId: 'document-1',
+    projectId: 'test-project',
+    dataset: 'test',
+  })
+
+  it('does not re-emit loading: true to a subscriber arriving right after a zero-subscriber gap', () => {
+    vi.useFakeTimers()
+    const previewStore = createPreviewStore()
+    const state$ = getOrCreateDocumentVersionsObservable(options(previewStore))
+
+    const first: DocumentPerspectiveState[] = []
+    const firstSub = state$.subscribe((value) => first.push(value))
+    expect(first.at(-1)?.loading).toBe(false)
+
+    // Churn: refcount drops to zero, then a new subscriber arrives before the
+    // teardown grace period has elapsed.
+    firstSub.unsubscribe()
+    vi.advanceTimersByTime(100)
+
+    const second: DocumentPerspectiveState[] = []
+    const secondSub = state$.subscribe((value) => second.push(value))
+
+    // The pipeline must still be warm: the new subscriber synchronously gets
+    // the loaded state, never a loading replay, and the cache entry survives.
+    expect(second).toHaveLength(1)
+    expect(second[0].loading).toBe(false)
+    expect(observableCache.size).toBe(1)
+    expect(previewStore.unstable_observeVersionDocumentIds).toHaveBeenCalledTimes(1)
+
+    secondSub.unsubscribe()
+  })
+
+  it('tears down and evicts the cache entry after the grace period', () => {
+    vi.useFakeTimers()
+    const previewStore = createPreviewStore()
+    const state$ = getOrCreateDocumentVersionsObservable(options(previewStore))
+
+    const sub = state$.subscribe()
+    sub.unsubscribe()
+    vi.advanceTimersByTime(2_000)
+
+    expect(observableCache.size).toBe(0)
   })
 })

--- a/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
@@ -10,9 +10,11 @@ import {
   map,
   type Observable,
   of,
-  shareReplay,
+  ReplaySubject,
+  share,
   startWith,
   switchMap,
+  timer,
 } from 'rxjs'
 
 import {useDataset} from '../../hooks/useDataset'
@@ -49,6 +51,17 @@ const INITIAL_VALUE: DocumentPerspectiveState = {
 // Create a singleton cache for observables
 export const observableCache = new Map<string, Observable<DocumentPerspectiveState>>()
 const swr = createSWR<string[]>({maxSize: 100})
+
+// How long to keep the pipeline alive after the last subscriber unsubscribes.
+// Subscriber churn (components re-rendering/remounting around commits) can
+// momentarily drop the refcount to zero. A bare teardown deletes the cache
+// entry, and the re-created pipeline synchronously re-enters the
+// `startWith(loadingState)` path (the version id set is non-empty for any
+// document with a draft or published variant), so `loading: true` reaches
+// `useDocumentForm`'s `ready` gate and flips the form read-only until the
+// `observePaths` round trip settles — silently swallowing keystrokes typed in
+// that window.
+const TEARDOWN_GRACE_PERIOD = 1_000
 
 /**
  * Fetches the document versions for a given document
@@ -223,7 +236,10 @@ export function getOrCreateDocumentVersionsObservable(options: {
     finalize(() => {
       observableCache.delete(cacheKey)
     }),
-    shareReplay({refCount: true, bufferSize: 1}),
+    share({
+      connector: () => new ReplaySubject(1),
+      resetOnRefCountZero: () => timer(TEARDOWN_GRACE_PERIOD),
+    }),
   )
 
   observableCache.set(cacheKey, newObservable)

--- a/packages/sanity/src/core/store/document/document-pair/editState.test.ts
+++ b/packages/sanity/src/core/store/document/document-pair/editState.test.ts
@@ -1,7 +1,7 @@
 import {type SanityClient} from '@sanity/client'
 import {type SanityDocument} from '@sanity/types'
 import {of, Subject} from 'rxjs'
-import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createMockSanityClient} from '../../../../../test/mocks/mockSanityClient'
 import {createSchema} from '../../../schema'
@@ -160,5 +160,109 @@ describe('editState — snapshot identity preservation', () => {
     expect(realEmissions).toHaveLength(2)
     expect(realEmissions[0].draft).toBe(draftA)
     expect(realEmissions[1].draft).toBe(draftB)
+  })
+})
+
+/**
+ * Regression tests for the read-only flip: subscriber churn (e.g. a React
+ * commit unsubscribing every consumer before the replacements subscribe)
+ * momentarily drops the shared pipeline's refcount to zero. With a bare
+ * teardown, the next subscriber re-enters the cold-start path — the SWR cache
+ * replays with `fromCache: true` → `ready: false` — flipping the form
+ * read-only mid-typing and silently swallowing keystrokes.
+ */
+describe('editState — subscriber churn', () => {
+  beforeEach(() => {
+    mockedSnapshotPair.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function setup() {
+    const draft$ = new Subject<SanityDocument | null>()
+    const published$ = new Subject<SanityDocument | null>()
+    const transactionsPendingEvents$ = new Subject<PendingMutationsEvent>()
+
+    mockedSnapshotPair.mockReturnValue(
+      of({
+        draft: {snapshots$: draft$.asObservable()},
+        published: {snapshots$: published$.asObservable()},
+        transactionsPendingEvents$,
+      }) as any,
+    )
+
+    // Unique id per test run avoids the editState/swr memoize caches.
+    const publishedId = `book-${Math.random().toString(36).slice(2)}`
+    const idPair = {publishedId, draftId: `drafts.${publishedId}`}
+    const state$ = editState(createCtx(), idPair, 'book')
+
+    const draftDoc: SanityDocument = {
+      _id: idPair.draftId,
+      _type: 'book',
+      _rev: 'r1',
+      _createdAt: '2024-01-01T00:00:00Z',
+      _updatedAt: '2024-01-01T00:00:00Z',
+    }
+
+    return {state$, draft$, published$, draftDoc}
+  }
+
+  it('does not emit ready: false to a subscriber arriving right after a zero-subscriber gap', () => {
+    vi.useFakeTimers()
+    const {state$, draft$, published$, draftDoc} = setup()
+
+    const first: EditStateFor[] = []
+    const firstSub = state$.subscribe((value) => first.push(value))
+    draft$.next(draftDoc)
+    published$.next(null)
+    expect(first.at(-1)?.ready).toBe(true)
+
+    // Churn: refcount drops to zero, then a new subscriber arrives before the
+    // teardown grace period has elapsed.
+    firstSub.unsubscribe()
+    vi.advanceTimersByTime(100)
+
+    const second: EditStateFor[] = []
+    const secondSub = state$.subscribe((value) => second.push(value))
+
+    // The pipeline must still be warm: the new subscriber synchronously gets
+    // the latest known state and never sees a ready: false / cache replay.
+    expect(second).toHaveLength(1)
+    expect(second[0].ready).toBe(true)
+    expect(second[0].draft).toBe(draftDoc)
+
+    secondSub.unsubscribe()
+  })
+
+  it('tears down and re-enters the cold-start path after the grace period', () => {
+    vi.useFakeTimers()
+    const {state$, draft$, published$, draftDoc} = setup()
+
+    const first: EditStateFor[] = []
+    const firstSub = state$.subscribe((value) => first.push(value))
+    draft$.next(draftDoc)
+    published$.next(null)
+    expect(first.at(-1)?.ready).toBe(true)
+
+    firstSub.unsubscribe()
+    vi.advanceTimersByTime(2_000)
+
+    const second: EditStateFor[] = []
+    const secondSub = state$.subscribe((value) => second.push(value))
+
+    // Cold start: the `startWith` placeholder, then the SWR cache replay —
+    // both with ready: false, and no stale ready: true replayed before them.
+    expect(second[0]).toMatchObject({ready: false, draft: null})
+    expect(second.at(-1)).toMatchObject({ready: false, draft: draftDoc})
+    expect(second.every((value) => !value.ready)).toBe(true)
+
+    // Fresh snapshots restore readiness.
+    draft$.next(draftDoc)
+    published$.next(null)
+    expect(second.at(-1)).toMatchObject({ready: true, draft: draftDoc})
+
+    secondSub.unsubscribe()
   })
 })

--- a/packages/sanity/src/core/store/document/document-pair/editState.ts
+++ b/packages/sanity/src/core/store/document/document-pair/editState.ts
@@ -1,7 +1,7 @@
 import {type SanityClient} from '@sanity/client'
 import {type SanityDocument, type Schema} from '@sanity/types'
-import {combineLatest, type Observable, of} from 'rxjs'
-import {map, publishReplay, refCount, startWith, switchMap} from 'rxjs/operators'
+import {combineLatest, type Observable, of, ReplaySubject, timer} from 'rxjs'
+import {map, share, startWith, switchMap} from 'rxjs/operators'
 
 import {getVersionFromId} from '../../../util'
 import {measureFirstEmission} from '../../../util/measureFirstEmission'
@@ -50,6 +50,16 @@ export interface EditStateFor {
 }
 const LOCKED: TransactionSyncLockState = {enabled: true}
 const NOT_LOCKED: TransactionSyncLockState = {enabled: false}
+
+// How long to keep the pipeline alive after the last subscriber unsubscribes.
+// Subscriber churn (e.g. a React commit that unsubscribes every consumer before
+// the replacements subscribe) can momentarily drop the refcount to zero. A bare
+// teardown would make the next subscriber re-enter the cold-start path: the SWR
+// cache replays with `fromCache: true`, which emits `ready: false` and flips the
+// form read-only until fresh snapshots arrive — silently swallowing keystrokes
+// typed in that window. The invariant: a momentary zero-subscriber gap on a
+// warm, healthy document pair must never surface as `ready: false`.
+const TEARDOWN_GRACE_PERIOD = 1_000
 
 /** @internal */
 export const editState = memoize(
@@ -130,8 +140,14 @@ export const editState = memoize(
         transactionSyncLock: null,
         release: idPair.versionId ? getVersionFromId(idPair.versionId) : undefined,
       }),
-      publishReplay(1),
-      refCount(),
+      // Unlike `publishReplay(1) + refCount()`, this resets the replay subject
+      // when the pipeline is torn down, so a later cold subscriber won't get a
+      // stale `ready: true` replayed before the cold-start emissions (and an
+      // error won't be replayed forever).
+      share({
+        connector: () => new ReplaySubject(1),
+        resetOnRefCountZero: () => timer(TEARDOWN_GRACE_PERIOD),
+      }),
     )
   },
   (ctx, idPair, typeName) => memoizeKeyGen(ctx.client, idPair, typeName),


### PR DESCRIPTION
### Description

When React re-renders the document form (typically right after a commit like publish), the components subscribing to `editState` and `useDocumentVersions` can all unsubscribe a moment before their replacements subscribe. Both of these are shared, reference-counted streams, and they tore down the instant their subscriber count hit zero. The new subscriber then found a torn-down stream and restarted it from scratch, and during a restart, both streams report "not ready" / "loading" until data arrives. That state reaches `useDocumentForm`'s `ready` gate, which flips the whole form to read-only for a moment. Any keystrokes typed during that moment are silently dropped.

The fix: instead of tearing down immediately when the subscriber count hits zero, both streams now stay alive for a 1-second grace period. If a new subscriber shows up within that window (which is what happens during a re-render), it gets the current state instantly and nothing restarts. If nobody shows up, the stream tears down as before.

In `editState` this also replaces the deprecated `publishReplay + refCount` combination with the `share()` equivalent, which fixes two latent bugs in the old pattern: after a real teardown, a new subscriber no longer receives a stale "ready" value from before the teardown, and a failed stream no longer replays its error forever.

### What to review

- The `share()` configuration and the comments explaining the invariant in `editState.ts` and `useDocumentVersions.tsx`
- In `useDocumentVersions`, the cache entry must survive the grace period and be evicted on real teardown (covered by tests)

### Testing

New regression tests for both streams cover both sides of the 1-second boundary: a subscriber arriving during the grace period gets the warm state immediately and never sees a "not ready" / "loading" emission, and after the grace period the stream tears down and restarts cleanly. The perf bench shows 0 typing interruptions with this fix.

### Notes for release

Fixes an issue where the document form could briefly turn read-only right after publishing (or another commit).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core document editing readiness (`editState`) and version loading observables; behavior change is narrow but user-visible if the grace window or share teardown is wrong.
> 
> **Overview**
> Fixes a bug where the document form could go **read-only** for a moment after publish (or similar commits) and **drop keystrokes** typed in that window.
> 
> React re-renders can leave `editState` and `useDocumentVersions` with **zero subscribers** briefly. Both pipelines used to tear down immediately; the next subscriber cold-started and re-emitted **`ready: false`** / **`loading: true`**, which hits `useDocumentForm`'s ready gate.
> 
> Both shared pipelines now stay alive for **`TEARDOWN_GRACE_PERIOD` (1s)** after the last unsubscribe via RxJS **`share()`** with **`resetOnRefCountZero: () => timer(...)`** and a **`ReplaySubject(1)`** connector. Subscribers that return during that window get the warm state without a loading/not-ready replay; after the grace period, teardown behaves as before (including cache eviction for document versions).
> 
> In **`editState`**, **`publishReplay(1) + refCount()`** is replaced with this **`share()`** setup so cold subscribers after a real teardown don't get a stale **`ready: true`** or a permanently replayed error.
> 
> Regression tests cover subscriber churn on both sides of the 1s boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0034704970e80c320ad0d2d23ba09f13027ff80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->