### PR TITLE
fix(core): update variant to variant definition and related copy

### DIFF
--- a/e2e/tests/variants/variantTool.spec.ts
+++ b/e2e/tests/variants/variantTool.spec.ts
@@ -148,16 +148,16 @@ function escapeRegExp(value: string): string {
 
 async function openVariantsTool(page: Page): Promise<void> {
   await page.goto('/variants')
-  await expect(page.getByRole('heading', {name: 'Variants'}).first()).toBeVisible()
+  await expect(page.getByRole('heading', {name: 'Variant definitions'}).first()).toBeVisible()
   // The heading renders before the overview has settled its data subscriptions.
   // Wait for the create button to be interactive so the first dialog-open click
   // is not dispatched while the page is still mounting and silently dropped.
-  await expect(page.getByRole('button', {name: 'Create variant'}).first()).toBeEnabled()
+  await expect(page.getByRole('button', {name: 'Create variant definition'}).first()).toBeEnabled()
 }
 
 async function openCreateVariantDialog(page: Page) {
-  const createVariantButton = page.getByRole('button', {name: 'Create variant'}).first()
-  const dialog = page.getByRole('dialog', {name: 'Create variant'})
+  const createVariantButton = page.getByRole('button', {name: 'Create variant definition'}).first()
+  const dialog = page.getByRole('dialog', {name: 'Create variant definition'})
 
   // Under parallel CI load the studio occasionally drops the first click while it
   // is still reconciling the shared variants subscription, leaving the dialog
@@ -475,7 +475,7 @@ test.describe('Variants create flow', () => {
     // Target the stable actions-menu id rather than the last button in the row,
     // which would break if the row gains more buttons. `variantId` is the short id.
     await page.locator(`#variant-actions-${variantId}`).click()
-    await page.getByRole('menuitem', {name: 'Delete variant'}).click()
+    await page.getByRole('menuitem', {name: 'Delete variant definition'}).click()
     await page.getByTestId('confirm-button').click()
 
     await expect(row).toBeHidden()
@@ -500,10 +500,10 @@ test.describe('Variants create flow', () => {
     await expect(page.getByRole('heading', {name: title})).toBeVisible()
 
     await page.locator(`#variant-detail-actions-${shortVariantId}`).click()
-    await page.getByRole('menuitem', {name: 'Delete variant'}).click()
+    await page.getByRole('menuitem', {name: 'Delete variant definition'}).click()
     await page.getByTestId('confirm-button').click()
 
-    await expect(page.getByRole('heading', {name: 'Variants'}).first()).toBeVisible()
+    await expect(page.getByRole('heading', {name: 'Variant definitions'}).first()).toBeVisible()
     await expect(getVariantRow(page, title)).toBeHidden()
     await expect.poll(async () => sanityClient.getDocument(documentId)).toBeUndefined()
   })

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
@@ -58,7 +58,7 @@ describe('CreateVariantDialog', () => {
     const result = render(<CreateVariantDialog onCancel={onCancel} onSubmit={onSubmit} />, {
       wrapper,
     })
-    await screen.findByRole('dialog', {name: 'Create variant'})
+    await screen.findByRole('dialog', {name: 'Create variant definition'})
     return result
   }
 
@@ -313,12 +313,12 @@ describe('CreateVariantDialog', () => {
     expect(toastMock.push).toHaveBeenCalledWith(
       expect.objectContaining({
         status: 'error',
-        title: 'Unable to create variant',
+        title: 'Unable to create variant definition',
       }),
     )
     expect(onCancel).not.toHaveBeenCalled()
     expect(onSubmit).not.toHaveBeenCalled()
-    expect(screen.getByRole('dialog', {name: 'Create variant'})).toBeInTheDocument()
+    expect(screen.getByRole('dialog', {name: 'Create variant definition'})).toBeInTheDocument()
 
     consoleError.mockRestore()
   })

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/VariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/VariantDialog.test.tsx
@@ -37,8 +37,8 @@ describe('VariantDialog', () => {
       <VariantDialog
         confirmDataTestId="save-variant-button"
         confirmText="Save"
-        errorTitle="Unable to update variant"
-        header="Edit variant"
+        errorTitle="Unable to update variant definition"
+        header="Edit variant definition"
         id="edit-variant-dialog"
         initialValue={props?.initialValue ?? getVariantDefaults()}
         onCancel={onCancel}
@@ -47,7 +47,7 @@ describe('VariantDialog', () => {
       />,
       {wrapper},
     )
-    await screen.findByRole('dialog', {name: 'Edit variant'})
+    await screen.findByRole('dialog', {name: 'Edit variant definition'})
     return result
   }
 
@@ -119,12 +119,12 @@ describe('VariantDialog', () => {
       expect(toastMock.push).toHaveBeenCalledWith(
         expect.objectContaining({
           status: 'error',
-          title: 'Unable to update variant',
+          title: 'Unable to update variant definition',
         }),
       )
     })
     expect(consoleError).toHaveBeenCalledWith(error)
-    expect(screen.getByRole('dialog', {name: 'Edit variant'})).toBeInTheDocument()
+    expect(screen.getByRole('dialog', {name: 'Edit variant definition'})).toBeInTheDocument()
     expect(onCancel).not.toHaveBeenCalled()
 
     consoleError.mockRestore()

--- a/packages/sanity/src/core/variants/hooks/__tests__/useVariantDeleteAction.test.ts
+++ b/packages/sanity/src/core/variants/hooks/__tests__/useVariantDeleteAction.test.ts
@@ -88,7 +88,7 @@ describe('useVariantDeleteAction', () => {
 
     expect(result.current.deleteDisabled).toBe(true)
     expect(result.current.deleteDisabledTooltip).toBe(
-      "This variant contains 1 document in it, it can't be removed until the documents have been removed.",
+      "This variant definition contains 1 document in it, it can't be removed until the documents have been removed.",
     )
 
     await act(async () => {
@@ -103,7 +103,7 @@ describe('useVariantDeleteAction', () => {
 
     expect(result.current.deleteDisabled).toBe(true)
     expect(result.current.deleteDisabledTooltip).toBe(
-      "This variant contains 2 documents in it, it can't be removed until the documents have been removed.",
+      "This variant definition contains 2 documents in it, it can't be removed until the documents have been removed.",
     )
   })
 
@@ -126,7 +126,7 @@ describe('useVariantDeleteAction', () => {
       expect(toastMock.push).toHaveBeenCalledWith(
         expect.objectContaining({
           status: 'error',
-          title: 'Unable to delete variant',
+          title: 'Unable to delete variant definition',
         }),
       )
     })

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -21,17 +21,17 @@ const variantsLocaleStrings = {
   /** Tooltip for clearing the selected variant. */
   'navbar.variant.clear': 'Clear variant selection',
   /** Label for the Variants overview create action. */
-  'overview.action.create-variant': 'Create variant',
+  'overview.action.create-variant': 'Create variant definition',
   /** Label for the Variants overview delete action. */
-  'overview.action.delete-variant': 'Delete variant',
+  'overview.action.delete-variant': 'Delete variant definition',
   /** Tooltip when delete is disabled because the variant contains one document. */
   'overview.action.delete-variant.disabled-hint_one':
-    "This variant contains {{count}} document in it, it can't be removed until the documents have been removed.",
+    "This variant definition contains {{count}} document in it, it can't be removed until the documents have been removed.",
   /** Tooltip when delete is disabled because the variant contains multiple documents. */
   'overview.action.delete-variant.disabled-hint_other':
-    "This variant contains {{count}} documents in it, it can't be removed until the documents have been removed.",
+    "This variant definition contains {{count}} documents in it, it can't be removed until the documents have been removed.",
   /** Error toast title when variant deletion fails. */
-  'overview.action.delete-variant.error.title': 'Unable to delete variant',
+  'overview.action.delete-variant.error.title': 'Unable to delete variant definition',
   /** Link label for Variants overview documentation (empty state). */
   'overview.action.documentation': 'Documentation',
   /** Description for the Variants overview empty state. */
@@ -41,33 +41,33 @@ const variantsLocaleStrings = {
   'overview.description':
     'Manage variant definitions that control how content is personalized for different audiences, locales, and segments.',
   /** Error message for the Variants overview. */
-  'overview.error': 'Unable to load variants',
+  'overview.error': 'Unable to load variant definitions',
   /** Placeholder for the Variants overview search field. */
   'overview.search.placeholder': 'Search variant definitions…',
   /** Column header for the variant title column in the overview table. */
-  'overview.table.variant': 'Variant',
+  'overview.table.variant': 'Variant definition',
   /** Column header for the documents count column in the overview table. */
   'overview.table.documents': 'Documents',
   /** Fallback text when a variant has no conditions. */
   'overview.table.no-conditions': 'No conditions',
   /** Title for the Variants overview. */
-  'overview.title': 'Variants',
+  'overview.title': 'Variant definitions',
   /** Edit action on the Variant detail page. */
-  'detail.action.edit-variant': 'Edit variant',
+  'detail.action.edit-variant': 'Edit variant definition',
   /** Tooltip for pinning a variant to the studio. */
-  'detail.pin-variant': 'Pin variant to studio',
+  'detail.pin-variant': 'Pin variant definition to studio',
   /** Tooltip for unpinning a variant from the studio. */
-  'detail.unpin-variant': 'Unpin variant from studio',
+  'detail.unpin-variant': 'Unpin variant definition from studio',
   /** Back action on the Variant detail page. */
-  'detail.back': 'Back to variants',
+  'detail.back': 'Back to variant definitions',
   /** Created status label in the Variant detail footer. */
   'detail.footer.created': 'Created',
   /** Loading message on the Variant detail page. */
-  'detail.loading': 'Loading variant',
+  'detail.loading': 'Loading variant definition',
   /** Fallback text when a variant has no description. */
   'detail.no-description': 'No description yet.',
   /** Empty state for variant document table. */
-  'detail.documents.no-documents': 'No documents in this variant',
+  'detail.documents.no-documents': 'No documents in this variant definition',
   /** Edited column header for variant document table. */
   'detail.documents.table.edited': 'Edited',
   /** Search placeholder for variant document table. */
@@ -81,15 +81,15 @@ const variantsLocaleStrings = {
   /** Validation error tooltip for multiple errors in the variant document table. */
   'detail.documents.table.validation.error_other': '{{count}} validation errors',
   /** Error message when variant documents fail to load. */
-  'detail.documents.error': 'Unable to load documents for this variant',
+  'detail.documents.error': 'Unable to load documents for this variant definition',
   /** Description for the missing Variant detail page. */
-  'detail.not-found.description': 'The requested variant could not be found.',
+  'detail.not-found.description': 'The requested variant definition could not be found.',
   /** Title for the missing Variant detail page. */
-  'detail.not-found.title': 'Variant not found',
+  'detail.not-found.title': 'Variant definition not found',
   /** Title for the create variant dialog. */
-  'dialog.create.title': 'Create variant',
+  'dialog.create.title': 'Create variant definition',
   /** Confirm action for the create variant dialog. */
-  'dialog.create.action.confirm': 'Create variant',
+  'dialog.create.action.confirm': 'Create variant definition',
   /** Add condition action for the create variant dialog. */
   'dialog.create.action.add-condition': 'Add condition',
   /** Tooltip when add condition is disabled because the current row is incomplete. */
@@ -106,12 +106,12 @@ const variantsLocaleStrings = {
   /** Label for the description field in the create variant dialog. */
   'dialog.create.description.label': 'Description',
   /** Placeholder for the description field in the create variant dialog. */
-  'dialog.create.description.placeholder': 'Describe who this variant targets',
+  'dialog.create.description.placeholder': 'Describe who this variant definition targets',
   /** Title for the conditions section in the create variant dialog. */
   'dialog.create.conditions.title': 'Conditions',
   /** Description for the conditions section in the create variant dialog. */
   'dialog.create.conditions.description':
-    'Add key/value pairs that define when this variant applies.',
+    'Add key/value pairs that define when this variant definition applies.',
   /** Label for the condition key field in the create variant dialog. */
   'dialog.create.condition-key.label': 'Key',
   /** Validation message when a condition key is repeated. */
@@ -134,15 +134,15 @@ const variantsLocaleStrings = {
   /** Placeholder for the condition value field in the create variant dialog. */
   'dialog.create.condition-value.placeholder': 'e.g. loyal-customers',
   /** Error toast title when variant creation fails. */
-  'dialog.create.error.title': 'Unable to create variant',
+  'dialog.create.error.title': 'Unable to create variant definition',
   /** Title for the edit variant dialog. */
-  'dialog.edit.title': 'Edit variant',
+  'dialog.edit.title': 'Edit variant definition',
   /** Confirm action for the edit variant dialog. */
   'dialog.edit.action.confirm': 'Save',
   /** Cancel action for the edit variant dialog. */
   'dialog.edit.action.cancel': 'Cancel',
   /** Error toast title when variant editing fails. */
-  'dialog.edit.error.title': 'Unable to update variant',
+  'dialog.edit.error.title': 'Unable to update variant definition',
   /** Title for the delete variant confirmation dialog. */
   'dialog.delete.title': 'Are you sure you want to delete this variant definition?',
   /** Description for the delete variant confirmation dialog. */

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -166,14 +166,14 @@ describe('VariantDetail', () => {
 
     expect(screen.getByText('Developer audience')).toBeInTheDocument()
     expect(screen.getByText('audience: "alpha", locale: "en-US"')).toBeInTheDocument()
-    expect(screen.getByRole('button', {name: 'Edit variant'})).toBeInTheDocument()
+    expect(screen.getByRole('button', {name: 'Edit variant definition'})).toBeInTheDocument()
     expect(screen.getByTestId('pin-variant-button')).toBeInTheDocument()
-    expect(screen.getByRole('button', {name: 'Back to variants'})).toBeInTheDocument()
+    expect(screen.getByRole('button', {name: 'Back to variant definitions'})).toBeInTheDocument()
     expect(screen.getByText('Bundle')).toBeInTheDocument()
     expect(screen.getByText('Type')).toBeInTheDocument()
     expect(screen.getByPlaceholderText('Search documents')).toBeInTheDocument()
     expect(screen.getByText('Edited')).toBeInTheDocument()
-    expect(screen.getByText('No documents in this variant')).toBeInTheDocument()
+    expect(screen.getByText('No documents in this variant definition')).toBeInTheDocument()
     expect(screen.getByText(/^Created/)).toBeInTheDocument()
     expect(screen.getByTestId('variant-detail-footer-actions')).toBeInTheDocument()
   })
@@ -197,10 +197,10 @@ describe('VariantDetail', () => {
 
     await renderDetail()
 
-    await user.click(screen.getByRole('button', {name: 'Edit variant'}))
+    await user.click(screen.getByRole('button', {name: 'Edit variant definition'}))
 
     await waitFor(() => {
-      expect(screen.getByRole('dialog', {name: 'Edit variant'})).toBeInTheDocument()
+      expect(screen.getByRole('dialog', {name: 'Edit variant definition'})).toBeInTheDocument()
     })
 
     expect(screen.getByTestId('variant-form-title')).toHaveValue('Alpha audience')
@@ -215,7 +215,7 @@ describe('VariantDetail', () => {
 
     await renderDetail()
 
-    await user.click(screen.getByRole('button', {name: 'Edit variant'}))
+    await user.click(screen.getByRole('button', {name: 'Edit variant definition'}))
     await user.clear(await screen.findByTestId('variant-form-title'))
     await user.type(screen.getByTestId('variant-form-title'), 'Beta audience')
     await user.type(screen.getByTestId('variant-form-description'), 'Audience for beta users')
@@ -246,7 +246,9 @@ describe('VariantDetail', () => {
     })
 
     await waitFor(() => {
-      expect(screen.queryByRole('dialog', {name: 'Edit variant'})).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('dialog', {name: 'Edit variant definition'}),
+      ).not.toBeInTheDocument()
     })
 
     await waitFor(() => {
@@ -261,7 +263,7 @@ describe('VariantDetail', () => {
 
     await renderDetail()
 
-    await user.click(screen.getByRole('button', {name: 'Edit variant'}))
+    await user.click(screen.getByRole('button', {name: 'Edit variant definition'}))
     const conditionKeys = screen.getAllByTestId('variant-form-condition-key')
     await user.clear(conditionKeys[1]!)
     await user.type(conditionKeys[1]!, 'audience')
@@ -282,12 +284,14 @@ describe('VariantDetail', () => {
 
     await renderDetail()
 
-    await user.click(screen.getByRole('button', {name: 'Edit variant'}))
+    await user.click(screen.getByRole('button', {name: 'Edit variant definition'}))
     await user.type(await screen.findByTestId('variant-form-title'), ' updated')
     await user.click(screen.getByRole('button', {name: 'Cancel'}))
 
     await waitFor(() => {
-      expect(screen.queryByRole('dialog', {name: 'Edit variant'})).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('dialog', {name: 'Edit variant definition'}),
+      ).not.toBeInTheDocument()
     })
     expect(variantOperationsMock.updateVariant).not.toHaveBeenCalled()
   })
@@ -299,12 +303,14 @@ describe('VariantDetail', () => {
 
     await renderDetail()
 
-    await user.click(screen.getByRole('button', {name: 'Edit variant'}))
+    await user.click(screen.getByRole('button', {name: 'Edit variant definition'}))
     await user.type(await screen.findByTestId('variant-form-title'), ' updated')
     await user.click(screen.getByLabelText('Close dialog'))
 
     await waitFor(() => {
-      expect(screen.queryByRole('dialog', {name: 'Edit variant'})).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('dialog', {name: 'Edit variant definition'}),
+      ).not.toBeInTheDocument()
     })
     expect(variantOperationsMock.updateVariant).not.toHaveBeenCalled()
     expect(screen.getByRole('heading', {level: 1, name: 'Alpha audience'})).toBeInTheDocument()
@@ -320,7 +326,7 @@ describe('VariantDetail', () => {
 
     await renderDetail()
 
-    await user.click(screen.getByRole('button', {name: 'Edit variant'}))
+    await user.click(screen.getByRole('button', {name: 'Edit variant definition'}))
     await user.type(await screen.findByTestId('variant-form-title'), ' updated')
     await user.click(screen.getByTestId('save-variant-button'))
 
@@ -328,12 +334,12 @@ describe('VariantDetail', () => {
       expect(toastMock.push).toHaveBeenCalledWith(
         expect.objectContaining({
           status: 'error',
-          title: 'Unable to update variant',
+          title: 'Unable to update variant definition',
         }),
       )
     })
     expect(consoleError).toHaveBeenCalledWith(error)
-    expect(screen.getByRole('dialog', {name: 'Edit variant'})).toBeInTheDocument()
+    expect(screen.getByRole('dialog', {name: 'Edit variant definition'})).toBeInTheDocument()
 
     consoleError.mockRestore()
   })
@@ -352,7 +358,7 @@ describe('VariantDetail', () => {
     if (!menuButton) throw new Error('Variant detail actions menu button not found')
 
     await user.click(menuButton)
-    await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByText('Delete variant definition'))
     await user.click(await screen.findByTestId('confirm-button'))
 
     await waitFor(() => {
@@ -378,14 +384,14 @@ describe('VariantDetail', () => {
     if (!menuButton) throw new Error('Variant detail actions menu button not found')
 
     await user.click(menuButton)
-    await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByText('Delete variant definition'))
     await user.click(await screen.findByTestId('confirm-button'))
 
     await waitFor(() => {
       expect(toastMock.push).toHaveBeenCalledWith(
         expect.objectContaining({
           status: 'error',
-          title: 'Unable to delete variant',
+          title: 'Unable to delete variant definition',
         }),
       )
     })
@@ -403,10 +409,12 @@ describe('VariantDetail', () => {
     await renderDetail()
 
     await waitFor(() => {
-      expect(screen.getByText('Variant not found')).toBeInTheDocument()
+      expect(screen.getByText('Variant definition not found')).toBeInTheDocument()
     })
 
-    expect(screen.getByText('The requested variant could not be found.')).toBeInTheDocument()
+    expect(
+      screen.getByText('The requested variant definition could not be found.'),
+    ).toBeInTheDocument()
   })
 
   it('navigates back to overview when Back is pressed', async () => {
@@ -417,10 +425,10 @@ describe('VariantDetail', () => {
     await renderDetail()
 
     await waitFor(() =>
-      expect(screen.getByRole('button', {name: 'Back to variants'})).toBeEnabled(),
+      expect(screen.getByRole('button', {name: 'Back to variant definitions'})).toBeEnabled(),
     )
 
-    await user.click(screen.getByRole('button', {name: 'Back to variants'}))
+    await user.click(screen.getByRole('button', {name: 'Back to variant definitions'}))
 
     expect(mockNavigate).toHaveBeenCalledWith({})
   })

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetailMenuButton.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetailMenuButton.test.tsx
@@ -80,7 +80,7 @@ describe('VariantDetailMenuButton', () => {
     await renderMenuButton()
 
     await user.click(screen.getByRole('button'))
-    await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByText('Delete variant definition'))
     await user.click(await screen.findByTestId('confirm-button'))
 
     await waitFor(() => {
@@ -99,7 +99,7 @@ describe('VariantDetailMenuButton', () => {
     const menuButton = screen.getByRole('button')
 
     await user.click(menuButton)
-    await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByText('Delete variant definition'))
     await user.click(await screen.findByTestId('confirm-button'))
 
     await waitFor(() => {
@@ -122,14 +122,14 @@ describe('VariantDetailMenuButton', () => {
     await renderMenuButton()
 
     await user.click(screen.getByRole('button'))
-    await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByText('Delete variant definition'))
     await user.click(await screen.findByTestId('confirm-button'))
 
     await waitFor(() => {
       expect(toastMock.push).toHaveBeenCalledWith(
         expect.objectContaining({
           status: 'error',
-          title: 'Unable to delete variant',
+          title: 'Unable to delete variant definition',
         }),
       )
     })
@@ -145,7 +145,7 @@ describe('VariantDetailMenuButton', () => {
     await renderMenuButton({documentCount: 1})
 
     await user.click(screen.getByRole('button'))
-    await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByText('Delete variant definition'))
 
     expect(variantOperationsMock.deleteVariant).not.toHaveBeenCalled()
     expect(mockNavigate).not.toHaveBeenCalled()
@@ -157,7 +157,7 @@ describe('VariantDetailMenuButton', () => {
     await renderMenuButton({documentCount: 0, documentsLoading: true})
 
     await user.click(screen.getByRole('button'))
-    await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByText('Delete variant definition'))
 
     expect(variantOperationsMock.deleteVariant).not.toHaveBeenCalled()
     expect(mockNavigate).not.toHaveBeenCalled()

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantMenuButton.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantMenuButton.test.tsx
@@ -52,7 +52,7 @@ describe('VariantMenuButton', () => {
     await renderMenuButton({documentCount: 0})
 
     await user.click(screen.getByRole('button'))
-    await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByText('Delete variant definition'))
     await user.click(await screen.findByTestId('confirm-button'))
 
     await waitFor(() => {
@@ -66,7 +66,7 @@ describe('VariantMenuButton', () => {
     await renderMenuButton({documentCount: 0})
 
     await user.click(screen.getByRole('button'))
-    await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByText('Delete variant definition'))
     await user.click(await screen.findByTestId('cancel-button'))
 
     expect(variantOperationsMock.deleteVariant).not.toHaveBeenCalled()
@@ -83,7 +83,7 @@ describe('VariantMenuButton', () => {
     const menuButton = screen.getByRole('button')
 
     await user.click(menuButton)
-    await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByText('Delete variant definition'))
     await user.click(await screen.findByTestId('confirm-button'))
 
     await waitFor(() => {
@@ -103,7 +103,7 @@ describe('VariantMenuButton', () => {
     await renderMenuButton({documentCount: 1})
 
     await user.click(screen.getByRole('button'))
-    await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByText('Delete variant definition'))
 
     expect(variantOperationsMock.deleteVariant).not.toHaveBeenCalled()
   })
@@ -114,7 +114,7 @@ describe('VariantMenuButton', () => {
     await renderMenuButton()
 
     await user.click(screen.getByRole('button'))
-    await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByText('Delete variant definition'))
 
     expect(variantOperationsMock.deleteVariant).not.toHaveBeenCalled()
   })

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -148,13 +148,13 @@ describe('VariantsOverview', () => {
 
     await renderOverview()
 
-    expect(screen.getByRole('heading', {level: 1, name: 'Variants'})).toBeInTheDocument()
+    expect(screen.getByRole('heading', {level: 1, name: 'Variant definitions'})).toBeInTheDocument()
     expect(
       screen.getByText(
         'Manage variant definitions that control how content is personalized for different audiences, locales, and segments.',
       ),
     ).toBeInTheDocument()
-    expect(screen.getByRole('button', {name: 'Create variant'})).toBeInTheDocument()
+    expect(screen.getByRole('button', {name: 'Create variant definition'})).toBeInTheDocument()
     expect(screen.getByPlaceholderText('Search variant definitions…')).toBeInTheDocument()
   })
 
@@ -283,7 +283,7 @@ describe('VariantsOverview', () => {
     if (!menuButton) throw new Error('Variant actions menu button not found')
 
     await user.click(menuButton)
-    await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByText('Delete variant definition'))
     await user.click(await screen.findByTestId('confirm-button'))
 
     await waitFor(() => {
@@ -308,7 +308,7 @@ describe('VariantsOverview', () => {
     if (!menuButton) throw new Error('Variant actions menu button not found')
 
     await user.click(menuButton)
-    await user.click(await screen.findByText('Delete variant'))
+    await user.click(await screen.findByText('Delete variant definition'))
 
     expect(variantOperationsMock.deleteVariant).not.toHaveBeenCalled()
   })
@@ -323,9 +323,11 @@ describe('VariantsOverview', () => {
     })
 
     expect(screen.getByTestId('variant-illustration')).toBeInTheDocument()
-    expect(screen.getByTestId('no-variants-info-text')).toHaveTextContent('Variants')
+    expect(screen.getByTestId('no-variants-info-text')).toHaveTextContent('Variant definitions')
     const emptyState = screen.getByTestId('variants-empty-state')
-    expect(within(emptyState).getByRole('button', {name: 'Create variant'})).toBeInTheDocument()
+    expect(
+      within(emptyState).getByRole('button', {name: 'Create variant definition'}),
+    ).toBeInTheDocument()
     expect(within(emptyState).getByRole('link', {name: 'Documentation'})).toHaveAttribute(
       'href',
       'https://www.sanity.io/docs/content-variants',
@@ -348,9 +350,9 @@ describe('VariantsOverview', () => {
 
     await renderOverview()
 
-    await user.click(screen.getAllByRole('button', {name: 'Create variant'})[0]!)
+    await user.click(screen.getAllByRole('button', {name: 'Create variant definition'})[0]!)
 
-    expect(screen.getByRole('dialog', {name: 'Create variant'})).toBeInTheDocument()
+    expect(screen.getByRole('dialog', {name: 'Create variant definition'})).toBeInTheDocument()
 
     await user.type(screen.getByTestId('variant-form-title'), 'Loyal customers')
     await user.type(screen.getByTestId('variant-form-condition-key'), 'audience')
@@ -379,7 +381,9 @@ describe('VariantsOverview', () => {
     await renderOverview()
 
     await waitFor(() => {
-      expect(screen.getAllByText('Unable to load variants').length).toBeGreaterThanOrEqual(1)
+      expect(
+        screen.getAllByText('Unable to load variant definitions').length,
+      ).toBeGreaterThanOrEqual(1)
     })
   })
 })

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsTool.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsTool.test.tsx
@@ -90,7 +90,9 @@ describe('VariantsTool', () => {
     await renderTool()
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', {level: 1, name: 'Variants'})).toBeInTheDocument()
+      expect(
+        screen.getByRole('heading', {level: 1, name: 'Variant definitions'}),
+      ).toBeInTheDocument()
     })
   })
 

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
@@ -123,14 +123,14 @@ describe('VariantDocumentsTable', () => {
   it('shows an empty state when there are no documents', async () => {
     await renderTable([])
 
-    expect(screen.getByText('No documents in this variant')).toBeInTheDocument()
+    expect(screen.getByText('No documents in this variant definition')).toBeInTheDocument()
   })
 
   it('shows loading skeleton rows while documents are loading', async () => {
     await renderTable([], true)
 
     expect(screen.getAllByTestId('table-row-skeleton')).toHaveLength(3)
-    expect(screen.queryByText('No documents in this variant')).not.toBeInTheDocument()
+    expect(screen.queryByText('No documents in this variant definition')).not.toBeInTheDocument()
   })
 
   it('renders document rows with bundle, title, type, and edited columns', async () => {

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -260,7 +260,8 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** Toast title in case an error occurs when adding a document to a variant */
   'banners.variant.error.title': 'Error adding document to variant',
   /** The text for the banner that appears when a document is not in the selected variant */
-  'banners.variant.not-in-variant': 'Not in the <VariantBadge>{{title}}</VariantBadge> variant.',
+  'banners.variant.not-in-variant':
+    'No variant document exists for <VariantBadge>{{title}}</VariantBadge>.',
   /** Description of toast that will appear while the document is added to the variant */
   'banners.variant.waiting.description':
     'Please hold tight while the document is added to the variant. It should not take longer than a few seconds.',


### PR DESCRIPTION
### Description
Updates "Variant" to "Variant definition" in the variants tool.
Also updates the copy for the document not in variant banner.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and i18n-only changes with matching test updates; no API or business-logic changes.
> 
> **Overview**
> Renames user-facing **variant** wording to **variant definition** across the variants tool so it matches the distinction between definitions and per-document variant content.
> 
> Updates `packages/sanity/src/core/variants/i18n/resources.ts` for overview, detail, dialogs, toasts, delete tooltips, and related strings (e.g. overview title **Variant definitions**, actions **Create/Delete/Edit variant definition**). Navbar strings that refer to selecting a variant perspective are unchanged.
> 
> In the structure tool, `banners.variant.not-in-variant` now says **No variant document exists for** the selected definition instead of **Not in the … variant**.
> 
> E2e and unit tests are aligned with the new accessible names and copy; no behavior changes beyond labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db70febff88c7ab6634b71325a883ec89377cfd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->