### PR TITLE
fix(structure): keep manage versions when document has no actions

### DIFF
--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.test.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.test.tsx
@@ -1,0 +1,127 @@
+import {render, screen} from '@testing-library/react'
+import {type ComponentType} from 'react'
+import {EMPTY} from 'rxjs'
+import {DocumentActionsStateContext} from 'sanity/_singletons'
+import {beforeAll, beforeEach, describe, expect, it, type MockedFunction, vi} from 'vitest'
+
+import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
+import {usePaneRouter} from '../../../components/paneRouter/usePaneRouter'
+import {type ResolvedAction} from '../../../components/RenderActionCollectionState'
+import {useDocumentPerspectiveList} from '../../../hooks/useDocumentPerspectiveList'
+import {structureUsEnglishLocaleBundle} from '../../../i18n'
+import {type DocumentPaneContextValue} from '../DocumentPaneContext'
+import {useDocumentPane} from '../useDocumentPane'
+import {DocumentStatusBarActions} from './DocumentStatusBarActions'
+
+vi.mock('sanity', async (importOriginal) => ({
+  ...(await importOriginal()),
+  DocumentGroupInventoryAction: () => (
+    <button type="button" data-testid="action-document-group-inventory">
+      Manage versions
+    </button>
+  ),
+  DocumentGroupInventory: () => null,
+  usePausedScheduledDraft: vi.fn(() => ({isPaused: false, currentRelease: undefined})),
+}))
+
+vi.mock('../useDocumentPane', () => ({
+  useDocumentPane: vi.fn(),
+}))
+
+vi.mock('../../../components/paneRouter/usePaneRouter', () => ({
+  usePaneRouter: vi.fn(() => ({
+    params: {},
+    setParams: vi.fn(),
+  })),
+}))
+
+vi.mock('../../../hooks/useDocumentPerspectiveList', () => ({
+  useDocumentPerspectiveList: vi.fn(() => ({})),
+}))
+
+vi.mock('../../../components/confirmDeleteDialog/useReferringDocuments', () => ({
+  referringDocuments: vi.fn(() => EMPTY),
+}))
+
+const mockUseDocumentPane = useDocumentPane as MockedFunction<typeof useDocumentPane>
+const mockUsePaneRouter = usePaneRouter as MockedFunction<typeof usePaneRouter>
+const mockUseDocumentPerspectiveList = useDocumentPerspectiveList as MockedFunction<
+  typeof useDocumentPerspectiveList
+>
+
+const PUBLISH_ACTION: ResolvedAction = {
+  label: 'Publish',
+  onHandle: vi.fn(),
+  action: 'publish',
+}
+
+function buildDocumentPaneValue(
+  overrides: Partial<DocumentPaneContextValue> = {},
+): DocumentPaneContextValue {
+  return {
+    displayed: {_id: 'doc-123', _type: 'author'},
+    documentId: 'doc-123',
+    documentType: 'author',
+    connectionState: 'connected',
+    isDocumentGroupInventoryActive: false,
+    setIsDocumentGroupInventoryActive: vi.fn(),
+    editState: {
+      id: 'doc-123',
+      type: 'author',
+      transactionSyncLock: {enabled: false},
+      liveEdit: false,
+      ready: true,
+      draft: {_id: 'drafts.doc-123', _type: 'author'},
+      published: {_id: 'doc-123', _type: 'author'},
+      version: undefined,
+    },
+    ...overrides,
+  } as DocumentPaneContextValue
+}
+
+let TestProvider: ComponentType<{children: React.ReactNode}>
+
+function renderActions(states: ResolvedAction[]) {
+  return render(
+    <DocumentActionsStateContext.Provider value={states}>
+      <DocumentStatusBarActions />
+    </DocumentActionsStateContext.Provider>,
+    {wrapper: TestProvider},
+  )
+}
+
+beforeAll(async () => {
+  TestProvider = await createTestProvider({
+    resources: [structureUsEnglishLocaleBundle],
+    config: {
+      beta: {
+        documentGroupInventory: {enabled: true},
+      },
+    },
+  })
+})
+
+describe('DocumentStatusBarActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseDocumentPane.mockReturnValue(buildDocumentPaneValue())
+    mockUsePaneRouter.mockReturnValue({params: {}, setParams: vi.fn()} as never)
+    mockUseDocumentPerspectiveList.mockReturnValue({} as never)
+  })
+
+  it('renders Manage versions when the document has no actions', () => {
+    renderActions([])
+
+    expect(screen.getByTestId('action-document-group-inventory')).toBeInTheDocument()
+    expect(screen.queryByTestId('action-publish')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('action-menu-button')).not.toBeInTheDocument()
+  })
+
+  it('renders the primary action when actions are present', () => {
+    renderActions([PUBLISH_ACTION])
+
+    expect(screen.getByTestId('action-document-group-inventory')).toBeInTheDocument()
+    expect(screen.getByTestId('action-publish')).toBeInTheDocument()
+    expect(screen.queryByTestId('action-menu-button')).not.toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx
@@ -200,8 +200,6 @@ function RenderDocumentStatusBarActions(props: {states: ResolvedAction[]}) {
     state.action ? state.action !== useHistoryRestoreAction.action : true,
   )
 
-  if (states.length === 0) return null
-
   return (
     <DocumentStatusBarActionsInner
       // Use document ID as key to make sure that the actions state is reset when the document changes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Documents with no resolved actions (empty `document.actions`, or every action hook returning null) skipped the entire footer actions cluster. Manage versions lives in that cluster, so it disappeared even when the document had versions to manage.

Always mount the footer actions inner. The primary action button and overflow menu already hide themselves when `states` is empty, so we do not add extra gating.

Why not move Manage versions out of the actions cluster: that would duplicate layout/portal wiring and still leave tasks footer actions with the same empty-states hole.

### What to review

- [`packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx`](packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.tsx): removed the `states.length === 0` early return
- New jsdom coverage in [`DocumentStatusBarActions.test.tsx`](packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.test.tsx)

Package: `sanity` (structure document footer)

### Testing

- `pnpm vitest run --project=sanity packages/sanity/src/structure/panes/document/statusBar/DocumentStatusBarActions.test.tsx`
- Empty actions: Manage versions still renders; Publish and the overflow menu do not
- With a Publish action: Manage versions and Publish both render

### Notes for release

When a document has no document actions, the **Manage versions** button in the document footer still appears if versions exist. The Publish/overflow action buttons stay hidden when there is nothing to show.

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98fb9b78-dcf2-454e-8d33-ff76d1582b52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98fb9b78-dcf2-454e-8d33-ff76d1582b52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

