### PR TITLE
fix(core): tasks now support variants and releases

### DIFF
--- a/packages/sanity/src/core/tasks/components/form/addonWorkspace/taskSchema.tsx
+++ b/packages/sanity/src/core/tasks/components/form/addonWorkspace/taskSchema.tsx
@@ -41,6 +41,13 @@ const targetContentField = (mode: FormMode) =>
         type: 'string',
         title: 'Document type',
       },
+      {
+        // The version segment of the targeted document id (release id or variant scope id) when
+        // the task was created for a version document. See `TaskTarget.documentVersionId`.
+        name: 'documentVersionId',
+        type: 'string',
+        hidden: true,
+      },
     ],
   })
 

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.test.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.test.tsx
@@ -8,7 +8,7 @@ import {TasksFormBuilder} from './TasksFormBuilder'
 
 // Replaces the addon workspace provider with a probe that exposes the perspective context the
 // task form would be mounted with, without rendering the (heavy) form itself.
-vi.mock('../addonWorkspace', async () => {
+vi.mock('../addonWorkspace/TasksAddOnWorkspaceProvider', async () => {
   const {usePerspective} = await import('../../../../perspective/usePerspective')
 
   function TasksAddonWorkspaceProvider() {
@@ -26,16 +26,25 @@ vi.mock('../addonWorkspace', async () => {
   return {TasksAddonWorkspaceProvider}
 })
 
-vi.mock('../../../context', () => ({
+vi.mock('../../../context/mentionUser/MentionUserProvider', () => ({
   MentionUserProvider: ({children}: {children: React.ReactNode}) => <>{children}</>,
+}))
+
+vi.mock('../../../context/mentionUser/useMentionUser', () => ({
   useMentionUser: () => ({setSelectedDocument: vi.fn()}),
+}))
+
+vi.mock('../../../context/tasks/useTasks', () => ({
   useTasks: () => ({activeDocument: null, data: [], isLoading: false}),
+}))
+
+vi.mock('../../../context/navigation/useTasksNavigation', () => ({
   useTasksNavigation: () => ({
     state: {selectedTask: 'task-1', viewMode: 'create', duplicateTaskValues: undefined},
   }),
 }))
 
-vi.mock('../../../../store', async (importOriginal) => ({
+vi.mock('../../../../store/user/hooks', async (importOriginal) => ({
   ...(await importOriginal<object>()),
   useCurrentUser: () => ({id: 'user-1'}),
 }))

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.test.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.test.tsx
@@ -102,7 +102,7 @@ describe('TasksFormBuilder', () => {
     expect(probe).toHaveAttribute('data-has-selected-variant', 'false')
   })
 
-  it('keeps the selected release perspective for the task form', () => {
+  it('does not let the task form inherit the selected release perspective', () => {
     renderWithPerspective(
       createOuterPerspective({
         selectedPerspectiveName: 'rSomeRelease',
@@ -114,8 +114,10 @@ describe('TasksFormBuilder', () => {
       }),
     )
 
+    // A selected release would make `useDocumentForm` check permissions against a nonexistent
+    // release version of the task document, which also blocks all edits.
     const probe = screen.getByTestId('addon-workspace')
-    expect(probe).toHaveAttribute('data-selected-perspective-name', 'rSomeRelease')
+    expect(probe).toHaveAttribute('data-selected-perspective-name', 'none')
     expect(probe).toHaveAttribute('data-selected-variant-name', 'none')
   })
 })

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.test.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.test.tsx
@@ -1,0 +1,121 @@
+import {render, screen} from '@testing-library/react'
+import {PerspectiveContext} from 'sanity/_singletons'
+import {describe, expect, it, vi} from 'vitest'
+
+import {type PerspectiveContextValue} from '../../../../perspective/types'
+import {type SystemVariant} from '../../../../variants/types'
+import {TasksFormBuilder} from './TasksFormBuilder'
+
+// Replaces the addon workspace provider with a probe that exposes the perspective context the
+// task form would be mounted with, without rendering the (heavy) form itself.
+vi.mock('../addonWorkspace', async () => {
+  const {usePerspective} = await import('../../../../perspective/usePerspective')
+
+  function TasksAddonWorkspaceProvider() {
+    const {selectedVariantName, selectedVariant, selectedPerspectiveName} = usePerspective()
+    return (
+      <div
+        data-testid="addon-workspace"
+        data-selected-variant-name={selectedVariantName ?? 'none'}
+        data-has-selected-variant={selectedVariant ? 'true' : 'false'}
+        data-selected-perspective-name={selectedPerspectiveName ?? 'none'}
+      />
+    )
+  }
+
+  return {TasksAddonWorkspaceProvider}
+})
+
+vi.mock('../../../context', () => ({
+  MentionUserProvider: ({children}: {children: React.ReactNode}) => <>{children}</>,
+  useMentionUser: () => ({setSelectedDocument: vi.fn()}),
+  useTasks: () => ({activeDocument: null, data: [], isLoading: false}),
+  useTasksNavigation: () => ({
+    state: {selectedTask: 'task-1', viewMode: 'create', duplicateTaskValues: undefined},
+  }),
+}))
+
+vi.mock('../../../../store', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useCurrentUser: () => ({id: 'user-1'}),
+}))
+
+vi.mock('../../../../studio/workspace', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useWorkspace: () => ({
+    dataset: 'test-dataset',
+    projectId: 'test-project',
+    document: {drafts: {enabled: true}},
+  }),
+}))
+
+vi.mock('../../../../releases/store/useActiveReleases', () => ({
+  useActiveReleases: () => ({data: [], error: undefined, loading: false, dispatch: vi.fn()}),
+}))
+
+vi.mock('../../../../variants/store/useAllVariants', () => ({
+  useAllVariants: () => ({data: [], byId: new Map(), error: undefined, loading: false}),
+}))
+
+const variant = {
+  _id: '_.variants.alpha-audience',
+  _type: 'system.variant',
+} as unknown as SystemVariant
+
+function createOuterPerspective(
+  overrides: Partial<PerspectiveContextValue>,
+): PerspectiveContextValue {
+  return {
+    selectedPerspectiveName: undefined,
+    selectedReleaseId: undefined,
+    selectedPerspective: 'drafts',
+    perspectiveStack: ['drafts'],
+    excludedPerspectives: [],
+    selectedVariantName: undefined,
+    selectedVariant: undefined,
+    bundle: 'drafts',
+    ...overrides,
+  }
+}
+
+function renderWithPerspective(outer: PerspectiveContextValue) {
+  return render(
+    <PerspectiveContext.Provider value={outer}>
+      <TasksFormBuilder />
+    </PerspectiveContext.Provider>,
+  )
+}
+
+describe('TasksFormBuilder', () => {
+  it('does not let the task form inherit the selected variant', () => {
+    renderWithPerspective(
+      createOuterPerspective({
+        selectedVariantName: 'alpha-audience',
+        selectedVariant: variant,
+      }),
+    )
+
+    // Task documents never have variant-scoped versions; inheriting the variant would make
+    // `useDocumentForm` treat the target as missing and block all edits.
+    const probe = screen.getByTestId('addon-workspace')
+    expect(probe).toHaveAttribute('data-selected-variant-name', 'none')
+    expect(probe).toHaveAttribute('data-has-selected-variant', 'false')
+  })
+
+  it('keeps the selected release perspective for the task form', () => {
+    renderWithPerspective(
+      createOuterPerspective({
+        selectedPerspectiveName: 'rSomeRelease',
+        selectedReleaseId: 'rSomeRelease',
+        selectedPerspective: 'rSomeRelease',
+        perspectiveStack: ['rSomeRelease', 'drafts'],
+        selectedVariantName: 'alpha-audience',
+        selectedVariant: variant,
+      }),
+    )
+
+    const probe = screen.getByTestId('addon-workspace')
+    expect(probe).toHaveAttribute('data-selected-perspective-name', 'rSomeRelease')
+    expect(probe).toHaveAttribute('data-selected-variant-name', 'none')
+  })
+})

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.tsx
@@ -10,7 +10,6 @@ import {createPatchChannel} from '../../../../form/patch/PatchChannel'
 import {FormBuilder} from '../../../../form/studio/FormBuilder'
 import {useDocumentForm} from '../../../../form/useDocumentForm'
 import {PerspectiveProvider} from '../../../../perspective/PerspectiveProvider'
-import {usePerspective} from '../../../../perspective/usePerspective'
 import {useCurrentUser} from '../../../../store/user/hooks'
 import {useWorkspace} from '../../../../studio/workspace'
 import {MentionUserProvider} from '../../../context/mentionUser/MentionUserProvider'
@@ -139,7 +138,6 @@ export function TasksFormBuilder() {
   const currentUser = useCurrentUser()
   const {activeDocument} = useTasks()
   const {dataset, projectId} = useWorkspace()
-  const {selectedPerspectiveName, excludedPerspectives} = usePerspective()
   const {
     state: {selectedTask, viewMode, duplicateTaskValues},
   } = useTasksNavigation()
@@ -184,15 +182,12 @@ export function TasksFormBuilder() {
   return (
     // This provider needs to be mounted before the TasksAddonWorkspaceProvider.
     <MentionUserProvider>
-      {/* Task documents live in the addon dataset and never have variant-scoped versions, so the
-          form must not inherit the globally selected variant: it would make `useDocumentForm`
-          treat the task's variant target as missing and block all edits. The selected release
-          perspective is intentionally kept, matching how the form behaves when a release is
-          selected (the task form itself never opts into it). */}
-      <PerspectiveProvider
-        selectedPerspectiveName={selectedPerspectiveName}
-        excludedPerspectives={excludedPerspectives}
-      >
+      {/* Task documents live in the addon dataset and never have release- or variant-scoped
+          versions, so the form must not inherit the globally selected perspective: a selected
+          variant makes `useDocumentForm` treat the task's variant target as missing (blocking all
+          edits), and a selected release makes it check permissions against a nonexistent version
+          document. Tasks always edit the base document, so the form gets a neutral perspective. */}
+      <PerspectiveProvider selectedPerspectiveName={undefined}>
         <TasksAddonWorkspaceProvider mode={viewMode === 'edit' ? 'edit' : 'create'}>
           <TasksFormBuilderInner documentId={selectedTask} initialValue={initialValue} />
         </TasksAddonWorkspaceProvider>

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.tsx
@@ -9,6 +9,8 @@ import {LoadingBlock} from '../../../../components/loadingBlock/LoadingBlock'
 import {createPatchChannel} from '../../../../form/patch/PatchChannel'
 import {FormBuilder} from '../../../../form/studio/FormBuilder'
 import {useDocumentForm} from '../../../../form/useDocumentForm'
+import {PerspectiveProvider} from '../../../../perspective/PerspectiveProvider'
+import {usePerspective} from '../../../../perspective/usePerspective'
 import {useCurrentUser} from '../../../../store/user/hooks'
 import {useWorkspace} from '../../../../studio/workspace'
 import {MentionUserProvider} from '../../../context/mentionUser/MentionUserProvider'
@@ -137,6 +139,7 @@ export function TasksFormBuilder() {
   const currentUser = useCurrentUser()
   const {activeDocument} = useTasks()
   const {dataset, projectId} = useWorkspace()
+  const {selectedPerspectiveName, excludedPerspectives} = usePerspective()
   const {
     state: {selectedTask, viewMode, duplicateTaskValues},
   } = useTasksNavigation()
@@ -181,9 +184,19 @@ export function TasksFormBuilder() {
   return (
     // This provider needs to be mounted before the TasksAddonWorkspaceProvider.
     <MentionUserProvider>
-      <TasksAddonWorkspaceProvider mode={viewMode === 'edit' ? 'edit' : 'create'}>
-        <TasksFormBuilderInner documentId={selectedTask} initialValue={initialValue} />
-      </TasksAddonWorkspaceProvider>
+      {/* Task documents live in the addon dataset and never have variant-scoped versions, so the
+          form must not inherit the globally selected variant: it would make `useDocumentForm`
+          treat the task's variant target as missing and block all edits. The selected release
+          perspective is intentionally kept, matching how the form behaves when a release is
+          selected (the task form itself never opts into it). */}
+      <PerspectiveProvider
+        selectedPerspectiveName={selectedPerspectiveName}
+        excludedPerspectives={excludedPerspectives}
+      >
+        <TasksAddonWorkspaceProvider mode={viewMode === 'edit' ? 'edit' : 'create'}>
+          <TasksFormBuilderInner documentId={selectedTask} initialValue={initialValue} />
+        </TasksAddonWorkspaceProvider>
+      </PerspectiveProvider>
     </MentionUserProvider>
   )
 }

--- a/packages/sanity/src/core/tasks/components/form/utils.ts
+++ b/packages/sanity/src/core/tasks/components/form/utils.ts
@@ -1,6 +1,6 @@
 import {isPortableTextTextBlock} from '@sanity/types'
 
-import {getPublishedId} from '../../../util/draftUtils'
+import {getPublishedId, getVersionFromId, getVersionId} from '../../../util/draftUtils'
 import {type TaskDocument, type TaskTarget} from '../../types'
 
 interface GetTargetValueOptions {
@@ -24,7 +24,21 @@ export function getTargetValue({
       _projectId: projectId,
       _weak: true,
     },
+    documentVersionId: getVersionFromId(documentId),
   }
+}
+
+/**
+ * The id of the document a task target points at: the version id when the task was created for
+ * a version document (release or variant), otherwise the published id stored in the reference.
+ * Matches the id shape of the tasks' active document, which keeps version ids as-is.
+ */
+export function getTargetDocumentId(target: TaskTarget | undefined): string | undefined {
+  const publishedId = target?.document?._ref
+  if (!publishedId) return undefined
+  return target.documentVersionId
+    ? getVersionId(publishedId, target.documentVersionId)
+    : publishedId
 }
 
 /**

--- a/packages/sanity/src/core/tasks/components/sidebar/TasksSidebar.tsx
+++ b/packages/sanity/src/core/tasks/components/sidebar/TasksSidebar.tsx
@@ -8,6 +8,7 @@ import {useTasksEnabled} from '../../context/enabled/useTasksEnabled'
 import {useTasksNavigation} from '../../context/navigation/useTasksNavigation'
 import {useTasks} from '../../context/tasks/useTasks'
 import {TasksFormBuilder} from '../form/tasksFormBuilder/TasksFormBuilder'
+import {getTargetDocumentId} from '../form/utils'
 import {TasksList} from '../list/TasksList'
 import {TasksUpsellPanel} from '../upsell/TasksUpsellPanel'
 import {TasksListTabs} from './TasksListTabs'
@@ -49,7 +50,9 @@ function TasksStudioSidebarInner() {
       return currentUser?.id && item.subscribers?.includes(currentUser.id)
     }
     if (activeTabId === 'document') {
-      return activeDocument?.documentId && item.target?.document._ref === activeDocument.documentId
+      return (
+        activeDocument?.documentId && getTargetDocumentId(item.target) === activeDocument.documentId
+      )
     }
     return false
   })

--- a/packages/sanity/src/core/tasks/plugin/TasksFooterOpenTasks.test.tsx
+++ b/packages/sanity/src/core/tasks/plugin/TasksFooterOpenTasks.test.tsx
@@ -56,10 +56,12 @@ const mockUseTasksStore = useTasksStore as ReturnType<typeof vi.fn>
 
 const createTaskMock = ({
   targetDocumentId,
+  targetDocumentVersionId,
   status = 'open',
   title = 'Test task',
 }: {
   targetDocumentId?: string
+  targetDocumentVersionId?: string
   status?: TaskDocument['status']
   title?: string
 }): TaskDocument => ({
@@ -80,6 +82,7 @@ const createTaskMock = ({
           _weak: true,
           _ref: targetDocumentId,
         },
+        documentVersionId: targetDocumentVersionId,
       }
     : undefined,
   title,
@@ -169,5 +172,75 @@ describe('TasksFooterOpenTasks', () => {
 
     expect(screen.getByRole('button')).toBeInTheDocument()
     expect(screen.getByTestId('tasks-badge')).toBeInTheDocument()
+  })
+
+  it('renders the button when a version document is active and the task targets that version', async () => {
+    setUpMocks({
+      tasks: [createTaskMock({targetDocumentId: 'doc1', targetDocumentVersionId: 'rRelease1'})],
+    })
+    render(
+      <>
+        <TasksFooterOpenTasks />
+        <SetActiveDocument documentId="versions.rRelease1.doc1" documentType="author" />
+      </>,
+      {wrapper},
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+
+  it('does not render the button when the task targets a version but the base document is active', async () => {
+    setUpMocks({
+      tasks: [createTaskMock({targetDocumentId: 'doc1', targetDocumentVersionId: 'rRelease1'})],
+    })
+    const {container} = render(
+      <>
+        <TasksFooterOpenTasks />
+        <SetActiveDocument documentId="doc1" documentType="author" />
+      </>,
+      {wrapper},
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('does not render the button when a version document is active but the task targets the base document', async () => {
+    setUpMocks({tasks: [createTaskMock({targetDocumentId: 'doc1'})]})
+    const {container} = render(
+      <>
+        <TasksFooterOpenTasks />
+        <SetActiveDocument documentId="versions.rRelease1.doc1" documentType="author" />
+      </>,
+      {wrapper},
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('does not render the button when the task targets a different version of the active document', async () => {
+    setUpMocks({
+      tasks: [createTaskMock({targetDocumentId: 'doc1', targetDocumentVersionId: 'rRelease1'})],
+    })
+    const {container} = render(
+      <>
+        <TasksFooterOpenTasks />
+        <SetActiveDocument documentId="versions.rRelease2.doc1" documentType="author" />
+      </>,
+      {wrapper},
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(container).toBeEmptyDOMElement()
   })
 })

--- a/packages/sanity/src/core/tasks/plugin/TasksFooterOpenTasks.tsx
+++ b/packages/sanity/src/core/tasks/plugin/TasksFooterOpenTasks.tsx
@@ -5,6 +5,7 @@ import {styled} from 'styled-components'
 
 import {Button} from '../../../ui-components/button/Button'
 import {useTranslation} from '../../i18n/hooks/useTranslation'
+import {getTargetDocumentId} from '../components/form/utils'
 import {useTasksNavigation} from '../context/navigation/useTasksNavigation'
 import {useTasks} from '../context/tasks/useTasks'
 import {tasksLocaleNamespace} from '../i18n'
@@ -32,7 +33,7 @@ export function TasksFooterOpenTasks() {
       activeDocument?.documentId
         ? data.filter((item) => {
             return (
-              item.target?.document._ref === activeDocument.documentId &&
+              getTargetDocumentId(item.target) === activeDocument.documentId &&
               item.status === 'open' &&
               item.createdByUser
             )

--- a/packages/sanity/src/core/tasks/types.ts
+++ b/packages/sanity/src/core/tasks/types.ts
@@ -64,6 +64,13 @@ export interface TaskTarget {
     _type: 'crossDatasetReference'
     _weak: boolean
   }
+  /**
+   * Set when the task was created for a version document (a release or variant version): the
+   * version segment of the document id (release id or variant scope id). The reference itself
+   * always stores the published id, so this is needed to resolve the exact version document the
+   * task belongs to. Absent for tasks targeting the draft/published document.
+   */
+  documentVersionId?: string
 }
 /**
  * @beta


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

[SAPP-4064](https://linear.app/sanity/issue/SAPP-4064/update-tasks-to-support-variants)

After merging the changes to support variants, tasks in releases stopped working. This restores that functionality and updates it to support creating tasks linked to variants or releases, through the document version id.

Creating a task now assigns the `documentVersionId` to it, with this property we can link together the task to the correct document id.
A task created in a release or in a variant will be displayed into the active document tasks only if that matches.


### What to review

- `packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksFormBuilder.tsx` — the provider placement: it sits outside `TasksAddonWorkspaceProvider` so `PerspectiveProvider`'s own release/variant store reads resolve against the main workspace, and inside `MentionUserProvider` ordering is preserved.
- Affected package: `sanity` (tasks plugin only).

### Testing

- Manually reproduced both failures in the test studio (variant selected and release selected) on `main`, then verified with the fix that creating tasks and changing task status/title succeed in both contexts:

[tasks_work_with_release_and_variant_selected.mp4](https://cursor.com/agents/bc-57973391-9ed3-4b7e-8fab-180fe0c9062d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftasks_work_with_release_and_variant_selected.mp4)

### Notes for release

Fixes an issue where Tasks could not be created or edited while a content release or a variant was selected in the studio. 
Creating a task in a release now links it with the release document, following the same behaviour in comments.

---

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57973391-9ed3-4b7e-8fab-180fe0c9062d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57973391-9ed3-4b7e-8fab-180fe0c9062d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

