### PR TITLE
fix(core): disable toolbar actions the caret position can't honor

### DIFF
--- a/dev/test-studio/schema/standard/portableText/customPlugins.tsx
+++ b/dev/test-studio/schema/standard/portableText/customPlugins.tsx
@@ -133,7 +133,7 @@ export const customPlugins = defineType({
       name: 'containerTable',
       title: 'Container Table',
       description:
-        'A defineContainer table (table > row > cell). Images and text blocks live at the root and inside cells. The field enables container support.',
+        'A defineContainer table (table > row > cell). Images and text blocks live at the root and inside cells. Cell blocks are deliberately narrower than root blocks (styles: normal/quote; decorators: strong/underline; lists: bullet; no annotations), so the toolbar disables the difference while the caret is inside a cell.',
       of: [
         defineArrayMember({
           type: 'block',
@@ -179,6 +179,26 @@ export const customPlugins = defineType({
                               of: [
                                 defineArrayMember({
                                   type: 'block',
+                                  // Deliberately narrower than the root
+                                  // block in every toolbar-gated category
+                                  // (styles, decorators, annotations,
+                                  // lists), so the toolbar's positional
+                                  // disabled state is easy to verify:
+                                  // caret in a cell disables everything
+                                  // the cell doesn't declare, caret at
+                                  // the root enables it all again.
+                                  styles: [
+                                    {title: 'Normal', value: 'normal'},
+                                    {title: 'Quote', value: 'blockquote'},
+                                  ],
+                                  marks: {
+                                    decorators: [
+                                      {title: 'Strong', value: 'strong'},
+                                      {title: 'Underline', value: 'underline'},
+                                    ],
+                                    annotations: [],
+                                  },
+                                  lists: [{title: 'Bullet', value: 'bullet'}],
                                   of: [
                                     defineArrayMember({
                                       type: 'object',

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/ToolbarApplicableSchema.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/ToolbarApplicableSchema.browser.test.tsx
@@ -1,0 +1,119 @@
+import {type SanityDocument} from '@sanity/types'
+import {describe, expect, it} from 'vitest'
+import {userEvent} from 'vitest/browser'
+
+import {testHelpers} from '../../../../../../test/browser/testHelpers'
+import {ToolbarApplicableSchemaStory} from './ToolbarApplicableSchemaStory'
+
+const {render} = await import('vitest-browser-react')
+
+const document: SanityDocument = {
+  _id: '123',
+  _type: 'test',
+  _createdAt: new Date().toISOString(),
+  _updatedAt: new Date().toISOString(),
+  _rev: '123',
+  body: [
+    {
+      _type: 'block',
+      _key: 'b0',
+      children: [{_type: 'span', _key: 's0', text: 'root text', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    },
+    {
+      _type: 'table',
+      _key: 't0',
+      headerRows: 0,
+      rows: [
+        {
+          _type: 'row',
+          _key: 'r0',
+          cells: [
+            {
+              _type: 'cell',
+              _key: 'c0',
+              value: [
+                {
+                  _type: 'block',
+                  _key: 'cb0',
+                  children: [{_type: 'span', _key: 'cs0', text: 'cell text', marks: []}],
+                  markDefs: [],
+                  style: 'normal',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+describe('Portable Text Input - toolbar reflects the positional schema', () => {
+  it('disables actions the caret position cannot honor, membership unchanged', async () => {
+    const {getFocusedPortableTextEditor, waitForFocusedNodeText} = testHelpers()
+
+    void render(<ToolbarApplicableSchemaStory document={document} />)
+
+    const $pte = await getFocusedPortableTextEditor('field-body')
+    await expect.element($pte).toHaveTextContent('cell text')
+
+    const clickText = async (text: string) => {
+      const node = [...$pte.element().querySelectorAll('*')].find(
+        (candidate) => candidate.childElementCount === 0 && candidate.textContent === text,
+      )
+      await userEvent.click(node as HTMLElement)
+      await waitForFocusedNodeText(text)
+    }
+
+    await clickText('root text')
+    // The narrow cell config removes nothing from the toolbar; at the
+    // root everything the field declares is actionable.
+    await expect
+      .poll(() => actionState())
+      .toEqual({
+        'strong': 'enabled',
+        'em': 'enabled',
+        'code': 'enabled',
+        'underline': 'enabled',
+        'strike-through': 'enabled',
+        'link': 'enabled',
+        'bullet': 'enabled',
+        'number': 'enabled',
+      })
+
+    await clickText('cell text')
+    // Same buttons, same order; the ones the cell's block config doesn't
+    // declare are disabled rather than gone.
+    await expect
+      .poll(() => actionState())
+      .toEqual({
+        'strong': 'enabled',
+        'em': 'disabled',
+        'code': 'disabled',
+        'underline': 'disabled',
+        'strike-through': 'disabled',
+        'link': 'disabled',
+        'bullet': 'disabled',
+        'number': 'disabled',
+      })
+  })
+})
+
+/**
+ * The responsive toolbar renders extra copies of each action button for
+ * collapse measurement inside `aria-hidden` containers, permanently
+ * disabled; only the visible copy carries the real state.
+ */
+function actionState(): Record<string, 'enabled' | 'disabled'> {
+  const state: Record<string, 'enabled' | 'disabled'> = {}
+  for (const button of window.document.querySelectorAll('[data-testid^="action-button-"]')) {
+    if (button.closest('[aria-hidden="true"], [hidden], [inert]')) {
+      continue
+    }
+    const key = button.getAttribute('data-testid')!.replace('action-button-', '')
+    state[key] = button.matches('[disabled], [data-disabled="true"]') ? 'disabled' : 'enabled'
+  }
+  return state
+}

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/ToolbarApplicableSchemaStory.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/ToolbarApplicableSchemaStory.tsx
@@ -1,0 +1,91 @@
+import {type SanityDocument, defineArrayMember, defineField, defineType} from '@sanity/types'
+
+import {TestForm} from '../../../../../../test/browser/TestForm'
+import {TestWrapper} from '../../../../../../test/browser/TestWrapper'
+
+// The root field allows the default decorators, annotations, and lists;
+// the cell's block config allows only `strong`, no annotations, no
+// lists. Toolbar membership stays field-stable, so the cell's narrower
+// config must surface as disabled actions, not missing ones.
+const SCHEMA_TYPES = [
+  defineType({
+    type: 'document',
+    name: 'test',
+    title: 'Test',
+    fields: [
+      defineField({
+        type: 'array',
+        name: 'body',
+        of: [
+          defineArrayMember({type: 'block'}),
+          defineArrayMember({
+            type: 'object',
+            name: 'table',
+            fields: [
+              defineField({type: 'number', name: 'headerRows'}),
+              defineField({
+                type: 'array',
+                name: 'rows',
+                of: [
+                  defineArrayMember({
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      defineField({
+                        type: 'array',
+                        name: 'cells',
+                        of: [
+                          defineArrayMember({
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              defineField({
+                                type: 'array',
+                                name: 'value',
+                                of: [
+                                  defineArrayMember({
+                                    type: 'block',
+                                    styles: [{title: 'Normal', value: 'normal'}],
+                                    lists: [],
+                                    marks: {
+                                      decorators: [{title: 'Strong', value: 'strong'}],
+                                      annotations: [],
+                                    },
+                                  }),
+                                ],
+                              }),
+                            ],
+                          }),
+                        ],
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+        components: {
+          portableText: {
+            plugins: (props) =>
+              props.renderDefault({
+                ...props,
+                plugins: {
+                  ...props.plugins,
+                  table: {enabled: true},
+                },
+              }),
+          },
+        },
+      }),
+    ],
+  }),
+]
+
+export function ToolbarApplicableSchemaStory(props: {document?: SanityDocument}) {
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <TestForm document={props.document} />
+    </TestWrapper>
+  )
+}

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/ActionMenu.tsx
@@ -95,7 +95,7 @@ export const ActionMenu = memo(function ActionMenu(props: ActionMenuProps) {
               action: action.title || action.key,
             })}
             data-testid={`action-button-${action.key}`}
-            disabled={disabled || annotationDisabled}
+            disabled={disabled || action.disabled || annotationDisabled}
             mode="bleed"
             dividerBefore={action.firstInGroup}
             icon={getActionIcon(action, active)}

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/BlockStyleSelect.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/BlockStyleSelect.tsx
@@ -24,6 +24,7 @@ import {
 } from '../text/textStyles'
 import {useActiveStyleKeys, useFocusBlock} from './hooks'
 import {type BlockStyleItem} from './types'
+import {useApplicableSchema} from './useApplicableSchema'
 
 const MenuButtonMemo = memo(MenuButton)
 
@@ -73,6 +74,7 @@ export const BlockStyleSelect = memo(function BlockStyleSelect(
   props: BlockStyleSelectProps,
 ): React.JSX.Element {
   const {disabled, items: itemsProp, boundaryElement} = props
+  const applicable = useApplicableSchema()
   const editor = usePortableTextEditor()
   const schemaTypes = usePortableTextMemberSchemaTypes()
   const focusBlock = useFocusBlock()
@@ -168,11 +170,13 @@ export const BlockStyleSelect = memo(function BlockStyleSelect(
     () => (
       <Menu disabled={_disabled}>
         {items.map((item) => {
+          const itemDisabled = _disabled || !applicable.styles.has(item.style)
           return (
             <StyledMenuItem
+              disabled={itemDisabled}
               key={item.key}
               pressed={activeItems.includes(item)}
-              onClick={_disabled ? undefined : () => handleChange(item)}
+              onClick={itemDisabled ? undefined : () => handleChange(item)}
             >
               {renderOption(item)}
             </StyledMenuItem>
@@ -180,7 +184,7 @@ export const BlockStyleSelect = memo(function BlockStyleSelect(
         })}
       </Menu>
     ),
-    [_disabled, activeItems, handleChange, items, renderOption],
+    [_disabled, activeItems, applicable, handleChange, items, renderOption],
   )
 
   return (

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/InsertMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/InsertMenu.tsx
@@ -9,6 +9,7 @@ import {useTranslation} from '../../../../i18n'
 import {usePortableTextMemberSchemaTypes} from '../contexts/PortableTextMemberSchemaTypes'
 import {useFocusBlock} from './hooks'
 import {type BlockItem} from './types'
+import {useApplicableSchema} from './useApplicableSchema'
 
 const CollapseMenuMemo = memo(CollapseMenu)
 
@@ -23,6 +24,7 @@ interface InsertMenuProps {
 
 export const InsertMenu = memo(function InsertMenu(props: InsertMenuProps) {
   const {disabled, items, isFullscreen, collapsed} = props
+  const applicable = useApplicableSchema()
   const {t} = useTranslation()
   const focusBlock = useFocusBlock()
   const editor = usePortableTextEditor()
@@ -50,7 +52,12 @@ export const InsertMenu = memo(function InsertMenu(props: InsertMenuProps) {
             {typeName: title},
           )}
           mode="bleed"
-          disabled={disabled || (isVoidFocus && item.inline) || Boolean(item.type.deprecated)}
+          disabled={
+            disabled ||
+            (isVoidFocus && item.inline) ||
+            Boolean(item.type.deprecated) ||
+            !applicable[item.inline ? 'inlineObjects' : 'blockObjects'].has(item.type.name)
+          }
           data-testid={`${item.type.name}-insert-menu-button`}
           icon={item.icon}
           onClick={item.handle}
@@ -71,7 +78,7 @@ export const InsertMenu = memo(function InsertMenu(props: InsertMenuProps) {
         />
       )
     })
-  }, [disabled, isVoidFocus, items, t, tooltipPlacement])
+  }, [applicable, disabled, isVoidFocus, items, t, tooltipPlacement])
 
   const menuButtonProps = useMemo(
     () => ({

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/Toolbar.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/Toolbar.tsx
@@ -239,7 +239,7 @@ export function Toolbar(props: ToolbarProps) {
     hotkeys,
     onMemberOpen,
     resolveInitialValue,
-    disabled: true,
+    disabled,
   })
 
   const blockStyles = useMemo(() => getBlockStyles(schemaTypes), [schemaTypes])

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/helpers.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/helpers.tsx
@@ -1,4 +1,5 @@
 import {type HotkeyOptions, PortableTextEditor} from '@portabletext/editor'
+import {type ApplicableSchema} from '@portabletext/editor/selectors'
 import {type PortableTextMemberSchemaTypes} from '@portabletext/sanity-bridge'
 import {BlockElementIcon} from '@sanity/icons/BlockElement'
 import {BoldIcon} from '@sanity/icons/Bold'
@@ -29,6 +30,7 @@ function getPTEFormatActions(
   editor: PortableTextEditor,
   schemaTypes: PortableTextMemberSchemaTypes,
   disabled: boolean,
+  applicable: ApplicableSchema,
   hotkeyOpts: HotkeyOptions,
   t?: (key: string) => string,
 ): PTEToolbarAction[] {
@@ -44,7 +46,7 @@ function getPTEFormatActions(
 
     return {
       type: 'format',
-      disabled: disabled,
+      disabled: disabled || !applicable.decorators.has(decorator.value),
       icon: decorator?.icon,
       key: decorator.value,
       handle: (): void => {
@@ -61,13 +63,14 @@ function getPTEListActions(
   editor: PortableTextEditor,
   schemaTypes: PortableTextMemberSchemaTypes,
   disabled: boolean,
+  applicable: ApplicableSchema,
   t?: (key: string) => string,
 ): PTEToolbarAction[] {
   return schemaTypes.lists.map((listItem) => {
     return {
       type: 'listStyle',
       key: listItem.value,
-      disabled: disabled,
+      disabled: disabled || !applicable.lists.has(listItem.value),
       icon: listItem?.icon,
       handle: (): void => {
         PortableTextEditor.toggleList(editor, listItem.value)
@@ -90,15 +93,17 @@ function getPTEAnnotationActions(
   editor: PortableTextEditor,
   schemaTypes: PortableTextMemberSchemaTypes,
   disabled: boolean,
+  applicable: ApplicableSchema,
   onInsert: (type: ObjectSchemaType) => void,
   t?: (key: string) => string,
 ): PTEToolbarAction[] {
-  const focusChild = PortableTextEditor.focusChild(editor)
-  const hasText = focusChild && focusChild.text
   return schemaTypes.annotations.map((aType) => {
     return {
       type: 'annotation',
-      disabled: !hasText || disabled,
+      // Empty-block and cross-block disabling live at the render site
+      // (`ActionMenu`), which re-renders with the focused block; anything
+      // read here is frozen until the memoized action groups rebuild.
+      disabled: disabled || !applicable.annotations.has(aType.name),
       icon: getAnnotationIcon(aType),
       key: aType.name,
       handle: (active?: boolean): void => {
@@ -123,18 +128,29 @@ export function getPTEToolbarActionGroups(
   options: {
     schemaTypes: PortableTextMemberSchemaTypes
     disabled: boolean
+    applicable: ApplicableSchema
     onInsertAnnotation: (type: ObjectSchemaType) => void
     hotkeyOpts: HotkeyOptions
     t?: (key: string) => string
   },
 ): PTEToolbarActionGroup[] {
-  const {schemaTypes, disabled, onInsertAnnotation, hotkeyOpts, t} = options
+  const {schemaTypes, disabled, applicable, onInsertAnnotation, hotkeyOpts, t} = options
   return [
-    {name: 'format', actions: getPTEFormatActions(editor, schemaTypes, disabled, hotkeyOpts, t)},
-    {name: 'list', actions: getPTEListActions(editor, schemaTypes, disabled, t)},
+    {
+      name: 'format',
+      actions: getPTEFormatActions(editor, schemaTypes, disabled, applicable, hotkeyOpts, t),
+    },
+    {name: 'list', actions: getPTEListActions(editor, schemaTypes, disabled, applicable, t)},
     {
       name: 'annotation',
-      actions: getPTEAnnotationActions(editor, schemaTypes, disabled, onInsertAnnotation, t),
+      actions: getPTEAnnotationActions(
+        editor,
+        schemaTypes,
+        disabled,
+        applicable,
+        onInsertAnnotation,
+        t,
+      ),
     },
   ]
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/hooks.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/hooks.ts
@@ -18,6 +18,7 @@ import {useUnique} from '../../../../util'
 import {usePortableTextMemberSchemaTypes} from '../contexts/PortableTextMemberSchemaTypes'
 import {getPTEToolbarActionGroups} from './helpers'
 import {type BlockStyleItem, type PTEToolbarAction, type PTEToolbarActionGroup} from './types'
+import {useApplicableSchema} from './useApplicableSchema'
 
 export function useFocusBlock(): PortableTextBlock | undefined {
   const editor = usePortableTextEditor()
@@ -52,6 +53,7 @@ export function useActionGroups({
 }): PTEToolbarActionGroup[] {
   const editor = usePortableTextEditor()
   const schemaTypes = usePortableTextMemberSchemaTypes()
+  const applicable = useApplicableSchema()
   const {t} = useTranslation()
 
   const handleInsertAnnotation = useCallback(
@@ -71,12 +73,13 @@ export function useActionGroups({
         ? getPTEToolbarActionGroups(editor, {
             schemaTypes,
             disabled,
+            applicable,
             onInsertAnnotation: handleInsertAnnotation,
             hotkeyOpts: hotkeys,
             t,
           })
         : [],
-    [disabled, editor, schemaTypes, handleInsertAnnotation, hotkeys, t],
+    [applicable, disabled, editor, schemaTypes, handleInsertAnnotation, hotkeys, t],
   )
 }
 

--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/useApplicableSchema.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/useApplicableSchema.ts
@@ -1,0 +1,23 @@
+import {useEditor, useEditorSelector} from '@portabletext/editor'
+import {
+  type ApplicableSchema,
+  compareApplicableSchema,
+  getApplicableSchema,
+} from '@portabletext/editor/selectors'
+
+export type {ApplicableSchema}
+
+/**
+ * The schema members applicable at the current selection, as name sets per
+ * category, with a stable reference across editor ticks while the sets are
+ * unchanged. Inside a container child (a table cell, for example) the sets
+ * reflect that position's block config rather than the root field's.
+ *
+ * Duplicated from `@portabletext/toolbar`'s `useApplicableSchema` rather
+ * than depending on that package for one hook; keep in sync with the
+ * source.
+ */
+export function useApplicableSchema(): ApplicableSchema {
+  const editor = useEditor()
+  return useEditorSelector(editor, getApplicableSchema, compareApplicableSchema)
+}


### PR DESCRIPTION
### Description

With the cursor inside a container child whose block config is narrower than the root field's, for example a table cell that only allows `strong`, the toolbar shows every action enabled. Pressing one does nothing: the editor rejects operations the position's schema doesn't allow, so the author clicks Italic and gets silence.

The fix keeps the toolbar's buttons stable, membership still comes from the root field, and disables the ones the cursor position can't honor, using the editor's `getApplicableSchema` selector (a five-line hook duplicated from `@portabletext/toolbar`). The gating covers the format actions, the insert menu's items, and the style select's options.

Landing it surfaced three fossils masking each other: `Toolbar` built every action with a hardcoded `disabled: true`, `ActionMenu` consequently ignored `action.disabled` at the render site, and the annotation builder froze a `hasText` check at build time, stale as soon as the memoized action groups stopped rebuilding (its reactive twin already lives at the render site as the empty-block rule). All three fixed; the per-action field is load-bearing and correct for the first time. The third fossil is what failed the `FullScreenEscape` E2E spec on this PR's first CI runs: an empty document froze `hasText` as false, permanently disabling annotation buttons in that flow.

<img width="662" height="445" alt="Screenshot 2026-07-21 at 17 22 05" src="https://github.com/user-attachments/assets/08845fd8-7a81-4ca4-bf84-1a8257d159bb" />


### What to review

All in the PT input's `toolbar/` directory. `Toolbar.tsx` passes its real disabled state instead of `true`; `ActionMenu.tsx` reads `action.disabled` (previously always `true` and ignored, so no behavior depended on it); the annotation builder's frozen `hasText` is deleted in favor of the render site's reactive empty-block rule; the rest is one `!applicable.<category>.has(name)` clause OR-ed into each surface's existing disabled computation.

### Testing

`ToolbarApplicableSchema.browser.test.tsx` pins the contract: at the root every declared action is enabled; inside a narrow cell the same buttons render with only `strong` enabled. The existing Toolbar, Decorators, Styles, ListItems, and Annotations suites (17 tests) pass unchanged. The second commit narrows the test-studio Container Table's cell config in every gated category, so the behavior is easy to verify by hand.

### Notes for release

Toolbar actions in the Portable Text editor now appear disabled when the cursor is inside a PTE Container whose schema doesn't allow them, for example inside a table cell with a restricted block configuration. Previously they appeared enabled but did nothing when pressed.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Portable Text toolbar behavior and annotation enablement; fixes prior bugs (hardcoded disabled, stale hasText) that may change when link/annotation buttons appear enabled in some flows.
> 
> **Overview**
> Portable Text toolbar buttons stay the same at the field level, but **decorators, lists, annotations, block styles, and insert items are disabled** when the caret sits in a nested position (e.g. a table cell) whose block schema is narrower than the root field’s. That uses a local **`useApplicableSchema`** hook wired to the editor’s **`getApplicableSchema`** selector.
> 
> **Toolbar wiring fixes** that were masking the behavior: **`Toolbar`** now passes the real **`disabled`** state into action groups instead of hardcoding **`true`**; **`ActionMenu`** respects **`action.disabled`**; annotation actions no longer bake in a frozen **`hasText`** check at build time (empty-block / multi-block rules stay reactive in **`ActionMenu`**).
> 
> Adds a **browser test** (`ToolbarApplicableSchema.browser.test.tsx`) and narrows the test-studio **Container Table** cell block config so positional disable state is easy to verify by hand.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0abd98576a53347a7d008a9b523e5709f6b54912. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->