### PR TITLE
fix(core): declare the `Style` and `ListItem` prop shapes locally

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/text/ListItem.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/ListItem.tsx
@@ -1,4 +1,4 @@
-import {type BlockListItemRenderProps} from '@portabletext/editor'
+import {type PortableTextTextBlock} from '@sanity/types'
 import {useMemo} from 'react'
 
 import {type BlockListItemProps} from '../../../types/blockProps'
@@ -8,7 +8,12 @@ const DefaultComponent = (dProps: BlockListItemProps) => {
   return <>{dProps.children}</>
 }
 
-type ListItemProps = Pick<BlockListItemRenderProps, 'block' | 'children' | 'focused' | 'selected'>
+type ListItemProps = {
+  block: PortableTextTextBlock
+  children: React.JSX.Element
+  focused: boolean
+  selected: boolean
+}
 
 export const ListItem = (props: ListItemProps) => {
   const {block, children, selected, focused} = props

--- a/packages/sanity/src/core/form/inputs/PortableText/text/Style.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/Style.tsx
@@ -1,11 +1,16 @@
-import {type BlockStyleRenderProps} from '@portabletext/editor'
+import {type PortableTextTextBlock} from '@sanity/types'
 import {useCallback, useMemo} from 'react'
 
 import {type BlockStyleProps} from '../../../types/blockProps'
 import {usePortableTextMemberSchemaTypes} from '../contexts/PortableTextMemberSchemaTypes'
 import {Normal as FallbackComponent, TEXT_STYLES, TextContainer} from './textStyles'
 
-type StyleProps = Pick<BlockStyleRenderProps, 'block' | 'children' | 'focused' | 'selected'>
+type StyleProps = {
+  block: PortableTextTextBlock
+  children: React.JSX.Element
+  focused: boolean
+  selected: boolean
+}
 
 export const Style = (props: StyleProps) => {
   const {block, focused, children, selected} = props


### PR DESCRIPTION
### Description

`BlockStyleRenderProps` and `BlockListItemRenderProps` will get removed in the next major version of PTE. Therefore, Studio now declares its own local versions of those types.

### Testing

n/a

### Notes for release

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor with equivalent field types; no runtime or behavioral changes.
> 
> **Overview**
> Prepares Studio for an upcoming `@portabletext/editor` major that drops `BlockStyleRenderProps` and `BlockListItemRenderProps`.
> 
> **`Style.tsx`** and **`ListItem.tsx`** replace `Pick<…RenderProps, 'block' | 'children' | 'focused' | 'selected'>` with local prop types using `PortableTextTextBlock` from `@sanity/types`. Runtime behavior is unchanged; only the type declarations and imports differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c77303642b94a8d683ada3c0b940b6fa03c489d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->