### PR TITLE
fix(deps): update playwright monorepo to v1.62.0

### DIFF
--- a/dev/tsconfig.dev.json
+++ b/dev/tsconfig.dev.json
@@ -1,5 +1,9 @@
 {
-  "extends": "@repo/tsconfig/base.json",
+  // Relative path rather than the `@repo/tsconfig/base.json` package specifier: this file lives in
+  // `dev/`, which is not a workspace package and therefore has no `node_modules` of its own.
+  // Playwright's tsconfig loader only looks for `<tsconfig dir>/node_modules`, so a bare specifier
+  // is unresolvable from here and `playwright test` fails to load configs that extend this file.
+  "extends": "../packages/@repo/tsconfig/base.json",
   "include": ["**/*.ts", "**/*.tsx"],
   "compilerOptions": {
     "rootDir": "..",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ catalogs:
       specifier: ^1.1.1
       version: 1.1.1
     '@playwright/test':
-      specifier: 1.61.1
-      version: 1.61.1
+      specifier: 1.62.0
+      version: 1.62.0
     '@rolldown/plugin-babel':
       specifier: ^0.2.3
       version: 0.2.3
@@ -71,8 +71,8 @@ catalogs:
       specifier: ^29.1.1
       version: 29.1.1
     playwright:
-      specifier: 1.61.1
-      version: 1.61.1
+      specifier: 1.62.0
+      version: 1.62.0
     react:
       specifier: ^19.2.8
       version: 19.2.8
@@ -173,7 +173,7 @@ importers:
         version: 0.0.78
       playwright:
         specifier: 'catalog:'
-        version: 1.61.1
+        version: 1.62.0
       sanity:
         specifier: workspace:*
         version: link:packages/sanity
@@ -290,7 +290,7 @@ importers:
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.61.1
+        version: 1.62.0
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -351,7 +351,7 @@ importers:
         version: 9.4.1
       playwright:
         specifier: 'catalog:'
-        version: 1.61.1
+        version: 1.62.0
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -837,7 +837,7 @@ importers:
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.61.1
+        version: 1.62.0
       '@repo/tsconfig':
         specifier: workspace:*
         version: link:../packages/@repo/tsconfig
@@ -861,7 +861,7 @@ importers:
         version: link:../tsconfig
       '@sanity/ailf':
         specifier: ^7.32.0
-        version: 7.32.0(@aws-sdk/credential-provider-node@3.972.70)(@noble/hashes@2.2.0)(@smithy/signature-v4@5.6.6)(@types/json-schema@7.0.15)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(debug@4.3.4)(pg@8.22.0)(playwright-core@1.61.1)(socks@2.8.9)(supports-color@8.1.1)
+        version: 7.32.0(@aws-sdk/credential-provider-node@3.972.70)(@noble/hashes@2.2.0)(@smithy/signature-v4@5.6.6)(@types/json-schema@7.0.15)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(debug@4.3.4)(pg@8.22.0)(playwright-core@1.62.0)(socks@2.8.9)(supports-color@8.1.1)
       sanity:
         specifier: workspace:*
         version: link:../../sanity
@@ -1949,7 +1949,7 @@ importers:
         version: 6.0.4(@rolldown/plugin-babel@0.2.3)(babel-plugin-react-compiler@1.0.0)(vite@8.1.5)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.10(playwright@1.61.1)(vite@8.1.5)(vitest@4.1.10)
+        version: 4.1.10(playwright@1.62.0)(vite@8.1.5)(vitest@4.1.10)
       '@vitest/expect':
         specifier: ^4.1.10
         version: 4.1.10
@@ -2045,7 +2045,7 @@ importers:
         version: 3.0.8
       playwright:
         specifier: 'catalog:'
-        version: 1.61.1
+        version: 1.62.0
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -2119,7 +2119,7 @@ importers:
     dependencies:
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.61.1
+        version: 1.62.0
       '@sanity/client':
         specifier: 'catalog:'
         version: 7.25.0
@@ -5736,9 +5736,9 @@ packages:
     resolution: {integrity: sha512-t3/zE0i9gik5R/NpRs7G2Xo/6NPeABW6ReplGdtkeWeAkaV764CgFgoKjJo21D2xgjnvDvRYubqBUu4xl0VCqA==}
     engines: {node: '>=18'}
 
-  '@playwright/test@1.61.1':
-    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
-    engines: {node: '>=18'}
+  '@playwright/test@1.62.0':
+    resolution: {integrity: sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==}
+    engines: {node: '>=20'}
     hasBin: true
 
   '@pnpm/config.env-replace@1.1.0':
@@ -11860,6 +11860,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  playwright-core@1.62.0:
+    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   playwright-extra@4.3.6:
     resolution: {integrity: sha512-q2rVtcE8V8K3vPVF1zny4pvwZveHLH8KBuVU2MoE3Jw4OKVoBWsHI9CH9zPydovHHOCDxjGN2Vg+2m644q3ijA==}
     engines: {node: '>=12'}
@@ -11875,6 +11880,11 @@ packages:
   playwright@1.61.1:
     resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.62.0:
+    resolution: {integrity: sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==}
+    engines: {node: '>=20'}
     hasBin: true
 
   pluralize-esm@9.0.5:
@@ -17602,9 +17612,9 @@ snapshots:
       playwright-core: 1.61.1
     optional: true
 
-  '@playwright/test@1.61.1':
+  '@playwright/test@1.62.0':
     dependencies:
-      playwright: 1.61.1
+      playwright: 1.62.0
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -17994,7 +18004,7 @@ snapshots:
 
   '@sanity-labs/design-tokens@0.0.2-alpha.4': {}
 
-  '@sanity/ailf@7.32.0(@aws-sdk/credential-provider-node@3.972.70)(@noble/hashes@2.2.0)(@smithy/signature-v4@5.6.6)(@types/json-schema@7.0.15)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(debug@4.3.4)(pg@8.22.0)(playwright-core@1.61.1)(socks@2.8.9)(supports-color@8.1.1)':
+  '@sanity/ailf@7.32.0(@aws-sdk/credential-provider-node@3.972.70)(@noble/hashes@2.2.0)(@smithy/signature-v4@5.6.6)(@types/json-schema@7.0.15)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(debug@4.3.4)(pg@8.22.0)(playwright-core@1.62.0)(socks@2.8.9)(supports-color@8.1.1)':
     dependencies:
       '@google-cloud/bigquery': 8.3.1(supports-color@8.1.1)
       '@google-cloud/storage': 7.21.0(supports-color@8.1.1)
@@ -18012,7 +18022,7 @@ snapshots:
       jiti: 2.7.0
       js-yaml: 4.3.0
       oxc-parser: 0.129.0
-      promptfoo: 0.120.27(@aws-sdk/credential-provider-node@3.972.70)(@noble/hashes@2.2.0)(@smithy/signature-v4@5.6.6)(@types/json-schema@7.0.15)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(debug@4.3.4)(pg@8.22.0)(playwright-core@1.61.1)(socks@2.8.9)(supports-color@8.1.1)
+      promptfoo: 0.120.27(@aws-sdk/credential-provider-node@3.972.70)(@noble/hashes@2.2.0)(@smithy/signature-v4@5.6.6)(@types/json-schema@7.0.15)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(debug@4.3.4)(pg@8.22.0)(playwright-core@1.62.0)(socks@2.8.9)(supports-color@8.1.1)
       zod: 4.4.3
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
@@ -20212,11 +20222,11 @@ snapshots:
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5)
       babel-plugin-react-compiler: 1.0.0
 
-  '@vitest/browser-playwright@4.1.10(playwright@1.61.1)(vite@8.1.5)(vitest@4.1.10)':
+  '@vitest/browser-playwright@4.1.10(playwright@1.62.0)(vite@8.1.5)(vitest@4.1.10)':
     dependencies:
       '@vitest/browser': 4.1.10(vite@8.1.5)(vitest@4.1.10)
       '@vitest/mocker': 4.1.10(vite@8.1.5)
-      playwright: 1.61.1
+      playwright: 1.62.0
       tinyrainbow: 3.1.0
       vitest: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.5)
     transitivePeerDependencies:
