### PR TITLE
fix(validation): respect Rule.uri scheme in array validation

### DIFF
--- a/packages/sanity/src/core/validation/util/normalizeValidationRules.ts
+++ b/packages/sanity/src/core/validation/util/normalizeValidationRules.ts
@@ -1,9 +1,11 @@
 import {
   type Rule,
+  type RuleSpec,
   type RuleTypeConstraint,
   type SchemaType,
   type ValidationContext,
 } from '@sanity/types'
+import isEqual from 'lodash-es/isEqual.js'
 
 import {Rule as RuleClass} from '../Rule'
 import {slugValidator} from '../validators/slugValidator'
@@ -84,6 +86,29 @@ function extractValueFromListOption(option: unknown, typeDef: SchemaType): unkno
     : (option as Record<string, unknown>).value
 }
 
+const isUriSpec = (spec: RuleSpec): spec is Extract<RuleSpec, {flag: 'uri'}> => spec.flag === 'uri'
+
+// A `url` type auto-injects the default `.uri()` onto every array element, so a
+// custom scheme on one element cannot override the default on its siblings (GH #3298).
+function omitLeakedDefaultUri(rules: Rule[], typeDef: SchemaType): Rule[] {
+  const isUrlType = getTypeChain(typeDef).some((type) => type.name === 'url')
+  if (!isUrlType) return rules
+
+  const defaultUri = new RuleClass(typeDef).uri()._rules.find(isUriSpec)?.constraint
+  const isDefaultUri = (spec: RuleSpec) => isUriSpec(spec) && isEqual(spec.constraint, defaultUri)
+  const isCustomUri = (spec: RuleSpec) => isUriSpec(spec) && !isEqual(spec.constraint, defaultUri)
+
+  const someElementSetsScheme = rules.some((rule) => rule._rules.some(isCustomUri))
+  if (!someElementSetsScheme) return rules
+
+  return rules.map((rule) => {
+    if (!rule._rules.some(isDefaultUri)) return rule
+    const cleaned = rule.clone()
+    cleaned._rules = rule._rules.filter((spec) => !isDefaultUri(spec))
+    return cleaned
+  })
+}
+
 export function normalizeValidationRules(
   typeDef: SchemaType | undefined,
   context?: ValidationContext,
@@ -95,7 +120,7 @@ export function normalizeValidationRules(
   const validation = typeDef.validation
 
   if (Array.isArray(validation)) {
-    return validation.flatMap((i) =>
+    const rules = validation.flatMap((i) =>
       normalizeValidationRules(
         {
           ...typeDef,
@@ -104,6 +129,7 @@ export function normalizeValidationRules(
         context,
       ),
     )
+    return omitLeakedDefaultUri(rules, typeDef)
   }
 
   const baseRule =

--- a/packages/sanity/test/validation/url.test.ts
+++ b/packages/sanity/test/validation/url.test.ts
@@ -1,0 +1,75 @@
+import {type Rule, type SchemaType} from '@sanity/types'
+import {describe, expect, test} from 'vitest'
+
+import {getFallbackLocaleSource} from '../../src/core/i18n/fallback'
+import {normalizeValidationRules} from '../../src/core/validation/util/normalizeValidationRules'
+
+const context: any = {client: {}, i18n: getFallbackLocaleSource()}
+
+const DISALLOWED_SCHEME_MESSAGE = 'Does not match allowed protocols/schemes'
+
+const urlType = (validation: SchemaType['validation']): SchemaType =>
+  ({name: 'url', jsonType: 'string', validation}) as SchemaType
+
+async function collectMarkers(typeDef: SchemaType, value: unknown) {
+  const rules = normalizeValidationRules(typeDef, context)
+  const markers = await Promise.all(rules.map((rule) => rule.validate(value, context)))
+  return markers.flat()
+}
+
+describe('url validation scheme override (SAPP-4059 / GH #3298)', () => {
+  test('single rule respects custom scheme', async () => {
+    const markers = await collectMarkers(
+      urlType((rule) => rule.uri({scheme: ['mailto', 'tel', 'http', 'https']})),
+      'mailto:hi@example.com',
+    )
+
+    expect(markers.map((marker) => marker.message)).not.toContain(DISALLOWED_SCHEME_MESSAGE)
+  })
+
+  test('array rule respects custom scheme on a sibling element', async () => {
+    const markers = await collectMarkers(
+      urlType((rule) => [
+        rule.uri({scheme: ['mailto', 'tel', 'http', 'https']}),
+        rule.custom(() => true),
+      ]),
+      'mailto:hi@example.com',
+    )
+
+    expect(markers.map((marker) => marker.message)).not.toContain(DISALLOWED_SCHEME_MESSAGE)
+  })
+
+  test('array rule preserves independent levels while respecting the custom scheme', async () => {
+    const markers = await collectMarkers(
+      urlType((rule) => [
+        rule.uri({scheme: ['mailto']}),
+        rule.custom<string>(() => 'always warn').warning(),
+      ]),
+      'mailto:hi@example.com',
+    )
+
+    expect(markers.map((marker) => marker.message)).not.toContain(DISALLOWED_SCHEME_MESSAGE)
+    expect(markers).toEqual([expect.objectContaining({level: 'warning', message: 'always warn'})])
+  })
+
+  test('array rule keeps the default scheme when no element overrides it', async () => {
+    const markers = await collectMarkers(
+      urlType((rule) => [rule.required(), rule.custom(() => true)]),
+      'ftp://example.com',
+    )
+
+    expect(markers.map((marker) => marker.message)).toContain(DISALLOWED_SCHEME_MESSAGE)
+  })
+
+  test('non-url string array is unaffected', async () => {
+    const stringType = {
+      name: 'coolString',
+      jsonType: 'string',
+      validation: (rule: Rule) => [rule.min(2), rule.custom(() => true)],
+    } as SchemaType
+
+    const markers = await collectMarkers(stringType, 'a')
+    expect(markers).toHaveLength(1)
+    expect(markers[0].message).not.toBe(DISALLOWED_SCHEME_MESSAGE)
+  })
+})


### PR DESCRIPTION
### Description

When a `url` field's `validation` returns an array - which is required to mix an error-level rule with a warning-level one - a custom `Rule.uri({ scheme })` on one element was ignored, so values like `mailto:` and `tel:` were wrongly rejected with "Does not match allowed protocols/schemes". Fixes #3298 (SAPP-4059).

This PR fixes the leak behind it: a `url` type auto-injects a default `.uri()` (http/https) onto every rule, and each array element clones that default, so the default sitting on the sibling elements overrode the custom scheme. The fix drops the auto-injected default from sibling rules once any element in the array supplies its own scheme, leaving single-rule and non-url validation untouched.

### What to review

- `normalizeValidationRules.ts`: `omitLeakedDefaultUri` runs only on the array branch and strips the auto-injected default `uri` spec from sibling rules, but only when another element carries a custom scheme.
- The guard for over-stripping: when no element overrides the scheme, the default `.uri()` is preserved so a plain `url` array is still validated as a URL.
- Single-rule and non-url paths are deliberately unchanged.

### Testing

Added `packages/sanity/test/validation/url.test.ts`, which drives the real `normalizeValidationRules` plus `.validate()` path across five cases: single-rule scheme override, array scheme override, an array mixing error and warning levels (scheme respected and levels preserved independently), a no-override array (default scheme still enforced), and a non-url string array for contrast.

### Notes for release

`Rule.uri({ scheme })` now respects the custom scheme when combined with other rules in a `validation` array, so schemes such as `mailto:` and `tel:` are no longer wrongly rejected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow validation normalization fix for url array rules with tests; single-rule and non-url behavior unchanged.
> 
> **Overview**
> Fixes **GH #3298**: when a `url` field uses a **validation array** (e.g. to mix error- and warning-level rules), a custom `Rule.uri({ scheme })` on one entry was ignored and `mailto:` / `tel:` could still fail with “Does not match allowed protocols/schemes”.
> 
> **`normalizeValidationRules`** now runs **`omitLeakedDefaultUri`** on the array branch only. Each array element still gets the type’s auto-injected default `.uri()` (http/https); if any element defines its own scheme, that default is stripped from sibling rules so it no longer overrides the custom scheme. When no element overrides schemes, default URL validation is unchanged. Single-rule and non-`url` paths are untouched.
> 
> Adds **`packages/sanity/test/validation/url.test.ts`** covering single vs array rules, mixed severity levels, default scheme preservation, and non-url string arrays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9255af30cd968704f646c2fb7c933234f70e2e22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->