### PR TITLE
feat(core): unclaimed project claim intake and nudge

### DIFF
--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -2365,35 +2365,6 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'tree-editing-dialog.sidebar.action.expand': 'Expand',
   /** Label to open the sidebar */
   'tree-editing-dialog.sidebar.action.open': 'Open sidebar',
-  /** Claim CTA in the unclaimed-project banner */
-  'unclaimed-project.banner.claim-button.text': "Claim it — it's free",
-  /** Unclaimed-project banner text as expiry nears; `expiry` is a localized relative time, e.g. "in 3 hours" */
-  'unclaimed-project.banner.critical.text':
-    'Last call — everything in this project is deleted {{expiry}} unless you claim it.',
-  /** Unclaimed-project banner text; `expiry` is a localized relative time, e.g. "in 2 days" */
-  'unclaimed-project.banner.text':
-    "You're building on a 72-hour fuse: this unclaimed project expires {{expiry}}.",
-  /** CTA in the banner shown once the project has been claimed */
-  'unclaimed-project.claimed.sign-in-button.text': 'Sign in',
-  /** Banner text shown once the project has been claimed while still on the pre-claim token */
-  'unclaimed-project.claimed.text':
-    'Claimed — this project is yours. Sign in to continue as yourself.',
-  /** Toast shown once when an unclaimed project has expired and been deleted */
-  'unclaimed-project.expired.toast.title': 'This unclaimed project expired and was deleted',
-  /** Recovery hint when the project is unclaimed but no claim link is stored in this browser */
-  'unclaimed-project.no-claim-url.text':
-    'Your claim link is in the terminal — run <code>sanity dev</code> and open the printed URL.',
-  /** Claim CTA in the unclaimed-project toast */
-  'unclaimed-project.toast.claim-button.text': 'Claim this project',
-  /** Unclaimed-project toast title as expiry nears; `expiry` is a localized relative time, e.g. "in 3 hours" */
-  'unclaimed-project.toast.critical.title': 'Last call: this project self-destructs {{expiry}}',
-  /** Unclaimed-project toast body */
-  'unclaimed-project.toast.description':
-    "It's minted but unclaimed. Claim it — free, takes about a minute — and the content, this Studio, and everything you've built stay yours for good.",
-  /** Snooze CTA in the unclaimed-project toast */
-  'unclaimed-project.toast.snooze-button.text': 'Remind me in 30 minutes',
-  /** Unclaimed-project toast title; `expiry` is a localized relative time, e.g. "in 2 days" */
-  'unclaimed-project.toast.title': 'This project self-destructs {{expiry}}',
   /** Label for the button showed after trial ended */
   'user-menu.action.free-trial-finished': 'Upgrade from free',
   /** Label for button showing the free trial days left */

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -2365,6 +2365,35 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'tree-editing-dialog.sidebar.action.expand': 'Expand',
   /** Label to open the sidebar */
   'tree-editing-dialog.sidebar.action.open': 'Open sidebar',
+  /** Claim CTA in the unclaimed-project banner */
+  'unclaimed-project.banner.claim-button.text': "Claim it — it's free",
+  /** Unclaimed-project banner text as expiry nears; `expiry` is a localized relative time, e.g. "in 3 hours" */
+  'unclaimed-project.banner.critical.text':
+    'Last call — everything in this project is deleted {{expiry}} unless you claim it.',
+  /** Unclaimed-project banner text; `expiry` is a localized relative time, e.g. "in 2 days" */
+  'unclaimed-project.banner.text':
+    "You're building on a 72-hour fuse: this unclaimed project expires {{expiry}}.",
+  /** CTA in the banner shown once the project has been claimed */
+  'unclaimed-project.claimed.sign-in-button.text': 'Sign in',
+  /** Banner text shown once the project has been claimed while still on the pre-claim token */
+  'unclaimed-project.claimed.text':
+    'Claimed — this project is yours. Sign in to continue as yourself.',
+  /** Toast shown once when an unclaimed project has expired and been deleted */
+  'unclaimed-project.expired.toast.title': 'This unclaimed project expired and was deleted',
+  /** Recovery hint when the project is unclaimed but no claim link is stored in this browser */
+  'unclaimed-project.no-claim-url.text':
+    'Your claim link is in the terminal — run <code>sanity dev</code> and open the printed URL.',
+  /** Claim CTA in the unclaimed-project toast */
+  'unclaimed-project.toast.claim-button.text': 'Claim this project',
+  /** Unclaimed-project toast title as expiry nears; `expiry` is a localized relative time, e.g. "in 3 hours" */
+  'unclaimed-project.toast.critical.title': 'Last call: this project self-destructs {{expiry}}',
+  /** Unclaimed-project toast body */
+  'unclaimed-project.toast.description':
+    "It's minted but unclaimed. Claim it — free, takes about a minute — and the content, this Studio, and everything you've built stay yours for good.",
+  /** Snooze CTA in the unclaimed-project toast */
+  'unclaimed-project.toast.snooze-button.text': 'Remind me in 30 minutes',
+  /** Unclaimed-project toast title; `expiry` is a localized relative time, e.g. "in 2 days" */
+  'unclaimed-project.toast.title': 'This project self-destructs {{expiry}}',
   /** Label for the button showed after trial ended */
   'user-menu.action.free-trial-finished': 'Upgrade from free',
   /** Label for button showing the free trial days left */

--- a/packages/sanity/src/core/store/authStore/__tests__/createAuthStore.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/createAuthStore.test.ts
@@ -1766,3 +1766,61 @@ describe('createAuthStore: workbench OS token', () => {
     expect(state.authenticated).toBe(true)
   })
 })
+
+describe('createAuthStore: hash claim intake', () => {
+  const CLAIM_URL = 'https://www.sanity.io/manage/claim/some-claim-token'
+  const CLAIM_STORAGE_KEY = `__studio_unclaimed_${PROJECT_ID}`
+
+  beforeEach(() => {
+    localStorage.clear()
+    window.location.hash = ''
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    window.location.hash = ''
+  })
+
+  it('consumes a #claim= fragment on boot and records it for the project', () => {
+    window.location.hash = `#claim=${encodeURIComponent(CLAIM_URL)}`
+    const mock = createMockClientFactory()
+
+    _createAuthStore({
+      projectId: PROJECT_ID,
+      dataset: DATASET,
+      loginMethod: 'token',
+      clientFactory: mock.factory,
+      getSessionId: () => undefined,
+      consumeHashToken: () => undefined,
+    })
+
+    expect(JSON.parse(localStorage.getItem(CLAIM_STORAGE_KEY)!)).toEqual({claimUrl: CLAIM_URL})
+    expect(window.location.hash).toBe('')
+  })
+
+  it('consumes a #claim= fragment pasted into an open tab', async () => {
+    const mock = createMockClientFactory()
+
+    const store = _createAuthStore({
+      projectId: PROJECT_ID,
+      dataset: DATASET,
+      loginMethod: 'token',
+      clientFactory: mock.factory,
+      getSessionId: () => undefined,
+      consumeHashToken: () => undefined,
+    })
+    const sub = store.state.subscribe(() => {})
+
+    try {
+      window.location.hash = `#claim=${encodeURIComponent(CLAIM_URL)}`
+      window.dispatchEvent(new HashChangeEvent('hashchange'))
+
+      await vi.waitFor(() => {
+        expect(JSON.parse(localStorage.getItem(CLAIM_STORAGE_KEY)!)).toEqual({claimUrl: CLAIM_URL})
+      })
+      expect(window.location.hash).toBe('')
+    } finally {
+      sub.unsubscribe()
+    }
+  })
+})

--- a/packages/sanity/src/core/store/authStore/__tests__/hashClaim.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/hashClaim.test.ts
@@ -1,0 +1,75 @@
+import {afterEach, describe, expect, it} from 'vitest'
+
+import {consumeHashClaim} from '../hashClaim'
+
+const CLAIM_URL = 'https://www.sanity.io/manage/claim/some-claim-token'
+const ROBOT_TOKEN = 'sk'.repeat(32)
+
+describe('consumeHashClaim', () => {
+  afterEach(() => {
+    history.replaceState(null, '', '/')
+  })
+
+  it('consumes a valid claim URL and strips it from the hash', () => {
+    window.location.hash = `#claim=${encodeURIComponent(CLAIM_URL)}`
+    expect(consumeHashClaim()).toBe(CLAIM_URL)
+    expect(window.location.hash).toBe('')
+  })
+
+  it('accepts the staging host', () => {
+    const stagingUrl = 'https://www.sanity.work/manage/claim/some-claim-token'
+    window.location.hash = `#claim=${encodeURIComponent(stagingUrl)}`
+    expect(consumeHashClaim()).toBe(stagingUrl)
+  })
+
+  it('leaves the token param for the token reader', () => {
+    window.location.hash = `#token=${ROBOT_TOKEN}&claim=${encodeURIComponent(CLAIM_URL)}`
+    expect(consumeHashClaim()).toBe(CLAIM_URL)
+    expect(window.location.hash).toContain(`token=${ROBOT_TOKEN}`)
+    expect(window.location.hash).not.toContain('claim=')
+  })
+
+  it('leaves unknown params untouched', () => {
+    window.location.hash = `#foo=bar&claim=${encodeURIComponent(CLAIM_URL)}&baz=qux`
+    expect(consumeHashClaim()).toBe(CLAIM_URL)
+    expect(window.location.hash).toBe('#foo=bar&baz=qux')
+  })
+
+  it('returns undefined and leaves the hash alone when there is no claim param', () => {
+    window.location.hash = '#foo=bar'
+    expect(consumeHashClaim()).toBeUndefined()
+    expect(window.location.hash).toBe('#foo=bar')
+  })
+
+  it('ignores params whose name merely ends in claim', () => {
+    window.location.hash = `#myclaim=${encodeURIComponent(CLAIM_URL)}`
+    expect(consumeHashClaim()).toBeUndefined()
+    expect(window.location.hash).toBe(`#myclaim=${encodeURIComponent(CLAIM_URL)}`)
+  })
+
+  it('ignores claim= embedded inside another value', () => {
+    window.location.hash = '#foo=xclaim=y'
+    expect(consumeHashClaim()).toBeUndefined()
+    expect(window.location.hash).toBe('#foo=xclaim=y')
+  })
+
+  it.each([
+    ['non-https URL', 'http://www.sanity.io/manage/claim/some-claim-token'],
+    ['non-Sanity host', 'https://evil.example.com/manage/claim/some-claim-token'],
+    ['host suffix impersonation', 'https://evilsanity.io/manage/claim/some-claim-token'],
+    ['missing claim token', 'https://www.sanity.io/manage/claim/'],
+    ['no claim path segment', 'https://www.sanity.io/manage/some-claim-token'],
+    ['javascript URL', 'javascript:alert(1)'],
+    ['not a URL', 'some-claim-token'],
+  ])('discards a %s but still strips it from the hash', (_label, value) => {
+    window.location.hash = `#claim=${encodeURIComponent(value)}`
+    expect(consumeHashClaim()).toBeUndefined()
+    expect(window.location.hash).toBe('')
+  })
+
+  it('discards malformed percent-encoding but still strips it from the hash', () => {
+    window.location.hash = '#claim=%E0%A4%A'
+    expect(consumeHashClaim()).toBeUndefined()
+    expect(window.location.hash).toBe('')
+  })
+})

--- a/packages/sanity/src/core/store/authStore/__tests__/unclaimedProjectStorage.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/unclaimedProjectStorage.test.ts
@@ -48,6 +48,37 @@ describe('unclaimedProjectStorage', () => {
     expect(readUnclaimedProjectRecord(PROJECT_ID)).toBeUndefined()
   })
 
+  it('drops invalid optional dates from an otherwise valid record', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        claimUrl: CLAIM_URL,
+        expiresAt: 'not-a-date',
+        lastLookupAt: 123,
+      }),
+    )
+
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toEqual({claimUrl: CLAIM_URL})
+  })
+
+  it('keeps valid optional dates and drops unknown properties', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        claimUrl: CLAIM_URL,
+        expiresAt: '2026-07-27T00:00:00.000Z',
+        lastLookupAt: '2026-07-24T12:00:00.000Z',
+        unexpected: 'value',
+      }),
+    )
+
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toEqual({
+      claimUrl: CLAIM_URL,
+      expiresAt: '2026-07-27T00:00:00.000Z',
+      lastLookupAt: '2026-07-24T12:00:00.000Z',
+    })
+  })
+
   it('scopes records by project', () => {
     writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
     expect(readUnclaimedProjectRecord('other-project')).toBeUndefined()

--- a/packages/sanity/src/core/store/authStore/__tests__/unclaimedProjectStorage.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/unclaimedProjectStorage.test.ts
@@ -1,0 +1,93 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getUnclaimedProjectStorageKey} from '../constants'
+import {
+  clearUnclaimedProjectRecord,
+  clearUnclaimedProjectSnooze,
+  readUnclaimedProjectRecord,
+  readUnclaimedProjectSnoozedAt,
+  recordHashClaimUrl,
+  writeUnclaimedProjectRecord,
+  writeUnclaimedProjectSnoozedAt,
+} from '../unclaimedProjectStorage'
+
+// In jsdom/Node.js supportsLocalStorage is false because process.versions.node is defined.
+vi.mock('../../../util/supportsLocalStorage', () => ({
+  supportsLocalStorage: true,
+}))
+
+const PROJECT_ID = 'test-project'
+const CLAIM_URL = 'https://www.sanity.io/manage/claim/some-claim-token'
+const STORAGE_KEY = getUnclaimedProjectStorageKey(PROJECT_ID)
+
+describe('unclaimedProjectStorage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('round-trips a record', () => {
+    const record = {claimUrl: CLAIM_URL, expiresAt: '2026-07-27T00:00:00.000Z'}
+    writeUnclaimedProjectRecord(PROJECT_ID, record)
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toEqual(record)
+    clearUnclaimedProjectRecord(PROJECT_ID)
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toBeUndefined()
+  })
+
+  it('reads a missing record as undefined', () => {
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toBeUndefined()
+  })
+
+  it.each([
+    ['invalid JSON', 'not-json'],
+    ['wrong shape', JSON.stringify({expiresAt: '2026-07-27T00:00:00.000Z'})],
+    ['non-object', JSON.stringify('claim-url')],
+    ['non-allowlisted claim URL', JSON.stringify({claimUrl: 'javascript:alert(1)'})],
+    ['non-Sanity host', JSON.stringify({claimUrl: 'https://evil.example.com/manage/claim/x'})],
+  ])('reads a corrupt record (%s) as absent', (_label, raw) => {
+    localStorage.setItem(STORAGE_KEY, raw)
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toBeUndefined()
+  })
+
+  it('scopes records by project', () => {
+    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+    expect(readUnclaimedProjectRecord('other-project')).toBeUndefined()
+  })
+
+  describe('recordHashClaimUrl', () => {
+    it('creates a record holding only the claim URL', () => {
+      recordHashClaimUrl(PROJECT_ID, CLAIM_URL)
+      expect(readUnclaimedProjectRecord(PROJECT_ID)).toEqual({claimUrl: CLAIM_URL})
+    })
+
+    it('keeps refinements when the claim URL is unchanged', () => {
+      const refined = {
+        claimUrl: CLAIM_URL,
+        expiresAt: '2026-07-27T00:00:00.000Z',
+        lastLookupAt: '2026-07-24T12:00:00.000Z',
+      }
+      writeUnclaimedProjectRecord(PROJECT_ID, refined)
+      recordHashClaimUrl(PROJECT_ID, CLAIM_URL)
+      expect(readUnclaimedProjectRecord(PROJECT_ID)).toEqual(refined)
+    })
+
+    it('replaces the record when a different claim URL arrives', () => {
+      writeUnclaimedProjectRecord(PROJECT_ID, {
+        claimUrl: CLAIM_URL,
+        expiresAt: '2026-07-27T00:00:00.000Z',
+      })
+      const nextClaimUrl = 'https://www.sanity.io/manage/claim/another-claim-token'
+      recordHashClaimUrl(PROJECT_ID, nextClaimUrl)
+      expect(readUnclaimedProjectRecord(PROJECT_ID)).toEqual({claimUrl: nextClaimUrl})
+    })
+  })
+
+  describe('snooze', () => {
+    it('round-trips independently of the record', () => {
+      writeUnclaimedProjectSnoozedAt(PROJECT_ID, '2026-07-24T12:00:00.000Z')
+      expect(readUnclaimedProjectSnoozedAt(PROJECT_ID)).toBe('2026-07-24T12:00:00.000Z')
+      expect(readUnclaimedProjectRecord(PROJECT_ID)).toBeUndefined()
+      clearUnclaimedProjectSnooze(PROJECT_ID)
+      expect(readUnclaimedProjectSnoozedAt(PROJECT_ID)).toBeUndefined()
+    })
+  })
+})

--- a/packages/sanity/src/core/store/authStore/constants.ts
+++ b/packages/sanity/src/core/store/authStore/constants.ts
@@ -14,6 +14,9 @@ const AUTH_TOKEN_STORAGE_PREFIX = '__studio_auth_token_'
 // Prefix for the BroadcastChannel / localStorage key for cross-tab cookie auth state.
 const COOKIE_AUTH_STATE_PREFIX = '__studio_auth_cookie_state_'
 
+// Prefix for the localStorage key holding the claim record of a minted-but-unclaimed project.
+const UNCLAIMED_PROJECT_STORAGE_PREFIX = '__studio_unclaimed_'
+
 /**
  * @internal
  * Timeout for the post-exchange `/users/me` probe (see
@@ -52,4 +55,9 @@ export function getAuthTokenStorageKey(projectId: string): string {
 /** @internal BroadcastChannel / localStorage key for cross-tab cookie auth state. */
 export function getCookieAuthStateKey(projectId: string): string {
   return `${COOKIE_AUTH_STATE_PREFIX}${projectId}`
+}
+
+/** @internal localStorage key holding the unclaimed-project claim record. Value shape: `UnclaimedProjectRecord`. */
+export function getUnclaimedProjectStorageKey(projectId: string): string {
+  return `${UNCLAIMED_PROJECT_STORAGE_PREFIX}${projectId}`
 }

