### PR TITLE
fix(core): enable clear button when perspective is the non default one

### DIFF
--- a/packages/sanity/src/core/variants/plugin/components/VariantsStudioNavbar.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/VariantsStudioNavbar.tsx
@@ -8,9 +8,9 @@ import {Button} from '../../../../ui-components/button/Button'
 import {type NavbarProps} from '../../../config/studio/types'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {ReleasesNav} from '../../../perspective/navbar/ReleasesNav'
+import {useGetDefaultPerspective} from '../../../perspective/useGetDefaultPerspective'
 import {usePerspective} from '../../../perspective/usePerspective'
 import {getReleaseTone} from '../../../releases/util/getReleaseTone'
-import {isDraftPerspective, isPublishedPerspective} from '../../../releases/util/util'
 import {variantsLocaleNamespace} from '../../i18n'
 import {VariantsNav} from './VariantsNav'
 
@@ -27,9 +27,8 @@ export function VariantsStudioNavbar(props: NavbarProps) {
   const router = useRouter()
 
   const hasVariantSelection = Boolean(router.stickyParams.variant)
-  const hasNonDefaultPerspective =
-    !isDraftPerspective(selectedPerspective) && !isPublishedPerspective(selectedPerspective)
-  const canClear = hasVariantSelection || hasNonDefaultPerspective
+  const defaultPerspective = useGetDefaultPerspective()
+  const canClear = hasVariantSelection || selectedPerspective !== defaultPerspective
 
   const handleClearViewAs = useCallback(() => {
     router.navigate({


### PR DESCRIPTION
### Description
Tiny update.
Show the `clear` perspective and variant button when the perspecitve is not the default one.
For example, for published.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---
