### PR TITLE
refactor(releases): route version discard through document operations

### DIFF
--- a/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/DiscardVersionDialog.tsx
@@ -1,24 +1,31 @@
-import {type ReleaseDocument} from '@sanity/client'
 import {getVersionNameFromId, type VersionId} from '@sanity/id-utils'
 import {Stack, Text} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
-import {useCallback, useState} from 'react'
+import {useCallback, useEffect, useRef, useState} from 'react'
 import {Box} from 'ui5'
 
 import {Dialog} from '../../../../ui-components/dialog/Dialog'
 import {LoadingBlock} from '../../../components/loadingBlock/LoadingBlock'
 import {useDocumentOperation} from '../../../hooks/useDocumentOperation'
+import {useDocumentOperationEvent} from '../../../hooks/useDocumentOperationEvent'
 import {useSchema} from '../../../hooks/useSchema'
-import {getPairTarget, useTargetDocumentState} from '../../../hooks/useTargetDocumentState'
+import {
+  getPairTarget,
+  getTargetScopeId,
+  useTargetDocumentState,
+} from '../../../hooks/useTargetDocumentState'
 import {useTranslation} from '../../../i18n/hooks/useTranslation'
 import {Translate} from '../../../i18n/Translate'
 import {type TargetPerspective} from '../../../perspective/types'
-import {usePerspective} from '../../../perspective/usePerspective'
 import {Preview} from '../../../preview/components/Preview'
-import {getPublishedId, getVersionFromId, isDraftId, isVersionId} from '../../../util/draftUtils'
-import {useVersionOperations} from '../../hooks/useVersionOperations'
+import {
+  getPublishedId,
+  getVersionFromId,
+  getVersionId,
+  isDraftId,
+  isVersionId,
+} from '../../../util/draftUtils'
 import {releasesLocaleNamespace} from '../../i18n'
