### PR TITLE
ci(e2e): propagate dataset setup failures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,8 +85,11 @@ jobs:
         run: |
           echo "Creating datasets: ${{ env.CHROMIUM_DATASET }} and ${{ env.FIREFOX_DATASET }}"
           SANITY_E2E_DATASET=${{ env.CHROMIUM_DATASET }} pnpm e2e:setup &
+          chromium_pid=$!
           SANITY_E2E_DATASET=${{ env.FIREFOX_DATASET }} pnpm e2e:setup &
-          wait
+          firefox_pid=$!
+          wait "$chromium_pid"
+          wait "$firefox_pid"
 
   deploy-preview:
     runs-on: ubuntu-8core


### PR DESCRIPTION
## Summary

Makes the parallel E2E dataset setup report a failure when either browser dataset cannot be created.

Linear: Fixes [AIGRO-5332](https://linear.app/sanity/issue/AIGRO-5332/make-e2e-dataset-setup-surface-provisioning-failures)

The workflow creates separate Chromium and Firefox datasets in background processes. Waiting for each process explicitly keeps the setup status aligned with the actual result. Downstream tests only start after both datasets are ready, and re-running failed jobs can retry dataset setup when needed.

## What prompted this

In a [previous E2E run](https://github.com/sanity-io/sanity/actions/runs/31012995098), the Firefox dataset creation request returned a server error, but the dataset setup job still completed successfully. All four Firefox shards then started without that dataset and failed before running tests with `Dataset not found` responses.

A failed-jobs rerun produced the same result because dataset setup was already marked successful. The [linked Firefox shard](https://github.com/sanity-io/sanity/actions/runs/31012995098/job/92332701761?pr=13879) shows the repeated missing-dataset failure.

With this change, the setup job reports the original provisioning failure instead. That keeps the failure close to its cause and allows a failed-jobs rerun to retry dataset creation.

## Testing

- Verified the previous wait behavior exits successfully when one background process fails, while the updated behavior exits with a failure
- Formatting check
- Actionlint
- Targeted zizmor audit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only shell change in dataset setup; no application, auth, or production runtime impact.
>
> **Overview**
> Fixes a **false-green** `dataset-setup` job when parallel Chromium/Firefox `pnpm e2e:setup` runs in the background.
>
> The step now records each background PID and runs **`wait "$chromium_pid"`** and **`wait "$firefox_pid"`** instead of a bare **`wait`**, so a failed dataset creation fails the job with that process’s exit code. **`playwright-test`** (which **`needs: dataset-setup`**) no longer starts on a missing Firefox/Chromium dataset, and **re-run failed jobs** can retry provisioning instead of skipping setup because the job was already marked successful.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ff62c8f111d1ec4499797e50c6537edaa212f94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
