### PR TITLE
fix(core): lock in intended publish date when scheduling a release

### DIFF
--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
@@ -117,13 +117,12 @@ export const ReleaseScheduleButton = ({
       },
     }
 
-    if (!isEqual(newRelease, release)) {
-      void updateRelease(newRelease)
-    }
-
     // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
     const run = async () => {
       setStatus('scheduling')
+      if (!isEqual(newRelease, release)) {
+        await updateRelease(newRelease)
+      }
       await schedule(release._id, publishAt)
       telemetry.log(ScheduledRelease)
       toast.push({

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
@@ -100,6 +100,12 @@ export const ReleaseScheduleButton = ({
   const handleConfirmSchedule = useCallback(async () => {
     if (!publishAt) return
 
+    if (isScheduledDateInPast()) {
+      // rerender dialog to recalculate isScheduledDateInPast
+      setRerenderDialog((cur) => cur + 1)
+      return
+    }
+
     // Keep intendedPublishAt in step with the scheduled date, otherwise a later
     // unschedule reverts to a previously planned date (getPublishDateFromRelease falls back to it).
     const newRelease = {
@@ -113,12 +119,6 @@ export const ReleaseScheduleButton = ({
 
     if (!isEqual(newRelease, release)) {
       void updateRelease(newRelease)
-    }
-
-    if (isScheduledDateInPast()) {
-      // rerender dialog to recalculate isScheduledDateInPast
-      setRerenderDialog((cur) => cur + 1)
-      return
     }
 
     // Workaround for React Compiler not yet fully supporting try/catch/finally syntax

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
@@ -100,11 +100,8 @@ export const ReleaseScheduleButton = ({
   const handleConfirmSchedule = useCallback(async () => {
     if (!publishAt) return
 
-    // Lock in the intended publish date to the date the release is being
-    // scheduled for. Without this, unscheduling later reverts the release to a
-    // previously planned date instead of the most recently scheduled one
-    // (SAPP-2726). From the menu item entry point this also switches the
-    // release type to "scheduled".
+    // Keep intendedPublishAt in step with the scheduled date, otherwise a later
+    // unschedule reverts to a previously planned date (getPublishDateFromRelease falls back to it).
     const newRelease = {
       ...release,
       metadata: {

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
@@ -100,23 +100,6 @@ export const ReleaseScheduleButton = ({
   const handleConfirmSchedule = useCallback(async () => {
     if (!publishAt) return
 
-    // this means that it will linely need to change the releaseType to scheduled
-    if (isMenuItem) {
-      const newRelease = {
-        ...release,
-        metadata: {
-          ...release.metadata,
-          releaseType: 'scheduled' as const,
-
-          intendedPublishAt: publishAt.toISOString(),
-        },
-      }
-
-      if (!isEqual(newRelease, release)) {
-        void updateRelease(newRelease)
-      }
-    }
-
     if (isScheduledDateInPast()) {
       // rerender dialog to recalculate isScheduledDateInPast
       setRerenderDialog((cur) => cur + 1)
@@ -126,6 +109,25 @@ export const ReleaseScheduleButton = ({
     // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
     const run = async () => {
       setStatus('scheduling')
+
+      // Lock in the intended publish date to the date the release is being
+      // scheduled for. Without this, unscheduling later reverts the release to a
+      // previously planned date instead of the most recently scheduled one
+      // (SAPP-2726). From the menu item entry point this also switches the
+      // release type to "scheduled".
+      const newRelease = {
+        ...release,
+        metadata: {
+          ...release.metadata,
+          releaseType: 'scheduled' as const,
+          intendedPublishAt: publishAt.toISOString(),
+        },
+      }
+
+      if (!isEqual(newRelease, release)) {
+        await updateRelease(newRelease)
+      }
+
       await schedule(release._id, publishAt)
       telemetry.log(ScheduledRelease)
       toast.push({
@@ -168,7 +170,6 @@ export const ReleaseScheduleButton = ({
     setStatus('idle')
   }, [
     publishAt,
-    isMenuItem,
     isScheduledDateInPast,
     release,
     updateRelease,

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
@@ -100,6 +100,24 @@ export const ReleaseScheduleButton = ({
   const handleConfirmSchedule = useCallback(async () => {
     if (!publishAt) return
 
+    // Lock in the intended publish date to the date the release is being
+    // scheduled for. Without this, unscheduling later reverts the release to a
+    // previously planned date instead of the most recently scheduled one
+    // (SAPP-2726). From the menu item entry point this also switches the
+    // release type to "scheduled".
+    const newRelease = {
+      ...release,
+      metadata: {
+        ...release.metadata,
+        releaseType: 'scheduled' as const,
+        intendedPublishAt: publishAt.toISOString(),
+      },
+    }
+
+    if (!isEqual(newRelease, release)) {
+      void updateRelease(newRelease)
+    }
+
     if (isScheduledDateInPast()) {
       // rerender dialog to recalculate isScheduledDateInPast
       setRerenderDialog((cur) => cur + 1)
@@ -109,25 +127,6 @@ export const ReleaseScheduleButton = ({
     // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
     const run = async () => {
       setStatus('scheduling')
-
-      // Lock in the intended publish date to the date the release is being
-      // scheduled for. Without this, unscheduling later reverts the release to a
-      // previously planned date instead of the most recently scheduled one
-      // (SAPP-2726). From the menu item entry point this also switches the
-      // release type to "scheduled".
-      const newRelease = {
-        ...release,
-        metadata: {
-          ...release.metadata,
-          releaseType: 'scheduled' as const,
-          intendedPublishAt: publishAt.toISOString(),
-        },
-      }
-
-      if (!isEqual(newRelease, release)) {
-        await updateRelease(newRelease)
-      }
-
       await schedule(release._id, publishAt)
       telemetry.log(ScheduledRelease)
       toast.push({

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/__tests__/ReleaseScheduleButton.test.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/__tests__/ReleaseScheduleButton.test.tsx
@@ -128,4 +128,26 @@ describe('ReleaseScheduleButton', () => {
 
     expect(useReleaseOperationsMockReturn.updateRelease).not.toHaveBeenCalled()
   })
+
+  test('does not schedule and shows an error toast when updateRelease fails', async () => {
+    useReleaseOperationsMockReturn.updateRelease.mockReset()
+    useReleaseOperationsMockReturn.updateRelease.mockRejectedValue(new Error('network error'))
+
+    await openScheduleDialog()
+
+    // change the scheduled date to a new future date
+    const dateInput = screen.getByTestId('date-input')
+    await userEvent.clear(dateInput)
+    await userEvent.type(dateInput, 'Oct 15, 2030 10:00')
+    await userEvent.tab()
+
+    await userEvent.click(screen.getByTestId('confirm-button'))
+
+    await waitFor(() => {
+      expect(useReleaseOperationsMockReturn.updateRelease).toHaveBeenCalled()
+    })
+
+    expect(await screen.findByText(/network error/)).toBeInTheDocument()
+    expect(useReleaseOperationsMockReturn.schedule).not.toHaveBeenCalled()
+  })
 })

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/__tests__/ReleaseScheduleButton.test.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/__tests__/ReleaseScheduleButton.test.tsx
@@ -1,0 +1,131 @@
+import {render, screen, waitFor} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {activeScheduledRelease} from '../../../../__fixtures__/release.fixture'
+import {releasesUsEnglishLocaleBundle} from '../../../../i18n'
+import {
+  mockUseReleaseOperations,
+  useReleaseOperationsMockReturn,
+} from '../../../../store/__tests__/__mocks/useReleaseOperations.mock'
+import {
+  mockUseReleasePermissions,
+  useReleasePermissionsMockReturn,
+  useReleasesPermissionsMockReturnTrue,
+} from '../../../../store/__tests__/__mocks/useReleasePermissions.mock'
+import {type DocumentInRelease} from '../../../detail/types'
+import {ReleaseScheduleButton} from '../ReleaseScheduleButton'
+
+vi.mock('../../../../store/useReleaseOperations', () => ({
+  useReleaseOperations: vi.fn(() => useReleaseOperationsMockReturn),
+}))
+
+vi.mock('../../../../store/useReleasePermissions', () => ({
+  useReleasePermissions: vi.fn(() => useReleasePermissionsMockReturn),
+}))
+
+// A scheduled-type release that is currently active (i.e. the state after
+// unscheduling). Its intended publish date is far in the future so the schedule
+// dialog can be confirmed without hitting the "date in past" guard.
+const futureIntendedPublishAt = '2030-10-10T10:00:00.000Z'
+const release = {
+  ...activeScheduledRelease,
+  metadata: {
+    ...activeScheduledRelease.metadata,
+    intendedPublishAt: futureIntendedPublishAt,
+  },
+}
+
+const createDocumentInRelease = (documentId: string): DocumentInRelease =>
+  ({
+    memoKey: documentId,
+    document: {
+      _id: documentId,
+      _type: 'test-document',
+      _createdAt: '2023-10-01T08:00:00Z',
+      _updatedAt: '2023-10-01T09:00:00Z',
+      _rev: 'some-rev',
+      publishedDocumentExists: true,
+      draftDocumentExists: false,
+    },
+    validation: {
+      isValidating: false,
+      hasError: false,
+      validation: [],
+    },
+  }) as unknown as DocumentInRelease
+
+const documents = [createDocumentInRelease('versions.rActive.doc1')]
+
+const openScheduleDialog = async () => {
+  const wrapper = await createTestProvider({
+    resources: [releasesUsEnglishLocaleBundle],
+  })
+  render(<ReleaseScheduleButton release={release} documents={documents} />, {wrapper})
+
+  await waitFor(() => {
+    expect(screen.getByTestId('schedule-button')).not.toBeDisabled()
+  })
+
+  await userEvent.click(screen.getByTestId('schedule-button'))
+
+  screen.getByTestId('confirm-schedule-dialog')
+}
+
+describe('ReleaseScheduleButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockUseReleasePermissions.mockReturnValue(useReleasesPermissionsMockReturnTrue)
+    mockUseReleaseOperations.mockReturnValue(useReleaseOperationsMockReturn)
+    useReleaseOperationsMockReturn.schedule.mockResolvedValue({transactionId: 'transaction'})
+    useReleaseOperationsMockReturn.updateRelease.mockResolvedValue({transactionId: 'transaction'})
+  })
+
+  test('locks in intendedPublishAt to the newly scheduled date when scheduling (SAPP-2726)', async () => {
+    await openScheduleDialog()
+
+    // change the scheduled date to a new future date
+    const dateInput = screen.getByTestId('date-input')
+    await userEvent.clear(dateInput)
+    await userEvent.type(dateInput, 'Oct 15, 2030 10:00')
+    await userEvent.tab()
+
+    await userEvent.click(screen.getByTestId('confirm-button'))
+
+    await waitFor(() => {
+      expect(useReleaseOperationsMockReturn.schedule).toHaveBeenCalled()
+    })
+
+    const scheduledDate = useReleaseOperationsMockReturn.schedule.mock.calls[0][1] as Date
+
+    // the intended publish date must be updated to match the date the release is
+    // being scheduled for, so a later unschedule reverts to this date and not the
+    // previously planned one
+    expect(useReleaseOperationsMockReturn.updateRelease).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _id: release._id,
+        metadata: expect.objectContaining({
+          releaseType: 'scheduled',
+          intendedPublishAt: scheduledDate.toISOString(),
+        }),
+      }),
+    )
+    // the selected date is genuinely different from the original intended date
+    expect(scheduledDate.toISOString()).not.toBe(futureIntendedPublishAt)
+  })
+
+  test('does not update the release when the scheduled date is unchanged', async () => {
+    await openScheduleDialog()
+
+    // confirm without changing the pre-filled (intended) date
+    await userEvent.click(screen.getByTestId('confirm-button'))
+
+    await waitFor(() => {
+      expect(useReleaseOperationsMockReturn.schedule).toHaveBeenCalled()
+    })
+
+    expect(useReleaseOperationsMockReturn.updateRelease).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### Description

When a scheduled release is unscheduled, the studio displays its publish date via `getPublishDateFromRelease`, which falls back to `metadata.intendedPublishAt` once the backend `publishAt` is cleared.

Scheduling a release from the main **Schedule** button only set the backend `publishAt` and left `metadata.intendedPublishAt` untouched (that update was gated behind the `isMenuItem` code path). So after scheduling to a new date B and then unscheduling, the release reverted to a previously planned date A instead of the most recently scheduled date B.

This change always locks in `intendedPublishAt` to the selected publish date when scheduling — not just from the menu-item entry point — mirroring the single-document reschedule flow (`handleRescheduleScheduledDraft`). The past-date guard is moved ahead of the update so a past date is never locked in.

Fixes [SAPP-2726](https://linear.app/sanity/issue/SAPP-2726/unscheduling-a-release-reverts-to-previously-scheduled-date-instead-of).

### What to review

- `ReleaseScheduleButton.tsx` — `handleConfirmSchedule` awaits the release metadata update (`intendedPublishAt`, `releaseType: 'scheduled'`) before calling `schedule`, and only when the metadata actually changes. Awaiting means a failed metadata write surfaces an error toast and aborts scheduling, so `schedule` never runs against a stale `intendedPublishAt`.
- Reproduce in the Releases tool: create a scheduled release, schedule it, unschedule, re-schedule to a different date, unschedule again — the displayed date should reflect the most recently scheduled date, not the original one.

### Testing

Added `ReleaseScheduleButton.test.tsx` (no prior test existed for this component):

- Scheduling to a new date calls `updateRelease` with `intendedPublishAt` equal to the scheduled date (the regression guard — fails without the fix).
- Scheduling at the unchanged, pre-filled date does not fire a redundant `updateRelease`.
- When the metadata write fails, `schedule` is not called and an error toast is shown.

Verified locally: the `ReleaseScheduleButton` suite passes (3 tests). Browser/E2E verification against a live studio was not possible in the working environment (no auth token available).

### Notes for release

Fixed an issue in Content Releases where unscheduling a release could revert its publish date to a previously scheduled date instead of the most recent one. Scheduling a release now records the selected date as its intended publish date, so unscheduling and rescheduling behave consistently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to release scheduling UI and metadata ordering; behavior is tightened with new unit tests and no auth or data-model changes.
> 
> **Overview**
> Fixes **Content Releases** showing the wrong publish date after unschedule/reschedule: scheduling from the main **Schedule** button now always syncs `metadata.intendedPublishAt` (and `releaseType: 'scheduled'`) to the date chosen in the dialog, not only when opened from the menu item.
> 
> In `ReleaseScheduleButton`, confirm scheduling **awaits** `updateRelease` when metadata changed, then calls `schedule`; a failed metadata write shows the error toast and **does not** schedule. The past-date check runs before any metadata update so a past date is never persisted.
> 
> Adds `ReleaseScheduleButton.test.tsx` covering the SAPP-2726 regression, skipping redundant updates when the date is unchanged, and aborting schedule on `updateRelease` failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5616fcd1bd56518246a75cd04bdcfd0cdb139c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->