### PR TITLE
chore(deps): remove @sanity/styled-components override and restore styled-components

### DIFF
--- a/packages/sanity/src/core/components/StatusButton.tsx
+++ b/packages/sanity/src/core/components/StatusButton.tsx
@@ -38,11 +38,11 @@ export const StatusButton = forwardRef(function StatusButton(
 ) {
   const {
     disabled: disabledProp,
-    icon,
     'aria-label': label,
     mode = 'bleed',
-    text,
     tone,
+    // `text` and `icon` stay in `restProps` so the ButtonWithText | IconButton
+    // union stays correlated when spread onto the styled component.
     ...restProps
   } = props
 
@@ -57,8 +57,6 @@ export const StatusButton = forwardRef(function StatusButton(
       disabled={disabled}
       mode={mode}
       ref={ref}
-      text={text}
-      icon={icon}
     >
       {tone && <Dot style={dotStyle} />}
     </StyledButton>

--- a/packages/sanity/src/core/form/inputs/files/common/FileInputButton/FileInputButton.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/FileInputButton/FileInputButton.tsx
@@ -23,7 +23,9 @@ export const FileInputButton = forwardRef(function FileInputButton(
     Omit<HTMLProps<HTMLButtonElement>, 'as' | 'ref' | 'type' | 'value' | 'onSelect'>,
   forwardedRef: ForwardedRef<HTMLInputElement>,
 ) {
-  const {icon, id: idProp, accept, capture, multiple, onSelect, text, disabled, ...rest} = props
+  // `text` and `icon` stay in `rest` so the ButtonWithText | IconButton union
+  // stays correlated when spread onto the styled component.
+  const {id: idProp, accept, capture, multiple, onSelect, disabled, ...rest} = props
   const id = `${idProp || ''}-${useId()}`
 
   const handleChange = useCallback(
@@ -36,7 +38,7 @@ export const FileInputButton = forwardRef(function FileInputButton(
   )
 
   return (
-    <FileButton {...rest} icon={icon} text={text} htmlFor={id} disabled={disabled}>
+    <FileButton {...rest} htmlFor={id} disabled={disabled}>
       {/* Visibly hidden input */}
       <input
         data-testid="file-button-input"

--- a/packages/sanity/vitest.config.mts
+++ b/packages/sanity/vitest.config.mts
@@ -6,6 +6,13 @@ import viteReact, {reactCompilerPreset} from '@vitejs/plugin-react'
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    // styled-components turns off its fast CSSOM injection path ("speedy"
+    // mode) whenever NODE_ENV !== 'production' and appends CSS text nodes to
+    // <style> tags instead. jsdom reparses the whole stylesheet on every such
+    // insertion, which slows first mounts of styled-heavy trees down enough to
+    // trip default testing-library timeouts. Force the production injection
+    // path, which is also what the @sanity/styled-components fork always used.
+    env: {SC_DISABLE_SPEEDY: 'false'},
     globalSetup: ['./test/setup/global.ts'],
     setupFiles: ['./test/setup/environment.ts'],
     exclude: ['./src/_internal/cli', '**/*.browser.test.*'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ catalogs:
       specifier: ^6.1.3
       version: 6.1.3
     styled-components:
-      specifier: npm:@sanity/styled-components@^6.1.24
-      version: 6.1.24
+      specifier: ^6.4.4
+      version: 6.4.4
     vite:
       specifier: ^8.1.5
       version: 8.1.5
@@ -212,7 +212,7 @@ importers:
         version: link:../../packages/sanity
       styled-components:
         specifier: 'catalog:'
-        version: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
     devDependencies:
       '@vanilla-extract/vite-plugin':
         specifier: 'catalog:'
@@ -237,7 +237,7 @@ importers:
         version: link:../../packages/sanity
       styled-components:
         specifier: 'catalog:'
-        version: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
 
   dev/design-studio:
     dependencies:
@@ -246,7 +246,7 @@ importers:
         version: 5.2.0(react@19.2.8)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)
+        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -258,7 +258,7 @@ importers:
         version: link:../../packages/sanity
       styled-components:
         specifier: 'catalog:'
-        version: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
       vite:
         specifier: 'catalog:'
         version: 8.1.5(@types/node@24.13.3)(@vitejs/devtools@0.4.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -283,7 +283,7 @@ importers:
         version: link:../../packages/sanity
       styled-components:
         specifier: 'catalog:'
-        version: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
@@ -308,10 +308,10 @@ importers:
     dependencies:
       sanity-plugin-internationalized-array:
         specifier: ^5.1.21
-        version: 5.1.22(@emotion/is-prop-valid@1.4.0)(@sanity/assist@6.1.15)(@sanity/language-filter@5.0.11)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)
+        version: 5.1.22(@emotion/is-prop-valid@1.4.0)(@sanity/assist@6.1.15)(@sanity/language-filter@5.0.11)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)
       styled-components:
         specifier: 'catalog:'
-        version: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
       tsx:
         specifier: ^4.23.1
         version: 4.23.1
@@ -372,7 +372,7 @@ importers:
     dependencies:
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)
+        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -384,7 +384,7 @@ importers:
         version: link:../../packages/sanity
       styled-components:
         specifier: 'catalog:'
-        version: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -415,7 +415,7 @@ importers:
         version: 5.2.0(react@19.2.8)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)
+        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       '@visx/axis':
         specifier: ^4.0.0
         version: 4.0.0(@types/react@19.2.17)(react@19.2.8)
@@ -451,7 +451,7 @@ importers:
         version: link:../../packages/sanity
       styled-components:
         specifier: 'catalog:'
-        version: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
       vite:
         specifier: 'catalog:'
         version: 8.1.5(@types/node@24.13.3)(@vitejs/devtools@0.4.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -491,7 +491,7 @@ importers:
         version: link:../../packages/sanity
       styled-components:
         specifier: 'catalog:'
-        version: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
     devDependencies:
       rimraf:
         specifier: 'catalog:'
@@ -519,7 +519,7 @@ importers:
         version: link:../../packages/sanity
       styled-components:
         specifier: 'catalog:'
-        version: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
     devDependencies:
       rimraf:
         specifier: 'catalog:'
@@ -541,7 +541,7 @@ importers:
         version: link:../../packages/sanity
       styled-components:
         specifier: 'catalog:'
-        version: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
     devDependencies:
       rimraf:
         specifier: 'catalog:'
@@ -554,13 +554,13 @@ importers:
         version: link:../../packages/@repo/utils
       '@sanity/google-maps-input':
         specifier: ^6.1.7
-        version: 6.1.7(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)
+        version: 6.1.7(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)
       '@sanity/icons':
         specifier: ^5.2.0
         version: 5.2.0(react@19.2.8)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)
+        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       '@sanity/vision':
         specifier: workspace:*
         version: link:../../packages/@sanity/vision
@@ -578,22 +578,22 @@ importers:
         version: link:../../packages/sanity
       sanity-plugin-internationalized-array:
         specifier: ^5.1.21
-        version: 5.1.22(@emotion/is-prop-valid@1.4.0)(@sanity/assist@6.1.15)(@sanity/language-filter@5.0.11)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)
+        version: 5.1.22(@emotion/is-prop-valid@1.4.0)(@sanity/assist@6.1.15)(@sanity/language-filter@5.0.11)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)
       sanity-plugin-media:
         specifier: ^6.0.3
-        version: 6.0.4(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(@types/react@19.2.17)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)
+        version: 6.0.4(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.17)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)
       sanity-test-studio:
         specifier: workspace:*
         version: link:../test-studio
       styled-components:
         specifier: 'catalog:'
-        version: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
 
   dev/test-create-integration-studio:
     dependencies:
       '@sanity/code-input':
         specifier: ^7.3.0
-        version: 7.3.0(@babel/runtime@7.29.7)(@codemirror/theme-one-dark@6.1.3)(@sanity/styled-components@6.1.24)(codemirror@6.0.2)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)
+        version: 7.3.0(@babel/runtime@7.29.7)(@codemirror/theme-one-dark@6.1.3)(codemirror@6.0.2)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -605,7 +605,7 @@ importers:
         version: link:../../packages/sanity
       styled-components:
         specifier: 'catalog:'
-        version: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
     devDependencies:
       rimraf:
         specifier: 'catalog:'
@@ -630,7 +630,7 @@ importers:
         version: 5.0.2
       '@sanity/assist':
         specifier: ^6.1.15
-        version: 6.1.15(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)
+        version: 6.1.15(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)
       '@sanity/client':
         specifier: 'catalog:'
         version: 7.24.0
@@ -642,10 +642,10 @@ importers:
         version: 2.0.19(@sanity/client@7.24.0)(react@19.2.8)(sanity@packages+sanity)
       '@sanity/document-internationalization':
         specifier: ^6.2.23
-        version: 6.2.23(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity-plugin-internationalized-array@5.1.22)(sanity@packages+sanity)
+        version: 6.2.23(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity-plugin-internationalized-array@5.1.22)(sanity@packages+sanity)(styled-components@6.4.4)
       '@sanity/google-maps-input':
         specifier: ^6.1.7
-        version: 6.1.7(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)
+        version: 6.1.7(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)
       '@sanity/icons':
         specifier: ^5.2.0
         version: 5.2.0(react@19.2.8)
@@ -669,7 +669,7 @@ importers:
         version: link:../../packages/@sanity/types
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)
+        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       '@sanity/util':
         specifier: workspace:*
         version: link:../../packages/@sanity/util
@@ -681,7 +681,7 @@ importers:
         version: link:../../packages/@sanity/vision
       '@sanity/visual-editing':
         specifier: ^5.6.0
-        version: 5.6.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.24.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react@19.2.8)(typescript@6.0.3)
+        version: 5.6.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.24.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.4.4)(typescript@6.0.3)
       '@turf/helpers':
         specifier: ^7.3.5
         version: 7.3.5
