### PR TITLE
fix(form): prevent pte caret from jumping to block start while typing on new documents

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -37,9 +37,33 @@ export function useTrackFocusPath(props: Props): void {
     selectionRef.current = selection
   }, [selection])
 
+  // The focusPath value that has already been effectuated: either applied to the editor
+  // (selected/focused below), or confirmed to match a selection the editor already owns.
+  // The effect re-runs on member/element-ref churn so that a focusPath whose target hasn't
+  // rendered yet can be retried, but a handled one must never be re-applied: unrelated re-runs
+  // (e.g. validation markers arriving while the user types) would otherwise re-select at
+  // offset 0 and hijack the caret to the start of the block (SAPP-4053). This matters whenever
+  // the editor transiently loses DOM focus while the form focusPath stays put — such as a brief
+  // readOnly flip toggling `contenteditable` off. Tracking by reference is safe because form
+  // paths are interned (`pathFor`), so the value only changes when focus actually moves; the
+  // ref is cleared whenever it does, keeping re-entry from outside (Visual Editing, #12894)
+  // working when the same path is focused again later.
+  const handledFocusPathRef = useRef<Path | null>(null)
+
   useLayoutEffect(() => {
+    // Focus moved elsewhere (or was cleared on blur): forget the handled path so that focusing
+    // the previous path again later is applied anew.
+    if (handledFocusPathRef.current !== focusPath) {
+      handledFocusPathRef.current = null
+    }
+
     // Don't do anything if no focusPath to track
     if (focusPath.length === 0) {
+      return
+    }
+
+    // This exact focusPath has already been effectuated; don't re-apply it on unrelated re-runs.
+    if (handledFocusPathRef.current === focusPath) {
       return
     }
 
@@ -71,6 +95,7 @@ export function useTrackFocusPath(props: Props): void {
       ) &&
       (editorHasDomFocus || Boolean(openEditingItem))
     ) {
+      handledFocusPathRef.current = focusPath
       return
     }
 
@@ -155,6 +180,7 @@ export function useTrackFocusPath(props: Props): void {
           if (isTextBlock) {
             PortableTextEditor.focus(legacyEditor)
           }
+          handledFocusPathRef.current = focusPath
         }
       }
     }

--- a/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useDocumentVersions.test.tsx
@@ -2,7 +2,7 @@ import {type ReleaseDocument} from '@sanity/client'
 import {getPublishedId} from '@sanity/client/csm'
 import {type DocumentSystem} from '@sanity/types'
 import {renderHook, waitFor} from '@testing-library/react'
-import {BehaviorSubject, concat, NEVER, of} from 'rxjs'
+import {BehaviorSubject, concat, NEVER, of, Subject} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
 import {type DocumentPreviewStore} from '../../../preview'
@@ -244,9 +244,11 @@ describe('getOrCreateDocumentVersionsObservable — subscriber churn', () => {
     } as unknown as DocumentPreviewStore
   }
 
