### PR TITLE
chore(structure): render doc badges even if the doc is missing

### DIFF
--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -473,6 +473,10 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   /** The "raw" view mode, meaning the JSON is presented syntax-highlighted, but with no other features - optimal for copying */
   'document-inspector.view-mode.raw-json': 'Raw JSON',
 
+  /** Tooltip on target badges when the document does not exist in the selected perspective */
+  'document-target-badges.not-in-target.tooltip':
+    "Document doesn't exist in the selected perspective yet.",
+
   /** The text for when a form is hidden */
   'document-view.form-view.form-hidden': 'This form is hidden',
   /** Fallback title shown when a form title is not provided */

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentTargetBadges.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentTargetBadges.tsx
@@ -24,7 +24,7 @@ import {
 } from 'sanity'
 import {styled} from 'styled-components'
 
-import {Tooltip} from '../../../../../ui-components'
+import {Tooltip} from '../../../../../ui-components/tooltip/Tooltip'
 import {structureLocaleNamespace} from '../../../../i18n'
 import {useDocumentPane} from '../../useDocumentPane'
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentTargetBadges.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentTargetBadges.tsx
@@ -15,9 +15,11 @@ import {
   isDraftPerspective,
   isPublishedPerspective,
   isReleaseDocument,
+  isSystemBundle,
   usePerspective,
   useTranslation,
   type SystemVariant,
+  type TargetDocumentState,
   type TargetPerspective,
 } from 'sanity'
 import {styled} from 'styled-components'
@@ -62,6 +64,39 @@ const BadgeContainer = styled(Flex)`
   user-select: none;
   flex: none;
 `
