### PR TITLE
fix: allow revert confirm popover to flip above the button

### DIFF
--- a/packages/sanity/src/core/field/diff/components/RevertChangesConfirmDialog.tsx
+++ b/packages/sanity/src/core/field/diff/components/RevertChangesConfirmDialog.tsx
@@ -40,7 +40,7 @@ export function RevertChangesConfirmDialog({
       referenceElement={referenceElement}
       tone="critical"
       placement="bottom"
-      fallbackPlacements={['bottom', 'bottom-start', 'bottom-end']}
+      fallbackPlacements={['bottom-start', 'bottom-end', 'top', 'top-start', 'top-end']}
     />
   )
 }


### PR DESCRIPTION
### Description

Fixes SAPP-3655

In the review changes panel, the revert confirmation popover opened from a change near the bottom of the panel is clipped by the panel boundary, cutting off the Cancel/Revert buttons.

The popover's `fallbackPlacements` were all `bottom` variants (set in #12255, which moved the popover from `left` to `bottom` to keep it from going offscreen horizontally), so floating-ui's `flip` middleware had no upward placement to fall back to when there's no room below the button. Adding `top` variants to the fallbacks lets the popover flip above the button in that case, while still preferring `bottom` — preserving the #12255 fix.

### What to review

One line in `packages/sanity/src/core/field/diff/components/RevertChangesConfirmDialog.tsx` (`sanity` package). The dialog is shared by `FieldChange`, `ChangeList` ("Revert all"), and `ChangeResolver`, so all revert popovers in the changes panel are covered.

### Testing

To verify manually: open Review changes, click the revert icon on the bottom-most change — the popover should flip above the button instead of clipping below the panel edge. No automated test — jsdom has no layout, so floating-ui's flip behavior can't be exercised there, and asserting the prop value would only be a change detector.

### Notes for release

Fixed an issue where the confirmation popover for reverting a change near the bottom of the review changes panel could be clipped by the panel edge, making its buttons inaccessible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single prop change to popover positioning only; no auth, data, or business-logic impact.
> 
> **Overview**
> Fixes revert confirmation popovers in the review changes panel being clipped when opened near the bottom of the panel.
> 
> **`RevertChangesConfirmDialog`** now passes `top`, `top-start`, and `top-end` in `fallbackPlacements` (and drops the redundant `bottom` entry) so floating-ui can flip the popover above the trigger when there isn’t space below, while still preferring `placement="bottom"`. All revert confirm flows that use this dialog (single change, revert all, resolver) get the same behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 146d450228f7cf112f05053d986d57957ab14ebe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->