### PR TITLE
docs(agents): adopt useful patterns from plugins AGENTS.md

### DIFF
--- a/.agents/skills/pr-description/SKILL.md
+++ b/.agents/skills/pr-description/SKILL.md
@@ -7,7 +7,7 @@ description: Write PR descriptions and release notes for the Sanity monorepo. Fo
 
 ## When creating a PR
 
-Follow the repo's PR template. Always create PRs as **drafts**.
+Follow the repo's PR template. Always create PRs as **drafts**. **All AI-agent PRs must include the `🤖 bot` label.**
 
 ### 1. Analyze the changes
 
@@ -88,10 +88,10 @@ This section is used by the docs team to write release notes.
 
 ### 4. Create the PR
 
-**Always create as draft.** Do not mark as ready for review until CI passes.
+**Always create as draft** and apply the `🤖 bot` label. Do not mark as ready for review until CI passes and the prompter approves.
 
 ```bash
-gh pr create --draft --title "type(scope): description" --body "$(cat <<'EOF'
+gh pr create --draft --label "🤖 bot" --title "type(scope): description" --body "$(cat <<'EOF'
 ### Description
 
 [what and why]
@@ -113,7 +113,13 @@ EOF
 )"
 ```
 
-After CI is green, mark ready for review:
+If the label was omitted at create time:
+
+```bash
+gh pr edit --add-label "🤖 bot"
+```
+
+After CI is green and the prompter approves, mark ready for review:
 
 ```bash
 gh pr ready

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 This document helps AI agents work successfully with the Sanity monorepo.
 
+> **Self-Improvement:** If you discover undocumented requirements, commands, or workflows during your work (e.g., a reviewer asks you to run something not covered here), update this file on the same PR. Keep this guide accurate and helpful for future agents.
+
 ## Prerequisites
 
 - **Node.js**: v24 or latest LTS
@@ -263,6 +265,20 @@ pnpm lint:fix          # Auto-fix issues (oxfmt + oxlint --fix)
 
 All packages use **ESM** (`"type": "module"`). TypeScript strict mode is enabled.
 
+### Dependencies
+
+**Always use `lodash-es` instead of `lodash`**
+
+Prefer per-function ESM imports so unused helpers can tree-shake:
+
+```ts
+import get from 'lodash-es/get.js'
+```
+
+**Prefer `date-fns` subpath imports**
+
+Import from subpaths (e.g. `date-fns/format`), not the package barrel.
+
 ## Testing
 
 ### Unit Tests (Vitest)
@@ -278,6 +294,22 @@ Tests require a build first because some tests use compiled output:
 
 ```bash
 pnpm build && pnpm test
+```
+
+#### Test Timeouts
+
+When a test needs a custom timeout, use the Vitest options object as the second argument (not the deprecated third-argument form). Prefer numeric separators for readability:
+
+```ts
+// Correct
+test('my test', {timeout: 30_000}, async () => {
+  // ...
+})
+
+// Wrong — timeout as third argument (deprecated)
+test('my test', async () => {
+  // ...
+}, 30000)
 ```
 
 #### Vanilla-extract in jsdom tests
@@ -395,19 +427,71 @@ added new feature                       # missing type and scope
 
 ## Pull Request Workflow
 
-**Always create PRs as drafts first.**
+### 1. Create as Draft PR First
+
+**Always create PRs as drafts first.** The prompter (person who requested the work) reviews before the broader team.
 
 ```bash
 # Create a draft PR — title MUST follow conventional commit format
