### PR TITLE
fix(build): bake correct package version into cdn module bundles

### DIFF
--- a/packages/@repo/package.bundle/src/__test__/package.bundle.test.ts
+++ b/packages/@repo/package.bundle/src/__test__/package.bundle.test.ts
@@ -1,6 +1,13 @@
 import {describe, expect, it} from 'vitest'
 
-import {cleanupCssOutputPlugin} from '../package.bundle'
+import {cleanupCssOutputPlugin, createDefaultConfig} from '../package.bundle'
+
+describe('createDefaultConfig()', () => {
+  it('injects the provided version as the __PKG_VERSION__ define', () => {
+    const config = createDefaultConfig({version: '9.9.9-test.1'})
+    expect(config.define?.['__PKG_VERSION__']).toBe('"9.9.9-test.1"')
+  })
+})
 
 function runPlugin(bundle: Record<string, any>) {
   const plugin = cleanupCssOutputPlugin()

--- a/packages/@repo/package.bundle/src/package.bundle.ts
+++ b/packages/@repo/package.bundle/src/package.bundle.ts
@@ -4,73 +4,87 @@ import viteReact, {reactCompilerPreset} from '@vitejs/plugin-react'
 import escapeRegExp from 'lodash-es/escapeRegExp.js'
 import {esmExternalRequirePlugin, type Plugin, type UserConfig} from 'vite'
 
-import packageJson from '../package.json' with {type: 'json'}
+export interface DefaultConfigOptions {
+  /**
+   * The version of the package being bundled (from that package's own package.json). Baked into
+   * the bundle as the `__PKG_VERSION__` global, which `SANITY_VERSION`
+   * (packages/sanity/src/core/version.ts) reports at runtime. The auto-update UI compares it to
+   * the module CDN manifest, so it must match the version the bundle is uploaded as — reading it
+   * from the wrong package.json causes an endless "Reload to update" loop in auto-updating
+   * studios.
+   */
+  version: string
+}
 
-export const defaultConfig: UserConfig = {
-  appType: 'custom',
-  define: {
-    '__SANITY_STAGING__': process.env.SANITY_INTERNAL_ENV === 'staging',
-    '__PKG_VERSION__': JSON.stringify(packageJson.version),
-    'process.env.NODE_ENV': '"production"',
-    'process.env': {},
-  },
-  plugins: [
-    viteReact(),
-    babel({presets: [reactCompilerPreset({target: '19'})]}),
-    vanillaExtractPlugin(),
-    cleanupCssOutputPlugin(),
-    esmExternalRequirePlugin({
-      // self-externals are required here in order to ensure that the presentation
-      // tool and future transitive dependencies that require sanity do not
-      // re-include sanity in their bundle
-      external: ['react', 'react-dom', 'styled-components', 'sanity', '@sanity/vision'].flatMap(
-        (dependency) => [
-          dependency,
-          // this matches `react/jsx-runtime`, `sanity/presentation` etc
-          new RegExp(`^${escapeRegExp(dependency)}\\/`),
-        ],
-      ),
-    }),
-  ],
-  build: {
-    emptyOutDir: true,
-    sourcemap: true,
-    lib: {
-      entry: {},
-      formats: ['es'],
+export function createDefaultConfig({version}: DefaultConfigOptions): UserConfig {
+  return {
+    appType: 'custom',
+    define: {
+      '__SANITY_STAGING__': process.env.SANITY_INTERNAL_ENV === 'staging',
+      '__PKG_VERSION__': JSON.stringify(version),
+      'process.env.NODE_ENV': '"production"',
+      'process.env': {},
     },
-    rolldownOptions: {
-      output: {
-        minify: true,
-        exports: 'named',
-        dir: 'dist',
-        format: 'es',
-        // Due to module server expecting `.mjs`, and packages/sanity/package.json#type now being `module`, it's necessary to configure vite to continue using `.mjs`
-        // Otherwise it'll start using `.js` instead: https://github.com/vitejs/vite/blob/a3cd262f37228967e455617e982b35fccc49ffe9/packages/vite/src/node/build.ts#L664-L679
-        entryFileNames: '[name].mjs',
-        chunkFileNames: '[name]-[hash].mjs',
-        // CSS assets get a predictable name so the module server can serve them at a known URL
-        assetFileNames: (assetInfo) =>
-          assetInfo.names?.some((n) => n.endsWith('.css')) ? 'index.css' : '[name]-[hash][extname]',
+    plugins: [
+      viteReact(),
+      babel({presets: [reactCompilerPreset({target: '19'})]}),
+      vanillaExtractPlugin(),
+      cleanupCssOutputPlugin(),
+      esmExternalRequirePlugin({
+        // self-externals are required here in order to ensure that the presentation
+        // tool and future transitive dependencies that require sanity do not
+        // re-include sanity in their bundle
+        external: ['react', 'react-dom', 'styled-components', 'sanity', '@sanity/vision'].flatMap(
+          (dependency) => [
+            dependency,
+            // this matches `react/jsx-runtime`, `sanity/presentation` etc
+            new RegExp(`^${escapeRegExp(dependency)}\\/`),
+          ],
+        ),
+      }),
+    ],
+    build: {
+      emptyOutDir: true,
+      sourcemap: true,
+      lib: {
+        entry: {},
+        formats: ['es'],
       },
-      transform: {
-        // Same options as pkg-utils: https://github.com/sanity-io/pkg-utils/blob/f4e229e2641049008b375caf67576130be83fcdd/packages/%40sanity/pkg-utils/src/node/tasks/rollup/resolveRollupConfig.ts#L220-L227
-        plugins: {
-          styledComponents: {
-            // Unnecessary, as the way we use styled-components in Sanity is usually by wrapping `@sanity/ui` primitives, not declaring new ones like "const Button = styled.button``"
-            fileName: false,
-            // Native template literals take less space than this transpilation
-            transpileTemplateLiterals: false,
-            // Massively helps dead code elimination and tree-shaking
-            pure: true,
-            // disabled, as pkg-utils tends to be used for npm publishing, while other tooling, like `sanity dev`, `next dev`, etc are used for testing
-            cssProp: false,
+      rolldownOptions: {
+        output: {
+          minify: true,
+          exports: 'named',
+          dir: 'dist',
+          format: 'es',
+          // Due to module server expecting `.mjs`, and packages/sanity/package.json#type now being `module`, it's necessary to configure vite to continue using `.mjs`
+          // Otherwise it'll start using `.js` instead: https://github.com/vitejs/vite/blob/a3cd262f37228967e455617e982b35fccc49ffe9/packages/vite/src/node/build.ts#L664-L679
+          entryFileNames: '[name].mjs',
+          chunkFileNames: '[name]-[hash].mjs',
+          // CSS assets get a predictable name so the module server can serve them at a known URL
+          assetFileNames: (assetInfo) =>
+            assetInfo.names?.some((n) => n.endsWith('.css'))
+              ? 'index.css'
+              : '[name]-[hash][extname]',
+        },
+        transform: {
+          // Same options as pkg-utils: https://github.com/sanity-io/pkg-utils/blob/f4e229e2641049008b375caf67576130be83fcdd/packages/%40sanity/pkg-utils/src/node/tasks/rollup/resolveRollupConfig.ts#L220-L227
+          plugins: {
+            styledComponents: {
+              // Unnecessary, as the way we use styled-components in Sanity is usually by wrapping `@sanity/ui` primitives, not declaring new ones like "const Button = styled.button``"
+              fileName: false,
+              // Native template literals take less space than this transpilation
+              transpileTemplateLiterals: false,
+              // Massively helps dead code elimination and tree-shaking
+              pure: true,
+              // disabled, as pkg-utils tends to be used for npm publishing, while other tooling, like `sanity dev`, `next dev`, etc are used for testing
+              cssProp: false,
+            },
           },
         },
+        treeshake: true,
       },
-      treeshake: true,
     },
-  },
+  }
 }
 
 /**

--- a/packages/@sanity/vision/package.bundle.ts
+++ b/packages/@sanity/vision/package.bundle.ts
@@ -1,8 +1,10 @@
-import {defaultConfig} from '@repo/package.bundle'
+import {createDefaultConfig} from '@repo/package.bundle'
 import {defineConfig, mergeConfig} from 'vite'
 
+import pkg from './package.json' with {type: 'json'}
+
 export default defineConfig(() => {
-  return mergeConfig(defaultConfig, {
+  return mergeConfig(createDefaultConfig({version: pkg.version}), {
     build: {
       lib: {
         entry: {

--- a/packages/sanity/package.bundle.ts
+++ b/packages/sanity/package.bundle.ts
@@ -1,8 +1,10 @@
-import {defaultConfig} from '@repo/package.bundle'
+import {createDefaultConfig} from '@repo/package.bundle'
 import {defineConfig, mergeConfig} from 'vite'
 
+import pkg from './package.json' with {type: 'json'}
+
 export default defineConfig(() => {
-  return mergeConfig(defaultConfig, {
+  return mergeConfig(createDefaultConfig({version: pkg.version}), {
     build: {
       lib: {
         entry: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Auto-updating studios are stuck in an endless "Reload to update" loop: the CDN module bundles self-report `SANITY_VERSION` as `6.9.2` no matter what version they were published as, so the running version never matches the manifest's latest and the banner never clears.

Root cause: the shared vite config in `@repo/package.bundle` defined `__PKG_VERSION__` from **its own** `package.json` — the private tooling package — not the package being bundled. That version is frozen at `6.9.2` forever: lerna (which bumped all packages in lockstep and masked this) was removed after v6.9.2, and the current release tooling (`@repo/release-notes` `selectPackagesToBump`) deliberately skips private packages. The npm tarballs were unaffected because the tsdown build reads the right `package.json`.

Fix: replace the `defaultConfig` export with a `createDefaultConfig({version})` factory; each consumer (`packages/sanity`, `packages/@sanity/vision`) passes its own `pkg.version`, mirroring the tsdown config pattern. No implicit `package.json` reads remain. `process.env.PKG_VERSION` support was deliberately **not** added to the bundle path — no workflow needs it (release workflows bump `package.json` on disk before building) and it would require turbo cache-key plumbing.

Evidence (byte-identical chunk served for two different versions, both reporting `6.9.2`):

- https://modules.sanity-cdn.com/modules/v1/sanity/6.10.1-next.3/bare/version-DugrgmqS.mjs
- https://modules.sanity-cdn.com/modules/v1/sanity/6.10.0/bare/version-DugrgmqS.mjs
- Publish run: https://github.com/sanity-io/sanity/actions/runs/32170735060/job/95821421371

### What to review

- `packages/@repo/package.bundle/src/package.bundle.ts` — the factory; everything except the `__PKG_VERSION__` define is unchanged (re-indent only)
- `packages/sanity/package.bundle.ts`, `packages/@sanity/vision/package.bundle.ts` — the two consumers
- The `{}.PKG_BUILD_VERSION` runtime override in the built output is untouched and verified intact (used by `sanity build` preview deployments)

### Testing

- New unit test: `createDefaultConfig()` injects the provided version as the `__PKG_VERSION__` define (`pnpm vitest run --project=@repo/package.bundle`, 14/14 pass)
- `pnpm build:bundle`, then verified `packages/sanity/dist/version-*.mjs` now bakes `6.10.0` (the package's real version), contains no `6.9.2` and no unresolved `__PKG_VERSION__`, and still contains the `PKG_BUILD_VERSION` runtime override
- `pnpm lint:fix` clean

### Notes for release

Fixes auto-updating studios getting stuck in an endless "Reload to update" loop. CDN module bundles reported a stale internal version (6.9.2) instead of their published version, so the update banner reappeared after every reload. Bundles published from this version onward self-report the correct version.

---

**After merge (maintainers):** already-uploaded bundles (`6.10.0`, `6.10.1-next.x`) remain wrong on the bucket and are cached immutably for a year — this fix only applies to bundles published after it lands. To break the loop on the next channel, publish a new version (e.g. trigger the "Release @next" workflow via workflow_dispatch); stable is corrected by the next stable release. Re-uploading existing version paths is not viable due to immutable CDN caching.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7df2f75-11c2-4148-b788-db65cc81cb81?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7df2f75-11c2-4148-b788-db65cc81cb81&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