+
+const BadgeMotionWrapper = styled(motion.div)`
+  flex: none;
+`
+
+function isTargetDocumentDefinitivelyMissing(
+  state: TargetDocumentState,
+  bundle: ReturnType<typeof usePerspective>['bundle'],
+): boolean {
+  switch (state.status) {
+    case 'resolving':
+      return false
+    case 'variant-definition-document-not-found':
+      return true
+    case 'variant-missing':
+      return true
+    case 'ready':
+      return !state.targetDocument && !state.variant && !isSystemBundle(bundle)
+    default:
+      return false
+  }
+}
+
+function getSelectedVariantFromState(
+  state: TargetDocumentState,
+  selectedVariant: SystemVariant | undefined,
+): SystemVariant | undefined {
+  if (state.status === 'ready' || state.status === 'variant-missing') {
+    return state.variant
+  }
+
+  return selectedVariant
+}
 
 function getPerspectiveBadgeTone(selectedPerspective: TargetPerspective): BadgeTone {
   if (isDraftPerspective(selectedPerspective)) {
@@ -131,20 +166,20 @@ const VariantBadgeLabel = memo(function VariantBadgeLabel({variant}: {variant: S
 
 export const DocumentTargetBadges = memo(function DocumentTargetBadges() {
   const {targetDocumentState} = useDocumentPane()
-  const {selectedPerspective, selectedVariant} = usePerspective()
+  const {bundle, selectedPerspective, selectedVariant} = usePerspective()
   const {t} = useTranslation(structureLocaleNamespace)
 
-  const isInCurrentTarget =
-    targetDocumentState.status === 'ready' && Boolean(targetDocumentState.targetDocument)
-  const badgeOpacity = isInCurrentTarget ? 1 : 0.5
+  const isTargetMissing = isTargetDocumentDefinitivelyMissing(targetDocumentState, bundle)
+  const badgeOpacity = isTargetMissing ? 0.5 : 1
+  const selectedVariantBadge = getSelectedVariantFromState(targetDocumentState, selectedVariant)
 
   return (
     <Tooltip
       content={t('document-target-badges.not-in-target.tooltip')}
-      disabled={isInCurrentTarget}
+      disabled={!isTargetMissing}
     >
       <Flex align="center" flex="none" gap={2} paddingRight={1}>
-        <motion.div animate={{opacity: badgeOpacity}} transition={{duration: 0.2}}>
+        <BadgeMotionWrapper animate={{opacity: badgeOpacity}} transition={{duration: 0.2}}>
           <TargetBadge
             tone={getPerspectiveBadgeTone(selectedPerspective)}
             border
@@ -153,13 +188,13 @@ export const DocumentTargetBadges = memo(function DocumentTargetBadges() {
           >
             <PerspectiveBadgeLabel selectedPerspective={selectedPerspective} />
           </TargetBadge>
-        </motion.div>
-        {selectedVariant ? (
-          <motion.div animate={{opacity: badgeOpacity}} transition={{duration: 0.2}}>
+        </BadgeMotionWrapper>
+        {selectedVariantBadge ? (
+          <BadgeMotionWrapper animate={{opacity: badgeOpacity}} transition={{duration: 0.2}}>
             <TargetBadge tone="suggest" border radius={4} data-ui="DocumentTargetVariantBadge">
-              <VariantBadgeLabel variant={selectedVariant} />
+              <VariantBadgeLabel variant={selectedVariantBadge} />
             </TargetBadge>
-          </motion.div>
+          </BadgeMotionWrapper>
         ) : null}
       </Flex>
     </Tooltip>

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentTargetBadges.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentTargetBadges.tsx
@@ -2,23 +2,23 @@ import {Card, Flex, Text, type BadgeTone} from '@sanity/ui'
 import {motion} from 'motion/react'
 import {
   forwardRef,
-  type ForwardRefExoticComponent,
   memo,
+  type ForwardRefExoticComponent,
   type RefAttributes,
   type SVGProps,
 } from 'react'
 import {
+  ReleaseAvatarIcon,
+  ReleaseTitle,
   getReleaseTone,
   getVariantTitle,
   isDraftPerspective,
   isPublishedPerspective,
   isReleaseDocument,
-  ReleaseTitle,
   usePerspective,
   useTranslation,
   type SystemVariant,
   type TargetPerspective,
-  ReleaseAvatarIcon,
 } from 'sanity'
 import {styled} from 'styled-components'
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentTargetBadges.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentTargetBadges.tsx
@@ -1,4 +1,5 @@
 import {Card, Flex, Text, type BadgeTone} from '@sanity/ui'
+import {motion} from 'motion/react'
 import {
   forwardRef,
   type ForwardRefExoticComponent,
@@ -21,6 +22,8 @@ import {
 } from 'sanity'
 import {styled} from 'styled-components'
 
+import {Tooltip} from '../../../../../ui-components'
+import {structureLocaleNamespace} from '../../../../i18n'
 import {useDocumentPane} from '../../useDocumentPane'
 
 /**
@@ -128,33 +131,37 @@ const VariantBadgeLabel = memo(function VariantBadgeLabel({variant}: {variant: S
 
 export const DocumentTargetBadges = memo(function DocumentTargetBadges() {
   const {targetDocumentState} = useDocumentPane()
-  const {selectedPerspective} = usePerspective()
+  const {selectedPerspective, selectedVariant} = usePerspective()
+  const {t} = useTranslation(structureLocaleNamespace)
 
   const isInCurrentTarget =
     targetDocumentState.status === 'ready' && Boolean(targetDocumentState.targetDocument)
-
-  if (!isInCurrentTarget) {
-    return null
-  }
-
-  const selectedVariant =
-    targetDocumentState.status === 'ready' ? targetDocumentState.variant : undefined
+  const badgeOpacity = isInCurrentTarget ? 1 : 0.5
 
   return (
-    <Flex align="center" flex="none" gap={2} paddingRight={1}>
-      <TargetBadge
-        tone={getPerspectiveBadgeTone(selectedPerspective)}
-        border
-        radius={4}
-        data-ui="DocumentTargetPerspectiveBadge"
-      >
-        <PerspectiveBadgeLabel selectedPerspective={selectedPerspective} />
-      </TargetBadge>
-      {selectedVariant ? (
-        <TargetBadge tone="suggest" border radius={4} data-ui="DocumentTargetVariantBadge">
-          <VariantBadgeLabel variant={selectedVariant} />
-        </TargetBadge>
-      ) : null}
-    </Flex>
+    <Tooltip
+      content={t('document-target-badges.not-in-target.tooltip')}
+      disabled={isInCurrentTarget}
+    >
+      <Flex align="center" flex="none" gap={2} paddingRight={1}>
+        <motion.div animate={{opacity: badgeOpacity}} transition={{duration: 0.2}}>
+          <TargetBadge
+            tone={getPerspectiveBadgeTone(selectedPerspective)}
+            border
+            radius={4}
+            data-ui="DocumentTargetPerspectiveBadge"
+          >
+            <PerspectiveBadgeLabel selectedPerspective={selectedPerspective} />
+          </TargetBadge>
+        </motion.div>
+        {selectedVariant ? (
+          <motion.div animate={{opacity: badgeOpacity}} transition={{duration: 0.2}}>
+            <TargetBadge tone="suggest" border radius={4} data-ui="DocumentTargetVariantBadge">
+              <VariantBadgeLabel variant={selectedVariant} />
+            </TargetBadge>
+          </motion.div>
+        ) : null}
+      </Flex>
+    </Tooltip>
   )
 })


### PR DESCRIPTION
### Description
If the document doesn't exist in the selected perspective render the badges anyways and use that space to render a tooltip with some extra information.

### Before
<img width="2350" height="1686" alt="image" src="https://github.com/user-attachments/assets/4bf2bb7e-934c-4d40-8b98-cb16806d2b57" />


### After
<img width="2350" height="1342" alt="image" src="https://github.com/user-attachments/assets/3e888ae2-6c44-437c-b627-b876170cb75a" />



What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---
