### PR TITLE
fix(deps): update @sanity/workbench to 0.1.0-alpha.28

### DIFF
--- a/packages/@repo/test-dts-exports/test/lib-check.test.ts
+++ b/packages/@repo/test-dts-exports/test/lib-check.test.ts
@@ -57,15 +57,6 @@ const filteredErrors = errors.filter((d) => {
     return false
   }
 
-  // Temporary workaround for broken d.ts output in @sanity/workbench (still reproduced with
-  // 0.1.0-alpha.26). The bundled declarations emit the same type alias twice (e.g. Canvas,
-  // Workspace), which fails TS2300 under skipLibCheck: false. This only affects type checking in
-  // node_modules and does not impact runtime behavior. Remove once @sanity/workbench ships a
-  // release without duplicate identifiers in its generated .d.ts files.
-  if (code === 2300 && file.fileName.includes('/node_modules/@sanity/workbench/')) {
-    return false
-  }
-
   // Temporary workaround for quick-lru's TS2416 declarations with TypeScript's new iterator helper
   // types in lib.esnext.iterator.d.ts. quick-lru's methods currently return IterableIterator while
   // Map now expects MapIterator. This originates from node_modules and does not affect runtime

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -191,7 +191,7 @@
     "@sanity/ui": "catalog:",
     "@sanity/util": "workspace:*",
     "@sanity/uuid": "^3.0.3",
-    "@sanity/workbench": "0.1.0-alpha.26",
+    "@sanity/workbench": "0.1.0-alpha.28",
     "@sentry/react": "^10.62.0",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.14.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1706,8 +1706,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@sanity/workbench':
-        specifier: 0.1.0-alpha.26
-        version: 0.1.0-alpha.26(@sanity/sdk@2.17.0)(react@19.2.7)(xstate@5.32.5)
+        specifier: 0.1.0-alpha.28
+        version: 0.1.0-alpha.28(@sanity/sdk@2.17.0)(react@19.2.7)(xstate@5.32.5)
       '@sentry/react':
         specifier: ^10.62.0
         version: 10.66.0(react@19.2.7)
@@ -6993,8 +6993,8 @@ packages:
     resolution: {integrity: sha512-n2ABuylzZd6VwuhiDa23OZEgPoaBb8ImUpZM0pAr/IFsmNtJCG9a3QBHzgSpB7uqKVNdPYskA6p2NyDCCDD6iQ==}
     engines: {node: '>=22.12'}
 
-  '@sanity/workbench@0.1.0-alpha.26':
-    resolution: {integrity: sha512-jERkSQyTo1/PwxGAVybqe7JRGCo9QAEnM+T6Jj5uQvZz7X7FokD3hUas2Pht5iEkc1jECzTwhhd1P50SPd0G7A==}
+  '@sanity/workbench@0.1.0-alpha.28':
+    resolution: {integrity: sha512-xMW9bqd7hwkBKpQAzgjOXQ17zrroh3GIkSYY7HvsFSyVTj/j7s8HMl9lc0q3PAHbXvvvaWrDWMTWjU79bsHO7A==}
     engines: {node: '>=20.19.1 <22 || >=22.12'}
     peerDependencies:
       '@sanity/sdk': ^2.9.0
@@ -14033,6 +14033,10 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
+  verkit@0.1.2:
+    resolution: {integrity: sha512-WqkT8n3hqizuCu71W3bUzf5fjBmkbXcudsehe/NbxA8PgqoKnSOY5K0Ba2ckg1qaRaSpSz7as/n9K1R9JXjQKg==}
+    engines: {node: '>=18.12.0'}
+
   version-range@4.15.0:
     resolution: {integrity: sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==}
     engines: {node: '>=4'}
@@ -19669,13 +19673,13 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@sanity/workbench@0.1.0-alpha.26(@sanity/sdk@2.17.0)(react@19.2.7)(xstate@5.32.5)':
+  '@sanity/workbench@0.1.0-alpha.28(@sanity/sdk@2.17.0)(react@19.2.7)(xstate@5.32.5)':
     dependencies:
       '@module-federation/runtime': 2.7.0
       '@sanity/sdk': 2.17.0(@types/react@19.2.17)(immer@11.1.15)(react@19.2.7)(use-sync-external-store@1.6.0)(xstate@5.32.5)
       '@sanity/telemetry': 1.1.0(react@19.2.7)
       rxjs: 7.8.2
-      semver: 7.8.5
+      verkit: 0.1.2
       xstate: 5.32.5
       zod: 4.4.3
     transitivePeerDependencies:
@@ -27708,6 +27712,8 @@ snapshots:
       - rollup
       - supports-color
       - utf-8-validate
+
+  verkit@0.1.2: {}
 
   version-range@4.15.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -87,6 +87,7 @@ minimumReleaseAgeExclude:
   - 'sanity-plugin-media'
   - 'sanity-plugin-asset-source-unsplash'
   - 'sanity-plugin-utils'
+  - 'verkit@0.1.2'
   - 'vitest'
   - 'vite'
 


### PR DESCRIPTION
### Description

Bumps `@sanity/workbench` to `0.1.0-alpha.28` in the `sanity` package and removes the dts duplicate-identifier workaround from #13572.

That workaround filtered TS2300 duplicate type aliases (`Canvas`, `Workspace`, etc.) in workbench's bundled `dist/_internal.d.ts`. alpha.28 fixes the emit upstream ([workbench#316](https://github.com/sanity-io/workbench/pull/316) switched dts generation to rolldown, [workbench#317](https://github.com/sanity-io/workbench/pull/317) suffixed the zod schemas so schema consts no longer collide with their exported types), so the duplicates are gone and the filter can be deleted.

alpha.28 also swaps workbench's `semver` dependency for `verkit`. `verkit@0.1.2` is only a day old, so it trips the repo's 3-day `minimumReleaseAge` supply-chain gate (locally and in CI). Added a pinned `verkit@0.1.2` entry to `minimumReleaseAgeExclude`, matching the existing `data-uri-to-buffer@7.0.0` / `get-uri@7.0.0` precedent.

Follows up #13593, which bumped to alpha.26 and kept the workaround because alpha.26 didn't fix the dts emit.

### What to review

- The `verkit@0.1.2` exclude in `pnpm-workspace.yaml` — a pinned exception for a fresh third-party transitive dep ([sxzz/verkit](https://github.com/sxzz/verkit)).
- Lockfile diff is limited to the workbench bump (`semver` → `verkit` in workbench's deps).
- The `lib-check.test.ts` workbench filter is removed (the quick-lru filter stays).

### Testing

- `pnpm --filter @repo/test-dts-exports test` passes (2952 tests) with the workaround removed on alpha.28.

### Notes for release

N/A – Internal tooling / dependency bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and type-check tooling only; no runtime auth or data-path changes, with a narrow supply-chain exclude for a new transitive package.
> 
> **Overview**
> Bumps **`@sanity/workbench`** in the `sanity` package from `0.1.0-alpha.26` to **`0.1.0-alpha.28`**, which fixes duplicate type aliases in workbench’s generated declarations so the monorepo no longer needs a local workaround.
> 
> Removes the **`lib-check.test.ts`** filter that ignored TS2300 duplicate identifiers under `node_modules/@sanity/workbench/`; **`@repo/test-dts-exports`** still enforces `skipLibCheck: false` with the remaining third-party filters unchanged.
> 
> Because alpha.28 replaces workbench’s **`semver`** dependency with **`verkit@0.1.2`**, adds a pinned **`verkit@0.1.2`** entry to **`minimumReleaseAgeExclude`** in `pnpm-workspace.yaml` so installs pass the repo’s 3-day release-age gate. Lockfile updates reflect the workbench version and new transitive **`verkit`** dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dde9c90c87c485913dc0033d0dc88a7158d8531c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->