@@ -726,16 +726,16 @@ importers:
         version: link:../../packages/sanity
       sanity-plugin-asset-source-unsplash:
         specifier: ^7.0.19
-        version: 7.0.19(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(@types/react@19.2.17)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)
+        version: 7.0.19(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.17)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)
       sanity-plugin-internationalized-array:
         specifier: ^5.1.21
-        version: 5.1.22(@emotion/is-prop-valid@1.4.0)(@sanity/assist@6.1.15)(@sanity/language-filter@5.0.11)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)
+        version: 5.1.22(@emotion/is-prop-valid@1.4.0)(@sanity/assist@6.1.15)(@sanity/language-filter@5.0.11)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)
       sanity-plugin-media:
         specifier: ^6.0.3
-        version: 6.0.4(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(@types/react@19.2.17)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)
+        version: 6.0.4(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.17)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)
       styled-components:
         specifier: 'catalog:'
-        version: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
     devDependencies:
       '@types/lodash-es':
         specifier: ^4.17.12
@@ -1424,7 +1424,7 @@ importers:
         version: 1.0.4
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)
+        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       '@sanity/uuid':
         specifier: ^3.0.3
         version: 3.0.3
@@ -1518,7 +1518,7 @@ importers:
         version: link:../../sanity
       styled-components:
         specifier: 'catalog:'
