### PR TITLE
fix(variants): allow colons and reject commas in condition values

### DIFF
--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -103,8 +103,6 @@ function getConditionRowsValidation(rows: ConditionRow[]): Map<number, Condition
 
     if ((key || isConditionRowEmpty(row)) && valueError === 'empty') {
       validation.value = 'dialog.create.condition-value.required'
-    } else if (valueError === 'invalid') {
-      validation.value = 'dialog.create.condition-value.invalid'
     }
 
     conditionRowsValidation.set(index, validation)

--- a/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/VariantForm.tsx
@@ -103,6 +103,8 @@ function getConditionRowsValidation(rows: ConditionRow[]): Map<number, Condition
 
     if ((key || isConditionRowEmpty(row)) && valueError === 'empty') {
       validation.value = 'dialog.create.condition-value.required'
+    } else if (valueError === 'invalid') {
+      validation.value = 'dialog.create.condition-value.invalid'
     }
 
     conditionRowsValidation.set(index, validation)

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
@@ -211,7 +211,7 @@ describe('CreateVariantDialog', () => {
     expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
   })
 
-  it('shows an error for invalid condition values', async () => {
+  it('allows colons in condition values', async () => {
     const user = userEvent.setup()
 
     await renderDialog()
@@ -221,10 +221,13 @@ describe('CreateVariantDialog', () => {
     await user.type(screen.getByTestId('variant-form-condition-value'), 'loyal:customers')
     await user.click(screen.getByTestId('submit-variant-button'))
 
-    expect(screen.getByTestId('variant-form-condition-value-error')).toHaveTextContent(
-      'Condition values cannot contain colons',
-    )
-    expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(variantOperationsMock.createVariant).toHaveBeenCalledTimes(1)
+    })
+
+    const createdVariant = variantOperationsMock.createVariant.mock.calls[0]![0]
+
+    expect(createdVariant.conditions).toEqual({audience: 'loyal:customers'})
   })
 
   it('requires a condition key before submitting a row with a value', async () => {

--- a/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
+++ b/packages/sanity/src/core/variants/components/dialog/__tests__/CreateVariantDialog.test.tsx
@@ -230,6 +230,22 @@ describe('CreateVariantDialog', () => {
     expect(createdVariant.conditions).toEqual({audience: 'loyal:customers'})
   })
 
+  it('shows an error for condition values that contain commas', async () => {
+    const user = userEvent.setup()
+
+    await renderDialog()
+
+    await user.type(screen.getByTestId('variant-form-title'), 'Loyal customers')
+    await user.type(screen.getByTestId('variant-form-condition-key'), 'audience')
+    await user.type(screen.getByTestId('variant-form-condition-value'), 'loyal,customers')
+    await user.click(screen.getByTestId('submit-variant-button'))
+
+    expect(screen.getByTestId('variant-form-condition-value-error')).toHaveTextContent(
+      'Condition values cannot contain commas',
+    )
+    expect(variantOperationsMock.createVariant).not.toHaveBeenCalled()
+  })
+
   it('requires a condition key before submitting a row with a value', async () => {
     const user = userEvent.setup()
 

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -170,8 +170,6 @@ const variantsLocaleStrings = {
   'dialog.create.condition-key.required': 'Condition key is required',
   /** Validation message when a condition value is missing. */
   'dialog.create.condition-value.required': 'Condition value is required',
-  /** Validation message when a condition value has an invalid format. */
-  'dialog.create.condition-value.invalid': 'Condition values cannot contain colons',
   /** Placeholder for the condition key field in the create variant dialog. */
   'dialog.create.condition-key.placeholder': 'e.g. audience',
   /** Label for the condition value field in the create variant dialog. */

--- a/packages/sanity/src/core/variants/i18n/resources.ts
+++ b/packages/sanity/src/core/variants/i18n/resources.ts
@@ -170,6 +170,8 @@ const variantsLocaleStrings = {
   'dialog.create.condition-key.required': 'Condition key is required',
   /** Validation message when a condition value is missing. */
   'dialog.create.condition-value.required': 'Condition value is required',
+  /** Validation message when a condition value has an invalid format. */
+  'dialog.create.condition-value.invalid': 'Condition values cannot contain commas',
   /** Placeholder for the condition key field in the create variant dialog. */
   'dialog.create.condition-key.placeholder': 'e.g. audience',
   /** Label for the condition value field in the create variant dialog. */

--- a/packages/sanity/src/core/variants/util/__tests__/conditionValidation.test.ts
+++ b/packages/sanity/src/core/variants/util/__tests__/conditionValidation.test.ts
@@ -22,6 +22,7 @@ describe('conditionValidation', () => {
       expect(getConditionKeyValidationError('Audience')).toBe('invalid')
       expect(getConditionKeyValidationError('1audience')).toBe('invalid')
       expect(getConditionKeyValidationError('audience:segment')).toBe('invalid')
+      expect(getConditionKeyValidationError('audience,segment')).toBe('invalid')
       expect(getConditionKeyValidationError('a'.repeat(65))).toBe('invalid')
     })
 
@@ -40,6 +41,10 @@ describe('conditionValidation', () => {
     it('rejects empty values', () => {
       expect(getConditionValueValidationError('')).toBe('empty')
       expect(getConditionValueValidationError('   ')).toBe('empty')
+    })
+
+    it('rejects values with commas', () => {
+      expect(getConditionValueValidationError('loyal,customers')).toBe('invalid')
     })
   })
 })

--- a/packages/sanity/src/core/variants/util/__tests__/conditionValidation.test.ts
+++ b/packages/sanity/src/core/variants/util/__tests__/conditionValidation.test.ts
@@ -34,15 +34,12 @@ describe('conditionValidation', () => {
   describe('getConditionValueValidationError', () => {
     it('accepts non-empty values', () => {
       expect(getConditionValueValidationError('loyal')).toBeUndefined()
+      expect(getConditionValueValidationError('loyal:customers')).toBeUndefined()
     })
 
     it('rejects empty values', () => {
       expect(getConditionValueValidationError('')).toBe('empty')
       expect(getConditionValueValidationError('   ')).toBe('empty')
-    })
-
-    it('rejects values with colons', () => {
-      expect(getConditionValueValidationError('loyal:customers')).toBe('invalid')
     })
   })
 })

--- a/packages/sanity/src/core/variants/util/conditionValidation.ts
+++ b/packages/sanity/src/core/variants/util/conditionValidation.ts
@@ -3,7 +3,7 @@ const CONDITION_SEPARATOR = ':'
 const RESERVED_KEY_PREFIXES = ['_', '$'] as const
 
 export type ConditionKeyValidationError = 'invalid' | 'reserved'
-export type ConditionValueValidationError = 'empty' | 'invalid'
+export type ConditionValueValidationError = 'empty'
 
 export function getConditionKeyValidationError(
   key: string,
@@ -32,10 +32,6 @@ export function getConditionValueValidationError(
 ): ConditionValueValidationError | undefined {
   if (!value.trim()) {
     return 'empty'
-  }
-
-  if (value.includes(CONDITION_SEPARATOR)) {
-    return 'invalid'
   }
 
   return undefined

--- a/packages/sanity/src/core/variants/util/conditionValidation.ts
+++ b/packages/sanity/src/core/variants/util/conditionValidation.ts
@@ -1,9 +1,10 @@
 const CONDITION_KEY_REGEX = /^[a-z][a-z0-9_-]{0,63}$/
 const CONDITION_SEPARATOR = ':'
+const CONDITION_VALUE_FORBIDDEN = ','
 const RESERVED_KEY_PREFIXES = ['_', '$'] as const
 
 export type ConditionKeyValidationError = 'invalid' | 'reserved'
-export type ConditionValueValidationError = 'empty'
+export type ConditionValueValidationError = 'empty' | 'invalid'
 
 export function getConditionKeyValidationError(
   key: string,
@@ -32,6 +33,10 @@ export function getConditionValueValidationError(
 ): ConditionValueValidationError | undefined {
   if (!value.trim()) {
     return 'empty'
+  }
+
+  if (value.includes(CONDITION_VALUE_FORBIDDEN)) {
+    return 'invalid'
   }
 
   return undefined


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Studio previously rejected `:` in variant condition values because they were treated as reserved separators. Content Lake now accepts those values, so the create/edit form was blocking valid variant definitions.

Content Lake still returns `400` when a condition value contains a comma (commas are reserved for combining query parameters). The form now rejects commas client-side instead of only failing on save.

Condition keys stay restricted to the existing identifier format (no colons or commas). Values must be non-empty and must not contain commas.

Variant definition condition **values** may now include colons (for example `audience: loyal:customers`). Commas are still not allowed in condition values. Condition **keys** are unchanged: they must still be lowercase identifiers using letters, numbers, underscores, or hyphens.

### What to review

- `packages/sanity/src/core/variants/util/conditionValidation.ts` — values may include `:`, but not `,`
- Form wiring and `dialog.create.condition-value.invalid` copy
- Unit and create-dialog tests for both cases

### Testing

- `conditionValidation` accepts `loyal:customers` and rejects `loyal,customers`
- `CreateVariantDialog` submits colon values and blocks comma values with an inline error

### Notes for release
n/a internal


---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d375f336-1d2f-4c95-8a35-973b8b336c06?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d375f336-1d2f-4c95-8a35-973b8b336c06&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

