### PR TITLE
chore(access-ui): resync package version with the lockstep release set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ sanity/
 
 - **Package Manager**: pnpm (version 10.x, enforced via `preinstall`)
 - **Build Orchestration**: Turbo (caches builds)
-- **Versioning**: Lerna-lite with conventional commits
+- **Versioning**: Custom tooling (`@repo/release-notes bump`) with conventional commits. Published packages version in lockstep with the root `package.json` version; the bump tool selects packages by `version === rootVersion`, so a package whose version lags the root is **silently excluded** from releases (stable and `next`). When creating a new package, set its version to the current root version, and if a release train passes while the PR is in flight, resync the version before or right after merge.
 
 ### Build Commands
 

--- a/packages/@sanity/access-ui/package.json
+++ b/packages/@sanity/access-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/access-ui",
-  "version": "6.9.1",
+  "version": "6.9.2",
   "description": "Shared request-access screen and access-request logic for Sanity applications",
   "keywords": [
     "access",


### PR DESCRIPTION
### Description

`@sanity/access-ui` published its first release at 6.9.1 while the v6.9.2 train was in flight, leaving it one patch behind the lockstep set. The release tooling (`release-notes bump`) only bumps packages whose version equals the root version, so access-ui is now silently skipped: last night's next run published every sibling at 6.10.0-next.15 except access-ui, and the pending v6.10.0 release PR (#13985) bumps every package but this one (it even writes the access-ui changelog while leaving the version at 6.9.1).

One line: bump the package to 6.9.2 so it rejoins the lockstep set. Once merged, the release PR regenerates and v6.10.0 (and next builds) will include access-ui with #13990's changes.

### What to review

That resyncing the version manually is the intended remedy here, vs teaching `getWorkspacePackages` in `@repo/release-notes` to tolerate lagging versions. Happy to do the latter instead if drift like this is expected to recur.

### Testing

No behavior change; `pnpm install --lockfile-only` reports no lockfile changes (workspace:* protocol).

### Notes for release

N/A, version bookkeeping only. 6.9.2 is skipped for this package (never published), which npm allows.
