### PR TITLE
chore(sanity): extend document group inventory events

### DIFF
--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -89,6 +89,10 @@ export interface DocumentGroupInventoryProps {
    */
   referringDocuments$: Observable<ReferringDocuments>
   /**
+   * Request the parent to close the document group inventory.
+   */
+  requestClose?: () => void
+  /**
    * Pane-coupled presentational components injected by the consumer.
    */
   components: {

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -111,6 +111,7 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
   portalElementName,
   perspectiveList,
   referringDocuments$,
+  requestClose,
   components,
 }) => {
   const {beta} = useWorkspace()
@@ -257,13 +258,20 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
         </Body>
         <Footer>
           <Button
-            text={t('document-group.delete.confirm-button.text', {count: selectionCount})}
-            onClick={() => deletionRef.send({type: 'delete.request'})}
-            disabled={!canRequestDeletion}
-            tone="critical"
+            text={t('document-group-inventory.action.cancel')}
             size="large"
-            icon={TrashIcon}
+            mode="bleed"
+            onClick={requestClose}
           />
+          {canRequestDeletion && (
+            <Button
+              text={t('document-group.delete.confirm-button.text', {count: selectionCount})}
+              onClick={() => deletionRef.send({type: 'delete.request'})}
+              tone="critical"
+              size="large"
+              icon={TrashIcon}
+            />
+          )}
         </Footer>
       </Container>
       <div ref={setMenuPortalElement} />

--- a/packages/sanity/src/core/documentGroupInventory/components/Footer.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/Footer.tsx
@@ -10,9 +10,6 @@ export const Footer = styled.div(({theme}) => {
     padding-block-start: calc(${space[5]}px * 0.5);
     padding-block-end: ${space[4]}px;
     gap: ${space[3]}px;
-
-    & > * {
-      flex-grow: 1;
-    }
+    justify-content: end;
   `
 })

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -514,6 +514,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
 
   /** --- Document inventory --- */
 
+  /** The label shown when dismissing the document group inventory */
+  'document-group-inventory.action.cancel': 'Cancel',
   /** The label used in the feedback dialog asking how easy the document group inventory is to use */
   'document-group-inventory.feedback.sentiment-label':
     'How easy or difficult is the new version inventory to use?',

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -1,5 +1,5 @@
 import {Flex, LayerProvider, Stack, Text} from '@sanity/ui'
-import {memo, useMemo, useState} from 'react'
+import {memo, useCallback, useMemo, useState} from 'react'
 import {
   DEFAULT_STUDIO_CLIENT_OPTIONS,
   DocumentGroupInventory,
@@ -64,6 +64,11 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
   const referringDocuments$ = useMemo(
     () => referringDocuments({documentId, versionedClient: client, documentStore}),
     [documentId, client, documentStore],
+  )
+
+  const requestDocumentGroupInventoryClose = useCallback(
+    () => setIsDocumentGroupInventoryActive(false),
+    [setIsDocumentGroupInventoryActive],
   )
 
   const {selectedReleaseId} = usePerspective()
@@ -140,6 +145,7 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
             portalElementName={DOCUMENT_PANEL_PORTAL_ELEMENT}
             perspectiveList={perspectiveList}
             referringDocuments$={referringDocuments$}
+            requestClose={requestDocumentGroupInventoryClose}
             components={documentGroupInventoryComponents}
           />
         </DocumentGroupInventoryAction>


### PR DESCRIPTION
### Description

A couple of small event-related changes for the document group inventory:

1. The parent component controls whether it is rendered. The parent can now pass a `requestClose` prop, allowing the document group inventory to signal to the parent component to close it.
2. The document group inventory now has a cancel action, triggering the aforementioned `requestClose` function.
3. The deletion action is now only rendered when the state machine dictates a deletion can occur (e.g. one or more variant is selected). Previously, it was always rendered, gated by an inactive state.
4. The document group inventory actions are now aligned with the end of the container, to match the design.

### What to review

The document group inventory.

### Testing

Existing state machine unit tests and manual verification in Test Studio.

--- 

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only changes to inventory footer and parent close wiring; deletion behavior still gated by the existing state machine.
> 
> **Overview**
> The document group inventory can now ask its parent to close via an optional **`requestClose`** callback; the structure tool wires this to clearing the inventory open state.
> 
> The footer adds a **Cancel** action (bleed style) that calls **`requestClose`**, and the delete control is **only mounted** when the deletion state machine allows **`delete.request`**—instead of always showing a disabled delete button. Footer layout is updated to **right-align** actions (`justify-content: end`) instead of stretching buttons full width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d00124d613ff209f15ee3bbbec9a7c7330f3a57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->