-gh pr create --draft --title "fix(scope): description" --body "..."
+gh pr create --draft --title "fix(scope): description" --body "..." --label "🤖 bot"
 ```
 
-Workflow:
+### 2. Apply the "🤖 bot" Label
 
-1. **Agent creates draft PR** - Push changes and open as draft
-2. **Prompter reviews** - The person who requested the changes reviews the draft
-3. **Mark ready for review** - Once the prompter approves, mark PR as ready: `gh pr ready`
-4. **Team reviews** - Team members review and approve
+**All PRs created by AI agents must be labeled with `🤖 bot`.** This label already exists on the repo and helps the team identify agent-created PRs for tracking and review workflows.
+
+When creating or updating a PR, always ensure the label is applied. If the create command did not accept `--label`, add it afterward:
+
+```bash
+gh pr edit --add-label "🤖 bot"
+```
+
+### 3. Move Out of Draft
+
+Once the prompter approves and CI is green, convert from draft to ready-for-review:
+
+```bash
+gh pr ready
+```
+
+### 4. What Not To Touch Unless Asked
+
+- **`.github/CODEOWNERS`** — do not add or change ownership rules unless explicitly requested
+- **Release automation / version bumps** — versioning is driven by conventional commits on merge; do not open manual version PRs unless asked
+
+### Useful PR Labels
+
+| Label                | When to use                                                                          |
+| -------------------- | ------------------------------------------------------------------------------------ |
+| `🤖 bot`             | **Required** on every AI-agent PR                                                    |
+| `trigger: preview`   | Publishes preview packages via [`pkg.pr.new`](https://pkg.pr.new) (maintainer-gated) |
+| `trigger:perf-bench` | Runs the `perf/bench` suite on the PR (maintainer-gated)                             |
+| `full-test-suite`    | Forces the full unit test suite to run                                               |
+
+Do **not** apply `trigger:*` labels unless the prompter or a maintainer asks — they kick off expensive or publish workflows.
+
+### Crediting Original Authors (Ported / Cherry-picked Work)
+
+When porting or rebasing someone else's PR (community contribution, backport, etc.), credit the **original author**, not only the agent or whoever opens the port PR:
+
+1. Prefer commits authored as the original contributor when history allows:
+
+   ```bash
+   git commit --author="their-name <their-github-email>" -m "..."
+   ```
+
+2. Otherwise add a `Co-authored-by:` trailer (and mention them in the PR description / Notes for release):
+
+   ```
+   Co-authored-by: Their Name <their-github-noreply@users.noreply.github.com>
+   ```
+
+Workflow summary:
+
+1. **Agent creates draft PR** with the `🤖 bot` label
+2. **Prompter reviews** the draft
+3. **Mark ready for review** once the prompter approves
+4. **Team reviews** and merges
 
 This ensures the person who prompted the changes can verify correctness before involving the broader team.
 
@@ -470,6 +554,17 @@ See `turbo.json` for full list of environment variables that affect builds.
 ## Cursor Cloud specific instructions
 
 These notes cover non-obvious gotchas for running in the Cursor Cloud VM. The startup update script already runs `pnpm install`.
+
+### Services
+
+| Service                                           | Port | Purpose                                          |
+| ------------------------------------------------- | ---- | ------------------------------------------------ |
+| Test studio (`pnpm dev` / `pnpm dev:test-studio`) | 3333 | Local Sanity Studio for manual verification      |
+| Preview iframe (`pnpm dev:preview-iframe`)        | 3334 | Cross-origin Presentation preview (vanilla Vite) |
+
+No Docker, databases, or other local services are required for unit tests, lint, or build. CI-style verification (`pnpm lint`, `pnpm build`, `pnpm test`) runs entirely in-process.
+
+### Gotchas
 
 - **Root `typescript` is TypeScript 7.** Catalog `typescript` (^7) is a normal root dependency and provides the native `tsc` binary for vitest typecheck (`*.test-d.*`) and for tsdown `dts: {tsgo: true}` (packages also declare catalog `typescript`). CI type checking of application code is owned by oxlint (`options.typeCheck`). Tools that still need the TypeScript 6 compiler API keep that isolated: `@repo/typedoc` (typedoc) and `@repo/test-dts-exports` (ts-morph) depend on `typescript` aliased to `@typescript/typescript6`. The old symlink workaround for a missing root `tsc` is no longer needed.
 - **Dev studio auth for cloud agents — use the `STUDIO_AUTH_TOKEN` secret, not interactive login.** `pnpm dev` runs `sanity dev --no-auto-updates` (non-interactive, no upgrade prompt) and serves the app at `http://localhost:3333`. The test studio connects to Sanity Cloud (project `ppsg7ml5`); its default workspace is `/test`. Without auth the workspaces show "Signed out" / "Choose login provider". To authenticate, put the injected `STUDIO_AUTH_TOKEN` in the URL hash — Sanity consumes it on load and strips it from the address bar:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,19 +265,19 @@ pnpm lint:fix          # Auto-fix issues (oxfmt + oxlint --fix)
 
 All packages use **ESM** (`"type": "module"`). TypeScript strict mode is enabled.
 
-### Dependencies
+Rules that the linter already enforces (restricted imports, type-aware rules, React Compiler rules, i18n rules, module boundaries) are not repeated in this guide — run `pnpm lint` and follow the reported messages, which explain the expected pattern.
 
-**Always use `lodash-es` instead of `lodash`**
+### Do Not Weaken the Linter
 
