### PR TITLE
chore(dev): perf bench followups

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,7 +2,7 @@ name: Studio Bench
 permissions: {}
 
 # Initial rollout is label-gated: PR jobs only run when the PR carries the
-# `perf-bench` label. Flipping to all code-change PRs later = replacing the
+# `trigger:perf-bench` label. Flipping to all code-change PRs later = replacing the
 # label condition with the detect-code-changes gate (already wired below).
 on:
   pull_request:
@@ -16,6 +16,11 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
     inputs:
+      run_suite:
+        description: "Run the full absolute-mode suite against main and store it (same as the daily cron)"
+        required: false
+        type: boolean
+        default: true
       self_test:
         description: "Compare the build against itself (harness self-test)"
         required: false
@@ -27,11 +32,11 @@ on:
 # a unique group (no cancellation). Adding an unrelated label must not cancel
 # an in-flight bench run (the new run's jobs all skip via their label guards,
 # which would leave no comment and no red check), so only cancel when the
-# trigger is a real bench trigger: any non-label event, or the `perf-bench`
-# label itself.
+# trigger is a real bench trigger: any non-label event, or the
+# `trigger:perf-bench` label itself.
 concurrency:
   group: bench-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event.action != 'labeled' || github.event.label.name == 'perf-bench' }}
+  cancel-in-progress: ${{ github.event.action != 'labeled' || github.event.label.name == 'trigger:perf-bench' }}
 
 jobs:
   build:
@@ -39,8 +44,8 @@ jobs:
     # the whole suite (the label set still gates via contains())
     if: >-
       (github.event_name == 'pull_request' &&
-       contains(github.event.pull_request.labels.*.name, 'perf-bench') &&
-       (github.event.action != 'labeled' || github.event.label.name == 'perf-bench')) ||
+       contains(github.event.pull_request.labels.*.name, 'trigger:perf-bench') &&
+       (github.event.action != 'labeled' || github.event.label.name == 'trigger:perf-bench')) ||
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule'
     runs-on: ubuntu-8core
@@ -83,8 +88,8 @@ jobs:
   build-reference:
     if: >-
       github.event_name == 'pull_request' &&
-      contains(github.event.pull_request.labels.*.name, 'perf-bench') &&
-      (github.event.action != 'labeled' || github.event.label.name == 'perf-bench')
+      contains(github.event.pull_request.labels.*.name, 'trigger:perf-bench') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'trigger:perf-bench')
     runs-on: ubuntu-8core
     timeout-minutes: 25
     permissions:
@@ -401,7 +406,7 @@ jobs:
   # trends dashboard's branch comparison has real data. Separate from `report`
   # so the metrics write token is never present in the write-scoped job that
   # runs PR-authored report code. Same-repo PRs only: fork PRs receive no
-  # secrets, and the `perf-bench` label is maintainer-applied (triage-gated).
+  # secrets, and the `trigger:perf-bench` label is maintainer-applied (triage-gated).
   store-pr:
     needs: [build-reference, report]
     if: >-
@@ -415,7 +420,7 @@ jobs:
       contents: read
     steps:
       # Deliberately check out BASE-branch code, not the PR merge commit: this
-      # job holds BENCH_METRICS_WRITE_TOKEN, and the perf-bench label persists
+      # job holds BENCH_METRICS_WRITE_TOKEN, and the trigger:perf-bench label persists
       # across pushes — checking out PR code would let any later push on a
       # labeled PR run arbitrary code with the token. The PR's benchmark
       # output is consumed purely as data via the artifact below. Do not
@@ -517,7 +522,12 @@ jobs:
     # Daily absolute-mode run against main HEAD, stored to the studio-metrics
     # project for time-series/drift tracking. Fixed session counts -
     # comparability over speed (no dynamic stopping shortcut across days).