@@ -24469,14 +24479,17 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  playwright-core@1.61.1: {}
+  playwright-core@1.61.1:
+    optional: true
 
-  playwright-extra@4.3.6(playwright-core@1.61.1)(playwright@1.61.1)(supports-color@8.1.1):
+  playwright-core@1.62.0: {}
+
+  playwright-extra@4.3.6(playwright-core@1.62.0)(playwright@1.61.1)(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     optionalDependencies:
       playwright: 1.61.1
-      playwright-core: 1.61.1
+      playwright-core: 1.62.0
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -24484,6 +24497,13 @@ snapshots:
   playwright@1.61.1:
     dependencies:
       playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    optional: true
+
+  playwright@1.62.0:
+    dependencies:
+      playwright-core: 1.62.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -24568,7 +24588,7 @@ snapshots:
 
   promisepipe@3.0.0: {}
 
-  promptfoo@0.120.27(@aws-sdk/credential-provider-node@3.972.70)(@noble/hashes@2.2.0)(@smithy/signature-v4@5.6.6)(@types/json-schema@7.0.15)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(debug@4.3.4)(pg@8.22.0)(playwright-core@1.61.1)(socks@2.8.9)(supports-color@8.1.1):
+  promptfoo@0.120.27(@aws-sdk/credential-provider-node@3.972.70)(@noble/hashes@2.2.0)(@smithy/signature-v4@5.6.6)(@types/json-schema@7.0.15)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(debug@4.3.4)(pg@8.22.0)(playwright-core@1.62.0)(socks@2.8.9)(supports-color@8.1.1):
     dependencies:
       '@anthropic-ai/sdk': 0.78.0(zod@4.4.3)
       '@apidevtools/json-schema-ref-parser': 15.5.0(@types/json-schema@7.0.15)
@@ -24688,7 +24708,7 @@ snapshots:
       node-sql-parser: 5.4.0
       pdf-parse: 2.4.5
       playwright: 1.61.1
-      playwright-extra: 4.3.6(playwright-core@1.61.1)(playwright@1.61.1)(supports-color@8.1.1)
+      playwright-extra: 4.3.6(playwright-core@1.62.0)(playwright@1.61.1)(supports-color@8.1.1)
       puppeteer-extra-plugin-stealth: 2.11.2(playwright-extra@4.3.6)(supports-color@8.1.1)
       read-excel-file: 7.0.3
       sharp: 0.34.5
@@ -24853,7 +24873,7 @@ snapshots:
       puppeteer-extra-plugin: 3.2.3(playwright-extra@4.3.6)(supports-color@8.1.1)
       puppeteer-extra-plugin-user-preferences: 2.4.1(playwright-extra@4.3.6)(supports-color@8.1.1)
     optionalDependencies:
-      playwright-extra: 4.3.6(playwright-core@1.61.1)(playwright@1.61.1)(supports-color@8.1.1)
+      playwright-extra: 4.3.6(playwright-core@1.62.0)(playwright@1.61.1)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -24865,7 +24885,7 @@ snapshots:
       puppeteer-extra-plugin: 3.2.3(playwright-extra@4.3.6)(supports-color@8.1.1)
       rimraf: 3.0.2
     optionalDependencies:
-      playwright-extra: 4.3.6(playwright-core@1.61.1)(playwright@1.61.1)(supports-color@8.1.1)
+      playwright-extra: 4.3.6(playwright-core@1.62.0)(playwright@1.61.1)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -24877,7 +24897,7 @@ snapshots:
       puppeteer-extra-plugin: 3.2.3(playwright-extra@4.3.6)(supports-color@8.1.1)
       puppeteer-extra-plugin-user-data-dir: 2.4.1(playwright-extra@4.3.6)(supports-color@8.1.1)
     optionalDependencies:
-      playwright-extra: 4.3.6(playwright-core@1.61.1)(playwright@1.61.1)(supports-color@8.1.1)
+      playwright-extra: 4.3.6(playwright-core@1.62.0)(playwright@1.61.1)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -24888,7 +24908,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       merge-deep: 3.0.3
     optionalDependencies:
-      playwright-extra: 4.3.6(playwright-core@1.61.1)(playwright@1.61.1)(supports-color@8.1.1)
+      playwright-extra: 4.3.6(playwright-core@1.62.0)(playwright@1.61.1)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -26638,7 +26658,7 @@ snapshots:
       '@edge-runtime/vm': 3.2.0
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.13.3
-      '@vitest/browser-playwright': 4.1.10(playwright@1.61.1)(vite@8.1.5)(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.0)(vite@8.1.5)(vitest@4.1.10)
       '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ allowBuilds:
 catalog:
   '@optique/core': ^1.1.1
   '@optique/run': ^1.1.1
-  '@playwright/test': 1.61.1
+  '@playwright/test': 1.62.0
   '@rolldown/plugin-babel': ^0.2.3
   '@sanity/client': ^7.25.0
   '@sanity/migrate': ^8.0.1
@@ -43,7 +43,7 @@ catalog:
   '@vitest/browser-playwright': ^4.1.10
   babel-plugin-react-compiler: ^1.0.0
   jsdom: ^29.1.1
-  playwright: 1.61.1
+  playwright: 1.62.0
   react: ^19.2.8
   react-dom: ^19.2.8
   react-is: ^19.2.8


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the `@playwright/test` and `playwright` catalog entries from `1.61.1` to `1.62.0`, and fixes the one repo-side breakage that came with it.

This replaces the Renovate PR #13750, which failed the `e2e-embedded` workflow.

## Description

Playwright 1.62.0 changed its tsconfig loader: an unresolvable `extends` path is now a hard error instead of being silently ignored ([`resolveConfigFile`](https://github.com/microsoft/playwright/blob/v1.62.0/packages/playwright/src/transform/tsconfig-loader.ts) now throws).

That broke `playwright test` in `dev/e2e-embedded-studio-vite`:

```
Error: Failed to load tsconfig file at dev/e2e-embedded-studio-vite/tsconfig.json:
Failed to resolve "extends" path "@repo/tsconfig/base.json" referenced from dev/tsconfig.dev.json
```

The chain is `dev/e2e-embedded-studio-vite/tsconfig.json` → `dev/tsconfig.dev.json` → `@repo/tsconfig/base.json`. Playwright resolves a bare specifier by checking only `<tsconfig dir>/node_modules` — it does not walk up the directory tree the way TypeScript does. `dev/` is not a workspace package, so it has no `node_modules`, and the specifier is unresolvable from there. Under 1.61.1 the same lookup failed but was swallowed, so the base config was silently dropped.

Fix: `dev/tsconfig.dev.json` now extends `../packages/@repo/tsconfig/base.json` by path. This resolves for Playwright, TypeScript, and oxlint alike. Every other `@repo/tsconfig` consumer is a real workspace package with the dependency linked into its own `node_modules`, so they are unaffected.

Note that the E2E test failures on #13750 were unrelated infrastructure flakes — `dataset-setup` hit a `429 API rate limit exceeded` from the staging API, so the per-PR dataset was never created and every shard died with `Dataset not found`. The same failure shows up on unrelated branches.

## What to review

- `pnpm-workspace.yaml` — catalog bump for both packages.
- `dev/tsconfig.dev.json` — the `extends` change and whether the relative path is preferred over adding `@repo/tsconfig` plumbing to `dev/`.
- `pnpm-lock.yaml` — regenerated.

## Testing

- `playwright test --list` in `dev/e2e-embedded-studio-vite` fails on 1.62.0 before the tsconfig fix and passes after it.
- `playwright test --list` in `e2e` loads its config and all spec files with no tsconfig error.
- Unit tests and the vitest browser-mode suite (which drives Playwright 1.62.0 against real Chromium) pass locally.

## Notes for release

Internal tooling only; no runtime or published-package changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bf68bd9-8007-403c-b578-968d0cf3a24b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bf68bd9-8007-403c-b578-968d0cf3a24b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

