### PR TITLE
chore(ci): publish next releases on a twice-daily schedule instead of per-commit

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -1,21 +1,90 @@
 name: Release @next
 
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    # 08:00 and 15:00 CET (GitHub cron is UTC-only; during CEST/summer these fire at 09:00/16:00 local time)
+    - cron: "0 7,14 * * *"
+  # Manual trigger for an on-demand next release between scheduled runs. Publishing is still
+  # skipped if the current HEAD of main has already been published.
+  workflow_dispatch:
 
 permissions:
   contents: read # for checkout
 
-jobs:
-  release-next:
-    concurrency:
-      group: release_next
+concurrency:
+  group: release_next
+  cancel-in-progress: false
 
-    # this runs in main, and we want to skip running it when release PRs are merged
-    if: >
-      !startsWith(github.event.head_commit.message, 'chore(release): publish')
+jobs:
+  check:
+    # scheduled runs always use the default branch, but workflow_dispatch can be pointed at any
+    # ref — never publish next releases from anything but main
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      publish: ${{ steps.decide.outputs.publish }}
+      version: ${{ steps.decide.outputs.version }}
+      sha: ${{ steps.decide.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup
+
+      - name: Check for unpublished changes
+        id: decide
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+          # A release commit has nothing new to cut. Checking the commit subject covers the
+          # window where the release PR has merged but the release workflow hasn't pushed the
+          # vX.Y.Z tag yet…
+          subject=$(git log -1 --format=%s)
+          if [[ "$subject" == "chore(release): publish"* ]]; then
+            echo "Skipping: HEAD is the release commit ($subject)"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # …and HEAD sitting exactly on the latest release tag covers it once the tag exists.
+          # `--match "v*"` must stay in sync with readGitInfo() in
+          # packages/@repo/release-notes/src/commands/bump.ts
+          described=$(git describe --tags --long --first-parent --match "v*")
+          if [[ "$described" =~ -0-g[0-9a-f]+$ ]]; then
+            echo "Skipping: HEAD ($described) is the release commit"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          version=$(pnpm --silent release-notes bump --preid=next --suffix-type=commits-ahead --dry-run)
+          if [ -z "$version" ]; then
+            echo "Failed to compute the next version"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          # Ask the registry whether this exact version already exists — the packages are
+          # versioned in lockstep, so checking `sanity` answers for all of them. Published
+          # versions are stored without the +hash build metadata, so strip it before the
+          # lookup. Anything other than 200/404 (registry outage etc.) fails the job rather
+          # than skipping silently.
+          http_status=$(curl -sS --retry 3 -o /dev/null -w '%{http_code}' "https://registry.npmjs.org/sanity/${version%%+*}")
+          if [ "$http_status" = "200" ]; then
+            echo "Skipping: sanity@$version is already published"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          elif [ "$http_status" = "404" ]; then
+            echo "Will publish sanity@$version"
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Failed to check the npm registry for sanity@$version (HTTP $http_status)"
+            exit 1
+          fi
+
+  release-next:
+    needs: [check]
+    if: needs.check.outputs.publish == 'true'
     permissions:
       id-token: write # to enable use of OIDC for npm provenance
     runs-on: ubuntu-latest
@@ -24,21 +93,25 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       EXPECTED_NPM_USER: sanity-svc.npm
     steps:
-      - uses: actions/create-github-app-token@v3
-        id: generate-token
-        with:
-          app-id: ${{ secrets.ECOSPARK_APP_ID }}
-          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
-
-      # Publish packages to npm under the `next` tag on new commits to main.
+      # Publish packages to npm under the `next` tag. Pin the checkout to the commit the check
+      # job validated, in case main has moved since.
       - uses: actions/checkout@v7
         with:
+          ref: ${{ needs.check.outputs.sha }}
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
 
       - name: Bump next versions
-        run: pnpm --silent release-notes bump --preid=next --suffix-type=commits-ahead
+        env:
+          EXPECTED_VERSION: ${{ needs.check.outputs.version }}
+        run: |
+          version=$(pnpm --silent release-notes bump --preid=next --suffix-type=commits-ahead)
+          echo "Bumped to $version"
+          if [ "$version" != "$EXPECTED_VERSION" ]; then
+            echo "::error::Version mismatch: check job computed $EXPECTED_VERSION but bump produced $version"
+            exit 1
+          fi
 
       - name: Build
         run: pnpm build --output-logs=full --log-order=grouped
@@ -84,7 +157,7 @@ jobs:
         run: pnpm bundle-manager publish --tag=next
 
   notify-on-failure:
-    needs: [release-next]
+    needs: [check, release-next]
     if: failure()
     runs-on: ubuntu-latest
     steps:

--- a/packages/@repo/release-notes/src/commands/bump.ts
+++ b/packages/@repo/release-notes/src/commands/bump.ts
@@ -39,7 +39,10 @@ function readGitInfo(): GitInfo {
     encoding: 'utf-8',
   }).trim()
 
-  const tagInfo = execSync('git describe --tags --long --first-parent', {
+  // scope to release tags (getVersionBump uses the same `v` prefix) so stray non-release tags
+  // on main history can't reset the commit count. Must stay in sync with the `git describe`
+  // in .github/workflows/release-next.yml.
+  const tagInfo = execSync('git describe --tags --long --first-parent --match "v*"', {
     cwd: MONOREPO_ROOT,
     encoding: 'utf-8',
   }).trim()


### PR DESCRIPTION
### Description

Every push to main published the full package set to npm under `next` and uploaded bundles to the staging and production buckets. This moves the workflow to a twice-daily cron (08:00/15:00 CET) plus `workflow_dispatch`, with a lightweight `check` job that skips before building when the current HEAD is already published. The existence check hits the registry's per-version endpoint and branches on HTTP status (the same mechanism lerna/pacote use).

Also scopes `git describe` to `v*` tags, in `bump.ts` and the workflow together, so stray tags can't skew the commit count or falsely trigger the skip.

### What to review

Behavioral changes: `sanity@next` and the `next` bundle tags (including auto-updating studios) now advance twice daily or on manual dispatch instead of per-commit. After an official release, the bundle `next` tag moves to the just-published `latest` version only after the next scheduled next release.

### Testing
Manually tested. Will do additional tests after merge.

### Notes for release

N/A – Internal only

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes when and whether packages hit npm and GCS under the `next` tag, but adds registry and version guards to reduce duplicate or mistaken publishes.
> 
> **Overview**
> **@next** publishing no longer runs on every push to `main`. The workflow now triggers on a twice-daily UTC cron (aligned to morning/afternoon CET) and on manual `workflow_dispatch`, with workflow-level concurrency so overlapping runs are serialized.
> 
> A new **`check`** job on `main` decides whether to publish: it skips release commits (by subject or `git describe` on `v*` tags), computes the would-be version via `release-notes bump --dry-run`, and queries the npm registry for `sanity@<version>` (stripping `+` build metadata). Only on **404** does **`release-next`** run; registry errors fail the job instead of skipping quietly. The publish job checks out the SHA from `check` and asserts the real bump matches the precomputed version.
> 
> `readGitInfo()` in **`bump.ts`** now uses `git describe --match "v*"` so non-release tags cannot skew commit counts—kept in sync with the workflow skip logic. The GitHub App token step was removed from the publish job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56dc85da9ee99799990138755c1d7e8d38e7f6b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->