### PR TITLE
fix(releases): avoid zero count flash in bulk action dialog

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/ReleaseBulkActionDialog.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseBulkActionDialog.tsx
@@ -1,4 +1,4 @@
-import {Box, Text, useToast} from '@sanity/ui'
+import {Box, Spinner, Text, useToast} from '@sanity/ui'
 import {useCallback, useState} from 'react'
 
 import {Dialog} from '../../../../ui-components/dialog/Dialog'
@@ -58,15 +58,19 @@ export function ReleaseBulkActionDialog({
       ? {
           header: t('dashboard.details.bulk.discard-dialog.header'),
           confirm: t('dashboard.details.bulk.discard-dialog.confirm'),
-          description: t('dashboard.details.bulk.discard-dialog.description', {count}),
           tone: 'critical' as const,
         }
       : {
           header: t('dashboard.details.bulk.unpublish-dialog.header'),
           confirm: t('dashboard.details.bulk.unpublish-dialog.confirm'),
-          description: t('dashboard.details.bulk.unpublish-dialog.description', {count}),
           tone: 'caution' as const,
         }
+
+  const description = isTargetsLoading
+    ? null
+    : action === 'discard'
+      ? t('dashboard.details.bulk.discard-dialog.description', {count})
+      : t('dashboard.details.bulk.unpublish-dialog.description', {count})
 
   const handleConfirm = useCallback(async () => {
     setIsProcessing(true)
@@ -172,9 +176,13 @@ export function ReleaseBulkActionDialog({
       width={1}
     >
       <Box padding={4}>
-        <Text muted size={1}>
-          {copy.description}
-        </Text>
+        {description ? (
+          <Text muted size={1}>
+            {description}
+          </Text>
+        ) : (
+          <Spinner data-testid="release-bulk-action-dialog-loading" muted size={1} />
+        )}
       </Box>
     </Dialog>
   )

--- a/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseBulkActionDialog.test.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseBulkActionDialog.test.tsx
@@ -1,7 +1,7 @@
-import {render, screen, waitFor} from '@testing-library/react'
+import {act, render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
 import {type ReactNode} from 'react'
-import {of} from 'rxjs'
+import {of, Subject} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {ReleaseBulkActionDialog} from '../ReleaseBulkActionDialog'
@@ -92,6 +92,7 @@ vi.mock('@sanity/ui', () => ({
   useToast: vi.fn(() => ({push: mockToastPush})),
   Box: ({children}: {children: ReactNode}) => <div>{children}</div>,
   Text: ({children}: {children: ReactNode}) => <span>{children}</span>,
+  Spinner: (props: {'data-testid'?: string}) => <div data-testid={props['data-testid']} />,
 }))
 
 function createRow(
@@ -182,6 +183,34 @@ describe('ReleaseBulkActionDialog', () => {
         title: 'No unpublish permission',
       }),
     )
+  })
+
+  it('does not show a zero document count while permissions are loading', async () => {
+    const permission$ = new Subject<{granted: boolean; reason: string}>()
+    mockGetDocumentPairPermissions.mockReturnValue(permission$.asObservable())
+
+    render(
+      <ReleaseBulkActionDialog
+        action="unpublish"
+        documents={[createRow('versions.rTest.doc-one')]}
+        releaseId="rTest"
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByText('Unpublish 0 documents')).not.toBeInTheDocument()
+    expect(screen.getByTestId('release-bulk-action-dialog-loading')).toBeInTheDocument()
+
+    await act(async () => {
+      permission$.next({granted: true, reason: ''})
+      permission$.complete()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Unpublish 1 documents')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('release-bulk-action-dialog-loading')).not.toBeInTheDocument()
   })
 
   it('shows the actionable document count in the dialog description', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

`useReleaseBulkActionTargets` emits an empty target list while permissions resolve (`startWith({targets: [], isLoading: true})`). The bulk action dialog already disabled Confirm during loading, but the body still interpolated `count === 0`, so users briefly saw copy about discarding or unpublishing zero documents.

Defer the description until loading finishes and show a spinner in the dialog body instead.

### What to review

- `ReleaseBulkActionDialog.tsx` — loading vs description rendering
- `ReleaseBulkActionDialog.test.tsx` — regression test with a delayed permission observable

### Testing

- `pnpm vitest run --project=sanity packages/sanity/src/core/releases/tool/detail/__tests__/ReleaseBulkActionDialog.test.tsx`

### Notes for release

N/A – Part of detail foundation releases work
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ef66fed-017c-4a54-a78d-0242546af275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ef66fed-017c-4a54-a78d-0242546af275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

