### PR TITLE
fix(deps): bump react-rx to 4.2.5

### DIFF
--- a/dev/metrics-studio/package.json
+++ b/dev/metrics-studio/package.json
@@ -22,7 +22,7 @@
     "babel-plugin-react-compiler": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-rx": "^4.2.3",
+    "react-rx": "^4.2.5",
     "rxjs": "^7.8.2",
     "sanity": "workspace:*",
     "styled-components": "catalog:",

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -49,7 +49,7 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-refractor": "^4.0.0",
-    "react-rx": "^4.2.3",
+    "react-rx": "^4.2.5",
     "refractor": "^5.0.0",
     "rxjs": "^7.8.2",
     "sanity": "workspace:*",

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -87,7 +87,7 @@
     "json5": "^2.2.3",
     "lodash-es": "^4.18.1",
     "quick-lru": "^7.3.0",
-    "react-rx": "^4.2.3",
+    "react-rx": "^4.2.5",
     "rxjs": "^7.8.2"
   },
   "devDependencies": {

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -215,7 +215,7 @@
     "react-i18next": "^17.0.11",
     "react-is": "catalog:",
     "react-refractor": "^4.0.0",
-    "react-rx": "^4.2.3",
+    "react-rx": "^4.2.5",
     "refractor": "^5.0.0",
     "rxjs": "^7.8.2",
     "rxjs-exhaustmap-with-trailing": "^2.1.1",

--- a/packages/sanity/src/core/util/__tests__/createHookFromObservableFactory.test.tsx
+++ b/packages/sanity/src/core/util/__tests__/createHookFromObservableFactory.test.tsx
@@ -68,7 +68,9 @@ describe('createHookFromObservableFactory', () => {
       [undefined, true],
       [{value: 'hello, world'}, false],
     ])
-    expect(observableFactory).toHaveBeenCalledTimes(2)
+    // One factory call per distinct arg — react-rx@4.2.5 fixed a useObservable cache
+    // leak that previously caused duplicate subscriptions (and thus double calls).
+    expect(observableFactory).toHaveBeenCalledTimes(1)
 
     rerender(<TestComponent value="hooks" />)
     await waitFor(() => expect(renderTimeline.length).toBe(4))
@@ -80,7 +82,7 @@ describe('createHookFromObservableFactory', () => {
       [{value: 'hello, hooks'}, false],
     ])
 
-    expect(observableFactory).toHaveBeenCalledTimes(4)
+    expect(observableFactory).toHaveBeenCalledTimes(2)
   })
 
   // createHookFromObservableFactory uses useSyncExternalStore to trigger re-renders in React if state changes
