### PR TITLE
chore(bench): improve metrics dashboard and bench measurements

### DIFF
--- a/dev/metrics-studio/SPEC.md
+++ b/dev/metrics-studio/SPEC.md
@@ -31,18 +31,84 @@ secondary: leads scanning health weekly.
 1. **Trends** — the first tool and the studio's default view. Small-multiples
    grid, one chart per scenario·metric (keystroke latency medians,
    time-to-editable, bundle initial JS, auth trips/in-flight), x = run date,
-   line = p50, shaded band = p75–p90, dots link to the run document.
+   line = p50, shaded band = p75–p90; clicking anywhere in the plot opens the
+   nearest run's document (the run under the crosshair is marked on hover /
+   keyboard focus — there are no resting dots, which at 30–90 runs in a small
+   multiple were mostly ink).
    Calibration strip at the top. Time range picker (30/90/all).
 2. **Run detail** (P2) — click-through from a dot: the PR-comment tables
    (absolute variant), soak slope chart, flake telemetry, run metadata.
 3. **Drift feed** (P2) — computed client-side, flagging a metric when it
    clears the same `rel`/`absMs` thresholds the gate uses
    (perf/bench/stats/gate.ts — one source of truth for "what matters").
-   Two baselines, both shown when they disagree:
-   - **trailing:** last-7-runs median vs the prior-21-runs median (slow
-     drift)
-   - **step:** latest run vs the median of the same weekday's last 4 runs
-     (sudden jumps, robust to day-of-week runner variance)
+
+   One baseline: the median of the last 7 runs vs the median of the prior 21.
+   Smoothing both sides is what makes it trustworthy — one noisy run barely
+   moves a median of 7, so a flag means a sustained shift.
+
+   Windows are counted in **runs, not days**, and the UI says so ("vs prior 21
+   runs"): the cron aims for one run a day, but the history has gaps and
+   same-day doubles, so a day-based label would be a guess.
+
+   `buildSeries` merges runs of the same commit into one point (their median), so
+   both the charts and drift see one point per commit. CI re-runs the suite on a
+   commit fairly often — 4 shas in the stored history have 2–3 runs each — and a
+   run document can contribute several points to one series (the pageload
+   scenario stores the INP metric twice). Unmerged, that stacked several dots on
+   one x-position, gave the commit several votes in every median, and made a
+   "21 runs" window cover fewer than 21 commits of history.
+
+   Median rather than mean, matching the p50 language used throughout: one
+   throttled or failed re-run can't drag the point. The merged point keeps a real
+   run's identity so click-through opens an actual document.
+
+   Honesty cost, stated plainly: re-runs of one commit often land on hosts of
+   different speed (sha `7147d045`'s two runs differ by 21% of calibration), so a
+   merged point averages across hosts. The **calibration strip is deliberately
+   not merged** — showing per-run and cross-shard host spread is its whole job.
+
+   There was a second, faster **step** baseline (latest run vs a median of
+   recent runs), meant to catch a jump the day it landed. It was removed:
+   measured against the stored history it fired on 74–92% of runs at every
+   window size tried, because run-to-run noise (~12% median) is well over the
+   5% threshold. Two baselines were also impossible to tell apart in the UI
+   while one of them fired constantly. Catching a single-run jump needs a more
+   precise measurement (more sessions per run), not different arithmetic.
+
+   An earlier version of step compared against the last 4 runs on the _same
+   weekday_, to control for day-of-week CI runner load. The stored history does
+   not support that either: weekday and weekend `calibrationMs` medians are
+   identical (7.60 vs 7.60) and only ~14% of calibration variance sits between
+   weekdays. Host speed is handled by the per-run `runner.calibrationMs`
+   measurement instead.
+
+   **Every** chart with enough history draws its baseline as an overlay — not
+   only the flagged ones. "Recent level vs prior level" is a useful reference
+   whether or not it crossed a threshold, and drawing it only on flagged charts
+   made the reference lines appear and vanish as metrics moved over the line. A
+   sub-threshold comparison is `direction: 'neutral'`: drawn in muted grey, and
+   filtered out of the review feed and the tab counts (`useDriftState`), so the
+   badge stays the signal for "this needs a look".
+
+   The overlay is the two window medians as a step (dashed "before", solid
+   "after", connected at the window boundary),
+   each spanning the runs it was measured over, so the header badge's percentage
+   can be checked against the runs that produced it. The overlay introduces **no
+   new statistic**: it draws what the gate thresholds already decided, so the
+   host-relativity caveat above still routes through the calibration strip
+   rather than being answered here. Suppressed when comparing branches (same
+   "mud" reason the p75–p90 band is) and on soak charts, whose x-axis is minutes
+   within one run.
+
+   Drift is computed over **all** history for the selected branches, never the
+   range-filtered view: its windows are defined in runs, so feeding it a 30-day
+   slice would make the verdict a function of the range picker.
+
+4. **Layer toggles** — the chart legend doubles as a switchboard: clicking an
+   entry shows/hides that layer (median, p75–p90 band, baseline overlay) across
+   the whole grid, persisted as `?layers=-band` so a stripped-back view is
+   shareable. Global rather than per-card because the grid is 40+ small
+   multiples.
 
 ## Architecture
 

--- a/dev/metrics-studio/SPEC.md
+++ b/dev/metrics-studio/SPEC.md
@@ -52,11 +52,11 @@ secondary: leads scanning health weekly.
 
    `buildSeries` merges runs of the same commit into one point (their median), so
    both the charts and drift see one point per commit. CI re-runs the suite on a
-   commit fairly often — 4 shas in the stored history have 2–3 runs each — and a
-   run document can contribute several points to one series (the pageload
-   scenario stores the INP metric twice). Unmerged, that stacked several dots on
-   one x-position, gave the commit several votes in every median, and made a
-   "21 runs" window cover fewer than 21 commits of history.
+   commit fairly often — 4 shas in the stored history have 2–3 runs each.
+   Unmerged, that stacked several dots on one x-position, gave the commit
+   several votes in every median, and made a "21 runs" window cover fewer than
+   21 commits of history. (The merge also collapses duplicates of one metric
+   within a single document, defensively — none are known to exist.)
 
    Median rather than mean, matching the p50 language used throughout: one
    throttled or failed re-run can't drag the point. The merged point keeps a real
@@ -67,20 +67,20 @@ secondary: leads scanning health weekly.
    merged point averages across hosts. The **calibration strip is deliberately
    not merged** — showing per-run and cross-shard host spread is its whole job.
 
-   There was a second, faster **step** baseline (latest run vs a median of
-   recent runs), meant to catch a jump the day it landed. It was removed:
-   measured against the stored history it fired on 74–92% of runs at every
-   window size tried, because run-to-run noise (~12% median) is well over the
-   5% threshold. Two baselines were also impossible to tell apart in the UI
-   while one of them fired constantly. Catching a single-run jump needs a more
-   precise measurement (more sessions per run), not different arithmetic.
+   A second, faster **step** baseline (latest run vs a median of recent runs,
+   to catch a jump the day it lands) was considered and rejected: measured
+   against the stored history it would fire on 74–92% of runs at every window
+   size, because run-to-run noise (~12% median) is well over the 5% threshold.
+   Two baselines would also be impossible to tell apart in the UI while one of
+   them fired constantly. Catching a single-run jump needs a more precise
+   measurement (more sessions per run), not different arithmetic.
 
-   An earlier version of step compared against the last 4 runs on the _same
-   weekday_, to control for day-of-week CI runner load. The stored history does
-   not support that either: weekday and weekend `calibrationMs` medians are
-   identical (7.60 vs 7.60) and only ~14% of calibration variance sits between
-   weekdays. Host speed is handled by the per-run `runner.calibrationMs`
-   measurement instead.
+   A weekday-matched variant (compare against the last 4 runs on the _same
+   weekday_, to control for day-of-week CI runner load) was rejected too: the
+   stored history does not support it — weekday and weekend `calibrationMs`
+   medians are identical (7.60 vs 7.60) and only ~14% of calibration variance
+   sits between weekdays. Host speed is handled by the per-run
+   `runner.calibrationMs` measurement instead.
 
    **Every** chart with enough history draws its baseline as an overlay — not
    only the flagged ones. "Recent level vs prior level" is a useful reference

--- a/dev/metrics-studio/schemaTypes/benchRun.ts
+++ b/dev/metrics-studio/schemaTypes/benchRun.ts
@@ -211,6 +211,22 @@ const benchScenario = defineType({
       ],
     }),
     defineField({
+      name: 'clsAttribution',
+      description: 'Which elements shifted during load, with summed CLS contribution',
+      type: 'array',
+      of: [
+        defineArrayMember({
+          type: 'object',
+          name: 'shiftSource',
+          fields: [
+            defineField({name: 'source', type: 'string'}),
+            defineField({name: 'totalValue', type: 'number'}),
+          ],
+          preview: {select: {title: 'source', subtitle: 'totalValue'}},
+        }),
+      ],
+    }),
+    defineField({
       name: 'resources',
       type: 'object',
       fields: [

--- a/dev/metrics-studio/tools/trends/ChartLegend.tsx
+++ b/dev/metrics-studio/tools/trends/ChartLegend.tsx
@@ -193,7 +193,7 @@ export function ChartLegend(props: {
           swatch={
             <>
               {/* Two stacked strokes, dashed over solid — the before/after pair.
-                  An explicit step glyph was tried and is illegible at 16×10px. */}
+                  An explicit step glyph is illegible at 16×10px. */}
               <line
                 x1={0}
                 y1={3}

--- a/dev/metrics-studio/tools/trends/ChartLegend.tsx
+++ b/dev/metrics-studio/tools/trends/ChartLegend.tsx
@@ -1,25 +1,96 @@
 import {Flex, Text} from '@sanity/ui'
 
 import {type TrendSeries} from './data'
+import {baselineDetail, baselineLabel, type DriftResult} from './drift'
+import {ALL_LAYERS_VISIBLE, type Layer, type LayerState} from './layers'
 import {categoricalColor} from './palette'
-import {COLOR} from './TrendChart'
+import {baselineToDraw, COLOR, seriesHasBand} from './TrendChart'
 
-function Swatch(props: {children: React.ReactNode}) {
+function Swatch(props: {children: React.ReactNode; dimmed?: boolean}) {
   return (
-    <svg width={16} height={10} aria-hidden="true" style={{flexShrink: 0}}>
+    <svg
+      width={16}
+      height={10}
+      aria-hidden="true"
+      style={{flexShrink: 0, opacity: props.dimmed ? 0.35 : 1}}
+    >
       {props.children}
     </svg>
   )
 }
 
 /**
- * Encoding key rendered under every chart. With one line it explains the
- * three marks (median / band / dots); comparing branches, it becomes the
- * branch color key — identity by color needs a legend, never color alone.
+ * One legend entry. A toggleable layer renders as a button (click to hide/show
+ * it across the whole grid); a non-toggleable key — branch colors, the "lower is
+ * better" note — stays plain text, so only the things that actually respond to a
+ * click look clickable.
  */
-export function ChartLegend(props: {series: TrendSeries}) {
-  const {series} = props
+function LegendItem(props: {
+  layer?: Layer
+  layers: LayerState
+  label: string
+  /** The arithmetic behind the label, surfaced on hover. */
+  hint?: string
+  swatch: React.ReactNode
+}) {
+  const {layer, layers, label, hint, swatch} = props
+  const hidden = layer ? !layers.visible(layer) : false
+  const content = (
+    <Flex gap={1} align="center">
+      <Swatch dimmed={hidden}>{swatch}</Swatch>
+      <Text size={0} muted style={hidden ? {textDecoration: 'line-through'} : undefined}>
+        {label}
+      </Text>
+    </Flex>
+  )
+  if (!layer) return content
+  return (
+    <button
+      type="button"
+      onClick={() => layers.toggle(layer)}
+      aria-pressed={!hidden}
+      title={[hint, hidden ? `Show ${label} on all charts` : `Hide ${label} on all charts`]
+        .filter(Boolean)
+        .join(' — ')}
+      style={{
+        background: 'none',
+        border: 0,
+        padding: 0,
+        margin: 0,
+        font: 'inherit',
+        color: 'inherit',
+        cursor: 'pointer',
+      }}
+    >
+      {content}
+    </button>
+  )
+}
+
+/**
+ * Encoding key rendered under every chart, doubling as the layer switchboard:
+ * clicking an entry shows/hides that layer on every chart (see layers.ts for
+ * why the toggle is global rather than per-card). Comparing branches, it becomes
+ * the branch color key — identity by color needs a legend, never color alone.
+ */
+export function ChartLegend(props: {
+  series: TrendSeries
+  drift?: DriftResult
+  layers?: LayerState
+}) {
+  const {series, drift, layers = ALL_LAYERS_VISIBLE} = props
   const comparing = series.lines.length > 1
+  // Whether this chart *has* a baseline to explain — independent of whether the
+  // layer is currently visible, so toggling it off doesn't remove the control
+  // that toggles it back on
+  const overlayBaseline = baselineToDraw(series, drift)
+
+  const overlayColor =
+    drift?.direction === 'regression'
+      ? COLOR.baselineRegression
+      : drift?.direction === 'improvement'
+        ? COLOR.baselineImprovement
+        : COLOR.baselineNeutral
 
   if (comparing) {
     return (
@@ -45,15 +116,19 @@ export function ChartLegend(props: {series: TrendSeries}) {
 
   const line = series.lines[0]
   const color = series.goal === 'context' ? COLOR.context : COLOR.line
-  const hasBand =
-    line && line.points.length > 1 && line.points.some((point) => point.p75 !== undefined)
+  // Same predicate the plot uses, so the legend can't offer a band that isn't
+  // drawn (low-sample metrics collapse the band to a line — see seriesHasBand)
+  const hasBand = line && line.points.length > 1 && seriesHasBand(series)
   const hasLine = line && line.points.length > 1
 
   return (
     <Flex gap={3} wrap="wrap" align="center">
       {hasLine && (
-        <Flex gap={1} align="center">
-          <Swatch>
+        <LegendItem
+          layer="median"
+          layers={layers}
+          label={series.goal === 'context' ? 'reference' : 'median (p50)'}
+          swatch={
             <line
               x1={0}
               y1={5}
@@ -63,21 +138,57 @@ export function ChartLegend(props: {series: TrendSeries}) {
               strokeWidth={2}
               strokeDasharray={series.goal === 'context' ? '3 2' : undefined}
             />
-          </Swatch>
-          <Text size={0} muted>
-            {series.goal === 'context' ? 'reference' : 'median (p50)'}
-          </Text>
-        </Flex>
+          }
+        />
       )}
       {hasBand && (
-        <Flex gap={1} align="center">
-          <Swatch>
-            <rect x={1} y={1} width={14} height={8} rx={2} fill={COLOR.band} />
-          </Swatch>
-          <Text size={0} muted>
-            p75–p90 spread
-          </Text>
-        </Flex>
+        <LegendItem
+          layer="band"
+          layers={layers}
+          label="p75–p90 spread"
+          swatch={
+            // Same construction as the plot: translucent fill with defined
+            // edges, in the series color
+            <>
+              <rect x={0} y={2} width={16} height={6} fill={color} opacity={0.22} />
+              <line x1={0} y1={2} x2={16} y2={2} stroke={color} strokeWidth={1} opacity={0.5} />
+              <line x1={0} y1={8} x2={16} y2={8} stroke={color} strokeWidth={1} opacity={0.5} />
+            </>
+          }
+        />
+      )}
+      {overlayBaseline && (
+        <LegendItem
+          layer="baseline"
+          layers={layers}
+          label={`baseline ${baselineLabel(overlayBaseline)}`}
+          hint={baselineDetail(overlayBaseline)}
+          swatch={
+            <>
+              {/* Two stacked strokes, dashed over solid — the before/after pair.
+                  An explicit step glyph was tried and is illegible at 16×10px. */}
+              <line
+                x1={0}
+                y1={3}
+                x2={16}
+                y2={3}
+                stroke={overlayColor}
+                strokeWidth={1.5}
+                strokeDasharray="3 2"
+                opacity={0.55}
+              />
+              <line
+                x1={0}
+                y1={8}
+                x2={16}
+                y2={8}
+                stroke={overlayColor}
+                strokeWidth={2}
+                opacity={0.9}
+              />
+            </>
+          }
+        />
       )}
       {series.goal === 'lower' && (
         <Text size={0} muted>

--- a/dev/metrics-studio/tools/trends/ChartLegend.tsx
+++ b/dev/metrics-studio/tools/trends/ChartLegend.tsx
@@ -1,6 +1,6 @@
 import {Flex, Text} from '@sanity/ui'
 
-import {type TrendSeries} from './data'
+import {formatValue, type TrendSeries} from './data'
 import {baselineDetail, baselineLabel, type DriftResult} from './drift'
 import {ALL_LAYERS_VISIBLE, type Layer, type LayerState} from './layers'
 import {categoricalColor} from './palette'
@@ -51,7 +51,7 @@ function LegendItem(props: {
       aria-pressed={!hidden}
       title={[hint, hidden ? `Show ${label} on all charts` : `Hide ${label} on all charts`]
         .filter(Boolean)
-        .join(' — ')}
+        .join('. ')}
       style={{
         background: 'none',
         border: 0,
@@ -92,6 +92,32 @@ export function ChartLegend(props: {
         ? COLOR.baselineImprovement
         : COLOR.baselineNeutral
 
+  // The web.dev "good" bar. Not a toggleable layer: it's the tab's whole
+  // frame of reference, and hiding it would make the amber rule unexplained.
+  const goodItem = series.goodThreshold !== undefined && (
+    <Flex
+      gap={1}
+      align="center"
+      title="web.dev 'good' recommendation, measured on field data at the 75th percentile; the lab medians here are not directly comparable"
+    >
+      <Swatch>
+        <line
+          x1={0}
+          y1={5}
+          x2={16}
+          y2={5}
+          stroke={COLOR.goodThreshold}
+          strokeWidth={1.5}
+          strokeDasharray="5 3"
+          opacity={0.7}
+        />
+      </Swatch>
+      <Text size={0} muted>
+        good ≤ {formatValue(series.goodThreshold, series.unit)}
+      </Text>
+    </Flex>
+  )
+
   if (comparing) {
     return (
       <Flex gap={3} wrap="wrap" align="center">
@@ -105,6 +131,7 @@ export function ChartLegend(props: {
             </Text>
           </Flex>
         ))}
+        {goodItem}
         {series.goal === 'lower' && (
           <Text size={0} muted>
             · lower is better
@@ -127,7 +154,7 @@ export function ChartLegend(props: {
         <LegendItem
           layer="median"
           layers={layers}
-          label={series.goal === 'context' ? 'reference' : 'median (p50)'}
+          label={series.goal === 'context' ? 'reference' : (series.lineLabel ?? 'median (p50)')}
           swatch={
             <line
               x1={0}
@@ -190,6 +217,7 @@ export function ChartLegend(props: {
           }
         />
       )}
+      {goodItem}
       {series.goal === 'lower' && (
         <Text size={0} muted>
           lower is better

--- a/dev/metrics-studio/tools/trends/DriftFeed.tsx
+++ b/dev/metrics-studio/tools/trends/DriftFeed.tsx
@@ -7,14 +7,9 @@ import {useState} from 'react'
 
 import {idSlug, SNOOZE_DAYS} from './acks'
 import {formatValue} from './data'
-import {type DriftBaseline, type DriftResult, worstOf} from './drift'
+import {baselineDetail, type DriftResult} from './drift'
 import {backlinksFor} from './links'
 import {type DriftState} from './useDriftState'
-
-const BASELINE_LABEL: Record<DriftBaseline['kind'], string> = {
-  trailing: 'vs prior 3 weeks',
-  step: 'vs same weekday',
-}
 
 function pct(fraction: number): string {
   const sign = fraction > 0 ? '+' : ''
@@ -30,7 +25,7 @@ function DriftRow(props: {
   onFocus: () => void
 }) {
   const {entry, showBranch, acked, onAck, onClear, onFocus} = props
-  const worst = worstOf(entry)
+  const worst = entry.baseline
   return (
     <Flex align="center" gap={2} wrap="wrap">
       <Badge tone={entry.direction === 'regression' ? 'critical' : 'positive'} fontSize={0}>
@@ -48,7 +43,7 @@ function DriftRow(props: {
       <Text size={0} muted>
         {formatValue(worst.baseline, entry.unit)} → {formatValue(worst.recent, entry.unit)}
         {' · '}
-        {entry.fired.map((f) => BASELINE_LABEL[f.kind]).join(', ')}
+        {baselineDetail(worst)}
       </Text>
       {backlinksFor(entry.latest).map((link) => (
         <Box

--- a/dev/metrics-studio/tools/trends/DriftFeed.tsx
+++ b/dev/metrics-studio/tools/trends/DriftFeed.tsx
@@ -64,7 +64,7 @@ function DriftRow(props: {
       ))}
       <Box flex={1} />
       {acked ? (
-        <Button mode="bleed" fontSize={0} padding={2} text="Un-ack" onClick={onClear} />
+        <Button mode="bleed" fontSize={0} padding={2} text="Reopen" onClick={onClear} />
       ) : (
         <MenuButton
           // Slugged: series keys contain spaces/`·`, which are invalid in DOM
@@ -74,7 +74,7 @@ function DriftRow(props: {
           menu={
             <Menu>
               <MenuItem text="Silence" onClick={() => onAck('silenced')} />
-              <MenuItem text={`Snooze ${SNOOZE_DAYS}d`} onClick={() => onAck('snoozed')} />
+              <MenuItem text={`Snooze ${SNOOZE_DAYS} days`} onClick={() => onAck('snoozed')} />
               {/* "Mark fixed" only for regressions — an improvement has nothing
                   to fix */}
               {entry.direction === 'regression' && (

--- a/dev/metrics-studio/tools/trends/RunDetailPopover.tsx
+++ b/dev/metrics-studio/tools/trends/RunDetailPopover.tsx
@@ -88,6 +88,11 @@ export function RunDetailPopover(props: {
       placement="top"
       fallbackPlacements={['bottom', 'right', 'left']}
       referenceElement={referenceElement}
+      // A drifted chart tints its card caution/positive, and the popover would
+      // otherwise inherit that tone through the theme context — making run
+      // details look like a warning about themselves. The run detail is neutral
+      // information; the flag belongs to the card, not to this panel.
+      tone="default"
       content={
         <Box ref={setContentEl} padding={4} style={{width: 288, maxWidth: '92vw'}}>
           <Stack gap={4}>

--- a/dev/metrics-studio/tools/trends/RunDetailPopover.tsx
+++ b/dev/metrics-studio/tools/trends/RunDetailPopover.tsx
@@ -1,5 +1,4 @@
 import {CloseIcon} from '@sanity/icons/Close'
-import {CopyIcon} from '@sanity/icons/Copy'
 import {LaunchIcon} from '@sanity/icons/Launch'
 import {
   Badge,
@@ -15,8 +14,8 @@ import {Popover} from '@sanity/ui/popover'
 import {useEffect, useRef, useState} from 'react'
 import {useIntentLink} from 'sanity/router'
 
-import {formatValue, type TrendPoint, type TrendSeries} from './data'
-import {abDispatchCommand, backlinksFor, sourceFileUrl} from './links'
+import {formatValue, INP_MIN_INTERACTIONS, type TrendPoint, type TrendSeries} from './data'
+import {backlinksFor, compareUrl, sourceFileUrl} from './links'
 
 const FULL_SHA = /^[0-9a-f]{40}$/i
 
@@ -38,13 +37,12 @@ export function RunDetailPopover(props: {
 }) {
   const {series, point, previousSha, referenceElement, onClose} = props
   const [contentEl, setContentEl] = useState<HTMLDivElement | null>(null)
-  const [abCopyState, setAbCopyState] = useState<'idle' | 'copied' | 'failed'>('idle')
-  // The bench workflow's ab_from/ab_to inputs require full shas, and GitHub
-  // has no URL that prefills a workflow_dispatch form — so the affordance is
-  // a copyable command, previous point as reference, this point as experiment
-  const abCommand =
+  // "What landed between this point and the previous one?" — the GitHub
+  // compare view answers it directly. Guarded by the full-sha shape so a
+  // 'unknown' or malformed sha never builds a dead link.
+  const compareHref =
     previousSha && FULL_SHA.test(previousSha) && FULL_SHA.test(point.sha)
-      ? abDispatchCommand(previousSha, point.sha)
+      ? compareUrl(previousSha, point.sha)
       : undefined
   const closeButtonRef = useRef<HTMLButtonElement>(null)
   const documentLink = useIntentLink({
@@ -139,7 +137,23 @@ export function RunDetailPopover(props: {
                     </Text>
                     <Text size={1}>{formatValue(point.p90 ?? point.value, series.unit)}</Text>
                   </Stack>
+                  {point.interactions !== undefined && (
+                    <Stack gap={2}>
+                      <Text size={0} muted>
+                        interactions
+                      </Text>
+                      <Text size={1}>{point.interactions}</Text>
+                    </Stack>
+                  )}
                 </Flex>
+              )}
+              {/* An INP from too few interactions is a weak estimate — say so
+                  where the number is read, not in a separate chart */}
+              {point.interactions !== undefined && point.interactions < INP_MIN_INTERACTIONS && (
+                <Badge tone="caution" fontSize={0}>
+                  Low confidence: only {point.interactions} interactions (a reliable INP needs{' '}
+                  {INP_MIN_INTERACTIONS})
+                </Badge>
               )}
             </Stack>
 
@@ -180,33 +194,21 @@ export function RunDetailPopover(props: {
               </Stack>
             )}
 
-            {abCommand && (
+            {compareHref && (
               <Stack gap={2}>
                 <Text size={0} muted weight="medium">
-                  Suspect a change at this point?
+                  Suspect a regression?
                 </Text>
                 <Button
+                  as="a"
+                  href={compareHref}
+                  target="_blank"
+                  rel="noreferrer"
                   mode="ghost"
                   fontSize={1}
-                  icon={CopyIcon}
-                  text={
-                    abCopyState === 'copied'
-                      ? 'Copied — paste in a terminal'
-                      : abCopyState === 'failed'
-                        ? 'Copy failed — command in tooltip'
-                        : 'Copy A/B vs previous run'
-                  }
-                  title={abCommand}
-                  aria-label="Copy the gh command dispatching an A/B bench comparison of this commit against the previous point's commit"
-                  onClick={() => {
-                    // Only claim success on success: clipboard access can be
-                    // denied (permissions, non-secure context) and the title
-                    // attribute is the manual fallback either way
-                    navigator.clipboard.writeText(abCommand).then(
-                      () => setAbCopyState('copied'),
-                      () => setAbCopyState('failed'),
-                    )
-                  }}
+                  icon={LaunchIcon}
+                  text="Compare diff with previous run"
+                  aria-label="GitHub compare view of the commits between the previous run's commit and this one (opens in a new tab)"
                 />
               </Stack>
             )}

--- a/dev/metrics-studio/tools/trends/TrendChart.tsx
+++ b/dev/metrics-studio/tools/trends/TrendChart.tsx
@@ -1,4 +1,4 @@
-import {Card, Flex, Stack, Text} from '@sanity/ui'
+import {Box, Card, Flex, Stack, Text} from '@sanity/ui'
 import {AxisBottom, AxisLeft} from '@visx/axis'
 import {Group} from '@visx/group'
 import {scaleLinear, scaleTime} from '@visx/scale'
@@ -6,6 +6,8 @@ import {Area, LinePath} from '@visx/shape'
 import {useRef, useState} from 'react'
 
 import {formatValue, isSignedUnit, type TrendLine, type TrendPoint, type TrendSeries} from './data'
+import {baselineDetail, type DriftBaseline, type DriftResult} from './drift'
+import {ALL_LAYERS_VISIBLE, type LayerState} from './layers'
 import {categoricalColor} from './palette'
 import {RunDetailPopover} from './RunDetailPopover'
 
@@ -31,7 +33,17 @@ function previousShaFor(lines: TrendLine[], selected: TrendPoint): string | unde
 /** Theme-aware colors via the studio's CSS custom properties. */
 export const COLOR = {
   line: 'var(--card-accent-fg-color, #556bfc)',
-  band: 'var(--card-badge-primary-bg-color, rgba(85, 107, 252, 0.15))',
+  /**
+   * The p75–p90 band. This used to be `--card-badge-primary-bg-color` — a badge
+   * *background* token pressed into service as a data fill, which in dark mode
+   * resolves to a desaturated navy barely separable from the card behind it.
+   *
+   * Instead the band is now the series' own color at low alpha, applied via
+   * `fill`/`stroke` + opacity rather than baked into the value: it ties the band
+   * to the line it describes (a percentile spread belongs to its median), and it
+   * inherits whatever contrast that color already has in both schemes.
+   */
+  band: 'var(--card-accent-fg-color, #556bfc)',
   axis: 'var(--card-muted-fg-color, #727892)',
   /**
    * Context lines (host calibration) recede — reference, not measurement — but
@@ -41,6 +53,41 @@ export const COLOR = {
    * the dashes keep it reading as reference rather than a measured line.
    */
   context: 'var(--card-fg-color, #101112)',
+  /**
+   * Baseline-overlay marks on a drifted chart. Tone-matched to the card tint
+   * the drift badge already applies (critical for a regression, positive for an
+   * improvement), so the overlay reads as "this is the flagged thing" rather
+   * than as another measured series. Deliberately *not* COLOR.band — that fill
+   * is taken by the p75–p90 spread, and two shaded things in one hue would
+   * read as one thing.
+   */
+  baselineRegression: 'var(--card-badge-critical-fg-color, #d13415)',
+  baselineImprovement: 'var(--card-badge-positive-fg-color, #3ab577)',
+  /**
+   * A baseline that did not clear the thresholds. Drawn on every chart as a
+   * reference, so it has to recede — a neutral grey says "here are the two
+   * levels" without the tonal claim that something needs attention.
+   */
+  baselineNeutral: 'var(--card-muted-fg-color, #727892)',
+}
+
+/**
+ * Whether a p75–p90 band is worth drawing for this series.
+ *
+ * Some metrics are computed from very few samples (INP is n=4, so p75/p90
+ * interpolate between the 3rd and 4th values and are sometimes equal — 88/88 on
+ * some runs), which collapses the area to a sliver that reads as a line. That is
+ * actively misleading with the median layer hidden: you hide the median and
+ * something line-shaped remains. Exported so `ChartLegend` keys off the same
+ * predicate and never advertises a band the plot isn't drawing.
+ */
+export function seriesHasBand(series: TrendSeries): boolean {
+  if (series.lines.length !== 1) return false
+  return series.lines[0].points.some((point) => {
+    if (point.p75 === undefined || point.p90 === undefined) return false
+    // Relative, so it scales across ms / bytes / CLS without a per-unit table
+    return Math.abs(point.p90 - point.p75) > Math.abs(point.value) * 0.02
+  })
 }
 
 /** Per-line color: the studio accent for a lone line, categorical when comparing. */
@@ -54,28 +101,16 @@ function lineColorFor(series: TrendSeries, index: number): string {
 }
 
 /**
- * A run marker. Not interactive itself — the plot-wide capture rect handles
- * clicks (it sits above the dots) and opens the nearest run. The `emphasized`
- * dot tracks the crosshair; pointerEvents none so it never intercepts.
+ * Index of the run time closest to `targetMs`. Shared by the crosshair snapping
+ * and the keyboard stepper so they can never disagree about which run is
+ * "current". `times` must be sorted; -1 when empty.
  */
-function RunDot(props: {
-  point: TrendPoint
-  cx: number
-  cy: number
-  color: string
-  emphasized?: boolean
-}) {
-  const {cx, cy, color, emphasized} = props
-  return (
-    <circle
-      cx={cx}
-      cy={cy}
-      // Smaller resting dot; the hovered one grows and switches to the accent
-      // color (a color change reads far better than the old subtle white ring)
-      r={emphasized ? 4 : 2}
-      fill={emphasized ? 'var(--card-focus-ring-color, #556bfc)' : color}
-      pointerEvents="none"
-    />
+function nearestTimeIndex(times: number[], targetMs: number): number {
+  if (times.length === 0) return -1
+  return times.reduce(
+    (nearest, time, index) =>
+      Math.abs(time - targetMs) < Math.abs(times[nearest] - targetMs) ? index : nearest,
+    0,
   )
 }
 
@@ -109,8 +144,149 @@ function nearestPointAcrossLines(lines: TrendLine[], targetMs: number): TrendPoi
   return best
 }
 
-export function TrendChart(props: {series: TrendSeries; width: number; height: number}) {
-  const {series, width, height} = props
+/**
+ * Which baseline a chart draws, and whether it draws one at all.
+ *
+ * Only the *worst* fired baseline is drawn — the same one `driftBadge` turns
+ * into the header percentage — so the chart and the badge can never tell two
+ * different stories. Drawing both would put four horizontal rules on a
+ * ~120px-tall small multiple while the badge still reported only one of them.
+ * (Both baselines remain visible as text in the drift feed.)
+ *
+ * Suppressed when:
+ * - **comparing branches** — the p75–p90 band is already suppressed as "mud"
+ *   for the same reason; overlapping baseline spans across branches are worse.
+ * - **x is minutes** — soak charts plot one run's samples, not run history, so
+ *   a run-window baseline is meaningless there.
+ * - **the drifted branch isn't the one plotted** — a stale/mismatched entry
+ *   must not annotate someone else's line.
+ */
+export function baselineToDraw(
+  series: TrendSeries,
+  drift: DriftResult | undefined,
+): DriftBaseline | null {
+  if (!drift) return null
+  if (series.lines.length !== 1) return null
+  if (series.xKind === 'minute') return null
+  if (series.lines[0].branch !== drift.branch) return null
+  return drift.baseline
+}
+
+/**
+ * The baseline overlay: the two window medians the drift check compared, each
+ * drawn across the runs it was measured over. Two rules, no fill — the p75–p90
+ * band already owns the fill channel, and a second shaded region reads as one
+ * thing with it.
+ *
+ * Purely explanatory of the badge — `aria-hidden`, because the badge already
+ * states the move numerically and the capture rect carries it in its label; the
+ * legend names the marks so the meaning never rests on color alone.
+ */
+function BaselineOverlay(props: {
+  baseline: DriftBaseline
+  direction: DriftResult['direction']
+  xScale: (ms: number) => number
+  yScale: (value: number) => number
+  innerWidth: number
+  innerHeight: number
+}) {
+  const {baseline, direction, xScale, yScale, innerWidth, innerHeight} = props
+  const color =
+    direction === 'regression'
+      ? COLOR.baselineRegression
+      : direction === 'improvement'
+        ? COLOR.baselineImprovement
+        : COLOR.baselineNeutral
+  const {recentPointsMs, baselinePointsMs} = baseline
+  if (baselinePointsMs.length === 0 || recentPointsMs.length === 0) return null
+
+  const baselineY = yScale(baseline.baseline)
+  const recentY = yScale(baseline.recent)
+
+  // The y-scale's domain comes from the *visible* points, but the medians come
+  // from full history — in a short range over gappy history a level can fall
+  // outside it, and an unclamped rule would draw into the axis or the header.
+  // Clamping y (as x is, below) would draw the level at the wrong value, which
+  // is worse than not drawing it: skip the overlay instead. The badge and the
+  // drift feed still state the move.
+  if (baselineY < 0 || baselineY > innerHeight || recentY < 0 || recentY > innerHeight) {
+    return null
+  }
+
+  // Clamp to the plot: drift reads full history, so a window can begin before the
+  // visible range (a 30-day view against a 28-run trailing window).
+  const clampX = (ms: number) => Math.max(0, Math.min(innerWidth, xScale(ms)))
+  const recentTo = clampX(recentPointsMs.at(-1)!)
+
+  // A window can be narrower than it is readable: 7 runs is a comfortable slice
+  // of a 90-day view today, but not of an "all" view once the history runs to
+  // hundreds of runs, and the newest run sits flush against the right edge so
+  // there is no room to pad rightward.
+  //
+  // So both rules get a floor, laid out as one step anchored at the right edge:
+  // the recent level takes the rightmost slice and the baseline level extends
+  // leftward from there. Padding them independently (tried both ways) either
+  // inverted the dashed rule or pushed the solid one over runs it never
+  // measured. Spans become approximate only when a window falls under its floor
+  // — the exact runs stay in the tooltip and the drift feed — but the shape (two
+  // levels, one step) always reads.
+  const MIN_RULE_WIDTH = 28
+  const boundary = Math.max(0, Math.min(clampX(recentPointsMs[0]), recentTo - MIN_RULE_WIDTH))
+  const baselineFrom = Math.max(0, Math.min(clampX(baselinePointsMs[0]), boundary - MIN_RULE_WIDTH))
+  const recentX2 = Math.max(recentTo, boundary + 2)
+
+  return (
+    <g aria-hidden="true" pointerEvents="none">
+      {/* The "before" level: dashed and recessive, so it never competes with the
+          measured median line for attention. Ends where the recent window starts,
+          so the two rules meet at the boundary instead of overlapping. */}
+      <line
+        x1={baselineFrom}
+        x2={boundary}
+        y1={baselineY}
+        y2={baselineY}
+        stroke={color}
+        strokeWidth={1.5}
+        strokeDasharray="4 3"
+        opacity={0.55}
+      />
+      {/* The step between the two levels. Without this the rules read as two
+          unrelated horizontal lines; the connector is what makes them one claim
+          ("it moved from here to here"). */}
+      <line
+        x1={boundary}
+        x2={boundary}
+        y1={baselineY}
+        y2={recentY}
+        stroke={color}
+        strokeWidth={1}
+        strokeDasharray="2 2"
+        opacity={0.5}
+      />
+      {/* The "after" level: solid and heavier — the value the badge is about. */}
+      <line
+        x1={boundary}
+        x2={recentX2}
+        y1={recentY}
+        y2={recentY}
+        stroke={color}
+        strokeWidth={2}
+        opacity={0.9}
+      />
+    </g>
+  )
+}
+
+export function TrendChart(props: {
+  series: TrendSeries
+  width: number
+  height: number
+  /** Active drift for this series, if any — draws the baseline overlay. */
+  drift?: DriftResult
+  /** Which encoding layers to draw; defaults to all. */
+  layers?: LayerState
+}) {
+  const {series, width, height, drift, layers = ALL_LAYERS_VISIBLE} = props
   const {lines, unit} = series
   const [hoverMs, setHoverMs] = useState<number | null>(null)
   // The selected point only — its anchor coords are derived from the current
@@ -151,9 +327,13 @@ export function TrendChart(props: {series: TrendSeries; width: number; height: n
   })
 
   const x = (point: TrendPoint) => xScale(point.date)
-  // The p75–p90 band only reads when there's one line — overlapping bands
-  // across branches would be mud, so comparison mode shows lines only
-  const showBand = lines.length === 1 && lines[0].points.some((p) => p.p75 !== undefined)
+  // The band only reads when there's one line — overlapping bands across branches
+  // would be mud, so comparison mode shows lines only (see seriesHasBand for the
+  // low-sample case)
+  const showBand = layers.visible('band') && seriesHasBand(series)
+  const overlayBaseline = layers.visible('baseline') ? baselineToDraw(series, drift) : null
+  // The band belongs to the line it describes, so it takes that line's color
+  const bandColor = lineColorFor(series, 0)
 
   const handleMove = (event: React.PointerEvent<SVGRectElement>) => {
     const rect = event.currentTarget.getBoundingClientRect()
@@ -168,14 +348,7 @@ export function TrendChart(props: {series: TrendSeries; width: number; height: n
     if (stepTimes.length === 0) return
     if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
       event.preventDefault()
-      const current =
-        hoverMs === null
-          ? stepTimes.length - 1
-          : stepTimes.reduce(
-              (nearest, time, index) =>
-                Math.abs(time - hoverMs) < Math.abs(stepTimes[nearest] - hoverMs) ? index : nearest,
-              0,
-            )
+      const current = hoverMs === null ? stepTimes.length - 1 : nearestTimeIndex(stepTimes, hoverMs)
       const next = Math.max(
         0,
         Math.min(stepTimes.length - 1, current + (event.key === 'ArrowRight' ? 1 : -1)),
@@ -191,16 +364,27 @@ export function TrendChart(props: {series: TrendSeries; width: number; height: n
     }
   }
 
-  const anchor = hoverMs === null ? null : xScale(new Date(hoverMs))
-  // Each line's nearest point to the hovered time, for the crosshair readout
+  // Snapped to the nearest run, not the raw pointer x: the crosshair *is* the
+  // run marker, so it has to sit on a run. It also has to be independent of any
+  // layer's y-value — a dot on the median is anchored to nothing once the median
+  // layer is toggled off.
+  const snappedIndex = hoverMs === null ? -1 : nearestTimeIndex(stepTimes, hoverMs)
+  // While a run's popover is open the marker stays on that run: reaching the
+  // popover means moving the pointer out of the plot, which clears `hoverMs`, and
+  // the line vanishing is exactly when you most need to see which run you opened.
+  const snappedMs =
+    snappedIndex === -1 ? (selected?.date.getTime() ?? null) : stepTimes[snappedIndex]
+  const anchor = snappedMs === null ? null : xScale(new Date(snappedMs))
+  // Read out the *snapped* run, so the rule and the tooltip always describe the
+  // same run rather than drifting apart by up to half a run's spacing
   const hovered =
-    hoverMs === null
+    snappedMs === null
       ? []
       : lines
           .map((line, index) => ({
             branch: line.branch,
             color: lineColorFor(series, index),
-            point: nearestPoint(line, hoverMs),
+            point: nearestPoint(line, snappedMs),
           }))
           .filter((entry): entry is {branch: string; color: string; point: TrendPoint} =>
             Boolean(entry.point),
@@ -224,20 +408,55 @@ export function TrendChart(props: {series: TrendSeries; width: number; height: n
               opacity={0.4}
             />
           )}
-          {showBand && (
-            <Area<TrendPoint>
-              data={lines[0].points}
-              x={x}
-              y0={(point) => yScale(point.p75 ?? point.value)}
-              y1={(point) => yScale(point.p90 ?? point.value)}
-              fill={COLOR.band}
+          {/* Baseline overlay sits under the band, line and dots — it's
+              annotation, and must never obscure the measurement it explains */}
+          {overlayBaseline && drift && (
+            <BaselineOverlay
+              baseline={overlayBaseline}
+              direction={drift.direction}
+              xScale={(ms) => xScale(new Date(ms))}
+              yScale={yScale}
+              innerWidth={innerWidth}
+              innerHeight={innerHeight}
             />
+          )}
+          {showBand && (
+            <>
+              <Area<TrendPoint>
+                data={lines[0].points}
+                x={x}
+                y0={(point) => yScale(point.p75 ?? point.value)}
+                y1={(point) => yScale(point.p90 ?? point.value)}
+                fill={bandColor}
+                opacity={0.22}
+              />
+              {/* Faint strokes on both edges. Without them the fill's boundary
+                  is the most line-like thing in the plot, so with the median
+                  layer toggled off the band gets read as the median itself —
+                  two defined edges make it unmistakably a region. */}
+              <LinePath<TrendPoint>
+                data={lines[0].points}
+                x={x}
+                y={(point) => yScale(point.p75 ?? point.value)}
+                stroke={bandColor}
+                strokeWidth={1}
+                opacity={0.5}
+              />
+              <LinePath<TrendPoint>
+                data={lines[0].points}
+                x={x}
+                y={(point) => yScale(point.p90 ?? point.value)}
+                stroke={bandColor}
+                strokeWidth={1}
+                opacity={0.5}
+              />
+            </>
           )}
           {lines.map((line, index) => {
             const color = lineColorFor(series, index)
             return (
               <g key={line.branch}>
-                {line.points.length > 1 && (
+                {line.points.length > 1 && layers.visible('median') && (
                   <LinePath<TrendPoint>
                     data={line.points}
                     x={x}
@@ -252,39 +471,23 @@ export function TrendChart(props: {series: TrendSeries; width: number; height: n
                     opacity={series.goal === 'context' ? 0.55 : 1}
                   />
                 )}
-                {line.points.map((point, pointIndex) => {
-                  const isHovered = hovered.some(
-                    (entry) => entry.branch === line.branch && entry.point === point,
-                  )
-                  return (
-                    // Soak charts encode one run as many minute samples, so every
-                    // point shares the same runId — index keeps the key unique
-                    <g key={`${point.runId}:${pointIndex}`}>
-                      {/* Soft halo behind the hovered point — reads clearly as
-                          "this run is targeted / clickable" */}
-                      {isHovered && (
-                        <circle
-                          cx={x(point)}
-                          cy={yScale(point.value)}
-                          r={9}
-                          fill={color}
-                          opacity={0.18}
-                          pointerEvents="none"
-                        />
-                      )}
-                      <RunDot
-                        point={point}
-                        cx={x(point)}
-                        cy={yScale(point.value)}
-                        color={color}
-                        emphasized={isHovered}
-                      />
-                    </g>
-                  )
-                })}
+                {/* A lone run draws no LinePath, so without a mark the chart
+                    would be blank — keep a resting dot for that case only
+                    (the `single-run` debug source, and a genuine first run). */}
+                {line.points.length === 1 && (
+                  <circle
+                    cx={x(line.points[0])}
+                    cy={yScale(line.points[0].value)}
+                    r={2.5}
+                    fill={color}
+                    pointerEvents="none"
+                  />
+                )}
               </g>
             )
           })}
+          {/* The run marker: a full-height rule snapped to the hovered/focused
+              run. Full height so it reads regardless of which layers are on. */}
           {anchor !== null && (
             <line
               x1={anchor}
@@ -293,7 +496,7 @@ export function TrendChart(props: {series: TrendSeries; width: number; height: n
               y2={innerHeight}
               stroke={COLOR.axis}
               strokeWidth={1}
-              strokeDasharray="3 3"
+              opacity={0.7}
               pointerEvents="none"
             />
           )}
@@ -334,7 +537,19 @@ export function TrendChart(props: {series: TrendSeries; width: number; height: n
             style={{cursor: 'pointer', outline: 'none'}}
             tabIndex={0}
             role="application"
-            aria-label={`${series.title} — ${stepTimes.length} run(s). Arrow keys inspect runs, Enter opens details.`}
+            aria-label={`${series.title} — ${stepTimes.length} run(s).${
+              overlayBaseline && drift
+                ? // "Flagged" only when something actually fired — neutral
+                  // overlays are drawn on nearly every chart, and announcing
+                  // those as flagged would dilute the word to nothing
+                  ` ${
+                    drift.direction === 'neutral' ? 'Baseline' : `Flagged ${drift.direction},`
+                  } ${baselineDetail(overlayBaseline)}: ${formatValue(
+                    overlayBaseline.baseline,
+                    unit,
+                  )} to ${formatValue(overlayBaseline.recent, unit)}.`
+                : ''
+            } Arrow keys inspect runs, Enter opens details.`}
             onPointerMove={handleMove}
             onPointerLeave={() => setHoverMs(null)}
             // Seed the crosshair on keyboard focus so there's an immediate
@@ -350,7 +565,10 @@ export function TrendChart(props: {series: TrendSeries; width: number; height: n
           />
         </Group>
       </svg>
-      {anchor !== null && hovered.length > 0 && (
+      {/* Tied to actual hovering, not to the marker: the marker also stands on
+          the selected run while its popover is open, and a hover tooltip on top
+          of that popover would report the same run twice. */}
+      {hoverMs !== null && anchor !== null && hovered.length > 0 && (
         <div
           style={{
             position: 'absolute',
@@ -398,6 +616,37 @@ export function TrendChart(props: {series: TrendSeries; width: number; height: n
                   </Text>
                 </Flex>
               ))}
+              {/* What the overlay rules are. Unlabelled in the plot they invite a
+                  fair "that isn't the middle of the data" — a median ignores how
+                  far outliers fall, so it sits with the cluster rather than
+                  between the extremes. Naming the statistic and its window size
+                  makes that readable instead of surprising. */}
+              {overlayBaseline && (
+                <>
+                  <Box
+                    aria-hidden="true"
+                    style={{height: 1, background: 'var(--card-border-color)'}}
+                  />
+                  <Stack gap={1}>
+                    <Flex align="center" gap={2}>
+                      <Text size={0} muted>
+                        baseline (median of {overlayBaseline.baselinePointsMs.length} runs)
+                      </Text>
+                      <Text size={0} weight="semibold">
+                        {formatValue(overlayBaseline.baseline, unit)}
+                      </Text>
+                    </Flex>
+                    <Flex align="center" gap={2}>
+                      <Text size={0} muted>
+                        recent (median of {overlayBaseline.recentPointsMs.length} runs)
+                      </Text>
+                      <Text size={0} weight="semibold">
+                        {formatValue(overlayBaseline.recent, unit)}
+                      </Text>
+                    </Flex>
+                  </Stack>
+                </>
+              )}
             </Stack>
           </Card>
         </div>

--- a/dev/metrics-studio/tools/trends/TrendChart.tsx
+++ b/dev/metrics-studio/tools/trends/TrendChart.tsx
@@ -43,14 +43,13 @@ function previousShaFor(lines: TrendLine[], selected: TrendPoint): string | unde
 export const COLOR = {
   line: 'var(--card-accent-fg-color, #556bfc)',
   /**
-   * The p75–p90 band. This used to be `--card-badge-primary-bg-color` — a badge
-   * *background* token pressed into service as a data fill, which in dark mode
-   * resolves to a desaturated navy barely separable from the card behind it.
-   *
-   * Instead the band is now the series' own color at low alpha, applied via
-   * `fill`/`stroke` + opacity rather than baked into the value: it ties the band
+   * The p75–p90 band: the series' own color at low alpha, applied via
+   * `fill`/`stroke` + opacity rather than baked into the value. It ties the band
    * to the line it describes (a percentile spread belongs to its median), and it
    * inherits whatever contrast that color already has in both schemes.
+   * Deliberately not a badge *background* token like
+   * `--card-badge-primary-bg-color`, which in dark mode resolves to a
+   * desaturated navy barely separable from the card behind it.
    */
   band: 'var(--card-accent-fg-color, #556bfc)',
   axis: 'var(--card-muted-fg-color, #727892)',
@@ -242,7 +241,7 @@ function BaselineOverlay(props: {
   //
   // So both rules get a floor, laid out as one step anchored at the right edge:
   // the recent level takes the rightmost slice and the baseline level extends
-  // leftward from there. Padding them independently (tried both ways) either
+  // leftward from there. Padding them independently either
   // inverted the dashed rule or pushed the solid one over runs it never
   // measured. Spans become approximate only when a window falls under its floor
   // — the exact runs stay in the tooltip and the drift feed — but the shape (two

--- a/dev/metrics-studio/tools/trends/TrendChart.tsx
+++ b/dev/metrics-studio/tools/trends/TrendChart.tsx
@@ -5,13 +5,22 @@ import {scaleLinear, scaleTime} from '@visx/scale'
 import {Area, LinePath} from '@visx/shape'
 import {useRef, useState} from 'react'
 
-import {formatValue, isSignedUnit, type TrendLine, type TrendPoint, type TrendSeries} from './data'
+import {
+  formatTick,
+  formatValue,
+  INP_MIN_INTERACTIONS,
+  isSignedUnit,
+  type TrendLine,
+  type TrendPoint,
+  type TrendSeries,
+} from './data'
 import {baselineDetail, type DriftBaseline, type DriftResult} from './drift'
 import {ALL_LAYERS_VISIBLE, type LayerState} from './layers'
 import {categoricalColor} from './palette'
 import {RunDetailPopover} from './RunDetailPopover'
 
-const MARGIN = {top: 8, right: 8, bottom: 22, left: 44}
+// Left gutter is computed per chart from its tick labels — see marginLeft
+const MARGIN = {top: 8, right: 8, bottom: 22}
 
 /**
  * The nearest earlier point on the selected point's own line that measured a
@@ -69,6 +78,14 @@ export const COLOR = {
    * levels" without the tonal claim that something needs attention.
    */
   baselineNeutral: 'var(--card-muted-fg-color, #727892)',
+  /**
+   * The web.dev "good" threshold rule on vitals charts. Amber because crossing
+   * it is a caution, and because the other overlay hues are claimed: critical
+   * red / positive green are the drift directions, grey is the neutral
+   * baseline — a grey-dashed quality bar would be indistinguishable from a
+   * neutral baseline's before-rule.
+   */
+  goodThreshold: 'var(--card-badge-caution-fg-color, #a35200)',
 }
 
 /**
@@ -298,8 +315,45 @@ export function TrendChart(props: {
   const allPoints = lines.flatMap((line) => line.points)
   if (width < 10 || allPoints.length === 0) return null
 
-  const innerWidth = width - MARGIN.left - MARGIN.right
   const innerHeight = height - MARGIN.top - MARGIN.bottom
+
+  // Signed units (slopes) center on zero with a symmetric domain, so a
+  // near-flat metric reads as a calm line through the middle rather than
+  // magnified jitter. Unsigned metrics keep the 0→max framing.
+  const values = allPoints.map((point) => point.value)
+  // The "good" bar is part of the question a vitals chart answers ("how far
+  // under the bar are we?"), so the domain always includes it — a bar clipped
+  // away because we're comfortably good would hide exactly that comfort. The
+  // resolution cost is real but bounded: the bar is never far from plausible
+  // values of its own metric.
+  const highs = allPoints.map((point) => point.p90 ?? point.value)
+  const dataTop = Math.max(...highs, series.goodThreshold ?? 0)
+  const yScale = scaleLinear({
+    domain: isSignedUnit(unit)
+      ? (() => {
+          const extent = Math.max(0.5, ...values.map((value) => Math.abs(value))) * 1.2
+          return [-extent, extent]
+        })()
+      : [0, dataTop > 0 ? dataTop * 1.1 : 1],
+    range: [innerHeight, 0],
+    nice: true,
+  })
+  const yDomainMax = yScale.domain().at(-1) ?? 0
+
+  // The gutter is sized to the labels it will actually hold, not hardcoded: a
+  // fixed width kept losing to whichever unit produced the widest tick next —
+  // and a label that overflows by a couple of pixels is the worst failure
+  // mode, shaving the leading glyph's left stroke so "8000ms" reads "3000ms".
+  // The labels are knowable here (scale.ticks(3) is exactly what AxisLeft
+  // draws for numTicks=3), so measure the longest and pad for the tick mark.
+  // 6.2px/char over-approximates fontSize 10 digits; the floor keeps charts
+  // with tiny labels ("0", "3") from hugging the card edge.
+  const tickLabels = yScale.ticks(3).map((tick) => formatTick(tick, unit, yDomainMax))
+  const marginLeft = Math.max(
+    36,
+    Math.ceil(Math.max(0, ...tickLabels.map((label) => label.length)) * 6.2) + 12,
+  )
+  const innerWidth = width - marginLeft - MARGIN.right
 
   const dates = allPoints.map((point) => point.date.getTime())
   let [minDate, maxDate] = [Math.min(...dates), Math.max(...dates)]
@@ -309,22 +363,6 @@ export function TrendChart(props: {
     maxDate += 24 * 60 * 60 * 1000
   }
   const xScale = scaleTime({domain: [new Date(minDate), new Date(maxDate)], range: [0, innerWidth]})
-
-  // Signed units (slopes) center on zero with a symmetric domain, so a
-  // near-flat metric reads as a calm line through the middle rather than
-  // magnified jitter. Unsigned metrics keep the 0→max framing.
-  const values = allPoints.map((point) => point.value)
-  const highs = allPoints.map((point) => point.p90 ?? point.value)
-  const yScale = scaleLinear({
-    domain: isSignedUnit(unit)
-      ? (() => {
-          const extent = Math.max(0.5, ...values.map((value) => Math.abs(value))) * 1.2
-          return [-extent, extent]
-        })()
-      : [0, Math.max(...highs) > 0 ? Math.max(...highs) * 1.1 : 1],
-    range: [innerHeight, 0],
-    nice: true,
-  })
 
   const x = (point: TrendPoint) => xScale(point.date)
   // The band only reads when there's one line — overlapping bands across branches
@@ -395,8 +433,10 @@ export function TrendChart(props: {
       {/* No role="img": the plot is interactive (see the focusable capture
           rect below), not a static image — claiming "img" would hide that */}
       <svg width={width} height={height}>
-        <Group left={MARGIN.left} top={MARGIN.top}>
-          {/* Zero reference for signed slope charts — the "flat is good" line */}
+        <Group left={marginLeft} top={MARGIN.top}>
+          {/* Zero reference for signed slope charts — the "flat is good" line.
+              Dashed like the other reference marks: solid, it reads as a flat
+              data series the moment the median layer is toggled off. */}
           {isSignedUnit(unit) && (
             <line
               x1={0}
@@ -405,7 +445,24 @@ export function TrendChart(props: {
               y2={yScale(0)}
               stroke={COLOR.axis}
               strokeWidth={1}
+              strokeDasharray="3 3"
               opacity={0.4}
+            />
+          )}
+          {/* The web.dev "good" bar. Long dashes so it never reads as the
+              baseline overlay's rules ("4 3" dashed) or the zero line ("3 3");
+              the legend names it, so the meaning never rests on color alone. */}
+          {series.goodThreshold !== undefined && (
+            <line
+              x1={0}
+              x2={innerWidth}
+              y1={yScale(series.goodThreshold)}
+              y2={yScale(series.goodThreshold)}
+              stroke={COLOR.goodThreshold}
+              strokeWidth={1}
+              strokeDasharray="7 4"
+              opacity={0.5}
+              pointerEvents="none"
             />
           )}
           {/* Baseline overlay sits under the band, line and dots — it's
@@ -520,7 +577,9 @@ export function TrendChart(props: {
             numTicks={3}
             stroke={COLOR.axis}
             tickStroke={COLOR.axis}
-            tickFormat={(value) => formatValue(Number(value), unit)}
+            // domainMax keeps every tick of one axis in one unit (all-seconds
+            // once the scale top crosses 10s, all-ms below it)
+            tickFormat={(value) => formatTick(Number(value), unit, yScale.domain().at(-1))}
             tickLabelProps={{fill: COLOR.axis, fontSize: 10, textAnchor: 'end', dx: -2, dy: 3}}
           />
           {/* Transparent capture rect over the plot area drives the crosshair
@@ -537,7 +596,7 @@ export function TrendChart(props: {
             style={{cursor: 'pointer', outline: 'none'}}
             tabIndex={0}
             role="application"
-            aria-label={`${series.title} — ${stepTimes.length} run(s).${
+            aria-label={`${series.title}: ${stepTimes.length} ${stepTimes.length === 1 ? 'run' : 'runs'}.${
               overlayBaseline && drift
                 ? // "Flagged" only when something actually fired — neutral
                   // overlays are drawn on nearly every chart, and announcing
@@ -548,6 +607,10 @@ export function TrendChart(props: {
                     overlayBaseline.baseline,
                     unit,
                   )} to ${formatValue(overlayBaseline.recent, unit)}.`
+                : ''
+            }${
+              series.goodThreshold !== undefined
+                ? ` Good is ${formatValue(series.goodThreshold, unit)} or less (web.dev).`
                 : ''
             } Arrow keys inspect runs, Enter opens details.`}
             onPointerMove={handleMove}
@@ -574,9 +637,8 @@ export function TrendChart(props: {
             position: 'absolute',
             top: 0,
             // Flip past the midpoint so the tooltip never runs off the edge
-            left: anchor + MARGIN.left > width / 2 ? undefined : anchor + MARGIN.left + 8,
-            right:
-              anchor + MARGIN.left > width / 2 ? width - (anchor + MARGIN.left) + 8 : undefined,
+            left: anchor + marginLeft > width / 2 ? undefined : anchor + marginLeft + 8,
+            right: anchor + marginLeft > width / 2 ? width - (anchor + marginLeft) + 8 : undefined,
             pointerEvents: 'none',
           }}
         >
@@ -599,6 +661,25 @@ export function TrendChart(props: {
                   <Text size={0} weight="semibold">
                     {formatValue(entry.point.value, unit)}
                   </Text>
+                  {/* INP confidence: the count qualifies the value, so it sits
+                      right next to it — caution-toned when below the floor the
+                      percentile rule wants, since that INP is a weak estimate */}
+                  {entry.point.interactions !== undefined && (
+                    <Text
+                      size={0}
+                      muted={entry.point.interactions >= INP_MIN_INTERACTIONS}
+                      style={
+                        entry.point.interactions < INP_MIN_INTERACTIONS
+                          ? {color: 'var(--card-badge-caution-fg-color)'}
+                          : undefined
+                      }
+                    >
+                      n={entry.point.interactions}
+                      {entry.point.interactions < INP_MIN_INTERACTIONS
+                        ? ` of ${INP_MIN_INTERACTIONS}`
+                        : ''}
+                    </Text>
+                  )}
                   <Text size={0} muted>
                     {lines.length > 1
                       ? entry.branch
@@ -660,7 +741,7 @@ export function TrendChart(props: {
             ref={setAnchorEl}
             style={{
               position: 'absolute',
-              left: MARGIN.left + x(selected),
+              left: marginLeft + x(selected),
               top: MARGIN.top + yScale(selected.value),
               width: 1,
               height: 1,

--- a/dev/metrics-studio/tools/trends/TrendsTool.tsx
+++ b/dev/metrics-studio/tools/trends/TrendsTool.tsx
@@ -47,6 +47,7 @@ import {
   type TrendGroup,
   type TrendRun,
   type TrendSeries,
+  vitalSections,
 } from './data'
 import {DEBUG_SOURCES, type DebugSource, generateDebugRuns} from './debugData'
 import {type DriftResult, worstBySeries} from './drift'
@@ -285,11 +286,11 @@ function AckMenu(props: {
       menu={
         <Menu>
           {props.acked ? (
-            <MenuItem text="Un-ack" onClick={props.onUnack} />
+            <MenuItem text="Reopen" onClick={props.onUnack} />
           ) : (
             <>
               <MenuItem text="Silence" onClick={() => props.onAck('silenced')} />
-              <MenuItem text="Snooze 7d" onClick={() => props.onAck('snoozed')} />
+              <MenuItem text="Snooze 7 days" onClick={() => props.onAck('snoozed')} />
               {/* "Mark fixed" only makes sense for a regression — an improvement
                   has nothing to fix */}
               {props.direction === 'regression' && (
@@ -367,7 +368,7 @@ function SeriesCard(props: {
               <Box
                 as="button"
                 onClick={onFocus}
-                title="Focus this chart"
+                title="Go to chart"
                 style={{
                   background: 'none',
                   border: 0,
@@ -507,20 +508,20 @@ function SoakPanel(props: {
     slopes.length > 0 && {
       id: 'slope',
       label: 'Slope over runs',
-      hint: 'Per-minute slope, across runs — is a leak or degradation worsening release over release?',
+      hint: 'Per-minute slope, across runs. Is a leak or degradation worsening release over release?',
       charts: slopes,
     },
     endValues.length > 0 && {
       id: 'end',
       label: 'End of run',
-      hint: 'End-of-run value, across runs — where each metric landed by the end of the soak.',
+      hint: 'End-of-run value, across runs: where each metric landed by the end of the soak.',
       charts: endValues,
     },
     latest &&
       latest.charts.length > 0 && {
         id: 'latest',
         label: 'Latest run',
-        hint: `Latest soak run — ${latest.run.git?.branch ?? 'unknown'} @ ${latest.run.git?.sha?.slice(0, 10) ?? '?'} · minute-by-minute.`,
+        hint: `Latest soak run: ${latest.run.git?.branch ?? 'unknown'} @ ${latest.run.git?.sha?.slice(0, 10) ?? '?'}, minute by minute.`,
         charts: latest.charts,
       },
   ].filter(Boolean) as {id: string; label: string; hint: string; charts: TrendSeries[]}[]
@@ -835,13 +836,13 @@ export function TrendsTool() {
                 <Stack gap={3}>
                   <Text size={1} muted>
                     One benchmark run per day of the studio built from <code>main</code>, measured
-                    against a local API mock (no network, no real project) — see{' '}
-                    <code>perf/bench</code>. Each chart tracks one metric over time; each dot is one
-                    run — click it for the run details and links to the PR, commit, and CI run.
+                    against a local API mock (no network, no real project); see{' '}
+                    <code>perf/bench</code>. Each chart tracks one metric over time. Click anywhere
+                    in a chart to open the nearest run, with links to the PR, commit, and CI run.
                   </Text>
                   <Text size={1} muted>
-                    Because the CI machine varies day to day, absolute numbers are host-relative:
-                    before trusting a spike, check the host calibration in the Calibration tab — if
+                    Because the CI machine varies day to day, absolute numbers depend on the host:
+                    before trusting a spike, check the host calibration in the Calibration tab. If
                     it spikes on the same day, suspect the runner, not the studio. Flat lines are
                     the goal; the ⓘ on each chart explains what it measures.
                   </Text>
@@ -851,7 +852,9 @@ export function TrendsTool() {
 
             {error && (
               <Card tone="critical" border padding={3} radius={2}>
-                <Text size={1}>Failed to load runs: {error}</Text>
+                <Text size={1}>
+                  Couldn't load benchmark runs: {error}. Reload the page to try again.
+                </Text>
               </Card>
             )}
             {loading && (
@@ -862,8 +865,8 @@ export function TrendsTool() {
             {!error && !loading && series.length === 0 && (
               <Card tone="transparent" border padding={4} radius={2}>
                 <Text size={1} muted>
-                  No benchmark runs in this range yet. The daily track-main cron stores one run per
-                  day once perf/bench is on the main branch.
+                  No benchmark runs in this range. Try a longer range, or wait for the daily
+                  benchmark (one run per day from main).
                 </Text>
               </Card>
             )}
@@ -925,6 +928,39 @@ export function TrendsTool() {
                         latest={latestSoak}
                         layers={layers}
                       />
+                    ) : activeTab.id === 'vitals' ? (
+                      // One section per vital, so the overview reads by metric
+                      // ("how is LCP doing, everywhere?") — see vitalSections.
+                      // The extra top padding separates the first section
+                      // header from the tab description it would otherwise hug.
+                      <Stack gap={6} paddingTop={3}>
+                        {vitalSections(series.filter((entry) => entry.group === 'vitals')).map(
+                          (section) => (
+                            <Stack key={section.vital} gap={4}>
+                              <Flex align="baseline" gap={2}>
+                                <Text size={1} weight="semibold">
+                                  {section.vital}
+                                </Text>
+                                {section.name && (
+                                  <Text size={1} muted>
+                                    {section.name}
+                                  </Text>
+                                )}
+                              </Flex>
+                              <ChartGrid
+                                layers={layers}
+                                series={section.series}
+                                driftBySeries={driftBySeries}
+                                silencedBySeries={silencedBySeries}
+                                baselineBySeries={baselineBySeries}
+                                drift={drift}
+                                focusedKey={focusedKey}
+                                onFocusMetric={focusMetric}
+                              />
+                            </Stack>
+                          ),
+                        )}
+                      </Stack>
                     ) : (
                       <ChartGrid
                         layers={layers}

--- a/dev/metrics-studio/tools/trends/TrendsTool.tsx
+++ b/dev/metrics-studio/tools/trends/TrendsTool.tsx
@@ -49,8 +49,9 @@ import {
   type TrendSeries,
 } from './data'
 import {DEBUG_SOURCES, type DebugSource, generateDebugRuns} from './debugData'
-import {type DriftResult, worstBySeries, worstOf} from './drift'
+import {type DriftResult, worstBySeries} from './drift'
 import {DriftFeed} from './DriftFeed'
+import {type LayerState, useLayerState} from './layers'
 import {efpsSourceUrl, sourceFileUrl, webVitalDocUrl} from './links'
 import {MAX_COMPARE_BRANCHES} from './palette'
 import {TrendChart} from './TrendChart'
@@ -309,7 +310,7 @@ function chartDomId(seriesKey: string): string {
 }
 
 function driftBadge(entry: DriftResult): {tone: 'caution' | 'positive'; label: string} {
-  const worst = worstOf(entry)
+  const worst = entry.baseline
   const sign = worst.deltaFraction > 0 ? '+' : ''
   const arrow = entry.direction === 'regression' ? '↑' : '↓'
   return {
@@ -323,12 +324,19 @@ function SeriesCard(props: {
   height: number
   drift?: DriftResult
   silenced?: DriftResult
+  /** The baseline to draw, flagged or not. Falls back to the flagged one. */
+  baseline?: DriftResult
   focused?: boolean
   onFocus?: () => void
   onAck?: (state: 'silenced' | 'snoozed' | 'fixed') => void
   onUnack?: () => void
+  layers?: LayerState
 }) {
-  const {series, height, drift, silenced, focused, onFocus, onAck, onUnack} = props
+  const {series, height, drift, silenced, baseline, focused, onFocus, onAck, onUnack, layers} =
+    props
+  // The overlay draws from any computed baseline; the badge and tint only from a
+  // flagged one
+  const overlay = baseline ?? drift ?? silenced
   // Latest value of the first line — a headline number only when not comparing
   const latest = series.lines.length === 1 ? series.lines[0].points.at(-1) : undefined
   const badge = drift ? driftBadge(drift) : null
@@ -425,9 +433,17 @@ function SeriesCard(props: {
             inside an auto-height Stack row, and a 0-sized parent means no
             chart gets rendered at all */}
         <ParentSize debounceTime={50} style={{height}}>
-          {({width}) => <TrendChart series={series} width={width} height={height} />}
+          {({width}) => (
+            <TrendChart
+              series={series}
+              width={width}
+              height={height}
+              drift={overlay}
+              layers={layers}
+            />
+          )}
         </ParentSize>
-        <ChartLegend series={series} />
+        <ChartLegend series={series} drift={overlay} layers={layers} />
       </Stack>
     </Card>
   )
@@ -438,15 +454,19 @@ function ChartGrid(props: {
   series: TrendSeries[]
   driftBySeries?: Map<string, DriftResult>
   silencedBySeries?: Map<string, DriftResult>
+  /** Baselines for the chart overlay, including sub-threshold ones. */
+  baselineBySeries?: Map<string, DriftResult>
   drift?: DriftState
   focusedKey?: string | null
   onFocusMetric?: (seriesKey: string) => void
+  layers?: LayerState
 }) {
   return (
     <Grid gridTemplateColumns={[1, 1, 2, 3]} gap={3}>
       {props.series.map((entry) => {
         const entryDrift = props.driftBySeries?.get(entry.key)
         const entrySilenced = props.silencedBySeries?.get(entry.key)
+        const entryBaseline = props.baselineBySeries?.get(entry.key)
         return (
           <SeriesCard
             key={entry.key}
@@ -454,6 +474,7 @@ function ChartGrid(props: {
             height={128}
             drift={entryDrift}
             silenced={entrySilenced}
+            baseline={entryBaseline}
             focused={props.focusedKey === entry.key}
             onFocus={props.onFocusMetric ? () => props.onFocusMetric!(entry.key) : undefined}
             onAck={
@@ -462,6 +483,7 @@ function ChartGrid(props: {
             onUnack={
               entrySilenced && props.drift ? () => props.drift!.clear(entrySilenced) : undefined
             }
+            layers={props.layers}
           />
         )
       })}
@@ -477,6 +499,7 @@ function ChartGrid(props: {
 function SoakPanel(props: {
   slopes: TrendSeries[]
   endValues: TrendSeries[]
+  layers?: LayerState
   latest: {run: TrendRun; charts: TrendSeries[]} | null
 }) {
   const {slopes, endValues, latest} = props
@@ -525,7 +548,7 @@ function SoakPanel(props: {
           <Text size={1} muted>
             {active.hint}
           </Text>
-          <ChartGrid series={active.charts} />
+          <ChartGrid series={active.charts} layers={props.layers} />
         </Stack>
       </TabPanel>
     </Stack>
@@ -542,6 +565,10 @@ export function TrendsTool() {
   // is shareable and the tool is explorable before real runs exist.
   const [rangeParam, setRangeParam] = useUrlState('range', '90')
   const [sourceParam, setSourceParam] = useUrlState('source', 'live')
+  // Encoding layers (median / band / baseline overlay), toggled from any chart
+  // legend and applied to the whole grid — see layers.ts
+  const [layersParam, setLayersParam] = useUrlState('layers', '')
+  const layers = useLayerState(layersParam, setLayersParam)
   const source: DataSource =
     sourceParam === 'live' || DEBUG_SOURCES.includes(sourceParam as DebugSource)
       ? (sourceParam as DataSource)
@@ -596,6 +623,22 @@ export function TrendsTool() {
     [inRange, selectedBranches],
   )
   const series = useMemo(() => buildSeries(filtered), [filtered])
+  /**
+   * Drift is computed over *all* history for the selected branches, never the
+   * range-filtered view. Its baseline is defined in runs (last 7 vs prior 21),
+   * so feeding it a 30-day slice would leave the baseline drawing on ~23 of 30
+   * visible runs and — worse — make the verdict a function of the range picker:
+   * the same metric could flag at 90d and not at 30d. The charts still render
+   * `series` (the range the user chose); only the drift math reads the full
+   * history.
+   */
+  const driftSeries = useMemo(
+    () =>
+      buildSeries(
+        (runs ?? []).filter((run) => run.git && selectedBranches.includes(run.git.branch)),
+      ),
+    [runs, selectedBranches],
+  )
   const soakSlopes = useMemo(() => soakSlopeSeries(filtered), [filtered])
   // End-of-run soak values across runs — the "where did it land" history that
   // complements the slope view
@@ -654,7 +697,7 @@ export function TrendsTool() {
 
   // Shared drift state (feeds both the pinned feed and the per-tab badges, so
   // they can't disagree). Badge = active regressions in that group.
-  const drift = useDriftState(series)
+  const drift = useDriftState(driftSeries)
   const showBranch = series.some((s) => s.lines.length > 1)
   const [focusedKey, setFocusedKey] = useState<string | null>(null)
   // A deep-linked (?chart=) focus arms only once data is in: at mount the
@@ -709,6 +752,10 @@ export function TrendsTool() {
   // on more than one branch; keep the worst so the card shows the biggest move,
   // regressions winning over improvements.
   const driftBySeries = useMemo(() => worstBySeries(drift.active), [drift.active])
+  // Every series' baseline, flagged or not — the charts draw an overlay from this
+  // so the reference lines don't appear and disappear as metrics cross the
+  // threshold. Badge, card tint and the ack menu still key off `drift.active`.
+  const baselineBySeries = useMemo(() => worstBySeries(drift.all), [drift.all])
   // Silenced/snoozed per series — the card keeps a muted "acknowledged" marker
   // with an Un-ack, so you can reverse it without opening the feed. Active
   // drift takes precedence, so drop any series that's also active.
@@ -876,9 +923,11 @@ export function TrendsTool() {
                         slopes={soakSlopes}
                         endValues={soakEndValues}
                         latest={latestSoak}
+                        layers={layers}
                       />
                     ) : (
                       <ChartGrid
+                        layers={layers}
                         series={
                           activeTab.id === 'environment'
                             ? environmentSeries
@@ -886,6 +935,7 @@ export function TrendsTool() {
                         }
                         driftBySeries={driftBySeries}
                         silencedBySeries={silencedBySeries}
+                        baselineBySeries={baselineBySeries}
                         drift={drift}
                         focusedKey={focusedKey}
                         onFocusMetric={focusMetric}

--- a/dev/metrics-studio/tools/trends/data.test.ts
+++ b/dev/metrics-studio/tools/trends/data.test.ts
@@ -1,6 +1,14 @@
 import {expect, test} from 'vitest'
 
-import {buildSeries, calibrationSeries, formatValue, type TrendRun} from './data'
+import {
+  buildSeries,
+  calibrationSeries,
+  formatTick,
+  formatValue,
+  type TrendRun,
+  type TrendSeries,
+  vitalSections,
+} from './data'
 
 const START = Date.UTC(2026, 0, 1)
 const DAY = 24 * 60 * 60 * 1000
@@ -122,6 +130,98 @@ test('merged points stay in chronological order', () => {
   expect(points.map((p) => p.value)).toEqual([100, 120, 130])
 })
 
+/** An INP-session run: the INP value plus its interaction-count companion. */
+function inpRun(options: {
+  id: string
+  sha: string
+  day: number
+  inp: number
+  count: number
+}): TrendRun {
+  const base = run({id: options.id, sha: options.sha, day: options.day, value: 0})
+  return {
+    ...base,
+    scenarios: [
+      {
+        scenario: 'singleString',
+        kind: 'pageload',
+        metrics: [
+          {
+            label: 'INP',
+            unit: 'ms' as const,
+            experiment: {summary: {median: options.inp, p75: options.inp, p90: options.inp}},
+          },
+          {
+            label: 'INP interactions',
+            unit: 'count' as const,
+            experiment: {summary: {median: options.count, p75: options.count, p90: options.count}},
+          },
+        ],
+      },
+    ],
+  }
+}
+
+// Vitals with a published web.dev recommendation carry it so the chart can
+// draw the "good" bar; metrics without one must NOT get an invented bar.
+test('web vitals carry their good threshold, other metrics do not', () => {
+  const [inp] = buildSeries([inpRun({id: 'a', sha: 'sha-1', day: 0, inp: 88, count: 62})])
+  expect(inp.goodThreshold).toBe(200)
+  const [keystroke] = buildSeries([run({id: 'b', sha: 'sha-2', day: 0, value: 40})])
+  expect(keystroke.goodThreshold).toBeUndefined()
+})
+
+// The interaction count is confidence context for INP, not a metric: it rides
+// on the INP point (for the tooltip/popover) instead of getting its own chart.
+test('INP interactions become point context, not a series', () => {
+  const series = buildSeries([inpRun({id: 'a', sha: 'sha-1', day: 0, inp: 88, count: 62})])
+  expect(series).toHaveLength(1)
+  expect(series[0].title).toBe('singleString · INP')
+  expect(series[0].lines[0].points[0].interactions).toBe(62)
+})
+
+test('merged INP points keep the median interaction count', () => {
+  const series = buildSeries([
+    inpRun({id: 'a1', sha: 'sha-1', day: 0, inp: 88, count: 40}),
+    inpRun({id: 'a2', sha: 'sha-1', day: 0, inp: 96, count: 62}),
+    inpRun({id: 'a3', sha: 'sha-1', day: 0, inp: 90, count: 55}),
+  ])
+  const [point] = series[0].lines[0].points
+  expect(point.value).toBe(90)
+  expect(point.interactions).toBe(55)
+})
+
+const vitalStub = (title: string) => ({title}) as TrendSeries
+
+// The vitals tab reads by vital ("how is LCP doing, everywhere?"): one section
+// per vital, Core Web Vitals first, scenarios alphabetical within each.
+test('vitals group into per-vital sections', () => {
+  const sections = vitalSections([
+    vitalStub('recipe · boot-cold · CLS'),
+    vitalStub('singleString · INP'),
+    vitalStub('recipe · boot-cold · LCP'),
+    vitalStub('article · boot-cold · LCP'),
+    vitalStub('article · boot-cold · TTFB'),
+  ])
+  expect(
+    sections.map((section) => [section.vital, section.series.map((entry) => entry.title)]),
+  ).toEqual([
+    ['INP', ['singleString · INP']],
+    ['LCP', ['article · boot-cold · LCP', 'recipe · boot-cold · LCP']],
+    ['CLS', ['recipe · boot-cold · CLS']],
+    ['TTFB', ['article · boot-cold · TTFB']],
+  ])
+})
+
+// A metric in the vitals group that isn't a known vital must still render —
+// never silently vanish from the dashboard
+test('unknown vitals fall into a catch-all section', () => {
+  const sections = vitalSections([vitalStub('singleString · somethingNew')])
+  expect(sections).toEqual([
+    {vital: 'Other', series: [expect.objectContaining({title: 'singleString · somethingNew'})]},
+  ])
+})
+
 // The calibration strip's job is showing host-speed spread, including between
 // re-runs of one commit — merging it would hide exactly what it exists to show.
 test('the calibration series is not merged', () => {
@@ -158,4 +258,45 @@ test('non-ms units are unaffected', () => {
   expect(formatValue(60_000, 'count')).toBe('60000')
   expect(formatValue(0.026, 'cls')).toBe('0.026')
   expect(formatValue(150_981, 'bytes')).toBe('147.4 KB')
+})
+
+// Slope-unit axis ticks are the number alone: the full "+1.08 MB/min" clips at
+// the 44px gutter leaving only "MB/min", which reads as a broken axis. The unit
+// stays in the title/header/tooltip.
+test('slope-unit ticks drop the unit, the sign and trailing zeros', () => {
+  expect(formatTick(1.5, 'mb-per-min')).toBe('1.5')
+  expect(formatTick(-0.5, 'mb-per-min')).toBe('-0.5')
+  expect(formatTick(0, 'ms-per-min')).toBe('0')
+  expect(formatTick(2307.48, 'ms-per-min')).toBe('2307.48')
+  expect(formatTick(1.0, 'count-per-min')).toBe('1')
+})
+
+// "40.0 MB" and "147.4 KB" are 7–8 characters — wider than the gutter, so the
+// leading digit clips ("0.0 MB"), which reads as wrong data
+test('byte-unit ticks compact to fit the gutter', () => {
+  expect(formatTick(40, 'megabytes')).toBe('40MB')
+  expect(formatTick(41.8, 'megabytes')).toBe('41.8MB')
+  expect(formatTick(150_000, 'bytes')).toBe('146KB')
+  expect(formatTick(0, 'bytes')).toBe('0KB')
+})
+
+// One unit per axis: formatValue's per-value 10s cutoff put "10.0s" above
+// "5000ms" on the same scale. The axis passes its domain top so every tick
+// speaks the unit the scale ends in — seconds already from 1s, because a
+// four-digit ms tick barely overflows the gutter and shaves its leading
+// glyph into a different number ("8000ms" reads "3000ms")
+test('ms ticks share one unit across the axis', () => {
+  expect(formatTick(10_000, 'ms', 10_450)).toBe('10s')
+  expect(formatTick(5_000, 'ms', 10_450)).toBe('5s')
+  expect(formatTick(0, 'ms', 10_450)).toBe('0s')
+  expect(formatTick(8_000, 'ms', 8_000)).toBe('8s')
+  expect(formatTick(2_500, 'ms', 2_750)).toBe('2.5s')
+  // Sub-second scales (keystroke latency) stay in exact milliseconds
+  expect(formatTick(88, 'ms', 200)).toBe('88ms')
+  expect(formatTick(800, 'ms', 900)).toBe('800ms')
+})
+
+test('other ticks keep the full formatValue rendering', () => {
+  expect(formatTick(88, 'ms')).toBe('88ms')
+  expect(formatTick(60_000, 'count')).toBe('60000')
 })

--- a/dev/metrics-studio/tools/trends/data.test.ts
+++ b/dev/metrics-studio/tools/trends/data.test.ts
@@ -1,0 +1,161 @@
+import {expect, test} from 'vitest'
+
+import {buildSeries, calibrationSeries, formatValue, type TrendRun} from './data'
+
+const START = Date.UTC(2026, 0, 1)
+const DAY = 24 * 60 * 60 * 1000
+
+/** A minimal absolute-mode run carrying one interaction metric. */
+function run(options: {
+  id: string
+  sha: string
+  day: number
+  value: number
+  /** Extra copies of the same metric, as the pageload scenario does for INP. */
+  repeats?: number
+  calibrationMs?: number
+}): TrendRun {
+  const {id, sha, day, value, repeats = 1, calibrationMs = 8} = options
+  return {
+    _id: id,
+    startedAt: new Date(START + day * DAY).toISOString(),
+    mode: 'absolute',
+    git: {sha, branch: 'main', committedAt: new Date(START + day * DAY).toISOString()},
+    runner: {calibrationMs, runId: id, runAttempt: 1},
+    bundle: null,
+    scenarios: [
+      {
+        scenario: 'singleString',
+        kind: 'interaction',
+        metrics: Array.from({length: repeats}, () => ({
+          label: 'stringField',
+          unit: 'ms' as const,
+          experiment: {summary: {median: value, p75: value * 1.1, p90: value * 1.2}},
+        })),
+      },
+    ],
+  }
+}
+
+function pointsOf(runs: TrendRun[]) {
+  const [series] = buildSeries(runs)
+  return series.lines[0].points
+}
+
+test('one run per commit is left alone', () => {
+  const points = pointsOf([
+    run({id: 'a', sha: 'sha-1', day: 0, value: 100}),
+    run({id: 'b', sha: 'sha-2', day: 1, value: 120}),
+  ])
+  expect(points.map((p) => p.value)).toEqual([100, 120])
+})
+
+// CI re-runs the suite on a commit fairly often. Without merging, that commit
+// gets several dots on one x-position and several votes in every median.
+test('re-runs of one commit merge to their median', () => {
+  const points = pointsOf([
+    run({id: 'a1', sha: 'sha-1', day: 0, value: 100}),
+    run({id: 'a2', sha: 'sha-1', day: 0, value: 140}),
+    run({id: 'a3', sha: 'sha-1', day: 0, value: 120}),
+  ])
+  expect(points).toHaveLength(1)
+  expect(points[0].value).toBe(120)
+})
+
+// Median, not mean: a single failed or throttled re-run must not drag the point.
+test('an outlier re-run does not drag the merged value', () => {
+  const points = pointsOf([
+    run({id: 'a1', sha: 'sha-1', day: 0, value: 100}),
+    run({id: 'a2', sha: 'sha-1', day: 0, value: 104}),
+    run({id: 'a3', sha: 'sha-1', day: 0, value: 900}),
+  ])
+  // Mean would be ~368
+  expect(points[0].value).toBe(104)
+})
+
+// The pageload scenario stores the INP metric twice per run document.
+test('repeated metrics within one run collapse to one point', () => {
+  const points = pointsOf([run({id: 'a', sha: 'sha-1', day: 0, value: 100, repeats: 2})])
+  expect(points).toHaveLength(1)
+  expect(points[0].value).toBe(100)
+})
+
+test('p75 and p90 merge alongside the value', () => {
+  const points = pointsOf([
+    run({id: 'a1', sha: 'sha-1', day: 0, value: 100}),
+    run({id: 'a2', sha: 'sha-1', day: 0, value: 200}),
+  ])
+  expect(points[0].value).toBe(150)
+  expect(points[0].p75).toBeCloseTo(165, 5)
+  expect(points[0].p90).toBeCloseTo(180, 5)
+})
+
+// The click-through has to open a real document, so the merged point keeps one
+// run's identity rather than inventing a synthetic id.
+test('a merged point keeps a real run identity', () => {
+  const points = pointsOf([
+    run({id: 'first', sha: 'sha-1', day: 0, value: 100}),
+    run({id: 'second', sha: 'sha-1', day: 0, value: 120}),
+  ])
+  expect(['first', 'second']).toContain(points[0].runId)
+  expect(points[0].sha).toBe('sha-1')
+})
+
+// Runs with no sha can't be grouped by commit; keying them by run keeps them
+// distinct instead of collapsing unrelated measurements into one point.
+test('runs without a sha stay separate', () => {
+  const a = run({id: 'a', sha: 'x', day: 0, value: 100})
+  const b = run({id: 'b', sha: 'y', day: 1, value: 120})
+  const points = pointsOf([
+    {...a, git: null},
+    {...b, git: null},
+  ])
+  expect(points).toHaveLength(2)
+})
+
+test('merged points stay in chronological order', () => {
+  const points = pointsOf([
+    run({id: 'c', sha: 'sha-3', day: 2, value: 130}),
+    run({id: 'a', sha: 'sha-1', day: 0, value: 100}),
+    run({id: 'b', sha: 'sha-2', day: 1, value: 120}),
+  ])
+  expect(points.map((p) => p.value)).toEqual([100, 120, 130])
+})
+
+// The calibration strip's job is showing host-speed spread, including between
+// re-runs of one commit — merging it would hide exactly what it exists to show.
+test('the calibration series is not merged', () => {
+  const series = calibrationSeries([
+    run({id: 'a1', sha: 'sha-1', day: 0, value: 100, calibrationMs: 7.6}),
+    run({id: 'a2', sha: 'sha-1', day: 0, value: 100, calibrationMs: 6}),
+  ])
+  expect(series.lines[0].points.map((p) => p.value).sort((x, y) => x - y)).toEqual([6, 7.6])
+})
+
+// A "60000ms" tick does not fit the 44px axis gutter and silently renders as
+// "0000ms", which reads as wrong data rather than a clipped label.
+test('long durations abbreviate to seconds', () => {
+  expect(formatValue(60_000, 'ms')).toBe('60.0s')
+  expect(formatValue(33_863, 'ms')).toBe('33.9s')
+  expect(formatValue(120_000, 'ms')).toBe('120s')
+})
+
+// Keystroke latency lives at 30–200ms; "0.09s" would throw away the precision
+// the whole suite exists to measure.
+test('short durations stay in exact milliseconds', () => {
+  expect(formatValue(88, 'ms')).toBe('88ms')
+  expect(formatValue(532, 'ms')).toBe('532ms')
+  expect(formatValue(9_999, 'ms')).toBe('9999ms')
+})
+
+test('the abbreviation boundary is 10s', () => {
+  expect(formatValue(9_999, 'ms')).toMatch(/ms$/)
+  expect(formatValue(10_000, 'ms')).toBe('10.0s')
+})
+
+// Other units are untouched by the ms abbreviation
+test('non-ms units are unaffected', () => {
+  expect(formatValue(60_000, 'count')).toBe('60000')
+  expect(formatValue(0.026, 'cls')).toBe('0.026')
+  expect(formatValue(150_981, 'bytes')).toBe('147.4 KB')
+})

--- a/dev/metrics-studio/tools/trends/data.test.ts
+++ b/dev/metrics-studio/tools/trends/data.test.ts
@@ -81,7 +81,9 @@ test('an outlier re-run does not drag the merged value', () => {
   expect(points[0].value).toBe(104)
 })
 
-// The pageload scenario stores the INP metric twice per run document.
+// Defensive: no run document is known to carry the same metric twice, but if
+// one ever does, it must collapse to one point rather than double-voting its
+// commit.
 test('repeated metrics within one run collapse to one point', () => {
   const points = pointsOf([run({id: 'a', sha: 'sha-1', day: 0, value: 100, repeats: 2})])
   expect(points).toHaveLength(1)
@@ -213,8 +215,8 @@ test('vitals group into per-vital sections', () => {
   ])
 })
 
-// TTFB is no longer collected (a constant of the local mock, not a studio
-// signal), but stored history still carries it — it must not chart
+// Older documents carry a TTFB metric (a constant of the local mock, not a
+// studio signal) — it must not chart
 test('TTFB metrics in stored documents are skipped', () => {
   const base = run({id: 'a', sha: 'sha-1', day: 0, value: 100})
   const withTtfb: TrendRun = {

--- a/dev/metrics-studio/tools/trends/data.test.ts
+++ b/dev/metrics-studio/tools/trends/data.test.ts
@@ -201,7 +201,7 @@ test('vitals group into per-vital sections', () => {
     vitalStub('singleString · INP'),
     vitalStub('recipe · boot-cold · LCP'),
     vitalStub('article · boot-cold · LCP'),
-    vitalStub('article · boot-cold · TTFB'),
+    vitalStub('article · boot-cold · FCP'),
   ])
   expect(
     sections.map((section) => [section.vital, section.series.map((entry) => entry.title)]),
@@ -209,8 +209,31 @@ test('vitals group into per-vital sections', () => {
     ['INP', ['singleString · INP']],
     ['LCP', ['article · boot-cold · LCP', 'recipe · boot-cold · LCP']],
     ['CLS', ['recipe · boot-cold · CLS']],
-    ['TTFB', ['article · boot-cold · TTFB']],
+    ['FCP', ['article · boot-cold · FCP']],
   ])
+})
+
+// TTFB is no longer collected (a constant of the local mock, not a studio
+// signal), but stored history still carries it — it must not chart
+test('TTFB metrics in stored documents are skipped', () => {
+  const base = run({id: 'a', sha: 'sha-1', day: 0, value: 100})
+  const withTtfb: TrendRun = {
+    ...base,
+    scenarios: [
+      {
+        scenario: 'singleString',
+        kind: 'pageload',
+        metrics: [
+          {
+            label: 'boot-cold · TTFB',
+            unit: 'ms' as const,
+            experiment: {summary: {median: 3.5, p75: 3.6, p90: 5.2}},
+          },
+        ],
+      },
+    ],
+  }
+  expect(buildSeries([withTtfb])).toHaveLength(0)
 })
 
 // A metric in the vitals group that isn't a known vital must still render —
@@ -278,6 +301,13 @@ test('byte-unit ticks compact to fit the gutter', () => {
   expect(formatTick(41.8, 'megabytes')).toBe('41.8MB')
   expect(formatTick(150_000, 'bytes')).toBe('146KB')
   expect(formatTick(0, 'bytes')).toBe('0KB')
+  expect(formatTick(2_424_945, 'bytes')).toBe('2.3MB')
+})
+
+// The total-JS series is in the megabytes; a KB rendering buries the magnitude
+test('byte values past 1 MiB render in MB', () => {
+  expect(formatValue(2_424_945, 'bytes')).toBe('2.31 MB')
+  expect(formatValue(150_981, 'bytes')).toBe('147.4 KB')
 })
 
 // One unit per axis: formatValue's per-value 10s cutoff put "10.0s" above

--- a/dev/metrics-studio/tools/trends/data.ts
+++ b/dev/metrics-studio/tools/trends/data.ts
@@ -505,11 +505,11 @@ function medianOf(values: number[]): number {
  * median.
  *
  * CI re-runs the suite on a commit fairly often (4 shas in the stored history
- * have 2–3 runs each), and a run document can also contribute more than one
- * point to a series — the pageload scenario stores the INP metric twice. Left
- * unmerged, both cases put several dots on one x-position, weight that commit
- * several times in every median, and make a "7 runs" window cover fewer than 7
- * commits' worth of history.
+ * have 2–3 runs each). Left unmerged, that puts several dots on one
+ * x-position, weights that commit several times in every median, and makes a
+ * "7 runs" window cover fewer than 7 commits' worth of history. Within-document
+ * duplicates of one metric are also collapsed — none are known to exist, but
+ * the merge guards against them all the same.
  *
  * Median rather than mean, matching the p50/median language used throughout the
  * dashboard: a single throttled or failed re-run can't drag the point.
@@ -592,9 +592,9 @@ export function buildSeries(runs: TrendRun[]): TrendSeries[] {
       )?.experiment?.summary?.median
       for (const metric of scenario.metrics ?? []) {
         if (metric.label === 'INP interactions') continue
-        // TTFB is no longer collected (against the local mock it was a 2–10ms
-        // constant of the bench setup, not a studio signal) — but documents
-        // stored before its removal still carry it, so skip it here too
+        // Older documents carry a TTFB metric; skip it. Against the local
+        // mock it is a 2–10ms constant of the bench setup, not a studio
+        // signal, and the bench does not store it anymore.
         if (metric.label.endsWith('TTFB')) continue
         const summary = metric.experiment?.summary
         if (!summary) continue

--- a/dev/metrics-studio/tools/trends/data.ts
+++ b/dev/metrics-studio/tools/trends/data.ts
@@ -367,6 +367,17 @@ export function formatValue(value: number, unit: TrendUnit): string {
   if (unit === 'mb-per-min') return `${value >= 0 ? '+' : ''}${value.toFixed(2)} MB/min`
   if (unit === 'count-per-min') return `${value >= 0 ? '+' : ''}${value.toFixed(2)}/min`
   if (unit === 'ms-per-min') return `${value >= 0 ? '+' : ''}${value.toFixed(2)} ms/min`
+  // Seconds past 10s. Load metrics run to tens of thousands of ms, and a
+  // "60000ms" tick does not fit the 44px axis gutter — it silently renders as
+  // "0000ms", which reads as wrong data rather than as a clipped label. Below 10s
+  // stay in exact ms: keystroke latency lives at 30–200ms, where "0.09s" would
+  // throw away the precision the whole suite exists to measure.
+  if (Math.abs(value) >= 10_000) {
+    const seconds = value / 1000
+    // One decimal under 100s keeps 27.0s distinguishable from 27.9s; past that
+    // the extra digit is noise and costs width again
+    return `${Math.abs(seconds) < 100 ? seconds.toFixed(1) : seconds.toFixed(0)}s`
+  }
   return `${value.toFixed(0)}ms`
 }
 
@@ -404,6 +415,64 @@ function pointMeta(
     ciRunId: run.runner?.runId,
     ciRunAttempt: run.runner?.runAttempt,
   }
+}
+
+function medianOf(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+}
+
+/**
+ * One point per commit: several runs of the same sha are merged into their
+ * median.
+ *
+ * CI re-runs the suite on a commit fairly often (4 shas in the stored history
+ * have 2–3 runs each), and a run document can also contribute more than one
+ * point to a series — the pageload scenario stores the INP metric twice. Left
+ * unmerged, both cases put several dots on one x-position, weight that commit
+ * several times in every median, and make a "7 runs" window cover fewer than 7
+ * commits' worth of history.
+ *
+ * Median rather than mean, matching the p50/median language used throughout the
+ * dashboard: a single throttled or failed re-run can't drag the point.
+ *
+ * The merged point keeps the *last* run's identity (runId, CI run, PR) so the
+ * click-through opens a real document, and takes the median of `value`/`p75`/
+ * `p90` independently. Note the honesty cost: re-runs of one commit often land
+ * on hosts of different speed (sha 7147d045's two runs differ by 21% of
+ * calibration), so a merged point averages across hosts. The calibration strip
+ * is where that stays visible — and it is deliberately NOT merged, since its
+ * whole job is showing per-run and cross-shard host spread.
+ */
+function mergeRunsPerCommit(points: TrendPoint[]): TrendPoint[] {
+  const byCommit = new Map<string, TrendPoint[]>()
+  for (const point of points) {
+    // An unknown sha can't be de-duplicated by commit — key those by run so
+    // they stay distinct rather than collapsing into one blob
+    const key = point.sha === 'unknown' ? `run:${point.runId}` : point.sha
+    const group = byCommit.get(key)
+    if (group) group.push(point)
+    else byCommit.set(key, [point])
+  }
+
+  const merged: TrendPoint[] = []
+  for (const group of byCommit.values()) {
+    const last = group[group.length - 1]
+    if (group.length === 1) {
+      merged.push(last)
+      continue
+    }
+    const p75s = group.map((point) => point.p75).filter((v): v is number => v !== undefined)
+    const p90s = group.map((point) => point.p90).filter((v): v is number => v !== undefined)
+    merged.push({
+      ...last,
+      value: medianOf(group.map((point) => point.value)),
+      p75: p75s.length > 0 ? medianOf(p75s) : undefined,
+      p90: p90s.length > 0 ? medianOf(p90s) : undefined,
+    })
+  }
+  return merged.sort((a, b) => a.date.getTime() - b.date.getTime())
 }
 
 export function buildSeries(runs: TrendRun[]): TrendSeries[] {
@@ -458,7 +527,12 @@ export function buildSeries(runs: TrendRun[]): TrendSeries[] {
       )
     }
   }
-  return [...series.values()]
+  // Merge after collection: one point per commit per line (calibrationSeries is
+  // deliberately left unmerged — see mergeRunsPerCommit)
+  return [...series.values()].map((entry) => ({
+    ...entry,
+    lines: entry.lines.map((line) => ({...line, points: mergeRunsPerCommit(line.points)})),
+  }))
 }
 
 /** The honesty overlay: host-speed score per run (higher = slower host). */

--- a/dev/metrics-studio/tools/trends/data.ts
+++ b/dev/metrics-studio/tools/trends/data.ts
@@ -16,7 +16,7 @@ export interface TrendRun {
     mergeBaseSha?: string
   } | null
   runner: {calibrationMs: number; runId?: string; runAttempt?: number} | null
-  bundle: {experiment: {initialJsBytes: number} | null} | null
+  bundle: {experiment: {initialJsBytes: number; totalJsBytes?: number | null} | null} | null
   scenarios:
     | {
         scenario: string
@@ -59,7 +59,7 @@ export const TREND_QUERY = `*[_type == "benchRun" && mode == "absolute"] | order
   mode,
   git{sha, branch, committedAt, prNumber, mergeBaseSha},
   runner{calibrationMs, runId, runAttempt},
-  bundle{experiment{initialJsBytes}},
+  bundle{experiment{initialJsBytes, totalJsBytes}},
   scenarios[]{
     scenario,
     sourceFile,
@@ -249,7 +249,7 @@ export const TREND_GROUPS: {id: TrendGroup; title: string; description: string}[
     // The individual vitals are named (and spelled out) by the per-vital
     // section headers right below, so the description doesn't list them
     description:
-      'Google Core Web Vitals and supporting load metrics. Lower is better on all of them.',
+      'Google Core Web Vitals and supporting load metrics; lower is better on all of them. Measured in a canned environment (local API mock, no external network), so vitals that would only measure that setup are left out. TTFB, for example, would just time the mock.',
   },
   {
     id: 'responsiveness',
@@ -264,7 +264,8 @@ export const TREND_GROUPS: {id: TrendGroup; title: string; description: string}[
   {
     id: 'bundle',
     title: 'Bundle size',
-    description: 'JavaScript shipped to boot the studio.',
+    description:
+      'How much JavaScript the build ships, and how much of it booting actually downloads.',
   },
   {
     id: 'soak',
@@ -306,14 +307,6 @@ function describeSeries(
   }
   // goodThreshold values are the web.dev "good" recommendations
   // (https://web.dev/articles/defining-core-web-vitals-thresholds)
-  if (label.endsWith('TTFB')) {
-    return {
-      group: 'vitals',
-      description: 'Time to first byte of the document response.',
-      goal: 'lower',
-      goodThreshold: 800,
-    }
-  }
   if (label.endsWith('FCP')) {
     return {
       group: 'vitals',
@@ -346,6 +339,14 @@ function describeSeries(
         'Interaction to Next Paint: a high percentile of interaction latencies (click/type → next paint) under a realistic interaction mix (Core Web Vital).',
       goal: 'lower',
       goodThreshold: 200,
+    }
+  }
+  if (label.includes('boot JS')) {
+    return {
+      group: 'bundle',
+      description:
+        'Exact gzip sum of the JS chunks fetched before the document was editable (boot-cold): what booting actually downloads. The entry-chunk chart counts only what index.html references.',
+      goal: 'lower',
     }
   }
   if (label.includes('auth round trips')) {
@@ -384,7 +385,13 @@ function describeSeries(
 export function formatValue(value: number, unit: TrendUnit): string {
   if (unit === 'count') return value.toFixed(0)
   if (unit === 'cls') return value.toFixed(3) // unitless layout-shift score
-  if (unit === 'bytes') return `${(value / 1024).toFixed(1)} KB`
+  // MB past 1 MiB: the total-JS series runs to megabytes, where "2368.1 KB"
+  // buries the magnitude a reader actually wants
+  if (unit === 'bytes') {
+    return Math.abs(value) >= 1024 * 1024
+      ? `${(value / (1024 * 1024)).toFixed(2)} MB`
+      : `${(value / 1024).toFixed(1)} KB`
+  }
   if (unit === 'megabytes') return `${value.toFixed(1)} MB`
   // Slope units are signed and typically fractional — keep the sign and
   // enough precision that a near-zero rate reads as "~0", not a rounded 0
@@ -432,7 +439,11 @@ export function formatValue(value: number, unit: TrendUnit): string {
 export function formatTick(value: number, unit: TrendUnit, domainMax = 0): string {
   if (isSignedUnit(unit)) return parseFloat(value.toFixed(2)).toString()
   if (unit === 'megabytes') return `${parseFloat(value.toFixed(1))}MB`
-  if (unit === 'bytes') return `${Math.round(value / 1024)}KB`
+  if (unit === 'bytes') {
+    return Math.abs(value) >= 1024 * 1024
+      ? `${parseFloat((value / (1024 * 1024)).toFixed(1))}MB`
+      : `${Math.round(value / 1024)}KB`
+  }
   if (unit === 'ms' && Math.max(Math.abs(value), domainMax) >= 1_000) {
     return `${parseFloat((value / 1000).toFixed(1))}s`
   }
@@ -581,6 +592,10 @@ export function buildSeries(runs: TrendRun[]): TrendSeries[] {
       )?.experiment?.summary?.median
       for (const metric of scenario.metrics ?? []) {
         if (metric.label === 'INP interactions') continue
+        // TTFB is no longer collected (against the local mock it was a 2–10ms
+        // constant of the bench setup, not a studio signal) — but documents
+        // stored before its removal still carry it, so skip it here too
+        if (metric.label.endsWith('TTFB')) continue
         const summary = metric.experiment?.summary
         if (!summary) continue
         push(
@@ -602,13 +617,18 @@ export function buildSeries(runs: TrendRun[]): TrendSeries[] {
     }
     const initialJs = run.bundle?.experiment?.initialJsBytes
     if (typeof initialJs === 'number') {
+      // Key stays 'bundle:initialJs' (acks and deep links reference it), but
+      // the title stopped claiming this is what boot downloads: it's only the
+      // chunk index.html references, ~6% of the build — the studio loads the
+      // rest through dynamic imports before it is usable.
       push(
         'bundle:initialJs',
-        'bundle · initial JS (gzip)',
+        'bundle · entry chunk (gzip)',
         'bytes',
         {
           group: 'bundle',
-          description: 'Initial JavaScript downloaded to boot the studio, gzip-compressed.',
+          description:
+            'The one JS chunk index.html references, gzip-compressed. Not what boot downloads: the studio dynamic-imports most of its code from here.',
           goal: 'lower',
           // A build measures one size — there is no distribution to take a
           // median of, so the default 'median (p50)' legend would be false
@@ -616,6 +636,23 @@ export function buildSeries(runs: TrendRun[]): TrendSeries[] {
         },
         run,
         {value: initialJs},
+      )
+    }
+    const totalJs = run.bundle?.experiment?.totalJsBytes
+    if (typeof totalJs === 'number') {
+      push(
+        'bundle:totalJs',
+        'bundle · total JS (gzip)',
+        'bytes',
+        {
+          group: 'bundle',
+          description:
+            'Gzipped bytes of every JS chunk in the build; the ceiling on what a session can download. Boot fetches most of it through dynamic imports.',
+          goal: 'lower',
+          lineLabel: 'size per run',
+        },
+        run,
+        {value: totalJs},
       )
     }
   }
@@ -641,7 +678,6 @@ const VITALS = [
   {vital: 'LCP', name: 'Largest Contentful Paint'},
   {vital: 'CLS', name: 'Cumulative Layout Shift'},
   {vital: 'FCP', name: 'First Contentful Paint'},
-  {vital: 'TTFB', name: 'Time to First Byte'},
 ] as const
 
 export interface VitalSection {

--- a/dev/metrics-studio/tools/trends/data.ts
+++ b/dev/metrics-studio/tools/trends/data.ts
@@ -86,6 +86,13 @@ export interface TrendPoint {
   value: number
   p75?: number
   p90?: number
+  /**
+   * INP points only: how many interactions the run's INP sessions observed
+   * (median across sessions) — confidence context for the INP value, shown in
+   * the tooltip/popover rather than charted as a series of its own. The
+   * percentile rule wants at least INP_MIN_INTERACTIONS.
+   */
+  interactions?: number
   sha: string
   /** benchRun document id — opens the run in the studio. */
   runId: string
@@ -120,6 +127,22 @@ export interface TrendSeries {
    * works unchanged.
    */
   xKind?: 'date' | 'minute'
+  /**
+   * What one plotted point *is*, for the legend. Defaults to 'median (p50)' —
+   * true for the interaction/pageload series, whose points are per-run medians
+   * — but a soak slope point is a least-squares fit and an end-of-run point is
+   * a single sample; calling those "median (p50)" would be a false label.
+   */
+  lineLabel?: string
+  /**
+   * Published "good" threshold for the metric, drawn as a reference rule on
+   * the chart. Only set where a real recommendation exists (the web.dev Core
+   * Web Vitals thresholds); made-up bars would dilute the real ones. Note the
+   * honesty gap: web.dev thresholds are for field data at the 75th percentile,
+   * while these charts plot lab-run medians — the bar is orientation, not a
+   * pass/fail verdict.
+   */
+  goodThreshold?: number
   /** One line per branch (usually just one — comparison overlays several). */
   lines: TrendLine[]
 }
@@ -223,8 +246,10 @@ export const TREND_GROUPS: {id: TrendGroup; title: string; description: string}[
   {
     id: 'vitals',
     title: 'Web Vitals',
+    // The individual vitals are named (and spelled out) by the per-vital
+    // section headers right below, so the description doesn't list them
     description:
-      'Google Core Web Vitals and supporting load metrics — LCP, INP, CLS, FCP, TTFB. The user-facing quality bar; lower is better on all of them.',
+      'Google Core Web Vitals and supporting load metrics. Lower is better on all of them.',
   },
   {
     id: 'responsiveness',
@@ -245,13 +270,13 @@ export const TREND_GROUPS: {id: TrendGroup; title: string; description: string}[
     id: 'soak',
     title: 'Soak (endurance)',
     description:
-      'One long session typing continuously into a self-erasing document. Every line should stay flat — an upward slope is a leak or degradation over time.',
+      'One long session typing continuously into a self-erasing document. Every line should stay flat. An upward slope is a leak or degradation over time.',
   },
   {
     id: 'environment',
     title: 'Calibration',
     description:
-      'CI host speed per run — honesty context for every other tab, since absolute numbers are host-relative.',
+      'CI host speed per run. Every number in the other tabs depends on how fast the host was, so check here before trusting a spike.',
   },
 ]
 
@@ -263,7 +288,7 @@ export const TREND_GROUPS: {id: TrendGroup; title: string; description: string}[
 function describeSeries(
   kind: 'interaction' | 'pageload',
   label: string,
-): Pick<TrendSeries, 'description' | 'goal' | 'group'> {
+): Pick<TrendSeries, 'description' | 'goal' | 'group' | 'goodThreshold'> {
   if (label.includes('time to editable')) {
     return {
       group: 'load',
@@ -275,53 +300,52 @@ function describeSeries(
     return {
       group: 'load',
       description:
-        'How long the main thread was frozen during load (long animation frames) — the UI is unresponsive for this time.',
+        'How long the main thread was frozen during load (long animation frames). The UI is unresponsive for this time.',
       goal: 'lower',
     }
   }
+  // goodThreshold values are the web.dev "good" recommendations
+  // (https://web.dev/articles/defining-core-web-vitals-thresholds)
   if (label.endsWith('TTFB')) {
     return {
       group: 'vitals',
       description: 'Time to first byte of the document response.',
       goal: 'lower',
+      goodThreshold: 800,
     }
   }
   if (label.endsWith('FCP')) {
     return {
       group: 'vitals',
-      description: 'First Contentful Paint — first pixels drawn.',
+      description: 'First Contentful Paint: first pixels drawn.',
       goal: 'lower',
+      goodThreshold: 1800,
     }
   }
   if (label.endsWith('LCP')) {
     return {
       group: 'vitals',
-      description: 'Largest Contentful Paint — the main content is visible (Core Web Vital).',
+      description: 'Largest Contentful Paint: the main content is visible (Core Web Vital).',
       goal: 'lower',
+      goodThreshold: 2500,
     }
   }
   if (label.endsWith('CLS')) {
     return {
       group: 'vitals',
       description:
-        'Cumulative Layout Shift — how much the layout jumps during load (Core Web Vital; lower is steadier).',
+        'Cumulative Layout Shift: how much the layout jumps during load (Core Web Vital; lower is steadier).',
       goal: 'lower',
-    }
-  }
-  if (label === 'INP interactions') {
-    return {
-      group: 'vitals',
-      description:
-        'How many distinct interactions the INP session observed — confidence context for the INP number (the percentile rule wants at least 50). Not a judged metric.',
-      goal: 'context',
+      goodThreshold: 0.1,
     }
   }
   if (label.endsWith('INP')) {
     return {
       group: 'vitals',
       description:
-        'Interaction to Next Paint — a high percentile of interaction latencies (click/type → next paint) under a realistic interaction mix (Core Web Vital).',
+        'Interaction to Next Paint: a high percentile of interaction latencies (click/type → next paint) under a realistic interaction mix (Core Web Vital).',
       goal: 'lower',
+      goodThreshold: 200,
     }
   }
   if (label.includes('auth round trips')) {
@@ -335,7 +359,7 @@ function describeSeries(
     return {
       group: 'load',
       description:
-        'How long after navigation the first auth request was issued — client-side work we control.',
+        'How long after navigation the first auth request was issued. This is client-side work we control.',
       goal: 'lower',
     }
   }
@@ -343,7 +367,7 @@ function describeSeries(
     return {
       group: 'load',
       description:
-        'Time auth requests spent waiting on the API before the form was editable — scales with real-world API latency.',
+        'Time auth requests spent waiting on the API before the form was editable. Scales with real-world API latency.',
       goal: 'lower',
     }
   }
@@ -381,6 +405,40 @@ export function formatValue(value: number, unit: TrendUnit): string {
   return `${value.toFixed(0)}ms`
 }
 
+/**
+ * Axis-tick variant of `formatValue`, sized for the 44px gutter — a label that
+ * doesn't fit clips at the SVG edge from the left ("40.0 MB" → "0.0 MB"), which
+ * reads as wrong data rather than as a clipped label. Position carries the
+ * precision on an axis, so ticks trade decimals and padding for width; the
+ * header and tooltip keep the full `formatValue` rendering.
+ *
+ * - Slope ticks are the number alone: the full form ("+1.08 MB/min") kept only
+ *   its unit visible. The unit stays in the title ("… per minute") and header,
+ *   and the "+" goes too — on an axis spanning zero the sign is the position.
+ * - MB/KB ticks drop the space and any spurious decimals: "40.0 MB" (clips its
+ *   first digit; "M" glyphs are wide) becomes "40MB". KB ticks round to whole
+ *   units — nice() picks round *byte* values, so the KB form is fractional
+ *   ("146.5 KB") and would both clip and imply precision a tick doesn't need.
+ * - ms ticks speak ONE unit per axis, decided by the scale top (`domainMax`),
+ *   not per tick: formatValue's per-value cutoff put "10.0s" above "5000ms" on
+ *   the same axis, which reads as two different scales.
+ * - ms ticks switch to seconds already at 1s, not at formatValue's 10s:
+ *   a four-digit ms tick ("8000ms") overflows the gutter by a couple of
+ *   pixels, which shaves the leading glyph's left stroke — "8000" reads as
+ *   "3000", "6000" as "5000". A wrong-but-plausible number is worse than an
+ *   obviously clipped one. Sub-second axes (keystroke latency) stay in ms,
+ *   where three digits fit and the precision matters.
+ */
+export function formatTick(value: number, unit: TrendUnit, domainMax = 0): string {
+  if (isSignedUnit(unit)) return parseFloat(value.toFixed(2)).toString()
+  if (unit === 'megabytes') return `${parseFloat(value.toFixed(1))}MB`
+  if (unit === 'bytes') return `${Math.round(value / 1024)}KB`
+  if (unit === 'ms' && Math.max(Math.abs(value), domainMax) >= 1_000) {
+    return `${parseFloat((value / 1000).toFixed(1))}s`
+  }
+  return formatValue(value, unit)
+}
+
 /** Slope/rate units are signed and centered on zero (flat = good). */
 export function isSignedUnit(unit: TrendUnit): boolean {
   return unit === 'mb-per-min' || unit === 'count-per-min' || unit === 'ms-per-min'
@@ -416,6 +474,14 @@ function pointMeta(
     ciRunAttempt: run.runner?.runAttempt,
   }
 }
+
+/**
+ * Mirrors perf/bench/stats/inp.ts INP_MIN_INTERACTIONS — the percentile rule
+ * wants at least this many interactions before an INP value is trustworthy.
+ * Mirrored rather than imported, like the gate thresholds in drift.ts: the
+ * dashboard has no build-time dependency on the bench suite.
+ */
+export const INP_MIN_INTERACTIONS = 50
 
 function medianOf(values: number[]): number {
   const sorted = [...values].sort((a, b) => a - b)
@@ -465,11 +531,15 @@ function mergeRunsPerCommit(points: TrendPoint[]): TrendPoint[] {
     }
     const p75s = group.map((point) => point.p75).filter((v): v is number => v !== undefined)
     const p90s = group.map((point) => point.p90).filter((v): v is number => v !== undefined)
+    const interactionCounts = group
+      .map((point) => point.interactions)
+      .filter((v): v is number => v !== undefined)
     merged.push({
       ...last,
       value: medianOf(group.map((point) => point.value)),
       p75: p75s.length > 0 ? medianOf(p75s) : undefined,
       p90: p90s.length > 0 ? medianOf(p90s) : undefined,
+      interactions: interactionCounts.length > 0 ? medianOf(interactionCounts) : undefined,
     })
   }
   return merged.sort((a, b) => a.date.getTime() - b.date.getTime())
@@ -481,9 +551,12 @@ export function buildSeries(runs: TrendRun[]): TrendSeries[] {
     key: string,
     title: string,
     unit: TrendUnit,
-    meta: Pick<TrendSeries, 'description' | 'goal' | 'group' | 'sourceFile'>,
+    meta: Pick<
+      TrendSeries,
+      'description' | 'goal' | 'group' | 'sourceFile' | 'lineLabel' | 'goodThreshold'
+    >,
     run: TrendRun,
-    point: Pick<TrendPoint, 'value' | 'p75' | 'p90'>,
+    point: Pick<TrendPoint, 'value' | 'p75' | 'p90' | 'interactions'>,
   ) => {
     const existing = series.get(key) ?? {key, title, unit, ...meta, lines: []}
     const branch = run.git?.branch ?? 'unknown'
@@ -498,7 +571,16 @@ export function buildSeries(runs: TrendRun[]): TrendSeries[] {
 
   for (const run of runs) {
     for (const scenario of run.scenarios ?? []) {
+      // The interaction count is confidence context for INP, not a health
+      // metric of its own — a chart of it answers no question ("are counts
+      // trending?" is nothing anyone asks) and its default goal framing is
+      // backwards (more interactions = MORE confidence). Attach it to the
+      // INP point instead, where the tooltip/popover can qualify the value.
+      const inpInteractions = scenario.metrics?.find(
+        (metric) => metric.label === 'INP interactions',
+      )?.experiment?.summary?.median
       for (const metric of scenario.metrics ?? []) {
+        if (metric.label === 'INP interactions') continue
         const summary = metric.experiment?.summary
         if (!summary) continue
         push(
@@ -507,7 +589,14 @@ export function buildSeries(runs: TrendRun[]): TrendSeries[] {
           metric.unit,
           {...describeSeries(scenario.kind, metric.label), sourceFile: scenario.sourceFile},
           run,
-          {value: summary.median, p75: summary.p75, p90: summary.p90},
+          {
+            value: summary.median,
+            p75: summary.p75,
+            p90: summary.p90,
+            ...(metric.label === 'INP' && inpInteractions !== undefined
+              ? {interactions: inpInteractions}
+              : {}),
+          },
         )
       }
     }
@@ -521,6 +610,9 @@ export function buildSeries(runs: TrendRun[]): TrendSeries[] {
           group: 'bundle',
           description: 'Initial JavaScript downloaded to boot the studio, gzip-compressed.',
           goal: 'lower',
+          // A build measures one size — there is no distribution to take a
+          // median of, so the default 'median (p50)' legend would be false
+          lineLabel: 'size per run',
         },
         run,
         {value: initialJs},
@@ -533,6 +625,46 @@ export function buildSeries(runs: TrendRun[]): TrendSeries[] {
     ...entry,
     lines: entry.lines.map((line) => ({...line, points: mergeRunsPerCommit(line.points)})),
   }))
+}
+
+/**
+ * Vitals-tab layout: one section per vital, not a flat scenario-ordered grid.
+ * The tab's question is per-vital ("how is LCP doing, everywhere?"), so all of
+ * one vital's charts sit under a shared header — same unit, similar scale —
+ * and a single scenario going bad stands out from its neighbours. Core Web
+ * Vitals first — INP leading, since responsiveness is this studio's whole
+ * reason to exist — then the supporting diagnostics; within a section, titles
+ * (= scenarios) keep a stable alphabetical order.
+ */
+const VITALS = [
+  {vital: 'INP', name: 'Interaction to Next Paint'},
+  {vital: 'LCP', name: 'Largest Contentful Paint'},
+  {vital: 'CLS', name: 'Cumulative Layout Shift'},
+  {vital: 'FCP', name: 'First Contentful Paint'},
+  {vital: 'TTFB', name: 'Time to First Byte'},
+] as const
+
+export interface VitalSection {
+  vital: string
+  /** Spelled-out name for the section header; absent for the catch-all. */
+  name?: string
+  series: TrendSeries[]
+}
+
+const byTitle = (a: TrendSeries, b: TrendSeries) => a.title.localeCompare(b.title)
+
+export function vitalSections(list: TrendSeries[]): VitalSection[] {
+  const matched = new Set<TrendSeries>()
+  const sections: VitalSection[] = VITALS.map(({vital, name}) => {
+    const series = list.filter((entry) => entry.title.endsWith(vital)).sort(byTitle)
+    for (const entry of series) matched.add(entry)
+    return {vital, name, series}
+  })
+  // Anything in the vitals group that isn't a known vital still renders —
+  // a new metric must never silently vanish from the dashboard
+  const leftover = list.filter((entry) => !matched.has(entry)).sort(byTitle)
+  if (leftover.length > 0) sections.push({vital: 'Other', series: leftover})
+  return sections.filter((section) => section.series.length > 0)
 }
 
 /** The honesty overlay: host-speed score per run (higher = slower host). */
@@ -576,7 +708,7 @@ export function calibrationSeries(runs: TrendRun[]): TrendSeries {
     title: 'host calibration (higher = slower host)',
     unit: 'ms',
     description:
-      'A fixed CPU workload run on the CI machine before each benchmark. All numbers above are relative to host speed — when this line spikes where a metric spikes, suspect the runner, not the studio.',
+      'A fixed CPU workload run on the CI machine before each benchmark. All numbers above are relative to host speed. When this line spikes where a metric spikes, suspect the runner, not the studio.',
     goal: 'context',
     group: 'environment',
     lines: [...byBranch.values()],
@@ -629,6 +761,7 @@ export function latestSoakCharts(runs: TrendRun[]): {run: TrendRun; charts: Tren
       group: 'soak',
       sourceFile: latest.sourceFile,
       xKind: 'minute',
+      lineLabel: 'per-minute sample',
       lines: [{branch: latest.run.git?.branch ?? 'unknown', points}],
     }
   }).filter((chart) => chart.lines[0].points.length > 0)
@@ -673,7 +806,7 @@ function soakHistory(
   reduce: (samples: SoakSample[], key: keyof SoakSample) => number | null,
   meta: (
     metric: (typeof SOAK_METRICS)[number],
-  ) => Pick<TrendSeries, 'title' | 'unit' | 'description'>,
+  ) => Pick<TrendSeries, 'title' | 'unit' | 'description' | 'lineLabel'>,
 ): TrendSeries[] {
   const withSoak = runsWithSoak(runs)
   const byMetric = SOAK_METRICS.map((metric): TrendSeries => {
@@ -715,6 +848,7 @@ export function soakSlopeSeries(runs: TrendRun[]): TrendSeries[] {
       title: `soak · ${metric.title} per minute`,
       unit: slopeUnitFor(metric.unit),
       description: `${metric.title} change per soak minute (linear fit), per run. Flat (~0) is healthy; a rising slope across runs is a worsening leak or degradation.`,
+      lineLabel: 'slope per run',
     }),
   )
 }
@@ -734,6 +868,7 @@ export function soakLatestValueSeries(runs: TrendRun[]): TrendSeries[] {
       title: `soak · ${metric.title} at end`,
       unit: metric.unit,
       description: `${metric.title} at the end of the soak run, tracked across runs. ${metric.description}`,
+      lineLabel: 'end-of-run value',
     }),
   )
 }

--- a/dev/metrics-studio/tools/trends/debugData.ts
+++ b/dev/metrics-studio/tools/trends/debugData.ts
@@ -112,7 +112,6 @@ function generateDemo(branch = 'main', shift = 0): TrendRun[] {
           // open-doc-warm (cached) — so demo both. Warm is faster (cache hits).
           metrics: [
             metric(rng, 'boot-cold · time to editable', day < 70 ? 4200 : 4600),
-            metric(rng, 'boot-cold · TTFB', 90 + (rng() - 0.5) * 20),
             metric(rng, 'boot-cold · FCP', 1200 + (rng() - 0.5) * 200),
             metric(rng, 'boot-cold · LCP', 1800 + (rng() - 0.5) * 300),
             metric(rng, 'boot-cold · CLS', 0.04 + rng() * 0.03, 'cls'),
@@ -121,7 +120,6 @@ function generateDemo(branch = 'main', shift = 0): TrendRun[] {
             metric(rng, 'boot-cold · auth round trips', day < 50 ? 2 : 1, 'count'),
             metric(rng, 'boot-cold · auth in flight', day < 50 ? 84 : 42),
             metric(rng, 'open-doc-warm · time to editable', day < 70 ? 1900 : 2100),
-            metric(rng, 'open-doc-warm · TTFB', 40 + (rng() - 0.5) * 12),
             metric(rng, 'open-doc-warm · FCP', 520 + (rng() - 0.5) * 90),
             metric(rng, 'open-doc-warm · LCP', 780 + (rng() - 0.5) * 140),
             metric(rng, 'open-doc-warm · CLS', 0.01 + rng() * 0.015, 'cls'),

--- a/dev/metrics-studio/tools/trends/drift.test.ts
+++ b/dev/metrics-studio/tools/trends/drift.test.ts
@@ -269,7 +269,7 @@ test('labels count the actual window on short history', () => {
 
   expect(fired.baselinePointsMs).toHaveLength(5)
   expect(baselineLabel(fired)).toBe('vs prior 5 runs')
-  expect(baselineDetail(fired)).toBe('median of the last 7 runs vs the prior 5')
+  expect(baselineDetail(fired)).toBe('median of the last 7 runs vs the prior 5 runs')
 })
 
 // Neutral entries share the list with flagged ones now, so precedence has to be

--- a/dev/metrics-studio/tools/trends/drift.test.ts
+++ b/dev/metrics-studio/tools/trends/drift.test.ts
@@ -1,7 +1,22 @@
 import {expect, test} from 'vitest'
 
 import {type TrendPoint, type TrendSeries} from './data'
-import {computeDrift, type DriftResult, worstBySeries, worstOf} from './drift'
+import {
+  baselineDetail,
+  baselineLabel,
+  computeDrift,
+  type DriftBaseline,
+  type DriftResult,
+  worstBySeries,
+} from './drift'
+
+/**
+ * Flagged results only. `computeDrift` also returns neutral comparisons (so the
+ * charts can draw an overlay everywhere), which are not findings.
+ */
+function flagged(results: ReturnType<typeof computeDrift>) {
+  return results.filter((entry) => entry.direction !== 'neutral')
+}
 
 const DAY = 24 * 60 * 60 * 1000
 const START = Date.UTC(2026, 0, 1)
@@ -27,29 +42,32 @@ function series(values: number[], overrides: Partial<TrendSeries> = {}): TrendSe
 
 test('flat series does not fire', () => {
   const drift = computeDrift([series(Array.from({length: 30}, () => 32))])
-  expect(drift).toHaveLength(0)
+  expect(flagged(drift)).toHaveLength(0)
+  // But a baseline is still computed, so the chart can draw the reference
+  expect(drift).toHaveLength(1)
+  expect(drift[0].direction).toBe('neutral')
 })
 
-// Trailing regression: prior ~32, last 7 jump to ~40 (25% > 5% and > 3ms)
-test('trailing regression fires', () => {
+// Prior ~32, last 7 jump to ~40 (25% > 5% and > 3ms)
+test('regression fires', () => {
   const values = [...Array.from({length: 21}, () => 32), ...Array.from({length: 9}, () => 40)]
   const drift = computeDrift([series(values)])
-  expect(drift).toHaveLength(1)
+  expect(flagged(drift)).toHaveLength(1)
   expect(drift[0].direction).toBe('regression')
-  expect(drift[0].fired.some((f) => f.kind === 'trailing')).toBe(true)
 })
 
-test('trailing improvement fires as improvement', () => {
+test('improvement fires as improvement', () => {
   const values = [...Array.from({length: 21}, () => 40), ...Array.from({length: 9}, () => 30)]
   const drift = computeDrift([series(values)])
   expect(drift[0].direction).toBe('improvement')
 })
 
-// Below the relative floor: 32 → 33 is ~3% < 5%, should not fire
+// Below the relative floor: 32 → 33 is ~3% < 5%
 test('sub-threshold move stays quiet', () => {
   const values = [...Array.from({length: 21}, () => 32), ...Array.from({length: 9}, () => 33)]
   const drift = computeDrift([series(values)])
-  expect(drift).toHaveLength(0)
+  expect(flagged(drift)).toHaveLength(0)
+  expect(drift[0].direction).toBe('neutral')
 })
 
 // Absolute floor: a count metric moving 100→101 is 1% — below 5%, quiet;
@@ -58,11 +76,11 @@ test('count metric respects both floors', () => {
   const quiet = computeDrift([
     series([...Array(21).fill(100), ...Array(9).fill(101)], {unit: 'count'}),
   ])
-  expect(quiet).toHaveLength(0)
+  expect(flagged(quiet)).toHaveLength(0)
   const loud = computeDrift([
     series([...Array(21).fill(100), ...Array(9).fill(106)], {unit: 'count'}),
   ])
-  expect(loud).toHaveLength(1)
+  expect(flagged(loud)).toHaveLength(1)
 })
 
 // CLS is unitless and small — a whole-unit absolute floor (the default) would
@@ -72,26 +90,38 @@ test('cls metric fires on small absolute moves', () => {
   const loud = computeDrift([
     series([...Array(21).fill(0.04), ...Array(9).fill(0.08)], {unit: 'cls'}),
   ])
-  expect(loud).toHaveLength(1)
+  expect(flagged(loud)).toHaveLength(1)
   expect(loud[0].direction).toBe('regression')
   const quiet = computeDrift([
     series([...Array(21).fill(0.04), ...Array(9).fill(0.05)], {unit: 'cls'}),
   ])
-  expect(quiet).toHaveLength(0)
+  expect(flagged(quiet)).toHaveLength(0)
 })
 
 // Context series (calibration) never flags
+// Context series (calibration) are skipped outright — no baseline, no overlay
 test('context series is ignored', () => {
   const values = [...Array(21).fill(10), ...Array(9).fill(20)]
-  const drift = computeDrift([series(values, {goal: 'context'})])
-  expect(drift).toHaveLength(0)
+  expect(computeDrift([series(values, {goal: 'context'})])).toHaveLength(0)
 })
 
-// Too little history: no trailing baseline
-test('short history does not fire trailing', () => {
-  const drift = computeDrift([series([32, 33, 40])])
-  // trailing needs ≥10 points; step needs same-weekday history — neither here
-  expect(drift).toHaveLength(0)
+// Both windows must exist: a median of 7 vs a median of 21 needs history. This
+// is deliberate — the removed "step" baseline fired on thin history and on ~80%
+// of runs generally; one trustworthy signal beats two.
+// Too little history means no comparison exists at all — distinct from a
+// computed-but-quiet one, and the charts get no overlay either
+test('short history yields no baseline at all', () => {
+  expect(computeDrift([series([32, 33, 40])])).toHaveLength(0)
+  expect(computeDrift([series([32, 40])])).toHaveLength(0)
+})
+
+// The whole point of neutral entries: a quiet chart still gets its reference
+// lines, so the overlay does not blink in and out as metrics cross the threshold.
+test('a quiet series still carries drawable windows', () => {
+  const drift = computeDrift([series(Array.from({length: 30}, () => 32))])
+  expect(drift[0].direction).toBe('neutral')
+  expect(drift[0].baseline.recentPointsMs).toHaveLength(7)
+  expect(drift[0].baseline.baselinePointsMs).toHaveLength(21)
 })
 
 test('regressions sort first', () => {
@@ -101,51 +131,51 @@ test('regressions sort first', () => {
   expect(drift[0].direction).toBe('regression')
 })
 
+// The list mixes three directions, so ordering has to hold for every pair —
+// a two-way "is it a regression" comparator answered improvement-vs-neutral
+// inconsistently, which makes Array.sort's output unspecified
+test('sorts regression, improvement, neutral in every input order', () => {
+  const reg = series([...Array(21).fill(32), ...Array(9).fill(42)], {key: 'reg', title: 'reg'})
+  const imp = series([...Array(21).fill(42), ...Array(9).fill(30)], {key: 'imp', title: 'imp'})
+  const quiet = series(
+    Array.from({length: 30}, () => 32),
+    {key: 'quiet', title: 'quiet'},
+  )
+  for (const input of [
+    [reg, imp, quiet],
+    [quiet, imp, reg],
+    [imp, quiet, reg],
+  ]) {
+    const drift = computeDrift(input)
+    expect(drift.map((entry) => entry.direction)).toEqual(['regression', 'improvement', 'neutral'])
+  }
+})
+
+function baseline(overrides: Partial<DriftBaseline> = {}): DriftBaseline {
+  return {
+    recent: 40,
+    baseline: 32,
+    delta: 8,
+    deltaFraction: 0.25,
+    direction: 'regression',
+    recentPointsMs: [START],
+    baselinePointsMs: [START - DAY],
+    ...overrides,
+  }
+}
+
 function driftResult(overrides: Partial<DriftResult>): DriftResult {
   return {
     seriesKey: 'test',
     title: 'test metric',
     unit: 'ms',
     branch: 'main',
-    fired: [
-      {
-        kind: 'trailing',
-        recent: 40,
-        baseline: 32,
-        delta: 8,
-        deltaFraction: 0.25,
-        direction: 'regression',
-      },
-    ],
+    baseline: baseline(),
     direction: 'regression',
     latest: {runId: 'run-1', sha: 'sha1'},
     ...overrides,
   }
 }
-
-test('worstOf picks the largest-magnitude fired baseline', () => {
-  const entry = driftResult({
-    fired: [
-      {
-        kind: 'trailing',
-        recent: 40,
-        baseline: 32,
-        delta: 8,
-        deltaFraction: 0.25,
-        direction: 'regression',
-      },
-      {
-        kind: 'step',
-        recent: 40,
-        baseline: 25,
-        delta: 15,
-        deltaFraction: 0.6,
-        direction: 'regression',
-      },
-    ],
-  })
-  expect(worstOf(entry).kind).toBe('step')
-})
 
 // The chart card badge must warn, not celebrate: a bigger improvement on one
 // branch must not displace a live regression on another.
@@ -154,16 +184,13 @@ test('worstBySeries never lets an improvement mask a regression', () => {
   const bigImprovement = driftResult({
     branch: 'feature',
     direction: 'improvement',
-    fired: [
-      {
-        kind: 'trailing',
-        recent: 20,
-        baseline: 40,
-        delta: -20,
-        deltaFraction: -0.5,
-        direction: 'improvement',
-      },
-    ],
+    baseline: baseline({
+      recent: 20,
+      baseline: 40,
+      delta: -20,
+      deltaFraction: -0.5,
+      direction: 'improvement',
+    }),
   })
   // Same result regardless of encounter order
   expect(worstBySeries([regression, bigImprovement]).get('test')?.direction).toBe('regression')
@@ -174,16 +201,106 @@ test('worstBySeries keeps the larger move within the same direction', () => {
   const small = driftResult({branch: 'main'})
   const large = driftResult({
     branch: 'feature',
-    fired: [
-      {
-        kind: 'trailing',
-        recent: 48,
-        baseline: 32,
-        delta: 16,
-        deltaFraction: 0.5,
-        direction: 'regression',
-      },
-    ],
+    baseline: baseline({recent: 48, delta: 16, deltaFraction: 0.5}),
   })
   expect(worstBySeries([small, large]).get('test')?.branch).toBe('feature')
+})
+
+// The chart overlay draws these windows, so they must be exactly the windows
+// the medians came from — otherwise the picture and the percentage disagree.
+test('baseline carries its two window timestamps', () => {
+  const values = [...Array.from({length: 21}, () => 32), ...Array.from({length: 9}, () => 40)]
+  const [entry] = computeDrift([series(values)])
+  const {baseline: fired} = entry
+
+  expect(fired.recentPointsMs).toHaveLength(7)
+  expect(fired.baselinePointsMs).toHaveLength(21)
+  // Windows are contiguous, adjacent, and end at the newest run
+  expect(fired.recentPointsMs.at(-1)).toBe(START + 29 * DAY)
+  expect(fired.recentPointsMs[0]).toBe(START + 23 * DAY)
+  expect(fired.baselinePointsMs.at(-1)).toBe(START + 22 * DAY)
+  expect(fired.baselinePointsMs[0]).toBe(START + 2 * DAY)
+  // Sorted oldest→newest, and the two windows do not overlap
+  expect([...fired.recentPointsMs].sort((a, b) => a - b)).toEqual(fired.recentPointsMs)
+  expect(fired.baselinePointsMs.at(-1)!).toBeLessThan(fired.recentPointsMs[0])
+})
+
+/** Independent median, so the test doesn't reuse drift.ts's implementation. */
+function medianOf(list: number[]): number {
+  const sorted = [...list].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+}
+
+// A window that doesn't contain the runs producing its median would draw the
+// rule in the wrong place; recomputing the median from the window guards that.
+test('window timestamps reproduce the reported medians', () => {
+  const values = [...Array.from({length: 21}, () => 32), ...Array.from({length: 9}, () => 40)]
+  const trend = series(values)
+  const points = trend.lines[0].points
+  const valueAt = (ms: number) => points.find((point) => point.date.getTime() === ms)!.value
+
+  const {baseline: fired} = computeDrift([trend])[0]
+  expect(medianOf(fired.recentPointsMs.map(valueAt))).toBe(fired.recent)
+  expect(medianOf(fired.baselinePointsMs.map(valueAt))).toBe(fired.baseline)
+})
+
+// The labels describe the windows the math uses, so a change to one must not
+// silently leave the other behind. Both are stated in runs (never days) because
+// the cron misses days and sometimes runs twice.
+test('baseline labels match the windows the math uses', () => {
+  const values = [...Array.from({length: 21}, () => 32), ...Array.from({length: 9}, () => 40)]
+  const {baseline: fired} = computeDrift([series(values)])[0]
+
+  expect(baselineLabel(fired)).toContain(`${fired.baselinePointsMs.length} runs`)
+  expect(baselineDetail(fired)).toContain(`${fired.recentPointsMs.length} runs`)
+  for (const text of [baselineLabel(fired), baselineDetail(fired)]) {
+    // Days/weeks would go stale the moment the cron skips a run
+    expect(text).not.toMatch(/week|day/)
+  }
+})
+
+// With just enough history the prior window holds fewer runs than its target
+// size, and the label must count the runs it actually has — "vs prior 21 runs"
+// over 5 runs of evidence would overstate it fourfold
+test('labels count the actual window on short history', () => {
+  const values = [...Array.from({length: 5}, () => 32), ...Array.from({length: 7}, () => 40)]
+  const {baseline: fired} = computeDrift([series(values)])[0]
+
+  expect(fired.baselinePointsMs).toHaveLength(5)
+  expect(baselineLabel(fired)).toBe('vs prior 5 runs')
+  expect(baselineDetail(fired)).toBe('median of the last 7 runs vs the prior 5')
+})
+
+// Neutral entries share the list with flagged ones now, so precedence has to be
+// explicit: a quiet branch must not win the card over a branch that moved.
+test('worstBySeries prefers a flagged result over a neutral one', () => {
+  const neutral = driftResult({
+    branch: 'main',
+    direction: 'neutral',
+    baseline: baseline({direction: 'neutral', deltaFraction: 0.01}),
+  })
+  const improvement = driftResult({
+    branch: 'feature',
+    direction: 'improvement',
+    baseline: baseline({direction: 'improvement', deltaFraction: -0.2}),
+  })
+  // Either encounter order picks the improvement
+  expect(worstBySeries([neutral, improvement]).get('test')?.direction).toBe('improvement')
+  expect(worstBySeries([improvement, neutral]).get('test')?.direction).toBe('improvement')
+})
+
+// ...and a bigger neutral must not beat a smaller regression
+test('worstBySeries prefers a regression over a larger neutral', () => {
+  const bigNeutral = driftResult({
+    branch: 'main',
+    direction: 'neutral',
+    baseline: baseline({direction: 'neutral', deltaFraction: 0.04}),
+  })
+  const smallRegression = driftResult({
+    branch: 'feature',
+    baseline: baseline({deltaFraction: 0.06}),
+  })
+  expect(worstBySeries([bigNeutral, smallRegression]).get('test')?.direction).toBe('regression')
+  expect(worstBySeries([smallRegression, bigNeutral]).get('test')?.direction).toBe('regression')
 })

--- a/dev/metrics-studio/tools/trends/drift.ts
+++ b/dev/metrics-studio/tools/trends/drift.ts
@@ -11,12 +11,12 @@
  * point (see `mergeRunsPerCommit`), so a window of 21 is 21 commits — and the
  * spans the chart overlay draws line up with the plotted points exactly.
  *
- * There used to be a second, faster "step" baseline (latest run vs a median of
- * recent runs) meant to catch a jump the day it landed. It was removed: measured
- * against the stored history it fired on 74–92% of runs at every window size
- * tried, because run-to-run noise on these metrics (~12% median) is well over
- * the 5% threshold. A detector that fires four runs out of five is not a signal,
- * and no windowing fixed it. Detecting a single-run jump needs a more precise
+ * A second, faster "step" baseline (latest run vs a median of recent runs, to
+ * catch a jump the day it lands) was considered and rejected: measured against
+ * the stored history it would fire on 74–92% of runs at every window size,
+ * because run-to-run noise on these metrics (~12% median) is well over the 5%
+ * threshold. A detector that fires four runs out of five is not a signal, and
+ * no windowing fixes it. Detecting a single-run jump needs a more precise
  * measurement (more sessions per run), not different arithmetic.
  *
  * "Enough to care" reuses the bench gate's thresholds (perf/bench/stats/

--- a/dev/metrics-studio/tools/trends/drift.ts
+++ b/dev/metrics-studio/tools/trends/drift.ts
@@ -88,7 +88,7 @@ export function baselineLabel(baseline: DriftBaseline): string {
 }
 
 export function baselineDetail(baseline: DriftBaseline): string {
-  return `median of the last ${baseline.recentPointsMs.length} runs vs the prior ${baseline.baselinePointsMs.length}`
+  return `median of the last ${baseline.recentPointsMs.length} runs vs the prior ${baseline.baselinePointsMs.length} runs`
 }
 
 export interface DriftResult {
@@ -96,7 +96,11 @@ export interface DriftResult {
   title: string
   unit: TrendUnit
   branch: string
-  /** The move that cleared the thresholds. */
+  /**
+   * The window comparison for this line. Not necessarily a flagged move:
+   * neutral entries exist so charts can draw the overlay everywhere — check
+   * `direction` before treating it as a finding.
+   */
   baseline: DriftBaseline
   direction: DriftDirection
   /** The most recent run in this line — for backlinks to the likely culprit. */

--- a/dev/metrics-studio/tools/trends/drift.ts
+++ b/dev/metrics-studio/tools/trends/drift.ts
@@ -1,11 +1,23 @@
 /**
- * Drift detection: "did any metric move enough to care?" Two baselines, both
- * reported when they disagree (SPEC.md):
+ * Drift detection: "did any metric move enough to care?"
  *
- * - **trailing** — median of the last 7 runs vs the median of the prior 21.
- *   Catches slow drift that no single-run comparison would show.
- * - **step** — the latest run vs the median of the same weekday's last 4 runs.
- *   Catches sudden jumps, robust to day-of-week runner variance.
+ * One baseline: the median of the last 7 runs against the median of the 21
+ * before them. Smoothing both sides is what makes it trustworthy — a single
+ * noisy run barely moves a median of 7, so a flag means a sustained shift.
+ *
+ * Windows are counted in **runs, not days**: the cron aims for one run a day but
+ * the history has gaps and same-day doubles, so a day-based label would be a
+ * guess. `buildSeries` has already merged re-runs of the same commit into one
+ * point (see `mergeRunsPerCommit`), so a window of 21 is 21 commits — and the
+ * spans the chart overlay draws line up with the plotted points exactly.
+ *
+ * There used to be a second, faster "step" baseline (latest run vs a median of
+ * recent runs) meant to catch a jump the day it landed. It was removed: measured
+ * against the stored history it fired on 74–92% of runs at every window size
+ * tried, because run-to-run noise on these metrics (~12% median) is well over
+ * the 5% threshold. A detector that fires four runs out of five is not a signal,
+ * and no windowing fixed it. Detecting a single-run jump needs a more precise
+ * measurement (more sessions per run), not different arithmetic.
  *
  * "Enough to care" reuses the bench gate's thresholds (perf/bench/stats/
  * gate.ts) so the dashboard and the PR gate share one definition of a
@@ -34,6 +46,10 @@ function thresholdFor(unit: TrendUnit): DriftThreshold {
   return {absolute: 1, relative: 0.05}
 }
 
+/** Window sizes, in runs — one point per commit, merged in `buildSeries`. */
+const RECENT_RUNS = 7
+const BASELINE_RUNS = 21
+
 function median(values: number[]): number | null {
   if (values.length === 0) return null
   const sorted = [...values].sort((a, b) => a - b)
@@ -44,13 +60,35 @@ function median(values: number[]): number | null {
 export type DriftDirection = 'regression' | 'improvement' | 'neutral'
 
 export interface DriftBaseline {
-  /** 'trailing' (slow drift) or 'step' (sudden jump). */
-  kind: 'trailing' | 'step'
   recent: number
   baseline: number
   delta: number
   deltaFraction: number
   direction: DriftDirection
+  /**
+   * Run timestamps of the window whose median is `recent`, and of the window
+   * whose median is `baseline` — what the chart overlay draws so the badge's
+   * percentage can be checked against the runs that produced it. Timestamps
+   * (not points) keep this small and serializable; the chart only needs the
+   * x-positions. Sorted oldest→newest.
+   */
+  recentPointsMs: number[]
+  baselinePointsMs: number[]
+}
+
+/**
+ * How a baseline is described in the UI. Lives here rather than in a component
+ * so the drift feed, the chart legend and the aria-labels can't describe it
+ * differently — and counts the *actual* windows rather than quoting the target
+ * sizes: with just enough history (10 runs) the prior window holds only 3 runs,
+ * and "vs prior 21 runs" would overstate the evidence sevenfold.
+ */
+export function baselineLabel(baseline: DriftBaseline): string {
+  return `vs prior ${baseline.baselinePointsMs.length} runs`
+}
+
+export function baselineDetail(baseline: DriftBaseline): string {
+  return `median of the last ${baseline.recentPointsMs.length} runs vs the prior ${baseline.baselinePointsMs.length}`
 }
 
 export interface DriftResult {
@@ -58,9 +96,8 @@ export interface DriftResult {
   title: string
   unit: TrendUnit
   branch: string
-  /** Only the baselines that fired (cleared the thresholds). */
-  fired: DriftBaseline[]
-  /** Worst direction across fired baselines, for sorting/coloring. */
+  /** The move that cleared the thresholds. */
+  baseline: DriftBaseline
   direction: DriftDirection
   /** The most recent run in this line — for backlinks to the likely culprit. */
   latest: Pick<TrendPoint, 'runId' | 'sha' | 'prNumber' | 'ciRunId' | 'ciRunAttempt'>
@@ -83,84 +120,88 @@ function classify(
 }
 
 function makeBaseline(
-  kind: DriftBaseline['kind'],
+  recentPoints: TrendPoint[],
+  baselinePoints: TrendPoint[],
   recent: number,
   baselineValue: number,
   threshold: DriftThreshold,
   goal: TrendSeries['goal'],
-): DriftBaseline | null {
+): DriftBaseline {
+  // A sub-threshold move is still a real comparison worth drawing — the charts
+  // show the overlay on every series, and `direction: 'neutral'` is what keeps
+  // it out of the review feed and the tab counts.
   const direction = classify(recent, baselineValue, threshold, goal)
-  if (direction === 'neutral') return null
   return {
-    kind,
     recent,
     baseline: baselineValue,
     delta: recent - baselineValue,
     deltaFraction: baselineValue === 0 ? 0 : (recent - baselineValue) / Math.abs(baselineValue),
     direction,
+    recentPointsMs: recentPoints.map((point) => point.date.getTime()),
+    baselinePointsMs: baselinePoints.map((point) => point.date.getTime()),
   }
 }
 
 /** Points sorted oldest→newest, most recent last. */
-function trailingBaseline(
+function computeBaseline(
   points: TrendPoint[],
   threshold: DriftThreshold,
   goal: TrendSeries['goal'],
 ): DriftBaseline | null {
+  // null here means "not enough history to compare", never "nothing moved" —
+  // a computed-but-quiet comparison comes back as direction: 'neutral' instead
   if (points.length < 10) return null // need a meaningful prior window
-  const values = points.map((point) => point.value)
-  const recent = median(values.slice(-7))
-  const prior = median(values.slice(-28, -7))
+  // Slice the points (not the values) so the same windows that produce the
+  // medians also carry their timestamps to the chart overlay
+  const recentPoints = points.slice(-RECENT_RUNS)
+  const priorPoints = points.slice(-(RECENT_RUNS + BASELINE_RUNS), -RECENT_RUNS)
+  const recent = median(recentPoints.map((point) => point.value))
+  const prior = median(priorPoints.map((point) => point.value))
   if (recent === null || prior === null) return null
-  return makeBaseline('trailing', recent, prior, threshold, goal)
-}
-
-function stepBaseline(
-  points: TrendPoint[],
-  threshold: DriftThreshold,
-  goal: TrendSeries['goal'],
-): DriftBaseline | null {
-  const latest = points.at(-1)
-  if (!latest) return null
-  const weekday = latest.date.getUTCDay()
-  const sameWeekday = points
-    .slice(0, -1)
-    .filter((point) => point.date.getUTCDay() === weekday)
-    .slice(-4)
-  if (sameWeekday.length < 2) return null
-  const priorMedian = median(sameWeekday.map((point) => point.value))
-  if (priorMedian === null) return null
-  return makeBaseline('step', latest.value, priorMedian, threshold, goal)
-}
-
-/** Worst (largest-magnitude) fired baseline of a drift result. */
-export function worstOf(entry: DriftResult): DriftBaseline {
-  return entry.fired.reduce((a, b) =>
-    Math.abs(b.deltaFraction) > Math.abs(a.deltaFraction) ? b : a,
-  )
+  return makeBaseline(recentPoints, priorPoints, recent, prior, threshold, goal)
 }
 
 /**
- * Reduce drift results to one per series, for flagging the chart card itself.
- * A regression always beats an improvement (a green badge must never mask a
- * live regression on another branch); within the same direction the larger
- * move wins.
+ * Reduce results to one per series, for flagging the chart card itself.
+ *
+ * Ranked by how much a human needs to look: a regression always beats an
+ * improvement (a green badge must never mask a live regression on another
+ * branch), and anything flagged beats a neutral comparison. Within one rank the
+ * larger move wins. Explicit precedence matters now that neutral entries are in
+ * the list — comparing only "same direction or not" let whichever arrived first
+ * win between, say, a neutral and an improvement.
  */
+const DIRECTION_RANK: Record<DriftDirection, number> = {
+  regression: 2,
+  improvement: 1,
+  neutral: 0,
+}
+
 export function worstBySeries(entries: DriftResult[]): Map<string, DriftResult> {
   const map = new Map<string, DriftResult>()
   for (const entry of entries) {
     const current = map.get(entry.seriesKey)
-    const better =
-      !current ||
-      (entry.direction === 'regression' && current.direction !== 'regression') ||
-      (entry.direction === current.direction &&
-        Math.abs(worstOf(entry).deltaFraction) > Math.abs(worstOf(current).deltaFraction))
-    if (better) map.set(entry.seriesKey, entry)
+    if (!current) {
+      map.set(entry.seriesKey, entry)
+      continue
+    }
+    const rank = DIRECTION_RANK[entry.direction] - DIRECTION_RANK[current.direction]
+    const bigger = Math.abs(entry.baseline.deltaFraction) > Math.abs(current.baseline.deltaFraction)
+    if (rank > 0 || (rank === 0 && bigger)) map.set(entry.seriesKey, entry)
   }
   return map
 }
 
-/** Flag every series whose recent runs drifted past the gate thresholds. */
+/**
+ * A baseline comparison for every series with enough history — including the ones
+ * that did not move enough to flag (`direction: 'neutral'`).
+ *
+ * The charts draw the overlay for all of them: "recent level vs prior level" is a
+ * useful reference whether or not it crossed a threshold, and hiding it on quiet
+ * charts made the overlay look like it came and went at random. Callers that mean
+ * "needs review" must filter to regressions/improvements — `useDriftState` does,
+ * so the feed and the tab badges only ever count real flags.
+ */
 export function computeDrift(seriesList: TrendSeries[]): DriftResult[] {
   const results: DriftResult[] = []
   for (const series of seriesList) {
@@ -168,22 +209,16 @@ export function computeDrift(seriesList: TrendSeries[]): DriftResult[] {
     const threshold = thresholdFor(series.unit)
     for (const line of series.lines) {
       const points = [...line.points].sort((a, b) => a.date.getTime() - b.date.getTime())
-      const fired = [
-        trailingBaseline(points, threshold, series.goal),
-        stepBaseline(points, threshold, series.goal),
-      ].filter((entry): entry is DriftBaseline => entry !== null)
-      if (fired.length === 0) continue
-      const direction: DriftDirection = fired.some((entry) => entry.direction === 'regression')
-        ? 'regression'
-        : 'improvement'
+      const baseline = computeBaseline(points, threshold, series.goal)
+      if (!baseline) continue
       const newest = points.at(-1)!
       results.push({
         seriesKey: series.key,
         title: series.title,
         unit: series.unit,
         branch: line.branch,
-        fired,
-        direction,
+        baseline,
+        direction: baseline.direction,
         latest: {
           runId: newest.runId,
           sha: newest.sha,
@@ -194,11 +229,14 @@ export function computeDrift(seriesList: TrendSeries[]): DriftResult[] {
       })
     }
   }
-  // Regressions first, then by largest relative move
-  return results.sort((a, b) => {
-    if (a.direction !== b.direction) return a.direction === 'regression' ? -1 : 1
-    const aMax = Math.max(...a.fired.map((f) => Math.abs(f.deltaFraction)))
-    const bMax = Math.max(...b.fired.map((f) => Math.abs(f.deltaFraction)))
-    return bMax - aMax
-  })
+  // Regressions first, then improvements, then neutral; within a direction the
+  // largest relative move first. Ranked (not "is it a regression") because the
+  // list mixes three directions — a two-way test gives contradictory answers
+  // for improvement-vs-neutral pairs, and an inconsistent comparator makes the
+  // sort order unspecified.
+  return results.sort(
+    (a, b) =>
+      DIRECTION_RANK[b.direction] - DIRECTION_RANK[a.direction] ||
+      Math.abs(b.baseline.deltaFraction) - Math.abs(a.baseline.deltaFraction),
+  )
 }

--- a/dev/metrics-studio/tools/trends/layers.test.ts
+++ b/dev/metrics-studio/tools/trends/layers.test.ts
@@ -1,0 +1,40 @@
+import {expect, test} from 'vitest'
+
+import {type Layer, LAYERS, parseHidden, serializeHidden} from './layers'
+
+test('a pristine param hides nothing', () => {
+  expect(parseHidden('')).toEqual(new Set())
+})
+
+test('round-trips a hidden set', () => {
+  const hidden = new Set<Layer>(['band', 'baseline'])
+  expect(parseHidden(serializeHidden(hidden))).toEqual(hidden)
+})
+
+// All layers visible must serialize to '' so useUrlState drops the param
+// entirely rather than leaving `?layers=` on every shared link
+test('everything visible serializes to the empty param', () => {
+  expect(serializeHidden(new Set())).toBe('')
+})
+
+test('serialization order is stable regardless of insertion order', () => {
+  const a = serializeHidden(new Set<Layer>(['baseline', 'band']))
+  const b = serializeHidden(new Set<Layer>(['band', 'baseline']))
+  expect(a).toBe(b)
+})
+
+// A hand-edited or stale URL must not produce a phantom layer
+test('unknown tokens are ignored', () => {
+  expect(parseHidden('-nope,-band,garbage')).toEqual(new Set(['band']))
+})
+
+test('tolerates tokens with and without the minus prefix', () => {
+  expect(parseHidden('band')).toEqual(new Set(['band']))
+  expect(parseHidden('-band')).toEqual(new Set(['band']))
+})
+
+test('every layer is individually representable', () => {
+  for (const layer of LAYERS) {
+    expect(parseHidden(serializeHidden(new Set([layer])))).toEqual(new Set([layer]))
+  }
+})

--- a/dev/metrics-studio/tools/trends/layers.ts
+++ b/dev/metrics-studio/tools/trends/layers.ts
@@ -1,0 +1,64 @@
+/**
+ * Which encoding layers the charts draw. Clicking a legend swatch toggles a
+ * layer across the whole grid (40+ small multiples — toggling per chart would
+ * be busywork) and the choice persists in the URL, so "look at this with the
+ * bands off" is a shareable link, like `?range=` and `?branches=`.
+ */
+import {useCallback, useMemo} from 'react'
+
+export const LAYERS = ['median', 'band', 'baseline'] as const
+export type Layer = (typeof LAYERS)[number]
+
+export interface LayerState {
+  visible: (layer: Layer) => boolean
+  toggle: (layer: Layer) => void
+}
+
+function isLayer(value: string): value is Layer {
+  return (LAYERS as readonly string[]).includes(value)
+}
+
+/**
+ * Encoded as the *hidden* set (`?layers=-band,-baseline`) rather than the
+ * visible one: the default is everything on, and a param that only appears once
+ * something is off keeps the common URL clean and makes the default obvious.
+ */
+export function parseHidden(param: string): Set<Layer> {
+  const hidden = new Set<Layer>()
+  for (const token of param.split(',')) {
+    const name = token.startsWith('-') ? token.slice(1) : token
+    if (isLayer(name)) hidden.add(name)
+  }
+  return hidden
+}
+
+export function serializeHidden(hidden: ReadonlySet<Layer>): string {
+  // Stable order (LAYERS order, not insertion order) so the same visual state
+  // always produces the same URL
+  return LAYERS.filter((layer) => hidden.has(layer))
+    .map((layer) => `-${layer}`)
+    .join(',')
+}
+
+export function useLayerState(param: string, setParam: (next: string) => void): LayerState {
+  const hidden = useMemo(() => parseHidden(param), [param])
+  const toggle = useCallback(
+    (layer: Layer) => {
+      const next = new Set(hidden)
+      if (next.has(layer)) next.delete(layer)
+      else next.add(layer)
+      setParam(serializeHidden(next))
+    },
+    [hidden, setParam],
+  )
+  return {
+    visible: (layer) => !hidden.has(layer),
+    toggle,
+  }
+}
+
+/** Every layer visible — for call sites with no toggle UI (e.g. stories). */
+export const ALL_LAYERS_VISIBLE: LayerState = {
+  visible: () => true,
+  toggle: () => {},
+}

--- a/dev/metrics-studio/tools/trends/links.ts
+++ b/dev/metrics-studio/tools/trends/links.ts
@@ -26,17 +26,13 @@ export function ciRunUrl(runId: string, attempt?: number): string {
 }
 
 /**
- * `gh` command dispatching an A/B bench run that compares two commits
- * (bench.yml `ab_from`/`ab_to` inputs). A command to copy rather than a link:
- * GitHub has no URL that prefills workflow_dispatch inputs.
+ * GitHub compare view listing every commit between two runs' commits — the
+ * question a suspicious step in a chart raises is "what landed between these
+ * two points". Three dots deliberately: the commit *range* reachable from
+ * `toSha` but not `fromSha`, not a two-endpoint diff.
  */
-export function abDispatchCommand(fromSha: string, toSha: string): string {
-  return `gh workflow run bench.yml -R ${REPO} -f ab_from=${fromSha} -f ab_to=${toSha}`
-}
-
-/** The dispatched-runs list, for watching an A/B comparison after copying. */
-export function dispatchRunsUrl(): string {
-  return `https://github.com/${REPO}/actions/workflows/bench.yml?query=event%3Aworkflow_dispatch`
+export function compareUrl(fromSha: string, toSha: string): string {
+  return `https://github.com/${REPO}/compare/${fromSha}...${toSha}`
 }
 
 /** Link a scenario's source file on the branch it was measured on (or main). */

--- a/dev/metrics-studio/tools/trends/links.ts
+++ b/dev/metrics-studio/tools/trends/links.ts
@@ -50,7 +50,6 @@ const WEB_VITAL_DOCS: Record<string, string> = {
   INP: 'https://web.dev/articles/inp',
   CLS: 'https://web.dev/articles/cls',
   FCP: 'https://web.dev/articles/fcp',
-  TTFB: 'https://web.dev/articles/ttfb',
 }
 
 export function webVitalDocUrl(label: string): string | undefined {

--- a/dev/metrics-studio/tools/trends/useDriftState.ts
+++ b/dev/metrics-studio/tools/trends/useDriftState.ts
@@ -6,9 +6,14 @@ import {useClient, useDocumentStore} from 'sanity'
 
 import {ackIsActive, clearAck, type DriftAck, DRIFT_ACK_QUERY, SNOOZE_DAYS, writeAck} from './acks'
 import {type TrendSeries} from './data'
-import {computeDrift, type DriftResult, worstOf} from './drift'
+import {computeDrift, type DriftResult} from './drift'
 
 export interface DriftState {
+  /**
+   * Every series with a computable baseline, including sub-threshold ones — what
+   * the charts draw their overlay from. Not a review list; see `active`.
+   */
+  all: DriftResult[]
   /** Drifted metrics not currently silenced/snoozed — the "to review" set. */
   active: DriftResult[]
   /** Drifted metrics muted by an active ack. */
@@ -52,9 +57,11 @@ export function useDriftState(series: TrendSeries[]): DriftState {
   const {active, silenced} = useMemo(() => {
     const activeList: DriftResult[] = []
     const silencedList: DriftResult[] = []
-    for (const entry of drift) {
+    // Neutral entries exist so the charts can draw an overlay everywhere; they are
+    // not findings, so they never reach the feed or the tab badges
+    for (const entry of drift.filter((candidate) => candidate.direction !== 'neutral')) {
       const found = acks.find((a) => a.metricKey === entry.seriesKey && a.branch === entry.branch)
-      const recent = worstOf(entry).recent
+      const recent = entry.baseline.recent
       if (found && ackIsActive(found, recent, now)) silencedList.push(entry)
       else activeList.push(entry)
     }
@@ -64,6 +71,7 @@ export function useDriftState(series: TrendSeries[]): DriftState {
   const regressionCount = active.filter((entry) => entry.direction === 'regression').length
 
   return {
+    all: drift,
     active,
     silenced,
     regressionCount,
@@ -75,7 +83,7 @@ export function useDriftState(series: TrendSeries[]): DriftState {
       writeAck(client, {
         metricKey: entry.seriesKey,
         branch: entry.branch,
-        baselineValue: worstOf(entry).recent,
+        baselineValue: entry.baseline.recent,
         state,
         until:
           state === 'snoozed'

--- a/perf/bench/cli/commands/runImpl.ts
+++ b/perf/bench/cli/commands/runImpl.ts
@@ -197,14 +197,17 @@ export async function runBench(argv: RunArgs): Promise<void> {
         scenarioReports.push(collectInp(scenario.name, results, scenario.sourceFile))
       }
     } else if (argv.mode === 'pageload') {
-      const sizes = await measureBundleSize(dist)
+      // sizesByPath feeds the per-scenario "boot JS" metric but must not be
+      // stored — it's ~400 map entries of per-chunk noise in a document
+      const {sizesByPath, ...sizes} = await measureBundleSize(dist)
       console.log(
         `bundle (experiment): initial JS ${(sizes.initialJsBytes / 1024).toFixed(1)} KB gzip, ` +
           `total ${(sizes.totalJsBytes / 1024).toFixed(1)} KB gzip across ${sizes.chunkCount} chunks`,
       )
       bundleReport = {experiment: sizes}
       if (referenceDist) {
-        const referenceSizes = await measureBundleSize(referenceDist)
+        const {sizesByPath: _referenceSizesByPath, ...referenceSizes} =
+          await measureBundleSize(referenceDist)
         bundleReport = {experiment: sizes, reference: referenceSizes}
         console.log(
           `bundle (reference):  initial JS ${(referenceSizes.initialJsBytes / 1024).toFixed(1)} KB gzip ` +
@@ -314,7 +317,13 @@ export async function runBench(argv: RunArgs): Promise<void> {
           }
         }
         scenarioReports.push(
-          collectPageLoad(scenario.name, bySide, conditionComparisons, scenario.sourceFile),
+          collectPageLoad(
+            scenario.name,
+            bySide,
+            conditionComparisons,
+            scenario.sourceFile,
+            sizesByPath,
+          ),
         )
       }
     } else {

--- a/perf/bench/cli/commands/runImpl.ts
+++ b/perf/bench/cli/commands/runImpl.ts
@@ -200,14 +200,16 @@ export async function runBench(argv: RunArgs): Promise<void> {
       // sizesByPath feeds the per-scenario "boot JS" metric but must not be
       // stored — it's ~400 map entries of per-chunk noise in a document
       const {sizesByPath, ...sizes} = await measureBundleSize(dist)
+      let referenceSizesByPath: Map<string, number> | undefined
       console.log(
         `bundle (experiment): initial JS ${(sizes.initialJsBytes / 1024).toFixed(1)} KB gzip, ` +
           `total ${(sizes.totalJsBytes / 1024).toFixed(1)} KB gzip across ${sizes.chunkCount} chunks`,
       )
       bundleReport = {experiment: sizes}
       if (referenceDist) {
-        const {sizesByPath: _referenceSizesByPath, ...referenceSizes} =
+        const {sizesByPath: refSizesByPath, ...referenceSizes} =
           await measureBundleSize(referenceDist)
+        referenceSizesByPath = refSizesByPath
         bundleReport = {experiment: sizes, reference: referenceSizes}
         console.log(
           `bundle (reference):  initial JS ${(referenceSizes.initialJsBytes / 1024).toFixed(1)} KB gzip ` +
@@ -317,13 +319,10 @@ export async function runBench(argv: RunArgs): Promise<void> {
           }
         }
         scenarioReports.push(
-          collectPageLoad(
-            scenario.name,
-            bySide,
-            conditionComparisons,
-            scenario.sourceFile,
-            sizesByPath,
-          ),
+          collectPageLoad(scenario.name, bySide, conditionComparisons, scenario.sourceFile, {
+            experiment: sizesByPath,
+            reference: referenceSizesByPath,
+          }),
         )
       }
     } else {

--- a/perf/bench/instrumentation/index.ts
+++ b/perf/bench/instrumentation/index.ts
@@ -96,13 +96,35 @@ function install(): void {
     }
   })
 
+  // Describe a shifted node compactly. data-testid first (stable across
+  // refactors), @sanity/ui's data-ui second, tag#id.class as the fallback —
+  // enough to find the element, small enough to store per shift.
+  function describeShiftedNode(node: Node | null | undefined): string {
+    if (!node || !(node instanceof Element)) return '(detached)'
+    const testId = node.getAttribute('data-testid')
+    if (testId) return `[data-testid="${testId}"]`
+    const ui = node.getAttribute('data-ui')
+    if (ui) return `[data-ui="${ui}"]`
+    const id = node.id ? `#${node.id}` : ''
+    const className =
+      typeof node.className === 'string' && node.className
+        ? `.${node.className.split(/\s+/)[0]}`
+        : ''
+    return `${node.tagName.toLowerCase()}${id}${className}`
+  }
+
   observe('layout-shift', (entries) => {
     for (const entry of entries) {
-      const shift = entry as PerformanceEntry & {value: number; hadRecentInput: boolean}
+      const shift = entry as PerformanceEntry & {
+        value: number
+        hadRecentInput: boolean
+        sources?: {node?: Node | null}[]
+      }
       layoutShifts.push({
         startTime: shift.startTime,
         value: shift.value,
         hadRecentInput: shift.hadRecentInput,
+        sources: (shift.sources ?? []).map((source) => describeShiftedNode(source.node)),
       })
     }
   })

--- a/perf/bench/instrumentation/types.ts
+++ b/perf/bench/instrumentation/types.ts
@@ -33,6 +33,12 @@ export interface LayoutShiftSample {
   startTime: number
   value: number
   hadRecentInput: boolean
+  /**
+   * Compact descriptors of the shifted elements (from LayoutShiftAttribution),
+   * e.g. '[data-testid="pane-content"]' or 'div.someClass' — so a CLS number
+   * can name its culprit instead of just existing.
+   */
+  sources: string[]
 }
 
 export interface NavigationSample {

--- a/perf/bench/report/__tests__/collect.test.ts
+++ b/perf/bench/report/__tests__/collect.test.ts
@@ -103,10 +103,11 @@ function sample(
   return {
     condition,
     timeToEditableMs,
-    ttfbMs: 100,
     fcpMs: 1000,
     lcpMs: 2000,
     cls: 0,
+    clsAttribution: [{source: '[data-testid="pane-content"]', totalValue: 0.01}],
+    jsUrls: ['/static/sanity-abc.js'],
     blockingMs: 50,
     loafAttribution: [
       {
@@ -140,7 +141,6 @@ describe('collectPageLoad', () => {
     const labels = report.metrics.map((metric) => `${metric.label} (${metric.unit})`)
     expect(labels).toEqual([
       'boot-cold · time to editable (ms)',
-      'boot-cold · TTFB (ms)',
       'boot-cold · FCP (ms)',
       'boot-cold · LCP (ms)',
       'boot-cold · CLS (cls)',
@@ -178,7 +178,6 @@ describe('collectPageLoad', () => {
     )
     expect(report.metrics.map((metric) => metric.label)).toEqual([
       'boot-cold · time to editable',
-      'boot-cold · TTFB',
       'boot-cold · FCP',
       'boot-cold · LCP',
       'boot-cold · CLS',
@@ -186,6 +185,65 @@ describe('collectPageLoad', () => {
       // auth first request is skipped (firstRequestMs is null in this fixture)
       'boot-cold · auth round trips',
       'boot-cold · auth in flight',
+    ])
+  })
+
+  it('emits a boot-cold boot JS row when chunk gzip sizes are provided', () => {
+    const report = collectPageLoad(
+      'singleString',
+      new Map([
+        [
+          'experiment',
+          [sample('boot-cold', 4000), sample('boot-cold', 4100), sample('open-doc-warm', 3900)],
+        ],
+      ]),
+      new Map(),
+      undefined,
+      new Map([['/static/sanity-abc.js', 140_000]]),
+    )
+    const bootJs = report.metrics.find((metric) => metric.label === 'boot-cold · boot JS')
+    expect(bootJs?.unit).toBe('bytes')
+    expect(bootJs?.experiment.summary.median).toBe(140_000)
+    // Warm pages replay the same chunk set from cache — no row for them
+    expect(report.metrics.some((metric) => metric.label.includes('open-doc-warm · boot JS'))).toBe(
+      false,
+    )
+  })
+
+  it('omits the boot JS row without chunk sizes and when no fetched path matches', () => {
+    const withoutSizes = collectPageLoad(
+      'singleString',
+      new Map([['experiment', [sample('boot-cold', 4000)]]]),
+      new Map(),
+    )
+    expect(withoutSizes.metrics.some((metric) => metric.label.includes('boot JS'))).toBe(false)
+
+    const noMatches = collectPageLoad(
+      'singleString',
+      new Map([['experiment', [sample('boot-cold', 4000)]]]),
+      new Map(),
+      undefined,
+      new Map([['/static/other.js', 1]]),
+    )
+    expect(noMatches.metrics.some((metric) => metric.label.includes('boot JS'))).toBe(false)
+  })
+
+  it('aggregates cls attribution across experiment samples, largest first', () => {
+    const shifted = {
+      ...sample('boot-cold', 4000),
+      clsAttribution: [
+        {source: 'div.banner', totalValue: 0.02},
+        {source: '[data-testid="pane-content"]', totalValue: 0.005},
+      ],
+    }
+    const report = collectPageLoad(
+      'singleString',
+      new Map([['experiment', [shifted, sample('boot-cold', 4100)]]]),
+      new Map(),
+    )
+    expect(report.clsAttribution).toEqual([
+      {source: 'div.banner', totalValue: 0.02},
+      {source: '[data-testid="pane-content"]', totalValue: 0.005 + 0.01},
     ])
   })
 })

--- a/perf/bench/report/__tests__/collect.test.ts
+++ b/perf/bench/report/__tests__/collect.test.ts
@@ -107,7 +107,7 @@ function sample(
     lcpMs: 2000,
     cls: 0,
     clsAttribution: [{source: '[data-testid="pane-content"]', totalValue: 0.01}],
-    jsUrls: ['/static/sanity-abc.js'],
+    jsPaths: ['/static/sanity-abc.js'],
     blockingMs: 50,
     loafAttribution: [
       {
@@ -199,7 +199,7 @@ describe('collectPageLoad', () => {
       ]),
       new Map(),
       undefined,
-      new Map([['/static/sanity-abc.js', 140_000]]),
+      {experiment: new Map([['/static/sanity-abc.js', 140_000]])},
     )
     const bootJs = report.metrics.find((metric) => metric.label === 'boot-cold · boot JS')
     expect(bootJs?.unit).toBe('bytes')
@@ -223,9 +223,37 @@ describe('collectPageLoad', () => {
       new Map([['experiment', [sample('boot-cold', 4000)]]]),
       new Map(),
       undefined,
-      new Map([['/static/other.js', 1]]),
+      {experiment: new Map([['/static/other.js', 1]])},
     )
     expect(noMatches.metrics.some((metric) => metric.label.includes('boot JS'))).toBe(false)
+  })
+
+  // Chunk names are content-hashed, so a side must be valued against its own
+  // build's sizes — the experiment map would give the reference side a partial
+  // sum that reads as a fake A/B diff
+  it('values each side of boot JS against its own chunk sizes', () => {
+    const referenceSample = {...sample('boot-cold', 4200), jsPaths: ['/static/sanity-old.js']}
+    const bothSides = new Map([
+      ['experiment', [sample('boot-cold', 4000)]],
+      ['reference', [referenceSample]],
+    ])
+    const withBoth = collectPageLoad('singleString', bothSides, new Map(), undefined, {
+      experiment: new Map([['/static/sanity-abc.js', 140_000]]),
+      reference: new Map([['/static/sanity-old.js', 120_000]]),
+    })
+    const bootJs = withBoth.metrics.find((metric) => metric.label === 'boot-cold · boot JS')
+    expect(bootJs?.experiment.summary.median).toBe(140_000)
+    expect(bootJs?.reference?.summary.median).toBe(120_000)
+
+    // Without a reference size map the row stays experiment-only
+    const withoutReferenceSizes = collectPageLoad('singleString', bothSides, new Map(), undefined, {
+      experiment: new Map([['/static/sanity-abc.js', 140_000]]),
+    })
+    const experimentOnly = withoutReferenceSizes.metrics.find(
+      (metric) => metric.label === 'boot-cold · boot JS',
+    )
+    expect(experimentOnly?.experiment.summary.median).toBe(140_000)
+    expect(experimentOnly?.reference).toBeUndefined()
   })
 
   it('aggregates cls attribution across experiment samples, largest first', () => {

--- a/perf/bench/report/collect.ts
+++ b/perf/bench/report/collect.ts
@@ -283,12 +283,32 @@ export function collectInp(
   }
 }
 
-/** pageLoad samples (both sides) → scenario report. */
+/** Exact gzip sum of the chunks a sample fetched; null when none matched. */
+function bootJsBytes(paths: string[], sizes: ReadonlyMap<string, number>): number | null {
+  let total = 0
+  let matched = 0
+  for (const path of paths) {
+    const size = sizes.get(path)
+    if (size !== undefined) {
+      total += size
+      matched += 1
+    }
+  }
+  return matched > 0 ? total : null
+}
+
+/**
+ * pageLoad samples (both sides) → scenario report. `chunkGzipSizes` (dist
+ * path → exact gzip bytes, from measureBundleSize) enables the "boot JS" row:
+ * what booting actually downloads, as opposed to the entry chunk the bundle
+ * report counts.
+ */
 export function collectPageLoad(
   scenario: string,
   samplesBySide: Map<string, PageLoadSample[]>,
   comparisons: Map<LoadCondition, {interval: DiffInterval; verdict: Verdict}>,
   sourceFile?: string,
+  chunkGzipSizes?: ReadonlyMap<string, number>,
 ): ScenarioReport {
   const experiment = samplesBySide.get('experiment') ?? []
   const reference = samplesBySide.get('reference')
@@ -362,8 +382,8 @@ export function collectPageLoad(
         },
         // Core Web Vitals (report-only) — captured per sample but previously
         // only logged; surface them so the dashboard tracks load quality, not
-        // just time-to-editable
-        ...reportOnly(condition, 'TTFB', 'ms', (sample) => sample.ttfbMs),
+        // just time-to-editable. No TTFB: against the local mock it's a
+        // constant of the bench setup, not a studio signal.
         ...reportOnly(condition, 'FCP', 'ms', (sample) => sample.fcpMs),
         ...reportOnly(condition, 'LCP', 'ms', (sample) => sample.lcpMs),
         ...reportOnly(condition, 'CLS', 'cls', (sample) => sample.cls),
@@ -383,6 +403,15 @@ export function collectPageLoad(
           (sample) => sample.auth.firstRequestMs,
         ),
         ...reportOnly(condition, 'auth in flight', 'ms', (sample) => sample.auth.inFlightMs),
+        // What booting actually downloads: exact gzip sum of the chunks this
+        // sample fetched before editable. boot-cold only — the warm page
+        // replays the same set from cache. (The bundle report's entry-chunk
+        // number is only what index.html references.)
+        ...(condition === 'boot-cold' && chunkGzipSizes
+          ? reportOnly(condition, 'boot JS', 'bytes', (sample) =>
+              bootJsBytes(sample.jsUrls, chunkGzipSizes),
+            )
+          : []),
       ]
     },
   )
@@ -400,6 +429,17 @@ export function collectPageLoad(
     }
   }
 
+  // Which elements shifted, summed across experiment samples — the CLS
+  // number's culprit list, same idea as the script blockers above
+  const byShiftSource = new Map<string, {source: string; totalValue: number}>()
+  for (const sample of experiment) {
+    for (const shift of sample.clsAttribution) {
+      const existing = byShiftSource.get(shift.source) ?? {source: shift.source, totalValue: 0}
+      existing.totalValue += shift.totalValue
+      byShiftSource.set(shift.source, existing)
+    }
+  }
+
   return {
     scenario,
     ...(sourceFile ? {sourceFile} : {}),
@@ -408,5 +448,8 @@ export function collectPageLoad(
     failures: [],
     interruptions: {experiment: {count: 0, totalMs: 0}},
     loafAttribution: [...byScript.values()].sort((a, b) => b.totalMs - a.totalMs).slice(0, 5),
+    clsAttribution: [...byShiftSource.values()]
+      .sort((a, b) => b.totalValue - a.totalValue)
+      .slice(0, 5),
   }
 }

--- a/perf/bench/report/collect.ts
+++ b/perf/bench/report/collect.ts
@@ -299,16 +299,21 @@ function bootJsBytes(paths: string[], sizes: ReadonlyMap<string, number>): numbe
 
 /**
  * pageLoad samples (both sides) → scenario report. `chunkGzipSizes` (dist
- * path → exact gzip bytes, from measureBundleSize) enables the "boot JS" row:
- * what booting actually downloads, as opposed to the entry chunk the bundle
- * report counts.
+ * path → exact gzip bytes per side, from measureBundleSize) enables the
+ * "boot JS" row: what booting actually downloads, as opposed to the entry
+ * chunk the bundle report counts. Per side because chunk names are
+ * content-hashed: valuing reference-side fetches against the experiment
+ * build's sizes would produce a partial sum that reads as a fake A/B diff.
  */
 export function collectPageLoad(
   scenario: string,
   samplesBySide: Map<string, PageLoadSample[]>,
   comparisons: Map<LoadCondition, {interval: DiffInterval; verdict: Verdict}>,
   sourceFile?: string,
-  chunkGzipSizes?: ReadonlyMap<string, number>,
+  chunkGzipSizes?: {
+    experiment: ReadonlyMap<string, number>
+    reference?: ReadonlyMap<string, number>
+  },
 ): ScenarioReport {
   const experiment = samplesBySide.get('experiment') ?? []
   const reference = samplesBySide.get('reference')
@@ -318,17 +323,17 @@ export function collectPageLoad(
     condition: LoadCondition,
     label: string,
     unit: MetricReport['unit'],
-    value: (sample: PageLoadSample) => number | null,
+    value: (sample: PageLoadSample, side: 'experiment' | 'reference') => number | null,
   ): MetricReport[] => {
-    const values = (samples: PageLoadSample[] | undefined) =>
+    const values = (samples: PageLoadSample[] | undefined, side: 'experiment' | 'reference') =>
       (samples ?? [])
         .filter((sample) => sample.condition === condition)
-        .map(value)
+        .map((sample) => value(sample, side))
         .filter((sampleValue): sampleValue is number => sampleValue !== null)
         .map((sampleValue) => [sampleValue])
-    const experimentValues = values(experiment)
+    const experimentValues = values(experiment, 'experiment')
     if (experimentValues.length === 0) return []
-    const referenceValues = values(reference)
+    const referenceValues = values(reference, 'reference')
     return [
       {
         label: `${condition} · ${label}`,
@@ -408,9 +413,14 @@ export function collectPageLoad(
         // replays the same set from cache. (The bundle report's entry-chunk
         // number is only what index.html references.)
         ...(condition === 'boot-cold' && chunkGzipSizes
-          ? reportOnly(condition, 'boot JS', 'bytes', (sample) =>
-              bootJsBytes(sample.jsUrls, chunkGzipSizes),
-            )
+          ? reportOnly(condition, 'boot JS', 'bytes', (sample, side) => {
+              // Each side's fetches valued against its own build's chunk
+              // sizes; a side without a size map gets no value at all rather
+              // than a misleading partial sum
+              const sizes =
+                side === 'reference' ? chunkGzipSizes.reference : chunkGzipSizes.experiment
+              return sizes ? bootJsBytes(sample.jsPaths, sizes) : null
+            })
           : []),
       ]
     },

--- a/perf/bench/report/storeShape.ts
+++ b/perf/bench/report/storeShape.ts
@@ -35,6 +35,14 @@ export function toStorableRun(document: BenchRunDocument) {
         ...entry,
         _key: `loaf-${index}`,
       })),
+      ...(scenario.clsAttribution
+        ? {
+            clsAttribution: scenario.clsAttribution.map((entry, index) => ({
+              ...entry,
+              _key: `shift-${index}`,
+            })),
+          }
+        : {}),
       ...(scenario.resources ? {resources: toStorableResources(scenario.resources)} : {}),
       ...(scenario.soak
         ? {

--- a/perf/bench/report/types.ts
+++ b/perf/bench/report/types.ts
@@ -100,6 +100,12 @@ export interface ScenarioReport {
   }
   /** Top blocking-script attributions (experiment side). */
   loafAttribution: {sourceUrl: string; functionName: string; totalMs: number}[]
+  /**
+   * Which elements shifted during load, with summed CLS contribution across
+   * experiment samples (pageload mode only) — names the culprit behind a CLS
+   * number instead of leaving it a bare score.
+   */
+  clsAttribution?: {source: string; totalValue: number}[]
   /** Resources bucket — report-only, never gated (per-session medians). */
   resources?: {
     experiment: ResourceSide
@@ -142,7 +148,7 @@ export interface MetricReport {
   /** e.g. "title", "body", "boot-cold · time to editable" */
   label: string
   /** 'cls' is the unitless layout-shift score (~0–0.25), shown to 3 decimals. */
-  unit: 'ms' | 'count' | 'cls'
+  unit: 'ms' | 'count' | 'cls' | 'bytes'
   /** Present the median as eFPS (1000/ms) in reports. */
   presentAsEfps: boolean
   experiment: SideMetric

--- a/perf/bench/runner/bundleSize.ts
+++ b/perf/bench/runner/bundleSize.ts
@@ -11,6 +11,13 @@ export interface BundleSizeReport {
   /** Gzipped bytes of every JS chunk in the build. */
   totalJsBytes: number
   chunkCount: number
+  /**
+   * Gzipped bytes per chunk, keyed by served path ('/static/foo.js') — joined
+   * with each boot-cold sample's fetched paths to compute the "boot JS" metric
+   * (what booting actually downloads). Not part of the stored report: callers
+   * strip it before persisting, it's ~400 entries of noise in a document.
+   */
+  sizesByPath: Map<string, number>
 }
 
 /**
@@ -31,14 +38,16 @@ export async function measureBundleSize(distDir: string): Promise<BundleSizeRepo
 
   let initialJsBytes = 0
   let totalJsBytes = 0
+  const sizesByPath = new Map<string, number>()
   for (const file of chunkFiles) {
     const contents = await fs.promises.readFile(path.join(staticDir, file))
     const gzippedBytes = (await gzip(contents)).byteLength
+    sizesByPath.set(`/static/${file}`, gzippedBytes)
     totalJsBytes += gzippedBytes
     if (initialPaths.has(`/static/${file}`)) {
       initialJsBytes += gzippedBytes
     }
   }
 
-  return {initialJsBytes, totalJsBytes, chunkCount: chunkFiles.length}
+  return {initialJsBytes, totalJsBytes, chunkCount: chunkFiles.length, sizesByPath}
 }

--- a/perf/bench/runner/session/pageLoad.ts
+++ b/perf/bench/runner/session/pageLoad.ts
@@ -24,11 +24,25 @@ export interface PageLoadSample {
   condition: LoadCondition
   /** Headline: navigation start → form editable + probe keystroke landed. */
   timeToEditableMs: number
-  ttfbMs: number | null
+  // No ttfbMs: the document is served by the local mock, so its TTFB is a
+  // 2–10ms constant of the bench setup (the navigation request also bypasses
+  // the emulated network latency) — a number we chose, not one we measure
   fcpMs: number | null
   lcpMs: number | null
   /** Cumulative layout shift (entries without recent input). */
   cls: number
+  /**
+   * Which elements shifted, with each one's summed contribution — so a CLS
+   * regression names its culprit. Directional: a shift entry listing several
+   * sources credits its full value to each of them.
+   */
+  clsAttribution: {source: string; totalValue: number}[]
+  /**
+   * Pathnames of the JS chunks fetched before the form was editable — joined
+   * with the dist's exact gzip sizes at report time to measure what booting
+   * actually downloads (the index.html entry chunk is a fraction of it).
+   */
+  jsUrls: string[]
   /** Total LoAF blocking during load. */
   blockingMs: number
   /**
@@ -92,6 +106,45 @@ export function foldLoafAttribution(
     }
   }
   return [...byScript.values()].sort((a, b) => b.totalMs - a.totalMs).slice(0, top)
+}
+
+/** Fold layout shifts into per-element value totals, largest first. */
+export function foldClsAttribution(
+  shifts: {value: number; hadRecentInput: boolean; sources: string[]}[],
+  top = 10,
+): PageLoadSample['clsAttribution'] {
+  const bySource = new Map<string, {source: string; totalValue: number}>()
+  for (const shift of shifts) {
+    if (shift.hadRecentInput) continue
+    for (const source of shift.sources) {
+      const existing = bySource.get(source) ?? {source, totalValue: 0}
+      existing.totalValue += shift.value
+      bySource.set(source, existing)
+    }
+  }
+  return [...bySource.values()].sort((a, b) => b.totalValue - a.totalValue).slice(0, top)
+}
+
+/**
+ * Pathnames of JS chunks fetched before the form became editable, deduped and
+ * sorted. Pathname only: the origin is the bench server, and the report-time
+ * gzip lookup is keyed by dist-relative path.
+ */
+export function bootJsPaths(
+  resources: {url: string; responseEnd: number}[],
+  editableAtMs: number,
+): string[] {
+  const paths = new Set<string>()
+  for (const resource of resources) {
+    if (resource.responseEnd <= 0 || resource.responseEnd > editableAtMs) continue
+    try {
+      const {pathname} = new URL(resource.url)
+      if (/\.m?js$/.test(pathname)) paths.add(pathname)
+    } catch {
+      // Not a URL (data: etc.) — not a chunk
+    }
+  }
+  return [...paths].sort()
 }
 
 /** Derive the auth milestones from resource timing (see PageLoadSample.auth). */
@@ -209,12 +262,13 @@ async function measureLoad(options: {
   return {
     condition,
     timeToEditableMs: timeToEditable.duration,
-    ttfbMs: entries.navigation?.responseStart ?? null,
     fcpMs: fcp?.startTime ?? null,
     lcpMs: entries.largestContentfulPaint?.startTime ?? null,
     cls: entries.layoutShifts
       .filter((shift) => !shift.hadRecentInput)
       .reduce((sum, shift) => sum + shift.value, 0),
+    clsAttribution: foldClsAttribution(entries.layoutShifts),
+    jsUrls: bootJsPaths(entries.resources, timeToEditable.duration),
     blockingMs: entries.loafs.reduce((sum, loaf) => sum + loaf.blockingDuration, 0),
     loafAttribution: foldLoafAttribution(entries.loafs),
     auth: deriveAuthMilestones(entries.resources, timeToEditable.duration),

--- a/perf/bench/runner/session/pageLoad.ts
+++ b/perf/bench/runner/session/pageLoad.ts
@@ -42,7 +42,7 @@ export interface PageLoadSample {
    * with the dist's exact gzip sizes at report time to measure what booting
    * actually downloads (the index.html entry chunk is a fraction of it).
    */
-  jsUrls: string[]
+  jsPaths: string[]
   /** Total LoAF blocking during load. */
   blockingMs: number
   /**
@@ -268,7 +268,7 @@ async function measureLoad(options: {
       .filter((shift) => !shift.hadRecentInput)
       .reduce((sum, shift) => sum + shift.value, 0),
     clsAttribution: foldClsAttribution(entries.layoutShifts),
-    jsUrls: bootJsPaths(entries.resources, timeToEditable.duration),
+    jsPaths: bootJsPaths(entries.resources, timeToEditable.duration),
     blockingMs: entries.loafs.reduce((sum, loaf) => sum + loaf.blockingDuration, 0),
     loafAttribution: foldLoafAttribution(entries.loafs),
     auth: deriveAuthMilestones(entries.resources, timeToEditable.duration),


### PR DESCRIPTION
### Description

Improvements to the metrics dashboard (dev/metrics-studio) and the bench suite (perf/bench), aimed at making the charts and measurements more accurate:

- Merge re-runs of the same commit into one chart point (median), so no commit gets several votes
- Draw each chart's drift baseline as an overlay (median of last 7 runs vs prior 21), colored by direction; the noisy "step" baseline is removed (it fired on 74–92% of runs)
- Toggle chart layers (median, p75–p90 band, baseline) from the legend, persisted in the URL
- Group Web Vitals into one section per vital, with web.dev "good" reference lines on the charts
- Show the INP interaction count as confidence context on the INP chart instead of a separate chart
- Fix clipped axis labels: gutter sized from the actual tick labels, one unit per axis
- Link each run to the GitHub compare view with the previous run (replaces the copy-A/B command)
- Remove TTFB: it only measured the local mock, not the studio
- Split bundle size into entry chunk, total JS, and (new) boot JS — the chunks actually fetched before the document is editable
- Record which elements caused layout shifts (CLS attribution), so the constant ~0.026 CLS can be traced and fixed
- Plain-language copy pass across the dashboard

### What to review

- Everything is dev/internal tooling: `dev/metrics-studio` (dashboard) and `perf/bench` (runner/report)
- `drift.ts` and `data.ts` carry the core logic (windows, merging, thresholds); the rest is charts and copy
- Bench report changes are additive; stored documents from before still render (TTFB in old documents is skipped)

### Testing

- 50 dashboard unit tests (`--project=metrics-studio`) and 125 bench unit tests (`--project=bench`) pass
- Verified visually against live data in the dev studio

### Notes for release

N/A – Internal only

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Internal dev tooling and additive bench fields; core behavior is covered by expanded unit tests with no production user-facing API changes.
> 
> **Overview**
> **Metrics studio (Trends)** tightens how history is shown and how drift is read. Re-runs of the same commit collapse to one median point per commit (calibration stays per-run). Drift drops the noisy step/weekday baselines and uses one trailing window (median of last 7 runs vs prior 21, counted in runs). Every chart with enough history draws that comparison as a baseline overlay; sub-threshold moves stay **neutral** (grey overlay only—feed and badges still flag real regressions/improvements). Drift math runs on full branch history, not the range picker.
> 
> Charts add web.dev **good** reference lines, vitals grouped by metric, INP interaction count on the point (not a separate series), legend-driven global layer toggles (`?layers=`), crosshair run selection instead of resting dots, dynamic Y-axis gutters/`formatTick`, and run popover links to GitHub **compare** with the previous commit. Bundle charts clarify entry vs total JS; TTFB is skipped for stored and new data.
> 
> **Bench / reporting** stops emitting TTFB and INP-interactions as standalone vitals; pageload collects **boot JS** (gzip sum of chunks fetched before editable, per build side) and **CLS attribution** (shifted element descriptors), persisted on `benchRun` via `clsAttribution` and optional `totalJsBytes`. Instrumentation records layout-shift sources; `sizesByPath` is stripped before document storage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5255d8e1ad080e77148a4cd2b4bf553dc6f85e2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->