### PR TITLE
refactor(portable-text): render decorators and annotations through editor node registrations

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -1,7 +1,10 @@
 import {
-  type BlockAnnotationRenderProps,
+  type AnnotationRenderProps,
   type BlockObjectRenderProps,
+  type DecoratorRenderProps,
+  defineAnnotation,
   defineBlockObject,
+  defineDecorator,
   defineInlineObject,
   defineTextBlock,
   type EditorSelection,
@@ -49,6 +52,7 @@ import {BlockObject} from './object/BlockObject'
 import {CombinedAnnotationPopover} from './object/CombinedAnnotationPopover'
 import {InlineObject} from './object/InlineObject'
 import {AnnotationObjectEditModal} from './object/modals/AnnotationObjectEditModal'
+import {Decorator} from './text/Decorator'
 import {ListItem} from './text/ListItem'
 import {Style} from './text/Style'
 import {TextBlock} from './text/TextBlock'
@@ -378,37 +382,29 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     ],
   )
 
-  // Stable reference: `NodePlugin` re-runs its registration effect when
-  // `nodes` changes by reference.
-  const catchAllNodes = useMemo<RegistrableNode[]>(
-    () => [
-      defineTextBlock({type: '*', render: renderTextBlock}),
-      defineBlockObject({type: '*', render: renderBlockObject}),
-      defineInlineObject({type: '*', render: renderInlineObject}),
-    ],
-    [renderTextBlock, renderBlockObject, renderInlineObject],
+  const renderDecoratorNode = useCallback(
+    (decoratorProps: DecoratorRenderProps) => <Decorator {...decoratorProps} />,
+    [],
   )
 
-  const editorRenderAnnotation = useCallback(
-    // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-    (annotationProps: BlockAnnotationRenderProps) => {
+  const renderAnnotationNode = useCallback(
+    (annotationProps: AnnotationRenderProps) => {
       const {
+        annotation,
         children,
         focused: editorNodeFocused,
         path: aPath,
         selected,
-        schemaType: aSchemaType,
-        value: aValue,
       } = annotationProps
-      const annotationPath = [...aPath.slice(0, -2), 'markDefs', {_key: aValue._key}]
+      const annotationPath = [...aPath.slice(0, -2), 'markDefs', {_key: annotation._key}]
       const sanitySchemaType = getSanitySubSchema(
         schemaTypes.portableText,
         editor.getSnapshot().context.value,
         annotationPath,
-      ).annotations.find((t) => t.name === aSchemaType.name)
+      ).annotations.find((t) => t.name === annotation._type)
       if (!sanitySchemaType) {
         // This should never happen
-        throw new Error(`Could not find Sanity schema type for annotation: ${aSchemaType.name}`)
+        throw new Error(`Could not find Sanity schema type for annotation: ${annotation._type}`)
       }
       return (
         <Annotation
@@ -432,7 +428,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
           schemaType={sanitySchemaType}
           selected={selected}
           setElementRef={setElementRef}
-          value={aValue}
+          value={annotation}
         >
           {children}
         </Annotation>
@@ -460,6 +456,26 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       editor,
     ],
   )
+
+  // Stable reference: `NodePlugin` re-runs its registration effect when
+  // `nodes` changes by reference.
+  const catchAllNodes = useMemo<RegistrableNode[]>(
+    () => [
+      defineTextBlock({type: '*', render: renderTextBlock}),
+      defineBlockObject({type: '*', render: renderBlockObject}),
+      defineInlineObject({type: '*', render: renderInlineObject}),
+      defineDecorator({type: '*', render: renderDecoratorNode}),
+      defineAnnotation({type: '*', render: renderAnnotationNode}),
+    ],
+    [
+      renderTextBlock,
+      renderBlockObject,
+      renderInlineObject,
+      renderDecoratorNode,
+      renderAnnotationNode,
+    ],
+  )
+
   const ariaDescribedBy = elementProps['aria-describedby']
 
   // Create an initial editor selection based on the focusPath
@@ -516,7 +532,6 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
             path={path}
             rangeDecorations={rangeDecorations}
             readOnly={readOnly}
-            renderAnnotation={editorRenderAnnotation}
             setPortalElement={setPortalElement}
             scrollElement={scrollElement}
             setScrollElement={setScrollElement}
@@ -546,7 +561,6 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       handleToggleFullscreen,
       path,
       rangeDecorations,
-      editorRenderAnnotation,
       scrollElement,
     ],
   )

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -1,5 +1,4 @@
 import {
-  type BlockDecoratorRenderProps,
   type EditorSelection,
   type HotkeyOptions,
   type OnCopyFn,
@@ -7,7 +6,6 @@ import {
   PortableTextEditable,
   type PortableTextEditableProps,
   type RangeDecoration,
-  type RenderAnnotationFunction,
 } from '@portabletext/editor'
 import {type Path} from '@sanity/types'
 import {BoundaryElementProvider, useBoundaryElement, useGlobalKeyDown, useLayer} from '@sanity/ui'
@@ -21,7 +19,6 @@ import {useFormBuilder} from '../../useFormBuilder'
 import {EditableCard, EditableWrapper, Root, Scroller, ToolbarCard} from './Editor.styles'
 import {useScrollSelectionIntoView} from './hooks/useScrollSelectionIntoView'
 import {useSpellCheck} from './hooks/useSpellCheck'
-import {Decorator} from './text/Decorator'
 import {Toolbar} from './toolbar/Toolbar'
 
 const noOutlineStyle = {outline: 'none'} as const
@@ -52,8 +49,6 @@ interface EditorProps {
   path: Path
   readOnly?: boolean
   rangeDecorations?: RangeDecoration[]
-  // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-  renderAnnotation: RenderAnnotationFunction
   scrollElement: HTMLElement | null
   setPortalElement?: (portalElement: HTMLDivElement | null) => void
   setScrollElement: (scrollElement: HTMLElement | null) => void
@@ -79,7 +74,6 @@ export function Editor(props: EditorProps): ReactNode {
     path,
     readOnly,
     rangeDecorations,
-    renderAnnotation,
     scrollElement,
     setPortalElement,
     setScrollElement,
@@ -116,10 +110,6 @@ export function Editor(props: EditorProps): ReactNode {
     [t],
   )
   const spellCheck = useSpellCheck()
-  // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-  const renderDecorator = useCallback((decoratorProps: BlockDecoratorRenderProps) => {
-    return <Decorator {...decoratorProps} />
-  }, [])
 
   const scrollSelectionIntoView = useScrollSelectionIntoView(scrollElement)
 
@@ -131,10 +121,6 @@ export function Editor(props: EditorProps): ReactNode {
       onPaste,
       rangeDecorations,
       'ref': elementRef,
-      // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-      renderAnnotation,
-      // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-      renderDecorator,
       renderPlaceholder,
       scrollSelectionIntoView,
       'selection': initialSelection,
@@ -151,8 +137,6 @@ export function Editor(props: EditorProps): ReactNode {
     onCopy,
     onPaste,
     rangeDecorations,
-    renderAnnotation,
-    renderDecorator,
     renderPlaceholder,
     scrollSelectionIntoView,
     spellCheck,

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/Decorators.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/Decorators.browser.test.tsx
@@ -113,5 +113,61 @@ describe('Portable Text Input', () => {
         await expect.element($icon).toBeVisible()
       })
     })
+
+    it('Renders a custom decorator component with its BlockDecoratorProps (title, value) and mounts renderDefault', async () => {
+      const {
+        findBySelector,
+        getFocusedPortableTextInput,
+        getFocusedPortableTextEditor,
+        insertPortableText,
+      } = testHelpers()
+      void render(<DecoratorsStory />)
+      const $portableTextInput = await getFocusedPortableTextInput('field-customDecorator')
+      const $pte = await getFocusedPortableTextEditor('field-customDecorator')
+
+      await $portableTextInput.getByRole('button', {name: 'Highlight'}).click()
+      await insertPortableText('highlighted text', $pte)
+
+      const $customComponent = await findBySelector(
+        $pte,
+        '[data-testid="custom-highlight-decorator"]',
+      )
+      await expect.element($customComponent).toBeVisible()
+      await expect.element($customComponent).toHaveTextContent('highlighted text')
+
+      await expect.element($customComponent).toHaveAttribute('data-title', 'Highlight')
+      await expect.element($customComponent).toHaveAttribute('data-value', 'highlight')
+
+      // `data-mark` comes from Studio's own `DefaultComponent` in
+      // `text/Decorator.tsx`; the editor's built-in default render for
+      // registered decorators is identity and adds no markup
+      const $defaultMarkup = page.elementLocator(
+        $customComponent.element().querySelector('[data-mark="highlight"]')!,
+      )
+      await expect.element($defaultMarkup).toBeVisible()
+      await expect.element($defaultMarkup).toHaveTextContent('highlighted text')
+    })
+
+    it('Renders a custom decorator component that renders only its children', async () => {
+      const {
+        findBySelector,
+        getFocusedPortableTextInput,
+        getFocusedPortableTextEditor,
+        insertPortableText,
+      } = testHelpers()
+      void render(<DecoratorsStory />)
+      const $portableTextInput = await getFocusedPortableTextInput('field-customDecorator')
+      const $pte = await getFocusedPortableTextEditor('field-customDecorator')
+
+      await $portableTextInput.getByRole('button', {name: 'Spoiler'}).click()
+      await insertPortableText('spoiler text', $pte)
+
+      const $customComponent = await findBySelector(
+        $pte,
+        '[data-testid="custom-spoiler-decorator"]',
+      )
+      await expect.element($customComponent).toBeVisible()
+      await expect.element($customComponent).toHaveTextContent('spoiler text')
+    })
   })
 })

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/DecoratorsStory.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/DecoratorsStory.tsx
@@ -3,6 +3,27 @@ import {defineArrayMember, defineField, defineType} from '@sanity/types'
 
 import {TestForm} from '../../../../../../test/browser/TestForm'
 import {TestWrapper} from '../../../../../../test/browser/TestWrapper'
