### PR TITLE
feat(releases): instrument release description usage

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -276,16 +276,17 @@ Tracked automatically via `web-vitals/attribution` library:
 
 ### Releases
 
-| Event                               | When                        |
-| ----------------------------------- | --------------------------- |
-| `Version Document Added to Release` | Document added to a release |
-| `Release Created/Deleted/Published` | Release lifecycle           |
-| `Release Scheduled/Unscheduled`     | Release scheduling          |
-| `Release Archived/Unarchived`       | Release archival            |
-| `Release Reverted/Duplicated`       | Release management          |
-| `Release Link/ID/Title Copied`      | Clipboard actions           |
-| `Navigated to Releases Overview`    | Navigation                  |
-| `Navigated to Scheduled Drafts`     | Navigation                  |
+| Event                               | When                                                                                                                       |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `Version Document Added to Release` | Document added to a release                                                                                                |
+| `Release Created/Deleted/Published` | Release lifecycle                                                                                                          |
+| `Release Scheduled/Unscheduled`     | Release scheduling                                                                                                         |
+| `Release Archived/Unarchived`       | Release archival                                                                                                           |
+| `Release Reverted/Duplicated`       | Release management                                                                                                         |
+| `Release Description Set`           | Release description usage - set at creation or edited in Studio (action, character count, contains-URL; never the content) |
+| `Release Link/ID/Title Copied`      | Clipboard actions                                                                                                          |
+| `Navigated to Releases Overview`    | Navigation                                                                                                                 |
+| `Navigated to Scheduled Drafts`     | Navigation                                                                                                                 |
 
 ### Scheduled Drafts
 

--- a/packages/sanity/src/core/releases/__telemetry__/releases.telemetry.ts
+++ b/packages/sanity/src/core/releases/__telemetry__/releases.telemetry.ts
@@ -27,6 +27,21 @@ export interface RevertInfo {
   revertType: 'immediate' | 'staged'
 }
 
+export interface ReleaseDescriptionInfo {
+  /**
+   * whether the description was set when creating the release, or edited on an existing release
+   */
+  action: 'create' | 'edit'
+  /**
+   * number of characters in the description - never the description content itself
+   */
+  characterCount: number
+  /**
+   * whether the description contains a URL
+   */
+  containsUrl: boolean
+}
+
 /**
  * When a document (version) is successfully added to a release
  */
@@ -118,4 +133,12 @@ export const ReleaseTitleCopied = defineEvent({
   name: 'Release Title Copied',
   version: 1,
   description: 'User copied release title to clipboard',
+})
+
+/** Records release description usage - set at creation or edited in Studio */
+export const ReleaseDescriptionSet = defineEvent<ReleaseDescriptionInfo>({
+  name: 'Release Description Set',
+  version: 1,
+  description:
+    'Whether a release description was set at creation or edited in Studio, with its character count (never the content itself)',
 })

--- a/packages/sanity/src/core/releases/components/dialog/CreateReleaseDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/CreateReleaseDialog.tsx
@@ -8,13 +8,18 @@ import {Button} from '../../../../ui-components/button/Button'
 import {Dialog} from '../../../../ui-components/dialog/Dialog'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {useSetPerspective} from '../../../perspective/useSetPerspective'
-import {CreatedRelease, type OriginInfo} from '../../__telemetry__/releases.telemetry'
+import {
+  CreatedRelease,
+  type OriginInfo,
+  ReleaseDescriptionSet,
+} from '../../__telemetry__/releases.telemetry'
 import {useCreateReleaseMetadata} from '../../hooks/useCreateReleaseMetadata'
 import {useGuardWithReleaseLimitUpsell} from '../../hooks/useGuardWithReleaseLimitUpsell'
 import {useReleaseFormStorage} from '../../hooks/useReleaseFormStorage'
 import {isReleaseLimitError} from '../../store/isReleaseLimitError'
 import {useReleaseOperations} from '../../store/useReleaseOperations'
 import {getIsReleaseInvalid} from '../../util/getIsReleaseInvalid'
