### PR TITLE
ci(release): comment on the release pr when a next release is published

### DIFF
--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -87,6 +87,7 @@ jobs:
     if: needs.check.outputs.publish == 'true'
     permissions:
       id-token: write # to enable use of OIDC for npm provenance
+      pull-requests: write # to comment on the release PR after publishing
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -155,6 +156,28 @@ jobs:
           GCLOUD_SERVICE_KEY: ${{ secrets.GCS_PRODUCTION_SERVICE_KEY }}
           GCLOUD_BUCKET: ${{ secrets.GCS_PRODUCTION_BUCKET }}
         run: pnpm bundle-manager publish --tag=next
+
+      # The release PR (ci/release-main) collects everything unreleased on main, so it's the
+      # natural place to surface which next snapshot contains those changes. Scheduled runs have
+      # no PR in their event payload, so look it up — and skip quietly when none is open. The
+      # published version is the computed one minus the +hash build metadata, which npm strips.
+      - name: Find the release PR
+        id: release-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.check.outputs.version }}
+        run: |
+          echo "number=$(gh pr list --repo "$GITHUB_REPOSITORY" --head ci/release-main --base main --state open --json number --jq '.[0].number // empty')" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION%%+*}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on the release PR
+        if: steps.release-pr.outputs.number != ''
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
+        with:
+          pr-number: ${{ steps.release-pr.outputs.number }}
+          comment-tag: "next-release"
+          message: |
+            The changes in this PR up to ${{ needs.check.outputs.sha }} are available on npm as [`sanity@${{ steps.release-pr.outputs.version }}`](https://www.npmjs.com/package/sanity/v/${{ steps.release-pr.outputs.version }}) (`npm install sanity@next`).
 
   notify-on-failure:
     needs: [check, release-next]


### PR DESCRIPTION
### Description

With next releases moving to a schedule (#14000) instead of per-commit, it's less obvious which snapshot contains a given change. After every successful publish, the workflow now upserts a single comment on the release PR (`ci/release-main`) — the one place that collects everything unreleased on main — stating the published version and the covered SHA. It uses the repo-standard `thollander/actions-comment-pull-request` with a `comment-tag`, so the comment is edited in place on each publish instead of accumulating.

### What to review

The two steps at the end of the publish job in `.github/workflows/release-next.yml`, plus `pull-requests: write` on the job. The comment step runs last, so it only fires once npm and both bundle uploads succeeded. Scheduled runs have no PR in their event payload, so the lookup step finds the open `ci/release-main` PR itself and the comment is skipped quietly when none is open.

### Testing

zizmor passes. The PR-lookup and build-metadata-stripping shell was exercised locally against the real registry and GitHub API. End-to-end behavior is verifiable via `workflow_dispatch` once merged.

### Notes for release

N/A – Internal only

---

_Created by an AI agent (Claude) prompted by @bjoerge, who reviewed the change._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with scoped PR comment permissions; no runtime or release artifact logic is altered beyond adding a post-publish notification step.
> 
> **Overview**
> After a successful **@next** publish, the `release-next` workflow now posts (or updates) a single comment on the open **`ci/release-main`** release PR so it’s clear which npm snapshot includes unreleased main changes.
> 
> The **`release-next`** job gains **`pull-requests: write`**, plus two steps at the end of the publish path (after npm and bundle uploads): one uses **`gh`** to find an open PR from **`ci/release-main`** → **`main`** and strips **`+hash`** build metadata from the version string; the other upserts a tagged comment (`next-release`) with the published version, covered SHA, and install hint. If no release PR is open, commenting is skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 360c751938ed30f20f993b91183b5ee8a4a5853b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->