### PR TITLE
feat(core): accept native table container definitions in the table plugin config

### DIFF
--- a/dev/test-studio/schema/standard/portableText/customPlugins.tsx
+++ b/dev/test-studio/schema/standard/portableText/customPlugins.tsx
@@ -94,6 +94,27 @@ function ContainerPlugins(props: PortableTextPluginsProps) {
   )
 }
 
+// Binds the built-in table plugin to `sanity-plugin-rich-table`'s schema
+// shape (`richTable` > `rows` > `row` > `cells` > `richTableCell` >
+// `content`) via native `defineContainer` definitions: type and field
+// names come from the containers, renders fall back to the studio's
+// table UI. Module scope so the plugin doesn't re-register per render.
+const richTableContainers = {
+  table: defineContainer({type: 'richTable', arrayField: 'rows'}),
+  row: defineContainer({type: 'row', arrayField: 'cells'}),
+  cell: defineContainer({type: 'richTableCell', arrayField: 'content'}),
+}
+
+function RichTableAdoptionPlugins(props: PortableTextPluginsProps) {
+  return props.renderDefault({
+    ...props,
+    plugins: {
+      ...props.plugins,
+      table: {enabled: true, containers: richTableContainers},
+    },
+  })
+}
+
 export const customPlugins = defineType({
   name: 'customPlugins',
   title: 'Custom Plugins',
@@ -209,6 +230,60 @@ export const customPlugins = defineType({
       components: {
         portableText: {
           plugins: ContainerPlugins,
+        },
+      },
+    },
+    {
+      type: 'array',
+      name: 'richTableAdoption',
+      title: 'Rich Table Adoption',
+      description:
+        "Built-in table editing bound to sanity-plugin-rich-table's schema shape (richTable > rows > row > cells > richTableCell > content) through the table plugin's containers config. The row's extra title field persists untouched; headerRows is the one field the built-in adds.",
+      of: [
+        defineArrayMember({type: 'block'}),
+        defineArrayMember({
+          type: 'object',
+          name: 'richTable',
+          fields: [
+            // Not part of the rich-table shape: the built-in's header-row
+            // toggle needs it declared or the value is stripped.
+            defineField({type: 'number', name: 'headerRows'}),
+            defineField({
+              type: 'array',
+              name: 'rows',
+              of: [
+                defineArrayMember({
+                  type: 'object',
+                  name: 'row',
+                  fields: [
+                    defineField({type: 'string', name: 'title'}),
+                    defineField({
+                      type: 'array',
+                      name: 'cells',
+                      of: [
+                        defineArrayMember({
+                          type: 'object',
+                          name: 'richTableCell',
+                          fields: [
+                            defineField({
+                              type: 'array',
+                              name: 'content',
+                              of: [defineArrayMember({type: 'block'})],
+                            }),
+                          ],
+                        }),
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+      components: {
+        portableText: {
+          plugins: RichTableAdoptionPlugins,
         },
       },
     },

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -178,7 +178,7 @@ function DefaultTablePlugin(props: PortableTextPluginsProps['plugins']['table'])
     return null
   }
 
-  return <PortableTextTablePlugin />
+  return <PortableTextTablePlugin containers={props.containers} />
 }
 
 function DefaultPasteLinkPlugin(props: PortableTextPluginsProps['plugins']['pasteLink']) {

--- a/packages/sanity/src/core/form/inputs/PortableText/object/TablePlugin.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/TablePlugin.tsx
@@ -1,10 +1,10 @@
 // oxlint-disable-next-line no-unassigned-import -- imported for its side effects
 import '@portabletext/plugin-table/ui/styles.css'
 
-import {defineContainer, type ContainerRenderProps} from '@portabletext/editor'
+import {type Container, type ContainerRenderProps} from '@portabletext/editor'
 import {defineBehavior, raise} from '@portabletext/editor/behaviors'
 import {BehaviorPlugin} from '@portabletext/editor/plugins'
-import {defineTable} from '@portabletext/plugin-table'
+import {defineTable, type TableContainers, type TableDefinition} from '@portabletext/plugin-table'
 import {
   referenceContainers,
   Table,
@@ -23,41 +23,73 @@ import {ContextMenuButton} from '../../../../components/contextMenuButton'
 import {useTranslation} from '../../../../i18n'
 import {useColorSchemeValue} from '../../../../studio/colorScheme'
 
-const table = defineTable({
-  containers: {
-    ...referenceContainers,
-    table: defineContainer({
-      type: 'table',
-      arrayField: 'rows',
-      render: (props) => <StudioTable {...props} />,
-    }),
-  },
-})
+const studioTableRender = (props: ContainerRenderProps) => <StudioTable {...props} />
+
+/**
+ * Merge consumer containers with the studio's defaults per role: consumer
+ * type and field names win, omitted renders fall back to the studio's
+ * table render (table role) or the reference renders (row and cell, which
+ * resolve their table definition from the node they render, so they work
+ * under renamed types).
+ */
+function resolveContainers(containers: TableContainers | undefined): TableContainers {
+  const tableRole: Container = containers?.table ?? {
+    kind: 'container',
+    type: 'table',
+    arrayField: 'rows',
+  }
+  return {
+    table: {...tableRole, render: tableRole.render ?? studioTableRender},
+    row: containers?.row
+      ? {...containers.row, render: containers.row.render ?? referenceContainers.row?.render}
+      : referenceContainers.row,
+    cell: containers?.cell
+      ? {...containers.cell, render: containers.cell.render ?? referenceContainers.cell?.render}
+      : referenceContainers.cell,
+  }
+}
 
 // Tables inserted from the insert menu have no rows yet. The guard also
 // makes sure the raise below doesn't loop.
-const scaffoldBehaviors = [
-  defineBehavior({
-    on: 'insert.block',
-    guard: ({event}) => {
-      if (event.block._type !== 'table') {
-        return false
-      }
-      const rows = 'rows' in event.block ? event.block.rows : undefined
-      return !(Array.isArray(rows) && rows.length > 0)
-    },
-    actions: [
-      ({event}) => [
-        raise({
-          ...event,
-          block: {...event.block, ...table.createBlock({headerRows: 1})},
-        }),
+function createScaffoldBehaviors(table: TableDefinition, tableType: string, rowsField: string) {
+  return [
+    defineBehavior({
+      on: 'insert.block',
+      guard: ({event}) => {
+        if (event.block._type !== tableType) {
+          return false
+        }
+        const rows =
+          rowsField in event.block ? (event.block as Record<string, unknown>)[rowsField] : undefined
+        return !(Array.isArray(rows) && rows.length > 0)
+      },
+      actions: [
+        ({event}) => [
+          raise({
+            ...event,
+            block: {...event.block, ...table.createBlock({headerRows: 1})},
+          }),
+        ],
       ],
-    ],
-  }),
-]
+    }),
+  ]
+}
 
-export function PortableTextTablePlugin(): React.JSX.Element {
+export function PortableTextTablePlugin(props: {containers?: TableContainers}): React.JSX.Element {
+  const {containers} = props
+  const {table, scaffoldBehaviors} = useMemo(() => {
+    const resolved = resolveContainers(containers)
+    const tableDefinition = defineTable({containers: resolved})
+    return {
+      table: tableDefinition,
+      scaffoldBehaviors: createScaffoldBehaviors(
+        tableDefinition,
+        resolved.table!.type,
+        resolved.table!.arrayField,
+      ),
+    }
+  }, [containers])
+
   return (
     <>
       <HeaderCellWeight />

--- a/packages/sanity/src/core/form/types/blockProps.ts
+++ b/packages/sanity/src/core/form/types/blockProps.ts
@@ -1,5 +1,6 @@
 import {type MarkdownShortcutsPluginProps} from '@portabletext/plugin-markdown-shortcuts'
 import {type PasteLinkPluginProps} from '@portabletext/plugin-paste-link'
+import {type TableContainers} from '@portabletext/plugin-table'
 import {type TypographyPluginProps} from '@portabletext/plugin-typography'
 import {
   type ArraySchemaType,
@@ -496,6 +497,19 @@ export interface PortableTextPluginsProps {
        * @defaultValue false
        */
       enabled?: boolean
+      /**
+       * Native `@portabletext/plugin-table` container definitions, one per
+       * role, for binding the plugin to your own type and field names
+       * (adopting a table shape that already exists in your dataset).
+       * Omitted renders fall back to the studio's table UI, and omitted
+       * roles fall back to the canonical `table`/`row`/`cell` names. The
+       * nesting shape and the `headerRows` field name stay fixed, and the
+       * schema must declare the same names the containers use.
+       *
+       * Define the containers at module scope: a new object identity
+       * re-registers the plugin on every render.
+       */
+      containers?: TableContainers
     }
   }
 }


### PR DESCRIPTION
#13445 shipped the table plugin bound to fixed names (`table` > `rows` > `row` > `cells` > `cell` > `value`).

Teams with an existing table-shaped type in their dataset can't adopt the built-in editing without either migrating data or colliding with their current `table` type. The underlying `@portabletext/plugin-table` already solved this: `defineTable` accepts role-keyed `defineContainer` definitions, only names are configurable, the three-level nesting and the `headerRows` field name are fixed, and omitted renders fall back to built-in ones. This PR exposes that same API through the studio config instead of inventing a parallel one:

```tsx
components: {
  portableText: {
    plugins: (props) =>
      props.renderDefault({
        ...props,
        plugins: {
          ...props.plugins,
          table: {
            enabled: true,
            containers: {
              table: defineContainer({type: 'richTable', arrayField: 'rows'}),
              row: defineContainer({type: 'row', arrayField: 'cells'}),
              cell: defineContainer({type: 'richTableCell', arrayField: 'content'}),
            },
          },
        },
      }),
  },
},
```

The studio reinterprets one word of the native contract: an omitted `render` falls back to the *studio's* table UI on the table role, and to the plugin's reference renders on row and cell, which resolve their table definition from the node they render and therefore work under renamed types without extra wiring. Consumers who do pass a render keep it, with the caveat that replacing the table role's render replaces the studio chrome (menus, header toggle) along with it. Omitting `containers` entirely resolves to the canonical names and the studio render, byte-identical to #13445's behavior, so the option is pure addition.

Implementation-wise the plugin's table definition and insert scaffolding move from module scope into a `useMemo` keyed on the containers object, and the scaffold guard derives its type and rows-field names from the resolved containers instead of `'table'`/`'rows'` literals. The `containers` docstring tells consumers to define the object at module scope, since a fresh identity per render re-registers the plugin.

The test-studio commit adds an adoption example on the Custom Plugins document binding the plugin to `sanity-plugin-rich-table`'s schema shape (`richTable` > `rows` > `row` > `cells` > `richTableCell` > `content`): the row's extra `title` field persists untouched by table editing, and `headerRows` is the one field the built-in requires the schema to add.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes portable text table plugin wiring and insert scaffolding; behavior is backward-compatible when `containers` is omitted, but misconfigured containers or unstable object identity could affect editing or plugin registration.
> 
> **Overview**
> Portable text **table** plugin config now accepts optional **`containers`** (`TableContainers` from `@portabletext/plugin-table`), so built-in table editing can target existing schema shapes (custom `_type` and array field names per table/row/cell role) without migrating data or colliding with a canonical `table` type.
> 
> **`PortableTextTablePlugin`** merges consumer containers with studio defaults: consumer types and field names win; missing **render** on the table role falls back to the studio table UI, and row/cell fall back to reference renders. Table definition and insert scaffolding are built in **`useMemo`** from resolved containers, and empty-table insert behavior uses the resolved table type and rows field instead of hard-coded `table`/`rows`. Omitting **`containers`** keeps prior default behavior.
> 
> **test-studio** adds a **Rich Table Adoption** field demonstrating binding to a `richTable` > `rows` > `row` > `cells` > `richTableCell` > `content` shape (including required **`headerRows`** and an extra row **`title`** field).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6a8e340428a25b6ecd5dd1761a141703d81e6da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->