### PR TITLE
refactor(field): migrate portable text diff Paragraph to vanilla-extract

### DIFF
--- a/packages/sanity/src/core/field/types/portableText/diff/components/Paragraph.css.ts
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Paragraph.css.ts
@@ -1,0 +1,8 @@
+import {style} from '@vanilla-extract/css'
+
+export const paragraph = style({
+  textTransform: 'none',
+  whiteSpace: 'wrap',
+  overflowWrap: 'break-word',
+  margin: 0,
+})

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Paragraph.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Paragraph.tsx
@@ -1,14 +1,8 @@
 import {type ReactNode} from 'react'
-import {styled} from 'styled-components'
 
-// This can contain nested <div> elements, so it's not rendered as a <p> element
-const StyledParagraph = styled.div`
-  text-transform: none;
-  white-space: wrap;
-  overflow-wrap: break-word;
-  margin: 0;
-`
+import {paragraph} from './Paragraph.css'
 
 export function Paragraph({children}: {children: ReactNode}): React.JSX.Element {
-  return <StyledParagraph>{children}</StyledParagraph>
+  // This can contain nested <div> elements, so it's not rendered as a <p> element
+  return <div className={paragraph}>{children}</div>
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Second of three low-hanging-fruit migrations applying the skill added in #14024 (stacked on #14025). `StyledParagraph` was a single-use static `styled.div` internal to `Paragraph`, so it takes the flatten shape from the skill: the class from the colocated `.css.ts` goes directly on the `<div>` and the intermediate component disappears. CSS values copied verbatim. The neighboring `Blockquote` is intentionally left for a follow-up — one instance per PR.

### What to review

- `packages/sanity/src/core/field/types/portableText/diff/components/Paragraph.css.ts` — rules should match the deleted template literal one-for-one
- `Paragraph.tsx` — the div-instead-of-p comment survives since nested `<div>` children are still the reason for the element choice

### Testing

No tests assert on this component's styles. Verified on the stack:

- `pnpm lint`, `pnpm build` pass; the rule lands in `packages/sanity/lib/bundle.css` verbatim
- Headless-browser assertions against the running dev studio with a portable text diff open in Review changes: computed `text-transform: none`, `overflow-wrap: break-word`, `margin: 0`, and `white-space` computing to `normal` — identical to before, since `white-space: wrap` is the modern alias of `normal` (collapse + wrap) and the applied CSSOM rule carries the declaration
- Manual check of the Review changes pane in the test studio (demo video on the stack's top PR, #14027)

[Portable text diff in review changes rendering through the migrated Paragraph](https://cursor.com/agents/bc-d6c1aa8a-ef0e-4f31-ba52-aac9781dbdf2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_paragraph_pt_diff_review_changes.png)

### Notes for release

N/A – Internal only

---

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6c1aa8a-ef0e-4f31-ba52-aac9781dbdf2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6c1aa8a-ef0e-4f31-ba52-aac9781dbdf2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

