### PR TITLE
feat(validation): add stable codes to validation markers

### DIFF
--- a/packages/@repo/test-dts-exports/test/fixtures/@sanity.validation._internal.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/@sanity.validation._internal.test-d.ts
@@ -3,18 +3,87 @@
 // If you need to investigate where new imports are coming from run `TEST_DTS_EXPORTS_DIAGNOSTICS=full pnpm generate:dts-exports`
 
 import type {
+  convertToValidationMarker,
+  getFallbackLocaleSource,
+  getTypeChain,
+  hasValidationContext,
   inferFromSchema,
+  inferFromSchemaType,
+  LocaleSource,
+  normalizeValidationRules,
+  pathToString,
+  resolveTypeForArrayItem,
   Rule,
+  typeString,
+  validateDocumentInternal,
   ValidateDocumentInternalOptions,
+  validateDocumentObservable,
+  ValidateDocumentObservableOptions,
+  validateItem,
   ValidationContext,
+  validationLocaleStrings,
 } from '@sanity/validation/_internal'
 import {describe, expectTypeOf, test} from 'vitest'
 
 describe('@sanity/validation/_internal', () => {
-  test('validation internals', () => {
+  test('convertToValidationMarker', () => {
+    expectTypeOf<typeof convertToValidationMarker>().toBeFunction()
+  })
+  test('getFallbackLocaleSource', () => {
+    expectTypeOf<typeof getFallbackLocaleSource>().toBeFunction()
+  })
+  test('getTypeChain', () => {
+    expectTypeOf<typeof getTypeChain>().toBeFunction()
+  })
+  test('hasValidationContext', () => {
+    expectTypeOf<typeof hasValidationContext>().toBeFunction()
+  })
+  test('inferFromSchema', () => {
     expectTypeOf<typeof inferFromSchema>().toBeFunction()
+  })
+  test('inferFromSchemaType', () => {
+    // This export has 2 declarations, run `TEST_DTS_EXPORTS_DIAGNOSTICS=duplicates pnpm generate:dts-exports` to see where each declaration is coming from
+    expectTypeOf<typeof inferFromSchemaType>().toBeFunction()
+  })
+  test('LocaleSource', () => {
+    expectTypeOf<LocaleSource>().toBeObject()
+  })
+  test('normalizeValidationRules', () => {
+    expectTypeOf<typeof normalizeValidationRules>().toBeFunction()
+  })
+  test('pathToString', () => {
+    expectTypeOf<typeof pathToString>().toBeFunction()
+  })
+  test('resolveTypeForArrayItem', () => {
+    expectTypeOf<typeof resolveTypeForArrayItem>().toBeFunction()
+  })
+  test('Rule', () => {
     expectTypeOf<typeof Rule>().not.toBeNever()
+  })
+  test('typeString', () => {
+    expectTypeOf<typeof typeString>().toBeFunction()
+  })
+  test('validateDocumentInternal', () => {
+    expectTypeOf<typeof validateDocumentInternal>().toBeFunction()
+  })
+  test('ValidateDocumentInternalOptions', () => {
     expectTypeOf<ValidateDocumentInternalOptions>().toBeObject()
     expectTypeOf<ValidationContext['i18n']>().toBeObject()
+  })
+  test('validateDocumentObservable', () => {
+    expectTypeOf<typeof validateDocumentObservable>().toBeFunction()
+  })
+  test('ValidateDocumentObservableOptions', () => {
+    expectTypeOf<ValidateDocumentObservableOptions>().toBeObject()
+  })
+  test('validateItem', () => {
+    expectTypeOf<typeof validateItem>().toBeFunction()
+  })
+  test('ValidationContext', () => {
+    // This export has 2 declarations, run `TEST_DTS_EXPORTS_DIAGNOSTICS=duplicates pnpm generate:dts-exports` to see where each declaration is coming from
+    expectTypeOf<ValidationContext>().toBeObject()
+  })
+  test('validationLocaleStrings', () => {
+    expectTypeOf<typeof validationLocaleStrings>().not.toBeNever()
   })
 })

--- a/packages/@repo/test-dts-exports/test/fixtures/@sanity.validation.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/@sanity.validation.test-d.ts
@@ -4,16 +4,26 @@
 
 import type {ValidationContext} from '@sanity/types'
 import type {
+  BuiltInValidationMarkerCode,
+  DocumentValidationMarker,
   validateDocument,
   ValidateDocumentOptions,
   validateDocumentWithWorkspace,
   ValidateDocumentWorkspaceOptions,
+  ValidationMarkerCode,
+  validationMarkerCodes,
   ValidationSource,
 } from '@sanity/validation'
 import type {Workspace} from 'sanity'
 import {describe, expectTypeOf, test} from 'vitest'
 
 describe('@sanity/validation', () => {
+  test('BuiltInValidationMarkerCode', () => {
+    expectTypeOf<BuiltInValidationMarkerCode>().not.toBeNever()
+  })
+  test('DocumentValidationMarker', () => {
+    expectTypeOf<DocumentValidationMarker>().not.toBeNever()
+  })
   test('validateDocument', () => {
     // This export has 2 declarations, run `TEST_DTS_EXPORTS_DIAGNOSTICS=duplicates pnpm generate:dts-exports` to see where each declaration is coming from
     expectTypeOf<typeof validateDocument>().toBeFunction()
@@ -22,6 +32,12 @@ describe('@sanity/validation', () => {
   })
   test('ValidateDocumentOptions', () => {
     expectTypeOf<ValidateDocumentOptions>().toBeObject()
+  })
+  test('ValidationMarkerCode', () => {
+    expectTypeOf<ValidationMarkerCode>().not.toBeNever()
+  })
+  test('validationMarkerCodes', () => {
+    expectTypeOf<typeof validationMarkerCodes>().not.toBeNever()
   })
   test('validateDocumentWithWorkspace', () => {
     expectTypeOf<typeof validateDocumentWithWorkspace>().toBeFunction()

--- a/packages/@repo/test-dts-exports/test/fixtures/@sanity.validation.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/@sanity.validation.test-d.ts
@@ -2,7 +2,6 @@
 // If deleting the exports, for example, then please use this command to regenerate the tests
 // If you need to investigate where new imports are coming from run `TEST_DTS_EXPORTS_DIAGNOSTICS=full pnpm generate:dts-exports`
 
-import type {SanityClient} from '@sanity/client'
 import type {ValidationContext} from '@sanity/types'
 import type {
   BuiltInValidationMarkerCode,
@@ -38,7 +37,6 @@ describe('@sanity/validation', () => {
   })
   test('ValidationClient', () => {
     expectTypeOf<ValidationClient>().toBeObject()
-    expectTypeOf<SanityClient>().toMatchTypeOf<ValidationClient>()
   })
   test('ValidationMarkerCode', () => {
     expectTypeOf<ValidationMarkerCode>().not.toBeNever()

--- a/packages/@repo/test-dts-exports/test/fixtures/@sanity.validation.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/@sanity.validation.test-d.ts
@@ -2,6 +2,7 @@
 // If deleting the exports, for example, then please use this command to regenerate the tests
 // If you need to investigate where new imports are coming from run `TEST_DTS_EXPORTS_DIAGNOSTICS=full pnpm generate:dts-exports`
 
+import type {SanityClient} from '@sanity/client'
 import type {ValidationContext} from '@sanity/types'
 import type {
   BuiltInValidationMarkerCode,
@@ -37,6 +38,7 @@ describe('@sanity/validation', () => {
   })
   test('ValidationClient', () => {
     expectTypeOf<ValidationClient>().toBeObject()
+    expectTypeOf<SanityClient>().toMatchTypeOf<ValidationClient>()
   })
   test('ValidationMarkerCode', () => {
     expectTypeOf<ValidationMarkerCode>().not.toBeNever()

--- a/packages/@repo/test-dts-exports/test/fixtures/@sanity.validation.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/@sanity.validation.test-d.ts
@@ -10,8 +10,10 @@ import type {
   ValidateDocumentOptions,
   validateDocumentWithWorkspace,
   ValidateDocumentWorkspaceOptions,
+  ValidationClient,
   ValidationMarkerCode,
   validationMarkerCodes,
+  ValidationSchema,
   ValidationSource,
 } from '@sanity/validation'
 import type {Workspace} from 'sanity'
@@ -33,6 +35,9 @@ describe('@sanity/validation', () => {
   test('ValidateDocumentOptions', () => {
     expectTypeOf<ValidateDocumentOptions>().toBeObject()
   })
+  test('ValidationClient', () => {
+    expectTypeOf<ValidationClient>().toBeObject()
+  })
   test('ValidationMarkerCode', () => {
     expectTypeOf<ValidationMarkerCode>().not.toBeNever()
   })
@@ -48,5 +53,8 @@ describe('@sanity/validation', () => {
   test('ValidationSource', () => {
     expectTypeOf<ValidationSource>().toBeObject()
     expectTypeOf<Workspace>().toMatchTypeOf<ValidationSource>()
+  })
+  test('ValidationSchema', () => {
+    expectTypeOf<ValidationSchema>().toBeObject()
   })
 })

--- a/packages/@sanity/types/src/markers/types.ts
+++ b/packages/@sanity/types/src/markers/types.ts
@@ -6,6 +6,17 @@ export interface ValidationMarker {
   level: 'error' | 'warning' | 'info'
 
   /**
+   * A machine-readable identifier for the validation failure.
+   *
+   * Built-in validators use stable codes exported by `@sanity/validation`.
+   * Custom validators may provide their own code.
+   */
+  code?: string
+
+  /** Structured information about the validation failure. */
+  details?: Record<string, unknown>
+
+  /**
    * The validation message for this marker. E.g. "Must be greater than 0"
    */
   message: string

--- a/packages/@sanity/types/src/validation/types.ts
+++ b/packages/@sanity/types/src/validation/types.ts
@@ -363,6 +363,15 @@ export interface ValidationErrorClass {
  */
 export interface ValidationError {
   /**
+   * A machine-readable identifier for the validation failure.
+   * Custom validators should namespace custom codes, for example `custom.seo-title`.
+   */
+  code?: string
+
+  /** Structured information about the validation failure. */
+  details?: Record<string, unknown>
+
+  /**
    * The message describing why the value is not valid. This message will be
    * included in the validation markers after validation has finished running.
    */

--- a/packages/@sanity/validation/README.md
+++ b/packages/@sanity/validation/README.md
@@ -9,9 +9,10 @@ const markers = await validateDocument({document, schema, client})
 
 for (const marker of markers) {
   if (marker.code === validationMarkerCodes.stringMinimumLength) {
-    console.log(
-      `Expected at least ${marker.details?.minimumLength} characters, got ${marker.details?.actualLength}`,
-    )
+    const {actualLength, minimumLength} = marker.details || {}
+    if (typeof actualLength === 'number' && typeof minimumLength === 'number') {
+      console.log(`Expected at least ${minimumLength} characters, got ${actualLength}`)
+    }
   }
 }
 

--- a/packages/@sanity/validation/README.md
+++ b/packages/@sanity/validation/README.md
@@ -3,13 +3,35 @@
 Validates complete Sanity documents against a compiled Sanity schema.
 
 ```ts
-import {validateDocument} from '@sanity/validation'
+import {validateDocument, validationMarkerCodes} from '@sanity/validation'
 
 const markers = await validateDocument({document, schema, client})
+
+for (const marker of markers) {
+  if (marker.code === validationMarkerCodes.stringMinimumLength) {
+    console.log(
+      `Expected at least ${marker.details?.minimumLength} characters, got ${marker.details?.actualLength}`,
+    )
+  }
+}
+
+const summary = markers
+  .map((marker) => {
+    const path = marker.path
+      .map((segment) => (typeof segment === 'object' ? segment._key : segment))
+      .join('.')
+
+    return `[${marker.level}] ${path || '<document>'}: ${marker.message} (${marker.code})`
+  })
+  .join('\n')
 ```
 
-The package reports validation markers. It does not apply mutations or decide whether a document
-may be edited or published.
+Every returned marker includes a stable machine-readable `code` alongside its localized `message`,
+`level`, and `path`. Built-in failures may also include structured `details`. Custom validators can
+return their own `code` and `details`; custom codes should be namespaced, for example
+`custom.seo-title`.
+
+The package does not apply mutations or decide whether a document may be edited or published.
 
 ## Migrating from `sanity`
 

--- a/packages/@sanity/validation/src/Rule.ts
+++ b/packages/@sanity/validation/src/Rule.ts
@@ -10,6 +10,7 @@ import {
 } from '@sanity/types'
 import get from 'lodash-es/get.js'
 
+import {validationMarkerCodes} from './codes'
 import {convertToValidationMarker} from './util/convertToValidationMarker'
 import {isLocalizedMessages, localizeMessage} from './util/localizeMessage'
 import {pathToString} from './util/pathToString'
@@ -36,6 +37,14 @@ const isFieldRef = (constraint: unknown): constraint is {type: symbol; path: str
 }
 
 const EMPTY_ARRAY: unknown[] = []
+
+const fallbackCodeForRule = (flag: string) => {
+  if (flag === 'custom') return validationMarkerCodes.custom
+  if (flag === 'media') return validationMarkerCodes.mediaCustom
+  if (flag === 'all') return validationMarkerCodes.ruleAllFailed
+  if (flag === 'either') return validationMarkerCodes.ruleEitherFailed
+  return validationMarkerCodes.validationFailed
+}
 
 /**
  * Concrete Rule implementation with validation logic.
@@ -140,13 +149,19 @@ export const Rule: RuleClass = class Rule extends BaseRule implements IRule {
 
         try {
           const result = await validator(specConstraint, value, message, context)
-          return convertToValidationMarker(result, this._level, context)
+          return convertToValidationMarker(result, this._level, context, {
+            code: fallbackCodeForRule(curr.flag),
+          })
         } catch (err) {
           const errorMessage = `${pathToString(
             context.path,
           )}: Exception occurred while validating value: ${err.message}`
 
-          return convertToValidationMarker({message: errorMessage}, 'error', context)
+          return convertToValidationMarker(
+            {code: validationMarkerCodes.validationException, message: errorMessage},
+            'error',
+            context,
+          )
         }
       }),
     )

--- a/packages/@sanity/validation/src/codes.ts
+++ b/packages/@sanity/validation/src/codes.ts
@@ -1,0 +1,66 @@
+import {type ValidationMarker as BaseValidationMarker} from '@sanity/types'
+
+/** Machine-readable codes emitted by built-in document validation. @beta */
+export const validationMarkerCodes = {
+  arrayDuplicateItem: 'array.duplicate-item',
+  arrayExactLength: 'array.exact-length',
+  arrayMaximumLength: 'array.maximum-length',
+  arrayMinimumLength: 'array.minimum-length',
+  assetRequired: 'asset.required',
+  custom: 'custom',
+  dateInvalidFormat: 'date.invalid-format',
+  dateMaximum: 'date.maximum',
+  dateMinimum: 'date.minimum',
+  documentUnknownType: 'document.unknown-type',
+  mediaCustom: 'media.custom',
+  mediaInvalidReference: 'media.invalid-reference',
+  mediaNotFound: 'media.not-found',
+  numberGreaterThan: 'number.greater-than',
+  numberInteger: 'number.integer',
+  numberLessThan: 'number.less-than',
+  numberMaximum: 'number.maximum',
+  numberMinimum: 'number.minimum',
+  numberPrecision: 'number.precision',
+  objectUnknownField: 'object.unknown-field',
+  referenceInvalid: 'reference.invalid',
+  referenceNotPublished: 'reference.not-published',
+  ruleAllFailed: 'rule.all-failed',
+  ruleEitherFailed: 'rule.either-failed',
+  slugInvalidType: 'slug.invalid-type',
+  slugMissingCurrent: 'slug.missing-current',
+  slugNotUnique: 'slug.not-unique',
+  stringEmail: 'string.email',
+  stringExactLength: 'string.exact-length',
+  stringLowercase: 'string.lowercase',
+  stringMaximumLength: 'string.maximum-length',
+  stringMinimumLength: 'string.minimum-length',
+  stringRegexMatch: 'string.regex-match',
+  stringRegexMismatch: 'string.regex-mismatch',
+  stringUppercase: 'string.uppercase',
+  stringUrlCredentialsNotAllowed: 'string.url.credentials-not-allowed',
+  stringUrlInvalid: 'string.url.invalid',
+  stringUrlNotAbsolute: 'string.url.not-absolute',
+  stringUrlNotRelative: 'string.url.not-relative',
+  stringUrlSchemeNotAllowed: 'string.url.scheme-not-allowed',
+  validationException: 'validation.exception',
+  validationFailed: 'validation.failed',
+  valueNotAllowed: 'value.not-allowed',
+  valueRequired: 'value.required',
+  valueTypeMismatch: 'value.type-mismatch',
+} as const
+
+/** A code emitted by a built-in validator. @beta */
+export type BuiltInValidationMarkerCode =
+  (typeof validationMarkerCodes)[keyof typeof validationMarkerCodes]
+
+/**
+ * A built-in validation code or an application-defined custom code.
+ * Custom validators should namespace their codes, for example `custom.seo-title`.
+ * @beta
+ */
+export type ValidationMarkerCode = BuiltInValidationMarkerCode | (string & {})
+
+/** A validation marker emitted by `validateDocument`, which always has a code. @beta */
+export type DocumentValidationMarker = Omit<BaseValidationMarker, 'code'> & {
+  code: ValidationMarkerCode
+}

--- a/packages/@sanity/validation/src/index.ts
+++ b/packages/@sanity/validation/src/index.ts
@@ -11,7 +11,9 @@ export {
   validateDocument,
   type ValidateDocumentOptions,
   type ValidateDocumentWorkspaceOptions,
+  type ValidationClient,
   // oxlint-disable-next-line typescript/no-deprecated -- public compatibility export
   validateDocumentWithWorkspace,
+  type ValidationSchema,
   type ValidationSource,
 } from './validateDocument'

--- a/packages/@sanity/validation/src/index.ts
+++ b/packages/@sanity/validation/src/index.ts
@@ -2,6 +2,12 @@
 import './types'
 
 export {
+  type BuiltInValidationMarkerCode,
+  type DocumentValidationMarker,
+  type ValidationMarkerCode,
+  validationMarkerCodes,
+} from './codes'
+export {
   validateDocument,
   type ValidateDocumentOptions,
   type ValidateDocumentWorkspaceOptions,

--- a/packages/@sanity/validation/src/util/convertToValidationMarker.ts
+++ b/packages/@sanity/validation/src/util/convertToValidationMarker.ts
@@ -5,10 +5,6 @@ import {type ValidationMarkerCode, validationMarkerCodes} from '../codes'
 import {type ValidationContext} from '../types'
 import {pathToString} from '../util/pathToString'
 
-function isNonNullable<T>(t: T): t is NonNullable<T> {
-  return t !== null || t !== undefined
-}
-
 export function convertToValidationMarker(
   validatorResult: true | true[] | string | string[] | ValidationError | ValidationError[],
   level: 'error' | 'warning' | 'info' | undefined,
@@ -24,9 +20,9 @@ export function convertToValidationMarker(
   if (validatorResult === true) return []
 
   if (Array.isArray(validatorResult)) {
-    return validatorResult
-      .flatMap((child) => convertToValidationMarker(child, level, context, fallback))
-      .filter(isNonNullable)
+    return validatorResult.flatMap((child) =>
+      convertToValidationMarker(child, level, context, fallback),
+    )
   }
 
   if (typeof validatorResult === 'string') {

--- a/packages/@sanity/validation/src/util/convertToValidationMarker.ts
+++ b/packages/@sanity/validation/src/util/convertToValidationMarker.ts
@@ -6,7 +6,7 @@ import {type ValidationContext} from '../types'
 import {pathToString} from '../util/pathToString'
 
 function isNonNullable<T>(t: T): t is NonNullable<T> {
-  return t !== null || t !== undefined
+  return t !== null && t !== undefined
 }
 
 export function convertToValidationMarker(

--- a/packages/@sanity/validation/src/util/convertToValidationMarker.ts
+++ b/packages/@sanity/validation/src/util/convertToValidationMarker.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable typescript/no-deprecated -- marker compatibility requires legacy fields */
 import {type Path, type ValidationError, type ValidationMarker} from '@sanity/types'
 
+import {type ValidationMarkerCode, validationMarkerCodes} from '../codes'
 import {type ValidationContext} from '../types'
 import {pathToString} from '../util/pathToString'
 
@@ -12,6 +13,9 @@ export function convertToValidationMarker(
   validatorResult: true | true[] | string | string[] | ValidationError | ValidationError[],
   level: 'error' | 'warning' | 'info' | undefined,
   context: ValidationContext,
+  fallback: {code: ValidationMarkerCode; details?: Record<string, unknown>} = {
+    code: validationMarkerCodes.validationFailed,
+  },
 ): ValidationMarker[] {
   if (!context) {
     throw new Error('missing context')
@@ -21,12 +25,12 @@ export function convertToValidationMarker(
 
   if (Array.isArray(validatorResult)) {
     return validatorResult
-      .flatMap((child) => convertToValidationMarker(child, level, context))
+      .flatMap((child) => convertToValidationMarker(child, level, context, fallback))
       .filter(isNonNullable)
   }
 
   if (typeof validatorResult === 'string') {
-    return convertToValidationMarker({message: validatorResult}, level, context)
+    return convertToValidationMarker({message: validatorResult}, level, context, fallback)
   }
 
   if (typeof validatorResult.message !== 'string') {
@@ -40,6 +44,8 @@ export function convertToValidationMarker(
   }
 
   const {message, __internal_metadata} = validatorResult
+  const code = validatorResult.code || fallback.code
+  const details = validatorResult.details || fallback.details
 
   const normalizedPaths: Path[] = []
   if (validatorResult.path) {
@@ -56,6 +62,8 @@ export function convertToValidationMarker(
   if (!normalizedPaths.length) {
     return [
       {
+        code,
+        ...(details && {details}),
         level: level || 'error',
         item: {message},
         message,
@@ -69,6 +77,8 @@ export function convertToValidationMarker(
   // each item-level relative path, create a validation marker that concatenates
   // the relative path with the path from the validation context
   return normalizedPaths.map((path) => ({
+    code,
+    ...(details && {details}),
     path: (context.path || []).concat(path),
     level: level || 'error',
     item: {message},

--- a/packages/@sanity/validation/src/util/convertToValidationMarker.ts
+++ b/packages/@sanity/validation/src/util/convertToValidationMarker.ts
@@ -6,7 +6,7 @@ import {type ValidationContext} from '../types'
 import {pathToString} from '../util/pathToString'
 
 function isNonNullable<T>(t: T): t is NonNullable<T> {
-  return t !== null && t !== undefined
+  return t !== null || t !== undefined
 }
 
 export function convertToValidationMarker(

--- a/packages/@sanity/validation/src/validateDocument.ts
+++ b/packages/@sanity/validation/src/validateDocument.ts
@@ -13,7 +13,8 @@ import {
 import {createClientConcurrencyLimiter} from '@sanity/util/client'
 import {ConcurrencyLimiter} from '@sanity/util/concurrency-limiter'
 import flatten from 'lodash-es/flatten.js'
-import uniqBy from 'lodash-es/uniqBy.js'
+import isEqual from 'lodash-es/isEqual.js'
+import uniqWith from 'lodash-es/uniqWith.js'
 import {concat, defer, from, lastValueFrom, merge, Observable, of} from 'rxjs'
 import {catchError, map, mergeAll, mergeMap, switchMap, toArray} from 'rxjs/operators'
 
@@ -162,7 +163,10 @@ export interface ValidationSchema {
 
 /** A configured Sanity client accepted across compatible client versions. @beta */
 export interface ValidationClient {
-  withConfig(config: {apiVersion: string}): unknown
+  fetch: SanityClient['fetch']
+  getDataUrl: SanityClient['getDataUrl']
+  observable: Pick<SanityClient['observable'], 'request'>
+  withConfig(config: Parameters<SanityClient['withConfig']>[0]): ValidationClient
 }
 
 /**
@@ -230,7 +234,7 @@ export function validateDocumentWithWorkspace({
     maxCustomValidationConcurrency,
     maxFetchConcurrency,
     schema: workspace.schema,
-  }) as Promise<DocumentValidationMarker[]>
+  })
 }
 
 /**
@@ -270,7 +274,7 @@ export function validateDocument(
     i18n: getFallbackLocaleSource(),
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- compiled schemas may come from another compatible package version
     schema: schema as Schema,
-  }) as Promise<DocumentValidationMarker[]>
+  })
 }
 
 /** @internal */
@@ -297,7 +301,7 @@ export function validateDocumentInternal({
   maxCustomValidationConcurrency,
   maxFetchConcurrency,
   currentUser,
-}: ValidateDocumentInternalOptions): Promise<ValidationMarker[]> {
+}: ValidateDocumentInternalOptions): Promise<DocumentValidationMarker[]> {
   const limitConcurrency = createClientConcurrencyLimiter(
     maxFetchConcurrency ?? DEFAULT_MAX_FETCH_CONCURRENCY,
   )
@@ -350,7 +354,7 @@ export function validateDocumentObservable({
   environment,
   maxCustomValidationConcurrency,
   currentUser,
-}: ValidateDocumentObservableOptions): Observable<ValidationMarker[]> {
+}: ValidateDocumentObservableOptions): Observable<DocumentValidationMarker[]> {
   if (typeof document?._type !== 'string') {
     throw new Error(`Tried to validate a value without a '_type'`)
   }
@@ -402,11 +406,12 @@ export function validateDocumentObservable({
 
   return from(i18n.loadNamespaces(['validation'])).pipe(
     switchMap(() => validateItemObservable(validationOptions)),
+    map((markers) => markers.map(toDocumentValidationMarker)),
     catchError((err) => {
       console.error(err)
 
       const message = err?.message || 'Unknown error'
-      const errorMarker: ValidationMarker = {
+      const errorMarker: DocumentValidationMarker = {
         code: validationMarkerCodes.validationException,
         level: 'error',
         message,
@@ -619,14 +624,21 @@ function validateItemObservable({
     toArray(),
     map(flatten),
     map((results) => {
-      // run `uniqBy` if `_fieldRules` are present because they can
+      // Deduplicate markers when `_fieldRules` are present because they can
       // cause repeat markers (check recursively for nested rules)
       if (rules.some((rule) => extractFieldRulesFromRule(rule).length > 0)) {
-        return uniqBy(results, (rule) => JSON.stringify(rule))
+        return uniqWith(results, isEqual)
       }
       return results
     }),
   )
+}
+
+function toDocumentValidationMarker(marker: ValidationMarker): DocumentValidationMarker {
+  return {
+    ...marker,
+    code: marker.code || validationMarkerCodes.validationFailed,
+  }
 }
 
 function idle(timeout?: number): Observable<never> {

--- a/packages/@sanity/validation/src/validateDocument.ts
+++ b/packages/@sanity/validation/src/validateDocument.ts
@@ -14,7 +14,6 @@ import {createClientConcurrencyLimiter} from '@sanity/util/client'
 import {ConcurrencyLimiter} from '@sanity/util/concurrency-limiter'
 import flatten from 'lodash-es/flatten.js'
 import isEqual from 'lodash-es/isEqual.js'
-import uniqWith from 'lodash-es/uniqWith.js'
 import {concat, defer, from, lastValueFrom, merge, Observable, of} from 'rxjs'
 import {catchError, map, mergeAll, mergeMap, switchMap, toArray} from 'rxjs/operators'
 
@@ -627,11 +626,29 @@ function validateItemObservable({
       // Deduplicate markers when `_fieldRules` are present because they can
       // cause repeat markers (check recursively for nested rules)
       if (rules.some((rule) => extractFieldRulesFromRule(rule).length > 0)) {
-        return uniqWith(results, isEqual)
+        return deduplicateMarkers(results)
       }
       return results
     }),
   )
+}
+
+function deduplicateMarkers(markers: ValidationMarker[]): ValidationMarker[] {
+  const buckets = new Map<string, ValidationMarker[]>()
+
+  return markers.filter((marker) => {
+    const key = JSON.stringify([marker.level, marker.code, marker.message, marker.path])
+    const bucket = buckets.get(key)
+    if (!bucket) {
+      buckets.set(key, [marker])
+      return true
+    }
+
+    if (bucket.some((existing) => isEqual(existing, marker))) return false
+
+    bucket.push(marker)
+    return true
+  })
 }
 
 function toDocumentValidationMarker(marker: ValidationMarker): DocumentValidationMarker {

--- a/packages/@sanity/validation/src/validateDocument.ts
+++ b/packages/@sanity/validation/src/validateDocument.ts
@@ -17,6 +17,7 @@ import uniqBy from 'lodash-es/uniqBy.js'
 import {concat, defer, from, lastValueFrom, merge, Observable, of} from 'rxjs'
 import {catchError, map, mergeAll, mergeMap, switchMap, toArray} from 'rxjs/operators'
 
+import {type DocumentValidationMarker, validationMarkerCodes} from './codes'
 import {getFallbackLocaleSource} from './i18n/fallback'
 import {type LocaleSource} from './i18n/types'
 import {resolveConditionalProperty} from './resolveConditionalProperty'
@@ -208,7 +209,7 @@ export function validateDocumentWithWorkspace({
   maxCustomValidationConcurrency,
   maxFetchConcurrency,
   currentUser,
-}: ValidateDocumentWorkspaceOptions): Promise<ValidationMarker[]> {
+}: ValidateDocumentWorkspaceOptions): Promise<DocumentValidationMarker[]> {
   return validateDocumentInternal({
     currentUser,
     document,
@@ -219,7 +220,7 @@ export function validateDocumentWithWorkspace({
     maxCustomValidationConcurrency,
     maxFetchConcurrency,
     schema: workspace.schema,
-  })
+  }) as Promise<DocumentValidationMarker[]>
 }
 
 /**
@@ -232,17 +233,19 @@ export function validateDocumentWithWorkspace({
  */
 export function validateDocument(
   options: ValidateDocumentWorkspaceOptions,
-): Promise<ValidationMarker[]>
+): Promise<DocumentValidationMarker[]>
 /**
  * Validates a document against a compiled schema. Returns validation markers
  * without deciding whether the document may be edited or published.
  *
  * @beta
  */
-export function validateDocument(options: ValidateDocumentOptions): Promise<ValidationMarker[]>
+export function validateDocument(
+  options: ValidateDocumentOptions,
+): Promise<DocumentValidationMarker[]>
 export function validateDocument(
   options: ValidateDocumentOptions | ValidateDocumentWorkspaceOptions,
-): Promise<ValidationMarker[]> {
+): Promise<DocumentValidationMarker[]> {
   if ('workspace' in options) {
     return validateDocumentWithWorkspace(options)
   }
@@ -255,7 +258,7 @@ export function validateDocument(
     getClient: ({apiVersion}) => client.withConfig({apiVersion}),
     i18n: getFallbackLocaleSource(),
     schema,
-  })
+  }) as Promise<DocumentValidationMarker[]>
 }
 
 /** @internal */
@@ -353,6 +356,8 @@ export function validateDocumentObservable({
 
     return of([
       {
+        code: validationMarkerCodes.documentUnknownType,
+        details: {documentType: document._type},
         level: 'warning',
         message: `Could not find schema type for type '${document._type}', skipping validation`,
         path: [],
@@ -390,6 +395,7 @@ export function validateDocumentObservable({
 
       const message = err?.message || 'Unknown error'
       const errorMarker: ValidationMarker = {
+        code: validationMarkerCodes.validationException,
         level: 'error',
         message,
         item: {message},

--- a/packages/@sanity/validation/src/validateDocument.ts
+++ b/packages/@sanity/validation/src/validateDocument.ts
@@ -160,7 +160,14 @@ export interface ValidationSchema {
   get(name: string): unknown
 }
 
-/** A configured Sanity client accepted across compatible client versions. @beta */
+/**
+ * A configured Sanity client accepted across compatible client versions.
+ *
+ * This structural type describes the capabilities used internally by validation.
+ * The configured client is exposed to custom validators as a `SanityClient`, so it must be compatible with the full client API.
+ *
+ * @beta
+ */
 export interface ValidationClient {
   fetch: SanityClient['fetch']
   getDataUrl: SanityClient['getDataUrl']

--- a/packages/@sanity/validation/src/validateDocument.ts
+++ b/packages/@sanity/validation/src/validateDocument.ts
@@ -14,7 +14,6 @@ import {createClientConcurrencyLimiter} from '@sanity/util/client'
 import {ConcurrencyLimiter} from '@sanity/util/concurrency-limiter'
 import flatten from 'lodash-es/flatten.js'
 import isEqual from 'lodash-es/isEqual.js'
-import uniqWith from 'lodash-es/uniqWith.js'
 import {concat, defer, from, lastValueFrom, merge, Observable, of} from 'rxjs'
 import {catchError, map, mergeAll, mergeMap, switchMap, toArray} from 'rxjs/operators'
 
@@ -627,17 +626,41 @@ function validateItemObservable({
       // Deduplicate markers when `_fieldRules` are present because they can
       // cause repeat markers (check recursively for nested rules)
       if (rules.some((rule) => extractFieldRulesFromRule(rule).length > 0)) {
-        return uniqWith(results, isEqual)
+        return deduplicateMarkers(results)
       }
       return results
     }),
   )
 }
 
+function deduplicateMarkers(markers: ValidationMarker[]): ValidationMarker[] {
+  const buckets = new Map<string, ValidationMarker[]>()
+
+  return markers.filter((marker) => {
+    const key = JSON.stringify([marker.level, marker.code, marker.message, marker.path])
+    const bucket = buckets.get(key)
+    if (!bucket) {
+      buckets.set(key, [marker])
+      return true
+    }
+
+    if (bucket.some((existing) => isEqual(existing, marker))) return false
+
+    bucket.push(marker)
+    return true
+  })
+}
+
+function hasValidationMarkerCode(marker: ValidationMarker): marker is DocumentValidationMarker {
+  return typeof marker.code === 'string'
+}
+
 function toDocumentValidationMarker(marker: ValidationMarker): DocumentValidationMarker {
+  if (hasValidationMarkerCode(marker)) return marker
+
   return {
     ...marker,
-    code: marker.code || validationMarkerCodes.validationFailed,
+    code: validationMarkerCodes.validationFailed,
   }
 }
 

--- a/packages/@sanity/validation/src/validateDocument.ts
+++ b/packages/@sanity/validation/src/validateDocument.ts
@@ -109,10 +109,10 @@ export interface ValidateDocumentOptions {
    */
   document: SanityDocument
   /** The compiled schema to validate against. */
-  schema: Schema
+  schema: ValidationSchema
 
   /** A configured client used for reference checks and custom validators. */
-  client: SanityClient
+  client: ValidationClient
 
   /**
    * Function used to check if referenced documents exists (and is published).
@@ -153,6 +153,16 @@ export interface ValidateDocumentOptions {
    * is resolved with no user (e.g. CLI or headless validation).
    */
   currentUser?: Omit<CurrentUser, 'role'> | null
+}
+
+/** A compiled schema accepted across compatible `@sanity/types` versions. @beta */
+export interface ValidationSchema {
+  get(name: string): unknown
+}
+
+/** A configured Sanity client accepted across compatible client versions. @beta */
+export interface ValidationClient {
+  withConfig(config: {apiVersion: string}): unknown
 }
 
 /**
@@ -255,9 +265,11 @@ export function validateDocument(
     ...internalOptions,
     document,
     environment: 'cli',
-    getClient: ({apiVersion}) => client.withConfig({apiVersion}),
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- runtime-compatible clients may come from another major
+    getClient: ({apiVersion}) => client.withConfig({apiVersion}) as SanityClient,
     i18n: getFallbackLocaleSource(),
-    schema,
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- compiled schemas may come from another compatible package version
+    schema: schema as Schema,
   }) as Promise<DocumentValidationMarker[]>
 }
 

--- a/packages/@sanity/validation/src/validateDocument.ts
+++ b/packages/@sanity/validation/src/validateDocument.ts
@@ -14,6 +14,7 @@ import {createClientConcurrencyLimiter} from '@sanity/util/client'
 import {ConcurrencyLimiter} from '@sanity/util/concurrency-limiter'
 import flatten from 'lodash-es/flatten.js'
 import isEqual from 'lodash-es/isEqual.js'
+import uniqWith from 'lodash-es/uniqWith.js'
 import {concat, defer, from, lastValueFrom, merge, Observable, of} from 'rxjs'
 import {catchError, map, mergeAll, mergeMap, switchMap, toArray} from 'rxjs/operators'
 
@@ -164,7 +165,7 @@ export interface ValidationSchema {
 export interface ValidationClient {
   fetch: SanityClient['fetch']
   getDataUrl: SanityClient['getDataUrl']
-  observable: Pick<SanityClient['observable'], 'request'>
+  observable: Pick<SanityClient['observable'], 'fetch' | 'request'>
   withConfig(config: Parameters<SanityClient['withConfig']>[0]): ValidationClient
 }
 
@@ -626,29 +627,11 @@ function validateItemObservable({
       // Deduplicate markers when `_fieldRules` are present because they can
       // cause repeat markers (check recursively for nested rules)
       if (rules.some((rule) => extractFieldRulesFromRule(rule).length > 0)) {
-        return deduplicateMarkers(results)
+        return uniqWith(results, isEqual)
       }
       return results
     }),
   )
-}
-
-function deduplicateMarkers(markers: ValidationMarker[]): ValidationMarker[] {
-  const buckets = new Map<string, ValidationMarker[]>()
-
-  return markers.filter((marker) => {
-    const key = JSON.stringify([marker.level, marker.code, marker.message, marker.path])
-    const bucket = buckets.get(key)
-    if (!bucket) {
-      buckets.set(key, [marker])
-      return true
-    }
-
-    if (bucket.some((existing) => isEqual(existing, marker))) return false
-
-    bucket.push(marker)
-    return true
-  })
 }
 
 function toDocumentValidationMarker(marker: ValidationMarker): DocumentValidationMarker {

--- a/packages/@sanity/validation/src/validators/arrayValidator.ts
+++ b/packages/@sanity/validation/src/validators/arrayValidator.ts
@@ -5,6 +5,7 @@ import {
   type Validators,
 } from '@sanity/types'
 
+import {validationMarkerCodes} from '../codes'
 import {deepEqualsIgnoreKey} from '../util/deepEqualsIgnoreKey'
 import {genericValidators} from './genericValidator'
 
@@ -17,7 +18,11 @@ export const arrayValidators: Validators = {
     }
 
     const context = isArrayOfBlocksSchemaType(type) ? 'blocks' : undefined
-    return message || i18n.t('validation:array.minimum-length', {minLength, context})
+    return {
+      code: validationMarkerCodes.arrayMinimumLength,
+      details: {actualLength: value.length, minimumLength: minLength},
+      message: message || i18n.t('validation:array.minimum-length', {minLength, context}),
+    }
   },
 
   max: (maxLength, value, message, {i18n, type}) => {
@@ -26,7 +31,11 @@ export const arrayValidators: Validators = {
     }
 
     const context = isArrayOfBlocksSchemaType(type) ? 'blocks' : undefined
-    return message || i18n.t('validation:array.maximum-length', {maxLength, context})
+    return {
+      code: validationMarkerCodes.arrayMaximumLength,
+      details: {actualLength: value.length, maximumLength: maxLength},
+      message: message || i18n.t('validation:array.maximum-length', {maxLength, context}),
+    }
   },
 
   length: (wantedLength, value, message, {i18n, type}) => {
@@ -35,12 +44,19 @@ export const arrayValidators: Validators = {
     }
 
     const context = isArrayOfBlocksSchemaType(type) ? 'blocks' : undefined
-    return message || i18n.t('validation:array.exact-length', {wantedLength, context})
+    return {
+      code: validationMarkerCodes.arrayExactLength,
+      details: {actualLength: value.length, expectedLength: wantedLength},
+      message: message || i18n.t('validation:array.exact-length', {wantedLength, context}),
+    }
   },
 
   presence: (flag, value, message, {i18n}) => {
     if (flag === 'required' && !value) {
-      return message || i18n.t('validation:generic.required', {context: 'array'})
+      return {
+        code: validationMarkerCodes.valueRequired,
+        message: message || i18n.t('validation:generic.required', {context: 'array'}),
+      }
     }
 
     return true
@@ -66,7 +82,12 @@ export const arrayValidators: Validators = {
     // we emit the same message for each path we find in this array
     const sharedMessage = message || i18n.t('validation:generic.not-allowed')
 
-    return paths.map((path) => ({message: sharedMessage, path}))
+    return paths.map((path) => ({
+      code: validationMarkerCodes.valueNotAllowed,
+      details: {allowedValues},
+      message: sharedMessage,
+      path,
+    }))
   },
 
   unique: (_unused, value, message, {i18n}) => {
@@ -103,6 +124,10 @@ export const arrayValidators: Validators = {
     // we emit the same message for each path we find in this array
     const sharedMessage = message || i18n.t('validation:array.item-duplicate')
 
-    return paths.map((path) => ({message: sharedMessage, path}))
+    return paths.map((path) => ({
+      code: validationMarkerCodes.arrayDuplicateItem,
+      message: sharedMessage,
+      path,
+    }))
   },
 }

--- a/packages/@sanity/validation/src/validators/arrayValidator.ts
+++ b/packages/@sanity/validation/src/validators/arrayValidator.ts
@@ -84,7 +84,7 @@ export const arrayValidators: Validators = {
 
     return paths.map((path) => ({
       code: validationMarkerCodes.valueNotAllowed,
-      details: {allowedValues},
+      details: {allowedValuesCount: allowedValues.length},
       message: sharedMessage,
       path,
     }))

--- a/packages/@sanity/validation/src/validators/booleanValidator.ts
+++ b/packages/@sanity/validation/src/validators/booleanValidator.ts
@@ -1,5 +1,6 @@
 import {type Validators} from '@sanity/types'
 
+import {validationMarkerCodes} from '../codes'
 import {genericValidators} from './genericValidator'
 
 export const booleanValidators: Validators = {
@@ -7,7 +8,10 @@ export const booleanValidators: Validators = {
 
   presence: (flag, value, message, {i18n}) => {
     if (flag === 'required' && typeof value !== 'boolean') {
-      return message || i18n.t('validation:generic.required', {context: 'boolean'})
+      return {
+        code: validationMarkerCodes.valueRequired,
+        message: message || i18n.t('validation:generic.required', {context: 'boolean'}),
+      }
     }
 
     return true

--- a/packages/@sanity/validation/src/validators/dateValidator.ts
+++ b/packages/@sanity/validation/src/validators/dateValidator.ts
@@ -1,6 +1,7 @@
 import {type Validators} from '@sanity/types'
 import * as legacyDateFormat from '@sanity/util/legacyDateFormat'
 
+import {validationMarkerCodes} from '../codes'
 import {genericValidators} from './genericValidator'
 
 function isRecord(obj: unknown): obj is Record<string, unknown> {
@@ -55,7 +56,11 @@ export const dateValidators: Validators = {
       return true
     }
 
-    return message || i18n.t('validation:date.invalid-format')
+    return {
+      code: validationMarkerCodes.dateInvalidFormat,
+      details: {actualValue: value},
+      message: message || i18n.t('validation:date.invalid-format'),
+    }
   },
 
   min: (minDate, value, message, {type, i18n}) => {
@@ -78,16 +83,19 @@ export const dateValidators: Validators = {
       ? (type.options as DateTimeOptions)
       : {}
 
-    return (
-      message ||
-      // Note that the `minDate` passed here is _formatted_, while the raw value provided to the
-      // validator is available as `providedMinDate`. This because the formatted date is likely
-      // what the developer wants to present to the user
-      i18n.t('validation:date.minimum', {
-        minDate: getFormattedDate(type.name, minDateVal, dateTimeOptions),
-        providedMinDate: minDate,
-      })
-    )
+    return {
+      code: validationMarkerCodes.dateMinimum,
+      details: {actualValue: value, minimum: minDate},
+      message:
+        message ||
+        // Note that the `minDate` passed here is _formatted_, while the raw value provided to the
+        // validator is available as `providedMinDate`. This because the formatted date is likely
+        // what the developer wants to present to the user
+        i18n.t('validation:date.minimum', {
+          minDate: getFormattedDate(type.name, minDateVal, dateTimeOptions),
+          providedMinDate: minDate,
+        }),
+    }
   },
 
   max: (maxDate, value, message, {type, i18n}) => {
@@ -110,15 +118,18 @@ export const dateValidators: Validators = {
       ? (type.options as DateTimeOptions)
       : {}
 
-    return (
-      message ||
-      // Note that the `maxDate` passed here is _formatted_, while the raw value provided to the
-      // validator is available as `providedMaxDate`. This because the formatted date is likely
-      // what the developer wants to present to the user
-      i18n.t('validation:date.maximum', {
-        maxDate: getFormattedDate(type.name, maxDateVal, dateTimeOptions),
-        providedMaxDate: maxDate,
-      })
-    )
+    return {
+      code: validationMarkerCodes.dateMaximum,
+      details: {actualValue: value, maximum: maxDate},
+      message:
+        message ||
+        // Note that the `maxDate` passed here is _formatted_, while the raw value provided to the
+        // validator is available as `providedMaxDate`. This because the formatted date is likely
+        // what the developer wants to present to the user
+        i18n.t('validation:date.maximum', {
+          maxDate: getFormattedDate(type.name, maxDateVal, dateTimeOptions),
+          providedMaxDate: maxDate,
+        }),
+    }
   },
 }

--- a/packages/@sanity/validation/src/validators/genericValidator.ts
+++ b/packages/@sanity/validation/src/validators/genericValidator.ts
@@ -32,10 +32,10 @@ const formatValidationErrors = (options: {
         ? validationMarkerCodes.ruleAllFailed
         : validationMarkerCodes.ruleEitherFailed,
     details: {
-      causes: options.results.map(({code, details, message: causeMessage, path}) => ({
+      causes: options.results.map(({code, details, item, message: causeMessage, path}) => ({
         code: code || validationMarkerCodes.validationFailed,
         details,
-        message: causeMessage,
+        message: causeMessage || item?.message,
         path,
       })),
     },

--- a/packages/@sanity/validation/src/validators/genericValidator.ts
+++ b/packages/@sanity/validation/src/validators/genericValidator.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable typescript/no-deprecated -- marker compatibility requires the legacy item field */
-import {type ValidationMarker, type Validators} from '@sanity/types'
+import {type ValidationError, type ValidationMarker, type Validators} from '@sanity/types'
 
+import {validationMarkerCodes} from '../codes'
 import {type LocaleSource} from '../i18n/types'
 import {deepEqualsIgnoreKey} from '../util/deepEqualsIgnoreKey'
 import {isLocalizedMessages, localizeMessage} from '../util/localizeMessage'
@@ -14,22 +15,43 @@ const formatValidationErrors = (options: {
   results: ValidationMarker[]
   operation: 'conjunction' | 'disjunction'
   i18n: LocaleSource
-}) => {
-  if (options.message) return options.message
-  if (options.results.length === 1) return options.results[0]?.message
+}): ValidationError => {
+  const message =
+    options.message ||
+    (options.results.length === 1
+      ? options.results[0]?.message
+      : // Intentionally hard-coded to use locale conjunction/disjunctions
+        options.i18n.t('{{messages, list}}', {
+          messages: options.results.map((err) => err.message || err.item?.message),
+          formatParams: {messages: {style: 'long', type: options.operation}},
+        }))
 
-  // Intentionally hard-coded to use locale conjunction/disjunctions
-  return options.i18n.t('{{messages, list}}', {
-    messages: options.results.map((err) => err.message || err.item?.message),
-    formatParams: {messages: {style: 'long', type: options.operation}},
-  })
+  return {
+    code:
+      options.operation === 'conjunction'
+        ? validationMarkerCodes.ruleAllFailed
+        : validationMarkerCodes.ruleEitherFailed,
+    details: {
+      causes: options.results.map(({code, details, message: causeMessage, path}) => ({
+        code,
+        details,
+        message: causeMessage,
+        path,
+      })),
+    },
+    message: message || 'Validation failed',
+  }
 }
 
 export const genericValidators: Validators = {
   type: (expectedType, value, message, {i18n}) => {
     const actualType = typeString(value)
     if (actualType !== expectedType && actualType !== 'undefined') {
-      return message || i18n.t('validation:generic.incorrect-type', {actualType, expectedType})
+      return {
+        code: validationMarkerCodes.valueTypeMismatch,
+        details: {actualType, expectedType},
+        message: message || i18n.t('validation:generic.incorrect-type', {actualType, expectedType}),
+      }
     }
 
     return true
@@ -37,7 +59,10 @@ export const genericValidators: Validators = {
 
   presence: (expected, value, message, {i18n}) => {
     if (value === undefined && expected === 'required') {
-      return message || i18n.t('validation:generic.required')
+      return {
+        code: validationMarkerCodes.valueRequired,
+        message: message || i18n.t('validation:generic.required'),
+      }
     }
 
     return true
@@ -85,13 +110,20 @@ export const genericValidators: Validators = {
     const value = (valueType === 'number' || valueType === 'string') && `${actual}`
     const strValue = value && value.length > 30 ? `${value.slice(0, 30)}…` : value
 
-    return allowedValues.some((expected) => deepEqualsIgnoreKey(expected, actual))
-      ? true
-      : message ||
-          i18n.t(
-            'validation:generic.not-allowed',
-            value ? {context: 'hint', replace: {hint: strValue}} : {},
-          )
+    if (allowedValues.some((expected) => deepEqualsIgnoreKey(expected, actual))) {
+      return true
+    }
+
+    return {
+      code: validationMarkerCodes.valueNotAllowed,
+      details: {allowedValues},
+      message:
+        message ||
+        i18n.t(
+          'validation:generic.not-allowed',
+          value ? {context: 'hint', replace: {hint: strValue}} : {},
+        ),
+    }
   },
 
   custom: async (fn, value, message, context) => {

--- a/packages/@sanity/validation/src/validators/genericValidator.ts
+++ b/packages/@sanity/validation/src/validators/genericValidator.ts
@@ -33,7 +33,7 @@ const formatValidationErrors = (options: {
         : validationMarkerCodes.ruleEitherFailed,
     details: {
       causes: options.results.map(({code, details, message: causeMessage, path}) => ({
-        code,
+        code: code || validationMarkerCodes.validationFailed,
         details,
         message: causeMessage,
         path,
@@ -116,7 +116,7 @@ export const genericValidators: Validators = {
 
     return {
       code: validationMarkerCodes.valueNotAllowed,
-      details: {allowedValues},
+      details: {allowedValuesCount: allowedValues.length},
       message:
         message ||
         i18n.t(

--- a/packages/@sanity/validation/src/validators/numberValidator.ts
+++ b/packages/@sanity/validation/src/validators/numberValidator.ts
@@ -1,5 +1,6 @@
 import {type Validators} from '@sanity/types'
 
+import {validationMarkerCodes} from '../codes'
 import {genericValidators} from './genericValidator'
 
 const precisionRx = /(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/
@@ -9,7 +10,11 @@ export const numberValidators: Validators = {
 
   integer: (_unused, value, message, {i18n}) => {
     if (!Number.isInteger(value)) {
-      return message || i18n.t('validation:number.non-integer')
+      return {
+        code: validationMarkerCodes.numberInteger,
+        details: {actualValue: value},
+        message: message || i18n.t('validation:number.non-integer'),
+      }
     }
 
     return true
@@ -25,7 +30,11 @@ export const numberValidators: Validators = {
     )
 
     if (decimals > limit) {
-      return message || i18n.t('validation:number.maximum-precision', {limit})
+      return {
+        code: validationMarkerCodes.numberPrecision,
+        details: {actualPrecision: decimals, maximumPrecision: limit},
+        message: message || i18n.t('validation:number.maximum-precision', {limit}),
+      }
     }
 
     return true
@@ -36,7 +45,11 @@ export const numberValidators: Validators = {
       return true
     }
 
-    return message || i18n.t('validation:number.minimum', {minNumber})
+    return {
+      code: validationMarkerCodes.numberMinimum,
+      details: {actualValue: value, minimum: minNumber},
+      message: message || i18n.t('validation:number.minimum', {minNumber}),
+    }
   },
 
   max: (maxNumber, value, message, {i18n}) => {
@@ -44,7 +57,11 @@ export const numberValidators: Validators = {
       return true
     }
 
-    return message || i18n.t('validation:number.maximum', {maxNumber})
+    return {
+      code: validationMarkerCodes.numberMaximum,
+      details: {actualValue: value, maximum: maxNumber},
+      message: message || i18n.t('validation:number.maximum', {maxNumber}),
+    }
   },
 
   greaterThan: (threshold, value, message, {i18n}) => {
@@ -52,7 +69,11 @@ export const numberValidators: Validators = {
       return true
     }
 
-    return message || i18n.t('validation:number.greater-than', {threshold})
+    return {
+      code: validationMarkerCodes.numberGreaterThan,
+      details: {actualValue: value, threshold},
+      message: message || i18n.t('validation:number.greater-than', {threshold}),
+    }
   },
 
   lessThan: (threshold, value, message, {i18n}) => {
@@ -60,6 +81,10 @@ export const numberValidators: Validators = {
       return true
     }
 
-    return message || i18n.t('validation:number.less-than', {threshold})
+    return {
+      code: validationMarkerCodes.numberLessThan,
+      details: {actualValue: value, threshold},
+      message: message || i18n.t('validation:number.less-than', {threshold}),
+    }
   },
 }

--- a/packages/@sanity/validation/src/validators/objectValidator.ts
+++ b/packages/@sanity/validation/src/validators/objectValidator.ts
@@ -4,6 +4,7 @@ import {type CustomValidatorResult, isReference, type Validators} from '@sanity/
 import {validationMarkerCodes} from '../codes'
 import {isLocalizedMessages, localizeMessage} from '../util/localizeMessage'
 import {pathToString} from '../util/pathToString'
+import {typeString} from '../util/typeString'
 import {genericValidators, SLOW_VALIDATOR_TIMEOUT} from './genericValidator'
 
 const metaKeys = ['_key', '_type', '_weak']
@@ -43,7 +44,7 @@ export const objectValidators: Validators = {
     if (!isReference(value)) {
       return {
         code: validationMarkerCodes.referenceInvalid,
-        details: {actualType: typeof value},
+        details: {actualType: typeString(value)},
         message: message || i18n.t('validation:object.not-reference'),
       }
     }

--- a/packages/@sanity/validation/src/validators/objectValidator.ts
+++ b/packages/@sanity/validation/src/validators/objectValidator.ts
@@ -1,6 +1,7 @@
 import {type DocumentId, getPublishedId} from '@sanity/id-utils'
 import {type CustomValidatorResult, isReference, type Validators} from '@sanity/types'
 
+import {validationMarkerCodes} from '../codes'
 import {isLocalizedMessages, localizeMessage} from '../util/localizeMessage'
 import {pathToString} from '../util/pathToString'
 import {genericValidators, SLOW_VALIDATOR_TIMEOUT} from './genericValidator'
@@ -23,7 +24,10 @@ export const objectValidators: Validators = {
     const keys = value && Object.keys(value).filter((key) => !metaKeys.includes(key))
 
     if (value === undefined || (keys && keys.length === 0)) {
-      return message || i18n.t('validation:generic.required', {context: 'object'})
+      return {
+        code: validationMarkerCodes.valueRequired,
+        message: message || i18n.t('validation:generic.required', {context: 'object'}),
+      }
     }
 
     return true
@@ -37,7 +41,11 @@ export const objectValidators: Validators = {
     const {type, document, getDocumentExists, i18n} = context
 
     if (!isReference(value)) {
-      return message || i18n.t('validation:object.not-reference')
+      return {
+        code: validationMarkerCodes.referenceInvalid,
+        details: {actualType: typeof value},
+        message: message || i18n.t('validation:object.not-reference'),
+      }
     }
 
     if (!type) {
@@ -59,7 +67,11 @@ export const objectValidators: Validators = {
     }
     const exists = await getDocumentExists({id: value._ref})
     if (!exists) {
-      return i18n.t('validation:object.reference-not-published', {documentId: value._ref})
+      return {
+        code: validationMarkerCodes.referenceNotPublished,
+        details: {referenceId: value._ref},
+        message: i18n.t('validation:object.reference-not-published', {documentId: value._ref}),
+      }
     }
 
     return true
@@ -71,6 +83,8 @@ export const objectValidators: Validators = {
         __internal_metadata: {
           name: 'assetRequired',
         },
+        code: validationMarkerCodes.assetRequired,
+        details: {assetType: flag.assetType},
         message:
           message || i18n.t('validation:object.asset-required', {context: flag.assetType || ''}),
       }
@@ -99,7 +113,10 @@ export const objectValidators: Validators = {
     // If the value is not an object or does not have a media reference, we return an error message.
     // It should not be allowed to use regular dataset assets with this validator.
     if (!value || !value.media || !value.media._ref) {
-      return context.i18n.t('validation:object.not-media-library-asset')
+      return {
+        code: validationMarkerCodes.mediaInvalidReference,
+        message: context.i18n.t('validation:object.not-media-library-asset'),
+      }
     }
 
     let result: CustomValidatorResult = true
@@ -121,7 +138,11 @@ export const objectValidators: Validators = {
         console.warn(
           `${context.i18n.t('validation:object.media-not-found')}\nAsset ID: ${value.media._ref}`,
         )
-        return context.i18n.t('validation:object.media-not-found')
+        return {
+          code: validationMarkerCodes.mediaNotFound,
+          details: {referenceId: value.media._ref},
+          message: context.i18n.t('validation:object.media-not-found'),
+        }
       }
 
       result = await fn(

--- a/packages/@sanity/validation/src/validators/slugValidator.ts
+++ b/packages/@sanity/validation/src/validators/slugValidator.ts
@@ -12,6 +12,7 @@ import {
 import memoize from 'lodash-es/memoize.js'
 
 import {validationMarkerCodes} from '../codes'
+import {typeString} from '../util/typeString'
 
 const DEFAULT_API_VERSION = '2025-02-19'
 
@@ -91,7 +92,7 @@ export const slugValidator: CustomValidator = async (value, context) => {
   if (typeof value !== 'object' || Array.isArray(value)) {
     return {
       code: validationMarkerCodes.slugInvalidType,
-      details: {actualType: Array.isArray(value) ? 'array' : typeof value},
+      details: {actualType: typeString(value)},
       message: i18n.t('validation:slug.not-object'),
     }
   }

--- a/packages/@sanity/validation/src/validators/slugValidator.ts
+++ b/packages/@sanity/validation/src/validators/slugValidator.ts
@@ -11,6 +11,8 @@ import {
 } from '@sanity/types'
 import memoize from 'lodash-es/memoize.js'
 
+import {validationMarkerCodes} from '../codes'
+
 const DEFAULT_API_VERSION = '2025-02-19'
 
 const memoizedWarnOnArraySlug = memoize(warnOnArraySlug)
@@ -87,11 +89,18 @@ export const slugValidator: CustomValidator = async (value, context) => {
   const {i18n} = context
 
   if (typeof value !== 'object' || Array.isArray(value)) {
-    return i18n.t('validation:slug.not-object')
+    return {
+      code: validationMarkerCodes.slugInvalidType,
+      details: {actualType: Array.isArray(value) ? 'array' : typeof value},
+      message: i18n.t('validation:slug.not-object'),
+    }
   }
 
   if (!isSlug(value) || value.current.trim().length === 0) {
-    return i18n.t('validation:slug.missing-current')
+    return {
+      code: validationMarkerCodes.slugMissingCurrent,
+      message: i18n.t('validation:slug.missing-current'),
+    }
   }
 
   const options = context?.type?.options as {isUnique?: SlugIsUniqueValidator} | undefined
@@ -109,5 +118,9 @@ export const slugValidator: CustomValidator = async (value, context) => {
     return true
   }
 
-  return i18n.t('validation:slug.not-unique', {slug: value.current})
+  return {
+    code: validationMarkerCodes.slugNotUnique,
+    details: {slug: value.current},
+    message: i18n.t('validation:slug.not-unique', {slug: value.current}),
+  }
 }

--- a/packages/@sanity/validation/src/validators/stringValidator.ts
+++ b/packages/@sanity/validation/src/validators/stringValidator.ts
@@ -1,5 +1,6 @@
 import {type Validators} from '@sanity/types'
 
+import {validationMarkerCodes} from '../codes'
 import {genericValidators} from './genericValidator'
 
 const DUMMY_ORIGIN = 'http://sanity'
@@ -15,7 +16,11 @@ export const stringValidators: Validators = {
       return true
     }
 
-    return message || i18n.t('validation:string.minimum-length', {minLength})
+    return {
+      code: validationMarkerCodes.stringMinimumLength,
+      details: {actualLength: value.length, minimumLength: minLength},
+      message: message || i18n.t('validation:string.minimum-length', {minLength}),
+    }
   },
 
   max: (maxLength, value, message, {i18n}) => {
@@ -23,7 +28,11 @@ export const stringValidators: Validators = {
       return true
     }
 
-    return message || i18n.t('validation:string.maximum-length', {maxLength})
+    return {
+      code: validationMarkerCodes.stringMaximumLength,
+      details: {actualLength: value.length, maximumLength: maxLength},
+      message: message || i18n.t('validation:string.maximum-length', {maxLength}),
+    }
   },
 
   length: (wantedLength, value, message, {i18n}) => {
@@ -32,7 +41,11 @@ export const stringValidators: Validators = {
       return true
     }
 
-    return message || i18n.t('validation:string.exact-length', {wantedLength})
+    return {
+      code: validationMarkerCodes.stringExactLength,
+      details: {actualLength: strValue.length, expectedLength: wantedLength},
+      message: message || i18n.t('validation:string.exact-length', {wantedLength}),
+    }
   },
 
   uri: (constraints, value, message, {i18n}) => {
@@ -51,19 +64,31 @@ export const stringValidators: Validators = {
       // to new URL(str, base), and will fail if invoked with new URL(strValue, undefined)
       url = allowRelative ? new URL(strValue, DUMMY_ORIGIN) : new URL(strValue)
     } catch {
-      return message || i18n.t('validation:string.url.invalid')
+      return {
+        code: validationMarkerCodes.stringUrlInvalid,
+        message: message || i18n.t('validation:string.url.invalid'),
+      }
     }
 
     if (relativeOnly && url.origin !== DUMMY_ORIGIN) {
-      return message || i18n.t('validation:string.url.not-relative')
+      return {
+        code: validationMarkerCodes.stringUrlNotRelative,
+        message: message || i18n.t('validation:string.url.not-relative'),
+      }
     }
 
     if (!allowRelative && url.origin === DUMMY_ORIGIN && isRelativeUrl(strValue)) {
-      return message || i18n.t('validation:string.url.not-absolute')
+      return {
+        code: validationMarkerCodes.stringUrlNotAbsolute,
+        message: message || i18n.t('validation:string.url.not-absolute'),
+      }
     }
 
     if (!allowCredentials && (url.username || url.password)) {
-      return message || i18n.t('validation:string.url.includes-credentials')
+      return {
+        code: validationMarkerCodes.stringUrlCredentialsNotAllowed,
+        message: message || i18n.t('validation:string.url.includes-credentials'),
+      }
     }
 
     const urlScheme = url.protocol.replace(/:$/, '')
@@ -71,7 +96,11 @@ export const stringValidators: Validators = {
     const matchesAllowedScheme =
       isRelative || options.scheme.some((scheme) => scheme.test(urlScheme))
     if (!matchesAllowedScheme) {
-      return message || i18n.t('validation:string.url.disallowed-scheme', {scheme: urlScheme})
+      return {
+        code: validationMarkerCodes.stringUrlSchemeNotAllowed,
+        details: {scheme: urlScheme},
+        message: message || i18n.t('validation:string.url.disallowed-scheme', {scheme: urlScheme}),
+      }
     }
 
     return true
@@ -80,11 +109,17 @@ export const stringValidators: Validators = {
   stringCasing: (casing, value, message, {i18n}) => {
     const strValue = value || ''
     if (casing === 'uppercase' && strValue !== strValue.toLocaleUpperCase()) {
-      return message || i18n.t('validation:string.uppercase')
+      return {
+        code: validationMarkerCodes.stringUppercase,
+        message: message || i18n.t('validation:string.uppercase'),
+      }
     }
 
     if (casing === 'lowercase' && strValue !== strValue.toLocaleLowerCase()) {
-      return message || i18n.t('validation:string.lowercase')
+      return {
+        code: validationMarkerCodes.stringLowercase,
+        message: message || i18n.t('validation:string.lowercase'),
+      }
     }
 
     return true
@@ -92,7 +127,10 @@ export const stringValidators: Validators = {
 
   presence: (flag, value, message, {i18n}) => {
     if (flag === 'required' && !value) {
-      return message || i18n.t('validation:generic.required', {context: 'string'})
+      return {
+        code: validationMarkerCodes.valueRequired,
+        message: message || i18n.t('validation:generic.required', {context: 'string'}),
+      }
     }
 
     return true
@@ -107,13 +145,17 @@ export const stringValidators: Validators = {
     pattern.lastIndex = 0
     const matches = pattern.test(strValue)
     if ((!invert && !matches) || (invert && matches)) {
-      if (message) {
-        return message
+      return {
+        code: invert
+          ? validationMarkerCodes.stringRegexMatch
+          : validationMarkerCodes.stringRegexMismatch,
+        details: {invert, name: regName, pattern: pattern.source},
+        message:
+          message ||
+          (invert
+            ? i18n.t('validation:string.regex-match', {name: regName})
+            : i18n.t('validation:string.regex-does-not-match', {name: regName})),
       }
-
-      return invert
-        ? i18n.t('validation:string.regex-match', {name: regName})
-        : i18n.t('validation:string.regex-does-not-match', {name: regName})
     }
 
     return true
@@ -125,6 +167,9 @@ export const stringValidators: Validators = {
       return true
     }
 
-    return message || i18n.t('validation:string.email')
+    return {
+      code: validationMarkerCodes.stringEmail,
+      message: message || i18n.t('validation:string.email'),
+    }
   },
 }

--- a/packages/@sanity/validation/src/validators/unknownFieldsValidator.ts
+++ b/packages/@sanity/validation/src/validators/unknownFieldsValidator.ts
@@ -1,5 +1,7 @@
 import {type CustomValidator, type ObjectSchemaType} from '@sanity/types'
 
+import {validationMarkerCodes} from '../codes'
+
 /**
  * Given a schema type, returns a custom validator used to warn users of unknown
  * fields found in an object.
@@ -17,6 +19,8 @@ export const unknownFieldsValidator =
       .filter((key) => !fieldNames.has(key))
 
     return unknownFields.map((unknownField) => ({
+      code: validationMarkerCodes.objectUnknownField,
+      details: {fieldName: unknownField, typeName: type.name},
       message: `Field '${unknownField}' does not exist on type '${type.name}'`,
       path: [unknownField],
     }))

--- a/packages/@sanity/validation/test/__snapshots__/array.test.ts.snap
+++ b/packages/@sanity/validation/test/__snapshots__/array.test.ts.snap
@@ -4,6 +4,11 @@ exports[`array > exact length constraint > exact length: too long 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "array.exact-length",
+    "details": {
+      "actualLength": 3,
+      "expectedLength": 2,
+    },
     "item": {
       "message": "Must have exactly 2 items",
     },
@@ -18,6 +23,11 @@ exports[`array > exact length constraint > exact length: too short 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "array.exact-length",
+    "details": {
+      "actualLength": 1,
+      "expectedLength": 2,
+    },
     "item": {
       "message": "Must have exactly 2 items",
     },
@@ -34,6 +44,11 @@ exports[`array > max length constraint > max length: too long 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "array.maximum-length",
+    "details": {
+      "actualLength": 4,
+      "maximumLength": 2,
+    },
     "item": {
       "message": "Must have at most 2 items",
     },
@@ -50,6 +65,11 @@ exports[`array > min length constraint > min length: too short 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "array.minimum-length",
+    "details": {
+      "actualLength": 1,
+      "minimumLength": 2,
+    },
     "item": {
       "message": "Must have at least 2 items",
     },
@@ -68,6 +88,11 @@ exports[`array > required constraint > required: null 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "value.type-mismatch",
+    "details": {
+      "actualType": "null",
+      "expectedType": "Array",
+    },
     "item": {
       "message": "Expected type "Array", got "null"",
     },
@@ -77,6 +102,7 @@ exports[`array > required constraint > required: null 1`] = `
   },
   {
     "__internal_metadata": undefined,
+    "code": "value.required",
     "item": {
       "message": "Required",
     },
@@ -91,6 +117,7 @@ exports[`array > required constraint > required: undefined 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "value.required",
     "item": {
       "message": "Required",
     },
@@ -107,6 +134,7 @@ exports[`array > unique constraint (default, array values) > array unique: dupli
 [
   {
     "__internal_metadata": undefined,
+    "code": "array.duplicate-item",
     "item": {
       "message": "Can't be a duplicate",
     },
@@ -118,6 +146,7 @@ exports[`array > unique constraint (default, array values) > array unique: dupli
   },
   {
     "__internal_metadata": undefined,
+    "code": "array.duplicate-item",
     "item": {
       "message": "Can't be a duplicate",
     },
@@ -136,6 +165,7 @@ exports[`array > unique constraint (default, bool values) > boolean unique: dupl
 [
   {
     "__internal_metadata": undefined,
+    "code": "array.duplicate-item",
     "item": {
       "message": "Can't be a duplicate",
     },
@@ -147,6 +177,7 @@ exports[`array > unique constraint (default, bool values) > boolean unique: dupl
   },
   {
     "__internal_metadata": undefined,
+    "code": "array.duplicate-item",
     "item": {
       "message": "Can't be a duplicate",
     },
@@ -165,6 +196,7 @@ exports[`array > unique constraint (default, numeric values) > numeric unique: d
 [
   {
     "__internal_metadata": undefined,
+    "code": "array.duplicate-item",
     "item": {
       "message": "Can't be a duplicate",
     },
@@ -176,6 +208,7 @@ exports[`array > unique constraint (default, numeric values) > numeric unique: d
   },
   {
     "__internal_metadata": undefined,
+    "code": "array.duplicate-item",
     "item": {
       "message": "Can't be a duplicate",
     },
@@ -194,6 +227,7 @@ exports[`array > unique constraint (default, object values) > object unique: dup
 [
   {
     "__internal_metadata": undefined,
+    "code": "array.duplicate-item",
     "item": {
       "message": "Can't be a duplicate",
     },
@@ -205,6 +239,7 @@ exports[`array > unique constraint (default, object values) > object unique: dup
   },
   {
     "__internal_metadata": undefined,
+    "code": "array.duplicate-item",
     "item": {
       "message": "Can't be a duplicate",
     },
@@ -223,6 +258,7 @@ exports[`array > unique constraint (default, simple values) > simple unique: dup
 [
   {
     "__internal_metadata": undefined,
+    "code": "array.duplicate-item",
     "item": {
       "message": "Can't be a duplicate",
     },
@@ -234,6 +270,7 @@ exports[`array > unique constraint (default, simple values) > simple unique: dup
   },
   {
     "__internal_metadata": undefined,
+    "code": "array.duplicate-item",
     "item": {
       "message": "Can't be a duplicate",
     },

--- a/packages/@sanity/validation/test/__snapshots__/children.test.ts.snap
+++ b/packages/@sanity/validation/test/__snapshots__/children.test.ts.snap
@@ -6,6 +6,30 @@ exports[`child rules > all() rules - multiple failures > all() rules - multiple 
 [
   {
     "__internal_metadata": undefined,
+    "code": "rule.all-failed",
+    "details": {
+      "causes": [
+        {
+          "code": "string.regex-mismatch",
+          "details": {
+            "invert": false,
+            "name": "/^[A-Z]/",
+            "pattern": "^[A-Z]",
+          },
+          "message": "Must start with an uppercase character",
+          "path": [],
+        },
+        {
+          "code": "string.minimum-length",
+          "details": {
+            "actualLength": 4,
+            "minimumLength": 5,
+          },
+          "message": "5 chars or more",
+          "path": [],
+        },
+      ],
+    },
     "item": {
       "message": "Must start with an uppercase character and 5 chars or more",
     },
@@ -22,6 +46,21 @@ exports[`child rules > all() rules - single failure > all() rules - single failu
 [
   {
     "__internal_metadata": undefined,
+    "code": "rule.all-failed",
+    "details": {
+      "causes": [
+        {
+          "code": "string.regex-mismatch",
+          "details": {
+            "invert": false,
+            "name": "/^[A-Z]/",
+            "pattern": "^[A-Z]",
+          },
+          "message": "Must start with an uppercase character",
+          "path": [],
+        },
+      ],
+    },
     "item": {
       "message": "Must start with an uppercase character",
     },
@@ -36,6 +75,30 @@ exports[`child rules > all() rules - single failure, custom, common error > all(
 [
   {
     "__internal_metadata": undefined,
+    "code": "rule.all-failed",
+    "details": {
+      "causes": [
+        {
+          "code": "string.regex-mismatch",
+          "details": {
+            "invert": false,
+            "name": "/^[A-Z]/",
+            "pattern": "^[A-Z]",
+          },
+          "message": "Does not match "/^[A-Z]/"-pattern",
+          "path": [],
+        },
+        {
+          "code": "string.minimum-length",
+          "details": {
+            "actualLength": 4,
+            "minimumLength": 5,
+          },
+          "message": "Must be at least 5 characters long",
+          "path": [],
+        },
+      ],
+    },
     "item": {
       "message": "Needs to be a capital letter followed by at least 4 lowercase characters",
     },
@@ -50,6 +113,21 @@ exports[`child rules > all() rules - single failure, custom, common error > all(
 [
   {
     "__internal_metadata": undefined,
+    "code": "rule.all-failed",
+    "details": {
+      "causes": [
+        {
+          "code": "string.regex-mismatch",
+          "details": {
+            "invert": false,
+            "name": "/^[A-Z]/",
+            "pattern": "^[A-Z]",
+          },
+          "message": "Does not match "/^[A-Z]/"-pattern",
+          "path": [],
+        },
+      ],
+    },
     "item": {
       "message": "Needs to start with a capital letter and then follow with lowercase characters",
     },
@@ -64,6 +142,31 @@ exports[`child rules > either() rules - all fail, custom, common error > either(
 [
   {
     "__internal_metadata": undefined,
+    "code": "rule.either-failed",
+    "details": {
+      "causes": [
+        {
+          "code": "string.regex-mismatch",
+          "details": {
+            "invert": false,
+            "name": "/^[A-Z]/",
+            "pattern": "^[A-Z]",
+          },
+          "message": "Does not match "/^[A-Z]/"-pattern",
+          "path": [],
+        },
+        {
+          "code": "string.regex-mismatch",
+          "details": {
+            "invert": false,
+            "name": "/^i[A-Z]/",
+            "pattern": "^i[A-Z]",
+          },
+          "message": "Does not match "/^i[A-Z]/"-pattern",
+          "path": [],
+        },
+      ],
+    },
     "item": {
       "message": "Needs to start with a capital letter, unless it's an iProduct",
     },
@@ -80,6 +183,31 @@ exports[`child rules > either() rules - all matches > either() rules - no matche
 [
   {
     "__internal_metadata": undefined,
+    "code": "rule.either-failed",
+    "details": {
+      "causes": [
+        {
+          "code": "string.regex-mismatch",
+          "details": {
+            "invert": false,
+            "name": "/^R/",
+            "pattern": "^R",
+          },
+          "message": "Must start with a capital R",
+          "path": [],
+        },
+        {
+          "code": "string.regex-mismatch",
+          "details": {
+            "invert": false,
+            "name": "/ed$/",
+            "pattern": "ed$",
+          },
+          "message": "Must end with "ed"",
+          "path": [],
+        },
+      ],
+    },
     "item": {
       "message": "Must start with a capital R or Must end with "ed"",
     },
@@ -94,6 +222,31 @@ exports[`child rules > either() rules - single failure > either() rules - match 
 [
   {
     "__internal_metadata": undefined,
+    "code": "rule.either-failed",
+    "details": {
+      "causes": [
+        {
+          "code": "string.regex-mismatch",
+          "details": {
+            "invert": false,
+            "name": "/^rgb(\\d+,\\s*\\d+,\\s*\\d+)$/",
+            "pattern": "^rgb(\\d+,\\s*\\d+,\\s*\\d+)$",
+          },
+          "message": "Must be rgb(num, num, num) format",
+          "path": [],
+        },
+        {
+          "code": "string.regex-mismatch",
+          "details": {
+            "invert": false,
+            "name": "/^#([a-f0-9]{3}|[a-f0-9]{6})$/",
+            "pattern": "^#([a-f0-9]{3}|[a-f0-9]{6})$",
+          },
+          "message": "Must be hex color with #-prefix",
+          "path": [],
+        },
+      ],
+    },
     "item": {
       "message": "Must be rgb(num, num, num) format or Must be hex color with #-prefix",
     },
@@ -108,6 +261,31 @@ exports[`child rules > either() rules - single failure > either() rules - single
 [
   {
     "__internal_metadata": undefined,
+    "code": "rule.either-failed",
+    "details": {
+      "causes": [
+        {
+          "code": "string.regex-mismatch",
+          "details": {
+            "invert": false,
+            "name": "/^rgb(\\d+,\\s*\\d+,\\s*\\d+)$/",
+            "pattern": "^rgb(\\d+,\\s*\\d+,\\s*\\d+)$",
+          },
+          "message": "Must be rgb(num, num, num) format",
+          "path": [],
+        },
+        {
+          "code": "string.regex-mismatch",
+          "details": {
+            "invert": false,
+            "name": "/^#([a-f0-9]{3}|[a-f0-9]{6})$/",
+            "pattern": "^#([a-f0-9]{3}|[a-f0-9]{6})$",
+          },
+          "message": "Must be hex color with #-prefix",
+          "path": [],
+        },
+      ],
+    },
     "item": {
       "message": "Must be rgb(num, num, num) format or Must be hex color with #-prefix",
     },

--- a/packages/@sanity/validation/test/__snapshots__/dates.test.ts.snap
+++ b/packages/@sanity/validation/test/__snapshots__/dates.test.ts.snap
@@ -4,6 +4,11 @@ exports[`date > with custom format > max length constraint > Must be at or befor
 [
   {
     "__internal_metadata": undefined,
+    "code": "date.maximum",
+    "details": {
+      "actualValue": "2024-01-02",
+      "maximum": "2024-01-01",
+    },
     "item": {
       "message": "Must be at or before 01-01-2024",
     },
@@ -18,6 +23,11 @@ exports[`date > with custom format > min length constraint > Must be at or after
 [
   {
     "__internal_metadata": undefined,
+    "code": "date.minimum",
+    "details": {
+      "actualValue": "2023-12-31",
+      "minimum": "2024-01-01",
+    },
     "item": {
       "message": "Must be at or after 01-01-2024",
     },
@@ -32,6 +42,11 @@ exports[`date > with default format > max length constraint > Must be at or befo
 [
   {
     "__internal_metadata": undefined,
+    "code": "date.maximum",
+    "details": {
+      "actualValue": "2024-01-02",
+      "maximum": "2024-01-01",
+    },
     "item": {
       "message": "Must be at or before 2024-01-01",
     },
@@ -46,6 +61,11 @@ exports[`date > with default format > min length constraint > Must be at or afte
 [
   {
     "__internal_metadata": undefined,
+    "code": "date.minimum",
+    "details": {
+      "actualValue": "2023-12-31",
+      "minimum": "2024-01-01",
+    },
     "item": {
       "message": "Must be at or after 2024-01-01",
     },
@@ -60,6 +80,11 @@ exports[`datetime > with custom format > max length constraint > Must be at or b
 [
   {
     "__internal_metadata": undefined,
+    "code": "date.maximum",
+    "details": {
+      "actualValue": "2024-01-02T17:31:00.000Z",
+      "maximum": "2024-01-01T17:31:00.000Z",
+    },
     "item": {
       "message": "Must be at or before 1st. January 2024 09:31",
     },
@@ -74,6 +99,11 @@ exports[`datetime > with custom format > min length constraint > Must be at or a
 [
   {
     "__internal_metadata": undefined,
+    "code": "date.minimum",
+    "details": {
+      "actualValue": "2023-12-31T17:31:00.000Z",
+      "minimum": "2024-01-01T17:31:00.000Z",
+    },
     "item": {
       "message": "Must be at or after 1st. January 2024 09:31",
     },
@@ -88,6 +118,11 @@ exports[`datetime > with default format > max length constraint > Must be at or 
 [
   {
     "__internal_metadata": undefined,
+    "code": "date.maximum",
+    "details": {
+      "actualValue": "2024-01-02T17:31:00.000Z",
+      "maximum": "2024-01-01T17:31:00.000Z",
+    },
     "item": {
       "message": "Must be at or before 2024-01-01 09:31",
     },
@@ -102,6 +137,11 @@ exports[`datetime > with default format > min length constraint > Must be at or 
 [
   {
     "__internal_metadata": undefined,
+    "code": "date.minimum",
+    "details": {
+      "actualValue": "2023-12-31T17:31:00.000Z",
+      "minimum": "2024-01-01T17:31:00.000Z",
+    },
     "item": {
       "message": "Must be at or after 2024-01-01 09:31",
     },

--- a/packages/@sanity/validation/test/__snapshots__/generics.test.ts.snap
+++ b/packages/@sanity/validation/test/__snapshots__/generics.test.ts.snap
@@ -4,6 +4,11 @@ exports[`generics > can customize error messages 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "value.type-mismatch",
+    "details": {
+      "actualType": "Number",
+      "expectedType": "String",
+    },
     "item": {
       "message": "Dude it needs to be a string",
     },
@@ -18,6 +23,11 @@ exports[`generics > can customize info messages 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "value.type-mismatch",
+    "details": {
+      "actualType": "Number",
+      "expectedType": "String",
+    },
     "item": {
       "message": "Dude it should probably be a string",
     },
@@ -32,6 +42,11 @@ exports[`generics > can customize warning messages 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "value.type-mismatch",
+    "details": {
+      "actualType": "Number",
+      "expectedType": "String",
+    },
     "item": {
       "message": "Dude it should probably be a string",
     },
@@ -46,6 +61,11 @@ exports[`generics > can demote errors to warnings 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "value.type-mismatch",
+    "details": {
+      "actualType": "Number",
+      "expectedType": "String",
+    },
     "item": {
       "message": "Expected type "String", got "Number"",
     },
@@ -60,6 +80,11 @@ exports[`generics > can merge rules 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.minimum-length",
+    "details": {
+      "actualLength": 3,
+      "minimumLength": 5,
+    },
     "item": {
       "message": "Must be at least 5 characters long",
     },
@@ -74,6 +99,11 @@ exports[`generics > returns arrays of errors/warnings by default 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "value.type-mismatch",
+    "details": {
+      "actualType": "Number",
+      "expectedType": "String",
+    },
     "item": {
       "message": "Expected type "String", got "Number"",
     },

--- a/packages/@sanity/validation/test/__snapshots__/numbers.test.ts.snap
+++ b/packages/@sanity/validation/test/__snapshots__/numbers.test.ts.snap
@@ -4,6 +4,11 @@ exports[`number > greater than constraint > gt: too low 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "number.greater-than",
+    "details": {
+      "actualValue": 3,
+      "threshold": 10,
+    },
     "item": {
       "message": "Must be greater than 10",
     },
@@ -18,6 +23,11 @@ exports[`number > greater than constraint > gt: too low, at limit 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "number.greater-than",
+    "details": {
+      "actualValue": 10,
+      "threshold": 10,
+    },
     "item": {
       "message": "Must be greater than 10",
     },
@@ -34,6 +44,10 @@ exports[`number > integer constraint > integer: invalid (float) 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "number.integer",
+    "details": {
+      "actualValue": 31.14,
+    },
     "item": {
       "message": "Must be an integer",
     },
@@ -50,6 +64,11 @@ exports[`number > less than constraint > lt: too high 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "number.less-than",
+    "details": {
+      "actualValue": 20,
+      "threshold": 10,
+    },
     "item": {
       "message": "Must be less than 10",
     },
@@ -64,6 +83,11 @@ exports[`number > less than constraint > lt: too high, at limit 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "number.less-than",
+    "details": {
+      "actualValue": 10,
+      "threshold": 10,
+    },
     "item": {
       "message": "Must be less than 10",
     },
@@ -80,6 +104,11 @@ exports[`number > max constraint > max: too large 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "number.maximum",
+    "details": {
+      "actualValue": 20,
+      "maximum": 10,
+    },
     "item": {
       "message": "Must be lower than or equal to 10",
     },
@@ -98,6 +127,11 @@ exports[`number > min constraint > min: too low 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "number.minimum",
+    "details": {
+      "actualValue": 3,
+      "minimum": 10,
+    },
     "item": {
       "message": "Must be greater than or equal to 10",
     },
@@ -116,6 +150,11 @@ exports[`number > negative constraint > negative: invalid (zero) 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "number.less-than",
+    "details": {
+      "actualValue": 0,
+      "threshold": 0,
+    },
     "item": {
       "message": "Must be less than 0",
     },
@@ -130,6 +169,11 @@ exports[`number > negative constraint > negative: invalid 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "number.less-than",
+    "details": {
+      "actualValue": 31.14,
+      "threshold": 0,
+    },
     "item": {
       "message": "Must be less than 0",
     },
@@ -146,6 +190,11 @@ exports[`number > positive constraint > positive: invalid 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "number.minimum",
+    "details": {
+      "actualValue": -31.14,
+      "minimum": 0,
+    },
     "item": {
       "message": "Must be greater than or equal to 0",
     },
@@ -164,6 +213,11 @@ exports[`number > precision constraint > precision: invalid (pi) 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "number.precision",
+    "details": {
+      "actualPrecision": 15,
+      "maximumPrecision": 3,
+    },
     "item": {
       "message": "Max precision is 3",
     },
@@ -182,6 +236,7 @@ exports[`number > required constraint > required: undefined 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "value.required",
     "item": {
       "message": "Required",
     },

--- a/packages/@sanity/validation/test/__snapshots__/strings.test.ts.snap
+++ b/packages/@sanity/validation/test/__snapshots__/strings.test.ts.snap
@@ -4,6 +4,7 @@ exports[`string > custom async rule with string > not a palindrome 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "custom",
     "item": {
       "message": "Must be a palindrome!",
     },
@@ -18,6 +19,7 @@ exports[`string > custom rule with string > not a palindrome 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "custom",
     "item": {
       "message": "Must be a palindrome!",
     },
@@ -32,6 +34,11 @@ exports[`string > exact length constraint > exact length: too long 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.exact-length",
+    "details": {
+      "actualLength": 8,
+      "expectedLength": 5,
+    },
     "item": {
       "message": "Must be exactly 5 characters long",
     },
@@ -46,6 +53,11 @@ exports[`string > exact length constraint > exact length: too short 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.exact-length",
+    "details": {
+      "actualLength": 3,
+      "expectedLength": 5,
+    },
     "item": {
       "message": "Must be exactly 5 characters long",
     },
@@ -62,6 +74,7 @@ exports[`string > lowercase constraint > lowercase: all uppercase 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.lowercase",
     "item": {
       "message": "Must be all lowercase characters",
     },
@@ -76,6 +89,7 @@ exports[`string > lowercase constraint > lowercase: locale characters 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.lowercase",
     "item": {
       "message": "Must be all lowercase characters",
     },
@@ -90,6 +104,7 @@ exports[`string > lowercase constraint > lowercase: some uppercase 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.lowercase",
     "item": {
       "message": "Must be all lowercase characters",
     },
@@ -106,6 +121,11 @@ exports[`string > max length constraint > max length: too long 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.maximum-length",
+    "details": {
+      "actualLength": 7,
+      "maximumLength": 5,
+    },
     "item": {
       "message": "Must be at most 5 characters long",
     },
@@ -122,6 +142,11 @@ exports[`string > min length constraint > min length: too short 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.minimum-length",
+    "details": {
+      "actualLength": 1,
+      "minimumLength": 2,
+    },
     "item": {
       "message": "Must be at least 2 characters long",
     },
@@ -140,6 +165,12 @@ exports[`string > regex constraint (custom pattern name) > regex: non-match w/ c
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.regex-mismatch",
+    "details": {
+      "invert": false,
+      "name": "PascalCase",
+      "pattern": "^[A-Z][a-z]+$",
+    },
     "item": {
       "message": "Does not match "PascalCase"-pattern",
     },
@@ -156,6 +187,12 @@ exports[`string > regex constraint (custom pattern name, as options) > regex: no
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.regex-mismatch",
+    "details": {
+      "invert": false,
+      "name": "PascalCase",
+      "pattern": "^[A-Z][a-z]+$",
+    },
     "item": {
       "message": "Does not match "PascalCase"-pattern",
     },
@@ -170,6 +207,12 @@ exports[`string > regex constraint (inverted) > regex: inverted match 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.regex-match",
+    "details": {
+      "invert": true,
+      "name": "/^[A-Z][a-z]+$/",
+      "pattern": "^[A-Z][a-z]+$",
+    },
     "item": {
       "message": "Should not match "/^[A-Z][a-z]+$/"-pattern",
     },
@@ -188,6 +231,12 @@ exports[`string > regex constraint > regex: non-match 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.regex-mismatch",
+    "details": {
+      "invert": false,
+      "name": "/^[A-Z][a-z]+$/",
+      "pattern": "^[A-Z][a-z]+$",
+    },
     "item": {
       "message": "Does not match "/^[A-Z][a-z]+$/"-pattern",
     },
@@ -202,6 +251,7 @@ exports[`string > required constraint > required: empty string 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "value.required",
     "item": {
       "message": "Required",
     },
@@ -216,6 +266,11 @@ exports[`string > required constraint > required: null 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "value.type-mismatch",
+    "details": {
+      "actualType": "null",
+      "expectedType": "String",
+    },
     "item": {
       "message": "Expected type "String", got "null"",
     },
@@ -225,6 +280,7 @@ exports[`string > required constraint > required: null 1`] = `
   },
   {
     "__internal_metadata": undefined,
+    "code": "value.required",
     "item": {
       "message": "Required",
     },
@@ -239,6 +295,7 @@ exports[`string > required constraint > required: undefined 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "value.required",
     "item": {
       "message": "Required",
     },
@@ -255,6 +312,7 @@ exports[`string > uppercase constraint > uppercase: all lowercase 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.uppercase",
     "item": {
       "message": "Must be all uppercase characters",
     },
@@ -269,6 +327,7 @@ exports[`string > uppercase constraint > uppercase: locale characters 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.uppercase",
     "item": {
       "message": "Must be all uppercase characters",
     },
@@ -283,6 +342,7 @@ exports[`string > uppercase constraint > uppercase: some lowercase 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.uppercase",
     "item": {
       "message": "Must be all uppercase characters",
     },
@@ -297,6 +357,7 @@ exports[`string > uppercase constraint > uppercase: some lowercase 2`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.uppercase",
     "item": {
       "message": "Must be all uppercase characters",
     },
@@ -313,6 +374,10 @@ exports[`string > uri constraint (allowRelative with restrictive scheme) > uri: 
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.url.scheme-not-allowed",
+    "details": {
+      "scheme": "http",
+    },
     "item": {
       "message": "Does not match allowed protocols/schemes",
     },
@@ -327,6 +392,7 @@ exports[`string > uri constraint (credentials) > uri: credentials specified but 
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.url.credentials-not-allowed",
     "item": {
       "message": "Username/password not allowed",
     },
@@ -341,6 +407,7 @@ exports[`string > uri constraint (credentials) > uri: username specified but not
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.url.credentials-not-allowed",
     "item": {
       "message": "Username/password not allowed",
     },
@@ -355,6 +422,10 @@ exports[`string > uri constraint (invalid protocol) > uri: protocol non-match 1`
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.url.scheme-not-allowed",
+    "details": {
+      "scheme": "https",
+    },
     "item": {
       "message": "Does not match allowed protocols/schemes",
     },
@@ -369,6 +440,7 @@ exports[`string > uri constraint (with unicode chars) > uri: non-match 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.url.invalid",
     "item": {
       "message": "Not a valid URL",
     },
@@ -383,6 +455,7 @@ exports[`string > uri constraint > uri: non-match 1`] = `
 [
   {
     "__internal_metadata": undefined,
+    "code": "string.url.invalid",
     "item": {
       "message": "Not a valid URL",
     },

--- a/packages/@sanity/validation/test/array.test.ts
+++ b/packages/@sanity/validation/test/array.test.ts
@@ -38,6 +38,15 @@ describe('array', () => {
     await expect(rule.validate(['a', 'b'], context)).resolves.toMatchSnapshot('exact length: valid')
   })
 
+  test('reports the allowed value count without retaining all values', async () => {
+    await expect(Rule.array().valid(['one', 'two']).validate(['three'], context)).resolves.toEqual([
+      expect.objectContaining({
+        code: 'value.not-allowed',
+        details: {allowedValuesCount: 2},
+      }),
+    ])
+  })
+
   test('unique constraint (default, simple values)', async () => {
     const rule = Rule.array().unique()
     await expect(rule.validate(['a', 'b', 'c', 'd'], context)).resolves.toMatchSnapshot(

--- a/packages/@sanity/validation/test/children.test.ts
+++ b/packages/@sanity/validation/test/children.test.ts
@@ -1,3 +1,4 @@
+import {type ValidationMarker} from '@sanity/types'
 import {describe, expect, test} from 'vitest'
 
 import {getFallbackLocaleSource, Rule} from '../src/_internal'
@@ -37,6 +38,23 @@ describe('child rules', () => {
     await expect(rule.validate('moop', context)).resolves.toMatchSnapshot(
       'all() rules - multiple failures, custom messages',
     )
+  })
+
+  test('all() rules - preserves legacy item messages in structured causes', async () => {
+    const legacyMarker: ValidationMarker = {
+      level: 'error',
+      message: 'Legacy failure',
+      path: [],
+    }
+    Object.assign(legacyMarker, {item: {message: legacyMarker.message}})
+    Reflect.deleteProperty(legacyMarker, 'message')
+
+    const legacyRule = Rule.string()
+    legacyRule.validate = async () => [legacyMarker]
+
+    const [marker] = await Rule.string().all([legacyRule]).validate('value', context)
+
+    expect(marker.details).toMatchObject({causes: [{message: 'Legacy failure'}]})
   })
 
   test('all() rules - single failure, custom, common error', async () => {

--- a/packages/@sanity/validation/test/engine.test.ts
+++ b/packages/@sanity/validation/test/engine.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@sanity/types'
 import {describe, expect, it, vi} from 'vitest'
 
+import {validationMarkerCodes} from '../src'
 import {
   getFallbackLocaleSource,
   inferFromSchema,
@@ -547,6 +548,40 @@ describe('validateItem', () => {
         path: ['bar'],
       },
     ])
+  })
+
+  it('deduplicates field-rule markers with non-serializable details', async () => {
+    const details: Record<string, unknown> = {count: 1n}
+    details.self = details
+    const schema = createSchema({
+      name: 'default',
+      types: [
+        {
+          name: 'testObj',
+          type: 'object',
+          fields: [{name: 'foo', type: 'string'}],
+          validation: (rule: Rule) =>
+            rule.fields({
+              foo: (fieldRule) => fieldRule.custom(() => ({details, message: 'Invalid field'})),
+            }),
+        },
+      ],
+    })
+
+    await expect(
+      validateItem({
+        getClient,
+        schema,
+        document: undefined,
+        parent: undefined,
+        path: undefined,
+        type: schema.get('testObj'),
+        value: {foo: 'value'},
+        getDocumentExists: undefined,
+        i18n: getFallbackLocaleSource(),
+        environment: 'studio',
+      }),
+    ).resolves.toEqual([expect.objectContaining({code: validationMarkerCodes.custom, details})])
   })
 
   it('runs nested validation for Rule.fields() inside Rule.all() (issue #8290)', async () => {

--- a/packages/@sanity/validation/test/generics.test.ts
+++ b/packages/@sanity/validation/test/generics.test.ts
@@ -58,6 +58,15 @@ describe('generics', () => {
     expect(result).toMatchSnapshot()
   })
 
+  test('reports the allowed value count without retaining all values', async () => {
+    await expect(Rule.string().valid(['one', 'two']).validate('three', context)).resolves.toEqual([
+      expect.objectContaining({
+        code: 'value.not-allowed',
+        details: {allowedValuesCount: 2},
+      }),
+    ])
+  })
+
   test('can merge rules', async () => {
     const rule = new Rule().required()
     const stringRule = Rule.string().min(5)

--- a/packages/@sanity/validation/test/infer.test.ts
+++ b/packages/@sanity/validation/test/infer.test.ts
@@ -6,7 +6,7 @@ import {type ObjectSchemaType, type Rule, type SanityDocument} from '@sanity/typ
 import has from 'lodash-es/has.js'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
-import {type ValidateDocumentOptions} from '../src'
+import {type ValidateDocumentOptions, validationMarkerCodes} from '../src'
 import {
   getFallbackLocaleSource,
   hasValidationContext,
@@ -181,6 +181,9 @@ describe('schema validation inference', () => {
         }),
       ).resolves.toEqual([
         {
+          __internal_metadata: undefined,
+          code: validationMarkerCodes.mediaNotFound,
+          details: {referenceId: 'media-library:abc:def'},
           item: {
             message: 'The asset could not be found in the Media Library',
           },
@@ -215,6 +218,7 @@ describe('schema validation inference', () => {
           __internal_metadata: {
             name: 'media',
           },
+          code: validationMarkerCodes.mediaCustom,
           item: {
             message: 'Image must be a summer image',
           },
@@ -306,6 +310,8 @@ describe('schema validation inference', () => {
         }),
       ).resolves.toMatchObject([
         {
+          code: validationMarkerCodes.slugNotUnique,
+          details: {slug: 'example-value'},
           path: ['slugField'],
           level: 'error',
           message: 'Slug is already in use',
@@ -378,6 +384,8 @@ describe('schema validation inference', () => {
         }),
       ).resolves.toMatchObject([
         {
+          code: validationMarkerCodes.referenceInvalid,
+          details: {actualType: 'object'},
           message: 'Must be a reference to a document',
           level: 'error',
           path: ['referenceField'],
@@ -401,6 +409,8 @@ describe('schema validation inference', () => {
         }),
       ).resolves.toMatchObject([
         {
+          code: validationMarkerCodes.referenceNotPublished,
+          details: {referenceId: 'example-id'},
           message: /.+/,
           level: 'error',
           path: ['referenceField'],

--- a/packages/@sanity/validation/test/infer.test.ts
+++ b/packages/@sanity/validation/test/infer.test.ts
@@ -267,6 +267,26 @@ describe('schema validation inference', () => {
       client.fetch.mockReset()
     })
 
+    test('reports the actual type for an invalid slug value', async () => {
+      await expect(
+        validateDocument({
+          client: sanityClient,
+          document: {...mockDocument, slugField: []},
+          getDocumentExists: () => Promise.resolve(true),
+          schema,
+        }),
+      ).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: validationMarkerCodes.slugInvalidType,
+            details: {actualType: 'Array'},
+            path: ['slugField'],
+          }),
+        ]),
+      )
+      expect(client.fetch).not.toHaveBeenCalled()
+    })
+
     test('slug is valid if uniqueness queries returns true', async () => {
       client.fetch.mockImplementation(() =>
         Promise.resolve(
@@ -391,7 +411,7 @@ describe('schema validation inference', () => {
       ).resolves.toMatchObject([
         {
           code: validationMarkerCodes.referenceInvalid,
-          details: {actualType: 'object'},
+          details: {actualType: 'Object'},
           message: 'Must be a reference to a document',
           level: 'error',
           path: ['referenceField'],

--- a/packages/@sanity/validation/test/infer.test.ts
+++ b/packages/@sanity/validation/test/infer.test.ts
@@ -6,11 +6,12 @@ import {type ObjectSchemaType, type Rule, type SanityDocument} from '@sanity/typ
 import has from 'lodash-es/has.js'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 
-import {type ValidateDocumentOptions, validationMarkerCodes} from '../src'
+import {validationMarkerCodes} from '../src'
 import {
   getFallbackLocaleSource,
   hasValidationContext,
   inferFromSchema,
+  type ValidateDocumentInternalOptions,
   validateDocumentInternal,
 } from '../src/_internal'
 import {createMockSanityClient} from './mocks/mockSanityClient'
@@ -24,7 +25,12 @@ function createSchema(schemaDef: {name: string; types: any[]}) {
   return inferFromSchema(SchemaBuilder.compile({...schemaDef, parent: builtinSchema}))
 }
 
-function validateDocument({client: documentClient, ...options}: ValidateDocumentOptions) {
+function validateDocument({
+  client: documentClient,
+  ...options
+}: Omit<ValidateDocumentInternalOptions, 'environment' | 'getClient' | 'i18n'> & {
+  client: SanityClient
+}) {
   return validateDocumentInternal({
     ...options,
     environment: 'studio',

--- a/packages/@sanity/validation/test/validateDocument.test.ts
+++ b/packages/@sanity/validation/test/validateDocument.test.ts
@@ -5,7 +5,7 @@ import {type Rule, type SanityDocument, type SchemaTypeDefinition} from '@sanity
 import {of} from 'rxjs'
 import {describe, expect, it, vi} from 'vitest'
 
-import {validateDocument, validateDocumentWithWorkspace} from '../src'
+import {validateDocument, validateDocumentWithWorkspace, validationMarkerCodes} from '../src'
 import {getFallbackLocaleSource} from '../src/_internal'
 
 const builtinSchema = SchemaBuilder.compile({name: 'studio', types: builtinTypes})
@@ -125,11 +125,15 @@ describe('validateDocument', () => {
     expect(markers).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
+          code: validationMarkerCodes.stringMinimumLength,
+          details: {actualLength: 5, minimumLength: 80},
           level: 'error',
           message: 'Must be at least 80 characters long',
           path: ['title'],
         }),
         expect.objectContaining({
+          code: validationMarkerCodes.objectUnknownField,
+          details: {fieldName: 'unexpected', typeName: 'article'},
           level: 'warning',
           message: "Field 'unexpected' does not exist on type 'article'",
           path: ['unexpected'],
@@ -137,6 +141,155 @@ describe('validateDocument', () => {
       ]),
     )
     expect(document).toEqual(before)
+    expect(markers.every((marker) => typeof marker.code === 'string')).toBe(true)
+  })
+
+  it('preserves custom codes and details and defaults uncoded custom failures', async () => {
+    const schema = createSchema([
+      {
+        name: 'article',
+        type: 'document',
+        fields: [
+          {
+            name: 'coded',
+            type: 'string',
+            validation: (rule: Rule) =>
+              rule.custom(() => ({
+                code: 'custom.reserved-title',
+                details: {reservedTitle: 'Reserved'},
+                message: 'This title is reserved',
+              })),
+          },
+          {
+            name: 'uncoded',
+            type: 'string',
+            validation: (rule: Rule) => rule.custom(() => 'Custom failure'),
+          },
+          {
+            name: 'localized',
+            type: 'string',
+            validation: (rule: Rule) => rule.custom(() => ({'en-US': 'Localized custom failure'})),
+          },
+        ],
+      },
+    ])
+    const {client} = createMockClient()
+
+    const markers = await validateDocument({
+      client,
+      document: createDocument({
+        _type: 'article',
+        coded: 'Reserved',
+        localized: 'invalid',
+        uncoded: 'invalid',
+      }),
+      schema,
+    })
+
+    expect(markers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'custom.reserved-title',
+          details: {reservedTitle: 'Reserved'},
+          message: 'This title is reserved',
+          path: ['coded'],
+        }),
+        expect.objectContaining({
+          code: validationMarkerCodes.custom,
+          message: 'Custom failure',
+          path: ['uncoded'],
+        }),
+        expect.objectContaining({
+          code: validationMarkerCodes.custom,
+          message: 'Localized custom failure',
+          path: ['localized'],
+        }),
+      ]),
+    )
+  })
+
+  it('codes exceptions thrown by custom validators', async () => {
+    const schema = createSchema([
+      {
+        name: 'article',
+        type: 'document',
+        fields: [
+          {
+            name: 'title',
+            type: 'string',
+            validation: (rule: Rule) =>
+              rule.custom(() => {
+                throw new Error('Custom validator failed')
+              }),
+          },
+        ],
+      },
+    ])
+    const {client} = createMockClient()
+
+    await expect(
+      validateDocument({
+        client,
+        document: createDocument({_type: 'article', title: 'Title'}),
+        schema,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        code: validationMarkerCodes.validationException,
+        message: expect.stringContaining('Custom validator failed'),
+        path: ['title'],
+      }),
+    ])
+  })
+
+  it('keeps built-in metadata when a rule overrides the message', async () => {
+    const schema = createSchema([
+      {
+        name: 'article',
+        type: 'document',
+        fields: [
+          {
+            name: 'title',
+            type: 'string',
+            validation: (rule: Rule) => rule.min(10).error('Use a longer title'),
+          },
+        ],
+      },
+    ])
+    const {client} = createMockClient()
+
+    await expect(
+      validateDocument({
+        client,
+        document: createDocument({_type: 'article', title: 'Short'}),
+        schema,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        code: validationMarkerCodes.stringMinimumLength,
+        details: {actualLength: 5, minimumLength: 10},
+        message: 'Use a longer title',
+      }),
+    ])
+  })
+
+  it('returns a coded marker for an unknown document type', async () => {
+    const schema = createSchema([])
+    const {client} = createMockClient()
+
+    await expect(
+      validateDocument({
+        client,
+        document: createDocument({_type: 'missing'}),
+        schema,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        code: validationMarkerCodes.documentUnknownType,
+        details: {documentType: 'missing'},
+        level: 'warning',
+      }),
+    ])
   })
 
   it('provides the configured client to executable custom validators', async () => {
@@ -243,6 +396,8 @@ describe('validateDocument', () => {
 
     expect(markers).toEqual([
       expect.objectContaining({
+        code: validationMarkerCodes.referenceNotPublished,
+        details: {referenceId: 'author-id'},
         level: 'error',
         message: 'Referenced document must be published',
         path: ['author'],

--- a/packages/@sanity/validation/test/validateDocument.test.ts
+++ b/packages/@sanity/validation/test/validateDocument.test.ts
@@ -208,6 +208,34 @@ describe('validateDocument', () => {
     )
   })
 
+  it('adds a fallback code to markers from legacy compiled rules', async () => {
+    const message = 'Legacy failure'
+    const legacyRule = {
+      _fieldRules: undefined,
+      _rules: [],
+      isRequired: () => false,
+      validate: async () => [{item: {message}, level: 'error' as const, message, path: ['title']}],
+    } as unknown as Rule
+    const schema = createSchema([
+      {
+        name: 'article',
+        type: 'document',
+        fields: [{name: 'title', type: 'string', validation: legacyRule}],
+      },
+    ])
+    const {client} = createMockClient()
+
+    await expect(
+      validateDocument({
+        client,
+        document: createDocument({_type: 'article', title: 'Title'}),
+        schema,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({code: validationMarkerCodes.validationFailed, message}),
+    ])
+  })
+
   it('codes exceptions thrown by custom validators', async () => {
     const schema = createSchema([
       {


### PR DESCRIPTION
Adds in stable codes to markers, so that programmatic validation can be done more easily.
Instead of doing something like a regex on the marker text, you can check the code itself.

Also includes a `details` object, which can include metadata about the validation error.

The diff on this PR seems kinda big at first glance, but it's mostly a lot of small additions of `code` and `details` to existing validator functions.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core validation pipeline and changes the public marker shape and return types; behavior is largely additive but deduplication and typing changes could affect integrators relying on duplicate markers or loose client/schema types.
> 
> **Overview**
> Validation markers from `validateDocument` now carry a **stable machine-readable `code`** and optional **`details`** so consumers can branch on failure type without parsing localized messages. Built-in validators emit codes from the new `validationMarkerCodes` export (e.g. `string.minimum-length` with `{ actualLength, minimumLength }`); custom validators can set their own namespaced codes and details on `ValidationError`.
> 
> `@sanity/types` extends `ValidationMarker` and `ValidationError` with optional `code` and `details`. `@sanity/validation` introduces `DocumentValidationMarker` (code required), wires codes through `convertToValidationMarker` and `Rule` fallbacks (`custom`, `validation.exception`, etc.), and normalizes legacy uncoded markers to `validation.failed`. Composite `all()` / `either()` failures use `rule.all-failed` / `rule.either-failed` with nested **causes** in `details`.
> 
> `ValidateDocumentOptions` now accepts structural **`ValidationSchema`** and **`ValidationClient`** types for cross-package-version use. Field-rule deduplication replaces `uniqBy(JSON.stringify)` with keying on level/code/message/path plus deep equality so markers with non-JSON-serializable `details` still dedupe correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fac8954bbfb0727740439c8541344c086370f1a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->