### PR TITLE
refactor(ui): migrate Stack and Button space prop to gap

### DIFF
--- a/examples/functions/social-media-crosspost/characterCount.tsx
+++ b/examples/functions/social-media-crosspost/characterCount.tsx
@@ -24,7 +24,7 @@ export function CharacterCount(props: any) {
 
   return (
     <Card shadow={1} padding={3} radius={2}>
-      <Stack space={3}>
+      <Stack gap={3}>
         <Flex gap={3} direction="row" align="center" wrap="wrap">
           {platformsToDisplay.map((platform: Platform) => {
             const platformSetting = Array.isArray(doc.platformOverrides)

--- a/examples/studios/intents-and-routing/schemaTypes/MovieTitleInput.tsx
+++ b/examples/studios/intents-and-routing/schemaTypes/MovieTitleInput.tsx
@@ -3,7 +3,7 @@ import {IntentLink} from 'sanity/router'
 
 export function MovieTitleInput(props) {
   return (
-    <Stack space={4}>
+    <Stack gap={4}>
       <Flex>
         <IntentLink intent="approve" params={{foo: 'bar'}}>
           Approve

--- a/packages/sanity/src/core/components/previews/general/MediaPreview.styled.ts
+++ b/packages/sanity/src/core/components/previews/general/MediaPreview.styled.ts
@@ -43,6 +43,6 @@ export const ProgressFlex = styled(Flex).attrs({align: 'center', justify: 'cente
   }
 `
 
-export const TooltipContentStack = styled(Stack).attrs({space: 2})`
+export const TooltipContentStack = styled(Stack).attrs({gap: 2})`
   max-width: ${rem(200)};
 `

--- a/packages/sanity/src/core/tasks/components/activity/TasksActivityLog.tsx
+++ b/packages/sanity/src/core/tasks/components/activity/TasksActivityLog.tsx
@@ -247,7 +247,7 @@ export function TasksActivityLog(props: TasksActivityLogProps) {
 
         <AnimatePresence>
           {!loading && (
-            <MotionStack animate="visible" initial="hidden" space={4} variants={VARIANTS}>
+            <MotionStack animate="visible" initial="hidden" gap={4} variants={VARIANTS}>
               {value.createdByUser && (
                 <Stack paddingBottom={1}>
                   <TasksActivityCreatedAt

--- a/packages/sanity/src/ui-components/button/Button.tsx
+++ b/packages/sanity/src/ui-components/button/Button.tsx
@@ -44,11 +44,11 @@ type IconButton = {
 export type ButtonProps = BaseButtonProps & (ButtonWithText | IconButton)
 
 const LARGE_BUTTON_PROPS = {
-  space: 3,
+  gap: 3,
   padding: 3,
 }
 const DEFAULT_BUTTON_PROPS = {
-  space: 2,
+  gap: 2,
   padding: 2,
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Split from #13817: migrate a small set of `@sanity/ui` `space` usages to `gap` while both props still work on 3.5.x. `space` is deprecated and removed in v4, so landing these early keeps the larger UI 4 bump smaller and avoids stacking more deprecated call sites.

Why not fold this into #13817: that PR mixes catalog pins, import migrations, and overlay/test harness changes; this rename is independently safe on current `@sanity/ui`.

### What to review

- The five call sites: `MediaPreview.styled`, tasks activity `MotionStack`, `Button` size defaults, and the two example studios
- Confirm no remaining `space` on these components in the listed files

### Testing

- Pre-commit oxfmt + oxlint on the touched files
- No dedicated tests: prop rename only; behavior is unchanged (`gap` is the supported replacement for deprecated `space`)

### Notes for release

N/A – Internal prop rename preparing for `@sanity/ui` v4; no studio user-facing change.

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6aec5163-0f47-4138-a26e-d3371ef2c101?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6aec5163-0f47-4138-a26e-d3371ef2c101&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

