### PR TITLE
chore(oxlint): allow side-effect css imports without suppressions

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -187,6 +187,8 @@
     "import/newline-after-import": "error",
     "import/no-duplicates": ["error", {"prefer-inline": true}],
     "import/consistent-type-specifier-style": ["error", "prefer-inline"],
+    // Side-effect CSS imports are intentional (bundler injects styles)
+    "import/no-unassigned-import": ["error", {"allow": ["**/*.css"]}],
     "import/extensions": [
       "error",
       {

--- a/dev/e2e-embedded-studio-vite/src/main.tsx
+++ b/dev/e2e-embedded-studio-vite/src/main.tsx
@@ -1,4 +1,3 @@
-// oxlint-disable-next-line no-unassigned-import
 import './index.css'
 
 import {StrictMode} from 'react'

--- a/dev/embedded-studio/src/main.tsx
+++ b/dev/embedded-studio/src/main.tsx
@@ -1,4 +1,3 @@
-// oxlint-disable-next-line no-unassigned-import
 import './index.css'
 
 import {StrictMode} from 'react'

--- a/dev/sdk-app/src/App.tsx
+++ b/dev/sdk-app/src/App.tsx
@@ -1,4 +1,3 @@
-// oxlint-disable-next-line no-unassigned-import
 import './App.css'
 
 import {type SanityConfig} from '@sanity/sdk'

--- a/dev/sdk-app/src/ExampleComponent.tsx
+++ b/dev/sdk-app/src/ExampleComponent.tsx
@@ -1,4 +1,3 @@
-// oxlint-disable-next-line no-unassigned-import
 import './ExampleComponent.css'
 
 import {type CurrentUser, useCurrentUser} from '@sanity/sdk-react'

--- a/packages/@sanity/vision/src/visionTool.ts
+++ b/packages/@sanity/vision/src/visionTool.ts
@@ -1,4 +1,3 @@
-// oxlint-disable-next-line no-unassigned-import -- style import is effectful
 import './styles.css'
 
 import {EyeOpenIcon} from '@sanity/icons/EyeOpen'

--- a/packages/sanity/src/_exports/index.ts
+++ b/packages/sanity/src/_exports/index.ts
@@ -1,3 +1,4 @@
+import '@sanity-labs/ui-poc/styles.css'
 // oxlint-disable-next-line import/no-unassigned-import -- side effect: keeps the module augmentations declared by this module on the public type surface
 import '../core/form/types/definitionExtensions'
 

--- a/packages/sanity/src/core/form/inputs/PortableText/object/TablePlugin.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/TablePlugin.tsx
@@ -1,4 +1,3 @@
-// oxlint-disable-next-line no-unassigned-import -- imported for its side effects
 import '@portabletext/plugin-table/ui/styles.css'
 
 import {type Container, type ContainerRenderProps} from '@portabletext/editor'

--- a/packages/sanity/src/core/studio/Studio.tsx
+++ b/packages/sanity/src/core/studio/Studio.tsx
@@ -1,5 +1,4 @@
 import './styles.css'
-// oxlint-disable-next-line no-unassigned-import -- Sanity UI POC styles are required for its components
 import '@sanity-labs/ui-poc/styles.css'
 
 /* disabling for now because the imports trigger side effects causing test snapshots to update */

--- a/packages/sanity/src/core/studio/Studio.tsx
+++ b/packages/sanity/src/core/studio/Studio.tsx
@@ -1,5 +1,4 @@
 import './styles.css'
-import '@sanity-labs/ui-poc/styles.css'
 
 /* disabling for now because the imports trigger side effects causing test snapshots to update */
 import {type Config} from '../config/types'

--- a/packages/sanity/src/core/studio/Studio.tsx
+++ b/packages/sanity/src/core/studio/Studio.tsx
@@ -1,4 +1,3 @@
-// oxlint-disable-next-line no-unassigned-import -- style import is effectful
 import './styles.css'
 // oxlint-disable-next-line no-unassigned-import -- Sanity UI POC styles are required for its components
 import '@sanity-labs/ui-poc/styles.css'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

`import/no-unassigned-import` was flagging intentional side-effect CSS imports, which forced repeated `oxlint-disable-next-line` comments. Those imports are effectful by design.

Configured the rule with `allow: ["**/*.css"]`, removed redundant suppressions, and moved `@sanity-labs/ui-poc/styles.css` to the top of the `sanity` package entry so UI CSS loads before Studio styles.

### What to review

- `.oxlintrc.json` — `import/no-unassigned-import` allowlist for `**/*.css`
- `packages/sanity/src/_exports/index.ts` — ui-poc styles at the very top
- Removed CSS suppressions / Studio-local ui-poc import

### Testing

- Confirmed with oxlint that CSS side-effect imports no longer fail, while non-CSS ones still do
- Ran `pnpm format` after rebase and follow-up edits
- Pre-commit oxlint/format passed on the touched files
- No unit tests: lint-config / import-order change only

### Notes for release

N/A – Internal only

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-571e4c1d-4df7-4502-9b10-a1f0dd0031b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-571e4c1d-4df7-4502-9b10-a1f0dd0031b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

