### PR TITLE
fix(structure): show published badge for live edit documents

### DIFF
--- a/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentTargetBadges.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/DocumentTargetBadges.tsx
@@ -9,7 +9,6 @@ import {
   isDraftPerspective,
   isPublishedPerspective,
   isReleaseDocument,
-  isSystemBundle,
   usePerspective,
   useTranslation,
   type SystemVariant,
@@ -19,11 +18,17 @@ import {
 import {styled} from 'styled-components'
 
 import {Tooltip} from '../../../../../ui-components/tooltip/Tooltip'
+import {isLiveEditEnabled} from '../../../../components/paneItem/helpers'
 import {structureLocaleNamespace} from '../../../../i18n'
 import {useDocumentPane} from '../../useDocumentPane'
+import {
+  getBadgeSystemDocument,
+  getTargetBadgePerspective,
+  isTargetBadgeMissing,
+} from './getTargetBadgePerspective'
 
 /**
- * TODO: Replace by the RhombusIcon from @sanity/icons once available.
+ * TODO: Replace by the RhombusIcon from Sanity icons once available.
  */
 function RhombusIcon(props: SVGProps<SVGSVGElement> & RefAttributes<SVGSVGElement>) {
   const {ref, ...rest} = props
@@ -61,24 +66,6 @@ const BadgeContainer = styled(Flex)`
 const BadgeMotionWrapper = styled(motion.div)`
   flex: none;
 `
-
-function isTargetDocumentDefinitivelyMissing(
-  state: TargetDocumentState,
-  bundle: ReturnType<typeof usePerspective>['bundle'],
-): boolean {
-  switch (state.status) {
-    case 'resolving':
-      return false
-    case 'variant-definition-document-not-found':
-      return true
-    case 'variant-missing':
-      return true
-    case 'ready':
-      return !state.targetDocument && !state.variant && !isSystemBundle(bundle)
-    default:
-      return false
-  }
-}
 
 function getSelectedVariantFromState(
   state: TargetDocumentState,
@@ -158,11 +145,17 @@ const VariantBadgeLabel = memo(function VariantBadgeLabel({variant}: {variant: S
 })
 
 export const DocumentTargetBadges = memo(function DocumentTargetBadges() {
-  const {targetDocumentState} = useDocumentPane()
+  const {displayed, schemaType, targetDocumentState} = useDocumentPane()
   const {bundle, selectedPerspective, selectedVariant} = usePerspective()
   const {t} = useTranslation(structureLocaleNamespace)
+  const isLiveEdit = isLiveEditEnabled(schemaType)
 
-  const isTargetMissing = isTargetDocumentDefinitivelyMissing(targetDocumentState, bundle)
+  const badgePerspective = getTargetBadgePerspective({
+    isLiveEdit,
+    selectedPerspective,
+    document: getBadgeSystemDocument(targetDocumentState, displayed),
+  })
+  const isTargetMissing = isTargetBadgeMissing({isLiveEdit, state: targetDocumentState, bundle})
   const badgeOpacity = isTargetMissing ? 0.5 : 1
   const selectedVariantBadge = getSelectedVariantFromState(targetDocumentState, selectedVariant)
 
@@ -174,12 +167,12 @@ export const DocumentTargetBadges = memo(function DocumentTargetBadges() {
       <Flex align="center" flex="none" gap={2} paddingRight={1}>
         <BadgeMotionWrapper animate={{opacity: badgeOpacity}} transition={{duration: 0.2}}>
           <TargetBadge
-            tone={getPerspectiveBadgeTone(selectedPerspective)}
+            tone={getPerspectiveBadgeTone(badgePerspective)}
             border
             radius={4}
             data-ui="DocumentTargetPerspectiveBadge"
           >
-            <PerspectiveBadgeLabel selectedPerspective={selectedPerspective} />
+            <PerspectiveBadgeLabel selectedPerspective={badgePerspective} />
           </TargetBadge>
         </BadgeMotionWrapper>
         {selectedVariantBadge ? (

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/DocumentTargetBadges.test.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/__tests__/DocumentTargetBadges.test.tsx
@@ -1,0 +1,252 @@
+import {type ObjectSchemaType} from '@sanity/types'
+import {render, screen} from '@testing-library/react'
+import {
+  type SystemVariant,
+  type TargetDocumentState,
+  type TargetPerspective,
+  type VersionInfoDocumentStub,
+  usePerspective,
+} from 'sanity'
+import {beforeAll, beforeEach, describe, expect, it, type Mock, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../../../test/testUtils/TestProvider'
+import {useDocumentPane} from '../../../useDocumentPane'
+import {DocumentTargetBadges} from '../DocumentTargetBadges'
+
+vi.mock('sanity', async (importOriginal) => ({
+  ...(await importOriginal()),
+  usePerspective: vi.fn(),
+}))
+
+vi.mock('../../../useDocumentPane')
+
+const mockUsePerspective = usePerspective as Mock<typeof usePerspective>
+const mockUseDocumentPane = useDocumentPane as Mock<typeof useDocumentPane>
+
+const groupRef = {_ref: 'doc-1', _weak: true as const}
+const variantRef = {_ref: '_.variants.alpha-audience', _weak: true as const}
+
+const versionStub = (
+  stub: Pick<VersionInfoDocumentStub, '_id' | '_system'>,
+): VersionInfoDocumentStub => ({
+  _rev: '',
+  _createdAt: '',
+  _updatedAt: '',
+  ...stub,
+})
+
+const publishedDocument = versionStub({
+  _id: 'doc-1',
+  _system: {group: groupRef},
+})
+
+const draftDocument = versionStub({
+  _id: 'drafts.doc-1',
+  _system: {bundleId: 'drafts', group: groupRef},
+})
+
+const publishedVariant = versionStub({
+  _id: 'versions.varscope.doc-1',
+  _system: {
+    variant: variantRef,
+    group: groupRef,
+    scopeId: 'varscope',
+  },
+})
+
+const variantAlphaAudience = {
+  _id: '_.variants.alpha-audience',
+  _type: 'system.variant',
+  _createdAt: '2025-01-01T00:00:00Z',
+  _updatedAt: '2025-01-01T00:00:00Z',
+  _rev: 'rev-alpha',
+  conditions: {audience: 'alpha'},
+  priority: 0,
+  metadata: {title: 'Alpha audience', description: []},
+} as SystemVariant
+
+const releaseDocument = {
+  _id: '_.releases.rSummer',
+  _type: 'system.release',
+  _rev: 'r1',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-01T00:00:00Z',
+  name: 'rSummer',
+  state: 'active' as const,
+  metadata: {title: 'Summer Drop', releaseType: 'asap' as const},
+} as TargetPerspective
+
+const readyState = (
+  targetDocument: VersionInfoDocumentStub | undefined,
+  variant?: SystemVariant,
+): Extract<TargetDocumentState, {status: 'ready'}> => ({
+  status: 'ready',
+  targetDocument,
+  scopeId: targetDocument?._system.scopeId,
+  variant,
+  publishedSibling: variant ? publishedVariant : undefined,
+})
+
+const DEFAULT_PERSPECTIVE = {
+  selectedPerspectiveName: undefined,
+  selectedReleaseId: undefined,
+  selectedPerspective: 'drafts' as const,
+  perspectiveStack: ['drafts'],
+  excludedPerspectives: [],
+  selectedVariantName: undefined,
+  selectedVariant: undefined,
+  bundle: 'drafts' as const,
+}
+
+function schemaType(liveEdit: boolean): ObjectSchemaType {
+  return {name: 'author', jsonType: 'object', liveEdit} as ObjectSchemaType
+}
+
+function mockPane({
+  liveEdit,
+  displayed,
+  targetDocumentState,
+}: {
+  liveEdit: boolean
+  displayed?: VersionInfoDocumentStub
+  targetDocumentState: TargetDocumentState
+}) {
+  mockUseDocumentPane.mockReturnValue({
+    displayed: displayed ?? publishedDocument,
+    schemaType: schemaType(liveEdit),
+    targetDocumentState,
+  } as ReturnType<typeof useDocumentPane>)
+}
+
+let wrapper: React.ComponentType<{children: React.ReactNode}>
+
+beforeAll(async () => {
+  wrapper = await createTestProvider()
+})
+
+describe('DocumentTargetBadges', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUsePerspective.mockReturnValue(DEFAULT_PERSPECTIVE)
+  })
+
+  it('shows Drafts for non-live-edit documents in the drafts perspective', async () => {
+    mockPane({
+      liveEdit: false,
+      displayed: draftDocument,
+      targetDocumentState: readyState(draftDocument),
+    })
+
+    render(<DocumentTargetBadges />, {wrapper})
+
+    expect(await screen.findByText('Drafts')).toBeInTheDocument()
+  })
+
+  it('shows Published for non-live-edit documents in the published perspective', async () => {
+    mockUsePerspective.mockReturnValue({
+      ...DEFAULT_PERSPECTIVE,
+      selectedPerspectiveName: 'published',
+      selectedPerspective: 'published',
+      perspectiveStack: ['published'],
+      bundle: 'published',
+    })
+    mockPane({
+      liveEdit: false,
+      displayed: publishedDocument,
+      targetDocumentState: readyState(publishedDocument),
+    })
+
+    render(<DocumentTargetBadges />, {wrapper})
+
+    expect(await screen.findByText('Published')).toBeInTheDocument()
+  })
+
+  it('shows Published for live-edit documents with published _system while drafts is selected', async () => {
+    mockPane({
+      liveEdit: true,
+      displayed: publishedDocument,
+      targetDocumentState: readyState(undefined),
+    })
+
+    render(<DocumentTargetBadges />, {wrapper})
+
+    expect(await screen.findByText('Published')).toBeInTheDocument()
+    expect(screen.queryByText('Drafts')).not.toBeInTheDocument()
+  })
+
+  it('shows Drafts for live-edit documents whose _system.bundleId is drafts', async () => {
+    mockPane({
+      liveEdit: true,
+      displayed: draftDocument,
+      targetDocumentState: readyState(draftDocument),
+    })
+
+    render(<DocumentTargetBadges />, {wrapper})
+
+    expect(await screen.findByText('Drafts')).toBeInTheDocument()
+  })
+
+  it('keeps the release title for live-edit documents in a release perspective', async () => {
+    mockUsePerspective.mockReturnValue({
+      ...DEFAULT_PERSPECTIVE,
+      selectedPerspectiveName: 'rSummer',
+      selectedReleaseId: 'rSummer',
+      selectedPerspective: releaseDocument,
+      perspectiveStack: ['rSummer', 'drafts'],
+      bundle: 'rSummer',
+    })
+    mockPane({
+      liveEdit: true,
+      displayed: publishedDocument,
+      targetDocumentState: readyState(undefined),
+    })
+
+    render(<DocumentTargetBadges />, {wrapper})
+
+    expect(await screen.findByText('Summer Drop')).toBeInTheDocument()
+  })
+
+  it('shows Published and the variant badge for a published live-edit variant', async () => {
+    mockUsePerspective.mockReturnValue({
+      ...DEFAULT_PERSPECTIVE,
+      selectedVariantName: 'alpha-audience',
+      selectedVariant: variantAlphaAudience,
+    })
+    mockPane({
+      liveEdit: true,
+      displayed: publishedVariant,
+      targetDocumentState: readyState(publishedVariant, variantAlphaAudience),
+    })
+
+    render(<DocumentTargetBadges />, {wrapper})
+
+    expect(await screen.findByText('Published')).toBeInTheDocument()
+    expect(screen.getByText('Alpha audience')).toBeInTheDocument()
+  })
+
+  it('shows Published without dimming when a live-edit variant is missing but a published sibling exists', async () => {
+    mockUsePerspective.mockReturnValue({
+      ...DEFAULT_PERSPECTIVE,
+      selectedVariantName: 'alpha-audience',
+      selectedVariant: variantAlphaAudience,
+    })
+    mockPane({
+      liveEdit: true,
+      displayed: publishedDocument,
+      targetDocumentState: {
+        status: 'variant-missing',
+        variant: variantAlphaAudience,
+        bundle: 'drafts',
+        publishedSibling: publishedVariant,
+      },
+    })
+
+    render(<DocumentTargetBadges />, {wrapper})
+
+    expect(await screen.findByText('Published')).toBeInTheDocument()
+    expect(screen.getByText('Alpha audience')).toBeInTheDocument()
+    expect(
+      screen.queryByText("Document doesn't exist in the selected perspective yet."),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/getTargetBadgePerspective.test.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/getTargetBadgePerspective.test.ts
@@ -1,0 +1,223 @@
+import {
+  type SystemVariant,
+  type TargetDocumentState,
+  type TargetPerspective,
+  type VersionInfoDocumentStub,
+} from 'sanity'
+import {describe, expect, it} from 'vitest'
+
+import {
+  getBadgeSystemDocument,
+  getTargetBadgePerspective,
+  isTargetBadgeMissing,
+} from './getTargetBadgePerspective'
+
+const groupRef = {_ref: 'doc-1', _weak: true as const}
+const variantRef = {_ref: '_.variants.alpha-audience', _weak: true as const}
+
+const versionStub = (
+  stub: Pick<VersionInfoDocumentStub, '_id' | '_system'>,
+): VersionInfoDocumentStub => ({
+  _rev: '',
+  _createdAt: '',
+  _updatedAt: '',
+  ...stub,
+})
+
+const publishedDocument = versionStub({
+  _id: 'doc-1',
+  _system: {group: groupRef},
+})
+
+const draftDocument = versionStub({
+  _id: 'drafts.doc-1',
+  _system: {bundleId: 'drafts', group: groupRef},
+})
+
+const publishedVariant = versionStub({
+  _id: 'versions.varscope.doc-1',
+  _system: {
+    variant: variantRef,
+    group: groupRef,
+    scopeId: 'varscope',
+  },
+})
+
+const draftVariant = versionStub({
+  _id: 'versions.varscopeDraft.doc-1',
+  _system: {
+    bundleId: 'drafts',
+    variant: variantRef,
+    group: groupRef,
+    scopeId: 'varscopeDraft',
+  },
+})
+
+const variantAlphaAudience = {
+  _id: '_.variants.alpha-audience',
+  _type: 'system.variant',
+  _createdAt: '2025-01-01T00:00:00Z',
+  _updatedAt: '2025-01-01T00:00:00Z',
+  _rev: 'rev-alpha',
+  conditions: {audience: 'alpha'},
+  priority: 0,
+  metadata: {title: 'Alpha audience', description: []},
+} as SystemVariant
+
+const releasePerspective = {
+  _id: '_.releases.rSummer',
+  _type: 'system.release',
+  _rev: 'r1',
+  _createdAt: '2024-01-01T00:00:00Z',
+  _updatedAt: '2024-01-01T00:00:00Z',
+  name: 'rSummer',
+  state: 'active',
+  metadata: {title: 'Summer', releaseType: 'asap'},
+} as TargetPerspective
+
+const readyState = (
+  targetDocument: VersionInfoDocumentStub | undefined,
+): Extract<TargetDocumentState, {status: 'ready'}> => ({
+  status: 'ready',
+  targetDocument,
+  scopeId: targetDocument?._system.scopeId,
+  variant: undefined,
+  publishedSibling: undefined,
+})
+
+const variantMissingState = (
+  publishedSibling: VersionInfoDocumentStub | undefined,
+): Extract<TargetDocumentState, {status: 'variant-missing'}> => ({
+  status: 'variant-missing',
+  variant: variantAlphaAudience,
+  bundle: 'drafts',
+  publishedSibling,
+})
+
+describe('getTargetBadgePerspective', () => {
+  it('mirrors the selected perspective for non-live-edit documents', () => {
+    expect(
+      getTargetBadgePerspective({
+        isLiveEdit: false,
+        selectedPerspective: 'drafts',
+        document: publishedDocument,
+      }),
+    ).toBe('drafts')
+
+    expect(
+      getTargetBadgePerspective({
+        isLiveEdit: false,
+        selectedPerspective: 'published',
+        document: publishedDocument,
+      }),
+    ).toBe('published')
+  })
+
+  it('shows published for live-edit documents with no bundleId while drafts is selected', () => {
+    expect(
+      getTargetBadgePerspective({
+        isLiveEdit: true,
+        selectedPerspective: 'drafts',
+        document: publishedDocument,
+      }),
+    ).toBe('published')
+  })
+
+  it('shows drafts for live-edit documents whose _system.bundleId is drafts', () => {
+    expect(
+      getTargetBadgePerspective({
+        isLiveEdit: true,
+        selectedPerspective: 'drafts',
+        document: draftDocument,
+      }),
+    ).toBe('drafts')
+  })
+
+  it('treats a live-edit document with no _system as published', () => {
+    expect(
+      getTargetBadgePerspective({
+        isLiveEdit: true,
+        selectedPerspective: 'drafts',
+        document: {},
+      }),
+    ).toBe('published')
+  })
+
+  it('does not override a selected release perspective', () => {
+    expect(
+      getTargetBadgePerspective({
+        isLiveEdit: true,
+        selectedPerspective: releasePerspective,
+        document: publishedDocument,
+      }),
+    ).toBe(releasePerspective)
+  })
+
+  it('classifies a published live-edit variant as published', () => {
+    expect(
+      getTargetBadgePerspective({
+        isLiveEdit: true,
+        selectedPerspective: 'drafts',
+        document: publishedVariant,
+      }),
+    ).toBe('published')
+  })
+
+  it('classifies a draft live-edit variant as drafts', () => {
+    expect(
+      getTargetBadgePerspective({
+        isLiveEdit: true,
+        selectedPerspective: 'drafts',
+        document: draftVariant,
+      }),
+    ).toBe('drafts')
+  })
+})
+
+describe('getBadgeSystemDocument', () => {
+  it('prefers the ready target document', () => {
+    expect(getBadgeSystemDocument(readyState(draftDocument), publishedDocument)).toBe(draftDocument)
+  })
+
+  it('uses the published sibling when the variant is missing', () => {
+    expect(getBadgeSystemDocument(variantMissingState(publishedVariant), publishedDocument)).toBe(
+      publishedVariant,
+    )
+  })
+
+  it('falls back to the displayed document', () => {
+    expect(getBadgeSystemDocument(readyState(undefined), publishedDocument)).toBe(publishedDocument)
+  })
+})
+
+describe('isTargetBadgeMissing', () => {
+  it('does not dim live-edit variant-missing when a published sibling exists', () => {
+    expect(
+      isTargetBadgeMissing({
+        isLiveEdit: true,
+        bundle: 'drafts',
+        state: variantMissingState(publishedVariant),
+      }),
+    ).toBe(false)
+  })
+
+  it('dims variant-missing for non-live-edit documents', () => {
+    expect(
+      isTargetBadgeMissing({
+        isLiveEdit: false,
+        bundle: 'drafts',
+        state: variantMissingState(publishedVariant),
+      }),
+    ).toBe(true)
+  })
+
+  it('does not dim a ready live-edit document in a system bundle with no target', () => {
+    expect(
+      isTargetBadgeMissing({
+        isLiveEdit: true,
+        bundle: 'drafts',
+        state: readyState(undefined),
+      }),
+    ).toBe(false)
+  })
+})

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/getTargetBadgePerspective.test.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/getTargetBadgePerspective.test.ts
@@ -87,10 +87,11 @@ const readyState = (
 
 const variantMissingState = (
   publishedSibling: VersionInfoDocumentStub | undefined,
+  bundle: 'drafts' | 'published' | (string & {}) = 'drafts',
 ): Extract<TargetDocumentState, {status: 'variant-missing'}> => ({
   status: 'variant-missing',
   variant: variantAlphaAudience,
-  bundle: 'drafts',
+  bundle,
   publishedSibling,
 })
 
@@ -199,6 +200,16 @@ describe('isTargetBadgeMissing', () => {
         state: variantMissingState(publishedVariant),
       }),
     ).toBe(false)
+  })
+
+  it('dims live-edit variant-missing in a release even when a published sibling exists', () => {
+    expect(
+      isTargetBadgeMissing({
+        isLiveEdit: true,
+        bundle: 'rSummer',
+        state: variantMissingState(publishedVariant, 'rSummer'),
+      }),
+    ).toBe(true)
   })
 
   it('dims variant-missing for non-live-edit documents', () => {

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/getTargetBadgePerspective.test.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/getTargetBadgePerspective.test.ts
@@ -144,6 +144,16 @@ describe('getTargetBadgePerspective', () => {
     ).toBe('published')
   })
 
+  it('treats a live-edit document whose _system.bundleId is null as published', () => {
+    expect(
+      getTargetBadgePerspective({
+        isLiveEdit: true,
+        selectedPerspective: 'drafts',
+        document: {_system: {bundleId: null, group: groupRef}},
+      }),
+    ).toBe('published')
+  })
+
   it('does not override a selected release perspective', () => {
     expect(
       getTargetBadgePerspective({

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/getTargetBadgePerspective.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/getTargetBadgePerspective.ts
@@ -1,0 +1,101 @@
+import {type DocumentSystem} from '@sanity/types'
+import {
+  isDraftPerspective,
+  isPublishedPerspective,
+  isSystemBundle,
+  type TargetDocumentState,
+  type TargetPerspective,
+} from 'sanity'
+
+/**
+ * A document (or version stub) that may carry `_system` metadata used to
+ * distinguish published vs draft for live-edit badge labeling.
+ */
+export type BadgeSystemDocument = {
+  _system?: Partial<DocumentSystem>
+}
+
+/**
+ * Picks the document whose `_system` should drive the live-edit header badge:
+ * the resolved target, the published variant sibling when the drafts-bundle
+ * variant is missing, or the currently displayed document.
+ */
+export function getBadgeSystemDocument(
+  state: TargetDocumentState,
+  displayed: BadgeSystemDocument | null | undefined,
+): BadgeSystemDocument | undefined {
+  if (state.status === 'ready' && state.targetDocument) {
+    return state.targetDocument
+  }
+
+  if (state.status === 'variant-missing' && state.publishedSibling) {
+    return state.publishedSibling
+  }
+
+  return displayed ?? undefined
+}
+
+/**
+ * Resolves the perspective the document-pane target badge should display.
+ *
+ * Non-live-edit documents mirror the selected perspective. Live-edit documents
+ * in a system bundle (`drafts` / `published`) are classified from `_system.bundleId`
+ * so a published live-edit doc is not labeled "Drafts" just because the studio
+ * is pinned to the drafts perspective.
+ */
+export function getTargetBadgePerspective({
+  isLiveEdit,
+  selectedPerspective,
+  document,
+}: {
+  isLiveEdit: boolean
+  selectedPerspective: TargetPerspective
+  document: BadgeSystemDocument | undefined
+}): TargetPerspective {
+  if (!isLiveEdit) {
+    return selectedPerspective
+  }
+
+  if (!isDraftPerspective(selectedPerspective) && !isPublishedPerspective(selectedPerspective)) {
+    return selectedPerspective
+  }
+
+  const bundleId = document?._system?.bundleId
+  if (bundleId === 'drafts') {
+    return 'drafts'
+  }
+
+  if (typeof bundleId === 'undefined') {
+    return 'published'
+  }
+
+  return selectedPerspective
+}
+
+/**
+ * Whether the target badge should appear dimmed (document does not exist in the
+ * selected perspective). Live-edit documents that fall back to a published
+ * variant sibling are not treated as missing.
+ */
+export function isTargetBadgeMissing({
+  isLiveEdit,
+  state,
+  bundle,
+}: {
+  isLiveEdit: boolean
+  state: TargetDocumentState
+  bundle: 'published' | 'drafts' | (string & {})
+}): boolean {
+  switch (state.status) {
+    case 'resolving':
+      return false
+    case 'variant-definition-document-not-found':
+      return true
+    case 'variant-missing':
+      return !(isLiveEdit && Boolean(state.publishedSibling))
+    case 'ready':
+      return !state.targetDocument && !state.variant && !isSystemBundle(bundle)
+    default:
+      return false
+  }
+}

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/getTargetBadgePerspective.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/getTargetBadgePerspective.ts
@@ -74,8 +74,9 @@ export function getTargetBadgePerspective({
 
 /**
  * Whether the target badge should appear dimmed (document does not exist in the
- * selected perspective). Live-edit documents that fall back to a published
- * variant sibling are not treated as missing.
+ * selected perspective). Live-edit documents in a system bundle (`drafts` /
+ * `published`) that fall back to a published variant sibling are not treated as
+ * missing. Release and agent bundles still dim when the variant is absent.
  */
 export function isTargetBadgeMissing({
   isLiveEdit,
@@ -92,7 +93,7 @@ export function isTargetBadgeMissing({
     case 'variant-definition-document-not-found':
       return true
     case 'variant-missing':
-      return !(isLiveEdit && Boolean(state.publishedSibling))
+      return !(isLiveEdit && Boolean(state.publishedSibling) && isSystemBundle(bundle))
     case 'ready':
       return !state.targetDocument && !state.variant && !isSystemBundle(bundle)
     default:

--- a/packages/sanity/src/structure/panes/document/documentPanel/header/getTargetBadgePerspective.ts
+++ b/packages/sanity/src/structure/panes/document/documentPanel/header/getTargetBadgePerspective.ts
@@ -12,7 +12,10 @@ import {
  * distinguish published vs draft for live-edit badge labeling.
  */
 export type BadgeSystemDocument = {
-  _system?: Partial<DocumentSystem>
+  // The Content Lake may serialize published `_system.bundleId` as `null`.
+  _system?: Partial<Omit<DocumentSystem, 'bundleId'>> & {
+    bundleId?: DocumentSystem['bundleId'] | null
+  }
 }
 
 /**
@@ -65,7 +68,7 @@ export function getTargetBadgePerspective({
     return 'drafts'
   }
 
-  if (typeof bundleId === 'undefined') {
+  if (bundleId == null) {
     return 'published'
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Live-edit documents are edited on the published record, but the studio’s default perspective is still drafts. The document-group inventory header badge labeled from perspective only, so a live document showed **Drafts** while the footer correctly said **Live**.

Classification uses `_system.bundleId` rather than always forcing Published, so leftover drafts and live-edit variants still show the right bundle. The older chip list is unchanged; it already selects Published for live-edit.

### What to review

- `getTargetBadgePerspective` — live-edit override only for system bundles (`drafts` / `published`); release/agent perspectives stay as-is
- Variant-missing dimming: live-edit + published sibling is not treated as missing
- Package: `sanity` (structure document pane header)

### Testing

Unit tests (20 passing) cover non-live-edit drafts/published, live-edit published and leftover draft, release perspective, published variants, and variant-missing with a published sibling.

### Notes for release

n/a part of variants work
---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55f09278-dfd2-4ab6-ae7c-74dfdf459ec7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55f09278-dfd2-4ab6-ae7c-74dfdf459ec7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

