### PR TITLE
fix(vision): stop swallowing paste events outside vision

### DIFF
--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -38,6 +38,7 @@ import {
 } from '../perspectives'
 import {type VisionProps} from '../types'
 import {encodeQueryString} from '../util/encodeQueryString'
+import {isVisionPasteTarget} from '../util/isVisionPasteTarget'
 import {getLocalStorage} from '../util/localStorage'
 import {parseApiQueryString, type ParsedApiQueryString} from '../util/parseApiQueryString'
 import {prefixApiVersion} from '../util/prefixApiVersion'
@@ -557,22 +558,25 @@ export function VisionGui(props: VisionGuiProps) {
 
   const handlePaste = useCallback(
     (evt: ClipboardEvent) => {
-      if (!evt.clipboardData) {
+      if (!evt.clipboardData || !isVisionPasteTarget(visionRootRef.current, evt)) {
         return
       }
 
-      const data = evt.clipboardData.getData('text/plain')
-      evt.preventDefault()
-      const urlState = getStateFromUrl(data)
-      if (urlState) {
-        setStateFromParsedUrl(urlState)
-        toast.push({
-          closable: true,
-          id: 'vision-paste',
-          status: 'info',
-          title: 'Parsed URL to query',
-        })
+      const urlState = getStateFromUrl(evt.clipboardData.getData('text/plain'))
+      if (!urlState) {
+        return
       }
+
+      // Only cancel the native paste once the clipboard is known to hold a query URL Vision can
+      // load, so unrelated content still pastes as usual.
+      evt.preventDefault()
+      setStateFromParsedUrl(urlState)
+      toast.push({
+        closable: true,
+        id: 'vision-paste',
+        status: 'info',
+        title: 'Parsed URL to query',
+      })
     },
     [getStateFromUrl, setStateFromParsedUrl, toast],
   )

--- a/packages/@sanity/vision/src/util/isVisionPasteTarget.test.ts
+++ b/packages/@sanity/vision/src/util/isVisionPasteTarget.test.ts
@@ -1,0 +1,95 @@
+import {afterEach, describe, expect, it} from 'vitest'
+
+import {isVisionPasteTarget} from './isVisionPasteTarget'
+
+function renderVisionRoot(): HTMLElement {
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  return root
+}
+
+function appendTo(parent: HTMLElement, tagName: string): HTMLElement {
+  const element = document.createElement(tagName)
+  parent.appendChild(element)
+  return element
+}
+
+/**
+ * Dispatches a paste event the way the browser does, then reports what the `document` level
+ * listener that Vision installs would decide about it.
+ */
+function pasteOn(root: Node | null, target: EventTarget): boolean {
+  let allowed = false
+  const listener = (event: Event) => {
+    allowed = isVisionPasteTarget(root, event as ClipboardEvent)
+  }
+
+  document.addEventListener('paste', listener)
+  target.dispatchEvent(new Event('paste', {bubbles: true, composed: true}))
+  document.removeEventListener('paste', listener)
+
+  return allowed
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('isVisionPasteTarget', () => {
+  it('accepts the body when nothing is focused', () => {
+    expect(pasteOn(renderVisionRoot(), document.body)).toBe(true)
+  })
+
+  it('accepts the vision root itself', () => {
+    const root = renderVisionRoot()
+    expect(pasteOn(root, root)).toBe(true)
+  })
+
+  it('accepts the query editor, which is a contenteditable inside the vision root', () => {
+    const root = renderVisionRoot()
+    const editor = appendTo(root, 'div')
+    editor.contentEditable = 'true'
+
+    expect(pasteOn(root, editor)).toBe(true)
+  })
+
+  it('accepts a target the editor detached while handling the paste itself', () => {
+    const root = renderVisionRoot()
+    const editor = appendTo(root, 'div')
+    const line = appendTo(editor, 'br')
+
+    // CodeMirror handles the paste on its own element and re-renders the affected line before the
+    // event reaches `document`, leaving the original target outside the document
+    editor.addEventListener('paste', () => line.remove())
+
+    expect(pasteOn(root, line)).toBe(true)
+  })
+
+  it('rejects an input rendered outside the vision root, such as the studio search field', () => {
+    const root = renderVisionRoot()
+
+    expect(pasteOn(root, appendTo(document.body, 'input'))).toBe(false)
+  })
+
+  it('rejects an input rendered inside the vision root', () => {
+    const root = renderVisionRoot()
+
+    expect(pasteOn(root, appendTo(root, 'input'))).toBe(false)
+  })
+
+  it('rejects a textarea', () => {
+    const root = renderVisionRoot()
+
+    expect(pasteOn(root, appendTo(document.body, 'textarea'))).toBe(false)
+  })
+
+  it('rejects an element outside the vision root', () => {
+    const root = renderVisionRoot()
+
+    expect(pasteOn(root, appendTo(document.body, 'div'))).toBe(false)
+  })
+
+  it('rejects an element when the vision root has not mounted', () => {
+    expect(pasteOn(null, appendTo(document.body, 'div'))).toBe(false)
+  })
+})

--- a/packages/@sanity/vision/src/util/isVisionPasteTarget.test.ts
+++ b/packages/@sanity/vision/src/util/isVisionPasteTarget.test.ts
@@ -21,11 +21,25 @@ function renderVision(): HTMLElement {
 }
 
 describe('isVisionPasteTarget', () => {
-  it('leaves a text field elsewhere in the studio alone', () => {
+  it('leaves the studio search field alone', () => {
     const vision = renderVision()
     const searchField = document.body.appendChild(document.createElement('input'))
 
     expect(pasteOn(searchField, vision)).toBe(false)
+  })
+
+  it('leaves an element elsewhere in the studio alone', () => {
+    const vision = renderVision()
+    const dialog = document.body.appendChild(document.createElement('div'))
+
+    expect(pasteOn(dialog, vision)).toBe(false)
+  })
+
+  it('leaves vision own text inputs alone', () => {
+    const vision = renderVision()
+    const apiVersionField = vision.appendChild(document.createElement('input'))
+
+    expect(pasteOn(apiVersionField, vision)).toBe(false)
   })
 
   it('claims a paste into the query editor', () => {
@@ -42,5 +56,9 @@ describe('isVisionPasteTarget', () => {
     editor.addEventListener('paste', () => line.remove())
 
     expect(pasteOn(line, vision)).toBe(true)
+  })
+
+  it('claims a paste with nothing focused', () => {
+    expect(pasteOn(document.body, renderVision())).toBe(true)
   })
 })

--- a/packages/@sanity/vision/src/util/isVisionPasteTarget.test.ts
+++ b/packages/@sanity/vision/src/util/isVisionPasteTarget.test.ts
@@ -2,59 +2,46 @@ import {describe, expect, it} from 'vitest'
 
 import {isVisionPasteTarget} from './isVisionPasteTarget'
 
-/**
- * Dispatches a paste event the way the browser does, then reports what the `document` level
- * listener Vision installs would decide about it.
- */
-function decide(root: Node | null, target: EventTarget): boolean | undefined {
+// `composedPath()` is only populated while an event is being dispatched, so the decision has to be
+// taken from a real listener rather than a hand-made event object.
+function pasteOn(target: Node, visionRoot: Node): boolean {
   const decisions: boolean[] = []
-  const listener = (event: Event) =>
-    decisions.push(isVisionPasteTarget(root, event as ClipboardEvent))
 
-  document.addEventListener('paste', listener)
+  document.addEventListener(
+    'paste',
+    (event) => decisions.push(isVisionPasteTarget(visionRoot, event as ClipboardEvent)),
+    {once: true},
+  )
   target.dispatchEvent(new Event('paste', {bubbles: true, composed: true}))
-  document.removeEventListener('paste', listener)
 
-  return decisions.at(0)
+  return decisions[0]
 }
 
-/** Renders `html`, where `#root` stands in for the Vision tool and `#target` receives the paste. */
-function pasteInto(html: string): boolean | undefined {
-  document.body.innerHTML = html
-
-  return decide(document.getElementById('root'), document.getElementById('target')!)
+function renderVision(): HTMLElement {
+  return document.body.appendChild(document.createElement('div'))
 }
 
 describe('isVisionPasteTarget', () => {
-  it('accepts the query editor, a contenteditable inside vision', () => {
-    expect(pasteInto('<div id="root"><div id="target" contenteditable></div></div>')).toBe(true)
+  it('leaves a text field elsewhere in the studio alone', () => {
+    const vision = renderVision()
+    const searchField = document.body.appendChild(document.createElement('input'))
+
+    expect(pasteOn(searchField, vision)).toBe(false)
   })
 
-  it('accepts a paste with nothing focused, which targets the body', () => {
-    document.body.innerHTML = '<div id="root"></div>'
+  it('claims a paste into the query editor', () => {
+    const vision = renderVision()
+    const editor = vision.appendChild(document.createElement('div'))
 
-    expect(decide(document.getElementById('root'), document.body)).toBe(true)
+    expect(pasteOn(editor, vision)).toBe(true)
   })
 
-  it('accepts a target the editor detached while handling the paste itself', () => {
-    document.body.innerHTML = '<div id="root"><div id="editor"><br id="target"></div></div>'
-    const editor = document.getElementById('editor')!
-    const line = document.getElementById('target')!
+  it('claims a paste even though the editor detached the target while handling it', () => {
+    const vision = renderVision()
+    const editor = vision.appendChild(document.createElement('div'))
+    const line = editor.appendChild(document.createElement('br'))
     editor.addEventListener('paste', () => line.remove())
 
-    expect(decide(document.getElementById('root'), line)).toBe(true)
-  })
-
-  it.each([
-    [
-      'the studio search field, rendered outside vision',
-      '<div id="root"></div><input id="target">',
-    ],
-    ['a text input inside vision', '<div id="root"><input id="target"></div>'],
-    ['a textarea', '<div id="root"><textarea id="target"></textarea></div>'],
-    ['an element outside vision', '<div id="root"></div><div id="target"></div>'],
-    ['anything at all before vision has mounted', '<div id="target"></div>'],
-  ])('rejects %s', (_, html) => {
-    expect(pasteInto(html)).toBe(false)
+    expect(pasteOn(line, vision)).toBe(true)
   })
 })

--- a/packages/@sanity/vision/src/util/isVisionPasteTarget.test.ts
+++ b/packages/@sanity/vision/src/util/isVisionPasteTarget.test.ts
@@ -42,6 +42,14 @@ describe('isVisionPasteTarget', () => {
     expect(pasteOn(apiVersionField, vision)).toBe(false)
   })
 
+  it('claims a paste while the readonly query url field holds focus', () => {
+    const vision = renderVision()
+    const queryUrlField = vision.appendChild(document.createElement('input'))
+    queryUrlField.readOnly = true
+
+    expect(pasteOn(queryUrlField, vision)).toBe(true)
+  })
+
   it('claims a paste into the query editor', () => {
     const vision = renderVision()
     const editor = vision.appendChild(document.createElement('div'))

--- a/packages/@sanity/vision/src/util/isVisionPasteTarget.test.ts
+++ b/packages/@sanity/vision/src/util/isVisionPasteTarget.test.ts
@@ -2,8 +2,7 @@ import {describe, expect, it} from 'vitest'
 
 import {isVisionPasteTarget} from './isVisionPasteTarget'
 
-// `composedPath()` is only populated while an event is being dispatched, so the decision has to be
-// taken from a real listener rather than a hand-made event object.
+// `composedPath()` is only populated while an event is being dispatched.
 function pasteOn(target: Node, visionRoot: Node): boolean {
   const decisions: boolean[] = []
 

--- a/packages/@sanity/vision/src/util/isVisionPasteTarget.test.ts
+++ b/packages/@sanity/vision/src/util/isVisionPasteTarget.test.ts
@@ -1,95 +1,60 @@
-import {afterEach, describe, expect, it} from 'vitest'
+import {describe, expect, it} from 'vitest'
 
 import {isVisionPasteTarget} from './isVisionPasteTarget'
 
-function renderVisionRoot(): HTMLElement {
-  const root = document.createElement('div')
-  document.body.appendChild(root)
-  return root
-}
-
-function appendTo(parent: HTMLElement, tagName: string): HTMLElement {
-  const element = document.createElement(tagName)
-  parent.appendChild(element)
-  return element
-}
-
 /**
  * Dispatches a paste event the way the browser does, then reports what the `document` level
- * listener that Vision installs would decide about it.
+ * listener Vision installs would decide about it.
  */
-function pasteOn(root: Node | null, target: EventTarget): boolean {
-  let allowed = false
-  const listener = (event: Event) => {
-    allowed = isVisionPasteTarget(root, event as ClipboardEvent)
-  }
+function decide(root: Node | null, target: EventTarget): boolean | undefined {
+  const decisions: boolean[] = []
+  const listener = (event: Event) =>
+    decisions.push(isVisionPasteTarget(root, event as ClipboardEvent))
 
   document.addEventListener('paste', listener)
   target.dispatchEvent(new Event('paste', {bubbles: true, composed: true}))
   document.removeEventListener('paste', listener)
 
-  return allowed
+  return decisions.at(0)
 }
 
-afterEach(() => {
-  document.body.innerHTML = ''
-})
+/** Renders `html`, where `#root` stands in for the Vision tool and `#target` receives the paste. */
+function pasteInto(html: string): boolean | undefined {
+  document.body.innerHTML = html
+
+  return decide(document.getElementById('root'), document.getElementById('target')!)
+}
 
 describe('isVisionPasteTarget', () => {
-  it('accepts the body when nothing is focused', () => {
-    expect(pasteOn(renderVisionRoot(), document.body)).toBe(true)
+  it('accepts the query editor, a contenteditable inside vision', () => {
+    expect(pasteInto('<div id="root"><div id="target" contenteditable></div></div>')).toBe(true)
   })
 
-  it('accepts the vision root itself', () => {
-    const root = renderVisionRoot()
-    expect(pasteOn(root, root)).toBe(true)
-  })
+  it('accepts a paste with nothing focused, which targets the body', () => {
+    document.body.innerHTML = '<div id="root"></div>'
 
-  it('accepts the query editor, which is a contenteditable inside the vision root', () => {
-    const root = renderVisionRoot()
-    const editor = appendTo(root, 'div')
-    editor.contentEditable = 'true'
-
-    expect(pasteOn(root, editor)).toBe(true)
+    expect(decide(document.getElementById('root'), document.body)).toBe(true)
   })
 
   it('accepts a target the editor detached while handling the paste itself', () => {
-    const root = renderVisionRoot()
-    const editor = appendTo(root, 'div')
-    const line = appendTo(editor, 'br')
-
-    // CodeMirror handles the paste on its own element and re-renders the affected line before the
-    // event reaches `document`, leaving the original target outside the document
+    document.body.innerHTML = '<div id="root"><div id="editor"><br id="target"></div></div>'
+    const editor = document.getElementById('editor')!
+    const line = document.getElementById('target')!
     editor.addEventListener('paste', () => line.remove())
 
-    expect(pasteOn(root, line)).toBe(true)
+    expect(decide(document.getElementById('root'), line)).toBe(true)
   })
 
-  it('rejects an input rendered outside the vision root, such as the studio search field', () => {
-    const root = renderVisionRoot()
-
-    expect(pasteOn(root, appendTo(document.body, 'input'))).toBe(false)
-  })
-
-  it('rejects an input rendered inside the vision root', () => {
-    const root = renderVisionRoot()
-
-    expect(pasteOn(root, appendTo(root, 'input'))).toBe(false)
-  })
-
-  it('rejects a textarea', () => {
-    const root = renderVisionRoot()
-
-    expect(pasteOn(root, appendTo(document.body, 'textarea'))).toBe(false)
-  })
-
-  it('rejects an element outside the vision root', () => {
-    const root = renderVisionRoot()
-
-    expect(pasteOn(root, appendTo(document.body, 'div'))).toBe(false)
-  })
-
-  it('rejects an element when the vision root has not mounted', () => {
-    expect(pasteOn(null, appendTo(document.body, 'div'))).toBe(false)
+  it.each([
+    [
+      'the studio search field, rendered outside vision',
+      '<div id="root"></div><input id="target">',
+    ],
+    ['a text input inside vision', '<div id="root"><input id="target"></div>'],
+    ['a textarea', '<div id="root"><textarea id="target"></textarea></div>'],
+    ['an element outside vision', '<div id="root"></div><div id="target"></div>'],
+    ['anything at all before vision has mounted', '<div id="target"></div>'],
+  ])('rejects %s', (_, html) => {
+    expect(pasteInto(html)).toBe(false)
   })
 })

--- a/packages/@sanity/vision/src/util/isVisionPasteTarget.ts
+++ b/packages/@sanity/vision/src/util/isVisionPasteTarget.ts
@@ -4,30 +4,22 @@ function isTextEntryElement(node: EventTarget | undefined): boolean {
 }
 
 /**
- * Vision listens for paste events on `document` so that a Sanity API URL can be pasted anywhere in
- * the tool without focusing the query editor first. Because the listener is global it also observes
- * pastes meant for elements Vision knows nothing about, such as the Studio search field that
- * renders in a portal above the tool, so the target has to be vetted before Vision consumes the
- * event.
+ * Whether a paste seen by Vision's `document` level listener was meant for Vision. The listener is
+ * global, so it also observes pastes aimed at unrelated elements such as the Studio search field.
  *
- * The dispatch path is used rather than `event.target`: CodeMirror handles the paste before it
- * bubbles up to `document` and re-renders the line it landed in, which detaches the original
- * target from the document. The path is captured when the event is dispatched, so it still
- * describes where the paste went.
+ * Uses the dispatch path rather than `event.target`, because CodeMirror handles the paste and
+ * re-renders the pasted line before the event reaches `document`, detaching the original target.
  */
 export function isVisionPasteTarget(root: Node | null, event: ClipboardEvent): boolean {
   const path = event.composedPath()
   const [target] = path
 
-  // Text fields keep their native paste behaviour, including Vision's own. The query and params
-  // editors are CodeMirror `contenteditable` elements rather than form fields, so URLs can still be
-  // pasted straight into them.
+  // Text fields paste natively; the query and params editors are `contenteditable`, not form fields
   if (isTextEntryElement(target)) {
     return false
   }
 
-  // A paste with nothing focused targets the document or its body. Vision fills the tool area, so
-  // treat those as intended for Vision.
+  // Nothing focused
   if (target === window.document || target === window.document.body) {
     return true
   }

--- a/packages/@sanity/vision/src/util/isVisionPasteTarget.ts
+++ b/packages/@sanity/vision/src/util/isVisionPasteTarget.ts
@@ -1,6 +1,7 @@
-function isTextEntryElement(node: EventTarget | undefined): boolean {
-  const tagName = (node as Partial<Element> | undefined)?.tagName
-  return tagName === 'INPUT' || tagName === 'TEXTAREA'
+function acceptsNativePaste(node: EventTarget | undefined): boolean {
+  const element = node as Partial<HTMLInputElement | HTMLTextAreaElement> | undefined
+  const isTextField = element?.tagName === 'INPUT' || element?.tagName === 'TEXTAREA'
+  return isTextField && element?.readOnly === false
 }
 
 /**
@@ -14,8 +15,8 @@ export function isVisionPasteTarget(root: Node | null, event: ClipboardEvent): b
   const path = event.composedPath()
   const [target] = path
 
-  // Text fields paste natively; the query and params editors are `contenteditable`, not form fields
-  if (isTextEntryElement(target)) {
+  // A readonly field keeps focus after Copy URL but drops the paste, so Vision still claims it
+  if (acceptsNativePaste(target)) {
     return false
   }
 

--- a/packages/@sanity/vision/src/util/isVisionPasteTarget.ts
+++ b/packages/@sanity/vision/src/util/isVisionPasteTarget.ts
@@ -1,0 +1,36 @@
+function isTextEntryElement(node: EventTarget | undefined): boolean {
+  const tagName = (node as Partial<Element> | undefined)?.tagName
+  return tagName === 'INPUT' || tagName === 'TEXTAREA'
+}
+
+/**
+ * Vision listens for paste events on `document` so that a Sanity API URL can be pasted anywhere in
+ * the tool without focusing the query editor first. Because the listener is global it also observes
+ * pastes meant for elements Vision knows nothing about, such as the Studio search field that
+ * renders in a portal above the tool, so the target has to be vetted before Vision consumes the
+ * event.
+ *
+ * The dispatch path is used rather than `event.target`: CodeMirror handles the paste before it
+ * bubbles up to `document` and re-renders the line it landed in, which detaches the original
+ * target from the document. The path is captured when the event is dispatched, so it still
+ * describes where the paste went.
+ */
+export function isVisionPasteTarget(root: Node | null, event: ClipboardEvent): boolean {
+  const path = event.composedPath()
+  const [target] = path
+
+  // Text fields keep their native paste behaviour, including Vision's own. The query and params
+  // editors are CodeMirror `contenteditable` elements rather than form fields, so URLs can still be
+  // pasted straight into them.
+  if (isTextEntryElement(target)) {
+    return false
+  }
+
+  // A paste with nothing focused targets the document or its body. Vision fills the tool area, so
+  // treat those as intended for Vision.
+  if (target === window.document || target === window.document.body) {
+    return true
+  }
+
+  return root !== null && path.includes(root)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Tracks [SAPP-4124](https://linear.app/sanity/issue/SAPP-4124/cannot-paste-into-vision-search-field).

Reported in Slack: with the Vision tool open, you cannot paste into the Studio's global search field. Confirmed on `main` — typing works, pasting does nothing.

Vision registers a `paste` listener on `document` so that a Sanity API URL can be pasted anywhere in the tool to load it as a query. That handler called `evt.preventDefault()` on **every** paste, before looking at the clipboard contents and regardless of where the paste landed. While Vision is mounted, that cancels the native paste for anything else on the page — the navbar search field, and Vision's own text inputs too.

Two changes:

- `evt.preventDefault()` now happens only once the clipboard is known to hold a query URL Vision can load, so unrelated content pastes as usual.
- A new `isVisionPasteTarget` guard vets where the paste landed before Vision considers consuming it. Editable text fields (`input` / `textarea`) keep their native paste behaviour, and otherwise the paste has to have landed inside the Vision root, or on the document/body when nothing is focused.

A readonly field is excluded from that carve-out. Vision's own Query URL input is `readOnly`, and its Copy button calls `select()`, which leaves focus sitting there. The browser still fires `paste` on that input and then drops the data, so pasting a URL straight after hitting Copy would do nothing at all if the guard declined it.

The guard uses `event.composedPath()` rather than `event.target`. CodeMirror handles the paste on its own element and re-renders the affected line before the event bubbles to `document`, so by the time the handler runs `event.target` is a detached node and a `compareDocumentPosition` containment check reports `false`. The dispatch path is captured up front and still describes where the paste went. Getting this wrong silently breaks the paste-a-URL feature, so there is a test covering it.

### What to review

- `packages/@sanity/vision/src/util/isVisionPasteTarget.ts` — the guard, in particular the `composedPath()` reasoning.
- `packages/@sanity/vision/src/components/VisionGui.tsx` — `handlePaste` now bails early and defers `preventDefault()`.

Affected flows: the Vision tool's paste-a-URL shortcut, and pasting anywhere in the Studio while Vision is the active tool.

### Testing

`packages/@sanity/vision/src/util/isVisionPasteTarget.test.ts` dispatches real paste events — `composedPath()` is only populated during dispatch — and asserts what Vision's `document` listener would decide.

The guard is new code, so it cannot be run against `main` to show the tests failing beforehand. Instead each branch was mutated in turn to confirm no test passes by accident:

| Guard mutated to | Test that fails |
| --- | --- |
| claim every paste (what `main` effectively did) | the three "leaves ... alone" cases |
| vet `event.target` instead of the dispatch path | claims a paste even though the editor detached the target |
| drop the text field check | leaves vision own text inputs alone |
| drop the readonly condition, so every text field is treated as native | claims a paste while the readonly query url field holds focus |
| drop the nothing-focused check | claims a paste with nothing focused |
| drop the containment check | leaves an element elsewhere in the studio alone |

Every mutation is caught, and each of the last five is caught by exactly one test.

Manually verified in the test studio against a real Chromium.

Pasting into global search while Vision is open (the reported bug):

[search_paste_works_while_vision_open.mp4](https://cursor.com/agents/bc-7cfad72b-5406-49cb-8613-d4d217e74040/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_paste_works_while_vision_open.mp4)

Vision's paste-a-URL feature still parses the URL, loads the query, applies the API version and runs it:

[vision_url_paste_still_loads_query.mp4](https://cursor.com/agents/bc-7cfad72b-5406-49cb-8613-d4d217e74040/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvision_url_paste_still_loads_query.mp4)

`pnpm check:format`, `pnpm check:oxlint` and `pnpm vitest run --project=@sanity/vision` all pass.

### Notes for release

Fixed a bug where having the Vision tool open prevented pasting into other fields in the Studio, such as the global search field in the navbar.

---


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7cfad72b-5406-49cb-8613-d4d217e74040?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cfad72b-5406-49cb-8613-d4d217e74040&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


