### PR TITLE
ci(bench): match track-main session counts to the PR shards

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -584,16 +584,24 @@ jobs:
           name: bench-dist-experiment
           path: perf/bench/dist
 
+      # Session counts match the PR shard jobs so track-main stays within its
+      # timeout: interaction uses the CLI default (6), and pageLoad runs the
+      # heavy syntheticLarge scenario at fewer sessions than singleString
+      # (~55s/sample × both conditions × 8 blows the budget). Two pageLoad
+      # commands (one per scenario) since a single invocation can't vary
+      # --sessions per scenario; separate --json-out files so neither clobbers
+      # the other (the report step globs bench-results__*.json).
       - name: Run interaction benchmarks (fixed sessions)
         run: |
-          pnpm bench run --mode interaction --sessions 8 \
+          pnpm bench run --mode interaction --sessions 6 \
             --json-out "$GITHUB_WORKSPACE/perf/bench/results/bench-results__interaction.json"
 
       - name: Run pageLoad benchmarks
         run: |
-          pnpm bench run --mode pageload --scenario singleString --scenario syntheticLarge \
-            --sessions 8 \
-            --json-out "$GITHUB_WORKSPACE/perf/bench/results/bench-results__pageload.json"
+          pnpm bench run --mode pageload --scenario singleString --sessions 8 \
+            --json-out "$GITHUB_WORKSPACE/perf/bench/results/bench-results__pageload-singleString.json"
+          pnpm bench run --mode pageload --scenario syntheticLarge --sessions 3 \
+            --json-out "$GITHUB_WORKSPACE/perf/bench/results/bench-results__pageload-syntheticLarge.json"
 
       - name: Run soak check
         run: |

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -153,17 +153,22 @@ jobs:
 
   bench-interaction:
     needs: [build, build-reference]
-    # Runs on the PR path (A/B vs the merge-base) and on the daily/dispatch
+    # Runs on the PR path (A/B vs the merge-base) and on the daily-tracking
     # path (absolute — build-reference is PR-only and gets skipped, so
     # COMPARISON is empty and the run step drops --reference-dist). Sharded per
     # scenario either way, so the daily run's wall-clock is the slowest single
-    # scenario, not the sum. The `!cancelled()` status function is required so
-    # the job still runs when build-reference is *skipped* (a plain custom if:
-    # would itself skip on a skipped need); guard on build succeeding.
+    # scenario, not the sum. Only on triggers whose results are consumed by
+    # track-main — NOT the weekly self-test cron or a self_test-only dispatch,
+    # which run their own job and would otherwise launch these shards for
+    # nothing. The `!cancelled()` status function is required so the job still
+    # runs when build-reference is *skipped* (a plain custom if: would itself
+    # skip on a skipped need); guard on build succeeding.
     if: >-
       !cancelled() && needs.build.result == 'success' &&
-      (needs.build.outputs.has_code_changes == 'true' ||
-       github.event_name != 'pull_request')
+      ((github.event_name == 'pull_request' &&
+        needs.build.outputs.has_code_changes == 'true') ||
+       (github.event_name == 'schedule' && github.event.schedule == '0 5 * * *') ||
+       (github.event_name == 'workflow_dispatch' && inputs.run_suite))
     runs-on: ubuntu-8core
     # Headroom for a/b runs of the heavy scenarios (synthetic sessions cost
     # ~90s each and run on both sides)
@@ -249,13 +254,16 @@ jobs:
 
   bench-pageload:
     needs: [build, build-reference]
-    # See bench-interaction: PR path is A/B, daily/dispatch is absolute
-    # (build-reference skipped). `!cancelled()` lets it run past the skipped
-    # build-reference need; guard on build succeeding.
+    # See bench-interaction: PR path is A/B, daily/run_suite is absolute
+    # (build-reference skipped). Gated to the triggers track-main consumes, so
+    # the self-test path doesn't launch these shards for nothing. `!cancelled()`
+    # lets it run past the skipped build-reference need; guard on build.
     if: >-
       !cancelled() && needs.build.result == 'success' &&
