### PR TITLE
fix(core): show variant title in document group inventory footer

### DIFF
--- a/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventoryAction.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/DocumentGroupInventoryAction.tsx
@@ -10,12 +10,12 @@ import {Button as BaseButton} from '../../../ui-components/button/Button'
 import {Popover} from '../../../ui-components/popover/Popover'
 import {useVersionRelease} from '../../hooks/useVersionRelease'
 import {useTranslation} from '../../i18n/hooks/useTranslation'
-import {type TFunction} from '../../i18n/types'
 import {type TargetPerspective} from '../../perspective/types'
+import {usePerspective} from '../../perspective/usePerspective'
 import {ReleaseAvatarIcon} from '../../releases/components/ReleaseAvatar'
 import {useDocumentVersionsObservable} from '../../releases/hooks/useDocumentVersions'
-import {isDraftPerspective, isPublishedPerspective} from '../../releases/util/util'
-import {isAgentBundleName} from '../../store/agent/createAgentBundlesStore'
+import {useAllVariants} from '../../variants/store/useAllVariants'
+import {getDocumentGroupInventoryActionLabel} from '../utils/getDocumentGroupInventoryActionLabel'
 
 export const DocumentGroupInventoryAction: ComponentType<
   PropsWithChildren<{
@@ -33,6 +33,8 @@ export const DocumentGroupInventoryAction: ComponentType<
 }) => {
   const {t} = useTranslation()
   const displayedRelease = useVersionRelease(documentId)
+  const {selectedVariant} = usePerspective()
+  const {byId: variantsById} = useAllVariants()
   const buttonElement = useRef<HTMLButtonElement | null>(null)
   const popoverElement = useRef<HTMLDivElement | null>(null)
 
@@ -44,6 +46,22 @@ export const DocumentGroupInventoryAction: ComponentType<
       [versionState],
     ),
   )
+
+  const currentVersion = useObservable(
+    useMemo(
+      () =>
+        versionState.pipe(
+          map(({versions}) => versions.find((version) => version._id === documentId)),
+        ),
+      [versionState, documentId],
+    ),
+  )
+
+  const variantRef = currentVersion?._system?.variant?._ref
+  const documentVariant = variantRef ? variantsById.get(variantRef) : undefined
+  // Prefer the open document's variant; fall back to the globally selected one
+  // (same title shown in the variants navbar).
+  const variant = documentVariant ?? selectedVariant
 
   useClickOutsideEvent(
     (event) => {
@@ -77,7 +95,11 @@ export const DocumentGroupInventoryAction: ComponentType<
         <Button
           ref={buttonElement}
           data-testid="action-document-group-inventory"
-          text={variantLabel({perspective: displayedRelease?.release, t})}
+          text={getDocumentGroupInventoryActionLabel({
+            perspective: displayedRelease?.release,
+            variant,
+            t,
+          })}
           tone="neutral"
           onClick={() => setIsDocumentGroupInventoryActive(!isDocumentGroupInventoryActive)}
           icon={<VariantIcon perspective={displayedRelease.release} />}
@@ -88,36 +110,6 @@ export const DocumentGroupInventoryAction: ComponentType<
       </Popover>
     </LayerProvider>
   )
-}
-
-function variantLabel({
-  perspective,
-  t,
-}: {
-  perspective: TargetPerspective | undefined
-  t: TFunction
-}): string {
-  if (typeof perspective === 'undefined') {
-    return ''
-  }
-
-  if (isAgentBundleName(perspective)) {
-    return t('version.agent-bundle.proposed-changes')
-  }
-
-  if (isDraftPerspective(perspective)) {
-    return 'Draft'
-  }
-
-  if (isPublishedPerspective(perspective)) {
-    return 'Published'
-  }
-
-  if (typeof perspective === 'string') {
-    return perspective
-  }
-
-  return perspective.metadata.title ?? perspective._id
 }
 
 const VariantIcon: ComponentType<{perspective: TargetPerspective | undefined}> = ({

--- a/packages/sanity/src/core/documentGroupInventory/utils/computeSets.test.ts
+++ b/packages/sanity/src/core/documentGroupInventory/utils/computeSets.test.ts
@@ -337,5 +337,22 @@ describe('computeSets', () => {
         'Alpha audience',
       ])
     })
