### PR TITLE
fix(structure): keep inspector crashes inside the inspector panel

### DIFF
--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencePreview.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencePreview.tsx
@@ -14,7 +14,12 @@ import {usePaneRouter} from '../paneRouter/usePaneRouter'
 interface IncomingReferencePreviewProps {
   type: SchemaType
   value: SanityDocument
-  path: Path
+  /**
+   * Path of the field holding the reference, used to deep link to that field. It is not always
+   * possible to resolve: the referencing document we have at hand may not contain the reference
+   * yet, for instance when the listener is lagging behind a recently created reference.
+   */
+  path?: Path
 }
 
 export function IncomingReferencePreview(props: IncomingReferencePreviewProps) {
@@ -28,13 +33,17 @@ export function IncomingReferencePreview(props: IncomingReferencePreviewProps) {
     function LinkComponent(linkProps: {children: ReactNode}) {
       return (
         <ChildLink
-          childId={getPublishedId(value?._id)}
-          childParameters={{type: type.name, path: pathToString(path)}}
+          childId={publishedId}
+          childParameters={{
+            type: type.name,
+            // Without a path, link to the document rather than to a specific field
+            ...(Array.isArray(path) && path.length > 0 ? {path: pathToString(path)} : {}),
+          }}
           {...linkProps}
         />
       )
     },
-    [ChildLink, type.name, value?._id, path],
+    [ChildLink, publishedId, type.name, path],
   )
 
   return (

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/__tests__/IncomingReferencePreview.test.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/__tests__/IncomingReferencePreview.test.tsx
@@ -1,0 +1,54 @@
+import {type SanityDocument, type SchemaType} from '@sanity/types'
+import {render, screen} from '@testing-library/react'
+import {describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {structureUsEnglishLocaleBundle} from '../../../i18n'
+import {IncomingReferencePreview} from '../IncomingReferencePreview'
+
+vi.mock('../../paneItem/PaneItemPreview', () => ({
+  PaneItemPreview: vi.fn(({value}) => <div>{value._id}</div>),
+}))
+
+vi.mock('../../paneRouter/usePaneRouter', () => ({
+  usePaneRouter: vi.fn(() => ({
+    ChildLink: vi.fn(({childId, childParameters, children}) => (
+      <a href="#" data-child-id={childId} data-child-parameters={JSON.stringify(childParameters)}>
+        {children}
+      </a>
+    )),
+  })),
+}))
+
+vi.mock('../../../../core/store/presence/useDocumentPresence', () => ({
+  useDocumentPresence: vi.fn(() => []),
+}))
+
+const schemaType = {name: 'book', title: 'Book'} as SchemaType
+const document = {_id: 'book-id', _type: 'book'} as SanityDocument
+
+async function renderPreview(props: {path?: (string | number | {_key: string})[]}) {
+  const wrapper = await createTestProvider({resources: [structureUsEnglishLocaleBundle]})
+
+  render(<IncomingReferencePreview type={schemaType} value={document} {...props} />, {wrapper})
+
+  const link = screen.getByRole('link')
+  return JSON.parse(link.getAttribute('data-child-parameters') || '{}')
+}
+
+describe('IncomingReferencePreview', () => {
+  it('links to the field holding the reference', async () => {
+    expect(await renderPreview({path: ['authors', {_key: 'abc'}, 'author']})).toEqual({
+      type: 'book',
+      path: 'authors[_key=="abc"].author',
+    })
+  })
+
+  it('links to the document when the reference path could not be resolved', async () => {
+    expect(await renderPreview({path: undefined})).toEqual({type: 'book'})
+  })
+
+  it('links to the document when the reference path is empty', async () => {
+    expect(await renderPreview({path: []})).toEqual({type: 'book'})
+  })
+})

--- a/packages/sanity/src/structure/i18n/resources.ts
+++ b/packages/sanity/src/structure/i18n/resources.ts
@@ -466,6 +466,14 @@ const structureLocaleStrings = defineLocalesResources('structure', {
   'document-inspector.dialog.title': 'Inspecting <DocumentTitle/>',
   /** The title shown in the dialog header, when the document being inspected is not created yet/has no value */
   'document-inspector.dialog.title-no-value': 'No value',
+  /** Accessibility label for the close button shown when an inspector panel failed to render */
+  'document-inspector.error.close-button.aria-label': 'Close panel',
+  /** Text explaining that the inspector panel failed to render */
+  'document-inspector.error.description': 'An error occurred while rendering this panel.',
+  /** Label for the button that attempts to render the inspector panel again */
+  'document-inspector.error.retry-button.text': 'Retry',
+  /** The title shown in the inspector panel header when the panel failed to render */
+  'document-inspector.error.title': 'Something went wrong',
   /** Title shown for menu item that opens the "Inspect" dialog */
   'document-inspector.menu-item.title': 'Inspect',
   /** the placeholder text for the search input on the inspect dialog */

--- a/packages/sanity/src/structure/panes/document/documentInspector/DocumentInspectorErrorBoundary.tsx
+++ b/packages/sanity/src/structure/panes/document/documentInspector/DocumentInspectorErrorBoundary.tsx
@@ -1,0 +1,79 @@
+import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
+import {SyncIcon} from '@sanity/icons/Sync'
+import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
+import {type ReactNode, useCallback, useState} from 'react'
+import {useTranslation} from 'sanity'
+
+import {Button} from '../../../../ui-components/button/Button'
+import {ErrorBoundary} from '../../../../ui-components/errorBoundary/ErrorBoundary'
+import {structureLocaleNamespace} from '../../../i18n'
+import {DocumentInspectorHeader} from './DocumentInspectorHeader'
+
+interface DocumentInspectorErrorBoundaryProps {
+  children: ReactNode
+  onClose: () => void
+}
+
+/**
+ * Contains inspector crashes to the inspector panel. Errors thrown while rendering an inspector
+ * would otherwise reach `StructureToolBoundary`, which rethrows anything that isn't a
+ * `PaneResolutionError` and brings down the entire structure tool.
+ *
+ * @internal
+ */
+export function DocumentInspectorErrorBoundary(props: DocumentInspectorErrorBoundaryProps) {
+  const {children, onClose} = props
+  const {t} = useTranslation(structureLocaleNamespace)
+  const [error, setError] = useState<Error | null>(null)
+
+  const handleCatch = useCallback(({error: caughtError}: {error: Error}) => {
+    setError(caughtError)
+  }, [])
+
+  // Unmounting the boundary discards its caught error, so a retry mounts a fresh one
+  const handleRetry = useCallback(() => setError(null), [])
+
+  if (error) {
+    return (
+      <Flex direction="column" height="fill" overflow="hidden">
+        <DocumentInspectorHeader
+          as="header"
+          closeButtonLabel={t('document-inspector.error.close-button.aria-label')}
+          flex="none"
+          onClose={onClose}
+          title={t('document-inspector.error.title')}
+        />
+
+        <Card flex={1} overflow="auto" padding={3}>
+          <Stack gap={3}>
+            <Card padding={3} radius={2} tone="critical">
+              <Flex gap={3}>
+                <Text size={1}>
+                  <ErrorOutlineIcon />
+                </Text>
+
+                <Stack flex={1} gap={3}>
+                  <Text size={1}>{t('document-inspector.error.description')}</Text>
+                  <Text muted size={1}>
+                    {error.message}
+                  </Text>
+                </Stack>
+              </Flex>
+            </Card>
+
+            <Box>
+              <Button
+                icon={SyncIcon}
+                mode="ghost"
+                onClick={handleRetry}
+                text={t('document-inspector.error.retry-button.text')}
+              />
+            </Box>
+          </Stack>
+        </Card>
+      </Flex>
+    )
+  }
+
+  return <ErrorBoundary onCatch={handleCatch}>{children}</ErrorBoundary>
+}

--- a/packages/sanity/src/structure/panes/document/documentInspector/DocumentInspectorPanel.tsx
+++ b/packages/sanity/src/structure/panes/document/documentInspector/DocumentInspectorPanel.tsx
@@ -6,6 +6,7 @@ import {usePane} from '../../../components/pane/usePane'
 import {useStructureTool} from '../../../useStructureTool'
 import {DOCUMENT_INSPECTOR_MAX_WIDTH, DOCUMENT_INSPECTOR_MIN_WIDTH} from '../constants'
 import {useDocumentPane} from '../useDocumentPane'
+import {DocumentInspectorErrorBoundary} from './DocumentInspectorErrorBoundary'
 
 interface DocumentInspectorPanelProps {
   documentId: string
@@ -29,9 +30,12 @@ export function DocumentInspectorPanel(
 
   const Component = inspector.component
   const element = (
-    <Suspense fallback={null}>
-      <Component onClose={handleClose} documentId={documentId} documentType={documentType} />
-    </Suspense>
+    // Keying on the inspector name clears a caught error when switching inspectors
+    <DocumentInspectorErrorBoundary key={inspector.name} onClose={handleClose}>
+      <Suspense fallback={null}>
+        <Component onClose={handleClose} documentId={documentId} documentType={documentType} />
+      </Suspense>
+    </DocumentInspectorErrorBoundary>
   )
 
   if (features.resizablePanes) {

--- a/packages/sanity/src/structure/panes/document/documentInspector/__tests__/DocumentInspectorPanel.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentInspector/__tests__/DocumentInspectorPanel.test.tsx
@@ -1,0 +1,88 @@
+import {render, screen} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {type DocumentInspector} from 'sanity'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {structureUsEnglishLocaleBundle} from '../../../../i18n'
+import {DocumentInspectorPanel} from '../DocumentInspectorPanel'
+
+vi.mock('../../../../components/pane/usePane', () => ({
+  usePane: vi.fn(() => ({collapsed: false})),
+}))
+
+vi.mock('../../../../useStructureTool', () => ({
+  useStructureTool: vi.fn(() => ({features: {resizablePanes: false}})),
+}))
+
+vi.mock('../../useDocumentPane', () => ({
+  useDocumentPane: vi.fn(),
+}))
+
+const {useDocumentPane} = vi.mocked(await import('../../useDocumentPane'))
+
+const closeInspector = vi.fn()
+
+async function renderInspectorPanel(component: DocumentInspector['component']) {
+  useDocumentPane.mockReturnValue({
+    closeInspector,
+    inspector: {name: 'test/inspector', component},
+  } as unknown as ReturnType<typeof useDocumentPane>)
+
+  const wrapper = await createTestProvider({resources: [structureUsEnglishLocaleBundle]})
+
+  render(<DocumentInspectorPanel documentId="doc-id" documentType="book" />, {
+    wrapper,
+    // React logs caught errors to the console by default, which only adds noise here
+    onCaughtError: () => {},
+  })
+}
+
+describe('DocumentInspectorPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the inspector', async () => {
+    await renderInspectorPanel(() => <div>Inspector contents</div>)
+
+    expect(await screen.findByText('Inspector contents')).toBeInTheDocument()
+  })
+
+  it('renders a recoverable error instead of letting an inspector crash escape the panel', async () => {
+    await renderInspectorPanel(() => {
+      throw new Error('Path is not an array')
+    })
+
+    expect(await screen.findByText('Something went wrong')).toBeInTheDocument()
+    expect(screen.getByText('An error occurred while rendering this panel.')).toBeInTheDocument()
+    expect(screen.getByText('Path is not an array')).toBeInTheDocument()
+  })
+
+  it('closes the inspector from the error state', async () => {
+    await renderInspectorPanel(() => {
+      throw new Error('Path is not an array')
+    })
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Close panel'}))
+
+    expect(closeInspector).toHaveBeenCalledWith('test/inspector')
+  })
+
+  it('renders the inspector again when retrying', async () => {
+    let shouldThrow = true
+
+    await renderInspectorPanel(() => {
+      if (shouldThrow) throw new Error('Path is not an array')
+      return <div>Inspector contents</div>
+    })
+
+    expect(await screen.findByText('Something went wrong')).toBeInTheDocument()
+
+    shouldThrow = false
+    await userEvent.click(screen.getByRole('button', {name: 'Retry'}))
+
+    expect(await screen.findByText('Inspector contents')).toBeInTheDocument()
+    expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/IncomingReferenceDocument.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/IncomingReferenceDocument.tsx
@@ -32,6 +32,9 @@ export const IncomingReferenceDocument = (props: {
     <Card radius={2} tone="default">
       <FadeInFlex initial={{opacity: 0}} animate={{opacity: 1}} gap={1} align="center">
         <Box flex={1}>
+          {/* The document may not hold a reference to this document yet – eg. when the listener
+              is behind after a reference was just created – in which case there is no path to
+              deep link to, and the preview links to the document itself */}
           <IncomingReferencePreview type={schemaType} value={document} path={referencePaths[0]} />
         </Box>
       </FadeInFlex>

--- a/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/IncomingReferenceDocument.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/IncomingReferenceDocument.tsx
@@ -32,7 +32,7 @@ export const IncomingReferenceDocument = (props: {
     <Card radius={2} tone="default">
       <FadeInFlex initial={{opacity: 0}} animate={{opacity: 1}} gap={1} align="center">
         <Box flex={1}>
-          {/* The document may not hold a reference to this document yet – eg. when the listener
+          {/* The document may not hold a reference to this document yet – e.g. when the listener
               is behind after a reference was just created – in which case there is no path to
               deep link to, and the preview links to the document itself */}
           <IncomingReferencePreview type={schemaType} value={document} path={referencePaths[0]} />

--- a/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/__tests__/IncomingReferenceDocument.test.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/__tests__/IncomingReferenceDocument.test.tsx
@@ -1,0 +1,58 @@
+import {type SanityDocument} from '@sanity/types'
+import {render, screen} from '@testing-library/react'
+import {defineConfig} from 'sanity'
+import {describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {structureUsEnglishLocaleBundle} from '../../../../../i18n'
+import {IncomingReferenceDocument} from '../IncomingReferenceDocument'
+
+vi.mock('../../../../../components/incomingReferencesDecoration/IncomingReferencePreview', () => ({
+  IncomingReferencePreview: vi.fn(({path}) => (
+    <div data-testid="preview" data-path={JSON.stringify(path ?? null)} />
+  )),
+}))
+
+const config = defineConfig({
+  projectId: 'test',
+  dataset: 'test',
+  schema: {
+    types: [
+      {
+        name: 'book',
+        type: 'document',
+        fields: [{name: 'author', type: 'reference', to: [{type: 'author'}]}],
+      },
+      {name: 'author', type: 'document', fields: [{name: 'name', type: 'string'}]},
+    ],
+  },
+})
+
+async function renderDocument(document: SanityDocument, referenceToId: string) {
+  const wrapper = await createTestProvider({config, resources: [structureUsEnglishLocaleBundle]})
+
+  render(<IncomingReferenceDocument document={document} referenceToId={referenceToId} />, {wrapper})
+
+  return JSON.parse((await screen.findByTestId('preview')).getAttribute('data-path') || 'null')
+}
+
+const book = {
+  _id: 'book-id',
+  _type: 'book',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-01T00:00:00Z',
+  _rev: 'rev',
+  author: {_ref: 'author-id', _type: 'reference'},
+} satisfies SanityDocument
+
+describe('IncomingReferenceDocument', () => {
+  it('passes the path of the referencing field to the preview', async () => {
+    expect(await renderDocument(book, 'author-id')).toEqual(['author'])
+  })
+
+  it('renders without a path when the document does not hold the reference', async () => {
+    // The document we receive from the listener can lag behind, and then holds no reference to
+    // the document being inspected. That must not take the inspector down.
+    expect(await renderDocument(book, 'some-other-author-id')).toBeNull()
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Opening a document with the incoming references inspector (`?inspect=sanity/structure/incoming-references`) could take down the entire structure tool with `Error: Path is not an array`. Two independent problems combined into that outcome:

1. Nothing catches errors thrown while rendering a document inspector. They reach `StructureToolBoundary`, which rethrows anything that isn't a `PaneResolutionError`, so a single broken panel unmounts the whole tool. The boundary is placed in `DocumentInspectorPanel` rather than inside the incoming references inspector, so every inspector (including third-party ones) is contained.
2. The incoming references inspector passed `getReferencePaths(document, referenceToId)[0]` straight to `pathToString`. That array is empty whenever the referencing document we have at hand does not (yet) contain the reference — for example when the listener lags behind a freshly created reference — and `pathToString(undefined)` throws. The decoration variant of the same component already guarded against this; the inspector variant did not.

For the empty-path case the preview now links to the referencing document without the `path` parameter, rather than rendering the placeholder skeleton the decoration variant uses: in the inspector the row is the primary way to reach the document, and a permanent skeleton would be worse than a link that just doesn't deep link to a field.

### What to review

Only `packages/sanity`, structure tool:

- `DocumentInspectorErrorBoundary.tsx` (new) and its use in `DocumentInspectorPanel.tsx`. Retry works by unmounting the boundary (a caught error is not resettable in place), and the `key={inspector.name}` clears the error state when switching inspectors.
- `IncomingReferencePreview.tsx` — `path` is now optional and omitted from the child pane parameters when it cannot be resolved. `DocumentPaneProvider` already treats a missing `path` param as "no initial focus path", so no downstream change was needed.
- Four new strings in `packages/sanity/src/structure/i18n/resources.ts`.

### Testing

`pnpm vitest run --project=sanity packages/sanity/src/structure` (all 46 files) plus `pnpm lint` (oxlint, includes type checking) and `pnpm build`.

New tests:

- `DocumentInspectorPanel.test.tsx` — a throwing inspector renders the recoverable error state instead of propagating, the close button closes the inspector, and Retry re-renders the inspector.
- `IncomingReferencePreview.test.tsx` — child pane parameters include `path` when resolvable and omit it for `undefined` / empty paths.
- `IncomingReferenceDocument.test.tsx` — regression test for the crash: a referencing document that does not hold the reference renders without a path instead of throwing.

Manually verified in the test studio (`pnpm dev:test-studio`, `/test` workspace) on an Author document with the Incoming references inspector open, by temporarily forcing the reference paths to be unresolvable — the exact condition behind the reported crash.

With the path guard temporarily reverted, the crash is now contained to the panel and the rest of the studio stays interactive:

[inspector_crash_contained_to_panel_studio_stays_usable.mp4](https://cursor.com/agents/bc-757f79f8-9edb-451b-9bd1-ce91e1a78e7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finspector_crash_contained_to_panel_studio_stays_usable.mp4)

[Inspector error state in the panel while the studio keeps working](https://cursor.com/agents/bc-757f79f8-9edb-451b-9bd1-ce91e1a78e7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finspector_error_state_contained_in_panel.webp)

With the guard in place, the panel lists the referencing documents and links to them (the child pane URL carries `type=book` and no `path`):

[incoming_references_renders_and_links_without_resolvable_path.mp4](https://cursor.com/agents/bc-757f79f8-9edb-451b-9bd1-ce91e1a78e7a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fincoming_references_renders_and_links_without_resolvable_path.mp4)

### Notes for release

Fixed a crash that could take down the whole structure tool when the Incoming references inspector was open. Inspector panels now show a recoverable error inside the panel instead of unmounting the tool, and the incoming references list links to the referencing document when the exact field path cannot be determined.

---


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-757f79f8-9edb-451b-9bd1-ce91e1a78e7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-757f79f8-9edb-451b-9bd1-ce91e1a78e7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