-  const options = (documentPreviewStore: DocumentPreviewStore) => ({
+  // The module-level swr cache is keyed by `projectId-dataset-publishedId` and survives across
+  // tests, so each test uses its own publishedId to avoid replaying another test's cached id set.
+  const options = (documentPreviewStore: DocumentPreviewStore, publishedId: string) => ({
     documentPreviewStore,
-    publishedId: 'document-1',
+    publishedId,
     projectId: 'test-project',
     dataset: 'test',
   })
@@ -254,7 +256,7 @@ describe('getOrCreateDocumentVersionsObservable — subscriber churn', () => {
   it('does not re-emit loading: true to a subscriber arriving right after a zero-subscriber gap', () => {
     vi.useFakeTimers()
     const previewStore = createPreviewStore()
-    const state$ = getOrCreateDocumentVersionsObservable(options(previewStore))
+    const state$ = getOrCreateDocumentVersionsObservable(options(previewStore, 'churn-1'))
 
     const first: DocumentPerspectiveState[] = []
     const firstSub = state$.subscribe((value) => first.push(value))
@@ -281,12 +283,66 @@ describe('getOrCreateDocumentVersionsObservable — subscriber churn', () => {
   it('tears down and evicts the cache entry after the grace period', () => {
     vi.useFakeTimers()
     const previewStore = createPreviewStore()
-    const state$ = getOrCreateDocumentVersionsObservable(options(previewStore))
+    const state$ = getOrCreateDocumentVersionsObservable(options(previewStore, 'churn-2'))
 
     const sub = state$.subscribe()
     sub.unsubscribe()
     vi.advanceTimersByTime(2_000)
 
     expect(observableCache.size).toBe(0)
+  })
+
+  /**
+   * Regression test for SAPP-4053: on a brand-new document the version id set
+   * changes as soon as the first keystroke creates the draft (`[]` →
+   * `['drafts.<id>']`). Re-emitting `loading: true` for that change flips the
+   * form read-only mid-typing, dropping DOM focus from the editor (which in
+   * turn caused the PTE caret to jump to the start of the block).
+   */
+  it('does not re-emit loading: true when the version id set changes after the initial load', () => {
+    const ids$ = new Subject<string[]>()
+    const observePaths = vi.fn((value: unknown) =>
+      concat(
+        of({
+          _id: (value as {_id: string})._id,
+          _rev: '',
+          _createdAt: '',
+          _updatedAt: '',
+        }),
+        NEVER,
+      ),
+    )
+    const previewStore = {
+      unstable_observeVersionDocumentIds: vi.fn(() => ids$),
+      observePaths,
+    } as unknown as DocumentPreviewStore
+
+    const state$ = getOrCreateDocumentVersionsObservable(options(previewStore, 'id-set-change'))
+    const emissions: DocumentPerspectiveState[] = []
+    const sub = state$.subscribe((value) => emissions.push(value))
+
+    // Cold start: a non-empty initial id set must still block with loading: true.
+    ids$.next(['drafts.document-1'])
+    expect(emissions.map((e) => e.loading)).toEqual([true, false])
+
+    // First keystroke on a new document: the draft id appears while the user
+    // is typing. The pipeline must go straight to the loaded state.
+    ids$.next(['drafts.document-1', 'versions.rASAP.document-1'])
+    expect(emissions.map((e) => e.loading)).toEqual([true, false, false])
+    expect(emissions.at(-1)?.data).toEqual(['drafts.document-1', 'versions.rASAP.document-1'])
+
+    sub.unsubscribe()
+  })
+
+  it('still emits loading: true for a cold start whose first id set is non-empty', () => {
+    const previewStore = createPreviewStore()
+    const state$ = getOrCreateDocumentVersionsObservable(options(previewStore, 'cold-start'))
+
+    const emissions: DocumentPerspectiveState[] = []
+    const sub = state$.subscribe((value) => emissions.push(value))
+
+    expect(emissions.map((e) => e.loading)).toEqual([true, false])
+
+    sub.unsubscribe()
   })
 })

--- a/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
@@ -244,19 +244,12 @@ export function getOrCreateDocumentVersionsObservable(options: {
     documentPreviewStore.unstable_observeVersionDocumentIds(publishedId).pipe(
       swr(cacheKey),
       map(({value}) => value),
-      switchMap((documentIds): Observable<DocumentPerspectiveState> => {
+      switchMap((documentIds, index): Observable<DocumentPerspectiveState> => {
         if (documentIds.length === 0) {
           return of({data: [], versions: [], error: null, loading: false})
         }
 
-        const loadingState: DocumentPerspectiveState = {
-          data: documentIds,
-          versions: [],
-          error: null,
-          loading: true,
-        }
-
-        return combineLatest(
+        const versions$ = combineLatest(
           documentIds.map((id) =>
             documentPreviewStore.observePaths({_id: id}, DOCUMENT_STUB_PATHS).pipe(
               map((versionInfo) => (isRecord(versionInfo) ? versionInfo : undefined)),
@@ -279,8 +272,27 @@ export function getOrCreateDocumentVersionsObservable(options: {
             error: null,
             loading: false,
           })),
-          startWith(loadingState),
         )
+
+        // Only the pipeline's very first id-set emission is a cold start that must block
+        // with `loading: true` (it gates `useDocumentForm`'s `ready` state). Later id-set
+        // changes happen while the user is editing — e.g. the draft id appearing on the
+        // first keystroke in a new document, or publish swapping draft for published — and
+        // re-emitting `loading: true` then would flip the whole form read-only mid-typing,
+        // silently dropping keystrokes and DOM focus. Keep replaying the last loaded state
+        // until the fresh stubs arrive instead.
+        if (index > 0) {
+          return versions$
+        }
+
+        const loadingState: DocumentPerspectiveState = {
+          data: documentIds,
+          versions: [],
+          error: null,
+          loading: true,
+        }
+
+        return versions$.pipe(startWith(loadingState))
       }),
       catchError((error) => {
         return of({


### PR DESCRIPTION
### Description

Fixes [SAPP-4053](https://linear.app/sanity/issue/SAPP-4053/pte-cursor-jumps-to-start-during-validation-on-new-documents), reported by a customer in studio support: typing in a Portable Text Editor on a **new** document gets interrupted after the first auto-save — the caret jumps to the start of the block and the rest of the input lands before the already-typed text. Reproduces since `v6.4.0` when the document has validation on other fields.

Two things conspire, and each gets its own commit:

1. `useDocumentVersions` **re-emits** `loading: true` **mid-editing.** On a new document, the first keystroke creates the draft, which changes the version-id set. The `switchMap` re-entered its `startWith(loadingState)` path, flipping `useDocumentForm`'s `ready` gate and briefly turning the form read-only. Toggling `contenteditable` off silently drops DOM focus from the editor. The fix keeps `startWith(loadingState)` only for the pipeline's first (cold-start) emission; later id-set changes replay the last loaded state until fresh stubs arrive.
2. `useTrackFocusPath` **hijacks the caret when DOM focus is lost (the** `v6.4.0` **regression).** Since `4c6e970a29` the hook resolves the enclosing block via the editor snapshot, so when it re-runs on unrelated churn (validation markers arriving) while the editor lacks DOM focus, it now finds the block and force-selects it at `offset: 0` — before `v6.4.0` this path resolved nothing and was a no-op. The fix tracks the last effectuated `focusPath` (by reference — form paths are interned via `pathFor`) and never re-applies it; the ref clears whenever focus actually moves, so re-entry from outside (Visual Editing, sanity-io/sanity#12894/sanity-io/sanity#13072) keeps working.

Layer 1 removes the trigger; layer 2 removes the caret hijack for any other transient focus loss.

**Alternatives considered:**

* Only fixing `useDocumentVersions`: leaves the caret hijack armed for any other readOnly flicker or transient focus loss.
* Bailing in `useTrackFocusPath` whenever the selection path matches regardless of DOM focus: breaks re-focus from Visual Editing (sanity-io/sanity#12894).

### What to review

* `packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx` — is it acceptable that after the initial load, id-set changes surface stale-but-loaded data instead of a loading state? (This is what keeps the form editable.)
* `packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx` — the handled-path ref must not break retry-on-churn (target not yet rendered) or Visual Editing re-entry; retries stay possible because the ref is only set after a successful select/bail.

### Testing

* Added regression tests in `useDocumentVersions.test.tsx`: id-set changes after initial load must not re-emit `loading: true`; cold start still does.
* Manually verified in the test studio (Playwright, video below): before the fix, typing "The quick brown fox…" into a fresh `allTypes` document produces `"ox jumps over the lazy dog and keeps typing alongThe quick b"`; after the fix the sentence stays intact.
* `pnpm check:format`, `pnpm check:oxlint`, `pnpm check:types`, and the `form` + `releases` vitest suites pass.

Before (caret jumps to block start mid-sentence):

[before_fix_pte_cursor_jumps_to_start_while_typing.webm](<https://cursor.com/agents/bc-019f7105-06ae-7750-a136-794b09b76b92/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_fix_pte_cursor_jumps_to_start_while_typing.webm>)

After (typing stays intact):

[after_fix_pte_typing_stays_intact.webm](<https://cursor.com/agents/bc-019f7105-06ae-7750-a136-794b09b76b92/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_fix_pte_typing_stays_intact.webm>)

### Notes for release

Fixes an issue where typing in a Portable Text Editor on a newly created document could be interrupted — the cursor jumped to the beginning of the text block after the first auto-save, scrambling the typed text. This was most noticeable on documents with validation rules on other fields.

To show artifacts inline, [enable](<https://cursor.com/dashboard/cloud-agents#team-pull-requests>) in settings.

<img src="https://camo.githubusercontent.com/ae5336cc4565ed7dd126cd5bfcb9f6a53979c32e32819e23ffd98524f0526bc9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d7765622d6461726b2e706e67 " alt="Open in Web" width="114" data-linear-height="28" /> <img src="https://camo.githubusercontent.com/583722e75417432aa96019715ba989e7851c00ce91b7725e7246cf7c45b1dae9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d637572736f722d6461726b2e706e67 " alt="Open in Cursor" width="131" data-linear-height="28" />