### PR TITLE
feat(presentation): share variant to presentation using comlink

### DIFF
--- a/dev/test-studio/preview/main.tsx
+++ b/dev/test-studio/preview/main.tsx
@@ -1,5 +1,16 @@
 import {type ClientPerspective} from '@sanity/client'
-import {Box, Card, Flex, Text, studioTheme, Tab, TabList, TabPanel, ThemeProvider} from '@sanity/ui'
+import {
+  Box,
+  Card,
+  Flex,
+  Stack,
+  studioTheme,
+  Tab,
+  TabList,
+  TabPanel,
+  Text,
+  ThemeProvider,
+} from '@sanity/ui'
 import {enableVisualEditing} from '@sanity/visual-editing'
 import {Suspense, useEffect, useState} from 'react'
 import {createRoot} from 'react-dom/client'
@@ -108,8 +119,16 @@ function Main() {
 
 function VisualEditing() {
   const [perspective, setPerspective] = useState<ClientPerspective>('published')
+  const [variant, setVariant] = useState<string | undefined>(undefined)
 
-  useEffect(() => enableVisualEditing({onPerspectiveChange: setPerspective}), [])
+  useEffect(
+    () =>
+      enableVisualEditing({
+        onPerspectiveChange: setPerspective,
+        onVariantChange: setVariant,
+      }),
+    [],
+  )
   useLiveMode({})
 
   return (
@@ -120,9 +139,14 @@ function VisualEditing() {
       style={{bottom: 16, maxWidth: 420, position: 'fixed', right: 16, zIndex: 1000}}
       tone="transparent"
     >
-      <Text muted size={1}>
-        perspective: {JSON.stringify(perspective)}
-      </Text>
+      <Stack space={2}>
+        <Text muted size={1}>
+          perspective: {JSON.stringify(perspective)}
+        </Text>
+        <Text muted size={1} data-testid="preview-variant">
+          variant: {variant ? JSON.stringify(variant) : 'none'}
+        </Text>
+      </Stack>
     </Card>
   )
 }

--- a/packages/sanity/src/presentation/PostMessagePerspective.tsx
+++ b/packages/sanity/src/presentation/PostMessagePerspective.tsx
@@ -6,25 +6,33 @@ import {type VisualEditingConnection} from './types'
 export interface PostMessagePerspectiveProps {
   comlink: VisualEditingConnection
   perspective: ClientPerspective
+  variant: string | undefined
   setHandlesPerspectiveChange: (payload: boolean) => void
+  setHandlesVariantChange: (payload: boolean) => void
 }
 
 const PostMessagePerspective: FC<PostMessagePerspectiveProps> = (props) => {
-  const {comlink, perspective, setHandlesPerspectiveChange} = props
+  const {comlink, perspective, variant, setHandlesPerspectiveChange, setHandlesVariantChange} =
+    props
 
-  // Return the perspective when requested
+  // Return the perspective and variant when requested
   useEffect(() => {
     return comlink.on('visual-editing/fetch-perspective', (payload) => {
       // Report back whether the visual editing handler is set up to own perspective switching or not, if the payload is `undefined` then it means the visual editing instance isn't recent enough and we treat it as false
-      startTransition(() => setHandlesPerspectiveChange(payload?.handlesPerspectiveChange === true))
-      return {perspective}
+      startTransition(() => {
+        setHandlesPerspectiveChange(payload?.handlesPerspectiveChange === true)
+        // Same capability handshake for variant switching: absent means the visual editing
+        // instance predates variants and a variant change should reload the iframe
+        setHandlesVariantChange(payload?.handlesVariantChange === true)
+      })
+      return {perspective, variant}
     })
-  }, [comlink, perspective, setHandlesPerspectiveChange])
+  }, [comlink, perspective, variant, setHandlesPerspectiveChange, setHandlesVariantChange])
 
-  // Dispatch a perspective message when the perspective changes
+  // Dispatch a perspective message when the perspective or variant changes
   useEffect(() => {
-    comlink.post('presentation/perspective', {perspective})
-  }, [comlink, perspective])
+    comlink.post('presentation/perspective', {perspective, variant})
+  }, [comlink, perspective, variant])
 
   return null
 }

--- a/packages/sanity/src/presentation/PresentationTool.tsx
+++ b/packages/sanity/src/presentation/PresentationTool.tsx
@@ -72,6 +72,7 @@ import {useMainDocument} from './useMainDocument'
 import {useParams} from './useParams'
 import {usePopups} from './usePopups'
 import {usePresentationPerspective} from './usePresentationPerspective'
+import {usePresentationVariant} from './usePresentationVariant'
 import {useStatus} from './useStatus'
 import {useTargetOrigin} from './useTargetOrigin'
 import {debounce} from './util/debounce'
@@ -162,6 +163,7 @@ export default function PresentationTool(props: {
       frameStateRef,
     })
   const perspective = usePresentationPerspective({scheduledDraft: params.scheduledDraft})
+  const variant = usePresentationVariant()
 
   const presentationRef = useActorRef(presentationMachine)
 
@@ -182,6 +184,7 @@ export default function PresentationTool(props: {
     targetOrigin,
     resolvers: tool.options?.resolve?.mainDocuments,
     perspective,
+    variant,
   })
 
   const [overlaysConnection, setOverlaysConnection] = useStatus()
