### PR TITLE
refactor(structure): rename document pane telemetry events to active voice

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderBreadcrumbItem.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderBreadcrumbItem.tsx
@@ -8,7 +8,7 @@ import {LOADING_PANE} from '../../../../constants'
 import {structureLocaleNamespace} from '../../../../i18n'
 import {type Panes} from '../../../../structureResolvers/useResolvedPanes'
 import {type RouterPanes} from '../../../../types'
-import {FocusDocumentPaneNavigated} from './__telemetry__/focus.telemetry'
+import {DocumentPaneNavigated} from './__telemetry__/focus.telemetry'
 
 export function DocumentHeaderBreadcrumbItem({
   paneData,
@@ -47,7 +47,7 @@ export function DocumentHeaderBreadcrumbItem({
   }, [documentId, previewValue, staticTitle, t, isLoading])
 
   const handleClick = useCallback(() => {
-    telemetry.log(FocusDocumentPaneNavigated)
+    telemetry.log(DocumentPaneNavigated, {path: 'breadcrumb'})
     router.navigate({panes: routerPanes.slice(0, paneData.groupIndex)})
   }, [telemetry, router, routerPanes, paneData.groupIndex])
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -47,7 +47,7 @@ import {type PaneMenuItem} from '../../../../types'
 import {useStructureTool} from '../../../../useStructureTool'
 import {ActionDialogWrapper, ActionMenuListItem} from '../../statusBar/ActionMenuButton'
 import {useDocumentPane} from '../../useDocumentPane'
-import {FocusDocumentPaneClicked, FocusDocumentPaneCollapsed} from './__telemetry__/focus.telemetry'
+import {DocumentPaneCollapsed, DocumentPaneMaximized} from './__telemetry__/focus.telemetry'
 import {CopyDocumentActions} from './CopyDocumentActions'
 import {DocumentGroupInventoryHint} from './documentGroupInventoryHint/DocumentGroupInventoryHint'
 import {DocumentHeaderTitle} from './DocumentHeaderTitle'
@@ -186,9 +186,9 @@ export const DocumentPanelHeader = memo(
       onSetMaximizedPane?.()
 
       if (isMaximizedPane) {
-        telemetry.log(FocusDocumentPaneCollapsed)
+        telemetry.log(DocumentPaneCollapsed)
       } else {
-        telemetry.log(FocusDocumentPaneClicked)
+        telemetry.log(DocumentPaneMaximized)
       }
     }, [onSetMaximizedPane, isMaximizedPane, telemetry])
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/__telemetry__/focus.telemetry.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/__telemetry__/focus.telemetry.ts
@@ -1,27 +1,33 @@
 import {defineEvent} from '@sanity/telemetry'
 
 /**
- * When a focus document pane button is clicked
+ * When a document pane is maximized via the focus pane button
  */
-export const FocusDocumentPaneClicked = defineEvent({
-  name: 'Maximized Document Pane Clicked',
+export const DocumentPaneMaximized = defineEvent({
+  name: 'Document Pane Maximized',
   version: 1,
-  description: 'User pressed to maximize a document by click the focus pane button',
+  description: 'User maximized a document pane via the focus pane button',
 })
 
 /**
- * When a focus document pane button is collapsed
+ * When a maximized document pane is collapsed via the focus pane button
  */
-export const FocusDocumentPaneCollapsed = defineEvent({
-  name: 'Maximized Document Pane Collapsed',
+export const DocumentPaneCollapsed = defineEvent({
+  name: 'Document Pane Collapsed',
   version: 1,
-  description:
-    'User disabled the maximization on a document pane by clicking the focus pane button',
+  description: 'User collapsed a maximized document pane via the focus pane button',
 })
 
-export const FocusDocumentPaneNavigated = defineEvent({
-  name: 'Maximized Document Pane Navigated Via Breadcrumbs',
+interface DocumentPaneNavigatedInfo {
+  /** How the user navigated to the document pane */
+  path: 'breadcrumb'
+}
+
+/**
+ * When the user navigates to a different document pane
+ */
+export const DocumentPaneNavigated = defineEvent<DocumentPaneNavigatedInfo>({
+  name: 'Document Pane Navigated',
   version: 1,
-  description:
-    'User navigated to a different document pane via the breadcrumbs in the document header',
+  description: 'User navigated to a different document pane via the breadcrumbs in the header',
 })


### PR DESCRIPTION
### Description

Resolves [SAPP-3823](https://linear.app/sanity/issue/SAPP-3823/rename-document-pane-events-to-active-voice-forms).

Three document-pane focus events used inconsistent, passive verb forms and baked "Maximized" into every name. Rename them to consistent active-voice forms:

| Before | After | Property |
| --- | --- | --- |
| `Maximized Document Pane Clicked` | `Document Pane Maximized` | – |
| `Maximized Document Pane Collapsed` | `Document Pane Collapsed` | – |
| `Maximized Document Pane Navigated Via Breadcrumbs` | `Document Pane Navigated` | `path: "breadcrumb"` |

`Document Pane Navigated` now carries the navigation trigger via the canonical `path` property from SAPP-3815 (currently only `breadcrumb`, typed so future triggers can be added).

Depends on the `path` value set from SAPP-3815 (#13770).

### What to review

- `focus.telemetry.ts` — event names and descriptions updated; exported constants renamed to match (`DocumentPaneMaximized`, `DocumentPaneCollapsed`, `DocumentPaneNavigated`); `DocumentPaneNavigated` gains a `DocumentPaneNavigatedInfo { path: 'breadcrumb' }` payload.
- `DocumentPanelHeader.tsx` — the focus-pane button logs `DocumentPaneCollapsed` when un-maximizing and `DocumentPaneMaximized` otherwise (unchanged logic, renamed events).
- `DocumentHeaderBreadcrumbItem.tsx` — breadcrumb click logs `DocumentPaneNavigated` with `path: "breadcrumb"`.
- **Analytics coordination:** confirmed that there is currently no usage of these events in any analytic reports

### Testing

No unit tests reference these events (verified by search); no snapshots to update. `oxlint` on the three changed files reports only pre-existing warnings; the pre-commit oxfmt/oxlint hook passed. The `path` literal on the navigate call site is type-checked against the new payload.

### Notes for release

N/A – internal telemetry only.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsWF28Y2Pr5d56uRWAMX9K)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal telemetry-only rename with no runtime or user-facing behavior changes; analytics pipelines must remap old event names.
> 
> **Overview**
> **Renames document pane focus telemetry** to consistent active-voice event names and aligned export constants (`DocumentPaneMaximized`, `DocumentPaneCollapsed`, `DocumentPaneNavigated`). The focus-pane button in `DocumentPanelHeader` and breadcrumb clicks in `DocumentHeaderBreadcrumbItem` now log the new events; maximize/collapse behavior is unchanged.
> 
> **Navigation telemetry** drops “Maximized” / “Via Breadcrumbs” from the event name: breadcrumb navigation emits **`Document Pane Navigated`** with **`path: 'breadcrumb'`** (typed via `DocumentPaneNavigatedInfo` for future triggers).
> 
> **Analytics note:** downstream dashboards (dbt/Looker) need remapping from the three legacy event names before or with this merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90f2e642612699c7fb82836ab5717da67c1deed8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->