### PR TITLE
refactor(core): consolidate array list object telemetry events

### DIFF
--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/ArrayOfObjectsFunctions.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/ArrayOfObjectsFunctions.tsx
@@ -8,7 +8,7 @@ import {Button} from '../../../../../ui-components/button/Button'
 import {Tooltip} from '../../../../../ui-components/tooltip/Tooltip'
 import {pathToString} from '../../../../field/paths/helpers'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
-import {CreatedNewObject} from '../../../studio/tree-editing/__telemetry__/nestedObjects.telemetry'
+import {ObjectCreated} from '../../../studio/tree-editing/__telemetry__/nestedObjects.telemetry'
 import {useEnhancedObjectDialog} from '../../../studio/tree-editing/context/enabled/useEnhancedObjectDialog'
 import {type ArrayInputFunctionsProps} from '../../../types/_transitional'
 import {type ObjectItem} from '../../../types/itemProps'
@@ -42,7 +42,9 @@ export function ArrayOfObjectsFunctions<
   )
 
   const handleAddBtnClick = useCallback(() => {
-    telemetry.log(CreatedNewObject, {
+    telemetry.log(ObjectCreated, {
+      location: 'array_list',
+      position: 'new',
       path: pathToString(path),
       origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
     })

--- a/packages/sanity/src/core/form/members/array/items/ArrayOfObjectsItem.tsx
+++ b/packages/sanity/src/core/form/members/array/items/ArrayOfObjectsItem.tsx
@@ -18,10 +18,9 @@ import {type ArrayOfObjectsItemMember} from '../../../store/types/members'
 import {isEmptyItem} from '../../../store/utils/isEmptyItem'
 import {FormCallbacksProvider, useFormCallbacks} from '../../../studio/contexts/FormCallbacks'
 import {
-  CreateAppendedObject,
-  CreatePrependedObject,
-  NavigatedToViaArrayList,
-  RemovedObject,
+  ObjectCreated,
+  ObjectEdited,
+  ObjectRemoved,
 } from '../../../studio/tree-editing/__telemetry__/nestedObjects.telemetry'
 import {useEnhancedObjectDialog} from '../../../studio/tree-editing/context/enabled/useEnhancedObjectDialog'
 import {type ArrayInputCopyEvent, type ArrayInputInsertEvent} from '../../../types/event'
@@ -99,7 +98,8 @@ export function ArrayOfObjectsItem(props: MemberItemProps) {
   })
 
   const onRemove = useCallback(() => {
-    telemetry.log(RemovedObject, {
+    telemetry.log(ObjectRemoved, {
+      location: 'array_list',
       path: pathToString(member.item.path),
       origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
     })
@@ -119,12 +119,16 @@ export function ArrayOfObjectsItem(props: MemberItemProps) {
   const telemetryInsertSiblingsTelemetry = useCallback(
     (event: Omit<ArrayInputInsertEvent<ObjectItem>, 'referenceItem'>) => {
       if (event.position === 'before') {
-        telemetry.log(CreatePrependedObject, {
+        telemetry.log(ObjectCreated, {
+          location: 'array_list',
+          position: 'prepended',
           path: pathToString(member.item.path),
           origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
         })
       } else {
-        telemetry.log(CreateAppendedObject, {
+        telemetry.log(ObjectCreated, {
+          location: 'array_list',
+          position: 'appended',
           path: pathToString(member.item.path),
           origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
         })
@@ -277,7 +281,9 @@ export function ArrayOfObjectsItem(props: MemberItemProps) {
   )
 
   const handleOpen = useCallback(() => {
-    telemetry.log(NavigatedToViaArrayList, {
+    telemetry.log(ObjectEdited, {
+      location: 'array_list',
+      position: 'nested',
       path: pathToString(member.item.path),
       origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
     })

--- a/packages/sanity/src/core/form/members/array/items/ArrayOfObjectsItem.tsx
+++ b/packages/sanity/src/core/form/members/array/items/ArrayOfObjectsItem.tsx
@@ -118,21 +118,12 @@ export function ArrayOfObjectsItem(props: MemberItemProps) {
 
   const telemetryInsertSiblingsTelemetry = useCallback(
     (event: Omit<ArrayInputInsertEvent<ObjectItem>, 'referenceItem'>) => {
-      if (event.position === 'before') {
-        telemetry.log(ObjectCreated, {
-          location: 'array_list',
-          position: 'prepended',
-          path: pathToString(member.item.path),
-          origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
-        })
-      } else {
-        telemetry.log(ObjectCreated, {
-          location: 'array_list',
-          position: 'appended',
-          path: pathToString(member.item.path),
-          origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
-        })
-      }
+      telemetry.log(ObjectCreated, {
+        location: 'array_list',
+        position: event.position === 'before' ? 'prepended' : 'appended',
+        path: pathToString(member.item.path),
+        origin: enhancedObjectDialogEnabled ? 'nested-object' : 'default',
+      })
     },
     [enhancedObjectDialogEnabled, member.item.path, telemetry],
   )

--- a/packages/sanity/src/core/form/studio/tree-editing/__telemetry__/nestedObjects.telemetry.ts
+++ b/packages/sanity/src/core/form/studio/tree-editing/__telemetry__/nestedObjects.telemetry.ts
@@ -8,6 +8,10 @@ interface NestedObjectInfoOrigin extends NestedDialogOpenedInfo {
   origin: 'default' | 'nested-object'
 }
 
+interface ArrayListObjectInfo extends NestedObjectInfoOrigin {
+  location: 'array_list'
+}
+
 /**
  * When a nested dialog is opened
  */
@@ -24,15 +28,12 @@ export const NestedDialogClosed = defineEvent({
   description: 'User closed a nested dialog',
 })
 
-/** When a nested object is edited */
-export const NavigatedToViaArrayList = defineEvent<NestedDialogOpenedInfo & NestedObjectInfoOrigin>(
-  {
-    name: 'Edited Nested Object in Array List',
-    version: 1,
-    description:
-      'User edited a object - meaning a navigation to a nested object was made through the array list',
-  },
-)
+/** When an existing object in an array list is opened for editing */
+export const ObjectEdited = defineEvent<ArrayListObjectInfo & {position: 'nested'}>({
+  name: 'Object Edited',
+  version: 1,
+  description: 'User opened an existing nested object in an array list for editing',
+})
 
 export const NavigatedToNestedObjectViaBreadcrumb = defineEvent<NestedDialogOpenedInfo>({
   name: 'Navigated to Nested Object via Breadcrumb',
@@ -53,28 +54,18 @@ export const navigatedToNestedObjectViaKeyboardShortcut = defineEvent({
   description: 'User navigated to a nested object via a keyboard shortcut',
 })
 
-export const CreatedNewObject = defineEvent<NestedDialogOpenedInfo & NestedObjectInfoOrigin>({
-  name: 'Created New Object in Array List',
+export const ObjectCreated = defineEvent<
+  ArrayListObjectInfo & {position: 'new' | 'appended' | 'prepended'}
+>({
+  name: 'Object Created',
   version: 1,
-  description: 'User created a new object in an array list',
+  description: 'User created an object in an array list',
 })
 
-export const CreatePrependedObject = defineEvent<NestedDialogOpenedInfo & NestedObjectInfoOrigin>({
-  name: 'Created Prepended Object in Array List',
+export const ObjectRemoved = defineEvent<ArrayListObjectInfo>({
+  name: 'Object Removed',
   version: 1,
-  description: 'User created a prepended object in an array list',
-})
-
-export const CreateAppendedObject = defineEvent<NestedDialogOpenedInfo & NestedObjectInfoOrigin>({
-  name: 'Created Appended Object in Array List',
-  version: 1,
-  description: 'User created an appended object in an array list',
-})
-
-export const RemovedObject = defineEvent<NestedDialogOpenedInfo & NestedObjectInfoOrigin>({
-  name: 'Removed Object in Array List',
-  version: 1,
-  description: 'User removed a object from an array list via actions',
+  description: 'User removed an object from an array list via actions',
 })
 
 interface EditorFullscreenInfo extends NestedObjectInfoOrigin {


### PR DESCRIPTION
### Description

Resolves [SAPP-3821](https://linear.app/sanity/issue/SAPP-3821/consolidate-array-list-object-operations).

Five array-list telemetry events baked the target and action variant into the event name, so a single conceptual action ("an object was created in an array list") was split across many high-cardinality names:

| Before | After | Properties |
| --- | --- | --- |
| `Created New Object in Array List` | `Object Created` | `location: "array_list"`, `position: "new"` |
| `Created Appended Object in Array List` | `Object Created` | `location: "array_list"`, `position: "appended"` |
| `Created Prepended Object in Array List` | `Object Created` | `location: "array_list"`, `position: "prepended"` |
| `Edited Nested Object in Array List` | `Object Edited` | `location: "array_list"`, `position: "nested"` |
| `Removed Object in Array List` | `Object Removed` | `location: "array_list"` |

The `location` and `position` values come from the canonical vocabulary defined in SAPP-3815. The pre-existing `path` and `origin` properties are preserved on all three events, so no data is lost.

Depends on the `location`/`position` value set from SAPP-3815 (#13770).

### What to review

- `nestedObjects.telemetry.ts` — the five `defineEvent` exports collapse to three (`ObjectCreated`, `ObjectEdited`, `ObjectRemoved`). A new `ArrayListObjectInfo` interface pins `location: "array_list"` and extends the existing `NestedObjectInfoOrigin` (which carries `path` + `origin`). This mirrors the `EditorFullscreenInfo` pattern already used by the `Editor Opened`/`Editor Closed` events in the same file.
- Call sites pass the new `location`/`position` literals:
  - `ArrayOfObjectsFunctions.tsx` — primary "Add item" → `position: "new"`
  - `ArrayOfObjectsItem.tsx` — insert-before/after → `position: "prepended"`/`"appended"`; open-for-edit → `ObjectEdited`; remove → `ObjectRemoved`
- **Analytics coordination:** no Omni consumer references the old event names. Scanned all 20 semantic models and all 60 documents (dashboards and workbooks) via the Omni CLI, case-insensitive, for any `array list` reference in field definitions and query filter values - zero matches. Looker is no longer in use. dbt was not verifiable from here (the Omni dbt-exposures API returned 403), so if a dbt project transforms the raw telemetry it should still be searched for the five old names before/alongside merge.

### Testing

No unit tests reference these events (verified by search), so there are no snapshots to update. `oxlint` on the three changed files reports only pre-existing warnings; the pre-commit oxfmt/oxlint hook passed. The change is a pure rename plus additive properties whose types are checked against each call site.

### Notes for release

N/A – internal telemetry only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal telemetry-only rename with additive properties; no runtime or security impact, though analytics pipelines must adopt the new event names.
> 
> **Overview**
> **Consolidates five array-list telemetry event names into three** (`Object Created`, `Object Edited`, `Object Removed`) and moves how the action happened into typed properties instead of separate event names.
> 
> In `nestedObjects.telemetry.ts`, the old exports (`CreatedNewObject`, `CreatePrependedObject`, `CreateAppendedObject`, `NavigatedToViaArrayList`, `RemovedObject`) are replaced by `ObjectCreated`, `ObjectEdited`, and `ObjectRemoved`, with a new `ArrayListObjectInfo` type that requires `location: 'array_list'`. Create/edit events also carry `position` (`new` / `prepended` / `appended` / `nested`); existing `path` and `origin` are unchanged.
> 
> Call sites in `ArrayOfObjectsFunctions.tsx` and `ArrayOfObjectsItem.tsx` log the new events with those literals (e.g. primary add → `position: 'new'`, sibling insert → `prepended`/`appended`, open item → `ObjectEdited`).
> 
> **Analytics note:** downstream dashboards must key off the new names and `location`/`position` instead of the retired event strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1089b6b5cf52063be25f72ca70d05fa729b23f90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->