@@ -190,6 +193,11 @@ export default function PresentationTool(props: {
   const [_handlesPerspectiveChange, setHandlesPerspectiveChange] = useState(false)
   // Loaders also handle perspective changes, and for legacy reasons we also consider them as a valid handler
   const handlesPerspectiveChange = _handlesPerspectiveChange || loadersConnection === 'connected'
+  const [_handlesVariantChange, setHandlesVariantChange] = useState(false)
+  // Same for variant changes: connected loaders re-register their queries when
+  // `loader/perspective` delivers a new variant, so they count as a valid handler.
+  // Preview apps are required to run loader versions that support variants.
+  const handlesVariantChange = _handlesVariantChange || loadersConnection === 'connected'
 
   const {open: handleOpenPopup} = usePopups(controller)
 
@@ -600,6 +608,7 @@ export default function PresentationTool(props: {
                             overlaysConnection={overlaysConnection}
                             previewUrl={params.preview}
                             perspective={perspective}
+                            variant={variant}
                             ref={iframeRef}
                             setViewport={setViewport}
                             targetOrigin={targetOrigin}
@@ -610,6 +619,7 @@ export default function PresentationTool(props: {
                             presentationRef={presentationRef}
                             previewUrlRef={previewUrlRef}
                             handlesPerspectiveChange={handlesPerspectiveChange}
+                            handlesVariantChange={handlesVariantChange}
                           />
                         </BoundaryElementProvider>
                       </Flex>
@@ -642,6 +652,7 @@ export default function PresentationTool(props: {
           <LiveQueries
             controller={controller}
             perspective={perspective}
+            variant={variant}
             liveDocument={displayedDocument}
             onDocumentsOnPage={setDocumentsOnPage}
             onLoadersConnection={setLoadersConnection}
@@ -657,7 +668,11 @@ export default function PresentationTool(props: {
           />
         )}
         {visualEditingComlink && (
-          <PostMessageSchema comlink={visualEditingComlink} perspective={perspective} />
+          <PostMessageSchema
+            comlink={visualEditingComlink}
+            perspective={perspective}
+            variant={variant}
+          />
         )}
         {visualEditingComlink && documentsOnPage.length > 0 && (
           <PostMessagePreviewSnapshots
@@ -667,14 +682,20 @@ export default function PresentationTool(props: {
           />
         )}
         {visualEditingComlink && (
-          <PostMessageDocuments comlink={visualEditingComlink} perspective={perspective} />
+          <PostMessageDocuments
+            comlink={visualEditingComlink}
+            perspective={perspective}
+            variant={variant}
+          />
         )}
         {visualEditingComlink && <PostMessageFeatures comlink={visualEditingComlink} />}
         {visualEditingComlink && (
           <PostMessagePerspective
             comlink={visualEditingComlink}
             perspective={perspective}
+            variant={variant}
             setHandlesPerspectiveChange={setHandlesPerspectiveChange}
+            setHandlesVariantChange={setHandlesVariantChange}
           />
         )}
         {visualEditingComlink && <PostMessageTelemetry comlink={visualEditingComlink} />}

--- a/packages/sanity/src/presentation/__tests__/usePresentationVariant.test.ts
+++ b/packages/sanity/src/presentation/__tests__/usePresentationVariant.test.ts
@@ -1,0 +1,38 @@
+import {renderHook} from '@testing-library/react'
+import {type PerspectiveContextValue} from 'sanity'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {usePresentationVariant} from '../usePresentationVariant'
+
+const mockUsePerspective = vi.fn()
+
+vi.mock('sanity', async (importOriginal) => ({
+  ...(await importOriginal()),
+  usePerspective: () => mockUsePerspective(),
+}))
+
+describe('usePresentationVariant', () => {
+  beforeEach(() => {
+    mockUsePerspective.mockReset()
+  })
+
+  it('should return the selected variant name as-is (bare variant id)', () => {
+    mockUsePerspective.mockReturnValue({
+      selectedVariantName: 'Ab12cd34',
+    } satisfies Partial<PerspectiveContextValue>)
+
+    const {result} = renderHook(() => usePresentationVariant())
+
+    expect(result.current).toBe('Ab12cd34')
+  })
+
+  it('should return undefined when no variant is selected', () => {
+    mockUsePerspective.mockReturnValue({
+      selectedVariantName: undefined,
+    } satisfies Partial<PerspectiveContextValue>)
+
+    const {result} = renderHook(() => usePresentationVariant())
+
+    expect(result.current).toBeUndefined()
+  })
+})

--- a/packages/sanity/src/presentation/actors/resolve-initial-url.ts
+++ b/packages/sanity/src/presentation/actors/resolve-initial-url.ts
@@ -10,11 +10,13 @@ export function defineResolveInitialUrlActor({
   studioBasePath,
   previewUrlOption,
   perspective,
+  variant,
 }: {
   client: SanityClient
   studioBasePath: string
   previewUrlOption: PreviewUrlOption | undefined
   perspective: PresentationPerspective
+  variant: string | undefined
 }): PromiseActorLogic<URL, {previewSearchParam: string | null}> {
   return fromPromise<URL, {previewSearchParam: string | null}>(
     async ({input}: {input: {previewSearchParam: string | null}}) => {
@@ -29,6 +31,7 @@ export function defineResolveInitialUrlActor({
           // @TODO handle checking permissions here, and then generating a secret
           previewUrlSecret: '',
           studioPreviewPerspective: encodeStudioPerspective(perspective),
+          studioPreviewVariant: variant,
           previewSearchParam: input.previewSearchParam,
         })
         return new URL(initial, origin)

--- a/packages/sanity/src/presentation/actors/resolve-preview-mode-url.ts
+++ b/packages/sanity/src/presentation/actors/resolve-preview-mode-url.ts
@@ -2,6 +2,7 @@ import {
   urlSearchParamPreviewPathname,
   urlSearchParamPreviewPerspective,
   urlSearchParamPreviewSecret,
+  urlSearchParamPreviewVariant,
 } from '@sanity/preview-url-secret/constants'
 import {type SanityClient} from 'sanity'
 import {fromPromise, type PromiseActorLogic} from 'xstate'
@@ -26,11 +27,13 @@ export function defineResolvePreviewModeUrlActor({
   studioBasePath,
   previewUrlOption,
   perspective,
+  variant,
 }: {
   client: SanityClient
   studioBasePath: string
   previewUrlOption: PreviewUrlOption | undefined
   perspective: PresentationPerspective
+  variant: string | undefined
 }): PromiseActorLogic<URL, ResolvePreviewModeUrlInput> {
   return fromPromise<URL, ResolvePreviewModeUrlInput>(async ({input}) => {
     const {previewUrlSecret, resolvedPreviewMode, initialUrl} = input
@@ -44,6 +47,7 @@ export function defineResolvePreviewModeUrlActor({
         studioBasePath,
         previewUrlSecret,
         studioPreviewPerspective: encodeStudioPerspective(perspective),
+        studioPreviewVariant: variant,
         previewSearchParam: initialUrl.toString(),
       })
       return new URL(initial, initialUrl)
@@ -60,6 +64,11 @@ export function defineResolvePreviewModeUrlActor({
 
     url.searchParams.set(urlSearchParamPreviewSecret, previewUrlSecret)
     url.searchParams.set(urlSearchParamPreviewPerspective, encodeStudioPerspective(perspective))
+    if (variant) {
+      url.searchParams.set(urlSearchParamPreviewVariant, variant)
+    } else {
+      url.searchParams.delete(urlSearchParamPreviewVariant)
+    }
     if (initialUrl.pathname !== url.pathname) {
       url.searchParams.set(
         urlSearchParamPreviewPathname,

--- a/packages/sanity/src/presentation/loader/LiveQueries.tsx
+++ b/packages/sanity/src/presentation/loader/LiveQueries.tsx
@@ -283,7 +283,15 @@ interface UseQuerySubscriptionProps extends Required<Pick<SharedProps, 'client'>
   liveEventsMessages: LiveEventMessage[]
 }
 function useQuerySubscription(props: UseQuerySubscriptionProps) {
-  const {liveDocument, client, query, params, perspective, variant, liveEventsMessages} = props
+  const {
+    liveDocument,
+    client: _client,
+    query,
+    params,
+    perspective,
+    variant,
+    liveEventsMessages,
+  } = props
   const [result, setResult] = useState<unknown>(null)
   const [resultSourceMap, setResultSourceMap] = useState<ContentSourceMap | null | undefined>(null)
   const [syncTags, setSyncTags] = useState<SyncTag[] | undefined>(undefined)
@@ -300,13 +308,13 @@ function useQuerySubscription(props: UseQuerySubscriptionProps) {
 
   useEffect(() => {
     const controller = new AbortController()
-    const clientApiVersion = variant
-      ? VARIANTS_STUDIO_CLIENT_OPTIONS.apiVersion
-      : client.config().apiVersion
+
+    // Parent client follows activeVariant synchronously; per-query variant comes from loader/query-listen and lags.
+    // Without this, a client downgrade can run a fetch that still passes variant, which the dated API rejects.
+    // Once we have a dated api for variants we can update the default API_VERSION we use for all clients in presentation
+    const client = variant ? _client.withConfig(VARIANTS_STUDIO_CLIENT_OPTIONS) : _client
+
     client
-      .withConfig({
-        apiVersion: clientApiVersion,
-      })
       .fetch(query, params, {
         lastLiveEventId,
         tag: 'presentation-loader',
@@ -334,7 +342,7 @@ function useQuerySubscription(props: UseQuerySubscriptionProps) {
     return () => {
       controller.abort()
     }
-  }, [client, lastLiveEventId, params, perspective, query, variant])
+  }, [_client, lastLiveEventId, params, perspective, query, variant])
 
   return useMemo(() => {
     if (liveDocument && resultSourceMap) {

--- a/packages/sanity/src/presentation/loader/LiveQueries.tsx
+++ b/packages/sanity/src/presentation/loader/LiveQueries.tsx
@@ -35,6 +35,7 @@ import {
   useClient,
   useDataset,
   useProjectId,
+  VARIANTS_STUDIO_CLIENT_OPTIONS,
 } from 'sanity'
 
 import {API_VERSION, MIN_LOADER_QUERY_LISTEN_HEARTBEAT_INTERVAL} from '../constants'
@@ -48,6 +49,10 @@ export interface LiveQueriesProps {
   liveDocument: Partial<SanityDocument> | null | undefined
   controller: Controller | undefined
   perspective: ClientPerspective
+  /**
+   * The selected editing variant as a bare variant id, or `undefined` when no variant is selected
+   */
+  variant: string | undefined
   onLoadersConnection: (event: StatusEvent) => void
   onDocumentsOnPage: (
     key: string,
@@ -57,7 +62,13 @@ export interface LiveQueriesProps {
 }
 
 export default function LiveQueries(props: LiveQueriesProps): React.JSX.Element {
-  const {controller, perspective: activePerspective, onLoadersConnection, onDocumentsOnPage} = props
+  const {
+    controller,
+    perspective: activePerspective,
+    variant: activeVariant,
+    onLoadersConnection,
+    onDocumentsOnPage,
+  } = props
 
   const [comlink, setComlink] = useState<ChannelInstance<LoaderControllerMsg, LoaderNodeMsg>>()
   const [liveQueries, liveQueriesDispatch] = useLiveQueries()
@@ -107,6 +118,10 @@ export default function LiveQueries(props: LiveQueriesProps): React.JSX.Element 
             type: 'query-listen',
             payload: {
               perspective: data.perspective,
+              // Round-tripped from the loader, like perspective: fetches use exactly what the
+              // subscription registered so results and cache keys stay coherent on both sides
+              // while re-registrations propagate after a variant switch
+              variant: data.variant || undefined,
               query: data.query,
               params: data.params,
               heartbeat: data.heartbeat ?? false,
@@ -121,10 +136,14 @@ export default function LiveQueries(props: LiveQueriesProps): React.JSX.Element 
   }, [controller, dataset, liveQueriesDispatch, onDocumentsOnPage, onLoadersConnection, projectId])
 
   const studioClient = useClient(
-    isReleasePerspective(activePerspective)
-      ? RELEASES_STUDIO_CLIENT_OPTIONS
-      : {apiVersion: API_VERSION},
+    // Fetching with a variant requires the `vX` API version for now
+    activeVariant
+      ? VARIANTS_STUDIO_CLIENT_OPTIONS
+      : isReleasePerspective(activePerspective)
+        ? RELEASES_STUDIO_CLIENT_OPTIONS
+        : {apiVersion: API_VERSION},
   )
+
   const client = useMemo(
     () =>
       studioClient.withConfig({
@@ -138,9 +157,10 @@ export default function LiveQueries(props: LiveQueriesProps): React.JSX.Element 
         projectId,
         dataset,
         perspective: activePerspective,
+        variant: activeVariant,
       })
     }
-  }, [comlink, activePerspective, projectId, dataset])
+  }, [comlink, activePerspective, activeVariant, projectId, dataset])
 
   /**
    * Defer the liveDocument to avoid unnecessary rerenders on rapid edits
@@ -151,12 +171,13 @@ export default function LiveQueries(props: LiveQueriesProps): React.JSX.Element 
 
   return (
     <>
-      {[...liveQueries.entries()].map(([key, {query, params, perspective}]) => (
+      {[...liveQueries.entries()].map(([key, {query, params, perspective, variant}]) => (
         <QuerySubscription
           key={`${liveEvents.resets}:${key}`}
           projectId={projectId}
           dataset={dataset}
           perspective={perspective}
+          variant={variant}
           query={query}
           params={params}
           comlink={comlink}
@@ -183,6 +204,7 @@ interface QuerySubscriptionProps extends Pick<
   projectId: string
   dataset: string
   perspective: ClientPerspective
+  variant: string | undefined
   query: string
   params: QueryParams
   comlink: LoaderConnection | undefined
@@ -192,6 +214,7 @@ function QuerySubscriptionComponent(props: QuerySubscriptionProps) {
     projectId,
     dataset,
     perspective,
+    variant,
     query,
     client,
     liveDocument,
@@ -209,6 +232,7 @@ function QuerySubscriptionComponent(props: QuerySubscriptionProps) {
     liveDocument,
     params,
     perspective,
+    variant,
     query,
     liveEventsMessages,
   }) || {}
@@ -217,6 +241,7 @@ function QuerySubscriptionComponent(props: QuerySubscriptionProps) {
     (
       comlink: LoaderConnection | undefined,
       perspective: ClientPerspective,
+      variant: string | undefined,
       query: string,
       params: QueryParams,
       result: unknown,
@@ -227,6 +252,7 @@ function QuerySubscriptionComponent(props: QuerySubscriptionProps) {
         projectId,
         dataset,
         perspective,
+        variant,
         query,
         params,
         result,
@@ -238,10 +264,10 @@ function QuerySubscriptionComponent(props: QuerySubscriptionProps) {
 
   useEffect(() => {
     if (resultSourceMap) {
-      handleQueryChange(comlink, perspective, query, params, result, resultSourceMap, tags)
+      handleQueryChange(comlink, perspective, variant, query, params, result, resultSourceMap, tags)
     }
     return undefined
-  }, [comlink, params, perspective, query, result, resultSourceMap, tags])
+  }, [comlink, params, perspective, query, result, resultSourceMap, tags, variant])
 
   return null
 }
@@ -253,10 +279,11 @@ interface UseQuerySubscriptionProps extends Required<Pick<SharedProps, 'client'>
   query: string
   params: QueryParams
   perspective: ClientPerspective
+  variant: string | undefined
   liveEventsMessages: LiveEventMessage[]
 }
 function useQuerySubscription(props: UseQuerySubscriptionProps) {
-  const {liveDocument, client, query, params, perspective, liveEventsMessages} = props
+  const {liveDocument, client, query, params, perspective, variant, liveEventsMessages} = props
   const [result, setResult] = useState<unknown>(null)
   const [resultSourceMap, setResultSourceMap] = useState<ContentSourceMap | null | undefined>(null)
   const [syncTags, setSyncTags] = useState<SyncTag[] | undefined>(undefined)
@@ -273,13 +300,19 @@ function useQuerySubscription(props: UseQuerySubscriptionProps) {
 
   useEffect(() => {
     const controller = new AbortController()
-
+    const clientApiVersion = variant
+      ? VARIANTS_STUDIO_CLIENT_OPTIONS.apiVersion
+      : client.config().apiVersion
     client
+      .withConfig({
+        apiVersion: clientApiVersion,
+      })
       .fetch(query, params, {
         lastLiveEventId,
         tag: 'presentation-loader',
         signal: controller.signal,
         perspective,
+        variant,
         filterResponse: false,
         returnQuery: false,
       })
@@ -301,7 +334,7 @@ function useQuerySubscription(props: UseQuerySubscriptionProps) {
     return () => {
       controller.abort()
     }
-  }, [client, lastLiveEventId, params, perspective, query])
+  }, [client, lastLiveEventId, params, perspective, query, variant])
 
   return useMemo(() => {
     if (liveDocument && resultSourceMap) {

--- a/packages/sanity/src/presentation/loader/__tests__/useLiveQueries.test.ts
+++ b/packages/sanity/src/presentation/loader/__tests__/useLiveQueries.test.ts
@@ -20,6 +20,7 @@ describe('useLiveQueries', () => {
           query: query1,
           params: params1,
           perspective: perspective1,
+          variant: undefined,
           heartbeat,
         },
       })
@@ -30,6 +31,7 @@ describe('useLiveQueries', () => {
         query: query1,
         params: params1,
         perspective: perspective1,
+        variant: undefined,
       })
       expect(state.heartbeats.get(key)).toStrictEqual({
         receivedAt: expect.any(Number),
@@ -44,6 +46,7 @@ describe('useLiveQueries', () => {
           query: query1,
           params: params1,
           perspective: perspective1,
+          variant: undefined,
           heartbeat,
         },
       })
@@ -53,6 +56,7 @@ describe('useLiveQueries', () => {
           query: query2,
           params: params2,
           perspective: perspective1,
+          variant: undefined,
           heartbeat,
         },
       })
@@ -62,6 +66,7 @@ describe('useLiveQueries', () => {
           query: query1,
           params: params1,
           perspective: perspective1,
+          variant: undefined,
           heartbeat,
         },
       })
@@ -72,6 +77,7 @@ describe('useLiveQueries', () => {
         query: query1,
         params: params1,
         perspective: perspective1,
+        variant: undefined,
       })
       expect(state.heartbeats.get(key1)).toStrictEqual({
         receivedAt: expect.any(Number),
@@ -81,6 +87,7 @@ describe('useLiveQueries', () => {
         query: query2,
         params: params2,
         perspective: perspective1,
+        variant: undefined,
       })
       expect(state.heartbeats.get(key2)).toStrictEqual({
         receivedAt: expect.any(Number),
@@ -98,6 +105,7 @@ describe('useLiveQueries', () => {
           query: query1,
           params: params1,
           perspective: perspective1,
+          variant: undefined,
           heartbeat,
         },
       })
@@ -109,6 +117,7 @@ describe('useLiveQueries', () => {
           query: query1,
           params: {...params1},
           perspective: perspective1,
+          variant: undefined,
           heartbeat,
         },
       })
@@ -125,6 +134,7 @@ describe('useLiveQueries', () => {
           query: query2,
           params: params2,
           perspective: perspective1,
+          variant: undefined,
           heartbeat,
         },
       })
@@ -136,6 +146,7 @@ describe('useLiveQueries', () => {
           query: query2,
           params: {...params2},
           perspective: perspective1,
+          variant: undefined,
           heartbeat,
         },
       })
@@ -148,6 +159,7 @@ describe('useLiveQueries', () => {
           query: query2,
           params: {...params2, type: 'bar'},
           perspective: perspective1,
+          variant: undefined,
           heartbeat,
         },
       })
@@ -166,6 +178,7 @@ describe('useLiveQueries', () => {
             bar: {baz: true},
           },
           perspective: perspective1,
+          variant: undefined,
           heartbeat,
         },
       })
@@ -181,6 +194,7 @@ describe('useLiveQueries', () => {
             bar: {baz: true},
           },
           perspective: perspective1,
+          variant: undefined,
           heartbeat,
         },
       })
@@ -197,10 +211,76 @@ describe('useLiveQueries', () => {
             bar: {baz: true},
           },
           perspective: perspective1,
+          variant: undefined,
           heartbeat,
         },
       })
       expect(state.queries).not.toBe(prevQueries)
+    })
+
+    test('the same query with different variants creates separate entries', () => {
+      const variant = 'Ab12cd34'
+      const prevState = reducer(initialState, {
+        type: 'query-listen',
+        payload: {
+          query: query1,
+          params: params1,
+          perspective: perspective1,
+          variant: undefined,
+          heartbeat,
+        },
+      })
+      const state = reducer(prevState, {
+        type: 'query-listen',
+        payload: {
+          query: query1,
+          params: params1,
+          perspective: perspective1,
+          variant,
+          heartbeat,
+        },
+      })
+      expect(state.queries.size).toBe(2)
+      const [key1, key2] = state.queries.keys()
+      expect(key1).not.toBe(key2)
+      expect(state.queries.get(key1)).toStrictEqual({
+        query: query1,
+        params: params1,
+        perspective: perspective1,
+        variant: undefined,
+      })
+      expect(state.queries.get(key2)).toStrictEqual({
+        query: query1,
+        params: params1,
+        perspective: perspective1,
+        variant,
+      })
+    })
+
+    test('listening again with the same variant is deduped', () => {
+      const variant = 'Ab12cd34'
+      const prevState = reducer(initialState, {
+        type: 'query-listen',
+        payload: {
+          query: query1,
+          params: params1,
+          perspective: perspective1,
+          variant,
+          heartbeat,
+        },
+      })
+      const state = reducer(prevState, {
+        type: 'query-listen',
+        payload: {
+          query: query1,
+          params: params1,
+          perspective: perspective1,
+          variant,
+          heartbeat,
+        },
+      })
+      expect(state.queries.size).toBe(1)
+      expect(state.queries).toBe(prevState.queries)
     })
 
     test('unstable perspective is fine', () => {
@@ -210,6 +290,7 @@ describe('useLiveQueries', () => {
           query: query2,
           params: params2,
           perspective: perspective2,
+          variant: undefined,
           heartbeat,
         },
       })
@@ -221,6 +302,7 @@ describe('useLiveQueries', () => {
           query: query2,
           params: params2,
           perspective: [...perspective2],
+          variant: undefined,
           heartbeat,
         },
       })
@@ -234,6 +316,7 @@ describe('useLiveQueries', () => {
           query: query2,
           params: params2,
           perspective: ['rBAR', 'drafts'],
+          variant: undefined,
           heartbeat,
         },
       })
@@ -258,6 +341,7 @@ describe('useLiveQueries', () => {
           query: query1,
           params: params1,
           perspective: perspective1,
+          variant: undefined,
           heartbeat,
         },
       })
@@ -290,6 +374,7 @@ describe('useLiveQueries', () => {
           query: query1,
           params: params1,
           perspective: perspective1,
+          variant: undefined,
           heartbeat,
         },
       })
@@ -299,6 +384,7 @@ describe('useLiveQueries', () => {
           query: query2,
           params: params2,
           perspective: perspective1,
+          variant: undefined,
           heartbeat: false,
         },
       })
@@ -326,6 +412,7 @@ describe('useLiveQueries', () => {
         query: query2,
         params: params2,
         perspective: perspective1,
+        variant: undefined,
       })
       expect(state.heartbeats.get(key)).toStrictEqual({
         receivedAt: expect.any(Number),
@@ -342,6 +429,7 @@ describe('useLiveQueries', () => {
           query: query1,
           params: params1,
           perspective: perspective1,
+          variant: undefined,
           heartbeat,
         },
       })
@@ -351,6 +439,7 @@ describe('useLiveQueries', () => {
           query: query2,
           params: params2,
           perspective: perspective1,
+          variant: undefined,
           heartbeat: heartbeat * 2,
         },
       })
@@ -380,6 +469,7 @@ describe('useLiveQueries', () => {
         query: query2,
         params: params2,
         perspective: perspective1,
+        variant: undefined,
       })
       expect(state.heartbeats.get(key)).toStrictEqual({
         receivedAt: expect.any(Number),

--- a/packages/sanity/src/presentation/loader/useLiveQueries.ts
+++ b/packages/sanity/src/presentation/loader/useLiveQueries.ts
@@ -12,6 +12,11 @@ type LiveQueriesState = Map<
     query: string
     params: QueryParams
     perspective: ClientPerspective
+    /**
+     * The editing variant the loader asked for (bare variant id), if any. Loaders that predate
+     * variants never send one.
+     */
+    variant: string | undefined
   }
 >
 
@@ -35,6 +40,7 @@ type QueryListenAction = {
   type: 'query-listen'
   payload: {
     perspective: ClientPerspective
+    variant: string | undefined
     query: string
     params: QueryParams
     heartbeat: number | false
@@ -68,8 +74,13 @@ function gc(state: State): State {
   return {...state, queries: nextQueries, heartbeats: nextHeartbeats}
 }
 function queryListen(state: State, {payload}: QueryListenAction): State {
-  const key = getQueryCacheKey(payload.perspective, payload.query, payload.params)
-  const data = {query: payload.query, params: payload.params, perspective: payload.perspective}
+  const key = getQueryCacheKey(payload.perspective, payload.variant, payload.query, payload.params)
+  const data = {
+    query: payload.query,
+    params: payload.params,
+    perspective: payload.perspective,
+    variant: payload.variant,
+  }
 
   const nextHeartbeats = new Map(state.heartbeats)
   nextHeartbeats.set(key, {

--- a/packages/sanity/src/presentation/loader/utils.ts
+++ b/packages/sanity/src/presentation/loader/utils.ts
@@ -36,14 +36,15 @@ export const mapChangedValue: ApplySourceDocumentsUpdateFunction = (
 /**
  * @internal
  */
-export type QueryCacheKey = `${string}:${string}:${string}`
+export type QueryCacheKey = `${string}:${string}:${string}:${string}`
 /**
  * @internal
  */
 export function getQueryCacheKey(
   perspective: ClientPerspective,
+  variant: string | undefined,
   query: string,
   params: QueryParams,
 ): QueryCacheKey {
-  return `${perspective}:${query}:${JSON.stringify(params)}`
+  return `${perspective}:${variant ?? ''}:${query}:${JSON.stringify(params)}`
 }

--- a/packages/sanity/src/presentation/machines/__tests__/preview-url.test.ts
+++ b/packages/sanity/src/presentation/machines/__tests__/preview-url.test.ts
@@ -55,9 +55,11 @@ const expiresAt = new Date(Date.now() + 1000 * 60 * 60)
 const mockActors = ({
   allowOption = undefined,
   previewUrlOption = undefined,
+  variant = undefined,
 }: {
   allowOption?: PreviewUrlAllowOption
   previewUrlOption?: PreviewUrlOption
+  variant?: string
 } = {}) => ({
   'create preview secret': fromPromise(() => Promise.resolve({secret: 'abc123', expiresAt})),
   'read shared preview secret': fromPromise<string | null>(() => Promise.resolve('dfg456')),
@@ -70,6 +72,7 @@ const mockActors = ({
     studioBasePath,
     previewUrlOption,
     perspective: 'drafts',
+    variant,
   }),
   'resolve preview mode': defineResolvePreviewModeActor({
     client,
@@ -80,6 +83,7 @@ const mockActors = ({
     studioBasePath,
     previewUrlOption,
     perspective: 'drafts',
+    variant,
   }),
   'check permission': fromObservable<PermissionCheckResult, CheckPermissionInput>(() =>
     of({granted: true, reason: 'Matching grant'}),
@@ -235,6 +239,7 @@ describe('Preview URL machine', () => {
               studioBasePath,
               previewUrlOption: previewUrlOption,
               perspective: 'drafts',
+              variant: undefined,
             }),
           },
         }),
@@ -244,6 +249,35 @@ describe('Preview URL machine', () => {
       const snapshot = await waitFor(actor, (state) => state.context.initialUrl !== null)
       expect(snapshot.context.initialUrl).toBeInstanceOf(URL)
       expect(snapshot.context.initialUrl!.toString()).toBe(expected)
+    })
+
+    test('passes the selected variant to legacy preview url resolvers', async () => {
+      const actor = createActor(
+        previewUrlMachine.provide({
+          actors: {
+            ...mockActors(),
+            'resolve initial url': defineResolveInitialUrlActor({
+              client,
+              studioBasePath,
+              previewUrlOption: (async ({studioPreviewVariant}) => {
+                const url = new URL('https://example.com')
+                if (studioPreviewVariant) {
+                  url.searchParams.set('sanity-preview-variant', studioPreviewVariant)
+                }
+                return url.toString()
+              }) as DeprecatedPreviewUrlResolver,
+              perspective: 'drafts',
+              variant: 'Ab12cd34',
+            }),
+          },
+        }),
+        {input: {previewSearchParam: null}},
+      ).start()
+
+      const snapshot = await waitFor(actor, (state) => state.context.initialUrl !== null)
+      expect(snapshot.context.initialUrl!.toString()).toBe(
+        'https://example.com/?sanity-preview-variant=Ab12cd34',
+      )
     })
   })
 
@@ -810,6 +844,38 @@ describe('Preview URL machine', () => {
           secret: expect.any(String),
           expiresAt: expect.any(Date),
         })
+      })
+
+      test('sets the selected variant on the preview mode enable url', async () => {
+        const actor = createActor(
+          previewUrlMachine.provide({
+            actors: mockActors({
+              previewUrlOption: {previewMode: {enable: '/api/preview'}},
+              variant: 'Ab12cd34',
+            }),
+          }),
+          {
+            input: {previewSearchParam: null},
+          },
+        ).start()
+        const {context} = await waitFor(actor, (state) => !state.hasTag('busy'))
+        expect(context.previewUrl?.searchParams.get('sanity-preview-variant')).toBe('Ab12cd34')
+        expect(context.previewUrl?.searchParams.get('sanity-preview-perspective')).toBe('drafts')
+      })
+
+      test('omits the variant param on the preview mode enable url when no variant is selected', async () => {
+        const actor = createActor(
+          previewUrlMachine.provide({
+            actors: mockActors({
+              previewUrlOption: {previewMode: {enable: '/api/preview'}},
+            }),
+          }),
+          {
+            input: {previewSearchParam: null},
+          },
+        ).start()
+        const {context} = await waitFor(actor, (state) => !state.hasTag('busy'))
+        expect(context.previewUrl?.searchParams.has('sanity-preview-variant')).toBe(false)
       })
 
       test('handles secret expiry', async () => {

--- a/packages/sanity/src/presentation/overlays/PostMessageDocuments.tsx
+++ b/packages/sanity/src/presentation/overlays/PostMessageDocuments.tsx
@@ -6,7 +6,12 @@ import {
 } from '@sanity/client'
 import {type FunctionComponent, memo, useEffect} from 'react'
 import {filter, first, merge, shareReplay} from 'rxjs'
-import {isReleasePerspective, RELEASES_STUDIO_CLIENT_OPTIONS, useClient} from 'sanity'
+import {
+  isReleasePerspective,
+  RELEASES_STUDIO_CLIENT_OPTIONS,
+  useClient,
+  VARIANTS_STUDIO_CLIENT_OPTIONS,
+} from 'sanity'
 
 import {API_VERSION} from '../constants'
 import {type VisualEditingConnection} from '../types'
@@ -14,13 +19,19 @@ import {type VisualEditingConnection} from '../types'
 interface PostMessageDocumentsProps {
   comlink: VisualEditingConnection
   perspective: ClientPerspective
+  variant: string | undefined
 }
 
 const PostMessageDocuments: FunctionComponent<PostMessageDocumentsProps> = (props) => {
-  const {comlink, perspective} = props
+  const {comlink, perspective, variant} = props
 
   const client = useClient(
-    isReleasePerspective(perspective) ? RELEASES_STUDIO_CLIENT_OPTIONS : {apiVersion: API_VERSION},
+    // Fetching with a variant requires the `vX` API version for now
+    variant
+      ? VARIANTS_STUDIO_CLIENT_OPTIONS
+      : isReleasePerspective(perspective)
+        ? RELEASES_STUDIO_CLIENT_OPTIONS
+        : {apiVersion: API_VERSION},
   )
 
   useEffect(() => {

--- a/packages/sanity/src/presentation/overlays/schema/PostMessageSchema.tsx
+++ b/packages/sanity/src/presentation/overlays/schema/PostMessageSchema.tsx
@@ -7,6 +7,7 @@ import {
   RELEASES_STUDIO_CLIENT_OPTIONS,
   useClient,
   useWorkspace,
+  VARIANTS_STUDIO_CLIENT_OPTIONS,
 } from 'sanity'
 
 import {API_VERSION} from '../../constants'
@@ -16,6 +17,7 @@ import {extractSchema} from './extract'
 export interface PostMessageSchemaProps {
   comlink: VisualEditingConnection
   perspective: ClientPerspective
+  variant: string | undefined
 }
 
 function getDocumentPathArray(paths: UnresolvedPath[]) {
@@ -39,7 +41,7 @@ function getDocumentPathArray(paths: UnresolvedPath[]) {
  * over postMessage so it can be used to enrich the Visual Editing experience
  */
 function PostMessageSchema(props: PostMessageSchemaProps): React.JSX.Element | null {
-  const {comlink, perspective} = props
+  const {comlink, perspective, variant} = props
 
   const workspace = useWorkspace()
 
@@ -60,7 +62,12 @@ function PostMessageSchema(props: PostMessageSchemaProps): React.JSX.Element | n
   }, [comlink, workspace])
 
   const client = useClient(
-    isReleasePerspective(perspective) ? RELEASES_STUDIO_CLIENT_OPTIONS : {apiVersion: API_VERSION},
+    // Fetching with a variant requires the `vX` API version for now
+    variant
+      ? VARIANTS_STUDIO_CLIENT_OPTIONS
+      : isReleasePerspective(perspective)
+        ? RELEASES_STUDIO_CLIENT_OPTIONS
+        : {apiVersion: API_VERSION},
   )
 
   // Resolve union types from an array of unresolved paths
@@ -79,6 +86,7 @@ function PostMessageSchema(props: PostMessageSchemaProps): React.JSX.Element | n
             {
               tag: 'presentation-schema',
               perspective,
+              variant,
             },
           )
           // `client.fetch` returns `null` when no document matches the active perspective,
@@ -99,7 +107,7 @@ function PostMessageSchema(props: PostMessageSchemaProps): React.JSX.Element | n
       })
       return {types: newState}
     })
-  }, [comlink, client, perspective])
+  }, [comlink, client, perspective, variant])
 
   return null
 }

--- a/packages/sanity/src/presentation/preview/OpenPreviewButton.tsx
+++ b/packages/sanity/src/presentation/preview/OpenPreviewButton.tsx
@@ -1,5 +1,8 @@
 import {LaunchIcon} from '@sanity/icons/Launch'
-import {urlSearchParamPreviewPerspective} from '@sanity/preview-url-secret/constants'
+import {
+  urlSearchParamPreviewPerspective,
+  urlSearchParamPreviewVariant,
+} from '@sanity/preview-url-secret/constants'
 import {Text} from '@sanity/ui'
 import {useCallback, useMemo} from 'react'
 import {useTranslation} from 'sanity'
@@ -16,18 +19,31 @@ export function OpenPreviewButton(
     previewLocationOrigin?: string
     previewLocationRoute: string
     perspective: PresentationPerspective
+    variant: string | undefined
     targetOrigin: string
   },
 ): React.ReactNode {
-  const {openPopup, previewLocationOrigin, previewLocationRoute, perspective, targetOrigin} = props
+  const {
+    openPopup,
+    previewLocationOrigin,
+    previewLocationRoute,
+    perspective,
+    variant,
+    targetOrigin,
+  } = props
 
   const openPreviewLink = useMemo(() => {
     const url = new URL(previewLocationRoute, previewLocationOrigin || targetOrigin)
     url.searchParams.set(urlSearchParamPreviewPerspective, encodeStudioPerspective(perspective))
+    if (variant) {
+      url.searchParams.set(urlSearchParamPreviewVariant, variant)
+    } else {
+      url.searchParams.delete(urlSearchParamPreviewVariant)
+    }
     const {pathname, search} = url
 
     return `${previewLocationOrigin}${pathname}${search}`
-  }, [perspective, previewLocationOrigin, previewLocationRoute, targetOrigin])
+  }, [perspective, previewLocationOrigin, previewLocationRoute, targetOrigin, variant])
 
   const {t} = useTranslation(presentationLocaleNamespace)
 

--- a/packages/sanity/src/presentation/preview/Preview.tsx
+++ b/packages/sanity/src/presentation/preview/Preview.tsx
@@ -6,6 +6,7 @@ import {
 } from '@sanity/presentation-comlink'
 import {
   urlSearchParamPreviewPerspective,
+  urlSearchParamPreviewVariant,
   urlSearchParamVercelProtectionBypass,
   urlSearchParamVercelSetBypassCookie,
   type VercelSetBypassCookieValue,
@@ -74,6 +75,10 @@ export interface PreviewProps {
   overlaysConnection: ConnectionStatus
   presentationRef: PresentationMachineRef
   perspective: PresentationPerspective
+  /**
+   * The selected editing variant as a bare variant id, or `undefined` when no variant is selected
+   */
+  variant: string | undefined
   previewUrl?: string
   setViewport: (mode: 'desktop' | 'mobile') => void
   targetOrigin: string
@@ -83,6 +88,7 @@ export interface PreviewProps {
   vercelProtectionBypass: string | null
   previewUrlRef: PreviewUrlRef
   handlesPerspectiveChange: boolean
+  handlesVariantChange: boolean
 }
 
 export const Preview = memo(
@@ -93,17 +99,25 @@ export const Preview = memo(
       loadersConnection,
       overlaysConnection,
       perspective,
+      variant,
       viewport,
       vercelProtectionBypass,
       presentationRef,
       previewUrlRef,
       handlesPerspectiveChange,
+      handlesVariantChange,
     } = props
 
     const [stablePerspective, setStablePerspective] = useState<typeof perspective | null>(null)
     const urlPerspective = encodeStudioPerspective(
       stablePerspective === null ? perspective : stablePerspective,
     )
+    /**
+     * `null` means "not frozen yet" — distinct from `undefined`, which is a valid frozen value
+     * meaning "no variant selected"
+     */
+    const [stableVariant, setStableVariant] = useState<string | undefined | null>(null)
+    const urlVariant = stableVariant === null ? variant : stableVariant
     const previewUrl = useMemo(() => {
       const url = new URL(initialUrl)
 
@@ -112,6 +126,13 @@ export const Preview = memo(
       // and a comlink node connecting to the iframe and reporting whether perspective switching is handled by the preview,
       // or if perspective switching should reload the iframe.
       url.searchParams.set(urlSearchParamPreviewPerspective, urlPerspective)
+
+      // Same for the editing variant, except the param is only present while a variant is selected
+      if (urlVariant) {
+        url.searchParams.set(urlSearchParamPreviewVariant, urlVariant)
+      } else {
+        url.searchParams.delete(urlSearchParamPreviewVariant)
+      }
 
       if (vercelProtectionBypass || url.searchParams.get(urlSearchParamVercelProtectionBypass)) {
         // samesitenone is required since the request is from an iframe
@@ -126,7 +147,7 @@ export const Preview = memo(
       }
 
       return url
-    }, [initialUrl, urlPerspective, vercelProtectionBypass])
+    }, [initialUrl, urlPerspective, urlVariant, vercelProtectionBypass])
 
     useEffect(() => {
       /**
@@ -143,6 +164,18 @@ export const Preview = memo(
         setStablePerspective((prev) => (prev === null ? perspective : prev))
       }
     }, [handlesPerspectiveChange, perspective])
+
+    useEffect(() => {
+      /**
+       * Same freeze mechanism for the editing variant: once the preview can handle variant changes
+       * in-place — reported over comlink, or implied by a connected loader — we stop reflecting
+       * variant changes in `src` so they no longer cause a full page reload.
+       */
+      if (handlesVariantChange) {
+        // oxlint-disable-next-line react/react-compiler
+        setStableVariant((prev) => (prev === null ? variant : prev))
+      }
+    }, [handlesVariantChange, variant])
 
     const {t} = useTranslation(presentationLocaleNamespace)
     const {devMode} = usePresentationTool()

--- a/packages/sanity/src/presentation/preview/PreviewHeader.tsx
+++ b/packages/sanity/src/presentation/preview/PreviewHeader.tsx
@@ -37,6 +37,7 @@ const PreviewHeaderDefault = (props: Omit<PreviewHeaderProps, 'renderDefault'>) 
     overlaysConnection,
     presentationRef,
     perspective,
+    variant,
     previewUrl,
     setViewport,
     targetOrigin,
@@ -207,6 +208,7 @@ const PreviewHeaderDefault = (props: Omit<PreviewHeaderProps, 'renderDefault'>) 
                 previewLocationOrigin={previewLocationOrigin}
                 previewLocationRoute={previewLocationRoute}
                 perspective={perspective}
+                variant={variant}
                 targetOrigin={targetOrigin}
               />
             </Box>
@@ -252,6 +254,7 @@ const PreviewHeaderDefault = (props: Omit<PreviewHeaderProps, 'renderDefault'>) 
             previewLocationRoute={previewLocationRoute}
             initialUrl={initialUrl}
             perspective={perspective}
+            variant={variant}
           />
         </Flex>
       )}

--- a/packages/sanity/src/presentation/preview/SharePreviewMenu.tsx
+++ b/packages/sanity/src/presentation/preview/SharePreviewMenu.tsx
@@ -39,6 +39,7 @@ export interface SharePreviewMenuProps {
   previewLocationRoute: string
   initialUrl: PreviewProps['initialUrl']
   perspective: ClientPerspective
+  variant: string | undefined
 }
 
 const QrCodeLogoSize = 24
@@ -65,6 +66,7 @@ export function SharePreviewMenu(props: SharePreviewMenuProps): React.JSX.Elemen
     initialUrl,
     previewLocationRoute,
     perspective,
+    variant,
   } = props
   const {t} = useTranslation(presentationLocaleNamespace)
   const {push: pushToast} = useToast()
@@ -83,9 +85,10 @@ export function SharePreviewMenu(props: SharePreviewMenuProps): React.JSX.Elemen
             secret,
             previewLocationRoute,
             encodeStudioPerspective(perspective),
+            variant,
           )
         : null,
-    [initialUrl, perspective, previewLocationRoute, secret],
+    [initialUrl, perspective, previewLocationRoute, secret, variant],
   )
 
   const [error, setError] = useState<unknown>(null)

--- a/packages/sanity/src/presentation/useMainDocument.ts
+++ b/packages/sanity/src/presentation/useMainDocument.ts
@@ -1,7 +1,7 @@
 import {type ResponseQueryOptions} from '@sanity/client'
 import {match, type Path} from 'path-to-regexp'
 import {useEffect, useEffectEvent, useRef, useState} from 'react'
-import {useClient} from 'sanity'
+import {useClient, VARIANTS_STUDIO_CLIENT_OPTIONS} from 'sanity'
 import {type RouterState, useRouter} from 'sanity/router'
 
 import {API_VERSION} from './constants'
@@ -99,10 +99,20 @@ export function useMainDocument(props: {
   targetOrigin: string
   resolvers?: DocumentResolver[]
   perspective: PresentationPerspective
+  variant: string | undefined
 }): MainDocumentState | undefined {
-  const {navigate, navigationHistory, path, targetOrigin, resolvers = [], perspective} = props
+  const {
+    navigate,
+    navigationHistory,
+    path,
+    targetOrigin,
+    resolvers = [],
+    perspective,
+    variant,
+  } = props
   const {state: routerState} = useRouter()
-  const client = useClient({apiVersion: API_VERSION})
+  // Fetching with a variant requires the `vX` API version for now
+  const client = useClient(variant ? VARIANTS_STUDIO_CLIENT_OPTIONS : {apiVersion: API_VERSION})
   const relativeUrl =
     path || routerState._searchParams?.find(([key]) => key === 'preview')?.[1] || ''
 
@@ -161,6 +171,7 @@ export function useMainDocument(props: {
           const controller = new AbortController()
           const options: ResponseQueryOptions = {
             perspective: perspective,
+            variant,
             signal: controller.signal,
             tag: 'use-main-document',
           }
@@ -183,7 +194,7 @@ export function useMainDocument(props: {
     setMainDocumentState(undefined)
     mainDocumentIdRef.current = undefined
     return undefined
-  }, [client, perspective, relativeUrl, resolvers, targetOrigin])
+  }, [client, perspective, relativeUrl, resolvers, targetOrigin, variant])
 
   return mainDocumentState
 }

--- a/packages/sanity/src/presentation/usePresentationVariant.ts
+++ b/packages/sanity/src/presentation/usePresentationVariant.ts
@@ -1,0 +1,13 @@
+import {usePerspective} from 'sanity'
+
+/**
+ * The selected editing variant as a bare variant id (e.g. `Ab12cd34`), or `undefined` when no
+ * variant is selected. This is the raw `variant` router sticky param value, available
+ * synchronously — orthogonal to the perspective, and passed alongside it wherever the
+ * perspective travels (iframe URL, comlink messages, loader fetches).
+ * @internal
+ */
+export function usePresentationVariant(): string | undefined {
+  const {selectedVariantName} = usePerspective()
+  return selectedVariantName
+}

--- a/packages/sanity/src/presentation/usePreviewUrlActorRef.ts
+++ b/packages/sanity/src/presentation/usePreviewUrlActorRef.ts
@@ -16,6 +16,7 @@ import {presentationLocaleNamespace} from './i18n'
 import {previewUrlMachine, type PreviewUrlRef} from './machines/preview-url'
 import {type PreviewUrlAllowOption, type PreviewUrlOption} from './types'
 import {usePresentationPerspective} from './usePresentationPerspective'
+import {usePresentationVariant} from './usePresentationVariant'
 
 export function usePreviewUrlActorRef(
   previewUrlOption: PreviewUrlOption | undefined,
@@ -36,6 +37,7 @@ export function usePreviewUrlActorRef(
   // TODO: Do we need to pass the scheduled draft perspective here?
   // Scheduled draft are a "local" perspective which applies only when the user is in the document pane and has selected the scheduled draft.
   const perspective = usePresentationPerspective({scheduledDraft: undefined})
+  const variant = usePresentationVariant()
 
   const actorRef = useActorRef(
     previewUrlMachine.provide({
@@ -61,6 +63,7 @@ export function usePreviewUrlActorRef(
           studioBasePath,
           previewUrlOption,
           perspective,
+          variant,
         }),
         'resolve preview mode': defineResolvePreviewModeActor({
           client,
@@ -71,6 +74,7 @@ export function usePreviewUrlActorRef(
           studioBasePath,
           previewUrlOption,
           perspective,
+          variant,
         }),
         'check permission': fromObservable(({input}) =>
           grantsStore.checkDocumentPermission(input.checkPermissionName, input.document),


### PR DESCRIPTION
### Description

The studio supports editing variants (`beta.variants.enabled`): the selected variant lands in the perspective provider via the `variant` sticky param, but Presentation ignored it, so previews could never reflect variant content. This threads the bare variant id down every path `perspective` already travels.
- The iframe URL (`sanity-preview-variant`)
- The comlink protocol (`presentation/perspective`, the `fetch-perspective` capability handshake.
-  refetches loader queries with `client.fetch(query, params, {perspective, variant})`, which the API accepts as `?variant={variantId}` on the `vX` API version.

Resolves [SAPP-4048](https://linear.app/sanity/issue/SAPP-4048).


https://github.com/user-attachments/assets/ce90265d-939c-489f-8307-daa8036a95e0


### What to review

- The changes to presentation, following `perspective` now we also share a `variant` field

### Testing

- New: `usePresentationVariant` hook test; variant cache-key separation/dedupe cases in `useLiveQueries`; preview-url machine tests asserting `sanity-preview-variant` is set on the enable URL when a variant is selected, omitted otherwise, and passed to legacy function resolvers.
- Full presentation suite passes (153 tests), type-checks clean against the released protocol types (no casts).
- Manual verification in the test studio (`/test` workspace → Presentation): selecting a variant adds `sanity-preview-variant` to the iframe URL, posts it over comlink (the preview debug card reports it via `onVariantChange`), and refetches loader queries with `?variant=<id>` against `vX` without a full iframe reload; clearing the variant returns base content.

### Notes for release

N/A – Part of the Content Variants feature (gated behind `beta.variants.enabled`, not generally available yet).