### PR TITLE
fix(bench): plot trend charts by commit date instead of run time

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -66,6 +66,10 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     outputs:
       has_code_changes: ${{ steps.changes.outputs.has_changes }}
+      # Committer date of the backfilled commit (empty on non-backfill runs) —
+      # resolved by prepare-backfill, consumed as BENCH_GIT_COMMITTED_AT by the
+      # measuring jobs so stored documents land on the commit's date
+      backfill_committed_at: ${{ steps.build.outputs.committed_at }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -110,6 +114,7 @@ jobs:
       # downstream jobs run unchanged and store the result under that sha
       # (BENCH_GIT_SHA below).
       - name: Build packages and experiment studio
+        id: build
         if: steps.changes.outputs.has_changes == 'true' || github.event_name != 'pull_request'
         env:
           BACKFILL_SHA: ${{ inputs.backfill_sha }}
@@ -224,6 +229,7 @@ jobs:
       # documents with that sha (empty on non-backfill events; see
       # report/collect.ts)
       BENCH_GIT_SHA: ${{ inputs.backfill_sha }}
+      BENCH_GIT_COMMITTED_AT: ${{ needs.build.outputs.backfill_committed_at }}
     strategy:
       fail-fast: false
       matrix:
@@ -319,6 +325,7 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       # See bench-interaction: stamps backfill runs with the measured sha
       BENCH_GIT_SHA: ${{ inputs.backfill_sha }}
+      BENCH_GIT_COMMITTED_AT: ${{ needs.build.outputs.backfill_committed_at }}
     strategy:
       fail-fast: false
       matrix:
@@ -626,6 +633,7 @@ jobs:
       # See bench-interaction: stamps backfill runs (soak/INP here) with the
       # measured sha
       BENCH_GIT_SHA: ${{ inputs.backfill_sha }}
+      BENCH_GIT_COMMITTED_AT: ${{ needs.build.outputs.backfill_committed_at }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/dev/metrics-studio/schemaTypes/benchRun.ts
+++ b/dev/metrics-studio/schemaTypes/benchRun.ts
@@ -280,6 +280,12 @@ const benchRun = defineType({
       fields: [
         defineField({name: 'sha', type: 'string'}),
         defineField({name: 'branch', type: 'string'}),
+        defineField({
+          name: 'committedAt',
+          type: 'datetime',
+          description:
+            'Committer date of the measured sha — the trend x-axis (differs from startedAt on backfilled runs). Absent on older documents.',
+        }),
         defineField({name: 'mergeBaseSha', type: 'string'}),
         defineField({name: 'prNumber', type: 'number'}),
       ],

--- a/dev/metrics-studio/tools/trends/data.ts
+++ b/dev/metrics-studio/tools/trends/data.ts
@@ -7,7 +7,14 @@ export interface TrendRun {
   _id: string
   startedAt: string
   mode: 'ab' | 'absolute'
-  git: {sha: string; branch: string; prNumber?: number; mergeBaseSha?: string} | null
+  git: {
+    sha: string
+    branch: string
+    /** Committer date of `sha` — absent on documents stored before it existed. */
+    committedAt?: string | null
+    prNumber?: number
+    mergeBaseSha?: string
+  } | null
   runner: {calibrationMs: number; runId?: string; runAttempt?: number} | null
   bundle: {experiment: {initialJsBytes: number} | null} | null
   scenarios:
@@ -43,11 +50,11 @@ export interface TrendRun {
     | null
 }
 
-export const TREND_QUERY = `*[_type == "benchRun"] | order(startedAt asc) {
+export const TREND_QUERY = `*[_type == "benchRun"] | order(coalesce(git.committedAt, startedAt) asc) {
   _id,
   startedAt,
   mode,
-  git{sha, branch, prNumber, mergeBaseSha},
+  git{sha, branch, committedAt, prNumber, mergeBaseSha},
   runner{calibrationMs, runId, runAttempt},
   bundle{experiment{initialJsBytes}},
   scenarios[]{
@@ -112,6 +119,18 @@ export interface TrendSeries {
   xKind?: 'date' | 'minute'
   /** One line per branch (usually just one — comparison overlays several). */
   lines: TrendLine[]
+}
+
+/**
+ * Where a run sits on the time axis: the measured commit's committer date.
+ * Backfilled runs measure a historical commit long after the fact — plotting
+ * them at `startedAt` stacks them all on the day the backfill ran instead of
+ * spreading them across the dates being repaired. Older documents predate
+ * `git.committedAt` and fall back to `startedAt` (within a day of the commit
+ * for cron runs, so the axis stays honest).
+ */
+export function runDate(run: TrendRun): Date {
+  return new Date(run.git?.committedAt || run.startedAt)
 }
 
 /** All git branches present in the runs, `main` first, then alphabetical. */
@@ -363,7 +382,7 @@ function slopeUnitFor(baseUnit: TrendUnit): TrendUnit {
 export function filterByRange(runs: TrendRun[], days: number | null): TrendRun[] {
   if (days === null) return runs
   const cutoff = Date.now() - days * 24 * 60 * 60 * 1000
-  return runs.filter((run) => new Date(run.startedAt).getTime() >= cutoff)
+  return runs.filter((run) => runDate(run).getTime() >= cutoff)
 }
 
 /**
@@ -401,7 +420,7 @@ export function buildSeries(runs: TrendRun[]): TrendSeries[] {
       line = {branch, points: []}
       existing.lines.push(line)
     }
-    line.points.push({date: new Date(run.startedAt), ...pointMeta(run), ...point})
+    line.points.push({date: runDate(run), ...pointMeta(run), ...point})
     series.set(key, existing)
   }
 
@@ -469,7 +488,7 @@ export function calibrationSeries(runs: TrendRun[]): TrendSeries {
     }
     for (const value of values) {
       line.points.push({
-        date: new Date(run.startedAt),
+        date: runDate(run),
         value,
         ...pointMeta(run),
       })
@@ -589,7 +608,7 @@ function soakHistory(
       sourceFile ??= file
       const branch = run.git?.branch ?? 'unknown'
       const line = lineByBranch.get(branch) ?? {branch, points: []}
-      line.points.push({date: new Date(run.startedAt), value, ...pointMeta(run)})
+      line.points.push({date: runDate(run), value, ...pointMeta(run)})
       lineByBranch.set(branch, line)
     }
     return {

--- a/perf/bench/cli/commands/prepareBackfill.ts
+++ b/perf/bench/cli/commands/prepareBackfill.ts
@@ -23,7 +23,9 @@ import {command, constant, option} from '@optique/core/primitives'
 import {string} from '@optique/core/valueparser'
 
 import {BENCH_ROOT} from '../benchRoot'
-import {buildDistAtCommit} from './prepareReference'
+import {buildDistAtCommit, git, setOutput} from './prepareReference'
+
+const REPO_ROOT = path.dirname(path.dirname(BENCH_ROOT))
 
 export const prepareBackfillCommand = command(
   'prepare-backfill',
@@ -50,5 +52,11 @@ export function prepareBackfill(argv: PrepareBackfillArgs): void {
   if (!/^[0-9a-f]{40}$/i.test(argv.sha)) {
     throw new Error(`--sha must be a full 40-char commit hash, got ${JSON.stringify(argv.sha)}`)
   }
+  // The measured commit's committer date — the workflow passes it to the
+  // measuring jobs (BENCH_GIT_COMMITTED_AT) so the stored documents land on
+  // the commit's date on the time-series x-axis, not the backfill run's.
+  // Resolved here because this is the only job with full history; the shard
+  // jobs are depth-1 checkouts of HEAD and cannot resolve the historical sha.
+  setOutput('committed_at', git(['show', '-s', '--format=%cI', argv.sha], REPO_ROOT))
   buildDistAtCommit(argv.sha, path.join(BENCH_ROOT, 'dist'))
 }

--- a/perf/bench/cli/commands/prepareReference.ts
+++ b/perf/bench/cli/commands/prepareReference.ts
@@ -50,7 +50,7 @@ export type PrepareReferenceArgs = InferValue<typeof prepareReferenceCommand>
 
 const REPO_ROOT = path.dirname(path.dirname(BENCH_ROOT))
 
-function git(args: string[], cwd: string): string {
+export function git(args: string[], cwd: string): string {
   const result = spawnSync('git', args, {cwd, encoding: 'utf8'})
   if (result.status !== 0) {
     throw new Error(`git ${args.join(' ')} failed: ${result.stderr?.trim()}`)
@@ -66,7 +66,7 @@ function step(executable: string, args: string[], cwd: string): void {
 }
 
 /** Write a step output for the workflow, and echo it for humans/local runs. */
-function setOutput(key: string, value: string): void {
+export function setOutput(key: string, value: string): void {
   console.log(`${key}=${value}`)
   if (process.env.GITHUB_OUTPUT) {
     fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`)

--- a/perf/bench/report/__tests__/collect.test.ts
+++ b/perf/bench/report/__tests__/collect.test.ts
@@ -14,6 +14,7 @@ const ENV_KEYS = [
   'GITHUB_RUN_ID',
   'BENCH_MERGE_BASE',
   'BENCH_GIT_SHA',
+  'BENCH_GIT_COMMITTED_AT',
 ] as const
 let savedEnv: Record<string, string | undefined>
 
@@ -76,6 +77,17 @@ describe('collectRunMetadata', () => {
     // arrives as the empty string and must fall through
     process.env.BENCH_GIT_SHA = ''
     expect(metadata().git.sha).toBe('abc')
+  })
+
+  it('stamps the measured commit date, preferring BENCH_GIT_COMMITTED_AT', () => {
+    process.env.GITHUB_SHA = 'abc'
+    process.env.GITHUB_HEAD_REF = 'perf-bench'
+    process.env.BENCH_GIT_COMMITTED_AT = '2026-08-02T14:30:00+02:00'
+    expect(metadata().git.committedAt).toBe('2026-08-02T14:30:00+02:00')
+    // Empty (non-backfill) falls through to HEAD's committer date — the test
+    // process runs inside the repo, so a real ISO date comes back
+    process.env.BENCH_GIT_COMMITTED_AT = ''
+    expect(metadata().git.committedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
   })
 })
 

--- a/perf/bench/report/__tests__/collect.test.ts
+++ b/perf/bench/report/__tests__/collect.test.ts
@@ -88,6 +88,10 @@ describe('collectRunMetadata', () => {
     // process runs inside the repo, so a real ISO date comes back
     process.env.BENCH_GIT_COMMITTED_AT = ''
     expect(metadata().git.committedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    // A malformed override is dropped, not stored — an unparseable date would
+    // poison the trend axis ordering/filtering built on this field
+    process.env.BENCH_GIT_COMMITTED_AT = 'not-a-date'
+    expect(metadata().git.committedAt).toBeUndefined()
   })
 })
 

--- a/perf/bench/report/collect.ts
+++ b/perf/bench/report/collect.ts
@@ -34,6 +34,14 @@ export function collectRunMetadata(options: {
   const prNumber = Number(
     (process.env.GITHUB_REF ?? '').match(/refs\/pull\/(\d+)\//)?.[1] ?? Number.NaN,
   )
+  // Committer date of the measured commit — the time-series x-axis (dashboards
+  // plot it instead of startedAt so backfilled points land on their commit's
+  // date). Backfill shards check out HEAD, not the measured sha, so the
+  // workflow resolves the date where full history exists (prepare-backfill)
+  // and passes it through; everywhere else HEAD is the measured commit and
+  // its committer date is resolvable even in a depth-1 clone.
+  const committedAt =
+    process.env.BENCH_GIT_COMMITTED_AT || git(['show', '-s', '--format=%cI', 'HEAD'])
   return {
     _type: 'benchRun',
     schemaVersion: 1,
@@ -52,6 +60,9 @@ export function collectRunMetadata(options: {
         process.env.GITHUB_HEAD_REF ||
         process.env.GITHUB_REF_NAME ||
         git(['rev-parse', '--abbrev-ref', 'HEAD']),
+      // The git() helper answers 'unknown' outside a repo — omit rather than
+      // store a non-date
+      ...(committedAt && committedAt !== 'unknown' ? {committedAt} : {}),
       // The sha the reference side was built at (bench.yml passes the
       // prepare-reference output through) — rendered in the report footer
       ...(process.env.BENCH_MERGE_BASE ? {mergeBaseSha: process.env.BENCH_MERGE_BASE} : {}),

--- a/perf/bench/report/collect.ts
+++ b/perf/bench/report/collect.ts
@@ -40,8 +40,12 @@ export function collectRunMetadata(options: {
   // workflow resolves the date where full history exists (prepare-backfill)
   // and passes it through; everywhere else HEAD is the measured commit and
   // its committer date is resolvable even in a depth-1 clone.
-  const committedAt =
+  const committedAtRaw =
     process.env.BENCH_GIT_COMMITTED_AT || git(['show', '-s', '--format=%cI', 'HEAD'])
+  // Omit anything unparseable — the git() helper answers 'unknown' outside a
+  // repo, and a malformed workflow override must not poison the time axis
+  // consumers sort and filter on
+  const committedAt = Number.isNaN(Date.parse(committedAtRaw)) ? undefined : committedAtRaw
   return {
     _type: 'benchRun',
     schemaVersion: 1,
@@ -60,9 +64,7 @@ export function collectRunMetadata(options: {
         process.env.GITHUB_HEAD_REF ||
         process.env.GITHUB_REF_NAME ||
         git(['rev-parse', '--abbrev-ref', 'HEAD']),
-      // The git() helper answers 'unknown' outside a repo — omit rather than
-      // store a non-date
-      ...(committedAt && committedAt !== 'unknown' ? {committedAt} : {}),
+      ...(committedAt ? {committedAt} : {}),
       // The sha the reference side was built at (bench.yml passes the
       // prepare-reference output through) — rendered in the report footer
       ...(process.env.BENCH_MERGE_BASE ? {mergeBaseSha: process.env.BENCH_MERGE_BASE} : {}),

--- a/perf/bench/report/types.ts
+++ b/perf/bench/report/types.ts
@@ -14,6 +14,13 @@ export interface BenchRunDocument {
   git: {
     sha: string
     branch: string
+    /**
+     * Committer date (ISO 8601) of `sha` — the time-series x-axis. For
+     * backfill runs this is the historical commit's date, not the run's;
+     * `startedAt` stays the wall-clock run time. Absent on documents stored
+     * before this field existed (consumers fall back to `startedAt`).
+     */
+    committedAt?: string
     mergeBaseSha?: string
     prNumber?: number
   }


### PR DESCRIPTION
### Description

> Written by an AI agent on behalf of @bjoerge, who has reviewed it.

Backfilled runs plot at the time the backfill ran, so backfill runs ends up stacking on one x position in the trend charts. With this PR, run documents now get a `git.committedAt` (resolved from HEAD normally; passed through from `prepare-backfill` on backfill runs, since the measuring shards can't resolve a historical sha from a depth-1 checkout), and the charts plot that instead of `startedAt`, falling back for older documents. Existing backfill documents have already been patched in place.

### What to review
- `runDate()` in `dev/metrics-studio/tools/trends/data.ts` — it feeds every chart point, the range filter, and the query order. Note repeat runs of the same commit (weekend crons) now intentionally stack at one x.

- Example here: https://studio-metrics-git-bench-trend-commit-date.sanity.dev/trends

### Testing

New unit test for the `BENCH_GIT_COMMITTED_AT` precedence and fall-through.

### Notes for release

N/A – Internal only

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Internal metrics storage and dashboard axis logic only; backward-compatible fallback to `startedAt` for legacy documents.
> 
> **Overview**
> Backfilled benchmark runs no longer pile up on the day the backfill job ran. Stored `benchRun` documents gain optional **`git.committedAt`** (measured commit’s committer date), and the Trends tool uses that for query ordering, date-range filtering, and every chart point via **`runDate()`**, with **`startedAt`** only as a fallback for older docs.
> 
> **CI / backfill:** `prepare-backfill` resolves the historical SHA’s committer date and exposes it as a workflow output; measuring jobs receive **`BENCH_GIT_COMMITTED_AT`**. **`collectRunMetadata`** prefers that env var, otherwise reads HEAD’s committer date, and drops unparseable values so bad data doesn’t break the axis.
> 
> **Schema:** Sanity `benchRun` and report types document the new field. Shared **`git`** / **`setOutput`** helpers are exported from `prepareReference` for reuse in backfill prep. Unit tests cover env precedence and malformed overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8e9a4e22cee40446c4d25a4168b1f1868f1e140. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->