### PR TITLE
chore(test-dts-exports): remove ui-poc styles.css TS2882 workaround

### DIFF
--- a/packages/@repo/test-dts-exports/test/lib-check.test.ts
+++ b/packages/@repo/test-dts-exports/test/lib-check.test.ts
@@ -72,12 +72,6 @@ const filteredErrors = errors.filter((d) => {
     return false
   }
 
-  // Workaround for @sanity-labs/ui-poc’s stylesheet, which TypeScript reports as a TS2882 under
-  // skipLibCheck: false in this suite.
-  if (code === 2882 && d.messageText.toString().includes('@sanity-labs/ui-poc/styles.css')) {
-    return false
-  }
-
   return true
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

`@sanity-labs/ui-poc` 0.0.1-alpha.25 ships types for the `./styles.css` export (`src/styles.css.d.ts`), so the temporary TS2882 filter in the dts lib-check suite is obsolete. It was left behind after #13832 bumped the package.

### What to review

- `packages/@repo/test-dts-exports/test/lib-check.test.ts` — only change is deleting the ui-poc CSS filter; other known false-negative filters stay.

### Testing

- Built workspace deps and ran `pnpm vitest run test/lib-check.test.ts` in `@repo/test-dts-exports` — passed with the filter removed (sanity still emits `import "@sanity-labs/ui-poc/styles.css"` in its `.d.ts`).

### Notes for release

N/A – Internal only

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a8aec00-beb8-476f-b107-cd42a3a5ff81?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a8aec00-beb8-476f-b107-cd42a3a5ff81&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

