### PR TITLE
fix(core): open the added annotation via `markDefPaths` instead of the deprecated `markDefPath`

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/toolbar/hooks.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/toolbar/hooks.ts
@@ -68,10 +68,9 @@ export function useActionGroups({
       const initialValue = await resolveInitialValue(schemaType)
       // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
       const paths = PortableTextEditor.addAnnotation(editor, schemaType, initialValue)
-      // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-      if (paths && paths.markDefPath) {
-        // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-        onMemberOpen(paths.markDefPath)
+      const markDefPath = paths?.markDefPaths[0]
+      if (markDefPath) {
+        onMemberOpen(markDefPath)
       }
     },
     [editor, onMemberOpen, resolveInitialValue],


### PR DESCRIPTION
### Description

The `markDefPath` on the return type of `addAnnotation` has been deprecated for a long time. The reason is that an annotation might span multiple blocks. Studio, however, enforces annotations so they don't span multiple blocks, which means we can just pluck the first path from `markDefPaths`.

### What to review

Verify that adding an annotation (in a single block) still works.

### Testing

Annotations already have automated tests.

### Notes for release

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted API alignment with equivalent paths and props; no auth, data, or broad behavioral changes beyond editor compatibility.
> 
> **Overview**
> Prepares Studio for the next **@portabletext/editor** major by updating the few places that still depended on deprecated APIs.
> 
> After inserting an annotation from the toolbar, the link (or other annotation) form still opens immediately, but the path now comes from **`markDefPaths[0]`** instead of **`markDefPath`**, with the related **`oxlint-disable no-deprecated`** comments removed. Behavior is unchanged when annotations are added from a single-block selection (the existing multi-block guard still prevents other cases).
> 
> **`ListItem`** and **`Style`** no longer **`Pick`** **`BlockListItemRenderProps`** / **`BlockStyleRenderProps`**; they declare the same **`block`**, **`children`**, **`focused`**, and **`selected`** props locally using **`PortableTextTextBlock`** and **`ReactElement`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef65c609871631ba7d91f7b19dc6615ab0f125aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

