### PR TITLE
feat(perf): add component-interaction benchmarking and comments feature module

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -182,7 +182,7 @@ jobs:
       fail-fast: false
       matrix:
         # One shard per scenario: wall-clock = slowest single scenario
-        scenario: [singleString, arrayI18n, article, recipe, synthetic, commentsField]
+        scenario: [singleString, arrayI18n, article, recipe, synthetic]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -387,7 +387,7 @@ jobs:
           # instead of rendering a clean table with a scenario silently
           # missing. Keep in sync with the bench-interaction matrix and the
           # bench-pageload --scenario flags above.
-          BENCH_EXPECTED_INTERACTION_SCENARIOS: singleString,arrayI18n,article,recipe,synthetic,commentsField
+          BENCH_EXPECTED_INTERACTION_SCENARIOS: singleString,arrayI18n,article,recipe,synthetic
           BENCH_EXPECTED_PAGELOAD_SCENARIOS: singleString,syntheticLarge
         run: pnpm bench report
 
@@ -639,7 +639,7 @@ jobs:
 
       - name: Run INP benchmarks
         run: |
-          pnpm bench run --mode inp --scenario singleString --scenario article --sessions 4 \
+          pnpm bench run --mode inp --scenario singleString --scenario article --scenario commentsField --sessions 4 \
             --json-out "$GITHUB_WORKSPACE/perf/bench/results/bench-results__inp.json"
 
       - name: Merge report

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -182,7 +182,7 @@ jobs:
       fail-fast: false
       matrix:
         # One shard per scenario: wall-clock = slowest single scenario
-        scenario: [singleString, arrayI18n, article, recipe, synthetic]
+        scenario: [singleString, arrayI18n, article, recipe, synthetic, commentsField]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -387,7 +387,7 @@ jobs:
           # instead of rendering a clean table with a scenario silently
           # missing. Keep in sync with the bench-interaction matrix and the
           # bench-pageload --scenario flags above.
-          BENCH_EXPECTED_INTERACTION_SCENARIOS: singleString,arrayI18n,article,recipe,synthetic
+          BENCH_EXPECTED_INTERACTION_SCENARIOS: singleString,arrayI18n,article,recipe,synthetic,commentsField
           BENCH_EXPECTED_PAGELOAD_SCENARIOS: singleString,syntheticLarge
         run: pnpm bench report
 

--- a/packages/sanity/src/core/comments/plugin/field/CommentsFieldButton.tsx
+++ b/packages/sanity/src/core/comments/plugin/field/CommentsFieldButton.tsx
@@ -170,6 +170,7 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
         <div>
           <Button
             aria-label={t('field-button.aria-label-add')}
+            data-testid="add-comment-button"
             disabled={isCreatingDataset || Boolean(addonDatasetError)}
             icon={AddCommentIcon}
             mode="bleed"
@@ -190,6 +191,7 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
     <Tooltip portal placement="top" content={t('field-button.content', {count})}>
       <SanityUIButton
         aria-label={t('field-button.aria-label-open')}
+        data-testid="open-comments-button"
         mode="bleed"
         onClick={onClick}
         padding={2}

--- a/packages/sanity/src/core/comments/plugin/field/CommentsFieldButton.tsx
+++ b/packages/sanity/src/core/comments/plugin/field/CommentsFieldButton.tsx
@@ -170,7 +170,6 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
         <div>
           <Button
             aria-label={t('field-button.aria-label-add')}
-            data-testid="add-comment-button"
             disabled={isCreatingDataset || Boolean(addonDatasetError)}
             icon={AddCommentIcon}
             mode="bleed"
@@ -191,7 +190,6 @@ export function CommentsFieldButton(props: CommentsFieldButtonProps) {
     <Tooltip portal placement="top" content={t('field-button.content', {count})}>
       <SanityUIButton
         aria-label={t('field-button.aria-label-open')}
-        data-testid="open-comments-button"
         mode="bleed"
         onClick={onClick}
         padding={2}

--- a/packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx
+++ b/packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx
@@ -411,7 +411,6 @@ function CommentsInspectorInner(
       )}
 
       <Flex
-        data-testid="comments-inspector"
         direction="column"
         flex={1}
         height="fill"

--- a/packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx
+++ b/packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx
@@ -411,6 +411,7 @@ function CommentsInspectorInner(
       )}
 
       <Flex
+        data-testid="comments-inspector"
         direction="column"
         flex={1}
         height="fill"

