### PR TITLE
fix(test-config): pin locale to en-US for deterministic test runs

### DIFF
--- a/packages/@repo/test-config/vitest/index.mjs
+++ b/packages/@repo/test-config/vitest/index.mjs
@@ -23,6 +23,11 @@ export function defineConfig(config) {
     ...config,
     test: {
       ...config?.test,
+      // Pin the locale so date/number formatting is deterministic regardless of the developer's OS
+      // locale (en-CA renders dates as 2023-10-10, en-US as 10/10/2023), matching the fixed TZ. ICU
+      // resolves its default locale once at worker startup and ignores later changes, so it must be
+      // set via env; the forks pool spawns workers with this env so ICU picks it up.
+      env: {LC_ALL: 'en_US.UTF-8', LANG: 'en_US.UTF-8', ...config?.test?.env},
       // Disable console interception to prevent `EnvironmentTeardownError: Closing rpc while
       // "onUserConsoleLog" was pending` when async emissions (e.g. RxJS catchError logs) fire
       // after a test's body resolves but before the worker finishes teardown. Tradeoff:


### PR DESCRIPTION
### Description

Local test runs fail on machines whose OS locale is not en-US, even though CI passes. Code that formats a date or number without an explicit locale falls back to the host locale, so an assertion expecting `10/10/2023` fails on en-CA (`2023-10-10`) or de-DE (`10.10.2023`); CI passes only because its runners resolve to en-US. Reported in SAPP-4078.

This PR pins the test-run locale to en-US in the shared `@repo/test-config` vitest config, so every project's workers format dates and numbers deterministically regardless of the contributor's machine.

### What to review

- The pin is set via `env` rather than at runtime because ICU resolves its default locale once at worker startup and ignores later changes; it relies on the forks pool spawning workers with that env. It mirrors the existing fixed `TZ` in the sanity global setup.

### Testing

- Ran the reported suite (`ReleasesNav`) and other date-sensitive suites under en_CA, de_DE, nb_NO, ja_JP, C, and an unset locale - all pass.
- Confirmed the pin is the controlling lever by editing the shared config to en_CA and re-running `ReleasesNav`: the two scheduled-release-date assertions fail (dates render as `2023-10-10` rather than a slash date) and reverting to en_US restores them to green.
- Full suite green: 553 test files, 5173 tests.

### Notes for release

N/A

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only shared config change with no production or security impact; consumers can still override via `test.env`.
> 
> **Overview**
> **Pins Vitest worker locale to en-US** in the shared `@repo/test-config` `defineConfig`, so date/number assertions that rely on the default locale match CI and pass on contributors’ machines (e.g. en-CA, de-DE).
> 
> Workers get `LC_ALL` and `LANG` set to `en_US.UTF-8` via `test.env` (before any runtime locale APIs), with `...config?.test?.env` so individual projects can still override. This aligns with the existing fixed timezone approach for deterministic tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c05a2bb7cdef2152003c88fd9a5f337851f63651. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
