### PR TITLE
perf(core): memoize document presence observable in useDocumentPresence

### DIFF
--- a/packages/sanity/src/core/store/presence/useDocumentPresence.test.tsx
+++ b/packages/sanity/src/core/store/presence/useDocumentPresence.test.tsx
@@ -1,0 +1,58 @@
+import {renderHook} from '@testing-library/react'
+import {of} from 'rxjs'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import {usePresenceStore} from '../datastores'
+import {type PresenceStore} from './presence-store'
+import {useDocumentPresence} from './useDocumentPresence'
+
+vi.mock('../datastores', () => ({
+  usePresenceStore: vi.fn(),
+}))
+
+const mockedUsePresenceStore = vi.mocked(usePresenceStore)
+
+function createMockPresenceStore(): PresenceStore {
+  return {
+    documentPresence: vi.fn(() => of([])),
+    globalPresence$: of([]),
+    reportLocations: vi.fn(() => of(undefined)),
+    setLocation: vi.fn(),
+    debugPresenceParam$: of([]),
+  }
+}
+
+describe('useDocumentPresence', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates the presence observable once across re-renders for a stable document id', () => {
+    const presenceStore = createMockPresenceStore()
+    mockedUsePresenceStore.mockReturnValue(presenceStore)
+
+    const {rerender} = renderHook(() => useDocumentPresence('doc-1'))
+
+    rerender()
+    rerender()
+    rerender()
+
+    expect(presenceStore.documentPresence).toHaveBeenCalledTimes(1)
+    expect(presenceStore.documentPresence).toHaveBeenCalledWith('doc-1')
+  })
+
+  it('recreates the presence observable when the document id changes', () => {
+    const presenceStore = createMockPresenceStore()
+    mockedUsePresenceStore.mockReturnValue(presenceStore)
+
+    const {rerender} = renderHook(({documentId}) => useDocumentPresence(documentId), {
+      initialProps: {documentId: 'doc-1'},
+    })
+
+    rerender({documentId: 'doc-2'})
+
+    expect(presenceStore.documentPresence).toHaveBeenCalledTimes(2)
+    expect(presenceStore.documentPresence).toHaveBeenNthCalledWith(1, 'doc-1')
+    expect(presenceStore.documentPresence).toHaveBeenNthCalledWith(2, 'doc-2')
+  })
+})

--- a/packages/sanity/src/core/store/presence/useDocumentPresence.tsx
+++ b/packages/sanity/src/core/store/presence/useDocumentPresence.tsx
@@ -1,4 +1,4 @@
-import {startTransition, useEffect, useReducer} from 'react'
+import {startTransition, useEffect, useMemo, useReducer} from 'react'
 import {useObservable} from 'react-rx'
 import {of} from 'rxjs'
 
@@ -15,5 +15,9 @@ export function useDocumentPresence(documentId: string): DocumentPresence[] {
   useEffect(() => startTransition(mount), [])
 
   const presenceStore = usePresenceStore()
-  return useObservable(mounted ? presenceStore.documentPresence(documentId) : fallback, initial)
+  const presence$ = useMemo(
+    () => (mounted ? presenceStore.documentPresence(documentId) : fallback),
+    [mounted, presenceStore, documentId],
+  )
+  return useObservable(presence$, initial)
 }


### PR DESCRIPTION
### Description

`useDocumentPresence` called `presenceStore.documentPresence(documentId)` inline in its `useObservable` argument. `documentPresence` returns a fresh `.pipe(map, distinctUntilChanged(isEqual))` observable on every call, and react-rx's `useObservable` caches by observable reference. So every render of a presence-bearing list row (`SearchResultItem`, `ReferencePreview`, `PaneItem`) handed `useObservable` a new reference, forcing a prime-subscribe during render plus a teardown/resubscribe on commit, re-running the map and deep-equal pipe each time. The upstream `allDocumentsPresence$` is `shareReplay(1)`, so this is CPU-only (no connection churn), but it lands on hot paths during search typing and list re-renders. From the SAPP-3745 useEffect audit (SAPP-4076).

This PR memoizes the observable with `useMemo` keyed on `[mounted, presenceStore, documentId]`, giving `useObservable` a stable reference across renders. This mirrors the sibling `useGlobalPresence`, which is already churn-free because it passes the stable `presenceStore.globalPresence$` property.

### What to review

- `useDocumentPresence.tsx` - the `useMemo` deps: it recreates the observable only when the store or document id changes, and the `fallback` behaviour before mount is preserved unchanged.
- `useDocumentPresence.test.tsx` - a regression guard asserting `documentPresence` is invoked once across re-renders for a stable id, and re-invoked when the id changes.

### Testing

Added a unit regression test that fails against the old inline-call code (factory called per render) and passes with the memo.

Also ran a live A/B validation in a dev studio on the `SearchResultItem` presence hot path (global search), toggling the memo on and off via Vite HMR and running the same character-by-character typing burst over four queries under identical conditions. Two metrics were instrumented: `documentPresence` factory calls and observable subscriptions per render (bucketed by document id), and main-thread blocking from Long Animation Frame entries under 4x CPU throttle. Dev StrictMode inflates both sides equally, so the fixed-vs-inline comparison is the verdict.

Subscribe/render count (primary, low-noise), for the two queries that produced an identical 130 renders under both variants:

| per 130 renders (13 rows) | memoized | inline | delta |
| --- | --- | --- | --- |
| `documentPresence` factory calls | 26 | 78 | -67% |
| observable subscriptions | 52 | 91 | -43% |

With the memo the factory runs exactly twice per row (2 x 13 = 26); inline it scales with render count.

CPU blocking (secondary, noisier): total LoAF blocking across the four bursts fell from 2007 ms to 1281 ms under 4x throttle (-36%), and every query showed lower blocking with the memo. Presence avatars resolved correctly throughout.

### Notes for release

N/A

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized hook performance fix with behavior preserved (including pre-mount fallback); covered by new unit tests.
> 
> **Overview**
> **`useDocumentPresence`** now wraps the per-document presence stream in **`useMemo`** (`mounted`, `presenceStore`, `documentId`) before passing it to **`useObservable`**, so list/search rows don’t get a new observable reference every render and avoid extra subscribe/teardown and pipe work on hot paths.
> 
> Adds **`useDocumentPresence.test.tsx`** to assert **`documentPresence`** is called once across re-renders for a stable id and again when the id changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1d4f7dc1d3d2e0b057de6b39b596f269e5d87a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->