### PR TITLE
feat(core): variant sets for generating and managing variant definitions

### DIFF
--- a/packages/sanity/src/core/variants/components/VariantSetExplainer.tsx
+++ b/packages/sanity/src/core/variants/components/VariantSetExplainer.tsx
@@ -1,0 +1,76 @@
+import {Card, Flex, Stack, Text} from '@sanity/ui'
+import {useCallback, useState} from 'react'
+
+import {Button} from '../../../ui-components'
+import {useTranslation} from '../../i18n'
+import {variantsLocaleNamespace} from '../i18n'
+
+// Shared across the overview and the create dialog: once dismissed in one place, it stays dismissed
+// everywhere for this browser. localStorage is intentional (no backend/schema for a spike).
+const STORAGE_KEY = 'sanity-studio.variants.set-explainer.dismissed'
+
+function readDismissed(): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * A dismissible, self-teaching card explaining the variant-set mental model (define dimensions →
+ * every combination becomes a definition → editing the set updates all, editing one forks it).
+ * Dismissal persists per-browser.
+ *
+ * @internal
+ */
+export function VariantSetExplainer() {
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const [dismissed, setDismissed] = useState(readDismissed)
+
+  const handleDismiss = useCallback(() => {
+    setDismissed(true)
+    try {
+      window.localStorage.setItem(STORAGE_KEY, 'true')
+    } catch {
+      // Ignore storage failures (private mode, quota) — the card just reappears next time.
+    }
+  }, [])
+
+  if (dismissed) {
+    return null
+  }
+
+  return (
+    <Card border data-testid="variant-set-explainer" padding={3} radius={2} tone="primary">
+      <Flex align="flex-start" gap={3}>
+        <Stack flex={1} space={3}>
+          <Text size={1} weight="semibold">
+            {t('explainer.title')}
+          </Text>
+          <Stack space={2}>
+            <Text muted size={1}>
+              1. {t('explainer.step1')}
+            </Text>
+            <Text muted size={1}>
+              2. {t('explainer.step2')}
+            </Text>
+            <Text muted size={1}>
+              3. {t('explainer.step3')}
+            </Text>
+          </Stack>
+        </Stack>
+        <Button
+          data-testid="variant-set-explainer-dismiss"
+          mode="bleed"
+          onClick={handleDismiss}
+          text={t('explainer.dismiss')}
+          type="button"
+        />
+      </Flex>
+    </Card>
+  )
+}

--- a/packages/sanity/src/core/variants/components/__tests__/VariantSetExplainer.test.tsx
+++ b/packages/sanity/src/core/variants/components/__tests__/VariantSetExplainer.test.tsx
@@ -1,0 +1,46 @@
+import {render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {beforeEach, describe, expect, it} from 'vitest'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {variantsUsEnglishLocaleBundle} from '../../i18n'
+import {VariantSetExplainer} from '../VariantSetExplainer'
+
+const STORAGE_KEY = 'sanity-studio.variants.set-explainer.dismissed'
+
+describe('VariantSetExplainer', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  const renderExplainer = async () => {
+    const wrapper = await createTestProvider({resources: [variantsUsEnglishLocaleBundle]})
+    return render(<VariantSetExplainer />, {wrapper})
+  }
+
+  it('renders the explainer by default', async () => {
+    await renderExplainer()
+    expect(await screen.findByTestId('variant-set-explainer')).toBeInTheDocument()
+    expect(screen.getByText('How variant sets work')).toBeInTheDocument()
+  })
+
+  it('dismisses and persists the choice to localStorage', async () => {
+    const user = userEvent.setup()
+    await renderExplainer()
+
+    await user.click(await screen.findByTestId('variant-set-explainer-dismiss'))
+
+    expect(screen.queryByTestId('variant-set-explainer')).not.toBeInTheDocument()
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('true')
+  })
+
+  it('stays hidden when already dismissed', async () => {
+    window.localStorage.setItem(STORAGE_KEY, 'true')
+    await renderExplainer()
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('loading-block')).not.toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('variant-set-explainer')).not.toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/core/variants/components/dialog/CreateVariantSetDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/CreateVariantSetDialog.tsx
@@ -1,0 +1,115 @@
+import {Box, Card, Flex, Text} from '@sanity/ui'
+import {type FormEvent, useCallback, useMemo, useState} from 'react'
+
+import {Button, Dialog} from '../../../../ui-components'
+import {useTranslation} from '../../../i18n'
+import {variantsLocaleNamespace} from '../../i18n'
+import {
+  countVariantSetPermutations,
+  type VariantSetDimension,
+} from '../../util/variantSetPermutations'
+import {VariantSetForm} from './VariantSetForm'
+
+export interface VariantSetInput {
+  name: string
+  dimensions: VariantSetDimension[]
+}
+
+interface CreateVariantSetDialogProps {
+  onCancel: () => void
+  onSubmit: (input: VariantSetInput) => void
+}
+
+export function CreateVariantSetDialog(props: CreateVariantSetDialogProps): React.JSX.Element {
+  const {onCancel, onSubmit} = props
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const [name, setName] = useState('')
+  const [dimensions, setDimensions] = useState<VariantSetDimension[]>([])
+  const [dimensionsInvalid, setDimensionsInvalid] = useState(false)
+  const [showValidation, setShowValidation] = useState(false)
+
+  const permutationCount = useMemo(() => countVariantSetPermutations(dimensions), [dimensions])
+  const canGenerate = Boolean(name.trim()) && permutationCount > 0 && !dimensionsInvalid
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+
+      if (!canGenerate) {
+        setShowValidation(true)
+        return
+      }
+
+      // TODO(variant-sets step 3): generate one variant definition per permutation and persist
+      // them, each tagged with a back-reference to this set. Step 2 delivers the key/value input
+      // and the live permutation preview only — generation is intentionally not wired yet.
+      onSubmit({name: name.trim(), dimensions})
+    },
+    [canGenerate, dimensions, name, onSubmit],
+  )
+
+  return (
+    <Dialog
+      __unstable_autoFocus={false}
+      header={t('dialog.create-set.title')}
+      id="create-variant-set-dialog"
+      onClickOutside={onCancel}
+      onClose={onCancel}
+      padding={false}
+      width={1}
+    >
+      <Card borderTop padding={4}>
+        <form onSubmit={handleSubmit}>
+          <Box paddingBottom={4}>
+            <VariantSetForm
+              name={name}
+              onDimensionsChange={setDimensions}
+              onDimensionsValidityChange={setDimensionsInvalid}
+              onNameChange={setName}
+              showValidation={showValidation}
+            />
+          </Box>
+
+          <Card
+            border
+            padding={3}
+            radius={2}
+            tone={permutationCount > 0 ? 'primary' : 'transparent'}
+          >
+            <Text data-testid="variant-set-preview" muted={permutationCount === 0} size={1}>
+              {permutationCount > 0
+                ? t(
+                    permutationCount === 1
+                      ? 'dialog.create-set.preview.count_one'
+                      : 'dialog.create-set.preview.count_other',
+                    {count: permutationCount},
+                  )
+                : t('dialog.create-set.preview.empty')}
+            </Text>
+          </Card>
+
+          <Flex gap={2} justify="flex-end" paddingTop={5}>
+            <Button
+              mode="ghost"
+              onClick={onCancel}
+              text={t('dialog.create-set.action.cancel')}
+              type="button"
+            />
+            <Button
+              data-testid="generate-variant-set-button"
+              disabled={!canGenerate}
+              size="large"
+              text={t(
+                permutationCount === 1
+                  ? 'dialog.create-set.action.generate_one'
+                  : 'dialog.create-set.action.generate_other',
+                {count: permutationCount},
+              )}
+              type="submit"
+            />
+          </Flex>
+        </form>
+      </Card>
+    </Dialog>
+  )
+}

--- a/packages/sanity/src/core/variants/components/dialog/CreateVariantSetDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/CreateVariantSetDialog.tsx
@@ -17,6 +17,7 @@ import {
   countVariantSetPermutations,
   type VariantSetDimension,
 } from '../../util/variantSetPermutations'
+import {VariantSetExplainer} from '../VariantSetExplainer'
 import {VariantSetForm} from './VariantSetForm'
 
 // Above this many permutations, generation asks for an extra confirmation so an accidental
@@ -200,6 +201,9 @@ export function CreateVariantSetDialog(props: CreateVariantSetDialogProps): Reac
     >
       <Card borderTop padding={4}>
         <form onSubmit={handleSubmit}>
+          <Box paddingBottom={4}>
+            <VariantSetExplainer />
+          </Box>
           <Box paddingBottom={4}>
             <VariantSetForm
               key={formKey}

--- a/packages/sanity/src/core/variants/components/dialog/CreateVariantSetDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/CreateVariantSetDialog.tsx
@@ -19,6 +19,10 @@ import {
 } from '../../util/variantSetPermutations'
 import {VariantSetForm} from './VariantSetForm'
 
+// Above this many permutations, generation asks for an extra confirmation so an accidental
+// combinatorial blow-up (a stray dimension) isn't created in one click.
+const LARGE_SET_THRESHOLD = 100
+
 interface CreateVariantSetDialogProps {
   onCancel: () => void
   onDone: () => void
@@ -36,6 +40,7 @@ export function CreateVariantSetDialog(props: CreateVariantSetDialogProps): Reac
   const [showValidation, setShowValidation] = useState(false)
   const [isGenerating, setIsGenerating] = useState(false)
   const [generated, setGenerated] = useState<EditableSystemVariant[] | null>(null)
+  const [armedForLargeSet, setArmedForLargeSet] = useState(false)
   // Seed + remount key so importing a JSON file can repopulate the (locally-stateful) form.
   const [formSeed, setFormSeed] = useState<VariantSetDimension[] | undefined>(undefined)
   const [formKey, setFormKey] = useState(0)
@@ -43,6 +48,13 @@ export function CreateVariantSetDialog(props: CreateVariantSetDialogProps): Reac
 
   const permutationCount = useMemo(() => countVariantSetPermutations(dimensions), [dimensions])
   const canGenerate = Boolean(name.trim()) && permutationCount > 0 && !dimensionsInvalid
+  const isLargeSet = permutationCount > LARGE_SET_THRESHOLD
+  const needsConfirmation = isLargeSet && !armedForLargeSet
+
+  const handleDimensionsChange = useCallback((next: VariantSetDimension[]) => {
+    setDimensions(next)
+    setArmedForLargeSet(false) // any edit re-arms the guardrail
+  }, [])
 
   const handleExport = useCallback(() => {
     const filename = `${name.trim() || 'variant-set'}.json`
@@ -68,6 +80,7 @@ export function CreateVariantSetDialog(props: CreateVariantSetDialogProps): Reac
       }
       setDimensions(result.dimensions)
       setDimensionsInvalid(false)
+      setArmedForLargeSet(false)
       setFormSeed(result.dimensions)
       setFormKey((current) => current + 1)
     },
@@ -84,6 +97,11 @@ export function CreateVariantSetDialog(props: CreateVariantSetDialogProps): Reac
 
       if (!canGenerate) {
         setShowValidation(true)
+        return
+      }
+
+      if (needsConfirmation) {
+        setArmedForLargeSet(true) // first click on a large set only arms; the next click generates
         return
       }
 
@@ -107,7 +125,7 @@ export function CreateVariantSetDialog(props: CreateVariantSetDialogProps): Reac
         setIsGenerating(false)
       }
     },
-    [canGenerate, createVariant, dimensions, isGenerating, name, t, toast],
+    [canGenerate, createVariant, dimensions, isGenerating, name, needsConfirmation, t, toast],
   )
 
   if (generated) {
@@ -187,7 +205,7 @@ export function CreateVariantSetDialog(props: CreateVariantSetDialogProps): Reac
               key={formKey}
               initialDimensions={formSeed}
               name={name}
-              onDimensionsChange={setDimensions}
+              onDimensionsChange={handleDimensionsChange}
               onDimensionsValidityChange={setDimensionsInvalid}
               onNameChange={setName}
               showValidation={showValidation}
@@ -259,6 +277,16 @@ export function CreateVariantSetDialog(props: CreateVariantSetDialogProps): Reac
             </Text>
           </Card>
 
+          {isLargeSet && (
+            <Box paddingTop={3}>
+              <Card border padding={3} radius={2} tone="caution">
+                <Text data-testid="variant-set-large-warning" size={1}>
+                  {t('dialog.create-set.large-set.warning', {count: permutationCount})}
+                </Text>
+              </Card>
+            </Box>
+          )}
+
           <Flex gap={2} justify="flex-end" paddingTop={5}>
             <Button
               disabled={isGenerating}
@@ -272,12 +300,17 @@ export function CreateVariantSetDialog(props: CreateVariantSetDialogProps): Reac
               disabled={!canGenerate || isGenerating}
               loading={isGenerating}
               size="large"
-              text={t(
-                permutationCount === 1
-                  ? 'dialog.create-set.action.generate_one'
-                  : 'dialog.create-set.action.generate_other',
-                {count: permutationCount},
-              )}
+              text={
+                armedForLargeSet
+                  ? t('dialog.create-set.action.generate-confirm')
+                  : t(
+                      permutationCount === 1
+                        ? 'dialog.create-set.action.generate_one'
+                        : 'dialog.create-set.action.generate_other',
+                      {count: permutationCount},
+                    )
+              }
+              tone={isLargeSet ? 'caution' : 'default'}
               type="submit"
             />
           </Flex>

--- a/packages/sanity/src/core/variants/components/dialog/CreateVariantSetDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/CreateVariantSetDialog.tsx
@@ -1,5 +1,8 @@
+import {DownloadIcon} from '@sanity/icons/Download'
+import {SyncIcon} from '@sanity/icons/Sync'
+import {UploadIcon} from '@sanity/icons/Upload'
 import {Box, Card, Flex, Stack, Text, useToast} from '@sanity/ui'
-import {type FormEvent, useCallback, useMemo, useState} from 'react'
+import {type ChangeEvent, type FormEvent, useCallback, useMemo, useRef, useState} from 'react'
 
 import {Button, Dialog} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
@@ -8,6 +11,8 @@ import {useVariantOperations} from '../../store/useVariantOperations'
 import {getVariantConditionsText} from '../../tool/util'
 import {type EditableSystemVariant} from '../../types'
 import {buildVariantSetDefinitions} from '../../util/buildVariantSetDefinitions'
+import {downloadTextFile} from '../../util/downloadTextFile'
+import {parseVariantSetJson, serializeVariantSet} from '../../util/variantSetJson'
 import {
   countVariantSetPermutations,
   type VariantSetDimension,
@@ -31,9 +36,43 @@ export function CreateVariantSetDialog(props: CreateVariantSetDialogProps): Reac
   const [showValidation, setShowValidation] = useState(false)
   const [isGenerating, setIsGenerating] = useState(false)
   const [generated, setGenerated] = useState<EditableSystemVariant[] | null>(null)
+  // Seed + remount key so importing a JSON file can repopulate the (locally-stateful) form.
+  const [formSeed, setFormSeed] = useState<VariantSetDimension[] | undefined>(undefined)
+  const [formKey, setFormKey] = useState(0)
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
 
   const permutationCount = useMemo(() => countVariantSetPermutations(dimensions), [dimensions])
   const canGenerate = Boolean(name.trim()) && permutationCount > 0 && !dimensionsInvalid
+
+  const handleExport = useCallback(() => {
+    const filename = `${name.trim() || 'variant-set'}.json`
+    downloadTextFile(filename, serializeVariantSet({name, dimensions}))
+  }, [dimensions, name])
+
+  const handleImportFile = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.currentTarget.files?.[0]
+      event.currentTarget.value = '' // allow re-importing the same file
+      if (!file) {
+        return
+      }
+
+      const result = parseVariantSetJson(await file.text())
+      if (!result.ok) {
+        toast.push({closable: true, status: 'error', title: t('dialog.create-set.import.error')})
+        return
+      }
+
+      if (result.name) {
+        setName(result.name)
+      }
+      setDimensions(result.dimensions)
+      setDimensionsInvalid(false)
+      setFormSeed(result.dimensions)
+      setFormKey((current) => current + 1)
+    },
+    [t, toast],
+  )
 
   const handleSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
@@ -145,6 +184,8 @@ export function CreateVariantSetDialog(props: CreateVariantSetDialogProps): Reac
         <form onSubmit={handleSubmit}>
           <Box paddingBottom={4}>
             <VariantSetForm
+              key={formKey}
+              initialDimensions={formSeed}
               name={name}
               onDimensionsChange={setDimensions}
               onDimensionsValidityChange={setDimensionsInvalid}
@@ -152,6 +193,53 @@ export function CreateVariantSetDialog(props: CreateVariantSetDialogProps): Reac
               showValidation={showValidation}
             />
           </Box>
+
+          <input
+            accept="application/json,.json"
+            data-testid="variant-set-file-input"
+            onChange={handleImportFile}
+            ref={fileInputRef}
+            style={{display: 'none'}}
+            type="file"
+          />
+
+          <Flex gap={2} paddingBottom={4} wrap="wrap">
+            <Button
+              data-testid="import-json-button"
+              icon={UploadIcon}
+              mode="ghost"
+              onClick={() => fileInputRef.current?.click()}
+              text={t('dialog.create-set.action.import-json')}
+              type="button"
+            />
+            <Button
+              data-testid="export-json-button"
+              disabled={permutationCount === 0}
+              icon={DownloadIcon}
+              mode="ghost"
+              onClick={handleExport}
+              text={t('dialog.create-set.action.export-json')}
+              type="button"
+            />
+            <Button
+              data-testid="import-cdp-button"
+              disabled
+              icon={UploadIcon}
+              mode="ghost"
+              text={t('dialog.create-set.action.import-cdp')}
+              tooltipProps={{content: t('dialog.create-set.cdp.coming-soon')}}
+              type="button"
+            />
+            <Button
+              data-testid="sync-cdp-button"
+              disabled
+              icon={SyncIcon}
+              mode="ghost"
+              text={t('dialog.create-set.action.sync-cdp')}
+              tooltipProps={{content: t('dialog.create-set.cdp.coming-soon')}}
+              type="button"
+            />
+          </Flex>
 
           <Card
             border

--- a/packages/sanity/src/core/variants/components/dialog/CreateVariantSetDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/CreateVariantSetDialog.tsx
@@ -1,60 +1,143 @@
-import {Box, Card, Flex, Text} from '@sanity/ui'
+import {Box, Card, Flex, Stack, Text, useToast} from '@sanity/ui'
 import {type FormEvent, useCallback, useMemo, useState} from 'react'
 
 import {Button, Dialog} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
 import {variantsLocaleNamespace} from '../../i18n'
+import {useVariantOperations} from '../../store/useVariantOperations'
+import {getVariantConditionsText} from '../../tool/util'
+import {type EditableSystemVariant} from '../../types'
+import {buildVariantSetDefinitions} from '../../util/buildVariantSetDefinitions'
 import {
   countVariantSetPermutations,
   type VariantSetDimension,
 } from '../../util/variantSetPermutations'
 import {VariantSetForm} from './VariantSetForm'
 
