### PR TITLE
perf(sanity): defer non-controlled useObservable subscriptions

### DIFF
--- a/e2e/tests/desk/documentList.spec.ts
+++ b/e2e/tests/desk/documentList.spec.ts
@@ -57,15 +57,22 @@ test(`navigating document creates only one listener connection`, async ({page, b
     document.querySelector('[data-testid="pane-content"] > *:first-of-type')?.scrollBy(0, 250)
   })
 
+  // NOTE: clicks are intentionally not `force: true`: a forced click dispatches
+  // at the resolved coordinates without hit-testing, so it can silently land on
+  // an overlay (and never navigate) while the panes are still settling. The
+  // regular click waits for the item to actually receive pointer events.
+  // Request waiters get explicit generous timeouts: their clock starts at
+  // creation (which must precede the triggering click), and the default 10s
+  // has proven too tight when the staging API is slow.
   const authorRequest = page.waitForRequest(
     (request) => request.url().includes('data/listen') && request.url().includes('author'),
+    {timeout: 30000},
   )
-  const bookRequest = page.waitForRequest(
-    (request) => request.url().includes('data/listen') && request.url().includes('book'),
-  )
-  const keyValueRequest = page.waitForResponse((response) => response.url().includes('keyvalue'))
+  const keyValueRequest = page.waitForResponse((response) => response.url().includes('keyvalue'), {
+    timeout: 30000,
+  })
 
-  await page.getByTestId('pane-item-Author').click({force: true})
+  await page.getByTestId('pane-item-Author').click()
   await expect(page.locator('#author-author-0')).toBeVisible()
   await expect(page.getByTestId('document-list-pane')).toBeVisible()
   await authorRequest
@@ -77,21 +84,25 @@ test(`navigating document creates only one listener connection`, async ({page, b
   await page.getByRole('menuitem', {name: 'Sort by Name'}).click()
   await keyValueRequest
 
-  await page.getByTestId('pane-item-Book').click({force: true})
+  const bookRequest = page.waitForRequest(
+    (request) => request.url().includes('data/listen') && request.url().includes('book'),
+    {timeout: 30000},
+  )
+  await page.getByTestId('pane-item-Book').click()
   await expect(page.locator('#book-book-0')).toBeVisible()
   await expect(page.getByTestId('document-list-pane')).toBeVisible()
   expect(authorListenersCount).toBe(0)
   expect(bookListenersCount).toBe(1)
   await bookRequest
 
-  await page.getByTestId('pane-item-Author').click({force: true})
+  await page.getByTestId('pane-item-Author').click()
   await expect(page.locator('#author-author-0')).toBeVisible()
   await expect(page.getByTestId('document-list-pane')).toBeVisible()
   expect(bookListenersCount).toBe(0)
   expect(authorListenersCount).toBe(1)
   await authorRequest
 
-  await page.getByTestId('pane-item-Book').click({force: true})
+  await page.getByTestId('pane-item-Book').click()
   await expect(page.locator('#book-book-0')).toBeVisible()
   await expect(page.getByTestId('document-list-pane')).toBeVisible()
   expect(authorListenersCount).toBe(0)

--- a/packages/@sanity/vision/src/hooks/useDatasets.ts
+++ b/packages/@sanity/vision/src/hooks/useDatasets.ts
@@ -1,6 +1,6 @@
 import {type SanityClient} from '@sanity/client'
-import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useDeferredValue, useMemo} from 'react'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {catchError, map, type Observable, of} from 'rxjs'
 
 import {type VisionConfig} from '../types'
@@ -26,7 +26,10 @@ export function useDatasets({
       catchError((err) => of(err)),
     )
   }, [client, configDatasets])
-  const datasets = useObservable(datasets$, null)
+  // A bare deferral is fine here: `datasets$` is memoized on `client`, and
+  // switching project triggers a full reload, so the client never swaps while
+  // this component stays mounted — there's no identity churn to guard against.
+  const datasets = useDeferredValue(useSyncObservable(datasets$, null))
 
   return datasets
 }

--- a/packages/sanity/src/core/canvas/actions/LinkToCanvas/useLinkToCanvas.ts
+++ b/packages/sanity/src/core/canvas/actions/LinkToCanvas/useLinkToCanvas.ts
@@ -1,7 +1,6 @@
 import {type SanityClient, type SanityDocument} from '@sanity/client'
 import {type Bridge} from '@sanity/message-protocol'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {catchError, combineLatest, map, type Observable, of, tap} from 'rxjs'
 
 import {useClient} from '../../../hooks/useClient'
@@ -10,6 +9,7 @@ import {useComlinkStore, useProjectStore} from '../../../store/datastores'
 import {useRenderingContext} from '../../../store/renderingContext/useRenderingContext'
 import {useStudioAppIdStore} from '../../../store/studio-app/useStudioAppIdStore'
 import {useWorkspace} from '../../../studio/workspace'
+import {useDeferredObservableValue} from '../../../util/useDeferredObservableValue'
 import {type CanvasDiff} from '../../types'
 import {useCanvasTelemetry} from '../../useCanvasTelemetry'
 
@@ -213,5 +213,9 @@ export function useLinkToCanvas({document}: {document: SanityDocument | undefine
     workspace.name,
   ])
 
-  return useObservable(linkToCanvas$, initialState)
+  // Deferred (per review): keyed on the stable document `_id`/`_type` and
+  // consumed inside a dialog the user opens for a fixed document, so there's
+  // no cross-document tear. The identity-coherent deferral falls back to the
+  // live value if the observable identity changes.
+  return useDeferredObservableValue(linkToCanvas$, initialState)
 }

--- a/packages/sanity/src/core/canvas/actions/useCanvasCompanionDoc.ts
+++ b/packages/sanity/src/core/canvas/actions/useCanvasCompanionDoc.ts
@@ -1,7 +1,7 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 
 import {getPublishedId} from '../../util/draftUtils'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {useCanvasCompanionDocsStore} from '../store/useCanvasCompanionDocsStore'
 
 /**
@@ -16,7 +16,12 @@ export const useCanvasCompanionDoc = (documentId: string) => {
     () => companionDocsStore.getCompanionDocs(publishedId),
     [publishedId, companionDocsStore],
   )
-  const companionDocs = useObservable(companionDocs$)
+  // Deferred (per review): the companion docs stream is keyed on the stable
+  // published id, and the `<DocumentPaneProvider>` remount on navigation
+  // resets this state, so there's no cross-document tear. The
+  // identity-coherent deferral additionally falls back to the live value if
+  // the observable identity ever changes.
+  const companionDocs = useDeferredObservableValue(companionDocs$)
 
   const companionDoc = useMemo(
     () => companionDocs?.data.find((companion) => companion?.studioDocumentId === documentId),

--- a/packages/sanity/src/core/comments/hooks/useNotificationTarget.ts
+++ b/packages/sanity/src/core/comments/hooks/useNotificationTarget.ts
@@ -1,11 +1,11 @@
 import {useCallback, useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {of} from 'rxjs'
 
 import {useSchema} from '../../hooks/useSchema'
 import {getPreviewStateObservable} from '../../preview/utils/getPreviewStateObservable'
 import {useDocumentPreviewStore} from '../../store/datastores'
 import {useWorkspace} from '../../studio/workspace'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {type CommentContext} from '../types'
 
 interface NotificationTargetHookOptions {
@@ -43,7 +43,11 @@ export function useNotificationTarget(
     const perspectiveStack = documentVersionId ? [documentVersionId, 'drafts'] : ['drafts']
     return getPreviewStateObservable(documentPreviewStore, schemaType, documentId, perspectiveStack)
   }, [documentId, documentPreviewStore, schemaType, documentVersionId])
-  const previewState = useObservable(previewStateObservable)
+  // Deferred (per review): `documentTitle` is only used in the notification
+  // email body, where a briefly stale title is harmless (it can go stale
+  // after send anyway). The identity-coherent deferral still falls back to
+  // the live value when the previewed document id changes.
+  const previewState = useDeferredObservableValue(previewStateObservable)
 
   const {snapshot, original} = previewState || {}
   const documentTitle = (snapshot?.title || original?.title || 'Sanity document') as string

--- a/packages/sanity/src/core/components/CapabilityGate.tsx
+++ b/packages/sanity/src/core/components/CapabilityGate.tsx
@@ -1,5 +1,5 @@
 import {type ComponentType, type PropsWithChildren} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 
 import {useRenderingContextStore} from '../store/datastores'
 import {type Capability} from '../store/renderingContext/types'
@@ -25,7 +25,9 @@ export const CapabilityGate: ComponentType<Props> = ({
   condition = 'unavailable',
 }) => {
   const renderingContextStore = useRenderingContextStore()
-  const renderingContextCapabilities = useObservable(renderingContextStore.capabilities, {})
+  // Kept synchronous: capabilities emit once at boot, so deferring only
+  // delays the gate flipping without any render-load benefit.
+  const renderingContextCapabilities = useSyncObservable(renderingContextStore.capabilities, {})
   const renderingContextHasCapability = renderingContextCapabilities[capability] === true
 
   if (condition === 'available' && !renderingContextHasCapability) {

--- a/packages/sanity/src/core/divergence/divergenceNavigator.ts
+++ b/packages/sanity/src/core/divergence/divergenceNavigator.ts
@@ -2,7 +2,7 @@ import {type ObjectSchemaType, type Path, type SchemaType} from '@sanity/types'
 import {fromString, startsWith, toString} from '@sanity/util/paths'
 import pick from 'lodash-es/pick.js'
 import {useCallback, useEffect, useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {
   BehaviorSubject,
   combineLatest,
@@ -238,7 +238,11 @@ export function useDivergenceNavigator({
     })
   }, [dispatch])
 
-  const state = useObservable(readState, {
+  // Kept synchronous: `previousDivergence` / `nextDivergence` are the targets
+  // the prev/next buttons pass to `focusDivergence`, so a deferred snapshot
+  // could re-focus a stale neighbor instead of advancing during rapid
+  // navigation.
+  const state = useSyncObservable(readState, {
     focusedDivergence: undefined,
     previousDivergence: undefined,
     nextDivergence: undefined,

--- a/packages/sanity/src/core/divergence/hooks/useDivergenceController.ts
+++ b/packages/sanity/src/core/divergence/hooks/useDivergenceController.ts
@@ -3,7 +3,7 @@ import {useTelemetry} from '@sanity/telemetry/react'
 import {type SanityDocument} from '@sanity/types'
 import {fromString, get} from '@sanity/util/paths'
 import {useContext, useEffect, useEffectEvent, useState} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {
   type Observable,
   EMPTY,
@@ -158,8 +158,11 @@ export function useDivergenceController(
       }),
     )
 
-  const upstreamBase = useObservable(readUpstreamBase, {isLoading: true})
-  const upstreamHead = useObservable(readUpstreamHead, {isLoading: true})
+  // Kept synchronous: `markResolved` / `takeUpstreamValue` build and execute
+  // patches from `upstreamHead.value.document` (and gate on `isLoading`), so a
+  // deferred snapshot could act against a stale upstream document head.
+  const upstreamBase = useSyncObservable(readUpstreamBase, {isLoading: true})
+  const upstreamHead = useSyncObservable(readUpstreamHead, {isLoading: true})
 
   const isLoading = upstreamBase.isLoading || upstreamHead.isLoading
   const isReadOnly = contextReadOnly || isLoading || isActionPending

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -7,14 +7,14 @@ import {type SanityDocumentLike} from '@sanity/types'
 import {Flex, PortalProvider, Stack, Text, TextInput} from '@sanity/ui'
 import {useActorRef, useSelector} from '@xstate/react'
 import {
-  type ComponentType,
-  useMemo,
   type ChangeEvent,
-  useState,
+  type ComponentType,
   useEffect,
   useLayoutEffect,
+  useMemo,
+  useState,
 } from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {
   combineLatest,
   debounceTime,
@@ -706,7 +706,11 @@ function usePreserveIntrinsicBlockSize({
   element: HTMLElement | null
 }): void {
   const size = useMemo(() => new Subject<DOMRect | undefined>(), [])
-  const currentSize = useObservable(size)
+  // Kept synchronous: this drives an imperative style write
+  // (`--intrinsic-block-size`) that preserves layout during activation, so a
+  // deferred snapshot lagging the latest ResizeObserver measurement could
+  // cause visible layout jumps.
+  const currentSize = useSyncObservable(size)
 
   useEffect(() => {
     const resizeObserver = new ResizeObserver(([entry]) => {

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventoryAction.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventoryAction.tsx
@@ -2,7 +2,6 @@ import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
 import {ChevronUpIcon} from '@sanity/icons/ChevronUp'
 import {LayerProvider, useClickOutsideEvent} from '@sanity/ui'
 import {type ComponentType, type PropsWithChildren, useMemo, useRef} from 'react'
-import {useObservable} from 'react-rx'
 import {map} from 'rxjs'
 import {styled} from 'styled-components'
 
@@ -16,6 +15,7 @@ import {ReleaseAvatarIcon} from '../../releases/components/ReleaseAvatar'
 import {useDocumentVersionsObservable} from '../../releases/hooks/useDocumentVersions'
 import {isDraftPerspective, isPublishedPerspective} from '../../releases/util/util'
 import {isAgentBundleName} from '../../store/agent/createAgentBundlesStore'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 
 export const DocumentGroupInventoryAction: ComponentType<
   PropsWithChildren<{
@@ -38,7 +38,7 @@ export const DocumentGroupInventoryAction: ComponentType<
 
   const versionState = useDocumentVersionsObservable({documentId})
 
-  const isAvailable = useObservable(
+  const isAvailable = useDeferredObservableValue(
     useMemo(
       () => versionState.pipe(map(({loading, versions}) => !loading && versions.length !== 0)),
       [versionState],

--- a/packages/sanity/src/core/field/diff/hooks/useRefValue.ts
+++ b/packages/sanity/src/core/field/diff/hooks/useRefValue.ts
@@ -1,5 +1,5 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {EMPTY} from 'rxjs'
 
 import {useClient} from '../../../hooks/useClient'
@@ -14,7 +14,10 @@ export function useRefValue<T extends Record<string, any> = Record<string, any>>
     () => (refId ? client.observable.getDocument<T>(refId) : EMPTY),
     [client, refId],
   )
-  const value = useObservable(document$)
+  // Kept synchronous: the falsy-ref guard below reads the live `refId`, so a
+  // deferred snapshot could return the previously referenced document under a
+  // newly selected ref.
+  const value = useSyncObservable(document$)
 
   // Always return undefined in the case of a falsey ref to prevent bug
   // when going from an ID to an undefined state

--- a/packages/sanity/src/core/form/contexts/DivergencesProvider.tsx
+++ b/packages/sanity/src/core/form/contexts/DivergencesProvider.tsx
@@ -10,7 +10,7 @@ import {
   useMemo,
   useState,
 } from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {BehaviorSubject, combineLatest, EMPTY, filter, map, of, Subject, tap} from 'rxjs'
 import {type DocumentDivergencesContextValue, DocumentDivergencesContext} from 'sanity/_singletons'
 
@@ -182,7 +182,10 @@ function useCollateDivergencesContext({
     get(subjectHead, ['_system', 'base', 'id']) === upstreamHead?._id &&
     get(subjectHead, ['_system', 'base', 'rev']) === upstreamHead?._rev
 
-  const mostRecentSharedTransaction = useObservable(
+  // Kept synchronous: this is an input to the `readUpstreamAtFork` stream that
+  // is combined with the live document heads below — a deferred snapshot could
+  // pair an outdated fork-point revision with newer heads.
+  const mostRecentSharedTransaction = useSyncObservable(
     shouldFindForkPoint && baseIsForkPoint
       ? EMPTY
       : readMostRecentSharedTransaction({
@@ -262,5 +265,8 @@ function useCollateDivergencesContext({
     }).pipe(tap((nextContext) => context.next(nextContext)))
   }, [readUpstreamAtFork, context, listenUpstreamHead, listenSubjectHead, listenResolutions])
 
-  return useObservable(listenContext)
+  // The subscription exists to drive the `context.next` pipeline above; the
+  // returned snapshot is not consumed for rendering, so deferring it would
+  // only desynchronize the pipeline.
+  return useSyncObservable(listenContext)
 }

--- a/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/PreviewReferenceValue.tsx
+++ b/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/PreviewReferenceValue.tsx
@@ -19,7 +19,7 @@ export function PreviewReferenceValue(props: {
   const {t} = useTranslation()
   const projectId = useProjectId()
 
-  if (referenceInfo.isLoading || referenceInfo.error) {
+  if (referenceInfo.isLoading || referenceInfo.error || !referenceInfo.result) {
     return (
       <Stack gap={2} padding={1}>
         <TextSkeleton style={{maxWidth: 320}} radius={1} animated={!referenceInfo.error} />
@@ -29,7 +29,7 @@ export function PreviewReferenceValue(props: {
   }
   const showTypeLabel = type.to.length > 1
 
-  const refTypeName = referenceInfo.result?.type
+  const refTypeName = referenceInfo.result.type
   const refType = type.to.find((toType) => toType.type === refTypeName)
 
   if (referenceInfo.result.availability?.available && !refType) {

--- a/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/useReferenceInfo.ts
+++ b/packages/sanity/src/core/form/inputs/CrossDatasetReferenceInput/useReferenceInfo.ts
@@ -1,5 +1,5 @@
 import {useCallback, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {type Observable, of} from 'rxjs'
 import {catchError, map, startWith} from 'rxjs/operators'
 
@@ -75,5 +75,6 @@ export function useReferenceInfo(
         : of(EMPTY_STATE),
     [docInfo, getReferenceInfo, retry, retryAttempt],
   )
-  return useObservable(referenceInfoObservable, INITIAL_LOADING_STATE)
+  // Do not defer: EMPTY_STATE is unsafe to show after the document id becomes set.
+  return useSyncObservable(referenceInfoObservable, INITIAL_LOADING_STATE)
 }

--- a/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/PreviewReferenceValue.tsx
+++ b/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/PreviewReferenceValue.tsx
@@ -20,7 +20,7 @@ export function PreviewReferenceValue(props: {
   const {value, type, showStudioUrlIcon, hasStudioUrl, referenceInfo} = props
   const {t} = useTranslation()
 
-  if (referenceInfo.isLoading || referenceInfo.error) {
+  if (referenceInfo.isLoading || referenceInfo.error || !referenceInfo.result) {
     return (
       <Stack gap={2} padding={1}>
         <TextSkeleton style={{maxWidth: 320}} radius={1} animated={!referenceInfo.error} />
@@ -30,7 +30,7 @@ export function PreviewReferenceValue(props: {
   }
   const showTypeLabel = type.to.length > 1
 
-  const refTypeName = referenceInfo.result?.type
+  const refTypeName = referenceInfo.result.type
   const refType = type.to.find((toType) => toType.type === refTypeName)
 
   if (referenceInfo.result.availability?.available && !refType) {

--- a/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/useReferenceInfo.ts
+++ b/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/useReferenceInfo.ts
@@ -1,5 +1,5 @@
 import {useCallback, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {type Observable, of} from 'rxjs'
 import {catchError, map, startWith} from 'rxjs/operators'
 
@@ -74,5 +74,6 @@ export function useReferenceInfo(
       }),
     )
   }, [doc, getReferenceInfo, retry, retryAttempt])
-  return useObservable(referenceInfoObservable, INITIAL_LOADING_STATE)
+  // Do not defer: EMPTY_STATE is unsafe to show after the document id becomes set.
+  return useSyncObservable(referenceInfoObservable, INITIAL_LOADING_STATE)
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/Toolbar.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/Toolbar.browser.test.tsx
@@ -144,7 +144,10 @@ describe('Portable Text Input', () => {
         expect(menuPopover).not.toBeNull()
       })
 
-      it('on a full screen multi nested PTE', async () => {
+      // Takes ~25s against the default 30s timeout on a healthy CI runner
+      // (firefox), so any runner slowdown pushed it over the limit. Give it
+      // explicit headroom instead.
+      it('on a full screen multi nested PTE', {timeout: 90_000}, async () => {
         const {getFocusedPortableTextInput} = testHelpers()
         void render(<ToolbarStory />)
         const $portableTextInput = await getFocusedPortableTextInput('field-body')

--- a/packages/sanity/src/core/form/inputs/PortableText/contexts/PortableTextMemberItemElementRefsProvider.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/contexts/PortableTextMemberItemElementRefsProvider.tsx
@@ -1,5 +1,5 @@
 import {useCallback, useContext} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {
   type PortableTextEditorElement,
   PortableTextMemberItemElementRefsContext,
@@ -21,7 +21,10 @@ export function usePortableTextMemberItemElementRefs(): Record<
 > {
   const behaviorSubject = useContext(PortableTextMemberItemElementRefsContext)
 
-  return useObservable(behaviorSubject, {})
+  // Kept synchronous: these are live DOM refs read imperatively (annotation
+  // popover reference elements, focus/scroll tracking in layout effects) — a
+  // deferred snapshot could miss the mounted node right when it's needed.
+  return useSyncObservable(behaviorSubject, {})
 }
 
 export function useSetPortableTextMemberItemElementRef(): SetPortableTextMemberItemElementRef {

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/PreviewReferenceValue.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/PreviewReferenceValue.tsx
@@ -27,7 +27,9 @@ export function PreviewReferenceValue(props: {
   const {layout = 'default', referenceInfo, renderPreview, type, value, showTypeLabel} = props
   const {t} = useTranslation()
 
-  if (referenceInfo.isLoading || referenceInfo.error) {
+  // Treat missing result as loading — EMPTY_STATE and deferred lag can yield
+  // isLoading:false with result:undefined while value._ref is already set.
+  if (referenceInfo.isLoading || referenceInfo.error || !referenceInfo.result) {
     return <SanityDefaultPreview isPlaceholder layout={layout} />
   }
 

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/useReferenceInfo.ts
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/useReferenceInfo.ts
@@ -1,6 +1,6 @@
 import {observableCallback} from 'observable-callback'
 import {useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {concat, type Observable, of} from 'rxjs'
 import {catchError, concatMap, map, startWith} from 'rxjs/operators'
 
@@ -71,5 +71,7 @@ export function useReferenceInfo(
       ),
     [getReferenceInfo, id, onRetry, onRetry$],
   )
-  return useObservable(referenceInfoObservable, INITIAL_LOADING_STATE)
+  // Do not defer: EMPTY_STATE (isLoading:false, result:undefined) is unsafe to show after
+  // id becomes set — PreviewReferenceValue assumes non-loading implies result is defined.
+  return useSyncObservable(referenceInfoObservable, INITIAL_LOADING_STATE)
 }

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetMenu.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAssetMenu.tsx
@@ -4,7 +4,7 @@ import {SearchIcon} from '@sanity/icons/Search'
 import {type AssetSource, type ImageAsset, type Reference} from '@sanity/types'
 import get from 'lodash-es/get.js'
 import {memo, type ReactNode, type RefObject, useCallback, useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {type Observable} from 'rxjs'
 
 import {MenuItem} from '../../../../../ui-components/menuItem/MenuItem'
@@ -190,7 +190,10 @@ function ImageInputAssetMenuWithReferenceAssetComponent(
 
   const documentId = reference?._ref
   const observable = useMemo(() => observeAsset(documentId), [documentId, observeAsset])
-  const asset = useObservable(observable)
+  // Kept synchronous: a deferred snapshot could pair the previous asset with a
+  // newly selected reference, pointing menu actions (e.g. open in source) at
+  // the wrong asset.
+  const asset = useSyncObservable(observable)
   const assetSourcesWithUpload = getAssetSourcesWithUpload(assetSources)
 
   // Find the first asset source that can handle opening this asset in source

--- a/packages/sanity/src/core/form/inputs/files/ImageToolInput/useLoadImage.ts
+++ b/packages/sanity/src/core/form/inputs/files/ImageToolInput/useLoadImage.ts
@@ -1,5 +1,5 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {catchError, map, Observable, of, startWith} from 'rxjs'
 
 // http://probablyprogramming.com/2009/03/15/the-tiniest-gif-ever
@@ -60,5 +60,8 @@ export function useLoadImage(url: string): ImageLoadState {
     [url],
   )
 
-  return useObservable(state$, INITIAL_STATE)
+  // Kept synchronous: `state$` resets to loading when `url` changes, and a
+  // deferred snapshot could briefly render the previous image element under
+  // the new url.
+  return useSyncObservable(state$, INITIAL_STATE)
 }

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/hooks/useEnsureMediaLibrary.ts
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/hooks/useEnsureMediaLibrary.ts
@@ -1,6 +1,5 @@
 import {type ObservableSanityClient} from '@sanity/client'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {
   catchError,
   concatMap,
@@ -15,6 +14,7 @@ import {
 } from 'rxjs'
 
 import {useClient} from '../../../../hooks/useClient'
+import {useDeferredObservableValue} from '../../../../util/useDeferredObservableValue'
 import {type MediaLibrary} from '../types'
 
 type ErrorCode = 'ERROR_NO_ORGANIZATION_FOUND' | 'ERROR_NO_LIBRARY_FOUND'
@@ -172,5 +172,5 @@ export function useEnsureMediaLibrary(
     )
   }, [client, props])
 
-  return useObservable(observable, {status: 'loading'})
+  return useDeferredObservableValue(observable, {status: 'loading'})
 }

--- a/packages/sanity/src/core/form/useComlinkViewHistory.ts
+++ b/packages/sanity/src/core/form/useComlinkViewHistory.ts
@@ -1,5 +1,5 @@
 import {useEffect, useRef} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 
 import {useRecordDocumentHistoryEvent} from '../hooks/useRecordDocumentHistoryEvent'
 import {useRenderingContextStore} from '../store/datastores'
@@ -15,7 +15,9 @@ import {useActiveWorkspace} from '../studio/activeWorkspaceMatcher/useActiveWork
  */
 export function useComlinkViewHistory({editState}: {editState: EditStateFor}): void {
   const renderingContextStore = useRenderingContextStore()
-  const capabilities = useObservable(renderingContextStore.capabilities)
+  // Kept synchronous: capabilities emit once at boot and gate the history
+  // recording effect below; deferring only delays it.
+  const capabilities = useSyncObservable(renderingContextStore.capabilities)
   const {activeWorkspace} = useActiveWorkspace()
   const displayed = editState.version ?? editState.draft ?? editState.published
 

--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -20,7 +20,6 @@ import {
   useState,
 } from 'react'
 import deepEquals from 'react-fast-compare'
-import {useObservable} from 'react-rx'
 import {distinctUntilChanged} from 'rxjs/operators'
 
 import {useCanvasCompanionDoc} from '../canvas/actions/useCanvasCompanionDoc'
@@ -64,6 +63,7 @@ import {
   isSystemBundle,
 } from '../util/draftUtils'
 import {EMPTY_ARRAY} from '../util/empty'
+import {useDeferredObservableValue} from '../util/useDeferredObservableValue'
 import {useUnique} from '../util/useUnique'
 import {CreatedDraft} from './__telemetry__/form.telemetry'
 import {type PatchEvent} from './patch/PatchEvent'
@@ -360,7 +360,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
         ),
     [presenceStore, value._id],
   )
