### PR TITLE
chore(sanity): refine document group inventory UI

### DIFF
--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -89,6 +89,10 @@ export interface DocumentGroupInventoryProps {
    */
   referringDocuments$: Observable<ReferringDocuments>
   /**
+   * Request the parent to close the document group inventory.
+   */
+  requestClose?: () => void
+  /**
    * Pane-coupled presentational components injected by the consumer.
    */
   components: {

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -223,11 +223,13 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
         <Header>
           <Stack gap={4}>
             <Flex gap={4} align="center" justify="flex-end">
-              <TextButton onClick={() => inventoryRef.send({type: 'feedback.begin'})}>
+              <TextButton
+                onClick={() => inventoryRef.send({type: 'feedback.begin'})}
+                title={feedbackT('feedback.menu-item')}
+                aria-label={feedbackT('feedback.menu-item')}
+              >
                 <Text size={1}>
-                  <Flex gap={2} align="center" justify="flex-end">
-                    <FeedbackIcon /> {feedbackT('feedback.menu-item')}
-                  </Flex>
+                  <FeedbackIcon />
                 </Text>
               </TextButton>
               <TextButton

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -1,3 +1,4 @@
+import CloseIcon from '@sanity/icons/Close'
 import {EyeOpenIcon} from '@sanity/icons/EyeOpen'
 import {FeedbackIcon} from '@sanity/icons/Feedback'
 import {SearchIcon} from '@sanity/icons/Search'
@@ -221,13 +222,24 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
       <Container ref={setContainerElement} data-testid="document-group-inventory">
         <Header>
           <Stack gap={4}>
-            <TextButton onClick={() => inventoryRef.send({type: 'feedback.begin'})}>
-              <Text size={1}>
-                <Flex gap={2} align="center" justify="flex-end">
-                  <FeedbackIcon /> {feedbackT('feedback.menu-item')}
-                </Flex>
-              </Text>
-            </TextButton>
+            <Flex gap={4} align="center" justify="flex-end">
+              <TextButton onClick={() => inventoryRef.send({type: 'feedback.begin'})}>
+                <Text size={1}>
+                  <Flex gap={2} align="center" justify="flex-end">
+                    <FeedbackIcon /> {feedbackT('feedback.menu-item')}
+                  </Flex>
+                </Text>
+              </TextButton>
+              <TextButton
+                onClick={requestClose}
+                title={t('document-group-inventory.action.cancel')}
+                aria-label={t('document-group-inventory.action.cancel')}
+              >
+                <Text size={1}>
+                  <CloseIcon />
+                </Text>
+              </TextButton>
+            </Flex>
             <search>
               <TextInput
                 name={t('document-group-inventory.filter-string.label', {

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -628,7 +628,7 @@ const TextButton = styled.button(({theme}) => {
     padding: 0;
     outline: none;
     all: unset;
-    color: ${color.link.fg};
+    color: ${color.button.ghost.neutral.enabled.fg};
 
     * {
       color: inherit;

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -111,6 +111,7 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
   portalElementName,
   perspectiveList,
   referringDocuments$,
+  requestClose,
   components,
 }) => {
   const {beta} = useWorkspace()
@@ -257,13 +258,20 @@ export const DocumentGroupInventory: ComponentType<DocumentGroupInventoryProps> 
         </Body>
         <Footer>
           <Button
-            text={t('document-group.delete.confirm-button.text', {count: selectionCount})}
-            onClick={() => deletionRef.send({type: 'delete.request'})}
-            disabled={!canRequestDeletion}
-            tone="critical"
+            text={t('document-group-inventory.action.cancel')}
             size="large"
-            icon={TrashIcon}
+            mode="bleed"
+            onClick={requestClose}
           />
+          {canRequestDeletion && (
+            <Button
+              text={t('document-group.delete.confirm-button.text', {count: selectionCount})}
+              onClick={() => deletionRef.send({type: 'delete.request'})}
+              tone="critical"
+              size="large"
+              icon={TrashIcon}
+            />
+          )}
         </Footer>
       </Container>
       <div ref={setMenuPortalElement} />

--- a/packages/sanity/src/core/documentGroupInventory/components/Footer.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/Footer.tsx
@@ -10,9 +10,6 @@ export const Footer = styled.div(({theme}) => {
     padding-block-start: calc(${space[5]}px * 0.5);
     padding-block-end: ${space[4]}px;
     gap: ${space[3]}px;
-
-    & > * {
-      flex-grow: 1;
-    }
+    justify-content: end;
   `
 })

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -514,6 +514,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
 
   /** --- Document inventory --- */
 
+  /** The label shown when dismissing the document group inventory */
+  'document-group-inventory.action.cancel': 'Cancel',
   /** The label used in the feedback dialog asking how easy the document group inventory is to use */
   'document-group-inventory.feedback.sentiment-label':
     'How easy or difficult is the new version inventory to use?',

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -1,5 +1,5 @@
 import {Flex, LayerProvider, Stack, Text} from '@sanity/ui'
-import {memo, useMemo, useState} from 'react'
+import {memo, useCallback, useMemo, useState} from 'react'
 import {
   DEFAULT_STUDIO_CLIENT_OPTIONS,
   DocumentGroupInventory,
@@ -64,6 +64,11 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
   const referringDocuments$ = useMemo(
     () => referringDocuments({documentId, versionedClient: client, documentStore}),
     [documentId, client, documentStore],
+  )
+
+  const requestDocumentGroupInventoryClose = useCallback(
+    () => setIsDocumentGroupInventoryActive(false),
+    [setIsDocumentGroupInventoryActive],
   )
 
   const {selectedReleaseId} = usePerspective()
@@ -140,6 +145,7 @@ const DocumentStatusBarActionsInner = memo(function DocumentStatusBarActionsInne
             portalElementName={DOCUMENT_PANEL_PORTAL_ELEMENT}
             perspectiveList={perspectiveList}
             referringDocuments$={referringDocuments$}
+            requestClose={requestDocumentGroupInventoryClose}
             components={documentGroupInventoryComponents}
           />
         </DocumentGroupInventoryAction>


### PR DESCRIPTION
### Description

A set of small UI refinements to align the document group inventory with the most recent design.

- Add a close icon.
- Switch feedback button to render icon only.
- Dull action text colour.

### What to review

Document group inventory UI.

### Testing

Verified intended changes in dark and light mode.

--- 

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentational header and theme token changes only; close still uses the same optional `requestClose` path as the footer cancel button.
> 
> **Overview**
> Aligns the document group inventory header with updated design: **feedback** is icon-only with `title`/`aria-label`, and a new **close** control (`CloseIcon`) calls the existing `requestClose` callback beside it.
> 
> Header actions use **neutral ghost** button foreground (`color.button.ghost.neutral.enabled.fg`) instead of link color so they read as secondary controls rather than links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 555e8bf7b602949a731ecfb722ea5b2345685f4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->