### PR TITLE
fix(structure): allow all document actions when a Canvas-linked document is editable

### DIFF
--- a/packages/sanity/src/structure/DocumentActionsProvider.tsx
+++ b/packages/sanity/src/structure/DocumentActionsProvider.tsx
@@ -70,10 +70,11 @@ export function DocumentActionsProvider(props: {children: React.ReactNode}) {
 }
 
 /**
- * This is a list of the actions that are supported when a document is linked to Canvas.
- * Custom actions and actions that are not supported by Canvas will be disabled and will include a tooltip explaining that the action is not supported.
+ * The actions that remain available while a document is locked by Canvas (i.e. not editable in
+ * Studio). Custom actions and other unsupported actions are disabled with a tooltip explaining why.
+ * When the document is linked but editable, no actions are disabled.
  */
-const SUPPORTED_LINKED_TO_CANVAS_ACTIONS: DocumentActionComponent['action'][] = [
+const SUPPORTED_CANVAS_LOCKED_ACTIONS: DocumentActionComponent['action'][] = [
   'delete',
   'duplicate',
   'publish',
@@ -97,14 +98,14 @@ function ActionsGuardWrapper(props: ActionsGuardWrapperProps) {
   const {states, children, actionProps} = props
   const {t} = useTranslation(structureLocaleNamespace)
 
-  const {isLinked} = useCanvasCompanionDoc(getDocumentIdForCanvasLink(actionProps))
+  const {isLockedByCanvas} = useCanvasCompanionDoc(getDocumentIdForCanvasLink(actionProps))
 
   return (
     <DocumentActionsStateContext.Provider
       value={
-        isLinked
+        isLockedByCanvas
           ? states.map((s) => {
-              if (!s.action || !SUPPORTED_LINKED_TO_CANVAS_ACTIONS.includes(s.action)) {
+              if (!s.action || !SUPPORTED_CANVAS_LOCKED_ACTIONS.includes(s.action)) {
                 return {
                   ...s,
                   disabled: true,


### PR DESCRIPTION
### Description

Custom (and other non-derived) document actions were disabled for **any** document linked to Canvas, showing the tooltip _"Some document actions are disabled for documents linked to Canvas."_ — even when the document had been unlocked and is fully editable in Studio.

The unlock feature (#11421, _"enable editing canvas documents"_) introduced `isStudioDocumentEditable` / `isLockedByCanvas` and wired it into the form read-only logic and the Canvas banner, but `DocumentActionsProvider` was left gating on `isLinked`. As a result, an editable Canvas-linked document had a fully editable form yet all its custom actions were disabled.

This gates the action guard on `isLockedByCanvas` instead of `isLinked`, matching every other Canvas consumer (`useDocumentForm`, `CanvasLinkedBanner`):

- **linked + locked** → restricted action set only (unchanged)
- **linked + editable (unlocked)** → all actions available (the fix)
- **not linked** → all actions available (unchanged)

Fixes [EDEX-1701](https://linear.app/sanity/issue/EDEX-1701/custom-document-actions-are-disabled-for-canvas-linked-documents).

### What to review

- `packages/sanity/src/structure/DocumentActionsProvider.tsx` — `ActionsGuardWrapper` now reads `isLockedByCanvas`. The local constant was renamed `SUPPORTED_LINKED_TO_CANVAS_ACTIONS` → `SUPPORTED_CANVAS_LOCKED_ACTIONS` to reflect that it lists the actions permitted while a document is *locked*, not merely linked.
- Repro: link a document to Canvas, register a custom document action, then unlock the document for editing in Studio. Before: the custom action is disabled with the Canvas tooltip. After: it's available.

### Testing

Verified via `tsgo` typecheck of the `sanity` package and `oxlint` (both clean). No dedicated unit test was added: `DocumentActionsProvider` has no existing test harness and exercising it requires mocking `useDocumentPane`, `GetHookCollectionState`, and the Canvas companion-doc store; the change is a one-line predicate swap onto an already-tested signal (`isLockedByCanvas`).

### Notes for release

Fixed custom document actions being incorrectly disabled for Canvas-linked documents that are editable in Studio.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single predicate change in document action UI; locked Canvas docs keep the same restricted action set.
> 
> **Overview**
> **Document action gating** in `DocumentActionsProvider` now follows **Canvas lock state** instead of mere Canvas linkage, so custom and other non-whitelisted actions stay enabled when a linked document has been unlocked for Studio editing.
> 
> `ActionsGuardWrapper` switches from `isLinked` to **`isLockedByCanvas`** (same signal as the form read-only logic and Canvas banner). The allowlist constant is renamed to **`SUPPORTED_CANVAS_LOCKED_ACTIONS`** to reflect that restrictions apply only while the document is locked, not for every linked document.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52ff6cb917f116182df92c22f128e4bba889b267. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->