### PR TITLE
fix(form): migrate decorator and annotation render props

### DIFF
--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -1,9 +1,12 @@
 import {
-  type BlockAnnotationRenderProps,
+  type AnnotationRenderProps,
   type BlockObjectRenderProps,
+  defineAnnotation,
   defineBlockObject,
+  defineDecorator,
   defineInlineObject,
   defineTextBlock,
+  type DecoratorRenderProps,
   type EditorSelection,
   type HotkeyOptions,
   type InlineObjectRenderProps,
@@ -49,6 +52,7 @@ import {BlockObject} from './object/BlockObject'
 import {CombinedAnnotationPopover} from './object/CombinedAnnotationPopover'
 import {InlineObject} from './object/InlineObject'
 import {AnnotationObjectEditModal} from './object/modals/AnnotationObjectEditModal'
+import {Decorator} from './text/Decorator'
 import {ListItem} from './text/ListItem'
 import {Style} from './text/Style'
 import {TextBlock} from './text/TextBlock'
@@ -378,37 +382,28 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
     ],
   )
 
-  // Stable reference: `NodePlugin` re-runs its registration effect when
-  // `nodes` changes by reference.
-  const catchAllNodes = useMemo<RegistrableNode[]>(
-    () => [
-      defineTextBlock({type: '*', render: renderTextBlock}),
-      defineBlockObject({type: '*', render: renderBlockObject}),
-      defineInlineObject({type: '*', render: renderInlineObject}),
-    ],
-    [renderTextBlock, renderBlockObject, renderInlineObject],
-  )
+  const renderDecorator = useCallback((decoratorProps: DecoratorRenderProps) => {
+    return <Decorator {...decoratorProps} />
+  }, [])
 
   const editorRenderAnnotation = useCallback(
-    // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-    (annotationProps: BlockAnnotationRenderProps) => {
+    (annotationProps: AnnotationRenderProps) => {
       const {
+        annotation,
         children,
         focused: editorNodeFocused,
         path: aPath,
         selected,
-        schemaType: aSchemaType,
-        value: aValue,
       } = annotationProps
-      const annotationPath = [...aPath.slice(0, -2), 'markDefs', {_key: aValue._key}]
+      const annotationPath = [...aPath.slice(0, -2), 'markDefs', {_key: annotation._key}]
       const sanitySchemaType = getSanitySubSchema(
         schemaTypes.portableText,
         editor.getSnapshot().context.value,
         annotationPath,
-      ).annotations.find((t) => t.name === aSchemaType.name)
+      ).annotations.find((t) => t.name === annotation._type)
       if (!sanitySchemaType) {
         // This should never happen
-        throw new Error(`Could not find Sanity schema type for annotation: ${aSchemaType.name}`)
+        throw new Error(`Could not find Sanity schema type for annotation: ${annotation._type}`)
       }
       return (
         <Annotation
@@ -432,7 +427,7 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
           schemaType={sanitySchemaType}
           selected={selected}
           setElementRef={setElementRef}
-          value={aValue}
+          value={annotation}
         >
           {children}
         </Annotation>
@@ -460,6 +455,26 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       editor,
     ],
   )
+
+  // Stable reference: `NodePlugin` re-runs its registration effect when
+  // `nodes` changes by reference.
+  const catchAllNodes = useMemo<RegistrableNode[]>(
+    () => [
+      defineTextBlock({type: '*', render: renderTextBlock}),
+      defineBlockObject({type: '*', render: renderBlockObject}),
+      defineInlineObject({type: '*', render: renderInlineObject}),
+      defineDecorator({type: '*', render: renderDecorator}),
+      defineAnnotation({type: '*', render: editorRenderAnnotation}),
+    ],
+    [
+      renderTextBlock,
+      renderBlockObject,
+      renderInlineObject,
+      renderDecorator,
+      editorRenderAnnotation,
+    ],
+  )
+
   const ariaDescribedBy = elementProps['aria-describedby']
 
   // Create an initial editor selection based on the focusPath
