### PR TITLE
fix(core): classify client v8 timeout errors in the request-error channel

### DIFF
--- a/packages/sanity/src/core/store/project/useProject.test.tsx
+++ b/packages/sanity/src/core/store/project/useProject.test.tsx
@@ -66,7 +66,16 @@ describe('useProject', () => {
     const get = vi
       .fn<ProjectStore['get']>()
       .mockReturnValueOnce(
-        throwError(() => new ClientError({statusCode: 429, headers: {}, body: {}} as never)),
+        throwError(
+          () =>
+            new ClientError({
+              statusCode: 429,
+              headers: {},
+              body: {},
+              url: 'https://abc123.api.sanity.io/v1/projects/abc123',
+              method: 'GET',
+            } as never),
+        ),
       )
       .mockReturnValueOnce(of(projectData))
     const {result} = setup(get, channel)

--- a/packages/sanity/src/core/studio/requestErrors/__tests__/diagnoseRequestFailure.test.ts
+++ b/packages/sanity/src/core/studio/requestErrors/__tests__/diagnoseRequestFailure.test.ts
@@ -86,4 +86,32 @@ describe('createRequestFailureProbe', () => {
     expect(await probe(clientError(500, {error: 'boom'}))).toEqual({type: 'unknown'})
     expect(await probe(new Error('nope'))).toEqual({type: 'unknown'})
   })
+
+  it('does not probe /check/cors for timeouts, including leftover get-it v8 codes', async () => {
+    const fetchSpy = vi.fn()
+    globalThis.fetch = fetchSpy as never
+    const probe = createRequestFailureProbe(fakeClient(), makeCache())
+
+    expect(
+      await probe(
+        Object.assign(new Error('The operation was aborted due to timeout'), {
+          name: 'TimeoutError',
+        }),
+      ),
+    ).toEqual({type: 'unknown'})
+    expect(
+      await probe(
+        Object.assign(new Error('Socket timed out on request to https://x.api.sanity.io/…'), {
+          code: 'ESOCKETTIMEDOUT',
+        }),
+      ),
+    ).toEqual({type: 'unknown'})
+    expect(await probe(Object.assign(new Error('connect ETIMEDOUT'), {code: 'ETIMEDOUT'}))).toEqual(
+      {
+        type: 'unknown',
+      },
+    )
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
 })

--- a/packages/sanity/src/core/studio/requestErrors/__tests__/requestErrors.test.ts
+++ b/packages/sanity/src/core/studio/requestErrors/__tests__/requestErrors.test.ts
@@ -130,6 +130,26 @@ describe('classifyRequestError', () => {
     expect(classifyRequestError(networkError())).toMatchObject({type: 'networkError'})
   })
 
+  it('classifies get-it v9 / platform TimeoutErrors as networkError', () => {
+    const timeout = Object.assign(new Error('The operation was aborted due to timeout'), {
+      name: 'TimeoutError',
+    })
+    expect(classifyRequestError(timeout)).toMatchObject({type: 'networkError'})
+  })
+
+  it('classifies get-it v8 socket timeouts as networkError', () => {
+    const timeout = Object.assign(
+      new Error('Socket timed out on request to https://x.api.sanity.io/…'),
+      {code: 'ESOCKETTIMEDOUT'},
+    )
+    expect(classifyRequestError(timeout)).toMatchObject({type: 'networkError'})
+  })
+
+  it('classifies Node ETIMEDOUT errors as networkError', () => {
+    const timeout = Object.assign(new Error('connect ETIMEDOUT'), {code: 'ETIMEDOUT'})
+    expect(classifyRequestError(timeout)).toMatchObject({type: 'networkError'})
+  })
+
   it('leaves arbitrary errors unclassified', () => {
     expect(classifyRequestError(new Error('nope'))).toBeNull()
   })

--- a/packages/sanity/src/core/studio/requestErrors/classify.ts
+++ b/packages/sanity/src/core/studio/requestErrors/classify.ts
@@ -15,6 +15,19 @@ export {isTimeoutError}
  */
 const LEGACY_TIMEOUT_CODES = new Set(['ESOCKETTIMEDOUT', 'ETIMEDOUT'])
 
+/**
+ * Timeouts the studio should treat as infrastructure failures and must not
+ * diagnose via `/check/cors` (the probe would just time out too). Covers
+ * get-it v9 / platform `TimeoutError` and leftover get-it v8 / Node codes.
+ *
+ * @internal
+ */
+export function isRequestTimeoutError(error: unknown): error is Error {
+  if (isTimeoutError(error)) return true
+  if (typeof error !== 'object' || error === null) return false
+  return 'code' in error && typeof error.code === 'string' && LEGACY_TIMEOUT_CODES.has(error.code)
+}
+
 /** @internal */
 export function isNetworkError(error: unknown): error is Error {
   if (typeof error !== 'object' || error === null) return false
@@ -22,10 +35,7 @@ export function isNetworkError(error: unknown): error is Error {
   if ('isNetworkError' in error && error.isNetworkError === true) return true
   // Treat both get-it header timeouts and platform request-deadline
   // TimeoutErrors as network errors so they get the same treatment.
-  if (isTimeoutError(error)) return true
-  if ('code' in error && typeof error.code === 'string' && LEGACY_TIMEOUT_CODES.has(error.code)) {
-    return true
-  }
+  if (isRequestTimeoutError(error)) return true
   return isNativeNetworkError(error)
 }
 

--- a/packages/sanity/src/core/studio/requestErrors/classify.ts
+++ b/packages/sanity/src/core/studio/requestErrors/classify.ts
@@ -7,6 +7,14 @@ import isNativeNetworkError from 'is-network-error'
 export {getApiErrorCode, isInvalidSessionError, isUnauthorizedError} from '../../util/apiErrors'
 export {isTimeoutError}
 
+/**
+ * Node / get-it v8 timeout codes. get-it v9 reports timeouts as
+ * `TimeoutError` (caught by {@link isTimeoutError}); older transports used
+ * `ESOCKETTIMEDOUT` (idle socket) or `ETIMEDOUT` (connect/request deadline)
+ * on a plain Error, which `isTimeoutError` no longer matches.
+ */
+const LEGACY_TIMEOUT_CODES = new Set(['ESOCKETTIMEDOUT', 'ETIMEDOUT'])
+
 /** @internal */
 export function isNetworkError(error: unknown): error is Error {
   if (typeof error !== 'object' || error === null) return false
@@ -15,6 +23,9 @@ export function isNetworkError(error: unknown): error is Error {
   // Treat both get-it header timeouts and platform request-deadline
   // TimeoutErrors as network errors so they get the same treatment.
   if (isTimeoutError(error)) return true
+  if ('code' in error && typeof error.code === 'string' && LEGACY_TIMEOUT_CODES.has(error.code)) {
+    return true
+  }
   return isNativeNetworkError(error)
 }
 

--- a/packages/sanity/src/core/studio/requestErrors/diagnoseRequestFailure.ts
+++ b/packages/sanity/src/core/studio/requestErrors/diagnoseRequestFailure.ts
@@ -1,7 +1,7 @@
 import {type SanityClient} from '@sanity/client'
 
 import {checkCors, type CorsCheckCache} from '../workspaces/corsCheck'
-import {classifyConfigError, isNetworkError, isTimeoutError} from './classify'
+import {classifyConfigError, isNetworkError, isRequestTimeoutError} from './classify'
 
 /**
  * A diagnosed request failure — the reason a request the studio can't recover
@@ -68,8 +68,9 @@ export function createRequestFailureProbe(
     }
 
     // Opaque network/CORS failure — probe `/check/cors` to learn why. Skip
-    // timeouts (the probe itself would just time out).
-    if (!isNetworkError(err) || isTimeoutError(err)) {
+    // timeouts (the probe itself would just time out), including leftover
+    // get-it v8 / Node timeout codes that `isTimeoutError` no longer matches.
+    if (!isNetworkError(err) || isRequestTimeoutError(err)) {
       return {type: 'unknown'}
     }
 

--- a/packages/sanity/src/structure/components/structureTool/intentResolver/__tests__/IntentResolver.test.tsx
+++ b/packages/sanity/src/structure/components/structureTool/intentResolver/__tests__/IntentResolver.test.tsx
@@ -57,9 +57,9 @@ class Boundary extends Component<{children: ReactNode}, {error: unknown}> {
   }
 }
 
-function socketTimeoutError() {
-  return Object.assign(new Error('Socket timed out on request to https://x.api.sanity.io/…'), {
-    code: 'ESOCKETTIMEDOUT',
+function timeoutError() {
+  return Object.assign(new Error('The operation was aborted due to timeout'), {
+    name: 'TimeoutError',
   })
 }
 
@@ -87,7 +87,7 @@ describe('IntentResolver', () => {
   }
 
   it('delegates infrastructure failures to the request-error channel instead of crashing', async () => {
-    mockResolveTypeForDocument.mockReturnValue(throwError(socketTimeoutError))
+    mockResolveTypeForDocument.mockReturnValue(throwError(timeoutError))
 
     const {channel, boundary} = renderResolver()
 
@@ -99,7 +99,7 @@ describe('IntentResolver', () => {
 
   it('re-runs intent resolution when the claimed error is retried', async () => {
     mockResolveTypeForDocument
-      .mockReturnValueOnce(throwError(socketTimeoutError))
+      .mockReturnValueOnce(throwError(timeoutError))
       .mockReturnValueOnce(of('author'))
 
     const {channel} = renderResolver()
@@ -114,7 +114,7 @@ describe('IntentResolver', () => {
   })
 
   it('does not re-fetch when the claimed error is retried after unmount', async () => {
-    mockResolveTypeForDocument.mockReturnValue(throwError(socketTimeoutError))
+    mockResolveTypeForDocument.mockReturnValue(throwError(timeoutError))
 
     const {channel, unmount} = renderResolver()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Unit tests on `main` started failing after `@sanity/client` v8 (get-it v9). Intent resolution timed out for 5 minutes waiting for a request-error claim, and `useProject` never saw a `rateLimited` claim.

get-it v9's `isTimeoutError` only matches `name === 'TimeoutError'` (or a full headers-timeout object). The previous fixtures used get-it v8's `ESOCKETTIMEDOUT` on a plain `Error`, which is no longer classified, so `attempt()` rethrew into the error boundary. `isHttpError` also now requires `response.url` and `response.method`, so a 429 `ClientError` constructed without those fields was treated as caller-domain.

Why not only update the test fixtures: leftover get-it v8 / Node timeout codes can still surface (get-it 8 remains in the lockfile), and those would still crash instead of opening the retry dialog.

Why not loosen `isHttpError`: real client errors already carry `url`/`method`; the 429 fixture was incomplete.

The CORS probe now uses the same timeout helper, so leftover timeout codes are not sent to `/check/cors` (that request would just time out too).

### What to review

- `isRequestTimeoutError` covering get-it v9 `TimeoutError` and leftover `ESOCKETTIMEDOUT` / `ETIMEDOUT`
- Test fixtures matching client v8 timeout and HTTP error shapes

### Testing

- Added classify coverage for `TimeoutError`, `ESOCKETTIMEDOUT`, and `ETIMEDOUT`
- Updated `IntentResolver` and `useProject` tests to use client v8 error shapes
- Added a request-failure-probe test that leftover timeouts skip `/check/cors`
- Local vitest: `requestErrors.test.ts`, `diagnoseRequestFailure.test.ts`, and `useProject.test.tsx` 61 passed; `IntentResolver.test.tsx` 4 passed

### Notes for release

N/A – Internal only: restores request-error classification for timeout codes after the client v8 upgrade; no user-facing API change.

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36eecd34-589c-4a82-b855-02d8bb1e88b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36eecd34-589c-4a82-b855-02d8bb1e88b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

