### PR TITLE
fix(structure): hide collapsed pane search controls

### DIFF
--- a/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
@@ -1,7 +1,7 @@
 import {SearchIcon} from '@sanity/icons/Search'
 import {SpinnerIcon} from '@sanity/icons/Spinner'
 import {Box, Stack, TextInput} from '@sanity/ui'
-import {memo, useCallback, useEffect, useMemo, useState} from 'react'
+import {Activity, memo, useCallback, useEffect, useMemo, useState} from 'react'
 import {useObservableEvent} from 'react-rx'
 import {debounce, map, type Observable, of, tap, timer} from 'rxjs'
 import {
@@ -103,10 +103,9 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
 
   const {t} = useTranslation(structureLocaleNamespace)
   const {title} = useI18nText(pane)
-  // A collapsed pane is only wide enough for the rotated header. The search
-  // area is kept mounted (so the query and the input element the results list
-  // uses for keyboard navigation survive a collapse) but hidden, otherwise its
-  // contents overflow the pane and bleed into the neighbouring one.
+  // A collapsed pane is only wide enough for the rotated header. Keep the pane
+  // body mounted so its state survives a collapse, but hide it to prevent its
+  // contents from bleeding into the neighbouring pane.
   const {collapsed} = usePane()
 
   const [searchQuery, setSearchQuery] = useState<string>('')
@@ -281,8 +280,8 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   useReconnectingToast(!connected)
 
   return (
-    <>
-      <Box data-testid="document-list-search" hidden={collapsed} paddingX={3} paddingBottom={3}>
+    <Activity mode={collapsed ? 'hidden' : 'visible'}>
+      <Box data-testid="document-list-search" paddingX={3} paddingBottom={3}>
         <Stack gap={3}>
           <TextInput
             aria-label={t('panes.document-list-pane.search-input.aria-label')}
@@ -341,6 +340,6 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
         showIcons={showIcons}
         sortOrder={orderByIdsParam ? DEFAULT_ORDERING : sortOrder}
       />
-    </>
+    </Activity>
   )
 })

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
@@ -19,6 +19,7 @@ import {
 } from 'sanity'
 import {keyframes, styled} from 'styled-components'
 
+import {usePane} from '../../components/pane/usePane'
 import {structureLocaleNamespace} from '../../i18n'
 import {type BaseStructureToolPaneProps} from '../types'
 import {DEFAULT_ORDERING, EMPTY_RECORD, FULL_LIST_LIMIT} from './constants'
@@ -102,6 +103,11 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
 
   const {t} = useTranslation(structureLocaleNamespace)
   const {title} = useI18nText(pane)
+  // A collapsed pane is only wide enough for the rotated header. The search
+  // area is kept mounted (so the query and the input element the results list
+  // uses for keyboard navigation survive a collapse) but hidden, otherwise its
+  // contents overflow the pane and bleed into the neighbouring one.
+  const {collapsed} = usePane()
 
   const [searchQuery, setSearchQuery] = useState<string>('')
   const [searchInputValue, setSearchInputValue] = useState<string>('')
