### PR TITLE
chore(core): export VARIANTS_STUDIO_CLIENT_OPTIONS from core

### DIFF
--- a/packages/sanity/src/core/index.ts
+++ b/packages/sanity/src/core/index.ts
@@ -100,6 +100,7 @@ export {
 } from './validation'
 export {isDocumentInSelectedVariant} from './variants/documents/isDocumentInSelectedVariant'
 export {useVariantDocumentOperations} from './variants/hooks/useVariantDocumentOperations'
+export {VARIANTS_STUDIO_CLIENT_OPTIONS} from './variants/store/constants'
 export {getVariantTitle} from './variants/tool/util'
 export {type SystemVariant} from './variants/types'
 export * from './version'

--- a/packages/sanity/src/core/variants/store/constants.ts
+++ b/packages/sanity/src/core/variants/store/constants.ts
@@ -9,11 +9,10 @@ export const VARIANT_DOCUMENT_TYPE: 'system.variant' = 'system.variant'
 export const VARIANT_DOCUMENTS_PATH: '_.variants' = '_.variants'
 
 /**
- * @internal This is the client options used for the variants studio client, using the `X` API version for now
- * Will change to a specific version soon.
- * TODO: Remove after API version is stable and support variants
+ * @internal
+ * This is the client options used for the variants studio client, using the `X` API version for now
+ * TODO: Replace with a dated version once we have a stable API version
  */
 export const VARIANTS_STUDIO_CLIENT_OPTIONS: SourceClientOptions = {
-  // TBD; using today for now
   apiVersion: 'X',
 }

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -237,6 +237,7 @@ exports[`exports snapshot 1`] = `
     "UrlInput": "function",
     "UserAvatar": "function",
     "UserColorManagerProvider": "function",
+    "VARIANTS_STUDIO_CLIENT_OPTIONS": "object",
     "VERSION_FOLDER": "string",
     "ValueError": "function",
     "VersionChip": "object",


### PR DESCRIPTION
### Description
I need to use VARIANTS_STUDIO_CLIENT_OPTIONS in presentation.
So it needs to be exported.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.
-->