-import {getReleaseIdFromReleaseDocumentId} from '../../util/getReleaseIdFromReleaseDocumentId'
 
 /**
  * @internal
@@ -29,23 +36,42 @@ export function DiscardVersionDialog(props: {
   documentType: string
   fromPerspective: string | TargetPerspective
   isGoingToUnpublish: boolean
+  /**
+   * Whether the dialog pushes its own failure toast. Callers rendered inside the document pane
+   * should leave this off: `DocumentOperationResults` already toasts the same operation events
+   * there, so the dialog would duplicate them. Defaults to `true` for the release tool, which
+   * has no such listener.
+   */
+  showCompletionToasts?: boolean
 }): React.JSX.Element {
-  const {onClose, versionId, documentType, fromPerspective, isGoingToUnpublish} = props
+  const {
+    onClose,
+    versionId,
+    documentType,
+    fromPerspective,
+    isGoingToUnpublish,
+    showCompletionToasts = true,
+  } = props
   const {t} = useTranslation(releasesLocaleNamespace)
   const {t: coreT} = useTranslation()
-  const targetDocumentState = useTargetDocumentState(getPublishedId(versionId))
-  // The scope of the document targeted by the selected perspective, so that discarding a draft
-  // targets the variant-scoped version when a variant is selected (undefined when the target is
-  // still resolving or the draft/published pair applies). While resolving, confirming is
+  const publishedId = getPublishedId(versionId)
+  const targetDocumentState = useTargetDocumentState(publishedId)
+  // Discarding a version must target the bundle encoded in `versionId`, not the globally selected
+  // perspective: the dialog is opened from version chips and the release tool's document table,
+  // where the selected perspective can be a different release (or the drafts pair) and would
+  // discard the wrong document.
+  // `|| undefined` so a malformed version id (no bundle segment) falls back to the perspective
+  // target below rather than checking out an empty scope.
+  const discardScopeId = (isVersionId(versionId) && getVersionFromId(versionId)) || undefined
+  // Only the draft case follows the selected perspective, so that discarding a draft targets the
+  // variant-scoped version when a variant is selected. While that lookup resolves, confirming is
   // disabled below instead of silently operating on the base pair.
-  const isTargetReady = targetDocumentState.status === 'ready'
+  const isTargetReady = Boolean(discardScopeId) || targetDocumentState.status === 'ready'
   const {discardChanges} = useDocumentOperation(
-    getPublishedId(versionId),
+    publishedId,
     documentType,
-    getPairTarget(targetDocumentState),
+    discardScopeId ?? getPairTarget(targetDocumentState),
   )
-  const {selectedPerspective} = usePerspective()
-  const {discardVersion} = useVersionOperations()
   const schema = useSchema()
   const toast = useToast()
   const [isDiscarding, setIsDiscarding] = useState(false)
@@ -57,37 +83,44 @@ export function DiscardVersionDialog(props: {
 
   const schemaType = schema.get(documentType)
 
-  const handleDiscardVersion = useCallback(async () => {
-    setIsDiscarding(true)
+  // The pair the operation runs against, used to recognise this dialog's own completion event:
+  // `operationEvents` is keyed by published id and type only, so a discard of another bundle of
+  // the same document would otherwise be mistaken for this one.
+  const targetScopeId = discardScopeId ?? getTargetScopeId(targetDocumentState)
+  const targetVersionId = targetScopeId ? getVersionId(publishedId, targetScopeId) : undefined
 
-    if (isVersionId(versionId)) {
-      // Workaround for React Compiler not yet fully supporting try/catch/finally syntax
-      const run = async () => {
-        await discardVersion(
-          getVersionFromId(versionId) ||
-            getReleaseIdFromReleaseDocumentId((selectedPerspective as ReleaseDocument)._id),
-          versionId,
-        )
-      }
-      try {
-        await run()
-      } catch (err) {
-        toast.push({
-          closable: true,
-          status: 'error',
-          title: coreT('release.action.discard-version.failure'),
-          description: err.message,
-        })
-      }
-    } else {
-      // on the document header you can also discard the draft
-      discardChanges.execute()
+  const event = useDocumentOperationEvent(publishedId, documentType)
+  const prevEvent = useRef(event)
+  const awaitingDiscardRef = useRef(false)
+
+  useEffect(() => {
+    if (!event || event === prevEvent.current) return
+    prevEvent.current = event
+
+    if (!awaitingDiscardRef.current) return
+    if (event.op !== 'discardChanges' || event.idPair.versionId !== targetVersionId) return
+
+    awaitingDiscardRef.current = false
+
+    if (event.type === 'error' && showCompletionToasts) {
+      toast.push({
+        closable: true,
+        status: 'error',
+        title: coreT('release.action.discard-version.failure'),
+        description: event.error.message,
+      })
     }
 
-    setIsDiscarding(false)
-
     onClose()
-  }, [versionId, onClose, discardVersion, selectedPerspective, toast, coreT, discardChanges])
+  }, [coreT, event, onClose, showCompletionToasts, targetVersionId, toast])
+
+  const handleDiscardVersion = useCallback(() => {
+    if (discardChanges.disabled) return
+
+    setIsDiscarding(true)
+    awaitingDiscardRef.current = true
+    discardChanges.execute()
+  }, [discardChanges])
 
   return (
     <Dialog
@@ -110,14 +143,15 @@ export function DiscardVersionDialog(props: {
         confirmButton: {
           text: t(`discard-version-dialog.title-${discardType}`),
           onClick: handleDiscardVersion,
-          disabled: isDiscarding || !isTargetReady,
+          disabled: isDiscarding || !isTargetReady || Boolean(discardChanges.disabled),
+          loading: isDiscarding,
         },
       }}
     >
       <Stack gap={3} paddingX={3} marginBottom={2}>
         {schemaType ? (
           <Preview
-            value={{_id: isGoingToUnpublish ? getPublishedId(versionId) : versionId}}
+            value={{_id: isGoingToUnpublish ? publishedId : versionId}}
             schemaType={schemaType}
             // Resolve the preview under the perspective of what's being discarded:
             // the published doc when unpublishing, the drafts perspective when

--- a/packages/sanity/src/core/releases/components/dialog/__tests__/DiscardVersionDialog.test.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/__tests__/DiscardVersionDialog.test.tsx
@@ -1,12 +1,21 @@
 import {defineType} from '@sanity/types'
-import {render, waitFor} from '@testing-library/react'
+import {render, screen, waitFor} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
 import {defineConfig} from '../../../../config/defineConfig'
+import {useDocumentOperation} from '../../../../hooks/useDocumentOperation'
+import {useDocumentOperationEvent} from '../../../../hooks/useDocumentOperationEvent'
+import {useTargetDocumentState} from '../../../../hooks/useTargetDocumentState'
 import {DiscardVersionDialog} from '../DiscardVersionDialog'
 
-const {previewSpy} = vi.hoisted(() => ({previewSpy: vi.fn()}))
+const {previewSpy, toastPush} = vi.hoisted(() => ({previewSpy: vi.fn(), toastPush: vi.fn()}))
+
+vi.mock('@sanity/ui/toast', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useToast: vi.fn(() => ({push: toastPush})),
+}))
 
 // Capture the props the document preview is rendered with so we can assert the
 // perspective the dialog resolves it under.
@@ -18,30 +27,27 @@ vi.mock('../../../../preview/components/Preview', () => ({
 }))
 
 vi.mock('../../../../hooks/useDocumentOperation', () => ({
-  useDocumentOperation: vi.fn(() => ({discardChanges: {execute: vi.fn()}})),
+  useDocumentOperation: vi.fn(),
 }))
 
-// The target document lookup needs the document preview store (mocked away above); these tests
-// only assert the preview perspective, so the target resolves to a ready state with no document
-// (base draft/published pair semantics, no scopeId).
+vi.mock('../../../../hooks/useDocumentOperationEvent', () => ({
+  useDocumentOperationEvent: vi.fn(),
+}))
+
+// The target document lookup needs the document preview store (mocked away above), so it is
+// mocked per test. The default resolves to the base draft/published pair (no scopeId).
 vi.mock('../../../../hooks/useTargetDocumentState', async (importOriginal) => ({
   ...(await importOriginal()),
-  useTargetDocumentState: vi.fn(() => ({
-    status: 'ready',
-    targetDocument: undefined,
-    scopeId: undefined,
-    variant: undefined,
-    publishedSibling: undefined,
-  })),
+  useTargetDocumentState: vi.fn(),
 }))
 
-vi.mock('../../../hooks/useVersionOperations', () => ({
-  useVersionOperations: vi.fn(() => ({discardVersion: vi.fn()})),
-}))
-
-vi.mock('../../../../perspective/usePerspective', () => ({
-  usePerspective: vi.fn(() => ({selectedPerspective: 'drafts'})),
-}))
+const READY_BASE_TARGET = {
+  status: 'ready',
+  targetDocument: undefined,
+  scopeId: undefined,
+  variant: undefined,
+  publishedSibling: undefined,
+} as const
 
 const config = defineConfig({
   projectId: 'test',
@@ -57,28 +63,71 @@ const config = defineConfig({
   },
 })
 
-async function renderDialog(props: {versionId: string; isGoingToUnpublish?: boolean}) {
-  const wrapper = await createTestProvider({config})
-  render(
+const CONFIRM_RELEASE = 'discard-version-dialog.title-release'
+const discardExecute = vi.fn()
+
+function mockDiscardOperation(disabled: false | 'NO_CHANGES' = false) {
+  vi.mocked(useDocumentOperation).mockReturnValue({
+    discardChanges: {disabled, execute: discardExecute},
+  } as unknown as ReturnType<typeof useDocumentOperation>)
+}
+
+function operationEvent(options: {
+  type: 'success' | 'error'
+  op?: string
+  versionId?: string
+}): ReturnType<typeof useDocumentOperationEvent> {
+  return {
+    type: options.type,
+    op: options.op ?? 'discardChanges',
+    id: 'my-doc',
+    ...(options.type === 'error' ? {error: new Error('nope')} : {}),
+    idPair: {
+      publishedId: 'my-doc',
+      draftId: 'drafts.my-doc',
+      versionId: options.versionId ?? 'versions.rSummer.my-doc',
+    },
+  } as unknown as ReturnType<typeof useDocumentOperationEvent>
+}
+
+async function renderDialog(props: {
+  versionId: string
+  isGoingToUnpublish?: boolean
+  onClose?: () => void
+  showCompletionToasts?: boolean
+}) {
+  const onClose = props.onClose ?? vi.fn()
+  // A fresh element per render: re-rendering the identical element lets React bail out of the
+  // subtree, so the component would never observe a newly mocked operation event.
+  const element = () => (
     <DiscardVersionDialog
-      onClose={vi.fn()}
+      onClose={onClose}
       versionId={props.versionId}
       documentType="testDoc"
       fromPerspective="drafts"
       isGoingToUnpublish={props.isGoingToUnpublish ?? false}
-    />,
-    {wrapper},
+      showCompletionToasts={props.showCompletionToasts}
+    />
   )
-  await waitFor(() => expect(previewSpy).toHaveBeenCalled())
+  const wrapper = await createTestProvider({config})
+  const result = render(element(), {wrapper})
+  return {...result, rerender: () => result.rerender(element())}
 }
 
-describe('DiscardVersionDialog preview perspective', () => {
-  beforeEach(() => {
-    previewSpy.mockClear()
-  })
+beforeEach(() => {
+  previewSpy.mockClear()
+  toastPush.mockClear()
+  discardExecute.mockClear()
+  vi.mocked(useDocumentOperation).mockReset()
+  vi.mocked(useDocumentOperationEvent).mockReturnValue(undefined)
+  vi.mocked(useTargetDocumentState).mockReturnValue(READY_BASE_TARGET)
+  mockDiscardOperation()
+})
 
+describe('DiscardVersionDialog preview perspective', () => {
   it('previews a discarded draft under the drafts perspective', async () => {
     await renderDialog({versionId: 'drafts.my-doc'})
+    await waitFor(() => expect(previewSpy).toHaveBeenCalled())
     expect(previewSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({perspectiveStack: ['drafts']}),
     )
@@ -86,6 +135,7 @@ describe('DiscardVersionDialog preview perspective', () => {
 
   it('previews a discarded release version under its release perspective', async () => {
     await renderDialog({versionId: 'versions.rSummer.my-doc'})
+    await waitFor(() => expect(previewSpy).toHaveBeenCalled())
     expect(previewSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({perspectiveStack: ['rSummer']}),
     )
@@ -93,6 +143,136 @@ describe('DiscardVersionDialog preview perspective', () => {
 
   it('previews the published document (empty perspective) when unpublishing', async () => {
     await renderDialog({versionId: 'drafts.my-doc', isGoingToUnpublish: true})
+    await waitFor(() => expect(previewSpy).toHaveBeenCalled())
     expect(previewSpy).toHaveBeenLastCalledWith(expect.objectContaining({perspectiveStack: []}))
+  })
+})
+
+describe('DiscardVersionDialog operation target', () => {
+  it('targets the release encoded in the version id, not the selected perspective', async () => {
+    // A variant of another bundle is selected while the dialog is opened for a release version.
+    vi.mocked(useTargetDocumentState).mockReturnValue({
+      status: 'ready',
+      targetDocument: undefined,
+      scopeId: 'someVariantScope',
+      variant: {_id: 'variant-doc'},
+      publishedSibling: undefined,
+    } as unknown as ReturnType<typeof useTargetDocumentState>)
+
+    await renderDialog({versionId: 'versions.rSummer.my-doc'})
+
+    expect(useDocumentOperation).toHaveBeenCalledWith('my-doc', 'testDoc', 'rSummer')
+  })
+
+  it('follows the selected perspective when discarding a draft', async () => {
+    await renderDialog({versionId: 'drafts.my-doc'})
+
+    expect(useDocumentOperation).toHaveBeenCalledWith('my-doc', 'testDoc', undefined)
+  })
+
+  it('disables confirm while the perspective target is still resolving for a draft', async () => {
+    vi.mocked(useTargetDocumentState).mockReturnValue({status: 'resolving'})
+
+    await renderDialog({versionId: 'drafts.my-doc'})
+
+    expect(screen.getByRole('button', {name: 'discard-version-dialog.title-draft'})).toBeDisabled()
+  })
+
+  it('confirms a release version even while the perspective target is resolving', async () => {
+    vi.mocked(useTargetDocumentState).mockReturnValue({status: 'resolving'})
+
+    await renderDialog({versionId: 'versions.rSummer.my-doc'})
+
+    expect(screen.getByRole('button', {name: CONFIRM_RELEASE})).toBeEnabled()
+  })
+})
+
+describe('DiscardVersionDialog completion', () => {
+  it('does not execute and disables confirm when the operation is disabled', async () => {
+    mockDiscardOperation('NO_CHANGES')
+
+    await renderDialog({versionId: 'versions.rSummer.my-doc'})
+
+    expect(screen.getByRole('button', {name: CONFIRM_RELEASE})).toBeDisabled()
+    expect(discardExecute).not.toHaveBeenCalled()
+  })
+
+  it('stays open until the discard operation reports success', async () => {
+    const onClose = vi.fn()
+    const {rerender} = await renderDialog({versionId: 'versions.rSummer.my-doc', onClose})
+
+    await userEvent.click(screen.getByRole('button', {name: CONFIRM_RELEASE}))
+
+    expect(discardExecute).toHaveBeenCalledTimes(1)
+    expect(onClose).not.toHaveBeenCalled()
+
+    vi.mocked(useDocumentOperationEvent).mockReturnValue(operationEvent({type: 'success'}))
+    rerender()
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+    expect(toastPush).not.toHaveBeenCalled()
+  })
+
+  it('ignores operation events for another bundle of the same document', async () => {
+    const onClose = vi.fn()
+    const {rerender} = await renderDialog({versionId: 'versions.rSummer.my-doc', onClose})
+
+    await userEvent.click(screen.getByRole('button', {name: CONFIRM_RELEASE}))
+
+    vi.mocked(useDocumentOperationEvent).mockReturnValue(
+      operationEvent({type: 'success', versionId: 'versions.rWinter.my-doc'}),
+    )
+    rerender()
+
+    await waitFor(() => expect(screen.getByRole('button', {name: CONFIRM_RELEASE})).toBeDisabled())
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('ignores operation events from a different operation on the same pair', async () => {
+    const onClose = vi.fn()
+    const {rerender} = await renderDialog({versionId: 'versions.rSummer.my-doc', onClose})
+
+    await userEvent.click(screen.getByRole('button', {name: CONFIRM_RELEASE}))
+
+    vi.mocked(useDocumentOperationEvent).mockReturnValue(
+      operationEvent({type: 'success', op: 'publish'}),
+    )
+    rerender()
+
+    await waitFor(() => expect(screen.getByRole('button', {name: CONFIRM_RELEASE})).toBeDisabled())
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('reports a failed discard instead of closing silently', async () => {
+    const onClose = vi.fn()
+    const {rerender} = await renderDialog({versionId: 'versions.rSummer.my-doc', onClose})
+
+    await userEvent.click(screen.getByRole('button', {name: CONFIRM_RELEASE}))
+    expect(toastPush).not.toHaveBeenCalled()
+
+    vi.mocked(useDocumentOperationEvent).mockReturnValue(operationEvent({type: 'error'}))
+    rerender()
+
+    await waitFor(() =>
+      expect(toastPush).toHaveBeenCalledWith(expect.objectContaining({status: 'error'})),
+    )
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('leaves the failure toast to DocumentOperationResults when opted out', async () => {
+    const onClose = vi.fn()
+    const {rerender} = await renderDialog({
+      versionId: 'versions.rSummer.my-doc',
+      onClose,
+      showCompletionToasts: false,
+    })
+
+    await userEvent.click(screen.getByRole('button', {name: CONFIRM_RELEASE}))
+
+    vi.mocked(useDocumentOperationEvent).mockReturnValue(operationEvent({type: 'error'}))
+    rerender()
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+    expect(toastPush).not.toHaveBeenCalled()
   })
 })

--- a/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuDialogs.tsx
+++ b/packages/sanity/src/core/releases/components/documentHeader/contextMenu/VersionContextMenuDialogs.tsx
@@ -64,6 +64,9 @@ export const VersionContextMenuDialogs = memo(function VersionContextMenuDialogs
           fromPerspective={title}
           documentType={documentType}
           isGoingToUnpublish={isGoingToUnpublish}
+          // Rendered from the document header, where `DocumentOperationResults` already toasts
+          // the discard operation events this dialog would report.
+          showCompletionToasts={false}
         />
       )}
 

--- a/packages/sanity/src/core/releases/hooks/__tests__/__mocks__/useVersionOperations.mock.ts
+++ b/packages/sanity/src/core/releases/hooks/__tests__/__mocks__/useVersionOperations.mock.ts
@@ -5,6 +5,7 @@ import {useVersionOperations, type VersionOperationsValue} from '../../useVersio
 // @ts-expect-error -- pre-existing, fix later
 export const useVersionOperationsReturn: Mocked<VersionOperationsValue> = {
   createVersion: vi.fn(),
+  // oxlint-disable-next-line no-deprecated
   discardVersion: vi.fn(),
   // oxlint-disable-next-line no-deprecated
   unpublishVersion: vi.fn(),

--- a/packages/sanity/src/core/releases/hooks/__tests__/useVersionOperations.test.tsx
+++ b/packages/sanity/src/core/releases/hooks/__tests__/useVersionOperations.test.tsx
@@ -59,6 +59,7 @@ describe('useVersionOperations', () => {
     const {result} = renderHook(() => useVersionOperations(), {wrapper})
 
     await act(async () => {
+      // oxlint-disable-next-line no-deprecated
       await result.current.discardVersion('releaseId', 'documentId')
     })
 

--- a/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
+++ b/packages/sanity/src/core/releases/hooks/useVersionOperations.tsx
@@ -22,6 +22,12 @@ export interface VersionOperationsValue {
     documentId: string,
     options?: CreateVersionOptions,
   ) => Promise<void>
+  /**
+   * @deprecated use `useDocumentOperation(publishedId, type, releaseId).discardChanges` instead
+   * which routes release versions through the same operation pipeline as draft and published edits.
+   *
+   * Kept for backwards compatibility
+   */
   discardVersion: (releaseId: string, documentId: string) => Promise<SingleActionResult>
   /**
    * @deprecated use `useDocumentOperation(publishedId, type, releaseId).unpublish` instead
@@ -67,6 +73,7 @@ export function useVersionOperations(): VersionOperationsValue {
 
   return {
     createVersion: handleCreateVersion,
+    // oxlint-disable-next-line no-deprecated
     discardVersion: handleDiscardVersion,
     // oxlint-disable-next-line no-deprecated
     unpublishVersion: handleUnpublishVersion,

--- a/packages/sanity/src/core/releases/plugin/documentActions/DiscardVersionAction.tsx
+++ b/packages/sanity/src/core/releases/plugin/documentActions/DiscardVersionAction.tsx
@@ -69,6 +69,9 @@ export const useDiscardVersionAction: DocumentActionComponent = (
           documentType={type}
           onClose={() => setDialogOpen(false)}
           fromPerspective={selectedPerspective}
+          // In the document pane `DocumentOperationResults` already toasts the discard
+          // operation events this dialog would report.
+          showCompletionToasts={false}
         />
       ),
     },

--- a/packages/sanity/src/core/store/document/document-pair/serverOperations/discardChanges.test.ts
+++ b/packages/sanity/src/core/store/document/document-pair/serverOperations/discardChanges.test.ts
@@ -5,6 +5,47 @@ import {createMockSanityClient} from '../../../../../../test/mocks/mockSanityCli
 import {type OperationArgs} from '../operations/types'
 import {discardChanges} from './discardChanges'
 
+const BASE_PAIR = {draftId: 'drafts.my-id', publishedId: 'my-id'}
+const RELEASE_PAIR = {...BASE_PAIR, versionId: 'versions.rSummer.my-id'}
+const VARIANT_PAIR = {...BASE_PAIR, versionId: 'versions.randomScope.my-id'}
+
+function draftDocument(): SanityDocument {
+  return {
+    _id: BASE_PAIR.draftId,
+    _type: 'example',
+    _rev: 'draftRev',
+    _createdAt: '2021-09-14T22:48:02.303Z',
+    _updatedAt: '2021-09-14T22:48:02.303Z',
+  }
+}
+
+function publishedDocument(): SanityDocument {
+  return {
+    _id: BASE_PAIR.publishedId,
+    _type: 'example',
+    _rev: 'publishedRev',
+    _createdAt: '2021-09-14T22:48:02.303Z',
+    _updatedAt: '2021-09-14T22:48:02.303Z',
+  }
+}
+
+/** A plain (non-variant) release version snapshot. */
+function releaseVersion(): SanityDocument {
+  return {
+    _id: RELEASE_PAIR.versionId,
+    _type: 'example',
+    _rev: 'releaseRev',
+    _createdAt: '2021-09-14T22:48:02.303Z',
+    _updatedAt: '2021-09-14T22:48:02.303Z',
+    _system: {
+      bundleId: 'rSummer',
+      release: {_ref: '_.releases.rSummer', _weak: true},
+      group: {_ref: 'my-id', _weak: true},
+      scopeId: 'rSummer',
+    },
+  }
+}
+
 /**
  * A variant-scoped version snapshot: `_system.variant` set, bundle per `bundleId`. Release
  * bundles carry the `_system.release` reference, matching real release-scoped variant documents.
@@ -12,7 +53,7 @@ import {discardChanges} from './discardChanges'
 function variantVersion(bundleId: 'drafts' | 'rSummer' | undefined): SanityDocument {
   const isReleaseBundle = Boolean(bundleId) && bundleId !== 'drafts'
   return {
-    _id: 'versions.varscope.my-id',
+    _id: VARIANT_PAIR.versionId,
     _type: 'example',
     _rev: 'variantRev',
     _createdAt: '2021-09-14T22:48:02.303Z',
@@ -22,30 +63,22 @@ function variantVersion(bundleId: 'drafts' | 'rSummer' | undefined): SanityDocum
       ...(isReleaseBundle ? {release: {_ref: `_.releases.${bundleId}`, _weak: true}} : {}),
       variant: {_ref: '_.variants.french', _weak: true},
       group: {_ref: 'my-id', _weak: true},
-      scopeId: 'varscope',
+      scopeId: 'randomScope',
     },
   }
 }
 
 describe('discardChanges', () => {
   describe('disabled', () => {
-    it('returns NO_CHANGES when there is neither a draft nor a version', () => {
+    it('is enabled for a draft', () => {
       expect(
         discardChanges.disabled({
-          snapshots: {draft: null, version: null},
+          snapshots: {draft: draftDocument(), published: publishedDocument()},
         } as unknown as OperationArgs),
-      ).toBe('NO_CHANGES')
+      ).toBe(false)
     })
 
-    it('returns NO_CHANGES for the variant-of-published document (removing it is unpublish)', () => {
-      expect(
-        discardChanges.disabled({
-          snapshots: {version: variantVersion(undefined)},
-        } as unknown as OperationArgs),
-      ).toBe('NO_CHANGES')
-    })
-
-    it('is enabled for a variant-over-drafts version', () => {
+    it('is enabled for a variant', () => {
       expect(
         discardChanges.disabled({
           snapshots: {version: variantVersion('drafts')},
@@ -53,134 +86,132 @@ describe('discardChanges', () => {
       ).toBe(false)
     })
 
-    it('is enabled for a release-scoped variant version', () => {
+    it('is enabled for a release version', () => {
+      expect(
+        discardChanges.disabled({
+          snapshots: {version: releaseVersion()},
+        } as unknown as OperationArgs),
+      ).toBe(false)
+    })
+
+    it('is enabled for a release-scoped variant', () => {
       expect(
         discardChanges.disabled({
           snapshots: {version: variantVersion('rSummer')},
         } as unknown as OperationArgs),
       ).toBe(false)
     })
+
+    it('returns NO_CHANGES for a published document', () => {
+      expect(
+        discardChanges.disabled({
+          snapshots: {draft: null, version: null, published: publishedDocument()},
+        } as unknown as OperationArgs),
+      ).toBe('NO_CHANGES')
+    })
+
+    it('returns NO_CHANGES for a published variant (removing it is unpublish)', () => {
+      expect(
+        discardChanges.disabled({
+          snapshots: {version: variantVersion(undefined)},
+        } as unknown as OperationArgs),
+      ).toBe('NO_CHANGES')
+    })
   })
 
   describe('execute', () => {
-    it('routes a variant-over-drafts version to the variant delete action', () => {
+    it('discards a draft via version.discard', () => {
       const client = createMockSanityClient()
 
       discardChanges.execute({
         client,
-        idPair: {
-          draftId: 'drafts.my-id',
-          publishedId: 'my-id',
-          versionId: 'versions.varscope.my-id',
+        idPair: BASE_PAIR,
+        snapshots: {draft: draftDocument()},
+      } as unknown as OperationArgs)
+
+      expect(client.$log.observable.action).toEqual([
+        {
+          actions: {
+            actionType: 'sanity.action.document.version.discard',
+            versionId: BASE_PAIR.draftId,
+          },
+          options: {tag: 'document.discard-changes'},
         },
+      ])
+    })
+
+    it('discards a variant via version.discard', () => {
+      const client = createMockSanityClient()
+
+      discardChanges.execute({
+        client,
+        idPair: VARIANT_PAIR,
         snapshots: {version: variantVersion('drafts')},
       } as unknown as OperationArgs)
 
       expect(client.$log.observable.action).toEqual([
         {
           actions: {
-            actionType: 'sanity.action.document.variant.delete',
-            publishedId: 'my-id',
-            variantId: 'french',
-            bundleId: 'drafts',
+            actionType: 'sanity.action.document.version.discard',
+            versionId: VARIANT_PAIR.versionId,
           },
           options: {tag: 'document.discard-changes'},
         },
       ])
     })
 
-    it('routes a release-scoped variant to the variant delete action with the release bundleId', () => {
+    it('discards a release version via version.discard', () => {
       const client = createMockSanityClient()
 
       discardChanges.execute({
         client,
-        idPair: {
-          draftId: 'drafts.my-id',
-          publishedId: 'my-id',
-          versionId: 'versions.varscope.my-id',
+        idPair: RELEASE_PAIR,
+        snapshots: {version: releaseVersion()},
+      } as unknown as OperationArgs)
+
+      expect(client.$log.observable.action).toEqual([
+        {
+          actions: {
+            actionType: 'sanity.action.document.version.discard',
+            versionId: RELEASE_PAIR.versionId,
+          },
+          options: {tag: 'document.discard-changes'},
         },
+      ])
+    })
+
+    it('discards a release-scoped variant via version.discard', () => {
+      const client = createMockSanityClient()
+
+      discardChanges.execute({
+        client,
+        idPair: VARIANT_PAIR,
         snapshots: {version: variantVersion('rSummer')},
       } as unknown as OperationArgs)
 
       expect(client.$log.observable.action).toEqual([
         {
           actions: {
-            actionType: 'sanity.action.document.variant.delete',
-            publishedId: 'my-id',
-            variantId: 'french',
-            bundleId: 'rSummer',
+            actionType: 'sanity.action.document.version.discard',
+            versionId: VARIANT_PAIR.versionId,
           },
           options: {tag: 'document.discard-changes'},
         },
       ])
     })
 
-    it('throws when executing against the variant-of-published document', () => {
+    it('throws when executing against a published variant', () => {
       const client = createMockSanityClient()
 
       expect(() => {
         discardChanges.execute({
           client,
-          idPair: {
-            draftId: 'drafts.my-id',
-            publishedId: 'my-id',
-            versionId: 'versions.varscope.my-id',
-          },
+          idPair: VARIANT_PAIR,
           snapshots: {version: variantVersion(undefined)},
         } as unknown as OperationArgs)
-      }).toThrow('Cannot discard changes of a published variant')
+      }).toThrow('Cannot discard changes of a published variant: unpublish it instead')
 
       expect(client.$log.observable.action).toEqual([])
-    })
-
-    it('keeps the generic discard action for non-variant documents', () => {
-      const client = createMockSanityClient()
-
-      discardChanges.execute({
-        client,
-        idPair: {draftId: 'drafts.my-id', publishedId: 'my-id'},
-        snapshots: {draft: {} as SanityDocument},
-      } as unknown as OperationArgs)
-
-      expect(client.$log.observable.action).toEqual([
-        {
-          actions: {
-            actionType: 'sanity.action.document.discard',
-            draftId: 'drafts.my-id',
-          },
-          options: {tag: 'document.discard-changes'},
-        },
-      ])
-    })
-
-    it('keeps the generic discard action targeting release versions via versionId', () => {
-      const client = createMockSanityClient()
-
-      discardChanges.execute({
-        client,
-        idPair: {
-          draftId: 'drafts.my-id',
-          publishedId: 'my-id',
-          versionId: 'versions.rSummer.my-id',
-        },
-        snapshots: {
-          version: {
-            _id: 'versions.rSummer.my-id',
-            _type: 'example',
-            _rev: 'r1',
-          } as SanityDocument,
-        },
-      } as unknown as OperationArgs)
-
-      expect(client.$log.observable.action).toEqual([
-        {
-          actions: {
-            actionType: 'sanity.action.document.discard',
-            draftId: 'versions.rSummer.my-id',
-          },
-          options: {tag: 'document.discard-changes'},
-        },
-      ])
     })
   })
 })

--- a/packages/sanity/src/core/store/document/document-pair/serverOperations/discardChanges.ts
+++ b/packages/sanity/src/core/store/document/document-pair/serverOperations/discardChanges.ts
@@ -1,7 +1,6 @@
 import {getVariantVersionInfo} from '../../../../variants/documents/getVariantVersionInfo'
 import {type OperationImpl} from '../operations/types'
 import {actionsApiClient} from '../utils/actionsApiClient'
-import {variantActionsApiClient} from '../utils/variantActionsApiClient'
 
 type DisabledReason = 'NO_CHANGES'
 
@@ -19,29 +18,14 @@ export const discardChanges: OperationImpl<[], DisabledReason> = {
   },
   execute: ({client, idPair, snapshots}) => {
     const variantVersion = getVariantVersionInfo(snapshots.version)
-    if (variantVersion) {
-      if (variantVersion.bundleId === 'published') {
-        throw new Error('Cannot discard changes of a published variant: unpublish it instead')
-      }
-      // Discarding a variant version (drafts- or release-scoped) is deleting the variant
-      // document in that bundle. The generic `sanity.action.document.discard` addresses drafts
-      // by raw id; the variant action addresses them by (publishedId, variantId, bundleId),
-      // which is the supported surface for variant-scoped versions.
-      return variantActionsApiClient(client).observable.action(
-        {
-          actionType: 'sanity.action.document.variant.delete',
-          publishedId: idPair.publishedId,
-          variantId: variantVersion.variantId,
-          bundleId: variantVersion.bundleId,
-        },
-        {tag: 'document.discard-changes'},
-      )
+    if (variantVersion?.bundleId === 'published') {
+      throw new Error('Cannot discard changes of a published variant: unpublish it instead')
     }
 
     return actionsApiClient(client, idPair).observable.action(
       {
-        actionType: 'sanity.action.document.discard',
-        draftId: idPair.versionId || idPair.draftId,
+        actionType: 'sanity.action.document.version.discard',
+        versionId: idPair.versionId || idPair.draftId,
       },
       {tag: 'document.discard-changes'},
     )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Replaces `sanity.action.document.discard` for `sanity.action.document.version.discard`  and routes discard through document operations.

`DiscardVersionDialog` was split down the middle: the draft case already went through `useDocumentOperation`, while the release-version case called `useVersionOperations().discardVersion`, a thin wrapper around `client.discardVersion`. So the dialog held two ways to discard, and the release path sat outside the pipeline that owns consistency, disabled states and operation events for every other edit.

Both cases now go through `useDocumentOperation`, targeting **the bundle encoded in the version id** rather than the globally selected perspective. That distinction matters: the dialog is opened from version chips and the release tool's document table, where the selected perspective is frequently a different release, so targeting the perspective would discard the wrong document. Only the draft case still follows the perspective — that is what makes discarding a draft target the variant-scoped version when a variant is selected — and confirm stays disabled while that lookup resolves rather than silently operating on the base pair.

### What to review



### Testing

Tests updated and passing.

[Release tool discard dialog with two documents in the release](https://cursor.com/agents/bc-8c736319-68ca-45aa-8545-298c684dd8f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frelease_tool_discard_dialog.webp)

[Release tool after discarding, one document remaining](https://cursor.com/agents/bc-8c736319-68ca-45aa-8545-298c684dd8f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frelease_tool_after_discard.webp)

Document pane — exactly one toast (no duplicate from the dialog), and the document drops out of the release:

[Document pane showing a single discard success toast and the not-in-release banner](https://cursor.com/agents/bc-8c736319-68ca-45aa-8545-298c684dd8f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocument_pane_discard_single_toast.webp)

[discard_release_version_from_document_pane_single_toast.mp4](https://cursor.com/agents/bc-8c736319-68ca-45aa-8545-298c684dd8f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdiscard_release_version_from_document_pane_single_toast.mp4)

### Notes for release

Discarding a release version now runs through the same document operation pipeline as draft and published edits. 
`useVersionOperations().discardVersion` is now deprecated in favor of `useDocumentOperation(publishedId, type, releaseId).discardChanges`.

---


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c736319-68ca-45aa-8545-298c684dd8f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c736319-68ca-45aa-8545-298c684dd8f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

