### PR TITLE
fix(bench): mock the document-at-revision history endpoint

### DIFF
--- a/perf/bench/mock-api/__tests__/contract.test.ts
+++ b/perf/bench/mock-api/__tests__/contract.test.ts
@@ -101,6 +101,19 @@ describe('mock Content Lake contract (real @sanity/client)', () => {
     expect(draft).toMatchObject({_id: DRAFT_ID, stringField: 'hello', _rev: 'seed'})
   })
 
+  it('serves a document-at-revision in the shape getDocumentAtRevision expects', async () => {
+    // The divergence/changes machinery fetches GET /data/history/<ds>/documents/
+    // <id>?revision=<rev> and reads response.documents[0]; a soak run triggers it
+    // once enough edits accumulate. Without a handler the studio logs a console
+    // error and the session fails (mock-drift detector).
+    mock.store.seed([{_id: DRAFT_ID, _type: 'singleString', stringField: 'hello'}])
+    const response = await client.request<{documents: unknown[]}>({
+      url: `/data/history/bench/documents/${encodeURIComponent(DRAFT_ID)}?revision=seed`,
+      tag: 'get-document-revision',
+    })
+    expect(response.documents[0]).toMatchObject({_id: DRAFT_ID, stringField: 'hello'})
+  })
+
   it('echoes an action as a mutation event with the submitted transactionId, rev-chained from the snapshot', async () => {
     mock.store.seed([{_id: DRAFT_ID, _type: 'singleString', stringField: 'hello'}])
     const [, snapshot] = await client.getDocuments([PUBLISHED_ID, DRAFT_ID])

--- a/perf/bench/mock-api/createServer.ts
+++ b/perf/bench/mock-api/createServer.ts
@@ -8,7 +8,7 @@ import {
 import {Subscription} from 'rxjs'
 
 import {BENCH_USER} from '../constants'
-import {handleActions, handleDoc, handleMutate, handleQuery} from './data'
+import {handleActions, handleDoc, handleDocRevision, handleMutate, handleQuery} from './data'
 import {RequestLedger} from './ledger'
 import {AUTH_PROBE, AUTH_PROVIDERS, DATASET_ACL, DATASETS, projectData} from './project'
 import {corsHeaders, handlePreflight, json, readBody} from './respond'
@@ -213,6 +213,13 @@ export function createMockApi(config: MockApiConfig): MockApiServer {
       // a console error on failure — answer with an empty event list
       // (shape: getInitialFetchEvents.ts)
       record('history', json(req, res, 200, {events: {}, nextCursor: ''}))
+      return
+    }
+    // A document at a specific revision (divergence/changes machinery). Must
+    // come before the general history routes; distinct from /events/documents/.
+    const docRevisionMatch = path.match(/^\/data\/history\/([^/]+)\/documents\/([^/?]+)/)
+    if (docRevisionMatch && method === 'GET') {
+      record('history', handleDocRevision(req, res, store, docRevisionMatch[2]))
       return
     }
     const translogMatch = path.match(/^\/data\/history\/([^/]+)\/transactions\//)

--- a/perf/bench/mock-api/data.ts
+++ b/perf/bench/mock-api/data.ts
@@ -26,6 +26,25 @@ export function handleDoc(
   return json(req, res, 200, {documents, omitted: []})
 }
 
+/**
+ * GET /data/history/<ds>/documents/<id>?revision=<rev> — the document at a
+ * past revision, used by the divergence/changes machinery
+ * (getDocumentAtRevision.ts) which reads `response.documents[0]`. The soak
+ * session triggers it after enough edits accumulate; without a handler the
+ * studio logs a console error per call and the session fails (mock-drift
+ * detector). The mock keeps no per-revision snapshots, so return the current
+ * document — the shape is what matters here, not historical diff fidelity.
+ */
+export function handleDocRevision(
+  req: ProxyRequest,
+  res: ProxyResponse,
+  store: DocumentStore,
+  idSegment: string,
+): number {
+  const doc = store.get(decodeURIComponent(idSegment))
+  return json(req, res, 200, {documents: doc ? [doc] : []})
+}
+
 /** GET|POST /data/query/<ds> — GROQ over the in-memory store via groq-js. */
 export async function handleQuery(
   req: ProxyRequest,


### PR DESCRIPTION
### Description

`perf/bench` runs a real Studio against an in-process mock Content Lake and fails a run on any request the mock doesn't handle. The soak run (~10 min of editing) trips this: the review-changes feature fetches an earlier document version (`GET /data/history/<ds>/documents/<id>?revision=<rev>`), the mock 404s, and the resulting console error fails the run. Shorter run modes never edit long enough to hit it.

Add a handler returning the current stored document as `{documents: [...]}`. The mock keeps no per-revision history, but the soak run doesn't read historical content — it only needs the request to succeed.

### Notes for release

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the perf bench mock API and its contract test; no production Studio or Content Lake behavior is modified.
> 
> **Overview**
> **perf/bench** soak runs were failing when Studio’s divergence/review-changes path called `GET /data/history/<ds>/documents/<id>?revision=<rev>` and the mock returned 404, which surfaced as console errors and tripped mock-drift detection.
> 
> The mock now routes that path (before other history handlers) via **`handleDocRevision`**, responding with `{documents: […]}` using the **current** in-memory document—no per-revision history. A contract test asserts the response shape Studio expects (`response.documents[0]`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2cd458188e8843cbf55d7f6cc9e0ff17c119b38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->