### PR TITLE
fix(e2e): pin workspace icon for chromatic snapshot stability

### DIFF
--- a/.agents/skills/sanity-visual-regression/REFERENCE.md
+++ b/.agents/skills/sanity-visual-regression/REFERENCE.md
@@ -71,6 +71,8 @@ CI flag semantics (all three uploads): `--only-changed` (TurboSnap), `--exit-zer
 - Only snapshot deterministic states: chrome (navbar, panes) without live data, and never
   anything showing relative timestamps ("2 minutes ago"), presence from other CI runs, or
   dataset-dependent lists.
+- The e2e studio (`dev/studio-e2e-testing`) must set a workspace `icon`. The default
+  letter-mark hashes `projectId` + `dataset` into a color, and e2e datasets change per PR.
 - Archives are written into the Playwright output dir during the run; the `e2e.yml` workflow
   merges shard artifacts and uploads once with `chromatic --playwright` using
   `CHROMATIC_PROJECT_TOKEN_E2E`.

--- a/dev/studio-e2e-testing/sanity.config.ts
+++ b/dev/studio-e2e-testing/sanity.config.ts
@@ -40,6 +40,10 @@ const TestReleaseAction: ReleaseActionComponent = (props) => {
 const defaultConfig = defineConfig({
   name: 'default',
   title: 'studio-e2e-testing',
+  // Pin a workspace icon so Chromatic e2e snapshots stay stable. Without this,
+  // createDefaultIcon hashes projectId + dataset into a color, and e2e datasets
+  // change per PR / browser shard.
+  icon: PlayIcon,
 
   projectId: process.env.SANITY_E2E_PROJECT_ID!,
   dataset: process.env.SANITY_E2E_DATASET!,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Chromatic e2e snapshots of the navbar were flipping the workspace letter-mark color between builds. With no workspace `icon`, Studio generates one via `createDefaultIcon`, which hashes `projectId` + `dataset` into a hue — and e2e datasets are unique per PR / browser shard.

Pinning `PlayIcon` on the e2e studio (same pattern as test-studio's `SanityMonogram`) keeps the navbar mark stable. Leaving the autogenerated mark would keep producing diffs whenever a new dataset name hashes to a different color.

### What to review

- `dev/studio-e2e-testing/sanity.config.ts` — workspace `icon` on the shared default config (chromium and firefox workspaces inherit it)
- Chromatic navbar snapshot after this lands: expect a one-time baseline update from the letter-mark to the play icon, then no more color flakes

### Testing

Config-only change; Chromatic Playwright snapshots are the real check and will run in CI.

Locally:
- Confirmed `createDefaultIcon` produces different fills for different dataset names (e.g. `#2927aa` vs `#4043e7` for the same title), which matches the Chromatic flake
- `createDefaultIcon` unit tests passed (`pnpm vitest run --project=sanity packages/sanity/src/core/config/__tests__/createDefaultIcon.test.tsx`)
- Could not run the Playwright e2e studio in this environment (`SANITY_E2E_*` tokens are not present)

The navbar Chromatic spec (`e2e/tests/default-layout/navbar.spec.ts`) is the snapshot that was catching this.

### Notes for release

N/A – Internal only (e2e studio config for visual regression stability)

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab5daaf5-afc5-4264-b837-846b3edffcc9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab5daaf5-afc5-4264-b837-846b3edffcc9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

