### PR TITLE
docs(presentation): add cross-repo plans for editing variant support

### DIFF
--- a/plans/presentation-variants/01-presentation-comlink.md
+++ b/plans/presentation-variants/01-presentation-comlink.md
@@ -1,0 +1,133 @@
+# Plan: add editing-variant fields to `@sanity/presentation-comlink`
+
+- **Repo**: [sanity-io/comlink](https://github.com/sanity-io/comlink)
+- **Package**: `packages/presentation-comlink` (`@sanity/presentation-comlink`)
+- **Rollout phase**: 1 of 4 — this ships first; the Sanity monorepo (`sanity/presentation`) and `sanity-io/visual-editing` both depend on the released types.
+
+## TLDR
+
+Sanity Studio now supports **editing variants** (content variants a document can be attached to). The selected variant must flow from the studio through the Presentation tool into preview frontends, following the exact same paths `perspective` uses today. `@sanity/presentation-comlink` defines the postMessage protocol between the Presentation tool and preview iframes. This change adds an optional `variant?: string` field next to every existing `perspective` field in the message types, plus a `handlesVariantChange?: boolean` capability flag. Types-only, fully backward compatible, minor release.
+
+## Why
+
+- The studio stores the selected variant in the `variant` router sticky param and exposes it via its perspective provider. `@sanity/client` is being updated (separately, by the client team) to accept a `variant` fetch option that it sends to the API as `?variant={variantId}`.
+- Presentation (studio side) and `@sanity/visual-editing` / loaders (iframe side) communicate through the message types defined in this package. Without `variant` in the protocol, the iframe can never learn which variant is selected, and Presentation can never refetch loader queries with it.
+- The end goal across all repos: select a variant in the studio → Presentation passes it to the iframe (URL param + these comlink messages) → the frontend persists it (cookie) and refetches with `client.fetch(query, params, {perspective, variant})` → the preview updates.
+
+## The end-to-end flow (where this package sits)
+
+```
+Studio (sanity/presentation)                         Preview iframe
+────────────────────────────                         ──────────────
+selected variant (bare id, e.g. "Ab12cd34")
+  │
+  ├─ posts presentation/perspective {perspective, variant}   → @sanity/visual-editing syncs it,
+  │                                                            calls onVariantChange (next-sanity
+  │                                                            stores it in a cookie + refreshes)
+  ├─ responds to visual-editing/fetch-perspective             ← iframe asks on connect, reports
+  │    with {perspective, variant}                              handlesPerspectiveChange /
+  │                                                             handlesVariantChange capability
+  ├─ posts loader/perspective {projectId, dataset,            → @sanity/core-loader updates its
+  │    perspective, variant}                                    $variant atom, re-registers queries
+  ├─ receives loader/query-listen {…, perspective, variant}   ← loaders declare what they need
+  └─ posts loader/query-change {…, perspective, variant,      → loaders render the new results
+       result} after fetching with {perspective, variant}
+```
+
+The **wire value** is always the bare variant id (`Ab12cd34`), never the full variant document id (`_.variants.Ab12cd34`). `undefined` means no variant selected (base content).
+
+## Changes in this repo
+
+All changes are in `packages/presentation-comlink/src/types.ts`. Add an optional `variant?: string` to the `data` (and where noted, `response`) of every message that carries `perspective`. Keep the field directly below `perspective` in each object for readability. Document each new field with a TSDoc comment: `The selected editing variant (bare variant id). Undefined when no variant is selected.`
+
+### 1. `VisualEditingControllerMsg` → `presentation/perspective`
+
+Current:
+
+```ts
+| {
+    type: 'presentation/perspective'
+    data: {
+      perspective: ClientPerspective
+    }
+  }
+```
+
+New: add `variant?: string` to `data`.
+
+### 2. `VisualEditingNodeMsg` → `visual-editing/fetch-perspective`
+
+Current:
+
+```ts
+| {
+    type: 'visual-editing/fetch-perspective'
+    data:
+      | undefined
+      | {
+          /**
+           * Specifies if <VisualEditing> has a `onPerspecticeChange` prop, …
+           */
+          handlesPerspectiveChange: boolean
+        }
+    response: {
+      perspective: ClientPerspective
+    }
+  }
+```
+
+New:
+
+- add `handlesVariantChange?: boolean` to the request `data` object (optional — older `@sanity/visual-editing` versions won't send it, and Presentation treats absence as `false`). TSDoc: `Specifies if <VisualEditing> has an onVariantChange prop, which signals variant changes are handled and should not trigger a full page reload.`
+- add `variant?: string` to the `response` object.
+
+### 3. `VisualEditingNodeMsg` → `visual-editing/documents`
+
+Add `variant?: string` to `data` (next to `perspective: ClientPerspective`).
+
+### 4. `LoaderControllerMsg` → `loader/perspective`
+
+Add `variant?: string` to `data` (`{projectId, dataset, perspective}`).
+
+### 5. `LoaderControllerMsg` → `loader/query-change`
+
+Add `variant?: string` to `data` (`{projectId, dataset, perspective, query, params, result, resultSourceMap?, tags?}`).
+
+### 6. `LoaderNodeMsg` → `loader/query-listen`
+
+Add `variant?: string` to `data` (`{projectId, dataset, perspective, query, params, heartbeat?}`).
+
+### 7. `LoaderNodeMsg` → `loader/documents`
+
+Add `variant?: string` to `data` (`{projectId, dataset, perspective, documents}`).
+
+### 8. `PreviewKitNodeMsg` → `preview-kit/documents`
+
+Add `variant?: string` to `data` for protocol completeness (`@sanity/preview-kit` is legacy and will likely never send it; the field just keeps the shape symmetrical).
+
+## Todo list
+
+- [ ] Add `variant?: string` to `presentation/perspective` data in `packages/presentation-comlink/src/types.ts`
+- [ ] Add `handlesVariantChange?: boolean` to `visual-editing/fetch-perspective` request data and `variant?: string` to its response
+- [ ] Add `variant?: string` to `visual-editing/documents` data
+- [ ] Add `variant?: string` to `loader/perspective` data
+- [ ] Add `variant?: string` to `loader/query-change` data
+- [ ] Add `variant?: string` to `loader/query-listen` data
+- [ ] Add `variant?: string` to `loader/documents` data
+- [ ] Add `variant?: string` to `preview-kit/documents` data
+- [ ] TSDoc every new field (bare variant id semantics, `undefined` = no variant)
+- [ ] Run `pnpm build`, `pnpm type-check`, `pnpm lint`, `pnpm test` at the repo root
+- [ ] Add a changeset (minor bump for `@sanity/presentation-comlink`) describing the new optional protocol fields
+- [ ] Open a PR; after merge, release so downstream repos (sanity monorepo, visual-editing) can bump
+
+## Additional knowledge for the agent
+
+- **Backward/forward compatibility is the hard requirement.** These messages cross a postMessage boundary between independently-released packages (studio plugin vs. frontend libraries), so every new field MUST be optional. Old senders won't include `variant`; old receivers must be able to ignore it. Making any of these required is a breaking protocol change — do not do it.
+- The message payloads are not runtime-validated in this package — it is types-only (`types.ts`), so no serialization/validation code needs to change. `comlinkCompatibility.ts` (compatibility actors) needs no changes.
+- Naming: the field is `variant`, not `variantId`, to mirror the client fetch option (`client.fetch(query, params, {perspective, variant})`) that the client team is adding.
+- There is an existing typo in the `handlesPerspectiveChange` TSDoc ("onPerspecticeChange"); feel free to fix it in passing, but do not rename the field.
+- Repo tooling: pnpm + turbo. Root scripts: `pnpm build`, `pnpm type-check`, `pnpm lint` (oxlint), `pnpm test`, releases via changesets (`pnpm release`).
+- Downstream consumers that will use these fields (context, not in scope here):
+  - `sanity` monorepo `packages/sanity/src/presentation`: posts `presentation/perspective` and `loader/perspective`, answers `visual-editing/fetch-perspective`, consumes `loader/query-listen`, posts `loader/query-change`.
+  - `@sanity/visual-editing`: consumes `presentation/perspective`, sends `visual-editing/fetch-perspective` and `visual-editing/documents`.
+  - `@sanity/core-loader`: consumes `loader/perspective` and `loader/query-change`, sends `loader/query-listen` and `loader/documents`.

--- a/plans/presentation-variants/02-visual-editing.md
+++ b/plans/presentation-variants/02-visual-editing.md
@@ -1,0 +1,142 @@
+# Plan: pass editing variants through preview-url-secret, loaders, and visual-editing
+
+- **Repo**: [sanity-io/visual-editing](https://github.com/sanity-io/visual-editing)
+- **Packages touched**: `packages/preview-url-secret` (`@sanity/preview-url-secret`), `packages/core-loader` (`@sanity/core-loader`), `packages/react-loader` (`@sanity/react-loader`), `packages/svelte-loader` (`@sanity/svelte-loader`), `packages/visual-editing` (`@sanity/visual-editing`)
+- **Rollout phase**: 2 of 4. Depends on phase 1: a released `@sanity/presentation-comlink` whose message types include the new optional `variant` fields (repo [sanity-io/comlink](https://github.com/sanity-io/comlink)). Blocks phase 4 (`next-sanity`). The `@sanity/preview-url-secret` part also blocks phase 3 (Sanity studio monorepo).
+
+## TLDR
+
+Sanity Studio now supports **editing variants** (content variants a document can be attached to). The selected variant must flow from the studio's Presentation tool into preview frontends following the exact same paths `perspective` uses today: a preview URL search param, comlink postMessages, loader query registration/refetch, and an `onVariantChange` callback so frameworks (next-sanity) can persist it in a cookie. This plan adds a parallel `variant` value beside every `perspective` touchpoint in this repo. Everything is optional and backward compatible.
+
+## Why
+
+- The studio stores the selected variant in its `variant` router sticky param; the Presentation tool (in the `sanity` monorepo, phase 3) will start emitting it via the iframe URL (`sanity-preview-variant`) and the comlink messages (`presentation/perspective`, `loader/perspective`, etc.).
+- `@sanity/client` is being updated (separately, by the client team — **not part of this work**) to accept a `variant` option in fetch, exactly like `perspective`, sent to the API as `?variant={variantId}`.
+- The end goal: select a variant in the studio → Presentation passes it down → the frontend persists it (cookie, phase 4 in next-sanity) and refetches with `client.fetch(query, params, {perspective, variant})` → the preview updates.
+
+## The shared contract (must match the other repos exactly)
+
+- **Wire value**: the bare variant id, e.g. `Ab12cd34` — never the full variant document id (`_.variants.Ab12cd34`). `undefined` = no variant selected (base content).
+- **URL search param**: `sanity-preview-variant` → new constant `urlSearchParamPreviewVariant` in `@sanity/preview-url-secret/constants`. Only present when a variant is selected.
+- **Cookie name**: `sanity-preview-variant` → new constant `variantCookieName` in `@sanity/preview-url-secret/constants` (the cookie itself is written by next-sanity in phase 4; this repo only owns the constant, mirroring `perspectiveCookieName`).
+- **Comlink fields** (already added to `@sanity/presentation-comlink` in phase 1): optional `variant?: string` on `presentation/perspective`, `visual-editing/fetch-perspective` (response), `visual-editing/documents`, `loader/perspective`, `loader/query-change`, `loader/query-listen`, `loader/documents`; optional `handlesVariantChange?: boolean` on the `visual-editing/fetch-perspective` request payload.
+- **Callbacks**: `onVariantChange?: (variant: string | undefined) => void` on `@sanity/visual-editing`, `onVariant?: (variant: string | undefined) => void` on `@sanity/core-loader` / `@sanity/react-loader` live mode.
+
+## The end-to-end flow (where this repo sits)
+
+```
+Studio Presentation tool
+  ├─ iframe URL: ?sanity-preview-secret=…&sanity-preview-perspective=…&sanity-preview-variant=Ab12cd34
+  │     → preview app enable route calls validatePreviewUrl (@sanity/preview-url-secret)
+  │       which now also returns studioPreviewVariant → next-sanity sets the cookie (phase 4)
+  ├─ comlink presentation/perspective {perspective, variant}
+  │     → @sanity/visual-editing usePerspectiveSync stores it in overlay state and calls
+  │       onPerspectiveChange(perspective) + onVariantChange(variant)
+  │       (next-sanity wires onVariantChange to a server action that sets the cookie + refresh())
+  └─ comlink loader/perspective {projectId, dataset, perspective, variant}
+        → @sanity/core-loader enableLiveMode updates $perspective and $variant,
+          re-posts loader/query-listen {…, perspective, variant} for each live query
+        → Presentation refetches with client.fetch(query, params, {perspective, variant})
+          and posts loader/query-change {…, perspective, variant, result}
+        → core-loader caches by {perspective, variant, query, params} and updates the UI
+```
+
+## Changes per package
+
+### A. `packages/preview-url-secret` (`@sanity/preview-url-secret`)
+
+Mirror everything `urlSearchParamPreviewPerspective` / `studioPreviewPerspective` does today:
+
+1. `src/constants.ts`:
+   - `export const urlSearchParamPreviewVariant = 'sanity-preview-variant'` (next to `urlSearchParamPreviewPerspective = 'sanity-preview-perspective'`).
+   - `export const variantCookieName = 'sanity-preview-variant'` (next to `perspectiveCookieName`).
+2. `src/parsePreviewUrl.ts`: read `url.searchParams.get(urlSearchParamPreviewVariant)` into `studioPreviewVariant`; when a `redirectTo` URL is built and it doesn't already carry the param, forward it (same block that forwards `studioPreviewPerspective` onto `redirectUrl`). Return `studioPreviewVariant` in the parsed result.
+3. `src/types.ts`: add `studioPreviewVariant` to `ParsedPreviewUrl` (`string | null`) and to `PreviewUrlValidateUrlResult` (`string | null | undefined`, only defined when `isValid`), mirroring how `studioPreviewPerspective` is declared on both.
+4. `src/validatePreviewUrl.ts`: `const studioPreviewVariant = isValid ? parsedPreviewUrl.studioPreviewVariant : undefined` and include it in the returned object.
+5. `src/withoutSecretSearchParams.ts`:
+   - `withoutSecretSearchParams`: also `searchParams.delete(urlSearchParamPreviewVariant)`.
+   - `setSecretSearchParams(url, secret, redirectTo, perspective)`: add an optional trailing parameter `variant?: string`; when provided, `searchParams.set(urlSearchParamPreviewVariant, variant)`, otherwise `searchParams.delete(urlSearchParamPreviewVariant)`. Keep it the last parameter so existing callers compile unchanged.
+6. `src/definePreviewUrl.ts` (used by standalone/preview-kit style setups): wherever `studioPreviewPerspective` is written into the enable URL as `sanity-preview-perspective`, accept and write an optional `studioPreviewVariant` as `sanity-preview-variant` the same way.
+7. `PreviewUrlResolverOptions` / resolver context types in `src/types.ts`: wherever `studioPreviewPerspective` appears as a context/options field (e.g. the resolver context used by the deprecated function-style `previewUrl` in Presentation), add an optional `studioPreviewVariant?: string` sibling.
+
+### B. `packages/core-loader` (`@sanity/core-loader`)
+
+All in `src/live-mode/enableLiveMode.ts` and `src/types.ts`:
+
+1. Add a `$variant` atom next to `$perspective`: `const $variant = atom<string | undefined>(undefined)` (no client-config fallback — the client currently has no variant config; if the client team later adds one, initialize from `client.config()` the same way perspective does).
+2. In the `comlink.on('loader/perspective', …)` handler: `const nextVariant = data.variant || undefined; $variant.set(nextVariant); onVariant?.(nextVariant)` next to the existing perspective handling, before `updateLiveQueries()`.
+3. Cache keys: the cache is keyed with `JSON.stringify({perspective, query, params})` in three places (the `loader/query-change` handler, `hydrate`, and `updateLiveQueries`). Change all of them to `JSON.stringify({perspective, variant, query, params})`. Note `JSON.stringify` drops `undefined` values, so the no-variant key stays byte-identical to today's key — this is intentional and keeps old studio versions (that never send `variant` on `loader/query-change`) compatible.
+4. `emitQueryListen()`: include `variant: $variant.get()` in the `loader/query-listen` post and `$fetch.setKey('variant', variant)` next to `$fetch.setKey('perspective', perspective)`.
+5. `updateLiveQueries()`: read `const variant = $variant.get()`, use it in the cache key, include it in the `$fetch.set({…})` state and in the `loader/documents` post.
+6. `src/types.ts`:
+   - `QueryStoreState`: add `variant?: string`.
+   - `EnableLiveModeOptions`: add `onVariant?: (variant: string | undefined) => void` with TSDoc mirroring `onPerspective` ("Fires when the variant changes in the Studio, allowing you to persist the change to a session cookie if needed").
+7. Destructure `onVariant` from options in `enableLiveMode` next to `onPerspective`.
+
+### C. `packages/react-loader` (`@sanity/react-loader`)
+
+1. `src/createQueryStore/universal.ts` (and `server-only.ts` if it duplicates the logic): `loadQuery` accepts `options.variant?: string`; resolve as `const variant = options.variant || undefined` (no client-config fallback), pass it to the `client.fetch` call next to `perspective`, include it in the returned initial payload and in the cache key `JSON.stringify({query, params, perspective, …})` → add `variant`.
+2. `src/types.ts`: add `variant?: string` to the fetch/`loadQuery` options type and to `QueryResponseInitial`.
+3. `src/defineUseLiveMode.ts`: forward a new `onVariant` option into `enableLiveMode` (mirror `onPerspective`).
+4. `src/defineUseQuery.ts`: if it reacts to snapshot `perspective` changes, mirror for `variant` (the `QueryStoreState.variant` key added in core-loader flows through automatically; verify nothing filters unknown keys).
+
+### D. `packages/svelte-loader` (`@sanity/svelte-loader`)
+
+Same as react-loader: `src/createQueryStore.ts` `loadQuery` accepts and forwards `options.variant`, includes it in the cache key and initial payload; `src/defineUseLiveMode.ts` forwards `onVariant` if it exposes `onPerspective`-style options (it currently calls `enableLiveMode` without exposing `onPerspective` — if so, just make sure nothing breaks and optionally expose `onVariant` alongside adding `onPerspective` passthrough only if trivial; do not redesign its public API here).
+
+### E. `packages/visual-editing` (`@sanity/visual-editing`)
+
+1. `src/types.ts` (`VisualEditingOptions`, around the existing `onPerspectiveChange` at ~line 596): add
+
+   ```ts
+   /**
+    * Fires when the editing variant changes in the Studio, with the bare variant id,
+    * or undefined when the variant is cleared. Allows persisting the change to a
+    * session cookie so server-side fetches can apply it.
+    */
+   onVariantChange?: (variant: string | undefined) => void
+   ```
+
+2. `src/ui/usePerspectiveSync.tsx`: extend the existing hook (do not create a separate variant hook — perspective and variant arrive on the same messages):
+   - New parameter `onVariantChange?: (variant: string | undefined) => void`.
+   - `const handlesVariantChange = !!onVariantChange`; include `handlesVariantChange` in the `visual-editing/fetch-perspective` request payload next to `handlesPerspectiveChange`.
+   - In `handlePerspective` (both the fetch response and the `presentation/perspective` listener): payload is now `{perspective, variant?}`; keep dispatching the whole message data and additionally call `onVariantChange?.(data.variant)`.
+   - Add `handlesVariantChange` to the effect dependency array like `handlesPerspectiveChange`.
+3. `src/ui/overlayStateReducer.ts`: state gains `variant: string | undefined`; the `presentation/perspective` case sets both `perspective` and `variant` from `message.data`.
+4. `src/ui/Overlays.tsx`: accept and thread `onVariantChange` (prop type around line 188, destructure ~line 201, pass to `usePerspectiveSync(comlink, dispatch, onPerspectiveChange, onVariantChange)` ~line 254). Pass the reducer's `variant` down wherever `perspective` is passed to `useReportDocuments`.
+5. `src/ui/VisualEditing.tsx`: destructure `onVariantChange` from options and forward to `Overlays` (mirror `onPerspectiveChange` at lines ~40 and ~114). Do the same in any framework wrapper components that explicitly enumerate props (`src/next-pages-router/`, `src/react-router/`, `src/remix/`, etc. — grep for `onPerspectiveChange` and mirror every occurrence).
+6. `src/ui/useReportDocuments.ts`: accept `variant: string | undefined` next to `perspective`, include it in the `visual-editing/documents` post, and include it in the "did it change" comparison (`lastReported`) so a variant switch re-reports documents.
+7. `src/ui/LoaderComlink.tsx` + `src/ui/loader-comlink/context.ts`:
+   - context: add `export let comlinkVariant: string | null = null` and `setLoaderVariant(variant: string | null)` mirroring `comlinkPerspective` / `setLoaderPerspective` (notify listeners).
+   - `LoaderComlink`: in the `loader/perspective` handler call `setLoaderVariant(data.variant ?? null)`; reset to `null` in the cleanup path alongside the perspective reset.
+8. `src/react/usePresentationQuery.ts`: subscribe to `comlinkVariant` via `useSyncExternalStore` like `comlinkPerspective`; include `variant: variant ?? undefined` in the `loader/query-listen` post. Do **not** gate posting on variant being set (variant is optional; the existing `if (!projectId || !dataset || !perspective) return` guard stays as-is). Optionally expose `variant` on the returned state like `perspective` (from `loader/query-change` events).
+9. `src/visual-editing-types` (`packages/visual-editing-types`): only if something there mirrors perspective at the node level — `SanityNode.perspective` is about studio intent links, **not** the preview data perspective. Leave it alone.
+
+## Todo list
+
+- [ ] preview-url-secret: add `urlSearchParamPreviewVariant` + `variantCookieName` constants
+- [ ] preview-url-secret: parse/forward/return `studioPreviewVariant` in `parsePreviewUrl` + `validatePreviewUrl` + types
+- [ ] preview-url-secret: handle the variant param in `withoutSecretSearchParams` / `setSecretSearchParams` / `definePreviewUrl` / resolver option types
+- [ ] preview-url-secret: extend existing unit tests for parse/validate/without/set with variant cases
+- [ ] core-loader: `$variant` atom, `loader/perspective` intake, `onVariant` option, `variant` in query-listen/documents posts, cache keys, `QueryStoreState.variant`
+- [ ] core-loader: unit tests for the new cache-key + message behavior where test coverage exists
+- [ ] react-loader: `loadQuery` `variant` option → fetch + initial payload + cache key; `useLiveMode` forwards `onVariant`
+- [ ] svelte-loader: `loadQuery` `variant` option → fetch + initial payload + cache key
+- [ ] visual-editing: `VisualEditingOptions.onVariantChange` + thread through `VisualEditing`/`Overlays`/framework wrappers
+- [ ] visual-editing: `usePerspectiveSync` handles `variant` + `handlesVariantChange`; reducer state gains `variant`
+- [ ] visual-editing: `LoaderComlink`/context `setLoaderVariant`; `usePresentationQuery` round-trips variant; `useReportDocuments` includes variant
+- [ ] Bump `@sanity/presentation-comlink` to the release containing the variant fields (phase 1)
+- [ ] Run `pnpm build`, `pnpm lint`, `pnpm test` at the repo root; fix fallout
+- [ ] Changesets: minor bumps for `@sanity/preview-url-secret`, `@sanity/core-loader`, `@sanity/react-loader`, `@sanity/svelte-loader`, `@sanity/visual-editing`
+- [ ] Open PR; after merge + release, unblock phases 3 (studio) and 4 (next-sanity)
+
+## Additional knowledge for the agent
+
+- **Backward compatibility is the hard requirement.** Old studios never send `variant`; old frontends never echo it. Everything must behave exactly as today when `variant` is absent. That's why the cache key uses `JSON.stringify({perspective, variant, query, params})` — `undefined` is dropped by `JSON.stringify`, so no-variant keys are identical to current keys on both sides of the wire.
+- **`variant` is orthogonal to `perspective`.** It is a plain string id, never an array, never part of the perspective stack. Don't run it through `validateApiPerspective` or any perspective normalization. Sanitization: treat empty string as `undefined`.
+- **Where the variant value comes from**: the studio Presentation tool (phase 3) reads `usePerspective().selectedVariantName` (bare id from the `variant` router sticky param) and emits it on the iframe URL + comlink. This repo only transports it.
+- **`@sanity/client` variant support is being added by the client team** and is not part of this work. `loadQuery` passing `variant` to `client.fetch` requires that release; if the published client types don't yet include it when you implement, pass it through a single narrowly-typed helper with a cast and a `// TODO(variant): remove cast once @sanity/client ships the variant fetch option` comment, and bump the client dependency when available.
+- The repo packages `packages/presentation`, `packages/next-loader`, and `packages/nuxt-loader` are migration stubs (moved to `sanity`, `next-sanity`, `@nuxtjs/sanity` respectively) — no changes there.
+- Repo tooling: pnpm + turbo + changesets. Root scripts: `pnpm build` (packages only), `pnpm lint`, `pnpm test`, `pnpm format`.
+- Reference implementations to mirror line-by-line: everything `perspective`-related in `packages/core-loader/src/live-mode/enableLiveMode.ts`, `packages/visual-editing/src/ui/usePerspectiveSync.tsx`, and `packages/preview-url-secret/src/parsePreviewUrl.ts`. When in doubt, do for `variant` exactly what the adjacent line does for `perspective`.
+- The apps under `apps/` (next, page-builder-demo, studio) are useful for manual smoke tests (`pnpm dev:next`) but updating them is not required for this phase; the studio side that emits variants ships in phase 3.

--- a/plans/presentation-variants/03-sanity-presentation.md
+++ b/plans/presentation-variants/03-sanity-presentation.md
@@ -1,0 +1,155 @@
+# Plan: emit the selected editing variant from the Presentation tool
+
+- **Repo**: [sanity-io/sanity](https://github.com/sanity-io/sanity) (this monorepo)
+- **Area**: `packages/sanity/src/presentation` (the Presentation tool)
+- **Rollout phase**: 3 of 4. Depends on phase 1 (`@sanity/presentation-comlink` release with the optional `variant` message fields, repo [sanity-io/comlink](https://github.com/sanity-io/comlink)) and on the `@sanity/preview-url-secret` release from phase 2 (repo [sanity-io/visual-editing](https://github.com/sanity-io/visual-editing)) for the `urlSearchParamPreviewVariant` constant. Can be implemented before those releases using the temporary fallbacks described below.
+
+## TLDR
+
+The studio already supports **editing variants**: the selected variant lands in the perspective provider (`usePerspective().selectedVariantName`, fed by the `variant` router sticky param). Presentation currently ignores it. This plan makes Presentation read the selected variant and pass it down to the preview iframe through the exact same paths `perspective` travels: the iframe URL (`sanity-preview-variant` search param), the comlink messages (`presentation/perspective`, `visual-editing/fetch-perspective`, `loader/perspective`, `loader/query-change`), and the loader refetches (`client.fetch(query, params, {perspective, variant})`).
+
+## Why
+
+- `@sanity/client` is being updated (separately, by the client team — **not part of this work**) to accept a `variant` fetch option, sent to the API as `?variant={variantId}`.
+- The frontend side (`@sanity/visual-editing`, `@sanity/core-loader`, `next-sanity`) is being updated in phases 2 and 4 to receive the variant over comlink/URL, persist it as a cookie, and refetch with it.
+- Objective once every phase ships: select a variant in the studio → the variant lands in the perspective provider → Presentation passes it to the iframe → the iframe refetches its documents with the variant → the preview updates.
+
+## The shared contract (must match the other repos exactly)
+
+- **Wire value**: the bare variant id, e.g. `Ab12cd34` — exactly the value of `usePerspective().selectedVariantName` / the `variant` router sticky param. Never the full variant document id (`_.variants.Ab12cd34`). `undefined` = no variant selected.
+- **URL search param**: `sanity-preview-variant` (constant `urlSearchParamPreviewVariant` from `@sanity/preview-url-secret/constants` once the phase-2 release is available). Only set when a variant is selected — never an empty string.
+- **Comlink fields** (from the phase-1 `@sanity/presentation-comlink` release): optional `variant?: string` on `presentation/perspective`, `visual-editing/fetch-perspective` response, `loader/perspective`, `loader/query-change`, `loader/query-listen`, `loader/documents`, `visual-editing/documents`; optional `handlesVariantChange?: boolean` on the `visual-editing/fetch-perspective` request payload.
+- **Client option**: `client.fetch(query, params, {perspective, variant})`.
+
+## The end-to-end flow (where this repo sits)
+
+```
+Studio URL sticky params: ?perspective=…&variant=Ab12cd34
+  → GlobalPerspectiveProvider → PerspectiveProvider → usePerspective().selectedVariantName
+  → PresentationTool (this plan)
+      ├─ iframe URL: &sanity-preview-variant=Ab12cd34  (initial load, and reloads for
+      │    frontends that don't handle in-place variant changes)
+      ├─ presentation/perspective {perspective, variant}   → @sanity/visual-editing → next-sanity
+      │                                                      cookie + refresh (phases 2+4)
+      ├─ visual-editing/fetch-perspective response {perspective, variant};
+      │    request payload {handlesPerspectiveChange, handlesVariantChange}
+      ├─ loader/perspective {projectId, dataset, perspective, variant} → loaders re-listen
+      ├─ loader/query-listen {…, perspective, variant}  ← intake, keyed per variant
+      └─ client.fetch(query, params, {perspective, variant, …}) → loader/query-change
+           {…, perspective, variant, result} → iframe view updates
+```
+
+## Changes in this repo
+
+All paths below are relative to `packages/sanity/src/presentation/`.
+
+### 1. New hook: `usePresentationVariant.ts`
+
+Mirror `usePresentationPerspective.ts` (which adapts `usePerspective()` for Presentation):
+
+```ts
+import {usePerspective} from 'sanity'
+
+/**
+ * The selected editing variant as a bare variant id (e.g. `Ab12cd34`),
+ * or undefined when no variant is selected.
+ * @internal
+ */
+export function usePresentationVariant(): string | undefined {
+  const {selectedVariantName} = usePerspective()
+  return selectedVariantName
+}
+```
+
+Notes: `selectedVariantName` is the raw sticky-param value and is available synchronously (no need to wait for `selectedVariant`, the resolved `system.variant` document). No feature-flag gating: when variants are disabled the sticky param is simply never set, so the value is `undefined` and everything behaves exactly as today.
+
+### 2. `PresentationTool.tsx`
+
+- `const variant = usePresentationVariant()` next to the existing `const perspective = usePresentationPerspective({scheduledDraft: params.scheduledDraft})`.
+- Add `const [handlesVariantChange, setHandlesVariantChange] = useState(false)` next to `_handlesPerspectiveChange`. **Important**: unlike perspective, do NOT add the `|| loadersConnection === 'connected'` legacy fallback — old loaders in the wild don't understand variants, so a connected loader is no proof the frontend can apply a variant change in place. Only the explicit `handlesVariantChange` capability reported over `visual-editing/fetch-perspective` counts; everything else falls back to a full iframe reload via the URL param (safe degradation).
+- Thread new props:
+  - `<Preview … variant={variant} handlesVariantChange={handlesVariantChange} />`
+  - `<PostMessagePerspective … variant={variant} setHandlesVariantChange={setHandlesVariantChange} />`
+  - `<LiveQueries … variant={variant} />`
+
+### 3. `PostMessagePerspective.tsx`
+
+- Props gain `variant: string | undefined` and `setHandlesVariantChange: (payload: boolean) => void`.
+- The `visual-editing/fetch-perspective` handler: also call `setHandlesVariantChange(payload?.handlesVariantChange === true)` (inside the same `startTransition`), and return `{perspective, variant}`.
+- The perspective-change effect: post `presentation/perspective` with `{perspective, variant}` and add `variant` to the dependency array, so a variant-only change also triggers a post.
+
+### 4. `preview/Preview.tsx`
+
+Mirror the `stablePerspective` freeze for variant:
+
+- `PreviewProps` gains `variant: string | undefined` and `handlesVariantChange: boolean`.
+- `const [stableVariant, setStableVariant] = useState<string | undefined | null>(null)` — `null` is the "not frozen yet" sentinel and is distinct from `undefined`, which is a legitimate frozen value ("no variant"). `const urlVariant = stableVariant === null ? variant : stableVariant`.
+- In the `previewUrl` memo: `if (urlVariant) { url.searchParams.set(urlSearchParamPreviewVariant, urlVariant) } else { url.searchParams.delete(urlSearchParamPreviewVariant) }` right after the perspective param is set; add `urlVariant` to the memo dependencies.
+- Freeze effect mirroring the perspective one: when `handlesVariantChange` becomes true, `setStableVariant((prev) => (prev === null ? variant : prev))`. Net effect: frontends that report `handlesVariantChange` keep a stable iframe `src` and get in-place updates over comlink; older frontends get a full iframe reload whenever the variant changes because `src` changes.
+- No `encodeStudioPerspective`-style helper is needed — the variant is a single plain string, and `URLSearchParams` handles encoding.
+
+### 5. Loader pipeline: `loader/LiveQueries.tsx`, `loader/useLiveQueries.ts`, `loader/utils.ts`
+
+- `LiveQueriesProps` gains `variant: string | undefined` (rename locally to `activeVariant` alongside `activePerspective` if that reads better).
+- The `loader/perspective` post effect includes `variant: activeVariant` and adds it to the dependency array — this is what makes updated loaders in the iframe re-register their queries when the studio variant changes.
+- The `loader/query-listen` intake: pass `data.variant` into the dispatch payload. The fetch must use the **round-tripped** value from the message (like perspective does), not the studio's current value — old loaders never send `variant`, so their queries keep fetching without it.
+- `loader/useLiveQueries.ts`: the state entry type, `QueryListenAction` payload, and `queryListen()` all gain `variant?: string`; the cache key call becomes `getQueryCacheKey(payload.perspective, payload.variant, payload.query, payload.params)`.
+- `loader/utils.ts`: `getQueryCacheKey(perspective, variant, query, params)` → `` `${perspective}:${variant ?? ''}:${query}:${JSON.stringify(params)}` `` (update the `QueryCacheKey` template-literal type accordingly; both are `@internal`).
+- `QuerySubscription` / `useQuerySubscription`: accept `variant`, pass it to `client.fetch(query, params, {…, perspective, variant})`, add it to the fetch effect dependencies, and echo it in the `loader/query-change` post. `turboChargeResultIfSourceMap` needs no changes (source-document overlay logic is perspective/id based).
+
+### 6. Preview URL machine (initial URL + preview-mode enable URL)
+
+- `usePreviewUrlActorRef.ts`: `const variant = usePresentationVariant()` and pass `variant` into `defineResolveInitialUrlActor({…})` and `defineResolvePreviewModeUrlActor({…})`.
+- `actors/resolve-preview-mode-url.ts`: accept `variant: string | undefined`; on the enable URL, after the perspective param: `if (variant) url.searchParams.set(urlSearchParamPreviewVariant, variant)`. For the deprecated function-style `previewUrl`, pass `studioPreviewVariant: variant` next to `studioPreviewPerspective` (requires the bumped `@sanity/preview-url-secret` resolver types from phase 2; skip with a TODO if the type isn't available yet — it's a deprecated code path).
+- `actors/resolve-initial-url.ts`: same `studioPreviewVariant` addition for the deprecated function-style `previewUrl`.
+
+### 7. Open-in-new-tab and share URLs
+
+- `preview/PreviewHeader.tsx`: thread `variant` (it receives all `Preview` props already; pass `variant` explicitly to `OpenPreviewButton` and `SharePreviewMenu`).
+- `preview/OpenPreviewButton.tsx`: `if (variant) url.searchParams.set(urlSearchParamPreviewVariant, variant)` next to the existing perspective param.
+- `preview/SharePreviewMenu.tsx`: pass the variant to `setSecretSearchParams(url, secret, redirectTo, encodeStudioPerspective(perspective), variant)` — the optional trailing parameter added to `@sanity/preview-url-secret` in phase 2.
+
+### 8. Types and dependency bumps
+
+- `types.ts`: no changes needed to `PresentationPerspective`; add `variant` to the `PreviewProps` interface (it lives in `preview/Preview.tsx`) and any prop interfaces you extend. Do not add a presentation-owned variant search param — the `variant` sticky param is persisted globally by the router (`STICKY_PARAMS` in `packages/sanity/src/router/stickyParams.ts`), so no `useParams.ts` changes.
+- `packages/sanity/package.json`: bump `@sanity/presentation-comlink` and `@sanity/preview-url-secret` to the phase-1/phase-2 releases.
+- **Temporary fallbacks if implementing before those releases** (keep CI green, forward-compatible):
+  - Comlink payloads: cast at the few `post`/`on` call sites (e.g. `{perspective, variant} as unknown as {perspective: ClientPerspective}` or read `(data as {variant?: string}).variant`) with `// TODO(variant): remove cast once @sanity/presentation-comlink ships the variant fields`.
+  - URL param: define `const urlSearchParamPreviewVariant = 'sanity-preview-variant'` in `constants.ts` with `// TODO(variant): import from @sanity/preview-url-secret/constants once released`.
+  - `client.fetch` `variant` option: if the installed `@sanity/client` doesn't type it yet, add it through a single typed helper with a cast and the same TODO convention.
+
+### 9. Tests
+
+- New `__tests__/usePresentationVariant.test.ts` mirroring `__tests__/usePresentationPerspective.test.ts` (mock `usePerspective`, assert bare-id passthrough and `undefined` default).
+- `loader/__tests__/useLiveQueries.test.ts`: extend cache-key/dedupe cases with variant (same query with different variants = different entries; absent variant keeps today's key shape).
+- `machines/__tests__/preview-url.test.ts`: assert `sanity-preview-variant` is set on the enable URL when a variant is selected and absent otherwise.
+- Component-level: if `PostMessagePerspective` or `Preview` have existing tests, extend them; otherwise rely on the hook/machine/reducer coverage above.
+
+## Non-goals (explicit follow-ups, do not do here)
+
+- Making the studio-side panes variant-aware: `useDocumentsOnPage`, `useMainDocument`, `useDocumentLocations`, `overlays/schema/PostMessageSchema`, `editor/PostMessagePreviewSnapshots`. These fetch studio-domain data and keep working on perspective alone; variant-awareness there is a separate task.
+- `loader/BroadcastDisplayedDocument.tsx` rebroadcast triggers.
+- Any `@sanity/client` changes (handled by the client team).
+
+## Todo list
+
+- [ ] Add `usePresentationVariant.ts` hook
+- [ ] `PresentationTool.tsx`: read variant, add `handlesVariantChange` state (no loaders fallback), thread props to `Preview`, `PostMessagePerspective`, `LiveQueries`
+- [ ] `PostMessagePerspective.tsx`: include variant in `presentation/perspective` post and `fetch-perspective` response; capture `handlesVariantChange`
+- [ ] `preview/Preview.tsx`: `sanity-preview-variant` URL param + `stableVariant` freeze gated on `handlesVariantChange`
+- [ ] `loader/LiveQueries.tsx` + `useLiveQueries.ts` + `utils.ts`: variant in `loader/perspective` post, query-listen intake, cache keys, `client.fetch`, `loader/query-change` echo
+- [ ] `usePreviewUrlActorRef.ts` + `actors/resolve-preview-mode-url.ts` + `actors/resolve-initial-url.ts`: variant on enable URL and function-resolver context
+- [ ] `preview/PreviewHeader.tsx` + `OpenPreviewButton.tsx` + `SharePreviewMenu.tsx`: variant on popup/share URLs
+- [ ] Bump `@sanity/presentation-comlink` + `@sanity/preview-url-secret` (or add TODO-tagged temporary casts/constants)
+- [ ] Tests: `usePresentationVariant`, `useLiveQueries` cache keys, preview-url machine
+- [ ] `pnpm build && pnpm test`, `pnpm lint:fix`, `pnpm check:types` all green
+- [ ] PR with conventional-commit title, e.g. `feat(presentation): pass selected editing variant to preview frontends`
+
+## Additional knowledge for the agent
+
+- **How variant selection already works in this repo** (do not rebuild any of this): the `variant` router sticky param (see `packages/sanity/src/router/stickyParams.ts`) is read by `packages/sanity/src/core/perspective/GlobalPerspectiveProvider.tsx` and exposed by `PerspectiveProvider` as `selectedVariantName` (raw bare id, synchronous) and `selectedVariant` (resolved `system.variant` document, async). It is set via `useSetVariant` (`packages/sanity/src/core/perspective/useSetVariant.tsx`), which stores the **bare** id (`getVariantId` strips the `_.variants.` prefix). The variants feature is gated by `workspace.beta.variants.enabled`, but reading `selectedVariantName` is safe regardless.
+- **Variant is orthogonal to perspective.** It must NOT be merged into `usePresentationPerspective`, the perspective stack, or `encodeStudioPerspective`. It travels as its own optional string next to perspective everywhere.
+- **Round-trip principle in the loader pipeline**: Presentation fetches with whatever `perspective`/`variant` the iframe's `loader/query-listen` declared, and pushes `loader/perspective` when the studio selection changes so updated loaders re-register. Old loaders simply never declare a variant — their behavior is unchanged.
+- **Reload vs in-place**: the only signal that a frontend handles variant changes in place is `handlesVariantChange: true` on the `visual-editing/fetch-perspective` request payload (sent by `@sanity/visual-editing` versions that have an `onVariantChange` prop wired, e.g. via next-sanity phase 4). Without it, variant changes flow through the iframe `src` and cause a reload — that is correct and intentional.
+- Repo commands (see `AGENTS.md` at the repo root): `pnpm build && pnpm test`; single project runs via `pnpm vitest run --project=sanity <path>`; `pnpm lint:fix`; `pnpm check:types`. PR titles must follow conventional commits.
+- Reference files to mirror line-by-line: `usePresentationPerspective.ts`, `PostMessagePerspective.tsx`, `preview/Preview.tsx` (stablePerspective block), `loader/LiveQueries.tsx`. When in doubt, do for `variant` exactly what the adjacent line does for `perspective`.

--- a/plans/presentation-variants/04-next-sanity.md
+++ b/plans/presentation-variants/04-next-sanity.md
@@ -1,0 +1,208 @@
+# Plan: persist and apply editing variants in next-sanity
+
+- **Repo**: [sanity-io/next-sanity](https://github.com/sanity-io/next-sanity)
+- **Package**: `packages/next-sanity` (`next-sanity`)
+- **Rollout phase**: 4 of 4. Depends on the phase-2 releases from [sanity-io/visual-editing](https://github.com/sanity-io/visual-editing): `@sanity/visual-editing` (new `onVariantChange` option) and `@sanity/preview-url-secret` (new `variantCookieName` constant + `studioPreviewVariant` in `validatePreviewUrl`). Also assumes phase 1 (`@sanity/presentation-comlink` variant message fields) and phase 3 (the studio Presentation tool emitting the variant).
+
+## TLDR
+
+Sanity Studio now supports **editing variants** (content variants a document can be attached to). The Presentation tool passes the selected variant to the preview app the same two ways it passes `perspective`: the draft-mode enable URL (`sanity-preview-variant` search param) and comlink messages relayed by `@sanity/visual-editing` (`onVariantChange`). next-sanity must persist the variant in a cookie (`sanity-preview-variant`, mirroring the `sanity-preview-perspective` cookie), resolve it in `sanityFetch`, and pass it to `client.fetch` so server-rendered content refetches with `?variant={variantId}` and the preview updates.
+
+## Why
+
+- The user-facing objective across all repos: select a variant in the studio → Presentation passes it down to the iframe → the frontend refetches its documents with the variant → the preview view updates.
+- next-sanity is where the **cookie storage** lives for perspective today (`sanity-preview-perspective`, written by `defineEnableDraftMode` on initial load and by `perspectiveChangeAction` on in-place changes). The variant must be stored the same way so RSC fetches on subsequent requests apply it.
+- `@sanity/client` is being updated (separately, by the client team — **not part of this work**) to accept a `variant` option in fetch, exactly like `perspective`, sent to the API as `?variant={variantId}`.
+
+## The shared contract (must match the other repos exactly)
+
+- **Wire value**: the bare variant id, e.g. `Ab12cd34` — never the full variant document id (`_.variants.Ab12cd34`). `undefined` = no variant selected (base content).
+- **URL search param**: `sanity-preview-variant` (`urlSearchParamPreviewVariant` from `@sanity/preview-url-secret/constants`), set by the studio on the draft-mode enable URL. `validatePreviewUrl` (phase 2) extracts it as `studioPreviewVariant`.
+- **Cookie**: `sanity-preview-variant` (`variantCookieName` from `@sanity/preview-url-secret/constants`), same attributes as the perspective cookie. Deleted — not set to an empty value — when the variant is cleared.
+- **Callback**: `@sanity/visual-editing` (phase 2) calls `onVariantChange(variant: string | undefined)` when the studio posts `presentation/perspective {perspective, variant}`, and reports `handlesVariantChange: true` back to the studio when the prop is wired — which prevents full iframe reloads on variant switches.
+- **Fetch option**: `sanityFetch({query, params, perspective, variant, …})` with the same precedence as perspective: explicit option > cookie auto-resolve (react-server condition, draft mode + serverToken only) > `undefined`.
+
+## The end-to-end flow (where this repo sits)
+
+```
+Studio Presentation tool
+  │
+  ├─(1) Initial load: GET /api/draft-mode/enable
+  │       ?sanity-preview-secret=…&sanity-preview-perspective=…&sanity-preview-variant=Ab12cd34
+  │       → defineEnableDraftMode → validatePreviewUrl → {studioPreviewPerspective, studioPreviewVariant}
+  │       → cookies: sanity-preview-perspective + sanity-preview-variant → redirect
+  │
+  ├─(2) In-place change: comlink presentation/perspective {perspective, variant}
+  │       → @sanity/visual-editing → <VisualEditing> onVariantChange
+  │       → variantChangeAction (server action): set/delete cookie + refresh()
+  │
+  └─(3) Server fetch: sanityFetch({query, params})
+          → resolve perspective + variant from cookies (draft mode)
+          → client.fetch(query, params, {perspective, variant, …}) → ?variant=Ab12cd34
+          → RSC re-renders with variant content
+```
+
+`<SanityLive>` is not involved — it doesn't handle perspective today and won't handle variant either.
+
+## Changes in this repo
+
+All paths relative to `packages/next-sanity/`.
+
+### 1. `src/draft-mode/define-enable-draft-mode.ts`
+
+- Destructure `studioPreviewVariant` from the `validatePreviewUrl(client, request.url)` result (available after bumping `@sanity/preview-url-secret`).
+- After the existing perspective-cookie block:
+
+  ```ts
+  if (studioPreviewVariant) {
+    cookieStore.set({
+      name: variantCookieName,
+      value: studioPreviewVariant,
+      httpOnly: true,
+      path: '/',
+      secure: isSecure,
+      sameSite: isSecure ? 'none' : 'lax',
+    })
+  } else {
+    cookieStore.delete(variantCookieName)
+  }
+  ```
+
+- The `else → delete` branch is deliberate and differs from perspective: perspective always has a value on the enable URL, but variant is optional, so entering preview without a variant must clear any stale variant cookie from a previous session.
+
+### 2. `src/visual-editing/server-actions/index.ts` (`'use server'`)
+
+Add `variantChangeAction` next to `perspectiveChangeAction`, following its structure (same `@internal` caveat comment, same dev-only skip when unchanged):
+
+```ts
+/**
+ * @internal CAUTION: this is an internal action and does not follow semver. Using it directly is at your own risk.
+ */
+export async function variantChangeAction(variant: string | undefined): Promise<void> {
+  const sanitizedVariant = sanitizeVariant(variant)
+  const jar = await cookies()
+  const current = jar.get(variantCookieName)?.value
+
+  if (!sanitizedVariant) {
+    if (!current) return
+    jar.delete(variantCookieName)
+    refresh()
+    return
+  }
+
+  if (sanitizedVariant === current && process.env.NODE_ENV !== 'production') {
+    // oxlint-disable-next-line no-console
+    console.debug('variantChangeAction', 'Variant is the same, skipping', sanitizedVariant)
+    return
+  }
+
+  jar.set(variantCookieName, sanitizedVariant, {
+    httpOnly: true,
+    path: '/',
+    secure: true,
+    sameSite: 'none',
+  })
+  refresh()
+}
+```
+
+Unlike `perspectiveChangeAction`, an empty/undefined value is not an error — it means "variant cleared".
+
+### 3. `src/visual-editing/VisualEditing.tsx` (RSC wrapper) and `src/visual-editing/client-component/VisualEditing.tsx`
+
+- RSC wrapper: `onVariantChange={variantChangeAction}` next to the existing `onPerspectiveChange={perspectiveChangeAction}`.
+- Client component: accept and forward the `onVariantChange` prop to the underlying `@sanity/visual-editing` component, exactly like `onPerspectiveChange` is forwarded today (grep both files for `onPerspectiveChange` and mirror every occurrence).
+- Requires the bumped `@sanity/visual-editing` with the `onVariantChange` option (phase 2).
+
+### 4. `src/live/shared/` helpers
+
+- New `sanitizeVariant.ts`: `sanitizeVariant(variant: unknown): string | undefined` — returns the trimmed string when it matches `/^[A-Za-z0-9._-]+$/` (the bare-variant-id charset; single value, never comma-separated, never an array), otherwise `undefined`. No perspective-style fallback parameter.
+- New `resolveVariantFromCookies.ts`, mirroring `resolvePerspectiveFromCookies.ts`:
+
+  ```ts
+  export async function resolveVariantFromCookies(options: {
+    cookies: ReadonlyRequestCookies
+  }): Promise<string | undefined> {
+    const {cookies: jar} = options
+    return jar.has(variantCookieName)
+      ? sanitizeVariant(jar.get(variantCookieName)?.value)
+      : undefined
+  }
+  ```
+
+  Note the different default from perspective: perspective falls back to `'drafts'`, variant falls back to `undefined` (no variant).
+
+- `src/live/shared/types.ts`: add `variant?: string` to the `sanityFetch` options type with TSDoc mirroring the `perspective` option docs (cookie name `sanity-preview-variant`, resolution rules below). Add it to the strict fetch type as **optional** (see strict-mode note).
+
+### 5. `src/live/conditions/react-server/defineLive.tsx` (legacy / non-Cache-Components condition)
+
+- `sanityFetch` signature gains `variant: _variant`.
+- Resolution, mirroring perspective exactly:
+
+  ```ts
+  const variant = strict
+    ? _variant
+    : (_variant ?? (serverToken ? await resolveCookieVariant() : undefined))
+  ```
+
+  with a private helper next to `resolveCookiePerspective()`:
+
+  ```ts
+  async function resolveCookieVariant(): Promise<string | undefined> {
+    return (await draftMode()).isEnabled
+      ? await resolveVariantFromCookies({cookies: await cookies()})
+      : undefined
+  }
+  ```
+
+- Pass `variant` into the `client.fetch(…)` options next to `perspective`.
+- Leave the `useCdn` and `token` derivations unchanged — they are keyed off `perspective`/`stega` only. (Variant content is only reachable in draft mode where `useCdn` is already false via non-published perspectives; if the client team later specifies CDN semantics for `variant`, that's a client-side concern.)
+- Re-export `resolveVariantFromCookies` from `src/live/conditions/react-server/index.ts` next to `resolvePerspectiveFromCookies`.
+
+### 6. `src/live/conditions/next-js/defineLive.tsx` (Cache Components condition)
+
+- `sanityFetch` accepts `variant` and passes it straight to `client.fetch` — no `draftMode()`/`cookies()` calls inside (same constraint as perspective: dynamic APIs cannot be used inside `'use cache'`).
+- Update the option docs/examples to show the recommended pattern: resolve outside the cached scope and drill as a prop, e.g. `const variant = isDraftMode ? await resolveVariantFromCookies({cookies: await cookies()}) : undefined`.
+- Re-export `resolveVariantFromCookies` from `src/live/conditions/next-js/index.ts`.
+- `src/live/conditions/default/index.ts` (client stub): add a throwing `resolveVariantFromCookies` stub mirroring the perspective one.
+
+### 7. Strict mode (`src/live/shared/strictValidation.ts`)
+
+No change to the validation itself: `strict: true` keeps requiring an explicit `perspective`, and `variant` stays optional — absence of a variant is a valid state, so there is nothing to force. The `strict` behavior for variant is simply "no cookie auto-resolution; only the explicit option is used" (covered by the `strict ? _variant : …` line). Document this in the option TSDoc.
+
+### 8. Exports and dependency bumps
+
+- Export `variantChangeAction` from `next-sanity/visual-editing/server-actions` next to `perspectiveChangeAction`; export `resolveVariantFromCookies` wherever `resolvePerspectiveFromCookies` is exported. Update `src/__tests__/exports.spec.ts` accordingly.
+- `package.json`: bump `@sanity/visual-editing` and `@sanity/preview-url-secret` to the phase-2 releases.
+- **Temporary fallbacks if implementing before those releases** (keep CI green, forward-compatible): define `const variantCookieName = 'sanity-preview-variant'` locally with `// TODO(variant): import from @sanity/preview-url-secret/constants once released`; read `studioPreviewVariant` via `new URL(request.url).searchParams.get('sanity-preview-variant')` after `isValid` (safe: the secret is already validated, same trust level as the perspective param); pass `onVariantChange` / the client `variant` fetch option through narrowly-typed casts with the same TODO tag.
+
+### 9. Tests
+
+- `test/sanityFetch.test.ts`: extend the perspective matrix with variant cases — explicit `variant` wins over cookie; cookie resolved only when draft mode + serverToken; no cookie → `undefined`; `strict: true` ignores the cookie; variant forwarded to the fetch query string.
+- `test/setupMocks.ts`: make the MSW handler echo the `variant` query param like it echoes `perspective`.
+- Add unit tests for `sanitizeVariant` (valid id, empty string, garbage, array) and `resolveVariantFromCookies` (cookie present/absent/invalid).
+- Optional but recommended: update `apps/mvp` to demonstrate variant resolution (mirroring its `DraftModePerspectiveProvider`/cookie-resolve pattern) for manual verification.
+
+## Todo list
+
+- [ ] Bump `@sanity/visual-editing` + `@sanity/preview-url-secret` (or add TODO-tagged temporary fallbacks)
+- [ ] `defineEnableDraftMode`: set/delete the `sanity-preview-variant` cookie from `studioPreviewVariant`
+- [ ] `variantChangeAction` server action (set/delete cookie + `refresh()`)
+- [ ] Wire `onVariantChange={variantChangeAction}` through the RSC wrapper and client `<VisualEditing>` component
+- [ ] `sanitizeVariant` + `resolveVariantFromCookies` helpers in `src/live/shared/`
+- [ ] `variant` option on `sanityFetch` in the `react-server` condition with cookie auto-resolve, passed to `client.fetch`
+- [ ] `variant` option on `sanityFetch` in the `next-js` (Cache Components) condition, explicit-only, docs show the drill-as-prop pattern
+- [ ] Export `variantChangeAction` + `resolveVariantFromCookies`; update `exports.spec.ts`
+- [ ] Extend `sanityFetch.test.ts` matrix + MSW mocks; unit-test the new helpers
+- [ ] `pnpm build`, `pnpm lint`, `pnpm test` green at the repo root
+- [ ] Changeset (minor bump for `next-sanity`); open PR
+
+## Additional knowledge for the agent
+
+- **Ownership map**: cookie names and URL params are owned by `@sanity/preview-url-secret`; the comlink protocol by `@sanity/presentation-comlink`; the in-iframe sync by `@sanity/visual-editing`; the studio emitter by `sanity/presentation`. next-sanity owns the Next.js glue: enable route, server actions, cookie resolution, `sanityFetch`. `@sanity/next-loader` is NOT a dependency (it was inlined into next-sanity; only legacy `next-loader.*` request-tag strings remain).
+- **The `#live/…` import alias** used inside the package (e.g. `#live/sanitizePerspective` in the server actions file) maps to `src/live/shared/*` via the package.json `imports` field — follow the same convention for the new helpers.
+- **Variant is orthogonal to perspective**: a plain string id, never an array, never comma-joined, not a `ClientPerspective`. Don't touch `sanitizePerspective`, `LivePerspective`, or perspective resolution.
+- **Deletion semantics matter**: perspective always has a value, variant doesn't. Anywhere the perspective code "sets", the variant code must "set or delete". A stale variant cookie silently changes what visitors in draft mode see, so both write paths (enable route and server action) clear it when no variant is active.
+- **Two `defineLive` implementations** are selected via package export conditions (`react-server` vs `next-js` vs throwing `default`); both must gain the option, but only `react-server` auto-resolves cookies. Keep them consistent with how they diverge for `perspective` today.
+- Repo tooling: pnpm + turbo + changesets; root scripts `pnpm build`, `pnpm lint` (oxlint), `pnpm test` (vitest, incl. browser tests), `pnpm format`.
+- Reference implementations to mirror line-by-line: `perspectiveChangeAction`, `resolvePerspectiveFromCookies`, the perspective blocks in both `defineLive.tsx` files, and the perspective cookie block in `define-enable-draft-mode.ts`. When in doubt, do for `variant` exactly what the adjacent line does for `perspective`, minus the `'drafts'` fallback and plus the delete-when-cleared behavior.

--- a/plans/presentation-variants/README.md
+++ b/plans/presentation-variants/README.md
@@ -1,0 +1,84 @@
+# Editing variants in Presentation — master plan
+
+This is the coordination document for adding **editing variant** support to the Presentation / Visual Editing / live preview stack. The work spans four repositories. Each repository has its own self-contained plan file (in this folder) that can be copy-pasted into that repository and handed to an agent as-is.
+
+## Objective
+
+The studio already supports editing variants: variant definitions can be created, documents can be attached to variants, and the selected variant lands in the studio's `PerspectiveProvider` (via the `variant` router sticky param → `usePerspective().selectedVariantName`).
+
+`@sanity/client` is being updated (by another team, **not part of this work**) to accept a `variant` option in the same way it accepts `perspective` today, which it sends to the API as `?variant={variantId}`.
+
+Once all phases are done: selecting a variant in the studio flows into Presentation, Presentation passes it to the preview iframe (URL param + comlink), the frontend persists it (cookie in next-sanity), refetches its queries with the `variant` parameter, and the preview updates — exactly mirroring how `perspective` behaves today.
+
+## Status tracker
+
+Mark each repo as done when its PR is merged and (where applicable) the package is released.
+
+| Done | Phase | Repo                                                                    | Plan                                                       | Packages affected                                                                                                              |
+| ---- | ----- | ----------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| [ ]  | 1     | [sanity-io/comlink](https://github.com/sanity-io/comlink)               | [01-presentation-comlink.md](./01-presentation-comlink.md) | `@sanity/presentation-comlink`                                                                                                 |
+| [ ]  | 2     | [sanity-io/visual-editing](https://github.com/sanity-io/visual-editing) | [02-visual-editing.md](./02-visual-editing.md)             | `@sanity/preview-url-secret`, `@sanity/core-loader`, `@sanity/react-loader`, `@sanity/svelte-loader`, `@sanity/visual-editing` |
+| [ ]  | 3     | [sanity-io/sanity](https://github.com/sanity-io/sanity)                 | [03-sanity-presentation.md](./03-sanity-presentation.md)   | `sanity` (`packages/sanity/src/presentation`)                                                                                  |
+| [ ]  | 4     | [sanity-io/next-sanity](https://github.com/sanity-io/next-sanity)       | [04-next-sanity.md](./04-next-sanity.md)                   | `next-sanity`                                                                                                                  |
+
+## The shared contract
+
+Every repo must follow this contract exactly; it is repeated in each plan file.
+
+- **Wire value**: the bare variant id, e.g. `Ab12cd34` — NOT the full variant document id (`_.variants.Ab12cd34`). This is the same value the studio stores in the `variant` router sticky param. `undefined` means "no variant selected" (base content).
+- **Client option**: `client.fetch(query, params, {perspective, variant})` → sent to the Content Lake API as `?variant={variantId}`. Client support is in progress by another team and is a prerequisite for fetches to actually apply the variant; all the plumbing in these plans is independent of it.
+- **URL search param**: `sanity-preview-variant`, exported as `urlSearchParamPreviewVariant` from `@sanity/preview-url-secret/constants`. Only set when a variant is selected; never set to an empty string.
+- **Cookie**: `sanity-preview-variant`, exported as `variantCookieName` from `@sanity/preview-url-secret/constants`. Same attributes as the existing `sanity-preview-perspective` cookie. Deleted (not set to empty) when the variant is cleared.
+- **Comlink protocol** (`@sanity/presentation-comlink`): every message `data` that carries `perspective` gains an optional `variant?: string` sibling. The `visual-editing/fetch-perspective` request payload gains `handlesVariantChange?: boolean` next to `handlesPerspectiveChange`. All additions are optional → the protocol stays backward and forward compatible.
+- **Callbacks**: `@sanity/visual-editing` gains `onVariantChange?: (variant: string | undefined) => void` mirroring `onPerspectiveChange`; `@sanity/core-loader` gains `onVariant?: (variant: string | undefined) => void` mirroring `onPerspective`.
+- **Fetch option surface**: `sanityFetch` (next-sanity) and `loadQuery` (react/svelte loaders) accept an optional `variant?: string` with the same precedence as `perspective`: explicit option > cookie auto-resolve (next-sanity react-server condition, draft mode only) > `undefined`.
+
+## The end-to-end flow (target state)
+
+```
+Studio URL sticky params: ?perspective=…&variant=Ab12cd34
+  → PerspectiveProvider (usePerspective().selectedVariantName)
+  → PresentationTool (sanity/presentation)
+      ├─ iframe URL: ?sanity-preview-perspective=…&sanity-preview-variant=Ab12cd34
+      │    → preview app draft-mode enable route (next-sanity defineEnableDraftMode)
+      │    → validatePreviewUrl (@sanity/preview-url-secret) extracts studioPreviewVariant
+      │    → cookies: sanity-preview-perspective + sanity-preview-variant
+      ├─ comlink presentation/perspective {perspective, variant}
+      │    → @sanity/visual-editing usePerspectiveSync
+      │    → onVariantChange(variant) → next-sanity variantChangeAction → cookie + refresh()
+      └─ comlink loader/perspective {projectId, dataset, perspective, variant}
+           → @sanity/core-loader live mode ($variant atom)
+           → loader/query-listen {perspective, variant, query, params}
+           → Presentation refetches: client.fetch(query, params, {perspective, variant})
+           → loader/query-change {perspective, variant, result} → view updates
+  Server fetches (sanityFetch / loadQuery) read the cookie or explicit option
+  → client.fetch(query, params, {perspective, variant}) → ?variant=Ab12cd34
+```
+
+Two delivery channels, exactly like perspective:
+
+1. **Initial load / reload**: the variant travels in the iframe URL (`sanity-preview-variant`) and is persisted as a cookie by the draft-mode enable route, so server-side rendering fetches with the right variant.
+2. **In-place change**: when the studio variant changes, Presentation posts comlink messages; frontends that handle them (new `@sanity/visual-editing` + next-sanity, or new loaders) refetch in place. Frontends that don't handle them get a full iframe reload with the new URL param (graceful degradation, same mechanism perspective uses via `handlesPerspectiveChange` / `handlesVariantChange`).
+
+## Rollout phases
+
+Phase order matters because of package dependencies. Phases 3 and 4 can run in parallel once phase 2 is released.
+
+- **Phase 0 — prerequisite (not part of these plans)**: `@sanity/client` release that accepts `variant` in fetch options (in progress by the client team). Plumbing work in all phases can land before this ships; fetches simply start applying the variant once consumers bump the client.
+- **Phase 1 — [sanity-io/comlink](https://github.com/sanity-io/comlink)**: add optional `variant` fields to the `@sanity/presentation-comlink` message types. Types-only, non-breaking. Release a minor version. Gates phases 2 and 3.
+- **Phase 2 — [sanity-io/visual-editing](https://github.com/sanity-io/visual-editing)**: bump `@sanity/presentation-comlink`; add the `sanity-preview-variant` constants and parsing to `@sanity/preview-url-secret`; thread variant through `@sanity/core-loader`, `@sanity/react-loader`, `@sanity/svelte-loader`; add `onVariantChange` sync to `@sanity/visual-editing`. Release all touched packages. Gates phase 4 (and the preview-url-secret part gates phase 3).
+- **Phase 3 — [sanity-io/sanity](https://github.com/sanity-io/sanity)**: bump `@sanity/presentation-comlink` + `@sanity/preview-url-secret` in `packages/sanity`; make Presentation read the selected variant and pass it via iframe URL + comlink; refetch loader queries with the variant.
+- **Phase 4 — [sanity-io/next-sanity](https://github.com/sanity-io/next-sanity)**: bump `@sanity/visual-editing` + `@sanity/preview-url-secret`; store the variant cookie in the draft-mode enable route and the new `variantChangeAction`; resolve variant from cookies in `sanityFetch`.
+- **Phase 5 — end-to-end validation**: see checklist below.
+
+## End-to-end validation checklist (phase 5)
+
+Using a studio with `beta.variants.enabled: true`, the Presentation tool, and a Next.js app on the updated `next-sanity`:
+
+- [ ] Select a variant in the studio: the `variant` sticky param appears in the studio URL and Presentation posts `presentation/perspective` + `loader/perspective` including the variant (inspect with the comlink debug logs or browser devtools).
+- [ ] The preview iframe URL / draft-mode enable URL contains `sanity-preview-variant=<id>`.
+- [ ] The preview app sets the `sanity-preview-variant` cookie (devtools → Application → Cookies).
+- [ ] Server-rendered content refetches with `?variant=<id>` (network tab on the API request) and the view updates to variant content.
+- [ ] Loader-based queries (`useQuery` / `usePresentationQuery`) refetch and update in place when switching variants, without a full page reload (new visual-editing), or with a reload (old visual-editing — graceful degradation).
+- [ ] Clearing the variant in the studio removes the cookie and the view returns to base content.
+- [ ] Perspective switching still behaves exactly as before (no regressions).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Adds coordination plans for threading the studio's selected **editing variant** through the Presentation / Visual Editing / live preview stack, mirroring every path `perspective` takes today (iframe URL param, comlink messages, loader refetch, and cookie storage).

The work spans four repositories, so this PR adds one self-contained plan per repo (intended to be copy-pasted into each repo and handed to an agent) plus a master plan with a status tracker and rollout phases:

- `plans/presentation-variants/README.md` — master plan: shared contract (bare variant id, `sanity-preview-variant` URL param + cookie, comlink `variant` fields), end-to-end flow, rollout phases 1–5, per-repo checkboxes, and an end-to-end validation checklist.
- `plans/presentation-variants/01-presentation-comlink.md` — [sanity-io/comlink](https://github.com/sanity-io/comlink): optional `variant` fields on every perspective-carrying message + `handlesVariantChange` capability flag.
- `plans/presentation-variants/02-visual-editing.md` — [sanity-io/visual-editing](https://github.com/sanity-io/visual-editing): `@sanity/preview-url-secret` constants/parsing, `@sanity/core-loader` `$variant` atom + cache keys, react/svelte `loadQuery` option, `@sanity/visual-editing` `onVariantChange` sync.
- `plans/presentation-variants/03-sanity-presentation.md` — this repo: Presentation reads `usePerspective().selectedVariantName` and emits it via iframe URL + comlink, refetching loader queries with `{perspective, variant}`.
- `plans/presentation-variants/04-next-sanity.md` — [sanity-io/next-sanity](https://github.com/sanity-io/next-sanity): `sanity-preview-variant` cookie (enable route + `variantChangeAction`), `resolveVariantFromCookies`, `variant` option on `sanityFetch` in both `defineLive` conditions.

`@sanity/client` gaining the `variant` fetch option (`?variant={variantId}`) is a prerequisite handled separately by the client team and explicitly out of scope for these plans.

### What to review

- Documentation only — no runtime code changes.
- Check the shared contract in `plans/presentation-variants/README.md` (bare variant id on the wire, param/cookie name `sanity-preview-variant`, optional comlink fields) is what we want to commit to across repos.
- Check the rollout order: comlink → visual-editing → (sanity, next-sanity in parallel).
- Spot-check the per-repo plans against the referenced files; every change mirrors an existing `perspective` code path line-by-line.

### Testing

Docs-only change: ran the repo formatter (`pnpm oxfmt plans/`, also enforced by the pre-commit hook). No automated tests apply.

### Notes for release

N/A: Internal planning documents only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27b6e1c2-77ce-439a-b23b-3942aaae4c92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27b6e1c2-77ce-439a-b23b-3942aaae4c92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

