### PR TITLE
fix(presentation): surface connection error when preview iframe never finishes loading

### DIFF
--- a/packages/sanity/src/presentation/constants.ts
+++ b/packages/sanity/src/presentation/constants.ts
@@ -10,6 +10,10 @@ export const EDIT_INTENT_MODE = 'presentation'
 // How long we wait until an iframe is loaded until we consider it to be slow and possibly failed
 export const MAX_TIME_TO_OVERLAYS_CONNECTION = 3_000 // ms
 
+// How long we wait for the iframe `load` event before surfacing the connection error UI.
+// Generous because dev servers can spend a long time compiling the preview on first load.
+export const MAX_TIME_TO_IFRAME_LOAD = 15_000 // ms
+
 // The API version to use when using `@sanity/client`
 export const API_VERSION = apiVersion
 

--- a/packages/sanity/src/presentation/constants.ts
+++ b/packages/sanity/src/presentation/constants.ts
@@ -7,7 +7,8 @@ export const DEFAULT_TOOL_TITLE = 'Presentation'
 
 export const EDIT_INTENT_MODE = 'presentation'
 
-// How long we wait until an iframe is loaded until we consider it to be slow and possibly failed
+// How long we wait for the Visual Editing overlays comlink connection, after the iframe has
+// loaded, before we consider it to be slow and possibly failed
 export const MAX_TIME_TO_OVERLAYS_CONNECTION = 3_000 // ms
 
 // How long we wait for the iframe `load` event before surfacing the connection error UI.

--- a/packages/sanity/src/presentation/preview/Preview.tsx
+++ b/packages/sanity/src/presentation/preview/Preview.tsx
@@ -34,7 +34,7 @@ import {useEffectEvent} from 'use-effect-event'
 import {Button} from '../../ui-components/button/Button'
 import {TooltipDelayGroupProvider} from '../../ui-components/tooltipDelayGroupProvider/TooltipDelayGroupProvider'
 import {ErrorCard} from '../components/ErrorCard'
-import {MAX_TIME_TO_OVERLAYS_CONNECTION} from '../constants'
+import {MAX_TIME_TO_IFRAME_LOAD, MAX_TIME_TO_OVERLAYS_CONNECTION} from '../constants'
 import {presentationLocaleNamespace} from '../i18n'
 import {type PresentationMachineRef} from '../machines/presentation-machine'
 import {type PreviewUrlRef} from '../machines/preview-url'
