### PR TITLE
chore: migrate box in core/perspective to core/variants

### DIFF
--- a/packages/sanity/src/core/perspective/navbar/AgentBundleMenuItem.tsx
+++ b/packages/sanity/src/core/perspective/navbar/AgentBundleMenuItem.tsx
@@ -1,8 +1,9 @@
 import {SparkleIcon} from '@sanity/icons/Sparkle'
-import {Box, Flex, Stack, Text} from '@sanity/ui'
+import {Flex, Stack, Text} from '@sanity/ui'
 // oxlint-disable-next-line no-restricted-imports -- MenuItem with custom children not supported by ui-components
 import {MenuItem} from '@sanity/ui/menu'
 import {type CSSProperties, memo, useCallback} from 'react'
+import {Box} from 'ui5'
 
 import {useTranslation} from '../../i18n/hooks/useTranslation'
 import {type AgentBundle} from '../../store/agent/createAgentBundlesStore'
@@ -37,7 +38,7 @@ export const AgentBundleMenuItem = memo(function AgentBundleMenuItem({
   return (
     <MenuItem onClick={handleClick} padding={1} pressed={active} selected={active}>
       <Flex align="flex-start" gap={1}>
-        <Box flex="none" paddingX={3} paddingY={2}>
+        <Box flexBasis="auto" flexGrow={0} flexShrink={0} paddingX={3} paddingY={2}>
           <Text size={1} style={iconStyle}>
             <SparkleIcon />
           </Text>

--- a/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenuItem.tsx
+++ b/packages/sanity/src/core/perspective/navbar/GlobalPerspectiveMenuItem.tsx
@@ -4,11 +4,12 @@ import {EyeClosedIcon} from '@sanity/icons/EyeClosed'
 import {EyeOpenIcon} from '@sanity/icons/EyeOpen'
 import {LockIcon} from '@sanity/icons/Lock'
 // oxlint-disable-next-line no-restricted-imports -- custom use for Button not supported by ui-components
-import {Box, Button, Flex, Stack, Text} from '@sanity/ui'
+import {Button, Flex, Stack, Text} from '@sanity/ui'
 // oxlint-disable-next-line no-restricted-imports -- custom use for MenuItem not supported by ui-components
 import {MenuItem} from '@sanity/ui/menu'
 import {type MouseEvent, useCallback, useMemo, type RefAttributes} from 'react'
 import {css, styled} from 'styled-components'
+import {Box} from 'ui5'
 
 import {ToneIcon} from '../../../ui-components/toneIcon/ToneIcon'
 import {Tooltip} from '../../../ui-components/tooltip/Tooltip'
@@ -156,7 +157,9 @@ export function GlobalPerspectiveMenuItem(
         <Flex align="flex-start" gap={1}>
           <IconWrapperBox
             $isExcluded={isReleasePerspectiveExcluded}
-            flex="none"
+            flexBasis="auto"
+            flexGrow={0}
+            flexShrink={0}
             data-testid="release-indicator-icon"
             paddingX={3}
             paddingY={2}
@@ -206,7 +209,7 @@ export function GlobalPerspectiveMenuItem(
                 </Text>
               )}
           </Stack>
-          <Box flex="none">
+          <Box flexBasis="auto" flexGrow={0} flexShrink={0}>
             {canReleaseBeExcluded && (
               <Tooltip portal content={t('release.layer.hide')} placement="bottom">
                 <ToggleLayerButton

--- a/packages/sanity/src/core/perspective/navbar/PerspectiveLayerIndicator.tsx
+++ b/packages/sanity/src/core/perspective/navbar/PerspectiveLayerIndicator.tsx
@@ -1,5 +1,5 @@
-import {Box} from '@sanity/ui'
 import {css, styled} from 'styled-components'
+import {Box} from 'ui5'
 
 const INDICATOR_LEFT_OFFSET = 20
 const INDICATOR_WIDTH = 1

--- a/packages/sanity/src/core/perspective/navbar/currentGlobalPerspectiveLabel.tsx
+++ b/packages/sanity/src/core/perspective/navbar/currentGlobalPerspectiveLabel.tsx
@@ -1,9 +1,10 @@
 import {type ReleaseDocument} from '@sanity/client'
 // oxlint-disable-next-line no-restricted-imports -- Bundle Button requires more fine-grained styling than studio button
-import {Box, Button, Text} from '@sanity/ui'
+import {Button, Text} from '@sanity/ui'
 import {useMemo, type RefAttributes} from 'react'
 import {IntentLink} from 'sanity/router'
 import {styled} from 'styled-components'
+import {Box} from 'ui5'
 
 import {useTranslation} from '../../i18n/hooks/useTranslation'
 import {ReleaseTitle} from '../../releases/components/ReleaseTitle'

--- a/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.tsx
+++ b/packages/sanity/src/core/singleDocRelease/components/DeleteScheduledDraftDialog.tsx
@@ -1,8 +1,9 @@
 import {type ReleaseDocument} from '@sanity/client'
 import {type PreviewValue} from '@sanity/types'
-import {Box, Checkbox, Flex, Stack, Text} from '@sanity/ui'
+import {Checkbox, Flex, Stack, Text} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import {type ChangeEvent, type ReactNode, useCallback, useMemo, useState} from 'react'
+import {Box} from 'ui5'
 
 import {Dialog} from '../../../ui-components/dialog/Dialog'
 import {LoadingBlock} from '../../components/loadingBlock/LoadingBlock'

--- a/packages/sanity/src/core/singleDocRelease/components/PublishScheduledDraftDialog.tsx
+++ b/packages/sanity/src/core/singleDocRelease/components/PublishScheduledDraftDialog.tsx
@@ -1,7 +1,8 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {Box, Stack, Text} from '@sanity/ui'
+import {Stack, Text} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import {useCallback, useState} from 'react'
+import {Box} from 'ui5'
 
 import {Dialog} from '../../../ui-components/dialog/Dialog'
 import {LoadingBlock} from '../../components/loadingBlock/LoadingBlock'

--- a/packages/sanity/src/core/store/authStore/createLoginComponent.tsx
+++ b/packages/sanity/src/core/store/authStore/createLoginComponent.tsx
@@ -2,10 +2,11 @@
 import {type AuthProvider, type AuthProviderResponse, type SanityClient} from '@sanity/client'
 import {ArrowLeftIcon} from '@sanity/icons/ArrowLeft'
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
-import {Badge, Box, Card, Flex, Heading, Stack, Text} from '@sanity/ui'
+import {Badge, Card, Flex, Heading, Stack, Text} from '@sanity/ui'
 import {useCallback, useEffect, useState} from 'react'
 import {useObservable} from 'react-rx'
 import {type Observable} from 'rxjs'
+import {Box} from 'ui5'
 
 import {Button, type ButtonProps} from '../../../ui-components/button/Button'
 import {LoadingBlock} from '../../components/loadingBlock/LoadingBlock'

--- a/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantDialog.tsx
@@ -1,8 +1,9 @@
 import {at, set} from '@sanity/mutate'
 import {applyPatches} from '@sanity/mutate/_unstable_apply'
-import {Box, Card, Flex} from '@sanity/ui'
+import {Card, Flex} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import {type FormEvent, useCallback, useState} from 'react'
+import {Box} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {Dialog} from '../../../../ui-components/dialog/Dialog'

--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -4,9 +4,10 @@ import {HelpCircleIcon} from '@sanity/icons/HelpCircle'
 import {TrashIcon} from '@sanity/icons/Trash'
 import {type Path} from '@sanity/mutate'
 import {type PortableTextBlock} from '@sanity/types'
-import {Box, Flex, Inline, Stack, Text, TextArea, TextInput} from '@sanity/ui'
+import {Flex, Inline, Stack, Text, TextArea, TextInput} from '@sanity/ui'
 import {randomKey} from '@sanity/util/content'
 import {type ChangeEvent, useCallback, useId, useMemo, useState} from 'react'
+import {Box} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
@@ -335,7 +336,7 @@ export function VariantForm(props: {
             return (
               <Stack key={row.id} gap={2}>
                 <Flex align="center" gap={2}>
-                  <Box flex={1}>
+                  <Box flexBasis="0%" flexGrow={1}>
                     <ConditionAutocompleteInput
                       autoFocus={index > 0}
                       ariaLabel={t('dialog.create.condition-key.label')}
@@ -348,7 +349,7 @@ export function VariantForm(props: {
                       value={row.key}
                     />
                   </Box>
-                  <Box flex={1}>
+                  <Box flexBasis="0%" flexGrow={1}>
                     <ConditionAutocompleteInput
                       ariaLabel={t('dialog.create.condition-value.label')}
                       customValidity={valueValidation ? t(valueValidation) : undefined}

--- a/packages/sanity/src/core/variants/plugin/components/CurrentVariantLabel.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/CurrentVariantLabel.tsx
@@ -1,8 +1,9 @@
 // oxlint-disable-next-line no-restricted-imports -- Button requires props, only supported by @sanity/ui
-import {Box, Flex, Button, Text} from '@sanity/ui'
+import {Button, Flex, Text} from '@sanity/ui'
 import {type HTMLProps, useMemo, type RefAttributes} from 'react'
 import {IntentLink} from 'sanity/router'
 import {styled} from 'styled-components'
+import {Box} from 'ui5'
 
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {AnimatedTextWidth} from '../../../perspective/navbar/AnimatedTextWidth'

--- a/packages/sanity/src/core/variants/plugin/components/VariantsMenu.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/VariantsMenu.tsx
@@ -1,10 +1,11 @@
 import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
 // oxlint-disable-next-line no-restricted-imports -- Button requires props, only supported by @sanity/ui
-import {Box, Button, Text, TextInput} from '@sanity/ui'
+import {Button, Text, TextInput} from '@sanity/ui'
 import {Menu, MenuDivider} from '@sanity/ui/menu'
 import {useCallback, useMemo, useState} from 'react'
 import {useRouter} from 'sanity/router'
 import {styled} from 'styled-components'
+import {Box} from 'ui5'
 
 import {MenuButton} from '../../../../ui-components/menuButton/MenuButton'
 import {MenuItem} from '../../../../ui-components/menuItem/MenuItem'

--- a/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/VariantDetail.tsx
@@ -2,9 +2,10 @@ import {DocumentsIcon} from '@sanity/icons/Documents'
 import {EditIcon} from '@sanity/icons/Edit'
 import {SortIcon} from '@sanity/icons/Sort'
 import {UserIcon} from '@sanity/icons/User'
-import {Box, Card, Container, Flex, Skeleton, Stack, Text} from '@sanity/ui'
+import {Card, Container, Flex, Skeleton, Stack, Text} from '@sanity/ui'
 import {useMemo} from 'react'
 import {useRouter} from 'sanity/router'
+import {Box} from 'ui5'
 
 import {
   DetailBackButton,
@@ -234,7 +235,7 @@ export function VariantDetail() {
                 </Flex>
               </Flex>
               <Flex align="flex-start" gap={4} wrap="wrap">
-                <Box flex={1} style={{minWidth: 280}}>
+                <Box flexBasis="0%" flexGrow={1} style={{minWidth: 280}}>
                   <DetailIdentity
                     description={description || undefined}
                     descriptionTestId="variant-description-display"

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentBundleChips.tsx
@@ -1,7 +1,8 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {Badge, Box, Flex, Stack, Text} from '@sanity/ui'
+import {Badge, Flex, Stack, Text} from '@sanity/ui'
 import {useMemo} from 'react'
 import {IntentLink} from 'sanity/router'
+import {Box} from 'ui5'
 
 import {Tooltip} from '../../../../../ui-components/tooltip/Tooltip'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentPreview.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentPreview.tsx
@@ -1,7 +1,8 @@
 import {type ReleaseDocument} from '@sanity/client'
-import {Box, Card, Flex, Text} from '@sanity/ui'
+import {Card, Flex, Text} from '@sanity/ui'
 import {useMemo, type RefAttributes} from 'react'
 import {IntentLink} from 'sanity/router'
+import {Box} from 'ui5'
 
 import {type PreviewLayoutKey} from '../../../../components/previews/types'
 import {DocumentPreviewPresence} from '../../../../presence/DocumentPreviewPresence'
@@ -35,7 +36,7 @@ function PrimaryBundleIcon({
   if (!primary) return null
 
   return (
-    <Box flex="none">
+    <Box flexBasis="auto" flexGrow={0} flexShrink={0}>
       <Text size={1}>
         {primary.kind === 'published' ? (
           // oxlint-disable-next-line no-deprecated -- will fix in follow up PR

--- a/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/detail/variantDocumentTable/VariantDocumentTableColumnDefs.tsx
@@ -2,10 +2,11 @@ import {type ReleaseDocument} from '@sanity/client'
 import {CheckmarkCircleIcon} from '@sanity/icons/CheckmarkCircle'
 import {ClockIcon} from '@sanity/icons/Clock'
 import {ErrorOutlineIcon} from '@sanity/icons/ErrorOutline'
-import {Box, Flex, Text} from '@sanity/ui'
+import {Flex, Text} from '@sanity/ui'
 // eslint-disable-next-line @sanity/i18n/no-i18next-import -- figure out how to have the linter be fine with importing types-only
 import {type TFunction} from 'i18next'
 import {memo} from 'react'
+import {Box} from 'ui5'
 
 import {ToneIcon} from '../../../../../ui-components/toneIcon/ToneIcon'
 import {Tooltip} from '../../../../../ui-components/tooltip/Tooltip'
@@ -236,7 +237,7 @@ export const getVariantDocumentTableColumnDefs = (
         paddingRight={2}
         sizing="border"
       >
-        <Box flex={1} style={{minWidth: 0}}>
+        <Box flexBasis="0%" flexGrow={1} style={{minWidth: 0}}>
           {datum.isLoading ? (
             <SanityDefaultPreview isPlaceholder />
           ) : (

--- a/packages/sanity/src/core/variants/tool/overview/VariantConditionFilters.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantConditionFilters.tsx
@@ -3,8 +3,9 @@ import {CheckmarkIcon} from '@sanity/icons/Checkmark'
 import {CloseIcon} from '@sanity/icons/Close'
 import {FilterIcon} from '@sanity/icons/Filter'
 import {SearchIcon} from '@sanity/icons/Search'
-import {Box, Card, Flex, Stack, Text, TextInput, useClickOutsideEvent} from '@sanity/ui'
+import {Card, Flex, Stack, Text, TextInput, useClickOutsideEvent} from '@sanity/ui'
 import {type ComponentType, useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {Box} from 'ui5'
 
 import {Button} from '../../../../ui-components/button/Button'
 import {Popover} from '../../../../ui-components/popover/Popover'
@@ -253,7 +254,8 @@ function ActiveChips({
 
   return (
     <Box
-      flex={1}
+      flexBasis="0%"
+      flexGrow={1}
       ref={containerRef}
       style={{minWidth: 0, overflow: 'hidden', position: 'relative'}}
     >

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
@@ -60,15 +60,7 @@ const VariantTitleCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, datum
 
   if (variant.isLoading) {
     return (
-      <Box
-        {...cellProps}
-        flexBasis="0%"
-        flexGrow={1}
-        paddingLeft={3}
-        paddingRight={2}
-        paddingY={2}
-        style={{boxSizing: 'border-box'}}
-      >
+      <Box {...cellProps} flexBasis="0%" flexGrow={1} paddingLeft={3} paddingRight={2} paddingY={2}>
         <Stack gap={2}>
           <Text size={1} weight="medium">
             <Skeleton animated radius={1} style={{width: '16ch'}} />
@@ -84,15 +76,7 @@ const VariantTitleCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, datum
   const conditionsText = getVariantConditionsText(variant.conditions)
 
   return (
-    <Box
-      {...cellProps}
-      flexBasis="0%"
-      flexGrow={1}
-      paddingLeft={3}
-      paddingRight={2}
-      paddingY={1}
-      style={{boxSizing: 'border-box'}}
-    >
+    <Box {...cellProps} flexBasis="0%" flexGrow={1} paddingLeft={3} paddingRight={2} paddingY={1}>
       <Flex align="center" gap={3}>
         <Card as={VariantLink} data-as="a" flex={1} padding={2} radius={2} tone="inherit">
           <Flex align="center" gap={3}>

--- a/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
+++ b/packages/sanity/src/core/variants/tool/overview/VariantsOverviewColumnDefs.tsx
@@ -1,6 +1,7 @@
-import {Box, Card, Flex, Skeleton, Stack, Text} from '@sanity/ui'
+import {Card, Flex, Skeleton, Stack, Text} from '@sanity/ui'
 import {type HTMLProps, useMemo, type RefAttributes} from 'react'
 import {StateLink} from 'sanity/router'
+import {Box} from 'ui5'
 
 import {useTranslation, type UseTranslationResponse} from '../../../i18n/hooks/useTranslation'
 import {Headers} from '../../../releases/tool/components/Table/TableHeader'
@@ -59,7 +60,15 @@ const VariantTitleCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, datum
 
   if (variant.isLoading) {
     return (
-      <Box {...cellProps} flex={1} paddingLeft={3} paddingRight={2} paddingY={2} sizing="border">
+      <Box
+        {...cellProps}
+        flexBasis="0%"
+        flexGrow={1}
+        paddingLeft={3}
+        paddingRight={2}
+        paddingY={2}
+        style={{boxSizing: 'border-box'}}
+      >
         <Stack gap={2}>
           <Text size={1} weight="medium">
             <Skeleton animated radius={1} style={{width: '16ch'}} />
@@ -75,7 +84,15 @@ const VariantTitleCell: VisibleColumn<TableVariant>['cell'] = ({cellProps, datum
   const conditionsText = getVariantConditionsText(variant.conditions)
 
   return (
-    <Box {...cellProps} flex={1} paddingLeft={3} paddingRight={2} paddingY={1} sizing="border">
+    <Box
+      {...cellProps}
+      flexBasis="0%"
+      flexGrow={1}
+      paddingLeft={3}
+      paddingRight={2}
+      paddingY={1}
+      style={{boxSizing: 'border-box'}}
+    >
       <Flex align="center" gap={3}>
         <Card as={VariantLink} data-as="a" flex={1} padding={2} radius={2} tone="inherit">
           <Flex align="center" gap={3}>


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR migrates the Box component from `@sanity/ui` v4 to v5 in the directories `perspective`, `singleDocRelease`, `store`, and `variants` inside `packages/sanity/src/core/`. It updates Box across 18 files containing 42 JSX or styled-component instances.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Make sure the prop updates look correct.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I manually tested in the Variants tab in Test Studio. I wasn't sure where exactly to find the`perspective`, `singleDocRelease`, and `store` components.

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

N/A

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mechanical import and flex-prop translation for layout wrappers only; no auth, data, or business-logic changes.
> 
> **Overview**
> Moves **`Box`** imports from `@sanity/ui` to **`ui5`** across perspective navbar, single-doc release dialogs, login, and variants UI (menus, forms, tables, filters).
> 
> Because ui5 **`Box`** no longer accepts shorthand flex props, usages are updated explicitly: **`flex="none"`** becomes **`flexBasis="auto"`** / **`flexGrow={0}`** / **`flexShrink={0}`**, and growing layout wrappers use **`flexBasis="0%"`** with **`flexGrow={1}`** instead of **`flex={1}`**. A few variants overview table cells drop **`sizing="border"`** on **`Box`** where that prop is not carried over.
> 
> No behavior or feature changes beyond matching the v5 **`Box`** API and preserving layout intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80d47c573e614239e61f267a90946a88b6df582f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->