### PR TITLE
refactor(structure): remove obsolete selectedVariantDisplay chip

### DIFF
--- a/packages/sanity/src/structure/hooks/useDocumentPerspectiveList.ts
+++ b/packages/sanity/src/structure/hooks/useDocumentPerspectiveList.ts
@@ -19,7 +19,6 @@ import {
   useAllVariants,
   type VersionInfoDocumentStub,
   useSetVariant,
-  getTargetDocument,
 } from 'sanity'
 
 import {isLiveEditEnabled} from '../components/paneItem/helpers'
@@ -60,8 +59,6 @@ interface DocumentPerspectiveList {
   variantVersions: VersionInfoDocumentStub[]
   /** Handles the selection of a variant. */
   handleVariantSelectionChange: (version: VersionInfoDocumentStub) => void
-  /** Display props for the currently selected variant in the active bundle, if any. */
-  selectedVariantDisplay: {displayName: string; tone: BadgeTone} | null
 }
 
 /**
@@ -75,7 +72,7 @@ interface DocumentPerspectiveList {
  * @internal
  */
 export function useDocumentPerspectiveList(): DocumentPerspectiveList {
-  const {selectedReleaseId, selectedPerspectiveName, selectedVariant, bundle} = usePerspective()
+  const {selectedReleaseId, selectedPerspectiveName} = usePerspective()
   const {params} = usePaneRouter()
   const schema = useSchema()
   const {editState, displayed} = useDocumentPane()
@@ -266,24 +263,6 @@ export function useDocumentPerspectiveList(): DocumentPerspectiveList {
     [setVariant, variants],
   )
 
-  // Temporarily display the selected variant in the header; this will be replaced by the inventory.
-  const selectedVariantDisplay = useMemo(() => {
-    if (!selectedVariant) {
-      return null
-    }
-
-    const targetVariantDocument = getTargetDocument({
-      bundle,
-      variant: selectedVariant._id,
-      documentVersions,
-    })
-
-    if (targetVariantDocument) {
-      return getVersionDisplay(targetVariantDocument)
-    }
-    return null
-  }, [selectedVariant, bundle, documentVersions, getVersionDisplay])
-
   return {
     filteredReleases,
     getVersionDisplay,
@@ -299,6 +278,5 @@ export function useDocumentPerspectiveList(): DocumentPerspectiveList {
     nonReleaseVersions,
     variantVersions,
     handleVariantSelectionChange,
-    selectedVariantDisplay,
   }
 }

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/perspective/DocumentPerspectiveList.tsx
@@ -1,7 +1,6 @@
 import {Stack, Text} from '@sanity/ui'
 import {memo} from 'react'
 import {
-  Chip,
   getDraftId,
   getPublishedId,
   getReleaseIdFromReleaseDocumentId,
@@ -99,7 +98,6 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
     isPublishedChipDisabled,
     isPublishSelected,
     nonReleaseVersions,
-    selectedVariantDisplay,
   } = useDocumentPerspectiveList()
 
   return (
@@ -291,14 +289,6 @@ export const DocumentPerspectiveList = memo(function DocumentPerspectiveList() {
         getVersionDisplay={getVersionDisplay}
         mode="versions"
       />
-      {selectedVariantDisplay ? (
-        <Chip
-          selected
-          tone={selectedVariantDisplay.tone}
-          mode="bleed"
-          text={selectedVariantDisplay.displayName}
-        />
-      ) : null}
       {variantVersions.length > 0 ? (
         <NonReleaseVersionsSelect
           nonReleaseVersions={variantVersions}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Removes the temporary `selectedVariantDisplay` chip from the document perspective list header. Document group inventory now surfaces the selected variant via `DocumentTargetBadges`, so this pre-inventory UI and its hook plumbing are no longer needed.

### What to review

- `useDocumentPerspectiveList`: dropped `selectedVariantDisplay` from the interface/return, plus unused `selectedVariant`/`bundle`/`getTargetDocument`
- `DocumentPerspectiveList`: removed the selected variant `<Chip />` render and unused `Chip` import

### Testing

No dedicated assertions existed for this temporary chip. Existing `DocumentPerspectiveList` coverage remains relevant for the rest of the perspective list.

Manual checks:
- Document with variants + inventory disabled: temporary selected-variant chip no longer appears
- Variant selection still works via the variants `NonReleaseVersionsSelect`
- Inventory enabled: selected variant still shows via inventory/`DocumentTargetBadges`

### Notes for release

N/A: Internal only cleanup of obsolete temporary UI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08e8a31b-9641-4d5e-9a8f-744cc8a96f8b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08e8a31b-9641-4d5e-9a8f-744cc8a96f8b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