-export interface VariantSetInput {
-  name: string
-  dimensions: VariantSetDimension[]
-}
-
 interface CreateVariantSetDialogProps {
   onCancel: () => void
-  onSubmit: (input: VariantSetInput) => void
+  onDone: () => void
 }
 
 export function CreateVariantSetDialog(props: CreateVariantSetDialogProps): React.JSX.Element {
-  const {onCancel, onSubmit} = props
+  const {onCancel, onDone} = props
   const {t} = useTranslation(variantsLocaleNamespace)
+  const toast = useToast()
+  const {createVariant} = useVariantOperations()
+
   const [name, setName] = useState('')
   const [dimensions, setDimensions] = useState<VariantSetDimension[]>([])
   const [dimensionsInvalid, setDimensionsInvalid] = useState(false)
   const [showValidation, setShowValidation] = useState(false)
+  const [isGenerating, setIsGenerating] = useState(false)
+  const [generated, setGenerated] = useState<EditableSystemVariant[] | null>(null)
 
   const permutationCount = useMemo(() => countVariantSetPermutations(dimensions), [dimensions])
   const canGenerate = Boolean(name.trim()) && permutationCount > 0 && !dimensionsInvalid
 
   const handleSubmit = useCallback(
-    (event: FormEvent<HTMLFormElement>) => {
+    async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault()
+
+      if (isGenerating) {
+        return
+      }
 
       if (!canGenerate) {
         setShowValidation(true)
         return
       }
 
-      // TODO(variant-sets step 3): generate one variant definition per permutation and persist
-      // them, each tagged with a back-reference to this set. Step 2 delivers the key/value input
-      // and the live permutation preview only — generation is intentionally not wired yet.
-      onSubmit({name: name.trim(), dimensions})
+      const {definitions} = buildVariantSetDefinitions({name, dimensions})
+      setIsGenerating(true)
+
+      try {
+        // No batch action exists, so each generated definition is created individually. This is
+        // not transactional: if one fails, earlier ones remain. Acceptable for now, since the
+        // permutation preview discourages very large sets.
+        await Promise.all(definitions.map((definition) => createVariant(definition)))
+        setGenerated(definitions)
+      } catch (error) {
+        console.error(error)
+        toast.push({
+          closable: true,
+          status: 'error',
+          title: t('dialog.create-set.error.title'),
+        })
+      } finally {
+        setIsGenerating(false)
+      }
     },
-    [canGenerate, dimensions, name, onSubmit],
+    [canGenerate, createVariant, dimensions, isGenerating, name, t, toast],
   )
+
+  if (generated) {
+    return (
+      <Dialog
+        __unstable_autoFocus={false}
+        header={t('dialog.create-set.title')}
+        id="create-variant-set-dialog"
+        onClickOutside={onDone}
+        onClose={onDone}
+        padding={false}
+        width={1}
+      >
+        <Card borderTop padding={4}>
+          <Stack space={4}>
+            <Stack space={2}>
+              <Text data-testid="variant-set-result-title" size={1} weight="semibold">
+                {t(
+                  generated.length === 1
+                    ? 'dialog.create-set.result.title_one'
+                    : 'dialog.create-set.result.title_other',
+                  {count: generated.length},
+                )}
+              </Text>
+              <Text muted size={1}>
+                {t('dialog.create-set.result.description')}
+              </Text>
+            </Stack>
+
+            <Card border padding={1} radius={2}>
+              <Box style={{maxHeight: 280, overflowY: 'auto'}}>
+                <Stack data-testid="variant-set-result-list" space={1}>
+                  {generated.map((definition) => (
+                    <Card key={definition._id} padding={3} radius={2}>
+                      <Stack space={2}>
+                        <Text size={1} weight="medium">
+                          {definition.metadata?.title}
+                        </Text>
+                        <Text muted size={1}>
+                          {getVariantConditionsText(definition.conditions)}
+                        </Text>
+                      </Stack>
+                    </Card>
+                  ))}
+                </Stack>
+              </Box>
+            </Card>
+
+            <Flex justify="flex-end">
+              <Button
+                data-testid="variant-set-done-button"
+                onClick={onDone}
+                size="large"
+                text={t('dialog.create-set.action.done')}
+              />
+            </Flex>
+          </Stack>
+        </Card>
+      </Dialog>
+    )
+  }
 
   return (
     <Dialog
       __unstable_autoFocus={false}
       header={t('dialog.create-set.title')}
       id="create-variant-set-dialog"
-      onClickOutside={onCancel}
-      onClose={onCancel}
+      onClickOutside={isGenerating ? undefined : onCancel}
+      onClose={isGenerating ? undefined : onCancel}
       padding={false}
       width={1}
     >
@@ -90,6 +173,7 @@ export function CreateVariantSetDialog(props: CreateVariantSetDialogProps): Reac
 
           <Flex gap={2} justify="flex-end" paddingTop={5}>
             <Button
+              disabled={isGenerating}
               mode="ghost"
               onClick={onCancel}
               text={t('dialog.create-set.action.cancel')}
@@ -97,7 +181,8 @@ export function CreateVariantSetDialog(props: CreateVariantSetDialogProps): Reac
             />
             <Button
               data-testid="generate-variant-set-button"
-              disabled={!canGenerate}
+              disabled={!canGenerate || isGenerating}
+              loading={isGenerating}
               size="large"
               text={t(
                 permutationCount === 1

--- a/packages/sanity/src/core/variants/components/dialog/DeleteVariantSetDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/DeleteVariantSetDialog.tsx
@@ -1,0 +1,118 @@
+import {Card, Stack, Text, useToast} from '@sanity/ui'
+import {useCallback, useMemo, useState} from 'react'
+
+import {Dialog} from '../../../../ui-components'
+import {useTranslation} from '../../../i18n'
+import {useVariantsDocumentCounts} from '../../hooks/useVariantsDocumentCounts'
+import {variantsLocaleNamespace} from '../../i18n'
+import {useAllVariants} from '../../store/useAllVariants'
+import {useVariantOperations} from '../../store/useVariantOperations'
+import {getVariantSetReference, type VariantSetReference} from '../../util/variantSet'
+import {planVariantSetDeletion} from '../../util/variantSetDelete'
+
+interface DeleteVariantSetDialogProps {
+  setReference: VariantSetReference
+  onClose: () => void
+  onDone: () => void
+}
+
+export function DeleteVariantSetDialog(props: DeleteVariantSetDialogProps): React.JSX.Element {
+  const {setReference, onClose, onDone} = props
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const toast = useToast()
+  const {deleteVariant, updateVariant} = useVariantOperations()
+  const {data: allVariants, loading} = useAllVariants()
+  const {data: documentCounts} = useVariantsDocumentCounts()
+
+  const children = useMemo(
+    () => allVariants.filter((variant) => getVariantSetReference(variant)?.id === setReference.id),
+    [allVariants, setReference.id],
+  )
+
+  const plan = useMemo(
+    () =>
+      planVariantSetDeletion({
+        setReference,
+        children,
+        documentCountById: documentCounts ?? {},
+      }),
+    [setReference, children, documentCounts],
+  )
+
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const ready = !loading && children.length > 0
+  const hasWork = plan.deleteIds.length > 0 || plan.detaches.length > 0
+
+  const handleConfirm = useCallback(async () => {
+    if (!hasWork || isDeleting) {
+      return
+    }
+
+    setIsDeleting(true)
+
+    try {
+      // Not transactional (no batch action); on partial failure some changes will have landed.
+      await Promise.all([
+        ...plan.deleteIds.map((id) => deleteVariant(id)),
+        ...plan.detaches.map((definition) => updateVariant(definition)),
+      ])
+      onDone()
+    } catch (error) {
+      console.error(error)
+      toast.push({closable: true, status: 'error', title: t('dialog.delete-set.error.title')})
+      setIsDeleting(false)
+    }
+  }, [deleteVariant, hasWork, isDeleting, onDone, plan, t, toast, updateVariant])
+
+  return (
+    <Dialog
+      data-testid="delete-variant-set-dialog"
+      footer={{
+        cancelButton: {
+          disabled: isDeleting,
+        },
+        confirmButton: {
+          disabled: isDeleting || !ready || !hasWork,
+          loading: isDeleting,
+          onClick: handleConfirm,
+          text: t('dialog.delete-set.action.confirm'),
+          tone: 'critical',
+        },
+      }}
+      header={t('dialog.delete-set.title')}
+      id="delete-variant-set-dialog"
+      onClose={isDeleting ? undefined : onClose}
+    >
+      <Stack space={4}>
+        <Text muted size={1}>
+          {t('dialog.delete-set.description', {name: setReference.name})}
+        </Text>
+
+        <Stack space={2}>
+          <Text data-testid="delete-set-summary" size={1}>
+            {t(
+              plan.deleteIds.length === 1
+                ? 'dialog.delete-set.summary.delete_one'
+                : 'dialog.delete-set.summary.delete_other',
+              {count: plan.deleteIds.length},
+            )}
+          </Text>
+        </Stack>
+
+        {plan.retainedCount > 0 && (
+          <Card border padding={3} radius={2} tone="caution">
+            <Text data-testid="delete-set-retained-warning" size={1}>
+              {t(
+                plan.retainedCount === 1
+                  ? 'dialog.delete-set.warning.retained_one'
+                  : 'dialog.delete-set.warning.retained_other',
+                {count: plan.retainedCount},
+              )}
+            </Text>
+          </Card>
+        )}
+      </Stack>
+    </Dialog>
+  )
+}

--- a/packages/sanity/src/core/variants/components/dialog/EditVariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/EditVariantDialog.tsx
@@ -4,6 +4,7 @@ import {useTranslation} from '../../../i18n'
 import {variantsLocaleNamespace} from '../../i18n'
 import {useVariantOperations} from '../../store/useVariantOperations'
 import {type EditableSystemVariant, type SystemVariant} from '../../types'
+import {forkVariantFromSetIfConditionsChanged} from '../../util/variantSet'
 import {VariantDialog} from './VariantDialog'
 
 interface EditVariantDialogProps {
@@ -30,10 +31,12 @@ export function EditVariantDialog(props: EditVariantDialogProps): React.JSX.Elem
 
   const handleSubmit = useCallback(
     async (variant: EditableSystemVariant) => {
-      await updateVariant(variant)
+      // Editing a set member's conditions detaches it from the set so the edit can't drift the
+      // canonical set; title/description-only edits keep membership.
+      await updateVariant(forkVariantFromSetIfConditionsChanged(initialVariant, variant))
       onSubmit()
     },
-    [onSubmit, updateVariant],
+    [initialVariant, onSubmit, updateVariant],
   )
 
   return (

--- a/packages/sanity/src/core/variants/components/dialog/EditVariantSetDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/EditVariantSetDialog.tsx
@@ -1,0 +1,201 @@
+import {Box, Card, Flex, Stack, Text, useToast} from '@sanity/ui'
+import {useCallback, useMemo, useState} from 'react'
+
+import {Button, Dialog} from '../../../../ui-components'
+import {useTranslation} from '../../../i18n'
+import {useVariantsDocumentCounts} from '../../hooks/useVariantsDocumentCounts'
+import {variantsLocaleNamespace} from '../../i18n'
+import {useAllVariants} from '../../store/useAllVariants'
+import {useVariantOperations} from '../../store/useVariantOperations'
+import {getVariantSetReference, type VariantSetReference} from '../../util/variantSet'
+import {
+  type DimensionEdit,
+  planVariantSetEdit,
+  reconstructVariantSetDimensions,
+} from '../../util/variantSetEdit'
+import {EditVariantSetForm} from './EditVariantSetForm'
+
+interface EditVariantSetDialogProps {
+  setReference: VariantSetReference
+  onCancel: () => void
+  onDone: () => void
+}
+
+export function EditVariantSetDialog(props: EditVariantSetDialogProps): React.JSX.Element {
+  const {setReference, onCancel, onDone} = props
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const toast = useToast()
+  const {createVariant, updateVariant, deleteVariant} = useVariantOperations()
+  const {data: allVariants, loading} = useAllVariants()
+  const {data: documentCounts} = useVariantsDocumentCounts()
+
+  const children = useMemo(
+    () => allVariants.filter((variant) => getVariantSetReference(variant)?.id === setReference.id),
+    [allVariants, setReference.id],
+  )
+  const initialDimensions = useMemo(() => reconstructVariantSetDimensions(children), [children])
+
+  const [edits, setEdits] = useState<DimensionEdit[]>([])
+  const [isApplying, setIsApplying] = useState(false)
+
+  const plan = useMemo(
+    () =>
+      planVariantSetEdit({
+        setReference,
+        children,
+        documentCountById: documentCounts ?? {},
+        edits,
+      }),
+    [setReference, children, documentCounts, edits],
+  )
+
+  const changeCount = plan.updates.length + plan.creates.length + plan.deletes.length
+  const hasChanges = changeCount > 0
+  const ready = !loading && children.length > 0
+
+  const handleApply = useCallback(async () => {
+    if (!hasChanges || isApplying) {
+      return
+    }
+
+    setIsApplying(true)
+
+    try {
+      // Not transactional (no batch action); on partial failure some changes will have landed.
+      await Promise.all([
+        ...plan.updates.map((definition) => updateVariant(definition)),
+        ...plan.creates.map((definition) => createVariant(definition)),
+        ...plan.deletes.map((deletion) => deleteVariant(deletion.id)),
+      ])
+      onDone()
+    } catch (error) {
+      console.error(error)
+      toast.push({closable: true, status: 'error', title: t('dialog.edit-set.error.title')})
+      setIsApplying(false)
+    }
+  }, [createVariant, deleteVariant, hasChanges, isApplying, onDone, plan, t, toast, updateVariant])
+
+  const previewLines = useMemo(() => {
+    const lines: string[] = []
+    if (plan.updates.length > 0) {
+      lines.push(
+        t(
+          plan.updates.length === 1
+            ? 'dialog.edit-set.preview.update_one'
+            : 'dialog.edit-set.preview.update_other',
+          {count: plan.updates.length},
+        ),
+      )
+    }
+    if (plan.creates.length > 0) {
+      lines.push(
+        t(
+          plan.creates.length === 1
+            ? 'dialog.edit-set.preview.create_one'
+            : 'dialog.edit-set.preview.create_other',
+          {count: plan.creates.length},
+        ),
+      )
+    }
+    if (plan.deletes.length > 0) {
+      lines.push(
+        t(
+          plan.deletes.length === 1
+            ? 'dialog.edit-set.preview.delete_one'
+            : 'dialog.edit-set.preview.delete_other',
+          {count: plan.deletes.length},
+        ),
+      )
+    }
+    return lines
+  }, [plan.creates.length, plan.deletes.length, plan.updates.length, t])
+
+  const blockedValues = plan.blockedRemovals.map((removal) => removal.value).join(', ')
+  const conflictValues = plan.renameConflicts.map((conflict) => conflict.to).join(', ')
+
+  return (
+    <Dialog
+      __unstable_autoFocus={false}
+      header={t('dialog.edit-set.title')}
+      id="edit-variant-set-dialog"
+      onClickOutside={isApplying ? undefined : onCancel}
+      onClose={isApplying ? undefined : onCancel}
+      padding={false}
+      width={1}
+    >
+      <Card borderTop padding={4}>
+        <Stack space={4}>
+          <Text muted size={1}>
+            {t('dialog.edit-set.description')}
+          </Text>
+
+          {ready ? (
+            <EditVariantSetForm
+              key={setReference.id}
+              initialDimensions={initialDimensions}
+              onChange={setEdits}
+            />
+          ) : (
+            <Box paddingY={4}>
+              <Text muted size={1}>
+                {t('detail.loading')}
+              </Text>
+            </Box>
+          )}
+
+          <Stack space={3}>
+            <Card border padding={3} radius={2} tone={hasChanges ? 'primary' : 'transparent'}>
+              <Stack space={2}>
+                {previewLines.length > 0 ? (
+                  previewLines.map((line) => (
+                    <Text key={line} data-testid="edit-set-preview-line" size={1}>
+                      {line}
+                    </Text>
+                  ))
+                ) : (
+                  <Text data-testid="edit-set-preview-line" muted size={1}>
+                    {t('dialog.edit-set.preview.none')}
+                  </Text>
+                )}
+              </Stack>
+            </Card>
+
+            {blockedValues && (
+              <Card border padding={3} radius={2} tone="caution">
+                <Text data-testid="edit-set-blocked-warning" size={1}>
+                  {t('dialog.edit-set.warning.blocked', {values: blockedValues})}
+                </Text>
+              </Card>
+            )}
+            {conflictValues && (
+              <Card border padding={3} radius={2} tone="caution">
+                <Text data-testid="edit-set-conflict-warning" size={1}>
+                  {t('dialog.edit-set.warning.conflict', {values: conflictValues})}
+                </Text>
+              </Card>
+            )}
+          </Stack>
+
+          <Flex gap={2} justify="flex-end">
+            <Button
+              disabled={isApplying}
+              mode="ghost"
+              onClick={onCancel}
+              text={t('dialog.edit-set.action.cancel')}
+              type="button"
+            />
+            <Button
+              data-testid="edit-set-apply-button"
+              disabled={!hasChanges || isApplying}
+              loading={isApplying}
+              onClick={handleApply}
+              size="large"
+              text={t('dialog.edit-set.action.apply')}
+              type="button"
+            />
+          </Flex>
+        </Stack>
+      </Card>
+    </Dialog>
+  )
+}

--- a/packages/sanity/src/core/variants/components/dialog/EditVariantSetForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/EditVariantSetForm.tsx
@@ -1,14 +1,12 @@
-import {AddIcon} from '@sanity/icons/Add'
-import {TrashIcon} from '@sanity/icons/Trash'
-import {Box, Flex, Stack, Text, TextInput} from '@sanity/ui'
+import {Stack, Text} from '@sanity/ui'
 import {randomKey} from '@sanity/util/content'
-import {useCallback, useMemo, useState} from 'react'
+import {useCallback, useState} from 'react'
 
-import {Button} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
 import {variantsLocaleNamespace} from '../../i18n'
 import {type DimensionEdit} from '../../util/variantSetEdit'
 import {type VariantSetDimension} from '../../util/variantSetPermutations'
+import {type ValueChip, ValueChipsInput} from './ValueChipsInput'
 
 interface ValueRow {
   id: string
@@ -24,11 +22,7 @@ interface KeyRow {
 function seedRows(dimensions: VariantSetDimension[]): KeyRow[] {
   return dimensions.map((dimension) => ({
     key: dimension.key,
-    values: dimension.values.map((value) => ({
-      id: randomKey(12),
-      originalValue: value,
-      value,
-    })),
+    values: dimension.values.map((value) => ({id: randomKey(12), originalValue: value, value})),
   }))
 }
 
@@ -47,104 +41,44 @@ export function EditVariantSetForm(props: {
   const {t} = useTranslation(variantsLocaleNamespace)
   const [rows, setRows] = useState<KeyRow[]>(() => seedRows(initialDimensions))
 
-  const update = useCallback(
-    (nextRows: KeyRow[]) => {
+  const handleValuesChange = useCallback(
+    (keyIndex: number, chips: ValueChip[]) => {
+      const nextRows = rows.map((row, index) => {
+        if (index !== keyIndex) {
+          return row
+        }
+        // Preserve each value's original for rename detection; chips added in the editor have none.
+        const originalById = new Map(row.values.map((value) => [value.id, value.originalValue]))
+        return {
+          ...row,
+          values: chips.map((chip) => ({
+            id: chip.id,
+            originalValue: originalById.get(chip.id) ?? null,
+            value: chip.value,
+          })),
+        }
+      })
+
       setRows(nextRows)
       onChange(toEdits(nextRows))
     },
-    [onChange],
+    [rows, onChange],
   )
-
-  const handleValueChange = useCallback(
-    (keyIndex: number, valueId: string, nextValue: string) => {
-      update(
-        rows.map((row, index) =>
-          index === keyIndex
-            ? {
-                ...row,
-                values: row.values.map((value) =>
-                  value.id === valueId ? {...value, value: nextValue} : value,
-                ),
-              }
-            : row,
-        ),
-      )
-    },
-    [rows, update],
-  )
-
-  const handleRemoveValue = useCallback(
-    (keyIndex: number, valueId: string) => {
-      update(
-        rows.map((row, index) =>
-          index === keyIndex
-            ? {...row, values: row.values.filter((value) => value.id !== valueId)}
-            : row,
-        ),
-      )
-    },
-    [rows, update],
-  )
-
-  const handleAddValue = useCallback(
-    (keyIndex: number) => {
-      update(
-        rows.map((row, index) =>
-          index === keyIndex
-            ? {...row, values: [...row.values, {id: randomKey(12), originalValue: null, value: ''}]}
-            : row,
-        ),
-      )
-    },
-    [rows, update],
-  )
-
-  const keySpacing = useMemo(() => (rows.length > 1 ? 4 : 3), [rows.length])
 
   return (
-    <Stack space={keySpacing}>
+    <Stack space={4}>
       {rows.map((row, keyIndex) => (
         <Stack key={row.key} space={3}>
           <Text size={1} weight="semibold">
             {row.key}
           </Text>
-          <Stack space={2}>
-            {row.values.map((value) => (
-              <Flex key={value.id} align="center" gap={2}>
-                <Box flex={1}>
-                  <TextInput
-                    aria-label={row.key}
-                    data-testid="edit-set-value-input"
-                    fontSize={1}
-                    onChange={(event) =>
-                      handleValueChange(keyIndex, value.id, event.currentTarget.value)
-                    }
-                    value={value.value}
-                  />
-                </Box>
-                <Button
-                  data-testid="edit-set-remove-value"
-                  disabled={row.values.length === 1}
-                  icon={TrashIcon}
-                  mode="bleed"
-                  onClick={() => handleRemoveValue(keyIndex, value.id)}
-                  tone="critical"
-                  tooltipProps={{content: t('dialog.edit-set.remove-value')}}
-                  type="button"
-                />
-              </Flex>
-            ))}
-          </Stack>
-          <Flex>
-            <Button
-              data-testid="edit-set-add-value"
-              icon={AddIcon}
-              mode="ghost"
-              onClick={() => handleAddValue(keyIndex)}
-              text={t('dialog.edit-set.add-value')}
-              type="button"
-            />
-          </Flex>
+          <ValueChipsInput
+            addPlaceholder={t('dialog.edit-set.add-value')}
+            ariaLabel={row.key}
+            chips={row.values.map((value) => ({id: value.id, value: value.value}))}
+            onChange={(chips) => handleValuesChange(keyIndex, chips)}
+            removeLabel={t('dialog.edit-set.remove-value')}
+          />
         </Stack>
       ))}
     </Stack>

--- a/packages/sanity/src/core/variants/components/dialog/EditVariantSetForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/EditVariantSetForm.tsx
@@ -1,0 +1,152 @@
+import {AddIcon} from '@sanity/icons/Add'
+import {TrashIcon} from '@sanity/icons/Trash'
+import {Box, Flex, Stack, Text, TextInput} from '@sanity/ui'
+import {randomKey} from '@sanity/util/content'
+import {useCallback, useMemo, useState} from 'react'
+
+import {Button} from '../../../../ui-components'
+import {useTranslation} from '../../../i18n'
+import {variantsLocaleNamespace} from '../../i18n'
+import {type DimensionEdit} from '../../util/variantSetEdit'
+import {type VariantSetDimension} from '../../util/variantSetPermutations'
+
+interface ValueRow {
+  id: string
+  originalValue: string | null
+  value: string
+}
+
+interface KeyRow {
+  key: string
+  values: ValueRow[]
+}
+
+function seedRows(dimensions: VariantSetDimension[]): KeyRow[] {
+  return dimensions.map((dimension) => ({
+    key: dimension.key,
+    values: dimension.values.map((value) => ({
+      id: randomKey(12),
+      originalValue: value,
+      value,
+    })),
+  }))
+}
+
+function toEdits(rows: KeyRow[]): DimensionEdit[] {
+  return rows.map((row) => ({
+    key: row.key,
+    values: row.values.map(({originalValue, value}) => ({originalValue, value})),
+  }))
+}
+
+export function EditVariantSetForm(props: {
+  initialDimensions: VariantSetDimension[]
+  onChange: (edits: DimensionEdit[]) => void
+}) {
+  const {initialDimensions, onChange} = props
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const [rows, setRows] = useState<KeyRow[]>(() => seedRows(initialDimensions))
+
+  const update = useCallback(
+    (nextRows: KeyRow[]) => {
+      setRows(nextRows)
+      onChange(toEdits(nextRows))
+    },
+    [onChange],
+  )
+
+  const handleValueChange = useCallback(
+    (keyIndex: number, valueId: string, nextValue: string) => {
+      update(
+        rows.map((row, index) =>
+          index === keyIndex
+            ? {
+                ...row,
+                values: row.values.map((value) =>
+                  value.id === valueId ? {...value, value: nextValue} : value,
+                ),
+              }
+            : row,
+        ),
+      )
+    },
+    [rows, update],
+  )
+
+  const handleRemoveValue = useCallback(
+    (keyIndex: number, valueId: string) => {
+      update(
+        rows.map((row, index) =>
+          index === keyIndex
+            ? {...row, values: row.values.filter((value) => value.id !== valueId)}
+            : row,
+        ),
+      )
+    },
+    [rows, update],
+  )
+
+  const handleAddValue = useCallback(
+    (keyIndex: number) => {
+      update(
+        rows.map((row, index) =>
+          index === keyIndex
+            ? {...row, values: [...row.values, {id: randomKey(12), originalValue: null, value: ''}]}
+            : row,
+        ),
+      )
+    },
+    [rows, update],
+  )
+
+  const keySpacing = useMemo(() => (rows.length > 1 ? 4 : 3), [rows.length])
+
+  return (
+    <Stack space={keySpacing}>
+      {rows.map((row, keyIndex) => (
+        <Stack key={row.key} space={3}>
+          <Text size={1} weight="semibold">
+            {row.key}
+          </Text>
+          <Stack space={2}>
+            {row.values.map((value) => (
+              <Flex key={value.id} align="center" gap={2}>
+                <Box flex={1}>
+                  <TextInput
+                    aria-label={row.key}
+                    data-testid="edit-set-value-input"
+                    fontSize={1}
+                    onChange={(event) =>
+                      handleValueChange(keyIndex, value.id, event.currentTarget.value)
+                    }
+                    value={value.value}
+                  />
+                </Box>
+                <Button
+                  data-testid="edit-set-remove-value"
+                  disabled={row.values.length === 1}
+                  icon={TrashIcon}
+                  mode="bleed"
+                  onClick={() => handleRemoveValue(keyIndex, value.id)}
+                  tone="critical"
+                  tooltipProps={{content: t('dialog.edit-set.remove-value')}}
+                  type="button"
+                />
+              </Flex>
+            ))}
+          </Stack>
+          <Flex>
+            <Button
+              data-testid="edit-set-add-value"
+              icon={AddIcon}
+              mode="ghost"
+              onClick={() => handleAddValue(keyIndex)}
+              text={t('dialog.edit-set.add-value')}
+              type="button"
+            />
+          </Flex>
+        </Stack>
+      ))}
+    </Stack>
+  )
+}

--- a/packages/sanity/src/core/variants/components/dialog/ValueChipsInput.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/ValueChipsInput.tsx
@@ -1,0 +1,140 @@
+import {CloseIcon} from '@sanity/icons/Close'
+import {Box, Flex, TextInput} from '@sanity/ui'
+import {randomKey} from '@sanity/util/content'
+import {type ChangeEvent, type KeyboardEvent, useCallback, useState} from 'react'
+
+import {Button} from '../../../../ui-components'
+
+/**
+ * A value in the chip editor. `id` is a stable local key so a rename (editing a chip in place) can
+ * be told apart from a remove-plus-add by callers that track value identity.
+ *
+ * @internal
+ */
+export interface ValueChip {
+  id: string
+  value: string
+}
+
+/**
+ * A compact, wrapping editor for a dimension's values. Each value is an inline editable field with
+ * a remove control, and a trailing field adds more — typing or pasting a comma-separated list
+ * splits it into chips, so bulk entry ("uk, us, de") still works while every value stays
+ * individually editable. Replaces the old stacked full-width inputs that grew unbounded.
+ *
+ * @internal
+ */
+export function ValueChipsInput(props: {
+  chips: ValueChip[]
+  onChange: (chips: ValueChip[]) => void
+  ariaLabel: string
+  addPlaceholder: string
+  removeLabel: string
+}) {
+  const {chips, onChange, ariaLabel, addPlaceholder, removeLabel} = props
+  const [draft, setDraft] = useState('')
+
+  const commit = useCallback(
+    (text: string, remainder: string) => {
+      const additions = text
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean)
+
+      if (additions.length > 0) {
+        const existing = new Set(chips.map((chip) => chip.value))
+        const next = [...chips]
+        for (const value of additions) {
+          if (!existing.has(value)) {
+            existing.add(value)
+            next.push({id: randomKey(12), value})
+          }
+        }
+        onChange(next)
+      }
+
+      setDraft(remainder)
+    },
+    [chips, onChange],
+  )
+
+  const handleDraftChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const value = event.currentTarget.value
+      if (value.includes(',')) {
+        const lastComma = value.lastIndexOf(',')
+        commit(value.slice(0, lastComma), value.slice(lastComma + 1))
+      } else {
+        setDraft(value)
+      }
+    },
+    [commit],
+  )
+
+  const handleDraftKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Enter' && draft.trim()) {
+        event.preventDefault()
+        commit(draft, '')
+      }
+    },
+    [commit, draft],
+  )
+
+  const handleChipChange = useCallback(
+    (id: string, value: string) => {
+      onChange(chips.map((chip) => (chip.id === id ? {...chip, value} : chip)))
+    },
+    [chips, onChange],
+  )
+
+  const handleRemove = useCallback(
+    (id: string) => {
+      onChange(chips.filter((chip) => chip.id !== id))
+    },
+    [chips, onChange],
+  )
+
+  return (
+    <Flex align="center" gap={2} wrap="wrap">
+      {chips.map((chip) => (
+        <Flex key={chip.id} align="center" gap={1} style={{width: 'min(160px, 100%)'}}>
+          <Box flex={1}>
+            <TextInput
+              aria-label={ariaLabel}
+              data-testid="value-chip-input"
+              fontSize={1}
+              onChange={(event) => handleChipChange(chip.id, event.currentTarget.value)}
+              padding={2}
+              radius={2}
+              value={chip.value}
+            />
+          </Box>
+          <Button
+            data-testid="value-chip-remove"
+            icon={CloseIcon}
+            mode="bleed"
+            onClick={() => handleRemove(chip.id)}
+            tone="critical"
+            tooltipProps={{content: removeLabel}}
+            type="button"
+          />
+        </Flex>
+      ))}
+      <Box style={{width: 'min(160px, 100%)'}}>
+        <TextInput
+          aria-label={addPlaceholder}
+          data-testid="value-chip-add"
+          fontSize={1}
+          onBlur={() => draft.trim() && commit(draft, '')}
+          onChange={handleDraftChange}
+          onKeyDown={handleDraftKeyDown}
+          padding={2}
+          placeholder={addPlaceholder}
+          radius={2}
+          value={draft}
+        />
+      </Box>
+    </Flex>
+  )
+}

--- a/packages/sanity/src/core/variants/components/dialog/VariantSetForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantSetForm.tsx
@@ -1,6 +1,6 @@
 import {AddIcon} from '@sanity/icons/Add'
 import {TrashIcon} from '@sanity/icons/Trash'
-import {Badge, Box, Flex, Stack, Text, TextInput} from '@sanity/ui'
+import {Box, Flex, Stack, Text, TextInput} from '@sanity/ui'
 import {randomKey} from '@sanity/util/content'
 import {type ChangeEvent, useCallback, useId, useMemo, useState} from 'react'
 
@@ -12,12 +12,13 @@ import {
   getConditionKeyValidationError,
   getConditionValueValidationError,
 } from '../../util/conditionValidation'
-import {parseVariantSetValues, type VariantSetDimension} from '../../util/variantSetPermutations'
+import {type VariantSetDimension} from '../../util/variantSetPermutations'
+import {type ValueChip, ValueChipsInput} from './ValueChipsInput'
 
 interface DimensionRow {
   id: string
   key: string
-  valuesInput: string
+  values: ValueChip[]
 }
 
 interface DimensionRowValidation {
@@ -26,7 +27,7 @@ interface DimensionRowValidation {
 }
 
 function createEmptyRow(): DimensionRow {
-  return {id: randomKey(12), key: '', valuesInput: ''}
+  return {id: randomKey(12), key: '', values: []}
 }
 
 function seedRows(initialDimensions?: VariantSetDimension[]): DimensionRow[] {
@@ -37,16 +38,25 @@ function seedRows(initialDimensions?: VariantSetDimension[]): DimensionRow[] {
   return initialDimensions.map((dimension) => ({
     id: randomKey(12),
     key: dimension.key,
-    valuesInput: dimension.values.join(', '),
+    values: dimension.values.map((value) => ({id: randomKey(12), value})),
   }))
 }
 
-function isRowEmpty(row: DimensionRow): boolean {
-  return !row.key.trim() && !row.valuesInput.trim()
+function dedupeValues(chips: ValueChip[]): string[] {
+  const seen = new Set<string>()
+  const values: string[] = []
+  for (const chip of chips) {
+    const value = chip.value.trim()
+    if (value && !seen.has(value)) {
+      seen.add(value)
+      values.push(value)
+    }
+  }
+  return values
 }
 
 function getDimensionsFromRows(rows: DimensionRow[]): VariantSetDimension[] {
-  return rows.map((row) => ({key: row.key.trim(), values: parseVariantSetValues(row.valuesInput)}))
+  return rows.map((row) => ({key: row.key.trim(), values: dedupeValues(row.values)}))
 }
 
 function getRowsValidation(rows: DimensionRow[]): Map<number, DimensionRowValidation> {
@@ -56,7 +66,7 @@ function getRowsValidation(rows: DimensionRow[]): Map<number, DimensionRowValida
   rows.forEach((row, index) => {
     const validation: DimensionRowValidation = {key: null, values: null}
     const key = row.key.trim()
-    const values = parseVariantSetValues(row.valuesInput)
+    const values = dedupeValues(row.values)
 
     if (key) {
       if (seenKeys.has(key)) {
@@ -64,7 +74,6 @@ function getRowsValidation(rows: DimensionRow[]): Map<number, DimensionRowValida
       } else {
         seenKeys.add(key)
         const keyError = getConditionKeyValidationError(key)
-
         if (keyError === 'reserved') {
           validation.key = 'dialog.create.condition-key.reserved'
         } else if (keyError === 'invalid') {
@@ -132,16 +141,14 @@ export function VariantSetForm(props: {
   const lastRow = rows[rows.length - 1]
   const canAddDimension = Boolean(
     lastRow &&
-    !isRowEmpty(lastRow) &&
     lastRow.key.trim() &&
-    parseVariantSetValues(lastRow.valuesInput).length > 0 &&
+    dedupeValues(lastRow.values).length > 0 &&
     !hasValidationErrors(rowsValidation),
   )
 
   const updateRows = useCallback(
     (nextRows: DimensionRow[]) => {
       const rowsToApply = nextRows.length ? nextRows : [createEmptyRow()]
-
       setRows(rowsToApply)
       onDimensionsChange(getDimensionsFromRows(rowsToApply))
       onDimensionsValidityChange?.(hasValidationErrors(getRowsValidation(rowsToApply)))
@@ -150,27 +157,28 @@ export function VariantSetForm(props: {
   )
 
   const handleNameChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      onNameChange(event.currentTarget.value)
-    },
+    (event: ChangeEvent<HTMLInputElement>) => onNameChange(event.currentTarget.value),
     [onNameChange],
   )
 
-  const handleRowChange = useCallback(
-    (index: number, field: 'key' | 'valuesInput', nextValue: string) => {
-      updateRows(
-        rows.map((row, rowIndex) => (rowIndex === index ? {...row, [field]: nextValue} : row)),
-      )
+  const handleKeyChange = useCallback(
+    (index: number, nextKey: string) => {
+      updateRows(rows.map((row, rowIndex) => (rowIndex === index ? {...row, key: nextKey} : row)))
+    },
+    [rows, updateRows],
+  )
+
+  const handleValuesChange = useCallback(
+    (index: number, values: ValueChip[]) => {
+      updateRows(rows.map((row, rowIndex) => (rowIndex === index ? {...row, values} : row)))
     },
     [rows, updateRows],
   )
 
   const handleAddDimension = useCallback(() => {
-    if (!canAddDimension) {
-      return
+    if (canAddDimension) {
+      updateRows([...rows, createEmptyRow()])
     }
-
-    updateRows([...rows, createEmptyRow()])
   }, [canAddDimension, rows, updateRows])
 
   const handleRemoveDimension = useCallback(
@@ -214,45 +222,28 @@ export function VariantSetForm(props: {
           </Text>
         </Stack>
 
-        <Stack space={3}>
+        <Stack space={4}>
           {rows.map((row, index) => {
             const validation = rowsValidation.get(index) ?? {key: null, values: null}
             const validationError = validation.key || validation.values
-            const parsedValues = parseVariantSetValues(row.valuesInput)
+            const example = index % EXAMPLE_KEY_PLACEHOLDERS.length
 
             return (
               <Stack key={row.id} space={2}>
-                <Flex align="flex-start" gap={2}>
+                <Flex align="center" gap={2}>
                   <Box flex={1}>
                     <TextInput
                       aria-label={t('dialog.create-set.dimension-key.label')}
                       customValidity={validation.key ? t(validation.key) : undefined}
                       data-testid="variant-set-form-dimension-key"
                       fontSize={1}
-                      onChange={(event) => handleRowChange(index, 'key', event.currentTarget.value)}
-                      placeholder={t(
-                        EXAMPLE_KEY_PLACEHOLDERS[index % EXAMPLE_KEY_PLACEHOLDERS.length]!,
-                      )}
+                      onChange={(event) => handleKeyChange(index, event.currentTarget.value)}
+                      placeholder={t(EXAMPLE_KEY_PLACEHOLDERS[example]!)}
                       value={row.key}
                     />
                   </Box>
-                  <Box flex={2}>
-                    <TextInput
-                      aria-label={t('dialog.create-set.dimension-values.label')}
-                      customValidity={validation.values ? t(validation.values) : undefined}
-                      data-testid="variant-set-form-dimension-values"
-                      fontSize={1}
-                      onChange={(event) =>
-                        handleRowChange(index, 'valuesInput', event.currentTarget.value)
-                      }
-                      placeholder={t(
-                        EXAMPLE_VALUES_PLACEHOLDERS[index % EXAMPLE_VALUES_PLACEHOLDERS.length]!,
-                      )}
-                      value={row.valuesInput}
-                    />
-                  </Box>
                   <Button
-                    disabled={isRowEmpty(row) && rows.length === 1}
+                    disabled={rows.length === 1 && !row.key.trim() && row.values.length === 0}
                     icon={TrashIcon}
                     mode="bleed"
                     onClick={() => handleRemoveDimension(index)}
@@ -261,15 +252,15 @@ export function VariantSetForm(props: {
                     type="button"
                   />
                 </Flex>
-                {parsedValues.length > 0 && (
-                  <Flex gap={1} paddingLeft={1} wrap="wrap">
-                    {parsedValues.map((value) => (
-                      <Badge key={value} fontSize={0} mode="outline" tone="primary">
-                        {value}
-                      </Badge>
-                    ))}
-                  </Flex>
-                )}
+                <Box paddingLeft={1}>
+                  <ValueChipsInput
+                    addPlaceholder={t(EXAMPLE_VALUES_PLACEHOLDERS[example]!)}
+                    ariaLabel={t('dialog.create-set.dimension-values.label')}
+                    chips={row.values}
+                    onChange={(values) => handleValuesChange(index, values)}
+                    removeLabel={t('dialog.create-set.remove-value')}
+                  />
+                </Box>
                 {validationError && (
                   <TextWithTone
                     data-testid="variant-set-form-dimension-error"

--- a/packages/sanity/src/core/variants/components/dialog/VariantSetForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantSetForm.tsx
@@ -1,6 +1,6 @@
 import {AddIcon} from '@sanity/icons/Add'
 import {TrashIcon} from '@sanity/icons/Trash'
-import {Box, Flex, Stack, Text, TextInput} from '@sanity/ui'
+import {Flex, Stack, Text, TextInput} from '@sanity/ui'
 import {randomKey} from '@sanity/util/content'
 import {type ChangeEvent, useCallback, useId, useMemo, useState} from 'react'
 
@@ -229,30 +229,36 @@ export function VariantSetForm(props: {
             const example = index % EXAMPLE_KEY_PLACEHOLDERS.length
 
             return (
-              <Stack key={row.id} space={2}>
-                <Flex align="center" gap={2}>
-                  <Box flex={1}>
-                    <TextInput
-                      aria-label={t('dialog.create-set.dimension-key.label')}
-                      customValidity={validation.key ? t(validation.key) : undefined}
-                      data-testid="variant-set-form-dimension-key"
-                      fontSize={1}
-                      onChange={(event) => handleKeyChange(index, event.currentTarget.value)}
-                      placeholder={t(EXAMPLE_KEY_PLACEHOLDERS[example]!)}
-                      value={row.key}
+              <Stack key={row.id} space={3}>
+                <Stack space={2}>
+                  <Flex align="center" justify="space-between">
+                    <Text muted size={0} weight="medium">
+                      {t('dialog.create-set.dimension-key.label')}
+                    </Text>
+                    <Button
+                      disabled={rows.length === 1 && !row.key.trim() && row.values.length === 0}
+                      icon={TrashIcon}
+                      mode="bleed"
+                      onClick={() => handleRemoveDimension(index)}
+                      tone="critical"
+                      tooltipProps={{content: t('dialog.create-set.remove-dimension')}}
+                      type="button"
                     />
-                  </Box>
-                  <Button
-                    disabled={rows.length === 1 && !row.key.trim() && row.values.length === 0}
-                    icon={TrashIcon}
-                    mode="bleed"
-                    onClick={() => handleRemoveDimension(index)}
-                    tone="critical"
-                    tooltipProps={{content: t('dialog.create-set.remove-dimension')}}
-                    type="button"
+                  </Flex>
+                  <TextInput
+                    aria-label={t('dialog.create-set.dimension-key.label')}
+                    customValidity={validation.key ? t(validation.key) : undefined}
+                    data-testid="variant-set-form-dimension-key"
+                    fontSize={1}
+                    onChange={(event) => handleKeyChange(index, event.currentTarget.value)}
+                    placeholder={t(EXAMPLE_KEY_PLACEHOLDERS[example]!)}
+                    value={row.key}
                   />
-                </Flex>
-                <Box paddingLeft={1}>
+                </Stack>
+                <Stack space={2}>
+                  <Text muted size={0} weight="medium">
+                    {t('dialog.create-set.dimension-values.label')}
+                  </Text>
                   <ValueChipsInput
                     addPlaceholder={t(EXAMPLE_VALUES_PLACEHOLDERS[example]!)}
                     ariaLabel={t('dialog.create-set.dimension-values.label')}
@@ -260,7 +266,7 @@ export function VariantSetForm(props: {
                     onChange={(values) => handleValuesChange(index, values)}
                     removeLabel={t('dialog.create-set.remove-value')}
                   />
-                </Box>
+                </Stack>
                 {validationError && (
                   <TextWithTone
                     data-testid="variant-set-form-dimension-error"

--- a/packages/sanity/src/core/variants/components/dialog/VariantSetForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantSetForm.tsx
@@ -79,6 +79,22 @@ function hasValidationErrors(validation: Map<number, DimensionRowValidation>): b
   return Array.from(validation.values()).some(({key, values}) => key || values)
 }
 
+// Rotating example placeholders so each dimension row hints at a different kind of dimension,
+// rather than repeating "market" and implying it's the only option. Cycled by row index.
+const EXAMPLE_KEY_PLACEHOLDERS = [
+  'dialog.create-set.example.0.key',
+  'dialog.create-set.example.1.key',
+  'dialog.create-set.example.2.key',
+  'dialog.create-set.example.3.key',
+] as const satisfies readonly VariantsLocaleResourceKeys[]
+
+const EXAMPLE_VALUES_PLACEHOLDERS = [
+  'dialog.create-set.example.0.values',
+  'dialog.create-set.example.1.values',
+  'dialog.create-set.example.2.values',
+  'dialog.create-set.example.3.values',
+] as const satisfies readonly VariantsLocaleResourceKeys[]
+
 export function VariantSetForm(props: {
   name: string
   onNameChange: (name: string) => void
@@ -200,7 +216,9 @@ export function VariantSetForm(props: {
                       data-testid="variant-set-form-dimension-key"
                       fontSize={1}
                       onChange={(event) => handleRowChange(index, 'key', event.currentTarget.value)}
-                      placeholder={t('dialog.create-set.dimension-key.placeholder')}
+                      placeholder={t(
+                        EXAMPLE_KEY_PLACEHOLDERS[index % EXAMPLE_KEY_PLACEHOLDERS.length]!,
+                      )}
                       value={row.key}
                     />
                   </Box>
@@ -213,7 +231,9 @@ export function VariantSetForm(props: {
                       onChange={(event) =>
                         handleRowChange(index, 'valuesInput', event.currentTarget.value)
                       }
-                      placeholder={t('dialog.create-set.dimension-values.placeholder')}
+                      placeholder={t(
+                        EXAMPLE_VALUES_PLACEHOLDERS[index % EXAMPLE_VALUES_PLACEHOLDERS.length]!,
+                      )}
                       value={row.valuesInput}
                     />
                   </Box>

--- a/packages/sanity/src/core/variants/components/dialog/VariantSetForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantSetForm.tsx
@@ -29,6 +29,18 @@ function createEmptyRow(): DimensionRow {
   return {id: randomKey(12), key: '', valuesInput: ''}
 }
 
+function seedRows(initialDimensions?: VariantSetDimension[]): DimensionRow[] {
+  if (!initialDimensions || initialDimensions.length === 0) {
+    return [createEmptyRow()]
+  }
+
+  return initialDimensions.map((dimension) => ({
+    id: randomKey(12),
+    key: dimension.key,
+    valuesInput: dimension.values.join(', '),
+  }))
+}
+
 function isRowEmpty(row: DimensionRow): boolean {
   return !row.key.trim() && !row.valuesInput.trim()
 }
@@ -101,6 +113,7 @@ export function VariantSetForm(props: {
   onDimensionsChange: (dimensions: VariantSetDimension[]) => void
   onDimensionsValidityChange?: (invalid: boolean) => void
   showValidation?: boolean
+  initialDimensions?: VariantSetDimension[]
 }) {
   const {
     name,
@@ -108,10 +121,11 @@ export function VariantSetForm(props: {
     onDimensionsChange,
     onDimensionsValidityChange,
     showValidation = false,
+    initialDimensions,
   } = props
   const {t} = useTranslation(variantsLocaleNamespace)
   const nameId = useId()
-  const [rows, setRows] = useState<DimensionRow[]>(() => [createEmptyRow()])
+  const [rows, setRows] = useState<DimensionRow[]>(() => seedRows(initialDimensions))
   const rowsValidation = useMemo(() => getRowsValidation(rows), [rows])
 
   const showNameError = showValidation && !name.trim()

--- a/packages/sanity/src/core/variants/components/dialog/VariantSetForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantSetForm.tsx
@@ -1,0 +1,271 @@
+import {AddIcon} from '@sanity/icons/Add'
+import {TrashIcon} from '@sanity/icons/Trash'
+import {Badge, Box, Flex, Stack, Text, TextInput} from '@sanity/ui'
+import {randomKey} from '@sanity/util/content'
+import {type ChangeEvent, useCallback, useId, useMemo, useState} from 'react'
+
+import {Button} from '../../../../ui-components'
+import {TextWithTone} from '../../../components/textWithTone/TextWithTone'
+import {useTranslation} from '../../../i18n'
+import {type VariantsLocaleResourceKeys, variantsLocaleNamespace} from '../../i18n'
+import {
+  getConditionKeyValidationError,
+  getConditionValueValidationError,
+} from '../../util/conditionValidation'
+import {parseVariantSetValues, type VariantSetDimension} from '../../util/variantSetPermutations'
+
+interface DimensionRow {
+  id: string
+  key: string
+  valuesInput: string
+}
+
+interface DimensionRowValidation {
+  key: VariantsLocaleResourceKeys | null
+  values: VariantsLocaleResourceKeys | null
+}
+
+function createEmptyRow(): DimensionRow {
+  return {id: randomKey(12), key: '', valuesInput: ''}
+}
+
+function isRowEmpty(row: DimensionRow): boolean {
+  return !row.key.trim() && !row.valuesInput.trim()
+}
+
+function getDimensionsFromRows(rows: DimensionRow[]): VariantSetDimension[] {
+  return rows.map((row) => ({key: row.key.trim(), values: parseVariantSetValues(row.valuesInput)}))
+}
+
+function getRowsValidation(rows: DimensionRow[]): Map<number, DimensionRowValidation> {
+  const rowsValidation = new Map<number, DimensionRowValidation>()
+  const seenKeys = new Set<string>()
+
+  rows.forEach((row, index) => {
+    const validation: DimensionRowValidation = {key: null, values: null}
+    const key = row.key.trim()
+    const values = parseVariantSetValues(row.valuesInput)
+
+    if (key) {
+      if (seenKeys.has(key)) {
+        validation.key = 'dialog.create.condition-key.duplicate'
+      } else {
+        seenKeys.add(key)
+        const keyError = getConditionKeyValidationError(key)
+
+        if (keyError === 'reserved') {
+          validation.key = 'dialog.create.condition-key.reserved'
+        } else if (keyError === 'invalid') {
+          validation.key = 'dialog.create.condition-key.invalid'
+        }
+      }
+    } else if (values.length > 0) {
+      validation.key = 'dialog.create.condition-key.required'
+    }
+
+    if (key && values.length === 0) {
+      validation.values = 'dialog.create-set.dimension-values.required'
+    } else if (values.some((value) => getConditionValueValidationError(value) === 'invalid')) {
+      validation.values = 'dialog.create.condition-value.invalid'
+    }
+
+    rowsValidation.set(index, validation)
+  })
+
+  return rowsValidation
+}
+
+function hasValidationErrors(validation: Map<number, DimensionRowValidation>): boolean {
+  return Array.from(validation.values()).some(({key, values}) => key || values)
+}
+
+export function VariantSetForm(props: {
+  name: string
+  onNameChange: (name: string) => void
+  onDimensionsChange: (dimensions: VariantSetDimension[]) => void
+  onDimensionsValidityChange?: (invalid: boolean) => void
+  showValidation?: boolean
+}) {
+  const {
+    name,
+    onNameChange,
+    onDimensionsChange,
+    onDimensionsValidityChange,
+    showValidation = false,
+  } = props
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const nameId = useId()
+  const [rows, setRows] = useState<DimensionRow[]>(() => [createEmptyRow()])
+  const rowsValidation = useMemo(() => getRowsValidation(rows), [rows])
+
+  const showNameError = showValidation && !name.trim()
+  const lastRow = rows[rows.length - 1]
+  const canAddDimension = Boolean(
+    lastRow &&
+    !isRowEmpty(lastRow) &&
+    lastRow.key.trim() &&
+    parseVariantSetValues(lastRow.valuesInput).length > 0 &&
+    !hasValidationErrors(rowsValidation),
+  )
+
+  const updateRows = useCallback(
+    (nextRows: DimensionRow[]) => {
+      const rowsToApply = nextRows.length ? nextRows : [createEmptyRow()]
+
+      setRows(rowsToApply)
+      onDimensionsChange(getDimensionsFromRows(rowsToApply))
+      onDimensionsValidityChange?.(hasValidationErrors(getRowsValidation(rowsToApply)))
+    },
+    [onDimensionsChange, onDimensionsValidityChange],
+  )
+
+  const handleNameChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onNameChange(event.currentTarget.value)
+    },
+    [onNameChange],
+  )
+
+  const handleRowChange = useCallback(
+    (index: number, field: 'key' | 'valuesInput', nextValue: string) => {
+      updateRows(
+        rows.map((row, rowIndex) => (rowIndex === index ? {...row, [field]: nextValue} : row)),
+      )
+    },
+    [rows, updateRows],
+  )
+
+  const handleAddDimension = useCallback(() => {
+    if (!canAddDimension) {
+      return
+    }
+
+    updateRows([...rows, createEmptyRow()])
+  }, [canAddDimension, rows, updateRows])
+
+  const handleRemoveDimension = useCallback(
+    (index: number) => {
+      updateRows(rows.filter((_, rowIndex) => rowIndex !== index))
+    },
+    [rows, updateRows],
+  )
+
+  return (
+    <Stack space={5}>
+      <Stack space={3}>
+        <Text as="label" htmlFor={nameId} size={1} weight="medium">
+          {t('dialog.create-set.name.label')}
+        </Text>
+        <TextInput
+          autoFocus
+          aria-invalid={showNameError ? 'true' : undefined}
+          customValidity={showNameError ? t('dialog.create-set.name.required') : undefined}
+          data-testid="variant-set-form-name"
+          fontSize={2}
+          id={nameId}
+          onChange={handleNameChange}
+          placeholder={t('dialog.create-set.name.placeholder')}
+          value={name}
+        />
+        {showNameError && (
+          <TextWithTone data-testid="variant-set-form-name-error" size={1} tone="critical">
+            {t('dialog.create-set.name.required')}
+          </TextWithTone>
+        )}
+      </Stack>
+
+      <Stack space={3}>
+        <Stack space={2}>
+          <Text size={1} weight="medium">
+            {t('dialog.create-set.dimensions.title')}
+          </Text>
+          <Text muted size={1}>
+            {t('dialog.create-set.dimensions.description')}
+          </Text>
+        </Stack>
+
+        <Stack space={3}>
+          {rows.map((row, index) => {
+            const validation = rowsValidation.get(index) ?? {key: null, values: null}
+            const validationError = validation.key || validation.values
+            const parsedValues = parseVariantSetValues(row.valuesInput)
+
+            return (
+              <Stack key={row.id} space={2}>
+                <Flex align="flex-start" gap={2}>
+                  <Box flex={1}>
+                    <TextInput
+                      aria-label={t('dialog.create-set.dimension-key.label')}
+                      customValidity={validation.key ? t(validation.key) : undefined}
+                      data-testid="variant-set-form-dimension-key"
+                      fontSize={1}
+                      onChange={(event) => handleRowChange(index, 'key', event.currentTarget.value)}
+                      placeholder={t('dialog.create-set.dimension-key.placeholder')}
+                      value={row.key}
+                    />
+                  </Box>
+                  <Box flex={2}>
+                    <TextInput
+                      aria-label={t('dialog.create-set.dimension-values.label')}
+                      customValidity={validation.values ? t(validation.values) : undefined}
+                      data-testid="variant-set-form-dimension-values"
+                      fontSize={1}
+                      onChange={(event) =>
+                        handleRowChange(index, 'valuesInput', event.currentTarget.value)
+                      }
+                      placeholder={t('dialog.create-set.dimension-values.placeholder')}
+                      value={row.valuesInput}
+                    />
+                  </Box>
+                  <Button
+                    disabled={isRowEmpty(row) && rows.length === 1}
+                    icon={TrashIcon}
+                    mode="bleed"
+                    onClick={() => handleRemoveDimension(index)}
+                    tone="critical"
+                    tooltipProps={{content: t('dialog.create-set.remove-dimension')}}
+                    type="button"
+                  />
+                </Flex>
+                {parsedValues.length > 0 && (
+                  <Flex gap={1} paddingLeft={1} wrap="wrap">
+                    {parsedValues.map((value) => (
+                      <Badge key={value} fontSize={0} mode="outline" tone="primary">
+                        {value}
+                      </Badge>
+                    ))}
+                  </Flex>
+                )}
+                {validationError && (
+                  <TextWithTone
+                    data-testid="variant-set-form-dimension-error"
+                    size={1}
+                    tone="critical"
+                  >
+                    {t(validationError)}
+                  </TextWithTone>
+                )}
+              </Stack>
+            )
+          })}
+        </Stack>
+
+        <Flex>
+          <Button
+            disabled={!canAddDimension}
+            icon={AddIcon}
+            mode="ghost"
+            onClick={handleAddDimension}
+            text={t('dialog.create-set.action.add-dimension')}
+            tooltipProps={
+              canAddDimension
+                ? null
+                : {content: t('dialog.create-set.action.add-dimension.disabled-hint')}
+            }
+            type="button"
+          />
+        </Flex>
+      </Stack>
+    </Stack>
+  )
+}

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantSetDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantSetDialog.test.tsx
@@ -1,21 +1,58 @@
-import {render, screen, waitFor} from '@testing-library/react'
+import {render, screen, waitFor, within} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
-import {describe, expect, it, vi} from 'vitest'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
 import {variantsUsEnglishLocaleBundle} from '../../../i18n'
+import {getVariantSetReference} from '../../../util/variantSet'
 import {CreateVariantSetDialog} from '../CreateVariantSetDialog'
 
+const variantOperationsMock = vi.hoisted(() => ({
+  createVariant: vi.fn(),
+  updateVariant: vi.fn(),
+  deleteVariant: vi.fn(),
+}))
+
+const toastMock = vi.hoisted(() => ({
+  push: vi.fn(),
+}))
+
+vi.mock('@sanity/ui', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useToast: vi.fn(() => toastMock),
+}))
+
+vi.mock('../../../store/useVariantOperations', () => ({
+  useVariantOperations: vi.fn(() => variantOperationsMock),
+}))
+
 describe('CreateVariantSetDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    variantOperationsMock.createVariant.mockResolvedValue(undefined)
+  })
+
   const renderDialog = async () => {
     const onCancel = vi.fn()
-    const onSubmit = vi.fn()
+    const onDone = vi.fn()
     const wrapper = await createTestProvider({
       resources: [variantsUsEnglishLocaleBundle],
     })
-    render(<CreateVariantSetDialog onCancel={onCancel} onSubmit={onSubmit} />, {wrapper})
+    render(<CreateVariantSetDialog onCancel={onCancel} onDone={onDone} />, {wrapper})
     await screen.findByTestId('variant-set-form-name')
-    return {onCancel, onSubmit}
+    return {onCancel, onDone}
+  }
+
+  const buildTwoByTwoSet = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.type(screen.getByTestId('variant-set-form-name'), 'Regional launch')
+    await user.type(screen.getByTestId('variant-set-form-dimension-key'), 'market')
+    await user.type(screen.getByTestId('variant-set-form-dimension-values'), 'uk, us')
+    await user.click(screen.getByRole('button', {name: 'Add dimension'}))
+
+    const keyInputs = screen.getAllByTestId('variant-set-form-dimension-key')
+    const valueInputs = screen.getAllByTestId('variant-set-form-dimension-values')
+    await user.type(keyInputs[1]!, 'segment')
+    await user.type(valueInputs[1]!, 'loyal, new')
   }
 
   it('previews the permutation count as a dimension is entered', async () => {
@@ -34,52 +71,91 @@ describe('CreateVariantSetDialog', () => {
     })
   })
 
-  it('multiplies the count across dimensions', async () => {
+  it('keeps generate disabled until the set has a name', async () => {
     const user = userEvent.setup()
     await renderDialog()
 
     await user.type(screen.getByTestId('variant-set-form-dimension-key'), 'market')
     await user.type(screen.getByTestId('variant-set-form-dimension-values'), 'uk, us, de')
-    await user.click(screen.getByRole('button', {name: 'Add dimension'}))
-
-    const keyInputs = screen.getAllByTestId('variant-set-form-dimension-key')
-    const valueInputs = screen.getAllByTestId('variant-set-form-dimension-values')
-    await user.type(keyInputs[1]!, 'segment')
-    await user.type(valueInputs[1]!, 'loyal, new')
-
-    await waitFor(() => {
-      expect(screen.getByTestId('variant-set-preview')).toHaveTextContent(
-        '6 variant definitions will be generated',
-      )
-    })
-  })
-
-  it('keeps generate disabled until the set has a name', async () => {
-    const user = userEvent.setup()
-    const {onSubmit} = await renderDialog()
-
-    await user.type(screen.getByTestId('variant-set-form-dimension-key'), 'market')
-    await user.type(screen.getByTestId('variant-set-form-dimension-values'), 'uk, us, de')
 
     expect(screen.getByTestId('generate-variant-set-button')).toBeDisabled()
-    expect(onSubmit).not.toHaveBeenCalled()
+    expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
   })
 
-  it('submits the parsed set when generate is clicked', async () => {
+  it('creates one variant definition per permutation, each tagged with the set', async () => {
     const user = userEvent.setup()
-    const {onSubmit} = await renderDialog()
+    await renderDialog()
+    await buildTwoByTwoSet(user)
 
-    await user.type(screen.getByTestId('variant-set-form-name'), 'Regional launch')
-    await user.type(screen.getByTestId('variant-set-form-dimension-key'), 'market')
-    await user.type(screen.getByTestId('variant-set-form-dimension-values'), 'uk, us, de')
+    await user.click(screen.getByTestId('generate-variant-set-button'))
 
-    const generateButton = screen.getByTestId('generate-variant-set-button')
-    await waitFor(() => expect(generateButton).toBeEnabled())
-    await user.click(generateButton)
-
-    expect(onSubmit).toHaveBeenCalledWith({
-      name: 'Regional launch',
-      dimensions: [{key: 'market', values: ['uk', 'us', 'de']}],
+    await waitFor(() => {
+      expect(variantOperationsMock.createVariant).toHaveBeenCalledTimes(4)
     })
+
+    const created = variantOperationsMock.createVariant.mock.calls.map((call) => call[0])
+
+    expect(created.map((definition) => definition.conditions)).toEqual([
+      {market: 'uk', segment: 'loyal'},
+      {market: 'uk', segment: 'new'},
+      {market: 'us', segment: 'loyal'},
+      {market: 'us', segment: 'new'},
+    ])
+
+    const references = created.map((definition) => getVariantSetReference(definition))
+    expect(references.every((reference) => reference?.name === 'Regional launch')).toBe(true)
+    expect(new Set(references.map((reference) => reference?.id)).size).toBe(1)
+  })
+
+  it('shows the generated definitions inline after generation', async () => {
+    const user = userEvent.setup()
+    await renderDialog()
+    await buildTwoByTwoSet(user)
+
+    await user.click(screen.getByTestId('generate-variant-set-button'))
+
+    expect(await screen.findByTestId('variant-set-result-title')).toHaveTextContent(
+      '4 variant definitions generated',
+    )
+    const list = screen.getByTestId('variant-set-result-list')
+    expect(within(list).getByText('Regional launch: uk / loyal')).toBeInTheDocument()
+    expect(within(list).getByText('Regional launch: us / new')).toBeInTheDocument()
+  })
+
+  it('calls onDone when the result is dismissed', async () => {
+    const user = userEvent.setup()
+    const {onDone} = await renderDialog()
+    await buildTwoByTwoSet(user)
+
+    await user.click(screen.getByTestId('generate-variant-set-button'))
+    await user.click(await screen.findByTestId('variant-set-done-button'))
+
+    expect(onDone).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the form open and toasts when generation fails', async () => {
+    const error = new Error('generate failed')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    variantOperationsMock.createVariant.mockRejectedValue(error)
+    const user = userEvent.setup()
+    const {onDone} = await renderDialog()
+    await buildTwoByTwoSet(user)
+
+    await user.click(screen.getByTestId('generate-variant-set-button'))
+
+    await waitFor(() => {
+      expect(toastMock.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          title: 'Unable to generate variant definitions',
+        }),
+      )
+    })
+
+    expect(onDone).not.toHaveBeenCalled()
+    expect(screen.getByTestId('variant-set-preview')).toBeInTheDocument()
+    expect(screen.queryByTestId('variant-set-result-list')).not.toBeInTheDocument()
+
+    consoleError.mockRestore()
   })
 })

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantSetDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantSetDialog.test.tsx
@@ -71,6 +71,19 @@ describe('CreateVariantSetDialog', () => {
     })
   })
 
+  it('varies the example placeholder per dimension row', async () => {
+    const user = userEvent.setup()
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-set-form-dimension-key'), 'market')
+    await user.type(screen.getByTestId('variant-set-form-dimension-values'), 'uk, us')
+    await user.click(screen.getByRole('button', {name: 'Add dimension'}))
+
+    const keyInputs = screen.getAllByTestId('variant-set-form-dimension-key')
+    expect(keyInputs[0]).toHaveAttribute('placeholder', 'e.g. market')
+    expect(keyInputs[1]).toHaveAttribute('placeholder', 'e.g. segment')
+  })
+
   it('keeps generate disabled until the set has a name', async () => {
     const user = userEvent.setup()
     await renderDialog()

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantSetDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantSetDialog.test.tsx
@@ -153,6 +153,41 @@ describe('CreateVariantSetDialog', () => {
     expect(screen.getByTestId('variant-set-form-name')).toHaveValue('Imported')
   })
 
+  it('requires a second confirmation before generating a very large set', async () => {
+    const user = userEvent.setup()
+    await renderDialog()
+
+    const values = Array.from({length: 11}, (_, index) => `v${index}`)
+    const file = new File(
+      [
+        JSON.stringify({
+          name: 'Big',
+          dimensions: [
+            {key: 'a', values},
+            {key: 'b', values},
+          ],
+        }),
+      ],
+      'big.json',
+      {type: 'application/json'},
+    )
+    await user.upload(screen.getByTestId('variant-set-file-input'), file)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variant-set-large-warning')).toBeInTheDocument()
+    })
+
+    const button = screen.getByTestId('generate-variant-set-button')
+    await user.click(button) // first click only arms
+    expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
+    await waitFor(() => expect(button).toHaveTextContent('Generate anyway'))
+
+    await user.click(button) // second click generates
+    await waitFor(() => {
+      expect(variantOperationsMock.createVariant).toHaveBeenCalledTimes(121)
+    })
+  })
+
   it('keeps generate disabled until the set has a name', async () => {
     const user = userEvent.setup()
     await renderDialog()

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantSetDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantSetDialog.test.tsx
@@ -84,6 +84,49 @@ describe('CreateVariantSetDialog', () => {
     expect(keyInputs[1]).toHaveAttribute('placeholder', 'e.g. segment')
   })
 
+  it('enables JSON export only once there is a complete dimension', async () => {
+    const user = userEvent.setup()
+    await renderDialog()
+
+    expect(screen.getByTestId('export-json-button')).toBeDisabled()
+
+    await user.type(screen.getByTestId('variant-set-form-dimension-key'), 'market')
+    await user.type(screen.getByTestId('variant-set-form-dimension-values'), 'uk, us')
+
+    await waitFor(() => expect(screen.getByTestId('export-json-button')).toBeEnabled())
+  })
+
+  it('offers CDP import and sync as not-yet-available actions', async () => {
+    await renderDialog()
+
+    expect(screen.getByTestId('import-cdp-button')).toBeDisabled()
+    expect(screen.getByTestId('sync-cdp-button')).toBeDisabled()
+  })
+
+  it('imports a JSON file and previews the resulting count', async () => {
+    const user = userEvent.setup()
+    await renderDialog()
+
+    const file = new File(
+      [
+        JSON.stringify({
+          name: 'Imported',
+          dimensions: [{key: 'market', values: ['uk', 'us', 'de']}],
+        }),
+      ],
+      'set.json',
+      {type: 'application/json'},
+    )
+    await user.upload(screen.getByTestId('variant-set-file-input'), file)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variant-set-preview')).toHaveTextContent(
+        '3 variant definitions will be generated',
+      )
+    })
+    expect(screen.getByTestId('variant-set-form-name')).toHaveValue('Imported')
+  })
+
   it('keeps generate disabled until the set has a name', async () => {
     const user = userEvent.setup()
     await renderDialog()

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantSetDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantSetDialog.test.tsx
@@ -43,16 +43,26 @@ describe('CreateVariantSetDialog', () => {
     return {onCancel, onDone}
   }
 
+  // Enter values through the chip add-field of a given dimension row; a trailing Enter commits the
+  // final value so nothing is left uncommitted in the draft field.
+  const addValues = async (
+    user: ReturnType<typeof userEvent.setup>,
+    rowIndex: number,
+    values: string,
+  ) => {
+    const addFields = screen.getAllByTestId('value-chip-add')
+    await user.type(addFields[rowIndex]!, `${values}{Enter}`)
+  }
+
   const buildTwoByTwoSet = async (user: ReturnType<typeof userEvent.setup>) => {
     await user.type(screen.getByTestId('variant-set-form-name'), 'Regional launch')
     await user.type(screen.getByTestId('variant-set-form-dimension-key'), 'market')
-    await user.type(screen.getByTestId('variant-set-form-dimension-values'), 'uk, us')
+    await addValues(user, 0, 'uk, us')
     await user.click(screen.getByRole('button', {name: 'Add dimension'}))
 
     const keyInputs = screen.getAllByTestId('variant-set-form-dimension-key')
-    const valueInputs = screen.getAllByTestId('variant-set-form-dimension-values')
     await user.type(keyInputs[1]!, 'segment')
-    await user.type(valueInputs[1]!, 'loyal, new')
+    await addValues(user, 1, 'loyal, new')
   }
 
   it('previews the permutation count as a dimension is entered', async () => {
@@ -62,7 +72,7 @@ describe('CreateVariantSetDialog', () => {
     expect(screen.getByTestId('generate-variant-set-button')).toBeDisabled()
 
     await user.type(screen.getByTestId('variant-set-form-dimension-key'), 'market')
-    await user.type(screen.getByTestId('variant-set-form-dimension-values'), 'uk, us, de')
+    await addValues(user, 0, 'uk, us, de')
 
     await waitFor(() => {
       expect(screen.getByTestId('variant-set-preview')).toHaveTextContent(
@@ -71,12 +81,28 @@ describe('CreateVariantSetDialog', () => {
     })
   })
 
+  it('splits comma-separated input into individual value chips', async () => {
+    const user = userEvent.setup()
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-set-form-dimension-key'), 'market')
+    await addValues(user, 0, 'uk, us, de')
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('value-chip-input')).toHaveLength(3)
+    })
+    const chipValues = screen
+      .getAllByTestId('value-chip-input')
+      .map((input) => (input as HTMLInputElement).value)
+    expect(chipValues).toEqual(['uk', 'us', 'de'])
+  })
+
   it('varies the example placeholder per dimension row', async () => {
     const user = userEvent.setup()
     await renderDialog()
 
     await user.type(screen.getByTestId('variant-set-form-dimension-key'), 'market')
-    await user.type(screen.getByTestId('variant-set-form-dimension-values'), 'uk, us')
+    await addValues(user, 0, 'uk, us')
     await user.click(screen.getByRole('button', {name: 'Add dimension'}))
 
     const keyInputs = screen.getAllByTestId('variant-set-form-dimension-key')
@@ -91,7 +117,7 @@ describe('CreateVariantSetDialog', () => {
     expect(screen.getByTestId('export-json-button')).toBeDisabled()
 
     await user.type(screen.getByTestId('variant-set-form-dimension-key'), 'market')
-    await user.type(screen.getByTestId('variant-set-form-dimension-values'), 'uk, us')
+    await addValues(user, 0, 'uk, us')
 
     await waitFor(() => expect(screen.getByTestId('export-json-button')).toBeEnabled())
   })
@@ -132,7 +158,7 @@ describe('CreateVariantSetDialog', () => {
     await renderDialog()
 
     await user.type(screen.getByTestId('variant-set-form-dimension-key'), 'market')
-    await user.type(screen.getByTestId('variant-set-form-dimension-values'), 'uk, us, de')
+    await addValues(user, 0, 'uk, us, de')
 
     expect(screen.getByTestId('generate-variant-set-button')).toBeDisabled()
     expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantSetDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantSetDialog.test.tsx
@@ -1,0 +1,85 @@
+import {render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {variantsUsEnglishLocaleBundle} from '../../../i18n'
+import {CreateVariantSetDialog} from '../CreateVariantSetDialog'
+
+describe('CreateVariantSetDialog', () => {
+  const renderDialog = async () => {
+    const onCancel = vi.fn()
+    const onSubmit = vi.fn()
+    const wrapper = await createTestProvider({
+      resources: [variantsUsEnglishLocaleBundle],
+    })
+    render(<CreateVariantSetDialog onCancel={onCancel} onSubmit={onSubmit} />, {wrapper})
+    await screen.findByTestId('variant-set-form-name')
+    return {onCancel, onSubmit}
+  }
+
+  it('previews the permutation count as a dimension is entered', async () => {
+    const user = userEvent.setup()
+    await renderDialog()
+
+    expect(screen.getByTestId('generate-variant-set-button')).toBeDisabled()
+
+    await user.type(screen.getByTestId('variant-set-form-dimension-key'), 'market')
+    await user.type(screen.getByTestId('variant-set-form-dimension-values'), 'uk, us, de')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variant-set-preview')).toHaveTextContent(
+        '3 variant definitions will be generated',
+      )
+    })
+  })
+
+  it('multiplies the count across dimensions', async () => {
+    const user = userEvent.setup()
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-set-form-dimension-key'), 'market')
+    await user.type(screen.getByTestId('variant-set-form-dimension-values'), 'uk, us, de')
+    await user.click(screen.getByRole('button', {name: 'Add dimension'}))
+
+    const keyInputs = screen.getAllByTestId('variant-set-form-dimension-key')
+    const valueInputs = screen.getAllByTestId('variant-set-form-dimension-values')
+    await user.type(keyInputs[1]!, 'segment')
+    await user.type(valueInputs[1]!, 'loyal, new')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variant-set-preview')).toHaveTextContent(
+        '6 variant definitions will be generated',
+      )
+    })
+  })
+
+  it('keeps generate disabled until the set has a name', async () => {
+    const user = userEvent.setup()
+    const {onSubmit} = await renderDialog()
+
+    await user.type(screen.getByTestId('variant-set-form-dimension-key'), 'market')
+    await user.type(screen.getByTestId('variant-set-form-dimension-values'), 'uk, us, de')
+
+    expect(screen.getByTestId('generate-variant-set-button')).toBeDisabled()
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('submits the parsed set when generate is clicked', async () => {
+    const user = userEvent.setup()
+    const {onSubmit} = await renderDialog()
+
+    await user.type(screen.getByTestId('variant-set-form-name'), 'Regional launch')
+    await user.type(screen.getByTestId('variant-set-form-dimension-key'), 'market')
+    await user.type(screen.getByTestId('variant-set-form-dimension-values'), 'uk, us, de')
+
+    const generateButton = screen.getByTestId('generate-variant-set-button')
+    await waitFor(() => expect(generateButton).toBeEnabled())
+    await user.click(generateButton)
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      name: 'Regional launch',
+      dimensions: [{key: 'market', values: ['uk', 'us', 'de']}],
+    })
+  })
+})

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/DeleteVariantSetDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/DeleteVariantSetDialog.test.tsx
@@ -1,0 +1,116 @@
+import {render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {variantsUsEnglishLocaleBundle} from '../../../i18n'
+import {type SystemVariant} from '../../../types'
+import {VARIANT_SET_METADATA_KEY} from '../../../util/variantSet'
+import {DeleteVariantSetDialog} from '../DeleteVariantSetDialog'
+
+const setReference = {id: 'set-1', name: 'Regional launch'}
+
+const variantOperationsMock = vi.hoisted(() => ({
+  createVariant: vi.fn(),
+  updateVariant: vi.fn(),
+  deleteVariant: vi.fn(),
+}))
+const toastMock = vi.hoisted(() => ({push: vi.fn()}))
+const variantsMock = vi.hoisted(() => ({data: [] as unknown[], byId: new Map(), loading: false}))
+const documentCountsMock = vi.hoisted(() => ({
+  data: {} as Record<string, number>,
+  error: undefined,
+}))
+
+vi.mock('@sanity/ui', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useToast: vi.fn(() => toastMock),
+}))
+vi.mock('../../../store/useVariantOperations', () => ({
+  useVariantOperations: vi.fn(() => variantOperationsMock),
+}))
+vi.mock('../../../store/useAllVariants', () => ({useAllVariants: vi.fn(() => variantsMock)}))
+vi.mock('../../../hooks/useVariantsDocumentCounts', () => ({
+  useVariantsDocumentCounts: vi.fn(() => documentCountsMock),
+}))
+
+function child(id: string, conditions: Record<string, string>): SystemVariant {
+  return {
+    _id: id,
+    _type: 'system.variant',
+    conditions,
+    priority: 0,
+    metadata: {
+      title: `Regional launch: ${Object.values(conditions).join(' / ')}`,
+      description: [],
+      [VARIANT_SET_METADATA_KEY]: setReference,
+    },
+  } as unknown as SystemVariant
+}
+
+describe('DeleteVariantSetDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    variantOperationsMock.updateVariant.mockResolvedValue(undefined)
+    variantOperationsMock.deleteVariant.mockResolvedValue(undefined)
+    variantsMock.data = [
+      child('c1', {market: 'uk'}),
+      child('c2', {market: 'us'}),
+      child('c3', {market: 'de'}),
+    ]
+    variantsMock.loading = false
+    documentCountsMock.data = {}
+  })
+
+  const renderDialog = async () => {
+    const onDone = vi.fn()
+    const wrapper = await createTestProvider({resources: [variantsUsEnglishLocaleBundle]})
+    render(
+      <DeleteVariantSetDialog onClose={vi.fn()} onDone={onDone} setReference={setReference} />,
+      {
+        wrapper,
+      },
+    )
+    await screen.findByTestId('delete-variant-set-dialog')
+    return {onDone}
+  }
+
+  it('deletes every definition when none has documents', async () => {
+    const user = userEvent.setup()
+    const {onDone} = await renderDialog()
+
+    expect(screen.getByTestId('delete-set-summary')).toHaveTextContent(
+      '3 definitions will be deleted',
+    )
+    expect(screen.queryByTestId('delete-set-retained-warning')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', {name: 'Delete set'}))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.deleteVariant).toHaveBeenCalledTimes(3)
+    })
+    expect(variantOperationsMock.updateVariant).not.toHaveBeenCalled()
+    await waitFor(() => expect(onDone).toHaveBeenCalled())
+  })
+
+  it('keeps and detaches definitions that still have documents', async () => {
+    documentCountsMock.data = {c2: 3}
+    const user = userEvent.setup()
+    const {onDone} = await renderDialog()
+
+    expect(screen.getByTestId('delete-set-summary')).toHaveTextContent(
+      '2 definitions will be deleted',
+    )
+    expect(screen.getByTestId('delete-set-retained-warning')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', {name: 'Delete set'}))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.deleteVariant).toHaveBeenCalledTimes(2)
+    })
+    // The document-bearing member is detached (updated), not deleted.
+    expect(variantOperationsMock.updateVariant).toHaveBeenCalledTimes(1)
+    expect(variantOperationsMock.updateVariant.mock.calls[0]![0]._id).toBe('c2')
+    await waitFor(() => expect(onDone).toHaveBeenCalled())
+  })
+})

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/EditVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/EditVariantDialog.test.tsx
@@ -1,0 +1,101 @@
+import {render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {variantsUsEnglishLocaleBundle} from '../../../i18n'
+import {type SystemVariant} from '../../../types'
+import {
+  getForkedFromSetReference,
+  getVariantSetReference,
+  VARIANT_SET_METADATA_KEY,
+} from '../../../util/variantSet'
+import {EditVariantDialog} from '../EditVariantDialog'
+
+const variantOperationsMock = vi.hoisted(() => ({
+  createVariant: vi.fn(),
+  updateVariant: vi.fn(),
+  deleteVariant: vi.fn(),
+}))
+
+const toastMock = vi.hoisted(() => ({push: vi.fn()}))
+const variantsMock = vi.hoisted(() => ({
+  data: [] as unknown[],
+  byId: new Map(),
+  loading: false,
+  error: undefined,
+}))
+
+vi.mock('@sanity/ui', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useToast: vi.fn(() => toastMock),
+}))
+
+vi.mock('../../../store/useVariantOperations', () => ({
+  useVariantOperations: vi.fn(() => variantOperationsMock),
+}))
+
+vi.mock('../../../store/useAllVariants', () => ({
+  useAllVariants: vi.fn(() => variantsMock),
+}))
+
+const setReference = {id: 'set-1', name: 'Regional launch'}
+
+function setMember(): SystemVariant {
+  return {
+    _id: '_.variants.abc',
+    _type: 'system.variant',
+    conditions: {market: 'uk'},
+    priority: 0,
+    metadata: {
+      title: 'Regional launch: uk',
+      description: [],
+      [VARIANT_SET_METADATA_KEY]: setReference,
+    },
+  } as unknown as SystemVariant
+}
+
+describe('EditVariantDialog fork-on-edit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    variantOperationsMock.updateVariant.mockResolvedValue(undefined)
+  })
+
+  const renderDialog = async (variant: SystemVariant) => {
+    const onSubmit = vi.fn()
+    const wrapper = await createTestProvider({resources: [variantsUsEnglishLocaleBundle]})
+    render(<EditVariantDialog onCancel={vi.fn()} onSubmit={onSubmit} variant={variant} />, {
+      wrapper,
+    })
+    await screen.findByTestId('save-variant-button')
+    return {onSubmit}
+  }
+
+  it('forks a set member when its conditions change', async () => {
+    const user = userEvent.setup()
+    await renderDialog(setMember())
+
+    const valueInput = screen.getByTestId('variant-form-condition-value')
+    await user.clear(valueInput)
+    await user.type(valueInput, 'gb')
+    await user.click(screen.getByTestId('save-variant-button'))
+
+    await waitFor(() => expect(variantOperationsMock.updateVariant).toHaveBeenCalledTimes(1))
+    const saved = variantOperationsMock.updateVariant.mock.calls[0]![0]
+    expect(saved.conditions).toEqual({market: 'gb'})
+    expect(getVariantSetReference(saved)).toBeUndefined()
+    expect(getForkedFromSetReference(saved)).toEqual(setReference)
+  })
+
+  it('keeps set membership when conditions are unchanged', async () => {
+    const user = userEvent.setup()
+    await renderDialog(setMember())
+
+    await user.click(screen.getByTestId('save-variant-button'))
+
+    await waitFor(() => expect(variantOperationsMock.updateVariant).toHaveBeenCalledTimes(1))
+    const saved = variantOperationsMock.updateVariant.mock.calls[0]![0]
+    expect(getVariantSetReference(saved)).toEqual(setReference)
+    expect(getForkedFromSetReference(saved)).toBeUndefined()
+  })
+})

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/EditVariantSetDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/EditVariantSetDialog.test.tsx
@@ -1,0 +1,123 @@
+import {render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {variantsUsEnglishLocaleBundle} from '../../../i18n'
+import {type SystemVariant} from '../../../types'
+import {VARIANT_SET_METADATA_KEY} from '../../../util/variantSet'
+import {EditVariantSetDialog} from '../EditVariantSetDialog'
+
+const setReference = {id: 'set-1', name: 'Regional launch'}
+
+const variantOperationsMock = vi.hoisted(() => ({
+  createVariant: vi.fn(),
+  updateVariant: vi.fn(),
+  deleteVariant: vi.fn(),
+}))
+const toastMock = vi.hoisted(() => ({push: vi.fn()}))
+const variantsMock = vi.hoisted(() => ({data: [] as unknown[], byId: new Map(), loading: false}))
+const documentCountsMock = vi.hoisted(() => ({
+  data: {} as Record<string, number>,
+  error: undefined,
+}))
+
+vi.mock('@sanity/ui', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useToast: vi.fn(() => toastMock),
+}))
+vi.mock('../../../store/useVariantOperations', () => ({
+  useVariantOperations: vi.fn(() => variantOperationsMock),
+}))
+vi.mock('../../../store/useAllVariants', () => ({useAllVariants: vi.fn(() => variantsMock)}))
+vi.mock('../../../hooks/useVariantsDocumentCounts', () => ({
+  useVariantsDocumentCounts: vi.fn(() => documentCountsMock),
+}))
+
+function child(id: string, conditions: Record<string, string>): SystemVariant {
+  return {
+    _id: id,
+    _type: 'system.variant',
+    conditions,
+    priority: 0,
+    metadata: {
+      title: `Regional launch: ${Object.values(conditions).join(' / ')}`,
+      description: [],
+      [VARIANT_SET_METADATA_KEY]: setReference,
+    },
+  } as unknown as SystemVariant
+}
+
+describe('EditVariantSetDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    variantOperationsMock.updateVariant.mockResolvedValue(undefined)
+    variantOperationsMock.deleteVariant.mockResolvedValue(undefined)
+    variantsMock.data = [
+      child('c1', {market: 'uk', segment: 'loyal'}),
+      child('c2', {market: 'uk', segment: 'new'}),
+      child('c3', {market: 'us', segment: 'loyal'}),
+      child('c4', {market: 'us', segment: 'new'}),
+    ]
+    variantsMock.loading = false
+    documentCountsMock.data = {}
+  })
+
+  const renderDialog = async () => {
+    const onDone = vi.fn()
+    const wrapper = await createTestProvider({resources: [variantsUsEnglishLocaleBundle]})
+    render(
+      <EditVariantSetDialog onCancel={vi.fn()} onDone={onDone} setReference={setReference} />,
+      {
+        wrapper,
+      },
+    )
+    await screen.findByTestId('edit-set-apply-button')
+    return {onDone}
+  }
+
+  it('propagates a value rename to every matching definition', async () => {
+    const user = userEvent.setup()
+    const {onDone} = await renderDialog()
+
+    const loyalInput = screen.getByDisplayValue('loyal')
+    await user.clear(loyalInput)
+    await user.type(loyalInput, 'loyal-users')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-set-preview-line')).toHaveTextContent(
+        '2 definitions will be updated',
+      )
+    })
+
+    await user.click(screen.getByTestId('edit-set-apply-button'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.updateVariant).toHaveBeenCalledTimes(2)
+    })
+    const updatedConditions = variantOperationsMock.updateVariant.mock.calls.map(
+      (c) => c[0].conditions,
+    )
+    expect(updatedConditions).toEqual([
+      {market: 'uk', segment: 'loyal-users'},
+      {market: 'us', segment: 'loyal-users'},
+    ])
+    await waitFor(() => expect(onDone).toHaveBeenCalled())
+  })
+
+  it('blocks removing a value whose definitions still have documents', async () => {
+    documentCountsMock.data = {c3: 2}
+    const user = userEvent.setup()
+    await renderDialog()
+
+    // Value inputs render in order: market[uk, us], segment[loyal, new], so the second remove
+    // button removes "us" from market (affecting c3 and c4). c3 has documents → removal blocked.
+    await user.click(screen.getAllByTestId('edit-set-remove-value')[1]!)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-set-blocked-warning')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('edit-set-apply-button')).toBeDisabled()
+    expect(variantOperationsMock.deleteVariant).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/EditVariantSetDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/EditVariantSetDialog.test.tsx
@@ -110,9 +110,9 @@ describe('EditVariantSetDialog', () => {
     const user = userEvent.setup()
     await renderDialog()
 
-    // Value inputs render in order: market[uk, us], segment[loyal, new], so the second remove
+    // Value chips render in order: market[uk, us], segment[loyal, new], so the second remove
     // button removes "us" from market (affecting c3 and c4). c3 has documents → removal blocked.
-    await user.click(screen.getAllByTestId('edit-set-remove-value')[1]!)
+    await user.click(screen.getAllByTestId('value-chip-remove')[1]!)
 
     await waitFor(() => {
       expect(screen.getByTestId('edit-set-blocked-warning')).toBeInTheDocument()

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -22,6 +22,8 @@ const variantsLocaleStrings = {
   'navbar.variant.clear': 'Clear variant selection',
   /** Label for the Variants overview create action. */
   'overview.action.create-variant': 'Create variant definition',
+  /** Label for the Variants overview create-set action. */
+  'overview.action.create-variant-set': 'Create variant set',
   /** Label for the Variants overview row edit action. */
   'overview.action.edit-variant': 'Edit variant definition',
   /** Label for the Variants overview delete action. */
@@ -137,6 +139,50 @@ const variantsLocaleStrings = {
   'dialog.create.condition-value.placeholder': 'e.g. loyal-customers',
   /** Error toast title when variant creation fails. */
   'dialog.create.error.title': 'Unable to create variant definition',
+  /** Title for the create variant set dialog. */
+  'dialog.create-set.title': 'Create variant set',
+  /** Label for the set name field in the create variant set dialog. */
+  'dialog.create-set.name.label': 'Set name',
+  /** Placeholder for the set name field in the create variant set dialog. */
+  'dialog.create-set.name.placeholder': 'e.g. Regional launch',
+  /** Validation message when the set name is missing. */
+  'dialog.create-set.name.required': 'Set name is required',
+  /** Title for the dimensions section in the create variant set dialog. */
+  'dialog.create-set.dimensions.title': 'Dimensions',
+  /** Description for the dimensions section in the create variant set dialog. */
+  'dialog.create-set.dimensions.description':
+    'Add each key and the list of values it can take. Every combination becomes a variant definition.',
+  /** Label for the dimension key field in the create variant set dialog. */
+  'dialog.create-set.dimension-key.label': 'Key',
+  /** Placeholder for the dimension key field in the create variant set dialog. */
+  'dialog.create-set.dimension-key.placeholder': 'e.g. market',
+  /** Label for the dimension values field in the create variant set dialog. */
+  'dialog.create-set.dimension-values.label': 'Values',
+  /** Placeholder for the dimension values field in the create variant set dialog. */
+  'dialog.create-set.dimension-values.placeholder': 'e.g. uk, us, de',
+  /** Hint explaining how to enter multiple dimension values. */
+  'dialog.create-set.dimension-values.hint': 'Separate values with commas',
+  /** Validation message when a dimension has a key but no values. */
+  'dialog.create-set.dimension-values.required': 'Add at least one value',
+  /** Add dimension action for the create variant set dialog. */
+  'dialog.create-set.action.add-dimension': 'Add dimension',
+  /** Tooltip when add dimension is disabled because the current row is incomplete. */
+  'dialog.create-set.action.add-dimension.disabled-hint':
+    'Complete the current key and values before adding another.',
+  /** Remove dimension action for the create variant set dialog. */
+  'dialog.create-set.remove-dimension': 'Remove dimension',
+  /** Cancel action for the create variant set dialog. */
+  'dialog.create-set.action.cancel': 'Cancel',
+  /** Preview shown before any complete dimension exists in the create variant set dialog. */
+  'dialog.create-set.preview.empty': 'Add at least one key and value to preview the combinations',
+  /** Preview of the number of variant definitions a set will generate (singular). */
+  'dialog.create-set.preview.count_one': '{{count}} variant definition will be generated',
+  /** Preview of the number of variant definitions a set will generate (plural). */
+  'dialog.create-set.preview.count_other': '{{count}} variant definitions will be generated',
+  /** Confirm action for the create variant set dialog (singular). */
+  'dialog.create-set.action.generate_one': 'Generate {{count}} variant definition',
+  /** Confirm action for the create variant set dialog (plural). */
+  'dialog.create-set.action.generate_other': 'Generate {{count}} variant definitions',
   /** Title for the edit variant dialog. */
   'dialog.edit.title': 'Edit variant definition',
   /** Confirm action for the edit variant dialog. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -154,14 +154,20 @@ const variantsLocaleStrings = {
     'Add each key and the list of values it can take. Every combination becomes a variant definition.',
   /** Label for the dimension key field in the create variant set dialog. */
   'dialog.create-set.dimension-key.label': 'Key',
-  /** Placeholder for the dimension key field in the create variant set dialog. */
-  'dialog.create-set.dimension-key.placeholder': 'e.g. market',
   /** Label for the dimension values field in the create variant set dialog. */
   'dialog.create-set.dimension-values.label': 'Values',
-  /** Placeholder for the dimension values field in the create variant set dialog. */
-  'dialog.create-set.dimension-values.placeholder': 'e.g. uk, us, de',
-  /** Hint explaining how to enter multiple dimension values. */
-  'dialog.create-set.dimension-values.hint': 'Separate values with commas',
+  /**
+   * Rotating example placeholders, one pair per dimension row, cycled by row index in
+   * VariantSetForm so the form doesn't imply "market" is the only kind of dimension.
+   */
+  'dialog.create-set.example.0.key': 'e.g. market',
+  'dialog.create-set.example.0.values': 'e.g. uk, us, de',
+  'dialog.create-set.example.1.key': 'e.g. segment',
+  'dialog.create-set.example.1.values': 'e.g. loyal, new, vip',
+  'dialog.create-set.example.2.key': 'e.g. brand',
+  'dialog.create-set.example.2.values': 'e.g. brand-a, brand-b',
+  'dialog.create-set.example.3.key': 'e.g. channel',
+  'dialog.create-set.example.3.values': 'e.g. web, app, email',
   /** Validation message when a dimension has a key but no values. */
   'dialog.create-set.dimension-values.required': 'Add at least one value',
   /** Add dimension action for the create variant set dialog. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -80,10 +80,6 @@ const variantsLocaleStrings = {
   'detail.loading': 'Loading variant definition',
   /** Fallback text when a variant has no description. */
   'detail.no-description': 'No description yet.',
-  /** Lineage label shown when a variant definition is a member of a generated set. */
-  'detail.lineage.part-of-set': 'Part of set: {{name}}',
-  /** Lineage label shown when a variant definition was forked from a generated set. */
-  'detail.lineage.forked-from-set': 'Forked from set: {{name}}',
   /** Badge on the overview row for a variant definition that belongs to a generated set. */
   'overview.badge.set': 'Set',
   /** Badge on the overview row for a variant definition forked from a generated set. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -211,6 +211,11 @@ const variantsLocaleStrings = {
   'dialog.create-set.action.generate_one': 'Generate {{count}} variant definition',
   /** Confirm action for the create variant set dialog (plural). */
   'dialog.create-set.action.generate_other': 'Generate {{count}} variant definitions',
+  /** Warning shown before generating an unusually large set. */
+  'dialog.create-set.large-set.warning':
+    'This creates {{count}} variant definitions, which is a lot at once. Double-check your dimensions before generating.',
+  /** Confirm action after the large-set warning has been shown. */
+  'dialog.create-set.action.generate-confirm': 'Generate anyway',
   /** Error toast title when generating a variant set fails. */
   'dialog.create-set.error.title': 'Unable to generate variant definitions',
   /** Result heading after a variant set is generated (singular). */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -34,6 +34,8 @@ const variantsLocaleStrings = {
   'overview.action.edit-variant': 'Edit variant definition',
   /** Label for the Variants overview row edit-set action (shown on set members). */
   'overview.action.edit-variant-set': 'Edit variant set',
+  /** Label for the Variants overview delete-set action (on a set aggregate row). */
+  'overview.action.delete-variant-set': 'Delete variant set',
   /** Label for the Variants overview delete action. */
   'overview.action.delete-variant': 'Delete variant definition',
   /** Tooltip when delete is disabled because the variant contains one document. */
@@ -289,6 +291,25 @@ const variantsLocaleStrings = {
   'dialog.edit-set.action.cancel': 'Cancel',
   /** Error toast title when applying a set edit fails. */
   'dialog.edit-set.error.title': 'Unable to update the variant set',
+  /** Title of the delete variant set dialog. */
+  'dialog.delete-set.title': 'Delete variant set',
+  /** Description of the delete variant set dialog. */
+  'dialog.delete-set.description':
+    'Delete the set "{{name}}" and its generated definitions? This cannot be undone.',
+  /** Confirm action in the delete variant set dialog. */
+  'dialog.delete-set.action.confirm': 'Delete set',
+  /** Summary line: how many definitions the delete removes (singular). */
+  'dialog.delete-set.summary.delete_one': '{{count}} definition will be deleted.',
+  /** Summary line: how many definitions the delete removes (plural). */
+  'dialog.delete-set.summary.delete_other': '{{count}} definitions will be deleted.',
+  /** Caution when a member definition has documents and is kept as standalone (singular). */
+  'dialog.delete-set.warning.retained_one':
+    '{{count}} definition has documents and will be kept as a standalone definition.',
+  /** Caution when member definitions have documents and are kept as standalone (plural). */
+  'dialog.delete-set.warning.retained_other':
+    '{{count}} definitions have documents and will be kept as standalone definitions.',
+  /** Error toast title when deleting a set fails. */
+  'dialog.delete-set.error.title': 'Unable to delete the variant set',
   /** Title for the edit variant dialog. */
   'dialog.edit.title': 'Edit variant definition',
   /** Confirm action for the edit variant dialog. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -70,6 +70,14 @@ const variantsLocaleStrings = {
   'detail.loading': 'Loading variant definition',
   /** Fallback text when a variant has no description. */
   'detail.no-description': 'No description yet.',
+  /** Lineage label shown when a variant definition is a member of a generated set. */
+  'detail.lineage.part-of-set': 'Part of set: {{name}}',
+  /** Lineage label shown when a variant definition was forked from a generated set. */
+  'detail.lineage.forked-from-set': 'Forked from set: {{name}}',
+  /** Badge on the overview row for a variant definition that belongs to a generated set. */
+  'overview.badge.set': 'Set',
+  /** Badge on the overview row for a variant definition forked from a generated set. */
+  'overview.badge.forked': 'Forked',
   /** Empty state for variant document table. */
   'detail.documents.no-documents': 'No documents in this variant definition',
   /** Edited column header for variant document table. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -187,6 +187,18 @@ const variantsLocaleStrings = {
     'Complete the current key and values before adding another.',
   /** Remove dimension action for the create variant set dialog. */
   'dialog.create-set.remove-dimension': 'Remove dimension',
+  /** Import-from-JSON action in the create variant set dialog. */
+  'dialog.create-set.action.import-json': 'Import JSON',
+  /** Export-to-JSON action in the create variant set dialog. */
+  'dialog.create-set.action.export-json': 'Export JSON',
+  /** Import-from-CDP action (not yet available) in the create variant set dialog. */
+  'dialog.create-set.action.import-cdp': 'Import from CDP',
+  /** Sync-from-CDP action (not yet available) in the create variant set dialog. */
+  'dialog.create-set.action.sync-cdp': 'Sync from CDP',
+  /** Tooltip on the not-yet-available CDP actions. */
+  'dialog.create-set.cdp.coming-soon': 'Coming soon',
+  /** Error toast when an imported file cannot be read as a variant set. */
+  'dialog.create-set.import.error': 'Could not read that file as a variant set',
   /** Cancel action for the create variant set dialog. */
   'dialog.create-set.action.cancel': 'Cancel',
   /** Preview shown before any complete dimension exists in the create variant set dialog. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -22,8 +22,14 @@ const variantsLocaleStrings = {
   'navbar.variant.clear': 'Clear variant selection',
   /** Label for the Variants overview create action. */
   'overview.action.create-variant': 'Create variant definition',
+  /** Tooltip for the Variants overview create action. */
+  'overview.action.create-variant.tooltip':
+    'Creates a single variant definition. To generate many at once, use Create variant set.',
   /** Label for the Variants overview create-set action. */
   'overview.action.create-variant-set': 'Create variant set',
+  /** Tooltip for the Variants overview create-set action. */
+  'overview.action.create-variant-set.tooltip':
+    'Define dimensions and generate a variant definition for every combination.',
   /** Label for the Variants overview row edit action. */
   'overview.action.edit-variant': 'Edit variant definition',
   /** Label for the Variants overview row edit-set action (shown on set members). */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -80,6 +80,10 @@ const variantsLocaleStrings = {
   'overview.badge.set': 'Set',
   /** Badge on the overview row for a variant definition forked from a generated set. */
   'overview.badge.forked': 'Forked',
+  /** Count of definitions on a collapsed set group row (singular). */
+  'overview.set-group.count_one': '{{count}} definition',
+  /** Count of definitions on a collapsed set group row (plural). */
+  'overview.set-group.count_other': '{{count}} definitions',
   /** Empty state for variant document table. */
   'detail.documents.no-documents': 'No documents in this variant definition',
   /** Edited column header for variant document table. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -26,6 +26,8 @@ const variantsLocaleStrings = {
   'overview.action.create-variant-set': 'Create variant set',
   /** Label for the Variants overview row edit action. */
   'overview.action.edit-variant': 'Edit variant definition',
+  /** Label for the Variants overview row edit-set action (shown on set members). */
+  'overview.action.edit-variant-set': 'Edit variant set',
   /** Label for the Variants overview delete action. */
   'overview.action.delete-variant': 'Delete variant definition',
   /** Tooltip when delete is disabled because the variant contains one document. */
@@ -208,6 +210,41 @@ const variantsLocaleStrings = {
     'These are now listed under variant definitions. Editing one on its own will save it as a separate definition.',
   /** Done action to close the create variant set dialog after generation. */
   'dialog.create-set.action.done': 'Done',
+  /** Title for the edit variant set dialog. */
+  'dialog.edit-set.title': 'Edit variant set',
+  /** Description for the edit variant set dialog. */
+  'dialog.edit-set.description':
+    'Rename a value to update every definition that uses it. Removing a value deletes its definitions, unless they still contain documents.',
+  /** Add value action in the edit variant set dialog. */
+  'dialog.edit-set.add-value': 'Add value',
+  /** Remove value action in the edit variant set dialog. */
+  'dialog.edit-set.remove-value': 'Remove value',
+  /** Preview shown when a set edit has no pending changes. */
+  'dialog.edit-set.preview.none': 'No changes yet',
+  /** Preview: number of definitions a set edit will update (singular). */
+  'dialog.edit-set.preview.update_one': '{{count}} definition will be updated',
+  /** Preview: number of definitions a set edit will update (plural). */
+  'dialog.edit-set.preview.update_other': '{{count}} definitions will be updated',
+  /** Preview: number of definitions a set edit will create (singular). */
+  'dialog.edit-set.preview.create_one': '{{count}} definition will be created',
+  /** Preview: number of definitions a set edit will create (plural). */
+  'dialog.edit-set.preview.create_other': '{{count}} definitions will be created',
+  /** Preview: number of definitions a set edit will delete (singular). */
+  'dialog.edit-set.preview.delete_one': '{{count}} definition will be deleted',
+  /** Preview: number of definitions a set edit will delete (plural). */
+  'dialog.edit-set.preview.delete_other': '{{count}} definitions will be deleted',
+  /** Warning when a value removal is blocked because definitions still have documents. */
+  'dialog.edit-set.warning.blocked':
+    'Cannot remove values that still have documents: {{values}}. Move or remove those documents first.',
+  /** Warning when renames were skipped because the target value already exists. */
+  'dialog.edit-set.warning.conflict':
+    'Renames skipped because the value already exists: {{values}}',
+  /** Apply action in the edit variant set dialog. */
+  'dialog.edit-set.action.apply': 'Apply changes',
+  /** Cancel action in the edit variant set dialog. */
+  'dialog.edit-set.action.cancel': 'Cancel',
+  /** Error toast title when applying a set edit fails. */
+  'dialog.edit-set.error.title': 'Unable to update the variant set',
   /** Title for the edit variant dialog. */
   'dialog.edit.title': 'Edit variant definition',
   /** Confirm action for the edit variant dialog. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -183,6 +183,17 @@ const variantsLocaleStrings = {
   'dialog.create-set.action.generate_one': 'Generate {{count}} variant definition',
   /** Confirm action for the create variant set dialog (plural). */
   'dialog.create-set.action.generate_other': 'Generate {{count}} variant definitions',
+  /** Error toast title when generating a variant set fails. */
+  'dialog.create-set.error.title': 'Unable to generate variant definitions',
+  /** Result heading after a variant set is generated (singular). */
+  'dialog.create-set.result.title_one': '{{count}} variant definition generated',
+  /** Result heading after a variant set is generated (plural). */
+  'dialog.create-set.result.title_other': '{{count}} variant definitions generated',
+  /** Result description after a variant set is generated. */
+  'dialog.create-set.result.description':
+    'These are now listed under variant definitions. Editing one on its own will save it as a separate definition.',
+  /** Done action to close the create variant set dialog after generation. */
+  'dialog.create-set.action.done': 'Done',
   /** Title for the edit variant dialog. */
   'dialog.edit.title': 'Edit variant definition',
   /** Confirm action for the edit variant dialog. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -84,6 +84,23 @@ const variantsLocaleStrings = {
   'overview.set-group.count_one': '{{count}} definition',
   /** Count of definitions on a collapsed set group row (plural). */
   'overview.set-group.count_other': '{{count}} definitions',
+  /** Tooltip on the "Set" badge explaining set membership. */
+  'overview.badge.set.tooltip':
+    'Generated from a variant set. Edit the set to change all its definitions at once.',
+  /** Tooltip on the "Forked" badge explaining a forked definition. */
+  'overview.badge.forked.tooltip':
+    'Generated from a variant set, then edited on its own. Set changes no longer affect it.',
+  /** Title of the "how variant sets work" explainer. */
+  'explainer.title': 'How variant sets work',
+  /** First step in the variant sets explainer. */
+  'explainer.step1': 'Define your dimensions: each key and the values it can take.',
+  /** Second step in the variant sets explainer. */
+  'explainer.step2': 'Sanity generates one variant definition for every combination.',
+  /** Third step in the variant sets explainer. */
+  'explainer.step3':
+    'Edit the set to update them all. Edit one on its own and it becomes a separate definition.',
+  /** Dismiss action for the variant sets explainer. */
+  'explainer.dismiss': 'Got it',
   /** Empty state for variant document table. */
   'detail.documents.no-documents': 'No documents in this variant definition',
   /** Edited column header for variant document table. */

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -8,6 +8,7 @@ import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
 import {variantAlphaAudience, variantNorwegianMarket} from '../../__fixtures__/variants.fixture'
 import {variantsUsEnglishLocaleBundle} from '../../i18n'
 import {type EditableSystemVariant, type SystemVariant} from '../../types'
+import {VARIANT_SET_METADATA_KEY} from '../../util/variantSet'
 import {VariantsOverview} from '../overview/VariantsOverview'
 import {getVariantId} from '../util'
 
@@ -156,6 +157,43 @@ describe('VariantsOverview', () => {
     ).toBeInTheDocument()
     expect(screen.getByRole('button', {name: 'Create variant definition'})).toBeInTheDocument()
     expect(screen.getByPlaceholderText('Search variant definitions…')).toBeInTheDocument()
+  })
+
+  it('collapses a set into one aggregate row and expands it on click', async () => {
+    const setReference = {id: 'set-1', name: 'Regional launch'}
+    const member = (suffix: string, conditions: Record<string, string>): SystemVariant =>
+      ({
+        _id: `_.variants.${suffix}`,
+        _type: 'system.variant',
+        _rev: 'r',
+        _createdAt: '',
+        _updatedAt: '',
+        conditions,
+        priority: 0,
+        metadata: {
+          title: `Regional launch: ${Object.values(conditions).join(' / ')}`,
+          description: [],
+          [VARIANT_SET_METADATA_KEY]: setReference,
+        },
+      }) as unknown as SystemVariant
+
+    setVariants([member('a', {market: 'uk'}), member('b', {market: 'us'})])
+
+    const user = userEvent.setup()
+    await renderOverview()
+
+    // Collapsed by default: one aggregate header, children hidden.
+    await waitFor(() => {
+      expect(screen.getByTestId('variant-set-aggregate-toggle')).toBeInTheDocument()
+    })
+    expect(screen.getByText('2 definitions')).toBeInTheDocument()
+    expect(screen.queryByText('Regional launch: uk')).not.toBeInTheDocument()
+
+    // Expand to reveal the members.
+    await user.click(screen.getByTestId('variant-set-aggregate-toggle'))
+
+    expect(await screen.findByText('Regional launch: uk')).toBeInTheDocument()
+    expect(screen.getByText('Regional launch: us')).toBeInTheDocument()
   })
 
   it('lists variants in the virtualized table', async () => {

--- a/packages/sanity/src/core/variants/tool/overview/VariantMenuButton.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantMenuButton.tsx
@@ -1,3 +1,4 @@
+import {BlockElementIcon} from '@sanity/icons/BlockElement'
 import {EditIcon} from '@sanity/icons/Edit'
 import {TrashIcon} from '@sanity/icons/Trash'
 import {Menu, MenuDivider} from '@sanity/ui'
@@ -8,9 +9,11 @@ import {ContextMenuButton} from '../../../components/contextMenuButton'
 import {useTranslation} from '../../../i18n'
 import {DeleteVariantDialog} from '../../components/dialog/DeleteVariantDialog'
 import {EditVariantDialog} from '../../components/dialog/EditVariantDialog'
+import {EditVariantSetDialog} from '../../components/dialog/EditVariantSetDialog'
 import {useVariantDeleteAction} from '../../hooks/useVariantDeleteAction'
 import {variantsLocaleNamespace} from '../../i18n'
 import {type SystemVariant} from '../../types'
+import {getVariantSetReference} from '../../util/variantSet'
 import {getVariantId, getVariantTitle} from '../util'
 
 export function VariantMenuButton({
@@ -22,7 +25,9 @@ export function VariantMenuButton({
 }) {
   const {t} = useTranslation(variantsLocaleNamespace)
   const variantTitle = getVariantTitle(variant)
+  const setReference = getVariantSetReference(variant)
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
+  const [isEditSetDialogOpen, setIsEditSetDialogOpen] = useState(false)
   const {
     deleteDisabled,
     deleteDisabledTooltip,
@@ -46,6 +51,13 @@ export function VariantMenuButton({
               onClick={() => setIsEditDialogOpen(true)}
               text={t('overview.action.edit-variant')}
             />
+            {setReference && (
+              <MenuItem
+                icon={BlockElementIcon}
+                onClick={() => setIsEditSetDialogOpen(true)}
+                text={t('overview.action.edit-variant-set')}
+              />
+            )}
             <MenuDivider />
             <MenuItem
               disabled={deleteDisabled}
@@ -64,6 +76,13 @@ export function VariantMenuButton({
           onCancel={() => setIsEditDialogOpen(false)}
           onSubmit={() => setIsEditDialogOpen(false)}
           variant={variant}
+        />
+      )}
+      {isEditSetDialogOpen && setReference && (
+        <EditVariantSetDialog
+          onCancel={() => setIsEditSetDialogOpen(false)}
+          onDone={() => setIsEditSetDialogOpen(false)}
+          setReference={setReference}
         />
       )}
       {isDeleteDialogOpen && (

--- a/packages/sanity/src/core/variants/tool/overview/VariantSetMenuButton.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantSetMenuButton.tsx
@@ -1,0 +1,67 @@
+import {BlockElementIcon} from '@sanity/icons/BlockElement'
+import {TrashIcon} from '@sanity/icons/Trash'
+import {Menu, MenuDivider} from '@sanity/ui'
+import {useState} from 'react'
+
+import {MenuButton, MenuItem} from '../../../../ui-components'
+import {ContextMenuButton} from '../../../components/contextMenuButton'
+import {useTranslation} from '../../../i18n'
+import {DeleteVariantSetDialog} from '../../components/dialog/DeleteVariantSetDialog'
+import {EditVariantSetDialog} from '../../components/dialog/EditVariantSetDialog'
+import {variantsLocaleNamespace} from '../../i18n'
+import {type VariantSetReference} from '../../util/variantSet'
+
+/**
+ * Actions menu for a variant set's aggregate row in the overview: edit or delete the whole set.
+ *
+ * @internal
+ */
+export function VariantSetMenuButton({
+  setReference,
+}: {
+  setReference: VariantSetReference
+}): React.JSX.Element {
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const [isEditSetDialogOpen, setIsEditSetDialogOpen] = useState(false)
+  const [isDeleteSetDialogOpen, setIsDeleteSetDialogOpen] = useState(false)
+
+  return (
+    <>
+      <MenuButton
+        button={<ContextMenuButton />}
+        id={`variant-set-actions-${setReference.id}`}
+        menu={
+          <Menu>
+            <MenuItem
+              icon={BlockElementIcon}
+              onClick={() => setIsEditSetDialogOpen(true)}
+              text={t('overview.action.edit-variant-set')}
+            />
+            <MenuDivider />
+            <MenuItem
+              icon={TrashIcon}
+              onClick={() => setIsDeleteSetDialogOpen(true)}
+              text={t('overview.action.delete-variant-set')}
+              tone="critical"
+            />
+          </Menu>
+        }
+        popover={{placement: 'bottom-end', portal: true}}
+      />
+      {isEditSetDialogOpen && (
+        <EditVariantSetDialog
+          onCancel={() => setIsEditSetDialogOpen(false)}
+          onDone={() => setIsEditSetDialogOpen(false)}
+          setReference={setReference}
+        />
+      )}
+      {isDeleteSetDialogOpen && (
+        <DeleteVariantSetDialog
+          onClose={() => setIsDeleteSetDialogOpen(false)}
+          onDone={() => setIsDeleteSetDialogOpen(false)}
+          setReference={setReference}
+        />
+      )}
+    </>
+  )
+}

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
@@ -9,6 +9,7 @@ import {useTranslation} from '../../../i18n'
 import {Table, type TableProps} from '../../../releases/tool/components/Table/Table'
 import {CreateVariantDialog} from '../../components/dialog/CreateVariantDialog'
 import {CreateVariantSetDialog} from '../../components/dialog/CreateVariantSetDialog'
+import {VariantSetExplainer} from '../../components/VariantSetExplainer'
 import {useVariantsDocumentCounts} from '../../hooks/useVariantsDocumentCounts'
 import {variantsLocaleNamespace} from '../../i18n'
 import {useAllVariants} from '../../store/useAllVariants'
@@ -228,6 +229,12 @@ export function VariantsOverview() {
               value={searchQuery}
             />
           </Box>
+
+          {hasVariants && (
+            <Box flex="none" paddingBottom={4}>
+              <VariantSetExplainer />
+            </Box>
+          )}
 
           {error && (
             <Card flex="none" padding={3} tone="critical">

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
@@ -13,6 +13,7 @@ import {useVariantsDocumentCounts} from '../../hooks/useVariantsDocumentCounts'
 import {variantsLocaleNamespace} from '../../i18n'
 import {useAllVariants} from '../../store/useAllVariants'
 import {type SystemVariant} from '../../types'
+import {getVariantSetReference, type VariantSetReference} from '../../util/variantSet'
 import {filterVariantsForSearch, getVariantId} from '../util'
 import {VariantMenuButton} from './VariantMenuButton'
 import {VariantsEmptyState} from './VariantsEmptyState'
@@ -28,6 +29,19 @@ export function VariantsOverview() {
   const [searchQuery, setSearchQuery] = useState('')
   const [isCreateVariantDialogOpen, setIsCreateVariantDialogOpen] = useState(false)
   const [isCreateVariantSetDialogOpen, setIsCreateVariantSetDialogOpen] = useState(false)
+  const [expandedSets, setExpandedSets] = useState<ReadonlySet<string>>(() => new Set())
+
+  const toggleSet = useCallback((setId: string) => {
+    setExpandedSets((previous) => {
+      const next = new Set(previous)
+      if (next.has(setId)) {
+        next.delete(setId)
+      } else {
+        next.add(setId)
+      }
+      return next
+    })
+  }, [])
 
   const handleCreateVariant = useCallback(() => {
     setIsCreateVariantDialogOpen(true)
@@ -48,15 +62,18 @@ export function VariantsOverview() {
   const columnDefs = useMemo(() => variantsOverviewColumnDefs(t), [t])
   const renderRowActions = useCallback<
     NonNullable<TableProps<TableVariant, undefined>['rowActions']>
-  >(
-    ({datum}) => (
+  >(({datum}) => {
+    // Set aggregate (group header) rows have no per-definition actions.
+    if ((datum as TableVariant).isSetAggregate) {
+      return null
+    }
+    return (
       <VariantMenuButton
         documentCount={(datum as TableVariant).documentCount}
         variant={datum as SystemVariant}
       />
-    ),
-    [],
-  )
+    )
+  }, [])
 
   const variantsList = useMemo(() => variants ?? [], [variants])
 
@@ -72,6 +89,70 @@ export function VariantsOverview() {
       ),
     [variantsList, searchQuery, documentCounts, documentCountsError],
   )
+
+  // Collapse each set's generated members under one aggregate header row so a large set doesn't
+  // flood the table. Skipped while searching (grouping would hide matches) and for singleton sets.
+  const displayRows = useMemo<TableVariant[]>(() => {
+    if (searchQuery.trim()) {
+      return filteredVariants
+    }
+
+    const membersBySet = new Map<string, {ref: VariantSetReference; children: TableVariant[]}>()
+    const standalone: TableVariant[] = []
+
+    for (const variant of filteredVariants) {
+      const ref = getVariantSetReference(variant)
+      if (ref) {
+        const group = membersBySet.get(ref.id) ?? {ref, children: []}
+        group.children.push(variant)
+        membersBySet.set(ref.id, group)
+      } else {
+        standalone.push(variant)
+      }
+    }
+
+    const rows: TableVariant[] = []
+    for (const [setId, {ref, children}] of membersBySet) {
+      if (children.length < 2) {
+        rows.push(...children)
+        continue
+      }
+
+      const documentTotal = children.reduce(
+        (sum, child) => sum + (typeof child.documentCount === 'number' ? child.documentCount : 0),
+        0,
+      )
+      const isSetExpanded = expandedSets.has(setId)
+
+      rows.push({
+        // Synthetic id that satisfies the variant id template while staying distinct from any real
+        // variant document id; only used as the table row key (never navigated to).
+        _id: `_.variants.set-${setId}`,
+        _type: 'system.variant',
+        _rev: '',
+        _createdAt: '',
+        _updatedAt: '',
+        conditions: {},
+        priority: 0,
+        metadata: {title: ref.name},
+        documentCount: documentTotal,
+        isSetAggregate: true,
+        setReference: ref,
+        setChildCount: children.length,
+        isSetExpanded,
+        onToggleSet: () => toggleSet(setId),
+      })
+
+      if (isSetExpanded) {
+        for (const child of children) {
+          rows.push({...child, isSetChild: true})
+        }
+      }
+    }
+
+    rows.push(...standalone)
+    return rows
+  }, [filteredVariants, searchQuery, expandedSets, toggleSet])
 
   const hasVariants = variantsList.length > 0
 
@@ -160,7 +241,7 @@ export function VariantsOverview() {
       <Box flex={1} overflow="auto" ref={setScrollContainerRef}>
         <Table<TableVariant>
           columnDefs={columnDefs}
-          data={filteredVariants}
+          data={displayRows}
           emptyState={tableEmptyState}
           loading={loading}
           rowId={VARIANT_TABLE_ROW_ID}

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
@@ -18,6 +18,7 @@ import {getVariantSetReference, type VariantSetReference} from '../../util/varia
 import {filterVariantsForSearch, getVariantId} from '../util'
 import {VariantMenuButton} from './VariantMenuButton'
 import {VariantsEmptyState} from './VariantsEmptyState'
+import {VariantSetMenuButton} from './VariantSetMenuButton'
 import {type TableVariant, variantsOverviewColumnDefs} from './VariantsOverviewColumnDefs'
 
 const VARIANT_TABLE_ROW_ID = '_id'
@@ -64,16 +65,12 @@ export function VariantsOverview() {
   const renderRowActions = useCallback<
     NonNullable<TableProps<TableVariant, undefined>['rowActions']>
   >(({datum}) => {
-    // Set aggregate (group header) rows have no per-definition actions.
-    if ((datum as TableVariant).isSetAggregate) {
-      return null
+    const row = datum as TableVariant
+    // Set aggregate (group header) rows carry set-scoped actions (edit / delete the whole set).
+    if (row.isSetAggregate) {
+      return row.setReference ? <VariantSetMenuButton setReference={row.setReference} /> : null
     }
-    return (
-      <VariantMenuButton
-        documentCount={(datum as TableVariant).documentCount}
-        variant={datum as SystemVariant}
-      />
-    )
+    return <VariantMenuButton documentCount={row.documentCount} variant={datum as SystemVariant} />
   }, [])
 
   const variantsList = useMemo(() => variants ?? [], [variants])

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
@@ -8,6 +8,7 @@ import {Button} from '../../../../ui-components/button/Button'
 import {useTranslation} from '../../../i18n'
 import {Table, type TableProps} from '../../../releases/tool/components/Table/Table'
 import {CreateVariantDialog} from '../../components/dialog/CreateVariantDialog'
+import {CreateVariantSetDialog} from '../../components/dialog/CreateVariantSetDialog'
 import {useVariantsDocumentCounts} from '../../hooks/useVariantsDocumentCounts'
 import {variantsLocaleNamespace} from '../../i18n'
 import {useAllVariants} from '../../store/useAllVariants'
@@ -26,9 +27,14 @@ export function VariantsOverview() {
   const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [isCreateVariantDialogOpen, setIsCreateVariantDialogOpen] = useState(false)
+  const [isCreateVariantSetDialogOpen, setIsCreateVariantSetDialogOpen] = useState(false)
 
   const handleCreateVariant = useCallback(() => {
     setIsCreateVariantDialogOpen(true)
+  }, [])
+
+  const handleCreateVariantSet = useCallback(() => {
+    setIsCreateVariantSetDialogOpen(true)
   }, [])
 
   const handleOnCreateVariant = useCallback(
@@ -69,16 +75,31 @@ export function VariantsOverview() {
 
   const hasVariants = variantsList.length > 0
 
-  const createVariantButton = useMemo(
+  const createButtons = useMemo(
     () => (
-      <Button
-        disabled={isCreateVariantDialogOpen}
-        icon={AddIcon}
-        onClick={handleCreateVariant}
-        text={t('overview.action.create-variant')}
-      />
+      <Flex gap={2}>
+        <Button
+          disabled={isCreateVariantDialogOpen}
+          icon={AddIcon}
+          onClick={handleCreateVariant}
+          text={t('overview.action.create-variant')}
+        />
+        <Button
+          disabled={isCreateVariantSetDialogOpen}
+          icon={AddIcon}
+          mode="ghost"
+          onClick={handleCreateVariantSet}
+          text={t('overview.action.create-variant-set')}
+        />
+      </Flex>
     ),
-    [handleCreateVariant, isCreateVariantDialogOpen, t],
+    [
+      handleCreateVariant,
+      handleCreateVariantSet,
+      isCreateVariantDialogOpen,
+      isCreateVariantSetDialogOpen,
+      t,
+    ],
   )
 
   const tableEmptyState = useCallback(() => {
@@ -92,8 +113,8 @@ export function VariantsOverview() {
       )
     }
 
-    return <VariantsEmptyState createVariantButton={createVariantButton} />
-  }, [createVariantButton, error, hasVariants, t])
+    return <VariantsEmptyState createVariantButton={createButtons} />
+  }, [createButtons, error, hasVariants, t])
 
   return (
     <Flex direction="column" flex={1} height="fill">
@@ -110,7 +131,7 @@ export function VariantsOverview() {
                   {t('overview.description')}
                 </Text>
               </Stack>
-              {createVariantButton}
+              {createButtons}
             </Flex>
           </Card>
 
@@ -152,6 +173,15 @@ export function VariantsOverview() {
         <CreateVariantDialog
           onCancel={() => setIsCreateVariantDialogOpen(false)}
           onSubmit={handleOnCreateVariant}
+        />
+      )}
+
+      {isCreateVariantSetDialogOpen && (
+        <CreateVariantSetDialog
+          onCancel={() => setIsCreateVariantSetDialogOpen(false)}
+          // Step 2 delivers the key/value input and live preview only. Persisting the generated
+          // variant definitions is step 3; for now, submitting simply closes the dialog.
+          onSubmit={() => setIsCreateVariantSetDialogOpen(false)}
         />
       )}
     </Flex>

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
@@ -157,13 +157,8 @@ export function VariantsOverview() {
   const createButtons = useMemo(
     () => (
       <Flex gap={2}>
-        <Button
-          disabled={isCreateVariantDialogOpen}
-          icon={AddIcon}
-          onClick={handleCreateVariant}
-          text={t('overview.action.create-variant')}
-          tooltipProps={{content: t('overview.action.create-variant.tooltip')}}
-        />
+        {/* Set comes first in reading order (we want people to reach for a set), while creating a
+            single definition stays the solid primary action. */}
         <Button
           disabled={isCreateVariantSetDialogOpen}
           icon={AddIcon}
@@ -171,6 +166,13 @@ export function VariantsOverview() {
           onClick={handleCreateVariantSet}
           text={t('overview.action.create-variant-set')}
           tooltipProps={{content: t('overview.action.create-variant-set.tooltip')}}
+        />
+        <Button
+          disabled={isCreateVariantDialogOpen}
+          icon={AddIcon}
+          onClick={handleCreateVariant}
+          text={t('overview.action.create-variant')}
+          tooltipProps={{content: t('overview.action.create-variant.tooltip')}}
         />
       </Flex>
     ),

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
@@ -179,9 +179,9 @@ export function VariantsOverview() {
       {isCreateVariantSetDialogOpen && (
         <CreateVariantSetDialog
           onCancel={() => setIsCreateVariantSetDialogOpen(false)}
-          // Step 2 delivers the key/value input and live preview only. Persisting the generated
-          // variant definitions is step 3; for now, submitting simply closes the dialog.
-          onSubmit={() => setIsCreateVariantSetDialogOpen(false)}
+          // The generated definitions surface in this table automatically via the live
+          // useAllVariants query, so closing the dialog is all that's needed on done.
+          onDone={() => setIsCreateVariantSetDialogOpen(false)}
         />
       )}
     </Flex>

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
@@ -165,6 +165,7 @@ export function VariantsOverview() {
           icon={AddIcon}
           onClick={handleCreateVariant}
           text={t('overview.action.create-variant')}
+          tooltipProps={{content: t('overview.action.create-variant.tooltip')}}
         />
         <Button
           disabled={isCreateVariantSetDialogOpen}
@@ -172,6 +173,7 @@ export function VariantsOverview() {
           mode="ghost"
           onClick={handleCreateVariantSet}
           text={t('overview.action.create-variant-set')}
+          tooltipProps={{content: t('overview.action.create-variant-set.tooltip')}}
         />
       </Flex>
     ),

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
@@ -4,6 +4,7 @@ import {Badge, Box, Card, Flex, Skeleton, Stack, Text} from '@sanity/ui'
 import {type ForwardedRef, forwardRef, type HTMLProps, useMemo} from 'react'
 import {StateLink} from 'sanity/router'
 
+import {Tooltip} from '../../../../ui-components'
 import {type UseTranslationResponse, useTranslation} from '../../../i18n'
 import {Headers} from '../../../releases/tool/components/Table/TableHeader'
 import {type Column, type VisibleColumn} from '../../../releases/tool/components/Table/types'
@@ -108,9 +109,18 @@ const VariantTitleCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, datum
             <Text size={1} weight="medium">
               {variant.setReference?.name}
             </Text>
-            <Badge fontSize={0} mode="outline" tone="primary">
-              {t('overview.badge.set')}
-            </Badge>
+            <Tooltip
+              content={
+                <Box padding={2}>
+                  <Text size={1}>{t('overview.badge.set.tooltip')}</Text>
+                </Box>
+              }
+              portal
+            >
+              <Badge fontSize={0} mode="outline" tone="primary">
+                {t('overview.badge.set')}
+              </Badge>
+            </Tooltip>
             <Text muted size={1}>
               {t(
                 variant.setChildCount === 1
@@ -150,14 +160,32 @@ const VariantTitleCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, datum
                   {getVariantTitle(variant)}
                 </Text>
                 {setReference && !variant.isSetChild && (
-                  <Badge fontSize={0} mode="outline" tone="primary">
-                    {t('overview.badge.set')}
-                  </Badge>
+                  <Tooltip
+                    content={
+                      <Box padding={2}>
+                        <Text size={1}>{t('overview.badge.set.tooltip')}</Text>
+                      </Box>
+                    }
+                    portal
+                  >
+                    <Badge fontSize={0} mode="outline" tone="primary">
+                      {t('overview.badge.set')}
+                    </Badge>
+                  </Tooltip>
                 )}
                 {forkedFromReference && (
-                  <Badge fontSize={0} mode="outline" tone="caution">
-                    {t('overview.badge.forked')}
-                  </Badge>
+                  <Tooltip
+                    content={
+                      <Box padding={2}>
+                        <Text size={1}>{t('overview.badge.forked.tooltip')}</Text>
+                      </Box>
+                    }
+                    portal
+                  >
+                    <Badge fontSize={0} mode="outline" tone="caution">
+                      {t('overview.badge.forked')}
+                    </Badge>
+                  </Tooltip>
                 )}
               </Flex>
               <Text muted size={1}>

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
@@ -1,3 +1,4 @@
+import {BlockElementIcon} from '@sanity/icons/BlockElement'
 import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
 import {ChevronRightIcon} from '@sanity/icons/ChevronRight'
 import {Badge, Box, Card, Flex, Skeleton, Stack, Text} from '@sanity/ui'
@@ -106,9 +107,7 @@ const VariantTitleCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, datum
             <Text size={1}>
               {variant.isSetExpanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
             </Text>
-            <Text size={1} weight="medium">
-              {variant.setReference?.name}
-            </Text>
+            {/* A set icon prefix (instead of a "Set" text badge) keeps the label short. */}
             <Tooltip
               content={
                 <Box padding={2}>
@@ -117,10 +116,13 @@ const VariantTitleCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, datum
               }
               portal
             >
-              <Badge fontSize={0} mode="outline" tone="primary">
-                {t('overview.badge.set')}
-              </Badge>
+              <Text size={1}>
+                <BlockElementIcon />
+              </Text>
             </Tooltip>
+            <Text size={1} weight="medium">
+              {variant.setReference?.name}
+            </Text>
             <Text muted size={1}>
               {t(
                 variant.setChildCount === 1

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
@@ -1,3 +1,5 @@
+import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
+import {ChevronRightIcon} from '@sanity/icons/ChevronRight'
 import {Badge, Box, Card, Flex, Skeleton, Stack, Text} from '@sanity/ui'
 import {type ForwardedRef, forwardRef, type HTMLProps, useMemo} from 'react'
 import {StateLink} from 'sanity/router'
@@ -7,7 +9,11 @@ import {Headers} from '../../../releases/tool/components/Table/TableHeader'
 import {type Column, type VisibleColumn} from '../../../releases/tool/components/Table/types'
 import {variantsLocaleNamespace} from '../../i18n'
 import {type SystemVariant} from '../../types'
-import {getForkedFromSetReference, getVariantSetReference} from '../../util/variantSet'
+import {
+  getForkedFromSetReference,
+  getVariantSetReference,
+  type VariantSetReference,
+} from '../../util/variantSet'
 import {getVariantId, getVariantConditionsText, getVariantTitle} from '../util'
 
 /**
@@ -16,10 +22,20 @@ import {getVariantId, getVariantConditionsText, getVariantTitle} from '../util'
  * `documentCount` is `undefined` while the count is being fetched and `null` when it could
  * not be fetched.
  *
+ * A row can also be a synthetic *set aggregate* — one collapsible header standing in for all of a
+ * set's generated members, so a large set doesn't flood the table. Aggregate rows carry
+ * `isSetAggregate` and the expand state/toggle; their `documentCount` is the members' total.
+ *
  * @internal
  */
 export interface TableVariant extends SystemVariant {
   documentCount?: number | null
+  isSetAggregate?: boolean
+  setReference?: VariantSetReference
+  setChildCount?: number
+  isSetExpanded?: boolean
+  onToggleSet?: () => void
+  isSetChild?: boolean
 }
 
 const VariantDocumentsCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, datum}) => {
@@ -73,12 +89,55 @@ const VariantTitleCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, datum
     )
   }
 
+  if (variant.isSetAggregate) {
+    return (
+      <Box {...cellProps} flex={1} paddingLeft={3} paddingRight={2} paddingY={2} sizing="border">
+        <Card
+          as="button"
+          data-testid="variant-set-aggregate-toggle"
+          onClick={variant.onToggleSet}
+          padding={2}
+          radius={2}
+          tone="inherit"
+          type="button"
+        >
+          <Flex align="center" gap={2}>
+            <Text size={1}>
+              {variant.isSetExpanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
+            </Text>
+            <Text size={1} weight="medium">
+              {variant.setReference?.name}
+            </Text>
+            <Badge fontSize={0} mode="outline" tone="primary">
+              {t('overview.badge.set')}
+            </Badge>
+            <Text muted size={1}>
+              {t(
+                variant.setChildCount === 1
+                  ? 'overview.set-group.count_one'
+                  : 'overview.set-group.count_other',
+                {count: variant.setChildCount ?? 0},
+              )}
+            </Text>
+          </Flex>
+        </Card>
+      </Box>
+    )
+  }
+
   const conditionsText = getVariantConditionsText(variant.conditions)
   const setReference = getVariantSetReference(variant)
   const forkedFromReference = getForkedFromSetReference(variant)
 
   return (
-    <Box {...cellProps} flex={1} paddingLeft={3} paddingRight={2} paddingY={1} sizing="border">
+    <Box
+      {...cellProps}
+      flex={1}
+      paddingLeft={variant.isSetChild ? 6 : 3}
+      paddingRight={2}
+      paddingY={1}
+      sizing="border"
+    >
       {/* The perspective "pin" was removed here to match the detail page: adopting a variant is a
           global authoring mode that belongs in perspective-bar chrome, not this list. Returns with
           the perspective-bar work. */}
@@ -90,7 +149,7 @@ const VariantTitleCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, datum
                 <Text size={1} weight="medium">
                   {getVariantTitle(variant)}
                 </Text>
-                {setReference && (
+                {setReference && !variant.isSetChild && (
                   <Badge fontSize={0} mode="outline" tone="primary">
                     {t('overview.badge.set')}
                   </Badge>
@@ -134,7 +193,13 @@ export function variantsOverviewColumnDefs(
         </Flex>
       ),
       cell: VariantTitleCell,
-      sortTransform: (variant) => getVariantTitle(variant),
+      // Sort set members (and the set's aggregate header) by the set name so a set stays clustered
+      // as one block; the aggregate is inserted before its children and V8's stable sort keeps that
+      // order among the equal keys. Standalone definitions sort by their own title.
+      sortTransform: (variant) =>
+        variant.setReference?.name ??
+        getVariantSetReference(variant)?.name ??
+        getVariantTitle(variant),
     },
     {
       id: 'documentCount',

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
@@ -1,4 +1,4 @@
-import {Box, Card, Flex, Skeleton, Stack, Text} from '@sanity/ui'
+import {Badge, Box, Card, Flex, Skeleton, Stack, Text} from '@sanity/ui'
 import {type ForwardedRef, forwardRef, type HTMLProps, useMemo} from 'react'
 import {StateLink} from 'sanity/router'
 
@@ -7,6 +7,7 @@ import {Headers} from '../../../releases/tool/components/Table/TableHeader'
 import {type Column, type VisibleColumn} from '../../../releases/tool/components/Table/types'
 import {variantsLocaleNamespace} from '../../i18n'
 import {type SystemVariant} from '../../types'
+import {getForkedFromSetReference, getVariantSetReference} from '../../util/variantSet'
 import {getVariantId, getVariantConditionsText, getVariantTitle} from '../util'
 
 /**
@@ -73,6 +74,8 @@ const VariantTitleCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, datum
   }
 
   const conditionsText = getVariantConditionsText(variant.conditions)
+  const setReference = getVariantSetReference(variant)
+  const forkedFromReference = getForkedFromSetReference(variant)
 
   return (
     <Box {...cellProps} flex={1} paddingLeft={3} paddingRight={2} paddingY={1} sizing="border">
@@ -83,9 +86,21 @@ const VariantTitleCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, datum
         <Card as={VariantLink} data-as="a" flex={1} padding={2} radius={2} tone="inherit">
           <Flex align="center" gap={3}>
             <Stack flex={1} space={2}>
-              <Text size={1} weight="medium">
-                {getVariantTitle(variant)}
-              </Text>
+              <Flex align="center" gap={2}>
+                <Text size={1} weight="medium">
+                  {getVariantTitle(variant)}
+                </Text>
+                {setReference && (
+                  <Badge fontSize={0} mode="outline" tone="primary">
+                    {t('overview.badge.set')}
+                  </Badge>
+                )}
+                {forkedFromReference && (
+                  <Badge fontSize={0} mode="outline" tone="caution">
+                    {t('overview.badge.forked')}
+                  </Badge>
+                )}
+              </Flex>
               <Text muted size={1}>
                 {conditionsText || t('overview.table.no-conditions')}
               </Text>

--- a/packages/sanity/src/core/variants/util/__tests__/buildVariantSetDefinitions.test.ts
+++ b/packages/sanity/src/core/variants/util/__tests__/buildVariantSetDefinitions.test.ts
@@ -1,0 +1,62 @@
+import {describe, expect, it} from 'vitest'
+
+import {buildVariantSetDefinitions} from '../buildVariantSetDefinitions'
+import {getVariantSetReference} from '../variantSet'
+
+describe('buildVariantSetDefinitions', () => {
+  const input = {
+    name: 'Regional launch',
+    dimensions: [
+      {key: 'market', values: ['uk', 'us']},
+      {key: 'segment', values: ['loyal', 'new']},
+    ],
+  }
+
+  it('creates one definition per permutation', () => {
+    const {definitions} = buildVariantSetDefinitions(input)
+
+    expect(definitions).toHaveLength(4)
+    expect(definitions.map((definition) => definition.conditions)).toEqual([
+      {market: 'uk', segment: 'loyal'},
+      {market: 'uk', segment: 'new'},
+      {market: 'us', segment: 'loyal'},
+      {market: 'us', segment: 'new'},
+    ])
+  })
+
+  it('gives every definition a unique id and the system.variant type', () => {
+    const {definitions} = buildVariantSetDefinitions(input)
+    const ids = definitions.map((definition) => definition._id)
+
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(definitions.every((definition) => definition._type === 'system.variant')).toBe(true)
+    expect(definitions.every((definition) => definition.priority === 0)).toBe(true)
+  })
+
+  it('auto-titles each definition with the set name and combination', () => {
+    const {definitions} = buildVariantSetDefinitions(input)
+
+    expect(definitions[0]?.metadata?.title).toBe('Regional launch: uk / loyal')
+    expect(definitions[3]?.metadata?.title).toBe('Regional launch: us / new')
+  })
+
+  it('stamps a shared, readable back-reference on every definition', () => {
+    const {setReference, definitions} = buildVariantSetDefinitions(input)
+
+    expect(setReference.name).toBe('Regional launch')
+    expect(setReference.id).toBeTruthy()
+
+    for (const definition of definitions) {
+      expect(getVariantSetReference(definition)).toEqual(setReference)
+    }
+  })
+
+  it('trims the set name', () => {
+    const {setReference} = buildVariantSetDefinitions({
+      name: '  Regional launch  ',
+      dimensions: [{key: 'market', values: ['uk']}],
+    })
+
+    expect(setReference.name).toBe('Regional launch')
+  })
+})

--- a/packages/sanity/src/core/variants/util/__tests__/variantSet.test.ts
+++ b/packages/sanity/src/core/variants/util/__tests__/variantSet.test.ts
@@ -1,0 +1,90 @@
+import {describe, expect, it} from 'vitest'
+
+import {type EditableSystemVariant, type SystemVariant} from '../../types'
+import {
+  forkVariantFromSetIfConditionsChanged,
+  getForkedFromSetReference,
+  getVariantSetReference,
+  VARIANT_SET_FORKED_FROM_METADATA_KEY,
+  VARIANT_SET_METADATA_KEY,
+} from '../variantSet'
+
+const setReference = {id: 'set-1', name: 'Regional launch'}
+
+function member(conditions: Record<string, string>): SystemVariant {
+  return {
+    _id: '_.variants.abc',
+    _type: 'system.variant',
+    _rev: 'r',
+    _createdAt: '',
+    _updatedAt: '',
+    conditions,
+    priority: 0,
+    metadata: {title: 'x', description: [], [VARIANT_SET_METADATA_KEY]: setReference},
+  } as unknown as SystemVariant
+}
+
+describe('getVariantSetReference / getForkedFromSetReference', () => {
+  it('reads a valid membership reference', () => {
+    expect(getVariantSetReference(member({market: 'uk'}))).toEqual(setReference)
+  })
+
+  it('returns undefined when there is no reference', () => {
+    expect(getVariantSetReference({metadata: {title: 'x'}})).toBeUndefined()
+    expect(getForkedFromSetReference({metadata: {title: 'x'}})).toBeUndefined()
+  })
+
+  it('returns undefined for a malformed reference', () => {
+    expect(
+      getVariantSetReference({metadata: {[VARIANT_SET_METADATA_KEY]: {id: 1}}}),
+    ).toBeUndefined()
+  })
+
+  it('reads a fork-origin reference', () => {
+    const forked = {metadata: {[VARIANT_SET_FORKED_FROM_METADATA_KEY]: setReference}}
+    expect(getForkedFromSetReference(forked)).toEqual(setReference)
+    expect(getVariantSetReference(forked)).toBeUndefined()
+  })
+})
+
+describe('forkVariantFromSetIfConditionsChanged', () => {
+  const edit = (conditions: Record<string, string>): EditableSystemVariant => ({
+    _id: '_.variants.abc',
+    _type: 'system.variant',
+    conditions,
+    priority: 0,
+    metadata: {title: 'x', description: [], [VARIANT_SET_METADATA_KEY]: setReference},
+  })
+
+  it('forks a member when its conditions change', () => {
+    const original = member({market: 'uk'})
+    const result = forkVariantFromSetIfConditionsChanged(original, edit({market: 'gb'}))
+
+    expect(getVariantSetReference(result)).toBeUndefined()
+    expect(getForkedFromSetReference(result)).toEqual(setReference)
+  })
+
+  it('keeps membership when only non-condition fields change', () => {
+    const original = member({market: 'uk'})
+    const result = forkVariantFromSetIfConditionsChanged(original, edit({market: 'uk'}))
+
+    expect(getVariantSetReference(result)).toEqual(setReference)
+    expect(getForkedFromSetReference(result)).toBeUndefined()
+  })
+
+  it('leaves a non-member untouched', () => {
+    const original = {
+      conditions: {market: 'uk'},
+      metadata: {title: 'x'},
+    }
+    const edited: EditableSystemVariant = {
+      _id: '_.variants.abc',
+      _type: 'system.variant',
+      conditions: {market: 'gb'},
+      priority: 0,
+      metadata: {title: 'x'},
+    }
+
+    expect(forkVariantFromSetIfConditionsChanged(original, edited)).toBe(edited)
+  })
+})

--- a/packages/sanity/src/core/variants/util/__tests__/variantSetDelete.test.ts
+++ b/packages/sanity/src/core/variants/util/__tests__/variantSetDelete.test.ts
@@ -1,0 +1,55 @@
+import {describe, expect, it} from 'vitest'
+
+import {type SystemVariant} from '../../types'
+import {getVariantSetReference, VARIANT_SET_METADATA_KEY} from '../variantSet'
+import {planVariantSetDeletion} from '../variantSetDelete'
+
+const setReference = {id: 'set-1', name: 'Regional launch'}
+
+function child(id: string, conditions: Record<string, string>, setId = 'set-1'): SystemVariant {
+  return {
+    _id: id,
+    _type: 'system.variant',
+    conditions,
+    priority: 0,
+    metadata: {
+      title: id,
+      [VARIANT_SET_METADATA_KEY]: {id: setId, name: 'Regional launch'},
+    },
+  } as unknown as SystemVariant
+}
+
+describe('planVariantSetDeletion', () => {
+  const children = [
+    child('c1', {market: 'uk'}),
+    child('c2', {market: 'us'}),
+    child('c3', {market: 'de'}),
+  ]
+
+  it('deletes every member when none has documents', () => {
+    const plan = planVariantSetDeletion({setReference, children, documentCountById: {}})
+
+    expect(plan.deleteIds).toEqual(['c1', 'c2', 'c3'])
+    expect(plan.detaches).toEqual([])
+    expect(plan.retainedCount).toBe(0)
+  })
+
+  it('retains and detaches members that still have documents', () => {
+    const plan = planVariantSetDeletion({setReference, children, documentCountById: {c2: 3}})
+
+    expect(plan.deleteIds).toEqual(['c1', 'c3'])
+    expect(plan.retainedCount).toBe(1)
+    expect(plan.detaches).toHaveLength(1)
+    expect(plan.detaches[0]!._id).toBe('c2')
+    // A detached member no longer references the (now deleted) set, so it becomes standalone.
+    expect(getVariantSetReference(plan.detaches[0]!)).toBeUndefined()
+  })
+
+  it('ignores variants that belong to a different set', () => {
+    const mixed = [...children, child('other', {market: 'fr'}, 'set-2')]
+    const plan = planVariantSetDeletion({setReference, children: mixed, documentCountById: {}})
+
+    expect(plan.deleteIds).toEqual(['c1', 'c2', 'c3'])
+    expect(plan.deleteIds).not.toContain('other')
+  })
+})

--- a/packages/sanity/src/core/variants/util/__tests__/variantSetEdit.test.ts
+++ b/packages/sanity/src/core/variants/util/__tests__/variantSetEdit.test.ts
@@ -1,0 +1,157 @@
+import {describe, expect, it} from 'vitest'
+
+import {type SystemVariant} from '../../types'
+import {VARIANT_SET_METADATA_KEY} from '../variantSet'
+import {
+  type DimensionEdit,
+  planVariantSetEdit,
+  reconstructVariantSetDimensions,
+} from '../variantSetEdit'
+
+const setReference = {id: 'set-1', name: 'Regional launch'}
+
+function child(id: string, conditions: Record<string, string>): SystemVariant {
+  return {
+    _id: id,
+    _type: 'system.variant',
+    conditions,
+    priority: 0,
+    metadata: {
+      title: `Regional launch: ${Object.values(conditions).join(' / ')}`,
+      description: [],
+      [VARIANT_SET_METADATA_KEY]: setReference,
+    },
+  } as unknown as SystemVariant
+}
+
+// A 2x2 set: market (uk, us) x segment (loyal, new).
+const children = [
+  child('c1', {market: 'uk', segment: 'loyal'}),
+  child('c2', {market: 'uk', segment: 'new'}),
+  child('c3', {market: 'us', segment: 'loyal'}),
+  child('c4', {market: 'us', segment: 'new'}),
+]
+
+const unchangedMarket: DimensionEdit = {
+  key: 'market',
+  values: [
+    {originalValue: 'uk', value: 'uk'},
+    {originalValue: 'us', value: 'us'},
+  ],
+}
+const unchangedSegment: DimensionEdit = {
+  key: 'segment',
+  values: [
+    {originalValue: 'loyal', value: 'loyal'},
+    {originalValue: 'new', value: 'new'},
+  ],
+}
+
+const plan = (edits: DimensionEdit[], documentCountById: Record<string, number> = {}) =>
+  planVariantSetEdit({setReference, children, documentCountById, edits})
+
+describe('reconstructVariantSetDimensions', () => {
+  it('rebuilds ordered unique values per key from children', () => {
+    expect(reconstructVariantSetDimensions(children)).toEqual([
+      {key: 'market', values: ['uk', 'us']},
+      {key: 'segment', values: ['loyal', 'new']},
+    ])
+  })
+})
+
+describe('planVariantSetEdit', () => {
+  it('propagates a value rename by patching the matching definitions in place', () => {
+    const result = plan([
+      unchangedMarket,
+      {
+        key: 'segment',
+        values: [
+          {originalValue: 'loyal', value: 'loyal-users'},
+          {originalValue: 'new', value: 'new'},
+        ],
+      },
+    ])
+
+    expect(result.creates).toHaveLength(0)
+    expect(result.deletes).toHaveLength(0)
+    expect(result.updates.map((u) => u._id).sort()).toEqual(['c1', 'c3'])
+    const c1 = result.updates.find((u) => u._id === 'c1')!
+    expect(c1.conditions).toEqual({market: 'uk', segment: 'loyal-users'})
+    expect(c1.metadata?.title).toBe('Regional launch: uk / loyal-users')
+  })
+
+  it('deletes the definitions for a removed value when none have documents', () => {
+    const result = plan([
+      {key: 'market', values: [{originalValue: 'uk', value: 'uk'}]},
+      unchangedSegment,
+    ])
+
+    expect(result.deletes.map((d) => d.id).sort()).toEqual(['c3', 'c4'])
+    expect(result.blockedRemovals).toHaveLength(0)
+  })
+
+  it('blocks a value removal when an affected definition has documents', () => {
+    const result = plan(
+      [{key: 'market', values: [{originalValue: 'uk', value: 'uk'}]}, unchangedSegment],
+      {c3: 2},
+    )
+
+    expect(result.deletes).toHaveLength(0)
+    expect(result.blockedRemovals).toHaveLength(1)
+    expect(result.blockedRemovals[0]).toMatchObject({key: 'market', value: 'us'})
+    expect(result.blockedRemovals[0]!.withDocuments.map((d) => d.id)).toEqual(['c3'])
+  })
+
+  it('generates deduped new definitions for an added value', () => {
+    const result = plan([
+      {
+        key: 'market',
+        values: [
+          {originalValue: 'uk', value: 'uk'},
+          {originalValue: 'us', value: 'us'},
+          {originalValue: null, value: 'de'},
+        ],
+      },
+      unchangedSegment,
+    ])
+
+    expect(result.creates.map((c) => c.conditions)).toEqual([
+      {market: 'de', segment: 'loyal'},
+      {market: 'de', segment: 'new'},
+    ])
+    expect(result.updates).toHaveLength(0)
+    expect(result.deletes).toHaveLength(0)
+  })
+
+  it('does not recreate a combination that already exists (dedupe)', () => {
+    const result = plan([
+      {
+        key: 'market',
+        values: [
+          {originalValue: 'uk', value: 'uk'},
+          {originalValue: 'us', value: 'us'},
+          {originalValue: null, value: 'uk'},
+        ],
+      },
+      unchangedSegment,
+    ])
+
+    expect(result.creates).toHaveLength(0)
+  })
+
+  it('skips a rename whose target already exists and reports the conflict', () => {
+    const result = plan([
+      {
+        key: 'market',
+        values: [
+          {originalValue: 'uk', value: 'uk'},
+          {originalValue: 'us', value: 'uk'},
+        ],
+      },
+      unchangedSegment,
+    ])
+
+    expect(result.renameConflicts).toEqual([{key: 'market', from: 'us', to: 'uk'}])
+    expect(result.updates).toHaveLength(0)
+  })
+})

--- a/packages/sanity/src/core/variants/util/__tests__/variantSetJson.test.ts
+++ b/packages/sanity/src/core/variants/util/__tests__/variantSetJson.test.ts
@@ -1,0 +1,85 @@
+import {describe, expect, it} from 'vitest'
+
+import {parseVariantSetJson, serializeVariantSet} from '../variantSetJson'
+
+describe('serializeVariantSet', () => {
+  it('serializes name and complete dimensions to pretty JSON', () => {
+    const json = serializeVariantSet({
+      name: '  Regional launch  ',
+      dimensions: [
+        {key: 'market', values: ['uk', 'us']},
+        {key: 'segment', values: ['loyal']},
+      ],
+    })
+
+    expect(JSON.parse(json)).toEqual({
+      name: 'Regional launch',
+      dimensions: [
+        {key: 'market', values: ['uk', 'us']},
+        {key: 'segment', values: ['loyal']},
+      ],
+    })
+  })
+
+  it('drops incomplete dimensions', () => {
+    const json = serializeVariantSet({
+      name: 'X',
+      dimensions: [
+        {key: 'market', values: ['uk']},
+        {key: '', values: ['ignored']},
+        {key: 'segment', values: []},
+      ],
+    })
+
+    expect(JSON.parse(json).dimensions).toEqual([{key: 'market', values: ['uk']}])
+  })
+})
+
+describe('parseVariantSetJson', () => {
+  it('round-trips the serialized shape', () => {
+    const input = {name: 'Regional launch', dimensions: [{key: 'market', values: ['uk', 'us']}]}
+    const result = parseVariantSetJson(JSON.stringify(input))
+
+    expect(result).toEqual({ok: true, name: 'Regional launch', dimensions: input.dimensions})
+  })
+
+  it('accepts a bare key/value map with array or comma-string values', () => {
+    const result = parseVariantSetJson('{"market": ["uk", "us"], "segment": "loyal, new"}')
+
+    expect(result).toEqual({
+      ok: true,
+      name: '',
+      dimensions: [
+        {key: 'market', values: ['uk', 'us']},
+        {key: 'segment', values: ['loyal', 'new']},
+      ],
+    })
+  })
+
+  it('reports invalid JSON', () => {
+    expect(parseVariantSetJson('{not json')).toEqual({ok: false, error: 'invalid-json'})
+  })
+
+  it('reports an unusable shape', () => {
+    expect(parseVariantSetJson('{"dimensions": [{"key": 1}]}')).toEqual({
+      ok: false,
+      error: 'invalid-shape',
+    })
+  })
+
+  it('reports when there are no usable dimensions', () => {
+    expect(parseVariantSetJson('{"name": "empty", "dimensions": []}')).toEqual({
+      ok: false,
+      error: 'no-dimensions',
+    })
+  })
+
+  it('de-duplicates imported values', () => {
+    const result = parseVariantSetJson('{"market": ["uk", "uk", "us"]}')
+    expect(result).toEqual({
+      ok: true,
+      name: '',
+      dimensions: [{key: 'market', values: ['uk', 'us']}],
+    })
+  })
+})

--- a/packages/sanity/src/core/variants/util/__tests__/variantSetPermutations.test.ts
+++ b/packages/sanity/src/core/variants/util/__tests__/variantSetPermutations.test.ts
@@ -1,6 +1,10 @@
 import {describe, expect, it} from 'vitest'
 
-import {countVariantSetPermutations, parseVariantSetValues} from '../variantSetPermutations'
+import {
+  countVariantSetPermutations,
+  generateVariantSetPermutations,
+  parseVariantSetValues,
+} from '../variantSetPermutations'
 
 describe('parseVariantSetValues', () => {
   it('splits on commas and trims surrounding whitespace', () => {
@@ -57,5 +61,54 @@ describe('countVariantSetPermutations', () => {
         {key: 'segment', values: []},
       ]),
     ).toBe(3)
+  })
+})
+
+describe('generateVariantSetPermutations', () => {
+  it('returns an empty list when there are no complete dimensions', () => {
+    expect(generateVariantSetPermutations([])).toEqual([])
+    expect(generateVariantSetPermutations([{key: 'market', values: []}])).toEqual([])
+  })
+
+  it('expands a single dimension into one condition object per value', () => {
+    expect(generateVariantSetPermutations([{key: 'market', values: ['uk', 'us']}])).toEqual([
+      {market: 'uk'},
+      {market: 'us'},
+    ])
+  })
+
+  it('produces the cartesian product across dimensions', () => {
+    expect(
+      generateVariantSetPermutations([
+        {key: 'market', values: ['uk', 'us']},
+        {key: 'segment', values: ['loyal', 'new']},
+      ]),
+    ).toEqual([
+      {market: 'uk', segment: 'loyal'},
+      {market: 'uk', segment: 'new'},
+      {market: 'us', segment: 'loyal'},
+      {market: 'us', segment: 'new'},
+    ])
+  })
+
+  it('always returns exactly countVariantSetPermutations entries', () => {
+    const dimensions = [
+      {key: 'brand', values: ['bk', 'th', 'popeyes']},
+      {key: 'market', values: ['uk', 'us', 'de']},
+      {key: 'segment', values: ['loyal', 'new', 'vip']},
+    ]
+
+    expect(generateVariantSetPermutations(dimensions)).toHaveLength(
+      countVariantSetPermutations(dimensions),
+    )
+  })
+
+  it('trims dimension keys and ignores incomplete dimensions', () => {
+    expect(
+      generateVariantSetPermutations([
+        {key: ' market ', values: ['uk']},
+        {key: '', values: ['ignored']},
+      ]),
+    ).toEqual([{market: 'uk'}])
   })
 })

--- a/packages/sanity/src/core/variants/util/__tests__/variantSetPermutations.test.ts
+++ b/packages/sanity/src/core/variants/util/__tests__/variantSetPermutations.test.ts
@@ -1,0 +1,61 @@
+import {describe, expect, it} from 'vitest'
+
+import {countVariantSetPermutations, parseVariantSetValues} from '../variantSetPermutations'
+
+describe('parseVariantSetValues', () => {
+  it('splits on commas and trims surrounding whitespace', () => {
+    expect(parseVariantSetValues('uk, us, de')).toEqual(['uk', 'us', 'de'])
+  })
+
+  it('drops blank entries', () => {
+    expect(parseVariantSetValues('uk, , us,')).toEqual(['uk', 'us'])
+  })
+
+  it('de-duplicates while preserving first-seen order', () => {
+    expect(parseVariantSetValues('uk, us, uk, de, us')).toEqual(['uk', 'us', 'de'])
+  })
+
+  it('returns an empty list for an empty or comma-only string', () => {
+    expect(parseVariantSetValues('')).toEqual([])
+    expect(parseVariantSetValues('  ,  ,')).toEqual([])
+  })
+})
+
+describe('countVariantSetPermutations', () => {
+  it('returns 0 when there are no dimensions', () => {
+    expect(countVariantSetPermutations([])).toBe(0)
+  })
+
+  it('returns the value count for a single dimension', () => {
+    expect(countVariantSetPermutations([{key: 'market', values: ['uk', 'us', 'de']}])).toBe(3)
+  })
+
+  it('multiplies value counts across dimensions', () => {
+    expect(
+      countVariantSetPermutations([
+        {key: 'market', values: ['uk', 'us', 'de']},
+        {key: 'segment', values: ['loyal', 'new']},
+      ]),
+    ).toBe(6)
+  })
+
+  it('handles the three-dimension case from the workshop feedback', () => {
+    expect(
+      countVariantSetPermutations([
+        {key: 'brand', values: ['bk', 'th', 'popeyes']},
+        {key: 'market', values: ['uk', 'us', 'de']},
+        {key: 'segment', values: ['loyal', 'new', 'vip']},
+      ]),
+    ).toBe(27)
+  })
+
+  it('ignores dimensions that are missing a key or values', () => {
+    expect(
+      countVariantSetPermutations([
+        {key: 'market', values: ['uk', 'us', 'de']},
+        {key: '', values: ['ignored']},
+        {key: 'segment', values: []},
+      ]),
+    ).toBe(3)
+  })
+})

--- a/packages/sanity/src/core/variants/util/buildVariantSetDefinitions.ts
+++ b/packages/sanity/src/core/variants/util/buildVariantSetDefinitions.ts
@@ -1,0 +1,53 @@
+import {randomKey} from '@sanity/util/content'
+
+import {type EditableSystemVariant} from '../types'
+import {createVariantId} from './createVariantId'
+import {VARIANT_SET_METADATA_KEY, type VariantSetReference} from './variantSet'
+import {generateVariantSetPermutations, type VariantSetDimension} from './variantSetPermutations'
+
+/**
+ * A generated variant set: the shared reference stamped onto every definition, plus the
+ * definitions themselves.
+ *
+ * @internal
+ */
+export interface BuiltVariantSet {
+  setReference: VariantSetReference
+  definitions: EditableSystemVariant[]
+}
+
+function buildTitle(setName: string, conditions: Record<string, string>): string {
+  const combination = Object.values(conditions).join(' / ')
+  return combination ? `${setName}: ${combination}` : setName
+}
+
+/**
+ * Turn a named set of dimensions into one ready-to-create variant definition per permutation.
+ * Each definition gets a fresh id, an auto-generated title, and a back-reference to the set so
+ * the generated batch can be grouped and traced later. Pure aside from id generation.
+ *
+ * @internal
+ */
+export function buildVariantSetDefinitions(input: {
+  name: string
+  dimensions: VariantSetDimension[]
+}): BuiltVariantSet {
+  const setReference: VariantSetReference = {id: randomKey(12), name: input.name.trim()}
+  const permutations = generateVariantSetPermutations(input.dimensions)
+
+  const definitions = permutations.map(
+    (conditions): EditableSystemVariant => ({
+      _id: createVariantId(),
+      _type: 'system.variant',
+      conditions,
+      priority: 0,
+      metadata: {
+        title: buildTitle(setReference.name, conditions),
+        description: [],
+        [VARIANT_SET_METADATA_KEY]: setReference,
+      },
+    }),
+  )
+
+  return {setReference, definitions}
+}

--- a/packages/sanity/src/core/variants/util/buildVariantSetDefinitions.ts
+++ b/packages/sanity/src/core/variants/util/buildVariantSetDefinitions.ts
@@ -16,7 +16,16 @@ export interface BuiltVariantSet {
   definitions: EditableSystemVariant[]
 }
 
-function buildTitle(setName: string, conditions: Record<string, string>): string {
+/**
+ * Auto-title for a generated variant definition: the set name plus its combination of values,
+ * e.g. `Regional launch: uk / loyal`. Shared so set edits retitle consistently with generation.
+ *
+ * @internal
+ */
+export function buildVariantDefinitionTitle(
+  setName: string,
+  conditions: Record<string, string>,
+): string {
   const combination = Object.values(conditions).join(' / ')
   return combination ? `${setName}: ${combination}` : setName
 }
@@ -42,7 +51,7 @@ export function buildVariantSetDefinitions(input: {
       conditions,
       priority: 0,
       metadata: {
-        title: buildTitle(setReference.name, conditions),
+        title: buildVariantDefinitionTitle(setReference.name, conditions),
         description: [],
         [VARIANT_SET_METADATA_KEY]: setReference,
       },

--- a/packages/sanity/src/core/variants/util/downloadTextFile.ts
+++ b/packages/sanity/src/core/variants/util/downloadTextFile.ts
@@ -1,0 +1,23 @@
+/**
+ * Trigger a browser download of a text file. Side-effectful and browser-only (used for exporting a
+ * variant set to JSON); kept tiny and separate so the surrounding logic stays pure and testable.
+ *
+ * @internal
+ */
+export function downloadTextFile(
+  filename: string,
+  contents: string,
+  type = 'application/json',
+): void {
+  const blob = new Blob([contents], {type})
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+
+  anchor.href = url
+  anchor.download = filename
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+
+  URL.revokeObjectURL(url)
+}

--- a/packages/sanity/src/core/variants/util/variantSet.ts
+++ b/packages/sanity/src/core/variants/util/variantSet.ts
@@ -1,0 +1,47 @@
+import {type SystemVariant} from '../types'
+
+/**
+ * Metadata key under which a generated variant definition records the set it came from.
+ * A "variant set" has no document of its own (yet) — it is reified as this shared reference
+ * across every definition its generation produced, which is enough to group the children in
+ * the overview and show lineage on the detail page.
+ *
+ * @internal
+ */
+export const VARIANT_SET_METADATA_KEY = 'variantSet'
+
+/**
+ * A back-reference from a generated variant definition to its parent set.
+ *
+ * @internal
+ */
+export interface VariantSetReference {
+  id: string
+  name: string
+}
+
+/**
+ * Read the parent-set reference off a variant definition, or `undefined` if it wasn't generated
+ * from a set (hand-built definitions, and definitions that have been forked off a set, carry no
+ * reference).
+ *
+ * @internal
+ */
+export function getVariantSetReference(
+  variant: Pick<SystemVariant, 'metadata'>,
+): VariantSetReference | undefined {
+  const reference = variant.metadata?.[VARIANT_SET_METADATA_KEY]
+
+  if (
+    typeof reference === 'object' &&
+    reference !== null &&
+    'id' in reference &&
+    'name' in reference &&
+    typeof reference.id === 'string' &&
+    typeof reference.name === 'string'
+  ) {
+    return {id: reference.id, name: reference.name}
+  }
+
+  return undefined
+}

--- a/packages/sanity/src/core/variants/util/variantSet.ts
+++ b/packages/sanity/src/core/variants/util/variantSet.ts
@@ -1,17 +1,26 @@
-import {type SystemVariant} from '../types'
+import {type EditableSystemVariant, type SystemVariant} from '../types'
 
 /**
- * Metadata key under which a generated variant definition records the set it came from.
- * A "variant set" has no document of its own (yet) — it is reified as this shared reference
- * across every definition its generation produced, which is enough to group the children in
- * the overview and show lineage on the detail page.
+ * Metadata key under which a generated variant definition records the set it currently belongs to.
+ * A "variant set" has no document of its own (yet) — it is reified as this shared reference across
+ * every definition its generation produced, which is enough to group the children in the overview,
+ * show lineage on the detail page, and reconstruct the set for editing.
  *
  * @internal
  */
 export const VARIANT_SET_METADATA_KEY = 'variantSet'
 
 /**
- * A back-reference from a generated variant definition to its parent set.
+ * Metadata key under which a definition records the set it was *originally* generated from, after
+ * being forked (edited on its own). It is no longer a member of the set — this is lineage only.
+ *
+ * @internal
+ */
+export const VARIANT_SET_FORKED_FROM_METADATA_KEY = 'forkedFromSet'
+
+/**
+ * A reference from a variant definition to a set — either current membership
+ * ({@link VARIANT_SET_METADATA_KEY}) or fork origin ({@link VARIANT_SET_FORKED_FROM_METADATA_KEY}).
  *
  * @internal
  */
@@ -20,17 +29,11 @@ export interface VariantSetReference {
   name: string
 }
 
-/**
- * Read the parent-set reference off a variant definition, or `undefined` if it wasn't generated
- * from a set (hand-built definitions, and definitions that have been forked off a set, carry no
- * reference).
- *
- * @internal
- */
-export function getVariantSetReference(
+function readReference(
   variant: Pick<SystemVariant, 'metadata'>,
+  key: string,
 ): VariantSetReference | undefined {
-  const reference = variant.metadata?.[VARIANT_SET_METADATA_KEY]
+  const reference = variant.metadata?.[key]
 
   if (
     typeof reference === 'object' &&
@@ -44,4 +47,60 @@ export function getVariantSetReference(
   }
 
   return undefined
+}
+
+/**
+ * Read the parent-set reference off a variant definition, or `undefined` if it isn't a current
+ * member of a set (hand-built definitions, and definitions forked off a set, carry no membership).
+ *
+ * @internal
+ */
+export function getVariantSetReference(
+  variant: Pick<SystemVariant, 'metadata'>,
+): VariantSetReference | undefined {
+  return readReference(variant, VARIANT_SET_METADATA_KEY)
+}
+
+/**
+ * Read the fork-origin reference off a variant definition, or `undefined` if it was never
+ * generated from a set (or is still a member of one).
+ *
+ * @internal
+ */
+export function getForkedFromSetReference(
+  variant: Pick<SystemVariant, 'metadata'>,
+): VariantSetReference | undefined {
+  return readReference(variant, VARIANT_SET_FORKED_FROM_METADATA_KEY)
+}
+
+function conditionsEqual(a: Record<string, string>, b: Record<string, string>): boolean {
+  const aKeys = Object.keys(a)
+  const bKeys = Object.keys(b)
+
+  return aKeys.length === bKeys.length && aKeys.every((key) => a[key] === b[key])
+}
+
+/**
+ * When a set member's *conditions* change, detach it from the set: drop the active membership and
+ * record where it came from, so the edit can't drift the canonical set. Title/description edits
+ * alone do not fork — they don't change the combination the set owns. Returns the edited variant
+ * unchanged when it isn't a set member or its conditions are untouched.
+ *
+ * @internal
+ */
+export function forkVariantFromSetIfConditionsChanged(
+  original: Pick<SystemVariant, 'metadata' | 'conditions'>,
+  edited: EditableSystemVariant,
+): EditableSystemVariant {
+  const membership = getVariantSetReference(original)
+
+  if (!membership || conditionsEqual(original.conditions, edited.conditions)) {
+    return edited
+  }
+
+  const nextMetadata = {...edited.metadata}
+  delete nextMetadata[VARIANT_SET_METADATA_KEY]
+  nextMetadata[VARIANT_SET_FORKED_FROM_METADATA_KEY] = membership
+
+  return {...edited, metadata: nextMetadata}
 }

--- a/packages/sanity/src/core/variants/util/variantSet.ts
+++ b/packages/sanity/src/core/variants/util/variantSet.ts
@@ -73,6 +73,26 @@ export function getForkedFromSetReference(
   return readReference(variant, VARIANT_SET_FORKED_FROM_METADATA_KEY)
 }
 
+/**
+ * Detach a definition from its set: drop the active membership reference, leaving a clean
+ * standalone definition. Used when a set is deleted but some members carry documents and must be
+ * kept — stripping the reference removes them from the (now gone) set's overview group.
+ *
+ * @internal
+ */
+export function detachVariantFromSet(variant: SystemVariant): EditableSystemVariant {
+  const nextMetadata = {...variant.metadata}
+  delete nextMetadata[VARIANT_SET_METADATA_KEY]
+
+  return {
+    _id: variant._id,
+    _type: variant._type,
+    conditions: variant.conditions,
+    priority: variant.priority,
+    metadata: nextMetadata,
+  }
+}
+
 function conditionsEqual(a: Record<string, string>, b: Record<string, string>): boolean {
   const aKeys = Object.keys(a)
   const bKeys = Object.keys(b)

--- a/packages/sanity/src/core/variants/util/variantSetDelete.ts
+++ b/packages/sanity/src/core/variants/util/variantSetDelete.ts
@@ -1,0 +1,53 @@
+import {type EditableSystemVariant, type SystemVariant, type VariantId} from '../types'
+import {detachVariantFromSet, getVariantSetReference, type VariantSetReference} from './variantSet'
+
+/**
+ * The plan for deleting a variant set, computed from its current members and their document counts.
+ *
+ * Members with no documents are deleted outright. Members that carry documents are *not* deleted
+ * (that would orphan content) — instead they are detached from the set, surviving as standalone
+ * definitions so the set itself disappears from the overview.
+ *
+ * @internal
+ */
+export interface VariantSetDeletionPlan {
+  /** Member definitions with no documents — safe to delete. */
+  deleteIds: VariantId[]
+  /** Member definitions with documents, rewritten to drop set membership (kept as standalone). */
+  detaches: EditableSystemVariant[]
+  /** Number of members kept (== detaches.length), surfaced for confirmation messaging. */
+  retainedCount: number
+}
+
+/**
+ * Plans the deletion of a variant set.
+ *
+ * @internal
+ */
+export function planVariantSetDeletion({
+  setReference,
+  children,
+  documentCountById,
+}: {
+  setReference: VariantSetReference
+  children: SystemVariant[]
+  documentCountById: Record<string, number | undefined>
+}): VariantSetDeletionPlan {
+  const members = children.filter(
+    (variant) => getVariantSetReference(variant)?.id === setReference.id,
+  )
+
+  const deleteIds: VariantId[] = []
+  const detaches: EditableSystemVariant[] = []
+
+  for (const member of members) {
+    const documentCount = documentCountById[member._id] ?? 0
+    if (documentCount > 0) {
+      detaches.push(detachVariantFromSet(member))
+    } else {
+      deleteIds.push(member._id)
+    }
+  }
+
+  return {deleteIds, detaches, retainedCount: detaches.length}
+}

--- a/packages/sanity/src/core/variants/util/variantSetEdit.ts
+++ b/packages/sanity/src/core/variants/util/variantSetEdit.ts
@@ -1,0 +1,261 @@
+import {type EditableSystemVariant, type SystemVariant} from '../types'
+import {buildVariantDefinitionTitle} from './buildVariantSetDefinitions'
+import {createVariantId} from './createVariantId'
+import {VARIANT_SET_METADATA_KEY, type VariantSetReference} from './variantSet'
+import {generateVariantSetPermutations, type VariantSetDimension} from './variantSetPermutations'
+
+/**
+ * One value in the edit table. `originalValue` is the value this entry started as (so a rename can
+ * be told apart from a remove-plus-add); it is `null` for a value the user just added.
+ *
+ * @internal
+ */
+export interface DimensionValueEdit {
+  originalValue: string | null
+  value: string
+}
+
+/**
+ * The edited value list for one dimension key. Only surviving entries are present — a value the
+ * user removed is simply absent, which is how removals are detected against the reconstructed set.
+ *
+ * @internal
+ */
+export interface DimensionEdit {
+  key: string
+  values: DimensionValueEdit[]
+}
+
+/**
+ * The reconciliation of a set edit against its existing member definitions. Nothing here is
+ * written until the caller applies it, so it doubles as the preview shown before confirmation.
+ *
+ * @internal
+ */
+export interface VariantSetEditPlan {
+  /** Renamed combinations: existing definitions patched in place (id and documents preserved). */
+  updates: EditableSystemVariant[]
+  /** Added combinations: brand-new definitions, deduped against what already exists. */
+  creates: EditableSystemVariant[]
+  /** Removed combinations with no documents: safe to delete. */
+  deletes: {id: string; title: string}[]
+  /** Removals blocked because a definition still contains documents (value kept intact). */
+  blockedRemovals: {key: string; value: string; withDocuments: {id: string; title: string}[]}[]
+  /** Renames skipped because the target value already exists on that key. */
+  renameConflicts: {key: string; from: string; to: string}[]
+}
+
+/**
+ * Rebuild a set's dimensions from its member definitions: each condition key mapped to the ordered,
+ * de-duplicated set of values its children use. This is the authoritative table when there is no
+ * set document (Option A), so it seeds the edit surface.
+ *
+ * @internal
+ */
+export function reconstructVariantSetDimensions(
+  children: Pick<SystemVariant, 'conditions'>[],
+): VariantSetDimension[] {
+  const valuesByKey = new Map<string, string[]>()
+
+  for (const child of children) {
+    for (const [key, value] of Object.entries(child.conditions)) {
+      const values = valuesByKey.get(key) ?? []
+      if (!values.includes(value)) {
+        values.push(value)
+      }
+      valuesByKey.set(key, values)
+    }
+  }
+
+  return Array.from(valuesByKey, ([key, values]) => ({key, values}))
+}
+
+function titleFor(setName: string, conditions: Record<string, string>): string {
+  return buildVariantDefinitionTitle(setName, conditions)
+}
+
+/**
+ * Reconcile an edit of a variant set's values against its existing member definitions, without
+ * writing anything. Value renames patch the matching definitions in place (propagation); added
+ * values generate new deduped combinations; removed values delete their definitions unless one
+ * still has documents, in which case that value's removal is blocked. Key add/remove is out of
+ * scope here — this operates on values within the set's existing keys.
+ *
+ * @internal
+ */
+export function planVariantSetEdit(input: {
+  setReference: VariantSetReference
+  children: SystemVariant[]
+  documentCountById: Record<string, number | null | undefined>
+  edits: DimensionEdit[]
+}): VariantSetEditPlan {
+  const {setReference, children, documentCountById, edits} = input
+  const original = reconstructVariantSetDimensions(children)
+  const originalByKey = new Map(original.map((dimension) => [dimension.key, dimension.values]))
+
+  const renamesByKey = new Map<string, Map<string, string>>()
+  const removedByKey = new Map<string, Set<string>>()
+  const addedByKey = new Map<string, string[]>()
+  const newValuesByKey = new Map<string, string[]>()
+  const renameConflicts: VariantSetEditPlan['renameConflicts'] = []
+
+  for (const edit of edits) {
+    const survivingOriginals = new Set<string>()
+    const renames = new Map<string, string>()
+    const added: string[] = []
+    const resultingValues: string[] = []
+
+    for (const {originalValue, value} of edit.values) {
+      const trimmed = value.trim()
+      if (originalValue !== null) {
+        // An empty current value on an existing entry means "remove it".
+        if (trimmed) {
+          survivingOriginals.add(originalValue)
+          if (trimmed !== originalValue) {
+            renames.set(originalValue, trimmed)
+          }
+          resultingValues.push(trimmed)
+        }
+      } else if (trimmed) {
+        added.push(trimmed)
+        resultingValues.push(trimmed)
+      }
+    }
+
+    // A rename whose target already exists on this key would merge two combinations; skip it and
+    // report the conflict rather than silently collapsing definitions (and their documents).
+    const resultingSet = new Set<string>()
+    const dedupedResulting: string[] = []
+    for (const value of resultingValues) {
+      if (resultingSet.has(value)) {
+        for (const [from, to] of renames) {
+          if (to === value) {
+            renameConflicts.push({key: edit.key, from, to})
+            renames.delete(from)
+          }
+        }
+      } else {
+        resultingSet.add(value)
+        dedupedResulting.push(value)
+      }
+    }
+
+    const originalValues = originalByKey.get(edit.key) ?? []
+    const removed = new Set(originalValues.filter((value) => !survivingOriginals.has(value)))
+
+    renamesByKey.set(edit.key, renames)
+    removedByKey.set(edit.key, removed)
+    addedByKey.set(edit.key, added)
+    newValuesByKey.set(edit.key, dedupedResulting)
+  }
+
+  const deletes: VariantSetEditPlan['deletes'] = []
+  const blockedByValue = new Map<string, {id: string; title: string}[]>()
+  const updates: EditableSystemVariant[] = []
+  const survivingConditions: Record<string, string>[] = []
+
+  for (const child of children) {
+    // A child is removed if any of its condition values was removed on its key.
+    let removedOnKey: {key: string; value: string} | null = null
+    for (const [key, value] of Object.entries(child.conditions)) {
+      if (removedByKey.get(key)?.has(value)) {
+        removedOnKey = {key, value}
+        break
+      }
+    }
+
+    if (removedOnKey) {
+      const count = documentCountById[child._id]
+      const entry = {id: child._id, title: child.metadata?.title ?? child._id}
+      if (typeof count === 'number' && count > 0) {
+        const key = `${removedOnKey.key}:${removedOnKey.value}`
+        blockedByValue.set(key, [...(blockedByValue.get(key) ?? []), entry])
+      } else {
+        deletes.push(entry)
+      }
+      continue
+    }
+
+    // Apply renames to the surviving child.
+    const nextConditions: Record<string, string> = {}
+    let changed = false
+    for (const [key, value] of Object.entries(child.conditions)) {
+      const renamed = renamesByKey.get(key)?.get(value)
+      nextConditions[key] = renamed ?? value
+      if (renamed && renamed !== value) {
+        changed = true
+      }
+    }
+    survivingConditions.push(nextConditions)
+
+    if (changed) {
+      updates.push({
+        _id: child._id,
+        _type: child._type,
+        conditions: nextConditions,
+        priority: child.priority,
+        metadata: {...child.metadata, title: titleFor(setReference.name, nextConditions)},
+      })
+    }
+  }
+
+  // Blocked removals keep their value intact, so drop any deletes that belong to a blocked value.
+  const blockedRemovals: VariantSetEditPlan['blockedRemovals'] = []
+  const blockedValueKeys = new Set(blockedByValue.keys())
+  for (const [composite, withDocuments] of blockedByValue) {
+    const [key, ...rest] = composite.split(':')
+    blockedRemovals.push({key: key!, value: rest.join(':'), withDocuments})
+  }
+  const safeDeletes = deletes.filter((entry) => {
+    // Re-derive which value drove this delete to exclude blocked ones.
+    const child = children.find((candidate) => candidate._id === entry.id)!
+    for (const [key, value] of Object.entries(child.conditions)) {
+      if (removedByKey.get(key)?.has(value) && blockedValueKeys.has(`${key}:${value}`)) {
+        return false
+      }
+    }
+    return true
+  })
+
+  // Existing combinations (post-rename, minus removed) used to dedupe new creations.
+  const existingCombos = new Set(survivingConditions.map((conditions) => comboKey(conditions)))
+  const creates: EditableSystemVariant[] = []
+  const keys = Array.from(new Set(children.flatMap((child) => Object.keys(child.conditions))))
+
+  for (const [addedKey, addedValues] of addedByKey) {
+    for (const addedValue of addedValues) {
+      const dimensions: VariantSetDimension[] = keys.map((key) =>
+        key === addedKey
+          ? {key, values: [addedValue]}
+          : {key, values: newValuesByKey.get(key) ?? originalByKey.get(key) ?? []},
+      )
+      for (const conditions of generateVariantSetPermutations(dimensions)) {
+        const key = comboKey(conditions)
+        if (existingCombos.has(key)) {
+          continue
+        }
+        existingCombos.add(key)
+        creates.push({
+          _id: createVariantId(),
+          _type: 'system.variant',
+          conditions,
+          priority: 0,
+          metadata: {
+            title: titleFor(setReference.name, conditions),
+            description: [],
+            [VARIANT_SET_METADATA_KEY]: setReference,
+          },
+        })
+      }
+    }
+  }
+
+  return {updates, creates, deletes: safeDeletes, blockedRemovals, renameConflicts}
+}
+
+function comboKey(conditions: Record<string, string>): string {
+  return Object.keys(conditions)
+    .sort()
+    .map((key) => `${key}=${conditions[key]}`)
+    .join('&')
+}

--- a/packages/sanity/src/core/variants/util/variantSetJson.ts
+++ b/packages/sanity/src/core/variants/util/variantSetJson.ts
@@ -1,0 +1,122 @@
+import {parseVariantSetValues, type VariantSetDimension} from './variantSetPermutations'
+
+/**
+ * The on-disk shape of a variant set: its name and dimension table. Deliberately just the
+ * keys/values — not the generated definitions — so a set can be authored elsewhere (or in a CDP)
+ * and imported, and re-exported round-trips cleanly.
+ *
+ * @internal
+ */
+export interface VariantSetJson {
+  name: string
+  dimensions: {key: string; values: string[]}[]
+}
+
+/**
+ * Serialize a set's name and dimensions to pretty-printed JSON. Incomplete dimensions (no key or
+ * no values) are dropped so the export always reflects what would actually generate.
+ *
+ * @internal
+ */
+export function serializeVariantSet(input: {
+  name: string
+  dimensions: VariantSetDimension[]
+}): string {
+  const payload: VariantSetJson = {
+    name: input.name.trim(),
+    dimensions: input.dimensions
+      .filter((dimension) => dimension.key.trim() && dimension.values.length > 0)
+      .map((dimension) => ({key: dimension.key.trim(), values: dimension.values})),
+  }
+
+  return JSON.stringify(payload, null, 2)
+}
+
+/**
+ * The result of parsing an imported variant-set JSON file: either the extracted name and
+ * dimensions, or an error code the UI can turn into a message. Values are run through the same
+ * parser the manual input uses, so imported and typed sets behave identically.
+ *
+ * @internal
+ */
+export type ParseVariantSetResult =
+  | {ok: true; name: string; dimensions: VariantSetDimension[]}
+  | {ok: false; error: 'invalid-json' | 'invalid-shape' | 'no-dimensions'}
+
+/**
+ * Parse imported JSON into a set's name and dimensions. Accepts the {@link VariantSetJson} shape
+ * as well as a bare `{key: [values]}` / `{key: "a, b"}` map, so hand-written files and CDP exports
+ * are both tolerated. Returns a typed error rather than throwing.
+ *
+ * @internal
+ */
+export function parseVariantSetJson(text: string): ParseVariantSetResult {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    return {ok: false, error: 'invalid-json'}
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    return {ok: false, error: 'invalid-shape'}
+  }
+
+  const record = parsed as Record<string, unknown>
+  let name = ''
+  const dimensions: VariantSetDimension[] = []
+
+  if (Array.isArray(record.dimensions)) {
+    // Canonical VariantSetJson shape.
+    if (typeof record.name === 'string') {
+      name = record.name
+    }
+    for (const entry of record.dimensions) {
+      if (typeof entry !== 'object' || entry === null) {
+        return {ok: false, error: 'invalid-shape'}
+      }
+      const dimension = entry as Record<string, unknown>
+      if (typeof dimension.key !== 'string' || !Array.isArray(dimension.values)) {
+        return {ok: false, error: 'invalid-shape'}
+      }
+      const values = dimension.values.filter((value): value is string => typeof value === 'string')
+      dimensions.push({key: dimension.key.trim(), values: dedupe(values)})
+    }
+  } else {
+    // Bare {key: values} map, where values may be an array or a comma-separated string.
+    for (const [key, value] of Object.entries(record)) {
+      if (key === 'name' && typeof value === 'string') {
+        name = value
+        continue
+      }
+      if (Array.isArray(value)) {
+        const values = value.filter((item): item is string => typeof item === 'string')
+        dimensions.push({key: key.trim(), values: dedupe(values)})
+      } else if (typeof value === 'string') {
+        dimensions.push({key: key.trim(), values: parseVariantSetValues(value)})
+      } else {
+        return {ok: false, error: 'invalid-shape'}
+      }
+    }
+  }
+
+  const usable = dimensions.filter((dimension) => dimension.key && dimension.values.length > 0)
+  if (usable.length === 0) {
+    return {ok: false, error: 'no-dimensions'}
+  }
+
+  return {ok: true, name, dimensions: usable}
+}
+
+function dedupe(values: string[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const raw of values) {
+    const value = raw.trim()
+    if (value && !seen.has(value)) {
+      seen.add(value)
+      result.push(value)
+    }
+  }
+  return result
+}

--- a/packages/sanity/src/core/variants/util/variantSetPermutations.ts
+++ b/packages/sanity/src/core/variants/util/variantSetPermutations.ts
@@ -1,0 +1,54 @@
+/**
+ * A single dimension of a variant set: one condition key and the list of values it can take.
+ * A variant set is the cartesian product of its dimensions, so `market: [uk, us, de]` combined
+ * with `segment: [loyal, new]` describes 3 × 2 = 6 variant definitions.
+ *
+ * @internal
+ */
+export interface VariantSetDimension {
+  key: string
+  values: string[]
+}
+
+/**
+ * Parse a comma-separated value string into a clean, de-duplicated, order-preserving list.
+ * Blank entries are dropped and surrounding whitespace trimmed, so `"uk, us, , uk"` becomes
+ * `['uk', 'us']`. This is what lets a user paste a whole dimension's values "in one shot".
+ *
+ * @internal
+ */
+export function parseVariantSetValues(input: string): string[] {
+  const seen = new Set<string>()
+  const values: string[] = []
+
+  for (const rawValue of input.split(',')) {
+    const value = rawValue.trim()
+
+    if (value && !seen.has(value)) {
+      seen.add(value)
+      values.push(value)
+    }
+  }
+
+  return values
+}
+
+/**
+ * Count the permutations a set of dimensions would generate: the product of each dimension's
+ * value count. Dimensions without a key or without any values are ignored, so a half-typed
+ * table still previews the combinations from the dimensions that are already complete. Returns
+ * 0 when no complete dimension exists.
+ *
+ * @internal
+ */
+export function countVariantSetPermutations(dimensions: VariantSetDimension[]): number {
+  const completeDimensions = dimensions.filter(
+    (dimension) => dimension.key.trim() && dimension.values.length > 0,
+  )
+
+  if (completeDimensions.length === 0) {
+    return 0
+  }
+
+  return completeDimensions.reduce((total, dimension) => total * dimension.values.length, 1)
+}

--- a/packages/sanity/src/core/variants/util/variantSetPermutations.ts
+++ b/packages/sanity/src/core/variants/util/variantSetPermutations.ts
@@ -52,3 +52,35 @@ export function countVariantSetPermutations(dimensions: VariantSetDimension[]): 
 
   return completeDimensions.reduce((total, dimension) => total * dimension.values.length, 1)
 }
+
+/**
+ * Expand a set of dimensions into the full cartesian product of conditions — one plain
+ * `{key: value}` object per permutation. Incomplete dimensions (no key, or no values) are
+ * ignored, mirroring {@link countVariantSetPermutations}, so this always returns exactly
+ * `countVariantSetPermutations(dimensions)` entries. Returns an empty list when no complete
+ * dimension exists.
+ *
+ * @internal
+ */
+export function generateVariantSetPermutations(
+  dimensions: VariantSetDimension[],
+): Array<Record<string, string>> {
+  const completeDimensions = dimensions.filter(
+    (dimension) => dimension.key.trim() && dimension.values.length > 0,
+  )
+
+  if (completeDimensions.length === 0) {
+    return []
+  }
+
+  return completeDimensions.reduce<Array<Record<string, string>>>(
+    (permutations, dimension) => {
+      const key = dimension.key.trim()
+
+      return permutations.flatMap((permutation) =>
+        dimension.values.map((value) => ({...permutation, [key]: value})),
+      )
+    },
+    [{}],
+  )
+}


### PR DESCRIPTION
# Draft PR body — C: variant sets

Proposed PR title (conventional commit): `feat(core): variant sets for generating and managing variant definitions`

Branch: `variants/set` → base `variants/overview-ui` (**stacked** on the overview PR; retarget to `main` once that merges). Open as a **draft** first, per AGENTS.md.

**This is the "decision" PR of the three.** The other two (`variants/detail-ui`, `variants/overview-ui`) are UI-only and safe to merge fast. This one introduces a new authoring concept and a temporary data model, so it is intended to be **held for discussion and stakeholder user-testing** before it merges. Part of the Content Variants closed beta, behind the existing `beta.variants` flag.

---

### Description

Adds "variant sets" to the Variant Definitions tool: instead of hand-building every combination, an editor defines dimensions (e.g. `market: uk, us, de` by `segment: loyal, new`) once and Studio generates a variant definition per permutation.

What's included:

- **Create variant set**: a key to value-list table (editable value chips) with a live permutation-count preview and a confirmation guardrail for very large sets; on generate it creates one definition per combination, auto-titled and tagged with the set reference, shown inline. Per-row example placeholders keep the form from implying "market" is the only dimension.
- **Overview grouping**: a set's generated members collapse under one expandable aggregate row (with a set-icon prefix) so a large set doesn't flood the table.
- **Fork-on-edit**: editing a generated definition's *conditions* detaches it from the set (records `forkedFromSet`) so edits can't drift the canonical set; title/description edits keep membership. Overview shows Set/Forked badges and lineage.
- **Edit variant set**: reconstructs the dimensions from the set's members and lets you edit values; renaming a value propagates in place to every definition that uses it (ids and documents preserved); adding generates deduped combinations; removing deletes the definitions unless one still has documents, in which case removal is blocked. Every change is previewed before applying.
- **Delete variant set** (completes CRUD): the set aggregate row carries a `⋯` menu with Edit set / Delete set. Delete removes document-free members and *detaches* any members that still carry documents (stripping the set reference so they survive as standalone definitions). The confirmation dialog previews the delete count and warns about retained definitions; content is never orphaned.
- **JSON import/export** of a set's keys/values, plus disabled Import from CDP / Sync from CDP stubs showing the future flow.
- **Reordered create buttons** and an **educational explainer** card ("How variant sets work") on the overview and create dialog, dismissible per browser.

Motivated by internal field feedback (EMEA CS hands-on + Pedro/Faheem debrief, 2026-07-17).

### The data model, and why it is temporary (the thing to discuss)

A set currently has **no document of its own**. It is reified as a shared `metadata.variantSet` back-reference stamped on each definition it generates, so it needs **no Content Lake schema change** and unblocks the Studio UX today. This matches the lightest-weight option discussed in the debrief.

It is deliberately a **temporary** model, not the long-term answer, for three reasons:

1. **It can drift.** The set's dimensions are *reconstructed* from its surviving children, so a set with zero remaining members ceases to exist, and manually-deleted combinations don't reappear. The set is only as real as the definitions that still point at it.
2. **It is Studio-maintained, not contract-enforced.** A definition created via the API or an MCP agent has no guarantee the `metadata.variantSet` back-reference is written consistently. The set concept holds only because this Studio code maintains it; nothing at the data layer enforces it.
3. **It is not directly addressable.** There is no queryable, CRUD-able set object for the API/MCP path to operate on, which is a stated requirement (bi-directional "do it by API", CDP sync).

The long-term answer is a **first-class `variant set` document** as the canonical schema (enables empty sets, survives child deletion, is a natural CDP-sync and API/MCP target with referential integrity), or at minimum a **well-specified metadata contract** the API and MCP layers are bound to honor. That decision belongs to the Content Variants engineering discussion this PR is meant to open, not to this spike.

### What to review

- Variant Definitions tool, **Create variant set** (top-right). Build a set, watch the count + large-set guardrail, generate.
- The set's **aggregate row**: expand/collapse; its `⋯` menu, **Edit variant set** (rename a value, confirm it propagates; try removing a value whose definition has documents, blocked) and **Delete variant set** (on a set with documents, 0 deleted, members detached to standalone).
- Edit a generated definition's conditions directly, confirm it forks (Set badge to Forked).
- Import/Export JSON on the create-set dialog.
- Key files: `util/{variantSetPermutations,buildVariantSetDefinitions,variantSet,variantSetEdit,variantSetDelete,variantSetJson}.ts` (pure, unit-tested); `components/dialog/{CreateVariantSetDialog,VariantSetForm,EditVariantSetDialog,EditVariantSetForm,DeleteVariantSetDialog}.tsx`; `tool/overview/{VariantsOverview,VariantSetMenuButton,VariantsOverviewColumnDefs}.tsx`.

### Testing

- Variant unit tests pass (267 across the variant suite), typecheck + lint + format clean. Reconciliation logic (permutations, generation, fork transform, set-edit planner, set-delete planner, JSON parse/serialize) is covered by pure unit tests; dialogs have component tests.
- Verified visually in the dev studio with test data (generate, edit set, rename propagation, delete-set document-guard, JSON toolbar).
- **Not yet added:** dedicated E2E coverage for the new flows.

### Known limitations (in this spike)

- **Edit-set is value-level only:** adding/removing dimension *keys* is out of scope; only values within existing keys.
- **CDP import/sync** are non-functional stubs.

### Follow-ups

Tracked in Linear on this PR's ticket (**FH-112**) and its related issues, not listed here.

### Notes for release

N/A. Part of the Content Variants closed-beta feature, behind the existing `beta.variants` flag; not separately enabled.
