### PR TITLE
fix(core): render validation messages on Portable Text table blocks

### DIFF
--- a/dev/test-studio/schema/standard/portableText/customPlugins.tsx
+++ b/dev/test-studio/schema/standard/portableText/customPlugins.tsx
@@ -6,6 +6,7 @@ import {
   defineArrayMember,
   defineField,
   defineType,
+  type PortableTextBlock,
   type PortableTextPluginsProps,
   useFormValue,
 } from 'sanity'
@@ -115,6 +116,19 @@ function RichTableAdoptionPlugins(props: PortableTextPluginsProps) {
   })
 }
 
+// Keyed per table, so toggling one table's header row clears only that
+// table's warning.
+function tablesMustHaveHeaderRow(blocks: PortableTextBlock[] | undefined) {
+  const tables = (blocks?.filter((block) => block._type === 'table') ??
+    []) as (PortableTextBlock & {
+    headerRows?: number
+  })[]
+  const warnings = tables
+    .filter((table) => !table.headerRows)
+    .map((table) => ({message: 'Table has no header row', path: [{_key: table._key}]}))
+  return warnings.length > 0 ? warnings : true
+}
+
 export const customPlugins = defineType({
   name: 'customPlugins',
   title: 'Custom Plugins',
@@ -134,6 +148,7 @@ export const customPlugins = defineType({
       title: 'Container Table',
       description:
         'A defineContainer table (table > row > cell). Images and text blocks live at the root and inside cells. Cell blocks are deliberately narrower than root blocks (styles: normal/quote; decorators: strong/underline; lists: bullet; no annotations), so the toolbar disables the difference while the caret is inside a cell.',
+      validation: (Rule) => Rule.custom(tablesMustHaveHeaderRow).warning(),
       of: [
         defineArrayMember({
           type: 'block',

--- a/packages/sanity/src/_exports/_singletons.ts
+++ b/packages/sanity/src/_exports/_singletons.ts
@@ -96,6 +96,7 @@ export {PaneLayoutContext} from '../_singletons/context/PaneLayoutContext'
 export {PaneRouterContext} from '../_singletons/context/PaneRouterContext'
 export {ParseErrorsContext, type SetParseError} from '../_singletons/context/ParseErrorsContext'
 export {PerspectiveContext} from '../_singletons/context/PerspectiveContext'
+export {PortableTextInputPathContext} from '../_singletons/context/PortableTextInputPathContext'
 export {PortableTextMarkersContext} from '../_singletons/context/PortableTextMarkersContext'
 export {
   type PortableTextEditorElement,

--- a/packages/sanity/src/_singletons/context/PortableTextInputPathContext.ts
+++ b/packages/sanity/src/_singletons/context/PortableTextInputPathContext.ts
@@ -1,0 +1,10 @@
+import type {Path} from '@sanity/types'
+import {createContext} from 'sanity/_createContext'
+
+/**
+ * @internal
+ */
+export const PortableTextInputPathContext = createContext<Path>(
+  'sanity/_singletons/context/portable-text-input-path',
+  [],
+)

--- a/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/Compositor.tsx
@@ -38,6 +38,7 @@ import {type ArrayOfObjectsInputProps, type OnPasteFn} from '../../types/inputPr
 import {pathToAnchorIdent} from '../../utils/pathToAnchorIdent'
 import {UploadTargetCard} from '../files/common/uploadTarget/UploadTargetCard'
 import {ExpandedLayer, Root, StringDiffContainer} from './Compositor.styles'
+import {PortableTextInputPathProvider} from './contexts/PortableTextInputPath'
 import {useSetPortableTextMemberItemElementRef} from './contexts/PortableTextMemberItemElementRefsProvider'
 import {usePortableTextMemberSchemaTypes} from './contexts/PortableTextMemberSchemaTypes'
 import {SelectedAnnotationsProvider} from './contexts/SelectedAnnotationsContext'
@@ -576,43 +577,45 @@ export function Compositor(props: Omit<InputProps, 'schemaType' | 'arrayFunction
   const editorFocused = focused || hasFocusWithin
 
   return (
-    <SelectedAnnotationsProvider>
-      <DndProvider>
-        <ListIndexProvider>
-          <NodePlugin nodes={catchAllNodes} />
-          <PortalProvider __unstable_elements={portalElements} element={portal.element}>
-            <BoundaryElementProvider element={floatingBoundary}>
-              <ActivateOnFocus onActivate={onActivate} isOverlayActive={!isActive}>
-                <ChangeIndicator
-                  disabled={isFullscreen}
-                  hasFocus={Boolean(focused)}
-                  isChanged={changed}
-                  path={path}
-                >
-                  <Root
-                    data-focused={editorFocused ? '' : undefined}
-                    data-read-only={readOnly ? '' : undefined}
+    <PortableTextInputPathProvider path={path}>
+      <SelectedAnnotationsProvider>
+        <DndProvider>
+          <ListIndexProvider>
+            <NodePlugin nodes={catchAllNodes} />
+            <PortalProvider __unstable_elements={portalElements} element={portal.element}>
+              <BoundaryElementProvider element={floatingBoundary}>
+                <ActivateOnFocus onActivate={onActivate} isOverlayActive={!isActive}>
+                  <ChangeIndicator
+                    disabled={isFullscreen}
+                    hasFocus={Boolean(focused)}
+                    isChanged={changed}
+                    path={path}
                   >
-                    <Box data-wrapper="" ref={setWrapperElement}>
-                      <Portal __unstable_name={isFullscreen ? 'expanded' : 'collapsed'}>
-                        {isFullscreen ? <ExpandedLayer>{editorNode}</ExpandedLayer> : editorNode}
-                        <AnnotationObjectEditModal
-                          focused={focused}
-                          onItemClose={onItemClose}
-                          referenceBoundary={scrollElement}
-                        />
-                        <CombinedAnnotationPopover referenceBoundary={scrollElement} />
-                      </Portal>
-                    </Box>
-                    <div data-border="" />
-                  </Root>
-                </ChangeIndicator>
-              </ActivateOnFocus>
-            </BoundaryElementProvider>
-          </PortalProvider>
-        </ListIndexProvider>
-      </DndProvider>
-    </SelectedAnnotationsProvider>
+                    <Root
+                      data-focused={editorFocused ? '' : undefined}
+                      data-read-only={readOnly ? '' : undefined}
+                    >
+                      <Box data-wrapper="" ref={setWrapperElement}>
+                        <Portal __unstable_name={isFullscreen ? 'expanded' : 'collapsed'}>
+                          {isFullscreen ? <ExpandedLayer>{editorNode}</ExpandedLayer> : editorNode}
+                          <AnnotationObjectEditModal
+                            focused={focused}
+                            onItemClose={onItemClose}
+                            referenceBoundary={scrollElement}
+                          />
+                          <CombinedAnnotationPopover referenceBoundary={scrollElement} />
+                        </Portal>
+                      </Box>
+                      <div data-border="" />
+                    </Root>
+                  </ChangeIndicator>
+                </ActivateOnFocus>
+              </BoundaryElementProvider>
+            </PortalProvider>
+          </ListIndexProvider>
+        </DndProvider>
+      </SelectedAnnotationsProvider>
+    </PortableTextInputPathProvider>
   )
 }
 

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/TableBlockValidation.browser.test.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/TableBlockValidation.browser.test.tsx
@@ -1,0 +1,94 @@
+import {type SanityDocument} from '@sanity/types'
+import {describe, expect, it} from 'vitest'
+import {page, userEvent} from 'vitest/browser'
+
+import {testHelpers} from '../../../../../../test/browser/testHelpers'
+import {TableBlockValidationStory} from './TableBlockValidationStory'
+
+const document: SanityDocument = {
+  _id: '123',
+  _type: 'test',
+  _createdAt: new Date().toISOString(),
+  _updatedAt: new Date().toISOString(),
+  _rev: '123',
+  body: [
+    {
+      _type: 'table',
+      _key: 't0',
+      headerRows: 0,
+      rows: [
+        {
+          _type: 'row',
+          _key: 'r0',
+          cells: [
+            {
+              _type: 'cell',
+              _key: 'c0',
+              value: [
+                {
+                  _type: 'block',
+                  _key: 'cb0',
+                  children: [{_type: 'span', _key: 'cb0-s', text: 'cell text', marks: []}],
+                  markDefs: [],
+                  style: 'normal',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      _type: 'table',
+      _key: 't1',
+      caption: 'A caption',
+      headerRows: 0,
+      rows: [
+        {
+          _type: 'row',
+          _key: 'r1',
+          cells: [
+            {
+              _type: 'cell',
+              _key: 'c1',
+              value: [
+                {
+                  _type: 'block',
+                  _key: 'cb1',
+                  children: [{_type: 'span', _key: 'cb1-s', text: 'other cell text', marks: []}],
+                  markDefs: [],
+                  style: 'normal',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+const {render} = await import('vitest-browser-react')
+
+describe('Portable Text Input - validation on a table block itself', () => {
+  it('renders a rule.custom error keyed to the table block on the table wrapper', async () => {
+    const {getFocusedPortableTextEditor} = testHelpers()
+
+    void render(<TableBlockValidationStory document={document} />)
+
+    const $pte = await getFocusedPortableTextEditor('field-body')
+    await expect.element($pte).toHaveTextContent('cell text')
+
+    const $table = page.getByTestId('pte-table-block').nth(0)
+    const $captionedTable = page.getByTestId('pte-table-block').nth(1)
+    await expect.poll(() => $table.element().hasAttribute('data-invalid')).toBe(true)
+
+    await userEvent.hover($table)
+    await expect.element(page.getByText('Table must have a caption')).toBeVisible()
+
+    // Both tables validate in the same pass, so once the caption-less one
+    // is marked, the captioned one has already been left unmarked.
+    expect($captionedTable.element().hasAttribute('data-invalid')).toBe(false)
+    expect($captionedTable.element().hasAttribute('data-warning')).toBe(false)
+  })
+})

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/TableBlockValidation.stories.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/TableBlockValidation.stories.tsx
@@ -1,0 +1,19 @@
+import {type Meta, type StoryObj} from '@storybook/react-vite'
+
+import {TableBlockValidationStory} from './TableBlockValidationStory'
+
+/**
+ * Reuses the `TableBlockValidation.browser.test.tsx` harness: a `rule.custom`
+ * error keyed to the table block's own path, verifying the table gets the
+ * same validation chrome as other object blocks.
+ */
+const meta = {
+  title: 'Portable Text/Table Block Validation',
+  component: TableBlockValidationStory,
+  parameters: {chromatic: {delay: 300}},
+} satisfies Meta<typeof TableBlockValidationStory>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/packages/sanity/src/core/form/inputs/PortableText/__tests__/TableBlockValidationStory.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/__tests__/TableBlockValidationStory.tsx
@@ -1,0 +1,97 @@
+import {
+  defineArrayMember,
+  defineField,
+  defineType,
+  type PortableTextBlock,
+  type SanityDocument,
+} from '@sanity/types'
+
+import {TestForm} from '../../../../../../test/browser/TestForm'
+import {TestWrapper} from '../../../../../../test/browser/TestWrapper'
+
+// Keyed per table: the negative assertion needs the captioned table left unmarked.
+const tablesMustHaveCaptions = (blocks: PortableTextBlock[] | undefined) => {
+  const tables = (blocks?.filter((block) => block._type === 'table') ??
+    []) as (PortableTextBlock & {
+    caption?: string
+  })[]
+  const errors = tables
+    .filter((table) => !table.caption)
+    .map((table) => ({message: 'Table must have a caption', path: [{_key: table._key}]}))
+  return errors.length > 0 ? errors : true
+}
+
+const SCHEMA_TYPES = [
+  defineType({
+    type: 'document',
+    name: 'test',
+    title: 'Test',
+    fields: [
+      defineField({
+        type: 'array',
+        name: 'body',
+        validation: (Rule) => Rule.custom(tablesMustHaveCaptions),
+        of: [
+          defineArrayMember({type: 'block'}),
+          defineArrayMember({
+            type: 'object',
+            name: 'table',
+            fields: [
+              defineField({type: 'string', name: 'caption'}),
+              defineField({type: 'number', name: 'headerRows'}),
+              defineField({
+                type: 'array',
+                name: 'rows',
+                of: [
+                  defineArrayMember({
+                    type: 'object',
+                    name: 'row',
+                    fields: [
+                      defineField({
+                        type: 'array',
+                        name: 'cells',
+                        of: [
+                          defineArrayMember({
+                            type: 'object',
+                            name: 'cell',
+                            fields: [
+                              defineField({
+                                type: 'array',
+                                name: 'value',
+                                of: [defineArrayMember({type: 'block'})],
+                              }),
+                            ],
+                          }),
+                        ],
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+        components: {
+          portableText: {
+            plugins: (props) =>
+              props.renderDefault({
+                ...props,
+                plugins: {
+                  ...props.plugins,
+                  table: {enabled: true},
+                },
+              }),
+          },
+        },
+      }),
+    ],
+  }),
+]
+
+export function TableBlockValidationStory(props: {document?: SanityDocument}) {
+  return (
+    <TestWrapper schemaTypes={SCHEMA_TYPES}>
+      <TestForm document={props.document} />
+    </TestWrapper>
+  )
+}

--- a/packages/sanity/src/core/form/inputs/PortableText/contexts/PortableTextInputPath.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/contexts/PortableTextInputPath.tsx
@@ -1,0 +1,22 @@
+import {type Path} from '@sanity/types'
+import {type ReactNode, useContext} from 'react'
+import {PortableTextInputPathContext} from 'sanity/_singletons'
+
+/**
+ * Provides the Portable Text input's own doc-absolute path, so container
+ * renders (which only receive an editor-relative path) can resolve their
+ * doc-absolute member path by concatenation.
+ * @internal
+ */
+export function PortableTextInputPathProvider(props: {path: Path; children: ReactNode}) {
+  return (
+    <PortableTextInputPathContext.Provider value={props.path}>
+      {props.children}
+    </PortableTextInputPathContext.Provider>
+  )
+}
+
+/** @internal */
+export function usePortableTextInputPath(): Path {
+  return useContext(PortableTextInputPathContext)
+}

--- a/packages/sanity/src/core/form/inputs/PortableText/object/TablePlugin.tsx
+++ b/packages/sanity/src/core/form/inputs/PortableText/object/TablePlugin.tsx
@@ -14,15 +14,23 @@ import {ThLargeIcon} from '@sanity/icons/ThLarge'
 import {TrashIcon} from '@sanity/icons/Trash'
 import {Flex, Switch, Text, usePortal} from '@sanity/ui'
 import {Menu, MenuDivider} from '@sanity/ui/menu'
-import {getTheme_v2} from '@sanity/ui/theme'
+import {getTheme_v2, type Theme} from '@sanity/ui/theme'
 import {useId, useMemo} from 'react'
-import {createGlobalStyle, useTheme} from 'styled-components'
+import {createGlobalStyle, css, styled, useTheme} from 'styled-components'
 
 import {MenuButton} from '../../../../../ui-components/menuButton/MenuButton'
 import {MenuItem} from '../../../../../ui-components/menuItem/MenuItem'
+import {Tooltip} from '../../../../../ui-components/tooltip/Tooltip'
 import {ContextMenuButton} from '../../../../components/contextMenuButton/ContextMenuButton'
+import {pathToString} from '../../../../field/paths/helpers'
 import {useTranslation} from '../../../../i18n/hooks/useTranslation'
 import {useColorSchemeValue} from '../../../../studio/colorScheme'
+import {EMPTY_ARRAY} from '../../../../util/empty'
+import {useFormBuilder} from '../../../useFormBuilder'
+import {usePortableTextInputPath} from '../contexts/PortableTextInputPath'
+import {useMemberValidation} from '../hooks/useMemberValidation'
+import {usePortableTextMemberItem} from '../hooks/usePortableTextMembers'
+import {TooltipBox} from './BlockObject.styles'
 
 const studioTableRender = (props: ContainerRenderProps) => <StudioTable {...props} />
 
@@ -106,28 +114,77 @@ function StudioTable(props: ContainerRenderProps): React.JSX.Element {
   const portal = usePortal()
   const {t} = useTranslation()
   const tokens = useTableTokens()
+  // oxlint-disable-next-line no-deprecated -- will fix in follow up PR
+  const {Markers} = useFormBuilder().__internal.components
+  const inputPath = usePortableTextInputPath()
+  const memberItem = usePortableTextMemberItem(pathToString(inputPath.concat(props.path)))
+  const {validation, hasError, hasWarning, hasInfo} = useMemberValidation(memberItem?.node)
+  const tooltipEnabled = hasError || hasWarning || hasInfo
+  const tooltipContent = useMemo(
+    () =>
+      (tooltipEnabled && (
+        <TooltipBox>
+          <Markers markers={EMPTY_ARRAY} validation={validation} />
+        </TooltipBox>
+      )) ||
+      null,
+    [Markers, tooltipEnabled, validation],
+  )
+
   return (
-    <Table
-      {...props}
-      icons={tableIcons}
-      portalElement={portal.element}
-      tokens={tokens}
-      labels={{
-        'add-column': t('inputs.portable-text.table.add-column'),
-        'add-row': t('inputs.portable-text.table.add-row'),
-        'column-handle': t('inputs.portable-text.table.column-handle'),
-        'delete-column': t('inputs.portable-text.table.delete-column'),
-        'delete-row': t('inputs.portable-text.table.delete-row'),
-        'insert-here': t('inputs.portable-text.table.insert-here'),
-        'row-handle': t('inputs.portable-text.table.row-handle'),
-      }}
-      // Wrapped in JSX because the plugin calls `renderMenu` as a plain
-      // function; a bare `StudioTableMenu` would run its hooks inside the
-      // plugin's render.
-      renderMenu={(menuProps) => <StudioTableMenu {...menuProps} />}
-    />
+    <TableValidationWrapper
+      data-invalid={hasError ? '' : undefined}
+      data-testid="pte-table-block"
+      data-warning={hasWarning ? '' : undefined}
+    >
+      <Tooltip content={tooltipContent} disabled={!tooltipEnabled} placement="top" portal="editor">
+        <div>
+          <Table
+            {...props}
+            icons={tableIcons}
+            portalElement={portal.element}
+            tokens={tokens}
+            labels={{
+              'add-column': t('inputs.portable-text.table.add-column'),
+              'add-row': t('inputs.portable-text.table.add-row'),
+              'column-handle': t('inputs.portable-text.table.column-handle'),
+              'delete-column': t('inputs.portable-text.table.delete-column'),
+              'delete-row': t('inputs.portable-text.table.delete-row'),
+              'insert-here': t('inputs.portable-text.table.insert-here'),
+              'row-handle': t('inputs.portable-text.table.row-handle'),
+            }}
+            // Wrapped in JSX because the plugin calls `renderMenu` as a plain
+            // function; a bare `StudioTableMenu` would run its hooks inside the
+            // plugin's render.
+            renderMenu={(menuProps) => <StudioTableMenu {...menuProps} />}
+          />
+        </div>
+      </Tooltip>
+    </TableValidationWrapper>
   )
 }
+
+// The `data-invalid`/`data-warning` states match `BlockObject.styles.ts`,
+// but the visual treatment is deliberately different: that file draws a
+// tinted `:after` overlay, this draws a box-shadow ring, scoped to a
+// wrapper around the table instead of the shared object-block `Root`
+// because the table renders its own borders and background via
+// `useTableTokens`, so reusing that `Card` here would fight the plugin's
+// own theming.
+const TableValidationWrapper = styled.div(({theme}: {theme: Theme}) => {
+  const {color, radius} = getTheme_v2(theme)
+  return css`
+    border-radius: ${radius[2]}px;
+
+    &[data-invalid] {
+      box-shadow: 0 0 0 2px ${color.input.invalid.enabled.border};
+    }
+
+    &[data-warning] {
+      box-shadow: 0 0 0 2px ${color.selectable.caution.enabled.border};
+    }
+  `
+})
 
 // The values ride the plugin's `tokens` prop, which applies them to the
 // plugin's own elements including the portal layers, so each table

--- a/packages/sanity/test/__snapshots__/exports.test.ts.snap
+++ b/packages/sanity/test/__snapshots__/exports.test.ts.snap
@@ -800,6 +800,7 @@ exports[`exports snapshot 1`] = `
     "PaneRouterContext": "object",
     "ParseErrorsContext": "object",
     "PerspectiveContext": "object",
+    "PortableTextInputPathContext": "object",
     "PortableTextMarkersContext": "object",
     "PortableTextMemberItemElementRefsContext": "object",
     "PortableTextMemberItemsContext": "object",


### PR DESCRIPTION
### Description

A `rule.custom` error targeting a Portable Text table block (`path: [{_key}]`) resolved to a validation marker but rendered nowhere: the table plugin's container render bypasses `BlockObject`, which is where object blocks get their validation tooltip and invalid state. Validation inside cells was unaffected. This PR gives the Studio table render the same validation surface: the messages show in a tooltip on hover and the table gets an error/warning outline. Info-level results show the tooltip without the outline, same as other object blocks. The table resolves its form member the same way `BlockObject` does, by absolute path; `Compositor` now shares the input's path through an internal context so container renders can build it.

### What to review

That the validation chrome does not interfere with table editing: selection, typing in cells, the row/column handles, and the table menu. For a hands-on check, test-studio's "Custom Plugins" document now warns on Container Table tables without a header row; toggling "Header row" in the table menu makes the warning outline and tooltip appear and disappear.

### Testing

A new browser test pins a table-keyed `rule.custom` message rendering on the table (red before the fix) and a passing table staying unmarked.

### Notes for release

Validation errors targeting a table block in the Portable Text editor now render like on any other block: the message shows in a tooltip on the table and the table gets an error or warning outline.

---
