### PR TITLE
fix(core): report the `.text` focus-path suffix for spans at any depth

### DIFF
--- a/dev/test-studio/preview/SimpleBlockPortableText.tsx
+++ b/dev/test-studio/preview/SimpleBlockPortableText.tsx
@@ -6,6 +6,45 @@ import {type PortableTextBlock} from 'sanity'
 
 import {imageBuilder, useQuery} from './loader'
 
+// Renders `table` blocks so the Presentation preview exercises overlays
+// at container depth. Cell text binds overlays via its stega-encoded
+// content; the `data-sanity` attribute on each `<td>` additionally binds
+// the element itself, so empty cells stay clickable (stega needs
+// rendered text, and an empty cell has none).
+function createTableComponent(documentId: string, documentType: string) {
+  const dataAttribute = createDataAttribute({id: documentId, type: documentType})
+  const TableComponent = ({value}: {value: any}) => (
+    <table style={{borderCollapse: 'collapse', margin: '8px 0'}}>
+      <tbody>
+        {(value.rows ?? []).map((row: any) => (
+          <tr key={row._key}>
+            {(row.cells ?? []).map((cell: any) => (
+              <td
+                key={cell._key}
+                // Bind the element to the first span's `.text` when the
+                // cell has content (the studio resolves text paths into
+                // containers; a bare array path selects in the preview but
+                // focuses nothing in the form).
+                data-sanity={dataAttribute
+                  .scope(
+                    cell.value?.[0]?.children?.[0]
+                      ? `body[_key=="${value._key}"].rows[_key=="${row._key}"].cells[_key=="${cell._key}"].value[_key=="${cell.value[0]._key}"].children[_key=="${cell.value[0].children[0]._key}"].text`
+                      : `body[_key=="${value._key}"].rows[_key=="${row._key}"].cells[_key=="${cell._key}"].value`,
+                  )
+                  .toString()}
+                style={{border: '1px solid #ccc', padding: 8}}
+              >
+                <PortableText components={components} value={cell.value ?? []} />
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+  return TableComponent
+}
+
 const components: PortableTextComponents = {
   types: {
     image: ({value}) => {
@@ -104,7 +143,13 @@ export function SimpleBlockPortableText(): React.JSX.Element {
               </div>
             ))}
             <p>{item.bodyString}</p>
-            <PortableText components={components} value={item.body} />
+            <PortableText
+              components={{
+                ...components,
+                types: {...components.types, table: createTableComponent(item._id, item._type)},
+              }}
+              value={item.body}
+            />
             {item.notes?.map((note) => (
               <div key={note._key}>
                 <h2>{note.title}</h2>

--- a/dev/test-studio/schema/standard/portableText/simpleBlock.tsx
+++ b/dev/test-studio/schema/standard/portableText/simpleBlock.tsx
@@ -1,5 +1,5 @@
 import {toPlainText} from '@portabletext/react'
-import {defineArrayMember, defineField, defineType} from 'sanity'
+import {defineArrayMember, defineField, defineType, type PortableTextPluginsProps} from 'sanity'
 
 import {CalloutPreview} from './components/CalloutPreview'
 
@@ -183,7 +183,58 @@ export default defineType({
             },
           ],
         },
+        // A canonical table member so the Presentation preview exercises
+        // editable Portable Text at container depth (overlays over cell
+        // text, focus paths into cells).
+        {
+          type: 'object',
+          name: 'table',
+          fields: [
+            {type: 'number', name: 'headerRows'},
+            {
+              type: 'array',
+              name: 'rows',
+              of: [
+                {
+                  type: 'object',
+                  name: 'row',
+                  fields: [
+                    {
+                      type: 'array',
+                      name: 'cells',
+                      of: [
+                        {
+                          type: 'object',
+                          name: 'cell',
+                          fields: [
+                            {
+                              type: 'array',
+                              name: 'value',
+                              of: [{type: 'block'}],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
       ],
+      components: {
+        portableText: {
+          plugins: (props: PortableTextPluginsProps) =>
+            props.renderDefault({
+              ...props,
+              plugins: {
+                ...props.plugins,
+                table: {enabled: true},
+              },
+            }),
+        },
+      },
     },
     {
       name: 'notes',

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -2,16 +2,19 @@ import {
   type EditorEmittedEvent,
   EditorProvider,
   type EditorSelection,
+  type EditorSnapshot,
   type Patch,
+  type Editor,
   PortableTextEditor,
   type RangeDecoration,
   useEditor,
   usePortableTextEditor,
 } from '@portabletext/editor'
 import {EventListenerPlugin} from '@portabletext/editor/plugins'
+import {getSpan} from '@portabletext/editor/traversal'
 import {sanitySchemaToPortableTextSchema} from '@portabletext/sanity-bridge'
 import {useTelemetry} from '@sanity/telemetry/react'
-import {isKeySegment, type Path, type PortableTextBlock} from '@sanity/types'
+import {type Path, type PortableTextBlock} from '@sanity/types'
 import {Box, useToast} from '@sanity/ui'
 import {randomKey} from '@sanity/util/content'
 import {fromString, startsWith} from '@sanity/util/paths'
@@ -64,14 +67,28 @@ function keyGenerator() {
 
 /**
  * `EditorProvider` doesn't have a `ref` prop. This custom PTE plugin takes
- * care of imperatively forwarding that ref.
+ * care of imperatively forwarding the legacy `PortableTextEditor` instance,
+ * the public `editorRef` prop's contract.
  */
-const EditorRefPlugin = forwardRef<PortableTextEditor | null>((_, ref) => {
+const LegacyEditorRefPlugin = forwardRef<PortableTextEditor | null>((_, ref) => {
   const portableTextEditor = usePortableTextEditor()
 
   const portableTextEditorRef = useRef(portableTextEditor)
 
   useImperativeHandle(ref, () => portableTextEditorRef.current, [])
+
+  return null
+})
+LegacyEditorRefPlugin.displayName = 'LegacyEditorRefPlugin'
+
+/**
+ * Captures the editor instance so callbacks defined outside
+ * `EditorProvider` can take snapshots.
+ */
+const EditorRefPlugin = forwardRef<Editor | null>((_, ref) => {
+  const editor = useEditor()
+
+  useImperativeHandle(ref, () => editor, [editor])
 
   return null
 })
@@ -125,8 +142,9 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
   } = props
 
   const {onBlur, ref: elementRef} = elementProps
-  const defaultEditorRef = useRef<PortableTextEditor | null>(null)
-  const editorRef = editorRefProp || defaultEditorRef
+  const defaultLegacyEditorRef = useRef<PortableTextEditor | null>(null)
+  const editorRef = useRef<Editor | null>(null)
+  const legacyEditorRef = editorRefProp || defaultLegacyEditorRef
 
   const presenceCursorDecorations = usePresenceCursorDecorations(
     useMemo(
@@ -257,23 +275,16 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
   }, [hasFocusWithin])
 
   const setFocusPathFromEditorSelection = useCallback(
-    (nextSelection: EditorSelection) => {
+    (nextSelection: EditorSelection, snapshot: EditorSnapshot | null) => {
       const focusPath = nextSelection?.focus.path
       if (!focusPath) return
 
-      // Report focus on spans with `.text` appended to the reported focusPath.
-      // This is done to support the Presentation tool which uses this kind of paths to refer to texts.
-      // The PT-input already supports these paths the other way around.
-      // It's a bit ugly right here, but it's a rather simple way to support the Presentation tool without
-      // having to change the PTE's internals.
-      const isSpanPath =
-        focusPath.length === 3 && // A span path is always 3 segments long
-        focusPath[1] === 'children' && // Is a child of a block
-        isKeySegment(focusPath[2]) && // Contains the key of the child
-        !portableTextMemberItems.some(
-          (item) => isKeySegment(focusPath[2]) && item.member.key === focusPath[2]._key,
-        )
-      const nextFocusPath = isSpanPath ? focusPath.concat(['text']) : focusPath
+      // Spans report with `.text` appended, the path shape the Presentation
+      // tool uses to address text. `useTrackFocusPath` resolves such paths
+      // in the other direction through the same `getSpan` traversal, so
+      // both directions agree on what a span path is at any depth.
+      const nextFocusPath =
+        snapshot && getSpan(snapshot, focusPath) ? focusPath.concat(['text']) : focusPath
 
       // Must called in a transition useTrackFocusPath hook
       // will try to effectuate a focusPath that is different from what currently is the editor focusPath
@@ -283,7 +294,7 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
         })
       })
     },
-    [onPathFocus, portableTextMemberItems],
+    [onPathFocus],
   )
 
   // Handle editor changes
@@ -295,7 +306,10 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
           onChange(toFormPatches(change.patches))
           break
         case 'selection':
-          setFocusPathFromEditorSelection(change.selection)
+          setFocusPathFromEditorSelection(
+            change.selection,
+            editorRef.current?.getSnapshot() ?? null,
+          )
           break
         case 'focus':
           setIsActive(true)
@@ -319,11 +333,19 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
           break
         default:
       }
-      if (editorRef.current && onEditorChange) {
-        onEditorChange(change, editorRef.current)
+      if (legacyEditorRef.current && onEditorChange) {
+        onEditorChange(change, legacyEditorRef.current)
       }
     },
-    [editorRef, onEditorChange, onChange, setFocusPathFromEditorSelection, onBlur, toast],
+    [
+      legacyEditorRef,
+      editorRef,
+      onEditorChange,
+      onChange,
+      setFocusPathFromEditorSelection,
+      onBlur,
+      toast,
+    ],
   )
 
   useEffect(() => {
@@ -355,11 +377,11 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
   const handleActivate = useCallback((): void => {
     if (!isActive) {
       setIsActive(true)
-      if (editorRef.current) {
-        PortableTextEditor.focus(editorRef.current)
+      if (legacyEditorRef.current) {
+        PortableTextEditor.focus(legacyEditorRef.current)
       }
     }
-  }, [editorRef, isActive])
+  }, [legacyEditorRef, isActive])
 
   const previousRangeDecorations = useRef<RangeDecoration[]>([])
 
@@ -404,6 +426,7 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
                   onChange={handleEditorChange}
                   onOptimisticChange={onOptimisticChange}
                 />
+                <LegacyEditorRefPlugin ref={legacyEditorRef} />
                 <EditorRefPlugin ref={editorRef} />
                 <PatchesPlugin path={path} />
                 <UpdateReadOnlyPlugin readOnly={readOnly || !ready} />

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -73,9 +73,7 @@ function keyGenerator() {
 const LegacyEditorRefPlugin = forwardRef<PortableTextEditor | null>((_, ref) => {
   const portableTextEditor = usePortableTextEditor()
 
-  const portableTextEditorRef = useRef(portableTextEditor)
-
-  useImperativeHandle(ref, () => portableTextEditorRef.current, [])
+  useImperativeHandle(ref, () => portableTextEditor, [portableTextEditor])
 
   return null
 })

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/FocusPathDepth.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/FocusPathDepth.browser.test.tsx
@@ -1,0 +1,117 @@
+import {type Path, type SanityDocument} from '@sanity/types'
+import {describe, expect, it} from 'vitest'
+import {page, userEvent} from 'vitest/browser'
+
+import {testHelpers} from '../../../../../../test/browser/testHelpers'
+import {FocusPathDepthStory} from './FocusPathDepthStory'
+
+const {render} = await import('vitest-browser-react')
+
+const document: SanityDocument = {
+  _id: '123',
+  _type: 'test',
+  _createdAt: new Date().toISOString(),
+  _updatedAt: new Date().toISOString(),
+  _rev: '123',
+  body: [
+    {
+      _type: 'block',
+      _key: 'b0',
+      children: [{_type: 'span', _key: 's0', text: 'root span', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    },
+    {
+      _type: 'table',
+      _key: 't0',
+      headerRows: 0,
+      rows: [
+        {
+          _type: 'row',
+          _key: 'r0',
+          cells: [
+            {
+              _type: 'cell',
+              _key: 'c0',
+              value: [
+                {
+                  _type: 'block',
+                  _key: 'cb0',
+                  children: [
+                    {_type: 'span', _key: 'cs0', text: 'cell span', marks: []},
+                    {_type: 'inlineNote', _key: 'cn0', note: 'deep note'},
+                    {_type: 'span', _key: 'cs1', text: '', marks: []},
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+describe('Portable Text Input - focus path span suffix at depth', () => {
+  it('reports spans with `.text` and inline objects without, at root and inside table cells', async () => {
+    const paths: Path[] = []
+    const pushPath = (path: Path) => paths.push(path)
+    const {getFocusedPortableTextEditor, waitForFocusedNodeText} = testHelpers()
+
+    void render(<FocusPathDepthStory document={document} onPathFocus={pushPath} />)
+
+    const $pte = await getFocusedPortableTextEditor('field-body')
+    await expect.element($pte).toHaveTextContent('cell span')
+    const lastPath = () => paths.slice(-1)[0]
+
+    const rootNode = [...$pte.element().querySelectorAll('*')].find(
+      (node) => node.childElementCount === 0 && node.textContent === 'root span',
+    )
+    await userEvent.click(rootNode as HTMLElement)
+    await waitForFocusedNodeText('root span')
+    await expect.poll(lastPath).toEqual(['body', {_key: 'b0'}, 'children', {_key: 's0'}, 'text'])
+
+    const cellNode = [...$pte.element().querySelectorAll('*')].find(
+      (node) => node.childElementCount === 0 && node.textContent === 'cell span',
+    )
+    await userEvent.click(cellNode as HTMLElement)
+    await waitForFocusedNodeText('cell span')
+    await expect
+      .poll(lastPath)
+      .toEqual([
+        'body',
+        {_key: 't0'},
+        'rows',
+        {_key: 'r0'},
+        'cells',
+        {_key: 'c0'},
+        'value',
+        {_key: 'cb0'},
+        'children',
+        {_key: 'cs0'},
+        'text',
+      ])
+
+    // An inline object is a child but not a span, so its reported path
+    // stays suffix-free; a span check by path shape would get this wrong
+    // at depth.
+    const $inlineObject = page.getByTestId('inline-preview')
+    await $inlineObject.click()
+    await expect
+      .poll(lastPath)
+      .toEqual([
+        'body',
+        {_key: 't0'},
+        'rows',
+        {_key: 'r0'},
+        'cells',
+        {_key: 'c0'},
+        'value',
+        {_key: 'cb0'},
+        'children',
+        {_key: 'cn0'},
+      ])
+  })
+})

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/FocusPathDepthStory.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/FocusPathDepthStory.tsx
@@ -1,0 +1,106 @@
+import {
+  defineArrayMember,
+  defineField,
+  defineType,
+  type Path,
+  type SanityDocument,
+} from '@sanity/types'
+
+import {TestForm} from '../../../../../../test/browser/TestForm'
+import {TestWrapper} from '../../../../../../test/browser/TestWrapper'
+
+// A table-enabled field whose cells hold spans and inline objects, for
+// pinning the focus-path span suffix (`.text`) at container depth.
+const SCHEMA_TYPES = [
+  defineType({
+    type: 'document',
+    name: 'test',
+    title: 'Test',
+    fields: [
+      defineField({
+        type: 'array',
+        name: 'body',
+        of: [
+          defineArrayMember({type: 'block'}),
+          defineArrayMember({
+            type: 'object',
+            name: 'table',
+            fields: [
+              defineField({type: 'number', name: 'headerRows'}),
+              defineField({
+                type: 'array',
+                name: 'rows',
+                of: [
+                  defineArrayMember({
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      defineField({
+                        type: 'array',
+                        name: 'cells',
+                        of: [
+                          defineArrayMember({
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              defineField({
+                                type: 'array',
+                                name: 'value',
+                                of: [
+                                  defineArrayMember({
+                                    type: 'block',
+                                    of: [
+                                      defineArrayMember({
+                                        type: 'object',
+                                        name: 'inlineNote',
+                                        title: 'Inline note',
+                                        fields: [
+                                          defineField({
+                                            type: 'string',
+                                            name: 'note',
+                                          }),
+                                        ],
+                                        preview: {select: {title: 'note'}},
+                                      }),
+                                    ],
+                                  }),
+                                ],
+                              }),
+                            ],
+                          }),
+                        ],
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+        components: {
+          portableText: {
+            plugins: (props) =>
+              props.renderDefault({
+                ...props,
+                plugins: {
+                  ...props.plugins,
+                  table: {enabled: true},
+                },
+              }),
+          },
+        },
+      }),
+    ],
+  }),
+]
+
+export function FocusPathDepthStory(props: {
+  document?: SanityDocument
+  onPathFocus?: (path: Path) => void
+}) {
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <TestForm document={props.document} onPathFocus={props.onPathFocus} />
+    </TestWrapper>
+  )
+}


### PR DESCRIPTION
### Description

In the Presentation tool, placing the cursor in text scrolls the preview to that text. That works for top-level text but not for text inside nested structures, for example a table cell: there the preview doesn't move.

The Portable Text input reports where the cursor is as a path, and appends a `.text` suffix when the cursor is in a span, that suffixed path is what visual editing matches (exactly, string for string) to find the preview element to scroll to. The suffix was only ever applied to top-level spans, because the code recognized spans by the shape of their path: "a span path is always 3 segments long". A span inside a table cell has a nine-segment path, so it never got the suffix and never matched.

This PR replaces the shape check with a lookup of the node the path actually points at (`getSpan` from `@portabletext/editor/traversal`, the same lookup already used when resolving paths in the opposite direction). Spans now get the suffix at any depth, and inline objects correctly never do, at any depth, which the old check only guaranteed at the top level.

### What to review

Everything is in `PortableTextInput.tsx`:

- The rewritten span check in `setFocusPathFromEditorSelection`.
- A new ref plugin that captures the editor instance, so the change handler (which lives outside `EditorProvider`) can take the snapshot the lookup needs.
- A rename: the new plugin takes the `EditorRefPlugin` name, and the existing plugin forwarding the legacy `PortableTextEditor` becomes `LegacyEditorRefPlugin`. The public `editorRef` prop still receives the legacy instance, unchanged.
- A small third commit aligns `LegacyEditorRefPlugin` with the same shape (expose the hook value directly instead of a first-render capture), so the handle stays current if the instance is ever recreated. No behavior change while the instance is stable, which it is today.

### Testing

`FocusPathDepth.browser.test.tsx` pins three cases: a top-level span gets the suffix (as before), a span inside a table cell now gets it, and an inline object inside a cell doesn't. The existing FocusTracking suite passes unchanged.

Verified manually in the Presentation tool (the second commit adds a table to the test-studio Presentation fixture): focusing top-level text scrolls the preview with and without this change; focusing cell text only scrolls with it.

<img width="1788" height="1104" alt="Screenshot 2026-07-21 at 11 54 28" src="https://github.com/user-attachments/assets/206ca5f1-6923-4f19-abeb-eb52fdb5c8bf" />


### Notes for release

In the Presentation tool, focusing text inside nested Portable Text structures, such as table cells, now scrolls the preview to that text, matching the behavior of top-level text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes focus-path reporting in the core Portable Text input, which Presentation and visual editing rely on; behavior is narrowed with browser tests but affects a sensitive editing/sync path.
> 
> **Overview**
> Fixes **Presentation** preview scroll when the cursor is in text inside nested Portable Text (e.g. table cells) by aligning reported focus paths with what visual editing expects.
> 
> In **`PortableTextInput`**, span detection for appending the `.text` suffix no longer assumes a three-segment path. On selection changes it uses an editor snapshot and **`getSpan`** (same traversal as reverse path resolution) so spans get `.text` at any depth and inline objects do not. A new **`EditorRefPlugin`** exposes the modern **`Editor`** for snapshots; the existing ref forwarding **`PortableTextEditor`** is **`LegacyEditorRefPlugin`**, and the public **`editorRef`** prop behavior is unchanged.
> 
> **test-studio** adds a **`table`** block to the simple-block schema (table plugin enabled) and renders it in the Presentation preview with **`data-sanity`** paths on cells for overlay/focus exercises. **`FocusPathDepth.browser.test.tsx`** locks root span, nested cell span, and inline-object focus paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b197895255cb0e3edae4350036bb6a29ca6cacb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