--- a/packages/sanity/src/core/store/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/authStore/createAuthStore.ts
@@ -52,6 +52,7 @@ import {
 import {createBroadcastState} from './createBroadcastState'
 import {createBroadcastStorage} from './createBroadcastStorage'
 import {createLoginComponent} from './createLoginComponent'
+import {consumeHashClaim} from './hashClaim'
 import {consumeHashToken as defaultConsumeHashToken} from './hashToken'
 import {clearHashSessionId, getHashSessionId as defaultGetSessionId} from './sessionId'
 import {
@@ -60,6 +61,7 @@ import {
   type AuthStore,
   type HandleCallbackResult,
 } from './types'
+import {recordHashClaimUrl} from './unclaimedProjectStorage'
 import {isCookielessCompatibleLoginMethod} from './utils/asserters'
 import {
   observeWorkbenchToken as defaultObserveWorkbenchToken,
@@ -320,6 +322,13 @@ export function _createAuthStore({
   // * if loginMethod == "cookie"
   //    1. HTTP cookie
 
+  // A `#claim=` fragment rides beside `#token=` (see hashClaim.ts) and is consumed at the same
+  // two lifecycle points, claim first, so both always land on the same project.
+  const consumeHashClaimUrl = () => {
+    const claimUrl = consumeHashClaim()
+    if (claimUrl) recordHashClaimUrl(projectId, claimUrl)
+  }
+
   const tokenStorage = createBroadcastStorage<{token?: string}>(
     getAuthTokenStorageKey(projectId),
     // sets the initial value
@@ -330,6 +339,7 @@ export function _createAuthStore({
         // store will log you out. Need to find a better way to deal with this
         // return undefined
       }
+      consumeHashClaimUrl()
       const hashToken = consumeHashToken()
       // use hash token if it exists, assume authenticated
       return hashToken ? {token: hashToken, authenticated: true} : currentTokenValue
@@ -464,6 +474,7 @@ export function _createAuthStore({
       ? EMPTY
       : fromEvent(window, 'hashchange').pipe(
           tap(() => {
+            consumeHashClaimUrl()
             const hashToken = consumeHashToken()
             if (hashToken) {
               tokenStorage.update({token: hashToken})

--- a/packages/sanity/src/core/store/authStore/hashClaim.ts
+++ b/packages/sanity/src/core/store/authStore/hashClaim.ts
@@ -1,0 +1,52 @@
+const CLAIM_URL_HOSTS = new Set(['sanity.io', 'www.sanity.io', 'sanity.work', 'www.sanity.work'])
+
+/**
+ * Whether a value is safe to render as a claim link: a well-formed https URL on a Sanity host
+ * with a `/claim/<token>` path. Applied at hash intake and again when reading the stored record
+ * (see `unclaimedProjectStorage.ts`), so a tampered record can't become a clickable link.
+ *
+ * @internal
+ */
+export const isValidClaimUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value)
+    const segments = url.pathname.split('/').filter(Boolean)
+    return (
+      url.protocol === 'https:' &&
+      CLAIM_URL_HOSTS.has(url.hostname) &&
+      segments.length >= 2 &&
+      segments[segments.length - 2] === 'claim'
+    )
+  } catch {
+    return false
+  }
+}
+
+export const consumeHashClaim = (): string | undefined => {
+  if (typeof window === 'undefined' || typeof window.location !== 'object') {
+    return undefined
+  }
+
+  // The fragment is a `&`-separated param list; take the `claim` param wherever it sits
+  // (humans re-paste and reorder URLs) and leave every other param alone.
+  const params = window.location.hash.replace(/^#/, '').split('&')
+  const claimIndex = params.findIndex((param) => param.startsWith('claim='))
+  if (claimIndex === -1) {
+    return undefined
+  }
+  const claimParam = params[claimIndex].slice('claim='.length)
+
+  // Remove the claim URL from the URL even when invalid — a bad fragment must never linger
+  params.splice(claimIndex, 1)
+  const newUrl = new URL(window.location.href)
+  newUrl.hash = params.filter(Boolean).join('&')
+  history.replaceState(null, '', newUrl)
+
+  let claimUrl: string
+  try {
+    claimUrl = decodeURIComponent(claimParam)
+  } catch {
+    return undefined
+  }
+  return isValidClaimUrl(claimUrl) ? claimUrl : undefined
+}

--- a/packages/sanity/src/core/store/authStore/unclaimedProjectStorage.ts
+++ b/packages/sanity/src/core/store/authStore/unclaimedProjectStorage.ts
@@ -1,0 +1,101 @@
+import {supportsLocalStorage} from '../../util/supportsLocalStorage'
+import {getUnclaimedProjectStorageKey} from './constants'
+import {isValidClaimUrl} from './hashClaim'
+
+/**
+ * Claim record for a minted-but-unclaimed project. Written by the auth store when a `#claim=`
+ * URL fragment is consumed (see `hashClaim.ts`), refined and eventually cleared by the
+ * in-studio claim nudge. Plain localStorage, not live auth state: a corrupt record reads as
+ * absent and gets replaced on the next write.
+ *
+ * @internal
+ */
+export interface UnclaimedProjectRecord {
+  claimUrl: string
+  expiresAt?: string
+  lastLookupAt?: string
+}
+
+/** @internal */
+export function readUnclaimedProjectRecord(projectId: string): UnclaimedProjectRecord | undefined {
+  if (!supportsLocalStorage) return undefined
+  try {
+    const raw = localStorage.getItem(getUnclaimedProjectStorageKey(projectId))
+    const record = raw ? JSON.parse(raw) : undefined
+    // The claim URL is rendered as a link, so a stored value must pass the same allowlist as
+    // hash intake — a tampered record reads as absent, like any other corruption.
+    return typeof record?.claimUrl === 'string' && isValidClaimUrl(record.claimUrl)
+      ? record
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** @internal */
+export function writeUnclaimedProjectRecord(
+  projectId: string,
+  record: UnclaimedProjectRecord,
+): void {
+  if (!supportsLocalStorage) return
+  try {
+    localStorage.setItem(getUnclaimedProjectStorageKey(projectId), JSON.stringify(record))
+  } catch {
+    // best-effort
+  }
+}
+
+/** @internal */
+export function clearUnclaimedProjectRecord(projectId: string): void {
+  if (!supportsLocalStorage) return
+  try {
+    localStorage.removeItem(getUnclaimedProjectStorageKey(projectId))
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Store a claim URL consumed from the URL fragment. The fragment carries no expiry, so a
+ * re-consumed URL for the same claim keeps the refinements already recorded.
+ *
+ * @internal
+ */
+export function recordHashClaimUrl(projectId: string, claimUrl: string): void {
+  if (readUnclaimedProjectRecord(projectId)?.claimUrl === claimUrl) return
+  writeUnclaimedProjectRecord(projectId, {claimUrl})
+}
+
+function getSnoozeKey(projectId: string): string {
+  return `${getUnclaimedProjectStorageKey(projectId)}_snooze`
+}
+
+/** @internal */
+export function readUnclaimedProjectSnoozedAt(projectId: string): string | undefined {
+  if (!supportsLocalStorage) return undefined
+  try {
+    return localStorage.getItem(getSnoozeKey(projectId)) ?? undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** @internal */
+export function writeUnclaimedProjectSnoozedAt(projectId: string, snoozedAt: string): void {
+  if (!supportsLocalStorage) return
+  try {
+    localStorage.setItem(getSnoozeKey(projectId), snoozedAt)
+  } catch {
+    // best-effort
+  }
+}
+
+/** @internal */
+export function clearUnclaimedProjectSnooze(projectId: string): void {
+  if (!supportsLocalStorage) return
+  try {
+    localStorage.removeItem(getSnoozeKey(projectId))
+  } catch {
+    // best-effort
+  }
+}

--- a/packages/sanity/src/core/store/authStore/unclaimedProjectStorage.ts
+++ b/packages/sanity/src/core/store/authStore/unclaimedProjectStorage.ts
@@ -16,17 +16,37 @@ export interface UnclaimedProjectRecord {
   lastLookupAt?: string
 }
 
+function isValidDateString(value: unknown): value is string {
+  return typeof value === 'string' && !Number.isNaN(new Date(value).getTime())
+}
+
 /** @internal */
 export function readUnclaimedProjectRecord(projectId: string): UnclaimedProjectRecord | undefined {
   if (!supportsLocalStorage) return undefined
   try {
     const raw = localStorage.getItem(getUnclaimedProjectStorageKey(projectId))
-    const record = raw ? JSON.parse(raw) : undefined
+    const record: unknown = raw ? JSON.parse(raw) : undefined
     // The claim URL is rendered as a link, so a stored value must pass the same allowlist as
     // hash intake — a tampered record reads as absent, like any other corruption.
-    return typeof record?.claimUrl === 'string' && isValidClaimUrl(record.claimUrl)
-      ? record
-      : undefined
+    if (
+      !record ||
+      typeof record !== 'object' ||
+      !('claimUrl' in record) ||
+      typeof record.claimUrl !== 'string' ||
+      !isValidClaimUrl(record.claimUrl)
+    ) {
+      return undefined
+    }
+
+    return {
+      claimUrl: record.claimUrl,
+      ...('expiresAt' in record && isValidDateString(record.expiresAt)
+        ? {expiresAt: record.expiresAt}
+        : {}),
+      ...('lastLookupAt' in record && isValidDateString(record.lastLookupAt)
+        ? {lastLookupAt: record.lastLookupAt}
+        : {}),
+    }
   } catch {
     return undefined
   }

--- a/packages/sanity/src/core/studio/StudioLayout.tsx
+++ b/packages/sanity/src/core/studio/StudioLayout.tsx
@@ -24,6 +24,7 @@ import {
 import {StudioErrorBoundary} from './StudioErrorBoundary'
 import {getPageVisibilitySnapshot} from './telemetry/pageVisibility'
 import {ToolMountTimer} from './ToolMountTimer'
+import {UnclaimedProjectNudge} from './unclaimedProject/UnclaimedProjectNudge'
 import {useWorkspace} from './workspace'
 
 const DetectViteDevServerStopped = lazy(() =>
@@ -230,6 +231,7 @@ export function StudioLayoutComponent() {
         {/* oxlint-disable-next-line react/react-compiler -- Navbar comes from useNavbarComponent(), stable per workspace */}
         <Navbar />
       </NavbarContext.Provider>
+      <UnclaimedProjectNudge />
       {isLegacyDeskRedirect && <RedirectingScreen />}
       {!activeTool && defaultRouteTools.length === 0 && <NoToolsScreen />}
       {tools.length > 0 && !activeTool && activeToolName && !isLegacyDeskRedirect && (

--- a/packages/sanity/src/core/studio/__tests__/StudioLayout.test.tsx
+++ b/packages/sanity/src/core/studio/__tests__/StudioLayout.test.tsx
@@ -50,6 +50,10 @@ vi.mock('../StudioErrorBoundary', () => ({
   StudioErrorBoundary: ({children}: {children: React.ReactNode}) => <>{children}</>,
 }))
 
+vi.mock('../unclaimedProject/UnclaimedProjectNudge', () => ({
+  UnclaimedProjectNudge: () => null,
+}))
+
 vi.mock('../screens/NoToolsScreen', () => ({
   NoToolsScreen: () => <div data-testid="no-tools" />,
 }))

--- a/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../store/authStore/unclaimedProjectStorage'
 import {interpolateTemplate} from '../../util/interpolateTemplate'
 import {useWorkspace} from '../workspace'
-import {useUnclaimedProject} from './useUnclaimedProject'
+import {type UnclaimedProjectState, useUnclaimedProject} from './useUnclaimedProject'
 import {
   getClaimedIdentityText,
   getClaimedIdentityTextParts,
@@ -28,12 +28,38 @@ import {
  * @internal
  */
 export function UnclaimedProjectNudge() {
-  const {auth, projectId} = useWorkspace()
+  const {currentUser} = useWorkspace()
+
+  if (currentUser?.provider !== 'sanity-token') return null
+
+  return <UnclaimedProjectNudgeStateCheck />
+}
+
+function UnclaimedProjectNudgeStateCheck() {
+  const {projectId} = useWorkspace()
   const [claimAttempt, setClaimAttempt] = useState<{projectId: string; startedAt: number}>()
   const claimAttemptedAt =
     claimAttempt?.projectId === projectId ? claimAttempt.startedAt : undefined
   const state = useUnclaimedProject({claimAttemptedAt})
-  const copy = useUnclaimedProjectCopy(Boolean(state))
+  const handleClaim = useCallback(
+    () => setClaimAttempt({projectId, startedAt: Date.now()}),
+    [projectId],
+  )
+
+  if (!state) return null
+
+  return <UnclaimedProjectNudgeInner onClaim={handleClaim} state={state} />
+}
+
+function UnclaimedProjectNudgeInner({
+  onClaim,
+  state,
+}: {
+  onClaim: () => void
+  state: UnclaimedProjectState
+}) {
+  const {auth, projectId} = useWorkspace()
+  const copy = useUnclaimedProjectCopy(true)
 
   const unclaimed = state?.status === 'unclaimed' ? state : undefined
   const now = useMinuteTick(Boolean(unclaimed))
@@ -55,10 +81,6 @@ export function UnclaimedProjectNudge() {
     writeUnclaimedProjectSnoozedAt(projectId, at)
     setSnoozeState({projectId, snoozedAt: at})
   }, [projectId])
-  const handleClaim = useCallback(
-    () => setClaimAttempt({projectId, startedAt: Date.now()}),
-    [projectId],
-  )
   const snoozeDurationMs = (copy?.snoozeMinutes ?? 0) * 60_000
   const isSnoozed = Boolean(
     snoozedAt && snoozeDurationMs && now - new Date(snoozedAt).getTime() < snoozeDurationMs,
@@ -109,7 +131,7 @@ export function UnclaimedProjectNudge() {
               size="default"
               iconRight={LaunchIcon}
               text={copy.toast.claimButtonText}
-              onClick={handleClaim}
+              onClick={onClaim}
             />
           )}
           <Button
@@ -218,7 +240,7 @@ export function UnclaimedProjectNudge() {
             size="default"
             iconRight={LaunchIcon}
             text={copy.banner.claimButtonText}
-            onClick={handleClaim}
+            onClick={onClaim}
           />
         ) : unclaimed.claimLinkSpent ? null : (
           <Text size={1}>{copy.noClaimUrl.text}</Text>

--- a/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
@@ -113,7 +113,7 @@ function UnclaimedProjectNudgeInner({
       ''
     ),
     description: unclaimed && copy && (
-      <Stack space={4} paddingY={2}>
+      <Stack gap={4} paddingY={2}>
         <Text size={1} weight="regular">
           {unclaimed.claimUrl || unclaimed.claimLinkSpent
             ? copy.toast.description
@@ -170,7 +170,7 @@ function UnclaimedProjectNudgeInner({
     return (
       <Card data-testid="unclaimed-project-banner" tone="positive" padding={3} borderBottom>
         <Box display={['block', 'block', 'none']}>
-          <Stack space={3}>
+          <Stack gap={3}>
             <Flex align="center" gap={3} justify="space-between">
               <Text size={1} weight="medium" style={{flex: 1, minWidth: 0}}>
                 {copy.claimed.text}
@@ -285,7 +285,6 @@ export function UnclaimedProjectCountdown({
       aria-hidden="true"
       data-testid="unclaimed-project-countdown"
       fontSize={1}
-      mode="outline"
       padding={2}
       radius={2}
       tone={critical ? 'critical' : 'caution'}

--- a/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
@@ -15,7 +15,11 @@ import {
 } from '../../store/authStore/unclaimedProjectStorage'
 import {interpolateTemplate} from '../../util/interpolateTemplate'
 import {useWorkspace} from '../workspace'
-import {type UnclaimedProjectState, useUnclaimedProject} from './useUnclaimedProject'
+import {
+  ROBOT_PROVIDER,
+  type UnclaimedProjectState,
+  useUnclaimedProject,
+} from './useUnclaimedProject'
 import {
   getClaimedIdentityText,
   getClaimedIdentityTextParts,
@@ -40,10 +44,10 @@ function UnclaimedProjectNudgeAuthCheck() {
   const provider = currentUser?.provider
 
   useEffect(() => {
-    if (provider && provider !== 'sanity-token') clearUnclaimedProjectRecord(projectId)
+    if (provider && provider !== ROBOT_PROVIDER) clearUnclaimedProjectRecord(projectId)
   }, [projectId, provider])
 
-  if (provider !== 'sanity-token') return null
+  if (provider !== ROBOT_PROVIDER) return null
 
   return <UnclaimedProjectNudgeStateCheck />
 }

--- a/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
@@ -1,6 +1,6 @@
 import {ClockIcon} from '@sanity/icons/Clock'
 import {LaunchIcon} from '@sanity/icons/Launch'
-import {Badge, Card, Flex, Stack, Text, useToast} from '@sanity/ui'
+import {Badge, Box, Card, Flex, Stack, Text, useToast} from '@sanity/ui'
 import {startTransition, useCallback, useEffect, useState} from 'react'
 
 import {Button} from '../../../ui-components/button/Button'
@@ -14,11 +14,15 @@ import {
 import {interpolateTemplate} from '../../util/interpolateTemplate'
 import {useWorkspace} from '../workspace'
 import {useUnclaimedProject} from './useUnclaimedProject'
-import {useUnclaimedProjectCopy} from './useUnclaimedProjectCopy'
+import {
+  getClaimedIdentityText,
+  getClaimedIdentityTextParts,
+  useUnclaimedProjectCopy,
+} from './useUnclaimedProjectCopy'
 
 /**
  * Persistent banner + snoozable toast nudging the user to claim a minted-but-unclaimed project
- * before it expires, flipping to a "sign in as yourself" banner once it's claimed. Renders
+ * before it expires, flipping to an identity-aware login banner once it's claimed. Renders
  * nothing for anything not part of mint-and-claim — see {@link useUnclaimedProject}.
  *
  * @internal
@@ -142,18 +146,41 @@ export function UnclaimedProjectNudge() {
   if (state?.status === 'claimed') {
     return (
       <Card data-testid="unclaimed-project-banner" tone="positive" padding={3} borderBottom>
-        <Flex align="center" gap={3} justify="center" wrap="wrap">
-          <Text size={1} weight="medium">
-            {copy.claimed.text}
-          </Text>
-          <Button
-            mode="default"
-            tone="positive"
-            size="default"
-            text={copy.claimed.signInButtonText}
-            onClick={handleSignIn}
-          />
-        </Flex>
+        <Box display={['block', 'block', 'none']}>
+          <Stack space={3}>
+            <Flex align="center" gap={3} justify="space-between">
+              <Text size={1} weight="medium" style={{flex: 1, minWidth: 0}}>
+                {copy.claimed.text}
+              </Text>
+              <Button
+                mode="default"
+                tone="positive"
+                size="default"
+                text={copy.claimed.signInButtonText}
+                onClick={handleSignIn}
+                style={{flexShrink: 0}}
+              />
+            </Flex>
+            <Text size={1} weight="medium" style={{overflowWrap: 'anywhere'}}>
+              <ClaimedIdentityText text={copy.claimed.identityText} email={state.email} />
+            </Text>
+          </Stack>
+        </Box>
+        <Box display={['none', 'none', 'block']}>
+          <Flex align="center" gap={3} justify="center" wrap="wrap">
+            <Text size={1} weight="medium" style={{overflowWrap: 'anywhere'}}>
+              {copy.claimed.text}{' '}
+              <ClaimedIdentityText text={copy.claimed.identityText} email={state.email} />
+            </Text>
+            <Button
+              mode="default"
+              tone="positive"
+              size="default"
+              text={copy.claimed.signInButtonText}
+              onClick={handleSignIn}
+            />
+          </Flex>
+        </Box>
       </Card>
     )
   }
@@ -198,6 +225,20 @@ export function UnclaimedProjectNudge() {
         )}
       </Flex>
     </Card>
+  )
+}
+
+function ClaimedIdentityText({text, email}: {text: string; email?: string}) {
+  const parts = getClaimedIdentityTextParts(text, email)
+
+  return parts ? (
+    <>
+      {parts.before}
+      <strong>{parts.identity}</strong>
+      {parts.after}
+    </>
+  ) : (
+    getClaimedIdentityText(text, email)
   )
 }
 

--- a/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
@@ -1,6 +1,6 @@
 import {ClockIcon} from '@sanity/icons/Clock'
 import {LaunchIcon} from '@sanity/icons/Launch'
-import {Badge, Box, Card, Flex, Stack, Text, useToast} from '@sanity/ui'
+import {Badge, Box, Card, Flex, Stack, Text} from '@sanity/ui'
 import {startTransition, useCallback, useEffect, useState} from 'react'
 
 import {Button} from '../../../ui-components/button/Button'
@@ -160,22 +160,6 @@ function UnclaimedProjectNudgeInner({
       </Stack>
     ),
   })
-
-  // One final farewell, pushed once so dismissing it sticks — unlike useConditionalToast,
-  // which re-pushes for as long as its condition holds.
-  const toast = useToast()
-  const expired = state?.status === 'expired'
-  const expiredToastTitle = copy?.expired.toastTitle
-  useEffect(() => {
-    if (!expired || !expiredToastTitle) return
-    toast.push({
-      id: 'unclaimed-project-expired',
-      status: 'warning',
-      closable: true,
-      duration: Infinity,
-      title: expiredToastTitle,
-    })
-  }, [expired, expiredToastTitle, toast])
 
   if (!copy) return null
 

--- a/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
@@ -1,0 +1,189 @@
+import {ClockIcon} from '@sanity/icons/Clock'
+import {LaunchIcon} from '@sanity/icons/Launch'
+import {Card, Flex, Stack, Text, useToast} from '@sanity/ui'
+import {startTransition, useCallback, useEffect, useState} from 'react'
+
+import {Button} from '../../../ui-components'
+import {useConditionalToast, useRelativeTime} from '../../hooks'
+import {Translate, useTranslation} from '../../i18n'
+import {
+  readUnclaimedProjectSnoozedAt,
+  writeUnclaimedProjectSnoozedAt,
+} from '../../store/authStore/unclaimedProjectStorage'
+import {useWorkspace} from '../workspace'
+import {useUnclaimedProject} from './useUnclaimedProject'
+
+/** Dismissing the toast buys this much quiet before it nudges again. */
+const SNOOZE_DURATION_MS = 30 * 60_000
+
+/** Below this long left, the nudge escalates from caution to critical. */
+const CRITICAL_THRESHOLD_MS = 8 * 3_600_000
+
+/**
+ * Persistent banner + snoozable toast nudging the user to claim a minted-but-unclaimed project
+ * before it expires, flipping to a "sign in as yourself" banner once it's claimed. Renders
+ * nothing for anything not part of mint-and-claim — see {@link useUnclaimedProject}.
+ *
+ * @internal
+ */
+export function UnclaimedProjectNudge() {
+  const state = useUnclaimedProject()
+  const {auth, projectId} = useWorkspace()
+  const {t} = useTranslation()
+
+  const unclaimed = state?.status === 'unclaimed' ? state : undefined
+  const now = useMinuteTick(Boolean(unclaimed))
+  const expiry = useRelativeTime(unclaimed?.expiresAt ?? '', {useTemporalPhrase: true})
+
+  const [snoozedAt, setSnoozedAt] = useState(() => readUnclaimedProjectSnoozedAt(projectId))
+  const [snoozeProject, setSnoozeProject] = useState(projectId)
+  if (snoozeProject !== projectId) {
+    setSnoozeProject(projectId)
+    setSnoozedAt(readUnclaimedProjectSnoozedAt(projectId))
+  }
+  const handleSnooze = useCallback(() => {
+    const at = new Date().toISOString()
+    writeUnclaimedProjectSnoozedAt(projectId, at)
+    setSnoozedAt(at)
+  }, [projectId])
+  const isSnoozed = Boolean(snoozedAt && now - new Date(snoozedAt).getTime() < SNOOZE_DURATION_MS)
+
+  const critical = Boolean(
+    unclaimed && unclaimed.expiresAt.getTime() - now <= CRITICAL_THRESHOLD_MS,
+  )
+
+  // The claim URL is spent; the robot token still works, so the token is cleared through this
+  // CTA rather than automatically — a fresh session lands on the login screen.
+  const handleSignIn = useCallback(() => void auth.logout?.(), [auth])
+
+  // Dismissal happens through the snooze button: useConditionalToast re-pushes while enabled,
+  // which would defeat a close control.
+  useConditionalToast({
+    id: 'unclaimed-project-nudge',
+    status: critical ? 'error' : 'warning',
+    enabled: Boolean(unclaimed) && !isSnoozed,
+    title: t(
+      critical ? 'unclaimed-project.toast.critical.title' : 'unclaimed-project.toast.title',
+      {expiry},
+    ),
+    description: unclaimed && (
+      <Stack space={4} paddingY={1}>
+        <Text size={1}>
+          {unclaimed.claimUrl || unclaimed.claimLinkSpent ? (
+            t('unclaimed-project.toast.description')
+          ) : (
+            <Translate t={t} i18nKey="unclaimed-project.no-claim-url.text" />
+          )}
+        </Text>
+        <Flex gap={3}>
+          {unclaimed.claimUrl && (
+            <Button
+              as="a"
+              href={unclaimed.claimUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              mode="ghost"
+              tone="primary"
+              size="default"
+              icon={LaunchIcon}
+              text={t('unclaimed-project.toast.claim-button.text')}
+            />
+          )}
+          <Button
+            mode="bleed"
+            tone="neutral"
+            size="default"
+            text={t('unclaimed-project.toast.snooze-button.text')}
+            onClick={handleSnooze}
+          />
+        </Flex>
+      </Stack>
+    ),
+  })
+
+  // One final farewell, pushed once so dismissing it sticks — unlike useConditionalToast,
+  // which re-pushes for as long as its condition holds.
+  const toast = useToast()
+  const expired = state?.status === 'expired'
+  useEffect(() => {
+    if (!expired) return
+    toast.push({
+      id: 'unclaimed-project-expired',
+      status: 'warning',
+      closable: true,
+      duration: Infinity,
+      title: t('unclaimed-project.expired.toast.title'),
+    })
+  }, [expired, t, toast])
+
+  if (state?.status === 'claimed') {
+    return (
+      <Card data-testid="unclaimed-project-banner" tone="positive" padding={3} borderBottom>
+        <Flex align="center" gap={3} justify="center" wrap="wrap">
+          <Text size={1} weight="medium">
+            {t('unclaimed-project.claimed.text')}
+          </Text>
+          <Button
+            mode="default"
+            tone="positive"
+            size="default"
+            text={t('unclaimed-project.claimed.sign-in-button.text')}
+            onClick={handleSignIn}
+          />
+        </Flex>
+      </Card>
+    )
+  }
+
+  if (!unclaimed) return null
+
+  return (
+    <Card
+      data-testid="unclaimed-project-banner"
+      tone={critical ? 'critical' : 'caution'}
+      padding={3}
+      borderBottom
+    >
+      <Flex align="center" gap={3} justify="center" wrap="wrap">
+        <Text size={1} weight="medium">
+          <ClockIcon style={{verticalAlign: 'text-bottom', marginRight: '0.5em'}} />
+          {t(
+            critical ? 'unclaimed-project.banner.critical.text' : 'unclaimed-project.banner.text',
+            {expiry},
+          )}
+        </Text>
+        {unclaimed.claimUrl ? (
+          <Button
+            as="a"
+            href={unclaimed.claimUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            mode="default"
+            tone={critical ? 'critical' : 'primary'}
+            size="default"
+            iconRight={LaunchIcon}
+            text={t('unclaimed-project.banner.claim-button.text')}
+          />
+        ) : unclaimed.claimLinkSpent ? null : (
+          <Text size={1}>
+            <Translate t={t} i18nKey="unclaimed-project.no-claim-url.text" />
+          </Text>
+        )}
+      </Flex>
+    </Card>
+  )
+}
+
+/** Re-evaluates the snooze window and the critical flip once a minute while the nudge shows. */
+function useMinuteTick(enabled: boolean): number {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    if (!enabled) return undefined
+    // Refresh right away — the interval alone would serve a clock up to a minute stale after a
+    // stretch with the nudge hidden.
+    startTransition(() => setNow(Date.now()))
+    const id = setInterval(() => setNow(Date.now()), 60_000)
+    return () => clearInterval(id)
+  }, [enabled])
+  return now
+}

--- a/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
@@ -24,9 +24,12 @@ import {useUnclaimedProjectCopy} from './useUnclaimedProjectCopy'
  * @internal
  */
 export function UnclaimedProjectNudge() {
-  const state = useUnclaimedProject()
-  const copy = useUnclaimedProjectCopy(Boolean(state))
   const {auth, projectId} = useWorkspace()
+  const [claimAttempt, setClaimAttempt] = useState<{projectId: string; startedAt: number}>()
+  const claimAttemptedAt =
+    claimAttempt?.projectId === projectId ? claimAttempt.startedAt : undefined
+  const state = useUnclaimedProject({claimAttemptedAt})
+  const copy = useUnclaimedProjectCopy(Boolean(state))
 
   const unclaimed = state?.status === 'unclaimed' ? state : undefined
   const now = useMinuteTick(Boolean(unclaimed))
@@ -48,6 +51,10 @@ export function UnclaimedProjectNudge() {
     writeUnclaimedProjectSnoozedAt(projectId, at)
     setSnoozeState({projectId, snoozedAt: at})
   }, [projectId])
+  const handleClaim = useCallback(
+    () => setClaimAttempt({projectId, startedAt: Date.now()}),
+    [projectId],
+  )
   const snoozeDurationMs = (copy?.snoozeMinutes ?? 0) * 60_000
   const isSnoozed = Boolean(
     snoozedAt && snoozeDurationMs && now - new Date(snoozedAt).getTime() < snoozeDurationMs,
@@ -98,6 +105,7 @@ export function UnclaimedProjectNudge() {
               size="default"
               iconRight={LaunchIcon}
               text={copy.toast.claimButtonText}
+              onClick={handleClaim}
             />
           )}
           <Button
@@ -183,6 +191,7 @@ export function UnclaimedProjectNudge() {
             size="default"
             iconRight={LaunchIcon}
             text={copy.banner.claimButtonText}
+            onClick={handleClaim}
           />
         ) : unclaimed.claimLinkSpent ? null : (
           <Text size={1}>{copy.noClaimUrl.text}</Text>

--- a/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
@@ -1,23 +1,20 @@
 import {ClockIcon} from '@sanity/icons/Clock'
 import {LaunchIcon} from '@sanity/icons/Launch'
-import {Card, Flex, Stack, Text, useToast} from '@sanity/ui'
+import {Badge, Card, Flex, Stack, Text, useToast} from '@sanity/ui'
 import {startTransition, useCallback, useEffect, useState} from 'react'
 
-import {Button} from '../../../ui-components'
-import {useConditionalToast, useRelativeTime} from '../../hooks'
-import {Translate, useTranslation} from '../../i18n'
+import {Button} from '../../../ui-components/button/Button'
+import {useConditionalToast} from '../../hooks/useConditionalToast'
+import {useDateTimeFormat} from '../../hooks/useDateTimeFormat'
+import {useRelativeTime} from '../../hooks/useRelativeTime'
 import {
   readUnclaimedProjectSnoozedAt,
   writeUnclaimedProjectSnoozedAt,
 } from '../../store/authStore/unclaimedProjectStorage'
+import {interpolateTemplate} from '../../util/interpolateTemplate'
 import {useWorkspace} from '../workspace'
 import {useUnclaimedProject} from './useUnclaimedProject'
-
-/** Dismissing the toast buys this much quiet before it nudges again. */
-const SNOOZE_DURATION_MS = 30 * 60_000
-
-/** Below this long left, the nudge escalates from caution to critical. */
-const CRITICAL_THRESHOLD_MS = 8 * 3_600_000
+import {useUnclaimedProjectCopy} from './useUnclaimedProjectCopy'
 
 /**
  * Persistent banner + snoozable toast nudging the user to claim a minted-but-unclaimed project
@@ -28,28 +25,38 @@ const CRITICAL_THRESHOLD_MS = 8 * 3_600_000
  */
 export function UnclaimedProjectNudge() {
   const state = useUnclaimedProject()
+  const copy = useUnclaimedProjectCopy(Boolean(state))
   const {auth, projectId} = useWorkspace()
-  const {t} = useTranslation()
 
   const unclaimed = state?.status === 'unclaimed' ? state : undefined
   const now = useMinuteTick(Boolean(unclaimed))
-  const expiry = useRelativeTime(unclaimed?.expiresAt ?? '', {useTemporalPhrase: true})
+  const timeLeft = useRelativeTime(unclaimed?.expiresAt ?? '')
+  const expiresAtFormatter = useDateTimeFormat({dateStyle: 'medium', timeStyle: 'short'})
+  const expiresAt = unclaimed ? expiresAtFormatter.format(unclaimed.expiresAt) : ''
+  const templateValues = {expiresAt, timeLeft}
 
-  const [snoozedAt, setSnoozedAt] = useState(() => readUnclaimedProjectSnoozedAt(projectId))
-  const [snoozeProject, setSnoozeProject] = useState(projectId)
-  if (snoozeProject !== projectId) {
-    setSnoozeProject(projectId)
-    setSnoozedAt(readUnclaimedProjectSnoozedAt(projectId))
-  }
+  const [snoozeState, setSnoozeState] = useState(() => ({
+    projectId,
+    snoozedAt: readUnclaimedProjectSnoozedAt(projectId),
+  }))
+  const snoozedAt =
+    snoozeState.projectId === projectId
+      ? snoozeState.snoozedAt
+      : readUnclaimedProjectSnoozedAt(projectId)
   const handleSnooze = useCallback(() => {
     const at = new Date().toISOString()
     writeUnclaimedProjectSnoozedAt(projectId, at)
-    setSnoozedAt(at)
+    setSnoozeState({projectId, snoozedAt: at})
   }, [projectId])
-  const isSnoozed = Boolean(snoozedAt && now - new Date(snoozedAt).getTime() < SNOOZE_DURATION_MS)
+  const snoozeDurationMs = (copy?.snoozeMinutes ?? 0) * 60_000
+  const isSnoozed = Boolean(
+    snoozedAt && snoozeDurationMs && now - new Date(snoozedAt).getTime() < snoozeDurationMs,
+  )
 
   const critical = Boolean(
-    unclaimed && unclaimed.expiresAt.getTime() - now <= CRITICAL_THRESHOLD_MS,
+    copy &&
+    unclaimed &&
+    unclaimed.expiresAt.getTime() - now <= copy.criticalThresholdHours * 3_600_000,
   )
 
   // The claim URL is spent; the robot token still works, so the token is cleared through this
@@ -61,19 +68,23 @@ export function UnclaimedProjectNudge() {
   useConditionalToast({
     id: 'unclaimed-project-nudge',
     status: critical ? 'error' : 'warning',
-    enabled: Boolean(unclaimed) && !isSnoozed,
-    title: t(
-      critical ? 'unclaimed-project.toast.critical.title' : 'unclaimed-project.toast.title',
-      {expiry},
+    enabled: Boolean(copy && unclaimed) && !isSnoozed,
+    title: copy ? (
+      <strong>
+        {interpolateTemplate(
+          critical ? copy.toast.criticalTitle : copy.toast.title,
+          templateValues,
+        )}
+      </strong>
+    ) : (
+      ''
     ),
-    description: unclaimed && (
-      <Stack space={4} paddingY={1}>
-        <Text size={1}>
-          {unclaimed.claimUrl || unclaimed.claimLinkSpent ? (
-            t('unclaimed-project.toast.description')
-          ) : (
-            <Translate t={t} i18nKey="unclaimed-project.no-claim-url.text" />
-          )}
+    description: unclaimed && copy && (
+      <Stack space={4} paddingY={2}>
+        <Text size={1} weight="regular">
+          {unclaimed.claimUrl || unclaimed.claimLinkSpent
+            ? copy.toast.description
+            : copy.noClaimUrl.text}
         </Text>
         <Flex gap={3}>
           {unclaimed.claimUrl && (
@@ -82,19 +93,21 @@ export function UnclaimedProjectNudge() {
               href={unclaimed.claimUrl}
               target="_blank"
               rel="noopener noreferrer"
-              mode="ghost"
-              tone="primary"
+              mode="default"
+              tone={critical ? 'critical' : 'primary'}
               size="default"
-              icon={LaunchIcon}
-              text={t('unclaimed-project.toast.claim-button.text')}
+              iconRight={LaunchIcon}
+              text={copy.toast.claimButtonText}
             />
           )}
           <Button
             mode="bleed"
             tone="neutral"
             size="default"
-            text={t('unclaimed-project.toast.snooze-button.text')}
+            paddingY={1}
+            text={copy.toast.snoozeButtonText}
             onClick={handleSnooze}
+            style={{fontSize: '0.6875rem', opacity: 0.6}}
           />
         </Flex>
       </Stack>
@@ -106,28 +119,30 @@ export function UnclaimedProjectNudge() {
   const toast = useToast()
   const expired = state?.status === 'expired'
   useEffect(() => {
-    if (!expired) return
+    if (!expired || !copy) return
     toast.push({
       id: 'unclaimed-project-expired',
       status: 'warning',
       closable: true,
       duration: Infinity,
-      title: t('unclaimed-project.expired.toast.title'),
+      title: copy.expired.toastTitle,
     })
-  }, [expired, t, toast])
+  }, [copy, expired, toast])
+
+  if (!copy) return null
 
   if (state?.status === 'claimed') {
     return (
       <Card data-testid="unclaimed-project-banner" tone="positive" padding={3} borderBottom>
         <Flex align="center" gap={3} justify="center" wrap="wrap">
           <Text size={1} weight="medium">
-            {t('unclaimed-project.claimed.text')}
+            {copy.claimed.text}
           </Text>
           <Button
             mode="default"
             tone="positive"
             size="default"
-            text={t('unclaimed-project.claimed.sign-in-button.text')}
+            text={copy.claimed.signInButtonText}
             onClick={handleSignIn}
           />
         </Flex>
@@ -145,13 +160,18 @@ export function UnclaimedProjectNudge() {
       borderBottom
     >
       <Flex align="center" gap={3} justify="center" wrap="wrap">
-        <Text size={1} weight="medium">
-          <ClockIcon style={{verticalAlign: 'text-bottom', marginRight: '0.5em'}} />
-          {t(
-            critical ? 'unclaimed-project.banner.critical.text' : 'unclaimed-project.banner.text',
-            {expiry},
-          )}
-        </Text>
+        <Flex align="center" gap={2}>
+          <Flex aria-hidden="true" align="center" justify="center" style={{lineHeight: 0}}>
+            <ClockIcon style={{display: 'block'}} />
+          </Flex>
+          <Text size={1} weight="medium">
+            {interpolateTemplate(
+              critical ? copy.banner.criticalText : copy.banner.text,
+              templateValues,
+            )}
+          </Text>
+        </Flex>
+        <UnclaimedProjectCountdown expiresAt={unclaimed.expiresAt} critical={critical} />
         {unclaimed.claimUrl ? (
           <Button
             as="a"
@@ -162,16 +182,60 @@ export function UnclaimedProjectNudge() {
             tone={critical ? 'critical' : 'primary'}
             size="default"
             iconRight={LaunchIcon}
-            text={t('unclaimed-project.banner.claim-button.text')}
+            text={copy.banner.claimButtonText}
           />
         ) : unclaimed.claimLinkSpent ? null : (
-          <Text size={1}>
-            <Translate t={t} i18nKey="unclaimed-project.no-claim-url.text" />
-          </Text>
+          <Text size={1}>{copy.noClaimUrl.text}</Text>
         )}
       </Flex>
     </Card>
   )
+}
+
+/** Isolates the per-second update so the full nudge does not re-render on every tick. */
+export function UnclaimedProjectCountdown({
+  critical,
+  expiresAt,
+}: {
+  critical: boolean
+  expiresAt: Date
+}) {
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1_000)
+    return () => clearInterval(id)
+  }, [])
+
+  return (
+    <Badge
+      aria-hidden="true"
+      data-testid="unclaimed-project-countdown"
+      fontSize={1}
+      mode="outline"
+      padding={2}
+      radius={2}
+      tone={critical ? 'critical' : 'caution'}
+      style={{
+        fontVariantNumeric: 'tabular-nums',
+        letterSpacing: '0.08em',
+        minWidth: '7.5ch',
+        textAlign: 'center',
+      }}
+    >
+      {formatCountdown(expiresAt, now)}
+    </Badge>
+  )
+}
+
+/** Formats the remaining expiry window without locale-specific unit labels. */
+export function formatCountdown(expiresAt: Date, now: number): string {
+  const totalSeconds = Math.max(0, Math.ceil((expiresAt.getTime() - now) / 1_000))
+  const hours = Math.floor(totalSeconds / 3_600)
+  const minutes = Math.floor((totalSeconds % 3_600) / 60)
+  const seconds = totalSeconds % 60
+
+  return [hours, minutes, seconds].map((value) => String(value).padStart(2, '0')).join(':')
 }
 
 /** Re-evaluates the snooze window and the critical flip once a minute while the nudge shows. */

--- a/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
@@ -152,16 +152,17 @@ function UnclaimedProjectNudgeInner({
   // which re-pushes for as long as its condition holds.
   const toast = useToast()
   const expired = state?.status === 'expired'
+  const expiredToastTitle = copy?.expired.toastTitle
   useEffect(() => {
-    if (!expired || !copy) return
+    if (!expired || !expiredToastTitle) return
     toast.push({
       id: 'unclaimed-project-expired',
       status: 'warning',
       closable: true,
       duration: Infinity,
-      title: copy.expired.toastTitle,
+      title: expiredToastTitle,
     })
-  }, [copy, expired, toast])
+  }, [expired, expiredToastTitle, toast])
 
   if (!copy) return null
 

--- a/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
@@ -9,6 +9,7 @@ import {useConditionalToast} from '../../hooks/useConditionalToast'
 import {useDateTimeFormat} from '../../hooks/useDateTimeFormat'
 import {useRelativeTime} from '../../hooks/useRelativeTime'
 import {
+  clearUnclaimedProjectRecord,
   readUnclaimedProjectSnoozedAt,
   writeUnclaimedProjectSnoozedAt,
 } from '../../store/authStore/unclaimedProjectStorage'
@@ -35,9 +36,14 @@ export function UnclaimedProjectNudge() {
 }
 
 function UnclaimedProjectNudgeAuthCheck() {
-  const {currentUser} = useWorkspace()
+  const {currentUser, projectId} = useWorkspace()
+  const provider = currentUser?.provider
 
-  if (currentUser?.provider !== 'sanity-token') return null
+  useEffect(() => {
+    if (provider && provider !== 'sanity-token') clearUnclaimedProjectRecord(projectId)
+  }, [projectId, provider])
+
+  if (provider !== 'sanity-token') return null
 
   return <UnclaimedProjectNudgeStateCheck />
 }

--- a/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
@@ -4,6 +4,7 @@ import {Badge, Box, Card, Flex, Stack, Text, useToast} from '@sanity/ui'
 import {startTransition, useCallback, useEffect, useState} from 'react'
 
 import {Button} from '../../../ui-components/button/Button'
+import {isDev} from '../../environment'
 import {useConditionalToast} from '../../hooks/useConditionalToast'
 import {useDateTimeFormat} from '../../hooks/useDateTimeFormat'
 import {useRelativeTime} from '../../hooks/useRelativeTime'
@@ -28,6 +29,12 @@ import {
  * @internal
  */
 export function UnclaimedProjectNudge() {
+  if (!isDev) return null
+
+  return <UnclaimedProjectNudgeAuthCheck />
+}
+
+function UnclaimedProjectNudgeAuthCheck() {
   const {currentUser} = useWorkspace()
 
   if (currentUser?.provider !== 'sanity-token') return null

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
@@ -3,11 +3,37 @@ import {act, render, screen} from '@testing-library/react'
 import {type ReactNode} from 'react'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
-import {formatCountdown, UnclaimedProjectCountdown} from '../UnclaimedProjectNudge'
+import {
+  formatCountdown,
+  UnclaimedProjectCountdown,
+  UnclaimedProjectNudge,
+} from '../UnclaimedProjectNudge'
+
+const {mockUseUnclaimedProject, mockUseWorkspace} = vi.hoisted(() => ({
+  mockUseUnclaimedProject: vi.fn(),
+  mockUseWorkspace: vi.fn(),
+}))
+
+vi.mock('../../workspace', () => ({useWorkspace: mockUseWorkspace}))
+vi.mock('../useUnclaimedProject', () => ({useUnclaimedProject: mockUseUnclaimedProject}))
 
 const wrapper = ({children}: {children: ReactNode}) => (
   <ThemeProvider theme={studioTheme}>{children}</ThemeProvider>
 )
+
+describe('UnclaimedProjectNudge', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not run the project state check for non-robot users', () => {
+    mockUseWorkspace.mockReturnValue({currentUser: {provider: 'google'}})
+
+    render(<UnclaimedProjectNudge />, {wrapper})
+
+    expect(mockUseUnclaimedProject).not.toHaveBeenCalled()
+  })
+})
 
 describe('UnclaimedProjectCountdown', () => {
   beforeEach(() => {

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
@@ -10,11 +10,13 @@ import {
   UnclaimedProjectNudge,
 } from '../UnclaimedProjectNudge'
 
-const {mockUseUnclaimedProject, mockUseWorkspace} = vi.hoisted(() => ({
+const {mockEnvironment, mockUseUnclaimedProject, mockUseWorkspace} = vi.hoisted(() => ({
+  mockEnvironment: {isDev: true},
   mockUseUnclaimedProject: vi.fn(),
   mockUseWorkspace: vi.fn(),
 }))
 
+vi.mock('../../../environment', () => mockEnvironment)
 vi.mock('../../workspace', () => ({useWorkspace: mockUseWorkspace}))
 vi.mock('../useUnclaimedProject', () => ({useUnclaimedProject: mockUseUnclaimedProject}))
 
@@ -26,7 +28,17 @@ const wrapper = ({children}: {children: ReactNode}) => (
 
 describe('UnclaimedProjectNudge', () => {
   afterEach(() => {
+    mockEnvironment.isDev = true
     vi.clearAllMocks()
+  })
+
+  it('does not inspect the workspace outside development', () => {
+    mockEnvironment.isDev = false
+
+    render(<UnclaimedProjectNudge />, {wrapper})
+
+    expect(mockUseWorkspace).not.toHaveBeenCalled()
+    expect(mockUseUnclaimedProject).not.toHaveBeenCalled()
   })
 
   it('does not run the project state check for non-robot users', () => {

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
@@ -1,0 +1,50 @@
+import {studioTheme, ThemeProvider} from '@sanity/ui'
+import {act, render, screen} from '@testing-library/react'
+import {type ReactNode} from 'react'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {formatCountdown, UnclaimedProjectCountdown} from '../UnclaimedProjectNudge'
+
+const wrapper = ({children}: {children: ReactNode}) => (
+  <ThemeProvider theme={studioTheme}>{children}</ThemeProvider>
+)
+
+describe('UnclaimedProjectCountdown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-28T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('ticks once per second with stable-width hours, minutes, and seconds', async () => {
+    const expiresAt = new Date('2026-07-28T13:00:00.000Z')
+    render(<UnclaimedProjectCountdown critical={false} expiresAt={expiresAt} />, {wrapper})
+    const countdown = screen.getByTestId('unclaimed-project-countdown')
+
+    expect(countdown).toHaveTextContent('01:00:00')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000)
+    })
+
+    expect(countdown).toHaveTextContent('00:59:59')
+  })
+})
+
+describe('formatCountdown', () => {
+  it('keeps durations over 24 hours in the hours position', () => {
+    const now = new Date('2026-07-28T12:00:00.000Z').getTime()
+    const expiresAt = new Date(now + (62 * 3_600 + 18 * 60 + 5) * 1_000)
+
+    expect(formatCountdown(expiresAt, now)).toBe('62:18:05')
+  })
+
+  it('clamps an elapsed countdown at zero', () => {
+    const now = new Date('2026-07-28T12:00:00.000Z').getTime()
+
+    expect(formatCountdown(new Date(now - 1_000), now)).toBe('00:00:00')
+  })
+})

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
@@ -10,17 +10,28 @@ import {
   UnclaimedProjectNudge,
 } from '../UnclaimedProjectNudge'
 
-const {mockEnvironment, mockUseUnclaimedProject, mockUseWorkspace} = vi.hoisted(() => ({
+const {
+  mockClearUnclaimedProjectRecord,
+  mockEnvironment,
+  mockUseUnclaimedProject,
+  mockUseWorkspace,
+} = vi.hoisted(() => ({
+  mockClearUnclaimedProjectRecord: vi.fn(),
   mockEnvironment: {isDev: true},
   mockUseUnclaimedProject: vi.fn(),
   mockUseWorkspace: vi.fn(),
 }))
 
+vi.mock('../../../store/authStore/unclaimedProjectStorage', async (importOriginal) => ({
+  ...(await importOriginal()),
+  clearUnclaimedProjectRecord: mockClearUnclaimedProjectRecord,
+}))
 vi.mock('../../../environment', () => mockEnvironment)
 vi.mock('../../workspace', () => ({useWorkspace: mockUseWorkspace}))
 vi.mock('../useUnclaimedProject', () => ({useUnclaimedProject: mockUseUnclaimedProject}))
 
 const theme = buildTheme()
+const PROJECT_ID = 'test-project'
 
 const wrapper = ({children}: {children: ReactNode}) => (
   <ThemeProvider theme={theme}>{children}</ThemeProvider>
@@ -41,11 +52,24 @@ describe('UnclaimedProjectNudge', () => {
     expect(mockUseUnclaimedProject).not.toHaveBeenCalled()
   })
 
-  it('does not run the project state check for non-robot users', () => {
-    mockUseWorkspace.mockReturnValue({currentUser: {provider: 'google'}})
+  it('clears a stale claim record without running the project state check for human users', () => {
+    mockUseWorkspace.mockReturnValue({
+      currentUser: {provider: 'google'},
+      projectId: PROJECT_ID,
+    })
 
     render(<UnclaimedProjectNudge />, {wrapper})
 
+    expect(mockClearUnclaimedProjectRecord).toHaveBeenCalledExactlyOnceWith(PROJECT_ID)
+    expect(mockUseUnclaimedProject).not.toHaveBeenCalled()
+  })
+
+  it('does not clear claim records while the current user is unresolved', () => {
+    mockUseWorkspace.mockReturnValue({currentUser: undefined, projectId: PROJECT_ID})
+
+    render(<UnclaimedProjectNudge />, {wrapper})
+
+    expect(mockClearUnclaimedProjectRecord).not.toHaveBeenCalled()
     expect(mockUseUnclaimedProject).not.toHaveBeenCalled()
   })
 })

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
@@ -28,7 +28,10 @@ vi.mock('../../../store/authStore/unclaimedProjectStorage', async (importOrigina
 }))
 vi.mock('../../../environment', () => mockEnvironment)
 vi.mock('../../workspace', () => ({useWorkspace: mockUseWorkspace}))
-vi.mock('../useUnclaimedProject', () => ({useUnclaimedProject: mockUseUnclaimedProject}))
+vi.mock('../useUnclaimedProject', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useUnclaimedProject: mockUseUnclaimedProject,
+}))
 
 const theme = buildTheme()
 const PROJECT_ID = 'test-project'

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
@@ -1,4 +1,5 @@
-import {studioTheme, ThemeProvider} from '@sanity/ui'
+import {ThemeProvider} from '@sanity/ui'
+import {buildTheme} from '@sanity/ui/theme'
 import {act, render, screen} from '@testing-library/react'
 import {type ReactNode} from 'react'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
@@ -17,8 +18,10 @@ const {mockUseUnclaimedProject, mockUseWorkspace} = vi.hoisted(() => ({
 vi.mock('../../workspace', () => ({useWorkspace: mockUseWorkspace}))
 vi.mock('../useUnclaimedProject', () => ({useUnclaimedProject: mockUseUnclaimedProject}))
 
+const theme = buildTheme()
+
 const wrapper = ({children}: {children: ReactNode}) => (
-  <ThemeProvider theme={studioTheme}>{children}</ThemeProvider>
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
 )
 
 describe('UnclaimedProjectNudge', () => {

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
@@ -443,7 +443,7 @@ describe('useUnclaimedProject', () => {
     }
   })
 
-  it('polls project status after a claim attempt and stops once claimed', async () => {
+  it('polls project status after a claim attempt and tears down safely once claimed', async () => {
     vi.useFakeTimers()
     try {
       mockRequest
@@ -452,7 +452,7 @@ describe('useUnclaimedProject', () => {
         .mockResolvedValue({createdAt: CREATED_AT, organizationId: 'oReal'})
 
       const initialProps: {claimAttemptedAt: number | undefined} = {claimAttemptedAt: undefined}
-      const {result, rerender} = renderHook(
+      const {result, rerender, unmount} = renderHook(
         ({claimAttemptedAt}: {claimAttemptedAt: number | undefined}) =>
           useUnclaimedProject({claimAttemptedAt}),
         {initialProps},
@@ -470,6 +470,7 @@ describe('useUnclaimedProject', () => {
 
       await act(() => vi.advanceTimersByTimeAsync(30_000))
       expect(mockRequest).toHaveBeenCalledTimes(3)
+      expect(() => unmount()).not.toThrow()
     } finally {
       vi.useRealTimers()
     }

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
@@ -353,6 +353,70 @@ describe('useUnclaimedProject', () => {
     }
   })
 
+  it('polls project status after a claim attempt and stops once claimed', async () => {
+    vi.useFakeTimers()
+    try {
+      mockRequest
+        .mockResolvedValueOnce({createdAt: CREATED_AT, organizationId: 'oSystemUnclaimed'})
+        .mockResolvedValueOnce({createdAt: CREATED_AT, organizationId: 'oSystemUnclaimed'})
+        .mockResolvedValue({createdAt: CREATED_AT, organizationId: 'oReal'})
+
+      const initialProps: {claimAttemptedAt: number | undefined} = {claimAttemptedAt: undefined}
+      const {result, rerender} = renderHook(
+        ({claimAttemptedAt}: {claimAttemptedAt: number | undefined}) =>
+          useUnclaimedProject({claimAttemptedAt}),
+        {initialProps},
+      )
+      await act(() => vi.advanceTimersByTimeAsync(0))
+      expect(result.current?.status).toBe('unclaimed')
+
+      rerender({claimAttemptedAt: Date.now()})
+      await act(() => vi.advanceTimersByTimeAsync(0))
+      expect(mockRequest).toHaveBeenCalledTimes(2)
+
+      await act(() => vi.advanceTimersByTimeAsync(10_000))
+      expect(mockRequest).toHaveBeenCalledTimes(3)
+      expect(result.current).toEqual({status: 'claimed'})
+
+      await act(() => vi.advanceTimersByTimeAsync(30_000))
+      expect(mockRequest).toHaveBeenCalledTimes(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('checks immediately on focus during a claim attempt', async () => {
+    vi.useFakeTimers()
+    try {
+      mockRequest
+        .mockResolvedValueOnce({createdAt: CREATED_AT, organizationId: 'oSystemUnclaimed'})
+        .mockResolvedValueOnce({createdAt: CREATED_AT, organizationId: 'oSystemUnclaimed'})
+        .mockResolvedValue({createdAt: CREATED_AT, organizationId: 'oReal'})
+
+      const initialProps: {claimAttemptedAt: number | undefined} = {claimAttemptedAt: undefined}
+      const {result, rerender} = renderHook(
+        ({claimAttemptedAt}: {claimAttemptedAt: number | undefined}) =>
+          useUnclaimedProject({claimAttemptedAt}),
+        {initialProps},
+      )
+      await act(() => vi.advanceTimersByTimeAsync(0))
+
+      rerender({claimAttemptedAt: Date.now()})
+      await act(() => vi.advanceTimersByTimeAsync(0))
+      expect(mockRequest).toHaveBeenCalledTimes(2)
+
+      act(() => {
+        window.dispatchEvent(new Event('focus'))
+      })
+      await act(() => vi.advanceTimersByTimeAsync(0))
+
+      expect(mockRequest).toHaveBeenCalledTimes(3)
+      expect(result.current).toEqual({status: 'claimed'})
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('resets state when the session stops being the robot', async () => {
     const {result, rerender} = renderHook(() => useUnclaimedProject())
     await waitFor(() => expect(result.current?.status).toBe('unclaimed'))

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
@@ -1,0 +1,345 @@
+import {act, renderHook, waitFor} from '@testing-library/react'
+import {StrictMode} from 'react'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getAuthTokenStorageKey} from '../../../store/authStore/constants'
+import {
+  readUnclaimedProjectRecord,
+  readUnclaimedProjectSnoozedAt,
+  writeUnclaimedProjectRecord,
+  writeUnclaimedProjectSnoozedAt,
+} from '../../../store/authStore/unclaimedProjectStorage'
+import {useUnclaimedProject} from '../useUnclaimedProject'
+
+const {mockRequest, mockUseWorkspace} = vi.hoisted(() => ({
+  mockRequest: vi.fn(),
+  mockUseWorkspace: vi.fn(),
+}))
+
+vi.mock('../../workspace', () => ({useWorkspace: mockUseWorkspace}))
+vi.mock('../../../hooks', () => {
+  const client = {config: () => ({apiHost: 'https://api.sanity.io'}), request: mockRequest}
+  return {useClient: () => client}
+})
+vi.mock('../../../util/supportsLocalStorage', () => ({supportsLocalStorage: true}))
+
+const PROJECT_ID = 'test-project'
+const CLAIM_URL = 'https://www.sanity.io/manage/claim/some-claim-token'
+const CREATED_AT = '2026-07-24T00:00:00.000Z'
+const TTL_MS = 72 * 3_600_000
+
+const ROBOT_USER = {id: 'robot', provider: 'sanity-token'}
+const HUMAN_USER = {id: 'human', provider: 'google'}
+
+const mockFetch = vi.fn()
+
+function lookupResponse(status: number, body?: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response
+}
+
+describe('useUnclaimedProject', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mockUseWorkspace.mockReturnValue({currentUser: ROBOT_USER, projectId: PROJECT_ID})
+    mockRequest.mockResolvedValue({createdAt: CREATED_AT, organizationId: 'oSystemUnclaimed'})
+    vi.stubGlobal('fetch', mockFetch)
+    mockFetch.mockResolvedValue(lookupResponse(429))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('stays quiet for a human session and clears any stale record', () => {
+    mockUseWorkspace.mockReturnValue({currentUser: HUMAN_USER, projectId: PROJECT_ID})
+    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    expect(result.current).toBeUndefined()
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toBeUndefined()
+    expect(mockRequest).not.toHaveBeenCalled()
+  })
+
+  it('reports unclaimed with the stored claim URL when the org read says so', async () => {
+    writeUnclaimedProjectRecord(PROJECT_ID, {
+      claimUrl: CLAIM_URL,
+      expiresAt: '2026-07-27T00:00:00.000Z',
+      lastLookupAt: new Date().toISOString(),
+    })
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        status: 'unclaimed',
+        claimUrl: CLAIM_URL,
+        expiresAt: new Date('2026-07-27T00:00:00.000Z'),
+        claimLinkSpent: false,
+      }),
+    )
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('derives expiry from createdAt + 72h without a stored record, and never calls the lookup', async () => {
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        status: 'unclaimed',
+        claimUrl: undefined,
+        expiresAt: new Date(new Date(CREATED_AT).getTime() + TTL_MS),
+        claimLinkSpent: false,
+      }),
+    )
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('reports claimed and cleans up when the project moved to a real organization', async () => {
+    mockRequest.mockResolvedValue({createdAt: CREATED_AT, organizationId: 'oReal'})
+    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+    writeUnclaimedProjectSnoozedAt(PROJECT_ID, new Date().toISOString())
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() => expect(result.current).toEqual({status: 'claimed'}))
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toBeUndefined()
+    expect(readUnclaimedProjectSnoozedAt(PROJECT_ID)).toBeUndefined()
+  })
+
+  it('reports expired and clears record and token when the project is gone', async () => {
+    mockRequest.mockRejectedValue({statusCode: 404})
+    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+    localStorage.setItem(getAuthTokenStorageKey(PROJECT_ID), JSON.stringify({token: 'sk-dead'}))
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() => expect(result.current).toEqual({status: 'expired'}))
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toBeUndefined()
+    expect(localStorage.getItem(getAuthTokenStorageKey(PROJECT_ID))).toBeNull()
+  })
+
+  it('treats a missing organization id as unverifiable, not as claimed', async () => {
+    mockRequest.mockResolvedValue({createdAt: CREATED_AT, organizationId: null})
+    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalled())
+    expect(result.current).toBeUndefined()
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toEqual({claimUrl: CLAIM_URL})
+  })
+
+  it('stays quiet and keeps the record on a transient org read failure', async () => {
+    mockRequest.mockRejectedValue({statusCode: 500})
+    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalled())
+    expect(result.current).toBeUndefined()
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toEqual({claimUrl: CLAIM_URL})
+  })
+
+  it('never expires on a transient failure, even past the recorded deadline', async () => {
+    mockRequest.mockRejectedValue(new TypeError('network error'))
+    const record = {claimUrl: CLAIM_URL, expiresAt: new Date(Date.now() - 60_000).toISOString()}
+    writeUnclaimedProjectRecord(PROJECT_ID, record)
+    localStorage.setItem(getAuthTokenStorageKey(PROJECT_ID), JSON.stringify({token: 'sk-live'}))
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalled())
+    expect(result.current).toBeUndefined()
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toEqual(record)
+    expect(localStorage.getItem(getAuthTokenStorageKey(PROJECT_ID))).not.toBeNull()
+  })
+
+  it('refines the expiry from the lookup and persists the throttle', async () => {
+    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+    mockFetch.mockResolvedValue(
+      lookupResponse(200, {state: 'claimable', expiresAt: '2026-07-26T18:00:00.000Z'}),
+    )
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        status: 'unclaimed',
+        claimUrl: CLAIM_URL,
+        expiresAt: new Date('2026-07-26T18:00:00.000Z'),
+        claimLinkSpent: false,
+      }),
+    )
+    expect(mockFetch).toHaveBeenCalledExactlyOnceWith(
+      'https://api.sanity.io/v2026-06-23/provision/some-claim-token/lookup',
+    )
+    const record = readUnclaimedProjectRecord(PROJECT_ID)
+    expect(record?.expiresAt).toBe('2026-07-26T18:00:00.000Z')
+    expect(record?.lastLookupAt).toBeDefined()
+  })
+
+  it('still refines via the lookup under Strict Mode double-mounting', async () => {
+    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+    mockFetch.mockResolvedValue(
+      lookupResponse(200, {state: 'claimable', expiresAt: '2026-07-26T18:00:00.000Z'}),
+    )
+
+    const {result} = renderHook(() => useUnclaimedProject(), {wrapper: StrictMode})
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        status: 'unclaimed',
+        claimUrl: CLAIM_URL,
+        expiresAt: new Date('2026-07-26T18:00:00.000Z'),
+        claimLinkSpent: false,
+      }),
+    )
+    expect(readUnclaimedProjectRecord(PROJECT_ID)?.lastLookupAt).toBeDefined()
+  })
+
+  it('keeps the refined deadline after the claim link is retired', async () => {
+    vi.useFakeTimers()
+    try {
+      const refined = new Date(Date.now() + 3_600_000).toISOString()
+      writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL, expiresAt: refined})
+      mockFetch.mockResolvedValue(lookupResponse(200, {state: 'expired'}))
+
+      const {result} = renderHook(() => useUnclaimedProject())
+      await act(() => vi.advanceTimersByTimeAsync(0))
+      expect(result.current).toEqual({
+        status: 'unclaimed',
+        claimUrl: undefined,
+        expiresAt: new Date(refined),
+        claimLinkSpent: true,
+      })
+
+      act(() => {
+        window.dispatchEvent(new Event('focus'))
+      })
+      await act(() => vi.advanceTimersByTimeAsync(5 * 60_000))
+      expect(mockRequest).toHaveBeenCalledTimes(2)
+      expect(result.current).toEqual({
+        status: 'unclaimed',
+        claimUrl: undefined,
+        expiresAt: new Date(refined),
+        claimLinkSpent: true,
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('never calls the lookup with a claim token outside the base64url charset', async () => {
+    writeUnclaimedProjectRecord(PROJECT_ID, {
+      claimUrl: 'https://www.sanity.io/manage/claim/a$b',
+    })
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() => expect(result.current?.status).toBe('unclaimed'))
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('skips the lookup inside the throttle window', async () => {
+    writeUnclaimedProjectRecord(PROJECT_ID, {
+      claimUrl: CLAIM_URL,
+      lastLookupAt: new Date(Date.now() - 60_000).toISOString(),
+    })
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() => expect(result.current?.status).toBe('unclaimed'))
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('flips to claimed when the lookup says the claim was spent', async () => {
+    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+    mockFetch.mockResolvedValue(lookupResponse(200, {state: 'claimed'}))
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() => expect(result.current).toEqual({status: 'claimed'}))
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toBeUndefined()
+  })
+
+  it('keeps the countdown when the lookup is rate-limited', async () => {
+    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+    mockFetch.mockResolvedValue(lookupResponse(429))
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled())
+    expect(result.current?.status).toBe('unclaimed')
+  })
+
+  it('retires the claim link when the lookup says expired, but never the session', async () => {
+    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+    localStorage.setItem(getAuthTokenStorageKey(PROJECT_ID), JSON.stringify({token: 'sk-live'}))
+    mockFetch.mockResolvedValue(lookupResponse(200, {state: 'expired'}))
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() => {
+      expect(result.current?.status).toBe('unclaimed')
+      expect(result.current?.status === 'unclaimed' && result.current.claimUrl).toBeUndefined()
+    })
+    expect(result.current?.status === 'unclaimed' && result.current.claimLinkSpent).toBe(true)
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toBeUndefined()
+    expect(localStorage.getItem(getAuthTokenStorageKey(PROJECT_ID))).not.toBeNull()
+  })
+
+  it('schedules a follow-up check when focus lands inside the throttle window', async () => {
+    vi.useFakeTimers()
+    try {
+      mockRequest
+        .mockResolvedValueOnce({createdAt: CREATED_AT, organizationId: 'oSystemUnclaimed'})
+        .mockResolvedValue({createdAt: CREATED_AT, organizationId: 'oReal'})
+
+      const {result} = renderHook(() => useUnclaimedProject())
+      await act(() => vi.advanceTimersByTimeAsync(0))
+      expect(result.current?.status).toBe('unclaimed')
+
+      act(() => {
+        window.dispatchEvent(new Event('focus'))
+      })
+      expect(mockRequest).toHaveBeenCalledTimes(1)
+
+      await act(() => vi.advanceTimersByTimeAsync(5 * 60_000))
+      expect(mockRequest).toHaveBeenCalledTimes(2)
+      expect(result.current).toEqual({status: 'claimed'})
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('resets state when the session stops being the robot', async () => {
+    const {result, rerender} = renderHook(() => useUnclaimedProject())
+    await waitFor(() => expect(result.current?.status).toBe('unclaimed'))
+
+    mockUseWorkspace.mockReturnValue({currentUser: HUMAN_USER, projectId: PROJECT_ID})
+    rerender()
+
+    await waitFor(() => expect(result.current).toBeUndefined())
+  })
+
+  it('picks up a claim record stored by a mid-session hash paste', async () => {
+    const {result} = renderHook(() => useUnclaimedProject())
+    await waitFor(() => expect(result.current?.status).toBe('unclaimed'))
+    expect(result.current?.status === 'unclaimed' && result.current.claimUrl).toBeUndefined()
+
+    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+    act(() => {
+      window.dispatchEvent(new Event('hashchange'))
+    })
+
+    await waitFor(() =>
+      expect(result.current?.status === 'unclaimed' && result.current.claimUrl).toBe(CLAIM_URL),
+    )
+  })
+})

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
@@ -112,6 +112,54 @@ describe('useUnclaimedProject', () => {
     expect(readUnclaimedProjectSnoozedAt(PROJECT_ID)).toBeUndefined()
   })
 
+  it('resolves the sole human project member for the claimed sign-in CTA', async () => {
+    mockRequest.mockImplementation(({uri}: {uri: string}) => {
+      if (uri === `/projects/${PROJECT_ID}`) {
+        return Promise.resolve({
+          createdAt: CREATED_AT,
+          organizationId: 'oReal',
+          members: [
+            {id: 'robot', isRobot: true},
+            {id: 'claimant', isRobot: false},
+          ],
+        })
+      }
+      if (uri === '/users/claimant') return Promise.resolve({email: 'claimant@example.com'})
+      return Promise.reject(new Error(`Unexpected request: ${uri}`))
+    })
+    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() =>
+      expect(result.current).toEqual({status: 'claimed', email: 'claimant@example.com'}),
+    )
+    expect(mockRequest).toHaveBeenCalledWith({
+      tag: 'unclaimed-project.claimant',
+      uri: '/users/claimant',
+    })
+  })
+
+  it('keeps the generic claimed state when the claimant is ambiguous', async () => {
+    mockRequest.mockResolvedValue({
+      createdAt: CREATED_AT,
+      organizationId: 'oReal',
+      members: [
+        {id: 'first-human', isRobot: false},
+        {id: 'second-human', isRobot: false},
+      ],
+    })
+    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() => expect(result.current).toEqual({status: 'claimed'}))
+    expect(mockRequest).toHaveBeenCalledExactlyOnceWith({
+      tag: 'unclaimed-project',
+      uri: `/projects/${PROJECT_ID}`,
+    })
+  })
+
   it('stays quiet for a regular robot-token session on a claimed project', async () => {
     mockRequest.mockResolvedValue({createdAt: CREATED_AT, organizationId: 'oReal'})
 

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
@@ -61,14 +61,12 @@ describe('useUnclaimedProject', () => {
     vi.clearAllMocks()
   })
 
-  it('stays quiet for a human session and clears any stale record', () => {
+  it('stays quiet for a human session', () => {
     mockUseWorkspace.mockReturnValue({currentUser: HUMAN_USER, projectId: PROJECT_ID})
-    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
 
     const {result} = renderHook(() => useUnclaimedProject())
 
     expect(result.current).toBeUndefined()
-    expect(readUnclaimedProjectRecord(PROJECT_ID)).toBeUndefined()
     expect(mockRequest).not.toHaveBeenCalled()
   })
 

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
@@ -17,7 +17,7 @@ const {mockRequest, mockUseWorkspace} = vi.hoisted(() => ({
 }))
 
 vi.mock('../../workspace', () => ({useWorkspace: mockUseWorkspace}))
-vi.mock('../../../hooks', () => {
+vi.mock('../../../hooks/useClient', () => {
   const client = {config: () => ({apiHost: 'https://api.sanity.io'}), request: mockRequest}
   return {useClient: () => client}
 })
@@ -112,6 +112,20 @@ describe('useUnclaimedProject', () => {
     expect(readUnclaimedProjectSnoozedAt(PROJECT_ID)).toBeUndefined()
   })
 
+  it('stays quiet for a regular robot-token session on a claimed project', async () => {
+    mockRequest.mockResolvedValue({createdAt: CREATED_AT, organizationId: 'oReal'})
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() =>
+      expect(mockRequest).toHaveBeenCalledExactlyOnceWith({
+        tag: 'unclaimed-project',
+        uri: `/projects/${PROJECT_ID}`,
+      }),
+    )
+    expect(result.current).toBeUndefined()
+  })
+
   it('reports expired and clears record and token when the project is gone', async () => {
     mockRequest.mockRejectedValue({statusCode: 404})
     writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
@@ -122,6 +136,27 @@ describe('useUnclaimedProject', () => {
     await waitFor(() => expect(result.current).toEqual({status: 'expired'}))
     expect(readUnclaimedProjectRecord(PROJECT_ID)).toBeUndefined()
     expect(localStorage.getItem(getAuthTokenStorageKey(PROJECT_ID))).toBeNull()
+  })
+
+  it('does not expire a regular robot-token session with no mint provenance', async () => {
+    mockRequest.mockRejectedValue({statusCode: 404})
+    localStorage.setItem(getAuthTokenStorageKey(PROJECT_ID), JSON.stringify({token: 'sk-live'}))
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalled())
+    expect(result.current).toBeUndefined()
+    expect(localStorage.getItem(getAuthTokenStorageKey(PROJECT_ID))).not.toBeNull()
+  })
+
+  it('stays quiet when an unclaimed project has no usable creation time', async () => {
+    mockRequest.mockResolvedValue({organizationId: 'oSystemUnclaimed'})
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalled())
+    expect(result.current).toBeUndefined()
+    expect(mockFetch).not.toHaveBeenCalled()
   })
 
   it('treats a missing organization id as unverifiable, not as claimed', async () => {
@@ -326,6 +361,40 @@ describe('useUnclaimedProject', () => {
     rerender()
 
     await waitFor(() => expect(result.current).toBeUndefined())
+  })
+
+  it('does not carry mint provenance across a robot to human to robot session change', async () => {
+    const {result, rerender} = renderHook(() => useUnclaimedProject())
+    await waitFor(() => expect(result.current?.status).toBe('unclaimed'))
+
+    mockUseWorkspace.mockReturnValue({currentUser: HUMAN_USER, projectId: PROJECT_ID})
+    rerender()
+    await waitFor(() => expect(result.current).toBeUndefined())
+
+    mockRequest.mockResolvedValue({createdAt: CREATED_AT, organizationId: 'oReal'})
+    mockUseWorkspace.mockReturnValue({currentUser: ROBOT_USER, projectId: PROJECT_ID})
+    rerender()
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2))
+    expect(result.current).toBeUndefined()
+  })
+
+  it('does not restore stale state after switching away from and back to a project', async () => {
+    const {result, rerender} = renderHook(() => useUnclaimedProject())
+    await waitFor(() => expect(result.current?.status).toBe('unclaimed'))
+
+    mockRequest.mockRejectedValue({statusCode: 500})
+    mockUseWorkspace.mockReturnValue({currentUser: ROBOT_USER, projectId: 'other-project'})
+    rerender()
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2))
+    expect(result.current).toBeUndefined()
+
+    mockRequest.mockResolvedValue({createdAt: CREATED_AT, organizationId: 'oReal'})
+    mockUseWorkspace.mockReturnValue({currentUser: ROBOT_USER, projectId: PROJECT_ID})
+    rerender()
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(3))
+    expect(result.current).toBeUndefined()
   })
 
   it('picks up a claim record stored by a mid-session hash paste', async () => {

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
@@ -197,6 +197,19 @@ describe('useUnclaimedProject', () => {
     expect(localStorage.getItem(getAuthTokenStorageKey(PROJECT_ID))).not.toBeNull()
   })
 
+  it('keeps mint credentials on a resource-level unauthorized response', async () => {
+    mockRequest.mockRejectedValue({statusCode: 401})
+    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+    localStorage.setItem(getAuthTokenStorageKey(PROJECT_ID), JSON.stringify({token: 'sk-live'}))
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalled())
+    expect(result.current).toBeUndefined()
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toEqual({claimUrl: CLAIM_URL})
+    expect(localStorage.getItem(getAuthTokenStorageKey(PROJECT_ID))).not.toBeNull()
+  })
+
   it('stays quiet when an unclaimed project has no usable creation time', async () => {
     mockRequest.mockResolvedValue({organizationId: 'oSystemUnclaimed'})
 

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
@@ -11,7 +11,8 @@ import {
 } from '../../../store/authStore/unclaimedProjectStorage'
 import {useUnclaimedProject} from '../useUnclaimedProject'
 
-const {mockRequest, mockUseWorkspace} = vi.hoisted(() => ({
+const {mockLogout, mockRequest, mockUseWorkspace} = vi.hoisted(() => ({
+  mockLogout: vi.fn(),
   mockRequest: vi.fn(),
   mockUseWorkspace: vi.fn(),
 }))
@@ -44,7 +45,12 @@ function lookupResponse(status: number, body?: unknown): Response {
 describe('useUnclaimedProject', () => {
   beforeEach(() => {
     localStorage.clear()
-    mockUseWorkspace.mockReturnValue({currentUser: ROBOT_USER, projectId: PROJECT_ID})
+    mockLogout.mockResolvedValue(undefined)
+    mockUseWorkspace.mockReturnValue({
+      auth: {logout: mockLogout},
+      currentUser: ROBOT_USER,
+      projectId: PROJECT_ID,
+    })
     mockRequest.mockResolvedValue({createdAt: CREATED_AT, organizationId: 'oSystemUnclaimed'})
     vi.stubGlobal('fetch', mockFetch)
     mockFetch.mockResolvedValue(lookupResponse(429))
@@ -174,7 +180,7 @@ describe('useUnclaimedProject', () => {
     expect(result.current).toBeUndefined()
   })
 
-  it('reports expired and clears record and token when the project is gone', async () => {
+  it('reports expired and logs out when the project is gone', async () => {
     mockRequest.mockRejectedValue({statusCode: 404})
     writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
     localStorage.setItem(getAuthTokenStorageKey(PROJECT_ID), JSON.stringify({token: 'sk-dead'}))
@@ -184,6 +190,7 @@ describe('useUnclaimedProject', () => {
     await waitFor(() => expect(result.current).toEqual({status: 'expired'}))
     expect(readUnclaimedProjectRecord(PROJECT_ID)).toBeUndefined()
     expect(localStorage.getItem(getAuthTokenStorageKey(PROJECT_ID))).toBeNull()
+    expect(mockLogout).toHaveBeenCalledOnce()
   })
 
   it('does not expire a regular robot-token session with no mint provenance', async () => {

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
@@ -220,6 +220,28 @@ describe('useUnclaimedProject', () => {
     expect(mockFetch).not.toHaveBeenCalled()
   })
 
+  it('looks up the authoritative expiry when a claim URL has no usable creation time', async () => {
+    mockRequest.mockResolvedValue({organizationId: 'oSystemUnclaimed'})
+    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+    mockFetch.mockResolvedValue(
+      lookupResponse(200, {state: 'claimable', expiresAt: '2026-07-26T18:00:00.000Z'}),
+    )
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        status: 'unclaimed',
+        claimUrl: CLAIM_URL,
+        expiresAt: new Date('2026-07-26T18:00:00.000Z'),
+        claimLinkSpent: false,
+      }),
+    )
+    expect(mockFetch).toHaveBeenCalledExactlyOnceWith(
+      'https://api.sanity.io/v2026-06-23/provision/some-claim-token/lookup',
+    )
+  })
+
   it('treats a missing organization id as unverifiable, not as claimed', async () => {
     mockRequest.mockResolvedValue({createdAt: CREATED_AT, organizationId: null})
     writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProjectCopy.test.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProjectCopy.test.ts
@@ -1,0 +1,119 @@
+import {renderHook, waitFor} from '@testing-library/react'
+import {of, throwError} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {
+  getLocalUnclaimedProjectCopyUrl,
+  parseUnclaimedProjectCopy,
+  type UnclaimedProjectCopy,
+  useUnclaimedProjectCopy,
+} from '../useUnclaimedProjectCopy'
+
+const {mockClient, mockRequest} = vi.hoisted(() => {
+  const request = vi.fn()
+  return {mockClient: {observable: {request}}, mockRequest: request}
+})
+
+vi.mock('../../../hooks/useClient', () => ({
+  useClient: () => mockClient,
+}))
+
+const COPY: UnclaimedProjectCopy = {
+  criticalThresholdHours: 8,
+  snoozeMinutes: 30,
+  banner: {
+    text: 'Expires in {{timeLeft}} ({{expiresAt}}).',
+    criticalText: 'Last call: expires in {{timeLeft}}.',
+    claimButtonText: 'Claim project',
+  },
+  toast: {
+    title: 'Expires in {{timeLeft}}.',
+    criticalTitle: 'Last call: expires at {{expiresAt}}.',
+    description: 'Keep everything you built.',
+    claimButtonText: 'Claim project',
+    snoozeButtonText: 'Remind me later',
+  },
+  claimed: {
+    text: 'Claimed.',
+    signInButtonText: 'Sign in',
+  },
+  expired: {
+    toastTitle: 'This project expired.',
+  },
+  noClaimUrl: {
+    text: 'Open the claim link printed in your terminal.',
+  },
+}
+
+describe('parseUnclaimedProjectCopy', () => {
+  it('accepts the complete Journey contract', () => {
+    expect(parseUnclaimedProjectCopy(COPY)).toEqual(COPY)
+  })
+
+  it.each([
+    undefined,
+    null,
+    {},
+    {...COPY, criticalThresholdHours: 0},
+    {...COPY, snoozeMinutes: 1.5},
+    {...COPY, banner: {...COPY.banner, text: undefined}},
+    {...COPY, toast: {...COPY.toast, description: 42}},
+    {...COPY, claimed: undefined},
+    {...COPY, expired: {}},
+    {...COPY, noClaimUrl: {text: null}},
+  ])('rejects an incomplete or malformed contract', (value) => {
+    expect(parseUnclaimedProjectCopy(value)).toBeUndefined()
+  })
+})
+
+describe('getLocalUnclaimedProjectCopyUrl', () => {
+  it.each([
+    'http://localhost:5002/v2026-07-28/journey/unclaimed-project',
+    'http://127.0.0.1:5002/v2026-07-28/journey/unclaimed-project',
+    'http://[::1]:5002/v2026-07-28/journey/unclaimed-project',
+  ])('allows a loopback HTTP endpoint during local development', (value) => {
+    expect(getLocalUnclaimedProjectCopyUrl({isDev: true, value})).toBe(value)
+  })
+
+  it.each([
+    ['a production build', false, 'http://localhost:5002/copy'],
+    ['an HTTPS URL', true, 'https://localhost:5002/copy'],
+    ['a non-loopback URL', true, 'http://example.com/copy'],
+    ['a malformed URL', true, 'not-a-url'],
+    ['a missing URL', true, undefined],
+  ])('rejects %s', (_label, isDev, value) => {
+    expect(getLocalUnclaimedProjectCopyUrl({isDev, value})).toBeUndefined()
+  })
+})
+
+describe('useUnclaimedProjectCopy', () => {
+  beforeEach(() => {
+    mockRequest.mockReset()
+    mockRequest.mockReturnValue(of(COPY))
+  })
+
+  it('does not request copy before mint-and-claim provenance is known', () => {
+    const {result} = renderHook(() => useUnclaimedProjectCopy(false))
+
+    expect(result.current).toBeUndefined()
+    expect(mockRequest).not.toHaveBeenCalled()
+  })
+
+  it('returns Journey copy when the optional request succeeds', async () => {
+    const {result} = renderHook(() => useUnclaimedProjectCopy(true))
+
+    await waitFor(() => expect(result.current).toEqual(COPY))
+    expect(mockRequest).toHaveBeenCalledExactlyOnceWith({uri: '/journey/unclaimed-project'})
+  })
+
+  it('stays quiet when the optional Journey request fails', async () => {
+    mockRequest.mockReturnValue(throwError(() => new Error('Journey unavailable')))
+
+    const {result} = renderHook(() => useUnclaimedProjectCopy(true))
+
+    await waitFor(() =>
+      expect(mockRequest).toHaveBeenCalledExactlyOnceWith({uri: '/journey/unclaimed-project'}),
+    )
+    expect(result.current).toBeUndefined()
+  })
+})

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProjectCopy.test.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProjectCopy.test.ts
@@ -3,6 +3,8 @@ import {of, throwError} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {
+  getClaimedIdentityText,
+  getClaimedIdentityTextParts,
   getLocalUnclaimedProjectCopyUrl,
   parseUnclaimedProjectCopy,
   type UnclaimedProjectCopy,
@@ -35,7 +37,8 @@ const COPY: UnclaimedProjectCopy = {
   },
   claimed: {
     text: 'Claimed.',
-    signInButtonText: 'Sign in',
+    identityText: 'Log in as {{identity}}.',
+    signInButtonText: 'Log in',
   },
   expired: {
     toastTitle: 'This project expired.',
@@ -44,6 +47,32 @@ const COPY: UnclaimedProjectCopy = {
     text: 'Open the claim link printed in your terminal.',
   },
 }
+
+describe('getClaimedIdentityText', () => {
+  const text = 'Log in as {{identity}}.'
+
+  it('puts the claimed email in the supporting copy when available', () => {
+    expect(getClaimedIdentityText(text, 'claimant@example.com')).toBe(
+      'Log in as claimant@example.com.',
+    )
+  })
+
+  it('uses an explicit account fallback when the email is unavailable', () => {
+    expect(getClaimedIdentityText(text)).toBe('Log in as the account tied to this project.')
+  })
+
+  it('isolates a known identity so Studio can emphasize it', () => {
+    expect(getClaimedIdentityTextParts(text, 'claimant@example.com')).toEqual({
+      before: 'Log in as ',
+      identity: 'claimant@example.com',
+      after: '.',
+    })
+  })
+
+  it('does not emphasize the generic fallback', () => {
+    expect(getClaimedIdentityTextParts(text)).toBeUndefined()
+  })
+})
 
 describe('parseUnclaimedProjectCopy', () => {
   it('accepts the complete Journey contract', () => {
@@ -59,6 +88,7 @@ describe('parseUnclaimedProjectCopy', () => {
     {...COPY, banner: {...COPY.banner, text: undefined}},
     {...COPY, toast: {...COPY.toast, description: 42}},
     {...COPY, claimed: undefined},
+    {...COPY, claimed: {...COPY.claimed, identityText: undefined}},
     {...COPY, expired: {}},
     {...COPY, noClaimUrl: {text: null}},
   ])('rejects an incomplete or malformed contract', (value) => {

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProjectCopy.test.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProjectCopy.test.ts
@@ -133,7 +133,10 @@ describe('useUnclaimedProjectCopy', () => {
     const {result} = renderHook(() => useUnclaimedProjectCopy(true))
 
     await waitFor(() => expect(result.current).toEqual(COPY))
-    expect(mockRequest).toHaveBeenCalledExactlyOnceWith({uri: '/journey/unclaimed-project'})
+    expect(mockRequest).toHaveBeenCalledExactlyOnceWith({
+      uri: '/journey/unclaimed-project',
+      tag: 'unclaimed-project-copy',
+    })
   })
 
   it('stays quiet when the optional Journey request fails', async () => {
@@ -142,7 +145,10 @@ describe('useUnclaimedProjectCopy', () => {
     const {result} = renderHook(() => useUnclaimedProjectCopy(true))
 
     await waitFor(() =>
-      expect(mockRequest).toHaveBeenCalledExactlyOnceWith({uri: '/journey/unclaimed-project'}),
+      expect(mockRequest).toHaveBeenCalledExactlyOnceWith({
+        uri: '/journey/unclaimed-project',
+        tag: 'unclaimed-project-copy',
+      }),
     )
     expect(result.current).toBeUndefined()
   })

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProjectCopy.test.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProjectCopy.test.ts
@@ -40,9 +40,6 @@ const COPY: UnclaimedProjectCopy = {
     identityText: 'Log in as {{identity}}.',
     signInButtonText: 'Log in',
   },
-  expired: {
-    toastTitle: 'This project expired.',
-  },
   noClaimUrl: {
     text: 'Open the claim link printed in your terminal.',
   },
@@ -79,6 +76,12 @@ describe('parseUnclaimedProjectCopy', () => {
     expect(parseUnclaimedProjectCopy(COPY)).toEqual(COPY)
   })
 
+  it('ignores legacy expired toast copy', () => {
+    expect(
+      parseUnclaimedProjectCopy({...COPY, expired: {toastTitle: 'This project expired.'}}),
+    ).toEqual(COPY)
+  })
+
   it.each([
     undefined,
     null,
@@ -89,7 +92,6 @@ describe('parseUnclaimedProjectCopy', () => {
     {...COPY, toast: {...COPY.toast, description: 42}},
     {...COPY, claimed: undefined},
     {...COPY, claimed: {...COPY.claimed, identityText: undefined}},
-    {...COPY, expired: {}},
     {...COPY, noClaimUrl: {text: null}},
   ])('rejects an incomplete or malformed contract', (value) => {
     expect(parseUnclaimedProjectCopy(value)).toBeUndefined()

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
@@ -266,7 +266,7 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
         const statusCode = getStatusCode(err)
         const hasMintProvenance =
           hasSeenUnclaimed() || Boolean(readUnclaimedProjectRecord(projectId))
-        if ((statusCode === 404 || statusCode === 401) && hasMintProvenance) finishExpired()
+        if (statusCode === 404 && hasMintProvenance) finishExpired()
         return
       }
       if (disposed || terminal) return

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
@@ -21,6 +21,12 @@ const UNCLAIMED_PROJECT_TTL_MS = 72 * 3_600_000
 /** Focus-driven project reads are throttled to this window. */
 const PROJECT_CHECK_INTERVAL_MS = 5 * 60_000
 
+/** While a claim is in progress, recheck often enough for the Studio to transition live. */
+const CLAIM_STATUS_POLL_INTERVAL_MS = 10_000
+
+/** Stop elevated polling if the claim flow is abandoned. */
+const CLAIM_STATUS_POLL_DURATION_MS = 10 * 60_000
+
 /** The unauthenticated provision lookup shares a ~20/hour per-IP budget with the CLI. */
 const CLAIM_LOOKUP_INTERVAL_MS = 30 * 60_000
 
@@ -47,6 +53,11 @@ interface ClaimLookupResponse {
   state?: 'claimable' | 'claimed' | 'expired'
 }
 
+interface UseUnclaimedProjectOptions {
+  /** Timestamp set when the claim flow is opened for this project. */
+  claimAttemptedAt?: number
+}
+
 // Claim tokens are base64url; anything else must not reach the lookup URL we build from it.
 function claimTokenFromClaimUrl(claimUrl: string): string | undefined {
   try {
@@ -68,7 +79,9 @@ function getStatusCode(error: unknown): number | undefined {
  *
  * @internal
  */
-export function useUnclaimedProject(): UnclaimedProjectState | undefined {
+export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptions = {}):
+  | UnclaimedProjectState
+  | undefined {
   const {currentUser, projectId} = useWorkspace()
   const client = useClient({apiVersion: PROJECTS_API_VERSION})
   const isRobot = currentUser?.provider === ROBOT_PROVIDER
@@ -100,6 +113,25 @@ export function useUnclaimedProject(): UnclaimedProjectState | undefined {
     let lastCheckedAt = 0
     let lookupSawNotFound = false
     let claimLinkSpent = false
+    let checkInFlight = false
+    let pendingCheck: ReturnType<typeof setTimeout> | undefined
+    let claimPollInterval: ReturnType<typeof setInterval> | undefined
+    let claimPollTimeout: ReturnType<typeof setTimeout> | undefined
+
+    const stopClaimPolling = () => {
+      if (claimPollInterval) clearInterval(claimPollInterval)
+      if (claimPollTimeout) clearTimeout(claimPollTimeout)
+      claimPollInterval = undefined
+      claimPollTimeout = undefined
+    }
+
+    const getRemainingClaimPollingDuration = () => {
+      if (claimAttemptedAt === undefined) return 0
+      const elapsed = Math.max(0, Date.now() - claimAttemptedAt)
+      return Math.max(0, CLAIM_STATUS_POLL_DURATION_MS - elapsed)
+    }
+
+    const isClaimPollingActive = () => getRemainingClaimPollingDuration() > 0
 
     const hasSeenUnclaimed = () =>
       provenanceRef.current.sessionKey === sessionKey && provenanceRef.current.seenUnclaimed
@@ -110,6 +142,7 @@ export function useUnclaimedProject(): UnclaimedProjectState | undefined {
 
     const finishClaimed = () => {
       terminal = true
+      stopClaimPolling()
       clearUnclaimedProjectRecord(projectId)
       clearUnclaimedProjectSnooze(projectId)
       update({status: 'claimed'})
@@ -117,6 +150,7 @@ export function useUnclaimedProject(): UnclaimedProjectState | undefined {
 
     const finishExpired = () => {
       terminal = true
+      stopClaimPolling()
       clearUnclaimedProjectRecord(projectId)
       clearUnclaimedProjectSnooze(projectId)
       if (supportsLocalStorage) {
@@ -194,10 +228,7 @@ export function useUnclaimedProject(): UnclaimedProjectState | undefined {
       }
     }
 
-    const check = async () => {
-      if (terminal) return
-      lastCheckedAt = Date.now()
-
+    const performCheck = async () => {
       let project: {createdAt?: string; organizationId?: string}
       try {
         project = await client.request({uri: `/projects/${projectId}`, tag: 'unclaimed-project'})
@@ -242,10 +273,30 @@ export function useUnclaimedProject(): UnclaimedProjectState | undefined {
       if (record) await refineFromLookup(record, expiresAt.getTime())
     }
 
+    const check = async () => {
+      if (terminal || checkInFlight) return
+      checkInFlight = true
+      lastCheckedAt = Date.now()
+
+      try {
+        await performCheck()
+      } finally {
+        checkInFlight = false
+      }
+    }
+
     void check()
 
-    let pendingCheck: ReturnType<typeof setTimeout> | undefined
+    if (isClaimPollingActive()) {
+      claimPollInterval = setInterval(() => void check(), CLAIM_STATUS_POLL_INTERVAL_MS)
+      claimPollTimeout = setTimeout(stopClaimPolling, getRemainingClaimPollingDuration())
+    }
+
     const onFocus = () => {
+      if (isClaimPollingActive()) {
+        void check()
+        return
+      }
       const wait = PROJECT_CHECK_INTERVAL_MS - (Date.now() - lastCheckedAt)
       if (wait <= 0) {
         void check()
@@ -257,6 +308,11 @@ export function useUnclaimedProject(): UnclaimedProjectState | undefined {
       }
     }
     window.addEventListener('focus', onFocus)
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible' && isClaimPollingActive()) void check()
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
 
     // The auth store consumes a `#claim=` fragment pasted into the open tab and writes the
     // record (see hashClaim.ts); pick it up here without waiting for the next check.
@@ -284,10 +340,12 @@ export function useUnclaimedProject(): UnclaimedProjectState | undefined {
     return () => {
       disposed = true
       if (pendingCheck) clearTimeout(pendingCheck)
+      stopClaimPolling()
       window.removeEventListener('focus', onFocus)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
       window.removeEventListener('hashchange', onHashChange)
     }
-  }, [client, isRobot, projectId, sessionKey])
+  }, [claimAttemptedAt, client, isRobot, projectId, sessionKey])
 
   return state
 }

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
@@ -45,8 +45,19 @@ export type UnclaimedProjectState =
       /** The lookup reported the claim link spent or gone — don't point the user at it. */
       claimLinkSpent?: boolean
     }
-  | {status: 'claimed'}
+  | {status: 'claimed'; email?: string}
   | {status: 'expired'}
+
+interface ProjectMember {
+  id?: string
+  isRobot?: boolean
+}
+
+interface ProjectResponse {
+  createdAt?: string
+  organizationId?: string
+  members?: ProjectMember[]
+}
 
 interface ClaimLookupResponse {
   expiresAt?: string | null
@@ -140,12 +151,31 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
       if (!disposed) setSessionState({sessionKey, value: next})
     }
 
-    const finishClaimed = () => {
+    const finishClaimed = (members?: ProjectMember[]) => {
       terminal = true
       stopClaimPolling()
       clearUnclaimedProjectRecord(projectId)
       clearUnclaimedProjectSnooze(projectId)
       update({status: 'claimed'})
+
+      const humanMembers = members?.filter(
+        (member): member is ProjectMember & {id: string} =>
+          member.isRobot === false && typeof member.id === 'string' && Boolean(member.id),
+      )
+      if (humanMembers?.length !== 1) return
+
+      void client
+        .request<{email?: string}>({
+          uri: `/users/${humanMembers[0].id}`,
+          tag: 'unclaimed-project.claimant',
+        })
+        .then((user) => {
+          const email = typeof user.email === 'string' ? user.email.trim() : ''
+          if (!disposed && email) update({status: 'claimed', email})
+        })
+        .catch(() => {
+          // The targeted label is optional; keep the generic sign-in CTA on any lookup failure.
+        })
     }
 
     const finishExpired = () => {
@@ -229,7 +259,7 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
     }
 
     const performCheck = async () => {
-      let project: {createdAt?: string; organizationId?: string}
+      let project: ProjectResponse
       try {
         project = await client.request({uri: `/projects/${projectId}`, tag: 'unclaimed-project'})
       } catch (err) {
@@ -244,7 +274,7 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
       if (!project.organizationId) return
       const record = readUnclaimedProjectRecord(projectId)
       if (project.organizationId !== UNCLAIMED_ORGANIZATION_ID) {
-        if (hasSeenUnclaimed() || record) finishClaimed()
+        if (hasSeenUnclaimed() || record) finishClaimed(project.members)
         return
       }
 

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
@@ -311,9 +311,10 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
 
       try {
         await performCheck()
-      } finally {
-        checkInFlight = false
+      } catch {
+        // Lifecycle checks are best-effort. Keep the nudge quiet and allow a later trigger to retry.
       }
+      checkInFlight = false
     }
 
     const remainingClaimPollingDuration = getRemainingClaimPollingDuration()

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
@@ -1,4 +1,5 @@
 import {useEffect, useRef, useState} from 'react'
+import {exhaustMap, filter, fromEvent, merge, of, Subject, takeUntil, tap, timer} from 'rxjs'
 
 import {useClient} from '../../hooks/useClient'
 import {getAuthTokenStorageKey} from '../../store/authStore/constants'
@@ -116,8 +117,11 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
       // An unclaimed project has no human members, so a human session means any stored claim
       // record is stale — storage never outlives the state that justified it.
       clearUnclaimedProjectRecord(projectId)
-      return undefined
     }
+  }, [isRobot, projectId, sessionKey])
+
+  useEffect(() => {
+    if (!isRobot) return undefined
 
     let disposed = false
     let terminal = false
@@ -125,15 +129,11 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
     let lookupSawNotFound = false
     let claimLinkSpent = false
     let checkInFlight = false
-    let pendingCheck: ReturnType<typeof setTimeout> | undefined
-    let claimPollInterval: ReturnType<typeof setInterval> | undefined
-    let claimPollTimeout: ReturnType<typeof setTimeout> | undefined
+    const claimPollingStopped$ = new Subject<void>()
 
     const stopClaimPolling = () => {
-      if (claimPollInterval) clearInterval(claimPollInterval)
-      if (claimPollTimeout) clearTimeout(claimPollTimeout)
-      claimPollInterval = undefined
-      claimPollTimeout = undefined
+      claimPollingStopped$.next()
+      claimPollingStopped$.complete()
     }
 
     const getRemainingClaimPollingDuration = () => {
@@ -316,34 +316,25 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
       }
     }
 
-    void check()
-
-    if (isClaimPollingActive()) {
-      claimPollInterval = setInterval(() => void check(), CLAIM_STATUS_POLL_INTERVAL_MS)
-      claimPollTimeout = setTimeout(stopClaimPolling, getRemainingClaimPollingDuration())
-    }
-
-    const onFocus = () => {
-      if (isClaimPollingActive()) {
-        void check()
-        return
-      }
-      const wait = PROJECT_CHECK_INTERVAL_MS - (Date.now() - lastCheckedAt)
-      if (wait <= 0) {
-        void check()
-      } else if (!pendingCheck) {
-        pendingCheck = setTimeout(() => {
-          pendingCheck = undefined
-          void check()
-        }, wait)
-      }
-    }
-    window.addEventListener('focus', onFocus)
-
-    const onVisibilityChange = () => {
-      if (document.visibilityState === 'visible' && isClaimPollingActive()) void check()
-    }
-    document.addEventListener('visibilitychange', onVisibilityChange)
+    const remainingClaimPollingDuration = getRemainingClaimPollingDuration()
+    const initialAndPolling$ = remainingClaimPollingDuration
+      ? timer(0, CLAIM_STATUS_POLL_INTERVAL_MS).pipe(
+          takeUntil(timer(remainingClaimPollingDuration)),
+          takeUntil(claimPollingStopped$),
+        )
+      : of(0)
+    const focus$ = fromEvent(window, 'focus').pipe(
+      exhaustMap(() => {
+        if (isClaimPollingActive()) return of(0)
+        return timer(Math.max(0, PROJECT_CHECK_INTERVAL_MS - (Date.now() - lastCheckedAt)))
+      }),
+    )
+    const visibleDuringClaim$ = fromEvent(document, 'visibilitychange').pipe(
+      filter(() => document.visibilityState === 'visible' && isClaimPollingActive()),
+    )
+    const checkSubscription = merge(initialAndPolling$, focus$, visibleDuringClaim$)
+      .pipe(tap(() => void check()))
+      .subscribe()
 
     // The auth store consumes a `#claim=` fragment pasted into the open tab and writes the
     // record (see hashClaim.ts); pick it up here without waiting for the next check.
@@ -366,15 +357,13 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
           : prev
       })
     }
-    window.addEventListener('hashchange', onHashChange)
+    const hashSubscription = fromEvent(window, 'hashchange').pipe(tap(onHashChange)).subscribe()
 
     return () => {
       disposed = true
-      if (pendingCheck) clearTimeout(pendingCheck)
       stopClaimPolling()
-      window.removeEventListener('focus', onFocus)
-      document.removeEventListener('visibilitychange', onVisibilityChange)
-      window.removeEventListener('hashchange', onHashChange)
+      checkSubscription.unsubscribe()
+      hashSubscription.unsubscribe()
     }
   }, [claimAttemptedAt, client, isRobot, projectId, sessionKey])
 

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
@@ -112,13 +112,7 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
       provenanceRef.current = {sessionKey, seenUnclaimed: false}
       setSessionState(undefined)
     }
-
-    if (!isRobot) {
-      // An unclaimed project has no human members, so a human session means any stored claim
-      // record is stale — storage never outlives the state that justified it.
-      clearUnclaimedProjectRecord(projectId)
-    }
-  }, [isRobot, projectId, sessionKey])
+  }, [sessionKey])
 
   useEffect(() => {
     if (!isRobot) return undefined

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
@@ -31,8 +31,8 @@ const CLAIM_STATUS_POLL_DURATION_MS = 10 * 60_000
 /** The unauthenticated provision lookup shares a ~20/hour per-IP budget with the CLI. */
 const CLAIM_LOOKUP_INTERVAL_MS = 30 * 60_000
 
-/** Identity provider of the pre-claim robot token. */
-const ROBOT_PROVIDER = 'sanity-token'
+/** Identity provider of the pre-claim robot token. @internal */
+export const ROBOT_PROVIDER = 'sanity-token'
 
 /** Holding organization that owns every minted-but-unclaimed project. */
 const UNCLAIMED_ORGANIZATION_ID = 'oSystemUnclaimed'

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
@@ -1,6 +1,6 @@
-import {useEffect, useState} from 'react'
+import {useEffect, useRef, useState} from 'react'
 
-import {useClient} from '../../hooks'
+import {useClient} from '../../hooks/useClient'
 import {getAuthTokenStorageKey} from '../../store/authStore/constants'
 import {
   clearUnclaimedProjectRecord,
@@ -57,6 +57,11 @@ function claimTokenFromClaimUrl(claimUrl: string): string | undefined {
   }
 }
 
+function getStatusCode(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object' || !('statusCode' in error)) return undefined
+  return typeof error.statusCode === 'number' ? error.statusCode : undefined
+}
+
 /**
  * Claim lifecycle of the current project.
  * Defaults to `undefined` when the project wasn't created via `sanity new` or public provisioning APIs.
@@ -67,18 +72,22 @@ export function useUnclaimedProject(): UnclaimedProjectState | undefined {
   const {currentUser, projectId} = useWorkspace()
   const client = useClient({apiVersion: PROJECTS_API_VERSION})
   const isRobot = currentUser?.provider === ROBOT_PROVIDER
-  const [state, setState] = useState<UnclaimedProjectState>()
-
-  // A workspace switch can swap the project or the identity under the mounted layout — reset
-  // during render so a previous project's nudge never lingers.
   const sessionKey = `${projectId}:${isRobot}`
-  const [prevSessionKey, setPrevSessionKey] = useState(sessionKey)
-  if (prevSessionKey !== sessionKey) {
-    setPrevSessionKey(sessionKey)
-    setState(undefined)
-  }
+  const provenanceRef = useRef({sessionKey, seenUnclaimed: false})
+  const [sessionState, setSessionState] = useState<{
+    sessionKey: string
+    value: UnclaimedProjectState
+  }>()
+  // A workspace switch can swap the project or identity under the mounted layout. Tagging the
+  // async state makes the previous session disappear immediately without setting state in render.
+  const state = sessionState?.sessionKey === sessionKey ? sessionState.value : undefined
 
   useEffect(() => {
+    if (provenanceRef.current.sessionKey !== sessionKey) {
+      provenanceRef.current = {sessionKey, seenUnclaimed: false}
+      setSessionState(undefined)
+    }
+
     if (!isRobot) {
       // An unclaimed project has no human members, so a human session means any stored claim
       // record is stale — storage never outlives the state that justified it.
@@ -92,8 +101,11 @@ export function useUnclaimedProject(): UnclaimedProjectState | undefined {
     let lookupSawNotFound = false
     let claimLinkSpent = false
 
+    const hasSeenUnclaimed = () =>
+      provenanceRef.current.sessionKey === sessionKey && provenanceRef.current.seenUnclaimed
+
     const update = (next: UnclaimedProjectState) => {
-      if (!disposed) setState(next)
+      if (!disposed) setSessionState({sessionKey, value: next})
     }
 
     const finishClaimed = () => {
@@ -121,11 +133,15 @@ export function useUnclaimedProject(): UnclaimedProjectState | undefined {
       claimLinkSpent = true
       clearUnclaimedProjectRecord(projectId)
       if (!disposed) {
-        setState((prev) =>
-          prev?.status === 'unclaimed'
-            ? {...prev, claimUrl: undefined, claimLinkSpent: true}
-            : prev,
-        )
+        setSessionState((prev) => {
+          const value = prev?.sessionKey === sessionKey ? prev.value : undefined
+          return value?.status === 'unclaimed'
+            ? {
+                sessionKey,
+                value: {...value, claimUrl: undefined, claimLinkSpent: true},
+              }
+            : prev
+        })
       }
     }
 
@@ -186,29 +202,42 @@ export function useUnclaimedProject(): UnclaimedProjectState | undefined {
       try {
         project = await client.request({uri: `/projects/${projectId}`, tag: 'unclaimed-project'})
       } catch (err) {
-        const statusCode = (err as {statusCode?: number} | null)?.statusCode
-        if (statusCode === 404 || statusCode === 401) finishExpired()
+        const statusCode = getStatusCode(err)
+        const hasMintProvenance =
+          hasSeenUnclaimed() || Boolean(readUnclaimedProjectRecord(projectId))
+        if ((statusCode === 404 || statusCode === 401) && hasMintProvenance) finishExpired()
         return
       }
       if (disposed || terminal) return
       // A response without an organization id is unverifiable, not a claim: fail open.
       if (!project.organizationId) return
+      const record = readUnclaimedProjectRecord(projectId)
       if (project.organizationId !== UNCLAIMED_ORGANIZATION_ID) {
-        finishClaimed()
+        if (hasSeenUnclaimed() || record) finishClaimed()
         return
       }
 
-      const record = readUnclaimedProjectRecord(projectId)
-      const expiresAt = record?.expiresAt
-        ? new Date(record.expiresAt)
-        : new Date(new Date(project.createdAt ?? Date.now()).getTime() + UNCLAIMED_PROJECT_TTL_MS)
+      provenanceRef.current = {sessionKey, seenUnclaimed: true}
+      const createdAt = project.createdAt ? new Date(project.createdAt) : undefined
+      const derivedExpiresAt =
+        createdAt && !Number.isNaN(createdAt.getTime())
+          ? new Date(createdAt.getTime() + UNCLAIMED_PROJECT_TTL_MS)
+          : undefined
+      const expiresAt = record?.expiresAt ? new Date(record.expiresAt) : derivedExpiresAt
+      if (!expiresAt) return
       if (!disposed) {
-        setState((prev) => ({
-          status: 'unclaimed',
-          claimUrl: record?.claimUrl,
-          expiresAt: !record && prev?.status === 'unclaimed' ? prev.expiresAt : expiresAt,
-          claimLinkSpent,
-        }))
+        setSessionState((prev) => {
+          const value = prev?.sessionKey === sessionKey ? prev.value : undefined
+          return {
+            sessionKey,
+            value: {
+              status: 'unclaimed',
+              claimUrl: record?.claimUrl,
+              expiresAt: !record && value?.status === 'unclaimed' ? value.expiresAt : expiresAt,
+              claimLinkSpent,
+            },
+          }
+        })
       }
       if (record) await refineFromLookup(record, expiresAt.getTime())
     }
@@ -235,16 +264,20 @@ export function useUnclaimedProject(): UnclaimedProjectState | undefined {
       const record = readUnclaimedProjectRecord(projectId)
       if (!record || disposed) return
       claimLinkSpent = false
-      setState((prev) =>
-        prev?.status === 'unclaimed'
+      setSessionState((prev) => {
+        const value = prev?.sessionKey === sessionKey ? prev.value : undefined
+        return value?.status === 'unclaimed'
           ? {
-              ...prev,
-              claimUrl: record.claimUrl,
-              expiresAt: record.expiresAt ? new Date(record.expiresAt) : prev.expiresAt,
-              claimLinkSpent: false,
+              sessionKey,
+              value: {
+                ...value,
+                claimUrl: record.claimUrl,
+                expiresAt: record.expiresAt ? new Date(record.expiresAt) : value.expiresAt,
+                claimLinkSpent: false,
+              },
             }
-          : prev,
-      )
+          : prev
+      })
     }
     window.addEventListener('hashchange', onHashChange)
 
@@ -254,7 +287,7 @@ export function useUnclaimedProject(): UnclaimedProjectState | undefined {
       window.removeEventListener('focus', onFocus)
       window.removeEventListener('hashchange', onHashChange)
     }
-  }, [client, isRobot, projectId])
+  }, [client, isRobot, projectId, sessionKey])
 
   return state
 }

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
@@ -1,0 +1,260 @@
+import {useEffect, useState} from 'react'
+
+import {useClient} from '../../hooks'
+import {getAuthTokenStorageKey} from '../../store/authStore/constants'
+import {
+  clearUnclaimedProjectRecord,
+  clearUnclaimedProjectSnooze,
+  readUnclaimedProjectRecord,
+  type UnclaimedProjectRecord,
+  writeUnclaimedProjectRecord,
+} from '../../store/authStore/unclaimedProjectStorage'
+import {supportsLocalStorage} from '../../util/supportsLocalStorage'
+import {useWorkspace} from '../workspace'
+
+const PROJECTS_API_VERSION = 'v2026-05-04'
+const PROVISION_API_VERSION = 'v2026-06-23'
+
+/** Unclaimed projects are hard-deleted this long after mint. */
+const UNCLAIMED_PROJECT_TTL_MS = 72 * 3_600_000
+
+/** Focus-driven project reads are throttled to this window. */
+const PROJECT_CHECK_INTERVAL_MS = 5 * 60_000
+
+/** The unauthenticated provision lookup shares a ~20/hour per-IP budget with the CLI. */
+const CLAIM_LOOKUP_INTERVAL_MS = 30 * 60_000
+
+/** Identity provider of the pre-claim robot token. */
+const ROBOT_PROVIDER = 'sanity-token'
+
+/** Holding organization that owns every minted-but-unclaimed project. */
+const UNCLAIMED_ORGANIZATION_ID = 'oSystemUnclaimed'
+
+/** @internal */
+export type UnclaimedProjectState =
+  | {
+      status: 'unclaimed'
+      claimUrl: string | undefined
+      expiresAt: Date
+      /** The lookup reported the claim link spent or gone — don't point the user at it. */
+      claimLinkSpent?: boolean
+    }
+  | {status: 'claimed'}
+  | {status: 'expired'}
+
+interface ClaimLookupResponse {
+  expiresAt?: string | null
+  state?: 'claimable' | 'claimed' | 'expired'
+}
+
+// Claim tokens are base64url; anything else must not reach the lookup URL we build from it.
+function claimTokenFromClaimUrl(claimUrl: string): string | undefined {
+  try {
+    const token = new URL(claimUrl).pathname.split('/').findLast(Boolean)
+    return token && /^[\w-]+$/.test(token) ? token : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Claim lifecycle of the current project.
+ * Defaults to `undefined` when the project wasn't created via `sanity new` or public provisioning APIs.
+ *
+ * @internal
+ */
+export function useUnclaimedProject(): UnclaimedProjectState | undefined {
+  const {currentUser, projectId} = useWorkspace()
+  const client = useClient({apiVersion: PROJECTS_API_VERSION})
+  const isRobot = currentUser?.provider === ROBOT_PROVIDER
+  const [state, setState] = useState<UnclaimedProjectState>()
+
+  // A workspace switch can swap the project or the identity under the mounted layout — reset
+  // during render so a previous project's nudge never lingers.
+  const sessionKey = `${projectId}:${isRobot}`
+  const [prevSessionKey, setPrevSessionKey] = useState(sessionKey)
+  if (prevSessionKey !== sessionKey) {
+    setPrevSessionKey(sessionKey)
+    setState(undefined)
+  }
+
+  useEffect(() => {
+    if (!isRobot) {
+      // An unclaimed project has no human members, so a human session means any stored claim
+      // record is stale — storage never outlives the state that justified it.
+      clearUnclaimedProjectRecord(projectId)
+      return undefined
+    }
+
+    let disposed = false
+    let terminal = false
+    let lastCheckedAt = 0
+    let lookupSawNotFound = false
+    let claimLinkSpent = false
+
+    const update = (next: UnclaimedProjectState) => {
+      if (!disposed) setState(next)
+    }
+
+    const finishClaimed = () => {
+      terminal = true
+      clearUnclaimedProjectRecord(projectId)
+      clearUnclaimedProjectSnooze(projectId)
+      update({status: 'claimed'})
+    }
+
+    const finishExpired = () => {
+      terminal = true
+      clearUnclaimedProjectRecord(projectId)
+      clearUnclaimedProjectSnooze(projectId)
+      if (supportsLocalStorage) {
+        try {
+          localStorage.removeItem(getAuthTokenStorageKey(projectId))
+        } catch {
+          // best-effort
+        }
+      }
+      update({status: 'expired'})
+    }
+
+    const dropClaimRecord = () => {
+      claimLinkSpent = true
+      clearUnclaimedProjectRecord(projectId)
+      if (!disposed) {
+        setState((prev) =>
+          prev?.status === 'unclaimed'
+            ? {...prev, claimUrl: undefined, claimLinkSpent: true}
+            : prev,
+        )
+      }
+    }
+
+    const refineFromLookup = async (record: UnclaimedProjectRecord, localExpiry: number) => {
+      const claimToken = claimTokenFromClaimUrl(record.claimUrl)
+      if (!claimToken) return
+      const lastLookupAt = record.lastLookupAt ? new Date(record.lastLookupAt).getTime() : 0
+      if (Date.now() - lastLookupAt < CLAIM_LOOKUP_INTERVAL_MS) return
+
+      const throttled = {...record, lastLookupAt: new Date().toISOString()}
+
+      let response: Response
+      try {
+        const {apiHost} = client.config()
+        response = await fetch(`${apiHost}/${PROVISION_API_VERSION}/provision/${claimToken}/lookup`)
+      } catch {
+        if (!disposed && !terminal) writeUnclaimedProjectRecord(projectId, throttled)
+        return
+      }
+
+      if (disposed || terminal) return
+
+      writeUnclaimedProjectRecord(projectId, throttled)
+
+      if (response.status === 404) {
+        if (lookupSawNotFound || Date.now() > localExpiry) dropClaimRecord()
+        lookupSawNotFound = true
+        return
+      }
+
+      if (!response.ok) return
+
+      let data: ClaimLookupResponse
+      try {
+        data = await response.json()
+      } catch {
+        return
+      }
+      if (disposed || terminal) return
+      if (data.state === 'claimed') {
+        finishClaimed()
+      } else if (data.state === 'expired') {
+        dropClaimRecord()
+      } else if (data.state === 'claimable' && data.expiresAt) {
+        const expiresAt = new Date(data.expiresAt)
+        if (Number.isNaN(expiresAt.getTime())) return
+        claimLinkSpent = false
+        writeUnclaimedProjectRecord(projectId, {...throttled, expiresAt: data.expiresAt})
+        update({status: 'unclaimed', claimUrl: record.claimUrl, expiresAt, claimLinkSpent: false})
+      }
+    }
+
+    const check = async () => {
+      if (terminal) return
+      lastCheckedAt = Date.now()
+
+      let project: {createdAt?: string; organizationId?: string}
+      try {
+        project = await client.request({uri: `/projects/${projectId}`, tag: 'unclaimed-project'})
+      } catch (err) {
+        const statusCode = (err as {statusCode?: number} | null)?.statusCode
+        if (statusCode === 404 || statusCode === 401) finishExpired()
+        return
+      }
+      if (disposed || terminal) return
+      // A response without an organization id is unverifiable, not a claim: fail open.
+      if (!project.organizationId) return
+      if (project.organizationId !== UNCLAIMED_ORGANIZATION_ID) {
+        finishClaimed()
+        return
+      }
+
+      const record = readUnclaimedProjectRecord(projectId)
+      const expiresAt = record?.expiresAt
+        ? new Date(record.expiresAt)
+        : new Date(new Date(project.createdAt ?? Date.now()).getTime() + UNCLAIMED_PROJECT_TTL_MS)
+      if (!disposed) {
+        setState((prev) => ({
+          status: 'unclaimed',
+          claimUrl: record?.claimUrl,
+          expiresAt: !record && prev?.status === 'unclaimed' ? prev.expiresAt : expiresAt,
+          claimLinkSpent,
+        }))
+      }
+      if (record) await refineFromLookup(record, expiresAt.getTime())
+    }
+
+    void check()
+
+    let pendingCheck: ReturnType<typeof setTimeout> | undefined
+    const onFocus = () => {
+      const wait = PROJECT_CHECK_INTERVAL_MS - (Date.now() - lastCheckedAt)
+      if (wait <= 0) {
+        void check()
+      } else if (!pendingCheck) {
+        pendingCheck = setTimeout(() => {
+          pendingCheck = undefined
+          void check()
+        }, wait)
+      }
+    }
+    window.addEventListener('focus', onFocus)
+
+    // The auth store consumes a `#claim=` fragment pasted into the open tab and writes the
+    // record (see hashClaim.ts); pick it up here without waiting for the next check.
+    const onHashChange = () => {
+      const record = readUnclaimedProjectRecord(projectId)
+      if (!record || disposed) return
+      claimLinkSpent = false
+      setState((prev) =>
+        prev?.status === 'unclaimed'
+          ? {
+              ...prev,
+              claimUrl: record.claimUrl,
+              expiresAt: record.expiresAt ? new Date(record.expiresAt) : prev.expiresAt,
+              claimLinkSpent: false,
+            }
+          : prev,
+      )
+    }
+    window.addEventListener('hashchange', onHashChange)
+
+    return () => {
+      disposed = true
+      if (pendingCheck) clearTimeout(pendingCheck)
+      window.removeEventListener('focus', onFocus)
+      window.removeEventListener('hashchange', onHashChange)
+    }
+  }, [client, isRobot, projectId])
+
+  return state
+}

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
@@ -209,7 +209,7 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
       }
     }
 
-    const refineFromLookup = async (record: UnclaimedProjectRecord, localExpiry: number) => {
+    const refineFromLookup = async (record: UnclaimedProjectRecord, localExpiry?: number) => {
       const claimToken = claimTokenFromClaimUrl(record.claimUrl)
       if (!claimToken) return
       const lastLookupAt = record.lastLookupAt ? new Date(record.lastLookupAt).getTime() : 0
@@ -231,7 +231,9 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
       writeUnclaimedProjectRecord(projectId, throttled)
 
       if (response.status === 404) {
-        if (lookupSawNotFound || Date.now() > localExpiry) dropClaimRecord()
+        if (lookupSawNotFound || (localExpiry !== undefined && Date.now() > localExpiry)) {
+          dropClaimRecord()
+        }
         lookupSawNotFound = true
         return
       }
@@ -285,8 +287,7 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
           ? new Date(createdAt.getTime() + UNCLAIMED_PROJECT_TTL_MS)
           : undefined
       const expiresAt = record?.expiresAt ? new Date(record.expiresAt) : derivedExpiresAt
-      if (!expiresAt) return
-      if (!disposed) {
+      if (expiresAt && !disposed) {
         setSessionState((prev) => {
           const value = prev?.sessionKey === sessionKey ? prev.value : undefined
           return {
@@ -300,7 +301,7 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
           }
         })
       }
-      if (record) await refineFromLookup(record, expiresAt.getTime())
+      if (record) await refineFromLookup(record, expiresAt?.getTime())
     }
 
     const check = async () => {

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
@@ -94,7 +94,7 @@ function getStatusCode(error: unknown): number | undefined {
 export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptions = {}):
   | UnclaimedProjectState
   | undefined {
-  const {currentUser, projectId} = useWorkspace()
+  const {auth, currentUser, projectId} = useWorkspace()
   const client = useClient({apiVersion: PROJECTS_API_VERSION})
   const isRobot = currentUser?.provider === ROBOT_PROVIDER
   const sessionKey = `${projectId}:${isRobot}`
@@ -191,6 +191,7 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
         }
       }
       update({status: 'expired'})
+      void auth.logout?.()
     }
 
     const dropClaimRecord = () => {
@@ -366,7 +367,7 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
       checkSubscription.unsubscribe()
       hashSubscription.unsubscribe()
     }
-  }, [claimAttemptedAt, client, isRobot, projectId, sessionKey])
+  }, [auth, claimAttemptedAt, client, isRobot, projectId, sessionKey])
 
   return state
 }

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProjectCopy.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProjectCopy.ts
@@ -1,5 +1,6 @@
-import {useEffect, useState} from 'react'
-import {catchError, defer, map, of, tap} from 'rxjs'
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {catchError, defer, map, of} from 'rxjs'
 
 import {useClient} from '../../hooks/useClient'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
@@ -155,15 +156,10 @@ export function useUnclaimedProjectCopy(enabled: boolean): UnclaimedProjectCopy 
     isDev: import.meta.env?.DEV ?? false,
     value: LOCAL_COPY_URL,
   })
-  const [copyState, setCopyState] = useState<{
-    client: typeof client
-    copy: UnclaimedProjectCopy | undefined
-  }>()
+  const copy$ = useMemo(() => {
+    if (!enabled) return of(undefined)
 
-  useEffect(() => {
-    if (!enabled) return undefined
-
-    const copy$ = localCopyUrl
+    const request$ = localCopyUrl
       ? defer(async () => {
           const response = await fetch(localCopyUrl, {credentials: 'omit'})
           if (!response.ok) throw new Error(`Journey copy request failed: ${response.status}`)
@@ -171,16 +167,11 @@ export function useUnclaimedProjectCopy(enabled: boolean): UnclaimedProjectCopy 
         })
       : client.observable.request<unknown>({uri: UNCLAIMED_PROJECT_COPY_URI})
 
-    const subscription = copy$
-      .pipe(
-        map(parseUnclaimedProjectCopy),
-        catchError(() => of(undefined)),
-        tap((copy) => setCopyState({client, copy})),
-      )
-      .subscribe()
-
-    return () => subscription.unsubscribe()
+    return request$.pipe(
+      map(parseUnclaimedProjectCopy),
+      catchError(() => of(undefined)),
+    )
   }, [client, enabled, localCopyUrl])
 
-  return enabled && copyState?.client === client ? copyState.copy : undefined
+  return useObservable(copy$)
 }

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProjectCopy.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProjectCopy.ts
@@ -3,6 +3,7 @@ import {catchError, defer, map, of, tap} from 'rxjs'
 
 import {useClient} from '../../hooks/useClient'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
+import {interpolateTemplate} from '../../util/interpolateTemplate'
 
 const UNCLAIMED_PROJECT_COPY_API_VERSION = '2026-07-28'
 const UNCLAIMED_PROJECT_COPY_URI = '/journey/unclaimed-project'
@@ -26,6 +27,7 @@ export interface UnclaimedProjectCopy {
   }
   claimed: {
     text: string
+    identityText: string
     signInButtonText: string
   }
   expired: {
@@ -33,6 +35,29 @@ export interface UnclaimedProjectCopy {
   }
   noClaimUrl: {
     text: string
+  }
+}
+
+/** Resolves the managed identity instruction without exposing email through Journey. */
+export function getClaimedIdentityText(text: string, email?: string): string {
+  return interpolateTemplate(text, {identity: email ?? 'the account tied to this project'})
+}
+
+/** Identifies the managed placeholder so a known claimant can be emphasized safely. */
+export function getClaimedIdentityTextParts(
+  text: string,
+  email?: string,
+): {before: string; identity: string; after: string} | undefined {
+  if (!email) return undefined
+
+  const marker = '{{identity}}'
+  const markerIndex = text.indexOf(marker)
+  if (markerIndex === -1) return undefined
+
+  return {
+    before: text.slice(0, markerIndex),
+    identity: email,
+    after: text.slice(markerIndex + marker.length),
   }
 }
 
@@ -63,7 +88,7 @@ export function parseUnclaimedProjectCopy(value: unknown): UnclaimedProjectCopy 
       'claimButtonText',
       'snoozeButtonText',
     ]) ||
-    !hasStringProperties(value.claimed, ['text', 'signInButtonText']) ||
+    !hasStringProperties(value.claimed, ['text', 'identityText', 'signInButtonText']) ||
     !hasStringProperties(value.expired, ['toastTitle']) ||
     !hasStringProperties(value.noClaimUrl, ['text'])
   ) {
@@ -87,6 +112,7 @@ export function parseUnclaimedProjectCopy(value: unknown): UnclaimedProjectCopy 
     },
     claimed: {
       text: value.claimed.text,
+      identityText: value.claimed.identityText,
       signInButtonText: value.claimed.signInButtonText,
     },
     expired: {

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProjectCopy.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProjectCopy.ts
@@ -31,9 +31,6 @@ export interface UnclaimedProjectCopy {
     identityText: string
     signInButtonText: string
   }
-  expired: {
-    toastTitle: string
-  }
   noClaimUrl: {
     text: string
   }
@@ -90,7 +87,6 @@ export function parseUnclaimedProjectCopy(value: unknown): UnclaimedProjectCopy 
       'snoozeButtonText',
     ]) ||
     !hasStringProperties(value.claimed, ['text', 'identityText', 'signInButtonText']) ||
-    !hasStringProperties(value.expired, ['toastTitle']) ||
     !hasStringProperties(value.noClaimUrl, ['text'])
   ) {
     return undefined
@@ -115,9 +111,6 @@ export function parseUnclaimedProjectCopy(value: unknown): UnclaimedProjectCopy 
       text: value.claimed.text,
       identityText: value.claimed.identityText,
       signInButtonText: value.claimed.signInButtonText,
-    },
-    expired: {
-      toastTitle: value.expired.toastTitle,
     },
     noClaimUrl: {
       text: value.noClaimUrl.text,

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProjectCopy.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProjectCopy.ts
@@ -1,0 +1,160 @@
+import {useEffect, useState} from 'react'
+import {catchError, defer, map, of, tap} from 'rxjs'
+
+import {useClient} from '../../hooks/useClient'
+import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
+
+const UNCLAIMED_PROJECT_COPY_API_VERSION = '2026-07-28'
+const UNCLAIMED_PROJECT_COPY_URI = '/journey/unclaimed-project'
+const LOCAL_COPY_URL = import.meta.env?.SANITY_STUDIO_UNCLAIMED_PROJECT_COPY_URL
+
+/** Copy owned and served by Journey so it can change independently of Studio releases. */
+export interface UnclaimedProjectCopy {
+  criticalThresholdHours: number
+  snoozeMinutes: number
+  banner: {
+    text: string
+    criticalText: string
+    claimButtonText: string
+  }
+  toast: {
+    title: string
+    criticalTitle: string
+    description: string
+    claimButtonText: string
+    snoozeButtonText: string
+  }
+  claimed: {
+    text: string
+    signInButtonText: string
+  }
+  expired: {
+    toastTitle: string
+  }
+  noClaimUrl: {
+    text: string
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object'
+}
+
+function hasStringProperties(value: unknown, keys: string[]): value is Record<string, string> {
+  return isRecord(value) && keys.every((key) => typeof value[key] === 'string')
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+}
+
+/** @internal */
+export function parseUnclaimedProjectCopy(value: unknown): UnclaimedProjectCopy | undefined {
+  if (!isRecord(value)) return undefined
+
+  if (
+    !isPositiveInteger(value.criticalThresholdHours) ||
+    !isPositiveInteger(value.snoozeMinutes) ||
+    !hasStringProperties(value.banner, ['text', 'criticalText', 'claimButtonText']) ||
+    !hasStringProperties(value.toast, [
+      'title',
+      'criticalTitle',
+      'description',
+      'claimButtonText',
+      'snoozeButtonText',
+    ]) ||
+    !hasStringProperties(value.claimed, ['text', 'signInButtonText']) ||
+    !hasStringProperties(value.expired, ['toastTitle']) ||
+    !hasStringProperties(value.noClaimUrl, ['text'])
+  ) {
+    return undefined
+  }
+
+  return {
+    criticalThresholdHours: value.criticalThresholdHours,
+    snoozeMinutes: value.snoozeMinutes,
+    banner: {
+      text: value.banner.text,
+      criticalText: value.banner.criticalText,
+      claimButtonText: value.banner.claimButtonText,
+    },
+    toast: {
+      title: value.toast.title,
+      criticalTitle: value.toast.criticalTitle,
+      description: value.toast.description,
+      claimButtonText: value.toast.claimButtonText,
+      snoozeButtonText: value.toast.snoozeButtonText,
+    },
+    claimed: {
+      text: value.claimed.text,
+      signInButtonText: value.claimed.signInButtonText,
+    },
+    expired: {
+      toastTitle: value.expired.toastTitle,
+    },
+    noClaimUrl: {
+      text: value.noClaimUrl.text,
+    },
+  }
+}
+
+/** @internal */
+export function getLocalUnclaimedProjectCopyUrl({
+  isDev,
+  value,
+}: {
+  isDev: boolean
+  value: string | undefined
+}): string | undefined {
+  if (!isDev || !value) return undefined
+
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' &&
+      (url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]')
+      ? url.href
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** Fetch Journey-owned copy only after the project is known to be part of mint-and-claim. */
+export function useUnclaimedProjectCopy(enabled: boolean): UnclaimedProjectCopy | undefined {
+  const client = useClient({
+    ...DEFAULT_STUDIO_CLIENT_OPTIONS,
+    apiVersion: UNCLAIMED_PROJECT_COPY_API_VERSION,
+  })
+  const localCopyUrl = getLocalUnclaimedProjectCopyUrl({
+    isDev: import.meta.env?.DEV ?? false,
+    value: LOCAL_COPY_URL,
+  })
+  const [copyState, setCopyState] = useState<{
+    client: typeof client
+    copy: UnclaimedProjectCopy | undefined
+  }>()
+
+  useEffect(() => {
+    if (!enabled) return undefined
+
+    const copy$ = localCopyUrl
+      ? defer(async () => {
+          const response = await fetch(localCopyUrl, {credentials: 'omit'})
+          if (!response.ok) throw new Error(`Journey copy request failed: ${response.status}`)
+          return response.json()
+        })
+      : client.observable.request<unknown>({uri: UNCLAIMED_PROJECT_COPY_URI})
+
+    const subscription = copy$
+      .pipe(
+        map(parseUnclaimedProjectCopy),
+        catchError(() => of(undefined)),
+        tap((copy) => setCopyState({client, copy})),
+      )
+      .subscribe()
+
+    return () => subscription.unsubscribe()
+  }, [client, enabled, localCopyUrl])
+
+  return enabled && copyState?.client === client ? copyState.copy : undefined
+}

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProjectCopy.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProjectCopy.ts
@@ -165,7 +165,10 @@ export function useUnclaimedProjectCopy(enabled: boolean): UnclaimedProjectCopy 
           if (!response.ok) throw new Error(`Journey copy request failed: ${response.status}`)
           return response.json()
         })
-      : client.observable.request<unknown>({uri: UNCLAIMED_PROJECT_COPY_URI})
+      : client.observable.request<unknown>({
+          uri: UNCLAIMED_PROJECT_COPY_URI,
+          tag: 'unclaimed-project-copy',
+        })
 
     return request$.pipe(
       map(parseUnclaimedProjectCopy),


### PR DESCRIPTION
### Linear

https://linear.app/sanity/issue/AIGRO-5196/studio-display-banner-and-toast-notifs-to-nudge-user-during-pre-claim

### Description

Mint-and-claim projects initially open Studio under a temporary robot identity and expire if they are not claimed. This adds provenance-gated banners and notifications that guide those users through claiming, while remaining a no-op for normal Studio sessions.

Copy, urgency thresholds, and snooze timing come from the Journey endpoint so they can change independently of Studio releases. The feature fails open when that optional endpoint is unavailable or malformed. After the user opens the claim flow, Studio temporarily polls project status and rechecks when the tab regains focus so the UI can transition to the claimed state without a refresh.

### Dependency: `personalization-forge`

Before releasing this Studio change, we'll need to deploy [personalization-forge#235](https://github.com/sanity-io/personalization-forge/pull/235) to production and ensure the production `unclaimedProjectCopy` document is published with the current contract, including `claimed.identityText`. Studio fails open if the endpoint is unavailable or malformed: the optional pre-claim experience remains hidden without affecting normal Studio use.

### What to review

- safe `#token` / `#claim` intake, project-scoped persistence, and mint-and-claim provenance gating
- unclaimed, claimed, and expired state transitions, including workspace changes and missing or invalid project metadata
- bounded post-claim polling, focus/visibility rechecks, overlap prevention, and cleanup
- strict validation and fail-open handling of Journey-owned copy, thresholds, snooze timing, and `{{timeLeft}}` / `{{expiresAt}}` templates
- banner and toast behavior, including snoozing, critical urgency, spent claim links, and the final sign-in transition

### Testing

- `pnpm check:format`
- `pnpm check:oxlint`
- `pnpm build && pnpm test`
- unit coverage for hash intake, storage validation, provenance gating, project-state resolution, Journey contract parsing, copy failure handling, polling, and focus-driven claim transitions
- manual Studio → claim flow UAT with a real unclaimed project and local Journey response:
  - opened the claim flow in a new tab
  - signed up or logged in and claimed the project
  - returned to the original Studio tab
  - confirmed the green “sign in as yourself” banner appeared without refreshing

### Walkthrough

https://www.loom.com/share/ece25ebd847543838f3d7a66b0be173a

### Notes for release

N/A – Part of the `sanity new` project claims lifecycle feature; operational in local studios only.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth URL hash handling and localStorage, renders stored claim URLs as links (mitigated by host/path allowlisting), and can clear tokens and logout when a minted project expires—though the UI is dev-gated and normal human sessions are unaffected.
> 
> **Overview**
> Adds **mint-and-claim** support for Studio sessions opened with a temporary robot token: the auth store now consumes a `#claim=` URL fragment (before `#token=`) on boot and on `hashchange`, validates it against Sanity HTTPS claim URLs, and persists it per project in localStorage.
> 
> A new **`UnclaimedProjectNudge`** (wired into `StudioLayout`, **development-only** for now) shows only for `sanity-token` robot users. It loads copy/thresholds from Journey (fail-open if missing), tracks unclaimed vs claimed vs expired via project org membership and optional provision lookup, and drives a caution/critical banner, snoozable toast, countdown, and external claim link. After claim it prompts sign-in (logout); on confirmed expiry for mint-proven projects it clears the token and logs out.
> 
> Includes focused unit tests for hash parsing, storage validation, auth-store intake, hook state transitions, polling, and UI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a241ddaa19886b83b932d20af284f4a621b5c66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->