### PR TITLE
fix(core): clear scheduled draft perspective after deleting scheduled draft

### DIFF
--- a/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
+++ b/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
@@ -5,6 +5,7 @@ import {type MouseEvent, type RefObject, useCallback, useRef, useState} from 're
 import {useTranslation} from '../../i18n'
 import {type TargetPerspective} from '../../perspective/types'
 import {useSingleDocRelease} from '../../singleDocRelease/context/SingleDocReleaseProvider'
+import {useClearScheduledDraftPerspectiveOnDelete} from '../../singleDocRelease/hooks/useClearScheduledDraftPerspectiveOnDelete'
 import {
   useScheduledDraftMenuActions,
   type UseScheduledDraftMenuActionsReturn,
@@ -173,12 +174,15 @@ export function useVersionContextMenu(
     onSetScheduledDraftPerspective(getReleaseIdFromReleaseDocumentId(release._id))
   }, [release, onSetScheduledDraftPerspective])
 
+  const onDeleteComplete = useClearScheduledDraftPerspectiveOnDelete(release)
+
   const scheduledDraftMenuActions = useScheduledDraftMenuActions({
     release,
     documentType,
     documentId,
     disabled,
     onActionComplete: handleEditScheduleComplete,
+    onDeleteComplete,
   })
 
   const sourceReleasePerspective =

