### PR TITLE
chore(test-dts-exports): note workbench TS2300 still present in alpha.26

### DIFF
--- a/packages/@repo/test-dts-exports/test/lib-check.test.ts
+++ b/packages/@repo/test-dts-exports/test/lib-check.test.ts
@@ -58,7 +58,7 @@ const filteredErrors = errors.filter((d) => {
   }
 
   // Temporary workaround for broken d.ts output in @sanity/workbench (reproduced with
-  // 0.1.0-alpha.24 and 0.1.0-alpha.25). The bundled declarations emit the same type alias twice
+  // 0.1.0-alpha.24 through 0.1.0-alpha.26). The bundled declarations emit the same type alias twice
   // (e.g. Canvas, Workspace), which fails TS2300 under skipLibCheck: false. This only affects type
   // checking in node_modules and does not impact runtime behavior. Remove once @sanity/workbench
   // ships a release without duplicate identifiers in its generated .d.ts files.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Follow-up to #13585 / [review comment](https://github.com/sanity-io/sanity/pull/13585/changes#r3613976230): after pinning `@sanity/workbench` to `0.1.0-alpha.26`, the dts-export workaround comment still said the TS2300 issue was reproduced only on `0.1.0-alpha.24`/`0.1.0-alpha.25`.

Checked `0.1.0-alpha.26` — duplicate `Canvas`/`Workspace` aliases are still emitted, so the filter stays; only the version note is updated.

### What to review

- Comment accuracy in `packages/@repo/test-dts-exports/test/lib-check.test.ts`

### Testing

- Inspected `@sanity/workbench@0.1.0-alpha.26` `.d.ts` files for duplicate type aliases (`Canvas`, `Workspace`)
- No test code changes beyond the comment

### Notes for release

N/A – Internal only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f624cb5-3cb5-4c7b-aec1-5f4046432b2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f624cb5-3cb5-4c7b-aec1-5f4046432b2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

