### PR TITLE
chore(codeowners): remove redundant presentation tool ownership rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,8 +15,5 @@
 # Telemetry definitions
 *.telemetry.ts @sanity-io/data-eng
 
-# Presentation Tool, which interfaces with Visual Editing libraries
-/packages/sanity/src/presentation/ @sanity-io/studio
-
 # Examples
 /examples/functions @kmelve @kenjonespizza @iamkevingreen

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,7 +16,7 @@
 *.telemetry.ts @sanity-io/data-eng
 
 # Presentation Tool, which interfaces with Visual Editing libraries
-/packages/sanity/src/presentation/ @sanity-io/ecosystem
+/packages/sanity/src/presentation/ @sanity-io/studio
 
 # Examples
 /examples/functions @kmelve @kenjonespizza @iamkevingreen


### PR DESCRIPTION
### Description

The Presentation tool path (`/packages/sanity/src/presentation/`) had an explicit `.github/CODEOWNERS` entry assigning it to `@sanity-io/ecosystem`.

Since Studio now owns the Presentation tool, the correct owner is `@sanity-io/studio` — which is already the repo-wide default via the top-level `* @sanity-io/studio` rule. Rather than reassign the path to `@sanity-io/studio` (a specific rule that just restates the default), this PR **removes the entry entirely** (comment + rule).

CODEOWNERS resolves ownership by last-matching pattern. With the presentation entry gone, no later rule matches `/packages/sanity/src/presentation/`, so it falls back to `* @sanity-io/studio`. The end result is identical ownership, with a cleaner file and no redundant rule to keep in sync.

### What to review

That removing the line (rather than reassigning it) yields the intended owner. `* @sanity-io/studio` is the default, and there is no rule after the removed entry that matches the presentation path, so review requests for `/packages/sanity/src/presentation/` route to `@sanity-io/studio`.

### Notes for release

N/A