-        version: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
       vite:
         specifier: 'catalog:'
         version: 8.1.5(@types/node@24.13.3)(@vitejs/devtools@0.4.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
@@ -1698,7 +1698,7 @@ importers:
         version: link:../@sanity/types
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)
+        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       '@sanity/util':
         specifier: workspace:*
         version: link:../@sanity/util
@@ -1960,7 +1960,7 @@ importers:
         version: 1.0.0
       babel-plugin-styled-components:
         specifier: 'catalog:'
-        version: 2.3.0(@babel/core@7.29.7)(@sanity/styled-components@6.1.24)
+        version: 2.3.0(@babel/core@7.29.7)(styled-components@6.4.4)
       blob-polyfill:
         specifier: ^9.0.20240710
         version: 9.0.20240710
@@ -1981,7 +1981,7 @@ importers:
         version: 10.6.2(rxjs@7.8.2)
       styled-components:
         specifier: 'catalog:'
-        version: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
       tsx:
         specifier: ^4.23.1
         version: 4.23.1
@@ -2008,7 +2008,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       styled-components:
         specifier: 'catalog:'
-        version: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
 
   perf/bench:
     dependencies:
@@ -2062,10 +2062,10 @@ importers:
         version: link:../../packages/sanity
       sanity-plugin-internationalized-array:
         specifier: ^5.1.22
