### PR TITLE
fix(comments): drop the teardown mutation of a reset editor instance

### DIFF
--- a/packages/sanity/src/core/comments/components/pte/comment-input/CommentInput.tsx
+++ b/packages/sanity/src/core/comments/components/pte/comment-input/CommentInput.tsx
@@ -128,6 +128,7 @@ export function CommentInput(props: CommentInputProps & RefAttributes<CommentInp
   const [focused, setFocused] = useState<boolean>(false)
   const editorRef = useRef<Editor | null>(null)
   const editorContainerRef = useRef<HTMLDivElement | null>(null)
+  const resetInstanceRef = useRef(false)
   const [showDiscardDialog, setShowDiscardDialog] = useState<boolean>(false)
 
   const preDivRef = useRef<HTMLDivElement | null>(null)
@@ -144,6 +145,10 @@ export function CommentInput(props: CommentInputProps & RefAttributes<CommentInp
   }, [])
 
   const resetEditorInstance = useCallback(() => {
+    // The discarded instance flushes pending mutations during teardown; drop
+    // them in `handleEvent` so a finished draft cannot overwrite the
+    // consumer's cleared draft state.
+    resetInstanceRef.current = true
     setEditorInstanceKey(keyGenerator())
   }, [])
 
@@ -152,6 +157,7 @@ export function CommentInput(props: CommentInputProps & RefAttributes<CommentInp
       // Focus the editor when ready if focusOnMount is true
       // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
       if (event.type === 'ready') {
+        resetInstanceRef.current = false
         if (focusOnMount) {
           requestFocus()
         }
@@ -168,7 +174,7 @@ export function CommentInput(props: CommentInputProps & RefAttributes<CommentInp
 
       // Update the comment value whenever the comment is edited by the user.
       // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-      if (event.type === 'mutation') {
+      if (event.type === 'mutation' && !resetInstanceRef.current) {
         onChange(event.value || EMPTY_ARRAY)
       }
     },

--- a/packages/sanity/src/core/comments/components/pte/comment-input/__tests__/CommentInput.browser.test.tsx
+++ b/packages/sanity/src/core/comments/components/pte/comment-input/__tests__/CommentInput.browser.test.tsx
@@ -1,3 +1,4 @@
+import {type PortableTextBlock} from '@sanity/types'
 import {describe, expect, it} from 'vitest'
 import {render} from 'vitest-browser-react'
 import {page, userEvent} from 'vitest/browser'
@@ -61,5 +62,37 @@ describe('Comments', () => {
       await userEvent.keyboard('{Enter}')
       await submitted
     })
+
+    it('Should start the next comment empty after submitting the previous one', async () => {
+      const {insertPortableText} = testHelpers()
+      let resolve!: (value: PortableTextBlock[]) => void
+      const submitted = new Promise<PortableTextBlock[]>((r) => (resolve = r))
+
+      void render(<CommentsInputStory onSubmit={resolve} />)
+      const $editable = page.getByTestId('comment-input-editable')
+      await expect.element($editable).toBeVisible()
+      await insertPortableText('First comment', $editable)
+      await expect.element(page.getByTestId('comment-input-send-button')).toBeEnabled()
+      // Submit while ' typed' still sits in the mutation debounce, so the
+      // discarded instance's teardown flush carries it.
+      await userEvent.keyboard(' typed')
+      await userEvent.keyboard('{Enter}')
+      expect(textOf(await submitted)).toBe('First comment typed')
+
+      await expect.element($editable).not.toHaveTextContent('First comment')
+
+      await insertPortableText('Second comment', $editable)
+      await expect.element($editable).toHaveTextContent(/^Second comment$/)
+    })
   })
 })
+
+function textOf(value: PortableTextBlock[]): string {
+  return value
+    .map((block) =>
+      Array.isArray(block.children)
+        ? block.children.map((child) => ('text' in child ? child.text : '')).join('')
+        : '',
+    )
+    .join('\n')
+}

--- a/packages/sanity/src/core/comments/components/pte/comment-input/__tests__/CommentInputStory.tsx
+++ b/packages/sanity/src/core/comments/components/pte/comment-input/__tests__/CommentInputStory.tsx
@@ -1,6 +1,6 @@
 import {type CurrentUser, type PortableTextBlock} from '@sanity/types'
 import noop from 'lodash-es/noop.js'