-  const presence = useObservable(presence$, [])
+  const presence = useDeferredObservableValue(presence$, [])
 
   const [openPath, onSetOpenPath] = useState<Path>(initialFocusPath || EMPTY_ARRAY)
   const [fieldGroupState, onSetFieldGroupState] = useState<StateTree<string>>()

--- a/packages/sanity/src/core/form/utils/WithReferencedAsset.tsx
+++ b/packages/sanity/src/core/form/utils/WithReferencedAsset.tsx
@@ -1,6 +1,6 @@
 import {type Reference} from '@sanity/types'
 import {type ReactNode, useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {type Observable} from 'rxjs'
 
 interface Props<AssetDoc> {
@@ -14,6 +14,9 @@ export function WithReferencedAsset<Asset>(props: Props<Asset>) {
   const {reference, children, observeAsset, waitPlaceholder} = props
   const documentId = reference?._ref
   const observable = useMemo(() => observeAsset(documentId), [documentId, observeAsset])
-  const asset = useObservable(observable)
+  // Kept synchronous: the render gates on the live `documentId`, so a deferred
+  // snapshot could hand `children` the previous asset after the reference
+  // changes to a new document.
+  const asset = useSyncObservable(observable)
   return <>{documentId && asset ? children(asset) : waitPlaceholder}</>
 }

--- a/packages/sanity/src/core/hooks/__tests__/useValidationStatus.test.tsx
+++ b/packages/sanity/src/core/hooks/__tests__/useValidationStatus.test.tsx
@@ -1,0 +1,104 @@
+import {act, render} from '@testing-library/react'
+import {useEffect, useState} from 'react'
+import {Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {type ValidationStatus} from '../../validation'
+import {useValidationStatus} from '../useValidationStatus'
+
+/**
+ * Guards the synchronous read in `useValidationStatus`. Its consumers use it
+ * as a write-side gate: `PublishAction` enables publish from
+ * `hasValidationErrors` and fires `doPublish()` once `isValidating` is false
+ * and `validationStatus.revision` matches the live edit revision.
+ * Reference-driven revalidation re-runs validation without changing the
+ * document revision, so a deferred read would let a stale — but
+ * revision-matching — "valid" snapshot pass that gate while live validation
+ * is discovering errors. Identity-coherent deferral cannot prevent this: the
+ * validation observable's identity is stable while the pane is mounted; only
+ * the value lags.
+ *
+ * The discriminating assertion below fails if the hook is ever routed
+ * through `useDeferredValue` / `useDeferredObservableValue` again: a
+ * deferred read commits one frame pairing fresh urgent state with the stale
+ * (error-free) validation snapshot.
+ */
+
+let validationSubject: Subject<ValidationStatus>
+
+// The store must be referentially stable across renders: the hook memoizes
+// the validation observable on `documentStore.pair`, and a fresh object per
+// render would rebuild + resubscribe every render (losing subject emissions).
+const mockDocumentStore = {
+  pair: {validation: () => validationSubject.asObservable()},
+}
+
+vi.mock('../../store/datastores', () => ({
+  useDocumentStore: () => mockDocumentStore,
+}))
+
+const errorMarker = {
+  level: 'error',
+  message: 'Reference is no longer published',
+  path: ['someRef'],
+} as unknown as ValidationStatus['validation'][number]
+
+describe('useValidationStatus', () => {
+  beforeEach(() => {
+    validationSubject = new Subject<ValidationStatus>()
+  })
+
+  it('returns the initial status until the observable emits', () => {
+    const results: ValidationStatus[] = []
+    function Probe() {
+      results.push(useValidationStatus('doc-1', 'author', false))
+      return null
+    }
+    render(<Probe />)
+
+    expect(results[results.length - 1]).toEqual({validation: [], isValidating: false})
+  })
+
+  it('commits validation emissions on the first frame, even batched with urgent updates', () => {
+    const frames: {tick: number; isValidating: boolean; errorCount: number}[] = []
+    let bumpTick: (() => void) | null = null
+
+    function Probe() {
+      const status = useValidationStatus('doc-1', 'author', false)
+      const [tick, setTick] = useState(0)
+      useEffect(() => {
+        bumpTick = () => setTick((current) => current + 1)
+      }, [])
+      frames.push({
+        tick,
+        isValidating: status.isValidating,
+        errorCount: status.validation.length,
+      })
+      return null
+    }
+    render(<Probe />)
+
+    // Reference-driven revalidation: same document revision throughout. The
+    // `isValidating: true` frame doubles as proof the subscription delivers.
+    act(() => {
+      validationSubject.next({validation: [], isValidating: true, revision: 'rev-1'})
+    })
+    expect(frames[frames.length - 1]).toMatchObject({isValidating: true, errorCount: 0})
+
+    // Validation discovers an error while an urgent update (any re-render
+    // source: presence, sync, a keystroke) lands in the same batch.
+    act(() => {
+      validationSubject.next({validation: [errorMarker], isValidating: false, revision: 'rev-1'})
+      bumpTick!()
+    })
+
+    // The frame carrying the urgent update must already show the error. A
+    // deferred read would commit {tick: 1, isValidating: true, errorCount: 0}
+    // first — the stale still-validating (or stale "valid") snapshot a
+    // publish gate could act on.
+    expect(frames).toContainEqual({tick: 1, isValidating: false, errorCount: 1})
+    expect(frames.filter((frame) => frame.tick === 1)).toEqual([
+      {tick: 1, isValidating: false, errorCount: 1},
+    ])
+  })
+})

--- a/packages/sanity/src/core/hooks/useConnectionState.ts
+++ b/packages/sanity/src/core/hooks/useConnectionState.ts
@@ -1,5 +1,5 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {type Observable, of, timer} from 'rxjs'
 import {distinctUntilChanged, map, mapTo, startWith, switchMap} from 'rxjs/operators'
 
@@ -49,5 +49,8 @@ export function useConnectionState(
     () => connectionState(documentStore, publishedDocId, docTypeName, version),
     [docTypeName, documentStore, publishedDocId, version],
   )
-  return useObservable(observable, INITIAL)
+  // Kept synchronous: `useDocumentForm` gates the form's `ready` / `readOnly`
+  // state on this (a `reconnecting` connection makes the editor read-only), so
+  // a deferred value could leave the editor writable while reconnecting.
+  return useSyncObservable(observable, INITIAL)
 }

--- a/packages/sanity/src/core/hooks/useDocumentOperation.ts
+++ b/packages/sanity/src/core/hooks/useDocumentOperation.ts
@@ -1,5 +1,5 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 
 import {useDocumentStore} from '../store/datastores'
 import {type OperationsAPI} from '../store/document/document-pair/operations/types'
@@ -33,8 +33,12 @@ export function useDocumentOperation(
   /**
    * We know that since the observable has a startWith operator, it will always emit a value
    * and that's why the non-null assertion is used here
+   *
+   * Kept synchronous: the operations are imperative emitters bound to the
+   * document id/type they were created for, so a deferred (stale) API could
+   * execute an action against the previously viewed document after navigation.
    */
-  const api = useObservable(observable)!
+  const api = useSyncObservable(observable)!
 
   return useDocumentOperationWithComlinkHistory({
     api,

--- a/packages/sanity/src/core/hooks/useDocumentOperationEvent.ts
+++ b/packages/sanity/src/core/hooks/useDocumentOperationEvent.ts
@@ -1,5 +1,5 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 
 import {useDocumentStore} from '../store/datastores'
 
@@ -11,5 +11,8 @@ export function useDocumentOperationEvent(publishedDocId: string, docTypeName: s
     () => documentStore.pair.operationEvents(publishedDocId, docTypeName),
     [docTypeName, documentStore.pair, publishedDocId],
   )
-  return useObservable(observable)
+  // Kept synchronous: this is an event stream driving effects (toasts,
+  // pane-close). Deferring could coalesce a quick success/error sequence into
+  // one render and drop an event consumers must react to.
+  return useSyncObservable(observable)
 }

--- a/packages/sanity/src/core/hooks/useDocumentOperationWithComlinkHistory.ts
+++ b/packages/sanity/src/core/hooks/useDocumentOperationWithComlinkHistory.ts
@@ -1,5 +1,5 @@
 import {useCallback, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 
 import {useRenderingContextStore} from '../store/datastores'
 import {type OperationsAPI} from '../store/document/document-pair/operations/types'
@@ -38,7 +38,10 @@ export function useDocumentOperationWithComlinkHistory({
   })
 
   const renderingContextStore = useRenderingContextStore()
-  const capabilities = useObservable(renderingContextStore.capabilities)
+  // Kept synchronous: capabilities emit once at boot and gate whether
+  // operations are decorated with comlink history capture; deferring only
+  // delays the decoration.
+  const capabilities = useSyncObservable(renderingContextStore.capabilities)
 
   // Used to prevent redundant `edited` events being recorded.
   const [hasRecordedEdit, setHasRecordedEdit] = useState<boolean>(false)

--- a/packages/sanity/src/core/hooks/useDocumentSyncState.ts
+++ b/packages/sanity/src/core/hooks/useDocumentSyncState.ts
@@ -1,5 +1,5 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {combineLatest, type Observable, of, timer} from 'rxjs'
 import {distinctUntilChanged, map, startWith, switchMap} from 'rxjs/operators'
 
@@ -183,5 +183,9 @@ export function useDocumentSyncState(
     [docTypeName, documentStore, publishedDocId, version],
   )
 
-  return useObservable(observable, INITIAL)
+  // Kept synchronous: `useDocumentForm` derives `syncBlocked` (part of
+  // `readOnly`) from this — a `stalled` / `recovering` sync locks the editor.
+  // A deferred value could keep the editor writable after sync is blocked,
+  // risking edits against unsynced state.
+  return useSyncObservable(observable, INITIAL)
 }

--- a/packages/sanity/src/core/hooks/useEditState.ts
+++ b/packages/sanity/src/core/hooks/useEditState.ts
@@ -1,5 +1,5 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {debounce, distinctUntilChanged, merge, share, shareReplay, skip, take, timer} from 'rxjs'
 
 import {useDocumentStore} from '../store/datastores'
@@ -51,5 +51,5 @@ export function useEditState(
    * We know that since the observable has a startWith operator, it will always emit a value
    * and that's why the non-null assertion is used here
    */
-  return useObservable(observable)!
+  return useSyncObservable(observable)!
 }

--- a/packages/sanity/src/core/hooks/useFeatureEnabled.ts
+++ b/packages/sanity/src/core/hooks/useFeatureEnabled.ts
@@ -1,11 +1,11 @@
 import {type SanityClient} from '@sanity/client'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {type Observable, of} from 'rxjs'
 import {catchError, map, shareReplay, startWith} from 'rxjs/operators'
 
 import {useSource} from '../studio/source'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../studioClient'
+import {useDeferredObservableValue} from '../util/useDeferredObservableValue'
 import {useClient} from './useClient'
 
 const EMPTY_ARRAY: [] = []
@@ -87,7 +87,7 @@ export function useFeatureEnabled(featureKey: keyof typeof FEATURES): Features {
       ),
     [featureKey, req],
   )
-  const featureInfo = useObservable(featureInfoObservable, INITIAL_LOADING_STATE)
+  const featureInfo = useDeferredObservableValue(featureInfoObservable, INITIAL_LOADING_STATE)
 
   return featureInfo
 }

--- a/packages/sanity/src/core/hooks/useManageFavorite.ts
+++ b/packages/sanity/src/core/hooks/useManageFavorite.ts
@@ -9,7 +9,7 @@ import {
 } from '@sanity/message-protocol'
 import {type DocumentHandle} from '@sanity/sdk'
 import {useCallback, useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {
   catchError,
   connect,
@@ -121,7 +121,10 @@ export function useManageFavorite({
   )
 
   const stateController = useMemo(() => optimisticState({node, context}), [context, node])
-  const state = useObservable(stateController.state)
+  // Kept synchronous: favorite()/unfavorite() push an optimistic SET into
+  // this stream so the toggle reflects the click immediately; deferring the
+  // state would make the control lag its own interaction.
+  const state = useSyncObservable(stateController.state)
 
   return {
     favorite: useCallback(() => stateController.setState(true), [stateController]),

--- a/packages/sanity/src/core/hooks/useProjectSubscriptions.ts
+++ b/packages/sanity/src/core/hooks/useProjectSubscriptions.ts
@@ -1,11 +1,11 @@
 import {type SanityClient} from '@sanity/client'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {type Observable, of} from 'rxjs'
 import {catchError, map, shareReplay, startWith} from 'rxjs/operators'
 
 import {useSource} from '../studio/source'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../studioClient'
+import {useDeferredObservableValue} from '../util/useDeferredObservableValue'
 import {useClient} from './useClient'
 
 type FeatureAttributes = Record<string, string | number | boolean | null>
@@ -152,5 +152,5 @@ export function useProjectSubscriptions(): ProjectSubscriptions {
     )
   }, [projectId])
 
-  return useObservable(projectSubscriptionsObservable, INITIAL_LOADING_STATE)
+  return useDeferredObservableValue(projectSubscriptionsObservable, INITIAL_LOADING_STATE)
 }

--- a/packages/sanity/src/core/hooks/useReferringDocuments.ts
+++ b/packages/sanity/src/core/hooks/useReferringDocuments.ts
@@ -1,9 +1,9 @@
 import {type SanityDocument} from '@sanity/types'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {map, startWith} from 'rxjs/operators'
 
 import {useDocumentStore} from '../store/datastores'
+import {useDeferredObservableValue} from '../util/useDeferredObservableValue'
 
 interface ReferringDocumentsState<Doc> {
   isLoading: boolean
@@ -61,7 +61,7 @@ export function useReferringDocuments<DocumentType extends SanityDocument>(
         startWith(INITIAL_STATE),
       )
   }, [documentStore, id, projection])
-  return useObservable(observable, INITIAL_STATE)
+  return useDeferredObservableValue(observable, INITIAL_STATE)
 }
 
 const EMPTY_FIELDS: never[] = []

--- a/packages/sanity/src/core/hooks/useSyncState.ts
+++ b/packages/sanity/src/core/hooks/useSyncState.ts
@@ -1,5 +1,5 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {type Observable} from 'rxjs'
 import {map} from 'rxjs/operators'
 
@@ -28,5 +28,5 @@ export function useSyncState(
         .pipe(map((isConsistent) => (isConsistent ? NOT_SYNCING : SYNCING))),
     [documentStore.pair, documentType, publishedDocId, version],
   )
-  return useObservable<Observable<SyncState>>(observable, NOT_SYNCING)
+  return useSyncObservable<Observable<SyncState>>(observable, NOT_SYNCING)
 }

