### PR TITLE
feat(access-ui): add renderAction slot and note in submit callback

### DIFF
--- a/packages/@sanity/access-ui/src/RequestAccessForm.tsx
+++ b/packages/@sanity/access-ui/src/RequestAccessForm.tsx
@@ -7,7 +7,6 @@ import {
   Suspense,
   use,
   useId,
-  useMemo,
   useState,
   useTransition,
 } from 'react'
@@ -43,9 +42,15 @@ export interface RequestAccessFormProps {
    */
   onSignOut?: () => void
   /** Called after a request is successfully submitted, e.g. for analytics. */
-  onRequestSubmitted?: () => void
+  onRequestSubmitted?: (details: {note?: string}) => void
   /** Optional slot rendered above the title, e.g. a resource preview. */
   preview?: ReactNode
+  /**
+   * Renders an optional action area at the bottom of the card's content, e.g.
+   * a navigation CTA. Called with the current view so the action can differ
+   * per state (or be omitted for some); return null to render nothing.
+   */
+  renderAction?: (context: {view: RequestAccessView}) => ReactNode
   /** Label overrides for hosts with their own i18n stack. */
   labels?: Partial<RequestAccessLabels>
 }
@@ -84,6 +89,13 @@ export function RequestAccessForm(props: RequestAccessFormProps) {
     </Card>
   )
 }
+
+/**
+ * The view the request-access card is currently showing.
+ *
+ * @public
+ */
+export type RequestAccessView = 'form' | 'sent' | 'pending' | 'blocked' | 'sso-enforced'
 
 type ViewState =
   | {view: 'form'; expired: boolean}
@@ -151,10 +163,11 @@ function RequestAccessFormContent(
     onSignOut,
     onRequestSubmitted,
     preview,
+    renderAction,
     requestsPromise,
   } = props
 
-  const labels = useMemo(() => ({...defaultLabels, ...props.labels}), [props.labels])
+  const labels = {...defaultLabels, ...props.labels}
   const fetchedRequests = use(requestsPromise)
   const titleId = useId()
 
@@ -190,15 +203,16 @@ function RequestAccessFormContent(
     event.preventDefault()
     if (isSubmitting) return
     startSubmit(async () => {
+      const trimmedNote = note.trim() || undefined
       const result = await submitAccessRequest({
         client,
         resourceType,
         resourceId,
-        note: note.trim() || undefined,
+        note: trimmedNote,
         requestUrl: getRequestUrl(),
       })
       setSubmitResult(result)
-      if (result.type === 'submitted') onRequestSubmitted?.()
+      if (result.type === 'submitted') onRequestSubmitted?.({note: trimmedNote})
     })
   }
 
@@ -289,6 +303,8 @@ function RequestAccessFormContent(
             />
           </Stack>
         ) : null}
+
+        {renderAction?.({view: state.view})}
       </Flex>
 
       {currentUser ? (

--- a/packages/@sanity/access-ui/src/__tests__/RequestAccessForm.test.tsx
+++ b/packages/@sanity/access-ui/src/__tests__/RequestAccessForm.test.tsx
@@ -115,10 +115,11 @@ describe('RequestAccessForm', () => {
     })
     window.location.hash = '#token=secret'
     await renderForm({client, onRequestSubmitted})
+    await userEvent.type(screen.getByRole('textbox', {name: 'Message'}), 'please')
     await submitRequest()
 
     expect(await screen.findByText('Access request sent')).toBeInTheDocument()
-    expect(onRequestSubmitted).toHaveBeenCalledTimes(1)
+    expect(onRequestSubmitted).toHaveBeenCalledExactlyOnceWith({note: 'please'})
     // The fragment can carry auth tokens and must not reach the API.
     expect(client.request).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -137,6 +138,22 @@ describe('RequestAccessForm', () => {
 
     expect(await screen.findByRole('alert')).toHaveTextContent(/problem submitting your request/)
     expect(screen.getByRole('form', {name: 'Request access'})).toBeInTheDocument()
+  })
+
+  it('lets renderAction vary the action per view', async () => {
+    const client = createClientStub({
+      submit: () => Promise.resolve(createAccessRequest()),
+    })
+    await renderForm({
+      client,
+      renderAction: ({view}) => (view === 'sent' ? <a href="/orgs">View organizations</a> : null),
+    })
+
+    expect(await screen.findByRole('form', {name: 'Request access'})).toBeInTheDocument()
+    expect(screen.queryByRole('link', {name: 'View organizations'})).not.toBeInTheDocument()
+
+    await submitRequest()
+    expect(await screen.findByRole('link', {name: 'View organizations'})).toBeInTheDocument()
   })
 
   it('renders the sign-out action only when onSignOut is provided', async () => {

--- a/packages/@sanity/access-ui/src/index.ts
+++ b/packages/@sanity/access-ui/src/index.ts
@@ -6,7 +6,11 @@ export {
 export {deriveAccessRequestState} from './deriveAccessRequestState'
 export {type RequestAccessLabels} from './labels'
 export {getProviderTitle} from './providerTitle'
-export {RequestAccessForm, type RequestAccessFormProps} from './RequestAccessForm'
+export {
+  RequestAccessForm,
+  type RequestAccessFormProps,
+  type RequestAccessView,
+} from './RequestAccessForm'
 export {
   type AccessRequest,
   type AccessRequestState,


### PR DESCRIPTION
### Description

Follow-up to #13977 from the Dashboard migration (SAGE-825). Two additions to `RequestAccessForm`, both non-breaking:

- `renderAction?: (context: {view: RequestAccessView}) => ReactNode`: renders an action area at the bottom of the card's content. It is a render prop rather than a static slot because the card owns its state internally, so this is the only way a host can vary the action per view (e.g. "View your organizations" when blocked, nothing while pending). Every view is passed, including `form`; the host returns null where it wants nothing, so there are no hidden gating rules. The context object keeps future additions non-breaking.
- `onRequestSubmitted` now receives `{note}` so hosts can report note usage in analytics (Dashboard tracks `includedMessageCount`).

Also exports the new `RequestAccessView` union.

### What to review

The render prop shape in `RequestAccessForm.tsx`. A static `ReactNode` slot and per-state props (`sentAction`, `blockedAction`, ...) were considered and rejected: the first cannot react to state the host cannot see, the second explodes the prop surface.

### Testing

Updated unit tests: per-view action rendering and the note payload in the callback. 34 total.

### Notes for release

N/A, additive API on a package with no released consumers yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, optional API on a shared UI package with no behavior change unless hosts opt in; callback signature change is backward-compatible for typical no-arg handlers.
> 
> **Overview**
> Extends **`RequestAccessForm`** with host hooks for Dashboard-style flows: a **`renderAction`** render prop that receives the current **`RequestAccessView`** (`form`, `sent`, `pending`, `blocked`, `sso-enforced`) so CTAs can appear only on specific states, and **`onRequestSubmitted`** now receives **`{ note?: string }`** (trimmed message) for analytics.
> 
> **`RequestAccessView`** is exported from the package entry. Label merging drops **`useMemo`** in favor of a plain spread. Tests cover per-view **`renderAction`** and the updated submit callback payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4482160915bc2c0c798b5739f325c470410e6e1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->