### PR TITLE
fix(core): record a resolvable schema type name at copy time

### DIFF
--- a/packages/sanity/src/core/studio/copyPaste/CopyPasteProvider.tsx
+++ b/packages/sanity/src/core/studio/copyPaste/CopyPasteProvider.tsx
@@ -20,7 +20,7 @@ import {useCurrentUser} from '../../store/user/hooks'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
 import {getPublishedId} from '../../util/draftUtils'
 import {FieldCopied, FieldPasted} from './__telemetry__/copyPaste.telemetry'
-import {resolveSchemaTypeForPath} from './resolveSchemaTypeForPath'
+import {getResolvableTypeName, resolveSchemaTypeForPath} from './resolveSchemaTypeForPath'
 import {transferValue, type TransferValueOptions} from './transferValue'
 import {
   type CopyOptions,
@@ -119,7 +119,7 @@ export const CopyPasteProvider: React.FC<{
         documentId,
         documentType,
         isDocument,
-        schemaTypeName: schemaTypeAtPath.name,
+        schemaTypeName: getResolvableTypeName(schema, schemaTypeAtPath),
         valuePath: normalizedPath,
         value: shouldWrapInArray ? [valueAtPath] : valueAtPath,
         patchType,
@@ -152,7 +152,7 @@ export const CopyPasteProvider: React.FC<{
         }
       }
     },
