### PR TITLE
feat(core): variant definitions overview redesign

### DIFF
--- a/e2e/tests/variants/variantTool.spec.ts
+++ b/e2e/tests/variants/variantTool.spec.ts
@@ -152,11 +152,11 @@ async function openVariantsTool(page: Page): Promise<void> {
   // The heading renders before the overview has settled its data subscriptions.
   // Wait for the create button to be interactive so the first dialog-open click
   // is not dispatched while the page is still mounting and silently dropped.
-  await expect(page.getByRole('button', {name: 'Create variant definition'}).first()).toBeEnabled()
+  await expect(page.getByRole('button', {name: 'New variant definition'}).first()).toBeEnabled()
 }
 
 async function openCreateVariantDialog(page: Page) {
-  const createVariantButton = page.getByRole('button', {name: 'Create variant definition'}).first()
+  const createVariantButton = page.getByRole('button', {name: 'New variant definition'}).first()
   const dialog = page.getByRole('dialog', {name: 'Create variant definition'})
 
   // Under parallel CI load the studio occasionally drops the first click while it

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -20,8 +20,6 @@ const variantsLocaleStrings = {
   'navbar.clear': 'Clear',
   /** Tooltip for clearing the selected variant. */
   'navbar.variant.clear': 'Clear variant selection',
-  /** Label for the Variants overview create action. */
-  'overview.action.create-variant': 'Create variant definition',
   /** Label for the Variants overview primary create action (mirrors "New release"). */
   'overview.action.new-variant': 'New variant definition',
   /** Label for the Variants overview row edit action. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -74,9 +74,21 @@ const variantsLocaleStrings = {
   /** Note about selected definitions kept because they contain documents (plural). */
   'overview.bulk.delete-dialog.kept_other':
     '{{count}} selected definitions contain documents and will be kept.',
+  /** Note about selected definitions kept while document count is loading or failed (singular). */
+  'overview.bulk.delete-dialog.kept-unresolved_one':
+    '{{count}} selected definition has an unknown document count and will be kept.',
+  /** Note about selected definitions kept while document count is loading or failed (plural). */
+  'overview.bulk.delete-dialog.kept-unresolved_other':
+    '{{count}} selected definitions have unknown document counts and will be kept.',
   /** Bulk delete dialog body when nothing can be deleted (all selected hold documents). */
   'overview.bulk.delete-dialog.none':
     'All selected definitions contain documents, so none can be deleted. Remove their documents first.',
+  /** Bulk delete dialog body when nothing can be deleted (document counts unknown). */
+  'overview.bulk.delete-dialog.none-unresolved':
+    'Document counts are still loading or unavailable for the selected definitions, so none can be deleted yet.',
+  /** Bulk delete dialog body when nothing can be deleted (mix of documents and unknown counts). */
+  'overview.bulk.delete-dialog.none-mixed':
+    'None of the selected definitions can be deleted. Remove documents first or wait for document counts to load.',
   /** Toast shown after a successful bulk delete (singular). */
   'overview.bulk.delete-toast.success_one': 'Deleted {{count}} variant definition',
   /** Toast shown after a successful bulk delete (plural). */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -99,6 +99,8 @@ const variantsLocaleStrings = {
   'overview.filter.no-dimensions': 'No dimensions',
   /** Hint in the add-filter menu's value pane before a dimension is chosen. */
   'overview.filter.pick-dimension-hint': 'Select a dimension to see its values',
+  /** Shown in the table when active condition filters hide every variant definition. */
+  'overview.filter.no-matching-definitions': 'No variant definitions match the active filters',
   /** Column header for the variant title column in the overview table. */
   'overview.table.variant': 'Variant definition',
   /** Column header for the documents count column in the overview table. */

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantMenuButton.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantMenuButton.test.tsx
@@ -46,6 +46,33 @@ describe('VariantMenuButton', () => {
     return result
   }
 
+  it('opens the edit dialog when edit is selected', async () => {
+    const user = userEvent.setup()
+
+    await renderMenuButton({documentCount: 0})
+
+    await user.click(screen.getByRole('button'))
+    await user.click(await screen.findByText('Edit variant definition'))
+
+    expect(await screen.findByTestId('save-variant-button')).toBeInTheDocument()
+    expect(variantOperationsMock.updateVariant).not.toHaveBeenCalled()
+  })
+
+  it('updates the variant when the edit dialog is submitted', async () => {
+    const user = userEvent.setup()
+    variantOperationsMock.updateVariant.mockResolvedValue(undefined)
+
+    await renderMenuButton({documentCount: 0})
+
+    await user.click(screen.getByRole('button'))
+    await user.click(await screen.findByText('Edit variant definition'))
+    await user.click(await screen.findByTestId('save-variant-button'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.updateVariant).toHaveBeenCalled()
+    })
+  })
+
   it('deletes the variant when delete is selected', async () => {
     const user = userEvent.setup()
 

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -328,12 +328,17 @@ describe('VariantsOverview', () => {
     await waitFor(() => expect(screen.getAllByTestId('table-row')).toHaveLength(2))
 
     await user.click(screen.getByRole('button', {name: 'Add filter'}))
-    await user.click(screen.getByRole('button', {name: 'Audience'}))
-    await user.click(screen.getByRole('button', {name: 'alpha'}))
+    const filterPopover = (await screen.findByPlaceholderText('Find a dimension…')).closest(
+      '[data-ui="Popover"]',
+    )
+    if (!filterPopover) throw new Error('Filter popover not found')
+    const filterMenu = within(filterPopover as HTMLElement)
 
-    await user.click(screen.getByRole('button', {name: 'Add filter'}))
-    await user.click(screen.getByRole('button', {name: 'Locale'}))
-    await user.click(screen.getByRole('button', {name: 'nb-NO'}))
+    await user.click(filterMenu.getByText('Audience'))
+    await user.click(filterMenu.getByRole('button', {name: 'alpha'}))
+
+    await user.click(filterMenu.getByText('Locale'))
+    await user.click(filterMenu.getByRole('button', {name: 'nb-NO'}))
 
     await waitFor(() => {
       expect(screen.queryByTestId('table-row')).not.toBeInTheDocument()

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -319,6 +319,32 @@ describe('VariantsOverview', () => {
     expect(variantOperationsMock.deleteVariant).toHaveBeenCalledTimes(1)
   })
 
+  it('shows filter empty state when condition filters exclude every definition', async () => {
+    setVariants([variantAlphaAudience, variantNorwegianMarket])
+    const user = userEvent.setup()
+
+    await renderOverview()
+
+    await waitFor(() => expect(screen.getAllByTestId('table-row')).toHaveLength(2))
+
+    await user.click(screen.getByRole('button', {name: 'Add filter'}))
+    await user.click(screen.getByRole('button', {name: 'Audience'}))
+    await user.click(screen.getByRole('button', {name: 'alpha'}))
+
+    await user.click(screen.getByRole('button', {name: 'Add filter'}))
+    await user.click(screen.getByRole('button', {name: 'Locale'}))
+    await user.click(screen.getByRole('button', {name: 'nb-NO'}))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('table-row')).not.toBeInTheDocument()
+    })
+
+    expect(screen.getByTestId('variants-filter-empty-state')).toHaveTextContent(
+      'No variant definitions match the active filters',
+    )
+    expect(screen.queryByTestId('variants-empty-state')).not.toBeInTheDocument()
+  })
+
   it('shows empty state when there are no variants', async () => {
     variantsMock.data = []
 

--- a/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
+++ b/packages/sanity/src/core/variants/tool/__tests__/VariantsOverview.test.tsx
@@ -11,18 +11,6 @@ import {type EditableSystemVariant, type SystemVariant} from '../../types'
 import {VariantsOverview} from '../overview/VariantsOverview'
 import {getVariantId} from '../util'
 
-const mockedSetVariant = vi.fn()
-
-vi.mock('../../../perspective/useSetVariant', () => ({
-  useSetVariant: vi.fn(() => mockedSetVariant),
-}))
-
-vi.mock('../../../perspective/usePerspective', () => ({
-  usePerspective: vi.fn(() => ({
-    selectedVariant: undefined,
-  })),
-}))
-
 const mockNavigate = vi.fn()
 
 const routerState = vi.hoisted(() => ({
@@ -111,7 +99,6 @@ describe('VariantsOverview', () => {
     documentCountsMock.loading = true
     documentCountsMock.error = null
     mockNavigate.mockClear()
-    mockedSetVariant.mockClear()
     variantOperationsMock.createVariant.mockReset()
     variantOperationsMock.deleteVariant.mockReset()
     variantOperationsMock.createVariant.mockImplementation(
@@ -134,7 +121,10 @@ describe('VariantsOverview', () => {
       resources: [variantsUsEnglishLocaleBundle],
     })
     const view = render(<VariantsOverview />, {wrapper})
-    await screen.findByPlaceholderText('Search variant definitions…', {}, {timeout: 5000})
+    // Wait on the always-present page description rather than the search box (search now lives in the
+    // shared DocumentTable command lane, which only renders once there are rows) — and not on the
+    // title, which the empty state duplicates as its own h1.
+    await screen.findByText(/Manage variant definitions/, {}, {timeout: 5000})
     return view
   }
 
@@ -154,7 +144,7 @@ describe('VariantsOverview', () => {
         'Manage variant definitions that control how content is personalized for different audiences, locales, and segments.',
       ),
     ).toBeInTheDocument()
-    expect(screen.getByRole('button', {name: 'Create variant definition'})).toBeInTheDocument()
+    expect(screen.getByRole('button', {name: 'New variant definition'})).toBeInTheDocument()
     expect(screen.getByPlaceholderText('Search variant definitions…')).toBeInTheDocument()
   })
 
@@ -253,19 +243,6 @@ describe('VariantsOverview', () => {
     })
   })
 
-  it('pins a variant from the overview table', async () => {
-    setVariants([variantAlphaAudience])
-    const user = userEvent.setup()
-
-    await renderOverview()
-
-    await waitFor(() => expect(screen.getAllByTestId('table-row')).toHaveLength(1))
-
-    await user.click(screen.getByTestId('pin-variant-button'))
-
-    expect(mockedSetVariant).toHaveBeenCalledWith({variantId: variantAlphaAudience._id})
-  })
-
   it('deletes a variant from the row actions menu', async () => {
     setVariants([variantAlphaAudience])
     documentCountsMock.data = {[variantAlphaAudience._id]: 0}
@@ -313,6 +290,35 @@ describe('VariantsOverview', () => {
     expect(variantOperationsMock.deleteVariant).not.toHaveBeenCalled()
   })
 
+  it('bulk-deletes only the selected definitions that have no documents', async () => {
+    setVariants([variantAlphaAudience, variantNorwegianMarket])
+    documentCountsMock.data = {
+      [variantAlphaAudience._id]: 0,
+      [variantNorwegianMarket._id]: 2,
+    }
+    documentCountsMock.loading = false
+    const user = userEvent.setup()
+
+    await renderOverview()
+
+    await waitFor(() => expect(screen.getAllByTestId('table-row')).toHaveLength(2))
+
+    // Select every row, then trigger the bulk delete.
+    await user.click(screen.getByTestId('variant-bulk-select-all'))
+    await user.click(await screen.findByTestId('variant-bulk-delete'))
+
+    // The confirmation dialog opens; confirm it.
+    await screen.findByTestId('variant-bulk-delete-dialog')
+    await user.click(await screen.findByTestId('confirm-button'))
+
+    // The empty definition is deleted; the one with documents is kept.
+    await waitFor(() => {
+      expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(variantAlphaAudience._id)
+    })
+    expect(variantOperationsMock.deleteVariant).not.toHaveBeenCalledWith(variantNorwegianMarket._id)
+    expect(variantOperationsMock.deleteVariant).toHaveBeenCalledTimes(1)
+  })
+
   it('shows empty state when there are no variants', async () => {
     variantsMock.data = []
 
@@ -326,7 +332,7 @@ describe('VariantsOverview', () => {
     expect(screen.getByTestId('no-variants-info-text')).toHaveTextContent('Variant definitions')
     const emptyState = screen.getByTestId('variants-empty-state')
     expect(
-      within(emptyState).getByRole('button', {name: 'Create variant definition'}),
+      within(emptyState).getByRole('button', {name: 'New variant definition'}),
     ).toBeInTheDocument()
     expect(within(emptyState).getByRole('link', {name: 'Documentation'})).toHaveAttribute(
       'href',
@@ -350,7 +356,7 @@ describe('VariantsOverview', () => {
 
     await renderOverview()
 
-    await user.click(screen.getAllByRole('button', {name: 'Create variant definition'})[0]!)
+    await user.click(screen.getAllByRole('button', {name: 'New variant definition'})[0]!)
 
     expect(screen.getByRole('dialog', {name: 'Create variant definition'})).toBeInTheDocument()
 

--- a/packages/sanity/src/core/variants/tool/__tests__/util.test.ts
+++ b/packages/sanity/src/core/variants/tool/__tests__/util.test.ts
@@ -2,7 +2,9 @@ import {describe, expect, it} from 'vitest'
 
 import {createMockVariant} from '../../__fixtures__/createMockVariant'
 import {VARIANT_DOCUMENTS_PATH} from '../../store/constants'
+import {type SystemVariant} from '../../types'
 import {
+  buildConditionFacets,
   decodeVariantIdFromRoute,
   filterVariantsForSearch,
   getVariantConditionsText,
@@ -12,6 +14,7 @@ import {
   getVariantTitle,
   isPublishedBundleId,
   isReleaseBundle,
+  variantMatchesConditionFilters,
 } from '../util'
 
 describe('variants tool utilities', () => {
@@ -115,5 +118,48 @@ describe('variants tool utilities', () => {
     expect(isReleaseBundle('published')).toBe(false)
     expect(isReleaseBundle('drafts')).toBe(false)
     expect(isReleaseBundle('rASAP')).toBe(true)
+  })
+})
+
+describe('buildConditionFacets', () => {
+  it('derives one sorted facet per condition key with its distinct values', () => {
+    const variants: SystemVariant[] = [
+      {...createMockVariant('a'), conditions: {market: 'london', brand: 'brand-z'}},
+      {...createMockVariant('b'), conditions: {market: 'plymouth', brand: 'brand-z'}},
+      {...createMockVariant('c'), conditions: {market: 'london'}},
+    ]
+
+    expect(buildConditionFacets(variants)).toEqual([
+      {key: 'brand', values: ['brand-z']},
+      {key: 'market', values: ['london', 'plymouth']},
+    ])
+  })
+
+  it('returns an empty list when no variant carries conditions', () => {
+    const variants: SystemVariant[] = [{...createMockVariant('a'), conditions: {}}]
+    expect(buildConditionFacets(variants)).toEqual([])
+  })
+})
+
+describe('variantMatchesConditionFilters', () => {
+  const variant: SystemVariant = {
+    ...createMockVariant('a'),
+    conditions: {market: 'london', segment: 'VIP'},
+  }
+
+  it('matches when there are no active filters', () => {
+    expect(variantMatchesConditionFilters(variant, {})).toBe(true)
+    expect(variantMatchesConditionFilters(variant, {market: []})).toBe(true)
+  })
+
+  it('ORs values within a dimension and ANDs across dimensions', () => {
+    expect(variantMatchesConditionFilters(variant, {market: ['london', 'plymouth']})).toBe(true)
+    expect(variantMatchesConditionFilters(variant, {market: ['london'], segment: ['VIP']})).toBe(
+      true,
+    )
+    expect(variantMatchesConditionFilters(variant, {market: ['london'], segment: ['New']})).toBe(
+      false,
+    )
+    expect(variantMatchesConditionFilters(variant, {brand: ['brand-z']})).toBe(false)
   })
 })

--- a/packages/sanity/src/core/variants/tool/__tests__/util.test.ts
+++ b/packages/sanity/src/core/variants/tool/__tests__/util.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it} from 'vitest'
 
 import {createMockVariant} from '../../__fixtures__/createMockVariant'
+import {variantAlphaAudience, variantNorwegianMarket} from '../../__fixtures__/variants.fixture'
 import {VARIANT_DOCUMENTS_PATH} from '../../store/constants'
 import {type SystemVariant} from '../../types'
 import {
@@ -14,6 +15,7 @@ import {
   getVariantTitle,
   isPublishedBundleId,
   isReleaseBundle,
+  resolveBulkDeleteVariants,
   variantMatchesConditionFilters,
 } from '../util'
 
@@ -161,5 +163,31 @@ describe('variantMatchesConditionFilters', () => {
       false,
     )
     expect(variantMatchesConditionFilters(variant, {brand: ['brand-z']})).toBe(false)
+  })
+})
+
+describe('resolveBulkDeleteVariants', () => {
+  it('keeps snapshotted keys when condition filters would hide them from table rows', () => {
+    const keys = [variantAlphaAudience._id, variantNorwegianMarket._id]
+    const variants = [variantAlphaAudience, variantNorwegianMarket]
+    const localeNbNoOnly = {locale: ['nb-NO']}
+
+    const filteredRows = variants.filter((variant) =>
+      variantMatchesConditionFilters(variant, localeNbNoOnly),
+    )
+    expect(filteredRows.map((variant) => variant._id)).toEqual([variantNorwegianMarket._id])
+
+    const rowsBasedSelection = filteredRows.filter((variant) => keys.includes(variant._id))
+    expect(rowsBasedSelection).toHaveLength(1)
+
+    const resolved = resolveBulkDeleteVariants(
+      keys,
+      variants,
+      {[variantAlphaAudience._id]: 0, [variantNorwegianMarket._id]: 2},
+      null,
+    )
+    expect(resolved.map((variant) => variant._id)).toEqual(keys)
+    expect(resolved[0]?.documentCount).toBe(0)
+    expect(resolved[1]?.documentCount).toBe(2)
   })
 })

--- a/packages/sanity/src/core/variants/tool/overview/VariantBulkDeleteDialog.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantBulkDeleteDialog.tsx
@@ -33,20 +33,41 @@ export function VariantBulkDeleteDialog({
   const {deleteVariant} = useVariantOperations()
   const [isProcessing, setIsProcessing] = useState(false)
 
-  // Deletable = definitely empty (count resolved to 0). Anything with documents — or whose count
-  // hasn't resolved yet — is kept, so we never delete a definition we can't confirm is empty.
-  const {deletable, kept} = useMemo(() => {
+  // Deletable = definitely empty (count resolved to 0). Definitions with documents, or whose count
+  // hasn't resolved yet, are kept so we never delete a definition we can't confirm is empty.
+  const {deletable, keptWithDocuments, keptUnresolved} = useMemo(() => {
     const deletableVariants: TableVariant[] = []
-    const keptVariants: TableVariant[] = []
+    const withDocuments: TableVariant[] = []
+    const unresolved: TableVariant[] = []
     for (const variant of variants) {
-      if (variant.documentCount === 0) deletableVariants.push(variant)
-      else keptVariants.push(variant)
+      if (variant.documentCount === 0) {
+        deletableVariants.push(variant)
+      } else if (typeof variant.documentCount === 'number' && variant.documentCount > 0) {
+        withDocuments.push(variant)
+      } else {
+        unresolved.push(variant)
+      }
     }
-    return {deletable: deletableVariants, kept: keptVariants}
+    return {
+      deletable: deletableVariants,
+      keptWithDocuments: withDocuments,
+      keptUnresolved: unresolved,
+    }
   }, [variants])
 
   const deletableCount = deletable.length
-  const keptCount = kept.length
+  const keptWithDocumentsCount = keptWithDocuments.length
+  const keptUnresolvedCount = keptUnresolved.length
+
+  const noneMessageKey = useMemo(() => {
+    if (keptUnresolvedCount > 0 && keptWithDocumentsCount === 0) {
+      return 'overview.bulk.delete-dialog.none-unresolved' as const
+    }
+    if (keptWithDocumentsCount > 0 && keptUnresolvedCount === 0) {
+      return 'overview.bulk.delete-dialog.none' as const
+    }
+    return 'overview.bulk.delete-dialog.none-mixed' as const
+  }, [keptUnresolvedCount, keptWithDocumentsCount])
 
   const handleConfirm = useCallback(async () => {
     if (deletableCount === 0) return
@@ -103,11 +124,16 @@ export function VariantBulkDeleteDialog({
               {t('overview.bulk.delete-dialog.description', {count: deletableCount})}
             </Text>
           ) : (
-            <Text size={1}>{t('overview.bulk.delete-dialog.none')}</Text>
+            <Text size={1}>{t(noneMessageKey)}</Text>
           )}
-          {keptCount > 0 && (
+          {keptWithDocumentsCount > 0 && (
             <Text muted size={1}>
-              {t('overview.bulk.delete-dialog.kept', {count: keptCount})}
+              {t('overview.bulk.delete-dialog.kept', {count: keptWithDocumentsCount})}
+            </Text>
+          )}
+          {keptUnresolvedCount > 0 && (
+            <Text muted size={1}>
+              {t('overview.bulk.delete-dialog.kept-unresolved', {count: keptUnresolvedCount})}
             </Text>
           )}
           {deletableCount > 0 && (

--- a/packages/sanity/src/core/variants/tool/overview/VariantBulkDeleteDialog.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantBulkDeleteDialog.tsx
@@ -72,8 +72,10 @@ export function VariantBulkDeleteDialog({
     }
 
     setIsProcessing(false)
-    onDeleted()
-    onClose()
+    if (succeeded > 0) {
+      onDeleted()
+      onClose()
+    }
   }, [deletable, deletableCount, deleteVariant, onClose, onDeleted, t, toast])
 
   return (

--- a/packages/sanity/src/core/variants/tool/overview/VariantBulkDeleteDialog.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantBulkDeleteDialog.tsx
@@ -1,0 +1,124 @@
+import {Box, Stack, Text, useToast} from '@sanity/ui'
+import {useCallback, useMemo, useState} from 'react'
+
+import {Dialog} from '../../../../ui-components/dialog/Dialog'
+import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {variantsLocaleNamespace} from '../../i18n'
+import {useVariantOperations} from '../../store/useVariantOperations'
+import {getVariantTitle} from '../util'
+import {type TableVariant} from './VariantsOverviewColumnDefs'
+
+/**
+ * Confirmation dialog for bulk-deleting variant definitions from the overview.
+ *
+ * A definition can only be deleted when it holds no documents (the same guard the single-row delete
+ * enforces). Rather than block the whole action when the selection is mixed, this partitions the
+ * selection and is explicit about the blast radius: it deletes the empty definitions and clearly
+ * reports the doc-bearing ones it is keeping, so the count in the header never hides what actually
+ * happens.
+ *
+ * @internal
+ */
+export function VariantBulkDeleteDialog({
+  variants,
+  onClose,
+  onDeleted,
+}: {
+  variants: TableVariant[]
+  onClose: () => void
+  onDeleted: () => void
+}): React.JSX.Element {
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const toast = useToast()
+  const {deleteVariant} = useVariantOperations()
+  const [isProcessing, setIsProcessing] = useState(false)
+
+  // Deletable = definitely empty (count resolved to 0). Anything with documents — or whose count
+  // hasn't resolved yet — is kept, so we never delete a definition we can't confirm is empty.
+  const {deletable, kept} = useMemo(() => {
+    const deletableVariants: TableVariant[] = []
+    const keptVariants: TableVariant[] = []
+    for (const variant of variants) {
+      if (variant.documentCount === 0) deletableVariants.push(variant)
+      else keptVariants.push(variant)
+    }
+    return {deletable: deletableVariants, kept: keptVariants}
+  }, [variants])
+
+  const deletableCount = deletable.length
+  const keptCount = kept.length
+
+  const handleConfirm = useCallback(async () => {
+    if (deletableCount === 0) return
+    setIsProcessing(true)
+
+    const results = await Promise.allSettled(deletable.map((variant) => deleteVariant(variant._id)))
+    const failed = results.filter((result) => result.status === 'rejected').length
+    const succeeded = deletableCount - failed
+
+    if (succeeded > 0) {
+      toast.push({
+        closable: true,
+        status: 'success',
+        title: t('overview.bulk.delete-toast.success', {count: succeeded}),
+      })
+    }
+    if (failed > 0) {
+      toast.push({
+        closable: true,
+        status: 'error',
+        title: t('overview.bulk.delete-toast.error'),
+      })
+    }
+
+    setIsProcessing(false)
+    onDeleted()
+    onClose()
+  }, [deletable, deletableCount, deleteVariant, onClose, onDeleted, t, toast])
+
+  return (
+    <Dialog
+      data-testid="variant-bulk-delete-dialog"
+      footer={{
+        cancelButton: {disabled: isProcessing},
+        confirmButton: {
+          text: t('overview.bulk.delete-dialog.confirm'),
+          tone: 'critical',
+          onClick: handleConfirm,
+          loading: isProcessing,
+          disabled: isProcessing || deletableCount === 0,
+        },
+      }}
+      header={t('overview.bulk.delete-dialog.header')}
+      id="variant-bulk-delete-dialog"
+      onClose={() => !isProcessing && onClose()}
+      width={1}
+    >
+      <Box padding={4}>
+        <Stack space={4}>
+          {deletableCount > 0 ? (
+            <Text size={1}>
+              {t('overview.bulk.delete-dialog.description', {count: deletableCount})}
+            </Text>
+          ) : (
+            <Text size={1}>{t('overview.bulk.delete-dialog.none')}</Text>
+          )}
+          {keptCount > 0 && (
+            <Text muted size={1}>
+              {t('overview.bulk.delete-dialog.kept', {count: keptCount})}
+            </Text>
+          )}
+          {deletableCount > 0 && (
+            <Stack as="ul" space={2}>
+              {deletable.map((variant) => (
+                <Text as="li" key={variant._id} size={1} textOverflow="ellipsis">
+                  {getVariantTitle(variant)}
+                </Text>
+              ))}
+            </Stack>
+          )}
+        </Stack>
+      </Box>
+    </Dialog>
+  )
+}

--- a/packages/sanity/src/core/variants/tool/overview/VariantConditionFilters.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantConditionFilters.tsx
@@ -1,0 +1,376 @@
+import {AddIcon} from '@sanity/icons/Add'
+import {CheckmarkIcon} from '@sanity/icons/Checkmark'
+import {CloseIcon} from '@sanity/icons/Close'
+import {FilterIcon} from '@sanity/icons/Filter'
+import {SearchIcon} from '@sanity/icons/Search'
+import {Box, Card, Flex, Stack, Text, TextInput, useClickOutsideEvent} from '@sanity/ui'
+import {type ComponentType, useCallback, useEffect, useMemo, useRef, useState} from 'react'
+
+import {Button} from '../../../../ui-components/button/Button'
+import {Popover} from '../../../../ui-components/popover/Popover'
+import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
+import {useTranslation} from '../../../i18n/hooks/useTranslation'
+import {variantsLocaleNamespace} from '../../i18n'
+import {getVariantConditionIcon} from '../detail/variantConditionIcons'
+import {type ConditionFacet} from '../util'
+
+// Condition keys are authored strings ("brand", "market", …); present them title-cased.
+function facetLabel(key: string): string {
+  return key.charAt(0).toUpperCase() + key.slice(1)
+}
+
+/**
+ * The single entry point for adding a filter — an "Add filter" button that opens a two-level menu:
+ * a searchable list of dimensions, then the values for the chosen dimension (multi-select, so the
+ * menu stays open). Scales to any number of dimensions without overflowing the lane, unlike a
+ * dropdown-per-dimension row.
+ */
+function AddFilterMenu({
+  facets,
+  value,
+  onToggleValue,
+}: {
+  facets: ConditionFacet[]
+  value: Record<string, string[]>
+  onToggleValue: (key: string, val: string) => void
+}): React.JSX.Element {
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const [open, setOpen] = useState(false)
+  const [dimensionKey, setDimensionKey] = useState<string | null>(null)
+  const [query, setQuery] = useState('')
+  const [buttonEl, setButtonEl] = useState<HTMLButtonElement | null>(null)
+  const [popoverEl, setPopoverEl] = useState<HTMLElement | null>(null)
+
+  const close = useCallback(() => {
+    setOpen(false)
+    setDimensionKey(null)
+    setQuery('')
+  }, [])
+
+  useClickOutsideEvent(close, () => [buttonEl, popoverEl])
+
+  const activeFacet = facets.find((facet) => facet.key === dimensionKey)
+
+  const matchingFacets = useMemo(() => {
+    const normalized = query.trim().toLowerCase()
+    if (!normalized) return facets
+    return facets.filter((facet) => facetLabel(facet.key).toLowerCase().includes(normalized))
+  }, [facets, query])
+
+  // Master-detail: dimensions on the left, the selected dimension's values on the right — both panes
+  // visible at once, so choosing a dimension and toggling its values needs no back-and-forth.
+  const content = (
+    <Stack space={0} style={{width: 520}}>
+      <Box padding={2} style={{borderBottom: '1px solid var(--card-border-color)'}}>
+        <TextInput
+          fontSize={1}
+          icon={SearchIcon}
+          onChange={(event) => setQuery(event.currentTarget.value)}
+          placeholder={t('overview.filter.find-dimension')}
+          radius={2}
+          value={query}
+        />
+      </Box>
+      <Flex>
+        {/* Left: dimensions — icon + label grouped left (flex-start); the highlighted row and the
+            live value pane convey the drill, so no trailing chevron is needed. */}
+        <Box style={{width: 240, borderRight: '1px solid var(--card-border-color)'}}>
+          <Stack padding={2} space={1}>
+            {matchingFacets.length === 0 ? (
+              <Box padding={3}>
+                <Text muted size={1}>
+                  {t('overview.filter.no-dimensions')}
+                </Text>
+              </Box>
+            ) : (
+              matchingFacets.map((facet) => {
+                const count = (value[facet.key] ?? []).length
+                return (
+                  <Button
+                    key={facet.key}
+                    icon={getVariantConditionIcon(facet.key)}
+                    justify="flex-start"
+                    mode="bleed"
+                    onClick={() => setDimensionKey(facet.key)}
+                    selected={facet.key === dimensionKey}
+                    text={count > 0 ? `${facetLabel(facet.key)} (${count})` : facetLabel(facet.key)}
+                  />
+                )
+              })
+            )}
+          </Stack>
+        </Box>
+        {/* Right: values of the selected dimension — a muted header names the dimension, then the
+            values (text left, selected checkmark pinned right via space-between). */}
+        <Box style={{flex: 1}}>
+          {activeFacet ? (
+            <Stack padding={2} space={1}>
+              <Box paddingBottom={1} paddingTop={1} paddingX={2}>
+                <Text muted size={0} weight="medium">
+                  {facetLabel(activeFacet.key)}
+                </Text>
+              </Box>
+              {activeFacet.values.map((val) => {
+                const isSelected = (value[activeFacet.key] ?? []).includes(val)
+                return (
+                  <Button
+                    key={val}
+                    iconRight={isSelected ? CheckmarkIcon : undefined}
+                    justify="space-between"
+                    mode="bleed"
+                    onClick={() => onToggleValue(activeFacet.key, val)}
+                    selected={isSelected}
+                    text={val}
+                  />
+                )
+              })}
+            </Stack>
+          ) : (
+            <Flex align="center" height="fill" justify="center" padding={4}>
+              <Text align="center" muted size={1}>
+                {t('overview.filter.pick-dimension-hint')}
+              </Text>
+            </Flex>
+          )}
+        </Box>
+      </Flex>
+    </Stack>
+  )
+
+  return (
+    <Popover ref={setPopoverEl} content={content} open={open} placement="bottom-start" portal>
+      <Button
+        ref={setButtonEl}
+        icon={AddIcon}
+        mode="ghost"
+        onClick={() => {
+          if (open) {
+            close()
+          } else {
+            // Default to the first dimension so the value pane is populated on open.
+            setDimensionKey((prev) => prev ?? facets[0]?.key ?? null)
+            setOpen(true)
+          }
+        }}
+        selected={open}
+        text={t('overview.filter.add')}
+      />
+    </Popover>
+  )
+}
+
+const NOOP = (): void => {}
+
+interface ActiveChip {
+  key: string
+  val: string
+  icon: ComponentType
+  /** The value, shown as the chip text. */
+  label: string
+  /** "Dimension: value", used as the tooltip (and the only cue when collapsed to an icon). */
+  title: string
+}
+
+/**
+ * A single active filter value, shown as a removable chip carrying its dimension icon. When
+ * `iconOnly` (the overflow-collapsed state) it drops the value text and surfaces it via a tooltip.
+ */
+function FilterChip({
+  chip,
+  iconOnly,
+  onRemove,
+}: {
+  chip: ActiveChip
+  iconOnly: boolean
+  onRemove: () => void
+}): React.JSX.Element {
+  const {t} = useTranslation(variantsLocaleNamespace)
+  const Icon = chip.icon
+  const body = (
+    <Card border padding={1} radius={2} style={{flex: 'none'}} tone="primary">
+      <Flex align="center" gap={2}>
+        <Box paddingLeft={1}>
+          <Text size={1}>
+            <Icon />
+          </Text>
+        </Box>
+        {!iconOnly && (
+          <Text muted size={1} style={{whiteSpace: 'nowrap'}}>
+            {chip.label}
+          </Text>
+        )}
+        <Button
+          icon={CloseIcon}
+          mode="bleed"
+          onClick={onRemove}
+          paddingY={1}
+          tooltipProps={{content: t('overview.filter.remove-value')}}
+        />
+      </Flex>
+    </Card>
+  )
+
+  // Collapsed chips are just an icon; the tooltip carries the dimension + value.
+  return iconOnly ? (
+    <Tooltip content={<Text size={1}>{chip.title}</Text>} portal>
+      <Box style={{flex: 'none'}}>{body}</Box>
+    </Tooltip>
+  ) : (
+    body
+  )
+}
+
+/**
+ * The active filter chips, in a flexible zone that never scrolls: a hidden, always-expanded copy is
+ * measured against the visible zone's width, and when the full chips would overflow they all collapse
+ * to icon-only (tooltip-labelled). The zone flexes, so "Add filter" and "Clear filters" beside it stay
+ * pinned and always visible.
+ */
+function ActiveChips({
+  chips,
+  onRemove,
+}: {
+  chips: ActiveChip[]
+  onRemove: (key: string, val: string) => void
+}): React.JSX.Element {
+  const [collapsed, setCollapsed] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const measureRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+    const measure = measureRef.current
+    if (!container || !measure || typeof ResizeObserver === 'undefined') return undefined
+    const observer = new ResizeObserver(() => {
+      setCollapsed(measure.scrollWidth > container.clientWidth)
+    })
+    observer.observe(container)
+    observer.observe(measure)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <Box
+      flex={1}
+      ref={containerRef}
+      style={{minWidth: 0, overflow: 'hidden', position: 'relative'}}
+    >
+      <Flex align="center" gap={2} wrap="nowrap">
+        {chips.map((chip) => (
+          <FilterChip
+            chip={chip}
+            iconOnly={collapsed}
+            key={`${chip.key}:${chip.val}`}
+            onRemove={() => onRemove(chip.key, chip.val)}
+          />
+        ))}
+      </Flex>
+      {/* Hidden, always-expanded copy — measured to decide whether the visible chips must collapse. */}
+      <Flex
+        aria-hidden
+        gap={2}
+        ref={measureRef}
+        style={{
+          left: 0,
+          pointerEvents: 'none',
+          position: 'absolute',
+          top: 0,
+          visibility: 'hidden',
+        }}
+        wrap="nowrap"
+      >
+        {chips.map((chip) => (
+          <FilterChip
+            chip={chip}
+            iconOnly={false}
+            key={`measure-${chip.key}:${chip.val}`}
+            onRemove={NOOP}
+          />
+        ))}
+      </Flex>
+    </Box>
+  )
+}
+
+/**
+ * Faceted filter bar for the variant definitions overview, rendered in the shared DocumentTable's
+ * filter-tabs slot. A bordered "Filters" group with a single "Add filter" entry point (a searchable
+ * dimension menu, derived from the data) and a removable chip per active value. Selecting narrows the
+ * list — OR within a dimension, AND across dimensions. The single entry point scales to any number of
+ * dimensions without overflowing the lane.
+ *
+ * @internal
+ */
+export function VariantConditionFilters({
+  facets,
+  value,
+  onChange,
+}: {
+  facets: ConditionFacet[]
+  value: Record<string, string[]>
+  onChange: (next: Record<string, string[]>) => void
+}): React.JSX.Element | null {
+  const {t} = useTranslation(variantsLocaleNamespace)
+
+  const activeChips: ActiveChip[] = Object.entries(value).flatMap(([key, values]) =>
+    values.map((val) => ({
+      key,
+      val,
+      icon: getVariantConditionIcon(key),
+      label: val,
+      title: `${facetLabel(key)}: ${val}`,
+    })),
+  )
+  const hasActive = activeChips.length > 0
+
+  const toggleValue = useCallback(
+    (key: string, val: string) => {
+      const current = value[key] ?? []
+      const next = current.includes(val) ? current.filter((v) => v !== val) : [...current, val]
+      const updated = {...value}
+      if (next.length > 0) updated[key] = next
+      else delete updated[key]
+      onChange(updated)
+    },
+    [onChange, value],
+  )
+
+  if (facets.length === 0) return null
+
+  return (
+    // Fill the lane when there are chips (so Clear pins right and the chips zone can measure its
+    // available width); shrink to content when there are none, so the empty bar stays compact.
+    <Card border padding={1} radius={2} style={hasActive ? undefined : {display: 'inline-flex'}}>
+      <Flex align="center" gap={2} wrap="nowrap">
+        <Box paddingX={1} style={{flex: 'none'}}>
+          <Text muted size={1}>
+            <FilterIcon />
+          </Text>
+        </Box>
+
+        <Box style={{flex: 'none'}}>
+          <AddFilterMenu facets={facets} onToggleValue={toggleValue} value={value} />
+        </Box>
+
+        {hasActive && (
+          <>
+            {/* Thin rule separating the add control from the active-value chips. */}
+            <Box
+              style={{flex: 'none', width: 1, height: 20, background: 'var(--card-border-color)'}}
+            />
+            <ActiveChips chips={activeChips} onRemove={toggleValue} />
+            <Box style={{flex: 'none'}}>
+              <Button
+                icon={CloseIcon}
+                mode="bleed"
+                onClick={() => onChange({})}
+                text={t('overview.filter.clear-all')}
+                tone="primary"
+              />
+            </Box>
+          </>
+        )}
+      </Flex>
+    </Card>
+  )
+}

--- a/packages/sanity/src/core/variants/tool/overview/VariantMenuButton.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantMenuButton.tsx
@@ -1,10 +1,14 @@
-import {Menu} from '@sanity/ui'
+import {EditIcon} from '@sanity/icons/Edit'
+import {TrashIcon} from '@sanity/icons/Trash'
+import {Menu, MenuDivider} from '@sanity/ui'
+import {useState} from 'react'
 
 import {MenuButton} from '../../../../ui-components/menuButton/MenuButton'
 import {MenuItem} from '../../../../ui-components/menuItem/MenuItem'
 import {ContextMenuButton} from '../../../components/contextMenuButton/ContextMenuButton'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {DeleteVariantDialog} from '../../components/dialog/DeleteVariantDialog'
+import {EditVariantDialog} from '../../components/dialog/EditVariantDialog'
 import {useVariantDeleteAction} from '../../hooks/useVariantDeleteAction'
 import {variantsLocaleNamespace} from '../../i18n'
 import {type SystemVariant} from '../../types'
@@ -19,6 +23,7 @@ export function VariantMenuButton({
 }) {
   const {t} = useTranslation(variantsLocaleNamespace)
   const variantTitle = getVariantTitle(variant)
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
   const {
     deleteDisabled,
     deleteDisabledTooltip,
@@ -38,7 +43,14 @@ export function VariantMenuButton({
         menu={
           <Menu>
             <MenuItem
+              icon={EditIcon}
+              onClick={() => setIsEditDialogOpen(true)}
+              text={t('overview.action.edit-variant')}
+            />
+            <MenuDivider />
+            <MenuItem
               disabled={deleteDisabled}
+              icon={TrashIcon}
               onClick={handleDelete}
               text={t('overview.action.delete-variant')}
               tone="critical"
@@ -48,6 +60,13 @@ export function VariantMenuButton({
         }
         popover={{placement: 'bottom-end', portal: true}}
       />
+      {isEditDialogOpen && (
+        <EditVariantDialog
+          onCancel={() => setIsEditDialogOpen(false)}
+          onSubmit={() => setIsEditDialogOpen(false)}
+          variant={variant}
+        />
+      )}
       {isDeleteDialogOpen && (
         <DeleteVariantDialog
           isDeleting={isDeleting}

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
@@ -19,6 +19,7 @@ import {
   buildConditionFacets,
   filterVariantsForSearch,
   getVariantId,
+  resolveBulkDeleteVariants,
   variantMatchesConditionFilters,
 } from '../util'
 import {VariantBulkDeleteDialog} from './VariantBulkDeleteDialog'
@@ -153,11 +154,15 @@ export function VariantsOverview(): React.JSX.Element {
     return <VariantsEmptyState createVariantButton={createVariantButton} />
   }, [createVariantButton, error, hasActiveConditionFilters, hasVariants, rows.length, t])
 
-  const selectedVariants = useMemo(() => {
+  const selectedVariants = useMemo((): TableVariant[] => {
     if (!bulkDelete) return []
-    const keys = new Set(bulkDelete.keys)
-    return rows.filter((variant) => keys.has(variant._id))
-  }, [bulkDelete, rows])
+    return resolveBulkDeleteVariants(
+      bulkDelete.keys,
+      variantsList,
+      documentCounts,
+      documentCountsError,
+    )
+  }, [bulkDelete, variantsList, documentCounts, documentCountsError])
 
   return (
     <Flex direction="column" flex={1} height="fill">

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
@@ -1,35 +1,48 @@
 import {AddIcon} from '@sanity/icons/Add'
-import {SearchIcon} from '@sanity/icons/Search'
-import {Box, Card, Container, Flex, Stack, Text, TextInput} from '@sanity/ui'
+import {TrashIcon} from '@sanity/icons/Trash'
+import {Card, Container, Flex, Stack, Text} from '@sanity/ui'
 import {useCallback, useMemo, useState} from 'react'
 import {useRouter} from 'sanity/router'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
-import {Table, type TableProps} from '../../../releases/tool/components/Table/Table'
+import {
+  DocumentTable,
+  type DocumentTableSelection,
+} from '../../../releases/tool/components/Table/DocumentTable'
 import {CreateVariantDialog} from '../../components/dialog/CreateVariantDialog'
 import {useVariantsDocumentCounts} from '../../hooks/useVariantsDocumentCounts'
 import {variantsLocaleNamespace} from '../../i18n'
 import {useAllVariants} from '../../store/useAllVariants'
 import {type SystemVariant} from '../../types'
-import {filterVariantsForSearch, getVariantId} from '../util'
+import {
+  buildConditionFacets,
+  filterVariantsForSearch,
+  getVariantId,
+  variantMatchesConditionFilters,
+} from '../util'
+import {VariantBulkDeleteDialog} from './VariantBulkDeleteDialog'
+import {VariantConditionFilters} from './VariantConditionFilters'
 import {VariantMenuButton} from './VariantMenuButton'
 import {VariantsEmptyState} from './VariantsEmptyState'
 import {type TableVariant, variantsOverviewColumnDefs} from './VariantsOverviewColumnDefs'
 
 const VARIANT_TABLE_ROW_ID = '_id'
+const getRowKey = (variant: TableVariant): string => variant._id
+// DocumentTable filters internally per-row; reuse the list matcher on a single-element list so the
+// search behaviour stays identical to the previous standalone search box.
+const searchPredicate = (variant: TableVariant, term: string): boolean =>
+  filterVariantsForSearch([variant], term).length > 0
 
-export function VariantsOverview() {
+export function VariantsOverview(): React.JSX.Element {
   const {t} = useTranslation(variantsLocaleNamespace)
   const router = useRouter()
   const {data: variants, error, loading} = useAllVariants()
-  const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(null)
-  const [searchQuery, setSearchQuery] = useState('')
   const [isCreateVariantDialogOpen, setIsCreateVariantDialogOpen] = useState(false)
+  const [bulkDelete, setBulkDelete] = useState<{keys: string[]; clear: () => void} | null>(null)
+  const [conditionFilters, setConditionFilters] = useState<Record<string, string[]>>({})
 
-  const handleCreateVariant = useCallback(() => {
-    setIsCreateVariantDialogOpen(true)
-  }, [])
+  const handleCreateVariant = useCallback(() => setIsCreateVariantDialogOpen(true), [])
 
   const handleOnCreateVariant = useCallback(
     (createdVariantId: string) => {
@@ -40,10 +53,9 @@ export function VariantsOverview() {
   )
 
   const columnDefs = useMemo(() => variantsOverviewColumnDefs(t), [t])
-  const renderRowActions = useCallback<
-    NonNullable<TableProps<TableVariant, undefined>['rowActions']>
-  >(
-    ({datum}) => (
+
+  const renderRowActions = useCallback(
+    ({datum}: {datum: unknown}) => (
       <VariantMenuButton
         documentCount={(datum as TableVariant).documentCount}
         variant={datum as SystemVariant}
@@ -53,18 +65,25 @@ export function VariantsOverview() {
   )
 
   const variantsList = useMemo(() => variants ?? [], [variants])
-
   const {data: documentCounts, error: documentCountsError} = useVariantsDocumentCounts()
 
-  const filteredVariants = useMemo(
+  // Facets come from the full list so the dropdown options never shrink as filters are applied.
+  const facets = useMemo(() => buildConditionFacets(variantsList), [variantsList])
+
+  // Rows are pre-filtered by the active condition filters; DocumentTable owns the free-text search
+  // on top of that via searchPredicate.
+  const rows = useMemo(
     () =>
-      filterVariantsForSearch(variantsList, searchQuery).map(
-        (variant): TableVariant => ({
-          ...variant,
-          documentCount: documentCounts?.[variant._id] ?? (documentCountsError ? null : undefined),
-        }),
-      ),
-    [variantsList, searchQuery, documentCounts, documentCountsError],
+      variantsList
+        .filter((variant) => variantMatchesConditionFilters(variant, conditionFilters))
+        .map(
+          (variant): TableVariant => ({
+            ...variant,
+            documentCount:
+              documentCounts?.[variant._id] ?? (documentCountsError ? null : undefined),
+          }),
+        ),
+    [variantsList, conditionFilters, documentCounts, documentCountsError],
   )
 
   const hasVariants = variantsList.length > 0
@@ -75,10 +94,35 @@ export function VariantsOverview() {
         disabled={isCreateVariantDialogOpen}
         icon={AddIcon}
         onClick={handleCreateVariant}
-        text={t('overview.action.create-variant')}
+        text={t('overview.action.new-variant')}
       />
     ),
     [handleCreateVariant, isCreateVariantDialogOpen, t],
+  )
+
+  // Bulk selection + a single destructive action. The delete itself is guarded per-definition in the
+  // dialog (only empty definitions are removed), so the toolbar keeps one clear "Delete" affordance.
+  const selection = useMemo<DocumentTableSelection>(
+    () => ({
+      labels: {
+        selectAll: t('overview.bulk.select-all'),
+        selectRow: t('overview.bulk.select-row'),
+        selectedCount: (count) => t('overview.bulk.selected', {count}),
+        clear: t('overview.bulk.clear'),
+      },
+      selectAllTestId: 'variant-bulk-select-all',
+      renderActions: ({selectedKeys, clear}) => (
+        <Button
+          data-testid="variant-bulk-delete"
+          icon={TrashIcon}
+          mode="bleed"
+          onClick={() => setBulkDelete({keys: selectedKeys, clear})}
+          text={t('overview.bulk.delete')}
+          tone="critical"
+        />
+      ),
+    }),
+    [t],
   )
 
   const tableEmptyState = useCallback(() => {
@@ -95,14 +139,21 @@ export function VariantsOverview() {
     return <VariantsEmptyState createVariantButton={createVariantButton} />
   }, [createVariantButton, error, hasVariants, t])
 
+  const selectedVariants = useMemo(() => {
+    if (!bulkDelete) return []
+    const keys = new Set(bulkDelete.keys)
+    return rows.filter((variant) => keys.has(variant._id))
+  }, [bulkDelete, rows])
+
   return (
     <Flex direction="column" flex={1} height="fill">
-      {/* Same container width as releases document table (`container[3]` in Table), so chrome aligns with row content */}
+      {/* Same container width as the releases document table (`container[3]`), so the page header
+          aligns with the table's row content below. */}
       <Container flex="none" width={3}>
         <Flex direction="column" paddingX={3}>
-          <Card flex="none" paddingY={5}>
+          <Card flex="none" paddingBottom={4} paddingTop={5}>
             <Flex align="flex-start" gap={4} justify="space-between">
-              <Stack space={3}>
+              <Stack space={2}>
                 <Text as="h1" size={4} weight="bold">
                   {t('overview.title')}
                 </Text>
@@ -114,44 +165,54 @@ export function VariantsOverview() {
             </Flex>
           </Card>
 
-          <Box flex="none" paddingBottom={4} paddingTop={2}>
-            <TextInput
-              clearButton={!!searchQuery}
-              fontSize={1}
-              icon={SearchIcon}
-              onChange={(event) => setSearchQuery(event.currentTarget.value)}
-              onClear={() => setSearchQuery('')}
-              placeholder={t('overview.search.placeholder')}
-              radius={3}
-              value={searchQuery}
-            />
-          </Box>
-
           {error && (
-            <Card flex="none" padding={3} tone="critical">
+            <Card flex="none" marginBottom={4} padding={3} tone="critical">
               <Text size={1}>{t('overview.error')}</Text>
             </Card>
           )}
         </Flex>
       </Container>
 
-      {/* Full-width scroll region so table borders span the tool pane (same pattern as release detail summary). */}
-      <Box flex={1} overflow="auto" ref={setScrollContainerRef}>
-        <Table<TableVariant>
-          columnDefs={columnDefs}
-          data={filteredVariants}
-          emptyState={tableEmptyState}
-          loading={loading}
-          rowId={VARIANT_TABLE_ROW_ID}
-          rowActions={renderRowActions}
-          scrollContainerRef={scrollContainerRef}
-        />
-      </Box>
+      {/* Shared DocumentTable — the same table the release and variant detail surfaces use: search in
+          the command lane, checkbox selection, and a bulk toolbar on selection. */}
+      <DocumentTable<TableVariant>
+        alwaysShowCommandLane
+        columnDefs={columnDefs}
+        // Reserve the bordered filter group's height so selecting rows (which swaps in the shorter
+        // bulk toolbar) never shifts the table.
+        commandLaneMinHeight={47}
+        emptyState={tableEmptyState}
+        filterTabs={
+          <VariantConditionFilters
+            facets={facets}
+            onChange={setConditionFilters}
+            value={conditionFilters}
+          />
+        }
+        filterTabsScroll={false}
+        getRowKey={getRowKey}
+        id="variant-definitions-table"
+        loading={loading}
+        rowActions={renderRowActions}
+        rowId={VARIANT_TABLE_ROW_ID}
+        rows={rows}
+        searchPlaceholder={t('overview.search.placeholder')}
+        searchPredicate={searchPredicate}
+        selection={selection}
+      />
 
       {isCreateVariantDialogOpen && (
         <CreateVariantDialog
           onCancel={() => setIsCreateVariantDialogOpen(false)}
           onSubmit={handleOnCreateVariant}
+        />
+      )}
+
+      {bulkDelete && (
+        <VariantBulkDeleteDialog
+          onClose={() => setBulkDelete(null)}
+          onDeleted={() => bulkDelete.clear()}
+          variants={selectedVariants}
         />
       )}
     </Flex>

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverview.tsx
@@ -87,6 +87,10 @@ export function VariantsOverview(): React.JSX.Element {
   )
 
   const hasVariants = variantsList.length > 0
+  const hasActiveConditionFilters = useMemo(
+    () => Object.values(conditionFilters).some((values) => values.length > 0),
+    [conditionFilters],
+  )
 
   const createVariantButton = useMemo(
     () => (
@@ -136,8 +140,18 @@ export function VariantsOverview(): React.JSX.Element {
       )
     }
 
+    if (hasVariants && hasActiveConditionFilters && rows.length === 0) {
+      return (
+        <Flex align="center" direction="column" gap={3} justify="center" padding={4}>
+          <Text data-testid="variants-filter-empty-state" muted size={1}>
+            {t('overview.filter.no-matching-definitions')}
+          </Text>
+        </Flex>
+      )
+    }
+
     return <VariantsEmptyState createVariantButton={createVariantButton} />
-  }, [createVariantButton, error, hasVariants, t])
+  }, [createVariantButton, error, hasActiveConditionFilters, hasVariants, rows.length, t])
 
   const selectedVariants = useMemo(() => {
     if (!bulkDelete) return []

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
@@ -7,7 +7,6 @@ import {Headers} from '../../../releases/tool/components/Table/TableHeader'
 import {type Column, type VisibleColumn} from '../../../releases/tool/components/Table/types'
 import {variantsLocaleNamespace} from '../../i18n'
 import {type SystemVariant} from '../../types'
-import {VariantPinButton} from '../components/VariantPinButton'
 import {getVariantId, getVariantConditionsText, getVariantTitle} from '../util'
 
 /**
@@ -78,7 +77,6 @@ const VariantTitleCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, datum
   return (
     <Box {...cellProps} flex={1} paddingLeft={3} paddingRight={2} paddingY={1} sizing="border">
       <Flex align="center" gap={3}>
-        <VariantPinButton variant={variant} />
         <Card as={VariantLink} data-as="a" flex={1} padding={2} radius={2} tone="inherit">
           <Flex align="center" gap={3}>
             <Stack flex={1} space={2}>

--- a/packages/sanity/src/core/variants/tool/overview/__tests__/VariantBulkDeleteDialog.test.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/__tests__/VariantBulkDeleteDialog.test.tsx
@@ -128,4 +128,35 @@ describe('VariantBulkDeleteDialog', () => {
     })
     expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(emptyVariant._id)
   })
+
+  it('does not claim unresolved document counts contain documents', async () => {
+    const loadingVariant: TableVariant = {...variantAlphaAudience, documentCount: undefined}
+    const failedCountVariant: TableVariant = {...variantNorwegianMarket, documentCount: null}
+
+    await renderDialog([loadingVariant, failedCountVariant])
+
+    expect(
+      screen.getByText(
+        'Document counts are still loading or unavailable for the selected definitions, so none can be deleted yet.',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/contain documents/)).not.toBeInTheDocument()
+    expect(screen.getByTestId('confirm-button')).toBeDisabled()
+  })
+
+  it('shows separate notes for definitions with documents and unknown counts', async () => {
+    const loadingVariant: TableVariant = {...variantAlphaAudience, documentCount: undefined}
+
+    await renderDialog([emptyVariant, variantWithDocs, loadingVariant])
+
+    expect(
+      screen.getByText('You are about to delete 1 variant definition. This cannot be undone.'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('1 selected definition contains documents and will be kept.'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('1 selected definition has an unknown document count and will be kept.'),
+    ).toBeInTheDocument()
+  })
 })

--- a/packages/sanity/src/core/variants/tool/overview/__tests__/VariantBulkDeleteDialog.test.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/__tests__/VariantBulkDeleteDialog.test.tsx
@@ -1,0 +1,131 @@
+import {render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {createMockVariant} from '../../../__fixtures__/createMockVariant'
+import {variantAlphaAudience, variantNorwegianMarket} from '../../../__fixtures__/variants.fixture'
+import {variantsUsEnglishLocaleBundle} from '../../../i18n'
+import {VariantBulkDeleteDialog} from '../VariantBulkDeleteDialog'
+import {type TableVariant} from '../VariantsOverviewColumnDefs'
+
+const variantOperationsMock = vi.hoisted(() => ({
+  createVariant: vi.fn(),
+  updateVariant: vi.fn(),
+  deleteVariant: vi.fn(),
+}))
+
+const toastMock = vi.hoisted(() => ({
+  push: vi.fn(),
+}))
+
+vi.mock('@sanity/ui', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useToast: vi.fn(() => toastMock),
+}))
+
+vi.mock('../../../store/useVariantOperations', () => ({
+  useVariantOperations: vi.fn(() => variantOperationsMock),
+}))
+
+const emptyVariant: TableVariant = {...variantAlphaAudience, documentCount: 0}
+const variantWithDocs: TableVariant = {...variantNorwegianMarket, documentCount: 2}
+
+describe('VariantBulkDeleteDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    variantOperationsMock.deleteVariant.mockResolvedValue(undefined)
+  })
+
+  const renderDialog = async (
+    variants: TableVariant[],
+    callbacks?: {onClose?: () => void; onDeleted?: () => void},
+  ) => {
+    const onClose = callbacks?.onClose ?? vi.fn()
+    const onDeleted = callbacks?.onDeleted ?? vi.fn()
+    const wrapper = await createTestProvider({
+      resources: [variantsUsEnglishLocaleBundle],
+    })
+
+    render(
+      <VariantBulkDeleteDialog onClose={onClose} onDeleted={onDeleted} variants={variants} />,
+      {
+        wrapper,
+      },
+    )
+
+    await screen.findByTestId('variant-bulk-delete-dialog')
+
+    return {onClose, onDeleted}
+  }
+
+  it('calls onDeleted and onClose when all deletions succeed', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    const onDeleted = vi.fn()
+    await renderDialog([emptyVariant], {onClose, onDeleted})
+
+    await user.click(screen.getByTestId('confirm-button'))
+
+    await waitFor(() => {
+      expect(onDeleted).toHaveBeenCalledTimes(1)
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('does not call onDeleted or onClose when every deletion fails', async () => {
+    const user = userEvent.setup()
+    variantOperationsMock.deleteVariant.mockRejectedValue(new Error('delete failed'))
+    const onClose = vi.fn()
+    const onDeleted = vi.fn()
+    await renderDialog([emptyVariant], {onClose, onDeleted})
+
+    await user.click(screen.getByTestId('confirm-button'))
+
+    await waitFor(() => {
+      expect(toastMock.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          title: 'Some variant definitions could not be deleted',
+        }),
+      )
+    })
+    expect(onDeleted).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+    expect(screen.getByTestId('variant-bulk-delete-dialog')).toBeInTheDocument()
+  })
+
+  it('calls onDeleted and onClose when at least one deletion succeeds', async () => {
+    const user = userEvent.setup()
+    const secondEmpty: TableVariant = {
+      ...createMockVariant('second-empty', 3),
+      documentCount: 0,
+    }
+    variantOperationsMock.deleteVariant.mockImplementation((id: string) => {
+      if (id === emptyVariant._id) return Promise.resolve(undefined)
+      return Promise.reject(new Error('delete failed'))
+    })
+    const onClose = vi.fn()
+    const onDeleted = vi.fn()
+    await renderDialog([emptyVariant, secondEmpty], {onClose, onDeleted})
+
+    await user.click(screen.getByTestId('confirm-button'))
+
+    await waitFor(() => {
+      expect(onDeleted).toHaveBeenCalledTimes(1)
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('only attempts to delete variants with no documents', async () => {
+    const user = userEvent.setup()
+    await renderDialog([emptyVariant, variantWithDocs])
+
+    await user.click(screen.getByTestId('confirm-button'))
+
+    await waitFor(() => {
+      expect(variantOperationsMock.deleteVariant).toHaveBeenCalledTimes(1)
+    })
+    expect(variantOperationsMock.deleteVariant).toHaveBeenCalledWith(emptyVariant._id)
+  })
+})

--- a/packages/sanity/src/core/variants/tool/util.ts
+++ b/packages/sanity/src/core/variants/tool/util.ts
@@ -129,3 +129,48 @@ export function filterVariantsForSearch(
     return searchableValues.some((value) => value.toLowerCase().includes(normalizedSearchTerm))
   })
 }
+
+/** A filterable condition dimension and the distinct values seen for it across all variants. */
+export interface ConditionFacet {
+  key: string
+  values: string[]
+}
+
+/**
+ * Derive the filterable facets from every variant's `conditions` key-value pairs: one facet per
+ * condition key, with its distinct values. Keys and values are sorted for a stable UI. Because the
+ * facets come from the full variant list (not the filtered view), the available options never shrink
+ * as filters are applied.
+ */
+export function buildConditionFacets(variants: SystemVariant[]): ConditionFacet[] {
+  const valuesByKey = new Map<string, Set<string>>()
+
+  for (const variant of variants) {
+    for (const [key, value] of Object.entries(variant.conditions)) {
+      if (typeof value !== 'string' || value.length === 0) continue
+      const values = valuesByKey.get(key) ?? new Set<string>()
+      values.add(value)
+      valuesByKey.set(key, values)
+    }
+  }
+
+  return Array.from(valuesByKey.entries())
+    .map(([key, values]) => ({key, values: Array.from(values).sort((a, b) => a.localeCompare(b))}))
+    .sort((a, b) => a.key.localeCompare(b.key))
+}
+
+/**
+ * A variant matches when, for every active facet, its value for that condition key is one of the
+ * selected values. Selecting several values within one facet is an OR; different facets AND together.
+ * An empty selection for a facet imposes no constraint.
+ */
+export function variantMatchesConditionFilters(
+  variant: SystemVariant,
+  filters: Record<string, string[]>,
+): boolean {
+  return Object.entries(filters).every(([key, selectedValues]) => {
+    if (selectedValues.length === 0) return true
+    const value = variant.conditions[key]
+    return typeof value === 'string' && selectedValues.includes(value)
+  })
+}

--- a/packages/sanity/src/core/variants/tool/util.ts
+++ b/packages/sanity/src/core/variants/tool/util.ts
@@ -174,3 +174,28 @@ export function variantMatchesConditionFilters(
     return typeof value === 'string' && selectedValues.includes(value)
   })
 }
+
+/** Variant definition plus overview document count (see `TableVariant`). */
+export type VariantWithDocumentCount = SystemVariant & {
+  documentCount?: number | null
+}
+
+/**
+ * Resolves bulk-delete targets from the full variant list and snapshotted row keys.
+ * Must not use condition-filtered table rows, or changing filters while the dialog is open
+ * can drop selected ids from the confirm action.
+ */
+export function resolveBulkDeleteVariants(
+  keys: readonly string[],
+  variantsList: SystemVariant[],
+  documentCounts: Record<string, number> | null | undefined,
+  documentCountsError: Error | null | undefined,
+): VariantWithDocumentCount[] {
+  const keySet = new Set(keys)
+  return variantsList
+    .filter((variant) => keySet.has(variant._id))
+    .map((variant) => ({
+      ...variant,
+      documentCount: documentCounts?.[variant._id] ?? (documentCountsError ? null : undefined),
+    }))
+}


### PR DESCRIPTION
## TL;DR

**Problem.** The variant definitions overview used the low-level table — no bulk actions, no filtering, and inconsistent with the (now redesigned) detail surfaces.

**Solution.** Migrate the overview to the shared **`DocumentTable`** (from PR1), and add **bulk delete** and a **faceted condition filter** — so it reads as the same table family as the detail pages.

Behind `beta.variants`.

## What's in it

- Overview on the shared `DocumentTable`: search in the command lane, checkbox selection + bulk toolbar.
- **Bulk delete** of zero-document definitions, with a confirmation dialog and an honest keep-list for any selected definitions that still contain documents.
- **Faceted condition filter**, derived from the variants' condition key-value pairs: a two-pane "Add filter" menu (searchable dimensions -> values), removable chips carrying each dimension's icon, and overflow-collapse to icon-only so the lane never scrolls and "Clear filters" stays pinned.
- Primary CTA renamed to **"New variant definition"** to mirror "New release".

## Scope & safety

- **Stacked on #13780.** Behind `beta.variants`.
- Full variants test suite green (37 files / 231 tests), type-clean, oxlint/oxfmt clean.
- Bulk multi-bundle disambiguation (Pedro) and the real bulk operations are deliberately out of scope here — decided + tracked as follow-ups.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk delete is destructive but gated on document counts and partial-failure handling; changes are confined to the variants overview UI behind beta.variants.
> 
> **Overview**
> Redesigns the **variant definitions overview** to use the shared **`DocumentTable`** (command-lane search, row checkboxes, bulk toolbar) instead of the standalone table and header search field.
> 
> Adds a **faceted condition filter** bar (`VariantConditionFilters`): dimensions and values come from variant `conditions`, with OR-within-dimension / AND-across-dimension matching, filter-empty state copy, and chip overflow handling. **Bulk delete** opens `VariantBulkDeleteDialog`, which only removes definitions with a resolved document count of 0 and explains kept rows (documents present or count unknown); selection resolves via `resolveBulkDeleteVariants` so active filters cannot drop ids from the confirm action.
> 
> Row actions gain **Edit variant definition** via `EditVariantDialog`; the overview table **pin** control is removed from column defs. The primary create action label is **"New variant definition"** (replacing "Create variant definition"). New i18n strings cover bulk-delete edge cases and filter-empty messaging; e2e and unit tests follow the new UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 252372cee9a93d5ebce20c03eccec6f36abdc845. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->