-Prefer per-function ESM imports so unused helpers can tree-shake:
+Fix the reported problem instead of silencing it. In order of preference:
 
-```ts
-import get from 'lodash-es/get.js'
-```
+1. **Fix the code** so the rule passes. This is almost always the right answer.
+2. **Suppress the single line** as a last resort, when the rule is genuinely wrong for that one spot: `// oxlint-disable-next-line <rule> -- <why>`. Always name the specific rule and explain the exception after `--`. Never suppress a rule merely to make CI green.
+3. **Change `.oxlintrc.json` only when a human explicitly asks.** Do not turn rules off, downgrade severity, add `overrides` entries, or widen `ignorePatterns` on your own initiative — an override silences the rule for every current and future file it matches. If you think a rule is wrong, leave it failing and raise it in your summary or the PR description.
 
-**Prefer `date-fns` subpath imports**
+File-wide `/* oxlint-disable <rule> */` is reserved for files that are an exception as a whole — vendored code, the `packages/sanity/src/ui-components` wrappers around raw `@sanity/ui`, CLI scripts that print to `console`. Follow that existing precedent rather than reaching for it to clear a handful of errors.
 
-Import from subpaths (e.g. `date-fns/format`), not the package barrel.
+`options.reportUnusedDisableDirectives` is `error`, so a suppression that stops being necessary fails CI — drop suppressions when the code underneath them changes.
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Want to file an issue? [Jump to _How to file an issue_ ⏬](#how-to-file-an-issu
 
 Contributions are always welcome, no matter how large or small.
 
+> **For AI Agents:** See [AGENTS.md](./AGENTS.md) for agent-specific instructions, quick-reference commands, PR labeling (`🤖 bot`), and Cursor Cloud gotchas.
+
 ## Getting started
 
 Before contributing, please read our [code of conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The plugins monorepo has a few agent-workflow habits this repo lacked, even though the `🤖 bot` label already exists here. This ports the transferable ones into `AGENTS.md` (and mirrors them in the PR description skill / CONTRIBUTING pointer) so agent PRs are easier to spot and agents avoid common footguns.

`AGENTS.md` deliberately does not restate anything oxlint already enforces — the linter's messages are better placed and can't drift. What agents *can't* learn from a lint message is the policy around silencing it, so the guide now says suppressions are a last resort and that `.oxlintrc.json` rules/overrides only change when a human asks.

Alternatives considered: copying plugins' changeset/`knip`/plugin-transfer guidance wholesale — skipped because this monorepo uses conventional commits + lerna-lite and different CI tooling.

Rebased onto latest `main`: kept the new Services/Gotchas structure and preserved main's TypeScript 7 `tsc` guidance (replacing the outdated symlink note).

### What to review

- `Do Not Weaken the Linter` — the escalation order and the carve-out for legitimate file-wide disables (`ui-components` wrappers, vendored code, CLI scripts)
- PR workflow: required `🤖 bot` label, maintainer-gated `trigger:*` labels, CODEOWNERS hands-off rule
- Ported-PR author credit via `--author` / `Co-authored-by` (adapted from plugins' changeset `author:` lines)
- Cursor Cloud services table

### Testing

Documentation only, but the claims in the new lint section were verified against the real config with a temporary probe file under `packages/sanity/src/core` (deleted afterwards):

```
$ pnpm exec oxlint --disable-nested-config packages/sanity/src/core/scratchLintProbe.ts
scratchLintProbe.ts:1:1: error eslint(no-restricted-imports): 'date-fns' import is restricted from being used. help: Import from individual modules instead, e.g. `import {startOfDay} from 'date-fns/startOfDay'`. Barrel imports are ~50% slower.
scratchLintProbe.ts:2:1: error eslint(no-restricted-imports): 'lodash-es' import is restricted from being used. help: Import from individual modules instead, e.g. `import debounce from 'lodash-es/debounce.js'`. Barrel imports are ~55% slower.
scratchLintProbe.ts:4:1: error: Unused oxlint-disable directive (no problems were reported).
```

That confirms the removed guidance is redundant (oxlint reports both barrel imports with the same advice), and that `reportUnusedDisableDirectives` fails stale suppressions. A follow-up run with the documented `// oxlint-disable-next-line <rule> -- <why>` form exited 0.

`pnpm check:format` passes.

### Notes for release

N/A – Internal only

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4132a053-deda-48f5-b9cf-201ed2ce7d2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4132a053-deda-48f5-b9cf-201ed2ce7d2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

