### PR TITLE
chore(structure): drop redundant incoming references comments

### DIFF
--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencePreview.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencePreview.tsx
@@ -36,7 +36,6 @@ export function IncomingReferencePreview(props: IncomingReferencePreviewProps) {
           childId={publishedId}
           childParameters={{
             type: type.name,
-            // Without a path, link to the document rather than to a specific field
             ...(Array.isArray(path) && path.length > 0 ? {path: pathToString(path)} : {}),
           }}
           {...linkProps}

--- a/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/IncomingReferenceDocument.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/incomingReferences/IncomingReferenceDocument.tsx
@@ -32,9 +32,6 @@ export const IncomingReferenceDocument = (props: {
     <Card radius={2} tone="default">
       <FadeInFlex initial={{opacity: 0}} animate={{opacity: 1}} gap={1} align="center">
         <Box flex={1}>
-          {/* The document may not hold a reference to this document yet – e.g. when the listener
-              is behind after a reference was just created – in which case there is no path to
-              deep link to, and the preview links to the document itself */}
           <IncomingReferencePreview type={schemaType} value={document} path={referencePaths[0]} />
         </Box>
       </FadeInFlex>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Follow-up to [#13845](https://github.com/sanity-io/sanity/pull/13845), which landed two comments that restate documentation the reader already has. `IncomingReferencePreview` documents on its `path` prop that the path is not always resolvable and why; editors surface that JSDoc on hover at the call site. The three-line JSX block above the call site said the same thing again, and the inline comment inside `childParameters` narrated the conditional spread directly below it.

Deleting both leaves the `path?: Path` JSDoc as the single place explaining the case.

### What to review

Comment-only deletion in `packages/sanity`, four lines across two files. No behavior change.

### Testing

`pnpm check:format`, `pnpm check:oxlint` (includes type checking), and the vitest suites covering both touched directories plus `documentInspector` (3 files, 9 tests) all pass.

### Notes for release

N/A – Internal only

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-757f79f8-9edb-451b-9bd1-ce91e1a78e7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-757f79f8-9edb-451b-9bd1-ce91e1a78e7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

