### PR TITLE
fix(core): improve unclaimed project nudge accessibility

### DIFF
--- a/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
@@ -149,7 +149,13 @@ function UnclaimedProjectNudgeInner({
               mode="default"
               tone={critical ? 'critical' : 'primary'}
               size="default"
-              iconRight={LaunchIcon}
+              iconRight={
+                <LaunchIcon
+                  aria-hidden="true"
+                  data-testid="unclaimed-project-launch-icon"
+                  focusable="false"
+                />
+              }
               text={copy.toast.claimButtonText}
               onClick={onClaim}
             />
@@ -161,7 +167,7 @@ function UnclaimedProjectNudgeInner({
             paddingY={1}
             text={copy.toast.snoozeButtonText}
             onClick={handleSnooze}
-            style={{fontSize: '0.6875rem', opacity: 0.6}}
+            style={{fontSize: '0.6875rem'}}
           />
         </Flex>
       </Stack>
@@ -243,7 +249,13 @@ function UnclaimedProjectNudgeInner({
             mode="default"
             tone={critical ? 'critical' : 'primary'}
             size="default"
-            iconRight={LaunchIcon}
+            iconRight={
+              <LaunchIcon
+                aria-hidden="true"
+                data-testid="unclaimed-project-launch-icon"
+                focusable="false"
+              />
+            }
             text={copy.banner.claimButtonText}
             onClick={onClaim}
           />

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
@@ -178,6 +178,14 @@ describe('UnclaimedProjectNudge', () => {
     expect(claimLink).toHaveAttribute('href', claimUrl)
     expect(claimLink).toHaveAttribute('target', '_blank')
     expect(claimLink).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(screen.getByTestId('unclaimed-project-launch-icon')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    )
+    expect(screen.getByTestId('unclaimed-project-launch-icon')).toHaveAttribute(
+      'focusable',
+      'false',
+    )
     expect(latestToast()).toMatchObject({enabled: true, status: 'warning'})
   })
 


### PR DESCRIPTION
### Description

Improves accessibility of the unclaimed-project Studio nudge.

The toast's “Remind me later” action now uses the full `@sanity/ui` foreground color instead of applying reduced opacity. Launch icons remain as visual cues but are hidden from assistive technology and removed from the focus model.

Tracks [AIGRO-5385](https://linear.app/sanity/issue/AIGRO-5385/improve-accessibility-of-the-unclaimed-project-studio-nudge).

### What to review

- Confirm the snooze action no longer applies custom opacity.
- Confirm launch icons remain visible while their SVGs are decorative and unfocusable.
- Confirm the change does not override critical or positive button tones owned by `@sanity/ui`.

### Testing

- `pnpm build`
- `pnpm vitest run --project=sanity` — 502 files and 4,752 tests passed
- `pnpm check:format`
- `pnpm check:oxlint`
- `pnpm depcheck`
- `pnpm test:exports`
- Cursor BugBot review

### Notes for release

Improve contrast and assistive technology behavior in the unclaimed-project Studio nudge.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UI-only changes in a dev-only nudge component with no auth, data, or API impact.
> 
> **Overview**
> Improves **contrast and assistive-tech behavior** on the unclaimed-project Studio nudge (banner and toast).
> 
> **Remind me later** no longer uses inline `opacity: 0.6`, so the snooze control relies on `@sanity/ui` foreground styling instead of a dimmed custom style.
> 
> **Claim** actions in the toast and banner now pass `LaunchIcon` as an element with `aria-hidden="true"` and `focusable="false"` (plus a test id), so the external-link graphic stays visible but is treated as decorative and kept out of the focus order. Tests assert those attributes on the launch icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f7ecc88bcf300072753e1bced259559ec9081e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->