### PR TITLE
feat(core): shared detail spine and document table, adopted on releases detail

### DIFF
--- a/packages/sanity/src/core/components/detailLayout/DetailActionRail.tsx
+++ b/packages/sanity/src/core/components/detailLayout/DetailActionRail.tsx
@@ -1,0 +1,29 @@
+import {Flex} from '@sanity/ui'
+import {type ReactNode} from 'react'
+
+/**
+ * The top-right action rail of an entity detail page: optional secondary action(s), one prominent
+ * primary action, then an overflow `⋯` menu. Placed top-right so the most primary action is where
+ * the eye lands first (F-pattern), rather than hunted for in a bottom footer. A pure layout shell —
+ * each page supplies its own actions, so the primary's weight can scale to its consequence (a loud,
+ * confirm-gated "Run release" vs. a calm "Edit definition"), with lighter secondary actions (e.g.
+ * an icon-only "Edit details") sitting beside it. Shared by the Releases and Variant-definition
+ * detail pages so both read as one family.
+ *
+ * @internal
+ */
+export function DetailActionRail(props: {
+  secondary?: ReactNode
+  primary?: ReactNode
+  menu?: ReactNode
+}): React.JSX.Element | null {
+  const {secondary, primary, menu} = props
+  if (!secondary && !primary && !menu) return null
+  return (
+    <Flex flex="none" gap={2} align="center" data-ui="detail-action-rail">
+      {secondary}
+      {primary}
+      {menu}
+    </Flex>
+  )
+}

--- a/packages/sanity/src/core/components/detailLayout/DetailBackButton.tsx
+++ b/packages/sanity/src/core/components/detailLayout/DetailBackButton.tsx
@@ -1,0 +1,37 @@
+import {ArrowLeftIcon} from '@sanity/icons/ArrowLeft'
+import {
+  // oxlint-disable-next-line no-restricted-imports
+  Button, // Restricted Button: needs textWeight="regular", which the ui-components wrapper does not expose.
+} from '@sanity/ui'
+
+// The bleed back-button carries its own horizontal padding, which would push the label right of the
+// title/table left edge. Cancel that padding so the button sits on the same hard left line as
+// everything below it, framing the pane.
+const BACK_ALIGN_STYLE = {marginLeft: -8}
+
+/**
+ * `← Back to all <X>` — the single back affordance at the top-left of a detail page. The entity
+ * title headlines the pane below, so the back control does not repeat it; it only says where "back"
+ * goes. Shared by the Releases and Variant-definition detail pages so both read as one family.
+ *
+ * @internal
+ */
+export function DetailBackButton(props: {
+  text: string
+  onClick: () => void
+  testId?: string
+}): React.JSX.Element {
+  const {text, onClick, testId} = props
+  return (
+    <Button
+      icon={ArrowLeftIcon}
+      mode="bleed"
+      onClick={onClick}
+      text={text}
+      textWeight="regular"
+      padding={2}
+      style={BACK_ALIGN_STYLE}
+      data-testid={testId}
+    />
+  )
+}

--- a/packages/sanity/src/core/components/detailLayout/DetailIdentity.tsx
+++ b/packages/sanity/src/core/components/detailLayout/DetailIdentity.tsx
@@ -1,0 +1,120 @@
+import {Box, Flex, Stack, Text} from '@sanity/ui'
+import {getTheme_v2} from '@sanity/ui/theme'
+import {type ElementType, type ReactNode} from 'react'
+import {css, styled} from 'styled-components'
+
+import {Tooltip} from '../../../ui-components/tooltip/Tooltip'
+
+const DESCRIPTION_TOOLTIP_MAX_WIDTH = 360
+
+// Bounded, four-line description: title + up to four lines makes the identity block sit at (and
+// never exceed) the height of the properties panel beside it, so the top band is one even zone.
+// Full text lives in the hover tooltip; maxWidth keeps the line length fixed rather than stretching
+// across the whole pane.
+//
+// This is a plain styled.div rather than @sanity/ui <Text> on purpose: <Text> forces its own
+// `display` (flow-root), which defeats `-webkit-line-clamp` (that needs display:-webkit-box) and
+// collapses the box, clipping the first line. Owning the element lets the clamp work correctly.
+const ClampedDescription = styled.div((props) => {
+  const {font} = getTheme_v2(props.theme)
+  return css`
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+    overflow: hidden;
+    max-width: 560px;
+    margin: 0;
+    font-family: ${font.text.family};
+    font-size: ${font.text.sizes[2].fontSize}px;
+    line-height: ${font.text.sizes[2].lineHeight}px;
+    color: var(--card-muted-fg-color);
+  `
+})
+
+// An optional action beside the title reveals on hover (or keyboard focus, for a11y), so at rest
+// the pane reads as plain content. Callers that pass no `titleAction` get a clean display surface.
+// (Title/panel top-edge alignment is handled on the panel side — it drops to meet the title's
+// cap-height — rather than lifting the title with a negative margin, which would clip its caps
+// under an overflow-hidden header.)
+const Identity = styled(Stack)`
+  [data-ui='detail-identity-action'] {
+    opacity: 0;
+    transition: opacity 150ms;
+  }
+
+  &:hover [data-ui='detail-identity-action'],
+  &:focus-within [data-ui='detail-identity-action'] {
+    opacity: 1;
+  }
+`
+
+/**
+ * The identity block (title + description) of an entity detail page, as a read-only **display**
+ * surface. Title renders bold; description clamps to four lines with the full text on hover. An
+ * optional `titleAction` (revealed on hover/focus) can sit beside the title. Shared by the Releases
+ * and Variant-definition detail pages so both read as one family.
+ *
+ * @internal
+ */
+export function DetailIdentity(props: {
+  title: string | undefined
+  titlePlaceholder: string
+  description?: string
+  titleAction?: ReactNode
+  /** Element the title renders as — pass `"h1"` to make it the page heading. Defaults to a span. */
+  titleAs?: ElementType
+  titleTestId?: string
+  descriptionTestId?: string
+}): React.JSX.Element {
+  const {
+    title,
+    titlePlaceholder,
+    description,
+    titleAction,
+    titleAs,
+    titleTestId,
+    descriptionTestId,
+  } = props
+
+  return (
+    <Identity space={3}>
+      <Flex align="center" gap={2}>
+        {/* Box flex={1} + min-width:0 lets the title shrink and truncate instead of overflowing its
+            zone; the full title is available on hover. */}
+        <Box flex={1} style={{minWidth: 0}}>
+          <Text
+            as={titleAs}
+            size={4}
+            weight="bold"
+            textOverflow="ellipsis"
+            title={title || undefined}
+            style={title ? undefined : {opacity: 0.5}}
+            data-testid={titleTestId}
+          >
+            {title || titlePlaceholder}
+          </Text>
+        </Box>
+        {titleAction && (
+          <Box flex="none" data-ui="detail-identity-action">
+            {titleAction}
+          </Box>
+        )}
+      </Flex>
+
+      {description && (
+        <Tooltip
+          placement="bottom-start"
+          content={
+            <Box padding={2} style={{maxWidth: DESCRIPTION_TOOLTIP_MAX_WIDTH}}>
+              <Text muted size={1} style={{whiteSpace: 'pre-wrap'}}>
+                {description}
+              </Text>
+            </Box>
+          }
+        >
+          <ClampedDescription data-testid={descriptionTestId}>{description}</ClampedDescription>
+        </Tooltip>
+      )}
+    </Identity>
+  )
+}

--- a/packages/sanity/src/core/components/detailLayout/DetailPropertiesPanel.tsx
+++ b/packages/sanity/src/core/components/detailLayout/DetailPropertiesPanel.tsx
@@ -64,7 +64,7 @@ const GlyphCell = styled.div`
  * A single row: an optional leading `icon` (a glyph accompanying the label), a `label`, and a
  * `value`. `null`/`false` rows are skipped, so callers can inline conditions.
  */
-export interface DetailPropertyRow {
+interface DetailPropertyRow {
   icon?: ReactNode
   label: string
   value: ReactNode

--- a/packages/sanity/src/core/components/detailLayout/DetailPropertiesPanel.tsx
+++ b/packages/sanity/src/core/components/detailLayout/DetailPropertiesPanel.tsx
@@ -1,0 +1,196 @@
+import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
+import {getTheme_v2} from '@sanity/ui/theme'
+import {Fragment, type ReactNode} from 'react'
+import {css, styled} from 'styled-components'
+
+// At or above this many rows, a `multiColumn` section splits into two side-by-side columns so a
+// long list (e.g. six targeting conditions) reads as a compact block instead of a tall stack.
+// Below it, a short list stays single-column — two columns of one or two rows just looks sparse.
+const MULTI_COLUMN_THRESHOLD = 5
+
+// The size of the detail-page title (bold, size 4) this panel sits beside. Used to drop the panel by
+// the title's top half-leading below.
+const TITLE_SIZE = 4
+
+// The panel sizes to its content (so a short two-row panel doesn't leave a wide empty gap) but never
+// grows past a sensible max, at which point long values truncate instead of stretching the pane.
+//
+// margin-top drops the panel by the title's top half-leading so its top border lines up with the
+// title's visible cap-height beside it (a text line-box is taller than its glyphs, so the title cap
+// sits a few px below its layout top). Compensating on the panel — moving it down — rather than
+// lifting the title up avoids clipping the title's caps under an overflow-hidden header. Derived from
+// theme font metrics so it tracks the type scale.
+const PropertiesCard = styled(Card)<{$maxWidth: number}>((props) => {
+  const {font} = getTheme_v2(props.theme)
+  const {fontSize, lineHeight} = font.text.sizes[TITLE_SIZE]
+  const titleTopLeading = Math.round((lineHeight - fontSize) / 2)
+  return css`
+    width: fit-content;
+    max-width: ${props.$maxWidth}px;
+    margin-top: ${titleTopLeading}px;
+  `
+})
+
+// One grid per section so every row shares column tracks and stays aligned:
+//  - glyph  (auto) — only present when the section has glyphs
+//  - label  (max-content) — sizes to the widest label, so labels never truncate and values start on
+//                           one clean left edge
+//  - value  (minmax(0, 1fr)) — takes the rest; min-width:0 lets a long value truncate in its column
+// grid-auto-rows keeps every row on an even minimum height, matching the old rhythm.
+const SectionGrid = styled.div<{$hasGlyphs: boolean}>`
+  display: grid;
+  align-items: center;
+  column-gap: 12px;
+  row-gap: 6px;
+  grid-auto-rows: minmax(25px, auto);
+  ${(props) =>
+    props.$hasGlyphs
+      ? css`
+          grid-template-columns: auto max-content minmax(0, 1fr);
+        `
+      : css`
+          grid-template-columns: max-content minmax(0, 1fr);
+        `}
+`
+
+const GlyphCell = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+`
+
+/**
+ * A single row: an optional leading `icon` (a glyph accompanying the label), a `label`, and a
+ * `value`. `null`/`false` rows are skipped, so callers can inline conditions.
+ */
+export interface DetailPropertyRow {
+  icon?: ReactNode
+  label: string
+  value: ReactNode
+  /**
+   * In a `multiColumn` section, keep this row out of the two-column split and render it full-width
+   * on its own line directly below the columns (e.g. a "Created" provenance row that isn't one of
+   * the split conditions). Ignored in single-column sections.
+   */
+  fullWidth?: boolean
+}
+
+/** A group of rows, optionally headed by a section title. */
+export interface DetailPropertiesSection {
+  title?: string
+  rows: (DetailPropertyRow | null | false | undefined)[]
+  /**
+   * When set, a section with several rows splits into two side-by-side columns (each a self-aligned
+   * `[glyph] [label] [value]` grid), collapsing back to one column when the panel is too narrow to
+   * hold both. Off by default, so single-column sections (e.g. Releases) are unaffected.
+   */
+  multiColumn?: boolean
+}
+
+// One aligned [glyph] [label] [value] grid for a set of rows. Factored out so a multi-column
+// section can render two of them side by side while each keeps its own internal alignment.
+function PropertyRowsGrid({
+  rows,
+  hasGlyphs,
+}: {
+  rows: DetailPropertyRow[]
+  hasGlyphs: boolean
+}): React.JSX.Element {
+  return (
+    <SectionGrid $hasGlyphs={hasGlyphs}>
+      {rows.map((row, rowIndex) => (
+        // oxlint-disable-next-line no-array-index-key
+        <Fragment key={rowIndex}>
+          {hasGlyphs && <GlyphCell>{row.icon}</GlyphCell>}
+          <Text muted size={1}>
+            {row.label}
+          </Text>
+          {/* Pure-text value on one left edge; a long value truncates (title tooltip shows the full
+              text) rather than wrapping and breaking the single-line grid. */}
+          <Box style={{minWidth: 0}}>
+            {typeof row.value === 'string' ? (
+              <Text size={1} textOverflow="ellipsis" title={row.value}>
+                {row.value}
+              </Text>
+            ) : (
+              row.value
+            )}
+          </Box>
+        </Fragment>
+      ))}
+    </SectionGrid>
+  )
+}
+
+/**
+ * The bordered "properties" surface beside the identity block on an entity detail page. Renders N
+ * labeled sections as an aligned `[glyph] [label] [value]` grid: a leading-glyph column, a
+ * content-sized label column, and a value column of pure single-line text (semantic colour carries
+ * meaning; no chips). The panel sizes to its content up to `maxWidth`; values that overflow truncate
+ * with a tooltip rather than wrap. Shared by the Releases and Variant-definition detail pages so both
+ * read as one family.
+ *
+ * @internal
+ */
+export function DetailPropertiesPanel(props: {
+  sections: DetailPropertiesSection[]
+  testId?: string
+  /** Upper bound on the panel width; it shrinks to fit its content below this. */
+  maxWidth?: number
+}): React.JSX.Element {
+  const {sections, testId, maxWidth = 300} = props
+
+  return (
+    <PropertiesCard
+      flex="none"
+      border
+      radius={3}
+      padding={3}
+      tone="transparent"
+      $maxWidth={maxWidth}
+      data-testid={testId}
+    >
+      <Stack space={4}>
+        {sections.map((section, sectionIndex) => {
+          const rows = section.rows.filter((row): row is DetailPropertyRow => Boolean(row))
+          if (rows.length === 0) return null
+          // Only reserve the glyph column when a row in this section actually carries a glyph.
+          const hasGlyphs = rows.some((row) => Boolean(row.icon))
+          // A multi-column section splits its regular rows into two balanced columns that wrap back
+          // to one when the panel is squeezed (flex-wrap, so no container-query fragility). Rows
+          // flagged `fullWidth` stay out of the split and render on their own line just below it —
+          // provenance like "Created" that isn't one of the split conditions. The first (left)
+          // column takes the ceiling half, so an odd count leans left.
+          const splitRows = section.multiColumn ? rows.filter((row) => !row.fullWidth) : rows
+          const fullWidthRows = section.multiColumn ? rows.filter((row) => row.fullWidth) : []
+          const splitIntoColumns = section.multiColumn && splitRows.length >= MULTI_COLUMN_THRESHOLD
+          const leftCount = Math.ceil(splitRows.length / 2)
+
+          return (
+            // Sections are positional and static, so the index is a stable key.
+            // oxlint-disable-next-line no-array-index-key
+            <Stack key={sectionIndex} space={2}>
+              {section.title && (
+                <Text muted size={0} weight="semibold" style={{textTransform: 'uppercase'}}>
+                  {section.title}
+                </Text>
+              )}
+              {splitIntoColumns ? (
+                <Flex gap={4} wrap="wrap">
+                  <PropertyRowsGrid hasGlyphs={hasGlyphs} rows={splitRows.slice(0, leftCount)} />
+                  <PropertyRowsGrid hasGlyphs={hasGlyphs} rows={splitRows.slice(leftCount)} />
+                </Flex>
+              ) : (
+                <PropertyRowsGrid hasGlyphs={hasGlyphs} rows={splitRows} />
+              )}
+              {fullWidthRows.length > 0 && (
+                <PropertyRowsGrid hasGlyphs={hasGlyphs} rows={fullWidthRows} />
+              )}
+            </Stack>
+          )
+        })}
+      </Stack>
+    </PropertiesCard>
+  )
+}

--- a/packages/sanity/src/core/components/detailLayout/index.ts
+++ b/packages/sanity/src/core/components/detailLayout/index.ts
@@ -1,0 +1,8 @@
+export {DetailActionRail} from './DetailActionRail'
+export {DetailBackButton} from './DetailBackButton'
+export {DetailIdentity} from './DetailIdentity'
+export {
+  DetailPropertiesPanel,
+  type DetailPropertiesSection,
+  type DetailPropertyRow,
+} from './DetailPropertiesPanel'

--- a/packages/sanity/src/core/components/detailLayout/index.ts
+++ b/packages/sanity/src/core/components/detailLayout/index.ts
@@ -1,8 +1,4 @@
 export {DetailActionRail} from './DetailActionRail'
 export {DetailBackButton} from './DetailBackButton'
 export {DetailIdentity} from './DetailIdentity'
-export {
-  DetailPropertiesPanel,
-  type DetailPropertiesSection,
-  type DetailPropertyRow,
-} from './DetailPropertiesPanel'
+export {DetailPropertiesPanel, type DetailPropertiesSection} from './DetailPropertiesPanel'

--- a/packages/sanity/src/core/components/documentTable/EditedByCell.tsx
+++ b/packages/sanity/src/core/components/documentTable/EditedByCell.tsx
@@ -1,0 +1,79 @@
+import {Flex, Text} from '@sanity/ui'
+import {styled} from 'styled-components'
+
+import {useDocumentLastEditedBy} from '../../store/translog/useDocumentLastEditedBy'
+import {useUser} from '../../store/user/hooks'
+import {AvatarSkeleton, UserAvatar} from '../userAvatar/UserAvatar'
+
+// container-query wrapper: show the editor's name when the cell has room, collapse to just the
+// avatar when the column is squeezed narrow. The avatar always carries the name in its tooltip, so
+// nothing is lost when the label is hidden. `width: 100%` is required: `container-type: inline-size`
+// imposes size containment, so without a definite width the element collapses to ~0 (a shrink-to-fit
+// flex item derives no intrinsic width once contained) and the query would report "narrow" always.
+const CellRoot = styled(Flex)`
+  container-type: inline-size;
+  width: 100%;
+  min-width: 0;
+`
+const NameText = styled(Text)`
+  min-width: 0;
+  @container (max-width: 108px) {
+    display: none;
+  }
+`
+
+/**
+ * Presentation for an "Edited by" cell: the avatar + display name of a resolved editor id. A
+ * person-named column (not just an avatar) is what distinguishes authorship from live presence — the
+ * two used to read as the same round avatar. Collapses to avatar-only when the column is too narrow
+ * to fit the name. Shared by the Releases and Variant document tables, each of which resolves the
+ * editor id through its own history source.
+ *
+ * @internal
+ */
+export function EditedByAvatar({
+  userId,
+  loading,
+}: {
+  userId: string | undefined
+  loading: boolean
+}): React.JSX.Element | null {
+  const [user] = useUser(userId ?? '')
+
+  if (loading) {
+    return <AvatarSkeleton $size={0} animated />
+  }
+
+  if (!userId) {
+    return null
+  }
+
+  return (
+    <CellRoot align="center" gap={2}>
+      <UserAvatar size={0} user={userId} withTooltip />
+      {user?.displayName && (
+        <NameText muted size={1} textOverflow="ellipsis">
+          {user.displayName}
+        </NameText>
+      )}
+    </CellRoot>
+  )
+}
+
+/**
+ * "Edited by" cell for the variant document table: resolves the last editor from the document's
+ * transaction log, then renders {@link EditedByAvatar}.
+ *
+ * @internal
+ */
+export function EditedByCell({
+  documentId,
+  revision,
+}: {
+  documentId: string | undefined
+  revision?: string
+}): React.JSX.Element | null {
+  const {lastEditedBy, loading} = useDocumentLastEditedBy(documentId, revision)
+
+  return <EditedByAvatar loading={loading} userId={lastEditedBy} />
+}