@@ -276,7 +282,7 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
 
   return (
     <>
-      <Box paddingX={3} paddingBottom={3}>
+      <Box data-testid="document-list-search" hidden={collapsed} paddingX={3} paddingBottom={3}>
         <Stack gap={3}>
           <TextInput
             aria-label={t('panes.document-list-pane.search-input.aria-label')}

--- a/packages/sanity/src/structure/panes/documentList/__tests__/DocumentListPane.test.tsx
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/DocumentListPane.test.tsx
@@ -15,9 +15,10 @@ vi.mock('../useDocumentList', () => ({
   useDocumentList: vi.fn(),
 }))
 
-// Stub out the heavy results content so we can focus on the search header.
+// Stub out the heavy results content while retaining a visible node so the
+// pane body's Activity boundary can be asserted.
 vi.mock('../DocumentListPaneContent', () => ({
-  DocumentListPaneContent: () => null,
+  DocumentListPaneContent: () => <div data-testid="document-list-content" />,
 }))
 
 vi.mock('sanity', async (importOriginal) => ({
@@ -50,6 +51,7 @@ const BASE_PERSPECTIVE: PerspectiveContextValue = {
   bundle: 'drafts',
 }
 
+const CONTENT_TESTID = 'document-list-content'
 const ORDERING_TESTID = 'document-list-search-ordering'
 const SEARCH_TESTID = 'document-list-search'
 
@@ -167,9 +169,10 @@ describe('DocumentListPane search area when the pane is collapsed', () => {
     await renderDocumentListPane()
 
     expect(await screen.findByTestId(SEARCH_TESTID)).toBeVisible()
+    expect(screen.getByTestId(CONTENT_TESTID)).toBeVisible()
   })
 
-  it('hides the search area, including the relevance indicator, while collapsed', async () => {
+  it('hides the pane body while collapsed and restores its state when expanded', async () => {
     const {rerender} = await renderDocumentListPane()
 
     // Enter a search term while expanded, so the relevance indicator renders,
@@ -183,10 +186,21 @@ describe('DocumentListPane search area when the pane is collapsed', () => {
       </PaneProvider>,
     )
 
-    // The search area stays mounted so the query survives the collapse, but a
+    // The pane body stays mounted so its state survives the collapse, but a
     // collapsed pane is too narrow to render it without overflowing.
     expect(screen.getByTestId(SEARCH_TESTID)).not.toBeVisible()
     expect(screen.getByTestId(ORDERING_TESTID)).not.toBeVisible()
+    expect(screen.getByTestId(CONTENT_TESTID)).not.toBeVisible()
+
+    rerender(
+      <PaneProvider>
+        <DocumentListPane {...getPaneProps()} />
+      </PaneProvider>,
+    )
+
+    expect(screen.getByLabelText('Search list')).toHaveValue('exodus')
+    expect(screen.getByTestId(ORDERING_TESTID)).toBeVisible()
+    expect(screen.getByTestId(CONTENT_TESTID)).toBeVisible()
   })
 })
 

--- a/packages/sanity/src/structure/panes/documentList/__tests__/DocumentListPane.test.tsx
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/DocumentListPane.test.tsx
@@ -213,12 +213,7 @@ describe('DocumentListPane perspective and variant', () => {
   })
 
   it('queries with the perspective stack and no variant by default', async () => {
-    const wrapper = await createTestProvider({
-      config: defineConfig({projectId: 'test', dataset: 'test'}),
-      resources: [structureUsEnglishLocaleBundle],
-    })
-
-    render(<DocumentListPane {...getPaneProps()} />, {wrapper})
+    await renderDocumentListPane()
 
     expect(mockUseDocumentList).toHaveBeenCalledWith(
       expect.objectContaining({perspective: ['drafts'], variant: undefined}),
@@ -228,12 +223,7 @@ describe('DocumentListPane perspective and variant', () => {
   it('queries with the selected variant alongside the perspective stack', async () => {
     mockUsePerspective.mockReturnValue({...BASE_PERSPECTIVE, selectedVariantName: 'alpha-audience'})
 
-    const wrapper = await createTestProvider({
-      config: defineConfig({projectId: 'test', dataset: 'test'}),
-      resources: [structureUsEnglishLocaleBundle],
-    })
-
-    render(<DocumentListPane {...getPaneProps()} />, {wrapper})
+    await renderDocumentListPane()
 
     expect(mockUseDocumentList).toHaveBeenCalledWith(
       expect.objectContaining({perspective: ['drafts'], variant: 'alpha-audience'}),

--- a/packages/sanity/src/structure/panes/documentList/__tests__/DocumentListPane.test.tsx
+++ b/packages/sanity/src/structure/panes/documentList/__tests__/DocumentListPane.test.tsx
@@ -1,6 +1,8 @@
 import {render, screen} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
+import {type ReactNode} from 'react'
 import {defineConfig, type PerspectiveContextValue, usePerspective} from 'sanity'
+import {PaneContext} from 'sanity/_singletons'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {createTestProvider} from '../../../../../test/testUtils/TestProvider'
@@ -49,6 +51,7 @@ const BASE_PERSPECTIVE: PerspectiveContextValue = {
 }
 
 const ORDERING_TESTID = 'document-list-search-ordering'
+const SEARCH_TESTID = 'document-list-search'
 
 function getPaneProps() {
   return {
@@ -63,6 +66,38 @@ function getPaneProps() {
       options: {filter: '_type == "author"'},
     } as DocumentListPaneNode,
   }
+}
+
+/** The pane reads its collapsed state from context, so tests must supply one. */
+function PaneProvider(props: {children: ReactNode; collapsed?: boolean}) {
+  return (
+    <PaneContext.Provider
+      value={{
+        collapse: vi.fn(),
+        collapsed: props.collapsed ?? false,
+        expand: vi.fn(),
+        index: 0,
+        isLast: true,
+        rootElement: null,
+      }}
+    >
+      {props.children}
+    </PaneContext.Provider>
+  )
+}
+
+async function renderDocumentListPane(options: {collapsed?: boolean} = {}) {
+  const wrapper = await createTestProvider({
+    config: defineConfig({projectId: 'test', dataset: 'test'}),
+    resources: [structureUsEnglishLocaleBundle],
+  })
+
+  return render(
+    <PaneProvider collapsed={options.collapsed}>
+      <DocumentListPane {...getPaneProps()} />
+    </PaneProvider>,
+    {wrapper},
+  )
 }
 
 describe('DocumentListPane search ordering indicator', () => {
@@ -84,23 +119,13 @@ describe('DocumentListPane search ordering indicator', () => {
   })
 
   it('does not show the relevance indicator when there is no search term', async () => {
-    const wrapper = await createTestProvider({
-      config: defineConfig({projectId: 'test', dataset: 'test'}),
-      resources: [structureUsEnglishLocaleBundle],
-    })
-
-    render(<DocumentListPane {...getPaneProps()} />, {wrapper})
+    await renderDocumentListPane()
 
     expect(screen.queryByTestId(ORDERING_TESTID)).toBeNull()
   })
 
   it('shows the relevance indicator once a search term is entered', async () => {
-    const wrapper = await createTestProvider({
-      config: defineConfig({projectId: 'test', dataset: 'test'}),
-      resources: [structureUsEnglishLocaleBundle],
-    })
-
-    render(<DocumentListPane {...getPaneProps()} />, {wrapper})
+    await renderDocumentListPane()
 
     await userEvent.type(await screen.findByLabelText('Search list'), 'exodus')
 
@@ -109,12 +134,7 @@ describe('DocumentListPane search ordering indicator', () => {
   })
 
   it('treats a whitespace-only query as empty and hides the indicator', async () => {
-    const wrapper = await createTestProvider({
-      config: defineConfig({projectId: 'test', dataset: 'test'}),
-      resources: [structureUsEnglishLocaleBundle],
-    })
-
-    render(<DocumentListPane {...getPaneProps()} />, {wrapper})
+    await renderDocumentListPane()
 
     await userEvent.type(await screen.findByLabelText('Search list'), '   ')
 
@@ -122,6 +142,51 @@ describe('DocumentListPane search ordering indicator', () => {
     // appear. Allow time for the debounced query to settle before asserting.
     await new Promise((resolve) => setTimeout(resolve, 400))
     expect(screen.queryByTestId(ORDERING_TESTID)).toBeNull()
+  })
+})
+
+describe('DocumentListPane search area when the pane is collapsed', () => {
+  beforeEach(() => {
+    mockUseDocumentList.mockReturnValue({
+      error: null,
+      onRetry: vi.fn(),
+      isLoading: false,
+      items: [],
+      isRetrying: false,
+      canRetry: false,
+      retryCount: 0,
+      autoRetry: false,
+      connected: true,
+      fromCache: false,
+      onLoadFullList: vi.fn(),
+      isLoadingFullList: false,
+    })
+  })
+
+  it('shows the search area while the pane is expanded', async () => {
+    await renderDocumentListPane()
+
+    expect(await screen.findByTestId(SEARCH_TESTID)).toBeVisible()
+  })
+
+  it('hides the search area, including the relevance indicator, while collapsed', async () => {
+    const {rerender} = await renderDocumentListPane()
+
+    // Enter a search term while expanded, so the relevance indicator renders,
+    // then collapse the pane.
+    await userEvent.type(await screen.findByLabelText('Search list'), 'exodus')
+    expect(await screen.findByTestId(ORDERING_TESTID)).toBeVisible()
+
+    rerender(
+      <PaneProvider collapsed>
+        <DocumentListPane {...getPaneProps()} />
+      </PaneProvider>,
+    )
+
+    // The search area stays mounted so the query survives the collapse, but a
+    // collapsed pane is too narrow to render it without overflowing.
+    expect(screen.getByTestId(SEARCH_TESTID)).not.toBeVisible()
+    expect(screen.getByTestId(ORDERING_TESTID)).not.toBeVisible()
   })
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Collapsing a searched document-list pane left the search-ordering control rendered at the pane's expanded width, causing “Sorted by relevance” to bleed into the neighboring pane. Wrap the complete non-header pane body in React `Activity`, hiding it on collapse while restoring its search and list UI on expansion.

### What to review

- The `Activity` boundary around both search controls and document-list content
- Regression coverage for hidden collapsed content and restored search state

### Testing

- Pre-commit formatting and lint checks pass
- `pnpm build` passes
- `pnpm vitest run --project=sanity packages/sanity/src/structure/panes/documentList/__tests__/DocumentListPane.test.tsx` passes (7 tests, no type errors)
- Manually verified the searched list collapses without leaked search, ordering, or list content, then expands with the query, selection, and filtered results restored

[activity_collapsed_document_list.mp4](https://cursor.com/agents/bc-5b9d48be-b72f-44b9-a275-fd76962ecfdf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivity_collapsed_document_list.mp4)

### Notes for release

Fixed a visual glitch where document-list search controls could overlap a neighboring pane after collapsing the list.

---

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b9d48be-b72f-44b9-a275-fd76962ecfdf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b9d48be-b72f-44b9-a275-fd76962ecfdf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