-    if: github.event_name == 'schedule' && github.event.schedule == '0 5 * * *'
+    # Also the on-demand "run the suite" path: a workflow_dispatch with
+    # run_suite triggers the same full run + store (e.g. to backfill a point or
+    # verify the store path without waiting for the 5am cron).
+    if: >-
+      (github.event_name == 'schedule' && github.event.schedule == '0 5 * * *') ||
+      (github.event_name == 'workflow_dispatch' && inputs.run_suite)
     needs: [build]
     runs-on: ubuntu-8core
     timeout-minutes: 90

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -251,8 +251,15 @@ jobs:
       fail-fast: false
       matrix:
         # One shard per scenario (mirrors bench-interaction): wall-clock =
-        # one scenario's samples instead of both sequentially
-        scenario: [singleString, syntheticLarge]
+        # one scenario's samples instead of both sequentially. Sessions are
+        # per-scenario: syntheticLarge takes ~55s per sample to become editable
+        # and runs both load conditions on both sides, so 8 sessions blows the
+        # 20-minute timeout — give it fewer (still enough for a p50).
+        include:
+          - scenario: singleString
+            sessions: 8
+          - scenario: syntheticLarge
+            sessions: 3
     steps:
       - uses: actions/checkout@v7
         with:
@@ -302,6 +309,7 @@ jobs:
       - name: Run pageLoad benchmark
         env:
           SCENARIO: ${{ matrix.scenario }}
+          SESSIONS: ${{ matrix.sessions }}
           COMPARISON: ${{ needs.build-reference.outputs.comparison }}
           BENCH_MERGE_BASE: ${{ needs.build-reference.outputs.merge_base }}
         run: |
@@ -311,7 +319,7 @@ jobs:
           fi
           # shellcheck disable=SC2086
           pnpm bench run --mode pageload --scenario "$SCENARIO" \
-            --sessions 8 \
+            --sessions "$SESSIONS" \
             --json-out "$GITHUB_WORKSPACE/perf/bench/results/bench-results__pageload-$SCENARIO.json" \
             $REFERENCE_ARGS
 

