### PR TITLE
fix(structure): variants unpublish updates

### DIFF
--- a/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx
@@ -50,6 +50,12 @@ export interface ConfirmDeleteDialogProps {
    * the same document deletion confirmation).
    */
   action?: 'delete' | 'unpublish'
+  /**
+   * When `false`, skips loading incoming references and shows a simple
+   * confirmation. Used when unpublishing a published content variant — refs
+   * always target the base published id, not the variant id.
+   */
+  checkIncomingReferences?: boolean
   onCancel: () => void
   onConfirm: (versions: string[], referenceCounts: DeleteReferenceCounts) => void
 }
@@ -65,6 +71,7 @@ export function ConfirmDeleteDialog({
   id,
   type,
   action = 'delete',
+  checkIncomingReferences = true,
   onCancel,
   onConfirm,
 }: ConfirmDeleteDialogProps) {
@@ -78,14 +85,15 @@ export function ConfirmDeleteDialog({
     projectIds,
     datasetNames,
     hasUnknownDatasetNames,
-  } = useReferringDocuments(id)
+  } = useReferringDocuments(id, {enabled: checkIncomingReferences})
   const documentTitle = <DocTitle document={useMemo(() => ({_id: id, _type: type}), [id, type])} />
   const {data: documentVersions, loading: versionsLoading} = useDocumentVersions({
     documentId: getPublishedId(id),
   })
   // Wait for the version count too, so the button copy doesn't flash from
-  // "Delete all versions" to "Delete document" while the count loads
-  const showConfirmButton = !isLoading && !versionsLoading
+  // "Delete all versions" to "Delete document" while the count loads. If incoming
+  // references are disabled, show the confirm button immediately.
+  const showConfirmButton = !checkIncomingReferences || (!isLoading && !versionsLoading)
 
   const handleConfirm = useCallback(() => {
     onConfirm(documentVersions, {

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/__tests__/ConfirmDeleteDialog.test.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/__tests__/ConfirmDeleteDialog.test.tsx
@@ -111,4 +111,28 @@ describe('ConfirmDeleteDialog', () => {
     expect(screen.queryByText('Delete all versions')).not.toBeInTheDocument()
     expect(screen.queryByText('Delete all versions anyway')).not.toBeInTheDocument()
   })
+
+  it('skips incoming ref validations on versions and shows a simple unpublish confirm when incoming refs are disabled', async () => {
+    mockUseDocumentVersions.mockReturnValue(withVersions(1))
+    const wrapper = await createTestProvider({resources: [structureUsEnglishLocaleBundle]})
+
+    render(
+      <ConfirmDeleteDialog
+        id="doc1"
+        type="post"
+        action="unpublish"
+        checkIncomingReferences={false}
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+      {wrapper},
+    )
+
+    expect(mockUseReferringDocuments).toHaveBeenCalledWith('doc1', {enabled: false})
+    expect(await screen.findByText('Unpublish now')).toBeInTheDocument()
+    expect(screen.queryByText('Unpublish anyway')).not.toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toHaveTextContent(
+      'Are you sure you want to unpublish “Doc title”?',
+    )
+  })
 })

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/useReferringDocuments.ts
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/useReferringDocuments.ts
@@ -244,16 +244,43 @@ const INITIAL_STATE: ReferringDocuments = {
   crossDatasetReferences: undefined,
 }
 
-export function useReferringDocuments(documentId: string): ReferringDocuments {
+const EMPTY_READY_STATE: ReferringDocuments = {
+  isLoading: false,
+  totalCount: 0,
+  projectIds: [],
+  datasetNames: [],
+  hasUnknownDatasetNames: false,
+  internalReferences: {totalCount: 0, references: []},
+  crossDatasetReferences: {totalCount: 0, references: []},
+}
+
+/**
+ * @internal
+ */
+export interface UseReferringDocumentsOptions {
+  /**
+   * When `false`, skips fetching incoming references and returns an empty ready
+   * state
+   */
+  enabled?: boolean
+}
+
+export function useReferringDocuments(
+  documentId: string,
+  options?: UseReferringDocumentsOptions,
+): ReferringDocuments {
+  const enabled = options?.enabled ?? true
   const versionedClient = useClient(DEFAULT_STUDIO_CLIENT_OPTIONS)
   const documentStore = useDocumentStore()
 
-  const referringDocuments$ = useMemo(
-    () => referringDocuments({documentId, versionedClient, documentStore}),
-    [documentId, versionedClient, documentStore],
-  )
+  const referringDocuments$ = useMemo(() => {
+    if (!enabled) {
+      return of(EMPTY_READY_STATE)
+    }
+    return referringDocuments({documentId, versionedClient, documentStore})
+  }, [documentId, documentStore, enabled, versionedClient])
 
-  return useObservable(referringDocuments$, INITIAL_STATE)
+  return useObservable(referringDocuments$, enabled ? INITIAL_STATE : EMPTY_READY_STATE)
 }
 
 /**

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/useReferringDocuments.ts
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/useReferringDocuments.ts
@@ -264,10 +264,12 @@ function fetchInternalReferences(
   documentId: string,
   documentStore: DocumentStore,
 ): Observable<ReferringDocuments['internalReferences']> {
-  const referencesClause = '*[references($documentId)][0...100]{_id,_type}'
-  const totalClause = 'count(*[references($documentId)])'
+  // Documents now self reference themselves, within the _system.group field. We need to exclude them from the references query.
+  const referencesQuery = `*[references($documentId) && _system.group._ref != $documentId]`
+  const referencesClause = `${referencesQuery}[0...100]{_id,_type}`
+  const totalClause = `count(${referencesQuery})`
   const fetchQuery = `{"references":${referencesClause},"totalCount":${totalClause}}`
-  const listenQuery = '*[references($documentId)]'
+  const listenQuery = referencesQuery
 
   return documentStore.listenQuery(
     {fetch: fetchQuery, listen: listenQuery},

--- a/packages/sanity/src/structure/documentActions/UnpublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/UnpublishAction.tsx
@@ -79,6 +79,9 @@ export const useUnpublishAction: DocumentActionComponent = ({
             id={draft?._id || id}
             type={type}
             action="unpublish"
+            // Published variants can always be unpublished — incoming refs point
+            // at the base published id, not the variant id.
+            checkIncomingReferences={!isVariantTarget}
             onCancel={handleCancel}
             onConfirm={handleConfirm}
           />
@@ -87,7 +90,7 @@ export const useUnpublishAction: DocumentActionComponent = ({
     }
 
     return null
-  }, [draft, id, handleCancel, handleConfirm, isConfirmDialogOpen, type])
+  }, [draft, handleCancel, handleConfirm, id, isConfirmDialogOpen, isVariantTarget, type])
 
   return useMemo(() => {
     if (release || isDraft) {

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
@@ -1,6 +1,7 @@
 import {Card, Flex} from '@sanity/ui'
 import {motion} from 'motion/react'
 import {type Ref, useCallback, useMemo, useState} from 'react'
+import {select} from 'react-i18next/icu.macro'
 import {
   getCreatableVariantTarget,
   isPublishedPerspective,
@@ -28,7 +29,7 @@ const AnimatedCard = motion.create(Card)
 
 export function DocumentStatusBar(props: DocumentStatusBarProps) {
   const {actionsBoxRef} = props
-  const {editState, revisionNotFound, targetDocumentState} = useDocumentPane()
+  const {editState, revisionNotFound, targetDocumentState, value} = useDocumentPane()
   const {params = EMPTY_PARAMS} = usePaneRouter()
   const {selectedPerspective, selectedVariantName} = usePerspective()
 
@@ -57,16 +58,13 @@ export function DocumentStatusBar(props: DocumentStatusBarProps) {
     ) {
       return false
     }
-
-    if (selectedPerspective) {
-      if (isPublishedPerspective(selectedPerspective)) {
-        return isReady && Boolean(editState?.published)
-      }
-      if (isReleaseDocument(selectedPerspective)) {
-        return isReady && Boolean(editState?.version)
-      }
-    }
-    return isReady
+    // Validates if for the selected perspective a document exists.
+    // Always true for drafts perspective.
+    return (
+      isReady &&
+      ((targetDocumentState.status === 'ready' && Boolean(targetDocumentState.targetDocument)) ||
+        selectedPerspective === 'drafts')
+    )
   }, [collapsed, editState, selectedPerspective, selectedVariantName, targetDocumentState])
 
   let actions: React.JSX.Element | null = null

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
@@ -58,22 +58,23 @@ export function DocumentStatusBar(props: DocumentStatusBarProps) {
       return false
     }
 
+    // Prefer `targetDocument` so published / release variants (which are not always present on
+    // `editState.published`) still render the footer.
     const hasTargetDocument =
       targetDocumentState.status === 'ready' && Boolean(targetDocumentState.targetDocument)
-
-    // Prefer `targetDocument` so published / release variants (which are not always present on
-    // `editState.published`) still render the footer. Keep the legacy `editState` checks for:
-    // - published base documents
-    // - release fallbacks: when the pinned release has no version, the form checks out the first
-    //   existing version into `editState.version` and the inventory/actions must stay available
-    if (isPublishedPerspective(selectedPerspective)) {
-      return isReady && (hasTargetDocument || Boolean(editState?.published))
-    }
-    if (isReleaseDocument(selectedPerspective)) {
-      return isReady && (hasTargetDocument || Boolean(editState?.version))
+    if (hasTargetDocument) {
+      return isReady
     }
 
-    // Drafts (and other system perspectives): always show once ready.
+    if (selectedPerspective) {
+      if (isPublishedPerspective(selectedPerspective)) {
+        return isReady && Boolean(editState?.published)
+      }
+      if (isReleaseDocument(selectedPerspective)) {
+        return isReady && Boolean(editState?.version)
+      }
+    }
+
     return isReady
   }, [collapsed, editState, selectedPerspective, selectedVariantName, targetDocumentState])
 

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
@@ -1,7 +1,6 @@
 import {Card, Flex} from '@sanity/ui'
 import {motion} from 'motion/react'
 import {type Ref, useCallback, useMemo, useState} from 'react'
-import {select} from 'react-i18next/icu.macro'
 import {
   getCreatableVariantTarget,
   isPublishedPerspective,
@@ -29,7 +28,7 @@ const AnimatedCard = motion.create(Card)
 
 export function DocumentStatusBar(props: DocumentStatusBarProps) {
   const {actionsBoxRef} = props
-  const {editState, revisionNotFound, targetDocumentState, value} = useDocumentPane()
+  const {editState, revisionNotFound, targetDocumentState} = useDocumentPane()
   const {params = EMPTY_PARAMS} = usePaneRouter()
   const {selectedPerspective, selectedVariantName} = usePerspective()
 
@@ -58,13 +57,24 @@ export function DocumentStatusBar(props: DocumentStatusBarProps) {
     ) {
       return false
     }
-    // Validates if for the selected perspective a document exists.
-    // Always true for drafts perspective.
-    return (
-      isReady &&
-      ((targetDocumentState.status === 'ready' && Boolean(targetDocumentState.targetDocument)) ||
-        selectedPerspective === 'drafts')
-    )
+
+    const hasTargetDocument =
+      targetDocumentState.status === 'ready' && Boolean(targetDocumentState.targetDocument)
+
+    // Prefer `targetDocument` so published / release variants (which are not always present on
+    // `editState.published`) still render the footer. Keep the legacy `editState` checks for:
+    // - published base documents
+    // - release fallbacks: when the pinned release has no version, the form checks out the first
+    //   existing version into `editState.version` and the inventory/actions must stay available
+    if (isPublishedPerspective(selectedPerspective)) {
+      return isReady && (hasTargetDocument || Boolean(editState?.published))
+    }
+    if (isReleaseDocument(selectedPerspective)) {
+      return isReady && (hasTargetDocument || Boolean(editState?.version))
+    }
+
+    // Drafts (and other system perspectives): always show once ready.
+    return isReady
   }, [collapsed, editState, selectedPerspective, selectedVariantName, targetDocumentState])
 
   let actions: React.JSX.Element | null = null


### PR DESCRIPTION
### Description
Some necessary updates for variants unpublish.
- The confirm dialog now doesn't check incoming references for variant documents unpublish, the reference is always to the `publishedId` so we don't need to validate this for variants, a variant can always be unpublished.
- The `references()` check now skips self referencing documents defined in the `_system.group._ref` field.
- The document status bar now renders for published variant documents. It was always supposed to render but there was a bug in how we checked the existence of the document.

Published defaults check for references
<img width="1077" height="945" alt="Screenshot 2026-08-10 at 15 24 07" src="https://github.com/user-attachments/assets/3ccc5862-7803-4f8c-be5c-d4da6ac9a6d4" />

Published variants do not check references
<img width="1072" height="941" alt="Screenshot 2026-08-10 at 15 24 18" src="https://github.com/user-attachments/assets/76ea6c4b-0525-45ab-9d79-ce25dbb82f93" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a internal variants work
<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches delete/unpublish confirmation and live reference listening; changes are scoped to variants and self-ref filtering but alter when users see reference warnings and status-bar actions.
> 
> **Overview**
> Fixes **published content variant** unpublish and related UI by skipping irrelevant incoming-reference checks and correcting when the document status bar appears.
> 
> **Unpublish for variants** passes `checkIncomingReferences={false}` into `ConfirmDeleteDialog` when the target is a variant, so users get a simple “Unpublish now” flow instead of blocking on refs that always point at the base published id. `useReferringDocuments` gains an `enabled` option that returns an empty ready state without fetching.
> 
> **Incoming reference queries** now exclude documents that only self-reference via `_system.group._ref`, so delete/unpublish warnings are not inflated by variant grouping metadata.
> 
> **Document status bar** `shouldRender` no longer keys off `editState.published` / release version flags alone; it shows when `targetDocumentState` has a resolved `targetDocument` for the current perspective (or when the drafts perspective is selected), so published variants get actions and status again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb972258416252657abb7b8fef06c42ecb91502f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->