### PR TITLE
test(studio): cover unclaimed project states

### DIFF
--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
@@ -5,6 +5,7 @@ import {userEvent} from '@testing-library/user-event'
 import {type ReactNode} from 'react'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
+import {writeUnclaimedProjectSnoozedAt} from '../../../store/authStore/unclaimedProjectStorage'
 import {
   formatCountdown,
   UnclaimedProjectCountdown,
@@ -15,6 +16,7 @@ const {
   mockClearUnclaimedProjectRecord,
   mockEnvironment,
   mockLogout,
+  mockUseConditionalToast,
   mockUseUnclaimedProject,
   mockUseUnclaimedProjectCopy,
   mockUseWorkspace,
@@ -22,6 +24,7 @@ const {
   mockClearUnclaimedProjectRecord: vi.fn(),
   mockEnvironment: {isDev: true},
   mockLogout: vi.fn(),
+  mockUseConditionalToast: vi.fn(),
   mockUseUnclaimedProject: vi.fn(),
   mockUseUnclaimedProjectCopy: vi.fn(),
   mockUseWorkspace: vi.fn(),
@@ -31,7 +34,9 @@ vi.mock('../../../store/authStore/unclaimedProjectStorage', async (importOrigina
   ...(await importOriginal()),
   clearUnclaimedProjectRecord: mockClearUnclaimedProjectRecord,
 }))
-vi.mock('../../../hooks/useConditionalToast', () => ({useConditionalToast: vi.fn()}))
+vi.mock('../../../hooks/useConditionalToast', () => ({
+  useConditionalToast: mockUseConditionalToast,
+}))
 vi.mock('../../../hooks/useDateTimeFormat', () => ({
   useDateTimeFormat: () => ({format: () => ''}),
 }))
@@ -76,7 +81,38 @@ const wrapper = ({children}: {children: ReactNode}) => (
   <ThemeProvider theme={theme}>{children}</ThemeProvider>
 )
 
+function renderNudge(
+  state:
+    | {status: 'claimed'; email?: string}
+    | {status: 'expired'}
+    | {
+        status: 'unclaimed'
+        claimUrl: string | undefined
+        expiresAt: Date
+        claimLinkSpent?: boolean
+      },
+  copy: typeof COPY | null = COPY,
+) {
+  mockUseWorkspace.mockReturnValue({
+    auth: {logout: mockLogout},
+    currentUser: {provider: 'sanity-token'},
+    projectId: PROJECT_ID,
+  })
+  mockUseUnclaimedProject.mockReturnValue(state)
+  mockUseUnclaimedProjectCopy.mockReturnValue(copy ?? undefined)
+
+  return render(<UnclaimedProjectNudge />, {wrapper})
+}
+
+function latestToast(): Record<string, unknown> {
+  return mockUseConditionalToast.mock.calls.at(-1)?.[0] as Record<string, unknown>
+}
+
 describe('UnclaimedProjectNudge', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
   afterEach(() => {
     mockEnvironment.isDev = true
     vi.clearAllMocks()
@@ -112,19 +148,175 @@ describe('UnclaimedProjectNudge', () => {
     expect(mockUseUnclaimedProject).not.toHaveBeenCalled()
   })
 
-  it('clears claim provenance before leaving the post-claim robot session', async () => {
+  it('renders nothing while the project lifecycle is unresolved', () => {
     mockUseWorkspace.mockReturnValue({
       auth: {logout: mockLogout},
       currentUser: {provider: 'sanity-token'},
       projectId: PROJECT_ID,
     })
-    mockUseUnclaimedProject.mockReturnValue({
-      status: 'claimed',
-      email: 'claimant@example.com',
-    })
-    mockUseUnclaimedProjectCopy.mockReturnValue(COPY)
+    mockUseUnclaimedProject.mockReturnValue(undefined)
 
     render(<UnclaimedProjectNudge />, {wrapper})
+
+    expect(screen.queryByTestId('unclaimed-project-banner')).not.toBeInTheDocument()
+    expect(mockUseUnclaimedProjectCopy).not.toHaveBeenCalled()
+  })
+
+  it('renders the normal claim banner and warning toast with a safe claim action', () => {
+    const claimUrl = 'https://www.sanity.io/manage/claim/claim-token'
+    renderNudge({
+      status: 'unclaimed',
+      claimUrl,
+      expiresAt: new Date(Date.now() + 24 * 3_600_000),
+      claimLinkSpent: false,
+    })
+
+    const banner = screen.getByTestId('unclaimed-project-banner')
+    expect(banner).toHaveTextContent('Claim this project before .')
+    expect(banner).toHaveAttribute('data-tone', 'caution')
+    const claimLink = screen.getByRole('link', {name: 'Claim project'})
+    expect(claimLink).toHaveAttribute('href', claimUrl)
+    expect(claimLink).toHaveAttribute('target', '_blank')
+    expect(claimLink).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(latestToast()).toMatchObject({enabled: true, status: 'warning'})
+  })
+
+  it('renders critical copy and an error toast inside the urgency threshold', () => {
+    renderNudge({
+      status: 'unclaimed',
+      claimUrl: 'https://www.sanity.io/manage/claim/claim-token',
+      expiresAt: new Date(Date.now() + 60_000),
+      claimLinkSpent: false,
+    })
+
+    const banner = screen.getByTestId('unclaimed-project-banner')
+    expect(banner).toHaveTextContent('Claim this project now.')
+    expect(banner).toHaveAttribute('data-tone', 'critical')
+    expect(latestToast()).toMatchObject({enabled: true, status: 'error'})
+  })
+
+  it('starts claim polling when the Studio claim action is opened', async () => {
+    renderNudge({
+      status: 'unclaimed',
+      claimUrl: 'https://www.sanity.io/manage/claim/claim-token',
+      expiresAt: new Date(Date.now() + 24 * 3_600_000),
+      claimLinkSpent: false,
+    })
+
+    await userEvent.click(screen.getByRole('link', {name: 'Claim project'}))
+
+    expect(mockUseUnclaimedProject).toHaveBeenLastCalledWith({claimAttemptedAt: expect.any(Number)})
+  })
+
+  it('renders recovery copy instead of a claim action when no claim URL was received', () => {
+    renderNudge({
+      status: 'unclaimed',
+      claimUrl: undefined,
+      expiresAt: new Date(Date.now() + 24 * 3_600_000),
+      claimLinkSpent: false,
+    })
+
+    expect(screen.getByTestId('unclaimed-project-banner')).toHaveTextContent(
+      'Open the original claim link.',
+    )
+    expect(screen.queryByRole('link', {name: 'Claim project'})).not.toBeInTheDocument()
+
+    render(<>{latestToast().description as ReactNode}</>, {wrapper})
+    expect(screen.getAllByText('Open the original claim link.')).toHaveLength(2)
+    expect(screen.queryByRole('link', {name: 'Claim project'})).not.toBeInTheDocument()
+  })
+
+  it('retires a spent claim action without mislabeling the working project as expired', () => {
+    renderNudge({
+      status: 'unclaimed',
+      claimUrl: undefined,
+      expiresAt: new Date(Date.now() + 24 * 3_600_000),
+      claimLinkSpent: true,
+    })
+
+    expect(screen.getByTestId('unclaimed-project-banner')).not.toHaveTextContent(
+      'Open the original claim link.',
+    )
+    expect(screen.queryByRole('link', {name: 'Claim project'})).not.toBeInTheDocument()
+
+    render(<>{latestToast().description as ReactNode}</>, {wrapper})
+    expect(screen.getByText('Keep everything you built.')).toBeInTheDocument()
+    expect(screen.queryByRole('link', {name: 'Claim project'})).not.toBeInTheDocument()
+  })
+
+  it('snoozes only the toast while keeping the persistent banner', async () => {
+    renderNudge({
+      status: 'unclaimed',
+      claimUrl: 'https://www.sanity.io/manage/claim/claim-token',
+      expiresAt: new Date(Date.now() + 24 * 3_600_000),
+      claimLinkSpent: false,
+    })
+    render(<>{latestToast().description as ReactNode}</>, {wrapper})
+
+    await userEvent.click(screen.getByRole('button', {name: 'Remind me later'}))
+
+    expect(latestToast()).toMatchObject({enabled: false})
+    expect(screen.getByTestId('unclaimed-project-banner')).toBeInTheDocument()
+  })
+
+  it('shows the toast again after the configured snooze interval', () => {
+    writeUnclaimedProjectSnoozedAt(
+      PROJECT_ID,
+      new Date(Date.now() - (COPY.snoozeMinutes + 1) * 60_000).toISOString(),
+    )
+
+    renderNudge({
+      status: 'unclaimed',
+      claimUrl: 'https://www.sanity.io/manage/claim/claim-token',
+      expiresAt: new Date(Date.now() + 24 * 3_600_000),
+      claimLinkSpent: false,
+    })
+
+    expect(latestToast()).toMatchObject({enabled: true})
+  })
+
+  it('renders the claimant identity when the project has been claimed', () => {
+    renderNudge({status: 'claimed', email: 'claimant@example.com'})
+
+    const banner = screen.getByTestId('unclaimed-project-banner')
+    expect(banner).toHaveTextContent('This project is yours.')
+    expect(banner).toHaveAttribute('data-tone', 'positive')
+    expect(screen.getAllByText('claimant@example.com')).toHaveLength(2)
+    expect(latestToast()).toMatchObject({enabled: false})
+  })
+
+  it('renders a generic claimed identity when the claimant cannot be resolved', () => {
+    renderNudge({status: 'claimed'})
+
+    expect(screen.getByTestId('unclaimed-project-banner')).toHaveTextContent(
+      'Log in as the account tied to this project.',
+    )
+  })
+
+  it('renders no stale banner for an expired project', () => {
+    renderNudge({status: 'expired'})
+
+    expect(screen.queryByTestId('unclaimed-project-banner')).not.toBeInTheDocument()
+    expect(latestToast()).toMatchObject({enabled: false})
+  })
+
+  it('renders no partial UI while managed copy is unavailable', () => {
+    renderNudge(
+      {
+        status: 'unclaimed',
+        claimUrl: 'https://www.sanity.io/manage/claim/claim-token',
+        expiresAt: new Date(Date.now() + 24 * 3_600_000),
+        claimLinkSpent: false,
+      },
+      null,
+    )
+
+    expect(screen.queryByTestId('unclaimed-project-banner')).not.toBeInTheDocument()
+    expect(latestToast()).toMatchObject({enabled: false})
+  })
+
+  it('clears claim provenance before leaving the post-claim robot session', async () => {
+    renderNudge({status: 'claimed', email: 'claimant@example.com'})
     const [signInButton] = screen.getAllByRole('button', {name: 'Log in'})
     await userEvent.click(signInButton)
 

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
@@ -179,6 +179,25 @@ describe('useUnclaimedProject', () => {
     })
   })
 
+  it('keeps the generic claimed state when claimant lookup fails', async () => {
+    mockRequest.mockImplementation(({uri}: {uri: string}) => {
+      if (uri === `/projects/${PROJECT_ID}`) {
+        return Promise.resolve({
+          createdAt: CREATED_AT,
+          organizationId: 'oReal',
+          members: [{id: 'claimant', isRobot: false}],
+        })
+      }
+      return Promise.reject(new Error('user lookup unavailable'))
+    })
+    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2))
+    expect(result.current).toEqual({status: 'claimed'})
+  })
+
   it('stays quiet for a regular robot-token session on a claimed project', async () => {
     mockRequest.mockResolvedValue({createdAt: CREATED_AT, organizationId: 'oReal'})
 
@@ -273,16 +292,19 @@ describe('useUnclaimedProject', () => {
     expect(readUnclaimedProjectRecord(PROJECT_ID)).toEqual({claimUrl: CLAIM_URL})
   })
 
-  it('stays quiet and keeps the record on a transient org read failure', async () => {
-    mockRequest.mockRejectedValue({statusCode: 500})
-    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+  it.each([429, 500])(
+    'stays quiet and keeps the record on a transient org read failure (%i)',
+    async (statusCode) => {
+      mockRequest.mockRejectedValue({statusCode})
+      writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
 
-    const {result} = renderHook(() => useUnclaimedProject())
+      const {result} = renderHook(() => useUnclaimedProject())
 
-    await waitFor(() => expect(mockRequest).toHaveBeenCalled())
-    expect(result.current).toBeUndefined()
-    expect(readUnclaimedProjectRecord(PROJECT_ID)).toEqual({claimUrl: CLAIM_URL})
-  })
+      await waitFor(() => expect(mockRequest).toHaveBeenCalled())
+      expect(result.current).toBeUndefined()
+      expect(readUnclaimedProjectRecord(PROJECT_ID)).toEqual({claimUrl: CLAIM_URL})
+    },
+  )
 
   it('never expires on a transient failure, even past the recorded deadline', async () => {
     mockRequest.mockRejectedValue(new TypeError('network error'))
@@ -414,6 +436,76 @@ describe('useUnclaimedProject', () => {
 
     await waitFor(() => expect(mockFetch).toHaveBeenCalled())
     expect(result.current?.status).toBe('unclaimed')
+  })
+
+  it.each([
+    ['the network fails', () => mockFetch.mockRejectedValue(new TypeError('network unavailable'))],
+    ['the service returns 500', () => mockFetch.mockResolvedValue(lookupResponse(500))],
+    [
+      'the response is not valid JSON',
+      () =>
+        mockFetch.mockResolvedValue({
+          ...lookupResponse(200),
+          json: () => Promise.reject(new SyntaxError('invalid JSON')),
+        }),
+    ],
+    [
+      'the success body has an unknown state',
+      () => mockFetch.mockResolvedValue(lookupResponse(200, {state: 'future-state'})),
+    ],
+    [
+      'claimable has an invalid expiry',
+      () =>
+        mockFetch.mockResolvedValue(
+          lookupResponse(200, {state: 'claimable', expiresAt: 'not-a-date'}),
+        ),
+    ],
+  ])('keeps the countdown and claim link when %s', async (_, arrangeLookup) => {
+    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+    arrangeLookup()
+
+    const {result} = renderHook(() => useUnclaimedProject())
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled())
+    expect(result.current).toMatchObject({
+      status: 'unclaimed',
+      claimUrl: CLAIM_URL,
+      claimLinkSpent: false,
+    })
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toMatchObject({claimUrl: CLAIM_URL})
+  })
+
+  it('requires a confirmed lookup 404 before retiring an unexpired claim link', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-25T00:00:00.000Z'))
+    try {
+      writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
+      mockFetch.mockResolvedValue(lookupResponse(404))
+
+      const {result} = renderHook(() => useUnclaimedProject())
+      await act(() => vi.advanceTimersByTimeAsync(0))
+
+      expect(mockFetch).toHaveBeenCalledOnce()
+      expect(result.current).toMatchObject({
+        status: 'unclaimed',
+        claimUrl: CLAIM_URL,
+        claimLinkSpent: false,
+      })
+
+      await act(() => vi.advanceTimersByTimeAsync(30 * 60_000))
+      await act(() => window.dispatchEvent(new Event('focus')))
+      await act(() => vi.advanceTimersByTimeAsync(0))
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(result.current).toMatchObject({
+        status: 'unclaimed',
+        claimUrl: undefined,
+        claimLinkSpent: true,
+      })
+      expect(readUnclaimedProjectRecord(PROJECT_ID)).toBeUndefined()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('retires the claim link when the lookup says expired, but never the session', async () => {


### PR DESCRIPTION
### Description

Adds regression tests that cover and codify observed unclaimed-project lifecycle and affordance behavior.

[AIGRO-5380](https://linear.app/sanity/issue/AIGRO-5380/mint-and-claim-failure-state-affordance-audit)

### What to review

- Banner and toast states for normal, critical, missing, spent, snoozed, claimed, and expired projects.
- State preservation for indeterminate API responses and first-404 handling.

### Testing

- `pnpm build`
- `pnpm test -- --project=sanity`
- `pnpm check:format`
- `pnpm check:oxlint`
- `pnpm depcheck`
- `pnpm test:exports`

### Notes for release

N/A: Test coverage only.

---
