### PR TITLE
chore(test-studio): add themer tool plugin

### DIFF
--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -32,6 +32,7 @@
     "@sanity/migrate": "catalog:",
     "@sanity/preview-url-secret": "^4.1.2",
     "@sanity/react-loader": "^2.1.2",
+    "@sanity/themer": "^0.2.0",
     "@sanity/types": "workspace:*",
     "@sanity/ui": "catalog:",
     "@sanity/util": "workspace:*",

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -7,6 +7,7 @@ import {EnvelopeIcon} from '@sanity/icons/Envelope'
 import {MobileDeviceIcon} from '@sanity/icons/MobileDevice'
 import {PresentationIcon} from '@sanity/icons/Presentation'
 import {SanityMonogram} from '@sanity/logos'
+import {themerTool} from '@sanity/themer/tool'
 import {visionTool} from '@sanity/vision'
 import {defineConfig, definePlugin, type WorkspaceOptions} from 'sanity'
 import {unsplashAssetSource, UnsplashIcon} from 'sanity-plugin-asset-source-unsplash'
@@ -243,6 +244,7 @@ const sharedSettings = ({projectId}: {projectId: string}) => {
         // uncomment to test
         //defaultApiVersion: '2025-02-05',
       }),
+      themerTool(),
       routerDebugTool(),
       formBuilderReproTool(),
       errorReportingTestPlugin(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -729,6 +729,9 @@ importers:
       '@sanity/react-loader':
         specifier: ^2.1.2
         version: 2.1.2(@sanity/types@packages+@sanity+types)(react@19.2.8)(typescript@6.0.3)
+      '@sanity/themer':
+        specifier: ^0.2.0
+        version: 0.2.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)
       '@sanity/types':
         specifier: workspace:*
         version: link:../../packages/@sanity/types
@@ -6550,6 +6553,19 @@ packages:
     resolution: {integrity: sha512-pIy9yXosuA2duaJH0J1V8RYrabGB/Jh77FGYozr2pGwmCFwnLw/W/FS99qbcsJZa3wXHSMhMRyYq7IbulbijZw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  '@sanity/themer@0.2.0':
+    resolution: {integrity: sha512-Q+rzoAJfsf2I3VnSuW/PDEtncuBAAckVJDYY6mKXPA7sm2GXkW95AaJgj6WYHdrXczkMgiQymkjJB7ZXsFKLHw==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      react: ^19
+      sanity: ^6
+      styled-components: ^6
+    peerDependenciesMeta:
+      sanity:
+        optional: true
+      styled-components:
+        optional: true
 
   '@sanity/tsdown-config@0.21.1':
     resolution: {integrity: sha512-PtsZegKJ/HIF9jk/bkyYO3XUYzVvX6vQIbXC3fn0YA/EuEcHIe8F5tmJvc8hL+GSYDP3UW8LAL/nYwAtTUznRg==}
@@ -18711,6 +18727,22 @@ snapshots:
       '@actions/core': 3.0.1
       '@actions/github': 9.1.1
       yaml: 2.9.0
+
+  '@sanity/themer@0.2.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.4.4)':
+    dependencies:
+      '@sanity/color': 3.0.8
+      '@sanity/icons': 5.2.1(react@19.2.8)
+      '@sanity/ui': 3.5.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.4.4)
+      react: 19.2.8
+      react-compiler-runtime: 1.0.0(react@19.2.8)
+      react-refractor: 4.0.0(react@19.2.8)
+      refractor: 5.0.0
+    optionalDependencies:
+      sanity: link:packages/sanity
+      styled-components: 6.4.4(react-dom@19.2.8)(react@19.2.8)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - react-dom
 
   '@sanity/tsdown-config@0.21.1(@babel/runtime@7.29.7)(babel-plugin-react-compiler@1.0.0)(rolldown@1.2.0)(supports-color@8.1.1)(tsdown@0.22.14)(typescript@6.0.3)(vite@8.1.5)':
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds the new `@sanity/themer/tool` studio plugin to the test studio so we can exercise live theme preview (presets, accent/text/background pickers, contrast slider) against a real studio config while dogfooding the package.

## What to review

- `dev/test-studio/sanity.config.ts` — `themerTool()` wired into shared settings plugins next to other studio tools
- `dev/test-studio/package.json` / lockfile — `@sanity/themer@^0.2.0` dependency

## Testing

- Pre-commit format/lint passed on the changed files
- Manual: open test studio and confirm the themer sidebar/toggle appears and live-previews theme changes

## Notes for release

N/A – Internal only (dev test studio)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf964621-7f9c-485b-a649-7719f3c54608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf964621-7f9c-485b-a649-7719f3c54608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

