### PR TITLE
fix(releases): throttle published archived history batches

### DIFF
--- a/packages/sanity/src/core/releases/tool/detail/__tests__/getPublishedArchivedReleaseDocumentsObservable.test.ts
+++ b/packages/sanity/src/core/releases/tool/detail/__tests__/getPublishedArchivedReleaseDocumentsObservable.test.ts
@@ -1,0 +1,133 @@
+import {type ReleaseDocument, type SanityClient} from '@sanity/client'
+import {firstValueFrom, of, Subject} from 'rxjs'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getPublishedArchivedReleaseDocumentsObservable} from '../getPublishedArchivedReleaseDocumentsObservable'
+
+function createRelease(documentCount: number, releaseId = 'release-1'): ReleaseDocument {
+  return {
+    _id: `_.releases.${releaseId}`,
+    _type: 'system.release',
+    _createdAt: '2024-01-01T00:00:00Z',
+    _updatedAt: '2024-01-01T00:00:00Z',
+    _rev: 'rev1',
+    name: 'Test release',
+    state: 'published',
+    metadata: {title: 'Test release', releaseType: 'asap'},
+    finalDocumentStates: Array.from({length: documentCount}, (_, i) => ({
+      id: `versions.${releaseId}.doc${i}`,
+    })),
+  } as ReleaseDocument
+}
+
+describe('getPublishedArchivedReleaseDocumentsObservable', () => {
+  const mockRequest = vi.fn()
+  const mockConfig = vi.fn().mockReturnValue({dataset: 'test-dataset'})
+  const mockClient = {
+    config: mockConfig,
+    observable: {
+      request: mockRequest,
+    },
+  } as unknown as SanityClient
+
+  const getClient = vi.fn().mockReturnValue(mockClient)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getClient.mockReturnValue(mockClient)
+    mockConfig.mockReturnValue({dataset: 'test-dataset'})
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns empty results when the release has no final document states', async () => {
+    const release = createRelease(0)
+
+    const result = await firstValueFrom(
+      getPublishedArchivedReleaseDocumentsObservable({getClient, release}),
+    )
+
+    expect(result).toEqual({loading: false, results: [], error: null})
+    expect(mockRequest).not.toHaveBeenCalled()
+  })
+
+  it('fetches a single batch immediately when there are at most 10 documents', async () => {
+    const release = createRelease(3)
+    mockRequest.mockReturnValue(
+      of({
+        documents: [
+          {_id: 'versions.release-1.doc0', _type: 'doc', _rev: 'r0'},
+          {_id: 'versions.release-1.doc1', _type: 'doc', _rev: 'r1'},
+          {_id: 'versions.release-1.doc2', _type: 'doc', _rev: 'r2'},
+        ],
+      }),
+    )
+
+    const result = await firstValueFrom(
+      getPublishedArchivedReleaseDocumentsObservable({getClient, release}),
+    )
+
+    expect(mockRequest).toHaveBeenCalledTimes(1)
+    expect(mockRequest).toHaveBeenCalledWith({
+      url: '/data/history/test-dataset/documents/versions.release-1.doc0,versions.release-1.doc1,versions.release-1.doc2?lastRevision=true',
+    })
+    expect(result.loading).toBe(false)
+    expect(result.error).toBeNull()
+    expect(result.results).toHaveLength(3)
+  })
+
+  it('waits 100ms before requesting each subsequent history batch', async () => {
+    vi.useFakeTimers()
+
+    const release = createRelease(12, 'release-throttle')
+    const firstBatch$ = new Subject<{documents: {_id: string; _type: string; _rev: string}[]}>()
+    const secondBatch$ = new Subject<{documents: {_id: string; _type: string; _rev: string}[]}>()
+
+    mockRequest.mockReturnValueOnce(firstBatch$).mockReturnValueOnce(secondBatch$)
+
+    const resultPromise = firstValueFrom(
+      getPublishedArchivedReleaseDocumentsObservable({getClient, release}),
+    )
+
+    expect(mockRequest).toHaveBeenCalledTimes(1)
+
+    firstBatch$.next({
+      documents: Array.from({length: 10}, (_, i) => ({
+        _id: `versions.release-throttle.doc${i}`,
+        _type: 'doc',
+        _rev: `r${i}`,
+      })),
+    })
+    firstBatch$.complete()
+
+    // Next batch must not start until the inter-batch delay elapses
+    expect(mockRequest).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(99)
+    expect(mockRequest).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(mockRequest).toHaveBeenCalledTimes(2)
+    expect(mockRequest).toHaveBeenLastCalledWith({
+      url: '/data/history/test-dataset/documents/versions.release-throttle.doc10,versions.release-throttle.doc11?lastRevision=true',
+    })
+
+    secondBatch$.next({
+      documents: [
+        {_id: 'versions.release-throttle.doc10', _type: 'doc', _rev: 'r10'},
+        {_id: 'versions.release-throttle.doc11', _type: 'doc', _rev: 'r11'},
+      ],
+    })
+    secondBatch$.complete()
+
+    const result = await resultPromise
+
+    expect(result).toMatchObject({
+      loading: false,
+      error: null,
+    })
+    expect(result.results).toHaveLength(12)
+  })
+})

