### PR TITLE
chore(structure): useCopyToDrafts changes

### DIFF
--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -548,7 +548,7 @@ const Variant: ComponentType<{
   const selectedIds = useSelector(machine, ({context}) => context.selectedIds)
   const releases = useSelector(inventoryRef, ({context}) => context.releases)
 
-  const {filteredReleases, handleCopyToDraftsNavigate} = perspectiveList
+  const {filteredReleases, clearScheduledDraftPerspective} = perspectiveList
 
   const release = versionName
     ? releases.get(getReleaseDocumentIdFromReleaseId(versionName))
@@ -564,7 +564,7 @@ const Variant: ComponentType<{
     closeDialog,
     openDiscardDialog,
     openCreateReleaseDialog,
-    openCopyToDraftsDialog,
+    handleCopyToDrafts,
     handleAddVersion,
     isScheduledDraft,
     scheduledDraftMenuActions,
@@ -576,6 +576,7 @@ const Variant: ComponentType<{
     isVersion,
     disabled: isReadOnly,
     release,
+    onCopyToDraftsComplete: clearScheduledDraftPerspective,
   })
 
   const contextMenuHandler = isReadOnly || !releasesToolAvailable ? undefined : handleContextMenu
@@ -668,8 +669,7 @@ const Variant: ComponentType<{
           releasesLoading={releasesLoading}
           onDiscard={openDiscardDialog}
           onCreateRelease={openCreateReleaseDialog}
-          onCopyToDrafts={openCopyToDraftsDialog}
-          onCopyToDraftsNavigate={handleCopyToDraftsNavigate}
+          onCopyToDrafts={handleCopyToDrafts}
           onCreateVersion={handleAddVersion}
           disabled={isReadOnly}
           release={release}
@@ -689,7 +689,7 @@ const Variant: ComponentType<{
         title={variant.name}
         sourceReleasePerspective={sourceReleasePerspective}
         onCreateVersion={handleAddVersion}
-        onCopyToDraftsNavigate={handleCopyToDraftsNavigate}
+        onCopyToDrafts={handleCopyToDrafts}
         scheduledDraftDialogs={isScheduledDraft && scheduledDraftMenuActions.dialogs}
       />
     </>

--- a/packages/sanity/src/core/documentGroupInventory/types.ts
+++ b/packages/sanity/src/core/documentGroupInventory/types.ts
@@ -22,7 +22,7 @@ export interface DocumentGroupInventoryReferencePreviewLinkProps {
 export interface DocumentGroupInventoryPerspectiveList {
   filteredReleases: {notCurrentReleases: ReleaseDocument[]}
   getReleaseChipState: (releaseId: string) => {selected: boolean; disabled?: boolean}
-  handleCopyToDraftsNavigate: () => void
+  clearScheduledDraftPerspective: () => void
   isDraftSelected: boolean
   isPublishSelected: boolean
 }

--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -47,7 +47,7 @@ export const VersionChip = memo(function VersionChip(props: {
   contextMenuPortal?: boolean
   tone: BadgeTone
   locked?: boolean
-  onCopyToDraftsNavigate: () => void
+  onCopyToDraftsComplete?: () => void
   contextValues: {
     documentId: string
     documentType: string
@@ -69,7 +69,7 @@ export const VersionChip = memo(function VersionChip(props: {
     contextMenuPortal = true,
     tone,
     locked = false,
-    onCopyToDraftsNavigate,
+    onCopyToDraftsComplete,
     contextValues: {
       documentId,
       releases,
@@ -101,7 +101,7 @@ export const VersionChip = memo(function VersionChip(props: {
     closeDialog,
     openDiscardDialog,
     openCreateReleaseDialog,
-    openCopyToDraftsDialog,
+    handleCopyToDrafts,
     handleAddVersion,
     isScheduledDraft,
     scheduledDraftMenuActions,
@@ -113,6 +113,7 @@ export const VersionChip = memo(function VersionChip(props: {
     isVersion,
     disabled: contextMenuDisabled,
     release,
+    onCopyToDraftsComplete,
   })
 
   const contextMenuHandler = disabled || !releasesToolAvailable ? undefined : handleContextMenu
@@ -159,8 +160,7 @@ export const VersionChip = memo(function VersionChip(props: {
         releasesLoading={releasesLoading}
         onDiscard={openDiscardDialog}
         onCreateRelease={openCreateReleaseDialog}
-        onCopyToDrafts={openCopyToDraftsDialog}
-        onCopyToDraftsNavigate={onCopyToDraftsNavigate}
+        onCopyToDrafts={handleCopyToDrafts}
         onCreateVersion={handleAddVersion}
         disabled={contextMenuDisabled}
         locked={locked}
@@ -181,7 +181,7 @@ export const VersionChip = memo(function VersionChip(props: {
         title={text}
         sourceReleasePerspective={sourceReleasePerspective}
         onCreateVersion={handleAddVersion}
-        onCopyToDraftsNavigate={onCopyToDraftsNavigate}
+        onCopyToDrafts={handleCopyToDrafts}
         isGoingToUnpublish={isGoingToUnpublish}
         scheduledDraftDialogs={isScheduledDraft && scheduledDraftMenuActions.dialogs}
       />

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CanonicalReleaseContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CanonicalReleaseContextMenu.tsx
@@ -8,6 +8,7 @@ import {IntentLink} from 'sanity/router'
 import {MenuItem} from '../../../../../ui-components/menuItem/MenuItem'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
 import {useWorkspace} from '../../../../studio/workspace'
+import {type CopyToDraftsOptions} from '../../../hooks/useCopyToDrafts'
 import {RELEASES_INTENT} from '../../../plugin'
 import {isReleaseScheduledOrScheduling} from '../../../util/util'
 import {useHasCopyToDraftOption} from './CopyToDraftsMenuItem'
@@ -15,12 +16,10 @@ import {CopyToReleaseMenuGroup} from './CopyToReleaseMenuGroup'
 
 interface CanonicalReleaseContextMenuProps {
   bundleId: string
-  isVersion: boolean
   release?: ReleaseDocument
   onDiscard: () => void
   onCreateRelease: () => void
-  onCopyToDrafts: () => void
-  onCopyToDraftsNavigate: () => void
+  onCopyToDrafts: (options: CopyToDraftsOptions) => Promise<void>
   onCreateVersion: (targetId: string) => void
   disabled?: boolean
   locked?: boolean
@@ -33,7 +32,6 @@ interface CanonicalReleaseContextMenuProps {
    * Defaults to `true`.
    */
   isDiscardable?: boolean
-  documentId: string
   documentType: string
   releases: ReleaseDocument[]
   releasesLoading: boolean
@@ -46,11 +44,9 @@ export const CanonicalReleaseContextMenu = memo(function CanonicalReleaseContext
     releases,
     releasesLoading,
     bundleId,
-    isVersion,
     onDiscard,
     onCreateRelease,
     onCopyToDrafts,
-    onCopyToDraftsNavigate,
     onCreateVersion,
     disabled,
     locked,
@@ -60,7 +56,6 @@ export const CanonicalReleaseContextMenu = memo(function CanonicalReleaseContext
     hasDiscardPermission,
     isPublished,
     isDiscardable = true,
-    documentId,
     documentType,
   } = props
   const {t} = useTranslation()
@@ -94,11 +89,9 @@ export const CanonicalReleaseContextMenu = memo(function CanonicalReleaseContext
           bundleId={bundleId}
           onCreateRelease={onCreateRelease}
           onCopyToDrafts={onCopyToDrafts}
-          onCopyToDraftsNavigate={onCopyToDraftsNavigate}
           onCreateVersion={onCreateVersion}
           disabled={isCopyToReleaseDisabled}
           hasCreatePermission={hasCreatePermission}
-          documentId={documentId}
           documentType={documentType}
         />
       )}

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CopyToDraftsMenuItem.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CopyToDraftsMenuItem.tsx
@@ -1,20 +1,18 @@
 import {Box, Flex, Text} from '@sanity/ui'
-import {memo, useCallback} from 'react'
+import {memo} from 'react'
 
 import {MenuItem} from '../../../../../ui-components/menuItem/MenuItem'
 import {useSchema} from '../../../../hooks/useSchema'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
 import {useWorkspace} from '../../../../studio/workspace'
-import {useCopyToDrafts} from '../../../hooks/useCopyToDrafts'
+import {type CopyToDraftsOptions} from '../../../hooks/useCopyToDrafts'
 import {LATEST} from '../../../util/const'
 import {ReleaseAvatar} from '../../ReleaseAvatar'
 
 interface CopyToDraftsMenuItemProps {
-  documentId: string
   documentType: string
   fromRelease: string
-  onClick: () => void
-  onNavigate: () => void
+  onClick: (options: CopyToDraftsOptions) => Promise<void>
 }
 
 /**
@@ -38,23 +36,9 @@ export const useHasCopyToDraftOption = (documentType: string, fromRelease: strin
 export const CopyToDraftsMenuItem = memo(function CopyToDraftsMenuItem(
   props: CopyToDraftsMenuItemProps,
 ) {
-  const {documentId, documentType, fromRelease, onClick, onNavigate} = props
+  const {documentType, fromRelease, onClick} = props
   const {t} = useTranslation()
   const shouldShowDraftsOption = useHasCopyToDraftOption(documentType, fromRelease)
-
-  const {handleCopyToDrafts, hasDraftVersion} = useCopyToDrafts({
-    documentId,
-    fromRelease,
-    onNavigate,
-  })
-
-  const handleDraftsClick = useCallback(() => {
-    if (hasDraftVersion) {
-      onClick()
-    } else {
-      void handleCopyToDrafts()
-    }
-  }, [hasDraftVersion, onClick, handleCopyToDrafts])
 
   if (!shouldShowDraftsOption) {
     return null
@@ -63,7 +47,7 @@ export const CopyToDraftsMenuItem = memo(function CopyToDraftsMenuItem(
   return (
     <MenuItem
       as="a"
-      onClick={handleDraftsClick}
+      onClick={() => void onClick({shouldConfirmDraftDiscard: true})}
       data-testid="copy-to-drafts-menu-item"
       renderMenuItem={() => (
         <Flex gap={3} align="center">

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CopyToReleaseMenuGroup.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/CopyToReleaseMenuGroup.tsx
@@ -7,6 +7,7 @@ import {styled} from 'styled-components'
 import {MenuGroup} from '../../../../../ui-components/menuGroup/MenuGroup'
 import {MenuItem} from '../../../../../ui-components/menuItem/MenuItem'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
+import {type CopyToDraftsOptions} from '../../../hooks/useCopyToDrafts'
 import {CreateReleaseMenuItem} from '../../CreateReleaseMenuItem'
 import {CopyToDraftsMenuItem} from './CopyToDraftsMenuItem'
 import {VersionContextMenuItem} from './VersionContextMenuItem'
@@ -21,12 +22,10 @@ interface CopyToReleaseMenuGroupProps {
   releases: ReleaseDocument[]
   bundleId: string
   onCreateRelease: () => void
-  onCopyToDrafts: () => void
-  onCopyToDraftsNavigate: () => void
+  onCopyToDrafts: (options: CopyToDraftsOptions) => Promise<void>
   onCreateVersion: (targetId: string) => void
   disabled: boolean
   hasCreatePermission: boolean | null
-  documentId: string
   documentType: string
   hasCopyToDraftOption?: boolean
   isReleasesEnabled?: boolean
@@ -40,13 +39,11 @@ export const CopyToReleaseMenuGroup = memo(function CopyToReleaseMenuGroup(
     bundleId,
     onCreateRelease,
     onCopyToDrafts,
-    onCopyToDraftsNavigate,
     onCreateVersion,
     disabled,
     isReleasesEnabled,
     hasCreatePermission,
     hasCopyToDraftOption,
-    documentId,
     documentType,
   } = props
   const {t} = useTranslation()
@@ -68,10 +65,8 @@ export const CopyToReleaseMenuGroup = memo(function CopyToReleaseMenuGroup(
           {hasCopyToDraftOption && (
             <CopyToDraftsMenuItem
               documentType={documentType}
-              documentId={documentId}
               fromRelease={bundleId}
               onClick={onCopyToDrafts}
-              onNavigate={onCopyToDraftsNavigate}
             />
           )}
           {releases.map((targetRelease) => {

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/ScheduledDraftContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/ScheduledDraftContextMenu.tsx
@@ -10,6 +10,7 @@ import {type UseScheduledDraftMenuActionsReturn} from '../../../../singleDocRele
 import {RELEASES_SCHEDULED_DRAFTS_INTENT} from '../../../../singleDocRelease/plugin'
 import {useWorkspace} from '../../../../studio/workspace'
 import {isPausedCardinalityOneRelease} from '../../../../util/releaseUtils'
+import {type CopyToDraftsOptions} from '../../../hooks/useCopyToDrafts'
 import {isReleaseScheduledOrScheduling} from '../../../util/util'
 import {useHasCopyToDraftOption} from './CopyToDraftsMenuItem'
 import {CopyToReleaseMenuGroup} from './CopyToReleaseMenuGroup'
@@ -18,14 +19,12 @@ interface ScheduledDraftContextMenuProps {
   releases: ReleaseDocument[]
   bundleId: string
   onCreateRelease: () => void
-  onCopyToDrafts: () => void
-  onCopyToDraftsNavigate: () => void
+  onCopyToDrafts: (options: CopyToDraftsOptions) => Promise<void>
   onCreateVersion: (targetId: string) => void
   disabled?: boolean
   isGoingToUnpublish?: boolean
   hasCreatePermission: boolean | null
   scheduledDraftMenuActions: UseScheduledDraftMenuActionsReturn
-  documentId: string
   documentType: string
   release?: ReleaseDocument
 }
@@ -38,13 +37,11 @@ export const ScheduledDraftContextMenu = memo(function ScheduledDraftContextMenu
     bundleId,
     onCreateRelease,
     onCopyToDrafts,
-    onCopyToDraftsNavigate,
     onCreateVersion,
     disabled,
     isGoingToUnpublish = false,
     hasCreatePermission,
     scheduledDraftMenuActions,
-    documentId,
     documentType,
     release,
   } = props
@@ -80,11 +77,9 @@ export const ScheduledDraftContextMenu = memo(function ScheduledDraftContextMenu
             isReleasesEnabled={isReleasesEnabled}
             onCreateRelease={onCreateRelease}
             onCopyToDrafts={onCopyToDrafts}
-            onCopyToDraftsNavigate={onCopyToDraftsNavigate}
             onCreateVersion={onCreateVersion}
             disabled={isCopyToReleaseDisabled}
             hasCreatePermission={hasCreatePermission}
-            documentId={documentId}
             documentType={documentType}
           />
           <MenuDivider />

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
@@ -4,6 +4,7 @@ import {memo, useEffect, useRef, useState} from 'react'
 import {type UseScheduledDraftMenuActionsReturn} from '../../../../singleDocRelease/hooks/useScheduledDraftMenuActions'
 import {useDocumentPairPermissions} from '../../../../store/grants/documentPairPermissions'
 import {getPublishedId, isPublishedId} from '../../../../util/draftUtils'
+import {type CopyToDraftsOptions} from '../../../hooks/useCopyToDrafts'
 import {useReleaseOperations} from '../../../store/useReleaseOperations'
 import {useReleasePermissions} from '../../../store/useReleasePermissions'
 import {getReleaseDefaults} from '../../../util/util'
@@ -18,8 +19,7 @@ interface VersionContextMenuProps {
   isVersion: boolean
   onDiscard: () => void
   onCreateRelease: () => void
-  onCopyToDrafts: () => void
-  onCopyToDraftsNavigate: () => void
+  onCopyToDrafts: (options: CopyToDraftsOptions) => Promise<void>
   onCreateVersion: (targetId: string) => void
   disabled?: boolean
   locked?: boolean
@@ -45,7 +45,6 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: Versio
     onDiscard,
     onCreateRelease,
     onCopyToDrafts,
-    onCopyToDraftsNavigate,
     onCreateVersion,
     disabled,
     locked,
@@ -97,13 +96,11 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: Versio
         release={release}
         onCreateRelease={onCreateRelease}
         onCopyToDrafts={onCopyToDrafts}
-        onCopyToDraftsNavigate={onCopyToDraftsNavigate}
         onCreateVersion={onCreateVersion}
         disabled={disabled}
         isGoingToUnpublish={isGoingToUnpublish}
         hasCreatePermission={hasCreatePermission}
         scheduledDraftMenuActions={scheduledDraftMenuActions}
-        documentId={documentId}
         documentType={type}
       />
     )
@@ -115,11 +112,9 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: Versio
       releasesLoading={releasesLoading}
       bundleId={fromRelease}
       release={release}
-      isVersion={isVersion}
       onDiscard={onDiscard}
       onCreateRelease={onCreateRelease}
       onCopyToDrafts={onCopyToDrafts}
-      onCopyToDraftsNavigate={onCopyToDraftsNavigate}
       onCreateVersion={onCreateVersion}
       disabled={disabled}
       locked={locked}
@@ -128,7 +123,6 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: Versio
       hasDiscardPermission={hasDiscardPermission || false}
       isPublished={isPublished}
       isDiscardable={isDiscardable}
-      documentId={documentId}
       documentType={type}
     />
   )

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuDialogs.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuDialogs.tsx
@@ -2,6 +2,7 @@ import {memo, type ReactNode} from 'react'
 
 import {type TargetPerspective} from '../../../../perspective/types'
 import {getVersionId} from '../../../../util/draftUtils'
+import {type CopyToDraftsOptions} from '../../../hooks/useCopyToDrafts'
 import {type VersionContextMenuDialogState} from '../../../hooks/useVersionContextMenu'
 import {DiscardVersionDialog} from '../../dialog/DiscardVersionDialog'
 import {CopyToDraftsDialog} from '../dialog/CopyToDraftsDialog'
@@ -24,7 +25,7 @@ export interface VersionContextMenuDialogsProps {
   /** The release or system bundle the dialogs act on behalf of. */
   sourceReleasePerspective: TargetPerspective
   onCreateVersion: (targetRelease: string) => void
-  onCopyToDraftsNavigate: () => void
+  onCopyToDrafts: (options: CopyToDraftsOptions) => Promise<void>
   isGoingToUnpublish?: boolean
   /**
    * Whether the UI permits discarding versions.
@@ -54,7 +55,7 @@ export const VersionContextMenuDialogs = memo(function VersionContextMenuDialogs
     title,
     sourceReleasePerspective,
     onCreateVersion,
-    onCopyToDraftsNavigate,
+    onCopyToDrafts,
     isGoingToUnpublish = false,
     isDiscardable = true,
     scheduledDraftDialogs,
@@ -84,12 +85,7 @@ export const VersionContextMenuDialogs = memo(function VersionContextMenuDialogs
       )}
 
       {dialogState === 'copy-to-drafts' && (
-        <CopyToDraftsDialog
-          onClose={onClose}
-          documentId={documentId}
-          fromRelease={bundleId}
-          onNavigate={onCopyToDraftsNavigate}
-        />
+        <CopyToDraftsDialog onClose={onClose} onConfirm={onCopyToDrafts} />
       )}
       {scheduledDraftDialogs}
     </>

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuPopover.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuPopover.tsx
@@ -3,6 +3,7 @@ import {memo, type RefObject} from 'react'
 
 import {Popover} from '../../../../../ui-components/popover/Popover'
 import {type UseScheduledDraftMenuActionsReturn} from '../../../../singleDocRelease/hooks/useScheduledDraftMenuActions'
+import {type CopyToDraftsOptions} from '../../../hooks/useCopyToDrafts'
 import {type VersionContextMenuState} from '../../../hooks/useVersionContextMenu'
 import {VersionContextMenu} from './VersionContextMenu'
 
@@ -25,8 +26,7 @@ export interface VersionContextMenuPopoverProps {
   releasesLoading: boolean
   onDiscard: () => void
   onCreateRelease: () => void
-  onCopyToDrafts: () => void
-  onCopyToDraftsNavigate: () => void
+  onCopyToDrafts: (options: CopyToDraftsOptions) => Promise<void>
   onCreateVersion: (targetRelease: string) => void
   disabled?: boolean
   locked?: boolean
@@ -70,7 +70,6 @@ export const VersionContextMenuPopover = memo(function VersionContextMenuPopover
     onDiscard,
     onCreateRelease,
     onCopyToDrafts,
-    onCopyToDraftsNavigate,
     onCreateVersion,
     disabled = false,
     locked = false,
@@ -95,7 +94,6 @@ export const VersionContextMenuPopover = memo(function VersionContextMenuPopover
           onDiscard={onDiscard}
           onCreateRelease={onCreateRelease}
           onCopyToDrafts={onCopyToDrafts}
-          onCopyToDraftsNavigate={onCopyToDraftsNavigate}
           disabled={disabled}
           onCreateVersion={onCreateVersion}
           locked={locked}

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
@@ -80,7 +80,6 @@ describe('VersionContextMenu', () => {
 
     const wrapper = await createTestProvider()
 
-    // @ts-expect-error -- pre-existing, fix later
     render(<VersionContextMenu {...defaultProps} />, {wrapper})
     await flushMicrotasksThisIsACodeSmell()
 
@@ -104,7 +103,6 @@ describe('VersionContextMenu', () => {
 
     const wrapper = await createTestProvider()
 
-    // @ts-expect-error -- pre-existing, fix later
     render(<VersionContextMenu {...defaultProps} />, {wrapper})
     await flushMicrotasksThisIsACodeSmell()
 
@@ -130,7 +128,6 @@ describe('VersionContextMenu', () => {
       isVersion: false,
     }
 
-    // @ts-expect-error -- pre-existing, fix later
     render(<VersionContextMenu {...publishedProps} />, {wrapper})
     await flushMicrotasksThisIsACodeSmell()
 
@@ -142,7 +139,6 @@ describe('VersionContextMenu', () => {
 
     const wrapper = await createTestProvider()
 
-    // @ts-expect-error -- pre-existing, fix later
     render(<VersionContextMenu {...defaultProps} />, {wrapper})
     await flushMicrotasksThisIsACodeSmell()
 
@@ -160,7 +156,6 @@ describe('VersionContextMenu', () => {
 
     const wrapper = await createTestProvider()
 
-    // @ts-expect-error -- pre-existing, fix later
     render(<VersionContextMenu {...defaultProps} />, {wrapper})
     await flushMicrotasksThisIsACodeSmell()
 
@@ -181,7 +176,6 @@ describe('VersionContextMenu', () => {
 
     const wrapper = await createTestProvider()
 
-    // @ts-expect-error -- pre-existing, fix later
     render(<VersionContextMenu {...defaultProps} />, {wrapper})
     await flushMicrotasksThisIsACodeSmell()
 
@@ -202,7 +196,6 @@ describe('VersionContextMenu', () => {
 
     const wrapper = await createTestProvider()
 
-    // @ts-expect-error -- pre-existing, fix later
     render(<VersionContextMenu {...defaultProps} isGoingToUnpublish />, {wrapper})
     await flushMicrotasksThisIsACodeSmell()
 

--- a/packages/sanity/src/core/releases/components/documentHeader/dialog/CopyToDraftsDialog.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/dialog/CopyToDraftsDialog.tsx
@@ -3,31 +3,27 @@ import {memo, useCallback, useTransition} from 'react'
 
 import {Dialog} from '../../../../../ui-components/dialog/Dialog'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
-import {useCopyToDrafts} from '../../../hooks/useCopyToDrafts'
+import {type CopyToDraftsOptions} from '../../../hooks/useCopyToDrafts'
 import {releasesLocaleNamespace} from '../../../i18n'
 
 interface CopyToDraftsDialogProps {
-  documentId: string
-  fromRelease: string
   onClose: () => void
-  onNavigate: () => void
+  onConfirm: (options: CopyToDraftsOptions) => Promise<void>
 }
 
 export const CopyToDraftsDialog = memo(function CopyToDraftsDialog(props: CopyToDraftsDialogProps) {
-  const {documentId, fromRelease, onClose, onNavigate} = props
+  const {onClose, onConfirm} = props
   const {t: tReleases} = useTranslation(releasesLocaleNamespace)
 
   const [isProcessing, startTransition] = useTransition()
 
-  const {handleCopyToDrafts} = useCopyToDrafts({documentId, fromRelease, onNavigate})
-
   const handleConfirm = useCallback(
     () =>
       startTransition(async () => {
-        await handleCopyToDrafts()
+        await onConfirm({shouldConfirmDraftDiscard: false})
         onClose()
       }),
-    [handleCopyToDrafts, onClose, startTransition],
+    [onConfirm, onClose, startTransition],
   )
 
   return (

--- a/packages/sanity/src/core/releases/hooks/useCopyToDrafts.ts
+++ b/packages/sanity/src/core/releases/hooks/useCopyToDrafts.ts
@@ -8,19 +8,23 @@ import {getPublishedId, getVersionId} from '../../util/draftUtils'
 import {getDocumentVersionInfoFromVersions} from '../util/getDocumentVersionInfoFromVersions'
 import {useDocumentVersions} from './useDocumentVersions'
 
+export interface CopyToDraftsOptions {
+  shouldConfirmDraftDiscard: boolean
+}
+
 export interface UseCopyToDraftsOptions {
   documentId: string
   fromRelease: string
   onNavigate: () => void
+  onConfirmationRequest: () => void
 }
 
 export interface UseCopyToDraftsReturn {
-  handleCopyToDrafts: () => Promise<void>
-  hasDraftVersion: boolean
+  handleCopyToDrafts: (options: CopyToDraftsOptions) => Promise<void>
 }
 
 export function useCopyToDrafts(options: UseCopyToDraftsOptions): UseCopyToDraftsReturn {
-  const {documentId, fromRelease, onNavigate} = options
+  const {documentId, fromRelease, onNavigate, onConfirmationRequest} = options
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const toast = useToast()
   const {t} = useTranslation()
@@ -38,41 +42,56 @@ export function useCopyToDrafts(options: UseCopyToDraftsOptions): UseCopyToDraft
     [versions],
   )
 
-  const handleCopyToDrafts = useCallback(async () => {
-    // Workaround for React Compiler not yet fully supporting try/catch syntax
-    const run = async () => {
-      const sourceDoc = await client.getDocument(sourceDocumentId)
-
-      if (!sourceDoc) {
-        throw new Error(`Source document ${sourceDocumentId} not found`)
+  const handleCopyToDrafts = useCallback(
+    async ({shouldConfirmDraftDiscard}: CopyToDraftsOptions) => {
+      if (shouldConfirmDraftDiscard && hasDraftVersion) {
+        onConfirmationRequest()
+        return
       }
+      // Workaround for React Compiler not yet fully supporting try/catch syntax
+      const run = async () => {
+        const sourceDoc = await client.getDocument(sourceDocumentId)
 
-      if (hasDraftVersion) {
-        await client.discardVersion({publishedId}, false)
+        if (!sourceDoc) {
+          throw new Error(`Source document ${sourceDocumentId} not found`)
+        }
+
+        if (hasDraftVersion) {
+          await client.discardVersion({publishedId}, false)
+        }
+
+        await client.createVersion({
+          baseId: sourceDocumentId,
+          ifBaseRevisionId: sourceDoc._rev,
+          publishedId,
+        })
+
+        onNavigate()
       }
-
-      await client.createVersion({
-        baseId: sourceDocumentId,
-        ifBaseRevisionId: sourceDoc._rev,
-        publishedId,
-      })
-
-      onNavigate()
-    }
-    try {
-      await run()
-    } catch (err) {
-      toast.push({
-        closable: true,
-        status: 'error',
-        title: t('release.action.create-version.failure'),
-        description: err.message,
-      })
-    }
-  }, [client, sourceDocumentId, hasDraftVersion, publishedId, toast, onNavigate, t])
+      try {
+        await run()
+      } catch (err) {
+        toast.push({
+          closable: true,
+          status: 'error',
+          title: t('release.action.create-version.failure'),
+          description: err.message,
+        })
+      }
+    },
+    [
+      client,
+      sourceDocumentId,
+      hasDraftVersion,
+      publishedId,
+      toast,
+      onNavigate,
+      t,
+      onConfirmationRequest,
+    ],
+  )
 
   return {
     handleCopyToDrafts,
-    hasDraftVersion,
   }
 }

--- a/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
+++ b/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
@@ -4,6 +4,7 @@ import {type MouseEvent, type RefObject, useCallback, useRef, useState} from 're
 
 import {useTranslation} from '../../i18n/hooks/useTranslation'
 import {type TargetPerspective} from '../../perspective/types'
+import {useSetPerspective} from '../../perspective/useSetPerspective'
 import {useSingleDocRelease} from '../../singleDocRelease/context/SingleDocReleaseProvider'
 import {useClearScheduledDraftPerspectiveOnDelete} from '../../singleDocRelease/hooks/useClearScheduledDraftPerspectiveOnDelete'
 import {
@@ -14,6 +15,7 @@ import {getVersionId} from '../../util/draftUtils'
 import {isCardinalityOneRelease} from '../../util/releaseUtils'
 import {LATEST, PUBLISHED} from '../util/const'
 import {getReleaseIdFromReleaseDocumentId} from '../util/getReleaseIdFromReleaseDocumentId'
+import {type CopyToDraftsOptions, useCopyToDrafts} from './useCopyToDrafts'
 import {useVersionOperations} from './useVersionOperations'
 
 const CONTEXT_MENU_CLOSED = {open: false as const}
@@ -51,6 +53,12 @@ export interface UseVersionContextMenuOptions {
   /** Disables the menu actions (the menu can still be opened). */
   disabled?: boolean
   release?: ReleaseDocument
+  /**
+   * Called after a successful copy-to-drafts (after navigating to drafts).
+   * Structure uses this to clear the pane-local scheduled draft perspective
+   * when needed.
+   */
+  onCopyToDraftsComplete?: () => void
 }
 
 /**
@@ -71,7 +79,12 @@ export interface UseVersionContextMenuReturn {
   closeDialog: () => void
   openDiscardDialog: () => void
   openCreateReleaseDialog: () => void
-  openCopyToDraftsDialog: () => void
+  /**
+   * Copies the version to drafts. Pass `shouldConfirmDraftDiscard: true` from
+   * the menu to open a confirm dialog when a draft already exists; pass
+   * `false` from the dialog confirm action to proceed without prompting.
+   */
+  handleCopyToDrafts: (options: CopyToDraftsOptions) => Promise<void>
   /** Creates a version of the document in the given release and closes the menu. */
   handleAddVersion: (targetRelease: string) => Promise<void>
   isScheduledDraft: boolean
@@ -93,7 +106,15 @@ export interface UseVersionContextMenuReturn {
 export function useVersionContextMenu(
   options: UseVersionContextMenuOptions,
 ): UseVersionContextMenuReturn {
-  const {documentId, documentType, bundleId, isVersion, disabled = false, release} = options
+  const {
+    documentId,
+    documentType,
+    bundleId,
+    isVersion,
+    disabled = false,
+    release,
+    onCopyToDraftsComplete,
+  } = options
 
   const [contextMenu, setContextMenu] = useState<VersionContextMenuState>({open: false})
   const popoverRef = useRef<HTMLDivElement | null>(null)
@@ -106,6 +127,7 @@ export function useVersionContextMenu(
   const toast = useToast()
   const {t} = useTranslation()
   const {onSetScheduledDraftPerspective} = useSingleDocRelease()
+  const setPerspective = useSetPerspective()
 
   const closeContextMenu = useCallback(() => setContextMenu(CONTEXT_MENU_CLOSED), [])
 
@@ -145,9 +167,17 @@ export function useVersionContextMenu(
     setDialogState('create-release')
   }, [])
 
-  const openCopyToDraftsDialog = useCallback(() => {
-    setDialogState('copy-to-drafts')
-  }, [])
+  const handleCopyToDraftsNavigate = useCallback(() => {
+    setPerspective('drafts')
+    onCopyToDraftsComplete?.()
+  }, [setPerspective, onCopyToDraftsComplete])
+
+  const {handleCopyToDrafts} = useCopyToDrafts({
+    documentId,
+    fromRelease: bundleId,
+    onNavigate: handleCopyToDraftsNavigate,
+    onConfirmationRequest: () => setDialogState('copy-to-drafts'),
+  })
 
   const handleAddVersion = useCallback(
     async (targetRelease: string) => {
@@ -199,7 +229,7 @@ export function useVersionContextMenu(
     closeDialog,
     openDiscardDialog,
     openCreateReleaseDialog,
-    openCopyToDraftsDialog,
+    handleCopyToDrafts,
     handleAddVersion,
     isScheduledDraft,
     scheduledDraftMenuActions,

--- a/packages/sanity/src/structure/hooks/useDocumentPerspectiveList.ts
+++ b/packages/sanity/src/structure/hooks/useDocumentPerspectiveList.ts
@@ -1,7 +1,6 @@
 import {type BadgeTone} from '@sanity/ui'
 import {useCallback, useMemo} from 'react'
 import {
-  getReleaseIdFromReleaseDocumentId,
   getVariantTitle,
   getVersionFromId,
   isDraftId,
@@ -15,7 +14,6 @@ import {
   useFilteredReleases,
   usePerspective,
   useSchema,
-  useSetPerspective,
   useSingleDocRelease,
   useWorkspace,
   useAllVariants,
@@ -43,8 +41,11 @@ interface DocumentPerspectiveList {
   } | null
   /** Returns the chip selection/disabled state for a given release id. */
   getReleaseChipState: (releaseId: string) => {selected: boolean; disabled?: boolean}
-  /** Navigates to the draft perspective after copying a version to drafts. */
-  handleCopyToDraftsNavigate: () => void
+  /**
+   * Clears the pane-local scheduled draft perspective when viewing one.
+   * Passed into version context menus for post copy-to-drafts cleanup.
+   */
+  clearScheduledDraftPerspective: () => void
   /** Navigates to the given perspective. */
   handlePerspectiveChange: (perspective: TargetPerspective) => void
   isDraftDisabled: boolean
@@ -75,7 +76,6 @@ interface DocumentPerspectiveList {
  */
 export function useDocumentPerspectiveList(): DocumentPerspectiveList {
   const {selectedReleaseId, selectedPerspectiveName, selectedVariant, bundle} = usePerspective()
-  const setPerspective = useSetPerspective()
   const {params} = usePaneRouter()
   const schema = useSchema()
   const {editState, displayed} = useDocumentPane()
@@ -97,17 +97,11 @@ export function useDocumentPerspectiveList(): DocumentPerspectiveList {
   const workspace = useWorkspace()
   const {onSetScheduledDraftPerspective} = useSingleDocRelease()
 
-  const handleCopyToDraftsNavigate = useCallback(() => {
-    // after copying to draft, we want to navigate to the draft version
+  const clearScheduledDraftPerspective = useCallback(() => {
     if (params?.scheduledDraft) {
-      // if currently viewing a scheduled draft, remove the scheduled draft perspective
-      // the global perspective is already set to drafts
       onSetScheduledDraftPerspective('')
-    } else {
-      // otherwise, only need to set the global perspective to drafts
-      setPerspective('drafts')
     }
-  }, [params, setPerspective, onSetScheduledDraftPerspective])
+  }, [params, onSetScheduledDraftPerspective])
 
   const {navigate: handlePerspectiveChange} = usePerspectiveNavigator()
 
@@ -294,7 +288,7 @@ export function useDocumentPerspectiveList(): DocumentPerspectiveList {
     filteredReleases,
     getVersionDisplay,
     getReleaseChipState,
-    handleCopyToDraftsNavigate,
+    clearScheduledDraftPerspective,
     handlePerspectiveChange,
     isDraftDisabled,
     isDraftModelEnabled,

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/NonReleaseVersionsSelect.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/NonReleaseVersionsSelect.tsx
@@ -20,7 +20,7 @@ export function NonReleaseVersionsSelect(props: {
   nonReleaseVersions: VersionInfoDocumentStub[]
   selectedPerspective?: string
   onSelectBundle: (version: VersionInfoDocumentStub) => void
-  onCopyToDraftsNavigate: () => void
+  onCopyToDraftsComplete: () => void
   releases: ReleaseDocument[]
   releasesLoading: boolean
   documentType: string
@@ -31,7 +31,7 @@ export function NonReleaseVersionsSelect(props: {
     nonReleaseVersions,
     selectedPerspective,
     onSelectBundle,
-    onCopyToDraftsNavigate,
+    onCopyToDraftsComplete,
     documentType,
     getVersionDisplay,
     releasesLoading,
@@ -85,7 +85,7 @@ export function NonReleaseVersionsSelect(props: {
               text={versionDisplay?.displayName ?? bundleId}
               tone={versionDisplay?.tone ?? 'default'}
               onClick={() => onSelectBundle(selectedNonReleaseVersion)}
-              onCopyToDraftsNavigate={onCopyToDraftsNavigate}
+              onCopyToDraftsComplete={onCopyToDraftsComplete}
               contextValues={{
                 documentId: getPublishedId(selectedNonReleaseVersion._id),
                 releases,
@@ -145,7 +145,7 @@ export function NonReleaseVersionsSelect(props: {
                     contextMenuPortal={false}
                     tone={versionDisplay?.tone ?? 'default'}
                     onClick={() => onSelectBundle(nonReleaseVersion)}
-                    onCopyToDraftsNavigate={onCopyToDraftsNavigate}
+                    onCopyToDraftsComplete={onCopyToDraftsComplete}
                     contextValues={{
                       documentId: getPublishedId(nonReleaseVersion._id),
                       releases,

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -85,7 +85,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
     filteredReleases,
     getVersionDisplay,
     getReleaseChipState,
-    handleCopyToDraftsNavigate,
+    clearScheduledDraftPerspective,
     handlePerspectiveChange,
     handleVariantSelectionChange,
     isDraftDisabled,
@@ -120,7 +120,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
         selected={isPublishSelected}
         text={t('release.chip.published')}
         tone="positive"
-        onCopyToDraftsNavigate={handleCopyToDraftsNavigate}
+        onCopyToDraftsComplete={clearScheduledDraftPerspective}
         contextValues={{
           documentId: editState?.published?._id || editState?.id || '',
           releases: filteredReleases.notCurrentReleases,
@@ -165,7 +165,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
           text={t('release.chip.draft')}
           tone={editState?.draft ? 'caution' : 'neutral'}
           onClick={() => handlePerspectiveChange('drafts')}
-          onCopyToDraftsNavigate={handleCopyToDraftsNavigate}
+          onCopyToDraftsComplete={clearScheduledDraftPerspective}
           contextValues={{
             documentId: editState?.draft?._id || editState?.published?._id || editState?.id || '',
             documentType: documentType,
@@ -201,7 +201,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
               locked={false}
               tone={getReleaseTone(filteredReleases.inCreation!)}
               text={displayTitle}
-              onCopyToDraftsNavigate={handleCopyToDraftsNavigate}
+              onCopyToDraftsComplete={clearScheduledDraftPerspective}
               contextValues={{
                 documentId: displayed?._id || '',
                 documentType,
@@ -244,7 +244,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
                 text={displayTitle}
                 tone={getReleaseTone(release)}
                 locked={isReleaseScheduledOrScheduling(release)}
-                onCopyToDraftsNavigate={handleCopyToDraftsNavigate}
+                onCopyToDraftsComplete={clearScheduledDraftPerspective}
                 contextValues={{
                   documentId: displayed?._id || '',
                   documentType,
@@ -268,7 +268,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
           const scopeId = version._system.scopeId!
           handlePerspectiveChange(scopeId)
         }}
-        onCopyToDraftsNavigate={handleCopyToDraftsNavigate}
+        onCopyToDraftsComplete={clearScheduledDraftPerspective}
         releases={filteredReleases.notCurrentReleases}
         releasesLoading={loading}
         documentType={documentType}
@@ -288,7 +288,7 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
           nonReleaseVersions={variantVersions}
           selectedPerspective={selectedPerspectiveName}
           onSelectBundle={handleVariantSelectionChange}
-          onCopyToDraftsNavigate={handleCopyToDraftsNavigate}
+          onCopyToDraftsComplete={clearScheduledDraftPerspective}
           releases={filteredReleases.notCurrentReleases}
           releasesLoading={loading}
           documentType={documentType}


### PR DESCRIPTION
### Description 
This is a pre requisite for allowing copying variant versions https://github.com/sanity-io/sanity/pull/13800/changes
While working on the changes for that, I noticed that `useCopyToDrafts` was called from two different locations in the same tree. This could end in a miss behavior on the action it's taking if the props are not equally provided.

With this changes, `useCopyToDrafts` now is called only inside `useVersionContextMenu` which is the hook that centralices all the logic for this context menu. 

This is the first PR of a stack. 
Follow up, update `useCopyToDrafts` to execute the copy in a transaction, with the current status it can remove the draft and then if it fails to copy the version it will leave an empty drafts.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Manual testing.
You can use this workspace for the old behavior https://test-studio-git-copy-to-drafts-updates.sanity.dev/custom-components/structure/book;8e1dd9a0-8b00-43f6-8de7-92a4c598023d
And this one for the new behavior https://test-studio-git-copy-to-drafts-updates.sanity.dev/test/structure/book;e659a720-34a5-4ee1-b8ae-ac714d9ec5cf

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---
