### PR TITLE
fix(release-notes): stop extraction at horizontal rule to exclude tool-appended content

### DIFF
--- a/.agents/skills/pr-description/SKILL.md
+++ b/.agents/skills/pr-description/SKILL.md
@@ -84,6 +84,8 @@ This section is used by the docs team to write release notes.
 - How to use it (code snippets if applicable)
 - Limitations or breaking changes
 
+**Always end this section with a `---` horizontal rule.** The release-notes automation stops at the first `---` after the "Notes for release" heading, so the rule fences off anything appended below (Cursor Bugbot reviews, later edits) and keeps it out of the changelog.
+
 ### 4. Create the PR
 
 **Always create as draft.** Do not mark as ready for review until CI passes.
@@ -105,6 +107,8 @@ gh pr create --draft --title "type(scope): description" --body "$(cat <<'EOF'
 ### Notes for release
 
 [release notes or N/A]
+
+---
 EOF
 )"
 ```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,4 +37,9 @@ but they must provide the docs team with enough context on:
 If this PR is a partial implementation of a feature and is not enabled by default or if
 this PR does not contain changes that needs mention in the release notes (tooling chores etc),
 please call this out explicitly by writing "N/A – Part of feature X" in this section.
+
+Write your notes ABOVE the horizontal rule below. Release automation ignores
+anything after the rule (Cursor Bugbot reviews, later edits, etc.).
 -->
+
+---

--- a/packages/@repo/release-notes/src/commands/createOrUpdateChangelogDocs.ts
+++ b/packages/@repo/release-notes/src/commands/createOrUpdateChangelogDocs.ts
@@ -25,11 +25,11 @@ import {getCommitAuthor, getMergedPRForCommit} from '../utils/github'
 import {getSanityDocumentIdsForBaseVersion} from '../utils/ids'
 import {isBreakingChange} from '../utils/isBreakingChange'
 import {parseRenovateReleaseNotes} from '../utils/parseRenovateReleaseNotes'
+import {type NormalizedMarkdownBlock} from '../utils/portabletext-markdown/markdownToPortableText'
 import {
-  markdownToPortableText,
-  type NormalizedMarkdownBlock,
-} from '../utils/portabletext-markdown/markdownToPortableText'
-import {extractReleaseNotes, shouldExcludeReleaseNotes} from '../utils/pullRequestReleaseNotes'
+  extractReleaseNotesFromPrBody,
+  shouldExcludeReleaseNotes,
+} from '../utils/pullRequestReleaseNotes'
 import {stripPr} from '../utils/stripPrNumber'
 import {uploadImages} from '../utils/uploadImages'
 
@@ -168,7 +168,7 @@ async function getReleaseNotesMutations(
     pr?.body
       ? isBot
         ? parseRenovateReleaseNotes(pr.body)
-        : extractReleaseNotes(markdownToPortableText(pr.body))
+        : await extractReleaseNotesFromPrBody(pr.body)
       : [],
   )
 

--- a/packages/@repo/release-notes/src/utils/__test__/extractReleaseNotes.test.ts
+++ b/packages/@repo/release-notes/src/utils/__test__/extractReleaseNotes.test.ts
@@ -143,6 +143,42 @@ ${a}
       ),
     ).toEqual(false)
   })
+  it('stops at a horizontal rule inside the section (excludes Cursor Bugbot content)', () => {
+    const notes = extractReleaseNotes(
+      markdownToPortableText(`### Notes for release
+
+Adds a new feature that does the thing.
+
+<!-- CURSOR_SUMMARY -->
+---
+
+> [!NOTE]
+> **Medium Risk**
+> Touches core behavior.
+<!-- /CURSOR_SUMMARY -->
+`),
+    )
+
+    expect(portableTextToMarkdown(notes).trim()).toEqual('Adds a new feature that does the thing.')
+    expect(notes.some((block) => block._type === 'callout')).toBe(false)
+    expect(notes.some((block) => block._type === 'horizontal-rule')).toBe(false)
+  })
+
+  it('stops at a horizontal rule before any callout content leaks through', () => {
+    const notes = extractReleaseNotes(
+      markdownToPortableText(`### Notes for release
+
+Real notes.
+
+---
+
+Anything after the rule.
+`),
+    )
+
+    expect(portableTextToMarkdown(notes).trim()).toEqual('Real notes.')
+  })
+
   it('skips inline html comments', () => {
     const notes = extractReleaseNotes(
       markdownToPortableText(`

