### PR TITLE
chore(core): updates @sanity-labs/ui-poc to 0.0.1-alpha.25

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -147,7 +147,7 @@
     "@portabletext/to-html": "^5.0.2",
     "@portabletext/toolkit": "^5.0.2",
     "@rexxars/react-json-inspector": "^9.0.1",
-    "@sanity-labs/ui-poc": "0.0.1-alpha.22",
+    "@sanity-labs/ui-poc": "0.0.1-alpha.25",
     "@sanity/asset-utils": "^2.3.0",
     "@sanity/bifur-client": "^1.0.0",
     "@sanity/cli": "^7.15.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1656,8 +1656,8 @@ importers:
         specifier: ^9.0.1
         version: 9.0.1(react@19.2.8)
       '@sanity-labs/ui-poc':
-        specifier: 0.0.1-alpha.22
-        version: 0.0.1-alpha.22(react-dom@19.2.8)(react@19.2.8)
+        specifier: 0.0.1-alpha.25
+        version: 0.0.1-alpha.25(react-dom@19.2.8)(react@19.2.8)
       '@sanity/asset-utils':
         specifier: ^2.3.0
         version: 2.3.0
@@ -6093,9 +6093,10 @@ packages:
     resolution: {integrity: sha512-+i7GXix4Akt34VDWgSM1Lpq8Hxf8SH8022uNsDRXSNuAqQMjKVGWLItAyc2TyfWVwWZLhsCF3lj5tdW7cecDxQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
-  '@sanity-labs/ui-poc@0.0.1-alpha.22':
-    resolution: {integrity: sha512-tCqeNli37iywzAJMBItf5psypwi3GHleAwWWr3d2jfByzymlpDwinElYS2sCofsXKEFuCWOIu43YuQgob/EJPA==}
+  '@sanity-labs/ui-poc@0.0.1-alpha.25':
+    resolution: {integrity: sha512-TaH3RSCRmceGCFMIrHBk0erSvmbYZxrlp9gnL5gXn8Yk7StK/M6qI7iB+gBdxmKcfGiwSbw82AbnXYf7KmpzCw==}
     engines: {node: '>=20.19 <22 || >=22.12'}
+    hasBin: true
     peerDependencies:
       react: ^19.2
       react-dom: ^19.2
@@ -8031,6 +8032,9 @@ packages:
   array-ify@1.0.0:
     resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
 
+  array-timsort@1.0.3:
+    resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
+
   array-treeify@0.1.5:
     resolution: {integrity: sha512-Ag85dlQyM0wahhm62ZvsLDLU0TcGNXjonRWpEUvlmmaFBuJNuzoc19Gi51uMs9HXoT2zwSewk6JzxUUw8b412g==}
 
@@ -8522,6 +8526,10 @@ packages:
 
   commander@5.1.0:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
+    engines: {node: '>= 6'}
+
+  comment-json@5.0.0:
+    resolution: {integrity: sha512-uiqLcOiVDJtBP8WGkZHEP+FZIhTzP1dxvn59EfoYUi9gqupjrBWVQkO2atDrbnKPwLeotFYDsuNb26uBMqB+hw==}
     engines: {node: '>= 6'}
 
   commondir@1.0.1:
@@ -17717,11 +17725,12 @@ snapshots:
 
   '@sanity-labs/design-tokens@0.0.2-alpha.4': {}
 
-  '@sanity-labs/ui-poc@0.0.1-alpha.22(react-dom@19.2.8)(react@19.2.8)':
+  '@sanity-labs/ui-poc@0.0.1-alpha.25(react-dom@19.2.8)(react@19.2.8)':
     dependencies:
       '@sanity-labs/design-tokens': 0.0.2-alpha.4
       '@sanity/icons': 3.8.0(react@19.2.8)
       clsx: 2.1.1
+      comment-json: 5.0.0
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       react-refractor: 4.0.0(react@19.2.8)
@@ -20216,6 +20225,8 @@ snapshots:
 
   array-ify@1.0.0: {}
 
+  array-timsort@1.0.3: {}
+
   array-treeify@0.1.5: {}
 
   array-union@2.1.0: {}
@@ -20697,6 +20708,11 @@ snapshots:
   commander@14.0.3: {}
 
   commander@5.1.0: {}
+
+  comment-json@5.0.0:
+    dependencies:
+      array-timsort: 1.0.3
+      esprima: 4.0.1
 
   commondir@1.0.1: {}
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR bumps `@sanity-labs/ui-poc` from `0.0.1-alpha.22` to `0.0.1-alpha.25`.

`0.0.1-alpha.25` includes a fix for the bug reported in [this Slack message](https://sanity-io.slack.com/archives/C047D4PF8E5/p1785439764204649) regarding the `@sanity-labs/ui-poc/styles.css` import causing an error when studio packages are imported into a user's `sanity.cli.ts` file. `@sanity-labs/ui-poc` now includes a node-safe shim which should handle that situaton.

The other changes since `0.0.1-alpha.22` are around exporting types which shouldn't affect anything here.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

The only change is in `package.json`.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Verified that `@sanity-labs/ui-poc` CSS is still loaded into studio.

### Notes for release

N/A: Internal only

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->
---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency-only version bump with no application code changes; risk is limited to UI POC styling/CLI import behavior in edge cases.
> 
> **Overview**
> Bumps **`@sanity-labs/ui-poc`** in `packages/sanity` from **0.0.1-alpha.22** to **0.0.1-alpha.25**, with matching **`pnpm-lock.yaml`** updates (including new transitive deps such as **`comment-json`** on the POC package).
> 
> The upgrade pulls in a **node-safe shim** so importing **`@sanity-labs/ui-poc/styles.css`** (via the main `sanity` entry) no longer breaks when Studio packages are loaded from **`sanity.cli.ts`**. Other alpha.25 changes are mainly type exports and should not alter runtime behavior in this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f63c9d8df1756c98fe89f0acc3ba139ed3f1d2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->