### PR TITLE
fix(structure): restore virtualised lists after pane expansion

### DIFF
--- a/packages/sanity/src/core/components/commandList/CommandList.tsx
+++ b/packages/sanity/src/core/components/commandList/CommandList.tsx
@@ -1,5 +1,10 @@
 import {Box, rem, Stack} from '@sanity/ui'
-import {type ScrollToOptions, useVirtualizer, type Virtualizer} from '@tanstack/react-virtual'
+import {
+  observeElementOffset,
+  type ScrollToOptions,
+  useVirtualizer,
+  type Virtualizer,
+} from '@tanstack/react-virtual'
 import throttle from 'lodash-es/throttle.js'
 import {
   cloneElement,
@@ -95,6 +100,35 @@ const VirtualListChildBox = styled(Box) //
   width: 100%;
 `
 
+const observeCommandListOffset = (
+  virtualizer: Virtualizer<HTMLElement, Element>,
+  callback: (offset: number, isScrolling: boolean) => void,
+) => {
+  const cleanupScrollObserver = observeElementOffset(virtualizer, callback)
+  const scrollElement = virtualizer.scrollElement
+  const targetWindow = scrollElement?.ownerDocument.defaultView
+  const ResizeObserver = targetWindow?.ResizeObserver
+
+  if (!scrollElement || !targetWindow || !ResizeObserver) return cleanupScrollObserver
+
+  let wasVisible = scrollElement.offsetWidth > 0 && scrollElement.offsetHeight > 0
+  const resizeObserver = new ResizeObserver(() => {
+    const isVisible = scrollElement.offsetWidth > 0 && scrollElement.offsetHeight > 0
+
+    if (!wasVisible && isVisible) {
+      scrollElement.dispatchEvent(new targetWindow.Event('scroll'))
+    }
+
+    wasVisible = isVisible
+  })
+  resizeObserver.observe(scrollElement)
+
+  return () => {
+    cleanupScrollObserver?.()
+    resizeObserver.disconnect()
+  }
+}
+
 // oxlint-disable-next-line react/react-compiler
 const CommandListComponent = forwardRef<CommandListHandle, CommandListProps>(function CommandList(
   {
@@ -158,6 +192,7 @@ const CommandListComponent = forwardRef<CommandListHandle, CommandListProps>(fun
     getScrollElement: () => virtualListElement,
     estimateSize: () => itemHeight,
     onChange: handleChange,
+    observeElementOffset: observeCommandListOffset,
     overscan,
   })
 

--- a/packages/sanity/src/core/components/commandList/CommandList.tsx
+++ b/packages/sanity/src/core/components/commandList/CommandList.tsx
@@ -195,7 +195,9 @@ const CommandListComponent = forwardRef<CommandListHandle, CommandListProps>(fun
     onChange: handleChange,
     measureElement: (element, entry, instance) => {
       const measuredSize = measureElement(element, entry, instance)
-      if (measuredSize > 0) return measuredSize
+      const scrollElement = instance.scrollElement
+      const isHidden = scrollElement?.offsetWidth === 0 || scrollElement?.offsetHeight === 0
+      if (measuredSize > 0 || !isHidden) return measuredSize
 
       // Hidden panes report zero-sized rows. Keep the last valid size so the list does not collapse.
       const index = instance.indexFromElement(element)

--- a/packages/sanity/src/core/components/commandList/CommandList.tsx
+++ b/packages/sanity/src/core/components/commandList/CommandList.tsx
@@ -1,5 +1,6 @@
 import {Box, rem, Stack} from '@sanity/ui'
 import {
+  measureElement,
   observeElementOffset,
   type ScrollToOptions,
   useVirtualizer,
@@ -192,6 +193,23 @@ const CommandListComponent = forwardRef<CommandListHandle, CommandListProps>(fun
     getScrollElement: () => virtualListElement,
     estimateSize: () => itemHeight,
     onChange: handleChange,
+    measureElement: (element, entry, instance) => {
+      const measuredSize = measureElement(element, entry, instance)
+      if (measuredSize > 0) return measuredSize
+
+      // Hidden panes report zero-sized rows. Keep the last valid size so the list does not collapse.
+      const index = instance.indexFromElement(element)
+      const domSize =
+        element instanceof HTMLElement
+          ? element[instance.options.horizontal ? 'offsetWidth' : 'offsetHeight']
+          : 0
+      if (domSize > 0) return domSize
+
+      const cachedSize = instance.itemSizeCache.get(instance.options.getItemKey(index))
+      return cachedSize !== undefined && cachedSize > 0
+        ? cachedSize
+        : instance.options.estimateSize(index)
+    },
     observeElementOffset: observeCommandListOffset,
     overscan,
   })

--- a/packages/sanity/src/core/components/commandList/__tests__/CommandList.test.tsx
+++ b/packages/sanity/src/core/components/commandList/__tests__/CommandList.test.tsx
@@ -35,24 +35,32 @@ class TestResizeObserver implements ResizeObserver {
     this.targets.delete(target)
   }
 
-  trigger() {
-    const entries = [...this.targets].map(
-      (target) =>
-        ({
-          contentRect: target.getBoundingClientRect(),
-          target,
-        }) as ResizeObserverEntry,
-    )
+  trigger(predicate: (target: Element) => boolean = () => true) {
+    const entries = [...this.targets].filter(predicate).map((target) => {
+      const element = target as HTMLElement
+      return {
+        borderBoxSize: [
+          {
+            blockSize: element.offsetHeight,
+            inlineSize: element.offsetWidth,
+          },
+        ],
+        contentRect: target.getBoundingClientRect(),
+        target,
+      } as unknown as ResizeObserverEntry
+    })
+    if (entries.length === 0) return
     this.callback(entries, this)
   }
 }
 
-const triggerResizeObservers = () => {
-  resizeObservers.forEach((observer) => observer.trigger())
+const triggerResizeObservers = (predicate?: (target: Element) => boolean) => {
+  resizeObservers.forEach((observer) => observer.trigger(predicate))
 }
 
 interface TestComponentProps {
   collapsed?: boolean
+  fixedHeight?: boolean
   initialIndex?: number
   items: Item[]
   overscan?: number
@@ -60,7 +68,14 @@ interface TestComponentProps {
 }
 
 function TestComponent(props: TestComponentProps) {
-  const {collapsed, initialIndex, items, overscan = items.length, withDisabledItems} = props
+  const {
+    collapsed,
+    fixedHeight = true,
+    initialIndex,
+    items,
+    overscan = items.length,
+    withDisabledItems,
+  } = props
 
   const getItemDisabled = useCallback(
     (item: Item) => {
@@ -86,7 +101,7 @@ function TestComponent(props: TestComponentProps) {
           activeItemDataAttr={CUSTOM_ACTIVE_ATTR}
           ariaLabel=""
           autoFocus="list"
-          fixedHeight
+          fixedHeight={fixedHeight}
           initialIndex={initialIndex}
           itemHeight={20}
           items={items}
@@ -115,7 +130,8 @@ describe('core/components: CommandList', () => {
     Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
       configurable: true,
       get() {
-        return this.closest('[hidden]') ? 0 : 800
+        if (this.closest('[hidden]')) return 0
+        return this.hasAttribute('data-index') ? 30 : 800
       },
     })
     Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
@@ -217,21 +233,35 @@ describe('core/components: CommandList', () => {
     expect(buttons[3]).toHaveAttribute(CUSTOM_ACTIVE_ATTR)
   })
 
-  it('should sync rendered items with the scroll position after becoming visible', async () => {
+  it('should preserve row measurements when becoming visible', async () => {
     const items = [...Array(100).keys()]
-    const {rerender} = render(<TestComponent items={items} overscan={0} />)
+    const {rerender} = render(<TestComponent fixedHeight={false} items={items} />)
     const commandList = screen.getByTestId(COMMAND_LIST_TEST_ID)
+    const scrollTargets: number[] = []
+    Object.defineProperty(commandList, 'scrollTo', {
+      configurable: true,
+      value: (options: ScrollToOptions) => {
+        commandList.scrollTop = options.top ?? commandList.scrollTop
+        scrollTargets.push(commandList.scrollTop)
+      },
+    })
 
-    commandList.scrollTop = 1200
+    commandList.scrollTop = 600
     fireEvent.scroll(commandList)
+    await act(() => new Promise<void>((resolve) => setTimeout(resolve, 200)))
 
-    await waitFor(() => expect(screen.queryByText('Button 0')).not.toBeInTheDocument())
-
-    rerender(<TestComponent collapsed items={items} overscan={0} />)
+    const measuredTotalSize = commandList.querySelector('ul')?.style.height
+    expect(measuredTotalSize).toBe('3000px')
+    rerender(<TestComponent collapsed fixedHeight={false} items={items} />)
     act(triggerResizeObservers)
+    expect(scrollTargets).toEqual([])
+    expect(commandList.querySelector('ul')).toHaveStyle({height: measuredTotalSize})
+
     commandList.scrollTop = 0
-    rerender(<TestComponent items={items} overscan={0} />)
-    act(triggerResizeObservers)
+    rerender(<TestComponent fixedHeight={false} items={items} />)
+    act(() =>
+      triggerResizeObservers((target) => !(target as HTMLElement).hasAttribute('data-index')),
+    )
 
     expect(await screen.findByText('Button 0')).toBeInTheDocument()
     await act(() => new Promise<void>((resolve) => setTimeout(resolve, 200)))

--- a/packages/sanity/src/core/components/commandList/__tests__/CommandList.test.tsx
+++ b/packages/sanity/src/core/components/commandList/__tests__/CommandList.test.tsx
@@ -1,5 +1,5 @@
 import {studioTheme, ThemeProvider} from '@sanity/ui'
-import {render, screen, waitFor} from '@testing-library/react'
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {useCallback} from 'react'
 import {beforeEach, describe, expect, it} from 'vitest'
@@ -11,14 +11,56 @@ const CUSTOM_ACTIVE_ATTR = 'my-active-data-attribute'
 
 type Item = number
 
+const resizeObservers = new Set<TestResizeObserver>()
+
+class TestResizeObserver implements ResizeObserver {
+  private readonly callback: ResizeObserverCallback
+  private readonly targets = new Set<Element>()
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+    resizeObservers.add(this)
+  }
+
+  disconnect() {
+    this.targets.clear()
+    resizeObservers.delete(this)
+  }
+
+  observe(target: Element) {
+    this.targets.add(target)
+  }
+
+  unobserve(target: Element) {
+    this.targets.delete(target)
+  }
+
+  trigger() {
+    const entries = [...this.targets].map(
+      (target) =>
+        ({
+          contentRect: target.getBoundingClientRect(),
+          target,
+        }) as ResizeObserverEntry,
+    )
+    this.callback(entries, this)
+  }
+}
+
+const triggerResizeObservers = () => {
+  resizeObservers.forEach((observer) => observer.trigger())
+}
+
 interface TestComponentProps {
+  collapsed?: boolean
   initialIndex?: number
   items: Item[]
+  overscan?: number
   withDisabledItems?: boolean
 }
 
 function TestComponent(props: TestComponentProps) {
-  const {initialIndex, items, withDisabledItems} = props
+  const {collapsed, initialIndex, items, overscan = items.length, withDisabledItems} = props
 
   const getItemDisabled = useCallback(
     (item: Item) => {
@@ -32,14 +74,14 @@ function TestComponent(props: TestComponentProps) {
   const renderItem = useCallback((item: Item) => {
     return (
       <button key={item.toString()} type="button" data-testid="button">
-        Button
+        Button {item}
       </button>
     )
   }, [])
 
   return (
     <ThemeProvider theme={studioTheme}>
-      <div style={{height: '400px', position: 'relative'}}>
+      <div hidden={collapsed} style={{height: '400px', position: 'relative'}}>
         <CommandList
           activeItemDataAttr={CUSTOM_ACTIVE_ATTR}
           ariaLabel=""
@@ -49,9 +91,7 @@ function TestComponent(props: TestComponentProps) {
           itemHeight={20}
           items={items}
           getItemDisabled={getItemDisabled}
-          // TODO: Figure out why we need the overscan to be the
-          // same as the number of items for the tests to pass
-          overscan={items.length}
+          overscan={overscan}
           renderItem={renderItem}
           testId={COMMAND_LIST_TEST_ID}
         />
@@ -62,6 +102,7 @@ function TestComponent(props: TestComponentProps) {
 
 describe('core/components: CommandList', () => {
   beforeEach(() => {
+    const originalResizeObserver = globalThis.ResizeObserver
     const originalOffsetHeight = Object.getOwnPropertyDescriptor(
       HTMLElement.prototype,
       'offsetHeight',
@@ -70,24 +111,23 @@ describe('core/components: CommandList', () => {
       HTMLElement.prototype,
       'offsetWidth',
     )
-    // Virtual list will return an empty list of items unless we have some size,
-    // so we need to mock offsetHeight and offsetWidth to return a size for the list.
-    // Not pretty, but it's what they recommend for testing outside of browsers:
-    // https://github.com/TanStack/virtual/issues/641
+    globalThis.ResizeObserver = TestResizeObserver
     Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
       configurable: true,
       get() {
-        return 800
+        return this.closest('[hidden]') ? 0 : 800
       },
     })
     Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
       configurable: true,
       get() {
-        return 800
+        return this.closest('[hidden]') ? 0 : 800
       },
     })
 
     return () => {
+      resizeObservers.clear()
+      globalThis.ResizeObserver = originalResizeObserver
       if (originalOffsetHeight) {
         Object.defineProperty(HTMLElement.prototype, 'offsetHeight', originalOffsetHeight)
       }
@@ -175,5 +215,26 @@ describe('core/components: CommandList', () => {
     expect(buttons[1]).not.toHaveAttribute(CUSTOM_ACTIVE_ATTR)
     expect(buttons[2]).not.toHaveAttribute(CUSTOM_ACTIVE_ATTR)
     expect(buttons[3]).toHaveAttribute(CUSTOM_ACTIVE_ATTR)
+  })
+
+  it('should sync rendered items with the scroll position after becoming visible', async () => {
+    const items = [...Array(100).keys()]
+    const {rerender} = render(<TestComponent items={items} overscan={0} />)
+    const commandList = screen.getByTestId(COMMAND_LIST_TEST_ID)
+
+    commandList.scrollTop = 1200
+    fireEvent.scroll(commandList)
+
+    await waitFor(() => expect(screen.queryByText('Button 0')).not.toBeInTheDocument())
+
+    rerender(<TestComponent collapsed items={items} overscan={0} />)
+    act(triggerResizeObservers)
+    commandList.scrollTop = 0
+    rerender(<TestComponent items={items} overscan={0} />)
+    act(triggerResizeObservers)
+
+    expect(await screen.findByText('Button 0')).toBeInTheDocument()
+    await act(() => new Promise<void>((resolve) => setTimeout(resolve, 200)))
+    expect(screen.getByText('Button 0')).toBeInTheDocument()
   })
 })

--- a/packages/sanity/src/core/components/commandList/__tests__/CommandList.test.tsx
+++ b/packages/sanity/src/core/components/commandList/__tests__/CommandList.test.tsx
@@ -267,4 +267,24 @@ describe('core/components: CommandList', () => {
     await act(() => new Promise<void>((resolve) => setTimeout(resolve, 200)))
     expect(screen.getByText('Button 0')).toBeInTheDocument()
   })
+
+  it('should sync rendered items with the scroll position after becoming visible', async () => {
+    const items = [...Array(100).keys()]
+    const {rerender} = render(<TestComponent items={items} overscan={0} />)
+    const commandList = screen.getByTestId(COMMAND_LIST_TEST_ID)
+
+    commandList.scrollTop = 1200
+    fireEvent.scroll(commandList)
+    await waitFor(() => expect(screen.queryByText('Button 0')).not.toBeInTheDocument())
+
+    rerender(<TestComponent collapsed items={items} overscan={0} />)
+    act(triggerResizeObservers)
+    commandList.scrollTop = 0
+    rerender(<TestComponent items={items} overscan={0} />)
+    act(triggerResizeObservers)
+
+    expect(await screen.findByText('Button 0')).toBeInTheDocument()
+    await act(() => new Promise<void>((resolve) => setTimeout(resolve, 200)))
+    expect(screen.getByText('Button 0')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Prevents hidden `CommandList` rows from replacing valid TanStack Virtual measurements with zero-sized values, and resynchronises the virtualizer with the real scroll position when the list becomes visible again.

Zero measurements had corrupted the row-size cache while Structure panes were collapsed. On expansion, TanStack’s anchor adjustment moved the virtual range towards the end even though the pane’s DOM `scrollTop` was zero.

Fixes https://github.com/sanity-io/sanity/issues/13760.

### What to review

- The `measureElement` fallback applies only while the command list itself is hidden, preserving legitimate zero-height rows in visible lists.
- The visibility offset observer refreshes TanStack’s offset when the pane reappears.
- Separate regression tests cover measurement-cache corruption and stale scroll offsets.

Before — the global Content pane has a large blank region and only lower rows remain:

[before_fix_content_pane_visible_blank_area.mp4](https://cursor.com/agents/bc-ac7835f2-8126-4372-9d8e-72e8f19eb3c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_fix_content_pane_visible_blank_area.mp4)

After — a controlled repeat of the original physical-window open/close sequence retains continuous rows from the top:

[controlled_repeat_content_pane_remains_complete.mp4](https://cursor.com/agents/bc-ac7835f2-8126-4372-9d8e-72e8f19eb3c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcontrolled_repeat_content_pane_remains_complete.mp4)

### Testing

- Reproduced the original far-left Content pane failure with physical browser-window sizing and captured the visible blank region.
- Captured runtime measurements showing hidden rows changing to `0px` and the rendered range advancing to indices 17–36.
- Strengthened regression test failed before the measurement fix with 10 unwanted scroll corrections.
- `pnpm vitest run --project=sanity packages/sanity/src/core/components/commandList/__tests__/CommandList.test.tsx --reporter=verbose` — 6 passed, no type errors.
- Repeated the exact physical-window open/close/fullscreen sequence after the fix and held the global Content pane visible after layout settling; it retained rows beginning with `DUDE UPPERCASE !` and no persistent blank region.

### Notes for release

Fixed Structure list panes rendering mostly empty after collapsing and re-expanding.

---

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac7835f2-8126-4372-9d8e-72e8f19eb3c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac7835f2-8126-4372-9d8e-72e8f19eb3c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

