### PR TITLE
ci: name pkg.pr.new pre-flight step for readability

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -22,7 +22,8 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
 
-      - id: pre-flight
+      - name: Resolve packages and PR version
+        id: pre-flight
         run: |
           PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
           # --silent keeps pnpm's own notices (e.g. the deprecated "$" overrides


### PR DESCRIPTION
## Problem

In `.github/workflows/pkg-pr-new.yml`, the `pre-flight` helper `run` step is unnamed and longer than **300 characters**. In the GitHub Actions UI that collapses into a generic label, which hurts readability when package list / PR version resolution fails.

## Changes

Semantics are unchanged: same step `id`, same `GITHUB_OUTPUT` keys, and the same later wiring (`steps.pre-flight.outputs.version` / `packages`).

- Add `name: Resolve packages and PR version` to `id: pre-flight`

## Test plan
- [ ] Confirm build still uses `PKG_VERSION: ${{ steps.pre-flight.outputs.version }}`
- [ ] Confirm publish still uses `steps.pre-flight.outputs.packages`
- [ ] Confirm the step shows the new name in the Actions UI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only display label with no changes to step id, outputs, or publish/build wiring.
> 
> **Overview**
> Adds **`name: Resolve packages and PR version`** to the existing `id: pre-flight` step in `.github/workflows/pkg-pr-new.yml` so the GitHub Actions UI shows a clear label instead of a collapsed generic run block when that step fails.
> 
> **No behavior change:** same `id`, same `packages` / `version` `GITHUB_OUTPUT` keys, and the same downstream use (`PKG_VERSION`, pkg.pr.new publish).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec010dfef2f59eced42e7bde766a1cf68b75ba5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->