### PR TITLE
fix(core): show document titles for unpublish actions in releases

### DIFF
--- a/packages/sanity/src/core/releases/tool/components/ReleaseDocumentPreview.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseDocumentPreview.tsx
@@ -20,7 +20,7 @@ interface ReleaseDocumentPreviewProps {
   documentRevision?: string
   hasValidationError?: boolean
   layout?: PreviewLayoutKey
-  isGoingToBePublished?: boolean
+  isGoingToUnpublish?: boolean
   isCardinalityOneRelease?: boolean
   variantId?: string
 }
@@ -33,7 +33,7 @@ export function ReleaseDocumentPreview({
   isCardinalityOneRelease,
   documentRevision,
   layout,
-  isGoingToBePublished = false,
+  isGoingToUnpublish = false,
   variantId,
 }: ReleaseDocumentPreviewProps) {
   const documentPresence = useDocumentPresence(documentId)
@@ -85,9 +85,15 @@ export function ReleaseDocumentPreview({
   )
 
   const {isLoading: previewLoading, value: resolvedPreview} = useDocumentPreviewValues({
-    documentId: isGoingToBePublished ? getPublishedId(documentId) : documentId,
+    documentId: isGoingToUnpublish ? getPublishedId(documentId) : documentId,
     documentType: documentTypeName,
-    perspectiveStack: isGoingToBePublished ? [] : [getReleaseIdFromReleaseDocumentId(releaseId)],
+    // A document going to be unpublished has a version tombstone (`_system.delete`) with no
+    // preview fields, so we resolve the still-existing published document instead. This must be
+    // an explicit `['published']` perspective: an empty stack (`[]`) no longer resolves the
+    // published document, which left these rows showing "Untitled".
+    perspectiveStack: isGoingToUnpublish
+      ? ['published']
+      : [getReleaseIdFromReleaseDocumentId(releaseId)],
   })
 
   return (

--- a/packages/sanity/src/core/releases/tool/components/__tests__/ReleaseDocumentPreview.test.tsx
+++ b/packages/sanity/src/core/releases/tool/components/__tests__/ReleaseDocumentPreview.test.tsx
@@ -147,6 +147,47 @@ describe('ReleaseDocumentPreview', () => {
     expect(searchParams).toBeNull()
   })
 
+  it('resolves the published document preview with a published perspective for unpublish documents', async () => {
+    const {useDocumentPreviewValues} =
+      await import('../../../../tasks/hooks/useDocumentPreviewValues')
+    vi.mocked(useDocumentPreviewValues).mockClear()
+
+    await renderTest({
+      documentId: 'versions.rASAP.doc123',
+      documentTypeName: 'post',
+      releaseId: activeASAPRelease._id,
+      releaseState: 'active',
+      isGoingToUnpublish: true,
+    })
+
+    // A version tombstone has no preview fields, so we must resolve the still-published
+    // document via its published id and an explicit `['published']` perspective.
+    expect(useDocumentPreviewValues).toHaveBeenCalledWith({
+      documentId: 'doc123',
+      documentType: 'post',
+      perspectiveStack: ['published'],
+    })
+  })
+
+  it('resolves the version preview with the release perspective for non-unpublish documents', async () => {
+    const {useDocumentPreviewValues} =
+      await import('../../../../tasks/hooks/useDocumentPreviewValues')
+    vi.mocked(useDocumentPreviewValues).mockClear()
+
+    await renderTest({
+      documentId: 'versions.rASAP.doc123',
+      documentTypeName: 'post',
+      releaseId: activeASAPRelease._id,
+      releaseState: 'active',
+    })
+
+    expect(useDocumentPreviewValues).toHaveBeenCalledWith({
+      documentId: 'versions.rASAP.doc123',
+      documentType: 'post',
+      perspectiveStack: ['rASAP'],
+    })
+  })
+
   it('creates link with variant and release perspective sticky params', async () => {
     const {container} = await renderTest({
       documentId: 'versions.buz.doc123',

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -38,7 +38,7 @@ const MemoReleaseDocumentPreview = memo(
     releaseState?: ReleaseState
     documentRevision?: string
   }) {
-    const isGoingToBePublished = isGoingToUnpublish(item.document)
+    const willUnpublish = isGoingToUnpublish(item.document)
     const variantId = getVariantIdFromDocument(item.document)
 
     return (
@@ -48,7 +48,7 @@ const MemoReleaseDocumentPreview = memo(
         releaseId={releaseId}
         releaseState={releaseState}
         documentRevision={documentRevision}
-        isGoingToBePublished={isGoingToBePublished}
+        isGoingToUnpublish={willUnpublish}
         variantId={variantId}
       />
     )


### PR DESCRIPTION
### Description

In the Content Releases detail modal (`/releases/:releaseId`), documents set to "Unpublish when releasing" rendered as **Untitled** instead of showing the document's title.

A document going to be unpublished is represented by a version tombstone (`_system.delete: true`) that carries no preview fields, so `ReleaseDocumentPreview` correctly resolves the still-published document instead. However, it did so with an **empty perspective stack (`[]`)**, which no longer resolves the published document — leaving the row (and its title) empty.

The fix uses an explicit `['published']` perspective, matching the sibling `VariantDocumentPreview` implementation, which already resolves published documents this way. The still-published document's preview now renders as expected.

While here, the misleadingly-named `isGoingToBePublished` prop/variable is renamed to `isGoingToUnpublish` — which is what it actually holds (`isGoingToUnpublish(document)`).

Fixes SAPP-3030.

### What to review

- `packages/sanity/src/core/releases/tool/components/ReleaseDocumentPreview.tsx` — the `perspectiveStack` passed to `useDocumentPreviewValues` for unpublish documents is now `['published']` instead of `[]`.
- `packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx` — the renamed prop is passed through.
- To verify manually: run a Studio, add a published document to a release, set it to *Unpublish when releasing*, open the release page, and confirm the document shows its title (not "Untitled").

### Testing

Added two unit tests to `ReleaseDocumentPreview.test.tsx`:
- Unpublish documents resolve the **published** document id with a `['published']` perspective stack.
- Non-unpublish documents keep resolving the version id with the release perspective stack.

The first test was confirmed to fail against the previous `[]` behaviour and pass with the fix. All existing release detail suites pass (`9` files, `100` tests).

### Notes for release

Fixed a regression in Content Releases where documents marked to be unpublished in a release showed "Untitled" instead of their document title in the release detail view.

---


---
_Generated by [Claude Code](https://claude.ai/code/session_01S1ntevrLeoDuDeEbzizRTe)_