### PR TITLE
feat(structure): support custom component pane widths

### DIFF
--- a/packages/sanity/src/structure/panes/userComponent/UserComponentPane.tsx
+++ b/packages/sanity/src/structure/panes/userComponent/UserComponentPane.tsx
@@ -18,8 +18,11 @@ export function UserComponentPane(props: UserComponentPaneProps) {
   const {
     child,
     component: UserComponent,
+    currentMaxWidth,
+    maxWidth,
     menuItems,
     menuItemGroups,
+    minWidth = 320,
     type: _unused,
     ...restPane
   } = pane
@@ -31,7 +34,13 @@ export function UserComponentPane(props: UserComponentPaneProps) {
   const {key, ...componentProps} = {...restProps, ...restPane}
 
   return (
-    <Pane id={paneKey} minWidth={320} selected={restProps.isSelected}>
+    <Pane
+      currentMaxWidth={currentMaxWidth}
+      id={paneKey}
+      maxWidth={maxWidth}
+      minWidth={minWidth}
+      selected={restProps.isSelected}
+    >
       <UserComponentPaneHeader
         actionHandlers={ref?.actionHandlers}
         index={index}

--- a/packages/sanity/src/structure/structureBuilder/Component.ts
+++ b/packages/sanity/src/structure/structureBuilder/Component.ts
@@ -29,6 +29,12 @@ export interface Component extends StructureNode {
   component: UserComponent
   /** Component child of type {@link Child} */
   child?: Child
+  /** Minimum width of the component pane in pixels */
+  minWidth?: number
+  /** Maximum width of the component pane before it is manually resized, in pixels */
+  currentMaxWidth?: number
+  /** Maximum width of the component pane in pixels */
+  maxWidth?: number
   /** Component menu items, array of type {@link MenuItem} */
   menuItems: MenuItem[]
   /** Component menu item group, array of type {@link MenuItemGroup} */
@@ -48,6 +54,12 @@ export interface ComponentInput extends StructureNode {
   component: UserComponent
   /** Component child of type {@link Child} */
   child?: Child
+  /** Minimum width of the component pane in pixels */
+  minWidth?: number
+  /** Maximum width of the component pane before it is manually resized, in pixels */
+  currentMaxWidth?: number
+  /** Maximum width of the component pane in pixels */
+  maxWidth?: number
   /** Component options */
   options?: {[key: string]: unknown}
   /** Component menu items. See {@link MenuItem} and {@link MenuItemBuilder}  */
@@ -66,6 +78,12 @@ export interface BuildableComponent extends Partial<StructureNode> {
   component?: UserComponent
   /** Component child of type {@link Child} */
   child?: Child
+  /** Minimum width of the component pane in pixels */
+  minWidth?: number
+  /** Maximum width of the component pane before it is manually resized, in pixels */
+  currentMaxWidth?: number
+  /** Maximum width of the component pane in pixels */
+  maxWidth?: number
   /** Component options */
   options?: {[key: string]: unknown}
   /** Component menu items. See {@link MenuItem} and {@link MenuItemBuilder}  */
@@ -148,6 +166,51 @@ export class ComponentBuilder implements Serializable<Component> {
     return this.spec.child
   }
 
+  /** Set the minimum width of the component pane
+   * @param minWidth - Minimum width in pixels
+   * @returns component builder with the minimum width applied
+   */
+  minWidth(minWidth: number): ComponentBuilder {
+    return this.clone({minWidth})
+  }
+
+  /** Get the minimum width of the component pane
+   * @returns minimum width in pixels
+   */
+  getMinWidth(): BuildableComponent['minWidth'] {
+    return this.spec.minWidth
+  }
+
+  /** Set the maximum width of the component pane before it is manually resized
+   * @param currentMaxWidth - Maximum width in pixels before manual resizing
+   * @returns component builder with the current maximum width applied
+   */
+  currentMaxWidth(currentMaxWidth: number): ComponentBuilder {
+    return this.clone({currentMaxWidth})
+  }
+
+  /** Get the maximum width of the component pane before it is manually resized
+   * @returns current maximum width in pixels
+   */
+  getCurrentMaxWidth(): BuildableComponent['currentMaxWidth'] {
+    return this.spec.currentMaxWidth
+  }
+
+  /** Set the maximum width of the component pane
+   * @param maxWidth - Maximum width in pixels
+   * @returns component builder with the maximum width applied
+   */
+  maxWidth(maxWidth: number): ComponentBuilder {
+    return this.clone({maxWidth})
+  }
+
+  /** Get the maximum width of the component pane
+   * @returns maximum width in pixels
+   */
+  getMaxWidth(): BuildableComponent['maxWidth'] {
+    return this.spec.maxWidth
+  }
+
   /** Set component
    * @param component - user built component
    * @returns component builder based on component provided
@@ -218,7 +281,16 @@ export class ComponentBuilder implements Serializable<Component> {
    *
    */
   serialize(options: SerializeOptions = {path: []}): Component {
-    const {id, title, child, options: componentOptions, component} = this.spec
+    const {
+      id,
+      title,
+      child,
+      minWidth,
+      currentMaxWidth,
+      maxWidth,
+      options: componentOptions,
+      component,
+    } = this.spec
     if (!id) {
       throw new SerializeError(
         '`id` is required for `component` structure item',
@@ -240,6 +312,9 @@ export class ComponentBuilder implements Serializable<Component> {
       title,
       type: 'component',
       child,
+      minWidth,
+      currentMaxWidth,
+      maxWidth,
       component,
       canHandleIntent: this.spec.canHandleIntent,
       options: componentOptions || {},

--- a/packages/sanity/src/structure/structureBuilder/__tests__/Component.test.ts
+++ b/packages/sanity/src/structure/structureBuilder/__tests__/Component.test.ts
@@ -1,0 +1,30 @@
+import {describe, expect, it} from 'vitest'
+
+import {ComponentBuilder} from '../Component'
+
+function TestComponent() {
+  return null
+}
+
+describe('ComponentBuilder', () => {
+  describe('pane widths', () => {
+    it('sets, gets, and serializes pane width constraints', () => {
+      const builder = new ComponentBuilder({
+        id: 'custom-pane',
+        component: TestComponent,
+      })
+        .minWidth(320)
+        .currentMaxWidth(350)
+        .maxWidth(640)
+
+      expect(builder.getMinWidth()).toBe(320)
+      expect(builder.getCurrentMaxWidth()).toBe(350)
+      expect(builder.getMaxWidth()).toBe(640)
+      expect(builder.serialize()).toMatchObject({
+        minWidth: 320,
+        currentMaxWidth: 350,
+        maxWidth: 640,
+      })
+    })
+  })
+})

--- a/packages/sanity/src/structure/types.ts
+++ b/packages/sanity/src/structure/types.ts
@@ -292,6 +292,9 @@ export interface BaseResolvedPaneNode<T extends PaneNode['type']> {
 export interface CustomComponentPaneNode extends BaseResolvedPaneNode<'component'> {
   component: UserComponent
   options?: Record<string, unknown>
+  minWidth?: number
+  currentMaxWidth?: number
+  maxWidth?: number
   // component: React.ComponentType<Props> | React.ReactNode
 }
 


### PR DESCRIPTION
## Summary

- add optional `minWidth`, `currentMaxWidth`, and `maxWidth` settings to custom component panes and the component structure builder
- forward configured width constraints to the pane layout while preserving the existing 320px minimum and unconstrained defaults
- add coverage for builder getters and serialized width settings

This enables custom list components such as `@sanity/orderable-document-list` to opt into the same sizing behavior as built-in document-list panes (`320 / 350 / 640`) without changing the default behavior of other custom panes.

Example showing the unconstrained width of `@sanity/orderable-document-list`:

<img width="3680" height="2284" alt="CleanShot 2026-07-15 at 12 36 22@2x" src="https://github.com/user-attachments/assets/38799d8e-e3f8-478e-887d-3ff4600adc43" />

## Test plan

- [x] `pnpm build`
- [x] `pnpm check:format`
- [x] `pnpm check:oxlint`
- [x] `pnpm check:types`
- [x] `pnpm depcheck`
- [x] `pnpm test:exports`
- [x] `pnpm vitest run --project=sanity packages/sanity/src/structure/structureBuilder/__tests__/Component.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public structure-builder API extension and UI layout wiring only; defaults preserve existing pane behavior when width options are omitted.
> 
> **Overview**
> Custom **component** structure panes can now opt into the same resizable width behavior as built-in list panes instead of being stuck with a fixed layout.
> 
> **`ComponentBuilder`** gains optional **`minWidth`**, **`currentMaxWidth`**, and **`maxWidth`** (with getters and serialization). Resolved component pane types carry these fields, and **`UserComponentPane`** passes them through to **`Pane`** while keeping **320px** as the default minimum when unset.
> 
> A small **`ComponentBuilder`** test covers set/get/serialize for the width settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4d2362916e9e570052d932b1586747bf8d4c527. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->