### PR TITLE
fix(schema): accept i18nTitleKey on portable text styles and lists

### DIFF
--- a/packages/@sanity/schema/src/sanity/validation/types/block.ts
+++ b/packages/@sanity/schema/src/sanity/validation/types/block.ts
@@ -21,9 +21,9 @@ const allowedKeys = [
   'validation',
 ]
 const allowedMarkKeys = ['decorators', 'annotations']
-const allowedStyleKeys = ['blockEditor', 'title', 'value', 'icon', 'component']
+const allowedStyleKeys = ['blockEditor', 'title', 'value', 'icon', 'component', 'i18nTitleKey']
 const allowedDecoratorKeys = ['blockEditor', 'title', 'value', 'icon', 'component', 'i18nTitleKey']
-const allowedListKeys = ['title', 'value', 'icon', 'component']
+const allowedListKeys = ['title', 'value', 'icon', 'component', 'i18nTitleKey']
 const supportedBuiltInObjectTypes = [
   'file',
   'image',

--- a/packages/@sanity/schema/test/validation/validation.test.ts
+++ b/packages/@sanity/schema/test/validation/validation.test.ts
@@ -318,6 +318,60 @@ describe('Validation test', () => {
     expect(validationErrors).toHaveLength(0)
   })
 
+  test('accepts i18nTitleKey on styles, lists and decorators', () => {
+    const schemaDef = [
+      {
+        name: 'testBlock',
+        type: 'block',
+        styles: [
+          {title: 'Normal', value: 'normal', i18nTitleKey: 'inputs.portable-text.style.normal'},
+        ],
+        lists: [
+          {
+            title: 'Bulleted list',
+            value: 'bullet',
+            i18nTitleKey: 'inputs.portable-text.list-type.bullet',
+          },
+        ],
+        marks: {
+          decorators: [
+            {
+              title: 'Strong',
+              value: 'strong',
+              i18nTitleKey: 'inputs.portable-text.decorator.strong',
+            },
+          ],
+        },
+      },
+    ]
+
+    const validation = validateSchema(schemaDef).get('testBlock')
+    const validationErrors = validation._problems.filter(
+      (problem: any) => problem.severity === 'error',
+    )
+    expect(validationErrors).toHaveLength(0)
+  })
+
+  test('still reports genuinely unknown properties on styles and lists', () => {
+    const schemaDef = [
+      {
+        name: 'testBlock',
+        type: 'block',
+        styles: [{title: 'Normal', value: 'normal', nope: true}],
+        lists: [{title: 'Bulleted list', value: 'bullet', alsoNope: true}],
+      },
+    ]
+
+    const validation = validateSchema(schemaDef).get('testBlock')
+    const validationErrors = validation._problems.filter(
+      (problem: any) => problem.severity === 'error',
+    )
+    expect(validationErrors).toMatchObject([
+      {message: 'Found unknown properties for style normal: "nope"'},
+      {message: 'Found unknown properties for list bullet: "alsoNope"'},
+    ])
+  })
+
   describe('field type is a document type', () => {
     test('warns when a field type references a document type', () => {
       const schemaDef = [


### PR DESCRIPTION
### Description

Reported in #13494: a user copying the built-in block defaults into their own schema (to keep `@sanity/locale-fr-fr` translations while customising the style list) hit `Found unknown properties for style h1: "i18nTitleKey"` and an invalid schema. Lists behaved the same way; decorators worked fine.

The key was only ever missing from the validator's allow-lists. The public TypeScript types (`BlockStyleDefinition`, `BlockListDefinition`) already declare `i18nTitleKey?: string`, the runtime already resolves it through `t()` (`BlockStyleSelect.tsx`, `toolbar/helpers.tsx`), and `allowedDecoratorKeys` already permitted it. So the built-in defaults in `defaults.ts` could use the key but userland schemas were rejected for copying them — the validator was the only layer that disagreed.

The alternative reading is that `i18nTitleKey` was deliberately decorator-only and the fix belongs in the types instead. Rejected: the style/list runtime paths were written to consume it, and `DEFAULT_BLOCK_STYLES` / `DEFAULT_LIST_TYPES` ship with it set.

Scoped deliberately to the validator. The issue also asks for `DEFAULT_BLOCK_STYLES` / `DEFAULT_LIST_TYPES` to be exported publicly (only `DEFAULT_ANNOTATIONS` and `DEFAULT_DECORATORS` are today) — that's a public API addition, so it's better as a separate `feat` PR than bundled into a patch.

### What to review

Single package: `@sanity/schema`. The whole change is two allow-list entries in `src/sanity/validation/types/block.ts`.

Worth a sanity check that widening these lists doesn't lose coverage — the second test pins that genuinely unknown keys on styles and lists are still reported as errors.

Also verified nothing downstream needs a matching change: the descriptor serialiser routes styles/lists through the generic `convertUnknown` walker (extras like `i18nTitleKey` are preserved), and the manifest extractor's `resolveTitleValueArray` already drops the key uniformly for decorators, styles and lists alike, so that behaviour is unchanged.

### Testing

Two tests added to `test/validation/validation.test.ts`:

- `accepts i18nTitleKey on styles, lists and decorators` — confirmed failing before the fix, passing after
- `still reports genuinely unknown properties on styles and lists` — regression guard so the wider allow-lists don't turn permissive

`pnpm vitest run --project=@sanity/schema` → 135 passed, 7 skipped. `pnpm check:oxlint` clean.

### Notes for release

Fixed: declaring `i18nTitleKey` on Portable Text `styles` or `lists` no longer produces a schema validation error. This lets you customise the available styles or list types while keeping the translated labels from a locale plugin, instead of having to duplicate the translated titles yourself:

```ts
defineArrayMember({
  type: 'block',
  styles: [
    {title: 'Normal', value: 'normal', i18nTitleKey: 'inputs.portable-text.style.normal'},
    {title: 'Heading 1', value: 'h1', i18nTitleKey: 'inputs.portable-text.style.h1'},
  ],
  lists: [
    {title: 'Bulleted list', value: 'bullet', i18nTitleKey: 'inputs.portable-text.list-type.bullet'},
  ],
})
```

The key was already supported on decorators, already declared on the `BlockStyleDefinition` and `BlockListDefinition` TypeScript types, and already honoured by the editor toolbar — only schema validation rejected it.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow schema-validator allow-list change with tests; unknown properties remain rejected. No auth, data, or runtime behavior change.
> 
> **Overview**
> Allows `i18nTitleKey` on Portable Text **styles** and **lists** so custom block schemas can keep locale-plugin titles without failing validation. Decorators already allowed this key; types and editor runtime already consume it.
> 
> Only the validator allow-lists in `block.ts` change. Tests cover acceptance of `i18nTitleKey` and that unknown keys on styles/lists are still errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d765db1b66d7fe7e2e4cda79143ec39d42c4d47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->