### PR TITLE
fix(core): use project api host for media library video asset queries

### DIFF
--- a/packages/sanity/src/core/form/studio/inputs/client-adapters/assets.ts
+++ b/packages/sanity/src/core/form/studio/inputs/client-adapters/assets.ts
@@ -5,6 +5,7 @@ import {catchError, map, mergeMap, startWith} from 'rxjs/operators'
 
 import {type VideoAsset} from '../../../../../media-library/plugin/schemas/types'
 import {type DocumentPreviewStore} from '../../../../preview/documentPreviewStore'
+import {createMediaLibraryClient} from '../../../../store/accessPolicy/fetch'
 import {sourceName as MEDIA_LIBRARY_SOURCE_NAME} from '../../assetSourceMediaLibrary'
 import {DEFAULT_API_VERSION} from '../../assetSourceMediaLibrary/constants'
 import {type UploadOptions} from '../../uploads/types'
@@ -235,11 +236,9 @@ export function observeVideoAsset(
     return observableOf(minimalAsset)
   }
 
-  const resourceConfig = {
-    resource: {type: 'media-library' as const, id: mediaLibraryId},
-  }
-  const mlClient = client.withConfig({
-    ...resourceConfig,
+  // Uses the project API host (projectId subdomain) rather than the global
+  // host, which lacks the project's CORS headers and fails in the browser.
+  const mlClient = createMediaLibraryClient(client, mediaLibraryId).withConfig({
     apiVersion: DEFAULT_API_VERSION,
   })
 

--- a/packages/sanity/src/core/form/studio/inputs/client-adapters/assets.ts
+++ b/packages/sanity/src/core/form/studio/inputs/client-adapters/assets.ts
@@ -5,7 +5,7 @@ import {catchError, map, mergeMap, startWith} from 'rxjs/operators'
 
 import {type VideoAsset} from '../../../../../media-library/plugin/schemas/types'
 import {type DocumentPreviewStore} from '../../../../preview/documentPreviewStore'
-import {createMediaLibraryClient} from '../../../../store/accessPolicy/fetch'
+import {createMediaLibraryClient} from '../../../../util/createMediaLibraryClient'
 import {sourceName as MEDIA_LIBRARY_SOURCE_NAME} from '../../assetSourceMediaLibrary'
 import {DEFAULT_API_VERSION} from '../../assetSourceMediaLibrary/constants'
 import {type UploadOptions} from '../../uploads/types'

--- a/packages/sanity/src/core/store/accessPolicy/fetch.ts
+++ b/packages/sanity/src/core/store/accessPolicy/fetch.ts
@@ -2,6 +2,7 @@ import {type SanityClient} from '@sanity/client'
 import DataLoader from 'dataloader'
 import QuickLRU from 'quick-lru'
 
+import {createMediaLibraryClient} from '../../util/createMediaLibraryClient'
 import {makeMediaLibraryRef, type MediaLibraryRef} from './refs'
 
 type AccessPolicyResult = 'public' | 'private' | undefined
@@ -58,35 +59,6 @@ async function fetchAccessPoliciesBatch(params: {
 
     return assetIds.map(() => undefined)
   }
-}
-
-/**
- * Creates a Media Library-specific client with an explicitly configured API
- * host that includes the project ID in the subdomain. This is to satisfy CORS
- * requirements, as browser requests will fail against the global host because
- * it does not include CORS headers. (Setting `resource` on a client makes it
- * ignore `useProjectHostname` and target the global API host.)
- *
- * @internal
- */
-export function createMediaLibraryClient(client: SanityClient, libraryId: string): SanityClient {
-  const {apiHost: base, projectId: subdomain} = client.config()
-
-  if (!subdomain) {
-    throw new Error('Cannot create Media Library client: missing projectId in client config')
-  }
-
-  const baseUrl = new URL(base)
-  baseUrl.hostname = `${subdomain}.${baseUrl.hostname}`
-  const apiHost = baseUrl.toString()
-
-  return client.withConfig({
-    apiHost,
-    resource: {
-      id: libraryId,
-      type: 'media-library',
-    },
-  })
 }
 
 /**

--- a/packages/sanity/src/core/store/accessPolicy/fetch.ts
+++ b/packages/sanity/src/core/store/accessPolicy/fetch.ts
@@ -63,10 +63,13 @@ async function fetchAccessPoliciesBatch(params: {
 /**
  * Creates a Media Library-specific client with an explicitly configured API
  * host that includes the project ID in the subdomain. This is to satisfy CORS
- * requirements when performing CDN access policy checks, as browser requests
- * will fail against the global host because it does not include CORS headers.
+ * requirements, as browser requests will fail against the global host because
+ * it does not include CORS headers. (Setting `resource` on a client makes it
+ * ignore `useProjectHostname` and target the global API host.)
+ *
+ * @internal
  */
-function createMediaLibraryClient(client: SanityClient, libraryId: string): SanityClient {
+export function createMediaLibraryClient(client: SanityClient, libraryId: string): SanityClient {
   const {apiHost: base, projectId: subdomain} = client.config()
 
   if (!subdomain) {

--- a/packages/sanity/src/core/util/__tests__/createMediaLibraryClient.test.ts
+++ b/packages/sanity/src/core/util/__tests__/createMediaLibraryClient.test.ts
@@ -1,0 +1,57 @@
+import {createClient} from '@sanity/client'
+import {describe, expect, it} from 'vitest'
+
+import {createMediaLibraryClient} from '../createMediaLibraryClient'
+
+function createTestClient(config: Record<string, unknown> = {}) {
+  return createClient({
+    projectId: 'abc123',
+    dataset: 'production',
+    apiVersion: '2025-02-19',
+    useCdn: false,
+    ...config,
+  })
+}
+
+describe('createMediaLibraryClient', () => {
+  it('rewrites apiHost to the project subdomain and sets the media library resource', () => {
+    const mlClient = createMediaLibraryClient(createTestClient(), 'ml123')
+    const config = mlClient.config()
+
+    expect(config.apiHost).toBe('https://abc123.api.sanity.io')
+    expect(config.resource).toEqual({id: 'ml123', type: 'media-library'})
+  })
+
+  it('produces request URLs on the project host without a double slash', () => {
+    // Setting `resource` makes @sanity/client ignore `useProjectHostname` and
+    // build URLs from `apiHost` directly, so the rewritten host must be an
+    // origin without a trailing slash.
+    const mlClient = createMediaLibraryClient(createTestClient(), 'ml123')
+
+    expect(mlClient.getUrl('/media-libraries/ml123/query')).toBe(
+      'https://abc123.api.sanity.io/v2025-02-19/media-libraries/ml123/query',
+    )
+  })
+
+  it('preserves custom API hosts (e.g. staging)', () => {
+    const client = createTestClient({apiHost: 'https://api.sanity.work'})
+    const mlClient = createMediaLibraryClient(client, 'ml123')
+
+    expect(mlClient.config().apiHost).toBe('https://abc123.api.sanity.work')
+  })
+
+  it('drops any pathname configured on apiHost', () => {
+    const client = createTestClient({apiHost: 'https://api.sanity.io/some/path'})
+    const mlClient = createMediaLibraryClient(client, 'ml123')
+
+    expect(mlClient.config().apiHost).toBe('https://abc123.api.sanity.io')
+  })
+
+  it('throws when the client has no projectId', () => {
+    const client = createTestClient({projectId: undefined, useProjectHostname: false})
+
+    expect(() => createMediaLibraryClient(client, 'ml123')).toThrow(
+      'Cannot create Media Library client: missing projectId in client config',
+    )
+  })
+})

--- a/packages/sanity/src/core/util/createMediaLibraryClient.ts
+++ b/packages/sanity/src/core/util/createMediaLibraryClient.ts
@@ -10,18 +10,19 @@ import {type SanityClient} from '@sanity/client'
  * @internal
  */
 export function createMediaLibraryClient(client: SanityClient, libraryId: string): SanityClient {
-  const {apiHost: base, projectId: subdomain} = client.config()
+  const {apiHost, projectId} = client.config()
 
-  if (!subdomain) {
+  if (!projectId) {
     throw new Error('Cannot create Media Library client: missing projectId in client config')
   }
 
-  const baseUrl = new URL(base)
-  baseUrl.hostname = `${subdomain}.${baseUrl.hostname}`
-  const apiHost = baseUrl.toString()
+  const baseUrl = new URL(apiHost)
+  baseUrl.hostname = `${projectId}.${baseUrl.hostname}`
 
   return client.withConfig({
-    apiHost,
+    // `origin` (rather than `toString()`) avoids a trailing slash and drops
+    // any pathname/search/hash that may have been configured on `apiHost`
+    apiHost: baseUrl.origin,
     resource: {
       id: libraryId,
       type: 'media-library',

--- a/packages/sanity/src/core/util/createMediaLibraryClient.ts
+++ b/packages/sanity/src/core/util/createMediaLibraryClient.ts
@@ -1,0 +1,30 @@
+import {type SanityClient} from '@sanity/client'
+
+/**
+ * Creates a Media Library-specific client with an explicitly configured API
+ * host that includes the project ID in the subdomain. This is to satisfy CORS
+ * requirements, as browser requests will fail against the global host because
+ * it does not include CORS headers. (Setting `resource` on a client makes it
+ * ignore `useProjectHostname` and target the global API host.)
+ *
+ * @internal
+ */
+export function createMediaLibraryClient(client: SanityClient, libraryId: string): SanityClient {
+  const {apiHost: base, projectId: subdomain} = client.config()
+
+  if (!subdomain) {
+    throw new Error('Cannot create Media Library client: missing projectId in client config')
+  }
+
+  const baseUrl = new URL(base)
+  baseUrl.hostname = `${subdomain}.${baseUrl.hostname}`
+  const apiHost = baseUrl.toString()
+
+  return client.withConfig({
+    apiHost,
+    resource: {
+      id: libraryId,
+      type: 'media-library',
+    },
+  })
+}


### PR DESCRIPTION
### Description

Setting `resource` on a client makes `@sanity/client` ignore `useProjectHostname` and target the global API host, which lacks the project's CORS headers and fails in the browser. `observeVideoAsset` now builds its Media Library client via `createMediaLibraryClient`, which points `apiHost` at the project subdomain — the same approach already used for CDN access-policy checks.

Follow-ups from review:

* The helper was extracted from `core/store/accessPolicy/fetch.ts` into a dependency-free `core/util/createMediaLibraryClient.ts`, so the broad UI/upload flows importing `client-adapters/assets.ts` don't eagerly pull in the access-policy DataLoader/QuickLRU caches.
* The helper now uses `URL.origin` instead of `URL.toString()` for the rewritten `apiHost`. This fixed a latent (harmless) bug: the trailing slash from `toString()` produced double-slash request URLs (`...api.sanity.io//v2025-...`).

An alternative would be a raw `client.request({uri: '/media-libraries/...'})` like `useVideoPlaybackInfo` does, but that means hand-encoding GROQ query params; keeping the `resource`-configured client with a corrected `apiHost` preserves normal `fetch()` semantics.

### What to review

* That this is the correct fix (for now).
* `packages/sanity/src/core/util/createMediaLibraryClient.ts` — the host rewriting and its placement in `core/util`.
* Only the `sanity` package is affected.

### Testing

* Added unit tests in `core/util/__tests__/createMediaLibraryClient.test.ts` covering host rewriting, resource config, custom API hosts (staging), pathname stripping, no double slash in generated URLs, and the missing-`projectId` error. They use the real `createClient` (no network) so the actual config plumbing is exercised.
* Manually: no more CORS errors on the path `test/structure/input-standard;videosTest;` documents (in this preview build) for studios running standalone on foreign hosts.

### Notes for release

* Fixed a CORS error when using video fields in your schema.

<!--
Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow client URL configuration change with existing pattern for access-policy fetches and new unit tests; no auth or data-model changes.
> 
> **Overview**
> **Fixes browser CORS failures** when Studio loads media-library video assets by routing those requests through the project subdomain API host instead of the global host (which lacks project CORS headers when `resource` is set on `@sanity/client`).
> 
> `createMediaLibraryClient` is **extracted** from `accessPolicy/fetch.ts` into `core/util/createMediaLibraryClient.ts` and reused in the form **assets** adapter for video observe/fetch. The shared helper now sets `apiHost` via `URL.origin` so URLs stay clean (no trailing slash or stray path segments). **Unit tests** cover host rewriting, custom/staging hosts, and missing `projectId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a4758efba1b4243e22e363b48a0770275773a00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

