### PR TITLE
fix(sanity): document group inventory font weights

### DIFF
--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -324,7 +324,7 @@ const Select: ComponentType<{
       {sets.map((set) => (
         <VariantSet key={set.key} data-variant-set={set.name}>
           <VariantSetHeader as="header">
-            <Text size={1} weight="bold">
+            <Text size={1} weight="medium">
               {set.name}
             </Text>
             <TextButton
@@ -482,7 +482,7 @@ const Variant: ComponentType<{
               }}
             />
           )}
-          <Text size={1} weight="bold" className="inert">
+          <Text size={1} weight="medium" className="inert">
             {variant.name}
           </Text>
         </div>


### PR DESCRIPTION
### Description

A very tiny change to fix font weights used in the document group inventory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic typography changes only; no logic, data, or API impact.
> 
> **Overview**
> Updates typography in **document group inventory** so variant set headers and per-row variant names use `weight="medium"` instead of `weight="bold"` on the shared `Text` components in `DocumentGroupInventory.tsx`.
> 
> This is a visual-only alignment with the intended emphasis for those labels; behavior and layout are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6080b6070e4e13be24e8865b07126dc29474a2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->