### PR TITLE
fix(deps): update @sanity/workbench to 0.1.0-alpha.26

### DIFF
--- a/packages/@repo/test-dts-exports/test/lib-check.test.ts
+++ b/packages/@repo/test-dts-exports/test/lib-check.test.ts
@@ -57,11 +57,11 @@ const filteredErrors = errors.filter((d) => {
     return false
   }
 
-  // Temporary workaround for broken d.ts output in @sanity/workbench (reproduced with
-  // 0.1.0-alpha.24 and 0.1.0-alpha.25). The bundled declarations emit the same type alias twice
-  // (e.g. Canvas, Workspace), which fails TS2300 under skipLibCheck: false. This only affects type
-  // checking in node_modules and does not impact runtime behavior. Remove once @sanity/workbench
-  // ships a release without duplicate identifiers in its generated .d.ts files.
+  // Temporary workaround for broken d.ts output in @sanity/workbench (still reproduced with
+  // 0.1.0-alpha.26). The bundled declarations emit the same type alias twice (e.g. Canvas,
+  // Workspace), which fails TS2300 under skipLibCheck: false. This only affects type checking in
+  // node_modules and does not impact runtime behavior. Remove once @sanity/workbench ships a
+  // release without duplicate identifiers in its generated .d.ts files.
   if (code === 2300 && file.fileName.includes('/node_modules/@sanity/workbench/')) {
     return false
   }

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -191,7 +191,7 @@
     "@sanity/ui": "catalog:",
     "@sanity/util": "workspace:*",
     "@sanity/uuid": "^3.0.3",
-    "@sanity/workbench": "0.1.0-alpha.24",
+    "@sanity/workbench": "0.1.0-alpha.26",
     "@sentry/react": "^10.62.0",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.14.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1706,8 +1706,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@sanity/workbench':
-        specifier: 0.1.0-alpha.24
-        version: 0.1.0-alpha.24(@sanity/sdk@2.15.0)(react@19.2.7)(xstate@5.32.4)
+        specifier: 0.1.0-alpha.26
+        version: 0.1.0-alpha.26(@sanity/sdk@2.15.0)(react@19.2.7)(xstate@5.32.4)
       '@sentry/react':
         specifier: ^10.62.0
         version: 10.62.0(react@19.2.7)
@@ -7020,8 +7020,8 @@ packages:
     resolution: {integrity: sha512-n2ABuylzZd6VwuhiDa23OZEgPoaBb8ImUpZM0pAr/IFsmNtJCG9a3QBHzgSpB7uqKVNdPYskA6p2NyDCCDD6iQ==}
     engines: {node: '>=22.12'}
 
-  '@sanity/workbench@0.1.0-alpha.24':
-    resolution: {integrity: sha512-235mR37+z8eg9OQqhUwgkQ4dZnveFHczUTgW2jk81qm1pP6vMlTdEAiKpz1Tq4zU9zRfg2xck51DP1VlkVzdWA==}
+  '@sanity/workbench@0.1.0-alpha.26':
+    resolution: {integrity: sha512-jERkSQyTo1/PwxGAVybqe7JRGCo9QAEnM+T6Jj5uQvZz7X7FokD3hUas2Pht5iEkc1jECzTwhhd1P50SPd0G7A==}
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
       '@sanity/sdk': ^2.9.0
@@ -19536,10 +19536,9 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@sanity/workbench@0.1.0-alpha.24(@sanity/sdk@2.15.0)(react@19.2.7)(xstate@5.32.4)':
+  '@sanity/workbench@0.1.0-alpha.26(@sanity/sdk@2.15.0)(react@19.2.7)(xstate@5.32.4)':
     dependencies:
       '@module-federation/runtime': 2.7.0
-      '@sanity/message-protocol': 0.23.0
       '@sanity/sdk': 2.15.0(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(use-sync-external-store@1.6.0)(xstate@5.32.4)
       '@sanity/telemetry': 1.1.0(react@19.2.7)
       rxjs: 7.8.2


### PR DESCRIPTION
### Description

Bumps `@sanity/workbench` from `0.1.0-alpha.24` to `0.1.0-alpha.26` in the `sanity` package.

alpha.26 includes [workbench#313](https://github.com/sanity-io/workbench/pull/313), which drops the `development` export condition that leaked onto npm and crashed bundlers (`next dev`) when consuming embedded studios.

The dts duplicate-identifier workaround from #13572 stays in place. That workaround was added for #12511 and filters TS2300 duplicate type aliases (`Canvas`, `Workspace`, etc.) in workbench's bundled `dist/_internal.d.ts`. #313 fixed a different problem (the export condition), not the dts emit — alpha.26 still ships the duplicates, so removing the filter fails `test:exports`. Comment updated to reflect that alpha.26 is still affected. The filter can go once workbench ships a release that dedupes those identifiers.

### What to review

- Lockfile diff is limited to the workbench bump (alpha.26 drops its `@sanity/message-protocol` dependency; nothing else changes).
- The `lib-check.test.ts` filter is intentionally kept, comment updated.

### Testing

- `test:exports` still passes with the filter kept; verified locally that removing it reintroduces the 8 TS2300 errors under alpha.26.

### Notes for release

N/A – Internal tooling / dependency bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version bump with no application logic changes; retained test filters document known third-party typing issues.
> 
> **Overview**
> Bumps **`@sanity/workbench`** in the `sanity` package from `0.1.0-alpha.24` to **`0.1.0-alpha.26`**, pulling in a fix that removes a leaked `development` export condition that could break bundlers (e.g. `next dev`) when using embedded studios.
> 
> The existing **`lib-check.test.ts`** TS2300 filter for duplicate type aliases in workbench’s bundled `.d.ts` is **unchanged**; only the comment is updated to note alpha.26 is still affected. Lockfile updates are limited to the workbench version (alpha.26 no longer depends on `@sanity/message-protocol`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d21283ac8159499724ce7f4885c8dcb780e2532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->