### PR TITLE
fix(core): copy to drafts using transaction, prepare for variants

### DIFF
--- a/packages/sanity/src/core/releases/hooks/__tests__/useCopyToDrafts.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useCopyToDrafts.test.tsx
@@ -1,0 +1,323 @@
+import {type SanityClient} from '@sanity/client'
+import {act, renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {useClient} from '../../../hooks/useClient'
+import {type VersionInfoDocumentStub} from '../../store/types'
+import {useCopyToDrafts} from '../useCopyToDrafts'
+import {useDocumentVersions} from '../useDocumentVersions'
+
+vi.mock('../../../hooks/useClient', () => ({
+  useClient: vi.fn(),
+}))
+
+vi.mock('../useDocumentVersions', () => ({
+  useDocumentVersions: vi.fn(),
+}))
+
+const toastMock = vi.hoisted(() => ({
+  push: vi.fn(),
+}))
+
+vi.mock('@sanity/ui', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useToast: vi.fn(() => toastMock),
+}))
+
+const publishedId = 'article-123'
+
+const publishedVersion: VersionInfoDocumentStub = {
+  _id: publishedId,
+  _rev: 'published-rev',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-02T00:00:00Z',
+  _system: {
+    group: {_ref: publishedId, _weak: true},
+  },
+}
+
+const draftVersion: VersionInfoDocumentStub = {
+  _id: 'drafts.article-123',
+  _rev: 'draft-rev',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-03T00:00:00Z',
+  _system: {
+    bundleId: 'drafts',
+    group: {_ref: publishedId, _weak: true},
+  },
+}
+
+const releaseVersion: VersionInfoDocumentStub = {
+  _id: 'versions.release1.article-123',
+  _rev: 'release-rev',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-04T00:00:00Z',
+  _system: {
+    bundleId: 'release1',
+    release: {_ref: '_.releases.release1', _weak: true},
+    group: {_ref: publishedId, _weak: true},
+    scopeId: 'release1',
+  },
+}
+
+const opaqueAgentVersion: VersionInfoDocumentStub = {
+  _id: 'opaque-agent-doc-id',
+  _rev: 'agent-rev',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-05T00:00:00Z',
+  _system: {
+    bundleId: 'agent.user-123',
+    group: {_ref: publishedId, _weak: true},
+    scopeId: 'opaque-scope-abc',
+  },
+}
+
+const variantVersion: VersionInfoDocumentStub = {
+  _id: 'opaque-variant-doc-id',
+  _rev: 'variant-rev',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-06T00:00:00Z',
+  _system: {
+    bundleId: 'release1',
+    release: {_ref: '_.releases.release1', _weak: true},
+    variant: {_ref: '_.variants.test', _weak: true},
+    group: {_ref: publishedId, _weak: true},
+    scopeId: 'opaque-variant-scope',
+  },
+}
+
+describe('useCopyToDrafts', () => {
+  const mockAction = vi.fn()
+  const mockClient = {
+    action: mockAction,
+  } as unknown as SanityClient
+
+  const mockUseClient = useClient as unknown as Mock<typeof useClient>
+  const mockUseDocumentVersions = useDocumentVersions as Mock<typeof useDocumentVersions>
+
+  const onNavigate = vi.fn()
+  const onConfirmationRequest = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseClient.mockReturnValue(mockClient)
+    mockAction.mockResolvedValue(undefined)
+    mockUseDocumentVersions.mockReturnValue({
+      data: [],
+      versions: [publishedVersion, releaseVersion, opaqueAgentVersion],
+      error: null,
+      loading: false,
+    })
+  })
+
+  async function renderCopyToDrafts(fromRelease: string) {
+    const wrapper = await createTestProvider()
+    return renderHook(
+      () =>
+        useCopyToDrafts({
+          documentId: publishedId,
+          fromRelease,
+          onNavigate,
+          onConfirmationRequest,
+        }),
+      {wrapper},
+    )
+  }
+
+  it('copies a published document to drafts without discarding', async () => {
+    const {result} = await renderCopyToDrafts('published')
+
+    await act(async () => {
+      await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
+    })
+
+    expect(onConfirmationRequest).not.toHaveBeenCalled()
+    expect(mockAction).toHaveBeenCalledWith(
+      [
+        {
+          actionType: 'sanity.action.document.version.create',
+          versionId: 'drafts.article-123',
+          baseId: publishedId,
+          ifBaseRevisionId: 'published-rev',
+          publishedId,
+        },
+      ],
+      {tag: 'document.copy-to-drafts'},
+    )
+    expect(onNavigate).toHaveBeenCalledTimes(1)
+  })
+
+  it('copies a release version to drafts by matching scopeId', async () => {
+    const {result} = await renderCopyToDrafts('release1')
+
+    await act(async () => {
+      await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
+    })
+
+    expect(mockAction).toHaveBeenCalledWith(
+      [
+        {
+          actionType: 'sanity.action.document.version.create',
+          versionId: 'drafts.article-123',
+          baseId: releaseVersion._id,
+          ifBaseRevisionId: 'release-rev',
+          publishedId,
+        },
+      ],
+      {tag: 'document.copy-to-drafts'},
+    )
+    expect(onNavigate).toHaveBeenCalledTimes(1)
+  })
+
+  it('copies an opaque agent version to drafts by matching scopeId', async () => {
+    const {result} = await renderCopyToDrafts('opaque-scope-abc')
+
+    await act(async () => {
+      await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
+    })
+
+    expect(mockAction).toHaveBeenCalledWith(
+      [
+        {
+          actionType: 'sanity.action.document.version.create',
+          versionId: 'drafts.article-123',
+          baseId: opaqueAgentVersion._id,
+          ifBaseRevisionId: 'agent-rev',
+          publishedId,
+        },
+      ],
+      {tag: 'document.copy-to-drafts'},
+    )
+    expect(onNavigate).toHaveBeenCalledTimes(1)
+  })
+
+  it('requests confirmation when a draft exists and shouldConfirmDraftDiscard is true', async () => {
+    mockUseDocumentVersions.mockReturnValue({
+      data: [],
+      versions: [publishedVersion, draftVersion, releaseVersion],
+      error: null,
+      loading: false,
+    })
+
+    const {result} = await renderCopyToDrafts('release1')
+
+    await act(async () => {
+      await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
+    })
+
+    expect(onConfirmationRequest).toHaveBeenCalledTimes(1)
+    expect(mockAction).not.toHaveBeenCalled()
+    expect(onNavigate).not.toHaveBeenCalled()
+  })
+
+  it('discards the existing draft then copies when shouldConfirmDraftDiscard is false', async () => {
+    mockUseDocumentVersions.mockReturnValue({
+      data: [],
+      versions: [publishedVersion, draftVersion, releaseVersion],
+      error: null,
+      loading: false,
+    })
+
+    const {result} = await renderCopyToDrafts('release1')
+
+    await act(async () => {
+      await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: false})
+    })
+
+    expect(onConfirmationRequest).not.toHaveBeenCalled()
+    expect(mockAction).toHaveBeenCalledWith(
+      [
+        {
+          actionType: 'sanity.action.document.discard',
+          draftId: 'drafts.article-123',
+        },
+        {
+          actionType: 'sanity.action.document.version.create',
+          versionId: 'drafts.article-123',
+          baseId: releaseVersion._id,
+          ifBaseRevisionId: 'release-rev',
+          publishedId,
+        },
+      ],
+      {tag: 'document.copy-to-drafts'},
+    )
+    expect(onNavigate).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows an error toast when the source version is not found', async () => {
+    const {result} = await renderCopyToDrafts('missing-scope')
+
+    await act(async () => {
+      await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
+    })
+
+    expect(mockAction).not.toHaveBeenCalled()
+    expect(onNavigate).not.toHaveBeenCalled()
+    expect(toastMock.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'error',
+        description: `Source document with id: ${publishedId} and release: missing-scope not found`,
+      }),
+    )
+  })
+
+  it('shows an error toast when copying a variant document', async () => {
+    mockUseDocumentVersions.mockReturnValue({
+      data: [],
+      versions: [publishedVersion, variantVersion],
+      error: null,
+      loading: false,
+    })
+
+    const {result} = await renderCopyToDrafts('opaque-variant-scope')
+
+    await act(async () => {
+      await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
+    })
+
+    expect(mockAction).not.toHaveBeenCalled()
+    expect(onNavigate).not.toHaveBeenCalled()
+    expect(toastMock.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'error',
+        description: 'Copying variant documents to drafts is not supported yet',
+      }),
+    )
+  })
+
+  it('shows an error toast when fromRelease is draft', async () => {
+    const {result} = await renderCopyToDrafts('draft')
+
+    await act(async () => {
+      await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
+    })
+
+    expect(mockAction).not.toHaveBeenCalled()
+    expect(onNavigate).not.toHaveBeenCalled()
+    expect(toastMock.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'error',
+        description: `Source document with id: ${publishedId} and release: draft not found`,
+      }),
+    )
+  })
+
+  it('shows an error toast when the client action fails', async () => {
+    mockAction.mockRejectedValue(new Error('action failed'))
+
+    const {result} = await renderCopyToDrafts('published')
+
+    await act(async () => {
+      await result.current.handleCopyToDrafts({shouldConfirmDraftDiscard: true})
+    })
+
+    expect(onNavigate).not.toHaveBeenCalled()
+    expect(toastMock.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'error',
+        description: 'action failed',
+      }),
+    )
+  })
+})

