### PR TITLE
fix(access-ui): submit the request on mod plus enter from the note field

### DIFF
--- a/packages/@sanity/access-ui/src/RequestAccessForm.tsx
+++ b/packages/@sanity/access-ui/src/RequestAccessForm.tsx
@@ -277,6 +277,11 @@ function RequestAccessFormContent(
                 aria-label={labels.noteAriaLabel}
                 disabled={isSubmitting}
                 fontSize={1}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+                    event.currentTarget.form?.requestSubmit()
+                  }
+                }}
                 maxLength={MAX_ACCESS_REQUEST_NOTE_LENGTH}
                 onChange={(event) => setNote(event.currentTarget.value)}
                 placeholder={labels.notePlaceholder}

--- a/packages/@sanity/access-ui/src/__tests__/RequestAccessForm.test.tsx
+++ b/packages/@sanity/access-ui/src/__tests__/RequestAccessForm.test.tsx
@@ -156,6 +156,18 @@ describe('RequestAccessForm', () => {
     expect(await screen.findByRole('link', {name: 'View organizations'})).toBeInTheDocument()
   })
 
+  it('submits on mod+enter from the note field', async () => {
+    const client = createClientStub({
+      submit: () => Promise.resolve(createAccessRequest()),
+    })
+    await renderForm({client})
+
+    const note = await screen.findByRole('textbox', {name: 'Message'})
+    await userEvent.type(note, 'please{Meta>}{Enter}{/Meta}')
+
+    expect(await screen.findByRole('heading', {name: 'Access request sent'})).toBeInTheDocument()
+  })
+
   it('renders the sign-out action only when onSignOut is provided', async () => {
     const onSignOut = vi.fn()
     const {rerender} = await renderForm({onSignOut})


### PR DESCRIPTION
### Description

The old Dashboard form submitted on meta+enter from the note textarea; the shared card silently dropped that when Dashboard migrated (caught by review on sanity-io/ada#3498). Restores it in the card so Studio and Context gain it too, and accepts ctrl+enter for non-mac.

### What to review

The keydown handler on the note TextArea in RequestAccessForm.tsx.

### Testing

One new unit test typing mod+enter into the note field. 35 total.

### Notes for release

Pressing cmd/ctrl+enter in the request-access note field now submits the request.
