### PR TITLE
fix(comments): isolate mention permission failures

### DIFF
--- a/packages/sanity/src/core/hooks/__tests__/useUserListWithPermissions.test.tsx
+++ b/packages/sanity/src/core/hooks/__tests__/useUserListWithPermissions.test.tsx
@@ -4,18 +4,16 @@ import {renderHook, waitFor} from '@testing-library/react'
 import {of} from 'rxjs'
 import {afterEach, describe, expect, it, vi} from 'vitest'
 
-import {useProjectStore, useUserStore} from '../../store'
+import {grantsPermissionOn, useProjectStore, useUserStore} from '../../store'
 import {type ProjectData, type ProjectStore} from '../../store/project'
 import {type UserStore} from '../../store/user'
 import {getSystemGroups$} from '../../util/getSystemGroups$'
 import {useClient} from '../useClient'
 import {useUserListWithPermissions} from '../useUserListWithPermissions'
 
-vi.mock('../../store', async () => {
-  const {grantsPermissionOn} = await import('../../store/grants/grantsStore')
-
+vi.mock('../../store', () => {
   return {
-    grantsPermissionOn,
+    grantsPermissionOn: vi.fn(),
     useProjectStore: vi.fn(),
     useUserStore: vi.fn(),
   }
@@ -26,6 +24,7 @@ vi.mock('../useClient', () => ({useClient: vi.fn()}))
 const users: User[] = [
   {id: 'admin-user', displayName: 'Ada Admin'},
   {id: 'regional-user', displayName: 'Riley Regional'},
+  {id: 'attribute-only-user', displayName: 'Uma Attribute Only'},
 ]
 const documentValue = {_id: 'book-1', _type: 'b2bBook', language: 'en'}
 
@@ -40,14 +39,21 @@ function setup() {
     getUsers: vi.fn().mockResolvedValue(users),
   } as unknown as UserStore)
   vi.mocked(useClient).mockReturnValue({observable: {}} as SanityClient)
+  vi.mocked(grantsPermissionOn).mockImplementation(async (_userId, grants) => {
+    if (grants.some((grant) => grant.filter.includes('user::attributes()'))) {
+      throw new Error('not implemented')
+    }
+
+    return {granted: true, reason: 'Matching grant'}
+  })
   vi.mocked(getSystemGroups$).mockReturnValue(
     of([
       {
-        members: ['admin-user'],
+        members: ['admin-user', 'regional-user'],
         grants: [{filter: '_id in path("**")', permissions: ['read']}],
       },
       {
-        members: ['regional-user'],
+        members: ['regional-user', 'attribute-only-user'],
         grants: [
           {
             filter:
@@ -72,7 +78,7 @@ afterEach(() => {
 })
 
 describe('useUserListWithPermissions', () => {
-  it('keeps evaluable users when another user has an unevaluable grant filter', async () => {
+  it('keeps successful grant results when another grant cannot be evaluated', async () => {
     const {result} = setup()
 
     await waitFor(() => expect(result.current.loading).toBe(false))
@@ -80,7 +86,8 @@ describe('useUserListWithPermissions', () => {
     expect(result.current).toEqual({
       data: [
         {id: 'admin-user', displayName: 'Ada Admin', granted: true},
-        {id: 'regional-user', displayName: 'Riley Regional', granted: false},
+        {id: 'regional-user', displayName: 'Riley Regional', granted: true},
+        {id: 'attribute-only-user', displayName: 'Uma Attribute Only', granted: false},
       ],
       error: null,
       loading: false,

--- a/packages/sanity/src/core/hooks/__tests__/useUserListWithPermissions.test.tsx
+++ b/packages/sanity/src/core/hooks/__tests__/useUserListWithPermissions.test.tsx
@@ -1,0 +1,89 @@
+import {type SanityClient} from '@sanity/client'
+import {type User} from '@sanity/types'
+import {renderHook, waitFor} from '@testing-library/react'
+import {of} from 'rxjs'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import {useProjectStore, useUserStore} from '../../store'
+import {type ProjectData, type ProjectStore} from '../../store/project'
+import {type UserStore} from '../../store/user'
+import {getSystemGroups$} from '../../util/getSystemGroups$'
+import {useClient} from '../useClient'
+import {useUserListWithPermissions} from '../useUserListWithPermissions'
+
+vi.mock('../../store', async () => {
+  const {grantsPermissionOn} = await import('../../store/grants/grantsStore')
+
+  return {
+    grantsPermissionOn,
+    useProjectStore: vi.fn(),
+    useUserStore: vi.fn(),
+  }
+})
+vi.mock('../../util/getSystemGroups$', () => ({getSystemGroups$: vi.fn()}))
+vi.mock('../useClient', () => ({useClient: vi.fn()}))
+
+const users: User[] = [
+  {id: 'admin-user', displayName: 'Ada Admin'},
+  {id: 'regional-user', displayName: 'Riley Regional'},
+]
+const documentValue = {_id: 'book-1', _type: 'b2bBook', language: 'en'}
+
+function setup() {
+  vi.mocked(useProjectStore).mockReturnValue({
+    get: () =>
+      of({
+        members: users.map((user) => ({id: user.id, isRobot: false})),
+      } as ProjectData),
+  } as ProjectStore)
+  vi.mocked(useUserStore).mockReturnValue({
+    getUsers: vi.fn().mockResolvedValue(users),
+  } as unknown as UserStore)
+  vi.mocked(useClient).mockReturnValue({observable: {}} as SanityClient)
+  vi.mocked(getSystemGroups$).mockReturnValue(
+    of([
+      {
+        members: ['admin-user'],
+        grants: [{filter: '_id in path("**")', permissions: ['read']}],
+      },
+      {
+        members: ['regional-user'],
+        grants: [
+          {
+            filter:
+              '(_type match "b2b*") && defined(language) && language in user::attributes().locales',
+            permissions: ['read'],
+          },
+        ],
+      },
+    ]),
+  )
+
+  return renderHook(() =>
+    useUserListWithPermissions({
+      documentValue,
+      permission: 'read',
+    }),
+  )
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useUserListWithPermissions', () => {
+  it('keeps evaluable users when another user has an unevaluable grant filter', async () => {
+    const {result} = setup()
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current).toEqual({
+      data: [
+        {id: 'admin-user', displayName: 'Ada Admin', granted: true},
+        {id: 'regional-user', displayName: 'Riley Regional', granted: false},
+      ],
+      error: null,
+      loading: false,
+    })
+  })
+})

--- a/packages/sanity/src/core/hooks/useUserListWithPermissions.ts
+++ b/packages/sanity/src/core/hooks/useUserListWithPermissions.ts
@@ -6,6 +6,7 @@ import {concat, forkJoin, map, mergeMap, type Observable, of, shareReplay, switc
 
 import {
   type DocumentValuePermission,
+  type Grant,
   grantsPermissionOn,
   type ProjectData,
   useProjectStore,
@@ -52,6 +53,32 @@ const INITIAL_STATE: UserListWithPermissionsHookValue = {
 export interface UserListWithPermissionsOptions {
   documentValue: SanityDocument | null
   permission: DocumentValuePermission
+}
+
+async function hasPermissionFromAnyGrant(
+  userId: string,
+  grants: Grant[],
+  permission: DocumentValuePermission,
+  documentValue: SanityDocument | null,
+): Promise<boolean> {
+  if (!documentValue) {
+    return true
+  }
+
+  const results = await Promise.all(
+    grants.map(async (grant) => {
+      try {
+        const {granted} = await grantsPermissionOn(userId, [grant], permission, documentValue)
+        return granted
+      } catch {
+        // Some grants cannot be evaluated client-side, such as filters using
+        // `user::attributes()`. Fail closed for only the unevaluable grant.
+        return false
+      }
+    }),
+  )
+
+  return results.some(Boolean)
 }
 
 /**
@@ -112,20 +139,12 @@ export function useUserListWithPermissions(
           })
 
           const flattenedGrants = [...grants].flat()
-          let granted = false
-          try {
-            const permissionResult = await grantsPermissionOn(
-              user.id,
-              flattenedGrants,
-              permission,
-              documentValue,
-            )
-            granted = permissionResult.granted
-          } catch {
-            // Some grants cannot be evaluated client-side, such as filters using
-            // `user::attributes()`. Fail closed for only this user so one
-            // unevaluable grant does not empty the entire mention list.
-          }
+          const granted = await hasPermissionFromAnyGrant(
+            user.id,
+            flattenedGrants,
+            permission,
+            documentValue,
+          )
 
           return {
             ...user,

--- a/packages/sanity/src/core/hooks/useUserListWithPermissions.ts
+++ b/packages/sanity/src/core/hooks/useUserListWithPermissions.ts
@@ -112,16 +112,24 @@ export function useUserListWithPermissions(
           })
 
           const flattenedGrants = [...grants].flat()
-          const {granted} = await grantsPermissionOn(
-            user.id,
-            flattenedGrants,
-            permission,
-            documentValue,
-          )
+          let granted = false
+          try {
+            const permissionResult = await grantsPermissionOn(
+              user.id,
+              flattenedGrants,
+              permission,
+              documentValue,
+            )
+            granted = permissionResult.granted
+          } catch {
+            // Some grants cannot be evaluated client-side, such as filters using
+            // `user::attributes()`. Fail closed for only this user so one
+            // unevaluable grant does not empty the entire mention list.
+          }
 
           return {
             ...user,
-            granted: granted,
+            granted,
           }
         })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Attribute-based RBAC filters cannot be evaluated for other users in the browser and previously caused one rejected permission check to empty the entire mention list. This fails closed per grant instead, preserving successfully evaluated permissions without guessing or broadening another user's attributes.

### What to review

Review the per-grant error boundary in `useUserListWithPermissions` and the deterministic mixed evaluable/attribute-based grant regression test in the `sanity` package.

### Testing

- `pnpm vitest run --project=sanity packages/sanity/src/core/hooks/__tests__/useUserListWithPermissions.test.tsx`
- `pnpm exec oxlint --disable-nested-config --quiet packages/sanity/src/core/hooks/useUserListWithPermissions.ts packages/sanity/src/core/hooks/__tests__/useUserListWithPermissions.test.tsx`
- `pnpm exec oxfmt --check packages/sanity/src/core/hooks/useUserListWithPermissions.ts packages/sanity/src/core/hooks/__tests__/useUserListWithPermissions.test.tsx`
- `pnpm --filter sanity check:types`
- `pnpm build && pnpm test -- --silent` (545 test files, 5,058 tests passed on the initial implementation)

### Notes for release

Fixed comment and task mention lists showing no users when a project member has an attribute-based role grant.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8225b140-4654-4bbc-afd2-3f486b02820b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8225b140-4654-4bbc-afd2-3f486b02820b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