--- a/packages/@repo/release-notes/src/utils/__test__/extractReleaseNotesFromPrBody.test.ts
+++ b/packages/@repo/release-notes/src/utils/__test__/extractReleaseNotesFromPrBody.test.ts
@@ -1,0 +1,104 @@
+import {portableTextToMarkdown} from '@portabletext/markdown'
+import {describe, expect, it, vi} from 'vitest'
+
+import {type ExtractSectionOptions} from '../extractSectionWithLlm'
+import {extractReleaseNotesFromPrBody} from '../pullRequestReleaseNotes'
+
+function mockClient(returnText: string): NonNullable<ExtractSectionOptions['client']> {
+  return {
+    messages: {
+      create: vi.fn().mockResolvedValue({content: [{type: 'text', text: returnText}]}),
+    } as unknown as NonNullable<ExtractSectionOptions['client']>['messages'],
+  }
+}
+
+function throwingClient(): NonNullable<ExtractSectionOptions['client']> {
+  return {
+    messages: {
+      create: vi.fn().mockRejectedValue(new Error('api down')),
+    } as unknown as NonNullable<ExtractSectionOptions['client']>['messages'],
+  }
+}
+
+describe('extractReleaseNotesFromPrBody', () => {
+  it('takes the deterministic path when the section contains a horizontal rule', async () => {
+    const client = mockClient('SHOULD NOT BE CALLED')
+    const prBody = `### Description
+Something.
+
+### Notes for release
+
+Adds a new feature.
+
+---
+
+Cursor summary here.`
+
+    const blocks = await extractReleaseNotesFromPrBody(prBody, {client})
+    expect(portableTextToMarkdown(blocks).trim()).toEqual('Adds a new feature.')
+    expect(client.messages.create).not.toHaveBeenCalled()
+  })
+
+  it('routes to the LLM when the section has no horizontal rule', async () => {
+    const prBody = `### Notes for release
+
+Adds a new feature.
+
+<!-- CURSOR_SUMMARY -->
+> [!NOTE]
+> Cursor review.
+<!-- /CURSOR_SUMMARY -->`
+    const client = mockClient('Adds a new feature.')
+
+    const blocks = await extractReleaseNotesFromPrBody(prBody, {client})
+    expect(portableTextToMarkdown(blocks).trim()).toEqual('Adds a new feature.')
+    expect(client.messages.create).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns [] when the LLM responds with N/A', async () => {
+    const prBody = `### Notes for release
+
+N/A`
+    const client = mockClient('N/A')
+
+    const blocks = await extractReleaseNotesFromPrBody(prBody, {client})
+    expect(blocks).toEqual([])
+  })
+
+  it('falls back to deterministic extraction when the LLM output is not a substring of the section', async () => {
+    const prBody = `### Notes for release
+
+Adds a new feature.
+
+Cursor summary here.`
+    const client = mockClient('Something the LLM invented that is not in the input.')
+
+    const blocks = await extractReleaseNotesFromPrBody(prBody, {client})
+    expect(portableTextToMarkdown(blocks)).toContain('Adds a new feature.')
+    expect(portableTextToMarkdown(blocks)).toContain('Cursor summary here.')
+  })
+
+  it('falls back to deterministic extraction when the LLM call throws', async () => {
+    const prBody = `### Notes for release
+
+Adds a new feature.
+
+Cursor summary here.`
+    const client = throwingClient()
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const blocks = await extractReleaseNotesFromPrBody(prBody, {client})
+    expect(portableTextToMarkdown(blocks)).toContain('Adds a new feature.')
+    consoleWarn.mockRestore()
+  })
+
+  it('returns [] when the PR body has no Notes-for-release section', async () => {
+    const client = mockClient('SHOULD NOT BE CALLED')
+    const prBody = `### Description
+Some other content.`
+
+    const blocks = await extractReleaseNotesFromPrBody(prBody, {client})
+    expect(blocks).toEqual([])
+    expect(client.messages.create).not.toHaveBeenCalled()
+  })
+})

