### PR TITLE
chore: migrate box in misc directories in structure

### DIFF
--- a/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialog.tsx
@@ -1,7 +1,8 @@
-import {Box, Flex} from '@sanity/ui'
+import {Flex} from '@sanity/ui'
 import {useCallback, useId, useMemo} from 'react'
 import {getPublishedId, LoadingBlock, useDocumentVersions, useTranslation} from 'sanity'
 import {styled} from 'styled-components'
+import {Box} from 'ui5'
 
 import {Dialog} from '../../../ui-components/dialog/Dialog'
 import {structureLocaleNamespace} from '../../i18n'

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialogBody.styles.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialogBody.styles.tsx
@@ -1,7 +1,8 @@
 import {InfoOutlineIcon} from '@sanity/icons/InfoOutline'
-import {Box, Flex, Inline, rem, Text} from '@sanity/ui'
+import {Flex, Inline, rem, Text} from '@sanity/ui'
 import {useTranslation} from 'sanity'
 import {styled} from 'styled-components'
+import {Box} from 'ui5'
 
 import {Tooltip} from '../../../ui-components/tooltip/Tooltip'
 import {structureLocaleNamespace} from '../../i18n'

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/ConfirmDeleteDialogBody.tsx
@@ -3,10 +3,11 @@ import {CopyIcon} from '@sanity/icons/Copy'
 import {DocumentsIcon} from '@sanity/icons/Documents'
 import {UnknownIcon} from '@sanity/icons/Unknown'
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
-import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Flex, Stack, Text} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import {useCallback} from 'react'
 import {SanityDefaultPreview, Translate, useSchema, useTranslation} from 'sanity'
+import {Box} from 'ui5'
 
 import {Button} from '../../../ui-components/button/Button'
 import {structureLocaleNamespace} from '../../i18n'
