### PR TITLE
fix(structure): incoming references shouldn't self refer

### DIFF
--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/getIncomingReferences.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/getIncomingReferences.tsx
@@ -85,7 +85,7 @@ export function getIncomingReferences({
     switchMap(({filter: filterQuery, filterParams}) => {
       return documentPreviewStore
         .unstable_observeDocumentIdSet(
-          `references("${publishedId}") ${type ? `&& _type == "${type}"` : ''} ${filterQuery ? `&& ${filterQuery}` : ''}`,
+          `references("${publishedId}") && _system.group._ref != "${publishedId}" ${type ? `&& _type == "${type}"` : ''} ${filterQuery ? `&& ${filterQuery}` : ''}`,
           filterParams,
           {insert: 'append'},
         )


### PR DESCRIPTION
### Description
Incoming references is crashing when opening documents with variants.
This is because variant documents are `self referenced` by the `_system.group._ref` field.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single GROQ filter change in incoming-references loading; no auth or data mutation, with a narrow fix for variant self-reference edge cases.
> 
> **Overview**
> Fixes crashes when opening documents with variants in the **incoming references** UI.
> 
> The `references()` query in `getIncomingReferences` now adds `&& _system.group._ref != "${publishedId}"` so variant documents are not counted as referencing themselves via `_system.group._ref` (the document group link), while real incoming references are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6b822bc968e4bfa418dc613bea2dc8915896ca6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->