### PR TITLE
feat(bench): add per-component interaction latency metrics to inp sessions

### DIFF
--- a/dev/metrics-studio/tools/trends/data.ts
+++ b/dev/metrics-studio/tools/trends/data.ts
@@ -242,6 +242,16 @@ function describeSeries(
   kind: 'interaction' | 'pageload',
   label: string,
 ): Pick<TrendSeries, 'description' | 'goal' | 'group'> {
+  if (label.startsWith('component: ')) {
+    const name = label.slice('component: '.length)
+    return {
+      group: 'responsiveness',
+      description:
+        `Interaction latency (click/type → next paint) for “${name}”. ` +
+        `A per-component latency percentile — not the page's INP Core Web Vital.`,
+      goal: 'lower',
+    }
+  }
   if (label.includes('time to editable')) {
     return {
       group: 'load',

--- a/perf/bench/report/__tests__/collect.test.ts
+++ b/perf/bench/report/__tests__/collect.test.ts
@@ -3,8 +3,10 @@ import process from 'node:process'
 
 import {afterEach, beforeEach, describe, expect, it} from 'vitest'
 
+import {type InpSessionResult} from '../../runner/session/inp'
 import {type PageLoadSample} from '../../runner/session/pageLoad'
-import {collectPageLoad, collectRunMetadata} from '../collect'
+import {summarize} from '../../stats/quantiles'
+import {collectInp, collectPageLoad, collectRunMetadata} from '../collect'
 
 const ENV_KEYS = [
   'GITHUB_SHA',
@@ -157,5 +159,89 @@ describe('collectPageLoad', () => {
       'boot-cold · auth round trips',
       'boot-cold · auth in flight',
     ])
+  })
+})
+
+function inpSession(
+  perLabel: InpSessionResult['perLabel'],
+  overrides: Partial<InpSessionResult> = {},
+): InpSessionResult {
+  return {
+    inpMs: 200,
+    interactionCount: 60,
+    reportable: true,
+    latencies: perLabel.flatMap((entry) => entry.latencies),
+    perLabel,
+    readOnlyInterruptions: {count: 0, totalMs: 0},
+    ...overrides,
+  }
+}
+
+describe('collectInp', () => {
+  it('leaves the INP and INP interactions rows first and unchanged', () => {
+    const report = collectInp('singleString', [
+      inpSession([{label: 'title', latencies: [20, 30]}], {inpMs: 210, interactionCount: 55}),
+    ])
+    expect(report.metrics[0].label).toBe('INP')
+    expect(report.metrics[1].label).toBe('INP interactions')
+    expect(report.metrics[0].experiment.summary.median).toBe(210)
+    expect(report.metrics[1].experiment.summary.median).toBe(55)
+  })
+
+  it('appends one component metric per label, in first-seen order', () => {
+    const sessions = [
+      inpSession([
+        {label: 'title', latencies: [20, 30]},
+        {label: 'body', latencies: [40, 50]},
+      ]),
+      inpSession([
+        {label: 'title', latencies: [25, 35]},
+        {label: 'body', latencies: [45, 55]},
+      ]),
+    ]
+    const report = collectInp('singleString', sessions)
+    const componentMetrics = report.metrics.slice(2)
+    expect(componentMetrics.map((metric) => metric.label)).toEqual([
+      'component: title',
+      'component: body',
+    ])
+
+    const titleMetric = componentMetrics[0]
+    expect(titleMetric.presentAsEfps).toBe(false)
+    expect(titleMetric.unit).toBe('ms')
+    expect(titleMetric.experiment.sessions).toEqual([
+      [20, 30],
+      [25, 35],
+    ])
+    expect(titleMetric.experiment.summary.median).toBe(summarize([20, 30, 25, 35]).median)
+
+    const bodyMetric = componentMetrics[1]
+    expect(bodyMetric.experiment.sessions).toEqual([
+      [40, 50],
+      [45, 55],
+    ])
+    expect(bodyMetric.experiment.summary.median).toBe(summarize([40, 50, 45, 55]).median)
+  })
+
+  it('reports an empty session array for a label absent from one session', () => {
+    const sessions = [
+      inpSession([{label: 'title', latencies: [20, 30]}]),
+      inpSession([{label: 'body', latencies: [40, 50]}]),
+    ]
+    const report = collectInp('singleString', sessions)
+    const componentMetrics = report.metrics.slice(2)
+    expect(componentMetrics.map((metric) => metric.label)).toEqual([
+      'component: title',
+      'component: body',
+    ])
+
+    const titleMetric = componentMetrics[0]
+    expect(titleMetric.experiment.sessions).toEqual([[20, 30], []])
+    expect(titleMetric.experiment.summary.n).toBe(2)
+    expect(titleMetric.experiment.summary.median).toBe(summarize([20, 30]).median)
+
+    const bodyMetric = componentMetrics[1]
+    expect(bodyMetric.experiment.sessions).toEqual([[], [40, 50]])
+    expect(bodyMetric.experiment.summary.n).toBe(2)
   })
 })