--- a/perf/bench/README.md
+++ b/perf/bench/README.md
@@ -101,9 +101,9 @@ A feature module is one file `mock-api/features/<name>.ts` exporting a `FeatureM
 
 The minimal case (comments) is flags-only: it rides the generic `/data/*` plane, so it only adds a `/features` flag and no routes.
 
-The `allow` allowlist is a report-only bootstrapping escape hatch — a 404'd endpoint means the feature is degrading, so never ship a benchmark whose target feature is allowlisted rather than served.
+The `allow` allowlist is a report-only bootstrapping escape hatch - a 404'd endpoint means the feature is degrading, so never ship a benchmark whose target feature is allowlisted rather than served.
 
-`bench dev --scenario <name>` seeds and opens any scenario (default `singleString`) with its features active — the interactive way to verify a feature module.
+`bench dev --scenario <name>` seeds and opens any scenario (default `singleString`) with its features active - the interactive way to verify a feature module.
 
 ## CI (`.github/workflows/bench.yml`)
 

--- a/perf/bench/README.md
+++ b/perf/bench/README.md
@@ -95,6 +95,16 @@ Useful `bench run` flags: `--headed`, `--throttle 1` (disable CPU throttle), `--
 3. Register in `scenarios/index.ts`; add the scenario to the `bench-interaction` matrix in `.github/workflows/bench.yml`.
 4. Verify: one absolute session passes with no failures — readback, console errors, hermeticity and endpoint drift are all hard session failures.
 
+## Adding a feature module
+
+A feature module is one file `mock-api/features/<name>.ts` exporting a `FeatureModule` (`name`, optional `featureFlags`, optional `routes`, optional `allow`), registered in `mock-api/features/index.ts`. A scenario opts in via `features: ['<name>']`.
+
+The minimal case (comments) is flags-only: it rides the generic `/data/*` plane, so it only adds a `/features` flag and no routes.
+
+The `allow` allowlist is a report-only bootstrapping escape hatch — a 404'd endpoint means the feature is degrading, so never ship a benchmark whose target feature is allowlisted rather than served.
+
+`bench dev --scenario <name>` seeds and opens any scenario (default `singleString`) with its features active — the interactive way to verify a feature module.
+
 ## CI (`.github/workflows/bench.yml`)
 
 - **Label-gated during burn-in**: PR jobs run only with the `trigger:perf-bench` label. The all-code-PRs gate is wired and one condition away.

--- a/perf/bench/cli/commands/dev.ts
+++ b/perf/bench/cli/commands/dev.ts
@@ -1,7 +1,21 @@
 import {object} from '@optique/core/constructs'
 import {message} from '@optique/core/message'
-import {command, constant} from '@optique/core/primitives'
+import {withDefault} from '@optique/core/modifiers'
+import {command, constant, option} from '@optique/core/primitives'
+import {string} from '@optique/core/valueparser'
 
-export const devCommand = command('dev', object({action: constant('dev')}), {
-  description: message`Start the mock Content Lake plus sanity dev for interactive debugging (no auth needed)`,
-})
+export const devCommand = command(
+  'dev',
+  object({
+    action: constant('dev'),
+    scenario: withDefault(
+      option('--scenario', string({metavar: 'NAME'}), {
+        description: message`Scenario to seed and open (default: singleString)`,
+      }),
+      'singleString',
+    ),
+  }),
+  {
+    description: message`Start the mock Content Lake plus sanity dev for interactive debugging (no auth needed)`,
+  },
+)

--- a/perf/bench/cli/index.ts
+++ b/perf/bench/cli/index.ts
@@ -62,7 +62,7 @@ switch (result.action) {
     ).storeRun(result.file ? resolveFromInvocation(result.file) : undefined)
     break
   case 'dev':
-    await (await import('../runner/devServer')).startBenchDev()
+    await (await import('../runner/devServer')).startBenchDev(result.scenario)
     break
   case 'scenarios':
     listScenarios(result.json)

--- a/perf/bench/mock-api/__tests__/contract.test.ts
+++ b/perf/bench/mock-api/__tests__/contract.test.ts
@@ -287,3 +287,102 @@ describe('mock Content Lake contract (real @sanity/client)', () => {
     expect(unexpected[0].path).toContain('/some/unknown/endpoint')
   })
 })
+
+describe('comments feature module (real @sanity/client)', () => {
+  const PORT = 43122
+  let mock: MockApiServer
+  let client: SanityClient
+
+  beforeAll(async () => {
+    mock = createMockApi({port: PORT, projectId: 'benchexp', dataset: 'bench'})
+    await mock.listen()
+    client = createClient({
+      projectId: 'benchexp',
+      dataset: 'bench',
+      apiHost: `http://127.0.0.1:${PORT}`,
+      useProjectHostname: false,
+      useCdn: false,
+      apiVersion: '2025-02-19',
+      token: 'bench-fake-token',
+    })
+  })
+
+  afterEach(() => {
+    mock.setActiveFeatures([])
+    mock.hub.closeAll()
+    mock.store.reset()
+    mock.ledger.reset()
+  })
+
+  afterAll(async () => {
+    await mock.close()
+  })
+
+  it('gates /features per activation', async () => {
+    expect(await client.request({uri: '/features'})).toEqual([])
+    mock.setActiveFeatures(['comments'])
+    expect(await client.request({uri: '/features'})).toEqual(['studioComments'])
+    mock.setActiveFeatures([])
+    expect(await client.request({uri: '/features'})).toEqual([])
+  })
+
+  it('resolves the comments addon-dataset handshake', async () => {
+    const datasets = await client.request<{name: string}[]>({
+      uri: '/projects/benchexp/datasets?datasetProfile=comments&addonFor=bench',
+    })
+    expect(Array.isArray(datasets)).toBe(true)
+    expect(datasets[0]?.name).toBeTruthy()
+  })
+
+  it('round-trips a comment create on the data plane', async () => {
+    mock.setActiveFeatures(['comments'])
+    const publishedId = 'comment-target'
+    const commentId = 'the-comment'
+    mock.store.seed([{_id: publishedId, _type: 'commentsField', stringField: 'x'}])
+    // The mock's mutate response carries no `document`, so the store is the round-trip oracle, not the client's return value.
+    await client.create({
+      _id: commentId,
+      _type: 'comment',
+      message: [
+        {
+          _type: 'block',
+          _key: 'b1',
+          children: [{_type: 'span', _key: 's1', text: 'nice work', marks: []}],
+          markDefs: [],
+        },
+      ],
+      target: {document: {_ref: publishedId}},
+    })
+    expect(mock.store.get(commentId)).toMatchObject({_type: 'comment'})
+  })
+
+  it('evaluates a comments GROQ query over the store', async () => {
+    const publishedId = 'comment-target'
+    mock.store.seed([
+      {_id: publishedId, _type: 'commentsField', stringField: 'x'},
+      {
+        _id: 'the-comment',
+        _type: 'comment',
+        message: [],
+        target: {document: {_ref: publishedId}},
+      },
+    ])
+    const result = await client.fetch(`*[_type == "comment" && target.document._ref == $id]{_id}`, {
+      id: publishedId,
+    })
+    expect(result).toEqual([{_id: 'the-comment'}])
+  })
+
+  it('records no unexpected endpoints while active', async () => {
+    mock.setActiveFeatures(['comments'])
+    await client.request({uri: '/features'})
+    await client.request({
+      uri: '/projects/benchexp/datasets?datasetProfile=comments&addonFor=bench',
+    })
+    expect(mock.ledger.snapshot().unexpected).toEqual([])
+  })
+
+  it('throws on an unknown feature name', () => {
+    expect(() => mock.setActiveFeatures(['bogus'])).toThrow(/bogus/)
+  })
+})

--- a/perf/bench/mock-api/createServer.ts
+++ b/perf/bench/mock-api/createServer.ts
@@ -251,6 +251,8 @@ export function createMockApi(config: MockApiConfig): MockApiServer {
       record('doc', handleDoc(req, res, store, docMatch[2]))
       return
     }
+    // Dataset segment is captured but ignored: one shared store serves every
+    // dataset (see DATASETS in project.ts).
     const queryMatch = path.match(/^\/data\/query\/([^/]+)/)
     if (queryMatch) {
       record('query', await handleQuery(req, res, store, url))

--- a/perf/bench/mock-api/createServer.ts
+++ b/perf/bench/mock-api/createServer.ts
@@ -9,6 +9,7 @@ import {Subscription} from 'rxjs'
 
 import {BENCH_USER} from '../constants'
 import {handleActions, handleDoc, handleDocRevision, handleMutate, handleQuery} from './data'
+import {type FeatureModule, resolveActiveModules} from './features'
 import {RequestLedger} from './ledger'
 import {AUTH_PROBE, AUTH_PROVIDERS, DATASET_ACL, DATASETS, projectData} from './project'
 import {corsHeaders, handlePreflight, json, readBody} from './respond'
@@ -33,6 +34,7 @@ export interface MockApiServer {
   store: DocumentStore
   hub: ListenHub
   ledger: RequestLedger
+  setActiveFeatures: (names: string[]) => void
 }
 
 /** Strip the `/vX.Y` API-version prefix @sanity/client puts on every path. */
