### PR TITLE
chore(sanity): variant creation in document group inventory

### DIFF
--- a/packages/sanity/src/_exports/index.ts
+++ b/packages/sanity/src/_exports/index.ts
@@ -99,6 +99,7 @@ export {
   type CommandListRenderItemCallback,
 } from '../core/components/commandList/types'
 export {ContextMenuButton} from '../core/components/contextMenuButton/ContextMenuButton'
+export {Delay} from '../core/components/Delay'
 export {DocumentStatus} from '../core/components/documentStatus/DocumentStatus'
 export {DocumentStatusIndicator} from '../core/components/documentStatusIndicator/DocumentStatusIndicator'
 export {ErrorActions, type ErrorActionsProps} from '../core/components/errorActions/ErrorActions'

--- a/packages/sanity/src/core/components/Delay.tsx
+++ b/packages/sanity/src/core/components/Delay.tsx
@@ -1,5 +1,10 @@
 import {useEffect, useState} from 'react'
 
+/**
+ * Renders its children after the given delay has elapsed.
+ *
+ * @internal
+ */
 export function Delay({
   children,
   ms = 0,

--- a/packages/sanity/src/core/documentGroupInventory/components/CreateVariant/CreateVariant.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/CreateVariant/CreateVariant.tsx
@@ -1,0 +1,36 @@
+import {useSelector} from '@xstate/react'
+import {type ComponentType} from 'react'
+import {type ActorRefFromLogic} from 'xstate'
+
+import {type selectionMachine} from '../../machines/selectionMachine'
+import {type variantCreationMachine} from '../../machines/variantCreationMachine'
+import {SelectBundle} from './SelectBundle'
+import {SelectVariantDefinition} from './SelectVariantDefinition'
+
+interface Props {
+  variantCreationRef: ActorRefFromLogic<typeof variantCreationMachine>
+  selectionRef: ActorRefFromLogic<typeof selectionMachine>
+}
+
+export const CreateVariant: ComponentType<Props> = ({variantCreationRef, selectionRef}) => {
+  const hasSelectedVariantId = useSelector(
+    variantCreationRef,
+    ({context}) => typeof context.selectedVariantId !== 'undefined',
+  )
+
+  const hasSelectedBundle = useSelector(
+    variantCreationRef,
+    ({context}) => typeof context.selectedBundle !== 'undefined',
+  )
+
+  return (
+    <>
+      {!hasSelectedVariantId && !hasSelectedBundle && (
+        <SelectVariantDefinition variantCreationRef={variantCreationRef} />
+      )}
+      {hasSelectedVariantId && (
+        <SelectBundle variantCreationRef={variantCreationRef} selectionRef={selectionRef} />
+      )}
+    </>
+  )
+}

--- a/packages/sanity/src/core/documentGroupInventory/components/CreateVariant/SelectBundle.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/CreateVariant/SelectBundle.tsx
@@ -1,0 +1,224 @@
+import {type ReleaseDocument} from '@sanity/client/stega'
+import ChevronLeftIcon from '@sanity/icons/ChevronLeft'
+// oxlint-disable-next-line no-restricted-imports -- `Button` requires fine-grained control
+import {Button, Flex, Label, Spinner, Stack, Text} from '@sanity/ui'
+import {useSelector} from '@xstate/react'
+import {type ComponentType} from 'react'
+import {styled} from 'styled-components'
+import {type ActorRefFromLogic} from 'xstate'
+
+import {Delay} from '../../../components/Delay'
+import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {studioLocaleNamespace} from '../../../i18n/localeNamespaces'
+import {useSetVariant} from '../../../perspective/useSetVariant'
+import {ReleaseAvatarIcon} from '../../../releases/components/ReleaseAvatar'
+import {getReleaseDocumentIdFromReleaseId} from '../../../releases/util/getReleaseDocumentIdFromReleaseId'
+import {getReleaseIdFromReleaseDocumentId} from '../../../releases/util/getReleaseIdFromReleaseDocumentId'
+import {isNotArchivedRelease, isReleaseScheduledOrScheduling} from '../../../releases/util/util'
+import {getVariantTitle} from '../../../variants/tool/util'
+import {type selectionMachine} from '../../machines/selectionMachine'
+import {type variantCreationMachine} from '../../machines/variantCreationMachine'
+import {Body} from '../Body'
+import {Header} from '../Header'
+import {TextButton} from '../TextButton'
+
+interface Props {
+  variantCreationRef: ActorRefFromLogic<typeof variantCreationMachine>
+  selectionRef: ActorRefFromLogic<typeof selectionMachine>
+}
+
+export const SelectBundle: ComponentType<Props> = ({variantCreationRef, selectionRef}) => {
+  const {t} = useTranslation(studioLocaleNamespace)
+  const setVariant = useSetVariant()
+
+  const selectedVariantDefinition = useSelector(variantCreationRef, ({context}) =>
+    context.variants?.variants.get(context.selectedVariantId ?? ''),
+  )
+
+  const bundles = useSelector(
+    variantCreationRef,
+    ({context}) => context.releases?.releases ?? new Map<string, ReleaseDocument>(),
+  )
+
+  const isVariantCreationPending = useSelector(variantCreationRef, (snapshot) =>
+    snapshot.matches({active: 'creating'}),
+  )
+
+  const canSelectBundle = useSelector(variantCreationRef, (snapshot) =>
+    snapshot.can({type: 'createVariant.selectBundle', bundle: undefined}),
+  )
+
+  const selectedBundle = useSelector(variantCreationRef, ({context}) => context.selectedBundle)
+
+  const existingVariants = useSelector(selectionRef, ({context}) => context.variants)
+
+  const headerTitle =
+    typeof selectedVariantDefinition === 'undefined'
+      ? t('document-group.create-variant')
+      : t('document-group.create-variant.for-target', {
+          variantDefinitionName: getVariantTitle(selectedVariantDefinition),
+        })
+
+  const existingBundles = existingVariants.reduce((bundleKeys, variant) => {
+    const variantId = variant.document?._system.variant?._ref
+
+    if (typeof variantId !== 'undefined' && variantId === selectedVariantDefinition?._id) {
+      bundleKeys.add(
+        variant.document?._system.bundleId ??
+          variant.document?._system.release?._ref ??
+          'published',
+      )
+    }
+
+    return bundleKeys
+  }, new Set<string>())
+
+  return (
+    <>
+      <Header>
+        <TextButton
+          title={headerTitle}
+          onClick={() =>
+            variantCreationRef.send({
+              type: 'createVariant.selectVariant',
+              variantId: undefined,
+            })
+          }
+        >
+          <Text size={1} weight="medium">
+            <Flex gap={2} align="center">
+              <ChevronLeftIcon />
+              <TruncatedText>{headerTitle}</TruncatedText>
+            </Flex>
+          </Text>
+        </TextButton>
+      </Header>
+      <Body>
+        <Stack gap={4}>
+          {!existingBundles.has('drafts') && (
+            <Stack gap={3}>
+              <Label as="h3">{t('document-group.create-variant.target-drafts')}</Label>
+              <Stack gap={1}>
+                <Button
+                  mode="bleed"
+                  justify="flex-start"
+                  paddingX={3}
+                  paddingY={3}
+                  text={t('release.chip.global.drafts')}
+                  // oxlint-disable-next-line @sanity/i18n/no-attribute-string-literals -- this string is not shown to users
+                  icon={<ReleaseAvatarIcon release="drafts" />}
+                  iconRight={
+                    isVariantCreationPending &&
+                    selectedBundle?.type === 'drafts' && (
+                      <Delay ms={500}>
+                        <Spinner />
+                      </Delay>
+                    )
+                  }
+                  disabled={!canSelectBundle}
+                  onClick={() => {
+                    variantCreationRef.send({
+                      type: 'createVariant.selectBundle',
+                      bundle: {type: 'drafts'},
+                    })
+
+                    variantCreationRef.send({
+                      type: 'createVariant.confirm',
+                    })
+                  }}
+                />
+              </Stack>
+            </Stack>
+          )}
+          <Stack gap={3}>
+            <Label as="h3">{t('document-group.create-variant.target-releases')}</Label>
+            <Stack gap={1}>
+              {[...bundles.entries()]
+                .filter(
+                  ([, bundle]) =>
+                    bundle.state !== 'published' &&
+                    isNotArchivedRelease(bundle) &&
+                    !isReleaseScheduledOrScheduling(bundle) &&
+                    !existingBundles.has(getReleaseIdFromReleaseDocumentId(bundle._id)),
+                )
+                .map(([id, bundle]) => (
+                  <Button
+                    key={id}
+                    mode="bleed"
+                    justify="flex-start"
+                    paddingX={3}
+                    paddingY={3}
+                    text={bundle.metadata.title ?? bundle._id}
+                    icon={<ReleaseAvatarIcon release={bundle} />}
+                    iconRight={
+                      isVariantCreationPending &&
+                      selectedBundle?.type === 'release' &&
+                      selectedBundle.releaseId === id && (
+                        <Delay ms={500}>
+                          <Spinner />
+                        </Delay>
+                      )
+                    }
+                    disabled={!canSelectBundle}
+                    onClick={() => {
+                      variantCreationRef.send({
+                        type: 'createVariant.selectBundle',
+                        bundle: {type: 'release', releaseId: id},
+                      })
+
+                      variantCreationRef.send({
+                        type: 'createVariant.confirm',
+                      })
+                    }}
+                  />
+                ))}
+            </Stack>
+          </Stack>
+          {existingBundles.size !== 0 && (
+            <Stack gap={3}>
+              <Label as="h3">{t('document-group.create-variant.view-existing-variants')}</Label>
+              <Stack gap={1}>
+                {[...existingBundles.values()].map((bundleKey) => {
+                  const bundle = bundles.get(getReleaseDocumentIdFromReleaseId(bundleKey))
+
+                  const bundleTitle =
+                    bundleKey === 'drafts'
+                      ? t('release.chip.draft')
+                      : bundleKey === 'published'
+                        ? t('release.chip.published')
+                        : (bundle?.metadata.title ?? bundle?._id)
+
+                  return (
+                    <Button
+                      key={bundleKey}
+                      mode="bleed"
+                      justify="flex-start"
+                      paddingX={3}
+                      paddingY={3}
+                      text={bundleTitle ?? bundleKey}
+                      icon={typeof bundle !== 'undefined' && <ReleaseAvatarIcon release={bundle} />}
+                      disabled={!canSelectBundle}
+                      onClick={() =>
+                        setVariant({
+                          perspective: bundleKey,
+                          variantId: selectedVariantDefinition?._id,
+                        })
+                      }
+                    />
+                  )
+                })}
+              </Stack>
+            </Stack>
+          )}
+        </Stack>
+      </Body>
+    </>
+  )
+}
+
+const TruncatedText = styled.span`
+  overflow: hidden;
+  min-inline-size: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`

--- a/packages/sanity/src/core/documentGroupInventory/components/CreateVariant/SelectVariantDefinition.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/CreateVariant/SelectVariantDefinition.tsx
@@ -1,0 +1,68 @@
+import ChevronLeftIcon from '@sanity/icons/ChevronLeft'
+// oxlint-disable-next-line no-restricted-imports -- `Button` requires fine-grained control.
+import {Button, Flex, Stack, Text} from '@sanity/ui'
+import {useSelector} from '@xstate/react'
+import {type ComponentType} from 'react'
+import {type ActorRefFromLogic} from 'xstate'
+
+import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {studioLocaleNamespace} from '../../../i18n/localeNamespaces'
+import {RhombusIcon} from '../../../variants/plugin/components/PersonalizationIcons'
+import {getVariantTitle} from '../../../variants/tool/util'
+import {type SystemVariant} from '../../../variants/types'
+import {type variantCreationMachine} from '../../machines/variantCreationMachine'
+import {Body} from '../Body'
+import {Header} from '../Header'
+import {TextButton} from '../TextButton'
+
+interface Props {
+  variantCreationRef: ActorRefFromLogic<typeof variantCreationMachine>
+}
+
+export const SelectVariantDefinition: ComponentType<Props> = ({variantCreationRef}) => {
+  const {t} = useTranslation(studioLocaleNamespace)
+
+  const variantDefinitions = useSelector(
+    variantCreationRef,
+    ({context}) => context.variants?.variants ?? new Map<string, SystemVariant>(),
+  )
+
+  return (
+    <>
+      <Header>
+        <TextButton
+          title={t('document-group.create-variant')}
+          onClick={() => variantCreationRef.send({type: 'createVariant.cancel'})}
+        >
+          <Text size={1} weight="medium">
+            <Flex gap={2} align="center">
+              <ChevronLeftIcon />
+              {t('document-group.create-variant')}
+            </Flex>
+          </Text>
+        </TextButton>
+      </Header>
+      <Body>
+        <Stack gap={1}>
+          {[...variantDefinitions.entries()].map(([id, variantDefinition]) => (
+            <Button
+              key={id}
+              mode="bleed"
+              justify="flex-start"
+              paddingX={3}
+              paddingY={3}
+              icon={RhombusIcon}
+              text={getVariantTitle(variantDefinition)}
+              onClick={() =>
+                variantCreationRef.send({
+                  type: 'createVariant.selectVariant',
+                  variantId: id,
+                })
+              }
+            />
+          ))}
+        </Stack>
+      </Body>
+    </>
+  )
+}

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -5,12 +5,27 @@ import {SearchIcon} from '@sanity/icons/Search'
 import {TrashIcon} from '@sanity/icons/Trash'
 import {type SanityDocumentLike} from '@sanity/types'
 import {Card, Flex, PortalProvider, Stack, Text, TextInput} from '@sanity/ui'
-import {getTheme_v2 as getThemeV2} from '@sanity/ui/theme'
 import {useActorRef, useSelector} from '@xstate/react'
-import {type ComponentType, useMemo, type ChangeEvent, useState, useEffect} from 'react'
+import {
+  type ComponentType,
+  useMemo,
+  type ChangeEvent,
+  useState,
+  useEffect,
+  useLayoutEffect,
+} from 'react'
 import {useObservable} from 'react-rx'
-import {combineLatest, debounceTime, map, type Observable, of, startWith, Subject} from 'rxjs'
-import {styled, css} from 'styled-components'
+import {
+  combineLatest,
+  debounceTime,
+  filter,
+  firstValueFrom,
+  map,
+  type Observable,
+  startWith,
+  Subject,
+  timeout,
+} from 'rxjs'
 import {type ActorRefFromLogic, fromObservable, fromPromise} from 'xstate'
 
 import {Button} from '../../../ui-components/button/Button'
@@ -35,6 +50,7 @@ import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseI
 import {useReleasesToolAvailable} from '../../schedules/hooks/useReleasesToolAvailable'
 import {isAgentBundleName} from '../../store/agent/createAgentBundlesStore'
 import {useAgentBundlesStore} from '../../store/agent/useAgentBundles'
+import {useDocumentStore} from '../../store/datastores'
 import {useWorkspace} from '../../studio/workspace'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
 import {
@@ -46,15 +62,14 @@ import {
   type SystemBundle,
 } from '../../util/draftUtils'
 import {readVersionType} from '../../util/versionsUtils'
-import {type VariantStoreState} from '../../variants/store/reducer'
+import {useVariantDocumentOperations} from '../../variants/hooks/useVariantDocumentOperations'
+import {CreateVariantIcon} from '../../variants/plugin/components/PersonalizationIcons'
 import {useVariantsStore} from '../../variants/store/useVariantsStore'
 import {isVariantId} from '../../variants/types'
 import {deletionMachine, type ReferringDocuments} from '../machines/deletionMachine'
-import {
-  documentGroupInventoryMachine,
-  type VariantSet as VariantSetType,
-} from '../machines/documentGroupInventoryMachine'
+import {documentGroupInventoryMachine} from '../machines/documentGroupInventoryMachine'
 import {selectionMachine, type Variant} from '../machines/selectionMachine'
+import {variantCreationMachine} from '../machines/variantCreationMachine'
 import {
   type DocumentGroupInventoryPerspectiveList,
   type DocumentGroupInventoryReferencePreviewLinkProps,
@@ -62,8 +77,10 @@ import {
 import {Body} from './Body'
 import {ConfirmDeleteDialog} from './ConfirmDeleteDialog'
 import {Container} from './Container'
+import {CreateVariant} from './CreateVariant/CreateVariant'
 import {Footer} from './Footer'
 import {Header} from './Header'
+import {TextButton} from './TextButton'
 import {StatusBadge} from './VariantSet/StatusBadge'
 import {VariantCheckbox} from './VariantSet/VariantCheckbox'
 import {VariantSet} from './VariantSet/VariantSet'
@@ -130,6 +147,8 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
   const [menuPortalElement, setMenuPortalElement] = useState<HTMLDivElement | null>(null)
   const {feedbackDialogOpened} = useFeedbackTelemetry()
   const setVariant = useSetVariant()
+  const {createVariantDocument} = useVariantDocumentOperations()
+  const documentStore = useDocumentStore()
 
   const filterString = useMemo(
     () =>
@@ -192,101 +211,205 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
           }),
         [referringDocuments$, client],
       ),
+      variantCreationMachine: useMemo(
+        () =>
+          variantCreationMachine.provide({
+            actors: {
+              variants: fromObservable(() => variants),
+              releases: fromObservable(() => releases),
+              createVariant: fromPromise(async ({input, signal}) => {
+                const bundleId =
+                  typeof input.bundle === 'string'
+                    ? undefined
+                    : getReleaseIdFromReleaseDocumentId(input.bundle._id)
+
+                const editStateSlot =
+                  typeof input.bundle === 'string'
+                    ? input.bundle === ('drafts' satisfies SystemBundle)
+                      ? 'draft'
+                      : 'published'
+                    : 'version'
+
+                const readTargetPair = documentStore.pair
+                  .editState(getPublishedId(documentId), documentType, bundleId)
+                  .pipe(
+                    filter(({ready}) => ready),
+                    timeout({first: 30_000}),
+                  )
+
+                const targetPair = await firstValueFrom(readTargetPair)
+                const baseVariant = targetPair[editStateSlot]
+
+                // If there is no base variant, create an empty variant.
+                if (baseVariant === null) {
+                  await createVariantDocument({
+                    documentGroupId: getPublishedId(documentId),
+                    document: {
+                      _type: documentType,
+                    },
+                    variant: input.variantDefinition,
+                    selectedPerspective: input.bundle,
+                    signal,
+                  })
+                }
+
+                // If there is a base variant, create a variant based on it.
+                if (baseVariant !== null) {
+                  await createVariantDocument({
+                    documentGroupId: getPublishedId(documentId),
+                    baseId: baseVariant._id,
+                    variant: input.variantDefinition,
+                    selectedPerspective: input.bundle,
+                    signal,
+                  })
+                }
+
+                // TODO: Would this be better encapsulated as a machine effect?
+                setVariant({
+                  variantId: input.variantDefinition._id,
+                  perspective:
+                    typeof input.bundle === 'string'
+                      ? input.bundle
+                      : getReleaseIdFromReleaseDocumentId(input.bundle._id),
+                })
+              }),
+            },
+          }),
+        [
+          variants,
+          releases,
+          createVariantDocument,
+          setVariant,
+          documentType,
+          documentId,
+          documentStore.pair,
+        ],
+      ),
     },
   })
 
   const selectionRef = useSelector(inventoryRef, ({context}) => context.selectionRef)
   const deletionRef = useSelector(inventoryRef, ({context}) => context.deletionRef)
