### PR TITLE
fix(portable-text): prevent duplicate nested annotation dialogs

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/Annotations.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/Annotations.browser.test.tsx
@@ -150,6 +150,26 @@ describe('Portable Text Input', () => {
       },
     )
 
+    it('Can edit a root-level annotation in fullscreen', {timeout: 30_000}, async () => {
+      const {getFocusedPortableTextEditor, insertPortableText} = testHelpers()
+      void render(<AnnotationsStory />)
+      const $pte = await getFocusedPortableTextEditor('field-body')
+
+      await insertPortableText('Fullscreen link', $pte)
+      await userEvent.keyboard('{Shift>}{ArrowLeft}{ArrowLeft}{ArrowLeft}{ArrowLeft}{/Shift}')
+      await page.getByRole('button', {name: 'Link'}).click()
+
+      const $linkInput = page.getByTestId('popover-edit-dialog').getByLabelText('Link')
+      await expect.element($linkInput).toBeVisible()
+      await $linkInput.fill('https://www.sanity.io')
+      await page.getByLabelText('Expand editor').click()
+
+      await expect.element(page.getByTestId('pt-editor')).toHaveAttribute('data-fullscreen', 'true')
+      await expect.element($linkInput).toBeVisible()
+      await $linkInput.element().focus()
+      await expect.element($linkInput).toHaveFocus()
+    })
+
     // Firefox has timing issues with PTE selection events (matches the original
     // Playwright `test.skip(browserName === 'firefox')`).
     it.skipIf(server.browser === 'firefox')(

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/NestedInput.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/NestedInput.browser.test.tsx
@@ -1,3 +1,4 @@
+import {type SanityDocument} from '@sanity/types'
 import {describe, expect, it} from 'vitest'
 import {page, userEvent} from 'vitest/browser'
 
@@ -64,6 +65,86 @@ describe('Portable Text Input', () => {
         failed = true
       }
       expect(failed).toBeTruthy()
+    })
+
+    it('opens one editable annotation dialog in an independently nested input', async () => {
+      const document: SanityDocument = {
+        _id: 'nested-input',
+        _type: 'test',
+        _createdAt: '2026-01-01T00:00:00Z',
+        _updatedAt: '2026-01-01T00:00:00Z',
+        _rev: 'nested-input',
+        body: [
+          {
+            _key: 'objectBlock',
+            _type: 'nestedObjectBlock',
+            siteOverrides: [
+              {
+                _key: 'siteOverride',
+                _type: 'siteOverride',
+                content: [
+                  {
+                    _key: 'nestedBlock',
+                    _type: 'block',
+                    children: [
+                      {
+                        _key: 'nestedSpan',
+                        _type: 'span',
+                        marks: ['nestedAnnotation'],
+                        text: 'nested link',
+                      },
+                    ],
+                    markDefs: [
+                      {
+                        _key: 'nestedAnnotation',
+                        _type: 'nestedAnnotation',
+                        value: '',
+                      },
+                    ],
+                    style: 'normal',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }
+      void render(
+        <NestedInputStory
+          document={document}
+          focusPath={[
+            'body',
+            {_key: 'objectBlock'},
+            'siteOverrides',
+            {_key: 'siteOverride'},
+            'content',
+            {_key: 'nestedBlock'},
+            'markDefs',
+            {_key: 'nestedAnnotation'},
+            'value',
+          ]}
+        />,
+      )
+
+      const annotationDialogs = () =>
+        page
+          .getByTestId('popover-edit-dialog')
+          .elements()
+          .filter((element) => element.textContent?.includes('Edit Nested annotation'))
+      await expect.poll(() => annotationDialogs().length).toBe(1)
+
+      const $annotationInput = page.getByLabelText('Annotation value')
+      await expect.element($annotationInput).toBeVisible()
+      await $annotationInput.click()
+      await expect.element($annotationInput).toHaveFocus()
+
+      await userEvent.keyboard('abc')
+      await expect.element($annotationInput).toHaveValue('abc')
+      await userEvent.keyboard('{ArrowLeft}{Shift>}{ArrowLeft}{/Shift}')
+
+      const annotationInput = $annotationInput.element() as HTMLInputElement
+      expect(annotationInput.selectionStart).toBe(1)
+      expect(annotationInput.selectionEnd).toBe(2)
     })
   })
 })

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/NestedInputStory.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/NestedInputStory.tsx
@@ -1,4 +1,10 @@
-import {defineArrayMember, defineField, defineType} from '@sanity/types'
+import {
+  defineArrayMember,
+  defineField,
+  defineType,
+  type Path,
+  type SanityDocument,
+} from '@sanity/types'
 
 import {TestForm} from '../../../../../../test/browser/TestForm'
 import {TestWrapper} from '../../../../../../test/browser/TestWrapper'
@@ -42,16 +48,62 @@ const SCHEMA_TYPES = [
               }),
             ],
           }),
