### PR TITLE
docs(telemetry): define standard location, position and path property value sets

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -99,33 +99,33 @@ Analytics team so downstream dbt models and Looker dashboards stay in sync.
 
 The UI surface an interaction happened on.
 
-| Value                  | Description                                                          |
-| ---------------------- | -------------------------------------------------------------------- |
-| `document_pane`        | The main document editor pane                                        |
-| `array_list`           | An array-of-objects list field                                       |
-| `nested_object_dialog` | A nested object edit dialog or popover (tree editing)                |
+| Value                  | Description                                           |
+| ---------------------- | ----------------------------------------------------- |
+| `document_pane`        | The main document editor pane                         |
+| `array_list`           | An array-of-objects list field                        |
+| `nested_object_dialog` | A nested object edit dialog or popover (tree editing) |
 
 ### `position`
 
 Where in a collection an object was created or edited. Pairs with
 `location: "array_list"`.
 
-| Value       | Description                                                       |
-| ----------- | ----------------------------------------------------------------- |
-| `new`       | Created via the array's primary add control                       |
-| `appended`  | Inserted after an existing item                                   |
-| `prepended` | Inserted before an existing item                                  |
-| `nested`    | An existing nested item opened for editing                        |
+| Value       | Description                                 |
+| ----------- | ------------------------------------------- |
+| `new`       | Created via the array's primary add control |
+| `appended`  | Inserted after an existing item             |
+| `prepended` | Inserted before an existing item            |
+| `nested`    | An existing nested item opened for editing  |
 
 ### `path`
 
 How a navigation or open interaction was triggered.
 
-| Value               | Description                                        |
-| ------------------- | -------------------------------------------------- |
-| `breadcrumb`        | Via a breadcrumb control                           |
-| `close_button`      | Via a dialog close button                          |
-| `keyboard_shortcut` | Via a keyboard shortcut                            |
+| Value               | Description               |
+| ------------------- | ------------------------- |
+| `breadcrumb`        | Via a breadcrumb control  |
+| `close_button`      | Via a dialog close button |
+| `keyboard_shortcut` | Via a keyboard shortcut   |
 
 ## How Events Are Sent
 

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -80,6 +80,53 @@ src/
     ...
 ```
 
+## Standard property value sets
+
+Some interactions happen on more than one UI surface or through more than one
+trigger. Rather than baking that context into the event name (which fragments a
+single action across many high-cardinality names), encode it as a property on a
+generic event. For those properties to be aggregatable, the values must come
+from a shared, low-cardinality vocabulary.
+
+The value sets below are canonical. When instrumenting a new event, reuse an
+existing value where one fits; only introduce a new value when no existing one
+describes the surface or trigger, and coordinate additions with the Data /
+Analytics team so downstream dbt models and Looker dashboards stay in sync.
+
+**Owner:** Studio App team (`SAPP`), in coordination with Data / Analytics.
+
+### `location`
+
+The UI surface an interaction happened on.
+
+| Value                  | Description                                                          |
+| ---------------------- | -------------------------------------------------------------------- |
+| `document_pane`        | The main document editor pane                                        |
+| `array_list`           | An array-of-objects list field                                       |
+| `nested_object_dialog` | A nested object edit dialog or popover (tree editing)                |
+
+### `position`
+
+Where in a collection an object was created or edited. Pairs with
+`location: "array_list"`.
+
+| Value       | Description                                                       |
+| ----------- | ----------------------------------------------------------------- |
+| `new`       | Created via the array's primary add control                       |
+| `appended`  | Inserted after an existing item                                   |
+| `prepended` | Inserted before an existing item                                  |
+| `nested`    | An existing nested item opened for editing                        |
+
+### `path`
+
+How a navigation or open interaction was triggered.
+
+| Value               | Description                                        |
+| ------------------- | -------------------------------------------------- |
+| `breadcrumb`        | Via a breadcrumb control                           |
+| `close_button`      | Via a dialog close button                          |
+| `keyboard_shortcut` | Via a keyboard shortcut                            |
+
 ## How Events Are Sent
 
 ### React Hook


### PR DESCRIPTION
### Description

Spike output for [SAPP-3815](https://linear.app/sanity/issue/SAPP-3815/define-the-location-property-value-set-spike). Several Studio telemetry events bake UI-surface context into the event name (e.g. `Created New Object in Array List`, `Navigated to Nested Object via Breadcrumb`), which fragments a single action across many high-cardinality names. The fix pattern — already used by the `Editor Opened`/`Editor Closed` events — is to emit a generic event and carry the surface/trigger as a property. That only aggregates cleanly if every event draws those property values from a shared, low-cardinality vocabulary.

This PR adds a **Standard property value sets** section to `docs/TELEMETRY.md` defining the canonical values for three properties, with descriptions and ownership:

- `location` — the UI surface an interaction happened on (`document_pane`, `array_list`, `nested_object_dialog`)
- `position` — where in an array an object was created/edited (`new`, `appended`, `prepended`, `nested`)
- `path` — how a navigation/open was triggered (`breadcrumb`, `close_button`, `keyboard_shortcut`)

It is the prerequisite for the three rename/consolidation issues that depend on it: SAPP-3821, SAPP-3822 and SAPP-3823.

### What to review

- `docs/TELEMETRY.md` — the new section, placed after "How Events Are Defined". Check the value set is complete for the surfaces we currently instrument and that ownership (Studio App, coordinating with Data / Analytics) reads correctly.
- The values match the literals the dependent rename PRs use (`array_list`, `document_pane`, `nested_object_dialog`, the `position` set, and the `path` set), so the doc and the code stay in lockstep.

### Testing

Docs-only change. No code paths affected.

### Notes for release

N/A – internal telemetry documentation.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsWF28Y2Pr5d56uRWAMX9K)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change with no runtime or data pipeline behavior changes.
> 
> **Overview**
> Adds a **Standard property value sets** section to `docs/TELEMETRY.md` so Studio telemetry can carry UI surface and trigger context on generic events instead of splitting actions across high-cardinality event names.
> 
> The doc defines canonical low-cardinality vocabularies for **`location`** (`document_pane`, `array_list`, `nested_object_dialog`), **`position`** (`new`, `appended`, `prepended`, `nested`), and **`path`** (`breadcrumb`, `close_button`, `keyboard_shortcut`), with descriptions and **SAPP** ownership plus coordination with Data / Analytics for new values.
> 
> This is documentation-only groundwork for follow-up event rename/consolidation work; values align with literals already used in places like nested object / editor telemetry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c5c34f8ea7d311532c7163ab7ac0e7f0349a764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->