### PR TITLE
fix: defer workspace menu content mount until interaction

### DIFF
--- a/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/WorkspaceMenuButton.tsx
@@ -32,6 +32,7 @@ export function WorkspaceMenuButton() {
   const {activeWorkspace} = useActiveWorkspace()
   const {t} = useTranslation()
   const [scrollbarWidth, setScrollbarWidth] = useState(0)
+  const [mountMenuContent, setMountMenuContent] = useState(false)
 
   const stackRef = useCallback((node: HTMLDivElement | null) => {
     if (node) {
@@ -43,7 +44,15 @@ export function WorkspaceMenuButton() {
   // Preload probes on hover/focus so the result is already buffered by the
   // time the user clicks. The probe's grace window keeps the cached value
   // alive across the transient subscribe/unsubscribe cycle from `take(1)`.
+  //
+  // This is also where the menu content gets mounted: from @sanity/ui v4,
+  // closed popovers keep their children mounted (React `<Activity>`), which
+  // would put the per-workspace `/auth/id` probes and the project/grants
+  // requests in ManageMenu on the studio boot path. Hover/focus always
+  // precedes the click that opens the menu, so mounting here keeps those
+  // requests deferred to interaction intent without an empty first frame.
   const handlePreload = useCallback(() => {
+    setMountMenuContent(true)
     visibleWorkspaces.forEach((workspace) => {
       probeWorkspaceAuth({
         projectId: workspace.projectId,
@@ -54,6 +63,11 @@ export function WorkspaceMenuButton() {
         .subscribe()
     })
   }, [visibleWorkspaces])
+
+  // Fallback for opens that are not preceded by hover/focus (e.g. Safari does
+  // not focus buttons on click): fires after the popover is shown, so the
+  // content mounts a frame late rather than not at all.
+  const handleOpen = useCallback(() => setMountMenuContent(true), [])
 
   return (
     <MenuButton
@@ -76,10 +90,11 @@ export function WorkspaceMenuButton() {
         </Flex>
       }
       id="workspace-menu"
+      onOpen={handleOpen}
       menu={
         <Menu padding={0} style={{maxWidth: '350px', minWidth: '250px', overflowY: 'hidden'}}>
-          <ManageMenu multipleWorkspaces={visibleWorkspaces.length > 1} />
-          {visibleWorkspaces.length > 1 && (
+          {mountMenuContent && <ManageMenu multipleWorkspaces={visibleWorkspaces.length > 1} />}
+          {mountMenuContent && visibleWorkspaces.length > 1 && (
             <>
               <MenuDivider style={{padding: 0}} />
               <Box paddingTop={2} paddingBottom={1}>

--- a/packages/sanity/src/core/studio/components/navbar/workspace/__tests__/WorkspaceMenuButton.test.tsx
+++ b/packages/sanity/src/core/studio/components/navbar/workspace/__tests__/WorkspaceMenuButton.test.tsx
@@ -1,0 +1,95 @@
+import {LayerProvider, ThemeProvider} from '@sanity/ui'
+import {buildTheme} from '@sanity/ui/theme'
+import {fireEvent, render, screen} from '@testing-library/react'
+import {userEvent} from '@testing-library/user-event'
+import {type ReactNode} from 'react'
+import {NEVER} from 'rxjs'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {type WorkspaceSummary} from '../../../../../config/types'
+import {WorkspaceMenuButton} from '../WorkspaceMenuButton'
+
+const {mockProbeWorkspaceAuth} = vi.hoisted(() => ({
+  mockProbeWorkspaceAuth: vi.fn(),
+}))
+
+vi.mock('../../../../../store/authStore/probeWorkspaceAuth', () => ({
+  probeWorkspaceAuth: mockProbeWorkspaceAuth,
+}))
+vi.mock('../../../../../i18n/hooks/useTranslation', () => ({
+  useTranslation: () => ({t: (key: string) => key}),
+}))
+vi.mock('../ManageMenu', () => ({
+  ManageMenu: () => <div data-testid="manage-menu" />,
+}))
+vi.mock('../WorkspaceMenuItem', () => ({
+  WorkspaceMenuItem: ({workspace}: {workspace: WorkspaceSummary}) => (
+    <div data-testid={`workspace-item-${workspace.name}`} />
+  ),
+}))
+
+const workspaceA = {
+  name: 'workspace-a',
+  title: 'Workspace A',
+  projectId: 'project-a',
+  dataset: 'production',
+} as unknown as WorkspaceSummary
+const workspaceB = {
+  name: 'workspace-b',
+  title: 'Workspace B',
+  projectId: 'project-b',
+  dataset: 'production',
+} as unknown as WorkspaceSummary
+
+vi.mock('../../../../workspaces/useVisibleWorkspaces', () => ({
+  useVisibleWorkspaces: () => ({visibleWorkspaces: [workspaceA, workspaceB]}),
+}))
+vi.mock('../../../../activeWorkspaceMatcher/useActiveWorkspace', () => ({
+  useActiveWorkspace: () => ({activeWorkspace: workspaceA}),
+}))
+
+const theme = buildTheme()
+const wrapper = ({children}: {children: ReactNode}) => (
+  <ThemeProvider theme={theme}>
+    <LayerProvider>{children}</LayerProvider>
+  </ThemeProvider>
+)
+
+describe('WorkspaceMenuButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockProbeWorkspaceAuth.mockReturnValue(NEVER)
+  })
+
+  it('does not mount menu content or probe workspace auth on mount', () => {
+    // From @sanity/ui v4, closed popovers keep their children mounted, which
+    // would put the /auth/id probes and ManageMenu requests on the studio
+    // boot path. The menu content must stay unmounted until interaction.
+    render(<WorkspaceMenuButton />, {wrapper})
+
+    expect(screen.queryByTestId('manage-menu')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('workspace-item-workspace-b')).not.toBeInTheDocument()
+    expect(mockProbeWorkspaceAuth).not.toHaveBeenCalled()
+  })
+
+  it('mounts menu content and preloads auth probes on hover', async () => {
+    render(<WorkspaceMenuButton />, {wrapper})
+
+    await userEvent.hover(screen.getByRole('button', {name: /Workspace A/}))
+
+    expect(await screen.findByTestId('manage-menu')).toBeInTheDocument()
+    expect(await screen.findByTestId('workspace-item-workspace-b')).toBeInTheDocument()
+    expect(mockProbeWorkspaceAuth).toHaveBeenCalledTimes(2)
+  })
+
+  it('mounts menu content when opened without a preceding hover or focus', async () => {
+    // Safari does not focus buttons on click, so the open itself must also
+    // latch the content mount (via MenuButton onOpen).
+    render(<WorkspaceMenuButton />, {wrapper})
+
+    // oxlint-disable-next-line testing-library/prefer-user-event -- userEvent.click emits hover and focus first, which would flip the latch before the open; this test needs a bare click to exercise the onOpen fallback
+    fireEvent.click(screen.getByRole('button', {name: /Workspace A/}))
+
+    expect(await screen.findByTestId('manage-menu')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
### Description

Since the @sanity/ui v4 bump, closed popovers keep their children mounted (React `<Activity>`), so the workspace switcher's per-workspace `/auth/id` probes and ManageMenu's project/grants requests moved onto the studio boot path. The perf bench measured an extra auth round trip before time-to-editable on every load. `@sanity/ui` has no opt-out currently, so the menu content is now gated on a latch that flips on hover/focus of the button (which always precedes the opening click, so no empty first frame) with `onOpen` as a fallback for opens without prior hover/focus (e.g. Safari, which doesn't focus buttons on click).

### What to review

`WorkspaceMenuButton.tsx` in `packages/sanity` — mainly that the two latch triggers cover every way the menu can open.

### Testing

New unit tests assert no menu content or auth probe at mount, mount + probes on hover, and the `onOpen` fallback. Verified with the perf bench: boot-cold auth round trips before editable dropped from 3 to 2 (the remaining duplicate comes from the embedded SDK's own auth bootstrap, tracked separately).

### Notes for release

N/A – Internal only (removes an unnecessary network request during studio startup)

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Navbar-only lazy-mount behavior with a documented Safari fallback; covered by new tests and aimed at reducing startup network work.
> 
> **Overview**
> **Defers workspace switcher menu work off studio boot** after `@sanity/ui` v4 started keeping closed popover children mounted, which pulled `ManageMenu` (project/grants) and per-workspace `/auth/id` probes onto the initial load path.
> 
> `WorkspaceMenuButton` now uses a `mountMenuContent` latch: **hover/focus** on the trigger flips it (same handler as auth preload), and **`MenuButton` `onOpen`** flips it when the menu opens without prior hover/focus (e.g. Safari). `ManageMenu` and the multi-workspace list render only when the latch is true.
> 
> Adds unit tests for no mount/probes at render, mount + probes on hover, and the `onOpen` fallback via a bare click.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c072f94d441ff067f9b45e1cb811911798e004e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->