-    [documentMeta, telemetry, toast, t],
+    [documentMeta, schema, telemetry, toast, t],
   )
 
   const onPaste = useCallback(
@@ -211,11 +211,13 @@ export const CopyPasteProvider: React.FC<{
       const updateItems: {patches: FormPatch[]; targetSchemaTypeTitle: string}[] = []
       const copiedJsonTypes: string[] = []
 
-      const sourceSchemaType = resolveSchemaTypeForPath(
-        sourceDocumentSchemaType,
-        clipboardItem.valuePath,
-        value,
-      )
+      // The name recorded at copy time is guaranteed to resolve to the copied type (or,
+      // for inline types, its nearest registered parent type) — see getResolvableTypeName.
+      // Note that the source path recorded on the clipboard cannot be resolved here
+      // instead: paths with key segments require the source document value, and the
+      // source `_key`s don't exist in the target document when pasting across documents
+      // (https://github.com/sanity-io/sanity/issues/13983)
+      const sourceSchemaType = schema.get(clipboardItem.schemaTypeName)
 
       if (!sourceSchemaType) {
         toast.push({

--- a/packages/sanity/src/core/studio/copyPaste/__test__/useCopyPaste.test.tsx
+++ b/packages/sanity/src/core/studio/copyPaste/__test__/useCopyPaste.test.tsx
@@ -1037,6 +1037,149 @@ describe('useCopyPaste', () => {
     )
   })
 
+  it('should record a resolvable schema type name when copying fields nested inside arrays', async () => {
+    const result = await setupUseCopyPaste()
+
+    setupClipboard()
+
+    act(() => {
+      result.current.setDocumentMeta({
+        documentId: 'doc1',
+        documentType: 'editor',
+        schemaType: schema.get('editor')! as ObjectSchemaType,
+        onChange: mockOnChange,
+      })
+    })
+
+    await act(async () => {
+      await result.current.onCopy(
+        ['arrayOfPredefinedOptions', {_key: 'blue'}, 'title'],
+        {
+          _type: 'editor',
+          _id: 'doc1',
+          arrayOfPredefinedOptions: [{_type: 'color', _key: 'blue', title: 'Blue', name: 'blue'}],
+        },
+        {
+          context: {source: 'fieldAction'},
+        },
+      )
+    })
+
+    expect(await getClipboardItem()).toEqual({
+      type: 'sanityClipboardItem',
+      documentId: 'doc1',
+      documentType: 'editor',
+      isDocument: false,
+      schemaTypeName: 'string',
+      valuePath: ['arrayOfPredefinedOptions', {_key: 'blue'}, 'title'],
+      value: 'Blue',
+      patchType: 'replace',
+    })
+  })
+
+  it('should record the nearest registered type name when copying items of inline array member types', async () => {
+    const result = await setupUseCopyPaste()
+
+    setupClipboard()
+
+    act(() => {
+      result.current.setDocumentMeta({
+        documentId: 'doc1',
+        documentType: 'editor',
+        schemaType: schema.get('editor')! as ObjectSchemaType,
+        onChange: mockOnChange,
+      })
+    })
+
+    await act(async () => {
+      await result.current.onCopy(
+        ['arrayOfPredefinedOptions', {_key: 'blue'}],
+        {
+          _type: 'editor',
+          _id: 'doc1',
+          arrayOfPredefinedOptions: [{_type: 'color', _key: 'blue', title: 'Blue', name: 'blue'}],
+        },
+        {
+          context: {source: 'arrayItem'},
+        },
+      )
+    })
+
+    // The `color` member type is declared inline on the array, so its name is not
+    // resolvable through `schema.get()` (and could even collide with an unrelated
+    // registered type of the same name) — the nearest registered parent type is
+    // recorded instead
+    expect(await getClipboardItem()).toEqual({
+      type: 'sanityClipboardItem',
+      documentId: 'doc1',
+      documentType: 'editor',
+      isDocument: false,
+      schemaTypeName: 'object',
+      valuePath: ['arrayOfPredefinedOptions'],
+      value: [{_type: 'color', _key: 'blue', title: 'Blue', name: 'blue'}],
+      patchType: 'append',
+    })
+  })
+
+  it('should handle pasting a field nested inside an array item into another document', async () => {
+    const result = await setupUseCopyPaste()
+
+    // Copied from doc1, where the array item has _key 'source-key'. That key does not
+    // exist in the target document, which used to break source schema type resolution
+    // on paste (https://github.com/sanity-io/sanity/issues/13983)
+    const mockClipboardItem: SanityClipboardItem = {
+      type: 'sanityClipboardItem',
+      documentId: 'doc1',
+      documentType: 'editor',
+      isDocument: false,
+      schemaTypeName: 'string',
+      valuePath: ['arrayOfPredefinedOptions', {_key: 'source-key'}, 'title'],
+      value: 'Red',
+      patchType: 'replace',
+    }
+
+    await setupMockClipboardRead(mockClipboardItem)
+
+    act(() => {
+      result.current.setDocumentMeta({
+        documentId: 'doc2',
+        documentType: 'editor',
+        schemaType: schema.get('editor')! as ObjectSchemaType,
+        onChange: mockOnChange,
+      })
+    })
+
+    await act(async () => {
+      await result.current.onPaste(
+        ['arrayOfPredefinedOptions', {_key: 'target-key'}, 'title'],
+        {
+          _type: 'editor',
+          _id: 'doc2',
+          arrayOfPredefinedOptions: [
+            {_type: 'color', _key: 'target-key', title: 'Blue', name: 'blue'},
+          ],
+        },
+        {
+          context: {source: 'fieldAction'},
+        },
+      )
+    })
+
+    expect(mockToast.push).not.toHaveBeenCalledWith(expect.objectContaining({status: 'error'}))
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        patches: [
+          expect.objectContaining({
+            type: 'set',
+            patchType: expect.any(Symbol),
+            path: ['arrayOfPredefinedOptions', {_key: 'target-key'}, 'title'],
+            value: 'Red',
+          }),
+        ],
+      }),
+    )
+  })
+
   it('should handle pasting between incompatible types', async () => {
     const result = await setupUseCopyPaste()
 

--- a/packages/sanity/src/core/studio/copyPaste/resolveSchemaTypeForPath.ts
+++ b/packages/sanity/src/core/studio/copyPaste/resolveSchemaTypeForPath.ts
@@ -6,6 +6,7 @@ import {
   type ObjectField,
   type ObjectSchemaType,
   type Path,
+  type Schema,
   type SchemaType,
 } from '@sanity/types'
 import {fromString, toString} from '@sanity/util/paths'
@@ -35,6 +36,21 @@ function getSchemaField(schemaType: SchemaType, fieldPath: string): ObjectField 
   }
 
   return undefined
+}
+
+/**
+ * Returns the name of the nearest type in the parent type chain that resolves back to
+ * that same type through `schema.get()` — or the core type at the root of the chain.
+ * Inline types carry names that are either not registered or, worse, can collide with an
+ * unrelated top-level type of the same name, so their name cannot be recorded on the
+ * clipboard and looked up again at paste time.
+ */
+export function getResolvableTypeName(schema: Schema, schemaType: SchemaType): string {
+  let current: SchemaType = schemaType
+  while (current.type && schema.get(current.name) !== current) {
+    current = current.type
+  }
+  return current.name
 }
 
 export function resolveSchemaTypeForPath(


### PR DESCRIPTION
### Description

Copying a field nested inside an array item and pasting it into the equivalent field in another document always failed with "Source and target schema types are not compatible" (fixes #13983). At paste time, the source schema type was re-resolved by walking the clipboard's source path over the *target* document value — key segments need the item value to determine the array member type, and the source `_key`s don't exist in the target document, so resolution silently returned the enclosing array type instead of the field type.

The fix records a schema type name at copy time that is guaranteed to resolve through `schema.get()` at paste time, and uses that instead of re-resolving the path. Inline types carry names that are unregistered — or could collide with an unrelated top-level type of the same name — so for those, the nearest registered parent type is recorded instead (found by walking the parent-type chain). The clipboard payload format is unchanged. This is safe because `transferValue` only consults the source type for jsonType-level compatibility plus the image/file and number→string checks; value collation is entirely driven by the target schema type.

Alternatives considered:

- Annotating clipboard path key segments with each array item's `_type` — rejected to keep the clipboard payload format untouched.
- Requiring structural compatibility only (derive the source side from the raw clipboard value, no source type resolution at all) — the better long-term design, but a larger `transferValue` refactor; planned as a follow-up, together with a confirmation step for pastes with partial structural overlap.

Thanks @nhIOD for the detailed analysis in #13983, which this fix builds on.

### What to review

- `getResolvableTypeName` in `resolveSchemaTypeForPath.ts` — it relies on registered types having stable identity in the schema registry (`schema.get(name)` returns the memoized instance that member/field types link to via `.type`, and core types are stable singletons or chain roots).
- `CopyPasteProvider.onPaste` no longer resolves the source path at all. Payloads written by older studio versions carrying an unresolvable inline type name now get a clear "incompatible" error toast; previously those mis-resolved silently and only worked for same-document pastes.
- Only the `sanity` package is affected.

### Testing

Three new tests: the cross-document paste repro from #13983, a copy-side test pinning the recorded type name and unchanged payload shape, and a test showing an inline array member type records its nearest registered ancestor (`object`) rather than its unresolvable inline name. The repro and the inline-member test fail against `main`.

### Notes for release

Fixed an issue where using the Copy field action on a field nested inside an array item (for example in a page-builder array) and pasting it into the equivalent field of another document failed with the error "Source and target schema types are not compatible".

---

_This PR was authored by an AI agent (Claude), prompted and reviewed by @bjoerge._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes studio copy/paste type resolution for all pastes, but behavior is narrowly scoped to schema lookup; older clipboard items with unresolvable inline type names may now show an explicit incompatible-type error instead of silent mis-resolution.
> 
> **Overview**
> Fixes **cross-document paste** failing with “Source and target schema types are not compatible” when copying a field nested under an array item (e.g. page-builder blocks). Paste used to re-resolve the source type by walking the clipboard **source path** against the **target** document; `_key` segments need the item value, so source keys missing on the target made resolution fall back to the array type instead of the field type.
> 
> **On copy**, clipboard `schemaTypeName` is now **`getResolvableTypeName(schema, type)`** instead of the raw type name. That walks the parent-type chain until the name is the same instance returned by `schema.get()`—needed because **inline** array member types are not safely re-lookupable (and names can collide with unrelated registered types). For those cases the nearest registered ancestor (e.g. `object`) is stored.
> 
> **On paste**, the source type comes from **`schema.get(clipboardItem.schemaTypeName)`** only; the clipboard path is no longer used for source type resolution. Clipboard payload shape is unchanged. Three tests cover array-nested copy metadata, inline members, and the #13983 cross-document paste case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64b0d8de44b9864d3ab3177852719fd7d4b24a07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->