--- a/packages/sanity/src/core/releases/tool/detail/getPublishedArchivedReleaseDocumentsObservable.ts
+++ b/packages/sanity/src/core/releases/tool/detail/getPublishedArchivedReleaseDocumentsObservable.ts
@@ -1,7 +1,16 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {uuid} from '@sanity/uuid'
-import {of} from 'rxjs'
-import {catchError, expand, finalize, map, reduce, shareReplay} from 'rxjs/operators'
+import {EMPTY, of} from 'rxjs'
+import {
+  catchError,
+  delay,
+  expand,
+  finalize,
+  map,
+  reduce,
+  shareReplay,
+  switchMap,
+} from 'rxjs/operators'
 
 import {type useSource} from '../../../studio/source'
 import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
@@ -11,6 +20,15 @@ import {type BundleDocumentsObservableResult} from './useBundleDocuments'
 
 const publishedArchivedReleaseDocumentsCache: Record<string, BundleDocumentsObservableResult> =
   Object.create(null)
+
+/** Matches the active-release batch size used elsewhere in the release detail view. */
+const HISTORY_BATCH_SIZE = 10
+/**
+ * Delay before each subsequent `/data/history` batch.
+ * That endpoint is not CDN-cached and counts fully against the shared per-IP rate limit;
+ * zero-gap sequential batches on large multi-locale releases can exhaust retries and 429.
+ */
+const HISTORY_BATCH_DELAY_MS = 100
 
 const buildPublishedArchivedReleaseDocumentsObservable = ({
   getClient,
@@ -26,7 +44,7 @@ const buildPublishedArchivedReleaseDocumentsObservable = ({
   if (!release.finalDocumentStates?.length) return of({loading: false, results: [], error: null})
 
   function batchRequestDocumentFromHistory(startIndex: number) {
-    const finalIndex = startIndex + 10
+    const finalIndex = startIndex + HISTORY_BATCH_SIZE
     return observableClient
       .request<{documents: DocumentInRelease['document'][]}>({
         url: `/data/history/${dataset}/documents/${release.finalDocumentStates
@@ -40,11 +58,13 @@ const buildPublishedArchivedReleaseDocumentsObservable = ({
   const documents$ = batchRequestDocumentFromHistory(0).pipe(
     expand((response) => {
       if (release.finalDocumentStates && response.finalIndex < release.finalDocumentStates.length) {
-        // Continue with next batch
-        return batchRequestDocumentFromHistory(response.finalIndex)
+        // Space subsequent batches (first batch is immediate), mirroring useBundleDocuments
+        return of(null).pipe(
+          delay(HISTORY_BATCH_DELAY_MS),
+          switchMap(() => batchRequestDocumentFromHistory(response.finalIndex)),
+        )
       }
-      // End recursion by emitting an empty observable
-      return of()
+      return EMPTY
     }),
     reduce(
       (documents: DocumentInRelease['document'][], batch) => documents.concat(batch.documents),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Occasional `429 API rate limit exceeded` errors when opening large published/archived Content Releases. Published/archived release detail loads documents via sequential `/data/history/.../documents/?lastRevision=true` batches of 10 with **no gap between batches**. That endpoint is not CDN-cached, so every request counts against the shared per-IP limit — large multi-locale releases (and multiple editors on the same network) can exhaust `@sanity/client`'s 429 retries and fail the whole view.

The active-release path already staggers batches (~100ms). This adds the same inter-batch delay on the published/archived history path so batches stay sequential but stop bursting.

Alternatives considered: raising concurrency limits / CDN-caching history (API-side, out of scope); parallelizing with a shared limiter (more invasive than matching the existing pattern).

### What to review

- `getPublishedArchivedReleaseDocumentsObservable.ts` — `delay(100)` before each recursive history batch inside `expand` (first batch still immediate)
- New unit test covering the 100ms gap before the second batch

### Testing

- Added `getPublishedArchivedReleaseDocumentsObservable.test.ts` (fake timers assert second `/data/history` call waits 100ms)
- `pnpm vitest run --project=sanity packages/sanity/src/core/releases/tool/detail/__tests__/getPublishedArchivedReleaseDocumentsObservable.test.ts`
- oxfmt + oxlint on changed files

### Notes for release

Fixes occasional rate-limit errors when opening large published or archived Content Releases in Studio by spacing history API requests the same way active releases already do.

---
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sanity-io.slack.com/archives/C043ZRB9E4S/p1785356305759379?thread_ts=1785356305.759379&cid=C043ZRB9E4S)

<div><a href="https://cursor.com/agents/bc-8ef4b60a-e1eb-5a7d-848f-c25f874ee058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ef4b60a-e1eb-5a7d-848f-c25f874ee058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

