### PR TITLE
fix(pkg): add missing engines.node fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This document helps AI agents work successfully with the Sanity monorepo.
 
 ## Prerequisites
 
-- **Node.js**: v24 or latest LTS
+- **Node.js**: v24 or latest LTS. Published packages must declare `"engines": { "node": ">=22.12" }` (`pnpm normalize-pkgfields` keeps this in sync; publint warns if the field is missing).
 - **Package Manager**: pnpm v10+ (exact version managed via `packageManager` field in package.json)
 
 ## Quick Reference

--- a/packages/@repo/test-exports/test/engines.node.test.mjs
+++ b/packages/@repo/test-exports/test/engines.node.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import {execSync} from 'node:child_process'
+import {readFileSync} from 'node:fs'
+import path from 'node:path'
+import {test} from 'node:test'
+import {fileURLToPath} from 'node:url'
+
+const EXPECTED_NODE_ENGINE = '>=22.12'
+const repoRoot = path.resolve(fileURLToPath(new URL('../../../../', import.meta.url)))
+const packagesDir = path.join(repoRoot, 'packages')
+
+const packages = JSON.parse(
+  execSync('pnpm ls -r --json --depth -1', {
+    cwd: repoRoot,
+    encoding: 'utf-8',
+    maxBuffer: 10 * 1024 * 1024,
+  }),
+)
+
+for (const pkg of packages) {
+  if (!pkg.path.startsWith(`${packagesDir}${path.sep}`)) continue
+
+  const manifest = JSON.parse(readFileSync(path.join(pkg.path, 'package.json'), 'utf8'))
+  if (manifest.private) continue
+
+  void test(`${manifest.name} declares engines.node ${EXPECTED_NODE_ENGINE}`, () => {
+    assert.equal(manifest.engines?.node, EXPECTED_NODE_ENGINE)
+  })
+}

--- a/packages/@sanity/mutator/package.json
+++ b/packages/@sanity/mutator/package.json
@@ -69,5 +69,8 @@
   "browserslist": [
     "node >=22.12",
     "baseline 2024"
-  ]
+  ],
+  "engines": {
+    "node": ">=22.12"
+  }
 }

--- a/packages/@sanity/schema/package.json
+++ b/packages/@sanity/schema/package.json
@@ -87,5 +87,8 @@
   "browserslist": [
     "node >=22.12",
     "baseline 2024"
-  ]
+  ],
+  "engines": {
+    "node": ">=22.12"
+  }
 }

--- a/packages/@sanity/types/package.json
+++ b/packages/@sanity/types/package.json
@@ -70,5 +70,8 @@
   "browserslist": [
     "node >=22.12",
     "baseline 2024"
-  ]
+  ],
+  "engines": {
+    "node": ">=22.12"
+  }
 }

--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -121,5 +121,8 @@
   "browserslist": [
     "node >=22.12",
     "baseline 2024"
-  ]
+  ],
+  "engines": {
+    "node": ">=22.12"
+  }
 }

--- a/scripts/normalizePackageFields.ts
+++ b/scripts/normalizePackageFields.ts
@@ -4,15 +4,17 @@ import {type PackageManifest} from './types'
 import transformPkgs from './utils/transformPkgs'
 
 const COMMON_KEYWORDS = ['sanity', 'cms', 'headless', 'realtime', 'content']
-const supportedNodeVersionRange = '>=14.18.0'
+const supportedNodeVersionRange = '>=22.12'
 
 transformPkgs((pkgManifest: PackageManifest, {relativeDir}) => {
   const name = pkgManifest.name.split('/').slice(-1)[0]
 
-  const engines = pkgManifest.engines
-  if (engines && engines.node) {
-    engines.node = supportedNodeVersionRange
-  }
+  // Published packages must declare engines.node so publint does not warn and consumers
+  // do not install on unsupported Node. Leave private packages' engines untouched
+  // (some, e.g. @repo/debug-proxy, pin a tighter range).
+  const engines = pkgManifest.private
+    ? pkgManifest.engines
+    : {...pkgManifest.engines, node: supportedNodeVersionRange}
 
   const publishedFields = {
     bugs: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

tsdown runs publint on every published package build. Four packages (`@sanity/schema`, `@sanity/mutator`, `@sanity/types`, `@sanity/vision`) omitted `engines.node`, so publint warned that consumers may install them on unsupported Node.

This does not raise the supported range. `sanity` and the other published packages already declare `>=22.12`, matching `browserslist`. Publint flags adding the field as possibly breaking because npm/pnpm can warn (or fail with `engine-strict`) on older Node; that is documenting the existing Sanity 6 floor, not changing it.

Alternatives: leaving the field off keeps the warning and lets installs on Node we do not support. Tightening private-package engines via `normalize-pkgfields` would clobber `@repo/debug-proxy`'s `>=22.18`, so private packages are left alone.

### What to review

- `engines.node` on the four previously incomplete published packages matches `>=22.12`
- `scripts/normalizePackageFields.ts` now writes that field for published packages instead of the stale `>=14.18.0` overwrite
- Regression test in `@repo/test-exports` covers every non-private package under `packages/`

### Testing

- `packages/@repo/test-exports/test/engines.node.test.mjs`: 9/9 published packages declare `engines.node >=22.12`
- Isolated publint on `@sanity/vision` (the package whose `exports.node` condition triggers `USE_ENGINES_NODE`): the engines.node suggestion is present on `origin/main` and gone after this change
- tsdown builds after the fix: `@sanity/types`, `@sanity/mutator`, and `@sanity/schema` report `[publint] No issues found`. `@sanity/vision` no longer reports the engines.node message. It still suggests adding `sideEffects` (pre-existing, not part of this change)

### Notes for release

Published packages that previously omitted `engines.node` (`@sanity/schema`, `@sanity/mutator`, `@sanity/types`, `@sanity/vision`) now declare Node `>=22.12`, the same floor as `sanity`. Installers on older Node may see an engines warning. This is not a change to the supported runtime.

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a86553b6-369a-43ee-8286-6e632bf72452?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a86553b6-369a-43ee-8286-6e632bf72452&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

