### PR TITLE
fix(deps): update dependency motion to v13

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -199,7 +199,7 @@
     "json-stable-stringify": "^1.3.0",
     "lodash-es": "^4.18.1",
     "mendoza": "^3.0.8",
-    "motion": "^12.43.0",
+    "motion": "^13.0.0",
     "nano-pubsub": "^3.0.0",
     "nanoid": "^6.0.1",
     "observable-callback": "^1.0.3",

--- a/packages/sanity/src/core/divergence/components/DivergenceIndicator.test.tsx
+++ b/packages/sanity/src/core/divergence/components/DivergenceIndicator.test.tsx
@@ -1,0 +1,62 @@
+import {render} from '@testing-library/react'
+import {expect, test, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../test/testUtils/TestProvider'
+import {type DivergenceNavigator, type ReachableDivergence} from '../divergenceNavigator'
+import {type Divergence} from '../readDocumentDivergences'
+import {DivergenceIndicator} from './DivergenceIndicator'
+
+const baseDivergence: Divergence = {
+  path: 'title',
+  effect: 'set',
+  documentId: 'upstream-doc',
+  documentType: 'article',
+  subjectId: 'drafts.doc-1',
+  sinceRevisionId: 'upstream-doc@rev-1',
+  isAddressable: true,
+  status: 'unresolved',
+  snapshots: {
+    subjectHead: undefined,
+    upstreamHead: undefined,
+    upstreamAtFork: undefined,
+  },
+}
+
+const divergence: ReachableDivergence = {
+  ...baseDivergence,
+  isComposite: false,
+  divergences: [['title', baseDivergence]],
+  schemaType: {name: 'string', jsonType: 'string'},
+}
+
+const divergenceNavigator: DivergenceNavigator = {
+  focusDivergence: vi.fn(),
+  blurDivergence: vi.fn(),
+  blurFocusedDivergence: vi.fn(),
+  state: {
+    focusedDivergence: undefined,
+    previousDivergence: undefined,
+    nextDivergence: undefined,
+    state: 'ready',
+    upstreamId: 'upstream-doc',
+    allDivergences: [['title', baseDivergence]],
+    divergences: [['title', divergence]],
+    divergencesByNode: {title: 1},
+  },
+}
+
+test('does not forward the styling path to the DOM', async () => {
+  const TestProvider = await createTestProvider()
+  const {container} = render(
+    <TestProvider>
+      <DivergenceIndicator
+        divergence={divergence}
+        divergenceNavigator={divergenceNavigator}
+        path={['title']}
+        upstreamBundle="published"
+      />
+    </TestProvider>,
+  )
+
+  expect(container.firstElementChild).not.toHaveAttribute('path')
+})

--- a/packages/sanity/src/core/divergence/components/DivergenceIndicator.test.tsx
+++ b/packages/sanity/src/core/divergence/components/DivergenceIndicator.test.tsx
@@ -58,5 +58,11 @@ test('does not forward the styling path to the DOM', async () => {
     </TestProvider>,
   )
 
-  expect(container.firstElementChild).not.toHaveAttribute('path')
+  const renderedElements = container.querySelectorAll('*')
+  expect(renderedElements.length).toBeGreaterThan(0)
+
+  for (const element of renderedElements) {
+    expect(element).not.toHaveAttribute('path')
+    expect(element).not.toHaveAttribute('$path')
+  }
 })

