### PR TITLE
fix(releases): use replace when syncing router state to URL

### DIFF
--- a/.github/actions/detect-code-changes/action.yml
+++ b/.github/actions/detect-code-changes/action.yml
@@ -12,6 +12,7 @@ runs:
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
       id: filter
       with:
+        initial-fetch-depth: 1000
         filters: |
           code:
             - '**'

--- a/.github/actions/detect-code-changes/action.yml
+++ b/.github/actions/detect-code-changes/action.yml
@@ -12,7 +12,6 @@ runs:
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
       id: filter
       with:
-        initial-fetch-depth: 1000
         filters: |
           code:
             - '**'

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
@@ -47,9 +47,12 @@ export function ReleaseDetail() {
 
   useEffect(() => {
     if (isNotFound) {
-      router.navigate({
-        _searchParams: [[RELEASE_NOT_FOUND_SEARCH_PARAM_KEY, 'true']],
-      })
+      router.navigate(
+        {
+          _searchParams: [[RELEASE_NOT_FOUND_SEARCH_PARAM_KEY, 'true']],
+        },
+        {replace: true},
+      )
     }
   }, [isNotFound, router])
 

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetail.test.tsx
@@ -490,9 +490,12 @@ describe('after releases have loaded', () => {
       await renderTest()
 
       await waitFor(() => {
-        expect(mockUseRouterReturn.navigate).toHaveBeenCalledWith({
-          _searchParams: [['releaseNotFound', 'true']],
-        })
+        expect(mockUseRouterReturn.navigate).toHaveBeenCalledWith(
+          {
+            _searchParams: [['releaseNotFound', 'true']],
+          },
+          {replace: true},
+        )
       })
     })
 

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -269,9 +269,7 @@ export function ReleasesOverview() {
     navigateRef.current = router.navigate
   })
 
-  // Sync filter/group state to URL, preserving the current cardinality view.
-  // Uses replace so the sync does not create a duplicate history entry alongside
-  // the user's navigation, which would swallow browser back clicks.
+  // replace avoids a duplicate history entry alongside the user's navigation, which would swallow back clicks.
   useEffect(() => {
     navigateRef.current(
       {

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -269,15 +269,20 @@ export function ReleasesOverview() {
     navigateRef.current = router.navigate
   })
 
-  // Sync filter/group state to URL, preserving the current cardinality view
+  // Sync filter/group state to URL, preserving the current cardinality view.
+  // Uses replace so the sync does not create a duplicate history entry alongside
+  // the user's navigation, which would swallow browser back clicks.
   useEffect(() => {
-    navigateRef.current({
-      _searchParams: buildReleasesSearchParams(
-        releaseFilterDate,
-        releaseGroupMode,
-        isScheduledDraftsEnabled ? cardinalityView : 'releases',
-      ),
-    })
+    navigateRef.current(
+      {
+        _searchParams: buildReleasesSearchParams(
+          releaseFilterDate,
+          releaseGroupMode,
+          isScheduledDraftsEnabled ? cardinalityView : 'releases',
+        ),
+      },
+      {replace: true},
+    )
   }, [releaseFilterDate, releaseGroupMode, cardinalityView, isScheduledDraftsEnabled])
 
   const [hasMounted, setHasMounted] = useState(false)

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
@@ -1419,9 +1419,12 @@ describe('ReleasesOverview', () => {
       const {unmount} = await mountAndFlush(<TestComponent />, {wrapper})
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith({
-          _searchParams: expect.arrayContaining([['view', 'drafts']]),
-        })
+        expect(mockNavigate).toHaveBeenCalledWith(
+          {
+            _searchParams: expect.arrayContaining([['view', 'drafts']]),
+          },
+          {replace: true},
+        )
       })
 
       unmount()
@@ -1443,6 +1446,30 @@ describe('ReleasesOverview', () => {
       for (const call of mockNavigate.mock.calls) {
         const searchParams: [string, string][] = call[0]?._searchParams || []
         expect(searchParams).not.toContainEqual(['view', 'drafts'])
+      }
+    })
+
+    it('uses replace when syncing filter/group state to URL to avoid duplicate history entries', async () => {
+      mockNavigate.mockClear()
+      vi.mocked(useScheduledDraftsEnabled).mockReturnValue(true)
+      vi.mocked(useRouter).mockReturnValue({
+        state: {},
+        navigate: mockNavigate,
+        resolveIntentLink: mockResolveIntentLink,
+      } as unknown as ReturnType<typeof useRouter>)
+
+      const wrapper = await createTestProvider({
+        resources: [releasesUsEnglishLocaleBundle],
+      })
+
+      await mountAndFlush(<TestComponent />, {wrapper})
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalled()
+      })
+
+      for (const call of mockNavigate.mock.calls) {
+        expect(call[1]).toEqual({replace: true})
       }
     })
   })