-      (needs.build.outputs.has_code_changes == 'true' ||
-       github.event_name != 'pull_request')
+      ((github.event_name == 'pull_request' &&
+        needs.build.outputs.has_code_changes == 'true') ||
+       (github.event_name == 'schedule' && github.event.schedule == '0 5 * * *') ||
+       (github.event_name == 'workflow_dispatch' && inputs.run_suite))
     runs-on: ubuntu-8core
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -153,7 +153,17 @@ jobs:
 
   bench-interaction:
     needs: [build, build-reference]
-    if: needs.build.outputs.has_code_changes == 'true'
+    # Runs on the PR path (A/B vs the merge-base) and on the daily/dispatch
+    # path (absolute — build-reference is PR-only and gets skipped, so
+    # COMPARISON is empty and the run step drops --reference-dist). Sharded per
+    # scenario either way, so the daily run's wall-clock is the slowest single
+    # scenario, not the sum. The `!cancelled()` status function is required so
+    # the job still runs when build-reference is *skipped* (a plain custom if:
+    # would itself skip on a skipped need); guard on build succeeding.
+    if: >-
+      !cancelled() && needs.build.result == 'success' &&
+      (needs.build.outputs.has_code_changes == 'true' ||
+       github.event_name != 'pull_request')
     runs-on: ubuntu-8core
     # Headroom for a/b runs of the heavy scenarios (synthetic sessions cost
     # ~90s each and run on both sides)
@@ -239,7 +249,13 @@ jobs:
 
   bench-pageload:
     needs: [build, build-reference]
-    if: needs.build.outputs.has_code_changes == 'true'
+    # See bench-interaction: PR path is A/B, daily/dispatch is absolute
+    # (build-reference skipped). `!cancelled()` lets it run past the skipped
+    # build-reference need; guard on build succeeding.
+    if: >-
+      !cancelled() && needs.build.result == 'success' &&
+      (needs.build.outputs.has_code_changes == 'true' ||
+       github.event_name != 'pull_request')
     runs-on: ubuntu-8core
     timeout-minutes: 20
     permissions:
@@ -527,18 +543,25 @@ jobs:
           retention-days: 30
 
   track-main:
-    # Daily absolute-mode run against main HEAD, stored to the studio-metrics
-    # project for time-series/drift tracking. Fixed session counts -
-    # comparability over speed (no dynamic stopping shortcut across days).
-    # Also the on-demand "run the suite" path: a workflow_dispatch with
-    # run_suite triggers the same full run + store (e.g. to backfill a point or
-    # verify the store path without waiting for the 5am cron).
+    # Daily absolute-mode tracking (and the on-demand run_suite dispatch): soak
+    # and INP run here (daily-only modes), then this job gathers the interaction
+    # and pageLoad shard results (bench-interaction / bench-pageload, which run
+    # absolute on this trigger) and stores one merged benchRun doc to the
+    # studio-metrics project. Interaction/pageLoad moved to the sharded jobs so
+    # the daily run is parallel (was a single ~90-minute sequential job); soak
+    # (~10m) + INP (~10m) are cheap and stay together here.
+    #
+    # Fixed session counts across the board — comparability over speed, no
+    # dynamic-stopping shortcut across days.
     if: >-
-      (github.event_name == 'schedule' && github.event.schedule == '0 5 * * *') ||
-      (github.event_name == 'workflow_dispatch' && inputs.run_suite)
-    needs: [build]
+      !cancelled() &&
+      needs.bench-interaction.result == 'success' &&
+      needs.bench-pageload.result == 'success' &&
+      ((github.event_name == 'schedule' && github.event.schedule == '0 5 * * *') ||
+       (github.event_name == 'workflow_dispatch' && inputs.run_suite))
+    needs: [build, bench-interaction, bench-pageload]
     runs-on: ubuntu-8core
-    timeout-minutes: 90
+    timeout-minutes: 45
     permissions:
       contents: read
     env:
@@ -584,24 +607,14 @@ jobs:
           name: bench-dist-experiment
           path: perf/bench/dist
 
