### PR TITLE
fix(core): clear scheduled draft perspective after deleting scheduled draft

### DIFF
--- a/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.test.tsx
@@ -1,9 +1,11 @@
 import {render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
+import {PerspectiveContext, SingleDocReleaseContext} from 'sanity/_singletons'
 import {beforeEach, describe, expect, it, type MockedFunction, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../test/testUtils/TestProvider'
 import {useSchema} from '../../hooks'
+import {perspectiveContextValueMock} from '../../perspective/__mocks__/usePerspective.mock'
 import {scheduledRelease} from '../../releases/__fixtures__/release.fixture'
 import {useDocumentVersions} from '../../releases/hooks/useDocumentVersions'
 import {
@@ -260,6 +262,70 @@ describe('DeleteScheduledDraftDialog', () => {
         false,
         undefined,
       )
+    })
+  })
+
+  describe('scheduled draft perspective cleanup', () => {
+    const mockOnSetScheduledDraftPerspective = vi.fn()
+    const singleDocReleaseContextValue = {
+      onSetScheduledDraftPerspective: mockOnSetScheduledDraftPerspective,
+    }
+
+    const renderWithPerspective = (selectedPerspectiveName: string | undefined) => {
+      mockUseDocumentVersions.mockReturnValue(createMockDocumentVersions(mockDraftDocument))
+      const perspectiveContextValue = {...perspectiveContextValueMock, selectedPerspectiveName}
+
+      return render(
+        <TestProvider>
+          <PerspectiveContext.Provider value={perspectiveContextValue}>
+            <SingleDocReleaseContext.Provider value={singleDocReleaseContextValue}>
+              <DeleteScheduledDraftDialog
+                documentId="article-123"
+                documentType="article"
+                release={scheduledRelease}
+                onClose={mockOnClose}
+              />
+            </SingleDocReleaseContext.Provider>
+          </PerspectiveContext.Provider>
+        </TestProvider>,
+      )
+    }
+
+    it('clears the scheduled draft perspective after deleting while viewing the scheduled draft', async () => {
+      // `rScheduled` is the release id of the `scheduledRelease` fixture
+      renderWithPerspective('rScheduled')
+
+      await userEvent.click(screen.getByText('Yes, delete schedule'))
+
+      await waitFor(() => {
+        expect(useScheduleDraftOperationsMockReturn.deleteScheduledDraft).toHaveBeenCalled()
+      })
+      expect(mockOnSetScheduledDraftPerspective).toHaveBeenCalledWith('')
+    })
+
+    it('does not clear the perspective when not viewing the scheduled draft', async () => {
+      renderWithPerspective(undefined)
+
+      await userEvent.click(screen.getByText('Yes, delete schedule'))
+
+      await waitFor(() => {
+        expect(useScheduleDraftOperationsMockReturn.deleteScheduledDraft).toHaveBeenCalled()
+      })
+      expect(mockOnSetScheduledDraftPerspective).not.toHaveBeenCalled()
+    })
+
+    it('does not clear the perspective when the delete operation fails', async () => {
+      useScheduleDraftOperationsMockReturn.deleteScheduledDraft.mockRejectedValue(
+        new Error('delete failed'),
+      )
+      renderWithPerspective('rScheduled')
+
+      await userEvent.click(screen.getByText('Yes, delete schedule'))
+
+      await waitFor(() => {
+        expect(useScheduleDraftOperationsMockReturn.deleteScheduledDraft).toHaveBeenCalled()
+      })
+      expect(mockOnSetScheduledDraftPerspective).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.tsx
+++ b/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.tsx
@@ -1,16 +1,19 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {type PreviewValue} from '@sanity/types'
 import {Box, Checkbox, Flex, Stack, Text, useToast} from '@sanity/ui'
-import {type ChangeEvent, type ReactNode, useCallback, useMemo, useState} from 'react'
+import {type ChangeEvent, type ReactNode, useCallback, useContext, useMemo, useState} from 'react'
+import {SingleDocReleaseContext} from 'sanity/_singletons'
 
 import {Dialog} from '../../../ui-components'
 import {LoadingBlock} from '../../components'
 import {useSchema} from '../../hooks'
 import {Translate, useTranslation} from '../../i18n'
+import {usePerspective} from '../../perspective/usePerspective'
 import {Preview} from '../../preview'
 import {useDocumentVersions} from '../../releases/hooks/useDocumentVersions'
 import {type VersionInfoDocumentStub} from '../../releases/store/types'
 import {getDocumentVersionInfoFromVersions} from '../../releases/util/getDocumentVersionInfoFromVersions'
+import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
 import {getErrorMessage, getPublishedId} from '../../util'
 import {useScheduledDraftDocument} from '../hooks/useScheduledDraftDocument'
 import {useScheduleDraftOperations} from '../hooks/useScheduleDraftOperations'
@@ -70,16 +73,30 @@ function useDeleteScheduledDraft(
   firstDocumentPreview: PreviewValue | undefined,
   onClose: () => void,
   deleteOperation: () => Promise<void>,
+  release: ReleaseDocument,
 ) {
   const {t} = useTranslation()
   const toast = useToast()
   const [isDeleting, setIsDeleting] = useState(false)
+
+  // Only provided within a document pane. The dialog can also be rendered outside
+  // one (e.g. from the scheduled drafts overview), where no cleanup is needed.
+  const singleDocRelease = useContext(SingleDocReleaseContext)
+  const {selectedPerspectiveName} = usePerspective()
+  const isViewingScheduledDraft =
+    selectedPerspectiveName === getReleaseIdFromReleaseDocumentId(release._id)
 
   const handleDeleteSchedule = useCallback(async () => {
     setIsDeleting(true)
     // The run().catch().finally() syntax instead of try/catch/finally is because of the React Compiler not fully supporting the syntax yet
     const run = async () => {
       await deleteOperation()
+      // The release backing the scheduled draft no longer exists. If the pane is
+      // currently viewing it, return to the default perspective so stale release
+      // UI (banners, read-only form) isn't left visible.
+      if (isViewingScheduledDraft) {
+        singleDocRelease?.onSetScheduledDraftPerspective('')
+      }
       toast.push({
         closable: true,
         status: 'success',
@@ -114,7 +131,15 @@ function useDeleteScheduledDraft(
         setIsDeleting(false)
         onClose()
       })
-  }, [toast, t, firstDocumentPreview?.title, onClose, deleteOperation])
+  }, [
+    toast,
+    t,
+    firstDocumentPreview?.title,
+    onClose,
+    deleteOperation,
+    isViewingScheduledDraft,
+    singleDocRelease,
+  ])
 
   return {isDeleting, handleDeleteSchedule}
 }
@@ -200,6 +225,7 @@ function DeleteScheduledDraftDialogWithCopyToDraft({
     firstDocumentPreview,
     onClose,
     deleteOperation,
+    release,
   )
 
   const schemaType = schema.get(documentType)
@@ -268,6 +294,7 @@ function DeleteScheduledDraftDialogWithEmptyRelease({
     firstDocumentPreview,
     onClose,
     deleteOperation,
+    release,
   )
 
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fixes SAPP-4016 (release UI remains visible after deleting scheduled draft).

Deleting a scheduled draft while the document pane was viewing it left the pane-local `scheduledDraft` router param behind, so the pane kept treating the deleted release as the active perspective: stale release banners (first "Schedule paused…", then "Not in the r… release"), a read-only form, and no way to recover except manually editing the URL. Every other way of leaving the scheduled-draft perspective (perspective navigation, copy-to-drafts) already clears the param — deletion was the missing case.

The fix resets the scheduled draft perspective (via the existing `SingleDocReleaseContext.onSetScheduledDraftPerspective` bridge) after the delete operation succeeds, but only when the pane is actually viewing the deleted release. The other delete entry points are unaffected: deleting from the scheduled drafts overview (no pane, context absent) and deleting from a version chip's context menu while viewing a different perspective (perspective name doesn't match) are both no-ops.

A pane-level "self-healing" watcher (clear the param whenever the release disappears from the store) was considered but rejected: it races with scheduled-draft creation, where the perspective is set before the releases store listener has seen the newly created release.

### What to review

- `packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.tsx` — the cleanup lives in the shared `useDeleteScheduledDraft` hook so both dialog variants get it. Only the `sanity` package is affected.
- The condition: cleanup only runs on delete success, when `selectedPerspectiveName` (pane-local, provided by `DocumentPerspectiveProvider` from `params.scheduledDraft`) matches the deleted release id.

### Testing

- Added unit tests: perspective cleared after successful delete while viewing the scheduled draft; not cleared when viewing another perspective; not cleared when the delete operation fails.
- Manually reproduced the original bug on `main` in the test studio, then verified the fix: schedule publish an author document → delete schedule → pane returns to the draft perspective, the `scheduledDraft` URL param is removed, no stale release UI, form editable again.

Before (bug): after deleting, the pane stayed on the deleted release perspective with a stale "Not in the … release" banner and read-only form:

[Bug: stale release UI after deleting scheduled draft](https://cursor.com/agents/bc-4d62b49a-5fc6-4f67-9ccd-69a3151aaac0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbug_before_stale_release_ui_after_delete.webp)

After (fixed): deleting the schedule returns the pane to the normal draft view:

[fix_delete_scheduled_draft_returns_to_draft_view.mp4](https://cursor.com/agents/bc-4d62b49a-5fc6-4f67-9ccd-69a3151aaac0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffix_delete_scheduled_draft_returns_to_draft_view.mp4)

### Notes for release

N/A – bug fix: the document pane no longer keeps showing release UI for a scheduled draft after the schedule is deleted.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d62b49a-5fc6-4f67-9ccd-69a3151aaac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d62b49a-5fc6-4f67-9ccd-69a3151aaac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

