### PR TITLE
fix(core): redirect to login after project claim

### DIFF
--- a/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/UnclaimedProjectNudge.tsx
@@ -22,17 +22,13 @@ import {
   type UnclaimedProjectState,
   useUnclaimedProject,
 } from './useUnclaimedProject'
-import {
-  getClaimedIdentityText,
-  getClaimedIdentityTextParts,
-  useUnclaimedProjectCopy,
-} from './useUnclaimedProjectCopy'
+import {useUnclaimedProjectCopy} from './useUnclaimedProjectCopy'
 
 /**
  * Persistent banner + snoozable toast nudging the user to claim a minted-but-unclaimed project
- * before it expires, flipping to an identity-aware login banner once it's claimed. Renders
- * nothing after the claim period or for anything not part of mint-and-claim — see
- * {@link useUnclaimedProject}.
+ * before it expires. Once claimed, the robot session is cleared and the user is sent directly
+ * to login. Renders nothing after the claim period or for anything not part of mint-and-claim —
+ * see {@link useUnclaimedProject}.
  *
  * @internal
  */
@@ -78,7 +74,7 @@ function UnclaimedProjectNudgeInner({
   onClaim: () => void
   state: UnclaimedProjectState
 }) {
-  const {auth, projectId} = useWorkspace()
+  const {projectId} = useWorkspace()
   const copy = useUnclaimedProjectCopy(true)
 
   const unclaimed = state?.status === 'unclaimed' ? state : undefined
@@ -111,13 +107,6 @@ function UnclaimedProjectNudgeInner({
     claimable &&
     claimable.expiresAt.getTime() - now <= copy.criticalThresholdHours * 3_600_000,
   )
-
-  // The claim URL is spent; keep its provenance while the robot token is active so this banner
-  // survives refreshes. Clear it together with the token so a fresh session lands on login.
-  const handleSignIn = useCallback(() => {
-    clearUnclaimedProjectRecord(projectId)
-    void auth.logout?.()
-  }, [auth, projectId])
 
   // Dismissal happens through the snooze button: useConditionalToast re-pushes while enabled,
   // which would defeat a close control.
@@ -179,48 +168,6 @@ function UnclaimedProjectNudgeInner({
 
   if (!copy) return null
 
-  if (state?.status === 'claimed') {
-    return (
-      <Card data-testid="unclaimed-project-banner" tone="positive" padding={3} borderBottom>
-        <Box display={['block', 'block', 'none']}>
-          <Stack gap={3}>
-            <Flex align="center" gap={3} justify="space-between">
-              <Text size={1} weight="medium" style={{flex: 1, minWidth: 0}}>
-                {copy.claimed.text}
-              </Text>
-              <Button
-                mode="default"
-                tone="positive"
-                size="default"
-                text={copy.claimed.signInButtonText}
-                onClick={handleSignIn}
-                style={{flexShrink: 0}}
-              />
-            </Flex>
-            <Text size={1} weight="medium" style={{overflowWrap: 'anywhere'}}>
-              <ClaimedIdentityText text={copy.claimed.identityText} email={state.email} />
-            </Text>
-          </Stack>
-        </Box>
-        <Box display={['none', 'none', 'block']}>
-          <Flex align="center" gap={3} justify="center" wrap="wrap">
-            <Text size={1} weight="medium" style={{overflowWrap: 'anywhere'}}>
-              {copy.claimed.text}{' '}
-              <ClaimedIdentityText text={copy.claimed.identityText} email={state.email} />
-            </Text>
-            <Button
-              mode="default"
-              tone="positive"
-              size="default"
-              text={copy.claimed.signInButtonText}
-              onClick={handleSignIn}
-            />
-          </Flex>
-        </Box>
-      </Card>
-    )
-  }
-
   if (!claimable) return null
 
   return (
@@ -267,20 +214,6 @@ function UnclaimedProjectNudgeInner({
         ) : null}
       </Flex>
     </Card>
-  )
-}
-
-function ClaimedIdentityText({text, email}: {text: string; email?: string}) {
-  const parts = getClaimedIdentityTextParts(text, email)
-
-  return parts ? (
-    <>
-      {parts.before}
-      <strong>{parts.identity}</strong>
-      {parts.after}
-    </>
-  ) : (
-    getClaimedIdentityText(text, email)
   )
 }
 

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/UnclaimedProjectNudge.test.tsx
@@ -69,11 +69,6 @@ const COPY = {
     claimButtonText: 'Claim project',
     snoozeButtonText: 'Remind me later',
   },
-  claimed: {
-    text: 'This project is yours.',
-    identityText: 'Log in as {{identity}}.',
-    signInButtonText: 'Log in',
-  },
   noClaimUrl: {text: 'Open the original claim link.'},
 }
 
@@ -83,7 +78,6 @@ const wrapper = ({children}: {children: ReactNode}) => (
 
 function renderNudge(
   state:
-    | {status: 'claimed'; email?: string}
     | {status: 'expired'}
     | {
         status: 'unclaimed'
@@ -283,24 +277,6 @@ describe('UnclaimedProjectNudge', () => {
     expect(latestToast()).toMatchObject({enabled: true})
   })
 
-  it('renders the claimant identity when the project has been claimed', () => {
-    renderNudge({status: 'claimed', email: 'claimant@example.com'})
-
-    const banner = screen.getByTestId('unclaimed-project-banner')
-    expect(banner).toHaveTextContent('This project is yours.')
-    expect(banner).toHaveAttribute('data-tone', 'positive')
-    expect(screen.getAllByText('claimant@example.com')).toHaveLength(2)
-    expect(latestToast()).toMatchObject({enabled: false})
-  })
-
-  it('renders a generic claimed identity when the claimant cannot be resolved', () => {
-    renderNudge({status: 'claimed'})
-
-    expect(screen.getByTestId('unclaimed-project-banner')).toHaveTextContent(
-      'Log in as the account tied to this project.',
-    )
-  })
-
   it('renders no stale banner for an expired project', () => {
     renderNudge({status: 'expired'})
 
@@ -321,15 +297,6 @@ describe('UnclaimedProjectNudge', () => {
 
     expect(screen.queryByTestId('unclaimed-project-banner')).not.toBeInTheDocument()
     expect(latestToast()).toMatchObject({enabled: false})
-  })
-
-  it('clears claim provenance before leaving the post-claim robot session', async () => {
-    renderNudge({status: 'claimed', email: 'claimant@example.com'})
-    const [signInButton] = screen.getAllByRole('button', {name: 'Log in'})
-    await userEvent.click(signInButton)
-
-    expect(mockClearUnclaimedProjectRecord).toHaveBeenCalledExactlyOnceWith(PROJECT_ID)
-    expect(mockLogout).toHaveBeenCalledOnce()
   })
 
   it('hides the complete nudge after the local project expiry', () => {

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
@@ -104,98 +104,49 @@ describe('useUnclaimedProject', () => {
     expect(mockFetch).not.toHaveBeenCalled()
   })
 
-  it('reports claimed, keeps mint provenance, and clears snooze state', async () => {
+  it('clears mint provenance and redirects to login when the project is claimed', async () => {
     mockRequest.mockResolvedValue({createdAt: CREATED_AT, organizationId: 'oReal'})
     writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
     writeUnclaimedProjectSnoozedAt(PROJECT_ID, new Date().toISOString())
 
     const {result} = renderHook(() => useUnclaimedProject())
 
-    await waitFor(() => expect(result.current).toEqual({status: 'claimed'}))
-    expect(readUnclaimedProjectRecord(PROJECT_ID)).toEqual({claimUrl: CLAIM_URL})
+    await waitFor(() => expect(mockLogout).toHaveBeenCalledOnce())
+    expect(result.current).toBeUndefined()
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toBeUndefined()
     expect(readUnclaimedProjectSnoozedAt(PROJECT_ID)).toBeUndefined()
   })
 
-  it('restores the claimed state after a remount while the robot session remains active', async () => {
+  it('keeps mint provenance until logout has cleared the robot session', async () => {
+    let resolveLogout: (() => void) | undefined
+    mockLogout.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveLogout = resolve
+      }),
+    )
     mockRequest.mockResolvedValue({createdAt: CREATED_AT, organizationId: 'oReal'})
     writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
 
-    const first = renderHook(() => useUnclaimedProject())
-    await waitFor(() => expect(first.result.current).toEqual({status: 'claimed'}))
-    first.unmount()
+    const {result} = renderHook(() => useUnclaimedProject())
 
-    const second = renderHook(() => useUnclaimedProject())
-    await waitFor(() => expect(second.result.current).toEqual({status: 'claimed'}))
-
+    await waitFor(() => expect(mockLogout).toHaveBeenCalledOnce())
+    expect(result.current).toBeUndefined()
     expect(readUnclaimedProjectRecord(PROJECT_ID)).toEqual({claimUrl: CLAIM_URL})
-    expect(mockRequest).toHaveBeenCalledTimes(2)
+
+    resolveLogout?.()
+
+    await waitFor(() => expect(readUnclaimedProjectRecord(PROJECT_ID)).toBeUndefined())
   })
 
-  it('resolves the sole human project member for the claimed sign-in CTA', async () => {
-    mockRequest.mockImplementation(({uri}: {uri: string}) => {
-      if (uri === `/projects/${PROJECT_ID}`) {
-        return Promise.resolve({
-          createdAt: CREATED_AT,
-          organizationId: 'oReal',
-          members: [
-            {id: 'robot', isRobot: true},
-            {id: 'claimant', isRobot: false},
-          ],
-        })
-      }
-      if (uri === '/users/claimant') return Promise.resolve({email: 'claimant@example.com'})
-      return Promise.reject(new Error(`Unexpected request: ${uri}`))
-    })
+  it('keeps mint provenance when logout rejects', async () => {
+    mockLogout.mockRejectedValue(new Error('logout failed'))
+    mockRequest.mockResolvedValue({createdAt: CREATED_AT, organizationId: 'oReal'})
     writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
 
-    const {result} = renderHook(() => useUnclaimedProject())
+    renderHook(() => useUnclaimedProject())
 
-    await waitFor(() =>
-      expect(result.current).toEqual({status: 'claimed', email: 'claimant@example.com'}),
-    )
-    expect(mockRequest).toHaveBeenCalledWith({
-      tag: 'unclaimed-project.claimant',
-      uri: '/users/claimant',
-    })
-  })
-
-  it('keeps the generic claimed state when the claimant is ambiguous', async () => {
-    mockRequest.mockResolvedValue({
-      createdAt: CREATED_AT,
-      organizationId: 'oReal',
-      members: [
-        {id: 'first-human', isRobot: false},
-        {id: 'second-human', isRobot: false},
-      ],
-    })
-    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
-
-    const {result} = renderHook(() => useUnclaimedProject())
-
-    await waitFor(() => expect(result.current).toEqual({status: 'claimed'}))
-    expect(mockRequest).toHaveBeenCalledExactlyOnceWith({
-      tag: 'unclaimed-project',
-      uri: `/projects/${PROJECT_ID}`,
-    })
-  })
-
-  it('keeps the generic claimed state when claimant lookup fails', async () => {
-    mockRequest.mockImplementation(({uri}: {uri: string}) => {
-      if (uri === `/projects/${PROJECT_ID}`) {
-        return Promise.resolve({
-          createdAt: CREATED_AT,
-          organizationId: 'oReal',
-          members: [{id: 'claimant', isRobot: false}],
-        })
-      }
-      return Promise.reject(new Error('user lookup unavailable'))
-    })
-    writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
-
-    const {result} = renderHook(() => useUnclaimedProject())
-
-    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2))
-    expect(result.current).toEqual({status: 'claimed'})
+    await waitFor(() => expect(mockLogout).toHaveBeenCalledOnce())
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toEqual({claimUrl: CLAIM_URL})
   })
 
   it('stays quiet for a regular robot-token session on a claimed project', async () => {
@@ -418,14 +369,15 @@ describe('useUnclaimedProject', () => {
     expect(mockFetch).not.toHaveBeenCalled()
   })
 
-  it('flips to claimed when the lookup says the claim was spent', async () => {
+  it('redirects to login when the lookup says the project was claimed', async () => {
     writeUnclaimedProjectRecord(PROJECT_ID, {claimUrl: CLAIM_URL})
     mockFetch.mockResolvedValue(lookupResponse(200, {state: 'claimed'}))
 
     const {result} = renderHook(() => useUnclaimedProject())
 
-    await waitFor(() => expect(result.current).toEqual({status: 'claimed'}))
-    expect(readUnclaimedProjectRecord(PROJECT_ID)).toMatchObject({claimUrl: CLAIM_URL})
+    await waitFor(() => expect(mockLogout).toHaveBeenCalledOnce())
+    expect(result.current).toBeUndefined()
+    expect(readUnclaimedProjectRecord(PROJECT_ID)).toBeUndefined()
   })
 
   it('keeps the countdown when the lookup is rate-limited', async () => {
@@ -542,7 +494,8 @@ describe('useUnclaimedProject', () => {
 
       await act(() => vi.advanceTimersByTimeAsync(5 * 60_000))
       expect(mockRequest).toHaveBeenCalledTimes(2)
-      expect(result.current).toEqual({status: 'claimed'})
+      expect(result.current).toBeUndefined()
+      expect(mockLogout).toHaveBeenCalledOnce()
     } finally {
       vi.useRealTimers()
     }
@@ -571,7 +524,8 @@ describe('useUnclaimedProject', () => {
 
       await act(() => vi.advanceTimersByTimeAsync(10_000))
       expect(mockRequest).toHaveBeenCalledTimes(3)
-      expect(result.current).toEqual({status: 'claimed'})
+      expect(result.current).toBeUndefined()
+      expect(mockLogout).toHaveBeenCalledOnce()
 
       await act(() => vi.advanceTimersByTimeAsync(30_000))
       expect(mockRequest).toHaveBeenCalledTimes(3)
@@ -607,7 +561,8 @@ describe('useUnclaimedProject', () => {
       await act(() => vi.advanceTimersByTimeAsync(0))
 
       expect(mockRequest).toHaveBeenCalledTimes(3)
-      expect(result.current).toEqual({status: 'claimed'})
+      expect(result.current).toBeUndefined()
+      expect(mockLogout).toHaveBeenCalledOnce()
     } finally {
       vi.useRealTimers()
     }

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProjectCopy.test.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProjectCopy.test.ts
@@ -3,8 +3,6 @@ import {of, throwError} from 'rxjs'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {
-  getClaimedIdentityText,
-  getClaimedIdentityTextParts,
   getLocalUnclaimedProjectCopyUrl,
   parseUnclaimedProjectCopy,
   type UnclaimedProjectCopy,
@@ -35,41 +33,10 @@ const COPY: UnclaimedProjectCopy = {
     claimButtonText: 'Claim project',
     snoozeButtonText: 'Remind me later',
   },
-  claimed: {
-    text: 'Claimed.',
-    identityText: 'Log in as {{identity}}.',
-    signInButtonText: 'Log in',
-  },
   noClaimUrl: {
     text: 'Open the claim link printed in your terminal.',
   },
 }
-
-describe('getClaimedIdentityText', () => {
-  const text = 'Log in as {{identity}}.'
-
-  it('puts the claimed email in the supporting copy when available', () => {
-    expect(getClaimedIdentityText(text, 'claimant@example.com')).toBe(
-      'Log in as claimant@example.com.',
-    )
-  })
-
-  it('uses an explicit account fallback when the email is unavailable', () => {
-    expect(getClaimedIdentityText(text)).toBe('Log in as the account tied to this project.')
-  })
-
-  it('isolates a known identity so Studio can emphasize it', () => {
-    expect(getClaimedIdentityTextParts(text, 'claimant@example.com')).toEqual({
-      before: 'Log in as ',
-      identity: 'claimant@example.com',
-      after: '.',
-    })
-  })
-
-  it('does not emphasize the generic fallback', () => {
-    expect(getClaimedIdentityTextParts(text)).toBeUndefined()
-  })
-})
 
 describe('parseUnclaimedProjectCopy', () => {
   it('accepts the complete Journey contract', () => {
@@ -90,8 +57,6 @@ describe('parseUnclaimedProjectCopy', () => {
     {...COPY, snoozeMinutes: 1.5},
     {...COPY, banner: {...COPY.banner, text: undefined}},
     {...COPY, toast: {...COPY.toast, description: 42}},
-    {...COPY, claimed: undefined},
-    {...COPY, claimed: {...COPY.claimed, identityText: undefined}},
     {...COPY, noClaimUrl: {text: null}},
   ])('rejects an incomplete or malformed contract', (value) => {
     expect(parseUnclaimedProjectCopy(value)).toBeUndefined()

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
@@ -46,18 +46,11 @@ export type UnclaimedProjectState =
       /** The lookup reported the claim link spent or gone — don't point the user at it. */
       claimLinkSpent?: boolean
     }
-  | {status: 'claimed'; email?: string}
   | {status: 'expired'}
-
-interface ProjectMember {
-  id?: string
-  isRobot?: boolean
-}
 
 interface ProjectResponse {
   createdAt?: string
   organizationId?: string
-  members?: ProjectMember[]
 }
 
 interface ClaimLookupResponse {
@@ -123,6 +116,7 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
     let lookupSawNotFound = false
     let claimLinkSpent = false
     let checkInFlight = false
+    let logoutInFlight = false
     const claimPollingStopped$ = new Subject<void>()
 
     const stopClaimPolling = () => {
@@ -145,30 +139,22 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
       if (!disposed) setSessionState({sessionKey, value: next})
     }
 
-    const finishClaimed = (members?: ProjectMember[]) => {
+    const finishClaimed = async () => {
+      if (!auth.logout || logoutInFlight) return
+      logoutInFlight = true
+
+      try {
+        await auth.logout()
+      } catch {
+        logoutInFlight = false
+        return
+      }
+
       terminal = true
       stopClaimPolling()
+      clearUnclaimedProjectRecord(projectId)
       clearUnclaimedProjectSnooze(projectId)
-      update({status: 'claimed'})
-
-      const humanMembers = members?.filter(
-        (member): member is ProjectMember & {id: string} =>
-          member.isRobot === false && typeof member.id === 'string' && Boolean(member.id),
-      )
-      if (humanMembers?.length !== 1) return
-
-      void client
-        .request<{email?: string}>({
-          uri: `/users/${humanMembers[0].id}`,
-          tag: 'unclaimed-project.claimant',
-        })
-        .then((user) => {
-          const email = typeof user.email === 'string' ? user.email.trim() : ''
-          if (!disposed && email) update({status: 'claimed', email})
-        })
-        .catch(() => {
-          // The targeted label is optional; keep the generic sign-in CTA on any lookup failure.
-        })
+      if (!disposed) setSessionState(undefined)
     }
 
     const finishExpired = () => {
@@ -242,7 +228,7 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
       }
       if (disposed || terminal) return
       if (data.state === 'claimed') {
-        finishClaimed()
+        await finishClaimed()
       } else if (data.state === 'expired') {
         dropClaimRecord()
       } else if (data.state === 'claimable' && data.expiresAt) {
@@ -270,7 +256,7 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
       if (!project.organizationId) return
       const record = readUnclaimedProjectRecord(projectId)
       if (project.organizationId !== UNCLAIMED_ORGANIZATION_ID) {
-        if (hasSeenUnclaimed() || record) finishClaimed(project.members)
+        if (hasSeenUnclaimed() || record) await finishClaimed()
         return
       }
 

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProjectCopy.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProjectCopy.ts
@@ -4,7 +4,6 @@ import {catchError, defer, map, of} from 'rxjs'
 
 import {useClient} from '../../hooks/useClient'
 import {DEFAULT_STUDIO_CLIENT_OPTIONS} from '../../studioClient'
-import {interpolateTemplate} from '../../util/interpolateTemplate'
 
 const UNCLAIMED_PROJECT_COPY_API_VERSION = '2026-07-28'
 const UNCLAIMED_PROJECT_COPY_URI = '/journey/unclaimed-project'
@@ -26,36 +25,8 @@ export interface UnclaimedProjectCopy {
     claimButtonText: string
     snoozeButtonText: string
   }
-  claimed: {
-    text: string
-    identityText: string
-    signInButtonText: string
-  }
   noClaimUrl: {
     text: string
-  }
-}
-
-/** Resolves the managed identity instruction without exposing email through Journey. */
-export function getClaimedIdentityText(text: string, email?: string): string {
-  return interpolateTemplate(text, {identity: email ?? 'the account tied to this project'})
-}
-
-/** Identifies the managed placeholder so a known claimant can be emphasized safely. */
-export function getClaimedIdentityTextParts(
-  text: string,
-  email?: string,
-): {before: string; identity: string; after: string} | undefined {
-  if (!email) return undefined
-
-  const marker = '{{identity}}'
-  const markerIndex = text.indexOf(marker)
-  if (markerIndex === -1) return undefined
-
-  return {
-    before: text.slice(0, markerIndex),
-    identity: email,
-    after: text.slice(markerIndex + marker.length),
   }
 }
 
@@ -86,7 +57,6 @@ export function parseUnclaimedProjectCopy(value: unknown): UnclaimedProjectCopy 
       'claimButtonText',
       'snoozeButtonText',
     ]) ||
-    !hasStringProperties(value.claimed, ['text', 'identityText', 'signInButtonText']) ||
     !hasStringProperties(value.noClaimUrl, ['text'])
   ) {
     return undefined
@@ -106,11 +76,6 @@ export function parseUnclaimedProjectCopy(value: unknown): UnclaimedProjectCopy 
       description: value.toast.description,
       claimButtonText: value.toast.claimButtonText,
       snoozeButtonText: value.toast.snoozeButtonText,
-    },
-    claimed: {
-      text: value.claimed.text,
-      identityText: value.claimed.identityText,
-      signInButtonText: value.claimed.signInButtonText,
     },
     noClaimUrl: {
       text: value.noClaimUrl.text,


### PR DESCRIPTION
### Description

Redirect robot-token users to the normal Studio login flow as soon as a provisioned project is claimed. This removes the intermediate success banner, claimant lookup, and extra sign-in click.

Claim provenance remains stored until logout completes. If teardown is interrupted, Studio can retry instead of silently leaving the user on the robot token.

Issue: [AIGRO-5398](https://linear.app/sanity/issue/AIGRO-5398/redirect-claimed-studio-banner-straight-to-loginsignup)

### What to review

Review the unclaimed-project claim transition and its logout sequencing. Confirm that claimed projects redirect automatically, regular robot-token projects remain unaffected, and interrupted logout retains recovery state.

### Testing

- Focused unclaimed-project tests: 77 passed
- Full Sanity test suite: 503 files and 4,753 tests passed, with no type errors
- Oxlint passed
- Full build passed
- Manual UAT with a freshly provisioned project passed on localhost

### Walkthrough

<img width="960" height="533" alt="shapiro sanity-new redirect-to-login-on-claim" src="https://github.com/user-attachments/assets/89958da2-d085-4be2-b39d-8fca78fe17c0" />

### Notes for release

Automatically redirect users to Studio login after they claim a provisioned project.

---
