### PR TITLE
refactor(sanity): adopt useObservablePromise for data loading states

### DIFF
--- a/dev/test-studio/schema/debug/components/AuthorReferenceInput.tsx
+++ b/dev/test-studio/schema/debug/components/AuthorReferenceInput.tsx
@@ -1,9 +1,17 @@
 import {createImageUrlBuilder} from '@sanity/image-url'
 import {type Reference, type ReferenceSchemaType} from '@sanity/types'
 import {Button, Spinner} from '@sanity/ui'
-import {type ForwardedRef, forwardRef, useImperativeHandle, useMemo, useRef} from 'react'
-import {useObservable} from 'react-rx'
-import {map, startWith} from 'rxjs/operators'
+import {
+  type ForwardedRef,
+  forwardRef,
+  type RefObject,
+  Suspense,
+  use,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from 'react'
+import {type ObservablePromise, useObservablePromise} from 'react-rx'
 import {type ObjectInputProps, set, setIfMissing, unset, useClient} from 'sanity'
 
 import styles from './AuthorReferenceInput.module.css'
@@ -16,36 +24,27 @@ interface AuthorReference {
   name: string
 }
 
-const INITIAL_STATE = {loading: true, authors: [] as AuthorReference[]}
-
 export const AuthorReferenceInput = forwardRef(function AuthorReferenceInput(
   props: ObjectInputProps<Reference, ReferenceSchemaType>,
   ref: ForwardedRef<any>,
 ) {
-  // @ts-expect-error -- pre-existing, fix later
-  const {inputProps, type, value} = props
-  const {readOnly} = inputProps
+  const {schemaType, value, readOnly} = props
   const client = useClient({apiVersion: '2022-09-09'})
   const current = value && value._ref
   const imageBuilder = createImageUrlBuilder(client)
 
   const inputRef = useRef<HTMLButtonElement | null>(null)
 
-  const state$ = useMemo(
+  const authors$ = useMemo(
     () =>
-      client.observable
-        .fetch(
-          // Select authors, with a defined image, which are published
-          '*[_type == "author" && defined(image) && _id in path("*")][0...10] {_id, image, name}',
-        )
-        .pipe(
-          map((authors: AuthorReference[]) => ({loading: false, authors})),
-          startWith(INITIAL_STATE),
-        ),
+      client.observable.fetch<AuthorReference[]>(
+        // Select authors, with a defined image, which are published
+        '*[_type == "author" && defined(image) && _id in path("*")][0...10] {_id, image, name}',
+      ),
     [client],
   )
 
-  const {loading, authors} = useObservable(state$, INITIAL_STATE)
+  const authorsPromise = useObservablePromise(authors$)
 
   const handleChange = (item: AuthorReference) => {
     // Are we selecting the same value as previously selected?
@@ -55,17 +54,16 @@ export const AuthorReferenceInput = forwardRef(function AuthorReferenceInput(
       return
     }
 
-    props.onChange(
+    props.onChange([
       // A reference is an object, so we need to initialize it before attempting to set subproperties
-      setIfMissing({_type: type.name, _ref: item._id}),
+      setIfMissing({_type: schemaType.name, _ref: item._id}),
 
       // Allow setting weak reference in schema options
-      // @ts-expect-error -- pre-existing, fix later
-      type.weak === true ? set(true, ['_weak']) : unset(['_weak']),
+      schemaType.weak === true ? set(true, ['_weak']) : unset(['_weak']),
 
       // Set the actual reference value
       set(item._id, ['_ref']),
-    )
+    ])
   }
 
   const handleClear = () => {
@@ -80,29 +78,53 @@ export const AuthorReferenceInput = forwardRef(function AuthorReferenceInput(
 
   return (
     <div className={styles.authorGroup}>
-      {loading ? (
-        <Spinner
-        //  message="Loading authors..."
+      <Suspense fallback={<Spinner />}>
+        <AuthorOptions
+          authorsPromise={authorsPromise}
+          current={current}
+          imageBuilder={imageBuilder}
+          inputRef={inputRef}
+          onSelect={readOnly ? noop : handleChange}
         />
-      ) : (
-        authors.map((author, i) => (
-          <Button
-            key={author._id}
-            ref={i === 0 ? inputRef : undefined}
-            type="button"
-            // className={current === author._id ? styles.activeButton : styles.button}
-            onClick={readOnly ? noop : () => handleChange(author)}
-            selected={current === author._id}
-          >
-            <img
-              className={styles.authorImage}
-              title={author.name}
-              alt={`${author.name || 'Author'}.`}
-              src={imageBuilder.image(author.image).width(150).height(150).fit('crop').url()}
-            />
-          </Button>
-        ))
-      )}
+      </Suspense>
     </div>
   )
 })
+
+function AuthorOptions({
+  authorsPromise,
+  current,
+  imageBuilder,
+  inputRef,
+  onSelect,
+}: {
+  authorsPromise: ObservablePromise<AuthorReference[]>
+  current: string | undefined
+  imageBuilder: ReturnType<typeof createImageUrlBuilder>
+  inputRef: RefObject<HTMLButtonElement | null>
+  onSelect: (item: AuthorReference) => void
+}) {
+  const authors = use(authorsPromise)
+
+  return (
+    <>
+      {authors.map((author, i) => (
+        <Button
+          key={author._id}
+          ref={i === 0 ? inputRef : undefined}
+          type="button"
+          // className={current === author._id ? styles.activeButton : styles.button}
+          onClick={() => onSelect(author)}
+          selected={current === author._id}
+        >
+          <img
+            className={styles.authorImage}
+            title={author.name}
+            alt={`${author.name || 'Author'}.`}
+            src={imageBuilder.image(author.image).width(150).height(150).fit('crop').url()}
+          />
+        </Button>
+      ))}
+    </>
+  )
+}

--- a/packages/@sanity/vision/src/containers/VisionContainer.tsx
+++ b/packages/@sanity/vision/src/containers/VisionContainer.tsx
@@ -1,4 +1,6 @@
 import {Flex} from '@sanity/ui'
+import {Suspense, use} from 'react'
+import {type ObservablePromise} from 'react-rx'
 import {useClient} from 'sanity'
 
 import {DelayedSpinner} from '../components/DelayedSpinner'
@@ -8,15 +10,26 @@ import {type VisionProps} from '../types'
 
 export function VisionContainer(props: VisionProps) {
   const datasetsClient = useClient({apiVersion: 'v2025-06-27'})
-  const loadedDatasets = useDatasets({client: datasetsClient, datasets: props.config.datasets})
+  const datasetsPromise = useDatasets({client: datasetsClient, datasets: props.config.datasets})
 
-  if (!loadedDatasets) {
-    return (
-      <Flex align="center" height="fill" justify="center">
-        <DelayedSpinner />
-      </Flex>
-    )
-  }
+  return (
+    <Suspense
+      fallback={
+        <Flex align="center" height="fill" justify="center">
+          <DelayedSpinner />
+        </Flex>
+      }
+    >
+      <LoadedVisionContainer {...props} datasetsPromise={datasetsPromise} />
+    </Suspense>
+  )
+}
+
+function LoadedVisionContainer({
+  datasetsPromise,
+  ...props
+}: VisionProps & {datasetsPromise: ObservablePromise<string[] | Error>}) {
+  const loadedDatasets = use(datasetsPromise)
 
   const datasets =
     loadedDatasets instanceof Error

--- a/packages/@sanity/vision/src/hooks/useDatasets.test.ts
+++ b/packages/@sanity/vision/src/hooks/useDatasets.test.ts
@@ -1,6 +1,6 @@
 import {type DatasetsResponse, type SanityClient} from '@sanity/client'
-import {renderHook} from '@testing-library/react'
-import {of, throwError} from 'rxjs'
+import {act, renderHook} from '@testing-library/react'
+import {of, Subject, throwError} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {useDatasets} from './useDatasets'
@@ -52,26 +52,40 @@ describe('useDatasets', () => {
     vi.clearAllMocks()
   })
 
-  it('should get datasets from client.observable.datasets.list() and return them', async () => {
+  it('should get datasets from client.observable.datasets.list() and resolve with them', async () => {
     mockDatasetsList.mockReturnValue(of(MOCK_DATASETS))
 
     const {result} = renderHook(() => useDatasets({client: mockClient, datasets: undefined}))
 
     expect(mockDatasetsList).toHaveBeenCalledTimes(1)
-    expect(result.current).toEqual(['production', 'staging', 'development'])
+    await expect(result.current).resolves.toEqual(['production', 'staging', 'development'])
   })
 
-  it('should return the array directly without calling client when configDatasets is an array', () => {
+  it('should stay pending until the datasets request emits', async () => {
+    const datasets$ = new Subject<DatasetsResponse>()
+    mockDatasetsList.mockReturnValue(datasets$)
+
+    const {result} = renderHook(() => useDatasets({client: mockClient, datasets: undefined}))
+
+    expect(result.current.status).toBe('pending')
+
+    await act(async () => {
+      datasets$.next(MOCK_DATASETS)
+    })
+    await expect(result.current).resolves.toEqual(['production', 'staging', 'development'])
+  })
+
+  it('should resolve with the array directly without calling client when configDatasets is an array', async () => {
     const mockDatasets = [{name: 'production'}, {name: 'staging'}, {name: 'development'}]
     mockDatasetsList.mockReturnValue(of(mockDatasets))
     const configDatasets = ['custom-dataset-1', 'custom-dataset-2']
     const {result} = renderHook(() => useDatasets({client: mockClient, datasets: configDatasets}))
 
     expect(mockDatasetsList).not.toHaveBeenCalled()
-    expect(result.current).toEqual(configDatasets)
+    await expect(result.current).resolves.toEqual(configDatasets)
   })
 
-  it('should call client.observable.datasets.list() and apply callback function when configDatasets is a function', () => {
+  it('should call client.observable.datasets.list() and apply callback function when configDatasets is a function', async () => {
     const datasetsCallback = (datasets: DatasetsResponse) =>
       datasets.filter((ds) => ds.name !== 'development')
 
@@ -83,10 +97,10 @@ describe('useDatasets', () => {
       }),
     )
     expect(mockDatasetsList).toHaveBeenCalledTimes(1)
-    expect(result.current).toEqual(['production', 'staging'])
+    await expect(result.current).resolves.toEqual(['production', 'staging'])
   })
 
-  it('should handle client error and return Error when configDatasets is undefined', async () => {
+  it('should handle client error and resolve with Error when configDatasets is undefined', async () => {
     const mockError = new Error('Network error')
     mockDatasetsList.mockReturnValue(throwError(() => mockError))
 
@@ -97,9 +111,9 @@ describe('useDatasets', () => {
       }),
     )
     expect(mockDatasetsList).toHaveBeenCalledTimes(1)
-    expect(result.current).toBe(mockError)
+    await expect(result.current).resolves.toBe(mockError)
   })
-  it('should handle client error and return Error even with function config', () => {
+  it('should handle client error and resolve with Error even with function config', async () => {
     const mockError = new Error('Network error')
     const datasetsCallback = (datasets: DatasetsResponse) => datasets
     mockDatasetsList.mockReturnValue(throwError(() => mockError))
@@ -110,6 +124,32 @@ describe('useDatasets', () => {
       }),
     )
     expect(mockDatasetsList).toHaveBeenCalledTimes(1)
-    expect(result.current).toBe(mockError)
+    await expect(result.current).resolves.toBe(mockError)
+  })
+
+  // Documents the base branch's no-tear requirement: `datasets$` is memoized
+  // on `client` and `VisionContainer` stays mounted across project switches,
+  // so the hook must never report the previous client's datasets under the
+  // newly selected client. With promise semantics, a client switch yields a
+  // new promise (new observable identity) that resolves with the new
+  // client's datasets — the stale promise is abandoned.
+  it('resolves with the new client datasets when the client changes (no stale tear)', async () => {
+    const clientA = {
+      observable: {datasets: {list: () => of([{name: 'a-dataset'}] as DatasetsResponse)}},
+    } as unknown as SanityClient
+    const clientB = {
+      observable: {datasets: {list: () => of([{name: 'b-dataset'}] as DatasetsResponse)}},
+    } as unknown as SanityClient
+
+    const {result, rerender} = renderHook(
+      ({client}: {client: SanityClient}) => useDatasets({client, datasets: undefined}),
+      {initialProps: {client: clientA}},
+    )
+    await expect(result.current).resolves.toEqual(['a-dataset'])
+
+    // Switch client in place (VisionContainer stays mounted). The returned
+    // promise must reflect clientB, never the stale clientA datasets.
+    rerender({client: clientB})
+    await expect(result.current).resolves.toEqual(['b-dataset'])
   })
 })

--- a/packages/@sanity/vision/src/hooks/useDatasets.ts
+++ b/packages/@sanity/vision/src/hooks/useDatasets.ts
@@ -1,6 +1,6 @@
 import {type SanityClient} from '@sanity/client'
 import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {type ObservablePromise, useObservablePromise} from 'react-rx'
 import {catchError, map, type Observable, of} from 'rxjs'
 
 import {type VisionConfig} from '../types'
@@ -11,7 +11,7 @@ export function useDatasets({
 }: {
   client: SanityClient
   datasets: VisionConfig['datasets']
-}): string[] | Error | null {
+}): ObservablePromise<string[] | Error> {
   const datasets$: Observable<string[] | Error> = useMemo(() => {
     if (Array.isArray(configDatasets)) {
       return of(configDatasets)
@@ -26,11 +26,6 @@ export function useDatasets({
       catchError((err) => of(err)),
     )
   }, [client, configDatasets])
-  // Deferred: `datasets$` is memoized on `client`, and switching project
-  // triggers a full reload, so the client never swaps while this component
-  // stays mounted. react-rx v5's built-in deferral is also identity-coherent,
-  // so even a client swap would fall back to the new observable's live value.
-  const datasets = useObservable(datasets$, null)
 
-  return datasets
+  return useObservablePromise(datasets$)
 }

--- a/packages/sanity/src/core/form/utils/WithReferencedAsset.tsx
+++ b/packages/sanity/src/core/form/utils/WithReferencedAsset.tsx
@@ -1,7 +1,7 @@
 import {type Reference} from '@sanity/types'
-import {type ReactNode, useMemo} from 'react'
-import {useSyncObservable} from 'react-rx'
-import {type Observable} from 'rxjs'
+import {type ReactNode, Suspense, use, useMemo} from 'react'
+import {type ObservablePromise, useObservablePromise} from 'react-rx'
+import {NEVER, type Observable} from 'rxjs'
 
 interface Props<AssetDoc> {
   reference: Reference
@@ -10,13 +10,41 @@ interface Props<AssetDoc> {
   waitPlaceholder?: ReactNode
 }
 
+function ReferencedAsset<Asset>(props: {
+  promise: ObservablePromise<Asset>
+  children: (assetDocument: Asset) => ReactNode
+  waitPlaceholder?: ReactNode
+}) {
+  const asset = use(props.promise)
+  // observeAsset implementations built on observePaths emit null while the
+  // referenced document is missing or not yet indexed. Keep the placeholder
+  // up for falsy emissions (matching the pre-Suspense behavior) — a later
+  // emission with the real asset swaps the content in.
+  return <>{asset ? props.children(asset) : props.waitPlaceholder}</>
+}
+
 export function WithReferencedAsset<Asset>(props: Props<Asset>) {
   const {reference, children, observeAsset, waitPlaceholder} = props
   const documentId = reference?._ref
-  const observable = useMemo(() => observeAsset(documentId), [documentId, observeAsset])
-  // Kept synchronous: the render gates on the live `documentId`, so a deferred
-  // snapshot could hand `children` the previous asset after the reference
-  // changes to a new document.
-  const asset = useSyncObservable(observable)
-  return <>{documentId && asset ? children(asset) : waitPlaceholder}</>
+  // Never invoke `observeAsset` without an id: some implementations parse the
+  // id synchronously at call time and would throw during render.
+  const observable = useMemo(
+    () => (documentId ? observeAsset(documentId) : NEVER),
+    [documentId, observeAsset],
+  )
+  // The promise is keyed to the observable identity (and thereby `documentId`),
+  // so when the reference changes `children` never receives the previous
+  // document's asset — the boundary suspends into `waitPlaceholder` until the
+  // new asset arrives.
+  const promise = useObservablePromise(observable, {disabled: !documentId})
+  if (!documentId) {
+    return <>{waitPlaceholder}</>
+  }
+  return (
+    <Suspense fallback={waitPlaceholder}>
+      <ReferencedAsset promise={promise} waitPlaceholder={waitPlaceholder}>
+        {children}
+      </ReferencedAsset>
+    </Suspense>
+  )
 }

--- a/packages/sanity/src/core/form/utils/__tests__/WithReferencedAsset.test.tsx
+++ b/packages/sanity/src/core/form/utils/__tests__/WithReferencedAsset.test.tsx
@@ -1,0 +1,145 @@
+import {type Reference} from '@sanity/types'
+import {act, render, screen} from '@testing-library/react'
+import {type ReactNode} from 'react'
+import {of, Subject} from 'rxjs'
+import {describe, expect, it, vi} from 'vitest'
+
+import {WithReferencedAsset} from '../WithReferencedAsset'
+
+interface AssetStub {
+  title: string
+}
+
+const reference = {_type: 'reference', _ref: 'image-abc'} as const
+
+/**
+ * Suspense recovery requires the initial render to happen inside an awaited
+ * `act` — otherwise React never attaches the promise ping and the boundary
+ * stays stuck on the fallback (same pattern as the react-rx test suite).
+ */
+async function renderAsync(ui: ReactNode) {
+  let result!: ReturnType<typeof render>
+  // oxlint-disable-next-line testing-library/no-unnecessary-act
+  await act(async () => {
+    result = render(ui)
+  })
+  return result
+}
+
+describe('WithReferencedAsset', () => {
+  it('renders children immediately when the asset observable emits synchronously', async () => {
+    await renderAsync(
+      <WithReferencedAsset
+        reference={reference}
+        observeAsset={() => of<AssetStub>({title: 'cat.png'})}
+        waitPlaceholder={<div data-testid="placeholder" />}
+      >
+        {(asset) => <div data-testid="asset">{asset.title}</div>}
+      </WithReferencedAsset>,
+    )
+
+    expect(screen.getByTestId('asset').textContent).toBe('cat.png')
+    expect(screen.queryByTestId('placeholder')).toBeNull()
+  })
+
+  it('renders the wait placeholder until the asset arrives', async () => {
+    const asset$ = new Subject<AssetStub>()
+
+    await renderAsync(
+      <WithReferencedAsset
+        reference={reference}
+        observeAsset={() => asset$}
+        waitPlaceholder={<div data-testid="placeholder" />}
+      >
+        {(asset) => <div data-testid="asset">{asset.title}</div>}
+      </WithReferencedAsset>,
+    )
+
+    expect(screen.getByTestId('placeholder')).toBeTruthy()
+    expect(screen.queryByTestId('asset')).toBeNull()
+
+    await act(async () => {
+      asset$.next({title: 'dog.png'})
+    })
+
+    expect(await screen.findByTestId('asset')).toHaveTextContent('dog.png')
+    expect(screen.queryByTestId('placeholder')).toBeNull()
+  })
+
+  it('updates children on later emissions without going back to the placeholder', async () => {
+    const asset$ = new Subject<AssetStub>()
+
+    await renderAsync(
+      <WithReferencedAsset
+        reference={reference}
+        observeAsset={() => asset$}
+        waitPlaceholder={<div data-testid="placeholder" />}
+      >
+        {(asset) => <div data-testid="asset">{asset.title}</div>}
+      </WithReferencedAsset>,
+    )
+
+    await act(async () => {
+      asset$.next({title: 'v1.png'})
+    })
+    expect(await screen.findByTestId('asset')).toHaveTextContent('v1.png')
+
+    await act(async () => {
+      asset$.next({title: 'v2.png'})
+    })
+    expect(await screen.findByTestId('asset')).toHaveTextContent('v2.png')
+    expect(screen.queryByTestId('placeholder')).toBeNull()
+  })
+
+  it('keeps the wait placeholder when the asset emission is null (missing document)', async () => {
+    const asset$ = new Subject<AssetStub | null>()
+
+    await renderAsync(
+      <WithReferencedAsset
+        reference={reference}
+        observeAsset={() => asset$}
+        waitPlaceholder={<div data-testid="placeholder" />}
+      >
+        {(asset) => <div data-testid="asset">{asset?.title}</div>}
+      </WithReferencedAsset>,
+    )
+
+    // observePaths-based sources emit null while the referenced document is
+    // missing or not yet indexed — the placeholder must stay up instead of
+    // handing null to children.
+    await act(async () => {
+      asset$.next(null)
+    })
+    expect(screen.getByTestId('placeholder')).toBeTruthy()
+    expect(screen.queryByTestId('asset')).toBeNull()
+
+    await act(async () => {
+      asset$.next({title: 'late.png'})
+    })
+    expect(await screen.findByTestId('asset')).toHaveTextContent('late.png')
+    expect(screen.queryByTestId('placeholder')).toBeNull()
+  })
+
+  it('renders the wait placeholder and never calls observeAsset when the reference has no _ref', async () => {
+    const asset$ = new Subject<AssetStub>()
+    // Implementations like observeVideoAsset parse the id synchronously at
+    // call time, so calling observeAsset without an id could throw in render.
+    const observeAsset = vi.fn(() => asset$)
+
+    await renderAsync(
+      <WithReferencedAsset
+        // Defensive: some callers pass incomplete reference values while an
+        // upload is still in flight.
+        reference={{_type: 'reference'} as Reference}
+        observeAsset={observeAsset}
+        waitPlaceholder={<div data-testid="placeholder" />}
+      >
+        {(asset: AssetStub) => <div data-testid="asset">{asset.title}</div>}
+      </WithReferencedAsset>,
+    )
+
+    expect(screen.getByTestId('placeholder')).toBeTruthy()
+    expect(screen.queryByTestId('asset')).toBeNull()
+    expect(observeAsset).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
+++ b/packages/sanity/src/core/studio/screens/RequestAccessScreen.tsx
@@ -1,11 +1,13 @@
 /* oxlint-disable i18next/no-literal-string,@sanity/i18n/no-attribute-string-literals */
+import {type SanityClient} from '@sanity/client'
+import {type CurrentUser} from '@sanity/types'
 import {Box, Card, Flex, Stack, Text, TextInput, useToast} from '@sanity/ui'
 import {addWeeks} from 'date-fns/addWeeks'
 import {isAfter} from 'date-fns/isAfter'
 import {isBefore} from 'date-fns/isBefore'
-import {useCallback, useMemo, useState} from 'react'
-import {useObservable, useSyncObservable} from 'react-rx'
-import {catchError, map, of, startWith} from 'rxjs'
+import {Suspense, use, useCallback, useMemo, useState} from 'react'
+import {type ObservablePromise, useObservablePromise, useSyncObservable} from 'react-rx'
+import {catchError, map, NEVER, of} from 'rxjs'
 
 import {Button} from '../../../ui-components/button/Button'
 import {Dialog} from '../../../ui-components/dialog/Dialog'
@@ -32,7 +34,6 @@ export interface AccessRequest {
 const MAX_NOTE_LENGTH = 150
 
 type AccessRequestStatus = {
-  loading: boolean
   hasBeenDenied: boolean
   hasPendingRequest: boolean
   hasExpiredPendingRequest: boolean
@@ -40,18 +41,10 @@ type AccessRequestStatus = {
   error: boolean
 }
 
-const INITIAL_ACCESS_REQUEST_STATUS: AccessRequestStatus = {
-  loading: true,
-  hasBeenDenied: false,
-  hasPendingRequest: false,
-  hasExpiredPendingRequest: false,
-  error: false,
-}
-
 function deriveAccessRequestStatus(
   requests: AccessRequest[] | null,
   projectId: string,
-): Omit<AccessRequestStatus, 'loading' | 'error'> {
+): Omit<AccessRequestStatus, 'error'> {
   if (!requests || !requests.length) {
     return {
       hasBeenDenied: false,
@@ -106,16 +99,6 @@ function deriveAccessRequestStatus(
 }
 
 export function RequestAccessScreen() {
-  const toast = useToast()
-
-  // Set by submitting the form; the observable below only reports what the API already knows.
-  const [msgError, setMsgError] = useState<string | undefined>()
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [submittedRequest, setSubmittedRequest] = useState(false)
-  const [hasTooManyRequests, setHasTooManyRequests] = useState(false)
-  const [submitDenied, setSubmitDenied] = useState(false)
-  const [note, setNote] = useState<string | undefined>()
-
   const {activeWorkspace} = useActiveWorkspace()
 
   const handleLogout = useCallback(() => {
@@ -133,7 +116,10 @@ export function RequestAccessScreen() {
 
   const accessRequests$ = useMemo(() => {
     if (!client || !projectId) {
-      return of(INITIAL_ACCESS_REQUEST_STATUS)
+      // Auth has not emitted yet. NEVER is only a safe placeholder observable:
+      // the hook below is disabled in this state, and the loading UI comes
+      // from the early `<LoadingBlock />` return before the Suspense boundary.
+      return NEVER
     }
 
     return client.observable
@@ -144,7 +130,6 @@ export function RequestAccessScreen() {
       .pipe(
         map(
           (requests): AccessRequestStatus => ({
-            loading: false,
             error: false,
             ...deriveAccessRequestStatus(requests, projectId),
           }),
@@ -154,29 +139,66 @@ export function RequestAccessScreen() {
         catchError((err) => {
           console.error(err)
           return of<AccessRequestStatus>({
-            ...INITIAL_ACCESS_REQUEST_STATUS,
-            loading: false,
+            hasBeenDenied: false,
+            hasPendingRequest: false,
+            hasExpiredPendingRequest: false,
             error: true,
           })
         }),
-        startWith(INITIAL_ACCESS_REQUEST_STATUS),
       )
   }, [client, projectId])
 
-  const {loading, error, hasExpiredPendingRequest, ...fetched} = useObservable(
-    accessRequests$,
-    INITIAL_ACCESS_REQUEST_STATUS,
+  const accessRequestsPromise = useObservablePromise(accessRequests$, {
+    // Nothing to fetch on behalf of this component until auth has emitted.
+    disabled: !client || !projectId,
+  })
+
+  if (!client || !projectId) return <LoadingBlock />
+
+  return (
+    <Suspense fallback={<LoadingBlock />}>
+      <RequestAccessScreenContent
+        accessRequestsPromise={accessRequestsPromise}
+        client={client}
+        projectId={projectId}
+        currentUser={currentUser ?? null}
+        onLogout={handleLogout}
+      />
+    </Suspense>
   )
+}
+
+function RequestAccessScreenContent({
+  accessRequestsPromise,
+  client,
+  projectId,
+  currentUser,
+  onLogout,
+}: {
+  accessRequestsPromise: ObservablePromise<AccessRequestStatus>
+  client: SanityClient
+  projectId: string
+  currentUser: CurrentUser | null
+  onLogout: () => void
+}) {
+  const {error, hasExpiredPendingRequest, ...fetched} = use(accessRequestsPromise)
+
+  const toast = useToast()
+
+  // Set by submitting the form; the resolved access request status only
+  // reports what the API already knew when this screen loaded.
+  const [msgError, setMsgError] = useState<string | undefined>()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [submittedRequest, setSubmittedRequest] = useState(false)
+  const [hasTooManyRequests, setHasTooManyRequests] = useState(false)
+  const [submitDenied, setSubmitDenied] = useState(false)
+  const [note, setNote] = useState<string | undefined>()
 
   const hasPendingRequest = fetched.hasPendingRequest || submittedRequest
   const hasBeenDenied = fetched.hasBeenDenied || submitDenied
   const noteLength = note?.length ?? 0
 
   const handleSubmitRequest = useCallback(() => {
-    // If we haven't loaded the client or projectId from
-    // current workspace, return early
-    if (!client || !projectId) return
-
     setIsSubmitting(true)
 
     client
@@ -215,7 +237,6 @@ export function RequestAccessScreen() {
   const providerTitle = getProviderTitle(currentUser?.provider)
   const providerHelp = providerTitle ? ` through ${providerTitle}` : ''
 
-  if (loading) return <LoadingBlock />
   // Fallback to the old not authorized screen
   // if error communicating with Access API
   if (error) return <NotAuthenticatedScreen />
@@ -288,13 +309,7 @@ export function RequestAccessScreen() {
             )}
           </Stack>
           <Flex align={'center'} justify={'space-between'} paddingTop={4}>
-            <Button
-              mode="bleed"
-              text={'Sign out'}
-              tone="default"
-              onClick={handleLogout}
-              size="large"
-            />
+            <Button mode="bleed" text={'Sign out'} tone="default" onClick={onLogout} size="large" />
             {!hasTooManyRequests && !hasBeenDenied && (
               <Button
                 mode="default"

--- a/packages/sanity/src/core/studio/screens/__tests__/RequestAccessScreen.test.tsx
+++ b/packages/sanity/src/core/studio/screens/__tests__/RequestAccessScreen.test.tsx
@@ -1,0 +1,128 @@
+import {ThemeProvider, ToastProvider} from '@sanity/ui'
+import {buildTheme} from '@sanity/ui/theme'
+import {act, render, screen} from '@testing-library/react'
+import {type ReactNode} from 'react'
+import {Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {type AccessRequest, RequestAccessScreen} from '../RequestAccessScreen'
+
+vi.mock('../../activeWorkspaceMatcher/useActiveWorkspace', () => ({
+  useActiveWorkspace: vi.fn(),
+}))
+
+// Leaf chrome that pulls in i18n — irrelevant to the behavior under test.
+vi.mock('../../../../ui-components/button/Button', () => ({
+  Button: (props: {text?: string; onClick?: () => void}) => (
+    <button type="button" onClick={props.onClick}>
+      {props.text}
+    </button>
+  ),
+}))
+vi.mock('../../../../ui-components/dialog/Dialog', () => ({
+  Dialog: (props: {children?: ReactNode}) => <div data-testid="dialog">{props.children}</div>,
+}))
+vi.mock('../../../components/loadingBlock/LoadingBlock', () => ({
+  LoadingBlock: () => <div data-testid="loading-block" />,
+}))
+
+interface AuthStateStub {
+  currentUser: {name: string; email: string; provider?: string}
+  client: unknown
+}
+
+function makeClient(projectId: string, requests$: Subject<AccessRequest[] | null>) {
+  const client: Record<string, unknown> = {
+    config: () => ({projectId}),
+    observable: {request: () => requests$},
+    request: vi.fn(() => Promise.resolve(null)),
+  }
+  client.withConfig = () => client
+  return client
+}
+
+/**
+ * Suspense recovery requires the initial render to happen inside an awaited
+ * `act`, otherwise React never attaches the promise ping and the boundary
+ * stays stuck on the fallback.
+ */
+const theme = buildTheme()
+
+async function renderAsync(ui: ReactNode) {
+  let result!: ReturnType<typeof render>
+  // oxlint-disable-next-line testing-library/no-unnecessary-act
+  await act(async () => {
+    result = render(
+      <ThemeProvider theme={theme}>
+        <ToastProvider>{ui}</ToastProvider>
+      </ThemeProvider>,
+    )
+  })
+  return result
+}
+
+describe('RequestAccessScreen', () => {
+  let authState$: Subject<AuthStateStub>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    authState$ = new Subject<AuthStateStub>()
+    const {useActiveWorkspace} = await import('../../activeWorkspaceMatcher/useActiveWorkspace')
+    ;(useActiveWorkspace as ReturnType<typeof vi.fn>).mockReturnValue({
+      activeWorkspace: {auth: {state: authState$, logout: vi.fn()}},
+    })
+  })
+
+  it('keeps in-progress form state when auth re-emits a new client (re-suspension)', async () => {
+    const currentUser = {name: 'Test User', email: 'test@example.com'}
+    const requestsA$ = new Subject<AccessRequest[] | null>()
+    const requestsB$ = new Subject<AccessRequest[] | null>()
+    const clientA = makeClient('projectA', requestsA$)
+    const clientB = makeClient('projectA', requestsB$)
+
+    await renderAsync(<RequestAccessScreen />)
+
+    // Before auth emits: loading block (early return, no form yet).
+    expect(screen.getByTestId('loading-block')).toBeTruthy()
+
+    await act(async () => {
+      authState$.next({currentUser, client: clientA})
+    })
+    // Access requests still pending: Suspense fallback.
+    expect(screen.getByTestId('loading-block')).toBeTruthy()
+
+    await act(async () => {
+      requestsA$.next([])
+    })
+    const input = (await screen.findByPlaceholderText('Add your note…')) as HTMLInputElement
+
+    // User types a note.
+    await act(async () => {
+      const setValue = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      )!.set!
+      setValue.call(input, 'please let me in')
+      input.dispatchEvent(new Event('input', {bubbles: true}))
+    })
+    expect((screen.getByPlaceholderText('Add your note…') as HTMLInputElement).value).toBe(
+      'please let me in',
+    )
+
+    // Auth re-emits with a NEW client identity: new observable, new promise,
+    // the boundary re-suspends into the fallback...
+    await act(async () => {
+      authState$.next({currentUser, client: clientB})
+    })
+    expect(screen.getByTestId('loading-block')).toBeTruthy()
+
+    // ...and once the new client's access requests resolve, the form returns
+    // with the in-progress note intact (content was hidden, not unmounted).
+    await act(async () => {
+      requestsB$.next([])
+    })
+    expect(((await screen.findByPlaceholderText('Add your note…')) as HTMLInputElement).value).toBe(
+      'please let me in',
+    )
+  })
+})

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/CrossDatasetIncomingReference/CrossDatasetIncomingReferenceType.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/CrossDatasetIncomingReference/CrossDatasetIncomingReferenceType.tsx
@@ -1,6 +1,7 @@
+import {type SchemaType} from '@sanity/types'
 import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
-import {useCallback, useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {Suspense, use, useCallback, useMemo} from 'react'
+import {type ObservablePromise, useObservablePromise} from 'react-rx'
 import {
   CommandList,
   type CommandListRenderItemCallback,
@@ -13,7 +14,6 @@ import {
 } from 'sanity'
 
 import {structureLocaleNamespace} from '../../../i18n'
-import {INITIAL_STATE} from '../getIncomingReferences'
 import {INCOMING_REFERENCES_ITEM_HEIGHT, IncomingReferencesListContainer} from '../shared'
 import {type CrossDatasetIncomingReference} from '../types'
 import {CrossDatasetIncomingReferenceDocumentPreview} from './CrossDatasetIncomingReferenceDocumentPreview'
@@ -45,11 +45,43 @@ export function CrossDatasetIncomingReferenceType({
     [client, type, referenced.id, documentPreviewStore],
   )
 
-  const {documents, loading} = useObservable(references$, INITIAL_STATE)
+  const referencesPromise = useObservablePromise(references$)
 
   const schema = useSchema()
   const {t} = useTranslation(structureLocaleNamespace)
   const schemaType = schema.get(type.type)
+
+  if (!schemaType) return null
+  return (
+    <Suspense
+      fallback={
+        <LoadingBlock showText title={t('incoming-references-input.types-loading-cross-dataset')} />
+      }
+    >
+      <CrossDatasetIncomingReferenceTypeList
+        referencesPromise={referencesPromise}
+        schemaType={schemaType}
+        shouldRenderTitle={shouldRenderTitle}
+        type={type}
+      />
+    </Suspense>
+  )
+}
+
+function CrossDatasetIncomingReferenceTypeList({
+  type,
+  shouldRenderTitle,
+  referencesPromise,
+  schemaType,
+}: {
+  shouldRenderTitle: boolean
+  type: CrossDatasetIncomingReference
+  referencesPromise: ObservablePromise<CrossDatasetIncomingReferenceDocument[]>
+  schemaType: SchemaType
+}) {
+  const documents = use(referencesPromise)
+
+  const {t} = useTranslation(structureLocaleNamespace)
 
   const renderItem = useCallback<
     CommandListRenderItemCallback<CrossDatasetIncomingReferenceDocument>
@@ -58,10 +90,6 @@ export function CrossDatasetIncomingReferenceType({
     [type],
   )
 
-  if (!schemaType) return null
-  if (loading) {
-    return <LoadingBlock showText title={t('incoming-references-input.types-loading')} />
-  }
   return (
     <Stack gap={2} marginBottom={2}>
       {shouldRenderTitle && (

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/CrossDatasetIncomingReference/getCrossDatasetIncomingReferences.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/CrossDatasetIncomingReference/getCrossDatasetIncomingReferences.tsx
@@ -1,6 +1,6 @@
 import {DocumentIcon} from '@sanity/icons/Document'
 import {type PreviewValue} from '@sanity/types'
-import {catchError, map, type Observable, of, startWith, switchMap} from 'rxjs'
+import {catchError, map, type Observable, of, switchMap} from 'rxjs'
 import {mergeMapArray} from 'rxjs-mergemap-array'
 import {
   type DocumentAvailability,
@@ -14,11 +14,6 @@ import {
 
 import {fetchCrossDatasetReferences} from '../../confirmDeleteDialog/useReferringDocuments'
 import {type CrossDatasetIncomingReference} from '../types'
-
-const INITIAL_STATE = {
-  documents: [],
-  loading: true,
-}
 
 interface InputIncomingReferencesOptions {
   documentId: string
@@ -49,22 +44,27 @@ export interface CrossDatasetIncomingReferenceDocument {
   projectId: string
   dataset: string
 }
+/**
+ * Emits the cross-dataset documents referencing `documentId`. The observable
+ * does not emit until the first list has loaded — consumers read it through
+ * `useObservablePromise`, so the pending window renders as a Suspense fallback.
+ */
 export function getCrossDatasetIncomingReferences({
   documentId,
   type,
   client,
   documentPreviewStore,
-}: InputIncomingReferencesOptions | InspectorIncomingReferencesOptions): Observable<{
-  documents: CrossDatasetIncomingReferenceDocument[]
-  loading: boolean
-}> {
+}: InputIncomingReferencesOptions | InspectorIncomingReferencesOptions): Observable<
+  CrossDatasetIncomingReferenceDocument[]
+> {
   // Here we get all the references to this document from the any other dataset.
   // `fetchCrossDatasetReferences` is poll-driven (it re-emits on visibility
   // changes), so we run the per-emission pipeline inside a `switchMap` and catch
   // there. That way a transient failure of a single poll degrades to an empty
   // list without completing the outer observable, allowing a later poll tick to
-  // recover. Consumers render this via `useObservable`, which rethrows stream
-  // errors during render and would crash the document pane.
+  // recover. Consumers read this via `useObservablePromise`, so an uncaught
+  // error would reject the promise and crash the document pane at the nearest
+  // error boundary.
   return fetchCrossDatasetReferences(documentId, {versionedClient: client}).pipe(
     switchMap((referencesResult) =>
       of(referencesResult).pipe(
@@ -146,17 +146,16 @@ export function getCrossDatasetIncomingReferences({
               }),
             )
         }),
-        map((documents) => ({documents: documents.filter(isNonNullable), loading: false})),
+        map((documents) => documents.filter(isNonNullable)),
         // Cross-dataset queries are failure-prone (token / dataset permission
         // errors). Degrade this poll tick to an empty list instead of erroring;
         // catching inside the `switchMap` keeps the outer stream alive so a
         // later poll can recover.
         catchError((err) => {
           console.error(new Error('Failed to load cross-dataset incoming references', {cause: err}))
-          return of({documents: [], loading: false})
+          return of<CrossDatasetIncomingReferenceDocument[]>([])
         }),
       ),
     ),
-    startWith(INITIAL_STATE),
   )
 }

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx
@@ -1,8 +1,8 @@
 import {AddIcon} from '@sanity/icons/Add'
-import {type SanityDocument} from '@sanity/types'
+import {type SanityDocument, type SchemaType} from '@sanity/types'
 import {Box, Card, Flex, Stack, Text, useToast} from '@sanity/ui'
-import {useCallback, useEffect, useMemo, useState} from 'react'
-import {useObservable} from 'react-rx'
+import {Suspense, use, useCallback, useEffect, useMemo, useState} from 'react'
+import {type ObservablePromise, useObservablePromise} from 'react-rx'
 import {
   CommandList,
   type CommandListRenderItemCallback,
@@ -24,7 +24,7 @@ import {structureLocaleNamespace} from '../../i18n'
 import {useDocumentPane} from '../../panes/document/useDocumentPane'
 import {AddIncomingReference} from './AddIncomingReference'
 import {CreateNewIncomingReference} from './CreateNewIncomingReference'
-import {getIncomingReferences, INITIAL_STATE} from './getIncomingReferences'
+import {getIncomingReferences} from './getIncomingReferences'
 import {IncomingReferenceDocument} from './IncomingReferenceDocument'
 import {INCOMING_REFERENCES_ITEM_HEIGHT, IncomingReferencesListContainer} from './shared'
 import {type IncomingReferencesOptions, type IncomingReferenceType} from './types'
@@ -82,11 +82,56 @@ export function IncomingReferencesType({
     [documentPreviewStore, type.type, memoizedFilter, memoizedFilterParams, displayedId, getClient],
   )
 
-  const {documents, loading} = useObservable(references$, INITIAL_STATE)
+  const referencesPromise = useObservablePromise(references$)
 
   const schema = useSchema()
   const {t} = useTranslation(structureLocaleNamespace)
   const schemaType = schema.get(type.type)
+
+  if (!schemaType) return null
+  return (
+    <Suspense
+      fallback={<LoadingBlock showText title={t('incoming-references-input.types-loading')} />}
+    >
+      <IncomingReferencesTypeList
+        actions={actions}
+        creationAllowed={creationAllowed}
+        fieldName={fieldName}
+        onLinkDocument={onLinkDocument}
+        referenced={referenced}
+        referencesPromise={referencesPromise}
+        schemaType={schemaType}
+        shouldRenderTitle={shouldRenderTitle}
+        type={type}
+      />
+    </Suspense>
+  )
+}
+
+function IncomingReferencesTypeList({
+  type,
+  referenced,
+  onLinkDocument,
+  actions,
+  shouldRenderTitle,
+  fieldName,
+  creationAllowed,
+  referencesPromise,
+  schemaType,
+}: {
+  shouldRenderTitle: boolean
+  referenced: {id: string; type: string}
+  fieldName: string
+  type: IncomingReferenceType
+  onLinkDocument: IncomingReferencesOptions['onLinkDocument']
+  actions: IncomingReferencesOptions['actions']
+  creationAllowed: IncomingReferencesOptions['creationAllowed']
+  referencesPromise: ObservablePromise<SanityDocument[]>
+  schemaType: SchemaType
+}) {
+  const documents = use(referencesPromise)
+
+  const {t} = useTranslation(structureLocaleNamespace)
   const client = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const [isAdding, setIsAdding] = useState(false)
   const [newReferenceId, setNewReferenceId] = useState<string | null>(null)
@@ -173,10 +218,6 @@ export function IncomingReferencesType({
     [referenced.id, actions],
   )
 
-  if (!schemaType) return null
-  if (loading) {
-    return <LoadingBlock showText title={t('incoming-references-input.types-loading')} />
-  }
   return (
     <Stack gap={2} marginBottom={2}>
       {shouldRenderTitle && (

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/getIncomingReferences.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/getIncomingReferences.tsx
@@ -1,13 +1,4 @@
-import {
-  catchError,
-  distinctUntilChanged,
-  filter,
-  map,
-  type Observable,
-  of,
-  startWith,
-  switchMap,
-} from 'rxjs'
+import {catchError, distinctUntilChanged, filter, map, type Observable, of, switchMap} from 'rxjs'
 import {mergeMapArray} from 'rxjs-mergemap-array'
 import {
   type DocumentPreviewStore,
@@ -17,11 +8,6 @@ import {
 } from 'sanity'
 
 import {type IncomingReferencesFilterResolver, type IncomingReferencesOptions} from './types'
-
-export const INITIAL_STATE = {
-  documents: [],
-  loading: true,
-}
 
 async function resolveRawFilterCallback(
   filterResolver: IncomingReferencesFilterResolver,
@@ -55,6 +41,11 @@ interface InspectorIncomingReferencesOptions {
   filterParams?: undefined
 }
 
+/**
+ * Emits the documents referencing `documentId`. The observable does not emit
+ * until the first list has loaded — consumers read it through
+ * `useObservablePromise`, so the pending window renders as a Suspense fallback.
+ */
 export function getIncomingReferences({
   documentId,
   documentPreviewStore,
@@ -62,10 +53,9 @@ export function getIncomingReferences({
   filter: filterQueryRaw,
   filterParams: filterParamsRaw,
   getClient,
-}: InspectorIncomingReferencesOptions | InputIncomingReferencesOptions): Observable<{
-  documents: SanityDocument[]
-  loading: boolean
-}> {
+}: InspectorIncomingReferencesOptions | InputIncomingReferencesOptions): Observable<
+  SanityDocument[]
+> {
   const publishedId = getPublishedId(documentId)
   const filterResolver: Observable<{
     filter: string | undefined
@@ -117,18 +107,16 @@ export function getIncomingReferences({
               return true
             })
           }),
-
-          map((documents) => ({documents, loading: false})),
-          startWith(INITIAL_STATE),
           // Catch inside the `switchMap` so a failure of this inner stream
           // degrades to an empty list without completing the outer observable.
-          // Consumers render this via `useObservable`, which rethrows stream
-          // errors during render and would crash the document pane. Keeping the
-          // outer stream alive means a later `filterResolver` emission can
-          // re-subscribe and recover from a transient error.
+          // Consumers read this via `useObservablePromise`, so an uncaught
+          // error would reject the promise and crash the document pane at the
+          // nearest error boundary. Keeping the outer stream alive means a
+          // later `filterResolver` emission can re-subscribe and recover from
+          // a transient error.
           catchError((err) => {
             console.error(new Error('Failed to load incoming references', {cause: err}))
-            return of({documents: [], loading: false})
+            return of<SanityDocument[]>([])
           }),
         )
     }),

--- a/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/IncomingReferencesList.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/IncomingReferencesList.tsx
@@ -1,7 +1,7 @@
 import {type SanityDocument} from '@sanity/types'
 import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
-import {useCallback, useMemo} from 'react'
-import {useObservable} from 'react-rx'
+import {Suspense, use, useCallback, useMemo} from 'react'
+import {type ObservablePromise, useObservablePromise} from 'react-rx'
 import {map} from 'rxjs'
 import {
   CommandList,
@@ -91,6 +91,19 @@ function TypeSection<T>({
   )
 }
 
+function groupByType<Doc>(documents: Doc[], getType: (doc: Doc) => string) {
+  // Group with a Map rather than a plain object: type names are user-defined,
+  // so keys like "__proto__" must not collide with object prototype members.
+  const documentsByType = new Map<string, Doc[]>()
+  for (const doc of documents) {
+    const type = getType(doc)
+    const group = documentsByType.get(type)
+    if (group) group.push(doc)
+    else documentsByType.set(type, [doc])
+  }
+  return Array.from(documentsByType, ([type, docs]) => ({type, documents: docs}))
+}
+
 export function IncomingReferencesList() {
   const {documentId} = useDocumentPaneInfo()
   const {t} = useTranslation(structureLocaleNamespace)
@@ -105,54 +118,50 @@ export function IncomingReferencesList() {
         documentId,
         documentPreviewStore,
         getClient,
-      }).pipe(
-        map(({documents, loading}) => {
-          const documentsByType = documents.reduce(
-            (acc, doc) => {
-              const type = doc._type
-              // If the type exists add the document to it.
-              if (acc[type]) acc[type].push(doc)
-              // else, create the type with the document.
-              else acc[type] = [doc]
-              return acc
-            },
-            {} as Record<string, SanityDocument[]>,
-          )
-          return {
-            list: Object.entries(documentsByType).map(([type, docs]) => ({type, documents: docs})),
-            loading,
-          }
-        }),
-      ),
+      }).pipe(map((documents) => groupByType(documents, (doc) => doc._type))),
     [documentId, documentPreviewStore, getClient],
   )
-  const references = useObservable(references$, null)
+  const referencesPromise = useObservablePromise(references$)
 
   const crossDatasetIncomingRefs$ = useMemo(
     () =>
       getCrossDatasetIncomingReferences({documentId, client, documentPreviewStore}).pipe(
-        map(({documents, loading}) => {
-          const documentsByType = documents.reduce(
-            (acc, doc) => {
-              const type = doc.type
-              // If the type exists add the document to it.
-              if (acc[type]) acc[type].push(doc)
-              // else, create the type with the document.
-              else acc[type] = [doc]
-              return acc
-            },
-            {} as Record<string, CrossDatasetIncomingReferenceDocument[]>,
-          )
-          return {
-            list: Object.entries(documentsByType).map(([type, docs]) => ({type, documents: docs})),
-            loading,
-          }
-        }),
+        map((documents) => groupByType(documents, (doc) => doc.type)),
       ),
     [client, documentId, documentPreviewStore],
   )
+  const crossDatasetRefsPromise = useObservablePromise(crossDatasetIncomingRefs$)
 
-  const crossDatasetRefs = useObservable(crossDatasetIncomingRefs$, null)
+  return (
+    <Suspense
+      fallback={<LoadingBlock showText title={t('incoming-references-input.types-loading')} />}
+    >
+      <LoadedIncomingReferencesList
+        crossDatasetRefsPromise={crossDatasetRefsPromise}
+        documentId={documentId}
+        referencesPromise={referencesPromise}
+      />
+    </Suspense>
+  )
+}
+
+function LoadedIncomingReferencesList({
+  documentId,
+  referencesPromise,
+  crossDatasetRefsPromise,
+}: {
+  documentId: string
+  referencesPromise: ObservablePromise<Array<{type: string; documents: SanityDocument[]}>>
+  crossDatasetRefsPromise: ObservablePromise<
+    Array<{type: string; documents: CrossDatasetIncomingReferenceDocument[]}>
+  >
+}) {
+  // Both requests run in parallel — they start when the parent creates the
+  // promises, and this component waits for the slower of the two.
+  const references = use(referencesPromise)
+  const crossDatasetRefs = use(crossDatasetRefsPromise)
+
+  const {t} = useTranslation(structureLocaleNamespace)
 
   const renderSameDatasetItem = useCallback<CommandListRenderItemCallback<SanityDocument>>(
     (document) => <IncomingReferenceDocument document={document} referenceToId={documentId} />,
@@ -165,11 +174,7 @@ export function IncomingReferencesList() {
 
   const emptyMessage = t('incoming-references-pane.no-references-found')
 
-  const showEmptyState =
-    !references?.loading &&
-    references?.list.length === 0 &&
-    !crossDatasetRefs?.loading &&
-    crossDatasetRefs?.list.length === 0
+  const showEmptyState = references.length === 0 && crossDatasetRefs.length === 0
 
   return (
     <>
@@ -182,34 +187,26 @@ export function IncomingReferencesList() {
           </Box>
         </Card>
       )}
-      {references?.loading ? (
-        <LoadingBlock showText title={t('incoming-references-input.types-loading')} />
-      ) : (
-        references?.list.map(({type, documents}) => (
-          <TypeSection
-            key={type}
-            type={type}
-            documents={documents}
-            renderItem={renderSameDatasetItem}
-            getItemKey={(index) => documents[index]._id}
-            emptyMessage={emptyMessage}
-          />
-        ))
-      )}
-      {crossDatasetRefs?.loading ? (
-        <LoadingBlock showText title={t('incoming-references-input.types-loading-cross-dataset')} />
-      ) : (
-        crossDatasetRefs?.list.map(({type, documents}) => (
-          <TypeSection
-            key={type}
-            type={type}
-            documents={documents}
-            renderItem={renderCrossDatasetItem}
-            getItemKey={(index) => documents[index].id}
-            emptyMessage={emptyMessage}
-          />
-        ))
-      )}
+      {references.map(({type, documents}) => (
+        <TypeSection
+          key={type}
+          type={type}
+          documents={documents}
+          renderItem={renderSameDatasetItem}
+          getItemKey={(index) => documents[index]._id}
+          emptyMessage={emptyMessage}
+        />
+      ))}
+      {crossDatasetRefs.map(({type, documents}) => (
+        <TypeSection
+          key={type}
+          type={type}
+          documents={documents}
+          renderItem={renderCrossDatasetItem}
+          getItemKey={(index) => documents[index].id}
+          emptyMessage={emptyMessage}
+        />
+      ))}
     </>
   )
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

react-rx 5.1 ships `useObservablePromise`, which turns an observable into a `use()`-compatible promise: the component suspends until the first emission, later emissions update in place without re-triggering the fallback, and sync sources never flash a fallback at all. That makes hand-rolled loading plumbing — `startWith({loading: true, ...})` placeholders, `isLoading` flags, null sentinels — unnecessary wherever the loading UI maps 1:1 to a Suspense fallback.

This PR (a single squashed commit) migrates the call sites where that mapping is clean and the wrapper shapes could be deleted outright:

- `WithReferencedAsset` (core form): `waitPlaceholder` sentinel → Suspense fallback; falsy emissions (missing/unindexed asset docs from `observePaths`) still render the placeholder rather than reaching `children`
- `RequestAccessScreen` (core): `loading` flag + `INITIAL_ACCESS_REQUEST_STATUS` + `startWith` → suspends into `LoadingBlock`; Access API failures still resolve to values (`catchError`) so the screen degrades to `NotAuthenticatedScreen`; the auth identity read stays on `useSyncObservable` so submits can't use a stale workspace identity; also fixes the pre-existing bug where a rate-limited (429) submit stacked the generic failure toast on top of the rate-limit message
- Incoming references (structure): `getIncomingReferences` / `getCrossDatasetIncomingReferences` now emit plain document lists instead of `{documents, loading}` wrappers; the three consumers read them with `use()` behind `LoadingBlock` fallbacks (the cross-dataset type list uses the cross-dataset-specific loading string per review); type grouping uses a `Map` so user-defined type names can't collide with object prototype keys
- `useDatasets` / `VisionContainer` (vision): null sentinel → promise; `DelayedSpinner` becomes the fallback
- `AuthorReferenceInput` (test-studio): the textbook `{loading, authors}` state machine → suspending reader, plus a fix for its long-broken props destructuring (`inputProps`/`type` don't exist on `ObjectInputProps`)

Relationship to the base branch (react-rx v5 migration): the base keeps these call sites on the v5 `useObservable`/`useSyncObservable` split (with react-rx 5.1.1's identity-coherent deferral) to keep its own tree consistent — this stacked PR then replaces those call sites with Suspense reads. Vision's direct react-rx dependency is provided by the base branch.

Sites deliberately left alone:

- Preview rows (`getPreviewStateObservable` consumers) render in-place `isPlaceholder` skeletons; Suspense would unmount list rows
- Hooks whose `loading` only gates a button/banner action (`useRoleRequestsStatus`, `useProjectOrganizationId`, `useHasUsedScheduledPublishing`) — suspending would block chrome that renders fine without the data
- Public API hooks (`useReferringDocuments`) — return-shape change would be breaking
- Continuous streams with pagination/retry state (`useEventsStore`, `useDocumentList`, `useLoadImage`/`ImageToolInput`)

### What to review

- **Behavior note (incoming references):** the `startWith(INITIAL_STATE)` sat *inside* the `switchMap`, so a function-filter re-resolution used to flash `LoadingBlock` over the existing list; now the previous list stays visible until the new one arrives (deferred-value semantics). Error degradation to an empty list is unchanged.
- **Behavior note (inspector):** `IncomingReferencesList` previously rendered two stacked `LoadingBlock`s (same-dataset + cross-dataset); it now shows one combined fallback (generic loading string) until both resolve. Both requests still start in parallel — the reader just waits for the slower one. The decoration's cross-dataset type list keeps its distinct `types-loading-cross-dataset` string.
- **Promise identity:** all observables handed to `useObservablePromise` are `useMemo`-stable (the cache is keyed by observable identity), and promises are created in parents that don't suspend, per the react-rx guidance. Identity keying is also what prevents a changed reference from rendering the previous document's asset in `WithReferencedAsset`, and re-suspension hides (not unmounts) committed content, so form state in `RequestAccessScreen` survives auth re-emissions — both pinned by tests.
- Affected packages: `sanity` (core + structure), `@sanity/vision`, `dev/test-studio`.

### Testing

- `WithReferencedAsset.test.tsx`: sync-source rendering without fallback, placeholder-until-first-emission, in-place updates on later emissions, null emissions (missing asset doc) keeping the placeholder, and the missing-`_ref` guard (no `observeAsset` call)
- `RequestAccessScreen.test.tsx`: form state (typed note) survives an auth re-emission that swaps the promise identity and re-suspends the boundary
- `useDatasets.test.ts`: promise resolution semantics — pending-until-emission, error-as-value, and no stale tear when the client switches in place
- Consumer suites that render the refactored components pass (`fileInput`, `assetSourceIntegration`, `videoInput`, `src/structure` subtree); `pnpm build`, `pnpm check:oxlint`, `pnpm check:format`, `pnpm depcheck` pass; the full CI pipeline (unit shards on Node 22/24/26, all e2e shards, browser component tests) has run green repeatedly on this content
- Manually verified in the test studio (video below): Vision loads its dataset list through the new promise and runs queries; the author custom input suspends into a spinner and renders clickable author buttons (select and clear both save); the Incoming references inspector suspends into its loading block and renders grouped reference lists for an author with ~91 incoming references

[demo_suspense_vision_author_input_incoming_references.mp4](https://cursor.com/agents/bc-12c1e3f3-8353-4e85-ac1b-a0b5ac5e7736/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_suspense_vision_author_input_incoming_references.mp4)

### Notes for release

N/A – Internal only

---

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12c1e3f3-8353-4e85-ac1b-a0b5ac5e7736?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12c1e3f3-8353-4e85-ac1b-a0b5ac5e7736&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

