### PR TITLE
perf(core): defer global search results rendering

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
@@ -1,6 +1,6 @@
 import {type StackablePerspective} from '@sanity/client'
 import {Card, Flex} from '@sanity/ui'
-import {type MouseEvent, useCallback} from 'react'
+import {type MouseEvent, useCallback, useDeferredValue} from 'react'
 import {styled} from 'styled-components'
 
 import {CommandList, type CommandListRenderItemCallback} from '../../../../../../components'
@@ -48,8 +48,14 @@ export function SearchResults({
   const {t} = useTranslation()
   const recentSearchesStore = useRecentSearchesStore()
 
-  const hasSearchResults = !!result.hits.length
-  const hasNoSearchResults = !result.hits.length && result.loaded
+  // useDeferredValue doesn't have an effect unless it's used to delay rendering a component that has React.memo
+  const deferredHits = useDeferredValue(result.hits)
+  const isPending = deferredHits !== result.hits
+
+  const hasSearchResults = deferredHits.length > 0
+  // gated on the deferred value having caught up, else "no results" flashes on the settle frame
+  const hasNoSearchResults =
+    deferredHits.length === 0 && result.loaded && deferredHits === result.hits
   const hasError = result.error
 
   /**
@@ -105,7 +111,7 @@ export function SearchResults({
           {/* Results */}
           <SearchResultsInnerFlex
             $loadingFirstPage={result.loading && cursor === null}
-            aria-busy={result.loading}
+            aria-busy={result.loading || isPending}
             flex={1}
           >
             {hasError ? (
@@ -121,7 +127,7 @@ export function SearchResults({
                     initialIndex={lastActiveIndex}
                     inputElement={inputElement}
                     itemHeight={VIRTUAL_LIST_SEARCH_RESULT_ITEM_HEIGHT}
-                    items={result.hits}
+                    items={deferredHits}
                     overscan={VIRTUAL_LIST_OVERSCAN}
                     onEndReached={handleEndReached}
                     paddingX={2}

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
@@ -48,14 +48,13 @@ export function SearchResults({
   const {t} = useTranslation()
   const recentSearchesStore = useRecentSearchesStore()
 
-  // useDeferredValue doesn't have an effect unless it's used to delay rendering a component that has React.memo
+  // deferral only pays off because CommandList is memo()'d, so the urgent render skips the heavy row subtree
   const deferredHits = useDeferredValue(result.hits)
   const isPending = deferredHits !== result.hits
 
-  const hasSearchResults = deferredHits.length > 0
-  // gated on the deferred value having caught up, else "no results" flashes on the settle frame
-  const hasNoSearchResults =
-    deferredHits.length === 0 && result.loaded && deferredHits === result.hits
+  // requiring result.hits too hides the stale list the instant an empty result settles
+  const hasSearchResults = deferredHits.length > 0 && result.hits.length > 0
+  const hasNoSearchResults = result.hits.length === 0 && result.loaded
   const hasError = result.error
 
   /**


### PR DESCRIPTION
### Description

When a global search request settles (`SEARCH_REQUEST_COMPLETE`) while the user is still typing or interacting, the new hits render the virtualized `CommandList` subtree synchronously on the urgent lane, blocking that interaction frame. Each result row mounts its own preview subscription and per-item permission checks, so the settle commit is heavy. Part of SAPP-3743.

This PR defers `result.hits` with `useDeferredValue`, so the heavy `CommandList` commit runs on a background lane behind its existing `memo` boundary while the interaction frame stays responsive. The header, sort menu, `aria-busy`, and empty-state flags all derive from the deferred value so the visible state stays internally consistent during the single stale frame, while a settled-empty result still hides the previous query's list immediately.

### What to review

- The deferral is a no-op while typing: the reducer keeps `result.hits` referentially stable on `TERMS_QUERY_SET` and `SEARCH_REQUEST_START`, so it only interrupts the settle commit.
- `hasSearchResults` requires both the deferred hits and the settled `result.hits` to be non-empty. The `deferredHits` term keeps the list mount deferred; the `result.hits` term hides the previous query's list the instant a search settles with zero hits, instead of holding it for one deferred commit.
- `hasNoSearchResults` derives from the settled `result.hits` directly, so "no results" shows immediately on an empty settle and never flashes during the empty-to-results transition.
- `CommandList` is already wrapped in `memo` (`CommandList.tsx`), the precondition for `useDeferredValue` to skip the heavy row subtree on the urgent render.

### Testing

Full quality gate green: format, oxlint, types, build, and the vitest suite (one unrelated exports-snapshot test times out only under parallel load and passes in isolation).

Profiled the deferral live in the test studio (dev build) against the 29k-document species dataset under 4x CPU throttle, driving global search via Playwright. Toggled the deferral on and off over HMR and compared with a temporary React `Profiler` around `CommandList` plus a `long-animation-frame` / `event` (INP) `PerformanceObserver` harness.

Single-settle A/B on the heaviest transition (`aca` to `acan`), 4 samples each side:

- Max long-animation-frame blocking on the settle frame: ~116ms median before, ~73ms after (roughly 37% lower).
- Max long-animation-frame duration: ~174ms before, ~123ms after (roughly 29% lower).
- Smaller transitions improved similarly (max blocking 31 to 14ms, 24 to 12ms).
- The `Profiler` confirms the mechanism: with the defer, the heavy list render lands in a separate deferred commit off the urgent settle commit; without it, it renders synchronously in the settle commit.
- INP (max event latency) was unchanged (~64 to 104ms both sides), bound by the input handler and data layer rather than list rendering. A proper INP A/B needs the not-yet-built globalSearch bench scenario.

Verified the empty-settle behavior live with a per-frame DOM sampler, driving a results-to-empty transition (`author` to `authorzzqxqzq`). Before the empty-state fix, the previous query's list stayed rendered through the whole pending window and dropped only when `aria-busy` cleared; with the fix the list unmounts the instant the empty result settles (a frame exists with the list gone while `aria-busy` is still true) and "no results" shows immediately.

Caveats: dev build (production is faster), single machine, dev-mode LoAF attribution, no fiber-level render counts.

### Notes for release

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only search results timing and accessibility busy state; no auth, data, or API changes.
> 
> **Overview**
> **Defers rendering of global search hits** so a heavy `CommandList` update does not block the frame when a search response lands while the user is still interacting.
> 
> `SearchResults` now passes `useDeferredValue(result.hits)` into the memoized `CommandList`, tracks `isPending`, and sets `aria-busy` while loading or deferred. **Visibility rules** were tightened: the list only shows when both deferred and settled hits are non-empty (so a query that settles empty drops the previous list immediately), while **no results** still keys off settled `result.hits` so the empty state appears as soon as the request finishes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc2b002cf67176afea1930ff4de3715bc045e538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

