### PR TITLE
fix(variants): report ALREADY_UNPUBLISHED for release-scoped variants

### DIFF
--- a/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/UnpublishVersionAction.tsx
@@ -24,7 +24,7 @@ import {isGoingToUnpublish} from '../../util/isGoingToUnpublish'
 export const useUnpublishVersionAction: DocumentActionComponent = (
   props: DocumentActionProps,
 ): DocumentActionDescription | null => {
-  const {id, type, release, published, version, liveEditSchemaType} = props
+  const {id, type, release, published, version} = props
   const currentUser = useCurrentUser()
   const {t} = useTranslation(releasesLocaleNamespace)
   const isAlreadyUnpublished = version ? isGoingToUnpublish(version) : false

--- a/packages/sanity/src/core/store/document/document-pair/serverOperations/unpublish.test.ts
+++ b/packages/sanity/src/core/store/document/document-pair/serverOperations/unpublish.test.ts
@@ -36,6 +36,7 @@ function variantVersion(bundleId: 'drafts' | 'rSummer' | undefined): SanityDocum
 
 const BASE_PAIR = {draftId: 'drafts.my-id', publishedId: 'my-id'}
 const RELEASE_PAIR = {...BASE_PAIR, versionId: 'versions.rSummer.my-id'}
+const VARIANT_PAIR = {...BASE_PAIR, versionId: 'versions.varscope.my-id'}
 
 /** A plain (non-variant) release version snapshot. */
 function releaseVersion(options: {markedForUnpublish?: boolean} = {}): SanityDocument {
@@ -71,6 +72,7 @@ describe('unpublish', () => {
       expect(
         unpublish.disabled({
           typeName: 'blah',
+          idPair: VARIANT_PAIR,
           snapshots: {version: variantVersion(undefined)},
         } as unknown as OperationArgs),
       ).toBe(false)
@@ -80,6 +82,7 @@ describe('unpublish', () => {
       expect(
         unpublish.disabled({
           typeName: 'blah',
+          idPair: VARIANT_PAIR,
           snapshots: {version: variantVersion('rSummer')},
         } as unknown as OperationArgs),
       ).toBe(false)
@@ -89,10 +92,26 @@ describe('unpublish', () => {
       expect(
         unpublish.disabled({
           typeName: 'blah',
+          idPair: VARIANT_PAIR,
           // The base published existing says nothing about the VARIANT being published.
           snapshots: {version: variantVersion('drafts'), published: {} as SanityDocument},
         } as unknown as OperationArgs),
       ).toBe('NOT_PUBLISHED')
+    })
+
+    it('returns ALREADY_UNPUBLISHED for a release-scoped variant already marked for unpublish', () => {
+      const version = variantVersion('rSummer')
+
+      expect(
+        unpublish.disabled({
+          typeName: 'blah',
+          idPair: {...BASE_PAIR, versionId: version._id},
+          snapshots: {
+            version: {...version, _system: {...version._system, delete: true}},
+            published: {} as SanityDocument,
+          },
+        } as unknown as OperationArgs),
+      ).toBe('ALREADY_UNPUBLISHED')
     })
 
     it('is enabled for a release version of a published document', () => {

--- a/packages/sanity/src/core/store/document/document-pair/serverOperations/unpublish.ts
+++ b/packages/sanity/src/core/store/document/document-pair/serverOperations/unpublish.ts
@@ -14,6 +14,13 @@ export const unpublish: OperationImpl<[], DisabledReason> = {
       return 'LIVE_EDIT_ENABLED'
     }
 
+    // A release version already carrying the unpublish marker would be a no-op: the release
+    // publish will remove the published document either way. Reverting it is a separate
+    // operation (`revertUnpublishVersion`), not a repeated unpublish.
+    if (idPair.versionId && snapshots.version && isGoingToUnpublish(snapshots.version)) {
+      return 'ALREADY_UNPUBLISHED'
+    }
+
     const variantVersion = getVariantVersionInfo(snapshots.version)
     if (variantVersion) {
       // Unpublishable variant versions:
@@ -21,13 +28,6 @@ export const unpublish: OperationImpl<[], DisabledReason> = {
       // - a release-scoped variant, which is soft-unpublished as part of its release
       // A drafts-scoped variant has nothing published in its slot to unpublish.
       return variantVersion.bundleId !== 'drafts' ? false : 'NOT_PUBLISHED'
-    }
-
-    // A release version already carrying the unpublish marker would be a no-op: the release
-    // publish will remove the published document either way. Reverting it is a separate
-    // operation (`revertUnpublishVersion`), not a repeated unpublish.
-    if (idPair.versionId && snapshots.version && isGoingToUnpublish(snapshots.version)) {
-      return 'ALREADY_UNPUBLISHED'
     }
 
     return snapshots.published ? false : 'NOT_PUBLISHED'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

> Stacked on [#14001](https://github.com/sanity-io/sanity/pull/14001) and targets that branch, because both touch `serverOperations/unpublish.ts`. Review that one first; retarget this to `main` once it lands.

Report ALREADY_UNPUBLISHED for release-scoped variants

### What to review

- Variant versions didn't report ALREADY_UNPUBLISHED because they bail out early , this fixes it by checking the version._system.delete=true to report if it's already unpublished

Affected package: `sanity` (core variants, releases store, document store operations).

### Testing

- `unpublish.test.ts` — `ALREADY_UNPUBLISHED` for a marked release-scoped variant. The existing execute tests already assert the variant payload for both flavours and cover the regression that a variant with a `versionId` in its id pair does not reach the version action


### Notes for release
n/a internal

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c736319-68ca-45aa-8545-298c684dd8f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c736319-68ca-45aa-8545-298c684dd8f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