-        version: 5.1.22(@emotion/is-prop-valid@1.4.0)(@sanity/assist@6.1.15)(@sanity/language-filter@5.0.11)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)
+        version: 5.1.22(@emotion/is-prop-valid@1.4.0)(@sanity/assist@6.1.15)(@sanity/language-filter@5.0.11)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)
       styled-components:
         specifier: 'catalog:'
-        version: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
       tsx:
         specifier: ^4.23.1
         version: 4.23.1
@@ -2105,7 +2105,7 @@ importers:
         version: link:../../packages/sanity
       styled-components:
         specifier: 'catalog:'
-        version: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
     devDependencies:
       '@repo/tsconfig':
         specifier: workspace:*
@@ -6790,14 +6790,6 @@ packages:
   '@sanity/signed-urls@2.0.4':
     resolution: {integrity: sha512-wH7L9iOxQDVTa7COVEXoknalNgjpqxLJoOcZYQa3D/2JVEQOGUm82RgFVgZkKoclhQ8Y8dBby+KPkFoIDoUc1g==}
 
-  '@sanity/styled-components@6.1.24':
-    resolution: {integrity: sha512-082MiJ6tufcXeuJGHgNbT7PhUHdFkk9GGKrlbBmHSPNnlJUCzZ6nKJC9nwjmeIIo7gDupOHuY9gP5f+Mu0yE0Q==}
-    engines: {node: '>= 20'}
-    deprecated: No longer maintained. Please migrate to StyleX or vanilla-extract.
-    peerDependencies:
-      react: ^18.3 || ^19
-      react-dom: ^18.3 || ^19
-
   '@sanity/telemetry@1.1.0':
     resolution: {integrity: sha512-ch8fLXjQi1p49rIj7yrvx6tDb0320hnzwQJBOk4Ik7MkWCE7hUjtZrhtjQaSOXJd5n/piUjK+krKxy6wFkm5TA==}
     engines: {node: '>=16.0.0'}
@@ -7400,9 +7392,6 @@ packages:
 
   '@types/speakingurl@13.0.6':
     resolution: {integrity: sha512-ywkRHNHBwq0mFs/2HRgW6TEBAzH66G8f2Txzh1aGR0UC9ZoAUHfHxLZGDhwMpck4BpSnB61eNFIFmlV+TJ+KUA==}
-
-  '@types/stylis@4.2.7':
-    resolution: {integrity: sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==}
 
   '@types/tough-cookie@4.0.0':
     resolution: {integrity: sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==}
@@ -12906,9 +12895,6 @@ packages:
   shallow-equals@1.0.0:
     resolution: {integrity: sha512-xd/FKcdmfmMbyYCca3QTVEJtqUOGuajNzvAX6nt8dXILwjAIEkfHc4hI8/JMGApAmb7VeULO0Q30NTxnbH/15g==}
 
