### PR TITLE
feat(core): three-zone table header for the variant detail table

### DIFF
--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -80,8 +80,6 @@ const variantsLocaleStrings = {
   'detail.documents.table.appears-in': 'Appears in',
   /** Header of the popover listing the bundles a document appears in beyond the first chip. */
   'detail.documents.appears-in.also-in': 'Also in',
-  /** Label for the release lane above the variant document table. */
-  'detail.release-lane.title': 'Releases',
   /** The "show all documents" segment of the release lane. */
   'detail.release-lane.all': 'All',
   /** A single release lane filter tab: a bundle label followed by its document count. */
@@ -106,8 +104,6 @@ const variantsLocaleStrings = {
   'detail.documents.bulk.delete': 'Delete selected',
   /** Label for clearing the current document selection. */
   'detail.documents.bulk.clear': 'Clear',
-  /** Note that bulk actions are prototyped but not yet wired to real operations. */
-  'detail.documents.bulk.stub-note': 'Bulk actions are being wired up',
   /** Error message when variant documents fail to load. */
   'detail.documents.error': 'Unable to load documents for this variant definition',
   /** Description for the missing Variant detail page. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -70,7 +70,9 @@ const variantsLocaleStrings = {
   'detail.documents.no-documents': 'No documents in this variant definition',
   /** Edited column header for variant document table. */
   'detail.documents.table.edited': 'Edited',
-  /** Search placeholder for variant document table. */
+  /** Document (title/preview) column header for variant document table. */
+  'detail.documents.table.document': 'Document',
+  /** Search placeholder for the variant document table search input in the command lane. */
   'detail.documents.table.search-placeholder': 'Search documents',
   /** Type column header for variant document table. */
   'detail.documents.table.type': 'Type',

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -177,7 +177,11 @@ describe('VariantDetail', () => {
     expect(screen.getByRole('button', {name: 'Back to variant definitions'})).toBeInTheDocument()
     expect(screen.getByText('Appears in')).toBeInTheDocument()
     expect(screen.getByText('Type')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('Search documents')).toBeInTheDocument()
+    // Search moved out of the column header into the command lane; the preview column is now a
+    // plain "Document" label. The command lane (and its search) is hidden for a variant with no
+    // documents, so the search box is absent here.
+    expect(screen.getByText('Document')).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Search documents')).not.toBeInTheDocument()
     expect(screen.getByText('Edited')).toBeInTheDocument()
     expect(screen.getByText('No documents in this variant definition')).toBeInTheDocument()
     expect(screen.getByText(/^Created/)).toBeInTheDocument()

--- a/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
@@ -162,11 +162,22 @@ export function VariantDocumentsTable({
 
   return (
     <Flex direction="column" flex={1} height="fill" overflow="hidden" style={{minHeight: 0}}>
-      {/* Command lane (three-zone header, zone 1): table-scoped controls — search + filter tabs —
-          kept out of the column-header row below. Bordered so it reads as distinct chrome. */}
+      {/* Command lane (three-zone header, zone 1): one persistent row of table-scoped controls —
+          select-all, search, filter tabs, and (right, under the header's Edit action) the bulk
+          actions. Because the lane is always present, selecting rows fills its right side in place
+          instead of inserting a new row, so nothing shifts vertically under the cursor. */}
       {hasDocuments && (
-        <Card flex="none" borderBottom paddingX={4} paddingY={3}>
+        <Card flex="none" borderBottom paddingX={4} paddingY={2}>
           <Flex align="center" gap={3}>
+            {/* Persistent select-all (leftmost, roughly over the checkbox column below), so it's
+                discoverable from a cold state — not revealed only after a first selection. */}
+            <Checkbox
+              aria-label={t('detail.documents.bulk.select-all')}
+              checked={allSelected}
+              data-testid="variant-bulk-select-all"
+              indeterminate={someSelected && !allSelected}
+              onChange={handleToggleAll}
+            />
             <Box flex="none" style={SEARCH_INPUT_STYLE}>
               <TextInput
                 aria-label={t('detail.documents.table.search-placeholder')}
@@ -180,75 +191,60 @@ export function VariantDocumentsTable({
                 value={searchTerm}
               />
             </Box>
-            {hasReleaseControls && (
-              <Box flex={1} style={{minWidth: 0, overflowX: 'auto'}}>
+            {/* Filter tabs fill the middle; the flex spacer keeps the bulk cluster right-aligned
+                even when there are no release controls to show. */}
+            <Box flex={1} style={{minWidth: 0, overflowX: 'auto'}}>
+              {hasReleaseControls && (
                 <VariantReleaseLane
                   activeLane={resolvedActiveLane}
                   onSelectLane={handleSelectLane}
                   segments={segments}
                   totalCount={rows.length}
                 />
-              </Box>
+              )}
+            </Box>
+            {/* Bulk actions appear here (right, under Edit) when a selection exists — in place, no
+                new row. Publish/Delete are prototyped-but-not-wired (stubbed disabled). */}
+            {selectedVisibleCount > 0 && (
+              <Flex align="center" flex="none" gap={2}>
+                <Text size={1} weight="medium">
+                  {t('detail.documents.bulk.selected', {count: selectedVisibleCount})}
+                </Text>
+                <MenuButton
+                  id="variant-bulk-actions"
+                  button={
+                    <Button
+                      data-testid="variant-bulk-actions-menu"
+                      icon={EllipsisHorizontalIcon}
+                      mode="bleed"
+                      text={t('detail.documents.bulk.actions')}
+                    />
+                  }
+                  menu={
+                    <Menu>
+                      <MenuItem
+                        disabled
+                        icon={PublishIcon}
+                        text={t('detail.documents.bulk.publish')}
+                      />
+                      <MenuItem
+                        disabled
+                        icon={TrashIcon}
+                        text={t('detail.documents.bulk.delete')}
+                        tone="critical"
+                      />
+                    </Menu>
+                  }
+                  popover={{placement: 'bottom-end', portal: true}}
+                />
+                <Button
+                  data-testid="variant-bulk-clear"
+                  mode="bleed"
+                  onClick={handleClearSelection}
+                  text={t('detail.documents.bulk.clear')}
+                />
+              </Flex>
             )}
-          </Flex>
-        </Card>
-      )}
-      {selectedVisibleCount > 0 && (
-        // Contextual selection bar (three-zone header): select-all lives here, not the column
-        // header. The publish/delete actions are prototyped-but-not-wired (stubbed disabled)
-        // pending the real document operations.
-        <Card flex="none" borderBottom paddingX={4} paddingY={2} tone="primary">
-          <Flex align="center" gap={3} justify="space-between">
-            <Flex align="center" gap={3} style={{minWidth: 0}}>
-              <Checkbox
-                aria-label={t('detail.documents.bulk.select-all')}
-                checked={allSelected}
-                data-testid="variant-bulk-select-all"
-                indeterminate={someSelected && !allSelected}
-                onChange={handleToggleAll}
-              />
-              <Text size={1} weight="medium">
-                {t('detail.documents.bulk.selected', {count: selectedVisibleCount})}
-              </Text>
-              <Text muted size={1} textOverflow="ellipsis">
-                {t('detail.documents.bulk.stub-note')}
-              </Text>
-            </Flex>
-            <Flex align="center" flex="none" gap={2}>
-              <MenuButton
-                id="variant-bulk-actions"
-                button={
-                  <Button
-                    data-testid="variant-bulk-actions-menu"
-                    icon={EllipsisHorizontalIcon}
-                    mode="bleed"
-                    text={t('detail.documents.bulk.actions')}
-                  />
-                }
-                menu={
-                  <Menu>
-                    <MenuItem
-                      disabled
-                      icon={PublishIcon}
-                      text={t('detail.documents.bulk.publish')}
-                    />
-                    <MenuItem
-                      disabled
-                      icon={TrashIcon}
-                      text={t('detail.documents.bulk.delete')}
-                      tone="critical"
-                    />
-                  </Menu>
-                }
-                popover={{placement: 'bottom-end', portal: true}}
-              />
-              <Button
-                data-testid="variant-bulk-clear"
-                mode="bleed"
-                onClick={handleClearSelection}
-                text={t('detail.documents.bulk.clear')}
-              />
-            </Flex>
           </Flex>
         </Card>
       )}

--- a/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
@@ -1,7 +1,8 @@
 import {EllipsisHorizontalIcon} from '@sanity/icons/EllipsisHorizontal'
 import {PublishIcon} from '@sanity/icons/Publish'
+import {SearchIcon} from '@sanity/icons/Search'
 import {TrashIcon} from '@sanity/icons/Trash'
-import {Box, Card, Flex, Menu, Text} from '@sanity/ui'
+import {Box, Card, Checkbox, Flex, Menu, Text, TextInput} from '@sanity/ui'
 import {type CSSProperties, useCallback, useMemo, useState} from 'react'
 
 import {Button, MenuButton, MenuItem} from '../../../../ui-components'
@@ -29,6 +30,9 @@ const TABLE_CARD_STYLE: CSSProperties = {
   scrollbarGutter: 'stable',
 }
 
+// The command-lane search input is a fixed leading control; the filter tabs fill the rest.
+const SEARCH_INPUT_STYLE: CSSProperties = {maxWidth: 280}
+
 function filterDocuments(
   rows: DocumentInVariantGroup[],
   searchTerm: string,
@@ -52,6 +56,7 @@ export function VariantDocumentsTable({
   const {t} = useTranslation(variantsLocaleNamespace)
   const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(null)
   const [activeLane, setActiveLane] = useState<string>(RELEASE_LANE_ALL)
+  const [searchTerm, setSearchTerm] = useState('')
   const [selectedGroupIds, setSelectedGroupIds] = useState<ReadonlySet<string>>(() => new Set())
   const {data: releases} = useActiveReleases()
   const releasesById = useMemo(
@@ -72,7 +77,7 @@ export function VariantDocumentsTable({
 
   // Filter tabs are the one way to scope by bundle (grouping was removed: filtering preserves
   // column sorting, which grouping cannot). A selected tab filters the flat, always-sortable list.
-  const displayRows = useMemo(() => {
+  const laneRows = useMemo(() => {
     const filtered =
       resolvedActiveLane === RELEASE_LANE_ALL
         ? rows
@@ -80,12 +85,18 @@ export function VariantDocumentsTable({
     return filtered.map((row) => ({...row, rowKey: row.groupId}))
   }, [rows, resolvedActiveLane, releasesById])
 
+  // Search is owned by this composition (not the low-level Table, whose search context is internal),
+  // so it can live in the command lane rather than the column-header row. Applied on top of the lane
+  // filter; the Table then sorts whatever it receives.
+  const displayRows = useMemo(() => filterDocuments(laneRows, searchTerm), [laneRows, searchTerm])
+
   const handleSelectLane = useCallback((laneId: string) => {
     // Clicking the already-active segment clears the filter back to "All".
     setActiveLane((previous) => (previous === laneId ? RELEASE_LANE_ALL : laneId))
   }, [])
 
-  const hasReleaseControls = !loading && segments.length > 1
+  const hasDocuments = !loading && rows.length > 0
+  const hasReleaseControls = hasDocuments && segments.length > 1
 
   // Bulk selection. Keyed by the document groupId. Selection persists across lane/search filters;
   // the count reflects what's currently visible so a filtered-out selection never inflates the bar.
@@ -151,26 +162,51 @@ export function VariantDocumentsTable({
 
   return (
     <Flex direction="column" flex={1} height="fill" overflow="hidden" style={{minHeight: 0}}>
-      {hasReleaseControls && (
-        // Bordered so the filter lane is visually distinct from the table's column-header row below.
+      {/* Command lane (three-zone header, zone 1): table-scoped controls — search + filter tabs —
+          kept out of the column-header row below. Bordered so it reads as distinct chrome. */}
+      {hasDocuments && (
         <Card flex="none" borderBottom paddingX={4} paddingY={3}>
-          <Box style={{minWidth: 0, overflowX: 'auto'}}>
-            <VariantReleaseLane
-              activeLane={resolvedActiveLane}
-              onSelectLane={handleSelectLane}
-              segments={segments}
-              totalCount={rows.length}
-            />
-          </Box>
+          <Flex align="center" gap={3}>
+            <Box flex="none" style={SEARCH_INPUT_STYLE}>
+              <TextInput
+                aria-label={t('detail.documents.table.search-placeholder')}
+                clearButton={Boolean(searchTerm)}
+                data-testid="variant-documents-search"
+                fontSize={1}
+                icon={SearchIcon}
+                onChange={(event) => setSearchTerm(event.currentTarget.value)}
+                onClear={() => setSearchTerm('')}
+                placeholder={t('detail.documents.table.search-placeholder')}
+                value={searchTerm}
+              />
+            </Box>
+            {hasReleaseControls && (
+              <Box flex={1} style={{minWidth: 0, overflowX: 'auto'}}>
+                <VariantReleaseLane
+                  activeLane={resolvedActiveLane}
+                  onSelectLane={handleSelectLane}
+                  segments={segments}
+                  totalCount={rows.length}
+                />
+              </Box>
+            )}
+          </Flex>
         </Card>
       )}
       {selectedVisibleCount > 0 && (
-        // Contextual bulk-action bar. Appears only while a selection exists. The publish/delete
-        // actions are prototyped-but-not-wired (stubbed disabled) pending the real document
-        // operations; the selection UX itself is the point of this first pass.
+        // Contextual selection bar (three-zone header): select-all lives here, not the column
+        // header. The publish/delete actions are prototyped-but-not-wired (stubbed disabled)
+        // pending the real document operations.
         <Card flex="none" borderBottom paddingX={4} paddingY={2} tone="primary">
           <Flex align="center" gap={3} justify="space-between">
             <Flex align="center" gap={3} style={{minWidth: 0}}>
+              <Checkbox
+                aria-label={t('detail.documents.bulk.select-all')}
+                checked={allSelected}
+                data-testid="variant-bulk-select-all"
+                indeterminate={someSelected && !allSelected}
+                onChange={handleToggleAll}
+              />
               <Text size={1} weight="medium">
                 {t('detail.documents.bulk.selected', {count: selectedVisibleCount})}
               </Text>
@@ -218,6 +254,7 @@ export function VariantDocumentsTable({
       )}
       <Card
         flex={1}
+        data-testid="variant-documents-table"
         id="variant-documents-table"
         ref={setScrollContainerRef}
         style={TABLE_CARD_STYLE}
@@ -231,7 +268,6 @@ export function VariantDocumentsTable({
           // oxlint-disable-next-line @sanity/i18n/no-attribute-string-literals
           rowId="rowKey"
           scrollContainerRef={scrollContainerRef}
-          searchFilter={filterDocuments}
         />
       </Card>
     </Flex>

--- a/packages/sanity/src/core/variants/tool/detail/VariantReleaseLane.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantReleaseLane.tsx
@@ -1,6 +1,4 @@
-import {FilterIcon} from '@sanity/icons/Filter'
-import {Card, Flex, TabList, Text} from '@sanity/ui'
-import {type CSSProperties} from 'react'
+import {Flex, TabList} from '@sanity/ui'
 
 import {Tab} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
@@ -12,9 +10,6 @@ function getSegmentTone(kind: ReleaseLaneKind): 'positive' | 'primary' | 'defaul
   if (kind === 'release') return 'primary'
   return 'default'
 }
-
-// Uppercase micro-label styling so "Releases" reads as a section header, not a peer of the tabs.
-const LABEL_STYLE: CSSProperties = {textTransform: 'uppercase', letterSpacing: '0.04em'}
 
 /**
  * The release lane: a filter-tab strip summarizing which bundles this variant's documents
@@ -44,16 +39,9 @@ export function VariantReleaseLane({
   }
 
   return (
-    <Flex align="center" gap={2} wrap="nowrap" data-testid="variant-release-lane">
-      <Flex align="center" flex="none" gap={1}>
-        <Text muted size={0}>
-          <FilterIcon />
-        </Text>
-        <Text muted size={0} style={LABEL_STYLE} weight="semibold">
-          {t('detail.release-lane.title')}
-        </Text>
-      </Flex>
-      <Card borderLeft flex="none" style={{height: 16}} />
+    <Flex align="center" wrap="nowrap" data-testid="variant-release-lane">
+      {/* No leading icon/label: the tabs (All, Published, Drafts, release names) are self-evidently
+          bundle filters. A filter icon here read as a clickable control that wasn't one. */}
       <TabList space={1}>
         {[
           <Tab

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
@@ -252,7 +252,7 @@ describe('VariantDocumentsTable', () => {
     expect(screen.getByTestId('variant-bulk-actions-menu')).toBeInTheDocument()
   })
 
-  it('reveals select-all in the selection bar (not the column header) and clear resets', async () => {
+  it('has a persistent command-lane select-all (not in the column header); clear resets', async () => {
     const user = userEvent.setup()
 
     await renderTable()
@@ -261,13 +261,11 @@ describe('VariantDocumentsTable', () => {
       expect(screen.getAllByTestId('table-row')).toHaveLength(2)
     })
 
-    // Select-all is not in the column header; it appears in the bar once a row is picked.
-    expect(screen.queryByRole('checkbox', {name: 'Select all documents'})).not.toBeInTheDocument()
+    // Select-all lives in the command lane and is present from a cold state (discoverable, not
+    // reveal-on-selection); there is exactly one (it is not also in the column header).
+    const selectAll = screen.getByRole('checkbox', {name: 'Select all documents'})
 
-    await user.click(screen.getAllByRole('checkbox', {name: 'Select document'})[0]!)
-
-    // The select-all now appears in the bar; clicking it selects the rest.
-    await user.click(screen.getByRole('checkbox', {name: 'Select all documents'}))
+    await user.click(selectAll)
     expect(screen.getByText('2 selected')).toBeInTheDocument()
 
     await user.click(screen.getByTestId('variant-bulk-clear'))

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
@@ -116,7 +116,9 @@ describe('VariantDocumentsTable', () => {
       resources: [variantsUsEnglishLocaleBundle],
     })
     const result = render(<VariantDocumentsTable rows={rows} loading={loading} />, {wrapper})
-    await screen.findByPlaceholderText('Search documents')
+    // Search now lives in the command lane (only shown with documents), so settle on the table
+    // container, which is always present regardless of rows/loading.
+    await screen.findByTestId('variant-documents-table')
     return result
   }
 
@@ -250,7 +252,7 @@ describe('VariantDocumentsTable', () => {
     expect(screen.getByTestId('variant-bulk-actions-menu')).toBeInTheDocument()
   })
 
-  it('select-all selects every document and clear resets the selection', async () => {
+  it('reveals select-all in the selection bar (not the column header) and clear resets', async () => {
     const user = userEvent.setup()
 
     await renderTable()
@@ -259,8 +261,13 @@ describe('VariantDocumentsTable', () => {
       expect(screen.getAllByTestId('table-row')).toHaveLength(2)
     })
 
-    await user.click(screen.getByRole('checkbox', {name: 'Select all documents'}))
+    // Select-all is not in the column header; it appears in the bar once a row is picked.
+    expect(screen.queryByRole('checkbox', {name: 'Select all documents'})).not.toBeInTheDocument()
 
+    await user.click(screen.getAllByRole('checkbox', {name: 'Select document'})[0]!)
+
+    // The select-all now appears in the bar; clicking it selects the rest.
+    await user.click(screen.getByRole('checkbox', {name: 'Select all documents'}))
     expect(screen.getByText('2 selected')).toBeInTheDocument()
 
     await user.click(screen.getByTestId('variant-bulk-clear'))
@@ -279,11 +286,24 @@ describe('VariantDocumentsTable', () => {
       expect(screen.getAllByTestId('table-row')).toHaveLength(2)
     })
 
-    await user.click(screen.getByRole('checkbox', {name: 'Select all documents'}))
+    await user.click(screen.getAllByRole('checkbox', {name: 'Select document'})[0]!)
     await user.click(screen.getByTestId('variant-bulk-actions-menu'))
 
     expect(await screen.findByText('Publish selected')).toBeInTheDocument()
     expect(screen.getByText('Delete selected')).toBeInTheDocument()
+  })
+
+  it('puts search in the command lane, not the column header', async () => {
+    await renderTable()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(2)
+    })
+
+    // Search moved out of the column-header row into the command lane; the preview column is now
+    // a plain sortable "Document" label.
+    expect(screen.getByTestId('variant-documents-search')).toBeInTheDocument()
+    expect(screen.getByText('Document')).toBeInTheDocument()
   })
 
   it('finds documents by name when title is missing', async () => {

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantReleaseLane.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantReleaseLane.test.tsx
@@ -40,7 +40,7 @@ describe('VariantReleaseLane', () => {
 
     // createTestProvider loads i18n asynchronously; wait for the lane to mount.
     await screen.findByTestId('variant-release-lane')
-    expect(screen.getByText('Releases')).toBeInTheDocument()
+    // No leading "Releases" label/icon — the tabs are self-evidently bundle filters.
     expect(screen.getByText('All (4)')).toBeInTheDocument()
     expect(screen.getByText('Published (2)')).toBeInTheDocument()
     expect(screen.getByText('Draft (1)')).toBeInTheDocument()

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
@@ -120,16 +120,10 @@ export const getVariantDocumentTableColumnDefs = (
           width: 44,
           style: {minWidth: 44, maxWidth: 44},
           sorting: false,
+          // Empty header: select-all lives in the command-lane selection bar, not here. The
+          // column-header row is column labels + sort only (three-zone header spec).
           header: ({headerProps}) => (
-            <Flex {...headerProps} align="center" justify="center" paddingY={3} sizing="border">
-              <Checkbox
-                aria-label={t('detail.documents.bulk.select-all')}
-                checked={selection.allSelected}
-                data-testid="variant-bulk-select-all"
-                indeterminate={selection.someSelected && !selection.allSelected}
-                onChange={selection.onToggleAll}
-              />
-            </Flex>
+            <Flex {...headerProps} align="center" justify="center" paddingY={3} sizing="border" />
           ),
           cell: ({cellProps, datum}) => (
             <Flex {...cellProps} align="center" justify="center" paddingX={2} sizing="border">
@@ -195,15 +189,17 @@ export const getVariantDocumentTableColumnDefs = (
     ),
   },
   {
+    // The document preview / title column. Search moved out of this header into the command lane
+    // (three-zone header spec); the header is now a plain sortable "Document" label.
     id: 'search',
     width: null,
     style: {minWidth: 'min(50%, calc(100vw - 80px))', maxWidth: 'min(50%, calc(100vw - 80px))'},
+    sorting: true,
     sortTransform: ({document}) => getDocumentPreviewTitle(document).toLowerCase(),
     header: (props) => (
-      <Headers.TableHeaderSearch
-        {...props}
-        placeholder={t('detail.documents.table.search-placeholder')}
-      />
+      <Flex {...props.headerProps} paddingY={3} sizing="border">
+        <Headers.SortHeaderButton text={t('detail.documents.table.document')} {...props} />
+      </Flex>
     ),
     cell: ({cellProps, datum}) => (
       <Flex


### PR DESCRIPTION
# Draft PR body — Convergence PR 1: three-zone table header

Proposed PR title (conventional commit): `feat(core): three-zone table header for the variant detail table`

Branch: `table/shared-header` → base `variants/detail-ui` (**stacked** on PR A #13595; retarget to `main` after A merges). Draft first.

First PR of the **Releases × Variants table convergence** lane (`docs/initiatives/releases-variants-table-convergence/`). Variants-only, behind `beta.variants` — the low-level shared `Table` and all Releases code are untouched.

---

### Description

Implements the [three-zone table-header spec](./table-header-spec.md) on the variant detail documents table, resolving the "table controls living in the column-header row" anti-pattern (search-in-header and select-all-in-header) together.

- **Command lane (zone 1)** — table-scoped controls: a **search input** and the **filter tabs**, plus a **contextual selection bar** when a selection exists. Shown whenever the variant has documents.
- **Column-header row (zone 2)** — labels + sort only. The former search column is now a plain sortable **"Document"** label; the checkbox column header is empty.
- **Rows (zone 3)** — unchanged.

Specifics:
- **Search ownership moves to the composition.** The low-level `Table`'s search state is internal to its own provider, so the command lane can't reach it. `VariantDocumentsTable` now owns `searchTerm`, renders the input in the command lane, and filters rows before they reach the Table (which just sorts what it receives). No change to the shared `Table`.
- **Select-all moves to the selection bar** (reveal-on-selection): tick a row → the bar appears with select-all (indeterminate-aware). The checkbox column header is empty. This is the spec's stated lean; flagged below as a reviewable UX call.
- Built as an extraction-ready shape so the shared `DocumentTable` (convergence PR 2, FH-90) can lift it and Releases can adopt it.

### What to review

- Open a variant definition with documents. The **search box** sits in the command lane (left), filter tabs beside it; the column-header row shows **Document** (sortable) where search used to be.
- Type in search → rows filter, and **column sorting still works** with a search/filter active.
- Tick a row → the **selection bar** appears with **select-all** + count + actions (Publish/Delete still stubbed) + Clear. There is no select-all in the column header.
- Empty variant (no documents): the command lane is hidden (nothing to search/select); column headers + empty state still render.
- Key file: `tool/detail/VariantDocumentsTable.tsx` (command lane + search ownership), `variantDocumentTable/VariantDocumentTableColumnDefs.tsx` (empty select header, Document label).

### Reviewable UX call

**Select-all is reveal-on-selection** (empty checkbox header; select-all appears in the bar after the first row is picked) rather than a persistent header checkbox. This honors "column-header row = labels only" but means you can't select-all in one click from a cold state (tick one, then select-all). Gmail keeps a persistent select-all; Material reveals it. Happy to switch to persistent if preferred.

### Testing

- Variant tests pass (222 across the branch), typecheck + lint + format clean. New/updated: search-in-command-lane, reveal-on-selection select-all, "Document" header, and the detail page's empty-variant search-absent case.

### Notes for release

N/A — behind `beta.variants`; not separately enabled. First brick of the shared-table convergence; the shared extraction + Releases adoption follow in later PRs on this lane.
