### PR TITLE
fix(core): scope editor presence to the selected content variant

### DIFF
--- a/packages/sanity/src/_exports/index.ts
+++ b/packages/sanity/src/_exports/index.ts
@@ -1735,10 +1735,6 @@ export {validateDocument, type ValidateDocumentOptions} from '../core/validation
 export {isDocumentInSelectedVariant} from '../core/variants/documents/isDocumentInSelectedVariant'
 export {useCreatableVariantInitialValue} from '../core/variants/hooks/useCreatableVariantInitialValue'
 export {useVariantDocumentOperations} from '../core/variants/hooks/useVariantDocumentOperations'
-export {
-  filterPresenceByVariant,
-  getVariantScopeIds,
-} from '../core/variants/presence/filterPresenceByVariant'
 export {useVariantScopedDocumentPresence} from '../core/variants/presence/useVariantScopedDocumentPresence'
 export {VARIANTS_STUDIO_CLIENT_OPTIONS} from '../core/variants/store/constants'
 export {useAllVariants} from '../core/variants/store/useAllVariants'

--- a/packages/sanity/src/_exports/index.ts
+++ b/packages/sanity/src/_exports/index.ts
@@ -1735,6 +1735,11 @@ export {validateDocument, type ValidateDocumentOptions} from '../core/validation
 export {isDocumentInSelectedVariant} from '../core/variants/documents/isDocumentInSelectedVariant'
 export {useCreatableVariantInitialValue} from '../core/variants/hooks/useCreatableVariantInitialValue'
 export {useVariantDocumentOperations} from '../core/variants/hooks/useVariantDocumentOperations'
+export {
+  filterPresenceByVariant,
+  getVariantScopeIds,
+} from '../core/variants/presence/filterPresenceByVariant'
+export {useVariantScopedDocumentPresence} from '../core/variants/presence/useVariantScopedDocumentPresence'
 export {VARIANTS_STUDIO_CLIENT_OPTIONS} from '../core/variants/store/constants'
 export {useAllVariants} from '../core/variants/store/useAllVariants'
 export {getVariantTitle} from '../core/variants/tool/util'

--- a/packages/sanity/src/core/form/useDocumentForm.presence.test.tsx
+++ b/packages/sanity/src/core/form/useDocumentForm.presence.test.tsx
@@ -1,0 +1,146 @@
+import {type SanityClient} from '@sanity/client'
+import {defineField, defineType} from '@sanity/types'
+import {renderHook, waitFor} from '@testing-library/react'
+import {of} from 'rxjs'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import {createMockSanityClient} from '../../../test/mocks/mockSanityClient'
+import {createTestProvider} from '../../../test/testUtils/TestProvider'
+import {defineConfig} from '../config/defineConfig'
+import {type TargetDocumentState, useTargetDocumentState} from '../hooks/useTargetDocumentState'
+import {usePresenceStore} from '../store/datastores'
+import {administrator} from '../store/grants/debug/exampleGrants'
+import {type PresenceStore} from '../store/presence/presence-store'
+import {variantAlphaAudience} from '../variants/__fixtures__/variants.fixture'
+import {useDocumentForm} from './useDocumentForm'
+
+vi.mock('../store/datastores', async (importOriginal) => ({
+  ...(await importOriginal()),
+  usePresenceStore: vi.fn(),
+}))
+
+// Only the hook is mocked; the accessor deriving the presence id from the state stays real.
+vi.mock('../hooks/useTargetDocumentState', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useTargetDocumentState: vi.fn(),
+}))
+
+const DOCUMENT_ID = 'article-1'
+const VARIANT_VERSION_ID = `versions.varscope.${DOCUMENT_ID}`
+const CREATABLE_DRAFT_ID = `versions.varscopeDraft.${DOCUMENT_ID}`
+
+const schemaTypes = [
+  defineType({
+    name: 'article',
+    type: 'document',
+    fields: [defineField({name: 'title', type: 'string'})],
+  }),
+]
+
+function createMockPresenceStore(): PresenceStore {
+  return {
+    documentPresence: vi.fn(() => of([])),
+    globalPresence$: of([]),
+    reportLocations: vi.fn(() => of(undefined)),
+    setLocation: vi.fn(),
+    debugPresenceParam$: of([]),
+  }
+}
+
+async function renderDocumentForm(targetDocumentState: TargetDocumentState) {
+  const presenceStore = createMockPresenceStore()
+  vi.mocked(usePresenceStore).mockReturnValue(presenceStore)
+  vi.mocked(useTargetDocumentState).mockReturnValue(targetDocumentState)
+
+  const client = createMockSanityClient({
+    requests: {'/acl': administrator},
+  }) as unknown as SanityClient
+  const wrapper = await createTestProvider({
+    client,
+    config: defineConfig({
+      projectId: 'test',
+      dataset: 'test',
+      schema: {types: schemaTypes},
+    }),
+  })
+
+  renderHook(() => useDocumentForm({documentId: DOCUMENT_ID, documentType: 'article'}), {wrapper})
+
+  // Presence is announced on the document root as soon as the form mounts.
+  await waitFor(() => expect(presenceStore.setLocation).toHaveBeenCalled())
+
+  return presenceStore
+}
+
+/**
+ * The form's presence document id is derived from the resolved target, not from the displayed
+ * value: the value falls back to the published group id whenever the variant-scoped version
+ * hasn't loaded (or doesn't exist yet), which would place editors of different variants in the
+ * same document.
+ */
+describe('useDocumentForm presence scoping', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reports presence at the resolved variant-scoped version', async () => {
+    const presenceStore = await renderDocumentForm({
+      status: 'ready',
+      targetDocument: {
+        _id: VARIANT_VERSION_ID,
+        _rev: 'rev',
+        _createdAt: '',
+        _updatedAt: '',
+        _system: {
+          bundleId: 'drafts',
+          group: {_ref: DOCUMENT_ID, _weak: true},
+          variant: {_ref: variantAlphaAudience._id, _weak: true},
+          scopeId: 'varscope',
+        },
+      },
+      scopeId: 'varscope',
+      variant: variantAlphaAudience,
+      publishedSibling: undefined,
+    })
+
+    expect(presenceStore.setLocation).toHaveBeenCalledWith([
+      expect.objectContaining({documentId: VARIANT_VERSION_ID}),
+    ])
+    expect(presenceStore.documentPresence).toHaveBeenCalledWith(VARIANT_VERSION_ID, {
+      excludeVersions: true,
+    })
+  })
+
+  it('reports presence at the advertised id of a creatable draft variant', async () => {
+    // The document does not exist until the first keystroke creates it, so the displayed value is
+    // still the published group id at this point.
+    const presenceStore = await renderDocumentForm({
+      status: 'variant-missing',
+      variant: variantAlphaAudience,
+      bundle: 'drafts',
+      publishedSibling: undefined,
+      creatableTarget: {id: CREATABLE_DRAFT_ID, scopeId: 'varscopeDraft'},
+    })
+
+    expect(presenceStore.setLocation).toHaveBeenCalledWith([
+      expect.objectContaining({documentId: CREATABLE_DRAFT_ID}),
+    ])
+    expect(presenceStore.documentPresence).toHaveBeenCalledWith(CREATABLE_DRAFT_ID, {
+      excludeVersions: true,
+    })
+  })
+
+  it('reports presence at the displayed document when no variant target applies', async () => {
+    const presenceStore = await renderDocumentForm({
+      status: 'ready',
+      targetDocument: undefined,
+      scopeId: undefined,
+      variant: undefined,
+      publishedSibling: undefined,
+    })
+
+    expect(presenceStore.setLocation).toHaveBeenCalledWith([
+      expect.objectContaining({documentId: DOCUMENT_ID}),
+    ])
+  })
+})

