### PR TITLE
chore(deps): update dependency @isaacs/ttlcache to v2

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -145,7 +145,7 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@isaacs/ttlcache": "^1.4.1",
+    "@isaacs/ttlcache": "^2.1.5",
     "@mux/mux-player-react": "^3.13.0",
     "@portabletext/editor": "^7.10.8",
     "@portabletext/html": "^1.1.1",

--- a/packages/sanity/src/core/store/document/utils/dedupeListenerEvents.ts
+++ b/packages/sanity/src/core/store/document/utils/dedupeListenerEvents.ts
@@ -1,4 +1,4 @@
-import TTLCache from '@isaacs/ttlcache'
+import {TTLCache} from '@isaacs/ttlcache'
 import {type MonoTypeOperatorFunction, type Observable} from 'rxjs'
 import {mergeMap, scan} from 'rxjs/operators'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1568,8 +1568,8 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.7)
       '@isaacs/ttlcache':
-        specifier: ^1.4.1
-        version: 1.4.1
+        specifier: ^2.1.5
+        version: 2.1.5
       '@mux/mux-player-react':
         specifier: ^3.13.0
         version: 3.13.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)
@@ -4347,10 +4347,6 @@ packages:
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
-
-  '@isaacs/ttlcache@1.4.1':
-    resolution: {integrity: sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==}
-    engines: {node: '>=12'}
 
   '@isaacs/ttlcache@2.1.5':
     resolution: {integrity: sha512-VwGZqqjAWPICTmxUZnbpEfO60LhPWzquik+bmyXGY7pYRn6diEvCI5i6Ca+J6o2y4vS73HrpuMTo2dOvUevH8w==}
@@ -16871,8 +16867,6 @@ snapshots:
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
-
-  '@isaacs/ttlcache@1.4.1': {}
 
   '@isaacs/ttlcache@2.1.5': {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Keeps `@isaacs/ttlcache` on a maintained major. v2 only changes the package to a hybrid TypeScript module with a named `TTLCache` export (no API behavior change for our usage).

Alternatives considered: stay on 1.4.1 — rejected; Renovate/squiggler is already targeting v2 and 1.x is effectively frozen.

### What to review

- Import change in `dedupeListenerEvents.ts` (`default` → named `TTLCache`)
- Version bump in `packages/sanity` only

### Testing

- `pnpm vitest run --project=sanity packages/sanity/src/core/store/document/getPairListener.test.ts` (12 passed)
- Verified named `TTLCache` import resolves from `packages/sanity`

### Notes for release

N/A – Internal only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90ca7594-28c7-4208-9b79-a5c9dbb36c52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90ca7594-28c7-4208-9b79-a5c9dbb36c52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

