### PR TITLE
chore(structure)!: remove DocumentPaneProvider forcedVersion override

### DIFF
--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -91,8 +91,6 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
     onFocusPath,
     onSetMaximizedPane,
     maximized = false,
-    // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-    forcedVersion,
     historyStore,
   } = props
   const {
@@ -136,25 +134,14 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
   const documentType = options.type
   // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
   const params = useUnique(paneRouter.params) || EMPTY_PARAMS
-  const perspective = usePerspective()
+  const {selectedReleaseId, selectedPerspectiveName, selectedVariantName, selectedPerspective} =
+    usePerspective()
 
   const workspace = useWorkspace()
   const advancedVersionControlEnabled = workspace.advancedVersionControl.enabled
   const isDraftModelEnabled = workspace.document.drafts.enabled
 
   const enhancedObjectDialogEnabled = true
-
-  const {selectedReleaseId, selectedPerspectiveName} = useMemo(() => {
-    // TODO: COREL - Remove this after updating sanity-assist to use <PerspectiveProvider>
-    if (forcedVersion) {
-      return forcedVersion
-    }
-
-    return {
-      selectedPerspectiveName: perspective.selectedPerspectiveName,
-      selectedReleaseId: perspective.selectedReleaseId,
-    }
-  }, [forcedVersion, perspective.selectedPerspectiveName, perspective.selectedReleaseId])
 
   const {data: releases = EMPTY_ARRAY} = useActiveReleases()
 
@@ -238,7 +225,7 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
   // Exception: a creatable missing draft variant (server-advertised id) is editable — typing
   // creates the document seeded from the published sibling.
   const isVariantTargetReadOnly =
-    Boolean(perspective.selectedVariantName) &&
+    Boolean(selectedVariantName) &&
     targetDocumentState.status !== 'ready' &&
     !getCreatableVariantTarget(targetDocumentState)
 
@@ -260,7 +247,7 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
         isVariantTargetReadOnly ||
         (!isPaused &&
           !isPerspectiveWriteable({
-            selectedPerspective: perspective.selectedPerspective,
+            selectedPerspective: selectedPerspective,
             isDraftModelEnabled,
             schemaType,
           }).result)
@@ -271,7 +258,7 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
       isDeleting,
       isDraftModelEnabled,
       params.rev,
-      perspective.selectedPerspective,
+      selectedPerspective,
       isVariantTargetReadOnly,
       schemaType,
       releases,

--- a/packages/sanity/src/structure/panes/types.ts
+++ b/packages/sanity/src/structure/panes/types.ts
@@ -10,18 +10,6 @@ export interface BaseStructureToolPaneProps<T extends PaneNode['type']> {
   isSelected?: boolean
   isActive?: boolean
   pane: Extract<PaneNode, {type: T}>
-  /**
-   * TODO: COREL - Remove this after updating sanity-assist to use <PerspectiveProvider>
-   *
-   * Allows to override the global version with a specific version or release.
-   * @deprecated use <PerspectiveProvider> instead
-   * @beta
-   */
-  forcedVersion?: {
-    selectedPerspectiveName: ReleaseId | 'published' | undefined
-    isReleaseLocked: boolean
-    selectedReleaseId: ReleaseId | undefined
-  }
 
   /**
    * @deprecated Avoid specifying a key, instead use `paneKey` if need be


### PR DESCRIPTION
### Description
Removes `DocumentPaneProvider` forced version.
Which was added two years ago to support sanity assist when we introduced content releases.
This has been deprecated for more than 18 months and sanity assist is not using it.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
perspective provider no longer accepts `forcedVersion`. use `<DocumentPaneProvider>` instead.

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---