--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -35,6 +35,7 @@ import {
   getCreatableVariantTarget,
   getPairTarget,
   getTargetScopeId,
+  getVariantTargetDocumentId,
   useTargetDocumentState,
 } from '../hooks/useTargetDocumentState'
 import {useValidationStatus} from '../hooks/useValidationStatus'
@@ -342,10 +343,17 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
     return comparisonValueRaw
   }, [comparisonValueRaw, upstreamEditState])
 
+  // The document presence is reported at and read from. For variant targets this must be the
+  // resolved variant-scoped version rather than `value._id`: the latter falls back to the
+  // published group id while the version snapshot loads, and stays there for a creatable draft
+  // variant until the first keystroke creates the document. Reporting at the group id puts
+  // editors of different variants — and of the base document — in the same place.
+  const presenceDocumentId = getVariantTargetDocumentId(targetDocumentState) ?? value._id
+
   const presence$ = useMemo(
     () =>
       presenceStore
-        .documentPresence(value._id, {excludeVersions: true})
+        .documentPresence(presenceDocumentId, {excludeVersions: true})
         .pipe(
           distinctUntilChanged(
             (prev, next) =>
@@ -358,7 +366,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
               ),
           ),
         ),
-    [presenceStore, value._id],
+    [presenceStore, presenceDocumentId],
   )
   const presence = useObservable(presence$, [])
 
@@ -656,14 +664,14 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
       presenceStore.setLocation([
         {
           type: 'document',
-          documentId: value._id,
+          documentId: presenceDocumentId,
           path: nextFocusPath,
           lastActiveAt: new Date().toISOString(),
           selection: payload?.selection,
         },
       ])
     },
-    [presenceStore, value._id],
+    [presenceStore, presenceDocumentId],
   )
 
   // Announce presence on the document root when the form mounts

--- a/packages/sanity/src/core/hooks/__tests__/useTargetDocumentState.test.ts
+++ b/packages/sanity/src/core/hooks/__tests__/useTargetDocumentState.test.ts
@@ -7,6 +7,7 @@ import {
   getPairTarget,
   getTargetDocumentState,
   getTargetScopeId,
+  getVariantTargetDocumentId,
 } from '../useTargetDocumentState'
 
 const PUBLISHED_ID = 'article-1'
