### PR TITLE
fix(core): link status.sanity.io in network troubleshooting tips

### DIFF
--- a/packages/sanity/src/core/studio/requestErrors/RequestErrorDialog.tsx
+++ b/packages/sanity/src/core/studio/requestErrors/RequestErrorDialog.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable i18next/no-literal-string */
 import {LaunchIcon} from '@sanity/icons/Launch'
 import {Card, Flex, Stack, Text} from '@sanity/ui'
-import {startTransition, useCallback, useEffect, useState} from 'react'
+import {type ReactNode, startTransition, useCallback, useEffect, useState} from 'react'
 import {Box} from 'ui5'
 
 import {Dialog} from '../../../ui-components/dialog/Dialog'
@@ -11,10 +11,29 @@ import {type RequestErrorClaim} from './types'
  * Things a user can check themselves when the studio can't reach the
  * Sanity API. Ordered most-likely-first.
  */
-const NETWORK_TROUBLESHOOTING = [
-  'Check that your device is online.',
-  'Disable VPNs, ad blockers, or browser extensions that may block requests.',
-  'Check status.sanity.io for ongoing incidents.',
+const NETWORK_TROUBLESHOOTING: {key: string; content: ReactNode}[] = [
+  {key: 'online', content: 'Check that your device is online.'},
+  {
+    key: 'blockers',
+    content: 'Disable VPNs, ad blockers, or browser extensions that may block requests.',
+  },
+  {
+    key: 'status',
+    content: (
+      <>
+        Check{' '}
+        <a
+          href="https://status.sanity.io"
+          rel="noopener noreferrer"
+          style={{color: 'var(--card-link-fg-color)'}}
+          target="_blank"
+        >
+          status.sanity.io
+        </a>{' '}
+        for ongoing incidents.
+      </>
+    ),
+  },
 ]
 
 function NetworkTroubleshooting() {
@@ -26,9 +45,9 @@ function NetworkTroubleshooting() {
         </Text>
         <Stack as="ul" gap={2} style={{margin: 0, paddingLeft: '1.25em'}}>
           {NETWORK_TROUBLESHOOTING.map((tip) => (
-            <Box as="li" key={tip}>
+            <Box as="li" key={tip.key}>
               <Text size={1} muted>
-                {tip}
+                {tip.content}
               </Text>
             </Box>
           ))}


### PR DESCRIPTION
### Description

Follow up from ##13367 that turns the mention of status.sanity.io in troubleshooting tips into a clickable link.

### What to review
Makes sense?

### Testing
Easiest way to trigger is to go to the preview build and enable network request blocking for one of the requests the studio does towards the sanity api.

### Notes for release
n/a

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0ecf9f9ca39dd6485028e66b494a99bb7e30e4cb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->