+  const variantCreationRef = useSelector(inventoryRef, ({context}) => context.variantCreationRef)
+  const metaState = useSelector(inventoryRef, ({context}) => context.metaState)
 
   const selectionCount = useSelector(selectionRef, ({context}) => context.selectedIds.size)
   const isReadOnly = useSelector(selectionRef, (snapshot) => snapshot.matches('readonly'))
   const isDeletionActive = useSelector(deletionRef, (snapshot) => snapshot.matches('active'))
   const isFeedbackActive = useSelector(inventoryRef, (snapshot) => snapshot.matches('feedback'))
 
+  const isVariantCreationActive = useSelector(inventoryRef, (snapshot) =>
+    snapshot.matches('creatingVariant'),
+  )
+
+  const isVariantCreationPending = useSelector(variantCreationRef, (snapshot) =>
+    snapshot.matches({active: 'creating'}),
+  )
+
   const canRequestDeletion = useSelector(deletionRef, (machine) =>
     machine.can({type: 'delete.request'}),
   )
 
-  const hasFilter = useSelector(
-    selectionRef,
-    ({context}) => typeof context.filterString === 'string',
-  )
+  const [isActive, setIsActive] = useState<boolean>(false)
+
+  useLayoutEffect(() => {
+    const frame = requestAnimationFrame(() => setIsActive(metaState === 'ready'))
+    return () => cancelAnimationFrame(frame)
+  }, [metaState])
 
   usePreserveIntrinsicBlockSize({
     element: containerElement,
-    isActive: hasFilter,
+    isActive,
   })
 
   return (
     <>
       <Container ref={setContainerElement} data-testid="document-group-inventory">
-        <Header>
-          <Stack gap={4}>
-            <Flex gap={4} align="center" justify="flex-end">
-              <TextButton
-                onClick={() => inventoryRef.send({type: 'feedback.begin'})}
-                title={feedbackT('feedback.menu-item')}
-                aria-label={feedbackT('feedback.menu-item')}
-              >
-                <Text size={1}>
-                  <FeedbackIcon />
-                </Text>
-              </TextButton>
-              <TextButton
+        {(isVariantCreationActive || isVariantCreationPending) && (
+          <CreateVariant variantCreationRef={variantCreationRef} selectionRef={selectionRef} />
+        )}
+        {!isVariantCreationActive && (
+          <>
+            <Header>
+              <Stack gap={4}>
+                <Flex gap={4} align="center" justify="flex-end">
+                  <TextButton
+                    onClick={() => inventoryRef.send({type: 'feedback.begin'})}
+                    title={feedbackT('feedback.menu-item')}
+                    aria-label={feedbackT('feedback.menu-item')}
+                  >
+                    <Text size={1}>
+                      <FeedbackIcon />
+                    </Text>
+                  </TextButton>
+                  <TextButton
+                    onClick={requestClose}
+                    title={t('document-group-inventory.action.cancel')}
+                    aria-label={t('document-group-inventory.action.cancel')}
+                  >
+                    <Text size={1}>
+                      <CloseIcon />
+                    </Text>
+                  </TextButton>
+                </Flex>
+                <search>
+                  <TextInput
+                    name={t('document-group-inventory.filter-string.label', {
+                      subject: t('document-group.subject.version_other'),
+                    })}
+                    placeholder={t('document-group-inventory.filter-string.label', {
+                      subject: t('document-group.subject.version_other'),
+                    })}
+                    icon={<SearchIcon />}
+                    readOnly={isReadOnly}
+                    onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                      filterStringEvent.next(event)
+                    }
+                  />
+                </search>
+              </Stack>
+            </Header>
+            <Body>
+              {schema && (
+                <Select
+                  machine={selectionRef}
+                  inventoryRef={inventoryRef}
+                  documentId={documentId}
+                  documentType={documentType}
+                  menuPortalElement={menuPortalElement}
+                  perspectiveList={perspectiveList}
+                  onPrimaryAction={setVariant}
+                />
+              )}
+            </Body>
+            <Footer>
+              <Button
+                text={t('document-group-inventory.action.cancel')}
+                size="large"
+                mode="bleed"
                 onClick={requestClose}
-                title={t('document-group-inventory.action.cancel')}
-                aria-label={t('document-group-inventory.action.cancel')}
-              >
-                <Text size={1}>
-                  <CloseIcon />
-                </Text>
-              </TextButton>
-            </Flex>
-            <search>
-              <TextInput
-                name={t('document-group-inventory.filter-string.label', {
-                  subject: t('document-group.subject.version_other'),
-                })}
-                placeholder={t('document-group-inventory.filter-string.label', {
-                  subject: t('document-group.subject.version_other'),
-                })}
-                icon={<SearchIcon />}
-                readOnly={isReadOnly}
-                onChange={(event: ChangeEvent<HTMLInputElement>) => filterStringEvent.next(event)}
               />
-            </search>
-          </Stack>
-        </Header>
-        <Body>
-          {schema && (
-            <Select
-              machine={selectionRef}
-              inventoryRef={inventoryRef}
-              documentId={documentId}
-              documentType={documentType}
-              menuPortalElement={menuPortalElement}
-              perspectiveList={perspectiveList}
-              onPrimaryAction={setVariant}
-            />
-          )}
-        </Body>
-        <Footer>
-          <Button
-            text={t('document-group-inventory.action.cancel')}
-            size="large"
-            mode="bleed"
-            onClick={requestClose}
-          />
-          {canRequestDeletion && (
-            <Button
-              text={t('document-group.delete.confirm-button.text', {count: selectionCount})}
-              onClick={() => deletionRef.send({type: 'delete.request'})}
-              tone="critical"
-              size="large"
-              icon={TrashIcon}
-            />
-          )}
-        </Footer>
+              {variantsEnabled && (
+                <Button
+                  text={t('document-group.create-variant')}
+                  tone="suggest"
+                  size="large"
+                  icon={CreateVariantIcon}
+                  onClick={() => variantCreationRef.send({type: 'createVariant.request'})}
+                />
+              )}
+              {canRequestDeletion && (
+                <Button
+                  text={t('document-group.delete.confirm-button.text', {count: selectionCount})}
+                  onClick={() => deletionRef.send({type: 'delete.request'})}
+                  tone="critical"
+                  size="large"
+                  icon={TrashIcon}
+                />
+              )}
+            </Footer>
+          </>
+        )}
       </Container>
       <div ref={setMenuPortalElement} />
       {isDeletionActive && (
@@ -618,26 +741,3 @@ function usePreserveIntrinsicBlockSize({
     return () => {}
   }, [element, currentSize, isActive])
 }
-
-const TextButton = styled.button(({theme}) => {
-  const {color} = getThemeV2(theme)
-
-  return css`
-    display: inline-block;
-    appearance: none;
-    border: 0;
-    margin: 0;
-    padding: 0;
-    outline: none;
-    all: unset;
-    color: ${color.button.ghost.neutral.enabled.fg};
-
-    * {
-      color: inherit;
-    }
-
-    svg[data-sanity-icon] {
-      color: currentColor;
-    }
-  `
-})

--- a/packages/sanity/src/core/documentGroupInventory/components/Header.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/Header.tsx
@@ -5,6 +5,7 @@ export const Header = styled.div(({theme}) => {
   const {space} = getThemeV2(theme)
 
   return css`
+    min-inline-size: 0;
     padding-inline: ${space[4]}px;
     padding-block-start: ${space[4]}px;
     padding-block-end: calc(${space[5]}px * 0.5);

--- a/packages/sanity/src/core/documentGroupInventory/components/TextButton.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/TextButton.tsx
@@ -1,0 +1,26 @@
+import {getTheme_v2 as getThemeV2} from '@sanity/ui/theme'
+import {css, styled} from 'styled-components'
+
+export const TextButton = styled.button(({theme}) => {
+  const {color} = getThemeV2(theme)
+
+  return css`
+    all: unset;
+    display: inline-block;
+    max-inline-size: 100%;
+    appearance: none;
+    border: 0;
+    margin: 0;
+    padding: 0;
+    outline: none;
+    color: ${color.button.ghost.neutral.enabled.fg};
+
+    * {
+      color: inherit;
+    }
+
+    svg[data-sanity-icon] {
+      color: currentColor;
+    }
+  `
+})

--- a/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.test.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.test.ts
@@ -1,5 +1,5 @@
 import {type MultipleMutationResult, type ReleaseDocument} from '@sanity/client'
-import {BehaviorSubject, of} from 'rxjs'
+import {BehaviorSubject, isObservable, of, type Observable} from 'rxjs'
 import {describe, expect, it, vi} from 'vitest'
 import {createActor, fromObservable, fromPromise} from 'xstate'
 
@@ -10,6 +10,7 @@ import {getPublishedId, getVersionFromId, isDraftId, isVersionId} from '../../ut
 import {deletionMachine} from './deletionMachine'
 import {documentGroupInventoryMachine, type Meta} from './documentGroupInventoryMachine'
 import {selectionMachine} from './selectionMachine'
+import {variantCreationMachine} from './variantCreationMachine'
 
 interface IncomingReference {
   _id: string
@@ -75,6 +76,19 @@ function withCrossDatasetReferences(
 // it up when the variants feature is disabled.
 const loadedVariants: Meta['variants'] = {variants: new Map(), state: 'loaded'}
 
+// Stores the variant creation machine resolves its captured inputs against.
+// The releases map is keyed by whatever id `createVariant.selectBundle`
+// carries, mirroring how `SelectBundle` sends the store's map key.
+const creationVariants = {
+  variants: new Map([['variant-a', {_id: 'variant-a', name: 'Variant A'}]]),
+  state: 'loaded',
+} as unknown as Meta['variants']
+
+const creationReleases = {
+  releases: new Map([['rABC', {_id: 'rABC'}]]),
+  state: 'loaded',
+} as unknown as Meta['releases']
+
 // Builds the version document stub the way `useDocumentVersions` emits it,
 // deriving `_system` from the document id.
 function versionStub(id: string): VersionInfoDocumentStub {
@@ -118,18 +132,20 @@ function createTestActor(
   {
     requestDeletionConfirmation,
     deleteVariants,
+    createVariant,
     meta = loadedMeta,
   }: {
     requestDeletionConfirmation?: () => void
     deleteVariants?: () => Promise<unknown>
-    meta?: Meta
+    createVariant?: (options: {signal: AbortSignal}) => Promise<unknown>
+    meta?: Meta | Observable<Meta>
   } = {},
 ) {
   const references$ = new BehaviorSubject<ReferringDocuments>(initial)
 
   const inventoryRef = createActor(
     documentGroupInventoryMachine.provide({
-      actors: {meta: fromObservable(() => of(meta))},
+      actors: {meta: fromObservable(() => (isObservable(meta) ? meta : of(meta)))},
     }),
     {
       input: {
@@ -151,14 +167,26 @@ function createTestActor(
           },
           actions: requestDeletionConfirmation ? {requestDeletionConfirmation} : {},
         }),
+        variantCreationMachine: variantCreationMachine.provide({
+          actors: {
+            variants: fromObservable(() => of(creationVariants)),
+            releases: fromObservable(() => of(creationReleases)),
+            createVariant: fromPromise(async ({signal}) => {
+              // Defaults to a resolving no-op; tests override to exercise
+              // outcomes. The signal is forwarded so tests can observe
+              // cancellation aborting the in-flight creation.
+              if (createVariant) await createVariant({signal})
+            }),
+          },
+        }),
       },
     },
   )
   inventoryRef.start()
 
-  const {selectionRef, deletionRef} = inventoryRef.getSnapshot().context
+  const {selectionRef, deletionRef, variantCreationRef} = inventoryRef.getSnapshot().context
 
-  return {inventoryRef, selectionRef, deletionRef, references$}
+  return {inventoryRef, selectionRef, deletionRef, variantCreationRef, references$}
 }
 
 describe('documentGroupInventoryMachine', () => {
@@ -547,6 +575,36 @@ describe('documentGroupInventoryMachine', () => {
     expect(selectionRef.getSnapshot().context.variants).toEqual(expectedVariants)
   })
 
+  it('reports meta as pending until every meta observable has settled', () => {
+    const meta$ = new BehaviorSubject<Meta>({
+      ...loadedMeta,
+      releases: {releases: new Map(), state: 'loading'},
+      agentBundles: {bundles: [], loading: true},
+    })
+
+    const {inventoryRef} = createTestActor(loading, {meta: meta$})
+    expect(inventoryRef.getSnapshot().context.metaState).toBe('pending')
+
+    // A single slice settling is not enough while others are still loading.
+    meta$.next({...meta$.getValue(), agentBundles: {bundles: [], loading: false}})
+    expect(inventoryRef.getSnapshot().context.metaState).toBe('pending')
+
+    meta$.next(loadedMeta)
+    expect(inventoryRef.getSnapshot().context.metaState).toBe('ready')
+  })
+
+  it('keeps meta ready once settled, even if a slice starts loading again', () => {
+    const meta$ = new BehaviorSubject<Meta>(loadedMeta)
+
+    const {inventoryRef} = createTestActor(loading, {meta: meta$})
+    expect(inventoryRef.getSnapshot().context.metaState).toBe('ready')
+
+    // Refetches (e.g. the releases store reloading) must not flip the
+    // inventory back to pending.
+    meta$.next({...loadedMeta, releases: {releases: new Map(), state: 'loading'}})
+    expect(inventoryRef.getSnapshot().context.metaState).toBe('ready')
+  })
+
   it('drives the selection machine into the error state when meta reports an error', () => {
     const meta = {
       versionState: {data: [], versions: [], loading: false, error: new Error('meta failed')},
@@ -573,5 +631,184 @@ describe('documentGroupInventoryMachine', () => {
     deletionRef.send({type: 'selection.changed', selectedIds: new Set(['drafts.foo'])})
     expect(deletionRef.getSnapshot().context.ids).toEqual(['drafts.foo'])
     expect(deletionRef.getSnapshot().hasTag('warnIncomingReferences')).toBe(false)
+  })
+
+  it('mirrors variant creation activity in the creatingVariant state', () => {
+    const {inventoryRef, variantCreationRef} = createTestActor(loading)
+
+    expect(inventoryRef.getSnapshot().matches('idle')).toBe(true)
+
+    // Requesting creation activates the flow, which the parent mirrors.
+    variantCreationRef.send({type: 'createVariant.request'})
+    expect(variantCreationRef.getSnapshot().matches({active: 'configuring'})).toBe(true)
+    expect(inventoryRef.getSnapshot().matches('creatingVariant')).toBe(true)
+
+    // Cancelling deactivates the flow and returns the parent to idle.
+    variantCreationRef.send({type: 'createVariant.cancel'})
+    expect(variantCreationRef.getSnapshot().matches('idle')).toBe(true)
+    expect(inventoryRef.getSnapshot().matches('idle')).toBe(true)
+  })
+
+  it('only allows confirming variant creation once both inputs are captured', () => {
+    const {variantCreationRef} = createTestActor(loading)
+
+    variantCreationRef.send({type: 'createVariant.request'})
+
+    // Neither input captured: confirmation is ignored.
+    variantCreationRef.send({type: 'createVariant.confirm'})
+    expect(variantCreationRef.getSnapshot().matches({active: 'configuring'})).toBe(true)
+
+    // The inputs are independent and may be captured in any order.
+    variantCreationRef.send({type: 'createVariant.selectBundle', bundle: {type: 'drafts'}})
+    variantCreationRef.send({type: 'createVariant.confirm'})
+    expect(variantCreationRef.getSnapshot().matches({active: 'configuring'})).toBe(true)
+
+    variantCreationRef.send({type: 'createVariant.selectVariant', variantId: 'variant-a'})
+    variantCreationRef.send({type: 'createVariant.confirm'})
+    expect(variantCreationRef.getSnapshot().matches({active: 'creating'})).toBe(true)
+  })
+
+  it('creates the variant with the captured inputs and returns to idle', async () => {
+    const createVariant = vi.fn().mockResolvedValue(undefined)
+    const {inventoryRef, variantCreationRef} = createTestActor(loading, {createVariant})
+
+    variantCreationRef.send({type: 'createVariant.request'})
+    variantCreationRef.send({type: 'createVariant.selectVariant', variantId: 'variant-a'})
+    variantCreationRef.send({
+      type: 'createVariant.selectBundle',
+      bundle: {type: 'release', releaseId: 'rABC'},
+    })
+    variantCreationRef.send({type: 'createVariant.confirm'})
+
+    await vi.waitFor(() => expect(variantCreationRef.getSnapshot().matches('idle')).toBe(true))
+    expect(createVariant).toHaveBeenCalledTimes(1)
+    expect(inventoryRef.getSnapshot().matches('idle')).toBe(true)
+
+    // Abandoned or completed selections are not carried into the next flow.
+    expect(variantCreationRef.getSnapshot().context.selectedVariantId).toBeUndefined()
+    expect(variantCreationRef.getSnapshot().context.selectedBundle).toBeUndefined()
+  })
+
+  it('captures the thrown value and enters the error state when variant creation fails', async () => {
+    const failure = new Error('create variant failed')
+    const {variantCreationRef} = createTestActor(loading, {
+      createVariant: async () => {
+        throw failure
+      },
+    })
+
+    variantCreationRef.send({type: 'createVariant.request'})
+    variantCreationRef.send({type: 'createVariant.selectVariant', variantId: 'variant-a'})
+    variantCreationRef.send({type: 'createVariant.selectBundle', bundle: {type: 'drafts'}})
+    variantCreationRef.send({type: 'createVariant.confirm'})
+
+    await vi.waitFor(() =>
+      expect(variantCreationRef.getSnapshot().matches({active: 'error'})).toBe(true),
+    )
+    expect(variantCreationRef.getSnapshot().context.error).toBe(failure)
+  })
+
+  it('ignores bundle selection and confirmation while the variant is being created', () => {
+    // A never-resolving creation keeps the machine in the `creating` state.
+    const createVariant = vi.fn(() => new Promise<void>(() => {}))
+    const {variantCreationRef} = createTestActor(loading, {createVariant})
+
+    variantCreationRef.send({type: 'createVariant.request'})
+    variantCreationRef.send({type: 'createVariant.selectVariant', variantId: 'variant-a'})
+    variantCreationRef.send({type: 'createVariant.selectBundle', bundle: {type: 'drafts'}})
+    variantCreationRef.send({type: 'createVariant.confirm'})
+    expect(variantCreationRef.getSnapshot().matches({active: 'creating'})).toBe(true)
+
+    // The captured bundle cannot be changed mid-creation.
+    variantCreationRef.send({
+      type: 'createVariant.selectBundle',
+      bundle: {type: 'release', releaseId: 'rABC'},
+    })
+    expect(variantCreationRef.getSnapshot().context.selectedBundle).toEqual({type: 'drafts'})
+
+    // Confirmation cannot start a second creation.
+    variantCreationRef.send({type: 'createVariant.confirm'})
+    expect(variantCreationRef.getSnapshot().matches({active: 'creating'})).toBe(true)
+    expect(createVariant).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not leave the feedback state when variant creation deactivates', () => {
+    const {inventoryRef, variantCreationRef} = createTestActor(loading)
+
+    variantCreationRef.send({type: 'createVariant.request'})
+    expect(inventoryRef.getSnapshot().matches('creatingVariant')).toBe(true)
+
+    // Feedback takes over the parent state while the creation flow is active.
+    inventoryRef.send({type: 'feedback.begin'})
+    expect(inventoryRef.getSnapshot().matches('feedback')).toBe(true)
+
+    // Deactivation must not yank the machine out of the feedback state.
+    variantCreationRef.send({type: 'createVariant.cancel'})
+    expect(inventoryRef.getSnapshot().matches('feedback')).toBe(true)
+
+    inventoryRef.send({type: 'feedback.end'})
+    expect(inventoryRef.getSnapshot().matches('idle')).toBe(true)
+  })
+
+  it('aborts the in-flight creation when cancelled mid-creation', () => {
+    // Cancellation relies on the invoked promise actor's abort signal to stop
+    // the underlying request; a never-resolving creation keeps the machine in
+    // the `creating` state until cancelled.
+    let capturedSignal: AbortSignal | undefined
+    const createVariant = vi.fn(({signal}: {signal: AbortSignal}) => {
+      capturedSignal = signal
+      return new Promise<void>(() => {})
+    })
+    const {inventoryRef, variantCreationRef} = createTestActor(loading, {createVariant})
+
+    variantCreationRef.send({type: 'createVariant.request'})
+    variantCreationRef.send({type: 'createVariant.selectVariant', variantId: 'variant-a'})
+    variantCreationRef.send({type: 'createVariant.selectBundle', bundle: {type: 'drafts'}})
+    variantCreationRef.send({type: 'createVariant.confirm'})
+
+    expect(variantCreationRef.getSnapshot().matches({active: 'creating'})).toBe(true)
+    expect(capturedSignal?.aborted).toBe(false)
+
+    variantCreationRef.send({type: 'createVariant.cancel'})
+    expect(variantCreationRef.getSnapshot().matches('idle')).toBe(true)
+    expect(inventoryRef.getSnapshot().matches('idle')).toBe(true)
+    expect(capturedSignal?.aborted).toBe(true)
+  })
+
+  it('allows retrying the creation after a failure', async () => {
+    const createVariant = vi
+      .fn<(options: {signal: AbortSignal}) => Promise<unknown>>()
+      .mockRejectedValueOnce(new Error('first attempt failed'))
+      .mockResolvedValueOnce(undefined)
+    const {variantCreationRef} = createTestActor(loading, {createVariant})
+
+    variantCreationRef.send({type: 'createVariant.request'})
+    variantCreationRef.send({type: 'createVariant.selectVariant', variantId: 'variant-a'})
+    variantCreationRef.send({type: 'createVariant.selectBundle', bundle: {type: 'drafts'}})
+    variantCreationRef.send({type: 'createVariant.confirm'})
+
+    await vi.waitFor(() =>
+      expect(variantCreationRef.getSnapshot().matches({active: 'error'})).toBe(true),
+    )
+
+    // The captured inputs survive the failure, so confirming again retries the
+    // creation without re-selecting.
+    variantCreationRef.send({type: 'createVariant.confirm'})
+    await vi.waitFor(() => expect(variantCreationRef.getSnapshot().matches('idle')).toBe(true))
+    expect(createVariant).toHaveBeenCalledTimes(2)
+  })
+
+  it('starts from a clean slate when creation is requested again after cancelling', () => {
+    const {variantCreationRef} = createTestActor(loading)
+
+    variantCreationRef.send({type: 'createVariant.request'})
+    variantCreationRef.send({type: 'createVariant.selectVariant', variantId: 'variant-a'})
+    variantCreationRef.send({type: 'createVariant.selectBundle', bundle: {type: 'drafts'}})
+    variantCreationRef.send({type: 'createVariant.cancel'})
+
+    variantCreationRef.send({type: 'createVariant.request'})
+    expect(variantCreationRef.getSnapshot().context.selectedVariantId).toBeUndefined()
+    expect(variantCreationRef.getSnapshot().context.selectedBundle).toBeUndefined()
+    expect(variantCreationRef.getSnapshot().context.error).toBeUndefined()
   })
 })

--- a/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.ts
@@ -1,6 +1,14 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {EMPTY} from 'rxjs'
-import {assign, forwardTo, fromObservable, sendTo, setup, type ActorRefFromLogic} from 'xstate'
+import {
+  assign,
+  forwardTo,
+  fromObservable,
+  sendTo,
+  setup,
+  stateIn,
+  type ActorRefFromLogic,
+} from 'xstate'
 
 import {type TFunction} from '../../i18n/types'
 import {type DocumentPerspectiveState} from '../../releases/hooks/useDocumentVersions'
@@ -10,9 +18,11 @@ import {type VariantStoreState} from '../../variants/store/reducer'
 import {computeSets} from '../utils/computeSets'
 import {type deletionMachine} from './deletionMachine'
 import {type selectionMachine, type Variant} from './selectionMachine'
+import {type variantCreationMachine} from './variantCreationMachine'
 
 type SelectionLogic = typeof selectionMachine
 type DeletionLogic = typeof deletionMachine
+type VariantCreationLogic = typeof variantCreationMachine
 
 export interface Meta {
   versionState: DocumentPerspectiveState
@@ -30,16 +40,20 @@ export interface VariantSet {
 interface DocumentGroupInventoryContext {
   selectionRef: ActorRefFromLogic<SelectionLogic>
   deletionRef: ActorRefFromLogic<DeletionLogic>
+  variantCreationRef: ActorRefFromLogic<VariantCreationLogic>
   sets: VariantSet[]
   releases: Map<string, ReleaseDocument>
   t: TFunction
   variantsEnabled: boolean | undefined
+  metaState: 'pending' | 'ready'
 }
 
 type DocumentGroupInventoryEvents =
   | {type: 'selection.changed'; selectedIds: Set<string>}
   | {type: 'deletion.activated'}
   | {type: 'deletion.deactivated'}
+  | {type: 'variantCreation.activated'}
+  | {type: 'variantCreation.deactivated'}
   | {type: 'feedback.begin'}
   | {type: 'feedback.end'}
 
@@ -48,6 +62,7 @@ export const documentGroupInventoryMachine = setup({
     input: {
       selectionMachine: SelectionLogic
       deletionMachine: DeletionLogic
+      variantCreationMachine: VariantCreationLogic
       t: TFunction
       variantsEnabled: boolean | undefined
     }
@@ -60,6 +75,9 @@ export const documentGroupInventoryMachine = setup({
   actions: {
     onFeedbackBegin: () => {},
   },
+  guards: {
+    isCreatingVariant: stateIn('creatingVariant'),
+  },
 }).createMachine({
   id: 'documentGroupInventory',
   context: ({input, spawn}) => ({
@@ -71,10 +89,15 @@ export const documentGroupInventoryMachine = setup({
       systemId: 'deletion',
       input: undefined,
     }),
+    variantCreationRef: spawn(input.variantCreationMachine, {
+      systemId: 'variantCreation',
+      input: undefined,
+    }),
     sets: [],
     releases: new Map(),
     t: input.t,
     variantsEnabled: input.variantsEnabled,
+    metaState: 'pending' as const,
   }),
   invoke: {
     src: 'meta',
@@ -89,6 +112,10 @@ export const documentGroupInventoryMachine = setup({
               variantsEnabled: context.variantsEnabled,
             }),
           releases: ({event}) => event.snapshot.context?.releases.releases ?? new Map(),
+          metaState: ({context, event}) =>
+            context.metaState === 'ready' || metaIsSettled(event.snapshot.context)
+              ? 'ready'
+              : 'pending',
         }),
         sendTo(
           ({context}) => context.selectionRef,
@@ -102,7 +129,7 @@ export const documentGroupInventoryMachine = setup({
             return {
               type: 'variants.changed',
               variants: context.sets.flatMap((set) => set.variants),
-              loaded: metaIsLoaded(meta),
+              loaded: metaIsSettled(meta),
             } as const
           },
         ),
@@ -125,12 +152,18 @@ export const documentGroupInventoryMachine = setup({
     'deletion.deactivated': {
       actions: sendTo(({context}) => context.selectionRef, {type: 'selection.unlock'}),
     },
+    'variantCreation.activated': '.creatingVariant',
+    'variantCreation.deactivated': {
+      guard: 'isCreatingVariant',
+      target: '.idle',
+    },
     'feedback.begin': '.feedback',
     'feedback.end': '.idle',
   },
   initial: 'idle',
   states: {
     idle: {},
+    creatingVariant: {},
     feedback: {
       entry: 'onFeedbackBegin',
     },
@@ -145,6 +178,17 @@ function metaHasError(meta: Meta | undefined): boolean {
   return Boolean(meta.versionState.error) || meta.releases.state === 'error'
 }
 
-function metaIsLoaded(meta: Meta | undefined): boolean {
-  return meta?.versionState.loading === false && meta.releases.state === 'loaded'
+function metaIsSettled(meta: Meta | undefined): boolean {
+  if (!meta) {
+    return false
+  }
+
+  return (
+    !meta.versionState.loading &&
+    meta.releases.state !== 'initialising' &&
+    meta.releases.state !== 'loading' &&
+    meta.variants.state !== 'initialising' &&
+    meta.variants.state !== 'loading' &&
+    !meta.agentBundles.loading
+  )
 }

--- a/packages/sanity/src/core/documentGroupInventory/machines/variantCreationMachine.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/variantCreationMachine.ts
@@ -1,0 +1,153 @@
+import {EMPTY} from 'rxjs'
+import {and, assign, fromObservable, fromPromise, not, sendParent, setup, stateIn} from 'xstate'
+
+import {type TargetPerspective} from '../../perspective/types'
+import {type ReleasesReducerState} from '../../releases/store/reducer'
+import {type SystemBundle} from '../../util/draftUtils'
+import {type VariantStoreState} from '../../variants/store/reducer'
+import {type SystemVariant} from '../../variants/types'
+
+/**
+ * @internal
+ */
+export type VariantCreationBundle =
+  | {type: Extract<SystemBundle, 'drafts'>}
+  | {type: 'release'; releaseId: string}
+
+interface VariantCreationContext {
+  variants: VariantStoreState | undefined
+  releases: ReleasesReducerState | undefined
+  selectedVariantId: string | undefined
+  selectedBundle: VariantCreationBundle | undefined
+  error?: unknown
+}
+
+type VariantCreationEvents =
+  | {type: 'createVariant.request'}
+  | {type: 'createVariant.cancel'}
+  | {type: 'createVariant.selectVariant'; variantId: string | undefined}
+  | {type: 'createVariant.selectBundle'; bundle: VariantCreationBundle | undefined}
+  | {type: 'createVariant.confirm'}
+
+export const variantCreationMachine = setup({
+  types: {} as {
+    context: VariantCreationContext
+    events: VariantCreationEvents
+  },
+  actors: {
+    variants: fromObservable<VariantStoreState, unknown>(() => EMPTY),
+    releases: fromObservable<ReleasesReducerState, unknown>(() => EMPTY),
+    createVariant: fromPromise<
+      void,
+      {variantDefinition: SystemVariant; bundle: Exclude<TargetPerspective, 'published'>}
+    >(() => Promise.reject(new Error('`createVariant` actor must be provided.'))),
+  },
+  guards: {
+    hasSelectedVariant: ({context}) => typeof context.selectedVariantId !== 'undefined',
+    hasSelectedBundle: ({context}) => typeof context.selectedBundle !== 'undefined',
+    canConfirmCreation: and(['hasSelectedVariant', 'hasSelectedBundle']),
+  },
+}).createMachine({
+  id: 'variantCreation',
+  context: {
+    variants: undefined,
+    releases: undefined,
+    selectedVariantId: undefined,
+    selectedBundle: undefined,
+    error: undefined,
+  },
+  invoke: [
+    {
+      src: 'variants',
+      onSnapshot: {
+        actions: assign({variants: ({event}) => event.snapshot.context}),
+      },
+    },
+    {
+      src: 'releases',
+      onSnapshot: {
+        actions: assign({releases: ({event}) => event.snapshot.context}),
+      },
+    },
+  ],
+  initial: 'idle',
+  states: {
+    idle: {
+      on: {
+        'createVariant.request': 'active',
+      },
+    },
+    active: {
+      entry: sendParent({type: 'variantCreation.activated'}),
+      exit: [
+        sendParent({type: 'variantCreation.deactivated'}),
+        assign({
+          selectedVariantId: undefined,
+          selectedBundle: undefined,
+          error: undefined,
+        }),
+      ],
+      on: {
+        'createVariant.cancel': '#variantCreation.idle',
+        'createVariant.selectVariant': {
+          guard: not(stateIn('#variantCreation.active.creating')),
+          actions: assign({selectedVariantId: ({event}) => event.variantId}),
+        },
+        'createVariant.selectBundle': {
+          guard: not(stateIn('#variantCreation.active.creating')),
+          actions: assign({selectedBundle: ({event}) => event.bundle}),
+        },
+      },
+      initial: 'configuring',
+      states: {
+        configuring: {
+          on: {
+            'createVariant.confirm': {
+              guard: 'canConfirmCreation',
+              target: 'creating',
+            },
+          },
+        },
+        creating: {
+          invoke: {
+            src: 'createVariant',
+            input: ({context}) => {
+              const {selectedVariantId, selectedBundle} = context
+
+              const variantDefinition = context.variants?.variants.get(selectedVariantId ?? '')
+
+              const bundle =
+                selectedBundle?.type === 'drafts'
+                  ? 'drafts'
+                  : context.releases?.releases.get(selectedBundle?.releaseId ?? '')
+
+              if (typeof variantDefinition === 'undefined' || typeof bundle === 'undefined') {
+                throw new Error('Cannot create a variant before a variant and bundle are selected.')
+              }
+
+              return {
+                variantDefinition,
+                bundle,
+              }
+            },
+            onDone: {
+              target: '#variantCreation.idle',
+            },
+            onError: {
+              target: 'error',
+              actions: assign({error: ({event}) => event.error}),
+            },
+          },
+        },
+        error: {
+          on: {
+            'createVariant.confirm': {
+              guard: 'canConfirmCreation',
+              target: 'creating',
+            },
+          },
+        },
+      },
+    },
+  },
+})

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -534,6 +534,16 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
 
   /** The label given to a document group's base variant */
   'document-group.base-variant': 'All users (Default)',
+  /** The header label for the variant creation flow before a variant definition has been selected */
+  'document-group.create-variant': 'Create variant',
+  /** The header label for the variant creation flow once a variant definition has been selected */
+  'document-group.create-variant.for-target': 'Create variant for {{variantDefinitionName}}',
+  /** The heading for the option to create a variant as a draft */
+  'document-group.create-variant.target-drafts': 'As a draft',
+  /** The label for the list of releases a variant can be created in */
+  'document-group.create-variant.target-releases': 'Into a release',
+  /** The label for the list of existing variants that can be viewed instead of creating a new one */
+  'document-group.create-variant.view-existing-variants': 'Or view existing variants',
   /** The text in the "Cancel" button in the confirm delete dialog that cancels the action */
   'document-group.delete.cancel-button.text': 'Cancel',
   /** Used in `document-group.delete.cdr-summary.title` */

--- a/packages/sanity/src/core/variants/documents/__tests__/createVariantScopedDocument.test.ts
+++ b/packages/sanity/src/core/variants/documents/__tests__/createVariantScopedDocument.test.ts
@@ -41,7 +41,8 @@ describe('createVariantScopedDocument', () => {
       createVariantScopedDocument({
         client: client as unknown as SanityClient,
         baseId: 'drafts.article-1',
-        baseRevisionId: 'rev-1',
+        ifBaseRevisionId: 'rev-1',
+        documentGroupId: 'article-1',
         variant: VARIANT,
         selectedPerspective: 'published',
       }),
@@ -57,6 +58,43 @@ describe('createVariantScopedDocument', () => {
       },
       {tag: 'variants.document.create'},
     )
+
+    // `toHaveBeenCalledWith` does not distinguish absent keys from `undefined`
+    // values, so assert explicitly that no bundle is sent for the published
+    // perspective.
+    expect(client.action.mock.calls[0][0]).not.toHaveProperty('bundleId')
+  })
+
+  it('creates a variant document from an in-memory document', async () => {
+    const client = {
+      action: vi.fn().mockResolvedValue(ACTION_RESULT),
+    }
+
+    await expect(
+      createVariantScopedDocument({
+        client: client as unknown as SanityClient,
+        document: {
+          _type: 'article',
+          title: 'Hello',
+        },
+        documentGroupId: 'article-1',
+        variant: VARIANT,
+        selectedPerspective: 'published',
+      }),
+    ).resolves.toEqual(ACTION_RESULT)
+
+    expect(client.action).toHaveBeenCalledWith(
+      {
+        actionType: 'sanity.action.document.variant.create',
+        publishedId: 'article-1',
+        variantId: 'Ab12cd34',
+        document: {
+          _type: 'article',
+          title: 'Hello',
+        },
+      },
+      {tag: 'variants.document.create'},
+    )
   })
 
   it('passes release bundleId when creating from a release perspective string', async () => {
@@ -67,6 +105,7 @@ describe('createVariantScopedDocument', () => {
     await createVariantScopedDocument({
       client: client as unknown as SanityClient,
       baseId: 'drafts.article-1',
+      documentGroupId: 'article-1',
       variant: VARIANT,
       selectedPerspective: 'my-release',
     })
@@ -81,6 +120,11 @@ describe('createVariantScopedDocument', () => {
       },
       {tag: 'variants.document.create'},
     )
+
+    // `toHaveBeenCalledWith` does not distinguish absent keys from `undefined`
+    // values, so assert explicitly that no revision constraint is sent when
+    // none is provided.
+    expect(client.action.mock.calls[0][0]).not.toHaveProperty('ifBaseRevisionId')
   })
 
   it('passes release bundleId when creating from a release document perspective', async () => {
@@ -91,6 +135,7 @@ describe('createVariantScopedDocument', () => {
     await createVariantScopedDocument({
       client: client as unknown as SanityClient,
       baseId: 'versions.rSummer123.article-1',
+      documentGroupId: 'article-1',
       variant: VARIANT,
       selectedPerspective: releaseDocument,
     })
@@ -115,6 +160,7 @@ describe('createVariantScopedDocument', () => {
     await createVariantScopedDocument({
       client: client as unknown as SanityClient,
       baseId: 'drafts.article-1',
+      documentGroupId: 'article-1',
       variant: VARIANT,
       selectedPerspective: 'drafts',
     })
@@ -129,5 +175,47 @@ describe('createVariantScopedDocument', () => {
       },
       {tag: 'variants.document.create'},
     )
+  })
+
+  it('forwards the abort signal to the action request when creating from a base document', async () => {
+    const client = {
+      action: vi.fn().mockResolvedValue(ACTION_RESULT),
+    }
+    const controller = new AbortController()
+
+    await createVariantScopedDocument({
+      client: client as unknown as SanityClient,
+      baseId: 'drafts.article-1',
+      documentGroupId: 'article-1',
+      variant: VARIANT,
+      selectedPerspective: 'published',
+      signal: controller.signal,
+    })
+
+    expect(client.action).toHaveBeenCalledWith(expect.anything(), {
+      tag: 'variants.document.create',
+      signal: controller.signal,
+    })
+  })
+
+  it('forwards the abort signal to the action request when creating from an in-memory document', async () => {
+    const client = {
+      action: vi.fn().mockResolvedValue(ACTION_RESULT),
+    }
+    const controller = new AbortController()
+
+    await createVariantScopedDocument({
+      client: client as unknown as SanityClient,
+      document: {_type: 'article'},
+      documentGroupId: 'article-1',
+      variant: VARIANT,
+      selectedPerspective: 'published',
+      signal: controller.signal,
+    })
+
+    expect(client.action).toHaveBeenCalledWith(expect.anything(), {
+      tag: 'variants.document.create',
+      signal: controller.signal,
+    })
   })
 })

--- a/packages/sanity/src/core/variants/documents/createVariantScopedDocument.ts
+++ b/packages/sanity/src/core/variants/documents/createVariantScopedDocument.ts
@@ -1,5 +1,4 @@
 import {type SanityClient, type SingleActionResult} from '@sanity/client'
-import {getPublishedId} from '@sanity/client/csm'
 import {type SanityDocumentLike} from '@sanity/types'
 
 import {type TargetPerspective} from '../../perspective/types'
@@ -24,6 +23,28 @@ function getSupportedBundleId(
   return bundleId
 }
 
+type BaseOptions = {
+  client: SanityClient
+  variant: Pick<SystemVariant, '_id'>
+  selectedPerspective: TargetPerspective
+  documentGroupId: string
+  signal?: AbortSignal
+}
+
+/**
+ * @internal
+ */
+export type CreateVariantScopedDocumentOptions = BaseOptions &
+  (
+    | {
+        document: Omit<SanityDocumentLike, '_id'>
+      }
+    | {
+        baseId: string
+        ifBaseRevisionId?: string
+      }
+  )
+
 /**
  * Creates a variant-scoped version document via the variants document create action.
  *
@@ -31,33 +52,52 @@ function getSupportedBundleId(
  */
 export async function createVariantScopedDocument({
   client,
-  baseId,
-  baseRevisionId,
   variant,
   selectedPerspective,
-}: {
-  client: SanityClient
-  /** Source document whose fields are copied into the new variant-scoped version. */
-  baseId: string
-  baseRevisionId?: string
-  variant: SystemVariant
-  selectedPerspective: TargetPerspective
-}): Promise<SingleActionResult> {
-  if (!baseId) {
-    throw new Error('Source document must have an _id')
-  }
-
-  const publishedId = getPublishedId(baseId)
+  documentGroupId,
+  signal,
+  ...options
+}: CreateVariantScopedDocumentOptions): Promise<SingleActionResult> {
   const bundleId = getSupportedBundleId(selectedPerspective)
 
-  const action: VariantDocumentCreateFromBaseAction = {
+  const action: Pick<
+    VariantDocumentCreateFromBaseAction,
+    'actionType' | 'variantId' | 'publishedId' | 'bundleId'
+  > = {
     actionType: 'sanity.action.document.variant.create',
-    publishedId,
     variantId: getVariantId(variant._id),
-    baseId,
-    ...(baseRevisionId ? {ifBaseRevisionId: baseRevisionId} : {}),
     ...(bundleId ? {bundleId} : {}),
+    publishedId: documentGroupId,
   }
 
-  return variantsClient(client).action(action, {tag: 'variants.document.create'})
+  if ('baseId' in options) {
+    return variantsClient(client).action(
+      {
+        baseId: options.baseId,
+        ...(typeof options.ifBaseRevisionId === 'string'
+          ? {ifBaseRevisionId: options.ifBaseRevisionId}
+          : {}),
+        ...action,
+      },
+      {
+        tag: 'variants.document.create',
+        signal,
+      },
+    )
+  }
+
+  if ('document' in options) {
+    return variantsClient(client).action(
+      {
+        document: options.document,
+        ...action,
+      },
+      {
+        tag: 'variants.document.create',
+        signal,
+      },
+    )
+  }
+
+  throw new Error('`createVariantScopedDocument`: `baseId` or `document` must be provided.')
 }

--- a/packages/sanity/src/core/variants/hooks/useVariantDocumentOperations.ts
+++ b/packages/sanity/src/core/variants/hooks/useVariantDocumentOperations.ts
@@ -1,3 +1,4 @@
+import {type SanityDocumentLike} from '@sanity/types'
 import {useCallback} from 'react'
 
 import {useClient} from '../../hooks/useClient'
@@ -12,18 +13,16 @@ import {type SystemVariant} from '../types'
 export function useVariantDocumentOperations() {
   const client = useClient(VARIANTS_STUDIO_CLIENT_OPTIONS)
 
-  const createVariantDocument = useCallback(
-    async (options: {
-      baseId: string
-      baseRevisionId?: string
-      variant: SystemVariant
-      selectedPerspective: TargetPerspective
-    }) => {
-      await createVariantScopedDocument({
+  const createVariantDocument = useCallback<
+    (
+      options: Omit<Parameters<typeof createVariantScopedDocument>[0], 'client'>,
+    ) => ReturnType<typeof createVariantScopedDocument>
+  >(
+    (options) =>
+      createVariantScopedDocument({
         client,
         ...options,
-      })
-    },
+      }),
     [client],
   )
 

--- a/packages/sanity/src/core/variants/hooks/useVariantDocumentOperations.ts
+++ b/packages/sanity/src/core/variants/hooks/useVariantDocumentOperations.ts
@@ -1,11 +1,16 @@
-import {type SanityDocumentLike} from '@sanity/types'
+import {type SingleActionResult} from '@sanity/client'
 import {useCallback} from 'react'
 
 import {useClient} from '../../hooks/useClient'
-import {type TargetPerspective} from '../../perspective/types'
-import {createVariantScopedDocument} from '../documents/createVariantScopedDocument'
+import {
+  createVariantScopedDocument,
+  type CreateVariantScopedDocumentOptions,
+} from '../documents/createVariantScopedDocument'
 import {VARIANTS_STUDIO_CLIENT_OPTIONS} from '../store/constants'
-import {type SystemVariant} from '../types'
+
+type DistributiveOmit<Type, Key extends PropertyKey> = Type extends unknown
+  ? Omit<Type, Key>
+  : never
 
 /**
  * @internal
@@ -15,8 +20,8 @@ export function useVariantDocumentOperations() {
 
   const createVariantDocument = useCallback<
     (
-      options: Omit<Parameters<typeof createVariantScopedDocument>[0], 'client'>,
-    ) => ReturnType<typeof createVariantScopedDocument>
+      options: DistributiveOmit<CreateVariantScopedDocumentOptions, 'client'>,
+    ) => Promise<SingleActionResult>
   >(
     (options) =>
       createVariantScopedDocument({

--- a/packages/sanity/src/core/variants/plugin/components/PersonalizationIcons.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/PersonalizationIcons.tsx
@@ -1,4 +1,10 @@
-import {forwardRef, type ForwardRefExoticComponent, type RefAttributes, type SVGProps} from 'react'
+import {
+  type ComponentType,
+  forwardRef,
+  type ForwardRefExoticComponent,
+  type RefAttributes,
+  type SVGProps,
+} from 'react'
 
 export const RhombusIcon: ForwardRefExoticComponent<
   Omit<SVGProps<SVGSVGElement>, 'ref'> & RefAttributes<SVGSVGElement>
@@ -23,3 +29,27 @@ export const RhombusIcon: ForwardRefExoticComponent<
     </svg>
   )
 })
+
+export const CreateVariantIcon: ComponentType = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="0 0 21 21"
+    fill="none"
+    {...props}
+  >
+    <path
+      d="M17.22 10.5L10.5 3.78003L3.78003 10.5L10.5 17.22"
+      stroke="currentColor"
+      strokeWidth={1.2}
+      strokeLinejoin="round"
+    />
+    <path
+      d="M16.7999 13.86H13.8599M13.8599 13.86H10.9199M13.8599 13.86V10.92M13.8599 13.86V16.8"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinejoin="round"
+    />
+  </svg>
+)

--- a/packages/sanity/src/core/variants/store/variantsClient.ts
+++ b/packages/sanity/src/core/variants/store/variantsClient.ts
@@ -63,7 +63,7 @@ interface VariantDocumentCreateActionBase {
 }
 
 export interface VariantDocumentCreateFromDocumentAction extends VariantDocumentCreateActionBase {
-  document: SanityDocumentLike
+  document: Omit<SanityDocumentLike, '_id'> & Partial<Pick<SanityDocumentLike, '_id'>>
 }
 
 export interface VariantDocumentCreateFromBaseAction extends VariantDocumentCreateActionBase {

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/DocumentNotInVariantBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/DocumentNotInVariantBanner.tsx
@@ -108,6 +108,7 @@ export function DocumentNotInVariantBanner() {
     description: t('banners.variant.waiting.description'),
   })
 
+  // TODO: Use machine.
   const isActionAllowed = selectedPerspective === defaultPerspective || selectedReleaseId
   return (
     <Banner

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/DocumentNotInVariantBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/DocumentNotInVariantBanner.tsx
@@ -70,7 +70,8 @@ export function DocumentNotInVariantBanner() {
 
       await createVariantDocument({
         baseId: baseDocument._id,
-        baseRevisionId: baseDocument._rev,
+        ifBaseRevisionId: baseDocument._rev,
+        documentGroupId: documentId,
         variant: selectedVariant,
         selectedPerspective,
       })
@@ -86,7 +87,16 @@ export function DocumentNotInVariantBanner() {
       })
       setStatus('failed')
     }
-  }, [createVariantDocument, value, selectedVariant, selectedPerspective, versions, t, toast])
+  }, [
+    createVariantDocument,
+    documentId,
+    value,
+    selectedVariant,
+    selectedPerspective,
+    t,
+    toast,
+    versions,
+  ])
 
   useConditionalToast({
     status: 'info',

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -11,6 +11,7 @@ import {
 import {tap} from 'rxjs/operators'
 import {
   createPatchChannel,
+  Delay,
   type DocumentMutationEvent,
   type DocumentRebaseEvent,
   FormBuilder,
@@ -28,7 +29,6 @@ import {
   useTranslation,
 } from 'sanity'
 
-import {Delay} from '../../../../components/Delay'
 import {structureLocaleNamespace} from '../../../../i18n'
 import {useDocumentPane} from '../../useDocumentPane'
 import {useDocumentTitle} from '../../useDocumentTitle'

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPaneContent.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPaneContent.tsx
@@ -4,6 +4,7 @@ import {useCallback, useEffect, useMemo, useState} from 'react'
 import {
   CommandList,
   type CommandListRenderItemCallback,
+  Delay,
   ErrorActions,
   type GeneralPreviewLayoutKey,
   getPublishedId,
@@ -16,7 +17,6 @@ import {
 } from 'sanity'
 import {styled} from 'styled-components'
 
-import {Delay} from '../../components/Delay'
 import {PaneContent} from '../../components/pane/PaneContent'
 import {usePane} from '../../components/pane/usePane'
 import {usePaneLayout} from '../../components/pane/usePaneLayout'

--- a/packages/sanity/src/structure/panes/loading/LoadingPane.tsx
+++ b/packages/sanity/src/structure/panes/loading/LoadingPane.tsx
@@ -1,10 +1,9 @@
 import {_raf2, type CardTone, Flex} from '@sanity/ui'
 import {memo, useEffect, useMemo, useState} from 'react'
 import {type Observable} from 'rxjs'
-import {LoadingBlock, useTranslation} from 'sanity'
+import {Delay, LoadingBlock, useTranslation} from 'sanity'
 import {styled} from 'styled-components'
 
-import {Delay} from '../../components/Delay'
 import {Pane} from '../../components/pane/Pane'
 import {PaneContent} from '../../components/pane/PaneContent'
 import {structureLocaleNamespace} from '../../i18n'

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -73,6 +73,7 @@ exports[`exports snapshot 1`] = `
     "DateInput": "function",
     "DateTimeInput": "function",
     "DefaultPreview": "function",
+    "Delay": "function",
     "DetailPreview": "function",
     "DiffCard": "object",
     "DiffErrorBoundary": "function",


### PR DESCRIPTION
### Description

This branch adds variant-creation abilities to the document group inventory. Variant creation is a two step process:

1. Select the target variant definition.
2. Select the target bundle (drafts or a release). Bundle selection is divided into three sections:
  i. Drafts
  ii. Releases (excluding releases that already include the selected variant).
  iii. Releases that include the selected variant (skips creation and simply navigates the document editor to the existing variant).

Upon successful creation, the document editor navigates to the created variant.

https://github.com/user-attachments/assets/baf8ec09-1785-4389-a549-b56bfdae84a7

#### Follow-up steps

This implementation is sufficient for closed beta, but we should follow-up to refine some aspects of this feature:

1. Accessibility: keyboard navigation, auto-focus, scroll position reset when moving between variant selection and bundle selection, back button title, and focus states.
2. Error handling: ensure we handle errors in the XState CRUD actors, including the event of a timeout in the variant creation actor.
3. Abstract the XState CRUD actors to dedicated files, bolster unit testing, and reuse in the "Create variant"  banner if it makes sense.

### What to review

The variant creation process in the document group inventory.

### Testing

Expanded state machine unit tests.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New document mutation and perspective navigation paths in the inventory, with async creation and abort handling; changes are covered by expanded XState tests but touch core variant document APIs.
> 
> **Overview**
> Adds a **Create variant** flow to the document group inventory when variants are enabled: a footer action opens a two-step UI (pick variant definition, then pick target bundle) driven by a new `variantCreationMachine` and a parent `creatingVariant` state.
> 
> Bundle selection supports creating into **drafts** or eligible **releases**, hides targets that already have that variant, and offers shortcuts to **navigate** to existing variant documents instead of duplicating. Confirming runs document-pair resolution (with timeout), then `createVariantDocument` from a base document or an empty stub, and **switches perspective** to the new variant.
> 
> `createVariantScopedDocument` now accepts either `baseId` or in-memory `document`, explicit `documentGroupId`, and optional `AbortSignal`; callers (including the not-in-variant banner) are updated. **`Delay`** is exported from `sanity` and structure panes import it from there; shared **`TextButton`** and header truncation support the wizard. Inventory **`metaState`** tracks when all meta slices have settled (sticky after first ready) for layout sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43928a7b2b6f953b020104d26e93cabac07c3ea1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->