### PR TITLE
fix(comments): clear the blur guard on mouse press inside the editor

### DIFF
--- a/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
+++ b/packages/sanity/src/core/comments/plugin/input/components/CommentsPortableTextInput.tsx
@@ -306,6 +306,10 @@ const CommentsPortableTextInputInner = memo(function CommentsPortableTextInputIn
   const debounceSelectionChange = useDebounceSelectionChange(handleSelectionChange)
 
   const handleMouseDown = useCallback(() => {
+    // A mouse press inside the editor means the selection that follows is
+    // made by the user, not restored by a re-focus, so the `blurred` guard
+    // in `handleSelectionChange` must not swallow it.
+    blurred.current = false
     startTransition(() => setMousePressed(true))
   }, [])
 


### PR DESCRIPTION
### Description

The floating comment button in Portable Text inputs intermittently fails to appear on the first double-click word selection; an identical second attempt shows it. It fails exactly when the editor was blurred before the selection: the `blurred` guard in `CommentsPortableTextInput` (added in ef50844e2b so a programmatic focus restore does not pop the button) swallows the single debounced selection change a double-click produces, and caret clicks return early before the guard, so the first range selection after any blur always fails and the second always works.

The fix clears `blurred` in `handleMouseDown`: a mouse press inside the editor means the selection that follows is user-made, not restored by a re-focus. Full failure sequence in the commit body.

This patches the existing mechanism rather than rethinking it. The popover is edge-triggered: it reconstructs "the user finished selecting" from event ordering (a 200ms debounced selection change, a blur flag, mouse-pressed state), and both bugs in this area have been mis-ordered edges; the guard #7588 added to suppress one edge is what swallows selections here. A level-triggered reimplementation, where visibility is a pure function of the current editor selection, would remove the class of bug entirely. Out of scope here.

### What to review

One line of code (plus a comment). To reproduce on `main`:

1. Open a document with a Portable Text field with text, comments enabled.
2. Click into the field (focus), then click outside it (blur arms the guard).
3. Double-click a word: the comment button does not appear. Double-click again: it does.

With the fix, step 3 shows the button on the first try. Also confirm the guard's original case (#7588): select text, open the link annotation popover, close it; the button must not appear on the restored selection.

### Testing

No automated test: the failure needs real browser double-click timing, an editor blur, and the debounce, which is not practical to pin as a unit test. Verified manually with the steps above: the button appears on the first double-click after a blur, and the restored selection after closing an annotation popover still does not pop the button.

### Notes for release

Fixed an issue where the inline comment button in Portable Text inputs would intermittently not appear on the first text selection when the editor was not already focused.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line behavioral tweak in comments PTE input event ordering; low blast radius with manual regression called out for annotation popover focus restore.
> 
> **Overview**
> Fixes the inline comment button sometimes missing on the **first** text selection after the Portable Text editor was blurred (e.g. first double-click word select fails; second works).
> 
> `handleMouseDown` now sets **`blurred.current = false`** before the debounced selection handler runs, so a press inside the editor is treated as an intentional user selection rather than a focus-restore event. The existing blur guard in `handleSelectionChange` (to avoid popping the button on restored selection after closing annotation UI) is unchanged for cases without a preceding mousedown in the editor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56cbb81bf65536900b82358b28d46dd0d8590924. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->