### PR TITLE
chore(deps): bump oxlint to v1.79 and enable react compiler rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -205,9 +205,16 @@
     "react/rules-of-hooks": "error",
     // Prefer function components; allow class-based error boundaries (no hook equivalent yet)
     "react/prefer-function-component": ["error", {"allowErrorBoundary": true}],
-    // React Compiler rules, native nursery rule (replaces eslint-plugin-react-hooks compiler rules).
+    // React Compiler rules (https://oxc.rs/blog/2026-08-18-react-compiler-support.html#oxlint).
+    // The old nursery `react/react-compiler` rule was replaced by 22 category-specific rules.
+    // The `correctness`, `suspicious`, and `perf` rules are already enabled via `categories`
+    // above; the `restriction`-category rules are not, so they are enabled explicitly here.
     // Pre-existing violations are grandfathered with inline `oxlint-disable-next-line` suppressions.
-    "react/react-compiler": "error",
+    "react/unsupported-syntax": "error",
+    "react/invariant": "error",
+    "react/rule-suppression": "error",
+    "react/syntax": "error",
+    "react/todo": "error",
     // Import hygiene previously enforced by eslint-plugin-import
     "import/first": "error",
     "import/newline-after-import": "error",

--- a/dev/metrics-studio/tools/trends/useUrlState.ts
+++ b/dev/metrics-studio/tools/trends/useUrlState.ts
@@ -26,6 +26,7 @@ export function useUrlState(
     const onPopState = () => setValue(read())
     window.addEventListener('popstate', onPopState)
     return () => window.removeEventListener('popstate', onPopState)
+    // oxlint-disable-next-line react/rule-suppression -- pre-existing violation, to be fixed in a follow-up
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key, fallback])
 

--- a/dev/test-studio/components/documentViews/VariantVersionsView.tsx
+++ b/dev/test-studio/components/documentViews/VariantVersionsView.tsx
@@ -334,6 +334,7 @@ function VersionSlotCard({label, contextTitle, snapshot, status}: VersionSlot) {
       await client.delete(documentId)
     } catch (deleteErr: unknown) {
       setDeleteError(deleteErr instanceof Error ? deleteErr.message : 'Failed to delete document')
+      // oxlint-disable-next-line react/todo -- pre-existing violation, to be fixed in a follow-up
     } finally {
       setDeleting(false)
     }

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "npm-run-all2": "^9.0.2",
     "only-allow": "^1.2.2",
     "oxfmt": "^0.63.0",
-    "oxlint": "^1.76.0",
+    "oxlint": "^1.79.0",
     "oxlint-tsgolint": "^7.0.2001",
     "pkg-pr-new": "^0.0.87",
     "playwright": "catalog:",