+import {getReleaseDescriptionTelemetry} from '../../util/getReleaseDescriptionTelemetry'
 import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
 import {getReleaseDefaults} from '../../util/util'
 import {ReleaseForm} from './ReleaseForm'
@@ -61,6 +66,12 @@ export function CreateReleaseDialog(props: CreateReleaseDialogProps): React.JSX.
         // Close the dialog after creating the release.
         onCancel()
         telemetry.log(CreatedRelease, {origin})
+        if (release.metadata?.description) {
+          telemetry.log(
+            ReleaseDescriptionSet,
+            getReleaseDescriptionTelemetry('create', release.metadata.description),
+          )
+        }
 
         // TODO: Remove this! temporary fix to give some time for the release to be created and the releases store state updated before closing the dialog.
         await new Promise((resolve) => setTimeout(resolve, 1000))

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetailsEditor.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetailsEditor.tsx
@@ -15,9 +15,11 @@ function ReleaseDetailsEditorProduction({release}: {release: ReleaseDocument}): 
   const {updateRelease} = useReleaseOperations()
   const [timer, setTimer] = useState<NodeJS.Timeout | undefined>(undefined)
   const telemetry = useTelemetry()
-  // Tracks the last description we logged so title-only edits and repeated saves
-  // of an unchanged description do not emit duplicate telemetry.
-  const lastLoggedDescription = useRef(release.metadata?.description ?? '')
+  // Scoped to a release id because this component instance is reused across release navigation.
+  const lastLoggedDescription = useRef({
+    releaseId: release._id,
+    description: release.metadata?.description ?? '',
+  })
 
   const {checkWithPermissionGuard} = useReleasePermissions()
   const [hasUpdatePermission, setHasUpdatePermission] = useState<boolean | null>(null)