--- a/packages/sanity/src/core/releases/hooks/useCopyToDrafts.ts
+++ b/packages/sanity/src/core/releases/hooks/useCopyToDrafts.ts
@@ -1,11 +1,13 @@
+import {type Action} from '@sanity/client'
 import {useToast} from '@sanity/ui'
 import {useCallback, useMemo} from 'react'
 
 import {useClient} from '../../hooks/useClient'
 import {useTranslation} from '../../i18n/hooks/useTranslation'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
-import {getPublishedId, getVersionId} from '../../util/draftUtils'
-import {getDocumentVersionInfoFromVersions} from '../util/getDocumentVersionInfoFromVersions'
+import {getPublishedId, getDraftId} from '../../util/draftUtils'
+import {getTargetDocument} from '../../util/getTargetDocument'
+import {isPublishedVersion} from '../../util/versionsUtils'
 import {useDocumentVersions} from './useDocumentVersions'
 
 export interface CopyToDraftsOptions {
@@ -30,15 +32,32 @@ export function useCopyToDrafts(options: UseCopyToDraftsOptions): UseCopyToDraft
   const {t} = useTranslation()
 
   const publishedId = useMemo(() => getPublishedId(documentId), [documentId])
-
-  const sourceDocumentId = useMemo(
-    () => (fromRelease === 'published' ? documentId : getVersionId(documentId, fromRelease)),
-    [documentId, fromRelease],
-  )
-
   const {versions} = useDocumentVersions({documentId: publishedId})
+  const sourceDocumentInfo = useMemo(() => {
+    if (fromRelease === 'published') {
+      return getTargetDocument({
+        bundle: 'published',
+        variant: undefined,
+        documentVersions: versions,
+      })
+    }
+    if (fromRelease === 'draft') {
+      return undefined
+    }
+    return versions.find((version) => {
+      // FromRelease now matches the scopeId of the version.
+      // So it will find the correct document, in the follow up enabling copying variants
+      // We need to check the variant and the release
+      // For that we can use the `getTargetDocument` function
+      return version._system.scopeId === fromRelease
+    })
+  }, [fromRelease, versions])
+
   const hasDraftVersion = useMemo(
-    () => Boolean(getDocumentVersionInfoFromVersions(versions).draft),
+    () =>
+      Boolean(
+        getTargetDocument({bundle: 'drafts', variant: undefined, documentVersions: versions}),
+      ),
     [versions],
   )
 
@@ -50,20 +69,33 @@ export function useCopyToDrafts(options: UseCopyToDraftsOptions): UseCopyToDraft
       }
       // Workaround for React Compiler not yet fully supporting try/catch syntax
       const run = async () => {
-        const sourceDoc = await client.getDocument(sourceDocumentId)
-
-        if (!sourceDoc) {
-          throw new Error(`Source document ${sourceDocumentId} not found`)
+        if (!sourceDocumentInfo) {
+          throw new Error(
+            `Source document with id: ${documentId} and release: ${fromRelease} not found`,
+          )
         }
+        if (sourceDocumentInfo._system.variant?._ref) {
+          throw new Error('Copying variant documents to drafts is not supported yet')
+        }
+
+        const actions: Action[] = []
 
         if (hasDraftVersion) {
-          await client.discardVersion({publishedId}, false)
+          actions.push({
+            actionType: 'sanity.action.document.discard',
+            draftId: getDraftId(publishedId),
+          })
         }
 
-        await client.createVersion({
-          baseId: sourceDocumentId,
-          ifBaseRevisionId: sourceDoc._rev,
+        actions.push({
+          actionType: 'sanity.action.document.version.create',
+          versionId: getDraftId(publishedId),
+          baseId: sourceDocumentInfo._id,
+          ifBaseRevisionId: sourceDocumentInfo._rev,
           publishedId,
+        })
+        await client.action(actions, {
+          tag: 'document.copy-to-drafts',
         })
 
         onNavigate()
@@ -81,8 +113,10 @@ export function useCopyToDrafts(options: UseCopyToDraftsOptions): UseCopyToDraft
     },
     [
       client,
-      sourceDocumentId,
+      documentId,
+      fromRelease,
       hasDraftVersion,
+      sourceDocumentInfo,
       publishedId,
       toast,
       onNavigate,


### PR DESCRIPTION
### Description
Updates useCopyToDraft to do the changes in a transaction and to use the `documentVersions` as the guide to find the correct documents.
Previously, if the creation failed we could end up in a situation where the draft is deleted and nothing is recreated.
By moving it to a transaction this is guarded now.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---