--- a/packages/sanity/src/core/divergence/components/DivergenceIndicator.tsx
+++ b/packages/sanity/src/core/divergence/components/DivergenceIndicator.tsx
@@ -32,7 +32,7 @@ export const DivergenceIndicator: ComponentType<DivergenceIndicatorProps> = ({
   const {t} = useTranslation()
 
   return (
-    <Container path={path} initial={{opacity: 0}} exit={{opacity: 0}} animate={{opacity: 1}}>
+    <Container $path={path} initial={{opacity: 0}} exit={{opacity: 0}} animate={{opacity: 1}}>
       <Button
         aria-label={t('divergence.unresolved-divergence', {
           count: 1,
@@ -62,10 +62,10 @@ export const DivergenceIndicator: ComponentType<DivergenceIndicatorProps> = ({
   )
 }
 
-const Container = styled(motion.div)<{path: Path}>`
+const Container = styled(motion.div)<{$path: Path}>`
   @supports (position-anchor: --anchor) {
     position: absolute;
-    ${({path}) => (path ? `position-anchor: ${pathToAnchorIdent('input', path)};` : undefined)}
+    ${({$path}) => ($path ? `position-anchor: ${pathToAnchorIdent('input', $path)};` : undefined)}
     inset-block-start: anchor(center);
     transform: translateY(-50%);
     line-height: 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1827,8 +1827,8 @@ importers:
         specifier: ^3.0.8
         version: 3.0.8
       motion:
-        specifier: ^12.43.0
-        version: 12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8)
+        specifier: ^13.0.0
+        version: 13.0.0(react-dom@19.2.8)(react@19.2.8)
       nano-pubsub:
         specifier: ^3.0.0
         version: 3.0.0
@@ -9552,20 +9552,6 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
-  framer-motion@12.43.0:
-    resolution: {integrity: sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   framer-motion@13.0.0:
     resolution: {integrity: sha512-nQGZXlsiigN48nzvE7AL1GLekql+etcphp8v+PQ0X04oxO20yVmV9rU9XQ25c136RdeIYoaWlKT9oAwvJza3mg==}
     peerDependencies:
@@ -10916,31 +10902,11 @@ packages:
     resolution: {integrity: sha512-hI00baDVPjV5VfYA3j+oLuPvLfmCQICWot9zJZgkuDMXnWEYhIx9xCPEOt2IC3lDJz6ajsz2bpgO24E+xsP6wg==}
     engines: {node: '>=20.19.0'}
 
-  motion-dom@12.43.0:
-    resolution: {integrity: sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==}
-
   motion-dom@13.0.0:
     resolution: {integrity: sha512-Xk+SJas70uMAUIApg+m3lZDShxI3LBFHq7mFGbBKoRXc2PVPDyAKmzN64Bbzt4CZdP/CItTiJxWtn4TA0v53Ng==}
 
-  motion-utils@12.39.0:
-    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
-
   motion-utils@13.0.0:
     resolution: {integrity: sha512-7DnN7TmbLcYXcG4RVadXIihWlyuM9afoUww8Y5Agg431kGKiuL2/OMyP4mJ5wLz+pvN3t5ySClLOaVXJ+wekRQ==}
-
-  motion@12.43.0:
-    resolution: {integrity: sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   motion@13.0.0:
     resolution: {integrity: sha512-RYZjEpgHUCKjBNqjmUQzW93VJWLvEZGTPdKRFSqOdOl07IIMvz+WrsZmD1XXAkoFLruW/8bO1L7UF+ViQTxtLg==}
@@ -21695,16 +21661,6 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
-  framer-motion@12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8):
-    dependencies:
-      motion-dom: 12.43.0
-      motion-utils: 12.39.0
-      tslib: 2.8.1
-    optionalDependencies:
-      '@emotion/is-prop-valid': 1.4.0
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-
   framer-motion@13.0.0(react-dom@19.2.8)(react@19.2.8):
     dependencies:
       motion-dom: 13.0.0
@@ -23122,26 +23078,11 @@ snapshots:
       - socks
     optional: true
 
-  motion-dom@12.43.0:
-    dependencies:
-      motion-utils: 12.39.0
-
   motion-dom@13.0.0:
     dependencies:
       motion-utils: 13.0.0
 
-  motion-utils@12.39.0: {}
-
   motion-utils@13.0.0: {}
-
-  motion@12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8):
-    dependencies:
-      framer-motion: 12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8)
-      tslib: 2.8.1
-    optionalDependencies:
-      '@emotion/is-prop-valid': 1.4.0
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
 
   motion@13.0.0(react-dom@19.2.8)(react@19.2.8):
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Upgrade Motion to v13 while preserving the DOM prop filtering that v13 no longer performs implicitly. The divergence indicator now uses a Styled Components transient prop so its internal path cannot leak onto the rendered element.

### What to review

Review the Motion lockfile deduplication and the `$path` compatibility change in the `sanity` package.

### Testing

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm vitest run --project=sanity packages/sanity/src/core/divergence/components/DivergenceIndicator.test.tsx`
- `pnpm check:format`
- `pnpm check:oxlint`
- `pnpm test` (5,489 passed; 2 expected failures; 103 skipped)
- `pnpm test:exports`
- Required CI passes, including unit, browser, E2E, dependency, export, lint, and build checks

### Notes for release

N/A – Internal dependency maintenance.

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe741c5c-ab1c-4604-8d14-d1c94e33d52c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe741c5c-ab1c-4604-8d14-d1c94e33d52c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

