### PR TITLE
feat(structure): add telemetry for the history and review changes pane

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -131,7 +131,19 @@ How a navigation or open interaction was triggered.
 | `pane_menu`         | Via a document pane menu item                                      |
 | `url`               | Via a deep link, reload, or history navigation (no in-app control) |
 
-`Nested Dialog Opened` also carries a `path`, holding a serialized document field path rather than a value from this table. Filter by event name before grouping on `path`.
+The nested object editing events - `Nested Dialog Opened`, `Object Created`, `Object Edited`, `Object Removed`, `Editor Opened` and `Editor Closed` - also carry a `path`, holding a serialized document field path rather than a value from this table. Those paths include array item `_key` values, so they are high cardinality. Filter by event name before grouping on `path`.
+
+### `context` (copy/paste only, not shared)
+
+`Field Copied` and `Field Pasted` carry a `context` describing the trigger. It is deliberately outside the shared vocabulary above and its values are camelCase, not snake_case. Do not "align" `keyboardShortcut` with `path`'s `keyboard_shortcut`: the value is emitted verbatim from `source` on the public `CopyOptions` / `PasteOptions` types, so renaming it breaks both plugin callers and the continuity of the existing time series. Group `context` only within these two events.
+
+| Value                 | Description                                                               |
+| --------------------- | ------------------------------------------------------------------------- |
+| `fieldAction`         | Via the field action menu                                                 |
+| `documentFieldAction` | Via a document-level field action (not currently emitted from the studio) |
+| `keyboardShortcut`    | Via Ctrl/Cmd+C or Ctrl/Cmd+V                                              |
+| `arrayItem`           | Via an array item menu                                                    |
+| `unknown`             | Fallback when the caller passed no source                                 |
 
 ## How Events Are Sent
 

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -121,11 +121,15 @@ Where in a collection an object was created or edited. Pairs with
 
 How a navigation or open interaction was triggered.
 
-| Value               | Description               |
-| ------------------- | ------------------------- |
-| `breadcrumb`        | Via a breadcrumb control  |
-| `close_button`      | Via a dialog close button |
-| `keyboard_shortcut` | Via a keyboard shortcut   |
+| Value               | Description                                                        |
+| ------------------- | ------------------------------------------------------------------ |
+| `breadcrumb`        | Via a breadcrumb control                                           |
+| `close_button`      | Via a dialog close button                                          |
+| `keyboard_shortcut` | Via a keyboard shortcut                                            |
+| `status_line`       | Via the document footer status button                              |
+| `change_indicator`  | Via the change bar beside an edited field                          |
+| `pane_menu`         | Via a document pane menu item                                      |
+| `url`               | Via a deep link, reload, or history navigation (no in-app control) |
 
 ## How Events Are Sent
 
@@ -273,6 +277,22 @@ Tracked automatically via `web-vitals/attribution` library:
 | `Document Published`                                  | Publish action completes                            |
 | `Publish Button Clicked`                              | Publish operation stages (started/completed/failed) |
 | `Publish Button Becomes Disabled - Started/Completed` | Publish button state transitions                    |
