### PR TITLE
chore(core): adds documentVersionsStatus tooltip info

### DIFF
--- a/packages/@repo/test-dts-exports/test/fixtures/sanity.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/sanity.test-d.ts
@@ -493,7 +493,7 @@ import type {
   DocumentRevision,
   DocumentRule,
   DocumentStackAvailability,
-  DocumentVersionsStatus,
+  DocumentStatus,
   DocumentStatusIndicator,
   DocumentStore,
   DocumentStoreExtraOptions,
@@ -3292,8 +3292,8 @@ describe('sanity', () => {
   test('DocumentStackAvailability', () => {
     expectTypeOf<DocumentStackAvailability>().toBeObject()
   })
-  test('DocumentVersionsStatus', () => {
-    expectTypeOf<typeof DocumentVersionsStatus>().toBeFunction()
+  test('DocumentStatus', () => {
+    expectTypeOf<typeof DocumentStatus>().toBeFunction()
   })
   test('DocumentStatusIndicator', () => {
     expectTypeOf<typeof DocumentStatusIndicator>().toBeFunction()

--- a/packages/@repo/test-dts-exports/test/fixtures/sanity.test-d.ts
+++ b/packages/@repo/test-dts-exports/test/fixtures/sanity.test-d.ts
@@ -493,7 +493,7 @@ import type {
   DocumentRevision,
   DocumentRule,
   DocumentStackAvailability,
-  DocumentStatus,
+  DocumentVersionsStatus,
   DocumentStatusIndicator,
   DocumentStore,
   DocumentStoreExtraOptions,
@@ -3292,8 +3292,8 @@ describe('sanity', () => {
   test('DocumentStackAvailability', () => {
     expectTypeOf<DocumentStackAvailability>().toBeObject()
   })
-  test('DocumentStatus', () => {
-    expectTypeOf<typeof DocumentStatus>().toBeFunction()
+  test('DocumentVersionsStatus', () => {
+    expectTypeOf<typeof DocumentVersionsStatus>().toBeFunction()
   })
   test('DocumentStatusIndicator', () => {
     expectTypeOf<typeof DocumentStatusIndicator>().toBeFunction()

--- a/packages/sanity/src/_exports/index.ts
+++ b/packages/sanity/src/_exports/index.ts
@@ -102,7 +102,9 @@ export {
 } from '../core/components/commandList/types'
 export {ContextMenuButton} from '../core/components/contextMenuButton/ContextMenuButton'
 export {Delay} from '../core/components/Delay'
+// oxlint-disable-next-line no-deprecated -- preserved for backwards compatibility
 export {DocumentStatus} from '../core/components/documentStatus/DocumentStatus'
+export {DocumentVersionsStatus} from '../core/components/documentStatus/DocumentVersionsStatus'
 // oxlint-disable-next-line no-deprecated -- preserved for backwards compatibility
 export {DocumentStatusIndicator} from '../core/components/documentStatusIndicator/DocumentStatusIndicator'
 export {DocumentVersionsStatusIndicator} from '../core/components/documentStatusIndicator/DocumentVersionsStatusIndicator'

--- a/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
@@ -27,7 +27,7 @@ interface DocumentStatusProps {
  *
  * Example: `**Published Oct 16 2023** Edited 8m ago`
  *
- * @internal
+ * @deprecated use DocumentVersionsStatus instead
  */
 export function DocumentStatus({draft, published, versions, singleLine}: DocumentStatusProps) {
   const {data: releases} = useActiveReleases()

--- a/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
@@ -27,7 +27,7 @@ interface DocumentStatusProps {
  *
  * Example: `**Published Oct 16 2023** Edited 8m ago`
  *
- * @deprecated use DocumentVersionsStatus instead
+ * @internal
  */
 export function DocumentStatus({draft, published, versions, singleLine}: DocumentStatusProps) {
   const {data: releases} = useActiveReleases()
@@ -67,7 +67,6 @@ export function DocumentStatus({draft, published, versions, singleLine}: Documen
         if (!snapshot) {
           return null
         }
-        const version = versions?.[versionName]
         const release = releases?.find(
           (r) => getReleaseIdFromReleaseDocumentId(r._id) === versionName,
         )
@@ -81,7 +80,6 @@ export function DocumentStatus({draft, published, versions, singleLine}: Documen
             title={release?.metadata.title || t('release.placeholder-untitled-release')}
             timestamp={snapshot?._updatedAt}
             release={release}
-            version={version}
           />
         )
       })}
@@ -103,13 +101,11 @@ const VersionStatus = ({
   timestamp,
   mode,
   release,
-  version,
 }: {
   title: string
   mode: Mode
   timestamp?: string
   release: TargetPerspective
-  version?: VersionInfoDocumentStub
 }) => {
   const {t} = useTranslation()
 
@@ -120,14 +116,13 @@ const VersionStatus = ({
 
   return (
     <Flex align="center" gap={2}>
+      <ReleaseAvatar release={release} padding={0} />
       <Text size={1}>
         {title} -{' '}
         <span style={{color: 'var(--card-muted-fg-color)'}}>
           {t(labels[mode], {date: relativeTime})}
         </span>
       </Text>
-      <ReleaseAvatar release={release} padding={0} />
-      {version?._system.variant?._ref && <Text size={1}>{version._system.variant?._ref}</Text>}
     </Flex>
   )
 }

--- a/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentStatus.tsx
@@ -27,7 +27,7 @@ interface DocumentStatusProps {
  *
  * Example: `**Published Oct 16 2023** Edited 8m ago`
  *
- * @internal
+ * @deprecated use DocumentVersionsStatus instead
  */
 export function DocumentStatus({draft, published, versions, singleLine}: DocumentStatusProps) {
   const {data: releases} = useActiveReleases()
@@ -67,6 +67,7 @@ export function DocumentStatus({draft, published, versions, singleLine}: Documen
         if (!snapshot) {
           return null
         }
+        const version = versions?.[versionName]
         const release = releases?.find(
           (r) => getReleaseIdFromReleaseDocumentId(r._id) === versionName,
         )
@@ -80,6 +81,7 @@ export function DocumentStatus({draft, published, versions, singleLine}: Documen
             title={release?.metadata.title || t('release.placeholder-untitled-release')}
             timestamp={snapshot?._updatedAt}
             release={release}
+            version={version}
           />
         )
       })}
@@ -101,11 +103,13 @@ const VersionStatus = ({
   timestamp,
   mode,
   release,
+  version,
 }: {
   title: string
   mode: Mode
   timestamp?: string
   release: TargetPerspective
+  version?: VersionInfoDocumentStub
 }) => {
   const {t} = useTranslation()
 
@@ -116,13 +120,14 @@ const VersionStatus = ({
 
   return (
     <Flex align="center" gap={2}>
-      <ReleaseAvatar release={release} padding={0} />
       <Text size={1}>
         {title} -{' '}
         <span style={{color: 'var(--card-muted-fg-color)'}}>
           {t(labels[mode], {date: relativeTime})}
         </span>
       </Text>
+      <ReleaseAvatar release={release} padding={0} />
+      {version?._system.variant?._ref && <Text size={1}>{version._system.variant?._ref}</Text>}
     </Flex>
   )
 }

--- a/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.css.ts
+++ b/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.css.ts
@@ -1,0 +1,13 @@
+import {style} from '@vanilla-extract/css'
+
+export const versionStatusTitles = style({
+  flex: '0 1 auto',
+  minWidth: 0,
+})
+
+export const variantIconCard = style({
+  vars: {
+    '--card-icon-color': 'var(--card-accent-fg-color)',
+  },
+  backgroundColor: 'transparent',
+})

--- a/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.css.ts
+++ b/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.css.ts
@@ -19,5 +19,9 @@ export const updatedAtText = style({
 })
 
 export const versionStatusItem = style({
-  padding: '2px 0',
+  selectors: {
+    '&&': {
+      padding: '2px 0',
+    },
+  },
 })

--- a/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.css.ts
+++ b/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.css.ts
@@ -1,7 +1,11 @@
 import {style} from '@vanilla-extract/css'
 
 export const variantIconCard = style({
-  backgroundColor: 'transparent',
+  selectors: {
+    '&&': {
+      backgroundColor: 'transparent',
+    },
+  },
 })
 
 export const titleStack = style({

--- a/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.css.ts
+++ b/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.css.ts
@@ -1,13 +1,19 @@
 import {style} from '@vanilla-extract/css'
 
-export const versionStatusTitles = style({
-  flex: '0 1 auto',
-  minWidth: 0,
+export const variantIconCard = style({
+  backgroundColor: 'transparent',
 })
 
-export const variantIconCard = style({
-  vars: {
-    '--card-icon-color': 'var(--card-accent-fg-color)',
-  },
-  backgroundColor: 'transparent',
+export const titleStack = style({
+  minWidth: 0,
+  width: '100%',
+})
+
+export const updatedAtText = style({
+  flex: 'none',
+  whiteSpace: 'nowrap',
+})
+
+export const versionStatusItem = style({
+  padding: '2px 0',
 })

--- a/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
@@ -11,12 +11,20 @@ import {useDocumentVersions} from '../../releases/hooks/useDocumentVersions'
 import {type VersionInfoDocumentStub} from '../../releases/store/types'
 import {useActiveReleases} from '../../releases/store/useActiveReleases'
 import {LATEST, PUBLISHED} from '../../releases/util/const'
+import {useAgentBundles} from '../../store/agent/useAgentBundles'
+import {getVersionFilterLabel} from '../../variants/plugin/components/getVersionFilterLabel'
 import {useAllVariants} from '../../variants/store/useAllVariants'
-import {variantIconCard, versionStatusTitles} from './DocumentVersionsStatus.css'
+import {
+  titleStack,
+  updatedAtText,
+  variantIconCard,
+  versionStatusItem,
+} from './DocumentVersionsStatus.css'
 import {
   type DocumentVersionStatusItem,
   groupDocumentVersionsForStatus,
 } from './sortDocumentVersionsForStatus'
+
 /**
  * Displays document status for all of the versions of a given document.
  *
@@ -52,13 +60,18 @@ export function DocumentVersionsStatus({documentGroupId}: {documentGroupId: stri
 
 function VersionStatus({release, version, variant}: DocumentVersionStatusItem) {
   const {t} = useTranslation()
+  const {bundles} = useAgentBundles()
 
   const variantTitle = variant
     ? variant.metadata?.title || variant.name
     : t('document-group.base-variant')
 
-  const releaseTitle = getReleaseTitle({release, t, version})
   const releasePerspective = getReleasePerspective({release, version})
+  const {
+    displayTitle: releaseTitle,
+    fullTitle,
+    isTruncated,
+  } = getVersionFilterLabel(releasePerspective, t, bundles)
 
   const updatedAt = useRelativeTime(version._updatedAt, {
     minimal: true,
@@ -66,16 +79,20 @@ function VersionStatus({release, version, variant}: DocumentVersionStatusItem) {
   })
 
   return (
-    <Box paddingX={0}>
-      <Flex align="center" gap={2} padding={2} style={{minWidth: 0, width: '100%'}}>
-        <Box className={versionStatusTitles} paddingY={1}>
-          <Text size={1} textOverflow="ellipsis">
-            {variantTitle} · {releaseTitle}
-          </Text>
-        </Box>
-        <Text muted size={1} style={{flex: 'none', whiteSpace: 'nowrap'}}>
-          · {updatedAt}
-        </Text>
+    <Box className={versionStatusItem}>
+      <Flex paddingX={0} gap={2} padding={2}>
+        <Stack className={titleStack} gap={2}>
+          <Box>
+            <Text size={1} title={isTruncated ? fullTitle : undefined} weight="medium">
+              {variantTitle} · {releaseTitle}
+            </Text>
+          </Box>
+          <Box>
+            <Text className={updatedAtText} muted size={1}>
+              {updatedAt}
+            </Text>
+          </Box>
+        </Stack>
         <Box flex={1} />
         <Flex align="center" flex="none" gap={2}>
           {variant ? (
@@ -92,30 +109,6 @@ function VersionStatus({release, version, variant}: DocumentVersionStatusItem) {
   )
 }
 
-function getReleaseTitle({
-  release,
-  t,
-  version,
-}: {
-  release?: ReleaseDocument
-  t: ReturnType<typeof useTranslation>['t']
-  version: VersionInfoDocumentStub
-}): string {
-  if (version._system.release?._ref) {
-    return release?.metadata.title || release?.name || t('release.placeholder-untitled-release')
-  }
-
-  if (version._system.bundleId === 'drafts') {
-    return t('release.chip.draft')
-  }
-
-  if (version._createdAt === version._updatedAt) {
-    return t('timeline.operation.created')
-  }
-
-  return t('release.chip.published')
-}
-
 function getReleasePerspective({
   release,
   version,
@@ -129,6 +122,10 @@ function getReleasePerspective({
 
   if (version._system.bundleId === 'drafts') {
     return LATEST
+  }
+
+  if (version._system.bundleId) {
+    return version._system.bundleId
   }
 
   return PUBLISHED

--- a/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
@@ -32,14 +32,25 @@ import {
  * @internal
  */
 export function DocumentVersionsStatus({documentGroupId}: {documentGroupId: string}) {
+  const {t} = useTranslation()
   const {data: releases} = useActiveReleases()
   const {byId: variantsById} = useAllVariants()
-  const {versions} = useDocumentVersions({documentId: documentGroupId})
+  const {loading, versions} = useDocumentVersions({documentId: documentGroupId})
 
   const versionGroups = useMemo(
     () => groupDocumentVersionsForStatus(versions, releases ?? [], variantsById),
     [releases, variantsById, versions],
   )
+
+  if (loading) {
+    return (
+      <Box padding={2}>
+        <Text muted size={1}>
+          {t('common.loading')}
+        </Text>
+      </Box>
+    )
+  }
 
   return (
     <Stack gap={1}>

--- a/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
@@ -4,6 +4,7 @@ import {useMemo} from 'react'
 
 import {RhombusIcon} from '../../components/temporary-icons/Rhombus'
 import {useRelativeTime} from '../../hooks/useRelativeTime'
+import {useSchema} from '../../hooks/useSchema'
 import {useTranslation} from '../../i18n/hooks/useTranslation'
 import {type TargetPerspective} from '../../perspective/types'
 import {ReleaseAvatar} from '../../releases/components/ReleaseAvatar'
@@ -20,6 +21,7 @@ import {
   variantIconCard,
   versionStatusItem,
 } from './DocumentVersionsStatus.css'
+import {getDocumentVersionStatusTimestampKey} from './getDocumentVersionStatusTimestampKey'
 import {
   type DocumentVersionStatusItem,
   groupDocumentVersionsForStatus,
@@ -71,7 +73,9 @@ export function DocumentVersionsStatus({documentGroupId}: {documentGroupId: stri
 
 function VersionStatus({release, version, variant}: DocumentVersionStatusItem) {
   const {t} = useTranslation()
+  const schema = useSchema()
   const {bundles} = useAgentBundles()
+  const liveEdit = Boolean(version._type && schema.get(version._type)?.liveEdit)
 
   const variantTitle = variant
     ? variant.metadata?.title || variant.name
@@ -88,6 +92,9 @@ function VersionStatus({release, version, variant}: DocumentVersionStatusItem) {
     minimal: true,
     useTemporalPhrase: true,
   })
+  const timestampLabel = t(getDocumentVersionStatusTimestampKey(version, liveEdit), {
+    date: updatedAt,
+  })
 
   return (
     <Box className={versionStatusItem}>
@@ -100,12 +107,12 @@ function VersionStatus({release, version, variant}: DocumentVersionStatusItem) {
           </Box>
           <Box>
             <Text className={updatedAtText} muted size={1}>
-              {updatedAt}
+              {timestampLabel}
             </Text>
           </Box>
         </Stack>
         <Box flex={1} />
-        <Flex align="center" flex="none" gap={2}>
+        <Flex align="center" flex="none" gap={1} paddingRight={2}>
           {variant ? (
             <Card className={variantIconCard} tone="suggest">
               <Text size={2}>

--- a/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
@@ -13,8 +13,10 @@ import {type VersionInfoDocumentStub} from '../../releases/store/types'
 import {useActiveReleases} from '../../releases/store/useActiveReleases'
 import {LATEST, PUBLISHED} from '../../releases/util/const'
 import {useAgentBundles} from '../../store/agent/useAgentBundles'
+import {readVersionType} from '../../util/versionsUtils'
 import {getVersionFilterLabel} from '../../variants/plugin/components/getVersionFilterLabel'
 import {useAllVariants} from '../../variants/store/useAllVariants'
+import {getVariantTitle} from '../../variants/tool/util'
 import {
   titleStack,
   updatedAtText,
@@ -77,9 +79,7 @@ function VersionStatus({release, version, variant}: DocumentVersionStatusItem) {
   const {bundles} = useAgentBundles()
   const liveEdit = Boolean(version._type && schema.get(version._type)?.liveEdit)
 
-  const variantTitle = variant
-    ? variant.metadata?.title || variant.name
-    : t('document-group.base-variant')
+  const variantTitle = variant ? getVariantTitle(variant) : t('document-group.base-variant')
 
   const releasePerspective = getReleasePerspective({release, version})
   const {
@@ -98,20 +98,15 @@ function VersionStatus({release, version, variant}: DocumentVersionStatusItem) {
 
   return (
     <Box className={versionStatusItem}>
-      <Flex paddingX={0} gap={2} padding={2}>
+      <Flex gap={2} justify="space-between" paddingY={2}>
         <Stack className={titleStack} gap={2}>
-          <Box>
-            <Text size={1} title={isTruncated ? fullTitle : undefined} weight="medium">
-              {variantTitle} · {releaseTitle}
-            </Text>
-          </Box>
-          <Box>
-            <Text className={updatedAtText} muted size={1}>
-              {timestampLabel}
-            </Text>
-          </Box>
+          <Text size={1} title={isTruncated ? fullTitle : undefined} weight="medium">
+            {variantTitle} · {releaseTitle}
+          </Text>
+          <Text className={updatedAtText} muted size={1}>
+            {timestampLabel}
+          </Text>
         </Stack>
-        <Box flex={1} />
         <Flex align="center" flex="none" gap={1} paddingRight={2}>
           {variant ? (
             <Card className={variantIconCard} tone="suggest">
@@ -134,17 +129,15 @@ function getReleasePerspective({
   release?: ReleaseDocument
   version: VersionInfoDocumentStub
 }): TargetPerspective {
-  if (release) {
-    return release
+  switch (readVersionType(version)) {
+    case 'draft':
+      return LATEST
+    case 'release':
+      return release ?? version._system.bundleId ?? PUBLISHED
+    case 'agent':
+      return version._system.bundleId ?? PUBLISHED
+    case 'published':
+    default:
+      return PUBLISHED
   }
-
-  if (version._system.bundleId === 'drafts') {
-    return LATEST
-  }
-
-  if (version._system.bundleId) {
-    return version._system.bundleId
-  }
-
-  return PUBLISHED
 }

--- a/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
+++ b/packages/sanity/src/core/components/documentStatus/DocumentVersionsStatus.tsx
@@ -1,0 +1,135 @@
+import {type ReleaseDocument} from '@sanity/client'
+import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
+import {useMemo} from 'react'
+
+import {RhombusIcon} from '../../components/temporary-icons/Rhombus'
+import {useRelativeTime} from '../../hooks/useRelativeTime'
+import {useTranslation} from '../../i18n/hooks/useTranslation'
+import {type TargetPerspective} from '../../perspective/types'
+import {ReleaseAvatar} from '../../releases/components/ReleaseAvatar'
+import {useDocumentVersions} from '../../releases/hooks/useDocumentVersions'
+import {type VersionInfoDocumentStub} from '../../releases/store/types'
+import {useActiveReleases} from '../../releases/store/useActiveReleases'
+import {LATEST, PUBLISHED} from '../../releases/util/const'
+import {useAllVariants} from '../../variants/store/useAllVariants'
+import {variantIconCard, versionStatusTitles} from './DocumentVersionsStatus.css'
+import {
+  type DocumentVersionStatusItem,
+  groupDocumentVersionsForStatus,
+} from './sortDocumentVersionsForStatus'
+/**
+ * Displays document status for all of the versions of a given document.
+ *
+ *
+ * @internal
+ */
+export function DocumentVersionsStatus({documentGroupId}: {documentGroupId: string}) {
+  const {data: releases} = useActiveReleases()
+  const {byId: variantsById} = useAllVariants()
+  const {versions} = useDocumentVersions({documentId: documentGroupId})
+
+  const versionGroups = useMemo(
+    () => groupDocumentVersionsForStatus(versions, releases ?? [], variantsById),
+    [releases, variantsById, versions],
+  )
+
+  return (
+    <Stack gap={1}>
+      {versionGroups.map((group, groupIndex, allGroups) => (
+        <Card
+          borderBottom={groupIndex < allGroups.length - 1}
+          key={group.variantId ?? 'default'}
+          paddingBottom={groupIndex < allGroups.length - 1 ? 1 : 0}
+        >
+          {group.items.map((item) => (
+            <VersionStatus key={item.version._id} {...item} />
+          ))}
+        </Card>
+      ))}
+    </Stack>
+  )
+}
+
+function VersionStatus({release, version, variant}: DocumentVersionStatusItem) {
+  const {t} = useTranslation()
+
+  const variantTitle = variant
+    ? variant.metadata?.title || variant.name
+    : t('document-group.base-variant')
+
+  const releaseTitle = getReleaseTitle({release, t, version})
+  const releasePerspective = getReleasePerspective({release, version})
+
+  const updatedAt = useRelativeTime(version._updatedAt, {
+    minimal: true,
+    useTemporalPhrase: true,
+  })
+
+  return (
+    <Box paddingX={0}>
+      <Flex align="center" gap={2} padding={2} style={{minWidth: 0, width: '100%'}}>
+        <Box className={versionStatusTitles} paddingY={1}>
+          <Text size={1} textOverflow="ellipsis">
+            {variantTitle} · {releaseTitle}
+          </Text>
+        </Box>
+        <Text muted size={1} style={{flex: 'none', whiteSpace: 'nowrap'}}>
+          · {updatedAt}
+        </Text>
+        <Box flex={1} />
+        <Flex align="center" flex="none" gap={2}>
+          {variant ? (
+            <Card className={variantIconCard} tone="suggest">
+              <Text size={2}>
+                <RhombusIcon />
+              </Text>
+            </Card>
+          ) : null}
+          <ReleaseAvatar fontSize={2} size="small" release={releasePerspective} padding={0} />
+        </Flex>
+      </Flex>
+    </Box>
+  )
+}
+
+function getReleaseTitle({
+  release,
+  t,
+  version,
+}: {
+  release?: ReleaseDocument
+  t: ReturnType<typeof useTranslation>['t']
+  version: VersionInfoDocumentStub
+}): string {
+  if (version._system.release?._ref) {
+    return release?.metadata.title || release?.name || t('release.placeholder-untitled-release')
+  }
+
+  if (version._system.bundleId === 'drafts') {
+    return t('release.chip.draft')
+  }
+
+  if (version._createdAt === version._updatedAt) {
+    return t('timeline.operation.created')
+  }
+
+  return t('release.chip.published')
+}
+
+function getReleasePerspective({
+  release,
+  version,
+}: {
+  release?: ReleaseDocument
+  version: VersionInfoDocumentStub
+}): TargetPerspective {
+  if (release) {
+    return release
+  }
+
+  if (version._system.bundleId === 'drafts') {
+    return LATEST
+  }
+
+  return PUBLISHED
+}

--- a/packages/sanity/src/core/components/documentStatus/__tests__/getDocumentVersionStatusTimestampKey.test.ts
+++ b/packages/sanity/src/core/components/documentStatus/__tests__/getDocumentVersionStatusTimestampKey.test.ts
@@ -1,0 +1,129 @@
+import {describe, expect, it} from 'vitest'
+
+import {type VersionInfoDocumentStub} from '../../../releases/store/types'
+import {getDocumentVersionStatusTimestampKey} from '../getDocumentVersionStatusTimestampKey'
+
+const CREATED_AT = '2026-01-01T00:00:00.000Z'
+const UPDATED_AT = '2026-01-02T00:00:00.000Z'
+
+function createVersion({
+  id,
+  bundleId,
+  createdAt = CREATED_AT,
+  updatedAt = UPDATED_AT,
+  releaseRef,
+  variantRef,
+}: {
+  id: string
+  bundleId?: string
+  createdAt?: string
+  updatedAt?: string
+  releaseRef?: string
+  variantRef?: string
+}): VersionInfoDocumentStub {
+  return {
+    _id: id,
+    _rev: `${id}-rev`,
+    _createdAt: createdAt,
+    _updatedAt: updatedAt,
+    _type: 'article',
+    _system: {
+      bundleId,
+      group: {_ref: 'article-1', _weak: true},
+      release: releaseRef ? {_ref: releaseRef, _weak: true} : undefined,
+      variant: variantRef ? {_ref: variantRef, _weak: true} : undefined,
+    },
+  }
+}
+
+describe('getDocumentVersionStatusTimestampKey', () => {
+  it('uses Published for a published document that is not live-edit', () => {
+    expect(getDocumentVersionStatusTimestampKey(createVersion({id: 'article-1'}), false)).toBe(
+      'document-status.published-at',
+    )
+  })
+
+  it('uses Published for a published document even when it has never been edited', () => {
+    expect(
+      getDocumentVersionStatusTimestampKey(
+        createVersion({id: 'article-1', createdAt: CREATED_AT, updatedAt: CREATED_AT}),
+        false,
+      ),
+    ).toBe('document-status.published-at')
+  })
+
+  it('uses Published for a published variant that is not live-edit', () => {
+    expect(
+      getDocumentVersionStatusTimestampKey(
+        createVersion({id: 'published.scope.article-1', variantRef: '_.variants.a'}),
+        false,
+      ),
+    ).toBe('document-status.published-at')
+  })
+
+  it('uses Edited for a live-edit published document that has been updated', () => {
+    expect(getDocumentVersionStatusTimestampKey(createVersion({id: 'article-1'}), true)).toBe(
+      'document-status.edited',
+    )
+  })
+
+  it('uses Created for a live-edit published document that has never been edited', () => {
+    expect(
+      getDocumentVersionStatusTimestampKey(
+        createVersion({id: 'article-1', createdAt: CREATED_AT, updatedAt: CREATED_AT}),
+        true,
+      ),
+    ).toBe('document-status.created')
+  })
+
+  it('uses Created for a draft that has never been edited', () => {
+    expect(
+      getDocumentVersionStatusTimestampKey(
+        createVersion({
+          id: 'drafts.article-1',
+          bundleId: 'drafts',
+          createdAt: CREATED_AT,
+          updatedAt: CREATED_AT,
+        }),
+        false,
+      ),
+    ).toBe('document-status.created')
+  })
+
+  it('uses Edited for a draft that has been updated', () => {
+    expect(
+      getDocumentVersionStatusTimestampKey(
+        createVersion({id: 'drafts.article-1', bundleId: 'drafts'}),
+        false,
+      ),
+    ).toBe('document-status.edited')
+  })
+
+  it('uses Created for a release version that has never been edited', () => {
+    expect(
+      getDocumentVersionStatusTimestampKey(
+        createVersion({
+          id: 'versions.rSummer.article-1',
+          bundleId: 'rSummer',
+          createdAt: CREATED_AT,
+          updatedAt: CREATED_AT,
+          releaseRef: '_.releases.rSummer',
+        }),
+        false,
+      ),
+    ).toBe('document-status.created')
+  })
+
+  it('uses Edited for a release version that has been updated', () => {
+    expect(
+      getDocumentVersionStatusTimestampKey(
+        createVersion({
+          id: 'versions.rSummer.article-1',
+          bundleId: 'rSummer',
+          releaseRef: '_.releases.rSummer',
+        }),
+        false,
+      ),
+    ).toBe('document-status.edited')
+  })
+})

--- a/packages/sanity/src/core/components/documentStatus/__tests__/sortDocumentVersionsForStatus.test.ts
+++ b/packages/sanity/src/core/components/documentStatus/__tests__/sortDocumentVersionsForStatus.test.ts
@@ -1,0 +1,197 @@
+import {describe, expect, it} from 'vitest'
+
+import {type VersionInfoDocumentStub} from '../../../releases/store/types'
+import {type SystemVariant} from '../../../variants/types'
+import {groupDocumentVersionsForStatus} from '../sortDocumentVersionsForStatus'
+
+const GROUP_ID = 'article-1'
+
+function createVersion({
+  id,
+  bundleId,
+  createdAt,
+  updatedAt,
+  releaseRef,
+  variantRef,
+}: {
+  id: string
+  bundleId?: string
+  createdAt: string
+  updatedAt: string
+  releaseRef?: string
+  variantRef?: string
+}): VersionInfoDocumentStub {
+  return {
+    _id: id,
+    _rev: `${id}-rev`,
+    _createdAt: createdAt,
+    _updatedAt: updatedAt,
+    _system: {
+      bundleId,
+      group: {_ref: GROUP_ID, _weak: true},
+      release: releaseRef ? {_ref: releaseRef, _weak: true} : undefined,
+      variant: variantRef ? {_ref: variantRef, _weak: true} : undefined,
+    },
+  }
+}
+
+const variantReturning: SystemVariant = {
+  _id: '_.variants.returning',
+  _type: 'system.variant',
+  _createdAt: '2025-01-01T00:00:00Z',
+  _updatedAt: '2025-01-01T00:00:00Z',
+  _rev: 'variant-returning-rev',
+  conditions: {},
+  priority: 0,
+  metadata: {title: 'Returning visitors'},
+}
+
+const variantFirstTime: SystemVariant = {
+  _id: '_.variants.first-time',
+  _type: 'system.variant',
+  _createdAt: '2025-01-01T00:00:00Z',
+  _updatedAt: '2025-01-01T00:00:00Z',
+  _rev: 'variant-first-time-rev',
+  conditions: {},
+  priority: 0,
+  metadata: {title: 'First-time visitors'},
+}
+
+const releaseSummer = {
+  _id: '_.releases.rSummer',
+  _type: 'system.release',
+  _createdAt: '2025-01-01T00:00:00Z',
+  _updatedAt: '2025-01-01T00:00:00Z',
+  _rev: 'release-summer-rev',
+  name: 'rSummer',
+  metadata: {
+    title: 'Summer Campaign',
+    releaseType: 'scheduled',
+  },
+  state: 'active',
+} as const
+
+const releaseHalloween = {
+  _id: '_.releases.rHalloween',
+  _type: 'system.release',
+  _createdAt: '2025-01-02T00:00:00Z',
+  _updatedAt: '2025-01-02T00:00:00Z',
+  _rev: 'release-halloween-rev',
+  name: 'rHalloween',
+  metadata: {
+    title: 'Halloween',
+    releaseType: 'scheduled',
+  },
+  state: 'active',
+} as const
+
+const releaseAsap = {
+  _id: '_.releases.rASAP',
+  _type: 'system.release',
+  _createdAt: '2025-01-03T00:00:00Z',
+  _updatedAt: '2025-01-03T00:00:00Z',
+  _rev: 'release-asap-rev',
+  name: 'rASAP',
+  metadata: {
+    title: 'ASAP',
+    releaseType: 'asap',
+  },
+  state: 'active',
+} as const
+
+describe('groupDocumentVersionsForStatus', () => {
+  it('groups default variant first, then sorts variants by id', () => {
+    const groups = groupDocumentVersionsForStatus(
+      [
+        createVersion({
+          id: 'drafts.first-time.article-1',
+          bundleId: 'drafts',
+          createdAt: '2025-06-01T00:00:00Z',
+          updatedAt: '2025-06-01T00:00:00Z',
+          variantRef: variantFirstTime._id,
+        }),
+        createVersion({
+          id: 'article-1',
+          createdAt: '2025-06-02T00:00:00Z',
+          updatedAt: '2025-06-02T00:00:00Z',
+        }),
+        createVersion({
+          id: 'drafts.returning.article-1',
+          bundleId: 'drafts',
+          createdAt: '2025-06-01T00:00:00Z',
+          updatedAt: '2025-06-01T00:00:00Z',
+          variantRef: variantReturning._id,
+        }),
+      ],
+      [],
+      new Map([
+        [variantReturning._id, variantReturning],
+        [variantFirstTime._id, variantFirstTime],
+      ]),
+    )
+
+    expect(groups.map((group) => group.variantId)).toEqual([
+      undefined,
+      variantFirstTime._id,
+      variantReturning._id,
+    ])
+  })
+
+  it('sorts bundles within a variant as published, drafts, then releases by title', () => {
+    const groups = groupDocumentVersionsForStatus(
+      [
+        createVersion({
+          id: 'versions.rASAP.scope.article-1',
+          bundleId: 'rASAP',
+          createdAt: '2025-06-04T00:00:00Z',
+          updatedAt: '2025-06-04T00:00:00Z',
+          releaseRef: releaseAsap._id,
+          variantRef: variantReturning._id,
+        }),
+        createVersion({
+          id: 'drafts.returning.article-1',
+          bundleId: 'drafts',
+          createdAt: '2025-06-01T00:00:00Z',
+          updatedAt: '2025-06-01T00:00:00Z',
+          variantRef: variantReturning._id,
+        }),
+        createVersion({
+          id: 'published.scope.article-1',
+          createdAt: '2025-06-03T00:00:00Z',
+          updatedAt: '2025-06-03T00:00:00Z',
+          variantRef: variantReturning._id,
+        }),
+        createVersion({
+          id: 'versions.rSummer.scope.article-1',
+          bundleId: 'rSummer',
+          createdAt: '2025-06-02T00:00:00Z',
+          updatedAt: '2025-06-02T00:00:00Z',
+          releaseRef: releaseSummer._id,
+        }),
+        createVersion({
+          id: 'versions.rHalloween.scope.article-1',
+          bundleId: 'rHalloween',
+          createdAt: '2025-06-05T00:00:00Z',
+          updatedAt: '2025-06-05T00:00:00Z',
+          releaseRef: releaseHalloween._id,
+          variantRef: variantReturning._id,
+        }),
+      ],
+      [releaseSummer, releaseHalloween, releaseAsap],
+      new Map([
+        [variantReturning._id, variantReturning],
+        [variantFirstTime._id, variantFirstTime],
+      ]),
+    )
+
+    expect(groups[0]?.items.map((item) => item.version._id)).toEqual([
+      'versions.rSummer.scope.article-1',
+    ])
+    expect(groups[1]?.items.map((item) => item.version._id)).toEqual([
+      'published.scope.article-1',
+      'drafts.returning.article-1',
+      'versions.rHalloween.scope.article-1',
+      'versions.rASAP.scope.article-1',
+    ])
+  })
+})

--- a/packages/sanity/src/core/components/documentStatus/__tests__/sortDocumentVersionsForStatus.test.ts
+++ b/packages/sanity/src/core/components/documentStatus/__tests__/sortDocumentVersionsForStatus.test.ts
@@ -23,6 +23,7 @@ function createVersion({
 }): VersionInfoDocumentStub {
   return {
     _id: id,
+    _type: 'version',
     _rev: `${id}-rev`,
     _createdAt: createdAt,
     _updatedAt: updatedAt,
@@ -192,6 +193,46 @@ describe('groupDocumentVersionsForStatus', () => {
       'drafts.returning.article-1',
       'versions.rHalloween.scope.article-1',
       'versions.rASAP.scope.article-1',
+    ])
+  })
+
+  it('sorts agent versions after published, drafts, and releases', () => {
+    const groups = groupDocumentVersionsForStatus(
+      [
+        createVersion({
+          id: 'versions.agent-abc.article-1',
+          bundleId: 'agent-abc',
+          createdAt: '2025-06-01T00:00:00Z',
+          updatedAt: '2025-06-01T00:00:00Z',
+        }),
+        createVersion({
+          id: 'drafts.article-1',
+          bundleId: 'drafts',
+          createdAt: '2025-06-01T00:00:00Z',
+          updatedAt: '2025-06-01T00:00:00Z',
+        }),
+        createVersion({
+          id: 'article-1',
+          createdAt: '2025-06-02T00:00:00Z',
+          updatedAt: '2025-06-02T00:00:00Z',
+        }),
+        createVersion({
+          id: 'versions.rSummer.article-1',
+          bundleId: 'rSummer',
+          createdAt: '2025-06-02T00:00:00Z',
+          updatedAt: '2025-06-02T00:00:00Z',
+          releaseRef: releaseSummer._id,
+        }),
+      ],
+      [releaseSummer],
+      new Map(),
+    )
+
+    expect(groups[0]?.items.map((item) => item.version._id)).toEqual([
+      'article-1',
+      'drafts.article-1',
+      'versions.rSummer.article-1',
+      'versions.agent-abc.article-1',
     ])
   })
 })

--- a/packages/sanity/src/core/components/documentStatus/getDocumentVersionStatusTimestampKey.ts
+++ b/packages/sanity/src/core/components/documentStatus/getDocumentVersionStatusTimestampKey.ts
@@ -1,0 +1,31 @@
+import {type StudioLocaleResourceKeys} from '../../i18n/bundles/studio'
+import {type VersionInfoDocumentStub} from '../../releases/store/types'
+import {isPublishedVersion} from '../../util/versionsUtils'
+
+type DocumentVersionStatusTimestampKey = Extract<
+  StudioLocaleResourceKeys,
+  'document-status.created' | 'document-status.edited' | 'document-status.published-at'
+>
+
+/**
+ * Relative-time label for a document version in the versions status tooltip.
+ *
+ * Published (non-live-edit) versions always use "Published". Everything else uses "Created"
+ * when `_createdAt` matches `_updatedAt`, otherwise "Edited".
+ *
+ * @internal
+ */
+export function getDocumentVersionStatusTimestampKey(
+  version: VersionInfoDocumentStub,
+  liveEdit: boolean,
+): DocumentVersionStatusTimestampKey {
+  if (isPublishedVersion(version) && !liveEdit) {
+    return 'document-status.published-at'
+  }
+
+  if (version._createdAt === version._updatedAt) {
+    return 'document-status.created'
+  }
+
+  return 'document-status.edited'
+}

--- a/packages/sanity/src/core/components/documentStatus/sortDocumentVersionsForStatus.ts
+++ b/packages/sanity/src/core/components/documentStatus/sortDocumentVersionsForStatus.ts
@@ -1,0 +1,149 @@
+import {type ReleaseDocument} from '@sanity/client'
+
+import {sortReleases} from '../../releases/hooks/utils'
+import {type VersionInfoDocumentStub} from '../../releases/store/types'
+import {type SystemVariant} from '../../variants/types'
+
+type ReleaseLaneKind = 'published' | 'drafts' | 'release'
+
+interface ResolvedVersionBundle {
+  id: string
+  kind: ReleaseLaneKind
+  release?: ReleaseDocument
+}
+
+/**
+ * @internal
+ */
+export interface DocumentVersionStatusItem {
+  version: VersionInfoDocumentStub
+  variant?: SystemVariant
+  release?: ReleaseDocument
+}
+
+/**
+ * @internal
+ */
+export interface DocumentVersionStatusGroup {
+  variantId?: string
+  items: DocumentVersionStatusItem[]
+}
+
+function getKindOrder(kind: ReleaseLaneKind): number {
+  if (kind === 'published') return 0
+  if (kind === 'drafts') return 1
+  return 2
+}
+
+function bundleSortLabel(bundle: ResolvedVersionBundle): string {
+  return bundle.release?.metadata?.title ?? bundle.id
+}
+
+function compareResolvedBundles(
+  left: ResolvedVersionBundle,
+  right: ResolvedVersionBundle,
+  sortedReleases: ReleaseDocument[],
+): number {
+  const kindDelta = getKindOrder(left.kind) - getKindOrder(right.kind)
+  if (kindDelta !== 0) {
+    return kindDelta
+  }
+
+  if (left.kind === 'release' && right.kind === 'release') {
+    const leftIndex = sortedReleases.findIndex((release) => release._id === left.id)
+    const rightIndex = sortedReleases.findIndex((release) => release._id === right.id)
+    const normalizedLeftIndex = leftIndex === -1 ? Number.MAX_SAFE_INTEGER : leftIndex
+    const normalizedRightIndex = rightIndex === -1 ? Number.MAX_SAFE_INTEGER : rightIndex
+
+    if (normalizedLeftIndex !== normalizedRightIndex) {
+      return normalizedLeftIndex - normalizedRightIndex
+    }
+  }
+
+  return bundleSortLabel(left).localeCompare(bundleSortLabel(right))
+}
+
+function resolveVersionBundle(
+  version: VersionInfoDocumentStub,
+  releasesById: Map<string, ReleaseDocument>,
+): ResolvedVersionBundle {
+  if (version._system.release?._ref) {
+    const releaseRef = version._system.release._ref
+    const release = releasesById.get(releaseRef)
+    return {id: release?._id ?? releaseRef, kind: 'release', release}
+  }
+
+  if (version._system.bundleId === 'drafts') {
+    return {id: 'drafts', kind: 'drafts'}
+  }
+
+  return {id: 'published', kind: 'published'}
+}
+
+function compareDocumentVersionsForStatus(
+  left: VersionInfoDocumentStub,
+  right: VersionInfoDocumentStub,
+  releasesById: Map<string, ReleaseDocument>,
+  sortedReleases: ReleaseDocument[],
+): number {
+  const leftVariantId = left._system.variant?._ref ?? ''
+  const rightVariantId = right._system.variant?._ref ?? ''
+
+  if (leftVariantId !== rightVariantId) {
+    if (!leftVariantId) return -1
+    if (!rightVariantId) return 1
+    return leftVariantId.localeCompare(rightVariantId)
+  }
+
+  return compareResolvedBundles(
+    resolveVersionBundle(left, releasesById),
+    resolveVersionBundle(right, releasesById),
+    sortedReleases,
+  )
+}
+
+/**
+ * Groups document versions by variant (default first, then by variant id) and sorts each group
+ * published → drafts → releases (by release title).
+ *
+ * @internal
+ */
+export function groupDocumentVersionsForStatus(
+  versions: VersionInfoDocumentStub[],
+  releases: ReleaseDocument[],
+  variantsById: Map<string, SystemVariant>,
+): DocumentVersionStatusGroup[] {
+  const sortedReleases = sortReleases(releases)
+  const releasesById = new Map(sortedReleases.map((release) => [release._id, release]))
+
+  const sortedVersions = versions.toSorted((left, right) =>
+    compareDocumentVersionsForStatus(left, right, releasesById, sortedReleases),
+  )
+
+  const groups: DocumentVersionStatusGroup[] = []
+
+  for (const version of sortedVersions) {
+    const variantId = version._system.variant?._ref
+    const lastGroup = groups.at(-1)
+
+    const item: DocumentVersionStatusItem = {
+      version,
+      variant: variantId ? variantsById.get(variantId) : undefined,
+      release: version._system.release?._ref
+        ? releasesById.get(version._system.release._ref)
+        : undefined,
+    }
+
+    if (lastGroup && lastGroup.variantId === variantId) {
+      lastGroup.items.push(item)
+      continue
+    }
+
+    groups.push({
+      variantId,
+      items: [item],
+    })
+  }
+
+  return groups
+}

--- a/packages/sanity/src/core/components/documentStatus/sortDocumentVersionsForStatus.ts
+++ b/packages/sanity/src/core/components/documentStatus/sortDocumentVersionsForStatus.ts
@@ -104,7 +104,8 @@ function compareDocumentVersionsForStatus(
 
 /**
  * Groups document versions by variant (default first, then by variant id) and sorts each group
- * published → drafts → releases (by release title).
+ * published → drafts → releases. Releases follow `sortReleases()`: undecided, then scheduled,
+ * then ASAP (each by date descending). Releases missing from that list fall back to title.
  *
  * @internal
  */

--- a/packages/sanity/src/core/components/documentStatus/sortDocumentVersionsForStatus.ts
+++ b/packages/sanity/src/core/components/documentStatus/sortDocumentVersionsForStatus.ts
@@ -2,9 +2,17 @@ import {type ReleaseDocument} from '@sanity/client'
 
 import {sortReleases} from '../../releases/hooks/utils'
 import {type VersionInfoDocumentStub} from '../../releases/store/types'
+import {readVersionType} from '../../util/versionsUtils'
 import {type SystemVariant} from '../../variants/types'
 
-type ReleaseLaneKind = 'published' | 'drafts' | 'release'
+type ReleaseLaneKind = 'published' | 'drafts' | 'release' | 'agent'
+
+const KIND_ORDER: Record<ReleaseLaneKind, number> = {
+  published: 0,
+  drafts: 1,
+  release: 2,
+  agent: 3,
+}
 
 interface ResolvedVersionBundle {
   id: string
@@ -29,12 +37,6 @@ export interface DocumentVersionStatusGroup {
   items: DocumentVersionStatusItem[]
 }
 
-function getKindOrder(kind: ReleaseLaneKind): number {
-  if (kind === 'published') return 0
-  if (kind === 'drafts') return 1
-  return 2
-}
-
 function bundleSortLabel(bundle: ResolvedVersionBundle): string {
   return bundle.release?.metadata?.title ?? bundle.id
 }
@@ -44,7 +46,7 @@ function compareResolvedBundles(
   right: ResolvedVersionBundle,
   sortedReleases: ReleaseDocument[],
 ): number {
-  const kindDelta = getKindOrder(left.kind) - getKindOrder(right.kind)
+  const kindDelta = KIND_ORDER[left.kind] - KIND_ORDER[right.kind]
   if (kindDelta !== 0) {
     return kindDelta
   }
@@ -67,17 +69,20 @@ function resolveVersionBundle(
   version: VersionInfoDocumentStub,
   releasesById: Map<string, ReleaseDocument>,
 ): ResolvedVersionBundle {
-  if (version._system.release?._ref) {
-    const releaseRef = version._system.release._ref
-    const release = releasesById.get(releaseRef)
-    return {id: release?._id ?? releaseRef, kind: 'release', release}
+  switch (readVersionType(version)) {
+    case 'release': {
+      const releaseRef = version._system.release?._ref
+      const release = releaseRef ? releasesById.get(releaseRef) : undefined
+      return {id: release?._id ?? releaseRef ?? version._id, kind: 'release', release}
+    }
+    case 'draft':
+      return {id: 'drafts', kind: 'drafts'}
+    case 'agent':
+      return {id: version._system.bundleId ?? version._id, kind: 'agent'}
+    case 'published':
+    default:
+      return {id: 'published', kind: 'published'}
   }
-
-  if (version._system.bundleId === 'drafts') {
-    return {id: 'drafts', kind: 'drafts'}
-  }
-
-  return {id: 'published', kind: 'published'}
 }
 
 function compareDocumentVersionsForStatus(
@@ -104,8 +109,8 @@ function compareDocumentVersionsForStatus(
 
 /**
  * Groups document versions by variant (default first, then by variant id) and sorts each group
- * published → drafts → releases. Releases follow `sortReleases()`: undecided, then scheduled,
- * then ASAP (each by date descending). Releases missing from that list fall back to title.
+ * published → drafts → releases → agent bundles. Releases follow `sortReleases()`: undecided, then
+ * scheduled, then ASAP (each by date descending). Releases missing from that list fall back to title.
  *
  * @internal
  */

--- a/packages/sanity/src/core/documentGroupInventory/components/TextButton.tsx
+++ b/packages/sanity/src/core/documentGroupInventory/components/TextButton.tsx
@@ -8,6 +8,7 @@ export const TextButton = styled.button(({theme}) => {
     all: unset;
     display: inline-block;
     max-inline-size: 100%;
+    white-space: nowrap;
     appearance: none;
     border: 0;
     margin: 0;

--- a/packages/sanity/src/core/form/inputs/ReferenceInput/ReferencePreview.tsx
+++ b/packages/sanity/src/core/form/inputs/ReferenceInput/ReferencePreview.tsx
@@ -3,12 +3,11 @@ import {Badge, Inline} from '@sanity/ui'
 import {useMemo} from 'react'
 import {Box} from 'ui5'
 
-import {DocumentStatus} from '../../../components/documentStatus/DocumentStatus'
+import {DocumentVersionsStatus} from '../../../components/documentStatus/DocumentVersionsStatus'
 import {DocumentVersionsStatusIndicator} from '../../../components/documentStatusIndicator/DocumentVersionsStatusIndicator'
 import {type PreviewLayoutKey} from '../../../components/previews/types'
 import {DocumentPreviewPresence} from '../../../presence/DocumentPreviewPresence'
 import {useDocumentVersions} from '../../../releases/hooks/useDocumentVersions'
-import {getDocumentVersionInfoFromVersions} from '../../../releases/util/getDocumentVersionInfoFromVersions'
 import {useDocumentPresence} from '../../../store/presence/useDocumentPresence'
 import {type RenderPreviewCallback} from '../../types/renderCallback'
 
@@ -28,7 +27,6 @@ export function ReferencePreview(props: {
   const documentPresence = useDocumentPresence(id)
 
   const {versions} = useDocumentVersions({documentId: id})
-  const versionsInfo = useMemo(() => getDocumentVersionInfoFromVersions(versions), [versions])
 
   // Note: we can't pass the preview values as-is to the Preview-component here since it's a "prepared" value and the
   // Preview component expects the "raw"/unprepared value. By passing only _id and _type we make sure the Preview-component
@@ -52,26 +50,10 @@ export function ReferencePreview(props: {
       ),
       layout,
       schemaType: refType,
-      tooltip: (
-        <DocumentStatus
-          draft={versionsInfo.draft}
-          published={versionsInfo.published}
-          versions={versionsInfo.versions}
-        />
-      ),
+      tooltip: <DocumentVersionsStatus documentGroupId={id} />,
       value: previewStub,
     }),
-    [
-      documentPresence,
-      layout,
-      previewStub,
-      refType,
-      showTypeLabel,
-      versions,
-      versionsInfo.draft,
-      versionsInfo.published,
-      versionsInfo.versions,
-    ],
+    [documentPresence, id, layout, previewStub, refType, showTypeLabel, versions],
   )
 
   return renderPreview(previewProps)

--- a/packages/sanity/src/core/i18n/bundles/studio.ts
+++ b/packages/sanity/src/core/i18n/bundles/studio.ts
@@ -633,6 +633,8 @@ export const studioLocaleStrings = defineLocalesResources('studio', {
   'document-status.not-published': 'Not published',
   /** Label to show in the document footer indicating the published date of the document */
   'document-status.published': 'Edited {{date}}',
+  /** Label to show in document versions status for a published (non-live-edit) document */
+  'document-status.published-at': 'Published {{date}}',
   /** Label to show in the document footer indicating the revision from date of the document */
   'document-status.revision-from': 'Revision from <em>{{date}}</em>',
 

--- a/packages/sanity/src/core/scheduled-publishing/components/scheduleItem/PreviewWrapper.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/scheduleItem/PreviewWrapper.tsx
@@ -5,7 +5,7 @@ import {styled} from 'styled-components'
 import {Box} from 'ui5'
 
 import {Tooltip} from '../../../../ui-components/tooltip/Tooltip'
-import {DocumentStatus} from '../../../components/documentStatus/DocumentStatus'
+import {DocumentVersionsStatus} from '../../../components/documentStatus/DocumentVersionsStatus'
 import {DocumentVersionsStatusIndicator} from '../../../components/documentStatusIndicator/DocumentVersionsStatusIndicator'
 import {useTimeZone} from '../../../hooks/useTimeZone'
 import {SanityDefaultPreview} from '../../../preview/components/SanityDefaultPreview'
@@ -17,7 +17,6 @@ import {
   SCHEDULE_ACTION_DICTIONARY,
 } from '../../constants'
 import {type Schedule} from '../../types'
-import {type PaneItemPreviewState} from '../../utils/paneItemHelpers'
 import {getLastExecuteDate} from '../../utils/scheduleUtils'
 import {EMPTY_VALIDATION_STATUS, useValidationState} from '../../utils/validationUtils'
 import {ValidateScheduleDoc} from '../validation/SchedulesValidation'
@@ -34,7 +33,6 @@ interface Props {
   contextMenu?: ReactNode
   linkComponent?: ElementType | keyof React.JSX.IntrinsicElements
   onClick?: () => void
-  previewState?: PaneItemPreviewState
   publishedDocumentId?: string
   schedule: Schedule
   schemaType?: SchemaType
@@ -47,7 +45,6 @@ const PreviewWrapper = (props: Props) => {
     contextMenu,
     linkComponent,
     onClick,
-    previewState,
     publishedDocumentId,
     schedule,
     schemaType,
@@ -75,9 +72,11 @@ const PreviewWrapper = (props: Props) => {
           delay={{open: 400}}
           placement="bottom-end"
           content={
-            <DocumentStatus draft={previewState?.draft} published={previewState?.published} />
+            publishedDocumentId ? (
+              <DocumentVersionsStatus documentGroupId={publishedDocumentId} />
+            ) : null
           }
-          disabled={!previewState?.draft && !previewState?.published}
+          disabled={!publishedDocumentId}
         >
           <Card
             __unstable_focusRing
@@ -148,7 +147,7 @@ const PreviewWrapper = (props: Props) => {
                 {/* Document status */}
                 <Box display={['none', 'block']} marginX={[2, 2, 3]} style={{flexShrink: 0}}>
                   {publishedDocumentId ? (
-                    <DocumentVersionsStatus publishedDocumentId={publishedDocumentId} />
+                    <ScheduleItemStatusIndicator publishedDocumentId={publishedDocumentId} />
                   ) : (
                     <StatusDotPlaceholder />
                   )}
@@ -202,7 +201,7 @@ const PreviewWrapper = (props: Props) => {
 
 export default PreviewWrapper
 
-function DocumentVersionsStatus({publishedDocumentId}: {publishedDocumentId: string}) {
+function ScheduleItemStatusIndicator({publishedDocumentId}: {publishedDocumentId: string}) {
   const {versions} = useDocumentVersions({documentId: publishedDocumentId})
   return <DocumentVersionsStatusIndicator documentVersions={versions} />
 }

--- a/packages/sanity/src/core/scheduled-publishing/components/scheduleItem/ToolPreview.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/scheduleItem/ToolPreview.tsx
@@ -74,7 +74,6 @@ const ToolPreview = (props: Props) => {
           />
         }
         linkComponent={LinkComponent}
-        previewState={previewState}
         publishedDocumentId={publishedId}
         schedule={schedule}
         schemaType={schemaType}

--- a/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx
@@ -5,7 +5,7 @@ import {useObservable} from 'react-rx'
 import {styled} from 'styled-components'
 import {Box} from 'ui5'
 
-import {DocumentStatus} from '../../../../../../../components/documentStatus/DocumentStatus'
+import {DocumentVersionsStatus} from '../../../../../../../components/documentStatus/DocumentVersionsStatus'
 import {DocumentVersionsStatusIndicator} from '../../../../../../../components/documentStatusIndicator/DocumentVersionsStatusIndicator'
 import {type GeneralPreviewLayoutKey} from '../../../../../../../components/previews/types'
 import {type PerspectiveStack} from '../../../../../../../perspective/types'
@@ -14,7 +14,6 @@ import {SanityDefaultPreview} from '../../../../../../../preview/components/Sani
 import {getPreviewStateObservable} from '../../../../../../../preview/utils/getPreviewStateObservable'
 import {getPreviewValueWithFallback} from '../../../../../../../preview/utils/getPreviewValueWithFallback'
 import {useDocumentVersions} from '../../../../../../../releases/hooks/useDocumentVersions'
-import {getDocumentVersionInfoFromVersions} from '../../../../../../../releases/util/getDocumentVersionInfoFromVersions'
 import {useDocumentPreviewStore} from '../../../../../../../store/datastores'
 import {type DocumentPresence} from '../../../../../../../store/presence/types'
 
@@ -87,7 +86,6 @@ export function SearchResultItemPreview({
   const {isLoading, snapshot, original} = useObservable(observable, INITIAL_PREVIEW_STATE)
 
   const {versions} = useDocumentVersions({documentId})
-  const versionsInfo = useMemo(() => getDocumentVersionInfoFromVersions(versions), [versions])
 
   const status = useMemo(() => {
     if (isLoading) return null
@@ -100,13 +98,7 @@ export function SearchResultItemPreview({
     )
   }, [isLoading, presence, schemaType.title, showBadge, versions])
 
-  const tooltip = (
-    <DocumentStatus
-      draft={versionsInfo.draft}
-      published={versionsInfo.published}
-      versions={versionsInfo.versions}
-    />
-  )
+  const tooltip = <DocumentVersionsStatus documentGroupId={documentId} />
 
   return (
     <SearchResultItemPreviewBox>

--- a/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
+++ b/packages/sanity/src/structure/components/paneItem/PaneItemPreview.tsx
@@ -11,14 +11,13 @@ import {
   type DocumentPresence,
   DocumentPreviewPresence,
   type DocumentPreviewStore,
-  DocumentStatus,
+  DocumentVersionsStatus,
   DocumentVersionsStatusIndicator,
   type GeneralPreviewLayoutKey,
   getPreviewStateObservable,
   getPreviewValueWithFallback,
   getPublishedId,
   SanityDefaultPreview,
-  useDocumentVersionInfo,
   useDocumentVersions,
   usePerspective,
 } from 'sanity'
@@ -51,9 +50,8 @@ const INITIAL_PREVIEW_STATE = {
 export function PaneItemPreview(props: PaneItemPreviewProps) {
   const {icon, layout, presence, schemaType, sortOrder, value} = props
 
-  // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-  const versionsInfo = useDocumentVersionInfo(value._id)
-  const {versions} = useDocumentVersions({documentId: getPublishedId(value._id)})
+  const publishedId = getPublishedId(value._id)
+  const {versions} = useDocumentVersions({documentId: publishedId})
 
   const {perspectiveStack, selectedVariantName} = usePerspective()
   const viewOptions = useMemo((): PrepareViewOptions | undefined => {
@@ -105,13 +103,7 @@ export function PaneItemPreview(props: PaneItemPreviewProps) {
     </TooltipDelayGroupProvider>
   )
 
-  const tooltip = (
-    <DocumentStatus
-      draft={versionsInfo.draft}
-      published={versionsInfo.published}
-      versions={versionsInfo.versions}
-    />
-  )
+  const tooltip = <DocumentVersionsStatus documentGroupId={publishedId} />
 
   return (
     <SanityDefaultPreview

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -88,6 +88,7 @@ exports[`exports snapshot 1`] = `
     "DocumentPreviewPresence": "function",
     "DocumentStatus": "function",
     "DocumentStatusIndicator": "function",
+    "DocumentVersionsStatus": "function",
     "DocumentVersionsStatusIndicator": "function",
     "EMPTY_ARRAY": "object",
     "EMPTY_OBJECT": "object",


### PR DESCRIPTION
### Description
Deprecates DocumentStatus and replaces it for DocumentVersionStatus.
Now documents render the versions tooltip in a cleaner user interface, using the new icons and new spacing.

<img width="367" height="619" alt="Screenshot 2026-08-20 at 12 29 35" src="https://github.com/user-attachments/assets/8b228101-19f2-4eff-968f-304e3b3c944e" />

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

### Notes for release
Deprecates DocumentStatus and replaces it for DocumentVersionStatus.

<!--
Leave this section empty or start with "N/A" if you don't want to include release notes with this PR. For example, "N/A: Internal only"

Engineers do not need to worry about the final copy,
but they must provide the docs team with enough context on:

* What changed
* How does one use it (code snippets, etc)
* Are there limitations we should be aware of
* [internal] Does this affect the docs team? If so, please ask a member of that team for a review

If this PR is a partial implementation of a feature and is not enabled by default or if
this PR does not contain changes that needs mention in the release notes (tooling chores etc),
please call this out explicitly by writing "N/A – Part of feature X" in this section.

Write your notes ABOVE the horizontal rule below. Release automation ignores
anything after the rule (Cursor Bugbot reviews, later edits, etc.).
-->

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Status badges and tooltips drive many list/preview surfaces and depend on perspective, releases, and variant resolution; regressions would be visible but logic is covered by new unit tests.
> 
> **Overview**
> Introduces **`DocumentVersionsStatus`** and **`DocumentVersionsStatusIndicator`** as the variant- and release-aware replacements for the deprecated **`DocumentStatus`** / **`DocumentStatusIndicator`**. Previews across structure, search, references, and scheduled publishing now load all document versions and show the new indicator plus a tooltip built from **`groupDocumentVersionsForStatus`** (grouped by variant, ordered published → drafts → releases).
> 
> **`DocumentVersionsStatusIndicator`** uses **`resolveDocumentStatusIcons`** with the current perspective and selected variant to show up to three icons (variant rhombus, release avatar, draft ring, published disc). **`ReleaseAvatar`** gains a **`size="small"`** mode with temporary icon glyphs; variants navbar adds **`VariantsToolLink`**, refreshed variant menu styling, and shared rhombus icons under **`temporary-icons`**.
> 
> Legacy components stay exported for compatibility; public API adds **`DocumentVersionsStatus`** exports and updates DTS fixtures accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b448b8eca69606f5f302a6441e769c375fd7db0e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->