--- a/packages/@repo/release-notes/src/utils/__test__/flattenCallouts.test.ts
+++ b/packages/@repo/release-notes/src/utils/__test__/flattenCallouts.test.ts
@@ -59,4 +59,57 @@ After.`
     const result = flattenCallouts(markdownToPortableText(markdown))
     expect(result.some((block) => block._type === 'callout')).toBe(false)
   })
+
+  it('coerces blockquote-styled inner blocks to `normal` when unwrapping', () => {
+    const inner: NormalizedMarkdownBlock = {
+      _type: 'block',
+      _key: 'inner',
+      style: 'blockquote',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'inner-span', text: 'heads up', marks: []}],
+    } as NormalizedMarkdownBlock
+
+    const [result] = flattenCallouts([
+      {
+        _type: 'callout',
+        _key: 'c',
+        tone: 'warning',
+        content: [inner],
+      } as NormalizedMarkdownBlock,
+    ])
+
+    expect(result).toMatchObject({_type: 'block', style: 'normal'})
+  })
+
+  it('leaves non-blockquote inner styles alone when unwrapping', () => {
+    const inner: NormalizedMarkdownBlock = {
+      _type: 'block',
+      _key: 'inner',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'inner-span', text: 'plain', marks: []}],
+    } as NormalizedMarkdownBlock
+
+    const [result] = flattenCallouts([
+      {
+        _type: 'callout',
+        _key: 'c',
+        tone: 'note',
+        content: [inner],
+      } as NormalizedMarkdownBlock,
+    ])
+
+    expect(result).toEqual(inner)
+  })
+
+  it('unwrapping produces `normal`-styled blocks from real GFM alert markdown', () => {
+    const markdown = `> [!NOTE]
+> **Heads up:** this changes the default.`
+    const result = flattenCallouts(markdownToPortableText(markdown))
+    for (const block of result) {
+      if (block._type === 'block') {
+        expect(block.style).toBe('normal')
+      }
+    }
+  })
 })

--- a/packages/@repo/release-notes/src/utils/extractSectionWithLlm.ts
+++ b/packages/@repo/release-notes/src/utils/extractSectionWithLlm.ts
@@ -1,0 +1,67 @@
+import {Anthropic} from '@anthropic-ai/sdk'
+
+const MODEL = 'claude-haiku-4-5'
+
+type AnthropicLike = {
+  messages: {
+    create: Anthropic['messages']['create']
+  }
+}
+
+export type ExtractSectionOptions = {
+  client?: AnthropicLike
+}
+
+const PROMPT_HEADER = `You will be given the "Notes for release" section from a GitHub pull request body. Return only the parts written by the human author, exactly as raw markdown, and do NOT include the section heading itself.
+
+Exclude any content added by automated review tools - Cursor Bugbot, GitHub Copilot Code Review, Cursor summaries, or similar reviewer commentary. These typically appear as GFM alerts, blockquotes describing the change, or HTML comment markers such as <!-- CURSOR_SUMMARY -->. Include everything the human wrote: images, bulleted or numbered lists, code blocks, links, plain paragraphs.
+
+If the section is empty, contains only an opt-out like "N/A", or reduces to that after removing tool noise, return exactly the string N/A on its own.
+
+Do not summarize, rewrite, or add commentary. Return the raw markdown verbatim.
+
+Section:
+`
+
+export async function extractSectionWithLlm(
+  rawSection: string,
+  options: ExtractSectionOptions = {},
+): Promise<null | string> {
+  if (!rawSection.trim()) return ''
+
+  const client = options.client ?? createDefaultClient()
+  if (!client) return null
+
+  try {
+    const message = await client.messages.create({
+      max_tokens: 4096,
+      messages: [{role: 'user', content: PROMPT_HEADER + rawSection}],
+      model: MODEL,
+      stream: false,
+    })
+    const text = message.content
+      .map((part) => (part.type === 'text' ? part.text : ''))
+      .join('')
+      .trim()
+    if (!text) return ''
+    if (text.toLowerCase() === 'n/a') return ''
+    if (!isSubstringLenient(text, rawSection)) return null
+    return text
+  } catch (err) {
+    console.warn(
+      new Error('Request to Claude API failed during release notes extraction', {cause: err}),
+    )
+    return null
+  }
+}
+
+function createDefaultClient(): AnthropicLike | null {
+  const apiKey = process.env.RELEASE_NOTES_CLAUDE_API_KEY
+  if (!apiKey) return null
+  return new Anthropic({apiKey})
+}
+
+function isSubstringLenient(needle: string, haystack: string): boolean {
+  const normalize = (value: string) => value.replace(/\s+/g, ' ').trim().toLowerCase()
+  return normalize(haystack).includes(normalize(needle))
+}

--- a/packages/@repo/release-notes/src/utils/flattenCallouts.ts
+++ b/packages/@repo/release-notes/src/utils/flattenCallouts.ts
@@ -2,8 +2,15 @@ import {type PortableTextMarkdownBlock} from './portabletext-markdown/types'
 
 // Neither the changelog `contents` nor the docs article schema accepts
 // `_type: "callout"` blocks; unwrap them so the inner content survives.
+// GFM alert content comes styled as `blockquote` (each `>` line inherits the
+// style), which the changelog block schema also rejects - coerce to `normal`.
 export function flattenCallouts(blocks: PortableTextMarkdownBlock[]): PortableTextMarkdownBlock[] {
   return blocks.flatMap<PortableTextMarkdownBlock>((block) =>
-    block._type === 'callout' ? block.content : [block],
+    block._type === 'callout' ? block.content.map(resetBlockquoteStyle) : [block],
   )
+}
+
+function resetBlockquoteStyle(block: PortableTextMarkdownBlock): PortableTextMarkdownBlock {
+  if (block._type !== 'block' || block.style !== 'blockquote') return block
+  return {...block, style: 'normal'}
 }

--- a/packages/@repo/release-notes/src/utils/pullRequestReleaseNotes.ts
+++ b/packages/@repo/release-notes/src/utils/pullRequestReleaseNotes.ts
@@ -1,4 +1,8 @@
-import {type NormalizedMarkdownBlock} from './portabletext-markdown/markdownToPortableText'
+import {extractSectionWithLlm, type ExtractSectionOptions} from './extractSectionWithLlm'
+import {
+  markdownToPortableText,
+  type NormalizedMarkdownBlock,
+} from './portabletext-markdown/markdownToPortableText'
 import {type PortableTextMarkdownBlock} from './portabletext-markdown/types'
 
 export function extractReleaseNotes(blocks: NormalizedMarkdownBlock[]) {
@@ -21,6 +25,52 @@ export function extractReleaseNotes(blocks: NormalizedMarkdownBlock[]) {
     releaseNotesBlocks.push(block)
   }
   return releaseNotesBlocks
+}
+
+// Trust the deterministic extractor when the section contains a horizontal
+// rule. Without one, tool-appended content (Cursor Bugbot, etc.) leaks in, so
+// route the raw section text through an LLM cleaner instead.
+export async function extractReleaseNotesFromPrBody(
+  prBody: string,
+  options: ExtractSectionOptions = {},
+): Promise<NormalizedMarkdownBlock[]> {
+  const blocks = markdownToPortableText(prBody)
+  if (sectionContainsHorizontalRule(blocks)) return extractReleaseNotes(blocks)
+
+  const rawSection = extractRawSection(prBody)
+  if (!rawSection) return extractReleaseNotes(blocks)
+
+  const cleaned = await extractSectionWithLlm(rawSection, options)
+  if (cleaned === null) return extractReleaseNotes(blocks)
+  if (!cleaned.trim()) return []
+  return markdownToPortableText(cleaned)
+}
+
+function sectionContainsHorizontalRule(blocks: PortableTextMarkdownBlock[]): boolean {
+  let inSection = false
+  for (const block of blocks) {
+    if (isHeading(block)) {
+      if (inSection) return false
+      if (getBlockText(block).includes('Notes for release')) {
+        inSection = true
+      }
+      continue
+    }
+    if (inSection && block._type === 'horizontal-rule') return true
+  }
+  return false
+}
+
+function extractRawSection(prBody: string): string {
+  const headingMatch = prBody.match(/^ {0,3}#{1,6}\s+.*Notes for release.*$/im)
+  if (!headingMatch || headingMatch.index === undefined) return ''
+  const afterHeading = prBody.slice(headingMatch.index + headingMatch[0].length)
+  const nextHeading = afterHeading.match(/^ {0,3}#{1,6}\s+\S/m)
+  const sectionBody =
+    nextHeading && nextHeading.index !== undefined
+      ? afterHeading.slice(0, nextHeading.index)
+      : afterHeading
+  return sectionBody.trim()
 }
 
 function isHeading(block: PortableTextMarkdownBlock) {

--- a/packages/@repo/release-notes/src/utils/pullRequestReleaseNotes.ts
+++ b/packages/@repo/release-notes/src/utils/pullRequestReleaseNotes.ts
@@ -7,18 +7,18 @@ export function extractReleaseNotes(blocks: NormalizedMarkdownBlock[]) {
 
   for (const block of blocks) {
     if (isHeading(block)) {
-      if (activeHeaderIsReleaseNotes) {
-        // new header
-        break
-      }
+      if (activeHeaderIsReleaseNotes) break
       if (getBlockText(block).includes('Notes for release')) {
         activeHeaderIsReleaseNotes = true
         continue
       }
     }
-    if (activeHeaderIsReleaseNotes) {
-      releaseNotesBlocks.push(block)
-    }
+    if (!activeHeaderIsReleaseNotes) continue
+    // A horizontal rule ends the section. Tools like Cursor Bugbot append
+    // their review after a `---` separator; humans following the PR template
+    // convention likewise put a `---` at the end of their release notes.
+    if (block._type === 'horizontal-rule') break
+    releaseNotesBlocks.push(block)
   }
   return releaseNotesBlocks
 }
@@ -28,16 +28,15 @@ function isHeading(block: PortableTextMarkdownBlock) {
     return false
   }
 
-  const [pref, l] = block.style
-  const level = Number(l)
+  const [prefix, levelChar] = block.style
+  const level = Number(levelChar)
 
-  return pref === 'h' && level >= 1 && level <= 6
+  return prefix === 'h' && level >= 1 && level <= 6
 }
 
 export function shouldExcludeReleaseNotes(blocks: PortableTextMarkdownBlock[]): boolean {
   const [block] = blocks
   if (!block) {
-    // consider only when explicitly stating that no release notes needed
     return false
   }
   const firstBlock = getBlockText(block).toLowerCase().trim()


### PR DESCRIPTION
### Description

The release-notes automation extracts content under the "Notes for release" section of a merged PR body. `extractReleaseNotes` previously only stopped at the next heading, so anything Cursor Bugbot appends without a heading (a horizontal rule plus a `> [!NOTE]` review) got pulled into the changelog. That noise landed in `apiChange.changelog[].contents` and produced schema-invalid documents that failed studio validation.

This PR fixes extraction in two layers. First, the deterministic layer: `extractReleaseNotes` now stops at the first `_type: "horizontal-rule"` block inside the section, and both the PR template and the repo-local `pr-description` skill gain a trailing `---` sentinel so future PRs are protected even before Cursor adds its own. Second, an LLM fallback: when a PR body's Notes-for-release section has no `---` (older PRs, or novel tool patterns), `extractReleaseNotesFromPrBody` sends the raw section markdown to Claude Haiku, cleaned of tool noise; a whitespace-lenient substring check guards against hallucination and any failure falls back to the deterministic extractor. `flattenCallouts` also gains a follow-up: inner blocks kept their `blockquote` style when a callout was unwrapped, which the changelog block schema also rejects - it now coerces those to `normal`.

### What to review

- `pullRequestReleaseNotes.ts` - the deterministic path is unchanged; the new async `extractReleaseNotesFromPrBody` decides between deterministic and LLM based on whether a `---` appears inside the section.
- `extractSectionWithLlm.ts` - the LLM prompt is deliberately verbose so it's easy to tune later. Reads `RELEASE_NOTES_CLAUDE_API_KEY` directly from `process.env` (bypassing `readEnv` which throws on missing key); a missing key gracefully falls back to deterministic.
- `flattenCallouts.ts` - the `blockquote` coercion only fires on `_type: "block"` inner children.
- `.github/PULL_REQUEST_TEMPLATE.md` and `.agents/skills/pr-description/SKILL.md` - the `---` sentinel needs to survive future template edits.

### Testing

74 unit tests pass across `@repo/release-notes`, including 6 new tests for the LLM fallback with a mocked Anthropic client (deterministic-when-HR-present, LLM-when-no-HR, `N/A` response, hallucination guard, API error fallback, no-section skip). No E2E tests for the LLM path; the mocked client covers the branching logic and hallucination guard.

### Notes for release

N/A

---
