### PR TITLE
fix: forward the workspace apiHost to the embedded sdk instance

### DIFF
--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -1172,6 +1172,15 @@ export interface ScheduledPublishingPluginOptions {
 export interface Workspace extends Omit<Source, 'type'> {
   type: 'workspace'
   /**
+   * API hostname used for requests, when the workspace config sets a custom
+   * one (staging, custom CNAMEs). Undefined for the default production host.
+   * Carried over from the workspace summary at runtime — typed here so
+   * consumers (e.g. the embedded SDK instance) don't have to re-derive it
+   * from a client.
+   * @internal
+   */
+  apiHost?: string
+  /**
    * URL base path to use, for instance `/myWorkspace`
    * Note that this will be prepended with any _studio_ base path, eg `/studio/myWorkspace`,
    * and is a client-side routing feature. If you're looking to serve your studio from a subpath,

--- a/packages/sanity/src/core/config/types.ts
+++ b/packages/sanity/src/core/config/types.ts
@@ -1172,10 +1172,12 @@ export interface ScheduledPublishingPluginOptions {
 export interface Workspace extends Omit<Source, 'type'> {
   type: 'workspace'
   /**
-   * API hostname used for requests, when the workspace config sets a custom
-   * one (staging, custom CNAMEs). Undefined for the default production host.
-   * Carried over from the workspace summary at runtime — typed here so
-   * consumers (e.g. the embedded SDK instance) don't have to re-derive it
+   * The API hostname *explicitly configured* on the workspace (custom CNAMEs,
+   * non-default environments). Undefined when the config sets none — note the
+   * effective host may still differ from the production default in that case
+   * (e.g. staging inferred via `isStaging`); environment defaults are applied
+   * where clients are created, not here. Carried over from the workspace
+   * summary at runtime; typed here so consumers don't have to re-derive it
    * from a client.
    * @internal
    */

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceLoader.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceLoader.tsx
@@ -7,6 +7,7 @@ import {catchError, map} from 'rxjs/operators'
 import {ErrorBoundary} from '../../../ui-components/errorBoundary/ErrorBoundary'
 import {ConfigResolutionError} from '../../config/ConfigResolutionError'
 import {type Source, type Workspace, type WorkspaceSummary} from '../../config/types'
+import {isStaging} from '../../environment/isStaging'
 import {useActiveWorkspace} from '../activeWorkspaceMatcher/useActiveWorkspace'
 import {SourceProvider} from '../source'
 import {WorkspaceProvider} from '../workspace'
@@ -109,10 +110,18 @@ function WorkspaceLoader({
         key={workspace.name}
         projectId={workspace.projectId}
         dataset={workspace.dataset}
-        // Without an explicit apiHost the SDK builds `https://<projectId>.api.sanity.io`
-        // for every request — a studio configured against another host (staging,
-        // custom CNAMEs) would leak its SDK traffic to production
-        auth={workspace.apiHost ? {apiHost: workspace.apiHost} : undefined}
+        // Without an effective apiHost the SDK builds `https://<projectId>.api.sanity.io`
+        // for every request — a studio on another host (staging, custom CNAMEs)
+        // would leak its SDK traffic to production. Mirrors createAuthStore's
+        // resolution: explicit workspace config wins, then the staging
+        // environment default. The staging arm matters because the SDK's own
+        // detection only sees the build-time flag, while isStaging also covers
+        // the runtime global and import-map signals of auto-updating studios.
+        auth={
+          workspace.apiHost || isStaging
+            ? {apiHost: workspace.apiHost ?? 'https://api.sanity.work'}
+            : undefined
+        }
         studio={{
           authenticated: workspace.authenticated,
           auth: workspace.auth.token ? {token: workspace.auth.token} : undefined,

--- a/packages/sanity/src/core/studio/workspaceLoader/WorkspaceLoader.tsx
+++ b/packages/sanity/src/core/studio/workspaceLoader/WorkspaceLoader.tsx
@@ -109,6 +109,10 @@ function WorkspaceLoader({
         key={workspace.name}
         projectId={workspace.projectId}
         dataset={workspace.dataset}
+        // Without an explicit apiHost the SDK builds `https://<projectId>.api.sanity.io`
+        // for every request — a studio configured against another host (staging,
+        // custom CNAMEs) would leak its SDK traffic to production
+        auth={workspace.apiHost ? {apiHost: workspace.apiHost} : undefined}
         studio={{
           authenticated: workspace.authenticated,
           auth: workspace.auth.token ? {token: workspace.auth.token} : undefined,


### PR DESCRIPTION
### Description

> Written by an AI agent on behalf of @bjoerge, who has reviewed it.

The embedded SDK instance added in #12157 isn't told which API host the workspace uses, so it builds `https://<projectId>.api.sanity.io` for every request — studios configured with a custom `apiHost` (staging, custom CNAMEs) leak SDK traffic to the production host. Caught by the bench suite's hermeticity guard, which failed the daily run ([example](https://github.com/sanity-io/sanity/actions/runs/31670624163)).

Fix: pass `workspace.apiHost` as the SDK's `auth.apiHost`. The value already existed on the workspace object at runtime (spread in from `WorkspaceSummary`), it just wasn't typed on `Workspace`, so the interface gains the field. Undefined for default production studios, so no change there.

### What to review

The `auth` prop in `WorkspaceLoader.tsx` and the `@internal` field addition on `Workspace`.

### Testing

Tested red/green against the bench suite: unmodified main reproduces the CI violation on both pageload and interaction; with the fix both run clean. Workspace unit tests and lint/type checks pass.

### Notes for release

n/a

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes which API host the embedded SDK uses for auth and requests; wrong resolution could misroute staging/custom-CNAME traffic, though logic mirrors existing auth store behavior and production defaults are unchanged.
> 
> **Overview**
> Fixes the embedded App SDK defaulting every request to `https://<projectId>.api.sanity.io` when the workspace uses a custom **`apiHost`** or staging, which sent SDK traffic to production.
> 
> **`WorkspaceLoader`** now sets **`ResourceProvider`** `auth.apiHost` using the same rules as **`createAuthStore`**: an explicit **`workspace.apiHost`** wins; otherwise, when **`isStaging`** is true, it uses `https://api.sanity.work`. Default production studios still omit `auth`, so behavior is unchanged there.
> 
> The **`Workspace`** type gains an **`@internal` `apiHost?`** field so the value already present from **`WorkspaceSummary`** at runtime is typed for consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b8ca61ece94cdee2a76fcc4e7c32190aadfb086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->