### PR TITLE
chore(metrics-studio): add workspace icon and dashboard tab icons

### DIFF
--- a/dev/metrics-studio/MetricsStudioIcon.tsx
+++ b/dev/metrics-studio/MetricsStudioIcon.tsx
@@ -1,0 +1,32 @@
+/**
+ * Workspace icon for the Metrics studio, drawn in the SanityMonogram's visual
+ * language (flat #FF5500 square, near-black glyph, full-bleed — the studio's
+ * WorkspacePreviewIcon container applies the corner rounding) but with a
+ * health-pulse line instead of the "S", since the structure pane is literally
+ * titled "Health metrics". Same-family-but-distinct, so it's recognizable as
+ * a Sanity studio yet tells the workspaces apart at a glance.
+ */
+const SANITY_ORANGE = '#FF5500'
+const SANITY_BLACK = '#0D0E12'
+
+export function MetricsStudioIcon() {
+  return (
+    <svg
+      data-sanity-icon="metrics-studio"
+      viewBox="0 0 192 192"
+      width="1em"
+      height="1em"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect width="192" height="192" fill={SANITY_ORANGE} />
+      <path
+        d="M30 111h30l18-54 24 78 18-48 9 24h33"
+        stroke={SANITY_BLACK}
+        strokeWidth="16"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}

--- a/dev/metrics-studio/sanity.config.ts
+++ b/dev/metrics-studio/sanity.config.ts
@@ -1,6 +1,7 @@
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 
+import {MetricsStudioIcon} from './MetricsStudioIcon'
 import {schemaTypes} from './schemaTypes'
 import {comparisonsTool} from './tools/comparisons'
 import {trendsTool} from './tools/trends'
@@ -8,6 +9,7 @@ import {trendsTool} from './tools/trends'
 export default defineConfig({
   name: 'default',
   title: 'Metrics Studio',
+  icon: MetricsStudioIcon,
   projectId: 'mhfozd0z',
   dataset: 'bench',
   // Trends first: it's the dashboard and the studio's default view

--- a/dev/metrics-studio/tools/trends/TrendsTool.tsx
+++ b/dev/metrics-studio/tools/trends/TrendsTool.tsx
@@ -1,10 +1,16 @@
 /// <reference types="vite/client" />
+import {ActivityIcon} from '@sanity/icons/Activity'
+import {BoltIcon} from '@sanity/icons/Bolt'
 import {CheckmarkIcon} from '@sanity/icons/Checkmark'
 import {ChevronDownIcon} from '@sanity/icons/ChevronDown'
+import {ClockIcon} from '@sanity/icons/Clock'
+import {ControlsIcon} from '@sanity/icons/Controls'
+import {DropIcon} from '@sanity/icons/Drop'
 import {EllipsisVerticalIcon} from '@sanity/icons/EllipsisVertical'
 import {HelpCircleIcon} from '@sanity/icons/HelpCircle'
 import {InfoOutlineIcon} from '@sanity/icons/InfoOutline'
 import {LaunchIcon} from '@sanity/icons/Launch'
+import {PackageIcon} from '@sanity/icons/Package'
 import {
   Badge,
   Box,
@@ -26,7 +32,7 @@ import {
 import {Menu, MenuButton, MenuItem} from '@sanity/ui/menu'
 import {Popover} from '@sanity/ui/popover'
 import {ParentSize} from '@visx/responsive'
-import {useEffect, useMemo, useRef, useState} from 'react'
+import {type ComponentType, useEffect, useMemo, useRef, useState} from 'react'
 import {useObservable} from 'react-rx'
 import {catchError, map, of} from 'rxjs'
 import {useDocumentStore} from 'sanity'
@@ -64,6 +70,16 @@ const RANGES = [
   {label: 'Last 90 days', days: 90},
   {label: 'All time', days: null},
 ] as const
+
+/** One glanceable glyph per metric-group tab; titles stay the identifier. */
+const GROUP_ICONS: Record<TrendGroup, ComponentType> = {
+  vitals: ActivityIcon,
+  responsiveness: BoltIcon,
+  load: ClockIcon,
+  bundle: PackageIcon,
+  soak: DropIcon,
+  environment: ControlsIcon,
+}
 
 type DataSource = 'live' | DebugSource
 
@@ -888,6 +904,7 @@ export function TrendsTool() {
                         key={tab.id}
                         id={`group-tab-${tab.id}`}
                         aria-controls={`group-panel-${tab.id}`}
+                        icon={GROUP_ICONS[tab.id]}
                         label={
                           <Flex align="center" gap={2}>
                             <span>{tab.title}</span>


### PR DESCRIPTION
### Description

Adding some icons to the metrics studio.

### What to review
Looks good? Preview here: https://studio-metrics-git-metrics-studio-icons.sanity.dev/

### Testing

### Notes for release

N/A – Internal only

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-only changes in the internal metrics studio dev app; no auth, data, or benchmark logic touched.
> 
> **Overview**
> Adds **visual identity** for the internal Metrics Studio: a custom workspace icon and icons on the Trends dashboard metric-group tabs.
> 
> A new **`MetricsStudioIcon`** SVG matches Sanity’s orange monogram style but uses a health-pulse line instead of the “S”, and it’s registered as the studio **`icon`** in `sanity.config.ts` so workspace switchers can distinguish this studio from others.
> 
> On the **Trends** tool, each metric group tab (vitals, responsiveness, load, bundle, soak, environment) now shows a matching **`@sanity/icons`** glyph via a `GROUP_ICONS` map passed to the tab `icon` prop; tab titles and regression badges are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 583282f804fc9ec34d639b81a88bd8d20266c205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->