### PR TITLE
fix(search): exclude agent versions from raw perspective results

### DIFF
--- a/packages/sanity/src/core/search/common/excludeAgentVersionsFilter.test.ts
+++ b/packages/sanity/src/core/search/common/excludeAgentVersionsFilter.test.ts
@@ -1,0 +1,29 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+  EXCLUDE_AGENT_VERSIONS_GROQ,
+  getExcludeAgentVersionsFilter,
+} from './excludeAgentVersionsFilter'
+
+describe('getExcludeAgentVersionsFilter', () => {
+  it('returns the agent-version exclusion when perspective is raw', () => {
+    expect(getExcludeAgentVersionsFilter('raw')).toBe(EXCLUDE_AGENT_VERSIONS_GROQ)
+  })
+
+  it('returns the agent-version exclusion when raw is in a perspective stack', () => {
+    expect(getExcludeAgentVersionsFilter(['raw'])).toBe(EXCLUDE_AGENT_VERSIONS_GROQ)
+  })
+
+  it('does not exclude agent versions for published, drafts, or release perspectives', () => {
+    expect(getExcludeAgentVersionsFilter(undefined)).toBeUndefined()
+    expect(getExcludeAgentVersionsFilter('published')).toBeUndefined()
+    expect(getExcludeAgentVersionsFilter('drafts')).toBeUndefined()
+    expect(getExcludeAgentVersionsFilter(['rSummer', 'drafts'])).toBeUndefined()
+  })
+
+  it('matches path-based and opaque agent version ids', () => {
+    expect(EXCLUDE_AGENT_VERSIONS_GROQ).toContain('versions.agent-')
+    expect(EXCLUDE_AGENT_VERSIONS_GROQ).toContain('_system.bundleId')
+    expect(EXCLUDE_AGENT_VERSIONS_GROQ).toContain('agent-')
+  })
+})

--- a/packages/sanity/src/core/search/common/excludeAgentVersionsFilter.ts
+++ b/packages/sanity/src/core/search/common/excludeAgentVersionsFilter.ts
@@ -1,0 +1,39 @@
+import {type ClientPerspective} from '@sanity/client'
+
+import {AGENT_BUNDLE_PREFIX} from '../../store/agent/createAgentBundlesStore'
+import {VERSION_FOLDER} from '../../util/draftUtils'
+
+const AGENT_VERSION_ID_PREFIX = `${VERSION_FOLDER}.${AGENT_BUNDLE_PREFIX}`
+
+/**
+ * GROQ clause that matches Content Agent version documents: path-based ids
+ * (`versions.agent-*.<id>`) and opaque ids that carry an agent `_system.bundleId`.
+ */
+const IS_AGENT_VERSION_GROQ = `(string::startsWith(_id, "${AGENT_VERSION_ID_PREFIX}") || string::startsWith(_system.bundleId, "${AGENT_BUNDLE_PREFIX}"))`
+
+/**
+ * Filter used when searching with `perspective: 'raw'` so agent versions do not
+ * appear as duplicate, often inaccessible hits.
+ *
+ * @internal
+ */
+export const EXCLUDE_AGENT_VERSIONS_GROQ = `!${IS_AGENT_VERSION_GROQ}`
+
+/**
+ * Agent versions are only readable by their author. `perspective: 'raw'` still
+ * returns them as distinct hits, which show up as duplicate empty documents for
+ * everyone else. Searching while an agent bundle is selected is unaffected:
+ * that perspective rewrites `_id` to the published id, so this filter does not
+ * apply.
+ *
+ * @internal
+ */
+export function getExcludeAgentVersionsFilter(
+  perspective: ClientPerspective | undefined,
+): string | undefined {
+  if (perspective === 'raw') return EXCLUDE_AGENT_VERSIONS_GROQ
+  if (Array.isArray(perspective) && perspective.includes('raw')) {
+    return EXCLUDE_AGENT_VERSIONS_GROQ
+  }
+  return undefined
+}

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.test.ts
@@ -2,6 +2,7 @@ import {Schema} from '@sanity/schema'
 import {defineArrayMember, defineField, defineType} from '@sanity/types'
 import {describe, expect, it} from 'vitest'
 
+import {EXCLUDE_AGENT_VERSIONS_GROQ} from '../common/excludeAgentVersionsFilter'
 import {DEFAULT_LIMIT} from '../weighted/createSearchQuery'
 import {createSearchQuery} from './createSearchQuery'
 
