### PR TITLE
chore(release-notes): bump all publishable packages

### DIFF
--- a/packages/@repo/release-notes/src/commands/__test__/bump.test.ts
+++ b/packages/@repo/release-notes/src/commands/__test__/bump.test.ts
@@ -1,6 +1,32 @@
 import {describe, expect, it} from 'vitest'
 
-import {computeVersion} from '../bump'
+import {type PnpmPackage, computeVersion, selectPackagesToBump} from '../bump'
+
+function pkg(name: string, version: string, isPrivate = false): PnpmPackage {
+  return {name, version, path: `/repo/packages/${name}`, private: isPrivate}
+}
+
+describe('selectPackagesToBump', () => {
+  it('includes a publishable package that has drifted from the root version', () => {
+    const selected = selectPackagesToBump([
+      pkg('sanity', '6.9.2'),
+      pkg('@sanity/access-ui', '6.9.1'),
+    ])
+
+    expect(selected.map((p) => p.name)).toStrictEqual(['sanity', '@sanity/access-ui'])
+  })
+
+  it('excludes private packages regardless of their version', () => {
+    const selected = selectPackagesToBump([
+      pkg('sanity', '6.9.2'),
+      pkg('sanity-root', '6.9.2', true),
+      pkg('sanity-test-studio', '6.9.2', true),
+      pkg('scripts', '4.11.0', true),
+    ])
+
+    expect(selected.map((p) => p.name)).toStrictEqual(['sanity'])
+  })
+})
 
 describe('computeVersion', () => {
   it('bumps a stable patch version', () => {

--- a/packages/@repo/release-notes/src/commands/bump.ts
+++ b/packages/@repo/release-notes/src/commands/bump.ts
@@ -16,7 +16,7 @@ interface BumpOptions {
   dryRun?: boolean
 }
 
-interface PnpmPackage {
+export interface PnpmPackage {
   name: string
   version: string
   path: string
@@ -49,16 +49,25 @@ function readGitInfo(): GitInfo {
   return {commitHash, commitCount}
 }
 
-function getWorkspacePackages(currentVersion: string): PnpmPackage[] {
+function getWorkspacePackages(): PnpmPackage[] {
   const output = execSync('pnpm ls -r --json --depth -1', {
     cwd: MONOREPO_ROOT,
     encoding: 'utf-8',
   })
-  const packages: PnpmPackage[] = JSON.parse(output)
-  return packages.filter((pkg) => pkg.version === currentVersion)
+  return selectPackagesToBump(JSON.parse(output))
 }
 
 // -- Pure computation --
+
+/**
+ * Every publishable package shares the root version, so selecting on `private` rather than on
+ * "already matches the root version" means a package added at the wrong version still gets
+ * bumped instead of being silently skipped and failing to publish. Private packages (dev
+ * studios, @repo tooling) are left alone — they are not published and have long since drifted.
+ */
+export function selectPackagesToBump(packages: PnpmPackage[]): PnpmPackage[] {
+  return packages.filter((pkg) => !pkg.private)
+}
 
 function zeroPad(value: number | string, length: number) {
   return String(value).padStart(length, '0')
@@ -128,10 +137,15 @@ export async function bump(options: BumpOptions = {}): Promise<void> {
   }
 
   // Write versions
-  const packages = getWorkspacePackages(currentVersion)
+  const packages = getWorkspacePackages()
   console.error(`Updating ${packages.length} packages`)
 
   for (const pkg of packages) {
+    if (pkg.version !== currentVersion) {
+      console.error(
+        `Note: ${pkg.name} was at ${pkg.version}, not the root version ${currentVersion} — syncing it to ${newVersion}`,
+      )
+    }
     writeVersion(pkg.path, newVersion)
   }
   writeVersion(MONOREPO_ROOT, newVersion)


### PR DESCRIPTION
### Description
Every public package should be published in lockstep. Fixes an issue where we would skip publish of a public package if its version didn't match the version of the workspace package.json.

### What to review


### Testing


### Notes for release
n/a

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes which `package.json` files get rewritten during release; wrong `private` flags could bump unintended packages, but scope is limited to internal release tooling.
> 
> **Overview**
> The release **bump** command no longer limits version writes to workspace packages whose `version` already matches the root. It now bumps **every non-`private` package** via a new exported `selectPackagesToBump`, so publishable packages that drifted from the root version are synced on release instead of being skipped.
> 
> **Private** workspaces (dev studios, `@repo` tooling) are excluded even when their versions differ. When a selected package’s version doesn’t match the root, the bump logs a note before writing the new version. Unit tests cover drifted publishable packages and private-package exclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b21255acdc75fde8442607708a3b6d7d6bfa9dc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->