### PR TITLE
chore(deps): remove unused @tanstack/react-table dependency

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -186,7 +186,6 @@
     "@sanity/uuid": "^3.0.3",
     "@sanity/workbench": "0.1.0-alpha.41",
     "@sentry/react": "^10.69.0",
-    "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.14.9",
     "@xstate/react": "^6.1.0",
     "clsx": "^2.1.1",

--- a/packages/sanity/typings/tanstack-table.d.ts
+++ b/packages/sanity/typings/tanstack-table.d.ts
@@ -1,9 +1,0 @@
-import {type RowData} from '@tanstack/react-table'
-
-declare module '@tanstack/react-table' {
-  interface TableMeta<TData extends RowData> {
-    patchDocument: (documentId: string, fieldId: string, value: any) => void
-    selectedAnchor: number | null
-    setSelectedAnchor: (anchorRowIndex: number | null) => void
-  }
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1919,9 +1919,6 @@ importers:
       '@sentry/react':
         specifier: ^10.69.0
         version: 10.69.0(react@19.2.8)
-      '@tanstack/react-table':
-        specifier: ^8.21.3
-        version: 8.21.3(react-dom@19.2.8)(react@19.2.8)
       '@tanstack/react-virtual':
         specifier: ^3.14.9
         version: 3.14.9(react-dom@19.2.8)(react@19.2.8)
@@ -7265,22 +7262,11 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/react-table@8.21.3':
-    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-
   '@tanstack/react-virtual@3.14.9':
     resolution: {integrity: sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@tanstack/table-core@8.21.3':
-    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
-    engines: {node: '>=12'}
 
   '@tanstack/virtual-core@3.17.7':
     resolution: {integrity: sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==}
@@ -20056,19 +20042,11 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@tanstack/react-table@8.21.3(react-dom@19.2.8)(react@19.2.8)':
-    dependencies:
-      '@tanstack/table-core': 8.21.3
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-
   '@tanstack/react-virtual@3.14.9(react-dom@19.2.8)(react@19.2.8)':
     dependencies:
       '@tanstack/virtual-core': 3.17.7
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-
-  '@tanstack/table-core@8.21.3': {}
 
   '@tanstack/virtual-core@3.17.7': {}
 
@@ -26685,7 +26663,7 @@ snapshots:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.1.0(react@19.2.8)
       '@testing-library/jest-dom': 6.10.0(@testing-library/dom@10.4.1)
-      '@testing-library/user-event': 14.6.3(@testing-library/dom@10.4.1)
+      '@testing-library/user-event': 14.6.4(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
       '@vitest/spy': 3.2.4
       esbuild: 0.27.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Started as the `@tanstack/react-table` v8 → v9 upgrade from #14114, done by hand while following the [v9 migration guide](https://tanstack.com/table/latest/docs/framework/react/guide/migrating) and the [React Compiler guide](https://tanstack.com/table/latest/docs/framework/react/guide/react-compiler). Working through those guides surfaced that there is nothing to migrate: the only consumer of `@tanstack/react-table` was the sheet list, removed in #12477 (March 2026). Since then the package has shipped as a runtime dependency of `sanity` — installed by every studio — while nothing imports it. The only remaining reference was `typings/tanstack-table.d.ts`, a `TableMeta` declaration merge whose members (`patchDocument`, `selectedAnchor`, `setSelectedAnchor`) all belonged to the removed sheet list, and whose v8-style single-generic signature conflicts with v9's `TableMeta<TFeatures, TData>` anyway.

Alternatives considered:

- **Bump to `^9.1.2` and keep the dependency** (what #14114 did): keeps an unused package in every studio install, and the stale typings file must either be ported to v9 generics (preserving dead sheet-list meta types) or deleted — and deleting it makes `knip --dependencies` correctly flag the package as unused. Removal avoids all of that. If table work is planned soon and keeping the dependency is preferred, the flip is a one-line `^9.1.2` bump plus a v9-arity rewrite of the typings file — happy to switch this PR over.
- **Remove only the typings file**: fails `pnpm depcheck` (knip flags the unused dependency).

From the React Compiler angle this is also the strongest outcome: v8's `useReactTable` is the canonical example in React's [`incompatible-library`](https://react.dev/reference/eslint-plugin-react-hooks/lints/incompatible-library) lint docs (interior mutability), and this repo compiles the studio with `babel-plugin-react-compiler` and enforces `react/react-compiler` via oxlint. Removing v8 means no compiler-incompatible table API remains anywhere; if tables return, they start from the compiler-compatible v9 `useTable`/`Subscribe` API. Repo audit found no `'use no memo'` directives, no `useReactTable`/`flexRender` usage, and no config special-casing react-table.

### What to review

- `packages/sanity/package.json` — the removed dependency line
- `packages/sanity/typings/tanstack-table.d.ts` — deleted; confirm nothing else relied on this `TableMeta` augmentation (repo-wide search found no other reference)
- Only the `sanity` package is affected; `@sanity/workbench` and other deps neither depend on nor peer-depend on `@tanstack/react-table`

### Testing

No tests added — the removed package had zero imports in the repo, so there is no behavior to cover. Verified locally: `pnpm install` (lockfile drops `@tanstack/react-table` + `@tanstack/table-core`), `pnpm build` (all 8 tasks pass), `pnpm check:format`, `pnpm check:oxlint` (includes type checking), `pnpm check:deps` (back to the same pre-existing `lefthook` warning as `main`), `pnpm test:exports` (3034 tests pass), and the unit test suite.

### Notes for release

N/A – Internal only. `@tanstack/react-table` was an unused leftover dependency of the `sanity` package since the sheet list removal; studios no longer download it.

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11d0b5ac-0c2d-4c74-a403-39cdc5489e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11d0b5ac-0c2d-4c74-a403-39cdc5489e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