+import {type BlockDecoratorProps} from '../../../types/blockProps'
+
+function Highlight(props: BlockDecoratorProps) {
+  return (
+    <span
+      data-testid="custom-highlight-decorator"
+      data-title={props.title}
+      data-value={props.value}
+    >
+      {props.renderDefault(props)}
+    </span>
+  )
+}
+
+function Spoiler(props: BlockDecoratorProps) {
+  return (
+    <span data-testid="custom-spoiler-decorator" style={{color: 'red'}}>
+      {props.children}
+    </span>
+  )
+}
 
 const SCHEMA_TYPES = [
   defineType({
@@ -26,7 +47,19 @@ const SCHEMA_TYPES = [
           defineArrayMember({
             type: 'block',
             marks: {
-              decorators: [{title: 'Highlight', value: 'highlight', icon: BulbOutlineIcon}],
+              decorators: [
+                {
+                  title: 'Highlight',
+                  value: 'highlight',
+                  icon: BulbOutlineIcon,
+                  component: Highlight,
+                },
+                {
+                  title: 'Spoiler',
+                  value: 'spoiler',
+                  component: Spoiler,
+                },
+              ],
             },
           }),
         ],

--- a/packages/sanity/src/core/form/inputs/PortableText/text/Decorator.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/Decorator.tsx
@@ -1,4 +1,4 @@
-import {type BlockDecoratorRenderProps} from '@portabletext/editor'
+import {type DecoratorRenderProps} from '@portabletext/editor'
 import {type Theme} from '@sanity/ui'
 import {useCallback, useMemo} from 'react'
 import {css, styled} from 'styled-components'
@@ -21,26 +21,25 @@ const Root = styled.span(({theme}: {theme: Theme}) => {
   `
 })
 
-// oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-export function Decorator(props: BlockDecoratorRenderProps) {
-  const {value, focused, selected, children, schemaType} = props
+export function Decorator(props: DecoratorRenderProps) {
+  const {decorator, focused, selected, children} = props
   const schemaTypes = usePortableTextMemberSchemaTypes()
-  const sanitySchemaType = schemaTypes.decorators.find((type) => type.value === schemaType.name)
+  const sanitySchemaType = schemaTypes.decorators.find((type) => type.value === decorator)
   if (!sanitySchemaType) {
     // This should never happen
-    throw new Error(`Could not find Sanity schema type for decorator: ${schemaType.name}`)
+    throw new Error(`Could not find Sanity schema type for decorator: ${decorator}`)
   }
-  const tag = TEXT_DECORATOR_TAGS[value]
+  const tag = TEXT_DECORATOR_TAGS[decorator]
   const CustomComponent = sanitySchemaType.component
   const DefaultComponent = useCallback(
     (defaultComponentProps: BlockDecoratorProps) => {
       return (
-        <Root as={tag} data-mark={value}>
+        <Root as={tag} data-mark={decorator}>
           {defaultComponentProps.children}
         </Root>
       )
     },
-    [tag, value],
+    [tag, decorator],
   )
   return useMemo(() => {
     const componentProps = {
@@ -49,7 +48,7 @@ export function Decorator(props: BlockDecoratorRenderProps) {
       schemaType: sanitySchemaType,
       selected,
       title: sanitySchemaType.title,
-      value,
+      value: decorator,
     }
     return CustomComponent ? (
       <CustomComponent {...componentProps}>{children}</CustomComponent>
@@ -57,5 +56,5 @@ export function Decorator(props: BlockDecoratorRenderProps) {
       // oxlint-disable-next-line react/static-components -- this is intentional and how the middleware components has to work
       <DefaultComponent {...componentProps}>{children}</DefaultComponent>
     )
-  }, [CustomComponent, DefaultComponent, children, focused, sanitySchemaType, selected, value])
+  }, [CustomComponent, DefaultComponent, children, focused, sanitySchemaType, selected, decorator])
 }


### PR DESCRIPTION
### Description

PTE deprecated the `renderDecorator` and `renderAnnotation` render props in 7.12.0; the replacement is registering marks through `defineDecorator`/`defineAnnotation`, the same pipeline the PT input already uses for blocks, text blocks, and inline objects. This PR removes the usage of the deprecated props in favour of catch-all registrations in `Compositor.tsx`.

### What to review

Verify that decorators and annotations still render and edit as before: toggle decorators, add/edit/remove a link annotation, and check that a decorator with a custom schema `component` still renders through it.

### Testing

The existing decorator and annotation browser suites already cover the consumer-facing render callbacks that Studio provides. A new browser test pins that a custom decorator component still receives its `title`, `value`, and that `renderDefault` still works.

### Notes for release

n/a

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core PTE rendering for all marks and annotations; behavior should be equivalent but regressions could affect every rich-text field.
> 
> **Overview**
> Studio’s Portable Text input stops using the deprecated `renderDecorator` and `renderAnnotation` props on `PortableTextEditable`. **Decorators and annotations are now wired through the same `NodePlugin` catch-all registrations** as blocks and inline objects, via `defineDecorator` / `defineAnnotation` in `Compositor.tsx`.
> 
> Annotation rendering is updated to the new `AnnotationRenderProps` shape (`annotation` instead of separate schema/value). `Decorator.tsx` switches to `DecoratorRenderProps` and reads the mark from `decorator` rather than `schemaType`/`value`. `Editor.tsx` no longer accepts or forwards those render callbacks.
> 
> Browser tests add coverage for custom schema decorator components (`title`, `value`, `renderDefault`, and children-only wrappers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66cb2a39d17f6bcebaad7829986352a9f696c116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->