### PR TITLE
feat(workbench): export AssetSource types from sanity/workbench

### DIFF
--- a/packages/sanity/src/_exports/workbench.ts
+++ b/packages/sanity/src/_exports/workbench.ts
@@ -5,3 +5,7 @@
 
 export {unstable_defineService, unstable_defineView} from '@sanity/cli/runtime'
 export {renderWorkbench} from '@sanity/workbench/_internal'
+// Props an `asset_source` view component receives. Sourced from `@sanity/types`
+// directly (same shape `@sanity/cli/runtime` re-exports) so authors can type an
+// `unstable_defineView('asset_source', …)` component from `sanity/workbench`.
+export type {AssetSource, AssetSourceComponentProps} from '@sanity/types'


### PR DESCRIPTION
### Description

Lets an author type an `unstable_defineView('asset_source', …)` component imported from `sanity/workbench`, by surfacing the asset source prop types through that entry point.

Part of the `asset_source` federated view interface ([SDK-2188](https://linear.app/sanity/issue/SDK-2188) / [SDK-2206](https://linear.app/sanity/issue/SDK-2206)).

### Notes for release

Authors can now type an `asset_source` workbench view directly from `sanity/workbench`:

```ts
import {unstable_defineView, type AssetSourceComponentProps} from 'sanity/workbench'

export default unstable_defineView('asset_source', {
  asset_source: (props: AssetSourceComponentProps) => { /* … */ },
})
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only re-exports with no runtime or behavioral changes.
> 
> **Overview**
> Re-exports **`AssetSource`** and **`AssetSourceComponentProps`** from the **`sanity/workbench`** entry so authors can type **`unstable_defineView('asset_source', …)`** view components without pulling types from **`@sanity/types`** separately.
> 
> This is a **type-only** surface change on the existing workbench barrel; runtime exports are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee6e41934c1a58d41c5fa3ee0ed652718cb61574. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->