### PR TITLE
refactor(core): deprecate legacy document timeline exports

### DIFF
--- a/packages/sanity/src/_exports/index.ts
+++ b/packages/sanity/src/_exports/index.ts
@@ -1359,6 +1359,7 @@ export {
   type HistoryStoreOptions,
   removeMissingReferences,
 } from '../core/store/history/createHistoryStore'
+/* oxlint-disable no-deprecated -- the legacy document timeline stays exported while deprecated; removing it is a breaking change deferred to the next major */
 export {
   type ParsedTimeRef,
   Timeline,
@@ -1378,9 +1379,9 @@ export {useTimelineSelector} from '../core/store/history/useTimelineSelector'
 export {
   type TimelineState,
   type TimelineStore,
-  // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
   useTimelineStore,
 } from '../core/store/history/useTimelineStore'
+/* oxlint-enable no-deprecated */
 export {createKeyValueStore} from '../core/store/key-value/keyValueStore'
 export {type KeyValueStore, type KeyValueStoreValue} from '../core/store/key-value/types'
 export {

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -917,6 +917,7 @@ function resolveSource({
 
     beta: {
       eventsAPI: {
+        // oxlint-disable-next-line no-deprecated -- still resolved so the legacy timeline opt-out keeps working until the next major
         documents: eventsAPIReducer({config, initialValue: true, key: 'documents'}),
         releases: eventsAPIReducer({config, initialValue: false, key: 'releases'}),
       },

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -1331,6 +1331,10 @@ export interface BetaFeatures {
    * If it is not enabled, it will continue using the legacy Timeline.
    */
   eventsAPI?: {
+    /**
+     * @deprecated This option will be removed in the next major version, after which document
+     * history will always use the events API and the legacy Timeline will no longer be available.
+     */
     documents?: boolean
     releases?: boolean
   }

--- a/packages/sanity/src/core/store/history/createHistoryStore.ts
+++ b/packages/sanity/src/core/store/history/createHistoryStore.ts
@@ -49,11 +49,15 @@ export interface HistoryStore {
     options?: RestoreOptions,
   ) => Observable<void>
 
-  /** @internal */
+  /**
+   * @deprecated Use the events API instead. The legacy document timeline will be removed in the next major version.
+   * @internal
+   */
   getTimelineController: (options: {
     client: SanityClient
     documentId: string
     documentType: string
+    // oxlint-disable-next-line no-deprecated -- part of the deprecated legacy document timeline
   }) => TimelineController
 }
 
@@ -149,11 +153,14 @@ const getTimelineController = ({
   client: SanityClient
   documentId: string
   documentType: string
+  // oxlint-disable-next-line no-deprecated -- part of the deprecated legacy document timeline
 }): TimelineController => {
+  // oxlint-disable-next-line no-deprecated -- part of the deprecated legacy document timeline
   const timeline = new Timeline({
     enableTrace: isDev,
     publishedId: documentId,
   })
+  // oxlint-disable-next-line no-deprecated -- part of the deprecated legacy document timeline
   return new TimelineController({
     client,
     documentId,
@@ -313,6 +320,7 @@ export function createHistoryStore({client}: HistoryStoreOptions): HistoryStore 
 
     restore: (id, targetId, rev, options) => restore(client, id, targetId, rev, options),
 
+    // oxlint-disable-next-line no-deprecated -- part of the deprecated legacy document timeline
     getTimelineController,
   }
 }

--- a/packages/sanity/src/core/store/history/history/Aligner.ts
+++ b/packages/sanity/src/core/store/history/history/Aligner.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable no-deprecated -- this module implements the deprecated legacy document timeline */
 import {type SanityDocument, type TransactionLogEventWithEffects} from '@sanity/types'
 import {applyPatch} from 'mendoza'
 

--- a/packages/sanity/src/core/store/history/history/Reconstruction.ts
+++ b/packages/sanity/src/core/store/history/history/Reconstruction.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable no-deprecated -- this module implements the deprecated legacy document timeline */
 import {type Diff} from '@sanity/diff'
 
 import {type Annotation, type Chunk} from '../../../field/types'

--- a/packages/sanity/src/core/store/history/history/Timeline.ts
+++ b/packages/sanity/src/core/store/history/history/Timeline.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable no-deprecated -- this module implements the deprecated legacy document timeline */
 import {type Diff} from '@sanity/diff'
 import {type TransactionLogEventWithEffects} from '@sanity/types'
 import {applyPatch, incremental} from 'mendoza'
@@ -15,11 +16,13 @@ import {
 import {getAttrs} from './utils'
 
 /**
+ * @deprecated Use the events API instead. The legacy document timeline will be removed in the next major version.
  * @hidden
  * @beta */
 export type ParsedTimeRef = Chunk | 'loading' | 'invalid'
 
 /**
+ * @deprecated Use the events API instead. The legacy document timeline will be removed in the next major version.
  * @hidden
  * @beta */
 export interface TimelineOptions {
@@ -36,6 +39,7 @@ export interface TimelineOptions {
  * but will only organize and structure the incoming translog entries.
  *
  *
+ * @deprecated Use the events API instead. The legacy document timeline will be removed in the next major version.
  * @hidden
  * @beta
  */

--- a/packages/sanity/src/core/store/history/history/TimelineController.ts
+++ b/packages/sanity/src/core/store/history/history/TimelineController.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable no-deprecated -- this module implements the deprecated legacy document timeline */
 import {type SanityClient} from '@sanity/client'
 import {type Diff, type ObjectDiff} from '@sanity/diff'
 
@@ -11,6 +12,7 @@ import {type ParsedTimeRef, type Timeline} from './Timeline'
 const TRANSLOG_ENTRY_LIMIT = 50
 
 /**
+ * @deprecated Use the events API instead. The legacy document timeline will be removed in the next major version.
  * @hidden
  * @beta */
 export type TimelineControllerOptions = {
@@ -22,6 +24,7 @@ export type TimelineControllerOptions = {
 }
 
 /**
+ * @deprecated Use the events API instead. The legacy document timeline will be removed in the next major version.
  * @hidden
  * @beta */
 export type SelectionState = 'inactive' | 'rev' | 'range' | 'loading' | 'invalid'
@@ -31,6 +34,7 @@ export type SelectionState = 'inactive' | 'rev' | 'range' | 'loading' | 'invalid
  * about a document and maintaining a Timeline.
  *
  *
+ * @deprecated Use the events API instead. The legacy document timeline will be removed in the next major version.
  * @hidden
  * @beta
  */

--- a/packages/sanity/src/core/store/history/history/chunker.ts
+++ b/packages/sanity/src/core/store/history/history/chunker.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable no-deprecated -- this module implements the deprecated legacy document timeline */
 import {type MendozaEffectPair, type MendozaPatch} from '@sanity/types'
 
 import {type Chunk, type ChunkType} from '../../../field/types'

--- a/packages/sanity/src/core/store/history/history/diffValue.ts
+++ b/packages/sanity/src/core/store/history/history/diffValue.ts
@@ -185,6 +185,7 @@ export function wrapValue<T>(
 }
 
 function extractAnnotationForFromInput(
+  // oxlint-disable-next-line no-deprecated -- part of the deprecated legacy document timeline
   timeline: Timeline,
   firstChunk: Chunk | null,
   meta: Meta,
@@ -199,6 +200,7 @@ function extractAnnotationForFromInput(
   return null
 }
 
+// oxlint-disable-next-line no-deprecated -- part of the deprecated legacy document timeline
 function extractAnnotationForToInput(timeline: Timeline, meta: Meta): Annotation {
   if (meta) {
     return annotationForTransactionIndex(timeline, meta.transactionIndex, meta.chunk.index)
@@ -207,6 +209,7 @@ function extractAnnotationForToInput(timeline: Timeline, meta: Meta): Annotation
   return null
 }
 
+// oxlint-disable-next-line no-deprecated -- part of the deprecated legacy document timeline
 function annotationForTransactionIndex(timeline: Timeline, idx: number, chunkIdx?: number) {
   const tx = timeline.transactionByIndex(idx)
   if (!tx) return null
@@ -222,6 +225,7 @@ function annotationForTransactionIndex(timeline: Timeline, idx: number, chunkIdx
 }
 
 export function diffValue(
+  // oxlint-disable-next-line no-deprecated -- part of the deprecated legacy document timeline
   timeline: Timeline,
   firstChunk: Chunk | null,
   from: incremental.Value<Meta>,

--- a/packages/sanity/src/core/store/history/history/replay.ts
+++ b/packages/sanity/src/core/store/history/history/replay.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable no-deprecated -- this module implements the deprecated legacy document timeline */
 import {type TransactionLogEventWithEffects} from '@sanity/types'
 
 import {type DocumentRemoteMutationVersionEvent} from './types'

--- a/packages/sanity/src/core/store/history/history/types.ts
+++ b/packages/sanity/src/core/store/history/history/types.ts
@@ -3,6 +3,7 @@ import {type MendozaEffectPair} from '@sanity/types'
 import {type RemoteSnapshotVersionEvent} from '../../document/document-pair/checkoutPair'
 
 /**
+ * @deprecated Use the events API instead. The legacy document timeline will be removed in the next major version.
  * @hidden
  * @beta */
 export type DocumentRemoteMutationVersionEvent = Exclude<
@@ -11,6 +12,7 @@ export type DocumentRemoteMutationVersionEvent = Exclude<
 >
 
 /**
+ * @deprecated Use the events API instead. The legacy document timeline will be removed in the next major version.
  * @hidden
  * @beta */
 export interface CombinedDocument {
@@ -19,6 +21,7 @@ export interface CombinedDocument {
 }
 
 /**
+ * @deprecated Use the events API instead. The legacy document timeline will be removed in the next major version.
  * @hidden
  * @beta */
 export interface Transaction {

--- a/packages/sanity/src/core/store/history/history/utils.ts
+++ b/packages/sanity/src/core/store/history/history/utils.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable no-deprecated -- this module implements the deprecated legacy document timeline */
 import {type Annotation} from '../../../field/types'
 import {type CombinedDocument} from './types'
 

--- a/packages/sanity/src/core/store/history/useTimelineSelector.ts
+++ b/packages/sanity/src/core/store/history/useTimelineSelector.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable no-deprecated -- this module implements the deprecated legacy document timeline */
 import {useSyncExternalStoreWithSelector} from 'use-sync-external-store/with-selector'
 
 import {type TimelineState, type TimelineStore} from './useTimelineStore'
@@ -6,6 +7,7 @@ import {type TimelineState, type TimelineStore} from './useTimelineStore'
  * Custom hook which wraps around `useSyncExternalStore`.
  * Accepts a selector function which can be used to opt-in to specific timelineStore updates.
  *
+ * @deprecated Use the events API instead. The legacy document timeline will be removed in the next major version.
  * @internal
  */
 export function useTimelineSelector<ReturnValue>(

--- a/packages/sanity/src/core/store/history/useTimelineStore.ts
+++ b/packages/sanity/src/core/store/history/useTimelineStore.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable no-deprecated -- this module implements the deprecated legacy document timeline */
 import {type ObjectDiff} from '@sanity/diff'
 import {useEffect, useMemo, useRef} from 'react'
 import deepEquals from 'react-fast-compare'
@@ -27,7 +28,10 @@ interface UseTimelineControllerOpts {
   since?: string
 }
 
-/** @internal */
+/**
+ * @deprecated Use the events API instead. The legacy document timeline will be removed in the next major version.
+ * @internal
+ */
 export interface TimelineState {
   chunks: Chunk[]
   diff: ObjectDiff<Annotation> | null
@@ -67,7 +71,10 @@ const INITIAL_TIMELINE_STATE: TimelineState = {
   timelineReady: false,
 }
 
-/** @internal */
+/**
+ * @deprecated Use the events API instead. The legacy document timeline will be removed in the next major version.
+ * @internal
+ */
 export interface TimelineStore {
   findRangeForRev: TimelineController['findRangeForNewRev']
   findRangeForSince: TimelineController['findRangeForNewSince']
@@ -84,7 +91,7 @@ export interface TimelineStore {
  * ranges and fetch more transactions. It can also be used with
  * `useSyncExternalStore` to subscribe to selected state changes.
  *
- * @deprecated Use events store instead, this will be removed in a future release
+ * @deprecated Use the events API instead. The legacy document timeline will be removed in the next major version.
  * @internal
  * */
 export function useTimelineStore({

--- a/packages/sanity/src/core/studio/__telemetry__/featureAvailability.telemetry.ts
+++ b/packages/sanity/src/core/studio/__telemetry__/featureAvailability.telemetry.ts
@@ -66,6 +66,7 @@ export function collectWorkspaceFeatures(workspace: Workspace): WorkspaceFeature
     canvasEnabled: workspace.apps?.canvas?.enabled,
     variantsEnabled: workspace.beta?.variants?.enabled,
     documentGroupInventoryEnabled: workspace.beta?.documentGroupInventory?.enabled,
+    // oxlint-disable-next-line no-deprecated -- keep reporting the deprecated opt-out until it is removed
     eventsApiDocumentsEnabled: workspace.beta?.eventsAPI?.documents,
     eventsApiReleasesEnabled: workspace.beta?.eventsAPI?.releases,
     announcementsEnabled: workspace.announcements?.enabled,

--- a/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneContext.ts
@@ -95,8 +95,9 @@ export interface DocumentPaneContextValue extends Pick<NodeChronologyProps, 'has
   setIsDocumentGroupInventoryActive: (active: boolean) => void
   timelineError: Error | null
   /**
-   * Soon to be deprecated with the upcoming `releases` changes.
+   * @deprecated Use the events API instead. The legacy document timeline will be removed in the next major version.
    */
+  // oxlint-disable-next-line no-deprecated -- part of the deprecated legacy document timeline
   timelineStore?: TimelineStore
   title: string | null
   validation: ValidationMarker[]

--- a/packages/sanity/src/structure/panes/document/DocumentPaneLegacyTimeline.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneLegacyTimeline.tsx
@@ -1,3 +1,4 @@
+/* oxlint-disable no-deprecated -- this module implements the deprecated legacy document timeline */
 import {type SanityDocument} from '@sanity/types'
 import {useMemo, useState} from 'react'
 import {getPublishedId, useTimelineSelector, useTimelineStore} from 'sanity'
@@ -8,6 +9,10 @@ import {DocumentPaneProvider} from './DocumentPaneProvider'
 import {type DocumentPaneProviderProps} from './types'
 import {usePaneOptions} from './usePaneOptions'
 
+/**
+ * @deprecated Use `DocumentEventsPane` instead. The legacy document timeline will be removed in the
+ * next major version, together with the `beta.eventsAPI.documents` opt-out that routes to it.
+ */
 export const DocumentPaneWithLegacyTimelineStore = (props: DocumentPaneProviderProps) => {
   const {pane} = props
   const paneRouter = usePaneRouter()

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -96,6 +96,7 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
     historyStore,
   } = props
   const {
+    // oxlint-disable-next-line no-deprecated -- part of the deprecated legacy document timeline
     store: timelineStore,
     error: timelineError,
     ready: timelineReady,
@@ -602,6 +603,7 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
         setIsDocumentGroupInventoryActive,
         isDeleted,
         timelineError,
+        // oxlint-disable-next-line no-deprecated -- part of the deprecated legacy document timeline
         timelineStore,
         title,
         value,

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProviderWrapper.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProviderWrapper.tsx
@@ -31,9 +31,11 @@ export const DocumentPaneProviderWrapper = memo((props: DocumentPaneProviderProp
   return (
     <DocumentPerspectiveProvider>
       <SingleDocReleaseProvider onSetScheduledDraftPerspective={handleSetScheduledDraftPerspective}>
+        {/* oxlint-disable-next-line no-deprecated -- the legacy timeline opt-out keeps working until the next major */}
         {source.beta?.eventsAPI?.documents ? (
           <DocumentEventsPane {...props} />
         ) : (
+          // oxlint-disable-next-line no-deprecated -- rendered only for the legacy timeline opt-out
           <DocumentPaneWithLegacyTimelineStore {...props} />
         )}
       </SingleDocReleaseProvider>

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/ChangesInspector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/ChangesInspector.tsx
@@ -1,3 +1,4 @@
+/* oxlint-disable no-deprecated -- this module implements the deprecated legacy document timeline */
 import {type ObjectDiff} from '@sanity/diff'
 import {BoundaryElementProvider, Box, Card, Flex, Text} from '@sanity/ui'
 import {useMemo, useState} from 'react'

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/ChangesTabs.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/ChangesTabs.tsx
@@ -130,6 +130,7 @@ export function ChangesTabs(props: DocumentInspectorProps) {
         hidden={paneRouterTab !== 'history'}
         id="history-panel"
       >
+        {/* oxlint-disable-next-line no-deprecated -- the legacy timeline opt-out keeps working until the next major */}
         {source.beta?.eventsAPI?.documents ? (
           <EventsSelector showList={paneRouterTab === 'history'} />
         ) : (
@@ -143,6 +144,7 @@ export function ChangesTabs(props: DocumentInspectorProps) {
         id="review-panel"
         height="fill"
       >
+        {/* oxlint-disable-next-line no-deprecated -- the legacy timeline opt-out keeps working until the next major */}
         {source.beta?.eventsAPI?.documents ? (
           <>
             {paneRouterTab === 'review' ? (

--- a/packages/sanity/src/structure/panes/document/inspectors/changes/HistorySelector.tsx
+++ b/packages/sanity/src/structure/panes/document/inspectors/changes/HistorySelector.tsx
@@ -1,3 +1,4 @@
+/* oxlint-disable no-deprecated -- this module implements the deprecated legacy document timeline */
 import {BoundaryElementProvider, Card, Flex, useToast} from '@sanity/ui'
 import {useCallback, useState} from 'react'
 import {

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusLine.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusLine.tsx
@@ -160,6 +160,7 @@ const EventsStatus = () => {
   )
 }
 
+/* oxlint-disable no-deprecated -- renders the deprecated legacy document timeline */
 const TimelineStatus = () => {
   const {timelineStore} = useDocumentPane()
   const chunks = useTimelineSelector(timelineStore, (state) => state.chunks)
@@ -182,6 +183,7 @@ const TimelineStatus = () => {
     />
   )
 }
+/* oxlint-enable no-deprecated */
 
 const SYNCING_TIMEOUT = 1000
 const SAVED_TIMEOUT = 3000
@@ -192,6 +194,7 @@ export function DocumentStatusLine() {
   const [status, setStatus] = useState<'saved' | 'syncing' | null>(null)
   // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
   const source = useSource()
+  // oxlint-disable-next-line no-deprecated -- the legacy timeline opt-out keeps working until the next major
   const eventsEnabled = source.beta?.eventsAPI?.documents
 
   // The scope of the document targeted by the selected perspective (undefined while the target is

--- a/packages/sanity/src/structure/panes/document/timeline/timelineMenu.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/timelineMenu.tsx
@@ -1,3 +1,4 @@
+/* oxlint-disable no-deprecated -- this module implements the deprecated legacy document timeline */
 import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
 import {
   Flex,

--- a/packages/sanity/src/structure/panes/document/types.ts
+++ b/packages/sanity/src/structure/panes/document/types.ts
@@ -13,6 +13,10 @@ export type DocumentPaneProviderProps = {
 
 /** @internal */
 export interface HistoryStoreProps {
+  /**
+   * @deprecated Use the events API instead. The legacy document timeline will be removed in the next major version.
+   */
+  // oxlint-disable-next-line no-deprecated -- part of the deprecated legacy document timeline
   store?: TimelineStore
   error: Error | null
   onOlderRevision: boolean


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Non-breaking alternative to #13545. That PR removes the legacy document timeline outright, which drops 13 symbols from the `sanity` package's public API. Since we are not doing a major yet, this PR keeps every export in place and only marks it `@deprecated`, so studios get an editor/TypeScript signal now and the actual removal can land in the next major.

Deprecated public exports (all still exported, all still working):

- `Timeline`, `TimelineOptions`, `ParsedTimeRef`
- `TimelineController`, `TimelineControllerOptions`, `SelectionState`
- `Transaction`, `CombinedDocument`, `DocumentRemoteMutationVersionEvent`
- `useTimelineStore`, `TimelineState`, `TimelineStore`
- `useTimelineSelector`
- `HistoryStore.getTimelineController`, and `timelineStore` on the value returned by `useDocumentPane`

Also deprecated, since they are the rest of the legacy path:

- `beta.eventsAPI.documents` — the opt-out that routes to the legacy timeline. Still resolved and still honoured; the tag just states it will be removed in the next major, after which document history always uses the events API. `beta.eventsAPI.releases` is untouched.
- `DocumentPaneWithLegacyTimelineStore` and `HistoryStoreProps.store` — not exported, tagged purely so the removal is tracked end to end.

The deprecation tags go on the declarations rather than the re-export specifiers so they survive into the generated `.d.ts` that consumers actually see. `useTimelineStore` already carried a `@deprecated` tag; its wording was aligned with the rest.

### What to review

- `packages/sanity/src/core/store/history/` — the `@deprecated` tags themselves.
- `packages/sanity/src/core/config/types.ts` — the flag deprecation covers only the `documents` key, not the whole `eventsAPI` object.
- The `oxlint-disable no-deprecated` suppressions. `typescript/no-deprecated` is `error` and the legacy path is still wired up, so tagging the declarations produced 112 errors across 19 files. Modules that are entirely legacy timeline get one file-level disable; modules that also serve the events path (`diffValue.ts`, `createHistoryStore.ts`, `DocumentPaneProvider.tsx`, `DocumentStatusLine.tsx`, `ChangesTabs.tsx`, `DocumentPaneProviderWrapper.tsx`, `prepareConfig.tsx`, the telemetry payload, and the export barrel) get targeted per-line or block disables. Each states that this is the deprecated legacy path rather than the existing "will fix in follow up PR" placeholder.
- Every change is a comment or a JSDoc block. No files deleted, no exports removed, no runtime behaviour changed.

### Testing

- `pnpm check:oxlint` passes. `reportUnusedDisableDirectives` is `error`, so every suppression added here is load-bearing.
- `pnpm check:format` passes.
- `pnpm build` succeeds, and the emitted declarations under `packages/sanity/lib` carry `@deprecated` on all 13 exported symbols plus `HistoryStore.getTimelineController`, `DocumentPaneContextValue.timelineStore`, and `beta.eventsAPI.documents` — checked by walking the built `.d.ts` with ts-morph, since that is what consumers actually resolve against.
- `pnpm test`: 5471 passed, 0 failed, no type errors. `pnpm test:exports`: 2958 passed. The export snapshot and the auto-generated dts-exports fixture are both unchanged, confirming nothing was dropped from the public surface.
- Confirmed the deprecation is signal-only for the config flag: a throwaway test against `eventsAPIReducer` showed `beta.eventsAPI.documents` still defaults to `true`, still resolves to `false` when a studio opts out into the legacy timeline, and still leaves `releases` alone.

### Notes for release

The legacy document timeline API is now deprecated and will be removed in the next major version. Nothing is removed in this release and no behaviour changes.

Deprecated exports from the `sanity` package: `Timeline`, `TimelineController`, `useTimelineStore`, `useTimelineSelector`, and the associated types `TimelineOptions`, `ParsedTimeRef`, `TimelineControllerOptions`, `SelectionState`, `TimelineState`, `TimelineStore`, `Transaction`, `CombinedDocument`, and `DocumentRemoteMutationVersionEvent`. Use the events API instead.

The `beta.eventsAPI.documents` workspace config option is also deprecated. It still works today, including setting it to `false` to opt back into the legacy timeline, but it will be removed in the next major, after which document history always uses the events API. `beta.eventsAPI.releases` is unaffected.

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46aa450b-fd0e-41e4-bcad-1827fba15ccf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46aa450b-fd0e-41e4-bcad-1827fba15ccf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

