### PR TITLE
fix(sanity): honor validation concurrency options

### DIFF
--- a/packages/sanity/src/core/validation/validateDocument.ts
+++ b/packages/sanity/src/core/validation/validateDocument.ts
@@ -39,11 +39,14 @@ const DEFAULT_MAX_FETCH_CONCURRENCY = 25
 // NOTE: ensure to update the TSDoc and CLI help test if this is changed
 const DEFAULT_MAX_CUSTOM_VALIDATION_CONCURRENCY = 5
 
-let _limitConcurrency: ReturnType<typeof createClientConcurrencyLimiter> | undefined
+const concurrencyLimiters = new Map<number, ReturnType<typeof createClientConcurrencyLimiter>>()
 const getConcurrencyLimiter = (maxConcurrency: number) => {
-  if (_limitConcurrency) return _limitConcurrency
-  _limitConcurrency = createClientConcurrencyLimiter(maxConcurrency)
-  return _limitConcurrency
+  let limiter = concurrencyLimiters.get(maxConcurrency)
+  if (!limiter) {
+    limiter = createClientConcurrencyLimiter(maxConcurrency)
+    concurrencyLimiters.set(maxConcurrency, limiter)
+  }
+  return limiter
 }
 
 const isRecord = (maybeRecord: unknown): maybeRecord is Record<string, unknown> =>
