### PR TITLE
feat(core): query documents in the selected variant alongside the perspective stack

### DIFF
--- a/dev/test-studio/structure/resolveStructure.ts
+++ b/dev/test-studio/structure/resolveStructure.ts
@@ -43,7 +43,7 @@ import {typesInOptionGroup} from './groupByOption'
 
 export const structure: StructureResolver = (
   S,
-  {schema, documentStore, i18n, perspectiveStack},
+  {schema, documentStore, i18n, perspectiveStack, selectedVariantName},
 ) => {
   const {t} = i18n
   return S.list()
@@ -59,6 +59,7 @@ export const structure: StructureResolver = (
             {},
             {
               perspective: perspectiveStack,
+              variant: selectedVariantName,
             },
           )
 

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/useReferenceInput.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/useReferenceInput.tsx
@@ -104,8 +104,19 @@ export function useReferenceInput(options: Options) {
 
   const getReferenceInfo = useCallback(
     (id: string) =>
-      adapter.getReferenceInfo(documentPreviewStore, id, schemaType, perspective.perspectiveStack),
-    [documentPreviewStore, schemaType, perspective.perspectiveStack],
+      adapter.getReferenceInfo(
+        documentPreviewStore,
+        id,
+        schemaType,
+        perspective.perspectiveStack,
+        perspective.selectedVariantName,
+      ),
+    [
+      documentPreviewStore,
+      schemaType,
+      perspective.perspectiveStack,
+      perspective.selectedVariantName,
+    ],
   )
 
   return {

--- a/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
+++ b/packages/sanity/src/core/form/studio/inputs/client-adapters/reference.ts
@@ -37,6 +37,12 @@ export function getReferenceInfo(
   id: string,
   referenceType: ReferenceSchemaType,
   perspective?: StackablePerspective[],
+  /**
+   * The selected editing variant as a bare variant id. Type resolution and preview values are
+   * resolved as seen through that variant. Availability keeps base perspective semantics, since
+   * variant documents carry server-generated ids that cannot be derived client-side.
+   */
+  variant?: string,
 ): Observable<ReferenceInfo> {
   const {publishedId, draftId} = getIdPair(id)
 
@@ -73,6 +79,7 @@ export function getReferenceInfo(
         draftId,
         undefined,
         perspective,
+        variant,
       )
 
       return typeName$.pipe(
@@ -119,6 +126,8 @@ export function getReferenceInfo(
             refSchemaType,
             publishedId,
             perspective,
+            undefined,
+            variant,
           )
 
           return combineLatest([previewState$, publishedDocumentExists$]).pipe(

--- a/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
+++ b/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
@@ -70,7 +70,7 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
   // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
   const source = useSource()
   const searchClient = source.getClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
-  const {perspectiveStack} = usePerspective()
+  const {perspectiveStack, selectedVariantName} = usePerspective()
   const schema = useSchema()
   const maxFieldDepth = useSearchMaxFieldDepth()
   const documentPreviewStore = useDocumentPreviewStore()
@@ -123,6 +123,7 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
           maxFieldDepth,
           strategy: searchStrategy,
           perspective: userDefinedFilterPerspective || perspectiveStack,
+          variant: selectedVariantName,
         }
 
         const search = createSearch(schemaType.to, searchClient, {
@@ -132,6 +133,7 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
 
         return search(searchString, {
           perspective: options.perspective,
+          variant: options.variant,
           // todo: consider using this to show a "More hits, please refine your search"-item at the end of the dropdown list
           limit: 101,
         }).pipe(
@@ -251,8 +253,14 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
 
   const getReferenceInfo = useCallback(
     (id: string, _type: ReferenceSchemaType) =>
-      adapter.getReferenceInfo(documentPreviewStore, id, _type, perspectiveStack),
-    [documentPreviewStore, perspectiveStack],
+      adapter.getReferenceInfo(
+        documentPreviewStore,
+        id,
+        _type,
+        perspectiveStack,
+        selectedVariantName,
+      ),
+    [documentPreviewStore, perspectiveStack, selectedVariantName],
   )
 
   return (

--- a/packages/sanity/src/core/preview/__test__/createPathObserver.test.ts
+++ b/packages/sanity/src/core/preview/__test__/createPathObserver.test.ts
@@ -424,7 +424,48 @@ describe('createPathObserver', () => {
       expect(values.length).toBeGreaterThanOrEqual(1)
       const last = values[values.length - 1]
       expect(last).toMatchObject({author: {name: 'Alice'}})
-      expect(observeFields).toHaveBeenCalledWith('author1', ['name'], undefined, undefined)
+      expect(observeFields).toHaveBeenCalledWith(
+        'author1',
+        ['name'],
+        undefined,
+        undefined,
+        undefined,
+      )
+
+      unsubscribe()
+    })
+
+    it('should keep resolving referenced documents within the given variant', () => {
+      const observeFields = vi.fn((id: string): Observable<Record<string, unknown> | null> => {
+        if (id === 'book1') {
+          return of({
+            _id: 'book1',
+            _rev: 'rev1',
+            _type: 'book',
+            author: {_ref: 'author1', _type: 'reference'},
+          })
+        }
+        return of({_id: 'author1', _rev: 'rev1', _type: 'author', name: 'Alice'})
+      })
+
+      const observePaths = createPathObserver({observeFields})
+      const {unsubscribe} = collectEmissions(
+        observePaths(
+          {_type: 'reference', _ref: 'book1'},
+          [['author', 'name']],
+          undefined,
+          ['drafts'],
+          'alpha-audience',
+        ),
+      )
+
+      expect(observeFields).toHaveBeenCalledWith(
+        'author1',
+        ['name'],
+        undefined,
+        ['drafts'],
+        'alpha-audience',
+      )
 
       unsubscribe()
     })

--- a/packages/sanity/src/core/preview/__test__/observeFields.test.ts
+++ b/packages/sanity/src/core/preview/__test__/observeFields.test.ts
@@ -418,4 +418,108 @@ describe('observeFields', () => {
       sub.unsubscribe()
     })
   })
+
+  describe('variant', () => {
+    const SETTLE_TIME = 200
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    function setupVariantTest() {
+      const fetches: {query: string; options: Record<string, unknown>}[] = []
+      const apiVersions: (string | undefined)[] = []
+
+      const client = {
+        observable: {
+          fetch: (query: string, _params: unknown, options: Record<string, unknown>) => {
+            fetches.push({query, options})
+            return of([
+              [{_id: 'foo', _rev: `rev${fetches.length}`, _type: 'testDoc', title: 'Test'}],
+            ])
+          },
+        },
+        withConfig: (config: {apiVersion?: string}) => {
+          apiVersions.push(config.apiVersion)
+          return client
+        },
+      }
+
+      const channel = new Subject<InvalidationChannelEvent>()
+      const observe = createObserveFields({
+        invalidationChannel: channel,
+        client: client as unknown as SanityClient,
+      })
+
+      return {fetches, apiVersions, channel, observe}
+    }
+
+    it('passes the variant to the query and uses the variants api version', async () => {
+      const harness = setupVariantTest()
+      const sub = harness.observe('foo', ['title'], undefined, ['drafts'], 'alpha').subscribe()
+
+      harness.channel.next({type: 'connected'})
+      await vi.advanceTimersByTimeAsync(SETTLE_TIME)
+
+      expect(harness.fetches[0].options).toMatchObject({
+        perspective: ['drafts'],
+        variant: 'alpha',
+      })
+      expect(harness.apiVersions).toContain('X')
+      sub.unsubscribe()
+    })
+
+    it('does not share cached field observers between variants', async () => {
+      const harness = setupVariantTest()
+      const subs = [
+        harness.observe('foo', ['title'], undefined, ['drafts']).subscribe(),
+        harness.observe('foo', ['title'], undefined, ['drafts'], 'alpha').subscribe(),
+        harness.observe('foo', ['title'], undefined, ['drafts'], 'beta').subscribe(),
+      ]
+
+      harness.channel.next({type: 'connected'})
+      await vi.advanceTimersByTimeAsync(SETTLE_TIME)
+
+      expect(harness.fetches.map((fetch) => fetch.options.variant)).toEqual([
+        undefined,
+        'alpha',
+        'beta',
+      ])
+      subs.forEach((sub) => sub.unsubscribe())
+    })
+
+    it('re-fetches for versions outside the perspective stack, since variant scope ids are opaque', async () => {
+      const harness = setupVariantTest()
+      const sub = harness.observe('foo', ['title'], undefined, ['drafts'], 'alpha').subscribe()
+
+      harness.channel.next({type: 'connected'})
+      await vi.advanceTimersByTimeAsync(SETTLE_TIME)
+      const afterConnect = harness.fetches.length
+
+      sendMutations(harness.channel, 'versions.p8Ab12cd34.foo')
+      await vi.advanceTimersByTimeAsync(SETTLE_TIME)
+
+      expect(harness.fetches.length).toBeGreaterThan(afterConnect)
+      sub.unsubscribe()
+    })
+
+    it('does not re-fetch for unrelated documents when a variant is selected', async () => {
+      const harness = setupVariantTest()
+      const sub = harness.observe('foo', ['title'], undefined, ['drafts'], 'alpha').subscribe()
+
+      harness.channel.next({type: 'connected'})
+      await vi.advanceTimersByTimeAsync(SETTLE_TIME)
+      const afterConnect = harness.fetches.length
+
+      sendMutations(harness.channel, ['bar', 'drafts.bar', 'versions.p8Ab12cd34.bar'])
+      await vi.advanceTimersByTimeAsync(SETTLE_TIME)
+
+      expect(harness.fetches.length).toBe(afterConnect)
+      sub.unsubscribe()
+    })
+  })
 })

--- a/packages/sanity/src/core/preview/components/Preview.tsx
+++ b/packages/sanity/src/core/preview/components/Preview.tsx
@@ -6,7 +6,9 @@ import {PreviewLoader} from './PreviewLoader'
 /**
  * @internal
  */
-export function Preview(props: RenderPreviewCallbackProps & {perspectiveStack?: PerspectiveStack}) {
+export function Preview(
+  props: RenderPreviewCallbackProps & {perspectiveStack?: PerspectiveStack; variant?: string},
+) {
   const PreviewComponent = usePreviewComponent()
   return <PreviewLoader {...props} component={PreviewComponent} />
 }

--- a/packages/sanity/src/core/preview/components/PreviewLoader.tsx
+++ b/packages/sanity/src/core/preview/components/PreviewLoader.tsx
@@ -21,6 +21,7 @@ export function PreviewLoader(
   props: RenderPreviewCallbackProps & {
     component: ComponentType<Omit<PreviewProps, 'renderDefault'>>
     perspectiveStack?: PerspectiveStack
+    variant?: string
   },
 ): React.JSX.Element {
   const {
@@ -31,6 +32,7 @@ export function PreviewLoader(
     schemaType,
     skipVisibilityCheck,
     perspectiveStack,
+    variant,
     ...restProps
   } = props
 
@@ -51,6 +53,7 @@ export function PreviewLoader(
     schemaType,
     value,
     perspectiveStack,
+    variant,
   })
 
   const style: CSSProperties = useMemo(

--- a/packages/sanity/src/core/preview/createPathObserver.ts
+++ b/packages/sanity/src/core/preview/createPathObserver.ts
@@ -31,6 +31,7 @@ type ObserveFieldsFn = (
   fields: FieldName[],
   apiConfig?: ApiConfig,
   perspective?: StackablePerspective[],
+  variant?: string,
 ) => Observable<Record<string, unknown> | null>
 
 function observePaths(
@@ -39,6 +40,7 @@ function observePaths(
   observeFields: ObserveFieldsFn,
   apiConfig?: ApiConfig,
   perspective?: StackablePerspective[],
+  variant?: string,
 ): Observable<Record<string, unknown> | null> {
   if (!value || typeof value !== 'object') {
     // Reached a leaf. Return as is
@@ -70,7 +72,7 @@ function observePaths(
       ? {projectId: value._projectId, dataset: value._dataset}
       : apiConfig
 
-    return observeFields(id, nextHeads, refApiConfig, perspective).pipe(
+    return observeFields(id, nextHeads, refApiConfig, perspective, variant).pipe(
       distinctUntilChanged((prev, curr) => prev?._rev === curr?._rev),
       switchMap((snapshot) => {
         if (snapshot === null) {
@@ -87,6 +89,7 @@ function observePaths(
           observeFields,
           refApiConfig,
           perspective,
+          variant,
         )
       }),
     )
@@ -110,7 +113,14 @@ function observePaths(
           ? (value as Record<string, unknown>)[head]
           : undefined
     } else {
-      res[head] = observePaths((value as any)[head], tails, observeFields, apiConfig, perspective)
+      res[head] = observePaths(
+        (value as any)[head],
+        tails,
+        observeFields,
+        apiConfig,
+        perspective,
+        variant,
+      )
     }
     return res
   }, currentValue)
@@ -141,7 +151,15 @@ export function createPathObserver(options: {observeFields: ObserveFieldsFn}) {
     paths: (FieldName | PreviewPath)[],
     apiConfig?: ApiConfig,
     perspective?: StackablePerspective[],
+    variant?: string,
   ): Observable<Record<string, unknown> | null> => {
-    return observePaths(value, normalizePaths(paths), observeFields, apiConfig, perspective)
+    return observePaths(
+      value,
+      normalizePaths(paths),
+      observeFields,
+      apiConfig,
+      perspective,
+      variant,
+    )
   }
 }

--- a/packages/sanity/src/core/preview/createPreviewObserver.ts
+++ b/packages/sanity/src/core/preview/createPreviewObserver.ts
@@ -46,9 +46,10 @@ export function createPreviewObserver(context: {
       viewOptions?: PrepareViewOptions
       apiConfig?: ApiConfig
       perspective?: StackablePerspective[]
+      variant?: string
     } = {},
   ): Observable<PreparedSnapshot> {
-    const {viewOptions = {}, apiConfig, perspective} = options
+    const {viewOptions = {}, apiConfig, perspective, variant} = options
     if (isCrossDatasetReferenceSchemaType(type)) {
       // if the value is of type crossDatasetReference, but has no _ref property, we cannot prepare any value for the preview
       // and the most appropriate thing to do is to return `undefined` for snapshot
@@ -58,7 +59,7 @@ export function createPreviewObserver(context: {
 
       const refApiConfig = {projectId: value._projectId, dataset: value._dataset}
 
-      return observeDocumentTypeFromId(value._ref, refApiConfig, perspective).pipe(
+      return observeDocumentTypeFromId(value._ref, refApiConfig, perspective, variant).pipe(
         switchMap((typeName) => {
           if (typeName) {
             const refType = type.to.find((toType) => toType.type === typeName)
@@ -67,6 +68,7 @@ export function createPreviewObserver(context: {
                 apiConfig: refApiConfig,
                 viewOptions,
                 perspective,
+                variant,
               })
             }
           }
@@ -83,12 +85,12 @@ export function createPreviewObserver(context: {
       // Previewing references actually means getting the referenced value,
       // and preview using the preview config of its type
       // We do this since there's no way of knowing the type of the referenced value by looking at the reference value alone
-      return observeDocumentTypeFromId(value._ref, undefined, perspective).pipe(
+      return observeDocumentTypeFromId(value._ref, undefined, perspective, variant).pipe(
         switchMap((typeName) => {
           if (typeName) {
             const refType = type.to.find((toType) => toType.name === typeName)
             if (refType) {
-              return observeForPreview(value, refType, {perspective})
+              return observeForPreview(value, refType, {perspective, variant})
             }
           }
           // todo: in case we can't read the document type, we can figure out the reason why e.g. whether it's because
@@ -101,7 +103,7 @@ export function createPreviewObserver(context: {
     }
     const paths = getPreviewPaths(type.preview)
     if (paths) {
-      return observePaths(value, paths, apiConfig, perspective).pipe(
+      return observePaths(value, paths, apiConfig, perspective, variant).pipe(
         map((snapshot) => ({
           type: type,
           snapshot: snapshot ? prepareForPreview(snapshot, type, viewOptions) : null,

--- a/packages/sanity/src/core/preview/documentPreviewStore.ts
+++ b/packages/sanity/src/core/preview/documentPreviewStore.ts
@@ -44,6 +44,11 @@ export type ObserveForPreviewFn = (
   options?: {
     viewOptions?: PrepareViewOptions
     perspective?: StackablePerspective[]
+    /**
+     * The selected editing variant as a bare variant id. When set, preview values are resolved as
+     * seen through that variant, on top of the given perspective.
+     */
+    variant?: string
     apiConfig?: ApiConfig
   },
 ) => Observable<PreparedSnapshot>
@@ -63,11 +68,13 @@ export interface DocumentPreviewStore {
     id: string,
     apiConfig?: ApiConfig,
     perspective?: StackablePerspective[],
+    variant?: string,
   ) => Observable<string | undefined>
   observeDocumentSystemFromId: (
     id: string,
     apiConfig?: ApiConfig,
     perspective?: StackablePerspective[],
+    variant?: string,
   ) => Observable<DocumentSystem | undefined>
 
   /**
@@ -190,8 +197,15 @@ export function createDocumentPreviewStore({
     id: string,
     apiConfig?: ApiConfig,
     perspective?: StackablePerspective[],
+    variant?: string,
   ): Observable<string | undefined> {
-    return observePaths({_type: 'reference', _ref: id}, ['_type'], apiConfig, perspective).pipe(
+    return observePaths(
+      {_type: 'reference', _ref: id},
+      ['_type'],
+      apiConfig,
+      perspective,
+      variant,
+    ).pipe(
       map((res) => (isRecord(res) && typeof res._type === 'string' ? res._type : undefined)),
       distinctUntilChanged(),
     )
@@ -200,6 +214,7 @@ export function createDocumentPreviewStore({
     id: string,
     apiConfig?: ApiConfig,
     perspective?: StackablePerspective[],
+    variant?: string,
     // TODO: This shouldn't be undefined once the documents are migrated.
   ): Observable<DocumentSystem | undefined> {
     return observePaths(
@@ -207,6 +222,7 @@ export function createDocumentPreviewStore({
       [DOCUMENT_SYSTEM_FIELD],
       apiConfig,
       perspective,
+      variant,
     ).pipe(
       map((res) =>
         isRecord(res) && isRecord(res[DOCUMENT_SYSTEM_FIELD])

--- a/packages/sanity/src/core/preview/observeFields.ts
+++ b/packages/sanity/src/core/preview/observeFields.ts
@@ -260,7 +260,7 @@ export function createObserveFields(options: {
           // Variant documents are `versions.<opaqueScopeId>.<groupId>`, and scope ids never appear
           // in the perspective stack, so the stack check can't recognise them. Under a variant
           // selection, any mutation within the document group is treated as relevant.
-          return variant ? true : idMatchesPerspective(perspective, event.documentId)
+          return Boolean(variant) || idMatchesPerspective(perspective, event.documentId)
         }
         // if not using perspective, refetch previews for the document that was actually changed
         return event.documentId === documentId

--- a/packages/sanity/src/core/preview/observeFields.ts
+++ b/packages/sanity/src/core/preview/observeFields.ts
@@ -32,6 +32,7 @@ import {RELEASES_STUDIO_CLIENT_OPTIONS} from '../releases/util/releasesClient'
 import {versionedClient} from '../studioClient'
 import {MAX_DOCUMENT_ID_CHUNK_SIZE} from '../util/const'
 import {getPublishedId, idMatchesPerspective, isVersionId} from '../util/draftUtils'
+import {variantApiVersion} from '../variants/util/variantApiVersion'
 import {INCLUDE_FIELDS} from './constants'
 import {
   type ApiConfig,
@@ -93,6 +94,18 @@ export function chunkCombinedSelections(
   return chunks
 }
 
+/**
+ * Cache key for the combination of perspective stack and variant a fetch is scoped to. Preview
+ * values differ per combination, so caches must never be shared across them.
+ */
+function getPerspectiveCacheKey(
+  perspective: StackablePerspective[] | undefined,
+  variant: string | undefined,
+): string {
+  const perspectiveKey = perspective?.join('-') || 'raw'
+  return variant ? `${perspectiveKey}-variant:${variant}` : perspectiveKey
+}
+
 type CachedFieldObserver = {
   id: Id
   fields: FieldName[]
@@ -130,7 +143,11 @@ export function createObserveFields(options: {
 }) {
   const {client: currentDatasetClient, invalidationChannel} = options
 
-  function fetchAllDocumentPathsWith(client: SanityClient, perspective?: StackablePerspective[]) {
+  function fetchAllDocumentPathsWith(
+    client: SanityClient,
+    perspective?: StackablePerspective[],
+    variant?: string,
+  ) {
     return function fetchAllDocumentPath(selections: Selection[]) {
       const combinedSelections = combineSelections(selections)
       // If any document is a version document we need to use the release API version
@@ -140,7 +157,10 @@ export function createObserveFields(options: {
 
       const apiClient = versionedClient(
         client,
-        useReleaseVersion ? RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion : undefined,
+        variantApiVersion(
+          variant,
+          useReleaseVersion ? RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion : undefined,
+        ),
       )
 
       // Chunk the selections to avoid massive queries that timeout
@@ -149,7 +169,7 @@ export function createObserveFields(options: {
       // Helper to fetch a single chunk
       const fetchChunk = (chunk: CombinedSelection[]) =>
         apiClient.observable
-          .fetch(toQuery(chunk), {}, {tag: 'preview.document-paths', perspective})
+          .fetch(toQuery(chunk), {}, {tag: 'preview.document-paths', perspective, variant})
           .pipe(
             retry({
               delay: (_: unknown, attempt) => timer(Math.min(30_000, attempt * 1000)),
@@ -184,14 +204,20 @@ export function createObserveFields(options: {
     }
   }
   const batchFetchersCache = new Map()
-  function getBatchFetchersForPerspective(perspective?: StackablePerspective[]) {
-    const key = perspective?.join('-') || 'raw'
+  function getBatchFetchersForPerspective(perspective?: StackablePerspective[], variant?: string) {
+    const key = getPerspectiveCacheKey(perspective, variant)
     if (batchFetchersCache.has(key)) {
       return batchFetchersCache.get(key)
     }
     const batchFetchers = {
-      fast: debounceCollect(fetchAllDocumentPathsWith(currentDatasetClient, perspective), 100),
-      slow: debounceCollect(fetchAllDocumentPathsWith(currentDatasetClient, perspective), 1000),
+      fast: debounceCollect(
+        fetchAllDocumentPathsWith(currentDatasetClient, perspective, variant),
+        100,
+      ),
+      slow: debounceCollect(
+        fetchAllDocumentPathsWith(currentDatasetClient, perspective, variant),
+        1000,
+      ),
     }
     batchFetchersCache.set(key, batchFetchers)
     return batchFetchers
@@ -201,9 +227,10 @@ export function createObserveFields(options: {
     documentId: Id,
     fields: FieldName[],
     perspective?: StackablePerspective[],
+    variant?: string,
   ) {
     const {fast: fetchDocumentPathsFast, slow: fetchDocumentPathsSlow} =
-      getBatchFetchersForPerspective(perspective)
+      getBatchFetchersForPerspective(perspective, variant)
 
     const hasPerspective = perspective && perspective.length > 0
     /**
@@ -227,10 +254,13 @@ export function createObserveFields(options: {
           // version is relevant to the current perspective stack (e.g. drafts,
           // a specific release). This avoids refetching for unrelated documents
           // or versions outside the active perspective.
-          return (
-            getPublishedId(event.documentId) === getPublishedId(documentId) &&
-            idMatchesPerspective(perspective, event.documentId)
-          )
+          if (getPublishedId(event.documentId) !== getPublishedId(documentId)) {
+            return false
+          }
+          // Variant documents are `versions.<opaqueScopeId>.<groupId>`, and scope ids never appear
+          // in the perspective stack, so the stack check can't recognise them. Under a variant
+          // selection, any mutation within the document group is treated as relevant.
+          return variant ? true : idMatchesPerspective(perspective, event.documentId)
         }
         // if not using perspective, refetch previews for the document that was actually changed
         return event.documentId === documentId
@@ -291,6 +321,7 @@ export function createObserveFields(options: {
     fields: FieldName[],
     apiConfig?: ApiConfig,
     perspective?: StackablePerspective[],
+    variant?: string,
   ): CachedFieldObserver {
     // Note: `undefined` means the memo has not been set, while `null` means the memo is explicitly set to null (e.g. we did fetch, but got null back)
     let latest: T | undefined | null
@@ -298,7 +329,7 @@ export function createObserveFields(options: {
       defer(() => (latest === undefined ? EMPTY : of(latest))),
       (apiConfig
         ? (crossDatasetListenFields(id, fields, apiConfig) as any)
-        : currentDatasetListenFields(id, fields, perspective)) as Observable<T>,
+        : currentDatasetListenFields(id, fields, perspective, variant)) as Observable<T>,
     ).pipe(
       tap((v: T | null) => (latest = v)),
       shareReplay({refCount: true, bufferSize: 1}),
@@ -312,10 +343,11 @@ export function createObserveFields(options: {
     fields: FieldName[],
     apiConfig?: ApiConfig,
     perspective?: StackablePerspective[],
+    variant?: string,
   ) {
     const cacheKey = apiConfig
       ? `${apiConfig.projectId}:${apiConfig.dataset}:${id}`
-      : `$current$-${id}-${perspective?.join('-') || 'raw'}`
+      : `$current$-${id}-${getPerspectiveCacheKey(perspective, variant)}`
 
     if (!(cacheKey in CACHE)) {
       CACHE[cacheKey] = []
@@ -328,7 +360,7 @@ export function createObserveFields(options: {
     )
 
     if (missingFields.length > 0) {
-      existingObservers.push(createCachedFieldObserver(id, fields, apiConfig, perspective))
+      existingObservers.push(createCachedFieldObserver(id, fields, apiConfig, perspective, variant))
     }
 
     const cachedFieldObservers = existingObservers

--- a/packages/sanity/src/core/preview/types.ts
+++ b/packages/sanity/src/core/preview/types.ts
@@ -160,6 +160,7 @@ export type ObserveDocumentTypeFromIdFn = (
   id: string,
   apiConfig?: ApiConfig,
   perspective?: StackablePerspective[],
+  variant?: string,
 ) => Observable<string | undefined>
 
 /**
@@ -171,6 +172,7 @@ export interface ObservePathsFn {
     paths: (string | PreviewPath)[],
     apiConfig?: ApiConfig,
     perspective?: StackablePerspective[],
+    variant?: string,
   ): Observable<PreviewValue | SanityDocumentLike | Reference | string | null>
 }
 

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -47,6 +47,14 @@ export function useValuePreview(props: {
   schemaType?: SchemaType
   value: unknown | undefined
   perspectiveStack?: PerspectiveStack
+  /**
+   * The variant to preview the value as seen through, as a bare variant id.
+   *
+   * The variant travels with the perspective: when no `perspectiveStack` is given, both default to
+   * the current selection in the perspective context. When a `perspectiveStack` is given, the
+   * caller is previewing a specific document version and only the variant it passes here is used.
+   */
+  variant?: string
 }): State {
   const {
     enabled = true,
@@ -54,23 +62,30 @@ export function useValuePreview(props: {
     schemaType,
     value: previewValue,
     perspectiveStack: chosenPerspectiveStack,
+    variant: chosenVariant,
   } = props || {}
   const {observeForPreview} = useDocumentPreviewStore()
-  const {perspectiveStack} = usePerspective()
+  const {perspectiveStack, selectedVariantName} = usePerspective()
   const observable = useMemo<Observable<State>>(() => {
     // this will render previews as "loaded" (i.e. not in loading state) – typically with "Untitled" text
     if (!enabled || !previewValue || !schemaType) return of(IDLE_STATE)
 
-    const updatedStack = isGoingToUnpublish(previewValue as SanityDocument)
-      ? []
-      : (chosenPerspectiveStack ?? perspectiveStack)
-    const updatedDocId = isGoingToUnpublish(previewValue as SanityDocument)
+    const goingToUnpublish = isGoingToUnpublish(previewValue as SanityDocument)
+
+    const updatedStack = goingToUnpublish ? [] : (chosenPerspectiveStack ?? perspectiveStack)
+    // A document slated for unpublishing is previewed as its published version, which is outside
+    // of any variant. Otherwise the variant follows the perspective: only inherited from the
+    // context when the perspective is too.
+    const updatedVariant = goingToUnpublish
+      ? undefined
+      : (chosenVariant ?? (chosenPerspectiveStack ? undefined : selectedVariantName))
+    const updatedDocId = goingToUnpublish
       ? getPublishedId((previewValue as SanityDocument)._id)
       : (previewValue as SanityDocument)._id
 
     // allow for previewing the published document when a version is slated for unpublishing
     // but if it's not for unpublishing, then we want to preview the content as was before
-    const restPreviewValue = isGoingToUnpublish(previewValue as SanityDocument)
+    const restPreviewValue = goingToUnpublish
       ? {}
       : {
           ...(previewValue as Previewable),
@@ -84,6 +99,7 @@ export function useValuePreview(props: {
       schemaType,
       {
         perspective: updatedStack,
+        variant: updatedVariant,
         viewOptions: {ordering: ordering},
       },
     ).pipe(
@@ -96,6 +112,8 @@ export function useValuePreview(props: {
     schemaType,
     chosenPerspectiveStack,
     perspectiveStack,
+    chosenVariant,
+    selectedVariantName,
     observeForPreview,
     ordering,
   ])

--- a/packages/sanity/src/core/preview/utils/getPreviewStateObservable.test.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewStateObservable.test.ts
@@ -15,7 +15,7 @@ function createMockDocumentPreviewStore() {
   const calls: Array<{
     document: {_id: string}
     schemaType: SchemaType
-    options: {perspective?: unknown; viewOptions?: PrepareViewOptions}
+    options: {perspective?: unknown; variant?: string; viewOptions?: PrepareViewOptions}
   }> = []
 
   return {
@@ -24,7 +24,7 @@ function createMockDocumentPreviewStore() {
       (
         document: {_id: string},
         schemaType: SchemaType,
-        options: {perspective?: unknown; viewOptions?: PrepareViewOptions},
+        options: {perspective?: unknown; variant?: string; viewOptions?: PrepareViewOptions},
       ) => {
         calls.push({document, schemaType, options})
         // Return a minimal observable that emits once
@@ -141,6 +141,40 @@ describe('getPreviewStateObservable', () => {
       expect(passedOrdering?.by).toHaveLength(2)
       expect(passedOrdering?.by[0]).toEqual({field: 'category', direction: 'asc'})
       expect(passedOrdering?.by[1]).toEqual({field: '_createdAt', direction: 'desc'})
+    })
+  })
+
+  describe('variant threading', () => {
+    it('passes the variant to both the perspective and the fallback snapshot', () => {
+      const store = createMockDocumentPreviewStore()
+
+      getPreviewStateObservable(
+        store as any,
+        mockSchemaType,
+        'article-123',
+        ['drafts'],
+        undefined,
+        'alpha-audience',
+      )
+
+      expect(store.calls[0].options).toMatchObject({
+        perspective: ['drafts'],
+        variant: 'alpha-audience',
+      })
+      // The fallback snapshot pins its own perspective, but must stay within the variant
+      expect(store.calls[1].options).toMatchObject({
+        perspective: ['drafts'],
+        variant: 'alpha-audience',
+      })
+    })
+
+    it('does not pass a variant when none is given', () => {
+      const store = createMockDocumentPreviewStore()
+
+      getPreviewStateObservable(store as any, mockSchemaType, 'article-123', ['drafts'])
+
+      expect(store.calls[0].options.variant).toBeUndefined()
+      expect(store.calls[1].options.variant).toBeUndefined()
     })
   })
 })

--- a/packages/sanity/src/core/preview/utils/getPreviewStateObservable.ts
+++ b/packages/sanity/src/core/preview/utils/getPreviewStateObservable.ts
@@ -38,11 +38,16 @@ export function getPreviewStateObservable(
   documentId: string,
   perspective?: PerspectiveStack,
   viewOptions?: PrepareViewOptions,
+  /**
+   * The selected editing variant as a bare variant id. When set, both the perspective snapshot and
+   * the fallback snapshot are resolved as seen through that variant.
+   */
+  variant?: string,
 ): Observable<PreviewState> {
   const perspectiveSnapshot = documentPreviewStore.observeForPreview(
     {_id: getPublishedId(documentId)},
     schemaType,
-    {perspective, viewOptions},
+    {perspective, variant, viewOptions},
   )
 
   const versionOrDraftId = isVersionId(documentId) ? getVersionFromId(documentId) : 'drafts'
@@ -50,6 +55,7 @@ export function getPreviewStateObservable(
   const preparedVersionSnapshot = versionOrDraftId
     ? documentPreviewStore.observeForPreview({_id: getPublishedId(documentId)}, schemaType, {
         perspective: [versionOrDraftId],
+        variant,
         viewOptions,
       })
     : of(null)

--- a/packages/sanity/src/core/search/common/types.ts
+++ b/packages/sanity/src/core/search/common/types.ts
@@ -81,6 +81,11 @@ export interface SearchFactoryOptions {
   unique?: boolean
   strategy?: SearchStrategy
   perspective?: ClientPerspective
+  /**
+   * The selected editing variant as a bare variant id. When set, documents are searched as seen
+   * through that variant, on top of `perspective`.
+   */
+  variant?: string
 }
 
 /**
@@ -121,6 +126,11 @@ export type SearchOptions = {
   cursor?: string
   limit?: number
   perspective?: ClientPerspective
+  /**
+   * The selected editing variant as a bare variant id. When set, documents are searched as seen
+   * through that variant, on top of `perspective`.
+   */
+  variant?: string
   isCrossDataset?: boolean
   queryType?: 'prefixLast' | 'prefixNone'
 }

--- a/packages/sanity/src/core/search/groq2024/createGroq2024Search.ts
+++ b/packages/sanity/src/core/search/groq2024/createGroq2024Search.ts
@@ -103,6 +103,7 @@ export const createGroq2024Search: SearchStrategyFactory<Groq2024SearchResults> 
       .fetch<string[]>(resolveQuery.query, resolveQuery.params, {
         tag: mergedOptions.tag,
         perspective: mergedOptions.perspective,
+        variant: mergedOptions.variant,
       })
       .pipe(
         // Reference resolution is an enhancement: if phase one fails, fall back

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
@@ -68,6 +68,7 @@ export function createSearchQuery(
   searchParams: string | SearchTerms,
   {
     perspective,
+    variant,
     sort,
     isCrossDataset,
     tag,
@@ -181,6 +182,7 @@ export function createSearchQuery(
     options: {
       tag: tag,
       perspective,
+      variant,
     },
     params: finalParams,
     sortOrder,

--- a/packages/sanity/src/core/search/search.ts
+++ b/packages/sanity/src/core/search/search.ts
@@ -2,6 +2,7 @@ import {type SearchStrategy} from '@sanity/types'
 
 import {isReleasePerspective, RELEASES_STUDIO_CLIENT_OPTIONS} from '../releases/util/releasesClient'
 import {versionedClient} from '../studioClient'
+import {variantApiVersion} from '../variants/util/variantApiVersion'
 import {
   type Groq2024SearchResults,
   type SearchStrategyFactory,
@@ -28,11 +29,12 @@ export const createSearch: SearchStrategyFactory<WeightedSearchResults | Groq202
 ) => {
   const factory = searchStrategies[options.strategy ?? DEFAULT_SEARCH_STRATEGY]
 
-  return factory(
-    searchableTypes,
+  const apiVersion = variantApiVersion(
+    options?.variant,
     isReleasePerspective(options?.perspective)
-      ? versionedClient(client, RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion)
-      : client,
-    options,
+      ? RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion
+      : undefined,
   )
+
+  return factory(searchableTypes, versionedClient(client, apiVersion), options)
 }

--- a/packages/sanity/src/core/search/weighted/createSearchQuery.test.ts
+++ b/packages/sanity/src/core/search/weighted/createSearchQuery.test.ts
@@ -352,6 +352,19 @@ describe('createSearchQuery', () => {
       expect(options.tag).toEqual('customTag')
     })
 
+    it('should pass the configured perspective and variant as query options', () => {
+      const {options} = createSearchQuery(
+        {
+          query: 'term',
+          types: [testType],
+        },
+        {perspective: ['rSummer', 'drafts'], variant: 'alpha-audience'},
+      )
+
+      expect(options.perspective).toEqual(['rSummer', 'drafts'])
+      expect(options.variant).toEqual('alpha-audience')
+    })
+
     it('should use configured sort field and direction', () => {
       const {query} = createSearchQuery(
         {

--- a/packages/sanity/src/core/search/weighted/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/weighted/createSearchQuery.ts
@@ -108,8 +108,18 @@ export function createSearchQuery(
   searchTerms: SearchTerms<SchemaType | CrossDatasetType>,
   searchOpts: SearchOptions & SearchFactoryOptions = {},
 ): SearchQuery {
-  const {filter, params, tag, maxDepth, isCrossDataset, perspective, sort, limit, comments} =
-    searchOpts
+  const {
+    filter,
+    params,
+    tag,
+    maxDepth,
+    isCrossDataset,
+    perspective,
+    variant,
+    sort,
+    limit,
+    comments,
+  } = searchOpts
 
   const specs = searchTerms.types
     .map((schemaType) =>
@@ -190,6 +200,7 @@ export function createSearchQuery(
     options: {
       tag,
       perspective,
+      variant,
     },
     searchSpec: specs,
     terms,

--- a/packages/sanity/src/core/search/weighted/createWeightedSearch.test.ts
+++ b/packages/sanity/src/core/search/weighted/createWeightedSearch.test.ts
@@ -52,6 +52,26 @@ describe('createWeightedSearch', () => {
     expect(client.withConfig).toHaveBeenCalledWith({apiVersion: 'v2025-02-19'})
   })
 
+  it('overrides to use the variants api version and passes the variant when searching a variant', async () => {
+    await lastValueFrom(
+      search({query: 'harry', types: []} as SearchTerms, {
+        perspective: ['r123', 'drafts'],
+        variant: 'alpha-audience',
+      }),
+    )
+
+    expect(client.withConfig).toHaveBeenCalledWith({apiVersion: 'X'})
+
+    const versionedClient = (client.withConfig as Mock).mock.results.at(-1)?.value as {
+      observable: {fetch: Mock}
+    }
+    expect(versionedClient.observable.fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      expect.objectContaining({variant: 'alpha-audience', perspective: ['r123', 'drafts']}),
+    )
+  })
+
   it('should order hits by score by default', async () => {
     const result = await lastValueFrom(search({query: 'harry', types: []} as SearchTerms))
 

--- a/packages/sanity/src/core/search/weighted/createWeightedSearch.ts
+++ b/packages/sanity/src/core/search/weighted/createWeightedSearch.ts
@@ -8,6 +8,7 @@ import {
 } from '../../releases/util/releasesClient'
 import {versionedClient} from '../../studioClient'
 import {removeDupes} from '../../util/draftUtils'
+import {variantApiVersion} from '../../variants/util/variantApiVersion'
 import {
   type SearchStrategyFactory,
   type SearchTerms,
@@ -47,9 +48,12 @@ export const createWeightedSearch: SearchStrategyFactory<WeightedSearchResults> 
       ...searchOptions,
     })
 
-    const apiVersion = isReleasePerspective(options?.perspective as string | string[] | undefined)
-      ? RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion
-      : undefined
+    const apiVersion = variantApiVersion(
+      options?.variant as string | undefined,
+      isReleasePerspective(options?.perspective as string | string[] | undefined)
+        ? RELEASES_STUDIO_CLIENT_OPTIONS.apiVersion
+        : undefined,
+    )
 
     return versionedClient(client, apiVersion)
       .observable.fetch<SanityDocumentLike[]>(query, params, options)

--- a/packages/sanity/src/core/store/document/listenQuery.ts
+++ b/packages/sanity/src/core/store/document/listenQuery.ts
@@ -3,6 +3,8 @@ import {asyncScheduler, defer, merge, type Observable, of, partition, throwError
 import {exhaustMapWithTrailing} from 'rxjs-exhaustmap-with-trailing'
 import {filter, mergeMap, share, take, throttleTime} from 'rxjs/operators'
 
+import {versionedClient} from '../../studioClient'
+import {variantApiVersion} from '../../variants/util/variantApiVersion'
 import {type MutationEvent, type ReconnectEvent, type WelcomeEvent} from './types'
 
 /** @internal */
@@ -15,6 +17,11 @@ export interface ListenQueryOptions {
   tag?: string
   apiVersion?: string
   perspective?: ClientPerspective
+  /**
+   * The selected editing variant as a bare variant id. When set, documents are resolved as seen
+   * through that variant, on top of `perspective`.
+   */
+  variant?: string
   throttleTime?: number
   transitions?: ('update' | 'appear' | 'disappear')[]
 }
@@ -26,10 +33,11 @@ const fetch = (
   options: ListenQueryOptions,
 ) =>
   defer(() =>
-    client.observable.fetch(query, params, {
+    versionedClient(client, variantApiVersion(options.variant)).observable.fetch(query, params, {
       tag: options.tag,
       filterResponse: true,
       perspective: options.perspective,
+      variant: options.variant,
     }),
   )
 

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -87,7 +87,7 @@ export function StudioNavbar(props: Omit<NavbarProps, 'renderDefault'>) {
     searchOpen,
   } = useContext(NavbarContext)
 
-  const {selectedPerspective, perspectiveStack} = usePerspective()
+  const {selectedPerspective, perspectiveStack, selectedVariantName} = usePerspective()
 
   const ToolMenu = useToolMenuComponent()
 
@@ -267,6 +267,7 @@ export function StudioNavbar(props: Omit<NavbarProps, 'renderDefault'>) {
                           onOpen={handleOpenSearch}
                           open={searchOpen}
                           previewPerspective={perspectiveStack}
+                          previewVariant={selectedVariantName}
                         />
                       )}
                     </BoundaryElementProvider>

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -259,6 +259,8 @@ export function StudioNavbar(props: Omit<NavbarProps, 'renderDefault'>) {
                             onClose={handleCloseSearchFullscreen}
                             onOpen={handleOpenSearchFullscreen}
                             open={searchFullscreenOpen}
+                            previewPerspective={perspectiveStack}
+                            previewVariant={selectedVariantName}
                           />
                         </PortalProvider>
                       ) : (

--- a/packages/sanity/src/core/studio/components/navbar/search/SearchDialog.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/SearchDialog.tsx
@@ -1,3 +1,4 @@
+import {type StackablePerspective} from '@sanity/client'
 import {Box, Card, Portal} from '@sanity/ui'
 import {useState} from 'react'
 import FocusLock from 'react-focus-lock'
@@ -17,6 +18,11 @@ interface SearchDialogProps {
   onClose: () => void
   onOpen: () => void
   open: boolean
+  previewPerspective?: StackablePerspective[]
+  /**
+   * The variant the result previews are resolved in, as a bare variant id.
+   */
+  previewVariant?: string
 }
 
 const InnerCard = styled(Card)`
@@ -42,7 +48,13 @@ const SearchDialogBox = styled(Box)`
 /**
  * @internal
  */
-export function SearchDialog({onClose, onOpen, open}: SearchDialogProps) {
+export function SearchDialog({
+  onClose,
+  onOpen,
+  open,
+  previewPerspective,
+  previewVariant,
+}: SearchDialogProps) {
   const [inputElement, setInputElement] = useState<HTMLInputElement | null>(null)
   const scheme = useColorSchemeValue()
 
@@ -66,7 +78,11 @@ export function SearchDialog({onClose, onOpen, open}: SearchDialogProps) {
                   </Card>
                 )}
                 {hasValidTerms ? (
-                  <SearchResults inputElement={inputElement} />
+                  <SearchResults
+                    inputElement={inputElement}
+                    previewPerspective={previewPerspective}
+                    previewVariant={previewVariant}
+                  />
                 ) : (
                   <RecentSearches inputElement={inputElement} />
                 )}

--- a/packages/sanity/src/core/studio/components/navbar/search/components/SearchPopover.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/SearchPopover.tsx
@@ -31,6 +31,10 @@ export interface SearchPopoverProps {
   onItemSelect?: ItemSelectHandler
   previewPerspective?: StackablePerspective[]
   /**
+   * The variant the result previews are resolved in, as a bare variant id.
+   */
+  previewVariant?: string
+  /**
    * If provided, will trigger to open the search popover when user types hotkey + k
    */
   onOpen?: () => void
@@ -86,6 +90,7 @@ export function SearchPopover({
   onItemSelect,
   onOpen,
   previewPerspective,
+  previewVariant,
   open,
 }: SearchPopoverProps) {
   const [inputElement, setInputElement] = useState<HTMLInputElement | null>(null)
@@ -147,6 +152,7 @@ export function SearchPopover({
                     onItemSelect={onItemSelect}
                     disableIntentLink={disableIntentLink}
                     previewPerspective={previewPerspective}
+                    previewVariant={previewVariant}
                   />
                 ) : (
                   <RecentSearches inputElement={inputElement} />

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/SearchResults.tsx
@@ -32,6 +32,10 @@ interface SearchResultsProps {
   inputElement: HTMLInputElement | null
   onItemSelect?: ItemSelectHandler
   previewPerspective?: StackablePerspective[]
+  /**
+   * The variant the result previews are resolved in, as a bare variant id.
+   */
+  previewVariant?: string
 }
 
 export function SearchResults({
@@ -39,6 +43,7 @@ export function SearchResults({
   inputElement,
   onItemSelect,
   previewPerspective,
+  previewVariant,
 }: SearchResultsProps) {
   const {
     dispatch,
@@ -89,13 +94,21 @@ export function SearchResults({
             onClick={handleSearchResultClick}
             onItemSelect={onItemSelect}
             previewPerspective={previewPerspective}
+            previewVariant={previewVariant}
             paddingY={1}
           />
           {debug && <DebugOverlay data={item} />}
         </>
       )
     },
-    [debug, disableIntentLink, handleSearchResultClick, onItemSelect, previewPerspective],
+    [
+      debug,
+      disableIntentLink,
+      handleSearchResultClick,
+      onItemSelect,
+      previewPerspective,
+      previewVariant,
+    ],
   )
 
   return (

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
@@ -90,6 +90,8 @@ export function SearchResultItem({
     enabled: true,
     schemaType: type,
     value: documentStub,
+    perspectiveStack: previewPerspective,
+    variant: previewVariant,
   })
 
   const handleClick = useCallback(

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
@@ -28,6 +28,10 @@ interface SearchResultItemProps extends ResponsiveMarginProps, ResponsivePadding
   onClick?: (e: MouseEvent<HTMLElement>) => void
   onItemSelect?: ItemSelectHandler
   previewPerspective?: StackablePerspective[]
+  /**
+   * The variant the result previews are resolved in, as a bare variant id.
+   */
+  previewVariant?: string
 }
 
 export function SearchResultItem({
@@ -38,6 +42,7 @@ export function SearchResultItem({
   onClick,
   onItemSelect,
   previewPerspective,
+  previewVariant,
   ...rest
 }: SearchResultItemProps) {
   const schema = useSchema()
@@ -120,6 +125,7 @@ export function SearchResultItem({
           documentType={documentType}
           layout={layout}
           perspective={previewPerspective}
+          variant={previewVariant}
           presence={documentPresence}
           schemaType={type}
         />

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
@@ -23,6 +23,10 @@ interface SearchResultItemPreviewProps {
   layout?: GeneralPreviewLayoutKey
   presence?: DocumentPresence[]
   perspective?: PerspectiveStack
+  /**
+   * The variant the preview is resolved in, as a bare variant id. Travels with `perspective`.
+   */
+  variant?: string
   schemaType: SchemaType
   showBadge?: boolean
 }
@@ -56,12 +60,20 @@ export function SearchResultItemPreview({
   schemaType,
   showBadge = true,
   perspective,
+  variant,
 }: SearchResultItemPreviewProps) {
   const documentPreviewStore = useDocumentPreviewStore()
 
   const observable = useMemo(() => {
-    return getPreviewStateObservable(documentPreviewStore, schemaType, documentId, perspective)
-  }, [documentPreviewStore, schemaType, documentId, perspective])
+    return getPreviewStateObservable(
+      documentPreviewStore,
+      schemaType,
+      documentId,
+      perspective,
+      undefined,
+      variant,
+    )
+  }, [documentPreviewStore, schemaType, documentId, perspective, variant])
 
   const documentStub = useMemo(
     () => ({_id: documentId, _type: documentType}),

--- a/packages/sanity/src/core/tasks/components/activity/helpers/index.tsx
+++ b/packages/sanity/src/core/tasks/components/activity/helpers/index.tsx
@@ -84,11 +84,12 @@ function TargetContentChange({target}: {target: TaskTarget}) {
   const documentId = target.document._ref
   const documentType = target.documentType
   const documentSchema = schema.get(documentType)
-  const {perspectiveStack} = usePerspective()
+  const {perspectiveStack, selectedVariantName} = usePerspective()
   const {isLoading, value} = useDocumentPreviewValues({
     documentId,
     documentType,
     perspectiveStack,
+    variant: selectedVariantName,
   })
 
   if (isLoading) {

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksNotificationTarget.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/TasksNotificationTarget.tsx
@@ -50,11 +50,12 @@ function TasksNotificationTargetInner(props: ObjectFieldProps<TaskDocument>) {
   const documentId = target?.document?._ref ?? ''
   const documentType = target?.documentType ?? ''
 
-  const {perspectiveStack} = usePerspective()
+  const {perspectiveStack, selectedVariantName} = usePerspective()
   const {isLoading: previewValuesLoading, value} = useDocumentPreviewValues({
     documentId,
     documentType,
     perspectiveStack,
+    variant: selectedVariantName,
   })
   const targetContentTitle = value?.title || null
   const imageUrl = isImageSource(value?.media)

--- a/packages/sanity/src/core/tasks/components/list/DocumentPreview.tsx
+++ b/packages/sanity/src/core/tasks/components/list/DocumentPreview.tsx
@@ -27,11 +27,12 @@ export function DocumentPreview({
 }) {
   const schema = useSchema()
   const documentSchema = schema.get(documentType)
-  const {perspectiveStack} = usePerspective()
+  const {perspectiveStack, selectedVariantName} = usePerspective()
   const {isLoading, value} = useDocumentPreviewValues({
     documentId,
     documentType,
     perspectiveStack,
+    variant: selectedVariantName,
   })
 
   const Link = useMemo(

--- a/packages/sanity/src/core/tasks/hooks/useDocumentPreviewValues.ts
+++ b/packages/sanity/src/core/tasks/hooks/useDocumentPreviewValues.ts
@@ -13,6 +13,12 @@ interface PreviewHookOptions {
   documentType: string
   // to make sure that you can get the preview values for a document in a specific perspective stack
   perspectiveStack: string[]
+  /**
+   * The variant to resolve the preview values in, as a bare variant id. Like `perspectiveStack`,
+   * this is explicit: callers that want the variant currently selected in the studio pass
+   * `usePerspective().selectedVariantName`.
+   */
+  variant?: string
 }
 
 interface PreviewHookValue {
@@ -22,7 +28,12 @@ interface PreviewHookValue {
 
 /** @internal */
 export function useDocumentPreviewValues(options: PreviewHookOptions): PreviewHookValue {
-  const {documentId, documentType, perspectiveStack: perspectiveStackFromOptions} = options || {}
+  const {
+    documentId,
+    documentType,
+    perspectiveStack: perspectiveStackFromOptions,
+    variant,
+  } = options || {}
   const schemaType = useSchema().get(documentType)
 
   const documentPreviewStore = useDocumentPreviewStore()
@@ -38,8 +49,17 @@ export function useDocumentPreviewValues(options: PreviewHookOptions): PreviewHo
       schemaType,
       documentId,
       perspectiveStackFromOptions ?? perspectiveStack,
+      undefined,
+      variant,
     )
-  }, [documentId, documentPreviewStore, schemaType, perspectiveStackFromOptions, perspectiveStack])
+  }, [
+    documentId,
+    documentPreviewStore,
+    schemaType,
+    perspectiveStackFromOptions,
+    perspectiveStack,
+    variant,
+  ])
   // Deferred: react-rx v5's deferral is identity-coherent, so on a document
   // id change the live snapshot wins and the previous document's title/media
   // never pairs with the new identity.

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentPreview.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentPreview.tsx
@@ -91,6 +91,9 @@ export function VariantDocumentPreview({
     documentId: row.document._id,
     documentType: row.document._type,
     perspectiveStack,
+    // The table lists documents of the variant being viewed, so previews resolve in that variant
+    // rather than whichever variant is selected globally
+    variant: variantId,
   })
 
   return (

--- a/packages/sanity/src/core/variants/util/variantApiVersion.ts
+++ b/packages/sanity/src/core/variants/util/variantApiVersion.ts
@@ -7,7 +7,7 @@ import {VARIANTS_STUDIO_CLIENT_OPTIONS} from '../store/constants'
  * over any other version the caller would otherwise use (e.g. the releases version for stacked
  * perspectives).
  *
- * Intended to be used with {@link versionedClient}:
+ * Intended to be used with `versionedClient`:
  *
  * ```ts
  * versionedClient(client, variantApiVersion(variant, releaseApiVersion))

--- a/packages/sanity/src/core/variants/util/variantApiVersion.ts
+++ b/packages/sanity/src/core/variants/util/variantApiVersion.ts
@@ -1,0 +1,23 @@
+import {VARIANTS_STUDIO_CLIENT_OPTIONS} from '../store/constants'
+
+/**
+ * Resolves the API version to use for a query that may carry a `variant` option.
+ *
+ * Fetching with a variant is only supported on the variants API version, which takes precedence
+ * over any other version the caller would otherwise use (e.g. the releases version for stacked
+ * perspectives).
+ *
+ * Intended to be used with {@link versionedClient}:
+ *
+ * ```ts
+ * versionedClient(client, variantApiVersion(variant, releaseApiVersion))
+ * ```
+ *
+ * @internal
+ */
+export function variantApiVersion(
+  variant: string | undefined,
+  fallbackApiVersion?: string,
+): string | undefined {
+  return variant ? VARIANTS_STUDIO_CLIENT_OPTIONS.apiVersion : fallbackApiVersion
+}

--- a/packages/sanity/src/presentation/editor/usePreviewState.ts
+++ b/packages/sanity/src/presentation/editor/usePreviewState.ts
@@ -19,14 +19,21 @@ const EMPTY_STATE: PreviewState = {}
 
 export default function usePreviewState(documentId: string, schemaType?: SchemaType): PreviewState {
   const documentPreviewStore = useDocumentPreviewStore()
-  const {perspectiveStack} = usePerspective()
+  const {perspectiveStack, selectedVariantName} = usePerspective()
 
   const preview$ = useMemo(
     () =>
       schemaType
-        ? getPreviewStateObservable(documentPreviewStore, schemaType, documentId, perspectiveStack)
+        ? getPreviewStateObservable(
+            documentPreviewStore,
+            schemaType,
+            documentId,
+            perspectiveStack,
+            undefined,
+            selectedVariantName,
+          )
         : of(EMPTY_STATE),
-    [documentPreviewStore, schemaType, documentId, perspectiveStack],
+    [documentPreviewStore, schemaType, documentId, perspectiveStack, selectedVariantName],
   )
 
   // Deferred: react-rx v5's deferral is identity-coherent, so on a document

--- a/packages/sanity/src/presentation/types.ts
+++ b/packages/sanity/src/presentation/types.ts
@@ -75,6 +75,11 @@ export type DocumentLocationResolver = (
     type: string
     version: string | undefined
     perspectiveStack: StackablePerspective[]
+    /**
+     * The selected editing variant as a bare variant id, or `undefined` when no variant is
+     * selected. Pass it as the variant param in the client, alongside `perspectiveStack`.
+     */
+    variant: string | undefined
   },
   context: {documentStore: DocumentStore},
 ) =>

--- a/packages/sanity/src/presentation/types.ts
+++ b/packages/sanity/src/presentation/types.ts
@@ -79,7 +79,7 @@ export type DocumentLocationResolver = (
      * The selected editing variant as a bare variant id, or `undefined` when no variant is
      * selected. Pass it as the variant param in the client, alongside `perspectiveStack`.
      */
-    variant: string | undefined
+    variant?: string
   },
   context: {documentStore: DocumentStore},
 ) =>

--- a/packages/sanity/src/presentation/useDocumentLocations.ts
+++ b/packages/sanity/src/presentation/useDocumentLocations.ts
@@ -16,6 +16,7 @@ import {
   type DocumentLocationsStatus,
 } from './types'
 import {usePresentationPerspectiveStack} from './usePresentationPerspectiveStack'
+import {usePresentationVariant} from './usePresentationVariant'
 
 const INITIAL_STATE: DocumentLocationsState = {locations: []}
 
@@ -38,6 +39,7 @@ export function useDocumentLocations(props: {
   const documentPreviewStore = useDocumentPreviewStore()
 
   const perspectiveStack = usePresentationPerspectiveStack()
+  const variant = usePresentationVariant()
 
   const resolver = resolvers && (typeof resolvers === 'function' ? resolvers : resolvers[type.name])
 
@@ -54,7 +56,7 @@ export function useDocumentLocations(props: {
 
     // Original/advanced resolver which requires explicit use of Observables
     if (typeof resolver === 'function') {
-      const params = {id, type: type.name, version, perspectiveStack}
+      const params = {id, type: type.name, version, perspectiveStack, variant}
       const context = {documentStore}
       const _result = resolver(params, context)
       return isObservable(_result) ? _result : of(_result)
@@ -66,7 +68,7 @@ export function useDocumentLocations(props: {
       // Override the preview selection in the schema type to use the user
       // defined selection defined by the resolver
       const _type = {...type, preview: {select: resolver.select}} satisfies PreviewableType
-      const options = {perspective: perspectiveStack}
+      const options = {perspective: perspectiveStack, variant}
       return documentPreviewStore
         .observeForPreview(doc, _type, options)
         .pipe(map((preview) => resolver.resolve(preview.snapshot || null)))
@@ -74,7 +76,7 @@ export function useDocumentLocations(props: {
 
     // Resolver is explicitly provided state
     return of(resolver)
-  }, [documentStore, documentPreviewStore, id, resolver, type, version, perspectiveStack])
+  }, [documentStore, documentPreviewStore, id, resolver, type, version, perspectiveStack, variant])
 
   const locationsResult$ = useMemo(() => {
     if (!result) return of(initialResult)

--- a/packages/sanity/src/structure/StructureToolProvider.tsx
+++ b/packages/sanity/src/structure/StructureToolProvider.tsx
@@ -29,15 +29,16 @@ export function StructureToolProvider({
   const configContext = useConfigContextFromSource(source)
   const documentStore = useDocumentStore()
 
-  const {perspectiveStack} = usePerspective()
+  const {perspectiveStack, selectedVariantName} = usePerspective()
 
   const S = useMemo(() => {
     return createStructureBuilder({
       defaultDocumentNode,
       source,
       perspectiveStack,
+      selectedVariantName,
     })
-  }, [defaultDocumentNode, source, perspectiveStack])
+  }, [defaultDocumentNode, source, perspectiveStack, selectedVariantName])
 
   const rootPaneNode = useMemo(() => {
     // TODO: unify types and remove cast
@@ -47,9 +48,10 @@ export function StructureToolProvider({
         documentStore,
 
         perspectiveStack,
+        selectedVariantName,
       }) as UnresolvedPaneNode
     return S.defaults() as UnresolvedPaneNode
-  }, [resolveStructure, S, configContext, documentStore, perspectiveStack])
+  }, [resolveStructure, S, configContext, documentStore, perspectiveStack, selectedVariantName])
 
   const features: StructureToolContextValue['features'] = useMemo(
     () => ({

--- a/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
+++ b/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
@@ -52,7 +52,7 @@ export function PaneItemPreview(props: PaneItemPreviewProps) {
   // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
   const versionsInfo = useDocumentVersionInfo(value._id)
 
-  const {perspectiveStack} = usePerspective()
+  const {perspectiveStack, selectedVariantName} = usePerspective()
   const viewOptions = useMemo((): PrepareViewOptions | undefined => {
     if (!sortOrder) return undefined
     return {
@@ -70,8 +70,16 @@ export function PaneItemPreview(props: PaneItemPreviewProps) {
       value._id,
       perspectiveStack,
       viewOptions,
+      selectedVariantName,
     )
-  }, [props.documentPreviewStore, schemaType, value._id, perspectiveStack, viewOptions])
+  }, [
+    props.documentPreviewStore,
+    schemaType,
+    value._id,
+    perspectiveStack,
+    viewOptions,
+    selectedVariantName,
+  ])
 
   // Deferred: react-rx v5's deferral is identity-coherent, so when a
   // (recycled) list item switches to a new document id the live snapshot for

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderBreadcrumbItem.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentHeaderBreadcrumbItem.tsx
@@ -24,7 +24,7 @@ export function DocumentHeaderBreadcrumbItem({
   const telemetry = useTelemetry()
   const routerPanes = useMemo(() => (routerState?.panes || []) as RouterPanes, [routerState?.panes])
 
-  const {perspectiveStack} = usePerspective()
+  const {perspectiveStack, selectedVariantName} = usePerspective()
   // In case if it's a pane with a title, use the title
   const staticTitle = pane !== LOADING_PANE && 'title' in pane ? pane.title : null
 
@@ -35,6 +35,7 @@ export function DocumentHeaderBreadcrumbItem({
     documentId: documentId ?? '',
     documentType: documentType ?? '',
     perspectiveStack: perspectiveStack,
+    variant: selectedVariantName,
   })
 
   // Use preview title for documents, static title for other panes

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
@@ -88,7 +88,7 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   const {childItemId, isActive, pane, paneKey, sortOrder: sortOrderRaw, layout} = props
   const schema = useSchema()
   const releases = useActiveReleases()
-  const {perspectiveStack} = usePerspective()
+  const {perspectiveStack, selectedVariantName} = usePerspective()
   const {displayOptions, options} = pane
   const {apiVersion, filter} = options
   const params = useShallowUnique(options.params || EMPTY_RECORD)
@@ -183,6 +183,7 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
     client,
     filter,
     perspective: perspectiveStack,
+    variant: selectedVariantName,
     params,
     searchQuery: trimmedSearchQuery,
     sortOrder: effectiveSortOrder,

--- a/packages/sanity/src/structure/panes/documentList/__tests__/DocumentListPane.test.tsx
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/DocumentListPane.test.tsx
@@ -1,7 +1,7 @@
 import {render, screen} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
-import {defineConfig, type PerspectiveContextValue} from 'sanity'
-import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {defineConfig, type PerspectiveContextValue, usePerspective} from 'sanity'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
 import {structureUsEnglishLocaleBundle} from '../../../i18n'
@@ -35,6 +35,18 @@ vi.mock('sanity', async (importOriginal) => ({
 }))
 
 const mockUseDocumentList = vi.mocked(useDocumentList)
+const mockUsePerspective = vi.mocked(usePerspective)
+
+const BASE_PERSPECTIVE: PerspectiveContextValue = {
+  perspectiveStack: ['drafts'],
+  excludedPerspectives: [],
+  selectedPerspective: 'drafts',
+  selectedPerspectiveName: undefined,
+  selectedReleaseId: undefined,
+  selectedVariantName: undefined,
+  selectedVariant: undefined,
+  bundle: 'drafts',
+}
 
 const ORDERING_TESTID = 'document-list-search-ordering'
 
@@ -110,5 +122,56 @@ describe('DocumentListPane search ordering indicator', () => {
     // appear. Allow time for the debounced query to settle before asserting.
     await new Promise((resolve) => setTimeout(resolve, 400))
     expect(screen.queryByTestId(ORDERING_TESTID)).toBeNull()
+  })
+})
+
+describe('DocumentListPane perspective and variant', () => {
+  beforeEach(() => {
+    mockUseDocumentList.mockReturnValue({
+      error: null,
+      onRetry: vi.fn(),
+      isLoading: false,
+      items: [],
+      isRetrying: false,
+      canRetry: false,
+      retryCount: 0,
+      autoRetry: false,
+      connected: true,
+      fromCache: false,
+      onLoadFullList: vi.fn(),
+      isLoadingFullList: false,
+    })
+  })
+
+  afterEach(() => {
+    mockUsePerspective.mockReturnValue(BASE_PERSPECTIVE)
+  })
+
+  it('queries with the perspective stack and no variant by default', async () => {
+    const wrapper = await createTestProvider({
+      config: defineConfig({projectId: 'test', dataset: 'test'}),
+      resources: [structureUsEnglishLocaleBundle],
+    })
+
+    render(<DocumentListPane {...getPaneProps()} />, {wrapper})
+
+    expect(mockUseDocumentList).toHaveBeenCalledWith(
+      expect.objectContaining({perspective: ['drafts'], variant: undefined}),
+    )
+  })
+
+  it('queries with the selected variant alongside the perspective stack', async () => {
+    mockUsePerspective.mockReturnValue({...BASE_PERSPECTIVE, selectedVariantName: 'alpha-audience'})
+
+    const wrapper = await createTestProvider({
+      config: defineConfig({projectId: 'test', dataset: 'test'}),
+      resources: [structureUsEnglishLocaleBundle],
+    })
+
+    render(<DocumentListPane {...getPaneProps()} />, {wrapper})
+
+    expect(mockUseDocumentList).toHaveBeenCalledWith(
+      expect.objectContaining({perspective: ['drafts'], variant: 'alpha-audience'}),
+    )
   })
 })

--- a/packages/sanity/src/structure/panes/documentList/__tests__/listenSearchQuery.test.ts
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/listenSearchQuery.test.ts
@@ -1,7 +1,19 @@
-import {type SearchSort} from 'sanity'
-import {describe, expect, it} from 'vitest'
+import {type SanityClient} from '@sanity/client'
+import {type Schema} from '@sanity/types'
+import {firstValueFrom, of} from 'rxjs'
+import {createSearch, type SearchSort} from 'sanity'
+import {describe, expect, it, vi} from 'vitest'
 
-import {resolveSearchOrdering} from '../listenSearchQuery'
+import {listenSearchQuery, resolveSearchOrdering} from '../listenSearchQuery'
+
+vi.mock('sanity', async (importOriginal) => ({
+  ...(await importOriginal()),
+  compileFieldPath: vi.fn(),
+  createSearch: vi.fn(() => vi.fn(() => of({hits: []}))),
+  getSearchableTypes: vi.fn(() => [{name: 'author'}]),
+}))
+
+const mockCreateSearch = vi.mocked(createSearch)
 
 const CONFIGURED_SORT: SearchSort[] = [{field: '_updatedAt', direction: 'desc'}]
 
@@ -58,5 +70,60 @@ describe('resolveSearchOrdering', () => {
         useRelevance: false,
       }),
     ).toEqual({skipSortByScore: true, sort: chosenSort})
+  })
+})
+
+describe('listenSearchQuery', () => {
+  function runListenSearchQuery(variant?: string) {
+    const client = {
+      listen: vi.fn(() => of({type: 'welcome'})),
+      observable: {fetch: vi.fn(() => of(['author']))},
+    } as unknown as SanityClient
+
+    return firstValueFrom(
+      listenSearchQuery({
+        client,
+        filter: '_type == "author"',
+        limit: 25,
+        params: {},
+        schema: {} as Schema,
+        searchQuery: '',
+        sort: {by: [{field: '_updatedAt', direction: 'desc'}]},
+        staticTypeNames: ['author'],
+        perspective: ['drafts'],
+        variant,
+      }),
+    )
+  }
+
+  it('searches within the selected variant', async () => {
+    mockCreateSearch.mockClear()
+    const search = vi.fn(() => of({hits: []}))
+    mockCreateSearch.mockReturnValue(search as never)
+
+    await runListenSearchQuery('alpha-audience')
+
+    expect(mockCreateSearch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({variant: 'alpha-audience'}),
+    )
+    expect(search).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({perspective: ['drafts'], variant: 'alpha-audience'}),
+    )
+  })
+
+  it('omits the variant when none is selected', async () => {
+    mockCreateSearch.mockClear()
+    const search = vi.fn(() => of({hits: []}))
+    mockCreateSearch.mockReturnValue(search as never)
+
+    await runListenSearchQuery()
+
+    expect(search).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({variant: undefined}),
+    )
   })
 })

--- a/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
+++ b/packages/sanity/src/structure/panes/documentList/listenSearchQuery.ts
@@ -40,6 +40,11 @@ interface ListenQueryOptions {
   searchQuery: string
   sort: SortOrder
   perspective?: ClientPerspective
+  /**
+   * The selected editing variant as a bare variant id. When set, the list resolves documents as
+   * seen through that variant, on top of `perspective`.
+   */
+  variant?: string
   staticTypeNames?: string[] | null
   maxFieldDepth?: number
   searchStrategy?: SearchStrategy
@@ -119,6 +124,7 @@ export function listenSearchQuery(options: ListenQueryOptions): Observable<Searc
     schema,
     sort,
     perspective,
+    variant,
     limit,
     params,
     filter: groqFilter,
@@ -168,6 +174,7 @@ export function listenSearchQuery(options: ListenQueryOptions): Observable<Searc
     params,
     searchQuery,
     perspective,
+    variant,
     sort: toStaticSortOrder(sort),
     staticTypeNames,
   })
@@ -208,6 +215,7 @@ export function listenSearchQuery(options: ListenQueryOptions): Observable<Searc
             params,
             strategy: searchStrategy,
             maxDepth: maxFieldDepth,
+            variant,
           })
 
           const doFetch = () => {
@@ -229,6 +237,7 @@ export function listenSearchQuery(options: ListenQueryOptions): Observable<Searc
               skipSortByScore,
               sort,
               perspective,
+              variant,
             }
 
             return search(searchTerms, searchOptions).pipe(

--- a/packages/sanity/src/structure/panes/documentList/useDocumentList.ts
+++ b/packages/sanity/src/structure/panes/documentList/useDocumentList.ts
@@ -40,6 +40,11 @@ interface UseDocumentListOpts {
   client: SanityClient
   filter: string
   perspective?: ClientPerspective
+  /**
+   * The selected editing variant as a bare variant id. When set, the list resolves documents as
+   * seen through that variant, on top of `perspective`.
+   */
+  variant?: string
   params: Record<string, unknown>
   searchQuery: string | null
   sortOrder?: SortOrder
@@ -112,6 +117,7 @@ export function useDocumentList(opts: UseDocumentListOpts): UseDocumentListHookV
     sortOrder,
     searchQuery,
     perspective,
+    variant,
     searchSortByRelevance = true,
   } = opts
   const {strategy: searchStrategy} = useWorkspace().search
@@ -136,6 +142,7 @@ export function useDocumentList(opts: UseDocumentListOpts): UseDocumentListHookV
       params: paramsProp,
       schema,
       perspective,
+      variant,
       searchQuery: searchQuery || '',
       sort: sortOrder || DEFAULT_ORDERING,
       staticTypeNames: typeNameFromFilter,
@@ -264,6 +271,7 @@ export function useDocumentList(opts: UseDocumentListOpts): UseDocumentListHookV
     paramsProp,
     schema,
     perspective,
+    variant,
     searchQuery,
     sortOrder,
     searchSortByRelevance,

--- a/packages/sanity/src/structure/structureBuilder/createStructureBuilder.ts
+++ b/packages/sanity/src/structure/structureBuilder/createStructureBuilder.ts
@@ -41,7 +41,7 @@ export interface StructureBuilderOptions {
   source: Source
   defaultDocumentNode?: DefaultDocumentNodeResolver
   perspectiveStack: PerspectiveStack
-  selectedVariantName: string | undefined
+  selectedVariantName?: string
 }
 
 function hasIcon(schemaType?: SchemaType | string): boolean {

--- a/packages/sanity/src/structure/structureBuilder/createStructureBuilder.ts
+++ b/packages/sanity/src/structure/structureBuilder/createStructureBuilder.ts
@@ -41,6 +41,7 @@ export interface StructureBuilderOptions {
   source: Source
   defaultDocumentNode?: DefaultDocumentNodeResolver
   perspectiveStack: PerspectiveStack
+  selectedVariantName: string | undefined
 }
 
 function hasIcon(schemaType?: SchemaType | string): boolean {
@@ -66,6 +67,7 @@ export function createStructureBuilder({
   defaultDocumentNode,
   source,
   perspectiveStack,
+  selectedVariantName,
 }: StructureBuilderOptions): StructureBuilder {
   const configContext = getConfigContextFromSource(source)
   const context: StructureContext = {
@@ -87,6 +89,7 @@ export function createStructureBuilder({
       return builder.schemaType(options.schemaType)
     },
     perspectiveStack,
+    selectedVariantName,
   }
 
   const structureBuilder: StructureBuilder = {

--- a/packages/sanity/src/structure/structureBuilder/types.ts
+++ b/packages/sanity/src/structure/structureBuilder/types.ts
@@ -103,7 +103,7 @@ export interface StructureContext extends Source {
    * It can be used as the variant param in the client, alongside `perspectiveStack`, to get the
    * view of the documents as seen through that variant.
    */
-  selectedVariantName: string | undefined
+  selectedVariantName?: string
 }
 
 /**

--- a/packages/sanity/src/structure/structureBuilder/types.ts
+++ b/packages/sanity/src/structure/structureBuilder/types.ts
@@ -98,6 +98,12 @@ export interface StructureContext extends Source {
    * See {@link PerspectiveStack}
    */
   perspectiveStack: PerspectiveStack
+  /**
+   * The selected editing variant as a bare variant id, or `undefined` when no variant is selected.
+   * It can be used as the variant param in the client, alongside `perspectiveStack`, to get the
+   * view of the documents as seen through that variant.
+   */
+  selectedVariantName: string | undefined
 }
 
 /**

--- a/packages/sanity/src/structure/types.ts
+++ b/packages/sanity/src/structure/types.ts
@@ -72,8 +72,11 @@ export interface StructureResolverContext extends ConfigContext {
    * The selected editing variant as a bare variant id, or `undefined` when no variant is selected.
    * It can be used as the variant param in the client, alongside `perspectiveStack`, to get the
    * view of the documents as seen through that variant.
+   *
+   * Always provided by the Studio. Declared optional so that structure resolvers written before
+   * variants existed keep type checking when they construct this context themselves.
    */
-  selectedVariantName: string | undefined
+  selectedVariantName?: string | undefined
 }
 
 /**

--- a/packages/sanity/src/structure/types.ts
+++ b/packages/sanity/src/structure/types.ts
@@ -68,6 +68,12 @@ export interface StructureResolverContext extends ConfigContext {
    * See {@link PerspectiveStack}
    */
   perspectiveStack: PerspectiveStack
+  /**
+   * The selected editing variant as a bare variant id, or `undefined` when no variant is selected.
+   * It can be used as the variant param in the client, alongside `perspectiveStack`, to get the
+   * view of the documents as seen through that variant.
+   */
+  selectedVariantName: string | undefined
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Selecting a variant in the navbar "View as" row only affected the document pane and Presentation. Everything else in the studio — the structure document lists, list item previews, breadcrumbs/titles, reference inputs, global search result previews, tasks previews — resolved documents through the perspective stack alone, so an editor viewing a variant still saw base draft/published content everywhere outside the open document.

Variant and perspective are parallel dimensions in the API (`client.fetch(query, params, {perspective, variant})`), so the fix is to send the variant wherever the perspective stack already travels, and to bump the client to the variants API version when a variant is present — the pattern `presentation/loader/LiveQueries.tsx` already established. `variantApiVersion(variant, fallback)` centralises that version choice next to the existing `versionedClient`/`isReleasePerspective` helpers.

Two decisions worth flagging:

- **The variant follows the perspective, and only travels implicitly where the perspective does.** Call sites that pass an explicit perspective stack for a specific document version (release tool previews, discard/unpublish dialogs, comment notification targets) stay variant-free unless they pass a variant themselves. Making the variant globally implicit would have silently rewritten those previews. `VariantDocumentPreview` now passes its own row's variant, which also fixes the variants tool table previewing base content.
- **Preview invalidation can't use the perspective stack under a variant.** Variant documents are `versions.<opaqueScopeId>.<groupId>` and scope ids never appear in the stack, so `idMatchesPerspective` rejects every variant mutation and previews would go stale. Under a variant selection, any mutation within the same document group is treated as relevant. Resolving scope ids first was rejected: they are server-generated and only discoverable per document.

Availability observers (`unstable_observeDocumentStackAvailability`) keep base-stack semantics, since they derive concrete ids from stack entries and variant scope ids cannot be derived client-side. Vision keeps its own perspective control and is untouched, and global search still queries with `perspective: 'raw'` — only its previews became variant-aware.

### What to review

Most of the diff is mechanical parameter threading. The parts that carry risk:

- `core/preview/observeFields.ts` — invalidation predicate under a variant, plus the variant in both the batch-fetcher key and the `CACHE` key (without those, variant and base previews would share cached field observers).
- `core/preview/useValuePreview.ts` — the "variant only inherited from context when the perspective is too" rule that keeps version-scoped previews variant-free.
- `core/search/*` — `variant` in `SearchOptions`/`SearchFactoryOptions`, both `createSearchQuery` implementations, and variant-over-release API version precedence.
- Public type additions: `StructureContext.selectedVariantName`, `StructureResolverContext.selectedVariantName`, and `variant` on `DocumentLocationResolver` params.

Affected packages: `sanity` (core preview/search/tasks/variants, structure, presentation) and `dev/test-studio` (structure resolver now forwards the variant to `listenQuery`).

### Testing

Unit tests added or extended:

- `core/preview/__test__/observeFields.test.ts` — variant in fetch options, variants API version, cache separation per variant, and the invalidation behaviour for out-of-stack version ids.
- `core/preview/__test__/createPathObserver.test.ts` — variant kept while materialising referenced documents.
- `core/preview/utils/getPreviewStateObservable.test.ts` — variant on both the perspective snapshot and the fallback snapshot.
- `core/search/weighted/createSearchQuery.test.ts` and `createWeightedSearch.test.ts` — variant reaches query options and selects the variants API version.
- `structure/panes/documentList/__tests__/listenSearchQuery.test.ts` and `DocumentListPane.test.tsx` — variant reaches the list search.

Full suite green (`pnpm build && pnpm test`: 5203 passed, no type errors), plus `pnpm check:format`, `pnpm check:oxlint` and `pnpm test:exports`.

Manually verified against the test studio (project `ppsg7ml5`, dataset `test`, which has real variant documents). First confirmed the API contract directly: the same query with `perspective=drafts` returns `"This is the SDK test author, as a draft"`, and with `variant=wjcXSbcJ` added returns `"This is the SDK test author in swedish variant"`. Then in the studio, selecting the "Swedish festival" variant switches the Author list item preview to the variant content and clearing it reverts:

[structure_list_previews_follow_selected_variant.mp4](https://cursor.com/agents/bc-3d4f6d3d-26aa-440f-89f3-ef24ca170cec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstructure_list_previews_follow_selected_variant.mp4)

Global search result previews follow the same selection (full, untruncated titles):

[Global search with the default variant](https://cursor.com/agents/bc-3d4f6d3d-26aa-440f-89f3-ef24ca170cec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_previews_default_variant.webp)
[Global search with the Swedish festival variant selected](https://cursor.com/agents/bc-3d4f6d3d-26aa-440f-89f3-ef24ca170cec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_previews_swedish_variant.webp)

### Notes for release

n/a internal variants work

---


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d4f6d3d-26aa-440f-89f3-ef24ca170cec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d4f6d3d-26aa-440f-89f3-ef24ca170cec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

