### PR TITLE
fix(core): update copying variants to different releases from context menu.

### DIFF
--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -4,7 +4,7 @@ import {FeedbackIcon} from '@sanity/icons/Feedback'
 import {SearchIcon} from '@sanity/icons/Search'
 import {TrashIcon} from '@sanity/icons/Trash'
 import {type SanityDocumentLike} from '@sanity/types'
-import {Card, Flex, PortalProvider, Stack, Text, TextInput} from '@sanity/ui'
+import {Flex, PortalProvider, Stack, Text, TextInput} from '@sanity/ui'
 import {useActorRef, useSelector} from '@xstate/react'
 import {
   type ComponentType,
@@ -578,13 +578,9 @@ const Variant: ComponentType<{
     sourceReleasePerspective,
   } = useVersionContextMenu({
     documentGroupId,
-    versionId,
     documentVersionInfoStub: document,
     documentType,
-    bundleId,
-    isVersion,
     disabled: isReadOnly,
-    release,
     onCopyToDraftsComplete: clearScheduledDraftPerspective,
   })
 

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -72,6 +72,7 @@ import {CreateVariant} from './CreateVariant/CreateVariant'
 import {Footer} from './Footer'
 import {Header} from './Header'
 import {TextButton} from './TextButton'
+import {useVariantPendingReleases} from './useVariantPendingReleases'
 import {StatusBadge} from './VariantSet/StatusBadge'
 import {VariantCheckbox} from './VariantSet/VariantCheckbox'
 import {VariantSet} from './VariantSet/VariantSet'
@@ -551,9 +552,15 @@ const Variant: ComponentType<{
   const selectedIds = useSelector(machine, ({context}) => context.selectedIds)
   const releases = useSelector(inventoryRef, ({context}) => context.releases)
 
-  const {filteredReleases, clearScheduledDraftPerspective} = perspectiveList
+  const {clearScheduledDraftPerspective} = perspectiveList
 
   const release = releaseRef ? releases.get(releaseRef) : undefined
+
+  const pendingReleases = useVariantPendingReleases({
+    documentId: documentGroupId,
+    variantRef: document._system.variant?._ref,
+  })
+
   const {
     contextMenu,
     handleContextMenu,
@@ -572,6 +579,7 @@ const Variant: ComponentType<{
   } = useVersionContextMenu({
     documentGroupId,
     versionId,
+    documentVersionInfoStub: document,
     documentType,
     bundleId,
     isVersion,
@@ -659,7 +667,7 @@ const Variant: ComponentType<{
           documentGroupId={documentGroupId}
           documentType={documentType}
           bundleId={bundleId}
-          releases={filteredReleases.notCurrentReleases}
+          releases={pendingReleases}
           releasesLoading={releasesLoading}
           versionId={versionId}
           onDiscard={openDiscardDialog}

--- a/packages/sanity/src/core/documentGroupInventory/components/useVariantPendingReleases.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/useVariantPendingReleases.tsx
@@ -1,0 +1,22 @@
+import {useDocumentVersions} from '../../releases/hooks/useDocumentVersions'
+import {useActiveReleases} from '../../releases/store/useActiveReleases'
+
+interface Options {
+  documentId: string
+  variantRef: string | undefined
+}
+/**
+ * Finds the releases a variant hasn't been added to yet.
+ */
+export function useVariantPendingReleases({documentId, variantRef}: Options) {
+  const {versions} = useDocumentVersions({documentId})
+  const {data: releases} = useActiveReleases()
+  const versionsOfThisVariant = versions.filter((version) =>
+    variantRef ? version._system.variant?._ref === variantRef : !version._system.variant?._ref,
+  )
+  const releasesOfThisVariant = versionsOfThisVariant.map(
+    (version) => version._system.release?._ref,
+  )
+
+  return releases.filter((release) => !releasesOfThisVariant.includes(release._id))
+}

--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -111,10 +111,7 @@ export const VersionChip = memo(function VersionChip(props: {
     documentGroupId,
     versionId,
     documentType,
-    bundleId,
-    isVersion,
     disabled: contextMenuDisabled,
-    release,
     onCopyToDraftsComplete,
   })
 

--- a/packages/sanity/src/core/releases/hooks/__tests__/useCopyToDrafts.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useCopyToDrafts.test.tsx
@@ -124,14 +124,13 @@ describe('useCopyToDrafts', () => {
     })
   })
 
-  async function renderCopyToDrafts(fromBundle: string, fromVariant?: string) {
+  async function renderCopyToDrafts(documentVersionInfoStub: VersionInfoDocumentStub | undefined) {
     const wrapper = await createTestProvider()
     return renderHook(
       () =>
         useCopyToDrafts({
-          documentId: publishedId,
-          fromBundle,
-          fromVariant,
+          documentGroupId: publishedId,
+          documentVersionInfoStub,
           onNavigate,
           onConfirmationRequest,
         }),
@@ -140,7 +139,7 @@ describe('useCopyToDrafts', () => {
   }
 
   it('copies a published document to drafts without discarding', async () => {
-    const {result} = await renderCopyToDrafts('published')
+    const {result} = await renderCopyToDrafts(publishedVersion)
 
     await act(async () => {
       await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
@@ -162,8 +161,8 @@ describe('useCopyToDrafts', () => {
     expect(onNavigate).toHaveBeenCalledTimes(1)
   })
 
-  it('copies a release version to drafts by matching its bundle', async () => {
-    const {result} = await renderCopyToDrafts('release1')
+  it('copies a release version to drafts using the provided stub', async () => {
+    const {result} = await renderCopyToDrafts(releaseVersion)
 
     await act(async () => {
       await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
@@ -184,8 +183,8 @@ describe('useCopyToDrafts', () => {
     expect(onNavigate).toHaveBeenCalledTimes(1)
   })
 
-  it('copies an agent version to drafts by matching its bundle, not its opaque id', async () => {
-    const {result} = await renderCopyToDrafts('agent.user-123')
+  it('copies an opaque agent version using the provided stub', async () => {
+    const {result} = await renderCopyToDrafts(opaqueAgentVersion)
 
     await act(async () => {
       await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
@@ -214,7 +213,7 @@ describe('useCopyToDrafts', () => {
       loading: false,
     })
 
-    const {result} = await renderCopyToDrafts('release1')
+    const {result} = await renderCopyToDrafts(releaseVersion)
 
     await act(async () => {
       await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
@@ -233,7 +232,7 @@ describe('useCopyToDrafts', () => {
       loading: false,
     })
 
-    const {result} = await renderCopyToDrafts('release1')
+    const {result} = await renderCopyToDrafts(releaseVersion)
 
     await act(async () => {
       await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: false})
@@ -259,8 +258,8 @@ describe('useCopyToDrafts', () => {
     expect(onNavigate).toHaveBeenCalledTimes(1)
   })
 
-  it('shows an error toast when the source version is not found', async () => {
-    const {result} = await renderCopyToDrafts('missing-bundle')
+  it('shows an error toast when the document version stub is missing', async () => {
+    const {result} = await renderCopyToDrafts(undefined)
 
     await act(async () => {
       await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
@@ -271,36 +270,8 @@ describe('useCopyToDrafts', () => {
     expect(toastMock.push).toHaveBeenCalledWith(
       expect.objectContaining({
         status: 'error',
-        description: `Source document with id: ${publishedId} and bundle: missing-bundle not found`,
+        description: `Document version info stub is required, not found for document group id: ${publishedId}`,
       }),
-    )
-  })
-
-  it('copies the base version when the same bundle also holds a variant version', async () => {
-    mockUseDocumentVersions.mockReturnValue({
-      data: [],
-      versions: [publishedVersion, releaseVersion, variantVersion],
-      error: null,
-      loading: false,
-    })
-
-    const {result} = await renderCopyToDrafts('release1')
-
-    await act(async () => {
-      await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
-    })
-
-    expect(mockAction).toHaveBeenCalledWith(
-      [
-        {
-          actionType: 'sanity.action.document.version.create',
-          versionId: 'drafts.article-123',
-          baseId: releaseVersion._id,
-          ifBaseRevisionId: 'release-rev',
-          publishedId,
-        },
-      ],
-      {tag: 'document.copy-to-drafts'},
     )
   })
 
@@ -312,7 +283,7 @@ describe('useCopyToDrafts', () => {
       loading: false,
     })
 
-    const {result} = await renderCopyToDrafts('release1', '_.variants.test')
+    const {result} = await renderCopyToDrafts(variantVersion)
 
     await act(async () => {
       await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
@@ -343,7 +314,7 @@ describe('useCopyToDrafts', () => {
       loading: false,
     })
 
-    const {result} = await renderCopyToDrafts('release1', '_.variants.test')
+    const {result} = await renderCopyToDrafts(variantVersion)
 
     await act(async () => {
       await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
@@ -362,7 +333,7 @@ describe('useCopyToDrafts', () => {
       loading: false,
     })
 
-    const {result} = await renderCopyToDrafts('release1', '_.variants.test')
+    const {result} = await renderCopyToDrafts(variantVersion)
 
     await act(async () => {
       await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: false})
@@ -398,7 +369,7 @@ describe('useCopyToDrafts', () => {
       loading: false,
     })
 
-    const {result} = await renderCopyToDrafts('drafts')
+    const {result} = await renderCopyToDrafts(draftVersion)
 
     await act(async () => {
       await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: false})
@@ -409,7 +380,7 @@ describe('useCopyToDrafts', () => {
     expect(toastMock.push).toHaveBeenCalledWith(
       expect.objectContaining({
         status: 'error',
-        description: `Source document with id: ${publishedId} and bundle: drafts not found`,
+        description: 'Cannot copy a draft onto itself',
       }),
     )
   })
@@ -417,7 +388,7 @@ describe('useCopyToDrafts', () => {
   it('shows an error toast when the client action fails', async () => {
     mockAction.mockRejectedValue(new Error('action failed'))
 
-    const {result} = await renderCopyToDrafts('published')
+    const {result} = await renderCopyToDrafts(publishedVersion)
 
     await act(async () => {
       await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})

--- a/packages/sanity/src/core/releases/hooks/__tests__/useCopyToDrafts.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useCopyToDrafts.test.tsx
@@ -124,13 +124,13 @@ describe('useCopyToDrafts', () => {
     })
   })
 
-  async function renderCopyToDrafts(fromRelease: string, fromVariant?: string) {
+  async function renderCopyToDrafts(fromBundle: string, fromVariant?: string) {
     const wrapper = await createTestProvider()
     return renderHook(
       () =>
         useCopyToDrafts({
           documentId: publishedId,
-          fromRelease,
+          fromBundle,
           fromVariant,
           onNavigate,
           onConfirmationRequest,
@@ -162,7 +162,7 @@ describe('useCopyToDrafts', () => {
     expect(onNavigate).toHaveBeenCalledTimes(1)
   })
 
-  it('copies a release version to drafts by matching scopeId', async () => {
+  it('copies a release version to drafts by matching its bundle', async () => {
     const {result} = await renderCopyToDrafts('release1')
 
     await act(async () => {
@@ -184,8 +184,8 @@ describe('useCopyToDrafts', () => {
     expect(onNavigate).toHaveBeenCalledTimes(1)
   })
 
-  it('copies an opaque agent version to drafts by matching scopeId', async () => {
-    const {result} = await renderCopyToDrafts('opaque-scope-abc')
+  it('copies an agent version to drafts by matching its bundle, not its opaque id', async () => {
+    const {result} = await renderCopyToDrafts('agent.user-123')
 
     await act(async () => {
       await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
@@ -260,7 +260,7 @@ describe('useCopyToDrafts', () => {
   })
 
   it('shows an error toast when the source version is not found', async () => {
-    const {result} = await renderCopyToDrafts('missing-scope')
+    const {result} = await renderCopyToDrafts('missing-bundle')
 
     await act(async () => {
       await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
@@ -271,8 +271,36 @@ describe('useCopyToDrafts', () => {
     expect(toastMock.push).toHaveBeenCalledWith(
       expect.objectContaining({
         status: 'error',
-        description: `Source document with id: ${publishedId} and release: missing-scope not found`,
+        description: `Source document with id: ${publishedId} and bundle: missing-bundle not found`,
       }),
+    )
+  })
+
+  it('copies the base version when the same bundle also holds a variant version', async () => {
+    mockUseDocumentVersions.mockReturnValue({
+      data: [],
+      versions: [publishedVersion, releaseVersion, variantVersion],
+      error: null,
+      loading: false,
+    })
+
+    const {result} = await renderCopyToDrafts('release1')
+
+    await act(async () => {
+      await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
+    })
+
+    expect(mockAction).toHaveBeenCalledWith(
+      [
+        {
+          actionType: 'sanity.action.document.version.create',
+          versionId: 'drafts.article-123',
+          baseId: releaseVersion._id,
+          ifBaseRevisionId: 'release-rev',
+          publishedId,
+        },
+      ],
+      {tag: 'document.copy-to-drafts'},
     )
   })
 
@@ -362,11 +390,18 @@ describe('useCopyToDrafts', () => {
     expect(onNavigate).toHaveBeenCalledTimes(1)
   })
 
-  it('shows an error toast when fromRelease is draft', async () => {
-    const {result} = await renderCopyToDrafts('draft')
+  it('refuses to copy drafts onto themselves', async () => {
+    mockUseDocumentVersions.mockReturnValue({
+      data: [],
+      versions: [publishedVersion, draftVersion],
+      error: null,
+      loading: false,
+    })
+
+    const {result} = await renderCopyToDrafts('drafts')
 
     await act(async () => {
-      await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
+      await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: false})
     })
 
     expect(mockAction).not.toHaveBeenCalled()
@@ -374,7 +409,7 @@ describe('useCopyToDrafts', () => {
     expect(toastMock.push).toHaveBeenCalledWith(
       expect.objectContaining({
         status: 'error',
-        description: `Source document with id: ${publishedId} and release: draft not found`,
+        description: `Source document with id: ${publishedId} and bundle: drafts not found`,
       }),
     )
   })

--- a/packages/sanity/src/core/releases/hooks/__tests__/useCopyToDrafts.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useCopyToDrafts.test.tsx
@@ -87,6 +87,19 @@ const variantVersion: VersionInfoDocumentStub = {
   },
 }
 
+const variantDraftVersion: VersionInfoDocumentStub = {
+  _id: 'opaque-variant-draft-doc-id',
+  _rev: 'variant-draft-rev',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-07T00:00:00Z',
+  _system: {
+    bundleId: 'drafts',
+    variant: {_ref: '_.variants.test', _weak: true},
+    group: {_ref: publishedId, _weak: true},
+    scopeId: 'opaque-variant-draft-scope',
+  },
+}
+
 describe('useCopyToDrafts', () => {
   const mockAction = vi.fn()
   const mockClient = {
@@ -111,13 +124,14 @@ describe('useCopyToDrafts', () => {
     })
   })
 
-  async function renderCopyToDrafts(fromRelease: string) {
+  async function renderCopyToDrafts(fromRelease: string, fromVariant?: string) {
     const wrapper = await createTestProvider()
     return renderHook(
       () =>
         useCopyToDrafts({
           documentId: publishedId,
           fromRelease,
+          fromVariant,
           onNavigate,
           onConfirmationRequest,
         }),
@@ -262,28 +276,90 @@ describe('useCopyToDrafts', () => {
     )
   })
 
-  it('shows an error toast when copying a variant document', async () => {
+  it('copies a variant version to the variant draft, ignoring the base draft', async () => {
     mockUseDocumentVersions.mockReturnValue({
       data: [],
-      versions: [publishedVersion, variantVersion],
+      versions: [publishedVersion, draftVersion, releaseVersion, variantVersion],
       error: null,
       loading: false,
     })
 
-    const {result} = await renderCopyToDrafts('opaque-variant-scope')
+    const {result} = await renderCopyToDrafts('release1', '_.variants.test')
 
     await act(async () => {
       await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
     })
 
+    expect(onConfirmationRequest).not.toHaveBeenCalled()
+    expect(mockAction).toHaveBeenCalledWith(
+      [
+        {
+          actionType: 'sanity.action.document.variant.create',
+          bundleId: 'drafts',
+          publishedId,
+          variantId: 'test',
+          baseId: variantVersion._id,
+          ifBaseRevisionId: 'variant-rev',
+        },
+      ],
+      {tag: 'document.copy-to-drafts'},
+    )
+    expect(onNavigate).toHaveBeenCalledTimes(1)
+  })
+
+  it('requests confirmation when the variant draft exists', async () => {
+    mockUseDocumentVersions.mockReturnValue({
+      data: [],
+      versions: [publishedVersion, variantVersion, variantDraftVersion],
+      error: null,
+      loading: false,
+    })
+
+    const {result} = await renderCopyToDrafts('release1', '_.variants.test')
+
+    await act(async () => {
+      await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
+    })
+
+    expect(onConfirmationRequest).toHaveBeenCalledTimes(1)
     expect(mockAction).not.toHaveBeenCalled()
     expect(onNavigate).not.toHaveBeenCalled()
-    expect(toastMock.push).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: 'error',
-        description: 'Copying variant documents to drafts is not supported yet',
-      }),
+  })
+
+  it('deletes the existing variant draft then copies when shouldConfirmDraftDiscard is false', async () => {
+    mockUseDocumentVersions.mockReturnValue({
+      data: [],
+      versions: [publishedVersion, variantVersion, variantDraftVersion],
+      error: null,
+      loading: false,
+    })
+
+    const {result} = await renderCopyToDrafts('release1', '_.variants.test')
+
+    await act(async () => {
+      await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: false})
+    })
+
+    expect(mockAction).toHaveBeenCalledWith(
+      [
+        {
+          actionType: 'sanity.action.document.variant.delete',
+          bundleId: 'drafts',
+          publishedId,
+          variantId: 'test',
+        },
+        {
+          actionType: 'sanity.action.document.variant.create',
+          bundleId: 'drafts',
+          publishedId,
+          variantId: 'test',
+          baseId: variantVersion._id,
+          ifBaseRevisionId: 'variant-rev',
+        },
+      ],
+      {tag: 'document.copy-to-drafts'},
     )
+    expect(onNavigate).toHaveBeenCalledTimes(1)
   })
 
   it('shows an error toast when fromRelease is draft', async () => {

--- a/packages/sanity/src/core/releases/hooks/__tests__/useVersionOperations.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useVersionOperations.test.tsx
@@ -39,6 +39,21 @@ describe('useVersionOperations', () => {
     expect(mockedUseSetPerspective).toHaveBeenCalledWith('releaseId')
   })
 
+  it('should skip perspective navigation when navigate is false', async () => {
+    const wrapper = await createTestProvider()
+    const {result} = renderHook(() => useVersionOperations(), {wrapper})
+
+    await act(async () => {
+      await result.current.createVersion('releaseId', 'documentId', {navigate: false})
+    })
+
+    expect(useReleaseOperationsMockReturn.createVersion).toHaveBeenCalledWith(
+      'releaseId',
+      'documentId',
+    )
+    expect(mockedUseSetPerspective).not.toHaveBeenCalled()
+  })
+
   it('should discard a version successfully', async () => {
     const wrapper = await createTestProvider()
     const {result} = renderHook(() => useVersionOperations(), {wrapper})

--- a/packages/sanity/src/core/releases/hooks/useCopyToDrafts.ts
+++ b/packages/sanity/src/core/releases/hooks/useCopyToDrafts.ts
@@ -7,7 +7,8 @@ import {useTranslation} from '../../i18n/hooks/useTranslation'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
 import {getPublishedId, getDraftId} from '../../util/draftUtils'
 import {getTargetDocument} from '../../util/getTargetDocument'
-import {isPublishedVersion} from '../../util/versionsUtils'
+import {type VariantDocumentAction} from '../../variants/store/variantsClient'
+import {getVariantId} from '../../variants/tool/util'
 import {useDocumentVersions} from './useDocumentVersions'
 
 export interface CopyToDraftsOptions {
@@ -17,6 +18,11 @@ export interface CopyToDraftsOptions {
 export interface UseCopyToDraftsOptions {
   documentId: string
   fromRelease: string
+  /**
+   * The variant reference (`_.variants.<id>`) of the version being copied. When
+   * set, the copy targets the variant's draft rather than the base draft.
+   */
+  fromVariant?: string
   onNavigate: () => void
   onConfirmationRequest: () => void
 }
@@ -26,7 +32,7 @@ export interface UseCopyToDraftsReturn {
 }
 
 export function useCopyToDrafts(options: UseCopyToDraftsOptions): UseCopyToDraftsReturn {
-  const {documentId, fromRelease, onNavigate, onConfirmationRequest} = options
+  const {documentId, fromRelease, fromVariant, onNavigate, onConfirmationRequest} = options
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const toast = useToast()
   const {t} = useTranslation()
@@ -34,31 +40,35 @@ export function useCopyToDrafts(options: UseCopyToDraftsOptions): UseCopyToDraft
   const publishedId = useMemo(() => getPublishedId(documentId), [documentId])
   const {versions} = useDocumentVersions({documentId: publishedId})
   const sourceDocumentInfo = useMemo(() => {
-    if (fromRelease === 'published') {
-      return getTargetDocument({
-        bundle: 'published',
-        variant: undefined,
-        documentVersions: versions,
-      })
-    }
     if (fromRelease === 'draft') {
       return undefined
     }
+    if (fromRelease === 'published') {
+      return getTargetDocument({
+        bundle: 'published',
+        variant: fromVariant,
+        documentVersions: versions,
+      })
+    }
     return versions.find((version) => {
-      // FromRelease now matches the scopeId of the version.
-      // So it will find the correct document, in the follow up enabling copying variants
-      // We need to check the variant and the release
-      // For that we can use the `getTargetDocument` function
-      return version._system.scopeId === fromRelease
+      const inVariant = fromVariant
+        ? version._system.variant?._ref === fromVariant
+        : !version._system.variant
+      // `fromRelease` matches a base version's `scopeId`, but a variant version's `scopeId`
+      // is its variant scope, so variant versions are matched by their bundle instead.
+      const inBundle = fromVariant
+        ? version._system.bundleId === fromRelease
+        : version._system.scopeId === fromRelease
+      return inVariant && inBundle
     })
-  }, [fromRelease, versions])
+  }, [fromRelease, fromVariant, versions])
 
   const hasDraftVersion = useMemo(
     () =>
       Boolean(
-        getTargetDocument({bundle: 'drafts', variant: undefined, documentVersions: versions}),
+        getTargetDocument({bundle: 'drafts', variant: fromVariant, documentVersions: versions}),
       ),
-    [versions],
+    [fromVariant, versions],
   )
 
   const handleCopyToDrafts = useCallback(
@@ -74,27 +84,47 @@ export function useCopyToDrafts(options: UseCopyToDraftsOptions): UseCopyToDraft
             `Source document with id: ${documentId} and release: ${fromRelease} not found`,
           )
         }
-        if (sourceDocumentInfo._system.variant?._ref) {
-          throw new Error('Copying variant documents to drafts is not supported yet')
-        }
+        const actions: (Action | VariantDocumentAction)[] = []
 
-        const actions: Action[] = []
+        if (fromVariant) {
+          const variantId = getVariantId(fromVariant)
 
-        if (hasDraftVersion) {
+          if (hasDraftVersion) {
+            actions.push({
+              actionType: 'sanity.action.document.variant.delete',
+              bundleId: 'drafts',
+              publishedId,
+              variantId,
+            })
+          }
+
           actions.push({
-            actionType: 'sanity.action.document.discard',
-            draftId: getDraftId(publishedId),
+            actionType: 'sanity.action.document.variant.create',
+            bundleId: 'drafts',
+            publishedId,
+            variantId,
+            baseId: sourceDocumentInfo._id,
+            ifBaseRevisionId: sourceDocumentInfo._rev,
+          })
+        } else {
+          if (hasDraftVersion) {
+            actions.push({
+              actionType: 'sanity.action.document.discard',
+              draftId: getDraftId(publishedId),
+            })
+          }
+
+          actions.push({
+            actionType: 'sanity.action.document.version.create',
+            versionId: getDraftId(publishedId),
+            baseId: sourceDocumentInfo._id,
+            ifBaseRevisionId: sourceDocumentInfo._rev,
+            publishedId,
           })
         }
 
-        actions.push({
-          actionType: 'sanity.action.document.version.create',
-          versionId: getDraftId(publishedId),
-          baseId: sourceDocumentInfo._id,
-          ifBaseRevisionId: sourceDocumentInfo._rev,
-          publishedId,
-        })
-        await client.action(actions, {
+        // `client.action` is not typed for variant actions yet; see `variantsClient`.
+        await client.action(actions as Action[], {
           tag: 'document.copy-to-drafts',
         })
 
@@ -115,6 +145,7 @@ export function useCopyToDrafts(options: UseCopyToDraftsOptions): UseCopyToDraft
       client,
       documentId,
       fromRelease,
+      fromVariant,
       hasDraftVersion,
       sourceDocumentInfo,
       publishedId,

--- a/packages/sanity/src/core/releases/hooks/useCopyToDrafts.ts
+++ b/packages/sanity/src/core/releases/hooks/useCopyToDrafts.ts
@@ -5,10 +5,11 @@ import {useCallback, useMemo} from 'react'
 import {useClient} from '../../hooks/useClient'
 import {useTranslation} from '../../i18n/hooks/useTranslation'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
-import {getPublishedId, getDraftId} from '../../util/draftUtils'
+import {getDraftId} from '../../util/draftUtils'
 import {getTargetDocument} from '../../util/getTargetDocument'
 import {type VariantDocumentAction} from '../../variants/store/variantsClient'
 import {getVariantId} from '../../variants/tool/util'
+import {type VersionInfoDocumentStub} from '../store/types'
 import {useDocumentVersions} from './useDocumentVersions'
 
 export interface CopyToDraftsOptions {
@@ -16,13 +17,8 @@ export interface CopyToDraftsOptions {
 }
 
 export interface UseCopyToDraftsOptions {
-  documentId: string
-  fromRelease: string
-  /**
-   * The variant reference (`_.variants.<id>`) of the version being copied. When
-   * set, the copy targets the variant's draft rather than the base draft.
-   */
-  fromVariant?: string
+  documentGroupId: string
+  documentVersionInfoStub: VersionInfoDocumentStub | undefined
   onNavigate: () => void
   onConfirmationRequest: () => void
 }
@@ -32,43 +28,23 @@ export interface UseCopyToDraftsReturn {
 }
 
 export function useCopyToDrafts(options: UseCopyToDraftsOptions): UseCopyToDraftsReturn {
-  const {documentId, fromRelease, fromVariant, onNavigate, onConfirmationRequest} = options
+  const {onNavigate, onConfirmationRequest, documentVersionInfoStub, documentGroupId} = options
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const toast = useToast()
   const {t} = useTranslation()
 
-  const publishedId = useMemo(() => getPublishedId(documentId), [documentId])
-  const {versions} = useDocumentVersions({documentId: publishedId})
-  const sourceDocumentInfo = useMemo(() => {
-    if (fromRelease === 'draft') {
-      return undefined
-    }
-    if (fromRelease === 'published') {
-      return getTargetDocument({
-        bundle: 'published',
-        variant: fromVariant,
-        documentVersions: versions,
-      })
-    }
-    return versions.find((version) => {
-      const inVariant = fromVariant
-        ? version._system.variant?._ref === fromVariant
-        : !version._system.variant
-      // `fromRelease` matches a base version's `scopeId`, but a variant version's `scopeId`
-      // is its variant scope, so variant versions are matched by their bundle instead.
-      const inBundle = fromVariant
-        ? version._system.bundleId === fromRelease
-        : version._system.scopeId === fromRelease
-      return inVariant && inBundle
-    })
-  }, [fromRelease, fromVariant, versions])
-
+  const {versions} = useDocumentVersions({documentId: documentGroupId})
+  const variantRef = documentVersionInfoStub?._system.variant?._ref
   const hasDraftVersion = useMemo(
     () =>
       Boolean(
-        getTargetDocument({bundle: 'drafts', variant: fromVariant, documentVersions: versions}),
+        getTargetDocument({
+          bundle: 'drafts',
+          variant: variantRef,
+          documentVersions: versions,
+        }),
       ),
-    [fromVariant, versions],
+    [variantRef, versions],
   )
 
   const handleCopyToDrafts = useCallback(
@@ -79,21 +55,25 @@ export function useCopyToDrafts(options: UseCopyToDraftsOptions): UseCopyToDraft
       }
       // Workaround for React Compiler not yet fully supporting try/catch syntax
       const run = async () => {
-        if (!sourceDocumentInfo) {
+        if (!documentVersionInfoStub) {
           throw new Error(
-            `Source document with id: ${documentId} and release: ${fromRelease} not found`,
+            'Document version info stub is required, not found for document group id: ' +
+              documentGroupId,
           )
+        }
+        if (documentVersionInfoStub._system.bundleId === 'drafts') {
+          throw new Error('Cannot copy a draft onto itself')
         }
         const actions: (Action | VariantDocumentAction)[] = []
 
-        if (fromVariant) {
-          const variantId = getVariantId(fromVariant)
+        if (documentVersionInfoStub._system.variant?._ref) {
+          const variantId = getVariantId(documentVersionInfoStub._system.variant?._ref)
 
           if (hasDraftVersion) {
             actions.push({
               actionType: 'sanity.action.document.variant.delete',
               bundleId: 'drafts',
-              publishedId,
+              publishedId: documentGroupId,
               variantId,
             })
           }
@@ -101,25 +81,25 @@ export function useCopyToDrafts(options: UseCopyToDraftsOptions): UseCopyToDraft
           actions.push({
             actionType: 'sanity.action.document.variant.create',
             bundleId: 'drafts',
-            publishedId,
+            publishedId: documentGroupId,
             variantId,
-            baseId: sourceDocumentInfo._id,
-            ifBaseRevisionId: sourceDocumentInfo._rev,
+            baseId: documentVersionInfoStub._id,
+            ifBaseRevisionId: documentVersionInfoStub._rev,
           })
         } else {
           if (hasDraftVersion) {
             actions.push({
               actionType: 'sanity.action.document.discard',
-              draftId: getDraftId(publishedId),
+              draftId: getDraftId(documentGroupId),
             })
           }
 
           actions.push({
             actionType: 'sanity.action.document.version.create',
-            versionId: getDraftId(publishedId),
-            baseId: sourceDocumentInfo._id,
-            ifBaseRevisionId: sourceDocumentInfo._rev,
-            publishedId,
+            versionId: getDraftId(documentGroupId),
+            baseId: documentVersionInfoStub._id,
+            ifBaseRevisionId: documentVersionInfoStub._rev,
+            publishedId: documentGroupId,
           })
         }
 
@@ -143,12 +123,9 @@ export function useCopyToDrafts(options: UseCopyToDraftsOptions): UseCopyToDraft
     },
     [
       client,
-      documentId,
-      fromRelease,
-      fromVariant,
+      documentVersionInfoStub,
       hasDraftVersion,
-      sourceDocumentInfo,
-      publishedId,
+      documentGroupId,
       toast,
       onNavigate,
       t,

--- a/packages/sanity/src/core/releases/hooks/useCopyToDrafts.ts
+++ b/packages/sanity/src/core/releases/hooks/useCopyToDrafts.ts
@@ -66,8 +66,9 @@ export function useCopyToDrafts(options: UseCopyToDraftsOptions): UseCopyToDraft
         }
         const actions: (Action | VariantDocumentAction)[] = []
 
-        if (documentVersionInfoStub._system.variant?._ref) {
-          const variantId = getVariantId(documentVersionInfoStub._system.variant?._ref)
+        const variantRef = documentVersionInfoStub._system.variant?._ref
+        if (variantRef) {
+          const variantId = getVariantId(variantRef)
 
           if (hasDraftVersion) {
             actions.push({

--- a/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
+++ b/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
@@ -1,6 +1,5 @@
-import {type ReleaseDocument} from '@sanity/client'
 import {useClickOutsideEvent, useGlobalKeyDown, useToast} from '@sanity/ui'
-import {type MouseEvent, type RefObject, useCallback, useRef, useState} from 'react'
+import {type MouseEvent, type RefObject, useCallback, useMemo, useRef, useState} from 'react'
 
 import {useTranslation} from '../../i18n/hooks/useTranslation'
 import {type TargetPerspective} from '../../perspective/types'
@@ -17,12 +16,13 @@ import {isCardinalityOneRelease} from '../../util/releaseUtils'
 import {useVariantDocumentOperations} from '../../variants/hooks/useVariantDocumentOperations'
 import {isVariantId} from '../../variants/types'
 import {type VersionInfoDocumentStub} from '../store/types'
-import {LATEST, PUBLISHED} from '../util/const'
+import {useAllReleases} from '../store/useAllReleases'
 import {
   getReleaseIdFromReleaseDocumentId,
   isReleaseDocumentId,
 } from '../util/getReleaseIdFromReleaseDocumentId'
 import {type CopyToDraftsOptions, useCopyToDrafts} from './useCopyToDrafts'
+import {useDocumentVersions} from './useDocumentVersions'
 import {useVersionOperations} from './useVersionOperations'
 
 const CONTEXT_MENU_CLOSED = {open: false as const}
@@ -48,31 +48,14 @@ export type VersionContextMenuState =
   | {open: true; translate: {x: number; y: number}}
   | {open: false}
 
-/**
- * @internal
- */
-export interface UseVersionContextMenuOptions {
+interface UseVersionContextMenuBaseOptions {
   /**
    * The document group id (published id with no `drafts.` / `versions.` prefix).
    */
   documentGroupId: string
-  /**
-   * The version id (with `drafts.` / `versions.` prefix) or even the published id (with no prefix).
-   * AKA the full document id
-   */
-  versionId: string
-  /**
-   * Required to add a variant version to a release, otherwise the created
-   * version wouldn't belong to the variant.
-   */
-  documentVersionInfoStub?: VersionInfoDocumentStub
   documentType: string
-  /** The perspective the menu acts on: 'published', 'draft', or a release ID. */
-  bundleId: string
-  isVersion: boolean
   /** Disables the menu actions (the menu can still be opened). */
   disabled?: boolean
-  release?: ReleaseDocument
   /**
    * Called after a successful copy-to-drafts (after navigating to drafts).
    * Structure uses this to clear the pane-local scheduled draft perspective
@@ -80,6 +63,30 @@ export interface UseVersionContextMenuOptions {
    */
   onCopyToDraftsComplete?: () => void
 }
+/**
+ * @internal
+ */
+type UseVersionContextMenuOptions =
+  | (UseVersionContextMenuBaseOptions & {
+      /**
+       * The version id (with `drafts.` / `versions.` prefix) or even the published id (with no prefix).
+       * AKA the full document id
+       *
+       * Provided by the legacy VersionChip
+       */
+      versionId: string
+      documentVersionInfoStub?: undefined
+    })
+  | (UseVersionContextMenuBaseOptions & {
+      /**
+       * Will be used if provided, for example coming from the document group inventory.
+       * If not provided, the versionId will be used to find it.
+       *
+       * Provided by the document group inventory
+       */
+      documentVersionInfoStub: VersionInfoDocumentStub
+      versionId?: undefined
+    })
 
 /**
  * @internal
@@ -130,13 +137,21 @@ export function useVersionContextMenu(
     documentGroupId,
     versionId,
     documentType,
-    bundleId,
-    isVersion,
     disabled = false,
-    release,
-    documentVersionInfoStub,
+    documentVersionInfoStub: _documentVersionInfoStub,
     onCopyToDraftsComplete,
   } = options
+
+  const {map: releasesMap} = useAllReleases()
+  const {versions} = useDocumentVersions({documentId: documentGroupId})
+  const documentVersionInfoStub = useMemo(() => {
+    if (_documentVersionInfoStub) return _documentVersionInfoStub
+
+    return versions.find((version) => version._id === versionId)
+  }, [versions, versionId, _documentVersionInfoStub])
+
+  const releaseRef = documentVersionInfoStub?._system.release?._ref
+  const release = releaseRef ? releasesMap.get(releaseRef) : undefined
 
   if (process.env.NODE_ENV !== 'production' && !isDocumentGroupId(documentGroupId)) {
     console.warn(
@@ -210,9 +225,8 @@ export function useVersionContextMenu(
   }, [variantRef, setVariant, setPerspective, onCopyToDraftsComplete])
 
   const {handleCopyToDrafts} = useCopyToDrafts({
-    documentId: documentGroupId,
-    fromRelease: bundleId,
-    fromVariant: variantRef,
+    documentGroupId,
+    documentVersionInfoStub,
     onNavigate: handleCopyToDraftsNavigate,
     onConfirmationRequest: () => setDialogState('copy-to-drafts'),
   })
@@ -220,7 +234,10 @@ export function useVersionContextMenu(
   const handleAddVersion = useCallback(
     async (targetRelease: string) => {
       const runCreateVersion = async () => {
-        if (documentVersionInfoStub && variantRef) {
+        if (!documentVersionInfoStub?._id) {
+          throw new Error('Document version info stub is required')
+        }
+        if (variantRef) {
           // A variant version can only be created through the variant action, otherwise
           // the new version would not belong to the variant.
           await createVariantDocument({
@@ -232,7 +249,10 @@ export function useVersionContextMenu(
               : targetRelease,
           })
         } else {
-          await createVersion(getReleaseIdFromReleaseDocumentId(targetRelease), versionId)
+          await createVersion(
+            getReleaseIdFromReleaseDocumentId(targetRelease),
+            documentVersionInfoStub._id,
+          )
         }
       }
 
@@ -253,7 +273,6 @@ export function useVersionContextMenu(
       closeContextMenu,
       createVersion,
       documentGroupId,
-      versionId,
       variantRef,
       t,
       toast,
@@ -262,7 +281,7 @@ export function useVersionContextMenu(
     ],
   )
 
-  const isScheduledDraft = Boolean(release && isVersion && isCardinalityOneRelease(release))
+  const isScheduledDraft = Boolean(release && isCardinalityOneRelease(release))
 
   const handleEditScheduleComplete = useCallback(() => {
     if (!release) return
@@ -280,8 +299,7 @@ export function useVersionContextMenu(
     onDeleteComplete,
   })
 
-  const sourceReleasePerspective =
-    release ?? (bundleId === 'published' ? PUBLISHED : bundleId === 'draft' ? LATEST : bundleId)
+  const sourceReleasePerspective = release ?? documentVersionInfoStub?._system.bundleId ?? 'drafts'
 
   return {
     contextMenu,

--- a/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
+++ b/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
@@ -251,17 +251,24 @@ export function useVersionContextMenu(
             selectedPerspective: perspective,
           })
         } else {
+          // Skip navigation here — the hook navigates once after creation so we
+          // don't double-navigate (and clear an active variant sticky param).
           await createVersion(
             getReleaseIdFromReleaseDocumentId(targetRelease),
             documentVersionInfoStub._id,
+            {navigate: false},
           )
         }
       }
 
       try {
         await runCreateVersion()
-        // Navigates to the new created version
-        setVariant({variantId: variantRef, perspective})
+        // Navigate to the newly created version in a single router update.
+        if (variantRef) {
+          setVariant({variantId: variantRef, perspective})
+        } else {
+          setPerspective(perspective)
+        }
       } catch (err) {
         toast.push({
           closable: true,
@@ -277,6 +284,7 @@ export function useVersionContextMenu(
       closeContextMenu,
       createVersion,
       documentGroupId,
+      setPerspective,
       setVariant,
       variantRef,
       t,

--- a/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
+++ b/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
@@ -5,6 +5,7 @@ import {type MouseEvent, type RefObject, useCallback, useRef, useState} from 're
 import {useTranslation} from '../../i18n/hooks/useTranslation'
 import {type TargetPerspective} from '../../perspective/types'
 import {useSetPerspective} from '../../perspective/useSetPerspective'
+import {useSetVariant} from '../../perspective/useSetVariant'
 import {useSingleDocRelease} from '../../singleDocRelease/context/SingleDocReleaseProvider'
 import {useClearScheduledDraftPerspectiveOnDelete} from '../../singleDocRelease/hooks/useClearScheduledDraftPerspectiveOnDelete'
 import {
@@ -145,6 +146,9 @@ export function useVersionContextMenu(
 
   const {createVariantDocument} = useVariantDocumentOperations()
 
+  const stubVariantRef = documentVersionInfoStub?._system.variant?._ref
+  const variantRef = isVariantId(stubVariantRef) ? stubVariantRef : undefined
+
   const [contextMenu, setContextMenu] = useState<VersionContextMenuState>({open: false})
   const popoverRef = useRef<HTMLDivElement | null>(null)
   const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null)
@@ -155,6 +159,7 @@ export function useVersionContextMenu(
   const {t} = useTranslation()
   const {onSetScheduledDraftPerspective} = useSingleDocRelease()
   const setPerspective = useSetPerspective()
+  const setVariant = useSetVariant()
 
   const closeContextMenu = useCallback(() => setContextMenu(CONTEXT_MENU_CLOSED), [])
 
@@ -195,13 +200,19 @@ export function useVersionContextMenu(
   }, [])
 
   const handleCopyToDraftsNavigate = useCallback(() => {
-    setPerspective('drafts')
+    if (variantRef) {
+      // Keep the variant applied, otherwise the copy lands out of view.
+      setVariant({variantId: variantRef, perspective: 'drafts'})
+    } else {
+      setPerspective('drafts')
+    }
     onCopyToDraftsComplete?.()
-  }, [setPerspective, onCopyToDraftsComplete])
+  }, [variantRef, setVariant, setPerspective, onCopyToDraftsComplete])
 
   const {handleCopyToDrafts} = useCopyToDrafts({
     documentId: documentGroupId,
     fromRelease: bundleId,
+    fromVariant: variantRef,
     onNavigate: handleCopyToDraftsNavigate,
     onConfirmationRequest: () => setDialogState('copy-to-drafts'),
   })
@@ -209,11 +220,13 @@ export function useVersionContextMenu(
   const handleAddVersion = useCallback(
     async (targetRelease: string) => {
       const runCreateVersion = async () => {
-        if (documentVersionInfoStub && isVariantId(documentVersionInfoStub._system.variant?._ref)) {
+        if (documentVersionInfoStub && variantRef) {
+          // A variant version can only be created through the variant action, otherwise
+          // the new version would not belong to the variant.
           await createVariantDocument({
             baseId: documentVersionInfoStub._id,
-            documentGroupId: documentVersionInfoStub._system.group._ref,
-            variant: {_id: documentVersionInfoStub._system.variant._ref},
+            documentGroupId,
+            variant: {_id: variantRef},
             selectedPerspective: isReleaseDocumentId(targetRelease)
               ? getReleaseIdFromReleaseDocumentId(targetRelease)
               : targetRelease,
@@ -239,7 +252,9 @@ export function useVersionContextMenu(
     [
       closeContextMenu,
       createVersion,
+      documentGroupId,
       versionId,
+      variantRef,
       t,
       toast,
       createVariantDocument,

--- a/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
+++ b/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
@@ -17,7 +17,7 @@ import {useVariantDocumentOperations} from '../../variants/hooks/useVariantDocum
 import {isVariantId} from '../../variants/types'
 import {type VersionInfoDocumentStub} from '../store/types'
 import {useAllReleases} from '../store/useAllReleases'
-import {PUBLISHED} from '../util/const'
+import {LATEST, PUBLISHED} from '../util/const'
 import {
   getReleaseIdFromReleaseDocumentId,
   isReleaseDocumentId,
@@ -300,8 +300,11 @@ export function useVersionContextMenu(
     onDeleteComplete,
   })
 
-  // Published stubs omit `_system.bundleId`; falling back to drafts would mislabel them.
-  const sourceReleasePerspective = release ?? documentVersionInfoStub?._system.bundleId ?? PUBLISHED
+  // A published stub omits `_system.bundleId`, so it can only be told apart from a version
+  // that doesn't exist yet (drafts, the only chip rendered without a document) by the stub.
+  const sourceReleasePerspective =
+    release ??
+    (documentVersionInfoStub ? (documentVersionInfoStub._system.bundleId ?? PUBLISHED) : LATEST)
 
   return {
     contextMenu,

--- a/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
+++ b/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
@@ -13,8 +13,14 @@ import {
 } from '../../singleDocRelease/hooks/useScheduledDraftMenuActions'
 import {isDocumentGroupId} from '../../util/draftUtils'
 import {isCardinalityOneRelease} from '../../util/releaseUtils'
+import {useVariantDocumentOperations} from '../../variants/hooks/useVariantDocumentOperations'
+import {isVariantId} from '../../variants/types'
+import {type VersionInfoDocumentStub} from '../store/types'
 import {LATEST, PUBLISHED} from '../util/const'
-import {getReleaseIdFromReleaseDocumentId} from '../util/getReleaseIdFromReleaseDocumentId'
+import {
+  getReleaseIdFromReleaseDocumentId,
+  isReleaseDocumentId,
+} from '../util/getReleaseIdFromReleaseDocumentId'
 import {type CopyToDraftsOptions, useCopyToDrafts} from './useCopyToDrafts'
 import {useVersionOperations} from './useVersionOperations'
 
@@ -54,6 +60,11 @@ export interface UseVersionContextMenuOptions {
    * AKA the full document id
    */
   versionId: string
+  /**
+   * Required to add a variant version to a release, otherwise the created
+   * version wouldn't belong to the variant.
+   */
+  documentVersionInfoStub?: VersionInfoDocumentStub
   documentType: string
   /** The perspective the menu acts on: 'published', 'draft', or a release ID. */
   bundleId: string
@@ -122,6 +133,7 @@ export function useVersionContextMenu(
     isVersion,
     disabled = false,
     release,
+    documentVersionInfoStub,
     onCopyToDraftsComplete,
   } = options
 
@@ -130,6 +142,8 @@ export function useVersionContextMenu(
       `useVersionContextMenu: expected a document group id, got "${documentGroupId}". Pass the group (published) id as \`documentGroupId\` and the full document id as \`versionId\`.`,
     )
   }
+
+  const {createVariantDocument} = useVariantDocumentOperations()
 
   const [contextMenu, setContextMenu] = useState<VersionContextMenuState>({open: false})
   const popoverRef = useRef<HTMLDivElement | null>(null)
@@ -194,8 +208,23 @@ export function useVersionContextMenu(
 
   const handleAddVersion = useCallback(
     async (targetRelease: string) => {
+      const runCreateVersion = async () => {
+        if (documentVersionInfoStub && isVariantId(documentVersionInfoStub._system.variant?._ref)) {
+          await createVariantDocument({
+            baseId: documentVersionInfoStub._id,
+            documentGroupId: documentVersionInfoStub._system.group._ref,
+            variant: {_id: documentVersionInfoStub._system.variant._ref},
+            selectedPerspective: isReleaseDocumentId(targetRelease)
+              ? getReleaseIdFromReleaseDocumentId(targetRelease)
+              : targetRelease,
+          })
+        } else {
+          await createVersion(getReleaseIdFromReleaseDocumentId(targetRelease), versionId)
+        }
+      }
+
       try {
-        await createVersion(getReleaseIdFromReleaseDocumentId(targetRelease), versionId)
+        await runCreateVersion()
       } catch (err) {
         toast.push({
           closable: true,
@@ -207,7 +236,15 @@ export function useVersionContextMenu(
 
       closeContextMenu()
     },
-    [closeContextMenu, createVersion, versionId, t, toast],
+    [
+      closeContextMenu,
+      createVersion,
+      versionId,
+      t,
+      toast,
+      createVariantDocument,
+      documentVersionInfoStub,
+    ],
   )
 
   const isScheduledDraft = Boolean(release && isVersion && isCardinalityOneRelease(release))

--- a/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
+++ b/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
@@ -17,6 +17,7 @@ import {useVariantDocumentOperations} from '../../variants/hooks/useVariantDocum
 import {isVariantId} from '../../variants/types'
 import {type VersionInfoDocumentStub} from '../store/types'
 import {useAllReleases} from '../store/useAllReleases'
+import {PUBLISHED} from '../util/const'
 import {
   getReleaseIdFromReleaseDocumentId,
   isReleaseDocumentId,
@@ -299,7 +300,8 @@ export function useVersionContextMenu(
     onDeleteComplete,
   })
 
-  const sourceReleasePerspective = release ?? documentVersionInfoStub?._system.bundleId ?? 'drafts'
+  // Published stubs omit `_system.bundleId`; falling back to drafts would mislabel them.
+  const sourceReleasePerspective = release ?? documentVersionInfoStub?._system.bundleId ?? PUBLISHED
 
   return {
     contextMenu,

--- a/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
+++ b/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
@@ -234,6 +234,9 @@ export function useVersionContextMenu(
 
   const handleAddVersion = useCallback(
     async (targetRelease: string) => {
+      const perspective = isReleaseDocumentId(targetRelease)
+        ? getReleaseIdFromReleaseDocumentId(targetRelease)
+        : targetRelease
       const runCreateVersion = async () => {
         if (!documentVersionInfoStub?._id) {
           throw new Error('Document version info stub is required')
@@ -245,9 +248,7 @@ export function useVersionContextMenu(
             baseId: documentVersionInfoStub._id,
             documentGroupId,
             variant: {_id: variantRef},
-            selectedPerspective: isReleaseDocumentId(targetRelease)
-              ? getReleaseIdFromReleaseDocumentId(targetRelease)
-              : targetRelease,
+            selectedPerspective: perspective,
           })
         } else {
           await createVersion(
@@ -259,6 +260,8 @@ export function useVersionContextMenu(
 
       try {
         await runCreateVersion()
+        // Navigates to the new created version
+        setVariant({variantId: variantRef, perspective})
       } catch (err) {
         toast.push({
           closable: true,
@@ -274,6 +277,7 @@ export function useVersionContextMenu(
       closeContextMenu,
       createVersion,
       documentGroupId,
+      setVariant,
       variantRef,
       t,
       toast,

--- a/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
+++ b/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
@@ -7,8 +7,21 @@ import {getDocumentVariantType} from '../../util/getDocumentVariantType'
 import {AddedVersion} from '../__telemetry__/releases.telemetry'
 import {useReleaseOperations} from '../store/useReleaseOperations'
 
+export interface CreateVersionOptions {
+  /**
+   * Whether to navigate to the created version's perspective after creation.
+   * Defaults to `true`. Callers that handle navigation themselves (e.g. to
+   * also update the variant sticky param) should pass `false`.
+   */
+  navigate?: boolean
+}
+
 export interface VersionOperationsValue {
-  createVersion: (releaseId: ReleaseId, documentId: string) => Promise<void>
+  createVersion: (
+    releaseId: ReleaseId,
+    documentId: string,
+    options?: CreateVersionOptions,
+  ) => Promise<void>
   discardVersion: (releaseId: string, documentId: string) => Promise<SingleActionResult>
   unpublishVersion: (documentId: string) => Promise<SingleActionResult>
   revertUnpublishVersion: (documentId: string) => Promise<SingleActionResult>
@@ -22,10 +35,17 @@ export function useVersionOperations(): VersionOperationsValue {
 
   const setPerspective = useSetPerspective()
 
-  const handleCreateVersion = async (releaseId: ReleaseId, documentId: string) => {
+  const handleCreateVersion = async (
+    releaseId: ReleaseId,
+    documentId: string,
+    options?: CreateVersionOptions,
+  ) => {
+    const {navigate = true} = options ?? {}
     const origin = getDocumentVariantType(documentId)
     await createVersion(releaseId, documentId)
-    setPerspective(releaseId)
+    if (navigate) {
+      setPerspective(releaseId)
+    }
     telemetry.log(AddedVersion, {
       documentOrigin: origin,
     })

--- a/packages/sanity/src/core/releases/store/__tests__/__mocks/useAllReleases.mock.ts
+++ b/packages/sanity/src/core/releases/store/__tests__/__mocks/useAllReleases.mock.ts
@@ -6,6 +6,7 @@ export const useAllReleasesMockReturn: Mocked<ReturnType<typeof useAllReleases>>
   data: [],
   error: undefined,
   loading: false,
+  map: new Map(),
 }
 
 export const mockUseAllReleases = useAllReleases as Mock<typeof useAllReleases>

--- a/packages/sanity/src/core/releases/store/useAllReleases.ts
+++ b/packages/sanity/src/core/releases/store/useAllReleases.ts
@@ -13,6 +13,7 @@ export function useAllReleases(): {
   data: ReleaseDocument[]
   error?: Error
   loading: boolean
+  map: Map<string, ReleaseDocument>
 } {
   const {state$} = useReleasesStore()
   const {releases, error, state} = useObservable(state$)!
@@ -20,6 +21,7 @@ export function useAllReleases(): {
   return useMemo(
     () => ({
       data: sortReleases(Array.from(releases.values())),
+      map: releases,
       error: error,
       loading: ['loading', 'initialising'].includes(state),
     }),

--- a/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/__tests__/ReleasesOverview.test.tsx
@@ -379,6 +379,7 @@ describe('ReleasesOverview', () => {
         data: releases,
         error: undefined,
         loading: false,
+        map: new Map(releases.map((release) => [release._id, release])),
       })
       mockUseArchivedReleases.mockReturnValue({
         ...useArchivedReleasesMockReturn,

--- a/packages/sanity/src/core/releases/util/getReleaseIdFromReleaseDocumentId.ts
+++ b/packages/sanity/src/core/releases/util/getReleaseIdFromReleaseDocumentId.ts
@@ -4,6 +4,16 @@ import {RELEASE_DOCUMENTS_PATH} from '../store/constants'
 const PATH_ID_PREFIX = `${RELEASE_DOCUMENTS_PATH}.`
 
 /**
+ * Whether the given id addresses a release document (`_.releases.<releaseId>`) rather than
+ * being a release id or a system bundle name.
+ *
+ * @internal
+ */
+export function isReleaseDocumentId(id: string): boolean {
+  return id.startsWith(PATH_ID_PREFIX)
+}
+
+/**
  * @internal
  * @param releaseDocumentId - the document id of the release
  */


### PR DESCRIPTION
### Description
Allows editors to copy a variant across bundles. 
For example, now users can select a draft variant and copy it to a release, or they can select a release variant and copy it to another release or to the drafts using the `DocumentInventory` 

It also simplifies a bit further the `useVersionsContextMenu` by updating it to accept the `versionId` when using the legacy `VersionChip` or the `DocumentVersionInfoStub` when used through the document inventory.


https://github.com/user-attachments/assets/17e79acb-ec79-47a8-b80c-570ba444fce8



<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Copy variants, it should work! 

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a variants is internal facing
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes document version and variant client actions (copy-to-drafts, add-to-release) and shared context-menu hooks; mistakes could affect editorial workflows, though variants remain internal-facing.
> 
> **Overview**
> **Variant bundle moves** are now supported from the version context menu: copy variant release → drafts (variant create/delete), copy between releases via **Add version**, with perspective kept on the variant after navigation.
> 
> **`useCopyToDrafts`** no longer resolves source by `fromRelease` / `scopeId`; it takes a **`documentVersionInfoStub`** and branches on variant vs base document for discard/create actions. Copying a draft onto itself is rejected explicitly.
> 
> **`useVersionContextMenu`** accepts either legacy **`versionId`** (`VersionChip`) or **`documentVersionInfoStub`** (document group inventory), derives release from **`useAllReleases().map`**, and routes **add version** through **`createVariantDocument`** when the stub is variant-scoped.
> 
> **Document group inventory** feeds the popover **`useVariantPendingReleases`** (active releases the variant is not on yet) instead of a generic filtered release list. **`useAllReleases`** exposes a **`map`**; **`isReleaseDocumentId`** is added for target release parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ba34eb536917fe7b8c6a83241cfc86b6b9a171a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->