@@ -124,7 +125,7 @@ export function ConfirmDeleteDialogBody({
             <Text aria-hidden="true" size={1}>
               <WarningOutlineIcon />
             </Text>
-            <Box flex={1} marginLeft={3}>
+            <Box flexBasis="0%" flexGrow={1} marginLeft={3}>
               <Text size={1}>
                 <Translate
                   i18nKey="confirm-delete-dialog.referring-document-count.text"
@@ -138,7 +139,7 @@ export function ConfirmDeleteDialogBody({
         </Card>
       </div>
 
-      <Box flex="none">
+      <Box flexBasis="auto" flexGrow={0} flexShrink={0}>
         <Text size={1}>
           <Translate
             i18nKey="confirm-delete-dialog.referring-documents-descriptor.text"
@@ -284,7 +285,7 @@ export function ConfirmDeleteDialogBody({
           )}
         </Flex>
       </Card>
-      <Box flex="none">
+      <Box flexBasis="auto" flexGrow={0} flexShrink={0}>
         <Text size={1}>
           <Translate
             i18nKey="confirm-delete-dialog.referential-integrity-disclaimer.text"

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/index.tsx
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/index.tsx
@@ -1,6 +1,7 @@
-import {Box, Text} from '@sanity/ui'
+import {Text} from '@sanity/ui'
 import {type ComponentProps, useCallback, useId, useState} from 'react'
 import {useTranslation} from 'sanity'
+import {Box} from 'ui5'
 
 import {Dialog} from '../../../ui-components/dialog/Dialog'
 import {ErrorBoundary} from '../../../ui-components/errorBoundary/ErrorBoundary'

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/AddIncomingReference.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/AddIncomingReference.tsx
@@ -1,6 +1,6 @@
 import {DEFAULT_MAX_FIELD_DEPTH} from '@sanity/schema/_internal'
 import {type SanityDocumentLike} from '@sanity/types'
-import {Box, Grid, Stack, Text} from '@sanity/ui'
+import {Grid, Stack, Text} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import {useCallback, useMemo, useState} from 'react'
 import {useObservableEvent} from 'react-rx'
@@ -23,6 +23,7 @@ import {
   useSource,
   useTranslation,
 } from 'sanity'
+import {Box} from 'ui5'
 
 import {structureLocaleNamespace} from '../../i18n'
 import {CreateNewIncomingReference} from './CreateNewIncomingReference'

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/CrossDatasetIncomingReference/CrossDatasetIncomingReferenceDocumentPreview.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/CrossDatasetIncomingReference/CrossDatasetIncomingReferenceDocumentPreview.tsx
@@ -1,5 +1,6 @@
-import {Box, Flex} from '@sanity/ui'
+import {Flex} from '@sanity/ui'
 import {CrossDatasetReferencePreview, PreviewCard} from 'sanity'
+import {Box} from 'ui5'
 
 import {type CrossDatasetIncomingReference} from '../types'
 import {type CrossDatasetIncomingReferenceDocument} from './getCrossDatasetIncomingReferences'
@@ -14,7 +15,7 @@ export function CrossDatasetIncomingReferenceDocumentPreview({
   const studioUrl = type?.studioUrl?.({id: document.id, type: document.type})
   return (
     <Flex key={document.id} gap={1} align="center">
-      <Box flex={1}>
+      <Box flexBasis="0%" flexGrow={1}>
         <PreviewCard
           data-as={studioUrl ? 'a' : 'div'}
           flex={1}

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/CrossDatasetIncomingReference/CrossDatasetIncomingReferenceType.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/CrossDatasetIncomingReference/CrossDatasetIncomingReferenceType.tsx
@@ -1,5 +1,5 @@
 import {type SchemaType} from '@sanity/types'
-import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Flex, Stack, Text} from '@sanity/ui'
 import {Suspense, use, useCallback, useMemo} from 'react'
 import {type ObservablePromise, useObservablePromise} from 'react-rx'
 import {
@@ -12,6 +12,7 @@ import {
   useSchema,
   useTranslation,
 } from 'sanity'
+import {Box} from 'ui5'
 
 import {structureLocaleNamespace} from '../../../i18n'
 import {INCOMING_REFERENCES_ITEM_HEIGHT, IncomingReferencesListContainer} from '../shared'

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferenceDocument.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferenceDocument.tsx
@@ -1,4 +1,4 @@
-import {Box, Card, Flex, Text} from '@sanity/ui'
+import {Card, Flex, Text} from '@sanity/ui'
 import {motion, type Variants} from 'motion/react'
 import {useState} from 'react'
 import {
@@ -8,6 +8,7 @@ import {
   useSchema,
   useTranslation,
 } from 'sanity'
+import {Box} from 'ui5'
 
 import {structureLocaleNamespace} from '../../i18n'
 import {IncomingReferenceDocumentActions} from './IncomingReferenceDocumentActions'
@@ -61,7 +62,7 @@ export const IncomingReferenceDocument = (props: {
       align="center"
       variants={variants}
     >
-      <Box flex={1}>
+      <Box flexBasis="0%" flexGrow={1}>
         {/* In some cases when the document has been recently linked the value we get
           in the listener is not the latest, but a previous value with the document not yet linked, this handles that */}
         {referencePaths.length > 0 ? (

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferenceDocumentActions.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferenceDocumentActions.tsx
@@ -1,4 +1,3 @@
-import {Box} from '@sanity/ui'
 import {Menu} from '@sanity/ui/menu'
 import {type Dispatch, type SetStateAction, useCallback, useState} from 'react'
 import {
@@ -8,6 +7,7 @@ import {
   type SanityDocument,
   useSource,
 } from 'sanity'
+import {Box} from 'ui5'
 
 import {MenuButton} from '../../../ui-components/menuButton/MenuButton'
 import {MenuItem} from '../../../ui-components/menuItem/MenuItem'

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesDecoration.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesDecoration.tsx
@@ -1,5 +1,6 @@
-import {Box, Flex, Stack, Text} from '@sanity/ui'
+import {Flex, Stack, Text} from '@sanity/ui'
 import startCase from 'lodash-es/startCase.js'
+import {Box} from 'ui5'
 
 import {IncomingReferencesList} from './IncomingReferencesList'
 import {type IncomingReferencesOptions} from './types'

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx
@@ -1,6 +1,6 @@
 import {AddIcon} from '@sanity/icons/Add'
 import {type SanityDocument, type SchemaType} from '@sanity/types'
-import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Flex, Stack, Text} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import {Suspense, use, useCallback, useEffect, useMemo, useState} from 'react'
 import {type ObservablePromise, useObservablePromise} from 'react-rx'
@@ -19,6 +19,7 @@ import {
   useSource,
   useTranslation,
 } from 'sanity'
+import {Box} from 'ui5'
 
 import {Button} from '../../../ui-components/button/Button'
 import {structureLocaleNamespace} from '../../i18n'

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/shared.ts
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/shared.ts
@@ -1,5 +1,5 @@
-import {Box} from '@sanity/ui'
 import {styled} from 'styled-components'
+import {Box} from 'ui5'
 
 export const INCOMING_REFERENCES_ITEM_HEIGHT = 51
 const INCOMING_REFERENCES_MAX_VISIBLE_ITEMS = 10

--- a/packages/sanity/src/structure/components/pane/PaneFooter.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneFooter.tsx
@@ -1,13 +1,13 @@
-import {Box} from '@sanity/ui'
 import {type ReactNode, type RefAttributes} from 'react'
 import {LegacyLayerProvider} from 'sanity'
+import {Box, type PaddingProps} from 'ui5'
 
 import {Root, RootCard} from './PaneFooter.styles'
 import {usePane} from './usePane'
 
 interface PaneFooterProps {
   children?: ReactNode
-  padding?: number | number[]
+  padding?: PaddingProps['padding']
 }
 
 /**

--- a/packages/sanity/src/structure/components/pane/PaneHeader.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneHeader.tsx
@@ -1,6 +1,7 @@
-import {Box, Card, Flex, LayerProvider, useElementSize} from '@sanity/ui'
+import {Card, Flex, LayerProvider, useElementSize} from '@sanity/ui'
 import {type ReactNode, type RefAttributes, useCallback, useMemo} from 'react'
 import {LegacyLayerProvider} from 'sanity'
+import {Box} from 'ui5'
 
 import {Layout, Root, TitleCard, TitleText, TitleTextSkeleton} from './PaneHeader.styles'
 import {usePane} from './usePane'
@@ -81,7 +82,11 @@ export function PaneHeader(props: PaneHeaderProps & RefAttributes<HTMLDivElement
               style={layoutStyle}
             >
               <Flex align="flex-start" gap={3}>
-                {backButton && <Box flex="none">{backButton}</Box>}
+                {backButton && (
+                  <Box flexBasis="auto" flexGrow={0} flexShrink={0}>
+                    {backButton}
+                  </Box>
+                )}
 
                 <TitleCard
                   __unstable_focusRing
@@ -115,7 +120,7 @@ export function PaneHeader(props: PaneHeaderProps & RefAttributes<HTMLDivElement
 
               {showTabsOrSubActions && (
                 <Flex align="center" hidden={collapsed} overflow="auto">
-                  <Box flex={1} marginRight={subActions ? 3 : 0}>
+                  <Box flexBasis="0%" flexGrow={1} marginRight={subActions ? 3 : 0}>
                     {tabs}
                   </Box>
 

--- a/packages/sanity/src/structure/components/pane/PaneMenuButtonItem.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneMenuButtonItem.tsx
@@ -1,9 +1,10 @@
 import {CheckmarkIcon} from '@sanity/icons/Checkmark'
-import {Box, Label, Text} from '@sanity/ui'
+import {Label, Text} from '@sanity/ui'
 import {MenuDivider} from '@sanity/ui/menu'
 import {type MouseEvent, useCallback} from 'react'
 import {TooltipOfDisabled, useGetI18nText, useI18nText} from 'sanity'
 import {useIntentLink} from 'sanity/router'
+import {Box} from 'ui5'
 
 import {MenuGroup} from '../../../ui-components/menuGroup/MenuGroup'
 import {MenuItem} from '../../../ui-components/menuItem/MenuItem'

--- a/packages/sanity/src/structure/components/paneItem/PaneItem.tsx
+++ b/packages/sanity/src/structure/components/paneItem/PaneItem.tsx
@@ -8,7 +8,7 @@ import {
   type SchemaType,
   type SortOrdering,
 } from '@sanity/types'
-import {Box, type CardProps, Text} from '@sanity/ui'
+import {type CardProps, Text} from '@sanity/ui'
 import {
   type ComponentType,
   type MouseEvent,
@@ -30,6 +30,7 @@ import {
   useEditState,
   useSchema,
 } from 'sanity'
+import {Box} from 'ui5'
 
 import {MissingSchemaType} from '../MissingSchemaType'
 import {usePaneRouter} from '../paneRouter/usePaneRouter'

--- a/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
+++ b/packages/sanity/src/structure/components/requestPermissionDialog/RequestPermissionDialog.tsx
@@ -1,11 +1,12 @@
 import {useTelemetry} from '@sanity/telemetry/react'
-import {Box, Card, DialogProvider, Flex, Stack, Text, TextInput} from '@sanity/ui'
+import {Card, DialogProvider, Flex, Stack, Text, TextInput} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import {useId, useMemo, useState} from 'react'
 import {useSyncObservable} from 'react-rx'
 import {catchError, map, type Observable, of, startWith} from 'rxjs'
 import {type Role, useClient, useProjectId, useTranslation, useZIndex} from 'sanity'
 import {styled} from 'styled-components'
+import {Box} from 'ui5'
 
 import {Dialog} from '../../../ui-components/dialog/Dialog'
 import {structureLocaleNamespace} from '../../i18n'

--- a/packages/sanity/src/structure/components/structureTool/NoDocumentTypesScreen.tsx
+++ b/packages/sanity/src/structure/components/structureTool/NoDocumentTypesScreen.tsx
@@ -1,6 +1,7 @@
 import {WarningOutlineIcon} from '@sanity/icons/WarningOutline'
-import {Box, Card, Container, Flex, Stack, Text} from '@sanity/ui'
+import {Card, Container, Flex, Stack, Text} from '@sanity/ui'
 import {useTranslation} from 'sanity'
+import {Box} from 'ui5'
 
 import {structureLocaleNamespace} from '../../i18n'
 

--- a/packages/sanity/src/structure/components/structureTool/StructureError.tsx
+++ b/packages/sanity/src/structure/components/structureTool/StructureError.tsx
@@ -1,10 +1,11 @@
 import {generateHelpUrl} from '@sanity/generate-help-url'
 import {SyncIcon} from '@sanity/icons/Sync'
-import {Box, Card, Container, Heading, Stack, Text} from '@sanity/ui'
+import {Card, Container, Heading, Stack, Text} from '@sanity/ui'
 import {Code} from '@sanity/ui/code'
 import {useCallback} from 'react'
 import {useTranslation} from 'sanity'
 import {styled} from 'styled-components'
+import {Box} from 'ui5'
 
 import {Button} from '../../../ui-components/button/Button'
 import {structureLocaleNamespace} from '../../i18n'

--- a/packages/sanity/src/structure/diffView/versionMode/components/VersionModeHeader.tsx
+++ b/packages/sanity/src/structure/diffView/versionMode/components/VersionModeHeader.tsx
@@ -3,7 +3,6 @@ import {LockIcon} from '@sanity/icons/Lock'
 import {TransferIcon} from '@sanity/icons/Transfer'
 import {
   Badge,
-  Box,
   // oxlint-disable-next-line no-restricted-imports -- we need more control over how the `Button` component is rendered
   Button,
   // oxlint-disable-next-line no-restricted-imports -- the resolved menu button props are spread onto the `@sanity/ui` Button above
@@ -46,6 +45,7 @@ import {
   useWorkspace,
 } from 'sanity'
 import {styled} from 'styled-components'
+import {Box} from 'ui5'
 
 import {MenuButton} from '../../../../ui-components/menuButton/MenuButton'
 import {structureLocaleNamespace} from '../../../i18n'


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This PR migrates the Box component from `@sanity/ui` v4 to v5 in the non-`panes` directories in `packages/sanity/src/structure`. It updates Box across 28 files containing 34 JSX or styled-component instances. This is stacked on the PR for the inputs directory https://github.com/sanity-io/sanity/pull/14086.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Make sure the prop and type import updates look correct.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I manually tested the Structure section trying to pay attention to column layout/scrolling, document header/footer/scrolling, and right sidebars like validation, history, and incoming references. 

### Notes for release

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

N/A

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mechanical component import and flex prop updates with no business-logic changes; layout risk is limited to subtle flex rendering differences between UI versions.
> 
> **Overview**
> Continues the **Sanity UI v5** rollout in `packages/sanity/src/structure` by moving **`Box`** off `@sanity/ui` onto the **`ui5`** alias (`@sanity/ui@alpha`) in shared structure UI outside the document panes tree—confirm delete, incoming references, pane chrome, structure tool screens, and compare-versions header.
> 
> Where v5 no longer accepts **`flex`** shortcuts, usages are spelled out explicitly (e.g. **`flex={1}`** → **`flexBasis="0%" flexGrow={1}`**, **`flex="none"`** → **`flexBasis="auto" flexGrow={0} flexShrink={0}`**). **`PaneFooter`**’s **`padding`** prop is typed from **`PaddingProps['padding']`** on **`ui5`** instead of loose **`number | number[]`**.
> 
> Behavior should be unchanged; this is import and layout-prop compatibility only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aea1ea6ac635385133033f4b1dbcd66e7f1768f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->