### PR TITLE
ci(bench): build packages in the self-test job

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -703,6 +703,14 @@ jobs:
           certutil -d "sql:$HOME/.pki/nssdb" -N --empty-password 2>/dev/null || true
           certutil -d "sql:$HOME/.pki/nssdb" -A -t "CT,," -n sanity-bench -i "$CERT_PATH"
 
+      # Unlike the measuring jobs, this one shells out to the `sanity` CLI
+      # below, whose entrypoint (sanity/lib/cli.js) is build output — the
+      # bench-dist-experiment artifact carries the built studio, not the built
+      # packages. `build:reference-config` calls the package script directly
+      # rather than going through turbo, so nothing else builds `sanity` here.
+      - name: Build packages
+        run: pnpm build --output-logs=full --log-order=grouped
+
       - uses: actions/download-artifact@v8
         with:
           name: bench-dist-experiment


### PR DESCRIPTION
### Description

> Written by an AI agent on behalf of @bjoerge, who has reviewed it.

The bench's `self-test` job runs the perf suite on two identical commits: it takes one build of the Studio and compares it against itself. It does this to catch issues with the bench suite itself. Self-test should report no difference, if it does, then something is wrong with the test suite.

It runs every Monday morning but has never been green, but that got lost due to lack of alerting. Alerting landed in #13937, surfacing the issue described and fixed by this PR.

### What to review

Just the one step in `bench.yml`, and mainly whether you agree with fixing this in the workflow rather than in `build:reference-config`. Only `perf/bench`'s workflow is affected; no published packages change.

### Testing
Yes

### Notes for release

N/A – Internal only

---


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Internal CI workflow change only; no runtime or published package behavior changes.
> 
> **Overview**
> The weekly bench **self-test** job (and `self_test` workflow dispatch) now runs **`pnpm build`** before downloading the experiment artifact and calling **`build:reference-config`**.
> 
> That job shells out to the **`sanity` CLI**, whose entrypoint is compiled package output. The **`bench-dist-experiment`** artifact only contains the built Studio under `perf/bench/dist`, not monorepo packages. **`build:reference-config`** invokes `sanity build` directly on the bench package script, so without an explicit full build the self-test could fail or behave inconsistently even when comparing identical builds.
> 
> The change is **workflow-only** (`bench.yml`); measuring jobs are unchanged. The fix keeps package compilation in CI rather than folding it into `build:reference-config`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95b8b5a323fc0718c2ca9a501915905bc522027d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->