@@ -30,8 +32,18 @@ function ReleaseDetailsEditorProduction({release}: {release: ReleaseDocument}): 
       const newTimer = setTimeout(() => {
         if (hasUpdatePermission) {
           const nextDescription = changedValue.metadata?.description ?? ''
-          if (nextDescription !== lastLoggedDescription.current) {
-            lastLoggedDescription.current = nextDescription
+          const isSameRelease = lastLoggedDescription.current.releaseId === release._id
+          const baselineDescription = isSameRelease
+            ? lastLoggedDescription.current.description
+            : (release.metadata?.description ?? '')
+          const hasChangedDescription = nextDescription !== baselineDescription
+
+          lastLoggedDescription.current = {
+            releaseId: release._id,
+            description: nextDescription,
+          }
+
+          if (hasChangedDescription) {
             telemetry.log(
               ReleaseDescriptionSet,
               getReleaseDescriptionTelemetry('edit', nextDescription),
@@ -43,7 +55,7 @@ function ReleaseDetailsEditorProduction({release}: {release: ReleaseDocument}): 
 
       setTimer(newTimer)
     },
-    [hasUpdatePermission, timer, updateRelease, telemetry],
+    [hasUpdatePermission, timer, updateRelease, telemetry, release],
   )
 
   const isMounted = useRef(false)

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetailsEditor.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetailsEditor.tsx
@@ -1,16 +1,23 @@
 import {type EditableReleaseDocument, type ReleaseDocument} from '@sanity/client'
+import {useTelemetry} from '@sanity/telemetry/react'
 import {useCallback, useEffect, useRef, useState} from 'react'
 
 import {DetailIdentity} from '../../../components/detailLayout'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {useWorkspace} from '../../../studio/workspace'
+import {ReleaseDescriptionSet} from '../../__telemetry__/releases.telemetry'
 import {getIsReleaseOpen, TitleDescriptionForm} from '../../components/dialog/TitleDescriptionForm'
 import {useReleaseOperations} from '../../store/useReleaseOperations'
 import {useReleasePermissions} from '../../store/useReleasePermissions'
+import {getReleaseDescriptionTelemetry} from '../../util/getReleaseDescriptionTelemetry'
 
 function ReleaseDetailsEditorProduction({release}: {release: ReleaseDocument}): React.JSX.Element {
   const {updateRelease} = useReleaseOperations()
   const [timer, setTimer] = useState<NodeJS.Timeout | undefined>(undefined)
+  const telemetry = useTelemetry()
+  // Tracks the last description we logged so title-only edits and repeated saves
+  // of an unchanged description do not emit duplicate telemetry.
+  const lastLoggedDescription = useRef(release.metadata?.description ?? '')
 
   const {checkWithPermissionGuard} = useReleasePermissions()
   const [hasUpdatePermission, setHasUpdatePermission] = useState<boolean | null>(null)
@@ -22,13 +29,21 @@ function ReleaseDetailsEditorProduction({release}: {release: ReleaseDocument}): 
       /** @todo I wasn't able to get this working with the debouncer that we use in other parts */
       const newTimer = setTimeout(() => {
         if (hasUpdatePermission) {
+          const nextDescription = changedValue.metadata?.description ?? ''
+          if (nextDescription !== lastLoggedDescription.current) {
+            lastLoggedDescription.current = nextDescription
+            telemetry.log(
+              ReleaseDescriptionSet,
+              getReleaseDescriptionTelemetry('edit', nextDescription),
+            )
+          }
           void updateRelease(changedValue)
         }
       }, 200)
 
       setTimer(newTimer)
     },
-    [hasUpdatePermission, timer, updateRelease],
+    [hasUpdatePermission, timer, updateRelease, telemetry],
   )
 
   const isMounted = useRef(false)

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetailsEditor.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetailsEditor.test.tsx
@@ -5,6 +5,7 @@ import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
 import {flushMicrotasksThisIsACodeSmell} from '../../../../../../test/testUtils/flushMicrotasks'
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {ReleaseDescriptionSet} from '../../../__telemetry__/releases.telemetry'
 import {
   mockUseReleasePermissions,
   useReleasePermissionsMockReturn,
@@ -13,6 +14,12 @@ import {
 } from '../../../store/__tests__/__mocks/useReleasePermissions.mock'
 import {useReleaseOperations} from '../../../store/useReleaseOperations'
 import {ReleaseDetailsEditor} from '../ReleaseDetailsEditor'
+
+const mockTelemetryLog = vi.fn<(event: unknown, payload?: unknown) => void>()
+
+vi.mock('@sanity/telemetry/react', () => ({
+  useTelemetry: vi.fn(() => ({log: mockTelemetryLog})),
+}))
 
 // Mock the dependencies
 vi.mock('../../../store/useReleaseOperations', () => ({
@@ -34,6 +41,26 @@ const initialRelease = {
     intendedPublishAt: undefined,
   },
 } as ReleaseDocument
+
+const otherRelease = {
+  _id: 'release2',
+  metadata: {
+    title: 'Other Title',
+    description: 'Another description',
+    releaseType: 'asap',
+    intendedPublishAt: undefined,
+  },
+} as ReleaseDocument
+
+function getDescriptionTelemetryPayloads(): unknown[] {
+  return mockTelemetryLog.mock.calls
+    .filter(([event]) => event === ReleaseDescriptionSet)
+    .map(([, payload]) => payload)
+}
+
+function getUpdateReleaseMock(): Mock {
+  return (useReleaseOperations as unknown as Mock).mock.results[0]?.value.updateRelease
+}
 
 describe('ReleaseDetailsEditor', () => {
   describe('production (inline editing)', () => {
@@ -57,9 +84,6 @@ describe('ReleaseDetailsEditor', () => {
       render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
       await flushMicrotasksThisIsACodeSmell()
 
-      const updateReleaseMock = (useReleaseOperations as unknown as Mock).mock.results[0]?.value
-        .updateRelease
-
       const titleInput = screen.getByTestId('release-form-title') as HTMLTextAreaElement
       await userEvent.clear(titleInput)
       await userEvent.type(titleInput, 'New Title')
@@ -67,11 +91,115 @@ describe('ReleaseDetailsEditor', () => {
       await vi.advanceTimersByTimeAsync(250)
 
       await waitFor(() => {
-        expect(updateReleaseMock).toHaveBeenCalledWith(
+        expect(getUpdateReleaseMock()).toHaveBeenCalledWith(
           expect.objectContaining({
             metadata: expect.objectContaining({title: 'New Title'}),
           }),
         )
+      })
+      vi.useRealTimers()
+    })
+
+    it('logs release description telemetry when the description changes', async () => {
+      vi.useFakeTimers({shouldAdvanceTime: true})
+      const wrapper = await createTestProvider()
+      render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
+      await flushMicrotasksThisIsACodeSmell()
+
+      const nextDescription = 'See https://sanity.io'
+      const descriptionInput = screen.getByTestId('release-form-description') as HTMLTextAreaElement
+      await userEvent.clear(descriptionInput)
+      await userEvent.type(descriptionInput, nextDescription, {delay: null})
+
+      await vi.advanceTimersByTimeAsync(250)
+
+      await waitFor(() => {
+        expect(getDescriptionTelemetryPayloads()).toEqual([
+          {
+            action: 'edit',
+            characterCount: nextDescription.length,
+            containsUrl: true,
+          },
+        ])
+      })
+      expect(JSON.stringify(getDescriptionTelemetryPayloads())).not.toContain(nextDescription)
+      vi.useRealTimers()
+    })
+
+    it('does not log release description telemetry when only the title changes', async () => {
+      vi.useFakeTimers({shouldAdvanceTime: true})
+      const wrapper = await createTestProvider()
+      render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
+      await flushMicrotasksThisIsACodeSmell()
+
+      const titleInput = screen.getByTestId('release-form-title') as HTMLTextAreaElement
+      await userEvent.clear(titleInput)
+      await userEvent.type(titleInput, 'New Title', {delay: null})
+
+      await vi.advanceTimersByTimeAsync(250)
+
+      await waitFor(() => {
+        expect(getUpdateReleaseMock()).toHaveBeenCalledWith(
+          expect.objectContaining({
+            metadata: expect.objectContaining({title: 'New Title'}),
+          }),
+        )
+      })
+      expect(getDescriptionTelemetryPayloads()).toEqual([])
+      vi.useRealTimers()
+    })
+
+    it('does not log release description telemetry for a title edit after switching release', async () => {
+      vi.useFakeTimers({shouldAdvanceTime: true})
+      const wrapper = await createTestProvider()
+      // No key: the same component instance has to survive the release switch for this regression.
+      const {rerender} = render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
+      await flushMicrotasksThisIsACodeSmell()
+
+      rerender(<ReleaseDetailsEditor release={otherRelease} />)
+      await flushMicrotasksThisIsACodeSmell()
+
+      const titleInput = screen.getByTestId('release-form-title') as HTMLTextAreaElement
+      await userEvent.clear(titleInput)
+      await userEvent.type(titleInput, 'Renamed Title', {delay: null})
+
+      await vi.advanceTimersByTimeAsync(250)
+
+      await waitFor(() => {
+        expect(getUpdateReleaseMock()).toHaveBeenCalledWith(
+          expect.objectContaining({
+            metadata: expect.objectContaining({title: 'Renamed Title'}),
+          }),
+        )
+      })
+      expect(getDescriptionTelemetryPayloads()).toEqual([])
+      vi.useRealTimers()
+    })
+
+    it('logs release description telemetry for a description edit after switching release', async () => {
+      vi.useFakeTimers({shouldAdvanceTime: true})
+      const wrapper = await createTestProvider()
+      const {rerender} = render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
+      await flushMicrotasksThisIsACodeSmell()
+
+      rerender(<ReleaseDetailsEditor release={otherRelease} />)
+      await flushMicrotasksThisIsACodeSmell()
+
+      const nextDescription = 'Reworded'
+      const descriptionInput = screen.getByTestId('release-form-description') as HTMLTextAreaElement
+      await userEvent.clear(descriptionInput)
+      await userEvent.type(descriptionInput, nextDescription, {delay: null})
+
+      await vi.advanceTimersByTimeAsync(250)
+
+      await waitFor(() => {
+        expect(getDescriptionTelemetryPayloads()).toEqual([
+          {
+            action: 'edit',
+            characterCount: nextDescription.length,
+            containsUrl: false,
+          },
+        ])
       })
       vi.useRealTimers()
     })

--- a/packages/sanity/src/core/releases/util/__tests__/getReleaseDescriptionTelemetry.test.ts
+++ b/packages/sanity/src/core/releases/util/__tests__/getReleaseDescriptionTelemetry.test.ts
@@ -1,0 +1,30 @@
+import {describe, expect, it} from 'vitest'
+
+import {getReleaseDescriptionTelemetry} from '../getReleaseDescriptionTelemetry'
+
+describe('getReleaseDescriptionTelemetry', () => {
+  it('reports an absent description as an empty count', () => {
+    expect(getReleaseDescriptionTelemetry('create')).toEqual({
+      action: 'create',
+      characterCount: 0,
+      containsUrl: false,
+    })
+  })
+
+  it('passes the action through', () => {
+    expect(getReleaseDescriptionTelemetry('create', 'hello').action).toBe('create')
+    expect(getReleaseDescriptionTelemetry('edit', 'hello').action).toBe('edit')
+  })
+
+  it('counts characters without leaking the content', () => {
+    expect(getReleaseDescriptionTelemetry('edit', '').characterCount).toBe(0)
+    expect(getReleaseDescriptionTelemetry('edit', 'hello').characterCount).toBe(5)
+    expect(getReleaseDescriptionTelemetry('edit', 'a'.repeat(500)).characterCount).toBe(500)
+  })
+
+  it('detects URLs in the description', () => {
+    expect(getReleaseDescriptionTelemetry('edit', 'see https://example.com').containsUrl).toBe(true)
+    expect(getReleaseDescriptionTelemetry('edit', 'see www.example.com').containsUrl).toBe(true)
+    expect(getReleaseDescriptionTelemetry('edit', 'no links here').containsUrl).toBe(false)
+  })
+})

--- a/packages/sanity/src/core/releases/util/getReleaseDescriptionTelemetry.ts
+++ b/packages/sanity/src/core/releases/util/getReleaseDescriptionTelemetry.ts
@@ -1,0 +1,22 @@
+import {type ReleaseDescriptionInfo} from '../__telemetry__/releases.telemetry'
+
+const URL_PATTERN = /(https?:\/\/|www\.)/i
+
+/**
+ * Derives low-cardinality, privacy-preserving telemetry about a release
+ * description. The description content is never included in the result - only
+ * the action (set at creation vs edited), its character count, and whether it
+ * contains a URL.
+ */
+export function getReleaseDescriptionTelemetry(
+  action: ReleaseDescriptionInfo['action'],
+  description?: string,
+): ReleaseDescriptionInfo {
+  const value = description ?? ''
+
+  return {
+    action,
+    characterCount: value.length,
+    containsUrl: URL_PATTERN.test(value),
+  }
+}


### PR DESCRIPTION
### Description

Part of [SAPP-3763](https://linear.app/sanity/issue/SAPP-3763/instrument-and-monitor-content-release-usage) - instrument content release usage.

We have no data on whether users set release descriptions when creating a release, or edit them afterward in Studio. This PR adds that instrumentation while guaranteeing the description content is never logged:

- New `Release Description Set` telemetry event with a privacy-preserving payload:
  - `action: 'create' | 'edit'` - set at creation vs edited on an existing release
  - `characterCount: number` - raw character count of the description (never the content)
  - `containsUrl: boolean`
- Logged with `action: 'create'` from `CreateReleaseDialog` when a description was provided at creation.
- Logged with `action: 'edit'` from the inline release-details editor whenever the persisted description actually changes. A ref tracks the last-logged description so title-only edits and duplicate autosaves of an unchanged description don't emit events.
- `getReleaseDescriptionTelemetry(action, description?)` derives the payload, unit-tested in isolation.
- Documents the new event in `docs/TELEMETRY.md`.

**Scope of this PR vs the issue.** Duplicate and revert events already exist (`Release Duplicated`, `Release Reverted` with `revertType`), and the release action coverage (create/delete/publish/schedule/unschedule/archive/unarchive/revert/duplicate/copy) is already comprehensive. The Looker dashboard (volume, success rate, description usage) is analytics work outside this repo and remains a follow-up on the Linear issue.

**Research instrumentation, versioned.** This is exploratory work to understand how release descriptions are actually used; it is not a stable data contract. The event is defined with `version: 1`, and the payload shape is expected to change as the questions change - for example, if URL presence stops being interesting we would drop `containsUrl` and bump the event to `version: 2`.

**Variants editor.** `main` split `ReleaseDetailsEditor` into an inline-editable production path (`ReleaseDetailsEditorProduction`) and a read-only display used behind the `beta.variants` flag (`ReleaseDetailsEditorVariants`). Edit telemetry lives in the production path. The variants path renders a read-only surface and edits through a separate dialog, so it emits no `action: 'edit'` events here; instrumenting that beta path is a follow-up if its edit coverage is needed.

### What to review

- `getReleaseDescriptionTelemetry.ts` - returns `{action, characterCount, containsUrl}`; character count is a raw `.length` (no bucketing), URL detection is `https?://` or `www.`. Content is never returned.
- `releases.telemetry.ts` - `ReleaseDescriptionInfo` + `ReleaseDescriptionSet` event, named to match the sibling `Release*` exports and following the `OriginInfo`/`RevertInfo` conventions in the same file.
- `CreateReleaseDialog.tsx` - logs `action: 'create'` after `CreatedRelease`, only when the user provided a description.
- `ReleaseDetailsEditor.tsx` - logs `action: 'edit'` inside `ReleaseDetailsEditorProduction`'s existing 200ms debounced autosave, gated by a `lastLoggedDescription` ref so it fires only on real description changes (not title edits). This path autosaves rather than having a submit boundary, which is why ref-based change detection is used instead of firing on every keystroke.
- `ReleaseDetailsEditor.tsx`, the shape of that ref - it holds `{releaseId, description}` rather than a bare description. Nothing in the chain from `ReleaseDetail` down keys the subtree, so the component instance survives navigation between releases; the pre-existing `<TitleDescriptionForm key={release._id}>` exists for exactly that reason. A description-only baseline would therefore carry the previous release's description into the next one and emit a false-positive event on a title-only edit. The baseline re-derives from the current release whenever the stored id differs. It is read inside the debounced callback rather than reset from an effect, so a timer scheduled before the release prop changed cannot be measured against the wrong baseline.
- `docs/TELEMETRY.md` - Releases table row.

### Testing

`getReleaseDescriptionTelemetry.test.ts` covers absent description, action pass-through (`create`/`edit`), exact character counts, and URL detection.

`ReleaseDetailsEditor.test.tsx` covers the gating in the component: an event fires on a description change carrying the derived payload and not the description text, no event fires on a title-only edit, no event fires on a title-only edit after switching release, and an event still fires on a description edit after switching release. The release-switch cases rerender the same instance with a different release and deliberately pass no key. Against a description-only baseline the title-only variant fails with a false-positive `{action: 'edit', characterCount: 19, containsUrl: false}` payload, which is the regression it pins.

```
pnpm vitest run --project=sanity packages/sanity/src/core/releases
```

53 test files and 573 tests pass with no type errors. Format (oxfmt) and type-aware oxlint on the changed files are clean, save one pre-existing `@todo` tsdoc warning inherited from the editor.

### Notes for release

N/A

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Analytics-only changes with no description content in payloads; no auth, persistence, or release lifecycle behavior changes.
> 
> **Overview**
> Adds **`Release Description Set`** telemetry so product can see whether release descriptions are set at creation or edited later, without ever logging description text.
> 
> Payload is derived by **`getReleaseDescriptionTelemetry`**: `action` (`create` | `edit`), **`characterCount`**, and **`containsUrl`**. **`CreateReleaseDialog`** emits `create` after a successful create when a description was provided. **`ReleaseDetailsEditor`** (production inline path) emits `edit` on debounced autosave only when the description actually changed; a **`{releaseId, description}`** ref avoids false events on title-only edits and when the same component instance navigates between releases.
> 
> Documented in **`docs/TELEMETRY.md`**, with unit and component tests covering payload shape, privacy, and release-switch gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0467e4f9a5e238da95592d998a7fe08ebb8dbd7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->