### PR TITLE
chore(releases): consolidate version discard and unpublish through document operations

### DIFF
--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -44,7 +44,9 @@ export function DiscardVersionDialog(props: {
   // perspective: the dialog is opened from version chips and the release tool's document table,
   // where the selected perspective can be a different release (or the drafts pair) and would
   // discard the wrong document.
-  const discardScopeId = isVersionId(versionId) ? getVersionFromId(versionId) : undefined
+  // `|| undefined` so a malformed version id (no bundle segment) falls back to the perspective
+  // target below rather than checking out an empty scope.
+  const discardScopeId = (isVersionId(versionId) && getVersionFromId(versionId)) || undefined
   // Only the draft case follows the selected perspective, so that discarding a draft targets the
   // variant-scoped version when a variant is selected. While that lookup resolves, confirming is
   // disabled below instead of silently operating on the base pair.

--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -1,22 +1,29 @@
-import {type ReleaseDocument} from '@sanity/client'
 import {getVersionNameFromId, type VersionId} from '@sanity/id-utils'
 import {Box, Stack, Text, useToast} from '@sanity/ui'
-import {useCallback, useState} from 'react'
+import {useCallback, useEffect, useRef, useState} from 'react'
 
 import {Dialog} from '../../../../ui-components/dialog/Dialog'
 import {LoadingBlock} from '../../../components/loadingBlock/LoadingBlock'
 import {useDocumentOperation} from '../../../hooks/useDocumentOperation'
+import {useDocumentOperationEvent} from '../../../hooks/useDocumentOperationEvent'
 import {useSchema} from '../../../hooks/useSchema'
-import {getPairTarget, useTargetDocumentState} from '../../../hooks/useTargetDocumentState'
+import {
+  getPairTarget,
+  getTargetScopeId,
+  useTargetDocumentState,
+} from '../../../hooks/useTargetDocumentState'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {Translate} from '../../../i18n/Translate'
 import {type TargetPerspective} from '../../../perspective/types'
-import {usePerspective} from '../../../perspective/usePerspective'
 import {Preview} from '../../../preview/components/Preview'
-import {getPublishedId, getVersionFromId, isDraftId, isVersionId} from '../../../util/draftUtils'
-import {useVersionOperations} from '../../hooks/useVersionOperations'
+import {
+  getPublishedId,
+  getVersionFromId,
+  getVersionId,
+  isDraftId,
+  isVersionId,
+} from '../../../util/draftUtils'
 import {releasesLocaleNamespace} from '../../i18n'
-import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
 
 /**
  * @internal
@@ -31,19 +38,22 @@ export function DiscardVersionDialog(props: {
   const {onClose, versionId, documentType, fromPerspective, isGoingToUnpublish} = props
   const {t} = useTranslation(releasesLocaleNamespace)
   const {t: coreT} = useTranslation()
-  const targetDocumentState = useTargetDocumentState(getPublishedId(versionId))
-  // The scope of the document targeted by the selected perspective, so that discarding a draft
-  // targets the variant-scoped version when a variant is selected (undefined when the target is
-  // still resolving or the draft/published pair applies). While resolving, confirming is
+  const publishedId = getPublishedId(versionId)
+  const targetDocumentState = useTargetDocumentState(publishedId)
+  // Discarding a version must target the bundle encoded in `versionId`, not the globally selected
+  // perspective: the dialog is opened from version chips and the release tool's document table,
+  // where the selected perspective can be a different release (or the drafts pair) and would
+  // discard the wrong document.
+  const discardScopeId = isVersionId(versionId) ? getVersionFromId(versionId) : undefined
+  // Only the draft case follows the selected perspective, so that discarding a draft targets the
+  // variant-scoped version when a variant is selected. While that lookup resolves, confirming is
   // disabled below instead of silently operating on the base pair.
-  const isTargetReady = targetDocumentState.status === 'ready'
+  const isTargetReady = Boolean(discardScopeId) || targetDocumentState.status === 'ready'
   const {discardChanges} = useDocumentOperation(
-    getPublishedId(versionId),
+    publishedId,
     documentType,
-    getPairTarget(targetDocumentState),
+    discardScopeId ?? getPairTarget(targetDocumentState),
   )
-  const {selectedPerspective} = usePerspective()
-  const {discardVersion} = useVersionOperations()
   const schema = useSchema()
   const toast = useToast()
   const [isDiscarding, setIsDiscarding] = useState(false)
@@ -55,37 +65,44 @@ export function DiscardVersionDialog(props: {
 
   const schemaType = schema.get(documentType)
 
-  const handleDiscardVersion = useCallback(async () => {
-    setIsDiscarding(true)
+  // The pair the operation runs against, used to recognise this dialog's own completion event:
+  // `operationEvents` is keyed by published id and type only, so a discard of another bundle of
+  // the same document would otherwise be mistaken for this one.
+  const targetScopeId = discardScopeId ?? getTargetScopeId(targetDocumentState)
+  const targetVersionId = targetScopeId ? getVersionId(publishedId, targetScopeId) : undefined
 
-    if (isVersionId(versionId)) {
-      // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
-      const run = async () => {
-        await discardVersion(
-          getVersionFromId(versionId) ||
-            getReleaseIdFromReleaseDocumentId((selectedPerspective as ReleaseDocument)._id),
-          versionId,
-        )
-      }
-      try {
-        await run()
-      } catch (err) {
-        toast.push({
-          closable: true,
-          status: 'error',
-          title: coreT('release.action.discard-version.failure'),
-          description: err.message,
-        })
-      }
-    } else {
-      // on the document header you can also discard the draft
-      discardChanges.execute()
+  const event = useDocumentOperationEvent(publishedId, documentType)
+  const prevEvent = useRef(event)
+  const awaitingDiscardRef = useRef(false)
+
+  useEffect(() => {
+    if (!event || event === prevEvent.current) return
+    prevEvent.current = event
+
+    if (!awaitingDiscardRef.current) return
+    if (event.op !== 'discardChanges' || event.idPair.versionId !== targetVersionId) return
+
+    awaitingDiscardRef.current = false
+
+    if (event.type === 'error') {
+      toast.push({
+        closable: true,
+        status: 'error',
+        title: coreT('release.action.discard-version.failure'),
+        description: event.error.message,
+      })
     }
 
-    setIsDiscarding(false)
-
     onClose()
-  }, [versionId, onClose, discardVersion, selectedPerspective, toast, coreT, discardChanges])
+  }, [coreT, event, onClose, targetVersionId, toast])
+
+  const handleDiscardVersion = useCallback(() => {
+    if (discardChanges.disabled) return
+
+    setIsDiscarding(true)
+    awaitingDiscardRef.current = true
+    discardChanges.execute()
+  }, [discardChanges])
 
   return (
     <Dialog
@@ -108,7 +125,8 @@ export function DiscardVersionDialog(props: {
         confirmButton: {
           text: t(`discard-version-dialog.title-${discardType}`),
           onClick: handleDiscardVersion,
-          disabled: isDiscarding || !isTargetReady,
+          disabled: isDiscarding || !isTargetReady || Boolean(discardChanges.disabled),
+          loading: isDiscarding,
         },
       }}
     >

--- a/packages/sanity/src/core/releases/components/dialog/UnpublishVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/UnpublishVersionDialog.tsx
@@ -1,16 +1,17 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {Stack, Text, useToast} from '@sanity/ui'
-import {type CSSProperties, useCallback, useState} from 'react'
+import {type CSSProperties, useCallback, useEffect, useRef, useState} from 'react'
 
 import {Dialog} from '../../../../ui-components/dialog/Dialog'
 import {LoadingBlock} from '../../../components/loadingBlock/LoadingBlock'
+import {useDocumentOperation} from '../../../hooks/useDocumentOperation'
+import {useDocumentOperationEvent} from '../../../hooks/useDocumentOperationEvent'
 import {useSchema} from '../../../hooks/useSchema'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {Translate} from '../../../i18n/Translate'
 import {Preview} from '../../../preview/components/Preview'
 import {useValuePreview} from '../../../preview/useValuePreview'
-import {getVersionFromId} from '../../../util/draftUtils'
-import {useVersionOperations} from '../../hooks/useVersionOperations'
+import {getPublishedId, getVersionFromId} from '../../../util/draftUtils'
 import {releasesLocaleNamespace} from '../../i18n'
 import {useActiveReleases} from '../../store/useActiveReleases'
 import {useArchivedReleases} from '../../store/useArchivedReleases'
@@ -21,13 +22,24 @@ export function UnpublishVersionDialog(props: {
   onClose: () => void
   documentVersionId: string
   documentType: string
+  /**
+   * Whether the dialog pushes its own completion toasts. Callers rendered inside the document
+   * pane should leave this off: `DocumentOperationResults` already toasts the same operation
+   * events there, so the dialog would duplicate them. Defaults to `true` for the release tool,
+   * which has no such listener.
+   */
+  showCompletionToasts?: boolean
 }): React.JSX.Element {
-  const {onClose, documentVersionId, documentType} = props
+  const {onClose, documentVersionId, documentType, showCompletionToasts = true} = props
   const {t} = useTranslation(releasesLocaleNamespace)
   const {t: coreT} = useTranslation()
 
   const schema = useSchema()
-  const {unpublishVersion} = useVersionOperations()
+  const publishedId = getPublishedId(documentVersionId)
+  // The bundle to unpublish is the one encoded in the id, never the selected perspective: the
+  // dialog is opened from the release tool's document table and from version chips.
+  const releaseId = getVersionFromId(documentVersionId)
+  const {unpublish} = useDocumentOperation(publishedId, documentType, releaseId)
   const [isUnpublishing, setIsUnpublishing] = useState(false)
   const toast = useToast()
   const {data} = useActiveReleases()
@@ -44,40 +56,56 @@ export function UnpublishVersionDialog(props: {
   const schemaType = schema.get(documentType)
 
   const preview = useValuePreview({schemaType, value: {_id: documentVersionId}})
+  const previewTitle = preview?.value?.title
 
-  const handleUnpublish = useCallback(async () => {
-    setIsUnpublishing(true)
+  const event = useDocumentOperationEvent(publishedId, documentType)
+  const prevEvent = useRef(event)
+  const awaitingUnpublishRef = useRef(false)
 
-    // The run() wrapper instead of doing it inline in try/catch is because of the React Compiler not fully supporting the syntax yet
-    const run = async () => {
-      await unpublishVersion(documentVersionId)
-      toast.push({
-        closable: true,
-        status: 'success',
-        description: (
-          <Translate
-            t={coreT}
-            i18nKey={'release.action.unpublish-version.success'}
-            values={{title: preview?.value?.title || documentVersionId}}
-          />
-        ),
-      })
+  useEffect(() => {
+    if (!event || event === prevEvent.current) return
+    prevEvent.current = event
+
+    if (!awaitingUnpublishRef.current) return
+    // `operationEvents` is keyed by published id and type only, so an unpublish of another bundle
+    // of the same document would otherwise be mistaken for this dialog's own result.
+    if (event.op !== 'unpublish' || event.idPair.versionId !== documentVersionId) return
+
+    awaitingUnpublishRef.current = false
+
+    if (showCompletionToasts) {
+      toast.push(
+        event.type === 'success'
+          ? {
+              closable: true,
+              status: 'success',
+              description: (
+                <Translate
+                  t={coreT}
+                  i18nKey={'release.action.unpublish-version.success'}
+                  values={{title: previewTitle || documentVersionId}}
+                />
+              ),
+            }
+          : {
+              closable: true,
+              status: 'error',
+              title: coreT('release.action.unpublish-version.failure'),
+              description: event.error.message,
+            },
+      )
     }
-    try {
-      await run()
-    } catch (err) {
-      toast.push({
-        closable: true,
-        status: 'error',
-        title: coreT('release.action.unpublish-version.failure'),
-        description: err.message,
-      })
-    }
-
-    setIsUnpublishing(false)
 
     onClose()
-  }, [coreT, documentVersionId, onClose, preview?.value?.title, toast, unpublishVersion])
+  }, [coreT, documentVersionId, event, onClose, previewTitle, showCompletionToasts, toast])
+
+  const handleUnpublish = useCallback(() => {
+    if (unpublish.disabled) return
+
+    setIsUnpublishing(true)
+    awaitingUnpublishRef.current = true
+    unpublish.execute()
+  }, [unpublish])
 
   return (
     <Dialog
@@ -96,7 +124,7 @@ export function UnpublishVersionDialog(props: {
           text: t('unpublish-dialog.action.unpublish'),
           onClick: handleUnpublish,
           tone: 'critical',
-          disabled: isUnpublishing,
+          disabled: isUnpublishing || Boolean(unpublish.disabled),
           loading: isUnpublishing,
         },
       }}

--- a/packages/sanity/src/core/releases/components/dialog/__tests__/DiscardVersionDialog.test.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/__tests__/DiscardVersionDialog.test.tsx
@@ -1,12 +1,21 @@
 import {defineType} from '@sanity/types'
-import {render, waitFor} from '@testing-library/react'
+import {render, screen, waitFor} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
 import {defineConfig} from '../../../../config/defineConfig'
+import {useDocumentOperation} from '../../../../hooks/useDocumentOperation'
+import {useDocumentOperationEvent} from '../../../../hooks/useDocumentOperationEvent'
+import {useTargetDocumentState} from '../../../../hooks/useTargetDocumentState'
 import {DiscardVersionDialog} from '../DiscardVersionDialog'
 
-const {previewSpy} = vi.hoisted(() => ({previewSpy: vi.fn()}))
+const {previewSpy, toastPush} = vi.hoisted(() => ({previewSpy: vi.fn(), toastPush: vi.fn()}))
+
+vi.mock('@sanity/ui', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  useToast: () => ({push: toastPush}),
+}))
 
 // Capture the props the document preview is rendered with so we can assert the
 // perspective the dialog resolves it under.
@@ -18,30 +27,27 @@ vi.mock('../../../../preview/components/Preview', () => ({
 }))
 
 vi.mock('../../../../hooks/useDocumentOperation', () => ({
-  useDocumentOperation: vi.fn(() => ({discardChanges: {execute: vi.fn()}})),
+  useDocumentOperation: vi.fn(),
 }))
 
-// The target document lookup needs the document preview store (mocked away above); these tests
-// only assert the preview perspective, so the target resolves to a ready state with no document
-// (base draft/published pair semantics, no scopeId).
+vi.mock('../../../../hooks/useDocumentOperationEvent', () => ({
+  useDocumentOperationEvent: vi.fn(),
+}))
+
+// The target document lookup needs the document preview store (mocked away above), so it is
+// mocked per test. The default resolves to the base draft/published pair (no scopeId).
 vi.mock('../../../../hooks/useTargetDocumentState', async (importOriginal) => ({
   ...(await importOriginal()),
-  useTargetDocumentState: vi.fn(() => ({
-    status: 'ready',
-    targetDocument: undefined,
-    scopeId: undefined,
-    variant: undefined,
-    publishedSibling: undefined,
-  })),
+  useTargetDocumentState: vi.fn(),
 }))
 
-vi.mock('../../../hooks/useVersionOperations', () => ({
-  useVersionOperations: vi.fn(() => ({discardVersion: vi.fn()})),
-}))
-
-vi.mock('../../../../perspective/usePerspective', () => ({
-  usePerspective: vi.fn(() => ({selectedPerspective: 'drafts'})),
-}))
+const READY_BASE_TARGET = {
+  status: 'ready',
+  targetDocument: undefined,
+  scopeId: undefined,
+  variant: undefined,
+  publishedSibling: undefined,
+} as const
 
 const config = defineConfig({
   projectId: 'test',
@@ -57,28 +63,52 @@ const config = defineConfig({
   },
 })
 
-async function renderDialog(props: {versionId: string; isGoingToUnpublish?: boolean}) {
-  const wrapper = await createTestProvider({config})
-  render(
+const discardExecute = vi.fn()
+
+function mockDiscardOperation(disabled: false | 'NO_CHANGES' = false) {
+  vi.mocked(useDocumentOperation).mockReturnValue({
+    discardChanges: {disabled, execute: discardExecute},
+  } as unknown as ReturnType<typeof useDocumentOperation>)
+}
+
+async function renderDialog(props: {
+  versionId: string
+  isGoingToUnpublish?: boolean
+  onClose?: () => void
+}) {
+  const onClose = props.onClose ?? vi.fn()
+  // A fresh element per render: re-rendering the identical element lets React bail out of the
+  // subtree, so the component would never observe a newly mocked operation event.
+  const element = () => (
     <DiscardVersionDialog
-      onClose={vi.fn()}
+      onClose={onClose}
       versionId={props.versionId}
       documentType="testDoc"
       fromPerspective="drafts"
       isGoingToUnpublish={props.isGoingToUnpublish ?? false}
-    />,
-    {wrapper},
+    />
   )
-  await waitFor(() => expect(previewSpy).toHaveBeenCalled())
+  const wrapper = await createTestProvider({config})
+  const result = render(element(), {wrapper})
+  return {...result, rerender: () => result.rerender(element())}
 }
 
-describe('DiscardVersionDialog preview perspective', () => {
-  beforeEach(() => {
-    previewSpy.mockClear()
-  })
+const CONFIRM_RELEASE = 'discard-version-dialog.title-release'
 
+beforeEach(() => {
+  previewSpy.mockClear()
+  toastPush.mockClear()
+  discardExecute.mockClear()
+  vi.mocked(useDocumentOperation).mockReset()
+  vi.mocked(useDocumentOperationEvent).mockReturnValue(undefined)
+  vi.mocked(useTargetDocumentState).mockReturnValue(READY_BASE_TARGET)
+  mockDiscardOperation()
+})
+
+describe('DiscardVersionDialog preview perspective', () => {
   it('previews a discarded draft under the drafts perspective', async () => {
     await renderDialog({versionId: 'drafts.my-doc'})
+    await waitFor(() => expect(previewSpy).toHaveBeenCalled())
     expect(previewSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({perspectiveStack: ['drafts']}),
     )
@@ -86,6 +116,7 @@ describe('DiscardVersionDialog preview perspective', () => {
 
   it('previews a discarded release version under its release perspective', async () => {
     await renderDialog({versionId: 'versions.rSummer.my-doc'})
+    await waitFor(() => expect(previewSpy).toHaveBeenCalled())
     expect(previewSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({perspectiveStack: ['rSummer']}),
     )
@@ -93,6 +124,129 @@ describe('DiscardVersionDialog preview perspective', () => {
 
   it('previews the published document (empty perspective) when unpublishing', async () => {
     await renderDialog({versionId: 'drafts.my-doc', isGoingToUnpublish: true})
+    await waitFor(() => expect(previewSpy).toHaveBeenCalled())
     expect(previewSpy).toHaveBeenLastCalledWith(expect.objectContaining({perspectiveStack: []}))
+  })
+})
+
+describe('DiscardVersionDialog operation target', () => {
+  it('targets the release encoded in the version id, not the selected perspective', async () => {
+    // A variant of another bundle is selected while the dialog is opened for a release version.
+    vi.mocked(useTargetDocumentState).mockReturnValue({
+      status: 'ready',
+      targetDocument: undefined,
+      scopeId: 'someVariantScope',
+      variant: {_id: 'variant-doc'},
+      publishedSibling: undefined,
+    } as unknown as ReturnType<typeof useTargetDocumentState>)
+
+    await renderDialog({versionId: 'versions.rSummer.my-doc'})
+
+    expect(useDocumentOperation).toHaveBeenCalledWith('my-doc', 'testDoc', 'rSummer')
+  })
+
+  it('follows the selected perspective when discarding a draft', async () => {
+    await renderDialog({versionId: 'drafts.my-doc'})
+
+    expect(useDocumentOperation).toHaveBeenCalledWith('my-doc', 'testDoc', undefined)
+  })
+
+  it('disables confirm while the perspective target is still resolving for a draft', async () => {
+    vi.mocked(useTargetDocumentState).mockReturnValue({status: 'resolving'})
+
+    await renderDialog({versionId: 'drafts.my-doc'})
+
+    expect(screen.getByRole('button', {name: 'discard-version-dialog.title-draft'})).toBeDisabled()
+  })
+
+  it('confirms a release version even while the perspective target is resolving', async () => {
+    vi.mocked(useTargetDocumentState).mockReturnValue({status: 'resolving'})
+
+    await renderDialog({versionId: 'versions.rSummer.my-doc'})
+
+    expect(screen.getByRole('button', {name: CONFIRM_RELEASE})).toBeEnabled()
+  })
+})
+
+describe('DiscardVersionDialog completion', () => {
+  it('does not execute and disables confirm when the operation is disabled', async () => {
+    mockDiscardOperation('NO_CHANGES')
+
+    await renderDialog({versionId: 'versions.rSummer.my-doc'})
+
+    expect(screen.getByRole('button', {name: CONFIRM_RELEASE})).toBeDisabled()
+    expect(discardExecute).not.toHaveBeenCalled()
+  })
+
+  it('stays open until the discard operation reports success', async () => {
+    const onClose = vi.fn()
+    const {rerender} = await renderDialog({versionId: 'versions.rSummer.my-doc', onClose})
+
+    await userEvent.click(screen.getByRole('button', {name: CONFIRM_RELEASE}))
+
+    expect(discardExecute).toHaveBeenCalledTimes(1)
+    expect(onClose).not.toHaveBeenCalled()
+
+    vi.mocked(useDocumentOperationEvent).mockReturnValue({
+      type: 'success',
+      op: 'discardChanges',
+      id: 'my-doc',
+      idPair: {
+        publishedId: 'my-doc',
+        draftId: 'drafts.my-doc',
+        versionId: 'versions.rSummer.my-doc',
+      },
+    })
+    rerender()
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+  })
+
+  it('ignores operation events for another bundle of the same document', async () => {
+    const onClose = vi.fn()
+    const {rerender} = await renderDialog({versionId: 'versions.rSummer.my-doc', onClose})
+
+    await userEvent.click(screen.getByRole('button', {name: CONFIRM_RELEASE}))
+
+    vi.mocked(useDocumentOperationEvent).mockReturnValue({
+      type: 'success',
+      op: 'discardChanges',
+      id: 'my-doc',
+      idPair: {
+        publishedId: 'my-doc',
+        draftId: 'drafts.my-doc',
+        versionId: 'versions.rWinter.my-doc',
+      },
+    })
+    rerender()
+
+    await waitFor(() => expect(screen.getByRole('button', {name: CONFIRM_RELEASE})).toBeDisabled())
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('reports a failed discard instead of closing silently', async () => {
+    const onClose = vi.fn()
+    const {rerender} = await renderDialog({versionId: 'versions.rSummer.my-doc', onClose})
+
+    await userEvent.click(screen.getByRole('button', {name: CONFIRM_RELEASE}))
+    expect(toastPush).not.toHaveBeenCalled()
+
+    vi.mocked(useDocumentOperationEvent).mockReturnValue({
+      type: 'error',
+      op: 'discardChanges',
+      id: 'my-doc',
+      error: new Error('nope'),
+      idPair: {
+        publishedId: 'my-doc',
+        draftId: 'drafts.my-doc',
+        versionId: 'versions.rSummer.my-doc',
+      },
+    })
+    rerender()
+
+    await waitFor(() =>
+      expect(toastPush).toHaveBeenCalledWith(expect.objectContaining({status: 'error'})),
+    )
+    expect(onClose).toHaveBeenCalled()
   })
 })

--- a/packages/sanity/src/core/releases/components/dialog/__tests__/UnpublishVersionDialog.test.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/__tests__/UnpublishVersionDialog.test.tsx
@@ -1,0 +1,182 @@
+import {defineType} from '@sanity/types'
+import {render, screen, waitFor} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {defineConfig} from '../../../../config/defineConfig'
+import {useDocumentOperation} from '../../../../hooks/useDocumentOperation'
+import {useDocumentOperationEvent} from '../../../../hooks/useDocumentOperationEvent'
+import {UnpublishVersionDialog} from '../UnpublishVersionDialog'
+
+const {toastPush} = vi.hoisted(() => ({toastPush: vi.fn()}))
+
+vi.mock('@sanity/ui', async (importOriginal) => ({
+  ...((await importOriginal()) as Record<string, unknown>),
+  useToast: () => ({push: toastPush}),
+}))
+
+vi.mock('../../../../hooks/useDocumentOperation', () => ({
+  useDocumentOperation: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useDocumentOperationEvent', () => ({
+  useDocumentOperationEvent: vi.fn(),
+}))
+
+vi.mock('../../../store/useActiveReleases', () => ({
+  useActiveReleases: vi.fn(() => ({data: []})),
+}))
+
+vi.mock('../../../store/useArchivedReleases', () => ({
+  useArchivedReleases: vi.fn(() => ({data: []})),
+}))
+
+vi.mock('../../../../preview/components/Preview', () => ({
+  Preview: () => null,
+}))
+
+vi.mock('../../../../preview/useValuePreview', () => ({
+  useValuePreview: vi.fn(() => ({value: {title: 'Test document'}})),
+}))
+
+const config = defineConfig({
+  projectId: 'test',
+  dataset: 'test',
+  schema: {
+    types: [
+      defineType({
+        name: 'testDoc',
+        type: 'document',
+        fields: [{name: 'title', type: 'string'}],
+      }),
+    ],
+  },
+})
+
+const VERSION_ID = 'versions.rSummer.my-doc'
+const CONFIRM = 'unpublish-dialog.action.unpublish'
+const unpublishExecute = vi.fn()
+
+function mockUnpublishOperation(disabled: false | 'ALREADY_UNPUBLISHED' = false) {
+  vi.mocked(useDocumentOperation).mockReturnValue({
+    unpublish: {disabled, execute: unpublishExecute},
+  } as unknown as ReturnType<typeof useDocumentOperation>)
+}
+
+function operationEvent(overrides: {type: 'success' | 'error'; versionId?: string}) {
+  return {
+    type: overrides.type,
+    op: 'unpublish',
+    id: 'my-doc',
+    ...(overrides.type === 'error' ? {error: new Error('nope')} : {}),
+    idPair: {
+      publishedId: 'my-doc',
+      draftId: 'drafts.my-doc',
+      versionId: overrides.versionId ?? VERSION_ID,
+    },
+  } as unknown as ReturnType<typeof useDocumentOperationEvent>
+}
+
+async function renderDialog(props: {onClose?: () => void; showCompletionToasts?: boolean} = {}) {
+  const onClose = props.onClose ?? vi.fn()
+  // A fresh element per render: re-rendering the identical element lets React bail out of the
+  // subtree, so the component would never observe a newly mocked operation event.
+  const element = () => (
+    <UnpublishVersionDialog
+      onClose={onClose}
+      documentVersionId={VERSION_ID}
+      documentType="testDoc"
+      showCompletionToasts={props.showCompletionToasts}
+    />
+  )
+  const wrapper = await createTestProvider({config})
+  const result = render(element(), {wrapper})
+  return {...result, rerender: () => result.rerender(element())}
+}
+
+beforeEach(() => {
+  toastPush.mockClear()
+  unpublishExecute.mockClear()
+  vi.mocked(useDocumentOperation).mockReset()
+  vi.mocked(useDocumentOperationEvent).mockReturnValue(undefined)
+  mockUnpublishOperation()
+})
+
+describe('UnpublishVersionDialog', () => {
+  it('uses the release encoded in the version id as the operation target', async () => {
+    await renderDialog()
+
+    expect(useDocumentOperation).toHaveBeenCalledWith('my-doc', 'testDoc', 'rSummer')
+  })
+
+  it('does not execute and disables confirm when the operation is disabled', async () => {
+    mockUnpublishOperation('ALREADY_UNPUBLISHED')
+
+    await renderDialog()
+
+    expect(screen.getByRole('button', {name: CONFIRM})).toBeDisabled()
+    expect(unpublishExecute).not.toHaveBeenCalled()
+  })
+
+  it('stays open until the unpublish operation reports success', async () => {
+    const onClose = vi.fn()
+    const {rerender} = await renderDialog({onClose})
+
+    await userEvent.click(screen.getByRole('button', {name: CONFIRM}))
+
+    expect(unpublishExecute).toHaveBeenCalledTimes(1)
+    expect(onClose).not.toHaveBeenCalled()
+
+    vi.mocked(useDocumentOperationEvent).mockReturnValue(operationEvent({type: 'success'}))
+    rerender()
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+    expect(toastPush).toHaveBeenCalledWith(expect.objectContaining({status: 'success'}))
+  })
+
+  it('ignores operation events for another bundle of the same document', async () => {
+    const onClose = vi.fn()
+    const {rerender} = await renderDialog({onClose})
+
+    await userEvent.click(screen.getByRole('button', {name: CONFIRM}))
+
+    vi.mocked(useDocumentOperationEvent).mockReturnValue(
+      operationEvent({type: 'success', versionId: 'versions.rWinter.my-doc'}),
+    )
+    rerender()
+
+    await waitFor(() => expect(screen.getByRole('button', {name: CONFIRM})).toBeDisabled())
+    expect(onClose).not.toHaveBeenCalled()
+    expect(toastPush).not.toHaveBeenCalled()
+  })
+
+  it('reports a failed unpublish instead of closing silently', async () => {
+    const onClose = vi.fn()
+    const {rerender} = await renderDialog({onClose})
+
+    await userEvent.click(screen.getByRole('button', {name: CONFIRM}))
+    expect(toastPush).not.toHaveBeenCalled()
+
+    vi.mocked(useDocumentOperationEvent).mockReturnValue(operationEvent({type: 'error'}))
+    rerender()
+
+    await waitFor(() =>
+      expect(toastPush).toHaveBeenCalledWith(expect.objectContaining({status: 'error'})),
+    )
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('leaves completion toasts to DocumentOperationResults when opted out', async () => {
+    const onClose = vi.fn()
+    const {rerender} = await renderDialog({onClose, showCompletionToasts: false})
+
+    await userEvent.click(screen.getByRole('button', {name: CONFIRM}))
+
+    vi.mocked(useDocumentOperationEvent).mockReturnValue(operationEvent({type: 'success'}))
+    rerender()
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+    expect(toastPush).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
+++ b/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
@@ -22,7 +22,17 @@ export interface VersionOperationsValue {
     documentId: string,
     options?: CreateVersionOptions,
   ) => Promise<void>
+  /**
+   * Prefer `useDocumentOperation(publishedId, type, releaseId).discardChanges`, which routes
+   * release versions through the same operation pipeline as draft and published edits. Kept for
+   * backwards compatibility; no studio code calls it any more.
+   */
   discardVersion: (releaseId: string, documentId: string) => Promise<SingleActionResult>
+  /**
+   * Prefer `useDocumentOperation(publishedId, type, releaseId).unpublish`, which routes release
+   * versions through the same operation pipeline as draft and published edits. Kept for
+   * backwards compatibility; no studio code calls it any more.
+   */
   unpublishVersion: (documentId: string) => Promise<SingleActionResult>
   revertUnpublishVersion: (documentId: string) => Promise<SingleActionResult>
 }

--- a/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
@@ -96,6 +96,9 @@ export const useUnpublishVersionAction: DocumentActionComponent = (
             documentVersionId={version._id}
             documentType={type}
             onClose={() => setDialogOpen(false)}
+            // In the document pane `DocumentOperationResults` already toasts the unpublish
+            // operation events this dialog would report.
+            showCompletionToasts={false}
           />
         ),
       },

--- a/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
+++ b/packages/sanity/src/core/releases/store/createReleaseOperationStore.ts
@@ -50,11 +50,21 @@ export interface ReleaseOperationsStore {
     documentId: string,
     opts?: BaseActionOptions,
   ) => Promise<SingleActionResult>
+  /**
+   * Prefer `useDocumentOperation(publishedId, type, releaseId).discardChanges`, which routes
+   * release versions through the same operation pipeline as draft and published edits. Kept for
+   * backwards compatibility; no studio code calls it any more.
+   */
   discardVersion: (
     releaseId: string,
     documentId: string,
     opts?: BaseActionOptions,
   ) => Promise<SingleActionResult>
+  /**
+   * Prefer `useDocumentOperation(publishedId, type, releaseId).unpublish`, which routes release
+   * versions through the same operation pipeline as draft and published edits. Kept for
+   * backwards compatibility; no studio code calls it any more.
+   */
   unpublishVersion: (documentId: string, opts?: BaseActionOptions) => Promise<SingleActionResult>
   revertUnpublishVersion: (
     documentId: string,

--- a/packages/sanity/src/core/store/document/document-pair/operations/types.ts
+++ b/packages/sanity/src/core/store/document/document-pair/operations/types.ts
@@ -47,7 +47,10 @@ export interface OperationsAPI {
     | Operation<[], 'NO_CHANGES' | 'NOT_PUBLISHED' | 'TARGET_NOT_FOUND'>
     | GuardedOperation
   unpublish:
-    | Operation<[], 'LIVE_EDIT_ENABLED' | 'NOT_PUBLISHED' | 'TARGET_NOT_FOUND'>
+    | Operation<
+        [],
+        'LIVE_EDIT_ENABLED' | 'NOT_PUBLISHED' | 'ALREADY_UNPUBLISHED' | 'TARGET_NOT_FOUND'
+      >
     | GuardedOperation
   duplicate:
     | Operation<

--- a/packages/sanity/src/core/store/document/document-pair/serverOperations/unpublish.test.ts
+++ b/packages/sanity/src/core/store/document/document-pair/serverOperations/unpublish.test.ts
@@ -34,12 +34,34 @@ function variantVersion(bundleId: 'drafts' | 'rSummer' | undefined): SanityDocum
   }
 }
 
+const BASE_PAIR = {draftId: 'drafts.my-id', publishedId: 'my-id'}
+const RELEASE_PAIR = {...BASE_PAIR, versionId: 'versions.rSummer.my-id'}
+
+/** A plain (non-variant) release version snapshot. */
+function releaseVersion(options: {markedForUnpublish?: boolean} = {}): SanityDocument {
+  return {
+    _id: RELEASE_PAIR.versionId,
+    _type: 'example',
+    _rev: 'releaseRev',
+    _createdAt: '2021-09-14T22:48:02.303Z',
+    _updatedAt: '2021-09-14T22:48:02.303Z',
+    _system: {
+      bundleId: 'rSummer',
+      release: {_ref: '_.releases.rSummer', _weak: true},
+      group: {_ref: 'my-id', _weak: true},
+      scopeId: 'rSummer',
+      ...(options.markedForUnpublish ? {delete: true} : {}),
+    },
+  }
+}
+
 describe('unpublish', () => {
   describe('disabled', () => {
     it('returns NOT_PUBLISHED when there is no published document', () => {
       expect(
         unpublish.disabled({
           typeName: 'blah',
+          idPair: BASE_PAIR,
           snapshots: {draft: {} as SanityDocument, published: null},
         } as unknown as OperationArgs),
       ).toBe('NOT_PUBLISHED')
@@ -71,6 +93,44 @@ describe('unpublish', () => {
           snapshots: {version: variantVersion('drafts'), published: {} as SanityDocument},
         } as unknown as OperationArgs),
       ).toBe('NOT_PUBLISHED')
+    })
+
+    it('is enabled for a release version of a published document', () => {
+      expect(
+        unpublish.disabled({
+          typeName: 'blah',
+          idPair: RELEASE_PAIR,
+          snapshots: {
+            draft: null,
+            published: {} as SanityDocument,
+            version: releaseVersion(),
+          },
+        } as unknown as OperationArgs),
+      ).toBe(false)
+    })
+
+    it('returns NOT_PUBLISHED for a release version with nothing published to unpublish', () => {
+      expect(
+        unpublish.disabled({
+          typeName: 'blah',
+          idPair: RELEASE_PAIR,
+          snapshots: {draft: null, published: null, version: releaseVersion()},
+        } as unknown as OperationArgs),
+      ).toBe('NOT_PUBLISHED')
+    })
+
+    it('returns ALREADY_UNPUBLISHED for a release version already marked for unpublish', () => {
+      expect(
+        unpublish.disabled({
+          typeName: 'blah',
+          idPair: RELEASE_PAIR,
+          snapshots: {
+            draft: null,
+            published: {} as SanityDocument,
+            version: releaseVersion({markedForUnpublish: true}),
+          },
+        } as unknown as OperationArgs),
+      ).toBe('ALREADY_UNPUBLISHED')
     })
   })
 
@@ -168,6 +228,31 @@ describe('unpublish', () => {
           options: {tag: 'document.unpublish', skipCrossDatasetReferenceValidation: true},
         },
       ])
+    })
+
+    it('routes a release version to the version unpublish action', () => {
+      const client = createMockSanityClient()
+
+      unpublish.execute({
+        client,
+        idPair: RELEASE_PAIR,
+        snapshots: {published: {} as SanityDocument, version: releaseVersion()},
+      } as unknown as OperationArgs)
+
+      expect(client.$log.observable.action).toEqual([
+        {
+          actions: {
+            actionType: 'sanity.action.document.version.unpublish',
+            versionId: 'versions.rSummer.my-id',
+            publishedId: 'my-id',
+          },
+          options: {tag: 'document.unpublish', skipCrossDatasetReferenceValidation: true},
+        },
+      ])
+      // The release unpublish must not write into the base draft: including a `draftId` here
+      // would restore release content into `drafts.my-id`.
+      // @ts-expect-error - $log is not typed
+      expect(client.$log.observable.action[0].actions.draftId).toBeUndefined()
     })
   })
 })

--- a/packages/sanity/src/core/store/document/document-pair/serverOperations/unpublish.ts
+++ b/packages/sanity/src/core/store/document/document-pair/serverOperations/unpublish.ts
@@ -1,3 +1,4 @@
+import {isGoingToUnpublish} from '../../../../releases/util/isGoingToUnpublish'
 import {getVariantVersionInfo} from '../../../../variants/documents/getVariantVersionInfo'
 import {type OperationImpl} from '../operations/types'
 import {actionsApiClient} from '../utils/actionsApiClient'
@@ -5,10 +6,10 @@ import {assertNotVariantVersion} from '../utils/assertNotVariantVersion'
 import {isLiveEditEnabled} from '../utils/isLiveEditEnabled'
 import {variantActionsApiClient} from '../utils/variantActionsApiClient'
 
-type DisabledReason = 'LIVE_EDIT_ENABLED' | 'NOT_PUBLISHED'
+type DisabledReason = 'LIVE_EDIT_ENABLED' | 'NOT_PUBLISHED' | 'ALREADY_UNPUBLISHED'
 
 export const unpublish: OperationImpl<[], DisabledReason> = {
-  disabled: ({schema, snapshots, typeName}) => {
+  disabled: ({schema, snapshots, typeName, idPair}) => {
     if (isLiveEditEnabled(schema, typeName)) {
       return 'LIVE_EDIT_ENABLED'
     }
@@ -20,6 +21,13 @@ export const unpublish: OperationImpl<[], DisabledReason> = {
       // - a release-scoped variant, which is soft-unpublished as part of its release
       // A drafts-scoped variant has nothing published in its slot to unpublish.
       return variantVersion.bundleId !== 'drafts' ? false : 'NOT_PUBLISHED'
+    }
+
+    // A release version already carrying the unpublish marker would be a no-op: the release
+    // publish will remove the published document either way. Reverting it is a separate
+    // operation (`revertUnpublishVersion`), not a repeated unpublish.
+    if (idPair.versionId && snapshots.version && isGoingToUnpublish(snapshots.version)) {
+      return 'ALREADY_UNPUBLISHED'
     }
 
     return snapshots.published ? false : 'NOT_PUBLISHED'
@@ -51,6 +59,24 @@ export const unpublish: OperationImpl<[], DisabledReason> = {
     }
 
     assertNotVariantVersion(snapshots.version, 'unpublish')
+
+    if (idPair.versionId) {
+      // Unpublishing inside a release is a soft unpublish: the backend marks the release version
+      // with `_system.delete: true` and removes the published document when the release is
+      // published. The base draft is deliberately absent from the payload — unlike the base
+      // unpublish below, nothing is written back into `drafts.<id>`.
+      return actionsApiClient(client, idPair).observable.action(
+        {
+          actionType: 'sanity.action.document.version.unpublish',
+          versionId: idPair.versionId,
+          publishedId: idPair.publishedId,
+        },
+        {
+          tag: 'document.unpublish',
+          skipCrossDatasetReferenceValidation: true,
+        },
+      )
+    }
 
     return actionsApiClient(client, idPair).observable.action(
       {

--- a/packages/sanity/src/structure/documentActions/UnpublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/UnpublishAction.tsx
@@ -18,6 +18,7 @@ import {structureLocaleNamespace} from '../i18n'
 import {useDocumentPane} from '../panes/document/useDocumentPane'
 
 const DISABLED_REASON_KEY = {
+  ALREADY_UNPUBLISHED: 'action.unpublish.disabled.already-unpublished',
   NOT_PUBLISHED: 'action.unpublish.disabled.not-published',
   NOT_READY: 'action.unpublish.disabled.not-ready',
   LIVE_EDIT_ENABLED: 'action.unpublish.disabled.live-edit-enabled',

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -117,6 +117,8 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** Default tooltip for the action */
   'action.restore.tooltip': 'Restore to this revision',
 
+  /** Tooltip when action is disabled because the version is already marked for unpublishing */
+  'action.unpublish.disabled.already-unpublished': 'This document is already set to be unpublished',
   /** Tooltip when action is disabled because the document is not already published */
   'action.unpublish.disabled.not-published': 'This document is not published',
   /** Tooltip when action is disabled because the operation is not ready   */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Release version discard and unpublish were duplicated: the dialogs called `useVersionOperations`, which wrapped `client.discardVersion` / `client.unpublishVersion`, while the document operation pipeline already had (or could have) equivalent server actions via `useDocumentOperation`. That left release mutations outside the pipeline that owns consistency, disabled states and operation events for every other edit.

Both dialogs now go through `useDocumentOperation`, targeting **the bundle encoded in the version id** rather than the globally selected perspective. That distinction matters: these dialogs are opened from version chips and the release tool's document table, where the selected perspective is frequently a different release — targeting the perspective would discard or unpublish the wrong document.

`serverOperations/unpublish` gains a release-version branch because unpublishing inside a release uses `sanity.action.document.version.unpublish` (a soft unpublish that marks the version with `_system.delete`), not the draft/published unpublish action. It also reports `ALREADY_UNPUBLISHED` for versions already carrying that marker.

**Why not** keep the version paths on `useVersionOperations`: they bypassed operation events, so the release tool could not distinguish "in flight" from "done", and the studio had two ways to mutate a release version. **Why not** also enforce `disabled` inside `wrap()` in `operations/helpers.ts` (discussed in review): `main` has since standardised store-level guards that *throw* (`GUARDED`, `TARGET_NOT_FOUND_OPERATIONS`), so a silent no-op would contradict that convention, and it would change behaviour for every operation including `patch` on each keystroke. Left as the separate follow-up it was described as.

`discardVersion` / `unpublishVersion` remain on `useVersionOperations` and `createReleaseOperationStore` for external consumers — no studio code calls them any more. They carry a doc comment pointing at the replacement rather than `@deprecated`, because the tag makes `no-deprecated` fail on the store's own implementation, its mocks and existing tests.

## What to review

- `DiscardVersionDialog.tsx` — target derived from the version id; only the draft case follows the selected perspective (so a selected variant still discards the variant draft) and waits for that lookup
- Both dialogs — confirm respects `disabled`, and the dialog stays open with a spinner until the operation reports success or failure instead of closing optimistically
- `serverOperations/unpublish.ts` — the release-version branch sits after the variant branch and the `assertNotVariantVersion` tripwire, so variant routing is unchanged
- `UnpublishVersionDialog.tsx` — `showCompletionToasts`, so the document pane leaves toasts to `DocumentOperationResults` instead of duplicating them
- `UnpublishAction.tsx` / `structure/i18n/resources.ts` — new disabled reason added to the tooltip map

## Testing

`pnpm test` — 585 files, 5489 tests, no failures. `pnpm check:oxlint` and `pnpm check:format` clean.

New/updated coverage:

```bash
pnpm vitest run --project=sanity \
  packages/sanity/src/core/releases/components/dialog \
  packages/sanity/src/core/store/document/document-pair/serverOperations
```

- `DiscardVersionDialog.test.tsx` — regression test that a version id wins over a conflicting selected perspective, plus disabled-guard, success/failure and cross-bundle event isolation
- `UnpublishVersionDialog.test.tsx` — target derivation, disabled guard, completion handling, toast opt-out
- `unpublish.test.ts` — release-version disabled states and the version action payload, asserting no `draftId` is sent

## Notes for release

Release version discard and unpublish now run through the same document operation pipeline as draft and published edits. The dialogs stay open until the operation completes and surface a toast when it fails, instead of closing immediately. Discarding or unpublishing a release version from a version chip or the release tool now always targets the release shown in the dialog, even when a different perspective is selected.

`useVersionOperations().discardVersion` / `.unpublishVersion` still work but are superseded by `useDocumentOperation(publishedId, type, releaseId).discardChanges` / `.unpublish`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aaa400f4-6a76-4a26-98fc-95f1e8b30143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aaa400f4-6a76-4a26-98fc-95f1e8b30143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

