### PR TITLE
fix(core): restore version pill labels and require remove copy

### DIFF
--- a/packages/sanity/src/core/variants/plugin/components/PerspectiveFilter.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/PerspectiveFilter.tsx
@@ -12,8 +12,12 @@ interface PerspectiveFilterProps {
   tone: CardTone
   /** The filter's main control — a single button that opens the filter's menu. */
   children: ReactNode
-  /** When set, the pill gains a remove segment that clears just this filter. */
+  /**
+   * When set with `removeLabel`, the pill gains a remove segment that clears just this filter.
+   * Both must be provided; an icon-only control is not rendered without an accessible label.
+   */
   onRemove?: () => void
+  /** Tooltip and accessible name for the remove segment. Required when `onRemove` is set. */
   removeLabel?: string
   label?: string
 }
@@ -40,18 +44,19 @@ export function PerspectiveFilter({
       <Card tone={tone} radius={2} border>
         <Flex align="center">
           {label ? <AnimatedTextWidth text={label}>{children}</AnimatedTextWidth> : children}
-          {onRemove && (
+          {onRemove && removeLabel ? (
             <>
               <div className={SegmentDivider} />
               <Button
+                aria-label={removeLabel}
                 data-testid="perspective-filter-remove"
                 icon={RemoveIcon}
                 mode="bleed"
                 onClick={onRemove}
-                tooltipProps={removeLabel ? {content: removeLabel} : null}
+                tooltipProps={{content: removeLabel}}
               />
             </>
-          )}
+          ) : null}
         </Flex>
       </Card>
     </Flex>

--- a/packages/sanity/src/core/variants/plugin/components/VariantsStudioNavbar.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/VariantsStudioNavbar.tsx
@@ -13,13 +13,13 @@ import {usePerspective} from '../../../perspective/usePerspective'
 import {useSetPerspective} from '../../../perspective/useSetPerspective'
 import {useSetVariant} from '../../../perspective/useSetVariant'
 import {ReleaseAvatarIcon} from '../../../releases/components/ReleaseAvatar'
-import {isReleaseDocument} from '../../../releases/store/types'
 import {getReleaseTone} from '../../../releases/util/getReleaseTone'
-import {isDraftPerspective, isPublishedPerspective} from '../../../releases/util/util'
 import {useReleasesToolAvailable} from '../../../schedules/hooks/useReleasesToolAvailable'
+import {useAgentBundles} from '../../../store/agent/useAgentBundles'
 import {useWorkspace} from '../../../studio/workspace'
 import {variantsLocaleNamespace} from '../../i18n'
 import {getVariantTitle} from '../../tool/util'
+import {getVersionFilterLabel} from './getVersionFilterLabel'
 import {PerspectiveFilter} from './PerspectiveFilter'
 import {VariantsMenu} from './VariantsMenu'
 
@@ -35,15 +35,12 @@ export function VariantsStudioNavbar(props: NavbarProps) {
   const hasVariantSelection = Boolean(router.stickyParams.variant)
   const defaultPerspective = useGetDefaultPerspective()
   const hasVersionSelection = selectedPerspective !== defaultPerspective
+  const {bundles} = useAgentBundles()
 
-  const versionLabel = useMemo(() => {
-    if (isPublishedPerspective(selectedPerspective)) return coreT('release.chip.published')
-    if (isDraftPerspective(selectedPerspective)) return coreT('release.chip.draft')
-    if (isReleaseDocument(selectedPerspective)) {
-      return selectedPerspective.metadata?.title ?? coreT('release.placeholder-untitled-release')
-    }
-    return String(selectedPerspective)
-  }, [selectedPerspective, coreT])
+  const versionTitle = useMemo(
+    () => getVersionFilterLabel(selectedPerspective, coreT, bundles),
+    [selectedPerspective, coreT, bundles],
+  )
 
   const variantLabel = selectedVariant
     ? getVariantTitle(selectedVariant)
@@ -72,7 +69,7 @@ export function VariantsStudioNavbar(props: NavbarProps) {
             tone={getReleaseTone(selectedPerspective)}
             onRemove={hasVersionSelection ? handleClearVersion : undefined}
             removeLabel={t('navbar.version.clear')}
-            label={versionLabel}
+            label={versionTitle.displayTitle}
           >
             <GlobalPerspectiveMenu
               selectedPerspectiveName={selectedPerspectiveName}
@@ -83,7 +80,10 @@ export function VariantsStudioNavbar(props: NavbarProps) {
                   icon={<ReleaseAvatarIcon release={selectedPerspective} />}
                   iconRight={ChevronDownIcon}
                   mode="bleed"
-                  text={versionLabel}
+                  text={versionTitle.displayTitle}
+                  tooltipProps={
+                    versionTitle.isTruncated ? {content: versionTitle.fullTitle} : undefined
+                  }
                 />
               }
             />

--- a/packages/sanity/src/core/variants/plugin/components/__tests__/PerspectiveFilter.test.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/__tests__/PerspectiveFilter.test.tsx
@@ -1,0 +1,36 @@
+import {render, screen} from '@testing-library/react'
+import {describe, expect, it} from 'vitest'
+
+import {createTestProvider} from '../../../../../../test/testUtils/TestProvider'
+import {PerspectiveFilter} from '../PerspectiveFilter'
+
+describe('PerspectiveFilter', () => {
+  it('does not render the remove control without an accessible label', async () => {
+    const wrapper = await createTestProvider()
+    render(
+      <PerspectiveFilter prefix="Version" tone="default" onRemove={() => {}}>
+        <button type="button">Draft</button>
+      </PerspectiveFilter>,
+      {wrapper},
+    )
+
+    expect(screen.queryByTestId('perspective-filter-remove')).not.toBeInTheDocument()
+  })
+
+  it('exposes the remove control by its accessible name', async () => {
+    const wrapper = await createTestProvider()
+    render(
+      <PerspectiveFilter
+        prefix="Version"
+        tone="default"
+        onRemove={() => {}}
+        removeLabel="Clear version selection"
+      >
+        <button type="button">Draft</button>
+      </PerspectiveFilter>,
+      {wrapper},
+    )
+
+    expect(screen.getByRole('button', {name: 'Clear version selection'})).toBeInTheDocument()
+  })
+})

--- a/packages/sanity/src/core/variants/plugin/components/__tests__/VariantsStudioNavbar.test.tsx
+++ b/packages/sanity/src/core/variants/plugin/components/__tests__/VariantsStudioNavbar.test.tsx
@@ -29,6 +29,10 @@ vi.mock('../../../../perspective/usePerspective', () => ({
   usePerspective: vi.fn(() => usePerspectiveMockReturn),
 }))
 
+vi.mock('../../../../store/agent/useAgentBundles', () => ({
+  useAgentBundles: vi.fn(() => ({bundles: [], loading: false})),
+}))
+
 vi.mock('../../../../perspective/navbar/GlobalPerspectiveMenu', () => ({
   GlobalPerspectiveMenu: () => <div data-testid="global-perspective-menu" />,
 }))
@@ -76,7 +80,7 @@ describe('VariantsStudioNavbar', () => {
     await renderNavbar()
 
     expect(
-      within(getFilter('Version')).getByTestId('perspective-filter-remove'),
+      within(getFilter('Version')).getByRole('button', {name: 'Clear version selection'}),
     ).toBeInTheDocument()
     expect(
       within(getFilter('Variant')).queryByTestId('perspective-filter-remove'),
@@ -92,7 +96,7 @@ describe('VariantsStudioNavbar', () => {
       within(getFilter('Version')).queryByTestId('perspective-filter-remove'),
     ).not.toBeInTheDocument()
     expect(
-      within(getFilter('Variant')).getByTestId('perspective-filter-remove'),
+      within(getFilter('Variant')).getByRole('button', {name: 'Clear variant selection'}),
     ).toBeInTheDocument()
   })
 
@@ -102,7 +106,7 @@ describe('VariantsStudioNavbar', () => {
     await renderNavbar()
 
     expect(
-      within(getFilter('Variant')).getByTestId('perspective-filter-remove'),
+      within(getFilter('Variant')).getByRole('button', {name: 'Clear variant selection'}),
     ).toBeInTheDocument()
   })
 

--- a/packages/sanity/src/core/variants/plugin/components/__tests__/getVersionFilterLabel.test.ts
+++ b/packages/sanity/src/core/variants/plugin/components/__tests__/getVersionFilterLabel.test.ts
@@ -1,0 +1,73 @@
+import {describe, expect, it} from 'vitest'
+
+import {type TFunction} from '../../../../i18n/types'
+import {activeASAPRelease} from '../../../../releases/__fixtures__/release.fixture'
+import {getVersionFilterLabel} from '../getVersionFilterLabel'
+
+const LABELS = {
+  'release.chip.published': 'Published',
+  'release.chip.draft': 'Draft',
+  'release.placeholder-untitled-release': 'Untitled release',
+  'version.agent-bundle.proposed-changes': 'Proposed changes',
+  'version.agent-bundle.agent-changes': 'Agent changes',
+} as const
+
+const t = ((key: string) => LABELS[key as keyof typeof LABELS] ?? key) as unknown as TFunction
+
+describe('getVersionFilterLabel', () => {
+  it('returns published and draft chip copy', () => {
+    expect(getVersionFilterLabel('published', t, [])).toEqual({
+      displayTitle: 'Published',
+      fullTitle: 'Published',
+      isTruncated: false,
+    })
+    expect(getVersionFilterLabel('drafts', t, [])).toEqual({
+      displayTitle: 'Draft',
+      fullTitle: 'Draft',
+      isTruncated: false,
+    })
+  })
+
+  it('truncates long release titles and keeps the full title', () => {
+    const longTitle = 'A'.repeat(60)
+    const result = getVersionFilterLabel(
+      {...activeASAPRelease, metadata: {...activeASAPRelease.metadata, title: longTitle}},
+      t,
+      [],
+    )
+
+    expect(result.isTruncated).toBe(true)
+    expect(result.fullTitle).toBe(longTitle)
+    expect(result.displayTitle).toBe(`${'A'.repeat(50)}\u2026`)
+  })
+
+  it('falls back to untitled copy when a release has no title', () => {
+    expect(
+      getVersionFilterLabel(
+        {...activeASAPRelease, metadata: {...activeASAPRelease.metadata, title: ''}},
+        t,
+        [],
+      ),
+    ).toEqual({
+      displayTitle: 'Untitled release',
+      fullTitle: 'Untitled release',
+      isTruncated: false,
+    })
+  })
+
+  it('labels the current user agent bundle as proposed changes', () => {
+    expect(getVersionFilterLabel('agent-mine', t, [{id: 'agent-mine'}])).toEqual({
+      displayTitle: 'Proposed changes',
+      fullTitle: 'Proposed changes',
+      isTruncated: false,
+    })
+  })
+
+  it('labels other agent bundles as agent changes', () => {
+    expect(getVersionFilterLabel('agent-other', t, [{id: 'agent-mine'}])).toEqual({
+      displayTitle: 'Agent changes',
+      fullTitle: 'Agent changes',
+      isTruncated: false,
+    })
+  })
+})

--- a/packages/sanity/src/core/variants/plugin/components/getVersionFilterLabel.ts
+++ b/packages/sanity/src/core/variants/plugin/components/getVersionFilterLabel.ts
@@ -1,0 +1,47 @@
+import {type TFunction} from '../../../i18n/types'
+import {type TargetPerspective} from '../../../perspective/types'
+import {isReleaseDocument} from '../../../releases/store/types'
+import {getReleaseTitleDetails} from '../../../releases/util/getReleaseTitleDetails'
+import {isDraftPerspective, isPublishedPerspective} from '../../../releases/util/util'
+import {isAgentBundleName} from '../../../store/agent/createAgentBundlesStore'
+
+/**
+ * Display copy for the version filter pill. Mirrors `CurrentGlobalPerspectiveLabel`
+ * so agent bundles keep proposed/agent-changes titles and long release names stay truncated.
+ *
+ * @internal
+ */
+export function getVersionFilterLabel(
+  selectedPerspective: TargetPerspective,
+  t: TFunction,
+  ownBundles: readonly {id: string}[],
+): {displayTitle: string; fullTitle: string; isTruncated: boolean} {
+  if (isPublishedPerspective(selectedPerspective)) {
+    const title = t('release.chip.published')
+    return {displayTitle: title, fullTitle: title, isTruncated: false}
+  }
+
+  if (isDraftPerspective(selectedPerspective)) {
+    const title = t('release.chip.draft')
+    return {displayTitle: title, fullTitle: title, isTruncated: false}
+  }
+
+  if (isReleaseDocument(selectedPerspective)) {
+    return getReleaseTitleDetails(
+      selectedPerspective.metadata?.title,
+      t('release.placeholder-untitled-release'),
+    )
+  }
+
+  if (isAgentBundleName(selectedPerspective)) {
+    const title = t(
+      ownBundles.some((bundle) => bundle.id === selectedPerspective)
+        ? 'version.agent-bundle.proposed-changes'
+        : 'version.agent-bundle.agent-changes',
+    )
+    return {displayTitle: title, fullTitle: title, isTruncated: false}
+  }
+
+  const title = String(selectedPerspective)
+  return {displayTitle: title, fullTitle: title, isTruncated: false}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Review follow-up for https://github.com/sanity-io/sanity/pull/14176.

The version pill only knew drafts, published, and raw release titles, so an agent-bundle perspective rendered as an id and long release names were no longer truncated. Label generation now matches `CurrentGlobalPerspectiveLabel`: proposed/agent-changes copy for bundles, and `getReleaseTitleDetails` for release titles (with a tooltip when truncated).

The remove segment no longer renders as an unlabeled icon-only button: it is omitted unless `removeLabel` is set, and that string is used for both the tooltip and `aria-label`.

Clear-all is not restored. Pedro already removed it in favor of per-filter remove; the parent PR description should say that instead of claiming a disabled clear-all control.

### What to review

Package: `sanity` (core).

- `getVersionFilterLabel.ts` — agent-bundle vs release vs system labels
- `PerspectiveFilter.tsx` — remove control gated on `removeLabel`

### Testing

Unit tests for `getVersionFilterLabel` (agent bundles, truncation, untitled fallback) and `PerspectiveFilter` (no remove without a label; accessible name when present). Navbar tests now query remove by accessible name.

### Notes for release

N/A – Part of the perspective bar redesign (SAPP-4097), behind the variants beta flag.

---

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97cd8d48-1609-4a76-8b71-1386801b5e97?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97cd8d48-1609-4a76-8b71-1386801b5e97&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