--- a/packages/@sanity/schema/src/sanity/extractSchema.ts
+++ b/packages/@sanity/schema/src/sanity/extractSchema.ts
@@ -731,7 +731,7 @@ function sortByDependencies(compiledSchema: SchemaDef): {
             if (hoistRepetitions && !validSchemaNames.has(field.type.name)) {
               const fieldPath = path.concat([field.name])
               if (!repeated.has(field) && objectMap.has(field)) {
-                // The field is not in the repeated set, but it's the second time we see it – time to add it
+                // The field is not in the repeated set, but it's the second time we see it – time to add it
                 const name = pickRepeatedName(fieldPath)
 
                 // If we couldn't pick a name, we skip hoisting for this field

--- a/packages/@sanity/vision/src/components/VisionGui.tsx
+++ b/packages/@sanity/vision/src/components/VisionGui.tsx
@@ -657,6 +657,7 @@ export function VisionGui(props: VisionGuiProps) {
       return
     }
     handleStudioVariantChange()
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [activeVariant])
 
   const handleStudioPerspectiveChange = useEffectEvent((stack: StackablePerspective[]) => {
@@ -667,6 +668,7 @@ export function VisionGui(props: VisionGuiProps) {
   // Handle pinned perspective changes
   useEffect(() => {
     handleStudioPerspectiveChange(perspectiveStack)
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [perspectiveStack])
 
   const generateUrl = useCallback(

--- a/packages/sanity/src/core/canvas/actions/LinkToCanvas/LinkToCanvasAction.tsx
+++ b/packages/sanity/src/core/canvas/actions/LinkToCanvas/LinkToCanvasAction.tsx
@@ -76,7 +76,7 @@ export const useLinkToCanvasAction: DocumentActionComponent = (props: DocumentAc
 
   useEffect(() => {
     if (isLinked) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       handleCloseDialog()
     }
   }, [isLinked, handleCloseDialog])

--- a/packages/sanity/src/core/changeIndicators/overlay/ConnectorsOverlay.tsx
+++ b/packages/sanity/src/core/changeIndicators/overlay/ConnectorsOverlay.tsx
@@ -170,6 +170,7 @@ export function ConnectorsOverlay(props: ConnectorsOverlayProps) {
   })
 
   useEffect(() => {
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
     scheduleUpdate()
   }, [allReportedValues, hovered, isReviewChangesOpen, rootElement])
 
@@ -187,11 +188,13 @@ export function ConnectorsOverlay(props: ConnectorsOverlayProps) {
     const observer = new ResizeObserver(() => scheduleUpdate())
     observer.observe(rootElement)
     return () => observer.disconnect()
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [rootElement])
 
   const scrollContext = use(ScrollContext)
   useEffect(() => {
     return scrollContext?.subscribe(() => scheduleUpdate())
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [scrollContext])
 
   const visibleConnector = useMemo(() => {

--- a/packages/sanity/src/core/comments/components/list/CommentsListItemLayout.tsx
+++ b/packages/sanity/src/core/comments/components/list/CommentsListItemLayout.tsx
@@ -234,7 +234,7 @@ export function CommentsListItemLayout(props: CommentsListItemLayoutProps) {
     if (isEditing) return
 
     startMessage.current = message
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setValue(message)
   }, [isEditing, message])
 

--- a/packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx
+++ b/packages/sanity/src/core/comments/plugin/inspector/CommentsInspector.tsx
@@ -324,7 +324,7 @@ function CommentsInspectorInner(
   const [loggedTelemetry, setLoggedTelemetry] = useState(false)
   useEffect(() => {
     if (loggedTelemetry || mode !== 'upsell') return undefined
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setLoggedTelemetry(true)
     if (selectedPath?.origin === 'form') {
       upsellTelemetryLogs.panelViewed('field_action')

--- a/packages/sanity/src/core/components/commandList/CommandList.tsx
+++ b/packages/sanity/src/core/components/commandList/CommandList.tsx
@@ -156,6 +156,7 @@ function CommandListComponent({
   )
 
   // This will trigger a re-render whenever its internal state changes
+  // oxlint-disable-next-line react/incompatible-library -- pre-existing violation, to be fixed in a follow-up
   const virtualizer = useVirtualizer({
     count: items.length,
     getItemKey,

--- a/packages/sanity/src/core/components/hookCollection/HookCollectionState.tsx
+++ b/packages/sanity/src/core/components/hookCollection/HookCollectionState.tsx
@@ -54,6 +54,6 @@ function RenderHook<Args, State>({
     [hook, id],
   )
 
-  // oxlint-disable-next-line react/react-compiler -- yes this is bad, but we can't fix it without a new document actions API that will be a breaking change
+  // oxlint-disable-next-line react/static-components -- yes this is bad, but we can't fix it without a new document actions API that will be a breaking change
   return <HookState args={args} handleNext={handleNext} />
 }

--- a/packages/sanity/src/core/components/inputs/DateFilters/calendar/CalendarFilter.tsx
+++ b/packages/sanity/src/core/components/inputs/DateFilters/calendar/CalendarFilter.tsx
@@ -153,6 +153,7 @@ export function CalendarFilter(props: CalendarProps & RefAttributes<HTMLDivEleme
     ) {
       focusCurrentWeekDay()
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [ref, focusCurrentWeekDay, focusedDate])
 
   // Select AND focus current date when 'today' is pressed

--- a/packages/sanity/src/core/components/inputs/DateInputs/calendar/Calendar.tsx
+++ b/packages/sanity/src/core/components/inputs/DateInputs/calendar/Calendar.tsx
@@ -174,7 +174,7 @@ export function Calendar(props: CalendarProps & RefAttributes<HTMLDivElement>) {
 
   useEffect(() => {
     // The change is coming from another source, so we need to update the timeValue to the new value.
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/no-deriving-state-in-effects, react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setTimeValue(timeFromDate)
   }, [timeFromDate])
 
@@ -251,6 +251,7 @@ export function Calendar(props: CalendarProps & RefAttributes<HTMLDivElement>) {
     ) {
       focusCurrentWeekDay()
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [ref, focusCurrentWeekDay, focusedDate])
 
   const handleYesterdayClick = useCallback(

--- a/packages/sanity/src/core/divergence/components/DivergenceDetail.tsx
+++ b/packages/sanity/src/core/divergence/components/DivergenceDetail.tsx
@@ -133,7 +133,7 @@ export const DivergenceDetail: ComponentType<DivergenceDetailProps> = ({
               <>
                 {diff &&
                   DiffComponent && (
-                    // oxlint-disable-next-line react/react-compiler
+                    // oxlint-disable-next-line react/static-components -- pre-existing violation, to be fixed in a follow-up
                     <DiffComponent diff={diff} schemaType={divergence.schemaType} />
                   )}
               </>

--- a/packages/sanity/src/core/feedback/hooks/useFeedbackAvailable.ts
+++ b/packages/sanity/src/core/feedback/hooks/useFeedbackAvailable.ts
@@ -21,7 +21,7 @@ export function useFeedbackAvailable(options: UseFeedbackAvailableOptions): bool
 
   useEffect(() => {
     if (skip) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setAvailable(false)
       return
     }

--- a/packages/sanity/src/core/field/diff/components/ChangeResolver.tsx
+++ b/packages/sanity/src/core/field/diff/components/ChangeResolver.tsx
@@ -193,7 +193,6 @@ export function GroupChange(
                 <RevertChangesButton
                   changeCount={changes.length}
                   onClick={handleRevertChangesConfirm}
-                  // oxlint-disable-next-line react/react-compiler
                   ref={setRevertButtonElement}
                   selected={confirmRevertOpen}
                   disabled={readOnly || !isTargetReady}
@@ -212,6 +211,7 @@ export function GroupChange(
           />
         </>
       ),
+    // oxlint-disable-next-line react/memo-dependencies -- pre-existing violation, to be fixed in a follow-up
     [
       changes,
       confirmRevertOpen,

--- a/packages/sanity/src/core/field/types/portableText/diff/components/Annotation.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/Annotation.tsx
@@ -141,7 +141,7 @@ function AnnnotationWithDiff({
 
   useEffect(() => {
     if (!open && isEditing) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setOpen(true)
       onSetFocus(myPath)
     }

--- a/packages/sanity/src/core/field/types/portableText/diff/components/InlineObject.tsx
+++ b/packages/sanity/src/core/field/types/portableText/diff/components/InlineObject.tsx
@@ -108,7 +108,7 @@ function InlineObjectWithDiff({
 
   useEffect(() => {
     if (isEditing) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setOpen(true)
       onSetFocus(focusPath)
     }

--- a/packages/sanity/src/core/form/components/Details.tsx
+++ b/packages/sanity/src/core/form/components/Details.tsx
@@ -51,7 +51,7 @@ export function Details(props: DetailsProps) {
 
   const handleToggle = useCallback(() => setOpen((v) => !v), [])
 
-  // oxlint-disable-next-line react/react-compiler
+  // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
   useEffect(() => setOpen(openProp || false), [openProp])
 
   return (

--- a/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
+++ b/packages/sanity/src/core/form/components/EnhancedObjectDialog.tsx
@@ -134,7 +134,7 @@ export function EnhancedObjectDialog(props: PopoverProps | DialogProps): React.J
   // Update state when we have nested dialogs
   useEffect(() => {
     if (stack.length > 1 && !hasEverBeenNested) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setHasEverBeenNested(true)
     }
   }, [stack.length, hasEverBeenNested])

--- a/packages/sanity/src/core/form/components/formField/FormFieldBaseHeader.tsx
+++ b/packages/sanity/src/core/form/components/formField/FormFieldBaseHeader.tsx
@@ -211,15 +211,16 @@ export function FormFieldBaseHeader(props: FormFieldBaseHeaderProps) {
 
   // Calculate floating card's width
   useEffect(() => {
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     handleSetFloatingCardElementWidth()
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [handleSetFloatingCardElementWidth, showFieldActions])
 
   // Calculate slot element's width
   useEffect(() => {
     if (slotElement) {
       const {width} = slotElement.getBoundingClientRect()
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setSlotWidth(width || 0)
     }
   }, [slotElement])

--- a/packages/sanity/src/core/form/components/tagInput/tagInput.tsx
+++ b/packages/sanity/src/core/form/components/tagInput/tagInput.tsx
@@ -249,6 +249,7 @@ export function TagInput(
       inputElement.style.width = '0'
       inputElement.style.width = `calc(${inputElement.scrollWidth}px + 1rem)`
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [inputValue])
 
   return (

--- a/packages/sanity/src/core/form/form-components-hooks/useResolveDefaultComponent.tsx
+++ b/packages/sanity/src/core/form/form-components-hooks/useResolveDefaultComponent.tsx
@@ -47,6 +47,6 @@ export function useResolveDefaultComponent<T extends {schemaType?: SchemaType}>(
     [componentResolver],
   )
 
-  // oxlint-disable-next-line react/react-compiler -- this is intentional and how the middleware components has to work
+  // oxlint-disable-next-line react/static-components -- this is intentional and how the middleware components has to work
   return <DefaultResolvedComponent {...componentProps} renderDefault={renderDefault} />
 }

--- a/packages/sanity/src/core/form/inputs/DateInputs/CommonDateTimeInput.tsx
+++ b/packages/sanity/src/core/form/inputs/DateInputs/CommonDateTimeInput.tsx
@@ -68,8 +68,9 @@ export function CommonDateTimeInput(
   const {t} = useTranslation()
 
   useEffect(() => {
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setLocalValue(null)
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [value])
 
   const handleDatePickerInputChange = useCallback(

--- a/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/ReferenceAutocomplete.test.tsx
+++ b/packages/sanity/src/core/form/inputs/GlobalDocumentReferenceInput/ReferenceAutocomplete.test.tsx
@@ -64,7 +64,7 @@ vi.mock('@sanity/ui/autocomplete', async (importOriginal) => {
     useLayoutEffect(() => {
       if (typeof renderPopover !== 'function') {
         // TODO(oxlint): remove this suppression in a follow-up when this test setup is refactored
-        // oxlint-disable-next-line react/react-compiler
+        // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
         setPopover(null)
         return
       }

--- a/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/PortableTextInput.tsx
@@ -247,6 +247,7 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
   const focusedDivergence = divergenceNavigator.enabled
     ? divergenceNavigator.state.focusedDivergence
     : undefined
+  // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   useEffect(() => controlImplicitExpandedState(), [focusedDivergence])
 
   const toast = useToast()
@@ -266,7 +267,7 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
   // Reset invalidValue if new value is coming in from props
   useEffect(() => {
     if (invalidValue && value !== invalidValue.value) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setInvalidValue(null)
     }
   }, [invalidValue, value])
@@ -276,7 +277,7 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
   // Set active if focused within the editor
   useEffect(() => {
     if (hasFocusWithin) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setIsActive(true)
     }
   }, [hasFocusWithin])
@@ -306,7 +307,6 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
 
   // Handle editor changes
   const handleEditorChange = useCallback(
-    // oxlint-disable-next-line react/react-compiler
     (change: EditorChange): void => {
       switch (change.type) {
         case 'mutation':
@@ -344,6 +344,7 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
         onEditorChange(change, legacyEditorRef.current)
       }
     },
+    // oxlint-disable-next-line react/preserve-manual-memoization -- pre-existing violation, to be fixed in a follow-up
     [
       legacyEditorRef,
       editorRef,
@@ -356,8 +357,9 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
   )
 
   useEffect(() => {
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setIgnoreValidationError(false)
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [value])
 
   const handleIgnoreInvalidValue = useCallback((): void => {
@@ -380,7 +382,6 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
     return null
   }, [handleEditorChange, handleIgnoreInvalidValue, invalidValue, readOnly])
 
-  // oxlint-disable-next-line react/react-compiler
   const handleActivate = useCallback((): void => {
     if (!isActive) {
       setIsActive(true)
@@ -389,6 +390,7 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
         PortableTextEditor.focus(legacyEditorRef.current)
       }
     }
+    // oxlint-disable-next-line react/preserve-manual-memoization -- pre-existing violation, to be fixed in a follow-up
   }, [legacyEditorRef, isActive])
 
   const previousRangeDecorations = useRef<RangeDecoration[]>([])
@@ -408,9 +410,9 @@ export function PortableTextInput(props: PortableTextInputProps): ReactNode {
       ? diffRangeDecorations
       : [...(rangeDecorationsProp || []), ...presenceCursorDecorations]
 
-    // oxlint-disable-next-line react/react-compiler -- @todo fix later, requires research to avoid perf degradation, for now "this is fine"
+    // oxlint-disable-next-line react/refs -- @todo fix later, requires research to avoid perf degradation, for now "this is fine"
     const reconciled = immutableReconcile(previousRangeDecorations.current, result)
-    // oxlint-disable-next-line react/react-compiler -- see above
+    // oxlint-disable-next-line react/refs -- see above
     previousRangeDecorations.current = reconciled
     return reconciled
   }, [diffRangeDecorations, displayInlineChanges, presenceCursorDecorations, rangeDecorationsProp])

--- a/packages/sanity/src/core/form/inputs/PortableText/diff/useOptimisticPortableTextDiff.ts
+++ b/packages/sanity/src/core/form/inputs/PortableText/diff/useOptimisticPortableTextDiff.ts
@@ -139,8 +139,9 @@ export function useOptimisticPortableTextDiff({
 
   // Reset the optimistic state after receiving definitive state.
   useEffect(() => {
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setOptimisticValue(undefined)
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [definitiveValue])
 
   return {

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useMemberValidation.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useMemberValidation.tsx
@@ -33,9 +33,9 @@ export function useMemberValidation(member: BaseFormNode | undefined) {
     [validation],
   )
 
-  // oxlint-disable-next-line react/react-compiler -- @todo fix later, requires research to avoid perf degradation, for now "this is fine"
+  // oxlint-disable-next-line react/refs -- @todo fix later, requires research to avoid perf degradation, for now "this is fine"
   const reconciled = immutableReconcile(prev.current, validation)
-  // oxlint-disable-next-line react/react-compiler -- see above
+  // oxlint-disable-next-line react/refs -- see above
   prev.current = reconciled
 
   return useMemo(() => {

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/usePortableTextMembers.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/usePortableTextMembers.tsx
@@ -128,10 +128,9 @@ export function usePortableTextMemberItemsFromProps(
       }
     }
 
-    // oxlint-disable-next-line react/react-compiler -- @todo this should be fixed but it's difficult and needs research
+    // oxlint-disable-next-line react/refs -- @todo this should be fixed but it's difficult and needs research
     const items: PortableTextMemberItem[] = result.map((item) => {
       const key = pathToString(item.node.path)
-      // oxlint-disable-next-line react/react-compiler
       const existingItem = portableTextMemberItemsRef.current.find((refItem) => refItem.key === key)
       const isObject = item.kind !== 'textBlock'
       let input: ReactNode = null
@@ -218,10 +217,11 @@ export function usePortableTextMemberItemsFromProps(
       }
     })
 
-    // oxlint-disable-next-line react/react-compiler -- @todo this should be fixed but it's difficult and needs research
+    // oxlint-disable-next-line react/refs -- @todo this should be fixed but it's difficult and needs research
     portableTextMemberItemsRef.current = items
 
     return items
+    // oxlint-disable-next-line react/memo-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [
     members,
     onPathFocus,

--- a/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/hooks/useTrackFocusPath.tsx
@@ -195,6 +195,7 @@ export function useTrackFocusPath(props: Props): void {
     elementRefs,
     focusPath,
     legacyEditor,
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
     onItemClose,
     portableTextMemberItems,
     ptInputPath,

--- a/packages/sanity/src/core/form/inputs/PortableText/object/CombinedAnnotationPopover.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/CombinedAnnotationPopover.tsx
@@ -109,7 +109,7 @@ export function CombinedAnnotationPopover(props: CombinedAnnotationPopoverProps)
   // misses the first click because annotations.length is still 0 when
   // selectionchange runs.
   useEffect(() => {
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     handleSelectionChange()
   }, [handleSelectionChange])
 
@@ -126,6 +126,7 @@ export function CombinedAnnotationPopover(props: CombinedAnnotationPopoverProps)
     if (sel && sel.rangeCount > 0) {
       rangeRef.current = sel.getRangeAt(0)
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [popoverOpen])
 
   // Listen for scroll events

--- a/packages/sanity/src/core/form/inputs/PortableText/object/InlineObjectToolbarPopover.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/InlineObjectToolbarPopover.tsx
@@ -92,7 +92,7 @@ export function InlineObjectToolbarPopover(props: InlineObjectToolbarPopoverProp
   useEffect(() => {
     focusTrappedRef.current = null
     if (inlineObjectOpen) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setPopoverOpen(false)
       return
     }

--- a/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/Plugins.tsx
@@ -212,6 +212,6 @@ const RenderDefault = (props: Omit<PortableTextPluginsProps, 'renderDefault'>) =
     defaultComponent: DefaultPortableTextEditorPlugins,
     pick: pickPortableTextEditorPluginsComponent,
   })
-  // oxlint-disable-next-line react/react-compiler -- this is intentional and how the middleware components has to work
+  // oxlint-disable-next-line react/static-components -- this is intentional and how the middleware components has to work
   return <RenderPlugins {...props} />
 }

--- a/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/modals/PopoverModal.tsx
@@ -114,7 +114,7 @@ function Content(props: PopoverEditDialogProps) {
 
   useEffect(() => {
     if (!contentElement) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setBoundaryElement(null)
       return
     }

--- a/packages/sanity/src/core/form/inputs/PortableText/presence-cursors/usePresenceCursorDecorations.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/presence-cursors/usePresenceCursorDecorations.tsx
@@ -84,7 +84,7 @@ export function usePresenceCursorDecorations(
       }
     }) as RangeDecoration[]
 
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setPresenceCursorDecorations(decorations.filter(Boolean))
   }, [currentPresence, handleRangeDecorationMoved])
 

--- a/packages/sanity/src/core/form/inputs/PortableText/text/Decorator.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/Decorator.tsx
@@ -53,7 +53,7 @@ export function Decorator(props: BlockDecoratorRenderProps) {
     return CustomComponent ? (
       <CustomComponent {...componentProps}>{children}</CustomComponent>
     ) : (
-      // oxlint-disable-next-line react/react-compiler -- this is intentional and how the middleware components has to work
+      // oxlint-disable-next-line react/static-components -- this is intentional and how the middleware components has to work
       <DefaultComponent {...componentProps}>{children}</DefaultComponent>
     )
   }, [CustomComponent, DefaultComponent, children, focused, sanitySchemaType, selected, value])

--- a/packages/sanity/src/core/form/inputs/PortableText/text/Style.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/Style.tsx
@@ -55,7 +55,7 @@ export const Style = (props: StyleProps) => {
     return CustomComponent ? (
       <CustomComponent {...componentProps}>{children}</CustomComponent>
     ) : (
-      // oxlint-disable-next-line react/react-compiler -- this is intentional and how the middleware components has to work
+      // oxlint-disable-next-line react/static-components -- this is intentional and how the middleware components has to work
       <DefaultComponent {...componentProps}>{children}</DefaultComponent>
     )
   }, [DefaultComponent, block, children, focused, sanitySchemaType, selected])

--- a/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/TextBlock.tsx
@@ -133,7 +133,7 @@ export function TextBlock(props: TextBlockProps) {
   const [memberItemRef, setMemberItemRef] = useState(memberItem)
   useEffect(() => {
     if (memberItem) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setMemberItemRef(memberItem)
     }
   }, [memberItem])

--- a/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/diff/useOptimisticDiff.tsx
+++ b/packages/sanity/src/core/form/inputs/StringInput/StringInputPortableText/diff/useOptimisticDiff.tsx
@@ -44,7 +44,7 @@ export function useOptimisticDiff({
   )
 
   useEffect(() => {
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setCurrentSignal('definitive')
     // Ensure the optimistic value is synced with the definitive value.
     setOptimisticValue(definitiveValue)

--- a/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/VirtualizedArrayList.tsx
+++ b/packages/sanity/src/core/form/inputs/arrays/ArrayOfObjectsInput/List/VirtualizedArrayList.tsx
@@ -192,6 +192,7 @@ export function VirtualizedArrayList<Item extends ObjectItem>(
   // custom components can have different dimensions and the library recalculate the size of the element
   const estimateSize = useCallback(() => 53, [])
 
+  // oxlint-disable-next-line react/incompatible-library -- pre-existing violation, to be fixed in a follow-up
   const virtualizer = useVirtualizer({
     count: members.length,
     estimateSize,

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAsset.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImageInputAsset.tsx
@@ -75,6 +75,7 @@ function ImageInputAssetComponent(props: {
         inputProps.elementProps.onFocus(event)
       }
     },
+    // oxlint-disable-next-line react/rule-suppression -- pre-existing violation, to be fixed in a follow-up
     // oxlint-disable-next-line react-hooks/exhaustive-deps
     [inputProps, elementProps.ref?.current],
   )

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/ImagePreview.tsx
@@ -21,9 +21,10 @@ export function ImagePreview(props: ComponentProps<typeof Card> & ImagePreviewPr
   useEffect(() => {
     /* set for when the src is being switched when the image input already had a image src
     - meaning it already had an asset */
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setLoaded(false)
     setHasError(false)
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [src])
 
   const onLoadChange = useCallback(() => {

--- a/packages/sanity/src/core/form/inputs/files/ImageInput/useImageObjectUrl.ts
+++ b/packages/sanity/src/core/form/inputs/files/ImageInput/useImageObjectUrl.ts
@@ -133,7 +133,7 @@ export function useImageObjectUrl(url: string | undefined): UseImageObjectUrlRes
     // No cacheKey (i.e. no URL or token) means we can't fetch. Reset to idle state,
     // skipping the update if already in an idle state
     if (!cacheKey) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setState((prev) => (prev.objectUrl || prev.isLoading || prev.error ? IDLE_RESULT : prev))
       return undefined
     }

--- a/packages/sanity/src/core/form/inputs/files/ImageToolInput/ImageToolInput.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageToolInput/ImageToolInput.tsx
@@ -88,7 +88,7 @@ export function ImageToolInput(props: ImageToolInputProps) {
   }, [onPathFocus])
 
   useEffect(() => {
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setLocalValue(value || DEFAULT_VALUE)
   }, [value])
 

--- a/packages/sanity/src/core/form/inputs/files/ImageToolInput/imagetool/ImageLoader.tsx
+++ b/packages/sanity/src/core/form/inputs/files/ImageToolInput/imagetool/ImageLoader.tsx
@@ -16,7 +16,7 @@ export function ImageLoader(props: ImageLoaderProps) {
   const [error, setError] = useState<Error | null>(null)
 
   useEffect(() => {
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setImage(null)
     setError(null)
     setIsLoading(true)

--- a/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/UploadAssetDialog.tsx
+++ b/packages/sanity/src/core/form/studio/assetSourceMediaLibrary/shared/UploadAssetDialog.tsx
@@ -133,7 +133,7 @@ export function UploadAssetsDialog(props: UploadAssetsDialogProps): ReactNode {
             type: 'uploadRequest',
             files: uploader.getFiles(),
           })
-          // oxlint-disable-next-line react/react-compiler
+          // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
           setPageReadyForUploads(false)
         }
       }

--- a/packages/sanity/src/core/form/studio/contexts/Presence.tsx
+++ b/packages/sanity/src/core/form/studio/contexts/Presence.tsx
@@ -30,13 +30,13 @@ export function useChildPresence(path: Path, inclusive?: boolean): FormNodePrese
   const presence = useFormFieldPresence()
   const prev = useRef(presence)
   const next = immutableReconcile(
-    // oxlint-disable-next-line react/react-compiler -- @todo fix later, requires research to avoid perf degradation, for now "this is fine"
+    // oxlint-disable-next-line react/refs -- @todo fix later, requires research to avoid perf degradation, for now "this is fine"
     prev.current,
     presence.filter(
       (item) => startsWith(path, item.path) && (inclusive || !isEqual(path, item.path)),
     ),
   )
-  // oxlint-disable-next-line react/react-compiler -- see above
+  // oxlint-disable-next-line react/refs -- see above
   prev.current = next
   return next
 }

--- a/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
+++ b/packages/sanity/src/core/form/studio/inputs/reference/StudioReferenceInput.tsx
@@ -269,6 +269,7 @@ export function StudioReferenceInput(props: StudioReferenceInputProps) {
       {...props}
       onSearch={
         // TODO(oxlint): remove this suppression in a follow-up once useEffectEvent support is fixed
+        // oxlint-disable-next-line react/rule-suppression -- pre-existing violation, to be fixed in a follow-up
         // oxlint-disable-next-line react-hooks/rules-of-hooks
         handleSearch
       }

--- a/packages/sanity/src/core/form/useDocumentForm.ts
+++ b/packages/sanity/src/core/form/useDocumentForm.ts
@@ -754,6 +754,7 @@ export function useDocumentForm(options: DocumentFormOptions): DocumentFormValue
     if (!ready || initialFocusPathAppliedRef.current) return
     initialFocusPathAppliedRef.current = true
     applyInitialFocusPath()
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [ready])
 
   return {

--- a/packages/sanity/src/core/hooks/useEffectEvent.test.tsx
+++ b/packages/sanity/src/core/hooks/useEffectEvent.test.tsx
@@ -24,6 +24,7 @@ describe('useEffectEvent', () => {
         return () => {
           listeners.delete(onEvent)
         }
+        // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
       }, [])
     }
 

--- a/packages/sanity/src/core/hooks/useGlobalCopyPasteElementHandler.ts
+++ b/packages/sanity/src/core/hooks/useGlobalCopyPasteElementHandler.ts
@@ -64,6 +64,7 @@ export function useGlobalCopyPasteElementHandler({
   })
 
   useEffect(() => {
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
     element?.addEventListener('keydown', handleKeydown)
 
     return () => {

--- a/packages/sanity/src/core/hooks/useTimeZone.tsx
+++ b/packages/sanity/src/core/hooks/useTimeZone.tsx
@@ -194,6 +194,7 @@ export const useTimeZone = (scope: TimeZoneScope) => {
         localStorage.removeItem(legacyKey)
       }
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [scope.type, keyValueStore, keyStoreId, currentLocale, relativeDate])
 
   const allTimeZones: NormalizedTimeZone[] = useMemo(() => {
@@ -264,7 +265,7 @@ export const useTimeZone = (scope: TimeZoneScope) => {
   const [timeZone, setTimeZone] = useState<NormalizedTimeZone>(() => getInitialTimeZone())
 
   useEffect(() => {
-    // oxlint-disable-next-line react/react-compiler -- @todo fix later
+    // oxlint-disable-next-line react/no-deriving-state-in-effects, react/set-state-in-effect -- @todo fix later
     setTimeZone(getInitialTimeZone())
   }, [getInitialTimeZone])
 

--- a/packages/sanity/src/core/perspective/navbar/AnimatedTextWidth.tsx
+++ b/packages/sanity/src/core/perspective/navbar/AnimatedTextWidth.tsx
@@ -15,6 +15,7 @@ export function AnimatedTextWidth({children, text}: {children: ReactNode; text: 
     if (!textRef.current) return
     const newWidth = textRef.current.offsetWidth
     setContainerWidth(newWidth)
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [text])
 
   const onAnimationStart = useCallback(() => {

--- a/packages/sanity/src/core/releases/components/dialog/EditReleaseDialog.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/EditReleaseDialog.tsx
@@ -57,6 +57,7 @@ export function EditReleaseDialog({
         status: 'error',
         title: t('release.toast.edit-release-error.title'),
       })
+      // oxlint-disable-next-line react/todo -- pre-existing violation, to be fixed in a follow-up
     } finally {
       isSavingRef.current = false
       setIsSaving(false)

--- a/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
+++ b/packages/sanity/src/core/releases/components/dialog/TitleDescriptionForm.tsx
@@ -128,6 +128,7 @@ export function TitleDescriptionForm({
     if (titleRef.current) {
       resizeTextarea(titleRef.current)
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [release.metadata.title])
 
   useEffect(() => {
@@ -135,6 +136,7 @@ export function TitleDescriptionForm({
       resizeTextarea(descriptionRef.current)
       setScrollHeight(descriptionRef.current.scrollHeight)
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [release.metadata.description])
 
   const handleTitleChange = useCallback(

--- a/packages/sanity/src/core/releases/contexts/ReleasesMetadataProvider.tsx
+++ b/packages/sanity/src/core/releases/contexts/ReleasesMetadataProvider.tsx
@@ -38,7 +38,7 @@ const ReleasesMetadataProviderInner = ({children}: {children: React.ReactNode}) 
   // patch metadata in local state
   useEffect(
     () =>
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setReleasesMetadata((prevReleaseMetadata) => {
         if (!observedResult.data) return prevReleaseMetadata
 

--- a/packages/sanity/src/core/releases/hooks/useGuardWithReleaseLimitUpsell.ts
+++ b/packages/sanity/src/core/releases/hooks/useGuardWithReleaseLimitUpsell.ts
@@ -9,7 +9,7 @@ export function useGuardWithReleaseLimitUpsell() {
   const {guardWithReleaseLimitUpsell} = useReleasesUpsell()
 
   useEffect(() => {
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setIsPendingGuardResponse(true)
 
     const promise = new Promise<boolean>((resolve) => {
@@ -19,6 +19,7 @@ export function useGuardWithReleaseLimitUpsell() {
     })
 
     setReleasePromise(promise)
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [guardWithReleaseLimitUpsell, isPendingGuardResponse])
 
   return {

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenu.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenu.tsx
@@ -96,6 +96,7 @@ export const ReleaseMenu = ({
     unarchive,
     archive,
     deleteRelease,
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
     release.metadata.releaseType,
     publishRelease,
     schedule,

--- a/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenuButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/ReleaseMenuButton/ReleaseMenuButton.tsx
@@ -227,6 +227,7 @@ export const ReleaseMenuButton = ({
     if (!selectedAction || isActionPublishOrSchedule) return
 
     if (!RELEASE_ACTION_MAP[selectedAction].confirmDialog) void handleAction(selectedAction)
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [documentsCount, handleAction, isActionPublishOrSchedule, selectedAction])
 
   const confirmActionDialog = useMemo(() => {

--- a/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
+++ b/packages/sanity/src/core/releases/tool/components/Table/Table.tsx
@@ -101,6 +101,7 @@ const TableInner = <TableData, AdditionalRowTableData>({
     })
   }, [columnDefs, data, searchFilter, searchTerm, sort])
 
+  // oxlint-disable-next-line react/incompatible-library -- pre-existing violation, to be fixed in a follow-up
   const rowVirtualizer = useVirtualizer({
     count: filteredData.length,
     getScrollElement: () => scrollContainerRef,

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleasePublishAllButton.tsx
@@ -95,6 +95,7 @@ export const ReleasePublishAllButton = ({
     return () => {
       isMounted.current = false
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [checkWithPermissionGuard, publishRelease, release._id, release.metadata.intendedPublishAt])
 
   const handleConfirmPublishAll = useCallback(async () => {

--- a/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
+++ b/packages/sanity/src/core/releases/tool/components/releaseCTAButtons/ReleaseScheduleButton.tsx
@@ -92,6 +92,7 @@ export const ReleaseScheduleButton = ({
     return () => {
       isMounted.current = false
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [checkWithPermissionGuard, release._id, release.metadata.intendedPublishAt, schedule])
 
   const isScheduledDateInPast = useCallback(() => {

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseActivityList.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseActivityList.tsx
@@ -77,6 +77,7 @@ export const ReleaseActivityList = ({
     })
   }, [events, hasMore, isLoading])
 
+  // oxlint-disable-next-line react/incompatible-library -- pre-existing violation, to be fixed in a follow-up
   const virtualizer = useVirtualizer({
     // If we have more events, or the events are loading, we add a loader row at the end
     count: hasMore || isLoading ? listEvents.length + 1 : listEvents.length,

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseDetailsEditor.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseDetailsEditor.tsx
@@ -73,6 +73,7 @@ function ReleaseDetailsEditorProduction({release}: {release: ReleaseDocument}): 
     return () => {
       isMounted.current = false
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [checkWithPermissionGuard, release, release._id, updateRelease])
 
   return (

--- a/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ReleaseSummary.tsx
@@ -180,10 +180,11 @@ export function ReleaseSummary(props: ReleaseSummaryProps) {
 
     if (documentsNoLongerPending.length)
       // cleanup all resolved added documents
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setPendingAddedDocument((prev) =>
         prev.filter(({document}) => !documentsNoLongerPending.includes(document._id)),
       )
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [documents, pendingAddedDocument, t, toast])
 
   const tableData = useMemo(

--- a/packages/sanity/src/core/releases/tool/detail/ValidationProgressIndicator.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/ValidationProgressIndicator.tsx
@@ -46,13 +46,14 @@ export function ValidationProgressIndicator({
       return () => clearTimeout(timer)
     }
     return undefined
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [isFinished, showCheckmark])
 
   useEffect(() => {
     // If it's not validating, we should not be showing the checkmark
     // it is only shown after a delay set by the previous useEffect
     if (isValidating) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setShowCheckmark(false)
     }
   }, [isValidating])

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/DocumentTableColumnDefs.tsx
@@ -124,6 +124,7 @@ export function DocumentType({type}: {type: string}) {
   // A title change rewrites the text without resizing the box, so re-measure on title change.
   useEffect(() => {
     checkTruncation()
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [title, checkTruncation])
 
   const textElement = (

--- a/packages/sanity/src/core/releases/tool/detail/documentTable/useReleaseHistory.ts
+++ b/packages/sanity/src/core/releases/tool/detail/documentTable/useReleaseHistory.ts
@@ -120,7 +120,7 @@ export function useReleaseHistory(
 
   useEffect(() => {
     cancelledRef.current = false
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     void fetchAndParse()
     return () => {
       cancelledRef.current = true

--- a/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
+++ b/packages/sanity/src/core/releases/tool/overview/ReleasesOverview.tsx
@@ -289,7 +289,7 @@ export function ReleasesOverview() {
   const [hasMounted, setHasMounted] = useState(false)
 
   useEffect(() => {
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setHasMounted(true)
   }, [])
 

--- a/packages/sanity/src/core/scheduled-publishing/components/dateInputs/CommonDateTimeInput.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/dateInputs/CommonDateTimeInput.tsx
@@ -56,8 +56,9 @@ export function CommonDateTimeInput(props: Props & RefAttributes<HTMLInputElemen
   const [localValue, setLocalValue] = useState<string | null>(null)
 
   useEffect(() => {
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setLocalValue(null)
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [value])
 
   const {zoneDateToUtc} = useTimeZone(timeZoneScope)

--- a/packages/sanity/src/core/scheduled-publishing/components/dateInputs/base/calendar/Calendar.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/dateInputs/base/calendar/Calendar.tsx
@@ -186,6 +186,7 @@ export function Calendar(props: CalendarProps & RefAttributes<HTMLDivElement>) {
     ) {
       focusCurrentWeekDay()
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [ref, focusCurrentWeekDay, focusedDate])
 
   const handleNowClick = useCallback(() => onSelect(new Date()), [onSelect])

--- a/packages/sanity/src/core/scheduled-publishing/components/scheduleItem/ToolPreview.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/components/scheduleItem/ToolPreview.tsx
@@ -50,7 +50,7 @@ const ToolPreview = (props: Props) => {
         />
       )
     }
-    // oxlint-disable-next-line react/react-compiler -- displayName assignment on render-local component
+    // oxlint-disable-next-line react/immutability -- displayName assignment on render-local component
     Component.displayName = 'LinkComponent'
     return Component
   }, [schemaType, visibleDocument])

--- a/packages/sanity/src/core/scheduled-publishing/tool/schedules/VirtualList.tsx
+++ b/packages/sanity/src/core/scheduled-publishing/tool/schedules/VirtualList.tsx
@@ -34,6 +34,7 @@ const VirtualList = () => {
   // Reset virtual list scroll position on state changes
   useEffect(() => {
     containerRef?.current?.scrollTo(0, 0)
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [scheduleState, sortBy, containerRef])
 
   return (
@@ -93,6 +94,7 @@ function useVirtualizedSchedules(activeSchedules: Schedule[], sortBy?: ScheduleS
     return items
   }, [activeSchedules, sortBy])
 
+  // oxlint-disable-next-line react/incompatible-library -- pre-existing violation, to be fixed in a follow-up
   const virtualizer = useVirtualizer({
     count: listSourceItems.length,
     getScrollElement: () => containerRef.current,

--- a/packages/sanity/src/core/store/translog/useDocumentLastEditedBy.ts
+++ b/packages/sanity/src/core/store/translog/useDocumentLastEditedBy.ts
@@ -106,7 +106,7 @@ export function useDocumentLastEditedBy(
 
   useEffect(() => {
     cancelledRef.current = false
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     void fetchLastEditor()
     return () => {
       cancelledRef.current = true

--- a/packages/sanity/src/core/studio/StudioErrorBoundary.tsx
+++ b/packages/sanity/src/core/studio/StudioErrorBoundary.tsx
@@ -75,7 +75,6 @@ export function StudioErrorBoundary(props: StudioErrorBoundaryProps) {
       setCaughtError({
         error: params.error,
         componentStack: params.info.componentStack,
-        // oxlint-disable-next-line react/react-compiler
         eventId,
       })
     },

--- a/packages/sanity/src/core/studio/StudioLayout.tsx
+++ b/packages/sanity/src/core/studio/StudioLayout.tsx
@@ -35,6 +35,6 @@ export function StudioLayout() {
   // The default component is `StudioLayoutComponent`.
   const Layout = useLayoutComponent()
 
-  // oxlint-disable-next-line react/react-compiler -- this is intentional and how the middleware components has to work
+  // oxlint-disable-next-line react/static-components -- this is intentional and how the middleware components has to work
   return <Layout />
 }

--- a/packages/sanity/src/core/studio/StudioLayoutComponent.tsx
+++ b/packages/sanity/src/core/studio/StudioLayoutComponent.tsx
@@ -186,7 +186,7 @@ export function StudioLayoutComponent() {
   return (
     <Flex data-ui="ToolScreen" direction="column" height="fill" data-testid="studio-layout">
       <NavbarContext.Provider value={navbarContextValue}>
-        {/* oxlint-disable-next-line react/react-compiler -- Navbar comes from useNavbarComponent(), stable per workspace */}
+        {/* oxlint-disable-next-line react/static-components -- Navbar comes from useNavbarComponent(), stable per workspace */}
         <Navbar />
       </NavbarContext.Provider>
       <UnclaimedProjectNudge />
@@ -215,7 +215,7 @@ export function StudioLayoutComponent() {
               }
             >
               <Suspense fallback={<LoadingBlock showText />}>
-                {/* oxlint-disable-next-line react/react-compiler -- ActiveToolLayout comes from useActiveToolLayoutComponent(), stable per workspace */}
+                {/* oxlint-disable-next-line react/static-components -- ActiveToolLayout comes from useActiveToolLayoutComponent(), stable per workspace */}
                 <ActiveToolLayout activeTool={activeTool} />
                 <ToolMountTimer toolName={activeTool.name} t0Ref={toolMountT0Ref} />
               </Suspense>

--- a/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/StudioNavbar.tsx
@@ -238,7 +238,7 @@ export function StudioNavbar(props: Omit<NavbarProps, 'renderDefault'>) {
             {/** Center flex */}
             <Flex align="center" justify="center" style={CENTER_TOOLS_STYLE}>
               {shouldRender.tools && (
-                // oxlint-disable-next-line react/react-compiler -- this is intentional and how the middleware components has to work
+                // oxlint-disable-next-line react/static-components -- this is intentional and how the middleware components has to work
                 <ToolMenu
                   activeToolName={activeToolName}
                   closeSidebar={handleCloseDrawer}

--- a/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrial.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/free-trial/FreeTrial.tsx
@@ -32,7 +32,7 @@ export function FreeTrial({type}: FreeTrialProps) {
   useEffect(() => {
     if (ref) {
       // set popover visible when the ref has been set (i.e. the element is ready)
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setShowPopover(true)
     }
   }, [ref])

--- a/packages/sanity/src/core/studio/components/navbar/navDrawer/NavDrawer.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/navDrawer/NavDrawer.tsx
@@ -202,7 +202,7 @@ export const NavDrawer = memo(function NavDrawer(props: NavDrawerProps) {
               <Flex direction="column" flex={1} justify="space-between" overflow="auto">
                 {/* Tools */}
                 <Card flex="none" padding={2}>
-                  {/* oxlint-disable-next-line react/react-compiler -- this is intentional and how the middleware components has to work */}
+                  {/* oxlint-disable-next-line react/static-components -- this is intentional and how the middleware components has to work */}
                   <ToolMenu
                     activeToolName={activeToolName}
                     closeSidebar={onClose}

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/Filters.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/Filters.tsx
@@ -37,7 +37,7 @@ export function Filters({showTypeFilter = true}: {showTypeFilter?: boolean}) {
   const clearFiltersButtonVisible = filters.length > 0 || (showTypeFilter && types.length > 0)
 
   useEffect(() => {
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setIsMounted(true)
   }, [])
 

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/common/FilterPopoverWrapper.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/common/FilterPopoverWrapper.tsx
@@ -83,7 +83,7 @@ function usePopoverOffset(element: HTMLElement | null) {
 
   useEffect(() => {
     if (element) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setOffset(calcPopoverOffset(element))
     }
   }, [element])

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/ParsedDateTextInput.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/ParsedDateTextInput.tsx
@@ -144,12 +144,13 @@ export function ParsedDateTextInput({
   useEffect(() => {
     const updatedDate = value && new Date(value)
     if (updatedDate) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       processInputString({
         dateString: format(updatedDate, dateFormat),
         triggerOnChange: false,
       })
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [dateFormat, processInputString, isDateTimeFormat, value])
 
   return (

--- a/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/datePicker/calendar/Calendar.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/components/filters/filter/inputs/date/datePicker/calendar/Calendar.tsx
@@ -150,6 +150,7 @@ export function Calendar(props: CalendarProps) {
     ) {
       focusCurrentWeekDay()
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [focusCurrentWeekDay, focusedDate])
 
   useEffect(() => {
@@ -162,7 +163,7 @@ export function Calendar(props: CalendarProps) {
     // Only date has changed
     if (onlyDateChanged) {
       if (dateIsAfterEndDate) {
-        // oxlint-disable-next-line react/react-compiler
+        // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
         setSelectEndValue(true)
         onSelect({date, endDate: null})
       }

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
@@ -253,6 +253,7 @@ export function SearchProvider({
     previousTermsRef.current = terms
   }, [
     completeFilters.length,
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
     currentFilters,
     documentTypes,
     handleSearch,
@@ -276,6 +277,7 @@ export function SearchProvider({
     }
 
     isMountedRef.current = true
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [dispatch, hasValidTerms, result.hits, terms.query, terms.types])
 
   const value = useMemo(

--- a/packages/sanity/src/core/studio/liveUserApplication/LiveUserApplicationProvider.tsx
+++ b/packages/sanity/src/core/studio/liveUserApplication/LiveUserApplicationProvider.tsx
@@ -28,7 +28,7 @@ export function LiveUserApplicationProvider({children}: LiveUserApplicationProvi
 
   useEffect(() => {
     let hasSubscriber = true
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setIsLoading(true)
     findUserApplication(userApplicationCache, workspaces)
       .then((found) => {

--- a/packages/sanity/src/core/studio/requestErrors/RequestErrorDialog.tsx
+++ b/packages/sanity/src/core/studio/requestErrors/RequestErrorDialog.tsx
@@ -194,6 +194,7 @@ function RateLimitedDialog(props: {
     // disabled state. Intentional sync to the external claim, not a cascade —
     // deferred via startTransition so React can schedule the re-render lazily.
     startTransition(() => setRetrying(false))
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [claim])
   const handleRetry = useCallback(() => {
     setRetrying(true)

--- a/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
+++ b/packages/sanity/src/core/studio/telemetry/StudioTelemetryProvider.tsx
@@ -183,7 +183,7 @@ export function StudioTelemetryProvider(props: {children: ReactNode}) {
 
   // The storeOptions callbacks access contextRef.current, but only when called
   // asynchronously (on flush), not during render. Suppress the lint warning.
-  // oxlint-disable-next-line react/react-compiler
+  // oxlint-disable-next-line react/refs -- pre-existing violation, to be fixed in a follow-up
   const store = useMemo(() => createBatchedStore(sessionId, storeOptions), [storeOptions])
 
   // Per-instance guard so StrictMode's double-invoked mount effect logs StudioLoaded once.

--- a/packages/sanity/src/core/tasks/components/form/fields/TitleField.tsx
+++ b/packages/sanity/src/core/tasks/components/form/fields/TitleField.tsx
@@ -71,6 +71,7 @@ export function Title(props: {
     if (!ref.current) return
     ref.current.style.height = 'auto'
     ref.current.style.height = `${ref.current.scrollHeight}px`
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [value])
 
   const handleChange = useCallback(

--- a/packages/sanity/src/core/tasks/components/form/fields/descriptionInput/DescriptionInput.tsx
+++ b/packages/sanity/src/core/tasks/components/form/fields/descriptionInput/DescriptionInput.tsx
@@ -70,8 +70,9 @@ export function DescriptionInput(props: ArrayFieldProps & {mode: FormMode}) {
 
   useEffect(() => {
     if (!rootRef) return
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setTextboxHeight(rootRef)
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [value, setTextboxHeight, rootRef])
 
   if (!currentUser) return null

--- a/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/FormCreate.tsx
+++ b/packages/sanity/src/core/tasks/components/form/tasksFormBuilder/FormCreate.tsx
@@ -73,6 +73,7 @@ export function FormCreate(props: ObjectInputProps) {
     if (creating && savedTask?.createdByUser) {
       handleCreatingSuccess()
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [creating, savedTask?.createdByUser])
 
   const handleCreatingTimeout = useEffectEvent(() => {
@@ -93,6 +94,7 @@ export function FormCreate(props: ObjectInputProps) {
     return () => {
       if (timeoutId) clearTimeout(timeoutId)
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [creating])
 
   const handleCreate = useCallback(async () => {

--- a/packages/sanity/src/core/tasks/hooks/useActivityLog.ts
+++ b/packages/sanity/src/core/tasks/hooks/useActivityLog.ts
@@ -54,6 +54,7 @@ export function useActivityLog(task: TaskDocument): {
   useEffect(() => {
     // Task is updated on every change, wait until the revision changes to update the activity log.
     void handleFetchAndParse(task._rev)
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [task._rev])
   return {changes}
 }

--- a/packages/sanity/src/core/util/__tests__/createHookFromObservableFactory.test.tsx
+++ b/packages/sanity/src/core/util/__tests__/createHookFromObservableFactory.test.tsx
@@ -126,6 +126,7 @@ describe('createHookFromObservableFactory', () => {
     })
     const TestComponent = ({value}: {value: string}) => {
       const result = useHook(value)
+      // oxlint-disable-next-line react/todo -- pre-existing violation, to be fixed in a follow-up
       syncRenders++
       const deferredResult = useDeferredValue(result)
       return <InnerMemoTestComponent tuple={deferredResult} />

--- a/packages/sanity/src/presentation/PresentationTool.tsx
+++ b/packages/sanity/src/presentation/PresentationTool.tsx
@@ -312,12 +312,13 @@ export default function PresentationTool(props: {
     comlink.onStatus(setOverlaysConnection)
 
     const stop = comlink.start()
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setVisualEditingComlink(comlink)
     return () => {
       stop()
       setVisualEditingComlink(null)
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [controller, presentationRef, setDocumentsOnPage, setOverlaysConnection, targetOrigin])
 
   useEffect(() => {
@@ -347,6 +348,7 @@ export default function PresentationTool(props: {
     })
 
     return comlink.start()
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [controller, dataset, projectId, setDocumentsOnPage, setPreviewKitConnection, targetOrigin])
 
   const handleFocusPath = useMemo(

--- a/packages/sanity/src/presentation/document/PresentationDocumentProvider.tsx
+++ b/packages/sanity/src/presentation/document/PresentationDocumentProvider.tsx
@@ -42,6 +42,7 @@ export function PresentationDocumentProvider(props: {
   const registerEffectEvent = useEffectEvent((options: PresentationPluginOptions) =>
     register(options),
   )
+  // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   useLayoutEffect(() => registerEffectEvent(options), [options])
 
   return (

--- a/packages/sanity/src/presentation/editor/DocumentListPane.tsx
+++ b/packages/sanity/src/presentation/editor/DocumentListPane.tsx
@@ -153,7 +153,7 @@ export function DocumentListPane(props: {
   const [structureParams] = useState(() => ({}))
 
   // Reset error state when `refs` value changes
-  // oxlint-disable-next-line react/react-compiler
+  // oxlint-disable-next-line react/exhaustive-effect-dependencies, react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
   useEffect(() => setErrorParams(null), [refs])
 
   if (errorParams) {

--- a/packages/sanity/src/presentation/editor/DocumentPane.tsx
+++ b/packages/sanity/src/presentation/editor/DocumentPane.tsx
@@ -86,8 +86,9 @@ export function DocumentPane(props: {
 
   // Reset error state when parameters change
   useEffect(() => {
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setErrorParams(null)
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [documentId, documentType, structureParams])
 
   if (errorParams) {

--- a/packages/sanity/src/presentation/loader/BroadcastDisplayedDocument.tsx
+++ b/packages/sanity/src/presentation/loader/BroadcastDisplayedDocument.tsx
@@ -17,6 +17,7 @@ function BroadcastDisplayedDocument(props: {
   useEffect(() => {
     const timeout = setTimeout(() => setDisplayedDocument?.(props.value), 10)
     return () => clearTimeout(timeout)
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [params?.perspective, props.value, setDisplayedDocument])
 
   return null

--- a/packages/sanity/src/presentation/loader/LiveQueries.tsx
+++ b/packages/sanity/src/presentation/loader/LiveQueries.tsx
@@ -81,7 +81,7 @@ export default function LiveQueries(props: LiveQueriesProps): React.JSX.Element 
           actors: createCompatibilityActors<LoaderControllerMsg>(),
         }),
       )
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setComlink(nextComlink)
 
       nextComlink.onStatus(onLoadersConnection)
@@ -260,6 +260,7 @@ function QuerySubscriptionComponent(props: QuerySubscriptionProps) {
       handleQueryChange(comlink, perspective, variant, query, params, result, resultSourceMap, tags)
     }
     return undefined
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [comlink, params, perspective, query, result, resultSourceMap, tags, variant])
 
   return null

--- a/packages/sanity/src/presentation/panels/Panels.tsx
+++ b/packages/sanity/src/presentation/panels/Panels.tsx
@@ -203,7 +203,7 @@ export const Panels: FunctionComponent<PropsWithChildren> = function ({children}
 
     if (storedWidths) {
       const validatedStoredWidths = validateWidths(panels, storedWidths, window.innerWidth)
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setWidths(validatedStoredWidths)
       return
     }

--- a/packages/sanity/src/presentation/preview/Preview.tsx
+++ b/packages/sanity/src/presentation/preview/Preview.tsx
@@ -155,7 +155,7 @@ export const Preview = memo(function PreviewComponent(
       /**
        * Only set the stable perspective if it hasn't been set yet.
        */
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setStablePerspective((prev) => (prev === null ? perspective : prev))
     }
   }, [handlesPerspectiveChange, perspective])
@@ -167,7 +167,7 @@ export const Preview = memo(function PreviewComponent(
      * variant changes in `src` so they no longer cause a full page reload.
      */
     if (handlesVariantChange) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setStableVariant((prev) => (prev === null ? variant : prev))
     }
   }, [handlesVariantChange, variant])
@@ -223,7 +223,7 @@ export const Preview = memo(function PreviewComponent(
      * deadline — a slow mutation or manual refresh is not a failed load.
      */
     if (!isLoading) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setLoadTimedOut(false)
       /**
        * A load-timeout dismissal has to be cleared here, since `continueAnyway` is otherwise only
@@ -278,7 +278,7 @@ export const Preview = memo(function PreviewComponent(
       return undefined
     }
     if (overlaysConnection === 'connected') {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setSomethingIsWrong(false)
       setShowOverlaysConnectionState(false)
       setTimedOut(false)
@@ -422,6 +422,7 @@ export const Preview = memo(function PreviewComponent(
       stop()
       controller.destroy()
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [checkOrigin])
   useEffect(() => {
     if (overlaysConnection === 'connecting' || overlaysConnection === 'reconnecting') {
@@ -455,6 +456,7 @@ export const Preview = memo(function PreviewComponent(
             'origin' in data.data &&
             typeof data.data.origin === 'string'
           ) {
+            // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
             reportMismatchingOrigin(data.data.origin)
           }
         },

--- a/packages/sanity/src/presentation/preview/PreviewLocationInput.tsx
+++ b/packages/sanity/src/presentation/preview/PreviewLocationInput.tsx
@@ -112,9 +112,10 @@ export function PreviewLocationInput(props: {
   }, [targetOrigin, value])
 
   useEffect(() => {
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setCustomValidity(undefined)
     setSessionValue(undefined)
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [targetOrigin, value])
 
   const resetButton: TextInputClearButtonProps = useMemo(() => ({icon: ResetIcon}), [])

--- a/packages/sanity/src/presentation/useMainDocument.ts
+++ b/packages/sanity/src/presentation/useMainDocument.ts
@@ -146,6 +146,7 @@ export function useMainDocument(props: {
    */
   if (resolvers.length > 0) {
     if (typeof URLPattern === 'undefined') {
+      // oxlint-disable-next-line react/todo -- pre-existing violation, to be fixed in a follow-up
       urlPatternPolyfillPromise ??= import('urlpattern-polyfill')
     }
     // Once a load has started, keep unwrapping the same promise on every render: the resolved
@@ -236,10 +237,11 @@ export function useMainDocument(props: {
         }
       }
     }
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setMainDocumentState(undefined)
     mainDocumentIdRef.current = undefined
     return undefined
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [client, perspective, relativeUrl, resolvers, targetOrigin, variant])
 
   return mainDocumentState

--- a/packages/sanity/src/structure/components/IntentButton.tsx
+++ b/packages/sanity/src/structure/components/IntentButton.tsx
@@ -28,7 +28,7 @@ export function IntentButton(
         />
       )
     }
-    // oxlint-disable-next-line react/react-compiler -- displayName assignment on render-local component
+    // oxlint-disable-next-line react/immutability -- displayName assignment on render-local component
     LinkComponent.displayName = 'Link'
     return LinkComponent
   }, [intent])

--- a/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx
+++ b/packages/sanity/src/structure/components/incomingReferencesDecoration/IncomingReferencesType.tsx
@@ -186,6 +186,7 @@ function IncomingReferencesTypeList({
           description: err instanceof Error ? err.message : undefined,
           status: 'error',
         })
+        // oxlint-disable-next-line react/todo -- pre-existing violation, to be fixed in a follow-up
       } finally {
         // Always clear the optimistic placeholder. The effect below also clears
         // it once the linked document shows up in `documents`, but that never
@@ -203,7 +204,7 @@ function IncomingReferencesTypeList({
       const isAdded = documents.find(
         (document) => getPublishedId(document._id) === getPublishedId(newReferenceId),
       )
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       if (isAdded) setNewReferenceId(null)
     }
   }, [documents, newReferenceId])

--- a/packages/sanity/src/structure/components/pane/PaneDivider.tsx
+++ b/packages/sanity/src/structure/components/pane/PaneDivider.tsx
@@ -91,7 +91,6 @@ export function PaneDivider({
         setDragging(false)
 
         window.removeEventListener('mousemove', handleMouseMove)
-        // oxlint-disable-next-line react/react-compiler
         window.removeEventListener('mouseup', handleMouseUp)
 
         resize('end', element, 0)

--- a/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx
+++ b/packages/sanity/src/structure/components/paneHeaderActions/PaneHeaderCreateButton.tsx
@@ -170,7 +170,7 @@ export function PaneHeaderCreateButton({templateItems}: PaneHeaderCreateButtonPr
               )
             }
 
-            // oxlint-disable-next-line react/react-compiler -- displayName assignment on render-local component
+            // oxlint-disable-next-line react/immutability -- displayName assignment on render-local component
             Link.displayName = 'Link'
 
             const {title} = getI18nText({

--- a/packages/sanity/src/structure/components/paneItem/PaneItem.tsx
+++ b/packages/sanity/src/structure/components/paneItem/PaneItem.tsx
@@ -144,7 +144,7 @@ export function PaneItem(props: PaneItemProps) {
   }, [])
 
   // Reset `clicked` state when `selected` prop changes
-  // oxlint-disable-next-line react/react-compiler
+  // oxlint-disable-next-line react/exhaustive-effect-dependencies, react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
   useEffect(() => setClicked(false), [selected])
 
   // Preloads the edit state on hover, using concurrent rendering with `startTransition` so preloads can be interrupted and not block rendering

--- a/packages/sanity/src/structure/components/structureTool/StructureTitle.tsx
+++ b/packages/sanity/src/structure/components/structureTool/StructureTitle.tsx
@@ -45,6 +45,7 @@ export const DocumentTitle = ({
     if (!ready || previewValueIsLoading) return
     // Set the title as the document title
     document.title = newTitle
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [documentTitle, ready, newTitle, previewValueIsLoading])
 
   return null
@@ -56,6 +57,7 @@ const PassthroughTitle = (props: {title?: string}) => {
   useEffect(() => {
     // Set the title as the document title
     document.title = newTitle
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [newTitle, title])
   return null
 }

--- a/packages/sanity/src/structure/diffView/components/DiffViewPane.tsx
+++ b/packages/sanity/src/structure/diffView/components/DiffViewPane.tsx
@@ -131,7 +131,7 @@ export function DiffViewPane({
                 <PortalProvider element={portalElement}>
                   <DialogProvider position="absolute">
                     <Container ref={containerElement} padding={4} width={1}>
-                      {/* oxlint-disable-next-line react/react-compiler -- this is intentional and how the middleware components has to work */}
+                      {/* oxlint-disable-next-line react/static-components -- this is intentional and how the middleware components has to work */}
                       <DocumentLayout documentId={documentId} documentType={documentType} />
                     </Container>
                   </DialogProvider>
@@ -204,6 +204,7 @@ const DiffViewDocument: ComponentType<DiffViewPaneProps> = ({
       onProgrammaticFocus(path)
     })
     return () => subscription.unsubscribe()
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [onPathOpenFromForm, onProgrammaticFocus, pathSyncChannel.path, role])
 
   return isLoading ? (

--- a/packages/sanity/src/structure/documentActions/PublishAction.tsx
+++ b/packages/sanity/src/structure/documentActions/PublishAction.tsx
@@ -134,7 +134,7 @@ export const usePublishAction: DocumentActionComponent = (props) => {
     }
 
     if (!hasValidationErrors) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       doPublish()
     } else {
       // User tried to publish before validation was complete
@@ -152,6 +152,7 @@ export const usePublishAction: DocumentActionComponent = (props) => {
     publishScheduled,
     validationStatus.revision,
     revision,
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
     isValidating,
     validationStatus.isValidating,
     toast,
@@ -182,6 +183,7 @@ export const usePublishAction: DocumentActionComponent = (props) => {
       setPublishState(nextState)
     }, delay)
     return () => clearTimeout(timer)
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [changesOpen, publishState, currentPublishRevision, telemetry, id])
 
   const isWaitingToPublish = Boolean(

--- a/packages/sanity/src/structure/panes/document/DocumentInspectorMenuItemsResolver.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentInspectorMenuItemsResolver.tsx
@@ -30,7 +30,7 @@ export function DocumentInspectorMenuItemsResolver(props: DocumentInspectorMenuI
         newFieldActions[i] = menuItems[i]
       }
 
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setMenuItems(newFieldActions)
     }
   }, [len, menuItems])

--- a/packages/sanity/src/structure/panes/document/DocumentPane.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPane.tsx
@@ -187,7 +187,7 @@ function DocumentPaneInner(props: DocumentPaneProviderProps) {
       >
         <DiffViewDocumentLayout documentId={options.id} documentType={options.type}>
           <CommentsWrapper documentId={options.id} documentType={options.type}>
-            {/* oxlint-disable-next-line react/react-compiler -- this is intentional and how the middleware components has to work */}
+            {/* oxlint-disable-next-line react/static-components -- this is intentional and how the middleware components has to work */}
             <DocumentLayout documentId={options.id} documentType={options.type} />
           </CommentsWrapper>
         </DiffViewDocumentLayout>

--- a/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
+++ b/packages/sanity/src/structure/panes/document/DocumentPaneProvider.tsx
@@ -756,6 +756,7 @@ export function DocumentPaneProvider(props: DocumentPaneProviderProps) {
     pathRef.current = paramPath
 
     return undefined
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [paramPath, ready])
 
   // Disable when `formState` or `schemaType` is transiently absent
@@ -842,6 +843,7 @@ const DivergenceAutofocus: ComponentType<
   })
 
   useEffect(() => {
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
     focusDivergentPath()
   }, [focusedDivergence])
 

--- a/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
+++ b/packages/sanity/src/structure/panes/document/documentPanel/documentViews/FormView.tsx
@@ -172,6 +172,7 @@ export function FormView(props: FormViewProps & RefAttributes<HTMLFormElement>) 
       handleInitialValue()
     }
     // React to changes in hasRev only
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [hasRev])
 
   const [formRef, setFormRef] = useState<null | HTMLFormElement>(null)
@@ -191,7 +192,7 @@ export function FormView(props: FormViewProps & RefAttributes<HTMLFormElement>) 
 
   useEffect(() => {
     if (focusPath.length !== 0) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setHasFocusedAnyPath(true)
     }
   }, [focusPath])

--- a/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusLine.tsx
+++ b/packages/sanity/src/structure/panes/document/statusBar/DocumentStatusLine.tsx
@@ -217,20 +217,23 @@ export function DocumentStatusLine() {
       const timerId = setTimeout(() => setStatus(null), SAVED_TIMEOUT)
       return () => clearTimeout(timerId)
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [status, lastUpdated, syncState.isSyncing])
 
   // Clear the status when documentId changes to make sure we don't show the wrong status when opening a new document
   useLayoutEffect(() => {
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     setStatus(null)
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [documentId])
 
   // Set status to 'syncing' when lastUpdated changes and we go from not syncing to syncing
   useLayoutEffect(() => {
     if (syncState.isSyncing) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setStatus('syncing')
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [syncState.isSyncing, lastUpdated])
 
   return (

--- a/packages/sanity/src/structure/panes/document/timeline/events/EventsTimeline.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/events/EventsTimeline.tsx
@@ -216,7 +216,7 @@ export const EventsTimeline = ({
     ],
   )
 
-  // oxlint-disable-next-line react/react-compiler
+  // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
   useEffect(() => setMounted(true), [])
   const selectedIndex = events.findIndex((event) => event.id === selectedEventId)
 

--- a/packages/sanity/src/structure/panes/document/timeline/timeline.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/timeline.tsx
@@ -61,7 +61,7 @@ export const Timeline = ({
       const selected = chunksWithMetadata.find((chunk) => chunk.id === selectedChunkId)
       if (selected && isNonPublishChunk(selected) && selected.parentId) {
         const parentId = selected.parentId
-        // oxlint-disable-next-line react/react-compiler
+        // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
         setExpandedParents((prev) => {
           if (prev.has(parentId)) return prev
           const next = new Set(prev)
@@ -159,7 +159,7 @@ export const Timeline = ({
     ],
   )
 
-  // oxlint-disable-next-line react/react-compiler
+  // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
   useEffect(() => setMounted(true), [])
 
   return (

--- a/packages/sanity/src/structure/panes/document/timeline/timelineItem.tsx
+++ b/packages/sanity/src/structure/panes/document/timeline/timelineItem.tsx
@@ -158,7 +158,7 @@ export function TimelineItem({
           <div style={{position: 'relative'}}>
             <UserAvatarStack maxLength={3} userIds={authorUserIds} size={2} />
             <IconBox align="center" justify="center" $color={TIMELINE_ITEM_EVENT_TONE[type]}>
-              {/* oxlint-disable-next-line react/react-compiler -- this is intentional and how the middleware components has to work */}
+              {/* oxlint-disable-next-line react/static-components -- this is intentional and how the middleware components has to work */}
               <Text size={0}>{IconComponent && <IconComponent />}</Text>
             </IconBox>
           </div>

--- a/packages/sanity/src/structure/panes/document/useResetHistoryParams.ts
+++ b/packages/sanity/src/structure/panes/document/useResetHistoryParams.ts
@@ -36,6 +36,7 @@ export function useResetHistoryParams() {
     if (isMounted.current) {
       updateHistoryParams(selectedPerspectiveName)
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [selectedPerspectiveName])
 
   useEffect(() => {

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx
@@ -232,7 +232,7 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
 
   useEffect(() => {
     if (!enableSearchSpinner && !isLoading) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setEnableSearchSpinner(paneKey)
     }
   }, [enableSearchSpinner, isLoading, paneKey])
@@ -240,9 +240,10 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
   useEffect(() => {
     // Clear search field and disable search spinner
     // when switching between panes (i.e. when paneKey changes).
-    // oxlint-disable-next-line react/react-compiler
+    // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
     handleClearSearch()
     setEnableSearchSpinner()
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [paneKey, handleClearSearch])
 
   useEffect(() => {
@@ -251,7 +252,7 @@ export const DocumentListPane = memo(function DocumentListPane(props: DocumentLi
     // applied ordering back to relevance.
     if (!trimmedSearchQuery) {
       // TODO: Refactor search ordering reset to avoid effect state updates.
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setSearchOrderingId(RELEVANCE_ORDERING_ID)
     }
   }, [trimmedSearchQuery])

--- a/packages/sanity/src/structure/panes/documentList/DocumentListPaneContent.tsx
+++ b/packages/sanity/src/structure/panes/documentList/DocumentListPaneContent.tsx
@@ -129,6 +129,7 @@ export function DocumentListPaneContent(props: DocumentListPaneContentProps) {
     return () => {
       clearTimeout(timer)
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- pre-existing violation, to be fixed in a follow-up
   }, [collapsed, items])
 
   const renderItem = useCallback<CommandListRenderItemCallback<SanityDocument>>(

--- a/packages/sanity/test/browser/TestForm.tsx
+++ b/packages/sanity/test/browser/TestForm.tsx
@@ -107,7 +107,7 @@ export function TestForm(props: TestFormProps) {
 
   useEffect(() => {
     if (documentFromProps) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setDocument(documentFromProps)
       windowWithDocumentState.documentState = documentFromProps
     }
@@ -115,7 +115,7 @@ export function TestForm(props: TestFormProps) {
 
   useEffect(() => {
     if (focusPathFromProps) {
-      // oxlint-disable-next-line react/react-compiler
+      // oxlint-disable-next-line react/set-state-in-effect -- pre-existing violation, to be fixed in a follow-up
       setFocusPath(focusPathFromProps)
 
       const lastSegment = focusPathFromProps[focusPathFromProps.length - 1]
@@ -273,12 +273,10 @@ export function TestForm(props: TestFormProps) {
       id: idFromProps,
       level: formState?.level || 0,
       members: formState?.members || EMPTY_ARRAY,
-      // oxlint-disable-next-line react/react-compiler
       onChange: handleChange,
       onFieldGroupSelect: NOOP,
       onPathBlur: handleBlur,
       onPathFocus: handleFocus,
-      // oxlint-disable-next-line react/react-compiler
       onPathOpen: setOpenPath,
       onSelectFieldGroup: handleSetActiveFieldGroup,
       onSetFieldSetCollapsed: handleOnSetCollapsedFieldSet,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,8 +164,8 @@ importers:
         specifier: ^0.63.0
         version: 0.63.0
       oxlint:
-        specifier: ^1.76.0
-        version: 1.77.0(oxlint-tsgolint@7.0.2001)
+        specifier: ^1.79.0
+        version: 1.79.0(oxlint-tsgolint@7.0.2001)
       oxlint-tsgolint:
         specifier: ^7.0.2001
         version: 7.0.2001
@@ -5858,124 +5858,124 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.77.0':
-    resolution: {integrity: sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ==}
+  '@oxlint/binding-android-arm-eabi@1.79.0':
+    resolution: {integrity: sha512-TebFaaMklO/RXzTv7PucaCq9l3X6D1gA+C8H6K4njtjFOV+zWE9MKLpulcJZN9bzytbUbQIY0mZuz12nQ5Kv4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.77.0':
-    resolution: {integrity: sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA==}
+  '@oxlint/binding-android-arm64@1.79.0':
+    resolution: {integrity: sha512-KqqnOtAVgNsPPF0YSodkFZA1O80jcKoCZCTu3bgsszxA+MrMP9TLzfXitKjEj1FmrPprKDMdRDMmY3weESO9sg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.77.0':
-    resolution: {integrity: sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA==}
+  '@oxlint/binding-darwin-arm64@1.79.0':
+    resolution: {integrity: sha512-BVC2nsMzqQzRDPc5RhixkZ+m1p7iH4bxRRvqkbwDXX0PlQKm1BPy8J8cRjnAFafOq2QzI+BfO3vE8w2GZ3CBag==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.77.0':
-    resolution: {integrity: sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA==}
+  '@oxlint/binding-darwin-x64@1.79.0':
+    resolution: {integrity: sha512-p6Lm+snmhGuLKL1+CpCV8L6ijkE/qJzK2H2jG9+eKJT0n31RbY4FLsdhexekgP3bLpw4Kgde+9DZuDZQ4yIInA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.77.0':
-    resolution: {integrity: sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg==}
+  '@oxlint/binding-freebsd-x64@1.79.0':
+    resolution: {integrity: sha512-qDMm0dXZnoHyRqSL4N4xUq82T4sqK5cbKSjvd/dF/YbMUXc2R1wEPf+vmA5S0qUmi0nwXfNbjXBtZaIqzQLIMg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.77.0':
-    resolution: {integrity: sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.79.0':
+    resolution: {integrity: sha512-2od7s0nuKPzqyUZAWk9KkCyGg7eI9dwFPZg+20lB15fKFkVZ0c9ZFxqPfiBAyDTlTkh9stPI0t+JlPCqMbItVA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.77.0':
-    resolution: {integrity: sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ==}
+  '@oxlint/binding-linux-arm-musleabihf@1.79.0':
+    resolution: {integrity: sha512-ZOQUjkzDnvlhSE3+tWC3YXx94MMl+sYMlwH+u1+YGApGHOJP/YAc8ZBRFOXZ6eOBmxtXAWuS/fBcdZr8qqNO1A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.77.0':
-    resolution: {integrity: sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw==}
+  '@oxlint/binding-linux-arm64-gnu@1.79.0':
+    resolution: {integrity: sha512-lu158FR4nGqGeRS3BQvtG85wRgU/Fy4MD5Cxp1hzJXizGiLo6u2742wJSCDKh8cFcZntvX7fcxlq4mMmfryH1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-arm64-musl@1.77.0':
-    resolution: {integrity: sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g==}
+  '@oxlint/binding-linux-arm64-musl@1.79.0':
+    resolution: {integrity: sha512-mbpKQeE2aflTjddaHK7MP8KP/OFbUM++lt5M635ENM8IyIdK0jm2t9pb+2v9mVVIvhF6TqA4l7F79Pll1mi+uw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.77.0':
-    resolution: {integrity: sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg==}
+  '@oxlint/binding-linux-ppc64-gnu@1.79.0':
+    resolution: {integrity: sha512-WpGNua7gaxaHnpSDeog2ji8IDHn/QLPl9LPzwkR/FvVv58vT5BcXjRXnU+wbu3N75cpeha8CdC7ho/U2OIsB4g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.77.0':
-    resolution: {integrity: sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q==}
+  '@oxlint/binding-linux-riscv64-gnu@1.79.0':
+    resolution: {integrity: sha512-tK1E93A5LVzISg4ngpKJnfTs7EqtIUceGI7MQ4GyDjJiLi8wPCkEyKlj2xkyKWZ1yzkDJyLHTBJ5/iFWRdnJvg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.77.0':
-    resolution: {integrity: sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA==}
+  '@oxlint/binding-linux-riscv64-musl@1.79.0':
+    resolution: {integrity: sha512-qhQvUIrngXivA2A9pQ+xPCychztn/5qUv7yS3gDwXv3w7Rag+eTeeXWmRyx+t7XsW5x6LuY/8AsTq36UgFIblg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.77.0':
-    resolution: {integrity: sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw==}
+  '@oxlint/binding-linux-s390x-gnu@1.79.0':
+    resolution: {integrity: sha512-sv6AaVgU/eE6u+6WFiQVDcPPwTxP6IJMSB9k701W2r/r6Tx465e8vPvVyRxquNH4Vy6KwRNu90mVbxXJN8+5gg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-gnu@1.77.0':
-    resolution: {integrity: sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw==}
+  '@oxlint/binding-linux-x64-gnu@1.79.0':
+    resolution: {integrity: sha512-iFZL02deziHslb3jEX9KdqlAkYoo4fGyotchKDzdfK1f5mxlIBeiQeHhvK3iFpuEJSB4ma/qeFn9oxPiwnhUPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.77.0':
-    resolution: {integrity: sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ==}
+  '@oxlint/binding-linux-x64-musl@1.79.0':
+    resolution: {integrity: sha512-3DtZR2raqObnh7wXZoFYFd0Fw7skBvcb3f7A+/lkEiDuh8hrE6vv9b/62Qxao1a9/OeHLw/FcXlXzgsW9wTRFg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.77.0':
-    resolution: {integrity: sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw==}
+  '@oxlint/binding-openharmony-arm64@1.79.0':
+    resolution: {integrity: sha512-Oatt4GuA1WJkqzk2ozx4HrWROOi7opV3AKDw/U8qDIqeTqzsjn5K2x3REJMNjU3/KU/Bkq96Zi3CknaiDTaC/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.77.0':
-    resolution: {integrity: sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA==}
+  '@oxlint/binding-win32-arm64-msvc@1.79.0':
+    resolution: {integrity: sha512-NAgZr9Qp8nIA9rpo0JEvwiabTF/2UVqBNnupBG9X4kxXcQoScJUTi+qHhvabb9s/thgj5wQ4XcIaJvb+ZMgoKw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.77.0':
-    resolution: {integrity: sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA==}
+  '@oxlint/binding-win32-ia32-msvc@1.79.0':
+    resolution: {integrity: sha512-+KyXjIvcpaXmWW/j9NNY5yWjrIVxaX18VyIheQy3jwc2GSYgpCr7MGI/HxIGQ/shAL5IWEKbhsqoMpAO5Stiog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.77.0':
-    resolution: {integrity: sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw==}
+  '@oxlint/binding-win32-x64-msvc@1.79.0':
+    resolution: {integrity: sha512-mEelcCMMBS57sIXh2veGMNy+pQwuGtcMxHxGIZWQ5Ba9pJ5jCCUFOZB9E2JhBaxGsURe+WGe0zJp4RVre52gpQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -11834,8 +11834,8 @@ packages:
     resolution: {integrity: sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg==}
     hasBin: true
 
-  oxlint@1.77.0:
-    resolution: {integrity: sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg==}
+  oxlint@1.79.0:
+    resolution: {integrity: sha512-hVJ9hq9m2unPS+Of4eJJgCPdIeCC+3DHEUX3tkmrPJr3OK2hz7PhXwgC+ZP71ZcYu8cCDEtQrqLxWNvxBppBVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -17961,61 +17961,61 @@ snapshots:
   '@oxlint-tsgolint/win32-x64@7.0.2001':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.77.0':
+  '@oxlint/binding-android-arm-eabi@1.79.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.77.0':
+  '@oxlint/binding-android-arm64@1.79.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.77.0':
+  '@oxlint/binding-darwin-arm64@1.79.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.77.0':
+  '@oxlint/binding-darwin-x64@1.79.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.77.0':
+  '@oxlint/binding-freebsd-x64@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.77.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.77.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.77.0':
+  '@oxlint/binding-linux-arm64-gnu@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.77.0':
+  '@oxlint/binding-linux-arm64-musl@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.77.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.77.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.77.0':
+  '@oxlint/binding-linux-riscv64-musl@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.77.0':
+  '@oxlint/binding-linux-s390x-gnu@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.77.0':
+  '@oxlint/binding-linux-x64-gnu@1.79.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.77.0':
+  '@oxlint/binding-linux-x64-musl@1.79.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.77.0':
+  '@oxlint/binding-openharmony-arm64@1.79.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.77.0':
+  '@oxlint/binding-win32-arm64-msvc@1.79.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.77.0':
+  '@oxlint/binding-win32-ia32-msvc@1.79.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.77.0':
+  '@oxlint/binding-win32-x64-msvc@1.79.0':
     optional: true
 
   '@pkgjs/parseargs@0.11.0':
@@ -24561,27 +24561,27 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 7.0.2001
       '@oxlint-tsgolint/win32-x64': 7.0.2001
 
-  oxlint@1.77.0(oxlint-tsgolint@7.0.2001):
+  oxlint@1.79.0(oxlint-tsgolint@7.0.2001):
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.77.0
-      '@oxlint/binding-android-arm64': 1.77.0
-      '@oxlint/binding-darwin-arm64': 1.77.0
-      '@oxlint/binding-darwin-x64': 1.77.0
-      '@oxlint/binding-freebsd-x64': 1.77.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.77.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.77.0
-      '@oxlint/binding-linux-arm64-gnu': 1.77.0
-      '@oxlint/binding-linux-arm64-musl': 1.77.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.77.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.77.0
-      '@oxlint/binding-linux-riscv64-musl': 1.77.0
-      '@oxlint/binding-linux-s390x-gnu': 1.77.0
-      '@oxlint/binding-linux-x64-gnu': 1.77.0
-      '@oxlint/binding-linux-x64-musl': 1.77.0
-      '@oxlint/binding-openharmony-arm64': 1.77.0
-      '@oxlint/binding-win32-arm64-msvc': 1.77.0
-      '@oxlint/binding-win32-ia32-msvc': 1.77.0
-      '@oxlint/binding-win32-x64-msvc': 1.77.0
+      '@oxlint/binding-android-arm-eabi': 1.79.0
+      '@oxlint/binding-android-arm64': 1.79.0
+      '@oxlint/binding-darwin-arm64': 1.79.0
+      '@oxlint/binding-darwin-x64': 1.79.0
+      '@oxlint/binding-freebsd-x64': 1.79.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.79.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.79.0
+      '@oxlint/binding-linux-arm64-gnu': 1.79.0
+      '@oxlint/binding-linux-arm64-musl': 1.79.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.79.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.79.0
+      '@oxlint/binding-linux-riscv64-musl': 1.79.0
+      '@oxlint/binding-linux-s390x-gnu': 1.79.0
+      '@oxlint/binding-linux-x64-gnu': 1.79.0
+      '@oxlint/binding-linux-x64-musl': 1.79.0
+      '@oxlint/binding-openharmony-arm64': 1.79.0
+      '@oxlint/binding-win32-arm64-msvc': 1.79.0
+      '@oxlint/binding-win32-ia32-msvc': 1.79.0
+      '@oxlint/binding-win32-x64-msvc': 1.79.0
       oxlint-tsgolint: 7.0.2001
 
   p-finally@1.0.0:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

oxlint 1.79.0 ships [React Compiler support](https://oxc.rs/blog/2026-08-18-react-compiler-support.html#oxlint), replacing the nursery `react/react-compiler` rule with 22 category-specific rules. Since we want every React Compiler rule active, this bump removes the dead nursery rule from `.oxlintrc.json` and adds the five `restriction`-category rules (`unsupported-syntax`, `invariant`, `rule-suppression`, `syntax`, `todo`) explicitly — the `correctness`, `suspicious`, and `perf` rules already activate through the existing `categories` config.

Per the task instructions, the ~190 violations surfaced by the new rules are suppressed inline with `oxlint-disable-next-line` rather than fixed, so they can be addressed in a follow-up without blocking the bump. The 104 existing `react/react-compiler` suppressions are migrated to the specific rule name(s) that now fire at each location (keeping their original `--` reasons), and 8 of them are deleted because no compiler rule flags those lines anymore.

`oxlint-tsgolint` (7.0.2001) and all eslint plugins loaded via `jsPlugins` (`eslint-plugin-tsdoc`, `eslint-plugin-i18next`, `@sanity/eslint-plugin-i18n`, `eslint-plugin-boundaries`, `eslint-plugin-testing-library`) are already at their latest published versions, so only `oxlint` moves.

New-rule violation counts, for follow-up planning: `exhaustive-effect-dependencies` 71, `set-state-in-effect` 70, `static-components` 14, `refs` 9, `todo` 5, `incompatible-library` 5, `rule-suppression` 3, `immutability` 3, `preserve-manual-memoization` 2, `no-deriving-state-in-effects` 2, `memo-dependencies` 2.

### What to review

- `.oxlintrc.json` — the rule swap and the reasoning comment
- The three `react/rule-suppression` suppressions (`ImageInputAsset.tsx`, `StudioReferenceInput.tsx`, `dev/metrics-studio/.../useUrlState.ts`): these stack a suppression on top of an existing `react-hooks/*` suppression, which is the mechanical consequence of enabling that rule while grandfathering violations
- `packages/@sanity/schema/src/sanity/extractSchema.ts` — a stray non-breaking space in a comment tripped the new `no-irregular-whitespace` detection; fixed directly instead of suppressed since it is a one-character comment typo
- Everything else is mechanical comment insertion/renaming; `options.reportUnusedDisableDirectives` is `error`, so a green lint run proves every remaining suppression is both placed correctly and used

### Testing

- `pnpm check:oxlint` passes with zero errors and zero unused disable directives
- `pnpm check:format` passes
- `pnpm build && pnpm test` passes: 617 test files passed (11 skipped), 5864 tests passed, no type errors

### Notes for release

N/A – Internal only

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7479ec7-d770-48b1-b3cc-968a5b04b7e9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7479ec7-d770-48b1-b3cc-968a5b04b7e9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

