### PR TITLE
ci(release): allow triggering next release via label on the release pr

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -7,6 +7,13 @@ on:
   # Manual trigger for an on-demand next release between scheduled runs. Publishing is still
   # skipped if the current HEAD of main has already been published.
   workflow_dispatch:
+  # Adding the `trigger: next-release` label to the release PR (ci/release-main) also starts an
+  # on-demand run. The release PR is used as the trigger surface because it always exists and
+  # always reflects the current state of main — main itself has no PR to label. The label is
+  # removed again by the check job, so it works as a repeatable button.
+  pull_request:
+    types: [labeled]
+    branches: [main]
 
 permissions:
   contents: read # for checkout
@@ -18,9 +25,17 @@ concurrency:
 jobs:
   check:
     # scheduled runs always use the default branch, but workflow_dispatch can be pointed at any
-    # ref — never publish next releases from anything but main
-    if: github.ref == 'refs/heads/main'
+    # ref — never publish next releases from anything but main. Label events only count when the
+    # trigger label lands on the release PR.
+    if: >
+      (github.event_name != 'pull_request' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' &&
+       github.event.label.name == 'trigger: next-release' &&
+       github.event.pull_request.head.ref == 'ci/release-main')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # to remove the trigger label after a label-triggered run
     outputs:
       publish: ${{ steps.decide.outputs.publish }}
       version: ${{ steps.decide.outputs.version }}
@@ -28,6 +43,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          # explicit ref so label-triggered runs check main rather than the PR merge ref (whose
+          # head commit is the release commit itself and would always hit the skip below)
+          ref: refs/heads/main
           fetch-depth: 0
           persist-credentials: false
 
@@ -81,6 +99,14 @@ jobs:
             echo "Failed to check the npm registry for sanity@$version (HTTP $http_status)"
             exit 1
           fi
+
+      - name: Remove trigger label
+        if: github.event_name == 'pull_request' && !cancelled()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TRIGGER_LABEL: "trigger: next-release"
+        run: gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "$TRIGGER_LABEL"
 
   release-next:
     needs: [check]

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -113,6 +113,7 @@ jobs:
     if: needs.check.outputs.publish == 'true'
     permissions:
       id-token: write # to enable use of OIDC for npm provenance
+      pull-requests: write # to comment on the release PR after publishing
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -181,6 +182,28 @@ jobs:
           GCLOUD_SERVICE_KEY: ${{ secrets.GCS_PRODUCTION_SERVICE_KEY }}
           GCLOUD_BUCKET: ${{ secrets.GCS_PRODUCTION_BUCKET }}
         run: pnpm bundle-manager publish --tag=next
+
+      # The release PR (ci/release-main) collects everything unreleased on main, so it's the
+      # natural place to surface which next snapshot contains those changes. Scheduled runs have
+      # no PR in their event payload, so look it up — and skip quietly when none is open. The
+      # published version is the computed one minus the +hash build metadata, which npm strips.
+      - name: Find the release PR
+        id: release-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.check.outputs.version }}
+        run: |
+          echo "number=$(gh pr list --repo "$GITHUB_REPOSITORY" --head ci/release-main --base main --state open --json number --jq '.[0].number // empty')" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION%%+*}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on the release PR
+        if: steps.release-pr.outputs.number != ''
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
+        with:
+          pr-number: ${{ steps.release-pr.outputs.number }}
+          comment-tag: "next-release"
+          message: |
+            The changes in this PR up to ${{ needs.check.outputs.sha }} are available on npm as [`sanity@${{ steps.release-pr.outputs.version }}`](https://www.npmjs.com/package/sanity/v/${{ steps.release-pr.outputs.version }}) (`npm install sanity@next`).
 
   notify-on-failure:
     needs: [check, release-next]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -532,12 +532,13 @@ gh pr ready
 
 ### Useful PR Labels
 
-| Label                | When to use                                                                          |
-| -------------------- | ------------------------------------------------------------------------------------ |
-| `🤖 bot`             | **Required** on every AI-agent PR                                                    |
-| `trigger: preview`   | Publishes preview packages via [`pkg.pr.new`](https://pkg.pr.new) (maintainer-gated) |
-| `trigger:perf-bench` | Runs the `perf/bench` suite on the PR (maintainer-gated)                             |
-| `full-test-suite`    | Forces the full unit test suite to run                                               |
+| Label                   | When to use                                                                                                           |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `🤖 bot`                | **Required** on every AI-agent PR                                                                                     |
+| `trigger: preview`      | Publishes preview packages via [`pkg.pr.new`](https://pkg.pr.new) (maintainer-gated)                                  |
+| `trigger:perf-bench`    | Runs the `perf/bench` suite on the PR (maintainer-gated)                                                              |
+| `trigger: next-release` | On the `ci/release-main` release PR only: dispatches an on-demand `next` release from current main (maintainer-gated) |
+| `full-test-suite`       | Forces the full unit test suite to run                                                                                |
 
 Do **not** apply `trigger:*` labels unless the prompter or a maintainer asks — they kick off expensive or publish workflows.
 


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends entry points into the npm `next` publish workflow; publish is still guarded by existing skip logic, but a mis-scoped trigger or permissions change could affect when packages ship.
> 
> **Overview**
> Adds an on-demand **`@next`** release path by applying **`trigger: next-release`** on the open **`ci/release-main`** release PR (in addition to schedule and `workflow_dispatch`).
> 
> The **`Release @next`** workflow now listens for **`pull_request` `labeled`** events, runs only when that label is added on the release PR, checks out **`refs/heads/main`** (not the PR merge ref), and strips the label after the check job so it can be reused. After a successful publish it looks up the same release PR and posts a tagged comment with the published **`sanity@`** version and **`npm install sanity@next`**.
> 
> **`AGENTS.md`** documents the new label as maintainer-gated, alongside the existing **`trigger:*`** labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e75e58dd10b3de99bae85cb5cbc3d10c69efab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->