--- a/perf/bench/README.md
+++ b/perf/bench/README.md
@@ -97,12 +97,12 @@ Useful `bench run` flags: `--headed`, `--throttle 1` (disable CPU throttle), `--
 
 ## CI (`.github/workflows/bench.yml`)
 
-- **Label-gated during burn-in**: PR jobs run only with the `perf-bench` label. The all-code-PRs gate is wired and one condition away.
+- **Label-gated during burn-in**: PR jobs run only with the `trigger:perf-bench` label. The all-code-PRs gate is wired and one condition away.
 - **Reference build**: `git worktree` at the merge-base with HEAD's committed `perf/bench/` tree checked out over it — harness and scenarios identical on both sides, only `packages/*` differs. Cached by merge-base sha; falls back to absolute mode (with a warning in the report) if the build fails or the merge-base predates the suite.
 - **Sharding**: one job per scenario + one pageLoad job; wall-clock = build + slowest scenario. Budgets are caps — the stopping rule exits early when the CI converges.
 - **PR comment**: always posted/updated in place (`bench-report` tag). Non-gating during burn-in.
 - **Self-test** (weekly cron / `workflow_dispatch` with `self_test`): compares a build against itself with `--fail-on-verdict` — any non-neutral metric is a harness bug, not a product change.
-- **track-main** (daily cron): absolute-mode run with fixed session counts + soak, stored as a `benchRun` document in the studio-metrics project (`c1zuxvqn`/`bench`) via `BENCH_METRICS_WRITE_TOKEN` — the only real secret in the suite.
+- **track-main** (daily cron, or `workflow_dispatch` with `run_suite`): absolute-mode run with fixed session counts + soak, stored as a `benchRun` document in the studio-metrics project (`c1zuxvqn`/`bench`) via `BENCH_METRICS_WRITE_TOKEN` — the only real secret in the suite. The dispatch path lets a maintainer run the full suite + store on demand (backfill a point, or verify the store path) without waiting for the 5am cron.
 
 ## Flake resistance rules
 

--- a/perf/bench/stats/__tests__/stats.test.ts
+++ b/perf/bench/stats/__tests__/stats.test.ts
@@ -55,6 +55,16 @@ describe('quantile (type-7)', () => {
     expect(() => quantile([Infinity], 0.5)).toThrow(/non-finite/)
     expect(() => median([2, -Infinity])).toThrow(/non-finite/)
   })
+
+  it('throws on an out-of-range or non-finite p (a caller bug, not silent NaN)', () => {
+    expect(() => quantile([1, 2, 3], -0.1)).toThrow(/in \[0, 1\]/)
+    expect(() => quantile([1, 2, 3], 1.5)).toThrow(/in \[0, 1\]/)
+    expect(() => quantile([1, 2, 3], NaN)).toThrow(/in \[0, 1\]/)
+    expect(() => quantile([1, 2, 3], Infinity)).toThrow(/in \[0, 1\]/)
+    // The boundaries are valid (min/max)
+    expect(() => quantile([1, 2, 3], 0)).not.toThrow()
+    expect(() => quantile([1, 2, 3], 1)).not.toThrow()
+  })
 })
 
 describe('mulberry32', () => {

--- a/perf/bench/stats/quantiles.ts
+++ b/perf/bench/stats/quantiles.ts
@@ -7,6 +7,12 @@ export function quantile(values: number[], p: number): number {
   if (values.length === 0) {
     throw new Error('Cannot compute quantile of empty sample')
   }
+  // An out-of-range or non-finite p indexes outside the sorted array and
+  // returns NaN/undefined, which then flows into gating — fail loudly instead
+  // of mis-gating a PR on a caller bug (p must be a probability in [0, 1])
+  if (!Number.isFinite(p) || p < 0 || p > 1) {
+    throw new Error(`quantile p must be a finite number in [0, 1], got ${p}`)
+  }
   // NaN poisons every `>` comparison downstream (gate() would silently
   // report `neutral` for a real regression) — a non-finite sample is a
   // collector bug and must fail loudly here, not gate a PR green


### PR DESCRIPTION
### Description

Two follow-ups on the Studio Bench suite (#13442), both in `.github/workflows/bench.yml`:

- **Rename the trigger label `perf-bench` → `trigger:perf-bench`.** The label is an action trigger (it gates whether the bench jobs run on a PR), not a topic/area tag — the `trigger:` prefix says so and won't be confused with a descriptive label. Renamed across the job `if:` guards, the concurrency `cancel-in-progress` condition, the labeled-event guards, and the docs.
- **Add an on-demand way to run the full suite.** `workflow_dispatch` previously only offered the harness self-test; a plain dispatch built the studio but measured nothing. A new `run_suite` input (default true) triggers the same `track-main` job the daily cron uses — full absolute-mode run + store — so a maintainer can backfill a data point or verify the store path without waiting for 05:00 UTC.

### What to review

- `.github/workflows/bench.yml` — the label expression changes (3 forms: `contains(...labels...)`, `label.name ==`, and prose), and the `track-main` `if:` now also fires on `workflow_dispatch && inputs.run_suite`.
- `perf/bench/README.md` — CI section updated for both.


### Notes for release

N/A – Internal CI tooling only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal CI and bench harness changes only; label rename requires updating existing PR labels manually, and default `run_suite: true` means a plain workflow_dispatch may run the long track-main job unless toggled off.
> 
> **Overview**
> **Studio Bench CI** renames the PR trigger label from `perf-bench` to **`trigger:perf-bench`** everywhere (job guards, concurrency cancel rule, store-pr comments, README).
> 
> **On-demand full suite:** `workflow_dispatch` gains a **`run_suite`** input (default true) so **`track-main`** runs on manual dispatch as well as the daily 05:00 cron—same absolute-mode run + metrics store for backfill or store-path checks.
> 
> **PageLoad sharding** no longer uses a fixed `--sessions 8` for every scenario: the matrix sets **8 sessions for `singleString`** and **3 for `syntheticLarge`** so the heavy scenario stays within the 20-minute job timeout while still yielding a p50.
> 
> **Stats:** `quantile()` now **throws** if `p` is non-finite or outside **[0, 1]**, avoiding silent NaN that could mis-gate PRs; unit tests cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ec6d1df38d1fed6d2f4828ea1b30d5ebbe5d721. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->