### PR TITLE
fix(studio): link studio registration docs from the cors interstitial

### DIFF
--- a/packages/sanity/src/core/studio/workspaces/CorsOriginErrorScreen.tsx
+++ b/packages/sanity/src/core/studio/workspaces/CorsOriginErrorScreen.tsx
@@ -60,6 +60,44 @@ const HelpLink = styled.a`
   }
 `
 
+const CORS_DOCS_URL = 'https://www.sanity.io/docs/cors'
+const STUDIO_REGISTRATION_DOCS_URL = 'https://www.sanity.io/docs/dashboard/dashboard-configure'
+
+interface HelpLinksProps {
+  includeRegistration: boolean
+}
+
+function HelpLinks(props: HelpLinksProps) {
+  const {includeRegistration} = props
+
+  return (
+    <Flex justify="flex-end" gap={4} wrap="wrap">
+      {includeRegistration ? (
+        <Text size={1}>
+          <HelpLink
+            href={STUDIO_REGISTRATION_DOCS_URL}
+            rel="noopener noreferrer"
+            style={{textDecoration: 'none'}}
+            target="_blank"
+          >
+            Learn about Studio registration &rarr;
+          </HelpLink>
+        </Text>
+      ) : null}
+      <Text size={1}>
+        <HelpLink
+          href={CORS_DOCS_URL}
+          rel="noopener noreferrer"
+          style={{textDecoration: 'none'}}
+          target="_blank"
+        >
+          Learn about CORS origins &rarr;
+        </HelpLink>
+      </Text>
+    </Flex>
+  )
+}
+
 // Mirror of the manage-side validation for registering a Studio host. If
 // the user's origin would be rejected by the registration form, we hide
 // the "Register Studio" option so they don't get sent to a page where the
