### PR TITLE
perf(presentation): cache container rect during panel resize drags

### DIFF
--- a/packages/sanity/src/presentation/panels/Panels.tsx
+++ b/packages/sanity/src/presentation/panels/Panels.tsx
@@ -88,7 +88,7 @@ export const Panels: FunctionComponent<PropsWithChildren> = function ({children}
 
   const dragRef = useRef<InitialDragState>({
     containerRect: null,
-    containerWidth: window.innerWidth,
+    windowWidth: window.innerWidth,
     dragOffset: 0,
     panelAfter: null,
     panelBefore: null,
@@ -119,7 +119,7 @@ export const Panels: FunctionComponent<PropsWithChildren> = function ({children}
           null as PanelElement | null,
         ),
         containerRect: getContainerRect(panelsEl.current),
-        containerWidth: window.innerWidth,
+        windowWidth: window.innerWidth,
         startX: event.pageX,
         dragOffset: getOffset(event, resizeElement),
         resizerRect: resizeElement.getBoundingClientRect(),
@@ -140,7 +140,7 @@ export const Panels: FunctionComponent<PropsWithChildren> = function ({children}
       event.preventDefault()
       event.stopPropagation()
 
-      const {containerRect, containerWidth, dragOffset, panelBefore, panelAfter, resizerRect} =
+      const {containerRect, windowWidth, dragOffset, panelBefore, panelAfter, resizerRect} =
         dragRef.current
 
       if (panelBefore == null || panelAfter == null) {
@@ -160,13 +160,13 @@ export const Panels: FunctionComponent<PropsWithChildren> = function ({children}
 
       const {widths: prevWidths} = panelsRef.current
       // Use the drag-start cached width to avoid a forced synchronous reflow per mousemove.
-      const containerWidthPx = containerRect?.width ?? getContainerRect(panelsEl.current)?.width
+      const containerWidthPx = containerRect?.width
       if (!containerWidthPx) return
       const delta = (offset / containerWidthPx) * 100
 
       const nextWidths = getNextWidths(
         delta,
-        containerWidth,
+        windowWidth,
         panelBefore,
         panelAfter,
         panelsRef.current,
@@ -220,7 +220,7 @@ export const Panels: FunctionComponent<PropsWithChildren> = function ({children}
 
   useLayoutEffect(() => {
     const resizeObserver = new ResizeObserver(() => {
-      // Refresh the drag's cached rect on a mid-drag window resize (cheap: post-layout, no reflow).
+      // Keep the drag's cached rect in sync when the container resizes (cheap: post-layout, no reflow).
       dragRef.current.containerRect = getContainerRect(panelsEl.current)
 
       const {panels, widths: prevWidths} = panelsRef.current

--- a/packages/sanity/src/presentation/panels/Panels.tsx
+++ b/packages/sanity/src/presentation/panels/Panels.tsx
@@ -24,6 +24,7 @@ import {
 } from './types'
 import {usePanelsStorage} from './usePanelsStorage'
 import {
+  getContainerRect,
   getDefaultWidths,
   getNextWidths,
   getOffset,
@@ -86,6 +87,7 @@ export const Panels: FunctionComponent<PropsWithChildren> = function ({children}
   }, [])
 
   const dragRef = useRef<InitialDragState>({
+    containerRect: null,
     containerWidth: window.innerWidth,
     dragOffset: 0,
     panelAfter: null,
@@ -116,6 +118,7 @@ export const Panels: FunctionComponent<PropsWithChildren> = function ({children}
           (acc, el, i) => (acc === null && isPanel(el) && i > index ? el : acc),
           null as PanelElement | null,
         ),
+        containerRect: getContainerRect(panelsEl.current),
         containerWidth: window.innerWidth,
         startX: event.pageX,
         dragOffset: getOffset(event, resizeElement),
@@ -137,7 +140,8 @@ export const Panels: FunctionComponent<PropsWithChildren> = function ({children}
       event.preventDefault()
       event.stopPropagation()
 
-      const {containerWidth, dragOffset, panelBefore, panelAfter, resizerRect} = dragRef.current
+      const {containerRect, containerWidth, dragOffset, panelBefore, panelAfter, resizerRect} =
+        dragRef.current
 
       if (panelBefore == null || panelAfter == null) {
         return
@@ -155,8 +159,10 @@ export const Panels: FunctionComponent<PropsWithChildren> = function ({children}
       }
 
       const {widths: prevWidths} = panelsRef.current
-      const rect = panelsEl.current!.getBoundingClientRect()
-      const delta = (offset / rect.width) * 100
+      // Use the drag-start cached width to avoid a forced synchronous reflow per mousemove.
+      const containerWidthPx = containerRect?.width ?? getContainerRect(panelsEl.current)?.width
+      if (!containerWidthPx) return
+      const delta = (offset / containerWidthPx) * 100
 
       const nextWidths = getNextWidths(
         delta,
@@ -214,6 +220,9 @@ export const Panels: FunctionComponent<PropsWithChildren> = function ({children}
 
   useLayoutEffect(() => {
     const resizeObserver = new ResizeObserver(() => {
+      // Refresh the drag's cached rect on a mid-drag window resize (cheap: post-layout, no reflow).
+      dragRef.current.containerRect = getContainerRect(panelsEl.current)
+
       const {panels, widths: prevWidths} = panelsRef.current
 
       const nextWidths = validateWidths(panels, prevWidths, window.innerWidth)

--- a/packages/sanity/src/presentation/panels/types.ts
+++ b/packages/sanity/src/presentation/panels/types.ts
@@ -25,6 +25,7 @@ export interface PanelsState {
 }
 
 export interface InitialDragState {
+  containerRect: DOMRect | null
   containerWidth: number
   panelAfter: PanelElement | null
   panelBefore: PanelElement | null

--- a/packages/sanity/src/presentation/panels/types.ts
+++ b/packages/sanity/src/presentation/panels/types.ts
@@ -26,7 +26,7 @@ export interface PanelsState {
 
 export interface InitialDragState {
   containerRect: DOMRect | null
-  containerWidth: number
+  windowWidth: number
   panelAfter: PanelElement | null
   panelBefore: PanelElement | null
   resizerIndex: number

--- a/packages/sanity/src/presentation/panels/util.ts
+++ b/packages/sanity/src/presentation/panels/util.ts
@@ -94,6 +94,10 @@ export function getPanelWidth(panels: PanelElement[], id: string, widths: number
   return width.toPrecision(10)
 }
 
+export function getContainerRect(containerElement: HTMLDivElement | null): DOMRect | null {
+  return containerElement?.getBoundingClientRect() ?? null
+}
+
 export function getOffset(
   event: MouseEvent,
   handleElement: HTMLDivElement,


### PR DESCRIPTION
### Description

Dragging the Presentation tool's panel divider forced a synchronous layout reflow on every mousemove. The per-move `drag` callback read `getBoundingClientRect()` on the panels container to derive its width, and because the previous move had already committed new `flexGrow` styles, layout was dirty at each read - so every mousemove triggered a full synchronous layout flush for the duration of the drag. Fixes [SAPP-4075](https://linear.app/sanity/issue/SAPP-4075).

This PR caches the container's rect into `dragRef` at drag start and reads the cached width during the drag. The container's own width is invariant during a drag (the wrapper is `width: 100%` and dragging only redistributes `flexGrow` among its children), and the existing `ResizeObserver` refreshes the cached rect if the window is resized mid-drag.

### What to review

- `Panels.tsx` `drag`: reads the cached `containerRect.width` and bails out of the move if it is zero or missing.
- `Panels.tsx` `ResizeObserver`: also refreshes the cached rect so a mid-drag window resize stays correct.
- `dragRef` state: the field holding `window.innerWidth` is named `windowWidth`, distinct from the container's own `containerRect.width` used to derive the drag delta; `getNextWidths` still takes it for min/max clamping.
- `getContainerRect` in `util.ts`: the shared helper both call sites use.

### Testing

Measured before/after on the live Presentation tool with a continuous ~5s, 100-move divider drag: forced container reflows dropped from 200 to 0, and accumulated long-task blocking from 4576ms to 1108ms. Verified manually that the drag stays smooth, min-width clamping still holds, and resizing the window mid-drag still behaves. No automated test added - there is no existing harness for the drag mechanics and the Presentation tool is not in the bench studio.

### Notes for release

N/A

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized performance change to Presentation panel drag math with the same clamping behavior; low risk aside from edge cases if cached width were stale without the ResizeObserver refresh.
> 
> **Overview**
> **Fixes janky Presentation panel divider drags** by stopping per-`mousemove` layout reads on the panels container.
> 
> During a drag, the delta is now computed from a **`containerRect` cached at drag start** (via new `getContainerRect`) instead of calling `getBoundingClientRect()` on every move after `flexGrow` updates. `InitialDragState` splits the old single width into **`containerRect`** (for percentage delta) and **`windowWidth`** (still passed to `getNextWidths` for min/max clamping). The existing **`ResizeObserver`** also refreshes the cached rect so mid-drag window/container resize stays correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e13a68e41888d9d482270ff80f8702d01f9731e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->