### PR TITLE
chore(structure): useDocumentTitle, use document pane provider value

### DIFF
--- a/e2e/tests/inputs/reference.spec.ts
+++ b/e2e/tests/inputs/reference.spec.ts
@@ -155,7 +155,9 @@ withDefaultClient((context) => {
     await page.getByTestId('create-new-document-select-aliasRef-selectTypeMenuButton').click()
 
     // Wait for the new document referenced to be created & loaded
-    await expect(page.getByTestId('document-panel-document-title').nth(1)).toContainText('Untitled')
+    await expect(page.getByTestId('document-panel-document-title').nth(1)).toContainText(
+      'New Simple references test',
+    )
 
     // switch to original doc
     await page.locator('[data-testid="document-pane"]', {hasText: originalTitle}).click()
@@ -196,7 +198,9 @@ withDefaultClient((context) => {
     await page.getByTestId('create-new-document-select-aliasRef-selectTypeMenuButton').click()
 
     // Wait for the new document referenced to be created & loaded
-    await expect(page.getByTestId('document-panel-document-title').nth(1)).toContainText('Untitled')
+    await expect(page.getByTestId('document-panel-document-title').nth(1)).toContainText(
+      'New Simple references test',
+    )
 
     // switch to original doc
     await page.locator('[data-testid="document-pane"]', {hasText: originalTitle}).click()
@@ -237,7 +241,9 @@ withDefaultClient((context) => {
     await page.getByTestId('create-new-document-select-referenceField-selectTypeMenuButton').click()
 
     // wait for the reference document to open
-    await expect(page.getByTestId('document-panel-document-title').nth(1)).toContainText('Untitled')
+    await expect(page.getByTestId('document-panel-document-title').nth(1)).toContainText(
+      'New Simple references test',
+    )
 
     // update and publish the reference
     await page.getByTestId('string-input').nth(1).fill('Reference test')
@@ -288,7 +294,9 @@ withDefaultClient((context) => {
       .click()
 
     // wait for the reference document to open
-    await expect(page.getByTestId('document-panel-document-title').nth(1)).toContainText('Untitled')
+    await expect(page.getByTestId('document-panel-document-title').nth(1)).toContainText(
+      'New Simple references test',
+    )
 
     // update and publish the reference
     await page.getByTestId('string-input').nth(1).fill('Reference test')

--- a/e2e/tests/pte/referencesInPopover.spec.ts
+++ b/e2e/tests/pte/referencesInPopover.spec.ts
@@ -50,7 +50,7 @@ test.describe('In PTE - references in popover', () => {
     await page.locator('[data-testid^="create-new-document-select-text"]').click()
 
     // A new document should open to the side and be untitled
-    await expect(page.getByTestId('document-panel-document-title').nth(1)).toContainText('Untitled')
+    await expect(page.getByTestId('document-panel-document-title').nth(1)).toContainText('New Book')
 
     // While the popover is open, we should be able to change the fields of the new document
     await expect(page.getByTestId('string-input').nth(1)).toBeVisible()

--- a/packages/sanity/src/structure/panes/document/__tests__/useDocumentTitle.test.tsx
+++ b/packages/sanity/src/structure/panes/document/__tests__/useDocumentTitle.test.tsx
@@ -252,6 +252,85 @@ describe('useDocumentTitle', () => {
       enabled: true,
       schemaType: {title: 'Test Schema', fields: [], jsonType: 'object', name: 'testSchema'},
       value: versionDocument,
+      perspectiveStack: undefined,
+    })
+  })
+
+  it('should pass an empty perspectiveStack when the version is going to unpublish', async () => {
+    const versionDocument = {
+      _id: 'versions.release1.test-id',
+      _type: 'testSchema',
+      _createdAt: '2023-01-01T00:00:00Z',
+      _updatedAt: '2023-01-01T00:00:00Z',
+      _rev: 'rev1',
+      title: 'Version Title',
+      _system: {delete: true},
+    }
+
+    mockUseDocumentPane.mockReturnValue({
+      ...defaultDocumentPaneValue,
+      value: versionDocument,
+      editState: {
+        ...defaultDocumentPaneValue.editState,
+        version: versionDocument,
+      },
+    } as unknown as DocumentPaneContextValue)
+
+    mockUseValuePreview.mockReturnValue({
+      error: undefined,
+      value: {title: 'Published Title'},
+      isLoading: false,
+    })
+
+    const {result} = renderHook(() => useDocumentTitle())
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        error: undefined,
+        title: 'Published Title',
+      })
+    })
+
+    expect(mockUseValuePreview).toHaveBeenCalledWith({
+      enabled: true,
+      schemaType: {title: 'Test Schema', fields: [], jsonType: 'object', name: 'testSchema'},
+      value: versionDocument,
+      perspectiveStack: [],
+    })
+  })
+
+  it('should not override perspectiveStack when the version is not going to unpublish', async () => {
+    const versionDocument = {
+      _id: 'versions.release1.test-id',
+      _type: 'testSchema',
+      _createdAt: '2023-01-01T00:00:00Z',
+      _updatedAt: '2023-01-01T00:00:00Z',
+      _rev: 'rev1',
+      title: 'Version Title',
+    }
+
+    mockUseDocumentPane.mockReturnValue({
+      ...defaultDocumentPaneValue,
+      value: versionDocument,
+      editState: {
+        ...defaultDocumentPaneValue.editState,
+        version: versionDocument,
+      },
+    } as unknown as DocumentPaneContextValue)
+
+    mockUseValuePreview.mockReturnValue({
+      error: undefined,
+      value: {title: 'Version Title'},
+      isLoading: false,
+    })
+
+    renderHook(() => useDocumentTitle())
+
+    expect(mockUseValuePreview).toHaveBeenCalledWith({
+      enabled: true,
+      schemaType: {title: 'Test Schema', fields: [], jsonType: 'object', name: 'testSchema'},
+      value: versionDocument,
+      perspectiveStack: undefined,
     })
   })
 
@@ -290,6 +369,7 @@ describe('useDocumentTitle', () => {
       enabled: true,
       schemaType: {title: 'Test Schema', name: 'testSchema', fields: [], jsonType: 'object'},
       value: draftDocument,
+      perspectiveStack: undefined,
     })
   })
 
@@ -328,6 +408,7 @@ describe('useDocumentTitle', () => {
       enabled: true,
       schemaType: {title: 'Test Schema', name: 'testSchema', fields: [], jsonType: 'object'},
       value: publishedDocument,
+      perspectiveStack: undefined,
     })
   })
 
