### PR TITLE
chore(lint): suppress remaining portabletext deprecation errors

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -390,6 +390,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
   )
 
   const editorRenderAnnotation = useCallback(
+    // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
     (annotationProps: BlockAnnotationRenderProps) => {
       const {
         children,

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -52,6 +52,7 @@ interface EditorProps {
   path: Path
   readOnly?: boolean
   rangeDecorations?: RangeDecoration[]
+  // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
   renderAnnotation: RenderAnnotationFunction
   scrollElement: HTMLElement | null
   setPortalElement?: (portalElement: HTMLDivElement | null) => void
@@ -115,6 +116,7 @@ export function Editor(props: EditorProps): ReactNode {
     [t],
   )
   const spellCheck = useSpellCheck()
+  // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
   const renderDecorator = useCallback((decoratorProps: BlockDecoratorRenderProps) => {
     return <Decorator {...decoratorProps} />
   }, [])
@@ -129,7 +131,9 @@ export function Editor(props: EditorProps): ReactNode {
       onPaste,
       rangeDecorations,
       'ref': elementRef,
+      // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
       renderAnnotation,
+      // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
       renderDecorator,
       renderPlaceholder,
       scrollSelectionIntoView,

--- a/packages/sanity/src/core/form/inputs/PortableText/text/Decorator.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/Decorator.tsx
@@ -21,6 +21,7 @@ const Root = styled.span(({theme}: {theme: Theme}) => {
   `
 })
 
+// oxlint-disable-next-line no-deprecated -- will fix in follow up PR
 export function Decorator(props: BlockDecoratorRenderProps) {
   const {value, focused, selected, children, schemaType} = props
   const schemaTypes = usePortableTextMemberSchemaTypes()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Oxlint on `main` fails with 6 `typescript/no-deprecated` errors after the portabletext upgrade in #14173. Remaining usages of `BlockDecoratorRenderProps`, `BlockAnnotationRenderProps`, `RenderAnnotationFunction`, `renderAnnotation`, and `renderDecorator` are not yet migrated.

This adds `oxlint-disable-next-line no-deprecated -- will fix in follow up PR` at those sites, matching the existing Portable Text deprecation suppressions.

### What to review

- `packages/sanity/src/core/form/inputs/PortableText/text/Decorator.tsx`
- `packages/sanity/src/core/form/inputs/PortableText/Editor.tsx`
- `packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx`

Comments only; no runtime changes.

### Testing

Ran `pnpm check:oxlint` and `pnpm check:format`. Both pass. No automated tests added because this only suppresses existing deprecations.

### Notes for release

N/A: Internal lint suppressions only.

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfb02039-6c6f-4872-8c38-4315215385a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfb02039-6c6f-4872-8c38-4315215385a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