@@ -516,7 +531,6 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
             path={path}
             rangeDecorations={rangeDecorations}
             readOnly={readOnly}
-            renderAnnotation={editorRenderAnnotation}
             setPortalElement={setPortalElement}
             scrollElement={scrollElement}
             setScrollElement={setScrollElement}
@@ -546,7 +560,6 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
       handleToggleFullscreen,
       path,
       rangeDecorations,
-      editorRenderAnnotation,
       scrollElement,
     ],
   )

--- a/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Editor.tsx
@@ -1,5 +1,4 @@
 import {
-  type BlockDecoratorRenderProps,
   type EditorSelection,
   type HotkeyOptions,
   type OnCopyFn,
@@ -7,7 +6,6 @@ import {
   PortableTextEditable,
   type PortableTextEditableProps,
   type RangeDecoration,
-  type RenderAnnotationFunction,
 } from '@portabletext/editor'
 import {type Path} from '@sanity/types'
 import {BoundaryElementProvider, useBoundaryElement, useGlobalKeyDown, useLayer} from '@sanity/ui'
@@ -21,7 +19,6 @@ import {useFormBuilder} from '../../useFormBuilder'
 import {EditableCard, EditableWrapper, Root, Scroller, ToolbarCard} from './Editor.styles'
 import {useScrollSelectionIntoView} from './hooks/useScrollSelectionIntoView'
 import {useSpellCheck} from './hooks/useSpellCheck'
-import {Decorator} from './text/Decorator'
 import {Toolbar} from './toolbar/Toolbar'
 
 const noOutlineStyle = {outline: 'none'} as const
@@ -52,8 +49,6 @@ interface EditorProps {
   path: Path
   readOnly?: boolean
   rangeDecorations?: RangeDecoration[]
-  // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-  renderAnnotation: RenderAnnotationFunction
   scrollElement: HTMLElement | null
   setPortalElement?: (portalElement: HTMLDivElement | null) => void
   setScrollElement: (scrollElement: HTMLElement | null) => void
@@ -79,7 +74,6 @@ export function Editor(props: EditorProps): ReactNode {
     path,
     readOnly,
     rangeDecorations,
-    renderAnnotation,
     scrollElement,
     setPortalElement,
     setScrollElement,
@@ -116,10 +110,6 @@ export function Editor(props: EditorProps): ReactNode {
     [t],
   )
   const spellCheck = useSpellCheck()
-  // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-  const renderDecorator = useCallback((decoratorProps: BlockDecoratorRenderProps) => {
-    return <Decorator {...decoratorProps} />
-  }, [])
 
   const scrollSelectionIntoView = useScrollSelectionIntoView(scrollElement)
 
@@ -131,10 +121,6 @@ export function Editor(props: EditorProps): ReactNode {
       onPaste,
       rangeDecorations,
       'ref': elementRef,
-      // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-      renderAnnotation,
-      // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-      renderDecorator,
       renderPlaceholder,
       scrollSelectionIntoView,
       'selection': initialSelection,
@@ -151,8 +137,6 @@ export function Editor(props: EditorProps): ReactNode {
     onCopy,
     onPaste,
     rangeDecorations,
-    renderAnnotation,
-    renderDecorator,
     renderPlaceholder,
     scrollSelectionIntoView,
     spellCheck,

--- a/packages/sanity/src/core/form/inputs/PortableText/text/Decorator.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/text/Decorator.tsx
@@ -1,4 +1,4 @@
-import {type BlockDecoratorRenderProps} from '@portabletext/editor'
+import {type DecoratorRenderProps} from '@portabletext/editor'
 import {type Theme} from '@sanity/ui'
 import {useCallback, useMemo} from 'react'
 import {css, styled} from 'styled-components'
@@ -21,26 +21,25 @@ const Root = styled.span(({theme}: {theme: Theme}) => {
   `
 })
 
-// oxlint-disable-next-line no-deprecated -- will fix in follow up PR
-export function Decorator(props: BlockDecoratorRenderProps) {
-  const {value, focused, selected, children, schemaType} = props
+export function Decorator(props: DecoratorRenderProps) {
+  const {decorator, focused, selected, children} = props
   const schemaTypes = usePortableTextMemberSchemaTypes()
-  const sanitySchemaType = schemaTypes.decorators.find((type) => type.value === schemaType.name)
+  const sanitySchemaType = schemaTypes.decorators.find((type) => type.value === decorator)
   if (!sanitySchemaType) {
     // This should never happen
-    throw new Error(`Could not find Sanity schema type for decorator: ${schemaType.name}`)
+    throw new Error(`Could not find Sanity schema type for decorator: ${decorator}`)
   }
-  const tag = TEXT_DECORATOR_TAGS[value]
+  const tag = TEXT_DECORATOR_TAGS[decorator]
   const CustomComponent = sanitySchemaType.component
   const DefaultComponent = useCallback(
     (defaultComponentProps: BlockDecoratorProps) => {
       return (
-        <Root as={tag} data-mark={value}>
+        <Root as={tag} data-mark={decorator}>
           {defaultComponentProps.children}
         </Root>
       )
     },
-    [tag, value],
+    [decorator, tag],
   )
   return useMemo(() => {
     const componentProps = {
@@ -49,7 +48,7 @@ export function Decorator(props: BlockDecoratorRenderProps) {
       schemaType: sanitySchemaType,
       selected,
       title: sanitySchemaType.title,
-      value,
+      value: decorator,
     }
     return CustomComponent ? (
       <CustomComponent {...componentProps}>{children}</CustomComponent>
@@ -57,5 +56,5 @@ export function Decorator(props: BlockDecoratorRenderProps) {
       // oxlint-disable-next-line react/static-components -- this is intentional and how the middleware components has to work
       <DefaultComponent {...componentProps}>{children}</DefaultComponent>
     )
-  }, [CustomComponent, DefaultComponent, children, focused, sanitySchemaType, selected, value])
+  }, [CustomComponent, DefaultComponent, children, decorator, focused, sanitySchemaType, selected])
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

#14183 silenced oxlint `no-deprecated` errors for the remaining Portable Text `renderDecorator` / `renderAnnotation` props after `@portabletext/editor` 7.12 deprecated them. Leaving those props in place would keep re-accumulating suppressions, and the editor already registers text blocks, block objects, and inline objects through `NodePlugin`.

Catch-all `defineDecorator({type: '*'})` / `defineAnnotation({type: '*'})` is the smallest equivalent of the previous switching callbacks. Per-type registrations would duplicate Studio’s schema-driven lookup (`getSanitySubSchema`, custom decorator components) without changing what actually renders.

### What to review

- `packages/sanity` Portable Text compositor: decorator and annotation registrations on the existing `NodePlugin`
- `Decorator` now types against `DecoratorRenderProps` (`decorator` instead of `value` / `schemaType`)
- Studio’s public `renderAnnotation` / `components.annotation` / `components.decorator` callbacks are unchanged

### Testing

Chromium vitest browser tests for the migrated paths (7/7 passed):

- `Decorators.browser.test.tsx`: default decorator keyboard shortcuts (`data-mark` markup), toolbar buttons, custom decorator icon
- `Annotations.browser.test.tsx`: create/edit link, reopen existing annotation, fullscreen annotation edit, combined popover for overlapping annotations

Type-aware oxlint on the three touched files: no remaining `no-deprecated` findings for these render props.

### Notes for release

N/A – Internal only. Studio’s public decorator and annotation component APIs are unchanged.

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-557d1855-1ac6-4993-ba91-8660217d3682?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-557d1855-1ac6-4993-ba91-8660217d3682&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

