### PR TITLE
fix(core): increase spacing between troubleshooting tips

### DIFF
--- a/packages/sanity/src/core/studio/requestErrors/RequestErrorDialog.tsx
+++ b/packages/sanity/src/core/studio/requestErrors/RequestErrorDialog.tsx
@@ -43,7 +43,7 @@ function NetworkTroubleshooting() {
         <Text size={1} weight="medium">
           Troubleshooting
         </Text>
-        <Stack as="ul" gap={2} style={{margin: 0, paddingLeft: '1.25em'}}>
+        <Stack as="ul" gap={3} style={{margin: 0, paddingLeft: '1.25em'}}>
           {NETWORK_TROUBLESHOOTING.map((tip) => (
             <Box as="li" key={tip.key}>
               <Text size={1} muted>


### PR DESCRIPTION
### Description
Adds a little bit of spacing between troubleshooting tips:

#### Before
<img width="668" height="278" alt="image" src="https://github.com/user-attachments/assets/bb8c1d00-dbb0-46cb-bdc3-df8871a6f254" />

#### After
<img width="737" height="328" alt="image" src="https://github.com/user-attachments/assets/aa72b018-4773-46c4-861f-b92d8e0dec8f" />

### What to review


### Testing


### Notes for release
n/a

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cosmetic layout-only change in the request error dialog; no logic, API, or data handling impact.
> 
> **Overview**
> Increases vertical spacing between items in the **Network error** dialog’s troubleshooting list by changing the list `Stack` **`gap`** from **`2`** to **`3`**, matching the surrounding card layout and improving readability of the tips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3add1aaf915515c07ac1f1ef287554d0655ae79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->