### PR TITLE
fix(core): defer onDeleteComplete until after dialog cleanup

### DIFF
--- a/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.test.tsx
+++ b/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.test.tsx
@@ -288,6 +288,32 @@ describe('DeleteScheduledDraftDialog', () => {
       expect(mockOnDeleteComplete).toHaveBeenCalledOnce()
     })
 
+    it('calls onDeleteComplete after onClose on successful delete', async () => {
+      const callOrder: string[] = []
+      const mockOnDeleteComplete = vi.fn(() => callOrder.push('onDeleteComplete'))
+      const onClose = vi.fn(() => callOrder.push('onClose'))
+      mockUseDocumentVersions.mockReturnValue(createMockDocumentVersions(mockDraftDocument))
+
+      render(
+        <TestProvider>
+          <DeleteScheduledDraftDialog
+            documentId="article-123"
+            documentType="article"
+            release={scheduledRelease}
+            onClose={onClose}
+            onDeleteComplete={mockOnDeleteComplete}
+          />
+        </TestProvider>,
+      )
+
+      await userEvent.click(screen.getByText('Yes, delete schedule'))
+
+      await waitFor(() => {
+        expect(mockOnDeleteComplete).toHaveBeenCalledOnce()
+      })
+      expect(callOrder).toEqual(['onClose', 'onDeleteComplete'])
+    })
+
     it('does not call onDeleteComplete when the delete operation fails', async () => {
       const mockOnDeleteComplete = vi.fn()
       useScheduleDraftOperationsMockReturn.deleteScheduledDraft.mockRejectedValue(

--- a/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.tsx
+++ b/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.tsx
@@ -79,14 +79,11 @@ function useDeleteScheduledDraft(
 
   const handleDeleteSchedule = useCallback(async () => {
     setIsDeleting(true)
+    let didDelete = false
     // The run().catch().finally() syntax instead of try/catch/finally is because of the React Compiler not fully supporting the syntax yet
     const run = async () => {
       await deleteOperation()
-      try {
-        onDeleteComplete?.()
-      } catch (error) {
-        console.error('onDeleteComplete callback failed:', error)
-      }
+      didDelete = true
       toast.push({
         closable: true,
         status: 'success',
@@ -120,6 +117,13 @@ function useDeleteScheduledDraft(
       .finally(() => {
         setIsDeleting(false)
         onClose()
+        if (didDelete) {
+          try {
+            onDeleteComplete?.()
+          } catch (error) {
+            console.error('onDeleteComplete callback failed:', error)
+          }
+        }
       })
   }, [toast, t, firstDocumentPreview?.title, onClose, deleteOperation, onDeleteComplete])
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Follow-up to #13509. Copilot flagged that `onDeleteComplete` ran immediately after `deleteOperation()`, before the `.finally()` cleanup. That callback clears the scheduled-draft perspective and can unmount the dialog, so the subsequent `setIsDeleting(false)` / `onClose()` risked state updates after unmount.

`onDeleteComplete` now runs in `.finally()` after local cleanup, gated by a `didDelete` flag so it still only fires on successful deletes.

### What to review

- `DeleteScheduledDraftDialog.tsx` — `useDeleteScheduledDraft` callback ordering in the `.finally()` block
- `DeleteScheduledDraftDialog.test.tsx` — new test asserting `onDeleteComplete` runs after `onClose`

### Testing

- `pnpm vitest run --project=sanity packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.test.tsx` (8 tests pass)

### Notes for release

N/A – Internal only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-218d4928-fe0a-44ec-b81a-bab361b2d53e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-218d4928-fe0a-44ec-b81a-bab361b2d53e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