-import {useState} from 'react'
+import {useCallback, useState} from 'react'
 import {CommentInput} from 'sanity'
 
 import {TestWrapper} from '../../../../../../../test/browser/TestWrapper'
@@ -40,10 +40,21 @@ export function CommentsInputStory({
 }: {
   onDiscardCancel?: () => void
   onDiscardConfirm?: () => void
-  onSubmit?: () => void
+  onSubmit?: (value: PortableTextBlock[]) => void
   value?: PortableTextBlock[] | null
 }) {
   const [valueState, setValueState] = useState<PortableTextBlock[] | null>(value)
+
+  const handleSubmit = useCallback(
+    (nextValue: PortableTextBlock[]) => {
+      // The Studio resets the `value` it passes to `CommentInput` after each
+      // submit; the story does the same.
+      setValueState(null)
+      onSubmit(nextValue)
+    },
+    [onSubmit],
+  )
+
   return (
     <TestWrapper schemaTypes={SCHEMA_TYPES}>
       <CommentInput
@@ -56,7 +67,7 @@ export function CommentsInputStory({
         mentionOptions={MENTION_DATA}
         onDiscardConfirm={onDiscardConfirm}
         onDiscardCancel={onDiscardCancel}
-        onSubmit={onSubmit}
+        onSubmit={handleSubmit}
       />
     </TestWrapper>
   )


### PR DESCRIPTION
### Description

Starting a new Portable Text comment sometimes pre-fills the comment input with the text of the previously submitted comment. It looks random in the wild; the trigger is timing.

The comment input mirrors the editor's draft in consumer state through `mutation` events, debounced while typing and flushed when an editor instance unmounts (so a document-backed editor never loses an edit). Submitting already reads the editor's live value, so the saved comment was always complete. But when a submit landed while the last keystrokes still sat in the debounce, the discarded instance's teardown flush ran `onChange` *after* the consumer had cleared its draft, writing the submitted text back, and the next comment input mounted from that resurrected state.

The fix: a mutation delivered by an instance that a reset has already discarded is addressed to a finished draft, so `CommentInput` drops it. `resetEditorInstance` marks the instance discarded, `handleEvent` ignores its remaining `mutation` events, and the next instance's `ready` clears the mark. The abandon path is untouched: closing a comment without submitting is a plain unmount with no reset, so the field draft cache still receives the final keystrokes from the teardown flush, the thing that flush is genuinely for.

### What to review

One guard in `CommentInput.tsx`. The browser test pins the contract and is red on `main`; the story now clears its mirrored draft on submit, like the real consumers do, so it reproduces the sequence users actually hit.

### Testing

The bug, manually:

1. Select text in a Portable Text field and write a comment. Wait for the send button to enable, type a few more characters, and press Enter immediately. The timing matters: the trailing keystrokes must still sit in the mutation debounce when the input resets, so submitting after any pause does not trigger the bug.
2. Select different text and start a new comment. The input is empty. Before the fix it contained the previous comment.

The browser test runs the same sequence deterministically and also asserts the submitted payload carries the full text.

### Notes for release

Fixes a bug where the comment input on Portable Text fields could open pre-filled with the text of the previously submitted comment.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized guard in comment input event handling with a targeted browser test; no auth, data, or API changes.
> 
> **Overview**
> Fixes a race where **submitting a comment** could leave the next input pre-filled with the previous comment when trailing keystrokes were still in the editor’s debounced mutation pipeline.
> 
> `CommentInput` now sets a **discard flag** when `resetEditorInstance` runs (after submit or discard confirm) and **ignores `mutation` events** until the replacement editor fires `ready`, so teardown flushes from the old instance no longer call `onChange` after the parent has cleared draft state. Abandon-without-submit paths are unchanged—they still unmount without this flag, so teardown flushes keep working for field draft caching.
> 
> A **browser test** reproduces submit-during-debounce and asserts the second comment starts empty; the test **story** clears mirrored `value` on submit like Studio consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5354783db4eae1b4dd4c42de56caae7b4a077b93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->