### PR TITLE
fix(core): disable schedule for publish actions while a variant is selected

### DIFF
--- a/packages/sanity/src/core/scheduled-publishing/plugin/documentActions/schedule/ScheduleAction.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/plugin/documentActions/schedule/ScheduleAction.tsx
@@ -65,7 +65,7 @@ export const useScheduleAction: DocumentActionComponent = (props: DocumentAction
   // Scheduling operates on the base draft, so it is not available while a variant is selected —
   // it would silently schedule the base document instead of the variant (SAPP-3986).
   const {selectedVariantName} = usePerspective()
-  const isVariantSelected = selectedVariantName !== undefined
+  const isVariantSelected = Boolean(selectedVariantName)
   // Check if the current project supports Scheduled Publishing
 
   const [dialogOpen, setDialogOpen] = useState(false)

--- a/packages/sanity/src/core/scheduled-publishing/plugin/documentActions/schedule/ScheduleAction.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/plugin/documentActions/schedule/ScheduleAction.tsx
@@ -9,6 +9,7 @@ import {
   type DocumentActionDialogProps,
   type DocumentActionProps,
 } from '../../../../config/document/actions'
+import {usePerspective} from '../../../../perspective/usePerspective'
 import {useScheduledPublishingEnabled} from '../../../../scheduledPublishing/contexts/ScheduledPublishingEnabledProvider'
 import {useDocumentPairPermissions} from '../../../../store/grants/documentPairPermissions'
 import {useCurrentUser} from '../../../../store/user/hooks'
@@ -61,6 +62,10 @@ export const useScheduleAction: DocumentActionComponent = (props: DocumentAction
   const {createSchedule} = useScheduleOperation()
   const {enabled, mode} = useScheduledPublishingEnabled()
   const {handleOpenDialog} = useSchedulePublishingUpsell()
+  // Scheduling operates on the base draft, so it is not available while a variant is selected —
+  // it would silently schedule the base document instead of the variant (SAPP-3986).
+  const {selectedVariantName} = usePerspective()
+  const isVariantSelected = selectedVariantName !== undefined
   // Check if the current project supports Scheduled Publishing
 
   const [dialogOpen, setDialogOpen] = useState(false)
@@ -127,6 +132,10 @@ export const useScheduleAction: DocumentActionComponent = (props: DocumentAction
     tooltip =
       'Live Edit is enabled for this content type and publishing happens automatically as you make changes'
   }
+  if (isVariantSelected) {
+    tooltip =
+      'Legacy scheduled publishing is not available for variants, use scheduled drafts instead'
+  }
 
   const dialog: DocumentActionDialogProps = {
     content: fetchError ? (
@@ -163,7 +172,7 @@ export const useScheduleAction: DocumentActionComponent = (props: DocumentAction
   if (!enabled) return null
   return {
     dialog: dialogOpen && dialog,
-    disabled: isInitialLoading || !documentExists || liveEdit,
+    disabled: isInitialLoading || !documentExists || liveEdit || isVariantSelected,
     label: title,
     icon: CalendarIcon,
     onHandle: handleDialogOpen,

--- a/packages/sanity/src/core/singleDocRelease/i18n/resources.ts
+++ b/packages/sanity/src/core/singleDocRelease/i18n/resources.ts
@@ -23,6 +23,8 @@ const singleDocReleaseLocaleStrings = defineLocalesResources('singleDocRelease',
   /** Tooltip text for when schedule publish is disabled due to cardinality one releases */
   'action.schedule-publish.disabled.cardinality-one':
     'A Scheduled Draft for this document already exists.',
+  /** Tooltip text for when schedule publish is disabled because a variant is selected */
+  'action.schedule-publish.disabled.variant': 'Scheduling is not yet available for variants.',
   /** Empty state title for scheduled drafts */
   'empty-state.title': 'Scheduled Drafts',
   /** Empty state description for scheduled drafts */

--- a/packages/sanity/src/core/singleDocRelease/plugin/documentActions/SchedulePublishAction.tsx
+++ b/packages/sanity/src/core/singleDocRelease/plugin/documentActions/SchedulePublishAction.tsx
@@ -36,7 +36,8 @@ export const useSchedulePublishAction: DocumentActionComponent = (
   const {handleOpenDialog: handleOpenUpsellDialog} = useSingleDocReleaseUpsell()
   // Check validation status.
   // No `getTargetScopeId(useTargetDocumentState())` here: scheduling a draft publish deliberately validates the
-  // explicit draft of the document, independent of the selected perspective.
+  // explicit draft of the document, independent of the selected perspective. This is safe because
+  // the action is disabled while a variant is selected (see `isVariantSelected` below).
   // TODO: this will be supported in the future, look for SAPP-3986 and SAPP-3987.
   const validationStatus = useValidationStatus(getDraftId(id), type, true)
   const hasValidationErrors = validationStatus.validation.some(isValidationErrorMarker)
@@ -51,6 +52,10 @@ export const useSchedulePublishAction: DocumentActionComponent = (
   // Check if current release is a paused scheduled draft
   const {data: releases = []} = useActiveReleases()
   const perspective = usePerspective()
+
+  // Scheduling operates on the base draft, so it is not available while a variant is selected —
+  // it would silently schedule the base document instead of the variant (SAPP-3986).
+  const isVariantSelected = perspective.selectedVariantName !== undefined
 
   const currentRelease = useMemo(
     () =>
@@ -119,11 +124,17 @@ export const useSchedulePublishAction: DocumentActionComponent = (
     ],
   )
 
-  const disabled = isPaused
-    ? hasValidationErrors // Only check validation errors for paused drafts
-    : hasCardinalityOneReleaseVersions || hasValidationErrors // Full check for regular drafts
+  const disabled =
+    isVariantSelected ||
+    (isPaused
+      ? hasValidationErrors // Only check validation errors for paused drafts
+      : hasCardinalityOneReleaseVersions || hasValidationErrors) // Full check for regular drafts
 
   const title = useMemo(() => {
+    if (isVariantSelected) {
+      return t('action.schedule-publish.disabled.variant')
+    }
+
     if (isPaused && hasValidationErrors) {
       return t('action.schedule-publish.disabled.validation-issues')
     }
@@ -137,7 +148,7 @@ export const useSchedulePublishAction: DocumentActionComponent = (
     }
 
     return t('action.schedule-publish')
-  }, [isPaused, hasValidationErrors, hasCardinalityOneReleaseVersions, t])
+  }, [isVariantSelected, isPaused, hasValidationErrors, hasCardinalityOneReleaseVersions, t])
 
   if (!singleDocReleaseEnabled) {
     return null

--- a/packages/sanity/src/core/singleDocRelease/plugin/documentActions/SchedulePublishAction.tsx
+++ b/packages/sanity/src/core/singleDocRelease/plugin/documentActions/SchedulePublishAction.tsx
@@ -55,7 +55,7 @@ export const useSchedulePublishAction: DocumentActionComponent = (
 
   // Scheduling operates on the base draft, so it is not available while a variant is selected —
   // it would silently schedule the base document instead of the variant (SAPP-3986).
-  const isVariantSelected = perspective.selectedVariantName !== undefined
+  const isVariantSelected = Boolean(perspective.selectedVariantName)
 
   const currentRelease = useMemo(
     () =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fixes [SAPP-3986](https://linear.app/sanity/issue/SAPP-3986/disable-schedule-for-publish-action-on-draft-variants). Both schedule document actions — `SchedulePublishAction` (scheduled drafts) and the legacy `ScheduleAction` (scheduled publishing) — operate on the base draft (`getDraftId(id)`), but they were still offered while a content variant was selected on the drafts perspective. Clicking them would silently schedule the *base* document instead of the variant. Published variants were already covered, since neither action is registered for the `published` version type.

The actions are now disabled with an explanatory tooltip ("Scheduling is not yet available for variants") whenever `usePerspective().selectedVariantName` is set. Disabling (rather than hiding) was chosen to make the out-of-scope state explicit, per the WS6 guidance in `EDITING_PLAN.md` ("explicit out-of-scope guards rather than silent base behavior"), and the guard lives in the actions rather than the resolvers because `DocumentActionsContext` carries no variant information.

#### Scheduled drafts
<img width="1219" height="896" alt="Screenshot 2026-07-24 at 12 41 55" src="https://github.com/user-attachments/assets/06cebdc0-f743-4db2-b476-04d2ccf2da32" />

#### Legacy scheduled publishing
<img width="1215" height="895" alt="Screenshot 2026-07-24 at 12 45 11" src="https://github.com/user-attachments/assets/4ae76302-cbd9-4fb4-88b3-f0d3b39f7155" />

### What to review

- `packages/sanity/src/core/singleDocRelease/plugin/documentActions/SchedulePublishAction.tsx` — the variant guard, including the paused-scheduled-draft branch
- `packages/sanity/src/core/scheduled-publishing/plugin/documentActions/schedule/ScheduleAction.tsx` — same guard for the deprecated scheduled publishing action (hardcoded tooltip, matching the file's existing non-i18n strings)
- New i18n key `action.schedule-publish.disabled.variant` in the `singleDocRelease` namespace

Only the `sanity` package is affected.

### Testing

Manual testing in the studio. Select a variant and confirm it's disabled.

### Notes for release

N/A – Part of the content variants feature (not yet generally enabled).

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75ca8c63-eb62-4ccb-9d23-03e68b83dcfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75ca8c63-eb62-4ccb-9d23-03e68b83dcfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

