### PR TITLE
fix(form): resolve context-aware validation rules in inputs

### DIFF
--- a/dev/test-studio/schema/debug/twoArgValidationRepro.ts
+++ b/dev/test-studio/schema/debug/twoArgValidationRepro.ts
@@ -1,0 +1,90 @@
+/**
+ * Reproduction schema for https://linear.app/sanity/issue/SAPP-4084
+ *
+ * Issue: `url`, `number`, and `array` fields crash at render when their
+ * `validation` is a two-argument function `(rule, context) => ...`:
+ *
+ *   Schema type "url"'s `validation` was not run though `inferFromSchema`
+ *
+ * The single-argument form `(rule) => ...` works. The docs recommend the
+ * two-argument form for conditionally hidden fields, but only `string` (and
+ * other inputs that never call `getValidationRule`) survive it today.
+ *
+ * Manual repro:
+ * 1. Structure → Inputs → Debug → Two-arg validation repro (SAPP-4084).
+ * 2. Create a new document.
+ * 3. `url`, `number`, and `array` fields show a red "An error occurred" box.
+ * 4. `string` control field renders normally.
+ */
+import {defineArrayMember, defineField, defineType} from 'sanity'
+
+export const twoArgValidationRepro = defineType({
+  name: 'twoArgValidationRepro',
+  type: 'document',
+  title: 'Two-arg validation repro (SAPP-4084)',
+  description: 'url/number/array fields crash when validation uses (rule, context) => ...',
+  fields: [
+    defineField({
+      name: 'title',
+      type: 'string',
+      title: 'Title',
+      initialValue: 'Two-arg validation repro',
+    }),
+
+    defineField({
+      name: 'instructions',
+      type: 'text',
+      title: 'How to reproduce',
+      readOnly: true,
+      initialValue:
+        'The url, number, and array fields below use two-argument validation and crash at render. The string control field uses the same pattern but works.',
+    }),
+
+    defineField({
+      name: 'link',
+      type: 'url',
+      title: 'URL (two-arg validation — crashes)',
+      description:
+        'Two-argument validation on url fields triggers getValidationRule during render.',
+      validation: (rule, context) =>
+        context?.hidden ? rule.skip() : rule.required().uri({scheme: ['https']}),
+    }),
+
+    defineField({
+      name: 'amount',
+      type: 'number',
+      title: 'Number (two-arg validation — crashes)',
+      description:
+        'Two-argument validation on number fields triggers getValidationRule during render.',
+      validation: (rule, context) => (context?.hidden ? rule.skip() : rule.required().min(1)),
+    }),
+
+    defineField({
+      name: 'tags',
+      type: 'array',
+      title: 'Array (two-arg validation — crashes)',
+      description:
+        'Two-argument validation on array fields triggers getValidationRule during render.',
+      of: [defineArrayMember({type: 'string'})],
+      validation: (rule, context) => (context?.hidden ? rule.skip() : rule.required().max(5)),
+    }),
+
+    defineField({
+      name: 'label',
+      type: 'string',
+      title: 'String control (two-arg validation — works)',
+      description:
+        'Same two-argument pattern on string; StringInput never reads validation rules at render.',
+      validation: (rule, context) => (context?.hidden ? rule.skip() : rule.required().min(1)),
+    }),
+  ],
+  preview: {
+    select: {title: 'title'},
+    prepare({title}) {
+      return {
+        title: title || 'Two-arg validation repro',
+        subtitle: 'SAPP-4084',
+      }
+    },
+  },
+})

--- a/dev/test-studio/schema/index.ts
+++ b/dev/test-studio/schema/index.ts
@@ -105,6 +105,7 @@ import select from './debug/select'
 import {navbarSettingsDialogRepro} from './debug/settingsV2DialogRepro'
 import {simpleArrayOfObjects} from './debug/simpleArrayOfObjects'
 import {simpleReferences} from './debug/simpleReferences'
+import {twoArgValidationRepro} from './debug/twoArgValidationRepro'
 import typeWithNoToplevelStrings from './debug/typeWithNoToplevelStrings'
 import uploads from './debug/uploads'
 import validation, {validationArraySuperType} from './debug/validation'
