### PR TITLE
test(core): pin validation markers and range decorations at container depth

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/TableRangeDecorationDepth.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/TableRangeDecorationDepth.browser.test.tsx
@@ -1,0 +1,76 @@
+import {type SanityDocument} from '@sanity/types'
+import {describe, expect, it} from 'vitest'
+
+import {testHelpers} from '../../../../../../test/browser/testHelpers'
+import {TableRangeDecorationDepthStory} from './TableRangeDecorationDepthStory'
+
+const {render} = await import('vitest-browser-react')
+
+const document: SanityDocument = {
+  _id: '123',
+  _type: 'test',
+  _createdAt: new Date().toISOString(),
+  _updatedAt: new Date().toISOString(),
+  _rev: '123',
+  body: [
+    {
+      _type: 'block',
+      _key: 'b0',
+      children: [{_type: 'span', _key: 'b0-s', text: 'root decorated here', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    },
+    {
+      _type: 'table',
+      _key: 't0',
+      headerRows: 0,
+      rows: [
+        {
+          _type: 'row',
+          _key: 'r0',
+          cells: [
+            {
+              _type: 'cell',
+              _key: 'c0',
+              value: [
+                {
+                  _type: 'block',
+                  _key: 'cb0',
+                  children: [
+                    {_type: 'span', _key: 'cb0-s', text: 'cell decorated here', marks: []},
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+describe('Portable Text Input - range decorations at depth', () => {
+  it('decorates ranges at the root and inside table cells alike', async () => {
+    const {getFocusedPortableTextEditor} = testHelpers()
+
+    void render(<TableRangeDecorationDepthStory document={document} />)
+
+    const $pte = await getFocusedPortableTextEditor('field-body')
+    await expect.element($pte).toHaveTextContent('cell decorated here')
+
+    await expect.poll(() => decorations().length).toBe(2)
+    expect(decorations()).toEqual([
+      {text: 'decorated', insideTable: false},
+      {text: 'decorated', insideTable: true},
+    ])
+  })
+})
+
+function decorations() {
+  return [...window.document.querySelectorAll('[data-testid="probe-decoration"]')].map((node) => ({
+    text: node.textContent,
+    insideTable: node.closest('table') !== null,
+  }))
+}

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/TableRangeDecorationDepthStory.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/TableRangeDecorationDepthStory.tsx
@@ -1,0 +1,127 @@
+import {type RangeDecoration} from '@portabletext/editor'
+import {defineArrayMember, defineField, defineType, type SanityDocument} from '@sanity/types'
+
+import {TestForm} from '../../../../../../test/browser/TestForm'
+import {TestWrapper} from '../../../../../../test/browser/TestWrapper'
+
+// Two decorations over the word "decorated", one targeting a root span
+// and one targeting a span inside a table cell. Range decorations are
+// the channel inline comments and presence cursors render through, so
+// this pins the rendering half of both at container depth.
+const rangeDecorations: RangeDecoration[] = [
+  {
+    component: ({children}) => <span data-testid="probe-decoration">{children}</span>,
+    selection: {
+      anchor: {path: [{_key: 'b0'}, 'children', {_key: 'b0-s'}], offset: 5},
+      focus: {path: [{_key: 'b0'}, 'children', {_key: 'b0-s'}], offset: 14},
+    },
+  },
+  {
+    component: ({children}) => <span data-testid="probe-decoration">{children}</span>,
+    selection: {
+      anchor: {
+        path: [
+          {_key: 't0'},
+          'rows',
+          {_key: 'r0'},
+          'cells',
+          {_key: 'c0'},
+          'value',
+          {_key: 'cb0'},
+          'children',
+          {_key: 'cb0-s'},
+        ],
+        offset: 5,
+      },
+      focus: {
+        path: [
+          {_key: 't0'},
+          'rows',
+          {_key: 'r0'},
+          'cells',
+          {_key: 'c0'},
+          'value',
+          {_key: 'cb0'},
+          'children',
+          {_key: 'cb0-s'},
+        ],
+        offset: 14,
+      },
+    },
+  },
+]
+
+const SCHEMA_TYPES = [
+  defineType({
+    type: 'document',
+    name: 'test',
+    title: 'Test',
+    fields: [
+      defineField({
+        type: 'array',
+        name: 'body',
+        of: [
+          defineArrayMember({type: 'block'}),
+          defineArrayMember({
+            type: 'object',
+            name: 'table',
+            fields: [
+              defineField({type: 'number', name: 'headerRows'}),
+              defineField({
+                type: 'array',
+                name: 'rows',
+                of: [
+                  defineArrayMember({
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      defineField({
+                        type: 'array',
+                        name: 'cells',
+                        of: [
+                          defineArrayMember({
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              defineField({
+                                type: 'array',
+                                name: 'value',
+                                of: [defineArrayMember({type: 'block'})],
+                              }),
+                            ],
+                          }),
+                        ],
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+        components: {
+          // oxlint-disable-next-line no-explicit-any -- probe wrapper injecting an input-level prop
+          input: (props: any) => props.renderDefault({...props, rangeDecorations}),
+          portableText: {
+            plugins: (props) =>
+              props.renderDefault({
+                ...props,
+                plugins: {
+                  ...props.plugins,
+                  table: {enabled: true},
+                },
+              }),
+          },
+        },
+      }),
+    ],
+  }),
+]
+
+export function TableRangeDecorationDepthStory(props: {document?: SanityDocument}) {
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <TestForm document={props.document} />
+    </TestWrapper>
+  )
+}

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/TableValidationDepth.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/TableValidationDepth.browser.test.tsx
@@ -1,0 +1,72 @@
+import {type SanityDocument} from '@sanity/types'
+import {describe, expect, it} from 'vitest'
+
+import {testHelpers} from '../../../../../../test/browser/testHelpers'
+import {TableValidationDepthStory} from './TableValidationDepthStory'
+
+const {render} = await import('vitest-browser-react')
+
+const block = (key: string, text: string) => ({
+  _type: 'block',
+  _key: key,
+  children: [{_type: 'span', _key: `${key}-s`, text, marks: []}],
+  markDefs: [],
+  style: 'normal',
+})
+
+const document: SanityDocument = {
+  _id: '123',
+  _type: 'test',
+  _createdAt: new Date().toISOString(),
+  _updatedAt: new Date().toISOString(),
+  _rev: '123',
+  body: [
+    block('b0', 'bad root text'),
+    block('b1', 'clean root text'),
+    {
+      _type: 'table',
+      _key: 't0',
+      headerRows: 0,
+      rows: [
+        {
+          _type: 'row',
+          _key: 'r0',
+          cells: [
+            {_type: 'cell', _key: 'c0', value: [block('cb0', 'bad cell text')]},
+            {_type: 'cell', _key: 'c1', value: [block('cb1', 'clean cell text')]},
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+describe('Portable Text Input - validation markers at depth', () => {
+  it('renders the error marker on failing blocks at root and inside table cells alike', async () => {
+    const {getFocusedPortableTextEditor} = testHelpers()
+
+    void render(<TableValidationDepthStory document={document} />)
+
+    const $pte = await getFocusedPortableTextEditor('field-body')
+    await expect.element($pte).toHaveTextContent('bad cell text')
+
+    // Validation runs async in the harness; poll until the root control
+    // shows its marker, then compare all four blocks in one snapshot.
+    await expect.poll(() => errorStateByText()['bad root text']).toBe(true)
+    expect(errorStateByText()).toEqual({
+      'bad root text': true,
+      'clean root text': false,
+      'bad cell text': true,
+      'clean cell text': false,
+    })
+  })
+})
+
+function errorStateByText() {
+  const entries: Record<string, boolean> = {}
+  for (const node of window.document.querySelectorAll('[data-testid="text-block__text"]')) {
+    const text = node.textContent ?? ''
+    entries[text.trim()] = node.hasAttribute('data-error')
+  }
+  return entries
+}

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/TableValidationDepthStory.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/TableValidationDepthStory.tsx
@@ -1,0 +1,100 @@
+import {
+  defineArrayMember,
+  defineField,
+  defineType,
+  type PortableTextBlock,
+  type SanityDocument,
+} from '@sanity/types'
+
+import {TestForm} from '../../../../../../test/browser/TestForm'
+import {TestWrapper} from '../../../../../../test/browser/TestWrapper'
+
+// The same custom rule guards root blocks and cell blocks, so validation
+// marker rendering can be compared across depths.
+const noBadWords = (block: PortableTextBlock | undefined) => {
+  const hasBad =
+    Array.isArray(block?.children) &&
+    block.children.some((child) => typeof child.text === 'string' && child.text.includes('bad'))
+  return hasBad ? 'No bad words' : true
+}
+
+const SCHEMA_TYPES = [
+  defineType({
+    type: 'document',
+    name: 'test',
+    title: 'Test',
+    fields: [
+      defineField({
+        type: 'array',
+        name: 'body',
+        of: [
+          defineArrayMember({
+            type: 'block',
+            validation: (Rule) => Rule.custom(noBadWords),
+          }),
+          defineArrayMember({
+            type: 'object',
+            name: 'table',
+            fields: [
+              defineField({type: 'number', name: 'headerRows'}),
+              defineField({
+                type: 'array',
+                name: 'rows',
+                of: [
+                  defineArrayMember({
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      defineField({
+                        type: 'array',
+                        name: 'cells',
+                        of: [
+                          defineArrayMember({
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              defineField({
+                                type: 'array',
+                                name: 'value',
+                                of: [
+                                  defineArrayMember({
+                                    type: 'block',
+                                    validation: (Rule) => Rule.custom(noBadWords),
+                                  }),
+                                ],
+                              }),
+                            ],
+                          }),
+                        ],
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+        components: {
+          portableText: {
+            plugins: (props) =>
+              props.renderDefault({
+                ...props,
+                plugins: {
+                  ...props.plugins,
+                  table: {enabled: true},
+                },
+              }),
+          },
+        },
+      }),
+    ],
+  }),
+]
+
+export function TableValidationDepthStory(props: {document?: SanityDocument}) {
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <TestForm document={props.document} />
+    </TestWrapper>
+  )
+}


### PR DESCRIPTION
### Description

Two browser test suites pinning that the Portable Text input's trust surfaces behave the same at the top level and inside containers (table cells): validation markers render on exactly the failing blocks at either depth, and range decorations wrap the right text at either depth. Range decorations are the channel inline comments and presence cursors render through, so the second suite pins the rendering half of both features.

These came out of a verification pass over the input after built-in tables shipped (#13445). The surfaces are correct today; the suites exist so a future regression at depth announces itself instead of failing silently inside a cell.

### What to review

Test-only, two story + test pairs in the PT input's `__tests__`. Worth checking that the fixtures read as documentation: each has a control at the root and its mirror inside a cell, asserted in one snapshot.

Screenshot of validation working in table cells:

<img width="669" height="319" alt="Screenshot 2026-07-21 at 13 29 27" src="https://github.com/user-attachments/assets/7fed2a48-c5bf-4f02-8d81-87e69e1c03ca" />


### Testing

The two new suites, plus the existing PT input suites are unaffected (no production code changes).

### Notes for release

N/A: test-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no runtime or schema changes.
> 
> **Overview**
> Adds **two browser test pairs** under the Portable Text input `__tests__` to lock in behavior at **root vs inside table cells**—no production changes.
> 
> **Validation:** A story applies the same `noBadWords` rule to top-level blocks and cell `value` blocks; the test asserts `data-error` on failing vs clean text in all four mirrored blocks (with async polling for markers).
> 
> **Range decorations:** A story injects probe decorations on a root span and a deeply pathed cell span (the same path shape comments/presence use); the test expects two decorations wrapping `"decorated"`, one outside and one inside the table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ccd9ef66f5081d976d48111af3928dd03f36ede. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->