### PR TITLE
refactor(comments): resolve notification title via one-shot promise

### DIFF
--- a/packages/sanity/src/core/comments/hooks/__tests__/useNotificationTarget.test.tsx
+++ b/packages/sanity/src/core/comments/hooks/__tests__/useNotificationTarget.test.tsx
@@ -1,0 +1,139 @@
+import {type SchemaType} from '@sanity/types'
+import {renderHook} from '@testing-library/react'
+import {Subject} from 'rxjs'
+import {beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
+
+import {useSchema} from '../../../hooks/useSchema'
+import {type DocumentPreviewStore} from '../../../preview/documentPreviewStore'
+import {useDocumentPreviewStore} from '../../../store/datastores'
+import {useWorkspace} from '../../../studio/workspace'
+import {useNotificationTarget} from '../useNotificationTarget'
+
+vi.mock('../../../hooks/useSchema', () => ({
+  useSchema: vi.fn(),
+}))
+
+vi.mock('../../../studio/workspace', () => ({
+  useWorkspace: vi.fn(),
+}))
+
+vi.mock('../../../store/datastores', () => ({
+  useDocumentPreviewStore: vi.fn(),
+}))
+
+const mockUseSchema = useSchema as Mock<typeof useSchema>
+const mockUseWorkspace = useWorkspace as Mock<typeof useWorkspace>
+const mockUseDocumentPreviewStore = useDocumentPreviewStore as Mock<typeof useDocumentPreviewStore>
+
+const mockSchemaType = {
+  name: 'article',
+  type: 'document',
+} as unknown as SchemaType
+
+describe('useNotificationTarget', () => {
+  let previewSubjects: Subject<{snapshot: {title?: string} | null}>[]
+  let observeForPreview: Mock
+
+  beforeEach(() => {
+    previewSubjects = []
+    observeForPreview = vi.fn(() => {
+      const subject = new Subject<{snapshot: {title?: string} | null}>()
+      previewSubjects.push(subject)
+      return subject.asObservable()
+    })
+
+    mockUseSchema.mockReturnValue({
+      get: vi.fn().mockReturnValue(mockSchemaType),
+    } as unknown as ReturnType<typeof useSchema>)
+
+    mockUseWorkspace.mockReturnValue({
+      title: 'My Workspace',
+      name: 'default',
+    } as unknown as ReturnType<typeof useWorkspace>)
+
+    mockUseDocumentPreviewStore.mockReturnValue({
+      observeForPreview,
+    } as unknown as DocumentPreviewStore)
+  })
+
+  it('does not subscribe to preview until getNotificationValue is called', () => {
+    renderHook(() =>
+      useNotificationTarget({
+        documentId: 'doc-1',
+        documentType: 'article',
+      }),
+    )
+
+    expect(observeForPreview).not.toHaveBeenCalled()
+    expect(previewSubjects).toHaveLength(0)
+  })
+
+  it('resolves the document title from the preview snapshot', async () => {
+    const getCommentLink = vi.fn((commentId: string) => `https://example.com/comment/${commentId}`)
+
+    const {result} = renderHook(() =>
+      useNotificationTarget({
+        documentId: 'doc-1',
+        documentType: 'article',
+        getCommentLink,
+      }),
+    )
+
+    const notificationPromise = result.current.getNotificationValue({commentId: 'comment-1'})
+
+    expect(observeForPreview).toHaveBeenCalled()
+    expect(previewSubjects.length).toBeGreaterThan(0)
+
+    // getPreviewStateObservable combines perspective + version/drafts snapshots.
+    // Emit a title on every active subject so combineLatest can produce a value.
+    for (const subject of previewSubjects) {
+      subject.next({snapshot: {title: 'Hello World'}})
+    }
+
+    await expect(notificationPromise).resolves.toEqual({
+      documentTitle: 'Hello World',
+      url: 'https://example.com/comment/comment-1',
+      workspaceTitle: 'My Workspace',
+      workspaceName: 'default',
+    })
+    expect(getCommentLink).toHaveBeenCalledWith('comment-1')
+  })
+
+  it('falls back to Sanity document when schema type is missing', async () => {
+    mockUseSchema.mockReturnValue({
+      get: vi.fn().mockReturnValue(undefined),
+    } as unknown as ReturnType<typeof useSchema>)
+
+    const {result} = renderHook(() =>
+      useNotificationTarget({
+        documentId: 'doc-1',
+        documentType: 'missing',
+      }),
+    )
+
+    await expect(result.current.getNotificationValue({commentId: 'comment-1'})).resolves.toEqual({
+      documentTitle: 'Sanity document',
+      url: undefined,
+      workspaceTitle: 'My Workspace',
+      workspaceName: 'default',
+    })
+    expect(observeForPreview).not.toHaveBeenCalled()
+  })
+
+  it('falls back to Sanity document when document id is empty', async () => {
+    const {result} = renderHook(() =>
+      useNotificationTarget({
+        documentId: '',
+        documentType: 'article',
+      }),
+    )
+
+    await expect(result.current.getNotificationValue({commentId: 'comment-1'})).resolves.toEqual({
+      documentTitle: 'Sanity document',
+      url: undefined,
+      workspaceTitle: 'My Workspace',
+      workspaceName: 'default',
+    })
+    expect(observeForPreview).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sanity/src/core/comments/hooks/use-comment-operations/createOperation.ts
+++ b/packages/sanity/src/core/comments/hooks/use-comment-operations/createOperation.ts
@@ -24,7 +24,7 @@ interface CreateOperationProps {
   documentVersionId?: string
   getComment?: (id: string) => CommentDocument | undefined
   getIntent?: CommentIntentGetter
-  getNotificationValue: (comment: {commentId: string}) => CommentContext['notification']
+  getNotificationValue: (comment: {commentId: string}) => Promise<CommentContext['notification']>
   getThreadLength?: (threadId: string) => number
   onCreate?: (comment: CommentPostPayload) => void
   onCreateError: (id: string, error: Error) => void
@@ -104,7 +104,7 @@ export async function createOperation(props: CreateOperationProps): Promise<void
       url = '',
       workspaceTitle = '',
       workspaceName = '',
-    } = getNotificationValue({commentId}) || {}
+    } = (await getNotificationValue({commentId})) || {}
 
     const notification: CommentContext['notification'] = {
       currentThreadLength,

--- a/packages/sanity/src/core/comments/hooks/useNotificationTarget.ts
+++ b/packages/sanity/src/core/comments/hooks/useNotificationTarget.ts
@@ -1,12 +1,16 @@
-import {useCallback, useMemo} from 'react'
-import {useObservable} from 'react-rx'
-import {of} from 'rxjs'
+import {useCallback} from 'react'
+import {filter, firstValueFrom, of, timeout} from 'rxjs'
 
 import {useSchema} from '../../hooks/useSchema'
 import {getPreviewStateObservable} from '../../preview/utils/getPreviewStateObservable'
 import {useDocumentPreviewStore} from '../../store/datastores'
 import {useWorkspace} from '../../studio/workspace'
 import {type CommentContext} from '../types'
+
+/** How long to wait for a preview title before falling back. */
+const PREVIEW_TITLE_TIMEOUT_MS = 3_000
+
+const FALLBACK_DOCUMENT_TITLE = 'Sanity document'
 
 interface NotificationTargetHookOptions {
   documentId: string
@@ -17,15 +21,23 @@ interface NotificationTargetHookOptions {
 
 interface NotificationTargetHookValue {
   /**
-   * Returns an object with notification-specific values for the selected comment, such as
-   * the current workspace + document title and full URL to the comment.
-   * These values are currently used in notification emails.
+   * Returns a promise that resolves with notification-specific values for the
+   * selected comment, such as the current workspace + document title and full
+   * URL to the comment. These values are currently used in notification emails.
+   *
+   * The document title is resolved on demand (one-shot preview subscription)
+   * rather than via a persistent listener, since it is only needed when a
+   * comment is created.
    *
    * **Please note:** this will generate a URL for the comment based on the current _active_ pane.
    * The current active pane may not necessarily be the right-most structure pane and in these
    * cases, the selected comment may not be visible on initial load when visiting these URLs.
    */
-  getNotificationValue: ({commentId}: {commentId: string}) => CommentContext['notification']
+  getNotificationValue: ({
+    commentId,
+  }: {
+    commentId: string
+  }) => Promise<CommentContext['notification']>
 }
 
 /** @internal */
@@ -38,24 +50,50 @@ export function useNotificationTarget(
 
   const documentPreviewStore = useDocumentPreviewStore()
 
-  const previewStateObservable = useMemo(() => {
-    if (!documentId || !schemaType) return of(null)
-    const perspectiveStack = documentVersionId ? [documentVersionId, 'drafts'] : ['drafts']
-    return getPreviewStateObservable(documentPreviewStore, schemaType, documentId, perspectiveStack)
-  }, [documentId, documentPreviewStore, schemaType, documentVersionId])
-  const previewState = useObservable(previewStateObservable)
-
-  const {snapshot, original} = previewState || {}
-  const documentTitle = (snapshot?.title || original?.title || 'Sanity document') as string
-
   const handleGetNotificationValue = useCallback(
-    ({commentId}: {commentId: string}) => ({
-      documentTitle,
-      url: getCommentLink?.(commentId),
-      workspaceTitle,
+    async ({commentId}: {commentId: string}): Promise<CommentContext['notification']> => {
+      let documentTitle = FALLBACK_DOCUMENT_TITLE
+
+      if (documentId && schemaType) {
+        const perspectiveStack = documentVersionId ? [documentVersionId, 'drafts'] : ['drafts']
+        const previewStateObservable = getPreviewStateObservable(
+          documentPreviewStore,
+          schemaType,
+          documentId,
+          perspectiveStack,
+        )
+
+        const previewState = await firstValueFrom(
+          previewStateObservable.pipe(
+            filter((state) => !state.isLoading),
+            timeout({
+              first: PREVIEW_TITLE_TIMEOUT_MS,
+              with: () => of(null),
+            }),
+          ),
+        )
+
+        documentTitle = (previewState?.snapshot?.title ||
+          previewState?.original?.title ||
+          FALLBACK_DOCUMENT_TITLE) as string
+      }
+
+      return {
+        documentTitle,
+        url: getCommentLink?.(commentId),
+        workspaceTitle,
+        workspaceName,
+      }
+    },
+    [
+      documentId,
+      documentPreviewStore,
+      documentVersionId,
+      getCommentLink,
+      schemaType,
       workspaceName,
-    }),
-    [documentTitle, getCommentLink, workspaceTitle, workspaceName],
+      workspaceTitle,
+    ],
   )
 
   return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`useNotificationTarget` kept a live preview subscription via `useObservable` only so comment creation could stamp a document title into the notification email payload. That title is only needed at create time, and a slightly stale title is low-harm for email notifications — so an always-alive listener is unnecessary cost.

Instead of deferring that subscription, `getNotificationValue` is now a promise that does a one-shot preview subscribe when a field comment is created (with a short timeout fallback to `"Sanity document"`).

## What to review

- [`useNotificationTarget.ts`](packages/sanity/src/core/comments/hooks/useNotificationTarget.ts) — promise-based one-shot title resolve
- [`createOperation.ts`](packages/sanity/src/core/comments/hooks/use-comment-operations/createOperation.ts) — awaits the notification value

## Testing

- Added unit tests covering lazy subscribe, title resolve, and missing schema/id fallbacks
- `pnpm vitest run --project=sanity packages/sanity/src/core/comments/hooks/__tests__/useNotificationTarget.test.tsx`

## Notes for release

N/A – Internal only

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0010ca73-f194-4b96-9c01-9f2ef177988f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0010ca73-f194-4b96-9c01-9f2ef177988f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

