### PR TITLE
fix(sanity): download asset in new browsing context

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/common/ActionsMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/common/ActionsMenu.tsx
@@ -48,6 +48,7 @@ export function ActionsMenu(props: Props) {
           icon={DownloadIcon}
           text={t('inputs.files.common.actions-menu.download.label')}
           href={downloadUrl}
+          target="_blank"
         />
       )}
       {copyUrl && (


### PR DESCRIPTION
### Description

Performing the download navigation in the `_self` context causes web browsers to close the Bifur WebSocket connection, because it appears the user is navigating away from the page. Subsequently, sending messages to Bifur triggers an error, and Presence ceases to update.

Fixes #12483.

### What to review

Downloading an asset.

### Testing

- Verified that downloading an asset no longer results in Bifur failing with `WebSocket is already in CLOSING or CLOSED state.` error.
- Verified asset download continues to work correctly.

### Notes for release

Fixes an issue causing `WebSocket is already in CLOSING or CLOSED state.` error to occur after downloading an asset.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-attribute change on a download link in shared file input UI; no auth, data, or API behavior changes.
> 
> **Overview**
> **Fixes Bifur WebSocket errors after asset download** by opening file downloads in a new tab instead of the current Studio page.
> 
> The shared `ActionsMenu` download link now sets `target="_blank"` on the anchor `MenuItem`, so the browser no longer treats the download as navigating away from the editor (which was closing the Bifur connection and breaking Presence).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d0d9f98837cb1b64605075f15d97fb76469d6c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->