### PR TITLE
fix(form): keep menus open over PTE annotation popover

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -120,23 +120,17 @@ function Content(props: PopoverEditDialogProps) {
     setBoundaryElement(contentElement.closest<HTMLElement>('[data-ui="Popover__wrapper"]'))
   }, [contentElement])
 
-  const handleFocusLockWhiteList = useCallback((element: HTMLElement) => {
-    // This is needed in order for focusLock not to trap focus in the
-    // popover when closing the popover and focus is to be returned to the editor
-    if (isClosedRef.current) return false
-
-    const target = element as Node
-    const portalElements = document.querySelectorAll('[data-portal]')
-    const isWithinPortal = Array.from(portalElements).some((portal) => portal.contains(target))
-
-    // We want to have an exception to the clicking when the target is outside of the portal
-    // And the popover is not closed.
-    // This is needed in order for focusLock not to trap focus in the modal
-    // Because then, if we are trying to change matters in an opened pane, focusLock will trap focus in the modal
-    if (!isWithinPortal && !isClosedRef.current) return false
-
-    return Boolean(element.contentEditable) || Boolean(containerElement.current?.contains(element))
-  }, [])
+  // react-focus-lock reclaims focus *toward* whitelisted elements, so whitelist only this
+  // popover's own wrapper: a menu opened over it (in a sibling portal) then keeps focus
+  // instead of being stolen back and closed. While closing, whitelist nothing so focus
+  // returns to the editor.
+  const handleFocusLockWhiteList = useCallback(
+    (element: HTMLElement) => {
+      if (isClosedRef.current) return false
+      return !boundaryElement || boundaryElement.contains(element)
+    },
+    [boundaryElement],
+  )
 
   return (
     <VirtualizerScrollInstanceProvider


### PR DESCRIPTION
### Description

Fixes SAPP-3952 - the document pane's top-right ellipsis menu closes the instant a Portable Text annotation popover (e.g. "Edit Link") is open, so its items cannot be used. Linear: https://linear.app/sanity/issue/SAPP-3952

The annotation popover wraps its content in `react-focus-lock`'s `<FocusLock>` to trap keyboard focus. react-focus-lock reclaims focus *toward* whitelisted elements, but the popover's `whiteList` returned truthy for elements in any portal (via an always-truthy `element.contentEditable` check) - including a menu opened over the popover. The trap pulled focus back into the popover, and the menu's `onBlurCapture` then closed it.

This PR scopes the whitelist to the popover's own wrapper, so the trap only governs focus inside the popover: a menu in a sibling portal keeps its focus and stays open, while `Tab` containment inside the popover is preserved. This also resolves the same-class issue #10821 (reference autocomplete opened from within the popover).

Before:
<img width="912" height="690" alt="focusMenuBEFOREPR" src="https://github.com/user-attachments/assets/9c8411f1-ad88-4ce0-9f99-b5fe10301582" />

After:
<img width="912" height="690" alt="focusMenuAFTERPR" src="https://github.com/user-attachments/assets/7f258a88-25c2-4b48-8cdd-201953817e18" />

### What to review

Single-file change: `packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx`. The `whiteList` now returns `true` only for the popover's own `Popover__wrapper` (`boundaryElement`), and `false` while closing so focus returns to the editor. The non-obvious part: react-focus-lock's `whiteList` marks where the trap reclaims focus toward, so returning `false` for foreign portals is what stops the steal - verified against the library source (`Trap.js`). This mirrors the existing pattern in `core/components/popoverDialog/PopoverDialog.tsx`.

### Testing

Verified live in the studio with real focus events (synthetic clicks do not reproduce the timing race). The focus-steal was first reproduced on the old whitelist, then the fix was confirmed across surfaces:

- Annotation popover with the ellipsis menu over it: menu stays open and its items fire (e.g. Inspect).
- Reference field inside the annotation popover: autocomplete opens, results render, a result can be selected (the #10821 case).
- Inline object popover: same menu-over-popover behaviour holds.
- Focus trap preserved: Tab wraps inside the popover; Escape, close button, and click-outside still return focus to the editor.

No unit test - the bug is a focus-timing race that jsdom cannot exercise.

### Notes for release

Fixes the document pane ellipsis menu (History, Duplicate, Inspect, Compare versions, etc.) closing itself when opened while a Portable Text annotation editor is on screen. The menu now stays open and its items work.