@@ -302,6 +303,51 @@ describe('getCreatableVariantTarget', () => {
     expect(getCreatableVariantTarget(getTargetDocumentState(baseOptions))).toBeUndefined()
     expect(
       getCreatableVariantTarget(
+        getTargetDocumentState({
+          ...variantOptions,
+          versions: [publishedBase, draftBase, publishedAlphaVariant],
+        }),
+      ),
+    ).toBeUndefined()
+  })
+})
+
+describe('getVariantTargetDocumentId', () => {
+  it('returns the resolved variant-scoped version id', () => {
+    expect(getVariantTargetDocumentId(getTargetDocumentState(variantOptions))).toBe(
+      draftAlphaVariant._id,
+    )
+  })
+
+  it('returns the advertised id of a creatable draft variant', () => {
+    // The document doesn't exist yet, but presence and permission checks must still address the
+    // id it will occupy rather than the published group id.
+    expect(
+      getVariantTargetDocumentId(
+        getTargetDocumentState({
+          ...variantOptions,
+          versions: [publishedBase, draftBase, publishedAlphaVariantAdvertisingDraft],
+        }),
+      ),
+    ).toBe(DRAFT_SIBLING_ID)
+  })
+
+  it('returns undefined when no variant target applies', () => {
+    // Base pair.
+    expect(getVariantTargetDocumentId(getTargetDocumentState(baseOptions))).toBeUndefined()
+    // Release version, no variant selected.
+    expect(
+      getVariantTargetDocumentId(getTargetDocumentState({...baseOptions, bundle: RELEASE_ID})),
+    ).toBeUndefined()
+    // Still resolving.
+    expect(
+      getVariantTargetDocumentId(
+        getTargetDocumentState({...variantOptions, versionsLoading: true}),
+      ),
+    ).toBeUndefined()
+    // Variant missing and not creatable.
+    expect(
+      getVariantTargetDocumentId(
         getTargetDocumentState({
           ...variantOptions,
           versions: [publishedBase, draftBase, publishedAlphaVariant],

--- a/packages/sanity/src/core/hooks/useTargetDocumentState.ts
+++ b/packages/sanity/src/core/hooks/useTargetDocumentState.ts
@@ -136,6 +136,28 @@ export function getTargetScopeId(state: TargetDocumentState): string | undefined
 }
 
 /**
+ * The id of the document a variant target resolves to: the variant-scoped version itself, or the
+ * (server-advertised) id a creatable draft variant will occupy once typing creates it.
+ *
+ * `undefined` for every state that isn't a variant target — the base draft/published pair, a
+ * release version, and a missing or unresolved variant that can't be created. Unlike
+ * {@link getTargetScopeId} this is a full document id, for consumers that address the document
+ * directly rather than checking out a pair (presence, permission checks).
+ *
+ * @internal
+ * @beta
+ */
+export function getVariantTargetDocumentId(state: TargetDocumentState): string | undefined {
+  if (state.status === 'ready') {
+    return state.variant ? state.targetDocument?._id : undefined
+  }
+  if (state.status === 'variant-missing') {
+    return state.creatableTarget?.id
+  }
+  return undefined
+}
+
+/**
  * The creatable draft variant of a `variant-missing` state, or `undefined` for every other
  * state. Present when the missing target can be created by typing at a server-advertised id
  * (see {@link CreatableTargetDocument}); consumers use it to exempt the state from the

--- a/packages/sanity/src/core/variants/EDITING.md
+++ b/packages/sanity/src/core/variants/EDITING.md
@@ -194,7 +194,20 @@ The pair holds only the variant document for the _current_ bundle. Everything th
 - **`getEditEvents`** — attribution fails soft for variants: `releaseId` carries the opaque hash, which can never collide with a real release name (regression-tested).
 - `useDocumentIdStack` is **unchanged**: variants are resolved by a separate API parameter and do not participate in the perspective stack.
 
-## 10. Invariants — the "never do" list
+## 10. Collaboration surfaces: comments and presence
+
+Both attach to a document group, so both need an explicit answer to "which variant is this about?".
+
+**Comments** are stored against the published id (`target.document._ref`) plus a scope in `target.documentVersionId`. `CommentsWrapper` fills that scope from `getTargetScopeId(targetDocumentState)`, so a variant target stores (and queries by) the variant's opaque scope hash the same way a release target stores the release id. Comments written on one variant are therefore invisible on another, and on the base document.
+
+**Presence** is variant-partitioned, and this took two parts:
+
+- **Reporting.** `useDocumentForm` reports at `getVariantTargetDocumentId(targetDocumentState) ?? value._id`. `value._id` alone is wrong for variants: it falls back to the published group id while the version snapshot loads, and stays there for a creatable draft variant until the first keystroke creates the document — so editors of _different_ variants would both announce themselves on the group document.
+- **Subscribing.** `useDocumentPresence(documentId)` aggregates the whole group by design (`documentIdEquals`), which is what you want across draft/published/release versions of one document — they are the same content at different points in its lifecycle. Variants are not: they are different content sharing a group. `useVariantScopedDocumentPresence` narrows the group list to the selected variant by attributing each presence location's scope id to a variant via the group's version stubs (`getVariantScopeIds`) — scope hashes are opaque, so this attribution can only be discovered, never computed. A scope the client has no stub for is treated as non-variant, which degrades to the old group-level behavior rather than hiding someone. `FormView` (overlay, Portable Text cursors) and `DocumentPanelHeader` (document-level avatars) use it; the form's own field-level presence is already exact-id matched (`excludeVersions: true`).
+
+Presence surfaces outside the document pane (search results, reference previews, list panes, the navbar presence menu) remain group-level: they identify a document group, not a variant of it.
+
+## 11. Invariants — the "never do" list
 
 These are the rules that keep the system correct. Violating any of them reintroduces a failure mode that was deliberately engineered away:
 
@@ -207,22 +220,23 @@ These are the rules that keep the system correct. Violating any of them reintrod
 7. **Infer loading from `loading` flags, never from stub presence.** `useDocumentVersions` emits `{loading: true, versions: []}` while fetching.
 8. **Declare targets to the store.** New operation call sites must pass `getPairTarget(targetDocumentState)`, not a bare scope id, or they lose the `unresolved`/`target-missing` guards.
 
-## 11. What is not done yet
+## 12. What is not done yet
 
 - **Permissions**: `documentPairPermissions` does not yet accept a target kind; variant grants are still checked against base-derived ids. The grants-engine match on `versions.<hash>.*` paths needs early manual verification.
-- **Peripheral subsystems**: comments scoping, presence scoping (group-level vs variant), UI truthfulness gates keyed on `!draft && !published`, Presentation/scheduled-publishing guards.
+- **Peripheral subsystems**: UI truthfulness gates keyed on `!draft && !published`, Presentation/scheduled-publishing guards.
 - **Optimistic locks**: `ifPublishedVariantRevisionId` is wired from `publishedSibling._rev` via `PublishOptions.publishedRevisionId` on `publish.execute`. `ifSourceRevisionId` remains blocked on the deployed action accepting that field.
 
-## 12. Map of key files
+## 13. Map of key files
 
-| Area              | Files                                                                                                                                                                                                                                                        |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Types & constants | `variants/types.ts`, `variants/store/constants.ts`, `@sanity/types` `DocumentSystem`                                                                                                                                                                         |
-| Selection         | `perspective/PerspectiveProvider.tsx`, `perspective/useSetVariant.tsx`, `variants/store/useAllVariants.ts`                                                                                                                                                   |
-| Resolution        | `hooks/useTargetDocumentState.ts`, `util/getTargetDocument.ts`, `releases/hooks/useDocumentVersions.tsx`, `releases/util/temporarilyBuildDocumentSystem.ts`                                                                                                  |
-| Pane wiring       | `structure/panes/document/DocumentPane.tsx` (mount gate + keying), `DocumentPaneProvider.tsx`, `documentPanel/banners/DocumentNotInVariantBanner.tsx`, `VariantDefinitionNotFoundBanner.tsx`, `core/form/useDocumentForm.ts`                                 |
-| Store & guards    | `store/document/document-store.ts`, `store/document/types.ts` (`DocumentPairTarget`), `document-pair/editState.ts`, `document-pair/operations/helpers.ts` (`GUARDED`, `TARGET_NOT_FOUND_OPERATIONS`, self-derived guard), `hooks/useDocumentOperation.ts`    |
-| Operation routing | `variants/documents/getVariantVersionInfo.ts`, `document-pair/serverOperations/{publish,unpublish,discardChanges}.ts`, `document-pair/utils/{assertNotVariantVersion,variantActionsApiClient}.ts`, `variants/store/variantsClient.ts`, `variants/ACTIONS.md` |
-| Creation          | `variants/documents/createVariantScopedDocument.ts`, `variants/hooks/useVariantDocumentOperations.ts`                                                                                                                                                        |
-| Publish-state UI  | `structure/documentActions/{PublishAction,UnpublishAction,DiscardChangesAction}.tsx`, `releases/plugin/documentActions/UnpublishVersionAction.tsx`                                                                                                           |
-| Diffs & history   | `structure/panes/document/inspectors/changes/EventsInspector.tsx`, `structure/panes/document/DocumentEventsPane.tsx`, `store/events/getEditEvents.ts`, `store/history/createHistoryStore.ts`, `document-pair/serverOperations/restore.ts`                    |
+| Area                | Files                                                                                                                                                                                                                                                        |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Types & constants   | `variants/types.ts`, `variants/store/constants.ts`, `@sanity/types` `DocumentSystem`                                                                                                                                                                         |
+| Selection           | `perspective/PerspectiveProvider.tsx`, `perspective/useSetVariant.tsx`, `variants/store/useAllVariants.ts`                                                                                                                                                   |
+| Resolution          | `hooks/useTargetDocumentState.ts`, `util/getTargetDocument.ts`, `releases/hooks/useDocumentVersions.tsx`, `releases/util/temporarilyBuildDocumentSystem.ts`                                                                                                  |
+| Pane wiring         | `structure/panes/document/DocumentPane.tsx` (mount gate + keying), `DocumentPaneProvider.tsx`, `documentPanel/banners/DocumentNotInVariantBanner.tsx`, `VariantDefinitionNotFoundBanner.tsx`, `core/form/useDocumentForm.ts`                                 |
+| Store & guards      | `store/document/document-store.ts`, `store/document/types.ts` (`DocumentPairTarget`), `document-pair/editState.ts`, `document-pair/operations/helpers.ts` (`GUARDED`, `TARGET_NOT_FOUND_OPERATIONS`, self-derived guard), `hooks/useDocumentOperation.ts`    |
+| Operation routing   | `variants/documents/getVariantVersionInfo.ts`, `document-pair/serverOperations/{publish,unpublish,discardChanges}.ts`, `document-pair/utils/{assertNotVariantVersion,variantActionsApiClient}.ts`, `variants/store/variantsClient.ts`, `variants/ACTIONS.md` |
+| Creation            | `variants/documents/createVariantScopedDocument.ts`, `variants/hooks/useVariantDocumentOperations.ts`                                                                                                                                                        |
+| Publish-state UI    | `structure/documentActions/{PublishAction,UnpublishAction,DiscardChangesAction}.tsx`, `releases/plugin/documentActions/UnpublishVersionAction.tsx`                                                                                                           |
+| Comments & presence | `structure/panes/document/comments/CommentsWrapper.tsx`, `variants/presence/{filterPresenceByVariant,useVariantScopedDocumentPresence}.ts`, `core/form/useDocumentForm.ts`                                                                                   |
+| Diffs & history     | `structure/panes/document/inspectors/changes/EventsInspector.tsx`, `structure/panes/document/DocumentEventsPane.tsx`, `store/events/getEditEvents.ts`, `store/history/createHistoryStore.ts`, `document-pair/serverOperations/restore.ts`                    |

--- a/packages/sanity/src/core/variants/EDITING_PLAN.md
+++ b/packages/sanity/src/core/variants/EDITING_PLAN.md
@@ -111,8 +111,8 @@ Replaces the current pattern of threading `useTargetDocument()` into ~12 files w
 
 ### WS6 — Peripheral subsystems
 
-- [ ] Comments: thread `scopeId` through `CommentsWrapper` → `CommentsProvider` (currently `selectedReleaseId` only) so `documentValue`/revision attach to the variant.
-- [ ] Presence: `FormView` subscribes on the base `documentId` while the form reports on `value._id`. Decide group-level vs variant-scoped presence; group-level is acceptable short-term, but make it a decision.
+- [x] Comments: `CommentsWrapper` passes `getTargetScopeId(targetDocumentState)` to `CommentsProvider`, so a variant target stores and queries `target.documentVersionId` as the variant scope hash (`useCommentsStore`, `createOperation`) and `documentValue`/revision come from the variant's version slot.
+- [x] Presence: decided **variant-scoped**. `useDocumentForm` reports at `getVariantTargetDocumentId(targetDocumentState) ?? value._id` (`value._id` is the published group id while the version loads, and for a creatable draft variant until it exists), and `FormView` / `DocumentPanelHeader` subscribe through `useVariantScopedDocumentPresence`, which attributes each location's scope id to a variant via the group's stubs. Presence outside the document pane stays group-level.
 - [ ] UI truthfulness: loading gates keyed on `!draft && !published` (`DocumentPanelHeader`, `DocumentPanelSubHeader`, `DocumentHeaderTabs`, `FormView` spinner) must count the version; `hasObsoleteDraft` skips under variant targets; `isNewDocument` / `mustChooseNewDocumentDestination` get per-target semantics; `DocumentStatusLine` fallback timestamps prefer the version under a variant.
 - [ ] Presentation (`PostMessageRefreshMutations`) and scheduled publishing (SAPP-3986 / SAPP-3987 TODOs): explicit out-of-scope guards rather than silent base behavior.
 
@@ -133,5 +133,4 @@ Each workstream carries its own unit tests (operation payload tests like the exi
 ## Open decisions
 
 - Duplicate semantics for variant documents (WS3).
-- Presence scoping: group-level vs variant-scoped (WS6).
 - Whether `variant-missing` read-only state should offer creation inline (current `DocumentNotInVariantBanner` CTA) for release-bundle variants once `sanity.action.document.variant.create` supports release `bundleId`s.

--- a/packages/sanity/src/core/variants/presence/__tests__/filterPresenceByVariant.test.ts
+++ b/packages/sanity/src/core/variants/presence/__tests__/filterPresenceByVariant.test.ts
@@ -1,0 +1,178 @@
+import {type DocumentSystem, type User} from '@sanity/types'
+import {describe, expect, it} from 'vitest'
+
+import {type VersionInfoDocumentStub} from '../../../releases/store/types'
+import {type DocumentPresence} from '../../../store/presence/types'
+import {filterPresenceByVariant, getVariantScopeIds} from '../filterPresenceByVariant'
+
+const GROUP_ID = 'article-1'
+const VARIANT_ALPHA = '_.variants.alpha'
+const VARIANT_BETA = '_.variants.beta'
+
+const user = {id: 'user-1', displayName: 'Ola'} as User
+
+function stub(system: Partial<DocumentSystem> & {scopeId?: string}): VersionInfoDocumentStub {
+  const {scopeId} = system
+  return {
+    _id: scopeId ? `versions.${scopeId}.${GROUP_ID}` : GROUP_ID,
+    _rev: 'rev',
+    _createdAt: '2026-01-01T00:00:00Z',
+    _updatedAt: '2026-01-01T00:00:00Z',
+    _system: {
+      group: {_ref: GROUP_ID, _weak: true},
+      ...system,
+    } as DocumentSystem,
+  }
+}
+
+function presenceAt(documentId: string): DocumentPresence {
+  return {
+    user,
+    path: [],
+    sessionId: `session-${documentId}`,
+    documentId,
+    lastActiveAt: '2026-01-01T00:00:00Z',
+  }
+}
+
+// A group with: the base published + draft documents, a release version, and two variants that
+// each exist in the published and drafts bundles.
+const documentVersions: VersionInfoDocumentStub[] = [
+  stub({}),
+  stub({bundleId: 'drafts', scopeId: 'drafts'}),
+  stub({bundleId: 'rSummer', scopeId: 'rSummer'}),
+  stub({variant: {_ref: VARIANT_ALPHA, _weak: true}, scopeId: 'alphaPub'}),
+  stub({variant: {_ref: VARIANT_ALPHA, _weak: true}, bundleId: 'drafts', scopeId: 'alphaDraft'}),
+  stub({variant: {_ref: VARIANT_BETA, _weak: true}, scopeId: 'betaPub'}),
+  stub({variant: {_ref: VARIANT_BETA, _weak: true}, bundleId: 'drafts', scopeId: 'betaDraft'}),
+]
+
+describe('getVariantScopeIds', () => {
+  it('maps the scope id of every variant document to its variant', () => {
+    expect(getVariantScopeIds(documentVersions)).toEqual(
+      new Map([
+        ['alphaPub', VARIANT_ALPHA],
+        ['alphaDraft', VARIANT_ALPHA],
+        ['betaPub', VARIANT_BETA],
+        ['betaDraft', VARIANT_BETA],
+      ]),
+    )
+  })
+
+  it('leaves the base and release documents unattributed', () => {
+    const scopeIds = getVariantScopeIds(documentVersions)
+    expect(scopeIds.has('drafts')).toBe(false)
+    expect(scopeIds.has('rSummer')).toBe(false)
+  })
+
+  it('attributes the advertised draft sibling of a published variant', () => {
+    // The draft variant doesn't exist yet, but the published variant advertises the id it will
+    // occupy — an editor creating it reports presence there before the document exists.
+    const scopeIds = getVariantScopeIds([
+      stub({
+        variant: {_ref: VARIANT_ALPHA, _weak: true},
+        scopeId: 'alphaPub',
+        draft: {_ref: `versions.alphaDraft.${GROUP_ID}`, _weak: true},
+      }),
+    ])
+
+    expect(scopeIds.get('alphaDraft')).toBe(VARIANT_ALPHA)
+  })
+
+  it('falls back to the id when a variant stub carries no scope id', () => {
+    const scopeIds = getVariantScopeIds([
+      {
+        ...stub({variant: {_ref: VARIANT_ALPHA, _weak: true}}),
+        _id: `versions.alphaPub.${GROUP_ID}`,
+      },
+    ])
+
+    expect(scopeIds.get('alphaPub')).toBe(VARIANT_ALPHA)
+  })
+})
+
+describe('filterPresenceByVariant', () => {
+  const variantScopeIds = getVariantScopeIds(documentVersions)
+
+  const presence = [
+    presenceAt(GROUP_ID),
+    presenceAt(`drafts.${GROUP_ID}`),
+    presenceAt(`versions.rSummer.${GROUP_ID}`),
+    presenceAt(`versions.alphaPub.${GROUP_ID}`),
+    presenceAt(`versions.alphaDraft.${GROUP_ID}`),
+    presenceAt(`versions.betaDraft.${GROUP_ID}`),
+  ]
+
+  it('shows only editors of the selected variant', () => {
+    const result = filterPresenceByVariant({
+      presence,
+      selectedVariantId: VARIANT_ALPHA,
+      variantScopeIds,
+    })
+
+    expect(result.map((item) => item.documentId)).toEqual([
+      `versions.alphaPub.${GROUP_ID}`,
+      `versions.alphaDraft.${GROUP_ID}`,
+    ])
+  })
+
+  it('keeps editors of different variants apart', () => {
+    const alpha = filterPresenceByVariant({
+      presence,
+      selectedVariantId: VARIANT_ALPHA,
+      variantScopeIds,
+    })
+    const beta = filterPresenceByVariant({
+      presence,
+      selectedVariantId: VARIANT_BETA,
+      variantScopeIds,
+    })
+
+    expect(alpha).not.toEqual(expect.arrayContaining(beta))
+    expect(beta.map((item) => item.documentId)).toEqual([`versions.betaDraft.${GROUP_ID}`])
+  })
+
+  it('hides variant editors from the base document, keeping draft, published and releases', () => {
+    const result = filterPresenceByVariant({
+      presence,
+      selectedVariantId: undefined,
+      variantScopeIds,
+    })
+
+    expect(result.map((item) => item.documentId)).toEqual([
+      GROUP_ID,
+      `drafts.${GROUP_ID}`,
+      `versions.rSummer.${GROUP_ID}`,
+    ])
+  })
+
+  it('returns the presence array unchanged when the group has no variants', () => {
+    const result = filterPresenceByVariant({
+      presence,
+      selectedVariantId: undefined,
+      variantScopeIds: new Map(),
+    })
+
+    expect(result).toBe(presence)
+  })
+
+  it('treats presence without a document id as base presence', () => {
+    const anonymous = {...presenceAt(GROUP_ID), documentId: undefined}
+
+    expect(
+      filterPresenceByVariant({
+        presence: [anonymous],
+        selectedVariantId: undefined,
+        variantScopeIds,
+      }),
+    ).toEqual([anonymous])
+
+    expect(
+      filterPresenceByVariant({
+        presence: [anonymous],
+        selectedVariantId: VARIANT_ALPHA,
+        variantScopeIds,
+      }),
+    ).toEqual([])
+  })
+})

--- a/packages/sanity/src/core/variants/presence/__tests__/useVariantScopedDocumentPresence.test.tsx
+++ b/packages/sanity/src/core/variants/presence/__tests__/useVariantScopedDocumentPresence.test.tsx
@@ -1,0 +1,92 @@
+import {type User} from '@sanity/types'
+import {renderHook} from '@testing-library/react'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import {type PerspectiveContextValue} from '../../../perspective/types'
+import {usePerspective} from '../../../perspective/usePerspective'
+import {useDocumentVersions} from '../../../releases/hooks/useDocumentVersions'
+import {type VersionInfoDocumentStub} from '../../../releases/store/types'
+import {type DocumentPresence} from '../../../store/presence/types'
+import {useDocumentPresence} from '../../../store/presence/useDocumentPresence'
+import {variantAlphaAudience, variantNorwegianMarket} from '../../__fixtures__/variants.fixture'
+import {useVariantScopedDocumentPresence} from '../useVariantScopedDocumentPresence'
+
+vi.mock('../../../store/presence/useDocumentPresence', () => ({
+  useDocumentPresence: vi.fn(),
+}))
+vi.mock('../../../releases/hooks/useDocumentVersions', () => ({
+  useDocumentVersions: vi.fn(),
+}))
+vi.mock('../../../perspective/usePerspective', () => ({
+  usePerspective: vi.fn(),
+}))
+
+const GROUP_ID = 'article-1'
+const groupRef = {_ref: GROUP_ID, _weak: true} as const
+
+const alphaDraft: VersionInfoDocumentStub = {
+  _id: `versions.alphaDraft.${GROUP_ID}`,
+  _rev: 'rev',
+  _createdAt: '',
+  _updatedAt: '',
+  _system: {
+    bundleId: 'drafts',
+    group: groupRef,
+    variant: {_ref: variantAlphaAudience._id, _weak: true},
+    scopeId: 'alphaDraft',
+  },
+}
+const norwegianDraft: VersionInfoDocumentStub = {
+  ...alphaDraft,
+  _id: `versions.norwegianDraft.${GROUP_ID}`,
+  _system: {
+    ...alphaDraft._system,
+    variant: {_ref: variantNorwegianMarket._id, _weak: true},
+    scopeId: 'norwegianDraft',
+  },
+}
+
+function presenceAt(documentId: string): DocumentPresence {
+  return {
+    user: {id: `user-${documentId}`} as User,
+    path: [],
+    sessionId: `session-${documentId}`,
+    documentId,
+    lastActiveAt: '',
+  }
+}
+
+function render(selectedVariant: PerspectiveContextValue['selectedVariant']) {
+  vi.mocked(useDocumentPresence).mockReturnValue([
+    presenceAt(`drafts.${GROUP_ID}`),
+    presenceAt(alphaDraft._id),
+    presenceAt(norwegianDraft._id),
+  ])
+  vi.mocked(useDocumentVersions).mockReturnValue({
+    versions: [alphaDraft, norwegianDraft],
+  } as ReturnType<typeof useDocumentVersions>)
+  vi.mocked(usePerspective).mockReturnValue({selectedVariant} as PerspectiveContextValue)
+
+  return renderHook(() => useVariantScopedDocumentPresence(GROUP_ID))
+}
+
+describe('useVariantScopedDocumentPresence', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('subscribes to presence for the whole document group', () => {
+    render(undefined)
+    expect(useDocumentPresence).toHaveBeenCalledWith(GROUP_ID)
+  })
+
+  it('narrows group presence to the selected variant', () => {
+    const {result} = render(variantAlphaAudience)
+    expect(result.current.map((item) => item.documentId)).toEqual([alphaDraft._id])
+  })
+
+  it('hides variant editors when no variant is selected', () => {
+    const {result} = render(undefined)
+    expect(result.current.map((item) => item.documentId)).toEqual([`drafts.${GROUP_ID}`])
+  })
+})

--- a/packages/sanity/src/core/variants/presence/filterPresenceByVariant.ts
+++ b/packages/sanity/src/core/variants/presence/filterPresenceByVariant.ts
@@ -1,0 +1,78 @@
+import {type VersionInfoDocumentStub} from '../../releases/store/types'
+import {type DocumentPresence} from '../../store/presence/types'
+import {getVersionFromId} from '../../util/draftUtils'
+
+/**
+ * Maps the scope id of every variant-scoped document in a group to the variant document id it
+ * belongs to, so a presence location (which only carries a document id) can be attributed to a
+ * variant.
+ *
+ * Variant scope ids are opaque server-generated hashes, so this mapping can only be discovered
+ * from the group's version stubs — never computed from the id shape. A scope id that isn't in the
+ * returned map therefore means "not a variant of this group as far as this client can see": the
+ * base draft/published pair, a release version, or a variant document that hasn't reached the
+ * client's stub list yet.
+ *
+ * @internal
+ */
+export function getVariantScopeIds(
+  documentVersions: readonly VersionInfoDocumentStub[],
+): Map<string, string> {
+  const scopeIds = new Map<string, string>()
+
+  for (const version of documentVersions) {
+    const variantId = version._system.variant?._ref
+    if (!variantId) {
+      continue
+    }
+
+    const scopeId = version._system.scopeId ?? getVersionFromId(version._id)
+    if (scopeId) {
+      scopeIds.set(scopeId, variantId)
+    }
+
+    // A variant-of-published document advertises the id its drafts sibling occupies whether or
+    // not that document exists yet. An editor creating that draft variant reports presence at the
+    // advertised id before it exists, so its scope has to attribute to the variant as well.
+    const draftScopeId = getVersionFromId(version._system.draft?._ref ?? '')
+    if (draftScopeId) {
+      scopeIds.set(draftScopeId, variantId)
+    }
+  }
+
+  return scopeIds
+}
+
+/**
+ * Partitions document presence by variant: an editor is only shown to editors looking at the same
+ * variant, and editors of the base document (or of a release version of it) only see each other.
+ *
+ * Presence is otherwise aggregated across the whole document group — draft, published and release
+ * versions of a document are the same content at different points in its lifecycle, so seeing
+ * everyone working on it is useful. Variants are not: two variants of a document are different
+ * content that happens to share a group, and showing their editors in the same place claims a
+ * collision that isn't there.
+ *
+ * @internal
+ */
+export function filterPresenceByVariant(options: {
+  presence: DocumentPresence[]
+  /** The `_id` of the selected variant (`_.variants.<name>`), or `undefined` for the base document. */
+  selectedVariantId: string | undefined
+  /** Scope id to variant document id, from {@link getVariantScopeIds}. */
+  variantScopeIds: ReadonlyMap<string, string>
+}): DocumentPresence[] {
+  const {presence, selectedVariantId, variantScopeIds} = options
+
+  // Nothing to partition: no variant is selected and the group has no variant documents. Keeps
+  // the array identity stable for the (common) case of a studio that doesn't use variants.
+  if (!selectedVariantId && variantScopeIds.size === 0) {
+    return presence
+  }
+
+  return presence.filter((item) => {
+    const scopeId = getVersionFromId(item.documentId ?? '')
+    const variantId = scopeId ? variantScopeIds.get(scopeId) : undefined
+    return variantId === selectedVariantId
+  })
+}

--- a/packages/sanity/src/core/variants/presence/useVariantScopedDocumentPresence.ts
+++ b/packages/sanity/src/core/variants/presence/useVariantScopedDocumentPresence.ts
@@ -1,0 +1,37 @@
+import {useMemo} from 'react'
+
+import {usePerspective} from '../../perspective/usePerspective'
+import {useDocumentVersions} from '../../releases/hooks/useDocumentVersions'
+import {type DocumentPresence} from '../../store/presence/types'
+import {useDocumentPresence} from '../../store/presence/useDocumentPresence'
+import {filterPresenceByVariant, getVariantScopeIds} from './filterPresenceByVariant'
+
+/**
+ * Document presence for a document group, scoped to the selected variant.
+ *
+ * {@link useDocumentPresence} aggregates presence across every document in the group, which means
+ * editors of different variants show up in the same place. This narrows that list to the variant
+ * currently being viewed (or, when no variant is selected, to the base document and its release
+ * versions).
+ *
+ * @param documentGroupId - The published id of the document group.
+ *
+ * @internal
+ */
+export function useVariantScopedDocumentPresence(documentGroupId: string): DocumentPresence[] {
+  const presence = useDocumentPresence(documentGroupId)
+  const {versions} = useDocumentVersions({documentId: documentGroupId})
+  const {selectedVariant} = usePerspective()
+
+  const variantScopeIds = useMemo(() => getVariantScopeIds(versions), [versions])
+
+  return useMemo(
+    () =>
+      filterPresenceByVariant({
+        presence,
+        selectedVariantId: selectedVariant?._id,
+        variantScopeIds,
+      }),
+    [presence, selectedVariant?._id, variantScopeIds],
+  )
+}

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -15,10 +15,10 @@ import {
   type PatchMsg,
   PresenceOverlay,
   useConditionalToast,
-  useDocumentPresence,
   useDocumentStore,
   usePerspective,
   useTranslation,
+  useVariantScopedDocumentPresence,
 } from 'sanity'
 import {useEffectEvent} from 'use-effect-event'
 
@@ -70,7 +70,7 @@ export function FormView(props: FormViewProps & RefAttributes<HTMLFormElement>) 
   // The scope of the document targeted by the selected perspective (undefined while the target is
   // resolving or when the draft/published pair applies).
   const scopeId = getTargetScopeId(targetDocumentState)
-  const presence = useDocumentPresence(documentId)
+  const presence = useVariantScopedDocumentPresence(documentId)
   const {title} = useDocumentTitle()
   // The `patchChannel` is an INTERNAL publish/subscribe channel that we use to notify form-builder
   // nodes about both remote and local patches.

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentPanelHeader.tsx
@@ -18,9 +18,9 @@ import {
 import {
   FieldPresenceInner,
   type DocumentActionDescription,
-  useDocumentPresence,
   useFieldActions,
   useTranslation,
+  useVariantScopedDocumentPresence,
   useZIndex,
   useWorkspace,
 } from 'sanity'
@@ -163,7 +163,7 @@ export const DocumentPanelHeader = memo(function DocumentPanelHeader(
   const showPaneGroupCloseButton = !showSplitPaneCloseButton && !showBackButton && !!BackLink
 
   const {t} = useTranslation(structureLocaleNamespace)
-  const presence = useDocumentPresence(documentId)
+  const presence = useVariantScopedDocumentPresence(documentId)
   const documentLevelPresence = useMemo(
     () => presence.filter((p) => p.path.length === 0),
     [presence],

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -721,6 +721,7 @@ exports[`exports snapshot 1`] = `
     "useValidationStatus": "function",
     "useValuePreview": "function",
     "useVariantDocumentOperations": "function",
+    "useVariantScopedDocumentPresence": "function",
     "useVersionOperations": "function",
     "useVersionRelease": "function",
     "useVirtualizerScrollInstance": "function",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Follow-up on a claim in some content-variant documentation:

> Comments and presence are not fully variant-scoped. Comments and editor presence work at the document group level in places where you'd expect them to be scoped to the variant you're viewing. Two editors working on different variants of the same document may appear to be in the same place.

Half of that is out of date, half of it was real:

- **Comments are already variant-scoped.** `CommentsWrapper` passes `getTargetScopeId(targetDocumentState)` into `CommentsProvider`, so a variant target stores and queries `target.documentVersionId` as the variant's opaque scope hash (`useCommentsStore`, `createOperation`), exactly the way a release target stores a release id. `CommentsWrapper.test.tsx` already covers this, including "uses variant scopeId rather than the release id when a variant is selected". Only the docs were stale — `EDITING_PLAN.md` still listed it as a TODO.
- **Presence was not.** Fixed here.

There were two separate causes, and the first is the one the reported symptom comes from.

**1. The form reported presence at the wrong id.** `useDocumentForm` announced its location at `value._id`. For a variant target that value is `editState.version || baseValue`, and `baseValue._id` is the **published group id**. So presence was announced on the group document:

- for the whole window between mount and the variant's version snapshot loading (presence is announced on mount, so this always happens), and
- for the entire time a *creatable draft variant* is open, since that document does not exist until the first keystroke creates it.

In both cases two editors on two different variants literally broadcast the same document id, so they were in the same place under any filtering. It now reports at the resolved variant target via a new `getVariantTargetDocumentId(targetDocumentState)` accessor, which returns the variant-scoped version id or the server-advertised id a creatable draft variant will occupy. This mirrors what `targetDocumentId` already does for permission checks.

**2. The document pane subscribed at the group level.** `useDocumentPresence(documentId)` matches on `documentIdEquals`, which collapses every `versions.*` id onto the published id. That is deliberate and right for drafts/published/release versions — same content at different points in its lifecycle — but wrong for variants, which are different content that happens to share a group. `useVariantScopedDocumentPresence` narrows the group list to the selected variant by attributing each presence location's scope id to a variant through the group's version stubs (`getVariantScopeIds`). Scope ids are opaque hashes, so this attribution can only be discovered from stubs, never computed. `FormView` (presence overlay, Portable Text cursors) and `DocumentPanelHeader` (document-level avatars) now use it.

The form's own field-level presence already used exact-id matching (`excludeVersions: true`), so it becomes correct as soon as the reported id is right.

Presence surfaces outside the document pane (search results, reference previews, list panes, navbar presence menu) intentionally stay group-level: they identify a document group, not a variant of it.

`EDITING.md` gets a new section recording the decision, and the corresponding `EDITING_PLAN.md` WS6 items and the "group-level vs variant-scoped" open decision are resolved.

### What to review

- `getVariantTargetDocumentId` in `useTargetDocumentState.ts` and its single use in `useDocumentForm.ts` — this is the behavioural fix.
- Whether variant-partitioned (rather than group-level) is the presence semantics we want. The concrete effect: an editor on the base draft no longer sees an editor working on variant A, and vice versa. Release versions still group with the base, unchanged.
- `filterPresenceByVariant.ts`, in particular the degradation path: a scope id the client has no stub for is treated as non-variant, so it falls back to today's group-level behaviour rather than hiding someone.

### Testing

`pnpm build && pnpm test` is green (5574 passed). New coverage:

- `useDocumentForm.presence.test.tsx` — asserts the form announces presence at the resolved variant version and at a creatable draft variant's advertised id. Both cases were verified to fail against the pre-fix code (see log below); the non-variant case passes either way.
- `filterPresenceByVariant.test.ts` — scope attribution and partitioning, including keeping two variants apart and hiding variant editors from the base document.
- `useVariantScopedDocumentPresence.test.tsx` — hook composition.
- `useTargetDocumentState.test.ts` — the new accessor across all target states.

No UI walkthrough: presence is a websocket feature that only shows a difference with two concurrent editor sessions on two different variants of one document, against a project with the variants backend enabled. The test log below includes the failing pre-fix run so the behaviour change is visible directly.

### Notes for release

Editor presence is now scoped to the content variant you are viewing. Previously, editors working on different variants of the same document could appear to be in the same place: the studio announced presence on the document group whenever a variant's version document had not loaded yet (or did not exist yet, for a draft variant being created), and the document header and presence overlay listened for presence across the whole group. Presence indicators in the document header, the presence overlay, and Portable Text cursors now only show the people working on the same variant as you. Presence in search results, reference previews, and document lists continues to cover the whole document group.

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75529e18-a20f-434d-b7d5-61c879f41618?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75529e18-a20f-434d-b7d5-61c879f41618&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