--- a/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.test.tsx
@@ -1,11 +1,9 @@
 import {render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
-import {PerspectiveContext, SingleDocReleaseContext} from 'sanity/_singletons'
 import {beforeEach, describe, expect, it, type MockedFunction, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../test/testUtils/TestProvider'
 import {useSchema} from '../../hooks'
-import {perspectiveContextValueMock} from '../../perspective/__mocks__/usePerspective.mock'
 import {scheduledRelease} from '../../releases/__fixtures__/release.fixture'
 import {useDocumentVersions} from '../../releases/hooks/useDocumentVersions'
 import {
@@ -265,67 +263,56 @@ describe('DeleteScheduledDraftDialog', () => {
     })
   })
 
-  describe('scheduled draft perspective cleanup', () => {
-    const mockOnSetScheduledDraftPerspective = vi.fn()
-    const singleDocReleaseContextValue = {
-      onSetScheduledDraftPerspective: mockOnSetScheduledDraftPerspective,
-    }
-
-    const renderWithPerspective = (selectedPerspectiveName: string | undefined) => {
+  describe('onDeleteComplete callback', () => {
+    it('calls onDeleteComplete after a successful delete', async () => {
+      const mockOnDeleteComplete = vi.fn()
       mockUseDocumentVersions.mockReturnValue(createMockDocumentVersions(mockDraftDocument))
-      const perspectiveContextValue = {...perspectiveContextValueMock, selectedPerspectiveName}
 
-      return render(
+      render(
         <TestProvider>
-          <PerspectiveContext.Provider value={perspectiveContextValue}>
-            <SingleDocReleaseContext.Provider value={singleDocReleaseContextValue}>
-              <DeleteScheduledDraftDialog
-                documentId="article-123"
-                documentType="article"
-                release={scheduledRelease}
-                onClose={mockOnClose}
-              />
-            </SingleDocReleaseContext.Provider>
-          </PerspectiveContext.Provider>
+          <DeleteScheduledDraftDialog
+            documentId="article-123"
+            documentType="article"
+            release={scheduledRelease}
+            onClose={mockOnClose}
+            onDeleteComplete={mockOnDeleteComplete}
+          />
         </TestProvider>,
       )
-    }
-
-    it('clears the scheduled draft perspective after deleting while viewing the scheduled draft', async () => {
-      // `rScheduled` is the release id of the `scheduledRelease` fixture
-      renderWithPerspective('rScheduled')
 
       await userEvent.click(screen.getByText('Yes, delete schedule'))
 
       await waitFor(() => {
         expect(useScheduleDraftOperationsMockReturn.deleteScheduledDraft).toHaveBeenCalled()
       })
-      expect(mockOnSetScheduledDraftPerspective).toHaveBeenCalledWith('')
+      expect(mockOnDeleteComplete).toHaveBeenCalledOnce()
     })
 
-    it('does not clear the perspective when not viewing the scheduled draft', async () => {
-      renderWithPerspective(undefined)
-
-      await userEvent.click(screen.getByText('Yes, delete schedule'))
-
-      await waitFor(() => {
-        expect(useScheduleDraftOperationsMockReturn.deleteScheduledDraft).toHaveBeenCalled()
-      })
-      expect(mockOnSetScheduledDraftPerspective).not.toHaveBeenCalled()
-    })
-
-    it('does not clear the perspective when the delete operation fails', async () => {
+    it('does not call onDeleteComplete when the delete operation fails', async () => {
+      const mockOnDeleteComplete = vi.fn()
       useScheduleDraftOperationsMockReturn.deleteScheduledDraft.mockRejectedValue(
         new Error('delete failed'),
       )
-      renderWithPerspective('rScheduled')
+      mockUseDocumentVersions.mockReturnValue(createMockDocumentVersions(mockDraftDocument))
+
+      render(
+        <TestProvider>
+          <DeleteScheduledDraftDialog
+            documentId="article-123"
+            documentType="article"
+            release={scheduledRelease}
+            onClose={mockOnClose}
+            onDeleteComplete={mockOnDeleteComplete}
+          />
+        </TestProvider>,
+      )
 
       await userEvent.click(screen.getByText('Yes, delete schedule'))
 
       await waitFor(() => {
         expect(useScheduleDraftOperationsMockReturn.deleteScheduledDraft).toHaveBeenCalled()
       })
-      expect(mockOnSetScheduledDraftPerspective).not.toHaveBeenCalled()
+      expect(mockOnDeleteComplete).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.test.tsx
@@ -1,9 +1,11 @@
 import {render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
+import {PerspectiveContext, SingleDocReleaseContext} from 'sanity/_singletons'
 import {beforeEach, describe, expect, it, type MockedFunction, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../test/testUtils/TestProvider'
 import {useSchema} from '../../hooks'
+import {perspectiveContextValueMock} from '../../perspective/__mocks__/usePerspective.mock'
 import {scheduledRelease} from '../../releases/__fixtures__/release.fixture'
 import {useDocumentVersions} from '../../releases/hooks/useDocumentVersions'
 import {
@@ -260,6 +262,70 @@ describe('DeleteScheduledDraftDialog', () => {
         false,
         undefined,
       )
+    })
+  })
+
+  describe('scheduled draft perspective cleanup', () => {
+    const mockOnSetScheduledDraftPerspective = vi.fn()
+    const singleDocReleaseContextValue = {
+      onSetScheduledDraftPerspective: mockOnSetScheduledDraftPerspective,
+    }
+
+    const renderWithPerspective = (selectedPerspectiveName: string | undefined) => {
+      mockUseDocumentVersions.mockReturnValue(createMockDocumentVersions(mockDraftDocument))
+      const perspectiveContextValue = {...perspectiveContextValueMock, selectedPerspectiveName}
+
+      return render(
+        <TestProvider>
+          <PerspectiveContext.Provider value={perspectiveContextValue}>
+            <SingleDocReleaseContext.Provider value={singleDocReleaseContextValue}>
+              <DeleteScheduledDraftDialog
+                documentId="article-123"
+                documentType="article"
+                release={scheduledRelease}
+                onClose={mockOnClose}
+              />
+            </SingleDocReleaseContext.Provider>
+          </PerspectiveContext.Provider>
+        </TestProvider>,
+      )
+    }
+
+    it('clears the scheduled draft perspective after deleting while viewing the scheduled draft', async () => {
+      // `rScheduled` is the release id of the `scheduledRelease` fixture
+      renderWithPerspective('rScheduled')
+
+      await userEvent.click(screen.getByText('Yes, delete schedule'))
+
+      await waitFor(() => {
+        expect(useScheduleDraftOperationsMockReturn.deleteScheduledDraft).toHaveBeenCalled()
+      })
+      expect(mockOnSetScheduledDraftPerspective).toHaveBeenCalledWith('')
+    })
+
+    it('does not clear the perspective when not viewing the scheduled draft', async () => {
+      renderWithPerspective(undefined)
+
+      await userEvent.click(screen.getByText('Yes, delete schedule'))
+
+      await waitFor(() => {
+        expect(useScheduleDraftOperationsMockReturn.deleteScheduledDraft).toHaveBeenCalled()
+      })
+      expect(mockOnSetScheduledDraftPerspective).not.toHaveBeenCalled()
+    })
+
+    it('does not clear the perspective when the delete operation fails', async () => {
+      useScheduleDraftOperationsMockReturn.deleteScheduledDraft.mockRejectedValue(
+        new Error('delete failed'),
+      )
+      renderWithPerspective('rScheduled')
+
+      await userEvent.click(screen.getByText('Yes, delete schedule'))
+
+      await waitFor(() => {
+        expect(useScheduleDraftOperationsMockReturn.deleteScheduledDraft).toHaveBeenCalled()
+      })
+      expect(mockOnSetScheduledDraftPerspective).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.tsx
+++ b/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.tsx
@@ -1,16 +1,19 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {type PreviewValue} from '@sanity/types'
 import {Box, Checkbox, Flex, Stack, Text, useToast} from '@sanity/ui'
-import {type ChangeEvent, type ReactNode, useCallback, useMemo, useState} from 'react'
+import {type ChangeEvent, type ReactNode, useCallback, useContext, useMemo, useState} from 'react'
+import {SingleDocReleaseContext} from 'sanity/_singletons'
 
 import {Dialog} from '../../../ui-components'
 import {LoadingBlock} from '../../components'
 import {useSchema} from '../../hooks'
 import {Translate, useTranslation} from '../../i18n'
+import {usePerspective} from '../../perspective/usePerspective'
 import {Preview} from '../../preview'
 import {useDocumentVersions} from '../../releases/hooks/useDocumentVersions'
 import {type VersionInfoDocumentStub} from '../../releases/store/types'
 import {getDocumentVersionInfoFromVersions} from '../../releases/util/getDocumentVersionInfoFromVersions'
+import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
 import {getErrorMessage, getPublishedId} from '../../util'
 import {useScheduledDraftDocument} from '../hooks/useScheduledDraftDocument'
 import {useScheduleDraftOperations} from '../hooks/useScheduleDraftOperations'
@@ -70,16 +73,30 @@ function useDeleteScheduledDraft(
   firstDocumentPreview: PreviewValue | undefined,
   onClose: () => void,
   deleteOperation: () => Promise<void>,
+  release: ReleaseDocument,
 ) {
   const {t} = useTranslation()
   const toast = useToast()
   const [isDeleting, setIsDeleting] = useState(false)
+
+  // Only provided within a document pane. The dialog can also be rendered outside
+  // one (e.g. from the scheduled drafts overview), where no cleanup is needed.
+  const singleDocRelease = useContext(SingleDocReleaseContext)
+  const {selectedPerspectiveName} = usePerspective()
+  const isViewingScheduledDraft =
+    selectedPerspectiveName === getReleaseIdFromReleaseDocumentId(release._id)
 
   const handleDeleteSchedule = useCallback(async () => {
     setIsDeleting(true)
     // The run().catch().finally() syntax instead of try/catch/finally is because of the React Compiler not fully supporting the syntax yet
     const run = async () => {
       await deleteOperation()
+      // The release backing the scheduled draft no longer exists. If the pane is
+      // currently viewing it, return to the default perspective so stale release
+      // UI (banners, read-only form) isn't left visible.
+      if (isViewingScheduledDraft) {
+        singleDocRelease?.onSetScheduledDraftPerspective('')
+      }
       toast.push({
         closable: true,
         status: 'success',
@@ -114,7 +131,15 @@ function useDeleteScheduledDraft(
         setIsDeleting(false)
         onClose()
       })
-  }, [toast, t, firstDocumentPreview?.title, onClose, deleteOperation])
+  }, [
+    toast,
+    t,
+    firstDocumentPreview?.title,
+    onClose,
+    deleteOperation,
+    isViewingScheduledDraft,
+    singleDocRelease,
+  ])
 
   return {isDeleting, handleDeleteSchedule}
 }
@@ -200,6 +225,7 @@ function DeleteScheduledDraftDialogWithCopyToDraft({
     firstDocumentPreview,
     onClose,
     deleteOperation,
+    release,
   )
 
   const schemaType = schema.get(documentType)
@@ -268,6 +294,7 @@ function DeleteScheduledDraftDialogWithEmptyRelease({
     firstDocumentPreview,
     onClose,
     deleteOperation,
+    release,
   )
 
   return (

--- a/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.tsx
+++ b/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.tsx
@@ -1,25 +1,23 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {type PreviewValue} from '@sanity/types'
 import {Box, Checkbox, Flex, Stack, Text, useToast} from '@sanity/ui'
-import {type ChangeEvent, type ReactNode, useCallback, useContext, useMemo, useState} from 'react'
-import {SingleDocReleaseContext} from 'sanity/_singletons'
+import {type ChangeEvent, type ReactNode, useCallback, useMemo, useState} from 'react'
 
 import {Dialog} from '../../../ui-components'
 import {LoadingBlock} from '../../components'
 import {useSchema} from '../../hooks'
 import {Translate, useTranslation} from '../../i18n'
-import {usePerspective} from '../../perspective/usePerspective'
 import {Preview} from '../../preview'
 import {useDocumentVersions} from '../../releases/hooks/useDocumentVersions'
 import {type VersionInfoDocumentStub} from '../../releases/store/types'
 import {getDocumentVersionInfoFromVersions} from '../../releases/util/getDocumentVersionInfoFromVersions'
-import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
 import {getErrorMessage, getPublishedId} from '../../util'
 import {useScheduledDraftDocument} from '../hooks/useScheduledDraftDocument'
 import {useScheduleDraftOperations} from '../hooks/useScheduleDraftOperations'
 
 interface DeleteScheduledDraftDialogBaseProps {
   onClose: () => void
+  onDeleteComplete?: () => void
   release: ReleaseDocument
 }
 
@@ -73,30 +71,18 @@ function useDeleteScheduledDraft(
   firstDocumentPreview: PreviewValue | undefined,
   onClose: () => void,
   deleteOperation: () => Promise<void>,
-  release: ReleaseDocument,
+  onDeleteComplete?: () => void,
 ) {
   const {t} = useTranslation()
   const toast = useToast()
   const [isDeleting, setIsDeleting] = useState(false)
-
-  // Only provided within a document pane. The dialog can also be rendered outside
-  // one (e.g. from the scheduled drafts overview), where no cleanup is needed.
-  const singleDocRelease = useContext(SingleDocReleaseContext)
-  const {selectedPerspectiveName} = usePerspective()
-  const isViewingScheduledDraft =
-    selectedPerspectiveName === getReleaseIdFromReleaseDocumentId(release._id)
 
   const handleDeleteSchedule = useCallback(async () => {
     setIsDeleting(true)
     // The run().catch().finally() syntax instead of try/catch/finally is because of the React Compiler not fully supporting the syntax yet
     const run = async () => {
       await deleteOperation()
-      // The release backing the scheduled draft no longer exists. If the pane is
-      // currently viewing it, return to the default perspective so stale release
-      // UI (banners, read-only form) isn't left visible.
-      if (isViewingScheduledDraft) {
-        singleDocRelease?.onSetScheduledDraftPerspective('')
-      }
+      onDeleteComplete?.()
       toast.push({
         closable: true,
         status: 'success',
@@ -131,15 +117,7 @@ function useDeleteScheduledDraft(
         setIsDeleting(false)
         onClose()
       })
-  }, [
-    toast,
-    t,
-    firstDocumentPreview?.title,
-    onClose,
-    deleteOperation,
-    isViewingScheduledDraft,
-    singleDocRelease,
-  ])
+  }, [toast, t, firstDocumentPreview?.title, onClose, deleteOperation, onDeleteComplete])
 
   return {isDeleting, handleDeleteSchedule}
 }
@@ -192,6 +170,7 @@ function DeleteScheduledDraftDialogWithCopyToDraft({
   documentId,
   documentType,
   onClose,
+  onDeleteComplete,
   release,
 }: DeleteScheduledDraftDialogWithCopyToDraftProps) {
   const {t} = useTranslation()
@@ -225,7 +204,7 @@ function DeleteScheduledDraftDialogWithCopyToDraft({
     firstDocumentPreview,
     onClose,
     deleteOperation,
-    release,
+    onDeleteComplete,
   )
 
   const schemaType = schema.get(documentType)
@@ -277,6 +256,7 @@ function DeleteScheduledDraftDialogWithCopyToDraft({
  */
 function DeleteScheduledDraftDialogWithEmptyRelease({
   onClose,
+  onDeleteComplete,
   release,
 }: DeleteScheduledDraftDialogBaseProps) {
   const {t} = useTranslation()
@@ -294,7 +274,7 @@ function DeleteScheduledDraftDialogWithEmptyRelease({
     firstDocumentPreview,
     onClose,
     deleteOperation,
-    release,
+    onDeleteComplete,
   )
 
   return (
@@ -316,10 +296,17 @@ export function DeleteScheduledDraftDialog({
   documentId,
   documentType,
   onClose,
+  onDeleteComplete,
   release,
 }: DeleteScheduledDraftDialogProps) {
   if (!documentId || !documentType) {
-    return <DeleteScheduledDraftDialogWithEmptyRelease onClose={onClose} release={release} />
+    return (
+      <DeleteScheduledDraftDialogWithEmptyRelease
+        onClose={onClose}
+        onDeleteComplete={onDeleteComplete}
+        release={release}
+      />
+    )
   }
 
   return (
@@ -327,6 +314,7 @@ export function DeleteScheduledDraftDialog({
       documentId={documentId}
       documentType={documentType}
       onClose={onClose}
+      onDeleteComplete={onDeleteComplete}
       release={release}
     />
   )

--- a/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.tsx
+++ b/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.tsx
@@ -82,7 +82,11 @@ function useDeleteScheduledDraft(
     // The run().catch().finally() syntax instead of try/catch/finally is because of the React Compiler not fully supporting the syntax yet
     const run = async () => {
       await deleteOperation()
-      onDeleteComplete?.()
+      try {
+        onDeleteComplete?.()
+      } catch (error) {
+        console.error('onDeleteComplete callback failed:', error)
+      }
       toast.push({
         closable: true,
         status: 'success',

--- a/packages/sanity/src/core/singleDocRelease/hooks/useClearScheduledDraftPerspectiveOnDelete.test.ts
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useClearScheduledDraftPerspectiveOnDelete.test.ts
@@ -1,0 +1,65 @@
+import {renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {perspectiveContextValueMock} from '../../perspective/__mocks__/usePerspective.mock'
+import {usePerspective} from '../../perspective/usePerspective'
+import {scheduledRelease} from '../../releases/__fixtures__/release.fixture'
+import {useSingleDocRelease} from '../context/SingleDocReleaseProvider'
+import {useClearScheduledDraftPerspectiveOnDelete} from './useClearScheduledDraftPerspectiveOnDelete'
+
+const mockOnSetScheduledDraftPerspective = vi.fn()
+
+vi.mock('../context/SingleDocReleaseProvider', () => ({
+  useSingleDocRelease: vi.fn(),
+}))
+
+vi.mock('../../perspective/usePerspective', () => ({
+  usePerspective: vi.fn(),
+}))
+
+const mockUseSingleDocRelease = useSingleDocRelease as ReturnType<typeof vi.fn>
+const mockUsePerspective = usePerspective as ReturnType<typeof vi.fn>
+
+describe('useClearScheduledDraftPerspectiveOnDelete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseSingleDocRelease.mockReturnValue({
+      onSetScheduledDraftPerspective: mockOnSetScheduledDraftPerspective,
+    })
+    mockUsePerspective.mockReturnValue(perspectiveContextValueMock)
+  })
+
+  it('clears the scheduled draft perspective when viewing the deleted release', () => {
+    mockUsePerspective.mockReturnValue({
+      ...perspectiveContextValueMock,
+      selectedPerspectiveName: 'rScheduled',
+    })
+
+    const {result} = renderHook(() => useClearScheduledDraftPerspectiveOnDelete(scheduledRelease))
+
+    result.current()
+
+    expect(mockOnSetScheduledDraftPerspective).toHaveBeenCalledWith('')
+  })
+
+  it('does not clear the perspective when not viewing the scheduled draft', () => {
+    mockUsePerspective.mockReturnValue({
+      ...perspectiveContextValueMock,
+      selectedPerspectiveName: 'drafts',
+    })
+
+    const {result} = renderHook(() => useClearScheduledDraftPerspectiveOnDelete(scheduledRelease))
+
+    result.current()
+
+    expect(mockOnSetScheduledDraftPerspective).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when release is undefined', () => {
+    const {result} = renderHook(() => useClearScheduledDraftPerspectiveOnDelete(undefined))
+
+    result.current()
+
+    expect(mockOnSetScheduledDraftPerspective).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sanity/src/core/singleDocRelease/hooks/useClearScheduledDraftPerspectiveOnDelete.ts
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useClearScheduledDraftPerspectiveOnDelete.ts
@@ -1,0 +1,30 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {useCallback} from 'react'
+
+import {usePerspective} from '../../perspective/usePerspective'
+import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
+import {useSingleDocRelease} from '../context/SingleDocReleaseProvider'
+
+/**
+ * Returns a callback that clears the pane-local scheduled draft perspective when
+ * the document pane is currently viewing the given release. Used after deleting
+ * a scheduled draft so stale release UI is not left visible.
+ *
+ * Must be used within a document pane (requires `SingleDocReleaseProvider`).
+ *
+ * @internal
+ */
+export function useClearScheduledDraftPerspectiveOnDelete(
+  release: ReleaseDocument | undefined,
+): () => void {
+  const {onSetScheduledDraftPerspective} = useSingleDocRelease()
+  const {selectedPerspectiveName} = usePerspective()
+
+  return useCallback(() => {
+    if (!release) return
+
+    if (selectedPerspectiveName === getReleaseIdFromReleaseDocumentId(release._id)) {
+      onSetScheduledDraftPerspective('')
+    }
+  }, [release, selectedPerspectiveName, onSetScheduledDraftPerspective])
+}

--- a/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.tsx
+++ b/packages/sanity/src/core/singleDocRelease/hooks/useScheduledDraftMenuActions.tsx
@@ -27,6 +27,7 @@ export interface UseScheduledDraftMenuActionsOptions {
   documentId?: string
   disabled?: boolean
   onActionComplete?: () => void
+  onDeleteComplete?: () => void
 }
 
 interface ScheduledDraftActionProps {
@@ -56,7 +57,14 @@ export interface UseScheduledDraftMenuActionsReturn {
 export function useScheduledDraftMenuActions(
   options: UseScheduledDraftMenuActionsOptions,
 ): UseScheduledDraftMenuActionsReturn {
-  const {release, documentType, documentId, disabled = false, onActionComplete} = options
+  const {
+    release,
+    documentType,
+    documentId,
+    disabled = false,
+    onActionComplete,
+    onDeleteComplete,
+  } = options
 
   const {t} = useTranslation()
   const toast = useToast()
@@ -202,6 +210,7 @@ export function useScheduledDraftMenuActions(
             documentType={documentType}
             documentId={documentId}
             onClose={handleDialogClose}
+            onDeleteComplete={onDeleteComplete}
           />
         )
 
@@ -227,6 +236,7 @@ export function useScheduledDraftMenuActions(
     handleDialogClose,
     handleSchedulePublish,
     isScheduling,
+    onDeleteComplete,
   ])
 
   return {

--- a/packages/sanity/src/core/singleDocRelease/plugin/documentActions/ScheduledDraftDocumentActions.tsx
+++ b/packages/sanity/src/core/singleDocRelease/plugin/documentActions/ScheduledDraftDocumentActions.tsx
@@ -8,6 +8,7 @@ import {
 import {useAllReleases} from '../../../releases/store/useAllReleases'
 import {getReleaseIdFromReleaseDocumentId} from '../../../releases/util/getReleaseIdFromReleaseDocumentId'
 import {isPausedCardinalityOneRelease} from '../../../util/releaseUtils'
+import {useClearScheduledDraftPerspectiveOnDelete} from '../../hooks/useClearScheduledDraftPerspectiveOnDelete'
 import {
   useScheduledDraftMenuActions,
   type UseScheduledDraftMenuActionsReturn,
@@ -32,10 +33,15 @@ const createScheduledDraftAction = (
       (r) => getReleaseIdFromReleaseDocumentId(r._id) === release,
     )
 
+    const onDeleteComplete = useClearScheduledDraftPerspectiveOnDelete(
+      actionKey === 'deleteSchedule' ? releaseDocument : undefined,
+    )
+
     const {actions, dialogs} = useScheduledDraftMenuActions({
       release: releaseDocument,
       documentType: type,
       documentId: id,
+      onDeleteComplete: actionKey === 'deleteSchedule' ? onDeleteComplete : undefined,
     })
 
     if (visibilityCheck && !visibilityCheck(releaseDocument)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fixes SAPP-4016. Deleting a scheduled draft while viewing it in the document pane left the pane-local `scheduledDraft` router param set, so stale release UI stayed visible.

Perspective cleanup is now handled via an `onDeleteComplete` callback passed from document-pane parents, rather than inside `DeleteScheduledDraftDialog`. A new `useClearScheduledDraftPerspectiveOnDelete` hook checks whether the pane is viewing the deleted release and calls `onSetScheduledDraftPerspective('')` to clear the pane-local param. Deleting from the scheduled drafts overview is unaffected (no callback passed).

### What to review

- `useClearScheduledDraftPerspectiveOnDelete.ts` — cleanup logic extracted from the dialog
- `DeleteScheduledDraftDialog.tsx` — now only invokes optional `onDeleteComplete` after successful delete
- `useScheduledDraftMenuActions.tsx` — threads `onDeleteComplete` through to the dialog
- `ScheduledDraftDocumentActions.tsx` and `useVersionContextMenu.ts` — wire up the hook in document-pane contexts

### Testing

- Create a scheduled draft of a document, then select the scheduled draft and remove it, the document perspecitve should clear and it should not show the add to release banner
### Notes for release

Fixes a bug where deleting a scheduled draft while viewing it left stale release UI visible in the document pane. The pane now returns to the draft perspective automatically after deletion.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fa36a7e-e30c-4fcc-9e34-2f8ab9a32004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fa36a7e-e30c-4fcc-9e34-2f8ab9a32004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