--- a/packages/sanity/src/core/components/documentTable/__tests__/EditedByCell.test.tsx
+++ b/packages/sanity/src/core/components/documentTable/__tests__/EditedByCell.test.tsx
@@ -1,0 +1,77 @@
+import {render, screen} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {useDocumentLastEditedBy} from '../../../store/translog/useDocumentLastEditedBy'
+import {useUser} from '../../../store/user/hooks'
+import {EditedByCell} from '../EditedByCell'
+
+vi.mock('../../../store/translog/useDocumentLastEditedBy', () => ({
+  useDocumentLastEditedBy: vi.fn(),
+}))
+
+// Partial mock: the test provider's internals (CopyPasteProvider) use useCurrentUser from this same
+// module, so keep everything real and override only useUser.
+vi.mock('../../../store/user/hooks', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useUser: vi.fn(() => [undefined, false]),
+}))
+
+// Isolate the cell from the real avatar/profile resolution; assert on stand-ins.
+vi.mock('../../userAvatar/UserAvatar', () => ({
+  UserAvatar: vi.fn(({user}) => <div data-testid="user-avatar">{user}</div>),
+  AvatarSkeleton: vi.fn(() => <div data-testid="avatar-skeleton" />),
+}))
+
+const mockUseDocumentLastEditedBy = vi.mocked(useDocumentLastEditedBy)
+const mockUseUser = vi.mocked(useUser)
+
+async function renderCell(ui: React.ReactElement) {
+  const wrapper = await createTestProvider()
+  return render(ui, {wrapper})
+}
+
+describe('EditedByCell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseUser.mockReturnValue([undefined, false])
+  })
+
+  it('shows a skeleton while the last editor is loading', async () => {
+    mockUseDocumentLastEditedBy.mockReturnValue({lastEditedBy: undefined, loading: true})
+
+    await renderCell(<EditedByCell documentId="doc-1" />)
+
+    expect(screen.getByTestId('avatar-skeleton')).toBeInTheDocument()
+    expect(screen.queryByTestId('user-avatar')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when there is no resolved editor', async () => {
+    mockUseDocumentLastEditedBy.mockReturnValue({lastEditedBy: undefined, loading: false})
+
+    await renderCell(<EditedByCell documentId="doc-1" />)
+
+    expect(screen.queryByTestId('user-avatar')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('avatar-skeleton')).not.toBeInTheDocument()
+  })
+
+  it('renders the editor avatar and display name once resolved', async () => {
+    mockUseDocumentLastEditedBy.mockReturnValue({lastEditedBy: 'user-42', loading: false})
+    mockUseUser.mockReturnValue([{id: 'user-42', displayName: 'Ada Lovelace'} as never, false])
+
+    await renderCell(<EditedByCell documentId="doc-1" revision="rev-1" />)
+
+    expect(screen.getByTestId('user-avatar')).toHaveTextContent('user-42')
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument()
+  })
+
+  it('renders the avatar without a name when the profile has no display name', async () => {
+    mockUseDocumentLastEditedBy.mockReturnValue({lastEditedBy: 'user-42', loading: false})
+    mockUseUser.mockReturnValue([{id: 'user-42'} as never, false])
+
+    await renderCell(<EditedByCell documentId="doc-1" />)
+
+    expect(screen.getByTestId('user-avatar')).toBeInTheDocument()
+    expect(screen.queryByText('Ada Lovelace')).not.toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/core/config/releases/actions.ts
+++ b/packages/sanity/src/core/config/releases/actions.ts
@@ -31,6 +31,11 @@ export interface ReleaseActionDescription {
   label: string
   onHandle?: () => void
   title?: ReactNode
+  /**
+   * Semantic tone for the action's menu item, so destructive or cautionary custom actions can read
+   * as such (e.g. a delete-like action in `critical`). Defaults to `default` when omitted.
+   */
+  tone?: 'default' | 'primary' | 'positive' | 'caution' | 'critical'
 }
 
 /**

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -1542,6 +1542,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'release.action.discard-version': 'Discard version',
   /** Description for toast when version discarding failed */
   'release.action.discard-version.failure': 'Failed to discard version',
+  /** Tooltip/label for the action that opens the release edit dialog on the detail page */
+  'release.action.edit-details': 'Edit details',
   /** Action message for editing the schedule of a scheduled publish */
   'release.action.edit-schedule': 'Edit schedule',
   /** Action message for when a new release is created off an existing version, draft or published document */
@@ -1628,6 +1630,14 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'release.dialog.create.confirm': 'Create release',
   /** Title for creating releases dialog */
   'release.dialog.create.title': 'New release',
+  /** Label for the save action in the edit release dialog */
+  'release.dialog.edit.confirm': 'Save',
+  /** Field label for the release description in the edit release dialog */
+  'release.dialog.edit.description-label': 'Description',
+  /** Title for the edit release dialog */
+  'release.dialog.edit.title': 'Edit release',
+  /** Field label for the release title in the edit release dialog */
+  'release.dialog.edit.title-label': 'Title',
   /** Body text when deleting scheduled draft and draft is already up to date */
   'release.dialog.delete-schedule-draft.body-already-current':
     'Delete this scheduled draft? Your draft is already up to date.',
@@ -1700,6 +1710,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'release.toast.archived-release.title': "The '{{title}}' release was archived",
   /** The toast title that will be shown the creating a release fails */
   'release.toast.create-release-error.title': 'Failed to create release',
+  /** The toast title shown when saving edits to a release's details fails */
+  'release.toast.edit-release-error.title': 'Failed to save release details',
   /** Error toast for deleting a scheduled draft */
   'release.toast.delete-schedule-draft.error':
     'Failed to delete the scheduled draft document <strong>{{title}}</strong>: {{error}}',

--- a/packages/sanity/src/core/releases/components/dialog/EditReleaseDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/EditReleaseDialog.tsx
@@ -1,0 +1,109 @@
+import {type EditableReleaseDocument, type ReleaseDocument} from '@sanity/client'
+import {Card, Flex, Stack, Text, TextArea, TextInput, useToast} from '@sanity/ui'
+import {type ChangeEvent, useCallback, useId, useState} from 'react'
+
+import {Button} from '../../../../ui-components/button/Button'
+import {Dialog} from '../../../../ui-components/dialog/Dialog'
+import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {useReleaseOperations} from '../../store/useReleaseOperations'
+
+/**
+ * Explicit edit surface for a release's title + description. The detail page is a read-only display
+ * surface; editing is a deliberate action that opens this dialog, so editing a release — a document
+ * — is intentional rather than an accidental inline edit.
+ *
+ * The fields are explicitly labelled ("Title" / "Description") so it reads as a form for changing
+ * those properties, not as free-floating text.
+ *
+ * @internal
+ */
+export function EditReleaseDialog({
+  release,
+  onClose,
+}: {
+  release: ReleaseDocument
+  onClose: () => void
+}): React.JSX.Element {
+  const {updateRelease} = useReleaseOperations()
+  const {t} = useTranslation()
+  const toast = useToast()
+  const titleId = useId()
+  const descriptionId = useId()
+
+  const [title, setTitle] = useState(release.metadata.title ?? '')
+  const [description, setDescription] = useState(release.metadata.description ?? '')
+  const [isSaving, setIsSaving] = useState(false)
+
+  const handleSave = useCallback(async () => {
+    setIsSaving(true)
+    try {
+      const next: EditableReleaseDocument = {
+        ...release,
+        metadata: {...release.metadata, title, description},
+      }
+      await updateRelease(next)
+      onClose()
+    } catch (err) {
+      console.error(err)
+      toast.push({
+        closable: true,
+        status: 'error',
+        title: t('release.toast.edit-release-error.title'),
+      })
+    } finally {
+      setIsSaving(false)
+    }
+  }, [description, onClose, release, t, title, toast, updateRelease])
+
+  return (
+    <Dialog
+      header={t('release.dialog.edit.title')}
+      id="edit-release-dialog"
+      onClickOutside={onClose}
+      onClose={onClose}
+      padding={false}
+      width={1}
+    >
+      <Card padding={4} borderTop>
+        <Stack space={5}>
+          <Stack space={3}>
+            <Text as="label" htmlFor={titleId} size={1} weight="medium">
+              {t('release.dialog.edit.title-label')}
+            </Text>
+            <TextInput
+              data-testid="release-form-title"
+              id={titleId}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                setTitle(event.currentTarget.value)
+              }
+              value={title}
+            />
+          </Stack>
+          <Stack space={3}>
+            <Text as="label" htmlFor={descriptionId} size={1} weight="medium">
+              {t('release.dialog.edit.description-label')}
+            </Text>
+            <TextArea
+              data-testid="release-form-description"
+              id={descriptionId}
+              onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
+                setDescription(event.currentTarget.value)
+              }
+              rows={6}
+              value={description}
+            />
+          </Stack>
+        </Stack>
+        <Flex justify="flex-end" paddingTop={5}>
+          <Button
+            data-testid="save-release-details-button"
+            loading={isSaving}
+            onClick={handleSave}
+            size="large"
+            text={t('release.dialog.edit.confirm')}
+          />
+        </Flex>
+      </Card>
+    </Dialog>
+  )
+}

--- a/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
@@ -7,6 +7,8 @@ import {css, styled} from 'styled-components'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {useReleaseFormOptimisticUpdating} from '../../hooks/useReleaseFormOptimisticUpdating'
 
+// Cap the description height and let it scroll internally past this point, so the dialog stays a
+// sensible size regardless of how long the description is.
 const MAX_DESCRIPTION_HEIGHT = 200
 
 const TitleTextArea = styled.textarea((props) => {
@@ -89,6 +91,11 @@ function resizeTextarea(element: HTMLTextAreaElement): void {
   element.style.height = `${element.scrollHeight}px`
 }
 
+/**
+ * The editable title + description form for a release. Used inside the create/edit dialogs — the
+ * release detail page itself is a read-only display surface (see ReleaseDetailsEditor), and routes
+ * edits here through a dialog so editing is an explicit, intentional action.
+ */
 export function TitleDescriptionForm({
   release,
   onChange,

--- a/packages/sanity/src/core/releases/hooks/useReleaseTime.ts
+++ b/packages/sanity/src/core/releases/hooks/useReleaseTime.ts
@@ -5,7 +5,10 @@ import {useTimeZone} from '../../hooks/useTimeZone'
 import {type TableRelease} from '../tool/overview/ReleasesOverview'
 import {getPublishDateFromRelease} from '../util/util'
 
-export const useReleaseTime = (): ((release: TableRelease) => string | null) => {
+export const useReleaseTime = (): ((
+  release: TableRelease,
+  opts?: {compact?: boolean},
+) => string | null) => {
   const {timeZone, utcToCurrentZoneDate, getLocalTimeZone} = useTimeZone({
     type: 'contentReleases',
   } as const)
@@ -18,12 +21,16 @@ export const useReleaseTime = (): ((release: TableRelease) => string | null) => 
   )
 
   return useCallback(
-    (release: TableRelease) => {
+    (release: TableRelease, opts?: {compact?: boolean}) => {
       const publishDate = getPublishDateFromRelease(release)
+      if (!publishDate) return null
 
-      return publishDate
-        ? `${format(utcToCurrentZoneDate(publishDate), 'PPpp')} ${getTimezoneAbbreviation()}`
-        : null
+      const zoned = utcToCurrentZoneDate(publishDate)
+      // Compact: no seconds and no timezone suffix — for dense surfaces (e.g. the properties panel)
+      // where the value must stay on a single line. `PPp` → "Jul 30, 2026, 12:27 AM".
+      if (opts?.compact) return format(zoned, 'PPp')
+
+      return `${format(zoned, 'PPpp')} ${getTimezoneAbbreviation()}`
     },
     [getTimezoneAbbreviation, utcToCurrentZoneDate],
   )

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -193,12 +193,24 @@ const releasesLocaleStrings = defineLocalesResources('releases', {
   'dashboard.details.bulk.discard-toast.success_other': 'Discarded {{count}} versions',
   /** Error toast when some bulk discards fail */
   'dashboard.details.bulk.discard-toast.error': 'Some versions could not be discarded',
+  /** Error toast when the user lacks permission to discard any selected documents */
+  'dashboard.details.bulk.discard-toast.no-permission':
+    'You do not have permission to discard the selected document versions',
   /** Success toast after a bulk unpublish (singular) */
   'dashboard.details.bulk.unpublish-toast.success_one': 'Marked 1 document to unpublish',
   /** Success toast after a bulk unpublish (plural) */
   'dashboard.details.bulk.unpublish-toast.success_other': 'Marked {{count}} documents to unpublish',
   /** Error toast when some bulk unpublishes fail */
   'dashboard.details.bulk.unpublish-toast.error': 'Some documents could not be unpublished',
+  /** Error toast when the user lacks permission to unpublish any selected documents */
+  'dashboard.details.bulk.unpublish-toast.no-permission':
+    'You do not have permission to unpublish the selected documents',
+  /** Warning toast when one selected document is skipped during a bulk action */
+  'dashboard.details.bulk.toast.documents-skipped_one':
+    '1 selected document was skipped because you cannot act on it',
+  /** Warning toast when some selected documents are skipped during a bulk action (plural) */
+  'dashboard.details.bulk.toast.documents-skipped_other':
+    '{{count}} selected documents were skipped because you cannot act on them',
 
   /** Header for deleting a release dialog */
   'delete-dialog.confirm-delete.header': 'Are you sure you want to delete this release?',

--- a/packages/sanity/src/core/releases/i18n/resources.ts
+++ b/packages/sanity/src/core/releases/i18n/resources.ts
@@ -93,6 +93,8 @@ const releasesLocaleStrings = defineLocalesResources('releases', {
   'activity.panel.error': 'An error occurred getting the release activity',
   /** The title for the activity panel shown in the releases detail screen */
   'activity.panel.title': 'Activity',
+  /** Tooltip/label for the button that closes the activity overlay panel */
+  'activity.panel.close': 'Close activity',
 
   /** Header for the dialog confirming the archive of a release */
   'archive-dialog.confirm-archive-header': 'Are you sure you want to archive this release?',
@@ -129,9 +131,74 @@ const releasesLocaleStrings = defineLocalesResources('releases', {
   'dashboard.details.pin-release': 'Pin release to studio',
   /** Text for the releases detail screen in the unpin release button. */
   'dashboard.details.unpin-release': 'Unpin release from studio',
+  /** Label for the schedule/type metadata in the release detail header zone. */
+  'dashboard.details.metadata.schedule': 'Schedule',
+  /** Label for the validation status metadata in the release detail header zone. */
+  'dashboard.details.metadata.status': 'Status',
+  /** Label for the "created" metadata in the release detail header zone. */
+  'dashboard.details.metadata.created': 'Created',
+  /** Label for the document-count metadata in the release detail header zone. */
+  'dashboard.details.metadata.documents': 'Documents',
+  /** Status badge value when every document in the release is valid. */
+  'dashboard.details.metadata.status-valid': 'Valid',
+  /** Status badge value when one or more documents have validation errors. */
+  'dashboard.details.metadata.status-errors': 'Errors',
+  /** Status badge value while document validation is still running. */
+  'dashboard.details.metadata.status-validating': 'Validating',
+  /** Status badge value when the release has no documents to validate. */
+  'dashboard.details.metadata.status-empty': 'No documents',
 
   /** Activity inspector button text */
   'dashboard.details.activity': 'Activity',
+
+  /** Accessible label for the bulk select-all checkbox on the release documents table */
+  'dashboard.details.bulk.select-all': 'Select all documents',
+  /** Accessible label for a per-row bulk select checkbox */
+  'dashboard.details.bulk.select-row': 'Select document',
+  /** Count shown in the bulk selection toolbar (singular) */
+  'dashboard.details.bulk.selected_one': '{{count}} selected',
+  /** Count shown in the bulk selection toolbar (plural) */
+  'dashboard.details.bulk.selected_other': '{{count}} selected',
+  /** Label for clearing the current bulk selection */
+  'dashboard.details.bulk.clear': 'Clear selection',
+  /** Bulk action: discard the selected document versions */
+  'dashboard.details.bulk.discard': 'Discard versions',
+  /** Bulk action: unpublish the selected documents */
+  'dashboard.details.bulk.unpublish': 'Unpublish',
+  /** Tooltip for the overflow button that holds bulk actions on narrow widths */
+  'dashboard.details.bulk.more': 'More actions',
+  /** Header for the bulk discard confirmation dialog */
+  'dashboard.details.bulk.discard-dialog.header': 'Discard versions',
+  /** Confirm button for the bulk discard dialog */
+  'dashboard.details.bulk.discard-dialog.confirm': 'Discard versions',
+  /** Body of the bulk discard dialog (singular) */
+  'dashboard.details.bulk.discard-dialog.description_one':
+    'Discard 1 document version from this release? This can’t be undone.',
+  /** Body of the bulk discard dialog (plural) */
+  'dashboard.details.bulk.discard-dialog.description_other':
+    'Discard {{count}} document versions from this release? This can’t be undone.',
+  /** Header for the bulk unpublish confirmation dialog */
+  'dashboard.details.bulk.unpublish-dialog.header': 'Unpublish documents',
+  /** Confirm button for the bulk unpublish dialog */
+  'dashboard.details.bulk.unpublish-dialog.confirm': 'Unpublish',
+  /** Body of the bulk unpublish dialog (singular) */
+  'dashboard.details.bulk.unpublish-dialog.description_one':
+    'Mark 1 document to be unpublished when this release is run?',
+  /** Body of the bulk unpublish dialog (plural) */
+  'dashboard.details.bulk.unpublish-dialog.description_other':
+    'Mark {{count}} documents to be unpublished when this release is run?',
+  /** Success toast after a bulk discard (singular) */
+  'dashboard.details.bulk.discard-toast.success_one': 'Discarded 1 version',
+  /** Success toast after a bulk discard (plural) */
+  'dashboard.details.bulk.discard-toast.success_other': 'Discarded {{count}} versions',
+  /** Error toast when some bulk discards fail */
+  'dashboard.details.bulk.discard-toast.error': 'Some versions could not be discarded',
+  /** Success toast after a bulk unpublish (singular) */
+  'dashboard.details.bulk.unpublish-toast.success_one': 'Marked 1 document to unpublish',
+  /** Success toast after a bulk unpublish (plural) */
+  'dashboard.details.bulk.unpublish-toast.success_other': 'Marked {{count}} documents to unpublish',
+  /** Error toast when some bulk unpublishes fail */
+  'dashboard.details.bulk.unpublish-toast.error': 'Some documents could not be unpublished',
 
   /** Header for deleting a release dialog */
   'delete-dialog.confirm-delete.header': 'Are you sure you want to delete this release?',
@@ -175,6 +242,8 @@ const releasesLocaleStrings = defineLocalesResources('releases', {
   'document-validation.error_other': '{{count}} validation errors',
   /** Label for when a document in a release has a single validation warning */
   'document-validation.error_one': '{{count}} validation error',
+  /** Tooltip for the validation status when a document has no errors (the "ready" state) */
+  'document-validation.valid': 'No validation errors',
 
   /** Label when a release has been deleted by a different user */
   'deleted-release': "The '<strong>{{title}}</strong>' release has been deleted",
@@ -244,6 +313,9 @@ const releasesLocaleStrings = defineLocalesResources('releases', {
 
   /** Text for the button name for the release tool */
   'overview.action.documentation': 'Documentation',
+  /** Label for the back button on a release detail page (returns to the releases list). The
+   * leading arrow already conveys "back", so the label names the destination only. */
+  'overview.back-to-all-releases': 'All releases',
   /** Tooltip for the calendar button in the release overview */
   'overview.calendar.tooltip': 'View calendar',
   /** Description for the release tool */
@@ -432,6 +504,10 @@ const releasesLocaleStrings = defineLocalesResources('releases', {
   'table-header.documents': 'Documents',
   /** Header for the document table in the release tool - edited */
   'table-header.edited': 'Edited',
+  /** Header for the document table - last editor (person) column */
+  'table-header.edited-by': 'Edited by',
+  /** Header for the document table - last edited (relative time) column */
+  'table-header.last-edited': 'Last edited',
   /** Header for the document table in the release tool - Published */
   'table-header.published-at': 'Published',
   /** Header for the document table in the release tool - Published */
@@ -450,6 +526,8 @@ const releasesLocaleStrings = defineLocalesResources('releases', {
   'table-header.title': 'Release',
   /** Header for the document table in the release tool - type */
   'table-header.type': 'Type',
+  /** Header for the document table in the release tool - variant (which variant a document targets) */
+  'table-header.variant': 'Variant',
   /** Header for the document table in the release tool - action */
   'table-header.action': 'Action',
 

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenu.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenu.tsx
@@ -146,6 +146,7 @@ export const ReleaseMenu = ({
         icon={ArchiveIcon}
         text={t('action.archive')}
         data-testid="archive-release-menu-item"
+        tone="caution"
         disabled={
           releaseMenuDisabled ||
           ['scheduled', 'scheduling'].includes(release.state) ||
@@ -175,6 +176,7 @@ export const ReleaseMenu = ({
         icon={TrashIcon}
         text={t('action.delete-release')}
         data-testid="delete-release-menu-item"
+        tone="critical"
         tooltipProps={{
           content: !hasDeletePermission && t('permissions.error.delete'),
         }}

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenuButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenuButton.tsx
@@ -320,6 +320,7 @@ export const ReleaseMenuButton = ({
         key={`custom-action-${index}`}
         icon={action.icon}
         text={action.label}
+        tone={action.tone}
         disabled={action.disabled || isPerformingOperation}
         onClick={handleOnActionClick(action)}
         tooltipProps={action.title ? {content: action.title} : undefined}

--- a/packages/sanity/src/core/releases/tool/components/Table/DocumentTable.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/DocumentTable.tsx
@@ -115,8 +115,9 @@ export function DocumentTable<Row extends object>({
   commandLaneMinHeight?: number
   /**
    * Keep the command lane (filters + search) mounted even when there are zero rows, so a filter or
-   * search that empties the result set doesn't also hide the controls needed to change it. Detail
-   * tables leave this off; list surfaces that own filters (the variants overview) turn it on.
+   * search that empties the result set doesn't also hide the controls needed to change it. Surfaces
+   * that own filter tabs and/or command-lane actions (release detail behind beta.variants, the
+   * variants overview) turn it on.
    */
   alwaysShowCommandLane?: boolean
   /** Extra command-lane controls rendered right of the search (e.g. an "Add document" button). */

--- a/packages/sanity/src/core/releases/tool/components/Table/DocumentTable.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/DocumentTable.tsx
@@ -1,0 +1,311 @@
+import {SearchIcon} from '@sanity/icons/Search'
+import {Badge, Box, Card, Checkbox, Container, Flex, TextInput, useMediaIndex} from '@sanity/ui'
+import {type CSSProperties, type ReactNode, useCallback, useMemo, useState} from 'react'
+
+import {Button} from '../../../../../ui-components/button/Button'
+import {Table} from './Table'
+import {type TableSort} from './TableProvider'
+import {type Column} from './types'
+
+const TABLE_CARD_STYLE: CSSProperties = {
+  height: '100%',
+  overflow: 'auto',
+  // Reserve the scrollbar gutter symmetrically (both edges). Rows are centered in a container[3]
+  // block; with a classic (non-overlay) scrollbar, filtering changes the row count, the scrollbar
+  // appears/disappears, the content box width changes, and the centered rows jump relative to the
+  // command lane above. "stable both-edges" keeps the content-box width constant and centered.
+  scrollbarGutter: 'stable both-edges',
+}
+
+// Right-aligned, fixed-width search input.
+const SEARCH_INPUT_STYLE: CSSProperties = {maxWidth: 280}
+
+// Default command-lane height so the browse↔bulk swap never shifts the rows below. Consumers with a
+// taller browse control (e.g. the variants overview's bordered filter group) raise it via the
+// `commandLaneMinHeight` prop so the shorter bulk toolbar reserves the same height.
+const DEFAULT_COMMAND_LANE_MIN_HEIGHT = 33
+
+// Filter-tab strip: scrolls horizontally when the tabs outrun the width, with a subtle right-edge
+// fade cueing the overflow. When the tabs fit, the fade falls over empty space and is invisible.
+const FILTER_TABS_STYLE: CSSProperties = {
+  minWidth: 0,
+  overflowX: 'auto',
+  maskImage: 'linear-gradient(to right, #000 0, #000 calc(100% - 24px), transparent 100%)',
+  WebkitMaskImage: 'linear-gradient(to right, #000 0, #000 calc(100% - 24px), transparent 100%)',
+}
+
+/**
+ * Declarative selection + bulk-action config for {@link DocumentTable}. When provided, the table
+ * gains a leading checkbox column (select-all in the header row, per-row checkboxes) and the command
+ * lane swaps to a bulk toolbar while a selection exists.
+ *
+ * @internal
+ */
+export interface DocumentTableSelection {
+  labels: {
+    selectAll: string
+    selectRow: string
+    /** e.g. "3 selected" */
+    selectedCount: (count: number) => string
+    clear: string
+  }
+  /** The bulk actions (right of the count). `compact` is true on narrow widths — collapse to a menu. */
+  renderActions: (context: {
+    selectedKeys: string[]
+    compact: boolean
+    clear: () => void
+  }) => ReactNode
+  /** testId for the select-all checkbox (per-surface, so existing tests keep working). */
+  selectAllTestId?: string
+}
+
+/**
+ * Shared document-table composition used by both the Releases and Variants detail tables. Wraps the
+ * low-level {@link Table} and owns the three-zone header: a command lane (zone 1) with search + a
+ * caller-provided filter-tab slot, swapping to a bulk toolbar on selection; the column-header row
+ * (zone 2, caller columns + an injected select column); and the rows (zone 3). Search is owned here
+ * (filtered before the Table sorts) so it lives in the command lane, not the column header.
+ *
+ * @internal
+ */
+export function DocumentTable<Row extends object>({
+  rows,
+  loading = false,
+  columnDefs,
+  rowId,
+  getRowKey,
+  searchPredicate,
+  searchPlaceholder,
+  searchTestId,
+  searchWidth,
+  filterTabs,
+  filterTabsScroll = true,
+  commandLaneMinHeight = DEFAULT_COMMAND_LANE_MIN_HEIGHT,
+  alwaysShowCommandLane = false,
+  commandLaneActions,
+  selection,
+  rowActions,
+  footer,
+  emptyState,
+  defaultSort,
+  id,
+}: {
+  rows: Row[]
+  loading?: boolean
+  columnDefs: Column<Row>[]
+  rowId: string
+  getRowKey: (row: Row) => string
+  searchPredicate: (row: Row, searchTerm: string) => boolean
+  searchPlaceholder: string
+  searchTestId?: string
+  /** Fixed width of the search input; defaults to 280. Set it to match a right-hand rail. */
+  searchWidth?: number
+  filterTabs?: ReactNode
+  /**
+   * When true (default), the filter-tabs slot scrolls horizontally with a right-edge fade — right for
+   * tab strips that outrun the width. Set false when the consumer manages its own overflow (e.g. the
+   * variants overview collapses its filter chips), so the slot just fills without a scroll or fade.
+   */
+  filterTabsScroll?: boolean
+  /**
+   * Minimum height of the command lane, reserved in both the browse and bulk states so swapping
+   * between them never shifts the rows. Raise it above the default when the browse controls are
+   * taller than the bulk toolbar (e.g. a bordered filter group).
+   */
+  commandLaneMinHeight?: number
+  /**
+   * Keep the command lane (filters + search) mounted even when there are zero rows, so a filter or
+   * search that empties the result set doesn't also hide the controls needed to change it. Detail
+   * tables leave this off; list surfaces that own filters (the variants overview) turn it on.
+   */
+  alwaysShowCommandLane?: boolean
+  /** Extra command-lane controls rendered right of the search (e.g. an "Add document" button). */
+  commandLaneActions?: ReactNode
+  selection?: DocumentTableSelection
+  rowActions?: (props: {datum: unknown}) => ReactNode
+  footer?: ReactNode
+  emptyState: (() => React.JSX.Element) | string
+  defaultSort?: TableSort
+  /** id + data-testid for the scroll container (the filter-tab `aria-controls` target). */
+  id?: string
+}): React.JSX.Element {
+  const mediaIndex = useMediaIndex()
+  const compactBulkActions = mediaIndex < 2
+  const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(null)
+  const [searchTerm, setSearchTerm] = useState('')
+  const [selectedKeys, setSelectedKeys] = useState<ReadonlySet<string>>(() => new Set())
+
+  const displayRows = useMemo(() => {
+    const term = searchTerm.trim()
+    return term ? rows.filter((row) => searchPredicate(row, term)) : rows
+  }, [rows, searchTerm, searchPredicate])
+
+  // Selection is keyed by the caller's row key. The count reflects only currently-visible rows so a
+  // filtered-out selection never inflates the bar.
+  const selectableKeys = useMemo(
+    () => new Set(displayRows.map((row) => getRowKey(row))),
+    [displayRows, getRowKey],
+  )
+  const selectedVisibleCount = useMemo(
+    () => [...selectedKeys].filter((key) => selectableKeys.has(key)).length,
+    [selectedKeys, selectableKeys],
+  )
+  const allSelected = selectableKeys.size > 0 && selectedVisibleCount === selectableKeys.size
+  const someSelected = selectedVisibleCount > 0
+
+  const toggleRow = useCallback((key: string) => {
+    setSelectedKeys((previous) => {
+      const next = new Set(previous)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }, [])
+
+  const toggleAll = useCallback(() => {
+    setSelectedKeys((previous) => {
+      // Doubles as clear: if anything visible is selected, clicking clears; otherwise selects all.
+      const anyVisibleSelected = [...selectableKeys].some((key) => previous.has(key))
+      return anyVisibleSelected ? new Set() : new Set(selectableKeys)
+    })
+  }, [selectableKeys])
+
+  const clearSelection = useCallback(() => setSelectedKeys(new Set()), [])
+
+  const selectColumn = useMemo<Column<Row> | null>(() => {
+    if (!selection) return null
+    const {labels, selectAllTestId} = selection
+    return {
+      id: 'select',
+      width: 44,
+      style: {minWidth: 44, maxWidth: 44},
+      sorting: false,
+      // Select-all lives in the column-header row (above the row checkboxes it governs), not the
+      // command lane. Doubles as clear.
+      header: ({headerProps}) => (
+        <Flex {...headerProps} align="center" justify="center" paddingY={3} sizing="border">
+          <Checkbox
+            aria-label={labels.selectAll}
+            checked={allSelected}
+            data-testid={selectAllTestId}
+            indeterminate={someSelected && !allSelected}
+            onChange={toggleAll}
+          />
+        </Flex>
+      ),
+      cell: ({cellProps, datum}) => (
+        <Flex {...cellProps} align="center" justify="center" paddingX={2} sizing="border">
+          {!datum.isLoading && (
+            <Checkbox
+              aria-label={labels.selectRow}
+              checked={selectedKeys.has(getRowKey(datum))}
+              onChange={() => toggleRow(getRowKey(datum))}
+              onClick={(event) => event.stopPropagation()}
+            />
+          )}
+        </Flex>
+      ),
+    }
+  }, [selection, allSelected, someSelected, toggleAll, selectedKeys, getRowKey, toggleRow])
+
+  const amalgamatedColumnDefs = useMemo(
+    () => (selectColumn ? [selectColumn, ...columnDefs] : columnDefs),
+    [selectColumn, columnDefs],
+  )
+
+  const selectedKeyList = useMemo(
+    () => [...selectedKeys].filter((key) => selectableKeys.has(key)),
+    [selectedKeys, selectableKeys],
+  )
+
+  const hasDocuments = !loading && rows.length > 0
+  // Keep the lane mounted for filter-owning surfaces even when a filter/search empties the rows, so
+  // the controls to undo that never disappear with the results.
+  const showCommandLane = hasDocuments || (alwaysShowCommandLane && !loading)
+  const showBulkToolbar = Boolean(selection) && selectedVisibleCount > 0
+
+  return (
+    <Flex direction="column" flex={1} height="fill" overflow="hidden" style={{minHeight: 0}}>
+      {/* Command lane (zone 1). Fixed height so the browse↔bulk swap never shifts the rows. Idle:
+          filter tabs lead from the left (aligned with the columns), search is right-aligned. On
+          selection: selected count + Clear on the left, caller's bulk actions on the right.
+          container[3] + paddingX={2} aligns the lane with the table's row content below. */}
+      {showCommandLane && (
+        <Card flex="none" borderBottom paddingY={2}>
+          <Container flex="none" width={3}>
+            <Box paddingX={2}>
+              <Flex align="center" gap={3} style={{minHeight: commandLaneMinHeight}}>
+                {showBulkToolbar && selection ? (
+                  <>
+                    <Badge data-testid="document-table-selected-count" fontSize={1} tone="primary">
+                      {selection.labels.selectedCount(selectedVisibleCount)}
+                    </Badge>
+                    <Button
+                      data-testid="document-table-clear-selection"
+                      mode="bleed"
+                      onClick={clearSelection}
+                      text={selection.labels.clear}
+                    />
+                    <Box flex={1} />
+                    {selection.renderActions({
+                      selectedKeys: selectedKeyList,
+                      compact: compactBulkActions,
+                      clear: clearSelection,
+                    })}
+                  </>
+                ) : (
+                  <>
+                    {filterTabs && (
+                      <Box flex={1} style={filterTabsScroll ? FILTER_TABS_STYLE : {minWidth: 0}}>
+                        {filterTabs}
+                      </Box>
+                    )}
+                    {/* With filter tabs, search is a fixed-width control pinned to the right (tabs
+                        lead from the left). Without them, it fills the lane so it doesn't strand a
+                        wide empty gutter — e.g. the variants overview, which has no filter tabs. */}
+                    <Box
+                      flex={filterTabs ? 'none' : 1}
+                      style={
+                        filterTabs
+                          ? searchWidth
+                            ? {maxWidth: searchWidth}
+                            : SEARCH_INPUT_STYLE
+                          : undefined
+                      }
+                    >
+                      <TextInput
+                        aria-label={searchPlaceholder}
+                        clearButton={Boolean(searchTerm)}
+                        data-testid={searchTestId}
+                        fontSize={1}
+                        icon={SearchIcon}
+                        onChange={(event) => setSearchTerm(event.currentTarget.value)}
+                        onClear={() => setSearchTerm('')}
+                        placeholder={searchPlaceholder}
+                        value={searchTerm}
+                      />
+                    </Box>
+                    {commandLaneActions ? <Box flex="none">{commandLaneActions}</Box> : null}
+                  </>
+                )}
+              </Flex>
+            </Box>
+          </Container>
+        </Card>
+      )}
+      <Card data-testid={id} flex={1} id={id} ref={setScrollContainerRef} style={TABLE_CARD_STYLE}>
+        <Table<Row>
+          columnDefs={amalgamatedColumnDefs}
+          data={displayRows}
+          defaultSort={defaultSort}
+          emptyState={emptyState}
+          loading={loading}
+          rowActions={rowActions}
+          rowId={rowId}
+          scrollContainerRef={scrollContainerRef}
+        />
+      </Card>
+      {footer}
+    </Flex>
+  )
+}

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -148,7 +148,7 @@ const TableInner = <TableData, AdditionalRowTableData>({
         datum: VirtualDatum &
           (TableData | (TableData & AdditionalRowTableData) | {_id: string; isLoading: boolean}),
       ) {
-        const cardRowProps = rowProps(datum as TableData)
+        const {style: rowPropsStyle, ...cardRowProps} = rowProps(datum as TableData)
         const cardKey = loading ? `skeleton-${datum.index}` : String(get(datum, rowId))
 
         return (
@@ -170,6 +170,9 @@ const TableInner = <TableData, AdditionalRowTableData>({
                 calc((100% - var(--maxInlineSize)) / 2),
                 var(--paddingInline)
               )`,
+              // Consumer-supplied row styles are merged (not clobbered) so they can tint/flag a row
+              // without dropping the virtualization layout (height/position/transform).
+              ...rowPropsStyle,
             }}
             {...cardRowProps}
           >

--- a/packages/sanity/src/core/releases/tool/components/Table/TableHeader.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/TableHeader.tsx
@@ -3,6 +3,7 @@ import {SearchIcon} from '@sanity/icons/Search'
 import {Box, Card, Flex, Stack, Text, TextInput} from '@sanity/ui'
 import {motion} from 'motion/react'
 import {type CSSProperties, useMemo} from 'react'
+import {styled} from 'styled-components'
 
 import {Button, type ButtonProps} from '../../../../../ui-components/button/Button'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
@@ -11,9 +12,18 @@ import {type HeaderProps, type TableHeaderProps} from './types'
 
 const MotionIcon = motion.create(ArrowUpIcon)
 
+// Column headers are semibold so the header row reads clearly as a header, distinct from the row
+// content below — especially on sparse, single-column tables. For sortable headers (rendered as a
+// button, whose label weight isn't a prop) the same weight is forced onto the inner Text.
+const HeaderSortButton = styled(Button)`
+  & [data-ui='Text'] {
+    font-weight: 600;
+  }
+`
+
 const BasicHeader = ({text}: {text: string}) => (
   <Box padding={2}>
-    <Text muted size={1} weight="medium">
+    <Text muted size={1} weight="semibold">
       {text}
     </Text>
   </Box>
@@ -22,6 +32,7 @@ const BasicHeader = ({text}: {text: string}) => (
 const SortHeaderButton = ({
   header,
   text,
+  paddingLeft,
 }: Omit<ButtonProps, 'text'> &
   HeaderProps & {
     text: string
@@ -39,11 +50,14 @@ const SortHeaderButton = ({
   )
 
   return (
-    <Button
+    <HeaderSortButton
       iconRight={header.sorting && sort?.column === header.id ? sortIcon : undefined}
       onClick={() => setSortColumn(String(header.id))}
       mode="bleed"
       size="default"
+      // Optional left-inset override so a header label can line up with content that is inset less
+      // than the default button padding (e.g. an 8px cell). Defaults to the button's own padding.
+      paddingLeft={paddingLeft}
       text={text}
     />
   )

--- a/packages/sanity/src/core/releases/tool/components/Table/TableLayout.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/TableLayout.tsx
@@ -7,15 +7,20 @@ interface TableLayoutProps {
   contentHeight?: string
 }
 
+// borderSpacing: 0 on both states so the header sits at the same offset whether the table renders
+// as a grid (empty state) or a default table box (populated). Without it, the populated table keeps
+// the browser-default 2px border-spacing and the header shifts ~2px when the last row filters out.
 const emptyTableStyle: CSSProperties = {
   width: '100%',
   height: '100%',
   display: 'grid',
   gridTemplateRows: 'auto 1fr',
+  borderSpacing: 0,
 }
 
 const defaultTableStyle: CSSProperties = {
   width: '100%',
+  borderSpacing: 0,
 }
 
 /**

--- a/packages/sanity/src/core/releases/tool/detail/CopyReleaseActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/CopyReleaseActions.tsx
@@ -5,7 +5,7 @@ import {TargetIcon} from '@sanity/icons/Target'
 import {TextIcon} from '@sanity/icons/Text'
 import {type DefinedTelemetryLog, useTelemetry} from '@sanity/telemetry/react'
 import {Menu, useToast} from '@sanity/ui'
-import {useCallback} from 'react'
+import {type ComponentType, useCallback} from 'react'
 import {useRouter} from 'sanity/router'
 
 import {Button} from '../../../../ui-components/button/Button'
@@ -23,10 +23,16 @@ import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromRele
 
 interface CopyReleaseActionsProps {
   release: ReleaseDocument
+  /**
+   * Button icon. Defaults to ShareIcon (the current header). The menu only copies things (link / id
+   * / title) to the clipboard, so callers that want the icon to match that — rather than imply
+   * sharing — can pass CopyIcon.
+   */
+  icon?: ComponentType
 }
 
 export function CopyReleaseActions(props: CopyReleaseActionsProps) {
-  const {release} = props
+  const {release, icon = ShareIcon} = props
   const {t} = useTranslation(releasesLocaleNamespace)
   const {t: tCore} = useTranslation()
   const telemetry = useTelemetry()
@@ -71,7 +77,7 @@ export function CopyReleaseActions(props: CopyReleaseActionsProps) {
       button={
         <Button
           data-testid="copy-release-actions-button"
-          icon={ShareIcon}
+          icon={icon}
           mode="bleed"
           tooltipProps={{content: t('action.copy-release.label')}}
         />

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseActionButton.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseActionButton.tsx
@@ -1,0 +1,65 @@
+import {type ReleaseDocument} from '@sanity/client'
+
+import {isReleaseScheduledOrScheduling} from '../../util/util'
+import {ReleasePublishAllButton} from '../components/releaseCTAButtons/ReleasePublishAllButton'
+import {ReleaseRevertButton} from '../components/releaseCTAButtons/ReleaseRevertButton/ReleaseRevertButton'
+import {ReleaseScheduleButton} from '../components/releaseCTAButtons/ReleaseScheduleButton'
+import {ReleaseUnscheduleButton} from '../components/releaseCTAButtons/ReleaseUnscheduleButton'
+import {type DocumentInRelease} from './types'
+
+/**
+ * The state-driven primary release action — publish-all / schedule / unschedule / revert, depending
+ * on the release's state and type. Extracted so it can render in both the footer (its original home)
+ * and the top action rail; each instance manages its own local dialog state, so having two is safe.
+ *
+ * @internal
+ */
+export function ReleaseActionButton({
+  release,
+  documents,
+}: {
+  release: ReleaseDocument
+  documents: DocumentInRelease[]
+}): React.JSX.Element | null {
+  if (release.state === 'archived') return null
+
+  if (isReleaseScheduledOrScheduling(release)) {
+    return (
+      <ReleaseUnscheduleButton
+        release={release}
+        documents={documents}
+        disabled={!documents.length}
+      />
+    )
+  }
+
+  if (release.state === 'active') {
+    if (release.metadata.releaseType === 'scheduled') {
+      return (
+        <ReleaseScheduleButton
+          release={release}
+          documents={documents}
+          disabled={!documents.length}
+        />
+      )
+    }
+
+    if (release.metadata.releaseType === 'asap') {
+      return (
+        <ReleasePublishAllButton
+          release={release}
+          documents={documents}
+          disabled={!documents.length}
+        />
+      )
+    }
+  }
+
+  if (release.state === 'published') {
+    return (
+      <ReleaseRevertButton release={release} documents={documents} disabled={!documents.length} />
+    )
+  }
+
+  return null
+}

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseActionRail.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseActionRail.tsx
@@ -1,0 +1,62 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {EditIcon} from '@sanity/icons/Edit'
+import {useState} from 'react'
+
+import {Button} from '../../../../ui-components/button/Button'
+import {DetailActionRail} from '../../../components/detailLayout'
+import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {EditReleaseDialog} from '../../components/dialog/EditReleaseDialog'
+import {ReleaseMenuButton} from '../components/ReleaseMenuButton/ReleaseMenuButton'
+import {ReleaseActionButton} from './ReleaseActionButton'
+import {type DocumentInRelease} from './types'
+import {useCanEditRelease} from './useCanEditRelease'
+
+/**
+ * The Releases top action rail (behind `beta.variants`): an icon-only "Edit details" secondary, the
+ * state-driven primary — Run release / Publish / Schedule / Unschedule / Revert — and the overflow
+ * `⋯` menu. Edit details is a defined, always-visible affordance (not an inline hover pencil, not
+ * buried in the overflow), which is more discoverable and keyboard-accessible, and mirrors the
+ * Variant-definition detail page's top-of-page edit. Replaces the bottom footer's action cluster,
+ * which is dropped in beta.
+ *
+ * @internal
+ */
+export function ReleaseActionRail({
+  release,
+  documents,
+}: {
+  release: ReleaseDocument
+  documents: DocumentInRelease[]
+}): React.JSX.Element {
+  const {t} = useTranslation()
+  const [editOpen, setEditOpen] = useState(false)
+  const canEdit = useCanEditRelease(release)
+
+  return (
+    <>
+      <DetailActionRail
+        secondary={
+          canEdit ? (
+            <Button
+              data-testid="edit-release-details-button"
+              icon={EditIcon}
+              mode="bleed"
+              onClick={() => setEditOpen(true)}
+              tooltipProps={{content: t('release.action.edit-details')}}
+            />
+          ) : undefined
+        }
+        primary={<ReleaseActionButton release={release} documents={documents} />}
+        menu={
+          <ReleaseMenuButton
+            release={release}
+            documentsCount={documents.length}
+            documents={documents}
+            ignoreCTA={release.metadata.releaseType !== 'undecided'}
+          />
+        }
+      />
+      {editOpen && <EditReleaseDialog release={release} onClose={() => setEditOpen(false)} />}
+    </>
+  )
+}

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseBulkActionDialog.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseBulkActionDialog.tsx
@@ -10,10 +10,14 @@ import {useCurrentUser} from '../../../store/user/hooks'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../studioClient'
 import {useVersionOperations} from '../../hooks/useVersionOperations'
 import {releasesLocaleNamespace} from '../../i18n'
-import {filterDocumentsWithPairPermission} from './releaseBulkDocumentPermissions'
+import {
+  filterDocumentsForBulkAction,
+  type ReleaseBulkAction,
+  useReleaseBulkActionTargets,
+} from './releaseBulkDocumentPermissions'
 import {type DocumentInRelease} from './types'
 
-export type ReleaseBulkAction = 'discard' | 'unpublish'
+export type {ReleaseBulkAction} from './releaseBulkDocumentPermissions'
 
 /**
  * Confirmation dialog for a bulk action (Discard versions / Unpublish) over the selected release
@@ -43,7 +47,11 @@ export function ReleaseBulkActionDialog({
   const currentUser = useCurrentUser()
   const {discardVersion, unpublishVersion} = useVersionOperations()
   const [isProcessing, setIsProcessing] = useState(false)
-  const count = documents.length
+  const {targets: actionTargets, isLoading: isTargetsLoading} = useReleaseBulkActionTargets(
+    documents,
+    action,
+  )
+  const count = actionTargets.length
 
   const copy =
     action === 'discard'
@@ -63,25 +71,35 @@ export function ReleaseBulkActionDialog({
   const handleConfirm = useCallback(async () => {
     setIsProcessing(true)
 
-    let targets = documents
+    const targets = await filterDocumentsForBulkAction(documents, action, {
+      client,
+      schema,
+      grantsStore,
+      userId: currentUser?.id,
+    })
 
-    if (action === 'unpublish' || action === 'discard') {
-      targets = await filterDocumentsWithPairPermission(
-        documents,
-        action === 'discard' ? 'discardVersion' : 'unpublish',
-        {
-          client,
-          schema,
-          grantsStore,
-          userId: currentUser?.id,
-        },
-      )
-    }
+    const skipped = documents.length - targets.length
 
     if (targets.length === 0) {
+      toast.push({
+        closable: true,
+        status: 'error',
+        title:
+          action === 'discard'
+            ? t('dashboard.details.bulk.discard-toast.no-permission')
+            : t('dashboard.details.bulk.unpublish-toast.no-permission'),
+      })
       setIsProcessing(false)
       onClose()
       return
+    }
+
+    if (skipped > 0) {
+      toast.push({
+        closable: true,
+        status: 'warning',
+        title: t('dashboard.details.bulk.toast.documents-skipped', {count: skipped}),
+      })
     }
 
     const results = await Promise.allSettled(
@@ -145,7 +163,7 @@ export function ReleaseBulkActionDialog({
           tone: copy.tone,
           onClick: handleConfirm,
           loading: isProcessing,
-          disabled: isProcessing,
+          disabled: isProcessing || isTargetsLoading || count === 0,
         },
       }}
       header={copy.header}

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseBulkActionDialog.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseBulkActionDialog.tsx
@@ -1,61 +1,19 @@
 import {Box, Text, useToast} from '@sanity/ui'
 import {useCallback, useState} from 'react'
-import {firstValueFrom} from 'rxjs'
 
 import {Dialog} from '../../../../ui-components/dialog/Dialog'
 import {useClient} from '../../../hooks/useClient'
 import {useSchema} from '../../../hooks/useSchema'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {useGrantsStore} from '../../../store/datastores'
-import {getDocumentPairPermissions} from '../../../store/grants/documentPairPermissions'
 import {useCurrentUser} from '../../../store/user/hooks'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../studioClient'
-import {getPublishedId, getVersionFromId} from '../../../util/draftUtils'
 import {useVersionOperations} from '../../hooks/useVersionOperations'
 import {releasesLocaleNamespace} from '../../i18n'
+import {filterDocumentsWithPairPermission} from './releaseBulkDocumentPermissions'
 import {type DocumentInRelease} from './types'
 
 export type ReleaseBulkAction = 'discard' | 'unpublish'
-
-async function filterDocumentsWithUnpublishPermission(
-  documents: DocumentInRelease[],
-  {
-    client,
-    schema,
-    grantsStore,
-    userId,
-  }: {
-    client: ReturnType<typeof useClient>
-    schema: ReturnType<typeof useSchema>
-    grantsStore: ReturnType<typeof useGrantsStore>
-    userId: string | undefined
-  },
-): Promise<DocumentInRelease[]> {
-  const permissionResults = await Promise.all(
-    documents.map(async (doc) => {
-      const publishedId = getPublishedId(doc.document._id)
-      const type = doc.document._type
-      const version = getVersionFromId(doc.document._id)
-
-      const {granted} = await firstValueFrom(
-        getDocumentPairPermissions({
-          client,
-          schema,
-          grantsStore,
-          id: publishedId,
-          type,
-          version,
-          permission: 'unpublish',
-          userId,
-        }),
-      )
-
-      return granted ? doc : null
-    }),
-  )
-
-  return permissionResults.filter((doc): doc is DocumentInRelease => doc !== null)
-}
 
 /**
  * Confirmation dialog for a bulk action (Discard versions / Unpublish) over the selected release
@@ -107,13 +65,17 @@ export function ReleaseBulkActionDialog({
 
     let targets = documents
 
-    if (action === 'unpublish') {
-      targets = await filterDocumentsWithUnpublishPermission(documents, {
-        client,
-        schema,
-        grantsStore,
-        userId: currentUser?.id,
-      })
+    if (action === 'unpublish' || action === 'discard') {
+      targets = await filterDocumentsWithPairPermission(
+        documents,
+        action === 'discard' ? 'discardVersion' : 'unpublish',
+        {
+          client,
+          schema,
+          grantsStore,
+          userId: currentUser?.id,
+        },
+      )
     }
 
     if (targets.length === 0) {

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseBulkActionDialog.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseBulkActionDialog.tsx
@@ -1,4 +1,4 @@
-import {Box, Text, useToast} from '@sanity/ui'
+import {Box, Spinner, Text, useToast} from '@sanity/ui'
 import {useCallback, useState} from 'react'
 
 import {Dialog} from '../../../../ui-components/dialog/Dialog'
@@ -58,15 +58,19 @@ export function ReleaseBulkActionDialog({
       ? {
           header: t('dashboard.details.bulk.discard-dialog.header'),
           confirm: t('dashboard.details.bulk.discard-dialog.confirm'),
-          description: t('dashboard.details.bulk.discard-dialog.description', {count}),
           tone: 'critical' as const,
         }
       : {
           header: t('dashboard.details.bulk.unpublish-dialog.header'),
           confirm: t('dashboard.details.bulk.unpublish-dialog.confirm'),
-          description: t('dashboard.details.bulk.unpublish-dialog.description', {count}),
           tone: 'caution' as const,
         }
+
+  const description = isTargetsLoading
+    ? null
+    : action === 'discard'
+      ? t('dashboard.details.bulk.discard-dialog.description', {count})
+      : t('dashboard.details.bulk.unpublish-dialog.description', {count})
 
   const handleConfirm = useCallback(async () => {
     setIsProcessing(true)
@@ -172,9 +176,13 @@ export function ReleaseBulkActionDialog({
       width={1}
     >
       <Box padding={4}>
-        <Text muted size={1}>
-          {copy.description}
-        </Text>
+        {description ? (
+          <Text muted size={1}>
+            {description}
+          </Text>
+        ) : (
+          <Spinner data-testid="release-bulk-action-dialog-loading" muted size={1} />
+        )}
       </Box>
     </Dialog>
   )

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseBulkActionDialog.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseBulkActionDialog.tsx
@@ -1,0 +1,129 @@
+import {Box, Text, useToast} from '@sanity/ui'
+import {useCallback, useState} from 'react'
+
+import {Dialog} from '../../../../ui-components/dialog/Dialog'
+import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {useVersionOperations} from '../../hooks/useVersionOperations'
+import {releasesLocaleNamespace} from '../../i18n'
+import {type DocumentInRelease} from './types'
+
+export type ReleaseBulkAction = 'discard' | 'unpublish'
+
+/**
+ * Confirmation dialog for a bulk action (Discard versions / Unpublish) over the selected release
+ * documents. The per-row menu acts on one document via its own dialog; this applies the same
+ * underlying version operation to each selected document, reporting partial failures.
+ *
+ * @internal
+ */
+export function ReleaseBulkActionDialog({
+  action,
+  documents,
+  releaseId,
+  onClose,
+  onSuccess,
+}: {
+  action: ReleaseBulkAction
+  documents: DocumentInRelease[]
+  releaseId: string
+  onClose: () => void
+  onSuccess: () => void
+}): React.JSX.Element {
+  const {t} = useTranslation(releasesLocaleNamespace)
+  const toast = useToast()
+  const {discardVersion, unpublishVersion} = useVersionOperations()
+  const [isProcessing, setIsProcessing] = useState(false)
+  const count = documents.length
+
+  const copy =
+    action === 'discard'
+      ? {
+          header: t('dashboard.details.bulk.discard-dialog.header'),
+          confirm: t('dashboard.details.bulk.discard-dialog.confirm'),
+          description: t('dashboard.details.bulk.discard-dialog.description', {count}),
+          tone: 'critical' as const,
+        }
+      : {
+          header: t('dashboard.details.bulk.unpublish-dialog.header'),
+          confirm: t('dashboard.details.bulk.unpublish-dialog.confirm'),
+          description: t('dashboard.details.bulk.unpublish-dialog.description', {count}),
+          tone: 'caution' as const,
+        }
+
+  const handleConfirm = useCallback(async () => {
+    setIsProcessing(true)
+
+    const results = await Promise.allSettled(
+      documents.map((doc) =>
+        action === 'discard'
+          ? discardVersion(releaseId, doc.document._id)
+          : unpublishVersion(doc.document._id),
+      ),
+    )
+
+    const failed = results.filter((result) => result.status === 'rejected').length
+    const succeeded = count - failed
+
+    if (succeeded > 0) {
+      toast.push({
+        closable: true,
+        status: 'success',
+        title:
+          action === 'discard'
+            ? t('dashboard.details.bulk.discard-toast.success', {count: succeeded})
+            : t('dashboard.details.bulk.unpublish-toast.success', {count: succeeded}),
+      })
+    }
+    if (failed > 0) {
+      toast.push({
+        closable: true,
+        status: 'error',
+        title:
+          action === 'discard'
+            ? t('dashboard.details.bulk.discard-toast.error')
+            : t('dashboard.details.bulk.unpublish-toast.error'),
+      })
+    }
+
+    setIsProcessing(false)
+    onSuccess()
+    onClose()
+  }, [
+    action,
+    count,
+    discardVersion,
+    documents,
+    onClose,
+    onSuccess,
+    releaseId,
+    t,
+    toast,
+    unpublishVersion,
+  ])
+
+  return (
+    <Dialog
+      data-testid={`release-bulk-${action}-dialog`}
+      footer={{
+        cancelButton: {disabled: isProcessing},
+        confirmButton: {
+          text: copy.confirm,
+          tone: copy.tone,
+          onClick: handleConfirm,
+          loading: isProcessing,
+          disabled: isProcessing,
+        },
+      }}
+      header={copy.header}
+      id={`release-bulk-${action}-dialog`}
+      onClose={() => !isProcessing && onClose()}
+      width={1}
+    >
+      <Box padding={4}>
+        <Text muted size={1}>
+          {copy.description}
+        </Text>
+      </Box>
+    </Dialog>
+  )
+}

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseBulkActionDialog.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseBulkActionDialog.tsx
@@ -1,13 +1,61 @@
 import {Box, Text, useToast} from '@sanity/ui'
 import {useCallback, useState} from 'react'
+import {firstValueFrom} from 'rxjs'
 
 import {Dialog} from '../../../../ui-components/dialog/Dialog'
+import {useClient} from '../../../hooks/useClient'
+import {useSchema} from '../../../hooks/useSchema'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {useGrantsStore} from '../../../store/datastores'
+import {getDocumentPairPermissions} from '../../../store/grants/documentPairPermissions'
+import {useCurrentUser} from '../../../store/user/hooks'
+import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../studioClient'
+import {getPublishedId, getVersionFromId} from '../../../util/draftUtils'
 import {useVersionOperations} from '../../hooks/useVersionOperations'
 import {releasesLocaleNamespace} from '../../i18n'
 import {type DocumentInRelease} from './types'
 
 export type ReleaseBulkAction = 'discard' | 'unpublish'
+
+async function filterDocumentsWithUnpublishPermission(
+  documents: DocumentInRelease[],
+  {
+    client,
+    schema,
+    grantsStore,
+    userId,
+  }: {
+    client: ReturnType<typeof useClient>
+    schema: ReturnType<typeof useSchema>
+    grantsStore: ReturnType<typeof useGrantsStore>
+    userId: string | undefined
+  },
+): Promise<DocumentInRelease[]> {
+  const permissionResults = await Promise.all(
+    documents.map(async (doc) => {
+      const publishedId = getPublishedId(doc.document._id)
+      const type = doc.document._type
+      const version = getVersionFromId(doc.document._id)
+
+      const {granted} = await firstValueFrom(
+        getDocumentPairPermissions({
+          client,
+          schema,
+          grantsStore,
+          id: publishedId,
+          type,
+          version,
+          permission: 'unpublish',
+          userId,
+        }),
+      )
+
+      return granted ? doc : null
+    }),
+  )
+
+  return permissionResults.filter((doc): doc is DocumentInRelease => doc !== null)
+}
 
 /**
  * Confirmation dialog for a bulk action (Discard versions / Unpublish) over the selected release
@@ -31,6 +79,10 @@ export function ReleaseBulkActionDialog({
 }): React.JSX.Element {
   const {t} = useTranslation(releasesLocaleNamespace)
   const toast = useToast()
+  const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+  const schema = useSchema()
+  const grantsStore = useGrantsStore()
+  const currentUser = useCurrentUser()
   const {discardVersion, unpublishVersion} = useVersionOperations()
   const [isProcessing, setIsProcessing] = useState(false)
   const count = documents.length
@@ -53,8 +105,25 @@ export function ReleaseBulkActionDialog({
   const handleConfirm = useCallback(async () => {
     setIsProcessing(true)
 
+    let targets = documents
+
+    if (action === 'unpublish') {
+      targets = await filterDocumentsWithUnpublishPermission(documents, {
+        client,
+        schema,
+        grantsStore,
+        userId: currentUser?.id,
+      })
+    }
+
+    if (targets.length === 0) {
+      setIsProcessing(false)
+      onClose()
+      return
+    }
+
     const results = await Promise.allSettled(
-      documents.map((doc) =>
+      targets.map((doc) =>
         action === 'discard'
           ? discardVersion(releaseId, doc.document._id)
           : unpublishVersion(doc.document._id),
@@ -62,7 +131,7 @@ export function ReleaseBulkActionDialog({
     )
 
     const failed = results.filter((result) => result.status === 'rejected').length
-    const succeeded = count - failed
+    const succeeded = targets.length - failed
 
     if (succeeded > 0) {
       toast.push({
@@ -90,12 +159,15 @@ export function ReleaseBulkActionDialog({
     onClose()
   }, [
     action,
-    count,
+    client,
+    currentUser?.id,
     discardVersion,
     documents,
+    grantsStore,
     onClose,
     onSuccess,
     releaseId,
+    schema,
     t,
     toast,
     unpublishVersion,

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseBulkSelectionActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseBulkSelectionActions.tsx
@@ -1,0 +1,116 @@
+import {CloseIcon} from '@sanity/icons/Close'
+import {EllipsisHorizontalIcon} from '@sanity/icons/EllipsisHorizontal'
+import {UnpublishIcon} from '@sanity/icons/Unpublish'
+import {Flex, Menu} from '@sanity/ui'
+import {useMemo} from 'react'
+
+import {Button} from '../../../../ui-components/button/Button'
+import {MenuButton} from '../../../../ui-components/menuButton/MenuButton'
+import {MenuItem} from '../../../../ui-components/menuItem/MenuItem'
+import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {releasesLocaleNamespace} from '../../i18n'
+import {useAnyDocumentInReleaseHasPairPermission} from './releaseBulkDocumentPermissions'
+import {isDocumentEligibleForUnpublish} from './releaseDocumentActions'
+import {type DocumentInReleaseDetail} from './ReleaseSummary'
+
+/**
+ * Bulk discard / unpublish controls for the release document table selection bar.
+ *
+ * @internal
+ */
+export function ReleaseBulkSelectionActions({
+  selectedKeys,
+  filterTabRows,
+  compact,
+  onDiscard,
+  onUnpublish,
+}: {
+  selectedKeys: string[]
+  filterTabRows: DocumentInReleaseDetail[]
+  compact: boolean
+  onDiscard: () => void
+  onUnpublish: () => void
+}): React.JSX.Element {
+  const {t} = useTranslation(releasesLocaleNamespace)
+
+  const selectedRows = useMemo(() => {
+    const byId = new Map(filterTabRows.map((row) => [row.document._id, row]))
+    return selectedKeys
+      .map((key) => byId.get(key))
+      .filter((row): row is DocumentInReleaseDetail => Boolean(row))
+  }, [filterTabRows, selectedKeys])
+
+  const canUnpublishSelection = selectedRows.some(isDocumentEligibleForUnpublish)
+
+  const {granted: canDiscardSelection, isLoading: isDiscardPermissionsLoading} =
+    useAnyDocumentInReleaseHasPairPermission(selectedRows, 'discardVersion')
+
+  const isDiscardDisabled = !canDiscardSelection || isDiscardPermissionsLoading
+  const discardTooltip = t('permissions.error.discard-version')
+
+  if (compact) {
+    return (
+      <MenuButton
+        id="release-bulk-more"
+        button={
+          <Button
+            data-testid="release-bulk-more"
+            icon={EllipsisHorizontalIcon}
+            mode="bleed"
+            tooltipProps={{content: t('dashboard.details.bulk.more')}}
+          />
+        }
+        menu={
+          <Menu>
+            <MenuItem
+              data-testid="release-bulk-discard"
+              disabled={isDiscardDisabled}
+              icon={CloseIcon}
+              onClick={onDiscard}
+              text={t('dashboard.details.bulk.discard')}
+              tone="critical"
+              tooltipProps={{
+                disabled: !isDiscardDisabled,
+                content: discardTooltip,
+              }}
+            />
+            <MenuItem
+              data-testid="release-bulk-unpublish"
+              disabled={!canUnpublishSelection}
+              icon={UnpublishIcon}
+              onClick={onUnpublish}
+              text={t('dashboard.details.bulk.unpublish')}
+            />
+          </Menu>
+        }
+        popover={{placement: 'bottom-end', portal: true}}
+      />
+    )
+  }
+
+  return (
+    <Flex align="center" flex="none" gap={2}>
+      <Button
+        data-testid="release-bulk-discard"
+        disabled={isDiscardDisabled}
+        icon={CloseIcon}
+        mode="ghost"
+        onClick={onDiscard}
+        text={t('dashboard.details.bulk.discard')}
+        tone="critical"
+        tooltipProps={{
+          disabled: !isDiscardDisabled,
+          content: discardTooltip,
+        }}
+      />
+      <Button
+        data-testid="release-bulk-unpublish"
+        disabled={!canUnpublishSelection}
+        icon={UnpublishIcon}
+        mode="ghost"
+        onClick={onUnpublish}
+        text={t('dashboard.details.bulk.unpublish')}
+      />
+    </Flex>
+  )
+}

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseBulkSelectionActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseBulkSelectionActions.tsx
@@ -40,13 +40,29 @@ export function ReleaseBulkSelectionActions({
       .filter((row): row is DocumentInReleaseDetail => Boolean(row))
   }, [filterTabRows, selectedKeys])
 
-  const canUnpublishSelection = selectedRows.some(isDocumentEligibleForUnpublish)
+  const hasUnpublishEligibleSelection = selectedRows.some(isDocumentEligibleForUnpublish)
 
   const {granted: canDiscardSelection, isLoading: isDiscardPermissionsLoading} =
     useAnyDocumentInReleaseHasPairPermission(selectedRows, 'discardVersion')
 
+  const {granted: canUnpublishSelection, isLoading: isUnpublishPermissionsLoading} =
+    useAnyDocumentInReleaseHasPairPermission(selectedRows, 'unpublish')
+
   const isDiscardDisabled = !canDiscardSelection || isDiscardPermissionsLoading
   const discardTooltip = t('permissions.error.discard-version')
+
+  const isUnpublishDisabled =
+    !hasUnpublishEligibleSelection || !canUnpublishSelection || isUnpublishPermissionsLoading
+
+  const unpublishTooltip = useMemo(() => {
+    if (!canUnpublishSelection || isUnpublishPermissionsLoading) {
+      return t('permissions.error.unpublish')
+    }
+    if (!hasUnpublishEligibleSelection) {
+      return t('unpublish.no-published-version')
+    }
+    return null
+  }, [canUnpublishSelection, hasUnpublishEligibleSelection, isUnpublishPermissionsLoading, t])
 
   if (compact) {
     return (
@@ -76,10 +92,14 @@ export function ReleaseBulkSelectionActions({
             />
             <MenuItem
               data-testid="release-bulk-unpublish"
-              disabled={!canUnpublishSelection}
+              disabled={isUnpublishDisabled}
               icon={UnpublishIcon}
               onClick={onUnpublish}
               text={t('dashboard.details.bulk.unpublish')}
+              tooltipProps={{
+                disabled: !isUnpublishDisabled,
+                content: unpublishTooltip,
+              }}
             />
           </Menu>
         }
@@ -105,11 +125,15 @@ export function ReleaseBulkSelectionActions({
       />
       <Button
         data-testid="release-bulk-unpublish"
-        disabled={!canUnpublishSelection}
+        disabled={isUnpublishDisabled}
         icon={UnpublishIcon}
         mode="ghost"
         onClick={onUnpublish}
         text={t('dashboard.details.bulk.unpublish')}
+        tooltipProps={{
+          disabled: !isUnpublishDisabled,
+          content: unpublishTooltip,
+        }}
       />
     </Flex>
   )

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseBulkSelectionActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseBulkSelectionActions.tsx
@@ -9,7 +9,7 @@ import {MenuButton} from '../../../../ui-components/menuButton/MenuButton'
 import {MenuItem} from '../../../../ui-components/menuItem/MenuItem'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {releasesLocaleNamespace} from '../../i18n'
-import {useAnyDocumentInReleaseHasPairPermission} from './releaseBulkDocumentPermissions'
+import {useAllDocumentsInReleaseHavePairPermission} from './releaseBulkDocumentPermissions'
 import {isDocumentEligibleForUnpublish} from './releaseDocumentActions'
 import {type DocumentInReleaseDetail} from './ReleaseSummary'
 
@@ -40,29 +40,34 @@ export function ReleaseBulkSelectionActions({
       .filter((row): row is DocumentInReleaseDetail => Boolean(row))
   }, [filterTabRows, selectedKeys])
 
-  const hasUnpublishEligibleSelection = selectedRows.some(isDocumentEligibleForUnpublish)
+  const allSelectedEligibleForUnpublish =
+    selectedRows.length > 0 && selectedRows.every(isDocumentEligibleForUnpublish)
 
   const {granted: canDiscardSelection, isLoading: isDiscardPermissionsLoading} =
-    useAnyDocumentInReleaseHasPairPermission(selectedRows, 'discardVersion')
+    useAllDocumentsInReleaseHavePairPermission(selectedRows, 'discardVersion')
 
   const {granted: canUnpublishSelection, isLoading: isUnpublishPermissionsLoading} =
-    useAnyDocumentInReleaseHasPairPermission(selectedRows, 'unpublish')
+    useAllDocumentsInReleaseHavePairPermission(selectedRows, 'unpublish')
 
-  const isDiscardDisabled = !canDiscardSelection || isDiscardPermissionsLoading
+  const isDiscardDisabled =
+    selectedRows.length === 0 || !canDiscardSelection || isDiscardPermissionsLoading
   const discardTooltip = t('permissions.error.discard-version')
 
   const isUnpublishDisabled =
-    !hasUnpublishEligibleSelection || !canUnpublishSelection || isUnpublishPermissionsLoading
+    selectedRows.length === 0 ||
+    !allSelectedEligibleForUnpublish ||
+    !canUnpublishSelection ||
+    isUnpublishPermissionsLoading
 
   const unpublishTooltip = useMemo(() => {
     if (!canUnpublishSelection || isUnpublishPermissionsLoading) {
       return t('permissions.error.unpublish')
     }
-    if (!hasUnpublishEligibleSelection) {
+    if (!allSelectedEligibleForUnpublish) {
       return t('unpublish.no-published-version')
     }
     return null
-  }, [canUnpublishSelection, hasUnpublishEligibleSelection, isUnpublishPermissionsLoading, t])
+  }, [allSelectedEligibleForUnpublish, canUnpublishSelection, isUnpublishPermissionsLoading, t])
 
   if (compact) {
     return (

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardActivityPanel.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardActivityPanel.tsx
@@ -1,8 +1,11 @@
 import {type ReleaseDocument} from '@sanity/client'
+import {CloseIcon} from '@sanity/icons/Close'
 import {Box, Card, Flex, Text} from '@sanity/ui'
 import {AnimatePresence, motion} from 'motion/react'
+import {useEffect} from 'react'
 import {styled} from 'styled-components'
 
+import {Button} from '../../../../ui-components/button/Button'
 import {LoadingBlock} from '../../../components/loadingBlock/LoadingBlock'
 import {Resizable} from '../../../components/resizer/Resizable'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
@@ -14,8 +17,16 @@ interface ReleaseDashboardActivityPanelProps {
   events: ReleaseEvents
   release: ReleaseDocument
   show: boolean
+  /**
+   * When true, the panel floats over the content as a right-anchored overlay (dismissed via the
+   * header close button or Escape) instead of pushing the layout aside. Activity is transient
+   * reference, not a co-editing surface, so it should not reflow the rail and table beneath it.
+   */
+  overlay?: boolean
+  onClose?: () => void
 }
 const MotionFlex = motion.create(Flex)
+const MotionCard = motion.create(Card)
 const FillHeight = styled.div`
   --card-border-color: transparent;
   height: 100%;
@@ -26,57 +37,135 @@ export function ReleaseDashboardActivityPanel({
   events,
   release,
   show,
+  overlay = false,
+  onClose,
 }: ReleaseDashboardActivityPanelProps) {
   const {t} = useTranslation(releasesLocaleNamespace)
   const {t: tCore} = useTranslation()
+
+  // In overlay mode the panel is not part of the layout, so Escape is the keyboard escape hatch
+  // (in addition to the header close button and the Activity toggle).
+  useEffect(() => {
+    if (!overlay || !show) return undefined
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose?.()
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [overlay, show, onClose])
+
+  const content = (
+    <MotionFlex flex="none" height="fill" direction="column">
+      <Flex align="center" gap={2} justify="space-between" padding={4}>
+        <Text size={1} weight="medium">
+          {t('activity.panel.title')}
+        </Text>
+        {overlay && onClose && (
+          <Button
+            icon={CloseIcon}
+            mode="bleed"
+            onClick={onClose}
+            tooltipProps={{content: t('activity.panel.close')}}
+          />
+        )}
+      </Flex>
+      {events.error && !events.events.length && (
+        <Card padding={3} tone="caution">
+          <Box padding={2}>
+            <Text size={0}>{t('activity.panel.error')}</Text>
+          </Box>
+        </Card>
+      )}
+      {events.loading && !events.events.length && (
+        <LoadingBlock title={t('activity.panel.loading')} />
+      )}
+      <ReleaseActivityList
+        releaseTitle={release.metadata.title || tCore('release.placeholder-untitled-release')}
+        releaseId={release._id}
+        events={events.events}
+        hasMore={events.hasMore}
+        loadMore={events.loadMore}
+        isLoading={events.loading}
+      />
+    </MotionFlex>
+  )
+
+  if (overlay) {
+    // Floats over the content (position:absolute against the relatively-positioned parent in
+    // ReleaseDetail), sliding in from the right; the rail and table beneath it do not move. A light
+    // scrim recedes everything behind the drawer (the rail, the properties block) so partial
+    // coverage reads as "behind the drawer" rather than clipped, and clicking it dismisses.
+    return (
+      <AnimatePresence>
+        {show && (
+          <>
+            <motion.div
+              onClick={onClose}
+              initial={{opacity: 0}}
+              animate={{opacity: 1}}
+              exit={{opacity: 0}}
+              transition={{duration: 0.2}}
+              style={{
+                position: 'absolute',
+                inset: 0,
+                zIndex: 199,
+                background: 'rgba(0, 0, 0, 0.45)',
+              }}
+            />
+            <MotionCard
+              borderLeft
+              shadow={4}
+              initial={{x: '100%'}}
+              animate={{x: 0}}
+              exit={{x: '100%'}}
+              transition={{type: 'spring', bounce: 0, duration: 0.2}}
+              style={{
+                position: 'absolute',
+                top: 0,
+                right: 0,
+                bottom: 0,
+                zIndex: 200,
+                display: 'flex',
+                flexDirection: 'column',
+              }}
+            >
+              <Resizable
+                as={FillHeight}
+                minWidth={320}
+                maxWidth={800}
+                initialWidth={360}
+                resizerPosition="left"
+                style={{display: 'flex', flexDirection: 'column', flex: 'none', height: '100%'}}
+              >
+                {content}
+              </Resizable>
+            </MotionCard>
+          </>
+        )}
+      </AnimatePresence>
+    )
+  }
+
   return (
     <AnimatePresence>
       {show && (
-        <>
-          <motion.div
-            animate={{width: 'auto', opacity: 1}}
-            initial={{width: 0, opacity: 0}}
-            exit={{width: 0, opacity: 0}}
-            transition={{type: 'spring', bounce: 0, duration: 0.2}}
+        <motion.div
+          animate={{width: 'auto', opacity: 1}}
+          initial={{width: 0, opacity: 0}}
+          exit={{width: 0, opacity: 0}}
+          transition={{type: 'spring', bounce: 0, duration: 0.2}}
+        >
+          <Resizable
+            as={FillHeight}
+            minWidth={320}
+            maxWidth={800}
+            initialWidth={320}
+            resizerPosition="left"
+            style={{display: 'flex', flexDirection: 'column', flex: 'none', maxHeight: '100%'}}
           >
-            <Resizable
-              as={FillHeight}
-              minWidth={320}
-              maxWidth={800}
-              initialWidth={320}
-              resizerPosition="left"
-              style={{display: 'flex', flexDirection: 'column', flex: 'none', maxHeight: '100%'}}
-            >
-              <MotionFlex flex="none" height="fill" direction="column">
-                <Box padding={4}>
-                  <Text size={1} weight="medium">
-                    {t('activity.panel.title')}
-                  </Text>
-                </Box>
-                {events.error && !events.events.length && (
-                  <Card padding={3} tone="caution">
-                    <Box padding={2}>
-                      <Text size={0}>{t('activity.panel.error')}</Text>
-                    </Box>
-                  </Card>
-                )}
-                {events.loading && !events.events.length && (
-                  <LoadingBlock title={t('activity.panel.loading')} />
-                )}
-                <ReleaseActivityList
-                  releaseTitle={
-                    release.metadata.title || tCore('release.placeholder-untitled-release')
-                  }
-                  releaseId={release._id}
-                  events={events.events}
-                  hasMore={events.hasMore}
-                  loadMore={events.loadMore}
-                  isLoading={events.loading}
-                />
-              </MotionFlex>
-            </Resizable>
-          </motion.div>
-        </>
+            {content}
+          </Resizable>
+        </motion.div>
       )}
     </AnimatePresence>
   )

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
@@ -8,7 +8,7 @@ import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
 import {Box, Card, Container, Flex, Stack, Text} from '@sanity/ui'
 import {useEffect, useRef, useState} from 'react'
 
-import {DetailPropertiesPanel} from '../../../components/detailLayout'
+import {DetailPropertiesPanel, type DetailPropertiesSection} from '../../../components/detailLayout'
 import {RelativeTime} from '../../../components/RelativeTime'
 import {UserAvatar} from '../../../components/userAvatar/UserAvatar'
 import {Details} from '../../../form/components/Details'
@@ -123,58 +123,60 @@ export function ReleaseDashboardDetails({
               behind beta.variants the footer is dropped, so a Created row is added here instead. */}
           <DetailPropertiesPanel
             testId="release-detail-metadata"
-            sections={[
-              {
-                rows: [
-                  isNotArchivedRelease(release) && {
-                    // Leading glyph reflects the live release type (bolt / clock / dot), tone-coloured.
-                    icon: variantsEnabled ? (
-                      <ReleaseAvatar release={release} padding={0} />
-                    ) : undefined,
-                    label: tRelease('dashboard.details.metadata.schedule'),
-                    value: <ReleaseTypePicker release={release} />,
-                  },
-                  {
-                    icon: variantsEnabled ? statusGlyph : undefined,
-                    label: tRelease('dashboard.details.metadata.status'),
-                    // Beta: semantic-coloured text ("Valid" / "Errors" / …) so the panel clearly
-                    // signals "good to go". Production keeps the minimal icon indicator unchanged.
-                    value: variantsEnabled ? (
-                      <ReleaseValidationBadge documents={documents} />
-                    ) : (
-                      <ValidationProgressIndicator documents={documents} layout="minimal" />
-                    ),
-                  },
-                  {
-                    icon: variantsEnabled ? (
-                      <Text size={1} muted>
-                        <DocumentsIcon />
-                      </Text>
-                    ) : undefined,
-                    label: tRelease('dashboard.details.metadata.documents'),
-                    value: String(documents.length),
-                  },
-                  variantsEnabled && {
-                    // The author avatar is the Created row's leading glyph. When the create-event
-                    // author doesn't resolve, fall back to a muted person glyph ("created by —
-                    // unknown") rather than a skeleton, which would read as perpetually loading.
-                    icon: createAuthor ? (
-                      <UserAvatar size={0} user={createAuthor} />
-                    ) : (
-                      <Text size={1} muted>
-                        <UserIcon />
-                      </Text>
-                    ),
-                    label: tRelease('footer.status.created'),
-                    value: (
-                      <Text size={1}>
-                        <RelativeTime time={release._createdAt} useTemporalPhrase minimal />
-                      </Text>
-                    ),
-                  },
-                ],
-              },
-            ]}
+            sections={
+              [
+                {
+                  rows: [
+                    isNotArchivedRelease(release) && {
+                      // Leading glyph reflects the live release type (bolt / clock / dot), tone-coloured.
+                      icon: variantsEnabled ? (
+                        <ReleaseAvatar release={release} padding={0} />
+                      ) : undefined,
+                      label: tRelease('dashboard.details.metadata.schedule'),
+                      value: <ReleaseTypePicker release={release} />,
+                    },
+                    {
+                      icon: variantsEnabled ? statusGlyph : undefined,
+                      label: tRelease('dashboard.details.metadata.status'),
+                      // Beta: semantic-coloured text ("Valid" / "Errors" / …) so the panel clearly
+                      // signals "good to go". Production keeps the minimal icon indicator unchanged.
+                      value: variantsEnabled ? (
+                        <ReleaseValidationBadge documents={documents} />
+                      ) : (
+                        <ValidationProgressIndicator documents={documents} layout="minimal" />
+                      ),
+                    },
+                    {
+                      icon: variantsEnabled ? (
+                        <Text size={1} muted>
+                          <DocumentsIcon />
+                        </Text>
+                      ) : undefined,
+                      label: tRelease('dashboard.details.metadata.documents'),
+                      value: String(documents.length),
+                    },
+                    variantsEnabled && {
+                      // The author avatar is the Created row's leading glyph. When the create-event
+                      // author doesn't resolve, fall back to a muted person glyph ("created by —
+                      // unknown") rather than a skeleton, which would read as perpetually loading.
+                      icon: createAuthor ? (
+                        <UserAvatar size={0} user={createAuthor} />
+                      ) : (
+                        <Text size={1} muted>
+                          <UserIcon />
+                        </Text>
+                      ),
+                      label: tRelease('footer.status.created'),
+                      value: (
+                        <Text size={1}>
+                          <RelativeTime time={release._createdAt} useTemporalPhrase minimal />
+                        </Text>
+                      ),
+                    },
+                  ],
+                },
+              ] satisfies DetailPropertiesSection[]
+            }
           />
         </Flex>
         {shouldDisplayError && (

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
@@ -1,50 +1,72 @@
 import {type ReleaseDocument} from '@sanity/client'
+import {CheckmarkCircleIcon} from '@sanity/icons/CheckmarkCircle'
+import {ClockIcon} from '@sanity/icons/Clock'
+import {DocumentsIcon} from '@sanity/icons/Documents'
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
-import {PinIcon} from '@sanity/icons/Pin'
-import {PinFilledIcon} from '@sanity/icons/PinFilled'
+import {UserIcon} from '@sanity/icons/User'
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
 import {Box, Card, Container, Flex, Stack, Text} from '@sanity/ui'
-import {useCallback, useEffect, useRef, useState} from 'react'
+import {useEffect, useRef, useState} from 'react'
 
-import {Button} from '../../../../ui-components/button/Button'
-import {ToneIcon} from '../../../../ui-components/toneIcon/ToneIcon'
-import {TextWithTone} from '../../../components/textWithTone/TextWithTone'
+import {DetailPropertiesPanel} from '../../../components/detailLayout'
+import {RelativeTime} from '../../../components/RelativeTime'
+import {UserAvatar} from '../../../components/userAvatar/UserAvatar'
 import {Details} from '../../../form/components/Details'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
-import {usePerspective} from '../../../perspective/usePerspective'
-import {useSetPerspective} from '../../../perspective/useSetPerspective'
 import {useWorkspace} from '../../../studio/workspace'
+import {ReleaseAvatar} from '../../components/ReleaseAvatar'
 import {releasesLocaleNamespace} from '../../i18n'
 import {useReleaseOperations} from '../../store/useReleaseOperations'
 import {useReleasePermissions} from '../../store/useReleasePermissions'
-import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
+import {getDocumentValidationLoading} from '../../util/getDocumentValidationLoading'
 import {isNotArchivedRelease} from '../../util/util'
 import {ArchivedReleaseBanner} from './ArchivedReleaseBanner'
+import {isCreateReleaseEvent, type ReleaseEvent} from './events/types'
 import {ReleaseDetailsEditor} from './ReleaseDetailsEditor'
 import {ReleaseTypePicker} from './ReleaseTypePicker'
+import {ReleaseValidationBadge} from './ReleaseValidationBadge'
 import {type DocumentInRelease} from './types'
 import {ValidationProgressIndicator} from './ValidationProgressIndicator'
 
 export function ReleaseDashboardDetails({
   release,
   documents,
+  events,
 }: {
   release: ReleaseDocument
   documents: DocumentInRelease[]
+  events: ReleaseEvent[]
 }) {
   const {state} = release
 
-  const releaseId = getReleaseIdFromReleaseDocumentId(release._id)
   const {checkWithPermissionGuard} = useReleasePermissions()
   const {publishRelease, schedule} = useReleaseOperations()
 
   const {t: tRelease} = useTranslation(releasesLocaleNamespace)
-  const {t: tCore} = useTranslation()
-  const {selectedReleaseId} = usePerspective()
-  const setPerspective = useSetPerspective()
+  // Behind beta.variants the footer is dropped, so its "Created" status is rehomed here.
+  const variantsEnabled = Boolean(useWorkspace().beta?.variants?.enabled)
+  const createAuthor = events.find(isCreateReleaseEvent)?.author
 
-  const isSelected = releaseId === selectedReleaseId
-  const releaseFullTitle = release.metadata.title || tCore('release.placeholder-untitled-release')
+  // Status glyph (beta): a semantic-coloured icon accompanying the Status label — checkmark when
+  // valid, error when any document fails, clock while validating. Mirrors the value that
+  // ReleaseValidationBadge renders. The tone-scoped transparent Card colours the icon.
+  const validation = getDocumentValidationLoading(documents)
+  const isFullyValidated = documents.length > 0 && validation.validatedCount === documents.length
+  const statusTone = validation.hasError ? 'critical' : isFullyValidated ? 'positive' : 'default'
+  const statusGlyphIcon = validation.hasError ? (
+    <ErrorOutlineIcon />
+  ) : isFullyValidated ? (
+    <CheckmarkCircleIcon />
+  ) : (
+    <ClockIcon />
+  )
+  const statusGlyph =
+    documents.length === 0 ? undefined : (
+      <Card tone={statusTone} style={{background: 'transparent'}}>
+        <Text size={1}>{statusGlyphIcon}</Text>
+      </Card>
+    )
+
   const isAtTimeRelease = release?.metadata?.releaseType === 'scheduled'
   const isReleaseOpen = state !== 'archived' && state !== 'published'
   const isActive = release.state === 'active'
@@ -52,10 +74,6 @@ export function ReleaseDashboardDetails({
   const [shouldDisplayPermissionWarning, setShouldDisplayPermissionWarning] = useState(false)
   const shouldDisplayWarnings = isActive && shouldDisplayPermissionWarning
   const isMounted = useRef(false)
-  const {document} = useWorkspace()
-  const {
-    drafts: {enabled: isDraftModelEnabled},
-  } = document
   useEffect(() => {
     isMounted.current = true
 
@@ -87,69 +105,80 @@ export function ReleaseDashboardDetails({
     schedule,
   ])
 
-  const handlePinRelease = useCallback(() => {
-    if (isSelected) {
-      setPerspective(isDraftModelEnabled ? 'drafts' : 'published')
-    } else {
-      setPerspective(releaseId)
-    }
-  }, [isDraftModelEnabled, isSelected, releaseId, setPerspective])
-
   return (
     <Container width={3}>
-      <Stack padding={3} paddingY={[3, 3, 4, 5]}>
-        <Flex gap={1} align="center">
-          {isReleaseOpen && (
-            <Button
-              icon={isSelected ? PinFilledIcon : PinIcon}
-              tooltipProps={{
-                placement: 'top',
-                content: isSelected
-                  ? tRelease('dashboard.details.unpin-release')
-                  : tRelease('dashboard.details.pin-release'),
-              }}
-              mode="bleed"
-              onClick={handlePinRelease}
-              radius="full"
-              selected={isSelected}
-              aria-label={
-                isSelected
-                  ? `${tRelease('dashboard.details.unpin-release')}: "${releaseFullTitle}"`
-                  : `${tRelease('dashboard.details.pin-release')}: "${releaseFullTitle}"`
-              }
-              aria-live="assertive"
-            />
-          )}
-          {isNotArchivedRelease(release) && <ReleaseTypePicker release={release} />}
-          <ValidationProgressIndicator documents={documents} />
-          {shouldDisplayError && (
-            <Flex gap={2} padding={2} data-testid="release-error-details">
-              <Text size={1}>
-                <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
-              </Text>
-              <TextWithTone size={1} tone="critical">
-                {isAtTimeRelease
-                  ? tRelease('failed-schedule-title')
-                  : tRelease('failed-publish-title')}
-              </TextWithTone>
-            </Flex>
-          )}
-          {shouldDisplayWarnings && (
-            <Flex gap={2} padding={2} data-testid="release-permission-error-details">
-              <Text size={1}>
-                <ToneIcon icon={WarningOutlineIcon} tone="caution" />
-              </Text>
-              <TextWithTone size={1} tone="caution">
-                {tRelease('permission-missing-title')}
-              </TextWithTone>
-            </Flex>
-          )}
+      {/* Tight top padding: the header above already pads its bottom, so the title sits close under
+          the breadcrumb instead of floating in a doubled gap. */}
+      <Stack paddingX={3} paddingBottom={3} paddingTop={1} space={4}>
+        {/* Clear zones: identity (title + description) on the left; a label -> value metadata panel
+            on the right. Wraps to a single column on narrow widths (metadata stacks under the
+            description). The pin control was removed (it's a global-perspective mode that belongs in
+            the perspective bar, matching the Variants pin removal). */}
+        <Flex align="flex-start" gap={4} wrap="wrap">
+          <Box flex={1} style={{minWidth: 280}}>
+            <ReleaseDetailsEditor release={release} />
+          </Box>
+          {/* The metadata is its own bordered surface — the shared properties panel — so it reads
+              as a discrete block next to the identity. In production "Created" lives in the footer;
+              behind beta.variants the footer is dropped, so a Created row is added here instead. */}
+          <DetailPropertiesPanel
+            testId="release-detail-metadata"
+            sections={[
+              {
+                rows: [
+                  isNotArchivedRelease(release) && {
+                    // Leading glyph reflects the live release type (bolt / clock / dot), tone-coloured.
+                    icon: variantsEnabled ? (
+                      <ReleaseAvatar release={release} padding={0} />
+                    ) : undefined,
+                    label: tRelease('dashboard.details.metadata.schedule'),
+                    value: <ReleaseTypePicker release={release} />,
+                  },
+                  {
+                    icon: variantsEnabled ? statusGlyph : undefined,
+                    label: tRelease('dashboard.details.metadata.status'),
+                    // Beta: semantic-coloured text ("Valid" / "Errors" / …) so the panel clearly
+                    // signals "good to go". Production keeps the minimal icon indicator unchanged.
+                    value: variantsEnabled ? (
+                      <ReleaseValidationBadge documents={documents} />
+                    ) : (
+                      <ValidationProgressIndicator documents={documents} layout="minimal" />
+                    ),
+                  },
+                  {
+                    icon: variantsEnabled ? (
+                      <Text size={1} muted>
+                        <DocumentsIcon />
+                      </Text>
+                    ) : undefined,
+                    label: tRelease('dashboard.details.metadata.documents'),
+                    value: String(documents.length),
+                  },
+                  variantsEnabled && {
+                    // The author avatar is the Created row's leading glyph. When the create-event
+                    // author doesn't resolve, fall back to a muted person glyph ("created by —
+                    // unknown") rather than a skeleton, which would read as perpetually loading.
+                    icon: createAuthor ? (
+                      <UserAvatar size={0} user={createAuthor} />
+                    ) : (
+                      <Text size={1} muted>
+                        <UserIcon />
+                      </Text>
+                    ),
+                    label: tRelease('footer.status.created'),
+                    value: (
+                      <Text size={1}>
+                        <RelativeTime time={release._createdAt} useTemporalPhrase minimal />
+                      </Text>
+                    ),
+                  },
+                ],
+              },
+            ]}
+          />
         </Flex>
-        <Box padding={2}>
-          <ReleaseDetailsEditor release={release} />
-        </Box>
         {shouldDisplayError && (
-          <Card padding={4} radius={4} tone="critical">
+          <Card data-testid="release-error-details" padding={4} radius={4} tone="critical">
             <Flex gap={3}>
               <Text size={1}>
                 <ErrorOutlineIcon />
@@ -171,7 +200,12 @@ export function ReleaseDashboardDetails({
         )}
 
         {shouldDisplayWarnings && (
-          <Card padding={4} radius={4} tone="caution">
+          <Card
+            data-testid="release-permission-error-details"
+            padding={4}
+            radius={4}
+            tone="caution"
+          >
             <Flex gap={3}>
               <Text size={1}>
                 <WarningOutlineIcon />

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardDetails.tsx
@@ -3,22 +3,30 @@ import {CheckmarkCircleIcon} from '@sanity/icons/CheckmarkCircle'
 import {ClockIcon} from '@sanity/icons/Clock'
 import {DocumentsIcon} from '@sanity/icons/Documents'
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
+import {PinIcon} from '@sanity/icons/Pin'
+import {PinFilledIcon} from '@sanity/icons/PinFilled'
 import {UserIcon} from '@sanity/icons/User'
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
 import {Box, Card, Container, Flex, Stack, Text} from '@sanity/ui'
-import {useEffect, useRef, useState} from 'react'
+import {useCallback, useEffect, useRef, useState} from 'react'
 
+import {Button} from '../../../../ui-components/button/Button'
+import {ToneIcon} from '../../../../ui-components/toneIcon/ToneIcon'
 import {DetailPropertiesPanel, type DetailPropertiesSection} from '../../../components/detailLayout'
 import {RelativeTime} from '../../../components/RelativeTime'
+import {TextWithTone} from '../../../components/textWithTone/TextWithTone'
 import {UserAvatar} from '../../../components/userAvatar/UserAvatar'
 import {Details} from '../../../form/components/Details'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {usePerspective} from '../../../perspective/usePerspective'
+import {useSetPerspective} from '../../../perspective/useSetPerspective'
 import {useWorkspace} from '../../../studio/workspace'
 import {ReleaseAvatar} from '../../components/ReleaseAvatar'
 import {releasesLocaleNamespace} from '../../i18n'
 import {useReleaseOperations} from '../../store/useReleaseOperations'
 import {useReleasePermissions} from '../../store/useReleasePermissions'
 import {getDocumentValidationLoading} from '../../util/getDocumentValidationLoading'
+import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
 import {isNotArchivedRelease} from '../../util/util'
 import {ArchivedReleaseBanner} from './ArchivedReleaseBanner'
 import {isCreateReleaseEvent, type ReleaseEvent} from './events/types'
@@ -27,6 +35,139 @@ import {ReleaseTypePicker} from './ReleaseTypePicker'
 import {ReleaseValidationBadge} from './ReleaseValidationBadge'
 import {type DocumentInRelease} from './types'
 import {ValidationProgressIndicator} from './ValidationProgressIndicator'
+
+function ReleaseDashboardDetailsProduction({
+  release,
+  documents,
+  shouldDisplayError,
+  shouldDisplayWarnings,
+  isAtTimeRelease,
+  isReleaseOpen,
+}: {
+  release: ReleaseDocument
+  documents: DocumentInRelease[]
+  shouldDisplayError: boolean
+  shouldDisplayWarnings: boolean
+  isAtTimeRelease: boolean
+  isReleaseOpen: boolean
+}) {
+  const {t: tRelease} = useTranslation(releasesLocaleNamespace)
+  const {t: tCore} = useTranslation()
+  const releaseId = getReleaseIdFromReleaseDocumentId(release._id)
+  const {selectedReleaseId} = usePerspective()
+  const setPerspective = useSetPerspective()
+  const {document} = useWorkspace()
+  const {
+    drafts: {enabled: isDraftModelEnabled},
+  } = document
+
+  const isSelected = releaseId === selectedReleaseId
+  const releaseFullTitle = release.metadata.title || tCore('release.placeholder-untitled-release')
+
+  const handlePinRelease = useCallback(() => {
+    if (isSelected) {
+      setPerspective(isDraftModelEnabled ? 'drafts' : 'published')
+    } else {
+      setPerspective(releaseId)
+    }
+  }, [isDraftModelEnabled, isSelected, releaseId, setPerspective])
+
+  return (
+    <Container width={3}>
+      <Stack padding={3} paddingY={[3, 3, 4, 5]}>
+        <Flex gap={1} align="center">
+          {isReleaseOpen && (
+            <Button
+              icon={isSelected ? PinFilledIcon : PinIcon}
+              tooltipProps={{
+                placement: 'top',
+                content: isSelected
+                  ? tRelease('dashboard.details.unpin-release')
+                  : tRelease('dashboard.details.pin-release'),
+              }}
+              mode="bleed"
+              onClick={handlePinRelease}
+              radius="full"
+              selected={isSelected}
+              aria-label={
+                isSelected
+                  ? `${tRelease('dashboard.details.unpin-release')}: "${releaseFullTitle}"`
+                  : `${tRelease('dashboard.details.pin-release')}: "${releaseFullTitle}"`
+              }
+              aria-live="assertive"
+            />
+          )}
+          {isNotArchivedRelease(release) && <ReleaseTypePicker release={release} />}
+          <ValidationProgressIndicator documents={documents} />
+          {shouldDisplayError && (
+            <Flex gap={2} padding={2} data-testid="release-error-details">
+              <Text size={1}>
+                <ToneIcon icon={ErrorOutlineIcon} tone="critical" />
+              </Text>
+              <TextWithTone size={1} tone="critical">
+                {isAtTimeRelease
+                  ? tRelease('failed-schedule-title')
+                  : tRelease('failed-publish-title')}
+              </TextWithTone>
+            </Flex>
+          )}
+          {shouldDisplayWarnings && (
+            <Flex gap={2} padding={2} data-testid="release-permission-error-details">
+              <Text size={1}>
+                <ToneIcon icon={WarningOutlineIcon} tone="caution" />
+              </Text>
+              <TextWithTone size={1} tone="caution">
+                {tRelease('permission-missing-title')}
+              </TextWithTone>
+            </Flex>
+          )}
+        </Flex>
+        <Box padding={2}>
+          <ReleaseDetailsEditor release={release} />
+        </Box>
+        {shouldDisplayError && (
+          <Card padding={4} radius={4} tone="critical">
+            <Flex gap={3}>
+              <Text size={1}>
+                <ErrorOutlineIcon />
+              </Text>
+              <Stack space={4}>
+                <Text size={1} weight="semibold">
+                  {isAtTimeRelease
+                    ? tRelease('failed-schedule-title')
+                    : tRelease('failed-publish-title')}
+                </Text>
+                <Details title={tRelease('error-details-title')}>
+                  <Text size={1} accent>
+                    <code>{release.error?.message}</code>
+                  </Text>
+                </Details>
+              </Stack>
+            </Flex>
+          </Card>
+        )}
+
+        {shouldDisplayWarnings && (
+          <Card padding={4} radius={4} tone="caution">
+            <Flex gap={3}>
+              <Text size={1}>
+                <WarningOutlineIcon />
+              </Text>
+              <Stack space={3}>
+                <Text size={1}>{tRelease('permission-missing-title')}</Text>
+                <Text size={1} muted>
+                  {tRelease('permission-missing-description')}
+                </Text>
+              </Stack>
+            </Flex>
+          </Card>
+        )}
+
+        {!isReleaseOpen && <ArchivedReleaseBanner release={release} />}
+      </Stack>
+    </Container>
+  )
+}
 
 export function ReleaseDashboardDetails({
   release,
@@ -43,13 +184,9 @@ export function ReleaseDashboardDetails({
   const {publishRelease, schedule} = useReleaseOperations()
 
   const {t: tRelease} = useTranslation(releasesLocaleNamespace)
-  // Behind beta.variants the footer is dropped, so its "Created" status is rehomed here.
   const variantsEnabled = Boolean(useWorkspace().beta?.variants?.enabled)
   const createAuthor = events.find(isCreateReleaseEvent)?.author
 
-  // Status glyph (beta): a semantic-coloured icon accompanying the Status label — checkmark when
-  // valid, error when any document fails, clock while validating. Mirrors the value that
-  // ReleaseValidationBadge renders. The tone-scoped transparent Card colours the icon.
   const validation = getDocumentValidationLoading(documents)
   const isFullyValidated = documents.length > 0 && validation.validatedCount === documents.length
   const statusTone = validation.hasError ? 'critical' : isFullyValidated ? 'positive' : 'default'
@@ -105,6 +242,19 @@ export function ReleaseDashboardDetails({
     schedule,
   ])
 
+  if (!variantsEnabled) {
+    return (
+      <ReleaseDashboardDetailsProduction
+        release={release}
+        documents={documents}
+        shouldDisplayError={shouldDisplayError}
+        shouldDisplayWarnings={shouldDisplayWarnings}
+        isAtTimeRelease={isAtTimeRelease}
+        isReleaseOpen={isReleaseOpen}
+      />
+    )
+  }
+
   return (
     <Container width={3}>
       {/* Tight top padding: the header above already pads its bottom, so the title sits close under
@@ -118,9 +268,6 @@ export function ReleaseDashboardDetails({
           <Box flex={1} style={{minWidth: 280}}>
             <ReleaseDetailsEditor release={release} />
           </Box>
-          {/* The metadata is its own bordered surface — the shared properties panel — so it reads
-              as a discrete block next to the identity. In production "Created" lives in the footer;
-              behind beta.variants the footer is dropped, so a Created row is added here instead. */}
           <DetailPropertiesPanel
             testId="release-detail-metadata"
             sections={
@@ -128,37 +275,25 @@ export function ReleaseDashboardDetails({
                 {
                   rows: [
                     isNotArchivedRelease(release) && {
-                      // Leading glyph reflects the live release type (bolt / clock / dot), tone-coloured.
-                      icon: variantsEnabled ? (
-                        <ReleaseAvatar release={release} padding={0} />
-                      ) : undefined,
+                      icon: <ReleaseAvatar release={release} padding={0} />,
                       label: tRelease('dashboard.details.metadata.schedule'),
                       value: <ReleaseTypePicker release={release} />,
                     },
                     {
-                      icon: variantsEnabled ? statusGlyph : undefined,
+                      icon: statusGlyph,
                       label: tRelease('dashboard.details.metadata.status'),
-                      // Beta: semantic-coloured text ("Valid" / "Errors" / …) so the panel clearly
-                      // signals "good to go". Production keeps the minimal icon indicator unchanged.
-                      value: variantsEnabled ? (
-                        <ReleaseValidationBadge documents={documents} />
-                      ) : (
-                        <ValidationProgressIndicator documents={documents} layout="minimal" />
-                      ),
+                      value: <ReleaseValidationBadge documents={documents} />,
                     },
                     {
-                      icon: variantsEnabled ? (
+                      icon: (
                         <Text size={1} muted>
                           <DocumentsIcon />
                         </Text>
-                      ) : undefined,
+                      ),
                       label: tRelease('dashboard.details.metadata.documents'),
                       value: String(documents.length),
                     },
-                    variantsEnabled && {
-                      // The author avatar is the Created row's leading glyph. When the create-event
-                      // author doesn't resolve, fall back to a muted person glyph ("created by —
-                      // unknown") rather than a skeleton, which would read as perpetually loading.
+                    {
                       icon: createAuthor ? (
                         <UserAvatar size={0} user={createAuthor} />
                       ) : (

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardFooter.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardFooter.tsx
@@ -1,14 +1,9 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {Card, Flex} from '@sanity/ui'
-import {useMemo} from 'react'
 
-import {isReleaseScheduledOrScheduling} from '../../util/util'
-import {ReleasePublishAllButton} from '../components/releaseCTAButtons/ReleasePublishAllButton'
-import {ReleaseRevertButton} from '../components/releaseCTAButtons/ReleaseRevertButton/ReleaseRevertButton'
-import {ReleaseScheduleButton} from '../components/releaseCTAButtons/ReleaseScheduleButton'
-import {ReleaseUnscheduleButton} from '../components/releaseCTAButtons/ReleaseUnscheduleButton'
 import {ReleaseMenuButton} from '../components/ReleaseMenuButton/ReleaseMenuButton'
 import {type ReleaseEvent} from './events/types'
+import {ReleaseActionButton} from './ReleaseActionButton'
 import {ReleaseStatusItems} from './ReleaseStatusItems'
 import {type DocumentInRelease} from './types'
 
@@ -18,50 +13,6 @@ export function ReleaseDashboardFooter(props: {
   events: ReleaseEvent[]
 }) {
   const {documents, release, events} = props
-
-  const releaseActionButton = useMemo(() => {
-    if (release.state === 'archived') return null
-
-    if (isReleaseScheduledOrScheduling(release)) {
-      return (
-        <ReleaseUnscheduleButton
-          release={release}
-          documents={documents}
-          disabled={!documents.length}
-        />
-      )
-    }
-
-    if (release.state === 'active') {
-      if (release.metadata.releaseType === 'scheduled') {
-        return (
-          <ReleaseScheduleButton
-            release={release}
-            documents={documents}
-            disabled={!documents.length}
-          />
-        )
-      }
-
-      if (release.metadata.releaseType === 'asap') {
-        return (
-          <ReleasePublishAllButton
-            release={release}
-            documents={documents}
-            disabled={!documents.length}
-          />
-        )
-      }
-    }
-
-    if (release.state === 'published') {
-      return (
-        <ReleaseRevertButton release={release} documents={documents} disabled={!documents.length} />
-      )
-    }
-
-    return null
-  }, [documents, release])
 
   return (
     <Card flex="none">
@@ -73,7 +24,7 @@ export function ReleaseDashboardFooter(props: {
         </Flex>
 
         <Flex flex="none" gap={1} data-testid="release-dashboard-footer-actions">
-          {releaseActionButton}
+          <ReleaseActionButton release={release} documents={documents} />
           <ReleaseMenuButton
             release={release}
             documentsCount={documents.length}

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardHeader.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDashboardHeader.tsx
@@ -5,28 +5,44 @@ import {
   Box,
   // oxlint-disable-next-line no-restricted-imports
   Button, // Custom button with a different textWeight, consider adding textWeight to the shared
+  Container,
   Flex,
   Text,
 } from '@sanity/ui'
 import {type Dispatch, type SetStateAction, useCallback} from 'react'
 import {useRouter} from 'sanity/router'
 
+import {DetailBackButton} from '../../../components/detailLayout'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {useWorkspace} from '../../../studio/workspace'
 import {releasesLocaleNamespace} from '../../i18n'
 import {GROUP_SEARCH_PARAM_KEY} from '../overview/queryParamUtils'
 import {CopyReleaseActions} from './CopyReleaseActions'
+import {ReleaseActionRail} from './ReleaseActionRail'
 import {type ReleaseInspector} from './ReleaseDetail'
+import {type DocumentInRelease} from './types'
+
+// The bleed back-button carries its own horizontal padding, which would push the breadcrumb text
+// right of the title/table left edge. Cancel that padding so the breadcrumb sits on the same hard
+// left line as everything below it, framing the pane.
+const BREADCRUMB_ALIGN_STYLE = {marginLeft: -8}
 
 export function ReleaseDashboardHeader(props: {
+  documents: DocumentInRelease[]
   inspector: ReleaseInspector | undefined
   release: ReleaseDocument
   setInspector: Dispatch<SetStateAction<ReleaseInspector | undefined>>
 }) {
-  const {inspector, release, setInspector} = props
+  const {documents, inspector, release, setInspector} = props
   const {t} = useTranslation(releasesLocaleNamespace)
   const {t: tCore} = useTranslation()
   const title = release.metadata.title || tCore('release.placeholder-untitled-release')
   const router = useRouter()
+
+  // Behind beta.variants the Share/Activity actions move into the table's command lane (one action
+  // lane). Production keeps them in the header until the flag flips.
+  const {beta} = useWorkspace()
+  const variantsEnabled = Boolean(beta?.variants?.enabled)
 
   const handleNavigateToReleasesList = useCallback(() => {
     const isReleaseOpen = release.state !== 'archived' && release.state !== 'published'
@@ -41,47 +57,75 @@ export function ReleaseDashboardHeader(props: {
   }, [setInspector])
 
   return (
-    <Flex align="flex-start">
-      <Flex flex={1} align="center" style={{minWidth: 0}}>
-        <Flex flex="none">
-          <Button
-            mode="bleed"
-            onClick={handleNavigateToReleasesList}
-            text={t('overview.title')}
-            textWeight="regular"
-            padding={2}
-            data-testid="back-to-releases-button"
-          />
-        </Flex>
-        <Box paddingY={2} flex="none">
-          <Text size={1}>
-            <ChevronRightIcon />
-          </Text>
-        </Box>
-        <Box padding={2} style={{minWidth: 0, maxWidth: '300px'}}>
-          <Text
-            size={1}
-            weight="semibold"
-            textOverflow="ellipsis"
-            style={release.metadata.title ? undefined : {opacity: 0.5}}
-          >
-            {title}
-          </Text>
-        </Box>
-      </Flex>
+    // Share the same width={3} gutter as the details/table panes below, so the breadcrumb aligns
+    // with the title and the Share/Activity actions align flush with the metadata rail's right edge.
+    <Container width={3}>
+      <Box padding={3}>
+        <Flex align="flex-start">
+          <Flex flex={1} align="center" style={{minWidth: 0}}>
+            {variantsEnabled ? (
+              // A single back affordance — the release title already headlines the pane below, so
+              // the breadcrumb's repeat of it is dropped. Mirrors the Variants detail's back arrow.
+              <DetailBackButton
+                text={t('overview.back-to-all-releases')}
+                onClick={handleNavigateToReleasesList}
+                testId="back-to-releases-button"
+              />
+            ) : (
+              <>
+                <Flex flex="none">
+                  <Button
+                    mode="bleed"
+                    onClick={handleNavigateToReleasesList}
+                    text={t('overview.title')}
+                    textWeight="regular"
+                    padding={2}
+                    style={BREADCRUMB_ALIGN_STYLE}
+                    data-testid="back-to-releases-button"
+                  />
+                </Flex>
+                <Box paddingY={2} flex="none">
+                  <Text size={1}>
+                    <ChevronRightIcon />
+                  </Text>
+                </Box>
+                <Box padding={2} style={{minWidth: 0, maxWidth: '300px'}}>
+                  <Text
+                    size={1}
+                    weight="semibold"
+                    textOverflow="ellipsis"
+                    style={release.metadata.title ? undefined : {opacity: 0.5}}
+                  >
+                    {title}
+                  </Text>
+                </Box>
+              </>
+            )}
+          </Flex>
 
-      <Flex flex="none" gap={2}>
-        <CopyReleaseActions release={release} />
-        <Button
-          icon={RestoreIcon}
-          mode="bleed"
-          onClick={handleActivityClick}
-          padding={2}
-          selected={inspector === 'activity'}
-          space={2}
-          text={t('dashboard.details.activity')}
-        />
-      </Flex>
-    </Flex>
+          {variantsEnabled ? (
+            // The F-pattern action rail: the release's primary action (Run release / Publish /
+            // Schedule / …) and its overflow menu sit top-right, where the eye lands first, instead
+            // of in a bottom footer. The footer is dropped in beta (see ReleaseDetail).
+            <Flex flex="none">
+              <ReleaseActionRail release={release} documents={documents} />
+            </Flex>
+          ) : (
+            <Flex flex="none" gap={2}>
+              <CopyReleaseActions release={release} />
+              <Button
+                icon={RestoreIcon}
+                mode="bleed"
+                onClick={handleActivityClick}
+                padding={2}
+                selected={inspector === 'activity'}
+                space={2}
+                text={t('dashboard.details.activity')}
+              />
+            </Flex>
+          )}
+        </Flex>
+      </Box>
+    </Container>
   )
 }

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetail.tsx
@@ -6,6 +6,7 @@ import {useRouter} from 'sanity/router'
 
 import {LoadingBlock} from '../../../components/loadingBlock/LoadingBlock'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {useWorkspace} from '../../../studio/workspace'
 import {releasesLocaleNamespace} from '../../i18n'
 import {useActiveReleases} from '../../store/useActiveReleases'
 import {useArchivedReleases} from '../../store/useArchivedReleases'
@@ -27,6 +28,8 @@ export function ReleaseDetail() {
   const router = useRouter()
   const [inspector, setInspector] = useState<ReleaseInspector | undefined>(undefined)
   const {t} = useTranslation(releasesLocaleNamespace)
+  // Behind beta.variants the action cluster moves to the top rail and the footer is dropped.
+  const variantsEnabled = Boolean(useWorkspace().beta?.variants?.enabled)
   const {releaseId: releaseIdRaw}: ReleasesRouterState = router.state
   const releaseId = decodeURIComponent(releaseIdRaw || '')
   const {data, loading} = useActiveReleases()
@@ -85,9 +88,15 @@ export function ReleaseDetail() {
     if (!releaseInDetail) return null
 
     return (
-      <ReleaseSummary isLoading={documentsLoading} documents={results} release={releaseInDetail} />
+      <ReleaseSummary
+        isLoading={documentsLoading}
+        documents={results}
+        release={releaseInDetail}
+        inspector={inspector}
+        setInspector={setInspector}
+      />
     )
-  }, [bundleDocumentsError, documentsLoading, releaseInDetail, results, t])
+  }, [bundleDocumentsError, documentsLoading, inspector, releaseInDetail, results, t])
 
   if (loading) {
     return (
@@ -101,9 +110,19 @@ export function ReleaseDetail() {
 
   if (releaseInDetail) {
     return (
-      <Flex direction="column" flex={1} height="fill" overflow="hidden">
-        <Card flex="none" padding={3}>
+      // position:relative anchors the beta activity overlay to the whole detail pane, so the
+      // right-anchored drawer covers the top action rail (Run release + menu) too — not just the
+      // content below it.
+      <Flex
+        direction="column"
+        flex={1}
+        height="fill"
+        overflow="hidden"
+        style={{position: 'relative'}}
+      >
+        <Card flex="none">
           <ReleaseDashboardHeader
+            documents={results}
             release={releaseInDetail}
             inspector={inspector}
             setInspector={setInspector}
@@ -113,23 +132,46 @@ export function ReleaseDetail() {
         <Flex flex={1}>
           <Flex direction="column" flex={1} height="fill">
             <Card flex={1} overflow="auto">
-              <ReleaseDashboardDetails release={releaseInDetail} documents={results} />
+              <ReleaseDashboardDetails
+                release={releaseInDetail}
+                documents={results}
+                events={releaseEvents.events}
+              />
               {detailContent}
             </Card>
 
-            <ReleaseDashboardFooter
-              documents={results}
-              release={releaseInDetail}
-              events={releaseEvents.events}
-            />
+            {/* In beta the footer's action cluster moved to the top rail and its Created status
+                moved into the properties panel, so the footer is dropped entirely. */}
+            {!variantsEnabled && (
+              <ReleaseDashboardFooter
+                documents={results}
+                release={releaseInDetail}
+                events={releaseEvents.events}
+              />
+            )}
           </Flex>
 
+          {/* Production: activity is an in-flow panel that pushes the content column aside. */}
+          {!variantsEnabled && (
+            <ReleaseDashboardActivityPanel
+              events={releaseEvents}
+              release={releaseInDetail}
+              show={inspector === 'activity'}
+            />
+          )}
+        </Flex>
+
+        {/* Beta: activity floats as a right-anchored drawer over the entire pane (covering the
+            rail), rather than pushing the layout. */}
+        {variantsEnabled && (
           <ReleaseDashboardActivityPanel
             events={releaseEvents}
             release={releaseInDetail}
             show={inspector === 'activity'}
+            overlay
+            onClose={() => setInspector(undefined)}
           />
-        </Flex>
+        )}
       </Flex>
     )
   }

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetailsEditor.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetailsEditor.tsx
@@ -1,53 +1,91 @@
-import {type ReleaseDocument} from '@sanity/client'
-import {EditIcon} from '@sanity/icons/Edit'
-import {useState} from 'react'
+import {type EditableReleaseDocument, type ReleaseDocument} from '@sanity/client'
+import {useCallback, useEffect, useRef, useState} from 'react'
 
-import {Button} from '../../../../ui-components/button/Button'
 import {DetailIdentity} from '../../../components/detailLayout'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {useWorkspace} from '../../../studio/workspace'
-import {EditReleaseDialog} from '../../components/dialog/EditReleaseDialog'
-import {useCanEditRelease} from './useCanEditRelease'
+import {getIsReleaseOpen, TitleDescriptionForm} from '../../components/dialog/TitleDescriptionForm'
+import {useReleaseOperations} from '../../store/useReleaseOperations'
+import {useReleasePermissions} from '../../store/useReleasePermissions'
+
+function ReleaseDetailsEditorProduction({release}: {release: ReleaseDocument}): React.JSX.Element {
+  const {updateRelease} = useReleaseOperations()
+  const [timer, setTimer] = useState<NodeJS.Timeout | undefined>(undefined)
+
+  const {checkWithPermissionGuard} = useReleasePermissions()
+  const [hasUpdatePermission, setHasUpdatePermission] = useState<boolean | null>(null)
+
+  const handleOnChange = useCallback(
+    (changedValue: EditableReleaseDocument) => {
+      clearTimeout(timer)
+
+      /** @todo I wasn't able to get this working with the debouncer that we use in other parts */
+      const newTimer = setTimeout(() => {
+        if (hasUpdatePermission) {
+          void updateRelease(changedValue)
+        }
+      }, 200)
+
+      setTimer(newTimer)
+    },
+    [hasUpdatePermission, timer, updateRelease],
+  )
+
+  const isMounted = useRef(false)
+  useEffect(() => {
+    isMounted.current = true
+
+    if (getIsReleaseOpen(release)) {
+      // title and description will be readOnly if release is not 'open'
+      // so only need to check permission to edit if release is 'open'
+      void checkWithPermissionGuard(updateRelease, release).then((hasPermission) => {
+        if (isMounted.current) setHasUpdatePermission(hasPermission)
+      })
+    }
+
+    return () => {
+      isMounted.current = false
+    }
+  }, [checkWithPermissionGuard, release, release._id, updateRelease])
+
+  return (
+    <TitleDescriptionForm
+      key={release._id}
+      release={release}
+      onChange={handleOnChange}
+      disabled={Boolean(!hasUpdatePermission)}
+    />
+  )
+}
 
 /**
  * The release identity (title + description) as a read-only display surface built on the shared
  * `DetailIdentity` spine.
  *
- * Editing is an explicit action, never inline. In production it is a hover-revealed pencil beside
- * the title; behind `beta.variants` the pencil is dropped in favour of a defined "Edit details"
- * action in the top action rail (a defined button is discoverable and keyboard/screen-reader
- * accessible in a way a hover-only affordance is not).
+ * Editing is an explicit action, never inline. Behind `beta.variants` the pencil is dropped in
+ * favour of a defined "Edit details" action in the top action rail (a defined button is discoverable
+ * and keyboard/screen-reader accessible in a way a hover-only affordance is not).
  */
-export function ReleaseDetailsEditor({release}: {release: ReleaseDocument}): React.JSX.Element {
+function ReleaseDetailsEditorVariants({release}: {release: ReleaseDocument}): React.JSX.Element {
   const {t} = useTranslation()
-  const [editOpen, setEditOpen] = useState(false)
-  const canEdit = useCanEditRelease(release)
-
-  // Behind beta.variants, editing lives in the action rail, so the identity block is pure display.
-  const variantsEnabled = Boolean(useWorkspace().beta?.variants?.enabled)
-  const showInlineEdit = canEdit && !variantsEnabled
 
   return (
-    <>
-      <DetailIdentity
-        title={release.metadata.title}
-        titlePlaceholder={t('release.placeholder-untitled-release')}
-        description={release.metadata.description}
-        titleTestId="release-title-display"
-        descriptionTestId="release-description-display"
-        titleAction={
-          showInlineEdit ? (
-            <Button
-              data-testid="edit-release-details-button"
-              icon={EditIcon}
-              mode="bleed"
-              onClick={() => setEditOpen(true)}
-              tooltipProps={{content: t('release.action.edit-details')}}
-            />
-          ) : undefined
-        }
-      />
-      {editOpen && <EditReleaseDialog release={release} onClose={() => setEditOpen(false)} />}
-    </>
+    <DetailIdentity
+      title={release.metadata.title}
+      titlePlaceholder={t('release.placeholder-untitled-release')}
+      description={release.metadata.description}
+      titleTestId="release-title-display"
+      descriptionTestId="release-description-display"
+    />
   )
+}
+
+export function ReleaseDetailsEditor({release}: {release: ReleaseDocument}): React.JSX.Element {
+  const variantsEnabled = Boolean(useWorkspace().beta?.variants?.enabled)
+
+  if (variantsEnabled) {
+    return <ReleaseDetailsEditorVariants release={release} />
+  }
+
+  return <ReleaseDetailsEditorProduction release={release} />
 }

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetailsEditor.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetailsEditor.tsx
@@ -1,56 +1,53 @@
-import {type EditableReleaseDocument, type ReleaseDocument} from '@sanity/client'
-import {useCallback, useEffect, useRef, useState} from 'react'
+import {type ReleaseDocument} from '@sanity/client'
+import {EditIcon} from '@sanity/icons/Edit'
+import {useState} from 'react'
 
-import {getIsReleaseOpen, TitleDescriptionForm} from '../../components/dialog/TitleDescriptionForm'
-import {useReleaseOperations} from '../../store/useReleaseOperations'
-import {useReleasePermissions} from '../../store/useReleasePermissions'
+import {Button} from '../../../../ui-components/button/Button'
+import {DetailIdentity} from '../../../components/detailLayout'
+import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {useWorkspace} from '../../../studio/workspace'
+import {EditReleaseDialog} from '../../components/dialog/EditReleaseDialog'
+import {useCanEditRelease} from './useCanEditRelease'
 
+/**
+ * The release identity (title + description) as a read-only display surface built on the shared
+ * `DetailIdentity` spine.
+ *
+ * Editing is an explicit action, never inline. In production it is a hover-revealed pencil beside
+ * the title; behind `beta.variants` the pencil is dropped in favour of a defined "Edit details"
+ * action in the top action rail (a defined button is discoverable and keyboard/screen-reader
+ * accessible in a way a hover-only affordance is not).
+ */
 export function ReleaseDetailsEditor({release}: {release: ReleaseDocument}): React.JSX.Element {
-  const {updateRelease} = useReleaseOperations()
-  const [timer, setTimer] = useState<NodeJS.Timeout | undefined>(undefined)
+  const {t} = useTranslation()
+  const [editOpen, setEditOpen] = useState(false)
+  const canEdit = useCanEditRelease(release)
 
-  const {checkWithPermissionGuard} = useReleasePermissions()
-  const [hasUpdatePermission, setHasUpdatePermission] = useState<boolean | null>(null)
-
-  const handleOnChange = useCallback(
-    (changedValue: EditableReleaseDocument) => {
-      clearTimeout(timer)
-
-      /** @todo I wasn't able to get this working with the debouncer that we use in other parts */
-      const newTimer = setTimeout(() => {
-        if (hasUpdatePermission) {
-          void updateRelease(changedValue)
-        }
-      }, 200)
-
-      setTimer(newTimer)
-    },
-    [hasUpdatePermission, timer, updateRelease],
-  )
-
-  const isMounted = useRef(false)
-  useEffect(() => {
-    isMounted.current = true
-
-    if (getIsReleaseOpen(release)) {
-      // title and description will be readOnly if release is not 'open'
-      // so only need to check permission to edit if release is 'open'
-      void checkWithPermissionGuard(updateRelease, release).then((hasPermission) => {
-        if (isMounted.current) setHasUpdatePermission(hasPermission)
-      })
-    }
-
-    return () => {
-      isMounted.current = false
-    }
-  }, [checkWithPermissionGuard, release, release._id, updateRelease])
+  // Behind beta.variants, editing lives in the action rail, so the identity block is pure display.
+  const variantsEnabled = Boolean(useWorkspace().beta?.variants?.enabled)
+  const showInlineEdit = canEdit && !variantsEnabled
 
   return (
-    <TitleDescriptionForm
-      key={release._id}
-      release={release}
-      onChange={handleOnChange}
-      disabled={Boolean(!hasUpdatePermission)}
-    />
+    <>
+      <DetailIdentity
+        title={release.metadata.title}
+        titlePlaceholder={t('release.placeholder-untitled-release')}
+        description={release.metadata.description}
+        titleTestId="release-title-display"
+        descriptionTestId="release-description-display"
+        titleAction={
+          showInlineEdit ? (
+            <Button
+              data-testid="edit-release-details-button"
+              icon={EditIcon}
+              mode="bleed"
+              onClick={() => setEditOpen(true)}
+              tooltipProps={{content: t('release.action.edit-details')}}
+            />
+          ) : undefined
+        }
+      />
+      {editOpen && <EditReleaseDialog release={release} onClose={() => setEditOpen(false)} />}
+    </>
   )
 }

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -385,6 +385,7 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
     <Flex direction="column" style={FULL_HEIGHT_STYLE}>
       {variantsEnabled ? (
         <DocumentTable<DocumentInReleaseDetail>
+          alwaysShowCommandLane
           columnDefs={documentTableColumnDefs}
           defaultSort={{column: 'search', direction: 'asc'}}
           emptyState={t('summary.no-documents')}

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -1,24 +1,45 @@
 import {type ReleaseDocument, type SanityDocument} from '@sanity/client'
 import {AddIcon} from '@sanity/icons/Add'
+import {CloseIcon} from '@sanity/icons/Close'
+import {CopyIcon} from '@sanity/icons/Copy'
+import {EllipsisHorizontalIcon} from '@sanity/icons/EllipsisHorizontal'
+import {RestoreIcon} from '@sanity/icons/Restore'
+import {UnpublishIcon} from '@sanity/icons/Unpublish'
 import {useTelemetry} from '@sanity/telemetry/react'
-import {Card, Container, Flex, Stack, Text, useToast} from '@sanity/ui'
-import {type CSSProperties, useCallback, useEffect, useMemo, useState} from 'react'
+import {Card, Container, Flex, Menu, Stack, Text, useToast} from '@sanity/ui'
+import {
+  type CSSProperties,
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 
 import {Button} from '../../../../ui-components/button/Button'
+import {MenuButton} from '../../../../ui-components/menuButton/MenuButton'
+import {MenuItem} from '../../../../ui-components/menuItem/MenuItem'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {useWorkspace} from '../../../studio/workspace'
 import {getVersionId} from '../../../util/draftUtils'
 import {getDocumentVariantType} from '../../../util/getDocumentVariantType'
 import {isCardinalityOneRelease} from '../../../util/releaseUtils'
+import {useAllVariants} from '../../../variants/store/useAllVariants'
 import {AddedVersion} from '../../__telemetry__/releases.telemetry'
 import {releasesLocaleNamespace} from '../../i18n'
 import {useReleaseOperations} from '../../store/useReleaseOperations'
 import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
+import {DocumentTable, type DocumentTableSelection} from '../components/Table/DocumentTable'
 import {Table} from '../components/Table/Table'
 import {AddDocumentSearch, type AddedDocument} from './AddDocumentSearch'
 import {ReleaseDocumentFilterTabs} from './components/ReleaseDocumentFilterTabs'
+import {CopyReleaseActions} from './CopyReleaseActions'
 import {DocumentActions} from './documentTable/DocumentActions'
 import {getDocumentTableColumnDefs} from './documentTable/DocumentTableColumnDefs'
 import {searchDocumentRelease} from './documentTable/searchDocumentRelease'
+import {ReleaseBulkActionDialog, type ReleaseBulkAction} from './ReleaseBulkActionDialog'
+import {type ReleaseInspector} from './ReleaseDetail'
 import {type DocumentFilterType, documentMatchesFilter} from './releaseDocumentActions'
 import {type DocumentInRelease} from './types'
 
@@ -32,6 +53,9 @@ export interface ReleaseSummaryProps {
   documents: DocumentInRelease[]
   release: ReleaseDocument
   isLoading?: boolean
+  /** Activity inspector state, so the command lane can host the Activity toggle (beta.variants). */
+  inspector?: ReleaseInspector
+  setInspector?: Dispatch<SetStateAction<ReleaseInspector | undefined>>
 }
 
 const FULL_HEIGHT_STYLE: CSSProperties = {height: '100%'}
@@ -54,7 +78,7 @@ const isBundleDocumentRow = (
   'validation' in maybeBundleDocumentRow
 
 export function ReleaseSummary(props: ReleaseSummaryProps) {
-  const {documents, isLoading = false, release} = props
+  const {documents, isLoading = false, release, inspector, setInspector} = props
   const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(null)
   const toast = useToast()
   const {createVersion} = useReleaseOperations()
@@ -63,8 +87,24 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
   const [openAddDocumentDialog, setAddDocumentDialog] = useState(false)
   const [pendingAddedDocument, setPendingAddedDocument] = useState<BundleDocumentRow[]>([])
   const [activeFilter, setActiveFilter] = useState<DocumentFilterType>('all')
+  // A pending bulk action (Discard / Unpublish): the selected row keys + the table's clear callback,
+  // resolved into documents and confirmed via ReleaseBulkActionDialog.
+  const [bulkAction, setBulkAction] = useState<{
+    action: ReleaseBulkAction
+    keys: readonly string[]
+    clear: () => void
+  } | null>(null)
 
   const {t} = useTranslation(releasesLocaleNamespace)
+
+  // Behind beta.variants: adopt the shared three-zone DocumentTable (command-lane search + filter
+  // tabs). Otherwise keep the current table (search in the column header). No user-facing change to
+  // production Releases until the flag is on.
+  const {beta} = useWorkspace()
+  const variantsEnabled = Boolean(beta?.variants?.enabled)
+  // Resolves each document's variant (via `_system.variant._ref`) to its definition for the
+  // "Variant" column. Provider-free + cached; returns empty when variants are disabled.
+  const {byId: variantsById} = useAllVariants()
 
   const releaseId = getReleaseIdFromReleaseDocumentId(release._id)
 
@@ -80,11 +120,20 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
   )
 
   const documentTableColumnDefs = useMemo(
-    () => getDocumentTableColumnDefs(release._id, release.state, t),
-    [release._id, release.state, t],
+    () =>
+      getDocumentTableColumnDefs(release._id, release.state, t, {
+        searchInCommandLane: variantsEnabled,
+        variantsById: variantsEnabled ? variantsById : undefined,
+      }),
+    [release._id, release.state, t, variantsEnabled, variantsById],
   )
 
   const handleAddDocumentClick = useCallback(() => setAddDocumentDialog(true), [])
+
+  const handleActivityClick = useCallback(
+    () => setInspector?.((prev) => (prev === 'activity' ? undefined : 'activity')),
+    [setInspector],
+  )
 
   const filterRows = useCallback(
     (data: DocumentInRelease[], searchTerm: string) => {
@@ -172,6 +221,97 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
     [documents, pendingAddedDocument],
   )
 
+  // In the DocumentTable (variants-enabled) shape, free-text search is owned by the table; the
+  // caller pre-filters by the active tab and passes those rows in.
+  const filterTabRows = useMemo(
+    () => tableData.filter((doc) => documentMatchesFilter(doc, activeFilter)),
+    [tableData, activeFilter],
+  )
+
+  // Resolve the pending bulk action's selected row keys back to their documents (from the visible,
+  // tab-filtered rows) for the confirmation dialog.
+  const selectedDocuments = useMemo(() => {
+    if (!bulkAction) return []
+    const byId = new Map(filterTabRows.map((row) => [row.document._id, row]))
+    return bulkAction.keys
+      .map((key) => byId.get(key))
+      .filter((row): row is DocumentInReleaseDetail => Boolean(row))
+  }, [bulkAction, filterTabRows])
+
+  // Multi-select is only meaningful on an active release (matching the per-row actions, which are
+  // hidden otherwise). Discard + Unpublish mirror the per-row menu, applied to the whole selection.
+  const isActiveRelease = release.state === 'active'
+  const selection = useMemo<DocumentTableSelection | undefined>(() => {
+    if (!isActiveRelease) return undefined
+    return {
+      labels: {
+        selectAll: t('dashboard.details.bulk.select-all'),
+        selectRow: t('dashboard.details.bulk.select-row'),
+        selectedCount: (count) => t('dashboard.details.bulk.selected', {count}),
+        clear: t('dashboard.details.bulk.clear'),
+      },
+      selectAllTestId: 'release-bulk-select-all',
+      renderActions: ({selectedKeys, compact, clear}) => {
+        const discard = () => setBulkAction({action: 'discard', keys: selectedKeys, clear})
+        const unpublish = () => setBulkAction({action: 'unpublish', keys: selectedKeys, clear})
+
+        if (compact) {
+          return (
+            <MenuButton
+              id="release-bulk-more"
+              button={
+                <Button
+                  data-testid="release-bulk-more"
+                  icon={EllipsisHorizontalIcon}
+                  mode="bleed"
+                  tooltipProps={{content: t('dashboard.details.bulk.more')}}
+                />
+              }
+              menu={
+                <Menu>
+                  <MenuItem
+                    data-testid="release-bulk-discard"
+                    icon={CloseIcon}
+                    onClick={discard}
+                    text={t('dashboard.details.bulk.discard')}
+                    tone="critical"
+                  />
+                  <MenuItem
+                    data-testid="release-bulk-unpublish"
+                    icon={UnpublishIcon}
+                    onClick={unpublish}
+                    text={t('dashboard.details.bulk.unpublish')}
+                  />
+                </Menu>
+              }
+              popover={{placement: 'bottom-end', portal: true}}
+            />
+          )
+        }
+
+        return (
+          <Flex align="center" flex="none" gap={2}>
+            <Button
+              data-testid="release-bulk-discard"
+              icon={CloseIcon}
+              mode="ghost"
+              onClick={discard}
+              text={t('dashboard.details.bulk.discard')}
+              tone="critical"
+            />
+            <Button
+              data-testid="release-bulk-unpublish"
+              icon={UnpublishIcon}
+              mode="ghost"
+              onClick={unpublish}
+              text={t('dashboard.details.bulk.unpublish')}
+            />
+          </Flex>
+        )
+      },
+    }
+  }, [isActiveRelease, t])
+
   const isCardinalityOne = isCardinalityOneRelease(release)
   const hasNoDocuments = !isLoading && documents.length === 0
 
@@ -197,49 +337,114 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
     )
   }
 
+  // Old (non-variant) path: Add-document lives at the end of the list.
+  const addDocumentFooter = release.state === 'active' && (
+    <Container width={3}>
+      <Card padding={3}>
+        <Button
+          icon={AddIcon}
+          disabled={isLoading}
+          mode="bleed"
+          onClick={handleAddDocumentClick}
+          text={t('action.add-document')}
+        />
+      </Card>
+    </Container>
+  )
+
+  // New (DocumentTable) path: one action lane. Activity + Share (icons) sit alongside Add document
+  // (the labeled primary), so every "do something" control lives together at the right of the lane
+  // instead of being scattered into the header.
+  const addDocumentButton = release.state === 'active' && (
+    <Button
+      disabled={isLoading}
+      icon={AddIcon}
+      mode="ghost"
+      onClick={handleAddDocumentClick}
+      text={t('action.add-document')}
+    />
+  )
+  const commandLaneActions = (
+    <Flex align="center" gap={2}>
+      {setInspector && (
+        <Button
+          data-testid="activity-button"
+          icon={RestoreIcon}
+          mode="bleed"
+          onClick={handleActivityClick}
+          selected={inspector === 'activity'}
+          tooltipProps={{content: t('dashboard.details.activity')}}
+        />
+      )}
+      <CopyReleaseActions release={release} icon={CopyIcon} />
+      {addDocumentButton}
+    </Flex>
+  )
+
   return (
     <Flex direction="column" style={FULL_HEIGHT_STYLE}>
-      <ReleaseDocumentFilterTabs
-        documents={tableData}
-        releaseState={release.state}
-        isLoading={isLoading}
-        activeFilter={activeFilter}
-        onFilterChange={setActiveFilter}
-      />
-      <Card
-        ref={setScrollContainerRef}
-        data-testid="document-table-card"
-        flex={1}
-        borderTop
-        style={SCROLL_CONTAINER_STYLE}
-      >
-        <div style={FIT_CONTENT_STYLE}>
-          <Table<DocumentInReleaseDetail>
-            loading={isLoading}
-            data={tableData}
-            emptyState={t('summary.no-documents')}
-            // oxlint-disable-next-line @sanity/i18n/no-attribute-string-literals
-            rowId="document._id"
-            columnDefs={documentTableColumnDefs}
-            rowActions={renderRowActions}
-            searchFilter={filterRows}
-            scrollContainerRef={scrollContainerRef}
-            defaultSort={{column: 'search', direction: 'asc'}}
-          />
-        </div>
-      </Card>
-      {release.state === 'active' && (
-        <Container width={3}>
-          <Card padding={3}>
-            <Button
-              icon={AddIcon}
-              disabled={isLoading}
-              mode="bleed"
-              onClick={handleAddDocumentClick}
-              text={t('action.add-document')}
+      {variantsEnabled ? (
+        <DocumentTable<DocumentInReleaseDetail>
+          columnDefs={documentTableColumnDefs}
+          defaultSort={{column: 'search', direction: 'asc'}}
+          emptyState={t('summary.no-documents')}
+          commandLaneActions={commandLaneActions}
+          filterTabs={
+            <ReleaseDocumentFilterTabs
+              activeFilter={activeFilter}
+              documents={tableData}
+              inline
+              isLoading={isLoading}
+              onFilterChange={setActiveFilter}
+              releaseState={release.state}
             />
+          }
+          getRowKey={(row) => row.document._id}
+          id="document-table-card"
+          loading={isLoading}
+          rowActions={renderRowActions}
+          rows={filterTabRows}
+          // oxlint-disable-next-line @sanity/i18n/no-attribute-string-literals
+          rowId="document._id"
+          searchPlaceholder={t('search-documents-placeholder')}
+          searchPredicate={(row, searchTerm) => searchDocumentRelease(row.document, searchTerm)}
+          searchTestId="release-documents-search"
+          searchWidth={260}
+          selection={selection}
+        />
+      ) : (
+        <>
+          <ReleaseDocumentFilterTabs
+            documents={tableData}
+            releaseState={release.state}
+            isLoading={isLoading}
+            activeFilter={activeFilter}
+            onFilterChange={setActiveFilter}
+          />
+          <Card
+            ref={setScrollContainerRef}
+            data-testid="document-table-card"
+            flex={1}
+            borderTop
+            style={SCROLL_CONTAINER_STYLE}
+          >
+            <div style={FIT_CONTENT_STYLE}>
+              <Table<DocumentInReleaseDetail>
+                loading={isLoading}
+                data={tableData}
+                emptyState={t('summary.no-documents')}
+                // oxlint-disable-next-line @sanity/i18n/no-attribute-string-literals
+                rowId="document._id"
+                columnDefs={documentTableColumnDefs}
+                rowActions={renderRowActions}
+                searchFilter={filterRows}
+                scrollContainerRef={scrollContainerRef}
+                defaultSort={{column: 'search', direction: 'asc'}}
+              />
+            </div>
           </Card>
-        </Container>
+          {addDocumentFooter}
+        </>
       )}
       <AddDocumentSearch
         open={openAddDocumentDialog}
@@ -247,6 +452,15 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
         releaseId={releaseId}
         idsInRelease={documents.map(({document}) => document._id)}
       />
+      {bulkAction && selectedDocuments.length > 0 && (
+        <ReleaseBulkActionDialog
+          action={bulkAction.action}
+          documents={selectedDocuments}
+          releaseId={releaseId}
+          onClose={() => setBulkAction(null)}
+          onSuccess={bulkAction.clear}
+        />
+      )}
     </Flex>
   )
 }

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -1,12 +1,9 @@
 import {type ReleaseDocument, type SanityDocument} from '@sanity/client'
 import {AddIcon} from '@sanity/icons/Add'
-import {CloseIcon} from '@sanity/icons/Close'
 import {CopyIcon} from '@sanity/icons/Copy'
-import {EllipsisHorizontalIcon} from '@sanity/icons/EllipsisHorizontal'
 import {RestoreIcon} from '@sanity/icons/Restore'
-import {UnpublishIcon} from '@sanity/icons/Unpublish'
 import {useTelemetry} from '@sanity/telemetry/react'
-import {Card, Container, Flex, Menu, Stack, Text, useToast} from '@sanity/ui'
+import {Card, Container, Flex, Stack, Text, useToast} from '@sanity/ui'
 import {
   type CSSProperties,
   type Dispatch,
@@ -18,8 +15,6 @@ import {
 } from 'react'
 
 import {Button} from '../../../../ui-components/button/Button'
-import {MenuButton} from '../../../../ui-components/menuButton/MenuButton'
-import {MenuItem} from '../../../../ui-components/menuItem/MenuItem'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {useWorkspace} from '../../../studio/workspace'
 import {getVersionId} from '../../../util/draftUtils'
@@ -39,6 +34,7 @@ import {DocumentActions} from './documentTable/DocumentActions'
 import {getDocumentTableColumnDefs} from './documentTable/DocumentTableColumnDefs'
 import {searchDocumentRelease} from './documentTable/searchDocumentRelease'
 import {ReleaseBulkActionDialog, type ReleaseBulkAction} from './ReleaseBulkActionDialog'
+import {ReleaseBulkSelectionActions} from './ReleaseBulkSelectionActions'
 import {type ReleaseInspector} from './ReleaseDetail'
 import {
   type DocumentFilterType,
@@ -263,71 +259,15 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
         clear: t('dashboard.details.bulk.clear'),
       },
       selectAllTestId: 'release-bulk-select-all',
-      renderActions: ({selectedKeys, compact, clear}) => {
-        const discard = () => setBulkAction({action: 'discard', keys: selectedKeys, clear})
-        const unpublish = () => setBulkAction({action: 'unpublish', keys: selectedKeys, clear})
-        const byId = new Map(filterTabRows.map((row) => [row.document._id, row]))
-        const selectedRows = selectedKeys
-          .map((key) => byId.get(key))
-          .filter((row): row is DocumentInReleaseDetail => Boolean(row))
-        const canUnpublishSelection = selectedRows.some(isDocumentEligibleForUnpublish)
-
-        if (compact) {
-          return (
-            <MenuButton
-              id="release-bulk-more"
-              button={
-                <Button
-                  data-testid="release-bulk-more"
-                  icon={EllipsisHorizontalIcon}
-                  mode="bleed"
-                  tooltipProps={{content: t('dashboard.details.bulk.more')}}
-                />
-              }
-              menu={
-                <Menu>
-                  <MenuItem
-                    data-testid="release-bulk-discard"
-                    icon={CloseIcon}
-                    onClick={discard}
-                    text={t('dashboard.details.bulk.discard')}
-                    tone="critical"
-                  />
-                  <MenuItem
-                    data-testid="release-bulk-unpublish"
-                    disabled={!canUnpublishSelection}
-                    icon={UnpublishIcon}
-                    onClick={unpublish}
-                    text={t('dashboard.details.bulk.unpublish')}
-                  />
-                </Menu>
-              }
-              popover={{placement: 'bottom-end', portal: true}}
-            />
-          )
-        }
-
-        return (
-          <Flex align="center" flex="none" gap={2}>
-            <Button
-              data-testid="release-bulk-discard"
-              icon={CloseIcon}
-              mode="ghost"
-              onClick={discard}
-              text={t('dashboard.details.bulk.discard')}
-              tone="critical"
-            />
-            <Button
-              data-testid="release-bulk-unpublish"
-              disabled={!canUnpublishSelection}
-              icon={UnpublishIcon}
-              mode="ghost"
-              onClick={unpublish}
-              text={t('dashboard.details.bulk.unpublish')}
-            />
-          </Flex>
-        )
-      },
+      renderActions: ({selectedKeys, compact, clear}) => (
+        <ReleaseBulkSelectionActions
+          compact={compact}
+          filterTabRows={filterTabRows}
+          onDiscard={() => setBulkAction({action: 'discard', keys: selectedKeys, clear})}
+          onUnpublish={() => setBulkAction({action: 'unpublish', keys: selectedKeys, clear})}
+          selectedKeys={selectedKeys}
+        />
+      ),
     }
   }, [isActiveRelease, t, filterTabRows])
 

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -40,7 +40,11 @@ import {getDocumentTableColumnDefs} from './documentTable/DocumentTableColumnDef
 import {searchDocumentRelease} from './documentTable/searchDocumentRelease'
 import {ReleaseBulkActionDialog, type ReleaseBulkAction} from './ReleaseBulkActionDialog'
 import {type ReleaseInspector} from './ReleaseDetail'
-import {type DocumentFilterType, documentMatchesFilter} from './releaseDocumentActions'
+import {
+  type DocumentFilterType,
+  documentMatchesFilter,
+  isDocumentEligibleForUnpublish,
+} from './releaseDocumentActions'
 import {type DocumentInRelease} from './types'
 
 export type DocumentInReleaseDetail = DocumentInRelease & {
@@ -238,6 +242,14 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
       .filter((row): row is DocumentInReleaseDetail => Boolean(row))
   }, [bulkAction, filterTabRows])
 
+  const bulkActionDocuments = useMemo(() => {
+    if (!bulkAction) return []
+    if (bulkAction.action === 'unpublish') {
+      return selectedDocuments.filter(isDocumentEligibleForUnpublish)
+    }
+    return selectedDocuments
+  }, [bulkAction, selectedDocuments])
+
   // Multi-select is only meaningful on an active release (matching the per-row actions, which are
   // hidden otherwise). Discard + Unpublish mirror the per-row menu, applied to the whole selection.
   const isActiveRelease = release.state === 'active'
@@ -254,6 +266,11 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
       renderActions: ({selectedKeys, compact, clear}) => {
         const discard = () => setBulkAction({action: 'discard', keys: selectedKeys, clear})
         const unpublish = () => setBulkAction({action: 'unpublish', keys: selectedKeys, clear})
+        const byId = new Map(filterTabRows.map((row) => [row.document._id, row]))
+        const selectedRows = selectedKeys
+          .map((key) => byId.get(key))
+          .filter((row): row is DocumentInReleaseDetail => Boolean(row))
+        const canUnpublishSelection = selectedRows.some(isDocumentEligibleForUnpublish)
 
         if (compact) {
           return (
@@ -278,6 +295,7 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
                   />
                   <MenuItem
                     data-testid="release-bulk-unpublish"
+                    disabled={!canUnpublishSelection}
                     icon={UnpublishIcon}
                     onClick={unpublish}
                     text={t('dashboard.details.bulk.unpublish')}
@@ -301,6 +319,7 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
             />
             <Button
               data-testid="release-bulk-unpublish"
+              disabled={!canUnpublishSelection}
               icon={UnpublishIcon}
               mode="ghost"
               onClick={unpublish}
@@ -310,7 +329,7 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
         )
       },
     }
-  }, [isActiveRelease, t])
+  }, [isActiveRelease, t, filterTabRows])
 
   const isCardinalityOne = isCardinalityOneRelease(release)
   const hasNoDocuments = !isLoading && documents.length === 0
@@ -453,10 +472,10 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
         releaseId={releaseId}
         idsInRelease={documents.map(({document}) => document._id)}
       />
-      {bulkAction && selectedDocuments.length > 0 && (
+      {bulkAction && bulkActionDocuments.length > 0 && (
         <ReleaseBulkActionDialog
           action={bulkAction.action}
-          documents={selectedDocuments}
+          documents={bulkActionDocuments}
           releaseId={releaseId}
           onClose={() => setBulkAction(null)}
           onSuccess={bulkAction.clear}

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseTypePicker.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseTypePicker.tsx
@@ -1,11 +1,13 @@
 import {type ReleaseType} from '@sanity/client'
-import {Card, Stack, TabList, Text, useClickOutsideEvent, useToast} from '@sanity/ui'
+import {PublishIcon} from '@sanity/icons/Publish'
+import {Card, Flex, Spinner, Stack, TabList, Text, useClickOutsideEvent, useToast} from '@sanity/ui'
 import {isBefore} from 'date-fns/isBefore'
 import {startOfMinute} from 'date-fns/startOfMinute'
 import isEqual from 'lodash-es/isEqual.js'
 import {useCallback, useMemo, useRef, useState} from 'react'
 import {styled} from 'styled-components'
 
+import {Button} from '../../../../ui-components/button/Button'
 import {Popover} from '../../../../ui-components/popover/Popover'
 import {Tab} from '../../../../ui-components/tab/Tab'
 import {MONTH_PICKER_VARIANT} from '../../../components/inputs/DateInputs/calendar/Calendar'
@@ -14,6 +16,8 @@ import {DatePicker} from '../../../components/inputs/DateInputs/DatePicker'
 import {getCalendarLabels} from '../../../form/inputs/DateInputs/utils'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {CONTENT_RELEASES_TIME_ZONE_SCOPE} from '../../../studio/constants'
+import {useWorkspace} from '../../../studio/workspace'
+import {ReleaseAvatar} from '../../components/ReleaseAvatar'
 import {useReleaseTime} from '../../hooks/useReleaseTime'
 import {releasesLocaleNamespace} from '../../i18n'
 import {useReleaseOperations} from '../../store/useReleaseOperations'
@@ -24,6 +28,7 @@ import {
   isReleaseScheduledOrScheduling,
   type NotArchivedRelease,
 } from '../../util/util'
+import {ReleaseTime} from '../components/ReleaseTime'
 import {ReleaseDateInput} from './ReleaseDateInput'
 
 // The Schedule value reads as plain text (matching the other property values), but stays clickable
@@ -49,6 +54,7 @@ const ScheduleTrigger = styled.button`
 
 export function ReleaseTypePicker(props: {release: NotArchivedRelease}): React.JSX.Element {
   const {release} = props
+  const variantsEnabled = Boolean(useWorkspace().beta?.variants?.enabled)
   const popoverRef = useRef<HTMLDivElement | null>(null)
   const buttonRef = useRef<HTMLButtonElement | null>(null)
   const inputRef = useRef<HTMLInputElement | null>(null)
@@ -134,9 +140,22 @@ export function ReleaseTypePicker(props: {release: NotArchivedRelease}): React.J
   const isPublishDateInPast = !!publishDate && isBefore(new Date(publishDate), new Date())
   const isReleaseScheduled = isReleaseScheduledOrScheduling(release)
 
+  const publishDateLabel = useMemo(() => {
+    if (release.state === 'published') {
+      if (isPublishDateInPast && publishDate)
+        return tRelease('dashboard.details.published-on', {
+          date: getReleaseTime(release),
+        })
+
+      return tRelease('dashboard.details.published-asap')
+    }
+
+    return <ReleaseTime release={release} />
+  }, [getReleaseTime, isPublishDateInPast, publishDate, release, tRelease])
+
   // A compact, single-line label for the properties-panel value: no seconds, and no
   // "Estimated ·"/"Scheduled ·" prefix (the row's leading glyph + label already convey the type).
-  const label = useMemo(() => {
+  const compactLabel = useMemo(() => {
     if (release.state === 'published') {
       return isPublishDateInPast && publishDate
         ? tRelease('dashboard.details.published-on', {
@@ -177,74 +196,133 @@ export function ReleaseTypePicker(props: {release: NotArchivedRelease}): React.J
 
   const tone = release.state === 'published' ? 'positive' : getReleaseTone(release)
 
+  const releaseTypeIcon = useMemo(() => {
+    if (isUpdating) return <Spinner size={1} data-testid="updating-release-spinner" />
+    if (release.state === 'published') return <PublishIcon />
+
+    return <ReleaseAvatar release={release} padding={0} />
+  }, [isUpdating, release])
+
+  const productionLabelContent = useMemo(
+    () => (
+      <Flex flex={1} gap={2} align={'center'}>
+        {releaseTypeIcon}
+        <span data-testid="release-type-label">{publishDateLabel}</span>
+      </Flex>
+    ),
+    [publishDateLabel, releaseTypeIcon],
+  )
+
+  const popoverContent = (
+    <Stack space={1}>
+      <TabList space={0.5}>
+        <Tab
+          aria-controls="release-timing-asap"
+          id="release-timing-asap-tab"
+          onClick={() => handleButtonReleaseTypeChange('asap')}
+          label={t('release.type.asap')}
+          selected={releaseType === 'asap'}
+        />
+        <Tab
+          aria-controls="release-timing-at-time"
+          id="release-timing-at-time-tab"
+          onClick={() => handleButtonReleaseTypeChange('scheduled')}
+          selected={releaseType === 'scheduled'}
+          label={t('release.type.scheduled')}
+        />
+        <Tab
+          aria-controls="release-timing-undecided"
+          id="release-timing-undecided-tab"
+          onClick={() => handleButtonReleaseTypeChange('undecided')}
+          selected={releaseType === 'undecided'}
+          label={t('release.type.undecided')}
+        />
+      </TabList>
+      {releaseType === 'scheduled' && (
+        <>
+          {isIntendedScheduleDateInPast && (
+            <Card margin={1} padding={2} radius={2} shadow={1} tone="critical">
+              <Text size={1}>{t('release.schedule-dialog.publish-date-in-past-warning')}</Text>
+            </Card>
+          )}
+          <ReleaseDateInput
+            setIsIntendedScheduleDateInPast={setIsIntendedScheduleDateInPast}
+            setIntendedPublishAt={setIntendedPublishAt}
+            intendedPublishAt={intendedPublishAt}
+          />
+          <DatePicker
+            ref={datePickerRef}
+            monthPickerVariant={MONTH_PICKER_VARIANT.carousel}
+            calendarLabels={calendarLabels}
+            selectTime
+            padding={0}
+            value={intendedPublishAt}
+            onChange={handlePublishAtCalendarChange}
+            isPastDisabled
+            showTimeZone
+            timeZoneScope={CONTENT_RELEASES_TIME_ZONE_SCOPE}
+          />
+        </>
+      )}
+    </Stack>
+  )
+
+  if (!variantsEnabled) {
+    return (
+      <Popover
+        content={popoverContent}
+        open={open}
+        padding={1}
+        placement="bottom-start"
+        ref={popoverRef}
+      >
+        {release.state === 'published' ? (
+          <Card
+            tone="default"
+            data-testid="published-release-type-label"
+            padding={2}
+            style={{borderRadius: '999px'}}
+          >
+            {productionLabelContent}
+          </Card>
+        ) : (
+          <Button
+            disabled={isReleaseScheduled}
+            mode="bleed"
+            onClick={handleOnPickerClick}
+            ref={buttonRef}
+            tooltipProps={{
+              placement: 'bottom',
+              content: isReleaseScheduled && tRelease('type-picker.tooltip.scheduled'),
+            }}
+            selected={open}
+            tone={tone}
+            style={{borderRadius: '999px'}}
+            data-testid="release-type-picker"
+          >
+            {productionLabelContent}
+          </Button>
+        )}
+      </Popover>
+    )
+  }
+
   const valueText = (
     <Text
       data-testid="release-type-label"
       size={1}
       weight="medium"
       textOverflow="ellipsis"
-      title={label}
+      title={compactLabel}
       style={{opacity: isUpdating ? 0.5 : 1}}
     >
-      {label}
+      {compactLabel}
     </Text>
   )
 
   return (
     <Popover
-      content={
-        <Stack space={1}>
-          <TabList space={0.5}>
-            <Tab
-              aria-controls="release-timing-asap"
-              id="release-timing-asap-tab"
-              onClick={() => handleButtonReleaseTypeChange('asap')}
-              label={t('release.type.asap')}
-              selected={releaseType === 'asap'}
-            />
-            <Tab
-              aria-controls="release-timing-at-time"
-              id="release-timing-at-time-tab"
-              onClick={() => handleButtonReleaseTypeChange('scheduled')}
-              selected={releaseType === 'scheduled'}
-              label={t('release.type.scheduled')}
-            />
-            <Tab
-              aria-controls="release-timing-undecided"
-              id="release-timing-undecided-tab"
-              onClick={() => handleButtonReleaseTypeChange('undecided')}
-              selected={releaseType === 'undecided'}
-              label={t('release.type.undecided')}
-            />
-          </TabList>
-          {releaseType === 'scheduled' && (
-            <>
-              {isIntendedScheduleDateInPast && (
-                <Card margin={1} padding={2} radius={2} shadow={1} tone="critical">
-                  <Text size={1}>{t('release.schedule-dialog.publish-date-in-past-warning')}</Text>
-                </Card>
-              )}
-              <ReleaseDateInput
-                setIsIntendedScheduleDateInPast={setIsIntendedScheduleDateInPast}
-                setIntendedPublishAt={setIntendedPublishAt}
-                intendedPublishAt={intendedPublishAt}
-              />
-              <DatePicker
-                ref={datePickerRef}
-                monthPickerVariant={MONTH_PICKER_VARIANT.carousel}
-                calendarLabels={calendarLabels}
-                selectTime
-                padding={0}
-                value={intendedPublishAt}
-                onChange={handlePublishAtCalendarChange}
-                isPastDisabled
-                showTimeZone
-                timeZoneScope={CONTENT_RELEASES_TIME_ZONE_SCOPE}
-              />
-            </>
-          )}
-        </Stack>
-      }
+      content={popoverContent}
       open={open}
       padding={1}
       placement="bottom-start"

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseTypePicker.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseTypePicker.tsx
@@ -1,12 +1,11 @@
 import {type ReleaseType} from '@sanity/client'
-import {PublishIcon} from '@sanity/icons/Publish'
-import {Card, Flex, Spinner, Stack, TabList, Text, useClickOutsideEvent, useToast} from '@sanity/ui'
+import {Card, Stack, TabList, Text, useClickOutsideEvent, useToast} from '@sanity/ui'
 import {isBefore} from 'date-fns/isBefore'
 import {startOfMinute} from 'date-fns/startOfMinute'
 import isEqual from 'lodash-es/isEqual.js'
 import {useCallback, useMemo, useRef, useState} from 'react'
+import {styled} from 'styled-components'
 
-import {Button} from '../../../../ui-components/button/Button'
 import {Popover} from '../../../../ui-components/popover/Popover'
 import {Tab} from '../../../../ui-components/tab/Tab'
 import {MONTH_PICKER_VARIANT} from '../../../components/inputs/DateInputs/calendar/Calendar'
@@ -15,7 +14,6 @@ import {DatePicker} from '../../../components/inputs/DateInputs/DatePicker'
 import {getCalendarLabels} from '../../../form/inputs/DateInputs/utils'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {CONTENT_RELEASES_TIME_ZONE_SCOPE} from '../../../studio/constants'
-import {ReleaseAvatar} from '../../components/ReleaseAvatar'
 import {useReleaseTime} from '../../hooks/useReleaseTime'
 import {releasesLocaleNamespace} from '../../i18n'
 import {useReleaseOperations} from '../../store/useReleaseOperations'
@@ -26,8 +24,28 @@ import {
   isReleaseScheduledOrScheduling,
   type NotArchivedRelease,
 } from '../../util/util'
-import {ReleaseTime} from '../components/ReleaseTime'
 import {ReleaseDateInput} from './ReleaseDateInput'
+
+// The Schedule value reads as plain text (matching the other property values), but stays clickable
+// to open the picker: a flush, chrome-free button that only underlines on hover — no pill, and its
+// text sits on the same left edge as every other value.
+const ScheduleTrigger = styled.button`
+  appearance: none;
+  background: none;
+  border: 0;
+  margin: 0;
+  padding: 0;
+  display: block;
+  width: 100%;
+  min-width: 0;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  &:hover {
+    text-decoration: underline;
+  }
+`
 
 export function ReleaseTypePicker(props: {release: NotArchivedRelease}): React.JSX.Element {
   const {release} = props
@@ -116,18 +134,20 @@ export function ReleaseTypePicker(props: {release: NotArchivedRelease}): React.J
   const isPublishDateInPast = !!publishDate && isBefore(new Date(publishDate), new Date())
   const isReleaseScheduled = isReleaseScheduledOrScheduling(release)
 
-  const publishDateLabel = useMemo(() => {
+  // A compact, single-line label for the properties-panel value: no seconds, and no
+  // "Estimated ·"/"Scheduled ·" prefix (the row's leading glyph + label already convey the type).
+  const label = useMemo(() => {
     if (release.state === 'published') {
-      if (isPublishDateInPast && publishDate)
-        return tRelease('dashboard.details.published-on', {
-          date: getReleaseTime(release),
-        })
-
-      return tRelease('dashboard.details.published-asap')
+      return isPublishDateInPast && publishDate
+        ? tRelease('dashboard.details.published-on', {
+            date: getReleaseTime(release, {compact: true}),
+          })
+        : tRelease('dashboard.details.published-asap')
     }
-
-    return <ReleaseTime release={release} />
-  }, [getReleaseTime, isPublishDateInPast, publishDate, release, tRelease])
+    if (release.metadata.releaseType === 'asap') return t('release.type.asap')
+    if (release.metadata.releaseType === 'undecided') return t('release.type.undecided')
+    return getReleaseTime(release, {compact: true}) ?? t('release.type.scheduled')
+  }, [getReleaseTime, isPublishDateInPast, publishDate, release, t, tRelease])
 
   const handleButtonReleaseTypeChange = useCallback(
     (pickedReleaseType: ReleaseType) => {
@@ -157,21 +177,17 @@ export function ReleaseTypePicker(props: {release: NotArchivedRelease}): React.J
 
   const tone = release.state === 'published' ? 'positive' : getReleaseTone(release)
 
-  const releaseTypeIcon = useMemo(() => {
-    if (isUpdating) return <Spinner size={1} data-testid="updating-release-spinner" />
-    if (release.state === 'published') return <PublishIcon />
-
-    return <ReleaseAvatar release={release} padding={0} />
-  }, [isUpdating, release])
-
-  const labelContent = useMemo(
-    () => (
-      <Flex flex={1} gap={2} align={'center'}>
-        {releaseTypeIcon}
-        <span data-testid="release-type-label">{publishDateLabel}</span>
-      </Flex>
-    ),
-    [publishDateLabel, releaseTypeIcon],
+  const valueText = (
+    <Text
+      data-testid="release-type-label"
+      size={1}
+      weight="medium"
+      textOverflow="ellipsis"
+      title={label}
+      style={{opacity: isUpdating ? 0.5 : 1}}
+    >
+      {label}
+    </Text>
   )
 
   return (
@@ -234,32 +250,30 @@ export function ReleaseTypePicker(props: {release: NotArchivedRelease}): React.J
       placement="bottom-start"
       ref={popoverRef}
     >
-      {release.state === 'published' ? (
+      {/* The tone-scoped Card (transparent bg) colours the value text; no filled pill. When the
+          schedule is editable it's a flush, chrome-free clickable trigger; when locked/published
+          it's static text. Either way it reads as plain text aligned with the other values. */}
+      {release.state === 'published' || isReleaseScheduled ? (
         <Card
-          tone="default"
-          data-testid="published-release-type-label"
-          padding={2}
-          style={{borderRadius: '999px'}}
+          tone={tone}
+          padding={0}
+          style={{background: 'transparent'}}
+          data-testid={
+            release.state === 'published' ? 'published-release-type-label' : 'release-type-picker'
+          }
         >
-          {labelContent}
+          {valueText}
         </Card>
       ) : (
-        <Button
-          disabled={isReleaseScheduled}
-          mode="bleed"
-          onClick={handleOnPickerClick}
-          ref={buttonRef}
-          tooltipProps={{
-            placement: 'bottom',
-            content: isReleaseScheduled && tRelease('type-picker.tooltip.scheduled'),
-          }}
-          selected={open}
-          tone={tone}
-          style={{borderRadius: '999px'}}
-          data-testid="release-type-picker"
-        >
-          {labelContent}
-        </Button>
+        <Card tone={tone} padding={0} style={{background: 'transparent'}}>
+          <ScheduleTrigger
+            ref={buttonRef}
+            onClick={handleOnPickerClick}
+            data-testid="release-type-picker"
+          >
+            {valueText}
+          </ScheduleTrigger>
+        </Card>
       )}
     </Popover>
   )

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseValidationBadge.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseValidationBadge.tsx
@@ -1,0 +1,57 @@
+import {Card, Text} from '@sanity/ui'
+
+import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {releasesLocaleNamespace} from '../../i18n'
+import {getDocumentValidationLoading} from '../../util/getDocumentValidationLoading'
+import {type DocumentInRelease} from './types'
+
+// Transparent background so the tone only colours the text (green/red), not a filled chip — the
+// properties block uses one value idiom (semantic-coloured text), not a mix of pills and badges.
+const TRANSPARENT_BG = {background: 'transparent'} as const
+
+/**
+ * The persistent validation status shown in the release properties panel, as semantic-coloured
+ * text: green "Valid" when every document validates, red "Errors" when any fail, plain "Validating"
+ * while in progress, and muted "No documents" when the release is empty. Unlike the shared
+ * ValidationProgressIndicator (whose green fades to a bare checkmark after a beat), this holds its
+ * state so the panel can clearly signal whether the release is good to go — and it reads as text,
+ * matching the other property values rather than sitting in a box.
+ *
+ * @internal
+ */
+export function ReleaseValidationBadge({
+  documents,
+}: {
+  documents: DocumentInRelease[]
+}): React.JSX.Element {
+  const {t} = useTranslation(releasesLocaleNamespace)
+  const totalCount = documents.length
+
+  if (totalCount === 0) {
+    return (
+      <Text muted size={1}>
+        {t('dashboard.details.metadata.status-empty')}
+      </Text>
+    )
+  }
+
+  const {hasError, validatedCount} = getDocumentValidationLoading(documents)
+  const isValidating = validatedCount !== totalCount
+
+  const tone = hasError ? 'critical' : isValidating ? 'default' : 'positive'
+  const label = hasError
+    ? t('dashboard.details.metadata.status-errors')
+    : isValidating
+      ? t('dashboard.details.metadata.status-validating')
+      : t('dashboard.details.metadata.status-valid')
+
+  // A tone-scoped Card sets the foreground colour var; with a transparent background the Text simply
+  // renders in the tone colour (green/red), no filled chip.
+  return (
+    <Card tone={tone} style={TRANSPARENT_BG}>
+      <Text size={1} weight="medium">
+        {label}
+      </Text>
+    </Card>
+  )
+}

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseBulkActionDialog.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseBulkActionDialog.test.tsx
@@ -11,6 +11,9 @@ const mockUnpublishVersion = vi.fn().mockResolvedValue({})
 const mockDiscardVersion = vi.fn().mockResolvedValue({})
 const mockGetDocumentPairPermissions = vi.fn()
 const mockToastPush = vi.fn()
+const mockClient = {}
+const mockSchema = {}
+const mockGrantsStore = {}
 
 vi.mock('../../../hooks/useVersionOperations', () => ({
   useVersionOperations: vi.fn(() => ({
@@ -24,15 +27,15 @@ vi.mock('../../../../store/grants/documentPairPermissions', () => ({
 }))
 
 vi.mock('../../../../hooks/useClient', () => ({
-  useClient: vi.fn(() => ({})),
+  useClient: vi.fn(() => mockClient),
 }))
 
 vi.mock('../../../../hooks/useSchema', () => ({
-  useSchema: vi.fn(() => ({})),
+  useSchema: vi.fn(() => mockSchema),
 }))
 
 vi.mock('../../../../store/datastores', () => ({
-  useGrantsStore: vi.fn(() => ({})),
+  useGrantsStore: vi.fn(() => mockGrantsStore),
 }))
 
 vi.mock('../../../../store/user/hooks', () => ({
@@ -51,6 +54,15 @@ vi.mock('../../../../i18n/hooks/useTranslation', () => ({
       if (key === 'dashboard.details.bulk.discard-dialog.header') return 'Discard versions'
       if (key === 'dashboard.details.bulk.discard-dialog.description') {
         return `Discard ${values?.count ?? 0} versions`
+      }
+      if (key === 'dashboard.details.bulk.unpublish-toast.no-permission') {
+        return 'No unpublish permission'
+      }
+      if (key === 'dashboard.details.bulk.discard-toast.no-permission') {
+        return 'No discard permission'
+      }
+      if (key === 'dashboard.details.bulk.toast.documents-skipped') {
+        return `Skipped ${values?.count ?? 0} documents`
       }
       return key
     },
@@ -142,15 +154,20 @@ describe('ReleaseBulkActionDialog', () => {
     mockGetDocumentPairPermissions.mockReturnValue(of({granted: false, reason: 'denied'}))
 
     const onClose = vi.fn()
+    const onSuccess = vi.fn()
     render(
       <ReleaseBulkActionDialog
         action="unpublish"
         documents={[createRow('versions.rTest.doc-one')]}
         releaseId="rTest"
         onClose={onClose}
-        onSuccess={vi.fn()}
+        onSuccess={onSuccess}
       />,
     )
+
+    await waitFor(() => {
+      expect(screen.getByText('Unpublish 0 documents')).toBeInTheDocument()
+    })
 
     await userEvent.click(await screen.findByText('Unpublish'))
 
@@ -158,6 +175,76 @@ describe('ReleaseBulkActionDialog', () => {
       expect(onClose).toHaveBeenCalled()
     })
     expect(mockUnpublishVersion).not.toHaveBeenCalled()
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect(mockToastPush).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'error',
+        title: 'No unpublish permission',
+      }),
+    )
+  })
+
+  it('shows the actionable document count in the dialog description', async () => {
+    const permitted = createRow('versions.rTest.doc-permitted')
+    const denied = createRow('versions.rTest.doc-denied')
+
+    mockGetDocumentPairPermissions.mockImplementation((options: {id: string}) => {
+      if (options.id === 'doc-permitted') {
+        return of({granted: true, reason: ''})
+      }
+      return of({granted: false, reason: 'denied'})
+    })
+
+    render(
+      <ReleaseBulkActionDialog
+        action="discard"
+        documents={[permitted, denied]}
+        releaseId="rTest"
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Discard 1 versions')).toBeInTheDocument()
+    })
+  })
+
+  it('warns when confirm skips documents that cannot be acted on', async () => {
+    const permitted = createRow('versions.rTest.doc-permitted')
+    const denied = createRow('versions.rTest.doc-denied')
+
+    mockGetDocumentPairPermissions.mockImplementation((options: {id: string}) => {
+      if (options.id === 'doc-permitted') {
+        return of({granted: true, reason: ''})
+      }
+      return of({granted: false, reason: 'denied'})
+    })
+
+    render(
+      <ReleaseBulkActionDialog
+        action="discard"
+        documents={[permitted, denied]}
+        releaseId="rTest"
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Discard 1 versions')).toBeInTheDocument()
+    })
+
+    await userEvent.click(await screen.findByText('Discard'))
+
+    await waitFor(() => {
+      expect(mockToastPush).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'warning',
+          title: 'Skipped 1 documents',
+        }),
+      )
+    })
   })
 
   it('only discards documents the user has permission for', async () => {
@@ -203,15 +290,20 @@ describe('ReleaseBulkActionDialog', () => {
     })
 
     const onClose = vi.fn()
+    const onSuccess = vi.fn()
     render(
       <ReleaseBulkActionDialog
         action="discard"
         documents={[createRow('versions.rTest.doc-one')]}
         releaseId="rTest"
         onClose={onClose}
-        onSuccess={vi.fn()}
+        onSuccess={onSuccess}
       />,
     )
+
+    await waitFor(() => {
+      expect(screen.getByText('Discard 0 versions')).toBeInTheDocument()
+    })
 
     await userEvent.click(await screen.findByText('Discard'))
 
@@ -219,5 +311,12 @@ describe('ReleaseBulkActionDialog', () => {
       expect(onClose).toHaveBeenCalled()
     })
     expect(mockDiscardVersion).not.toHaveBeenCalled()
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect(mockToastPush).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'error',
+        title: 'No discard permission',
+      }),
+    )
   })
 })

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseBulkActionDialog.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseBulkActionDialog.test.tsx
@@ -8,12 +8,13 @@ import {ReleaseBulkActionDialog} from '../ReleaseBulkActionDialog'
 import {type DocumentInRelease} from '../types'
 
 const mockUnpublishVersion = vi.fn().mockResolvedValue({})
+const mockDiscardVersion = vi.fn().mockResolvedValue({})
 const mockGetDocumentPairPermissions = vi.fn()
 const mockToastPush = vi.fn()
 
 vi.mock('../../../hooks/useVersionOperations', () => ({
   useVersionOperations: vi.fn(() => ({
-    discardVersion: vi.fn(),
+    discardVersion: mockDiscardVersion,
     unpublishVersion: mockUnpublishVersion,
   })),
 }))
@@ -45,6 +46,11 @@ vi.mock('../../../../i18n/hooks/useTranslation', () => ({
       if (key === 'dashboard.details.bulk.unpublish-dialog.header') return 'Unpublish documents'
       if (key === 'dashboard.details.bulk.unpublish-dialog.description') {
         return `Unpublish ${values?.count ?? 0} documents`
+      }
+      if (key === 'dashboard.details.bulk.discard-dialog.confirm') return 'Discard'
+      if (key === 'dashboard.details.bulk.discard-dialog.header') return 'Discard versions'
+      if (key === 'dashboard.details.bulk.discard-dialog.description') {
+        return `Discard ${values?.count ?? 0} versions`
       }
       return key
     },
@@ -152,5 +158,66 @@ describe('ReleaseBulkActionDialog', () => {
       expect(onClose).toHaveBeenCalled()
     })
     expect(mockUnpublishVersion).not.toHaveBeenCalled()
+  })
+
+  it('only discards documents the user has permission for', async () => {
+    const permitted = createRow('versions.rTest.doc-permitted')
+    const denied = createRow('versions.rTest.doc-denied')
+
+    mockGetDocumentPairPermissions.mockImplementation(
+      (options: {id: string; permission: string}) => {
+        if (options.permission !== 'discardVersion') {
+          return of({granted: true, reason: ''})
+        }
+        if (options.id === 'doc-permitted') {
+          return of({granted: true, reason: ''})
+        }
+        return of({granted: false, reason: 'denied'})
+      },
+    )
+
+    render(
+      <ReleaseBulkActionDialog
+        action="discard"
+        documents={[permitted, denied]}
+        releaseId="rTest"
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(await screen.findByText('Discard'))
+
+    await waitFor(() => {
+      expect(mockDiscardVersion).toHaveBeenCalledTimes(1)
+    })
+    expect(mockDiscardVersion).toHaveBeenCalledWith('rTest', 'versions.rTest.doc-permitted')
+  })
+
+  it('does not call discard when no documents are permitted', async () => {
+    mockGetDocumentPairPermissions.mockImplementation((options: {permission: string}) => {
+      if (options.permission === 'discardVersion') {
+        return of({granted: false, reason: 'denied'})
+      }
+      return of({granted: true, reason: ''})
+    })
+
+    const onClose = vi.fn()
+    render(
+      <ReleaseBulkActionDialog
+        action="discard"
+        documents={[createRow('versions.rTest.doc-one')]}
+        releaseId="rTest"
+        onClose={onClose}
+        onSuccess={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(await screen.findByText('Discard'))
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled()
+    })
+    expect(mockDiscardVersion).not.toHaveBeenCalled()
   })
 })

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseBulkActionDialog.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseBulkActionDialog.test.tsx
@@ -1,0 +1,156 @@
+import {render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {type ReactNode} from 'react'
+import {of} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {ReleaseBulkActionDialog} from '../ReleaseBulkActionDialog'
+import {type DocumentInRelease} from '../types'
+
+const mockUnpublishVersion = vi.fn().mockResolvedValue({})
+const mockGetDocumentPairPermissions = vi.fn()
+const mockToastPush = vi.fn()
+
+vi.mock('../../../hooks/useVersionOperations', () => ({
+  useVersionOperations: vi.fn(() => ({
+    discardVersion: vi.fn(),
+    unpublishVersion: mockUnpublishVersion,
+  })),
+}))
+
+vi.mock('../../../../store/grants/documentPairPermissions', () => ({
+  getDocumentPairPermissions: (...args: unknown[]) => mockGetDocumentPairPermissions(...args),
+}))
+
+vi.mock('../../../../hooks/useClient', () => ({
+  useClient: vi.fn(() => ({})),
+}))
+
+vi.mock('../../../../hooks/useSchema', () => ({
+  useSchema: vi.fn(() => ({})),
+}))
+
+vi.mock('../../../../store/datastores', () => ({
+  useGrantsStore: vi.fn(() => ({})),
+}))
+
+vi.mock('../../../../store/user/hooks', () => ({
+  useCurrentUser: vi.fn(() => ({id: 'user-1'})),
+}))
+
+vi.mock('../../../../i18n/hooks/useTranslation', () => ({
+  useTranslation: vi.fn(() => ({
+    t: (key: string, values?: {count?: number}) => {
+      if (key === 'dashboard.details.bulk.unpublish-dialog.confirm') return 'Unpublish'
+      if (key === 'dashboard.details.bulk.unpublish-dialog.header') return 'Unpublish documents'
+      if (key === 'dashboard.details.bulk.unpublish-dialog.description') {
+        return `Unpublish ${values?.count ?? 0} documents`
+      }
+      return key
+    },
+  })),
+}))
+
+vi.mock('../../../../../ui-components/dialog/Dialog', () => ({
+  Dialog: ({
+    footer,
+    children,
+  }: {
+    footer: {
+      confirmButton: {text: string; onClick: () => void}
+    }
+    children: ReactNode
+  }) => (
+    <div>
+      {children}
+      <button type="button" onClick={footer.confirmButton.onClick}>
+        {footer.confirmButton.text}
+      </button>
+    </div>
+  ),
+}))
+
+vi.mock('@sanity/ui', () => ({
+  useToast: vi.fn(() => ({push: mockToastPush})),
+  Box: ({children}: {children: ReactNode}) => <div>{children}</div>,
+  Text: ({children}: {children: ReactNode}) => <span>{children}</span>,
+}))
+
+function createRow(
+  id: string,
+  overrides: Partial<{publishedDocumentExists: boolean; systemDelete: boolean}> = {},
+): DocumentInRelease {
+  const {publishedDocumentExists = true, systemDelete = false} = overrides
+  return {
+    memoKey: id,
+    isPending: false,
+    document: {
+      _id: id,
+      _type: 'testDoc',
+      _rev: 'rev',
+      _createdAt: '2024-01-01T00:00:00.000Z',
+      _updatedAt: '2024-01-01T00:00:00.000Z',
+      publishedDocumentExists,
+      _system: systemDelete ? {delete: true} : undefined,
+    },
+    validation: {hasError: false, isValidating: false, validation: []},
+  }
+}
+
+describe('ReleaseBulkActionDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetDocumentPairPermissions.mockReturnValue(of({granted: true, reason: ''}))
+  })
+
+  it('only unpublishes documents the user has permission for', async () => {
+    const permitted = createRow('versions.rTest.doc-permitted')
+    const denied = createRow('versions.rTest.doc-denied')
+
+    mockGetDocumentPairPermissions.mockImplementation((options: {id: string}) => {
+      if (options.id === 'doc-permitted') {
+        return of({granted: true, reason: ''})
+      }
+      return of({granted: false, reason: 'denied'})
+    })
+
+    render(
+      <ReleaseBulkActionDialog
+        action="unpublish"
+        documents={[permitted, denied]}
+        releaseId="rTest"
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(await screen.findByText('Unpublish'))
+
+    await waitFor(() => {
+      expect(mockUnpublishVersion).toHaveBeenCalledTimes(1)
+    })
+    expect(mockUnpublishVersion).toHaveBeenCalledWith('versions.rTest.doc-permitted')
+  })
+
+  it('does not call unpublish when no documents are permitted', async () => {
+    mockGetDocumentPairPermissions.mockReturnValue(of({granted: false, reason: 'denied'}))
+
+    const onClose = vi.fn()
+    render(
+      <ReleaseBulkActionDialog
+        action="unpublish"
+        documents={[createRow('versions.rTest.doc-one')]}
+        releaseId="rTest"
+        onClose={onClose}
+        onSuccess={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(await screen.findByText('Unpublish'))
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled()
+    })
+    expect(mockUnpublishVersion).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseBulkActionDialog.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseBulkActionDialog.test.tsx
@@ -1,7 +1,7 @@
-import {render, screen, waitFor} from '@testing-library/react'
+import {act, render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
 import {type ReactNode} from 'react'
-import {of} from 'rxjs'
+import {of, Subject} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {ReleaseBulkActionDialog} from '../ReleaseBulkActionDialog'
@@ -92,6 +92,7 @@ vi.mock('@sanity/ui', () => ({
   useToast: vi.fn(() => ({push: mockToastPush})),
   Box: ({children}: {children: ReactNode}) => <div>{children}</div>,
   Text: ({children}: {children: ReactNode}) => <span>{children}</span>,
+  Spinner: (props: {'data-testid'?: string}) => <div data-testid={props['data-testid']} />,
 }))
 
 function createRow(
@@ -182,6 +183,32 @@ describe('ReleaseBulkActionDialog', () => {
         title: 'No unpublish permission',
       }),
     )
+  })
+
+  it('does not show a zero document count while permissions are loading', async () => {
+    const permission$ = new Subject<{granted: boolean; reason: string}>()
+    mockGetDocumentPairPermissions.mockReturnValue(permission$.asObservable())
+
+    render(
+      <ReleaseBulkActionDialog
+        action="unpublish"
+        documents={[createRow('versions.rTest.doc-one')]}
+        releaseId="rTest"
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByText('Unpublish 0 documents')).not.toBeInTheDocument()
+    expect(screen.getByTestId('release-bulk-action-dialog-loading')).toBeInTheDocument()
+
+    permission$.next({granted: true, reason: ''})
+    permission$.complete()
+
+    await waitFor(() => {
+      expect(screen.getByText('Unpublish 1 documents')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('release-bulk-action-dialog-loading')).not.toBeInTheDocument()
   })
 
   it('shows the actionable document count in the dialog description', async () => {

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseBulkSelectionActions.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseBulkSelectionActions.test.tsx
@@ -59,17 +59,22 @@ function createRow(id: string): DocumentInReleaseDetail {
 describe('ReleaseBulkSelectionActions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUseAnyDocumentInReleaseHasPairPermission.mockReturnValue({
-      granted: true,
-      isLoading: false,
-    })
+    mockUseAnyDocumentInReleaseHasPairPermission.mockImplementation(
+      (_documents: unknown, permission: string) => ({
+        granted: true,
+        isLoading: false,
+        permission,
+      }),
+    )
   })
 
   it('disables bulk discard when the user lacks discardVersion on the selection', async () => {
-    mockUseAnyDocumentInReleaseHasPairPermission.mockReturnValue({
-      granted: false,
-      isLoading: false,
-    })
+    mockUseAnyDocumentInReleaseHasPairPermission.mockImplementation(
+      (_documents: unknown, permission: string) => ({
+        granted: permission !== 'discardVersion',
+        isLoading: false,
+      }),
+    )
 
     render(
       <ReleaseBulkSelectionActions
@@ -87,10 +92,12 @@ describe('ReleaseBulkSelectionActions', () => {
   })
 
   it('disables bulk discard while permissions are loading', async () => {
-    mockUseAnyDocumentInReleaseHasPairPermission.mockReturnValue({
-      granted: false,
-      isLoading: true,
-    })
+    mockUseAnyDocumentInReleaseHasPairPermission.mockImplementation(
+      (_documents: unknown, permission: string) => ({
+        granted: true,
+        isLoading: permission === 'discardVersion',
+      }),
+    )
 
     render(
       <ReleaseBulkSelectionActions
@@ -103,5 +110,49 @@ describe('ReleaseBulkSelectionActions', () => {
     )
 
     expect(screen.getByTestId('release-bulk-discard')).toBeDisabled()
+  })
+
+  it('disables bulk unpublish when the user lacks unpublish on the selection', async () => {
+    mockUseAnyDocumentInReleaseHasPairPermission.mockImplementation(
+      (_documents: unknown, permission: string) => ({
+        granted: permission !== 'unpublish',
+        isLoading: false,
+      }),
+    )
+
+    render(
+      <ReleaseBulkSelectionActions
+        compact={false}
+        filterTabRows={[createRow('versions.rTest.doc-one')]}
+        onDiscard={vi.fn()}
+        onUnpublish={vi.fn()}
+        selectedKeys={['versions.rTest.doc-one']}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('release-bulk-unpublish')).toBeDisabled()
+    })
+  })
+
+  it('disables bulk unpublish while permissions are loading', async () => {
+    mockUseAnyDocumentInReleaseHasPairPermission.mockImplementation(
+      (_documents: unknown, permission: string) => ({
+        granted: true,
+        isLoading: permission === 'unpublish',
+      }),
+    )
+
+    render(
+      <ReleaseBulkSelectionActions
+        compact={false}
+        filterTabRows={[createRow('versions.rTest.doc-one')]}
+        onDiscard={vi.fn()}
+        onUnpublish={vi.fn()}
+        selectedKeys={['versions.rTest.doc-one']}
+      />,
+    )
+
+    expect(screen.getByTestId('release-bulk-unpublish')).toBeDisabled()
   })
 })

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseBulkSelectionActions.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseBulkSelectionActions.test.tsx
@@ -1,0 +1,107 @@
+import {render, screen, waitFor} from '@testing-library/react'
+import {type ReactNode} from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {ReleaseBulkSelectionActions} from '../ReleaseBulkSelectionActions'
+import {type DocumentInReleaseDetail} from '../ReleaseSummary'
+
+const mockUseAnyDocumentInReleaseHasPairPermission = vi.fn()
+
+vi.mock('../releaseBulkDocumentPermissions', () => ({
+  useAnyDocumentInReleaseHasPairPermission: (...args: unknown[]) =>
+    mockUseAnyDocumentInReleaseHasPairPermission(...args),
+}))
+
+vi.mock('../../../i18n/hooks/useTranslation', () => ({
+  useTranslation: vi.fn(() => ({
+    t: (key: string) => key,
+  })),
+}))
+
+vi.mock('../../../../../ui-components/menuButton/MenuButton', () => ({
+  MenuButton: () => null,
+}))
+
+vi.mock('../../../../../ui-components/menuItem/MenuItem', () => ({
+  MenuItem: () => null,
+}))
+
+vi.mock('@sanity/ui', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    Flex: ({children}: {children: ReactNode}) => <div>{children}</div>,
+  }
+})
+
+vi.mock('../../../../../ui-components/button/Button', () => ({
+  Button: ({disabled, 'data-testid': testId}: {'disabled'?: boolean; 'data-testid'?: string}) => (
+    <button data-testid={testId} disabled={disabled} type="button" />
+  ),
+}))
+
+function createRow(id: string): DocumentInReleaseDetail {
+  return {
+    memoKey: id,
+    isPending: false,
+    document: {
+      _id: id,
+      _type: 'testDoc',
+      _rev: 'rev',
+      _createdAt: '2024-01-01T00:00:00.000Z',
+      _updatedAt: '2024-01-01T00:00:00.000Z',
+      publishedDocumentExists: true,
+    },
+    validation: {hasError: false, isValidating: false, validation: []},
+  }
+}
+
+describe('ReleaseBulkSelectionActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseAnyDocumentInReleaseHasPairPermission.mockReturnValue({
+      granted: true,
+      isLoading: false,
+    })
+  })
+
+  it('disables bulk discard when the user lacks discardVersion on the selection', async () => {
+    mockUseAnyDocumentInReleaseHasPairPermission.mockReturnValue({
+      granted: false,
+      isLoading: false,
+    })
+
+    render(
+      <ReleaseBulkSelectionActions
+        compact={false}
+        filterTabRows={[createRow('versions.rTest.doc-one')]}
+        onDiscard={vi.fn()}
+        onUnpublish={vi.fn()}
+        selectedKeys={['versions.rTest.doc-one']}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('release-bulk-discard')).toBeDisabled()
+    })
+  })
+
+  it('disables bulk discard while permissions are loading', async () => {
+    mockUseAnyDocumentInReleaseHasPairPermission.mockReturnValue({
+      granted: false,
+      isLoading: true,
+    })
+
+    render(
+      <ReleaseBulkSelectionActions
+        compact={false}
+        filterTabRows={[createRow('versions.rTest.doc-one')]}
+        onDiscard={vi.fn()}
+        onUnpublish={vi.fn()}
+        selectedKeys={['versions.rTest.doc-one']}
+      />,
+    )
+
+    expect(screen.getByTestId('release-bulk-discard')).toBeDisabled()
+  })
+})

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseBulkSelectionActions.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseBulkSelectionActions.test.tsx
@@ -5,11 +5,11 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {ReleaseBulkSelectionActions} from '../ReleaseBulkSelectionActions'
 import {type DocumentInReleaseDetail} from '../ReleaseSummary'
 
-const mockUseAnyDocumentInReleaseHasPairPermission = vi.fn()
+const mockUseAllDocumentsInReleaseHavePairPermission = vi.fn()
 
 vi.mock('../releaseBulkDocumentPermissions', () => ({
-  useAnyDocumentInReleaseHasPairPermission: (...args: unknown[]) =>
-    mockUseAnyDocumentInReleaseHasPairPermission(...args),
+  useAllDocumentsInReleaseHavePairPermission: (...args: unknown[]) =>
+    mockUseAllDocumentsInReleaseHavePairPermission(...args),
 }))
 
 vi.mock('../../../i18n/hooks/useTranslation', () => ({
@@ -40,7 +40,11 @@ vi.mock('../../../../../ui-components/button/Button', () => ({
   ),
 }))
 
-function createRow(id: string): DocumentInReleaseDetail {
+function createRow(
+  id: string,
+  overrides: Partial<{publishedDocumentExists: boolean}> = {},
+): DocumentInReleaseDetail {
+  const {publishedDocumentExists = true} = overrides
   return {
     memoKey: id,
     isPending: false,
@@ -50,7 +54,7 @@ function createRow(id: string): DocumentInReleaseDetail {
       _rev: 'rev',
       _createdAt: '2024-01-01T00:00:00.000Z',
       _updatedAt: '2024-01-01T00:00:00.000Z',
-      publishedDocumentExists: true,
+      publishedDocumentExists,
     },
     validation: {hasError: false, isValidating: false, validation: []},
   }
@@ -59,7 +63,7 @@ function createRow(id: string): DocumentInReleaseDetail {
 describe('ReleaseBulkSelectionActions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockUseAnyDocumentInReleaseHasPairPermission.mockImplementation(
+    mockUseAllDocumentsInReleaseHavePairPermission.mockImplementation(
       (_documents: unknown, permission: string) => ({
         granted: true,
         isLoading: false,
@@ -69,7 +73,7 @@ describe('ReleaseBulkSelectionActions', () => {
   })
 
   it('disables bulk discard when the user lacks discardVersion on the selection', async () => {
-    mockUseAnyDocumentInReleaseHasPairPermission.mockImplementation(
+    mockUseAllDocumentsInReleaseHavePairPermission.mockImplementation(
       (_documents: unknown, permission: string) => ({
         granted: permission !== 'discardVersion',
         isLoading: false,
@@ -92,7 +96,7 @@ describe('ReleaseBulkSelectionActions', () => {
   })
 
   it('disables bulk discard while permissions are loading', async () => {
-    mockUseAnyDocumentInReleaseHasPairPermission.mockImplementation(
+    mockUseAllDocumentsInReleaseHavePairPermission.mockImplementation(
       (_documents: unknown, permission: string) => ({
         granted: true,
         isLoading: permission === 'discardVersion',
@@ -113,7 +117,7 @@ describe('ReleaseBulkSelectionActions', () => {
   })
 
   it('disables bulk unpublish when the user lacks unpublish on the selection', async () => {
-    mockUseAnyDocumentInReleaseHasPairPermission.mockImplementation(
+    mockUseAllDocumentsInReleaseHavePairPermission.mockImplementation(
       (_documents: unknown, permission: string) => ({
         granted: permission !== 'unpublish',
         isLoading: false,
@@ -136,7 +140,7 @@ describe('ReleaseBulkSelectionActions', () => {
   })
 
   it('disables bulk unpublish while permissions are loading', async () => {
-    mockUseAnyDocumentInReleaseHasPairPermission.mockImplementation(
+    mockUseAllDocumentsInReleaseHavePairPermission.mockImplementation(
       (_documents: unknown, permission: string) => ({
         granted: true,
         isLoading: permission === 'unpublish',
@@ -154,5 +158,24 @@ describe('ReleaseBulkSelectionActions', () => {
     )
 
     expect(screen.getByTestId('release-bulk-unpublish')).toBeDisabled()
+  })
+
+  it('disables bulk unpublish when not every selected document can be unpublished', async () => {
+    render(
+      <ReleaseBulkSelectionActions
+        compact={false}
+        filterTabRows={[
+          createRow('versions.rTest.doc-published'),
+          createRow('versions.rTest.doc-draft-only', {publishedDocumentExists: false}),
+        ]}
+        onDiscard={vi.fn()}
+        onUnpublish={vi.fn()}
+        selectedKeys={['versions.rTest.doc-published', 'versions.rTest.doc-draft-only']}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('release-bulk-unpublish')).toBeDisabled()
+    })
   })
 })

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetailsEditor.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetailsEditor.test.tsx
@@ -36,24 +36,23 @@ const initialRelease = {
 } as ReleaseDocument
 
 describe('ReleaseDetailsEditor', () => {
-  describe('as a display surface', () => {
+  describe('production (inline editing)', () => {
     beforeEach(() => {
       vi.clearAllMocks()
       mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
     })
 
-    it('renders the title and description as read-only display, not inline inputs', async () => {
+    it('renders inline title and description fields', async () => {
       const wrapper = await createTestProvider()
       render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
       await flushMicrotasksThisIsACodeSmell()
 
-      expect(screen.getByTestId('release-title-display')).toHaveTextContent('Initial Title')
-      expect(screen.getByTestId('release-description-display')).toHaveTextContent('A description')
-      // The editable fields are not present on the page itself — they live in the edit dialog.
-      expect(screen.queryByTestId('release-form-title')).toBeNull()
+      expect(screen.getByTestId('release-form-title')).toHaveValue('Initial Title')
+      expect(screen.queryByTestId('release-title-display')).toBeNull()
     })
 
-    it('opens the edit dialog and saves changes via updateRelease', async () => {
+    it('debounces changes and saves via updateRelease', async () => {
+      vi.useFakeTimers({shouldAdvanceTime: true})
       const wrapper = await createTestProvider()
       render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
       await flushMicrotasksThisIsACodeSmell()
@@ -61,14 +60,11 @@ describe('ReleaseDetailsEditor', () => {
       const updateReleaseMock = (useReleaseOperations as unknown as Mock).mock.results[0]?.value
         .updateRelease
 
-      const editButton = await screen.findByTestId('edit-release-details-button')
-      await userEvent.click(editButton)
-
-      const titleInput = (await screen.findByTestId('release-form-title')) as HTMLTextAreaElement
+      const titleInput = screen.getByTestId('release-form-title') as HTMLTextAreaElement
       await userEvent.clear(titleInput)
       await userEvent.type(titleInput, 'New Title')
 
-      await userEvent.click(screen.getByTestId('save-release-details-button'))
+      await vi.advanceTimersByTimeAsync(250)
 
       await waitFor(() => {
         expect(updateReleaseMock).toHaveBeenCalledWith(
@@ -77,6 +73,26 @@ describe('ReleaseDetailsEditor', () => {
           }),
         )
       })
+      vi.useRealTimers()
+    })
+  })
+
+  describe('with beta.variants (read-only identity)', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
+    })
+
+    it('renders the title and description as read-only display, not inline inputs', async () => {
+      const wrapper = await createTestProvider({
+        config: {beta: {variants: {enabled: true}}},
+      })
+      render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
+      await flushMicrotasksThisIsACodeSmell()
+
+      expect(screen.getByTestId('release-title-display')).toHaveTextContent('Initial Title')
+      expect(screen.getByTestId('release-description-display')).toHaveTextContent('A description')
+      expect(screen.queryByTestId('release-form-title')).toBeNull()
     })
   })
 
@@ -86,12 +102,12 @@ describe('ReleaseDetailsEditor', () => {
       mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnFalse)
     })
 
-    it('does not show the edit affordance', async () => {
+    it('disables inline fields in production', async () => {
       const wrapper = await createTestProvider()
       render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
       await flushMicrotasksThisIsACodeSmell()
 
-      expect(screen.queryByTestId('edit-release-details-button')).toBeNull()
+      expect(screen.getByTestId('release-form-title')).toBeDisabled()
     })
   })
 })

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetailsEditor.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseDetailsEditor.test.tsx
@@ -1,7 +1,7 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
-import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
 
 import {flushMicrotasksThisIsACodeSmell} from '../../../../../../test/testUtils/flushMicrotasks'
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
@@ -13,6 +13,7 @@ import {
 } from '../../../store/__tests__/__mocks/useReleasePermissions.mock'
 import {useReleaseOperations} from '../../../store/useReleaseOperations'
 import {ReleaseDetailsEditor} from '../ReleaseDetailsEditor'
+
 // Mock the dependencies
 vi.mock('../../../store/useReleaseOperations', () => ({
   useReleaseOperations: vi.fn().mockReturnValue({
@@ -24,121 +25,73 @@ vi.mock('../../../store/useReleasePermissions', () => ({
   useReleasePermissions: vi.fn(() => useReleasePermissionsMockReturn),
 }))
 
-describe('ReleaseDetailsEditor', () => {
-  describe('when there is permission', () => {
-    const initialRelease = {
-      _id: 'release1',
-      metadata: {
-        title: 'Initial Title',
-        description: '',
-        releaseType: 'asap',
-        intendedPublishAt: undefined,
-      },
-    } as ReleaseDocument
+const initialRelease = {
+  _id: 'release1',
+  metadata: {
+    title: 'Initial Title',
+    description: 'A description',
+    releaseType: 'asap',
+    intendedPublishAt: undefined,
+  },
+} as ReleaseDocument
 
-    beforeEach(async () => {
+describe('ReleaseDetailsEditor', () => {
+  describe('as a display surface', () => {
+    beforeEach(() => {
       vi.clearAllMocks()
       mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
     })
 
-    it('should call updateRelease after title change', async () => {
-      const wrapper = await createTestProvider()
-      const {container} = render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
-      await flushMicrotasksThisIsACodeSmell()
-
-      const release = {
-        _id: 'release1',
-        metadata: {
-          title: 'New Title',
-          description: '',
-          releaseType: 'asap',
-          intendedPublishAt: undefined,
-        },
-      } as ReleaseDocument
-
-      const input = screen.getByTestId('release-form-title') as HTMLInputElement
-
-      await waitFor(() => {
-        expect(input).not.toBeDisabled()
-      })
-
-      // @ts-expect-error -- pre-existing, fix later
-      const updateReleaseMock = (useReleaseOperations as unknown as vi.Mock).mock.results[0]?.value
-        .updateRelease
-
-      await userEvent.clear(input)
-      await userEvent.type(input, release.metadata.title!)
-
-      // Wait for debounce (200ms) + some buffer
-      await waitFor(
-        () => {
-          expect(updateReleaseMock).toHaveBeenCalledWith(release)
-        },
-        {timeout: 1000},
-      )
-    })
-
-    it('should call updateRelease after description change', async () => {
-      const wrapper = await createTestProvider()
-      const {container} = render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
-      await flushMicrotasksThisIsACodeSmell()
-
-      const release = {
-        _id: 'release1',
-        metadata: {
-          title: 'Initial Title',
-          description: 'woo hoo',
-          releaseType: 'asap',
-          intendedPublishAt: undefined,
-        },
-      } as ReleaseDocument
-
-      const input = screen.getByTestId('release-form-description') as HTMLTextAreaElement
-
-      await waitFor(() => {
-        expect(input).not.toBeDisabled()
-      })
-
-      // @ts-expect-error -- pre-existing, fix later
-      const updateReleaseMock = (useReleaseOperations as unknown as vi.Mock).mock.results[0]?.value
-        .updateRelease
-
-      await userEvent.clear(input)
-      await userEvent.type(input, release.metadata.description!)
-
-      // Wait for debounce (200ms) + some buffer
-      await waitFor(
-        () => {
-          expect(updateReleaseMock).toHaveBeenCalledWith(release)
-        },
-        {timeout: 1000},
-      )
-    })
-  })
-
-  describe('when there is no permission', () => {
-    const initialRelease = {
-      _id: 'release1',
-      metadata: {
-        title: 'Initial Title',
-        description: '',
-        releaseType: 'asap',
-        intendedPublishAt: undefined,
-      },
-    } as ReleaseDocument
-
-    beforeEach(async () => {
-      vi.clearAllMocks()
-      mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnFalse)
-    })
-
-    it('when there is no permission, should not call updateRelease', async () => {
+    it('renders the title and description as read-only display, not inline inputs', async () => {
       const wrapper = await createTestProvider()
       render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
       await flushMicrotasksThisIsACodeSmell()
 
-      const input = screen.getByTestId('release-form-description')
-      expect(input).toBeDisabled()
+      expect(screen.getByTestId('release-title-display')).toHaveTextContent('Initial Title')
+      expect(screen.getByTestId('release-description-display')).toHaveTextContent('A description')
+      // The editable fields are not present on the page itself — they live in the edit dialog.
+      expect(screen.queryByTestId('release-form-title')).toBeNull()
+    })
+
+    it('opens the edit dialog and saves changes via updateRelease', async () => {
+      const wrapper = await createTestProvider()
+      render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
+      await flushMicrotasksThisIsACodeSmell()
+
+      const updateReleaseMock = (useReleaseOperations as unknown as Mock).mock.results[0]?.value
+        .updateRelease
+
+      const editButton = await screen.findByTestId('edit-release-details-button')
+      await userEvent.click(editButton)
+
+      const titleInput = (await screen.findByTestId('release-form-title')) as HTMLTextAreaElement
+      await userEvent.clear(titleInput)
+      await userEvent.type(titleInput, 'New Title')
+
+      await userEvent.click(screen.getByTestId('save-release-details-button'))
+
+      await waitFor(() => {
+        expect(updateReleaseMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            metadata: expect.objectContaining({title: 'New Title'}),
+          }),
+        )
+      })
+    })
+  })
+
+  describe('when there is no permission', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnFalse)
+    })
+
+    it('does not show the edit affordance', async () => {
+      const wrapper = await createTestProvider()
+      render(<ReleaseDetailsEditor release={initialRelease} />, {wrapper})
+      await flushMicrotasksThisIsACodeSmell()
+
+      expect(screen.queryByTestId('edit-release-details-button')).toBeNull()
     })
   })
 })

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
@@ -32,6 +32,10 @@ vi.mock('../useBundleDocuments', () => ({
   useBundleDocuments: vi.fn(() => useBundleDocumentsMockReturnWithResults),
 }))
 
+vi.mock('../CopyReleaseActions', () => ({
+  CopyReleaseActions: () => <div data-testid="copy-release-actions" />,
+}))
+
 vi.mock('../../../../preview/components/SanityDefaultPreview', () => ({
   SanityDefaultPreview: vi.fn(({isPlaceholder, title, subtitle, status}) => (
     <div data-ui={isPlaceholder ? 'Placeholder' : 'Preview'}>
@@ -138,9 +142,13 @@ const ScrollContainer: FC<PropsWithChildren> = ({children}) => {
   )
 }
 
-const renderTest = async (props: Partial<ReleaseSummaryProps>) => {
+const renderTest = async (
+  props: Partial<ReleaseSummaryProps>,
+  options?: {variantsEnabled?: boolean},
+) => {
   const wrapper = await createTestProvider({
     resources: [releasesUsEnglishLocaleBundle],
+    ...(options?.variantsEnabled ? {config: {beta: {variants: {enabled: true}}}} : undefined),
   })
 
   return render(
@@ -307,6 +315,32 @@ describe('ReleaseSummary', () => {
 
       expect(screen.queryByTestId('cardinality-one-empty-state')).not.toBeInTheDocument()
       expect(screen.getAllByTestId('table-row')).toHaveLength(2)
+    })
+  })
+
+  describe('with beta.variants (DocumentTable command lane)', () => {
+    const prerenderVariantsTest = async (props: Partial<ReleaseSummaryProps> = {}) => {
+      await renderTest(props, {variantsEnabled: true})
+      await screen.findByTestId('document-table-card')
+    }
+
+    it('keeps the command lane when the release has no documents', async () => {
+      await prerenderVariantsTest({documents: []})
+
+      expect(screen.getByTestId('release-documents-search')).toBeInTheDocument()
+      expect(screen.getByText('Add document')).toBeInTheDocument()
+      expect(screen.getByTestId('copy-release-actions')).toBeInTheDocument()
+    })
+
+    it('keeps filter tabs when search yields no results', async () => {
+      await prerenderVariantsTest()
+
+      const searchInput = screen.getByTestId('release-documents-search')
+      await userEvent.type(searchInput, 'nonexistent query')
+
+      expect(screen.queryAllByTestId('table-row')).toHaveLength(0)
+      expect(screen.getByRole('tab', {name: /all/i})).toBeInTheDocument()
+      expect(searchInput).toHaveFocus()
     })
   })
 

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseSummary.test.tsx
@@ -199,7 +199,7 @@ describe('ReleaseSummary', () => {
       within(initialFirstDocument).getByText('First document')
       within(initialSecondDocument).getByText('Second document')
 
-      await userEvent.click(within(screen.getByRole('table')).getByText('Edited'))
+      await userEvent.click(within(screen.getByRole('table')).getByText('Last edited'))
 
       const [sortedCreatedAscFirstDocument, sortedCreatedAscSecondDocument] =
         screen.getAllByTestId('table-row')
@@ -207,7 +207,7 @@ describe('ReleaseSummary', () => {
       within(sortedCreatedAscFirstDocument).getByText('Second document')
       within(sortedCreatedAscSecondDocument).getByText('First document')
 
-      await userEvent.click(within(screen.getByRole('table')).getByText('Edited'))
+      await userEvent.click(within(screen.getByRole('table')).getByText('Last edited'))
 
       const [sortedEditedDescFirstDocument, sortedEditedDescSecondDocument] =
         screen.getAllByTestId('table-row')

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseTypePicker.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseTypePicker.test.tsx
@@ -92,7 +92,7 @@ describe('ReleaseTypePicker', () => {
 
       expect(screen.getByTestId('published-release-type-label')).toBeInTheDocument()
 
-      expect(screen.getByText('Published on Oct 10, 2023, 3:00:00 AM')).toBeInTheDocument()
+      expect(screen.getByText('Published on Oct 10, 2023, 3:00 AM')).toBeInTheDocument()
     })
 
     it('renders the label with a published text when release was schedule published', async () => {
@@ -102,7 +102,7 @@ describe('ReleaseTypePicker', () => {
 
       expect(screen.getByTestId('published-release-type-label')).toBeInTheDocument()
 
-      expect(screen.getByText('Published on Oct 10, 2023, 3:00:00 AM')).toBeInTheDocument()
+      expect(screen.getByText('Published on Oct 10, 2023, 3:00 AM')).toBeInTheDocument()
     })
   })
 

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseTypePicker.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseTypePicker.test.tsx
@@ -92,7 +92,7 @@ describe('ReleaseTypePicker', () => {
 
       expect(screen.getByTestId('published-release-type-label')).toBeInTheDocument()
 
-      expect(screen.getByText('Published on Oct 10, 2023, 3:00 AM')).toBeInTheDocument()
+      expect(screen.getByText('Published on Oct 10, 2023, 3:00:00 AM')).toBeInTheDocument()
     })
 
     it('renders the label with a published text when release was schedule published', async () => {
@@ -102,7 +102,7 @@ describe('ReleaseTypePicker', () => {
 
       expect(screen.getByTestId('published-release-type-label')).toBeInTheDocument()
 
-      expect(screen.getByText('Published on Oct 10, 2023, 3:00 AM')).toBeInTheDocument()
+      expect(screen.getByText('Published on Oct 10, 2023, 3:00:00 AM')).toBeInTheDocument()
     })
   })
 

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/releaseDocumentActions.test.ts
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/releaseDocumentActions.test.ts
@@ -4,6 +4,7 @@ import {
   countDocumentsByAction,
   type DocumentFilterType,
   documentMatchesFilter,
+  isDocumentEligibleForUnpublish,
 } from '../releaseDocumentActions'
 import {type DocumentInRelease} from '../types'
 
@@ -163,6 +164,35 @@ describe('releaseDocumentActions', () => {
       expect(documentMatchesFilter(addedDoc, 'changed')).toBe(false)
       expect(documentMatchesFilter(addedDoc, 'unpublished')).toBe(false)
       expect(documentMatchesFilter(addedDoc, 'errors')).toBe(false)
+    })
+  })
+
+  describe('isDocumentEligibleForUnpublish', () => {
+    it('returns true for published documents not already marked to unpublish', () => {
+      const changedDoc = createMockDocument({publishedDocumentExists: true})
+
+      expect(isDocumentEligibleForUnpublish(changedDoc)).toBe(true)
+    })
+
+    it('returns false when there is no published document', () => {
+      const addedDoc = createMockDocument({publishedDocumentExists: false})
+
+      expect(isDocumentEligibleForUnpublish(addedDoc)).toBe(false)
+    })
+
+    it('returns false when the version is already marked to unpublish', () => {
+      const unpublishedDoc = createMockDocument({
+        publishedDocumentExists: true,
+        systemDelete: true,
+      })
+
+      expect(isDocumentEligibleForUnpublish(unpublishedDoc)).toBe(false)
+    })
+
+    it('returns false for pending rows', () => {
+      const pendingDoc = createMockDocument({isPending: true, publishedDocumentExists: true})
+
+      expect(isDocumentEligibleForUnpublish(pendingDoc)).toBe(false)
     })
   })
 })

--- a/packages/sanity/src/core/releases/tool/detail/components/ReleaseDocumentFilterTabs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/components/ReleaseDocumentFilterTabs.tsx
@@ -19,6 +19,8 @@ interface ReleaseDocumentFilterTabsProps {
   isLoading?: boolean
   activeFilter: DocumentFilterType
   onFilterChange: (filter: DocumentFilterType) => void
+  /** Render just the tabs (no Container/padding) for hosting inside the shared table command lane. */
+  inline?: boolean
 }
 
 export function ReleaseDocumentFilterTabs({
@@ -27,6 +29,7 @@ export function ReleaseDocumentFilterTabs({
   isLoading = false,
   activeFilter,
   onFilterChange,
+  inline = false,
 }: ReleaseDocumentFilterTabsProps) {
   const {t} = useTranslation(releasesLocaleNamespace)
 
@@ -36,20 +39,22 @@ export function ReleaseDocumentFilterTabs({
   }
 
   if (isLoading) {
+    const skeletons = (
+      <Flex align="center" gap={2}>
+        {FILTER_TAB_CONFIGS.filter((config) => config.key !== 'errors').map((config) => (
+          <Skeleton
+            key={`loading-skeleton-${config.key}`}
+            animated
+            style={{width: '70px', height: '32px'}}
+            radius={2}
+          />
+        ))}
+      </Flex>
+    )
+    if (inline) return skeletons
     return (
       <Container width={3}>
-        <Box padding={3}>
-          <Flex align="center" gap={2}>
-            {FILTER_TAB_CONFIGS.filter((config) => config.key !== 'errors').map((config) => (
-              <Skeleton
-                key={`loading-skeleton-${config.key}`}
-                animated
-                style={{width: '70px', height: '32px'}}
-                radius={2}
-              />
-            ))}
-          </Flex>
-        </Box>
+        <Box padding={3}>{skeletons}</Box>
       </Container>
     )
   }
@@ -62,6 +67,7 @@ export function ReleaseDocumentFilterTabs({
     <ReleaseDocumentFilterTabsInner
       documents={documents}
       activeFilter={activeFilter}
+      inline={inline}
       onFilterChange={onFilterChange}
       t={t}
     />
@@ -72,6 +78,7 @@ interface ReleaseDocumentFilterTabsInnerProps {
   documents: DocumentInRelease[]
   activeFilter: DocumentFilterType
   onFilterChange: (filter: DocumentFilterType) => void
+  inline: boolean
   t: ReturnType<typeof useTranslation>['t']
 }
 
@@ -79,6 +86,7 @@ function ReleaseDocumentFilterTabsInner({
   documents,
   activeFilter,
   onFilterChange,
+  inline,
   t,
 }: ReleaseDocumentFilterTabsInnerProps) {
   const counts = useMemo(() => countDocumentsByAction(documents), [documents])
@@ -104,32 +112,37 @@ function ReleaseDocumentFilterTabsInner({
     return 'default'
   }
 
+  const tabList = (
+    <TabList space={1}>
+      {FILTER_TAB_CONFIGS.map((config) => {
+        const isSelected = activeFilter === config.key
+
+        // Hide tabs with zero counts (except "All")
+        if (config.key !== 'all' && counts[config.key] === 0) {
+          return null
+        }
+
+        return (
+          <Tab
+            key={config.key}
+            id={`filter-tab-${config.key}`}
+            aria-controls="document-table-card"
+            label={getTabLabel(config)}
+            onClick={() => onFilterChange(config.key)}
+            selected={isSelected}
+            tone={getTabTone(config)}
+          />
+        )
+      })}
+    </TabList>
+  )
+
+  // Inline: bare tabs for the shared table's command lane (the lane supplies container + padding).
+  if (inline) return tabList
+
   return (
     <Container width={3}>
-      <Box padding={3}>
-        <TabList space={1}>
-          {FILTER_TAB_CONFIGS.map((config) => {
-            const isSelected = activeFilter === config.key
-
-            // Hide tabs with zero counts (except "All")
-            if (config.key !== 'all' && counts[config.key] === 0) {
-              return null
-            }
-
-            return (
-              <Tab
-                key={config.key}
-                id={`filter-tab-${config.key}`}
-                aria-controls="document-table-card"
-                label={getTabLabel(config)}
-                onClick={() => onFilterChange(config.key)}
-                selected={isSelected}
-                tone={getTabTone(config)}
-              />
-            )
-          })}
-        </TabList>
-      </Box>
+      <Box padding={3}>{tabList}</Box>
     </Container>
   )
 }

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -1,20 +1,28 @@
 import {type ReleaseState} from '@sanity/client'
+import {CheckmarkCircleIcon} from '@sanity/icons/CheckmarkCircle'
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
-import {Badge, Box, Flex, Text} from '@sanity/ui'
+import {Badge, Box, Card, Flex, Text} from '@sanity/ui'
 import {toString as pathToString} from '@sanity/util/paths'
 // oxlint-disable-next-line @sanity/i18n/no-i18next-import -- figure out how to have the linter be fine with importing types-only
 import {type TFunction} from 'i18next'
-import {memo, useCallback, useEffect, useRef, useState} from 'react'
+import {type CSSProperties, memo, useCallback, useEffect, useRef, useState} from 'react'
 import {IntentLink} from 'sanity/router'
 import {styled} from 'styled-components'
 
 import {ToneIcon} from '../../../../../ui-components/toneIcon/ToneIcon'
 import {Tooltip} from '../../../../../ui-components/tooltip/Tooltip'
+import {EditedByAvatar} from '../../../../components/documentTable/EditedByCell'
 import {RelativeTime} from '../../../../components/RelativeTime'
 import {AvatarSkeleton, UserAvatar} from '../../../../components/userAvatar/UserAvatar'
 import {useSchema} from '../../../../hooks/useSchema'
 import {SanityDefaultPreview} from '../../../../preview/components/SanityDefaultPreview'
-import {getVariantIdFromDocument} from '../../../../variants/tool/util'
+import {RhombusIcon} from '../../../../variants/plugin/components/PersonalizationIcons'
+import {
+  getVariantConditionsText,
+  getVariantIdFromDocument,
+  getVariantTitle,
+} from '../../../../variants/tool/util'
+import {type SystemVariant} from '../../../../variants/types'
 import {getReleaseIdFromReleaseDocumentId} from '../../../util/getReleaseIdFromReleaseDocumentId'
 import {isGoingToUnpublish} from '../../../util/isGoingToUnpublish'
 import {getReleaseDocumentIntent} from '../../components/getReleaseDocumentIntent'
@@ -133,9 +141,14 @@ const documentActionColumn: (t: TFunction<'releases'>) => Column<BundleDocumentR
   id: 'action',
   width: null,
   style: {minWidth: 100},
+  sorting: true,
+  // Sort by the action type (Add / Change / Unpublish) so like actions group together.
+  sortTransform(value) {
+    return getDocumentActionType(value) || ''
+  },
   header: (props) => (
     <Flex {...props.headerProps} paddingY={3} sizing="border">
-      <Headers.BasicHeader text={t('table-header.action')} />
+      <Headers.SortHeaderButton text={t('table-header.action')} {...props} />
     </Flex>
   ),
   cell: ({cellProps, datum}) => {
@@ -165,11 +178,72 @@ const documentActionColumn: (t: TFunction<'releases'>) => Column<BundleDocumentR
   },
 })
 
+// Purple, matching the perspective bar's variant motif. The perspective bar gets its purple from a
+// `tone="suggest"` Card context (which defines --card-icon-color as the suggest purple); the
+// --card-badge-* vars only exist inside a Badge, so we replicate the Card approach: a transparent
+// suggest-toned wrapper, with the RhombusIcon (stroke=currentColor) picking up --card-icon-color.
+const VARIANT_ICON_CARD_STYLE: CSSProperties = {backgroundColor: 'transparent'}
+const VARIANT_ICON_STYLE: CSSProperties = {color: 'var(--card-icon-color)'}
+
+/** Resolves a document's variant definition from its `_system.variant._ref` (full variant id). */
+function resolveDocumentVariant(
+  document: BundleDocumentRow['document'],
+  variantsById: Map<string, SystemVariant>,
+): SystemVariant | undefined {
+  const variantRef = (document as {_system?: {variant?: {_ref?: string}}})._system?.variant?._ref
+  return variantRef ? variantsById.get(variantRef) : undefined
+}
+
+// Which variant a release document targets: ◆ diamond + the variant title, with the full
+// conditions ("flags") on hover. Empty for base (non-variant) documents.
+const VariantCell = memo(
+  function VariantCell({
+    document,
+    variantsById,
+  }: {
+    document: BundleDocumentRow['document']
+    variantsById: Map<string, SystemVariant>
+  }) {
+    const variant = resolveDocumentVariant(document, variantsById)
+    if (!variant) return null
+
+    const conditions = getVariantConditionsText(variant.conditions)
+
+    return (
+      <Tooltip
+        portal
+        placement="bottom-start"
+        disabled={!conditions}
+        content={
+          conditions ? (
+            <Box padding={2}>
+              <Text size={1}>{conditions}</Text>
+            </Box>
+          ) : undefined
+        }
+      >
+        <Flex align="center" gap={2}>
+          <Card tone="suggest" padding={0} style={VARIANT_ICON_CARD_STYLE}>
+            <Text size={1} style={VARIANT_ICON_STYLE}>
+              <RhombusIcon />
+            </Text>
+          </Card>
+          <Text size={1} textOverflow="ellipsis" weight="medium">
+            {getVariantTitle(variant)}
+          </Text>
+        </Flex>
+      </Tooltip>
+    )
+  },
+  (prev, next) => prev.document === next.document && prev.variantsById === next.variantsById,
+)
+
 export const getDocumentTableColumnDefs: (
   releaseId: string,
   releaseState: ReleaseState,
   t: TFunction<'releases'>,
-) => Column<BundleDocumentRow>[] = (releaseId, releaseState, t) => [
+  options?: {searchInCommandLane?: boolean; variantsById?: Map<string, SystemVariant>},
+) => Column<BundleDocumentRow>[] = (releaseId, releaseState, t, options) => [
   /**
    * Hiding action for archived and published releases of v1.0
    * This will be added once Events API has reverse order lookup supported
@@ -179,7 +253,9 @@ export const getDocumentTableColumnDefs: (
     id: 'document._type',
     // Header and body rows are independent flexboxes, so a content-sized column (width: null)
     // settles at different widths in each and misaligns. A fixed width keeps them in sync.
-    width: 150,
+    // Type only ever holds short schema titles (Book / Author / demoBlogPost), and DocumentType
+    // truncates + shows a tooltip on overflow, so a tighter width reclaims space for Document.
+    width: 120,
     sorting: true,
     header: (props) => (
       <Flex {...props.headerProps} paddingY={3} sizing="border">
@@ -194,10 +270,46 @@ export const getDocumentTableColumnDefs: (
       </Flex>
     ),
   },
+  // "Variant" column — shows which variant each document targets. Only present when the caller
+  // passes a resolved variants map (i.e. variants enabled). This is the functional point of the
+  // release-detail reconciliation: the inverse of the Variants table's "Appears in" column.
+  ...(options?.variantsById
+    ? [
+        {
+          id: 'variant',
+          width: 180,
+          style: {minWidth: 120, maxWidth: 180},
+          sorting: true,
+          sortTransform(value) {
+            const variant = resolveDocumentVariant(value.document, options.variantsById!)
+            return variant ? getVariantTitle(variant).toLowerCase() : ''
+          },
+          header: (props) => (
+            <Flex {...props.headerProps} paddingY={3} sizing="border">
+              <Headers.SortHeaderButton text={t('table-header.variant')} {...props} />
+            </Flex>
+          ),
+          cell: ({cellProps, datum}) => (
+            <Flex align="center" {...cellProps}>
+              <Box paddingX={2} style={{minWidth: 0}}>
+                {!datum.isLoading && (
+                  <VariantCell document={datum.document} variantsById={options.variantsById!} />
+                )}
+              </Box>
+            </Flex>
+          ),
+        } satisfies Column<BundleDocumentRow>,
+      ]
+    : []),
   {
     id: 'search',
     width: null,
-    style: {minWidth: 'min(50%, calc(100vw - 80px))', maxWidth: 'min(50%, calc(100vw - 80px))'},
+    // When search lives in the command lane, this column grows to fill (like Variants) so "Edited"
+    // pins to the right edge; otherwise it holds the header search input at a capped width.
+    style: options?.searchInCommandLane
+      ? {minWidth: 240}
+      : {minWidth: 'min(50%, calc(100vw - 80px))', maxWidth: 'min(50%, calc(100vw - 80px))'},
+    sorting: options?.searchInCommandLane ? true : undefined,
     sortTransform(value) {
       return (
         String(
@@ -205,9 +317,16 @@ export const getDocumentTableColumnDefs: (
         ).toLowerCase() || 0
       )
     },
-    header: (props) => (
-      <Headers.TableHeaderSearch {...props} placeholder={t('search-documents-placeholder')} />
-    ),
+    header: (props) =>
+      options?.searchInCommandLane ? (
+        // Search moved to the command lane; the header is a plain sortable "Document" label that
+        // grows to fill (flex) in both header and body.
+        <Flex {...props.headerProps} flex={1} paddingY={3} sizing="border">
+          <Headers.SortHeaderButton text={t('table-header.document')} {...props} />
+        </Flex>
+      ) : (
+        <Headers.TableHeaderSearch {...props} placeholder={t('search-documents-placeholder')} />
+      ),
     cell: ({cellProps, datum}) => (
       <Box {...cellProps} flex={1} padding={1} paddingRight={2} sizing="border">
         {datum.isPending || datum.isLoading ? (
@@ -224,15 +343,51 @@ export const getDocumentTableColumnDefs: (
     ),
   },
   {
+    // "Last edited" (relative time) comes BEFORE "Edited by" so this text column sits between the
+    // document preview's live-presence avatar and the edited-by avatar — otherwise the two round
+    // avatars would neighbour across the column boundary and read as one crowded cluster. Also reads
+    // naturally: "last edited 6 days ago, by …".
     id: 'document._updatedAt',
     sorting: true,
     width: 130,
     header: (props) => (
       <Flex {...props.headerProps} paddingY={3} sizing="border">
-        <Headers.SortHeaderButton text={t('table-header.edited')} {...props} />
+        <Headers.SortHeaderButton paddingLeft={2} text={t('table-header.last-edited')} {...props} />
       </Flex>
     ),
-    cell: (props) => <UpdatedAtCell {...props} releaseDocumentId={releaseId} />,
+    cell: ({cellProps, datum}) => (
+      <Flex
+        {...cellProps}
+        align="center"
+        paddingX={2}
+        paddingY={3}
+        style={{minWidth: 130}}
+        sizing="border"
+      >
+        {!datum.isLoading && datum.document._updatedAt && (
+          <Text muted size={1}>
+            <RelativeTime time={datum.document._updatedAt} useTemporalPhrase minimal />
+          </Text>
+        )}
+      </Flex>
+    ),
+  },
+  {
+    // Edited by — the last editor (person), its own named column so authorship reads distinctly
+    // from live presence. Plain-text header so it aligns with the avatar at the content edge (a
+    // sort button never lands its label on the same edge).
+    id: 'editedBy',
+    sorting: false,
+    width: 170,
+    style: {minWidth: 44, maxWidth: 170},
+    header: ({headerProps}) => (
+      <Flex {...headerProps} align="center" paddingX={2} paddingY={3} sizing="border">
+        <Text muted size={1} textOverflow="ellipsis" weight="medium">
+          {t('table-header.edited-by')}
+        </Text>
+      </Flex>
+    ),
+    cell: (props) => <EditedByReleaseCell {...props} releaseDocumentId={releaseId} />,
   },
 
   {
@@ -274,7 +429,16 @@ export const getDocumentTableColumnDefs: (
       )
 
       return (
-        <Flex {...cellProps} flex={1} padding={1} justify="center" align="center" sizing="border">
+        // In the command-lane layout only the Document column grows; keep validation fixed at its
+        // width (flex:1 here would split the free space with Document and misalign the header/body).
+        <Flex
+          {...cellProps}
+          flex={options?.searchInCommandLane ? undefined : 1}
+          padding={1}
+          justify="center"
+          align="center"
+          sizing="border"
+        >
           {datum.validation.hasError && (
             <Tooltip
               portal
@@ -301,13 +465,33 @@ export const getDocumentTableColumnDefs: (
               </Text>
             </Tooltip>
           )}
+          {/* Positive "ready" state so the column is a scannable ready-vs-error rail — an empty cell
+              would be ambiguous ("fine" or "not checked?"). */}
+          {!datum.validation.hasError && (
+            <Tooltip
+              portal
+              placement="bottom-end"
+              content={
+                <Text muted size={1}>
+                  <Box padding={1}>{t('document-validation.valid')}</Box>
+                </Text>
+              }
+            >
+              <Text muted size={1} data-testid={`validation-valid-${datum.document._id}`}>
+                <ToneIcon icon={CheckmarkCircleIcon} tone="positive" />
+              </Text>
+            </Tooltip>
+          )}
         </Flex>
       )
     },
   },
 ]
 
-function UpdatedAtCell({
+// "Edited by" cell: the last editor's avatar + name, resolved from the release document history.
+// Shares the EditedByAvatar presentation with the variant table so both read the same; presence
+// (who's viewing now) stays separate in the document preview.
+function EditedByReleaseCell({
   cellProps,
   datum,
   releaseDocumentId,
@@ -320,30 +504,11 @@ function UpdatedAtCell({
   const bundleId = getReleaseIdFromReleaseDocumentId(releaseDocumentId)
   const historyDocumentId =
     datum.isPending || document?._id?.endsWith('-pending') ? undefined : document?._id
-  const {documentHistory} = useReleaseHistory(historyDocumentId, bundleId, document?._rev)
+  const {documentHistory, loading} = useReleaseHistory(historyDocumentId, bundleId, document?._rev)
 
   return (
-    <Flex
-      {...cellProps}
-      align="center"
-      paddingX={2}
-      paddingY={3}
-      style={{minWidth: 130}}
-      sizing="border"
-    >
-      <Flex align="center" gap={2}>
-        {(isLoading || !documentHistory?.lastEditedBy) && <AvatarSkeleton $size={0} animated />}
-        {!isLoading && document._updatedAt && (
-          <>
-            {documentHistory?.lastEditedBy && (
-              <UserAvatar size={0} user={documentHistory.lastEditedBy} />
-            )}
-            <Text muted size={1}>
-              <RelativeTime time={document._updatedAt} useTemporalPhrase minimal />
-            </Text>
-          </>
-        )}
-      </Flex>
+    <Flex {...cellProps} align="center" paddingX={2} paddingY={3} sizing="border">
+      <EditedByAvatar loading={isLoading || loading} userId={documentHistory?.lastEditedBy} />
     </Flex>
   )
 }

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -1,5 +1,6 @@
 import {type ReleaseState} from '@sanity/client'
 import {CheckmarkCircleIcon} from '@sanity/icons/CheckmarkCircle'
+import {ClockIcon} from '@sanity/icons/Clock'
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
 import {Badge, Box, Card, Flex, Text} from '@sanity/ui'
 import {toString as pathToString} from '@sanity/util/paths'
@@ -467,7 +468,22 @@ export const getDocumentTableColumnDefs: (
           )}
           {/* Positive "ready" state so the column is a scannable ready-vs-error rail — an empty cell
               would be ambiguous ("fine" or "not checked?"). */}
-          {!datum.validation.hasError && (
+          {datum.validation.isValidating && !datum.validation.hasError && (
+            <Tooltip
+              portal
+              placement="bottom-end"
+              content={
+                <Text muted size={1}>
+                  <Box padding={1}>{t('dashboard.details.metadata.status-validating')}</Box>
+                </Text>
+              }
+            >
+              <Text muted size={1} data-testid={`validation-validating-${datum.document._id}`}>
+                <ToneIcon icon={ClockIcon} tone="default" />
+              </Text>
+            </Tooltip>
+          )}
+          {!datum.validation.hasError && !datum.validation.isValidating && (
             <Tooltip
               portal
               placement="bottom-end"

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentTableColumnDefs.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/__tests__/DocumentTableColumnDefs.test.tsx
@@ -1,17 +1,33 @@
 import {type Schema} from '@sanity/types'
 import {render, screen, waitFor} from '@testing-library/react'
+// oxlint-disable-next-line @sanity/i18n/no-i18next-import -- test stub for column defs
+import {type TFunction} from 'i18next'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {useSchema} from '../../../../../hooks/useSchema'
-import {DocumentType} from '../DocumentTableColumnDefs'
+import {type InjectedTableProps} from '../../../components/Table/types'
+import {type BundleDocumentRow} from '../../ReleaseSummary'
+import {DocumentType, getDocumentTableColumnDefs} from '../DocumentTableColumnDefs'
 
 vi.mock('../../../../../hooks/useSchema', () => ({useSchema: vi.fn()}))
 
 vi.mock('@sanity/ui', async (importOriginal) => ({
   ...(await importOriginal()),
-  Text: ({children, size: _size}: {children: React.ReactNode; size?: number}) => (
-    <span data-ui="Text">{children}</span>
+  Text: ({
+    children,
+    size: _size,
+    ...rest
+  }: {children: React.ReactNode; size?: number} & Record<string, unknown>) => (
+    <span data-ui="Text" {...rest}>
+      {children}
+    </span>
   ),
+  Flex: ({children}: {children: React.ReactNode}) => <div data-ui="Flex">{children}</div>,
+  Box: ({children}: {children: React.ReactNode}) => <div data-ui="Box">{children}</div>,
+}))
+
+vi.mock('../../../../../../ui-components/toneIcon/ToneIcon', () => ({
+  ToneIcon: () => <span data-testid="tone-icon" />,
 }))
 
 // Stub Tooltip so we can assert its presence without a portal/full DOM tree.
@@ -31,6 +47,66 @@ function buildMockSchema(typeTitle: string | undefined): Schema {
     get: vi.fn().mockReturnValue(typeTitle !== undefined ? {title: typeTitle} : undefined),
   } as unknown as Schema
 }
+
+const releaseDocumentId = '_.releases.active-release'
+const baseDatum: BundleDocumentRow = {
+  memoKey: 'doc-1',
+  document: {
+    _id: 'versions.doc-1',
+    _type: 'article',
+    _rev: 'rev-1',
+    _createdAt: '2023-10-01T08:00:00Z',
+    _updatedAt: '2023-10-01T09:00:00Z',
+    publishedDocumentExists: true,
+  },
+  validation: {
+    hasError: false,
+    isValidating: false,
+    validation: [],
+  },
+}
+
+function getValidationColumnCell() {
+  const t = ((key: string) => key) as TFunction<'releases'>
+  const columns = getDocumentTableColumnDefs(releaseDocumentId, 'active', t)
+  const validationColumn = columns.find((column) => column.id === 'validation')
+  if (!validationColumn || validationColumn.hidden || !validationColumn.cell) {
+    throw new Error('Expected validation column')
+  }
+  return validationColumn.cell
+}
+
+function renderValidationCell(datum: BundleDocumentRow) {
+  const ValidationCell = getValidationColumnCell()
+  const cellProps = {id: 'validation', style: {}} as InjectedTableProps
+
+  render(<ValidationCell datum={datum} cellProps={cellProps} sorting={false} />)
+}
+
+describe('validation column cell', () => {
+  it('shows a validating indicator while validation is in progress', () => {
+    renderValidationCell({
+      ...baseDatum,
+      validation: {hasError: false, isValidating: true, validation: []},
+    })
+
+    expect(
+      screen.getByTestId(`validation-validating-${baseDatum.document._id}`),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByTestId(`validation-valid-${baseDatum.document._id}`),
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows the ready checkmark only after validation completes without errors', () => {
+    renderValidationCell(baseDatum)
+
+    expect(screen.getByTestId(`validation-valid-${baseDatum.document._id}`)).toBeInTheDocument()
+    expect(
+      screen.queryByTestId(`validation-validating-${baseDatum.document._id}`),
+    ).not.toBeInTheDocument()
+  })
+})
 
 describe('DocumentType', () => {
   beforeEach(() => {

--- a/packages/sanity/src/core/releases/tool/detail/releaseBulkDocumentPermissions.ts
+++ b/packages/sanity/src/core/releases/tool/detail/releaseBulkDocumentPermissions.ts
@@ -1,0 +1,112 @@
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {combineLatest, firstValueFrom, of} from 'rxjs'
+import {map, startWith} from 'rxjs/operators'
+
+import {useClient} from '../../../hooks/useClient'
+import {useSchema} from '../../../hooks/useSchema'
+import {useGrantsStore} from '../../../store/datastores'
+import {
+  type DocumentPermission,
+  getDocumentPairPermissions,
+} from '../../../store/grants/documentPairPermissions'
+import {useCurrentUser} from '../../../store/user/hooks'
+import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../studioClient'
+import {getPublishedId, getVersionFromId} from '../../../util/draftUtils'
+import {type DocumentInRelease} from './types'
+
+type PermissionDeps = {
+  client: ReturnType<typeof useClient>
+  schema: ReturnType<typeof useSchema>
+  grantsStore: ReturnType<typeof useGrantsStore>
+  userId: string | undefined
+}
+
+function permissionOptionsForDocument(
+  doc: DocumentInRelease,
+  permission: DocumentPermission,
+  deps: PermissionDeps,
+) {
+  const publishedId = getPublishedId(doc.document._id)
+  const type = doc.document._type
+  const version = getVersionFromId(doc.document._id)
+
+  return {
+    client: deps.client,
+    schema: deps.schema,
+    grantsStore: deps.grantsStore,
+    id: publishedId,
+    type,
+    version,
+    permission,
+    userId: deps.userId,
+  }
+}
+
+/**
+ * Keeps only release documents the current user may act on with the given pair permission.
+ *
+ * @internal
+ */
+export async function filterDocumentsWithPairPermission(
+  documents: DocumentInRelease[],
+  permission: DocumentPermission,
+  deps: PermissionDeps,
+): Promise<DocumentInRelease[]> {
+  const permissionResults = await Promise.all(
+    documents.map(async (doc) => {
+      const {granted} = await firstValueFrom(
+        getDocumentPairPermissions(permissionOptionsForDocument(doc, permission, deps)),
+      )
+
+      return granted ? doc : null
+    }),
+  )
+
+  return permissionResults.filter((doc): doc is DocumentInRelease => doc !== null)
+}
+
+/**
+ * Whether any of the given release documents grant the pair permission (for bulk action affordances).
+ *
+ * @internal
+ */
+export function useAnyDocumentInReleaseHasPairPermission(
+  documents: DocumentInRelease[],
+  permission: DocumentPermission,
+): {granted: boolean; isLoading: boolean} {
+  const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+  const schema = useSchema()
+  const grantsStore = useGrantsStore()
+  const currentUser = useCurrentUser()
+
+  const deps = useMemo(
+    () => ({
+      client,
+      schema,
+      grantsStore,
+      userId: currentUser?.id,
+    }),
+    [client, schema, grantsStore, currentUser?.id],
+  )
+
+  const observable = useMemo(() => {
+    if (documents.length === 0) {
+      return of({granted: false, isLoading: false})
+    }
+
+    return combineLatest(
+      documents.map((doc) =>
+        getDocumentPairPermissions(permissionOptionsForDocument(doc, permission, deps)),
+      ),
+    ).pipe(
+      map((results) => ({
+        granted: results.some((result) => result.granted),
+        isLoading: false,
+      })),
+      startWith({granted: false, isLoading: true}),
+    )
+  }, [deps, documents, permission])
+
+  return useObservable(observable, {granted: false, isLoading: true})
+}

--- a/packages/sanity/src/core/releases/tool/detail/releaseBulkDocumentPermissions.ts
+++ b/packages/sanity/src/core/releases/tool/detail/releaseBulkDocumentPermissions.ts
@@ -13,7 +13,10 @@ import {
 import {useCurrentUser} from '../../../store/user/hooks'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../studioClient'
 import {getPublishedId, getVersionFromId} from '../../../util/draftUtils'
+import {isDocumentEligibleForUnpublish} from './releaseDocumentActions'
 import {type DocumentInRelease} from './types'
+
+export type ReleaseBulkAction = 'discard' | 'unpublish'
 
 type PermissionDeps = {
   client: ReturnType<typeof useClient>
@@ -67,11 +70,31 @@ export async function filterDocumentsWithPairPermission(
 }
 
 /**
- * Whether any of the given release documents grant the pair permission (for bulk action affordances).
+ * Keeps release documents that will be affected by a bulk discard or unpublish action.
  *
  * @internal
  */
-export function useAnyDocumentInReleaseHasPairPermission(
+export async function filterDocumentsForBulkAction(
+  documents: DocumentInRelease[],
+  action: ReleaseBulkAction,
+  deps: PermissionDeps,
+): Promise<DocumentInRelease[]> {
+  const permission = action === 'discard' ? 'discardVersion' : 'unpublish'
+  const permitted = await filterDocumentsWithPairPermission(documents, permission, deps)
+
+  if (action === 'unpublish') {
+    return permitted.filter(isDocumentEligibleForUnpublish)
+  }
+
+  return permitted
+}
+
+/**
+ * Whether every given release document grants the pair permission (for bulk action affordances).
+ *
+ * @internal
+ */
+export function useAllDocumentsInReleaseHavePairPermission(
   documents: DocumentInRelease[],
   permission: DocumentPermission,
 ): {granted: boolean; isLoading: boolean} {
@@ -101,7 +124,7 @@ export function useAnyDocumentInReleaseHasPairPermission(
       ),
     ).pipe(
       map((results) => ({
-        granted: results.some((result) => result.granted),
+        granted: documents.length > 0 && results.every((result) => result.granted),
         isLoading: false,
       })),
       startWith({granted: false, isLoading: true}),
@@ -109,4 +132,57 @@ export function useAnyDocumentInReleaseHasPairPermission(
   }, [deps, documents, permission])
 
   return useObservable(observable, {granted: false, isLoading: true})
+}
+
+/**
+ * Release documents that would be affected if the bulk action ran now (permissions + unpublish rules).
+ *
+ * @internal
+ */
+export function useReleaseBulkActionTargets(
+  documents: DocumentInRelease[],
+  action: ReleaseBulkAction,
+): {targets: DocumentInRelease[]; isLoading: boolean} {
+  const permission = action === 'discard' ? 'discardVersion' : 'unpublish'
+  const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+  const schema = useSchema()
+  const grantsStore = useGrantsStore()
+  const currentUser = useCurrentUser()
+
+  const deps = useMemo(
+    () => ({
+      client,
+      schema,
+      grantsStore,
+      userId: currentUser?.id,
+    }),
+    [client, schema, grantsStore, currentUser?.id],
+  )
+
+  const observable = useMemo(() => {
+    if (documents.length === 0) {
+      return of({targets: [] as DocumentInRelease[], isLoading: false})
+    }
+
+    return combineLatest(
+      documents.map((doc) =>
+        getDocumentPairPermissions(permissionOptionsForDocument(doc, permission, deps)).pipe(
+          map((result) => ({doc, granted: result.granted})),
+        ),
+      ),
+    ).pipe(
+      map((results) => {
+        let targets = results.filter((result) => result.granted).map((result) => result.doc)
+
+        if (action === 'unpublish') {
+          targets = targets.filter(isDocumentEligibleForUnpublish)
+        }
+
+        return {targets, isLoading: false}
+      }),
+      startWith({targets: [] as DocumentInRelease[], isLoading: true}),
+    )
+  }, [action, deps, documents, permission])
+
+  return useObservable(observable, {targets: [], isLoading: true})
 }

--- a/packages/sanity/src/core/releases/tool/detail/releaseDocumentActions.ts
+++ b/packages/sanity/src/core/releases/tool/detail/releaseDocumentActions.ts
@@ -97,6 +97,24 @@ export function getDocumentActionType(
   return 'added'
 }
 
+/**
+ * Whether a release row can be marked to unpublish (matches per-row menu gating, excluding
+ * permissions which are checked separately).
+ */
+export function isDocumentEligibleForUnpublish(
+  document: DocumentInRelease | BundleDocumentRow,
+): boolean {
+  if (!document.document || document.isPending) {
+    return false
+  }
+
+  if (!document.document.publishedDocumentExists) {
+    return false
+  }
+
+  return !isGoingToUnpublish(document.document)
+}
+
 export function getReleaseDocumentActionConfig(
   actionType: DocumentActionConfig['key'],
 ): DocumentActionConfig | undefined {

--- a/packages/sanity/src/core/releases/tool/detail/useCanEditRelease.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useCanEditRelease.ts
@@ -1,0 +1,40 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {useEffect, useRef, useState} from 'react'
+
+import {getIsReleaseOpen} from '../../components/dialog/TitleDescriptionForm'
+import {useReleaseOperations} from '../../store/useReleaseOperations'
+import {useReleasePermissions} from '../../store/useReleasePermissions'
+
+/**
+ * Whether the current user may edit a release's details (title/description). True only when the
+ * release is open (editing a published/archived release is not possible) and the permission guard
+ * on `updateRelease` passes. Shared by the display-surface edit affordance and the action rail so
+ * both gate on exactly the same condition.
+ *
+ * @internal
+ */
+export function useCanEditRelease(release: ReleaseDocument): boolean {
+  const {updateRelease} = useReleaseOperations()
+  const {checkWithPermissionGuard} = useReleasePermissions()
+  const [hasUpdatePermission, setHasUpdatePermission] = useState<boolean | null>(null)
+
+  const isReleaseOpen = getIsReleaseOpen(release)
+  const isMounted = useRef(false)
+
+  useEffect(() => {
+    isMounted.current = true
+
+    if (isReleaseOpen) {
+      // Editing is only possible on an open release, so only check permission when it's open.
+      void checkWithPermissionGuard(updateRelease, release).then((hasPermission) => {
+        if (isMounted.current) setHasUpdatePermission(hasPermission)
+      })
+    }
+
+    return () => {
+      isMounted.current = false
+    }
+  }, [checkWithPermissionGuard, isReleaseOpen, release, updateRelease])
+
+  return isReleaseOpen && Boolean(hasUpdatePermission)
+}

--- a/packages/sanity/src/core/store/translog/useDocumentLastEditedBy.ts
+++ b/packages/sanity/src/core/store/translog/useDocumentLastEditedBy.ts
@@ -1,0 +1,103 @@
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+
+import {useClient} from '../../hooks/useClient'
+import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
+import {getTransactionsLogs} from './getTransactionsLogs'
+
+// Cache the resolved editor per (documentId, revision) so re-renders and remounts don't refetch the
+// same transaction. Keyed on revision too, so a fresh edit invalidates the entry.
+const lastEditedByCache: Record<string, string | undefined> = Object.create(null)
+
+// The history/translog API 429s when many rows fetch at once (e.g. a large documents table mounting
+// all at once). Limit concurrency to the same ceiling the release document-history hook uses — 10
+// was the highest that ran without consistent 429s.
+let activeStreams = 0
+const pendingResolvers: Array<() => void> = []
+async function acquireSlot(maxConcurrent = 10): Promise<void> {
+  if (activeStreams >= maxConcurrent) {
+    await new Promise<void>((resolve) => pendingResolvers.push(resolve))
+  }
+  activeStreams += 1
+}
+function releaseSlot(): void {
+  activeStreams = Math.max(0, activeStreams - 1)
+  const next = pendingResolvers.shift()
+  if (next) next()
+}
+
+/**
+ * Resolves the user id of whoever last edited a document — the author of its most recent
+ * transaction. Reads a single transaction (`limit: 1, reverse: true`) from the transaction log,
+ * concurrency-limited so a table of rows doesn't stampede the history API, and cached per
+ * `(documentId, revision)`.
+ *
+ * Returns just the user id; render it with `UserAvatar` / `useUser` at the call site.
+ *
+ * @internal
+ */
+export function useDocumentLastEditedBy(
+  documentId: string | undefined,
+  revision?: string,
+): {lastEditedBy: string | undefined; loading: boolean} {
+  const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
+  const cacheKey = documentId ? `${documentId}-${revision ?? ''}` : ''
+  const cachedInitial = cacheKey ? lastEditedByCache[cacheKey] : undefined
+  const [lastEditedBy, setLastEditedBy] = useState<string | undefined>(cachedInitial)
+  const [loading, setLoading] = useState<boolean>(
+    Boolean(documentId) && !(cacheKey in lastEditedByCache),
+  )
+  const cancelledRef = useRef(false)
+
+  const fetchLastEditor = useCallback(async (): Promise<void> => {
+    if (!documentId) {
+      setLastEditedBy(undefined)
+      setLoading(false)
+      return
+    }
+
+    if (cacheKey in lastEditedByCache) {
+      setLastEditedBy(lastEditedByCache[cacheKey])
+      setLoading(false)
+      return
+    }
+
+    setLoading(true)
+    await acquireSlot()
+    // run().catch().finally() rather than try/catch/finally because the React Compiler does not yet
+    // fully support the latter — matches the sibling release-history hook.
+    const run = async () => {
+      const transactions = await getTransactionsLogs(client, documentId, {
+        tag: 'sanity.studio.document.last-edited-by',
+        effectFormat: 'mendoza',
+        excludeContent: true,
+        includeIdentifiedDocumentsOnly: true,
+        limit: 1,
+        reverse: true,
+      })
+      if (cancelledRef.current) return
+      const author = transactions[0]?.author
+      lastEditedByCache[cacheKey] = author
+      setLastEditedBy(author)
+    }
+    await run()
+      .catch((error) => {
+        console.error('Failed to fetch document last-editor history:', error)
+        if (!cancelledRef.current) setLastEditedBy(undefined)
+      })
+      .finally(() => {
+        releaseSlot()
+        if (!cancelledRef.current) setLoading(false)
+      })
+  }, [cacheKey, client, documentId])
+
+  useEffect(() => {
+    cancelledRef.current = false
+    // oxlint-disable-next-line react/react-compiler
+    void fetchLastEditor()
+    return () => {
+      cancelledRef.current = true
+    }
+  }, [fetchLastEditor])
+
+  return useMemo(() => ({lastEditedBy, loading}), [lastEditedBy, loading])
+}


### PR DESCRIPTION
## TL;DR

**Problem.** The release and variant definition detail pages grew independently — different headers, different tables, no shared building blocks — so they read as different products and duplicated layout/table logic.

**Solution.** Introduce a shared **detail spine** and a shared **document table**, and adopt them on the **Releases detail** page as the first consumer. This defines the pattern the variant surfaces (in the following PRs) build on.

All behind `beta.variants`; production is unchanged.

## What's in it

- **Shared detail spine** (`core/components/detailLayout/`): `DetailBackButton`, `DetailIdentity`, `DetailPropertiesPanel`, `DetailActionRail`.
- **Shared `DocumentTable`** (`releases/tool/components/Table/`): command-lane search, checkbox selection + bulk toolbar, a `filterTabs` slot (with `filterTabsScroll` / `commandLaneMinHeight` options), Edited-by / Last-edited / validation columns, and semibold table headers.
- **Shared cell + hook**: `documentTable/EditedByCell`, `store/translog/useDocumentLastEditedBy`.
- **Releases detail adopts them**: top action rail (Run release + `⋯`), a properties panel, Edited by / Last edited / validation columns, bulk Discard/Unpublish; the footer is dropped in beta; custom actions can carry a semantic `tone`.

## Scope & safety

- Behind `beta.variants` — production Releases detail keeps its current footer + inline edit.
- Full releases test suite green (48 files / 529 tests), type-clean, oxlint/oxfmt clean.

## For reviewers

First of a stacked set on one foundation: **PR 13780** adopts it on the variant definition detail page; **PR 13781** on the variants overview. A combined, clickable preview of all three lives on the `preview/variant-release-detail` branch (Vercel test-studio).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, flag-gated UI refactor on the releases detail path; bulk discard/unpublish reuses version operations and document-pair permissions, so partial failures and permission edge cases matter even though production is unchanged without the flag.
> 
> **Overview**
> Adds reusable **detail layout** pieces (`DetailBackButton`, `DetailIdentity`, `DetailPropertiesPanel`, `DetailActionRail`) and a **`DocumentTable`** wrapper (command-lane search/filters, optional row selection + bulk toolbar, shared column patterns). Releases detail is the first adopter when **`beta.variants`** is on.
> 
> **Releases detail (beta):** Top **action rail** (Edit details → dialog, primary CTA, overflow menu) replaces the footer action cluster; title/description become **read-only** with metadata in a properties panel; **Activity** is a right overlay instead of pushing layout; document table gains **Last edited** / **Edited by**, optional **Variant** column, validation status rail, and **bulk Discard / Unpublish** with permission-aware confirm dialogs. Production behavior stays on the old inline edit, header actions, footer, and legacy table until the flag is enabled.
> 
> Smaller table polish (header weight, row style merge, `borderSpacing`) and release menu **tones** for archive/delete/custom actions; i18n for new strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cb15376df4eb03f2bad20ab98cc75c12829cce0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->