### PR TITLE
fix(release-notes): unwrap invalid callout blocks written to apiChange docs

### DIFF
--- a/packages/@repo/release-notes/src/commands/createOrUpdateChangelogDocs.ts
+++ b/packages/@repo/release-notes/src/commands/createOrUpdateChangelogDocs.ts
@@ -19,6 +19,7 @@ import pMap from 'p-map'
 import {getClient} from '../client'
 import {STUDIO_PLATFORM_DOCUMENT_ID} from '../constants'
 import {type PullRequestInfo, type StudioChangelogEntry} from '../types'
+import {flattenCallouts} from '../utils/flattenCallouts'
 import {getCommits, getSemverTags} from '../utils/getCommits'
 import {getCommitAuthor, getMergedPRForCommit} from '../utils/github'
 import {getSanityDocumentIdsForBaseVersion} from '../utils/ids'
@@ -163,11 +164,13 @@ async function getReleaseNotesMutations(
   const userType = pr?.user?.type?.toLowerCase()
   const isBot = userType === 'bot'
 
-  const releaseNoteBlocks = pr?.body
-    ? isBot
-      ? parseRenovateReleaseNotes(pr.body)
-      : extractReleaseNotes(markdownToPortableText(pr.body))
-    : []
+  const releaseNoteBlocks = flattenCallouts(
+    pr?.body
+      ? isBot
+        ? parseRenovateReleaseNotes(pr.body)
+        : extractReleaseNotes(markdownToPortableText(pr.body))
+      : [],
+  )
 
   const breaking = isBreakingChange(conventionalCommit)
 

--- a/packages/@repo/release-notes/src/utils/__test__/docsArticleContent.test.ts
+++ b/packages/@repo/release-notes/src/utils/__test__/docsArticleContent.test.ts
@@ -86,6 +86,113 @@ describe('toDocsArticleContent', () => {
     expect(result).not.toHaveProperty('level')
   })
 
+  it('maps GFM alert callouts to docsCallout with a schema-valid `type`', () => {
+    const callout = {
+      _type: 'callout' as const,
+      _key: 'callout-key',
+      tone: 'warning',
+      content: [
+        {
+          _type: 'block' as const,
+          _key: 'inner',
+          style: 'normal' as const,
+          markDefs: [],
+          children: [{_type: 'span' as const, _key: 'inner-span', text: 'watch out', marks: []}],
+        },
+      ],
+    }
+
+    expect(toDocsArticleContent(callout)).toEqual([
+      {
+        _type: 'docsCallout',
+        _key: 'callout-key',
+        type: 'warning',
+        content: [callout.content[0]],
+      },
+    ])
+  })
+
+  it('maps every known GFM alert tone to a schema-valid docsCallout type', () => {
+    const cases: {tone: string; expected: 'error' | 'info' | 'tip' | 'warning'}[] = [
+      {tone: 'note', expected: 'info'},
+      {tone: 'important', expected: 'info'},
+      {tone: 'tip', expected: 'tip'},
+      {tone: 'warning', expected: 'warning'},
+      {tone: 'caution', expected: 'error'},
+    ]
+
+    for (const {tone, expected} of cases) {
+      const [result] = toDocsArticleContent({
+        _type: 'callout',
+        _key: `k-${tone}`,
+        tone,
+        content: [],
+      } as NormalizedMarkdownBlock)
+      expect(result).toMatchObject({_type: 'docsCallout', type: expected})
+    }
+  })
+
+  it('falls back to `info` for unknown callout tones', () => {
+    const [result] = toDocsArticleContent({
+      _type: 'callout',
+      _key: 'k',
+      tone: 'mystery',
+      content: [],
+    } as NormalizedMarkdownBlock)
+
+    expect(result).toMatchObject({_type: 'docsCallout', type: 'info'})
+  })
+
+  it('normalizes link markDefs inside callout content', () => {
+    const [result] = toDocsArticleContent({
+      _type: 'callout',
+      _key: 'callout-key',
+      tone: 'note',
+      content: [
+        textBlock({
+          markDefs: [{_key: 'link-1', _type: 'link', href: 'https://example.com'}],
+        }),
+      ],
+    } as NormalizedMarkdownBlock)
+
+    expect(result).toMatchObject({
+      _type: 'docsCallout',
+      content: [{markDefs: [{_key: 'link-1', _type: 'link', url: 'https://example.com'}]}],
+    })
+  })
+
+  it('drops non-block inner content (docsCallout.content only accepts blocks)', () => {
+    const [result] = toDocsArticleContent({
+      _type: 'callout',
+      _key: 'callout-key',
+      tone: 'note',
+      content: [
+        textBlock({_key: 'text'}),
+        {_type: 'image' as const, _key: 'img', src: 'https://example.com/x.png'},
+        {_type: 'code' as const, _key: 'code', language: 'ts', code: 'const a = 1'},
+      ],
+    } as NormalizedMarkdownBlock)
+
+    expect(result).toMatchObject({_type: 'docsCallout'})
+    const content = (result as {content: {_type: string}[]}).content
+    expect(content).toHaveLength(1)
+    expect(content[0]).toMatchObject({_type: 'block', _key: 'text'})
+  })
+
+  it('coerces heading styles inside callout content back to `normal`', () => {
+    const [result] = toDocsArticleContent({
+      _type: 'callout',
+      _key: 'callout-key',
+      tone: 'warning',
+      content: [textBlock({_key: 'heading', style: 'h2'})],
+    } as NormalizedMarkdownBlock)
+
+    expect(result).toMatchObject({
+      _type: 'docsCallout',
+      content: [{_type: 'block', style: 'normal'}],
+    })
+  })
+
   it('produces schema-valid blocks from real PR markdown with a separator and a link', () => {
     const markdown = `Fixed a bug, see [the docs](https://example.com/docs).
 
@@ -107,5 +214,21 @@ describe('toDocsArticleContent', () => {
         }
       }
     }
+  })
+
+  it('converts a real PR markdown GFM alert into a docsCallout with a schema-valid type', () => {
+    const markdown = `Before.
+
+> [!WARNING]
+> Heads up.
+
+After.`
+    const blocks = markdownToPortableText(markdown).flatMap((block) => toDocsArticleContent(block))
+
+    // The docs schema rejects _type: "callout"; only docsCallout is allowed.
+    expect(blocks.some((block) => block._type === 'callout')).toBe(false)
+
+    const callout = blocks.find((block) => block._type === 'docsCallout')
+    expect(callout).toMatchObject({_type: 'docsCallout', type: 'warning'})
   })
 })

--- a/packages/@repo/release-notes/src/utils/__test__/flattenCallouts.test.ts
+++ b/packages/@repo/release-notes/src/utils/__test__/flattenCallouts.test.ts
@@ -1,0 +1,62 @@
+import {describe, expect, it} from 'vitest'
+
+import {flattenCallouts} from '../flattenCallouts'
+import {
+  markdownToPortableText,
+  type NormalizedMarkdownBlock,
+} from '../portabletext-markdown/markdownToPortableText'
+
+function textBlock(_key: string, text: string): NormalizedMarkdownBlock {
+  return {
+    _type: 'block',
+    _key,
+    style: 'normal',
+    markDefs: [],
+    children: [{_type: 'span', _key: `${_key}-span`, text, marks: []}],
+  } as NormalizedMarkdownBlock
+}
+
+describe('flattenCallouts', () => {
+  it('leaves non-callout blocks untouched', () => {
+    const blocks = [textBlock('a', 'hello')]
+    expect(flattenCallouts(blocks)).toEqual(blocks)
+  })
+
+  it('unwraps callout content in place, preserving order', () => {
+    const before = textBlock('before', 'before')
+    const inner1 = textBlock('inner1', 'inner one')
+    const inner2 = textBlock('inner2', 'inner two')
+    const after = textBlock('after', 'after')
+
+    const result = flattenCallouts([
+      before,
+      {
+        _type: 'callout',
+        _key: 'c',
+        tone: 'note',
+        content: [inner1, inner2],
+      } as NormalizedMarkdownBlock,
+      after,
+    ])
+
+    expect(result).toEqual([before, inner1, inner2, after])
+  })
+
+  it('drops callouts with empty content', () => {
+    const result = flattenCallouts([
+      {_type: 'callout', _key: 'c', tone: 'note', content: []} as NormalizedMarkdownBlock,
+    ])
+    expect(result).toEqual([])
+  })
+
+  it('produces no `callout` blocks from real PR markdown containing a GFM alert', () => {
+    const markdown = `Before.
+
+> [!WARNING]
+> Heads up.
+
+After.`
+    const result = flattenCallouts(markdownToPortableText(markdown))
+    expect(result.some((block) => block._type === 'callout')).toBe(false)
+  })
+})

--- a/packages/@repo/release-notes/src/utils/docsArticleContent.ts
+++ b/packages/@repo/release-notes/src/utils/docsArticleContent.ts
@@ -9,27 +9,25 @@ type DocsArticleCodeBlock = {
   blocks: {_key: string; code: NormalizedMarkdownBlock}[]
 }
 
-export type DocsArticleBlock = NormalizedMarkdownBlock | DocsArticleCodeBlock
+type DocsCalloutType = 'error' | 'info' | 'tip' | 'warning'
 
-/**
- * Convert a single changelog-entry block into the shape expected by the docs
- * article content schema (used by `apiChange.releaseAutomation.suggestedContent`).
- *
- * Changelog-entry contents come straight from `@portabletext/markdown`, which
- * targets a different — and more permissive — schema than the docs article, so a
- * few things have to be reconciled before they validate as suggested content:
- *
- * - Markdown thematic breaks (`---`) become `horizontal-rule` blocks. Sanity type
- *   names cannot contain hyphens and the docs article schema does not allow that
- *   block, so they are dropped.
- * - Fenced code becomes a `code` block; the docs article wraps code in `codeBlock`.
- * - Only text blocks carry `style`/`listItem`/`level` props, so list overrides are
- *   applied to text blocks only (never to images, tables, etc.).
- * - The markdown `link` annotation stores its destination in `href`, but the docs
- *   article `link` annotation requires `url` (see {@link normalizeLinkMarkDefs}).
- *
- * Returns an array so callers can `flatMap` and drop unsupported blocks.
- */
+type DocsArticleCallout = {
+  _type: 'docsCallout'
+  _key: string
+  type: DocsCalloutType
+  content: NormalizedMarkdownBlock[]
+}
+
+export type DocsArticleBlock = NormalizedMarkdownBlock | DocsArticleCodeBlock | DocsArticleCallout
+
+const CALLOUT_TONE_TO_DOCS_TYPE: Record<string, DocsCalloutType> = {
+  caution: 'error',
+  important: 'info',
+  note: 'info',
+  tip: 'tip',
+  warning: 'warning',
+}
+
 export function toDocsArticleContent(
   block: NormalizedMarkdownBlock,
   overrides?: ListOverrides,
@@ -42,6 +40,22 @@ export function toDocsArticleContent(
     return [{_type: 'codeBlock', _key: block._key, blocks: [{_key: block._key, code: block}]}]
   }
 
+  if (block._type === 'callout') {
+    // docsCallout.content only allows `block` types with `normal` style.
+    return [
+      {
+        _type: 'docsCallout',
+        _key: block._key,
+        type: CALLOUT_TONE_TO_DOCS_TYPE[block.tone] ?? 'info',
+        content: block.content.flatMap((innerBlock) =>
+          innerBlock._type === 'block'
+            ? [normalizeLinkMarkDefs({...innerBlock, style: 'normal'})]
+            : [],
+        ),
+      },
+    ]
+  }
+
   if (block._type === 'block') {
     return [normalizeLinkMarkDefs(overrides ? {...block, ...overrides} : block)]
   }
@@ -49,11 +63,6 @@ export function toDocsArticleContent(
   return [block]
 }
 
-/**
- * Rename `href` → `url` on `link` mark definitions so they satisfy the docs
- * article `link` annotation, which requires a `url` field. Mark definitions that
- * already have a `url`, or that are not links, are left untouched.
- */
 function normalizeLinkMarkDefs(block: PortableTextBlock): PortableTextBlock {
   if (!Array.isArray(block.markDefs) || block.markDefs.length === 0) {
     return block

--- a/packages/@repo/release-notes/src/utils/flattenCallouts.ts
+++ b/packages/@repo/release-notes/src/utils/flattenCallouts.ts
@@ -1,0 +1,9 @@
+import {type PortableTextMarkdownBlock} from './portabletext-markdown/types'
+
+// Neither the changelog `contents` nor the docs article schema accepts
+// `_type: "callout"` blocks; unwrap them so the inner content survives.
+export function flattenCallouts(blocks: PortableTextMarkdownBlock[]): PortableTextMarkdownBlock[] {
+  return blocks.flatMap<PortableTextMarkdownBlock>((block) =>
+    block._type === 'callout' ? block.content : [block],
+  )
+}

--- a/packages/@repo/release-notes/src/utils/portabletext-markdown/types.ts
+++ b/packages/@repo/release-notes/src/utils/portabletext-markdown/types.ts
@@ -62,6 +62,13 @@ export type PortableTextTable = {
   rows: unknown[]
 }
 
+export type PortableTextCallout = {
+  _type: 'callout'
+  _key: string
+  tone: string
+  content: Exclude<PortableTextMarkdownBlock, PortableTextHtml>[]
+}
+
 export type PortableTextMarkdownBlock =
   | PortableTextBlock
   | PortableTextCode
@@ -69,3 +76,4 @@ export type PortableTextMarkdownBlock =
   | PortableTextHorizontalRule
   | PortableTextHtml
   | PortableTextTable
+  | PortableTextCallout


### PR DESCRIPTION
### Description

The release-notes automation writes portable-text blocks from PR bodies into `apiChange.changelog[].contents` and, later, into `releaseAutomation.suggestedContent`. `@portabletext/markdown` emits GFM alerts (`> [!NOTE]`) as `_type: "callout"` blocks with a `tone` field. Neither the changelog schema (which accepts only `image`, `block`, and `code`) nor the docs article schema (which accepts `docsCallout`, not `callout`) will validate that shape, so any PR whose body contains a GFM alert produces an invalid `apiChange` document.

This PR unwraps `callout` blocks via a new `flattenCallouts` utility before they land in `changelog[].contents`, so their inner content survives as regular blocks and `uploadImages` still processes any inline images. `toDocsArticleContent` also gains a defensive `callout` → `docsCallout` branch that maps GFM alert tones (`note`/`important` → `info`, `tip`, `warning`, `caution` → `error`, unknown → `info`) and filters inner content down to what the `docsCallout` schema accepts (only `block` types, coerced to `normal` style).

### What to review

- `createOrUpdateChangelogDocs.ts` wraps `releaseNoteBlocks` in `flattenCallouts` before `uploadImages`, so inline images inside callouts still get uploaded.
- The `callout` branch in `docsArticleContent.ts` is defensive - after `flattenCallouts` runs upstream, callouts should never reach it in production. Kept for hand-edited or externally-sourced data.
- Existing `apiChange` documents with invalid `callout` blocks are not migrated by this PR.

### Testing

63/63 unit tests pass across `@repo/release-notes`, including new coverage for tone mapping, unknown-tone fallback, inner-content filtering, style coercion, link-markDef normalization, and end-to-end conversion from real markdown.

### Notes for release

N/A - Internal release-notes tooling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to internal release-notes tooling with defensive transforms and broad unit tests; no migration of existing invalid documents.
> 
> **Overview**
> GFM alerts in PR bodies were emitted as `_type: "callout"` portable text, which **neither** `changelog[].contents` **nor** docs `suggestedContent` schemas accept—so those PRs could produce invalid `apiChange` documents.
> 
> **Changelog path:** New `flattenCallouts` unwraps callouts into their inner blocks before `uploadImages` and persistence in `createOrUpdateChangelogDocs`, so alert text (and images inside callouts) still land as allowed block types.
> 
> **Docs path:** `toDocsArticleContent` now maps any remaining `callout` blocks to `docsCallout` (GFM tones → `info` / `tip` / `warning` / `error`), normalizes links, coerces inner headings to `normal`, and drops non-block inner content. `PortableTextCallout` is added to markdown block types. Unit tests cover flattening, tone mapping, and end-to-end markdown alerts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47ae08b39ecb65cc42e175ee72d4bb52e2615aa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->