### PR TITLE
fix(core): stop permission loading-flag churn on every document change

### DIFF
--- a/packages/sanity/src/core/store/grants/documentValuePermissions.test.ts
+++ b/packages/sanity/src/core/store/grants/documentValuePermissions.test.ts
@@ -1,4 +1,5 @@
 import {act, renderHook} from '@testing-library/react'
+import {StrictMode} from 'react'
 import {Subject} from 'rxjs'
 import {describe, expect, test, vi} from 'vitest'
 
@@ -8,6 +9,7 @@ import {type GrantsStore, type PermissionCheckResult} from './types'
 vi.mock('../datastores', () => ({useGrantsStore: () => undefined}))
 
 const GRANTED: PermissionCheckResult = {granted: true, reason: 'ok'}
+// Deep-equal to GRANTED but a distinct reference, to exercise the isEqual bailout.
 const GRANTED_COPY: PermissionCheckResult = {granted: true, reason: 'ok'}
 const DENIED: PermissionCheckResult = {granted: false, reason: 'nope'}
 
@@ -46,6 +48,22 @@ describe('useDocumentValuePermissions', () => {
     const {result, rerender} = renderHook(
       ({document}) => useDocumentValuePermissions({grantsStore, document, permission: 'update'}),
       {initialProps: {document: {_id: 'doc', _type: 'author', name: 'a'}}},
+    )
+
+    emitLatest(GRANTED)
+    expect(result.current).toEqual([GRANTED, false])
+
+    rerender({document: {_id: 'doc', _type: 'author', name: 'ab'}})
+
+    expect(result.current).toEqual([GRANTED, false])
+  })
+
+  // The fix relies on a ref surviving StrictMode's mount→unmount→remount double-invoke.
+  test('does not flip loading back on under StrictMode', () => {
+    const {grantsStore, emitLatest} = createControllableGrantsStore()
+    const {result, rerender} = renderHook(
+      ({document}) => useDocumentValuePermissions({grantsStore, document, permission: 'update'}),
+      {wrapper: StrictMode, initialProps: {document: {_id: 'doc', _type: 'author', name: 'a'}}},
     )
 
     emitLatest(GRANTED)

--- a/packages/sanity/src/core/store/grants/documentValuePermissions.test.ts
+++ b/packages/sanity/src/core/store/grants/documentValuePermissions.test.ts
@@ -1,0 +1,90 @@
+import {act, renderHook} from '@testing-library/react'
+import {Subject} from 'rxjs'
+import {describe, expect, test, vi} from 'vitest'
+
+import {useDocumentValuePermissions} from './documentValuePermissions'
+import {type GrantsStore, type PermissionCheckResult} from './types'
+
+vi.mock('../datastores', () => ({useGrantsStore: () => undefined}))
+
+const GRANTED: PermissionCheckResult = {granted: true, reason: 'ok'}
+const GRANTED_COPY: PermissionCheckResult = {granted: true, reason: 'ok'}
+const DENIED: PermissionCheckResult = {granted: false, reason: 'nope'}
+
+function createControllableGrantsStore() {
+  const emitters: Subject<PermissionCheckResult>[] = []
+  const grantsStore: GrantsStore = {
+    checkDocumentPermission() {
+      const subject = new Subject<PermissionCheckResult>()
+      emitters.push(subject)
+      return subject.asObservable()
+    },
+  }
+  // A fresh subscription is created per effect run, so only the latest subject is subscribed.
+  const emitLatest = (value: PermissionCheckResult) =>
+    act(() => emitters[emitters.length - 1].next(value))
+  return {grantsStore, emitLatest}
+}
+
+describe('useDocumentValuePermissions', () => {
+  test('shows loading on first evaluation until the first result arrives', () => {
+    const {grantsStore, emitLatest} = createControllableGrantsStore()
+    const {result} = renderHook(
+      ({document}) => useDocumentValuePermissions({grantsStore, document, permission: 'update'}),
+      {initialProps: {document: {_id: 'doc', _type: 'author', name: 'a'}}},
+    )
+
+    expect(result.current).toEqual([undefined, true])
+
+    emitLatest(GRANTED)
+
+    expect(result.current).toEqual([GRANTED, false])
+  })
+
+  test('re-evaluating on a document change does not flip loading back on', () => {
+    const {grantsStore, emitLatest} = createControllableGrantsStore()
+    const {result, rerender} = renderHook(
+      ({document}) => useDocumentValuePermissions({grantsStore, document, permission: 'update'}),
+      {initialProps: {document: {_id: 'doc', _type: 'author', name: 'a'}}},
+    )
+
+    emitLatest(GRANTED)
+    expect(result.current).toEqual([GRANTED, false])
+
+    rerender({document: {_id: 'doc', _type: 'author', name: 'ab'}})
+
+    expect(result.current).toEqual([GRANTED, false])
+  })
+
+  test('bails out (stable state reference) when the re-evaluated result is unchanged', () => {
+    const {grantsStore, emitLatest} = createControllableGrantsStore()
+    const {result, rerender} = renderHook(
+      ({document}) => useDocumentValuePermissions({grantsStore, document, permission: 'update'}),
+      {initialProps: {document: {_id: 'doc', _type: 'author', name: 'a'}}},
+    )
+
+    emitLatest(GRANTED)
+    const settledState = result.current
+
+    rerender({document: {_id: 'doc', _type: 'author', name: 'ab'}})
+    emitLatest(GRANTED_COPY)
+
+    expect(result.current).toBe(settledState)
+  })
+
+  test('updates when a re-evaluated result genuinely changes', () => {
+    const {grantsStore, emitLatest} = createControllableGrantsStore()
+    const {result, rerender} = renderHook(
+      ({document}) => useDocumentValuePermissions({grantsStore, document, permission: 'update'}),
+      {initialProps: {document: {_id: 'doc', _type: 'author', name: 'a'}}},
+    )
+
+    emitLatest(GRANTED)
+    expect(result.current).toEqual([GRANTED, false])
+
+    rerender({document: {_id: 'doc', _type: 'author', name: 'ab'}})
+    emitLatest(DENIED)
+
+    expect(result.current).toEqual([DENIED, false])
+  })
+})

--- a/packages/sanity/src/core/store/grants/documentValuePermissions.ts
+++ b/packages/sanity/src/core/store/grants/documentValuePermissions.ts
@@ -83,9 +83,15 @@ export function useDocumentValuePermissions({
 
   const [state, dispatch] = useReducer(stateReducer, INITIAL_STATE)
   const subscriptionRef = useRef<Subscription | null>(null)
+  const hasEvaluatedRef = useRef(false)
 
   useEffect(() => {
-    dispatch({type: 'loading'})
+    // Dispatch loading only on the first eval; re-dispatching it on per-keystroke re-runs keeps
+    // prevIsLoading true, which defeats the reducer's isEqual bailout and forces a re-render.
+    if (!hasEvaluatedRef.current) {
+      hasEvaluatedRef.current = true
+      dispatch({type: 'loading'})
+    }
 
     // Unsubscribe from any previous subscription
     if (subscriptionRef.current) {

--- a/packages/sanity/src/core/store/grants/documentValuePermissions.ts
+++ b/packages/sanity/src/core/store/grants/documentValuePermissions.ts
@@ -83,13 +83,13 @@ export function useDocumentValuePermissions({
 
   const [state, dispatch] = useReducer(stateReducer, INITIAL_STATE)
   const subscriptionRef = useRef<Subscription | null>(null)
-  const hasEvaluatedRef = useRef(false)
+  const hasDispatchedInitialLoadingRef = useRef(false)
 
   useEffect(() => {
     // Dispatch loading only on the first eval; re-dispatching it on per-keystroke re-runs keeps
     // prevIsLoading true, which defeats the reducer's isEqual bailout and forces a re-render.
-    if (!hasEvaluatedRef.current) {
-      hasEvaluatedRef.current = true
+    if (!hasDispatchedInitialLoadingRef.current) {
+      hasDispatchedInitialLoadingRef.current = true
       dispatch({type: 'loading'})
     }
 


### PR DESCRIPTION
### Description

`useDocumentValuePermissions` dispatched a `loading` action on every effect re-run ([SAPP-4073](https://linear.app/sanity/issue/SAPP-4073/stop-permission-loading-flag-churn-on-every-document-change)). The effect's deps include the live document, whose identity changes on every keystroke (via `useDocumentForm`'s memo), so each keystroke flipped `loading` back on. That kept `prevIsLoading` true, which defeated the reducer's `isEqual` bailout and forced a fresh state tuple - and an extra re-render of the form owner - even when the permission result was unchanged.

This PR dispatches `loading` only on the first evaluation. Re-runs keep `prevIsLoading` false, so identical results no-op through the existing bailout while genuine permission changes still propagate and the last-known result stays in place during async re-evaluation. First-load loading UX is unchanged, since `INITIAL_STATE` already carries it.

This ships option (a) from the ticket (drop the re-evaluation `loading` dispatch). The larger restructure to a single long-lived subscription is deferred; the ticket notes option (a) captures most of the win. It also does not wait on SAPP-4072 (the bench richGrants infra), which measures grant-filter CPU at scale - a separate concern from this render-count reduction.

### What to review

- `documentValuePermissions.ts`: the `hasDispatchedInitialLoadingRef` guard is the whole fix. Confirm first-load still shows loading and that re-runs keeping `prevIsLoading` false is what reactivates the reducer's `isEqual` no-op.
- Permission correctness on the security-adjacent `readOnly` path: genuine changes still propagate (covered by the DENIED test) and no stale-permission window is introduced, since re-evaluation still runs on every document change - only the loading flag stops churning.
- Because the guard latches after the first evaluation, loading is also suppressed on subsequent `permission`/`grantsStore` changes, not only per-keystroke document changes. Both call sites pass a constant `permission`, so this never triggers in practice, but flagging it as an intentional consequence of keying the guard on "first eval ever".

### Testing

- 5 unit tests added, run A/B against the fixed and unfixed code: 2 fail cleanly on the unfixed code (loading flips back on; bailout reference stability) and pass on the fix; the others (first-load loading, genuine-change propagation, and a StrictMode variant that guards the ref surviving StrictMode's mount/unmount/remount double-invoke) pass on both, confirming no behavior regression.
- Manual validation against the real dev studio (12 keystrokes into a document field, renders counted via temporary instrumentation since removed): ~7.25 renders/keystroke fixed vs ~9.7 unfixed, consistent across repeats. Zero console errors, field stayed editable, initial loading UX unchanged.
- No bench A/B: that needs the SAPP-4072 richGrants ACL to make grant-eval CPU visible at scale, which this render-count fix is not trying to produce.

### Notes for release

N/A

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches grant-based document permissions used for read-only UI, though behavior is limited to loading/render churn with re-evaluation unchanged and covered by tests.
> 
> **Overview**
> Fixes **SAPP-4073** by stopping `useDocumentValuePermissions` from re-dispatching `loading` on every effect run when the live document reference changes (e.g. each keystroke in the form).
> 
> A **`hasDispatchedInitialLoadingRef`** guard limits the `loading` dispatch to the **first** evaluation, so re-runs keep `prevIsLoading` false and the reducer’s **`isEqual` bailout** can skip redundant state updates when the permission result is unchanged. Permissions still re-check on document changes; only the loading flag and extra re-renders stop churning. Initial load still shows loading via `INITIAL_STATE`.
> 
> Adds **five** `renderHook` tests (first-load loading, no loading flip on document/StrictMode re-runs, reference stability on unchanged results, propagation when results change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c08bba52b89eb48a08dadff8d0fa774af7ed4442. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->