### PR TITLE
fix(structure): clear preference on restore-default and honor menuItems([])

### DIFF
--- a/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderActions.tsx
+++ b/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderActions.tsx
@@ -110,6 +110,16 @@ export const PaneHeaderActions = memo(function PaneHeaderActions(props: PaneHead
   const actionNodes = useMemo(() => menuNodes.filter(isMenuNodeButton), [menuNodes])
   const contextMenuNodes = useMemo(() => menuNodes.filter(isNotMenuNodeButton), [menuNodes])
 
+  // Empty groups still resolve to nodes, so guard against a button that opens
+  // to nothing.
+  const hasContextMenuContent = useMemo(
+    () =>
+      contextMenuNodes.some(
+        (node) => node.type === 'item' || (node.type === 'group' && node.children.length > 0),
+      ),
+    [contextMenuNodes],
+  )
+
   const initialValueTemplateItemFromMenuItems = useMemo(() => {
     return menuItems
       .map((item, menuItemIndex) => {
@@ -176,7 +186,7 @@ export const PaneHeaderActions = memo(function PaneHeaderActions(props: PaneHead
         <PaneHeaderActionButton key={node.key} node={node} />
       ))}
 
-      {contextMenuNodes.length > 0 && <PaneContextMenuButton nodes={contextMenuNodes} />}
+      {hasContextMenuContent && <PaneContextMenuButton nodes={contextMenuNodes} />}
     </Flex>
   )
 })

--- a/packages/sanity/src/structure/panes/documentList/PaneContainer.tsx
+++ b/packages/sanity/src/structure/panes/documentList/PaneContainer.tsx
@@ -133,6 +133,15 @@ export const appendRestoreDefaultItems = (options: {
 
   if (suppressRestoreDefaults) return menuItems
 
+  // Only attach a restore item to a group that already has items, so a pane
+  // that removed them (e.g. `menuItems([])`) does not get them back.
+  const hasSortItems = menuItems.some(
+    (item) => item.group === 'sorting' || item.action === 'setSortOrder',
+  )
+  const hasLayoutItems = menuItems.some(
+    (item) => item.group === 'layout' || item.action === 'setLayout',
+  )
+
   const restoreDefaultSortOrderItem: PaneMenuItem = {
     group: 'sorting',
     action: 'restoreDefaultSortOrder',
@@ -151,7 +160,11 @@ export const appendRestoreDefaultItems = (options: {
     ...(isLayoutDefault && {disabled: {reason: restoreLayoutDisabledReason}}),
   }
 
-  return [...menuItems, restoreDefaultSortOrderItem, restoreDefaultLayoutItem]
+  return [
+    ...menuItems,
+    ...(hasSortItems ? [restoreDefaultSortOrderItem] : []),
+    ...(hasLayoutItems ? [restoreDefaultLayoutItem] : []),
+  ]
 }
 
 export function useShallowUnique<ValueType>(value: ValueType): ValueType {
@@ -236,14 +249,15 @@ export const PaneContainer = memo(function PaneContainer(
     [setStoredSortOrder, schemaType, defaultSortOrder],
   )
 
-  // Write the default back so its matching menu item regains its checkmark.
+  // Clear the stored preference instead of writing the default: the key is
+  // shared per type, so writing would leak this list's default onto its siblings.
   const handleRestoreDefaultSortOrder = useCallback(async () => {
-    await setStoredSortOrder(toStaticSortOrder(defaultSortOrder))
-  }, [setStoredSortOrder, defaultSortOrder])
+    await setStoredSortOrder(null)
+  }, [setStoredSortOrder])
 
   const handleRestoreDefaultLayout = useCallback(async () => {
-    await setLayout(defaultLayout)
-  }, [setLayout, defaultLayout])
+    await setLayout(null)
+  }, [setLayout])
 
   const [customMenuItemState, setCustomMenuItemState] = useState<CustomMenuItemState>({})
 

--- a/packages/sanity/src/structure/panes/documentList/__tests__/PaneContainer.test.tsx
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/PaneContainer.test.tsx
@@ -1,5 +1,6 @@
 import {render, screen} from '@testing-library/react'
-import {defineConfig, type PerspectiveContextValue, useSearchState} from 'sanity'
+import {userEvent} from '@testing-library/user-event'
+import {defineConfig, type PerspectiveContextValue} from 'sanity'
 import {describe, expect, it, type Mock, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
@@ -28,6 +29,15 @@ vi.mock('../../../components/pane/usePaneLayout', () => ({
   usePaneLayout: vi.fn().mockReturnValue({panes: [], mount: vi.fn()}),
 }))
 
+// Stub the list body so tests render the pane header (and its menu) without the
+// heavy preview subtree, while preserving the testid the render test asserts on.
+vi.mock('../DocumentListPane', async () => {
+  const {createElement} = await import('react')
+  return {
+    DocumentListPane: () => createElement('div', {'data-testid': 'document-list-pane'}),
+  }
+})
+
 vi.mock('sanity', async (importOriginal) => ({
   ...(await importOriginal()),
   useSearchState: vi.fn(),
@@ -52,8 +62,6 @@ vi.mock('sanity/router', async (importOriginal) => ({
     navigate: vi.fn(),
   }),
 }))
-
-const mockUseSearchState = useSearchState as Mock
 
 const mockUseStructureToolSetting = useStructureToolSetting as Mock<typeof useStructureToolSetting>
 
@@ -81,6 +89,65 @@ describe('PaneContainer', () => {
 
     await screen.findByTestId('document-list-pane')
   })
+
+  // Restoring must clear the shared per-type key, not write a concrete default
+  // that would leak onto sibling lists. See issue #12835.
+  it('restoring the default clears the persisted sort order instead of writing the configured default', async () => {
+    const config = defineConfig({projectId: 'test', dataset: 'test'})
+    const wrapper = await createTestProvider({
+      config,
+      resources: [structureUsEnglishLocaleBundle],
+    })
+
+    const setSortOrder = vi.fn()
+    const setLayout = vi.fn()
+
+    // The user has manually picked a non-default sort, so "Default sort" is
+    // enabled (the persisted value differs from the configured defaultOrdering).
+    const storedSortOrder = {by: [{field: '_updatedAt', direction: 'desc'}]}
+
+    mockUseStructureToolSetting.mockImplementation(
+      (namespace: string) =>
+        (namespace === 'layout'
+          ? ['default', setLayout]
+          : [storedSortOrder, setSortOrder]) as ReturnType<typeof useStructureToolSetting>,
+    )
+
+    render(
+      <PaneContainer
+        paneKey="paneKey"
+        index={1}
+        itemId="123"
+        pane={
+          {
+            id: 'books-by-title',
+            options: {
+              filter: '_type == $type',
+              params: {type: 'book'},
+              defaultOrdering: [{field: 'title', direction: 'asc'}],
+            },
+            menuItems: [
+              {
+                group: 'sorting',
+                action: 'setSortOrder',
+                title: 'Name',
+                params: {by: [{field: 'name', direction: 'asc'}]},
+              },
+            ],
+          } as unknown as DocumentListPaneNode
+        }
+      />,
+      {wrapper},
+    )
+
+    await userEvent.click(await screen.findByTestId('pane-context-menu-button'))
+    await userEvent.click(await screen.findByText('Default sort'))
+
+    expect(setSortOrder).toHaveBeenCalledTimes(1)
+    // A concrete sort order here leaks into every sibling list of the same type;
+    // clearing (null) lets each list fall back to its own configured default.
+    expect(setSortOrder).toHaveBeenCalledWith(null)
+  })
 })
 
 describe('appendRestoreDefaultItems', () => {
@@ -102,17 +169,52 @@ describe('appendRestoreDefaultItems', () => {
   })
 
   it('appends restore-default items when not suppressed', () => {
+    const sortAndLayout: PaneMenuItem[] = [
+      {group: 'sorting', action: 'setSortOrder', title: 'Last edited'},
+      {group: 'layout', action: 'setLayout', title: 'Detailed view'},
+    ]
+
     const result = appendRestoreDefaultItems({
-      menuItems,
+      menuItems: sortAndLayout,
       isSortDefault: false,
       isLayoutDefault: false,
       restoreSortDisabledReason: 'sort',
       restoreLayoutDisabledReason: 'layout',
     })
 
-    expect(result).toHaveLength(menuItems.length + 2)
+    expect(result).toHaveLength(sortAndLayout.length + 2)
     expect(result.map((item) => item.action)).toContain('restoreDefaultSortOrder')
     expect(result.map((item) => item.action)).toContain('restoreDefaultLayout')
+  })
+
+  it('does not inject restore-default items when there are no menu items to attach to', () => {
+    const result = appendRestoreDefaultItems({
+      menuItems: [],
+      isSortDefault: false,
+      isLayoutDefault: false,
+      restoreSortDisabledReason: 'sort',
+      restoreLayoutDisabledReason: 'layout',
+    })
+
+    expect(result).toEqual([])
+  })
+
+  it('only appends the sort restore item when a sorting item is present', () => {
+    const sortingOnly: PaneMenuItem[] = [
+      {group: 'sorting', action: 'setSortOrder', title: 'Last edited'},
+    ]
+
+    const result = appendRestoreDefaultItems({
+      menuItems: sortingOnly,
+      isSortDefault: false,
+      isLayoutDefault: false,
+      restoreSortDisabledReason: 'sort',
+      restoreLayoutDisabledReason: 'layout',
+    })
+
+    const actions = result.map((item) => item.action)
+    expect(actions).toContain('restoreDefaultSortOrder')
+    expect(actions).not.toContain('restoreDefaultLayout')
   })
 })
 

--- a/packages/sanity/src/structure/panes/documentList/__tests__/addSelectedStateToMenuItems.test.ts
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/addSelectedStateToMenuItems.test.ts
@@ -170,13 +170,22 @@ describe('appendRestoreDefaultItems', () => {
     restoreLayoutDisabledReason: 'Already using the default view',
   }
 
+  // Restore items are only attached to groups that already have items.
+  const baseMenuItems: PaneMenuItem[] = [
+    {id: 'sort', title: 'Sort', group: 'sorting', action: 'setSortOrder'},
+    {id: 'layout', title: 'Layout', group: 'layout', action: 'setLayout'},
+  ]
+
+  const restoreItemsOf = (items: PaneMenuItem[]) =>
+    items.filter(
+      (item) => item.action === 'restoreDefaultSortOrder' || item.action === 'restoreDefaultLayout',
+    )
+
   test('appends a restore-default item to the sorting and layout groups', () => {
-    const existing: PaneMenuItem[] = [{id: 'existing', title: 'Existing', group: 'sorting'}]
+    const result = appendRestoreDefaultItems({menuItems: baseMenuItems, ...restoreOptions})
 
-    const result = appendRestoreDefaultItems({menuItems: existing, ...restoreOptions})
-
-    expect(result).toHaveLength(3)
-    expect(result[0]).toBe(existing[0])
+    expect(result).toHaveLength(4)
+    expect(result[0]).toBe(baseMenuItems[0])
 
     const sortItem = result.find((item) => item.action === 'restoreDefaultSortOrder')
     const layoutItem = result.find((item) => item.action === 'restoreDefaultLayout')
@@ -186,31 +195,42 @@ describe('appendRestoreDefaultItems', () => {
   })
 
   test('hides the selection indicator on both restore items', () => {
-    const result = appendRestoreDefaultItems(restoreOptions)
+    const result = restoreItemsOf(
+      appendRestoreDefaultItems({menuItems: baseMenuItems, ...restoreOptions}),
+    )
 
+    expect(result).toHaveLength(2)
     expect(result.every((item) => item.params?.hideSelectionIndicator === true)).toBe(true)
   })
 
   test('restore items have no id so they do not trigger toggle-state tracking', () => {
-    const result = appendRestoreDefaultItems(restoreOptions)
+    const result = restoreItemsOf(
+      appendRestoreDefaultItems({menuItems: baseMenuItems, ...restoreOptions}),
+    )
 
     expect(result.every((item) => item.id === undefined)).toBe(true)
   })
 
   test('restore items carry no icon', () => {
-    const result = appendRestoreDefaultItems(restoreOptions)
+    const result = restoreItemsOf(
+      appendRestoreDefaultItems({menuItems: baseMenuItems, ...restoreOptions}),
+    )
 
     expect(result.every((item) => item.icon === undefined)).toBe(true)
   })
 
-  test('handles an undefined menu item list', () => {
+  test('appends nothing when there are no groups to attach to', () => {
     const result = appendRestoreDefaultItems(restoreOptions)
 
-    expect(result).toHaveLength(2)
+    expect(result).toHaveLength(0)
   })
 
   test('disables only the sort restore item when sort is already default', () => {
-    const result = appendRestoreDefaultItems({...restoreOptions, isSortDefault: true})
+    const result = appendRestoreDefaultItems({
+      menuItems: baseMenuItems,
+      ...restoreOptions,
+      isSortDefault: true,
+    })
 
     const sortItem = result.find((item) => item.action === 'restoreDefaultSortOrder')
     const layoutItem = result.find((item) => item.action === 'restoreDefaultLayout')
@@ -220,7 +240,11 @@ describe('appendRestoreDefaultItems', () => {
   })
 
   test('disables only the layout restore item when layout is already default', () => {
-    const result = appendRestoreDefaultItems({...restoreOptions, isLayoutDefault: true})
+    const result = appendRestoreDefaultItems({
+      menuItems: baseMenuItems,
+      ...restoreOptions,
+      isLayoutDefault: true,
+    })
 
     const sortItem = result.find((item) => item.action === 'restoreDefaultSortOrder')
     const layoutItem = result.find((item) => item.action === 'restoreDefaultLayout')
@@ -230,7 +254,9 @@ describe('appendRestoreDefaultItems', () => {
   })
 
   test('leaves both restore items enabled when neither setting is default', () => {
-    const result = appendRestoreDefaultItems(restoreOptions)
+    const result = restoreItemsOf(
+      appendRestoreDefaultItems({menuItems: baseMenuItems, ...restoreOptions}),
+    )
 
     expect(result.every((item) => item.disabled === undefined)).toBe(true)
   })

--- a/packages/sanity/src/structure/useStructureToolSetting.ts
+++ b/packages/sanity/src/structure/useStructureToolSetting.ts
@@ -1,7 +1,7 @@
 import {useCallback, useMemo} from 'react'
 import {useObservable} from 'react-rx'
 import {map} from 'rxjs/operators'
-import {useKeyValueStore} from 'sanity'
+import {type KeyValueStoreValue, useKeyValueStore} from 'sanity'
 
 const STRUCTURE_TOOL_NAMESPACE = 'studio.structure-tool'
 
@@ -12,22 +12,25 @@ export function useStructureToolSetting<ValueType>(
   namespace: string,
   key: string | null,
   defaultValue?: ValueType,
-): [ValueType | undefined, (_value: ValueType) => Promise<void>] {
+): [ValueType | undefined, (_value: ValueType | null) => Promise<void>] {
   const keyValueStore = useKeyValueStore()
 
   const keyValueStoreKey = [STRUCTURE_TOOL_NAMESPACE, namespace, key].filter(Boolean).join('.')
 
   const value$ = useMemo(() => {
-    return keyValueStore
-      .getKey(keyValueStoreKey)
-      .pipe(map((value) => (value === null ? defaultValue : value)))
+    return keyValueStore.getKey(keyValueStoreKey).pipe(
+      // The backend persists a cleared entry as `''`, so treat it like `null`.
+      map((value) => (value === null || value === '' ? defaultValue : value)),
+    )
   }, [defaultValue, keyValueStore, keyValueStoreKey])
 
   const value = useObservable(value$, defaultValue) as ValueType
   const set = useCallback(
-    async (newValue: ValueType) => {
+    async (newValue: ValueType | null) => {
       if (newValue !== value) {
-        await keyValueStore.setKey(keyValueStoreKey, newValue as string)
+        // A `null` value clears the stored entry: `getKey` coerces the empty
+        // value back to `null`, so reads fall through to `defaultValue`.
+        await keyValueStore.setKey(keyValueStoreKey, newValue as KeyValueStoreValue)
       }
     },
     [keyValueStore, keyValueStoreKey, value],


### PR DESCRIPTION
### Description

Follow-up to #12835. The restore-default sort and layout feature shipped with two issues: a document list configured with `menuItems([])` still showed injected "Default sort" and "Default view" entries, and because sort order and layout are persisted under a key shared by every list of the same document type, choosing "Default sort" or "Default view" wrote that list's default into the shared key and overrode sibling lists configured with a different default.

This PR makes restore clear the stored preference instead of writing a concrete default, so each list falls back to its own configured default, and only injects restore items into a menu group that already has items, so `menuItems([])` yields an empty menu. It also hides the pane context-menu button when it would open to nothing, and treats the backend's empty-string cleared value as unset so an in-session restore reverts without a reload.

### What to review

- `useStructureToolSetting` now accepts `null` to clear an entry and treats `''` (the backend's cleared value) as unset.
- `appendRestoreDefaultItems` only attaches a restore item to a `sorting` or `layout` group that already has items.

### Testing

Added unit tests in `PaneContainer.test.tsx` for the clear-on-restore behaviour and the empty-menu case. Manually verified in the test studio with several lists of the same type configured with different defaults.

### Notes for release

"Default sort" and "Default view" in a document list now return that list to its own configured default instead of overriding other lists of the same type, and a list configured with `menuItems([])` no longer shows injected menu items.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persisted sort/layout semantics on a shared per-document-type key and menu injection rules, which affects all document lists of a type but is a targeted bugfix with unit coverage.
> 
> **Overview**
> Fixes document list pane menu and restore-default behavior from #12835: **"Default sort" / "Default view"** now **clear** the shared per-type persisted preference (`null`) instead of writing that list’s concrete default, so sibling lists keep their own `defaultOrdering` / layout defaults.
> 
> **Restore-default injection** only adds those items when the menu already has sorting or layout entries, so **`menuItems([])`** stays empty. **`PaneHeaderActions`** hides the context-menu control when resolved nodes would be empty (non-empty groups with no children).
> 
> **`useStructureToolSetting`** allows **`null`** to clear storage and treats backend **`''`** as unset so restore applies in-session without a reload. Tests cover clear-on-restore and empty-menu cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93417130b9e75ddbcc59ba954de87b31dc5a3270. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->