+
+### Document History and Changes
+
+These events cover the history / review changes side pane. `Document History Inspector Opened` fires from an effect watching the inspector transition open, so it captures every entry point, including deep links and reloads that arrive with the pane already open (`path: 'url'`). Treat `url` opens as views rather than intent, and filter them out when measuring engagement. There is no close event, so dwell time is not derivable.
+
+| Event                                    | When                                            | Payload                                                       |
+| ---------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------- |
+| `Document History Inspector Opened`      | The pane transitions open                       | `{ tab: 'history' \| 'review', path }`                        |
+| `Document History Inspector Tab Changed` | The active tab changes while the pane is open   | `{ tab, previousTab }`                                        |
+| `Document Changes Reverted`              | A revert is confirmed in the review changes tab | `{ scope: 'all' \| 'group' \| 'field', changeCount: number }` |
+
+`path` uses the shared [`path`](#path) vocabulary (`status_line`, `change_indicator`, `pane_menu`, `url`). To split opens by events-API rollout, join on `eventsApiDocumentsEnabled` from `Workspace Features Observed` via the envelope's `activeWorkspace`. `Document Changes Reverted` counts confirmed reverts; opening the confirmation dialog logs nothing.
+
+`Tab Changed` fires from the same effect, watching the resolved tab, so it covers every switch including the ones that bypass the tab list, such as the status line jumping to review while the pane is already open on history. The two events never overlap: an open seeds the previous tab from the entry point, so the tab shown on open is reported by `Opened` alone.
+
+`Tab Changed` carries no attribution. Tab-list clicks, status-line jumps and change-indicator jumps are indistinguishable. Browser back and forward between `?changesInspectorTab=history` and `?changesInspectorTab=review` fires it too, inflating the count the way `url` inflates `Opened`.
 
 ### Releases
 

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -131,6 +131,8 @@ How a navigation or open interaction was triggered.
 | `pane_menu`         | Via a document pane menu item                                      |
 | `url`               | Via a deep link, reload, or history navigation (no in-app control) |
 
+`Nested Dialog Opened` also carries a `path`, holding a serialized document field path rather than a value from this table. Filter by event name before grouping on `path`.
+
 ## How Events Are Sent
 
 ### React Hook
@@ -288,7 +290,9 @@ These events cover the history / review changes side pane. `Document History Ins
 | `Document History Inspector Tab Changed` | The active tab changes while the pane is open   | `{ tab, previousTab }`                                        |
 | `Document Changes Reverted`              | A revert is confirmed in the review changes tab | `{ scope: 'all' \| 'group' \| 'field', changeCount: number }` |
 
-`path` uses the shared [`path`](#path) vocabulary (`status_line`, `change_indicator`, `pane_menu`, `url`). To split opens by events-API rollout, join on `eventsApiDocumentsEnabled` from `Workspace Features Observed` via the envelope's `activeWorkspace`. `Document Changes Reverted` counts confirmed reverts; opening the confirmation dialog logs nothing.
+`path` uses the shared [`path`](#path) vocabulary (`status_line`, `change_indicator`, `pane_menu`, `url`). To split opens by events-API rollout, join on `eventsApiDocumentsEnabled` from `Workspace Features Observed` via the envelope's `activeWorkspace`.
+
+`Document Changes Reverted` counts confirmed reverts; opening the confirmation dialog logs nothing. `changeCount` is the flat count of field changes, so `all`, `group` and `field` measure at the same depth and compare directly. It runs ahead of the rows on screen, which collapse sibling changes into groups: a 20-block Portable Text edit is one row and 20 changes. One event covers one gesture, so the count will not reconcile against mutations - reverting a group issues a patch per field. Discard changes and release revert are separate events.
 
 `Tab Changed` fires from the same effect, watching the resolved tab, so it covers every switch including the ones that bypass the tab list, such as the status line jumping to review while the pane is already open on history. The two events never overlap: an open seeds the previous tab from the entry point, so the tab shown on open is reported by `Opened` alone.
 

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -294,7 +294,7 @@ Tracked automatically via `web-vitals/attribution` library:
 
 ### Document History and Changes
 
-These events cover the history / review changes side pane. `Document History Inspector Opened` fires from an effect watching the inspector transition open, so it captures every entry point, including deep links and reloads that arrive with the pane already open (`path: 'url'`). Treat `url` opens as views rather than intent, and filter them out when measuring engagement. There is no close event, so dwell time is not derivable.
+These events cover the history / review changes side pane. `Document History Inspector Opened` fires from an effect watching the inspector transition open, so it captures every entry point, including deep links and reloads that arrive with the pane already open (`path: 'url'`). `url` also covers any pane remount, such as switching perspective or release variant with the pane already open, since `DocumentPane` keys the provider on those. Treat `url` opens as views rather than intent, and filter them out when measuring engagement. There is no close event, so dwell time is not derivable.
 
 | Event                                    | When                                            | Payload                                                       |
 | ---------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------- |

--- a/packages/sanity/src/core/field/diff/__telemetry__/diff.telemetry.ts
+++ b/packages/sanity/src/core/field/diff/__telemetry__/diff.telemetry.ts
@@ -1,0 +1,15 @@
+import {defineEvent} from '@sanity/telemetry'
+
+interface DocumentChangesRevertedInfo {
+  /** Breadth of the revert: the whole document, a field group, or a single field */
+  scope: 'all' | 'group' | 'field'
+  /** Number of field changes the revert covered; always 1 for the `field` scope */
+  changeCount: number
+}
+
+/** When changes are reverted from the review changes pane */
+export const DocumentChangesReverted = defineEvent<DocumentChangesRevertedInfo>({
+  name: 'Document Changes Reverted',
+  version: 1,
+  description: 'User reverted changes from the review changes pane',
+})

--- a/packages/sanity/src/core/field/diff/__telemetry__/diff.telemetry.ts
+++ b/packages/sanity/src/core/field/diff/__telemetry__/diff.telemetry.ts
@@ -3,11 +3,16 @@ import {defineEvent} from '@sanity/telemetry'
 interface DocumentChangesRevertedInfo {
   /** Breadth of the revert: the whole document, a field group, or a single field */
   scope: 'all' | 'group' | 'field'
-  /** Number of field changes the revert covered; always 1 for the `field` scope */
+  /**
+   * Flat count of field changes the revert covered. Every scope measures at this depth, so the
+   * three compare directly. Runs ahead of the rows on screen, which collapse siblings into groups.
+   */
   changeCount: number
 }
 
-/** When changes are reverted from the review changes pane */
+/**
+ * @internal
+ */
 export const DocumentChangesReverted = defineEvent<DocumentChangesRevertedInfo>({
   name: 'Document Changes Reverted',
   version: 1,

--- a/packages/sanity/src/core/field/diff/components/ChangeList.tsx
+++ b/packages/sanity/src/core/field/diff/components/ChangeList.tsx
@@ -19,6 +19,7 @@ import {useConditionalProperty} from '../../conditional-property/useConditionalP
 import {type ChangeNode, type ObjectDiff} from '../../types'
 import {DocumentChangesReverted} from '../__telemetry__/diff.telemetry'
 import {buildObjectChangeList} from '../changes/buildChangeList'
+import {flattenChangeNode} from '../changes/helpers'
 import {undoChange} from '../changes/undoChange'
 import {useDocumentChange} from '../hooks/useDocumentChange'
 import {ChangeListWrapper} from './ChangeList.styled'
@@ -95,10 +96,13 @@ export function ChangeList({diff, fields, schemaType}: ChangeListProps): React.J
   const rootChange = allChanges[0]
 
   const revertAllChanges = useCallback(() => {
-    telemetry.log(DocumentChangesReverted, {scope: 'all', changeCount: changes.length})
+    telemetry.log(DocumentChangesReverted, {
+      scope: 'all',
+      changeCount: flattenChangeNode(rootChange).length,
+    })
     undoChange(rootChange, diff, docOperations)
     setConfirmRevertAllOpen(false)
-  }, [changes.length, rootChange, diff, docOperations, telemetry])
+  }, [rootChange, diff, docOperations, telemetry])
 
   const handleRevertAllChangesClick = useCallback(() => {
     setConfirmRevertAllOpen(true)

--- a/packages/sanity/src/core/field/diff/components/ChangeList.tsx
+++ b/packages/sanity/src/core/field/diff/components/ChangeList.tsx
@@ -1,5 +1,6 @@
 import {type SanityDocument} from '@sanity/client'
 import {RevertIcon} from '@sanity/icons/Revert'
+import {useTelemetry} from '@sanity/telemetry/react'
 import {type ObjectSchemaType} from '@sanity/types'
 import {Card, Stack} from '@sanity/ui'
 import {startTransition, useCallback, useContext, useMemo, useState} from 'react'
@@ -16,6 +17,7 @@ import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {useDocumentPairPermissions} from '../../../store/grants/documentPairPermissions'
 import {useConditionalProperty} from '../../conditional-property/useConditionalProperty'
 import {type ChangeNode, type ObjectDiff} from '../../types'
+import {DocumentChangesReverted} from '../__telemetry__/diff.telemetry'
 import {buildObjectChangeList} from '../changes/buildChangeList'
 import {undoChange} from '../changes/undoChange'
 import {useDocumentChange} from '../hooks/useDocumentChange'
@@ -46,6 +48,7 @@ export function ChangeList({diff, fields, schemaType}: ChangeListProps): React.J
     getPairTarget(targetDocumentState),
   )
   const {path} = useContext(DiffContext)
+  const telemetry = useTelemetry()
   const isRoot = path.length === 0
   const [confirmRevertAllOpen, setConfirmRevertAllOpen] = useState(false)
   const [confirmRevertAllHover, setConfirmRevertAllHover] = useState(false)
@@ -92,9 +95,10 @@ export function ChangeList({diff, fields, schemaType}: ChangeListProps): React.J
   const rootChange = allChanges[0]
 
   const revertAllChanges = useCallback(() => {
+    telemetry.log(DocumentChangesReverted, {scope: 'all', changeCount: changes.length})
     undoChange(rootChange, diff, docOperations)
     setConfirmRevertAllOpen(false)
-  }, [rootChange, diff, docOperations])
+  }, [changes.length, rootChange, diff, docOperations, telemetry])
 
   const handleRevertAllChangesClick = useCallback(() => {
     setConfirmRevertAllOpen(true)

--- a/packages/sanity/src/core/field/diff/components/ChangeResolver.tsx
+++ b/packages/sanity/src/core/field/diff/components/ChangeResolver.tsx
@@ -26,6 +26,7 @@ import {pathsAreEqual} from '../../paths/helpers'
 import {type ChangeNode, type GroupChangeNode} from '../../types'
 import {isPTSchemaType} from '../../types/portableText/diff/helpers'
 import {DocumentChangesReverted} from '../__telemetry__/diff.telemetry'
+import {flattenChangeNode} from '../changes/helpers'
 import {undoChange} from '../changes/undoChange'
 import {isFieldChange} from '../helpers'
 import {useDocumentChange} from '../hooks/useDocumentChange'
@@ -155,10 +156,13 @@ export function GroupChange(
   })
 
   const handleRevertChanges = useCallback(() => {
-    telemetry.log(DocumentChangesReverted, {scope: 'group', changeCount: changes.length})
+    telemetry.log(DocumentChangesReverted, {
+      scope: 'group',
+      changeCount: flattenChangeNode(group).length,
+    })
     undoChange(group, rootDiff, docOperations)
     setConfirmRevertOpen(false)
-  }, [changes.length, group, rootDiff, docOperations, telemetry])
+  }, [group, rootDiff, docOperations, telemetry])
 
   const handleRevertChangesConfirm = useCallback(() => {
     setConfirmRevertOpen(true)

--- a/packages/sanity/src/core/field/diff/components/ChangeResolver.tsx
+++ b/packages/sanity/src/core/field/diff/components/ChangeResolver.tsx
@@ -1,3 +1,4 @@
+import {useTelemetry} from '@sanity/telemetry/react'
 import {type ConditionalProperty, type SanityDocument} from '@sanity/types'
 import {Stack, Text} from '@sanity/ui'
 import {
@@ -24,6 +25,7 @@ import {useConditionalProperty} from '../../conditional-property/useConditionalP
 import {pathsAreEqual} from '../../paths/helpers'
 import {type ChangeNode, type GroupChangeNode} from '../../types'
 import {isPTSchemaType} from '../../types/portableText/diff/helpers'
+import {DocumentChangesReverted} from '../__telemetry__/diff.telemetry'
 import {undoChange} from '../changes/undoChange'
 import {isFieldChange} from '../helpers'
 import {useDocumentChange} from '../hooks/useDocumentChange'
@@ -107,6 +109,7 @@ export function GroupChange(
   const {change: group, readOnly, hidden, ...restProps} = props
   const {titlePath, changes, path: groupPath} = group
   const {path: diffPath} = useContext(DiffContext)
+  const telemetry = useTelemetry()
   const {
     documentId,
     schemaType,
@@ -152,9 +155,10 @@ export function GroupChange(
   })
 
   const handleRevertChanges = useCallback(() => {
+    telemetry.log(DocumentChangesReverted, {scope: 'group', changeCount: changes.length})
     undoChange(group, rootDiff, docOperations)
     setConfirmRevertOpen(false)
-  }, [group, rootDiff, docOperations])
+  }, [changes.length, group, rootDiff, docOperations, telemetry])
 
   const handleRevertChangesConfirm = useCallback(() => {
     setConfirmRevertOpen(true)

--- a/packages/sanity/src/core/field/diff/components/FieldChange.tsx
+++ b/packages/sanity/src/core/field/diff/components/FieldChange.tsx
@@ -1,3 +1,4 @@
+import {useTelemetry} from '@sanity/telemetry/react'
 import {type ObjectSchemaType, type Path} from '@sanity/types'
 import {Stack} from '@sanity/ui'
 import {Fragment, type HTMLAttributes, startTransition, useCallback, useMemo, useState} from 'react'
@@ -12,6 +13,7 @@ import {
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {useDocumentPairPermissions} from '../../../store/grants/documentPairPermissions'
 import {type FieldChangeNode} from '../../types'
+import {DocumentChangesReverted} from '../__telemetry__/diff.telemetry'
 import {undoChange} from '../changes/undoChange'
 import {useDocumentChange} from '../hooks/useDocumentChange'
 import {ChangeBreadcrumb} from './ChangeBreadcrumb'
@@ -90,6 +92,7 @@ export function FieldChange(
     startTransition(() => _setButtonElement(element))
   }
   const {t} = useTranslation()
+  const telemetry = useTelemetry()
 
   const [permissions, isPermissionsLoading] = useDocumentPairPermissions({
     id: documentId,
@@ -99,9 +102,10 @@ export function FieldChange(
   })
 
   const handleRevertChanges = useCallback(() => {
+    telemetry.log(DocumentChangesReverted, {scope: 'field', changeCount: 1})
     undoChange(change, rootDiff, ops)
     setConfirmRevertOpen(false)
-  }, [change, rootDiff, ops])
+  }, [change, rootDiff, ops, telemetry])
 
   const handleRevertChangesConfirm = useCallback(() => {
     setConfirmRevertOpen(true)

--- a/packages/sanity/src/core/field/diff/components/__tests__/diff.telemetry.test.tsx
+++ b/packages/sanity/src/core/field/diff/components/__tests__/diff.telemetry.test.tsx
@@ -1,0 +1,220 @@
+import {render, screen} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {beforeAll, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {type FieldChangeNode, type GroupChangeNode} from '../../../types'
+import {DocumentChangesReverted} from '../../__telemetry__/diff.telemetry'
+import {ChangeList} from '../ChangeList'
+import {GroupChange} from '../ChangeResolver'
+import {FieldChange} from '../FieldChange'
+
+const mockTelemetryLog = vi.hoisted(() => vi.fn())
+const mockUndoChange = vi.hoisted(() => vi.fn())
+
+vi.mock('@sanity/telemetry/react', () => ({
+  useTelemetry: () => ({log: mockTelemetryLog}),
+}))
+
+const FieldWrapper = ({children}: {children: React.ReactNode}) => children
+
+vi.mock('../../hooks/useDocumentChange', () => ({
+  useDocumentChange: () => ({
+    documentId: 'doc-1',
+    schemaType: {name: 'article', jsonType: 'object'},
+    rootDiff: {},
+    isComparingCurrent: true,
+    value: {_id: 'doc-1'},
+    FieldWrapper,
+  }),
+}))
+
+vi.mock('../../../../hooks/useTargetDocumentState', () => ({
+  useTargetDocumentState: () => ({status: 'ready'}),
+  getPairTarget: () => undefined,
+  getTargetScopeId: () => undefined,
+}))
+
+vi.mock('../../../../hooks/useDocumentOperation', () => ({
+  useDocumentOperation: () => ({}),
+}))
+
+vi.mock('../../../../store/grants/documentPairPermissions', () => ({
+  useDocumentPairPermissions: () => [{granted: true}, false],
+}))
+
+vi.mock('../../../../i18n/hooks/useTranslation', () => ({
+  useTranslation: () => ({t: (key: string) => key}),
+}))
+
+vi.mock('../../../conditional-property/useConditionalProperty', () => ({
+  useConditionalProperty: ({checkProperty}: {checkProperty?: unknown}) => checkProperty === true,
+}))
+
+vi.mock('../../changes/undoChange', () => ({
+  undoChange: mockUndoChange,
+}))
+
+vi.mock('../../changes/buildChangeList', () => ({
+  buildObjectChangeList: () => [
+    {key: 'a', type: 'field', path: ['a']},
+    {key: 'b', type: 'field', path: ['b']},
+  ],
+}))
+
+// Render only the confirm/cancel controls so the revert flow can be driven without the popover.
+vi.mock('../RevertChangesConfirmDialog', () => ({
+  RevertChangesConfirmDialog: ({
+    onConfirm,
+    onCancel,
+  }: {
+    onConfirm: () => void
+    onCancel: () => void
+  }) => (
+    <div>
+      <button type="button" data-testid="confirm-revert" onClick={onConfirm}>
+        confirm
+      </button>
+      <button type="button" data-testid="cancel-revert" onClick={onCancel}>
+        cancel
+      </button>
+    </div>
+  ),
+}))
+
+// `GroupChange` shares a module with `ChangeResolver`, so only the resolver is stubbed out
+vi.mock(import('../ChangeResolver'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  ChangeResolver: () => null,
+}))
+vi.mock('../ChangeBreadcrumb', () => ({ChangeBreadcrumb: () => null}))
+vi.mock('../ValueError', () => ({ValueError: () => null}))
+vi.mock('../DiffInspectWrapper', () => ({
+  DiffInspectWrapper: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
+}))
+vi.mock('../RevertChangesButton', () => ({
+  RevertChangesButton: function RevertChangesButton() {
+    return null
+  },
+}))
+
+let wrapper: React.ComponentType<{children: React.ReactNode}>
+
+beforeAll(async () => {
+  wrapper = await createTestProvider()
+})
+
+describe('revert telemetry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('ChangeList (revert all)', () => {
+    const renderChangeList = () =>
+      render(
+        <ChangeList
+          diff={{} as never}
+          schemaType={{name: 'article', jsonType: 'object'} as never}
+        />,
+        {wrapper},
+      )
+
+    it('logs scope "all" with the total change count on confirm', async () => {
+      renderChangeList()
+
+      await userEvent.click(screen.getByTestId('confirm-revert'))
+
+      expect(mockTelemetryLog).toHaveBeenCalledWith(DocumentChangesReverted, {
+        scope: 'all',
+        changeCount: 2,
+      })
+      expect(mockUndoChange).toHaveBeenCalledTimes(1)
+    })
+
+    it('logs nothing when the revert is cancelled', async () => {
+      renderChangeList()
+
+      await userEvent.click(screen.getByTestId('cancel-revert'))
+
+      expect(mockTelemetryLog).not.toHaveBeenCalled()
+      expect(mockUndoChange).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('GroupChange (revert group)', () => {
+    const group = {
+      type: 'group',
+      key: 'group-key',
+      path: [],
+      titlePath: [],
+      // The nested changes are hidden so the group's own revert controls are the only ones rendered.
+      changes: [
+        {
+          key: 'c1',
+          type: 'field',
+          path: ['c1'],
+          diff: {},
+          schemaType: {jsonType: 'string', hidden: true},
+        },
+        {
+          key: 'c2',
+          type: 'field',
+          path: ['c2'],
+          diff: {},
+          schemaType: {jsonType: 'string', hidden: true},
+        },
+      ],
+    } as unknown as GroupChangeNode
+
+    it('logs scope "group" with the group change count on confirm', async () => {
+      render(<GroupChange change={group} />, {wrapper})
+
+      await userEvent.click(screen.getByTestId('confirm-revert'))
+
+      expect(mockTelemetryLog).toHaveBeenCalledWith(DocumentChangesReverted, {
+        scope: 'group',
+        changeCount: 2,
+      })
+    })
+
+    it('logs nothing when the revert is cancelled', async () => {
+      render(<GroupChange change={group} />, {wrapper})
+
+      await userEvent.click(screen.getByTestId('cancel-revert'))
+
+      expect(mockTelemetryLog).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('FieldChange (revert field)', () => {
+    const change = {
+      type: 'field',
+      key: 'field-key',
+      path: [],
+      titlePath: [],
+      showHeader: false,
+      error: {} as never,
+      diff: {} as never,
+      schemaType: {name: 'title', jsonType: 'string'},
+    } as unknown as FieldChangeNode
+
+    it('logs scope "field" with a change count of one on confirm', async () => {
+      render(<FieldChange change={change} />, {wrapper})
+
+      await userEvent.click(screen.getByTestId('confirm-revert'))
+
+      expect(mockTelemetryLog).toHaveBeenCalledWith(DocumentChangesReverted, {
+        scope: 'field',
+        changeCount: 1,
+      })
+    })
+
+    it('logs nothing when the revert is cancelled', async () => {
+      render(<FieldChange change={change} />, {wrapper})
+
+      await userEvent.click(screen.getByTestId('cancel-revert'))
+
+      expect(mockTelemetryLog).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/sanity/src/core/field/diff/components/__tests__/diff.telemetry.test.tsx
+++ b/packages/sanity/src/core/field/diff/components/__tests__/diff.telemetry.test.tsx
@@ -9,14 +9,38 @@ import {ChangeList} from '../ChangeList'
 import {GroupChange} from '../ChangeResolver'
 import {FieldChange} from '../FieldChange'
 
+interface MockChangeNode {
+  key: string
+  type: 'field' | 'group'
+  path: string[]
+  titlePath?: string[]
+  changes?: MockChangeNode[]
+}
+
 const mockTelemetryLog = vi.hoisted(() => vi.fn())
 const mockUndoChange = vi.hoisted(() => vi.fn())
+const mockBuildObjectChangeList = vi.hoisted(() =>
+  vi.fn((): MockChangeNode[] => [
+    {
+      key: 'root',
+      type: 'group',
+      path: [],
+      titlePath: [],
+      changes: [
+        {key: 'a', type: 'field', path: ['a']},
+        {key: 'b', type: 'field', path: ['b']},
+      ],
+    },
+  ]),
+)
 
 vi.mock('@sanity/telemetry/react', () => ({
   useTelemetry: () => ({log: mockTelemetryLog}),
 }))
 
-const FieldWrapper = ({children}: {children: React.ReactNode}) => children
+function FieldWrapper({children}: {children: React.ReactNode}) {
+  return children
+}
 
 vi.mock('../../hooks/useDocumentChange', () => ({
   useDocumentChange: () => ({
@@ -56,21 +80,17 @@ vi.mock('../../changes/undoChange', () => ({
 }))
 
 vi.mock('../../changes/buildChangeList', () => ({
-  buildObjectChangeList: () => [
-    {key: 'a', type: 'field', path: ['a']},
-    {key: 'b', type: 'field', path: ['b']},
-  ],
+  buildObjectChangeList: mockBuildObjectChangeList,
 }))
 
-// Render only the confirm/cancel controls so the revert flow can be driven without the popover.
-vi.mock('../RevertChangesConfirmDialog', () => ({
-  RevertChangesConfirmDialog: ({
-    onConfirm,
-    onCancel,
-  }: {
-    onConfirm: () => void
-    onCancel: () => void
-  }) => (
+function RevertChangesConfirmDialogStub({
+  onConfirm,
+  onCancel,
+}: {
+  onConfirm: () => void
+  onCancel: () => void
+}) {
+  return (
     <div>
       <button type="button" data-testid="confirm-revert" onClick={onConfirm}>
         confirm
@@ -79,24 +99,47 @@ vi.mock('../RevertChangesConfirmDialog', () => ({
         cancel
       </button>
     </div>
-  ),
+  )
+}
+
+// Render only the confirm/cancel controls so the revert flow can be driven without the popover.
+vi.mock('../RevertChangesConfirmDialog', () => ({
+  RevertChangesConfirmDialog: RevertChangesConfirmDialogStub,
 }))
+
+function ChangeResolverStub() {
+  return null
+}
 
 // `GroupChange` shares a module with `ChangeResolver`, so only the resolver is stubbed out
 vi.mock(import('../ChangeResolver'), async (importOriginal) => ({
   ...(await importOriginal()),
-  ChangeResolver: () => null,
+  ChangeResolver: ChangeResolverStub,
 }))
-vi.mock('../ChangeBreadcrumb', () => ({ChangeBreadcrumb: () => null}))
-vi.mock('../ValueError', () => ({ValueError: () => null}))
-vi.mock('../DiffInspectWrapper', () => ({
-  DiffInspectWrapper: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
-}))
-vi.mock('../RevertChangesButton', () => ({
-  RevertChangesButton: function RevertChangesButton() {
-    return null
-  },
-}))
+
+function ChangeBreadcrumbStub() {
+  return null
+}
+
+vi.mock('../ChangeBreadcrumb', () => ({ChangeBreadcrumb: ChangeBreadcrumbStub}))
+
+function ValueErrorStub() {
+  return null
+}
+
+vi.mock('../ValueError', () => ({ValueError: ValueErrorStub}))
+
+function DiffInspectWrapperStub({children}: {children: React.ReactNode}) {
+  return <div>{children}</div>
+}
+
+vi.mock('../DiffInspectWrapper', () => ({DiffInspectWrapper: DiffInspectWrapperStub}))
+
+function RevertChangesButtonStub() {
+  return null
+}
+
+vi.mock('../RevertChangesButton', () => ({RevertChangesButton: RevertChangesButtonStub}))
 
 let wrapper: React.ComponentType<{children: React.ReactNode}>
 
@@ -119,7 +162,7 @@ describe('revert telemetry', () => {
         {wrapper},
       )
 
-    it('logs scope "all" with the total change count on confirm', async () => {
+    it('logs scope "all" with the flat leaf change count on confirm', async () => {
       renderChangeList()
 
       await userEvent.click(screen.getByTestId('confirm-revert'))
@@ -129,6 +172,39 @@ describe('revert telemetry', () => {
         changeCount: 2,
       })
       expect(mockUndoChange).toHaveBeenCalledTimes(1)
+    })
+
+    it('counts flat leaf changes, not direct children, when a group nests another group', async () => {
+      mockBuildObjectChangeList.mockReturnValueOnce([
+        {
+          key: 'root',
+          type: 'group',
+          path: [],
+          titlePath: [],
+          changes: [
+            {key: 'a', type: 'field', path: ['a']},
+            {
+              key: 'nested',
+              type: 'group',
+              path: ['nested'],
+              titlePath: [],
+              changes: [
+                {key: 'b', type: 'field', path: ['nested', 'b']},
+                {key: 'c', type: 'field', path: ['nested', 'c']},
+              ],
+            },
+          ],
+        },
+      ])
+
+      renderChangeList()
+
+      await userEvent.click(screen.getByTestId('confirm-revert'))
+
+      expect(mockTelemetryLog).toHaveBeenCalledWith(DocumentChangesReverted, {
+        scope: 'all',
+        changeCount: 3,
+      })
     })
 
     it('logs nothing when the revert is cancelled', async () => {
@@ -176,14 +252,6 @@ describe('revert telemetry', () => {
         changeCount: 2,
       })
     })
-
-    it('logs nothing when the revert is cancelled', async () => {
-      render(<GroupChange change={group} />, {wrapper})
-
-      await userEvent.click(screen.getByTestId('cancel-revert'))
-
-      expect(mockTelemetryLog).not.toHaveBeenCalled()
-    })
   })
 
   describe('FieldChange (revert field)', () => {
@@ -207,14 +275,6 @@ describe('revert telemetry', () => {
         scope: 'field',
         changeCount: 1,
       })
-    })
-
-    it('logs nothing when the revert is cancelled', async () => {
-      render(<FieldChange change={change} />, {wrapper})
-
-      await userEvent.click(screen.getByTestId('cancel-revert'))
-
-      expect(mockTelemetryLog).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/sanity/src/core/form/components/EnhancedObjectDialog.test.tsx
+++ b/packages/sanity/src/core/form/components/EnhancedObjectDialog.test.tsx
@@ -205,4 +205,18 @@ describe('EnhancedObjectDialog: open telemetry', () => {
 
     expect(log).toHaveBeenCalledTimes(1)
   })
+
+  it('logs once when the stack empties while the dialog stays mounted', () => {
+    const {rerender} = render(objectDialog({path: ['arr', {_key: 'k'}]}))
+
+    mockState.stack = [{id: 'dialog-1', path: ['arr', {_key: 'k'}]}]
+    rerender(objectDialog({path: ['arr', {_key: 'k'}]}))
+
+    // navigateTo filters out entries at or below the target depth, so selecting this dialog's own
+    // breadcrumb drops its entry and empties the stack without unmounting it.
+    mockState.stack = []
+    rerender(objectDialog({path: ['arr', {_key: 'k'}]}))
+
+    expect(log).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/sanity/src/core/form/components/EnhancedObjectDialog.test.tsx
+++ b/packages/sanity/src/core/form/components/EnhancedObjectDialog.test.tsx
@@ -1,6 +1,8 @@
+import {type Path} from '@sanity/types'
 import {render} from '@testing-library/react'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
+import {NestedDialogOpened} from '../studio/tree-editing/__telemetry__/nestedObjects.telemetry'
 import {EnhancedObjectDialog} from './EnhancedObjectDialog'
 
 const close = vi.fn()
@@ -9,11 +11,13 @@ const log = vi.fn()
 
 let mockState: {isTop: boolean; stack: {id: string; path: (string | {_key: string})[]}[]}
 
+// The real hook falls back to a fresh array when no DialogStackProvider is mounted,
+// so the mock deliberately returns a new array on every render.
 vi.mock('../../hooks/useDialogStack', () => ({
   useDialogStack: () => ({
     dialogId: 'dialog-1',
     topEntry: mockState.stack[mockState.stack.length - 1] ?? null,
-    stack: mockState.stack,
+    stack: [...mockState.stack],
     isTop: mockState.isTop,
     close,
     navigateTo,
@@ -24,8 +28,11 @@ vi.mock('../useFormBuilder', () => ({
   useFormBuilder: () => ({__internal: {inspectOpen: false}}),
 }))
 
+// The real hook reads the logger off a context, so the mock keeps one stable instance.
+const telemetryLogger = {log}
+
 vi.mock('@sanity/telemetry/react', () => ({
-  useTelemetry: () => ({log}),
+  useTelemetry: () => telemetryLogger,
 }))
 
 // Keep the real useGlobalKeyDown (it registers the window keydown listener under
@@ -56,6 +63,18 @@ function renderDialog() {
     <EnhancedObjectDialog type="dialog" header="Header" width={1}>
       <div />
     </EnhancedObjectDialog>,
+  )
+}
+
+function ObjectInput(_props: {path?: Path; absolutePath?: Path}) {
+  return <div />
+}
+
+function objectDialog(props: {path?: Path; absolutePath?: Path}) {
+  return (
+    <EnhancedObjectDialog type="dialog" header="Header" width={1}>
+      <ObjectInput {...props} />
+    </EnhancedObjectDialog>
   )
 }
 
@@ -148,5 +167,42 @@ describe('EnhancedObjectDialog: Cmd/Ctrl+ArrowUp handler', () => {
 
     expect(close).not.toHaveBeenCalled()
     expect(navigateTo).not.toHaveBeenCalled()
+  })
+})
+
+describe('EnhancedObjectDialog: open telemetry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockState = {isTop: true, stack: []}
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('logs the serialized field path of the object being opened', () => {
+    render(objectDialog({path: ['arr', {_key: 'k'}, 'title']}))
+
+    expect(log).toHaveBeenCalledWith(NestedDialogOpened, {path: 'arr[_key=="k"].title'})
+  })
+
+  it('prefers the absolute path over the relative one', () => {
+    render(objectDialog({path: ['title'], absolutePath: ['body', {_key: 'block'}, 'title']}))
+
+    expect(log).toHaveBeenCalledWith(NestedDialogOpened, {path: 'body[_key=="block"].title'})
+  })
+
+  it('logs an empty path when the child exposes none', () => {
+    render(objectDialog({}))
+
+    expect(log).toHaveBeenCalledWith(NestedDialogOpened, {path: ''})
+  })
+
+  it('logs once per open, not once per render', () => {
+    const {rerender} = render(objectDialog({path: ['arr', {_key: 'k'}]}))
+
+    rerender(objectDialog({path: ['arr', {_key: 'k'}]}))
+
+    expect(log).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
+++ b/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
@@ -112,10 +112,17 @@ export function EnhancedObjectDialog(props: PopoverProps | DialogProps): React.J
 
   const currentPathString = pathToString(currentPath ?? EMPTY_ARRAY)
 
+  // navigateTo drops entries at or below the target depth, so the stack can empty while this dialog
+  // stays mounted. Without the ref that reads as a second open.
+  const hasLoggedOpen = useRef(false)
+
   useEffect(() => {
-    if (stack.length === 0) {
-      telemetry.log(NestedDialogOpened, {path: currentPathString})
+    if (hasLoggedOpen.current || stack.length > 0) {
+      return
     }
+
+    hasLoggedOpen.current = true
+    telemetry.log(NestedDialogOpened, {path: currentPathString})
   }, [currentPathString, stack.length, telemetry])
 
   const contents = (

--- a/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
+++ b/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
@@ -10,6 +10,7 @@ import {pathToString} from '../../field/paths/helpers'
 import {useDialogStack} from '../../hooks/useDialogStack'
 import {PresenceOverlay} from '../../presence/overlay/PresenceOverlay'
 import {isNativeEditableElement} from '../../studio/copyPaste/utils'
+import {EMPTY_ARRAY} from '../../util/empty'
 import {VirtualizerScrollInstanceProvider} from '../inputs/arrays/ArrayOfObjectsInput/List/VirtualizerScrollInstanceProvider'
 import {
   NestedDialogClosed,
@@ -109,14 +110,13 @@ export function EnhancedObjectDialog(props: PopoverProps | DialogProps): React.J
     setDocumentScrollElement(element)
   }, [])
 
-  // Log telemetry when the dialog opens
+  const currentPathString = pathToString(currentPath ?? EMPTY_ARRAY)
+
   useEffect(() => {
     if (stack.length === 0) {
-      telemetry.log(NestedDialogOpened, {
-        path: pathToString([]),
-      })
+      telemetry.log(NestedDialogOpened, {path: currentPathString})
     }
-  }, [stack, telemetry])
+  }, [currentPathString, stack.length, telemetry])
 
   const contents = (
     <PresenceOverlay margins={PRESENCE_MARGINS}>

--- a/packages/sanity/src/core/form/studio/tree-editing/__telemetry__/nestedObjects.telemetry.ts
+++ b/packages/sanity/src/core/form/studio/tree-editing/__telemetry__/nestedObjects.telemetry.ts
@@ -1,6 +1,7 @@
 import {defineEvent} from '@sanity/telemetry'
 
 interface NestedDialogOpenedInfo {
+  /** Serialized document field path of the object the interaction targets */
   path: string
 }
 

--- a/packages/sanity/src/core/studio/copyPaste/__telemetry__/copyPaste.telemetry.ts
+++ b/packages/sanity/src/core/studio/copyPaste/__telemetry__/copyPaste.telemetry.ts
@@ -1,10 +1,15 @@
 import {defineEvent} from '@sanity/telemetry'
 
+import {type BaseOptions} from '../types'
+
+/**
+ * The context the action was triggered from. Emitted verbatim, so the camelCase
+ * spelling is fixed by both the public options type and the existing time series.
+ */
+export type CopyPasteContext = BaseOptions['context']['source']
+
 interface FieldCopiedInfo {
-  /**
-   * The context the action was triggered from
-   */
-  context: 'fieldAction' | 'documentFieldAction' | 'keyboardShortcut' | 'arrayItem' | 'unknown'
+  context: CopyPasteContext
   /**
    * The schema type(s) that was copied
    */
@@ -12,10 +17,7 @@ interface FieldCopiedInfo {
 }
 
 interface FieldPastedInfo {
-  /**
-   * The context the action was triggered from
-   */
-  context: 'fieldAction' | 'documentFieldAction' | 'keyboardShortcut' | 'arrayItem' | 'unknown'
+  context: CopyPasteContext
   /**
    * The schema(s) type that was copied
    */

--- a/packages/sanity/src/presentation/__tests__/useParams.test.ts
+++ b/packages/sanity/src/presentation/__tests__/useParams.test.ts
@@ -1,0 +1,84 @@
+import {act, renderHook} from '@testing-library/react'
+import {type RouterState, type SearchParam} from 'sanity/router'
+import {describe, expect, it, vi} from 'vitest'
+
+import {type PresentationNavigateOptions} from '../types'
+import {useParams} from '../useParams'
+
+const routerState = {
+  id: 'book-1',
+  type: 'book',
+  _searchParams: [
+    ['perspective', 'drafts'],
+    ['preview', '/index'],
+    ['viewport', 'mobile'],
+    ['changesInspectorTab', 'review'],
+    ['comment', 'comment-1'],
+    ['unrecognised', 'dropped'],
+  ] satisfies SearchParam[],
+}
+
+function navigate(options: PresentationNavigateOptions): SearchParam[] {
+  const routerNavigate = vi.fn()
+
+  const {result} = renderHook(() =>
+    useParams({
+      initialPreviewUrl: new URL('https://example.com'),
+      routerNavigate,
+      routerState,
+      routerSearchParams: Object.fromEntries(routerState._searchParams),
+      frameStateRef: {current: {title: undefined, url: undefined}},
+    }),
+  )
+
+  act(() => result.current.navigate(options))
+
+  const [nextRouterState] = routerNavigate.mock.calls[0] as [RouterState]
+  return nextRouterState._searchParams ?? []
+}
+
+function definedParams(searchParams: SearchParam[]): Record<string, string> {
+  return Object.fromEntries(searchParams.filter(([, value]) => value !== undefined))
+}
+
+describe('useParams', () => {
+  it('maintains presentation and document pane params when the document is unchanged', () => {
+    const searchParams = navigate({state: {id: 'book-1', type: 'book'}})
+
+    expect(definedParams(searchParams)).toEqual({
+      perspective: 'drafts',
+      preview: '/index',
+      viewport: 'mobile',
+      changesInspectorTab: 'review',
+      comment: 'comment-1',
+    })
+  })
+
+  it('drops document pane params when navigating to another document', () => {
+    const searchParams = navigate({state: {id: 'book-2', type: 'book'}})
+
+    expect(definedParams(searchParams)).toEqual({
+      perspective: 'drafts',
+      preview: '/index',
+      viewport: 'mobile',
+    })
+  })
+
+  it('lets explicit params override the maintained ones', () => {
+    const searchParams = navigate({
+      state: {id: 'book-1', type: 'book'},
+      params: {changesInspectorTab: 'history', viewport: 'desktop'},
+    })
+
+    expect(definedParams(searchParams)).toMatchObject({
+      changesInspectorTab: 'history',
+      viewport: 'desktop',
+    })
+  })
+
+  it('records maintained keys with no current value as undefined', () => {
+    const searchParams = navigate({state: {id: 'book-1', type: 'book'}})
+
+    expect(searchParams).toContainEqual(['inspect', undefined])
+  })
+})

--- a/packages/sanity/src/presentation/useParams.ts
+++ b/packages/sanity/src/presentation/useParams.ts
@@ -187,13 +187,12 @@ export function useParams({
         ...(isSameDocument(nextState) ? maintainOnSameDocument : []),
       ] satisfies (keyof CombinedSearchParams)[]
 
-      const maintainedParams = maintainedParamKeys.reduce<Record<string, string | undefined>>(
-        (acc, key) => {
-          acc[key] = currentParams[key]
-          return acc
-        },
-        {},
-      )
+      const maintainedParams = maintainedParamKeys.reduce<
+        Partial<Record<keyof CombinedSearchParams, string>>
+      >((acc, key) => {
+        acc[key] = currentParams[key]
+        return acc
+      }, {})
 
       // If params are provided, merge them with the maintained params
       const nextParams = {...maintainedParams, ...params}

--- a/packages/sanity/src/presentation/useParams.ts
+++ b/packages/sanity/src/presentation/useParams.ts
@@ -175,7 +175,7 @@ export function useParams({
         type: current.type,
         path: current.path,
       } satisfies PresentationStateParams
-      const currentParams = Object.fromEntries(current._searchParams || []) as CombinedSearchParams
+      const currentParams: Record<string, string> = Object.fromEntries(current._searchParams || [])
 
       // If state is provided, replace the current state with the provided
       // state, otherwise maintain the current state
@@ -187,12 +187,13 @@ export function useParams({
         ...(isSameDocument(nextState) ? maintainOnSameDocument : []),
       ] satisfies (keyof CombinedSearchParams)[]
 
-      const maintainedParams = maintainedParamKeys.reduce((acc, key) => {
-        // @ts-expect-error changesInspectorTab union type doesn't play nicely
-        // here, if it were just a string it would be fine
-        acc[key] = currentParams[key]
-        return acc
-      }, {} as Partial<CombinedSearchParams>)
+      const maintainedParams = maintainedParamKeys.reduce<Record<string, string | undefined>>(
+        (acc, key) => {
+          acc[key] = currentParams[key]
+          return acc
+        },
+        {},
+      )
 
       // If params are provided, merge them with the maintained params
       const nextParams = {...maintainedParams, ...params}

--- a/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
@@ -25,6 +25,7 @@ import {
 
 import {type View} from '../../structureBuilder/types'
 import {type PaneMenuItem, type PaneMenuItemGroup} from '../../types'
+import {type DocumentHistoryOpenPath} from './__telemetry__/documentPanes.telemetry'
 
 /** @internal */
 export interface DocumentPaneContextValue extends Pick<NodeChronologyProps, 'hasUpstreamVersion'> {
@@ -59,7 +60,7 @@ export interface DocumentPaneContextValue extends Pick<NodeChronologyProps, 'has
   onChange: (event: PatchEvent) => void
   onFocus: (pathOrEvent: Path) => void
   onHistoryClose: () => void
-  onHistoryOpen: () => void
+  onHistoryOpen: (path?: DocumentHistoryOpenPath) => void
   onInspectClose: () => void
   onMenuAction: (item: PaneMenuItem) => void
   onPaneClose: () => void

--- a/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
@@ -60,7 +60,7 @@ export interface DocumentPaneContextValue extends Pick<NodeChronologyProps, 'has
   onChange: (event: PatchEvent) => void
   onFocus: (pathOrEvent: Path) => void
   onHistoryClose: () => void
-  onHistoryOpen: (path?: DocumentHistoryOpenPath) => void
+  onHistoryOpen: (path: DocumentHistoryOpenPath) => void
   onInspectClose: () => void
   onMenuAction: (item: PaneMenuItem) => void
   onPaneClose: () => void

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -480,7 +480,7 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
       }
 
       if (item.action === 'reviewChanges') {
-        handleHistoryOpen()
+        handleHistoryOpen('pane_menu')
         return true
       }
 

--- a/packages/sanity/src/structure/panes/document/__telemetry__/documentPanes.telemetry.ts
+++ b/packages/sanity/src/structure/panes/document/__telemetry__/documentPanes.telemetry.ts
@@ -1,5 +1,47 @@
 import {defineEvent} from '@sanity/telemetry'
 
+import {type ChangesInspectorTab} from '../constants'
+
+/**
+ * Values belong to the shared `path` vocabulary documented in `docs/TELEMETRY.md`.
+ *
+ * @internal
+ */
+export type DocumentHistoryOpenPath = 'status_line' | 'change_indicator' | 'pane_menu' | 'url'
+
+interface DocumentHistoryInspectorOpenedInfo {
+  /** Tab shown on open */
+  tab: ChangesInspectorTab
+  /** What triggered the open; `url` means a deep link rather than an in-studio interaction */
+  path: DocumentHistoryOpenPath
+}
+
+/**
+ * @internal
+ */
+export const DocumentHistoryInspectorOpened = defineEvent<DocumentHistoryInspectorOpenedInfo>({
+  name: 'Document History Inspector Opened',
+  version: 1,
+  description: 'User opened the history and review changes inspector',
+})
+
+interface DocumentHistoryInspectorTabChangedInfo {
+  /** Tab being switched to */
+  tab: ChangesInspectorTab
+  /** Tab being switched away from */
+  previousTab: ChangesInspectorTab
+}
+
+/**
+ * @internal
+ */
+export const DocumentHistoryInspectorTabChanged =
+  defineEvent<DocumentHistoryInspectorTabChangedInfo>({
+    name: 'Document History Inspector Tab Changed',
+    version: 1,
+    description: 'User changed the active tab in the history and review changes inspector',
+  })
+
 /**
  * @internal
  */

--- a/packages/sanity/src/structure/panes/document/__tests__/useDocumentPaneInspector.test.tsx
+++ b/packages/sanity/src/structure/panes/document/__tests__/useDocumentPaneInspector.test.tsx
@@ -1,10 +1,12 @@
 import {act, renderHook} from '@testing-library/react'
-import {afterEach, describe, expect, it, vi} from 'vitest'
+import {StrictMode} from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {type PaneMenuItem} from '../../../types'
 import {
   DocumentHistoryInspectorOpened,
   DocumentHistoryInspectorTabChanged,
+  type DocumentHistoryOpenPath,
 } from '../__telemetry__/documentPanes.telemetry'
 import {
   HISTORY_INSPECTOR_NAME,
@@ -23,7 +25,7 @@ vi.mock('@sanity/telemetry/react', () => ({
 const validationInspector = {name: VALIDATION_INSPECTOR_NAME}
 
 const mockSource = {
-  document: {inspectors: vi.fn(() => [changesInspector, validationInspector])},
+  document: {inspectors: () => [changesInspector, validationInspector]},
 }
 
 vi.mock('sanity', () => ({
@@ -41,6 +43,11 @@ function setup(initialParams: Record<string, string | undefined> = {}) {
   const paramsHolder = {current: {...initialParams}}
   const setParams = vi.fn()
 
+  // The real router navigates on a `setTimeout`, so params land a tick after the handler ran.
+  setParams.mockImplementation((next: Record<string, string | undefined>) => {
+    paramsHolder.current = {...paramsHolder.current, ...next}
+  })
+
   const view = renderHook(
     ({params}: {params: Record<string, string | undefined>}) =>
       useDocumentPaneInspector({
@@ -49,13 +56,8 @@ function setup(initialParams: Record<string, string | undefined> = {}) {
         params,
         setParams,
       }),
-    {initialProps: {params: paramsHolder.current}},
+    {initialProps: {params: paramsHolder.current}, wrapper: StrictMode},
   )
-
-  // The real router navigates on a `setTimeout`, so params land a tick after the handler ran.
-  setParams.mockImplementation((next: Record<string, string | undefined>) => {
-    paramsHolder.current = {...paramsHolder.current, ...next}
-  })
 
   const flushParams = () => view.rerender({params: paramsHolder.current})
 
@@ -72,44 +74,24 @@ function inspectMenuItem(inspectorName: string): PaneMenuItem {
 }
 
 describe('useDocumentPaneInspector telemetry', () => {
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('logs a status-line open when the status button opens the pane', () => {
-    const {result} = setup()
+  it.each(['status_line', 'change_indicator'] satisfies DocumentHistoryOpenPath[])(
+    'logs a %s open with the path it is given',
+    (path) => {
+      const {result} = setup()
 
-    act(() => result.current.handleHistoryOpen('status_line'))
+      act(() => result.current.handleHistoryOpen(path))
 
-    expect(mockLog).toHaveBeenCalledTimes(1)
-    expect(mockLog).toHaveBeenCalledWith(DocumentHistoryInspectorOpened, {
-      tab: 'review',
-      path: 'status_line',
-    })
-  })
-
-  it('logs a change-indicator open with the path it is given', () => {
-    const {result} = setup()
-
-    act(() => result.current.handleHistoryOpen('change_indicator'))
-
-    expect(mockLog).toHaveBeenCalledTimes(1)
-    expect(mockLog).toHaveBeenCalledWith(DocumentHistoryInspectorOpened, {
-      tab: 'review',
-      path: 'change_indicator',
-    })
-  })
-
-  it('defaults handleHistoryOpen attribution to status-line', () => {
-    const {result} = setup()
-
-    act(() => result.current.handleHistoryOpen())
-
-    expect(mockLog).toHaveBeenCalledWith(DocumentHistoryInspectorOpened, {
-      tab: 'review',
-      path: 'status_line',
-    })
-  })
+      expect(mockLog).toHaveBeenCalledTimes(1)
+      expect(mockLog).toHaveBeenCalledWith(DocumentHistoryInspectorOpened, {
+        tab: 'review',
+        path,
+      })
+    },
+  )
 
   it('logs a pane-menu open with the tab left at the current param', () => {
     const {result} = setup()
@@ -156,15 +138,6 @@ describe('useDocumentPaneInspector telemetry', () => {
     expect(mockLog).not.toHaveBeenCalled()
   })
 
-  it('does not double-fire when the handler sets both the inspector and the params', () => {
-    const {result, flushParams} = setup()
-
-    act(() => result.current.handleHistoryOpen('status_line'))
-    flushParams()
-
-    expect(mockLog).toHaveBeenCalledTimes(1)
-  })
-
   it('does not log a tab change when the tab param lands after the pane opened on review', () => {
     const {result, flushParams} = setup()
 
@@ -179,23 +152,6 @@ describe('useDocumentPaneInspector telemetry', () => {
     flushParams()
 
     expect(mockLog).toHaveBeenCalledTimes(1)
-  })
-
-  it('logs a tab change when the status line switches an already-open pane to review', () => {
-    const {result, flushParams} = setup({
-      inspect: HISTORY_INSPECTOR_NAME,
-      changesInspectorTab: 'history',
-    })
-    mockLog.mockClear()
-
-    act(() => result.current.handleHistoryOpen('status_line'))
-    flushParams()
-
-    expect(mockLog).toHaveBeenCalledTimes(1)
-    expect(mockLog).toHaveBeenCalledWith(DocumentHistoryInspectorTabChanged, {
-      tab: 'review',
-      previousTab: 'history',
-    })
   })
 
   it('logs one tab change per switch, each against the tab it left', () => {

--- a/packages/sanity/src/structure/panes/document/__tests__/useDocumentPaneInspector.test.tsx
+++ b/packages/sanity/src/structure/panes/document/__tests__/useDocumentPaneInspector.test.tsx
@@ -28,8 +28,10 @@ const mockSource = {
   document: {inspectors: () => [changesInspector, validationInspector]},
 }
 
+// The real changesInspector is used below, and it reaches for useTranslation in its menu item.
 vi.mock('sanity', () => ({
   useSource: () => mockSource,
+  useTranslation: () => ({t: (key: string) => key}),
 }))
 
 vi.mock('../../../useStructureTool', () => ({

--- a/packages/sanity/src/structure/panes/document/__tests__/useDocumentPaneInspector.test.tsx
+++ b/packages/sanity/src/structure/panes/document/__tests__/useDocumentPaneInspector.test.tsx
@@ -1,0 +1,302 @@
+import {act, renderHook} from '@testing-library/react'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import {type PaneMenuItem} from '../../../types'
+import {
+  DocumentHistoryInspectorOpened,
+  DocumentHistoryInspectorTabChanged,
+} from '../__telemetry__/documentPanes.telemetry'
+import {
+  HISTORY_INSPECTOR_NAME,
+  INSPECT_ACTION_PREFIX,
+  VALIDATION_INSPECTOR_NAME,
+} from '../constants'
+import {changesInspector} from '../inspectors/changes'
+import {useDocumentPaneInspector} from '../useDocumentPaneInspector'
+
+const mockLog = vi.fn()
+
+vi.mock('@sanity/telemetry/react', () => ({
+  useTelemetry: () => ({log: mockLog}),
+}))
+
+const validationInspector = {name: VALIDATION_INSPECTOR_NAME}
+
+const mockSource = {
+  document: {inspectors: vi.fn(() => [changesInspector, validationInspector])},
+}
+
+vi.mock('sanity', () => ({
+  useSource: () => mockSource,
+}))
+
+vi.mock('../../../useStructureTool', () => ({
+  useStructureTool: () => ({features: {reviewChanges: true}}),
+}))
+
+// The inspector's own onOpen / onClose rewrite the tab params, so the real ones are under test here.
+vi.mock('../inspectors/changes/ChangesTabs', () => ({ChangesTabs: () => null}))
+
+function setup(initialParams: Record<string, string | undefined> = {}) {
+  const paramsHolder = {current: {...initialParams}}
+  const setParams = vi.fn()
+
+  const view = renderHook(
+    ({params}: {params: Record<string, string | undefined>}) =>
+      useDocumentPaneInspector({
+        documentId: 'doc-1',
+        documentType: 'article',
+        params,
+        setParams,
+      }),
+    {initialProps: {params: paramsHolder.current}},
+  )
+
+  // The real router navigates on a `setTimeout`, so params land a tick after the handler ran.
+  setParams.mockImplementation((next: Record<string, string | undefined>) => {
+    paramsHolder.current = {...paramsHolder.current, ...next}
+  })
+
+  const flushParams = () => view.rerender({params: paramsHolder.current})
+
+  const setParamsExternally = (next: Record<string, string | undefined>) => {
+    paramsHolder.current = {...paramsHolder.current, ...next}
+    flushParams()
+  }
+
+  return {...view, setParams, flushParams, setParamsExternally}
+}
+
+function inspectMenuItem(inspectorName: string): PaneMenuItem {
+  return {action: `${INSPECT_ACTION_PREFIX}${inspectorName}`} as PaneMenuItem
+}
+
+describe('useDocumentPaneInspector telemetry', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('logs a status-line open when the status button opens the pane', () => {
+    const {result} = setup()
+
+    act(() => result.current.handleHistoryOpen('status_line'))
+
+    expect(mockLog).toHaveBeenCalledTimes(1)
+    expect(mockLog).toHaveBeenCalledWith(DocumentHistoryInspectorOpened, {
+      tab: 'review',
+      path: 'status_line',
+    })
+  })
+
+  it('logs a change-indicator open with the path it is given', () => {
+    const {result} = setup()
+
+    act(() => result.current.handleHistoryOpen('change_indicator'))
+
+    expect(mockLog).toHaveBeenCalledTimes(1)
+    expect(mockLog).toHaveBeenCalledWith(DocumentHistoryInspectorOpened, {
+      tab: 'review',
+      path: 'change_indicator',
+    })
+  })
+
+  it('defaults handleHistoryOpen attribution to status-line', () => {
+    const {result} = setup()
+
+    act(() => result.current.handleHistoryOpen())
+
+    expect(mockLog).toHaveBeenCalledWith(DocumentHistoryInspectorOpened, {
+      tab: 'review',
+      path: 'status_line',
+    })
+  })
+
+  it('logs a pane-menu open with the tab left at the current param', () => {
+    const {result} = setup()
+
+    act(() => {
+      result.current.handleInspectorAction(inspectMenuItem(HISTORY_INSPECTOR_NAME))
+    })
+
+    expect(mockLog).toHaveBeenCalledTimes(1)
+    expect(mockLog).toHaveBeenCalledWith(DocumentHistoryInspectorOpened, {
+      tab: 'history',
+      path: 'pane_menu',
+    })
+  })
+
+  it('logs a url open when mounted with the inspector already open', () => {
+    setup({inspect: HISTORY_INSPECTOR_NAME, changesInspectorTab: 'review'})
+
+    expect(mockLog).toHaveBeenCalledTimes(1)
+    expect(mockLog).toHaveBeenCalledWith(DocumentHistoryInspectorOpened, {
+      tab: 'review',
+      path: 'url',
+    })
+  })
+
+  it('does not log when the pane closes', () => {
+    const {result} = setup()
+
+    act(() => result.current.handleHistoryOpen('status_line'))
+    mockLog.mockClear()
+
+    act(() => result.current.handleHistoryClose())
+
+    expect(mockLog).not.toHaveBeenCalled()
+  })
+
+  it('does not log when a different inspector opens', () => {
+    const {result} = setup()
+
+    act(() => {
+      result.current.handleInspectorAction(inspectMenuItem(VALIDATION_INSPECTOR_NAME))
+    })
+
+    expect(mockLog).not.toHaveBeenCalled()
+  })
+
+  it('does not double-fire when the handler sets both the inspector and the params', () => {
+    const {result, flushParams} = setup()
+
+    act(() => result.current.handleHistoryOpen('status_line'))
+    flushParams()
+
+    expect(mockLog).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not log a tab change when the tab param lands after the pane opened on review', () => {
+    const {result, flushParams} = setup()
+
+    act(() => result.current.handleHistoryOpen('status_line'))
+
+    expect(mockLog).toHaveBeenCalledTimes(1)
+    expect(mockLog).toHaveBeenCalledWith(DocumentHistoryInspectorOpened, {
+      tab: 'review',
+      path: 'status_line',
+    })
+
+    flushParams()
+
+    expect(mockLog).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs a tab change when the status line switches an already-open pane to review', () => {
+    const {result, flushParams} = setup({
+      inspect: HISTORY_INSPECTOR_NAME,
+      changesInspectorTab: 'history',
+    })
+    mockLog.mockClear()
+
+    act(() => result.current.handleHistoryOpen('status_line'))
+    flushParams()
+
+    expect(mockLog).toHaveBeenCalledTimes(1)
+    expect(mockLog).toHaveBeenCalledWith(DocumentHistoryInspectorTabChanged, {
+      tab: 'review',
+      previousTab: 'history',
+    })
+  })
+
+  it('logs one tab change per switch, each against the tab it left', () => {
+    const {result, flushParams, setParamsExternally} = setup({
+      inspect: HISTORY_INSPECTOR_NAME,
+      changesInspectorTab: 'history',
+    })
+    mockLog.mockClear()
+
+    act(() => result.current.handleHistoryOpen('status_line'))
+    flushParams()
+
+    expect(mockLog).toHaveBeenCalledTimes(1)
+    expect(mockLog).toHaveBeenLastCalledWith(DocumentHistoryInspectorTabChanged, {
+      tab: 'review',
+      previousTab: 'history',
+    })
+
+    setParamsExternally({changesInspectorTab: 'history'})
+
+    expect(mockLog).toHaveBeenCalledTimes(2)
+    expect(mockLog).toHaveBeenLastCalledWith(DocumentHistoryInspectorTabChanged, {
+      tab: 'history',
+      previousTab: 'review',
+    })
+  })
+
+  it('logs a tab change when the tab list writes the tab param', () => {
+    const {setParamsExternally} = setup({
+      inspect: HISTORY_INSPECTOR_NAME,
+      changesInspectorTab: 'history',
+    })
+    mockLog.mockClear()
+
+    setParamsExternally({changesInspectorTab: 'review'})
+
+    expect(mockLog).toHaveBeenCalledTimes(1)
+    expect(mockLog).toHaveBeenCalledWith(DocumentHistoryInspectorTabChanged, {
+      tab: 'review',
+      previousTab: 'history',
+    })
+
+    setParamsExternally({changesInspectorTab: 'history'})
+
+    expect(mockLog).toHaveBeenCalledTimes(2)
+    expect(mockLog).toHaveBeenLastCalledWith(DocumentHistoryInspectorTabChanged, {
+      tab: 'history',
+      previousTab: 'review',
+    })
+  })
+
+  it('does not log a tab change while the pane is closed', () => {
+    const {setParamsExternally} = setup({changesInspectorTab: 'history'})
+
+    setParamsExternally({changesInspectorTab: 'review'})
+
+    expect(mockLog).not.toHaveBeenCalled()
+  })
+
+  it('does not carry the previous tab across a close and reopen', () => {
+    const {result, flushParams} = setup()
+
+    act(() => result.current.handleHistoryOpen('status_line'))
+    flushParams()
+    act(() => result.current.handleHistoryClose())
+    flushParams()
+    mockLog.mockClear()
+
+    act(() => {
+      result.current.handleInspectorAction(inspectMenuItem(HISTORY_INSPECTOR_NAME))
+    })
+    flushParams()
+
+    expect(mockLog).toHaveBeenCalledTimes(1)
+    expect(mockLog).toHaveBeenCalledWith(DocumentHistoryInspectorOpened, {
+      tab: 'history',
+      path: 'pane_menu',
+    })
+  })
+
+  it('reports the tab the reopen writes when another inspector was shown in between', () => {
+    const {result, flushParams} = setup()
+
+    act(() => result.current.handleHistoryOpen('status_line'))
+    flushParams()
+
+    act(() => {
+      result.current.handleInspectorAction(inspectMenuItem(VALIDATION_INSPECTOR_NAME))
+    })
+    flushParams()
+    mockLog.mockClear()
+
+    act(() => {
+      result.current.handleInspectorAction(inspectMenuItem(HISTORY_INSPECTOR_NAME))
+    })
+    flushParams()
+
+    expect(mockLog).toHaveBeenCalledTimes(1)
+    expect(mockLog).toHaveBeenCalledWith(DocumentHistoryInspectorOpened, {
+      tab: 'history',
+      path: 'pane_menu',
+    })
+  })
+})

--- a/packages/sanity/src/structure/panes/document/constants.ts
+++ b/packages/sanity/src/structure/panes/document/constants.ts
@@ -26,10 +26,6 @@ const CHANGES_INSPECTOR_TABS = ['history', 'review'] as const
 
 export type ChangesInspectorTab = (typeof CHANGES_INSPECTOR_TABS)[number]
 
-function isValidChangesInspectorTab(tab: string | undefined): tab is ChangesInspectorTab {
-  return typeof tab === 'string' && (CHANGES_INSPECTOR_TABS as readonly string[]).includes(tab)
-}
-
 export function resolveChangesInspectorTab(tab: string | undefined): ChangesInspectorTab {
-  return isValidChangesInspectorTab(tab) ? tab : CHANGES_INSPECTOR_TABS[0]
+  return CHANGES_INSPECTOR_TABS.find((candidate) => candidate === tab) ?? CHANGES_INSPECTOR_TABS[0]
 }

--- a/packages/sanity/src/structure/panes/document/constants.ts
+++ b/packages/sanity/src/structure/panes/document/constants.ts
@@ -20,3 +20,16 @@ export const INCOMING_REFERENCES_INSPECTOR_NAME = 'sanity/structure/incoming-ref
 
 // timeline
 export const TIMELINE_LIST_WRAPPER_ID = 'timeline-list-wrapper'
+
+// history / review changes inspector tabs
+const CHANGES_INSPECTOR_TABS = ['history', 'review'] as const
+
+export type ChangesInspectorTab = (typeof CHANGES_INSPECTOR_TABS)[number]
+
+function isValidChangesInspectorTab(tab: string | undefined): tab is ChangesInspectorTab {
+  return typeof tab === 'string' && (CHANGES_INSPECTOR_TABS as readonly string[]).includes(tab)
+}
+
+export function resolveChangesInspectorTab(tab: string | undefined): ChangesInspectorTab {
+  return isValidChangesInspectorTab(tab) ? tab : CHANGES_INSPECTOR_TABS[0]
+}

--- a/packages/sanity/src/structure/panes/document/document-layout/DocumentLayout.tsx
+++ b/packages/sanity/src/structure/panes/document/document-layout/DocumentLayout.tsx
@@ -171,6 +171,12 @@ export function DocumentLayout() {
     [onPathOpen, onFocus],
   )
 
+  // Wrapped so the change-bar's onClick MouseEvent isn't passed through as the telemetry path.
+  const handleOpenReviewChanges = useCallback(
+    () => onHistoryOpen('change_indicator'),
+    [onHistoryOpen],
+  )
+
   if (!schemaType) {
     return (
       <DocumentLayoutError
@@ -224,7 +230,7 @@ export function DocumentLayout() {
                 <StyledChangeConnectorRoot
                   data-testid="change-connector-root"
                   isReviewChangesOpen={changesOpen && paneParams?.changesInspectorTab === 'review'}
-                  onOpenReviewChanges={onHistoryOpen}
+                  onOpenReviewChanges={handleOpenReviewChanges}
                   onSetFocus={onConnectorSetFocus}
                 >
                   <DocumentPanel

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/ChangesTabs.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/ChangesTabs.tsx
@@ -19,7 +19,11 @@ import {Tab} from '../../../../../ui-components/tab/Tab'
 import {Tooltip} from '../../../../../ui-components/tooltip/Tooltip'
 import {usePaneRouter} from '../../../../components/paneRouter/usePaneRouter'
 import {structureLocaleNamespace} from '../../../../i18n'
-import {HISTORY_INSPECTOR_NAME} from '../../constants'
+import {
+  type ChangesInspectorTab,
+  HISTORY_INSPECTOR_NAME,
+  resolveChangesInspectorTab,
+} from '../../constants'
 import {ChangesInspector} from './ChangesInspector'
 import {EventsInspector} from './EventsInspector'
 import {EventsSelector} from './EventsSelector'
@@ -32,11 +36,6 @@ const FadeInFlex = styled(Flex)`
     opacity: 1;
   }
 `
-const TABS = ['history', 'review'] as const
-const isValidTab = (tab: string | undefined): tab is (typeof TABS)[number] =>
-  // @ts-expect-error TS doesn't understand the type guard
-  tab && TABS.includes(tab)
-
 export function ChangesTabs(props: DocumentInspectorProps) {
   const {params, setParams} = usePaneRouter()
   // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
@@ -47,11 +46,9 @@ export function ChangesTabs(props: DocumentInspectorProps) {
   const isReady = params?.inspect === HISTORY_INSPECTOR_NAME
   const {selectedPerspective} = usePerspective()
 
-  const paneRouterTab = isValidTab(params?.changesInspectorTab)
-    ? params.changesInspectorTab
-    : TABS[0]
+  const paneRouterTab = resolveChangesInspectorTab(params?.changesInspectorTab)
 
-  const setPaneRouterTab = (tab: (typeof TABS)[number]) =>
+  const setPaneRouterTab = (tab: ChangesInspectorTab) =>
     setParams({
       ...params,
       changesInspectorTab: tab,

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/__tests__/ChangesTabs.test.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/__tests__/ChangesTabs.test.tsx
@@ -3,23 +3,24 @@ import {userEvent} from '@testing-library/user-event'
 import {beforeAll, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
-import {structureUsEnglishLocaleBundle} from '../../../../../i18n'
 import {ChangesTabs} from '../ChangesTabs'
 
-const mockTelemetryLog = vi.hoisted(() => vi.fn())
 const mockSetParams = vi.hoisted(() => vi.fn())
 const mockParams = vi.hoisted(() => ({current: {} as Record<string, string | undefined>}))
-
-vi.mock('@sanity/telemetry/react', () => ({
-  useTelemetry: () => ({log: mockTelemetryLog}),
-}))
 
 vi.mock('../../../../../components/paneRouter/usePaneRouter', () => ({
   usePaneRouter: () => ({params: mockParams.current, setParams: mockSetParams}),
 }))
 
-vi.mock('sanity', async (importOriginal) => ({
-  ...(await importOriginal()),
+function isReleaseDocument(doc: unknown): boolean {
+  return typeof doc === 'object' && doc !== null && '_type' in doc && doc._type === 'system.release'
+}
+
+vi.mock('sanity', () => ({
+  isReleaseDocument,
+  // ChangesTabs imports `structureLocaleNamespace` from the structure i18n barrel, which calls
+  // this at module load time to define `structureUsEnglishLocaleBundle`.
+  defineLocaleResourceBundle: (bundle: unknown) => bundle,
   useSource: () => ({beta: {eventsAPI: {documents: false}}}),
   usePerspective: () => ({selectedPerspective: 'drafts'}),
   // Identity translations keep the i18n Suspense from swapping the tabs for a loading spinner.
@@ -36,9 +37,7 @@ vi.mock('../ChangesInspector', () => ({ChangesInspector: () => null}))
 let wrapper: React.ComponentType<{children: React.ReactNode}>
 
 beforeAll(async () => {
-  wrapper = await createTestProvider({
-    resources: [structureUsEnglishLocaleBundle],
-  })
+  wrapper = await createTestProvider()
 })
 
 describe('ChangesTabs', () => {
@@ -53,7 +52,7 @@ describe('ChangesTabs', () => {
     mockParams.current = {since: 'rev-1'}
     render(<ChangesTabs {...inspectorProps} />, {wrapper})
 
-    const [, reviewTab] = screen.getAllByRole('tab')
+    const reviewTab = screen.getByRole('tab', {name: 'changes.tab.review-changes'})
     await userEvent.click(reviewTab)
 
     expect(mockSetParams).toHaveBeenCalledWith({since: 'rev-1', changesInspectorTab: 'review'})
@@ -63,28 +62,9 @@ describe('ChangesTabs', () => {
     mockParams.current = {since: 'rev-1', changesInspectorTab: 'review'}
     render(<ChangesTabs {...inspectorProps} />, {wrapper})
 
-    const [historyTab] = screen.getAllByRole('tab')
+    const historyTab = screen.getByRole('tab', {name: 'changes.tab.history'})
     await userEvent.click(historyTab)
 
     expect(mockSetParams).toHaveBeenCalledWith({since: undefined, changesInspectorTab: 'history'})
-  })
-
-  it('still writes the params when the already-selected tab is clicked', async () => {
-    mockParams.current = {since: 'rev-1', changesInspectorTab: 'review'}
-    render(<ChangesTabs {...inspectorProps} />, {wrapper})
-
-    const [, reviewTab] = screen.getAllByRole('tab')
-    await userEvent.click(reviewTab)
-
-    expect(mockSetParams).toHaveBeenCalledWith({since: 'rev-1', changesInspectorTab: 'review'})
-  })
-
-  it('logs no tab-change telemetry itself, leaving useDocumentPaneInspector the single emitter', async () => {
-    render(<ChangesTabs {...inspectorProps} />, {wrapper})
-
-    const [, reviewTab] = screen.getAllByRole('tab')
-    await userEvent.click(reviewTab)
-
-    expect(mockTelemetryLog).not.toHaveBeenCalled()
   })
 })

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/__tests__/ChangesTabs.test.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/__tests__/ChangesTabs.test.tsx
@@ -1,0 +1,90 @@
+import {render, screen} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {beforeAll, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {structureUsEnglishLocaleBundle} from '../../../../../i18n'
+import {ChangesTabs} from '../ChangesTabs'
+
+const mockTelemetryLog = vi.hoisted(() => vi.fn())
+const mockSetParams = vi.hoisted(() => vi.fn())
+const mockParams = vi.hoisted(() => ({current: {} as Record<string, string | undefined>}))
+
+vi.mock('@sanity/telemetry/react', () => ({
+  useTelemetry: () => ({log: mockTelemetryLog}),
+}))
+
+vi.mock('../../../../../components/paneRouter/usePaneRouter', () => ({
+  usePaneRouter: () => ({params: mockParams.current, setParams: mockSetParams}),
+}))
+
+vi.mock('sanity', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useSource: () => ({beta: {eventsAPI: {documents: false}}}),
+  usePerspective: () => ({selectedPerspective: 'drafts'}),
+  // Identity translations keep the i18n Suspense from swapping the tabs for a loading spinner.
+  useTranslation: () => ({t: (key: string) => key}),
+  Translate: () => null,
+}))
+
+// The tab bodies are heavy and irrelevant here; only the tab list behaviour is under test.
+vi.mock('../HistorySelector', () => ({HistorySelector: () => null}))
+vi.mock('../EventsSelector', () => ({EventsSelector: () => null}))
+vi.mock('../EventsInspector', () => ({EventsInspector: () => null}))
+vi.mock('../ChangesInspector', () => ({ChangesInspector: () => null}))
+
+let wrapper: React.ComponentType<{children: React.ReactNode}>
+
+beforeAll(async () => {
+  wrapper = await createTestProvider({
+    resources: [structureUsEnglishLocaleBundle],
+  })
+})
+
+describe('ChangesTabs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockParams.current = {}
+  })
+
+  const inspectorProps = {onClose: vi.fn(), documentId: 'doc-1', documentType: 'article'}
+
+  it('writes the selected tab to the pane router params', async () => {
+    mockParams.current = {since: 'rev-1'}
+    render(<ChangesTabs {...inspectorProps} />, {wrapper})
+
+    const [, reviewTab] = screen.getAllByRole('tab')
+    await userEvent.click(reviewTab)
+
+    expect(mockSetParams).toHaveBeenCalledWith({since: 'rev-1', changesInspectorTab: 'review'})
+  })
+
+  it('clears the since param when returning to the history tab', async () => {
+    mockParams.current = {since: 'rev-1', changesInspectorTab: 'review'}
+    render(<ChangesTabs {...inspectorProps} />, {wrapper})
+
+    const [historyTab] = screen.getAllByRole('tab')
+    await userEvent.click(historyTab)
+
+    expect(mockSetParams).toHaveBeenCalledWith({since: undefined, changesInspectorTab: 'history'})
+  })
+
+  it('still writes the params when the already-selected tab is clicked', async () => {
+    mockParams.current = {since: 'rev-1', changesInspectorTab: 'review'}
+    render(<ChangesTabs {...inspectorProps} />, {wrapper})
+
+    const [, reviewTab] = screen.getAllByRole('tab')
+    await userEvent.click(reviewTab)
+
+    expect(mockSetParams).toHaveBeenCalledWith({since: 'rev-1', changesInspectorTab: 'review'})
+  })
+
+  it('logs no tab-change telemetry itself, leaving useDocumentPaneInspector the single emitter', async () => {
+    render(<ChangesTabs {...inspectorProps} />, {wrapper})
+
+    const [, reviewTab] = screen.getAllByRole('tab')
+    await userEvent.click(reviewTab)
+
+    expect(mockTelemetryLog).not.toHaveBeenCalled()
+  })
+})

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusLine.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusLine.tsx
@@ -7,7 +7,7 @@ import {
   Text,
 } from '@sanity/ui'
 import {AnimatePresence, motion} from 'motion/react'
-import {useEffect, useLayoutEffect, useState} from 'react'
+import {useCallback, useEffect, useLayoutEffect, useState} from 'react'
 import {
   AvatarSkeleton,
   getTargetScopeId,
@@ -69,6 +69,15 @@ const DocumentStatusButton = ({
   const {t} = useTranslation()
   const relativeTime = useRelativeTime(timestamp, RELATIVE_TIME_OPTIONS)
 
+  const isHistoryOpen = inspector?.name === HISTORY_INSPECTOR_NAME
+  const handleStatusClick = useCallback(() => {
+    if (isHistoryOpen) {
+      onHistoryClose()
+    } else {
+      onHistoryOpen('status_line')
+    }
+  }, [isHistoryOpen, onHistoryClose, onHistoryOpen])
+
   return (
     <MotionButton
       data-testid="pane-footer-document-status"
@@ -76,7 +85,7 @@ const DocumentStatusButton = ({
       initial={{opacity: 0}}
       exit={{opacity: 0}}
       mode="bleed"
-      onClick={inspector?.name === HISTORY_INSPECTOR_NAME ? onHistoryClose : onHistoryOpen}
+      onClick={handleStatusClick}
       padding={2}
       muted
     >

--- a/packages/sanity/src/structure/panes/document/useDocumentHistoryTelemetry.ts
+++ b/packages/sanity/src/structure/panes/document/useDocumentHistoryTelemetry.ts
@@ -1,0 +1,95 @@
+import {useTelemetry} from '@sanity/telemetry/react'
+import {useCallback, useEffect, useRef} from 'react'
+
+import {
+  DocumentHistoryInspectorOpened,
+  DocumentHistoryInspectorTabChanged,
+  type DocumentHistoryOpenPath,
+} from './__telemetry__/documentPanes.telemetry'
+import {type ChangesInspectorTab} from './constants'
+
+interface UseDocumentHistoryTelemetryOptions {
+  /** true while the history / review changes inspector is the open inspector */
+  changesOpen: boolean
+  /** tab resolved from the pane router params */
+  activeTab: ChangesInspectorTab
+}
+
+interface DocumentHistoryTelemetry {
+  /**
+   * Attributes the open the caller is about to perform. An open with no recorded intent is reported
+   * as `url`, covering deep links, reloads and history navigation.
+   */
+  recordOpenIntent: (path: DocumentHistoryOpenPath) => void
+  /**
+   * Records the tab an in-flight open writes. Pane router params round-trip a macrotask later, so
+   * the open transition would otherwise read the tab that was showing beforehand.
+   */
+  recordOpenTab: (tab: ChangesInspectorTab) => void
+}
+
+/**
+ * Fires `Document History Inspector Opened` when the history / review changes inspector transitions
+ * open, and `Document History Inspector Tab Changed` on every subsequent tab switch. Watching the
+ * transition rather than the controls catches entry points that bypass them, deep links included.
+ *
+ * Extracted from `useDocumentPaneInspector` to keep the inspector state separate from the reporting
+ * and to give the transition logic a focused test target.
+ */
+export function useDocumentHistoryTelemetry({
+  changesOpen,
+  activeTab,
+}: UseDocumentHistoryTelemetryOptions): DocumentHistoryTelemetry {
+  const telemetry = useTelemetry()
+
+  const openIntentRef = useRef<{path: DocumentHistoryOpenPath; tab?: ChangesInspectorTab} | null>(
+    null,
+  )
+  // The tab last reported to telemetry; null while the inspector is closed.
+  const reportedTabRef = useRef<ChangesInspectorTab | null>(null)
+
+  const recordOpenIntent = useCallback((path: DocumentHistoryOpenPath) => {
+    openIntentRef.current = {path}
+  }, [])
+
+  const recordOpenTab = useCallback((tab: ChangesInspectorTab) => {
+    if (openIntentRef.current) {
+      openIntentRef.current.tab = tab
+    }
+  }, [])
+
+  useEffect(() => {
+    const intent = openIntentRef.current
+    const reportedTab = reportedTabRef.current
+
+    openIntentRef.current = null
+
+    if (changesOpen) {
+      if (reportedTab === null) {
+        // Seeded from the intent so the tab param landing a tick later is not read as a tab change.
+        const openedTab = intent?.tab ?? activeTab
+
+        reportedTabRef.current = openedTab
+        telemetry.log(DocumentHistoryInspectorOpened, {
+          tab: openedTab,
+          path: intent?.path ?? 'url',
+        })
+        return
+      }
+
+      reportedTabRef.current = activeTab
+
+      if (reportedTab !== activeTab) {
+        telemetry.log(DocumentHistoryInspectorTabChanged, {
+          tab: activeTab,
+          previousTab: reportedTab,
+        })
+      }
+      return
+    }
+
+    reportedTabRef.current = null
+  }, [activeTab, changesOpen, telemetry])
+
+  return {recordOpenIntent, recordOpenTab}
+}

--- a/packages/sanity/src/structure/panes/document/useDocumentHistoryTelemetry.ts
+++ b/packages/sanity/src/structure/panes/document/useDocumentHistoryTelemetry.ts
@@ -48,9 +48,18 @@ export function useDocumentHistoryTelemetry({
   // The tab last reported to telemetry; null while the inspector is closed.
   const reportedTabRef = useRef<ChangesInspectorTab | null>(null)
 
-  const recordOpenIntent = useCallback((path: DocumentHistoryOpenPath) => {
-    openIntentRef.current = {path}
-  }, [])
+  // An intent recorded while the inspector is already open has no transition to be consumed by, so
+  // skipping it keeps a stale path from outliving the interaction that set it.
+  const recordOpenIntent = useCallback(
+    (path: DocumentHistoryOpenPath) => {
+      if (changesOpen) {
+        return
+      }
+
+      openIntentRef.current = {path}
+    },
+    [changesOpen],
+  )
 
   const recordOpenTab = useCallback((tab: ChangesInspectorTab) => {
     if (openIntentRef.current) {

--- a/packages/sanity/src/structure/panes/document/useDocumentPaneInspector.ts
+++ b/packages/sanity/src/structure/panes/document/useDocumentPaneInspector.ts
@@ -1,22 +1,16 @@
-import {useTelemetry} from '@sanity/telemetry/react'
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {type DocumentInspector, useSource} from 'sanity'
-import {useEffectEvent} from 'use-effect-event'
 
 import {type PaneRouterContextValue} from '../../components/paneRouter/types'
 import {type PaneMenuItem} from '../../types'
 import {useStructureTool} from '../../useStructureTool'
+import {type DocumentHistoryOpenPath} from './__telemetry__/documentPanes.telemetry'
 import {
-  DocumentHistoryInspectorOpened,
-  DocumentHistoryInspectorTabChanged,
-  type DocumentHistoryOpenPath,
-} from './__telemetry__/documentPanes.telemetry'
-import {
-  type ChangesInspectorTab,
   HISTORY_INSPECTOR_NAME,
   INSPECT_ACTION_PREFIX,
   resolveChangesInspectorTab,
 } from './constants'
+import {useDocumentHistoryTelemetry} from './useDocumentHistoryTelemetry'
 
 export function useDocumentPaneInspector({
   documentId,
@@ -30,7 +24,6 @@ export function useDocumentPaneInspector({
   setParams: (params: Record<string, string | undefined>) => void
 }) {
   const {features} = useStructureTool()
-  const telemetry = useTelemetry()
   // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
   const source = useSource()
   const inspectorsResolver = source.document.inspectors
@@ -63,50 +56,7 @@ export function useDocumentPaneInspector({
   const changesOpen = currentInspector?.name === HISTORY_INSPECTOR_NAME
   const activeTab = resolveChangesInspectorTab(params.changesInspectorTab)
 
-  // Open handlers stash attribution here before flipping the inspector; the effect below reads it on
-  // the open transition, then clears it. An empty ref means no handler ran (the URL / deep-link case).
-  const openIntentRef = useRef<{path: DocumentHistoryOpenPath; tab?: ChangesInspectorTab} | null>(
-    null,
-  )
-  const wasChangesOpenRef = useRef(false)
-  const previousTabRef = useRef(activeTab)
-
-  const logHistoryInspectorOpened = useEffectEvent(() => {
-    const intent = openIntentRef.current
-    const openedTab = intent?.tab ?? activeTab
-
-    telemetry.log(DocumentHistoryInspectorOpened, {
-      tab: openedTab,
-      path: intent?.path ?? 'url',
-    })
-
-    // Seeded from the intent so the tab param landing a tick later is not read as a tab change.
-    previousTabRef.current = openedTab
-  })
-
-  const logHistoryInspectorTabChanged = useEffectEvent(() => {
-    telemetry.log(DocumentHistoryInspectorTabChanged, {
-      tab: activeTab,
-      previousTab: previousTabRef.current,
-    })
-  })
-
-  useEffect(() => {
-    const justOpened = changesOpen && !wasChangesOpenRef.current
-
-    if (justOpened) {
-      logHistoryInspectorOpened()
-    } else {
-      if (changesOpen && previousTabRef.current !== activeTab) {
-        logHistoryInspectorTabChanged()
-      }
-
-      previousTabRef.current = activeTab
-    }
-
-    openIntentRef.current = null
-    wasChangesOpenRef.current = changesOpen
-  }, [activeTab, changesOpen])
+  const {recordOpenIntent, recordOpenTab} = useDocumentHistoryTelemetry({changesOpen, activeTab})
 
   const closeInspector = useCallback(
     (closeInspectorName?: string) => {
@@ -180,15 +130,13 @@ export function useDocumentPaneInspector({
         inspect: nextInspector.name,
       }
 
-      // Pane-router params round-trip a macrotask later, so capture the tab this open writes; it is
-      // not always the tab that was showing beforehand.
-      if (openIntentRef.current && nextInspector.name === HISTORY_INSPECTOR_NAME) {
-        openIntentRef.current.tab = resolveChangesInspectorTab(nextParams.changesInspectorTab)
+      if (nextInspector.name === HISTORY_INSPECTOR_NAME) {
+        recordOpenTab(resolveChangesInspectorTab(nextParams.changesInspectorTab))
       }
 
       setParams(nextParams)
     },
-    [currentInspector, inspectors, params, setParams],
+    [currentInspector, inspectors, params, recordOpenTab, setParams],
   )
   const handleHistoryClose = useCallback(() => {
     if (historyInspector) {
@@ -197,17 +145,17 @@ export function useDocumentPaneInspector({
   }, [closeInspector, historyInspector])
 
   const handleHistoryOpen = useCallback(
-    (openPath: DocumentHistoryOpenPath = 'status_line') => {
+    (openPath: DocumentHistoryOpenPath) => {
       if (!features.reviewChanges) {
         return
       }
 
       if (historyInspector) {
-        openIntentRef.current = {path: openPath}
+        recordOpenIntent(openPath)
         openInspector(historyInspector.name, {changesInspectorTab: 'review'})
       }
     },
-    [features.reviewChanges, openInspector, historyInspector],
+    [features.reviewChanges, openInspector, historyInspector, recordOpenIntent],
   )
 
   const inspectOpen = params.inspect === 'on'
@@ -244,7 +192,7 @@ export function useDocumentPaneInspector({
           closeInspector(nextInspector.name)
         } else {
           if (nextInspector.name === HISTORY_INSPECTOR_NAME) {
-            openIntentRef.current = {path: 'pane_menu'}
+            recordOpenIntent('pane_menu')
           }
           openInspector(nextInspector.name)
         }
@@ -252,7 +200,14 @@ export function useDocumentPaneInspector({
       }
       return false
     },
-    [closeInspector, inspectorName, inspectors, openInspector, toggleLegacyInspect],
+    [
+      closeInspector,
+      inspectorName,
+      inspectors,
+      openInspector,
+      recordOpenIntent,
+      toggleLegacyInspect,
+    ],
   )
 
   return {

--- a/packages/sanity/src/structure/panes/document/useDocumentPaneInspector.ts
+++ b/packages/sanity/src/structure/panes/document/useDocumentPaneInspector.ts
@@ -1,10 +1,22 @@
+import {useTelemetry} from '@sanity/telemetry/react'
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {type DocumentInspector, useSource} from 'sanity'
+import {useEffectEvent} from 'use-effect-event'
 
 import {type PaneRouterContextValue} from '../../components/paneRouter/types'
 import {type PaneMenuItem} from '../../types'
 import {useStructureTool} from '../../useStructureTool'
-import {HISTORY_INSPECTOR_NAME, INSPECT_ACTION_PREFIX} from './constants'
+import {
+  DocumentHistoryInspectorOpened,
+  DocumentHistoryInspectorTabChanged,
+  type DocumentHistoryOpenPath,
+} from './__telemetry__/documentPanes.telemetry'
+import {
+  type ChangesInspectorTab,
+  HISTORY_INSPECTOR_NAME,
+  INSPECT_ACTION_PREFIX,
+  resolveChangesInspectorTab,
+} from './constants'
 
 export function useDocumentPaneInspector({
   documentId,
@@ -18,6 +30,7 @@ export function useDocumentPaneInspector({
   setParams: (params: Record<string, string | undefined>) => void
 }) {
   const {features} = useStructureTool()
+  const telemetry = useTelemetry()
   // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
   const source = useSource()
   const inspectorsResolver = source.document.inspectors
@@ -48,6 +61,52 @@ export function useDocumentPaneInspector({
   )
 
   const changesOpen = currentInspector?.name === HISTORY_INSPECTOR_NAME
+  const activeTab = resolveChangesInspectorTab(params.changesInspectorTab)
+
+  // Open handlers stash attribution here before flipping the inspector; the effect below reads it on
+  // the open transition, then clears it. An empty ref means no handler ran (the URL / deep-link case).
+  const openIntentRef = useRef<{path: DocumentHistoryOpenPath; tab?: ChangesInspectorTab} | null>(
+    null,
+  )
+  const wasChangesOpenRef = useRef(false)
+  const previousTabRef = useRef(activeTab)
+
+  const logHistoryInspectorOpened = useEffectEvent(() => {
+    const intent = openIntentRef.current
+    const openedTab = intent?.tab ?? activeTab
+
+    telemetry.log(DocumentHistoryInspectorOpened, {
+      tab: openedTab,
+      path: intent?.path ?? 'url',
+    })
+
+    // Seeded from the intent so the tab param landing a tick later is not read as a tab change.
+    previousTabRef.current = openedTab
+  })
+
+  const logHistoryInspectorTabChanged = useEffectEvent(() => {
+    telemetry.log(DocumentHistoryInspectorTabChanged, {
+      tab: activeTab,
+      previousTab: previousTabRef.current,
+    })
+  })
+
+  useEffect(() => {
+    const justOpened = changesOpen && !wasChangesOpenRef.current
+
+    if (justOpened) {
+      logHistoryInspectorOpened()
+    } else {
+      if (changesOpen && previousTabRef.current !== activeTab) {
+        logHistoryInspectorTabChanged()
+      }
+
+      previousTabRef.current = activeTab
+    }
+
+    openIntentRef.current = null
+    wasChangesOpenRef.current = changesOpen
+  }, [activeTab, changesOpen])
 
   const closeInspector = useCallback(
     (closeInspectorName?: string) => {
@@ -115,7 +174,19 @@ export function useDocumentPaneInspector({
       setInspectorName(nextInspector.name)
       inspectParamRef.current = nextInspector.name
 
-      setParams({...result.params, ...paneParams, inspect: nextInspector.name})
+      const nextParams: Record<string, string | undefined> = {
+        ...result.params,
+        ...paneParams,
+        inspect: nextInspector.name,
+      }
+
+      // Pane-router params round-trip a macrotask later, so capture the tab this open writes; it is
+      // not always the tab that was showing beforehand.
+      if (openIntentRef.current && nextInspector.name === HISTORY_INSPECTOR_NAME) {
+        openIntentRef.current.tab = resolveChangesInspectorTab(nextParams.changesInspectorTab)
+      }
+
+      setParams(nextParams)
     },
     [currentInspector, inspectors, params, setParams],
   )
@@ -125,15 +196,19 @@ export function useDocumentPaneInspector({
     }
   }, [closeInspector, historyInspector])
 
-  const handleHistoryOpen = useCallback(() => {
-    if (!features.reviewChanges) {
-      return
-    }
+  const handleHistoryOpen = useCallback(
+    (openPath: DocumentHistoryOpenPath = 'status_line') => {
+      if (!features.reviewChanges) {
+        return
+      }
 
-    if (historyInspector) {
-      openInspector(historyInspector.name, {changesInspectorTab: 'review'})
-    }
-  }, [features.reviewChanges, openInspector, historyInspector])
+      if (historyInspector) {
+        openIntentRef.current = {path: openPath}
+        openInspector(historyInspector.name, {changesInspectorTab: 'review'})
+      }
+    },
+    [features.reviewChanges, openInspector, historyInspector],
+  )
 
   const inspectOpen = params.inspect === 'on'
 
@@ -168,6 +243,9 @@ export function useDocumentPaneInspector({
         if (nextInspector.name === inspectorName) {
           closeInspector(nextInspector.name)
         } else {
+          if (nextInspector.name === HISTORY_INSPECTOR_NAME) {
+            openIntentRef.current = {path: 'pane_menu'}
+          }
           openInspector(nextInspector.name)
         }
         return true


### PR DESCRIPTION
### Description

The studio has no telemetry for the history and review changes side pane, so we cannot tell how often it is opened and from where, which tab people use, or whether they revert changes wholesale or field by field. The inspector, its tabs, and the revert actions were entirely uninstrumented.

This PR adds three events. `Document History Inspector Opened` carries the `tab` and the trigger `path` (`status_line`, `change_indicator`, `pane_menu`, or `url`). `Document History Inspector Tab Changed` records tab switches with the previous and new tab. `Document Changes Reverted` records confirmed reverts with a `scope` of `all`, `group`, or `field` and a flat count of the field changes covered.

Instrumenting the shared `path` vocabulary surfaced four defects in neighbouring telemetry, one of which was emitting an event on every render. They are fixed here rather than deferred, which widens the diff into `core/form`, `core/studio/copyPaste` and `presentation`. Happy to split them out if reviewers would rather take them separately.

### What to review

**The history and review changes events**

- Both inspector events fire from `useDocumentHistoryTelemetry.ts`, a dedicated hook watching the open transition and the resolved tab rather than the click handlers. `PaneRouterProvider.setParams` defers via `setTimeout(..., 0)`, so the inspector state flips a macrotask before the tab param lands. Emitting from `ChangesTabs` would log a spurious tab change on every open, and emitting from the handlers would miss every tab change that does not come from the tab list. `ChangesTabs` logs nothing itself. The hook follows `useDocumentInitialLoadTelemetry.ts` in the same directory, keeping `useDocumentPaneInspector` about inspector state.
- The open transition seeds the previous tab from the params the open actually writes, not from the tab showing beforehand, so the two events never overlap. Those differ because `openInspector` runs the history inspector's own `onClose`, which clears `changesInspectorTab`. That is a pre-existing bug worth its own ticket: `openInspector` calls `nextInspector.onClose` where it means `currentInspector.onClose`. Left alone here rather than fixed in a telemetry PR.
- `changeCount` is the flat leaf count via `flattenChangeNode`, the helper `undoChange` itself uses to decide what to revert. Counting the rows on screen instead would measure `all` and `group` at a different depth from `field`, and would under-report grouped edits, since the pane nests a group wherever a schema has two or more sibling changes. A 20-block Portable Text edit is one row and 20 changes.
- `onHistoryOpen` takes a required `path`. The `reviewChanges` pane menu action in `DocumentPaneProvider` called it with no argument, so it reported `status_line`. Making the parameter required fixed that caller and turned the two wrappers in `DocumentLayout` and `DocumentStatusLine` into compile errors if unwrapped, since `(path: X) => void` is not assignable to `() => void` while the optional form was.
- The open event deliberately carries no events-API flag. `Workspace Features Observed` already emits `eventsApiDocumentsEnabled` per workspace, so splitting opens by rollout is a join on the envelope's `activeWorkspace`. Copying it per event would also mean reading a deprecated config field.
- `Tab Changed` carries no attribution, so tab-list clicks and status-line jumps are indistinguishable, and browser back/forward between the two tab values inflates the count. Adding a `path` here would mean a new `tab_list` value in the shared vocabulary and a further round with Data / Analytics, so it is documented as a limitation instead.
- `path: 'url'` also absorbs pane remounts. `DocumentPane` keys the provider on the perspective and variant, so switching either with the pane open emits another open. Documented alongside the deep-link case.
- The group-revert call sits in `ChangeResolver.tsx` rather than `GroupChange.tsx` because #13753 inlined `GroupChange` into that module to break an import cycle.

**The adjacent defects**

- `Nested Dialog Opened` fired once per render for the dialog's whole lifetime. `useDialogStack` returns `context?.stack ?? []`, a fresh array each render when no `DialogStackProvider` is mounted, so the effect's dependency changed constantly while its `stack.length === 0` guard stayed true.
- Narrowing that dependency to `stack.length` was not enough, because the guard means the stack is empty rather than this dialog just opened. `DialogStackProvider.navigateTo` filters out entries at or below the target depth, so selecting the dialog's own breadcrumb drops its entry and empties the stack without unmounting it, firing a second event with the same path. A ref now holds it to one per mount. The `>=` predicate is the actual root cause and also makes `isTop` false for a mounted dialog, which renders it at `opacity: 0`; that is worth its own ticket since it touches `close({toParent})` and `closeWithFullscreen`.
- The same event emitted `pathToString([])`, always the empty string. It now sends the real field path, which every sibling event in that family (`Object Created`, `Object Edited`, `Object Removed`, `Editor Opened`, `Editor Closed`) already did. Those paths include array item `_key` values, so grouping by `path` goes from one row to one per field instance. `version` stays at 1: the payload shape is unchanged, which is the criterion `defineEvent` documents, and the five siblings already ship the same value at 1.
- Presentation's `useParams` asserted `Object.fromEntries(current._searchParams)` to `CombinedSearchParams` when it really yields `Record<string, string>`. That assertion is what forced the `@ts-expect-error` below it; typing it honestly removes both. `useParams.ts:101` is deliberately untouched: swapping its cast for the tab resolver would make the value non-optional, survive `pruneObject`, and write `changesInspectorTab=history` into every presentation user's URL.
- The copy/paste `context` union was written out twice. It now derives from `BaseOptions['context']['source']`, collapsing three copies to one. The values stay camelCase against the snake_case `path` vocabulary, because they are emitted verbatim from the public `CopyOptions` and `PasteOptions` types, so renaming them would break plugin callers as well as the existing series.

### Testing

34 unit tests across five files.

`useDocumentPaneInspector.test.tsx` (12) covers the open entry points and the no-fire cases (close, a different inspector, no double-fire), then the tab-change paths: tab-list writes in both directions, one event per switch against the tab it left, no tab change on open despite the deferred param, nothing while the pane is closed, no stale previous tab across a close and reopen, and the tab reported when history is reopened after another inspector was shown in between. Three details make those meaningful: `setParams` only records, so params land on an explicit flush the way the router's `setTimeout` makes them; the suite uses the real `changesInspector` rather than a name-only stub, so the inspector's own `onOpen` / `onClose` param rewriting is exercised; and the hook renders under `StrictMode`, so every single-emission assertion also guards the double-invoked effect.

`EnhancedObjectDialog.test.tsx` (11) covers the real path, `absolutePath` winning over `path`, the empty case, one event per open rather than per render, and one event when the stack empties under a mounted dialog. That last one fails on its own if the ref guard is removed, and nothing else in the file does.

`ChangesTabs.test.tsx` (2) covers the tab param contract. `diff.telemetry.test.tsx` (5) covers the three revert scopes, a cancel, and a nested group asserting the flat count rather than the direct-child count. `useParams.test.ts` (4, the first tests this hook has had) covers param maintenance across same-document and cross-document navigation, explicit overrides, and the existing `[key, undefined]` behaviour.

Format, oxlint (which includes type checking), and the full `sanity` project suite (5771 tests) pass locally.

### Notes for release

N/A

---
