### PR TITLE
fix: redirect hidden workspace urls to the first visible workspace

### DIFF
--- a/packages/sanity/src/core/studio/activeWorkspaceMatcher/ActiveWorkspaceMatcher.tsx
+++ b/packages/sanity/src/core/studio/activeWorkspaceMatcher/ActiveWorkspaceMatcher.tsx
@@ -59,17 +59,12 @@ export function ActiveWorkspaceMatcher({
     case 'match': {
       const matchedWorkspace = result.workspace
 
-      if (
-        typeof matchedWorkspace.hidden === 'function' &&
-        workspaceAuthStates[matchedWorkspace.name] === undefined
-      ) {
-        return <LoadingComponent />
-      }
-
       const matchedWorkspaceIsVisible = visibleWorkspaces.some(
         (workspace) => workspace.name === matchedWorkspace.name,
       )
 
+      // Only reachable when every workspace is hidden: matchWorkspace redirects
+      // away from a hidden workspace whenever a visible one exists.
       if (!matchedWorkspaceIsVisible) {
         return <NotFoundComponent onNavigateToDefaultWorkspace={handleNavigateToDefaultWorkspace} />
       }

--- a/packages/sanity/src/core/studio/activeWorkspaceMatcher/__tests__/ActiveWorkspaceMatcher.test.tsx
+++ b/packages/sanity/src/core/studio/activeWorkspaceMatcher/__tests__/ActiveWorkspaceMatcher.test.tsx
@@ -183,7 +183,7 @@ describe('ActiveWorkspaceMatcher hidden workspace behaviour', () => {
     expect(screen.queryByTestId('not-found')).toBeNull()
   })
 
-  it('renders NotFoundComponent for static hidden: true workspace URL', () => {
+  it('redirects a static hidden: true workspace URL to the first visible workspace', async () => {
     const hiddenWorkspace = createWorkspace({
       name: 'hidden',
       basePath: '/hidden',
@@ -206,13 +206,17 @@ describe('ActiveWorkspaceMatcher hidden workspace behaviour', () => {
           LoadingComponent={LoadingComponent}
           NotFoundComponent={NotFoundComponent}
         >
-          <div data-testid="children">Should not render</div>
+          <div data-testid="children">Visible workspace content</div>
         </ActiveWorkspaceMatcher>
       </TestWrapper>,
     )
 
-    expect(screen.getByTestId('not-found')).toBeDefined()
-    expect(screen.queryByTestId('children')).toBeNull()
+    await waitFor(() => {
+      expect(history.location.pathname).toBe('/visible')
+    })
+
+    expect(screen.getByTestId('children')).toBeDefined()
+    expect(screen.queryByTestId('not-found')).toBeNull()
   })
 
   it('renders children when callback evaluates to false (visible)', () => {
@@ -514,21 +518,54 @@ describe('ActiveWorkspaceMatcher hidden workspace behaviour', () => {
     expect(screen.queryByTestId('not-found')).toBeNull()
   })
 
-  it('navigates to first visible workspace when go-to-default is clicked from NotFoundComponent', async () => {
-    const staticHidden = createWorkspace({
-      name: 'static-hidden',
-      basePath: '/static-hidden',
-      hidden: true,
+  it('redirects a callback-hidden workspace URL to the first visible workspace, preserving search', async () => {
+    // Mirrors the hosted-studio auth flow: the auth round trip returns the
+    // browser to a workspace URL resolved before the user was known, which may
+    // point at a workspace hidden for that user.
+    const fnHidden = createWorkspace({
+      name: 'fn-hidden',
+      basePath: '/fn-hidden',
+      hidden: () => true,
     })
     const staticVisible = createWorkspace({name: 'static-visible', basePath: '/static-visible'})
 
-    const workspaces = [staticHidden, staticVisible]
+    const workspaces = [fnHidden, staticVisible]
     const contextValue = createContextValue(workspaces, {
-      'static-hidden': createAuthState(),
+      'fn-hidden': createAuthState(),
       'static-visible': createAuthState(),
     })
 
-    const history = createMemoryHistory({initialEntries: ['/static-hidden']})
+    const history = createMemoryHistory({initialEntries: ['/fn-hidden?foo=bar']})
+
+    render(
+      <TestWrapper contextValue={contextValue} allWorkspaces={workspaces}>
+        <ActiveWorkspaceMatcher
+          unstable_history={history}
+          LoadingComponent={LoadingComponent}
+          NotFoundComponent={NotFoundComponent}
+        >
+          <div data-testid="children">Visible workspace content</div>
+        </ActiveWorkspaceMatcher>
+      </TestWrapper>,
+    )
+
+    await waitFor(() => {
+      expect(history.location.pathname).toBe('/static-visible')
+    })
+    expect(history.location.search).toBe('?foo=bar')
+
+    expect(screen.getByTestId('children')).toBeDefined()
+    expect(screen.queryByTestId('not-found')).toBeNull()
+  })
+
+  it('navigates to root when go-to-default is clicked from NotFoundComponent', async () => {
+    const visible = createWorkspace({name: 'visible', basePath: '/common/visible'})
+
+    const workspaces = [visible]
+    const contextValue = createContextValue(workspaces, {visible: createAuthState()})
+
+    // A path outside any workspace basePath renders the not-found screen.
+    const history = createMemoryHistory({initialEntries: ['/no-such-workspace']})
 
     render(
       <TestWrapper contextValue={contextValue} allWorkspaces={workspaces}>
@@ -547,7 +584,7 @@ describe('ActiveWorkspaceMatcher hidden workspace behaviour', () => {
     await userEvent.click(screen.getByTestId('not-found'))
 
     await waitFor(() => {
-      expect(history.location.pathname).toBe('/static-visible')
+      expect(history.location.pathname).toBe('/common/visible')
     })
 
     expect(screen.getByTestId('children')).toBeDefined()

--- a/packages/sanity/src/core/studio/activeWorkspaceMatcher/__tests__/matchWorkspace.test.ts
+++ b/packages/sanity/src/core/studio/activeWorkspaceMatcher/__tests__/matchWorkspace.test.ts
@@ -178,6 +178,97 @@ describe('matchWorkspace', () => {
     expect(result.pathname).toBe(visible.basePath)
   })
 
+  it('redirects to the first visible workspace when the pathname matches a statically hidden workspace', () => {
+    const hidden = {name: 'hidden', basePath: '/common/hidden', hidden: true}
+    const visible = {name: 'visible', basePath: '/common/visible'}
+
+    const result = matchWorkspace({
+      workspaces: [hidden, visible],
+      pathname: '/common/hidden',
+    })
+
+    assert(result.type === 'redirect')
+    expect(result.pathname).toBe(visible.basePath)
+  })
+
+  it('redirects to the first visible workspace when the pathname matches a function-hidden workspace', () => {
+    const fnHidden = {
+      name: 'fnHidden',
+      basePath: '/common/fn-hidden',
+      hidden: () => true,
+    }
+    const visible = {name: 'visible', basePath: '/common/visible'}
+
+    const result = matchWorkspace({
+      workspaces: [fnHidden, visible],
+      pathname: '/common/fn-hidden',
+      workspaceAuthStates: {fnHidden: createAuthState()},
+    })
+
+    assert(result.type === 'redirect')
+    expect(result.pathname).toBe(visible.basePath)
+  })
+
+  it('redirects a deep path within a hidden workspace to the first visible workspace basePath', () => {
+    const hidden = {name: 'hidden', basePath: '/common/hidden', hidden: true}
+    const visible = {name: 'visible', basePath: '/common/visible'}
+
+    const result = matchWorkspace({
+      workspaces: [hidden, visible],
+      pathname: '/common/hidden/structure/some-document',
+    })
+
+    assert(result.type === 'redirect')
+    expect(result.pathname).toBe(visible.basePath)
+  })
+
+  it('returns loading when the matched function-hidden workspace has no auth state yet', () => {
+    const fnHidden = {
+      name: 'fnHidden',
+      basePath: '/common/fn-hidden',
+      hidden: () => false,
+    }
+    const other = {name: 'other', basePath: '/common/other'}
+
+    const result = matchWorkspace({
+      workspaces: [fnHidden, other],
+      pathname: '/common/fn-hidden',
+      workspaceAuthStates: {},
+    })
+
+    expect(result.type).toBe('loading')
+  })
+
+  it('returns loading when the matched workspace is hidden and a redirect candidate is still resolving', () => {
+    const hidden = {name: 'hidden', basePath: '/common/hidden', hidden: true}
+    const fnHidden = {
+      name: 'fnHidden',
+      basePath: '/common/fn-hidden',
+      hidden: () => false,
+    }
+
+    const result = matchWorkspace({
+      workspaces: [hidden, fnHidden],
+      pathname: '/common/hidden',
+      workspaceAuthStates: {},
+    })
+
+    expect(result.type).toBe('loading')
+  })
+
+  it('returns the hidden match when every workspace is hidden', () => {
+    const hiddenA = {name: 'hiddenA', basePath: '/common/hidden-a', hidden: true}
+    const hiddenB = {name: 'hiddenB', basePath: '/common/hidden-b', hidden: true}
+
+    const result = matchWorkspace({
+      workspaces: [hiddenA, hiddenB],
+      pathname: '/common/hidden-a',
+    })
+
+    assert(result.type === 'match')
+    expect(result.workspace).toBe(hiddenA)
+  })
+
   it('results in a redirect to the first workspace if the incoming `pathname` partially matches the common base path', () => {
     const commonBasePath = `/x/common`
     const foo = {name: 'foo', basePath: `${commonBasePath}/foo`}

--- a/packages/sanity/src/core/studio/activeWorkspaceMatcher/matchWorkspace.ts
+++ b/packages/sanity/src/core/studio/activeWorkspaceMatcher/matchWorkspace.ts
@@ -19,15 +19,40 @@ export type MatchWorkspaceResult =
   | {type: 'loading'}
 
 /**
+ * Walks workspaces in config order and returns a redirect to the first one
+ * visible to the current user, skipping any with `hidden: true` or with a
+ * `hidden()` callback that returns `true`. Returns `loading` when a
+ * function-hidden workspace is reached whose auth state has not yet resolved,
+ * and `undefined` when every workspace is hidden.
+ */
+function redirectToFirstVisibleWorkspace(
+  workspaces: NormalizedWorkspace[],
+  workspaceAuthStates: WorkspaceAuthStates,
+): {type: 'redirect'; pathname: string} | {type: 'loading'} | undefined {
+  for (const {workspace, basePath} of workspaces) {
+    const {hidden} = workspace
+    if (hidden === true) continue
+    if (typeof hidden === 'function') {
+      const authState = workspaceAuthStates[workspace.name]
+      if (authState === undefined) return {type: 'loading'}
+      if (evaluateWorkspaceHidden(workspace, authState)) continue
+    }
+    return {type: 'redirect', pathname: basePath}
+  }
+  return undefined
+}
+
+/**
  * Resolves a pathname against the configured workspaces. Returns a match for a
  * known workspace path, a redirect to the first visible workspace when the
  * pathname is the common base path, or not-found otherwise.
  *
- * The default redirect walks workspaces in config order, skipping any with
- * `hidden: true` or with a `hidden()` callback that returns `true`. It returns
- * `loading` only when a function-hidden workspace is reached whose auth state
- * has not yet resolved. If every workspace is hidden, it falls back to the
- * first configured workspace.
+ * A pathname that points at a workspace hidden for the current user also
+ * redirects to the first visible workspace — the auth flow can return the
+ * browser to a URL that was resolved before the user was known (e.g. a hosted
+ * studio's `redirectTo`), and that URL may name a workspace the user cannot
+ * see. When every workspace is hidden, the hidden match is returned as-is so
+ * the caller can render its not-found screen.
  *
  * @internal
  */
@@ -44,23 +69,34 @@ export function matchWorkspace({
     // e.g. if the `workspace.basePath` is `/base/foobar` and the current
     // pathname is `/base/foo`, then that should not be a match
     if (basePathRegex.test(pathname) || basePath === '/') {
-      return {type: 'match', workspace}
+      if (
+        typeof workspace.hidden === 'function' &&
+        workspaceAuthStates[workspace.name] === undefined
+      ) {
+        return {type: 'loading'}
+      }
+      if (!evaluateWorkspaceHidden(workspace, workspaceAuthStates[workspace.name])) {
+        return {type: 'match', workspace}
+      }
+      // The pathname points at a workspace hidden for the current user;
+      // redirect to the first visible one instead of dead-ending.
+      return (
+        redirectToFirstVisibleWorkspace(workspaces, workspaceAuthStates) ?? {
+          type: 'match',
+          workspace,
+        }
+      )
     }
   }
 
   if (pathname === '/' || basePathRegex.test(pathname)) {
-    for (const {workspace, basePath} of workspaces) {
-      const {hidden} = workspace
-      if (hidden === true) continue
-      if (typeof hidden === 'function') {
-        const authState = workspaceAuthStates[workspace.name]
-        if (authState === undefined) return {type: 'loading'}
-        if (evaluateWorkspaceHidden(workspace, authState)) continue
+    return (
+      redirectToFirstVisibleWorkspace(workspaces, workspaceAuthStates) ?? {
+        // Every workspace is hidden; fall back to the first configured one.
+        type: 'redirect',
+        pathname: workspaces[0].basePath,
       }
-      return {type: 'redirect', pathname: basePath}
-    }
-    // Every workspace is hidden; fall back to the first configured one.
-    return {type: 'redirect', pathname: workspaces[0].basePath}
+    )
   }
 
   // if the pathname was not a subset of the common base path, then the route


### PR DESCRIPTION
### Description
The  auth round trip for a hosted-studio returns the browser to a workspace URL resolved *before* the user was authenticated. Before auth, the `hidden()` callback can't know the user, so the first *configured* workspace's `basePath` gets used as the login's `redirectTo`. Post-auth, the studio loads directly at that (now hidden) workspace's path, and the user ends up on the "Workspace not found" dead-end.

Since per-user visibility can't be evaluated before authentication, the studio now treats a URL pointing at a hidden workspace as "fixable" by redirecting to the first visible workspace (the same config-order walk from #12826). Instead of rendering the not-found screen whose only affordance was a button doing exactly that navigation. Note that when *every* workspace is hidden, the not-found screen still renders, which also prevents redirect loops with the all-hidden fallback.

### What to review
Note that when the hidden workspace and the first visible one belong to *different projects*, the user will have to log in twice, as there's no way to know that a workspace is hidden for a specific user without knowing who the user is. This double login is not new, and already happens today whenever the user switches to a workspace for another project.

### Testing

Unit tests added for the hidden-match redirect (static and callback `hidden`, deep paths, loading states, all-hidden); the two component tests asserting the old dead-end were updated, plus a test that search params survive the redirect. Manual check: `pnpm dev` → `/default-hidden` now redirects to the default workspace.

### Notes for release

Navigating to the URL of a workspace that is hidden for the current user (via `hidden: true` or a `hidden()` callback) now redirects to the first visible workspace instead of showing a "Workspace not found" screen. This fixes Sanity-hosted studios landing on "Workspace not found" after logging in, when the first configured workspace is hidden for the user.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core studio routing and post-auth navigation; behavior is well-covered by tests but affects all multi-workspace entry paths.
> 
> **Overview**
> Fixes hosted-studio logins landing on **"Workspace not found"** when auth returns the browser to a workspace URL that is **hidden for the authenticated user** (e.g. first configured workspace used as `redirectTo` before `hidden()` can run).
> 
> **`matchWorkspace`** now treats a path that matches a hidden workspace (static `hidden: true` or `hidden()` returning true) as a **redirect** to the first visible workspace in config order, including deep paths under that base path. Query strings are preserved via existing `history.replace` behavior. It returns **`loading`** while function-hidden visibility is unresolved, and when **every** workspace is hidden it still **matches** the hidden workspace so the UI can show not-found without redirect loops.
> 
> **`ActiveWorkspaceMatcher`** drops redundant loading logic for callback-hidden matches (handled in `matchWorkspace`) and documents that the in-match not-found branch is only for the all-hidden case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b15fb1cf082c273deec9191331d21385d3506396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->