### PR TITLE
fix(sanity): use displayed document id to drive active variant

### DIFF
--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -389,7 +389,7 @@ const Variant: ComponentType<{
   const versionName = getVersionFromId(variant.id)
   const bundleId = isPublishedVersion ? 'published' : isDraftVersion ? 'draft' : (versionName ?? '')
 
-  const isReadOnly = useSelector(machine, (s) => s.matches('readonly'))
+  const isReadOnly = useSelector(machine, (snapshot) => snapshot.matches('readonly'))
   const selectedIds = useSelector(machine, ({context}) => context.selectedIds)
   const releases = useSelector(inventoryRef, ({context}) => context.releases)
 

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -243,6 +243,7 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
             <Select
               machine={selectionRef}
               inventoryRef={inventoryRef}
+              documentId={documentId}
               documentType={documentType}
               menuPortalElement={menuPortalElement}
               perspectiveList={perspectiveList}
@@ -288,6 +289,7 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
 const Select: ComponentType<{
   machine: ActorRefFromLogic<typeof selectionMachine>
   inventoryRef: ActorRefFromLogic<typeof documentGroupInventoryMachine>
+  documentId: string
   documentType: string
   onPrimaryAction: SetVariant
   menuPortalElement: HTMLElement | null
@@ -295,6 +297,7 @@ const Select: ComponentType<{
 }> = ({
   machine,
   inventoryRef,
+  documentId,
   documentType,
   onPrimaryAction,
   menuPortalElement,
@@ -349,6 +352,7 @@ const Select: ComponentType<{
                 inventoryRef={inventoryRef}
                 documentType={documentType}
                 onPrimaryAction={onPrimaryAction}
+                isActive={documentId === variant.id}
                 isSelectable={isSelectable}
                 menuPortalElement={menuPortalElement}
                 perspectiveList={perspectiveList}
@@ -366,6 +370,7 @@ const Variant: ComponentType<{
   inventoryRef: ActorRefFromLogic<typeof documentGroupInventoryMachine>
   documentType: string
   onPrimaryAction: SetVariant
+  isActive: boolean
   isSelectable: boolean
   menuPortalElement: HTMLElement | null
   perspectiveList: DocumentGroupInventoryPerspectiveList
@@ -375,6 +380,7 @@ const Variant: ComponentType<{
   inventoryRef,
   documentType,
   onPrimaryAction,
+  isActive: isSelected,
   isSelectable,
   menuPortalElement,
   perspectiveList,
@@ -393,18 +399,7 @@ const Variant: ComponentType<{
   const selectedIds = useSelector(machine, ({context}) => context.selectedIds)
   const releases = useSelector(inventoryRef, ({context}) => context.releases)
 
-  const {
-    filteredReleases,
-    getReleaseChipState,
-    handleCopyToDraftsNavigate,
-    isDraftSelected,
-    isPublishSelected,
-  } = perspectiveList
-
-  const isSelected =
-    (isPublishedVersion && isPublishSelected) ||
-    (isDraftVersion && isDraftSelected) ||
-    (isVersion && getReleaseChipState(getVersionFromId(variant.id) ?? '').selected)
+  const {filteredReleases, handleCopyToDraftsNavigate} = perspectiveList
 
   const release = versionName
     ? releases.get(getReleaseDocumentIdFromReleaseId(versionName))

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -6,6 +6,7 @@ import {
   DocumentGroupInventoryAction,
   type DocumentGroupInventoryProps,
   Hotkeys,
+  isGoingToUnpublish,
   isSanityDefinedAction,
   useClient,
   useDocumentStore,
@@ -112,18 +113,32 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
       : [firstActionState, ...menuActionStates].filter(Boolean)
   }, [showFirstActionButton, firstActionState, menuActionStates])
 
+  // When a document is designated to be unpublished in a release, the published
+  // document is displayed instead.
+  //
+  // The document group inventory must always reflect the intended document id,
+  // even if the document pane decided to display a different document for some
+  // reason.
+  //
+  // In the future, this would be more robust if `DocumentPaneProvider`
+  // exposed both the displayed document and the original source document.
+  const targetDocumentId =
+    editState?.version && isGoingToUnpublish(editState?.version)
+      ? editState.version._id
+      : displayed?._id
+
   return (
     <Flex align="center" gap={3}>
       {__internal_tasks && __internal_tasks.footerAction}
-      {hasDocumentGroupInventory && typeof displayed?._id !== 'undefined' && (
+      {hasDocumentGroupInventory && typeof targetDocumentId !== 'undefined' && (
         <DocumentGroupInventoryAction
-          documentId={displayed._id}
+          documentId={targetDocumentId}
           portalElementName={DOCUMENT_PANEL_PORTAL_ELEMENT}
           isDocumentGroupInventoryActive={isDocumentGroupInventoryActive}
           setIsDocumentGroupInventoryActive={setIsDocumentGroupInventoryActive}
         >
           <DocumentGroupInventory
-            documentId={displayed._id}
+            documentId={targetDocumentId}
             documentType={documentType}
             portalElementName={DOCUMENT_PANEL_PORTAL_ELEMENT}
             perspectiveList={perspectiveList}

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -47,10 +47,17 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
 ) {
   const {disabled, states} = props
   const {__internal_tasks, beta} = useSource()
-  const {displayed, editState, isDocumentGroupInventoryActive, setIsDocumentGroupInventoryActive} =
-    useDocumentPane()
+
+  const {
+    displayed,
+    editState,
+    isDocumentGroupInventoryActive,
+    setIsDocumentGroupInventoryActive,
+    documentId,
+    documentType,
+  } = useDocumentPane()
   const {params} = usePaneRouter()
-  const {documentId, documentType} = useDocumentPane()
+
   const showingRevision = Boolean(params?.rev)
 
   const perspectiveList = useDocumentPerspectiveList()


### PR DESCRIPTION
### Description

This branch changes the document group inventory so that the active variant state is driven directly by the displayed document id, rather than depending on `getReleaseChipState` combined with other conditions. This is possible thanks to @pedrobonamin's work to make the displayed document id work for variants.

There are also a couple of tiny formatting fixes included.

### What to review

The "viewing" state in the document group inventory.

### Testing

Verified state is reflected correctly with variants switched on and switched off.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only selection highlighting and id plumbing for an edge case; no auth, data writes, or API changes.
> 
> **Overview**
> **Document group inventory** now marks the “viewing” row by comparing the inventory’s `documentId` to each variant’s id, instead of inferring selection from release chip / draft / publish flags on `perspectiveList`.
> 
> The status bar passes that id through as **`targetDocumentId`**: when the open release version is **going to unpublish** (pane may show the published doc), the inventory still uses the version document’s `_id` so the correct row stays active.
> 
> Minor cleanup: `useSelector` callbacks use a `snapshot` parameter name in a couple of places.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ffb420a16b3f8bfb49992e2b61e493a51278c85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->