### PR TITLE
feat(variants): add confirmation dialog for delete variant action

### DIFF
--- a/e2e/tests/variants/variantTool.spec.ts
+++ b/e2e/tests/variants/variantTool.spec.ts
@@ -476,7 +476,7 @@ test.describe('Variants create flow', () => {
     // which would break if the row gains more buttons. `variantId` is the short id.
     await page.locator(`#variant-actions-${variantId}`).click()
     await page.getByRole('menuitem', {name: 'Delete variant'}).click()
-    await expect(page.getByRole('menuitem', {name: 'Delete variant'})).toBeHidden()
+    await page.getByTestId('confirm-button').click()
 
     await expect(row).toBeHidden()
     await expect.poll(async () => sanityClient.getDocument(documentId)).toBeUndefined()
@@ -501,7 +501,7 @@ test.describe('Variants create flow', () => {
 
     await page.locator(`#variant-detail-actions-${shortVariantId}`).click()
     await page.getByRole('menuitem', {name: 'Delete variant'}).click()
-    await expect(page.getByRole('menuitem', {name: 'Delete variant'})).toBeHidden()
+    await page.getByTestId('confirm-button').click()
 
     await expect(page.getByRole('heading', {name: 'Variants'}).first()).toBeVisible()
     await expect(getVariantRow(page, title)).toBeHidden()

--- a/packages/sanity/src/core/variants/components/dialog/DeleteVariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/DeleteVariantDialog.tsx
@@ -1,0 +1,46 @@
+import {Text} from '@sanity/ui'
+
+import {Dialog} from '../../../../ui-components'
+import {useTranslation} from '../../../i18n'
+import {variantsLocaleNamespace} from '../../i18n'
+
+interface DeleteVariantDialogProps {
+  isDeleting: boolean
+  onClose: () => void
+  onConfirm: () => void
+  variantTitle: string
+}
+
+export function DeleteVariantDialog({
+  isDeleting,
+  onClose,
+  onConfirm,
+  variantTitle,
+}: DeleteVariantDialogProps): React.JSX.Element {
+  const {t} = useTranslation(variantsLocaleNamespace)
+
+  return (
+    <Dialog
+      data-testid="delete-variant-dialog"
+      footer={{
+        cancelButton: {
+          disabled: isDeleting,
+        },
+        confirmButton: {
+          disabled: isDeleting,
+          loading: isDeleting,
+          onClick: onConfirm,
+          text: t('dialog.delete.action.confirm'),
+          tone: 'critical',
+        },
+      }}
+      header={t('dialog.delete.title')}
+      id="delete-variant-dialog"
+      onClose={isDeleting ? undefined : onClose}
+    >
+      <Text muted size={1}>
+        {t('dialog.delete.description', {title: variantTitle})}
+      </Text>
+    </Dialog>
+  )
+}

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/DeleteVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/DeleteVariantDialog.test.tsx
@@ -1,0 +1,76 @@
+import {render, screen} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {variantsUsEnglishLocaleBundle} from '../../i18n'
+import {DeleteVariantDialog} from '../DeleteVariantDialog'
+
+describe('DeleteVariantDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const renderDialog = async (props?: Partial<Parameters<typeof DeleteVariantDialog>[0]>) => {
+    const onClose = vi.fn()
+    const onConfirm = vi.fn()
+    const wrapper = await createTestProvider({
+      resources: [variantsUsEnglishLocaleBundle],
+    })
+
+    render(
+      <DeleteVariantDialog
+        isDeleting={false}
+        onClose={onClose}
+        onConfirm={onConfirm}
+        variantTitle="Alpha audience"
+        {...props}
+      />,
+      {wrapper},
+    )
+
+    await screen.findByTestId('delete-variant-dialog')
+
+    return {onClose, onConfirm}
+  }
+
+  it('renders the confirmation dialog with the variant title', async () => {
+    await renderDialog()
+
+    expect(
+      screen.getByRole('dialog', {name: 'Are you sure you want to delete this variant?'}),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'This will permanently delete "Alpha audience". This action cannot be undone.',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('confirm-button')).toHaveTextContent('Yes, delete variant')
+  })
+
+  it('calls onConfirm when the confirm button is clicked', async () => {
+    const user = userEvent.setup()
+    const {onConfirm} = await renderDialog()
+
+    await user.click(screen.getByTestId('confirm-button'))
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when the cancel button is clicked', async () => {
+    const user = userEvent.setup()
+    const {onClose} = await renderDialog()
+
+    await user.click(screen.getByTestId('cancel-button'))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables actions while deleting', async () => {
+    await renderDialog({isDeleting: true})
+
+    expect(screen.getByTestId('confirm-button')).toBeDisabled()
+    expect(screen.getByTestId('cancel-button')).toBeDisabled()
+    expect(screen.getByTestId('cancel-button')).toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/DeleteVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/DeleteVariantDialog.test.tsx
@@ -2,8 +2,8 @@ import {render, screen} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
-import {variantsUsEnglishLocaleBundle} from '../../i18n'
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {variantsUsEnglishLocaleBundle} from '../../../i18n'
 import {DeleteVariantDialog} from '../DeleteVariantDialog'
 
 describe('DeleteVariantDialog', () => {
@@ -66,11 +66,10 @@ describe('DeleteVariantDialog', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  it('disables actions while deleting', async () => {
+  it('disables confirm and hides cancel while deleting', async () => {
     await renderDialog({isDeleting: true})
 
     expect(screen.getByTestId('confirm-button')).toBeDisabled()
-    expect(screen.getByTestId('cancel-button')).toBeDisabled()
-    expect(screen.getByTestId('cancel-button')).toBeInTheDocument()
+    expect(screen.queryByTestId('cancel-button')).not.toBeInTheDocument()
   })
 })

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/DeleteVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/DeleteVariantDialog.test.tsx
@@ -38,14 +38,16 @@ describe('DeleteVariantDialog', () => {
     await renderDialog()
 
     expect(
-      screen.getByRole('dialog', {name: 'Are you sure you want to delete this variant?'}),
+      screen.getByRole('dialog', {
+        name: 'Are you sure you want to delete this variant definition?',
+      }),
     ).toBeInTheDocument()
     expect(
       screen.getByText(
         'This will permanently delete "Alpha audience". This action cannot be undone.',
       ),
     ).toBeInTheDocument()
-    expect(screen.getByTestId('confirm-button')).toHaveTextContent('Yes, delete variant')
+    expect(screen.getByTestId('confirm-button')).toHaveTextContent('Yes, delete variant definition')
   })
 
   it('calls onConfirm when the confirm button is clicked', async () => {

--- a/packages/sanity/src/core/variants/hooks/__tests__/useVariantDeleteAction.test.ts
+++ b/packages/sanity/src/core/variants/hooks/__tests__/useVariantDeleteAction.test.ts
@@ -41,19 +41,31 @@ describe('useVariantDeleteAction', () => {
 
   it('deletes the variant when it has no documents', async () => {
     const onDeleted = vi.fn()
-    const {result} = await renderDeleteAction({documentCount: 0, onDeleted})
+    const {result} = await renderDeleteAction({
+      documentCount: 0,
+      onDeleted,
+      variantTitle: 'Alpha audience',
+    })
 
     await waitFor(() => {
       expect(result.current).not.toBeNull()
     })
 
+    act(() => {
+      result.current.handleDelete()
+    })
+
+    expect(result.current.isDeleteDialogOpen).toBe(true)
+    expect(variantOperationsMock.deleteVariant).not.toHaveBeenCalled()
+
     await act(async () => {
-      await result.current.handleDelete()
+      await result.current.handleConfirmDelete()
     })
 
     await waitFor(() => {
       expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
       expect(onDeleted).toHaveBeenCalledTimes(1)
+      expect(result.current.isDeleteDialogOpen).toBe(false)
     })
   })
 
@@ -80,7 +92,7 @@ describe('useVariantDeleteAction', () => {
     )
 
     await act(async () => {
-      await result.current.handleDelete()
+      await result.current.handleConfirmDelete()
     })
 
     expect(variantOperationsMock.deleteVariant).not.toHaveBeenCalled()
@@ -102,8 +114,12 @@ describe('useVariantDeleteAction', () => {
 
     const {result} = await renderDeleteAction({documentCount: 0})
 
+    act(() => {
+      result.current.handleDelete()
+    })
+
     await act(async () => {
-      await result.current.handleDelete()
+      await result.current.handleConfirmDelete()
     })
 
     await waitFor(() => {

--- a/packages/sanity/src/core/variants/hooks/useVariantDeleteAction.ts
+++ b/packages/sanity/src/core/variants/hooks/useVariantDeleteAction.ts
@@ -9,6 +9,7 @@ interface UseVariantDeleteActionOptions {
   documentCount?: number | null
   documentsLoading?: boolean
   onDeleted?: () => void
+  variantTitle?: string
 }
 
 /**
@@ -22,14 +23,19 @@ export function useVariantDeleteAction(
 ): {
   deleteDisabled: boolean
   deleteDisabledTooltip: string | undefined
-  handleDelete: () => Promise<void>
+  handleCloseDeleteDialog: () => void
+  handleConfirmDelete: () => Promise<void>
+  handleDelete: () => void
+  isDeleteDialogOpen: boolean
   isDeleting: boolean
+  variantTitle: string
 } {
-  const {documentCount, documentsLoading = false, onDeleted} = options ?? {}
+  const {documentCount, documentsLoading = false, onDeleted, variantTitle = ''} = options ?? {}
   const {t} = useTranslation(variantsLocaleNamespace)
   const toast = useToast()
   const {deleteVariant} = useVariantOperations()
   const [isDeleting, setIsDeleting] = useState(false)
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
 
   const hasDocuments = typeof documentCount === 'number' && documentCount > 0
   const countUnknown = documentsLoading || documentCount === undefined || documentCount === null
@@ -49,7 +55,23 @@ export function useVariantDeleteAction(
     )
   }, [documentCount, hasDocuments, t])
 
-  const handleDelete = useCallback(async () => {
+  const handleDelete = useCallback(() => {
+    if (countUnknown || hasDocuments) {
+      return
+    }
+
+    setIsDeleteDialogOpen(true)
+  }, [countUnknown, hasDocuments])
+
+  const handleCloseDeleteDialog = useCallback(() => {
+    if (isDeleting) {
+      return
+    }
+
+    setIsDeleteDialogOpen(false)
+  }, [isDeleting])
+
+  const handleConfirmDelete = useCallback(async () => {
     if (countUnknown || hasDocuments) {
       return
     }
@@ -59,6 +81,7 @@ export function useVariantDeleteAction(
     try {
       await deleteVariant(variantId)
       setIsDeleting(false)
+      setIsDeleteDialogOpen(false)
       onDeleted?.()
     } catch (error) {
       console.error(error)
@@ -74,7 +97,11 @@ export function useVariantDeleteAction(
   return {
     deleteDisabled,
     deleteDisabledTooltip,
+    handleCloseDeleteDialog,
+    handleConfirmDelete,
     handleDelete,
+    isDeleteDialogOpen,
     isDeleting,
+    variantTitle,
   }
 }

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -144,12 +144,12 @@ const variantsLocaleStrings = {
   /** Error toast title when variant editing fails. */
   'dialog.edit.error.title': 'Unable to update variant',
   /** Title for the delete variant confirmation dialog. */
-  'dialog.delete.title': 'Are you sure you want to delete this variant?',
+  'dialog.delete.title': 'Are you sure you want to delete this variant definition?',
   /** Description for the delete variant confirmation dialog. */
   'dialog.delete.description':
     'This will permanently delete "{{title}}". This action cannot be undone.',
   /** Confirm action for the delete variant confirmation dialog. */
-  'dialog.delete.action.confirm': 'Yes, delete variant',
+  'dialog.delete.action.confirm': 'Yes, delete variant definition',
 }
 
 /**

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -143,6 +143,13 @@ const variantsLocaleStrings = {
   'dialog.edit.action.cancel': 'Cancel',
   /** Error toast title when variant editing fails. */
   'dialog.edit.error.title': 'Unable to update variant',
+  /** Title for the delete variant confirmation dialog. */
+  'dialog.delete.title': 'Are you sure you want to delete this variant?',
+  /** Description for the delete variant confirmation dialog. */
+  'dialog.delete.description':
+    'This will permanently delete "{{title}}". This action cannot be undone.',
+  /** Confirm action for the delete variant confirmation dialog. */
+  'dialog.delete.action.confirm': 'Yes, delete variant',
 }
 
 /**

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -353,6 +353,7 @@ describe('VariantDetail', () => {
 
     await user.click(menuButton)
     await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByTestId('confirm-button'))
 
     await waitFor(() => {
       expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
@@ -378,6 +379,7 @@ describe('VariantDetail', () => {
 
     await user.click(menuButton)
     await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByTestId('confirm-button'))
 
     await waitFor(() => {
       expect(toastMock.push).toHaveBeenCalledWith(

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetailMenuButton.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetailMenuButton.test.tsx
@@ -81,6 +81,7 @@ describe('VariantDetailMenuButton', () => {
 
     await user.click(screen.getByRole('button'))
     await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByTestId('confirm-button'))
 
     await waitFor(() => {
       expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
@@ -99,6 +100,7 @@ describe('VariantDetailMenuButton', () => {
 
     await user.click(menuButton)
     await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByTestId('confirm-button'))
 
     await waitFor(() => {
       expect(menuButton).toBeDisabled()
@@ -121,6 +123,7 @@ describe('VariantDetailMenuButton', () => {
 
     await user.click(screen.getByRole('button'))
     await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByTestId('confirm-button'))
 
     await waitFor(() => {
       expect(toastMock.push).toHaveBeenCalledWith(

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantMenuButton.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantMenuButton.test.tsx
@@ -53,10 +53,24 @@ describe('VariantMenuButton', () => {
 
     await user.click(screen.getByRole('button'))
     await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByTestId('confirm-button'))
 
     await waitFor(() => {
       expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
     })
+  })
+
+  it('does not delete the variant when the confirmation dialog is cancelled', async () => {
+    const user = userEvent.setup()
+
+    await renderMenuButton({documentCount: 0})
+
+    await user.click(screen.getByRole('button'))
+    await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByTestId('cancel-button'))
+
+    expect(variantOperationsMock.deleteVariant).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('delete-variant-dialog')).not.toBeInTheDocument()
   })
 
   it('shows a loading state on the menu button while deleting', async () => {
@@ -70,6 +84,7 @@ describe('VariantMenuButton', () => {
 
     await user.click(menuButton)
     await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByTestId('confirm-button'))
 
     await waitFor(() => {
       expect(menuButton).toBeDisabled()

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -284,6 +284,7 @@ describe('VariantsOverview', () => {
 
     await user.click(menuButton)
     await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByTestId('confirm-button'))
 
     await waitFor(() => {
       expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(variantAlphaAudience._id)

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetailMenuButton.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetailMenuButton.tsx
@@ -4,10 +4,11 @@ import {useRouter} from 'sanity/router'
 import {MenuButton, MenuItem} from '../../../../ui-components'
 import {ContextMenuButton} from '../../../components/contextMenuButton'
 import {useTranslation} from '../../../i18n'
+import {DeleteVariantDialog} from '../../components/dialog/DeleteVariantDialog'
 import {useVariantDeleteAction} from '../../hooks/useVariantDeleteAction'
 import {variantsLocaleNamespace} from '../../i18n'
 import {type SystemVariant} from '../../types'
-import {getVariantId} from '../util'
+import {getVariantId, getVariantTitle} from '../util'
 
 export function VariantDetailMenuButton({
   documentCount,
@@ -20,31 +21,49 @@ export function VariantDetailMenuButton({
 }): React.JSX.Element {
   const {t} = useTranslation(variantsLocaleNamespace)
   const router = useRouter()
-  const {deleteDisabled, deleteDisabledTooltip, handleDelete, isDeleting} = useVariantDeleteAction(
-    variant._id,
-    {
-      documentCount,
-      documentsLoading,
-      onDeleted: () => router.navigate({}),
-    },
-  )
+  const variantTitle = getVariantTitle(variant)
+  const {
+    deleteDisabled,
+    deleteDisabledTooltip,
+    handleCloseDeleteDialog,
+    handleConfirmDelete,
+    handleDelete,
+    isDeleteDialogOpen,
+    isDeleting,
+    variantTitle: dialogVariantTitle,
+  } = useVariantDeleteAction(variant._id, {
+    documentCount,
+    documentsLoading,
+    onDeleted: () => router.navigate({}),
+    variantTitle,
+  })
 
   return (
-    <MenuButton
-      button={<ContextMenuButton disabled={isDeleting} loading={isDeleting} />}
-      id={`variant-detail-actions-${getVariantId(variant._id)}`}
-      menu={
-        <Menu>
-          <MenuItem
-            disabled={deleteDisabled}
-            onClick={handleDelete}
-            text={t('overview.action.delete-variant')}
-            tone="critical"
-            tooltipProps={deleteDisabledTooltip ? {content: deleteDisabledTooltip} : undefined}
-          />
-        </Menu>
-      }
-      popover={{placement: 'bottom-end', portal: true}}
-    />
+    <>
+      <MenuButton
+        button={<ContextMenuButton disabled={isDeleting} loading={isDeleting} />}
+        id={`variant-detail-actions-${getVariantId(variant._id)}`}
+        menu={
+          <Menu>
+            <MenuItem
+              disabled={deleteDisabled}
+              onClick={handleDelete}
+              text={t('overview.action.delete-variant')}
+              tone="critical"
+              tooltipProps={deleteDisabledTooltip ? {content: deleteDisabledTooltip} : undefined}
+            />
+          </Menu>
+        }
+        popover={{placement: 'bottom-end', portal: true}}
+      />
+      {isDeleteDialogOpen && (
+        <DeleteVariantDialog
+          isDeleting={isDeleting}
+          onClose={handleCloseDeleteDialog}
+          onConfirm={handleConfirmDelete}
+          variantTitle={dialogVariantTitle}
+        />
+      )}
+    </>
   )
 }

--- a/packages/sanity/src/core/variants/tool/overview/VariantMenuButton.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantMenuButton.tsx
@@ -3,10 +3,11 @@ import {Menu} from '@sanity/ui'
 import {MenuButton, MenuItem} from '../../../../ui-components'
 import {ContextMenuButton} from '../../../components/contextMenuButton'
 import {useTranslation} from '../../../i18n'
+import {DeleteVariantDialog} from '../../components/dialog/DeleteVariantDialog'
 import {useVariantDeleteAction} from '../../hooks/useVariantDeleteAction'
 import {variantsLocaleNamespace} from '../../i18n'
 import {type SystemVariant} from '../../types'
-import {getVariantId} from '../util'
+import {getVariantId, getVariantTitle} from '../util'
 
 export function VariantMenuButton({
   documentCount,
@@ -16,27 +17,44 @@ export function VariantMenuButton({
   variant: SystemVariant
 }) {
   const {t} = useTranslation(variantsLocaleNamespace)
-  const {deleteDisabled, deleteDisabledTooltip, handleDelete, isDeleting} = useVariantDeleteAction(
-    variant._id,
-    {documentCount},
-  )
+  const variantTitle = getVariantTitle(variant)
+  const {
+    deleteDisabled,
+    deleteDisabledTooltip,
+    handleCloseDeleteDialog,
+    handleConfirmDelete,
+    handleDelete,
+    isDeleteDialogOpen,
+    isDeleting,
+    variantTitle: dialogVariantTitle,
+  } = useVariantDeleteAction(variant._id, {documentCount, variantTitle})
 
   return (
-    <MenuButton
-      button={<ContextMenuButton disabled={isDeleting} loading={isDeleting} />}
-      id={`variant-actions-${getVariantId(variant._id)}`}
-      menu={
-        <Menu>
-          <MenuItem
-            disabled={deleteDisabled}
-            onClick={handleDelete}
-            text={t('overview.action.delete-variant')}
-            tone="critical"
-            tooltipProps={deleteDisabledTooltip ? {content: deleteDisabledTooltip} : undefined}
-          />
-        </Menu>
-      }
-      popover={{placement: 'bottom-end', portal: true}}
-    />
+    <>
+      <MenuButton
+        button={<ContextMenuButton disabled={isDeleting} loading={isDeleting} />}
+        id={`variant-actions-${getVariantId(variant._id)}`}
+        menu={
+          <Menu>
+            <MenuItem
+              disabled={deleteDisabled}
+              onClick={handleDelete}
+              text={t('overview.action.delete-variant')}
+              tone="critical"
+              tooltipProps={deleteDisabledTooltip ? {content: deleteDisabledTooltip} : undefined}
+            />
+          </Menu>
+        }
+        popover={{placement: 'bottom-end', portal: true}}
+      />
+      {isDeleteDialogOpen && (
+        <DeleteVariantDialog
+          isDeleting={isDeleting}
+          onClose={handleCloseDeleteDialog}
+          onConfirm={handleConfirmDelete}
+          variantTitle={dialogVariantTitle}
+        />
+      )}
+    </>
   )
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Deleting a variant definition is irreversible, but the delete action ran immediately from the row/detail menus with no confirmation step. This adds a confirmation dialog before the delete API call, matching the pattern used for release delete/archive actions.

The dialog is centralized in `useVariantDeleteAction` so both the overview row menu and detail page menu share the same behavior. Clicking "Delete variant" now opens the dialog; deletion only proceeds after confirming.

https://github.com/user-attachments/assets/8c25e51c-3b75-4b2b-99a9-7eb17a750fb4


### What to review

- `packages/sanity/src/core/variants/hooks/useVariantDeleteAction.ts` — dialog open/confirm/close flow
- `packages/sanity/src/core/variants/components/dialog/DeleteVariantDialog.tsx` — new confirmation dialog UI
- `packages/sanity/src/core/variants/tool/overview/VariantMenuButton.tsx` and `VariantDetailMenuButton.tsx` — dialog wiring

### Testing

- Added `DeleteVariantDialog.test.tsx`
- Updated unit tests for `useVariantDeleteAction`, `VariantMenuButton`, `VariantDetailMenuButton`, `VariantsOverview`, and `VariantDetail`
- Updated e2e tests in `e2e/tests/variants/variantTool.spec.ts` to confirm deletion via the dialog

Ran:
```bash
pnpm build --filter=sanity
pnpm vitest run --project=sanity packages/sanity/src/core/variants/hooks/__tests__/useVariantDeleteAction.test.ts packages/sanity/src/core/variants/components/dialog/__tests__/DeleteVariantDialog.test.tsx packages/sanity/src/core/variants/tool/__tests__/VariantMenuButton.test.tsx packages/sanity/src/core/variants/tool/__tests__/VariantDetailMenuButton.test.tsx packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
```

### Notes for release

When deleting a variant definition from the Variants tool, Studio now shows a confirmation dialog asking you to confirm before the variant is permanently deleted.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69e3b2b6-5bc0-47dc-93b7-ae5a5843733f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69e3b2b6-5bc0-47dc-93b7-ae5a5843733f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

