### PR TITLE
fix(core): keep mention list working with attribute-based RBAC

### DIFF
--- a/packages/sanity/src/core/hooks/useUserListWithPermissions.ts
+++ b/packages/sanity/src/core/hooks/useUserListWithPermissions.ts
@@ -6,6 +6,7 @@ import {concat, forkJoin, map, mergeMap, type Observable, of, shareReplay, switc
 
 import {
   type DocumentValuePermission,
+  grantFilterUsesUserAttributes,
   grantsPermissionOn,
   type ProjectData,
   useProjectStore,
@@ -118,6 +119,25 @@ export function useUserListWithPermissions(
             permission,
             documentValue,
           )
+
+          // Other users' attributes are not available client-side, and groq-js
+          // cannot evaluate `user::attributes()`. Without this fallback, any
+          // member with an attribute-based grant used to throw and empty the
+          // entire mention list. Prefer showing those users as mentionable.
+          if (
+            !granted &&
+            flattenedGrants.some(
+              (grant) =>
+                grant?.permissions?.includes(permission) &&
+                typeof grant.filter === 'string' &&
+                grantFilterUsesUserAttributes(grant.filter),
+            )
+          ) {
+            return {
+              ...user,
+              granted: true,
+            }
+          }
 
           return {
             ...user,

--- a/packages/sanity/src/core/store/datastores.ts
+++ b/packages/sanity/src/core/store/datastores.ts
@@ -89,7 +89,13 @@ export function useGrantsStore(): GrantsStore {
       resourceCache.get<GrantsStore>({
         namespace: 'grantsStore',
         dependencies: [client, currentUser, errorHandler],
-      }) || createGrantsStore({client, userId: currentUser?.id || null, errorHandler})
+      }) ||
+      createGrantsStore({
+        client,
+        userId: currentUser?.id || null,
+        userAttributes: currentUser?.attributes,
+        errorHandler,
+      })
 
     resourceCache.set({
       namespace: 'grantsStore',

--- a/packages/sanity/src/core/store/grants/__tests__/grantsPermissionOn.test.ts
+++ b/packages/sanity/src/core/store/grants/__tests__/grantsPermissionOn.test.ts
@@ -1,0 +1,101 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+  applyUserAttributesToFilter,
+  grantFilterUsesUserAttributes,
+  grantsPermissionOn,
+  userAttributesToObject,
+} from '../grantsStore'
+import {type Grant} from '../types'
+
+const bookDoc = {_id: 'book-1', _type: 'book', branch: 'london'}
+
+describe('grantFilterUsesUserAttributes', () => {
+  it('detects user::attributes() in grant filters', () => {
+    expect(
+      grantFilterUsesUserAttributes('_type == "book" && branch == user::attributes().branch'),
+    ).toBe(true)
+    expect(grantFilterUsesUserAttributes('_id in path("**")')).toBe(false)
+  })
+})
+
+describe('applyUserAttributesToFilter', () => {
+  it('rewrites user::attributes() to a GROQ object literal', () => {
+    expect(
+      applyUserAttributesToFilter('branch == user::attributes().branch', {branch: 'london'}),
+    ).toBe('branch == {"branch":"london"}.branch')
+  })
+})
+
+describe('userAttributesToObject', () => {
+  it('maps CurrentUser attributes to a plain object', () => {
+    expect(
+      userAttributesToObject([
+        {key: 'branch', type: 'string', value: 'london'},
+        {key: 'locales', type: 'string-array', value: ['en', 'es']},
+      ]),
+    ).toEqual({branch: 'london', locales: ['en', 'es']})
+  })
+
+  it('returns an empty object when attributes are missing', () => {
+    expect(userAttributesToObject(undefined)).toEqual({})
+    expect(userAttributesToObject([])).toEqual({})
+  })
+})
+
+describe('grantsPermissionOn', () => {
+  it('does not throw when a grant filter uses user::attributes() without attribute values', async () => {
+    const grants: Grant[] = [
+      {
+        filter: '_type == "book" && branch == user::attributes().branch',
+        permissions: ['read'],
+      },
+    ]
+
+    await expect(grantsPermissionOn('user-1', grants, 'read', bookDoc)).resolves.toEqual({
+      granted: false,
+      reason: 'No matching grants found',
+    })
+  })
+
+  it('still grants access from evaluable grants when another grant uses user::attributes()', async () => {
+    const grants: Grant[] = [
+      {
+        filter: '_id in path("**")',
+        permissions: ['read', 'update'],
+      },
+      {
+        filter: '_type == "book" && branch == user::attributes().branch',
+        permissions: ['read'],
+      },
+    ]
+
+    await expect(grantsPermissionOn('admin-1', grants, 'read', bookDoc)).resolves.toEqual({
+      granted: true,
+      reason: 'Matching grant',
+    })
+  })
+
+  it('evaluates user::attributes() filters when attribute values are provided', async () => {
+    const grants: Grant[] = [
+      {
+        filter: '_type == "book" && branch == user::attributes().branch',
+        permissions: ['read'],
+      },
+    ]
+
+    await expect(
+      grantsPermissionOn('user-1', grants, 'read', bookDoc, {branch: 'london'}),
+    ).resolves.toEqual({
+      granted: true,
+      reason: 'Matching grant',
+    })
+
+    await expect(
+      grantsPermissionOn('user-1', grants, 'read', bookDoc, {branch: 'oslo'}),
+    ).resolves.toEqual({
+      granted: false,
+      reason: 'No matching grants found',
+    })
+  })
+})

--- a/packages/sanity/src/core/store/grants/grantsStore.ts
+++ b/packages/sanity/src/core/store/grants/grantsStore.ts
@@ -1,5 +1,5 @@
 import {type SanityClient} from '@sanity/client'
-import {type CurrentUser, type SanityDocument} from '@sanity/types'
+import {type CurrentUser, type CurrentUserAttribute, type SanityDocument} from '@sanity/types'
 import {evaluate, parse} from 'groq-js'
 import {defer, of} from 'rxjs'
 import {refCountDelay} from 'rxjs-etc/operators'
@@ -15,6 +15,9 @@ import {
   type GrantsStore,
   type PermissionCheckResult,
 } from './types'
+
+/** Matches `user::attributes()` in role grant filters (attribute-based RBAC). */
+const USER_ATTRIBUTES_FN = 'user::attributes()'
 
 async function getDatasetGrants(
   client: SanityClient,
@@ -45,23 +48,77 @@ function getParams(userId: string | null): EvaluationParams {
   return params
 }
 
+/**
+ * Convert `CurrentUser.attributes` into a plain object for GROQ evaluation.
+ * @internal
+ */
+export function userAttributesToObject(
+  attributes: CurrentUserAttribute[] | undefined,
+): Record<string, unknown> {
+  if (!attributes?.length) {
+    return {}
+  }
+
+  return Object.fromEntries(attributes.map((attribute) => [attribute.key, attribute.value]))
+}
+
+/**
+ * groq-js does not implement `user::attributes()`. When we have attribute
+ * values, rewrite the function call to a GROQ object literal so filters can
+ * be evaluated client-side.
+ * @internal
+ */
+export function applyUserAttributesToFilter(
+  filter: string,
+  userAttributes: Record<string, unknown>,
+): string {
+  if (!grantFilterUsesUserAttributes(filter)) {
+    return filter
+  }
+
+  return filter.replaceAll(USER_ATTRIBUTES_FN, JSON.stringify(userAttributes))
+}
+
+/** @internal */
+export function grantFilterUsesUserAttributes(filter: string): boolean {
+  return filter.includes(USER_ATTRIBUTES_FN)
+}
+
 const PARSED_FILTERS_MEMO = new Map()
-async function matchesFilter(userId: string | null, filter: string, document: SanityDocument) {
-  if (!PARSED_FILTERS_MEMO.has(filter)) {
+async function matchesFilter(
+  userId: string | null,
+  filter: string,
+  document: SanityDocument,
+  userAttributes?: Record<string, unknown>,
+) {
+  const effectiveFilter =
+    userAttributes && grantFilterUsesUserAttributes(filter)
+      ? applyUserAttributesToFilter(filter, userAttributes)
+      : filter
+
+  if (!PARSED_FILTERS_MEMO.has(effectiveFilter)) {
     // note: it might be tempting to also memoize the result of the evaluation here,
     // Currently these filters are typically evaluated whenever a document change, which means they will be evaluated
     // quite frequently with different versions of the document. There might be some gains in finding out which subset of document
     // properties to use as key (e.g. by looking at the parsed filter and see what properties the filter cares about)
     // But as always, it's worth considering if the complexity/memory usage is worth the potential perf gain…
-    PARSED_FILTERS_MEMO.set(filter, parse(`*[${filter}]`))
+    PARSED_FILTERS_MEMO.set(effectiveFilter, parse(`*[${effectiveFilter}]`))
   }
-  const parsed = PARSED_FILTERS_MEMO.get(filter)
+  const parsed = PARSED_FILTERS_MEMO.get(effectiveFilter)
 
   const evalParams = getParams(userId)
   const {identity} = evalParams
   const params: Record<string, unknown> = {...evalParams}
-  const data = await (await evaluate(parsed, {dataset: [document], identity, params})).get()
-  return data?.length === 1
+
+  try {
+    const data = await (await evaluate(parsed, {dataset: [document], identity, params})).get()
+    return data?.length === 1
+  } catch {
+    // groq-js throws for unimplemented functions (e.g. user::attributes() when
+    // we have no attribute values to rewrite). Fail closed for this filter so
+    // a single unevaluable grant cannot abort the entire permission check.
+    return false
+  }
 }
 interface GrantsStoreOptionsCurrentUser {
   client: SanityClient
@@ -84,6 +141,11 @@ interface GrantsStoreOptionsUserId {
    */
   errorHandler?: StoreRequestErrorHandler
   userId: string | null
+  /**
+   * Organization-scoped user attributes for the authenticated user.
+   * Used to evaluate grant filters that reference `user::attributes()`.
+   */
+  userAttributes?: CurrentUserAttribute[]
 }
 
 /** @internal */
@@ -94,6 +156,9 @@ export function createGrantsStore(opts: GrantsStoreOptions): GrantsStore {
   const {client, errorHandler} = opts
   const versionedClient = client.withConfig({apiVersion: '2021-06-07'})
   const userId = 'userId' in opts ? opts.userId : opts?.currentUser?.id || null
+  const userAttributes = userAttributesToObject(
+    'userAttributes' in opts ? opts.userAttributes : opts.currentUser?.attributes,
+  )
 
   const datasetGrants$ = defer(() => of(versionedClient.config())).pipe(
     switchMap(({projectId, dataset}) => {
@@ -113,7 +178,9 @@ export function createGrantsStore(opts: GrantsStoreOptions): GrantsStore {
   return {
     checkDocumentPermission(permission: DocumentValuePermission, document: SanityDocument) {
       return currentUserDatasetGrants.pipe(
-        switchMap((grants) => grantsPermissionOn(userId, grants, permission, document)),
+        switchMap((grants) =>
+          grantsPermissionOn(userId, grants, permission, document, userAttributes),
+        ),
         distinctUntilChanged(shallowEquals),
       )
     },
@@ -130,6 +197,7 @@ export async function grantsPermissionOn(
   grants: Grant[],
   permission: DocumentValuePermission,
   document: SanityDocument | null,
+  userAttributes?: Record<string, unknown>,
 ): Promise<PermissionCheckResult> {
   if (!document) {
     // we say it's granted if null due to initial states
@@ -143,7 +211,7 @@ export async function grantsPermissionOn(
   const matchingGrants: Grant[] = []
 
   for (const grant of grants) {
-    if (await matchesFilter(userId, grant.filter, document)) {
+    if (await matchesFilter(userId, grant.filter, document, userAttributes)) {
       matchingGrants.push(grant)
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Projects using attribute-based RBAC (`user::attributes()` in role grant filters) saw comment @mentions return "No users found" for every user, including admins. Client-side grant evaluation uses groq-js, which throws `not implemented` for `user::attributes()`. That exception rejected `Promise.all` in `useUserListWithPermissions` and emptied the mention list—the same silent-failure shape as #12290.

Alternatives considered:
- **Fetch other users' attributes and evaluate accurately** — rejected for this fix; attributes are only available for the current user via `/users/me`, not arbitrary user lookups.
- **Fail closed and show ABAC members as unauthorized** — restores the list for admins, but leaves attribute-based members unmentionable.

This change catches unevaluable filters so one ABAC grant cannot abort permission checks, rewrites `user::attributes()` with the current user's attributes for own permission checks, and treats attribute-based grants as mentionable when other users' attributes are unavailable.

Related: #12290

### What to review

- `grantsStore.ts`: fail-closed catch + rewrite of `user::attributes()` when attribute values are provided
- `useUserListWithPermissions.ts`: mention fallback for attribute-based grants without other users' attributes
- `datastores.ts`: pass `currentUser.attributes` into `createGrantsStore`

### Testing

- Added `grantsPermissionOn.test.ts` covering: no throw without attributes, mixed grants still grant access, and correct evaluation when attributes are supplied
- `pnpm vitest run --project=sanity packages/sanity/src/core/store/grants/__tests__/grantsPermissionOn.test.ts packages/sanity/src/core/store/grants/__tests__/createGrantsStore.test.ts`

### Notes for release

Fixes comment @mentions showing "No users found" on projects that use attribute-based RBAC (`user::attributes()` in role grant filters). Mentions again list project members; users whose access depends only on attribute-based grants remain mentionable even though their exact document access cannot be evaluated client-side without their attributes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfba7fca-b5f2-4cfb-b495-58be48a73f33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfba7fca-b5f2-4cfb-b495-58be48a73f33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

