### PR TITLE
docs: drop eslint-config from the ARCHITECTURE package tree

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -29,7 +29,6 @@ sanity/
 │   │   ├── util/              # Shared utilities
 │   │   └── vision/            # GROQ query tool (Studio plugin)
 │   └── @repo/                  # Internal monorepo tooling (not published)
-│       ├── eslint-config/     # Shared ESLint configuration
 │       ├── test-config/       # Shared test configuration
 │       ├── tsconfig/          # Shared TypeScript configuration
 │       ├── tsdown.config/     # Build configuration utilities


### PR DESCRIPTION
`ARCHITECTURE.md:32` lists `packages/@repo/eslint-config` in the repository layout diagram. That package was removed in `13b79343da` (*"chore(lint): replace eslint with oxlint jsplugins (#13114)"*), so the diagram describes a directory that is not in the tree.

This removes that one line. Nothing else in the block is stale: I resolved all nineteen paths in the diagram against `main` and `eslint-config/` is the only one gone. `ARCHITECTURE.md` mentions lint nowhere else, so there is no second reference to update.

Found by [docproof](https://github.com/melbinjp/docproof), a documentation checker that verifies claims in docs against the repository and its git history. Hand-checked against the current tree before opening the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a layout diagram; no code or build behavior is affected.
> 
> **Overview**
> Updates the **Repository Structure** diagram in `ARCHITECTURE.md` so it matches the current monorepo layout.
> 
> Removes the `packages/@repo/eslint-config` line from the `@repo/` tooling list. That package was deleted when ESLint was replaced with oxlint; leaving it in the diagram pointed at a path that no longer exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12d7264e97c059e16cb4f61e221c17f3de406d8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->