### PR TITLE
refactor: workbench auth

### DIFF
--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -272,7 +272,6 @@ export function prepareConfig(
   config: Config | MissingConfigFile,
   options?: {
     basePath?: string
-    token?: string
     requestHandler?: RequestHandler
     requestErrorChannel?: RequestErrorChannel
     requestFailureDiagnostics?: RequestFailureDiagnostics
@@ -369,7 +368,6 @@ export function prepareConfig(
       }
 
       const auth = getAuthStore(source, {
-        token: options?.token,
         requestHandler: options?.requestHandler,
         requestErrorChannel: options?.requestErrorChannel,
         requestFailureDiagnostics: options?.requestFailureDiagnostics,
@@ -435,12 +433,10 @@ export function prepareConfig(
 function getAuthStore(
   source: SourceOptions,
   {
-    token,
     requestHandler,
     requestErrorChannel,
     requestFailureDiagnostics,
   }: {
-    token?: string
     requestHandler?: RequestHandler
     requestErrorChannel?: RequestErrorChannel
     requestFailureDiagnostics?: RequestFailureDiagnostics
@@ -465,7 +461,6 @@ function getAuthStore(
     getRequestFailureDiagnostics: () => requestFailureDiagnostics,
     dataset,
     projectId,
-    token,
   })
 }
 

--- a/packages/sanity/src/core/store/authStore/__tests__/createAuthStore.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/createAuthStore.test.ts
@@ -1077,6 +1077,26 @@ describe('createAuthStore: workbench OS token', () => {
     expect(localStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull()
   })
 
+  it('exposes the OS token on the token output (for Bifur/realtime), not the stored one', async () => {
+    // Bifur authenticates from `auth.token`, so it must carry the OS token —
+    // not the (unwritten/stale) storage token.
+    localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify({token: 'stale-stored-token'}))
+    const OS_TOKEN = 'workbench-os-token'
+    const factory = createCredentialAwareClientFactory({token: OS_TOKEN, cookieValid: false})
+
+    const store = _createAuthStore({
+      projectId: PROJECT_ID,
+      dataset: DATASET,
+      loginMethod: 'cookie',
+      clientFactory: factory,
+      getSessionId: () => undefined,
+      consumeHashToken: () => undefined,
+      observeWorkbenchToken: () => of(OS_TOKEN),
+    })
+
+    expect(await firstValueFrom(store.token)).toBe(OS_TOKEN)
+  })
+
   it('is unauthenticated when the OS is signed out, ignoring a stored token', async () => {
     // Even with a valid stored token, an OS-embedded studio must follow the OS:
     // a `null` emission means signed out, and the loginMethod flow is bypassed.

--- a/packages/sanity/src/core/store/authStore/__tests__/createAuthStore.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/createAuthStore.test.ts
@@ -4,7 +4,7 @@ import {
   type SanityClient,
 } from '@sanity/client'
 import {type CurrentUser} from '@sanity/types'
-import {firstValueFrom} from 'rxjs'
+import {BehaviorSubject, firstValueFrom, of} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {_createAuthStore} from '../createAuthStore'
@@ -1037,5 +1037,107 @@ describe('createAuthStore: currentUser attributes', () => {
 
     const state = await waitForState(store, (s) => s.authenticated)
     expect(state.currentUser?.attributes).toEqual(MOCK_USER.attributes)
+  })
+})
+
+describe('createAuthStore: workbench OS token', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    window.location.hash = ''
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    window.location.hash = ''
+    vi.restoreAllMocks()
+  })
+
+  it('authenticates from the OS token, overriding loginMethod, without persisting it', async () => {
+    const OS_TOKEN = 'workbench-os-token'
+    // Cookie mode with an invalid cookie: without the OS token the store would be
+    // unauthenticated. Authenticating proves the OS token takes precedence and the
+    // loginMethod machinery is bypassed.
+    const factory = createCredentialAwareClientFactory({token: OS_TOKEN, cookieValid: false})
+
+    const store = _createAuthStore({
+      projectId: PROJECT_ID,
+      dataset: DATASET,
+      loginMethod: 'cookie',
+      clientFactory: factory,
+      getSessionId: () => undefined,
+      consumeHashToken: () => undefined,
+      observeWorkbenchToken: () => of(OS_TOKEN),
+    })
+
+    const state = await waitForState(store, (s) => s.authenticated, 2000)
+    expect(state.authenticated).toBe(true)
+    expect(state.currentUser).toEqual(MOCK_USER)
+
+    // The OS token is used in-memory only and must never be written to storage.
+    expect(localStorage.getItem(TOKEN_STORAGE_KEY)).toBeNull()
+  })
+
+  it('is unauthenticated when the OS is signed out, ignoring a stored token', async () => {
+    // Even with a valid stored token, an OS-embedded studio must follow the OS:
+    // a `null` emission means signed out, and the loginMethod flow is bypassed.
+    localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify({token: 'mock-token'}))
+    const mock = createMockClientFactory()
+
+    const store = _createAuthStore({
+      projectId: PROJECT_ID,
+      dataset: DATASET,
+      loginMethod: 'token',
+      clientFactory: mock.factory,
+      getSessionId: () => undefined,
+      consumeHashToken: () => undefined,
+      observeWorkbenchToken: () => of(null),
+    })
+
+    const state = await firstValueFrom(store.state)
+    expect(state.authenticated).toBe(false)
+  })
+
+  it('tracks the OS auth state over time — a later sign-out logs the studio out', async () => {
+    // Regression guard for the "auth frozen after OS token" case: the stream must
+    // keep emitting so an OS sign-out (null) transitions to unauthenticated
+    // instead of replaying the authenticated result forever.
+    const OS_TOKEN = 'workbench-os-token'
+    const factory = createCredentialAwareClientFactory({token: OS_TOKEN, cookieValid: false})
+    const token$ = new BehaviorSubject<string | null>(OS_TOKEN)
+
+    const store = _createAuthStore({
+      projectId: PROJECT_ID,
+      dataset: DATASET,
+      loginMethod: 'cookie',
+      clientFactory: factory,
+      getSessionId: () => undefined,
+      consumeHashToken: () => undefined,
+      observeWorkbenchToken: () => token$,
+    })
+
+    await waitForState(store, (s) => s.authenticated, 2000)
+
+    // OS signs out.
+    token$.next(null)
+    const state = await waitForState(store, (s) => !s.authenticated, 2000)
+    expect(state.authenticated).toBe(false)
+  })
+
+  it('falls through to the normal flow when not embedded in the workbench', async () => {
+    localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify({token: 'mock-token'}))
+    const mock = createMockClientFactory()
+
+    const store = _createAuthStore({
+      projectId: PROJECT_ID,
+      dataset: DATASET,
+      loginMethod: 'token',
+      clientFactory: mock.factory,
+      getSessionId: () => undefined,
+      consumeHashToken: () => undefined,
+      observeWorkbenchToken: () => undefined,
+    })
+
+    const state = await waitForState(store, (s) => s.authenticated)
+    expect(state.authenticated).toBe(true)
   })
 })

