### PR TITLE
feat(test-studio): add sso login option for sandbox org

### DIFF
--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -9,7 +9,7 @@ import {PresentationIcon} from '@sanity/icons/Presentation'
 import {SanityMonogram} from '@sanity/logos'
 import {themerTool} from '@sanity/themer/tool'
 import {visionTool} from '@sanity/vision'
-import {defineConfig, definePlugin, type WorkspaceOptions} from 'sanity'
+import {defineConfig, definePlugin, type AuthProvider, type WorkspaceOptions} from 'sanity'
 import {unsplashAssetSource, UnsplashIcon} from 'sanity-plugin-asset-source-unsplash'
 import {internationalizedArray} from 'sanity-plugin-internationalized-array'
 import {media} from 'sanity-plugin-media'
@@ -79,6 +79,22 @@ function getDebugProxyApiHost(): string | undefined {
 }
 
 const debugProxyApiHost = getDebugProxyApiHost()
+
+// Sanity Sandbox org SAML SSO (`ppsg7ml5`). `/auth/providers` reports `sso.saml: true`
+// but does not include the login URL, so Studio will not offer SSO unless we add it.
+// Same configuration ID as `dev/auth-test-studio`.
+const sanitySandboxSsoProvider: AuthProvider = {
+  name: 'saml',
+  title: 'SSO',
+  url: 'https://api.sanity.io/v2021-10-01/auth/saml/login/91cadf2a',
+}
+
+const sanitySandboxAuth = {
+  providers: (prev: AuthProvider[]) =>
+    prev.some((provider) => provider.name === sanitySandboxSsoProvider.name)
+      ? prev
+      : [...prev, sanitySandboxSsoProvider],
+}
 
 const envConfig = {
   // use this for production workspaces
@@ -279,6 +295,7 @@ const defaultWorkspace = defineConfig({
   dataset: 'test',
   ...envConfig.production,
   plugins: [sharedSettings({projectId: 'ppsg7ml5'})],
+  auth: sanitySandboxAuth,
 
   onUncaughtError: (error, errorInfo) => {
     console.log(error)
@@ -404,6 +421,8 @@ export default defineConfig([
     projectId: 'q5caobza',
     dataset: 'production',
     basePath: '/secondary',
+    // Different project/org than Sanity Sandbox — keep the default providers.
+    auth: undefined,
   },
   {
     ...defaultWorkspace,
@@ -426,6 +445,7 @@ export default defineConfig([
     dataset: 'partial-indexing-2',
     plugins: [sharedSettings({projectId: 'ppsg7ml5'})],
     basePath: '/partial-indexing',
+    auth: sanitySandboxAuth,
     ...envConfig.production,
     search: {
       unstable_partialIndexing: {
@@ -451,6 +471,7 @@ export default defineConfig([
     ...envConfig.production,
     plugins: [sharedSettings({projectId: 'ppsg7ml5'})],
     basePath: '/playground',
+    auth: sanitySandboxAuth,
     beta: {
       eventsAPI: {
         releases: true,
@@ -475,6 +496,7 @@ export default defineConfig([
     ...envConfig.production,
     plugins: [sharedSettings({projectId: 'ppsg7ml5'})],
     basePath: '/listener-events',
+    auth: sanitySandboxAuth,
     mediaLibrary: {
       enabled: true,
     },
@@ -488,6 +510,7 @@ export default defineConfig([
     dataset: 'playground-partial-indexing',
     plugins: [sharedSettings({projectId: 'ppsg7ml5'})],
     basePath: '/playground-partial-indexing',
+    auth: sanitySandboxAuth,
     mediaLibrary: {
       enabled: true,
     },
@@ -596,6 +619,7 @@ export default defineConfig([
       formComponentsPlugin(),
     ],
     basePath: '/custom-components',
+    auth: sanitySandboxAuth,
     onUncaughtError: (error, errorInfo) => {
       console.log(error)
       console.log(errorInfo)
@@ -631,6 +655,7 @@ export default defineConfig([
     ...envConfig.production,
     plugins: [sharedSettings({projectId: 'ppsg7ml5'}), assist()],
     basePath: '/ai-assist',
+    auth: sanitySandboxAuth,
     mediaLibrary: {
       enabled: true,
     },
@@ -643,6 +668,7 @@ export default defineConfig([
     ...envConfig.production,
     plugins: [sharedSettings({projectId: 'ppsg7ml5'})],
     basePath: '/stega',
+    auth: sanitySandboxAuth,
     form: {
       components: {
         input: StegaDebugger,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Invites to the Sanity Sandbox test-studio (`ppsg7ml5`) are often accepted via Okta SSO, but the Studio login dialog only listed Google, GitHub, and email. Those identities are separate accounts, so SSO members then hit “not authorised” and end up duplicated in Manage ([SAPP-3245](https://linear.app/sanity/issue/SAPP-3245)).

`/auth/providers` reports `sso.saml: true` but does not include a SAML login URL, so Studio cannot offer SSO unless the studio config adds it. This appends the existing Sandbox SAML provider (same ID as `dev/auth-test-studio`) to `ppsg7ml5` workspaces and leaves other projects on the default providers.

Alternatives considered: auto-adding SSO in core when `sso.saml` is true — rejected because the API still does not return the login URL; a generic product fix needs a backend change.

### What to review

- `dev/test-studio/sanity.config.ts`: provider URL/ID, append-not-replace callback, and that non-`ppsg7ml5` workspaces are unchanged.

### Testing

No automated test — this is internal studio config, and the SAML redirect is a live Okta flow.

Before/after on the same `/test` login chooser:
- `main`: Google, GitHub, E-mail / password only
- this branch: those three plus SSO (Last used after the first click)

[Login chooser on main without SSO](https://cursor.com/agents/bc-815057f3-d54b-46cc-bf19-ebbb245253be/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_studio_login_before_main.webp)
[Login chooser on this branch with SSO](https://cursor.com/agents/bc-815057f3-d54b-46cc-bf19-ebbb245253be/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_studio_login_after_sso.webp)
[test_studio_login_main_vs_sso_branch.mp4](https://cursor.com/agents/bc-815057f3-d54b-46cc-bf19-ebbb245253be/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_studio_login_main_vs_sso_branch.mp4)

### Notes for release

N/A – Internal only (test-studio)

---


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-815057f3-d54b-46cc-bf19-ebbb245253be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-815057f3-d54b-46cc-bf19-ebbb245253be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