@@ -181,6 +182,59 @@ describe('createSearchQuery', () => {
 
       expect(query).toContain('*[_type in $__types && (randomCondition == $customParam)]')
       expect(params.customParam).toEqual('custom')
+    })
+
+    it('should exclude agent versions when perspective is raw', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
+      const {query} = createSearchQuery(
+        {
+          query: 'term',
+          types: [testType],
+        },
+        '',
+        {perspective: 'raw'},
+      )
+
+      expect(query).toContain(EXCLUDE_AGENT_VERSIONS_GROQ)
+    })
+
+    it('should not exclude agent versions when perspective is not raw', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
+      const {query} = createSearchQuery(
+        {
+          query: 'term',
+          types: [testType],
+        },
+        '',
+        {perspective: ['rSummer', 'drafts']},
+      )
+
+      expect(query).not.toContain(EXCLUDE_AGENT_VERSIONS_GROQ)
+    })
+
+    it('should AND agent-version exclusion with an existing filter when perspective is raw', () => {
+      const testType = Schema.compile({
+        types: schemaTypes,
+      }).get('basic-schema-test')
+
+      const {query} = createSearchQuery(
+        {
+          query: 'term',
+          types: [testType],
+        },
+        '',
+        {filter: 'randomCondition == $customParam', perspective: 'raw'},
+      )
+
+      expect(query).toContain(
+        `*[_type in $__types && ${EXCLUDE_AGENT_VERSIONS_GROQ} && (randomCondition == $customParam)]`,
+      )
     })
 
     it('should use configured tag', () => {

--- a/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/groq2024/createSearchQuery.ts
@@ -8,6 +8,7 @@ import groupBy from 'lodash-es/groupBy.js'
 
 import {compileSortExpression, type CompiledSortEntry} from '../common/compileSortExpression'
 import {deriveSearchWeightsFromType2024} from '../common/deriveSearchWeightsFromType2024'
+import {getExcludeAgentVersionsFilter} from '../common/excludeAgentVersionsFilter'
 import {prefixLast} from '../common/token'
 import {toOrderClause} from '../common/toOrderClause'
 import {
@@ -135,11 +136,13 @@ export function createSearchQuery(
   // Unscored has no `[_score > 0]` gate, so the reference match must live in the
   // filter for documents found only through a referenced leaf to surface.
   const unscoredMatch = hasReferenceIds ? `(${baseMatch} || references($__refIds))` : baseMatch
+  const excludeAgentVersions = getExcludeAgentVersionsFilter(perspective)
 
   const filters: string[] = [
     '_type in $__types',
     // If the search request doesn't use scoring, directly filter documents.
     isScored ? [] : unscoredMatch,
+    excludeAgentVersions ?? [],
     filter ? `(${filter})` : [],
     searchTerms.filter ? `(${searchTerms.filter})` : [],
     cursor ?? [],

--- a/packages/sanity/src/core/search/weighted/createSearchQuery.test.ts
+++ b/packages/sanity/src/core/search/weighted/createSearchQuery.test.ts
@@ -2,6 +2,7 @@ import {Schema} from '@sanity/schema'
 import {defineArrayMember, defineField, defineType} from '@sanity/types'
 import {describe, expect, it, test} from 'vitest'
 
+import {EXCLUDE_AGENT_VERSIONS_GROQ} from '../common/excludeAgentVersionsFilter'
 import {FINDABILITY_MVI} from '../constants'
 import {
   createSearchQuery,
@@ -325,6 +326,44 @@ describe('createSearchQuery', () => {
         '*[_type in $__types && (_id match $t0 || _type match $t0 || title match $t0) && (randomCondition == $customParam)]',
       )
       expect(params.customParam).toEqual('custom')
+    })
+
+    it('should exclude agent versions when perspective is raw', () => {
+      const {query} = createSearchQuery(
+        {
+          query: 'term',
+          types: [testType],
+        },
+        {perspective: 'raw'},
+      )
+
+      expect(query).toContain(EXCLUDE_AGENT_VERSIONS_GROQ)
+    })
+
+    it('should not exclude agent versions when perspective is not raw', () => {
+      const {query} = createSearchQuery(
+        {
+          query: 'term',
+          types: [testType],
+        },
+        {perspective: ['rSummer', 'drafts']},
+      )
+
+      expect(query).not.toContain(EXCLUDE_AGENT_VERSIONS_GROQ)
+    })
+
+    it('should AND agent-version exclusion with an existing filter when perspective is raw', () => {
+      const {query} = createSearchQuery(
+        {
+          query: 'term',
+          types: [testType],
+        },
+        {filter: 'randomCondition == $customParam', perspective: 'raw'},
+      )
+
+      expect(query).toContain(
+        `*[_type in $__types && (_id match $t0 || _type match $t0 || title match $t0) && ${EXCLUDE_AGENT_VERSIONS_GROQ} && (randomCondition == $customParam)]`,
+      )
     })
 
     it('should add configured common limit', () => {

--- a/packages/sanity/src/core/search/weighted/createSearchQuery.ts
+++ b/packages/sanity/src/core/search/weighted/createSearchQuery.ts
@@ -11,6 +11,7 @@ import words from 'lodash-es/words.js'
 
 import {compileSortExpression} from '../common/compileSortExpression'
 import {deriveSearchWeightsFromType} from '../common/deriveSearchWeightsFromType'
+import {getExcludeAgentVersionsFilter} from '../common/excludeAgentVersionsFilter'
 import {toOrderClause} from '../common/toOrderClause'
 import {
   ORDERINGS_PROJECTION_KEY,
@@ -138,6 +139,7 @@ export function createSearchQuery(
   const filters = [
     '_type in $__types',
     ...createConstraints(terms, specs),
+    getExcludeAgentVersionsFilter(perspective) ?? '',
     filter ? `(${filter})` : '',
     searchTerms.filter ? `(${searchTerms.filter})` : '',
   ].filter(Boolean)

--- a/packages/sanity/src/core/store/agent/createAgentBundlesStore.ts
+++ b/packages/sanity/src/core/store/agent/createAgentBundlesStore.ts
@@ -13,7 +13,8 @@ import {
   switchMap,
 } from 'rxjs'
 
-const AGENT_BUNDLE_PREFIX = 'agent-'
+/** @internal */
+export const AGENT_BUNDLE_PREFIX = 'agent-'
 
 /**
  * A single active agent bundle as reported by the SSE endpoint.

--- a/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/search/contexts/search/SearchProvider.tsx
@@ -233,6 +233,9 @@ export function SearchProvider({
           skipSortByScore: ordering.ignoreScore,
           ...(ordering.sort ? {sort: [ordering.sort]} : {}),
           cursor: cursor || undefined,
+          // Raw so drafts, published, and release versions are all findable.
+          // Agent versions are dropped in the search GROQ — they are only
+          // readable by their author and otherwise appear as empty duplicates.
           perspective: 'raw',
         },
         terms: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Global search uses `perspective=raw` so drafts, published docs, and release versions are all findable. That also returns Content Agent versions (`versions.agent-*` and opaque ids with an agent `_system.bundleId`). Those versions are only readable by their author, so everyone else gets duplicate hits that open an empty document.

This filters agent versions out of both groq2024 and weighted search whenever the perspective is `raw`. Searching while an agent bundle is selected is unchanged: that perspective rewrites `_id` to the published id, so the filter does not apply.

Keeping the current user's own agent versions was considered and rejected: they still duplicate the published/draft article in global search, and wiring ownership through the agent-bundles SSE would re-run search as bundles load. Authors can still open proposed changes from the document itself.

Fixes [SAPP-3895](https://linear.app/sanity/issue/SAPP-3895/search-shows-duplicate-inaccessible-agent-documents)

### What to review

- `getExcludeAgentVersionsFilter` and that it only applies for `perspective: 'raw'`
- Both search strategies (`groq2024` and weighted) AND the filter with existing constraints
- Whether excluding *all* agent versions from raw search is the right call vs keeping the author's

### Testing

Unit tests cover the filter helper and both `createSearchQuery` builders: raw perspective excludes agent versions, other perspectives do not, and an existing `filter` is still AND-ed.

### Notes for release

Studio search no longer lists Content Agent document versions when querying across all versions. Those versions were often duplicates of the real article and opened as empty documents for anyone who was not the author.

---
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab025f7c-145c-4381-a166-85fca572410d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab025f7c-145c-4381-a166-85fca572410d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