@@ -197,11 +197,37 @@ export const Preview = memo(function PreviewComponent(
   const [somethingIsWrong, setSomethingIsWrong] = useState(false)
   const iframeIsBusy = isLoading || isRefreshing || overlaysConnection === 'connecting'
 
+  /**
+   * If the iframe never fires its `load` event — for example when the preview is stuck in a
+   * reload loop, like Next.js dev servers before 16.3.0 get in Firefox when embedded cross-origin
+   * (vercel/next.js#94128) — the presentation machine stays in `loading` forever. Surface the
+   * connection error UI after a deadline instead of spinning indefinitely.
+   */
+  const [loadTimedOut, setLoadTimedOut] = useState(false)
+  useEffect(() => {
+    if (!isLoading && !isRefreshing) {
+      // oxlint-disable-next-line react/react-compiler
+      setLoadTimedOut(false)
+      return undefined
+    }
+    if (loadTimedOut) {
+      return undefined
+    }
+    const timeout = setTimeout(() => {
+      setLoadTimedOut(true)
+      console.error(
+        `The preview iframe hasn't finished loading after ${MAX_TIME_TO_IFRAME_LOAD}ms. If the preview keeps reloading itself, note that Next.js dev servers older than 16.3.0 enter an infinite reload loop in Firefox when embedded cross-origin (https://github.com/vercel/next.js/pull/94128) — upgrade Next.js, or set 'experimental.reactDebugChannel: false' in next.config as a workaround.`,
+      )
+    }, MAX_TIME_TO_IFRAME_LOAD)
+    return () => clearTimeout(timeout)
+  }, [isLoading, isRefreshing, loadTimedOut])
+
   const handleRetry = useCallback(() => {
     if (!ref.current) {
       return
     }
 
+    setLoadTimedOut(false)
     ref.current.src = previewUrl.toString()
 
     presentationRef.send({type: 'iframe reload'})
@@ -503,6 +529,7 @@ export const Preview = memo(function PreviewComponent(
                   </Flex>
                 </MotionFlex>
               ) : (isLoading || (overlaysConnection === 'connecting' && !isRefreshing)) &&
+                !loadTimedOut &&
                 !continueAnyway ? (
                 <MotionFlex
                   initial="initial"
@@ -530,7 +557,7 @@ export const Preview = memo(function PreviewComponent(
                     </Text>
                   </Flex>
                 </MotionFlex>
-              ) : somethingIsWrong && !continueAnyway ? (
+              ) : (somethingIsWrong || loadTimedOut) && !continueAnyway ? (
                 <MotionFlex
                   initial="initial"
                   animate="animate"
@@ -542,6 +569,9 @@ export const Preview = memo(function PreviewComponent(
                     background: 'var(--card-bg-color)',
                     inset: '0',
                     position: 'absolute',
+                    // Stay above the click-prevention overlay so "Retry" stays clickable while
+                    // the iframe is still considered busy (e.g. a load that never finishes)
+                    zIndex: 1,
                   }}
                 >
                   <ErrorCard

--- a/packages/sanity/src/presentation/preview/Preview.tsx
+++ b/packages/sanity/src/presentation/preview/Preview.tsx
@@ -197,11 +197,6 @@ export const Preview = memo(function PreviewComponent(
   const [somethingIsWrong, setSomethingIsWrong] = useState(false)
   const iframeIsBusy = isLoading || isRefreshing || overlaysConnection === 'connecting'
 
-  const [continueAnyway, setContinueAnyway] = useState(false)
-  const handleContinueAnyway = useCallback(() => {
-    setContinueAnyway(true)
-  }, [])
-
   /**
    * If the iframe never fires its `load` event — for example when the preview is stuck in a
    * reload loop, like Next.js dev servers before 16.3.0 get in Firefox when embedded cross-origin
@@ -209,6 +204,18 @@ export const Preview = memo(function PreviewComponent(
    * connection error UI after a deadline instead of spinning indefinitely.
    */
   const [loadTimedOut, setLoadTimedOut] = useState(false)
+
+  const [continueAnyway, setContinueAnyway] = useState(false)
+  /**
+   * Whether the current `continueAnyway` dismissal was for a load timeout, as opposed to an
+   * overlays connection error. The two are cleared at different times.
+   */
+  const dismissedLoadTimeoutRef = useRef(false)
+  const handleContinueAnyway = useCallback(() => {
+    dismissedLoadTimeoutRef.current = loadTimedOut
+    setContinueAnyway(true)
+  }, [loadTimedOut])
+
   useEffect(() => {
     /**
      * Only `loading` waits on the iframe `load` event. `refreshing` waits for a
@@ -219,11 +226,13 @@ export const Preview = memo(function PreviewComponent(
       // oxlint-disable-next-line react/react-compiler
       setLoadTimedOut(false)
       /**
-       * `continueAnyway` is otherwise only cleared once the overlays reconnect, which never
-       * happens when the user dismissed a load timeout. Leaving it set would suppress the
-       * loading and error UI for the rest of the session.
+       * A load-timeout dismissal has to be cleared here, since `continueAnyway` is otherwise only
+       * reset once the overlays reconnect — which never happens in this scenario, leaving the
+       * loading and error UI suppressed for the rest of the session. Only clear our own dismissal:
+       * an overlays-error dismissal must survive reloads until the overlays reconnect.
        */
-      setContinueAnyway(false)
+      setContinueAnyway((prev) => (dismissedLoadTimeoutRef.current ? false : prev))
+      dismissedLoadTimeoutRef.current = false
       return undefined
     }
     if (loadTimedOut) {

--- a/packages/sanity/src/presentation/preview/Preview.tsx
+++ b/packages/sanity/src/presentation/preview/Preview.tsx
@@ -216,7 +216,7 @@ export const Preview = memo(function PreviewComponent(
     const timeout = setTimeout(() => {
       setLoadTimedOut(true)
       console.error(
-        `The preview iframe hasn't finished loading after ${MAX_TIME_TO_IFRAME_LOAD}ms. If the preview keeps reloading itself, note that Next.js dev servers older than 16.3.0 enter an infinite reload loop in Firefox when embedded cross-origin (https://github.com/vercel/next.js/pull/94128) — upgrade Next.js, or set 'experimental.reactDebugChannel: false' in next.config as a workaround.`,
+        `The preview iframe hasn't finished loading after ${MAX_TIME_TO_IFRAME_LOAD}ms. If the preview keeps reloading itself, note that Next.js dev servers older than 16.3.0 enter an infinite reload loop in Firefox when embedded cross-origin (https://github.com/vercel/next.js/pull/94128) — upgrade Next.js, or add \`experimental: {reactDebugChannel: false}\` to your Next.js config as a workaround.`,
       )
     }, MAX_TIME_TO_IFRAME_LOAD)
     return () => clearTimeout(timeout)
@@ -557,7 +557,8 @@ export const Preview = memo(function PreviewComponent(
                     </Text>
                   </Flex>
                 </MotionFlex>
-              ) : (somethingIsWrong || loadTimedOut) && !continueAnyway ? (
+              ) : (somethingIsWrong || (loadTimedOut && (isLoading || isRefreshing))) &&
+                !continueAnyway ? (
                 <MotionFlex
                   initial="initial"
                   animate="animate"

--- a/packages/sanity/src/presentation/preview/Preview.tsx
+++ b/packages/sanity/src/presentation/preview/Preview.tsx
@@ -197,6 +197,11 @@ export const Preview = memo(function PreviewComponent(
   const [somethingIsWrong, setSomethingIsWrong] = useState(false)
   const iframeIsBusy = isLoading || isRefreshing || overlaysConnection === 'connecting'
 
+  const [continueAnyway, setContinueAnyway] = useState(false)
+  const handleContinueAnyway = useCallback(() => {
+    setContinueAnyway(true)
+  }, [])
+
   /**
    * If the iframe never fires its `load` event — for example when the preview is stuck in a
    * reload loop, like Next.js dev servers before 16.3.0 get in Firefox when embedded cross-origin
@@ -205,9 +210,20 @@ export const Preview = memo(function PreviewComponent(
    */
   const [loadTimedOut, setLoadTimedOut] = useState(false)
   useEffect(() => {
-    if (!isLoading && !isRefreshing) {
+    /**
+     * Only `loading` waits on the iframe `load` event. `refreshing` waits for a
+     * `visual-editing/refreshed` ack from an already loaded preview, so it must not arm this
+     * deadline — a slow mutation or manual refresh is not a failed load.
+     */
+    if (!isLoading) {
       // oxlint-disable-next-line react/react-compiler
       setLoadTimedOut(false)
+      /**
+       * `continueAnyway` is otherwise only cleared once the overlays reconnect, which never
+       * happens when the user dismissed a load timeout. Leaving it set would suppress the
+       * loading and error UI for the rest of the session.
+       */
+      setContinueAnyway(false)
       return undefined
     }
     if (loadTimedOut) {
@@ -220,7 +236,7 @@ export const Preview = memo(function PreviewComponent(
       )
     }, MAX_TIME_TO_IFRAME_LOAD)
     return () => clearTimeout(timeout)
-  }, [isLoading, isRefreshing, loadTimedOut])
+  }, [isLoading, loadTimedOut])
 
   const handleRetry = useCallback(() => {
     if (!ref.current) {
@@ -233,10 +249,6 @@ export const Preview = memo(function PreviewComponent(
     presentationRef.send({type: 'iframe reload'})
   }, [presentationRef, previewUrl])
 
-  const [continueAnyway, setContinueAnyway] = useState(false)
-  const handleContinueAnyway = useCallback(() => {
-    setContinueAnyway(true)
-  }, [])
   const [showOverlaysConnectionStatus, setShowOverlaysConnectionState] = useState(false)
   useEffect(() => {
     if (isLoading || isRefreshing) {
@@ -557,8 +569,7 @@ export const Preview = memo(function PreviewComponent(
                     </Text>
                   </Flex>
                 </MotionFlex>
-              ) : (somethingIsWrong || (loadTimedOut && (isLoading || isRefreshing))) &&
-                !continueAnyway ? (
+              ) : (somethingIsWrong || (loadTimedOut && isLoading)) && !continueAnyway ? (
                 <MotionFlex
                   initial="initial"
                   animate="animate"


### PR DESCRIPTION
### Description

> Written by an AI agent on behalf of @bjoerge, who has reviewed it.

If the preview iframe never fires its `load` event, the Presentation tool spins forever: every timeout/error state in the preview pane is gated on the load having completed, so the user gets no retry, no error card, and no console output.

One known way to end up there: Next.js 16.2.x dev servers embedded cross-origin in Firefox enter an infinite reload loop (a Next bug, fixed in 16.3.0 via [vercel/next.js#94128](https://github.com/vercel/next.js/pull/94128), not backported to 16.2.x), so the iframe never finishes loading and the preview pane stays on the loading spinner indefinitely.

This PR does *not* fix that bug: upgrading Next (or setting `experimental.reactDebugChannel: false` on 16.2.x) does. This PR rather adds a missing escape hatch for any preview that never finishes loading: after 15 seconds the studio shows the existing "Could not connect to the preview" error card (Retry / Continue anyway) and logs a console error naming the known Firefox/Next cause and its workarounds. The deadline is generous because dev servers can compile for a while on first load, and a false positive self-heals. The error state resets when the load completes.

### What to review

- The `loadTimedOut` effect and render-branch changes in `packages/sanity/src/presentation/preview/Preview.tsx`.
- Is the 15 seconds timeout sensible?
- The error card gets `zIndex: 1` so Retry stays clickable above the click-prevention overlay, which is still active while the machine is in `loading`.

### Testing

No new automated test: this needs an iframe whose `load` never fires inside the studio shell, which jsdom can't simulate meaningfully. Verified against a live repro (Next 16.2.12 dev previewed cross-origin in Firefox): before, the iframe reloads endlessly and the spinner never goes away; with this change the error card appears after 15s.

### Notes for release

If a Presentation preview never finishes loading, the studio now shows a connection error with a retry option after 15 seconds instead of an endless loading spinner. The most common cause is a Next.js 16.2.x dev server previewed in Firefox, which enters an infinite reload loop. If you experience this issue, please upgrade to Next.js 16.3.0, or set `experimental: {reactDebugChannel: false}` in `next.config`.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive preview error-handling timeout with no auth or data-path changes; false positives self-heal when the iframe eventually loads.
> 
> **Overview**
> Stops the Presentation preview from spinning forever when the iframe never fires `load` (e.g. Next.js 16.2.x infinite reload loops in Firefox).
> 
> After **15s** (`MAX_TIME_TO_IFRAME_LOAD`), the existing connection error card (Retry / Continue anyway) is shown and a console error names the known Next/Firefox cause. The timeout only arms during `loading`, not refresh, and load-timeout dismissals are cleared separately from overlays-connection dismissals so the UI can recover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3051d8dbdf70455982815ef56c11710fb221f09e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->