### PR TITLE
fix: prevent layout shift when switching field groups in dialog

### DIFF
--- a/packages/sanity/src/core/components/popoverDialog/PopoverDialog.tsx
+++ b/packages/sanity/src/core/components/popoverDialog/PopoverDialog.tsx
@@ -19,9 +19,12 @@ import {PopoverContainer} from './PopoverContainer'
 
 const StyledPopover = styled(Popover)(() => {
   return css`
-    /* Make the popover scrollable if it overflows the viewport */
+    /* Make the popover scrollable if it overflows the viewport.
+     * Reserve space for the scrollbar so content that grows past the viewport
+     * (e.g. when switching tabs) doesn't cause a horizontal layout shift. */
     [data-ui='Popover__wrapper'] {
       overflow: auto;
+      scrollbar-gutter: stable;
     }
   `
 })

--- a/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
+++ b/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
@@ -99,6 +99,16 @@ export function EnhancedObjectDialog(props: PopoverProps | DialogProps): React.J
     path: currentPath,
   })
 
+  // Reserve space for the scrollbar in the dialog's scrollable content element,
+  // so that switching to a tab with overflowing (scrollable) content doesn't
+  // cause a horizontal layout shift when the scrollbar appears.
+  const handleContentRef = useCallback((element: HTMLDivElement | null) => {
+    if (element) {
+      element.style.scrollbarGutter = 'stable'
+    }
+    setDocumentScrollElement(element)
+  }, [])
+
   // Log telemetry when the dialog opens
   useEffect(() => {
     if (stack.length === 0) {
@@ -193,7 +203,7 @@ export function EnhancedObjectDialog(props: PopoverProps | DialogProps): React.J
         <StyledDialog
           $isHidden={!isTop}
           __unstable_autoFocus={isTop ? props.autofocus : false}
-          contentRef={setDocumentScrollElement}
+          contentRef={handleContentRef}
           data-testid="nested-object-dialog"
           header={
             <DialogBreadcrumbs


### PR DESCRIPTION
### Description

Switching to a field group tab with scrolling content in the enhanced object dialog makes the scrollbar steal ~15px of content width, so the tabs and fields jump horizontally (SAPP-4119). Only reproducible with classic scrollbars (Windows, or macOS with "Show scroll bars: Always"). Fixed by reserving the gutter with `scrollbar-gutter: stable` on both scroll containers.

The dialog variant applies it via the `contentRef` callback instead of CSS because `@sanity/ui`'s internal `DialogContent` has no stable selector.

The dialog still resizes vertically between tabs of different heights; that's content-driven auto-sizing and out of scope here.

### What to review

The two touched files in the `sanity` package: the `contentRef` callback in `EnhancedObjectDialog.tsx`, and the `[data-ui='Popover__wrapper']` override in `PopoverDialog.tsx`.

### Testing

Existing `EnhancedObjectDialog` tests pass. No new automated test — jsdom can't reproduce native scrollbar geometry. Verified manually in the test studio with classic scrollbars enabled.

### Notes for release

Fixed a horizontal layout shift in the object editing dialog when switching between field group tabs: the dialog now reserves space for the scrollbar so content stays put. Only affected setups with always-visible scrollbars (e.g. Windows).

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CSS/layout-only change on dialog scroll containers; no auth, data, or API impact.
> 
> **Overview**
> Fixes **horizontal jumping** in the enhanced object editor when switching field group tabs: always-visible scrollbars no longer steal ~15px of content width (SAPP-4119).
> 
> **Popover** dialogs get `scrollbar-gutter: stable` on `[data-ui='Popover__wrapper']`. The **full dialog** variant sets the same on the scrollable content node via a `contentRef` callback (`handleContentRef`), because `@sanity/ui` dialog content has no stable CSS hook.
> 
> Vertical resizing between tabs of different height is unchanged and out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26d728913a293e22850f5e7044cba95c72e27209. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->