@@ -151,18 +189,7 @@ export function CorsOriginErrorScreen(props: CorsOriginErrorScreenProps) {
                 />
               </Flex>
 
-              <Flex justify="flex-end">
-                <Text size={1}>
-                  <HelpLink
-                    href="https://www.sanity.io/docs/cors"
-                    rel="noopener noreferrer"
-                    style={{textDecoration: 'none'}}
-                    target="_blank"
-                  >
-                    Need help with CORS? &rarr;
-                  </HelpLink>
-                </Text>
-              </Flex>
+              <HelpLinks includeRegistration={false} />
             </Stack>
           </ContentWrapper>
         </CenteredContainer>
@@ -246,18 +273,7 @@ export function CorsOriginErrorScreen(props: CorsOriginErrorScreenProps) {
               </Card>
             </Grid>
 
-            <Flex justify="flex-end">
-              <Text size={1}>
-                <HelpLink
-                  href="https://www.sanity.io/docs/cors"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{textDecoration: 'none'}}
-                >
-                  Need help with CORS? &rarr;
-                </HelpLink>
-              </Text>
-            </Flex>
+            <HelpLinks includeRegistration={showRegisterOption} />
           </Stack>
         </ContentWrapper>
       </CenteredContainer>

--- a/packages/sanity/src/core/studio/workspaces/__tests__/CorsOriginErrorScreen.test.tsx
+++ b/packages/sanity/src/core/studio/workspaces/__tests__/CorsOriginErrorScreen.test.tsx
@@ -1,0 +1,89 @@
+import {ThemeProvider} from '@sanity/ui'
+import {buildTheme} from '@sanity/ui/theme'
+import {render, screen} from '@testing-library/react'
+import {type ReactNode} from 'react'
+import {describe, expect, it} from 'vitest'
+
+import {CorsOriginErrorScreen} from '../CorsOriginErrorScreen'
+
+const theme = buildTheme()
+const wrapper = ({children}: {children: ReactNode}) => (
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+)
+
+const CORS_DOCS_URL = 'https://www.sanity.io/docs/cors'
+const STUDIO_REGISTRATION_DOCS_URL = 'https://www.sanity.io/docs/dashboard/dashboard-configure'
+
+describe('CorsOriginErrorScreen', () => {
+  it('links to Studio registration and CORS docs when Register Studio is offered', () => {
+    render(
+      <CorsOriginErrorScreen
+        allowed={false}
+        isStaging={false}
+        origin="https://studio.example.com"
+        primaryProjectId="project-a"
+        projectId="project-a"
+        withCredentials={false}
+      />,
+      {wrapper},
+    )
+
+    expect(screen.getByRole('heading', {name: 'Connect this Studio to your project'})).toBeVisible()
+    expect(screen.getByRole('link', {name: 'Register Studio'})).toBeVisible()
+    expect(screen.queryByRole('link', {name: 'Need help with CORS? →'})).not.toBeInTheDocument()
+
+    const registrationLink = screen.getByRole('link', {name: 'Learn about Studio registration →'})
+    expect(registrationLink).toHaveAttribute('href', STUDIO_REGISTRATION_DOCS_URL)
+    expect(registrationLink).toHaveAttribute('target', '_blank')
+
+    const corsLink = screen.getByRole('link', {name: 'Learn about CORS origins →'})
+    expect(corsLink).toHaveAttribute('href', CORS_DOCS_URL)
+    expect(corsLink).toHaveAttribute('target', '_blank')
+  })
+
+  it('omits the Studio registration docs link when Register Studio is hidden', () => {
+    render(
+      <CorsOriginErrorScreen
+        allowed={false}
+        isStaging={false}
+        origin="http://localhost:3333"
+        primaryProjectId="project-a"
+        projectId="project-a"
+        withCredentials={false}
+      />,
+      {wrapper},
+    )
+
+    expect(screen.queryByRole('link', {name: 'Register Studio'})).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', {name: 'Learn about Studio registration →'}),
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('link', {name: 'Learn about CORS origins →'})).toHaveAttribute(
+      'href',
+      CORS_DOCS_URL,
+    )
+  })
+
+  it('keeps CORS-only help on the credentials-disabled screen', () => {
+    render(
+      <CorsOriginErrorScreen
+        allowed
+        isStaging={false}
+        origin="https://studio.example.com"
+        primaryProjectId="project-a"
+        projectId="project-a"
+        withCredentials={false}
+      />,
+      {wrapper},
+    )
+
+    expect(screen.getByRole('heading', {name: 'Enable credentials for this Studio'})).toBeVisible()
+    expect(
+      screen.queryByRole('link', {name: 'Learn about Studio registration →'}),
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('link', {name: 'Learn about CORS origins →'})).toHaveAttribute(
+      'href',
+      CORS_DOCS_URL,
+    )
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

[SAPP-4205](https://linear.app/sanity/issue/SAPP-4205/link-studio-registration-docs-from-the-cors-interstitial): the "Connect this Studio to your project" screen recommends Register Studio, but its only help link said "Need help with CORS?" and pointed at the CORS docs. That makes the recommended path look like a CORS-only problem.

The footer now links to the Dashboard setup docs (`Learn about Studio registration`) alongside the CORS docs (`Learn about CORS origins`) when Register Studio is offered. Localhost and the credentials-disabled screen stay CORS-only, with the same reworded CORS label.

Left the Register/CORS card copy alone — that already shipped in v6.4.0, and this ticket is the leftover docs-link item from SAPP-3590.

### What to review

- `packages/sanity/src/core/studio/workspaces/CorsOriginErrorScreen.tsx` — help-link copy, URLs, and when the registration link appears
- Whether `https://www.sanity.io/docs/dashboard/dashboard-configure` is the right registration docs target (called out in SAPP-3590 as the Dashboard setup docs)

### Testing

Unit tests cover the three screen branches: registerable origin (both links), localhost (CORS only), credentials-disabled (CORS only). Previewed the live screen from the error-reporting playground: Request errors → "Custom domain · unregistered Studio (UI preview)".

[Interstitial footer with Studio registration link hovered](https://cursor.com/agents/bc-36f65a9b-7bad-4b05-ba3c-8774c21e1938/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcors_interstitial_registration_link_hover.webp)
[Dashboard setup docs opened from the registration link](https://cursor.com/agents/bc-36f65a9b-7bad-4b05-ba3c-8774c21e1938/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudio_registration_docs_page.webp)
[Interstitial footer with CORS origins link hovered](https://cursor.com/agents/bc-36f65a9b-7bad-4b05-ba3c-8774c21e1938/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcors_interstitial_cors_link_hover.webp)
[cors_interstitial_registration_docs_link.mp4](https://cursor.com/agents/bc-36f65a9b-7bad-4b05-ba3c-8774c21e1938/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcors_interstitial_registration_docs_link.mp4)

### Notes for release

The CORS interstitial ("Connect this Studio to your project") now links to [Studio registration / Dashboard setup](https://www.sanity.io/docs/dashboard/dashboard-configure) as well as [CORS origins](https://www.sanity.io/docs/cors), instead of a CORS-only "Need help with CORS?" link.

---

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36f65a9b-7bad-4b05-ba3c-8774c21e1938?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36f65a9b-7bad-4b05-ba3c-8774c21e1938&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

