### PR TITLE
chore(core): variants UI updates

### DIFF
--- a/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
@@ -92,10 +92,6 @@ export function VariantDetail() {
                     {description || t('detail.no-description')}
                   </Text>
                 </Stack>
-                <Button
-                  onClick={() => setEditDialogOpen(true)}
-                  text={t('detail.action.edit-variant')}
-                />
               </Flex>
 
               <Box paddingTop={4}>
@@ -128,6 +124,7 @@ export function VariantDetail() {
         </Flex>
       </Flex>
       <VariantDetailFooter
+        openEditDialog={() => setEditDialogOpen(true)}
         documentCount={tableRows.length}
         documentsLoading={documentsLoading}
         variant={variant}

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetailFooter.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetailFooter.tsx
@@ -1,6 +1,7 @@
 import {DiamondIcon} from '@sanity/icons/Diamond'
 import {Card, Flex, Text} from '@sanity/ui'
 
+import {Button} from '../../../../ui-components/button'
 import {RelativeTime} from '../../../components'
 import {useTranslation} from '../../../i18n'
 import {variantsLocaleNamespace} from '../../i18n'
@@ -8,10 +9,12 @@ import {type SystemVariant} from '../../types'
 import {VariantDetailMenuButton} from './VariantDetailMenuButton'
 
 export function VariantDetailFooter({
+  openEditDialog,
   documentCount,
   documentsLoading = false,
   variant,
 }: {
+  openEditDialog: () => void
   documentCount: number
   documentsLoading?: boolean
   variant: SystemVariant
@@ -38,6 +41,7 @@ export function VariantDetailFooter({
         </Flex>
 
         <Flex flex="none" gap={1} data-testid="variant-detail-footer-actions">
+          <Button onClick={openEditDialog} text={t('detail.action.edit-variant')} />
           <VariantDetailMenuButton
             documentCount={documentCount}
             documentsLoading={documentsLoading}

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -250,7 +250,7 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'banners.unpublished-release-banner.text-with-published':
     'Showing the current <strong>published</strong> version:',
   /** The text that appears for the action button to add the current document to the selected variant */
-  'banners.variant.action.add-to-variant': 'Add to variant',
+  'banners.variant.action.add-to-variant': 'Create variant',
   /** The text for the banner that appears when the selected variant matches no variant definition */
   'banners.variant.definition-not-found':
     'The selected variant <VariantName>{{name}}</VariantName> could not be found.',

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -50,6 +50,7 @@ import {FocusDocumentPaneClicked, FocusDocumentPaneCollapsed} from './__telemetr
 import {CopyDocumentActions} from './CopyDocumentActions'
 import {DocumentGroupInventoryHint} from './documentGroupInventoryHint/DocumentGroupInventoryHint'
 import {DocumentHeaderTitle} from './DocumentHeaderTitle'
+import {DocumentTargetBadges} from './DocumentTargetBadges'
 import {useChipScrollPosition} from './hook/useChipScrollPosition'
 import {DocumentPerspectiveList} from './perspective/DocumentPerspectiveList'
 
@@ -236,9 +237,10 @@ export const DocumentPanelHeader = memo(
                 </HorizontalScroller>
               )}
               {hasDocumentGroupInventory && (
-                <Box paddingX={3}>
+                <Flex paddingX={3} gap={2} align={'center'}>
+                  <DocumentTargetBadges />
                   <DocumentGroupInventoryHint />
-                </Box>
+                </Flex>
               )}
 
               <Box flex="none" paddingRight={3}>

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -237,10 +237,24 @@ export const DocumentPanelHeader = memo(
                 </HorizontalScroller>
               )}
               {hasDocumentGroupInventory && (
-                <Flex paddingX={3} gap={2} align={'center'}>
-                  <DocumentTargetBadges />
-                  <DocumentGroupInventoryHint />
-                </Flex>
+                <HorizontalScroller $showGradient={false}>
+                  <Flex
+                    flex={1}
+                    gap={2}
+                    align="center"
+                    overflow="auto"
+                    paddingX={3}
+                    data-testid="document-target-badges"
+                    style={{minWidth: 0}}
+                  >
+                    <Box flex="none">
+                      <DocumentTargetBadges />
+                    </Box>
+                    <Box flex="none">
+                      <DocumentGroupInventoryHint />
+                    </Box>
+                  </Flex>
+                </HorizontalScroller>
               )}
 
               <Box flex="none" paddingRight={3}>

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentTargetBadges.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentTargetBadges.tsx
@@ -53,13 +53,11 @@ const RhombusIcon: ForwardRefExoticComponent<
 const TargetBadge = styled(Card)`
   display: inline-flex;
   align-items: center;
+  flex: none;
 `
 const BadgeContainer = styled(Flex)`
   user-select: none;
-  overflow: hidden;
-  max-width: 300px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  flex: none;
 `
 
 function getPerspectiveBadgeTone(selectedPerspective: TargetPerspective): BadgeTone {
@@ -80,7 +78,7 @@ const PerspectiveBadgeLabel = memo(function PerspectiveBadgeLabel({
   if (isPublishedPerspective(selectedPerspective) || isDraftPerspective(selectedPerspective)) {
     return (
       <BadgeContainer padding={2}>
-        <Text size={1} textOverflow="ellipsis" weight="medium">
+        <Text size={1} weight="medium">
           {isPublishedPerspective(selectedPerspective)
             ? t('release.chip.published')
             : t('release.chip.global.drafts')}
@@ -98,7 +96,7 @@ const PerspectiveBadgeLabel = memo(function PerspectiveBadgeLabel({
           title={selectedPerspective.metadata?.title}
           fallback={t('release.placeholder-untitled-release')}
           enableTooltip={false}
-          textProps={{size: 1, weight: 'medium', textOverflow: 'ellipsis'}}
+          textProps={{size: 1, weight: 'medium'}}
         />
       </BadgeContainer>
     )
@@ -120,7 +118,7 @@ const VariantBadgeLabel = memo(function VariantBadgeLabel({variant}: {variant: S
         <Text size={0}>
           <RhombusIcon />
         </Text>
-        <Text size={1} textOverflow="ellipsis" weight="medium">
+        <Text size={1} weight="medium">
           {getVariantTitle(variant)}
         </Text>
       </Flex>
@@ -143,7 +141,7 @@ export const DocumentTargetBadges = memo(function DocumentTargetBadges() {
     targetDocumentState.status === 'ready' ? targetDocumentState.variant : undefined
 
   return (
-    <Flex align="center" gap={2} paddingRight={1}>
+    <Flex align="center" flex="none" gap={2} paddingRight={1}>
       <TargetBadge
         tone={getPerspectiveBadgeTone(selectedPerspective)}
         border

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentTargetBadges.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentTargetBadges.tsx
@@ -1,0 +1,162 @@
+import {Card, Flex, Text, type BadgeTone} from '@sanity/ui'
+import {
+  forwardRef,
+  type ForwardRefExoticComponent,
+  memo,
+  type RefAttributes,
+  type SVGProps,
+} from 'react'
+import {
+  getReleaseTone,
+  getVariantTitle,
+  isDraftPerspective,
+  isPublishedPerspective,
+  isReleaseDocument,
+  ReleaseTitle,
+  usePerspective,
+  useTranslation,
+  type SystemVariant,
+  type TargetPerspective,
+  ReleaseAvatarIcon,
+} from 'sanity'
+import {styled} from 'styled-components'
+
+import {useDocumentPane} from '../../useDocumentPane'
+
+/**
+ * TODO: Replace by the RhombusIcon from @sanity/icons once available.
+ */
+const RhombusIcon: ForwardRefExoticComponent<
+  Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
+> = forwardRef(function RhombusIcon(props, ref) {
+  return (
+    <svg
+      data-sanity-icon="rhombus"
+      width="1em"
+      height="1em"
+      viewBox="0 0 21 21"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+      ref={ref}
+    >
+      <path
+        d="M10.5 3.78L17.22 10.5L10.5 17.22L3.78 10.5L10.5 3.78Z"
+        stroke="currentColor"
+        strokeWidth={1.2}
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+})
+
+const TargetBadge = styled(Card)`
+  display: inline-flex;
+  align-items: center;
+`
+const BadgeContainer = styled(Flex)`
+  user-select: none;
+  overflow: hidden;
+  max-width: 300px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`
+
+function getPerspectiveBadgeTone(selectedPerspective: TargetPerspective): BadgeTone {
+  if (isDraftPerspective(selectedPerspective)) {
+    return 'caution'
+  }
+
+  return getReleaseTone(selectedPerspective)
+}
+
+const PerspectiveBadgeLabel = memo(function PerspectiveBadgeLabel({
+  selectedPerspective,
+}: {
+  selectedPerspective: TargetPerspective
+}) {
+  const {t} = useTranslation()
+
+  if (isPublishedPerspective(selectedPerspective) || isDraftPerspective(selectedPerspective)) {
+    return (
+      <BadgeContainer padding={2}>
+        <Text size={1} textOverflow="ellipsis" weight="medium">
+          {isPublishedPerspective(selectedPerspective)
+            ? t('release.chip.published')
+            : t('release.chip.global.drafts')}
+        </Text>
+      </BadgeContainer>
+    )
+  }
+
+  if (isReleaseDocument(selectedPerspective)) {
+    return (
+      <BadgeContainer gap={2} paddingY={1} paddingRight={2} align="center">
+        <ReleaseAvatarIcon release={selectedPerspective} />
+
+        <ReleaseTitle
+          title={selectedPerspective.metadata?.title}
+          fallback={t('release.placeholder-untitled-release')}
+          enableTooltip={false}
+          textProps={{size: 1, weight: 'medium', textOverflow: 'ellipsis'}}
+        />
+      </BadgeContainer>
+    )
+  }
+
+  return (
+    <BadgeContainer padding={2}>
+      <Text size={1} textOverflow="ellipsis" weight="medium">
+        {t('version.agent-bundle.proposed-changes')}
+      </Text>
+    </BadgeContainer>
+  )
+})
+
+const VariantBadgeLabel = memo(function VariantBadgeLabel({variant}: {variant: SystemVariant}) {
+  return (
+    <BadgeContainer padding={2}>
+      <Flex align="center" gap={2}>
+        <Text size={0}>
+          <RhombusIcon />
+        </Text>
+        <Text size={1} textOverflow="ellipsis" weight="medium">
+          {getVariantTitle(variant)}
+        </Text>
+      </Flex>
+    </BadgeContainer>
+  )
+})
+
+export const DocumentTargetBadges = memo(function DocumentTargetBadges() {
+  const {targetDocumentState} = useDocumentPane()
+  const {selectedPerspective} = usePerspective()
+
+  const isInCurrentTarget =
+    targetDocumentState.status === 'ready' && Boolean(targetDocumentState.targetDocument)
+
+  if (!isInCurrentTarget) {
+    return null
+  }
+
+  const selectedVariant =
+    targetDocumentState.status === 'ready' ? targetDocumentState.variant : undefined
+
+  return (
+    <Flex align="center" gap={2} paddingRight={1}>
+      <TargetBadge
+        tone={getPerspectiveBadgeTone(selectedPerspective)}
+        border
+        radius={4}
+        data-ui="DocumentTargetPerspectiveBadge"
+      >
+        <PerspectiveBadgeLabel selectedPerspective={selectedPerspective} />
+      </TargetBadge>
+      {selectedVariant ? (
+        <TargetBadge tone="suggest" border radius={4} data-ui="DocumentTargetVariantBadge">
+          <VariantBadgeLabel variant={selectedVariant} />
+        </TargetBadge>
+      ) : null}
+    </Flex>
+  )
+})

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/documentGroupInventoryHint/DocumentGroupInventoryHint.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/documentGroupInventoryHint/DocumentGroupInventoryHint.tsx
@@ -30,7 +30,7 @@ export const DocumentGroupInventoryHint: ComponentType = () => {
       }}
     >
       <Text size={1} weight="medium">
-        <Flex gap={2} align="center" justify="flex-end">
+        <Flex gap={2} align="center" flex="none" justify="flex-end">
           <InfoOutlineIcon /> {t('document-group-inventory.onboarding-hint')}
         </Flex>
       </Text>
@@ -48,6 +48,8 @@ const TextButton = styled.button(({theme}) => {
     padding: 0;
     outline: none;
     all: unset;
+    flex: none;
+    white-space: nowrap;
     color: var(--card-badge-suggest-fg-color);
     cursor: pointer;
 


### PR DESCRIPTION
### Description
Some ui updates related to variants.

Documents will display the variant and bundle they belong to when the document exists, to help indicate the user that they are editing the correct document
<img width="1224" height="785" alt="Screenshot 2026-07-16 at 18 33 09" src="https://github.com/user-attachments/assets/5f204b38-18e8-41a9-97a7-7515512b2291" />
<img width="1218" height="741" alt="Screenshot 2026-07-16 at 18 33 26" src="https://github.com/user-attachments/assets/2c24c4d8-f204-4c5f-bebd-0c9fbf23b0e7" />

The **Edit variant** button position is changed to the bottom of the variants detail page.
The variants create button text is updated.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a internal facing
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