### PR DESCRIPTION
### Description

Fixes SAPP-3950 - the browser back button was silently swallowed when using the Content Releases tool. First back click from `/releases` looked like it did nothing; after switching to Scheduled drafts, further back clicks could get stuck on Releases entirely.

Root cause: `ReleasesOverview`'s state-sync `useEffect` and `ReleaseDetail`'s not-found redirect called `router.navigate(...)` without `{replace: true}`. That routes through `WorkspaceRouterProvider.handleNavigate` -> `history.push`, and the `history` library pushes a new stack entry even when the resulting URL is identical. Every mount and every filter/group/cardinality-view change added a duplicate entry alongside the entry the user actually created, so browser-back needed multiple clicks to make visible progress.

Fix: pass `{replace: true}` to state-sync navigations and to the not-found redirect. User-initiated navigations (row clicks, tab switches, delete, revert, create) keep default push.

Note on `handleCardinalityViewChange`: it still uses default push, but the sync effect immediately replaces the entry. Net effect: clicking the cardinality tab picker does not add a discrete history entry, which is consistent with how filter-date and group-mode changes already behave (and is an improvement over the pre-fix duplicate-push, where back required two clicks to undo a tab switch).

Linear: https://linear.app/sanity/issue/SAPP-3950

Before:
<img width="912" height="690" alt="backReleasesBEFOREPR" src="https://github.com/user-attachments/assets/1c103ea3-c428-418d-bdc9-9f011f3f7978" />

After:
<img width="912" height="690" alt="backReleasesAFTERPR" src="https://github.com/user-attachments/assets/75808708-99c5-4e92-b6a5-f561313dbd87" />

### What to review

Files:
- `packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx` - sync effect gains `{replace: true}`
- `packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx` - not-found redirect gains `{replace: true}`
- Both `__tests__` files - updated one existing assertion each; added one regression test in `ReleasesOverview.test.tsx` that iterates every `mockNavigate` call from mount and asserts each carries `{replace: true}`

Please sanity-check:
- The three touched call sites are the right ones (all sync/redirect flows; no user-event handlers were touched)
- The regression test is scoped correctly (mount-with-empty-state assertion covers the class of bug without over-fitting)
- The cardinality-view behaviour note above is acceptable

### Testing

- Unit: 100/100 tests pass across `ReleasesOverview.test.tsx` (63) and `ReleaseDetail.test.tsx` (37). New regression test guards the invariant.
- Manual repro (Flow A): Structure -> Sections by perspective -> click perspective pill to `/test/releases` -> single browser-back returns to Sections. Before fix: first back click swallowed; needed 2-3 clicks.
- Manual repro (Flow B): `/test/releases` -> Releases dropdown -> Scheduled drafts -> three browser-back clicks step `?releases[view]=drafts` -> `/test/releases` -> `sections-by-perspective` -> `/test/structure`. Before fix: got stuck on Releases entirely.

### Notes for release

Fixes browser back-button navigation inside the Content Releases tool. Previously, clicking the back button from the Releases page or from Scheduled drafts required multiple clicks to leave, with the first click(s) appearing to do nothing. Each browser-back click now moves back exactly one step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted router-option change in releases UI with tests; no auth, data, or API changes.
> 
> **Overview**
> Fixes **browser back** in the Content Releases tool (SAPP-3950) by passing **`{replace: true}`** on navigations that only sync UI state to the URL, instead of pushing duplicate history entries.
> 
> **`ReleasesOverview`** now replaces the current entry when its effect writes filter, group mode, and cardinality view to search params. **`ReleaseDetail`** does the same for the not-found redirect that sets `releaseNotFound`. User-driven navigations (row clicks, tabs, create, etc.) are unchanged and still push.
> 
> Tests assert the new `navigate` second argument and add a regression that every overview sync call uses `replace`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f80c1e48d6633eedcdd4a86c031b814a05d9ab2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->