### PR TITLE
fix(core): remove stale hardcoded client api version pins

### DIFF
--- a/packages/sanity/src/core/form/studio/assetSourceDataset/shared/SelectAssetsDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceDataset/shared/SelectAssetsDialog.tsx
@@ -11,7 +11,6 @@ import {
   type MouseEvent,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from 'react'
@@ -105,7 +104,6 @@ const SelectAssetsComponent = function SelectAssetsComponent(
   ref: ForwardedRef<HTMLDivElement>,
 ) {
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
-  const versionedClient = useMemo(() => client.withConfig({apiVersion: '2023-02-14'}), [client])
   const [_elementId] = useState(() => `default-asset-source-${uniqueId()}`)
   const currentPageNumber = useRef(0)
   const {t} = useTranslation()
@@ -129,7 +127,7 @@ const SelectAssetsComponent = function SelectAssetsComponent(
       setIsLoading(true)
 
       if (typeof accept !== 'undefined') {
-        fetch$.current = versionedClient.observable
+        fetch$.current = client.observable
           .fetch(buildQuery(start, end, assetTypeParam, accept), {}, {tag})
           .subscribe({
             next: (result) => {
@@ -153,7 +151,7 @@ const SelectAssetsComponent = function SelectAssetsComponent(
           })
       }
     },
-    [assetType, accept, versionedClient, toast, t],
+    [assetType, accept, client, toast, t],
   )
 
   const handleDeleteFinished = useCallback(

--- a/packages/sanity/src/core/tasks/constants/API_VERSION.ts
+++ b/packages/sanity/src/core/tasks/constants/API_VERSION.ts
@@ -1,1 +1,3 @@
-export const API_VERSION = '2024-03-05'
+import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
+
+export const API_VERSION = DEFAULT_STUDIO_CLIENT_OPTIONS.apiVersion

--- a/packages/sanity/src/core/validation/validateDocument.ts
+++ b/packages/sanity/src/core/validation/validateDocument.ts
@@ -19,6 +19,7 @@ import {catchError, map, mergeAll, mergeMap, switchMap, toArray} from 'rxjs/oper
 import {type SourceClientOptions, type Workspace} from '../config'
 import {resolveConditionalProperty} from '../form/store/conditional-property/resolveConditionalProperty'
 import {getFallbackLocaleSource} from '../i18n/fallback'
+import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../studioClient'
 import {type ValidationContext} from './types'
 import {createBatchedGetDocumentExists} from './util/createBatchedGetDocumentExists'
 import {getTypeChain, normalizeValidationRules} from './util/normalizeValidationRules'
@@ -200,7 +201,7 @@ export function validateDocument({
       schema: workspace.schema,
       getDocumentExists:
         options.getDocumentExists ||
-        createBatchedGetDocumentExists(getClient({apiVersion: 'v2021-03-25'})),
+        createBatchedGetDocumentExists(getClient(DEFAULT_STUDIO_CLIENT_OPTIONS)),
       environment,
       currentUser,
     }),


### PR DESCRIPTION
### Description

The default image and file asset selector pinned its client to a hardcoded `apiVersion` of `2023-02-14`, predating the shared studio default. Users on custom roles whose grants use attribute-based conditions (`user::attributes()`) got the error `Grant requires API version 2024-05-23 or higher, but the request is using version 2023-02-14`, and the selector failed to load - that grant feature enforces a minimum API version the pinned request fell below. Two other call sites carried the same stale-pin pattern below the same floor: reference-existence validation and the tasks addon client. Fixes [SAPP-4066](https://linear.app/sanity/issue/SAPP-4066/image-selector-results-in-error-due-to-custom-role).

This PR removes the bespoke `apiVersion` pins from all three call sites so they inherit the shared studio default (`DEFAULT_STUDIO_CLIENT_OPTIONS`, currently `2025-02-19`), which clears the grant version floor. It finishes a migration the rest of the studio already made.

### What to review

- `SelectAssetsDialog.tsx` - the reported failure; the removed `versionedClient` was downgrading an already-correctly-configured `client`, so it now uses `client` directly.
- `validateDocument.ts` - same bug class: it feeds the grant-evaluated document-availability endpoint (`getDataUrl('doc', ...)`) and was pinned to `v2021-03-25`, roughly four years stale.
- `tasks/constants/API_VERSION.ts` - the constant now sources from the shared default instead of a frozen date.

### Testing

No new automated test: the failure is server-side Content Lake grant enforcement, not reproducible in jsdom, and the change swaps only the API version string while leaving the queries byte-identical. Verified lint, types, and the existing unit suites covering the touched paths (`createBatchedGetDocumentExists`, tasks).

### Notes for release

Fixes an error that prevented users on custom roles with attribute-based grants from loading the default image and file asset selector.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches validation and API client versioning used against grant-enforced endpoints; behavior change is limited to API version strings with queries unchanged, but those paths are user-facing and security-sensitive.
> 
> **Overview**
> Removes **hardcoded `apiVersion` overrides** at three call sites so they use **`DEFAULT_STUDIO_CLIENT_OPTIONS`** (the shared studio default) instead of frozen dates that sit below Content Lake grant floors.
> 
> The default **image/file asset selector** no longer builds a `versionedClient` pinned to `2023-02-14`; it fetches with the same `client` already obtained via `useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)`. **Document validation** reference-existence checks stop using `v2021-03-25` for `createBatchedGetDocumentExists`. The **tasks** `API_VERSION` constant is wired to the shared default rather than a fixed `2024-03-05`.
> 
> Together this fixes users on **custom roles with attribute-based grants** (`user::attributes()`) hitting errors like “Grant requires API version 2024-05-23 or higher” when opening the asset selector or running validation that hits grant-evaluated endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4e96bad38a8ee6c35e772cce93218d3d58dab3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->