--- a/packages/sanity/src/core/hooks/useTimeZone.tsx
+++ b/packages/sanity/src/core/hooks/useTimeZone.tsx
@@ -4,7 +4,7 @@ import {useToast} from '@sanity/ui'
 import {sanitizeLocale} from '@sanity/util/legacyDateFormat'
 import {format as dateFnsFormat} from 'date-fns/format'
 import {useCallback, useEffect, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {startWith} from 'rxjs/operators'
 
 import {useKeyValueStore} from '../store/datastores'
@@ -212,7 +212,10 @@ export const useTimeZone = (scope: TimeZoneScope) => {
     [keyValueStore, keyStoreId],
   )
 
-  const storedTimeZone = useObservable(keyValueTimeZone$, null)
+  // Kept synchronous: `getStoredTimeZone` migrates legacy values by writing
+  // back to the key-value store, so a deferred snapshot could trigger stale or
+  // redundant writes after the store has already advanced.
+  const storedTimeZone = useSyncObservable(keyValueTimeZone$, null)
 
   const getStoredTimeZone = useCallback((): NormalizedTimeZone | undefined => {
     if (!storedTimeZone) return undefined

--- a/packages/sanity/src/core/hooks/useUpsellData.ts
+++ b/packages/sanity/src/core/hooks/useUpsellData.ts
@@ -1,6 +1,5 @@
 import {useTelemetry} from '@sanity/telemetry/react'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {catchError, map, of} from 'rxjs'
 
 import {
@@ -13,6 +12,7 @@ import {
 import {type UpsellData} from '../studio/upsell/types'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../studioClient'
 import {interpolateTemplate} from '../util/interpolateTemplate'
+import {useDeferredObservableValue} from '../util/useDeferredObservableValue'
 import {useClient} from './useClient'
 import {useProjectId} from './useProjectId'
 
@@ -105,7 +105,7 @@ export const useUpsellData = ({dataUri, feature}: UpsellDataProps) => {
     [client, projectId, baseUrl, dataUri],
   )
 
-  const {upsellData, hasError} = useObservable(upsellResult$, INITIAL_UPSELL_RESULT)
+  const {upsellData, hasError} = useDeferredObservableValue(upsellResult$, INITIAL_UPSELL_RESULT)
 
   return {upsellData, telemetryLogs, hasError}
 }

--- a/packages/sanity/src/core/hooks/useUserListWithPermissions.ts
+++ b/packages/sanity/src/core/hooks/useUserListWithPermissions.ts
@@ -2,7 +2,6 @@ import {type SanityDocument} from '@sanity/client'
 import {type User} from '@sanity/types'
 import sortBy from 'lodash-es/sortBy.js'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {
   catchError,
   concat,
@@ -21,6 +20,7 @@ import {type DocumentValuePermission, type Grant} from '../store/grants/types'
 import {type ProjectData} from '../store/project/types'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../studioClient'
 import {getSystemGroups$} from '../util/getSystemGroups$'
+import {useDeferredObservableValue} from '../util/useDeferredObservableValue'
 import {useClient} from './useClient'
 
 type Loadable<T> = {
@@ -175,5 +175,5 @@ export function useUserListWithPermissions(
     )
   }, [documentValue, permission, users$, systemGroup$])
 
-  return useObservable(state$, INITIAL_STATE)
+  return useDeferredObservableValue(state$, INITIAL_STATE)
 }

--- a/packages/sanity/src/core/hooks/useValidationStatus.ts
+++ b/packages/sanity/src/core/hooks/useValidationStatus.ts
@@ -1,7 +1,7 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 
 import {useDocumentStore} from '../store/datastores'
+import {useDeferredObservableValue} from '../util/useDeferredObservableValue'
 import {type ValidationStatus} from '../validation'
 
 const INITIAL: ValidationStatus = {validation: [], isValidating: false}
@@ -20,5 +20,5 @@ export function useValidationStatus(
     [docTypeName, documentStore.pair, validationTargetId, requirePublishedReferences],
   )
 
-  return useObservable(observable, INITIAL)
+  return useDeferredObservableValue(observable, INITIAL)
 }

--- a/packages/sanity/src/core/hooks/useValidationStatus.ts
+++ b/packages/sanity/src/core/hooks/useValidationStatus.ts
@@ -1,7 +1,7 @@
 import {useMemo} from 'react'
+import {useObservable as useSyncObservable} from 'react-rx'
 
 import {useDocumentStore} from '../store/datastores'
-import {useDeferredObservableValue} from '../util/useDeferredObservableValue'
 import {type ValidationStatus} from '../validation'
 
 const INITIAL: ValidationStatus = {validation: [], isValidating: false}
@@ -20,5 +20,14 @@ export function useValidationStatus(
     [docTypeName, documentStore.pair, validationTargetId, requirePublishedReferences],
   )
 
-  return useDeferredObservableValue(observable, INITIAL)
+  // Kept synchronous: consumers use this as a write-side gate, not just for
+  // display. PublishAction enables publish from `hasValidationErrors` and
+  // fires `doPublish()` once `isValidating` is false and `revision` matches
+  // the live edit revision — and reference-driven revalidation re-runs
+  // validation without changing the document revision, so a deferred (stale
+  // but revision-matching) "valid" snapshot could publish before live errors
+  // catch up. Identity-coherent deferral cannot help there: the observable
+  // identity is stable while the pane is mounted; only the value lags.
+  // Proof: hooks/__tests__/useValidationStatus.test.tsx.
+  return useSyncObservable(observable, INITIAL)
 }

--- a/packages/sanity/src/core/hooks/useVersionRelease.ts
+++ b/packages/sanity/src/core/hooks/useVersionRelease.ts
@@ -1,4 +1,4 @@
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {type Observable} from 'rxjs'
 
 import {type TargetPerspective} from '../perspective/types'
@@ -21,7 +21,7 @@ type Result = Pick<ReleasesReducerState, 'error' | 'state'> & {
 export function useVersionRelease(documentId: string | undefined): Result {
   const {state$: readReleasesState} = useReleasesStore()
 
-  const releasesState = useObservable<Observable<ReleasesReducerState>>(readReleasesState, {
+  const releasesState = useSyncObservable<Observable<ReleasesReducerState>>(readReleasesState, {
     releases: new Map(),
     state: 'initialising',
   })

--- a/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
+++ b/packages/sanity/src/core/perspective/PerspectiveProvider.tsx
@@ -3,13 +3,12 @@ import {PerspectiveContext} from 'sanity/_singletons'
 
 import {getReleasesPerspectiveStack} from '../releases/hooks/utils'
 import {useActiveReleases} from '../releases/store/useActiveReleases'
-import {getReleaseIdFromReleaseDocumentId} from '../releases/util/getReleaseIdFromReleaseDocumentId'
 import {useWorkspace} from '../studio/workspace'
-import {isSystemBundleName} from '../util/draftUtils'
 import {EMPTY_ARRAY} from '../util/empty'
 import {getBundleIdFromPerspective} from '../variants/documents/getBundleIdFromPerspective'
 import {useAllVariants} from '../variants/store/useAllVariants'
 import {getSelectedPerspective} from './getSelectedPerspective'
+import {getSelectedReleaseId} from './getSelectedReleaseId'
 import {getSelectedVariant} from './getSelectedVariant'
 import {type PerspectiveContextValue, type ReleaseId} from './types'
 
@@ -62,11 +61,7 @@ export function PerspectiveProvider({
     return {
       selectedPerspective,
       selectedPerspectiveName,
-      selectedReleaseId: isSystemBundleName(selectedPerspectiveName)
-        ? undefined
-        : releases
-            .map((release) => getReleaseIdFromReleaseDocumentId(release._id))
-            .find((releaseName) => releaseName === selectedPerspectiveName),
+      selectedReleaseId: getSelectedReleaseId(selectedPerspectiveName, releases),
       perspectiveStack,
       excludedPerspectives,
       selectedVariantName,

--- a/packages/sanity/src/core/perspective/ReleasesToolLink.tsx
+++ b/packages/sanity/src/core/perspective/ReleasesToolLink.tsx
@@ -1,7 +1,6 @@
 // oxlint-disable-next-line no-restricted-imports -- Bundle Button requires more fine-grained styling than studio button
 import {Button} from '@sanity/ui'
 import {useCallback} from 'react'
-import {useObservable} from 'react-rx'
 import {useRouterState} from 'sanity/router'
 import {styled} from 'styled-components'
 
@@ -11,6 +10,7 @@ import {ReleaseAvatarIcon} from '../releases/components/ReleaseAvatar'
 import {useReleasesStore} from '../releases/store/useReleasesStore'
 import {SCHEDULES_TOOL_NAME} from '../schedules/plugin'
 import {ToolLink} from '../studio/components/navbar/tools/ToolLink'
+import {useDeferredObservableValue} from '../util/useDeferredObservableValue'
 import {oversizedButtonStyle} from './styles'
 import {usePerspective} from './usePerspective'
 
@@ -32,7 +32,7 @@ const OversizedButton = styled(ToolLink)`
 export function ReleasesToolLink(): React.JSX.Element {
   const {t} = useTranslation()
   const {errorCount$} = useReleasesStore()
-  const errorCount = useObservable(errorCount$)
+  const errorCount = useDeferredObservableValue(errorCount$)
   const hasError = errorCount !== 0
   const {selectedPerspective} = usePerspective()
   const activeToolName = useRouterState(

--- a/packages/sanity/src/core/perspective/__tests__/deferralSafety.test.tsx
+++ b/packages/sanity/src/core/perspective/__tests__/deferralSafety.test.tsx
@@ -1,0 +1,326 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {act, render} from '@testing-library/react'
+import {useMemo} from 'react'
+import {useObservable as useSyncObservable} from 'react-rx'
+import {BehaviorSubject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../test/testUtils/TestProvider'
+import {activeASAPRelease} from '../../releases/__fixtures__/release.fixture'
+import {sortReleases} from '../../releases/hooks/utils'
+import {useActiveReleases} from '../../releases/store/useActiveReleases'
+import {useAllReleases} from '../../releases/store/useAllReleases'
+import {useReleasesStore} from '../../releases/store/useReleasesStore'
+import {ARCHIVED_RELEASE_STATES} from '../../releases/util/const'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
+import {variantAlphaAudience} from '../../variants/__fixtures__/variants.fixture'
+import {type VariantStoreState} from '../../variants/store/reducer'
+import {useVariantsStore} from '../../variants/store/useVariantsStore'
+import {getSelectedReleaseId} from '../getSelectedReleaseId'
+import {getSelectedVariant} from '../getSelectedVariant'
+import {PerspectiveProvider} from '../PerspectiveProvider'
+import {type ReleaseId} from '../types'
+import {usePerspective} from '../usePerspective'
+
+/**
+ * Executable answer to the review follow-up on this PR:
+ *
+ * > "I'm not sure about the `useAllReleases`, `useActiveReleases` and
+ * > `useAllVariants` hooks.. we can defer those, but it's ok to keep them
+ * > sync now. We can have a follow up to verify that"
+ *
+ * Verdict, as proof: it is NOT safe to defer them — not even through the
+ * identity-coherent `useDeferredObservableValue` helper. Their store
+ * observables have a stable identity for the lifetime of the workspace, so
+ * the helper's identity fallback never engages; deferral simply makes the
+ * list lag one render behind urgent updates. The lists are paired with LIVE
+ * selection state (the router-driven perspective / variant params feeding
+ * `PerspectiveProvider`) and with each other, so that one-render lag is a
+ * tear with real consequences:
+ *
+ * - `selectedReleaseId` resolves `undefined` under a just-selected release
+ *   name (callers like reference create-in-place treat that as "no release").
+ * - `selectedVariant` resolves `undefined` under a just-selected variant name
+ *   (target-document scoping would bind to the wrong variant).
+ * - a deferred `useAllReleases` disagrees with the synchronous
+ *   `useActiveReleases` about the same store snapshot, producing the
+ *   impossible state "active release missing from all releases".
+ *
+ * Each deferred counterfactual below is the exact hook body with only the
+ * read made deferred, so these tests double as regression proofs: if the
+ * hooks are ever deferred, the paired sync tests here spell out precisely
+ * which coherent frames consumers rely on.
+ *
+ * The selection values are read synchronously from their own subjects (like
+ * the live router state they model), so a single `act` batches "the store
+ * learned about the release/variant" and "the user selected it" into one
+ * update — the create-then-navigate flow.
+ */
+
+interface MockReleasesState {
+  releases: Map<string, ReleaseDocument>
+  error?: Error
+  state: 'initialising' | 'loading' | 'loaded' | 'error'
+}
+
+const releasesState$ = new BehaviorSubject<MockReleasesState>({
+  releases: new Map(),
+  state: 'initialising',
+})
+const variantsState$ = new BehaviorSubject<VariantStoreState>({
+  variants: new Map(),
+  state: 'initialising',
+})
+
+// Live selection state, standing in for the router-driven perspective /
+// variant params. Read synchronously, never deferred — like the real thing.
+const selectedReleaseName$ = new BehaviorSubject<ReleaseId | undefined>(undefined)
+const selectedVariantName$ = new BehaviorSubject<string | undefined>(undefined)
+
+vi.mock('../../releases/store/useReleasesStore', () => ({
+  useReleasesStore: () => ({state$: releasesState$, dispatch: vi.fn()}),
+}))
+vi.mock('../../variants/store/useVariantsStore', () => ({
+  useVariantsStore: () => ({state$: variantsState$, dispatch: vi.fn()}),
+}))
+
+const RELEASE_NAME = 'rASAP' as ReleaseId
+const VARIANT_NAME = 'alpha-audience'
+
+const releasesLoaded: MockReleasesState = {
+  releases: new Map([[activeASAPRelease._id, activeASAPRelease]]),
+  state: 'loaded',
+}
+const variantsLoaded: VariantStoreState = {
+  variants: new Map([[variantAlphaAudience._id, variantAlphaAudience]]),
+  state: 'loaded',
+}
+
+// Per-render frames recorded by the probes below. Assertions use
+// contains/not-contains (not exact sequences) so they stay robust to extra
+// renders.
+const releaseFrames: {name: string | undefined; releaseId: string | undefined}[] = []
+const variantFrames: {name: string | undefined; variantId: string | undefined}[] = []
+const crossFrames: {active: string[]; all: string[]}[] = []
+
+function ReleaseIdProbe() {
+  const {selectedPerspectiveName, selectedReleaseId} = usePerspective()
+  releaseFrames.push({name: selectedPerspectiveName, releaseId: selectedReleaseId})
+  return null
+}
+
+/** The real provider fed by the live selection, as wired in the studio. */
+function SyncReleaseHarness() {
+  const name = useSyncObservable(selectedReleaseName$)
+  return (
+    <PerspectiveProvider selectedPerspectiveName={name} excludedPerspectives={[]}>
+      <ReleaseIdProbe />
+    </PerspectiveProvider>
+  )
+}
+
+function VariantProbe() {
+  const {selectedVariantName, selectedVariant} = usePerspective()
+  variantFrames.push({name: selectedVariantName, variantId: selectedVariant?._id})
+  return null
+}
+
+function SyncVariantHarness() {
+  const name = useSyncObservable(selectedVariantName$)
+  return (
+    <PerspectiveProvider
+      selectedPerspectiveName={undefined}
+      selectedVariantName={name}
+      excludedPerspectives={[]}
+    >
+      <VariantProbe />
+    </PerspectiveProvider>
+  )
+}
+
+/**
+ * `useActiveReleases` body with only the read deferred — what the hook would
+ * become if it adopted `useDeferredObservableValue` — paired with the same
+ * live selection and `getSelectedReleaseId` derivation the provider uses.
+ */
+function DeferredActiveReleasesCounterfactual() {
+  const name = useSyncObservable(selectedReleaseName$)
+  const {state$} = useReleasesStore()
+  const state = useDeferredObservableValue(state$)!
+  const data = useMemo(
+    () =>
+      sortReleases(
+        Array.from(state.releases.values()).filter(
+          (release) => !ARCHIVED_RELEASE_STATES.includes(release.state),
+        ),
+      ).reverse(),
+    [state.releases],
+  )
+  releaseFrames.push({name, releaseId: getSelectedReleaseId(name, data)})
+  return null
+}
+
+/**
+ * `useAllVariants` body with only the read deferred, paired with the same
+ * `getSelectedVariant` derivation `PerspectiveProvider` uses.
+ */
+function DeferredAllVariantsCounterfactual() {
+  const name = useSyncObservable(selectedVariantName$)
+  const {state$} = useVariantsStore()
+  const {variants} = useDeferredObservableValue(state$)!
+  variantFrames.push({
+    name,
+    variantId: getSelectedVariant({selectedVariantName: name, variantsById: variants})?._id,
+  })
+  return null
+}
+
+/**
+ * The real synchronous `useActiveReleases` next to what `useAllReleases`
+ * would return if deferred. Both read the same store observable.
+ */
+function MixedSyncDeferredReleasesProbe() {
+  const {data: active} = useActiveReleases()
+  const {state$} = useReleasesStore()
+  const deferredState = useDeferredObservableValue(state$)!
+  const all = useMemo(
+    () => sortReleases(Array.from(deferredState.releases.values())),
+    [deferredState.releases],
+  )
+  crossFrames.push({
+    active: active.map((release) => release._id),
+    all: all.map((release) => release._id),
+  })
+  return null
+}
+
+/** Control: both real (synchronous) hooks over the same store. */
+function SyncReleasesProbe() {
+  const {data: active} = useActiveReleases()
+  const {data: all} = useAllReleases()
+  crossFrames.push({
+    active: active.map((release) => release._id),
+    all: all.map((release) => release._id),
+  })
+  return null
+}
+
+beforeEach(() => {
+  releasesState$.next({releases: new Map(), state: 'initialising'})
+  variantsState$.next({variants: new Map(), state: 'initialising'})
+  selectedReleaseName$.next(undefined)
+  selectedVariantName$.next(undefined)
+  releaseFrames.length = 0
+  variantFrames.length = 0
+  crossFrames.length = 0
+})
+
+describe('deferral safety of useActiveReleases / useAllVariants / useAllReleases', () => {
+  describe('release identity (PerspectiveProvider pairs the list with the live perspective name)', () => {
+    it('sync (current): no frame pairs a selected release name with an unresolved release id', async () => {
+      const wrapper = await createTestProvider()
+      render(<SyncReleaseHarness />, {wrapper})
+
+      // Model "create release, then navigate to it in the same handler": the
+      // store emits the new release and the selection updates in one batch.
+      act(() => {
+        releasesState$.next(releasesLoaded)
+        selectedReleaseName$.next(RELEASE_NAME)
+      })
+
+      expect(releaseFrames).toContainEqual({name: RELEASE_NAME, releaseId: RELEASE_NAME})
+      // The frame a deferred list would produce must never be committed.
+      expect(releaseFrames).not.toContainEqual({name: RELEASE_NAME, releaseId: undefined})
+    })
+
+    it('deferred (counterfactual): the selected release renders as unresolved for a frame', () => {
+      render(<DeferredActiveReleasesCounterfactual />)
+
+      act(() => {
+        releasesState$.next(releasesLoaded)
+        selectedReleaseName$.next(RELEASE_NAME)
+      })
+
+      // The tear: the new perspective name paired with the stale (empty)
+      // deferred list — this is the frame the sync test proves never happens.
+      expect(releaseFrames).toContainEqual({name: RELEASE_NAME, releaseId: undefined})
+      // It converges afterwards, but consumers have already observed the
+      // torn frame (e.g. reference create-in-place reading "no release").
+      expect(releaseFrames[releaseFrames.length - 1]).toEqual({
+        name: RELEASE_NAME,
+        releaseId: RELEASE_NAME,
+      })
+    })
+  })
+
+  describe('variant identity (PerspectiveProvider pairs the map with the live variant name)', () => {
+    it('sync (current): no frame pairs a selected variant name with an unresolved variant', async () => {
+      const wrapper = await createTestProvider()
+      render(<SyncVariantHarness />, {wrapper})
+
+      act(() => {
+        variantsState$.next(variantsLoaded)
+        selectedVariantName$.next(VARIANT_NAME)
+      })
+
+      expect(variantFrames).toContainEqual({
+        name: VARIANT_NAME,
+        variantId: variantAlphaAudience._id,
+      })
+      expect(variantFrames).not.toContainEqual({name: VARIANT_NAME, variantId: undefined})
+    })
+
+    it('deferred (counterfactual): the selected variant renders as unresolved for a frame', () => {
+      render(<DeferredAllVariantsCounterfactual />)
+
+      act(() => {
+        variantsState$.next(variantsLoaded)
+        selectedVariantName$.next(VARIANT_NAME)
+      })
+
+      expect(variantFrames).toContainEqual({name: VARIANT_NAME, variantId: undefined})
+      expect(variantFrames[variantFrames.length - 1]).toEqual({
+        name: VARIANT_NAME,
+        variantId: variantAlphaAudience._id,
+      })
+    })
+  })
+
+  describe('cross-hook coherence (useActiveReleases and useAllReleases read the same store)', () => {
+    it('sync (current): active releases are always a subset of all releases', () => {
+      render(<SyncReleasesProbe />)
+
+      act(() => {
+        releasesState$.next(releasesLoaded)
+      })
+
+      for (const frame of crossFrames) {
+        for (const id of frame.active) {
+          expect(frame.all).toContain(id)
+        }
+      }
+      expect(crossFrames[crossFrames.length - 1]).toEqual({
+        active: [activeASAPRelease._id],
+        all: [activeASAPRelease._id],
+      })
+    })
+
+    it('deferring only useAllReleases (counterfactual) commits the impossible state "active release missing from all releases"', () => {
+      render(<MixedSyncDeferredReleasesProbe />)
+
+      act(() => {
+        releasesState$.next(releasesLoaded)
+      })
+
+      // The tear: the sync hook already contains the release while the
+      // deferred read of the very same store snapshot does not. Consumers
+      // pairing the two lists (e.g. document actions gating on membership)
+      // cannot defend against this frame.
+      expect(crossFrames).toContainEqual({active: [activeASAPRelease._id], all: []})
+      expect(crossFrames[crossFrames.length - 1]).toEqual({
+        active: [activeASAPRelease._id],
+        all: [activeASAPRelease._id],
+      })
+    })
+  })
+})

--- a/packages/sanity/src/core/perspective/__tests__/getSelectedReleaseId.test.ts
+++ b/packages/sanity/src/core/perspective/__tests__/getSelectedReleaseId.test.ts
@@ -1,0 +1,38 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {describe, expect, it} from 'vitest'
+
+import {getSelectedReleaseId} from '../getSelectedReleaseId'
+
+const release = (id: string): ReleaseDocument =>
+  ({
+    _id: `_.releases.${id}`,
+    _type: 'system.release',
+  }) as unknown as ReleaseDocument
+
+/**
+ * Documents why `useActiveReleases` must stay synchronous rather than be
+ * deferred: `PerspectiveProvider` resolves `selectedReleaseId` by pairing the
+ * live `selectedPerspectiveName` with the `releases` list. A deferred read
+ * would let the list lag behind the selected name, and these tests show that a
+ * lagging list resolves the release identity to `undefined` — the state that
+ * makes reference create-in-place write a weak ref / open the wrong version.
+ */
+describe('getSelectedReleaseId', () => {
+  it('resolves the release id when the releases list contains the selected release', () => {
+    // Coherent (synchronous) list: the selected release is present.
+    expect(getSelectedReleaseId('rABC' as never, [release('rABC'), release('rDEF')])).toBe('rABC')
+  })
+
+  it('returns undefined when the releases list lags behind the selected release (the deferral tear)', () => {
+    // A deferred `useActiveReleases` would produce exactly this: the user has
+    // selected release `rABC`, but the list hasn't caught up yet. The identity
+    // resolves to undefined, which is the create-in-place `_weak` tear.
+    expect(getSelectedReleaseId('rABC' as never, [])).toBeUndefined()
+    expect(getSelectedReleaseId('rABC' as never, [release('rDEF')])).toBeUndefined()
+  })
+
+  it('returns undefined for system perspectives (drafts/published)', () => {
+    expect(getSelectedReleaseId(undefined, [release('rABC')])).toBeUndefined()
+    expect(getSelectedReleaseId('published', [release('rABC')])).toBeUndefined()
+  })
+})

--- a/packages/sanity/src/core/perspective/__tests__/getSelectedVariant.test.ts
+++ b/packages/sanity/src/core/perspective/__tests__/getSelectedVariant.test.ts
@@ -39,4 +39,25 @@ describe('getSelectedVariant', () => {
       }),
     ).toBeUndefined()
   })
+
+  // Documents why `useAllVariants` must stay synchronous rather than be
+  // deferred: `getSelectedVariant` pairs the live `selectedVariantName` with
+  // the `variantsById` map. A deferred read would let the map lag behind the
+  // selected name — resolving the variant identity to `undefined` even for a
+  // valid selection until the deferred value catches up.
+  it('resolves only when byId is coherent with the selected name (deferral would tear this)', () => {
+    // Lagging map (what a deferred useAllVariants yields right after selecting
+    // the variant): identity is undefined.
+    expect(
+      getSelectedVariant({selectedVariantName: 'alpha-audience', variantsById: new Map()}),
+    ).toBeUndefined()
+
+    // Coherent (synchronous) map: identity resolves.
+    expect(
+      getSelectedVariant({
+        selectedVariantName: 'alpha-audience',
+        variantsById: new Map([[variantAlphaAudience._id, variantAlphaAudience]]),
+      }),
+    ).toBe(variantAlphaAudience)
+  })
 })

--- a/packages/sanity/src/core/perspective/getSelectedReleaseId.ts
+++ b/packages/sanity/src/core/perspective/getSelectedReleaseId.ts
@@ -1,0 +1,29 @@
+import {type ReleaseDocument} from '@sanity/client'
+
+import {getReleaseIdFromReleaseDocumentId} from '../releases/util/getReleaseIdFromReleaseDocumentId'
+import {isSystemBundleName} from '../util/draftUtils'
+import {type ReleaseId} from './types'
+
+/**
+ * Resolve the currently selected release id by looking up the live
+ * `selectedPerspectiveName` in the active `releases` list.
+ *
+ * The lookup pairs a list value with the live perspective name, so `releases`
+ * must be coherent with `selectedPerspectiveName`: if the list lags behind the
+ * selection (e.g. right after a release is created, or if the read were
+ * deferred) this returns `undefined` for a release perspective, which callers
+ * like reference create-in-place treat as "no release" — writing a weak ref /
+ * opening the wrong version. That's why `useActiveReleases` must stay
+ * synchronous.
+ *
+ * @internal
+ */
+export function getSelectedReleaseId(
+  selectedPerspectiveName: 'published' | ReleaseId | undefined,
+  releases: ReleaseDocument[],
+): ReleaseId | undefined {
+  if (isSystemBundleName(selectedPerspectiveName)) return undefined
+  return releases
+    .map((release) => getReleaseIdFromReleaseDocumentId(release._id))
+    .find((releaseName) => releaseName === selectedPerspectiveName) as ReleaseId | undefined
+}

--- a/packages/sanity/src/core/preview/useObserveDocument.ts
+++ b/packages/sanity/src/core/preview/useObserveDocument.ts
@@ -1,6 +1,6 @@
 import {type SanityDocument} from '@sanity/types'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {map} from 'rxjs/operators'
 
 import {useDocumentPreviewStore} from '../store/datastores'
@@ -30,7 +30,10 @@ export function useUnstableObserveDocument<T extends SanityDocument>(
         .pipe(map((document) => ({loading: false, document: document as T}))),
     [documentId, documentPreviewStore, apiConfig],
   )
-  return useObservable(observable, INITIAL_STATE)
+  // Kept synchronous: the observable is keyed to the live `documentId`, so a
+  // deferred snapshot could briefly hand callers the previous document with
+  // `loading: false` under the new id.
+  return useSyncObservable(observable, INITIAL_STATE)
 }
 
 /**

--- a/packages/sanity/src/core/preview/useValuePreview.ts
+++ b/packages/sanity/src/core/preview/useValuePreview.ts
@@ -5,7 +5,7 @@ import {
   type SortOrdering,
 } from '@sanity/types'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {type Observable, of} from 'rxjs'
 import {catchError, map} from 'rxjs/operators'
 
@@ -100,5 +100,6 @@ export function useValuePreview(props: {
     ordering,
   ])
 
-  return useObservable(observable, INITIAL_STATE)
+  // Do not defer: search/reference UIs assert on preview titles synchronously after selection.
+  return useSyncObservable(observable, INITIAL_STATE)
 }

--- a/packages/sanity/src/core/preview/useVisibility.ts
+++ b/packages/sanity/src/core/preview/useVisibility.ts
@@ -1,8 +1,8 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {concat, of} from 'rxjs'
 import {delay, distinctUntilChanged, map, startWith, switchMap} from 'rxjs/operators'
 
+import {useDeferredObservableValue} from '../util/useDeferredObservableValue'
 import {intersectionObservableFor} from './streams/intersectionObservableFor'
 import {visibilityChange$} from './streams/visibilityChange'
 
@@ -27,7 +27,7 @@ export function useVisibility(props: Props): boolean {
 
     // Seed with the element's current visibility so the first paint is
     // correct — every code path here emits synchronously on subscribe, so
-    // useObservable's fallback initial value is never read.
+    // useSyncObservable's fallback initial value is never read.
     const seed = 'checkVisibility' in element ? element.checkVisibility() : false
 
     const isDocumentVisible$ = concat(
@@ -49,7 +49,7 @@ export function useVisibility(props: Props): boolean {
     )
   }, [element, hideDelay, disabled])
 
-  const visible = useObservable(visible$, false)
+  const visible = useDeferredObservableValue(visible$, false)
 
   return disabled ? false : visible
 }

--- a/packages/sanity/src/core/releases/components/CreateReleaseMenuItem.tsx
+++ b/packages/sanity/src/core/releases/components/CreateReleaseMenuItem.tsx
@@ -1,11 +1,11 @@
 import {AddIcon} from '@sanity/icons/Add'
 import {type ComponentProps, type ComponentType, useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {from} from 'rxjs'
 
 import {MenuItem} from '../../../ui-components/menuItem/MenuItem'
 import {useTranslation} from '../../i18n/hooks/useTranslation'
 import {useWorkspace} from '../../studio/workspace'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {useCreateReleaseMetadata} from '../hooks/useCreateReleaseMetadata'
 import {useActiveReleases} from '../store/useActiveReleases'
 import {useReleaseOperations} from '../store/useReleaseOperations'
@@ -22,7 +22,7 @@ export const CreateReleaseMenuItem: ComponentType<Props> = ({onCreateRelease}) =
   const {checkWithPermissionGuard} = useReleasePermissions()
   const createReleaseMetadata = useCreateReleaseMetadata()
 
-  const hasCreatePermission = useObservable(
+  const hasCreatePermission = useDeferredObservableValue(
     useMemo(
       () =>
         from(checkWithPermissionGuard(createRelease, createReleaseMetadata(getReleaseDefaults()))),

--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -4,13 +4,13 @@ import {LockIcon} from '@sanity/icons/Lock'
 import {UnlockIcon} from '@sanity/icons/Unlock'
 import {type BadgeTone} from '@sanity/ui'
 import {memo, type ReactNode, useEffect, useMemo, useRef} from 'react'
-import {useObservable} from 'react-rx'
 
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
 import {useCanvasCompanionDocsStore} from '../../../canvas/store/useCanvasCompanionDocsStore'
 import {useReleasesToolAvailable} from '../../../schedules/hooks/useReleasesToolAvailable'
 import {getDraftId, getPublishedId, getVersionId} from '../../../util/draftUtils'
 import {isPausedCardinalityOneRelease} from '../../../util/releaseUtils'
+import {useDeferredObservableValue} from '../../../util/useDeferredObservableValue'
 import {useVersionContextMenu} from '../../hooks/useVersionContextMenu'
 import {Chip} from '../Chip'
 import {ReleaseAvatarIcon} from '../ReleaseAvatar'
@@ -29,7 +29,12 @@ const useVersionIsLinked = (documentId: string, fromRelease: string) => {
     () => companionDocsStore.getCompanionDocs(documentId),
     [documentId, companionDocsStore],
   )
-  const companionDocs = useObservable(companionDocs$)
+  // Deferred (per review): navigating to another document remounts the
+  // document pane (its `_key` changes), resetting this state, so a deferred
+  // read can't report linkage for a previous document. The identity-coherent
+  // deferral also falls back to the live value if the observable identity
+  // changes without a remount.
+  const companionDocs = useDeferredObservableValue(companionDocs$)
   return companionDocs?.data.some((companion) => companion?.studioDocumentId === versionId)
 }
 

--- a/packages/sanity/src/core/releases/contexts/ReleasesMetadataProvider.tsx
+++ b/packages/sanity/src/core/releases/contexts/ReleasesMetadataProvider.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useContext, useEffect, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
 import {ReleasesMetadataContext} from 'sanity/_singletons'
 
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {type MetadataWrapper} from '../store/createReleaseMetadataAggregator'
 import {type ReleasesMetadata} from '../store/useReleasesMetadata'
 import {useReleasesStore} from '../store/useReleasesStore'
@@ -33,7 +33,7 @@ const ReleasesMetadataProviderInner = ({children}: {children: React.ReactNode}) 
     [getMetadataStateForSlugs$, listenerReleaseIds],
   )
 
-  const observedResult = useObservable(memoObservable) || DEFAULT_METADATA_STATE
+  const observedResult = useDeferredObservableValue(memoObservable) || DEFAULT_METADATA_STATE
 
   // patch metadata in local state
   useEffect(

--- a/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
+++ b/packages/sanity/src/core/releases/hooks/useDocumentVersions.tsx
@@ -2,7 +2,7 @@ import {type ReleaseDocument} from '@sanity/client'
 import {getVersionFromId} from '@sanity/client/csm'
 import {type DocumentSystem} from '@sanity/types'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {
   catchError,
   combineLatest,
@@ -75,7 +75,11 @@ const TEARDOWN_GRACE_PERIOD = 1_000
  */
 export function useDocumentVersions(props: DocumentPerspectiveProps): DocumentPerspectiveState {
   const observable = useDocumentVersionsObservable(props)
-  return useObservable(observable, INITIAL_VALUE)
+  // Kept synchronous: `useTargetDocumentState` / `useDocumentForm` derive the
+  // pair-checkout scope and the form's ready gate from this state, so a
+  // deferred snapshot could bind the form to the wrong version scope after
+  // navigation or a version change.
+  return useSyncObservable(observable, INITIAL_VALUE)
 }
 
 /**

--- a/packages/sanity/src/core/releases/store/useActiveReleases.ts
+++ b/packages/sanity/src/core/releases/store/useActiveReleases.ts
@@ -1,6 +1,6 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 
 import {sortReleases} from '../hooks/utils'
 import {ARCHIVED_RELEASE_STATES} from '../util/const'
@@ -23,7 +23,12 @@ interface ReleasesState {
  */
 export function useActiveReleases(): ReleasesState {
   const {state$, dispatch} = useReleasesStore()
-  const state = useObservable(state$)!
+  // Kept synchronous: PerspectiveProvider derives `selectedReleaseId` from
+  // this list while `selectedPerspectiveName` stays live, so a deferred
+  // snapshot could tear the release identity (e.g. reference create-in-place
+  // writing `_weak` or opening the wrong version). Executable proof:
+  // perspective/__tests__/deferralSafety.test.tsx.
+  const state = useSyncObservable(state$)!
   const releasesAsArray = useMemo(
     () =>
       sortReleases(

--- a/packages/sanity/src/core/releases/store/useAllReleases.ts
+++ b/packages/sanity/src/core/releases/store/useAllReleases.ts
@@ -1,6 +1,6 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 
 import {sortReleases} from '../hooks/utils'
 import {useReleasesStore} from './useReleasesStore'
@@ -16,7 +16,12 @@ export function useAllReleases(): {
   map: Map<string, ReleaseDocument>
 } {
   const {state$} = useReleasesStore()
-  const {releases, error, state} = useObservable(state$)!
+  // Kept synchronous: release lists feed perspective/version identity
+  // resolution alongside live perspective state, so a deferred snapshot could
+  // pair a stale release list with the current selection — or disagree with
+  // the synchronous `useActiveReleases` read of the same store. Executable
+  // proof: perspective/__tests__/deferralSafety.test.tsx.
+  const {releases, error, state} = useSyncObservable(state$)!
 
   return useMemo(
     () => ({

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/useDocumentRevertStates.ts
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/useDocumentRevertStates.ts
@@ -1,6 +1,6 @@
 import {type SanityDocument} from '@sanity/types'
 import {useCallback, useEffect, useMemo, useRef} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {catchError, forkJoin, from, map, type Observable, of, switchMap} from 'rxjs'
 
 import {useClient} from '../../../../../hooks/useClient'
@@ -111,7 +111,10 @@ export const useDocumentRevertStates = (releaseDocuments: DocumentInRelease[]) =
     return documentRevertStates$
   }, [client, releaseDocuments, transactionId, observableClient, dataset])
 
-  const documentRevertStatesResult = useObservable(memoDocumentRevertStates, null)
+  // Kept synchronous: the effect below resolves an imperative promise/ref with
+  // this value for the revert action, so a deferred snapshot could delay the
+  // resolution or hand the action a stale revert state.
+  const documentRevertStatesResult = useSyncObservable(memoDocumentRevertStates, null)
 
   useEffect(() => {
     if (documentRevertStatesResult !== null) {

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/usePostPublishTransactions.ts
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseRevertButton/usePostPublishTransactions.ts
@@ -1,10 +1,10 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {catchError, from, map, of} from 'rxjs'
 
 import {useClient} from '../../../../../hooks/useClient'
 import {getTransactionsLogs} from '../../../../../store/translog/getTransactionsLogs'
 import {getPublishedId} from '../../../../../util/draftUtils'
+import {useDeferredObservableValue} from '../../../../../util/useDeferredObservableValue'
 import {RELEASES_STUDIO_CLIENT_OPTIONS} from '../../../../util/releasesClient'
 import {type DocumentInRelease} from '../../../detail/types'
 
@@ -33,5 +33,5 @@ export const usePostPublishTransactions = (documents: DocumentInRelease[]) => {
     )
   }, [client, documents, transactionId])
 
-  return useObservable(memoHasPostPublishTransactions, null)
+  return useDeferredObservableValue(memoHasPostPublishTransactions, null)
 }

--- a/packages/sanity/src/core/releases/tool/detail/events/useReleaseEvents.ts
+++ b/packages/sanity/src/core/releases/tool/detail/events/useReleaseEvents.ts
@@ -1,9 +1,9 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 
 import {useClient} from '../../../../hooks/useClient'
 import {useDocumentPreviewStore} from '../../../../store/datastores'
 import {useSource} from '../../../../studio/source'
+import {useDeferredObservableValue} from '../../../../util/useDeferredObservableValue'
 import {useReleasesStore} from '../../../store/useReleasesStore'
 import {getReleaseDocumentIdFromReleaseId} from '../../../util/getReleaseDocumentIdFromReleaseId'
 import {RELEASES_STUDIO_CLIENT_OPTIONS} from '../../../util/releasesClient'
@@ -37,7 +37,7 @@ export function useReleaseEvents(releaseId: string): ReleaseEvents {
       }),
     [releaseId, client, releasesState$, documentPreviewStore, eventsAPIEnabled],
   )
-  const events = useObservable(releaseEvents.events$, EVENTS_INITIAL_VALUE)
+  const events = useDeferredObservableValue(releaseEvents.events$, EVENTS_INITIAL_VALUE)
 
   return {
     events: events.events,

--- a/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useBundleDocuments.ts
@@ -6,7 +6,6 @@ import {
 } from '@sanity/types'
 import {uuid} from '@sanity/uuid'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {combineLatest, from, type Observable, of} from 'rxjs'
 import {mergeMapArray} from 'rxjs-mergemap-array'
 import {catchError, delay, filter, finalize, map, shareReplay, switchMap} from 'rxjs/operators'
@@ -17,6 +16,7 @@ import {type DocumentPreviewStore} from '../../../preview/documentPreviewStore'
 import {useDocumentPreviewStore} from '../../../store/datastores'
 import {useSource} from '../../../studio/source'
 import {schedulerYield} from '../../../util/schedulerYield'
+import {useDeferredObservableValue} from '../../../util/useDeferredObservableValue'
 import {validateDocumentWithReferences, type ValidationStatus} from '../../../validation'
 import {RELEASES_STUDIO_CLIENT_OPTIONS} from '../../util/releasesClient'
 
@@ -296,7 +296,7 @@ export function useBundleDocuments(options: {
     ],
   )
 
-  return useObservable(
+  return useDeferredObservableValue(
     bundleDocumentsObservable,
     enabled ? BUNDLE_DOCUMENTS_LOADING : BUNDLE_DOCUMENTS_EMPTY,
   )

--- a/packages/sanity/src/core/releases/tool/detail/useReleaseDocuments.ts
+++ b/packages/sanity/src/core/releases/tool/detail/useReleaseDocuments.ts
@@ -1,6 +1,5 @@
 import {type CurrentUser, type Schema} from '@sanity/types'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {distinctUntilChanged, filter, map, shareReplay, startWith, switchMap} from 'rxjs/operators'
 
 import {useSchema} from '../../../hooks/useSchema'
@@ -8,6 +7,7 @@ import {type LocaleSource} from '../../../i18n/types'
 import {type DocumentPreviewStore} from '../../../preview/documentPreviewStore'
 import {useDocumentPreviewStore} from '../../../store/datastores'
 import {useSource} from '../../../studio/source'
+import {useDeferredObservableValue} from '../../../util/useDeferredObservableValue'
 import {useReleasesStore} from '../../store/useReleasesStore'
 import {getReleaseDocumentIdFromReleaseId} from '../../util/getReleaseDocumentIdFromReleaseId'
 import {isGoingToUnpublish} from '../../util/isGoingToUnpublish'
@@ -114,7 +114,7 @@ export function useReleaseDocuments(releaseId: string): {
     [schema, documentPreviewStore, getClient, releaseId, i18n, releasesState$, currentUser],
   )
 
-  return useObservable(releaseDocumentsObservable, {
+  return useDeferredObservableValue(releaseDocumentsObservable, {
     loading: true,
     results: [],
     error: null,

--- a/packages/sanity/src/core/scheduled-publishing/hooks/usePreviewState.ts
+++ b/packages/sanity/src/core/scheduled-publishing/hooks/usePreviewState.ts
@@ -1,9 +1,9 @@
 import {type SchemaType} from '@sanity/types'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {of} from 'rxjs'
 
 import {useDocumentPreviewStore} from '../../store/datastores'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {getPreviewStateObservable, type PaneItemPreviewState} from '../utils/paneItemHelpers'
 
 const EMPTY_STATE: PaneItemPreviewState = {}
@@ -22,5 +22,5 @@ export default function usePreviewState(
     [documentPreviewStore, schemaType, documentId],
   )
 
-  return useObservable(preview$, EMPTY_STATE)
+  return useDeferredObservableValue(preview$, EMPTY_STATE)
 }

--- a/packages/sanity/src/core/scheduledPublishing/tool/contexts/useHasUsedScheduledPublishing.ts
+++ b/packages/sanity/src/core/scheduledPublishing/tool/contexts/useHasUsedScheduledPublishing.ts
@@ -1,11 +1,11 @@
 import {type SanityClient} from '@sanity/client'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {catchError, map, type Observable, of, shareReplay} from 'rxjs'
 
 import {useClient} from '../../../hooks/useClient'
 import {useWorkspace} from '../../../studio/workspace'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../studioClient'
+import {useDeferredObservableValue} from '../../../util/useDeferredObservableValue'
 
 export interface HasUsedScheduledPublishing {
   used: boolean
@@ -60,5 +60,5 @@ export function useHasUsedScheduledPublishing({
     return cachedUsedScheduledPublishing.get(key) || of(HAS_USED_SCHEDULED_PUBLISHING)
   }, [key, explicitEnabled, isWorkspaceEnabled])
 
-  return useObservable(hasUsedScheduledPublishing$, HAS_USED_SCHEDULED_PUBLISHING)
+  return useDeferredObservableValue(hasUsedScheduledPublishing$, HAS_USED_SCHEDULED_PUBLISHING)
 }

--- a/packages/sanity/src/core/store/agent/useAgentBundles.ts
+++ b/packages/sanity/src/core/store/agent/useAgentBundles.ts
@@ -1,8 +1,8 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 
 import {useClient} from '../../hooks/useClient'
 import {useWorkspace} from '../../studio/workspace'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {useProjectStore} from '../datastores'
 import {useResourceCache} from '../ResourceCacheProvider'
 import {
@@ -58,5 +58,5 @@ export function useAgentBundlesStore(): AgentBundlesStore {
  */
 export function useAgentBundles(): AgentBundlesState {
   const {state$} = useAgentBundlesStore()
-  return useObservable(state$, INITIAL_STATE)
+  return useDeferredObservableValue(state$, INITIAL_STATE)
 }

--- a/packages/sanity/src/core/store/authStore/createLoginComponent.tsx
+++ b/packages/sanity/src/core/store/authStore/createLoginComponent.tsx
@@ -4,13 +4,13 @@ import {ArrowLeftIcon} from '@sanity/icons/ArrowLeft'
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
 import {Badge, Box, Card, Flex, Heading, Stack, Text} from '@sanity/ui'
 import {useCallback, useEffect, useState} from 'react'
-import {useObservable} from 'react-rx'
 import {type Observable} from 'rxjs'
 
 import {Button, type ButtonProps} from '../../../ui-components/button/Button'
 import {LoadingBlock} from '../../components/loadingBlock/LoadingBlock'
 import {type AuthConfig} from '../../config/auth/types'
 import {useTranslation} from '../../i18n/hooks/useTranslation'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {CustomLogo, providerLogos} from './providerLogos'
 import {type LoginComponentProps} from './types'
 
@@ -122,7 +122,11 @@ export function createLoginComponent({
     const [error, setError] = useState<unknown>(null)
     if (error) throw error
 
-    const client = useObservable(client$)
+    // Deferred (per review): the only way to change workspace mid-login is a
+    // URL change, which triggers a full reload — so `client$` doesn't swap
+    // under a mounted login screen. The identity-coherent deferral also falls
+    // back to the live value if the client ever does change.
+    const client = useDeferredObservableValue(client$)
 
     const getProviderData = useCallback(async () => {
       let providers = [] as AuthProvider[]

--- a/packages/sanity/src/core/store/datastores.ts
+++ b/packages/sanity/src/core/store/datastores.ts
@@ -2,7 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {useToast} from '@sanity/ui'
 import {useCallback, useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 
 import {useClient} from '../hooks/useClient'
 import {useSchema} from '../hooks/useSchema'
@@ -446,7 +446,11 @@ export function useRenderingContextStore(): RenderingContextStore {
 export function useComlinkStore(): ComlinkStore {
   const resourceCache = useResourceCache()
   const renderingContext = useRenderingContextStore()
-  const capabilities = useObservable(renderingContext.capabilities, {})
+  // Kept synchronous: `createComlinkStore` starts the comlink node when
+  // `capabilities.comlink` flips true, so a deferred snapshot would delay
+  // comlink initialization. Capabilities emit once at boot; there is nothing
+  // to gain from deferring them.
+  const capabilities = useSyncObservable(renderingContext.capabilities, {})
 
   return useMemo(() => {
     const comlinkStore =

--- a/packages/sanity/src/core/store/document/hooks/useDocumentType.ts
+++ b/packages/sanity/src/core/store/document/hooks/useDocumentType.ts
@@ -1,5 +1,5 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {of} from 'rxjs'
 import {map, startWith} from 'rxjs/operators'
 
@@ -43,7 +43,11 @@ export function useDocumentType(documentId: string, specifiedType = '*'): Docume
     [documentStore, isResolved, publishedId, specifiedType, SYNC_RESOLVED_STATE],
   )
 
-  const resolvedState = useObservable(
+  // Kept synchronous: the lookup is keyed to the live document id, so a
+  // deferred snapshot could report the previous document's type as
+  // `isLoaded: true` during an id transition, mounting the form against the
+  // wrong schema type.
+  const resolvedState = useSyncObservable(
     resolvedState$,
     isResolved ? SYNC_RESOLVED_STATE : LOADING_STATE,
   )

--- a/packages/sanity/src/core/store/document/useInitialValue.ts
+++ b/packages/sanity/src/core/store/document/useInitialValue.ts
@@ -1,7 +1,7 @@
 import {type InitialValueResolverContext, type SanityDocumentLike} from '@sanity/types'
 import {useToast} from '@sanity/ui'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {map, startWith, tap} from 'rxjs/operators'
 
 import {useDataset} from '../../hooks/useDataset'
@@ -126,7 +126,7 @@ export function useInitialValue(props: {
 
   // Seeded with loadingState to match the stream's synchronous
   // startWith(loadingState) first emission.
-  return useObservable(state$, loadingState)
+  return useSyncObservable(state$, loadingState)
 }
 
 /**

--- a/packages/sanity/src/core/store/events/useEventsStore.ts
+++ b/packages/sanity/src/core/store/events/useEventsStore.ts
@@ -1,6 +1,6 @@
 import {type ObjectSchemaType} from '@sanity/types'
 import {useCallback, useEffect, useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {of} from 'rxjs'
 
 import {useClient} from '../../hooks/useClient'
@@ -8,6 +8,7 @@ import {useSchema} from '../../hooks/useSchema'
 import {useReleasesStore} from '../../releases/store/useReleasesStore'
 import {RELEASES_STUDIO_CLIENT_OPTIONS} from '../../releases/util/releasesClient'
 import {getDocumentVariantType} from '../../util/getDocumentVariantType'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {createEventsStore} from './createEventsStore'
 import {getDocumentAtRevision as getDocumentAtRevisionFunction} from './getDocumentAtRevision'
 import {
@@ -65,7 +66,14 @@ export function useEventsStore({
       }),
     [client, documentId, documentType, releases$, isLiveEdit],
   )
-  const {events, loading, error, nextCursor} = useObservable(
+  // Deferred (per review): these events drive the review-changes list, which
+  // users don't expect to update synchronously on every edit. `revisionId` /
+  // `sinceId` and the `revision` / `sinceRevision` documents are all derived
+  // from this deferred value, so they lag together (coherently) rather than
+  // pairing a stale diff with fresh state. Verified against the
+  // `revertArrayChanges` e2e flow, which previously crashed only when the
+  // diff was deferred incoherently while events stayed live.
+  const {events, loading, error, nextCursor} = useDeferredObservableValue(
     eventsStore.eventsObservable$,
     INITIAL_VALUE,
   )
@@ -130,7 +138,7 @@ export function useEventsStore({
     () => (revisionId ? getDocumentAtRevision(revisionId) : of(null)),
     [getDocumentAtRevision, revisionId],
   )
-  const revision = useObservable(revision$, null)
+  const revision = useSyncObservable(revision$, null)
 
   const sinceId = useMemo(() => {
     if (since && since !== '@lastPublished') return since
@@ -169,7 +177,7 @@ export function useEventsStore({
     [eventsStore, revision$, since$],
   )
 
-  const sinceRevision = useObservable(since$, null)
+  const sinceRevision = useSyncObservable(since$, null)
 
   const documentVariantType = getDocumentVariantType(documentId)
   const findRangeForRevision = useCallback(

--- a/packages/sanity/src/core/store/presence/useDocumentPresence.tsx
+++ b/packages/sanity/src/core/store/presence/useDocumentPresence.tsx
@@ -1,7 +1,7 @@
 import {startTransition, useEffect, useMemo, useReducer} from 'react'
-import {useObservable} from 'react-rx'
 import {of} from 'rxjs'
 
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {usePresenceStore} from '../datastores'
 import {type DocumentPresence} from './types'
 
@@ -19,5 +19,5 @@ export function useDocumentPresence(documentId: string): DocumentPresence[] {
     () => (mounted ? presenceStore.documentPresence(documentId) : fallback),
     [mounted, presenceStore, documentId],
   )
-  return useObservable(presence$, initial)
+  return useDeferredObservableValue(presence$, initial)
 }

--- a/packages/sanity/src/core/store/presence/useGlobalPresence.tsx
+++ b/packages/sanity/src/core/store/presence/useGlobalPresence.tsx
@@ -1,7 +1,7 @@
 import {startTransition, useEffect, useReducer} from 'react'
-import {useObservable} from 'react-rx'
 import {of} from 'rxjs'
 
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {usePresenceStore} from '../datastores'
 import {type GlobalPresence} from './types'
 
@@ -15,5 +15,5 @@ export function useGlobalPresence(): GlobalPresence[] {
   useEffect(() => startTransition(mount), [])
 
   const presenceStore = usePresenceStore()
-  return useObservable(mounted ? presenceStore.globalPresence$ : fallback, initial)
+  return useDeferredObservableValue(mounted ? presenceStore.globalPresence$ : fallback, initial)
 }

--- a/packages/sanity/src/core/store/project/useProjectDatasets.ts
+++ b/packages/sanity/src/core/store/project/useProjectDatasets.ts
@@ -1,6 +1,6 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {useProjectStore} from '../datastores'
 import {type ProjectDatasetData} from './types'
 
@@ -9,7 +9,7 @@ export function useProjectDatasets(): {value: ProjectDatasetData[] | null} {
   const projectStore = useProjectStore()
 
   const project$ = useMemo(() => projectStore.getDatasets(), [projectStore])
-  const value = useObservable(project$, null)
+  const value = useDeferredObservableValue(project$, null)
 
   return {value}
 }

--- a/packages/sanity/src/core/store/project/useProjectOrganizationData.ts
+++ b/packages/sanity/src/core/store/project/useProjectOrganizationData.ts
@@ -1,7 +1,7 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {map, startWith} from 'rxjs'
 
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {useProjectStore} from '../datastores'
 import {type ProjectOrganizationData} from './types'
 
@@ -28,5 +28,5 @@ export function useProjectOrganizationData(): {
     [projectStore],
   )
 
-  return useObservable(obs$, INITIAL_STATE)
+  return useDeferredObservableValue(obs$, INITIAL_STATE)
 }

--- a/packages/sanity/src/core/store/project/useProjectOrganizationId.ts
+++ b/packages/sanity/src/core/store/project/useProjectOrganizationId.ts
@@ -1,7 +1,7 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {map, startWith} from 'rxjs'
 
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {useProjectStore} from '../datastores'
 
 const INITIAL_STATE = {value: null, loading: true}
@@ -24,5 +24,5 @@ export function useProjectOrganizationId(): {value: string | null; loading: bool
     [projectStore],
   )
 
-  return useObservable(obs$, INITIAL_STATE)
+  return useDeferredObservableValue(obs$, INITIAL_STATE)
 }

--- a/packages/sanity/src/core/store/renderingContext/useRenderingContext.ts
+++ b/packages/sanity/src/core/store/renderingContext/useRenderingContext.ts
@@ -1,9 +1,11 @@
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 
 import {useRenderingContextStore} from '../datastores'
 
 export function useRenderingContext() {
   const renderingContextStore = useRenderingContextStore()
 
-  return useObservable(renderingContextStore.renderingContext)
+  // Kept synchronous: the rendering context emits once at boot; deferring
+  // only delays consumers reacting to it.
+  return useSyncObservable(renderingContextStore.renderingContext)
 }

--- a/packages/sanity/src/core/studio/AuthBoundary.tsx
+++ b/packages/sanity/src/core/studio/AuthBoundary.tsx
@@ -1,6 +1,6 @@
 import {useTelemetry} from '@sanity/telemetry/react'
 import {type ComponentType, type ReactNode, useEffect, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {catchError, map, of} from 'rxjs'
 
 import {LoadingBlock} from '../components/loadingBlock/LoadingBlock'
@@ -96,7 +96,10 @@ export function AuthBoundary({
     [activeWorkspace],
   )
 
-  const authResult = useObservable(authStatus$, INITIAL_AUTH_RESULT)
+  // Kept synchronous: this gates authenticated children and is compared with
+  // the live `callbackSettled` state — a deferred snapshot could keep children
+  // mounted after logout or pair stale `loggedIn` with fresh settlement state.
+  const authResult = useSyncObservable(authStatus$, INITIAL_AUTH_RESULT)
   if (authResult.type === 'error') throw authResult.error
 
   const {loggedIn, loginProvider} = authResult.status

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrialProvider.tsx
@@ -1,6 +1,6 @@
 import {useTelemetry} from '@sanity/telemetry/react'
 import {type ReactNode, useEffect, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {BehaviorSubject, catchError, distinctUntilChanged, EMPTY, map, switchMap} from 'rxjs'
 import {FreeTrialContext} from 'sanity/_singletons'
 import {useRouter} from 'sanity/router'
@@ -60,7 +60,7 @@ export const FreeTrialProvider = ({children}: FreeTrialProviderProps) => {
 
   // Each response is tagged with the fetch key it answers, so auto-show can
   // tell a kept-while-refetching response from one matching the current params.
-  const trial = useObservable(
+  const trial = useSyncObservable(
     useMemo(
       () =>
         params$.pipe(

--- a/packages/sanity/src/core/studio/components/navbar/resources/useCanDeployStudio.ts
+++ b/packages/sanity/src/core/studio/components/navbar/resources/useCanDeployStudio.ts
@@ -1,7 +1,7 @@
-import {useObservable} from 'react-rx'
 import {map, of} from 'rxjs'
 
 import {useProjectStore} from '../../../../store/datastores'
+import {useDeferredObservableValue} from '../../../../util/useDeferredObservableValue'
 import {hasDeployStudioGrant} from '../../../manifest/canDeployStudio'
 
 /**
@@ -17,5 +17,5 @@ export function useCanDeployStudio(enabled: boolean = true): boolean {
   // If the hook is disabled, don't subscribe to the observable
   const canDeploy$ = enabled ? result$ : of(false)
 
-  return useObservable(canDeploy$, false)
+  return useDeferredObservableValue(canDeploy$, false)
 }

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/common/ReferencePreviewTitle.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/common/ReferencePreviewTitle.tsx
@@ -1,10 +1,16 @@
 import {type SchemaType} from '@sanity/types'
 import {Skeleton} from '@sanity/ui'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 
 import {getPreviewStateObservable} from '../../../../../../../preview/utils/getPreviewStateObservable'
 import {useDocumentPreviewStore} from '../../../../../../../store/datastores'
+import {useDeferredObservableValue} from '../../../../../../../util/useDeferredObservableValue'
+
+const INITIAL_PREVIEW_STATE = {
+  isLoading: true,
+  snapshot: null,
+  original: null,
+}
 
 export function ReferencePreviewTitle({
   documentId,
@@ -19,11 +25,13 @@ export function ReferencePreviewTitle({
     () => getPreviewStateObservable(documentPreviewStore, schemaType, documentId),
     [documentId, documentPreviewStore, schemaType],
   )
-  const {snapshot, original, isLoading} = useObservable(observable, {
-    isLoading: true,
-    snapshot: null,
-    original: null,
-  })
+  // Identity-coherent deferral: on a document id change the live (loading)
+  // snapshot wins, so the previous document's title never renders for the
+  // new id (including its slice fallback).
+  const {snapshot, original, isLoading} = useDeferredObservableValue(
+    observable,
+    INITIAL_PREVIEW_STATE,
+  )
 
   if (isLoading) {
     return <Skeleton animated marginLeft={1} radius={2} style={{width: '10ch', height: '1em'}} />

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItem.tsx
@@ -2,7 +2,7 @@ import {type StackablePerspective} from '@sanity/client'
 import {type SanityDocumentLike} from '@sanity/types'
 import {Box, type ResponsiveMarginProps, type ResponsivePaddingProps} from '@sanity/ui'
 import {type MouseEvent, useCallback, useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {of} from 'rxjs'
 import {useIntentLink} from 'sanity/router'
 
@@ -63,7 +63,11 @@ export function SearchResultItem({
         : of(null),
     [documentId, documentType, grantsStore, state.canDisableAction],
   )
-  const createPermission = useObservable(createPermission$, null)
+  // Kept synchronous: this gates `disabledAction` together with the live
+  // `documentId` release-membership check, so a deferred snapshot on a
+  // recycled row could leave the new document actionable with the previous
+  // row's granted permission.
+  const createPermission = useSyncObservable(createPermission$, null)
   const hasCreatePermission = createPermission?.granted
 
   // the current search result exists in the release provided by the search provider

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
@@ -1,7 +1,6 @@
 import {type SchemaType} from '@sanity/types'
 import {Badge, Box, Flex} from '@sanity/ui'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {styled} from 'styled-components'
 
 import {DocumentStatus} from '../../../../../../../components/documentStatus/DocumentStatus'
@@ -16,6 +15,7 @@ import {useDocumentVersions} from '../../../../../../../releases/hooks/useDocume
 import {getDocumentVersionInfoFromVersions} from '../../../../../../../releases/util/getDocumentVersionInfoFromVersions'
 import {useDocumentPreviewStore} from '../../../../../../../store/datastores'
 import {type DocumentPresence} from '../../../../../../../store/presence/types'
+import {useDeferredObservableValue} from '../../../../../../../util/useDeferredObservableValue'
 
 interface SearchResultItemPreviewProps {
   documentId: string
@@ -25,6 +25,12 @@ interface SearchResultItemPreviewProps {
   perspective?: PerspectiveStack
   schemaType: SchemaType
   showBadge?: boolean
+}
+
+const INITIAL_PREVIEW_STATE = {
+  snapshot: null,
+  isLoading: true,
+  original: null,
 }
 
 /**
@@ -62,11 +68,13 @@ export function SearchResultItemPreview({
     [documentId, documentType],
   )
 
-  const {isLoading, snapshot, original} = useObservable(observable, {
-    snapshot: null,
-    isLoading: true,
-    original: null,
-  })
+  // Identity-coherent deferral: on a document id change the live (loading)
+  // snapshot wins, so the previous document's title/media never renders next
+  // to the new document's version badges.
+  const {isLoading, snapshot, original} = useDeferredObservableValue(
+    observable,
+    INITIAL_PREVIEW_STATE,
+  )
 
   const {versions} = useDocumentVersions({documentId})
   const versionsInfo = useMemo(() => getDocumentVersionInfoFromVersions(versions), [versions])

--- a/packages/sanity/src/core/studio/components/navbar/search/datastores/useStoredSearch.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/datastores/useStoredSearch.ts
@@ -1,5 +1,5 @@
 import {useCallback, useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {merge, Subject} from 'rxjs'
 import {map, startWith, tap} from 'rxjs/operators'
 
@@ -60,7 +60,10 @@ export function useStoredSearch(): [StoredSearch, (_value: StoredSearch) => void
     [keyValueStore, keyValueStoreKey, optimisticWrites$],
   )
 
-  const value = useObservable(value$, defaultValue)
+  // Kept synchronous: callers (recentSearches) rebuild the stored list from
+  // this value before writing it back, so a stale deferred snapshot could
+  // clobber a concurrent write and drop a recent search.
+  const value = useSyncObservable(value$, defaultValue)
 
   const set = useCallback(
     (newValue: StoredSearch) => {

--- a/packages/sanity/src/core/studio/components/navbar/search/hooks/useSearchMaxFieldDepth.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/hooks/useSearchMaxFieldDepth.ts
@@ -2,12 +2,12 @@ import {type SanityClient} from '@sanity/client'
 import {DEFAULT_MAX_FIELD_DEPTH} from '@sanity/schema/_internal'
 import isFinite from 'lodash-es/isFinite.js'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {type Observable, of} from 'rxjs'
 import {catchError, map, shareReplay, startWith} from 'rxjs/operators'
 
 import {useClient} from '../../../../../hooks/useClient'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../../../../studioClient'
+import {useDeferredObservableValue} from '../../../../../util/useDeferredObservableValue'
 import {useWorkspace} from '../../../../workspace'
 
 /** By default the API will return 0 = all fields */
@@ -87,7 +87,7 @@ export function useSearchMaxFieldDepth(overrideClient?: SanityClient): number {
       ),
     [dataset],
   )
-  const indexSettings = useObservable(indexSettingsObservable, INITIAL_LOADING_STATE)
+  const indexSettings = useDeferredObservableValue(indexSettingsObservable, INITIAL_LOADING_STATE)
 
   const maxFieldDepth = indexSettings?.settings?.partialIndexSettings?.maxFieldDepth
 

--- a/packages/sanity/src/core/studio/components/navbar/useCanInviteMembers.ts
+++ b/packages/sanity/src/core/studio/components/navbar/useCanInviteMembers.ts
@@ -1,7 +1,7 @@
-import {useObservable} from 'react-rx'
 import {map, of} from 'rxjs'
 
 import {useProjectStore} from '../../../store/datastores'
+import {useDeferredObservableValue} from '../../../util/useDeferredObservableValue'
 
 const PERMISSION_NAME = 'sanity.project.members'
 const GRANT_NAME = 'invite'
@@ -35,5 +35,5 @@ export function useCanInviteProjectMembers(opts?: UseCanInviteProjectMembersOpti
   // If the hook is disabled, don't subscribe to the observable
   const canInvite$ = enabled ? result$ : of(false)
 
-  return useObservable(canInvite$, false)
+  return useDeferredObservableValue(canInvite$, false)
 }

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuthCard.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceAuth/WorkspaceAuthCard.tsx
@@ -1,10 +1,10 @@
 import {ChevronRightIcon} from '@sanity/icons/ChevronRight'
 import {Card} from '@sanity/ui'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 
 import {type WorkspaceSummary} from '../../../../../config/types'
 import {probeWorkspaceAuth} from '../../../../../store/authStore/probeWorkspaceAuth'
+import {useDeferredObservableValue} from '../../../../../util/useDeferredObservableValue'
 import {WorkspacePreview} from '../WorkspacePreview'
 
 interface WorkspaceAuthCardProps {
@@ -29,7 +29,7 @@ export function WorkspaceAuthCard({workspace, onSelect}: WorkspaceAuthCardProps)
       }),
     [workspace.apiHost, workspace.dataset, workspace.projectId],
   )
-  const probe = useObservable(probe$)
+  const probe = useDeferredObservableValue(probe$)
 
   const state: 'loading' | 'logged-in' | 'logged-out' | 'no-access' = !probe
     ? 'loading'

--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuItem.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuItem.tsx
@@ -1,10 +1,10 @@
 import {CheckmarkIcon} from '@sanity/icons/Checkmark'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 
 import {MenuItem} from '../../../../../ui-components/menuItem/MenuItem'
 import {type WorkspaceSummary} from '../../../../config/types'
 import {probeWorkspaceAuth} from '../../../../store/authStore/probeWorkspaceAuth'
+import {useDeferredObservableValue} from '../../../../util/useDeferredObservableValue'
 import {STATE_TITLES, WorkspacePreviewIcon} from './WorkspacePreview'
 
 interface WorkspaceMenuItemProps {
@@ -30,7 +30,7 @@ export function WorkspaceMenuItem({workspace, isSelected, scrollbarWidth}: Works
       }),
     [workspace.apiHost, workspace.dataset, workspace.projectId],
   )
-  const probe = useObservable(probe$)
+  const probe = useDeferredObservableValue(probe$)
 
   const state: keyof typeof STATE_TITLES = !probe
     ? 'loading'

--- a/packages/sanity/src/core/studio/networkCheck/useNetworkProtocolCheck.tsx
+++ b/packages/sanity/src/core/studio/networkCheck/useNetworkProtocolCheck.tsx
@@ -2,7 +2,6 @@ import {generateHelpUrl} from '@sanity/generate-help-url'
 import {LaunchIcon} from '@sanity/icons/Launch'
 import {Flex, Stack, Text} from '@sanity/ui'
 import {useCallback, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
 import {of} from 'rxjs'
 
 import {Button} from '../../../ui-components/button/Button'
@@ -10,6 +9,7 @@ import {useClient} from '../../hooks/useClient'
 import {useConditionalToast} from '../../hooks/useConditionalToast'
 import {useTranslation} from '../../i18n/hooks/useTranslation'
 import {isUsingLegacyHttp} from '../../network/isUsingLegacyHttp'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 
 const HTTP_HELP_URL = generateHelpUrl('http1-performance-issues')
 
@@ -46,7 +46,7 @@ export function useNetworkProtocolCheck(): undefined {
     () => (isWarningSnoozed ? of(undefined) : isUsingLegacyHttp(client)),
     [client, isWarningSnoozed],
   )
-  const isOnLegacyHttp = useObservable(isOnLegacyHttp$)
+  const isOnLegacyHttp = useDeferredObservableValue(isOnLegacyHttp$)
 
   const handleSnooze = useCallback(
     () => setWarningSnoozedAt(new Date().toISOString()),

--- a/packages/sanity/src/core/studio/screens/ImportErrorScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/ImportErrorScreen.tsx
@@ -2,7 +2,7 @@
 import {SyncIcon} from '@sanity/icons/Sync'
 import {Box, Card, Code, Container, Heading, Inline, Stack, Text} from '@sanity/ui'
 import {useEffect, useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {of, take, timer} from 'rxjs'
 import {map} from 'rxjs/operators'
 import {styled} from 'styled-components'
@@ -21,7 +21,10 @@ const COUNTDOWN_SECONDS = 5
 export function ImportErrorScreen(props: {error: Error; eventId?: string; autoReload?: boolean}) {
   const {error, eventId, autoReload} = props
 
-  const countdownSeconds = useObservable(
+  // Kept synchronous: the countdown drives the imperative auto-reload effect
+  // below, so a deferred value lagging real time could fire the reload late
+  // or transiently miss the threshold.
+  const countdownSeconds = useSyncObservable(
     useMemo(
       () =>
         autoReload

--- a/packages/sanity/src/core/studio/screens/NotAuthenticatedScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/NotAuthenticatedScreen.tsx
@@ -1,10 +1,10 @@
 /* oxlint-disable i18next/no-literal-string */
 import {Card, Stack, Text} from '@sanity/ui'
 import {useCallback} from 'react'
-import {useObservable} from 'react-rx'
 
 import {Dialog} from '../../../ui-components/dialog/Dialog'
 import {getProviderTitle} from '../../store/authStore/providerTitle'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {useActiveWorkspace} from '../activeWorkspaceMatcher/useActiveWorkspace'
 
 export function NotAuthenticatedScreen() {
@@ -14,7 +14,7 @@ export function NotAuthenticatedScreen() {
     void activeWorkspace.auth.logout?.()
   }, [activeWorkspace])
 
-  const currentUser = useObservable(activeWorkspace.auth.state, null)?.currentUser
+  const currentUser = useDeferredObservableValue(activeWorkspace.auth.state, null)?.currentUser
 
   const providerTitle = getProviderTitle(currentUser?.provider)
   const providerHelp = providerTitle ? ` through ${providerTitle}` : ''

--- a/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
@@ -4,13 +4,14 @@ import {addWeeks} from 'date-fns/addWeeks'
 import {isAfter} from 'date-fns/isAfter'
 import {isBefore} from 'date-fns/isBefore'
 import {useCallback, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {catchError, map, of, startWith} from 'rxjs'
 
 import {Button} from '../../../ui-components/button/Button'
 import {Dialog} from '../../../ui-components/dialog/Dialog'
 import {LoadingBlock} from '../../components/loadingBlock/LoadingBlock'
 import {getProviderTitle} from '../../store/authStore/providerTitle'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {useActiveWorkspace} from '../activeWorkspaceMatcher/useActiveWorkspace'
 import {NotAuthenticatedScreen} from './NotAuthenticatedScreen'
 
@@ -123,8 +124,10 @@ export function RequestAccessScreen() {
   }, [activeWorkspace])
 
   // The client, projectId and user come from the workspace because this screen
-  // renders outside the SourceContext.
-  const auth = useObservable(activeWorkspace.auth.state, null)
+  // renders outside the SourceContext. Kept synchronous: `client`/`projectId`
+  // derived from this are read into the access-request POST, so a deferred
+  // snapshot could submit against a stale workspace identity.
+  const auth = useSyncObservable(activeWorkspace.auth.state, null)
   const currentUser = auth?.currentUser
   const projectId = auth?.client.config().projectId
   const client = useMemo(() => auth?.client.withConfig({apiVersion: '2024-07-01'}), [auth?.client])
@@ -161,7 +164,7 @@ export function RequestAccessScreen() {
       )
   }, [client, projectId])
 
-  const {loading, error, hasExpiredPendingRequest, ...fetched} = useObservable(
+  const {loading, error, hasExpiredPendingRequest, ...fetched} = useDeferredObservableValue(
     accessRequests$,
     INITIAL_ACCESS_REQUEST_STATUS,
   )

--- a/packages/sanity/src/core/studio/studioAnnouncements/StudioAnnouncementsProvider.tsx
+++ b/packages/sanity/src/core/studio/studioAnnouncements/StudioAnnouncementsProvider.tsx
@@ -1,12 +1,12 @@
 import {useTelemetry} from '@sanity/telemetry/react'
 import {useCallback, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
 import {catchError, combineLatest, map, type Observable, startWith} from 'rxjs'
 import {StudioAnnouncementContext} from 'sanity/_singletons'
 
 import {useClient} from '../../hooks/useClient'
 import {useSource} from '../../studio/source'
 import {useWorkspace} from '../../studio/workspace'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {SANITY_VERSION} from '../../version'
 import {
   ProductAnnouncementCardClicked,
@@ -68,7 +68,7 @@ function StudioAnnouncementsProviderInner({children}: StudioAnnouncementsProvide
     )
   }, [client.observable, currentUser?.roles, seenAnnouncements$])
 
-  const announcements = useObservable(getAnnouncements$, {unseen: [], all: []})
+  const announcements = useDeferredObservableValue(getAnnouncements$, {unseen: [], all: []})
   const unseenAnnouncements = announcements.unseen
   const studioAnnouncements = announcements.all
 

--- a/packages/sanity/src/core/studio/telemetry/useTelemetryConsent.ts
+++ b/packages/sanity/src/core/studio/telemetry/useTelemetryConsent.ts
@@ -1,8 +1,8 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {catchError, of} from 'rxjs'
 
 import {useClient} from '../../hooks/useClient'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {type ConsentStatus, getTelemetryConsent$} from './telemetryConsent'
 
 /**
@@ -20,5 +20,5 @@ export function useTelemetryConsent(): ConsentStatus {
     [client],
   )
 
-  return useObservable(consent$, 'loading')
+  return useDeferredObservableValue(consent$, 'loading')
 }

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceLoader.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceLoader.tsx
@@ -1,5 +1,5 @@
 import {type ComponentType, type ReactNode, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {combineLatest, of} from 'rxjs'
 import {catchError, map} from 'rxjs/operators'
 
@@ -68,7 +68,10 @@ export function useWorkspaceLoader(activeWorkspace: WorkspaceSummary) {
     [activeWorkspace],
   )
 
-  const result = useObservable(workspace$, INITIAL_WORKSPACE_RESULT)
+  // Kept synchronous: `activeWorkspace` (identity) updates synchronously on a
+  // workspace switch, so a deferred resolved workspace would briefly serve the
+  // previous workspace's project/dataset/schema under the new identity.
+  const result = useSyncObservable(workspace$, INITIAL_WORKSPACE_RESULT)
   if (result.type === 'error') throw result.error
 
   return result.value

--- a/packages/sanity/src/core/studio/workspaces/WorkspacesProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaces/WorkspacesProvider.tsx
@@ -10,7 +10,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {defer, firstValueFrom, from, NEVER, Subject, type Observable} from 'rxjs'
 import {catchError, mergeMap, take, tap} from 'rxjs/operators'
 import {
@@ -249,8 +249,10 @@ export function WorkspacesProvider({
 
   // `null` initial value (rather than undefined) so react-rx provides a
   // server snapshot — SSR renders without a dialog instead of warning
-  // about a missing getServerSnapshot.
-  const claim = useObservable(requestErrorChannel.claim$, null) ?? undefined
+  // about a missing getServerSnapshot. Kept synchronous: the `unauthorized`
+  // claim drives forced logout, and session teardown shouldn't wait for a
+  // deferred re-render.
+  const claim = useSyncObservable(requestErrorChannel.claim$, null) ?? undefined
 
   // Why we logged the user out, consumed by the login screen to surface a
   // toast. Derived from the live `unauthorized` claim, so it's present exactly

--- a/packages/sanity/src/core/tasks/hooks/useDocumentPreviewValues.ts
+++ b/packages/sanity/src/core/tasks/hooks/useDocumentPreviewValues.ts
@@ -1,12 +1,12 @@
 import {type PreviewValue} from '@sanity/types'
 import {type ElementType, type ReactNode, useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {of} from 'rxjs'
 
 import {useSchema} from '../../hooks/useSchema'
 import {usePerspective} from '../../perspective/usePerspective'
 import {getPreviewStateObservable} from '../../preview/utils/getPreviewStateObservable'
 import {useDocumentPreviewStore} from '../../store/datastores'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 
 interface PreviewHookOptions {
   documentId: string
@@ -40,7 +40,10 @@ export function useDocumentPreviewValues(options: PreviewHookOptions): PreviewHo
       perspectiveStackFromOptions ?? perspectiveStack,
     )
   }, [documentId, documentPreviewStore, schemaType, perspectiveStackFromOptions, perspectiveStack])
-  const previewState = useObservable(previewStateObservable)
+  // Identity-coherent deferral: on a document id change the live (loading)
+  // snapshot wins, so the previous document's title/media never pairs with
+  // the new identity.
+  const previewState = useDeferredObservableValue(previewStateObservable)
 
   const isLoading = previewState?.isLoading ?? true
 

--- a/packages/sanity/src/core/user-color/hooks.ts
+++ b/packages/sanity/src/core/user-color/hooks.ts
@@ -1,8 +1,8 @@
 import {useContext, useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {EMPTY} from 'rxjs'
 import {UserColorManagerContext} from 'sanity/_singletons'
 
+import {useDeferredObservableValue} from '../util/useDeferredObservableValue'
 import {type UserColor, type UserColorManager} from './types'
 
 /** @internal */
@@ -21,5 +21,5 @@ export function useUserColor(userId: string | null): UserColor {
   const manager = useUserColorManager()
 
   const observable = useMemo(() => (userId ? manager.listen(userId) : EMPTY), [manager, userId])
-  return useObservable(observable, manager.get(null))
+  return useDeferredObservableValue(observable, manager.get(null))
 }

--- a/packages/sanity/src/core/util/__tests__/createHookFromObservableFactory.test.tsx
+++ b/packages/sanity/src/core/util/__tests__/createHookFromObservableFactory.test.tsx
@@ -1,11 +1,35 @@
-import {render, renderHook, waitFor} from '@testing-library/react'
-import {Component, memo, Profiler, type PropsWithChildren, useDeferredValue} from 'react'
+import {act, render, renderHook, waitFor} from '@testing-library/react'
+import {Component, memo, type PropsWithChildren, useDeferredValue} from 'react'
 import * as Rx from 'rxjs'
 import {describe, expect, it, vi} from 'vitest'
 
 import {createHookFromObservableFactory} from '../createHookFromObservableFactory'
 
 const tick = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+/**
+ * Renders `null` once a child throws; reports every caught error via
+ * `onError`. Reset by remounting (pass a new `key`), which mirrors how
+ * boundaries recover in the studio (the pane subtree remounts).
+ */
+class TestErrorBoundary extends Component<
+  PropsWithChildren<{onError: (error: Error) => void}>,
+  {hasError: boolean}
+> {
+  constructor(props: PropsWithChildren<{onError: (error: Error) => void}>) {
+    super(props)
+    this.state = {hasError: false}
+  }
+  static getDerivedStateFromError() {
+    return {hasError: true}
+  }
+  override componentDidCatch(error: Error) {
+    this.props.onError(error)
+  }
+  override render() {
+    return this.state.hasError ? null : this.props.children
+  }
+}
 
 describe('createHookFromObservableFactory', () => {
   it('takes in an observable factory and returns a loading-tuple hook', async () => {
@@ -15,30 +39,23 @@ describe('createHookFromObservableFactory', () => {
         Rx.from(tick().then(() => `hi, ${value}`)),
       )
     const useHook = createHookFromObservableFactory(observableFactory)
-    const phasesTimeline: any[] = []
     const renderTimeline: ReturnType<typeof useHook>[] = []
     const TestComponent = ({value}: {value: string}) => {
       renderTimeline.push(useHook(value))
       return null
     }
-    render(<TestComponent value="world" />, {
-      wrapper: ({children}) => (
-        <Profiler id="test" onRender={(id, phase) => phasesTimeline.push(phase)}>
-          {children}
-        </Profiler>
-      ),
-    })
-    await waitFor(() => expect(renderTimeline.length).toBe(3))
+    render(<TestComponent value="world" />)
 
-    expect(renderTimeline).toEqual([
-      [undefined, true],
-      // note: the loading state staying at false is expected here because the
-      // next update came from the observable which doesn't tell us when it has
-      // an incoming update from it's source (it just pushes and we consume)
-      ['hello, world', false],
-      ['hi, world', false],
-    ])
-    expect(phasesTimeline).toEqual(['mount', 'update', 'update'])
+    // First render is always the loading tuple
+    expect(renderTimeline[0]).toEqual([undefined, true])
+    // Eventually the final value arrives. Intermediate emissions may be coalesced away,
+    // since the hook defers updates.
+    // note: the loading state staying at false is expected here because the
+    // next update came from the observable which doesn't tell us when it has
+    // an incoming update from it's source (it just pushes and we consume)
+    await waitFor(() =>
+      expect(renderTimeline[renderTimeline.length - 1]).toEqual(['hi, world', false]),
+    )
   })
 
   it('flips the loading state if the hook argument changes', async () => {
@@ -46,7 +63,6 @@ describe('createHookFromObservableFactory', () => {
       Rx.from(tick().then(() => ({value: `hello, ${value}`}))),
     )
     const useHook = createHookFromObservableFactory(observableFactory)
-    const phasesTimeline: any[] = []
     const renderTimeline: ReturnType<typeof useHook>[] = []
 
     const TestComponent = ({value}: {value: string}) => {
@@ -55,31 +71,32 @@ describe('createHookFromObservableFactory', () => {
       return null
     }
 
-    const {rerender} = render(<TestComponent value="world" />, {
-      wrapper: ({children}) => (
-        <Profiler id="test" onRender={(...args) => phasesTimeline.push(args)}>
-          {children}
-        </Profiler>
-      ),
-    })
+    const {rerender} = render(<TestComponent value="world" />)
 
-    await waitFor(() => expect(renderTimeline.length).toBe(2))
-    expect(renderTimeline).toEqual([
-      [undefined, true],
-      [{value: 'hello, world'}, false],
-    ])
+    // First render is always the loading tuple
+    expect(renderTimeline[0]).toEqual([undefined, true])
+    // Eventually the first value arrives
+    await waitFor(() =>
+      expect(renderTimeline[renderTimeline.length - 1]).toEqual([{value: 'hello, world'}, false]),
+    )
     // One factory call per distinct arg — react-rx@4.2.5 fixed a useObservable cache
     // leak that previously caused duplicate subscriptions (and thus double calls).
     expect(observableFactory).toHaveBeenCalledTimes(1)
 
+    const timelineLengthBeforeArgChange = renderTimeline.length
     rerender(<TestComponent value="hooks" />)
-    await waitFor(() => expect(renderTimeline.length).toBe(4))
-
-    expect(renderTimeline).toEqual([
-      [undefined, true],
-      [{value: 'hello, world'}, false],
-      [undefined, true],
-      [{value: 'hello, hooks'}, false],
+    // The first render after the arg change must be the loading tuple: the
+    // deferred snapshot belonging to the previous arg must never render as
+    // loaded state under the new identity.
+    expect(renderTimeline[timelineLengthBeforeArgChange]).toEqual([undefined, true])
+    // Eventually the second value arrives
+    await waitFor(() =>
+      expect(renderTimeline[renderTimeline.length - 1]).toEqual([{value: 'hello, hooks'}, false]),
+    )
+    // The previous arg's loaded tuple never re-rendered after the arg change.
+    expect(renderTimeline.slice(timelineLengthBeforeArgChange)).not.toContainEqual([
+      {value: 'hello, world'},
+      false,
     ])
 
     expect(observableFactory).toHaveBeenCalledTimes(2)
@@ -88,15 +105,14 @@ describe('createHookFromObservableFactory', () => {
   // createHookFromObservableFactory uses useSyncExternalStore to trigger re-renders in React if state changes
   // startTransition marks re-renders triggered by new state in one of `useState|useReducer|setState` as low and interruptible priority.
   // But startTransition have no effect on useSyncExternalStore. Which kinda makes sense if you think about it, the hook is named after how it *really wants external stores to be in sync*.
-  // This is where the `useDeferredValue` hook comes into play, in fact, pairing up `useDefferedValue` with a child component wrapped in `React.memo` lets you build the same
+  // This is where the `useDeferredValue` hook comes into play, in fact, pairing up `useDeferredValue` with a child component wrapped in `React.memo` lets you build the same
   // great end-results as pairing `startTransition` + `<Suspense>` boundaries in apps that don't have external state.
   // And this test demonstrates how to do that.
-  it('Using React.memo + useDeferrableValue should interrupt and reduce re-renders down the tree similar to startTransition + Suspense', async () => {
+  it('Using React.memo + useDeferredValue should interrupt and reduce re-renders down the tree similar to startTransition + Suspense', async () => {
     const observableFactory = vi.fn((value: string) =>
       Rx.from(tick().then(() => ({value: `hello, ${value}`}))),
     )
     const useHook = createHookFromObservableFactory(observableFactory)
-    const phasesTimeline: [id: string, phase: string][] = []
     let syncRenders = 0
     let deferRenders = 0
 
@@ -106,7 +122,7 @@ describe('createHookFromObservableFactory', () => {
       tuple: ReturnType<typeof useHook>
     }) {
       deferRenders++
-      return <Profiler id="defer" onRender={(id, phase) => phasesTimeline.push([id, phase])} />
+      return null
     })
     const TestComponent = ({value}: {value: string}) => {
       const result = useHook(value)
@@ -115,48 +131,24 @@ describe('createHookFromObservableFactory', () => {
       return <InnerMemoTestComponent tuple={deferredResult} />
     }
 
-    const {rerender} = render(<TestComponent value="world" />, {
-      wrapper: ({children}) => (
-        <Profiler id="sync" onRender={(id, phase) => phasesTimeline.push([id, phase])}>
-          {children}
-        </Profiler>
-      ),
-    })
+    const {rerender} = render(<TestComponent value="world" />)
 
-    await waitFor(() => expect(syncRenders).toBe(3))
-    await waitFor(() => expect(deferRenders).toBe(2))
+    // Wait for the initial render cycle to settle with the resolved value
+    await waitFor(() => expect(syncRenders).toBeGreaterThan(1))
+    await waitFor(() => expect(deferRenders).toBeGreaterThan(0))
     // One factory call per distinct arg (see react-rx@4.2.5 cache-leak fix note above).
     expect(observableFactory).toHaveBeenCalledTimes(1)
-    expect(phasesTimeline).toEqual([
-      ['defer', 'mount'],
-      ['sync', 'mount'],
-      ['sync', 'update'],
-      ['defer', 'update'],
-      ['sync', 'update'],
-    ])
+    // Deferred child should render fewer or equal times than the sync parent
+    expect(deferRenders).toBeLessThanOrEqual(syncRenders)
 
+    const syncRendersBeforeRerender = syncRenders
     rerender(<TestComponent value="fast" />)
     rerender(<TestComponent value="hooks" />)
-    await waitFor(() => expect(syncRenders).toBe(7))
-    await waitFor(() => expect(deferRenders).toBe(5))
+    await waitFor(() => expect(syncRenders).toBeGreaterThan(syncRendersBeforeRerender + 1))
 
     expect(observableFactory).toHaveBeenCalledTimes(3)
-    expect(phasesTimeline).toEqual([
-      ['defer', 'mount'],
-      ['sync', 'mount'],
-      ['sync', 'update'],
-      ['defer', 'update'],
-      ['sync', 'update'],
-      ['sync', 'update'],
-      ['defer', 'update'],
-      ['sync', 'update'],
-      ['sync', 'update'],
-      ['defer', 'update'],
-      ['sync', 'update'],
-      ['sync', 'update'],
-      ['defer', 'update'],
-      ['sync', 'update'],
-    ])
+    // Deferred child continues to render fewer or equal times than the sync parent
+    expect(deferRenders).toBeLessThanOrEqual(syncRenders)
   })
 
   it('accepts an initial value and will return that immediately', async () => {
@@ -173,15 +165,14 @@ describe('createHookFromObservableFactory', () => {
     }
     render(<TestComponent value="world" />)
 
-    expect(renderTimeline).toEqual([['factory initial', true]])
+    // First render returns the initial value in loading state
+    expect(renderTimeline[0]).toEqual(['factory initial', true])
     expect(observableFactory).toHaveBeenCalledTimes(1)
 
-    await waitFor(() => expect(renderTimeline.length).toBe(2))
-
-    expect(renderTimeline).toEqual([
-      ['factory initial', true],
-      ['hello, world', false],
-    ])
+    // Eventually the resolved value arrives as the last entry
+    await waitFor(() =>
+      expect(renderTimeline[renderTimeline.length - 1]).toEqual(['hello, world', false]),
+    )
     // Still a single subscription for the same arg after the value arrives.
     expect(observableFactory).toHaveBeenCalledTimes(1)
   })
@@ -212,5 +203,100 @@ describe('createHookFromObservableFactory', () => {
     })
 
     await waitFor(() => expect(error?.message).toBe('test error'))
+  })
+
+  it('throws from the live snapshot: no stale frame is committed between the error and the boundary', async () => {
+    // Guards the "throw errors from the live snapshot" behavior: the render
+    // that observes the error must throw immediately. If the throw were moved
+    // to the deferred snapshot instead, the error render would first commit
+    // one more frame with the stale (pre-error) tuple — deferred values lag
+    // one render behind — and only the deferred catch-up render would throw.
+    // The frame count below is the discriminating observation.
+    const subject = new Rx.Subject<string>()
+    const useHook = createHookFromObservableFactory(() => subject)
+
+    const caughtErrors: Error[] = []
+    const renderTimeline: ReturnType<typeof useHook>[] = []
+    const TestComponent = () => {
+      renderTimeline.push(useHook())
+      return null
+    }
+    render(
+      <TestErrorBoundary onError={(error) => caughtErrors.push(error)}>
+        <TestComponent />
+      </TestErrorBoundary>,
+      {onCaughtError: () => {}},
+    )
+
+    act(() => subject.next('value before error'))
+    await waitFor(() =>
+      expect(renderTimeline[renderTimeline.length - 1]).toEqual(['value before error', false]),
+    )
+
+    const framesBeforeError = renderTimeline.length
+    act(() => subject.error(new Error('live error')))
+
+    await waitFor(() => expect(caughtErrors.map((err) => err.message)).toContain('live error'))
+    // The discriminating assertion: the erroring render threw before
+    // returning, so it committed no frame. A deferred-side throw would have
+    // appended at least one more stale `['value before error', false]` frame.
+    expect(renderTimeline.length).toBe(framesBeforeError)
+  })
+
+  it('recovers cleanly after an errored arg: the new arg loads without re-throwing or leaking stale state', async () => {
+    // Guards the "drops stale errors after recovery" behavior: once an arg's
+    // observable has errored (and the boundary caught it), moving on to
+    // another arg must render that arg's own loading -> value sequence — the
+    // stale error must not be re-thrown and the errored arg's data must not
+    // reappear.
+    const subjects = new Map<string, Rx.Subject<string>>()
+    const observableFactory = vi.fn((arg: string) => {
+      if (!subjects.has(arg)) subjects.set(arg, new Rx.Subject<string>())
+      return subjects.get(arg)!
+    })
+    const useHook = createHookFromObservableFactory(observableFactory)
+
+    const caughtErrors: Error[] = []
+    const renderTimeline: ReturnType<typeof useHook>[] = []
+    const TestComponent = ({value}: {value: string}) => {
+      renderTimeline.push(useHook(value))
+      return null
+    }
+    const view = render(
+      <TestErrorBoundary key="a" onError={(error) => caughtErrors.push(error)}>
+        <TestComponent value="a" />
+      </TestErrorBoundary>,
+      {onCaughtError: () => {}},
+    )
+
+    act(() => subjects.get('a')!.next('value for a'))
+    await waitFor(() =>
+      expect(renderTimeline[renderTimeline.length - 1]).toEqual(['value for a', false]),
+    )
+
+    act(() => subjects.get('a')!.error(new Error('error for a')))
+    await waitFor(() => expect(caughtErrors.map((err) => err.message)).toContain('error for a'))
+
+    // Recovery: move on to arg "b". The boundary is keyed, so it remounts —
+    // the same way studio boundaries recover when the pane subtree remounts.
+    const framesBeforeRecovery = renderTimeline.length
+    const catchesBeforeRecovery = caughtErrors.length
+    view.rerender(
+      <TestErrorBoundary key="b" onError={(error) => caughtErrors.push(error)}>
+        <TestComponent value="b" />
+      </TestErrorBoundary>,
+    )
+    act(() => subjects.get('b')!.next('value for b'))
+
+    await waitFor(() =>
+      expect(renderTimeline[renderTimeline.length - 1]).toEqual(['value for b', false]),
+    )
+    const framesAfterRecovery = renderTimeline.slice(framesBeforeRecovery)
+    // The recovery starts from b's own loading state and never renders the
+    // errored arg's data again.
+    expect(framesAfterRecovery[0]).toEqual([undefined, true])
+    expect(framesAfterRecovery).not.toContainEqual(['value for a', false])
+    // The stale error was not re-thrown into the boundary after recovery.
+    expect(caughtErrors.length).toBe(catchesBeforeRecovery)
   })
 })

--- a/packages/sanity/src/core/util/__tests__/useDeferredObservableValue.test.tsx
+++ b/packages/sanity/src/core/util/__tests__/useDeferredObservableValue.test.tsx
@@ -1,0 +1,135 @@
+import {render, waitFor} from '@testing-library/react'
+import {useDeferredValue} from 'react'
+import {useObservable as useSyncObservable} from 'react-rx'
+import {BehaviorSubject, type Observable} from 'rxjs'
+import {describe, expect, it} from 'vitest'
+
+import {useDeferredObservableValue} from '../useDeferredObservableValue'
+
+/**
+ * These tests document the central claim debated in the review of the
+ * "defer non-controlled useObservable subscriptions" PR:
+ *
+ * > Is it safe to defer a document-keyed observable read?
+ *
+ * Two sides were argued, and both are captured here as executable tests:
+ *
+ *  - The risk (raised by Bugbot / initial caution): a *bare*
+ *    `useDeferredValue(useSyncObservable(x))` renders the *previous* observable's
+ *    value on the render right after the observable identity changes in place
+ *    (no remount). For a document-keyed read that means briefly showing the
+ *    previous document's data under the new id — a tear.
+ *
+ *  - The resolution (Pedro): navigating to another document remounts the
+ *    consumer because `<DocumentPaneProvider>`'s `key` changes, so per-document
+ *    state resets and a deferred value can never leak across documents. See
+ *    the "remount" test below.
+ *
+ * `useDeferredObservableValue` makes deferral safe in *both* situations: it
+ * defers identity and value together and falls back to the live value when the
+ * observable identity changes, so it never tears even without a remount.
+ */
+
+// Bare pattern the helper replaces — used only to document the tear it prevents.
+function useBareDeferredObservableValue<T>(observable: Observable<T>, initialValue: T): T {
+  return useDeferredValue(useSyncObservable(observable, initialValue))
+}
+
+describe('useDeferredObservableValue', () => {
+  it('emits the observable values', async () => {
+    const subject = new BehaviorSubject('first')
+    const renderTimeline: (string | undefined)[] = []
+
+    function TestComponent() {
+      renderTimeline.push(useDeferredObservableValue(subject))
+      return null
+    }
+    render(<TestComponent />)
+
+    expect(renderTimeline[0]).toBe('first')
+
+    subject.next('second')
+    await waitFor(() => expect(renderTimeline[renderTimeline.length - 1]).toBe('second'))
+  })
+
+  it('falls back to the live value when the observable identity changes in place', async () => {
+    const subjectA = new BehaviorSubject('value for a')
+    const subjectB = new BehaviorSubject('initial for b')
+    const renderTimeline: string[] = []
+
+    function TestComponent({observable}: {observable: BehaviorSubject<string>}) {
+      renderTimeline.push(useDeferredObservableValue(observable, 'fallback'))
+      return null
+    }
+    const {rerender} = render(<TestComponent observable={subjectA} />)
+    await waitFor(() => expect(renderTimeline[renderTimeline.length - 1]).toBe('value for a'))
+
+    const timelineLengthBeforeSwitch = renderTimeline.length
+    rerender(<TestComponent observable={subjectB} />)
+
+    // The render right after the identity change must reflect the new
+    // observable (BehaviorSubject emits synchronously), never the deferred
+    // snapshot belonging to the previous observable.
+    expect(renderTimeline[timelineLengthBeforeSwitch]).toBe('initial for b')
+    expect(renderTimeline.slice(timelineLengthBeforeSwitch)).not.toContain('value for a')
+
+    subjectB.next('updated for b')
+    await waitFor(() => expect(renderTimeline[renderTimeline.length - 1]).toBe('updated for b'))
+  })
+
+  it('documents the tear a bare useDeferredValue(useSyncObservable(...)) produces on an in-place identity change', async () => {
+    // This is the failure mode the helper exists to prevent. It is asserted
+    // here so the risk is captured and cannot silently regress: a bare
+    // deferral renders the PREVIOUS observable's value on the first render
+    // after the identity switches without a remount.
+    const subjectA = new BehaviorSubject('value for a')
+    const subjectB = new BehaviorSubject('initial for b')
+    const renderTimeline: string[] = []
+
+    function TestComponent({observable}: {observable: BehaviorSubject<string>}) {
+      renderTimeline.push(useBareDeferredObservableValue(observable, 'fallback'))
+      return null
+    }
+    const {rerender} = render(<TestComponent observable={subjectA} />)
+    await waitFor(() => expect(renderTimeline[renderTimeline.length - 1]).toBe('value for a'))
+
+    const timelineLengthBeforeSwitch = renderTimeline.length
+    rerender(<TestComponent observable={subjectB} />)
+
+    // The tear: the previous observable's value leaks under the new identity.
+    expect(renderTimeline[timelineLengthBeforeSwitch]).toBe('value for a')
+    // It does eventually converge to the new value.
+    await waitFor(() => expect(renderTimeline[renderTimeline.length - 1]).toBe('initial for b'))
+  })
+
+  it('remount on key change resets state, so even a bare deferral cannot leak across documents', async () => {
+    // Documents Pedro's justification: `<DocumentPaneProvider>` changes its
+    // `key` when the document changes, so the subtree remounts and per-document
+    // state resets. A fresh mount subscribes to the new observable and shows
+    // its value immediately — no stale value from the previous document, even
+    // with the bare pattern.
+    const subjectA = new BehaviorSubject('value for a')
+    const subjectB = new BehaviorSubject('initial for b')
+    const renderTimeline: string[] = []
+
+    function Consumer({observable}: {observable: BehaviorSubject<string>}) {
+      renderTimeline.push(useBareDeferredObservableValue(observable, 'fallback'))
+      return null
+    }
+    // `docKey` mirrors the DocumentPaneProvider key: it changes with the doc.
+    function Harness({docKey, observable}: {docKey: string; observable: BehaviorSubject<string>}) {
+      return <Consumer key={docKey} observable={observable} />
+    }
+
+    const {rerender} = render(<Harness docKey="a" observable={subjectA} />)
+    await waitFor(() => expect(renderTimeline[renderTimeline.length - 1]).toBe('value for a'))
+
+    const timelineLengthBeforeSwitch = renderTimeline.length
+    rerender(<Harness docKey="b" observable={subjectB} />)
+
+    // Fresh mount for document "b": the new document's value renders
+    // immediately and the previous document's value never appears afterwards.
+    expect(renderTimeline[timelineLengthBeforeSwitch]).toBe('initial for b')
+    expect(renderTimeline.slice(timelineLengthBeforeSwitch)).not.toContain('value for a')
+  })
+})

--- a/packages/sanity/src/core/util/createHookFromObservableFactory.ts
+++ b/packages/sanity/src/core/util/createHookFromObservableFactory.ts
@@ -1,5 +1,5 @@
-import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useDeferredValue, useMemo} from 'react'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {concat, type Observable, of} from 'rxjs'
 import {catchError, distinctUntilChanged, map, scan, switchMap} from 'rxjs/operators'
 
@@ -65,9 +65,30 @@ export function createHookFromObservableFactory<T, TArg = void>(
         ),
       [arg],
     )
-    const result = useObservable(observable, initialResult)
+    const syncResult = useSyncObservable(observable, initialResult)
+    // Identity and result are deferred as one snapshot so they can never tear
+    // (the deferred result always belongs to the deferred observable).
+    const syncSnapshot = useMemo(() => ({observable, result: syncResult}), [observable, syncResult])
+    const deferredSnapshot = useDeferredValue(syncSnapshot)
 
-    if (result.type === 'error') throw result.error
+    // Throw from the live snapshot so errors reach the error boundary as soon
+    // as the observable errors, instead of after the deferred snapshot
+    // catches up.
+    if (syncResult.type === 'error') throw syncResult.error
+
+    // A deferred snapshot is only coherent while it belongs to the current
+    // observable identity (same `arg`). Across identity changes (e.g. a new
+    // document id) fall back to the live snapshot — which synchronously resets
+    // to loading — so the previous arg's value never renders as loaded state
+    // for the new one.
+    const deferredResult =
+      deferredSnapshot.observable === observable ? deferredSnapshot.result : syncResult
+    // Defense-in-depth: an error result should never commit (the render that
+    // observes it throws above, and recovery remounts with fresh state), so a
+    // stale deferred error should be unreachable. But if observable identity
+    // is ever cached/reused across an error (e.g. a future factory-level
+    // cache), fall back to the live tuple rather than re-throwing it.
+    const result = deferredResult.type === 'error' ? syncResult : deferredResult
 
     return result.tuple
   }

--- a/packages/sanity/src/core/util/useDeferredObservableValue.ts
+++ b/packages/sanity/src/core/util/useDeferredObservableValue.ts
@@ -1,0 +1,39 @@
+import {useDeferredValue, useMemo} from 'react'
+import {useObservable as useSyncObservable} from 'react-rx'
+import {type Observable} from 'rxjs'
+
+/** @internal */
+export interface UseDeferredObservableValue {
+  <T>(observable: Observable<T>): T | undefined
+  <T>(observable: Observable<T>, initialValue: T): T
+}
+
+/**
+ * Subscribes to an observable like `useSyncObservable`, but returns a deferred
+ * snapshot of its value (via `useDeferredValue`) so high-frequency emissions
+ * don't force synchronous, blocking renders.
+ *
+ * Unlike a bare `useDeferredValue(useSyncObservable(...))`, the deferred snapshot
+ * is identity-coherent: identity and value are deferred as one object, and
+ * when the observable identity changes (e.g. it is memoized on a document id
+ * that just changed) the hook falls back to the live value — typically the
+ * new observable's initial/loading state — so the previous identity's value
+ * never renders under the new one.
+ *
+ * Values that feed writes, imperative reads, or gating logic paired with live
+ * state should use `useSyncObservable` directly instead of this hook.
+ *
+ * @internal
+ */
+// Declared as a typed const rather than overloaded function declarations: the
+// React Compiler babel transform fails on overloaded hook declarations with a
+// "duplicate declaration" error.
+export const useDeferredObservableValue: UseDeferredObservableValue =
+  function useDeferredObservableValue<T>(observable: Observable<T>, initialValue?: T) {
+    const value = useSyncObservable(observable, initialValue as T)
+    // Defer identity and value as one snapshot so they can never tear (the
+    // deferred value always belongs to the deferred observable).
+    const snapshot = useMemo(() => ({observable, value}), [observable, value])
+    const deferredSnapshot = useDeferredValue(snapshot)
+    return deferredSnapshot.observable === observable ? deferredSnapshot.value : value
+  } as UseDeferredObservableValue

--- a/packages/sanity/src/core/util/useLoadable.ts
+++ b/packages/sanity/src/core/util/useLoadable.ts
@@ -1,7 +1,8 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {type Observable, of, type OperatorFunction} from 'rxjs'
 import {catchError, map} from 'rxjs/operators'
+
+import {useDeferredObservableValue} from './useDeferredObservableValue'
 
 /** @internal */
 export type LoadableState<T> = LoadingState | LoadedState<T> | ErrorState
@@ -48,7 +49,7 @@ export function useLoadable<T>(
       : {isLoading: false, value: initialValue, error: null}
 
   const loadableObservable = useMemo(() => value$.pipe(asLoadable()), [value$])
-  return useObservable(loadableObservable, initial)
+  return useDeferredObservableValue(loadableObservable, initial)
 }
 
 /** @internal */

--- a/packages/sanity/src/core/variants/hooks/useVariantsDocumentCounts.ts
+++ b/packages/sanity/src/core/variants/hooks/useVariantsDocumentCounts.ts
@@ -1,11 +1,11 @@
 import {type SanityClient} from '@sanity/client'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {type Observable, of} from 'rxjs'
 import {catchError, distinctUntilChanged, map, scan, startWith, switchMap} from 'rxjs/operators'
 
 import {useClient} from '../../hooks/useClient'
 import {listenQuery} from '../../store/document/listenQuery'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {VARIANTS_STUDIO_CLIENT_OPTIONS} from '../store/constants'
 import {type VariantStoreState} from '../store/reducer'
 import {useVariantsStore} from '../store/useVariantsStore'
@@ -163,5 +163,5 @@ export function useVariantsDocumentCounts(): VariantsDocumentCountsState {
 
   const observable = useMemo(() => getVariantsDocumentCounts(client, state$), [client, state$])
 
-  return useObservable(observable, INITIAL_STATE)
+  return useDeferredObservableValue(observable, INITIAL_STATE)
 }

--- a/packages/sanity/src/core/variants/store/useAllVariants.ts
+++ b/packages/sanity/src/core/variants/store/useAllVariants.ts
@@ -1,5 +1,5 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 
 import {type SystemVariant} from '../types'
 import {useVariantsStore} from './useVariantsStore'
@@ -15,7 +15,11 @@ export function useAllVariants(): {
   loading: boolean
 } {
   const {state$} = useVariantsStore()
-  const {variants, error, state} = useObservable(state$)!
+  // Kept synchronous: variant resolution feeds `useTargetDocumentState`'s
+  // target scope, so a deferred snapshot could bind the form checkout to the
+  // wrong variant after navigation. Executable proof:
+  // perspective/__tests__/deferralSafety.test.tsx.
+  const {variants, error, state} = useSyncObservable(state$)!
 
   return useMemo(
     () => ({

--- a/packages/sanity/src/media-library/plugin/VideoInput/VideoPreview.tsx
+++ b/packages/sanity/src/media-library/plugin/VideoInput/VideoPreview.tsx
@@ -3,7 +3,7 @@ import {SearchIcon} from '@sanity/icons/Search'
 import {type AssetSource} from '@sanity/types'
 import get from 'lodash-es/get.js'
 import {type ReactNode, useCallback, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {EMPTY} from 'rxjs'
 
 import {ActionsMenu} from '../../../core/form/inputs/files/common/ActionsMenu'
@@ -132,7 +132,9 @@ export function VideoPreview(props: VideoAssetInputProps) {
     () => (documentId && observeAsset ? observeAsset(documentId) : EMPTY),
     [documentId, observeAsset],
   )
-  const resolvedAsset = useObservable(observable)
+  // Kept synchronous: a deferred snapshot could pair the previous asset with a
+  // newly selected reference, pointing open-in-source at the wrong asset.
+  const resolvedAsset = useSyncObservable(observable)
 
   const openInSourceResult = useMemo(() => {
     if (resolvedAsset) {

--- a/packages/sanity/src/media-library/plugin/VideoInput/useVideoPlaybackInfo.ts
+++ b/packages/sanity/src/media-library/plugin/VideoInput/useVideoPlaybackInfo.ts
@@ -1,7 +1,7 @@
 import {type SanityClient} from '@sanity/client'
 import {type Reference, type SanityDocument} from '@sanity/types'
 import {useCallback, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {defer, from, type Observable, of, Subject, timer} from 'rxjs'
 import {
   catchError,
@@ -205,5 +205,8 @@ export function useVideoPlaybackInfo(
     return [loadingState, obs$]
   }, [params, client, retrySubject, retry])
 
-  return useObservable(playbackInfoObservable, initialState)
+  // Kept synchronous: the playback info is keyed to the live asset ref, so a
+  // deferred snapshot could keep serving the previous asset's playbackId and
+  // tokens after the selection changes.
+  return useSyncObservable(playbackInfoObservable, initialState)
 }

--- a/packages/sanity/src/presentation/editor/usePreviewState.ts
+++ b/packages/sanity/src/presentation/editor/usePreviewState.ts
@@ -1,6 +1,5 @@
 import {type SchemaType} from '@sanity/types'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {of} from 'rxjs'
 import {
   getPreviewStateObservable,
@@ -9,6 +8,8 @@ import {
   useDocumentPreviewStore,
   usePerspective,
 } from 'sanity'
+
+import {useDeferredObservableValue} from '../../core/util/useDeferredObservableValue'
 
 interface PreviewState {
   isLoading?: boolean
@@ -29,5 +30,8 @@ export default function usePreviewState(documentId: string, schemaType?: SchemaT
     [documentPreviewStore, schemaType, documentId, perspectiveStack],
   )
 
-  return useObservable(preview$, EMPTY_STATE)
+  // Identity-coherent deferral: on a document id change the live snapshot
+  // wins, so the previous document's preview never renders under the new
+  // identity.
+  return useDeferredObservableValue(preview$, EMPTY_STATE)
 }

--- a/packages/sanity/src/presentation/loader/useLiveEvents.ts
+++ b/packages/sanity/src/presentation/loader/useLiveEvents.ts
@@ -1,6 +1,6 @@
 import {type LiveEvent, type LiveEventMessage} from '@sanity/client'
 import {useDeferredValue, useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {catchError, scan, throwError} from 'rxjs'
 import {type SanityClient} from 'sanity'
 
@@ -74,7 +74,7 @@ export function useLiveEvents(client: SanityClient): State {
     [client.live],
   )
 
-  // Stream errors are re-thrown by `useObservable` during render, so they reach the nearest
+  // Stream errors are re-thrown by `useSyncObservable` during render, so they reach the nearest
   // error boundary without any explicit handling here.
-  return useDeferredValue(useObservable(state$, initialState))
+  return useDeferredValue(useSyncObservable(state$, initialState))
 }

--- a/packages/sanity/src/presentation/useDocumentLocations.ts
+++ b/packages/sanity/src/presentation/useDocumentLocations.ts
@@ -1,5 +1,4 @@
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {isObservable, map, of} from 'rxjs'
 import {startWith} from 'rxjs/operators'
 import {
@@ -9,6 +8,7 @@ import {
   useDocumentStore,
 } from 'sanity'
 
+import {useDeferredObservableValue} from '../core/util/useDeferredObservableValue'
 import {
   type DocumentLocationResolver,
   type DocumentLocationResolvers,
@@ -90,7 +90,7 @@ export function useDocumentLocations(props: {
     )
   }, [result, initialResult])
 
-  const {state, status} = useObservable(locationsResult$, initialResult)
+  const {state, status} = useDeferredObservableValue(locationsResult$, initialResult)
 
   return {
     state,

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/VersionsPreviewList.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/VersionsPreviewList.tsx
@@ -1,6 +1,5 @@
 import {Card, Flex, Stack, Text} from '@sanity/ui'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {
   getDocumentVariantType,
   getPreviewStateObservable,
@@ -19,6 +18,8 @@ import {
   useTranslation,
 } from 'sanity'
 import {styled} from 'styled-components'
+
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 
 const EllipsisText = styled(Text)`
   /* text-overflow: ellipsis;
@@ -59,7 +60,7 @@ const VersionItemPreview = ({
     snapshot,
     original,
     isLoading: previewIsLoading,
-  } = useObservable(previewStateObservable, {
+  } = useDeferredObservableValue(previewStateObservable, {
     snapshot: null,
     isLoading: true,
     original: null,

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/useReferringDocuments.ts
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/useReferringDocuments.ts
@@ -1,6 +1,5 @@
 import {type ClientError, type SanityClient} from '@sanity/client'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {combineLatest, concat, EMPTY, fromEvent, type Observable, of, timer} from 'rxjs'
 import {
   catchError,
@@ -19,6 +18,8 @@ import {
   useClient,
   useDocumentStore,
 } from 'sanity'
+
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 
 // this is used in place of `instanceof` so the matching can be more robust and
 // won't have any issues with dual packages etc
@@ -253,13 +254,13 @@ export function useReferringDocuments(documentId: string): ReferringDocuments {
     [documentId, versionedClient, documentStore],
   )
 
-  return useObservable(referringDocuments$, INITIAL_STATE)
+  return useDeferredObservableValue(referringDocuments$, INITIAL_STATE)
 }
 
 /**
-+ * Fetches the documents within the same dataset that reference the subject
-+ * document using the document store's `listenQuery`
-+ */
+ * Fetches the documents within the same dataset that reference the subject
+ * document using the document store's `listenQuery`
+ */
 function fetchInternalReferences(
   documentId: string,
   documentStore: DocumentStore,

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/CrossDatasetIncomingReference/CrossDatasetIncomingReferenceType.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/CrossDatasetIncomingReference/CrossDatasetIncomingReferenceType.tsx
@@ -1,6 +1,5 @@
 import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
 import {useCallback, useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {
   CommandList,
   type CommandListRenderItemCallback,
@@ -13,6 +12,7 @@ import {
 } from 'sanity'
 
 import {structureLocaleNamespace} from '../../../i18n'
+import {useDeferredObservableValue} from '../../../util/useDeferredObservableValue'
 import {INITIAL_STATE} from '../getIncomingReferences'
 import {INCOMING_REFERENCES_ITEM_HEIGHT, IncomingReferencesListContainer} from '../shared'
 import {type CrossDatasetIncomingReference} from '../types'
@@ -45,7 +45,7 @@ export function CrossDatasetIncomingReferenceType({
     [client, type, referenced.id, documentPreviewStore],
   )
 
-  const {documents, loading} = useObservable(references$, INITIAL_STATE)
+  const {documents, loading} = useDeferredObservableValue(references$, INITIAL_STATE)
 
   const schema = useSchema()
   const {t} = useTranslation(structureLocaleNamespace)

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx
@@ -2,7 +2,6 @@ import {AddIcon} from '@sanity/icons/Add'
 import {type SanityDocument} from '@sanity/types'
 import {Box, Card, Flex, Stack, Text, useToast} from '@sanity/ui'
 import {useCallback, useEffect, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
 import {
   CommandList,
   type CommandListRenderItemCallback,
@@ -22,6 +21,7 @@ import {
 import {Button} from '../../../ui-components/button/Button'
 import {structureLocaleNamespace} from '../../i18n'
 import {useDocumentPane} from '../../panes/document/useDocumentPane'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {AddIncomingReference} from './AddIncomingReference'
 import {CreateNewIncomingReference} from './CreateNewIncomingReference'
 import {getIncomingReferences, INITIAL_STATE} from './getIncomingReferences'
@@ -82,7 +82,7 @@ export function IncomingReferencesType({
     [documentPreviewStore, type.type, memoizedFilter, memoizedFilterParams, displayedId, getClient],
   )
 
-  const {documents, loading} = useObservable(references$, INITIAL_STATE)
+  const {documents, loading} = useDeferredObservableValue(references$, INITIAL_STATE)
 
   const schema = useSchema()
   const {t} = useTranslation(structureLocaleNamespace)

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/LinkToExistingPreview.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/LinkToExistingPreview.tsx
@@ -1,7 +1,6 @@
 import {type SchemaType} from '@sanity/types'
 import {type BadgeTone, Text} from '@sanity/ui'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {
   type DocumentPreviewStore,
   getPreviewStateObservable,
@@ -20,6 +19,8 @@ import {
   VersionInlineBadge,
 } from 'sanity'
 
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
+
 export interface LinkToExistingPreviewProps {
   documentPreviewStore: DocumentPreviewStore
   schemaType: SchemaType
@@ -32,6 +33,12 @@ const getPerspective = (id: string) => {
   if (isVersionId(id)) return [getVersionFromId(id) as string]
   if (isPublishedId(id)) return ['published']
   return ['raw']
+}
+
+const INITIAL_PREVIEW_STATE = {
+  snapshot: null,
+  isLoading: true,
+  original: null,
 }
 
 export function LinkToExistingPreview(props: LinkToExistingPreviewProps) {
@@ -48,11 +55,14 @@ export function LinkToExistingPreview(props: LinkToExistingPreviewProps) {
     )
   }, [props.documentPreviewStore, schemaType, value._id])
 
-  const {snapshot, original, isLoading} = useObservable(previewStateObservable, {
-    snapshot: null,
-    isLoading: true,
-    original: null,
-  })
+  // Identity-coherent deferral: when this component is reused for a new
+  // document id the live (loading) snapshot wins, so the previous document's
+  // title/media never renders beside the new document's version badge
+  // (derived from the live `value._id`).
+  const {snapshot, original, isLoading} = useDeferredObservableValue(
+    previewStateObservable,
+    INITIAL_PREVIEW_STATE,
+  )
 
   const badgeProps = useMemo(():
     | {kind: 'static'; tone: BadgeTone; text: string}

--- a/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
+++ b/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
@@ -6,7 +6,6 @@ import {
 } from '@sanity/types'
 import {Flex} from '@sanity/ui'
 import {type ComponentType, useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {
   type DocumentPresence,
   DocumentPreviewPresence,
@@ -22,6 +21,7 @@ import {
 } from 'sanity'
 
 import {TooltipDelayGroupProvider} from '../../../ui-components/tooltipDelayGroupProvider/TooltipDelayGroupProvider'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 
 export interface PaneItemPreviewProps {
   documentPreviewStore: DocumentPreviewStore
@@ -31,6 +31,12 @@ export interface PaneItemPreviewProps {
   schemaType: SchemaType
   sortOrder?: Pick<SortOrdering, 'by'>
   value: SanityDocument | {_id: string; _type: string}
+}
+
+const INITIAL_PREVIEW_STATE = {
+  snapshot: null,
+  isLoading: true,
+  original: null,
 }
 
 /**
@@ -67,15 +73,14 @@ export function PaneItemPreview(props: PaneItemPreviewProps) {
     )
   }, [props.documentPreviewStore, schemaType, value._id, perspectiveStack, viewOptions])
 
+  // Identity-coherent deferral: when a (recycled) list item switches to a new
+  // document id the live (loading) snapshot wins, so the previous document's
+  // title/media never renders next to the new document's version badges.
   const {
     snapshot,
     original,
     isLoading: previewIsLoading,
-  } = useObservable(previewStateObservable, {
-    snapshot: null,
-    isLoading: true,
-    original: null,
-  })
+  } = useDeferredObservableValue(previewStateObservable, INITIAL_PREVIEW_STATE)
 
   const isLoading = previewIsLoading
 

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -1,7 +1,7 @@
 import {useTelemetry} from '@sanity/telemetry/react'
 import {Box, Card, DialogProvider, Flex, Stack, Text, TextInput, useToast} from '@sanity/ui'
 import {useId, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {catchError, map, type Observable, of, startWith} from 'rxjs'
 import {type Role, useClient, useProjectId, useTranslation, useZIndex} from 'sanity'
 import {styled} from 'styled-components'
@@ -75,7 +75,10 @@ export function RequestPermissionDialog({
       )
   }, [projectId, client])
 
-  const requestedRole = useObservable(requestedRole$)
+  // Kept synchronous: `onSubmit` reads this value into the request body, so a
+  // deferred snapshot could submit the stale startWith('administrator') role
+  // after the observable has already resolved to 'editor'.
+  const requestedRole = useSyncObservable(requestedRole$)
 
   const onSubmit = () => {
     setIsSubmitting(true)

--- a/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/useRoleRequestsStatus.tsx
@@ -2,10 +2,11 @@ import {addWeeks} from 'date-fns/addWeeks'
 import {isAfter} from 'date-fns/isAfter'
 import {isBefore} from 'date-fns/isBefore'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {of} from 'rxjs'
 import {catchError, map, startWith} from 'rxjs/operators'
 import {type SanityClient, useClient, useProjectId} from 'sanity'
+
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 
 /** @internal */
 export interface AccessRequest {
@@ -41,7 +42,7 @@ export const useRoleRequestsStatus = () => {
     return checkRoleRequests(client, projectId)
   }, [client, projectId])
 
-  const {loading, error, status} = useObservable(checkRoleRequests$, LOADING_STATE)
+  const {loading, error, status} = useDeferredObservableValue(checkRoleRequests$, LOADING_STATE)
   return {data: status, loading, error}
 }
 

--- a/packages/sanity/src/structure/components/structureTool/StructureTool.tsx
+++ b/packages/sanity/src/structure/components/structureTool/StructureTool.tsx
@@ -13,6 +13,7 @@ import {useResolvedPanes} from '../../structureResolvers/useResolvedPanes'
 import {type PaneNode, type RouterPanes} from '../../types'
 import {useStructureTool} from '../../useStructureTool'
 import {PaneLayout} from '../pane/PaneLayout'
+import {getMaximizedPaneTransition} from './getMaximizedPaneTransition'
 import {NoDocumentTypesScreen} from './NoDocumentTypesScreen'
 import {StructureTitle} from './StructureTitle'
 
@@ -166,44 +167,24 @@ export const StructureTool = memo(function StructureTool({onPaneChange}: Structu
     navigate({panes: panesWithoutFocus}, {replace: true})
   }, [navigate, paneDataItems, routerState?.panes, setMaximizedPane])
 
-  // Manage maximised pane: sync with navigation and handle cleanup
+  // Manage maximised pane: sync with navigation and handle cleanup. The
+  // decision logic lives in `getMaximizedPaneTransition` (covered by unit
+  // tests); most importantly it skips transient snapshots (intent resolution,
+  // loading placeholders) so navigation churn cannot drop the maximize state.
   useEffect(() => {
-    const selectedIndex = paneDataItems.findIndex((pane) => pane.selected)
-    const prevSelectedIndex = previousSelectedIndexRef.current
-    previousSelectedIndexRef.current = selectedIndex
+    const transition = getMaximizedPaneTransition({
+      isResolvingIntent,
+      paneDataItems,
+      maximizedPane,
+      previousSelectedIndex: previousSelectedIndexRef.current,
+    })
+    if (transition.type === 'skip-transient') return
 
-    if (!maximizedPane) return
-
-    // Clear focus if the maximised pane is not a document pane (focus only works with documents)
-    if (maximizedPane.pane !== LOADING_PANE && maximizedPane.pane.type !== 'document') {
-      setMaximizedPane(null)
-      return
+    previousSelectedIndexRef.current = transition.selectedIndex
+    if (transition.type === 'set') {
+      setMaximizedPane(transition.pane)
     }
-
-    // When navigating in focus mode, update focus to follow the newly selected pane
-    // This ensures opening a document to the right works correctly even when they were opened previously
-    if (selectedIndex !== -1 && selectedIndex !== prevSelectedIndex) {
-      const selectedPane = paneDataItems[selectedIndex]
-      // Only set focus if the newly selected pane is a document pane
-      setMaximizedPane(selectedPane)
-
-      return
-    }
-
-    // Clean up or find fallback when maximised pane no longer exists
-    const isMaximizedPanePresent = paneDataItems.some((pane) => pane.key === maximizedPane.key)
-
-    if (!isMaximizedPanePresent) {
-      const fallbackPane = paneDataItems.find(
-        (pane) =>
-          pane.groupIndex === maximizedPane.groupIndex &&
-          pane.siblingIndex === maximizedPane.siblingIndex &&
-          pane.pane !== LOADING_PANE &&
-          pane.pane.type === 'document',
-      )
-      setMaximizedPane(fallbackPane || null)
-    }
-  }, [maximizedPane, paneDataItems, setMaximizedPane])
+  }, [isResolvingIntent, maximizedPane, paneDataItems, setMaximizedPane])
 
   if (!hasDefinedDocumentTypes) {
     return <NoDocumentTypesScreen />

--- a/packages/sanity/src/structure/components/structureTool/__tests__/getMaximizedPaneTransition.test.ts
+++ b/packages/sanity/src/structure/components/structureTool/__tests__/getMaximizedPaneTransition.test.ts
@@ -1,0 +1,214 @@
+import {describe, expect, it} from 'vitest'
+
+import {LOADING_PANE} from '../../../constants'
+import {type PaneNode} from '../../../types'
+import {getMaximizedPaneTransition} from '../getMaximizedPaneTransition'
+
+/**
+ * Covers the "maximize-sync effect skips transient snapshots" claim from the
+ * pane-tree-stays-live design: while intent resolution is in flight or
+ * loading placeholders replace real panes, the pane set is transient, and
+ * acting on it could drop the maximize state (the maximized key appears
+ * missing) or follow the wrong pane. The settled-snapshot decisions (follow
+ * the moved selection, fall back when the maximized pane disappears) are
+ * covered alongside, so regressions in either direction are caught.
+ */
+
+interface TestPaneData {
+  key: string
+  groupIndex: number
+  siblingIndex: number
+  selected: boolean
+  pane: PaneNode | typeof LOADING_PANE
+}
+
+function documentPane(key: string, options: Partial<TestPaneData> = {}): TestPaneData {
+  return {
+    key,
+    groupIndex: 0,
+    siblingIndex: 0,
+    selected: false,
+    pane: {id: key, type: 'document'} as PaneNode,
+    ...options,
+  }
+}
+
+function listPane(key: string, options: Partial<TestPaneData> = {}): TestPaneData {
+  return {
+    key,
+    groupIndex: 0,
+    siblingIndex: 0,
+    selected: false,
+    pane: {id: key, type: 'list'} as PaneNode,
+    ...options,
+  }
+}
+
+function loadingPane(key: string, options: Partial<TestPaneData> = {}): TestPaneData {
+  return {
+    key,
+    groupIndex: 0,
+    siblingIndex: 0,
+    selected: false,
+    pane: LOADING_PANE,
+    ...options,
+  }
+}
+
+describe('getMaximizedPaneTransition', () => {
+  describe('transient snapshots are skipped (maximize state survives navigation churn)', () => {
+    it('skips while intent resolution is in flight', () => {
+      const maximized = documentPane('doc-a')
+      expect(
+        getMaximizedPaneTransition({
+          isResolvingIntent: true,
+          // An intent state has no router panes, so the set collapses to the
+          // root — the maximized key appears missing. Acting here would drop
+          // the maximize state.
+          paneDataItems: [listPane('root', {selected: true})],
+          maximizedPane: maximized,
+          previousSelectedIndex: 1,
+        }),
+      ).toEqual({type: 'skip-transient'})
+    })
+
+    it('skips while any pane is a loading placeholder', () => {
+      const maximized = documentPane('doc-a')
+      expect(
+        getMaximizedPaneTransition({
+          isResolvingIntent: false,
+          // Mid-navigation the target pane resolves asynchronously: the real
+          // pane is temporarily replaced by a loading placeholder while the
+          // selection has already moved.
+          paneDataItems: [listPane('root'), loadingPane('loading-b', {selected: true})],
+          maximizedPane: maximized,
+          previousSelectedIndex: 1,
+        }),
+      ).toEqual({type: 'skip-transient'})
+    })
+
+    it('churn sequence: maximize state survives a loading snapshot and follows the settled selection', () => {
+      // The claim, as a sequence. A document is maximized; the user opens a
+      // referenced document to the right. The pane stream first emits a
+      // transient snapshot (loading placeholder), then the settled one.
+      const docA = documentPane('doc-a', {groupIndex: 1, selected: true})
+      let previousSelectedIndex = 1
+
+      // Settled baseline: doc-a selected and maximized.
+      const baseline = getMaximizedPaneTransition({
+        isResolvingIntent: false,
+        paneDataItems: [listPane('root'), docA],
+        maximizedPane: docA,
+        previousSelectedIndex,
+      })
+      expect(baseline).toEqual({type: 'keep', selectedIndex: 1})
+      previousSelectedIndex = 1
+
+      // Transient snapshot: doc-b still resolving. Without the skip, the
+      // "follow selection" branch would run against the placeholder and
+      // maximize a loading pane (or the cleanup branch could drop the state).
+      const transient = getMaximizedPaneTransition({
+        isResolvingIntent: false,
+        paneDataItems: [
+          listPane('root'),
+          documentPane('doc-a', {groupIndex: 1}),
+          loadingPane('loading-doc-b', {groupIndex: 2, selected: true}),
+        ],
+        maximizedPane: docA,
+        previousSelectedIndex,
+      })
+      expect(transient).toEqual({type: 'skip-transient'})
+      // skip-transient means the previous selected index is NOT committed —
+      // the settled snapshot below is compared against the settled baseline.
+
+      // Settled snapshot: doc-b resolved and selected. The selection moved
+      // (1 -> 2 against the last settled index), so maximize follows it.
+      const docB = documentPane('doc-b', {groupIndex: 2, selected: true})
+      const settled = getMaximizedPaneTransition({
+        isResolvingIntent: false,
+        paneDataItems: [listPane('root'), documentPane('doc-a', {groupIndex: 1}), docB],
+        maximizedPane: docA,
+        previousSelectedIndex,
+      })
+      expect(settled).toEqual({type: 'set', pane: docB, selectedIndex: 2})
+    })
+  })
+
+  describe('settled snapshots', () => {
+    it('keeps (and records the selected index) when nothing is maximized', () => {
+      expect(
+        getMaximizedPaneTransition({
+          isResolvingIntent: false,
+          paneDataItems: [listPane('root'), documentPane('doc-a', {selected: true})],
+          maximizedPane: null,
+          previousSelectedIndex: -1,
+        }),
+      ).toEqual({type: 'keep', selectedIndex: 1})
+    })
+
+    it('clears a non-document maximized pane', () => {
+      const maximizedList = listPane('some-list')
+      expect(
+        getMaximizedPaneTransition({
+          isResolvingIntent: false,
+          paneDataItems: [listPane('root', {selected: true})],
+          maximizedPane: maximizedList,
+          previousSelectedIndex: 0,
+        }),
+      ).toEqual({type: 'set', pane: null, selectedIndex: 0})
+    })
+
+    it('follows the newly selected pane when the selection moves', () => {
+      const docA = documentPane('doc-a', {groupIndex: 1})
+      const docB = documentPane('doc-b', {groupIndex: 2, selected: true})
+      expect(
+        getMaximizedPaneTransition({
+          isResolvingIntent: false,
+          paneDataItems: [listPane('root'), docA, docB],
+          maximizedPane: docA,
+          previousSelectedIndex: 1,
+        }),
+      ).toEqual({type: 'set', pane: docB, selectedIndex: 2})
+    })
+
+    it('keeps the maximized pane when the selection has not moved', () => {
+      const docA = documentPane('doc-a', {groupIndex: 1, selected: true})
+      expect(
+        getMaximizedPaneTransition({
+          isResolvingIntent: false,
+          paneDataItems: [listPane('root'), docA],
+          maximizedPane: docA,
+          previousSelectedIndex: 1,
+        }),
+      ).toEqual({type: 'keep', selectedIndex: 1})
+    })
+
+    it('falls back to the document pane at the same position when the maximized pane disappears', () => {
+      const replacement = documentPane('doc-replacement', {
+        groupIndex: 1,
+        siblingIndex: 0,
+        selected: true,
+      })
+      expect(
+        getMaximizedPaneTransition({
+          isResolvingIntent: false,
+          paneDataItems: [listPane('root'), replacement],
+          maximizedPane: documentPane('doc-gone', {groupIndex: 1, siblingIndex: 0}),
+          // Selection index unchanged, so the follow branch does not apply.
+          previousSelectedIndex: 1,
+        }),
+      ).toEqual({type: 'set', pane: replacement, selectedIndex: 1})
+    })
+
+    it('clears when the maximized pane disappears and no document pane occupies its position', () => {
+      expect(
+        getMaximizedPaneTransition({
+          isResolvingIntent: false,
+          paneDataItems: [listPane('root', {selected: true})],
+          maximizedPane: documentPane('doc-gone', {groupIndex: 1, siblingIndex: 0}),
+          previousSelectedIndex: 0,
+        }),
+      ).toEqual({type: 'set', pane: null, selectedIndex: 0})
+    })
+  })
+})

--- a/packages/sanity/src/structure/components/structureTool/getMaximizedPaneTransition.ts
+++ b/packages/sanity/src/structure/components/structureTool/getMaximizedPaneTransition.ts
@@ -1,0 +1,87 @@
+import {LOADING_PANE} from '../../constants'
+import {type PaneNode} from '../../types'
+
+/** The subset of `PaneData` the maximize-sync decision depends on. */
+interface MaximizablePaneData {
+  key: string
+  groupIndex: number
+  siblingIndex: number
+  selected: boolean
+  pane: PaneNode | typeof LOADING_PANE
+}
+
+/** @internal */
+export type MaximizedPaneTransition<TPaneData extends MaximizablePaneData> =
+  /**
+   * The snapshot is transient (intent resolution in flight or loading
+   * placeholders present): do nothing — don't even record the selected index,
+   * so the next settled snapshot is compared against the last settled one.
+   */
+  | {type: 'skip-transient'}
+  /** Settled snapshot, no maximize change: record the selected index only. */
+  | {type: 'keep'; selectedIndex: number}
+  /** Settled snapshot: record the selected index and update the maximized pane. */
+  | {type: 'set'; pane: TPaneData | null; selectedIndex: number}
+
+/**
+ * Pure decision for `StructureTool`'s maximize-sync effect, extracted so the
+ * "navigation churn cannot drop the maximize state" behavior is directly
+ * testable.
+ *
+ * While pane or intent resolution is in flight the pane set is transient:
+ * loading placeholders replace real panes, and intent states have no router
+ * panes at all (collapsing the set to the root). Acting on such a snapshot
+ * could drop the maximize state (the maximized key appears missing) or follow
+ * the wrong pane — so transient snapshots are skipped wholesale.
+ *
+ * On settled snapshots:
+ * - a non-document maximized pane clears the maximize state (focus only works
+ *   with documents)
+ * - if the selection moved, the maximize state follows the newly selected pane
+ * - if the maximized pane no longer exists, fall back to the document pane at
+ *   the same group/sibling position, or clear
+ *
+ * @internal
+ */
+export function getMaximizedPaneTransition<TPaneData extends MaximizablePaneData>(options: {
+  isResolvingIntent: boolean
+  paneDataItems: TPaneData[]
+  maximizedPane: TPaneData | null
+  previousSelectedIndex: number
+}): MaximizedPaneTransition<TPaneData> {
+  const {isResolvingIntent, paneDataItems, maximizedPane, previousSelectedIndex} = options
+
+  if (isResolvingIntent || paneDataItems.some((pane) => pane.pane === LOADING_PANE)) {
+    return {type: 'skip-transient'}
+  }
+
+  const selectedIndex = paneDataItems.findIndex((pane) => pane.selected)
+
+  if (!maximizedPane) return {type: 'keep', selectedIndex}
+
+  // Clear focus if the maximised pane is not a document pane (focus only works with documents)
+  if (maximizedPane.pane !== LOADING_PANE && maximizedPane.pane.type !== 'document') {
+    return {type: 'set', pane: null, selectedIndex}
+  }
+
+  // When navigating in focus mode, update focus to follow the newly selected pane
+  // This ensures opening a document to the right works correctly even when they were opened previously
+  if (selectedIndex !== -1 && selectedIndex !== previousSelectedIndex) {
+    return {type: 'set', pane: paneDataItems[selectedIndex], selectedIndex}
+  }
+
+  // Clean up or find fallback when maximised pane no longer exists
+  const isMaximizedPanePresent = paneDataItems.some((pane) => pane.key === maximizedPane.key)
+  if (!isMaximizedPanePresent) {
+    const fallbackPane = paneDataItems.find(
+      (pane) =>
+        pane.groupIndex === maximizedPane.groupIndex &&
+        pane.siblingIndex === maximizedPane.siblingIndex &&
+        pane.pane !== LOADING_PANE &&
+        pane.pane.type === 'document',
+    )
+    return {type: 'set', pane: fallbackPane || null, selectedIndex}
+  }
+
+  return {type: 'keep', selectedIndex}
+}

--- a/packages/sanity/src/structure/panes/document/documentPanel/banners/ReferenceChangedBanner.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/banners/ReferenceChangedBanner.tsx
@@ -5,7 +5,7 @@ import {type KeyedSegment, type Reference} from '@sanity/types'
 import {Text} from '@sanity/ui'
 import {fromString as pathFromString, get as pathGet} from '@sanity/util/paths'
 import {memo, useCallback, useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {concat, type Observable, of} from 'rxjs'
 import {debounceTime, map} from 'rxjs/operators'
 import {
@@ -114,7 +114,10 @@ export const ReferenceChangedBanner = memo(() => {
         ),
     )
   }, [selectedPerspectiveName, documentPreviewStore, parentId, parentRefPath])
-  const referenceInfo = useObservable(referenceInfoObservable, {loading: true})
+  // Kept synchronous: `handleReloadReference` navigates to `refValue` from
+  // this snapshot, so a deferred value could point the reload action at a
+  // stale parent reference.
+  const referenceInfo = useSyncObservable(referenceInfoObservable, {loading: true})
 
   const handleReloadReference = useCallback(() => {
     if (referenceInfo.loading) return

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/documentGroupInventoryHint/DocumentGroupInventoryHint.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/documentGroupInventoryHint/DocumentGroupInventoryHint.tsx
@@ -1,12 +1,12 @@
 import {InfoOutlineIcon} from '@sanity/icons/InfoOutline'
 import {useTelemetry} from '@sanity/telemetry/react'
 import {Flex, Text} from '@sanity/ui'
-import {useMemo, type ComponentType} from 'react'
-import {useObservable} from 'react-rx'
+import {type ComponentType, useMemo} from 'react'
 import {useTranslation} from 'sanity'
 import {styled, css} from 'styled-components'
 
 import {structureLocaleNamespace} from '../../../../../i18n'
+import {useDeferredObservableValue} from '../../../../../util/useDeferredObservableValue'
 import {useDocumentPane} from '../../../useDocumentPane'
 import {DocumentGroupInventoryHintPressed} from '../__telemetry__/documentGroupInventoryHint.telemetry'
 import {browserStorageAdapter, hintStatus, suppressHint} from './hintStatus'
@@ -15,7 +15,7 @@ export const DocumentGroupInventoryHint: ComponentType = () => {
   const {t} = useTranslation(structureLocaleNamespace)
   const {setIsDocumentGroupInventoryActive} = useDocumentPane()
   const telemetry = useTelemetry()
-  const status = useObservable(useMemo(() => hintStatus(browserStorageAdapter), []))
+  const status = useDeferredObservableValue(useMemo(() => hintStatus(browserStorageAdapter), []))
 
   if (status === 'inactive') {
     return null

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/EventsInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/EventsInspector.tsx
@@ -2,7 +2,7 @@ import {diffInput, wrap} from '@sanity/diff'
 import {BoundaryElementProvider, Box, Card, Flex, Spinner, Stack, Text} from '@sanity/ui'
 import {motion} from 'motion/react'
 import {type ReactElement, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {
   ChangeFieldWrapper,
   ChangeList,
@@ -143,11 +143,15 @@ export function EventsInspector({showChanges}: {showChanges: boolean}): ReactEle
 
   const isComparingCurrent = !revision?.revisionId
   const changesList$ = useMemo(() => getChangesList(), [getChangesList])
+  // Kept synchronous: the diff must stay coherent with the synchronous
+  // `events` / `revision` / `sinceRevision` values it is derived from, and it
+  // feeds `undoChange` revert patches — a stale deferred diff could build
+  // revert writes against outdated document state.
   const {
     diff,
     loading: diffLoading,
     error: diffError,
-  } = useObservable(changesList$, DIFF_INITIAL_VALUE)
+  } = useSyncObservable(changesList$, DIFF_INITIAL_VALUE)
 
   const {t} = useTranslation('studio')
 

--- a/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/IncomingReferencesList.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/IncomingReferencesList.tsx
@@ -1,7 +1,6 @@
 import {type SanityDocument} from '@sanity/types'
 import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
 import {useCallback, useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {map} from 'rxjs'
 import {
   CommandList,
@@ -26,6 +25,7 @@ import {
   IncomingReferencesListContainer,
 } from '../../../../components/incomingReferencesDecoration/shared'
 import {structureLocaleNamespace} from '../../../../i18n'
+import {useDeferredObservableValue} from '../../../../util/useDeferredObservableValue'
 import {useDocumentPaneInfo} from '../../useDocumentPaneInfo'
 import {IncomingReferenceDocument} from './IncomingReferenceDocument'
 
@@ -126,7 +126,7 @@ export function IncomingReferencesList() {
       ),
     [documentId, documentPreviewStore, getClient],
   )
-  const references = useObservable(references$, null)
+  const references = useDeferredObservableValue(references$, null)
 
   const crossDatasetIncomingRefs$ = useMemo(
     () =>
@@ -152,7 +152,7 @@ export function IncomingReferencesList() {
     [client, documentId, documentPreviewStore],
   )
 
-  const crossDatasetRefs = useObservable(crossDatasetIncomingRefs$, null)
+  const crossDatasetRefs = useDeferredObservableValue(crossDatasetIncomingRefs$, null)
 
   const renderSameDatasetItem = useCallback<CommandListRenderItemCallback<SanityDocument>>(
     (document) => <IncomingReferenceDocument document={document} referenceToId={documentId} />,

--- a/packages/sanity/src/structure/panes/document/usePreviewUrl.ts
+++ b/packages/sanity/src/structure/panes/document/usePreviewUrl.ts
@@ -1,9 +1,10 @@
 import {type SanityDocument} from '@sanity/types'
 import {useEffect, useMemo} from 'react'
-import {useObservable} from 'react-rx'
 import {BehaviorSubject, from, of} from 'rxjs'
 import {catchError, debounceTime, distinctUntilChanged, switchMap} from 'rxjs/operators'
 import {isRecord, useSource} from 'sanity'
+
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 
 const isSanityDocument = (value: unknown): value is SanityDocument =>
   isRecord(value) && typeof value._id === 'string' && typeof value._type === 'string'
@@ -37,5 +38,5 @@ export function usePreviewUrl(value: Partial<SanityDocument> | undefined): strin
     )
   }, [resolveProductionUrl, subject])
 
-  return useObservable(resolvedUrlObservable)
+  return useDeferredObservableValue(resolvedUrlObservable)
 }

--- a/packages/sanity/src/structure/panes/documentList/useDocumentList.ts
+++ b/packages/sanity/src/structure/panes/documentList/useDocumentList.ts
@@ -8,7 +8,6 @@ import {
 import {useTelemetry} from '@sanity/telemetry/react'
 import {observableCallback} from 'observable-callback'
 import {useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
 import {concat, fromEvent, merge, NEVER, of, timer} from 'rxjs'
 import {
   filter,
@@ -30,6 +29,7 @@ import {
   useWorkspace,
 } from 'sanity'
 
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {DocumentListLoadTimeMeasured} from './__telemetry__/documentListSearch.telemetry'
 import {DEFAULT_ORDERING, FULL_LIST_LIMIT, PARTIAL_PAGE_LIMIT} from './constants'
 import {findStaticTypesInFilter, removePublishedWithDrafts} from './helpers'
@@ -286,7 +286,7 @@ export function useDocumentList(opts: UseDocumentListOpts): UseDocumentListHookV
     isRetrying,
     autoRetry,
     retryCount,
-  } = useObservable(queryResults$, INITIAL_QUERY_STATE)
+  } = useDeferredObservableValue(queryResults$, INITIAL_QUERY_STATE)
 
   return {
     error,

--- a/packages/sanity/src/structure/panes/loading/LoadingPane.tsx
+++ b/packages/sanity/src/structure/panes/loading/LoadingPane.tsx
@@ -1,6 +1,5 @@
 import {_raf2, type CardTone, Flex} from '@sanity/ui'
 import {memo, useEffect, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
 import {isObservable, type Observable, of} from 'rxjs'
 import {map} from 'rxjs/operators'
 import {Delay, LoadingBlock, useTranslation} from 'sanity'
@@ -9,6 +8,7 @@ import {styled} from 'styled-components'
 import {Pane} from '../../components/pane/Pane'
 import {PaneContent} from '../../components/pane/PaneContent'
 import {structureLocaleNamespace} from '../../i18n'
+import {useDeferredObservableValue} from '../../util/useDeferredObservableValue'
 import {getWaitMessages, type WaitMessage} from './getWaitMessages'
 
 interface LoadingPaneProps {
@@ -79,7 +79,7 @@ export const LoadingPane = memo((props: LoadingPaneProps) => {
     )
   }, [resolvedMessage, t, defaultMessage])
 
-  const currentMessage = useObservable(message$, defaultMessage)
+  const currentMessage = useDeferredObservableValue(message$, defaultMessage)
 
   const [contentElement, setContentElement] = useState<HTMLDivElement | null>(null)
   const [mounted, setMounted] = useState(false)

--- a/packages/sanity/src/structure/structureResolvers/__tests__/useResolvedPanes.test.tsx
+++ b/packages/sanity/src/structure/structureResolvers/__tests__/useResolvedPanes.test.tsx
@@ -1,4 +1,5 @@
-import {act, renderHook, waitFor} from '@testing-library/react'
+import {act, render, renderHook, waitFor} from '@testing-library/react'
+import {useEffect, useState} from 'react'
 import {Subject} from 'rxjs'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
@@ -535,6 +536,51 @@ describe('useResolvedPanes', () => {
       expect(result.current.routerPanes[1]).toEqual([
         {id: 'doc-123', params: {}, payload: undefined},
       ])
+    })
+  })
+
+  describe('live pane data (not deferred)', () => {
+    it('commits a new pane emission on the first frame, even when urgent updates land in the same batch', async () => {
+      // Guards the "pane tree stays live" behavior: the pane data must be
+      // read synchronously (not via useDeferredValue). If it were deferred,
+      // the first committed frame after a pane emission batched with an
+      // urgent update would still show the PREVIOUS pane tree — and under
+      // continuous urgent updates (presence/sync/validation on a fresh
+      // draft), each interruption restarts the deferred catch-up, so that
+      // stale frame can repeat indefinitely: the livelock this test pins the
+      // first frame of.
+      const frames: {tick: number; itemIds: string[]}[] = []
+      let bumpTick: (() => void) | null = null
+
+      function LiveRenderProbe() {
+        const {paneDataItems} = useResolvedPanes()
+        const [tick, setTick] = useState(0)
+        useEffect(() => {
+          bumpTick = () => setTick((current) => current + 1)
+        }, [])
+        frames.push({tick, itemIds: paneDataItems.map((item) => item.itemId)})
+        return null
+      }
+      render(<LiveRenderProbe />)
+
+      act(() => {
+        resolvedPanesSubject.next([createMockListPane()])
+      })
+      await waitFor(() => expect(frames[frames.length - 1].itemIds).toEqual(['root']))
+
+      // Model navigation: the pane stream emits the new tree while an urgent
+      // update (like a presence/sync emission re-rendering the tree) lands in
+      // the same batch.
+      act(() => {
+        resolvedPanesSubject.next([createMockListPane(), createMockDocumentPane()])
+        bumpTick!()
+      })
+
+      // The frame carrying the urgent update must already show the new pane
+      // tree. A deferred pane read would commit {tick: 1, itemIds: ['root']}
+      // first — the stale tree under fresh urgent state.
+      expect(frames).toContainEqual({tick: 1, itemIds: ['root', 'doc-123']})
+      expect(frames).not.toContainEqual({tick: 1, itemIds: ['root']})
     })
   })
 

--- a/packages/sanity/src/structure/structureResolvers/useResolvedPanes.ts
+++ b/packages/sanity/src/structure/structureResolvers/useResolvedPanes.ts
@@ -1,5 +1,5 @@
 import {useEffect, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {map, ReplaySubject} from 'rxjs'
 import {type RouterState, useRouter} from 'sanity/router'
 
@@ -118,9 +118,14 @@ export function useResolvedPanes(): Panes {
     [rootPaneNode, routerPanesStream, structureContext],
   )
 
-  // Stream errors are re-thrown by `useObservable` during render, so they bubble to the
+  // Stream errors are re-thrown by `useSyncObservable` during render, so they bubble to the
   // nearest error boundary without any explicit handling here.
-  const data = useObservable(data$, INITIAL_DATA)
+  // NOTE: the pane data is intentionally not deferred (`useDeferredValue`): the
+  // structural pane tree only changes on navigation and must always commit.
+  // Deferring it lets continuous urgent updates (presence, sync, validation)
+  // starve the catch-up render indefinitely, leaving a stale pane tree on
+  // screen (seen as a livelock on slower browsers).
+  const data = useSyncObservable(data$, INITIAL_DATA)
 
   useEffect(
     function maybeOpenDefaultPanes() {

--- a/packages/sanity/src/structure/structureResolvers/useResolvedPanesList.ts
+++ b/packages/sanity/src/structure/structureResolvers/useResolvedPanesList.ts
@@ -3,7 +3,7 @@ import {ResolvedPanesContext} from 'sanity/_singletons'
 
 import {type Panes} from './useResolvedPanes'
 
-const DEFAULT_VALUE = {
+const DEFAULT_VALUE: Panes = {
   paneDataItems: [],
   routerPanes: [],
   resolvedPanes: [],

--- a/packages/sanity/src/structure/useStructureToolSetting.ts
+++ b/packages/sanity/src/structure/useStructureToolSetting.ts
@@ -1,5 +1,5 @@
-import {useCallback, useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {useCallback, useDeferredValue, useMemo} from 'react'
+import {useObservable as useSyncObservable} from 'react-rx'
 import {map} from 'rxjs/operators'
 import {type KeyValueStoreValue, useKeyValueStore} from 'sanity'
 
@@ -24,16 +24,28 @@ export function useStructureToolSetting<ValueType>(
     )
   }, [defaultValue, keyValueStore, keyValueStoreKey])
 
-  const value = useObservable(value$, defaultValue) as ValueType
+  // Keep the immediate store value for write-side equality checks; only defer
+  // the value returned for rendering so a stale deferred snapshot cannot skip
+  // (or redundantly issue) a setKey while the store has already moved on. The
+  // rendered value defers identity and value as one snapshot (reusing the
+  // single subscription) so a storage key change never renders the previous
+  // key's value.
+  const observedValue = useSyncObservable(value$, defaultValue) as ValueType
+  const snapshot = useMemo(
+    () => ({observable: value$, value: observedValue}),
+    [value$, observedValue],
+  )
+  const deferredSnapshot = useDeferredValue(snapshot)
+  const value = deferredSnapshot.observable === value$ ? deferredSnapshot.value : observedValue
   const set = useCallback(
     async (newValue: ValueType | null) => {
-      if (newValue !== value) {
+      if (newValue !== observedValue) {
         // A `null` value clears the stored entry: `getKey` coerces the empty
         // value back to `null`, so reads fall through to `defaultValue`.
         await keyValueStore.setKey(keyValueStoreKey, newValue as KeyValueStoreValue)
       }
     },
-    [keyValueStore, keyValueStoreKey, value],
+    [keyValueStore, keyValueStoreKey, observedValue],
   )
 
   return useMemo(() => [value, set], [set, value])

--- a/packages/sanity/src/structure/util/useDeferredObservableValue.ts
+++ b/packages/sanity/src/structure/util/useDeferredObservableValue.ts
@@ -1,0 +1,41 @@
+import {useDeferredValue, useMemo} from 'react'
+import {useObservable as useSyncObservable} from 'react-rx'
+import {type Observable} from 'rxjs'
+
+/** @internal */
+export interface UseDeferredObservableValue {
+  <T>(observable: Observable<T>): T | undefined
+  <T>(observable: Observable<T>, initialValue: T): T
+}
+
+/**
+ * Structure-local twin of `core/util/useDeferredObservableValue`: the
+ * boundaries policy only lets `structure` import core code through the public
+ * `sanity` export surface, and this helper is intentionally not part of that
+ * surface. Keep both implementations in sync.
+ *
+ * Subscribes to an observable like `useSyncObservable`, but returns a deferred
+ * snapshot of its value (via `useDeferredValue`) so high-frequency emissions
+ * don't force synchronous, blocking renders. The deferred snapshot is
+ * identity-coherent: when the observable identity changes (e.g. it is
+ * memoized on a document id that just changed) the hook falls back to the
+ * live value so the previous identity's value never renders under the new
+ * one.
+ *
+ * Values that feed writes, imperative reads, or gating logic paired with live
+ * state should use `useSyncObservable` directly instead of this hook.
+ *
+ * @internal
+ */
+// Declared as a typed const rather than overloaded function declarations: the
+// React Compiler babel transform fails on overloaded hook declarations with a
+// "duplicate declaration" error.
+export const useDeferredObservableValue: UseDeferredObservableValue =
+  function useDeferredObservableValue<T>(observable: Observable<T>, initialValue?: T) {
+    const value = useSyncObservable(observable, initialValue as T)
+    // Defer identity and value as one snapshot so they can never tear (the
+    // deferred value always belongs to the deferred observable).
+    const snapshot = useMemo(() => ({observable, value}), [observable, value])
+    const deferredSnapshot = useDeferredValue(snapshot)
+    return deferredSnapshot.observable === observable ? deferredSnapshot.value : value
+  } as UseDeferredObservableValue


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`useObservable` (via `useSyncExternalStore`) forces synchronous React updates. For presence, permissions, previews, and other chrome that is *not* a controlled input value, that work can yield under load. Pairing with `useDeferredValue` is the established pattern in this codebase (see `createHookFromObservableFactory` tests / document action headers).

### `useSyncObservable` import alias

Every react-rx `useObservable` import is aliased as `useSyncObservable` (`import {useObservable as useSyncObservable} from 'react-rx'`). Call sites then read as either `useSyncObservable(...)` (intentionally synchronous) or `useDeferredObservableValue(...)` (intentionally deferred), which makes the sync-vs-deferred decision explicit at each site and keeps future deltas easy to follow. `useObservableEvent` imports are untouched.

### `useDeferredObservableValue`

Review iterations kept surfacing the same class of bug in individual files: a bare `useDeferredValue(useObservable(...))` can keep the previous identity's value rendered after the observable (memoized on a document id or similar) has already changed. The fix is structural: deferred observable reads go through an internal `useDeferredObservableValue` helper, which defers identity and value as one snapshot and falls back to the live value when the observable identity changes — so the previous identity's value never renders under the new one. Unit tests cover both the deferral and the identity reset. `createHookFromObservableFactory` keeps its own inline variant because it additionally throws errors from the live snapshot; both error semantics are pinned by mutation-verified tests (no stale frame commits between an observable error and the boundary catch, and recovery after an errored arg renders the new arg cleanly).

The helper is **not part of the public export surface**: core and presentation import it relatively, `structure` has a local twin (the boundaries policy only lets structure reach core code through the public exports), and `@sanity/vision` uses a bare `useDeferredValue` directly since its dataset list is keyed to a stable client with no identity churn.

### Pane tree stays live

The structural pane tree (`useResolvedPanes` / `StructureTool`) is intentionally **not** deferred. Deferring it livelocked on slower engines: after opening a referenced document, continuous urgent updates on the fresh draft (presence/sync/validation emissions) kept interrupting the deferred catch-up render, so the pane tree could render a stale snapshot indefinitely — diagnosed with runtime instrumentation reproducing the firefox `expanded-document` e2e failure locally, where the live maximize state was correct but the rendered tree never caught up. Pane structure changes only on navigation, so a deferral buys nothing there anyway. The maximize-sync effect also skips transient snapshots (intent resolution, loading placeholders) so navigation churn can't drop the maximize state.

Both behaviors are covered by mutation-verified unit tests: a live-render test in `useResolvedPanes.test.tsx` asserts a pane emission batched with an urgent update commits the new tree on the first frame (re-deferring the pane read fails it — that stale frame is the livelock's first frame), and the maximize-sync decision logic is extracted behavior-identically into `getMaximizedPaneTransition` with tests for the transient skips (including the churn sequence), selection following, and fallback cleanup.

### Kept fully synchronous

Values that feed controlled form inputs, write-side logic, identity/auth gates, imperative reads, event streams, or one-shot boot state stay synchronous (`useEditState`, `useInitialValue`, `useValidationStatus`, history/events diffs, document operations, auth, etc.).

`useValidationStatus` stays synchronous because it is a write-side gate, not just display: `PublishAction` enables publish from `hasValidationErrors` and fires `doPublish()` once `isValidating` is false and the snapshot revision matches the live edit revision — and reference-driven revalidation re-runs validation without changing the revision, so a stale deferred "valid" snapshot would pass that guard while live validation is discovering errors (identity-coherent deferral can't help: the observable identity is stable while the pane is mounted). A mutation-verified test in `hooks/__tests__/useValidationStatus.test.tsx` fails if the hook is ever deferred again.

Per the review follow-up on `useActiveReleases` / `useAllReleases` / `useAllVariants` ("we can defer those, but it's ok to keep them sync now. We can have a follow up to verify that"): `perspective/__tests__/deferralSafety.test.tsx` answers this with executable proof. For each hook, a sync/deferred test pair drives the same create-then-select update: the sync (current) code never commits a frame pairing the new selection with an unresolved release/variant identity, while a deferred counterfactual (the exact hook body with only the read deferred, even through `useDeferredObservableValue`) provably commits that torn frame — and a deferred `useAllReleases` disagrees with the sync `useActiveReleases` about the same store snapshot. The store observables have stable identity, so the identity-coherent helper cannot prevent this class of tear; the lists pair with live router state. Conclusion: these three stay synchronous, with tests guarding the reasoning.

### Test stabilization

Two CI-blocking flakes with timing-margin root causes (reproduced across branches on identical trees) are hardened: `documentList.spec.ts` now uses actionability-checked clicks instead of `force: true` and gives its request waiters explicit timeouts attached right before the triggering interaction; the full-screen multi-nested PTE toolbar browser test gets explicit 90s headroom (it needs ~25s on a healthy firefox runner against the default 30s ceiling).

## What to review

- `useDeferredObservableValue` and call sites that opted into deferral
- The `useSyncObservable` alias rename (mechanical; import specifier + call sites only)
- Structure pane tree remaining live: the `useResolvedPanes` live-render test and the `getMaximizedPaneTransition` extraction (behavior-identical refactor of the `StructureTool` effect)
- `perspective/__tests__/deferralSafety.test.tsx` — the sync/deferred proof pairs for the releases/variants hooks

## Testing

- Unit tests for `useDeferredObservableValue` identity reset
- `deferralSafety.test.tsx` proving the releases/variants hooks must stay synchronous (sync never tears; deferred counterfactuals do)
- `createHookFromObservableFactory` error semantics (live-snapshot throw, post-error recovery), mutation-verified
- `useResolvedPanes` live pane rendering + `getMaximizedPaneTransition` transient-skip decisions, mutation-verified
- `useValidationStatus` synchronous-read regression test, mutation-verified
- Existing vitest / e2e coverage for deferred chrome paths

## Notes for release

N/A – Internal only (performance / reactivity plumbing; no user-facing API change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-945f3acf-be4e-403b-b8a9-c5d18be7b5ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-945f3acf-be4e-403b-b8a9-c5d18be7b5ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

