### PR TITLE
chore(deps): reapply client v8 upgrade after hotfix release

### DIFF
--- a/dev/preview-iframe/src/loader.tsx
+++ b/dev/preview-iframe/src/loader.tsx
@@ -14,5 +14,12 @@ const client = createClient({
   stega: {enabled: true, studioUrl},
 })
 
-export const {useQuery, useLiveMode} = createQueryStore({client})
+export const {useQuery, useLiveMode} = createQueryStore({
+  // @ts-expect-error -- `@sanity/react-loader` pins `@sanity/client@^7`, so two copies of the
+  // package are installed and its `createQueryStore` is typed against the v7 `SanityClient`.
+  // `SanityClient` carries an ES private field, which TypeScript compares nominally, so the two
+  // copies are never assignable to each other even though the API we use here is identical.
+  // Remove once the loader chain supports `@sanity/client@^8`.
+  client,
+})
 export const imageBuilder: ImageUrlBuilder = createImageUrlBuilder(client)

--- a/dev/test-studio/plugins/error-reporting-test/demoInterceptor.ts
+++ b/dev/test-studio/plugins/error-reporting-test/demoInterceptor.ts
@@ -1,29 +1,29 @@
 /**
  * Dev-only client wrapper for the error playground. Composes the studio's
- * workspace `_requestHandler` so the full classification pipeline runs,
- * but substitutes a synthetic `defaultRequester` for matching demo URLs.
+ * workspace transport so the full classification pipeline runs, while
+ * retaining the synthetic request shapes used by the demo scenarios.
  *
  * Why not patch XHR / fetch directly? get-it can swap transport adapters
  * (xhr in browsers, fetch in workers, possibly more in the future). A
- * client-layer composition is transport-agnostic — it sees only the
- * rxjs Observable<HttpRequestEvent> contract, which is stable.
- *
- * Why not just override `_requestHandler` with synthesis? Because
- * `_requestHandler` is a single slot — overriding it replaces the
- * workspace handler. The classification + dialog pipeline disappears.
- * Composing means we delegate to the workspace handler, only substituting
- * the underlying HTTP at its `defaultRequester` callback.
+ * client-layer composition is transport-agnostic and uses the same parsed
+ * response and normalized-error contract as normal client requests.
  */
 
-import {
-  ClientError,
-  type HttpRequestEvent,
-  type RequestHandler,
-  type RequestOptions,
-  type SanityClient,
-  ServerError,
-} from '@sanity/client'
-import {defer, Observable, throwError} from 'rxjs'
+import {ClientError, type RequestHandler, type SanityClient, ServerError} from '@sanity/client'
+import {firstValueFrom, Observable, throwError} from 'rxjs'
+
+type RequestOptions = {method?: string; url: string}
+type HttpRequestEvent =
+  | {type: 'progress'; stage: 'upload' | 'download'; percent: number; lengthComputable: boolean}
+  | {
+      type: 'response'
+      body: unknown
+      headers: Record<string, string>
+      method: string
+      statusCode: number
+      statusMessage: string
+      url: string
+    }
 
 const DEMO_PATH_PREFIX = '/demo/global-error/'
 
