### PR TITLE
fix(releases): keep copy-to sub-menu on the side at narrow widths

### DIFF
--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CopyToReleaseMenuGroup.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CopyToReleaseMenuGroup.tsx
@@ -6,6 +6,7 @@ import {styled} from 'styled-components'
 
 import {MenuGroup} from '../../../../../ui-components/menuGroup/MenuGroup'
 import {MenuItem} from '../../../../../ui-components/menuItem/MenuItem'
+import {type PopoverProps} from '../../../../../ui-components/popover/Popover'
 import {useTranslation} from '../../../../i18n'
 import {CreateReleaseMenuItem} from '../../CreateReleaseMenuItem'
 import {CopyToDraftsMenuItem} from './CopyToDraftsMenuItem'
@@ -16,6 +17,11 @@ const ReleasesList = styled(Stack)`
   max-height: 200px;
   overflow-y: auto;
 `
+
+const SUBMENU_POPOVER_PROPS: PopoverProps = {
+  placement: 'right-start',
+  fallbackPlacements: ['left-start'],
+}
 
 interface CopyToReleaseMenuGroupProps {
   releases: ReleaseDocument[]
@@ -54,7 +60,7 @@ export const CopyToReleaseMenuGroup = memo(function CopyToReleaseMenuGroup(
   return (
     <MenuGroup
       icon={CopyIcon}
-      popover={{placement: 'right-start'}}
+      popover={SUBMENU_POPOVER_PROPS}
       text={t('release.action.copy-to')}
       disabled={disabled}
       tooltipProps={{

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CopyToReleaseMenuGroup.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CopyToReleaseMenuGroup.tsx
@@ -6,7 +6,6 @@ import {styled} from 'styled-components'
 
 import {MenuGroup} from '../../../../../ui-components/menuGroup/MenuGroup'
 import {MenuItem} from '../../../../../ui-components/menuItem/MenuItem'
-import {type PopoverProps} from '../../../../../ui-components/popover/Popover'
 import {useTranslation} from '../../../../i18n'
 import {CreateReleaseMenuItem} from '../../CreateReleaseMenuItem'
 import {CopyToDraftsMenuItem} from './CopyToDraftsMenuItem'
@@ -17,11 +16,6 @@ const ReleasesList = styled(Stack)`
   max-height: 200px;
   overflow-y: auto;
 `
-
-const SUBMENU_POPOVER_PROPS: PopoverProps = {
-  placement: 'right-start',
-  fallbackPlacements: ['left-start'],
-}
 
 interface CopyToReleaseMenuGroupProps {
   releases: ReleaseDocument[]
@@ -60,7 +54,7 @@ export const CopyToReleaseMenuGroup = memo(function CopyToReleaseMenuGroup(
   return (
     <MenuGroup
       icon={CopyIcon}
-      popover={SUBMENU_POPOVER_PROPS}
+      popover={{placement: 'right-start', fallbackPlacements: ['left-start']}}
       text={t('release.action.copy-to')}
       disabled={disabled}
       tooltipProps={{


### PR DESCRIPTION
### Description

Fixes SAPP-3949 - the "Copy version to" sub-menu on a right-clicked release version chip could drop below its trigger and cover "Discard version" (and other parent-menu items) when the document pane was narrow.

Root cause: `CopyToReleaseMenuGroup` passed `popover={{placement: 'right-start'}}` with no `fallbackPlacements`. floating-ui's `flip` middleware, given only `placement: 'right-start'` and no fallbacks, defaults to opposite-axis fallbacks (`bottom-start`, `top-start`, ...) when the requested side is cramped, which visually overlays the parent menu items.

Fix: constrain `fallbackPlacements` to `['left-start']` so the sub-menu can only flip perpendicular (side-to-side), never top or bottom. Worst case is horizontal clipping past the pane / viewport boundary - a strictly better failure mode than covering a destructive action like "Discard version" / "Delete schedule".

Linear: https://linear.app/sanity/issue/SAPP-3949

### What to review

Single-file, one-line change: `packages/sanity/src/core/releases/components/documentHeader/contextMenu/CopyToReleaseMenuGroup.tsx` - adds `fallbackPlacements: ['left-start']` to the `MenuGroup` popover prop.

Scope note: this component is reached by BOTH the older `VersionChip` context menu AND the newer `DocumentGroupInventory` UI (via `VersionContextMenuPopover` -> `VersionContextMenu` -> `Canonical/ScheduledDraftContextMenu`). The fix applies to both. In the `ScheduledDraftContextMenu` flow the item at risk of being overlaid is `deleteSchedule`; in the `Canonical` flow it is `discard-version`.

RTL: Studio has no RTL infrastructure. Not a concern.

### Testing

- Existing tests: 7/7 pass in `packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx`
- No new unit test added: placement is not meaningfully unit-testable without a floating-ui layout mock, and the existing test file has no placement assertions anywhere. A shallow prop assertion would be a change-detector rather than a real guard.
- Manual repro: with `beta.variants.enabled: false` (or on any doc that has multiple release version chips), open a document, narrow the doc pane under ~750px, right-click a release chip, hover "Copy version to". Before: sub-menu dropped below the trigger, covering "Discard version". After: sub-menu opens to the left of the parent menu (or right, when there is room), and "Discard version" stays visible.

### Notes for release

Fixes the "Copy version to" sub-menu inside the release version-chip right-click menu overlaying "Discard version" (and other parent menu items) when the document pane is narrow. The sub-menu now always opens side-to-side, never downwards.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line popover placement tweak in a release context-menu component; no auth, data, or API changes.
> 
> **Overview**
> Fixes **SAPP-3949**: on narrow document panes, the **“Copy version to”** nested menu could flip below its trigger and hide parent actions like **Discard version** or **Delete schedule**.
> 
> `CopyToReleaseMenuGroup` now passes **`fallbackPlacements: ['left-start']`** on the `MenuGroup` popover (alongside `right-start`), so floating-ui may only flip **horizontally** when space is tight—not to top/bottom overlays on the parent context menu. Applies wherever that menu group is used (version chip and document group inventory flows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4998d4d9f22e8279bf49a81724de91bd4100a4ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->