### PR TITLE
fix(structure): hide share action when the targeted document does not exist

### DIFF
--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -11,8 +11,6 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'action.copy-document-id.label': 'Copy document ID',
   /** Tooltip for the copy actions dropdown button in the document panel header */
   'action.copy-document-url.label': 'Copy',
-  /** Tooltip for the copy actions dropdown button when disabled because the document does not exist in the current perspective */
-  'action.copy-document-url.disabled.no-document': "This document doesn't exist yet",
   /** Label for the "Copy document URL" menu item */
   'action.copy-link-to-document.label': 'Copy document URL',
   /** Tooltip when action button is disabled because the operation is not ready   */

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -11,6 +11,8 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'action.copy-document-id.label': 'Copy document ID',
   /** Tooltip for the copy actions dropdown button in the document panel header */
   'action.copy-document-url.label': 'Copy',
+  /** Tooltip for the copy actions dropdown button when disabled because the document does not exist in the current perspective */
+  'action.copy-document-url.disabled.no-document': "This document doesn't exist yet",
   /** Label for the "Copy document URL" menu item */
   'action.copy-link-to-document.label': 'Copy document URL',
   /** Tooltip when action button is disabled because the operation is not ready   */

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/CopyDocumentActions.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/CopyDocumentActions.tsx
@@ -118,6 +118,10 @@ export function CopyDocumentActions() {
     })
   }, [contextAwareDocumentId, pushToast, t, telemetry])
 