@@ -123,7 +125,8 @@ describe('createHookFromObservableFactory', () => {
 
     await waitFor(() => expect(syncRenders).toBe(3))
     await waitFor(() => expect(deferRenders).toBe(2))
-    expect(observableFactory).toHaveBeenCalledTimes(3)
+    // One factory call per distinct arg (see react-rx@4.2.5 cache-leak fix note above).
+    expect(observableFactory).toHaveBeenCalledTimes(1)
     expect(phasesTimeline).toEqual([
       ['defer', 'mount'],
       ['sync', 'mount'],
@@ -137,7 +140,7 @@ describe('createHookFromObservableFactory', () => {
     await waitFor(() => expect(syncRenders).toBe(7))
     await waitFor(() => expect(deferRenders).toBe(5))
 
-    expect(observableFactory).toHaveBeenCalledTimes(7)
+    expect(observableFactory).toHaveBeenCalledTimes(3)
     expect(phasesTimeline).toEqual([
       ['defer', 'mount'],
       ['sync', 'mount'],
@@ -179,7 +182,8 @@ describe('createHookFromObservableFactory', () => {
       ['factory initial', true],
       ['hello, world', false],
     ])
-    expect(observableFactory).toHaveBeenCalledTimes(2)
+    // Still a single subscription for the same arg after the value arrives.
+    expect(observableFactory).toHaveBeenCalledTimes(1)
   })
 
   it('bubbles errors throws in the observable factory', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,8 +438,8 @@ importers:
         specifier: 'catalog:'
         version: 19.2.8(react@19.2.8)
       react-rx:
-        specifier: ^4.2.3
-        version: 4.2.3(react@19.2.8)(rxjs@7.8.2)
+        specifier: ^4.2.5
+        version: 4.2.5(react@19.2.8)(rxjs@7.8.2)
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
@@ -781,8 +781,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0(react@19.2.8)
       react-rx:
-        specifier: ^4.2.3
-        version: 4.2.3(react@19.2.8)(rxjs@7.8.2)
+        specifier: ^4.2.5
+        version: 4.2.5(react@19.2.8)(rxjs@7.8.2)
       refractor:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1485,8 +1485,8 @@ importers:
         specifier: ^7.3.0
         version: 7.3.0
       react-rx:
-        specifier: ^4.2.3
-        version: 4.2.3(react@19.2.8)(rxjs@7.8.2)
+        specifier: ^4.2.5
+        version: 4.2.5(react@19.2.8)(rxjs@7.8.2)
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
@@ -1824,8 +1824,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0(react@19.2.8)
       react-rx:
-        specifier: ^4.2.3
-        version: 4.2.3(react@19.2.8)(rxjs@7.8.2)
+        specifier: ^4.2.5
+        version: 4.2.5(react@19.2.8)(rxjs@7.8.2)
       refractor:
         specifier: ^5.0.0
         version: 5.0.0
@@ -11925,8 +11925,8 @@ packages:
     peerDependencies:
       react: '>=18.0.0'
 
-  react-rx@4.2.3:
-    resolution: {integrity: sha512-AzuecrOdmoIgVA/wYCCFUnWc1nFtu+6sd++uH03gYAHte/ujYApHPOPEgSlWbKDhMjiXrcYtzv9IJrxwtmurIw==}
+  react-rx@4.2.5:
+    resolution: {integrity: sha512-n1kHm1W81p9FgBygKpw1pkqJAIp2xAJS5Jpbef89UgPxG6twsuQfj5TRnCeTkr5GiA36qgxkMjkmUjNWQT1tVg==}
     peerDependencies:
       react: ^18.3 || >=19.0.0-0
       rxjs: ^7
@@ -18131,7 +18131,7 @@ snapshots:
       '@sanity/ui': 3.5.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      react-rx: 4.2.3(react@19.2.8)(rxjs@7.8.2)
+      react-rx: 4.2.5(react@19.2.8)(rxjs@7.8.2)
       rxjs: 7.8.2
       sanity: link:packages/sanity
     transitivePeerDependencies:
@@ -24451,7 +24451,7 @@ snapshots:
       unist-util-filter: 5.0.1
       unist-util-visit-parents: 6.0.2
 
-  react-rx@4.2.3(react@19.2.8)(rxjs@7.8.2):
+  react-rx@4.2.5(react@19.2.8)(rxjs@7.8.2):
     dependencies:
       observable-callback: 1.0.3(rxjs@7.8.2)
       react: 19.2.8


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`react-rx@4.2.5` fixes a `useObservable` memory leak where observables that complete or error synchronously on subscribe left cache entries that teardown could no longer evict. That showed up as duplicate subscriptions (extra factory invocations) under Studio hooks that use `useObservable` / `createHookFromObservableFactory`.

Alternatives considered: stay on 4.2.3 and paper over leaks in Studio (rejected — the fix belongs in react-rx); jump to 5.x next (rejected — still pre-release and includes unrelated breaking peer changes).

Also deduped so only `4.2.5` remains in the lockfile (no lingering `4.2.3`).

## What to review

- Dependency bumps in `sanity`, `@sanity/vision`, `test-studio`, `metrics-studio`, and lockfile resolution/dedupe
- `createHookFromObservableFactory` test call-count expectations — previously ~2× per arg because of the leak; now one call per distinct arg

## Testing

- `pnpm update` / `pnpm dedupe` — confirmed single `react-rx@4.2.5` via `pnpm why` / lockfile
- `pnpm vitest run --project=sanity packages/sanity/src/core/util/__tests__/createHookFromObservableFactory.test.tsx` — 5/5 pass after adjusting call counts
- Related util/hooks/presence/project tests also green

## Notes for release

Fixes a memory leak in Studio's RxJS↔React bridging by upgrading `react-rx` to 4.2.5.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17147ead-df10-4aeb-b136-d79e4d79e6be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17147ead-df10-4aeb-b136-d79e4d79e6be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

