### PR TITLE
fix(core): keep an open object dialog open when focus lands on the item itself

### DIFF
--- a/packages/sanity/src/core/form/useDocumentForm.test.tsx
+++ b/packages/sanity/src/core/form/useDocumentForm.test.tsx
@@ -1,0 +1,96 @@
+import {type SanityClient} from '@sanity/client'
+import {defineArrayMember, defineField, defineType, type Path} from '@sanity/types'
+import {act, renderHook, waitFor} from '@testing-library/react'
+import {beforeEach, describe, expect, it} from 'vitest'
+
+import {createMockSanityClient} from '../../../test/mocks/mockSanityClient'
+import {createTestProvider} from '../../../test/testUtils/TestProvider'
+import {defineConfig} from '../config/defineConfig'
+import {administrator} from '../store/grants/debug/exampleGrants'
+import {useDocumentForm} from './useDocumentForm'
+
+const schemaTypes = [
+  defineType({
+    name: 'article',
+    type: 'document',
+    fields: [
+      defineField({
+        name: 'body',
+        type: 'array',
+        of: [defineArrayMember({type: 'block'}), defineArrayMember({type: 'image', name: 'image'})],
+      }),
+    ],
+  }),
+]
+
+const BLOCK_PATH: Path = ['body', {_key: 'block-a'}]
+const OTHER_BLOCK_PATH: Path = ['body', {_key: 'block-b'}]
+
+async function renderDocumentForm() {
+  const client = createMockSanityClient({
+    requests: {
+      // The permission checks behind the form's `readOnly` state read the dataset ACL.
+      '/acl': administrator,
+    },
+  }) as unknown as SanityClient
+  const wrapper = await createTestProvider({
+    client,
+    config: defineConfig({
+      projectId: 'test',
+      dataset: 'test',
+      schema: {types: schemaTypes},
+    }),
+  })
+
+  const {result} = renderHook(
+    () => useDocumentForm({documentId: 'article-1', documentType: 'article'}),
+    {wrapper},
+  )
+
+  // `onPathOpen` is a no-op until the form state exists, since it needs it to expand
+  // collapsed ancestors of the path being opened.
+  await waitFor(() => expect(result.current.formState).not.toBeNull())
+
+  return result
+}
+
+describe('useDocumentForm', () => {
+  let result: Awaited<ReturnType<typeof renderDocumentForm>>
+
+  beforeEach(async () => {
+    result = await renderDocumentForm()
+  })
+
+  it('follows the focused field into the object that contains it', async () => {
+    act(() => result.current.onFocus([...BLOCK_PATH, 'alt']))
+    await waitFor(() => expect(result.current.openPath).toEqual(BLOCK_PATH))
+  })
+
+  it('keeps an open array item open when focus lands on the item itself', async () => {
+    act(() => result.current.onPathOpen(BLOCK_PATH))
+    await waitFor(() => expect(result.current.openPath).toEqual(BLOCK_PATH))
+
+    // The Portable Text editor reports the block object's own path as the focus path
+    // whenever its selection is (re-)announced — while an upload is in flight, for
+    // instance. Stepping one segment up from there used to close the dialog editing the
+    // block, which unmounted the image input and aborted the upload.
+    act(() => result.current.onFocus(BLOCK_PATH))
+    await waitFor(() => expect(result.current.openPath).toEqual(BLOCK_PATH))
+  })
+
+  it('closes an open array item when focus moves to a sibling item', async () => {
+    act(() => result.current.onPathOpen(BLOCK_PATH))
+    await waitFor(() => expect(result.current.openPath).toEqual(BLOCK_PATH))
+
+    act(() => result.current.onFocus(OTHER_BLOCK_PATH))
+    await waitFor(() => expect(result.current.openPath).toEqual(['body']))
+  })
+
+  it('closes an open array item when focus moves to an unrelated field', async () => {
+    act(() => result.current.onPathOpen(BLOCK_PATH))
+    await waitFor(() => expect(result.current.openPath).toEqual(BLOCK_PATH))
+
+    act(() => result.current.onFocus(['title']))
+    await waitFor(() => expect(result.current.openPath).toEqual([]))
+  })
+})

--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -7,7 +7,7 @@ import {
   type SanityDocumentLike,
   type ValidationMarker,
 } from '@sanity/types'
-import {pathFor, resolveKeyedPath} from '@sanity/util/paths'
+import {isEqual, pathFor, resolveKeyedPath} from '@sanity/util/paths'
 import throttle from 'lodash-es/throttle.js'
 import {
   type RefObject,
@@ -363,6 +363,9 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
   const presence = useObservable(presence$, [])
 
   const [openPath, onSetOpenPath] = useState<Path>(initialFocusPath || EMPTY_ARRAY)
+  // Mirrors `openPath` so `handleFocus` sees writes made earlier in the same tick,
+  // before the state update has been rendered.
+  const openPathRef = useRef<Path>(openPath)
   const [fieldGroupState, onSetFieldGroupState] = useState<StateTree<string>>()
   const [collapsedPaths, onSetCollapsedPath] = useState<StateTree<boolean>>()
   const [collapsedFieldSets, onSetCollapsedFieldSets] = useState<StateTree<boolean>>()
@@ -644,6 +647,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
         onSetFieldGroupState((prevState) => setAtPath(prevState, op.path, op.groupName))
       }
     })
