### PR TITLE
fix(sanity): virtualised item dimensions in hidden `CommandList`

### DIFF
--- a/packages/sanity/src/core/components/commandList/CommandList.tsx
+++ b/packages/sanity/src/core/components/commandList/CommandList.tsx
@@ -1,5 +1,10 @@
 import {Box, rem, Stack} from '@sanity/ui'
-import {type ScrollToOptions, useVirtualizer, type Virtualizer} from '@tanstack/react-virtual'
+import {
+  measureElement,
+  type ScrollToOptions,
+  useVirtualizer,
+  type Virtualizer,
+} from '@tanstack/react-virtual'
 import throttle from 'lodash-es/throttle.js'
 import {
   cloneElement,
@@ -157,6 +162,7 @@ const CommandListComponent = forwardRef<CommandListHandle, CommandListProps>(fun
     getItemKey,
     getScrollElement: () => virtualListElement,
     estimateSize: () => itemHeight,
+    measureElement: measureVisibleElement,
     onChange: handleChange,
     overscan,
   })
@@ -748,4 +754,40 @@ function getItemIndicies(
     }
     return acc
   }, [])
+}
+
+/**
+ * Retrieve the element's measured dimensions if its scroll element is visible
+ * or its measured dimensions are greater than zero, otherwise retrieve its
+ * cached or estimated dimensions.
+ *
+ * This prevents the element's lack of dimensions when its scroll element is
+ * hidden from poisoning its virtualization state.
+ */
+function measureVisibleElement(
+  element: Element,
+  entry: ResizeObserverEntry | undefined,
+  instance: Virtualizer<HTMLElement, Element>,
+): number {
+  const measuredSize = measureElement(element, entry, instance)
+
+  if (measuredSize > 0) {
+    return measuredSize
+  }
+
+  const scrollElement = instance.scrollElement
+  const isHidden = scrollElement?.offsetWidth === 0 || scrollElement?.offsetHeight === 0
+
+  if (!isHidden) {
+    return measuredSize
+  }
+
+  const index = instance.indexFromElement(element)
+  const cachedSize = instance.itemSizeCache.get(instance.options.getItemKey(index))
+
+  if (cachedSize !== undefined && cachedSize > 0) {
+    return cachedSize
+  }
+
+  return instance.options.estimateSize(index)
 }

--- a/packages/sanity/src/core/components/commandList/__tests__/CommandList.browser.test.tsx
+++ b/packages/sanity/src/core/components/commandList/__tests__/CommandList.browser.test.tsx
@@ -1,0 +1,79 @@
+import {studioTheme, ThemeProvider} from '@sanity/ui'
+import {useCallback} from 'react'
+import {describe, expect, it} from 'vitest'
+import {render} from 'vitest-browser-react'
+import {page} from 'vitest/browser'
+
+import {CommandList} from '../CommandList'
+
+const COMMAND_LIST_TEST_ID = 'command-list'
+
+type Item = number
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => resolve())
+  })
+}
+
+interface TestComponentProps {
+  hidden?: boolean
+  items: Item[]
+}
+
+function TestComponent(props: TestComponentProps) {
+  const {hidden, items} = props
+
+  const renderItem = useCallback((item: Item) => {
+    return (
+      <button key={item.toString()} type="button" data-testid="button">
+        Button {item}
+      </button>
+    )
+  }, [])
+
+  return (
+    <ThemeProvider theme={studioTheme}>
+      <div hidden={hidden} style={{height: '400px', position: 'relative'}}>
+        <CommandList
+          ariaLabel=""
+          autoFocus="list"
+          fixedHeight={false}
+          itemHeight={20}
+          items={items}
+          overscan={0}
+          renderItem={renderItem}
+          testId={COMMAND_LIST_TEST_ID}
+        />
+      </div>
+    </ThemeProvider>
+  )
+}
+
+describe('CommandList', () => {
+  it('preserves row measurements while hidden so the list recovers when shown again', async () => {
+    const items = [...Array(100).keys()]
+    const {rerender} = await render(<TestComponent items={items} />)
+
+    // The first row is rendered and measured (dynamic row heights) while visible.
+    await expect.element(page.getByText('Button 0', {exact: true})).toBeVisible()
+
+    // Hide the list (like PaneContent does for a collapsed structure pane): the
+    // rows lose their boxes and ResizeObserver reports them as zero-sized.
+    // Without preserving cached sizes, the zeroed rows make the virtualizer
+    // compensate its tracked scroll offset when they regrow on re-show,
+    // desyncing it from the element's real scroll position and breaking the
+    // rendered range.
+    await rerender(<TestComponent hidden items={items} />)
+    await expect.element(page.getByTestId(COMMAND_LIST_TEST_ID)).not.toBeVisible()
+
+    // Wait a couple of frames so ResizeObserver delivers the zero-size entries
+    // while hidden.
+    await nextFrame()
+    await nextFrame()
+
+    // Show the list again: it should recover and still render from the top.
+    await rerender(<TestComponent items={items} />)
+    await expect.element(page.getByText('Button 0', {exact: true})).toBeVisible()
+  })
+})


### PR DESCRIPTION
### Description

When measuring `CommandList` elements, retrieve the element's measured dimensions if its scroll element is visible or its measured dimensions are greater than zero, otherwise retrieve its cached or estimated dimensions.

This prevents the element's lack of dimensions when its scroll element is hidden from poisoning its virtualisation state. This problem manifested as list items failing to render after expanding a collapsed list pane.

This is slightly simpler than the fix in #13782, and includes a more robust browser-mode test.

### What to review

`CommandList` item measurement for virtualisation. When collapsing and then expanding a list pane, items must be rendered if they are in the viewport.

### Testing

Added a Vitest Browser Mode test. This allows us to test real browser behaviour, without resorting to mocking `ResizeObserver`, which is not implemented in jsdom.

### Notes for release

Fixes a bug in which Structure Tool list items would erroneously be hidden after expanding a collapsed list pane.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped to CommandList virtualization measurement with a targeted browser regression test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes Structure Tool lists that went blank after expanding a collapsed pane by changing how **`CommandList`** measures row heights for **`@tanstack/react-virtual`**.
> 
> A custom **`measureVisibleElement`** hook is wired into **`useVirtualizer`**. When the scroll container is hidden and **`ResizeObserver`** reports zero height, measurements no longer overwrite the virtualizer cache; it keeps prior cached sizes or falls back to **`estimateSize`**. That stops the tracked scroll offset from drifting when the pane is shown again.
> 
> Adds a **Vitest Browser Mode** test that hides the list (like a collapsed pane), waits for zero-size observations, then re-shows and asserts the first item is still visible—without mocking **`ResizeObserver`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 429c9a615a2c9c8573da79ad23b2a930ca2b5a84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->