@@ -248,39 +248,26 @@ function responseObservable(
  * responses. Non-matching requests fall through to the workspace request
  * handler unchanged.
  *
- * `_requestHandler` lives on the underlying `ClientConfig` (it's how
- * `withConfig` propagates handlers) but isn't on the public TypeScript
- * surface for `client.config()` / `withConfig`. The two casts below
- * launder that single internal field.
- *
  * @internal
  */
 export function makeDemoClient(baseClient: SanityClient): SanityClient {
-  // Capture the workspace handler so we can delegate to it for both demo
-  // and non-demo requests. The workspace handler owns the classification +
-  // dialog pipeline; we just substitute its inner `defaultRequester`
-  // callback for matched URLs.
-  // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-  const workspaceHandler = (baseClient.config() as unknown as {_requestHandler?: RequestHandler})
-    ._requestHandler
+  const demoRequestHandler: RequestHandler = async (request, next) => {
+    const synthetic = synthesize(request)
+    if (!synthetic) return next(request)
 
-  // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-  const handler: RequestHandler = (req, defaultRequester, client) => {
-    const synthRequester = (opts: RequestOptions & {url: string}) => {
-      const synthetic = synthesize(opts)
-      return synthetic ?? defer(() => defaultRequester(opts))
+    const event = await firstValueFrom(synthetic)
+    if (event.type !== 'response') {
+      throw new Error('Synthetic request completed without a response')
     }
-    if (workspaceHandler) {
-      return workspaceHandler(req, synthRequester, client)
-    }
-    // No workspace handler attached → just synthesize directly. Used in
-    // tests / standalone client setups.
-    return synthRequester(req)
+    return event.body
   }
 
+  const workspaceRequestHandler = baseClient.config().requestHandler
   return baseClient.withConfig({
-    // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-    _requestHandler: handler,
+    requestHandler: workspaceRequestHandler
+      ? (request, next) =>
+          workspaceRequestHandler(request, (nextRequest) => demoRequestHandler(nextRequest, next))
+      : demoRequestHandler,
   })
 }
 

--- a/e2e/helpers/clearKeyValueKey.ts
+++ b/e2e/helpers/clearKeyValueKey.ts
@@ -17,7 +17,7 @@ function getStatusCode(err: unknown): number | undefined {
 export async function clearKeyValueKey(client: SanityClient, key: string): Promise<void> {
   try {
     await client.withConfig({apiVersion: '2024-03-12'}).request({
-      uri: `/users/me/keyvalue/${encodeURIComponent(key)}`,
+      url: `/users/me/keyvalue/${encodeURIComponent(key)}`,
       method: 'DELETE',
     })
   } catch (err) {

--- a/e2e/studio-test.ts
+++ b/e2e/studio-test.ts
@@ -1,6 +1,6 @@
 // oxlint-disable-next-line no-restricted-imports
 import {expect, test as baseTest} from '@playwright/test'
-import {createClient, type SanityClient, type SanityDocument} from '@sanity/client'
+import {createClient, type MultipleMutationResult, type SanityClient} from '@sanity/client'
 import {uuid} from '@sanity/uuid'
 
 import {watchForStudioErrors} from './helpers/studioErrors'
@@ -25,7 +25,7 @@ class _TestSanityContext {
   }
 
   // TODO: confirm we want this teardown, datasets are at the end, deleted (not in main), persisting the document could help us debug
-  teardown(sanityClient: SanityClient): Promise<SanityDocument<Record<string, unknown>>> {
+  teardown(sanityClient: SanityClient): Promise<MultipleMutationResult> {
     return sanityClient.delete({
       query: '*[_id in $ids]',
       params: {ids: [...this.documentIds].map((id) => `drafts.${id}`)},

--- a/e2e/tests/releases/utils/methods.ts
+++ b/e2e/tests/releases/utils/methods.ts
@@ -25,7 +25,7 @@ export const createRelease = async ({
   metadata: Record<string, any>
 }) => {
   await sanityClient.withConfig(CLIENT_OPTIONS).request({
-    uri: `/data/actions/${dataset}`,
+    url: `/data/actions/${dataset}`,
     method: 'POST',
     body: {
       actions: [
@@ -50,7 +50,7 @@ export const archiveRelease = async ({
 }) => {
   try {
     await sanityClient.withConfig(CLIENT_OPTIONS).request({
-      uri: `/data/actions/${dataset}`,
+      url: `/data/actions/${dataset}`,
       method: 'POST',
       body: {
         actions: [
@@ -78,7 +78,7 @@ export const unarchiveRelease = async ({
 }) => {
   try {
     await sanityClient.withConfig(CLIENT_OPTIONS).request({
-      uri: `/data/actions/${dataset}`,
+      url: `/data/actions/${dataset}`,
       method: 'POST',
       body: {
         actions: [
@@ -106,7 +106,7 @@ export const deleteRelease = async ({
 }) => {
   // delete release
   await sanityClient.withConfig(CLIENT_OPTIONS).request({
-    uri: `/data/actions/${dataset}`,
+    url: `/data/actions/${dataset}`,
     method: 'POST',
     body: {
       actions: [
@@ -144,7 +144,7 @@ export const discardVersion = async ({
 }) => {
   // discard release
   await sanityClient.withConfig(CLIENT_OPTIONS).request({
-    uri: `/data/actions/${dataset}`,
+    url: `/data/actions/${dataset}`,
     method: 'POST',
     body: {
       actions: [

--- a/packages/sanity/src/core/config/__tests__/prepareConfig.test.ts
+++ b/packages/sanity/src/core/config/__tests__/prepareConfig.test.ts
@@ -1,3 +1,4 @@
+import {createClient, type RequestHandler} from '@sanity/client'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {getCollectedConfigWarnings} from '../configWarnings'
@@ -189,5 +190,21 @@ describe('prepareConfig — workspace hidden property', () => {
     ])
 
     expect(workspaces.find((w) => w.name === 'callback')?.hidden).toBe(hidden)
+  })
+})
+
+describe('prepareConfig — studio request handler', () => {
+  it('passes the handler to a custom client factory', () => {
+    const requestHandler: RequestHandler = (request, next) => next(request)
+    const clientFactory = vi.fn(createClient)
+
+    prepareConfig(createWorkspace({unstable_clientFactory: clientFactory}), {
+      createStudioRequestHandler: () => requestHandler,
+    })
+
+    expect(clientFactory).toHaveBeenCalled()
+    for (const [config] of clientFactory.mock.calls) {
+      expect(config.requestHandler).toBe(requestHandler)
+    }
   })
 })

--- a/packages/sanity/src/core/config/prepareConfig.tsx
+++ b/packages/sanity/src/core/config/prepareConfig.tsx
@@ -271,8 +271,7 @@ export function prepareConfig(
   config: Config | MissingConfigFile,
   options?: {
     basePath?: string
-    // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-    requestHandler?: RequestHandler
+    createStudioRequestHandler?: (getClient: () => SanityClient) => RequestHandler
     requestErrorChannel?: RequestErrorChannel
     requestFailureDiagnostics?: RequestFailureDiagnostics
   },
@@ -368,7 +367,7 @@ export function prepareConfig(
       }
 
       const auth = getAuthStore(source, {
-        requestHandler: options?.requestHandler,
+        createStudioRequestHandler: options?.createStudioRequestHandler,
         requestErrorChannel: options?.requestErrorChannel,
         requestFailureDiagnostics: options?.requestFailureDiagnostics,
       })
@@ -435,12 +434,11 @@ export function prepareConfig(
 function getAuthStore(
   source: SourceOptions,
   {
-    requestHandler,
+    createStudioRequestHandler,
     requestErrorChannel,
     requestFailureDiagnostics,
   }: {
-    // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-    requestHandler?: RequestHandler
+    createStudioRequestHandler?: (getClient: () => SanityClient) => RequestHandler
     requestErrorChannel?: RequestErrorChannel
     requestFailureDiagnostics?: RequestFailureDiagnostics
   },
@@ -449,15 +447,21 @@ function getAuthStore(
     return source.auth
   }
 
-  const _clientFactory = source.unstable_clientFactory || createClient
+  const clientFactory = source.unstable_clientFactory ?? createClient
 
   const {projectId, dataset, apiHost} = source
   return createAuthStore({
     apiHost,
     ...source.auth,
     clientFactory: (config) => {
-      // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-      return _clientFactory({...config, _requestHandler: requestHandler})
+      let client: SanityClient
+      client = clientFactory({
+        ...config,
+        ...(createStudioRequestHandler
+          ? {requestHandler: createStudioRequestHandler(() => client)}
+          : {}),
+      })
+      return client
     },
     // Passed as getters so this unhashable runtime wiring stays out of the
     // auth-store memo key.

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/__tests__/MediaLibrary.test.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/__tests__/MediaLibrary.test.tsx
@@ -85,7 +85,7 @@ describe('provisioning', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
     const client = createMockSanityClient({
       requestCallback: (request) => {
-        switch (request.uri) {
+        switch (request.url) {
           case '/projects/mock-project-id':
             return {
               statusCode: 200,

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/hooks/useEnsureMediaLibrary.ts
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/hooks/useEnsureMediaLibrary.ts
@@ -46,7 +46,7 @@ function getMediaLibrariesForOrganization(
 ): Observable<MediaLibrary> {
   return client
     .request<{data?: MediaLibrary[]}>({
-      uri: `/media-libraries?organizationId=${organizationId}`,
+      url: `/media-libraries?organizationId=${organizationId}`,
       method: 'GET',
     })
     .pipe(
@@ -65,7 +65,7 @@ function getOrganizationIdFromLibraryId(
 ): Observable<string> {
   return client
     .request({
-      uri: `/media-libraries/${libraryId}`,
+      url: `/media-libraries/${libraryId}`,
       method: 'GET',
     })
     .pipe(
@@ -88,7 +88,7 @@ function getOrganizationIdFromProjectId(
 ): Observable<string> {
   return client
     .request({
-      uri: `/projects/${projectId}`,
+      url: `/projects/${projectId}`,
       method: 'GET',
     })
     .pipe(

--- a/packages/sanity/src/core/form/studio/inputs/client-adapters/assets.ts
+++ b/packages/sanity/src/core/form/studio/inputs/client-adapters/assets.ts
@@ -1,4 +1,4 @@
-import {type ProgressEvent, type SanityAssetDocument, type SanityClient} from '@sanity/client'
+import {type SanityAssetDocument, type SanityClient, type UploadProgressEvent} from '@sanity/client'
 import {type FileAsset, type ImageAsset} from '@sanity/types'
 import {from, Observable, of as observableOf} from 'rxjs'
 import {catchError, map, mergeMap, startWith} from 'rxjs/operators'
@@ -13,7 +13,7 @@ import {withMaxConcurrency} from '../../utils/withMaxConcurrency'
 
 const MAX_CONCURRENT_UPLOADS = 4
 
-type UploadEvent = ProgressEvent | {type: 'complete'; id: string; asset: SanityAssetDocument}
+type UploadEvent = UploadProgressEvent | {type: 'complete'; id: string; asset: SanityAssetDocument}
 
 function uploadSanityAsset(
   client: SanityClient,

--- a/packages/sanity/src/core/form/studio/inputs/crossDatasetReference/datastores/getReferenceInfo.ts
+++ b/packages/sanity/src/core/form/studio/inputs/crossDatasetReference/datastores/getReferenceInfo.ts
@@ -102,7 +102,7 @@ function fetchDocumentAvailability(
   id: string,
 ): Observable<DocumentAvailability | null> {
   const requestOptions = {
-    uri: client.getDataUrl('doc', id),
+    url: client.getDataUrl('doc', id),
     json: true,
     query: {excludeContent: 'true'},
     tag: `${REQUEST_TAG_BASE}.availability`,

--- a/packages/sanity/src/core/form/studio/inputs/globalDocumentReference/datastores/getReferenceInfo.ts
+++ b/packages/sanity/src/core/form/studio/inputs/globalDocumentReference/datastores/getReferenceInfo.ts
@@ -159,7 +159,7 @@ function fetchDocumentAvailability(
   id: string,
 ): Observable<DocumentAvailability | null> {
   const requestOptions = {
-    uri: client.getDataUrl('doc', id),
+    url: client.getDataUrl('doc', id),
     json: true,
     excludeContent: 'true',
     tag: `${REQUEST_TAG_BASE}.availability`,

--- a/packages/sanity/src/core/hooks/useFeatureEnabled.ts
+++ b/packages/sanity/src/core/hooks/useFeatureEnabled.ts
@@ -37,7 +37,7 @@ export const FEATURES: Record<string, string> = {
  */
 function fetchFeatures({versionedClient}: {versionedClient: SanityClient}): Observable<string[]> {
   return versionedClient.observable.request<string[]>({
-    uri: `/features`,
+    url: `/features`,
     tag: 'features',
   })
 }

--- a/packages/sanity/src/core/hooks/useProjectSubscriptions.ts
+++ b/packages/sanity/src/core/hooks/useProjectSubscriptions.ts
@@ -104,7 +104,7 @@ function fetchProjectSubscriptions({
   versionedClient: SanityClient
 }): Observable<ProjectSubscriptionsResponse> {
   return versionedClient.observable.request<ProjectSubscriptionsResponse>({
-    uri: `/subscriptions/project/${versionedClient.config().projectId}`,
+    url: `/subscriptions/project/${versionedClient.config().projectId}`,
     tag: 'project-subscriptions',
   })
 }

--- a/packages/sanity/src/core/hooks/useUpsellData.ts
+++ b/packages/sanity/src/core/hooks/useUpsellData.ts
@@ -84,7 +84,7 @@ export const useUpsellData = ({dataUri, feature}: UpsellDataProps) => {
 
   const upsellResult$ = useMemo(
     () =>
-      client.observable.request<UpsellData | null>({uri: dataUri}).pipe(
+      client.observable.request<UpsellData | null>({url: dataUri}).pipe(
         map((data): UpsellResult => {
           if (!data) {
             return {upsellData: null, hasError: true}

--- a/packages/sanity/src/core/preview/availability.ts
+++ b/packages/sanity/src/core/preview/availability.ts
@@ -91,7 +91,7 @@ function createDocumentAvailabilityObserver(
   function fetchDocumentReadabilityChunked(ids: string[]): Observable<DocumentAvailability[]> {
     return defer(() => {
       const requestOptions = {
-        uri: versionedClient.getDataUrl('doc', ids.join(',')),
+        url: versionedClient.getDataUrl('doc', ids.join(',')),
         json: true,
         query: {excludeContent: 'true'},
         tag: 'preview.documents-availability',

--- a/packages/sanity/src/core/releases/contexts/upsell/fetchReleaseLimits.ts
+++ b/packages/sanity/src/core/releases/contexts/upsell/fetchReleaseLimits.ts
@@ -43,7 +43,7 @@ export function fetchReleaseLimits(
 
   return clientX.observable
     .request<ReleaseLimitsResponse>({
-      uri: `projects/${projectId}/new-content-release-allowed`,
+      url: `projects/${projectId}/new-content-release-allowed`,
       /**
        * In a particular case when both releaseLimits
        * and orgActiveReleaseCount stores are empty, 2 fetch calls are made

--- a/packages/sanity/src/core/scheduled-publishing/hooks/usePollSchedules.ts
+++ b/packages/sanity/src/core/scheduled-publishing/hooks/usePollSchedules.ts
@@ -34,7 +34,7 @@ function useFetcher(queryKey: QueryKey) {
       client.request<{schedules: Schedule[] | undefined}>({
         query: queryKey.params,
         method: 'GET',
-        uri: queryKey.url,
+        url: queryKey.url,
       }),
     [client, queryKey],
   )

--- a/packages/sanity/src/core/scheduled-publishing/hooks/useScheduleApi.ts
+++ b/packages/sanity/src/core/scheduled-publishing/hooks/useScheduleApi.ts
@@ -29,7 +29,7 @@ function createScheduleApi(client: SanityClient) {
         name: roundedDate,
       },
       method: 'POST',
-      uri: `/schedules/${projectId}/${dataset}`,
+      url: `/schedules/${projectId}/${dataset}`,
     })
   }
 
@@ -37,7 +37,7 @@ function createScheduleApi(client: SanityClient) {
     debug('_delete:', scheduleId)
     return client.request<void>({
       method: 'DELETE',
-      uri: `/schedules/${projectId}/${dataset}/${scheduleId}`,
+      url: `/schedules/${projectId}/${dataset}/${scheduleId}`,
     })
   }
 
@@ -52,7 +52,7 @@ function createScheduleApi(client: SanityClient) {
 
     return client.request<{transactionId: string}>({
       method: 'POST',
-      uri: `/schedules/${projectId}/${dataset}/${scheduleId}/publish`,
+      url: `/schedules/${projectId}/${dataset}/${scheduleId}/publish`,
     })
   }
 
@@ -67,7 +67,7 @@ function createScheduleApi(client: SanityClient) {
     return client.request<{transactionId: string}>({
       body: documentSchedule,
       method: 'PATCH',
-      uri: `/schedules/${projectId}/${dataset}/${scheduleId}`,
+      url: `/schedules/${projectId}/${dataset}/${scheduleId}`,
     })
   }
 

--- a/packages/sanity/src/core/scheduledPublishing/tool/contexts/useHasUsedScheduledPublishing.ts
+++ b/packages/sanity/src/core/scheduledPublishing/tool/contexts/useHasUsedScheduledPublishing.ts
@@ -24,7 +24,7 @@ function fetchUsedScheduledPublishing(
 ): Observable<HasUsedScheduledPublishing> {
   const {dataset, projectId} = client.config()
   return client.observable
-    .request({uri: `/schedules/${projectId}/${dataset}?limit=1`, tag: 'scheduled-publishing-used'})
+    .request({url: `/schedules/${projectId}/${dataset}?limit=1`, tag: 'scheduled-publishing-used'})
     .pipe(
       map((res) => {
         return {used: res.schedules?.length > 0, loading: false}

--- a/packages/sanity/src/core/store/authStore/__tests__/createAuthStore.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/createAuthStore.test.ts
@@ -1,6 +1,7 @@
 import {
   type ClientConfig as SanityClientConfig,
   ClientError,
+  type RequestHandler,
   type SanityClient,
 } from '@sanity/client'
 import {type CurrentUser} from '@sanity/types'
@@ -36,6 +37,7 @@ const MOCK_USER: CurrentUser = {
 const PROJECT_ID = 'test-project'
 const DATASET = 'test-dataset'
 const TOKEN_STORAGE_KEY = `__studio_auth_token_${PROJECT_ID}`
+const parkingRequestHandler: RequestHandler = () => new Promise(() => {})
 
 /**
  * Create a 401 error that matches what the sanity client throws — a real
@@ -47,7 +49,10 @@ function create401Error(): ClientError {
   return new ClientError({
     statusCode: 401,
     headers: {},
-    body: {error: 'Unauthorized', statusCode: 401},
+    body: {error: 'Unauthorized', errorCode: 'SIO-401-ANF', statusCode: 401},
+    method: 'GET',
+    statusMessage: 'Unauthorized',
+    url: `https://${PROJECT_ID}.api.sanity.io/v1/users/me`,
   })
 }
 
@@ -61,14 +66,14 @@ function createMockClientFactory(): MockClientFactoryResult {
 
   const factory = (_options: SanityClientConfig): SanityClient => {
     const client = {
-      request: vi.fn(({uri, method}: {uri: string; method?: string}) => {
-        if (uri === '/users/me') {
+      request: vi.fn(({url, method}: {url: string; method?: string}) => {
+        if (url === '/users/me') {
           if (authenticated) {
             return Promise.resolve(MOCK_USER)
           }
           return Promise.reject(create401Error())
         }
-        if (uri === '/auth/id') {
+        if (url === '/auth/id') {
           if (authenticated) {
             return Promise.resolve({
               id: 'mock-auth-id',
@@ -77,10 +82,10 @@ function createMockClientFactory(): MockClientFactoryResult {
           }
           return Promise.reject(create401Error())
         }
-        if (uri === '/auth/fetch') {
+        if (url === '/auth/fetch') {
           return Promise.resolve({token: 'mock-exchanged-token'})
         }
-        if (uri === '/auth/logout' && method === 'POST') {
+        if (url === '/auth/logout' && method === 'POST') {
           return Promise.resolve({ok: true})
         }
         return Promise.resolve({})
@@ -118,17 +123,17 @@ function createCredentialAwareClientFactory(opts: {
       options.token === opts.token || (options.withCredentials === true && opts.cookieValid)
 
     return {
-      request: vi.fn(({uri}: {uri: string}) => {
-        if (uri === '/auth/fetch') return Promise.resolve({token: opts.token})
-        if (uri === '/auth/logout') return Promise.resolve({ok: true})
+      request: vi.fn(({url}: {url: string}) => {
+        if (url === '/auth/fetch') return Promise.resolve({token: opts.token})
+        if (url === '/auth/logout') return Promise.resolve({ok: true})
 
-        if (uri === '/auth/id') {
+        if (url === '/auth/id') {
           return authed()
             ? Promise.resolve({id: 'mock-auth-id', expiry: Math.floor(Date.now() / 1000) + 3600})
             : Promise.reject(create401Error())
         }
 
-        if (uri === '/users/me') {
+        if (url === '/users/me') {
           return authed() ? Promise.resolve(MOCK_USER) : Promise.reject(create401Error())
         }
 
@@ -733,12 +738,12 @@ describe('createAuthStore: cross-tab sync', () => {
       let usersMeProbes = 0
       const factory = (_options: SanityClientConfig): SanityClient =>
         ({
-          request: vi.fn(({uri}: {uri: string}) => {
-            if (uri === '/users/me') {
+          request: vi.fn(({url}: {url: string}) => {
+            if (url === '/users/me') {
               usersMeProbes += 1
               return Promise.resolve(MOCK_USER)
             }
-            if (uri === '/auth/id') {
+            if (url === '/auth/id') {
               return Promise.resolve({id: 'x', expiry: Math.floor(Date.now() / 1000) + 3600})
             }
             return Promise.resolve({})
@@ -764,34 +769,34 @@ describe('createAuthStore: cross-tab sync', () => {
     it('transitions to unauthenticated on logout despite the forced-logout middleware parking 401s', async () => {
       // Regression: after a mid-session 401 forces a logout, the dual-mode
       // re-check probes /users/me again. In the studio that probe rides a
-      // client carrying the forced-logout middleware (`_requestHandler`), which
+      // client carrying the forced-logout request handler, which
       // claims the 401 and parks it forever — so the probe never settles,
       // `getCurrentUser`'s own 401-catch never runs, authState$ never emits
       // `authenticated: false`, and the studio freezes instead of showing the
       // login screen.
       //
-      // The fix probes with `withConfig({_requestHandler: undefined})`, so the
-      // 401 reaches getCurrentUser's catch. We model the middleware faithfully:
-      // a client built WITH `_requestHandler` parks its /users/me 401 (hangs);
+      // The fix probes with `withConfig({requestHandler: undefined})`, so the
+      // 401 reaches getCurrentUser's catch. We model the handler faithfully:
+      // a client built with `requestHandler` parks its /users/me 401 (hangs);
       // stripping it via withConfig makes the same 401 reject normally.
       let sessionValid = true
 
       const makeClient = (options: SanityClientConfig): SanityClient => {
-        const middlewareActive = Boolean((options as {_requestHandler?: unknown})._requestHandler)
+        const requestHandlerActive = Boolean(options.requestHandler)
         const client = {
           config: () => options,
           // Mirrors @sanity/client: withConfig merges config and returns a new
-          // client. The fix calls this with `_requestHandler: undefined`.
+          // client. The fix calls this with `requestHandler: undefined`.
           withConfig: (next: SanityClientConfig) => makeClient({...options, ...next}),
-          request: vi.fn(({uri, method}: {uri: string; method?: string}) => {
-            if (uri === '/auth/logout' && method === 'POST') return Promise.resolve({ok: true})
-            if (uri === '/users/me') {
+          request: vi.fn(({url, method}: {url: string; method?: string}) => {
+            if (url === '/auth/logout' && method === 'POST') return Promise.resolve({ok: true})
+            if (url === '/users/me') {
               if (sessionValid) return Promise.resolve(MOCK_USER)
               // A 401 on a middleware-bearing client is parked forever; on a
               // stripped client it rejects normally (the real behavior).
-              return middlewareActive ? new Promise(() => {}) : Promise.reject(create401Error())
+              return requestHandlerActive ? new Promise(() => {}) : Promise.reject(create401Error())
             }
-            if (uri === '/auth/id') {
+            if (url === '/auth/id') {
               return sessionValid
                 ? Promise.resolve({id: 'x', expiry: Math.floor(Date.now() / 1000) + 3600})
                 : Promise.reject(create401Error())
@@ -802,11 +807,10 @@ describe('createAuthStore: cross-tab sync', () => {
         return client as unknown as SanityClient
       }
 
-      // prepareConfig installs `_requestHandler` on every studio client; emulate
+      // prepareConfig installs `requestHandler` on every studio client; emulate
       // that so the probe client carries the parking middleware by default.
       const factory = (options: SanityClientConfig): SanityClient =>
-        // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-        makeClient({...options, _requestHandler: (() => {}) as never})
+        makeClient({...options, requestHandler: parkingRequestHandler})
 
       const store = _createAuthStore({
         projectId: PROJECT_ID,
@@ -836,7 +840,7 @@ describe('createAuthStore: cross-tab sync', () => {
     it('transitions to unauthenticated when /auth/logout itself 401s on a middleware-bearing client', async () => {
       // Regression: a forced logout reacting to a mid-session 401 POSTs
       // /auth/logout to invalidate the (already-gone) session. In the studio
-      // those clients carry the forced-logout middleware (`_requestHandler`),
+      // those clients carry the forced-logout request handler,
       // which parks any 401 forever. If the logout endpoint answers 401 (the
       // session is already gone), the parked request never settles,
       // `Promise.allSettled` never resolves, and the local teardown that
@@ -844,7 +848,7 @@ describe('createAuthStore: cross-tab sync', () => {
       // freezes instead of landing on the login screen.
       //
       // The fix strips the middleware from the logout clients via
-      // `withConfig({_requestHandler: undefined})`, so the 401 rejects normally
+      // `withConfig({requestHandler: undefined})`, so the 401 rejects normally
       // and teardown proceeds. We model the middleware faithfully: /auth/logout
       // 401s, parked on a middleware-bearing client, rejecting on a stripped
       // one.
@@ -853,23 +857,23 @@ describe('createAuthStore: cross-tab sync', () => {
       let sessionValid = true
 
       const makeClient = (options: SanityClientConfig): SanityClient => {
-        const middlewareActive = Boolean((options as {_requestHandler?: unknown})._requestHandler)
+        const requestHandlerActive = Boolean(options.requestHandler)
         const client = {
           config: () => options,
           withConfig: (next: SanityClientConfig) => makeClient({...options, ...next}),
-          request: vi.fn(({uri, method}: {uri: string; method?: string}) => {
-            if (uri === '/auth/logout' && method === 'POST') {
+          request: vi.fn(({url, method}: {url: string; method?: string}) => {
+            if (url === '/auth/logout' && method === 'POST') {
               // Session already gone: the logout endpoint 401s. Parked forever
               // on a middleware-bearing client; rejects on a stripped one.
-              return middlewareActive ? new Promise(() => {}) : Promise.reject(create401Error())
+              return requestHandlerActive ? new Promise(() => {}) : Promise.reject(create401Error())
             }
-            if (uri === '/users/me') {
+            if (url === '/users/me') {
               if (sessionValid) return Promise.resolve(MOCK_USER)
               // A 401 on a middleware-bearing client is parked forever; on a
               // stripped (probe) client it rejects normally.
-              return middlewareActive ? new Promise(() => {}) : Promise.reject(create401Error())
+              return requestHandlerActive ? new Promise(() => {}) : Promise.reject(create401Error())
             }
-            if (uri === '/auth/id') {
+            if (url === '/auth/id') {
               return sessionValid
                 ? Promise.resolve({id: 'x', expiry: Math.floor(Date.now() / 1000) + 3600})
                 : Promise.reject(create401Error())
@@ -880,11 +884,10 @@ describe('createAuthStore: cross-tab sync', () => {
         return client as unknown as SanityClient
       }
 
-      // prepareConfig installs `_requestHandler` on every studio client; emulate
+      // prepareConfig installs `requestHandler` on every studio client; emulate
       // that so the logout clients carry the parking middleware by default.
       const factory = (options: SanityClientConfig): SanityClient =>
-        // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-        makeClient({...options, _requestHandler: (() => {}) as never})
+        makeClient({...options, requestHandler: parkingRequestHandler})
 
       const store = _createAuthStore({
         projectId: PROJECT_ID,
@@ -914,12 +917,12 @@ describe('createAuthStore: cross-tab sync', () => {
       // Regression: on login-after-logout, `handleCallbackUrl` exchanges the sid
       // for a token, then `probeCurrentUser` checks /auth/id to see whether the
       // cookie was established. In the studio that probe rides a client carrying
-      // the forced-logout middleware (`_requestHandler`); when the cookie is NOT
+      // the forced-logout request handler; when the cookie is NOT
       // established, /auth/id 401s, the middleware parks it forever, and
       // `processCallback` (which awaits the probe) never resolves — the login
       // callback hangs and the navbar never appears (the auth e2e failure).
       //
-      // The fix probes with `withConfig({_requestHandler: undefined})` so the
+      // The fix probes with `withConfig({requestHandler: undefined})` so the
       // 401 reaches probeCurrentUser's own catch and the flow falls back to
       // token auth. We model the middleware faithfully: /auth/id 401s (cookie
       // not established), parked on a middleware-bearing client, rejecting on a
@@ -927,21 +930,21 @@ describe('createAuthStore: cross-tab sync', () => {
       const TOKEN = 'valid-exchanged-token'
 
       const makeClient = (options: SanityClientConfig): SanityClient => {
-        const middlewareActive = Boolean((options as {_requestHandler?: unknown})._requestHandler)
-        const usesToken = (options as {token?: string}).token === TOKEN
+        const requestHandlerActive = Boolean(options.requestHandler)
+        const usesToken = options.token === TOKEN
         const client = {
           config: () => options,
           withConfig: (next: SanityClientConfig) => makeClient({...options, ...next}),
-          request: vi.fn(({uri, method}: {uri: string; method?: string}) => {
-            if (uri === '/auth/fetch') return Promise.resolve({token: TOKEN})
-            if (uri === '/auth/logout' && method === 'POST') return Promise.resolve({ok: true})
+          request: vi.fn(({url, method}: {url: string; method?: string}) => {
+            if (url === '/auth/fetch') return Promise.resolve({token: TOKEN})
+            if (url === '/auth/logout' && method === 'POST') return Promise.resolve({ok: true})
             // The cookie is never established, so /auth/id 401s. Parked forever
             // on a middleware-bearing client; rejects on a stripped one.
-            if (uri === '/auth/id') {
-              return middlewareActive ? new Promise(() => {}) : Promise.reject(create401Error())
+            if (url === '/auth/id') {
+              return requestHandlerActive ? new Promise(() => {}) : Promise.reject(create401Error())
             }
             // /users/me authenticates only via the exchanged token.
-            if (uri === '/users/me') {
+            if (url === '/users/me') {
               return usesToken ? Promise.resolve(MOCK_USER) : Promise.reject(create401Error())
             }
             return Promise.resolve({})
@@ -950,10 +953,9 @@ describe('createAuthStore: cross-tab sync', () => {
         return client as unknown as SanityClient
       }
 
-      // prepareConfig installs `_requestHandler` on every studio client.
+      // prepareConfig installs `requestHandler` on every studio client.
       const factory = (options: SanityClientConfig): SanityClient =>
-        // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-        makeClient({...options, _requestHandler: (() => {}) as never})
+        makeClient({...options, requestHandler: parkingRequestHandler})
 
       let sessionIdConsumed = false
       const getSessionId = () => {
@@ -988,8 +990,8 @@ describe('createAuthStore: cross-tab sync', () => {
       // reported, and the probe resolves as logged-out (no thrown boot error).
       const factory = (_options: SanityClientConfig): SanityClient =>
         ({
-          request: vi.fn(({uri}: {uri: string}) => {
-            if (uri === '/users/me') {
+          request: vi.fn(({url}: {url: string}) => {
+            if (url === '/users/me') {
               return Promise.reject(
                 Object.assign(new Error('Failed to fetch'), {isNetworkError: true}),
               )
@@ -1140,11 +1142,11 @@ describe('createAuthStore: handleCallbackUrl settle contract', () => {
   it('resolves promptly with success: false when the exchange fails, without waiting for state', async () => {
     const factory = (_options: SanityClientConfig): SanityClient =>
       ({
-        request: vi.fn(({uri}: {uri: string}) => {
-          if (uri === '/auth/fetch') {
+        request: vi.fn(({url}: {url: string}) => {
+          if (url === '/auth/fetch') {
             return Promise.reject(new Error('sid expired'))
           }
-          if (uri === '/users/me') return Promise.reject(create401Error())
+          if (url === '/users/me') return Promise.reject(create401Error())
           return Promise.resolve({})
         }),
       }) as unknown as SanityClient
@@ -1173,9 +1175,9 @@ describe('createAuthStore: handleCallbackUrl settle contract', () => {
     try {
       const factory = (_options: SanityClientConfig): SanityClient =>
         ({
-          request: vi.fn(({uri}: {uri: string}) => {
-            if (uri === '/auth/fetch') return Promise.resolve({token: 'exchanged-token'})
-            if (uri === '/auth/id') {
+          request: vi.fn(({url}: {url: string}) => {
+            if (url === '/auth/fetch') return Promise.resolve({token: 'exchanged-token'})
+            if (url === '/auth/id') {
               return Promise.resolve({id: 'x', expiry: Math.floor(Date.now() / 1000) + 3600})
             }
             // /users/me hangs: authState$ never emits a post-exchange state.
@@ -1212,15 +1214,15 @@ describe('createAuthStore: handleCallbackUrl settle contract', () => {
     const TOKEN = 'valid-exchanged-token'
     const factory = (options: SanityClientConfig): SanityClient =>
       ({
-        request: vi.fn(({uri}: {uri: string}) => {
-          if (uri === '/auth/fetch') {
+        request: vi.fn(({url}: {url: string}) => {
+          if (url === '/auth/fetch') {
             exchangeCount += 1
             return Promise.resolve({token: TOKEN})
           }
-          if (uri === '/auth/id') {
+          if (url === '/auth/id') {
             return Promise.resolve({id: 'x', expiry: Math.floor(Date.now() / 1000) + 3600})
           }
-          if (uri === '/users/me') {
+          if (url === '/users/me') {
             return options.token === TOKEN
               ? Promise.resolve(MOCK_USER)
               : Promise.reject(create401Error())
@@ -1282,10 +1284,10 @@ describe('createAuthStore: handleCallbackUrl settle contract', () => {
     const TOKEN = 'valid-exchanged-token'
     const factory = (options: SanityClientConfig): SanityClient =>
       ({
-        request: vi.fn(({uri}: {uri: string}) => {
-          if (uri === '/auth/fetch') return Promise.resolve({token: TOKEN})
-          if (uri === '/auth/id') return Promise.reject(new Error('transient server error'))
-          if (uri === '/users/me') {
+        request: vi.fn(({url}: {url: string}) => {
+          if (url === '/auth/fetch') return Promise.resolve({token: TOKEN})
+          if (url === '/auth/id') return Promise.reject(new Error('transient server error'))
+          if (url === '/users/me') {
             return options.token === TOKEN
               ? Promise.resolve(MOCK_USER)
               : Promise.reject(create401Error())
@@ -1317,10 +1319,10 @@ describe('createAuthStore: handleCallbackUrl settle contract', () => {
     // times out if that wait regresses.
     const factory = (_options: SanityClientConfig): SanityClient =>
       ({
-        request: vi.fn(({uri}: {uri: string}) => {
-          if (uri === '/auth/fetch') return Promise.resolve({token: ''})
-          if (uri === '/auth/id') return Promise.reject(create401Error())
-          if (uri === '/users/me') return Promise.reject(create401Error())
+        request: vi.fn(({url}: {url: string}) => {
+          if (url === '/auth/fetch') return Promise.resolve({token: ''})
+          if (url === '/auth/id') return Promise.reject(create401Error())
+          if (url === '/users/me') return Promise.reject(create401Error())
           return Promise.resolve({})
         }),
       }) as unknown as SanityClient
@@ -1349,9 +1351,9 @@ describe('createAuthStore: handleCallbackUrl settle contract', () => {
     let probesWithToken = 0
     const factory = (options: SanityClientConfig): SanityClient =>
       ({
-        request: vi.fn(({uri}: {uri: string}) => {
-          if (uri === '/auth/fetch') return Promise.resolve({token: TOKEN})
-          if (uri === '/users/me') {
+        request: vi.fn(({url}: {url: string}) => {
+          if (url === '/auth/fetch') return Promise.resolve({token: TOKEN})
+          if (url === '/users/me') {
             if (options.token === TOKEN) {
               probesWithToken += 1
               return Promise.resolve(MOCK_USER)
@@ -1424,16 +1426,16 @@ describe('createAuthStore: handleCallbackUrl settle contract', () => {
     let usersMeCalls = 0
     const factory = (_options: SanityClientConfig): SanityClient =>
       ({
-        request: vi.fn(({uri}: {uri: string}) => {
-          if (uri === '/auth/fetch') {
+        request: vi.fn(({url}: {url: string}) => {
+          if (url === '/auth/fetch') {
             return Promise.resolve({token: 'token-unused-in-cookie-mode'})
           }
-          if (uri === '/auth/id') {
+          if (url === '/auth/id') {
             return cookieValid
               ? Promise.resolve({id: 'mock-auth-id', expiry: Math.floor(Date.now() / 1000) + 3600})
               : Promise.reject(create401Error())
           }
-          if (uri === '/users/me') {
+          if (url === '/users/me') {
             usersMeCalls += 1
             // The first call is the initial probe: held pending until the
             // test releases it, after the callback has settled the channel.
@@ -1487,15 +1489,15 @@ describe('createAuthStore: handleCallbackUrl settle contract', () => {
     let currentUser: CurrentUser = MOCK_USER
     const factory = (_options: SanityClientConfig): SanityClient =>
       ({
-        request: vi.fn(({uri}: {uri: string}) => {
-          if (uri === '/auth/fetch') return Promise.resolve({token: 'exchanged-token'})
-          if (uri === '/auth/id') {
+        request: vi.fn(({url}: {url: string}) => {
+          if (url === '/auth/fetch') return Promise.resolve({token: 'exchanged-token'})
+          if (url === '/auth/id') {
             return Promise.resolve({
               id: 'mock-auth-id',
               expiry: Math.floor(Date.now() / 1000) + 3600,
             })
           }
-          if (uri === '/users/me') return Promise.resolve(currentUser)
+          if (url === '/users/me') return Promise.resolve(currentUser)
           return Promise.resolve({})
         }),
       }) as unknown as SanityClient
@@ -1544,15 +1546,15 @@ describe('createAuthStore: handleCallbackUrl settle contract', () => {
     let currentUser: CurrentUser = MOCK_USER
     const factory = (_options: SanityClientConfig): SanityClient =>
       ({
-        request: vi.fn(({uri}: {uri: string}) => {
-          if (uri === '/auth/fetch') return Promise.resolve({token: 'exchanged-token'})
-          if (uri === '/auth/id') {
+        request: vi.fn(({url}: {url: string}) => {
+          if (url === '/auth/fetch') return Promise.resolve({token: 'exchanged-token'})
+          if (url === '/auth/id') {
             return Promise.resolve({
               id: 'mock-auth-id',
               expiry: Math.floor(Date.now() / 1000) + 3600,
             })
           }
-          if (uri === '/users/me') return Promise.resolve(currentUser)
+          if (url === '/users/me') return Promise.resolve(currentUser)
           return Promise.resolve({})
         }),
       }) as unknown as SanityClient

--- a/packages/sanity/src/core/store/authStore/__tests__/probeWorkspaceAuth.test.ts
+++ b/packages/sanity/src/core/store/authStore/__tests__/probeWorkspaceAuth.test.ts
@@ -40,8 +40,8 @@ function createMockFactory({
   const factory = (config: SanityClientConfig): SanityClient => {
     configs.push(config)
     return {
-      request: vi.fn(({uri}: {uri: string}) => {
-        if (uri === '/auth/id') {
+      request: vi.fn(({url}: {url: string}) => {
+        if (url === '/auth/id') {
           calls++
           if (authIdImpl) return authIdImpl(config)
           if (authenticated) {

--- a/packages/sanity/src/core/store/authStore/createAuthStore.ts
+++ b/packages/sanity/src/core/store/authStore/createAuthStore.ts
@@ -149,6 +149,12 @@ export interface RequestFailureDiagnostics {
   ) => void
 }
 
+function withoutRequestHandler(client: SanityClient): SanityClient {
+  return typeof client.withConfig === 'function'
+    ? client.withConfig({requestHandler: undefined})
+    : client
+}
+
 const getCurrentUser = async (
   client: SanityClient,
   tag: string,
@@ -165,15 +171,11 @@ const getCurrentUser = async (
   //
   // Guarded for custom `unstable_clientFactory` clients that may not implement
   // `withConfig` — those don't carry the middleware anyway.
-  const probeClient =
-    typeof client.withConfig === 'function'
-      ? // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-        client.withConfig({_requestHandler: undefined})
-      : client
+  const probeClient = withoutRequestHandler(client)
   const fetchUser = () =>
     probeClient
       .request({
-        uri: '/users/me',
+        url: '/users/me',
         tag: `users.get-current${tag ? `.${tag}` : ''}`,
       })
       .catch(async (err) => {
@@ -239,22 +241,18 @@ const getCurrentUser = async (
  * Probe whether a given auth method works by calling /auth/id.
  */
 const probeCurrentUser = (client: SanityClient): Promise<AuthProbeResult> => {
-  // Strip the studio's request handler: it parks any 401 (returns a
-  // never-settling observable) so the studio can show the login screen. But
+  // Strip the studio's request handler: it parks any invalid-session 401 so
+  // the studio can show the login screen. But
   // this probe IS an auth-state check and handles its own 401 below — if the
   // middleware parked it, the probe would never settle, and the post-login
   // callback (`processCallback`) that awaits it would hang, leaving the studio
   // stuck instead of transitioning to authenticated. The 401 must reach the
   // `.catch` here. Guarded for custom clients that may not implement
   // `withConfig` (those don't carry the middleware anyway).
-  const probeClient =
-    typeof client.withConfig === 'function'
-      ? // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-        client.withConfig({_requestHandler: undefined})
-      : client
+  const probeClient = withoutRequestHandler(client)
   return probeClient
     .request<{id: string; expiry: number}>({
-      uri: '/auth/id',
+      url: '/auth/id',
       tag: 'auth.check-id',
     })
     .then(
@@ -286,7 +284,7 @@ const probeCurrentUser = (client: SanityClient): Promise<AuthProbeResult> => {
 async function exchangeSessionForToken(client: SanityClient, sessionId: string): Promise<string> {
   const {token} = await client.request<{token: string}>({
     method: 'GET',
-    uri: `/auth/fetch`,
+    url: `/auth/fetch`,
     query: {sid: sessionId},
     tag: 'auth.fetch-token',
   })
@@ -961,8 +959,8 @@ export function _createAuthStore({
     // to this request succeeding would leave the studio frozen on a failed
     // logout instead of landing on the login screen.
     //
-    // The parking middleware must be stripped: it catches any 401 and returns
-    // a never-settling observable, so a forced logout reacting to a 401 (the
+    // The parking request handler must be stripped: it catches an
+    // invalid-session 401, so a forced logout reacting to a 401 (the
     // session is already gone) would hit an `/auth/logout` that also 401s, and
     // `Promise.allSettled` would never resolve — the exact freeze this branch
     // fixes for the `/users/me` probe. Guarded for custom clients that may not
@@ -970,12 +968,9 @@ export function _createAuthStore({
     //
     // Both clients are hit: even with loginMethod=token an auth cookie may
     // be set on the project api domain, so both must be destroyed.
-    const stripMiddleware = (c: SanityClient) =>
-      // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-      typeof c.withConfig === 'function' ? c.withConfig({_requestHandler: undefined}) : c
     await Promise.allSettled([
-      stripMiddleware(tokenClient).request({uri: '/auth/logout', method: 'POST'}),
-      stripMiddleware(cookieClient).request({uri: '/auth/logout', method: 'POST'}),
+      withoutRequestHandler(tokenClient).request({url: '/auth/logout', method: 'POST'}),
+      withoutRequestHandler(cookieClient).request({url: '/auth/logout', method: 'POST'}),
     ])
 
     // Clear local auth state regardless of the server call's outcome. This

--- a/packages/sanity/src/core/store/authStore/createLoginComponent.tsx
+++ b/packages/sanity/src/core/store/authStore/createLoginComponent.tsx
@@ -39,7 +39,7 @@ export async function getProviders({
   // sidesteps that — anonymous callers get the public provider list.
   const credentiallessClient = client.withConfig({token: undefined, withCredentials: false})
   const {providers} = await credentiallessClient.request<AuthProviderResponse>({
-    uri: '/auth/providers',
+    url: '/auth/providers',
   })
 
   return customProviders

--- a/packages/sanity/src/core/store/authStore/probeWorkspaceAuth.ts
+++ b/packages/sanity/src/core/store/authStore/probeWorkspaceAuth.ts
@@ -60,7 +60,7 @@ function resolveApiHost(apiHost?: string): string | undefined {
 async function callAuthId(client: SanityClient): Promise<WorkspaceAuthProbeResult> {
   try {
     const response = await client.request<{id?: string}>({
-      uri: '/auth/id',
+      url: '/auth/id',
       tag: 'auth.probe',
     })
     return typeof response?.id === 'string' ? AUTHENTICATED : UNAUTHENTICATED

--- a/packages/sanity/src/core/store/grants/__tests__/createGrantsStore.test.ts
+++ b/packages/sanity/src/core/store/grants/__tests__/createGrantsStore.test.ts
@@ -21,8 +21,8 @@ function createMockClient(data: {requests?: Record<string, any>} = {}): SanityCl
   const mockClient = {
     config: () => mockConfig,
     withConfig: () => mockClient,
-    request: vi.fn((opts: {uri: string; tag?: string; withCredentials?: boolean}) => {
-      const path = opts.uri.slice(requestUriPrefix.length)
+    request: vi.fn((opts: {url: string; tag?: string; withCredentials?: boolean}) => {
+      const path = opts.url.slice(requestUriPrefix.length)
 
       if (data?.requests?.[path]) {
         return Promise.resolve(data?.requests?.[path])
@@ -65,7 +65,7 @@ describe('checkDocumentPermission', () => {
       [
         {
           tag: 'acl.get',
-          uri: '/projects/mock-project-id/datasets/mock-data-set/acl',
+          url: '/projects/mock-project-id/datasets/mock-data-set/acl',
         },
       ],
     ])

--- a/packages/sanity/src/core/store/grants/grantsStore.ts
+++ b/packages/sanity/src/core/store/grants/grantsStore.ts
@@ -25,7 +25,7 @@ async function getDatasetGrants(
   // `acl` stands for access control list and returns a list of grants
   const fetchGrants = () =>
     client.request<Grant[]>({
-      uri: `/projects/${projectId}/datasets/${dataset}/acl`,
+      url: `/projects/${projectId}/datasets/${dataset}/acl`,
       tag: 'acl.get',
     })
 

--- a/packages/sanity/src/core/store/key-value/storage/serverStorage.ts
+++ b/packages/sanity/src/core/store/key-value/storage/serverStorage.ts
@@ -25,7 +25,7 @@ export function createServerStorage({client: _client}: ServerStorageOptions): Se
   const keyValueLoader = new DataLoader<string, KeyValueStoreValue | null>(async (keys) => {
     const value = await client
       .request<KeyValuePair[]>({
-        uri: `/users/me/keyvalue/${keys.join(',')}`,
+        url: `/users/me/keyvalue/${keys.join(',')}`,
       })
       .catch((error) => {
         console.error('Error fetching data:', error)
@@ -54,7 +54,7 @@ export function createServerStorage({client: _client}: ServerStorageOptions): Se
     return client
       .request<KeyValuePair[]>({
         method: 'PUT',
-        uri: `/users/me/keyvalue`,
+        url: `/users/me/keyvalue`,
         body: [{key, value: nextValue}],
       })
       .then(

--- a/packages/sanity/src/core/store/project/useProject.test.tsx
+++ b/packages/sanity/src/core/store/project/useProject.test.tsx
@@ -66,7 +66,16 @@ describe('useProject', () => {
     const get = vi
       .fn<ProjectStore['get']>()
       .mockReturnValueOnce(
-        throwError(() => new ClientError({statusCode: 429, headers: {}, body: {}} as never)),
+        throwError(
+          () =>
+            new ClientError({
+              statusCode: 429,
+              headers: {},
+              body: {},
+              url: 'https://abc123.api.sanity.io/v1/projects/abc123',
+              method: 'GET',
+            } as never),
+        ),
       )
       .mockReturnValueOnce(of(projectData))
     const {result} = setup(get, channel)

--- a/packages/sanity/src/core/store/user/__tests__/userStore.test.ts
+++ b/packages/sanity/src/core/store/user/__tests__/userStore.test.ts
@@ -26,8 +26,8 @@ const failingClient = {
 // Mock client which always throws 403 Forbidden errors on `request`
 const getClient = () => {
   const client = {
-    request: vi.fn((options: {uri: string}) => {
-      const userIds = options.uri.slice(options.uri.lastIndexOf('/') + 1).split(',')
+    request: vi.fn((options: {url: string}) => {
+      const userIds = options.url.slice(options.url.lastIndexOf('/') + 1).split(',')
       return Promise.resolve(
         userIds
           // Skip IDs that do not start with a `p`, to allow us to test the case where some users are not returned
@@ -113,7 +113,7 @@ describe('userStore', () => {
       await expect(getUserStore({client}).getUsers(userIds)).resolves.toHaveLength(userIds.length)
       expect(client.request).toHaveBeenCalledTimes(4) // Math.ceil(1500 / 400) = 4, eg 4 batches
       expect(client.request).toHaveBeenLastCalledWith({
-        uri: `/users/${lastBatch.join(',')}`,
+        url: `/users/${lastBatch.join(',')}`,
         tag: 'users.get',
       })
     })

--- a/packages/sanity/src/core/store/user/userStore.ts
+++ b/packages/sanity/src/core/store/user/userStore.ts
@@ -39,7 +39,7 @@ export function createUserStore({client: _client, currentUser}: UserStoreOptions
   const userLoader = new DataLoader<string, User | null>(
     async (userIds) => {
       const value = await client.request<(User | null)[]>({
-        uri: `/users/${userIds.join(',')}`,
+        url: `/users/${userIds.join(',')}`,
         tag: 'users.get',
       })
       const response = Array.isArray(value) ? value : [value]

--- a/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx
+++ b/packages/sanity/src/core/studio/addonDataset/AddonDatasetProvider.tsx
@@ -22,7 +22,7 @@ function AddonDatasetProviderInner(props: AddonDatasetSetupProviderProps) {
 
   const getAddonDatasetName = useCallback(async (): Promise<string | undefined> => {
     const res = await originalClient.request({
-      uri: `/projects/${projectId}/datasets?datasetProfile=comments&addonFor=${dataset}`,
+      url: `/projects/${projectId}/datasets?datasetProfile=comments&addonFor=${dataset}`,
       tag: 'sanity.studio',
     })
 
@@ -71,7 +71,7 @@ function AddonDatasetProviderInner(props: AddonDatasetSetupProviderProps) {
     const run = async () => {
       // 1. Create the addon dataset
       const res = await originalClient.request({
-        uri: `/comments/${dataset}/setup`,
+        url: `/comments/${dataset}/setup`,
         method: 'POST',
       })
 

--- a/packages/sanity/src/core/studio/components/navbar/resources/helper-functions/helpResources.ts
+++ b/packages/sanity/src/core/studio/components/navbar/resources/helper-functions/helpResources.ts
@@ -21,6 +21,5 @@ export function getHelpResources(
       */
     query: {m: [`sanity@${SANITY_VERSION}`], locale},
     tag: 'module.version-check',
-    json: true,
   })
 }

--- a/packages/sanity/src/core/studio/components/navbar/search/hooks/useSearchMaxFieldDepth.ts
+++ b/packages/sanity/src/core/studio/components/navbar/search/hooks/useSearchMaxFieldDepth.ts
@@ -43,7 +43,7 @@ const INITIAL_LOADING_STATE: Settings = {
 function fetchMaxDepth({client}: {client: SanityClient}): Observable<PartialIndexSettings> {
   const {projectId, dataset} = client.config()
   return client.observable.request<PartialIndexSettings>({
-    uri: `/projects/${projectId}/datasets/${dataset}/settings/indexing`,
+    url: `/projects/${projectId}/datasets/${dataset}/settings/indexing`,
     tag: 'search.getPartialIndexSettings',
   })
 }

--- a/packages/sanity/src/core/studio/manifest/__tests__/registerLiveStudioManifest.test.tsx
+++ b/packages/sanity/src/core/studio/manifest/__tests__/registerLiveStudioManifest.test.tsx
@@ -133,7 +133,7 @@ describe('registerStudioManifest', () => {
 
       expect(mockRequest).toHaveBeenCalledWith({
         method: 'POST',
-        uri: '/projects/app-project/user-applications/app-123/config/live-manifest',
+        url: '/projects/app-project/user-applications/app-123/config/live-manifest',
         body: {
           value: expect.objectContaining({
             workspaces: expect.any(Array),

--- a/packages/sanity/src/core/studio/manifest/__tests__/uploadSchema.test.ts
+++ b/packages/sanity/src/core/studio/manifest/__tests__/uploadSchema.test.ts
@@ -64,7 +64,7 @@ describe('uploadSchema', () => {
     expect(client.request).toHaveBeenCalledTimes(1)
     expect(client.request).toHaveBeenCalledWith(
       expect.objectContaining({
-        uri: '/descriptors/claim',
+        url: '/descriptors/claim',
         method: 'POST',
       }),
     )

--- a/packages/sanity/src/core/studio/manifest/registerLiveStudioManifest.tsx
+++ b/packages/sanity/src/core/studio/manifest/registerLiveStudioManifest.tsx
@@ -102,7 +102,7 @@ export async function registerStudioManifest(
   // Post the live manifest via the global api
   await studioClient.request({
     method: 'POST',
-    uri: `/projects/${projectId}/user-applications/${id}/config/live-manifest`,
+    url: `/projects/${projectId}/user-applications/${id}/config/live-manifest`,
     body: {
       value: liveManifest,
     },

--- a/packages/sanity/src/core/studio/manifest/uploadSchema.ts
+++ b/packages/sanity/src/core/studio/manifest/uploadSchema.ts
@@ -110,7 +110,7 @@ export async function uploadSchema(
     }
 
     const claimResponse = await client.request<ClaimResponse>({
-      uri: '/descriptors/claim',
+      url: '/descriptors/claim',
       method: 'POST',
       body: claimRequest,
       headers: {
@@ -127,7 +127,7 @@ export async function uploadSchema(
       if (syncRequest === null) return descriptorId
 
       syncResult = await client.request<SchemaSynchronizationResult>({
-        uri: '/descriptors/synchronize',
+        url: '/descriptors/synchronize',
         method: 'POST',
         body: syncRequest,
       })

--- a/packages/sanity/src/core/studio/requestErrors/RequestErrorDialog.tsx
+++ b/packages/sanity/src/core/studio/requestErrors/RequestErrorDialog.tsx
@@ -178,7 +178,7 @@ export function RequestErrorDialog(props: {
 }
 
 function RateLimitedDialog(props: {
-  claim: {type: 'rateLimited'; error: Error; retryAfterSeconds?: number; retryable: boolean}
+  claim: Extract<RequestErrorClaim, {type: 'rateLimited'}>
   onRetry: () => void
 }) {
   const {claim, onRetry} = props

--- a/packages/sanity/src/core/studio/requestErrors/__tests__/createStudioRequestHandler.test.ts
+++ b/packages/sanity/src/core/studio/requestErrors/__tests__/createStudioRequestHandler.test.ts
@@ -1,0 +1,90 @@
+import {ClientError, createClient, ServerError} from '@sanity/client'
+import {filter, firstValueFrom, take} from 'rxjs'
+import {describe, expect, it, vi} from 'vitest'
+
+import {createRequestErrorChannel} from '../createRequestErrorChannel'
+import {createStudioRequestHandler} from '../createStudioRequestHandler'
+
+const request = {
+  method: 'GET',
+  url: 'https://abc123.api.sanity.io/v1/data/query/test',
+}
+
+function responseShape(statusCode: number, body: unknown) {
+  return {
+    body,
+    headers: {'content-type': 'application/json'},
+    method: request.method,
+    statusCode,
+    statusMessage: statusCode === 401 ? 'Unauthorized' : 'Service Unavailable',
+    url: request.url,
+  }
+}
+
+describe('createStudioRequestHandler', () => {
+  it('claims a tagged invalid-session error', async () => {
+    const channel = createRequestErrorChannel()
+    const error = new ClientError(responseShape(401, {errorCode: 'SIO-401-ANF'}))
+    const handler = createStudioRequestHandler({channel})
+
+    void handler(request, vi.fn().mockRejectedValue(error))
+
+    await expect(
+      firstValueFrom(
+        channel.claim$.pipe(
+          filter((claim) => claim !== undefined),
+          take(1),
+        ),
+      ),
+    ).resolves.toMatchObject({
+      type: 'unauthorized',
+      projectId: 'abc123',
+    })
+  })
+
+  it('leaves caller-domain errors unchanged', async () => {
+    const channel = createRequestErrorChannel()
+    const error = new ClientError(responseShape(403, {error: 'Forbidden'}))
+    const handler = createStudioRequestHandler({channel})
+
+    await expect(handler(request, vi.fn().mockRejectedValue(error))).rejects.toBe(error)
+    await expect(firstValueFrom(channel.claim$.pipe(take(1)))).resolves.toBeUndefined()
+  })
+
+  it('leaves server errors for callers to delegate explicitly', async () => {
+    const channel = createRequestErrorChannel()
+    const error = new ServerError(responseShape(503, {error: 'Unavailable'}))
+    const handler = createStudioRequestHandler({channel})
+
+    await expect(handler(request, vi.fn().mockRejectedValue(error))).rejects.toBe(error)
+    await expect(firstValueFrom(channel.claim$.pipe(take(1)))).resolves.toBeUndefined()
+  })
+
+  it('retries a request after a diagnosed CORS failure is resolved', async () => {
+    const channel = createRequestErrorChannel()
+    const client = createClient({
+      apiVersion: '2025-02-19',
+      dataset: 'test',
+      projectId: 'abc123',
+      useCdn: false,
+    })
+    const error = new Error('Failed to fetch')
+    const next = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce({result: 'ok'})
+    const waitForCorsRetry = vi.fn().mockResolvedValue(undefined)
+    const diagnostics = {
+      diagnose: vi.fn().mockResolvedValue({type: 'cors', allowed: false, withCredentials: false}),
+      onRequestFailure: vi.fn(),
+    }
+    const handler = createStudioRequestHandler({
+      channel,
+      diagnostics,
+      getClient: () => client,
+      waitForCorsRetry,
+    })
+
+    await expect(handler(request, next)).resolves.toEqual({result: 'ok'})
+    expect(next).toHaveBeenCalledTimes(2)
+    expect(diagnostics.onRequestFailure).toHaveBeenCalledOnce()
+    expect(waitForCorsRetry).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/sanity/src/core/studio/requestErrors/__tests__/diagnoseRequestFailure.test.ts
+++ b/packages/sanity/src/core/studio/requestErrors/__tests__/diagnoseRequestFailure.test.ts
@@ -86,4 +86,32 @@ describe('createRequestFailureProbe', () => {
     expect(await probe(clientError(500, {error: 'boom'}))).toEqual({type: 'unknown'})
     expect(await probe(new Error('nope'))).toEqual({type: 'unknown'})
   })
+
+  it('does not probe /check/cors for timeouts, including leftover get-it v8 codes', async () => {
+    const fetchSpy = vi.fn()
+    globalThis.fetch = fetchSpy as never
+    const probe = createRequestFailureProbe(fakeClient(), makeCache())
+
+    expect(
+      await probe(
+        Object.assign(new Error('The operation was aborted due to timeout'), {
+          name: 'TimeoutError',
+        }),
+      ),
+    ).toEqual({type: 'unknown'})
+    expect(
+      await probe(
+        Object.assign(new Error('Socket timed out on request to https://x.api.sanity.io/…'), {
+          code: 'ESOCKETTIMEDOUT',
+        }),
+      ),
+    ).toEqual({type: 'unknown'})
+    expect(await probe(Object.assign(new Error('connect ETIMEDOUT'), {code: 'ETIMEDOUT'}))).toEqual(
+      {
+        type: 'unknown',
+      },
+    )
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
 })

--- a/packages/sanity/src/core/studio/requestErrors/__tests__/requestErrors.test.ts
+++ b/packages/sanity/src/core/studio/requestErrors/__tests__/requestErrors.test.ts
@@ -109,8 +109,45 @@ describe('classifyRequestError', () => {
     expect(classifyRequestError(serverError())).toMatchObject({type: 'serverError'})
   })
 
+  it('classifies an HTTP error from another client copy by its public shape', () => {
+    const error = {
+      message: 'HTTP 503: Service Unavailable',
+      response: {
+        body: {error: 'Unavailable'},
+        headers: {},
+        method: 'GET',
+        statusCode: 503,
+        statusMessage: 'Service Unavailable',
+        url: 'https://abc123.api.sanity.io/v1/foo',
+      },
+      statusCode: 503,
+    }
+
+    expect(classifyRequestError(error)).toEqual({type: 'serverError', error})
+  })
+
   it('classifies network errors', () => {
     expect(classifyRequestError(networkError())).toMatchObject({type: 'networkError'})
+  })
+
+  it('classifies get-it v9 / platform TimeoutErrors as networkError', () => {
+    const timeout = Object.assign(new Error('The operation was aborted due to timeout'), {
+      name: 'TimeoutError',
+    })
+    expect(classifyRequestError(timeout)).toMatchObject({type: 'networkError'})
+  })
+
+  it('classifies get-it v8 socket timeouts as networkError', () => {
+    const timeout = Object.assign(
+      new Error('Socket timed out on request to https://x.api.sanity.io/…'),
+      {code: 'ESOCKETTIMEDOUT'},
+    )
+    expect(classifyRequestError(timeout)).toMatchObject({type: 'networkError'})
+  })
+
+  it('classifies Node ETIMEDOUT errors as networkError', () => {
+    const timeout = Object.assign(new Error('connect ETIMEDOUT'), {code: 'ETIMEDOUT'})
+    expect(classifyRequestError(timeout)).toMatchObject({type: 'networkError'})
   })
 
   it('leaves arbitrary errors unclassified', () => {
@@ -189,6 +226,23 @@ describe('isInvalidSessionError', () => {
       statusCode: 401,
       body: {error: 'Unauthorized', errorCode: 'SIO-401-ANF', message: 'Session not found'},
     })
+    expect(isInvalidSessionError(err)).toBe(true)
+  })
+
+  it('matches an invalid-session error from another client copy by its public shape', () => {
+    const err = {
+      message: 'Unauthorized',
+      response: {
+        body: {errorCode: 'SIO-401-ANF'},
+        headers: {},
+        method: 'GET',
+        statusCode: 401,
+        statusMessage: 'Unauthorized',
+        url: 'https://abc123.api.sanity.io/v1/users/me',
+      },
+      statusCode: 401,
+    }
+
     expect(isInvalidSessionError(err)).toBe(true)
   })
 

--- a/packages/sanity/src/core/studio/requestErrors/classify.ts
+++ b/packages/sanity/src/core/studio/requestErrors/classify.ts
@@ -1,33 +1,41 @@
-import {ClientError, ServerError} from '@sanity/client'
+import {type HttpError, isHttpError, isTimeoutError} from '@sanity/client'
 import isNativeNetworkError from 'is-network-error'
 
 // These live in `util` so that non-studio code (e.g. the document store) can
 // depend on them without importing from `studio`; re-exported here to keep
 // the public API surface and existing import sites unchanged.
 export {getApiErrorCode, isInvalidSessionError, isUnauthorizedError} from '../../util/apiErrors'
+export {isTimeoutError}
 
-/** @internal */
-export function isTimeoutError(
-  error: unknown,
-): error is Error & {code: 'ESOCKETTIMEDOUT' | 'ETIMEDOUT'} {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    (error.code === 'ESOCKETTIMEDOUT' || error.code === 'ETIMEDOUT')
-  )
+/**
+ * Node / get-it v8 timeout codes. get-it v9 reports timeouts as
+ * `TimeoutError` (caught by {@link isTimeoutError}); older transports used
+ * `ESOCKETTIMEDOUT` (idle socket) or `ETIMEDOUT` (connect/request deadline)
+ * on a plain Error, which `isTimeoutError` no longer matches.
+ */
+const LEGACY_TIMEOUT_CODES = new Set(['ESOCKETTIMEDOUT', 'ETIMEDOUT'])
+
+/**
+ * Timeouts the studio should treat as infrastructure failures and must not
+ * diagnose via `/check/cors` (the probe would just time out too). Covers
+ * get-it v9 / platform `TimeoutError` and leftover get-it v8 / Node codes.
+ *
+ * @internal
+ */
+export function isRequestTimeoutError(error: unknown): error is Error {
+  if (isTimeoutError(error)) return true
+  if (typeof error !== 'object' || error === null) return false
+  return 'code' in error && typeof error.code === 'string' && LEGACY_TIMEOUT_CODES.has(error.code)
 }
 
 /** @internal */
 export function isNetworkError(error: unknown): error is Error {
   if (typeof error !== 'object' || error === null) return false
-  // get-it v8 sets isNetworkError=true on connection errors
-  // https://github.com/sanity-io/get-it/blob/9ffc7e0c2d41ffcfd3a33e7525d9d1f6b188f812/src/request/browser-request.ts#L194
+  // get-it sets isNetworkError=true on connection errors.
   if ('isNetworkError' in error && error.isNetworkError === true) return true
-  // get-it's connect/socket timeout path publishes a plain Error with a code
-  // but does not set isNetworkError. Treat these timeouts as network errors
-  // so they get the same treatment.
-  if (isTimeoutError(error)) return true
+  // Treat both get-it header timeouts and platform request-deadline
+  // TimeoutErrors as network errors so they get the same treatment.
+  if (isRequestTimeoutError(error)) return true
   return isNativeNetworkError(error)
 }
 
@@ -37,10 +45,8 @@ export function isNetworkError(error: unknown): error is Error {
  *
  * @internal
  */
-export function parseRetryAfter(err: ClientError): number | undefined {
-  const headers = (err as ClientError & {response?: {headers?: Record<string, string>}}).response
-    ?.headers
-  const value = headers?.['retry-after']
+export function parseRetryAfter(err: HttpError): number | undefined {
+  const value = err.response.headers['retry-after']
   if (!value) return undefined
   // Numeric-looking values go through the integer path even when out of
   // range, so negative numbers don't accidentally fall through to the date
@@ -67,8 +73,8 @@ export function parseRetryAfter(err: ClientError): number | undefined {
  */
 export type RequestErrorClassification =
   | {type: 'networkError'; error: Error}
-  | {type: 'serverError'; error: Error}
-  | {type: 'rateLimited'; error: Error; retryAfterSeconds?: number}
+  | {type: 'serverError'; error: HttpError}
+  | {type: 'rateLimited'; error: HttpError; retryAfterSeconds?: number}
 
 /**
  * Classify an error as an infrastructure-level request failure, or return
@@ -83,15 +89,15 @@ export type RequestErrorClassification =
  * @internal
  */
 export function classifyRequestError(err: unknown): RequestErrorClassification | null {
-  if (err instanceof ClientError) {
+  if (isHttpError(err)) {
     if (err.statusCode === 429) {
       return {type: 'rateLimited', error: err, retryAfterSeconds: parseRetryAfter(err)}
     }
-    // 4xx other than 429 are caller-domain — they carry structured context
+    if (err.statusCode >= 500) return {type: 'serverError', error: err}
+    // 4xx other than 429 are caller-domain. They carry structured context
     // the caller is better positioned to render than a generic dialog.
     return null
   }
-  if (err instanceof ServerError) return {type: 'serverError', error: err}
   if (isNetworkError(err)) return {type: 'networkError', error: err}
   return null
 }
@@ -120,10 +126,18 @@ interface NotFoundBody {
   attributes?: {type?: unknown}
 }
 
-function notFoundBody(err: ClientError): NotFoundBody | undefined {
-  const body = (err as ClientError & {response?: {body?: unknown}}).response?.body
-  if (body && typeof body === 'object') return body as NotFoundBody
-  return undefined
+function notFoundBody(err: HttpError): NotFoundBody | undefined {
+  const body = err.response.body
+  if (!body || typeof body !== 'object') return undefined
+
+  const attributes = 'attributes' in body ? body.attributes : undefined
+  return {
+    error: 'error' in body ? body.error : undefined,
+    attributes:
+      attributes && typeof attributes === 'object'
+        ? {type: 'type' in attributes ? attributes.type : undefined}
+        : undefined,
+  }
 }
 
 /**
@@ -145,7 +159,7 @@ function notFoundBody(err: ClientError): NotFoundBody | undefined {
  * @internal
  */
 export function classifyConfigError(err: unknown): ConfigErrorClassification | null {
-  if (!(err instanceof ClientError) || err.statusCode !== 404) return null
+  if (!isHttpError(err) || err.statusCode !== 404) return null
   const body = notFoundBody(err)
   if (!body) return null
 
@@ -173,5 +187,5 @@ export function classifyConfigError(err: unknown): ConfigErrorClassification | n
  * @internal
  */
 export function isClientRequestError(err: unknown): boolean {
-  return err instanceof ClientError || err instanceof ServerError || isNetworkError(err)
+  return isHttpError(err) || isNetworkError(err)
 }

--- a/packages/sanity/src/core/studio/requestErrors/createRequestErrorChannel.ts
+++ b/packages/sanity/src/core/studio/requestErrors/createRequestErrorChannel.ts
@@ -1,3 +1,4 @@
+import {type HttpError} from '@sanity/client'
 import {BehaviorSubject, isObservable, lastValueFrom, type Observable} from 'rxjs'
 
 import {classifyRequestError, isInvalidSessionError} from './classify'
@@ -13,10 +14,8 @@ import {
  * (`https://{projectId}.api.sanity.io/...`). Used to route a delegated
  * 401 to the right workspace's auth store for forced logout.
  */
-function projectIdFromError(err: Error): string | undefined {
-  const url =
-    (err as Error & {response?: {url?: string}}).response?.url ??
-    (err as Error & {request?: {url?: string}}).request?.url
+function projectIdFromError(err: HttpError): string | undefined {
+  const url = err.response.url
   if (!url) return undefined
   try {
     const host = new URL(url).hostname

--- a/packages/sanity/src/core/studio/requestErrors/createStudioRequestHandler.ts
+++ b/packages/sanity/src/core/studio/requestErrors/createStudioRequestHandler.ts
@@ -1,0 +1,55 @@
+import {type RequestHandler, type SanityClient} from '@sanity/client'
+
+import {type RequestFailureDiagnostics} from '../../store/authStore/createAuthStore'
+import {isInvalidSessionError} from './classify'
+import {type RequestErrorChannel} from './types'
+
+interface StudioRequestHandlerOptions {
+  channel: RequestErrorChannel
+  diagnostics?: RequestFailureDiagnostics
+  getClient?: () => SanityClient
+  waitForCorsRetry?: () => Promise<void>
+}
+
+/**
+ * Handles the request failures that prevent the Studio itself from operating:
+ * invalid sessions, invalid project or dataset configuration, and CORS
+ * misconfiguration. All other failures remain the caller's responsibility.
+ *
+ * @internal
+ */
+export function createStudioRequestHandler({
+  channel,
+  diagnostics,
+  getClient,
+  waitForCorsRetry,
+}: StudioRequestHandlerOptions): RequestHandler {
+  return (request, next) => {
+    const execute = async (): Promise<unknown> => {
+      try {
+        return await next(request)
+      } catch (error) {
+        if (isInvalidSessionError(error)) {
+          return channel.handle(error)
+        }
+
+        if (diagnostics && getClient) {
+          const client = getClient()
+          const result = await diagnostics.diagnose(error, client)
+          if (result.type !== 'unknown') {
+            diagnostics.onRequestFailure(result, client)
+            if (result.type === 'cors' && waitForCorsRetry) {
+              await waitForCorsRetry()
+              return execute()
+            }
+            return new Promise<never>(() => {})
+          }
+        }
+
+        throw error
+      }
+    }
+
+    return execute()
+  }
+}

--- a/packages/sanity/src/core/studio/requestErrors/diagnoseRequestFailure.ts
+++ b/packages/sanity/src/core/studio/requestErrors/diagnoseRequestFailure.ts
@@ -1,7 +1,7 @@
 import {type SanityClient} from '@sanity/client'
 
 import {checkCors, type CorsCheckCache} from '../workspaces/corsCheck'
-import {classifyConfigError, isNetworkError, isTimeoutError} from './classify'
+import {classifyConfigError, isNetworkError, isRequestTimeoutError} from './classify'
 
 /**
  * A diagnosed request failure — the reason a request the studio can't recover
@@ -68,8 +68,9 @@ export function createRequestFailureProbe(
     }
 
     // Opaque network/CORS failure — probe `/check/cors` to learn why. Skip
-    // timeouts (the probe itself would just time out).
-    if (!isNetworkError(err) || isTimeoutError(err)) {
+    // timeouts (the probe itself would just time out), including leftover
+    // get-it v8 / Node timeout codes that `isTimeoutError` no longer matches.
+    if (!isNetworkError(err) || isRequestTimeoutError(err)) {
       return {type: 'unknown'}
     }
 

--- a/packages/sanity/src/core/studio/requestErrors/types.ts
+++ b/packages/sanity/src/core/studio/requestErrors/types.ts
@@ -1,3 +1,4 @@
+import {type HttpError} from '@sanity/client'
 import {type Observable} from 'rxjs'
 
 /**
@@ -32,9 +33,9 @@ export interface RequestErrorReportOptions {
  */
 export type RequestErrorClaim =
   | {type: 'networkError'; error: Error; retryable: boolean}
-  | {type: 'serverError'; error: Error; retryable: boolean}
-  | {type: 'rateLimited'; error: Error; retryAfterSeconds?: number; retryable: boolean}
-  | {type: 'unauthorized'; error: Error; projectId?: string}
+  | {type: 'serverError'; error: HttpError; retryable: boolean}
+  | {type: 'rateLimited'; error: HttpError; retryAfterSeconds?: number; retryable: boolean}
+  | {type: 'unauthorized'; error: HttpError; projectId?: string}
 
 /**
  * Call-site API for delegating unrecoverable request errors to the
@@ -51,7 +52,7 @@ export type RequestErrorClaim =
  *
  * // 1. Thunk wrapper — the dialog's "Try again" re-invokes the thunk.
  * //    The thunk may return a promise or a (single-shot) observable:
- * const user = await attempt(() => client.request({uri: '/users/me'}), {
+ * const user = await attempt(() => client.request({url: '/users/me'}), {
  *   retryable: true,
  * })
  *

--- a/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
+++ b/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
@@ -150,7 +150,7 @@ export function StudioTelemetryProvider(props: {children: ReactNode}) {
     return {
       flushInterval: 30000,
       resolveConsent: () =>
-        client.request({uri: '/intake/telemetry-status', tag: 'telemetry-consent.studio'}),
+        client.request({url: '/intake/telemetry-status', tag: 'telemetry-consent.studio'}),
 
       // Each event is enriched with the current context
       sendEvents: (batch) => {
@@ -161,9 +161,8 @@ export function StudioTelemetryProvider(props: {children: ReactNode}) {
           context,
         }))
         return client.request({
-          uri: '/intake/batch',
+          url: '/intake/batch',
           method: 'POST',
-          json: true,
           body: {projectId, batch: enrichedBatch},
         })
       },

--- a/packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx
+++ b/packages/sanity/src/core/studio/telemetry/__tests__/StudioTelemetryProvider.test.tsx
@@ -174,9 +174,8 @@ describe('StudioTelemetryProvider', () => {
     // Verify client.request was called with enriched batch
     expect(mockClient.request).toHaveBeenCalledWith(
       expect.objectContaining({
-        uri: '/intake/batch',
+        url: '/intake/batch',
         method: 'POST',
-        json: true,
         body: expect.objectContaining({
           projectId: 'test-project',
           batch: expect.arrayContaining([

--- a/packages/sanity/src/core/studio/telemetry/telemetryConsent.ts
+++ b/packages/sanity/src/core/studio/telemetry/telemetryConsent.ts
@@ -19,7 +19,7 @@ export function getTelemetryConsent$(client: SanityClient): Observable<ConsentSt
   let cached$ = cache.get(projectId)
   if (!cached$) {
     cached$ = client.observable
-      .request<{status: string}>({uri: '/intake/telemetry-status', tag: 'telemetry-consent'})
+      .request<{status: string}>({url: '/intake/telemetry-status', tag: 'telemetry-consent'})
       .pipe(
         map((res): ConsentStatus => (res?.status === 'granted' ? 'granted' : 'denied')),
         shareReplay(1),

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProject.test.ts
@@ -157,7 +157,7 @@ describe('useUnclaimedProject', () => {
     await waitFor(() =>
       expect(mockRequest).toHaveBeenCalledExactlyOnceWith({
         tag: 'unclaimed-project',
-        uri: `/projects/${PROJECT_ID}`,
+        url: `/projects/${PROJECT_ID}`,
       }),
     )
     expect(result.current).toBeUndefined()

--- a/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProjectCopy.test.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/__tests__/useUnclaimedProjectCopy.test.ts
@@ -101,7 +101,7 @@ describe('useUnclaimedProjectCopy', () => {
 
     await waitFor(() => expect(result.current).toEqual(COPY))
     expect(mockRequest).toHaveBeenCalledExactlyOnceWith({
-      uri: '/journey/unclaimed-project',
+      url: '/journey/unclaimed-project',
       tag: 'unclaimed-project-copy',
     })
   })
@@ -113,7 +113,7 @@ describe('useUnclaimedProjectCopy', () => {
 
     await waitFor(() =>
       expect(mockRequest).toHaveBeenCalledExactlyOnceWith({
-        uri: '/journey/unclaimed-project',
+        url: '/journey/unclaimed-project',
         tag: 'unclaimed-project-copy',
       }),
     )

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProject.ts
@@ -243,7 +243,7 @@ export function useUnclaimedProject({claimAttemptedAt}: UseUnclaimedProjectOptio
     const performCheck = async () => {
       let project: ProjectResponse
       try {
-        project = await client.request({uri: `/projects/${projectId}`, tag: 'unclaimed-project'})
+        project = await client.request({url: `/projects/${projectId}`, tag: 'unclaimed-project'})
       } catch (err) {
         const statusCode = getStatusCode(err)
         const hasMintProvenance =

--- a/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProjectCopy.ts
+++ b/packages/sanity/src/core/studio/unclaimedProject/useUnclaimedProjectCopy.ts
@@ -124,7 +124,7 @@ export function useUnclaimedProjectCopy(enabled: boolean): UnclaimedProjectCopy 
           return response.json()
         })
       : client.observable.request<unknown>({
-          uri: UNCLAIMED_PROJECT_COPY_URI,
+          url: UNCLAIMED_PROJECT_COPY_URI,
           tag: 'unclaimed-project-copy',
         })
 

--- a/packages/sanity/src/core/studio/workspaces/WorkspacesProvider.tsx
+++ b/packages/sanity/src/core/studio/workspaces/WorkspacesProvider.tsx
@@ -1,4 +1,4 @@
-import {type RequestHandler, type SanityClient} from '@sanity/client'
+import {type SanityClient} from '@sanity/client'
 import QuickLRU from 'quick-lru'
 import {
   type ComponentType,
@@ -11,8 +11,8 @@ import {
   useState,
 } from 'react'
 import {useSyncObservable} from 'react-rx'
-import {defer, firstValueFrom, from, NEVER, Subject, type Observable} from 'rxjs'
-import {catchError, mergeMap, take, tap} from 'rxjs/operators'
+import {firstValueFrom, Subject, type Observable} from 'rxjs'
+import {take} from 'rxjs/operators'
 import {
   ConfigErrorContext,
   type ConfigErrorValue,
@@ -23,8 +23,9 @@ import {
 
 import {prepareConfig} from '../../config/prepareConfig'
 import {type Config} from '../../config/types'
-import {getApiErrorCode, isInvalidSessionError} from '../requestErrors/classify'
+import {getApiErrorCode} from '../requestErrors/classify'
 import {createRequestErrorChannel} from '../requestErrors/createRequestErrorChannel'
+import {createStudioRequestHandler as createStudioRequestHandlerFactory} from '../requestErrors/createStudioRequestHandler'
 import {
   createRequestFailureProbe,
   type RequestFailureResult,
@@ -166,56 +167,6 @@ export function WorkspacesProvider({
   // Everything else — network errors, 5xx, 429 — propagates to the caller
   // unchanged. Callers that cannot recover locally delegate explicitly via
   // `useStudioErrorHandler()`; the studio never decides on their behalf.
-  // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-  const requestHandler: RequestHandler = useCallback(
-    (requestOptions, originalRequest, client) => {
-      return defer(() => originalRequest(requestOptions)).pipe(
-        catchError((requestError: unknown, caught) => {
-          // An invalid-session 401 means the session is no longer
-          // authenticated. Hand it to the channel — it claims the
-          // `unauthorized` state once, driving the forced logout below —
-          // and park this request, since the session is being torn down.
-          if (isInvalidSessionError(requestError)) {
-            void requestErrorChannel.handle(requestError)
-            return NEVER
-          }
-
-          // Diagnose config (missing project/dataset) and CORS failures with
-          // the shared probe — the same diagnosis the auth store's `/users/me`
-          // probe uses, so both agree regardless of which request fails first.
-          return from(createRequestFailureProbe(client, corsCache)(requestError)).pipe(
-            mergeMap((result) => {
-              if (result.type === 'unknown') {
-                // Not a config/CORS failure — re-throw so it surfaces normally.
-                throw requestError
-              }
-
-              applyRequestFailure(result, client)
-
-              // For a CORS misconfig the view polls and resolves itself: when
-              // `onCorsRetry` fires we resubscribe to `caught`.
-              if (result.type === 'cors') {
-                return corsRetry.pipe(
-                  take(1),
-                  mergeMap(() => caught.pipe(tap(() => setCorsError(undefined)))),
-                )
-              }
-
-              // Config error: park (never emit) rather than re-throw. The
-              // takeover screen replaces the workspace render, so the failed
-              // request has nowhere useful to go — and re-throwing would
-              // propagate into a live store subscription's render path (e.g.
-              // switching between two misconfigured workspaces), tripping the
-              // error boundary.
-              return NEVER
-            }),
-          )
-        }),
-      )
-    },
-    [applyRequestFailure, corsCache, corsRetry, requestErrorChannel],
-  )
-
   // Diagnostics for the auth store's `/users/me` probe, which runs on a client
   // with this request handler stripped and so can't rely on it for CORS /
   // config detection. Same classifier + the same screen-takeover side effect.
@@ -231,10 +182,24 @@ export function WorkspacesProvider({
     [applyRequestFailure, corsCache],
   )
 
+  const createStudioRequestHandler = useCallback(
+    (getClient: () => SanityClient) =>
+      createStudioRequestHandlerFactory({
+        channel: requestErrorChannel,
+        diagnostics: requestFailureDiagnostics,
+        getClient,
+        waitForCorsRetry: async () => {
+          await firstValueFrom(corsRetry.pipe(take(1)))
+          setCorsError(undefined)
+        },
+      }),
+    [corsRetry, requestErrorChannel, requestFailureDiagnostics],
+  )
+
   const workspaces = useDeferredValue(
     prepareConfig(config, {
       basePath,
-      requestHandler,
+      createStudioRequestHandler,
       requestErrorChannel,
       requestFailureDiagnostics,
     }).workspaces satisfies WorkspacesContextValue,

--- a/packages/sanity/src/core/util/apiErrors.ts
+++ b/packages/sanity/src/core/util/apiErrors.ts
@@ -1,8 +1,8 @@
-import {ClientError} from '@sanity/client'
+import {type HttpError, isHttpError} from '@sanity/client'
 
 /** @internal */
-export function isUnauthorizedError(err: unknown): err is ClientError {
-  return err instanceof ClientError && err.statusCode === 401
+export function isUnauthorizedError(err: unknown): err is HttpError {
+  return isHttpError(err) && err.statusCode === 401
 }
 
 /**
@@ -26,7 +26,7 @@ const INVALID_SESSION_ERROR_CODES = ['SIO-401-AEX', 'SIO-401-ANF']
  *
  * @internal
  */
-export function isInvalidSessionError(err: unknown): err is ClientError {
+export function isInvalidSessionError(err: unknown): err is HttpError {
   if (!isUnauthorizedError(err)) return false
   const code = getApiErrorCode(err)
   return code !== undefined && INVALID_SESSION_ERROR_CODES.includes(code)
@@ -42,11 +42,13 @@ export function isInvalidSessionError(err: unknown): err is ClientError {
  * @internal
  */
 export function getApiErrorCode(err: unknown): string | undefined {
-  if (!(err instanceof ClientError)) return undefined
-  const fromResponse = readErrorCode(err.response?.body)
+  if (!isHttpError(err)) return undefined
+  const fromResponse = readErrorCode(err.response.body)
   if (fromResponse) return fromResponse
+  const responseBody = 'responseBody' in err ? err.responseBody : undefined
+  if (typeof responseBody !== 'string') return undefined
   try {
-    return readErrorCode(JSON.parse(err.responseBody ?? ''))
+    return readErrorCode(JSON.parse(responseBody))
   } catch {
     return undefined
   }

--- a/packages/sanity/src/core/validation/util/__tests__/createBatchedGetDocumentExists.test.ts
+++ b/packages/sanity/src/core/validation/util/__tests__/createBatchedGetDocumentExists.test.ts
@@ -53,10 +53,10 @@ describe('createBatchedGetDocumentExists', () => {
     expect(mockClient.observable.request).toHaveBeenCalledTimes(2)
     const [firstCall, secondCall] = mockClient.observable.request.mock.calls
 
-    expect(firstCall[0].uri).toEqual(
+    expect(firstCall[0].url).toEqual(
       `https://example.com/doc/${ids.slice(0, MAX_BUFFER_SIZE).join(',')}`,
     )
-    expect(secondCall[0].uri).toEqual(
+    expect(secondCall[0].url).toEqual(
       `https://example.com/doc/${ids.slice(MAX_BUFFER_SIZE).join(',')}`,
     )
   })

--- a/packages/sanity/src/core/validation/util/createBatchedGetDocumentExists.ts
+++ b/packages/sanity/src/core/validation/util/createBatchedGetDocumentExists.ts
@@ -49,8 +49,7 @@ export function createBatchedGetDocumentExists(
         switchMap(() =>
           client.observable
             .request<AvailabilityResponse>({
-              uri: client.getDataUrl('doc', ids.join(',')),
-              json: true,
+              url: client.getDataUrl('doc', ids.join(',')),
               query: {excludeContent: 'true'},
               tag: 'documents-availability',
             })

--- a/packages/sanity/src/media-library/plugin/VideoInput/useVideoPlaybackInfo.ts
+++ b/packages/sanity/src/media-library/plugin/VideoInput/useVideoPlaybackInfo.ts
@@ -163,7 +163,7 @@ export function useVideoPlaybackInfo(
           const assetInstanceId = parseAssetInstanceId(assetRef._ref)
           return from(
             client.request<VideoPlaybackInfo>({
-              uri: `/media-libraries/${mediaLibraryId}/video/${assetInstanceId}/playback-info`,
+              url: `/media-libraries/${mediaLibraryId}/video/${assetInstanceId}/playback-info`,
               tag: 'media-library.video-playback-info',
             }),
           )

--- a/packages/sanity/src/structure/components/confirmDeleteDialog/useReferringDocuments.ts
+++ b/packages/sanity/src/structure/components/confirmDeleteDialog/useReferringDocuments.ts
@@ -95,7 +95,7 @@ function getDocumentExistence(
   const draftId = getDraftId(documentId)
   const publishedId = getPublishedId(documentId)
   const requestOptions = {
-    uri: versionedClient.getDataUrl('doc', `${draftId},${publishedId}`),
+    url: versionedClient.getDataUrl('doc', `${draftId},${publishedId}`),
     json: true,
     query: {excludeContent: 'true'},
     tag: 'use-referring-documents.document-existence',

--- a/packages/sanity/src/structure/components/structureTool/intentResolver/__tests__/IntentResolver.test.tsx
+++ b/packages/sanity/src/structure/components/structureTool/intentResolver/__tests__/IntentResolver.test.tsx
@@ -57,9 +57,9 @@ class Boundary extends Component<{children: ReactNode}, {error: unknown}> {
   }
 }
 
-function socketTimeoutError() {
-  return Object.assign(new Error('Socket timed out on request to https://x.api.sanity.io/…'), {
-    code: 'ESOCKETTIMEDOUT',
+function timeoutError() {
+  return Object.assign(new Error('The operation was aborted due to timeout'), {
+    name: 'TimeoutError',
   })
 }
 
@@ -87,7 +87,7 @@ describe('IntentResolver', () => {
   }
 
   it('delegates infrastructure failures to the request-error channel instead of crashing', async () => {
-    mockResolveTypeForDocument.mockReturnValue(throwError(socketTimeoutError))
+    mockResolveTypeForDocument.mockReturnValue(throwError(timeoutError))
 
     const {channel, boundary} = renderResolver()
 
@@ -99,7 +99,7 @@ describe('IntentResolver', () => {
 
   it('re-runs intent resolution when the claimed error is retried', async () => {
     mockResolveTypeForDocument
-      .mockReturnValueOnce(throwError(socketTimeoutError))
+      .mockReturnValueOnce(throwError(timeoutError))
       .mockReturnValueOnce(of('author'))
 
     const {channel} = renderResolver()
@@ -114,7 +114,7 @@ describe('IntentResolver', () => {
   })
 
   it('does not re-fetch when the claimed error is retried after unmount', async () => {
-    mockResolveTypeForDocument.mockReturnValue(throwError(socketTimeoutError))
+    mockResolveTypeForDocument.mockReturnValue(throwError(timeoutError))
 
     const {channel, unmount} = renderResolver()
 

--- a/packages/sanity/test/mocks/mockSanityClient.ts
+++ b/packages/sanity/test/mocks/mockSanityClient.ts
@@ -31,7 +31,7 @@ export interface MockClientLog {
 export function createMockSanityClient(
   data: {
     requests?: Record<string, any>
-    requestCallback?: (request: {uri: string; method: HTTPMethod}) =>
+    requestCallback?: (request: {url: string; method: HTTPMethod}) =>
       | {
           statusCode: number
           data: any
@@ -113,17 +113,17 @@ export function createMockSanityClient(
 
     config: () => mockConfig,
 
-    getUrl: (uri: string) => {
-      return BASE_URL + uri
+    getUrl: (url: string) => {
+      return BASE_URL + url
     },
 
     withConfig: () => mockClient,
 
-    request: (opts: {uri: string; tag?: string; withCredentials?: boolean; method: HTTPMethod}) => {
+    request: (opts: {url: string; tag?: string; withCredentials?: boolean; method: HTTPMethod}) => {
       $log.request.push(opts)
 
       const requestCallbackValue =
-        data.requestCallback && data.requestCallback({uri: opts.uri, method: opts.method})
+        data.requestCallback && data.requestCallback({url: opts.url, method: opts.method})
 
       if (requestCallbackValue) {
         return requestCallbackValue.statusCode >= 400
@@ -131,15 +131,15 @@ export function createMockSanityClient(
           : Promise.resolve(requestCallbackValue)
       }
 
-      if (opts.uri.startsWith(requestUriPrefix)) {
-        const path = opts.uri.slice(requestUriPrefix.length)
+      if (opts.url.startsWith(requestUriPrefix)) {
+        const path = opts.url.slice(requestUriPrefix.length)
 
         if (requests[path]) {
           return Promise.resolve(requests[path])
         }
       }
 
-      return Promise.resolve(requests[opts.uri] || requests['*'] || null)
+      return Promise.resolve(requests[opts.url] || requests['*'] || null)
     },
 
     listen: (query: string, params?: any) => {
@@ -177,7 +177,7 @@ export function createMockSanityClient(
       },
 
       request: (opts: {
-        uri: string
+        url: string
         tag?: string
         withCredentials?: boolean
         method: HTTPMethod
@@ -186,7 +186,7 @@ export function createMockSanityClient(
 
         $log.observable.request.push(opts)
         const requestCallbackValue =
-          data.requestCallback && data.requestCallback({uri: opts.uri, method: opts.method})
+          data.requestCallback && data.requestCallback({url: opts.url, method: opts.method})
 
         if (requestCallbackValue) {
           return requestCallbackValue.statusCode >= 400
@@ -194,15 +194,15 @@ export function createMockSanityClient(
             : of(requestCallbackValue.data)
         }
 
-        if (opts.uri?.startsWith(requestUriPrefix)) {
-          const path = opts.uri.slice(requestUriPrefix.length)
+        if (opts.url?.startsWith(requestUriPrefix)) {
+          const path = opts.url.slice(requestUriPrefix.length)
 
           if (requests[path]) {
             return of(requests[path])
           }
         }
 
-        return of(requests[opts.uri] || requests['*'] || null)
+        return of(requests[opts.url] || requests['*'] || null)
       },
 
       assets: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ catalogs:
       specifier: ^0.2.3
       version: 0.2.3
     '@sanity/client':
-      specifier: ^7.26.2
-      version: 7.26.2
+      specifier: ^8.1.0
+      version: 8.1.0
     '@sanity/migrate':
       specifier: ^8.0.2
       version: 8.0.2
@@ -328,7 +328,7 @@ importers:
         version: link:../../packages/@repo/utils
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.26.2
+        version: 8.1.0(vitest@4.1.10)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
@@ -508,7 +508,7 @@ importers:
         version: 8.0.0(react@19.2.8)
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.26.2
+        version: 8.1.0(vitest@4.1.10)
       '@sanity/image-url':
         specifier: ^2.1.1
         version: 2.1.1
@@ -523,7 +523,7 @@ importers:
         version: 4.0.3(react-dom@19.2.8)(react@19.2.8)(styled-components@6.5.3)
       '@sanity/visual-editing':
         specifier: ^6.0.4
-        version: 6.0.4(@sanity/client@7.26.2)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.5.3)(typescript@7.0.2)
+        version: 6.0.4(@sanity/client@8.1.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.5.3)(typescript@7.0.2)
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -772,13 +772,13 @@ importers:
         version: 6.1.19(react-dom@19.2.8)(react@19.2.8)(sanity@packages+sanity)(styled-components@6.5.3)
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.26.2
+        version: 8.1.0(vitest@4.1.10)
       '@sanity/color':
         specifier: ^3.0.8
         version: 3.0.8
       '@sanity/debug-preview-url-secret-plugin':
         specifier: ^2.0.20
-        version: 2.0.20(@sanity/client@7.26.2)(react@19.2.8)(sanity@packages+sanity)
+        version: 2.0.20(@sanity/client@8.1.0)(react@19.2.8)(sanity@packages+sanity)
       '@sanity/document-internationalization':
         specifier: ^6.2.31
         version: 6.2.31(react-dom@19.2.8)(react@19.2.8)(sanity-plugin-internationalized-array@5.2.0)(sanity@packages+sanity)(styled-components@6.5.3)
@@ -799,7 +799,7 @@ importers:
         version: 8.0.2(supports-color@8.1.1)(xstate@5.32.5)
       '@sanity/preview-url-secret':
         specifier: ^4.1.4
-        version: 4.1.4(@sanity/client@7.26.2)
+        version: 4.1.4(@sanity/client@8.1.0)
       '@sanity/react-loader':
         specifier: ^2.1.4
         version: 2.1.4(@sanity/types@packages+@sanity+types)(react@19.2.8)(typescript@7.0.2)
@@ -823,7 +823,7 @@ importers:
         version: link:../../packages/@sanity/vision
       '@sanity/visual-editing':
         specifier: ^6.0.4
-        version: 6.0.4(@sanity/client@7.26.2)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.5.3)(typescript@7.0.2)
+        version: 6.0.4(@sanity/client@8.1.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.5.3)(typescript@7.0.2)
       '@turf/helpers':
         specifier: ^7.4.0
         version: 7.4.0
@@ -935,7 +935,7 @@ importers:
         version: link:../packages/@repo/utils
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.26.2
+        version: 8.1.0(vitest@4.1.10)
       '@sanity/uuid':
         specifier: ^3.0.3
         version: 3.0.3
@@ -1099,7 +1099,7 @@ importers:
         version: 6.0.0
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.26.2
+        version: 8.1.0(vitest@4.1.10)
       '@sanity/id-utils':
         specifier: ^1.0.0
         version: 1.0.0
@@ -1318,7 +1318,7 @@ importers:
     dependencies:
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.26.2
+        version: 8.1.0(vitest@4.1.10)
       '@sanity/icons':
         specifier: ^5.2.1
         version: 5.2.1(react@19.2.8)
@@ -1520,7 +1520,7 @@ importers:
     dependencies:
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.26.2
+        version: 8.1.0(vitest@4.1.10)
       '@sanity/media-library-types':
         specifier: ^1.6.0
         version: 1.6.0
@@ -1566,7 +1566,7 @@ importers:
         version: 2.1.1
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.26.2
+        version: 8.1.0(vitest@4.1.10)
       '@sanity/types':
         specifier: workspace:*
         version: link:../types
@@ -1636,7 +1636,7 @@ importers:
         version: 1.0.0(react-dom@19.2.8)(react@19.2.8)
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.26.2
+        version: 8.1.0(vitest@4.1.10)
       '@sanity/color':
         specifier: ^3.0.8
         version: 3.0.8
@@ -1834,7 +1834,7 @@ importers:
         version: 8.0.2(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@vitejs/devtools@0.4.12)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.2)(jiti@2.7.0)(oxfmt@0.63.0)(rolldown@1.2.4)(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.10)(xstate@5.32.5)
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.26.2
+        version: 8.1.0(vitest@4.1.10)
       '@sanity/color':
         specifier: ^3.0.8
         version: 3.0.8
@@ -1888,7 +1888,7 @@ importers:
         version: 2.2.3(@sanity/types@packages+@sanity+types)
       '@sanity/preview-url-secret':
         specifier: ^4.1.4
-        version: 4.1.4(@sanity/client@7.26.2)
+        version: 4.1.4(@sanity/client@8.1.0)
       '@sanity/prism-groq':
         specifier: ^1.1.2
         version: 1.1.2
@@ -2102,7 +2102,7 @@ importers:
         version: 0.2.13(babel-plugin-macros@3.1.0)(vite@8.2.1)
       '@sanity/visual-editing-csm':
         specifier: ^3.0.15
-        version: 3.0.15(@sanity/client@7.26.2)(@sanity/types@packages+@sanity+types)(typescript@7.0.2)
+        version: 3.0.15(@sanity/client@8.1.0)(@sanity/types@packages+@sanity+types)(typescript@7.0.2)
       '@storybook/react-vite':
         specifier: ^10.5.8
         version: 10.5.8(@types/react-dom@19.2.4)(@types/react@19.2.18)(esbuild@0.28.2)(react-dom@19.2.8)(react@19.2.8)(storybook@10.5.8)(supports-color@8.1.1)(typescript@7.0.2)(vite@8.2.1)
@@ -2237,7 +2237,7 @@ importers:
         version: link:../../packages/@repo/utils
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.26.2
+        version: 8.1.0(vitest@4.1.10)
       '@sanity/mutator':
         specifier: workspace:*
         version: link:../../packages/@sanity/mutator
@@ -2335,7 +2335,7 @@ importers:
         version: 1.62.1
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.26.2
+        version: 8.1.0(vitest@4.1.10)
       '@sanity/uuid':
         specifier: ^3.0.3
         version: 3.0.3
@@ -2393,7 +2393,7 @@ importers:
         version: link:../packages/@repo/utils
       '@sanity/client':
         specifier: 'catalog:'
-        version: 7.26.2
+        version: 8.1.0(vitest@4.1.10)
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -18795,10 +18795,10 @@ snapshots:
       - '@sanity/types'
       - typescript
 
-  '@sanity/debug-preview-url-secret-plugin@2.0.20(@sanity/client@7.26.2)(react@19.2.8)(sanity@packages+sanity)':
+  '@sanity/debug-preview-url-secret-plugin@2.0.20(@sanity/client@8.1.0)(react@19.2.8)(sanity@packages+sanity)':
     dependencies:
       '@sanity/icons': 5.2.1(react@19.2.8)
-      '@sanity/preview-url-secret': 4.1.4(@sanity/client@7.26.2)
+      '@sanity/preview-url-secret': 4.1.4(@sanity/client@8.1.0)
       react: 19.2.8
       sanity: link:packages/sanity
     transitivePeerDependencies:
@@ -18980,9 +18980,9 @@ snapshots:
     transitivePeerDependencies:
       - '@sanity/types'
 
-  '@sanity/preview-url-secret@4.1.4(@sanity/client@7.26.2)':
+  '@sanity/preview-url-secret@4.1.4(@sanity/client@8.1.0)':
     dependencies:
-      '@sanity/client': 7.26.2
+      '@sanity/client': 8.1.0(vitest@4.1.10)
       '@sanity/uuid': 3.0.3
 
   '@sanity/prism-groq@1.1.2': {}
@@ -19231,22 +19231,37 @@ snapshots:
       - '@sanity/types'
       - typescript
 
+  '@sanity/visual-editing-csm@3.0.15(@sanity/client@8.1.0)(@sanity/types@packages+@sanity+types)(typescript@7.0.2)':
+    dependencies:
+      '@sanity/client': 8.1.0(vitest@4.1.10)
+      '@sanity/visual-editing-types': 2.0.14(@sanity/client@8.1.0)(@sanity/types@packages+@sanity+types)
+      valibot: 1.4.2(typescript@7.0.2)
+    transitivePeerDependencies:
+      - '@sanity/types'
+      - typescript
+
   '@sanity/visual-editing-types@2.0.14(@sanity/client@7.26.2)(@sanity/types@packages+@sanity+types)':
     dependencies:
       '@sanity/client': 7.26.2
     optionalDependencies:
       '@sanity/types': link:packages/@sanity/types
 
-  '@sanity/visual-editing@6.0.4(@sanity/client@7.26.2)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.5.3)(typescript@7.0.2)':
+  '@sanity/visual-editing-types@2.0.14(@sanity/client@8.1.0)(@sanity/types@packages+@sanity+types)':
+    dependencies:
+      '@sanity/client': 8.1.0(vitest@4.1.10)
+    optionalDependencies:
+      '@sanity/types': link:packages/@sanity/types
+
+  '@sanity/visual-editing@6.0.4(@sanity/client@8.1.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.5.3)(typescript@7.0.2)':
     dependencies:
       '@sanity/comlink': 4.0.3
       '@sanity/icons': 5.2.1(react@19.2.8)
       '@sanity/mutate': 0.18.1(xstate@5.32.5)
       '@sanity/presentation-comlink': 2.2.3(@sanity/types@packages+@sanity+types)
-      '@sanity/preview-url-secret': 4.1.4(@sanity/client@7.26.2)
+      '@sanity/preview-url-secret': 4.1.4(@sanity/client@8.1.0)
       '@sanity/types': link:packages/@sanity/types
       '@sanity/ui': 4.0.3(react-dom@19.2.8)(react@19.2.8)(styled-components@6.5.3)
-      '@sanity/visual-editing-csm': 3.0.15(@sanity/client@7.26.2)(@sanity/types@packages+@sanity+types)(typescript@7.0.2)
+      '@sanity/visual-editing-csm': 3.0.15(@sanity/client@8.1.0)(@sanity/types@packages+@sanity+types)(typescript@7.0.2)
       '@vercel/stega': 1.1.0
       dequal: 2.0.3
       lodash-es: 4.18.1
@@ -19258,7 +19273,7 @@ snapshots:
       styled-components: 6.5.3(react-dom@19.2.8)(react@19.2.8)
       xstate: 5.32.5
     optionalDependencies:
-      '@sanity/client': 7.26.2
+      '@sanity/client': 8.1.0(vitest@4.1.10)
     transitivePeerDependencies:
       - typescript
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,7 +26,7 @@ catalog:
   '@optique/run': ^1.1.1
   '@playwright/test': 1.62.1
   '@rolldown/plugin-babel': ^0.2.3
-  '@sanity/client': ^7.26.2
+  '@sanity/client': ^8.1.0
   '@sanity/migrate': ^8.0.2
   '@sanity/telemetry': ^1.1.0
   '@sanity/tsdown-config': ^0.25.0
@@ -77,16 +77,11 @@ minimumReleaseAgeExclude:
   - '@typescript/*'
   - '@vanilla-extract/*'
   - '@vercel/stega'
-  # Scoped packages of the yuku toolchain used by rolldown-plugin-dts (native codegen/parser
-  # bindings plus shared types), they release in lockstep with it (like @oxlint/* for oxlint)
-  - '@yuku-codegen/*'
-  - '@yuku-parser/*'
   - '@yuku-toolchain/*'
   - 'csstype'
   - 'data-uri-to-buffer@7.0.0'
   - 'eslint-plugin-boundaries'
   - 'get-it'
-  - 'get-uri@7.0.0'
   - 'groq-js'
   # lightningcss and its per-platform native bindings (lightningcss-linux-x64-gnu etc.) release
   # in lockstep; @sanity/tsdown-config tracks its latest so builds pick up new bindings together


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

`main` currently ships with the `@sanity/client` v8 upgrade temporarily reverted (#14153) so a hotfix release can be cut without it. This PR restores the upgrade once the hotfix has shipped, by reverting that revert in a single commit: it brings back #14092 (`@sanity/client` v8 upgrade) and its follow-up fix #14146 (timeout error classification) exactly as they were on `main` at dc5e4c0 — the restored tree is byte-identical to that commit, so there is no rebase drift to review.

**Do not merge until the hotfix release is out.** That timing constraint is the only reason this is a separate PR.

This branch was originally stacked on #14153's branch; after that PR was squash-merged the stacked history rendered as an empty diff, so the branch was recreated as a `git revert` of the squash commit (fdb7c52) directly on top of current `main`. Same content, correct diff.

Alternative considered: cherry-picking the two original commits back onto `main` — rejected because reverting the revert is guaranteed to be the exact inverse of what #14153 removed (verifiable by tree hash), whereas cherry-picks could drift silently if anything else touches the same files in the meantime.

### What to review

- The diff is the combined diff of #14092 + #14146 and nothing more: `git rev-parse HEAD^{tree}` equals the tree of dc5e4c0, the last commit on `main` before the revert, which is the state all CI checks last passed on.
- Exact mirror of #14153: `packages/sanity` sources, the `pnpm-workspace.yaml` catalog (`@sanity/client` back to `^8.1.0`, re-removal of the stale `minimumReleaseAgeExclude` entries), and `pnpm-lock.yaml`.
- Beyond that, timing is the main review concern: merge only after the hotfix release has been cut from `main`.

### Testing

- Tree-identity verification: the restored tree hash is byte-identical to `main` at dc5e4c0 (`git rev-parse dc5e4c0^{tree}` == `git rev-parse HEAD^{tree}`), i.e. the exact tree that was green on `main` and on #14146.
- The revert pair was validated while preparing #14153: on the reverted tree, `pnpm build`, `pnpm check:oxlint` (includes the full TypeScript type check), and the full unit suite (610 files / 5825 tests, exit 0) all passed — confirming both directions of the revert are lossless.
- CI on this PR re-runs the full suite against the restored tree.

### Notes for release

N/A – restores #14092 and #14146 unchanged after the hotfix. Neither original PR carried release notes (both were N/A: an internal dependency upgrade and an internal error-classification fix), so there is nothing new to announce here.

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d91a8ae-8377-4195-a70f-fbf243049851?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d91a8ae-8377-4195-a70f-fbf243049851&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