--- a/packages/sanity/src/core/store/authStore/__tests__/createAuthStore.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/createAuthStore.test.ts
@@ -1143,6 +1143,33 @@ describe('createAuthStore: workbench OS token', () => {
     expect(state.authenticated).toBe(false)
   })
 
+  it('refreshes the OS token instead of tearing down on logout (forced 401)', async () => {
+    // In the workbench, a forced logout (rejected token) must ask the OS to
+    // reissue rather than clear local state or hit /auth/logout.
+    localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify({token: 'stored-token'}))
+    const OS_TOKEN = 'workbench-os-token'
+    const factory = createCredentialAwareClientFactory({token: OS_TOKEN, cookieValid: false})
+    const refreshWorkbenchToken = vi.fn()
+
+    const store = _createAuthStore({
+      projectId: PROJECT_ID,
+      dataset: DATASET,
+      loginMethod: 'cookie',
+      clientFactory: factory,
+      getSessionId: () => undefined,
+      consumeHashToken: () => undefined,
+      observeWorkbenchToken: () => of(OS_TOKEN),
+      refreshWorkbenchToken,
+    })
+
+    await waitForState(store, (s) => s.authenticated, 2000)
+    await store.logout!()
+
+    expect(refreshWorkbenchToken).toHaveBeenCalledTimes(1)
+    // Local state is left intact — the OS drives sign-out, not us.
+    expect(localStorage.getItem(TOKEN_STORAGE_KEY)).toEqual(JSON.stringify({token: 'stored-token'}))
+  })
+
   it('falls through to the normal flow when not embedded in the workbench', async () => {
     localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify({token: 'mock-token'}))
     const mock = createMockClientFactory()

--- a/packages/sanity/src/core/store/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/authStore/createAuthStore.ts
@@ -528,8 +528,12 @@ export function _createAuthStore({
   // current token (or `null` when the OS is signed out) and keeps emitting as
   // that changes, so `loginMethod` and the recheck streams are bypassed and a
   // later OS sign-out transitions the Studio to unauthenticated. The token is
-  // never persisted (so it can't go stale in storage).
-  const workbenchToken$ = observeWorkbenchToken()
+  // never persisted (so it can't go stale in storage), which is also why it
+  // feeds the `token` output below — consumers like Bifur (realtime) read that
+  // directly and would otherwise authenticate from empty/stale storage.
+  const workbenchToken$ = observeWorkbenchToken()?.pipe(
+    shareReplay({bufferSize: 1, refCount: true}),
+  )
 
   const authState$ = (
     workbenchToken$
@@ -776,7 +780,7 @@ export function _createAuthStore({
   return {
     handleCallbackUrl,
     state: authState$,
-    token: tokenStorage.value.pipe(map((t) => t?.token || null)),
+    token: workbenchToken$ ?? tokenStorage.value.pipe(map((t) => t?.token || null)),
     LoginComponent,
     logout,
   }

--- a/packages/sanity/src/core/store/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/authStore/createAuthStore.ts
@@ -58,7 +58,10 @@ import {
   type HandleCallbackResult,
 } from './types'
 import {isCookielessCompatibleLoginMethod} from './utils/asserters'
-import {observeWorkbenchToken as defaultObserveWorkbenchToken} from './workbenchToken'
+import {
+  observeWorkbenchToken as defaultObserveWorkbenchToken,
+  refreshWorkbenchToken as defaultRefreshWorkbenchToken,
+} from './workbenchToken'
 
 /** @internal */
 export interface AuthStoreOptions extends AuthConfig {
@@ -107,6 +110,15 @@ export interface AuthStoreOptions extends AuthConfig {
    * @internal
    */
   observeWorkbenchToken?: () => Observable<string | null> | undefined
+  /**
+   * Asks the workbench "OS" to reissue its session token, called when the
+   * current one is rejected (a 401 surfaced as forced logout). In the workbench
+   * this replaces tearing down the session locally, since the OS owns it — the
+   * reissued token flows back through `observeWorkbenchToken`. Defaults to a
+   * no-op.
+   * @internal
+   */
+  refreshWorkbenchToken?: () => void
 }
 
 /**
@@ -286,6 +298,7 @@ export function _createAuthStore({
   getSessionId,
   consumeHashToken,
   observeWorkbenchToken = () => undefined,
+  refreshWorkbenchToken = () => {},
   getRequestErrorHandler,
   getRequestFailureDiagnostics,
   ...providerOptions
@@ -735,6 +748,15 @@ export function _createAuthStore({
   let _didLogOut = false
 
   async function logout() {
+    // In the workbench the OS owns the session, so a logout here is really a
+    // rejected/expired OS token (surfaced as a forced logout on a 401). Ask the
+    // OS to reissue rather than tearing the session down ourselves — the new
+    // token arrives via `observeWorkbenchToken` and re-drives `authState$`.
+    if (workbenchToken$) {
+      refreshWorkbenchToken()
+      return
+    }
+
     _didLogOut = true
     const tokenClient = await firstValueFrom(tokenClient$)
 
@@ -787,14 +809,14 @@ export function _createAuthStore({
 }
 
 /**
- * Public options for `createAuthStore`. The `getSessionId`, `consumeHashToken`
- * and `observeWorkbenchToken` dependencies are wired automatically using the
- * default implementations.
+ * Public options for `createAuthStore`. The `getSessionId`, `consumeHashToken`,
+ * `observeWorkbenchToken` and `refreshWorkbenchToken` dependencies are wired
+ * automatically using the default implementations.
  * @internal
  */
 export type CreateAuthStoreOptions = Omit<
   AuthStoreOptions,
-  'getSessionId' | 'consumeHashToken' | 'observeWorkbenchToken'
+  'getSessionId' | 'consumeHashToken' | 'observeWorkbenchToken' | 'refreshWorkbenchToken'
 >
 
 /**
@@ -807,6 +829,7 @@ export const createAuthStore: (options: CreateAuthStoreOptions) => AuthStore = m
       getSessionId: defaultGetSessionId,
       consumeHashToken: defaultConsumeHashToken,
       observeWorkbenchToken: defaultObserveWorkbenchToken,
+      refreshWorkbenchToken: defaultRefreshWorkbenchToken,
     }),
   // `getRequestErrorHandler` / `getRequestFailureDiagnostics` are functions
   // (not hashable, and not part of the store's identity — they just look up UI

--- a/packages/sanity/src/core/store/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/authStore/createAuthStore.ts
@@ -7,7 +7,19 @@ import {
 import {type CurrentUser} from '@sanity/types'
 import isEqual from 'lodash-es/isEqual.js'
 import memoize from 'lodash-es/memoize.js'
-import {concat, EMPTY, firstValueFrom, fromEvent, merge, of, ReplaySubject, skip, timer} from 'rxjs'
+import {
+  concat,
+  EMPTY,
+  firstValueFrom,
+  from,
+  fromEvent,
+  merge,
+  type Observable,
+  of,
+  ReplaySubject,
+  skip,
+  timer,
+} from 'rxjs'
 import {
   distinctUntilChanged,
   filter,
@@ -46,6 +58,7 @@ import {
   type HandleCallbackResult,
 } from './types'
 import {isCookielessCompatibleLoginMethod} from './utils/asserters'
+import {observeWorkbenchToken as defaultObserveWorkbenchToken} from './workbenchToken'
 
 /** @internal */
 export interface AuthStoreOptions extends AuthConfig {
@@ -84,12 +97,16 @@ export interface AuthStoreOptions extends AuthConfig {
    */
   consumeHashToken: () => string | undefined
   /**
-   * Temporary auth token provided by the embedding environment (e.g.
-   * the workbench). When set, it is used as the initial token for the
-   * auth store's clients, taking precedence over any token persisted in
-   * storage. It is not written back to storage.
+   * Observes the session token issued by the embedding workbench "OS", if the
+   * Studio is running as a federated remote inside it. While it yields a token,
+   * that token is authoritative: it takes precedence over `loginMethod` and
+   * every other mechanism, is used in-memory only (never persisted), and the
+   * auth state tracks it over time — so an OS sign-out (`null`) transitions the
+   * Studio to unauthenticated. Returns `undefined` outside the workbench, in
+   * which case the normal auth flow runs. Defaults to a no-op.
+   * @internal
    */
-  token?: string
+  observeWorkbenchToken?: () => Observable<string | null> | undefined
 }
 
 /**
@@ -268,12 +285,15 @@ export function _createAuthStore({
   loginMethod = 'dual',
   getSessionId,
   consumeHashToken,
+  observeWorkbenchToken = () => undefined,
   getRequestErrorHandler,
   getRequestFailureDiagnostics,
-  token: providedToken,
   ...providerOptions
 }: AuthStoreOptions): AuthStore {
   // Precedence when initializing auth:
+  // * if embedded in the workbench (`observeWorkbenchToken`), the OS auth state
+  //   is authoritative and overrides everything below — see the `authState$`
+  //   branch. Otherwise `loginMethod` decides:
   // * if loginMethod == 'dual':
   //    1. token in hash (if exists) – will be written as new localStorage token
   //    2. token in localStorage (if it exists)
@@ -329,16 +349,15 @@ export function _createAuthStore({
   })
 
   const currentTokenState = tokenStorage.get()
-  // A token provided by the embedding environment (e.g. the workbench) takes
-  // precedence over any token persisted in storage for the initial clients.
-  const initialToken = providedToken || currentTokenState?.token
 
   const initialTokenClient = clientFactory({
     ...AUTH_CLIENT_OPTIONS,
     ...hostOptions,
     projectId,
     dataset,
-    ...(initialToken ? {token: initialToken, ignoreBrowserTokenWarning: true} : {}),
+    ...(currentTokenState?.token
+      ? {token: currentTokenState.token, ignoreBrowserTokenWarning: true}
+      : {}),
   })
 
   const initialDualClient = clientFactory({
@@ -346,8 +365,8 @@ export function _createAuthStore({
     ...hostOptions,
     projectId,
     dataset,
-    ...(initialToken
-      ? {token: initialToken, ignoreBrowserTokenWarning: true}
+    ...(currentTokenState?.token
+      ? {token: currentTokenState.token, ignoreBrowserTokenWarning: true}
       : {withCredentials: true}),
   })
 
@@ -471,6 +490,7 @@ export function _createAuthStore({
 
   // For dual mode, re-probe when the token changes from what the initial probe
   // already used
+  const initialToken = currentTokenState?.token ?? null
   const dualTokenRecheck$ =
     loginMethod === 'dual'
       ? tokenStorage.value.pipe(
@@ -481,7 +501,7 @@ export function _createAuthStore({
         )
       : EMPTY
 
-  const authState$ = concat(
+  const existingAuthState$ = concat(
     initial$,
     merge(workspaceClient$.pipe(skip(1)), dualCookieRecheck$, dualTokenRecheck$).pipe(
       mergeMap(async (client): Promise<AuthState> => {
@@ -501,6 +521,50 @@ export function _createAuthStore({
         }
       }),
     ),
+  )
+
+  // Outside the workbench this is `undefined` and the normal reactive graph
+  // runs unchanged. Inside, the OS auth state is authoritative: it emits the
+  // current token (or `null` when the OS is signed out) and keeps emitting as
+  // that changes, so `loginMethod` and the recheck streams are bypassed and a
+  // later OS sign-out transitions the Studio to unauthenticated. The token is
+  // never persisted (so it can't go stale in storage).
+  const workbenchToken$ = observeWorkbenchToken()
+
+  const authState$ = (
+    workbenchToken$
+      ? workbenchToken$.pipe(
+          switchMap((workbenchToken): Observable<AuthState> => {
+            if (!workbenchToken) {
+              return of({client: cookieClient, authenticated: false, currentUser: null})
+            }
+            const client = clientFactory({
+              ...AUTH_CLIENT_OPTIONS,
+              ...hostOptions,
+              projectId,
+              dataset,
+              token: workbenchToken,
+              ignoreBrowserTokenWarning: true,
+            })
+            return from(
+              getCurrentUser(
+                client,
+                'initial',
+                getRequestErrorHandler,
+                getRequestFailureDiagnostics?.(),
+              ),
+            ).pipe(
+              map(
+                (currentUser): AuthState => ({
+                  client,
+                  authenticated: Boolean(currentUser?.id),
+                  currentUser: currentUser || null,
+                }),
+              ),
+            )
+          }),
+        )
+      : existingAuthState$
   ).pipe(
     // Cookie state is broadcast to other tabs (and sibling workspaces for the
     // same project in this page) only on meaningful events: post-login probe
@@ -719,11 +783,15 @@ export function _createAuthStore({
 }
 
 /**
- * Public options for `createAuthStore`. The `getSessionId` and `consumeHashToken`
- * dependencies are wired automatically using the default implementations.
+ * Public options for `createAuthStore`. The `getSessionId`, `consumeHashToken`
+ * and `observeWorkbenchToken` dependencies are wired automatically using the
+ * default implementations.
  * @internal
  */
-export type CreateAuthStoreOptions = Omit<AuthStoreOptions, 'getSessionId' | 'consumeHashToken'>
+export type CreateAuthStoreOptions = Omit<
+  AuthStoreOptions,
+  'getSessionId' | 'consumeHashToken' | 'observeWorkbenchToken'
+>
 
 /**
  * @internal
@@ -734,6 +802,7 @@ export const createAuthStore: (options: CreateAuthStoreOptions) => AuthStore = m
       ...options,
       getSessionId: defaultGetSessionId,
       consumeHashToken: defaultConsumeHashToken,
+      observeWorkbenchToken: defaultObserveWorkbenchToken,
     }),
   // `getRequestErrorHandler` / `getRequestFailureDiagnostics` are functions
   // (not hashable, and not part of the store's identity — they just look up UI

--- a/packages/sanity/src/core/store/authStore/workbenchToken.ts
+++ b/packages/sanity/src/core/store/authStore/workbenchToken.ts
@@ -1,0 +1,44 @@
+import {from, type Observable, of} from 'rxjs'
+import {catchError, switchMap} from 'rxjs/operators'
+
+// The workbench host installs its shared message bus on this well-known global
+// symbol before it loads federated remotes. It must match the key used by
+// `@sanity/workbench` (`Symbol.for('sanity.os.bus')`).
+const OS_BUS_KEY = Symbol.for('sanity.os.bus')
+
+/**
+ * Whether this Studio is running as a federated remote inside the workbench.
+ *
+ * Federation shares the host's realm, so the installed bus is visible on
+ * `globalThis`. This is `false` in a standalone Studio, where we must never
+ * import `@sanity/workbench` (it would install a bus and add bundle weight for
+ * no reason). Note: this is a different embedding model to the Core UI iframe
+ * (`_context=…&mode=core-ui`), which is detected separately via the rendering
+ * context — that signal is not set on the federation path.
+ */
+function isWorkbenchEnvironment(): boolean {
+  return typeof globalThis === 'object' && OS_BUS_KEY in globalThis
+}
+
+/**
+ * Observes the session token issued by the workbench "OS", tracking the OS auth
+ * state over time.
+ *
+ * Returns `undefined` when the Studio is not embedded in the workbench, so the
+ * caller uses its normal auth flow. Inside the workbench, subscribes to the
+ * `auth.token` state topic, emitting the current token — or `null` when the OS
+ * is signed out — and re-emitting as the OS auth state changes, so sign-in/out
+ * propagates instead of being captured once. Any bus error is treated as "no
+ * token" (`null`). The token is used in-memory only and never persisted.
+ *
+ * @internal
+ */
+export function observeWorkbenchToken(): Observable<string | null> | undefined {
+  if (!isWorkbenchEnvironment()) return undefined
+
+  return from(import('@sanity/workbench')).pipe(
+    switchMap(({os}) => os.subscribe('auth.token')),
+    // Any failure (importing the host bundle, or the subscription) means "no OS token".
+    catchError(() => of(null)),
+  )
+}

--- a/packages/sanity/src/core/store/authStore/workbenchToken.ts
+++ b/packages/sanity/src/core/store/authStore/workbenchToken.ts
@@ -42,3 +42,20 @@ export function observeWorkbenchToken(): Observable<string | null> | undefined {
     catchError(() => of(null)),
   )
 }
+
+/**
+ * Asks the workbench "OS" to reissue the session token, e.g. after its current
+ * one was rejected with a 401. Fire-and-forget: the reissued token arrives via
+ * the `auth.token` subscription in {@link observeWorkbenchToken}. No-op outside
+ * the workbench.
+ *
+ * @internal
+ */
+export function refreshWorkbenchToken(): void {
+  if (!isWorkbenchEnvironment()) return
+
+  void import('@sanity/workbench').then(
+    ({os}) => os.emit('auth.token.refresh', undefined),
+    () => {},
+  )
+}

--- a/packages/sanity/src/core/studio/Studio.tsx
+++ b/packages/sanity/src/core/studio/Studio.tsx
@@ -89,15 +89,6 @@ export interface StudioProps {
    * @hidden
    * @beta */
   unstable_noAuthBoundary?: boolean
-
-  /**
-   * Used as a temporary measure to forward the token from workbench to the studio for instant
-   * authentication.
-   * @internal
-   * @hidden
-   * @experimental
-   */
-  unstable_temporaryToken?: string
 }
 
 /**
@@ -112,7 +103,6 @@ export function Studio(props: StudioProps): React.JSX.Element {
     unstable_globalStyles: globalStyles,
     unstable_history,
     unstable_noAuthBoundary,
-    unstable_temporaryToken,
   } = props
 
   return (
@@ -123,7 +113,6 @@ export function Studio(props: StudioProps): React.JSX.Element {
       scheme={scheme}
       unstable_history={unstable_history}
       unstable_noAuthBoundary={unstable_noAuthBoundary}
-      unstable_temporaryToken={unstable_temporaryToken}
     >
       {globalStyles && <GlobalStyle />}
       <StudioLayout />

--- a/packages/sanity/src/core/studio/StudioProvider.tsx
+++ b/packages/sanity/src/core/studio/StudioProvider.tsx
@@ -53,7 +53,6 @@ export function StudioProvider({
   scheme,
   unstable_history: history,
   unstable_noAuthBoundary: noAuthBoundary,
-  unstable_temporaryToken: token,
 }: StudioProviderProps) {
   // Run in an effect to keep render pure; both calls are idempotent and buffer/guard
   // their own work, so StrictMode's double mount is safe.
@@ -115,7 +114,6 @@ export function StudioProvider({
                 basePath={basePath}
                 LoadingComponent={LoadingBlock}
                 primaryProjectId={primaryProjectId}
-                token={token}
               >
                 <VisibleWorkspacesProvider>
                   <ActiveWorkspaceMatcher

--- a/packages/sanity/src/core/studio/renderStudio.tsx
+++ b/packages/sanity/src/core/studio/renderStudio.tsx
@@ -4,7 +4,7 @@ import {createRoot} from 'react-dom/client'
 import {type Config} from '../config'
 import {Studio, type StudioProps} from './Studio'
 
-interface RenderStudioOptions extends Pick<StudioProps, 'basePath' | 'unstable_temporaryToken'> {
+interface RenderStudioOptions extends Pick<StudioProps, 'basePath'> {
   reactStrictMode?: boolean
 }
 
@@ -39,19 +39,14 @@ export function renderStudio(
   }
 
   const opts = typeof options === 'boolean' ? {reactStrictMode: options} : options
-  const {reactStrictMode = true, basePath, unstable_temporaryToken} = opts
+  const {reactStrictMode = true, basePath} = opts
 
   const root = createRoot(rootElement)
 
   root.render(
     reactStrictMode ? (
       <StrictMode>
-        <Studio
-          config={config}
-          basePath={basePath}
-          unstable_globalStyles
-          unstable_temporaryToken={unstable_temporaryToken}
-        />
+        <Studio config={config} basePath={basePath} unstable_globalStyles />
       </StrictMode>
     ) : (
       <Studio config={config} basePath={basePath} unstable_globalStyles />

--- a/packages/sanity/src/core/studio/workspaces/WorkspacesProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaces/WorkspacesProvider.tsx
@@ -45,7 +45,6 @@ export interface WorkspacesProviderProps {
    * when the failing project matches the studio's primary project.
    */
   primaryProjectId?: string
-  token?: string
 }
 
 /**
@@ -94,7 +93,6 @@ export function WorkspacesProvider({
   basePath,
   LoadingComponent,
   primaryProjectId,
-  token,
 }: WorkspacesProviderProps) {
   const [corsError, setCorsError] = useState<CorsErrorState>()
   const [configError, setConfigError] = useState<ConfigErrorValue>()
@@ -234,7 +232,6 @@ export function WorkspacesProvider({
   const workspaces = useDeferredValue(
     prepareConfig(config, {
       basePath,
-      token,
       requestHandler,
       requestErrorChannel,
       requestFailureDiagnostics,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1634,7 +1634,7 @@ importers:
         version: 3.0.3
       '@sanity/workbench':
         specifier: latest
-        version: 0.1.0-alpha.23(@sanity/sdk@2.15.0)(react@19.2.7)(xstate@5.32.2)
+        version: 0.1.0-alpha.24(@sanity/sdk@2.15.0)(react@19.2.7)(xstate@5.32.2)
       '@sentry/react':
         specifier: ^10.62.0
         version: 10.62.0(react@19.2.7)
@@ -5854,8 +5854,8 @@ packages:
     resolution: {integrity: sha512-VypASfPMTFvqQ5beQ0zxQ0rByDk81UatmuPreIN8PAHSczCQI/B1KZPB2TLOCj0RJicZiHoz4k64GjyOIJkcFQ==}
     engines: {node: '>=22.12'}
 
-  '@sanity/workbench@0.1.0-alpha.23':
-    resolution: {integrity: sha512-MvGZa7fvnrT30NZu4WkSidpcGp+ekfn0yeRXaC2ib8bmA/ewEDKBm4mAh8Sb2sit/LFCOVbFR/v4HstB0xualA==}
+  '@sanity/workbench@0.1.0-alpha.24':
+    resolution: {integrity: sha512-235mR37+z8eg9OQqhUwgkQ4dZnveFHczUTgW2jk81qm1pP6vMlTdEAiKpz1Tq4zU9zRfg2xck51DP1VlkVzdWA==}
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
       '@sanity/sdk': ^2.9.0
@@ -15266,7 +15266,7 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@sanity/workbench@0.1.0-alpha.23(@sanity/sdk@2.15.0)(react@19.2.7)(xstate@5.32.2)':
+  '@sanity/workbench@0.1.0-alpha.24(@sanity/sdk@2.15.0)(react@19.2.7)(xstate@5.32.2)':
     dependencies:
       '@module-federation/runtime': 2.7.0
       '@sanity/message-protocol': 0.23.0


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Drops the token pass-through for auth and instead pulls the token from the OS layer when the studio's rendered in the workbench.

The old approach pushed a one-shot token in as a prop, so auth couldn't follow the OS session — sign-out and refresh never propagated. Now we subscribe to the OS `auth.token`, so:

- the OS token is authoritative (overrides loginMethod/hash/localStorage/cookie), kept in-memory, never persisted
- signing out of the OS signs the studio out
- Bifur/realtime uses it too
- a forced logout asks the OS to refresh (`auth.token.refresh`) rather than tearing down

Standalone studios are untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core authentication for workbench federation (session ownership, logout, and realtime token wiring); mistakes could break embedded login or leave stale auth, though standalone behavior is gated and heavily tested.
> 
> **Overview**
> **Workbench-embedded Studio** no longer receives a one-shot token via `unstable_temporaryToken` / `prepareConfig` `token`. Auth instead **subscribes to the workbench OS** (`auth.token` on `Symbol.for('sanity.os.bus')`) through new `workbenchToken.ts`, with **dynamic `@sanity/workbench` import** only when that bus is present.
> 
> When embedded, the **OS token overrides** `loginMethod`, hash/localStorage, and cookies: it is **in-memory only**, **`auth.state` tracks OS sign-out** (`null` → unauthenticated), **`auth.token` exposes the OS token** for Bifur/realtime, and **`logout` calls `auth.token.refresh`** instead of local teardown or `/auth/logout`. Standalone studios keep the existing auth graph unchanged.
> 
> **Removed surface area:** `Studio` / `StudioProvider` / `WorkspacesProvider` / `renderStudio` props and `prepareConfig` options that forwarded the temporary token.
> 
> **Tests** cover OS precedence, non-persistence, Bifur token output, sign-out propagation, refresh-on-logout, and fallback when not in the workbench. Lockfile bumps `@sanity/workbench` to `0.1.0-alpha.24`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b9c096923bd97e75e8666e11dc95b99946523de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
