### PR TITLE
fix(form): opt hotspot preview images out of the global img reset

### DIFF
--- a/packages/sanity/src/core/form/inputs/files/ImageToolInput/imagetool/__tests__/HotspotImage.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageToolInput/imagetool/__tests__/HotspotImage.browser.test.tsx
@@ -1,0 +1,73 @@
+import {Card, ThemeProvider} from '@sanity/ui'
+import {buildTheme} from '@sanity/ui/theme'
+import {beforeAll, describe, expect, it} from 'vitest'
+import {render} from 'vitest-browser-react'
+
+import {RatioBox} from '../../../common/RatioBox'
+import {HotspotImage} from '../HotspotImage'
+
+const theme = buildTheme()
+
+// The layout is driven entirely by the styles `calculateStyles` computes, so the
+// intrinsic size of the image is irrelevant here.
+const SRC = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
+
+const CROP = {top: 0, bottom: 0.014, left: 0.138, right: 0.182}
+const HOTSPOT = {x: 0.467, y: 0.493, height: 0.984, width: 0.617}
+
+const PREVIEW_ASPECT_RATIOS = [3 / 4, 1, 16 / 9, 4]
+
+// The studio applies a global reset (via `@sanity-labs/ui-poc/styles.css`) that
+// clamps every image to the width of its container. `HotspotImage` scales the
+// image past its crop viewport, so it has to survive that reset.
+beforeAll(() => {
+  const style = document.createElement('style')
+  style.textContent = 'img,object,picture,video{display:block;max-width:100%}'
+  document.head.appendChild(style)
+})
+
+function renderPreview(aspectRatio: number, srcAspectRatio: number) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <div style={{width: 147}}>
+        <RatioBox ratio={aspectRatio}>
+          <Card __unstable_checkered border>
+            <HotspotImage
+              aspectRatio={aspectRatio}
+              src={SRC}
+              srcAspectRatio={srcAspectRatio}
+              hotspot={HOTSPOT}
+              crop={CROP}
+            />
+          </Card>
+        </RatioBox>
+      </div>
+    </ThemeProvider>,
+  )
+}
+
+function measure(root: HTMLElement) {
+  const img = root.querySelector('img')!
+  const cropBox = img.parentElement!
+  return {img: img.getBoundingClientRect(), crop: cropBox.getBoundingClientRect()}
+}
+
+describe('HotspotImage', () => {
+  for (const srcAspectRatio of [1, 16 / 9, 2 / 3]) {
+    for (const aspectRatio of PREVIEW_ASPECT_RATIOS) {
+      it(`renders a ${srcAspectRatio.toFixed(2)} image undistorted in a ${aspectRatio.toFixed(2)} preview`, async () => {
+        const {container} = await renderPreview(aspectRatio, srcAspectRatio)
+        const {img, crop} = measure(container as HTMLElement)
+
+        // The image must keep the aspect ratio of the source, otherwise the
+        // preview shows a stretched or squashed version of the image.
+        expect(img.width / img.height).toBeCloseTo(srcAspectRatio, 2)
+
+        // ...and it must cover the crop viewport, otherwise the preview shows
+        // the wrong part of the image with a gap next to it.
+        expect(img.width).toBeGreaterThanOrEqual(crop.width - 0.5)
+        expect(img.height).toBeGreaterThanOrEqual(crop.height - 0.5)
+      })
+    }
+  }
+})

--- a/packages/sanity/src/core/form/inputs/files/ImageToolInput/imagetool/calculateStyles.ts
+++ b/packages/sanity/src/core/form/inputs/files/ImageToolInput/imagetool/calculateStyles.ts
@@ -80,6 +80,12 @@ export function calculateStyles(options: Options = {}): CalculatedStyles {
     },
     image: {
       position: 'absolute',
+      // The image is scaled past its crop viewport on purpose (it is clipped by
+      // the crop box), so it has to opt out of the global
+      // `img {max-width: 100%}` reset the studio ships, which would otherwise
+      // squash it back to the viewport width.
+      maxWidth: 'none',
+      maxHeight: 'none',
       height: toStylePercentage(result.image.height),
       width: toStylePercentage(result.image.width),
       top: toStylePercentage(result.image.top),


### PR DESCRIPTION
Fixes [SAPP-4092](https://linear.app/sanity/issue/SAPP-4092/crop-hotspot-previews-are-broken)

### Description

The crop/hotspot previews in the image input started rendering a squashed image that doesn't match the actual crop. The cause is outside the imagetool code: #13776 added `import '@sanity-labs/ui-poc/styles.css'` to the studio entry point, and that stylesheet contains a global reset `img,object,picture,video{display:block;max-width:100%}`.

`HotspotImage` positions an absolutely placed `img` that is intentionally *larger* than the crop box that clips it — that's how the crop is expressed. Once the image needs to be wider than its offset parent (any crop that trims the sides, or any source/preview aspect ratio mismatch), the reset clamps it back to 100% while the inline `height` percentage stays as computed, so the image gets horizontally compressed and slides out of alignment with the intended crop. The 3:4 preview in the report is the worst case because it needs the largest upscale.

The `img` is the only place the override can live: the styles are computed per-render in `calculateStyles`, and the element has no stable class to target. A CSS rule in the imagetool stylesheet would work but would have to out-specify a global element selector from a package we don't control; inline styles avoid that fight entirely.

The broader concern — a global element reset applied studio-wide from `ui-poc` — is worth a separate look, since anything else that relies on unclamped `img` sizing will hit the same wall.


| Before (crop is not properly respected) | After |
|--------|--------|
|<img width="640" height="676" alt="Screenshot 2026-08-05 at 09 35 24" src="https://github.com/user-attachments/assets/22fb7aa5-1f72-4c71-81f3-df6f1a90e955" />| <img width="631" height="685" alt="Screenshot 2026-08-05 at 09 35 18" src="https://github.com/user-attachments/assets/85d2f98b-bd99-4d3a-80d8-0b4624a5189b" />|

### What to review

Only `packages/sanity`. The one-line style addition in `calculateStyles.ts` is the fix; the rest is the regression test. Worth confirming the test's premise: it injects the same global reset into the test document, so it fails on `main` and passes here.

### Testing

Added `HotspotImage.browser.test.tsx` (vitest browser mode, real layout) covering three source aspect ratios against the four default preview ratios. Each case asserts the rendered `img` keeps the source aspect ratio and still covers the crop viewport. Verified it fails without the fix.

Also verified visually in a scratch browser test rendering before/after side by side with a circle-and-grid pattern: before, circles render as ellipses and the visible region is offset; after, they're round and the crop matches.

### Notes for release

Fixed a regression where the crop and hotspot previews in the image input rendered a horizontally squashed image that did not match the configured crop.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped to imagetool preview inline styles and new tests; no auth, data, or API changes.
> 
> **Overview**
> Fixes crop/hotspot previews in the image input that looked **horizontally squashed** after a studio-wide `img { max-width: 100% }` reset from `@sanity-labs/ui-poc/styles.css`.
> 
> `calculateStyles` now sets **`maxWidth` and `maxHeight` to `none`** on the absolutely positioned preview `img`, so sizing past the crop clip box is not clamped to the viewport width while percentage height/width from the imagetool math stay intact.
> 
> Adds **`HotspotImage.browser.test.tsx`**: vitest browser tests that inject the same global reset and assert the rendered image keeps source aspect ratio and covers the crop box across several source and preview aspect ratios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4066e45ad938b55a116b1c3228bf2af4dc89cefa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->