### PR TITLE
chore(renovate): drop unused v3 preset, use org min-age-3days preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>sanity-io/renovate-config",
-    "github>sanity-io/renovate-config:studio-v3",
+    "github>sanity-io/renovate-config:min-age-3days",
     ":dependencyDashboardApproval"
   ],
   "ignorePresets": [
@@ -12,19 +12,7 @@
   ],
   "branchConcurrentLimit": 3,
   "prConcurrentLimit": 5,
-  "minimumReleaseAge": "3 days",
   "packageRules": [
-    {
-      "description": "Exclude @sanity/* packages from minimumReleaseAge (no delay for internal packages)",
-      "matchPackageNames": [
-        "/^@sanity\\//",
-        "/^@portabletext\\//",
-        "/^react-rx$/",
-        "/^groq-js$/",
-        "/^oxfmt$/"
-      ],
-      "minimumReleaseAge": "0 days"
-    },
     {
       "description": "Enable automerge with GitHub merge queues (note that this doesn't bypass required checks and code reviews)",
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
### Description

Drops unused v3 preset and switches to the org defined min-age-3days preset. The exclude list we used to have should already be captured by the exclude list included by the 3days preset.

The only effect of removing the v3 preset is that renovate may open a PR for react 20 once it is released, but think we can live with that (or inline that rule here)

### What to review
Makes sense?

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
n/a – internal

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only Renovate bot configuration changes; no application runtime or dependency resolution in CI beyond how/when update PRs are opened.
> 
> **Overview**
> **Renovate** config is aligned with the org **min-age-3days** preset instead of maintaining duplicate release-delay rules locally.
> 
> The unused **`studio-v3`** preset is removed from **`extends`**, and the repo-level **`minimumReleaseAge`** setting plus the **`packageRules`** block that zeroed the delay for **`@sanity/*`**, **`@portabletext/*`**, and a few other internal packages are deleted in favor of the shared preset (which is expected to include equivalent exclusions). Automerge, semantic commit, and grouping rules elsewhere in **`.github/renovate.json`** are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d1e8b1ff24afaf67ae7fa19037513f37e191378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->