-      # Session counts match the PR shard jobs so track-main stays within its
-      # timeout: interaction uses the CLI default (6), and pageLoad runs the
-      # heavy syntheticLarge scenario at fewer sessions than singleString
-      # (~55s/sample × both conditions × 8 blows the budget). Two pageLoad
-      # commands (one per scenario) since a single invocation can't vary
-      # --sessions per scenario; separate --json-out files so neither clobbers
-      # the other (the report step globs bench-results__*.json).
-      - name: Run interaction benchmarks (fixed sessions)
-        run: |
-          pnpm bench run --mode interaction --sessions 6 \
-            --json-out "$GITHUB_WORKSPACE/perf/bench/results/bench-results__interaction.json"
-
-      - name: Run pageLoad benchmarks
-        run: |
-          pnpm bench run --mode pageload --scenario singleString --sessions 8 \
-            --json-out "$GITHUB_WORKSPACE/perf/bench/results/bench-results__pageload-singleString.json"
-          pnpm bench run --mode pageload --scenario syntheticLarge --sessions 3 \
-            --json-out "$GITHUB_WORKSPACE/perf/bench/results/bench-results__pageload-syntheticLarge.json"
+      # Gather the interaction + pageLoad shard results into the shared results
+      # dir; soak and INP write their own JSON alongside, and `bench report`
+      # merges everything into one document (bench-results__*.json).
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: bench-results-*
+          merge-multiple: true
+          path: perf/bench/results
 
       - name: Run soak check
         run: |

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -609,10 +609,18 @@ jobs:
 
       # Gather the interaction + pageLoad shard results into the shared results
       # dir; soak and INP write their own JSON alongside, and `bench report`
-      # merges everything into one document (bench-results__*.json).
+      # merges everything into one document (bench-results__*.json). Two
+      # explicit patterns (not a broad bench-results-*) so nothing unrelated —
+      # e.g. bench-results-self-test from a dispatch with both run_suite and
+      # self_test — leaks into the stored daily doc.
       - uses: actions/download-artifact@v8
         with:
-          pattern: bench-results-*
+          pattern: bench-results-interaction-*
+          merge-multiple: true
+          path: perf/bench/results
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: bench-results-pageload-*
           merge-multiple: true
           path: perf/bench/results
 


### PR DESCRIPTION
### Description

The `perf/bench` suite has two run paths: a per-PR A/B comparison (already sharded — one parallel job per scenario) and a daily "track-main" run that records an absolute time-series for the trends dashboard. The daily run put every mode — interaction, pageLoad, soak, INP — in one sequential job with a 90-minute cap. Interaction alone took ~68 minutes, so the daily run was at real risk of timing out (and did, on a manual dispatch).

Make the daily run parallel by reusing the PR shard jobs instead of the monolithic one:

- `bench-interaction` / `bench-pageload` now also run on the schedule/dispatch triggers. There's no reference build on those triggers (it's PR-only), so they run in absolute mode — the run step already drops `--reference-dist` when there's nothing to compare against. Session counts now match the PR path in both directions (interaction 6, pageLoad singleString 8 / syntheticLarge 3), so a PR and the daily series measure the same thing.
- `track-main` shrinks to the daily-only modes (soak, INP), then gathers the interaction/pageLoad shard artifacts, merges, and stores one `benchRun` doc.

Wall-clock drops from the sum of all modes (~90 min) to the slowest single scenario in parallel (~20 min) plus soak + INP.

### Notes for release

N/A


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI orchestration for the metrics time-series path; a bad `if` or artifact merge could skip or corrupt daily `benchRun` storage without affecting product runtime code.
> 
> **Overview**
> **Parallelizes the daily `track-main` bench path** by reusing the existing sharded `bench-interaction` and `bench-pageload` jobs instead of running those modes sequentially inside one ~90-minute job.
> 
> `bench-interaction` and `bench-pageload` now also run on the **5am daily cron** and **`workflow_dispatch` with `run_suite`**, in **absolute mode** when `build-reference` is skipped. Job `if` guards use **`!cancelled()`** so they still run when `build-reference` is skipped, and they **exclude** the weekly self-test cron and self-test-only dispatches so shards are not launched for nothing.
> 
> **`track-main`** now **depends on** successful shard jobs, **downloads** `bench-results-interaction-*` and `bench-results-pageload-*` artifacts (narrow patterns so self-test results do not merge in), runs only **soak** and **INP** locally, then **`bench report`** / **`bench store`**. Its timeout drops from **90 to 45 minutes** because interaction and pageLoad wall-clock is bounded by the slowest shard, not the sum of all modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe8fe03945cba760db84c8182c139fe22cf59d63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->