+
+    it('uses the short variant id when a variant definition has no title', () => {
+      const untitled = {
+        ...variantAlphaAudience,
+        metadata: undefined,
+      }
+      const versions = [variantDraft(untitled, 'scopeA')]
+
+      const meta = createMeta({
+        versions,
+        variants: new Map([[untitled._id, untitled]]),
+      })
+
+      const sets = computeSets({meta, current: [], t, variantsEnabled: true})
+
+      expect(sets[0]?.variants.map(({name}) => name)).toEqual(['alpha-audience'])
+    })
   })
 })

--- a/packages/sanity/src/core/documentGroupInventory/utils/computeSets.ts
+++ b/packages/sanity/src/core/documentGroupInventory/utils/computeSets.ts
@@ -5,6 +5,7 @@ import {type VersionInfoDocumentStub} from '../../releases/store/types'
 import {isAgentBundleName} from '../../store/agent/createAgentBundlesStore'
 import {getVersionFromId, type SystemBundle} from '../../util/draftUtils'
 import {readVersionType} from '../../util/versionsUtils'
+import {getVariantTitle} from '../../variants/tool/util'
 import {type SystemVariant} from '../../variants/types'
 import {type Meta, type VariantSet} from '../machines/documentGroupInventoryMachine'
 import {type Variant} from '../machines/selectionMachine'