-  shallowequal@1.1.0:
-    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
-
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -13222,6 +13208,22 @@ packages:
 
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
+  styled-components@6.4.4:
+    resolution: {integrity: sha512-tJk5CmKUPMDoTsZQ8m0hHInBk9HFKUPSusqmbBuefDX+yUbMBWea2Ob/wdXFyHW8XZqXkprJscysAdKeGWNqlA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      css-to-react-native: '>= 3.2.0'
+      react: '>= 16.8.0'
+      react-dom: '>= 16.8.0'
+      react-native: '>= 0.68.0'
+    peerDependenciesMeta:
+      css-to-react-native:
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
 
   stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
@@ -18535,14 +18537,14 @@ snapshots:
 
   '@sanity/asset-utils@2.3.0': {}
 
-  '@sanity/assist@6.1.15(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)':
+  '@sanity/assist@6.1.15(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)':
     dependencies:
       '@portabletext/types': 4.0.2
       '@sanity/client': 7.24.0
       '@sanity/color': 3.0.6
       '@sanity/icons': 5.2.0(react@19.2.8)
       '@sanity/mutator': link:packages/@sanity/mutator
-      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)
+      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       date-fns: 4.4.0
       lodash-es: 4.18.1
       react: 19.2.8
@@ -18551,7 +18553,7 @@ snapshots:
       rxjs: 7.8.2
       rxjs-exhaustmap-with-trailing: 2.1.1(rxjs@7.8.2)
       sanity: link:packages/sanity
-      styled-components: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+      styled-components: 6.4.4(react-dom@19.2.8)(react@19.2.8)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react-is
@@ -18765,7 +18767,7 @@ snapshots:
       nanoid: 3.3.16
       rxjs: 7.8.2
 
-  '@sanity/code-input@7.3.0(@babel/runtime@7.29.7)(@codemirror/theme-one-dark@6.1.3)(@sanity/styled-components@6.1.24)(codemirror@6.0.2)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)':
+  '@sanity/code-input@7.3.0(@babel/runtime@7.29.7)(@codemirror/theme-one-dark@6.1.3)(codemirror@6.0.2)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)':
     dependencies:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/lang-java': 6.0.2
@@ -18781,12 +18783,12 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@sanity/icons': 5.2.0(react@19.2.8)
       '@sanity/lezer-groq': 1.0.4
-      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)
+      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       '@uiw/codemirror-themes': 4.25.11(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)
       '@uiw/react-codemirror': 4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.6)(codemirror@6.0.2)(react-dom@19.2.8)(react@19.2.8)
       react: 19.2.8
       sanity: link:packages/sanity
-      styled-components: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+      styled-components: 6.4.4(react-dom@19.2.8)(react@19.2.8)
     transitivePeerDependencies:
       - '@babel/runtime'
       - '@codemirror/autocomplete'
@@ -18870,19 +18872,19 @@ snapshots:
     dependencies:
       '@sanity/diff-match-patch': 3.2.0
 
-  '@sanity/document-internationalization@6.2.23(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity-plugin-internationalized-array@5.1.22)(sanity@packages+sanity)':
+  '@sanity/document-internationalization@6.2.23(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity-plugin-internationalized-array@5.1.22)(sanity@packages+sanity)(styled-components@6.4.4)':
     dependencies:
       '@sanity/icons': 5.2.0(react@19.2.8)
       '@sanity/mutator': link:packages/@sanity/mutator
-      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)
+      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       '@sanity/util': link:packages/@sanity/util
       '@sanity/uuid': 3.0.3
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       rxjs: 7.8.2
       sanity: link:packages/sanity
