### PR TITLE
chore(core): versions context menu use documentGroupId and versionId

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -338,6 +338,17 @@ export default defineConfig([
   defaultWorkspace,
   {
     ...defaultWorkspace,
+    title: 'Test Studio (variants disabled)',
+    name: 'test-studio-variants-disabled',
+    basePath: '/test-studio-variants-disabled',
+    beta: {
+      variants: {
+        enabled: false,
+      },
+    },
+  },
+  {
+    ...defaultWorkspace,
     projectId: 'nonexistent',
     name: 'nonexistent-project',
     title: 'Nonexistent project',

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -51,14 +51,7 @@ import {useAgentBundlesStore} from '../../store/agent/useAgentBundles'
 import {useDocumentStore} from '../../store/datastores'
 import {useWorkspace} from '../../studio/workspace'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
-import {
-  getPublishedId,
-  getVersionFromId,
-  isDraftId,
-  isPublishedId,
-  isVersionId,
-  type SystemBundle,
-} from '../../util/draftUtils'
+import {getPublishedId, isVersionId, type SystemBundle} from '../../util/draftUtils'
 import {readVersionType} from '../../util/versionsUtils'
 import {useVariantDocumentOperations} from '../../variants/hooks/useVariantDocumentOperations'
 import {CreateVariantIcon} from '../../variants/plugin/components/PersonalizationIcons'
@@ -535,22 +528,24 @@ const Variant: ComponentType<{
   const {t} = useTranslation(studioLocaleNamespace)
   const releasesToolAvailable = useReleasesToolAvailable()
   const {loading: releasesLoading} = useActiveReleases()
-  // Agent bundle entries are listed without a document, so their ids remain the only source of
-  // truth. Everything else is derived from `_system`, which is authoritative: it distinguishes a
-  // variant-scoped draft (`versions.<scope>.<id>` with `bundleId: 'drafts'`) from a release
-  // version, which the id alone cannot.
+  // Derived from `_system` rather than the id, because `_system` is authoritative: it
+  // distinguishes a variant-scoped draft (`versions.<scope>.<id>` with `bundleId: 'drafts'`)
+  // from a release version, which the id alone cannot.
   const {document} = variant
-  const versionId = document?._id ?? variant.id
-  const documentGroupId = document?._system.group._ref ?? getPublishedId(variant.id)
-  const releaseRef = document?._system.release?._ref
-  const isPublishedVersion = document ? !document._system.bundleId : isPublishedId(variant.id)
-  const isDraftVersion = document ? document._system.bundleId === 'drafts' : isDraftId(variant.id)
+  const versionId = document._id
+  const documentGroupId = document._system.group._ref
+  const releaseRef = document._system.release?._ref
+  const isPublishedVersion = !document._system.bundleId
+  const isDraftVersion = document._system.bundleId === 'drafts'
   const isVersion = isVersionId(versionId)
   const bundleId = isPublishedVersion
     ? 'published'
     : isDraftVersion
       ? 'draft'
-      : (document?._system.bundleId ?? getVersionFromId(variant.id) ?? '')
+      : (document._system.bundleId ?? '')
+  const agentBundleName = isAgentBundleName(document._system.bundleId)
+    ? document._system.bundleId
+    : undefined
 
   const isReadOnly = useSelector(machine, (snapshot) => snapshot.matches('readonly'))
   const selectedIds = useSelector(machine, ({context}) => context.selectedIds)
@@ -598,11 +593,9 @@ const Variant: ComponentType<{
             onClick={() => {
               let bundle
 
-              switch (readVersionType(variant.document)) {
+              switch (readVersionType(document)) {
                 case 'release':
-                  bundle = getReleaseIdFromReleaseDocumentId(
-                    variant?.document?._system.release?._ref ?? '',
-                  )
+                  bundle = getReleaseIdFromReleaseDocumentId(releaseRef ?? '')
                   break
                 case 'published':
                   bundle = 'published'
@@ -612,15 +605,11 @@ const Variant: ComponentType<{
                   break
               }
 
-              const variantId = isVariantId(variant.document?._system?.variant?._ref)
-                ? variant.document._system.variant._ref
+              const variantId = isVariantId(document._system.variant?._ref)
+                ? document._system.variant._ref
                 : undefined
 
-              const agentId = isAgentBundleName(getVersionFromId(variant.id))
-                ? getVersionFromId(variant.id)
-                : undefined
-
-              onPrimaryAction({variantId, perspective: agentId ?? bundle})
+              onPrimaryAction({variantId, perspective: agentBundleName ?? bundle})
             }}
             onContextMenu={contextMenuHandler}
           >
@@ -649,7 +638,7 @@ const Variant: ComponentType<{
             </StatusBadge>
           )}
           <Text size={1}>
-            {isAgentBundleName(getVersionFromId(variant.id)) ? (
+            {agentBundleName ? (
               <ReleaseAvatarIcon tone="suggest" />
             ) : (
               <ReleaseAvatarIcon

--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventory.tsx
@@ -36,7 +36,6 @@ import {useClient} from '../../hooks/useClient'
 import {useSchema} from '../../hooks/useSchema'
 import {useTranslation} from '../../i18n/hooks/useTranslation'
 import {feedbackLocaleNamespace, studioLocaleNamespace} from '../../i18n/localeNamespaces'
-import {type TargetPerspective} from '../../perspective/types'
 import {type SetVariant, useSetVariant} from '../../perspective/useSetVariant'
 import {VersionContextMenuDialogs} from '../../releases/components/documentHeader/contextMenu/VersionContextMenuDialogs'
 import {VersionContextMenuPopover} from '../../releases/components/documentHeader/contextMenu/VersionContextMenuPopover'
@@ -45,7 +44,6 @@ import {useDocumentVersionsObservable} from '../../releases/hooks/useDocumentVer
 import {useVersionContextMenu} from '../../releases/hooks/useVersionContextMenu'
 import {useActiveReleases} from '../../releases/store/useActiveReleases'
 import {useReleasesStore} from '../../releases/store/useReleasesStore'
-import {getReleaseDocumentIdFromReleaseId} from '../../releases/util/getReleaseDocumentIdFromReleaseId'
 import {getReleaseIdFromReleaseDocumentId} from '../../releases/util/getReleaseIdFromReleaseDocumentId'
 import {useReleasesToolAvailable} from '../../schedules/hooks/useReleasesToolAvailable'
 import {isAgentBundleName} from '../../store/agent/createAgentBundlesStore'
@@ -537,12 +535,22 @@ const Variant: ComponentType<{
   const {t} = useTranslation(studioLocaleNamespace)
   const releasesToolAvailable = useReleasesToolAvailable()
   const {loading: releasesLoading} = useActiveReleases()
-  const isPublishedVersion = isPublishedId(variant.id)
-  const isDraftVersion = isDraftId(variant.id)
-  const isVersion = isVersionId(variant.id)
-  const documentId = getPublishedId(variant.id)
-  const versionName = getVersionFromId(variant.id)
-  const bundleId = isPublishedVersion ? 'published' : isDraftVersion ? 'draft' : (versionName ?? '')
+  // Agent bundle entries are listed without a document, so their ids remain the only source of
+  // truth. Everything else is derived from `_system`, which is authoritative: it distinguishes a
+  // variant-scoped draft (`versions.<scope>.<id>` with `bundleId: 'drafts'`) from a release
+  // version, which the id alone cannot.
+  const {document} = variant
+  const versionId = document?._id ?? variant.id
+  const documentGroupId = document?._system.group._ref ?? getPublishedId(variant.id)
+  const releaseRef = document?._system.release?._ref
+  const isPublishedVersion = document ? !document._system.bundleId : isPublishedId(variant.id)
+  const isDraftVersion = document ? document._system.bundleId === 'drafts' : isDraftId(variant.id)
+  const isVersion = isVersionId(versionId)
+  const bundleId = isPublishedVersion
+    ? 'published'
+    : isDraftVersion
+      ? 'draft'
+      : (document?._system.bundleId ?? getVersionFromId(variant.id) ?? '')
 
   const isReadOnly = useSelector(machine, (snapshot) => snapshot.matches('readonly'))
   const selectedIds = useSelector(machine, ({context}) => context.selectedIds)
@@ -550,10 +558,7 @@ const Variant: ComponentType<{
 
   const {filteredReleases, clearScheduledDraftPerspective} = perspectiveList
 
-  const release = versionName
-    ? releases.get(getReleaseDocumentIdFromReleaseId(versionName))
-    : undefined
-
+  const release = releaseRef ? releases.get(releaseRef) : undefined
   const {
     contextMenu,
     handleContextMenu,
@@ -570,7 +575,8 @@ const Variant: ComponentType<{
     scheduledDraftMenuActions,
     sourceReleasePerspective,
   } = useVersionContextMenu({
-    documentId,
+    documentGroupId,
+    versionId,
     documentType,
     bundleId,
     isVersion,
@@ -661,12 +667,12 @@ const Variant: ComponentType<{
           contextMenu={contextMenu}
           popoverRef={popoverRef}
           referenceElement={referenceElement}
-          documentId={documentId}
+          documentGroupId={documentGroupId}
           documentType={documentType}
           bundleId={bundleId}
-          isVersion={isVersion}
           releases={filteredReleases.notCurrentReleases}
           releasesLoading={releasesLoading}
+          versionId={versionId}
           onDiscard={openDiscardDialog}
           onCreateRelease={openCreateReleaseDialog}
           onCopyToDrafts={handleCopyToDrafts}
@@ -682,10 +688,8 @@ const Variant: ComponentType<{
       <VersionContextMenuDialogs
         dialogState={dialogState}
         onClose={closeDialog}
-        documentId={documentId}
+        versionId={versionId}
         documentType={documentType}
-        bundleId={bundleId}
-        isVersion={isVersion}
         title={variant.name}
         sourceReleasePerspective={sourceReleasePerspective}
         onCreateVersion={handleAddVersion}

--- a/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.test.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/documentGroupInventoryMachine.test.ts
@@ -562,7 +562,11 @@ describe('documentGroupInventoryMachine', () => {
     const expectedVariants = [
       // Agent bundle versions are dropped from the version state and only the
       // most recent bundle is prepended, labelled through the translator.
-      {id: 'versions.agent-abc.foo', name: 'version.agent-bundle.proposed-changes'},
+      {
+        id: 'versions.agent-abc.foo',
+        name: 'version.agent-bundle.proposed-changes',
+        document: versionStub('versions.agent-abc.foo'),
+      },
       {id: 'drafts.foo', name: 'release.chip.draft', document: versionStub('drafts.foo')},
       {id: 'foo', name: 'release.chip.published', document: versionStub('foo')},
     ]

--- a/packages/sanity/src/core/documentGroupInventory/machines/selectionMachine.test.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/selectionMachine.test.ts
@@ -2,15 +2,31 @@ import {BehaviorSubject, EMPTY, type Observable, Subject} from 'rxjs'
 import {describe, expect, it} from 'vitest'
 import {createActor, fromObservable} from 'xstate'
 
+import {getPublishedId, isDraftId} from '../../util/draftUtils'
 import {selectionMachine, type Variant} from './selectionMachine'
+
+// The selection machine only reads `id` and `name`; the document stub is present to satisfy the
+// `Variant` shape. Only drafts and published documents are needed here.
+function variant(id: string, name: string): Variant {
+  const group = {_ref: getPublishedId(id), _weak: true} as const
+
+  return {
+    id,
+    name,
+    document: {
+      _id: id,
+      _rev: 'rev',
+      _createdAt: '2026-01-01T00:00:00.000Z',
+      _updatedAt: '2026-01-01T00:00:00.000Z',
+      _system: isDraftId(id) ? {bundleId: 'drafts', group} : {group},
+    },
+  }
+}
 
 // The available variants are computed by the parent inventory machine and
 // relayed down as a `variants.changed` event; name derivation is covered in
 // documentGroupInventoryMachine.test.ts.
-const DEFAULT_VARIANTS: Variant[] = [
-  {id: 'drafts.foo', name: 'Draft'},
-  {id: 'foo', name: 'Published'},
-]
+const DEFAULT_VARIANTS: Variant[] = [variant('drafts.foo', 'Draft'), variant('foo', 'Published')]
 
 function createSelectionActor({
   variants = DEFAULT_VARIANTS,
@@ -148,11 +164,11 @@ describe('selectionMachine', () => {
     // The published variant is no longer available, so it is pruned.
     selection.send({
       type: 'variants.changed',
-      variants: [{id: 'drafts.foo', name: 'Draft'}],
+      variants: [variant('drafts.foo', 'Draft')],
       loaded: true,
     })
     expect([...selection.getSnapshot().context.selectedIds]).toEqual(['drafts.foo'])
-    expect(selection.getSnapshot().context.variants).toEqual([{id: 'drafts.foo', name: 'Draft'}])
+    expect(selection.getSnapshot().context.variants).toEqual([variant('drafts.foo', 'Draft')])
   })
 
   it('computes case-insensitive filter matches', () => {

--- a/packages/sanity/src/core/documentGroupInventory/machines/selectionMachine.ts
+++ b/packages/sanity/src/core/documentGroupInventory/machines/selectionMachine.ts
@@ -7,7 +7,7 @@ import {type VersionInfoDocumentStub} from '../../releases/store/types'
 export interface Variant {
   id: string
   name: string
-  document?: VersionInfoDocumentStub
+  document: VersionInfoDocumentStub
   releaseDocument?: ReleaseDocument
 }
 

--- a/packages/sanity/src/core/documentGroupInventory/utils/computeSets.test.ts
+++ b/packages/sanity/src/core/documentGroupInventory/utils/computeSets.test.ts
@@ -142,6 +142,7 @@ describe('computeSets', () => {
             {
               id: `versions.${AGENT_BUNDLE_ID}.${PUBLISHED_ID}`,
               name: 'version.agent-bundle.proposed-changes',
+              document: versions[3],
             },
             {id: `drafts.${PUBLISHED_ID}`, name: 'release.chip.draft', document: versions[0]},
             {id: PUBLISHED_ID, name: 'release.chip.published', document: versions[1]},
@@ -189,6 +190,7 @@ describe('computeSets', () => {
             {
               id: `versions.${AGENT_BUNDLE_ID}.${PUBLISHED_ID}`,
               name: 'version.agent-bundle.proposed-changes',
+              document: versions[8],
             },
           ],
         },

--- a/packages/sanity/src/core/documentGroupInventory/utils/computeSets.ts
+++ b/packages/sanity/src/core/documentGroupInventory/utils/computeSets.ts
@@ -31,8 +31,8 @@ export function computeSets({
   const {variants} = meta.variants
   const userBundleIds = new Set(meta.agentBundles.bundles.map(({id}) => id))
 
-  const proposedChangesId = meta.versionState.data.find((id) => {
-    const bundleId = getVersionFromId(id)
+  const proposedChanges = meta.versionState.versions.find((version) => {
+    const bundleId = getVersionFromId(version._id)
     return typeof bundleId === 'string' && userBundleIds.has(bundleId)
   })
 
@@ -54,10 +54,11 @@ Switch Content Variants on in your Studio configuration to ensure variants are d
         document: version,
       }))
 
-    if (typeof proposedChangesId !== 'undefined') {
+    if (proposedChanges) {
       variants.unshift({
-        id: proposedChangesId,
+        id: proposedChanges._id,
         name: t('version.agent-bundle.proposed-changes'),
+        document: proposedChanges,
       })
     }
 
@@ -119,14 +120,15 @@ Switch Content Variants on in your Studio configuration to ensure variants are d
     }
   })
 
-  if (typeof proposedChangesId !== 'undefined') {
+  if (proposedChanges) {
     return sets.toSpliced(0, 0, {
       key: 'studio:content-agent',
       name: t('content-agent'),
       variants: [
         {
-          id: proposedChangesId,
+          id: proposedChanges._id,
           name: t('version.agent-bundle.proposed-changes'),
+          document: proposedChanges,
         },
       ],
     })

--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -23,22 +23,22 @@ import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromRele
  */
 export function DiscardVersionDialog(props: {
   onClose: () => void
-  documentId: string
+  versionId: string
   documentType: string
   fromPerspective: string | TargetPerspective
   isGoingToUnpublish: boolean
 }): React.JSX.Element {
-  const {onClose, documentId, documentType, fromPerspective, isGoingToUnpublish} = props
+  const {onClose, versionId, documentType, fromPerspective, isGoingToUnpublish} = props
   const {t} = useTranslation(releasesLocaleNamespace)
   const {t: coreT} = useTranslation()
-  const targetDocumentState = useTargetDocumentState(getPublishedId(documentId))
+  const targetDocumentState = useTargetDocumentState(getPublishedId(versionId))
   // The scope of the document targeted by the selected perspective, so that discarding a draft
   // targets the variant-scoped version when a variant is selected (undefined when the target is
   // still resolving or the draft/published pair applies). While resolving, confirming is
   // disabled below instead of silently operating on the base pair.
   const isTargetReady = targetDocumentState.status === 'ready'
   const {discardChanges} = useDocumentOperation(
-    getPublishedId(documentId),
+    getPublishedId(versionId),
     documentType,
     getPairTarget(targetDocumentState),
   )
@@ -47,10 +47,10 @@ export function DiscardVersionDialog(props: {
   const schema = useSchema()
   const toast = useToast()
   const [isDiscarding, setIsDiscarding] = useState(false)
-  const discardType = isDraftId(documentId) ? 'draft' : 'release'
+  const discardType = isDraftId(versionId) ? 'draft' : 'release'
   const rawReleaseName =
     typeof fromPerspective === 'string' ? fromPerspective : fromPerspective.metadata.title
-  const currentRelease = getVersionNameFromId(documentId as VersionId)
+  const currentRelease = getVersionNameFromId(versionId as VersionId)
   const releaseName = rawReleaseName || coreT('release.placeholder-untitled-release')
 
   const schemaType = schema.get(documentType)
@@ -58,13 +58,13 @@ export function DiscardVersionDialog(props: {
   const handleDiscardVersion = useCallback(async () => {
     setIsDiscarding(true)
 
-    if (isVersionId(documentId)) {
+    if (isVersionId(versionId)) {
       // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
       const run = async () => {
         await discardVersion(
-          getVersionFromId(documentId) ||
+          getVersionFromId(versionId) ||
             getReleaseIdFromReleaseDocumentId((selectedPerspective as ReleaseDocument)._id),
-          documentId,
+          versionId,
         )
       }
       try {
@@ -85,7 +85,7 @@ export function DiscardVersionDialog(props: {
     setIsDiscarding(false)
 
     onClose()
-  }, [documentId, onClose, discardVersion, selectedPerspective, toast, coreT, discardChanges])
+  }, [versionId, onClose, discardVersion, selectedPerspective, toast, coreT, discardChanges])
 
   return (
     <Dialog
@@ -115,7 +115,7 @@ export function DiscardVersionDialog(props: {
       <Stack space={3} paddingX={3} marginBottom={2}>
         {schemaType ? (
           <Preview
-            value={{_id: isGoingToUnpublish ? getPublishedId(documentId) : documentId}}
+            value={{_id: isGoingToUnpublish ? getPublishedId(versionId) : versionId}}
             schemaType={schemaType}
             // Resolve the preview under the perspective of what's being discarded:
             // the published doc when unpublishing, the drafts perspective when

--- a/packages/sanity/src/core/releases/components/dialog/__tests__/DiscardVersionDialog.test.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/__tests__/DiscardVersionDialog.test.tsx
@@ -57,12 +57,12 @@ const config = defineConfig({
   },
 })
 
-async function renderDialog(props: {documentId: string; isGoingToUnpublish?: boolean}) {
+async function renderDialog(props: {versionId: string; isGoingToUnpublish?: boolean}) {
   const wrapper = await createTestProvider({config})
   render(
     <DiscardVersionDialog
       onClose={vi.fn()}
-      documentId={props.documentId}
+      versionId={props.versionId}
       documentType="testDoc"
       fromPerspective="drafts"
       isGoingToUnpublish={props.isGoingToUnpublish ?? false}
@@ -78,21 +78,21 @@ describe('DiscardVersionDialog preview perspective', () => {
   })
 
   it('previews a discarded draft under the drafts perspective', async () => {
-    await renderDialog({documentId: 'drafts.my-doc'})
+    await renderDialog({versionId: 'drafts.my-doc'})
     expect(previewSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({perspectiveStack: ['drafts']}),
     )
   })
 
   it('previews a discarded release version under its release perspective', async () => {
-    await renderDialog({documentId: 'versions.rSummer.my-doc'})
+    await renderDialog({versionId: 'versions.rSummer.my-doc'})
     expect(previewSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({perspectiveStack: ['rSummer']}),
     )
   })
 
   it('previews the published document (empty perspective) when unpublishing', async () => {
-    await renderDialog({documentId: 'drafts.my-doc', isGoingToUnpublish: true})
+    await renderDialog({versionId: 'drafts.my-doc', isGoingToUnpublish: true})
     expect(previewSpy).toHaveBeenLastCalledWith(expect.objectContaining({perspectiveStack: []}))
   })
 })

--- a/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/VersionChip.tsx
@@ -49,7 +49,8 @@ export const VersionChip = memo(function VersionChip(props: {
   locked?: boolean
   onCopyToDraftsComplete?: () => void
   contextValues: {
-    documentId: string
+    documentGroupId: string
+    versionId: string
     documentType: string
     releases: ReleaseDocument[]
     releasesLoading: boolean
@@ -71,7 +72,8 @@ export const VersionChip = memo(function VersionChip(props: {
     locked = false,
     onCopyToDraftsComplete,
     contextValues: {
-      documentId,
+      documentGroupId,
+      versionId,
       releases,
       releasesLoading,
       documentType,
@@ -83,8 +85,7 @@ export const VersionChip = memo(function VersionChip(props: {
     },
   } = props
   const releasesToolAvailable = useReleasesToolAvailable()
-  const isLinked = useVersionIsLinked(documentId, bundleId)
-
+  const isLinked = useVersionIsLinked(documentGroupId, bundleId)
   const chipRef = useRef<HTMLButtonElement | null>(null)
 
   useEffect(() => {
@@ -107,7 +108,8 @@ export const VersionChip = memo(function VersionChip(props: {
     scheduledDraftMenuActions,
     sourceReleasePerspective,
   } = useVersionContextMenu({
-    documentId,
+    documentGroupId,
+    versionId,
     documentType,
     bundleId,
     isVersion,
@@ -152,10 +154,10 @@ export const VersionChip = memo(function VersionChip(props: {
         contextMenu={contextMenu}
         popoverRef={popoverRef}
         referenceElement={referenceElement}
-        documentId={documentId}
+        documentGroupId={documentGroupId}
+        versionId={versionId}
         documentType={documentType}
         bundleId={bundleId}
-        isVersion={isVersion}
         releases={releases}
         releasesLoading={releasesLoading}
         onDiscard={openDiscardDialog}
@@ -174,10 +176,8 @@ export const VersionChip = memo(function VersionChip(props: {
       <VersionContextMenuDialogs
         dialogState={dialogState}
         onClose={closeDialog}
-        documentId={documentId}
+        versionId={versionId}
         documentType={documentType}
-        bundleId={bundleId}
-        isVersion={isVersion}
         title={text}
         sourceReleasePerspective={sourceReleasePerspective}
         onCreateVersion={handleAddVersion}

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenu.tsx
@@ -3,7 +3,7 @@ import {memo, useEffect, useRef, useState} from 'react'
 
 import {type UseScheduledDraftMenuActionsReturn} from '../../../../singleDocRelease/hooks/useScheduledDraftMenuActions'
 import {useDocumentPairPermissions} from '../../../../store/grants/documentPairPermissions'
-import {getPublishedId, isPublishedId} from '../../../../util/draftUtils'
+import {getVersionFromId, isPublishedId} from '../../../../util/draftUtils'
 import {type CopyToDraftsOptions} from '../../../hooks/useCopyToDrafts'
 import {useReleaseOperations} from '../../../store/useReleaseOperations'
 import {useReleasePermissions} from '../../../store/useReleasePermissions'
@@ -12,11 +12,11 @@ import {CanonicalReleaseContextMenu} from './CanonicalReleaseContextMenu'
 import {ScheduledDraftContextMenu} from './ScheduledDraftContextMenu'
 
 interface VersionContextMenuProps {
-  documentId: string
+  documentGroupId: string
   releases: ReleaseDocument[]
   releasesLoading: boolean
   fromRelease: string
-  isVersion: boolean
+  versionId: string
   onDiscard: () => void
   onCreateRelease: () => void
   onCopyToDrafts: (options: CopyToDraftsOptions) => Promise<void>
@@ -37,12 +37,12 @@ interface VersionContextMenuProps {
 
 export const VersionContextMenu = memo(function VersionContextMenu(props: VersionContextMenuProps) {
   const {
-    documentId,
+    documentGroupId,
     releases,
     releasesLoading,
     fromRelease,
-    isVersion,
     onDiscard,
+    versionId,
     onCreateRelease,
     onCopyToDrafts,
     onCreateVersion,
@@ -55,7 +55,8 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: Versio
     scheduledDraftMenuActions,
     isDiscardable = true,
   } = props
-  const isPublished = isPublishedId(documentId) && !isVersion
+  const isPublished = isPublishedId(versionId)
+  const versionName = getVersionFromId(versionId)
 
   const {checkWithPermissionGuard} = useReleasePermissions()
   const {createRelease} = useReleaseOperations()
@@ -64,9 +65,9 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: Versio
   // TODO: SAPP-4023: update this component to receive the `VersionInfoDocumentStub` instead of a plain id, and use that
   // stub to verify permissions and run the actions on the specific version.
   const [permissions, isPermissionsLoading] = useDocumentPairPermissions({
-    id: getPublishedId(documentId),
+    id: documentGroupId,
     type,
-    version: isVersion ? fromRelease : undefined,
+    version: versionName,
     // Note: the result of this discard permission check is disregarded for the published document
     // version. Discarding is never available for the published document version. Therefore, the
     // parameters provided here are not configured to handle published document versions.
@@ -88,7 +89,7 @@ export const VersionContextMenu = memo(function VersionContextMenu(props: Versio
   }, [checkWithPermissionGuard, createRelease])
 
   // Scheduled drafts use different menu with publish-now, reschedule, and delete actions
-  if (isScheduledDraft && isVersion && release && scheduledDraftMenuActions) {
+  if (isScheduledDraft && versionName && release && scheduledDraftMenuActions) {
     return (
       <ScheduledDraftContextMenu
         releases={releases}

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuDialogs.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuDialogs.tsx
@@ -1,7 +1,6 @@
 import {memo, type ReactNode} from 'react'
 
 import {type TargetPerspective} from '../../../../perspective/types'
-import {getVersionId} from '../../../../util/draftUtils'
 import {type CopyToDraftsOptions} from '../../../hooks/useCopyToDrafts'
 import {type VersionContextMenuDialogState} from '../../../hooks/useVersionContextMenu'
 import {DiscardVersionDialog} from '../../dialog/DiscardVersionDialog'
@@ -15,11 +14,8 @@ export interface VersionContextMenuDialogsProps {
   /** The dialog state returned by `useVersionContextMenu`. */
   dialogState: VersionContextMenuDialogState
   onClose: () => void
-  documentId: string
+  versionId: string
   documentType: string
-  /** The perspective the menu acts on: 'published', 'draft', or a release ID. */
-  bundleId: string
-  isVersion: boolean
   /** Display title of the perspective the dialogs act on. */
   title: string
   /** The release or system bundle the dialogs act on behalf of. */
@@ -48,10 +44,8 @@ export const VersionContextMenuDialogs = memo(function VersionContextMenuDialogs
   const {
     dialogState,
     onClose,
-    documentId,
     documentType,
-    bundleId,
-    isVersion,
+    versionId,
     title,
     sourceReleasePerspective,
     onCreateVersion,
@@ -66,7 +60,7 @@ export const VersionContextMenuDialogs = memo(function VersionContextMenuDialogs
       {dialogState === 'discard-version' && isDiscardable && (
         <DiscardVersionDialog
           onClose={onClose}
-          documentId={isVersion ? getVersionId(documentId, bundleId) : documentId}
+          versionId={versionId}
           fromPerspective={title}
           documentType={documentType}
           isGoingToUnpublish={isGoingToUnpublish}
@@ -77,7 +71,7 @@ export const VersionContextMenuDialogs = memo(function VersionContextMenuDialogs
         <CopyToNewReleaseDialog
           onClose={onClose}
           onCreateVersion={onCreateVersion}
-          documentId={isVersion ? getVersionId(documentId, bundleId) : documentId}
+          versionId={versionId}
           documentType={documentType}
           release={sourceReleasePerspective}
           title={title}

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuPopover.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuPopover.tsx
@@ -17,13 +17,13 @@ export interface VersionContextMenuPopoverProps {
   popoverRef: RefObject<HTMLDivElement | null>
   /** The element the menu popover is positioned relative to. */
   referenceElement: HTMLElement | null
-  documentId: string
+  documentGroupId: string
   documentType: string
   /** The perspective the menu acts on: 'published', 'draft', or a release ID. */
   bundleId: string
-  isVersion: boolean
   releases: ReleaseDocument[]
   releasesLoading: boolean
+  versionId: string
   onDiscard: () => void
   onCreateRelease: () => void
   onCopyToDrafts: (options: CopyToDraftsOptions) => Promise<void>
@@ -61,10 +61,10 @@ export const VersionContextMenuPopover = memo(function VersionContextMenuPopover
     contextMenu,
     popoverRef,
     referenceElement,
-    documentId,
+    documentGroupId,
+    versionId,
     documentType,
     bundleId,
-    isVersion,
     releases,
     releasesLoading,
     onDiscard,
@@ -86,11 +86,11 @@ export const VersionContextMenuPopover = memo(function VersionContextMenuPopover
       animate={false}
       content={
         <VersionContextMenu
-          documentId={documentId}
+          documentGroupId={documentGroupId}
           releases={releases}
           releasesLoading={releasesLoading}
           fromRelease={bundleId}
-          isVersion={isVersion}
+          versionId={versionId}
           onDiscard={onDiscard}
           onCreateRelease={onCreateRelease}
           onCopyToDrafts={onCopyToDrafts}

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/__tests__/VersionContextMenu.test.tsx
@@ -62,11 +62,11 @@ describe('VersionContextMenu', () => {
   ]
 
   const defaultProps = {
-    documentId: 'versions.bundle.doc1',
+    documentGroupId: 'doc1',
+    versionId: 'versions.bundle.doc1',
     releases: mockReleases,
     releasesLoading: false,
     fromRelease: 'release1',
-    isVersion: true,
     onDiscard: vi.fn(),
     onCreateRelease: vi.fn(),
     onCopyToDrafts: vi.fn(),
@@ -124,8 +124,8 @@ describe('VersionContextMenu', () => {
     const wrapper = await createTestProvider()
     const publishedProps = {
       ...defaultProps,
-      documentId: 'testid',
-      isVersion: false,
+      documentGroupId: 'testid',
+      versionId: 'testid',
     }
 
     render(<VersionContextMenu {...publishedProps} />, {wrapper})

--- a/packages/sanity/src/core/releases/components/documentHeader/dialog/CopyToNewReleaseDialog.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/dialog/CopyToNewReleaseDialog.tsx
@@ -25,13 +25,13 @@ import {ReleaseAvatar} from '../../ReleaseAvatar'
 
 export function CopyToNewReleaseDialog(props: {
   onClose: () => void
-  documentId: string
+  versionId: string
   documentType: string
   release: TargetPerspective
   title: string
   onCreateVersion: (releaseId: string) => void
 }): React.JSX.Element {
-  const {onClose, documentId, documentType, release: sourceRelease, title, onCreateVersion} = props
+  const {onClose, versionId, documentType, release: sourceRelease, title, onCreateVersion} = props
   const {t} = useTranslation()
   const toast = useToast()
   const createReleaseMetadata = useCreateReleaseMetadata()
@@ -139,7 +139,7 @@ export function CopyToNewReleaseDialog(props: {
       >
         <Flex align="center" padding={4} paddingTop={1} justify="space-between">
           {schemaType ? (
-            <Preview value={{_id: documentId}} schemaType={schemaType} />
+            <Preview value={{_id: versionId}} schemaType={schemaType} />
           ) : (
             <LoadingBlock />
           )}

--- a/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
+++ b/packages/sanity/src/core/releases/hooks/useVersionContextMenu.ts
@@ -11,7 +11,7 @@ import {
   useScheduledDraftMenuActions,
   type UseScheduledDraftMenuActionsReturn,
 } from '../../singleDocRelease/hooks/useScheduledDraftMenuActions'
-import {getVersionId} from '../../util/draftUtils'
+import {isDocumentGroupId} from '../../util/draftUtils'
 import {isCardinalityOneRelease} from '../../util/releaseUtils'
 import {LATEST, PUBLISHED} from '../util/const'
 import {getReleaseIdFromReleaseDocumentId} from '../util/getReleaseIdFromReleaseDocumentId'
@@ -45,7 +45,15 @@ export type VersionContextMenuState =
  * @internal
  */
 export interface UseVersionContextMenuOptions {
-  documentId: string
+  /**
+   * The document group id (published id with no `drafts.` / `versions.` prefix).
+   */
+  documentGroupId: string
+  /**
+   * The version id (with `drafts.` / `versions.` prefix) or even the published id (with no prefix).
+   * AKA the full document id
+   */
+  versionId: string
   documentType: string
   /** The perspective the menu acts on: 'published', 'draft', or a release ID. */
   bundleId: string
@@ -107,7 +115,8 @@ export function useVersionContextMenu(
   options: UseVersionContextMenuOptions,
 ): UseVersionContextMenuReturn {
   const {
-    documentId,
+    documentGroupId,
+    versionId,
     documentType,
     bundleId,
     isVersion,
@@ -116,12 +125,16 @@ export function useVersionContextMenu(
     onCopyToDraftsComplete,
   } = options
 
+  if (process.env.NODE_ENV !== 'production' && !isDocumentGroupId(documentGroupId)) {
+    console.warn(
+      `useVersionContextMenu: expected a document group id, got "${documentGroupId}". Pass the group (published) id as \`documentGroupId\` and the full document id as \`versionId\`.`,
+    )
+  }
+
   const [contextMenu, setContextMenu] = useState<VersionContextMenuState>({open: false})
   const popoverRef = useRef<HTMLDivElement | null>(null)
   const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(null)
   const [dialogState, setDialogState] = useState<VersionContextMenuDialogState>('idle')
-
-  const docId = isVersion ? getVersionId(documentId, bundleId) : documentId // operations recognises publish and draft as empty
 
   const {createVersion} = useVersionOperations()
   const toast = useToast()
@@ -173,7 +186,7 @@ export function useVersionContextMenu(
   }, [setPerspective, onCopyToDraftsComplete])
 
   const {handleCopyToDrafts} = useCopyToDrafts({
-    documentId,
+    documentId: documentGroupId,
     fromRelease: bundleId,
     onNavigate: handleCopyToDraftsNavigate,
     onConfirmationRequest: () => setDialogState('copy-to-drafts'),
@@ -182,7 +195,7 @@ export function useVersionContextMenu(
   const handleAddVersion = useCallback(
     async (targetRelease: string) => {
       try {
-        await createVersion(getReleaseIdFromReleaseDocumentId(targetRelease), docId)
+        await createVersion(getReleaseIdFromReleaseDocumentId(targetRelease), versionId)
       } catch (err) {
         toast.push({
           closable: true,
@@ -194,7 +207,7 @@ export function useVersionContextMenu(
 
       closeContextMenu()
     },
-    [closeContextMenu, createVersion, docId, t, toast],
+    [closeContextMenu, createVersion, versionId, t, toast],
   )
 
   const isScheduledDraft = Boolean(release && isVersion && isCardinalityOneRelease(release))
@@ -209,7 +222,7 @@ export function useVersionContextMenu(
   const scheduledDraftMenuActions = useScheduledDraftMenuActions({
     release,
     documentType,
-    documentId,
+    documentId: documentGroupId,
     disabled,
     onActionComplete: handleEditScheduleComplete,
     onDeleteComplete,

--- a/packages/sanity/src/core/releases/plugin/documentActions/DiscardVersionAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/DiscardVersionAction.tsx
@@ -65,7 +65,7 @@ export const useDiscardVersionAction: DocumentActionComponent = (
       component: (
         <DiscardVersionDialog
           isGoingToUnpublish={willUnpublish}
-          documentId={version._id}
+          versionId={version._id}
           documentType={type}
           onClose={() => setDialogOpen(false)}
           fromPerspective={selectedPerspective}

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentActions.tsx
@@ -117,7 +117,7 @@ const DocumentActionsInner = memo(
           <DiscardVersionDialog
             isGoingToUnpublish={isGoingToUnpublish(document.document)}
             onClose={() => setShowDiscardDialog(false)}
-            documentId={document.document._id}
+            versionId={document.document._id}
             documentType={document.document._type}
             fromPerspective={releaseTitle || t('release-placeholder.title')}
           />

--- a/packages/sanity/src/core/util/__tests__/draftUtils.test.ts
+++ b/packages/sanity/src/core/util/__tests__/draftUtils.test.ts
@@ -8,6 +8,7 @@ import {
   getPublishedId,
   getVersionFromId,
   getVersionId,
+  isDocumentGroupId,
   removeDupes,
 } from '../draftUtils'
 
@@ -99,6 +100,16 @@ describe('getVersionFromId', () => {
   it('should return the undefined if no bundle slug is found and document is published', () => {
     expect(getVersionFromId('my-document-id')).toBe(undefined)
   })
+})
+
+test.each([
+  ['published id', 'agot', true],
+  ['draft id', 'drafts.agot', false],
+  ['version id', 'versions.summer-drop.agot', false],
+  ['id starting with the drafts folder name', 'draftsy', true],
+  ['id starting with the versions folder name', 'versionsy', true],
+])('isDocumentGroupId(): %s', (_, documentId, shouldEqual) => {
+  expect(isDocumentGroupId(documentId)).toBe(shouldEqual)
 })
 
 describe('getIdPair', () => {

--- a/packages/sanity/src/core/util/draftUtils.ts
+++ b/packages/sanity/src/core/util/draftUtils.ts
@@ -251,3 +251,19 @@ export function removeDupes(documents: SanityDocumentLike[]): SanityDocumentLike
     .map((entry) => entry.draft || entry.published || entry.versions[0])
     .filter(isNonNullable)
 }
+
+/**
+ * Checks whether `id` is a document group id, i.e. an id carrying neither the `drafts.` nor the
+ * `versions.` prefix. The group document is the published document, so this is the same check as
+ * {@link isPublishedId}, named for call sites that care about the group rather than the published
+ * version.
+ *
+ * @internal
+ *
+ * @param id - The document ID to check
+ *
+ * @returns `true` if the document ID is a group ID, `false` otherwise
+ */
+export function isDocumentGroupId(id: string): boolean {
+  return isPublishedId(id)
+}

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/NonReleaseVersionsSelect.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/NonReleaseVersionsSelect.tsx
@@ -87,7 +87,8 @@ export function NonReleaseVersionsSelect(props: {
               onClick={() => onSelectBundle(selectedNonReleaseVersion)}
               onCopyToDraftsComplete={onCopyToDraftsComplete}
               contextValues={{
-                documentId: getPublishedId(selectedNonReleaseVersion._id),
+                documentGroupId: getPublishedId(selectedNonReleaseVersion._id),
+                versionId: selectedNonReleaseVersion._id,
                 releases,
                 releasesLoading: releasesLoading,
                 documentType: documentType,
@@ -147,7 +148,8 @@ export function NonReleaseVersionsSelect(props: {
                     onClick={() => onSelectBundle(nonReleaseVersion)}
                     onCopyToDraftsComplete={onCopyToDraftsComplete}
                     contextValues={{
-                      documentId: getPublishedId(nonReleaseVersion._id),
+                      documentGroupId: getPublishedId(nonReleaseVersion._id),
+                      versionId: nonReleaseVersion._id,
                       releases,
                       releasesLoading: releasesLoading,
                       documentType: documentType,

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -2,8 +2,11 @@ import {Stack, Text} from '@sanity/ui'
 import {memo} from 'react'
 import {
   Chip,
+  getDraftId,
+  getPublishedId,
   getReleaseIdFromReleaseDocumentId,
   getReleaseTone,
+  getVersionId,
   isGoingToUnpublish,
   isReleaseScheduledOrScheduling,
   type ReleaseDocument,
@@ -78,9 +81,9 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
   const {t} = useTranslation()
   const dateTimeFormat = useDateTimeFormat(DATE_TIME_FORMAT)
   const {loading} = useActiveReleases()
-  const {editState, displayed} = useDocumentPane()
+  const {editState, displayed, documentId} = useDocumentPane()
   const {documentType} = useDocumentPaneInfo()
-
+  const documentGroupId = getPublishedId(documentId)
   const {
     filteredReleases,
     getVersionDisplay,
@@ -122,7 +125,8 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
         tone="positive"
         onCopyToDraftsComplete={clearScheduledDraftPerspective}
         contextValues={{
-          documentId: editState?.published?._id || editState?.id || '',
+          documentGroupId,
+          versionId: getPublishedId(documentGroupId),
           releases: filteredReleases.notCurrentReleases,
           releasesLoading: loading,
           documentType,
@@ -167,7 +171,8 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
           onClick={() => handlePerspectiveChange('drafts')}
           onCopyToDraftsComplete={clearScheduledDraftPerspective}
           contextValues={{
-            documentId: editState?.draft?._id || editState?.published?._id || editState?.id || '',
+            documentGroupId,
+            versionId: getDraftId(documentId),
             documentType: documentType,
             releases: filteredReleases.notCurrentReleases,
             releasesLoading: loading,
@@ -203,7 +208,11 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
               text={displayTitle}
               onCopyToDraftsComplete={clearScheduledDraftPerspective}
               contextValues={{
-                documentId: displayed?._id || '',
+                documentGroupId,
+                versionId: getVersionId(
+                  documentGroupId,
+                  getReleaseIdFromReleaseDocumentId(filteredReleases.inCreation!._id),
+                ),
                 documentType,
                 disabled: true,
                 releases: filteredReleases.notCurrentReleases,
@@ -246,7 +255,11 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
                 locked={isReleaseScheduledOrScheduling(release)}
                 onCopyToDraftsComplete={clearScheduledDraftPerspective}
                 contextValues={{
-                  documentId: displayed?._id || '',
+                  documentGroupId,
+                  versionId: getVersionId(
+                    documentGroupId,
+                    getReleaseIdFromReleaseDocumentId(release._id),
+                  ),
                   documentType,
                   releases: filteredReleases.notCurrentReleases,
                   releasesLoading: loading,

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -172,7 +172,10 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
           onCopyToDraftsComplete={clearScheduledDraftPerspective}
           contextValues={{
             documentGroupId,
-            versionId: getDraftId(documentId),
+            // With no draft the chip displays the published document, so act on that instead —
+            // adding to a release should duplicate the content on screen.
+            versionId:
+              editState?.draft?._id ?? editState?.published?._id ?? getDraftId(documentGroupId),
             documentType: documentType,
             releases: filteredReleases.notCurrentReleases,
             releasesLoading: loading,


### PR DESCRIPTION
### Description

Refactoring VersionsContextMenu.

The VersionsContextMenu was using `documentId`.
In some cases depending on the caller the `documentId` is the versionId and in other cases it was the `publishedId` , this is confusing a requires extra checks in multiple locations.
Now, the versions context menu and the internal components and hooks will either get the `documentGroupId` or the `versionId` , and with that id they will behave the way they need to , without guessing if it's a published  a draft or a version.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Use the context menu in the studio through the `DocumentGroupInventory` it should behave the same as before.
Use the context menu in the new studio with variants disabled through the `DocumentPerspectiveList` it should behave the same as before.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---
