### PR TITLE
chore(deps): upgrade web-vitals to v6

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -232,7 +232,7 @@
     "use-hot-module-reload": "^2.0.0",
     "use-sync-external-store": "^1.6.0",
     "uuid": "^14.0.1",
-    "web-vitals": "^5.3.0",
+    "web-vitals": "^6.0.0",
     "xstate": "^5.32.5"
   },
   "devDependencies": {

--- a/packages/sanity/src/core/studio/telemetry/useWebVitalsTelemetry.ts
+++ b/packages/sanity/src/core/studio/telemetry/useWebVitalsTelemetry.ts
@@ -81,9 +81,14 @@ export function useWebVitalsTelemetry(): void {
     // Measures responsiveness - the worst interaction latency
     // This runs alongside the existing INP hook during migration
     // Attribution: interactionTarget, inputDelay, processingDuration, etc.
-    onINP((metric) => {
-      telemetry.log(PerformanceINPMeasuredV2, metric)
-    })
+    // v6 defaults includeProcessedEventEntries to false; opt in to keep
+    // processedEventEntries in attribution (same coverage as v5).
+    onINP(
+      (metric) => {
+        telemetry.log(PerformanceINPMeasuredV2, metric)
+      },
+      {includeProcessedEventEntries: true},
+    )
 
     // No cleanup function needed:
     // - web-vitals manages its own PerformanceObserver lifecycle

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1898,8 +1898,8 @@ importers:
         specifier: ^14.0.1
         version: 14.0.1
       web-vitals:
-        specifier: ^5.3.0
-        version: 5.3.0
+        specifier: ^6.0.0
+        version: 6.0.0
       xstate:
         specifier: ^5.32.5
         version: 5.32.5
@@ -14003,8 +14003,8 @@ packages:
   web-vitals@0.2.4:
     resolution: {integrity: sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==}
 
-  web-vitals@5.3.0:
-    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
+  web-vitals@6.0.0:
+    resolution: {integrity: sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -27411,7 +27411,7 @@ snapshots:
 
   web-vitals@0.2.4: {}
 
-  web-vitals@5.3.0: {}
+  web-vitals@6.0.0: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -112,6 +112,8 @@ minimumReleaseAgeExclude:
   - 'verkit'
   - 'vitest'
   - 'vite'
+  # Fresh major; exclude so install can resolve before the age gate would allow it
+  - 'web-vitals'
   # covers yuku-ast/yuku-codegen/yuku-parser, which ship together with rolldown-plugin-dts
   - 'yuku-*'
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Replaces https://github.com/sanity-io/sanity/pull/13662.

`web-vitals` v6 flips `includeProcessedEventEntries` to default `false`, which would silently drop `processedEventEntries` from Studio INP attribution telemetry. This PR upgrades to `^6.0.0` and opts `onINP` back into that option so we keep the same diagnostic coverage as v5.

Also adds `web-vitals` to `minimumReleaseAgeExclude` so the fresh major can resolve under the 3-day age gate (same fix needed on the Renovate PR).

### What to review

- `useWebVitalsTelemetry`: `onINP(..., {includeProcessedEventEntries: true})`
- `pnpm-workspace.yaml` age-exclude entry
- Dependency bump is scoped to `web-vitals` only (no unrelated lockfile churn)

### Testing

- Confirmed installed package is `web-vitals@6.0.0`
- Confirmed v6 source requires the opt-in (`if (opts.includeProcessedEventEntries)`)
- oxlint/oxfmt clean on changed files
- No automated test for RUM callbacks; behavior is covered by the explicit options pass-through

### Notes for release

N/A – Internal telemetry/deps only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad80cf04-6ad4-4293-8c17-cc0bd2abdc02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad80cf04-6ad4-4293-8c17-cc0bd2abdc02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