+    openPathRef.current = path
     onSetOpenPath(path)
   }
 
@@ -685,7 +689,12 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
     if (nextFocusPath !== focusPathRef.current) {
       setFocusPath(pathFor(nextFocusPath))
 
-      if (enhancedObjectDialogEnabled) {
+      // Focusing a field inside a nested object reveals the dialog that edits it, so
+      // `openPath` follows the focused field's parent. An array item reports its own
+      // path as the focus path though, so when focus lands on whatever is already open
+      // — a Portable Text block object re-reporting the editor selection, for instance —
+      // stepping one segment up from there would close the dialog editing it.
+      if (enhancedObjectDialogEnabled && !isEqual(openPathRef.current, nextFocusPath)) {
         handleSetOpenPath(pathFor(nextFocusPath.slice(0, -1)))
       }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Fixes [#13912](https://github.com/sanity-io/sanity/issues/13912): uploading a new image from inside a Portable Text field closes the block's edit dialog the moment the upload starts, cancels the upload, and leaves an empty image block behind.

`useDocumentForm`'s focus handler moves `openPath` to the focused field's parent, so that focusing a field inside a nested object reveals the dialog editing it. Array items report their *own* path as the focus path, so when a focus event describes whatever is already open, stepping one segment up closes that dialog.

That is reachable in the Portable Text editor because inserting a block object leaves the two paths inconsistent: opening the dialog blurs the editor (so `focusPath` becomes empty) while `openPath` points at the block. The first selection the editor re-announces afterwards therefore looks like a focus change *onto* the block. `openPath` collapses to the Portable Text array, `member.open` flips to false, the block dialog unmounts, and `useAssetSourceUploader`'s unmount cleanup aborts the in-flight upload — which is the reporter's "Status: (canceled)" with no asset attached. It also explains why opening the same dialog straight from a URL works: `focusPath` and `openPath` both start out at the block, so the editor's selection is not a change.

Alternatives considered:

- **Stop the editor announcing its selection while a block dialog is open.** `focusPath` should keep tracking the selection; suppressing it would desync the form from the editor and would not protect other array inputs from the same collapse.
- **Don't abort the upload when the input unmounts.** Worth revisiting separately (the dataset uploader in `ImageInput` deliberately doesn't), but it only hides the dialog closing rather than fixing it.
- **Widen the guard to "focus is anywhere inside `openPath`".** That also stops `openPath` from *deepening* when focus lands inside a nested object that isn't open yet, which is exactly the behaviour the current derivation exists for.

### What to review

Only `packages/sanity/src/core/form/useDocumentForm.ts` changes behaviour: `handleFocus` skips the `openPath` update when the focused path is exactly what is already open, and `openPathRef` mirrors `openPath` so the check sees writes made earlier in the same tick (the compiler-memoized `handleFocus` would otherwise close over a stale render's `openPath`).

The guard is deliberately equality, not prefix matching — since `openPath` must be a prefix of the focused path for the check to matter at all, "is a prefix and at least as long" reduces to "is equal", and anything looser would suppress the intended deepening of `openPath`.

Affects the `sanity` package (document form / Portable Text / array item dialogs).

### Testing

New `packages/sanity/src/core/form/useDocumentForm.test.tsx` renders the real hook and pins all four cases: focus into a child field still opens the containing item, focus on the open item keeps it open (fails on `main`), and focus on a sibling item or an unrelated field still closes it. Full unit suite, `check:format` and `check:oxlint` pass.

Verified end-to-end against the reporter's stack — an embedded studio on Next.js 16.3.0 / React 19.2.8 / `sanity@5.31.1` / `next-sanity@13.3.1`, driven against the real project API. Baseline reproduced 3/3 runs (dialog closes, no asset attached); with the equivalent guard applied to that studio's bundle it passed 3/3 (dialog stays open, asset attached). The current `main` studio also still uploads correctly, and the block dialog still opens, closes and navigates as before.

Before (upload cancelled, dialog gone, empty block):

[Portable Text image upload before the fix](https://cursor.com/agents/bc-a6acd970-ef6b-434d-8d46-1dbcf14de1a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpt_image_upload_before_fix.png)

After (dialog stays open, asset attached):

[Portable Text image upload after the fix](https://cursor.com/agents/bc-a6acd970-ef6b-434d-8d46-1dbcf14de1a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpt_image_upload_after_fix.png)

Full flow on the fixed studio — insert image block, upload through the native file picker, dialog stays open and the asset lands:

[portable_text_image_upload_succeeds_with_fix.mp4](https://cursor.com/agents/bc-a6acd970-ef6b-434d-8d46-1dbcf14de1a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportable_text_image_upload_succeeds_with_fix.mp4)

### Notes for release

Fixed a bug where uploading a new image from inside a Portable Text field could close the image block's edit dialog as soon as the upload started, cancelling the upload and leaving an empty image block in the editor. The same collapse could close any array item's edit dialog when focus landed on the item it was editing.

---


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6acd970-ef6b-434d-8d46-1dbcf14de1a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6acd970-ef6b-434d-8d46-1dbcf14de1a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

