### PR TITLE
fix(test-studio): keep readable component names in profiling builds

### DIFF
--- a/dev/auth-test-studio/sanity.cli.ts
+++ b/dev/auth-test-studio/sanity.cli.ts
@@ -72,10 +72,19 @@ export default defineCliConfig({
       return mergeConfig(nextConfig, {
         // Aliasing to react-dom/profiling is necessary in the production build, otherwise React can't run the profiler on the deployed studio
         resolve: {alias: {'react-dom/client': require.resolve('react-dom/profiling')}},
-        // Not minifying identifiers ensures that the React DevTools components inspector has readable component names
-        esbuild: {minifyIdentifiers: false},
-        // Enable production source maps to easier debug deployed test studios
-        build: {sourcemap: true},
+        build: {
+          // Enable production source maps to easier debug deployed test studios
+          sourcemap: true,
+          rolldownOptions: {
+            output: {
+              // Disabling `mangle` (while keeping compression and whitespace removal) ensures that
+              // the React DevTools components inspector has readable component names.
+              // This overrides the `build.minify: 'oxc'` default set by `sanity build`, replacing
+              // `esbuild: {minifyIdentifiers: false}` which the rolldown-powered Vite silently ignores.
+              minify: {compress: true, mangle: false, codegen: true},
+            },
+          },
+        },
       } satisfies UserConfig)
     }
 

--- a/dev/test-studio/sanity.cli.ts
+++ b/dev/test-studio/sanity.cli.ts
@@ -103,10 +103,19 @@ export default defineCliConfig({
       return mergeConfig(nextConfig, {
         // Aliasing to react-dom/profiling is necessary in the production build, otherwise React can't run the profiler on the deployed studio
         resolve: {alias: {'react-dom/client': require.resolve('react-dom/profiling')}},
-        // Not minifying identifiers ensures that the React DevTools components inspector has readable component names
-        esbuild: {minifyIdentifiers: false},
-        // Enable production source maps to easier debug deployed test studios
-        build: {sourcemap: true},
+        build: {
+          // Enable production source maps to easier debug deployed test studios
+          sourcemap: true,
+          rolldownOptions: {
+            output: {
+              // Disabling `mangle` (while keeping compression and whitespace removal) ensures that
+              // the React DevTools components inspector has readable component names.
+              // This overrides the `build.minify: 'oxc'` default set by `sanity build`, replacing
+              // `esbuild: {minifyIdentifiers: false}` which the rolldown-powered Vite silently ignores.
+              minify: {compress: true, mangle: false, codegen: true},
+            },
+          },
+        },
       } satisfies UserConfig)
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

`test-studio.sanity.dev` is deployed with `REACT_PRODUCTION_PROFILING=true`, but React DevTools still shows mangled component names like `REt`. The profiling block in `sanity.cli.ts` relies on `esbuild: {minifyIdentifiers: false}`, which the Rolldown-powered Vite 8 silently drops: `convertEsbuildConfigToOxcConfig` only converts jsx/define/include/exclude options, and `sanity build` minifies with `build.minify: 'oxc'`, so identifiers get mangled anyway.

The fix overrides the minifier at the Rolldown output level (`build.rolldownOptions.output.minify: {compress: true, mangle: false, codegen: true}`), which takes precedence over the `'oxc'` default. Mangling is disabled so component names survive, while compression and whitespace removal stay on. Setting `build.minify: false` instead was rejected because it maps to `dce-only` and would disable compression entirely.

`dev/auth-test-studio` has the same profiling block, so it gets the same fix.

### What to review

- `dev/test-studio/sanity.cli.ts` and `dev/auth-test-studio/sanity.cli.ts` — the profiling-only branch (`REACT_PRODUCTION_PROFILING=true` + `command === 'build'`). Regular builds are unaffected.
- The override survives `finalizeViteConfig` in `@sanity/cli-build`, which re-merges default `rolldownOptions` but never sets `output.minify`.

### Testing

React DevTools (standalone) connected to locally served `REACT_PRODUCTION_PROFILING=true` builds of the test studio, before and after this change:

| Before | After |
| --- | --- |
| [React DevTools components tree with mangled names like M$t, yft, bft, RQt](https://cursor.com/agents/bc-db4561f1-dd24-4b29-8b80-38dc5d25a923/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freact_devtools_before_mangled_names.png) | [React DevTools components tree with readable names like Studio, StudioProvider, ColorSchemeProvider](https://cursor.com/agents/bc-db4561f1-dd24-4b29-8b80-38dc5d25a923/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freact_devtools_after_readable_names.png) |

Verified on the emitted bundles (`REACT_PRODUCTION_PROFILING=true pnpm --filter sanity-test-studio sanity:build`):

- Before: component names absent from all JS chunks (only in sourcemaps); every function mangled to 1–3 chars. `rg "function (StudioLayout|DocumentPane|StructureToolBoundary)\(" dist/static/*.js` → no matches.
- After: `function StudioLayout(`, `function DocumentPane(`, `function StructureToolBoundary(`, `function UserComponentPane(` and `var TasksNavigationProvider=…` (the component from the reported screenshot) all present.
- Compression still applied: main chunk is ~13.7K chars/line over 111 lines. JS payload grows 9.7 MB → 14 MB, only in profiling builds.
- `react-dom/profiling` alias still in effect (a `profiling-*.js` chunk is emitted).
- `auth-test-studio` builds successfully with the same result.
- `oxfmt --check` and `oxlint` pass on the changed files; `tsc --noEmit` for the studio reports the identical set of pre-existing errors on main and on this branch (none in the changed files).

### Notes for release

N/A – Internal only (dev studio tooling).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db4561f1-dd24-4b29-8b80-38dc5d25a923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db4561f1-dd24-4b29-8b80-38dc5d25a923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

