### PR TITLE
feat(sanity): install ui-poc for Studio, migrate 2 Boxes

### DIFF
--- a/packages/@repo/test-dts-exports/test/lib-check.test.ts
+++ b/packages/@repo/test-dts-exports/test/lib-check.test.ts
@@ -72,6 +72,12 @@ const filteredErrors = errors.filter((d) => {
     return false
   }
 
+  // Workaround for @sanity-labs/ui-poc’s stylesheet, which TypeScript reports as a TS2882 under
+  // skipLibCheck: false in this suite.
+  if (code === 2882 && d.messageText.toString().includes('@sanity-labs/ui-poc/styles.css')) {
+    return false
+  }
+
   return true
 })
 

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -149,6 +149,7 @@
     "@portabletext/to-html": "^5.0.2",
     "@portabletext/toolkit": "^5.0.2",
     "@rexxars/react-json-inspector": "^9.0.1",
+    "@sanity-labs/ui-poc": "0.0.1-alpha.22",
     "@sanity/asset-utils": "^2.3.0",
     "@sanity/bifur-client": "^1.0.0",
     "@sanity/cli": "^7.14.0",

--- a/packages/sanity/src/core/studio/Studio.tsx
+++ b/packages/sanity/src/core/studio/Studio.tsx
@@ -1,5 +1,7 @@
 // oxlint-disable-next-line no-unassigned-import -- style import is effectful
 import './styles.css'
+// oxlint-disable-next-line no-unassigned-import -- Sanity UI POC styles are required for its components
+import '@sanity-labs/ui-poc/styles.css'
 
 /* disabling for now because the imports trigger side effects causing test snapshots to update */
 import {type Config} from '../config/types'

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPaneSearchOrdering.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPaneSearchOrdering.tsx
@@ -1,5 +1,6 @@
+import {Box} from '@sanity-labs/ui-poc'
 import {SortIcon} from '@sanity/icons/Sort'
-import {Box, Menu, MenuDivider, Text} from '@sanity/ui'
+import {Menu, MenuDivider, Text} from '@sanity/ui'
 import {memo, useId} from 'react'
 import {useGetI18nText, useTranslation} from 'sanity'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1625,6 +1625,9 @@ importers:
       '@rexxars/react-json-inspector':
         specifier: ^9.0.1
         version: 9.0.1(react@19.2.8)
+      '@sanity-labs/ui-poc':
+        specifier: 0.0.1-alpha.22
+        version: 0.0.1-alpha.22(react-dom@19.2.8)(react@19.2.8)
       '@sanity/asset-utils':
         specifier: ^2.3.0
         version: 2.3.0