+  if (!documentExists) {
+    return null
+  }
+
   return (
     <MenuButton
       id="copy-document-actions"
@@ -125,12 +129,7 @@ export function CopyDocumentActions() {
         <Button
           icon={ShareIcon}
           mode="bleed"
-          disabled={!documentExists}
-          tooltipProps={{
-            content: documentExists
-              ? t('action.copy-document-url.label')
-              : t('action.copy-document-url.disabled.no-document'),
-          }}
+          tooltipProps={{content: t('action.copy-document-url.label')}}
           data-testid="copy-document-actions-button"
         />
       }

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/CopyDocumentActions.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/CopyDocumentActions.tsx
@@ -65,10 +65,10 @@ export function CopyDocumentActions() {
     targetDocumentState.status === 'variant-missing' ||
     targetDocumentState.status === 'variant-definition-document-not-found'
 
-  const documentReady = Boolean(editState?.ready) && !documentVersionsLoading
+  const existenceCheckReady = Boolean(editState?.ready) && !documentVersionsLoading
 
   const copiedVersionMissing =
-    documentReady &&
+    existenceCheckReady &&
     isVersionId(contextAwareDocumentId) &&
     !isNewDocument(editState) &&
     !existingDocumentIds.includes(contextAwareDocumentId)

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/CopyDocumentActions.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/CopyDocumentActions.tsx
@@ -30,7 +30,7 @@ import {useDocumentPaneInfo} from '../../useDocumentPaneInfo'
  */
 export function CopyDocumentActions() {
   const {documentId, documentType, schemaType} = useDocumentPaneInfo()
-  const {editState} = useDocumentPane()
+  const {editState, displayed} = useDocumentPane()
   const targetDocumentState = useTargetDocumentState(documentId)
   const {selectedReleaseId, selectedPerspectiveName} = usePerspective()
   const {params} = usePaneRouter()
@@ -55,11 +55,15 @@ export function CopyDocumentActions() {
     return getDraftId(documentId)
   }, [documentId, scheduledDraft, schemaType?.liveEdit, selectedPerspectiveName, selectedReleaseId])
 
+  const isCreatingDocument = Boolean(displayed && !displayed._createdAt)
+
   const selectedVariantMissing =
     targetDocumentState.status === 'variant-missing' ||
     targetDocumentState.status === 'variant-definition-document-not-found'
 
-  const pinnedVersionMissing = Boolean(editState?.ready && editState.scopeId && !editState.version)
+  const pinnedVersionMissing = Boolean(
+    editState?.ready && editState.scopeId && !editState.version && !isCreatingDocument,
+  )
 
   const documentExists = !selectedVariantMissing && !pinnedVersionMissing
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/CopyDocumentActions.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/CopyDocumentActions.tsx
@@ -11,6 +11,7 @@ import {Button, MenuButton, MenuItem} from '../../../../../ui-components'
 import {usePaneRouter} from '../../../../components'
 import {structureLocaleNamespace} from '../../../../i18n'
 import {DocumentIDCopied, DocumentURLCopied} from '../../__telemetry__'
+import {useDocumentPane} from '../../useDocumentPane'
 import {useDocumentPaneInfo} from '../../useDocumentPaneInfo'
 
 /**
@@ -22,6 +23,7 @@ import {useDocumentPaneInfo} from '../../useDocumentPaneInfo'
  */
 export function CopyDocumentActions() {
   const {documentId, documentType, schemaType} = useDocumentPaneInfo()
+  const {editState} = useDocumentPane()
   const {selectedReleaseId, selectedPerspectiveName} = usePerspective()
   const {params} = usePaneRouter()
   const {resolveIntentLink} = useRouter()
@@ -44,6 +46,30 @@ export function CopyDocumentActions() {
 
     return getDraftId(documentId)
   }, [documentId, scheduledDraft, schemaType?.liveEdit, selectedPerspectiveName, selectedReleaseId])
+
+  /**
+   * Whether the document referenced by `contextAwareDocumentId` actually exists in the current
+   * perspective. When a release perspective is pinned but the document isn't part of that release
+   * (or when viewing a published/draft that doesn't exist yet), copying the id/URL would hand out a
+   * reference to a document that doesn't exist. In that case we disable the button.
+   *
+   * Gated on `editState.ready` so we don't flash the disabled state while the initial snapshots are
+   * still loading (all snapshots are `null` until then).
+   */
+  const documentExists = useMemo(() => {
+    if (!editState?.ready) return true
+
+    const versionReleaseId = scheduledDraft || selectedReleaseId
+    if (versionReleaseId) {
+      return Boolean(editState.version)
+    }
+
+    if (selectedPerspectiveName === 'published' || schemaType?.liveEdit) {
+      return Boolean(editState.published)
+    }
+
+    return Boolean(editState.draft || editState.published)
+  }, [editState, scheduledDraft, selectedReleaseId, selectedPerspectiveName, schemaType?.liveEdit])
 
   const handleCopyLink = useCallback(async () => {
     telemetry.log(DocumentURLCopied)
@@ -95,7 +121,12 @@ export function CopyDocumentActions() {
         <Button
           icon={ShareIcon}
           mode="bleed"
-          tooltipProps={{content: t('action.copy-document-url.label')}}
+          disabled={!documentExists}
+          tooltipProps={{
+            content: documentExists
+              ? t('action.copy-document-url.label')
+              : t('action.copy-document-url.disabled.no-document'),
+          }}
           data-testid="copy-document-actions-button"
         />
       }

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/CopyDocumentActions.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/CopyDocumentActions.tsx
@@ -7,6 +7,9 @@ import {useCallback, useMemo} from 'react'
 import {
   getDraftId,
   getVersionId,
+  isNewDocument,
+  isVersionId,
+  useDocumentVersions,
   usePerspective,
   useStudioUrl,
   useTargetDocumentState,
@@ -30,8 +33,11 @@ import {useDocumentPaneInfo} from '../../useDocumentPaneInfo'
  */
 export function CopyDocumentActions() {
   const {documentId, documentType, schemaType} = useDocumentPaneInfo()
-  const {editState, displayed} = useDocumentPane()
+  const {editState} = useDocumentPane()
   const targetDocumentState = useTargetDocumentState(documentId)
+  const {data: existingDocumentIds, loading: documentVersionsLoading} = useDocumentVersions({
+    documentId,
+  })
   const {selectedReleaseId, selectedPerspectiveName} = usePerspective()
   const {params} = usePaneRouter()
   const {resolveIntentLink} = useRouter()
@@ -55,17 +61,19 @@ export function CopyDocumentActions() {
     return getDraftId(documentId)
   }, [documentId, scheduledDraft, schemaType?.liveEdit, selectedPerspectiveName, selectedReleaseId])
 
-  const isCreatingDocument = Boolean(displayed && !displayed._createdAt)
-
   const selectedVariantMissing =
     targetDocumentState.status === 'variant-missing' ||
     targetDocumentState.status === 'variant-definition-document-not-found'
 
-  const pinnedVersionMissing = Boolean(
-    editState?.ready && editState.scopeId && !editState.version && !isCreatingDocument,
-  )
+  const documentReady = Boolean(editState?.ready) && !documentVersionsLoading
 
-  const documentExists = !selectedVariantMissing && !pinnedVersionMissing
+  const copiedVersionMissing =
+    documentReady &&
+    isVersionId(contextAwareDocumentId) &&
+    !isNewDocument(editState) &&
+    !existingDocumentIds.includes(contextAwareDocumentId)
+
+  const documentExists = !selectedVariantMissing && !copiedVersionMissing
 
   const handleCopyLink = useCallback(async () => {
     telemetry.log(DocumentURLCopied)

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/CopyDocumentActions.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/CopyDocumentActions.tsx
@@ -4,7 +4,14 @@ import {TargetIcon} from '@sanity/icons/Target'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {Menu, useToast} from '@sanity/ui'
 import {useCallback, useMemo} from 'react'
-import {getDraftId, getVersionId, usePerspective, useStudioUrl, useTranslation} from 'sanity'
+import {
+  getDraftId,
+  getVersionId,
+  usePerspective,
+  useStudioUrl,
+  useTargetDocumentState,
+  useTranslation,
+} from 'sanity'
 import {useRouter} from 'sanity/router'
 
 import {Button, MenuButton, MenuItem} from '../../../../../ui-components'
@@ -24,6 +31,7 @@ import {useDocumentPaneInfo} from '../../useDocumentPaneInfo'
 export function CopyDocumentActions() {
   const {documentId, documentType, schemaType} = useDocumentPaneInfo()
   const {editState} = useDocumentPane()
+  const targetDocumentState = useTargetDocumentState(documentId)
   const {selectedReleaseId, selectedPerspectiveName} = usePerspective()
   const {params} = usePaneRouter()
   const {resolveIntentLink} = useRouter()
@@ -47,26 +55,13 @@ export function CopyDocumentActions() {
     return getDraftId(documentId)
   }, [documentId, scheduledDraft, schemaType?.liveEdit, selectedPerspectiveName, selectedReleaseId])
 
-  /**
-   * Whether the document the copy actions would reference actually exists.
-   *
-   * This only matters when the pane is checked out on a *version* — a release bundle or a variant —
-   * which `editState.scopeId` identifies (it's `undefined` for the base draft/published pair). If a
-   * release perspective is pinned (or a variant is selected) but that version doesn't exist, copying
-   * the id/URL would hand out a `versions.<scopeId>.<id>` reference to a document that isn't there,
-   * so we disable the button.
-   *
-   * The base draft/published pair always allows sharing: a missing draft is represented by a
-   * pseudo-draft, so there's still a meaningful document to share.
-   *
-   * Gated on `editState.ready` so we don't flash the disabled state while the initial snapshots are
-   * still loading (all snapshots are `null` until then).
-   */
-  const documentExists = useMemo(() => {
-    if (!editState?.ready) return true
-    if (!editState.scopeId) return true
-    return Boolean(editState.version)
-  }, [editState])
+  const selectedVariantMissing =
+    targetDocumentState.status === 'variant-missing' ||
+    targetDocumentState.status === 'variant-definition-document-not-found'
+
+  const pinnedVersionMissing = Boolean(editState?.ready && editState.scopeId && !editState.version)
+
+  const documentExists = !selectedVariantMissing && !pinnedVersionMissing
 
   const handleCopyLink = useCallback(async () => {
     telemetry.log(DocumentURLCopied)

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/CopyDocumentActions.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/CopyDocumentActions.tsx
@@ -48,28 +48,25 @@ export function CopyDocumentActions() {
   }, [documentId, scheduledDraft, schemaType?.liveEdit, selectedPerspectiveName, selectedReleaseId])
 
   /**
-   * Whether the document referenced by `contextAwareDocumentId` actually exists in the current
-   * perspective. When a release perspective is pinned but the document isn't part of that release
-   * (or when viewing a published/draft that doesn't exist yet), copying the id/URL would hand out a
-   * reference to a document that doesn't exist. In that case we disable the button.
+   * Whether the document the copy actions would reference actually exists.
+   *
+   * This only matters when the pane is checked out on a *version* — a release bundle or a variant —
+   * which `editState.scopeId` identifies (it's `undefined` for the base draft/published pair). If a
+   * release perspective is pinned (or a variant is selected) but that version doesn't exist, copying
+   * the id/URL would hand out a `versions.<scopeId>.<id>` reference to a document that isn't there,
+   * so we disable the button.
+   *
+   * The base draft/published pair always allows sharing: a missing draft is represented by a
+   * pseudo-draft, so there's still a meaningful document to share.
    *
    * Gated on `editState.ready` so we don't flash the disabled state while the initial snapshots are
    * still loading (all snapshots are `null` until then).
    */
   const documentExists = useMemo(() => {
     if (!editState?.ready) return true
-
-    const versionReleaseId = scheduledDraft || selectedReleaseId
-    if (versionReleaseId) {
-      return Boolean(editState.version)
-    }
-
-    if (selectedPerspectiveName === 'published' || schemaType?.liveEdit) {
-      return Boolean(editState.published)
-    }
-
-    return Boolean(editState.draft || editState.published)
-  }, [editState, scheduledDraft, selectedReleaseId, selectedPerspectiveName, schemaType?.liveEdit])
+    if (!editState.scopeId) return true
+    return Boolean(editState.version)
+  }, [editState])
 
   const handleCopyLink = useCallback(async () => {
     telemetry.log(DocumentURLCopied)

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
@@ -82,6 +82,12 @@ const EXISTING_EDIT_STATE = {
   version: null,
 }
 
+const EXISTING_DISPLAYED = {
+  _id: 'drafts.doc-123',
+  _type: 'article',
+  _createdAt: '2026-01-01T00:00:00Z',
+}
+
 let wrapper: React.ComponentType<{children: React.ReactNode}>
 
 beforeAll(async () => {
@@ -108,6 +114,7 @@ describe('CopyDocumentActions', () => {
       documentId: 'doc-123',
       documentType: 'article',
       editState: EXISTING_EDIT_STATE,
+      displayed: EXISTING_DISPLAYED,
     })
     mockUseTargetDocumentState.mockReturnValue(READY_TARGET_STATE)
   })
@@ -309,11 +316,38 @@ describe('CopyDocumentActions', () => {
           published: {_id: 'doc-123'},
           version: null,
         },
+        displayed: EXISTING_DISPLAYED,
       })
 
       render(<CopyDocumentActions />, {wrapper})
 
       expect(screen.getByTestId('copy-document-actions-button')).toBeDisabled()
+    })
+
+    it('stays enabled when creating a new document inside a release', () => {
+      mockUsePerspective.mockReturnValue({
+        ...DEFAULT_PERSPECTIVE,
+        selectedPerspectiveName: 'rMyRelease',
+        selectedReleaseId: 'rMyRelease',
+        selectedPerspective: 'rMyRelease',
+        perspectiveStack: ['rMyRelease', 'drafts'],
+      })
+      mockUseDocumentPane.mockReturnValue({
+        documentId: 'doc-123',
+        documentType: 'article',
+        editState: {
+          ready: true,
+          scopeId: 'rMyRelease',
+          draft: null,
+          published: null,
+          version: null,
+        },
+        displayed: {_id: 'versions.rMyRelease.doc-123', _type: 'article'},
+      })
+
+      render(<CopyDocumentActions />, {wrapper})
+
+      expect(screen.getByTestId('copy-document-actions-button')).not.toBeDisabled()
     })
 
     it('enables the button when the pinned release contains the version', () => {
@@ -357,6 +391,7 @@ describe('CopyDocumentActions', () => {
           published: {_id: 'doc-123'},
           version: null,
         },
+        displayed: {_id: 'doc-123', _type: 'article'},
       })
 
       render(<CopyDocumentActions />, {wrapper})

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
@@ -299,7 +299,7 @@ describe('CopyDocumentActions', () => {
     })
   })
 
-  describe('Disabled state', () => {
+  describe('Visibility', () => {
     const pinRelease = (releaseId: string) =>
       mockUsePerspective.mockReturnValue({
         ...DEFAULT_PERSPECTIVE,
@@ -309,7 +309,7 @@ describe('CopyDocumentActions', () => {
         perspectiveStack: [releaseId, 'drafts'],
       })
 
-    it('disables the button when a release is pinned but the version does not exist', () => {
+    it('hides the button when a release is pinned but the version does not exist', () => {
       pinRelease('rMyRelease')
       mockUseDocumentPane.mockReturnValue({
         documentId: 'doc-123',
@@ -320,10 +320,10 @@ describe('CopyDocumentActions', () => {
 
       render(<CopyDocumentActions />, {wrapper})
 
-      expect(screen.getByTestId('copy-document-actions-button')).toBeDisabled()
+      expect(screen.queryByTestId('copy-document-actions-button')).not.toBeInTheDocument()
     })
 
-    it('disables the button when the pinned release differs from the only existing version', () => {
+    it('hides the button when the pinned release differs from the only existing version', () => {
       pinRelease('rMyRelease')
       mockUseDocumentPane.mockReturnValue({
         documentId: 'doc-123',
@@ -342,10 +342,10 @@ describe('CopyDocumentActions', () => {
 
       render(<CopyDocumentActions />, {wrapper})
 
-      expect(screen.getByTestId('copy-document-actions-button')).toBeDisabled()
+      expect(screen.queryByTestId('copy-document-actions-button')).not.toBeInTheDocument()
     })
 
-    it('stays enabled when creating a new document inside a release', () => {
+    it('stays visible when creating a new document inside a release', () => {
       pinRelease('rMyRelease')
       mockUseDocumentPane.mockReturnValue({
         documentId: 'doc-123',
@@ -356,10 +356,10 @@ describe('CopyDocumentActions', () => {
 
       render(<CopyDocumentActions />, {wrapper})
 
-      expect(screen.getByTestId('copy-document-actions-button')).not.toBeDisabled()
+      expect(screen.getByTestId('copy-document-actions-button')).toBeInTheDocument()
     })
 
-    it('enables the button when the pinned release contains the version', () => {
+    it('shows the button when the pinned release contains the version', () => {
       pinRelease('rMyRelease')
       mockUseDocumentPane.mockReturnValue({
         documentId: 'doc-123',
@@ -378,10 +378,10 @@ describe('CopyDocumentActions', () => {
 
       render(<CopyDocumentActions />, {wrapper})
 
-      expect(screen.getByTestId('copy-document-actions-button')).not.toBeDisabled()
+      expect(screen.getByTestId('copy-document-actions-button')).toBeInTheDocument()
     })
 
-    it('disables the button when the selected variant does not exist', () => {
+    it('hides the button when the selected variant does not exist', () => {
       mockUseTargetDocumentState.mockReturnValue({
         status: 'variant-missing',
         variant: {_id: 'variant-1'},
@@ -390,10 +390,10 @@ describe('CopyDocumentActions', () => {
 
       render(<CopyDocumentActions />, {wrapper})
 
-      expect(screen.getByTestId('copy-document-actions-button')).toBeDisabled()
+      expect(screen.queryByTestId('copy-document-actions-button')).not.toBeInTheDocument()
     })
 
-    it('disables the button when the selected variant definition is not found', () => {
+    it('hides the button when the selected variant definition is not found', () => {
       mockUseTargetDocumentState.mockReturnValue({
         status: 'variant-definition-document-not-found',
         requestedVariantName: 'unknown-variant',
@@ -401,10 +401,10 @@ describe('CopyDocumentActions', () => {
 
       render(<CopyDocumentActions />, {wrapper})
 
-      expect(screen.getByTestId('copy-document-actions-button')).toBeDisabled()
+      expect(screen.queryByTestId('copy-document-actions-button')).not.toBeInTheDocument()
     })
 
-    it('enables the button when the selected variant exists', () => {
+    it('shows the button when the selected variant exists', () => {
       mockUseTargetDocumentState.mockReturnValue({
         status: 'ready',
         targetDocument: {_id: 'versions.v1a2b3c4.doc-123'},
@@ -414,10 +414,10 @@ describe('CopyDocumentActions', () => {
 
       render(<CopyDocumentActions />, {wrapper})
 
-      expect(screen.getByTestId('copy-document-actions-button')).not.toBeDisabled()
+      expect(screen.getByTestId('copy-document-actions-button')).toBeInTheDocument()
     })
 
-    it('stays enabled on the drafts perspective when no draft exists (pseudo-draft)', () => {
+    it('stays visible on the drafts perspective when no draft exists (pseudo-draft)', () => {
       mockUseDocumentPane.mockReturnValue({
         documentId: 'doc-123',
         documentType: 'article',
@@ -427,10 +427,10 @@ describe('CopyDocumentActions', () => {
 
       render(<CopyDocumentActions />, {wrapper})
 
-      expect(screen.getByTestId('copy-document-actions-button')).not.toBeDisabled()
+      expect(screen.getByTestId('copy-document-actions-button')).toBeInTheDocument()
     })
 
-    it('stays enabled while the document versions are still loading', () => {
+    it('stays visible while the document versions are still loading', () => {
       pinRelease('rMyRelease')
       mockUseDocumentPane.mockReturnValue({
         documentId: 'doc-123',
@@ -446,18 +446,18 @@ describe('CopyDocumentActions', () => {
 
       render(<CopyDocumentActions />, {wrapper})
 
-      expect(screen.getByTestId('copy-document-actions-button')).not.toBeDisabled()
+      expect(screen.getByTestId('copy-document-actions-button')).toBeInTheDocument()
     })
 
-    it('stays enabled while the target document state is still resolving', () => {
+    it('stays visible while the target document state is still resolving', () => {
       mockUseTargetDocumentState.mockReturnValue({status: 'resolving'})
 
       render(<CopyDocumentActions />, {wrapper})
 
-      expect(screen.getByTestId('copy-document-actions-button')).not.toBeDisabled()
+      expect(screen.getByTestId('copy-document-actions-button')).toBeInTheDocument()
     })
 
-    it('stays enabled while the edit state is not yet ready', () => {
+    it('stays visible while the edit state is not yet ready', () => {
       pinRelease('rMyRelease')
       mockUseDocumentPane.mockReturnValue({
         documentId: 'doc-123',
@@ -467,7 +467,7 @@ describe('CopyDocumentActions', () => {
 
       render(<CopyDocumentActions />, {wrapper})
 
-      expect(screen.getByTestId('copy-document-actions-button')).not.toBeDisabled()
+      expect(screen.getByTestId('copy-document-actions-button')).toBeInTheDocument()
     })
   })
 })

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
@@ -1,6 +1,6 @@
 import {render, screen} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
-import {usePerspective} from 'sanity'
+import {usePerspective, useTargetDocumentState} from 'sanity'
 import {type Mock, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
@@ -25,9 +25,17 @@ const DEFAULT_PERSPECTIVE = {
   excludedPerspectives: [],
 }
 
+const READY_TARGET_STATE = {
+  status: 'ready' as const,
+  targetDocument: undefined,
+  scopeId: undefined,
+  variant: undefined,
+}
+
 vi.mock('sanity', async (importOriginal) => ({
   ...(await importOriginal()),
   usePerspective: vi.fn(() => DEFAULT_PERSPECTIVE),
+  useTargetDocumentState: vi.fn(() => READY_TARGET_STATE),
   useStudioUrl: vi.fn(() => ({
     studioUrl: 'http://localhost:3333',
     buildIntentUrl: mockBuildIntentUrl,
@@ -64,9 +72,8 @@ const mockUsePerspective = usePerspective as Mock
 const mockUsePaneRouter = usePaneRouter as Mock
 const mockUseDocumentPaneInfo = useDocumentPaneInfo as Mock
 const mockUseDocumentPane = useDocumentPane as Mock
+const mockUseTargetDocumentState = useTargetDocumentState as Mock
 
-// An edit state for the base draft/published pair (no version checked out), so the share button is
-// enabled regardless of the selected perspective.
 const EXISTING_EDIT_STATE = {
   ready: true,
   scopeId: undefined,
@@ -102,6 +109,7 @@ describe('CopyDocumentActions', () => {
       documentType: 'article',
       editState: EXISTING_EDIT_STATE,
     })
+    mockUseTargetDocumentState.mockReturnValue(READY_TARGET_STATE)
   })
 
   async function clickMenuItem(testId: string) {
@@ -334,12 +342,39 @@ describe('CopyDocumentActions', () => {
     })
 
     it('disables the button when the selected variant does not exist', () => {
+      mockUseTargetDocumentState.mockReturnValue({
+        status: 'variant-missing',
+        variant: {_id: 'variant-1'},
+        bundle: 'published',
+      })
       mockUseDocumentPane.mockReturnValue({
         documentId: 'doc-123',
         documentType: 'article',
         editState: {
           ready: true,
-          scopeId: 'v1a2b3c4',
+          scopeId: undefined,
+          draft: null,
+          published: {_id: 'doc-123'},
+          version: null,
+        },
+      })
+
+      render(<CopyDocumentActions />, {wrapper})
+
+      expect(screen.getByTestId('copy-document-actions-button')).toBeDisabled()
+    })
+
+    it('disables the button when the selected variant definition is not found', () => {
+      mockUseTargetDocumentState.mockReturnValue({
+        status: 'variant-definition-document-not-found',
+        requestedVariantName: 'unknown-variant',
+      })
+      mockUseDocumentPane.mockReturnValue({
+        documentId: 'doc-123',
+        documentType: 'article',
+        editState: {
+          ready: true,
+          scopeId: undefined,
           draft: null,
           published: {_id: 'doc-123'},
           version: null,
@@ -352,6 +387,12 @@ describe('CopyDocumentActions', () => {
     })
 
     it('enables the button when the selected variant exists', () => {
+      mockUseTargetDocumentState.mockReturnValue({
+        status: 'ready',
+        targetDocument: {_id: 'versions.v1a2b3c4.doc-123'},
+        scopeId: 'v1a2b3c4',
+        variant: {_id: 'variant-1'},
+      })
       mockUseDocumentPane.mockReturnValue({
         documentId: 'doc-123',
         documentType: 'article',

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
@@ -449,6 +449,14 @@ describe('CopyDocumentActions', () => {
       expect(screen.getByTestId('copy-document-actions-button')).not.toBeDisabled()
     })
 
+    it('stays enabled while the target document state is still resolving', () => {
+      mockUseTargetDocumentState.mockReturnValue({status: 'resolving'})
+
+      render(<CopyDocumentActions />, {wrapper})
+
+      expect(screen.getByTestId('copy-document-actions-button')).not.toBeDisabled()
+    })
+
     it('stays enabled while the edit state is not yet ready', () => {
       pinRelease('rMyRelease')
       mockUseDocumentPane.mockReturnValue({

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
@@ -1,6 +1,6 @@
 import {render, screen} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
-import {usePerspective, useTargetDocumentState} from 'sanity'
+import {useDocumentVersions, usePerspective, useTargetDocumentState} from 'sanity'
 import {type Mock, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
@@ -32,10 +32,18 @@ const READY_TARGET_STATE = {
   variant: undefined,
 }
 
+const EXISTING_DOCUMENT_VERSIONS = {
+  data: ['drafts.doc-123', 'doc-123', 'versions.rMyRelease.doc-123', 'versions.rScheduled.doc-123'],
+  versions: [],
+  loading: false,
+  error: null,
+}
+
 vi.mock('sanity', async (importOriginal) => ({
   ...(await importOriginal()),
   usePerspective: vi.fn(() => DEFAULT_PERSPECTIVE),
   useTargetDocumentState: vi.fn(() => READY_TARGET_STATE),
+  useDocumentVersions: vi.fn(() => EXISTING_DOCUMENT_VERSIONS),
   useStudioUrl: vi.fn(() => ({
     studioUrl: 'http://localhost:3333',
     buildIntentUrl: mockBuildIntentUrl,
@@ -73,19 +81,13 @@ const mockUsePaneRouter = usePaneRouter as Mock
 const mockUseDocumentPaneInfo = useDocumentPaneInfo as Mock
 const mockUseDocumentPane = useDocumentPane as Mock
 const mockUseTargetDocumentState = useTargetDocumentState as Mock
+const mockUseDocumentVersions = useDocumentVersions as Mock
 
 const EXISTING_EDIT_STATE = {
   ready: true,
-  scopeId: undefined,
   draft: {_id: 'drafts.doc-123'},
   published: {_id: 'doc-123'},
   version: null,
-}
-
-const EXISTING_DISPLAYED = {
-  _id: 'drafts.doc-123',
-  _type: 'article',
-  _createdAt: '2026-01-01T00:00:00Z',
 }
 
 let wrapper: React.ComponentType<{children: React.ReactNode}>
@@ -114,9 +116,9 @@ describe('CopyDocumentActions', () => {
       documentId: 'doc-123',
       documentType: 'article',
       editState: EXISTING_EDIT_STATE,
-      displayed: EXISTING_DISPLAYED,
     })
     mockUseTargetDocumentState.mockReturnValue(READY_TARGET_STATE)
+    mockUseDocumentVersions.mockReturnValue(EXISTING_DOCUMENT_VERSIONS)
   })
 
   async function clickMenuItem(testId: string) {
@@ -298,25 +300,44 @@ describe('CopyDocumentActions', () => {
   })
 
   describe('Disabled state', () => {
-    it('disables the button when a release is pinned but the version does not exist', () => {
+    const pinRelease = (releaseId: string) =>
       mockUsePerspective.mockReturnValue({
         ...DEFAULT_PERSPECTIVE,
-        selectedPerspectiveName: 'rMyRelease',
-        selectedReleaseId: 'rMyRelease',
-        selectedPerspective: 'rMyRelease',
-        perspectiveStack: ['rMyRelease', 'drafts'],
+        selectedPerspectiveName: releaseId,
+        selectedReleaseId: releaseId,
+        selectedPerspective: releaseId,
+        perspectiveStack: [releaseId, 'drafts'],
       })
+
+    it('disables the button when a release is pinned but the version does not exist', () => {
+      pinRelease('rMyRelease')
+      mockUseDocumentPane.mockReturnValue({
+        documentId: 'doc-123',
+        documentType: 'article',
+        editState: {ready: true, draft: null, published: {_id: 'doc-123'}, version: null},
+      })
+      mockUseDocumentVersions.mockReturnValue({...EXISTING_DOCUMENT_VERSIONS, data: ['doc-123']})
+
+      render(<CopyDocumentActions />, {wrapper})
+
+      expect(screen.getByTestId('copy-document-actions-button')).toBeDisabled()
+    })
+
+    it('disables the button when the pinned release differs from the only existing version', () => {
+      pinRelease('rMyRelease')
       mockUseDocumentPane.mockReturnValue({
         documentId: 'doc-123',
         documentType: 'article',
         editState: {
           ready: true,
-          scopeId: 'rMyRelease',
           draft: null,
-          published: {_id: 'doc-123'},
-          version: null,
+          published: null,
+          version: {_id: 'versions.rOther.doc-123'},
         },
-        displayed: EXISTING_DISPLAYED,
+      })
+      mockUseDocumentVersions.mockReturnValue({
+        ...EXISTING_DOCUMENT_VERSIONS,
+        data: ['versions.rOther.doc-123'],
       })
 
       render(<CopyDocumentActions />, {wrapper})
@@ -325,25 +346,13 @@ describe('CopyDocumentActions', () => {
     })
 
     it('stays enabled when creating a new document inside a release', () => {
-      mockUsePerspective.mockReturnValue({
-        ...DEFAULT_PERSPECTIVE,
-        selectedPerspectiveName: 'rMyRelease',
-        selectedReleaseId: 'rMyRelease',
-        selectedPerspective: 'rMyRelease',
-        perspectiveStack: ['rMyRelease', 'drafts'],
-      })
+      pinRelease('rMyRelease')
       mockUseDocumentPane.mockReturnValue({
         documentId: 'doc-123',
         documentType: 'article',
-        editState: {
-          ready: true,
-          scopeId: 'rMyRelease',
-          draft: null,
-          published: null,
-          version: null,
-        },
-        displayed: {_id: 'versions.rMyRelease.doc-123', _type: 'article'},
+        editState: {ready: true, draft: null, published: null, version: null},
       })
+      mockUseDocumentVersions.mockReturnValue({...EXISTING_DOCUMENT_VERSIONS, data: []})
 
       render(<CopyDocumentActions />, {wrapper})
 
@@ -351,23 +360,20 @@ describe('CopyDocumentActions', () => {
     })
 
     it('enables the button when the pinned release contains the version', () => {
-      mockUsePerspective.mockReturnValue({
-        ...DEFAULT_PERSPECTIVE,
-        selectedPerspectiveName: 'rMyRelease',
-        selectedReleaseId: 'rMyRelease',
-        selectedPerspective: 'rMyRelease',
-        perspectiveStack: ['rMyRelease', 'drafts'],
-      })
+      pinRelease('rMyRelease')
       mockUseDocumentPane.mockReturnValue({
         documentId: 'doc-123',
         documentType: 'article',
         editState: {
           ready: true,
-          scopeId: 'rMyRelease',
           draft: null,
           published: null,
           version: {_id: 'versions.rMyRelease.doc-123'},
         },
+      })
+      mockUseDocumentVersions.mockReturnValue({
+        ...EXISTING_DOCUMENT_VERSIONS,
+        data: ['versions.rMyRelease.doc-123'],
       })
 
       render(<CopyDocumentActions />, {wrapper})
@@ -381,18 +387,6 @@ describe('CopyDocumentActions', () => {
         variant: {_id: 'variant-1'},
         bundle: 'published',
       })
-      mockUseDocumentPane.mockReturnValue({
-        documentId: 'doc-123',
-        documentType: 'article',
-        editState: {
-          ready: true,
-          scopeId: undefined,
-          draft: null,
-          published: {_id: 'doc-123'},
-          version: null,
-        },
-        displayed: {_id: 'doc-123', _type: 'article'},
-      })
 
       render(<CopyDocumentActions />, {wrapper})
 
@@ -403,17 +397,6 @@ describe('CopyDocumentActions', () => {
       mockUseTargetDocumentState.mockReturnValue({
         status: 'variant-definition-document-not-found',
         requestedVariantName: 'unknown-variant',
-      })
-      mockUseDocumentPane.mockReturnValue({
-        documentId: 'doc-123',
-        documentType: 'article',
-        editState: {
-          ready: true,
-          scopeId: undefined,
-          draft: null,
-          published: {_id: 'doc-123'},
-          version: null,
-        },
       })
 
       render(<CopyDocumentActions />, {wrapper})
@@ -428,17 +411,6 @@ describe('CopyDocumentActions', () => {
         scopeId: 'v1a2b3c4',
         variant: {_id: 'variant-1'},
       })
-      mockUseDocumentPane.mockReturnValue({
-        documentId: 'doc-123',
-        documentType: 'article',
-        editState: {
-          ready: true,
-          scopeId: 'v1a2b3c4',
-          draft: null,
-          published: null,
-          version: {_id: 'versions.v1a2b3c4.doc-123'},
-        },
-      })
 
       render(<CopyDocumentActions />, {wrapper})
 
@@ -449,13 +421,27 @@ describe('CopyDocumentActions', () => {
       mockUseDocumentPane.mockReturnValue({
         documentId: 'doc-123',
         documentType: 'article',
-        editState: {
-          ready: true,
-          scopeId: undefined,
-          draft: null,
-          published: {_id: 'doc-123'},
-          version: null,
-        },
+        editState: {ready: true, draft: null, published: {_id: 'doc-123'}, version: null},
+      })
+      mockUseDocumentVersions.mockReturnValue({...EXISTING_DOCUMENT_VERSIONS, data: ['doc-123']})
+
+      render(<CopyDocumentActions />, {wrapper})
+
+      expect(screen.getByTestId('copy-document-actions-button')).not.toBeDisabled()
+    })
+
+    it('stays enabled while the document versions are still loading', () => {
+      pinRelease('rMyRelease')
+      mockUseDocumentPane.mockReturnValue({
+        documentId: 'doc-123',
+        documentType: 'article',
+        editState: {ready: true, draft: null, published: {_id: 'doc-123'}, version: null},
+      })
+      mockUseDocumentVersions.mockReturnValue({
+        data: [],
+        versions: [],
+        loading: true,
+        error: null,
       })
 
       render(<CopyDocumentActions />, {wrapper})
@@ -464,23 +450,11 @@ describe('CopyDocumentActions', () => {
     })
 
     it('stays enabled while the edit state is not yet ready', () => {
-      mockUsePerspective.mockReturnValue({
-        ...DEFAULT_PERSPECTIVE,
-        selectedPerspectiveName: 'rMyRelease',
-        selectedReleaseId: 'rMyRelease',
-        selectedPerspective: 'rMyRelease',
-        perspectiveStack: ['rMyRelease', 'drafts'],
-      })
+      pinRelease('rMyRelease')
       mockUseDocumentPane.mockReturnValue({
         documentId: 'doc-123',
         documentType: 'article',
-        editState: {
-          ready: false,
-          scopeId: 'rMyRelease',
-          draft: null,
-          published: null,
-          version: null,
-        },
+        editState: {ready: false, draft: null, published: null, version: null},
       })
 
       render(<CopyDocumentActions />, {wrapper})

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
@@ -65,13 +65,14 @@ const mockUsePaneRouter = usePaneRouter as Mock
 const mockUseDocumentPaneInfo = useDocumentPaneInfo as Mock
 const mockUseDocumentPane = useDocumentPane as Mock
 
-// An edit state where every representation of the document exists, so the share button is enabled
-// regardless of the selected perspective.
+// An edit state for the base draft/published pair (no version checked out), so the share button is
+// enabled regardless of the selected perspective.
 const EXISTING_EDIT_STATE = {
   ready: true,
+  scopeId: undefined,
   draft: {_id: 'drafts.doc-123'},
   published: {_id: 'doc-123'},
-  version: {_id: 'versions.rMyRelease.doc-123'},
+  version: null,
 }
 
 let wrapper: React.ComponentType<{children: React.ReactNode}>
@@ -293,7 +294,13 @@ describe('CopyDocumentActions', () => {
       mockUseDocumentPane.mockReturnValue({
         documentId: 'doc-123',
         documentType: 'article',
-        editState: {ready: true, draft: null, published: {_id: 'doc-123'}, version: null},
+        editState: {
+          ready: true,
+          scopeId: 'rMyRelease',
+          draft: null,
+          published: {_id: 'doc-123'},
+          version: null,
+        },
       })
 
       render(<CopyDocumentActions />, {wrapper})
@@ -314,6 +321,7 @@ describe('CopyDocumentActions', () => {
         documentType: 'article',
         editState: {
           ready: true,
+          scopeId: 'rMyRelease',
           draft: null,
           published: null,
           version: {_id: 'versions.rMyRelease.doc-123'},
@@ -325,22 +333,58 @@ describe('CopyDocumentActions', () => {
       expect(screen.getByTestId('copy-document-actions-button')).not.toBeDisabled()
     })
 
-    it('disables the button on the published perspective when no published document exists', () => {
-      mockUsePerspective.mockReturnValue({
-        ...DEFAULT_PERSPECTIVE,
-        selectedPerspectiveName: 'published',
-        selectedPerspective: 'published',
-        perspectiveStack: ['published'],
-      })
+    it('disables the button when the selected variant does not exist', () => {
       mockUseDocumentPane.mockReturnValue({
         documentId: 'doc-123',
         documentType: 'article',
-        editState: {ready: true, draft: {_id: 'drafts.doc-123'}, published: null, version: null},
+        editState: {
+          ready: true,
+          scopeId: 'v1a2b3c4',
+          draft: null,
+          published: {_id: 'doc-123'},
+          version: null,
+        },
       })
 
       render(<CopyDocumentActions />, {wrapper})
 
       expect(screen.getByTestId('copy-document-actions-button')).toBeDisabled()
+    })
+
+    it('enables the button when the selected variant exists', () => {
+      mockUseDocumentPane.mockReturnValue({
+        documentId: 'doc-123',
+        documentType: 'article',
+        editState: {
+          ready: true,
+          scopeId: 'v1a2b3c4',
+          draft: null,
+          published: null,
+          version: {_id: 'versions.v1a2b3c4.doc-123'},
+        },
+      })
+
+      render(<CopyDocumentActions />, {wrapper})
+
+      expect(screen.getByTestId('copy-document-actions-button')).not.toBeDisabled()
+    })
+
+    it('stays enabled on the drafts perspective when no draft exists (pseudo-draft)', () => {
+      mockUseDocumentPane.mockReturnValue({
+        documentId: 'doc-123',
+        documentType: 'article',
+        editState: {
+          ready: true,
+          scopeId: undefined,
+          draft: null,
+          published: {_id: 'doc-123'},
+          version: null,
+        },
+      })
+
+      render(<CopyDocumentActions />, {wrapper})
+
+      expect(screen.getByTestId('copy-document-actions-button')).not.toBeDisabled()
     })
 
     it('stays enabled while the edit state is not yet ready', () => {
@@ -354,7 +398,13 @@ describe('CopyDocumentActions', () => {
       mockUseDocumentPane.mockReturnValue({
         documentId: 'doc-123',
         documentType: 'article',
-        editState: {ready: false, draft: null, published: null, version: null},
+        editState: {
+          ready: false,
+          scopeId: 'rMyRelease',
+          draft: null,
+          published: null,
+          version: null,
+        },
       })
 
       render(<CopyDocumentActions />, {wrapper})

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/CopyDocumentActions.test.tsx
@@ -6,6 +6,7 @@ import {type Mock, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest
 import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
 import {usePaneRouter} from '../../../../../components'
 import {structureUsEnglishLocaleBundle} from '../../../../../i18n'
+import {useDocumentPane} from '../../../useDocumentPane'
 import {useDocumentPaneInfo} from '../../../useDocumentPaneInfo'
 import {CopyDocumentActions} from '../CopyDocumentActions'
 
@@ -51,12 +52,7 @@ vi.mock('../../../../../components', () => ({
   })),
 }))
 
-vi.mock('../../../useDocumentPane', () => ({
-  useDocumentPane: vi.fn(() => ({
-    documentId: 'doc-123',
-    documentType: 'article',
-  })),
-}))
+vi.mock('../../../useDocumentPane')
 
 vi.mock('../../../useDocumentPaneInfo')
 
@@ -67,6 +63,17 @@ vi.mock('@sanity/telemetry/react', () => ({
 const mockUsePerspective = usePerspective as Mock
 const mockUsePaneRouter = usePaneRouter as Mock
 const mockUseDocumentPaneInfo = useDocumentPaneInfo as Mock
+const mockUseDocumentPane = useDocumentPane as Mock
+
+// An edit state where every representation of the document exists, so the share button is enabled
+// regardless of the selected perspective.
+const EXISTING_EDIT_STATE = {
+  ready: true,
+  draft: {_id: 'drafts.doc-123'},
+  published: {_id: 'doc-123'},
+  version: {_id: 'versions.rMyRelease.doc-123'},
+}
+
 let wrapper: React.ComponentType<{children: React.ReactNode}>
 
 beforeAll(async () => {
@@ -88,6 +95,11 @@ describe('CopyDocumentActions', () => {
       documentType: 'article',
       documentId: 'doc-123',
       schemaType: {liveEdit: false},
+    })
+    mockUseDocumentPane.mockReturnValue({
+      documentId: 'doc-123',
+      documentType: 'article',
+      editState: EXISTING_EDIT_STATE,
     })
   })
 
@@ -266,6 +278,88 @@ describe('CopyDocumentActions', () => {
       expect(mockTelemetryLog).toHaveBeenCalledWith(
         expect.objectContaining({name: 'Document ID Copied'}),
       )
+    })
+  })
+
+  describe('Disabled state', () => {
+    it('disables the button when a release is pinned but the version does not exist', () => {
+      mockUsePerspective.mockReturnValue({
+        ...DEFAULT_PERSPECTIVE,
+        selectedPerspectiveName: 'rMyRelease',
+        selectedReleaseId: 'rMyRelease',
+        selectedPerspective: 'rMyRelease',
+        perspectiveStack: ['rMyRelease', 'drafts'],
+      })
+      mockUseDocumentPane.mockReturnValue({
+        documentId: 'doc-123',
+        documentType: 'article',
+        editState: {ready: true, draft: null, published: {_id: 'doc-123'}, version: null},
+      })
+
+      render(<CopyDocumentActions />, {wrapper})
+
+      expect(screen.getByTestId('copy-document-actions-button')).toBeDisabled()
+    })
+
+    it('enables the button when the pinned release contains the version', () => {
+      mockUsePerspective.mockReturnValue({
+        ...DEFAULT_PERSPECTIVE,
+        selectedPerspectiveName: 'rMyRelease',
+        selectedReleaseId: 'rMyRelease',
+        selectedPerspective: 'rMyRelease',
+        perspectiveStack: ['rMyRelease', 'drafts'],
+      })
+      mockUseDocumentPane.mockReturnValue({
+        documentId: 'doc-123',
+        documentType: 'article',
+        editState: {
+          ready: true,
+          draft: null,
+          published: null,
+          version: {_id: 'versions.rMyRelease.doc-123'},
+        },
+      })
+
+      render(<CopyDocumentActions />, {wrapper})
+
+      expect(screen.getByTestId('copy-document-actions-button')).not.toBeDisabled()
+    })
+
+    it('disables the button on the published perspective when no published document exists', () => {
+      mockUsePerspective.mockReturnValue({
+        ...DEFAULT_PERSPECTIVE,
+        selectedPerspectiveName: 'published',
+        selectedPerspective: 'published',
+        perspectiveStack: ['published'],
+      })
+      mockUseDocumentPane.mockReturnValue({
+        documentId: 'doc-123',
+        documentType: 'article',
+        editState: {ready: true, draft: {_id: 'drafts.doc-123'}, published: null, version: null},
+      })
+
+      render(<CopyDocumentActions />, {wrapper})
+
+      expect(screen.getByTestId('copy-document-actions-button')).toBeDisabled()
+    })
+
+    it('stays enabled while the edit state is not yet ready', () => {
+      mockUsePerspective.mockReturnValue({
+        ...DEFAULT_PERSPECTIVE,
+        selectedPerspectiveName: 'rMyRelease',
+        selectedReleaseId: 'rMyRelease',
+        selectedPerspective: 'rMyRelease',
+        perspectiveStack: ['rMyRelease', 'drafts'],
+      })
+      mockUseDocumentPane.mockReturnValue({
+        documentId: 'doc-123',
+        documentType: 'article',
+        editState: {ready: false, draft: null, published: null, version: null},
+      })
+
+      render(<CopyDocumentActions />, {wrapper})
+
+      expect(screen.getByTestId('copy-document-actions-button')).not.toBeDisabled()
     })
   })
 })


### PR DESCRIPTION
### Description

When a release perspective is pinned, the document header share menu (Copy document URL / Copy document ID) produced a `versions.<releaseId>.<id>` reference for documents that are not part of the release, an id that resolves to nothing ([SAPP-4021](https://linear.app/sanity/issue/SAPP-4021/disable-copy-document-id-for-documents-outside-a-pinned-release)). The same gap applied to a selected variant that does not exist.

This PR hides the share button whenever the id it would copy does not exist in the current context, so the action is offered only when there is a real document to share. Existence is checked against the exact id the actions produce, using the document's version set rather than the checked-out edit state, because the two diverge when the pinned release differs from where the document exists. Missing drafts (pseudo-draft), published documents, and new-document creation keep the button visible.

### What to review

- `CopyDocumentActions.tsx` - the `documentExists` derivation and the early `return null` when it is false. Hiding an unavailable header action matches the surrounding header, where sibling actions already render conditionally. Only the `sanity` package is affected.

### Testing

Unit tests in `CopyDocumentActions.test.tsx` cover the release, variant, pseudo-draft, creation, and loading cases. Verified in the studio: the button is absent in a release perspective where the version does not exist, and present in the drafts perspective where it does.

### Notes for release

The document header share button is now hidden when the current perspective points to a document that does not exist, such as one outside a pinned release or an uncreated variant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only conditional rendering in the structure document header with no auth or data-path changes; behavior is covered by new unit tests.
> 
> **Overview**
> The document header **share** menu (copy URL / copy ID) is **hidden** when the perspective-aware ID it would copy does not actually exist, instead of offering bogus `versions.<release>.<id>` references for documents outside a pinned release or missing variants.
> 
> `CopyDocumentActions` now derives **`documentExists`** from `useTargetDocumentState` (variant missing / definition not found), `useDocumentVersions` (whether the exact `contextAwareDocumentId` is in the version set), and edit readiness—only running the version check once loading is done. It **returns null** before rendering the menu when the target is missing. **New documents**, **pseudo-draft** (drafts perspective with only published), and **in-flight** states (versions loading, target resolving, edit not ready) still show the button.
> 
> Tests add a **Visibility** suite with mocks for the new hooks and cases for releases, variants, creation, and loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fad14efe9bbae4aa609f0dd0e1c4eca7c4c2af5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->