### PR TITLE
feat(perf): add per-pr inp a/b and declarative scenario modes

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -284,6 +284,8 @@ jobs:
             sessions: 8
           - scenario: syntheticLarge
             sessions: 3
+          - scenario: commentsField
+            sessions: 3
     steps:
       - uses: actions/checkout@v7
         with:
@@ -355,8 +357,132 @@ jobs:
           overwrite: true
           retention-days: 30
 
+  bench-inp-scenarios:
+    # Enumerates the scenarios declaring `modes.inp.perPr` (perf/bench/scenarios/*)
+    # so bench-inp's matrix and the report job's BENCH_EXPECTED_INP_SCENARIOS
+    # derive from scenario metadata instead of a hand-typed list. PR-only, like
+    # bench-inp and report - daily inp is track-main's job.
+    needs: [build]
+    if: >-
+      !cancelled() && needs.build.result == 'success' &&
+      github.event_name == 'pull_request' &&
+      needs.build.outputs.has_code_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      scenarios_json: ${{ steps.list.outputs.json }}
+      scenarios_csv: ${{ steps.list.outputs.csv }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+
+      - name: Enumerate per-PR inp scenarios
+        id: list
+        run: |
+          JSON=$(pnpm --silent bench scenarios --mode inp --json)
+          echo "json=$JSON" >> "$GITHUB_OUTPUT"
+          echo "csv=$(echo "$JSON" | jq -r 'join(",")')" >> "$GITHUB_OUTPUT"
+
+  bench-inp:
+    needs: [build, build-reference, bench-inp-scenarios]
+    # PR-only: per-PR INP is an A/B vs merge-base (build-reference runs on PRs).
+    # Daily/absolute INP is track-main's job, so running here on schedule would
+    # only duplicate it and orphan the artifacts (report is PR-only).
+    if: >-
+      !cancelled() && needs.build.result == 'success' &&
+      github.event_name == 'pull_request' &&
+      needs.build.outputs.has_code_changes == 'true'
+    runs-on: ubuntu-8core
+    # One value per session (not multiple samples like pageload), so the A/B
+    # bootstrap needs more sessions/side for power - 8/side, matrix-sharded so
+    # wall-clock per shard stays comfortably under this budget (P1 §3).
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # One shard per scenario, sourced from bench-inp-scenarios (derived
+        # from scenario `modes.inp.perPr` metadata) instead of a hand-typed list.
+        scenario: ${{ fromJSON(needs.bench-inp-scenarios.outputs.scenarios_json || '[]') }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+
+      - name: Store Playwright's Version
+        id: playwright-version
+        run: |
+          PLAYWRIGHT_VERSION=$(pnpm exec playwright --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          echo "version=${PLAYWRIGHT_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright Browsers for Playwright's Version
+        id: cache-playwright-browsers
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ steps.playwright-version.outputs.version }}-playwright-browsers-all
+
+      - name: Install Playwright Browsers
+        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+        run: pnpm playwright install --with-deps
+
+      # Chromium on Linux validates TLS against the NSS store; the SPKI
+      # allowlist launch flag used locally is not reliably honored here, and
+      # a bypassed-instead-of-valid cert disables the browser HTTP cache
+      # (breaking warm-load measurements) - so import the bench cert properly
+      - name: Trust the bench TLS certificate
+        run: |
+          command -v certutil >/dev/null || sudo apt-get install -y -qq libnss3-tools >/dev/null
+          CERT_PATH=$(pnpm --silent bench cert-path | tail -n 1)
+          mkdir -p "$HOME/.pki/nssdb"
+          certutil -d "sql:$HOME/.pki/nssdb" -N --empty-password 2>/dev/null || true
+          certutil -d "sql:$HOME/.pki/nssdb" -A -t "CT,," -n sanity-bench -i "$CERT_PATH"
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: bench-dist-experiment
+          path: perf/bench/dist
+
+      - uses: actions/download-artifact@v8
+        if: needs.build-reference.outputs.comparison == 'ab'
+        with:
+          name: bench-dist-reference
+          path: perf/bench/.reference/dist
+
+      - name: Run INP benchmark
+        env:
+          SCENARIO: ${{ matrix.scenario }}
+          COMPARISON: ${{ needs.build-reference.outputs.comparison }}
+          BENCH_MERGE_BASE: ${{ needs.build-reference.outputs.merge_base }}
+        run: |
+          REFERENCE_ARGS=""
+          if [ "$COMPARISON" = "ab" ]; then
+            REFERENCE_ARGS="--reference-dist $GITHUB_WORKSPACE/perf/bench/.reference/dist"
+          fi
+          # shellcheck disable=SC2086
+          pnpm bench run --mode inp --scenario "$SCENARIO" --sessions 8 \
+            --json-out "$GITHUB_WORKSPACE/perf/bench/results/bench-results__inp-$SCENARIO.json" \
+            $REFERENCE_ARGS
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: bench-results-inp-${{ matrix.scenario }}
+          path: perf/bench/results/
+          overwrite: true
+          retention-days: 30
+
   report:
-    needs: [build-reference, bench-interaction, bench-pageload]
+    needs: [build-reference, bench-interaction, bench-pageload, bench-inp-scenarios, bench-inp]
     if: >-
       !cancelled() &&
       github.event_name == 'pull_request' &&
@@ -386,9 +512,12 @@ jobs:
           # A failed shard uploads no result JSON; the report must say so
           # instead of rendering a clean table with a scenario silently
           # missing. Keep in sync with the bench-interaction matrix and the
-          # bench-pageload --scenario flags above.
+          # bench-pageload --scenario flags above. INP's list is NOT
+          # hand-typed - it comes from bench-inp-scenarios (scenario
+          # `modes.inp.perPr` metadata), the same source as bench-inp's matrix.
           BENCH_EXPECTED_INTERACTION_SCENARIOS: singleString,arrayI18n,article,recipe,synthetic
-          BENCH_EXPECTED_PAGELOAD_SCENARIOS: singleString,syntheticLarge
+          BENCH_EXPECTED_PAGELOAD_SCENARIOS: singleString,syntheticLarge,commentsField
+          BENCH_EXPECTED_INP_SCENARIOS: ${{ needs.bench-inp-scenarios.outputs.scenarios_csv }}
         run: pnpm bench report
 
       # Always posted/updated in place - all-neutral is information, silence
@@ -637,9 +766,21 @@ jobs:
           pnpm bench run --mode soak --scenario singleString --minutes 10 \
             --json-out "$GITHUB_WORKSPACE/perf/bench/results/bench-results__soak.json"
 
-      - name: Run INP benchmarks
+      # singleString/commentsField come from scenario `modes.inp.daily` metadata
+      # (same source bench-inp-scenarios uses for the per-PR list) - only
+      # `article` is still hand-flagged, since it doesn't declare `modes` yet.
+      - name: Compute daily inp scenario args
+        id: inp-scenarios
         run: |
-          pnpm bench run --mode inp --scenario singleString --scenario article --scenario commentsField --sessions 4 \
+          JSON=$(pnpm --silent bench scenarios --mode inp --schedule daily --json)
+          echo "args=$(echo "$JSON" | jq -r '.[] | "--scenario " + .' | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+
+      - name: Run INP benchmarks
+        env:
+          INP_SCENARIO_ARGS: ${{ steps.inp-scenarios.outputs.args }}
+        run: |
+          # shellcheck disable=SC2086
+          pnpm bench run --mode inp $INP_SCENARIO_ARGS --scenario article --sessions 4 \
             --json-out "$GITHUB_WORKSPACE/perf/bench/results/bench-results__inp.json"
 
       - name: Merge report

--- a/perf/bench/README.md
+++ b/perf/bench/README.md
@@ -92,8 +92,19 @@ Useful `bench run` flags: `--headed`, `--throttle 1` (disable CPU throttle), `--
 
 1. Schema: `studio/schemas/<name>.ts` exporting a workspace partial; register in `sanity.config.ts`.
 2. Scenario: `scenarios/<name>.ts` via `defineScenario` — deterministic fixture (use `scenarios/fixtures/prng.ts`, never `Math.random`), `interactions` (fields to type into; `kind: 'pte'` for Portable Text; `readbackText` if the value isn't a plain string at the field path), seeded image assets if needed (`cdn.sanity.io/images/*` is served a constant PNG by the route guard).
-3. Register in `scenarios/index.ts`; add the scenario to the `bench-interaction` matrix in `.github/workflows/bench.yml`.
-4. Verify: one absolute session passes with no failures — readback, console errors, hermeticity and endpoint drift are all hard session failures.
+3. Register in `scenarios/index.ts`.
+4. Declare `modes` on the scenario to opt into CI's bench modes. This is the single source of truth, so nothing else needs hand-editing:
+   - `modes.inp.perPr`: measured per PR (A/B, 8 sessions/side, report-only).
+   - `modes.inp.daily`: measured on the daily/track-main run.
+   - `modes.pageload` (`{sessions: N}`): add the scenario to the `bench-pageload` matrix in `.github/workflows/bench.yml` with that session count - `modes.pageload` itself only declares participation, not the count CI uses.
+   - `bench scenarios --mode inp [--schedule daily] --json` derives the per-PR/daily scenario lists straight from this metadata. The CI matrix (`bench-inp-scenarios`) and the report job's expected-scenario guard (`BENCH_EXPECTED_INP_SCENARIOS`) both read it, so adding a scenario to inp is a one-line `modes` edit, never a `bench.yml` matrix edit.
+5. Verify: one absolute session passes with no failures - readback, console errors, hermeticity and endpoint drift are all hard session failures.
+
+`commentsField` is the canonical worked example: `modes: {inp: {perPr: true, daily: true}, pageload: {sessions: 3}}`. It is measured by INP (per-PR A/B plus daily) and by pageload (the other vitals), deliberately not by eFPS - its interesting behaviour is the hover-gated comment composer, a component interaction rather than steady typing (see `scenarios/commentsField.ts` and `mock-api/features/comments.ts`).
+
+Per-PR INP is report-only, never gated: it's one INP value per session, so an 8/side A/B is coarse (`stats/gate.ts`'s `INP_THRESHOLDS` are deliberately looser than the pageload floors - see the comment there for the rationale). Treat it as a signal to investigate, not a pass/fail check.
+
+eFPS (`bench-interaction`, the per-keystroke latency mode) is legacy and being retired in favor of INP + pageload. Do not add new scenarios to its matrix.
 
 ## Adding a feature module
 

--- a/perf/bench/cli/commands/__tests__/scenarios.test.ts
+++ b/perf/bench/cli/commands/__tests__/scenarios.test.ts
@@ -1,0 +1,47 @@
+import {describe, expect, it} from 'vitest'
+
+import {type BenchScenario} from '../../../scenarios/types'
+import {participatesInMode} from '../scenarios'
+
+function scenario(modes?: BenchScenario['modes']): BenchScenario {
+  return {
+    name: 'fixtureScenario',
+    sourceFile: 'perf/bench/scenarios/fixtureScenario.ts',
+    documentType: 'article',
+    documentId: 'fixture-doc',
+    fixture: () => [],
+    interactions: [],
+    modes,
+  }
+}
+
+describe('participatesInMode', () => {
+  it('selects a scenario for --mode inp only via the requested schedule', () => {
+    const perPrOnly = scenario({inp: {perPr: true}})
+    expect(participatesInMode(perPrOnly, 'inp', 'perPr')).toBe(true)
+    expect(participatesInMode(perPrOnly, 'inp', 'daily')).toBe(false)
+
+    const dailyOnly = scenario({inp: {daily: true}})
+    expect(participatesInMode(dailyOnly, 'inp', 'daily')).toBe(true)
+    expect(participatesInMode(dailyOnly, 'inp', 'perPr')).toBe(false)
+  })
+
+  it('selects a scenario for --mode pageload regardless of schedule', () => {
+    const pageloadOnly = scenario({pageload: {sessions: 3}})
+    expect(participatesInMode(pageloadOnly, 'pageload', 'perPr')).toBe(true)
+    expect(participatesInMode(pageloadOnly, 'pageload', 'daily')).toBe(true)
+    expect(participatesInMode(pageloadOnly, 'inp', 'perPr')).toBe(false)
+  })
+
+  it('excludes a scenario with no modes declared from either mode', () => {
+    const undeclared = scenario()
+    expect(participatesInMode(undeclared, 'inp', 'perPr')).toBe(false)
+    expect(participatesInMode(undeclared, 'inp', 'daily')).toBe(false)
+    expect(participatesInMode(undeclared, 'pageload', 'perPr')).toBe(false)
+  })
+
+  it('selects every scenario when no --mode filter is given', () => {
+    expect(participatesInMode(scenario(), undefined, 'perPr')).toBe(true)
+    expect(participatesInMode(scenario({inp: {perPr: true}}), undefined, 'perPr')).toBe(true)
+  })
+})

--- a/perf/bench/cli/commands/runImpl.ts
+++ b/perf/bench/cli/commands/runImpl.ts
@@ -14,6 +14,7 @@ import {
   collectInp,
   collectPageLoad,
   collectRunMetadata,
+  type InpComparison,
 } from '../../report/collect'
 import {type BenchRunDocument, type ScenarioReport} from '../../report/types'
 import {calibrateHost, launchBrowser} from '../../runner/browser'
@@ -36,7 +37,7 @@ import {
 } from '../../runner/session/pageLoad'
 import {getScenario, SCENARIOS} from '../../scenarios'
 import {bootstrapDiffOfMedians} from '../../stats/bootstrap'
-import {gate, PAGELOAD_THRESHOLDS} from '../../stats/gate'
+import {gate, INP_THRESHOLDS, PAGELOAD_THRESHOLDS} from '../../stats/gate'
 import {summarize} from '../../stats/quantiles'
 import {mulberry32} from '../../stats/rng'
 import {resolveFromInvocation} from '../benchRoot'
@@ -170,31 +171,71 @@ export async function runBench(argv: RunArgs): Promise<void> {
       }
     } else if (argv.mode === 'inp') {
       for (const scenario of scenarios) {
-        console.log(`\n${chalk.cyan(scenario.name)} — INP, ${argv.sessions} session(s)`)
-        const results: InpSessionResult[] = []
+        console.log(`\n${chalk.cyan(scenario.name)} — INP, ${argv.sessions} session(s)/side`)
+        const sides: {name: 'reference' | 'experiment'; side: typeof running}[] = reference
+          ? [
+              {name: 'reference', side: reference},
+              {name: 'experiment', side: running},
+            ]
+          : [{name: 'experiment', side: running}]
+        const bySide = new Map<string, InpSessionResult[]>()
+
         for (let i = 0; i < argv.sessions; i++) {
-          const result = await withSessionRetries(scenario.name, () =>
-            runInpSession({
-              browser,
-              running,
-              scenario,
-              instrumentation,
-              config: {cpuThrottleRate: argv.throttle},
-            }),
-          )
-          results.push(result)
-          console.log(
-            `  session ${i + 1}/${argv.sessions}: INP ${result.inpMs.toFixed(0)}ms ` +
-              `across ${result.interactionCount} interactions` +
-              `${result.reportable ? '' : chalk.yellow(' (below reportable interaction count)')}`,
-          )
+          // Alternate which side samples first each pair — same bias-control
+          // rationale as the pageLoad A/B loop below.
+          const ordered = i % 2 === 0 ? sides : sides.toReversed()
+          for (const {name, side} of ordered) {
+            const result = await withSessionRetries(`${scenario.name} ${name}`, () =>
+              runInpSession({
+                browser,
+                running: side,
+                scenario,
+                instrumentation,
+                config: {cpuThrottleRate: argv.throttle},
+              }),
+            )
+            bySide.set(name, [...(bySide.get(name) ?? []), result])
+            console.log(
+              `  session ${i + 1}/${argv.sessions} ${name}: INP ${result.inpMs.toFixed(0)}ms ` +
+                `across ${result.interactionCount} interactions` +
+                `${result.reportable ? '' : chalk.yellow(' (below reportable interaction count)')}`,
+            )
+          }
         }
-        const inpValues = results.map((result) => result.inpMs)
+
+        const experimentResults = bySide.get('experiment') ?? []
+        const inpValues = experimentResults.map((result) => result.inpMs)
         console.log(
           `  ${chalk.bold('INP')} (experiment): p50 ${summarize(inpValues).median.toFixed(0)}ms ` +
-            `across ${results.length} session(s)`,
+            `across ${experimentResults.length} session(s)`,
         )
-        scenarioReports.push(collectInp(scenario.name, results, scenario.sourceFile))
+
+        const referenceResults = bySide.get('reference')
+        let comparison: InpComparison | undefined
+        if (referenceResults && referenceResults.length > 0) {
+          const interval = bootstrapDiffOfMedians({
+            aSessions: referenceResults.map((result) => [result.inpMs]),
+            bSessions: experimentResults.map((result) => [result.inpMs]),
+            rng: mulberry32(argv.seed),
+          })
+          const referenceMedian = summarize(referenceResults.map((result) => result.inpMs)).median
+          const verdict = gate(interval, referenceMedian, INP_THRESHOLDS)
+          comparison = {interval, verdict}
+          console.log(
+            `  ${chalk.bold('INP')}: reference ${referenceMedian.toFixed(0)}ms → ` +
+              `Δ ${formatDiff(interval.diff)} [${formatDiff(interval.lo)}, ${formatDiff(interval.hi)}] ${VERDICT_ICON[verdict]}`,
+          )
+        }
+
+        scenarioReports.push(
+          collectInp(
+            scenario.name,
+            experimentResults,
+            scenario.sourceFile,
+            referenceResults,
+            comparison,
+          ),
+        )
       }
     } else if (argv.mode === 'pageload') {
       const sizes = await measureBundleSize(dist)

--- a/perf/bench/cli/commands/scenarios.ts
+++ b/perf/bench/cli/commands/scenarios.ts
@@ -1,9 +1,12 @@
 // oxlint-disable no-console
 import {object} from '@optique/core/constructs'
 import {message} from '@optique/core/message'
+import {optional, withDefault} from '@optique/core/modifiers'
 import {command, constant, option} from '@optique/core/primitives'
+import {choice} from '@optique/core/valueparser'
 
 import {SCENARIOS} from '../../scenarios'
+import {type BenchScenario} from '../../scenarios/types'
 
 export const scenariosCommand = command(
   'scenarios',
@@ -12,17 +15,43 @@ export const scenariosCommand = command(
     json: option('--json', {
       description: message`Print a machine-readable name array (for CI matrices)`,
     }),
+    mode: optional(
+      option('--mode', choice(['inp', 'pageload']), {
+        description: message`Filter to scenarios declaring participation in this bench mode`,
+      }),
+    ),
+    schedule: withDefault(
+      option('--schedule', choice(['perPr', 'daily']), {
+        description: message`With --mode inp, which schedule's scenario list to select`,
+      }),
+      'perPr' as const,
+    ),
   }),
   {description: message`List the available benchmark scenarios`},
 )
 
-export function listScenarios(json: boolean): void {
+export function participatesInMode(
+  scenario: BenchScenario,
+  mode: 'inp' | 'pageload' | undefined,
+  schedule: 'perPr' | 'daily',
+): boolean {
+  if (mode === undefined) return true
+  if (mode === 'pageload') return Boolean(scenario.modes?.pageload)
+  return Boolean(scenario.modes?.inp?.[schedule])
+}
+
+export function listScenarios(
+  json: boolean,
+  mode?: 'inp' | 'pageload',
+  schedule: 'perPr' | 'daily' = 'perPr',
+): void {
+  const selected = SCENARIOS.filter((scenario) => participatesInMode(scenario, mode, schedule))
   if (json) {
-    console.log(JSON.stringify(SCENARIOS.map((scenario) => scenario.name)))
+    console.log(JSON.stringify(selected.map((scenario) => scenario.name)))
     return
   }
-  const width = Math.max(...SCENARIOS.map((scenario) => scenario.name.length))
-  for (const scenario of SCENARIOS) {
+  const width = Math.max(...selected.map((scenario) => scenario.name.length))
+  for (const scenario of selected) {
     const fields = scenario.interactions
       .map((target) => target.label ?? target.fieldPath)
       .join(', ')

--- a/perf/bench/cli/index.ts
+++ b/perf/bench/cli/index.ts
@@ -65,7 +65,7 @@ switch (result.action) {
     await (await import('../runner/devServer')).startBenchDev(result.scenario)
     break
   case 'scenarios':
-    listScenarios(result.json)
+    listScenarios(result.json, result.mode, result.schedule)
     break
   case 'prepare-reference':
     prepareReference(result)

--- a/perf/bench/report/__tests__/collect.test.ts
+++ b/perf/bench/report/__tests__/collect.test.ts
@@ -3,8 +3,9 @@ import process from 'node:process'
 
 import {afterEach, beforeEach, describe, expect, it} from 'vitest'
 
+import {type InpSessionResult} from '../../runner/session/inp'
 import {type PageLoadSample} from '../../runner/session/pageLoad'
-import {collectPageLoad, collectRunMetadata} from '../collect'
+import {collectInp, collectPageLoad, collectRunMetadata} from '../collect'
 
 const ENV_KEYS = [
   'GITHUB_SHA',
@@ -157,5 +158,49 @@ describe('collectPageLoad', () => {
       'boot-cold · auth round trips',
       'boot-cold · auth in flight',
     ])
+  })
+})
+
+function inpSession(inpMs: number, interactionCount = 60): InpSessionResult {
+  return {
+    inpMs,
+    interactionCount,
+    reportable: true,
+    latencies: [inpMs],
+    readOnlyInterruptions: {count: 0, totalMs: 0},
+  }
+}
+
+describe('collectInp', () => {
+  it('attaches reference and comparison to the INP metric only, when both are given', () => {
+    const report = collectInp(
+      'commentsField',
+      [inpSession(300), inpSession(340)],
+      'perf/bench/scenarios/commentsField.ts',
+      [inpSession(200), inpSession(220)],
+      {
+        interval: {diff: 110, lo: 40, hi: 180, level: 0.95, iterations: 2000},
+        verdict: 'regression',
+      },
+    )
+    const inp = report.metrics.find((metric) => metric.label === 'INP')!
+    const interactions = report.metrics.find((metric) => metric.label === 'INP interactions')!
+
+    expect(inp.reference?.summary.median).toBe(210)
+    expect(inp.comparison).toMatchObject({diff: 110, lo: 40, hi: 180, verdict: 'regression'})
+    expect(interactions.reference).toBeUndefined()
+    expect(interactions.comparison).toBeUndefined()
+  })
+
+  it('carries no reference/comparison keys at all when omitted (absolute-mode run)', () => {
+    const report = collectInp(
+      'commentsField',
+      [inpSession(300), inpSession(340)],
+      'perf/bench/scenarios/commentsField.ts',
+    )
+    const inp = report.metrics.find((metric) => metric.label === 'INP')!
+    expect('reference' in inp).toBe(false)
+    expect('comparison' in inp).toBe(false)
+    expect(report.interruptions).toEqual({experiment: {count: 0, totalMs: 0}})
   })
 })

--- a/perf/bench/report/__tests__/markdown.test.ts
+++ b/perf/bench/report/__tests__/markdown.test.ts
@@ -242,6 +242,36 @@ describe('renderMarkdownReport', () => {
     expect(renderMarkdownReport(RUN)).not.toContain('Missing results')
   })
 
+  it('renders a report-only INP comparison as informational, never as a blocking regression', () => {
+    const withInp: BenchRunDocument = {
+      ...RUN,
+      scenarios: [
+        {
+          ...RUN.scenarios[0],
+          metrics: [metric('stringField', {experiment: 32, reference: 32}, 'neutral')],
+        },
+        {
+          scenario: 'commentsField',
+          kind: 'pageload',
+          mode: 'inp',
+          metrics: [metric('INP', {experiment: 420, reference: 260}, 'regression', false)],
+          failures: [],
+          interruptions: {experiment: {count: 0, totalMs: 0}},
+          loafAttribution: [],
+        },
+      ],
+    }
+    const report = renderMarkdownReport(withInp)
+    // The headline stays clean — a report-only INP swing must never flip it
+    expect(report).toContain('✅ no regressions')
+    expect(report).not.toContain('🔴')
+    expect(report).not.toContain('regression(s)')
+    // ...but the delta still surfaces, decoupled, as informational context
+    expect(report).toContain('ℹ️ **Per-PR INP** (report-only, not gated):')
+    expect(report).toContain('`commentsField · INP` +160.0ms')
+    expect(report).toContain('(regression)')
+  })
+
   it('renders absolute mode without comparison columns', () => {
     const absolute: BenchRunDocument = {
       ...RUN,

--- a/perf/bench/report/__tests__/writeReport.test.ts
+++ b/perf/bench/report/__tests__/writeReport.test.ts
@@ -3,7 +3,7 @@ import {describe, expect, it} from 'vitest'
 import {mergeShards} from '../mergeShards'
 import {documentIdForRun} from '../storeToSanity'
 import {type BenchRunDocument, type MetricReport, type ScenarioReport} from '../types'
-import {toAbsolute} from '../writeReport'
+import {computeMissingScenarios, toAbsolute} from '../writeReport'
 
 const AB_METRIC: MetricReport = {
   label: 'stringField',
@@ -134,36 +134,36 @@ describe('toAbsolute', () => {
   })
 })
 
+const scenarioReport = (
+  scenarioName: string,
+  kind: ScenarioReport['kind'],
+  mode?: ScenarioReport['mode'],
+): ScenarioReport => ({
+  scenario: scenarioName,
+  kind,
+  ...(mode ? {mode} : {}),
+  metrics: [],
+  failures: [],
+  interruptions: {experiment: {count: 0, totalMs: 0}},
+  loafAttribution: [],
+})
+
 describe('mergeShards', () => {
   const shard = (scenario: ScenarioReport): BenchRunDocument => ({
     ...AB_RUN,
     mode: 'absolute',
     scenarios: [scenario],
   })
-  const report = (
-    scenarioName: string,
-    kind: ScenarioReport['kind'],
-    mode?: ScenarioReport['mode'],
-  ): ScenarioReport => ({
-    scenario: scenarioName,
-    kind,
-    ...(mode ? {mode} : {}),
-    metrics: [],
-    failures: [],
-    interruptions: {experiment: {count: 0, totalMs: 0}},
-    loafAttribution: [],
-  })
-
   it('merges a track-main set without colliding soak/inp against interaction/pageload', () => {
     // The daily cron produces all four for the same scenario: interaction,
     // pageload, soak (kind interaction), inp (kind pageload). Before `mode`
     // disambiguated the key, soak collided with interaction and inp with
     // pageload, and the merge threw — storing nothing.
     const merged = mergeShards([
-      shard(report('singleString', 'interaction')),
-      shard(report('singleString', 'pageload')),
-      shard(report('singleString', 'interaction', 'soak')),
-      shard(report('singleString', 'pageload', 'inp')),
+      shard(scenarioReport('singleString', 'interaction')),
+      shard(scenarioReport('singleString', 'pageload')),
+      shard(scenarioReport('singleString', 'interaction', 'soak')),
+      shard(scenarioReport('singleString', 'pageload', 'inp')),
     ])
     expect(merged.scenarios).toHaveLength(4)
   })
@@ -171,8 +171,8 @@ describe('mergeShards', () => {
   it('still rejects a genuinely duplicated shard (same mode + scenario)', () => {
     expect(() =>
       mergeShards([
-        shard(report('singleString', 'interaction')),
-        shard(report('singleString', 'interaction')),
+        shard(scenarioReport('singleString', 'interaction')),
+        shard(scenarioReport('singleString', 'interaction')),
       ]),
     ).toThrow(/duplicate/)
   })
@@ -202,5 +202,46 @@ describe('documentIdForRun', () => {
       runner: {...AB_RUN.runner, runId: undefined},
     }
     expect(documentIdForRun(localRun)).toBe('benchRun-abcdef1234567890-local')
+  })
+})
+
+describe('computeMissingScenarios', () => {
+  // INP reports share `kind: 'pageload'` with plain pageload reports (see
+  // ScenarioReport.mode) — the guard must key off `mode` too, or a dead INP
+  // shard passes silently and a dead pageload shard could false-match an INP
+  // expectation.
+
+  it('reports nothing missing when the expected inp scenario is present', () => {
+    const missing = computeMissingScenarios([scenarioReport('commentsField', 'pageload', 'inp')], {
+      inp: 'commentsField',
+    })
+    expect(missing).toEqual([])
+  })
+
+  it('fails loud when an expected inp scenario is absent', () => {
+    const missing = computeMissingScenarios([], {inp: 'commentsField'})
+    expect(missing).toEqual([{scenario: 'commentsField', kind: 'pageload'}])
+  })
+
+  it('does not let a plain pageload report satisfy an inp expectation', () => {
+    const missing = computeMissingScenarios([scenarioReport('commentsField', 'pageload')], {
+      inp: 'commentsField',
+    })
+    expect(missing).toEqual([{scenario: 'commentsField', kind: 'pageload'}])
+  })
+
+  it('does not let an inp report satisfy a plain pageload expectation', () => {
+    const missing = computeMissingScenarios([scenarioReport('commentsField', 'pageload', 'inp')], {
+      pageload: 'commentsField',
+    })
+    expect(missing).toEqual([{scenario: 'commentsField', kind: 'pageload'}])
+  })
+
+  it('still guards interaction and pageload scenarios unchanged', () => {
+    const missing = computeMissingScenarios(
+      [scenarioReport('singleString', 'interaction'), scenarioReport('article', 'pageload')],
+      {interaction: 'singleString', pageload: 'article'},
+    )
+    expect(missing).toEqual([])
   })
 })

--- a/perf/bench/report/collect.ts
+++ b/perf/bench/report/collect.ts
@@ -212,26 +212,67 @@ export function collectAbsoluteInteraction(
   }
 }
 
+function sumReadOnlyInterruptions(sessions: InpSessionResult[]): {count: number; totalMs: number} {
+  return sessions.reduce(
+    (acc, session) => ({
+      count: acc.count + session.readOnlyInterruptions.count,
+      totalMs: acc.totalMs + session.readOnlyInterruptions.totalMs,
+    }),
+    {count: 0, totalMs: 0},
+  )
+}
+
+export interface InpComparison {
+  interval: DiffInterval
+  verdict: Verdict
+}
+
 /**
  * INP sessions → scenario report. INP is a Core Web Vital, reported (not
  * gated) during burn-in like the other vitals; each session contributes one
  * INP value. Filed under `pageload` kind so the dashboard groups it with the
  * load vitals (see the dashboard's describeSeries), and the interaction-count
  * row travels alongside so a low-confidence INP (few interactions) is visible.
+ *
+ * `referenceSessions`/`comparison` are only present for a per-PR A/B run
+ * (report-only — see gate.ts's INP_THRESHOLDS); the comparison is attached to
+ * the `INP` metric only, never to `INP interactions`, so the interaction-count
+ * context row stays silent in the PR comment either way.
  */
 export function collectInp(
   scenario: string,
   sessions: InpSessionResult[],
   sourceFile?: string,
+  referenceSessions?: InpSessionResult[],
+  comparison?: InpComparison,
 ): ScenarioReport {
   const inpValues = sessions.map((session) => [session.inpMs])
   const interactionCounts = sessions.map((session) => [session.interactionCount])
+  const referenceInpValues = referenceSessions?.map((session) => [session.inpMs])
   const metrics: MetricReport[] = [
     {
       label: 'INP',
       unit: 'ms',
       presentAsEfps: false,
       experiment: {sessions: inpValues, summary: summarize(inpValues.flat())},
+      ...(referenceInpValues && referenceInpValues.length > 0
+        ? {
+            reference: {
+              sessions: referenceInpValues,
+              summary: summarize(referenceInpValues.flat()),
+            },
+          }
+        : {}),
+      ...(comparison
+        ? {
+            comparison: {
+              diff: comparison.interval.diff,
+              lo: comparison.interval.lo,
+              hi: comparison.interval.hi,
+              verdict: comparison.verdict,
+            },
+          }
+        : {}),
     },
     {
       label: 'INP interactions',
@@ -253,13 +294,10 @@ export function collectInp(
     metrics,
     failures: [],
     interruptions: {
-      experiment: sessions.reduce(
-        (acc, session) => ({
-          count: acc.count + session.readOnlyInterruptions.count,
-          totalMs: acc.totalMs + session.readOnlyInterruptions.totalMs,
-        }),
-        {count: 0, totalMs: 0},
-      ),
+      experiment: sumReadOnlyInterruptions(sessions),
+      ...(referenceSessions && referenceSessions.length > 0
+        ? {reference: sumReadOnlyInterruptions(referenceSessions)}
+        : {}),
     },
     loafAttribution: [],
   }

--- a/perf/bench/report/markdown.ts
+++ b/perf/bench/report/markdown.ts
@@ -63,7 +63,11 @@ export function renderMarkdownReport(
   options: {missingScenarios?: MissingScenario[]} = {},
 ): string {
   const missing = options.missingScenarios ?? []
-  const regressed = run.scenarios.flatMap((scenario) =>
+  // Per-PR INP (mode `inp`) is report-only (see gate.ts's INP_THRESHOLDS) —
+  // its comparison must never feed the blocking regression/inconclusive
+  // headline, only its own informational line below.
+  const gatedScenarios = run.scenarios.filter((scenario) => scenario.mode !== 'inp')
+  const regressed = gatedScenarios.flatMap((scenario) =>
     scenario.metrics
       .filter((metric) => metric.comparison?.verdict === 'regression')
       .map((metric) => ({
@@ -74,7 +78,7 @@ export function renderMarkdownReport(
   // Inconclusive verdicts exist precisely so a too-noisy run never reads as a
   // pass — count them into the headline instead of hiding them behind
   // "no regressions"
-  const inconclusiveCount = run.scenarios.reduce(
+  const inconclusiveCount = gatedScenarios.reduce(
     (count, scenario) =>
       count +
       scenario.metrics.filter((metric) => metric.comparison?.verdict === 'inconclusive').length,
@@ -82,6 +86,17 @@ export function renderMarkdownReport(
   )
   const inconclusiveSuffix =
     inconclusiveCount > 0 ? ` (${inconclusiveCount} inconclusive — CI too wide to decide)` : ''
+
+  const inpLines = run.scenarios
+    .filter((scenario) => scenario.mode === 'inp')
+    .flatMap((scenario) =>
+      scenario.metrics
+        .filter((metric) => metric.comparison)
+        .map((metric) => {
+          const {diff, lo, hi, verdict} = metric.comparison!
+          return `- \`${scenario.scenario} · ${metric.label}\` ${formatDiff(diff)} [${formatDiff(lo)}, ${formatDiff(hi)}] (${verdict})`
+        }),
+    )
 
   const headline =
     run.mode === 'absolute'
@@ -106,6 +121,11 @@ export function renderMarkdownReport(
     '',
     headline,
     ...(regressionLines.length > 0 ? ['', ...regressionLines, '', regressionChart(regressed)] : []),
+    // Informational only — never folded into the headline/regression count
+    // above (see gatedScenarios)
+    ...(inpLines.length > 0
+      ? ['', 'ℹ️ **Per-PR INP** (report-only, not gated):', ...inpLines]
+      : []),
     // A failed shard uploads no results — say so loudly instead of staying
     // silent about a scenario that never ran
     ...(missing.length > 0

--- a/perf/bench/report/writeReport.ts
+++ b/perf/bench/report/writeReport.ts
@@ -38,17 +38,53 @@ export function toAbsolute(run: BenchRunDocument): BenchRunDocument {
   }
 }
 
+interface ExpectedEntry {
+  missing: MissingScenario
+  /**
+   * The value a real report's `mode ?? kind` resolves to (mirrors the
+   * mergeShards dedup key). INP reports share `kind: 'pageload'` with plain
+   * pageload reports, so `kind` alone can't tell an expected INP scenario
+   * apart from an expected pageload one — this can.
+   */
+  reportKind: string
+}
+
 /**
  * CI passes the scenario sets it scheduled (comma-separated env vars, set in
  * bench.yml next to the shard matrix) so a shard that failed and uploaded no
  * result JSON is called out in the report instead of silently missing.
  */
-function expectedScenarios(value: string | undefined, kind: ScenarioReport['kind']) {
+function expectedEntries(
+  value: string | undefined,
+  kind: ScenarioReport['kind'],
+  reportKind: string = kind,
+): ExpectedEntry[] {
   return (value ?? '')
     .split(',')
     .map((name) => name.trim())
     .filter(Boolean)
-    .map((scenario): MissingScenario => ({scenario, kind}))
+    .map((scenario) => ({missing: {scenario, kind}, reportKind}))
+}
+
+function isReported(scenarios: ScenarioReport[], entry: ExpectedEntry): boolean {
+  return scenarios.some(
+    (scenario) =>
+      scenario.scenario === entry.missing.scenario &&
+      (scenario.mode ?? scenario.kind) === entry.reportKind,
+  )
+}
+
+export function computeMissingScenarios(
+  scenarios: ScenarioReport[],
+  expected: {interaction?: string; pageload?: string; inp?: string},
+): MissingScenario[] {
+  return [
+    ...expectedEntries(expected.interaction, 'interaction'),
+    ...expectedEntries(expected.pageload, 'pageload'),
+    ...expectedEntries(expected.inp, 'pageload', 'inp'),
+  ]
+    .filter((entry) => !isReported(scenarios, entry))
+    .map((entry) => entry.missing)
 }
 
 export function writeMergedReport(resultsDirArg?: string): void {
@@ -69,15 +105,11 @@ export function writeMergedReport(resultsDirArg?: string): void {
   )
   const merged = mergeShards(shards)
 
-  const missingScenarios = [
-    ...expectedScenarios(process.env.BENCH_EXPECTED_INTERACTION_SCENARIOS, 'interaction'),
-    ...expectedScenarios(process.env.BENCH_EXPECTED_PAGELOAD_SCENARIOS, 'pageload'),
-  ].filter(
-    (expected) =>
-      !merged.scenarios.some(
-        (scenario) => scenario.scenario === expected.scenario && scenario.kind === expected.kind,
-      ),
-  )
+  const missingScenarios = computeMissingScenarios(merged.scenarios, {
+    interaction: process.env.BENCH_EXPECTED_INTERACTION_SCENARIOS,
+    pageload: process.env.BENCH_EXPECTED_PAGELOAD_SCENARIOS,
+    inp: process.env.BENCH_EXPECTED_INP_SCENARIOS,
+  })
   // Marker for CI: a shard that dies without results (a job timeout
   // surfaces as "cancelled", which never turns the run red) must still fail
   // the check — but only AFTER the comment is posted, so the report job

--- a/perf/bench/scenarios/commentsField.ts
+++ b/perf/bench/scenarios/commentsField.ts
@@ -15,4 +15,5 @@ export const commentsField = defineScenario({
   ],
   interactions: [{fieldPath: 'stringField', kind: 'string'}],
   steps: addCommentSteps('stringField'),
+  modes: {inp: {perPr: true, daily: true}, pageload: {sessions: 3}},
 })

--- a/perf/bench/scenarios/singleString.ts
+++ b/perf/bench/scenarios/singleString.ts
@@ -15,4 +15,5 @@ export const singleString = defineScenario({
     },
   ],
   interactions: [{fieldPath: 'stringField', kind: 'string'}],
+  modes: {inp: {perPr: true, daily: true}},
 })

--- a/perf/bench/scenarios/types.ts
+++ b/perf/bench/scenarios/types.ts
@@ -60,6 +60,15 @@ export interface BenchScenario {
    * HEAD on both).
    */
   keystrokes?: {warmup?: number; measured?: number; burst?: number}
+  /**
+   * Declares which bench modes/schedules this scenario participates in.
+   * Absent (or a sub-field absent) means no participation — existing
+   * behaviour is unchanged until a scenario file sets this explicitly.
+   */
+  modes?: {
+    inp?: {perPr?: boolean; daily?: boolean}
+    pageload?: {sessions: number}
+  }
 }
 
 /** Where a step acts. Field selectors reuse the existing focusField/fieldInput logic. */

--- a/perf/bench/stats/__tests__/stats.test.ts
+++ b/perf/bench/stats/__tests__/stats.test.ts
@@ -1,7 +1,13 @@
 import {describe, expect, it} from 'vitest'
 
 import {bootstrapDiffOfMedians, type DiffInterval} from '../bootstrap'
-import {gate, INTERACTION_THRESHOLDS, PAGELOAD_THRESHOLDS, shouldStop} from '../gate'
+import {
+  gate,
+  INP_THRESHOLDS,
+  INTERACTION_THRESHOLDS,
+  PAGELOAD_THRESHOLDS,
+  shouldStop,
+} from '../gate'
 import {median, quantile, summarize} from '../quantiles'
 import {mulberry32, type Rng} from '../rng'
 
@@ -247,6 +253,27 @@ describe('gate', () => {
         }
       }
     }
+  })
+})
+
+describe('INP_THRESHOLDS (report-only signal, never gates CI)', () => {
+  it('reads a small delta within the loose floors as not a regression', () => {
+    // referenceMedian 300: minimumEffect = max(150, 0.15·300) = 150. A 40ms
+    // delta stays well inside that even with a fairly tight CI.
+    expect(gate(interval(40, 10, 70), 300, INP_THRESHOLDS)).not.toBe('regression')
+    expect(gate(interval(40, 10, 70), 300, INP_THRESHOLDS)).toBe('neutral')
+  })
+
+  it('flags a regression only once a large delta clears both floors with a CI excluding zero', () => {
+    // Diff 200ms clears both the absolute (150) and relative (0.15·300 = 45)
+    // floors, and the CI [120, 280] excludes zero.
+    expect(gate(interval(200, 120, 280), 300, INP_THRESHOLDS)).toBe('regression')
+  })
+
+  it('is looser than PAGELOAD_THRESHOLDS, matching the report-only rationale', () => {
+    expect(INP_THRESHOLDS.absMs).toBeGreaterThan(PAGELOAD_THRESHOLDS.absMs)
+    expect(INP_THRESHOLDS.rel).toBeGreaterThan(PAGELOAD_THRESHOLDS.rel)
+    expect(INP_THRESHOLDS.targetHalfWidthMs).toBeGreaterThan(PAGELOAD_THRESHOLDS.targetHalfWidthMs)
   })
 })
 

--- a/perf/bench/stats/gate.ts
+++ b/perf/bench/stats/gate.ts
@@ -26,6 +26,17 @@ export const PAGELOAD_THRESHOLDS: GateThresholds = {
 }
 
 /**
+ * INP: one value/session, so a per-PR A/B is coarse (see P2 doc) — kept
+ * report-only and never gates CI, so these floors are deliberately looser
+ * than pageload's to avoid reading session noise as a real regression.
+ */
+export const INP_THRESHOLDS: GateThresholds = {
+  absMs: 150,
+  rel: 0.15,
+  targetHalfWidthMs: 150,
+}
+
+/**
  * Verdict rule: a difference is real only when the CI excludes zero AND the
  * point estimate exceeds both threshold floors. `inconclusive` (CI too wide
  * to decide at these thresholds when the budget ran out) is distinct from


### PR DESCRIPTION
### Description

The bench suite measures INP only in the daily `track-main` job, so no scenario gets a per-PR INP signal, and a scenario's mode coverage is hand-synced across several places in `bench.yml`, which makes adding new scenarios error-prone. SAPP-3751 wants a clear example of adding a scenario that is benchmarked for INP both per-PR and daily.

This PR adds per-PR INP as a report-only A/B (branch vs merge-base) via a new `bench-inp` job, and makes a scenario's mode coverage declarative so the inp matrix and its expected-scenario guard derive from scenario metadata rather than hand-typed lists. Adding a scenario to per-PR-inp and daily becomes a one-line `modes` edit, with `commentsField` as the worked example. Stacked on #13557.

### What to review

- `runImpl.ts` inp branch is now dual-side, mirroring the existing pageload inline A/B; `collect.ts` attaches the `comparison` to the `INP` metric only, leaving `INP interactions` silent.
- Report-only by design: INP is one value per session, so an 8-sessions/side A/B is deliberately coarse. `markdown.ts` renders it in a decoupled informational section that never feeds the blocking regression headline, and `INP_THRESHOLDS` are loose and non-gating.
- `bench-inp` is PR-only; daily INP stays in `track-main`. The job matrix and `BENCH_EXPECTED_INP_SCENARIOS` both derive from `bench scenarios --mode inp`, and a missing inp shard now fails the report loudly.
- `modes` on the scenario object is the single source of truth; migrating the existing interaction/pageload matrices to it is a deliberate follow-up.

### Testing

`pnpm bench:unit` (143 tests) and `pnpm --filter bench check:types` pass. New unit tests cover the INP comparison emission, `INP_THRESHOLDS` gate classification, the `bench scenarios --mode` enumeration, the markdown non-blocking behaviour, and the fail-loud inp guard. The end-to-end A/B smoke needs a merge-base reference build and runs in CI.

### Notes for release

N/A
