### PR TITLE
feat(core): three-zone table header for the variant detail table

### DIFF
--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -70,7 +70,9 @@ const variantsLocaleStrings = {
   'detail.documents.no-documents': 'No documents in this variant definition',
   /** Edited column header for variant document table. */
   'detail.documents.table.edited': 'Edited',
-  /** Search placeholder for variant document table. */
+  /** Document (title/preview) column header for variant document table. */
+  'detail.documents.table.document': 'Document',
+  /** Search placeholder for the variant document table search input in the command lane. */
   'detail.documents.table.search-placeholder': 'Search documents',
   /** Type column header for variant document table. */
   'detail.documents.table.type': 'Type',
@@ -78,8 +80,6 @@ const variantsLocaleStrings = {
   'detail.documents.table.appears-in': 'Appears in',
   /** Header of the popover listing the bundles a document appears in beyond the first chip. */
   'detail.documents.appears-in.also-in': 'Also in',
-  /** Label for the release lane above the variant document table. */
-  'detail.release-lane.title': 'Releases',
   /** The "show all documents" segment of the release lane. */
   'detail.release-lane.all': 'All',
   /** A single release lane filter tab: a bundle label followed by its document count. */
@@ -88,6 +88,24 @@ const variantsLocaleStrings = {
   'detail.documents.table.validation.error_one': '{{count}} validation error',
   /** Validation error tooltip for multiple errors in the variant document table. */
   'detail.documents.table.validation.error_other': '{{count}} validation errors',
+  /** Accessible label for the command-lane select-all checkbox. */
+  'detail.documents.bulk.select-all': 'Select all documents',
+  /** Accessible label for a per-row selection checkbox. */
+  'detail.documents.bulk.select-row': 'Select document',
+  /** Count of selected documents in the bulk-action bar (singular). */
+  'detail.documents.bulk.selected_one': '{{count}} selected',
+  /** Count of selected documents in the bulk-action bar (plural). */
+  'detail.documents.bulk.selected_other': '{{count}} selected',
+  /** Primary bulk action: publish the selected documents. */
+  'detail.documents.bulk.publish': 'Publish',
+  /** Primary bulk action: delete the selected documents. */
+  'detail.documents.bulk.delete': 'Delete',
+  /** Overflow menu of secondary bulk actions. */
+  'detail.documents.bulk.more': 'More bulk actions',
+  /** Secondary bulk action: unpublish the selected documents. */
+  'detail.documents.bulk.unpublish': 'Unpublish',
+  /** Secondary bulk action: add the selected documents to a release. */
+  'detail.documents.bulk.add-to-release': 'Add to release',
   /** Error message when variant documents fail to load. */
   'detail.documents.error': 'Unable to load documents for this variant definition',
   /** Description for the missing Variant detail page. */

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantDetail.test.tsx
@@ -177,7 +177,10 @@ describe('VariantDetail', () => {
     expect(screen.getByRole('button', {name: 'Back to variant definitions'})).toBeInTheDocument()
     expect(screen.getByText('Appears in')).toBeInTheDocument()
     expect(screen.getByText('Type')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('Search documents')).toBeInTheDocument()
+    // Search moved out of the column-header row into the command lane; the preview column header is
+    // now a plain "Document" label. The command lane (and its search) is hidden with no documents.
+    expect(screen.getByText('Document')).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Search documents')).not.toBeInTheDocument()
     expect(screen.getByText('Edited')).toBeInTheDocument()
     expect(screen.getByText('No documents in this variant definition')).toBeInTheDocument()
     // Created status is a compact clock icon (full "Created <when>" in a hover tooltip).

--- a/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDocumentsTable.tsx
@@ -1,6 +1,13 @@
-import {Box, Card, Container, Flex} from '@sanity/ui'
+import {AddIcon} from '@sanity/icons/Add'
+import {EllipsisHorizontalIcon} from '@sanity/icons/EllipsisHorizontal'
+import {PublishIcon} from '@sanity/icons/Publish'
+import {SearchIcon} from '@sanity/icons/Search'
+import {TrashIcon} from '@sanity/icons/Trash'
+import {UnpublishIcon} from '@sanity/icons/Unpublish'
+import {Badge, Box, Card, Checkbox, Container, Flex, Menu, TextInput} from '@sanity/ui'
 import {type CSSProperties, useCallback, useMemo, useState} from 'react'
 
+import {Button, MenuButton, MenuItem} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
 import {useActiveReleases} from '../../../releases/store/useActiveReleases'
 import {Table} from '../../../releases/tool/components/Table/Table'
@@ -9,18 +16,24 @@ import {searchDocumentRelease} from '../../../releases/tool/detail/documentTable
 import {variantsLocaleNamespace} from '../../i18n'
 import {computeReleaseLaneSegments, RELEASE_LANE_ALL, rowMatchesLane} from './releaseLane'
 import {type DocumentInVariantGroup} from './types'
-import {getVariantDocumentTableColumnDefs} from './variantDocumentTable/VariantDocumentTableColumnDefs'
+import {
+  getVariantDocumentTableColumnDefs,
+  type VariantDocumentSelection,
+} from './variantDocumentTable/VariantDocumentTableColumnDefs'
 import {VariantReleaseLane} from './VariantReleaseLane'
 
 const TABLE_CARD_STYLE: CSSProperties = {
   height: '100%',
   overflow: 'auto',
-  // No scrollbar-gutter: it forces a fixed reserve the Container-based header/lane don't have,
+  // No scrollbar-gutter: it forces a fixed reserve the Container-based command lane doesn't have,
   // which misaligns the centered rows from the chrome as the viewport narrows. Without it, the
   // rows and chrome share the same centered inset at every width (with overlay scrollbars). The
   // minor horizontal shift when a filter toggles a non-overlay scrollbar is deferred to the shared
   // document-table work (FH-90), where header + table live in one scroll context.
 }
+
+// The command-lane search input is a fixed leading control; the filter tabs fill the rest.
+const SEARCH_INPUT_STYLE: CSSProperties = {maxWidth: 280}
 
 function filterDocuments(
   rows: DocumentInVariantGroup[],
@@ -45,6 +58,8 @@ export function VariantDocumentsTable({
   const {t} = useTranslation(variantsLocaleNamespace)
   const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(null)
   const [activeLane, setActiveLane] = useState<string>(RELEASE_LANE_ALL)
+  const [searchTerm, setSearchTerm] = useState('')
+  const [selectedGroupIds, setSelectedGroupIds] = useState<ReadonlySet<string>>(() => new Set())
   const {data: releases} = useActiveReleases()
   const releasesById = useMemo(
     () => new Map(releases.map((release) => [release._id, release])),
@@ -64,7 +79,7 @@ export function VariantDocumentsTable({
 
   // Filter tabs are the one way to scope by bundle (grouping was removed: filtering preserves
   // column sorting, which grouping cannot). A selected tab filters the flat, always-sortable list.
-  const displayRows = useMemo(() => {
+  const laneRows = useMemo(() => {
     const filtered =
       resolvedActiveLane === RELEASE_LANE_ALL
         ? rows
@@ -72,41 +87,190 @@ export function VariantDocumentsTable({
     return filtered.map((row) => ({...row, rowKey: row.groupId}))
   }, [rows, resolvedActiveLane, releasesById])
 
+  // Search is owned by this composition (not the low-level Table, whose search context is internal),
+  // so it can live in the command lane rather than the column-header row. Applied on top of the lane
+  // filter; the Table then sorts whatever it receives.
+  const displayRows = useMemo(() => filterDocuments(laneRows, searchTerm), [laneRows, searchTerm])
+
   const handleSelectLane = useCallback((laneId: string) => {
     // Clicking the already-active segment clears the filter back to "All".
     setActiveLane((previous) => (previous === laneId ? RELEASE_LANE_ALL : laneId))
   }, [])
 
-  const hasReleaseControls = !loading && segments.length > 1
+  const hasDocuments = !loading && rows.length > 0
+  const hasReleaseControls = hasDocuments && segments.length > 1
+
+  // Bulk selection. Keyed by the document groupId. Selection persists across lane/search filters;
+  // the count reflects what's currently visible so a filtered-out selection never inflates the bar.
+  const selectableGroupIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const row of displayRows) {
+      ids.add(row.groupId)
+    }
+    return ids
+  }, [displayRows])
+
+  const selectedVisibleCount = useMemo(
+    () => [...selectedGroupIds].filter((id) => selectableGroupIds.has(id)).length,
+    [selectedGroupIds, selectableGroupIds],
+  )
+  const allSelected =
+    selectableGroupIds.size > 0 && selectedVisibleCount === selectableGroupIds.size
+  const someSelected = selectedVisibleCount > 0
+
+  const handleToggleRow = useCallback((groupId: string) => {
+    setSelectedGroupIds((previous) => {
+      const next = new Set(previous)
+      if (next.has(groupId)) {
+        next.delete(groupId)
+      } else {
+        next.add(groupId)
+      }
+      return next
+    })
+  }, [])
+
+  const handleToggleAll = useCallback(() => {
+    setSelectedGroupIds((previous) => {
+      // GitHub-style: the select-all box doubles as clear — if anything visible is selected,
+      // clicking it clears; otherwise it selects every currently-visible document.
+      const anyVisibleSelected = [...selectableGroupIds].some((id) => previous.has(id))
+      return anyVisibleSelected ? new Set() : new Set(selectableGroupIds)
+    })
+  }, [selectableGroupIds])
+
+  const isSelected = useCallback(
+    (groupId: string) => selectedGroupIds.has(groupId),
+    [selectedGroupIds],
+  )
+
+  const selection = useMemo<VariantDocumentSelection>(
+    () => ({
+      isSelected,
+      onToggleRow: handleToggleRow,
+      allSelected,
+      someSelected,
+      onToggleAll: handleToggleAll,
+    }),
+    [isSelected, handleToggleRow, allSelected, someSelected, handleToggleAll],
+  )
 
   const columnDefs = useMemo<Column<DocumentInVariantGroup>[]>(
-    () => getVariantDocumentTableColumnDefs(t, variantId, releasesById),
-    [t, variantId, releasesById],
+    () => getVariantDocumentTableColumnDefs(t, variantId, releasesById, selection),
+    [t, variantId, releasesById, selection],
   )
 
   return (
     <Flex direction="column" flex={1} height="fill" overflow="hidden" style={{minHeight: 0}}>
-      {hasReleaseControls && (
-        // Bordered so the filter lane is visually distinct from the table's column-header row below.
-        <Card flex="none" borderBottom paddingY={3}>
-          {/* container[3] chrome so the lane aligns with the table's row content (which the shared
-              Table centers at container[3]); the inner box still scrolls if the tabs overflow. */}
+      {/* Command lane (three-zone header, zone 1). Persistent, so nothing shifts vertically. It
+          swaps GitHub-style: idle shows browse controls (search + filter tabs); on selection it
+          becomes a bulk-action toolbar — select-all + count on the left, actions on the right.
+          container[3] + paddingX={2} so the lane aligns with the table's row content below (the
+          shared Table centers rows at container[3]; the first column insets by 8px). */}
+      {hasDocuments && (
+        <Card flex="none" borderBottom paddingY={2}>
           <Container flex="none" width={3}>
-            <Box paddingX={2} style={{minWidth: 0, overflowX: 'auto'}}>
-              <VariantReleaseLane
-                activeLane={resolvedActiveLane}
-                onSelectLane={handleSelectLane}
-                segments={segments}
-                totalCount={rows.length}
-              />
+            <Box paddingX={2}>
+              <Flex align="center" gap={3}>
+                {/* Select-all is persistent and leftmost (over the checkbox column). Clicking it
+                    when anything is selected clears — so "clear" lives with the count, not between
+                    actions. */}
+                <Checkbox
+                  aria-label={t('detail.documents.bulk.select-all')}
+                  checked={allSelected}
+                  data-testid="variant-bulk-select-all"
+                  indeterminate={someSelected && !allSelected}
+                  onChange={handleToggleAll}
+                />
+                {selectedVisibleCount > 0 ? (
+                  <>
+                    {/* Selection mode: count beside the box (primary-toned, live indicator); browse
+                        controls give way to the bulk actions on the right. */}
+                    <Badge data-testid="variant-bulk-selected-count" fontSize={1} tone="primary">
+                      {t('detail.documents.bulk.selected', {count: selectedVisibleCount})}
+                    </Badge>
+                    <Box flex={1} />
+                    <Flex align="center" flex="none" gap={2}>
+                      <Button
+                        data-testid="variant-bulk-publish"
+                        disabled
+                        icon={PublishIcon}
+                        mode="ghost"
+                        text={t('detail.documents.bulk.publish')}
+                      />
+                      <Button
+                        data-testid="variant-bulk-delete"
+                        disabled
+                        icon={TrashIcon}
+                        mode="ghost"
+                        text={t('detail.documents.bulk.delete')}
+                        tone="critical"
+                      />
+                      <MenuButton
+                        id="variant-bulk-more"
+                        button={
+                          <Button
+                            data-testid="variant-bulk-more"
+                            icon={EllipsisHorizontalIcon}
+                            mode="bleed"
+                            tooltipProps={{content: t('detail.documents.bulk.more')}}
+                          />
+                        }
+                        menu={
+                          <Menu>
+                            <MenuItem
+                              disabled
+                              icon={UnpublishIcon}
+                              text={t('detail.documents.bulk.unpublish')}
+                            />
+                            <MenuItem
+                              disabled
+                              icon={AddIcon}
+                              text={t('detail.documents.bulk.add-to-release')}
+                            />
+                          </Menu>
+                        }
+                        popover={{placement: 'bottom-end', portal: true}}
+                      />
+                    </Flex>
+                  </>
+                ) : (
+                  <>
+                    <Box flex="none" style={SEARCH_INPUT_STYLE}>
+                      <TextInput
+                        aria-label={t('detail.documents.table.search-placeholder')}
+                        clearButton={Boolean(searchTerm)}
+                        data-testid="variant-documents-search"
+                        fontSize={1}
+                        icon={SearchIcon}
+                        onChange={(event) => setSearchTerm(event.currentTarget.value)}
+                        onClear={() => setSearchTerm('')}
+                        placeholder={t('detail.documents.table.search-placeholder')}
+                        value={searchTerm}
+                      />
+                    </Box>
+                    <Box flex={1} style={{minWidth: 0, overflowX: 'auto'}}>
+                      {hasReleaseControls && (
+                        <VariantReleaseLane
+                          activeLane={resolvedActiveLane}
+                          onSelectLane={handleSelectLane}
+                          segments={segments}
+                          totalCount={rows.length}
+                        />
+                      )}
+                    </Box>
+                  </>
+                )}
+              </Flex>
             </Box>
           </Container>
         </Card>
       )}
       {/* Full-width scroll region so the table borders span the pane; the shared Table centers its
-          rows at container[3], matching the chrome above. */}
+          rows at container[3], matching the command lane above. */}
       <Card
         flex={1}
+        data-testid="variant-documents-table"
         id="variant-documents-table"
         ref={setScrollContainerRef}
         style={TABLE_CARD_STYLE}
@@ -120,7 +284,6 @@ export function VariantDocumentsTable({
           // oxlint-disable-next-line @sanity/i18n/no-attribute-string-literals
           rowId="rowKey"
           scrollContainerRef={scrollContainerRef}
-          searchFilter={filterDocuments}
         />
       </Card>
     </Flex>

--- a/packages/sanity/src/core/variants/tool/detail/VariantReleaseLane.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantReleaseLane.tsx
@@ -1,6 +1,4 @@
-import {FilterIcon} from '@sanity/icons/Filter'
-import {Card, Flex, TabList, Text} from '@sanity/ui'
-import {type CSSProperties} from 'react'
+import {Flex, TabList} from '@sanity/ui'
 
 import {Tab} from '../../../../ui-components'
 import {useTranslation} from '../../../i18n'
@@ -12,9 +10,6 @@ function getSegmentTone(kind: ReleaseLaneKind): 'positive' | 'primary' | 'defaul
   if (kind === 'release') return 'primary'
   return 'default'
 }
-
-// Uppercase micro-label styling so "Releases" reads as a section header, not a peer of the tabs.
-const LABEL_STYLE: CSSProperties = {textTransform: 'uppercase', letterSpacing: '0.04em'}
 
 /**
  * The release lane: a filter-tab strip summarizing which bundles this variant's documents
@@ -44,16 +39,9 @@ export function VariantReleaseLane({
   }
 
   return (
-    <Flex align="center" gap={2} wrap="nowrap" data-testid="variant-release-lane">
-      <Flex align="center" flex="none" gap={1}>
-        <Text muted size={0}>
-          <FilterIcon />
-        </Text>
-        <Text muted size={0} style={LABEL_STYLE} weight="semibold">
-          {t('detail.release-lane.title')}
-        </Text>
-      </Flex>
-      <Card borderLeft flex="none" style={{height: 16}} />
+    <Flex align="center" wrap="nowrap" data-testid="variant-release-lane">
+      {/* No leading icon/label: the tabs (All, Published, Drafts, release names) are self-evidently
+          bundle filters. A filter icon here read as a clickable control that wasn't one. */}
       <TabList space={1}>
         {[
           <Tab

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantDocumentsTable.test.tsx
@@ -116,7 +116,9 @@ describe('VariantDocumentsTable', () => {
       resources: [variantsUsEnglishLocaleBundle],
     })
     const result = render(<VariantDocumentsTable rows={rows} loading={loading} />, {wrapper})
-    await screen.findByPlaceholderText('Search documents')
+    // Search now lives in the command lane (only shown with documents), so settle on the table
+    // container, which is always present regardless of rows/loading.
+    await screen.findByTestId('variant-documents-table')
     return result
   }
 
@@ -227,6 +229,90 @@ describe('VariantDocumentsTable', () => {
     const renderedTitles = screen.getAllByTestId('preview').map((node) => node.textContent)
 
     expect(renderedTitles).toEqual(['Alpha article', 'Zulu article'])
+  })
+
+  it('swaps the command lane into a bulk toolbar on selection', async () => {
+    const user = userEvent.setup()
+
+    await renderTable()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(2)
+    })
+
+    // Idle: search is shown, no bulk toolbar.
+    expect(screen.getByTestId('variant-documents-search')).toBeInTheDocument()
+    expect(screen.queryByTestId('variant-bulk-publish')).not.toBeInTheDocument()
+
+    const rowCheckboxes = screen.getAllByRole('checkbox', {name: 'Select document'})
+    expect(rowCheckboxes).toHaveLength(2)
+
+    await user.click(rowCheckboxes[0]!)
+
+    // Selecting swaps browse controls (search) for the bulk toolbar: count + primary actions.
+    expect(screen.getByText('1 selected')).toBeInTheDocument()
+    expect(screen.getByTestId('variant-bulk-publish')).toBeInTheDocument()
+    expect(screen.getByTestId('variant-bulk-delete')).toBeInTheDocument()
+    expect(screen.queryByTestId('variant-documents-search')).not.toBeInTheDocument()
+  })
+
+  it('uses the select-all box to select every document and to clear', async () => {
+    const user = userEvent.setup()
+
+    await renderTable()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(2)
+    })
+
+    // Select-all lives in the command lane, present from a cold state (not reveal-on-selection),
+    // and there is exactly one (not also in the column header).
+    const selectAll = screen.getByRole('checkbox', {name: 'Select all documents'})
+
+    await user.click(selectAll)
+    expect(screen.getByText('2 selected')).toBeInTheDocument()
+
+    // Clicking it again clears (GitHub-style) — the toolbar reverts to the search control.
+    await user.click(screen.getByRole('checkbox', {name: 'Select all documents'}))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('variant-documents-search')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('2 selected')).not.toBeInTheDocument()
+  })
+
+  it('shows Publish and Delete as primary actions and the rest under a more menu', async () => {
+    const user = userEvent.setup()
+
+    await renderTable()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(2)
+    })
+
+    await user.click(screen.getAllByRole('checkbox', {name: 'Select document'})[0]!)
+
+    // Publish + Delete are explicit primary buttons (stubbed disabled).
+    expect(screen.getByTestId('variant-bulk-publish')).toBeDisabled()
+    expect(screen.getByTestId('variant-bulk-delete')).toBeDisabled()
+
+    // Secondary actions live behind the "more" overflow.
+    await user.click(screen.getByTestId('variant-bulk-more'))
+    expect(await screen.findByText('Unpublish')).toBeInTheDocument()
+    expect(screen.getByText('Add to release')).toBeInTheDocument()
+  })
+
+  it('puts search in the command lane, not the column header', async () => {
+    await renderTable()
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('table-row')).toHaveLength(2)
+    })
+
+    // Search moved out of the column-header row into the command lane; the preview column is now
+    // a plain sortable "Document" label.
+    expect(screen.getByTestId('variant-documents-search')).toBeInTheDocument()
+    expect(screen.getByText('Document')).toBeInTheDocument()
   })
 
   it('finds documents by name when title is missing', async () => {

--- a/packages/sanity/src/core/variants/tool/detail/__tests__/VariantReleaseLane.test.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/__tests__/VariantReleaseLane.test.tsx
@@ -40,7 +40,6 @@ describe('VariantReleaseLane', () => {
 
     // createTestProvider loads i18n asynchronously; wait for the lane to mount.
     await screen.findByTestId('variant-release-lane')
-    expect(screen.getByText('Releases')).toBeInTheDocument()
     expect(screen.getByText('All (4)')).toBeInTheDocument()
     expect(screen.getByText('Published (2)')).toBeInTheDocument()
     expect(screen.getByText('Draft (1)')).toBeInTheDocument()

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
@@ -1,6 +1,6 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
-import {Box, Flex, Text} from '@sanity/ui'
+import {Box, Checkbox, Flex, Text} from '@sanity/ui'
 // eslint-disable-next-line @sanity/i18n/no-i18next-import -- figure out how to have the linter be fine with importing types-only
 import {type TFunction} from 'i18next'
 import {memo} from 'react'
@@ -85,10 +85,24 @@ function ValidationErrorIndicator({
   )
 }
 
+/**
+ * Row-selection state + handlers for the bulk-action UX, threaded into the leading checkbox column.
+ *
+ * @internal
+ */
+export interface VariantDocumentSelection {
+  isSelected: (groupId: string) => boolean
+  onToggleRow: (groupId: string) => void
+  allSelected: boolean
+  someSelected: boolean
+  onToggleAll: () => void
+}
+
 export const getVariantDocumentTableColumnDefs = (
   t: TFunction<'variants'>,
   variantId: string | undefined,
   releasesById: Map<string, ReleaseDocument>,
+  selection?: VariantDocumentSelection,
 ): Column<DocumentInVariantGroup>[] => [
   {
     id: 'documentGroup',
@@ -97,6 +111,36 @@ export const getVariantDocumentTableColumnDefs = (
     sorting: true,
     sortTransform: (row) => row.rowKey ?? row.groupId,
   },
+  // Leading checkbox column for bulk selection. Only present when the table is wired for selection;
+  // loading rows render no checkbox (they aren't documents you can act on).
+  ...(selection
+    ? [
+        {
+          id: 'select',
+          width: 44,
+          style: {minWidth: 44, maxWidth: 44},
+          sorting: false,
+          // Empty header: select-all lives in the command-lane selection bar, not here. The
+          // column-header row is column labels + sort only (three-zone header spec).
+          header: ({headerProps}) => (
+            <Flex {...headerProps} align="center" justify="center" paddingY={3} sizing="border" />
+          ),
+          cell: ({cellProps, datum}) => (
+            <Flex {...cellProps} align="center" justify="center" paddingX={2} sizing="border">
+              {!datum.isLoading && (
+                <Checkbox
+                  aria-label={t('detail.documents.bulk.select-row')}
+                  checked={selection.isSelected(datum.groupId)}
+                  // Stop the row's own click/navigation from firing when toggling the checkbox.
+                  onClick={(event) => event.stopPropagation()}
+                  onChange={() => selection.onToggleRow(datum.groupId)}
+                />
+              )}
+            </Flex>
+          ),
+        } satisfies Column<DocumentInVariantGroup>,
+      ]
+    : []),
   {
     id: 'bundle',
     // Wider than the old 140 so typical release names ("Compliance Dashboard") render in full;
@@ -145,15 +189,17 @@ export const getVariantDocumentTableColumnDefs = (
     ),
   },
   {
+    // The document preview / title column. Search moved out of this header into the command lane
+    // (three-zone header spec); the header is now a plain sortable "Document" label.
     id: 'search',
     width: null,
     style: {minWidth: 'min(50%, calc(100vw - 80px))', maxWidth: 'min(50%, calc(100vw - 80px))'},
+    sorting: true,
     sortTransform: ({document}) => getDocumentPreviewTitle(document).toLowerCase(),
     header: (props) => (
-      <Headers.TableHeaderSearch
-        {...props}
-        placeholder={t('detail.documents.table.search-placeholder')}
-      />
+      <Flex {...props.headerProps} paddingY={3} sizing="border">
+        <Headers.SortHeaderButton text={t('detail.documents.table.document')} {...props} />
+      </Flex>
     ),
     cell: ({cellProps, datum}) => (
       <Flex


### PR DESCRIPTION
First PR of the **Releases × Variants table convergence** lane. Variants-only, behind `beta.variants` — the low-level shared `Table` and all Releases code are untouched.

> Stacked on #13595 (variant detail redesign). Base will retarget to `main` once that merges.

### Description

Implements a three-zone table header on the variant detail documents table, resolving the "table controls living in the column-header row" anti-pattern (search-in-header and select-all-in-header) together.

- **Command lane (zone 1)** — table-scoped controls in a `Container width={3}` lane aligned with the rows below. Idle shows a **search input** + the **filter tabs**; the moment a row is selected it swaps GitHub-style into a **bulk toolbar**: a persistent leftmost select-all, a primary-toned selected count, Publish / Delete, and a "more" overflow (Unpublish, Add to release). Bulk actions are stubbed (disabled) for now.
- **Column-header row (zone 2)** — labels + sort only. The former search column is now a plain sortable **"Document"** label; the checkbox column header is empty.
- **Rows (zone 3)** — unchanged.

Specifics:
- **Search ownership moves to the composition.** The low-level `Table`'s search state is internal to its own provider, so the command lane can't reach it. `VariantDocumentsTable` now owns `searchTerm`, renders the input in the command lane, and filters rows before they reach the Table (which just sorts what it receives). No change to the shared `Table`.
- **Select-all is persistent** (leftmost, over the checkbox column) rather than reveal-on-selection, so nothing shifts vertically when you tick the first row. Clicking it while anything is selected clears (GitHub-style).
- The release/filter lane drops its filter icon + "Releases" label — the tabs (All, Published, Drafts, release names) are self-evidently bundle filters, and the icon read as a clickable control that wasn't one.
- Built as an extraction-ready shape so the shared `DocumentTable` (convergence PR 2) can lift it and Releases can adopt it.

### What to review

- Open a variant definition with documents. The **search box** sits in the command lane (left), filter tabs beside it; the column-header row shows **Document** (sortable) where search used to be.
- Type in search → rows filter, and **column sorting still works** with a search/filter active.
- Tick a row → the lane **swaps to the bulk toolbar** with count + Publish/Delete/⋯ (stubbed). Untick / clear → it reverts to search + filters.
- Empty variant (no documents): the command lane is hidden; column headers + empty state still render.

### Reviewable UX call

**Select-all is persistent** (always visible in the lane) rather than reveal-on-selection. This keeps the layout from shifting when you pick the first row, at the cost of one always-present checkbox in the idle state. Happy to switch to reveal-on-selection if preferred.

### Testing

Variant suite green (222), typecheck + lint + format clean. New/updated: bulk-toolbar swap, persistent select-all + clear, primary/overflow bulk actions, search-in-command-lane, "Document" header, and the empty-variant search-absent case.

### Notes for release

N/A — behind `beta.variants`, not separately enabled. First brick of the shared-table convergence; the shared extraction + Releases adoption follow in later PRs on this lane.