@@ -6066,6 +6069,13 @@ packages:
     resolution: {integrity: sha512-+i7GXix4Akt34VDWgSM1Lpq8Hxf8SH8022uNsDRXSNuAqQMjKVGWLItAyc2TyfWVwWZLhsCF3lj5tdW7cecDxQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
+  '@sanity-labs/ui-poc@0.0.1-alpha.22':
+    resolution: {integrity: sha512-tCqeNli37iywzAJMBItf5psypwi3GHleAwWWr3d2jfByzymlpDwinElYS2sCofsXKEFuCWOIu43YuQgob/EJPA==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      react: ^19.2
+      react-dom: ^19.2
+
   '@sanity/ailf@7.32.0':
     resolution: {integrity: sha512-M40pmQFraebMDrucx7FPAUPDu9sccX9Zp5xvthnM5c31QZpMoodnMc9IOko5+QvPDwdcMm7a9TebQe/c0pihUg==}
     hasBin: true
@@ -6223,6 +6233,12 @@ packages:
       react: ^19.2
       react-dom: ^19.2
       sanity: ^5 || ^6.0.0-0
+
+  '@sanity/icons@3.8.0':
+    resolution: {integrity: sha512-LXa8eoE6U2e46L/9Pk6VU1aOWNxEqEG1osTb2YWItPIAa8MyXkICRwdNRWwW3kr5gmf+Sh2ZmfKol/Q+oGKSqw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^18.3 || ^19.0.0-0
 
   '@sanity/icons@5.2.1':
     resolution: {integrity: sha512-P5gY1HRungh4RgCcypdIpu/SKoTwRBTttpbHntZjdW1MO3MK6xEOs+pbAzSARyhh22OcN9PkBBEYk2FL34BvfQ==}
@@ -17623,6 +17639,15 @@ snapshots:
 
   '@sanity-labs/design-tokens@0.0.2-alpha.4': {}
 
+  '@sanity-labs/ui-poc@0.0.1-alpha.22(react-dom@19.2.8)(react@19.2.8)':
+    dependencies:
+      '@sanity-labs/design-tokens': 0.0.2-alpha.4
+      '@sanity/icons': 3.8.0(react@19.2.8)
+      clsx: 2.1.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-refractor: 4.0.0(react@19.2.8)
+
   '@sanity/ailf@7.32.0(@aws-sdk/credential-provider-node@3.972.70)(@noble/hashes@2.2.0)(@smithy/signature-v4@5.6.6)(@types/json-schema@7.0.15)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(debug@4.3.4)(pg@8.22.0)(playwright-core@1.62.0)(socks@2.8.9)(supports-color@8.1.1)':
     dependencies:
       '@google-cloud/bigquery': 8.3.1(supports-color@8.1.1)
@@ -18137,6 +18162,10 @@ snapshots:
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - styled-components
+
+  '@sanity/icons@3.8.0(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
 
   '@sanity/icons@5.2.1(react@19.2.8)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,6 +68,7 @@ minimumReleaseAgeExclude:
   - '@vitejs/plugin-react'
   - '@portabletext/*'
   - '@sanity/*'
+  - '@sanity-labs/ui-poc'
   - '@yuku-codegen/*'
   - '@yuku-parser/*'
   - '@yuku-toolchain/types'


### PR DESCRIPTION
### Description

This PR installs the latest `@sanity-labs/ui-poc` as a dependency for Studio as a test case for us (Sanity UI team) getting up and running with the Studio/monorepo workflow. As CI hit me with a ‘no unused dependencies’ failure when I tried to just install the package, I've now also migrated Box in 1 file (2 instances).

- `@sanity-labs/ui-poc` added as a dependency
  - also added to the minimumReleaseAge allow list, since this package will be changing frequently
- I had to add a case for the lib-check test to bypass a TS2882 error for UI POC. @jordanl17 suggested this approach, but on further research [it looks like ambient module declaration is what's recommended by the TS team](https://schalkneethling.com/posts/typescript-6-0-and-css-side-effect-imports-what-changed-and-how-to-fix-it/). I'm also happy to do that, or whatever else if anyone feels there's a preferred option over what's in this PR.
  - Note: The `file.fileName` strategy didn't work in the lib-check test for this exception as the fileName was pointing to an index file in the Studio app; thus, I relied on the diagnostic's message text to catch it.
- Migrated 2 Boxes in [DocumentListPaneSearchOrdering.tsx‎](https://github.com/sanity-io/sanity/pull/13776/changes#diff-9f4142af225b41c4feaed964f705ed9c2fe9bfa88a7604a82e4ca76b3f7b3e07) — I've verified that the rendered output is unchanged.

### What to review

- Any changes you'd like to see re: catching the lib-check issue?
- Open to any and all feedback otherwise!

### Testing

- Verified rendered output for migrated Box is unchanged

### Notes for release

N/A: Internal only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to an alpha UI dependency, a global stylesheet import on Studio boot, and two Box swaps in one structure pane; no auth or data-path changes.
> 
> **Overview**
> Adds **`@sanity-labs/ui-poc`** (`0.0.1-alpha.22`) to the **`sanity`** package so the UI team can exercise the Studio monorepo workflow, with **`@sanity-labs/ui-poc`** on **`minimumReleaseAgeExclude`** for frequent alpha publishes.
> 
> **Studio** now loads **`@sanity-labs/ui-poc/styles.css`** alongside existing studio styles. **`DocumentListPaneSearchOrdering`** uses **`Box`** from the POC instead of **`@sanity/ui`** (two call sites); menus/text still come from **`@sanity/ui`**.
> 
> The **`skipLibCheck: false`** DTS export test ignores **TS2882** when diagnostics mention **`@sanity-labs/ui-poc/styles.css`**, matching the side-effect CSS import pattern used for **`@sanity/vision`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8343f33f529830012e5c837f14c20867fd793ce9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->