@@ -150,9 +151,14 @@ function getVariantName({
   document: VersionInfoDocumentStub
   variants: Map<string, SystemVariant>
 }): string {
-  const releaseDocumentId = document._system.variant?._ref
-  const release = releaseDocumentId ? variants.get(releaseDocumentId) : undefined
-  return release?.metadata?.title ?? t('document-group.base-variant')
+  const variantDocumentId = document._system.variant?._ref
+  const variant = variantDocumentId ? variants.get(variantDocumentId) : undefined
+
+  if (!variant) {
+    return t('document-group.base-variant')
+  }
+
+  return getVariantTitle(variant)
 }
 
 function getVersionName({

--- a/packages/sanity/src/core/documentGroupInventory/utils/getDocumentGroupInventoryActionLabel.test.ts
+++ b/packages/sanity/src/core/documentGroupInventory/utils/getDocumentGroupInventoryActionLabel.test.ts
@@ -1,0 +1,98 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {describe, expect, it} from 'vitest'
+
+import {type TFunction} from '../../i18n/types'
+import {createMockVariant} from '../../variants/__fixtures__/createMockVariant'
+import {variantAlphaAudience} from '../../variants/__fixtures__/variants.fixture'
+import {getDocumentGroupInventoryActionLabel} from './getDocumentGroupInventoryActionLabel'
+
+const t = ((key: string) => key) as unknown as TFunction
+
+describe('getDocumentGroupInventoryActionLabel', () => {
+  it('returns an empty string when there is no perspective', () => {
+    expect(
+      getDocumentGroupInventoryActionLabel({
+        perspective: undefined,
+        variant: undefined,
+        t,
+      }),
+    ).toBe('')
+  })
+
+  it('labels drafts and published perspectives', () => {
+    expect(
+      getDocumentGroupInventoryActionLabel({
+        perspective: 'drafts',
+        variant: undefined,
+        t,
+      }),
+    ).toBe('Draft')
+
+    expect(
+      getDocumentGroupInventoryActionLabel({
+        perspective: 'published',
+        variant: undefined,
+        t,
+      }),
+    ).toBe('Published')
+  })
+
+  it('labels agent bundles', () => {
+    expect(
+      getDocumentGroupInventoryActionLabel({
+        perspective: 'agent-abc123',
+        variant: undefined,
+        t,
+      }),
+    ).toBe('version.agent-bundle.proposed-changes')
+  })
+
+  it('uses the release title when the perspective is a release document', () => {
+    const release = {
+      _id: '_.releases.rSummer',
+      metadata: {title: 'Summer drop'},
+    } as unknown as ReleaseDocument
+
+    expect(
+      getDocumentGroupInventoryActionLabel({
+        perspective: release,
+        variant: variantAlphaAudience,
+        t,
+      }),
+    ).toBe('Summer drop')
+  })
+
+  it('uses the variant title when the perspective is a raw scope id', () => {
+    // Variant documents live at `versions.<scopeId>.<docId>`. `useVersionRelease`
+    // cannot resolve that scope id to a release, so it falls back to the raw id.
+    expect(
+      getDocumentGroupInventoryActionLabel({
+        perspective: 'Ab12cd34',
+        variant: variantAlphaAudience,
+        t,
+      }),
+    ).toBe('Alpha audience')
+  })
+
+  it('falls back to the short variant id when the variant has no title', () => {
+    const untitled = createMockVariant('Ab12cd34')
+
+    expect(
+      getDocumentGroupInventoryActionLabel({
+        perspective: 'Ab12cd34',
+        variant: untitled,
+        t,
+      }),
+    ).toBe('Ab12cd34')
+  })
+
+  it('falls back to the raw perspective string when no variant is available', () => {
+    expect(
+      getDocumentGroupInventoryActionLabel({
+        perspective: 'Ab12cd34',
+        variant: undefined,
+        t,
+      }),
+    ).toBe('Ab12cd34')
+  })
+})

--- a/packages/sanity/src/core/documentGroupInventory/utils/getDocumentGroupInventoryActionLabel.ts
+++ b/packages/sanity/src/core/documentGroupInventory/utils/getDocumentGroupInventoryActionLabel.ts
@@ -1,0 +1,53 @@
+import {type TFunction} from '../../i18n/types'
+import {type TargetPerspective} from '../../perspective/types'
+import {isDraftPerspective, isPublishedPerspective} from '../../releases/util/util'
+import {isAgentBundleName} from '../../store/agent/createAgentBundlesStore'
+import {getVariantTitle} from '../../variants/tool/util'
+import {type SystemVariant} from '../../variants/types'
+
+/**
+ * Label for the document group inventory footer action.
+ *
+ * Release documents show their release title. Variant-scoped documents (whose
+ * version id is a scope id, not a release) fall back from `useVersionRelease` to
+ * that raw id string — those must show the variant title instead.
+ *
+ * @internal
+ */
+export function getDocumentGroupInventoryActionLabel({
+  perspective,
+  variant,
+  t,
+}: {
+  perspective: TargetPerspective | undefined
+  variant: SystemVariant | undefined
+  t: TFunction
+}): string {
+  if (typeof perspective === 'undefined') {
+    return ''
+  }
+
+  if (isAgentBundleName(perspective)) {
+    return t('version.agent-bundle.proposed-changes')
+  }
+
+  if (isDraftPerspective(perspective)) {
+    return 'Draft'
+  }
+
+  if (isPublishedPerspective(perspective)) {
+    return 'Published'
+  }
+
+  if (typeof perspective === 'string') {
+    // Anonymous / variant scope ids are not releases. Prefer the variant title
+    // (matches the selected variant shown in the studio navbar).
+    if (variant) {
+      return getVariantTitle(variant)
+    }
+
+    return perspective
+  }
+
+  return perspective.metadata.title ?? perspective._id
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Variant-scoped documents live at `versions.<scopeId>.<docId>`. The inventory footer action used `useVersionRelease`, which only resolves releases — for a bare scope id it fell back to that raw id, so the button showed alphanumeric scope ids instead of the variant title shown in the navbar.

When the perspective is an unresolved string (not draft/published/release), resolve the open document's variant (falling back to the selected perspective variant) and label with `getVariantTitle`. Release documents keep showing the release title.

Also route inventory list entry names through `getVariantTitle` so untitled variants fall back to the short variant id instead of incorrectly showing "Base variant".

## What to review

- `DocumentGroupInventoryAction` variant resolution for the footer label
- `getDocumentGroupInventoryActionLabel` string-perspective + variant title path
- `computeSets` `getVariantName` using `getVariantTitle`

## Testing

- Unit tests for `getDocumentGroupInventoryActionLabel` (scope id → variant title, release title unchanged)
- Extended `computeSets` coverage for untitled variants
- `pnpm vitest run --project=sanity` on the inventory util tests

## Notes for release

Fixes the document group inventory footer so variant documents show the variant name instead of an opaque scope id.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88dc1b9e-048e-4509-8966-f1cfa8ed8b38?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88dc1b9e-048e-4509-8966-f1cfa8ed8b38&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

