### PR TITLE
fix(structure): keep status bar for release version fallback

### DIFF
--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBar.tsx
@@ -1,7 +1,6 @@
 import {Card, Flex} from '@sanity/ui'
 import {motion} from 'motion/react'
 import {type Ref, useCallback, useMemo, useState} from 'react'
-import {select} from 'react-i18next/icu.macro'
 import {
   getCreatableVariantTarget,
   isPublishedPerspective,
@@ -29,7 +28,7 @@ const AnimatedCard = motion.create(Card)
 
 export function DocumentStatusBar(props: DocumentStatusBarProps) {
   const {actionsBoxRef} = props
-  const {editState, revisionNotFound, targetDocumentState, value} = useDocumentPane()
+  const {editState, revisionNotFound, targetDocumentState} = useDocumentPane()
   const {params = EMPTY_PARAMS} = usePaneRouter()
   const {selectedPerspective, selectedVariantName} = usePerspective()
 
@@ -58,13 +57,24 @@ export function DocumentStatusBar(props: DocumentStatusBarProps) {
     ) {
       return false
     }
-    // Validates if for the selected perspective a document exists.
-    // Always true for drafts perspective.
-    return (
-      isReady &&
-      ((targetDocumentState.status === 'ready' && Boolean(targetDocumentState.targetDocument)) ||
-        selectedPerspective === 'drafts')
-    )
+
+    const hasTargetDocument =
+      targetDocumentState.status === 'ready' && Boolean(targetDocumentState.targetDocument)
+
+    // Prefer `targetDocument` so published / release variants (which are not always present on
+    // `editState.published`) still render the footer. Keep the legacy `editState` checks for:
+    // - published base documents
+    // - release fallbacks: when the pinned release has no version, the form checks out the first
+    //   existing version into `editState.version` and the inventory/actions must stay available
+    if (isPublishedPerspective(selectedPerspective)) {
+      return isReady && (hasTargetDocument || Boolean(editState?.published))
+    }
+    if (isReleaseDocument(selectedPerspective)) {
+      return isReady && (hasTargetDocument || Boolean(editState?.version))
+    }
+
+    // Drafts (and other system perspectives): always show once ready.
+    return isReady
   }, [collapsed, editState, selectedPerspective, selectedVariantName, targetDocumentState])
 
   let actions: React.JSX.Element | null = null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

#13938 tightened `DocumentStatusBar` `shouldRender` to key off `targetDocument` so published variants get a footer again. That also hid the footer when a pinned release has no version of the document: the form still falls back to the first existing version (`editState.version`), but `targetDocument` is empty for the pinned release, so `action-document-group-inventory` never mounts and `DisplayedDocument` E2E fails.

Restoring the legacy `editState.version` / `editState.published` checks alongside `targetDocument` keeps the published-variant fix without dropping the release-fallback inventory path.

### What to review

- `DocumentStatusBar.tsx` `shouldRender` — especially the release fallback branch (`hasTargetDocument || editState.version`)

### Testing

- Logic matches the failing E2E case (`different version pinned - shows first version`): not-in-release banner + first-version form + inventory button.
- Did not re-run the full Playwright suite here (needs E2E tokens/deploy); fix is localized to the gate that removed the locator.

### Notes for release

N/A – Internal only (stacked on variants unpublish work)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-695cb55f-9750-4235-a1d3-1ecf6c12fc87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-695cb55f-9750-4235-a1d3-1ecf6c12fc87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