--- a/perf/bench/report/__tests__/storeShape.test.ts
+++ b/perf/bench/report/__tests__/storeShape.test.ts
@@ -77,6 +77,37 @@ const RUN: BenchRunDocument = {
         ],
       },
     },
+    {
+      scenario: 'singleString',
+      kind: 'pageload',
+      mode: 'inp',
+      metrics: [
+        {
+          label: 'INP',
+          unit: 'ms',
+          presentAsEfps: false,
+          experiment: {
+            sessions: [[210], [220]],
+            summary: {n: 2, median: 215, p75: 220, p90: 220, p99: 220, min: 210, max: 220},
+          },
+        },
+        {
+          label: 'component: title',
+          unit: 'ms',
+          presentAsEfps: false,
+          experiment: {
+            sessions: [
+              [20, 30],
+              [25, 35],
+            ],
+            summary: {n: 4, median: 27.5, p75: 32.5, p90: 34, p99: 34.9, min: 20, max: 35},
+          },
+        },
+      ],
+      failures: [],
+      interruptions: {experiment: {count: 0, totalMs: 0}},
+      loafAttribution: [],
+    },
   ],
 }
 

--- a/perf/bench/report/collect.ts
+++ b/perf/bench/report/collect.ts
@@ -226,6 +226,20 @@ export function collectInp(
 ): ScenarioReport {
   const inpValues = sessions.map((session) => [session.inpMs])
   const interactionCounts = sessions.map((session) => [session.interactionCount])
+  const labels = [
+    ...new Set(sessions.flatMap((session) => session.perLabel.map((entry) => entry.label))),
+  ]
+  const perComponent: MetricReport[] = labels.map((label) => {
+    const perSession = sessions.map(
+      (session) => session.perLabel.find((entry) => entry.label === label)?.latencies ?? [],
+    )
+    return {
+      label: `component: ${label}`,
+      unit: 'ms',
+      presentAsEfps: false,
+      experiment: {sessions: perSession, summary: summarize(perSession.flat())},
+    }
+  })
   const metrics: MetricReport[] = [
     {
       label: 'INP',
@@ -242,6 +256,7 @@ export function collectInp(
         summary: summarize(interactionCounts.flat()),
       },
     },
+    ...perComponent,
   ]
   return {
     scenario,

--- a/perf/bench/runner/__tests__/interaction.test.ts
+++ b/perf/bench/runner/__tests__/interaction.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment node
+import {describe, expect, it} from 'vitest'
+
+import {OBSERVABILITY_FLOOR_MS, padToFloor} from '../session/interaction'
+
+describe('padToFloor', () => {
+  it('pads missing interactions with the observability floor', () => {
+    expect(padToFloor([10, 20], 5)).toEqual([
+      10,
+      20,
+      OBSERVABILITY_FLOOR_MS,
+      OBSERVABILITY_FLOOR_MS,
+      OBSERVABILITY_FLOOR_MS,
+    ])
+  })
+
+  it('pads nothing when observed already matches driven', () => {
+    expect(padToFloor([10, 20], 2)).toEqual([10, 20])
+  })
+
+  it('clamps to no padding when observed exceeds driven', () => {
+    expect(padToFloor([10, 20, 30], 2)).toEqual([10, 20, 30])
+  })
+})

--- a/perf/bench/runner/session/inp.ts
+++ b/perf/bench/runner/session/inp.ts
@@ -11,11 +11,17 @@ import {
   focusField,
   HERMETICITY_HINT,
   interactionMaxDurations,
+  padToFloor,
   type ReadOnlyInterruptions,
   type SessionConfig,
   SessionError,
   typeBurst,
 } from './interaction'
+
+export interface LabelledLatencies {
+  label: string
+  latencies: number[]
+}
 
 export interface InpSessionResult extends InpResult {
   /**
@@ -24,6 +30,8 @@ export interface InpSessionResult extends InpResult {
    * Timing observability floor produce no entry.
    */
   latencies: number[]
+  /** Per-field breakdown of the same latencies, floor-padded (see padToFloor). */
+  perLabel: LabelledLatencies[]
   readOnlyInterruptions: ReadOnlyInterruptions
 }
 
@@ -105,6 +113,7 @@ export async function runInpSession(options: {
     let driven = 0
     const keystrokesPerField = 4
     let offset = 0
+    const byLabel = new Map<string, {observed: number[]; driven: number}>()
 
     // Cycle through the scenario's fields, one click + short burst per field,
     // draining after each so a single field's rendering can't be double-counted.
@@ -137,9 +146,16 @@ export async function runInpSession(options: {
           interruptions,
         )
         offset += keystrokesPerField
-        driven += clicks + keystrokesPerField
+        const fieldDriven = clicks + keystrokesPerField
+        driven += fieldDriven
         const entries: BenchEntries = await drainEntries(page)
-        latencies.push(...interactionMaxDurations(entries))
+        const fieldLatencies = interactionMaxDurations(entries)
+        latencies.push(...fieldLatencies)
+        const label = target.label ?? target.fieldPath
+        const labelEntry = byLabel.get(label) ?? {observed: [], driven: 0}
+        labelEntry.observed.push(...fieldLatencies)
+        labelEntry.driven += fieldDriven
+        byLabel.set(label, labelEntry)
         round += 1
         if (driven >= config.targetInteractions || round >= config.maxRounds) break
       }
@@ -176,7 +192,17 @@ export async function runInpSession(options: {
       )
     }
 
-    return {...computeInp(latencies, driven), latencies, readOnlyInterruptions: interruptions}
+    const perLabel: LabelledLatencies[] = [...byLabel.entries()].map(([label, entry]) => ({
+      label,
+      latencies: padToFloor(entry.observed, entry.driven),
+    }))
+
+    return {
+      ...computeInp(latencies, driven),
+      latencies,
+      perLabel,
+      readOnlyInterruptions: interruptions,
+    }
   } finally {
     await context.close()
   }

--- a/perf/bench/runner/session/interaction.ts
+++ b/perf/bench/runner/session/interaction.ts
@@ -19,6 +19,16 @@ export const CHARACTERS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0
  */
 export const OBSERVABILITY_FLOOR_MS = 16
 
+/**
+ * Pad `observed` up to `driven` entries with the observability floor, the
+ * same accounting `toLatencies` does — reused for per-label attribution so a
+ * label's below-floor interactions aren't just dropped from its latency list.
+ */
+export function padToFloor(observed: number[], driven: number): number[] {
+  const missing = driven - observed.length
+  return missing > 0 ? observed.concat(Array(missing).fill(OBSERVABILITY_FLOOR_MS)) : observed
+}
+
 export interface SessionConfig {
   warmupKeystrokes: number
   measuredKeystrokes: number


### PR DESCRIPTION
### Description

The perf/bench INP session drives a realistic interaction mix across every field of a scenario but reported only a single whole-session INP number, so there was no way to see which component or input type (a plain string, a nested object field, Portable Text) actually drove the latency. The loop already grouped observed latencies per target internally, then flattened them away.

This PR retains that grouping and emits it. `runInpSession` now buckets each interaction's observed latency by component label alongside the unchanged flat whole-session `latencies`, floor-padding each bucket through a new `padToFloor` helper. `collectInp` appends one `component: <label>` latency metric (p50/p75/p90, in ms) per component after the existing `INP` and `INP interactions` metrics, and the trends dashboard renders them under Editing responsiveness, labelled as per-component latency percentiles rather than the page's INP Core Web Vital. Whole-session INP math is untouched: the `latencies` array fed to `computeInp` is byte-identical.

### What to review

- The attribution boundary in the `runInpSession` loop (`perf/bench/runner/session/inp.ts`): each per-target `drainEntries` maps exactly to that target's clicks plus keystrokes, so buckets do not bleed across components.
- `padToFloor` semantics (`perf/bench/runner/session/interaction.ts`): below-floor interactions are padded to `OBSERVABILITY_FLOOR_MS` so a cheap component is not flattered by dropped samples.
- Open question 1: the per-component ms series currently reuse the eFPS-presented Editing responsiveness group (`presentAsEfps: false` amid `presentAsEfps: true` siblings). A dedicated components tab may be the better home, deferred to a follow-up unless you want it here.
- Open question 2: these series only populate once a stored `benchRun` has run `--mode inp`. If the daily/CI store pipeline runs absolute/ab mode only, the dashboard stays dormant until inp is wired into that pipeline. Follow-up, or in scope here?

### Testing

- `pnpm bench:unit`: 113/113 green, including new `padToFloor` unit tests, a `collectInp` per-component block, and an inp-mode `storeShape` round-trip.
- `stats/inp.test.ts` unchanged and green (12/12), guarding the whole-session INP math.
- Hermetic functional run `pnpm bench run --mode inp --scenario article --sessions 6` emitted exactly 4 `component:` metrics (title, body, string inside object, string inside array) with `INP` and `INP interactions` still first, all medians finite and at or above 16ms.

### Notes for release

N/A