@@ -163,7 +166,7 @@ export interface ValidateDocumentOptions {
    * this value if you have complex custom validations that require many
    * `client.fetch` requests at once. It's possible for custom validator to
    * stall if there are not enough concurrent fetch requests available to
-   * fullfil the custom validation. This is 25 by default.
+   * fulfill the custom validation. This is 25 by default.
    */
   maxFetchConcurrency?: number
 
@@ -244,7 +247,7 @@ export function validateDocumentObservable({
   currentUser,
 }: ValidateDocumentObservableOptions): Observable<ValidationMarker[]> {
   if (typeof document?._type !== 'string') {
-    throw new Error(`Tried to validated a value without a '_type'`)
+    throw new Error(`Tried to validate a value without a '_type'`)
   }
 
   const documentType = schema.get(document._type)

--- a/packages/sanity/src/core/validation/validateDocument.ts
+++ b/packages/sanity/src/core/validation/validateDocument.ts
@@ -41,6 +41,10 @@ const DEFAULT_MAX_CUSTOM_VALIDATION_CONCURRENCY = 5
 
 const concurrencyLimiters = new Map<number, ReturnType<typeof createClientConcurrencyLimiter>>()
 const getConcurrencyLimiter = (maxConcurrency: number) => {
+  if (!Number.isInteger(maxConcurrency) || maxConcurrency <= 0) {
+    throw new RangeError('`maxFetchConcurrency` must be a positive integer')
+  }
+
   let limiter = concurrencyLimiters.get(maxConcurrency)
   if (!limiter) {
     limiter = createClientConcurrencyLimiter(maxConcurrency)
@@ -166,7 +170,8 @@ export interface ValidateDocumentOptions {
    * this value if you have complex custom validations that require many
    * `client.fetch` requests at once. It's possible for custom validator to
    * stall if there are not enough concurrent fetch requests available to
-   * fulfill the custom validation. This is 25 by default.
+   * fulfill the custom validation. Must be a positive integer. This is 25 by
+   * default.
    */
   maxFetchConcurrency?: number
 

--- a/packages/sanity/src/core/validation/validateDocument.ts
+++ b/packages/sanity/src/core/validation/validateDocument.ts
@@ -41,10 +41,6 @@ const DEFAULT_MAX_CUSTOM_VALIDATION_CONCURRENCY = 5
 
 const concurrencyLimiters = new Map<number, ReturnType<typeof createClientConcurrencyLimiter>>()
 const getConcurrencyLimiter = (maxConcurrency: number) => {
-  if (!Number.isInteger(maxConcurrency) || maxConcurrency <= 0) {
-    throw new RangeError('`maxFetchConcurrency` must be a positive integer')
-  }
-
   let limiter = concurrencyLimiters.get(maxConcurrency)
   if (!limiter) {
     limiter = createClientConcurrencyLimiter(maxConcurrency)
@@ -171,7 +167,7 @@ export interface ValidateDocumentOptions {
    * if you have complex custom validations that require many
    * `client.fetch` requests at once. It's possible for a custom validator to
    * stall if there are not enough concurrent fetch requests available to fulfill
-   * the custom validation. Must be a positive integer. This is 25 by default.
+   * the custom validation. This is 25 by default.
    */
   maxFetchConcurrency?: number
 

--- a/packages/sanity/src/core/validation/validateDocument.ts
+++ b/packages/sanity/src/core/validation/validateDocument.ts
@@ -166,12 +166,12 @@ export interface ValidateDocumentOptions {
   maxCustomValidationConcurrency?: number
 
   /**
-   * The amount of allowed inflight fetch requests at once. You may need to up
-   * this value if you have complex custom validations that require many
-   * `client.fetch` requests at once. It's possible for custom validator to
-   * stall if there are not enough concurrent fetch requests available to
-   * fulfill the custom validation. Must be a positive integer. This is 25 by
-   * default.
+   * The amount of allowed inflight fetch requests at once for validations using
+   * the same configured client and concurrency value. You may need to up this
+   * value if you have complex custom validations that require many
+   * `client.fetch` requests at once. It's possible for a custom validator to
+   * stall if there are not enough concurrent fetch requests available to fulfill
+   * the custom validation. Must be a positive integer. This is 25 by default.
    */
   maxFetchConcurrency?: number
 

--- a/packages/sanity/src/core/validation/validateDocument.ts
+++ b/packages/sanity/src/core/validation/validateDocument.ts
@@ -166,9 +166,9 @@ export interface ValidateDocumentOptions {
   maxCustomValidationConcurrency?: number
 
   /**
-   * The amount of allowed inflight fetch requests at once for validations using
-   * the same configured client and concurrency value. You may need to up this
-   * value if you have complex custom validations that require many
+   * The amount of allowed inflight fetch requests at once across validations in
+   * this process using the same concurrency value. You may need to up this value
+   * if you have complex custom validations that require many
    * `client.fetch` requests at once. It's possible for a custom validator to
    * stall if there are not enough concurrent fetch requests available to fulfill
    * the custom validation. Must be a positive integer. This is 25 by default.

--- a/packages/sanity/src/core/validation/validateDocument.ts
+++ b/packages/sanity/src/core/validation/validateDocument.ts
@@ -39,16 +39,6 @@ const DEFAULT_MAX_FETCH_CONCURRENCY = 25
 // NOTE: ensure to update the TSDoc and CLI help test if this is changed
 const DEFAULT_MAX_CUSTOM_VALIDATION_CONCURRENCY = 5
 
-const concurrencyLimiters = new Map<number, ReturnType<typeof createClientConcurrencyLimiter>>()
-const getConcurrencyLimiter = (maxConcurrency: number) => {
-  let limiter = concurrencyLimiters.get(maxConcurrency)
-  if (!limiter) {
-    limiter = createClientConcurrencyLimiter(maxConcurrency)
-    concurrencyLimiters.set(maxConcurrency, limiter)
-  }
-  return limiter
-}
-
 const isRecord = (maybeRecord: unknown): maybeRecord is Record<string, unknown> =>
   typeof maybeRecord === 'object' && maybeRecord !== null && !Array.isArray(maybeRecord)
 
@@ -162,9 +152,8 @@ export interface ValidateDocumentOptions {
   maxCustomValidationConcurrency?: number
 
   /**
-   * The amount of allowed inflight fetch requests at once across validations in
-   * this process using the same concurrency value. You may need to up this value
-   * if you have complex custom validations that require many
+   * The amount of allowed inflight fetch requests at once for this validation.
+   * You may need to up this value if you have complex custom validations that require many
    * `client.fetch` requests at once. It's possible for a custom validator to
    * stall if there are not enough concurrent fetch requests available to fulfill
    * the custom validation. This is 25 by default.
@@ -195,7 +184,7 @@ export function validateDocument({
 }: ValidateDocumentOptions): Promise<ValidationMarker[]> {
   // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
   const getClient = options.getClient || workspace.getClient
-  const limitConcurrency = getConcurrencyLimiter(
+  const limitConcurrency = createClientConcurrencyLimiter(
     maxFetchConcurrency ?? DEFAULT_MAX_FETCH_CONCURRENCY,
   )
   const getConcurrencyLimitedClient = (clientOptions: SourceClientOptions) =>

--- a/packages/sanity/test/validation/validateDocument.test.ts
+++ b/packages/sanity/test/validation/validateDocument.test.ts
@@ -212,6 +212,7 @@ describe('validateDocument', () => {
           document: {_type: 'simpleDoc'} as SanityDocument,
           maxFetchConcurrency,
           workspace: {
+            getClient,
             schema: createSchema({
               name: 'default',
               types: [{name: 'simpleDoc', type: 'document', fields: []}],

--- a/packages/sanity/test/validation/validateDocument.test.ts
+++ b/packages/sanity/test/validation/validateDocument.test.ts
@@ -203,6 +203,24 @@ describe('validateDocument', () => {
     await expect(validateWithConcurrency(1)).resolves.toBe(1)
     await expect(validateWithConcurrency(2)).resolves.toBe(2)
   })
+
+  it.each([0, -1, NaN, 1.5, Infinity])(
+    'rejects invalid maxFetchConcurrency value %s',
+    (maxFetchConcurrency) => {
+      expect(() =>
+        validateDocument({
+          document: {_type: 'simpleDoc'} as SanityDocument,
+          maxFetchConcurrency,
+          workspace: {
+            schema: createSchema({
+              name: 'default',
+              types: [{name: 'simpleDoc', type: 'document', fields: []}],
+            }),
+          } as Workspace,
+        }),
+      ).toThrow('`maxFetchConcurrency` must be a positive integer')
+    },
+  )
 })
 
 describe('validateItem', () => {

--- a/packages/sanity/test/validation/validateDocument.test.ts
+++ b/packages/sanity/test/validation/validateDocument.test.ts
@@ -145,6 +145,64 @@ describe('validateDocument', () => {
       },
     ])
   })
+
+  it('honors maxFetchConcurrency values across validation calls', async () => {
+    const schema = createSchema({
+      name: 'default',
+      types: [
+        {
+          name: 'concurrentDoc',
+          type: 'document',
+          fields: ['first', 'second', 'third'].map((name) => ({
+            name,
+            type: 'string',
+            validation: (rule: Rule) =>
+              rule.custom(async (_value, context) => {
+                await context.getClient({apiVersion: '2026-01-01'}).fetch('*[]')
+                return true as const
+              }),
+          })),
+        },
+      ],
+    })
+    const document: SanityDocument = {
+      _id: 'testId',
+      _createdAt: '2021-08-27T14:48:51.650Z',
+      _rev: 'exampleRev',
+      _type: 'concurrentDoc',
+      _updatedAt: '2021-08-27T14:48:51.650Z',
+      first: 'one',
+      second: 'two',
+      third: 'three',
+    }
+
+    const validateWithConcurrency = async (maxFetchConcurrency: number) => {
+      let active = 0
+      let peak = 0
+      const testClient = {
+        fetch: async () => {
+          active += 1
+          peak = Math.max(peak, active)
+          await new Promise((resolve) => setTimeout(resolve, 5))
+          active -= 1
+          return null
+        },
+      }
+
+      await validateDocument({
+        document,
+        // oxlint-disable-next-line no-deprecated -- explicit client isolates the concurrency limit under test
+        getClient: () => testClient as unknown as ReturnType<ValidationContext['getClient']>,
+        maxFetchConcurrency,
+        workspace: {schema} as Workspace,
+      })
+
+      return peak
+    }
+
+    await expect(validateWithConcurrency(1)).resolves.toBe(1)
+    await expect(validateWithConcurrency(2)).resolves.toBe(2)
+  })
 })
 
 describe('validateItem', () => {

--- a/packages/sanity/test/validation/validateDocument.test.ts
+++ b/packages/sanity/test/validation/validateDocument.test.ts
@@ -207,7 +207,7 @@ describe('validateDocument', () => {
   it.each([0, -1, NaN, 1.5, Infinity])(
     'rejects invalid maxFetchConcurrency value %s',
     (maxFetchConcurrency) => {
-      expect(() =>
+      const validate = () =>
         validateDocument({
           document: {_type: 'simpleDoc'} as SanityDocument,
           maxFetchConcurrency,
@@ -217,8 +217,10 @@ describe('validateDocument', () => {
               types: [{name: 'simpleDoc', type: 'document', fields: []}],
             }),
           } as Workspace,
-        }),
-      ).toThrow('`maxFetchConcurrency` must be a positive integer')
+        })
+
+      expect(validate).toThrow(RangeError)
+      expect(validate).toThrow('`maxFetchConcurrency` must be a positive integer')
     },
   )
 })

--- a/packages/sanity/test/validation/validateDocument.test.ts
+++ b/packages/sanity/test/validation/validateDocument.test.ts
@@ -203,27 +203,6 @@ describe('validateDocument', () => {
     await expect(validateWithConcurrency(1)).resolves.toBe(1)
     await expect(validateWithConcurrency(2)).resolves.toBe(2)
   })
-
-  it.each([0, -1, NaN, 1.5, Infinity])(
-    'rejects invalid maxFetchConcurrency value %s',
-    (maxFetchConcurrency) => {
-      const validate = () =>
-        validateDocument({
-          document: {_type: 'simpleDoc'} as SanityDocument,
-          maxFetchConcurrency,
-          workspace: {
-            getClient,
-            schema: createSchema({
-              name: 'default',
-              types: [{name: 'simpleDoc', type: 'document', fields: []}],
-            }),
-          } as Workspace,
-        })
-
-      expect(validate).toThrow(RangeError)
-      expect(validate).toThrow('`maxFetchConcurrency` must be a positive integer')
-    },
-  )
 })
 
 describe('validateItem', () => {


### PR DESCRIPTION
Fixes:
- A typo
- Another typo
- `validateDocument()` concurrency limiting
   - The first `validateDocument()` call created a single global concurrency limiter, causing all later calls to ignore their own `maxFetchConcurrency` values
   - This PR changes the cache to be one limiter per concurrency value, so calls using the same limit still share capacity
   - Calls specifying different limits are handled correctly
- Upgrade @testing-library/jest-dom to v7, which fixes a pnpm package link error I was seeing locally
   - This is a safe upgrade, it just makes Node v22 the minimum which we already use


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how async custom validators throttle `client.fetch` during document validation, which can affect backend load and whether validators stall in multi-call or Studio scenarios.
> 
> **Overview**
> **`validateDocument()` no longer reuses a process-wide fetch concurrency limiter**, so each validation run respects its own `maxFetchConcurrency` instead of being stuck with whatever limit the first call used.
> 
> The old module-level `getConcurrencyLimiter` cache is removed; each call now builds a fresh `createClientConcurrencyLimiter` from `maxFetchConcurrency` (default 25). TSDoc for that option is clarified, and a thrown error message typo is fixed (`validate` vs `validated`).
> 
> A regression test runs three parallel custom validators that `fetch`, and asserts peak in-flight requests match `maxFetchConcurrency` of 1 and 2 across separate validation calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68891aa2ccb0a83841c16b11991911c3ac560424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->