### PR TITLE
feat: add resources export for resource binding lookup

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -69,6 +69,10 @@
       "monorepo": "./src/_exports/presentation.ts",
       "default": "./lib/presentation.js"
     },
+    "./resources": {
+      "monorepo": "./src/_exports/resources.ts",
+      "default": "./lib/resources.js"
+    },
     "./router": {
       "monorepo": "./src/_exports/router.ts",
       "default": "./lib/router.js"
@@ -101,6 +105,7 @@
       "./media-library": "./lib/media-library.js",
       "./migrate": "./lib/migrate.js",
       "./presentation": "./lib/presentation.js",
+      "./resources": "./lib/resources.js",
       "./router": "./lib/router.js",
       "./structure": "./lib/structure.js",
       "./workbench": "./lib/workbench.js",

--- a/packages/sanity/src/_exports/resources.ts
+++ b/packages/sanity/src/_exports/resources.ts
@@ -1,0 +1,1 @@
+export {resourceRef} from '../core/resources'

--- a/packages/sanity/src/core/resources/__test__/index.test.ts
+++ b/packages/sanity/src/core/resources/__test__/index.test.ts
@@ -1,0 +1,109 @@
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import {type RefFunc} from '..'
+
+const SCRIPT_ID = 'sanity-resource-bindings'
+
+const BINDINGS = [
+  {id: 'cors-1', name: 'localhost', type: 'sanity.project.cors'},
+  {id: 'dataset-1', name: 'production', type: 'sanity.project.dataset'},
+  {id: 'project-1', name: 'my-project', type: 'sanity.project'},
+  {id: 'role-1', name: 'editor', type: 'sanity.access.role'},
+  {id: 'studio-1', name: 'my-studio', type: 'sanity.studio'},
+  // Deliberately reuses the `my-project` name under a different type, so the
+  // tests can prove lookups are scoped by type and not by name alone.
+  {id: 'dataset-2', name: 'my-project', type: 'sanity.project.dataset'},
+]
+
+/**
+ * The module reads the `<script>` element and builds `resourceRef` at *import*
+ * time, so the bindings have to be in the DOM before the module is evaluated.
+ * `vi.resetModules()` drops the cached instance so each call re-runs that
+ * top-level code against the DOM as it stands right now.
+ *
+ * Passing no argument omits the script element entirely, which is what a studio
+ * built without blueprint resource bindings looks like.
+ */
+async function loadResourceRef(scriptContent?: string): Promise<Record<string, RefFunc>> {
+  if (typeof scriptContent === 'string') {
+    const el = document.createElement('script')
+    el.id = SCRIPT_ID
+    el.type = 'application/json'
+    el.textContent = scriptContent
+    document.body.appendChild(el)
+  }
+
+  vi.resetModules()
+  const mod = await import('..')
+  return mod.resourceRef
+}
+
+afterEach(() => {
+  // jsdom's `document` is shared by every test in this file (the environment is
+  // created per file, not per test), so the injected element has to be removed
+  // or it leaks into the next test.
+  document.getElementById(SCRIPT_ID)?.remove()
+  vi.resetModules()
+})
+
+describe('resourceRef', () => {
+  it('should have functions for each resource type', async () => {
+    const resourceRef = await loadResourceRef(JSON.stringify(BINDINGS))
+    const types = ['cors', 'dataset', 'project', 'role', 'studio']
+    for (const t of types) {
+      expect(t in resourceRef).toBeTruthy()
+    }
+  })
+
+  it('resolves ids from the parsed script element for every resource type', async () => {
+    const resourceRef = await loadResourceRef(JSON.stringify(BINDINGS))
+
+    expect(resourceRef.cors('localhost')).toBe('cors-1')
+    expect(resourceRef.dataset('production')).toBe('dataset-1')
+    expect(resourceRef.project('my-project')).toBe('project-1')
+    expect(resourceRef.role('editor')).toBe('role-1')
+    expect(resourceRef.studio('my-studio')).toBe('studio-1')
+  })
+
+  it('scopes lookups by resource type when a name is used more than once', async () => {
+    const resourceRef = await loadResourceRef(JSON.stringify(BINDINGS))
+
+    expect(resourceRef.project('my-project')).toBe('project-1')
+    expect(resourceRef.dataset('my-project')).toBe('dataset-2')
+    // `localhost` only exists as a cors binding, so asking for it as a dataset
+    // must not fall back to matching on name alone.
+    expect(() => resourceRef.dataset('localhost')).toThrow('Unable to find dataset with name')
+  })
+
+  it('throws a named error when the binding is missing', async () => {
+    const resourceRef = await loadResourceRef(JSON.stringify(BINDINGS))
+
+    expect(() => resourceRef.project('nope')).toThrow('Unable to find project with name nope')
+  })
+
+  it('treats a missing script element as having no bindings', async () => {
+    const resourceRef = await loadResourceRef()
+
+    expect(() => resourceRef.project('my-project')).toThrow(
+      'Unable to find project with name my-project',
+    )
+  })
+
+  it('treats an empty script element as having no bindings', async () => {
+    const resourceRef = await loadResourceRef('')
+
+    expect(() => resourceRef.project('my-project')).toThrow(
+      'Unable to find project with name my-project',
+    )
+  })
+
+  it('does not fail at import time when the script content is not valid JSON', async () => {
+    // A truncated or HTML-escaped payload must not take the whole studio down
+    // at module evaluation; it degrades to "no bindings" instead.
+    const resourceRef = await loadResourceRef('{not json')
+
+    expect(() => resourceRef.project('my-project')).toThrow(
+      'Unable to find project with name my-project',
+    )
+  })
+})

--- a/packages/sanity/src/core/resources/index.ts
+++ b/packages/sanity/src/core/resources/index.ts
@@ -34,7 +34,12 @@ export const resourceRef: Record<string, RefFunc> = {}
 
 // TODO: do we need to defer this code until the document is loaded?
 const el = document.getElementById('sanity-resource-bindings')
-const bindings: ResourceBinding[] = el ? JSON.parse(el.textContent || '[]') : []
+let bindings: ResourceBinding[]
+try {
+  bindings = el ? JSON.parse(el.textContent || '[]') : []
+} catch {
+  bindings = []
+}
 
 Object.entries(RESOURCE_MAP).forEach(([resourceType, data]) => {
   resourceRef[resourceType] = (name: string) => {

--- a/packages/sanity/src/core/resources/index.ts
+++ b/packages/sanity/src/core/resources/index.ts
@@ -1,0 +1,47 @@
+/**
+ * A map of supported resource types to their blueprint-specific information.
+ */
+const RESOURCE_MAP: Record<string, {type: string}> = {
+  cors: {type: 'sanity.project.cors'},
+  dataset: {type: 'sanity.project.dataset'},
+  project: {type: 'sanity.project'},
+  role: {type: 'sanity.access.role'},
+  studio: {type: 'sanity.studio'},
+}
+
+/**
+ * The shape of the resources in the script element
+ */
+interface ResourceBinding {
+  id: string
+  name: string
+  type: string
+}
+
+/**
+ * A function that looks up a resource binding based on its name.
+ */
+export type RefFunc = (name: string) => string
+
+/**
+ * An object that allows resource identifier to be looked up based on its name in a blueprint.
+ *
+ * ```
+ * resourceRef.project('my-project') // returns the project ID
+ * ```
+ */
+export const resourceRef: Record<string, RefFunc> = {}
+
+// TODO: do we need to defer this code until the document is loaded?
+const el = document.getElementById('sanity-resource-bindings')
+const bindings: ResourceBinding[] = el ? JSON.parse(el.textContent || '[]') : []
+
+Object.entries(RESOURCE_MAP).forEach(([resourceType, data]) => {
+  resourceRef[resourceType] = (name: string) => {
+    const found = bindings.find((b) => b.name === name && b.type === data.type)
+    if (!found) {
+      throw new Error(`Unable to find ${resourceType} with name ${name}`)
+    }
+    return found.id
+  }
+})


### PR DESCRIPTION
### Description

This PR adds logic that will allow studios to reference other blueprint resources by name to get their id.

```ts
resourceRef.project('my-project') // returns the project ID
```

### What to review

Determine if the logic needs to wait until the document is loaded. Unsure of how the config is loaded but the `sanity-resource-bindings` will precede the config script in the document when using the standard index.html generated during bundling.

### Testing

Verified locally in a studio. Added unit tests.

### Notes for release

N/A: Internal only, part of unreleased feature

---