+          defineArrayMember({
+            type: 'object',
+            name: 'nestedObjectBlock',
+            title: 'Nested Object Block',
+            fields: [
+              defineField({
+                type: 'array',
+                name: 'siteOverrides',
+                title: 'Site overrides',
+                of: [
+                  defineArrayMember({
+                    type: 'object',
+                    name: 'siteOverride',
+                    fields: [
+                      defineField({
+                        type: 'array',
+                        name: 'content',
+                        title: 'Content',
+                        of: [
+                          {
+                            type: 'block',
+                            marks: {
+                              annotations: [
+                                {
+                                  type: 'object',
+                                  name: 'nestedAnnotation',
+                                  title: 'Nested annotation',
+                                  fields: [
+                                    defineField({
+                                      type: 'string',
+                                      name: 'value',
+                                      title: 'Annotation value',
+                                    }),
+                                  ],
+                                },
+                              ],
+                            },
+                          },
+                        ],
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
         ],
       }),
     ],
   }),
 ]
 
-function NestedInputStory() {
+function NestedInputStory({document, focusPath}: {document?: SanityDocument; focusPath?: Path}) {
   return (
     <TestWrapper schemaTypes={SCHEMA_TYPES}>
-      <TestForm />
+      <TestForm document={document} focusPath={focusPath} />
     </TestWrapper>
   )
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/AnnotationObjectEditModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/AnnotationObjectEditModal.tsx
@@ -40,7 +40,7 @@ export function AnnotationObjectEditModal(props: {
 
   const elementRef = elementRefs[openAnnotation.key]
 
-  if (!elementRef) {
+  if (!elementRef || !props.referenceBoundary?.contains(elementRef)) {
     return null
   }
 


### PR DESCRIPTION
### Description

Fixes #13550

Portable Text member collection now includes nested annotations, so an open deeply nested annotation can be surfaced to ancestor editors as well as its owning editor. This renders overlapping edit dialogs and leaves the visible input without the active caret or text selection.

Only render an annotation edit modal when its reference element is contained by the current editor boundary. This leaves the nested editor responsible for its annotation dialog while preserving root-level and fullscreen editing.

### What to review

- Whether the existing reference boundary is the appropriate ownership boundary for annotation modals.
- The nested Portable Text browser fixture and its focus, caret selection, and fullscreen regression coverage.

### Testing

- Added browser regression coverage for independently nested and fullscreen annotation editing.
- Focused browser tests pass in Chromium, Firefox, and WebKit.
- Type checking, formatting, linting, the full test suite, and package build pass.

### Notes for release

Fixed annotation inputs in deeply nested Portable Text fields losing their visible caret and text selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted guard in annotation modal rendering with focused browser coverage; no auth or data-layer changes.
> 
> **Overview**
> Fixes overlapping annotation edit popovers when a deeply nested Portable Text field opens an annotation: ancestor editors were also rendering modals for the same open member, which broke caret and selection in the visible input.
> 
> **`AnnotationObjectEditModal`** now mounts only when the annotation’s reference element is inside that editor’s **`referenceBoundary`** (`contains` check), so the owning nested editor keeps the dialog while root-level and fullscreen editing still work.
> 
> Browser regressions cover a **nested annotation** fixture (exactly one dialog, focus, typing, text selection) and **fullscreen** link editing on a root field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daad182f7e78f1e46fa7441b53416e0e0d8af06d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->