@@ -318,6 +319,7 @@ export function createSchemaTypes(projectId: string) {
     reservedFieldNames,
     review,
     navbarSettingsDialogRepro,
+    twoArgValidationRepro,
     select,
     typeWithNoToplevelStrings,
     uploads,

--- a/dev/test-studio/structure/constants.ts
+++ b/dev/test-studio/structure/constants.ts
@@ -106,6 +106,7 @@ export const DEBUG_INPUT_TYPES = [
   'annotationCustomTypeTest',
   'arrayModalWidthReproTest',
   'nestedArrayInsertMenuRepro',
+  'twoArgValidationRepro',
   'arrayOfStringsGridCustomInputTest',
   'withObjectFieldsOrder',
 ]

--- a/packages/@sanity/types/src/schema/types.ts
+++ b/packages/@sanity/types/src/schema/types.ts
@@ -197,22 +197,18 @@ export type InitialValueProperty<Params, Value> =
  * If the schema has not been run through `inferFromSchema` from
  * `sanity/validation` then value could be a function.
  *
- * `inferFromSchema` mutates the schema converts this value to an array of
- * `Rule` instances.
+ * `inferFromSchema` mutates the schema and converts this value to an array of
+ * `Rule` instances, _except_ for context-aware validation (a function declaring a
+ * `context` parameter), which stays a function so it can be re-evaluated against
+ * the value being validated.
  *
  * @privateRemarks
  *
- * Usage of the schema inside the studio will almost always be from the compiled
- * `createSchema` function. In this case, you can cast the value or throw to
- * narrow the type. E.g.:
- *
- * ```ts
- * if (typeof type.validation === 'function') {
- *   throw new Error(
- *     `Schema type "${type.name}"'s \`validation\` was not run though \`inferFromSchema\``
- *   )
- * }
- * ```
+ * This means a compiled schema can still hold a function here, so do not treat
+ * that as a sign the schema was never compiled. To read rules outside of document
+ * validation, normalize on demand with `normalizeValidationRules(type)` and be
+ * ready for it to throw, since context-aware validation may dereference a context
+ * that only exists while validating. `getValidationRule` does this.
  *
  * @public
  */

--- a/packages/sanity/src/core/form/inputs/NumberInput/NumberInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/NumberInput/NumberInput.test.tsx
@@ -95,4 +95,19 @@ describe('number-input', () => {
     const input = result.container.querySelector('input')!
     expect(input.inputMode).toBe('numeric')
   })
+
+  it('renders rules declared by context-aware validation', async () => {
+    const {result} = await renderNumberInput({
+      fieldDefinition: {
+        name: 'contextAwarePositiveInteger',
+        title: 'Integer',
+        type: 'number',
+        validation: (Rule, context) => (context?.hidden ? Rule.skip() : Rule.integer().positive()),
+      },
+      render: (inputProps) => <NumberInput {...inputProps} />,
+    })
+
+    const input = result.container.querySelector('input')!
+    expect(input.inputMode).toBe('numeric')
+  })
 })

--- a/packages/sanity/src/core/form/inputs/UrlInput.test.tsx
+++ b/packages/sanity/src/core/form/inputs/UrlInput.test.tsx
@@ -1,0 +1,48 @@
+import {describe, expect, it} from 'vitest'
+
+import {renderStringInput} from '../../../../test/form/renderStringInput'
+import {UrlInput} from './UrlInput'
+
+describe('url-input', () => {
+  it('renders type equals "url" by default', async () => {
+    const {result} = await renderStringInput({
+      fieldDefinition: {
+        name: 'defaultUrl',
+        title: 'Url',
+        type: 'url',
+      },
+      render: (inputProps) => <UrlInput {...inputProps} />,
+    })
+
+    expect(result.container.querySelector('input')).toHaveAttribute('type', 'url')
+  })
+
+  it('renders type equals "text" when relative urls are allowed', async () => {
+    const {result} = await renderStringInput({
+      fieldDefinition: {
+        name: 'relativeUrl',
+        title: 'Url',
+        type: 'url',
+        validation: (rule) => rule.uri({allowRelative: true}),
+      },
+      render: (inputProps) => <UrlInput {...inputProps} />,
+    })
+
+    expect(result.container.querySelector('input')).toHaveAttribute('type', 'text')
+  })
+
+  it('renders rules declared by context-aware validation', async () => {
+    const {result} = await renderStringInput({
+      fieldDefinition: {
+        name: 'contextAwareRelativeUrl',
+        title: 'Url',
+        type: 'url',
+        validation: (rule, context) =>
+          context?.hidden ? rule.skip() : rule.uri({allowRelative: true}),
+      },
+      render: (inputProps) => <UrlInput {...inputProps} />,
+    })
+
+    expect(result.container.querySelector('input')).toHaveAttribute('type', 'text')
+  })
+})

--- a/packages/sanity/src/core/form/utils/getValidationRule.test.ts
+++ b/packages/sanity/src/core/form/utils/getValidationRule.test.ts
@@ -1,0 +1,118 @@
+import {
+  defineField,
+  defineType,
+  type NumberRule,
+  type ObjectSchemaType,
+  type SchemaType,
+  type ValidationContext,
+} from '@sanity/types'
+import {describe, expect, test} from 'vitest'
+
+import {createSchema} from '../../schema/createSchema'
+import {getValidationRule} from './getValidationRule'
+
+// `defineField` types `validation` as a single builder function, while the runtime also accepts an
+// array of them, so this type is declared without `defineType`
+const arrayValidationDoc = {
+  name: 'arrayValidation',
+  type: 'document',
+  fields: [
+    {
+      name: 'mixedArity',
+      type: 'number',
+      validation: [
+        (rule: NumberRule) => rule.integer(),
+        (rule: NumberRule, context?: ValidationContext) =>
+          context?.hidden ? rule.skip() : rule.min(2),
+      ],
+    },
+  ],
+}
+
+const schema = createSchema({
+  name: 'test',
+  types: [
+    defineType({
+      name: 'validationArity',
+      type: 'document',
+      fields: [
+        defineField({
+          name: 'urlArity1',
+          type: 'url',
+          validation: (rule) => rule.uri({allowRelative: true}),
+        }),
+        defineField({
+          name: 'urlArity2',
+          type: 'url',
+          validation: (rule, context) =>
+            context?.hidden ? rule.skip() : rule.uri({allowRelative: true}),
+        }),
+        defineField({
+          name: 'numberArity2',
+          type: 'number',
+          validation: (rule, context) =>
+            context?.hidden ? rule.skip() : rule.required().min(1).integer(),
+        }),
+        defineField({
+          name: 'arrayArity2',
+          type: 'array',
+          of: [{type: 'string'}],
+          validation: (rule, context) => (context?.hidden ? rule.skip() : rule.max(3)),
+        }),
+        defineField({
+          name: 'urlUnsafeContextAccess',
+          type: 'url',
+          // Simulates validation that assumes a context is always present, which only holds while
+          // validating a document
+          validation: (rule, context) => rule.uri({scheme: [context!.document!._type]}),
+        }),
+      ],
+    }),
+    arrayValidationDoc,
+  ],
+})
+
+function getFieldType(typeName: string, fieldName: string): SchemaType {
+  const document = schema.get(typeName) as ObjectSchemaType
+  const field = document.fields.find((candidate) => candidate.name === fieldName)
+  if (!field) throw new Error(`No such field: ${typeName}.${fieldName}`)
+  return field.type
+}
+
+describe('getValidationRule', () => {
+  test('reads rules from single-argument validation', () => {
+    expect(
+      getValidationRule(getFieldType('validationArity', 'urlArity1'), 'uri')?.constraint?.options,
+    ).toMatchObject({allowRelative: true})
+  })
+
+  test('reads rules from two-argument (context-aware) validation', () => {
+    expect(
+      getValidationRule(getFieldType('validationArity', 'urlArity2'), 'uri')?.constraint?.options,
+    ).toMatchObject({allowRelative: true})
+    expect(
+      getValidationRule(getFieldType('validationArity', 'numberArity2'), 'min')?.constraint,
+    ).toBe(1)
+    expect(
+      getValidationRule(getFieldType('validationArity', 'numberArity2'), 'integer'),
+    ).not.toBeNull()
+    expect(
+      getValidationRule(getFieldType('validationArity', 'arrayArity2'), 'max')?.constraint,
+    ).toBe(3)
+  })
+
+  test('reads rules from an array mixing plain and context-aware validation', () => {
+    expect(
+      getValidationRule(getFieldType('arrayValidation', 'mixedArity'), 'integer'),
+    ).not.toBeNull()
+    expect(
+      getValidationRule(getFieldType('arrayValidation', 'mixedArity'), 'min')?.constraint,
+    ).toBe(2)
+  })
+
+  test('returns null when validation cannot be resolved without a context', () => {
+    expect(
+      getValidationRule(getFieldType('validationArity', 'urlUnsafeContextAccess'), 'uri'),
+    ).toBeNull()
+  })
+})

--- a/packages/sanity/src/core/form/utils/getValidationRule.ts
+++ b/packages/sanity/src/core/form/utils/getValidationRule.ts
@@ -1,19 +1,44 @@
-import {type Rule, type RuleSpec, type SchemaType, type SchemaValidationValue} from '@sanity/types'
+import {type Rule, type RuleSpec, type SchemaType} from '@sanity/types'
 
-const normalizeRules = (
-  validation: SchemaValidationValue | undefined,
-  type?: SchemaType,
-): Rule[] => {
-  if (typeof validation === 'function') {
-    throw new Error(
-      `Schema type "${
-        type?.name || '<not-found>'
-      }"'s \`validation\` was not run though \`inferFromSchema\``,
-    )
+import {normalizeValidationRules} from '../../validation/util/normalizeValidationRules'
+
+const isRuleInstance = (validation: unknown): validation is Rule =>
+  typeof validation === 'object' && validation !== null && '_rules' in validation
+
+const deferredRules = new WeakMap<SchemaType, Rule[]>()
+
+/**
+ * Resolves the rules of a type whose `validation` schema compilation left un-normalized.
+ *
+ * `inferFromSchemaType` only normalizes validation that doesn't declare a `context` parameter,
+ * since context-aware validation has to be re-evaluated per value while validating a document.
+ * The rules read here are static input hints, so they're resolved without a context — which is
+ * what schema compilation did for every validation function before context support was added.
+ */
+function resolveDeferredRules(type: SchemaType): Rule[] {
+  const cached = deferredRules.get(type)
+  if (cached) return cached
+
+  let rules: Rule[]
+  try {
+    rules = normalizeValidationRules(type)
+  } catch {
+    // Validation that dereferences `context` unconditionally can only be evaluated while
+    // validating a document, so it cannot contribute any input hints.
+    rules = []
   }
-  if (!validation) return []
-  if (Array.isArray(validation)) return validation as Rule[]
-  return [validation]
+
+  deferredRules.set(type, rules)
+  return rules
+}
+
+function getRules(type: SchemaType | undefined): Rule[] {
+  const validation = type?.validation
+  if (!type || !validation) return []
+  if (Array.isArray(validation)) {
+    return validation.every(isRuleInstance) ? validation : resolveDeferredRules(type)
+  }
+  return isRuleInstance(validation) ? [validation] : resolveDeferredRules(type)
 }
 
 /**
@@ -26,7 +51,7 @@ export function getValidationRule<RuleFlag extends RuleSpec['flag']>(
   type: SchemaType | undefined,
   ruleName: RuleFlag,
 ): Extract<RuleSpec, {flag: RuleFlag}> | null {
-  for (const rule of normalizeRules(type?.validation, type)) {
+  for (const rule of getRules(type)) {
     // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
     for (const ruleSpec of rule._rules) {
       if (ruleSpec.flag === ruleName) {


### PR DESCRIPTION
> [!NOTE]
> **See the crash before the fix.** This deployment is built from the repro schema commit *without* the fix:
> [Open the repro document](https://test-studio-6kojzo1bl.sanity.dev/test/structure/input-debug;twoArgValidationRepro;5aa29d8c-abb4-4a85-b9fd-f54eb2a08e49%2Ctemplate%3DtwoArgValidationRepro) and the [fixed here ](https://test-studio-git-sapp-4084.sanity.dev/test/structure/input-debug;twoArgValidationRepro;5aa29d8c-abb4-4a85-b9fd-f54eb2a08e49%2Ctemplate%3DtwoArgValidationRepro)
>
> The **URL**, **Number**, and **Array** fields each render a red "An error occurred" box with an "Unset value" button. The **String control** field at the bottom uses the same two-argument validation and renders fine — that contrast is the whole bug. After this PR all four render normally.

### Description

Fixes [SAPP-4084](https://linear.app/sanity/issue/SAPP-4084/studio-crashes-on-urlnumberarray-fields-with-a-two-argument-validation) / [#13559](https://github.com/sanity-io/sanity/issues/13559): a `url`, `number`, or `array` field is unusable if its `validation` takes two arguments — which is the form [the validation docs recommend](https://www.sanity.io/docs/studio/validation) for conditionally hidden fields (`(rule, context) => context?.hidden ? rule.skip() : rule.required()`).

`@sanity/types` documents that after `inferFromSchema`, `validation` is always an array of `Rule` instances. [#12050](https://github.com/sanity-io/sanity/issues/12050) (5.9.0) stopped upholding that for context-aware validation, since such a function has to be re-evaluated per value while validating. That deferral is correct; the bug is that `getValidationRule` still assumed the old invariant and threw. It's the only form-layer consumer of raw `validation`, and only `UrlInput` (`uri`), `NumberInput` (`min`/`integer`/`precision`) and `ArrayValidationProvider` (`max`) call it — hence exactly those three field types.

Resolving the deferred function *without* a context isn't a guess: pre-5.9.0 schema compilation did precisely that for every validation function, so these inputs read the same rules they did before the regression. `extractSchema` and the descriptor converter in `@sanity/schema` already use the same trick. It's also semantically right here, since these rules are presentation hints and a falsy `context?.hidden` yields the visible-field rules.

Alternatives rejected:

- **Restore the invariant** by storing a normalized snapshot on the schema type alongside the raw function — more invasive, and adds schema-layer surface to serve one presentational consumer.
- **Return no rules when deferred** — stops the crash but silently degrades `type="url"`, `inputMode`, and max-items-reached instead of recovering the real hints. Kept only as the fallback for validation that genuinely can't be evaluated without a context.

### What to review

Single package: `sanity`.

- `packages/sanity/src/core/form/utils/getValidationRule.ts` is the whole fix. Two bits worth a look: the `try`/`catch` (validation that reads `context.document` without optional chaining would otherwise just swap the old error for a `TypeError`), and the `WeakMap` cache (`NumberInput` calls this three times per render unmemoized, and normalization invokes user code; context-aware `validation` is never mutated after compilation, so the entry is stable).
- The issue misses a **second failure mode**: when `validation` is an *array* containing a context-aware function, the whole array is left un-normalized, slips past the `typeof === 'function'` check, and dies later on `rule._rules is not iterable`. Covered by a test.

### Testing

- New `getValidationRule.test.ts` compiles a real schema and covers arity-1 (control), arity-2 on `url`/`number`/`array`, mixed arrays, and unsafe context access.
- New `NumberInput` render test proves the input renders rather than hitting the error boundary.
- Both confirmed failing on stashed code with the issue's exact message, and passing with the fix.
- Full `test/validation` + `src/core/form` suites: 822 passing. The one failure (`FormBuilder.test.tsx` snapshot) reproduces without this change and is unrelated.
- `dev/test-studio` gains a `twoArgValidationRepro` document type under Structure → Inputs → Debug for manual checks.

Not covered: no automated test for `UrlInput`/array inputs specifically. They fail through the same single function, which is unit-tested directly, and the deployment above covers them visually.

### Notes for release

Fixed a crash where `url`, `number`, and `array` fields became unusable — showing "An error occurred" instead of an input — when their `validation` used the two-argument form that receives the validation context:

```js
defineField({
  name: 'link',
  type: 'url',
  validation: (rule, context) => (context?.hidden ? rule.skip() : rule.required().uri({scheme: ['https']})),
})
```

This is the pattern the validation documentation recommends for conditionally hidden fields, and it previously only worked on `string` fields. It now works on every field type. If you worked around this by moving context access into a `custom()` callback, that workaround is still valid and needs no change.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches form-layer validation rule resolution used by UrlInput, NumberInput, and array inputs; behavior change is intentional recovery of pre-5.9.0 hints with a safe empty fallback when context is required.
> 
> **Overview**
> Fixes **SAPP-4084**: `url`, `number`, and `array` fields no longer crash at render when `validation` uses the documented two-argument form `(rule, context) => ...`.
> 
> **`getValidationRule`** no longer throws when schema compilation left validation as a raw function (context-aware rules are deferred at compile time). It now **lazily normalizes** those rules via `normalizeValidationRules` (without validation context), caches results in a **`WeakMap`**, and returns **no hints** if normalization fails because validation requires a real context.
> 
> Also handles **mixed validation arrays** (plain + context-aware functions) that previously failed with `_rules is not iterable`.
> 
> Adds **`getValidationRule` unit tests**, a **`NumberInput`** render test for context-aware validation, and a **test-studio debug schema** (`twoArgValidationRepro`) for manual repro.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38779f6eba472fbce215ccb31b8fa27c94eb48bb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->