@@ -345,6 +426,7 @@ describe('useDocumentTitle', () => {
         enabled: true,
         schemaType: {title: 'Test Schema', name: 'testSchema', fields: [], jsonType: 'object'},
         value: baseValue,
+        perspectiveStack: undefined,
       })
     })
   })
@@ -357,6 +439,7 @@ describe('useDocumentTitle', () => {
         enabled: true,
         schemaType: {title: 'Test Schema', name: 'testSchema', fields: [], jsonType: 'object'},
         value: defaultDocumentValue,
+        perspectiveStack: undefined,
       })
     })
   })
@@ -432,6 +515,7 @@ describe('useDocumentTitle', () => {
       enabled: false,
       schemaType: {title: 'Test Schema', name: 'testSchema', fields: [], jsonType: 'object'},
       value: lastRevisionDocument,
+      perspectiveStack: undefined,
     })
   })
 })

--- a/packages/sanity/src/structure/panes/document/__tests__/useDocumentTitle.test.tsx
+++ b/packages/sanity/src/structure/panes/document/__tests__/useDocumentTitle.test.tsx
@@ -57,9 +57,23 @@ function createWrapperComponent(client: SanityClient) {
 }
 
 describe('useDocumentTitle', () => {
+  const baseValue = {
+    _id: 'test-id',
+    _type: 'testSchema',
+  }
+
+  const defaultDocumentValue = {
+    ...baseValue,
+    _createdAt: '2023-01-01T00:00:00Z',
+    _updatedAt: '2023-01-01T00:00:00Z',
+    _rev: 'rev1',
+    title: 'Test Document',
+  }
+
   const defaultDocumentPaneValue = {
     connectionState: 'connected' as const,
     schemaType: {title: 'Test Schema', name: 'testSchema', jsonType: 'object', fields: []},
+    value: defaultDocumentValue,
     editState: {
       id: 'test-id',
       type: 'testSchema',
@@ -108,9 +122,10 @@ describe('useDocumentTitle', () => {
     })
   })
 
-  it('should return "New {schemaType.title}" when no document value exists', async () => {
+  it('should return "New {schemaType.title}" when preview has no title for base value', async () => {
     mockUseDocumentPane.mockReturnValue({
       ...defaultDocumentPaneValue,
+      value: baseValue,
       editState: null,
     } as DocumentPaneContextValue)
 
@@ -137,6 +152,7 @@ describe('useDocumentTitle', () => {
     mockUseDocumentPane.mockReturnValue({
       ...defaultDocumentPaneValue,
       schemaType: {name: 'testSchema'}, // No title
+      value: baseValue,
       editState: null,
     } as DocumentPaneContextValue)
 
@@ -182,10 +198,12 @@ describe('useDocumentTitle', () => {
     })
   })
 
-  it('should return undefined title and error when connecting and not subscribed', async () => {
+  it('should return undefined title when connecting and not subscribed', async () => {
     mockUseDocumentPane.mockReturnValue({
       ...defaultDocumentPaneValue,
       connectionState: 'connecting',
+      isDeleted: true,
+      value: baseValue,
       editState: null,
     } as DocumentPaneContextValue)
 
@@ -199,41 +217,19 @@ describe('useDocumentTitle', () => {
     })
   })
 
-  it('should use version over draft over published for document value', async () => {
+  it('should use document pane value for preview', async () => {
+    const versionDocument = {
+      _id: 'versions.release1.test-id',
+      _type: 'testSchema',
+      _createdAt: '2023-01-01T00:00:00Z',
+      _updatedAt: '2023-01-01T00:00:00Z',
+      _rev: 'rev1',
+      title: 'Version Title',
+    }
+
     mockUseDocumentPane.mockReturnValue({
       ...defaultDocumentPaneValue,
-      editState: {
-        id: 'test-id',
-        type: 'testSchema',
-        transactionSyncLock: {enabled: false},
-        liveEdit: {enabled: false},
-        version: {
-          _id: 'versions.release1.test-id',
-          _type: 'testSchema',
-          _createdAt: '2023-01-01T00:00:00Z',
-          _updatedAt: '2023-01-01T00:00:00Z',
-          _rev: 'rev1',
-          title: 'Version Title',
-        },
-        draft: {
-          _id: 'drafts.test-id',
-          _type: 'testSchema',
-          _createdAt: '2023-01-01T00:00:00Z',
-          _updatedAt: '2023-01-01T00:00:00Z',
-          _rev: 'rev1',
-          title: 'Draft Title',
-        },
-        published: {
-          _id: 'test-id',
-          _type: 'testSchema',
-          _createdAt: '2023-01-01T00:00:00Z',
-          _updatedAt: '2023-01-01T00:00:00Z',
-          _rev: 'rev1',
-          title: 'Published Title',
-        },
-        patches: [],
-        historyController: {} as any,
-      },
+      value: versionDocument,
     } as unknown as DocumentPaneContextValue)
 
     mockUseValuePreview.mockReturnValue({
@@ -241,8 +237,6 @@ describe('useDocumentTitle', () => {
       value: {title: 'Version Title'},
       isLoading: false,
     })
-
-    const client = createMockSanityClient()
 
     const {result} = renderHook(() => useDocumentTitle())
 
@@ -253,49 +247,27 @@ describe('useDocumentTitle', () => {
       })
     })
 
-    // Verify that useValuePreview was called with the version value
+    // Verify that useValuePreview was called with the document pane value
     expect(mockUseValuePreview).toHaveBeenCalledWith({
       enabled: true,
       schemaType: {title: 'Test Schema', fields: [], jsonType: 'object', name: 'testSchema'},
-      value: {
-        _id: 'versions.release1.test-id',
-        _type: 'testSchema',
-        title: 'Version Title',
-        _createdAt: '2023-01-01T00:00:00Z',
-        _updatedAt: '2023-01-01T00:00:00Z',
-        _rev: 'rev1',
-      },
+      value: versionDocument,
     })
   })
 
-  it('should use draft when version is not available', async () => {
+  it('should use draft document pane value for preview', async () => {
+    const draftDocument = {
+      _id: 'drafts.test-id',
+      _type: 'testSchema',
+      _createdAt: '2023-01-01T00:00:00Z',
+      _updatedAt: '2023-01-01T00:00:00Z',
+      _rev: 'rev1',
+      title: 'Draft Title',
+    }
+
     mockUseDocumentPane.mockReturnValue({
       ...defaultDocumentPaneValue,
-      editState: {
-        id: 'test-id',
-        type: 'testSchema',
-        transactionSyncLock: {enabled: false},
-        liveEdit: {enabled: false},
-        version: undefined,
-        draft: {
-          _id: 'drafts.test-id',
-          _type: 'testSchema',
-          _createdAt: '2023-01-01T00:00:00Z',
-          _updatedAt: '2023-01-01T00:00:00Z',
-          _rev: 'rev1',
-          title: 'Draft Title',
-        },
-        published: {
-          _id: 'test-id',
-          _type: 'testSchema',
-          _createdAt: '2023-01-01T00:00:00Z',
-          _updatedAt: '2023-01-01T00:00:00Z',
-          _rev: 'rev1',
-          title: 'Published Title',
-        },
-        patches: [],
-        historyController: {} as any,
-      },
+      value: draftDocument,
     } as unknown as DocumentPaneContextValue)
 
     mockUseValuePreview.mockReturnValue({
@@ -317,38 +289,23 @@ describe('useDocumentTitle', () => {
     expect(mockUseValuePreview).toHaveBeenCalledWith({
       enabled: true,
       schemaType: {title: 'Test Schema', name: 'testSchema', fields: [], jsonType: 'object'},
-      value: {
-        _id: 'drafts.test-id',
-        _type: 'testSchema',
-        title: 'Draft Title',
-        _createdAt: '2023-01-01T00:00:00Z',
-        _updatedAt: '2023-01-01T00:00:00Z',
-        _rev: 'rev1',
-      },
+      value: draftDocument,
     })
   })
 
-  it('should use published when version and draft are not available', async () => {
+  it('should use published document pane value for preview', async () => {
+    const publishedDocument = {
+      _id: 'test-id',
+      _type: 'testSchema',
+      _createdAt: '2023-01-01T00:00:00Z',
+      _updatedAt: '2023-01-01T00:00:00Z',
+      _rev: 'rev1',
+      title: 'Published Title',
+    }
+
     mockUseDocumentPane.mockReturnValue({
       ...defaultDocumentPaneValue,
-      editState: {
-        id: 'test-id',
-        type: 'testSchema',
-        transactionSyncLock: {enabled: false},
-        liveEdit: {enabled: false},
-        version: undefined,
-        draft: undefined,
-        published: {
-          _id: 'test-id',
-          _type: 'testSchema',
-          _createdAt: '2023-01-01T00:00:00Z',
-          _updatedAt: '2023-01-01T00:00:00Z',
-          _rev: 'rev1',
-          title: 'Published Title',
-        },
-        patches: [],
-        historyController: {} as any,
-      },
+      value: publishedDocument,
     } as unknown as DocumentPaneContextValue)
 
     mockUseValuePreview.mockReturnValue({
@@ -370,20 +327,14 @@ describe('useDocumentTitle', () => {
     expect(mockUseValuePreview).toHaveBeenCalledWith({
       enabled: true,
       schemaType: {title: 'Test Schema', name: 'testSchema', fields: [], jsonType: 'object'},
-      value: {
-        _id: 'test-id',
-        _type: 'testSchema',
-        title: 'Published Title',
-        _createdAt: '2023-01-01T00:00:00Z',
-        _updatedAt: '2023-01-01T00:00:00Z',
-        _rev: 'rev1',
-      },
+      value: publishedDocument,
     })
   })
 
-  it('should disable preview when no document value is available', async () => {
+  it('should enable preview with base value for new documents', async () => {
     mockUseDocumentPane.mockReturnValue({
       ...defaultDocumentPaneValue,
+      value: baseValue,
       editState: null,
     } as DocumentPaneContextValue)
 
@@ -391,9 +342,9 @@ describe('useDocumentTitle', () => {
 
     await waitFor(() => {
       expect(mockUseValuePreview).toHaveBeenCalledWith({
-        enabled: false,
+        enabled: true,
         schemaType: {title: 'Test Schema', name: 'testSchema', fields: [], jsonType: 'object'},
-        value: undefined,
+        value: baseValue,
       })
     })
   })
@@ -405,14 +356,7 @@ describe('useDocumentTitle', () => {
       expect(mockUseValuePreview).toHaveBeenCalledWith({
         enabled: true,
         schemaType: {title: 'Test Schema', name: 'testSchema', fields: [], jsonType: 'object'},
-        value: {
-          _id: 'test-id',
-          _type: 'testSchema',
-          title: 'Test Document',
-          _createdAt: '2023-01-01T00:00:00Z',
-          _updatedAt: '2023-01-01T00:00:00Z',
-          _rev: 'rev1',
-        },
+        value: defaultDocumentValue,
       })
     })
   })
@@ -433,49 +377,6 @@ describe('useDocumentTitle', () => {
     })
   })
 
-  it('should handle empty editState with connecting state', async () => {
-    mockUseDocumentPane.mockReturnValue({
-      ...defaultDocumentPaneValue,
-      connectionState: 'connecting',
-      editState: null,
-    } as DocumentPaneContextValue)
-
-    const client = createMockSanityClient()
-    const wrapper = await createWrapperComponent(client as any)
-
-    const {result} = renderHook(() => useDocumentTitle(), {wrapper})
-
-    await waitFor(() => {
-      expect(result.current).toEqual({
-        error: undefined,
-        title: undefined,
-      })
-    })
-  })
-
-  it('should handle empty editState with non-connecting state', async () => {
-    mockUseDocumentPane.mockReturnValue({
-      ...defaultDocumentPaneValue,
-      connectionState: 'connected',
-      editState: null,
-    } as DocumentPaneContextValue)
-
-    mockUseValuePreview.mockReturnValue({
-      error: undefined,
-      value: undefined,
-      isLoading: false,
-    })
-
-    const {result} = renderHook(() => useDocumentTitle())
-
-    await waitFor(() => {
-      expect(result.current).toEqual({
-        error: undefined,
-        title: 'New Test Schema',
-      })
-    })
-  })
-
   it('should handle deleted documents by using prepareForPreview directly', async () => {
     const lastRevisionDocument = {
       _id: 'test-id',
@@ -490,6 +391,7 @@ describe('useDocumentTitle', () => {
       ...defaultDocumentPaneValue,
       isDeleted: true,
       lastRevisionDocument,
+      value: baseValue,
       editState: null, // No edit state for deleted documents
     } as DocumentPaneContextValue)
 

--- a/packages/sanity/src/structure/panes/document/useDocumentTitle.ts
+++ b/packages/sanity/src/structure/panes/document/useDocumentTitle.ts
@@ -1,11 +1,5 @@
 import {useMemo} from 'react'
-import {
-  isPublishedPerspective,
-  prepareForPreview,
-  usePerspective,
-  useTranslation,
-  useValuePreview,
-} from 'sanity'
+import {prepareForPreview, useTranslation, useValuePreview} from 'sanity'
 
 import {structureLocaleNamespace} from '../../i18n'
 import {useDocumentPane} from './useDocumentPane'

--- a/packages/sanity/src/structure/panes/document/useDocumentTitle.ts
+++ b/packages/sanity/src/structure/panes/document/useDocumentTitle.ts
@@ -30,21 +30,20 @@ export interface UseDocumentTitle {
  * @returns The document title or error. See {@link UseDocumentTitle}
  */
 export function useDocumentTitle(): UseDocumentTitle {
-  const {connectionState, schemaType, editState, isDeleted, lastRevisionDocument} =
-    useDocumentPane()
-  const {selectedPerspectiveName} = usePerspective()
+  const {
+    connectionState,
+    schemaType,
+    isDeleted,
+    lastRevisionDocument,
+    value: documentPaneValue,
+  } = useDocumentPane()
   const {t} = useTranslation(structureLocaleNamespace)
+
   // follows the same logic as the StructureTitle component
   const documentValue = useMemo(() => {
-    if (isDeleted) {
-      return lastRevisionDocument
-    }
-    // When viewing published perspective, prioritize published document
-    if (selectedPerspectiveName && isPublishedPerspective(selectedPerspectiveName)) {
-      return editState?.published
-    }
-    return editState?.version || editState?.draft || editState?.published
-  }, [isDeleted, lastRevisionDocument, editState, selectedPerspectiveName])
+    if (isDeleted) return lastRevisionDocument
+    return documentPaneValue
+  }, [isDeleted, lastRevisionDocument, documentPaneValue])
   const subscribed = Boolean(documentValue)
 
   // For deleted documents, we need to handle the preview differently since useValuePreview

--- a/packages/sanity/src/structure/panes/document/useDocumentTitle.ts
+++ b/packages/sanity/src/structure/panes/document/useDocumentTitle.ts
@@ -1,5 +1,5 @@
 import {useMemo} from 'react'
-import {prepareForPreview, useTranslation, useValuePreview} from 'sanity'
+import {prepareForPreview, useTranslation, useValuePreview, isGoingToUnpublish} from 'sanity'
 
 import {structureLocaleNamespace} from '../../i18n'
 import {useDocumentPane} from './useDocumentPane'
@@ -30,6 +30,7 @@ export function useDocumentTitle(): UseDocumentTitle {
     isDeleted,
     lastRevisionDocument,
     value: documentPaneValue,
+    editState,
   } = useDocumentPane()
   const {t} = useTranslation(structureLocaleNamespace)
 
@@ -61,6 +62,8 @@ export function useDocumentTitle(): UseDocumentTitle {
     enabled: subscribed && !isDeleted,
     schemaType,
     value: documentValue,
+    // Documents that are going to be unpublished need to be handled specially
+    perspectiveStack: editState?.version && isGoingToUnpublish(editState?.version) ? [] : undefined,
   })
 
   if (connectionState === 'connecting' && !subscribed) {


### PR DESCRIPTION
### Description
Instead of juggling with the editState and guessing which one we need to use, which will not exist for documents not created yet, like drafts variants, use the document pane provider value, which is the same value we are using in the form.
This way both will always match.


It also fixes the `Untitled` displayed when creating a new document and now it renders the expected `New <schemaType> ` 
<img width="682" height="292" alt="Screenshot 2026-07-27 at 18 47 14" src="https://github.com/user-attachments/assets/4087e55e-9292-4c51-b26d-0190519fb110" />

<img width="729" height="274" alt="Screenshot 2026-07-27 at 18 48 30" src="https://github.com/user-attachments/assets/2fc8ea48-f2c9-41fc-ad84-54f1715061d9" />


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---