-      sanity-plugin-internationalized-array: 5.1.22(@emotion/is-prop-valid@1.4.0)(@sanity/assist@6.1.15)(@sanity/language-filter@5.0.11)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)
-      sanity-plugin-utils: 2.0.11(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)
+      sanity-plugin-internationalized-array: 5.1.22(@emotion/is-prop-valid@1.4.0)(@sanity/assist@6.1.15)(@sanity/language-filter@5.0.11)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)
+      sanity-plugin-utils: 2.0.11(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react-is
@@ -18913,10 +18915,10 @@ snapshots:
 
   '@sanity/generate-help-url@4.0.0': {}
 
-  '@sanity/google-maps-input@6.1.7(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)':
+  '@sanity/google-maps-input@6.1.7(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)':
     dependencies:
       '@sanity/icons': 5.2.0(react@19.2.8)
-      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)
+      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       '@vis.gl/react-google-maps': 1.9.0(react-dom@19.2.8)(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -18960,10 +18962,10 @@ snapshots:
 
   '@sanity/json-match@1.0.5': {}
 
-  '@sanity/language-filter@5.0.11(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)':
+  '@sanity/language-filter@5.0.11(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)':
     dependencies:
       '@sanity/icons': 5.2.0(react@19.2.8)
-      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)
+      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       react-rx: 4.2.3(react@19.2.8)(rxjs@7.8.2)
@@ -19204,17 +19206,6 @@ snapshots:
       '@noble/ed25519': 3.1.0
       '@noble/hashes': 2.2.0
 
-  '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)':
-    dependencies:
-      '@emotion/is-prop-valid': 1.4.0
-      '@emotion/unitless': 0.10.0
-      '@types/stylis': 4.2.7
-      csstype: 3.2.3
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      shallowequal: 1.1.0
-      stylis: 4.3.6
-
   '@sanity/telemetry@1.1.0(react@19.2.8)':
     dependencies:
       rxjs: 7.8.2
@@ -19228,7 +19219,7 @@ snapshots:
       '@actions/github': 9.1.1
       yaml: 2.9.0
 
-  '@sanity/ui@3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)':
+  '@sanity/ui@3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4)':
     dependencies:
       '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8)(react@19.2.8)
       '@juggle/resize-observer': 3.4.0
@@ -19241,7 +19232,7 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       react-is: 19.2.8
       react-refractor: 4.0.0(react@19.2.8)
-      styled-components: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+      styled-components: 6.4.4(react-dom@19.2.8)(react@19.2.8)
       use-effect-event: 2.0.3(react@19.2.8)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
@@ -19271,7 +19262,7 @@ snapshots:
     optionalDependencies:
       '@sanity/types': link:packages/@sanity/types
 
-  '@sanity/visual-editing@5.6.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.24.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react@19.2.8)(typescript@6.0.3)':
+  '@sanity/visual-editing@5.6.0(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.24.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.4.4)(typescript@6.0.3)':
     dependencies:
       '@sanity/comlink': 4.0.1
       '@sanity/icons': 5.2.0(react@19.2.8)
@@ -19279,7 +19270,7 @@ snapshots:
       '@sanity/presentation-comlink': 2.2.0(@sanity/client@7.24.0)(@sanity/types@packages+@sanity+types)
       '@sanity/preview-url-secret': 4.1.0(@sanity/client@7.24.0)
       '@sanity/types': link:packages/@sanity/types
-      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)
+      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       '@sanity/visual-editing-csm': 3.0.11(@sanity/client@7.24.0)(@sanity/types@packages+@sanity+types)(typescript@6.0.3)
       '@vercel/stega': 1.1.0
       dequal: 2.0.3
@@ -19289,7 +19280,7 @@ snapshots:
       react-is: 19.2.8
       rxjs: 7.8.2
       scroll-into-view-if-needed: 3.1.0
-      styled-components: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+      styled-components: 6.4.4(react-dom@19.2.8)(react@19.2.8)
       xstate: 5.32.5
     optionalDependencies:
       '@sanity/client': 7.24.0
@@ -19866,8 +19857,6 @@ snapshots:
   '@types/shallow-equals@1.0.3': {}
 
   '@types/speakingurl@13.0.6': {}
-
-  '@types/stylis@4.2.7': {}
 
   '@types/tough-cookie@4.0.0':
     optional: true
