### PR TITLE
fix(core): declare sideEffects true to silence publint suggestion

### DIFF
--- a/packages/@sanity/vision/package.json
+++ b/packages/@sanity/vision/package.json
@@ -28,6 +28,7 @@
     "lib"
   ],
   "type": "module",
+  "sideEffects": true,
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/@sanity/vision/tsdown.config.ts
+++ b/packages/@sanity/vision/tsdown.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
   reactCompiler: {target: '19'},
   // Extracts the CSS from vanilla-extract `.css.ts` files into `lib/bundle.css` and wires up the
   // conditional `./bundle.css` export pattern (self-referential import + node shim), like the
-  // `rollup: {vanillaExtract: true}` option in `@sanity/pkg-utils` did
+  // `rollup: {vanillaExtract: true}` option in `@sanity/pkg-utils` did.
+  // The `import '@sanity/vision/bundle.css'` this injects into the entry barrel is also why
+  // package.json declares `sideEffects: true`: with `false` or a `*.css` allowlist, bundlers
+  // bypass the side-effect-free barrel and eliminate the bare CSS import together with it, before
+  // the stylesheet's own side-effect status is ever consulted (see #13322 and #13332)
   vanillaExtract: true,
 })

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -32,6 +32,7 @@
     "!lib/analyze-data.md"
   ],
   "type": "module",
+  "sideEffects": true,
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {

--- a/packages/sanity/tsdown.config.ts
+++ b/packages/sanity/tsdown.config.ts
@@ -24,7 +24,11 @@ export default defineConfig({
   styledComponents: true,
   // Extracts the CSS from vanilla-extract `.css.ts` files into `lib/bundle.css` and wires up the
   // conditional `./bundle.css` export pattern (self-referential import + node shim), like the
-  // `rollup: {vanillaExtract: true}` option in `@sanity/pkg-utils` did
+  // `rollup: {vanillaExtract: true}` option in `@sanity/pkg-utils` did.
+  // The `import 'sanity/bundle.css'` this injects into the entry barrels is also why package.json
+  // declares `sideEffects: true`: with `false` or a `*.css` allowlist, bundlers bypass the
+  // side-effect-free barrels and eliminate the bare CSS import together with them, before the
+  // stylesheet's own side-effect status is ever consulted (see #13322 and #13332)
   vanillaExtract: true,
   define: {
     // Injects the version `SANITY_VERSION` reports (see `src/core/version.ts`). An explicit


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

`sanity` and `@sanity/vision` builds emit the publint suggestion `The package appears to be consumed by bundlers but does not specify "sideEffects"` (the other six tsdown-built packages already declare `sideEffects: false`). Both packages omit the field *deliberately*: their entry barrels carry injected bare CSS imports (`sanity/bundle.css` / `@sanity/vision/bundle.css`, plus `@sanity/ui/styles.css` and `ui5/styles.css`), and a hashed inner chunk imports `@portabletext/plugin-table/ui/styles.css`. #13322 and #13332 established that any side-effect-free declaration lets production bundlers bypass the barrels and eliminate those bare CSS imports before the stylesheet's own side-effect status is consulted.

`"sideEffects": true` is behaviorally identical to the absent field (bundlers assume side effects either way) while making the declaration explicit, which is all publint asks for. Alternatives rejected:

- `sideEffects: false` or a `["*.css", ...]` allowlist — re-introduces the CSS tree-shaking regressions fixed in #13322/#13332.
- Allowlisting the entry barrels too — an inner chunk with a hashed name (`PerspectiveProvider-*.js`) also carries a bare CSS import, so the list can't be kept accurate across builds.

### What to review

- `packages/sanity/package.json`, `packages/@sanity/vision/package.json`: the `"sideEffects": true` field.
- `packages/sanity/tsdown.config.ts`, `packages/@sanity/vision/tsdown.config.ts`: comments recording why `true` and not `false`/allowlist.
- Affected packages: `sanity`, `@sanity/vision`.

### Testing

Packaging metadata only, no runtime logic, so no unit tests. Verified:

- `pnpm build`: publint now reports `No issues found` for `sanity`; the `sideEffects` suggestion is gone for `@sanity/vision` (its unrelated `engines.node` suggestion remains, intentionally untouched — publint marks adding it as potentially breaking).
- The built `lib` output still carries all bare CSS imports (`sanity/bundle.css` in `index`/`desk`/`structure`/`_unstable-embedded`, `@sanity/ui/styles.css`, `ui5/styles.css`, `@portabletext/plugin-table/ui/styles.css`, `@sanity/vision/bundle.css`).
- Production `sanity build` of `dev/test-studio` against the built packages: the emitted stylesheet retains the `--n-studio` and `--n-vision` markers set by the packages' `styles.css.ts`, proving the injected CSS imports survive consumer tree-shaking.
- `pnpm check:oxlint`, `pnpm check:format`, and the `sanity`/`@sanity/vision` unit test projects pass.

### Notes for release

N/A – Internal only (packaging metadata; behavior is unchanged for consumers).

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4af5e1d1-1eff-4b0c-a593-af71218cb71b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4af5e1d1-1eff-4b0c-a593-af71218cb71b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

