### PR TITLE
ci(release): reconcile in-flight release checks on a schedule

### DIFF
--- a/.github/workflows/check-inflight-release.yml
+++ b/.github/workflows/check-inflight-release.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     # synchronize is needed for check-pr-release-status
     types: [opened, closed, reopened, ready_for_review, converted_to_draft, synchronize]
+  schedule:
+    # safety-net sweep behind the per-PR fast paths; GitHub drops/delays scheduled runs, so convergence is best-effort and self-heals on the next tick
+    - cron: "*/15 * * * *"
+  # manual trigger for immediate verification / on-demand unstick
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -12,6 +17,7 @@ jobs:
   update-release-status:
     name: "Update status checks for open PRs"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     if: |
       (github.head_ref == 'ci/release-main' &&
@@ -40,6 +46,7 @@ jobs:
   check-pr-release-status:
     runs-on: ubuntu-latest
     name: "Update status check for PR"
+    timeout-minutes: 10
 
     if: github.event_name == 'pull_request'
 
@@ -64,3 +71,51 @@ jobs:
           RELEASE_NOTES_ADMIN_STUDIO_URL: ${{ vars.RELEASE_NOTES_ADMIN_STUDIO_URL }}
           RELEASE_NOTES_SANITY_TOKEN: ${{ secrets.RELEASE_NOTES_SANITY_TOKEN }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  reconcile-open-prs:
+    name: "Reconcile in-flight release checks for all open PRs"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+
+    concurrency:
+      group: inflight-release-reconcile
+      # overlapping ticks queue rather than cancel a sweep mid-flight
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.ECOSPARK_APP_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+
+      - name: Reconcile in-flight release status checks for all open PRs
+        run: |
+          pnpm --silent release-notes status-check-prs
+        env:
+          RELEASE_NOTES_SANITY_PROJECT_ID: ${{ vars.RELEASE_NOTES_SANITY_PROJECT_ID }}
+          RELEASE_NOTES_SANITY_DATASET: ${{ vars.RELEASE_NOTES_SANITY_DATASET }}
+          RELEASE_NOTES_ADMIN_STUDIO_URL: ${{ vars.RELEASE_NOTES_ADMIN_STUDIO_URL }}
+          RELEASE_NOTES_SANITY_TOKEN: ${{ secrets.RELEASE_NOTES_SANITY_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  # the reconciler is the safety net for stuck PRs, so a failed sweep needs to be seen
+  notify-on-failure:
+    needs: [reconcile-open-prs]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_CI_ALERTS }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":alert-dot: The in-flight release reconciler failed on <${{ github.server_url }}/${{ github.repository }}|${{github.repository}}> - open PRs may be stuck BLOCKED (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run >)"
+            }

--- a/.github/workflows/check-inflight-release.yml
+++ b/.github/workflows/check-inflight-release.yml
@@ -5,9 +5,9 @@ on:
     # synchronize is needed for check-pr-release-status
     types: [opened, closed, reopened, ready_for_review, converted_to_draft, synchronize]
   schedule:
-    # safety-net sweep behind the per-PR fast paths; GitHub drops/delays scheduled runs, so convergence is best-effort and self-heals on the next tick
+    # safety net behind the per-PR paths; best-effort and self-healing, since GitHub delays scheduled ticks
     - cron: "*/15 * * * *"
-  # manual trigger for immediate verification / on-demand unstick
+  # on-demand unstick and verification
   workflow_dispatch: {}
 
 permissions:
@@ -104,7 +104,7 @@ jobs:
           RELEASE_NOTES_SANITY_TOKEN: ${{ secrets.RELEASE_NOTES_SANITY_TOKEN }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
-  # the reconciler is the safety net for stuck PRs, so a failed sweep needs to be seen
+  # a failed sweep can leave PRs stuck BLOCKED, so it must page
   notify-on-failure:
     needs: [reconcile-open-prs]
     if: failure()

--- a/packages/@repo/release-notes/package.json
+++ b/packages/@repo/release-notes/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.112.3",
     "@conventional-changelog/git-client": "^2.7.0",
+    "@octokit/plugin-throttling": "^11.0.5",
     "@octokit/rest": "^22.0.1",
     "@optique/core": "catalog:",
     "@optique/run": "catalog:",

--- a/packages/@repo/release-notes/src/commands/writePrChecks.ts
+++ b/packages/@repo/release-notes/src/commands/writePrChecks.ts
@@ -8,13 +8,11 @@ import {writeCheck} from '../utils/writeCheck'
 export async function writePrChecks() {
   const releasePr = await getReleasePr()
 
-  // get the 100 most recently updated PRs
-  const {data: prs} = await getOctokit().pulls.list({
+  const octokit = getOctokit()
+  const prs = await octokit.paginate(octokit.pulls.list, {
     ...REPO,
     per_page: 100,
     state: 'open',
-    sort: 'updated',
-    directory: 'desc',
     base: 'main',
   })
 

--- a/packages/@repo/release-notes/src/octokit.ts
+++ b/packages/@repo/release-notes/src/octokit.ts
@@ -1,13 +1,32 @@
+import {throttling} from '@octokit/plugin-throttling'
 import {Octokit} from '@octokit/rest'
 import {readEnv} from '@repo/utils'
 
 import {type KnownEnvVar} from './types'
 
+const ThrottledOctokit = Octokit.plugin(throttling)
+
 let _octokit: Octokit | undefined
 
 export function getOctokit(): Octokit {
   if (!_octokit) {
-    _octokit = new Octokit({auth: readEnv<KnownEnvVar>('GITHUB_TOKEN')})
+    _octokit = new ThrottledOctokit({
+      auth: readEnv<KnownEnvVar>('GITHUB_TOKEN'),
+      throttle: {
+        onRateLimit: (retryAfter, options, octokit, retryCount) => {
+          octokit.log.warn(
+            `Request quota exhausted for ${options.method} ${options.url}; retry after ${retryAfter}s`,
+          )
+          return retryCount < 2
+        },
+        onSecondaryRateLimit: (retryAfter, options, octokit) => {
+          octokit.log.warn(
+            `Secondary rate limit hit for ${options.method} ${options.url}; retry after ${retryAfter}s`,
+          )
+          return true
+        },
+      },
+    })
   }
   return _octokit
 }

--- a/packages/@repo/release-notes/src/utils/__test__/writeCheck.test.ts
+++ b/packages/@repo/release-notes/src/utils/__test__/writeCheck.test.ts
@@ -1,0 +1,156 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getOctokit} from '../../octokit'
+import {CHECK_NAME, EXTERNAL_ID, writeCheck} from '../writeCheck'
+
+vi.mock('../../octokit', () => ({getOctokit: vi.fn()}))
+
+const HEAD_SHA = 'abc123'
+const BLOCKING_RELEASE_PR = {
+  number: 99,
+  draft: false,
+  html_url: 'https://example.test/99',
+} as never
+
+function mockOctokit(checkRuns: unknown[]) {
+  const octokit = {
+    checks: {
+      listForRef: vi.fn().mockResolvedValue({data: {check_runs: checkRuns}}),
+      update: vi.fn().mockResolvedValue({data: {}}),
+      create: vi.fn().mockResolvedValue({data: {}}),
+    },
+  }
+  vi.mocked(getOctokit).mockReturnValue(octokit as never)
+  return octokit
+}
+
+describe('writeCheck', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('clearing (no in-flight release)', () => {
+    it('creates a success run when none exists', async () => {
+      const octokit = mockOctokit([])
+
+      await writeCheck({currentPrNumber: 1, headSha: HEAD_SHA})
+
+      expect(octokit.checks.update).not.toHaveBeenCalled()
+      expect(octokit.checks.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          head_sha: HEAD_SHA,
+          external_id: EXTERNAL_ID,
+          name: CHECK_NAME,
+          status: 'completed',
+          conclusion: 'success',
+        }),
+      )
+    })
+
+    it('is a no-op when a success run already exists', async () => {
+      const octokit = mockOctokit([
+        {
+          id: 10,
+          external_id: EXTERNAL_ID,
+          status: 'completed',
+          conclusion: 'success',
+          started_at: '1',
+        },
+      ])
+
+      await writeCheck({currentPrNumber: 1, headSha: HEAD_SHA})
+
+      expect(octokit.checks.create).not.toHaveBeenCalled()
+      expect(octokit.checks.update).not.toHaveBeenCalled()
+    })
+
+    it('finishes the most recently started in-progress run rather than creating a new one', async () => {
+      const octokit = mockOctokit([
+        {
+          id: 10,
+          external_id: EXTERNAL_ID,
+          status: 'in_progress',
+          conclusion: null,
+          started_at: '1',
+        },
+        {
+          id: 20,
+          external_id: EXTERNAL_ID,
+          status: 'in_progress',
+          conclusion: null,
+          started_at: '3',
+        },
+        {
+          id: 15,
+          external_id: EXTERNAL_ID,
+          status: 'in_progress',
+          conclusion: null,
+          started_at: '2',
+        },
+        {
+          id: 99,
+          external_id: 'unrelated',
+          status: 'completed',
+          conclusion: 'success',
+          started_at: '9',
+        },
+      ])
+
+      await writeCheck({currentPrNumber: 1, headSha: HEAD_SHA})
+
+      expect(octokit.checks.create).not.toHaveBeenCalled()
+      expect(octokit.checks.update).toHaveBeenCalledWith(
+        expect.objectContaining({check_run_id: 20, status: 'completed', conclusion: 'success'}),
+      )
+    })
+  })
+
+  describe('blocking (in-flight release)', () => {
+    it('creates a fresh in-progress run when none exists', async () => {
+      const octokit = mockOctokit([])
+
+      await writeCheck({currentPrNumber: 1, headSha: HEAD_SHA, releasePr: BLOCKING_RELEASE_PR})
+
+      expect(octokit.checks.update).not.toHaveBeenCalled()
+      expect(octokit.checks.create).toHaveBeenCalledWith(
+        expect.objectContaining({status: 'in_progress', external_id: EXTERNAL_ID}),
+      )
+    })
+
+    it('creates a fresh in-progress run rather than reopening a completed run', async () => {
+      const octokit = mockOctokit([
+        {
+          id: 10,
+          external_id: EXTERNAL_ID,
+          status: 'completed',
+          conclusion: 'success',
+          started_at: '1',
+        },
+      ])
+
+      await writeCheck({currentPrNumber: 1, headSha: HEAD_SHA, releasePr: BLOCKING_RELEASE_PR})
+
+      expect(octokit.checks.update).not.toHaveBeenCalled()
+      expect(octokit.checks.create).toHaveBeenCalledWith(
+        expect.objectContaining({head_sha: HEAD_SHA, status: 'in_progress'}),
+      )
+    })
+
+    it('is a no-op when an in-progress run already exists', async () => {
+      const octokit = mockOctokit([
+        {
+          id: 10,
+          external_id: EXTERNAL_ID,
+          status: 'in_progress',
+          conclusion: null,
+          started_at: '1',
+        },
+      ])
+
+      await writeCheck({currentPrNumber: 1, headSha: HEAD_SHA, releasePr: BLOCKING_RELEASE_PR})
+
+      expect(octokit.checks.create).not.toHaveBeenCalled()
+      expect(octokit.checks.update).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/@repo/release-notes/src/utils/__test__/writeCheck.test.ts
+++ b/packages/@repo/release-notes/src/utils/__test__/writeCheck.test.ts
@@ -64,7 +64,7 @@ describe('writeCheck', () => {
       expect(octokit.checks.update).not.toHaveBeenCalled()
     })
 
-    it('finishes the most recently started in-progress run rather than creating a new one', async () => {
+    it('finishes the newest in-progress run rather than creating a new one', async () => {
       const octokit = mockOctokit([
         {
           id: 10,
@@ -93,6 +93,32 @@ describe('writeCheck', () => {
           status: 'completed',
           conclusion: 'success',
           started_at: '9',
+        },
+      ])
+
+      await writeCheck({currentPrNumber: 1, headSha: HEAD_SHA})
+
+      expect(octokit.checks.create).not.toHaveBeenCalled()
+      expect(octokit.checks.update).toHaveBeenCalledWith(
+        expect.objectContaining({check_run_id: 20, status: 'completed', conclusion: 'success'}),
+      )
+    })
+
+    it('finishes a newer queued run (null started_at) instead of no-oping on an older success', async () => {
+      const octokit = mockOctokit([
+        {
+          id: 10,
+          external_id: EXTERNAL_ID,
+          status: 'completed',
+          conclusion: 'success',
+          started_at: '5',
+        },
+        {
+          id: 20,
+          external_id: EXTERNAL_ID,
+          status: 'queued',
+          conclusion: null,
+          started_at: null,
         },
       ])
 

--- a/packages/@repo/release-notes/src/utils/writeCheck.ts
+++ b/packages/@repo/release-notes/src/utils/writeCheck.ts
@@ -2,7 +2,10 @@ import {REPO} from '../constants'
 import {getOctokit} from '../octokit'
 import {type PullRequest} from '../types'
 
-export function writeCheck({
+export const CHECK_NAME = 'Check for in-flight release'
+export const EXTERNAL_ID = 'release-pr-status-check'
+
+export async function writeCheck({
   currentPrNumber,
   headSha,
   releasePr,
@@ -17,22 +20,69 @@ export function writeCheck({
     // Release PR should always be mergeable
     releasePr.number === currentPrNumber
 
-  return getOctokit().checks.create({
+  const output = {
+    title: canMerge
+      ? '✅ There is no in-flight release, merging is OK.'
+      : '‼️ Release in progress, merging is blocked.',
+    summary: canMerge
+      ? releasePr
+        ? `✅ The [release PR](${releasePr.html_url}) is still a draft, merging is OK.`
+        : `✅ There is no release PR, merging is OK`
+      : `⚠️️ The [release PR](${releasePr.html_url}) is marked as ready for review. Please wait for the release to complete before merging.`,
+  }
+
+  const octokit = getOctokit()
+
+  // external_id is not server-filterable, so list by name and match client-side
+  const {data} = await octokit.checks.listForRef({
     ...REPO,
-    external_id: 'release-pr-status-check',
-    name: 'Check for in-flight release',
+    ref: headSha,
+    check_name: CHECK_NAME,
+    per_page: 100,
+  })
+
+  const matching = data.check_runs.filter((run) => run.external_id === EXTERNAL_ID)
+  const latest = matching.reduce<(typeof matching)[number] | undefined>(
+    (mostRecent, run) =>
+      !mostRecent || (run.started_at ?? '') > (mostRecent.started_at ?? '') ? run : mostRecent,
+    undefined,
+  )
+
+  if (canMerge) {
+    if (latest?.status === 'completed' && latest.conclusion === 'success') {
+      return latest
+    }
+    if (latest && latest.status !== 'completed') {
+      // finishing an in-progress run is the reliable lifecycle direction
+      return octokit.checks.update({
+        ...REPO,
+        check_run_id: latest.id,
+        status: 'completed',
+        conclusion: 'success',
+        output,
+      })
+    }
+    return octokit.checks.create({
+      ...REPO,
+      head_sha: headSha,
+      external_id: EXTERNAL_ID,
+      name: CHECK_NAME,
+      status: 'completed',
+      conclusion: 'success',
+      output,
+    })
+  }
+
+  if (latest && latest.status !== 'completed') {
+    return latest
+  }
+  // a completed run cannot be reliably reopened, so block with a fresh run; the newest run wins the gate
+  return octokit.checks.create({
+    ...REPO,
     head_sha: headSha,
-    status: canMerge ? 'completed' : 'in_progress',
-    ...(canMerge ? {conclusion: 'success'} : {}),
-    output: {
-      title: canMerge
-        ? '✅ There is no in-flight release, merging is OK.'
-        : '‼️ Release in progress, merging is blocked.',
-      summary: canMerge
-        ? releasePr
-          ? `✅ The [release PR](${releasePr.html_url}) is still a draft, merging is OK.`
-          : `✅ There is no release PR, merging is OK`
-        : `⚠️️ The [release PR](${releasePr.html_url}) is marked as ready for review. Please wait for the release to complete before merging.`,
-    },
+    external_id: EXTERNAL_ID,
+    name: CHECK_NAME,
+    status: 'in_progress',
+    output,
   })
 }

--- a/packages/@repo/release-notes/src/utils/writeCheck.ts
+++ b/packages/@repo/release-notes/src/utils/writeCheck.ts
@@ -42,9 +42,9 @@ export async function writeCheck({
   })
 
   const matching = data.check_runs.filter((run) => run.external_id === EXTERNAL_ID)
+  // check-run ids are monotonic, so the highest id is the newest run; started_at is null for queued runs
   const latest = matching.reduce<(typeof matching)[number] | undefined>(
-    (mostRecent, run) =>
-      !mostRecent || (run.started_at ?? '') > (mostRecent.started_at ?? '') ? run : mostRecent,
+    (newest, run) => (!newest || run.id > newest.id ? run : newest),
     undefined,
   )
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1002,6 +1002,9 @@ importers:
       '@conventional-changelog/git-client':
         specifier: ^2.7.0
         version: 2.7.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)
+      '@octokit/plugin-throttling':
+        specifier: ^11.0.5
+        version: 11.0.5(@octokit/core@7.0.7)
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
@@ -4804,6 +4807,12 @@ packages:
     peerDependencies:
       '@octokit/core': '>=6'
 
+  '@octokit/plugin-throttling@11.0.5':
+    resolution: {integrity: sha512-LIdrkrUv+DWbKeg/49rGuFJ3SU0d3hUS+B4MhNZLepBoNUFXms8Ic9edJjrlx+zycqJHjrMRudVpVb/bAXM2Lw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': ^7.0.0
+
   '@octokit/request-error@7.1.1':
     resolution: {integrity: sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==}
     engines: {node: '>= 20'}
@@ -8114,6 +8123,9 @@ packages:
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
@@ -16670,6 +16682,12 @@ snapshots:
       '@octokit/core': 7.0.7
       '@octokit/types': 16.0.0
 
+  '@octokit/plugin-throttling@11.0.5(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 17.0.0
+      bottleneck: 2.19.5
+
   '@octokit/request-error@7.1.1':
     dependencies:
       '@octokit/types': 17.0.0
@@ -20212,6 +20230,8 @@ snapshots:
 
   boolean@3.2.0:
     optional: true
+
+  bottleneck@2.19.5: {}
 
   bowser@2.14.1:
     optional: true


### PR DESCRIPTION
### Description

Merging into `main` requires the status context `Check for in-flight release` (GitHub ruleset "Release branches"). That context is produced imperatively by a single per-PR-event job. When that job never reaches its check write - because it is cancelled or runner-starved, or gated `action_required` on bot PRs (renovate/copilot/cursor) - the required context is never reported. An absent required check has nothing to re-run, so the PR sits BLOCKED indefinitely with no way to recover it.

This PR adds a scheduled reconciler that sweeps every open PR (`workflow_dispatch` plus a `*/15` cron) and forces each `Check for in-flight release` into the correct state. Scheduled runs are never `action_required`, never superseded by a new commit, and run on the default branch, so correctness stops depending on any single per-PR job reaching the API and self-heals on the next tick. The existing per-PR jobs stay as latency accelerators.

Supporting changes: `writeCheck` is now idempotent and lifecycle-safe (it finishes an in-progress run to clear, and creates a fresh run to block, because GitHub may refuse to reopen a `completed` run - the newest run wins the required-check gate); the sweep is paginated to cover every open PR rather than the newest 100; and the octokit client gains request throttling for the transition-time burst.

### What to review

- `writeCheck.ts` - the create-fresh-on-block vs update-to-finish distinction is deliberate. Blocking creates a new `in_progress` run rather than reopening a `completed` one; the most recent run of a given name is what GitHub honors for the required context.
- `check-inflight-release.yml` - the `*/15` cron and `workflow_dispatch` triggers, the dedicated `reconcile-open-prs` job (concurrency group, `timeout-minutes`), the `notify-on-failure` alert, and the timeouts added to the two existing jobs.
- Scope: this covers PRs targeting `main`. The same ruleset also requires the context on `v4`/`v5`, which remain a known follow-up.

### Testing

- Unit tests for `writeCheck` cover the create, no-op, finish-in-progress, and fresh-block branches.
- The scheduled workflow cannot run from a branch; after merge it is verifiable via `workflow_dispatch` or one cron tick.

### Notes for release

N/A

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes merge-gating GitHub check lifecycle and adds broad API sweeps; mistakes could block or unblock merges incorrectly, though behavior is covered by tests and a failure alert.
> 
> **Overview**
> Fixes PRs stuck **BLOCKED** when the required `Check for in-flight release` context is never written (cancelled jobs, runner issues, bot PR `action_required`).
> 
> A **15-minute cron** and **`workflow_dispatch`** run a new `reconcile-open-prs` job that sweeps all open PRs via `status-check-prs`; per-PR workflow jobs remain for faster updates. Failed reconciles **page Slack**; existing jobs get **10-minute timeouts**.
> 
> **`writeCheck`** is now **idempotent**: it lists existing check runs, no-ops when state is already correct, **completes** in-progress/queued runs to clear the gate, and **creates a fresh in-progress** run to block (instead of reopening completed runs). **`writePrChecks`** paginates **all** open PRs to `main` (not only the latest 100). Octokit uses **`@octokit/plugin-throttling`** for burst retries during sweeps. Unit tests cover the new `writeCheck` branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17639ab31a0109a0ed03fffbcea693e2a90258c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->