### PR TITLE
fix(core): hide lapsed unclaimed project nudge

### DIFF
--- a/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
@@ -1,7 +1,9 @@
 import {ClockIcon} from '@sanity/icons/Clock'
 import {LaunchIcon} from '@sanity/icons/Launch'
 import {Badge, Box, Card, Flex, Stack, Text} from '@sanity/ui'
-import {startTransition, useCallback, useEffect, useState} from 'react'
+import {useCallback, useEffect, useMemo, useState} from 'react'
+import {useObservable} from 'react-rx'
+import {EMPTY, fromEvent, map, merge, of, timer, timestamp} from 'rxjs'
 
 import {Button} from '../../../ui-components/button/Button'
 import {isDev} from '../../environment'
@@ -29,7 +31,8 @@ import {
 /**
  * Persistent banner + snoozable toast nudging the user to claim a minted-but-unclaimed project
  * before it expires, flipping to an identity-aware login banner once it's claimed. Renders
- * nothing for anything not part of mint-and-claim — see {@link useUnclaimedProject}.
+ * nothing after the claim period or for anything not part of mint-and-claim — see
+ * {@link useUnclaimedProject}.
  *
  * @internal
  */
@@ -79,7 +82,8 @@ function UnclaimedProjectNudgeInner({
   const copy = useUnclaimedProjectCopy(true)
 
   const unclaimed = state?.status === 'unclaimed' ? state : undefined
-  const now = useMinuteTick(Boolean(unclaimed))
+  const now = useUnclaimedProjectClock(Boolean(unclaimed), unclaimed?.expiresAt)
+  const claimable = unclaimed && unclaimed.expiresAt.getTime() > now ? unclaimed : undefined
   const timeLeft = useRelativeTime(unclaimed?.expiresAt ?? '')
   const expiresAtFormatter = useDateTimeFormat({dateStyle: 'medium', timeStyle: 'short'})
   const expiresAt = unclaimed ? expiresAtFormatter.format(unclaimed.expiresAt) : ''
@@ -102,11 +106,10 @@ function UnclaimedProjectNudgeInner({
   const isSnoozed = Boolean(
     snoozedAt && snoozeDurationMs && now - new Date(snoozedAt).getTime() < snoozeDurationMs,
   )
-
   const critical = Boolean(
     copy &&
-    unclaimed &&
-    unclaimed.expiresAt.getTime() - now <= copy.criticalThresholdHours * 3_600_000,
+    claimable &&
+    claimable.expiresAt.getTime() - now <= copy.criticalThresholdHours * 3_600_000,
   )
 
   // The claim URL is spent; keep its provenance while the robot token is active so this banner
@@ -121,7 +124,7 @@ function UnclaimedProjectNudgeInner({
   useConditionalToast({
     id: 'unclaimed-project-nudge',
     status: critical ? 'error' : 'warning',
-    enabled: Boolean(copy && unclaimed) && !isSnoozed,
+    enabled: Boolean(copy && claimable) && !isSnoozed,
     title: copy ? (
       <strong>
         {interpolateTemplate(
@@ -132,18 +135,18 @@ function UnclaimedProjectNudgeInner({
     ) : (
       ''
     ),
-    description: unclaimed && copy && (
+    description: claimable && copy && (
       <Stack gap={4} paddingY={2}>
         <Text size={1} weight="regular">
-          {unclaimed.claimUrl || unclaimed.claimLinkSpent
+          {claimable.claimUrl || claimable.claimLinkSpent
             ? copy.toast.description
             : copy.noClaimUrl.text}
         </Text>
         <Flex gap={3}>
-          {unclaimed.claimUrl && (
+          {claimable.claimUrl && (
             <Button
               as="a"
-              href={unclaimed.claimUrl}
+              href={claimable.claimUrl}
               target="_blank"
               rel="noopener noreferrer"
               mode="default"
@@ -212,7 +215,7 @@ function UnclaimedProjectNudgeInner({
     )
   }
 
-  if (!unclaimed) return null
+  if (!claimable) return null
 
   return (
     <Card
@@ -233,11 +236,11 @@ function UnclaimedProjectNudgeInner({
             )}
           </Text>
         </Flex>
-        <UnclaimedProjectCountdown expiresAt={unclaimed.expiresAt} critical={critical} />
-        {unclaimed.claimUrl ? (
+        <UnclaimedProjectCountdown expiresAt={claimable.expiresAt} critical={critical} />
+        {claimable.claimUrl ? (
           <Button
             as="a"
-            href={unclaimed.claimUrl}
+            href={claimable.claimUrl}
             target="_blank"
             rel="noopener noreferrer"
             mode="default"
@@ -247,9 +250,9 @@ function UnclaimedProjectNudgeInner({
             text={copy.banner.claimButtonText}
             onClick={onClaim}
           />
-        ) : unclaimed.claimLinkSpent ? null : (
+        ) : !claimable.claimLinkSpent ? (
           <Text size={1}>{copy.noClaimUrl.text}</Text>
-        )}
+        ) : null}
       </Flex>
     </Card>
   )
@@ -314,16 +317,24 @@ export function formatCountdown(expiresAt: Date, now: number): string {
   return [hours, minutes, seconds].map((value) => String(value).padStart(2, '0')).join(':')
 }
 
-/** Re-evaluates the snooze window and the critical flip once a minute while the nudge shows. */
-function useMinuteTick(enabled: boolean): number {
-  const [now, setNow] = useState(() => Date.now())
-  useEffect(() => {
-    if (!enabled) return undefined
-    // Refresh right away — the interval alone would serve a clock up to a minute stale after a
-    // stretch with the nudge hidden.
-    startTransition(() => setNow(Date.now()))
-    const id = setInterval(() => setNow(Date.now()), 60_000)
-    return () => clearInterval(id)
-  }, [enabled])
-  return now
+/** Keeps all time-based nudge state on one clock, including resume after timer throttling. */
+function useUnclaimedProjectClock(enabled: boolean, expiresAt: Date | undefined): number {
+  const [initialNow] = useState(() => Date.now())
+  const expiresAtTime = expiresAt?.getTime()
+  const clock$ = useMemo(() => {
+    if (!enabled) return EMPTY
+
+    return merge(
+      of(undefined),
+      timer(60_000, 60_000),
+      expiresAtTime === undefined ? EMPTY : timer(new Date(expiresAtTime)),
+      fromEvent(window, 'focus'),
+      fromEvent(document, 'visibilitychange'),
+    ).pipe(
+      timestamp(),
+      map(({timestamp: now}) => now),
+    )
+  }, [enabled, expiresAtTime])
+
+  return useObservable(clock$, initialNow)
 }

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
@@ -1,8 +1,8 @@
 import {ThemeProvider} from '@sanity/ui'
 import {buildTheme} from '@sanity/ui/theme'
-import {act, render, screen} from '@testing-library/react'
+import {act, render, screen, waitFor} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
-import {type ReactNode} from 'react'
+import {type ReactNode, useState} from 'react'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {writeUnclaimedProjectSnoozedAt} from '../../../store/authStore/unclaimedProjectStorage'
@@ -322,6 +322,82 @@ describe('UnclaimedProjectNudge', () => {
 
     expect(mockClearUnclaimedProjectRecord).toHaveBeenCalledExactlyOnceWith(PROJECT_ID)
     expect(mockLogout).toHaveBeenCalledOnce()
+  })
+
+  it('hides the complete nudge after the local project expiry', () => {
+    renderNudge({
+      status: 'unclaimed',
+      claimUrl: 'https://www.sanity.io/manage/claim/claim-token',
+      expiresAt: new Date(Date.now() - 1),
+      claimLinkSpent: false,
+    })
+
+    expect(screen.queryByTestId('unclaimed-project-banner')).not.toBeInTheDocument()
+    expect(latestToast()).toMatchObject({enabled: false})
+  })
+
+  it('hides the complete nudge when the project expiry is corrected to a past time', async () => {
+    const initialExpiry = new Date(Date.now() + 60_000)
+    const correctedExpiry = new Date(Date.now() - 1)
+    let applyCorrectedExpiry: (() => void) | undefined
+
+    mockUseWorkspace.mockReturnValue({
+      auth: {logout: mockLogout},
+      currentUser: {provider: 'sanity-token'},
+      projectId: PROJECT_ID,
+    })
+    mockUseUnclaimedProject.mockImplementation(() => {
+      const [expiresAt, setExpiresAt] = useState(initialExpiry)
+      applyCorrectedExpiry = () => setExpiresAt(correctedExpiry)
+      return {
+        status: 'unclaimed' as const,
+        claimUrl: 'https://www.sanity.io/manage/claim/claim-token',
+        expiresAt,
+        claimLinkSpent: false,
+      }
+    })
+    mockUseUnclaimedProjectCopy.mockReturnValue(COPY)
+
+    render(<UnclaimedProjectNudge />, {wrapper})
+
+    expect(screen.getByRole('link', {name: 'Claim project'})).toBeInTheDocument()
+    expect(latestToast()).toMatchObject({enabled: true})
+
+    await act(async () => {
+      applyCorrectedExpiry?.()
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('unclaimed-project-banner')).not.toBeInTheDocument()
+      expect(latestToast()).toMatchObject({enabled: false})
+    })
+  })
+
+  it('refreshes claimability on focus when the expiry timer was delayed', async () => {
+    vi.useFakeTimers()
+    const initialTime = new Date('2026-08-12T12:00:00.000Z')
+
+    try {
+      vi.setSystemTime(initialTime)
+      renderNudge({
+        status: 'unclaimed',
+        claimUrl: 'https://www.sanity.io/manage/claim/claim-token',
+        expiresAt: new Date(initialTime.getTime() + 60_000),
+        claimLinkSpent: false,
+      })
+
+      expect(screen.getByRole('link', {name: 'Claim project'})).toBeInTheDocument()
+
+      await act(async () => {
+        vi.setSystemTime(new Date(initialTime.getTime() + 61_000))
+        window.dispatchEvent(new Event('focus'))
+      })
+
+      expect(screen.queryByTestId('unclaimed-project-banner')).not.toBeInTheDocument()
+      expect(latestToast()).toMatchObject({enabled: false})
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 


### PR DESCRIPTION
### Description

Hide the complete unclaimed-project nudge once its authoritative provisioning expiry has passed.

The active-state message, countdown, claim action, and reminder toast all disappear together, avoiding stale guidance after the deadline. This intentionally does not add a replacement mint or restart action until that workflow is defined.

Issue: [AIGRO-5383](https://linear.app/sanity/issue/AIGRO-5383/hide-the-unclaimed-project-nudge-after-a-project-lapses)

<!-- GIF placeholder: Daniel will attach a recording of the countdown crossing zero and the complete nudge disappearing here. -->

### What to review

Review the shared `claimable` invariant and observable clock in the unclaimed project nudge. The clock refreshes at the expiry deadline, every minute, and when the document regains focus or changes visibility.

Confirm that active projects keep the existing nudge, while initially lapsed projects, corrected past expiries, and delayed timers hide the complete nudge.

### Testing

- `pnpm vitest run --project=sanity packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx`
- `pnpm --filter sanity test` — 501 files and 4,752 tests passed
- `pnpm build`
- `pnpm check:format`
- `pnpm check:oxlint`
- `git diff --check`

### Walkthrough

<img width="960" height="907" alt="shapiro sanity-new studio-project-lapsed" src="https://github.com/user-attachments/assets/aff508b6-e47e-4b03-9725-13dbbb6fa981" />

### Notes for release

Hide the unclaimed-project nudge after its claim period ends.

---
