### PR TITLE
test(bench): add scenario covering first edit of a published document

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -182,7 +182,7 @@ jobs:
       fail-fast: false
       matrix:
         # One shard per scenario: wall-clock = slowest single scenario
-        scenario: [singleString, arrayI18n, article, recipe, synthetic]
+        scenario: [singleString, firstEditPublished, arrayI18n, article, recipe, synthetic]
     steps:
       - uses: actions/checkout@v7
         with:
@@ -387,7 +387,7 @@ jobs:
           # instead of rendering a clean table with a scenario silently
           # missing. Keep in sync with the bench-interaction matrix and the
           # bench-pageload --scenario flags above.
-          BENCH_EXPECTED_INTERACTION_SCENARIOS: singleString,arrayI18n,article,recipe,synthetic
+          BENCH_EXPECTED_INTERACTION_SCENARIOS: singleString,firstEditPublished,arrayI18n,article,recipe,synthetic
           BENCH_EXPECTED_PAGELOAD_SCENARIOS: singleString,syntheticLarge
         run: pnpm bench report
 

--- a/perf/bench/scenarios/firstEditPublished.ts
+++ b/perf/bench/scenarios/firstEditPublished.ts
@@ -1,0 +1,28 @@
+import {defineScenario} from './types'
+
+const DOCUMENT_ID = 'bench-first-edit-published'
+
+/**
+ * First edit of a published document that has no draft yet (issue #13511):
+ * the first keystroke creates the draft as a separate transaction, which
+ * changes the version-id set and echoes back through the pair listener
+ * mid-typing. Regressions on this path historically flipped the form
+ * read-only while the user was typing (see the read-only interruption
+ * metric), silently swallowing keystrokes — a state the draft-seeded
+ * scenarios can never reach.
+ */
+export const firstEditPublished = defineScenario({
+  name: 'firstEditPublished',
+  sourceFile: 'perf/bench/scenarios/firstEditPublished.ts',
+  workspace: 'singleString',
+  documentType: 'singleString',
+  documentId: DOCUMENT_ID,
+  fixture: () => [
+    {
+      _id: DOCUMENT_ID,
+      _type: 'singleString',
+      stringField: 'Published text that gets its first edit during the session. ',
+    },
+  ],
+  interactions: [{fieldPath: 'stringField', kind: 'string'}],
+})

--- a/perf/bench/scenarios/index.ts
+++ b/perf/bench/scenarios/index.ts
@@ -1,5 +1,6 @@
 import {arrayI18n} from './arrayI18n'
 import {article} from './article'
+import {firstEditPublished} from './firstEditPublished'
 import {recipe} from './recipe'
 import {singleString} from './singleString'
 import {synthetic, syntheticLarge} from './synthetic'
@@ -7,6 +8,7 @@ import {type BenchScenario} from './types'
 
 export const SCENARIOS: BenchScenario[] = [
   singleString,
+  firstEditPublished,
   arrayI18n,
   article,
   recipe,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Investigation of [#13511](https://github.com/sanity-io/sanity/issues/13511) (whole form briefly turns read-only mid-typing on a published document with no draft). The bug replicates on v6.5.0 and is **already fixed** by #13574 (commit `a54b0bafbb`, first released in v6.6.0). The reporter's retest ("still persists") was on v6.5.0, posted about four hours before v6.6.0 was published — and the fix they were told about (#13490, shipped in v6.5.0) was indeed not the fix for this path.

The trigger: the first keystroke creates the draft, the draft id joins the version-id set once the debounced discovery refetch settles (~1s after a typing pause — every commit echo restarts the debounce, which is why the flash hits mid-sentence right after a pause), and pre-#13574 `useDocumentVersions` re-entered its `startWith(loading: true)` path on every id-set emission, flipping `useDocumentForm`'s `ready` gate and painting every field read-only. Causal isolation: with everything else on `main` unchanged (including #13490 and #13390), reverting only #13574's `index > 0` guard reintroduces the bug; restoring it removes it.

No product code changes: this PR adds the missing regression coverage. All existing bench scenarios seed a draft, so none of them can ever reach the published-only → first-edit journey that broke here. The new `firstEditPublished` scenario seeds only the published document, so the session exercises draft creation (a separate transaction), the listener echo, and the version-id-set change mid-typing — the read-only interruption metric and readback validation both catch a regression on this path.

### What to review

- `perf/bench/scenarios/firstEditPublished.ts` — the fixture seeds only the published id (no `drafts.` document), sharing the existing `singleString` workspace/schema
- `.github/workflows/bench.yml` — scenario added to the `bench-interaction` matrix and the expected-scenarios list (kept in sync per the comment there)

Packages affected: none (bench harness + CI only).

### Testing

Replication on the hermetic bench mock (temporary instrumented Playwright script, MutationObserver on `data-read-only`, typing in word-bursts with >1s pauses):

- #13574's guard reverted (v6.5.0 behaviour): form flips read-only ~2s into typing, right after the first pause
- Current `main`: zero read-only flips, draft created, every keystroke intact

Verification on the **real Sanity API** (standalone studio built from released npm packages, project `ppsg7ml5`, published-only `author` documents, identical automated journey):

- `sanity@6.5.0` (what the reporter tested): the `data-read-only` flip reproduced on every run, ~1–2s into typing. Keys pressed inside the window are silently swallowed (fired `XYZ` during the flip; they never appeared in the field or the document) — the reporter's "space bar not registered" symptom. Screenshot captured 29ms after the flip shows the muted read-only rendering; note the visual change is subtle with this minimal schema (muted input background, disabled Add item), which is why it is hard to spot in a compressed video:

[Name field during vs after the read-only flip on sanity 6.5.0](https://cursor.com/agents/bc-f3385d4b-a57c-4502-be2c-a20ea9bfe3e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frepro13511_name_field_during_vs_after.png)
[Add item button during vs after the read-only flip on sanity 6.5.0](https://cursor.com/agents/bc-f3385d4b-a57c-4502-be2c-a20ea9bfe3e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frepro13511_additem_during_vs_after.png)

- `sanity@6.6.0` (first release containing #13574), same instrumentation: 200 keystrokes across 25 pause-separated bursts, **zero** `data-read-only` flips, all characters landed
- `sanity@6.7.0` (latest release), same instrumentation: 200 keystrokes, **zero** flips, all characters landed

Permanent coverage: `pnpm bench run --scenario firstEditPublished --sessions 2` passes cleanly (readback validated, 0 interruptions). `pnpm bench:unit` passes (110 tests). The unit-level id-set-change regression tests from #13574 already cover the observable path.

### Notes for release

N/A – Internal only (benchmark regression coverage; the user-facing fix shipped in v6.6.0 via #13574).

---

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3385d4b-a57c-4502-be2c-a20ea9bfe3e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3385d4b-a57c-4502-be2c-a20ea9bfe3e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