@@ -21224,14 +21213,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  babel-plugin-styled-components@2.3.0(@babel/core@7.29.7)(@sanity/styled-components@6.1.24):
+  babel-plugin-styled-components@2.3.0(@babel/core@7.29.7)(styled-components@6.4.4):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-module-imports': 7.29.7
       '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
       picomatch: 4.0.5
-      styled-components: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+      styled-components: 6.4.4(react-dom@19.2.8)(react@19.2.8)
     transitivePeerDependencies:
       - supports-color
 
@@ -26015,46 +26004,46 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  sanity-plugin-asset-source-unsplash@7.0.19(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(@types/react@19.2.17)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity):
+  sanity-plugin-asset-source-unsplash@7.0.19(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.17)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4):
     dependencies:
       '@sanity/icons': 5.2.0(react@19.2.8)
-      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)
+      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       lodash-es: 4.18.1
       react: 19.2.8
       react-photo-album: 3.6.0(@types/react@19.2.17)(react@19.2.8)
       sanity: link:packages/sanity
-      styled-components: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+      styled-components: 6.4.4(react-dom@19.2.8)(react@19.2.8)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@types/react'
       - react-dom
       - react-is
 
-  sanity-plugin-internationalized-array@5.1.22(@emotion/is-prop-valid@1.4.0)(@sanity/assist@6.1.15)(@sanity/language-filter@5.0.11)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity):
+  sanity-plugin-internationalized-array@5.1.22(@emotion/is-prop-valid@1.4.0)(@sanity/assist@6.1.15)(@sanity/language-filter@5.0.11)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4):
     dependencies:
       '@sanity/icons': 5.2.0(react@19.2.8)
-      '@sanity/language-filter': 5.0.11(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)
-      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)
+      '@sanity/language-filter': 5.0.11(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)
+      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       '@sanity/util': link:packages/@sanity/util
       lodash-es: 4.18.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       sanity: link:packages/sanity
     optionalDependencies:
-      '@sanity/assist': 6.1.15(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)
+      '@sanity/assist': 6.1.15(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react-is
       - styled-components
 
-  sanity-plugin-media@6.0.4(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(@types/react@19.2.17)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity):
+  sanity-plugin-media@6.0.4(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.17)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4):
     dependencies:
       '@hookform/resolvers': 4.1.3(react-hook-form@7.82.0)
       '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0)(react@19.2.8)
       '@sanity/client': 7.24.0
       '@sanity/color': 3.0.6
       '@sanity/icons': 5.2.0(react@19.2.8)
-      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)
+      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       '@sanity/uuid': 3.0.3
       '@tanem/react-nprogress': 5.0.63(react-dom@19.2.8)(react@19.2.8)
       copy-to-clipboard: 3.3.3
@@ -26076,7 +26065,7 @@ snapshots:
       redux-observable: 3.0.0-rc.2(redux@5.0.1)(rxjs@7.8.2)
       rxjs: 7.8.2
       sanity: link:packages/sanity
-      styled-components: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+      styled-components: 6.4.4(react-dom@19.2.8)(react@19.2.8)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
@@ -26084,18 +26073,18 @@ snapshots:
       - react-is
       - supports-color
 
-  sanity-plugin-utils@2.0.11(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity):
+  sanity-plugin-utils@2.0.11(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4):
     dependencies:
       '@sanity/asset-utils': 2.3.0
       '@sanity/icons': 5.2.0(react@19.2.8)
       '@sanity/image-url': 2.1.1
-      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)
+      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react-is@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       react-fast-compare: 3.2.2
       rxjs: 7.8.2
       sanity: link:packages/sanity
-      styled-components: '@sanity/styled-components@6.1.24(react-dom@19.2.8)(react@19.2.8)'
+      styled-components: 6.4.4(react-dom@19.2.8)(react@19.2.8)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react-is
@@ -26189,8 +26178,6 @@ snapshots:
       kind-of: 6.0.3
 
   shallow-equals@1.0.0: {}