@@ -54,6 +56,7 @@ export function createMockApi(config: MockApiConfig): MockApiServer {
   const store = new DocumentStore()
   const hub = new ListenHub()
   const ledger = new RequestLedger()
+  let activeFeatures: FeatureModule[] = []
 
   async function handle(req: ProxyRequest, res: ProxyResponse): Promise<void> {
     const url = new URL(req.url ?? '/', 'http://localhost')
@@ -175,7 +178,8 @@ export function createMockApi(config: MockApiConfig): MockApiServer {
       return
     }
     if (path === '/features' || path.startsWith('/features/')) {
-      record('features', json(req, res, 200, []))
+      const flags = activeFeatures.flatMap((featureModule) => featureModule.featureFlags ?? [])
+      record('features', json(req, res, 200, flags))
       return
     }
     if (path.startsWith('/journey')) {
@@ -268,6 +272,12 @@ export function createMockApi(config: MockApiConfig): MockApiServer {
       return
     }
 
+    for (const featureModule of activeFeatures) {
+      for (const handleRoute of featureModule.routes ?? []) {
+        if (await handleRoute({req, res, method, path, rawPath, url, store, hub, record})) return
+      }
+    }
+
     // --- unknown -------------------------------------------------------------
     ledger.recordUnexpected(method, rawPath)
     record('other', json(req, res, 404, {error: `bench mock: no handler for ${method} ${rawPath}`}))
@@ -312,5 +322,9 @@ export function createMockApi(config: MockApiConfig): MockApiServer {
     store,
     hub,
     ledger,
+    setActiveFeatures: (names: string[]) => {
+      activeFeatures = resolveActiveModules(names)
+      ledger.setAllow(activeFeatures.flatMap((featureModule) => featureModule.allow ?? []))
+    },
   }
 }

--- a/perf/bench/mock-api/features/comments.ts
+++ b/perf/bench/mock-api/features/comments.ts
@@ -1,0 +1,6 @@
+import {type FeatureModule} from './types'
+
+export const commentsModule: FeatureModule = {
+  name: 'comments',
+  featureFlags: ['studioComments'],
+}

--- a/perf/bench/mock-api/features/index.ts
+++ b/perf/bench/mock-api/features/index.ts
@@ -1,0 +1,20 @@
+import {commentsModule} from './comments'
+import {type FeatureModule} from './types'
+
+export {type FeatureModule} from './types'
+
+export const FEATURE_MODULES: FeatureModule[] = [commentsModule]
+
+export function resolveActiveModules(names: string[]): FeatureModule[] {
+  return names.map((name) => {
+    const featureModule = FEATURE_MODULES.find((candidate) => candidate.name === name)
+    if (!featureModule) {
+      throw new Error(
+        `Unknown feature module "${name}". Available: ${FEATURE_MODULES.map(
+          (candidate) => candidate.name,
+        ).join(', ')}`,
+      )
+    }
+    return featureModule
+  })
+}

--- a/perf/bench/mock-api/features/types.ts
+++ b/perf/bench/mock-api/features/types.ts
@@ -1,0 +1,28 @@
+import {type ProxyRequest, type ProxyResponse} from '@repo/debug-proxy'
+
+import {type ListenHub} from '../sse'
+import {type DocumentStore} from '../store'
+
+export interface FeatureRequestContext {
+  req: ProxyRequest
+  res: ProxyResponse
+  method: string
+  /** version-stripped path */
+  path: string
+  rawPath: string
+  url: URL
+  store: DocumentStore
+  hub: ListenHub
+  record: (endpointClass: string, bytesOut: number) => void
+}
+
+export interface FeatureModule {
+  /** Matches entries in scenario.features (e.g. 'comments'). */
+  name: string
+  /** Keys unioned into the /features response while active (e.g. ['studioComments']). */
+  featureFlags?: readonly string[]
+  /** Extra routes, tried after built-ins, before the 404 fallthrough. Returns true if handled. */
+  routes?: readonly ((context: FeatureRequestContext) => boolean | Promise<boolean>)[]
+  /** Ledger allowlist patterns active only while this module is (report-only escape hatch). */
+  allow?: readonly RegExp[]
+}

--- a/perf/bench/mock-api/ledger.ts
+++ b/perf/bench/mock-api/ledger.ts
@@ -42,13 +42,19 @@ const UNIMPLEMENTED_BUT_GRACEFUL = [
 export class RequestLedger {
   private entries: LedgerEntry[] = []
   private unexpected: UnexpectedRequest[] = []
+  private moduleAllow: RegExp[] = []
 
   record(entry: LedgerEntry): void {
     this.entries.push(entry)
   }
 
+  setAllow(patterns: RegExp[]): void {
+    this.moduleAllow = patterns
+  }
+
   recordUnexpected(method: string, path: string): void {
-    if (UNIMPLEMENTED_BUT_GRACEFUL.some((pattern) => pattern.test(path))) {
+    const allowed = [...UNIMPLEMENTED_BUT_GRACEFUL, ...this.moduleAllow]
+    if (allowed.some((pattern) => pattern.test(path))) {
       return
     }
     this.unexpected.push({method, path, at: Date.now()})

--- a/perf/bench/mock-api/project.ts
+++ b/perf/bench/mock-api/project.ts
@@ -52,4 +52,6 @@ export function projectData(projectId: string): Record<string, unknown> {
   }
 }
 
+// One dataset-agnostic store backs every dataset (incl. the comments addon
+// dataset), so a single entry is enough here and for the /datasets handshake.
 export const DATASETS = [{name: DATASET, aclMode: 'public'}]

--- a/perf/bench/runner/devServer.ts
+++ b/perf/bench/runner/devServer.ts
@@ -14,12 +14,12 @@ import {fileURLToPath} from 'node:url'
 import {DATASET, EXPERIMENT} from '../constants'
 import {createMockApi} from '../mock-api/createServer'
 import {getBenchTls} from '../mock-api/tls'
+import {getScenario} from '../scenarios'
 
 const benchRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)))
 
-const SEED_DOCUMENT_ID = 'bench-dev-doc'
-
-export async function startBenchDev(): Promise<void> {
+export async function startBenchDev(scenarioName: string): Promise<void> {
+  const scenario = getScenario(scenarioName)
   const mock = createMockApi({
     port: EXPERIMENT.apiPort,
     projectId: EXPERIMENT.projectId,
@@ -27,10 +27,8 @@ export async function startBenchDev(): Promise<void> {
     tls: await getBenchTls(),
   })
   await mock.listen()
-  mock.store.seed([
-    {_id: SEED_DOCUMENT_ID, _type: 'singleString', stringField: 'type here'},
-    {_id: `drafts.${SEED_DOCUMENT_ID}`, _type: 'singleString', stringField: 'type here'},
-  ])
+  mock.setActiveFeatures(scenario.features ?? [])
+  mock.store.seed(scenario.fixture())
 
   console.log(`[bench] mock API listening on ${mock.url} (project ${EXPERIMENT.projectId})`)
 
@@ -44,7 +42,7 @@ export async function startBenchDev(): Promise<void> {
     [
       '',
       `[bench] once the studio is up, open:`,
-      `[bench]   http://localhost:${EXPERIMENT.studioPort}/singleString/intent/edit/id=${SEED_DOCUMENT_ID};type=singleString`,
+      `[bench]   http://localhost:${EXPERIMENT.studioPort}/${scenario.workspace ?? scenario.name}/intent/edit/id=${scenario.documentId};type=${scenario.documentType}`,
       '',
     ].join('\n'),
   )

--- a/perf/bench/runner/session/__tests__/steps.test.ts
+++ b/perf/bench/runner/session/__tests__/steps.test.ts
@@ -6,6 +6,7 @@ import {resolveLocator, runStep, toTypeStep} from '../steps'
 interface FakeLocator {
   selector: string
   scope?: string
+  labelOptions?: {exact?: boolean}
   first: () => FakeLocator
   locator: (inner: string) => FakeLocator
   getByLabel: (label: string, options?: {exact?: boolean}) => FakeLocator
@@ -14,13 +15,18 @@ interface FakeLocator {
   click: () => Promise<void>
 }
 
-function makeLocator(selector: string, scope?: string): FakeLocator {
+function makeLocator(
+  selector: string,
+  scope?: string,
+  labelOptions?: {exact?: boolean},
+): FakeLocator {
   const locator: FakeLocator = {
     selector,
     scope,
+    labelOptions,
     first: () => locator,
     locator: (inner) => makeLocator(inner, selector),
-    getByLabel: (label) => makeLocator(label, selector),
+    getByLabel: (label, options) => makeLocator(label, selector, options),
     waitFor: async () => {},
     hover: async () => {},
     click: async () => {},
@@ -31,7 +37,11 @@ function makeLocator(selector: string, scope?: string): FakeLocator {
 function createFakePage() {
   return {
     locator: (selector: string) => makeLocator(selector),
-    getByLabel: (label: string) => makeLocator(label),
+    getByLabel: (label: string, options?: {exact?: boolean}) =>
+      makeLocator(label, undefined, options),
+    keyboard: {type: async () => {}, press: async () => {}},
+    evaluate: async () => false,
+    waitForTimeout: async () => {},
   }
 }
 
@@ -79,6 +89,7 @@ describe('resolveLocator', () => {
     }) as unknown as FakeLocator
     expect(locator.selector).toBe('Add comment')
     expect(locator.scope).toBe('[data-testid="field-stringField"]')
+    expect(locator.labelOptions).toEqual({exact: true})
   })
 
   it('passes a raw css selector through', () => {
@@ -112,6 +123,16 @@ describe('runStep interaction counts', () => {
       drive: async () => ({interactions: 7}),
     }
     expect(await runStep(fakeContext(), step)).toEqual({interactions: 7})
+  })
+
+  it('type with text reports focus click plus one interaction per character', async () => {
+    const step: ScenarioStep = {kind: 'type', selector: {css: '.x'}, text: 'abcd'}
+    expect(await runStep(fakeContext(), step)).toEqual({interactions: 5})
+  })
+
+  it('type with keystrokes reports focus click plus the keystroke count', async () => {
+    const step: ScenarioStep = {kind: 'type', selector: {css: '.x'}, keystrokes: 5}
+    expect(await runStep(fakeContext(), step)).toEqual({interactions: 6})
   })
 })
 

--- a/perf/bench/runner/session/__tests__/steps.test.ts
+++ b/perf/bench/runner/session/__tests__/steps.test.ts
@@ -9,6 +9,7 @@ interface FakeLocator {
   first: () => FakeLocator
   locator: (inner: string) => FakeLocator
   waitFor: () => Promise<void>
+  hover: () => Promise<void>
   click: () => Promise<void>
 }
 
@@ -19,6 +20,7 @@ function makeLocator(selector: string, scope?: string): FakeLocator {
     first: () => locator,
     locator: (inner) => makeLocator(inner, selector),
     waitFor: async () => {},
+    hover: async () => {},
     click: async () => {},
   }
   return locator
@@ -81,6 +83,11 @@ describe('runStep interaction counts', () => {
 
   it('awaitVisible reports 0', async () => {
     const step: ScenarioStep = {kind: 'awaitVisible', selector: {css: '.x'}}
+    expect(await runStep(fakeContext(), step)).toEqual({interactions: 0})
+  })
+
+  it('hover reports 0', async () => {
+    const step: ScenarioStep = {kind: 'hover', selector: {css: '.x'}}
     expect(await runStep(fakeContext(), step)).toEqual({interactions: 0})
   })
 

--- a/perf/bench/runner/session/__tests__/steps.test.ts
+++ b/perf/bench/runner/session/__tests__/steps.test.ts
@@ -1,0 +1,104 @@
+import {describe, expect, it} from 'vitest'
+
+import {type ScenarioStep, type StepContext} from '../../../scenarios/types'
+import {resolveLocator, runStep, toTypeStep} from '../steps'
+
+interface FakeLocator {
+  selector: string
+  scope?: string
+  first: () => FakeLocator
+  locator: (inner: string) => FakeLocator
+  waitFor: () => Promise<void>
+  click: () => Promise<void>
+}
+
+function makeLocator(selector: string, scope?: string): FakeLocator {
+  const locator: FakeLocator = {
+    selector,
+    scope,
+    first: () => locator,
+    locator: (inner) => makeLocator(inner, selector),
+    waitFor: async () => {},
+    click: async () => {},
+  }
+  return locator
+}
+
+function createFakePage() {
+  return {locator: (selector: string) => makeLocator(selector)}
+}
+
+function fakeContext(): StepContext {
+  return {
+    page: createFakePage() as unknown as StepContext['page'],
+    running: {} as StepContext['running'],
+    timeoutMs: 1000,
+    interruptions: {count: 0, totalMs: 0},
+  }
+}
+
+describe('resolveLocator', () => {
+  it('builds the composite input selector for a string field', () => {
+    const locator = resolveLocator(createFakePage() as never, {
+      field: 'stringField',
+      kind: 'string',
+    }) as unknown as FakeLocator
+    expect(locator.selector).toBe(
+      '[data-testid="field-stringField"] input[type="text"], [data-testid="field-stringField"] textarea',
+    )
+  })
+
+  it('builds the contenteditable selector for a pte field', () => {
+    const locator = resolveLocator(createFakePage() as never, {
+      field: 'body',
+      kind: 'pte',
+    }) as unknown as FakeLocator
+    expect(locator.selector).toBe('[data-testid="field-body"] [contenteditable="true"]')
+  })
+
+  it('scopes a testId selector under a within ancestor', () => {
+    const locator = resolveLocator(createFakePage() as never, {
+      testId: 'add-comment-button',
+      within: 'field-stringField',
+    }) as unknown as FakeLocator
+    expect(locator.selector).toBe('[data-testid="add-comment-button"]')
+    expect(locator.scope).toBe('[data-testid="field-stringField"]')
+  })
+
+  it('passes a raw css selector through', () => {
+    const locator = resolveLocator(createFakePage() as never, {
+      css: '.some-thing',
+    }) as unknown as FakeLocator
+    expect(locator.selector).toBe('.some-thing')
+  })
+})
+
+describe('runStep interaction counts', () => {
+  it('click reports 1', async () => {
+    const step: ScenarioStep = {kind: 'click', selector: {css: '.x'}}
+    expect(await runStep(fakeContext(), step)).toEqual({interactions: 1})
+  })
+
+  it('awaitVisible reports 0', async () => {
+    const step: ScenarioStep = {kind: 'awaitVisible', selector: {css: '.x'}}
+    expect(await runStep(fakeContext(), step)).toEqual({interactions: 0})
+  })
+
+  it('raw reports its own count', async () => {
+    const step: ScenarioStep = {
+      kind: 'raw',
+      label: 'custom',
+      drive: async () => ({interactions: 7}),
+    }
+    expect(await runStep(fakeContext(), step)).toEqual({interactions: 7})
+  })
+})
+
+describe('toTypeStep', () => {
+  it('maps an interaction target to a field type step', () => {
+    expect(toTypeStep({fieldPath: 'title', kind: 'string'})).toEqual({
+      kind: 'type',
+      selector: {field: 'title', kind: 'string'},
+    })
+  })
+})

--- a/perf/bench/runner/session/__tests__/steps.test.ts
+++ b/perf/bench/runner/session/__tests__/steps.test.ts
@@ -8,6 +8,7 @@ interface FakeLocator {
   scope?: string
   first: () => FakeLocator
   locator: (inner: string) => FakeLocator
+  getByLabel: (label: string, options?: {exact?: boolean}) => FakeLocator
   waitFor: () => Promise<void>
   hover: () => Promise<void>
   click: () => Promise<void>
@@ -19,6 +20,7 @@ function makeLocator(selector: string, scope?: string): FakeLocator {
     scope,
     first: () => locator,
     locator: (inner) => makeLocator(inner, selector),
+    getByLabel: (label) => makeLocator(label, selector),
     waitFor: async () => {},
     hover: async () => {},
     click: async () => {},
@@ -27,7 +29,10 @@ function makeLocator(selector: string, scope?: string): FakeLocator {
 }
 
 function createFakePage() {
-  return {locator: (selector: string) => makeLocator(selector)}
+  return {
+    locator: (selector: string) => makeLocator(selector),
+    getByLabel: (label: string) => makeLocator(label),
+  }
 }
 
 function fakeContext(): StepContext {
@@ -64,6 +69,15 @@ describe('resolveLocator', () => {
       within: 'field-stringField',
     }) as unknown as FakeLocator
     expect(locator.selector).toBe('[data-testid="add-comment-button"]')
+    expect(locator.scope).toBe('[data-testid="field-stringField"]')
+  })
+
+  it('resolves a label selector via getByLabel scoped under within', () => {
+    const locator = resolveLocator(createFakePage() as never, {
+      label: 'Add comment',
+      within: 'field-stringField',
+    }) as unknown as FakeLocator
+    expect(locator.selector).toBe('Add comment')
     expect(locator.scope).toBe('[data-testid="field-stringField"]')
   })
 

--- a/perf/bench/runner/session/inp.ts
+++ b/perf/bench/runner/session/inp.ts
@@ -14,8 +14,8 @@ import {
   type ReadOnlyInterruptions,
   type SessionConfig,
   SessionError,
-  typeBurst,
 } from './interaction'
+import {runStep, toTypeStep} from './steps'
 
 export interface InpSessionResult extends InpResult {
   /**
@@ -65,6 +65,7 @@ export async function runInpSession(options: {
   const {browser, running, scenario, instrumentation} = options
   const config = {...DEFAULT_INP_CONFIG, ...options.config}
 
+  running.mock.setActiveFeatures(scenario.features ?? [])
   running.mock.hub.closeAll()
   running.mock.store.reset()
   running.mock.ledger.reset()
@@ -103,14 +104,14 @@ export async function runInpSession(options: {
     // web-vitals performance.interactionCount), or INP would drop when a
     // regression pushes below-floor interactions over the floor.
     let driven = 0
-    const keystrokesPerField = 4
-    let offset = 0
 
-    // Cycle through the scenario's fields, one click + short burst per field,
-    // draining after each so a single field's rendering can't be double-counted.
-    // Fail fast on page/console errors instead of burning the whole budget.
+    const steps = scenario.steps ?? scenario.interactions.map(toTypeStep)
+
+    // Cycle through the scenario's steps, draining after each so a single
+    // step's rendering can't be double-counted. Fail fast on page/console
+    // errors instead of burning the whole budget.
     for (let round = 0; round < config.maxRounds && driven < config.targetInteractions; ) {
-      for (const target of scenario.interactions) {
+      for (const step of steps) {
         if (session.pageErrors.length > 0) {
           throw new SessionError('page-error', session.pageErrors.join('\n'))
         }
@@ -121,27 +122,31 @@ export async function runInpSession(options: {
             session.httpErrors,
           )
         }
-        // The click is itself an interaction (pointerdown/up + click share an
-        // interactionId); focusField clicks the field root and the input.
-        const {clicks} = await focusField(page, target, 30_000)
-        // A short burst, isolated cadence so each keystroke is its own
-        // interaction (the Event Timing observer needs a paint between them).
-        // typeBurst gates read-only once per field, not per keystroke — a
-        // per-keystroke in-page round-trip would serialize dispatch behind
-        // the main thread and suppress INP's input-delay component.
-        await typeBurst(
-          page,
-          keystrokesPerField,
-          DEFAULT_SESSION_CONFIG.isolatedCadenceMs,
-          offset,
-          interruptions,
+        const {interactions} = await runStep(
+          {page, running, timeoutMs: 30_000, interruptions},
+          step,
         )
-        offset += keystrokesPerField
-        driven += clicks + keystrokesPerField
+        driven += interactions
         const entries: BenchEntries = await drainEntries(page)
         latencies.push(...interactionMaxDurations(entries))
         round += 1
         if (driven >= config.targetInteractions || round >= config.maxRounds) break
+      }
+    }
+
+    const oracles = steps.flatMap((step) => ('oracle' in step && step.oracle ? [step.oracle] : []))
+    if (oracles.length > 0) {
+      const deadline = Date.now() + DEFAULT_SESSION_CONFIG.readbackTimeoutMs
+      for (;;) {
+        const allSatisfied = oracles.every((oracle) => oracle(running.mock.store))
+        if (allSatisfied) break
+        if (Date.now() > deadline) {
+          throw new SessionError(
+            'readback-mismatch',
+            'step oracle(s) not satisfied before deadline',
+          )
+        }
+        await new Promise((resolve) => setTimeout(resolve, 250))
       }
     }
 

--- a/perf/bench/runner/session/inp.ts
+++ b/perf/bench/runner/session/inp.ts
@@ -107,8 +107,9 @@ export async function runInpSession(options: {
 
     const steps = scenario.steps ?? scenario.interactions.map(toTypeStep)
     // A step scenario's sequence is an atomic choreography (e.g. open a comment
-    // composer, type, send) - breaking mid-sequence would skip its terminal
-    // step, so those run each pass to completion and check the target only at a
+    // composer, type, send) - breaking mid-sequence would skip its terminal step
+    // (and one step can cost more than the round budget left, stranding later
+    // steps), so those run each pass to completion and check the target only at a
     // pass boundary. Field-only scenarios keep the per-step break unchanged.
     const runToCompletion = scenario.steps !== undefined
 
@@ -144,6 +145,16 @@ export async function runInpSession(options: {
     if (oracles.length > 0) {
       const deadline = Date.now() + DEFAULT_SESSION_CONFIG.readbackTimeoutMs
       for (;;) {
+        if (session.pageErrors.length > 0) {
+          throw new SessionError('page-error', session.pageErrors.join('\n'))
+        }
+        if (session.consoleErrors.length > 0) {
+          throw new SessionError(
+            'console-error',
+            session.consoleErrors.join('\n'),
+            session.httpErrors,
+          )
+        }
         const allSatisfied = oracles.every((oracle) => oracle(running.mock.store))
         if (allSatisfied) break
         if (Date.now() > deadline) {

--- a/perf/bench/runner/session/inp.ts
+++ b/perf/bench/runner/session/inp.ts
@@ -107,7 +107,7 @@ export async function runInpSession(options: {
 
     const steps = scenario.steps ?? scenario.interactions.map(toTypeStep)
     // A step scenario's sequence is an atomic choreography (e.g. open a comment
-    // composer, type, send) — breaking mid-sequence would skip its terminal
+    // composer, type, send) - breaking mid-sequence would skip its terminal
     // step, so those run each pass to completion and check the target only at a
     // pass boundary. Field-only scenarios keep the per-step break unchanged.
     const runToCompletion = scenario.steps !== undefined

--- a/perf/bench/runner/session/inp.ts
+++ b/perf/bench/runner/session/inp.ts
@@ -106,6 +106,11 @@ export async function runInpSession(options: {
     let driven = 0
 
     const steps = scenario.steps ?? scenario.interactions.map(toTypeStep)
+    // A step scenario's sequence is an atomic choreography (e.g. open a comment
+    // composer, type, send) — breaking mid-sequence would skip its terminal
+    // step, so those run each pass to completion and check the target only at a
+    // pass boundary. Field-only scenarios keep the per-step break unchanged.
+    const runToCompletion = scenario.steps !== undefined
 
     // Cycle through the scenario's steps, draining after each so a single
     // step's rendering can't be double-counted. Fail fast on page/console
@@ -130,6 +135,7 @@ export async function runInpSession(options: {
         const entries: BenchEntries = await drainEntries(page)
         latencies.push(...interactionMaxDurations(entries))
         round += 1
+        if (runToCompletion) continue
         if (driven >= config.targetInteractions || round >= config.maxRounds) break
       }
     }

--- a/perf/bench/runner/session/interaction.ts
+++ b/perf/bench/runner/session/interaction.ts
@@ -202,7 +202,7 @@ function toLatencies(
   }
 }
 
-function fieldInput(page: Page, target: InteractionTarget): Locator {
+export function fieldInput(page: Page, target: InteractionTarget): Locator {
   if (target.kind === 'pte') {
     return page
       .locator(`[data-testid="field-${target.fieldPath}"] [contenteditable="true"]`)

--- a/perf/bench/runner/session/interaction.ts
+++ b/perf/bench/runner/session/interaction.ts
@@ -389,6 +389,7 @@ export async function runInteractionSession(options: {
   const draftId = `drafts.${scenario.documentId}`
 
   // Fresh state, in-process — no HTTP round-trips to our own mock
+  running.mock.setActiveFeatures(scenario.features ?? [])
   running.mock.hub.closeAll()
   running.mock.store.reset()
   running.mock.ledger.reset()
@@ -720,6 +721,7 @@ export async function runSoakSession(options: {
   const config = {...DEFAULT_SESSION_CONFIG, ...options.config}
   const log = options.log ?? (() => {})
 
+  running.mock.setActiveFeatures(scenario.features ?? [])
   running.mock.hub.closeAll()
   running.mock.store.reset()
   running.mock.ledger.reset()

--- a/perf/bench/runner/session/pageLoad.ts
+++ b/perf/bench/runner/session/pageLoad.ts
@@ -238,6 +238,7 @@ export async function runPageLoadSample(options: {
   const {browser, running, scenario, instrumentation} = options
   const config = {...DEFAULT_PAGELOAD_CONFIG, ...options.config}
 
+  running.mock.setActiveFeatures(scenario.features ?? [])
   running.mock.hub.closeAll()
   running.mock.store.reset()
   running.mock.ledger.reset()

--- a/perf/bench/runner/session/steps.ts
+++ b/perf/bench/runner/session/steps.ts
@@ -79,8 +79,10 @@ export async function runStep(context: StepContext, step: ScenarioStep): Promise
       return {interactions: 0}
     case 'raw':
       return step.drive(context)
-    default:
-      return step
+    default: {
+      const exhaustiveStep: never = step
+      throw new Error(`runStep received an unhandled step kind: ${JSON.stringify(exhaustiveStep)}`)
+    }
   }
 }
 

--- a/perf/bench/runner/session/steps.ts
+++ b/perf/bench/runner/session/steps.ts
@@ -23,6 +23,10 @@ export function resolveLocator(page: Page, selector: StepSelector): Locator {
     const scope = selector.within ? page.locator(`[data-testid="${selector.within}"]`) : page
     return scope.locator(`[data-testid="${selector.testId}"]`).first()
   }
+  if ('label' in selector) {
+    const scope = selector.within ? page.locator(`[data-testid="${selector.within}"]`) : page
+    return scope.getByLabel(selector.label, {exact: true}).first()
+  }
   return page.locator(selector.css).first()
 }
 

--- a/perf/bench/runner/session/steps.ts
+++ b/perf/bench/runner/session/steps.ts
@@ -68,6 +68,9 @@ export async function runStep(context: StepContext, step: ScenarioStep): Promise
         timeout: context.timeoutMs,
       })
       return {interactions: 0}
+    case 'hover':
+      await resolveLocator(context.page, step.selector).hover({timeout: context.timeoutMs})
+      return {interactions: 0}
     case 'raw':
       return step.drive(context)
     default:

--- a/perf/bench/runner/session/steps.ts
+++ b/perf/bench/runner/session/steps.ts
@@ -1,0 +1,80 @@
+import {type Locator, type Page} from 'playwright'
+
+import {
+  type InteractionTarget,
+  type ScenarioStep,
+  type StepContext,
+  type StepSelector,
+} from '../../scenarios/types'
+import {DEFAULT_SESSION_CONFIG, fieldInput, focusField, typeBurst} from './interaction'
+
+export interface StepResult {
+  /** Interactions driven (clicks + keystrokes) — folded into INP's `driven` total. */
+  interactions: number
+}
+
+const DEFAULT_KEYSTROKES = 4
+
+export function resolveLocator(page: Page, selector: StepSelector): Locator {
+  if ('field' in selector) {
+    return fieldInput(page, {fieldPath: selector.field, kind: selector.kind})
+  }
+  if ('testId' in selector) {
+    const scope = selector.within ? page.locator(`[data-testid="${selector.within}"]`) : page
+    return scope.locator(`[data-testid="${selector.testId}"]`).first()
+  }
+  return page.locator(selector.css).first()
+}
+
+async function focusForType(context: StepContext, selector: StepSelector): Promise<number> {
+  if ('field' in selector) {
+    const {clicks} = await focusField(
+      context.page,
+      {fieldPath: selector.field, kind: selector.kind},
+      context.timeoutMs,
+    )
+    return clicks
+  }
+  await resolveLocator(context.page, selector).click()
+  return 1
+}
+
+export async function runStep(context: StepContext, step: ScenarioStep): Promise<StepResult> {
+  switch (step.kind) {
+    case 'type': {
+      const clicks = await focusForType(context, step.selector)
+      if (step.text !== undefined) {
+        await context.page.keyboard.type(step.text, {
+          delay: DEFAULT_SESSION_CONFIG.isolatedCadenceMs,
+        })
+        return {interactions: clicks + step.text.length}
+      }
+      const keystrokes = step.keystrokes ?? DEFAULT_KEYSTROKES
+      await typeBurst(
+        context.page,
+        keystrokes,
+        DEFAULT_SESSION_CONFIG.isolatedCadenceMs,
+        0,
+        context.interruptions,
+      )
+      return {interactions: clicks + keystrokes}
+    }
+    case 'click':
+      await resolveLocator(context.page, step.selector).click()
+      return {interactions: 1}
+    case 'awaitVisible':
+      await resolveLocator(context.page, step.selector).waitFor({
+        state: 'visible',
+        timeout: context.timeoutMs,
+      })
+      return {interactions: 0}
+    case 'raw':
+      return step.drive(context)
+    default:
+      return step
+  }
+}
+
+export function toTypeStep(target: InteractionTarget): ScenarioStep {
+  return {kind: 'type', selector: {field: target.fieldPath, kind: target.kind}}
+}

--- a/perf/bench/runner/session/steps.ts
+++ b/perf/bench/runner/session/steps.ts
@@ -15,17 +15,19 @@ export interface StepResult {
 
 const DEFAULT_KEYSTROKES = 4
 
+function scopeFor(page: Page, within?: string): Page | Locator {
+  return within ? page.locator(`[data-testid="${within}"]`) : page
+}
+
 export function resolveLocator(page: Page, selector: StepSelector): Locator {
   if ('field' in selector) {
     return fieldInput(page, {fieldPath: selector.field, kind: selector.kind})
   }
   if ('testId' in selector) {
-    const scope = selector.within ? page.locator(`[data-testid="${selector.within}"]`) : page
-    return scope.locator(`[data-testid="${selector.testId}"]`).first()
+    return scopeFor(page, selector.within).locator(`[data-testid="${selector.testId}"]`).first()
   }
   if ('label' in selector) {
-    const scope = selector.within ? page.locator(`[data-testid="${selector.within}"]`) : page
-    return scope.getByLabel(selector.label, {exact: true}).first()
+    return scopeFor(page, selector.within).getByLabel(selector.label, {exact: true}).first()
   }
   return page.locator(selector.css).first()
 }

--- a/perf/bench/sanity.config.ts
+++ b/perf/bench/sanity.config.ts
@@ -3,6 +3,7 @@ import {defineConfig} from 'sanity'
 import {apiConfig} from './studio/apiConfig'
 import {arrayI18nWorkspace} from './studio/schemas/arrayI18n'
 import {articleWorkspace} from './studio/schemas/article'
+import {commentsFieldWorkspace} from './studio/schemas/commentsField'
 import {recipeWorkspace} from './studio/schemas/recipe'
 import {singleStringWorkspace} from './studio/schemas/singleString'
 import {syntheticWorkspace} from './studio/schemas/synthetic'
@@ -44,5 +45,10 @@ export default defineConfig([
     basePath: '/synthetic',
     ...common,
     ...syntheticWorkspace,
+  },
+  {
+    basePath: '/commentsField',
+    ...common,
+    ...commentsFieldWorkspace,
   },
 ])

--- a/perf/bench/scenarios/commentsField.ts
+++ b/perf/bench/scenarios/commentsField.ts
@@ -1,0 +1,18 @@
+import {addCommentSteps} from './features/comments'
+import {defineScenario} from './types'
+
+const DOCUMENT_ID = 'bench-comments-field'
+
+export const commentsField = defineScenario({
+  name: 'commentsField',
+  sourceFile: 'perf/bench/scenarios/commentsField.ts',
+  documentType: 'commentsField',
+  documentId: DOCUMENT_ID,
+  features: ['comments'],
+  fixture: () => [
+    {_id: `drafts.${DOCUMENT_ID}`, _type: 'commentsField', stringField: ''},
+    {_id: DOCUMENT_ID, _type: 'commentsField', stringField: ''},
+  ],
+  interactions: [{fieldPath: 'stringField', kind: 'string'}],
+  steps: addCommentSteps('stringField', 'looks good to me'),
+})

--- a/perf/bench/scenarios/commentsField.ts
+++ b/perf/bench/scenarios/commentsField.ts
@@ -14,5 +14,5 @@ export const commentsField = defineScenario({
     {_id: DOCUMENT_ID, _type: 'commentsField', stringField: ''},
   ],
   interactions: [{fieldPath: 'stringField', kind: 'string'}],
-  steps: addCommentSteps('stringField', 'looks good to me'),
+  steps: addCommentSteps('stringField'),
 })

--- a/perf/bench/scenarios/features/comments.ts
+++ b/perf/bench/scenarios/features/comments.ts
@@ -2,6 +2,8 @@ import {type DocumentStore} from '../../mock-api/store'
 import {type ScenarioStep} from '../types'
 
 const COMMENT_KEYSTROKES = 64
+// Accessible name of the add-comment field button (comments i18n `field-button.aria-label-add`).
+const ADD_COMMENT_LABEL = 'Add comment'
 
 function commentExists(store: DocumentStore): boolean {
   return store.getAll().some((doc) => doc._type === 'comment')
@@ -13,7 +15,7 @@ export function addCommentSteps(fieldPath: string): ScenarioStep[] {
     {
       kind: 'click',
       label: 'open comment composer',
-      selector: {testId: 'add-comment-button', within: `field-${fieldPath}`},
+      selector: {label: ADD_COMMENT_LABEL, within: `field-${fieldPath}`},
     },
     {
       kind: 'type',

--- a/perf/bench/scenarios/features/comments.ts
+++ b/perf/bench/scenarios/features/comments.ts
@@ -1,9 +1,15 @@
-import {portableText} from '../article'
+import {type DocumentStore} from '../../mock-api/store'
 import {type ScenarioStep} from '../types'
 
-export function addCommentSteps(fieldPath: string, text: string): ScenarioStep[] {
+const COMMENT_KEYSTROKES = 64
+
+function commentExists(store: DocumentStore): boolean {
+  return store.getAll().some((doc) => doc._type === 'comment')
+}
+
+export function addCommentSteps(fieldPath: string): ScenarioStep[] {
   return [
-    {kind: 'awaitVisible', selector: {field: fieldPath, kind: 'string'}},
+    {kind: 'hover', selector: {testId: `field-${fieldPath}`}},
     {
       kind: 'click',
       label: 'open comment composer',
@@ -13,16 +19,13 @@ export function addCommentSteps(fieldPath: string, text: string): ScenarioStep[]
       kind: 'type',
       label: 'comment body',
       selector: {testId: 'comment-input-editable'},
-      text,
-      oracle: (store) =>
-        store
-          .getAll()
-          .some(
-            (doc) =>
-              doc._type === 'comment' &&
-              portableText((doc as {message?: unknown}).message).includes(text),
-          ),
+      keystrokes: COMMENT_KEYSTROKES,
     },
-    {kind: 'click', label: 'send comment', selector: {testId: 'comment-input-send-button'}},
+    {
+      kind: 'click',
+      label: 'send comment',
+      selector: {testId: 'comment-input-send-button'},
+      oracle: commentExists,
+    },
   ]
 }

--- a/perf/bench/scenarios/features/comments.ts
+++ b/perf/bench/scenarios/features/comments.ts
@@ -1,0 +1,28 @@
+import {portableText} from '../article'
+import {type ScenarioStep} from '../types'
+
+export function addCommentSteps(fieldPath: string, text: string): ScenarioStep[] {
+  return [
+    {kind: 'awaitVisible', selector: {field: fieldPath, kind: 'string'}},
+    {
+      kind: 'click',
+      label: 'open comment composer',
+      selector: {testId: 'add-comment-button', within: `field-${fieldPath}`},
+    },
+    {
+      kind: 'type',
+      label: 'comment body',
+      selector: {testId: 'comment-input-editable'},
+      text,
+      oracle: (store) =>
+        store
+          .getAll()
+          .some(
+            (doc) =>
+              doc._type === 'comment' &&
+              portableText((doc as {message?: unknown}).message).includes(text),
+          ),
+    },
+    {kind: 'click', label: 'send comment', selector: {testId: 'comment-input-send-button'}},
+  ]
+}

--- a/perf/bench/scenarios/index.ts
+++ b/perf/bench/scenarios/index.ts
@@ -1,5 +1,6 @@
 import {arrayI18n} from './arrayI18n'
 import {article} from './article'
+import {commentsField} from './commentsField'
 import {recipe} from './recipe'
 import {singleString} from './singleString'
 import {synthetic, syntheticLarge} from './synthetic'
@@ -12,6 +13,7 @@ export const SCENARIOS: BenchScenario[] = [
   recipe,
   synthetic,
   syntheticLarge,
+  commentsField,
 ]
 
 export function getScenario(name: string): BenchScenario {

--- a/perf/bench/scenarios/types.ts
+++ b/perf/bench/scenarios/types.ts
@@ -66,6 +66,7 @@ export interface BenchScenario {
 export type StepSelector =
   | {field: string; kind: 'string' | 'pte'}
   | {testId: string; within?: string}
+  | {label: string; within?: string}
   | {css: string}
 
 export interface StepContext {

--- a/perf/bench/scenarios/types.ts
+++ b/perf/bench/scenarios/types.ts
@@ -1,4 +1,9 @@
+import {type Page} from 'playwright'
+
+import {type DocumentStore} from '../mock-api/store'
 import {type BenchDocument} from '../mock-api/types'
+import {type RunningSide} from '../runner/servers'
+import {type ReadOnlyInterruptions} from '../runner/session/interaction'
 
 /** A field the interaction mode types into. */
 export interface InteractionTarget {
@@ -42,6 +47,10 @@ export interface BenchScenario {
   fixture: () => BenchDocument[]
   /** Fields measured by interaction mode, in fixed execution order. */
   interactions: InteractionTarget[]
+  /** Opt-in mock feature modules to activate for this scenario, e.g. ['comments']. */
+  features?: string[]
+  /** Richer component-interaction sequence (INP mode). Absent ⇒ derived from interactions. */
+  steps?: ScenarioStep[]
   /**
    * Per-scenario keystroke counts, overriding the session defaults. For
    * scenarios with pathologically slow keystrokes (synthetic: ~10× the
@@ -52,6 +61,42 @@ export interface BenchScenario {
    */
   keystrokes?: {warmup?: number; measured?: number; burst?: number}
 }
+
+/** Where a step acts. Field selectors reuse the existing focusField/fieldInput logic. */
+export type StepSelector =
+  | {field: string; kind: 'string' | 'pte'}
+  | {testId: string; within?: string}
+  | {css: string}
+
+export interface StepContext {
+  page: Page
+  running: RunningSide
+  timeoutMs: number
+  interruptions: ReadOnlyInterruptions
+}
+
+export type ScenarioStep =
+  | {
+      kind: 'type'
+      label?: string
+      selector: StepSelector
+      text?: string
+      keystrokes?: number
+      oracle?: (store: DocumentStore) => boolean
+    }
+  | {
+      kind: 'click'
+      label?: string
+      selector: StepSelector
+      oracle?: (store: DocumentStore) => boolean
+    }
+  | {kind: 'awaitVisible'; selector: StepSelector}
+  | {
+      kind: 'raw'
+      label: string
+      drive: (context: StepContext) => Promise<{interactions: number}>
+      oracle?: (store: DocumentStore) => boolean
+    }
 
 export function defineScenario(scenario: BenchScenario): BenchScenario {
   return scenario

--- a/perf/bench/scenarios/types.ts
+++ b/perf/bench/scenarios/types.ts
@@ -91,6 +91,7 @@ export type ScenarioStep =
       oracle?: (store: DocumentStore) => boolean
     }
   | {kind: 'awaitVisible'; selector: StepSelector}
+  | {kind: 'hover'; selector: StepSelector}
   | {
       kind: 'raw'
       label: string

--- a/perf/bench/studio/schemas/commentsField.ts
+++ b/perf/bench/studio/schemas/commentsField.ts
@@ -1,0 +1,16 @@
+import {type Config, defineField, defineType} from 'sanity'
+import {structureTool} from 'sanity/structure'
+
+export const commentsFieldWorkspace = {
+  name: 'comments-field-bench',
+  plugins: [structureTool()],
+  schema: {
+    types: [
+      defineType({
+        name: 'commentsField',
+        type: 'document',
+        fields: [defineField({name: 'stringField', type: 'string'})],
+      }),
+    ],
+  },
+} satisfies Partial<Config>


### PR DESCRIPTION
### Description

The `perf/bench` suite can only type into fields; it cannot drive or measure field-level component surfaces (comments, tasks, AI Assist), which is exactly what SAPP-3751 "field-level component performance" needs to attribute INP per surface.

This PR widens the bench interaction model with an optional declarative step vocabulary and adds an opt-in mock feature-module system, landing comments as the first module - a real field-level component driven end-to-end (open composer, type, send) in a hermetic INP session. It also adds `bench dev --scenario <name>` to seed and open any scenario with its features active.

Part of SAPP-3751.

### What to review

- The model is additive: existing scenarios set no `steps`/`features`, so field-only behaviour is byte-identical - backward-compat is structural, and confirmed empirically (`singleString` INP still drives exactly 60 interactions).
- `perf/bench/runner/session/steps.ts` - the step registry and `resolveLocator` (`field`/`testId`/`label`/`css`). The comments choreography locates the field affordance by accessible label (`getByLabel('Add comment')`), so no `data-testid` attributes were added to `packages/sanity` (net-zero production diff). An unknown step kind now fails loud rather than silently returning a non-result.
- `perf/bench/mock-api/features/*` plus the `createServer`/`ledger` wiring - the opt-in `FeatureModule` boundary. The comments module is flags-only: it rides the generic `/data/*` plane, adding one `/features` flag and no routes. It works because the mock is dataset-agnostic (the comments addon dataset resolves to the same store), noted at the two collapse points.
- `perf/bench/runner/session/inp.ts` - the comment choreography is consumed only by INP mode, so `commentsField` is registered in the daily inp run, not the interaction matrix (interaction mode ignores `steps` and would only measure plain field typing). Step scenarios run each pass to completion so the terminal `send` is never skipped; the oracle-wait now surfaces page/console errors instead of masking them as a generic readback timeout.

### Testing

- `pnpm bench:unit` - 128 tests, including a step-registry suite (with `type`-step interaction-count coverage) and a comments feature-module contract block exercised over a real `@sanity/client` against the mock.
- Real runs (`pnpm build:bench` then `pnpm bench run`): `singleString` interaction and INP unchanged (backward-compat), and `commentsField` INP green - hermetic, no console errors, no endpoint drift, store-based oracle satisfied, INP driving 67 interactions (the comment steps counted).

### Notes for release

N/A
