### PR TITLE
feat(structure): list documents in the selected release or variant

### DIFF
--- a/dev/test-studio/structure/resolveStructure.ts
+++ b/dev/test-studio/structure/resolveStructure.ts
@@ -18,6 +18,7 @@ import {type Observable, timer} from 'rxjs'
 import {map} from 'rxjs/operators'
 import {type DocumentStore, type SanityDocument, type Schema} from 'sanity'
 import {
+  getReleaseOrVariantMembership,
   type ItemChild,
   type StructureBuilder,
   structureLocaleNamespace,
@@ -46,10 +47,27 @@ export const structure: StructureResolver = (
   {schema, documentStore, i18n, perspectiveStack, selectedVariantName},
 ) => {
   const {t} = i18n
+  const currentReleaseOrVariant = getReleaseOrVariantMembership({
+    perspectiveStack,
+    selectedVariantName,
+  })
   return S.list()
     .title(t('testStudio:structure.root.title' as const) || 'Content')
     .items([
       S.documentListItem().id('validation').schemaType('allTypes'),
+      S.listItem()
+        .id('current-release-or-variant')
+        .title(currentReleaseOrVariant.title)
+        .icon(FilterIcon)
+        .child(
+          S.documentList()
+            .id('current-release-or-variant-list')
+            .title(currentReleaseOrVariant.title)
+            .filter(currentReleaseOrVariant.filter)
+            .params(currentReleaseOrVariant.params)
+            .apiVersion('X')
+            .perspective('raw'),
+        ),
       S.listItem()
         .title('Sections by perspective')
         .id('sections-by-perspective')

--- a/packages/sanity/src/_exports/structure.ts
+++ b/packages/sanity/src/_exports/structure.ts
@@ -61,6 +61,7 @@ export {
   getTypeNamesFromFilter,
   type PartialDocumentList,
 } from '../structure/structureBuilder/DocumentList'
+export {getReleaseOrVariantMembership} from '../structure/structureBuilder/util/getReleaseOrVariantMembership'
 export {
   type DocumentListItem,
   DocumentListItemBuilder,

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
@@ -90,8 +90,12 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   const releases = useActiveReleases()
   const {perspectiveStack, selectedVariantName} = usePerspective()
   const {displayOptions, options} = pane
-  const {apiVersion, filter} = options
+  const {apiVersion, filter, perspective: listPerspective} = options
   const params = useShallowUnique(options.params || EMPTY_RECORD)
+  // An explicit list perspective owns the query options: do not also apply the
+  // navbar stack or selected variant (membership filters need `raw`).
+  const queryPerspective = listPerspective ?? perspectiveStack
+  const queryVariant = listPerspective === undefined ? selectedVariantName : undefined
   const typeName = useMemo(() => {
     const staticTypes = findStaticTypesInFilter(filter, params)
     if (staticTypes?.length === 1) return staticTypes[0]
@@ -182,8 +186,8 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   } = useDocumentList({
     client,
     filter,
-    perspective: perspectiveStack,
-    variant: selectedVariantName,
+    perspective: queryPerspective,
+    variant: queryVariant,
     params,
     searchQuery: trimmedSearchQuery,
     sortOrder: effectiveSortOrder,

--- a/packages/sanity/src/structure/panes/documentList/__tests__/DocumentListPane.test.tsx
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/DocumentListPane.test.tsx
@@ -174,4 +174,32 @@ describe('DocumentListPane perspective and variant', () => {
       expect.objectContaining({perspective: ['drafts'], variant: 'alpha-audience'}),
     )
   })
+
+  it('uses an explicit list perspective and ignores the navbar variant', async () => {
+    mockUsePerspective.mockReturnValue({...BASE_PERSPECTIVE, selectedVariantName: 'alpha-audience'})
+
+    const wrapper = await createTestProvider({
+      config: defineConfig({projectId: 'test', dataset: 'test'}),
+      resources: [structureUsEnglishLocaleBundle],
+    })
+
+    render(
+      <DocumentListPane
+        {...getPaneProps()}
+        pane={{
+          ...getPaneProps().pane,
+          options: {
+            filter: 'sanity::partOfRelease($releaseId)',
+            params: {releaseId: 'rSummer'},
+            perspective: 'raw',
+          },
+        }}
+      />,
+      {wrapper},
+    )
+
+    expect(mockUseDocumentList).toHaveBeenCalledWith(
+      expect.objectContaining({perspective: 'raw', variant: undefined}),
+    )
+  })
 })

--- a/packages/sanity/src/structure/structureBuilder/DocumentList.ts
+++ b/packages/sanity/src/structure/structureBuilder/DocumentList.ts
@@ -1,3 +1,4 @@
+import {type ClientPerspective} from '@sanity/client'
 import {generateHelpUrl} from '@sanity/generate-help-url'
 import {AddIcon} from '@sanity/icons/Add'
 import {type SchemaType, type SortOrderingItem} from '@sanity/types'
@@ -105,6 +106,15 @@ export interface DocumentListOptions {
   apiVersion?: string
   /** Document list API default ordering array. */
   defaultOrdering?: SortOrderingItem[]
+  /**
+   * Query perspective for this list. When set, the list uses this value instead of the
+   * navbar perspective stack and does not apply the selected navbar variant.
+   *
+   * Use `'raw'` for membership filters such as `sanity::partOfRelease()` /
+   * `sanity::partOfVariant()`, which match version documents that stacked
+   * perspectives do not expose.
+   */
+  perspective?: ClientPerspective
 }
 
 /**
@@ -216,6 +226,26 @@ export class DocumentListBuilder extends GenericListBuilder<
    */
   getDefaultOrdering(): SortOrderingItem[] | undefined {
     return this.spec.options?.defaultOrdering
+  }
+
+  /**
+   * Set the query perspective for this list.
+   *
+   * When set, the document list pane uses this value instead of the navbar
+   * perspective stack, and does not apply the selected navbar variant.
+   *
+   * @param perspective - Client perspective, e.g. `'raw'`
+   * @returns document list builder based on the perspective provided. See {@link DocumentListBuilder}
+   */
+  perspective(perspective: ClientPerspective): DocumentListBuilder {
+    return this.clone({options: {...(this.spec.options || {filter: ''}), perspective}})
+  }
+
+  /** Get Document list query perspective
+   * @returns query perspective, if set
+   */
+  getPerspective(): ClientPerspective | undefined {
+    return this.spec.options?.perspective
   }
 
   /** Serialize Document list

--- a/packages/sanity/src/structure/structureBuilder/util/getReleaseOrVariantMembership.test.ts
+++ b/packages/sanity/src/structure/structureBuilder/util/getReleaseOrVariantMembership.test.ts
@@ -1,0 +1,47 @@
+import {describe, expect, it} from 'vitest'
+
+import {getReleaseOrVariantMembership} from './getReleaseOrVariantMembership'
+
+describe('getReleaseOrVariantMembership', () => {
+  it('returns an empty filter when neither a release nor a variant is selected', () => {
+    expect(getReleaseOrVariantMembership({perspectiveStack: ['drafts']})).toEqual({
+      filter: 'false',
+      params: {},
+      title: 'Select a release or variant',
+    })
+  })
+
+  it('filters to the selected release only', () => {
+    expect(getReleaseOrVariantMembership({perspectiveStack: ['rSummer', 'drafts']})).toEqual({
+      filter: 'sanity::partOfRelease($releaseId)',
+      params: {releaseId: 'rSummer'},
+      title: 'Release: rSummer',
+    })
+  })
+
+  it('filters to the selected variant only', () => {
+    expect(
+      getReleaseOrVariantMembership({
+        perspectiveStack: ['published'],
+        selectedVariantName: 'alpha-audience',
+      }),
+    ).toEqual({
+      filter: 'sanity::partOfVariant($variantId)',
+      params: {variantId: 'alpha-audience'},
+      title: 'Variant: alpha-audience',
+    })
+  })
+
+  it('intersects release and variant membership when both are selected', () => {
+    expect(
+      getReleaseOrVariantMembership({
+        perspectiveStack: ['rSummer', 'drafts'],
+        selectedVariantName: 'alpha-audience',
+      }),
+    ).toEqual({
+      filter: 'sanity::partOfRelease($releaseId) && sanity::partOfVariant($variantId)',
+      params: {releaseId: 'rSummer', variantId: 'alpha-audience'},
+      title: 'Release: rSummer and variant: alpha-audience',
+    })
+  })
+})

--- a/packages/sanity/src/structure/structureBuilder/util/getReleaseOrVariantMembership.ts
+++ b/packages/sanity/src/structure/structureBuilder/util/getReleaseOrVariantMembership.ts
@@ -1,0 +1,51 @@
+import {isSystemBundle, type PerspectiveStack} from 'sanity'
+
+/**
+ * Build a document-list filter that matches documents belonging to the selected
+ * release and/or variant, using `sanity::partOfRelease` / `sanity::partOfVariant`.
+ *
+ * @internal
+ */
+export function getReleaseOrVariantMembership(options: {
+  perspectiveStack: PerspectiveStack
+  selectedVariantName?: string
+}): {
+  filter: string
+  params: {releaseId?: string; variantId?: string}
+  title: string
+} {
+  const releaseId = !isSystemBundle(options.perspectiveStack[0])
+    ? options.perspectiveStack[0]
+    : undefined
+  const variantId = options.selectedVariantName
+
+  const filterParts = [
+    releaseId ? 'sanity::partOfRelease($releaseId)' : undefined,
+    variantId ? 'sanity::partOfVariant($variantId)' : undefined,
+  ].filter((part): part is string => Boolean(part))
+
+  return {
+    filter: filterParts.join(' && ') || 'false',
+    params: {
+      ...(releaseId ? {releaseId} : {}),
+      ...(variantId ? {variantId} : {}),
+    },
+    title: getReleaseOrVariantMembershipTitle(releaseId, variantId),
+  }
+}
+
+function getReleaseOrVariantMembershipTitle(
+  releaseId: string | undefined,
+  variantId: string | undefined,
+): string {
+  if (releaseId && variantId) {
+    return `Release: ${releaseId} and variant: ${variantId}`
+  }
+  if (releaseId) {
+    return `Release: ${releaseId}`
+  }
+  if (variantId) {
+    return `Variant: ${variantId}`
+  }
+  return 'Select a release or variant'
+}

--- a/packages/sanity/src/structure/types.ts
+++ b/packages/sanity/src/structure/types.ts
@@ -1,3 +1,4 @@
+import {type ClientPerspective} from '@sanity/client'
 import {type SchemaType} from '@sanity/types'
 import {type Observable} from 'rxjs'
 import {
@@ -331,6 +332,11 @@ export interface DocumentListPaneNode extends BaseResolvedPaneNode<'documentList
     defaultOrdering?: Array<{field: string; direction: 'asc' | 'desc'}>
     params?: Record<string, unknown>
     apiVersion?: string
+    /**
+     * When set, the list queries with this perspective instead of the navbar stack
+     * and does not apply the selected navbar variant.
+     */
+    perspective?: ClientPerspective
   }
   /** Suppresses auto-injected restore-default sort/layout menu items for panes with a fixed ordering choice. */
   suppressRestoreDefaultMenuItems?: boolean

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -1069,6 +1069,7 @@ exports[`exports snapshot 1`] = `
     "form": "function",
     "getOrderingMenuItem": "function",
     "getOrderingMenuItemsForSchemaType": "function",
+    "getReleaseOrVariantMembership": "function",
     "getTypeNamesFromFilter": "function",
     "isDocumentListItem": "function",
     "isIncomingReferenceCreation": "function",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Structure lists resolve documents *through* the navbar perspective. That is the wrong query for "documents that belong to this release or variant": `sanity::partOfRelease` and `sanity::partOfVariant` match version documents, which stacked perspectives hide.

A default `documentTypeList` was not enough. Querying with the navbar stack (or with the selected variant as a client option) would return an empty or incomplete set. The list now opts into `perspective: 'raw'` so membership filters can see those versions.

Alternatives considered: filtering every structure list automatically (too invasive); using `_originalId in path("versions.*")` instead of the GROQ functions (not what the membership APIs are for); a custom pane instead of `documentList` (loses search/sort).

### What to review

- `DocumentListOptions.perspective` and how `DocumentListPane` treats an explicit perspective as owning the query (navbar variant is not applied).
- `getReleaseOrVariantMembership` filter composition (release, variant, both, neither).
- The new test-studio root item in `resolveStructure.ts`.

### Testing

- Unit tests for `getReleaseOrVariantMembership` (release only / variant only / both / neither).
- `DocumentListPane` test that `options.perspective: 'raw'` is passed through and the navbar variant is ignored.
- Export snapshot updated for the new `getReleaseOrVariantMembership` helper.
- Manual verification in the test studio: changing the selected release and variant updates the list.

[structure_list_membership_filter_walkthrough.mp4](https://cursor.com/agents/bc-674ddf43-dd10-4765-b12f-d625a9c8cdea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstructure_list_membership_filter_walkthrough.mp4)

[Empty list when no release or variant is selected](https://cursor.com/agents/bc-674ddf43-dd10-4765-b12f-d625a9c8cdea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flist_empty_no_selection.webp)
[Release-only membership list](https://cursor.com/agents/bc-674ddf43-dd10-4765-b12f-d625a9c8cdea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flist_release_only.webp)
[Release and variant intersection list](https://cursor.com/agents/bc-674ddf43-dd10-4765-b12f-d625a9c8cdea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flist_release_and_variant.webp)
[Variant-only membership list](https://cursor.com/agents/bc-674ddf43-dd10-4765-b12f-d625a9c8cdea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flist_variant_only.webp)

### Notes for release

Document lists can now set an explicit query perspective. Use `'raw'` with `sanity::partOfRelease()` / `sanity::partOfVariant()` to list documents that belong to the selected release and/or variant, instead of documents as seen through the navbar stack.

```ts
S.documentList()
  .filter('sanity::partOfRelease($releaseId) && sanity::partOfVariant($variantId)')
  .params({releaseId, variantId})
  .apiVersion('X')
  .perspective('raw')
```

---


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-674ddf43-dd10-4765-b12f-d625a9c8cdea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-674ddf43-dd10-4765-b12f-d625a9c8cdea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

