### PR TITLE
refactor(core): consolidate nested object navigation telemetry events

### DIFF
--- a/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
+++ b/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
@@ -12,10 +12,9 @@ import {PresenceOverlay} from '../../presence/overlay/PresenceOverlay'
 import {isNativeEditableElement} from '../../studio/copyPaste/utils'
 import {VirtualizerScrollInstanceProvider} from '../inputs/arrays/ArrayOfObjectsInput/List/VirtualizerScrollInstanceProvider'
 import {
-  NavigatedToNestedObjectViaCloseButton,
-  navigatedToNestedObjectViaKeyboardShortcut,
   NestedDialogClosed,
   NestedDialogOpened,
+  NestedObjectOpened,
 } from '../studio/tree-editing/__telemetry__/nestedObjects.telemetry'
 import {useFormBuilder} from '../useFormBuilder'
 import {DialogBreadcrumbs} from './breadcrumbs/DialogBreadcrumbs'
@@ -150,7 +149,7 @@ export function EnhancedObjectDialog(props: PopoverProps | DialogProps): React.J
           const newLastStackPath = lastStackPath.slice(0, -1)
 
           if (newLastStackPath.length > 1) {
-            telemetry.log(navigatedToNestedObjectViaKeyboardShortcut)
+            telemetry.log(NestedObjectOpened, {path: 'keyboard_shortcut'})
             navigateTo(newLastStackPath)
           } else {
             telemetry.log(NestedDialogClosed)
@@ -165,7 +164,7 @@ export function EnhancedObjectDialog(props: PopoverProps | DialogProps): React.J
   const handleStackedDialogClose = useCallback(
     (closeAll?: boolean) => {
       if (!closeAll && stack.length >= 2) {
-        telemetry.log(NavigatedToNestedObjectViaCloseButton)
+        telemetry.log(NestedObjectOpened, {path: 'close_button'})
         close({toParent: true})
       } else {
         telemetry.log(NestedDialogClosed)

--- a/packages/sanity/src/core/form/components/breadcrumbs/DialogBreadcrumbs.tsx
+++ b/packages/sanity/src/core/form/components/breadcrumbs/DialogBreadcrumbs.tsx
@@ -12,13 +12,12 @@ import {
 } from 'react'
 
 import {MenuButton} from '../../../../ui-components/menuButton/MenuButton'
-import {pathToString} from '../../../field/paths/helpers'
 import {resolveSchemaTypeForPath} from '../../../studio/copyPaste/resolveSchemaTypeForPath'
 import {useFormValue} from '../../contexts/FormValue'
 import {useBreadcrumbPreview} from '../../hooks/useBreadcrumbPreview'
 import {useBreadcrumbSiblingInfo} from '../../hooks/useBreadcrumbSiblingInfo'
 import {useFormCallbacks} from '../../studio/contexts/FormCallbacks'
-import {NavigatedToNestedObjectViaBreadcrumb} from '../../studio/tree-editing/__telemetry__/nestedObjects.telemetry'
+import {NestedObjectOpened} from '../../studio/tree-editing/__telemetry__/nestedObjects.telemetry'
 import {shouldBeInBreadcrumb} from '../../studio/tree-editing/utils/build-tree-editing-state/utils'
 import {useFormBuilder} from '../../useFormBuilder'
 
@@ -98,8 +97,8 @@ function BreadcrumbButton({
 
   const handleClick = useCallback(() => {
     onPathSelect(itemPath)
-    telemetry.log(NavigatedToNestedObjectViaBreadcrumb, {
-      path: pathToString(itemPath),
+    telemetry.log(NestedObjectOpened, {
+      path: 'breadcrumb',
     })
   }, [onPathSelect, itemPath, telemetry])
 

--- a/packages/sanity/src/core/form/studio/tree-editing/__telemetry__/nestedObjects.telemetry.ts
+++ b/packages/sanity/src/core/form/studio/tree-editing/__telemetry__/nestedObjects.telemetry.ts
@@ -34,23 +34,16 @@ export const NavigatedToViaArrayList = defineEvent<NestedDialogOpenedInfo & Nest
   },
 )
 
-export const NavigatedToNestedObjectViaBreadcrumb = defineEvent<NestedDialogOpenedInfo>({
-  name: 'Navigated to Nested Object via Breadcrumb',
-  version: 1,
-  description: 'User navigated to a nested object via a breadcrumb',
-})
+interface NestedObjectOpenedInfo {
+  /** How the user navigated to (opened) the nested object */
+  path: 'breadcrumb' | 'close_button' | 'keyboard_shortcut'
+}
 
-export const NavigatedToNestedObjectViaCloseButton = defineEvent({
-  name: 'Navigated to Nested Object via Close Button',
+/** When a nested object is navigated to (opened), regardless of trigger */
+export const NestedObjectOpened = defineEvent<NestedObjectOpenedInfo>({
+  name: 'Nested Object Opened',
   version: 1,
-  description:
-    'User navigated to a nested object via closing the top most dialog via the close button',
-})
-
-export const navigatedToNestedObjectViaKeyboardShortcut = defineEvent({
-  name: 'Navigated to Nested Object via Keyboard Shortcut',
-  version: 1,
-  description: 'User navigated to a nested object via a keyboard shortcut',
+  description: 'User navigated to a nested object',
 })
 
 export const CreatedNewObject = defineEvent<NestedDialogOpenedInfo & NestedObjectInfoOrigin>({


### PR DESCRIPTION
### Description

Resolves [SAPP-3822](https://linear.app/sanity/issue/SAPP-3822/consolidate-navigated-to-nested-object-events-into-nested-object).

Three navigation events differed only by their trigger, so the same conceptual action was split across three high-cardinality names:

| Before | After | Property |
| --- | --- | --- |
| `Navigated to Nested Object via Breadcrumb` | `Nested Object Opened` | `path: "breadcrumb"` |
| `Navigated to Nested Object via Close Button` | `Nested Object Opened` | `path: "close_button"` |
| `Navigated to Nested Object via Keyboard Shortcut` | `Nested Object Opened` | `path: "keyboard_shortcut"` |

The trigger is now carried on the single `Nested Object Opened` event via the canonical `path` property from SAPP-3815.

Depends on the `path` value set from SAPP-3815 (#13770).

### What to review

- `nestedObjects.telemetry.ts` — the three exports collapse to one `NestedObjectOpened`, typed with a `NestedObjectOpenedInfo { path: 'breadcrumb' | 'close_button' | 'keyboard_shortcut' }` interface.
- Call sites:
  - `DialogBreadcrumbs.tsx` — breadcrumb click → `path: "breadcrumb"`. The old event sent the document field path string as `path`; the consolidated event uses `path` for the trigger instead (matching the analytics taxonomy in the issue), and the now-unused `pathToString` import was removed.
  - `EnhancedObjectDialog.tsx` — close-button navigation → `path: "close_button"`, keyboard-shortcut navigation → `path: "keyboard_shortcut"`.
- **Naming note for reviewers/analytics:** `path` here means *trigger*, not the document field path. Older array-list events (see SAPP-3821) still carry a `path` that holds the field-path string. Reconciling that overload is analytics-coordination follow-up; this PR follows the property names the issue specifies.
- **Analytics coordination:** confirmed that there are no references to the original event names in analytic reports

### Testing

No unit tests reference these events (verified by search); no snapshots to update. `oxlint` on the three changed files reports only a pre-existing warning; the pre-commit oxfmt/oxlint hook passed. Types on each call site are checked against the new `NestedObjectOpenedInfo` payload.

### Notes for release

N/A – internal telemetry only.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsWF28Y2Pr5d56uRWAMX9K)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal telemetry-only refactor with no runtime or product behavior changes; analytics dashboards must use the new event name and `path` semantics.
> 
> **Overview**
> Replaces three separate nested-object navigation telemetry events with a single **`Nested Object Opened`** event. The navigation trigger is now sent as **`path`**: `"breadcrumb"`, `"close_button"`, or `"keyboard_shortcut"` instead of three distinct event names.
> 
> **`EnhancedObjectDialog`** logs the unified event for close-button parent navigation and Cmd/Ctrl+ArrowUp. **`DialogBreadcrumbs`** logs it on breadcrumb clicks with `path: "breadcrumb"` (previously the breadcrumb event used `path` for the document field string; that import was removed).
> 
> **`nestedObjects.telemetry.ts`** drops the three old exports and adds typed **`NestedObjectOpened`** / **`NestedObjectOpenedInfo`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bdadbb3c9bdf0059334e96a528bb8cc2802e94e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->