-
-  shallowequal@1.1.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -26544,6 +26531,15 @@ snapshots:
   stubs@3.0.0: {}
 
   style-mod@4.1.3: {}
+
+  styled-components@6.4.4(react-dom@19.2.8)(react@19.2.8):
+    dependencies:
+      '@emotion/is-prop-valid': 1.4.0
+      csstype: 3.2.3
+      react: 19.2.8
+      stylis: 4.3.6
+    optionalDependencies:
+      react-dom: 19.2.8(react@19.2.8)
 
   stylis@4.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,7 +49,7 @@ catalog:
   react-dom: ^19.2.7
   react-is: ^19.2.7
   rimraf: ^6.1.3
-  styled-components: npm:@sanity/styled-components@^6.1.24
+  styled-components: ^6.4.4
   vite: ^8.1.5
   vitest: ^4.1.10
   vitest-browser-react: ^2.2.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The monorepo has been aliasing `styled-components` to the [`@sanity/styled-components`](https://github.com/sanity-io/styled-components-last-resort) fork since #9486, which existed to get concurrent-rendering-friendly style injection while upstream was dormant. Upstream is actively maintained again and 6.4 landed the equivalent performance work (render cache + synchronous injection, evaluated against the `useInsertionEffect` approach in [styled-components#4332](https://github.com/styled-components/styled-components/pull/4332)), so the catalog entry moves back to regular `styled-components@^6.4.4`.

Two follow-on fixes were needed to keep CI green:

- **jsdom test slowdown:** upstream disables its "speedy" CSSOM injection path whenever `NODE_ENV !== 'production'` and appends CSS text nodes instead, which jsdom reparses on every insertion. That made first mounts of styled-heavy trees (~2.3s vs ~0.4s with the fork, which always uses the speedy path) trip default testing-library timeouts in the variants suite. `packages/sanity/vitest.config.mts` now sets `SC_DISABLE_SPEEDY=false` to force the production injection path, matching the fork's behavior.
- **Typing regression:** upstream 6.4's `styled()` typings collapse discriminated prop unions differently than the fork's 6.1 typings; `StatusButton` and `FileInputButton` re-passed destructured `text`/`icon` individually, which decorrelated the `ButtonWithText | IconButton` union and failed `check:types`. They now keep those props in the rest spread.

### What to review

- `pnpm-workspace.yaml` catalog entry + regenerated, deduped `pnpm-lock.yaml` (no `@sanity/styled-components` references remain).
- `packages/sanity/vitest.config.mts` — the `SC_DISABLE_SPEEDY` env and its comment.
- `StatusButton.tsx` / `FileInputButton.tsx` — prop forwarding is behavior-preserving (same props end up on the styled component via the spread).

### Testing

- `pnpm build`, `pnpm test` (5133 passed, 0 failed), `pnpm check:types`, `pnpm check:format`, `pnpm check:oxlint`, `pnpm test:exports` all pass locally.
- Manually verified the test studio (`pnpm dev`) renders fully styled with upstream styled-components: `<style data-styled="active" data-styled-version="6.4.4">` in `<head>`, document editing, tooltips, and pane navigation all work.

[Studio home rendered with styled-components 6.4.4](https://cursor.com/agents/bc-d64eebf9-a2c5-4855-b397-2abdadff95b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_studio_home_styled_644.webp)

[studio_editing_with_upstream_styled_components.mp4](https://cursor.com/agents/bc-d64eebf9-a2c5-4855-b397-2abdadff95b2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio_editing_with_upstream_styled_components.mp4)

### Notes for release

N/A – monorepo-internal dependency change. Userland projects that aliased `styled-components@npm:@sanity/styled-components` can keep doing so or switch back to regular `styled-components`; the `sanity` package's peer dependency range (`^6.1.15`) is unchanged.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d64eebf9-a2c5-4855-b397-2abdadff95b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d64eebf9-a2c5-4855-b397-2abdadff95b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

