### PR TITLE
test(e2e): add tasks e2e tests for create, release scoping and resolve

### DIFF
--- a/e2e/tests/tasks/tasks.spec.ts
+++ b/e2e/tests/tasks/tasks.spec.ts
@@ -16,7 +16,10 @@ import {
  */
 async function openTasksSidebar(page: Page) {
   await page.getByTestId('tasks-toolbar').click()
-  await expect(page.getByRole('button', {name: 'New task'})).toBeVisible({timeout: 30_000})
+  // `exact` avoids also matching the empty state's "Create new task" button.
+  await expect(page.getByRole('button', {name: 'New task', exact: true})).toBeVisible({
+    timeout: 30_000,
+  })
 }
 
 /**
@@ -25,9 +28,12 @@ async function openTasksSidebar(page: Page) {
  * automatically switches to the "Subscribed" tab, where the new task is listed.
  */
 async function createTask(page: Page, title: string) {
-  await page.getByRole('button', {name: 'New task'}).click()
+  await page.getByRole('button', {name: 'New task', exact: true}).click()
   const titleInput = page.getByPlaceholder('Task title')
   await expect(titleInput).toBeVisible({timeout: 30_000})
+  // The active document is picked up with a debounce; wait for the target field to be
+  // pre-populated so the task is created with the (version-aware) document target.
+  await expect(page.getByTestId('task-target-field-preview')).toBeVisible({timeout: 30_000})
   await titleInput.fill(title)
   await page.getByRole('button', {name: 'Create Task'}).click()
   await expect(page.getByTestId('tasks-list-item').filter({hasText: title})).toBeVisible({

--- a/e2e/tests/tasks/tasks.spec.ts
+++ b/e2e/tests/tasks/tasks.spec.ts
@@ -1,0 +1,133 @@
+import {expect, type Page} from '@playwright/test'
+
+import {test} from '../../studio-test'
+import {partialASAPReleaseMetadata} from '../releases/utils/__fixtures__/releases'
+import {
+  archiveAndDeleteRelease,
+  createDocument,
+  createRelease,
+  getRandomReleaseId,
+  skipIfBrowser,
+} from '../releases/utils/methods'
+
+/**
+ * Opens the tasks sidebar from the navbar. The first use in a fresh dataset may create the
+ * tasks addon dataset, so the readiness check gets a generous timeout.
+ */
+async function openTasksSidebar(page: Page) {
+  await page.getByTestId('tasks-toolbar').click()
+  await expect(page.getByRole('button', {name: 'New task'})).toBeVisible({timeout: 30_000})
+}
+
+/**
+ * Creates a task with the given title through the sidebar form. The target document is
+ * pre-populated with the active document. After a successful creation the sidebar
+ * automatically switches to the "Subscribed" tab, where the new task is listed.
+ */
+async function createTask(page: Page, title: string) {
+  await page.getByRole('button', {name: 'New task'}).click()
+  const titleInput = page.getByPlaceholder('Task title')
+  await expect(titleInput).toBeVisible({timeout: 30_000})
+  await titleInput.fill(title)
+  await page.getByRole('button', {name: 'Create Task'}).click()
+  await expect(page.getByTestId('tasks-list-item').filter({hasText: title})).toBeVisible({
+    timeout: 30_000,
+  })
+}
+
+test.describe('Tasks', () => {
+  test.beforeEach(({browserName}) => {
+    skipIfBrowser(browserName)
+  })
+
+  test('creates a task targeting the active document', async ({page, createDraftDocument}) => {
+    await createDraftDocument('/content/species')
+    const title = `Task e2e create ${Date.now()}`
+
+    await openTasksSidebar(page)
+    await createTask(page, title)
+
+    // The task targets the open document, so the "Active Document" tab lists it and the
+    // document footer counts it.
+    await page.getByRole('tab', {name: 'Active Document'}).click()
+    await expect(page.getByTestId('tasks-list-item').filter({hasText: title})).toBeVisible()
+    await expect(page.getByRole('button', {name: '1 open task'})).toBeVisible()
+  })
+
+  test('creates a task for a release version document and scopes it to that version', async ({
+    page,
+    sanityClient,
+    _testContext,
+  }) => {
+    const releaseId = getRandomReleaseId()
+    const dataset = sanityClient.config().dataset
+
+    await createRelease({
+      sanityClient,
+      dataset,
+      releaseId,
+      metadata: partialASAPReleaseMetadata,
+    })
+
+    try {
+      const docId = _testContext.getUniqueDocumentId()
+      // A draft and a release version of the same document, so both perspectives display a
+      // real document of their own.
+      await createDocument(sanityClient, {
+        _type: 'species',
+        name: 'Tasks e2e draft',
+        _id: `drafts.${docId}`,
+      })
+      await createDocument(sanityClient, {
+        _type: 'species',
+        name: 'Tasks e2e release version',
+        _id: `versions.${releaseId}.${docId}`,
+      })
+
+      // Create the task while the release version of the document is displayed: its target
+      // stores the version id, scoping it to that exact version document.
+      await page.goto(`/content/species;${docId}?perspective=${releaseId}`)
+      await expect(page.locator('[data-testid="form-view"]')).toBeVisible({timeout: 30_000})
+
+      const title = `Task e2e release ${Date.now()}`
+      await openTasksSidebar(page)
+      await createTask(page, title)
+
+      await page.getByRole('tab', {name: 'Active Document'}).click()
+      await expect(page.getByTestId('tasks-list-item').filter({hasText: title})).toBeVisible()
+      await expect(page.getByRole('button', {name: '1 open task'})).toBeVisible()
+
+      // The draft of the same document must not list the version-scoped task.
+      await page.goto(`/content/species;${docId}`)
+      await expect(page.locator('[data-testid="form-view"]')).toBeVisible({timeout: 30_000})
+
+      await openTasksSidebar(page)
+      await page.getByRole('tab', {name: 'Active Document'}).click()
+      // Waiting for the loaded empty state ensures the list has resolved before the negative
+      // assertions below.
+      await expect(page.getByText("This document doesn't have any tasks yet")).toBeVisible({
+        timeout: 30_000,
+      })
+      await expect(page.getByTestId('tasks-list-item').filter({hasText: title})).not.toBeVisible()
+      await expect(page.getByRole('button', {name: '1 open task'})).not.toBeVisible()
+    } finally {
+      await archiveAndDeleteRelease({sanityClient, dataset, releaseId})
+    }
+  })
+
+  test('resolves a task from the tasks list', async ({page, createDraftDocument}) => {
+    await createDraftDocument('/content/species')
+    const title = `Task e2e resolve ${Date.now()}`
+
+    await openTasksSidebar(page)
+    await createTask(page, title)
+
+    const taskItem = page.getByTestId('tasks-list-item').filter({hasText: title})
+    await taskItem.getByRole('checkbox').click()
+
+    // The resolved task moves out of the "To Do" section into the collapsed "Done" section.
+    await expect(taskItem).not.toBeVisible()
+    await page.getByText('Done', {exact: true}).click()
+    await expect(page.getByTestId('tasks-list-item').filter({hasText: title})).toBeVisible()
+  })
+})

--- a/e2e/tests/tasks/tasks.spec.ts
+++ b/e2e/tests/tasks/tasks.spec.ts
@@ -1,5 +1,6 @@
 import {expect, type Page} from '@playwright/test'
 
+import {expectSavedStatus} from '../../helpers/documentStatusAssertions'
 import {test} from '../../studio-test'
 import {partialASAPReleaseMetadata} from '../releases/utils/__fixtures__/releases'
 import {
@@ -9,6 +10,24 @@ import {
   getRandomReleaseId,
   skipIfBrowser,
 } from '../releases/utils/methods'
+
+/**
+ * Navigates to a new species draft, types a name to persist it, and waits for the save to
+ * complete before continuing.
+ */
+async function createSpeciesDocument(
+  page: Page,
+  createDraftDocument: (navigationPath: string) => Promise<string>,
+) {
+  await createDraftDocument('/content/species')
+
+  const nameInput = page.locator('#name')
+  await expect(nameInput).toBeVisible({timeout: 30_000})
+  await expect(nameInput).toBeEnabled()
+  await nameInput.fill(`Tasks e2e species ${Date.now()}`)
+
+  await expectSavedStatus(page.getByTestId('pane-footer'), {timeout: 30_000})
+}
 
 /**
  * Opens the tasks sidebar from the navbar. The first use in a fresh dataset may create the
@@ -47,7 +66,8 @@ test.describe('Tasks', () => {
   })
 
   test('creates a task targeting the active document', async ({page, createDraftDocument}) => {
-    await createDraftDocument('/content/species')
+    await createSpeciesDocument(page, createDraftDocument)
+
     const title = `Task e2e create ${Date.now()}`
 
     await openTasksSidebar(page)
@@ -122,7 +142,7 @@ test.describe('Tasks', () => {
   })
 
   test('resolves a task from the tasks list', async ({page, createDraftDocument}) => {
-    await createDraftDocument('/content/species')
+    await createSpeciesDocument(page, createDraftDocument)
     const title = `Task e2e resolve ${Date.now()}`
 
     await openTasksSidebar(page)

--- a/packages/sanity/src/core/tasks/components/form/fields/TargetField.tsx
+++ b/packages/sanity/src/core/tasks/components/form/fields/TargetField.tsx
@@ -121,7 +121,7 @@ function Preview(props: {value: TaskTarget; handleRemove: () => void}) {
   }
 
   return (
-    <TargetRoot border radius={2}>
+    <TargetRoot border radius={2} data-testid="task-target-field-preview">
       <Flex gap={1} align={'center'} justify={'space-between'}>
         <Card as={CardLink} radius={2} data-as="button">
           <SearchResultItemPreview

--- a/packages/sanity/src/core/tasks/components/list/TasksListItem.tsx
+++ b/packages/sanity/src/core/tasks/components/list/TasksListItem.tsx
@@ -95,7 +95,7 @@ export function TasksListItem(props: TasksListItemProps) {
   const targetDocument = useMemo(() => getTargetDocumentMeta(target), [target])
 
   return (
-    <Stack gap={3}>
+    <Stack gap={3} data-testid="tasks-list-item">
       <Flex align="center" gap={1}>
         <Box>
           <TasksStatus documentId={documentId} status={status} />


### PR DESCRIPTION
### Description

Tasks had no e2e coverage beyond the navbar toolbar visibility check, and the recent tasks work (neutral perspective for the task form, `documentVersionId` scoping of task targets) is exactly the kind of perspective-dependent behavior unit tests can't fully cover. This adds a `Tasks` suite covering the three core flows: creating a task for the active document, creating a task while a release version is displayed, and resolving a task from the list.

The release test is the one that pins down the new version scoping: it creates both a draft and a release version of the same document, creates a task with the release perspective selected, and asserts the task is listed and counted only on the version document — reloading the draft shows the empty state and no footer badge.

Stacked on `cursor/tasks-support-variants-062d` since the tests depend on the fixes there.

### What to review

- `e2e/tests/tasks/tasks.spec.ts` — follows the releases specs' conventions (release utils, `createDraftDocument` fixture, firefox skipped via `skipIfBrowser`). Task documents live in the addon dataset and are not cleaned up by the test teardown (same as the comments specs); assertions use unique timestamped titles so leftovers can't collide.
- `packages/sanity/src/core/tasks/components/list/TasksListItem.tsx` — adds `data-testid="tasks-list-item"`, the only product change, needed to scope title/checkbox lookups to a single task in the list.

### Testing

- Verified the spec compiles and all 9 test entries (3 tests × 3 browsers) are discovered via `playwright test --list`.
- Not executed locally (no `SANITY_E2E_*` credentials configured in this checkout) — relying on the e2e CI run for this PR.

### Notes for release

N/A – Internal only

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only coverage plus non-functional test IDs; no runtime behavior changes beyond those attributes.
> 
> **Overview**
> Adds Playwright coverage for Tasks where behavior depends on document perspective—something unit tests don’t fully exercise.
> 
> The new **`e2e/tests/tasks/tasks.spec.ts`** suite exercises three flows: creating a task against the active document (Active Document tab + footer “1 open task”), creating a task while viewing a **release version** and asserting it appears only on that version (not on the draft of the same id), and resolving a task via the list checkbox (moves from To Do into Done). Helpers mirror releases e2e patterns (`createDraftDocument`, release utils, Firefox skipped).
> 
> Product changes are minimal **`data-testid`** hooks only: `task-target-field-preview` on the task form target preview (wait for debounced active-document prefill) and `tasks-list-item` on list rows (scoped title/checkbox lookups).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b4713b7cbf5333ef9493d9506bb2f2829854664. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->